### PR TITLE
Fix `RichTextLabel` not updating after change `scroll_active` field

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -5182,6 +5182,8 @@ void RichTextLabel::set_scroll_active(bool p_active) {
 
 	scroll_active = p_active;
 	vscroll->set_drag_node_enabled(p_active);
+	vscroll->set_visible(p_active);
+	_apply_translation(); // without this, RichLabelText is not updated in the editor/game.
 	queue_redraw();
 }
 


### PR DESCRIPTION
Fix of [#114341](https://github.com/godotengine/godot/issues/114341)

This PR will fix the problem described in the issue, and also resolve the problem that when changing `scroll_active` in `RichTextLabel`, it was not updated, including at runtime (in user projects).

Before PR:
[before_patch.webm](https://github.com/user-attachments/assets/84695497-54c9-40d7-ab36-9e2c086e7b49)

After PR:
[after_patch.webm](https://github.com/user-attachments/assets/4a62392f-31a1-4760-9147-94b03d01913d)

<i>Bugsquad edit:</i>

- Fix https://github.com/godotengine/godot/issues/114341

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
