### PR TITLE
[Android editor] Restrict Android editor support for hybrid app projects to XR devices

### DIFF
--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotGame.kt
@@ -104,8 +104,8 @@ abstract class BaseGodotGame: GodotEditor() {
 	@CallSuper
 	override fun supportsFeature(featureTag: String): Boolean {
 		if (HYBRID_APP_FEATURE == featureTag) {
-			// Check if hybrid is enabled
-			return isHybridAppEnabled()
+			// Check if hybrid is enabled.
+			return godot?.isXrRuntime == true && isHybridAppEnabled()
 		}
 
 		return super.supportsFeature(featureTag)

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
@@ -135,6 +135,8 @@ class Godot private constructor(val context: Context) {
 	private val gyroscopeEnabled = AtomicBoolean(false)
 	private val mGyroscope: Sensor? by lazy { mSensorManager?.getDefaultSensor(Sensor.TYPE_GYROSCOPE) }
 
+	val isXrRuntime: Boolean by lazy { hasFeature("xr_runtime") }
+
 	val tts = GodotTTS(context)
 	val directoryAccessHandler = DirectoryAccessHandler(context)
 	val fileAccessHandler = FileAccessHandler(context)

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotGLRenderView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotGLRenderView.java
@@ -80,13 +80,11 @@ class GodotGLRenderView extends GLSurfaceView implements GodotRenderView {
 	private final GodotInputHandler inputHandler;
 	private final GodotRenderer godotRenderer;
 	private final SparseArray<PointerIcon> customPointerIcons = new SparseArray<>();
-	private final boolean isXrDevice;
 
 	public GodotGLRenderView(Godot godot, GodotInputHandler inputHandler, XRMode xrMode, boolean useDebugOpengl, boolean shouldBeTranslucent) {
 		super(godot.getContext());
 
 		this.godot = godot;
-		isXrDevice = godot.hasFeature("xr_runtime");
 		this.inputHandler = inputHandler;
 		this.godotRenderer = new GodotRenderer();
 		setPointerIcon(PointerIcon.getSystemIcon(getContext(), PointerIcon.TYPE_DEFAULT));
@@ -177,7 +175,7 @@ class GodotGLRenderView extends GLSurfaceView implements GodotRenderView {
 	@Override
 	public boolean canCapturePointer() {
 		// Pointer capture is not supported on XR devices.
-		return !isXrDevice && inputHandler.canCapturePointer();
+		return !godot.isXrRuntime() && inputHandler.canCapturePointer();
 	}
 
 	@Override

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotVulkanRenderView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotVulkanRenderView.java
@@ -55,13 +55,11 @@ class GodotVulkanRenderView extends VkSurfaceView implements GodotRenderView {
 	private final GodotInputHandler mInputHandler;
 	private final VkRenderer mRenderer;
 	private final SparseArray<PointerIcon> customPointerIcons = new SparseArray<>();
-	private final boolean isXrDevice;
 
 	public GodotVulkanRenderView(Godot godot, GodotInputHandler inputHandler, boolean shouldBeTranslucent) {
 		super(godot.getContext());
 
 		this.godot = godot;
-		isXrDevice = godot.hasFeature("xr_runtime");
 		mInputHandler = inputHandler;
 		mRenderer = new VkRenderer();
 		setPointerIcon(PointerIcon.getSystemIcon(getContext(), PointerIcon.TYPE_DEFAULT));
@@ -156,7 +154,7 @@ class GodotVulkanRenderView extends VkSurfaceView implements GodotRenderView {
 	@Override
 	public boolean canCapturePointer() {
 		// Pointer capture is not supported on XR devices.
-		return !isXrDevice && mInputHandler.canCapturePointer();
+		return !godot.isXrRuntime() && mInputHandler.canCapturePointer();
 	}
 	@Override
 	public void requestPointerCapture() {


### PR DESCRIPTION
The [OpenXRHybridApp#is_hybrid_app()](https://godotvr.github.io/godot_openxr_vendors/api/class_openxrhybridapp.html#class-openxrhybridapp-method-is-hybrid-app) method currently returns `true` on the Android editor even when running on devices that don't support XR / immersive activities. 
This PR fixes the logic to only return `true` on devices with a XR runtime.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
