### PR TITLE
Fix crash when invoking `EditorFileSystem::scan_changes()` in the Project Manager

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -39,6 +39,7 @@
 #include "core/version.h"
 #include "editor/asset_library/asset_library_editor_plugin.h"
 #include "editor/editor_string_names.h"
+#include "editor/file_system/editor_file_system.h"
 #include "editor/gui/editor_about.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_title_bar.h"
@@ -1755,6 +1756,9 @@ ProjectManager::ProjectManager() {
 		quick_settings_dialog = memnew(QuickSettingsDialog);
 		add_child(quick_settings_dialog);
 		quick_settings_dialog->connect("restart_required", callable_mp(this, &ProjectManager::_restart_confirmed));
+
+		EditorFileSystem *efs = memnew(EditorFileSystem);
+		add_child(efs);
 
 		scan_dir = memnew(EditorFileDialog);
 		scan_dir->set_access(EditorFileDialog::ACCESS_FILESYSTEM);


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/113541

Fixes crash triggered by invoking [`EditorFileSystem::get_singleton()->scan_changes()`](https://github.com/Rindbee/godot/blob/1559ab34c645abf14f8b8cf61e1a6f0eddaf6285/editor/gui/editor_file_dialog.cpp#L112) in the project manager. 

The crash occurs because `EditorFileSystem` is initialized in the `EditorNode`, but not in `ProjectManager` and so is `null` when invoked.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
