### PR TITLE
Apply `CPUParticles2D` hue variation even when curve is unset

### DIFF
--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1131,7 +1131,7 @@ void CPUParticles2D::_particles_process(double p_delta) {
 			}
 		}
 
-		real_t tex_hue_variation = 0.0;
+		real_t tex_hue_variation = 1.0;
 		if (curve_parameters[PARAM_HUE_VARIATION].is_valid()) {
 			tex_hue_variation = curve_parameters[PARAM_HUE_VARIATION]->sample(tv);
 		}

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -1161,7 +1161,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 			}
 		}
 
-		real_t tex_hue_variation = 0.0;
+		real_t tex_hue_variation = 1.0;
 		if (curve_parameters[PARAM_HUE_VARIATION].is_valid()) {
 			tex_hue_variation = curve_parameters[PARAM_HUE_VARIATION]->sample(tv);
 		}


### PR DESCRIPTION
Fixes #93330

# "Bug" / Existing Behavior

In Godot 4, `CPUParticles2D` allow for the minimum and maximum hue variation to be set. However, these values have no effect unless a curve is set for that variation to sample from. This is not the case for `GPUParticles2D`.

As a user, I would expect at least one of the below to be the case:
1. My hue variation is applied as I specified, regardless of the curve.
2. If no curve is set the default curve is applied (1.0).
3. `CPUParticles2D` and `GPUParticles2D` treat hue variation the same.
4. Godot 3's behavior is "replicated" (this is technically not possible; see the next section).

None of these are the case, currently.

## What Changed

In Godot 3, instead of a minimum and maximum variation, the hue variation was set using "variation" and "variation randomness". The values would change the hue even if the curve was unset. The logic for this was:

```cpp
float tex_hue_variation = 0.0;
if (curve_parameters[PARAM_HUE_VARIATION].is_valid()) {
		tex_hue_variation = curve_parameters[PARAM_HUE_VARIATION]->interpolate(tv);
}

float hue_rot_angle = (parameters[PARAM_HUE_VARIATION] + tex_hue_variation) * Math_PI * 2.0 * Math::lerp(1.0f, p.hue_rot_rand * 2.0f - 1.0f, randomness[PARAM_HUE_VARIATION]);
```

In Godot 4, this was changed to:

```cpp
real_t tex_hue_variation = 0.0;
if (curve_parameters[PARAM_HUE_VARIATION].is_valid()) {
	tex_hue_variation = curve_parameters[PARAM_HUE_VARIATION]->sample(tv);
}

real_t hue_rot_angle = (tex_hue_variation)*Math::TAU * Math::lerp(parameters_min[PARAM_HUE_VARIATION], parameters_max[PARAM_HUE_VARIATION], p.hue_rot_rand);
```

The most important difference here is that Godot 3 added the variation to `tex_hue_variation` while Godot 4 is pure multiplication before the lerp. This means that so long as the curve is unset in Godot 4, `hue_rot_angle` will always be 0 (a `tex_hue_variation` of 0 times anything will be 0). This is different from Godot 3, where the variation would have been added to this 0.

Based on this, I believe this has been the behavior since Godot 4 was released.

## Proposed Fix

The simplest fix is to just use the same value as the default curve: 1.0 (instead of 0.0). With that value, the minimum and maximum variance will be applied. The curve will still be used if it is set, so this change should be isolated.

## Related Behavior & Code

### Other parameter groups that use curves

During my testing, all other parameter groups that take a curve still have an effect even when their curve is unset.

### `GPUParticles2D`
For reference, the generated shader has:

```
params.hue_rotation = pi * 2.0 * mix(hue_variation_min, hue_variation_max, rand_from_seed(alt_seed));
```

And, if a curve is set:
```
parameters.hue_rotation *= texture(hue_rot_curve, vec2(lifetime)).r;
```

And:

```
parameters.color = rotate_hue(parameters.color, parameters.hue_rotation);
```

In short, the min and max variation have an effect even when the curve is unset.

# Testing

I have attached an MRP for Godot 4 and Godot 3. Testing is as simple as opening the project (and the default MRP scene). The MRP scenes contain CPU and GPU particle emitters with their relevant hue variance values set (min/max for Godot 4, variance/randomness for 3). If you launch Godot 3.6 for this MRP, you will see that both are affected by the hue variance. If you open the project with Godot 4's master branch, you will see the hue variance only affects `GPUParticles2D`.

[cpu-particles-godot-3-mrp.zip](https://github.com/user-attachments/files/24388426/cpu-particles-godot-3-mrp.zip)
[cpu-particles-mrp.zip](https://github.com/user-attachments/files/24388440/cpu-particles-mrp.zip)


# Is this even a bug?

I can see the argument that this is not a bug and this is the new (expected) behavior in Godot 4. That makes sense if you are familiar with the formula for `tex_hue_variation` (no curve means it will always be 0) or are familiar with how `CPUParticles2D` changed between Godot 3 and 4 (hue variation randomness was removed and used to default to 0). However, I think that Godot 3's behavior without a curve, the behavior of other parameter groups, and the behavior of `GPUParticles2D` would lead most people to expect that setting the minimum and maximum hue variance would cause some hue variance even without a curve. At least, I expected this as did the writer of #93330 and the person he helped on the Godot forms.

All this is to say: if you do not consider this to be a bug, I still think this would then be helpful as an "enhancement" then.