### PR TITLE
GLTF: Zero out padding bytes when encoding buffer views

### DIFF
--- a/modules/gltf/structures/gltf_buffer_view.cpp
+++ b/modules/gltf/structures/gltf_buffer_view.cpp
@@ -154,10 +154,15 @@ GLTFBufferViewIndex GLTFBufferView::write_new_buffer_view_into_state(const Ref<G
 	// This is used by accessors. The byte offset of an accessor MUST be a multiple of the accessor's component size.
 	// https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#data-alignment
 	int64_t byte_offset = state_buffer.size();
+	int64_t padding_bytes = 0;
 	if (byte_offset % p_alignment != 0) {
-		byte_offset += p_alignment - (byte_offset % p_alignment);
+		padding_bytes = p_alignment - (byte_offset % p_alignment);
+		byte_offset += padding_bytes;
 	}
 	state_buffer.resize(byte_offset + input_data_size);
+	if (padding_bytes > 0) {
+		memset(state_buffer.ptrw() + (byte_offset - padding_bytes), 0, padding_bytes);
+	}
 	uint8_t *buffer_ptr = state_buffer.ptrw();
 	memcpy(buffer_ptr + byte_offset, p_input_data.ptr(), input_data_size);
 	state_buffers.set(p_buffer_index, state_buffer);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

During buffer view encoding, when padding out the buffers to align the accessors, we weren't zeroing out the padding bytes; this resulted in non-deterministic scene buffers being output. Fixed to just memset the padding bytes to 0.