### PR TITLE
Add custom axis sort to CanvasItem

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -654,6 +654,17 @@
 		</method>
 	</methods>
 	<members>
+		<member name="axis_sort_enabled" type="bool" setter="set_axis_sort_enabled" getter="is_axis_sort_enabled" default="false">
+			If [code]true[/code], this and child [CanvasItem] nodes are rendered in custom order based on their coordinates. If [code]false[/code], this and child [CanvasItem] nodes are rendered normally in scene tree order.
+			With axis sorting enabled on a parent node ('A') but disabled on a child node ('B'), the child node ('B') is sorted but its children ('C1', 'C2', etc.) render together on the same position as the child node ('B'). This allows you to organize the render order of a scene without changing the scene tree.
+			Nodes sort relative to each other only if they are on the same [member z_index].
+		</member>
+		<member name="axis_sort_x_ascending" type="bool" setter="set_axis_sort_x_ascending" getter="is_axis_sort_x_ascending" default="true">
+		</member>
+		<member name="axis_sort_y_as_main" type="bool" setter="set_axis_sort_y_as_main" getter="is_axis_sort_y_as_main" default="true">
+		</member>
+		<member name="axis_sort_y_ascending" type="bool" setter="set_axis_sort_y_ascending" getter="is_axis_sort_y_ascending" default="true">
+		</member>
 		<member name="clip_children" type="int" setter="set_clip_children_mode" getter="get_clip_children_mode" enum="CanvasItem.ClipChildrenMode" default="0">
 			The mode in which this node clips its children, acting as a mask.
 			[b]Note:[/b] Clipping nodes cannot be nested or placed within a [CanvasGroup]. If an ancestor of this node clips its children or is a [CanvasGroup], then this node's clip mode should be set to [constant CLIP_CHILDREN_DISABLED] to avoid unexpected behavior.
@@ -694,11 +705,6 @@
 		<member name="visible" type="bool" setter="set_visible" getter="is_visible" default="true">
 			If [code]true[/code], this [CanvasItem] may be drawn. Whether this [CanvasItem] is actually drawn depends on the visibility of all of its [CanvasItem] ancestors. In other words: this [CanvasItem] will be drawn when [method is_visible_in_tree] returns [code]true[/code] and all [CanvasItem] ancestors share at least one [member visibility_layer] with this [CanvasItem].
 			[b]Note:[/b] For controls that inherit [Popup], the correct way to make them visible is to call one of the multiple [code]popup*()[/code] functions instead.
-		</member>
-		<member name="y_sort_enabled" type="bool" setter="set_y_sort_enabled" getter="is_y_sort_enabled" default="false">
-			If [code]true[/code], this and child [CanvasItem] nodes with a higher Y position are rendered in front of nodes with a lower Y position. If [code]false[/code], this and child [CanvasItem] nodes are rendered normally in scene tree order.
-			With Y-sorting enabled on a parent node ('A') but disabled on a child node ('B'), the child node ('B') is sorted but its children ('C1', 'C2', etc.) render together on the same Y position as the child node ('B'). This allows you to organize the render order of a scene without changing the scene tree.
-			Nodes sort relative to each other only if they are on the same [member z_index].
 		</member>
 		<member name="z_as_relative" type="bool" setter="set_z_as_relative" getter="is_z_relative" default="true">
 			If [code]true[/code], this node's final Z index is relative to its parent's Z index.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -617,12 +617,32 @@
 				Multiplies the color of the canvas item specified by the [param item] RID, without affecting its children. See also [method canvas_item_set_modulate]. Equivalent to [member CanvasItem.self_modulate].
 			</description>
 		</method>
-		<method name="canvas_item_set_sort_children_by_y">
+		<method name="canvas_item_set_sort_children_by_axis">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If [param enabled] is [code]true[/code], child nodes with the lowest Y position are drawn before those with a higher Y position. Y-sorting only affects children that inherit from the canvas item specified by the [param item] RID, not the canvas item itself. Equivalent to [member CanvasItem.y_sort_enabled].
+			</description>
+		</method>
+		<method name="canvas_item_set_sort_children_by_axis_x_ascending">
+			<return type="void" />
+			<param index="0" name="item" type="RID" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_set_sort_children_by_axis_y_as_main">
+			<return type="void" />
+			<param index="0" name="item" type="RID" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="canvas_item_set_sort_children_by_axis_y_ascending">
+			<return type="void" />
+			<param index="0" name="item" type="RID" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
 			</description>
 		</method>
 		<method name="canvas_item_set_transform">

--- a/doc/classes/TileData.xml
+++ b/doc/classes/TileData.xml
@@ -270,6 +270,8 @@
 		</method>
 	</methods>
 	<members>
+		<member name="axis_sort_origin" type="Vector2i" setter="set_axis_sort_origin" getter="get_axis_sort_origin" default="Vector2i(0, 0)">
+		</member>
 		<member name="flip_h" type="bool" setter="set_flip_h" getter="get_flip_h" default="false">
 			If [code]true[/code], the tile will have its texture flipped horizontally.
 		</member>
@@ -296,9 +298,6 @@
 		</member>
 		<member name="transpose" type="bool" setter="set_transpose" getter="get_transpose" default="false">
 			If [code]true[/code], the tile will display transposed, i.e. with horizontal and vertical texture UVs swapped.
-		</member>
-		<member name="y_sort_origin" type="int" setter="set_y_sort_origin" getter="get_y_sort_origin" default="0">
-			Vertical point of the tile used for determining y-sorted order.
 		</member>
 		<member name="z_index" type="int" setter="set_z_index" getter="get_z_index" default="0">
 			Ordering index of this tile, relative to [TileMapLayer].

--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -145,6 +145,12 @@
 				Returns the coordinates of the tile for given physics body RID. Such RID can be retrieved from [method KinematicCollision2D.get_collider_rid], when colliding with a tile.
 			</description>
 		</method>
+		<method name="get_layer_axis_sort_origin" qualifiers="const">
+			<return type="Vector2i" />
+			<param index="0" name="layer" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="get_layer_for_body_rid">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
@@ -175,14 +181,6 @@
 				Returns the [RID] of the [NavigationServer2D] navigation map assigned to the specified TileMap layer [param layer].
 				By default the TileMap uses the default [World2D] navigation map for the first TileMap layer. For each additional TileMap layer a new navigation map is created for the additional layer.
 				In order to make [NavigationAgent2D] switch between TileMap layer navigation maps use [method NavigationAgent2D.set_navigation_map] with the navigation map received from [method get_layer_navigation_map].
-				If [param layer] is negative, the layers are accessed from the last one.
-			</description>
-		</method>
-		<method name="get_layer_y_sort_origin" qualifiers="const">
-			<return type="int" />
-			<param index="0" name="layer" type="int" />
-			<description>
-				Returns a TileMap layer's Y sort origin.
 				If [param layer] is negative, the layers are accessed from the last one.
 			</description>
 		</method>
@@ -285,6 +283,12 @@
 				Returns [code]true[/code] if the cell on layer [param layer] at coordinates [param coords] is transposed. The result is valid only for atlas sources.
 			</description>
 		</method>
+		<method name="is_layer_axis_sort_enabled" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="layer" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="is_layer_enabled" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer" type="int" />
@@ -298,14 +302,6 @@
 			<param index="0" name="layer" type="int" />
 			<description>
 				Returns if a layer's built-in navigation regions generation is enabled.
-			</description>
-		</method>
-		<method name="is_layer_y_sort_enabled" qualifiers="const">
-			<return type="bool" />
-			<param index="0" name="layer" type="int" />
-			<description>
-				Returns if a layer Y-sorts its tiles.
-				If [param layer] is negative, the layers are accessed from the last one.
 			</description>
 		</method>
 		<method name="local_to_map" qualifiers="const">
@@ -401,6 +397,20 @@
 				[b]Note:[/b] To work correctly, this method requires the TileMap's TileSet to have terrains set up with all required terrain combinations. Otherwise, it may produce unexpected results.
 			</description>
 		</method>
+		<method name="set_layer_axis_sort_enabled">
+			<return type="void" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="axis_sort_enabled" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="set_layer_axis_sort_origin">
+			<return type="void" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="axis_sort_origin" type="Vector2i" />
+			<description>
+			</description>
+		</method>
 		<method name="set_layer_enabled">
 			<return type="void" />
 			<param index="0" name="layer" type="int" />
@@ -444,26 +454,6 @@
 				Assigns [param map] as a [NavigationServer2D] navigation map for the specified TileMap layer [param layer].
 				By default the TileMap uses the default [World2D] navigation map for the first TileMap layer. For each additional TileMap layer a new navigation map is created for the additional layer.
 				In order to make [NavigationAgent2D] switch between TileMap layer navigation maps use [method NavigationAgent2D.set_navigation_map] with the navigation map received from [method get_layer_navigation_map].
-				If [param layer] is negative, the layers are accessed from the last one.
-			</description>
-		</method>
-		<method name="set_layer_y_sort_enabled">
-			<return type="void" />
-			<param index="0" name="layer" type="int" />
-			<param index="1" name="y_sort_enabled" type="bool" />
-			<description>
-				Enables or disables a layer's Y-sorting. If a layer is Y-sorted, the layer will behave as a CanvasItem node where each of its tile gets Y-sorted.
-				Y-sorted layers should usually be on different Z-index values than not Y-sorted layers, otherwise, each of those layer will be Y-sorted as whole with the Y-sorted one. This is usually an undesired behavior.
-				If [param layer] is negative, the layers are accessed from the last one.
-			</description>
-		</method>
-		<method name="set_layer_y_sort_origin">
-			<return type="void" />
-			<param index="0" name="layer" type="int" />
-			<param index="1" name="y_sort_origin" type="int" />
-			<description>
-				Sets a layer's Y-sort origin value. This Y-sort origin value is added to each tile's Y-sort origin value.
-				This allows, for example, to fake a different height level on each layer. This can be useful for top-down view games.
 				If [param layer] is negative, the layers are accessed from the last one.
 			</description>
 		</method>

--- a/doc/classes/TileMapLayer.xml
+++ b/doc/classes/TileMapLayer.xml
@@ -322,7 +322,7 @@
 		</member>
 		<member name="rendering_quadrant_size" type="int" setter="set_rendering_quadrant_size" getter="get_rendering_quadrant_size" default="16">
 			The [TileMapLayer]'s rendering quadrant size. A quadrant is a group of tiles to be drawn together on a single canvas item, for optimization purposes. [member rendering_quadrant_size] defines the length of a square's side, in the map's coordinate system, that forms the quadrant. Thus, the default quadrant size groups together [code]16 * 16 = 256[/code] tiles.
-			The quadrant size does not apply on a Y-sorted [TileMapLayer], as tiles are grouped by Y position instead in that case.
+			The quadrant size does not apply on a axis sorted [TileMapLayer], as tiles are grouped by coordinates instead in that case.
 			[b]Note:[/b] As quadrants are created according to the map's coordinate system, the quadrant's "square shape" might not look like square in the [TileMapLayer]'s local coordinate system.
 		</member>
 		<member name="tile_map_data" type="PackedByteArray" setter="set_tile_map_data_from_array" getter="get_tile_map_data_as_array" default="PackedByteArray()">
@@ -335,7 +335,6 @@
 			If [code]true[/code], this [TileMapLayer] collision shapes will be instantiated as kinematic bodies. This can be needed for moving [TileMapLayer] nodes (i.e. moving platforms).
 		</member>
 		<member name="x_draw_order_reversed" type="bool" setter="set_x_draw_order_reversed" getter="is_x_draw_order_reversed" default="false">
-			If [member CanvasItem.y_sort_enabled] is enabled, setting this to [code]true[/code] will reverse the order the tiles are drawn on the X-axis.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/TileMapLayer.xml
+++ b/doc/classes/TileMapLayer.xml
@@ -294,6 +294,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="axis_sort_origin" type="Vector2i" setter="set_axis_sort_origin" getter="get_axis_sort_origin" default="Vector2i(0, 0)">
+			This axis sort origin value is added to each tile's axis sort origin value. This allows, for example, to fake a different height level by changing origin's Y value. This can be useful for top-down view games.
+		</member>
 		<member name="collision_enabled" type="bool" setter="set_collision_enabled" getter="is_collision_enabled" default="true">
 			Enable or disable collisions.
 		</member>
@@ -333,9 +336,6 @@
 		</member>
 		<member name="x_draw_order_reversed" type="bool" setter="set_x_draw_order_reversed" getter="is_x_draw_order_reversed" default="false">
 			If [member CanvasItem.y_sort_enabled] is enabled, setting this to [code]true[/code] will reverse the order the tiles are drawn on the X-axis.
-		</member>
-		<member name="y_sort_origin" type="int" setter="set_y_sort_origin" getter="get_y_sort_origin" default="0">
-			This Y-sort origin value is added to each tile's Y-sort origin value. This allows, for example, to fake a different height level. This can be useful for top-down view games.
 		</member>
 	</members>
 	<signals>

--- a/editor/scene/2d/tiles/tile_data_editors.cpp
+++ b/editor/scene/2d/tiles/tile_data_editors.cpp
@@ -1447,7 +1447,7 @@ void TileDataPositionEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform
 	p_canvas_item->draw_texture(position_icon, p_transform.xform(Vector2(value)) - position_icon->get_size() / 2, color);
 }
 
-void TileDataYSortEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform2D p_transform, TileMapCell p_cell, bool p_selected) {
+void TileDataAxisSortEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform2D p_transform, TileMapCell p_cell, bool p_selected) {
 	TileData *tile_data = _get_tile_data(p_cell);
 	ERR_FAIL_NULL(tile_data);
 
@@ -1460,13 +1460,13 @@ void TileDataYSortEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform2D 
 	Vector2 texture_origin = tile_data->get_texture_origin();
 	TileSetSource *source = *(tile_set->get_source(p_cell.source_id));
 	TileSetAtlasSource *atlas_source = Object::cast_to<TileSetAtlasSource>(source);
-	if (atlas_source->is_position_in_tile_texture_region(p_cell.get_atlas_coords(), p_cell.alternative_tile, Vector2(0, tile_data->get_y_sort_origin()))) {
+	if (atlas_source->is_position_in_tile_texture_region(p_cell.get_atlas_coords(), p_cell.alternative_tile, tile_data->get_axis_sort_origin())) {
 		Ref<Texture2D> position_icon = TileSetEditor::get_singleton()->get_editor_theme_icon(SNAME("EditorPosition"));
-		p_canvas_item->draw_texture(position_icon, p_transform.xform(Vector2(0, tile_data->get_y_sort_origin())) - position_icon->get_size() / 2, color);
+		p_canvas_item->draw_texture(position_icon, p_transform.xform(tile_data->get_axis_sort_origin()) - position_icon->get_size() / 2, color);
 	} else {
 		Ref<Font> font = TileSetEditor::get_singleton()->get_theme_font(SNAME("bold"), EditorStringName(EditorFonts));
 		int font_size = TileSetEditor::get_singleton()->get_theme_font_size(SNAME("bold_size"), EditorStringName(EditorFonts));
-		String text = vformat("%s", tile_data->get_y_sort_origin());
+		String text = vformat("%s", tile_data->get_axis_sort_origin());
 
 		Vector2 string_size = font->get_string_size(text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size);
 		p_canvas_item->draw_string_outline(font, p_transform.xform(-texture_origin) + Vector2i(-string_size.x / 2, string_size.y / 2), text, HORIZONTAL_ALIGNMENT_CENTER, string_size.x, font_size, 1, Color(0, 0, 0, 1));

--- a/editor/scene/2d/tiles/tile_data_editors.h
+++ b/editor/scene/2d/tiles/tile_data_editors.h
@@ -263,8 +263,8 @@ public:
 	virtual void draw_over_tile(CanvasItem *p_canvas_item, Transform2D p_transform, TileMapCell p_cell, bool p_selected = false) override;
 };
 
-class TileDataYSortEditor : public TileDataDefaultEditor {
-	GDCLASS(TileDataYSortEditor, TileDataDefaultEditor);
+class TileDataAxisSortEditor : public TileDataDefaultEditor {
+	GDCLASS(TileDataAxisSortEditor, TileDataDefaultEditor);
 
 public:
 	virtual void draw_over_tile(CanvasItem *p_canvas_item, Transform2D p_transform, TileMapCell p_cell, bool p_selected = false) override;

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -682,14 +682,14 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 		tile_data_editors["z_index"] = tile_data_z_index_editor;
 	}
 
-	ADD_TILE_DATA_EDITOR(group, TTR("Y Sort Origin"), "y_sort_origin");
-	if (!tile_data_editors.has("y_sort_origin")) {
-		TileDataYSortEditor *tile_data_y_sort_editor = memnew(TileDataYSortEditor);
-		tile_data_y_sort_editor->hide();
-		tile_data_y_sort_editor->setup_property_editor(Variant::INT, "y_sort_origin");
-		tile_data_y_sort_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::queue_redraw));
-		tile_data_y_sort_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::queue_redraw));
-		tile_data_editors["y_sort_origin"] = tile_data_y_sort_editor;
+	ADD_TILE_DATA_EDITOR(group, TTR("Axis Sort Origin"), "axis_sort_origin");
+	if (!tile_data_editors.has("axis_sort_origin")) {
+		TileDataAxisSortEditor *tile_data_axis_sort_editor = memnew(TileDataAxisSortEditor);
+		tile_data_axis_sort_editor->hide();
+		tile_data_axis_sort_editor->setup_property_editor(Variant::INT, "axis_sort_origin");
+		tile_data_axis_sort_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::queue_redraw));
+		tile_data_axis_sort_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::queue_redraw));
+		tile_data_editors["axis_sort_origin"] = tile_data_axis_sort_editor;
 	}
 
 	for (int i = 0; i < tile_set->get_occlusion_layers_count(); i++) {
@@ -2451,7 +2451,8 @@ void TileSetAtlasSourceEditor::_notification(int p_what) {
 			tile_inspector->add_custom_property_description("AtlasTileProxyObject", "modulate", TTR("The color multiplier to use when rendering the tile."));
 			tile_inspector->add_custom_property_description("AtlasTileProxyObject", "material", TTR("The material to use for this tile. This can be used to apply a different blend mode or custom shaders to a single tile."));
 			tile_inspector->add_custom_property_description("AtlasTileProxyObject", "z_index", TTR("The sorting order for this tile. Higher values will make the tile render in front of others on the same layer. The index is relative to the TileMap's own Z index."));
-			tile_inspector->add_custom_property_description("AtlasTileProxyObject", "y_sort_origin", TTR("The vertical offset to use for tile sorting based on its Y coordinate (in pixels). This allows using layers as if they were on different height for top-down games. Adjusting this can help alleviate issues with sorting certain tiles. Only effective if Y Sort Enabled is true on the TileMap layer the tile is placed on."));
+			// MARKER DESCRIPTION NEEDS TO BE UPDATED. SOLVE THIS COMMENT BEFORE FINAL PULL REQUEST.
+			tile_inspector->add_custom_property_description("AtlasTileProxyObject", "axis_sort_origin", TTR("The vertical offset to use for tile sorting based on its Y coordinate (in pixels). This allows using layers as if they were on different height for top-down games. Adjusting this can help alleviate issues with sorting certain tiles. Only effective if Y Sort Enabled is true on the TileMap layer the tile is placed on."));
 			tile_inspector->add_custom_property_description("AtlasTileProxyObject", "terrain_set", TTR("The index of the terrain set this tile belongs to. [code]-1[/code] means it will not be used in terrains."));
 			tile_inspector->add_custom_property_description("AtlasTileProxyObject", "terrain", TTR("The index of the terrain inside the terrain set this tile belongs to. [code]-1[/code] means it will not be used in terrains."));
 			tile_inspector->add_custom_property_description("AtlasTileProxyObject", "probability", TTR("The relative probability of this tile appearing when painting with \"Place Random Tile\" enabled."));

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -354,22 +354,22 @@ Color TileMap::get_layer_modulate(int p_layer) const {
 	TILEMAP_CALL_FOR_LAYER_V(p_layer, Color(), get_modulate);
 }
 
-void TileMap::set_layer_y_sort_enabled(int p_layer, bool p_y_sort_enabled) {
-	TILEMAP_CALL_FOR_LAYER(p_layer, set_y_sort_enabled, p_y_sort_enabled);
+void TileMap::set_layer_axis_sort_enabled(int p_layer, bool p_axis_sort_enabled) {
+	TILEMAP_CALL_FOR_LAYER(p_layer, set_axis_sort_enabled, p_axis_sort_enabled);
 	update_configuration_warnings();
 }
 
-bool TileMap::is_layer_y_sort_enabled(int p_layer) const {
-	TILEMAP_CALL_FOR_LAYER_V(p_layer, false, is_y_sort_enabled);
+bool TileMap::is_layer_axis_sort_enabled(int p_layer) const {
+	TILEMAP_CALL_FOR_LAYER_V(p_layer, false, is_axis_sort_enabled);
 }
 
-void TileMap::set_layer_y_sort_origin(int p_layer, int p_y_sort_origin) {
-	TILEMAP_CALL_FOR_LAYER(p_layer, set_y_sort_origin, p_y_sort_origin);
+void TileMap::set_layer_axis_sort_origin(int p_layer, Vector2i p_axis_sort_origin) {
+	TILEMAP_CALL_FOR_LAYER(p_layer, set_axis_sort_origin, p_axis_sort_origin);
 	update_configuration_warnings();
 }
 
-int TileMap::get_layer_y_sort_origin(int p_layer) const {
-	TILEMAP_CALL_FOR_LAYER_V(p_layer, 0, get_y_sort_origin);
+Vector2i TileMap::get_layer_axis_sort_origin(int p_layer) const {
+	TILEMAP_CALL_FOR_LAYER_V(p_layer, Vector2i(0, 0), get_axis_sort_origin);
 }
 
 void TileMap::set_layer_z_index(int p_layer, int p_z_index) {
@@ -446,11 +446,11 @@ TileMap::VisibilityMode TileMap::get_navigation_visibility_mode() const {
 }
 #endif // NAVIGATION_2D_DISABLED
 
-void TileMap::set_y_sort_enabled(bool p_enable) {
-	if (is_y_sort_enabled() == p_enable) {
+void TileMap::set_axis_sort_enabled(bool p_enable) {
+	if (is_axis_sort_enabled() == p_enable) {
 		return;
 	}
-	Node2D::set_y_sort_enabled(p_enable);
+	Node2D::set_axis_sort_enabled(p_enable);
 	_emit_changed();
 	update_configuration_warnings();
 }
@@ -843,25 +843,25 @@ PackedStringArray TileMap::get_configuration_warnings() const {
 	warnings.push_back(RTR("The TileMap node is deprecated as it is superseded by the use of multiple TileMapLayer nodes.\nTo convert a TileMap to a set of TileMapLayer nodes, open the TileMap bottom panel with this node selected, click the toolbox icon in the top-right corner and choose \"Extract TileMap layers as individual TileMapLayer nodes\"."));
 
 	// Retrieve the set of Z index values with a Y-sorted layer.
-	RBSet<int> y_sorted_z_index;
+	RBSet<int> axis_sorted_z_index;
 	for (const TileMapLayer *layer : layers) {
-		if (layer->is_y_sort_enabled()) {
-			y_sorted_z_index.insert(layer->get_z_index());
+		if (layer->is_axis_sort_enabled()) {
+			axis_sorted_z_index.insert(layer->get_z_index());
 		}
 	}
 
 	// Check if we have a non-sorted layer in a Z-index with a Y-sorted layer.
 	for (const TileMapLayer *layer : layers) {
-		if (!layer->is_y_sort_enabled() && y_sorted_z_index.has(layer->get_z_index())) {
+		if (!layer->is_axis_sort_enabled() && axis_sorted_z_index.has(layer->get_z_index())) {
 			warnings.push_back(RTR("A Y-sorted layer has the same Z-index value as a not Y-sorted layer.\nThis may lead to unwanted behaviors, as a layer that is not Y-sorted will be Y-sorted as a whole with tiles from Y-sorted layers."));
 			break;
 		}
 	}
 
-	if (!is_y_sort_enabled()) {
+	if (!is_axis_sort_enabled()) {
 		// Check if Y-sort is enabled on a layer but not on the node.
 		for (const TileMapLayer *layer : layers) {
-			if (layer->is_y_sort_enabled()) {
+			if (layer->is_axis_sort_enabled()) {
 				warnings.push_back(RTR("A TileMap layer is set as Y-sorted, but Y-sort is not enabled on the TileMap node itself."));
 				break;
 			}
@@ -870,7 +870,7 @@ PackedStringArray TileMap::get_configuration_warnings() const {
 		// Check if Y-sort is enabled on the node, but not on any of the layers.
 		bool need_warning = true;
 		for (const TileMapLayer *layer : layers) {
-			if (layer->is_y_sort_enabled()) {
+			if (layer->is_axis_sort_enabled()) {
 				need_warning = false;
 				break;
 			}
@@ -882,10 +882,10 @@ PackedStringArray TileMap::get_configuration_warnings() const {
 
 	// Check if we are in isometric mode without Y-sort enabled.
 	if (tile_set.is_valid() && tile_set->get_tile_shape() == TileSet::TILE_SHAPE_ISOMETRIC) {
-		bool warn = !is_y_sort_enabled();
+		bool warn = !is_axis_sort_enabled();
 		if (!warn) {
 			for (const TileMapLayer *layer : layers) {
-				if (!layer->is_y_sort_enabled()) {
+				if (!layer->is_axis_sort_enabled()) {
 					warn = true;
 					break;
 				}
@@ -925,10 +925,10 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_layer_enabled", "layer"), &TileMap::is_layer_enabled);
 	ClassDB::bind_method(D_METHOD("set_layer_modulate", "layer", "modulate"), &TileMap::set_layer_modulate);
 	ClassDB::bind_method(D_METHOD("get_layer_modulate", "layer"), &TileMap::get_layer_modulate);
-	ClassDB::bind_method(D_METHOD("set_layer_y_sort_enabled", "layer", "y_sort_enabled"), &TileMap::set_layer_y_sort_enabled);
-	ClassDB::bind_method(D_METHOD("is_layer_y_sort_enabled", "layer"), &TileMap::is_layer_y_sort_enabled);
-	ClassDB::bind_method(D_METHOD("set_layer_y_sort_origin", "layer", "y_sort_origin"), &TileMap::set_layer_y_sort_origin);
-	ClassDB::bind_method(D_METHOD("get_layer_y_sort_origin", "layer"), &TileMap::get_layer_y_sort_origin);
+	ClassDB::bind_method(D_METHOD("set_layer_axis_sort_enabled", "layer", "axis_sort_enabled"), &TileMap::set_layer_axis_sort_enabled);
+	ClassDB::bind_method(D_METHOD("is_layer_axis_sort_enabled", "layer"), &TileMap::is_layer_axis_sort_enabled);
+	ClassDB::bind_method(D_METHOD("set_layer_axis_sort_origin", "layer", "axis_sort_origin"), &TileMap::set_layer_axis_sort_origin);
+	ClassDB::bind_method(D_METHOD("get_layer_axis_sort_origin", "layer"), &TileMap::get_layer_axis_sort_origin);
 	ClassDB::bind_method(D_METHOD("set_layer_z_index", "layer", "z_index"), &TileMap::set_layer_z_index);
 	ClassDB::bind_method(D_METHOD("get_layer_z_index", "layer"), &TileMap::get_layer_z_index);
 #ifndef NAVIGATION_2D_DISABLED
@@ -1030,8 +1030,8 @@ TileMap::TileMap() {
 		base_property_helper.register_property(PropertyInfo(Variant::STRING, "name"), defaults->get_name(), &TileMap::set_layer_name, &TileMap::get_layer_name);
 		base_property_helper.register_property(PropertyInfo(Variant::BOOL, "enabled"), defaults->is_enabled(), &TileMap::set_layer_enabled, &TileMap::is_layer_enabled);
 		base_property_helper.register_property(PropertyInfo(Variant::COLOR, "modulate"), defaults->get_modulate(), &TileMap::set_layer_modulate, &TileMap::get_layer_modulate);
-		base_property_helper.register_property(PropertyInfo(Variant::BOOL, "y_sort_enabled"), defaults->is_y_sort_enabled(), &TileMap::set_layer_y_sort_enabled, &TileMap::is_layer_y_sort_enabled);
-		base_property_helper.register_property(PropertyInfo(Variant::INT, "y_sort_origin", PROPERTY_HINT_NONE, "suffix:px"), defaults->get_y_sort_origin(), &TileMap::set_layer_y_sort_origin, &TileMap::get_layer_y_sort_origin);
+		base_property_helper.register_property(PropertyInfo(Variant::BOOL, "axis_sort_enabled"), defaults->is_axis_sort_enabled(), &TileMap::set_layer_axis_sort_enabled, &TileMap::is_layer_axis_sort_enabled);
+		base_property_helper.register_property(PropertyInfo(Variant::VECTOR2I, "axis_sort_origin", PROPERTY_HINT_NONE, "suffix:px"), defaults->get_axis_sort_origin(), &TileMap::set_layer_axis_sort_origin, &TileMap::get_layer_axis_sort_origin);
 		base_property_helper.register_property(PropertyInfo(Variant::INT, "z_index"), defaults->get_z_index(), &TileMap::set_layer_z_index, &TileMap::get_layer_z_index);
 #ifndef NAVIGATION_2D_DISABLED
 		base_property_helper.register_property(PropertyInfo(Variant::BOOL, "navigation_enabled"), defaults->is_navigation_enabled(), &TileMap::set_layer_navigation_enabled, &TileMap::is_layer_navigation_enabled);

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -141,10 +141,10 @@ public:
 	bool is_layer_enabled(int p_layer) const;
 	void set_layer_modulate(int p_layer, Color p_modulate);
 	Color get_layer_modulate(int p_layer) const;
-	void set_layer_y_sort_enabled(int p_layer, bool p_enabled);
-	bool is_layer_y_sort_enabled(int p_layer) const;
-	void set_layer_y_sort_origin(int p_layer, int p_y_sort_origin);
-	int get_layer_y_sort_origin(int p_layer) const;
+	void set_layer_axis_sort_enabled(int p_layer, bool p_enabled);
+	bool is_layer_axis_sort_enabled(int p_layer) const;
+	void set_layer_axis_sort_origin(int p_layer, Vector2i p_axis_sort_origin);
+	Vector2i get_layer_axis_sort_origin(int p_layer) const;
 	void set_layer_z_index(int p_layer, int p_z_index);
 	int get_layer_z_index(int p_layer) const;
 #ifndef NAVIGATION_2D_DISABLED
@@ -198,7 +198,7 @@ public:
 	TileMapCell get_cell(int p_layer, const Vector2i &p_coords, bool p_use_proxies = false) const;
 	int get_effective_quadrant_size(int p_layer) const;
 
-	virtual void set_y_sort_enabled(bool p_enable) override;
+	virtual void set_axis_sort_enabled(bool p_enable) override;
 
 	Vector2 map_to_local(const Vector2i &p_pos) const;
 	Vector2i local_to_map(const Vector2 &p_pos) const;

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -304,7 +304,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 				rendering_quadrant->canvas_items.clear();
 
 				// Sort the quadrant cells.
-				if (is_axis_sort_enabled() && x_draw_order_reversed) {
+				if (is_axis_sort_enabled()) {
 					rendering_quadrant->cells.sort_custom<CellDataAxisSortComparator>();
 				} else {
 					rendering_quadrant->cells.sort();

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -243,8 +243,8 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 
 	// Check if anything changed that might change the quadrant shape.
 	// If so, recreate everything.
-	bool quadrant_shape_changed = dirty.flags[DIRTY_FLAGS_LAYER_axis_sort_ENABLED] || dirty.flags[DIRTY_FLAGS_TILE_SET] ||
-			(is_axis_sort_enabled() && (dirty.flags[DIRTY_FLAGS_LAYER_axis_sort_ORIGIN] || dirty.flags[DIRTY_FLAGS_LAYER_X_DRAW_ORDER_REVERSED] || dirty.flags[DIRTY_FLAGS_LAYER_LOCAL_TRANSFORM])) ||
+	bool quadrant_shape_changed = dirty.flags[DIRTY_FLAGS_LAYER_AXIS_SORT_ENABLED] || dirty.flags[DIRTY_FLAGS_TILE_SET] ||
+			(is_axis_sort_enabled() && (dirty.flags[DIRTY_FLAGS_LAYER_AXIS_SORT_ORIGIN] || dirty.flags[DIRTY_FLAGS_LAYER_X_DRAW_ORDER_REVERSED] || dirty.flags[DIRTY_FLAGS_LAYER_LOCAL_TRANSFORM])) ||
 			(!is_axis_sort_enabled() && dirty.flags[DIRTY_FLAGS_LAYER_RENDERING_QUADRANT_SIZE]);
 
 	// Free all quadrants.
@@ -305,7 +305,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 
 				// Sort the quadrant cells.
 				if (is_axis_sort_enabled() && x_draw_order_reversed) {
-					rendering_quadrant->cells.sort_custom<CellDataYSortedXReversedComparator>();
+					rendering_quadrant->cells.sort_custom<CellDataAxisSortComparator>();
 				} else {
 					rendering_quadrant->cells.sort();
 				}
@@ -3310,7 +3310,7 @@ void TileMapLayer::set_axis_sort_enabled(bool p_axis_sort_enabled) {
 		return;
 	}
 	CanvasItem::set_axis_sort_enabled(p_axis_sort_enabled);
-	dirty.flags[DIRTY_FLAGS_LAYER_axis_sort_ENABLED] = true;
+	dirty.flags[DIRTY_FLAGS_LAYER_AXIS_SORT_ENABLED] = true;
 	_queue_internal_update();
 	emit_signal(CoreStringName(changed));
 
@@ -3323,7 +3323,7 @@ void TileMapLayer::set_axis_sort_origin(Vector2i p_axis_sort_origin) {
 		return;
 	}
 	axis_sort_origin = p_axis_sort_origin;
-	dirty.flags[DIRTY_FLAGS_LAYER_axis_sort_ORIGIN] = true;
+	dirty.flags[DIRTY_FLAGS_LAYER_AXIS_SORT_ORIGIN] = true;
 	_queue_internal_update();
 	emit_signal(CoreStringName(changed));
 }

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -243,9 +243,9 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 
 	// Check if anything changed that might change the quadrant shape.
 	// If so, recreate everything.
-	bool quadrant_shape_changed = dirty.flags[DIRTY_FLAGS_LAYER_Y_SORT_ENABLED] || dirty.flags[DIRTY_FLAGS_TILE_SET] ||
-			(is_y_sort_enabled() && (dirty.flags[DIRTY_FLAGS_LAYER_Y_SORT_ORIGIN] || dirty.flags[DIRTY_FLAGS_LAYER_X_DRAW_ORDER_REVERSED] || dirty.flags[DIRTY_FLAGS_LAYER_LOCAL_TRANSFORM])) ||
-			(!is_y_sort_enabled() && dirty.flags[DIRTY_FLAGS_LAYER_RENDERING_QUADRANT_SIZE]);
+	bool quadrant_shape_changed = dirty.flags[DIRTY_FLAGS_LAYER_axis_sort_ENABLED] || dirty.flags[DIRTY_FLAGS_TILE_SET] ||
+			(is_axis_sort_enabled() && (dirty.flags[DIRTY_FLAGS_LAYER_axis_sort_ORIGIN] || dirty.flags[DIRTY_FLAGS_LAYER_X_DRAW_ORDER_REVERSED] || dirty.flags[DIRTY_FLAGS_LAYER_LOCAL_TRANSFORM])) ||
+			(!is_axis_sort_enabled() && dirty.flags[DIRTY_FLAGS_LAYER_RENDERING_QUADRANT_SIZE]);
 
 	// Free all quadrants.
 	if (!_rendering_was_cleaned_up && (forced_cleanup || quadrant_shape_changed)) {
@@ -304,7 +304,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 				rendering_quadrant->canvas_items.clear();
 
 				// Sort the quadrant cells.
-				if (is_y_sort_enabled() && x_draw_order_reversed) {
+				if (is_axis_sort_enabled() && x_draw_order_reversed) {
 					rendering_quadrant->cells.sort_custom<CellDataYSortedXReversedComparator>();
 				} else {
 					rendering_quadrant->cells.sort();
@@ -520,9 +520,9 @@ void TileMapLayer::_rendering_notification(int p_what) {
 }
 
 void TileMapLayer::_rendering_quadrants_update_cell(CellData &r_cell_data, SelfList<RenderingQuadrant>::List &r_dirty_rendering_quadrant_list) {
-	// Check if the cell is valid and retrieve its y_sort_origin.
+	// Check if the cell is valid and retrieve its axis_sort_origin.
 	bool is_valid = false;
-	int tile_y_sort_origin = 0;
+	Vector2i tile_axis_sort_origin = Vector2i(0, 0);
 	TileSetSource *source;
 	if (tile_set->has_source(r_cell_data.cell.source_id)) {
 		source = *tile_set->get_source(r_cell_data.cell.source_id);
@@ -535,7 +535,7 @@ void TileMapLayer::_rendering_quadrants_update_cell(CellData &r_cell_data, SelfL
 			} else {
 				tile_data = atlas_source->get_tile_data(r_cell_data.cell.get_atlas_coords(), r_cell_data.cell.alternative_tile);
 			}
-			tile_y_sort_origin = tile_data->get_y_sort_origin();
+			tile_axis_sort_origin = tile_data->get_axis_sort_origin();
 		}
 	}
 
@@ -543,8 +543,8 @@ void TileMapLayer::_rendering_quadrants_update_cell(CellData &r_cell_data, SelfL
 		// Get the quadrant coords.
 		Vector2 canvas_items_position;
 		Vector2i quadrant_coords;
-		if (is_y_sort_enabled()) {
-			canvas_items_position = Vector2(0, tile_set->map_to_local(r_cell_data.coords).y + tile_y_sort_origin + y_sort_origin);
+		if (is_axis_sort_enabled()) {
+			canvas_items_position = tile_set->map_to_local(r_cell_data.coords) + tile_axis_sort_origin + axis_sort_origin;
 			quadrant_coords = canvas_items_position * 100;
 		} else {
 			const Vector2i &coords = r_cell_data.coords;
@@ -979,7 +979,7 @@ void TileMapLayer::_physics_update(bool p_force_cleanup) {
 }
 
 void TileMapLayer::_physics_quadrants_update_cell(CellData &r_cell_data, SelfList<PhysicsQuadrant>::List &r_dirty_physics_quadrant_list) {
-	// Check if the cell is valid and retrieve its y_sort_origin.
+	// Check if the cell is valid and retrieve its axis_sort_origin.
 	bool is_valid = false;
 	TileSetSource *source;
 	if (tile_set->has_source(r_cell_data.cell.source_id)) {
@@ -2021,9 +2021,9 @@ void TileMapLayer::_renamed() {
 }
 
 void TileMapLayer::_update_notify_local_transform() {
-	bool notify = is_using_kinematic_bodies() || is_y_sort_enabled();
+	bool notify = is_using_kinematic_bodies() || is_axis_sort_enabled();
 	if (!notify) {
-		if (is_y_sort_enabled()) {
+		if (is_axis_sort_enabled()) {
 			notify = true;
 		}
 	}
@@ -2232,8 +2232,8 @@ void TileMapLayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_tile_set", "tile_set"), &TileMapLayer::set_tile_set);
 	ClassDB::bind_method(D_METHOD("get_tile_set"), &TileMapLayer::get_tile_set);
 
-	ClassDB::bind_method(D_METHOD("set_y_sort_origin", "y_sort_origin"), &TileMapLayer::set_y_sort_origin);
-	ClassDB::bind_method(D_METHOD("get_y_sort_origin"), &TileMapLayer::get_y_sort_origin);
+	ClassDB::bind_method(D_METHOD("set_axis_sort_origin", "axis_sort_origin"), &TileMapLayer::set_axis_sort_origin);
+	ClassDB::bind_method(D_METHOD("get_axis_sort_origin"), &TileMapLayer::get_axis_sort_origin);
 	ClassDB::bind_method(D_METHOD("set_x_draw_order_reversed", "x_draw_order_reversed"), &TileMapLayer::set_x_draw_order_reversed);
 	ClassDB::bind_method(D_METHOD("is_x_draw_order_reversed"), &TileMapLayer::is_x_draw_order_reversed);
 	ClassDB::bind_method(D_METHOD("set_rendering_quadrant_size", "size"), &TileMapLayer::set_rendering_quadrant_size);
@@ -2270,7 +2270,7 @@ void TileMapLayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "tile_set", PROPERTY_HINT_RESOURCE_TYPE, "TileSet"), "set_tile_set", "get_tile_set");
 	ADD_GROUP("Rendering", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "occlusion_enabled"), "set_occlusion_enabled", "is_occlusion_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "y_sort_origin"), "set_y_sort_origin", "get_y_sort_origin");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "axis_sort_origin"), "set_axis_sort_origin", "get_axis_sort_origin");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "x_draw_order_reversed"), "set_x_draw_order_reversed", "is_x_draw_order_reversed");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "rendering_quadrant_size"), "set_rendering_quadrant_size", "get_rendering_quadrant_size");
 	ADD_GROUP("Physics", "");
@@ -2297,7 +2297,7 @@ void TileMapLayer::_validate_property(PropertyInfo &p_property) const {
 	if (!Engine::get_singleton()->is_editor_hint()) {
 		return;
 	}
-	if (is_y_sort_enabled()) {
+	if (is_axis_sort_enabled()) {
 		if (p_property.name == "rendering_quadrant_size") {
 			p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 		}
@@ -3305,12 +3305,12 @@ void TileMapLayer::set_self_modulate(const Color &p_self_modulate) {
 	emit_signal(CoreStringName(changed));
 }
 
-void TileMapLayer::set_y_sort_enabled(bool p_y_sort_enabled) {
-	if (is_y_sort_enabled() == p_y_sort_enabled) {
+void TileMapLayer::set_axis_sort_enabled(bool p_axis_sort_enabled) {
+	if (is_axis_sort_enabled() == p_axis_sort_enabled) {
 		return;
 	}
-	CanvasItem::set_y_sort_enabled(p_y_sort_enabled);
-	dirty.flags[DIRTY_FLAGS_LAYER_Y_SORT_ENABLED] = true;
+	CanvasItem::set_axis_sort_enabled(p_axis_sort_enabled);
+	dirty.flags[DIRTY_FLAGS_LAYER_axis_sort_ENABLED] = true;
 	_queue_internal_update();
 	emit_signal(CoreStringName(changed));
 
@@ -3318,18 +3318,18 @@ void TileMapLayer::set_y_sort_enabled(bool p_y_sort_enabled) {
 	_update_notify_local_transform();
 }
 
-void TileMapLayer::set_y_sort_origin(int p_y_sort_origin) {
-	if (y_sort_origin == p_y_sort_origin) {
+void TileMapLayer::set_axis_sort_origin(Vector2i p_axis_sort_origin) {
+	if (axis_sort_origin == p_axis_sort_origin) {
 		return;
 	}
-	y_sort_origin = p_y_sort_origin;
-	dirty.flags[DIRTY_FLAGS_LAYER_Y_SORT_ORIGIN] = true;
+	axis_sort_origin = p_axis_sort_origin;
+	dirty.flags[DIRTY_FLAGS_LAYER_axis_sort_ORIGIN] = true;
 	_queue_internal_update();
 	emit_signal(CoreStringName(changed));
 }
 
-int TileMapLayer::get_y_sort_origin() const {
-	return y_sort_origin;
+Vector2i TileMapLayer::get_axis_sort_origin() const {
+	return axis_sort_origin;
 }
 
 void TileMapLayer::set_x_draw_order_reversed(bool p_x_draw_order_reversed) {

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -170,10 +170,25 @@ struct CellData {
 	}
 };
 
-// We use another comparator for Y-sorted layers with reversed X drawing order.
-struct CellDataYSortedXReversedComparator {
+struct CellDataAxisSortComparator {
+	bool y_as_main = true;
+	bool x_ascending = true;
+	bool y_ascending = true;
+
 	_FORCE_INLINE_ bool operator()(const CellData &p_a, const CellData &p_b) const {
-		return p_a.coords.x == p_b.coords.x ? (p_a.coords.y < p_b.coords.y) : (p_a.coords.x > p_b.coords.x);
+		const Vector2i a_coords = p_a.coords;
+		const Vector2i b_coords = p_b.coords;
+		int a_main = y_as_main ? a_coords.y : a_coords.x;
+		int b_main = y_as_main ? b_coords.y : b_coords.x;
+		int a_secondary = y_as_main ? a_coords.x : a_coords.y;
+		int b_secondary = y_as_main ? b_coords.x : b_coords.y;
+		bool main_ascending = y_as_main ? y_ascending : x_ascending;
+		bool secondary_ascending = y_as_main ? x_ascending : y_ascending;
+
+		if (a_main == b_main) {
+			return secondary_ascending ? a_secondary < b_secondary : a_secondary > b_secondary;
+		}
+		return main_ascending ? a_main < b_main : a_main > b_main;
 	}
 };
 
@@ -352,8 +367,8 @@ public:
 		DIRTY_FLAGS_LAYER_LOCAL_TRANSFORM,
 		DIRTY_FLAGS_LAYER_VISIBILITY,
 		DIRTY_FLAGS_LAYER_SELF_MODULATE,
-		DIRTY_FLAGS_LAYER_axis_sort_ENABLED,
-		DIRTY_FLAGS_LAYER_axis_sort_ORIGIN,
+		DIRTY_FLAGS_LAYER_AXIS_SORT_ENABLED,
+		DIRTY_FLAGS_LAYER_AXIS_SORT_ORIGIN,
 		DIRTY_FLAGS_LAYER_X_DRAW_ORDER_REVERSED,
 		DIRTY_FLAGS_LAYER_Z_INDEX,
 		DIRTY_FLAGS_LAYER_LIGHT_MASK,

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -352,8 +352,8 @@ public:
 		DIRTY_FLAGS_LAYER_LOCAL_TRANSFORM,
 		DIRTY_FLAGS_LAYER_VISIBILITY,
 		DIRTY_FLAGS_LAYER_SELF_MODULATE,
-		DIRTY_FLAGS_LAYER_Y_SORT_ENABLED,
-		DIRTY_FLAGS_LAYER_Y_SORT_ORIGIN,
+		DIRTY_FLAGS_LAYER_axis_sort_ENABLED,
+		DIRTY_FLAGS_LAYER_axis_sort_ORIGIN,
 		DIRTY_FLAGS_LAYER_X_DRAW_ORDER_REVERSED,
 		DIRTY_FLAGS_LAYER_Z_INDEX,
 		DIRTY_FLAGS_LAYER_LIGHT_MASK,
@@ -392,7 +392,7 @@ private:
 
 	HighlightMode highlight_mode = HIGHLIGHT_MODE_DEFAULT;
 
-	int y_sort_origin = 0;
+	Vector2i axis_sort_origin = Vector2i(0, 0);
 	bool x_draw_order_reversed = false;
 	int rendering_quadrant_size = 16;
 
@@ -612,9 +612,9 @@ public:
 	HighlightMode get_highlight_mode() const;
 
 	virtual void set_self_modulate(const Color &p_self_modulate) override;
-	virtual void set_y_sort_enabled(bool p_y_sort_enabled) override;
-	void set_y_sort_origin(int p_y_sort_origin);
-	int get_y_sort_origin() const;
+	virtual void set_axis_sort_enabled(bool p_axis_sort_enabled) override;
+	void set_axis_sort_origin(Vector2i p_axis_sort_origin);
+	Vector2i get_axis_sort_origin() const;
 	void set_x_draw_order_reversed(bool p_x_draw_order_reversed);
 	bool is_x_draw_order_reversed() const;
 	virtual void set_z_index(int p_z_index) override;

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -703,15 +703,48 @@ int CanvasItem::get_effective_z_index() const {
 	return effective_z_index;
 }
 
-void CanvasItem::set_y_sort_enabled(bool p_enabled) {
+void CanvasItem::set_axis_sort_enabled(bool p_enabled) {
 	ERR_THREAD_GUARD;
-	y_sort_enabled = p_enabled;
-	RS::get_singleton()->canvas_item_set_sort_children_by_y(canvas_item, y_sort_enabled);
+	axis_sort_enabled = p_enabled;
+	RS::get_singleton()->canvas_item_set_sort_children_by_axis(canvas_item, axis_sort_enabled);
 }
 
-bool CanvasItem::is_y_sort_enabled() const {
+bool CanvasItem::is_axis_sort_enabled() const {
 	ERR_READ_THREAD_GUARD_V(false);
-	return y_sort_enabled;
+	return axis_sort_enabled;
+}
+
+void CanvasItem::set_axis_sort_y_as_main(bool p_enabled) {
+	ERR_THREAD_GUARD;
+	axis_sort_y_as_main = p_enabled;
+	RS::get_singleton()->canvas_item_set_sort_children_by_axis_y_as_main(canvas_item, axis_sort_y_as_main);
+}
+
+bool CanvasItem::is_axis_sort_y_as_main() const {
+	ERR_READ_THREAD_GUARD_V(false);
+	return axis_sort_y_as_main;
+}
+
+void CanvasItem::set_axis_sort_x_ascending(bool p_enabled) {
+	ERR_THREAD_GUARD;
+	axis_sort_x_ascending = p_enabled;
+	RS::get_singleton()->canvas_item_set_sort_children_by_axis_x_ascending(canvas_item, axis_sort_x_ascending);
+}
+
+bool CanvasItem::is_axis_sort_x_ascending() const {
+	ERR_READ_THREAD_GUARD_V(false);
+	return axis_sort_x_ascending;
+}
+
+void CanvasItem::set_axis_sort_y_ascending(bool p_enabled) {
+	ERR_THREAD_GUARD;
+	axis_sort_y_ascending = p_enabled;
+	RS::get_singleton()->canvas_item_set_sort_children_by_axis_y_ascending(canvas_item, axis_sort_y_ascending);
+}
+
+bool CanvasItem::is_axis_sort_y_ascending() const {
+	ERR_READ_THREAD_GUARD_V(false);
+	return axis_sort_y_ascending;
 }
 
 void CanvasItem::draw_dashed_line(const Point2 &p_from, const Point2 &p_to, const Color &p_color, real_t p_width, real_t p_dash, bool p_aligned, bool p_antialiased) {
@@ -1379,8 +1412,14 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_z_as_relative", "enable"), &CanvasItem::set_z_as_relative);
 	ClassDB::bind_method(D_METHOD("is_z_relative"), &CanvasItem::is_z_relative);
 
-	ClassDB::bind_method(D_METHOD("set_y_sort_enabled", "enabled"), &CanvasItem::set_y_sort_enabled);
-	ClassDB::bind_method(D_METHOD("is_y_sort_enabled"), &CanvasItem::is_y_sort_enabled);
+	ClassDB::bind_method(D_METHOD("set_axis_sort_enabled", "enabled"), &CanvasItem::set_axis_sort_enabled);
+	ClassDB::bind_method(D_METHOD("is_axis_sort_enabled"), &CanvasItem::is_axis_sort_enabled);
+	ClassDB::bind_method(D_METHOD("set_axis_sort_y_as_main", "enabled"), &CanvasItem::set_axis_sort_y_as_main);
+	ClassDB::bind_method(D_METHOD("is_axis_sort_y_as_main"), &CanvasItem::is_axis_sort_y_as_main);
+	ClassDB::bind_method(D_METHOD("set_axis_sort_x_ascending", "enabled"), &CanvasItem::set_axis_sort_x_ascending);
+	ClassDB::bind_method(D_METHOD("is_axis_sort_x_ascending"), &CanvasItem::is_axis_sort_x_ascending);
+	ClassDB::bind_method(D_METHOD("set_axis_sort_y_ascending", "enabled"), &CanvasItem::set_axis_sort_y_ascending);
+	ClassDB::bind_method(D_METHOD("is_axis_sort_y_ascending"), &CanvasItem::is_axis_sort_y_ascending);
 
 	ClassDB::bind_method(D_METHOD("set_draw_behind_parent", "enable"), &CanvasItem::set_draw_behind_parent);
 	ClassDB::bind_method(D_METHOD("is_draw_behind_parent_enabled"), &CanvasItem::is_draw_behind_parent_enabled);
@@ -1480,7 +1519,10 @@ void CanvasItem::_bind_methods() {
 	ADD_GROUP("Ordering", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "z_index", PROPERTY_HINT_RANGE, itos(RS::CANVAS_ITEM_Z_MIN) + "," + itos(RS::CANVAS_ITEM_Z_MAX) + ",1"), "set_z_index", "get_z_index");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "z_as_relative"), "set_z_as_relative", "is_z_relative");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "y_sort_enabled"), "set_y_sort_enabled", "is_y_sort_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "axis_sort_enabled"), "set_axis_sort_enabled", "is_axis_sort_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "axis_sort_y_as_main"), "set_axis_sort_y_as_main", "is_axis_sort_y_as_main");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "axis_sort_x_ascending"), "set_axis_sort_x_ascending", "is_axis_sort_x_ascending");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "axis_sort_y_ascending"), "set_axis_sort_y_ascending", "is_axis_sort_y_ascending");
 
 	ADD_GROUP("Texture", "texture_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filter", PROPERTY_HINT_ENUM, "Inherit,Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), "set_texture_filter", "get_texture_filter");

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1520,7 +1520,7 @@ void CanvasItem::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "z_index", PROPERTY_HINT_RANGE, itos(RS::CANVAS_ITEM_Z_MIN) + "," + itos(RS::CANVAS_ITEM_Z_MAX) + ",1"), "set_z_index", "get_z_index");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "z_as_relative"), "set_z_as_relative", "is_z_relative");
 	ADD_SUBGROUP("Axis Sort", "axis_sort_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "axis_sort_enabled", PROPERTY_HINT_GROUP_ENABLE),  "set_axis_sort_enabled", "is_axis_sort_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "axis_sort_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_axis_sort_enabled", "is_axis_sort_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "axis_sort_y_as_main"), "set_axis_sort_y_as_main", "is_axis_sort_y_as_main");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "axis_sort_x_ascending"), "set_axis_sort_x_ascending", "is_axis_sort_x_ascending");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "axis_sort_y_ascending"), "set_axis_sort_y_ascending", "is_axis_sort_y_ascending");

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1519,7 +1519,8 @@ void CanvasItem::_bind_methods() {
 	ADD_GROUP("Ordering", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "z_index", PROPERTY_HINT_RANGE, itos(RS::CANVAS_ITEM_Z_MIN) + "," + itos(RS::CANVAS_ITEM_Z_MAX) + ",1"), "set_z_index", "get_z_index");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "z_as_relative"), "set_z_as_relative", "is_z_relative");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "axis_sort_enabled"), "set_axis_sort_enabled", "is_axis_sort_enabled");
+	ADD_SUBGROUP("Axis Sort", "axis_sort_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "axis_sort_enabled", PROPERTY_HINT_GROUP_ENABLE),  "set_axis_sort_enabled", "is_axis_sort_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "axis_sort_y_as_main"), "set_axis_sort_y_as_main", "is_axis_sort_y_as_main");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "axis_sort_x_ascending"), "set_axis_sort_x_ascending", "is_axis_sort_x_ascending");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "axis_sort_y_ascending"), "set_axis_sort_y_ascending", "is_axis_sort_y_ascending");

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -101,9 +101,9 @@ private:
 	int z_index = 0;
 	bool z_relative = true;
 	bool axis_sort_enabled = false;
-	bool axis_sort_enabled_y_as_main = false;
-	bool axis_sort_enabled_x_ascending = false;
-	bool axis_sort_enabled_y_ascending = false;
+	bool axis_sort_y_as_main = false;
+	bool axis_sort_x_ascending = false;
+	bool axis_sort_y_ascending = false;
 
 	Window *window = nullptr;
 	bool visible = true;

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -101,9 +101,9 @@ private:
 	int z_index = 0;
 	bool z_relative = true;
 	bool axis_sort_enabled = false;
-	bool axis_sort_y_as_main = false;
-	bool axis_sort_x_ascending = false;
-	bool axis_sort_y_ascending = false;
+	bool axis_sort_y_as_main = true;
+	bool axis_sort_x_ascending = true;
+	bool axis_sort_y_ascending = true;
 
 	Window *window = nullptr;
 	bool visible = true;

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -100,7 +100,10 @@ private:
 
 	int z_index = 0;
 	bool z_relative = true;
-	bool y_sort_enabled = false;
+	bool axis_sort_enabled = false;
+	bool axis_sort_enabled_y_as_main = false;
+	bool axis_sort_enabled_x_ascending = false;
+	bool axis_sort_enabled_y_ascending = false;
 
 	Window *window = nullptr;
 	bool visible = true;
@@ -300,8 +303,14 @@ public:
 	void set_z_as_relative(bool p_enabled);
 	bool is_z_relative() const;
 
-	virtual void set_y_sort_enabled(bool p_enabled);
-	virtual bool is_y_sort_enabled() const;
+	virtual void set_axis_sort_enabled(bool p_enabled);
+	virtual bool is_axis_sort_enabled() const;
+	virtual void set_axis_sort_y_as_main(bool p_enabled);
+	virtual bool is_axis_sort_y_as_main() const;
+	virtual void set_axis_sort_x_ascending(bool p_enabled);
+	virtual bool is_axis_sort_x_ascending() const;
+	virtual void set_axis_sort_y_ascending(bool p_enabled);
+	virtual bool is_axis_sort_y_ascending() const;
 
 	/* DRAWING API */
 

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -6166,7 +6166,7 @@ TileData *TileData::duplicate() {
 	output->material = material;
 	output->modulate = modulate;
 	output->z_index = z_index;
-	output->y_sort_origin = y_sort_origin;
+	output->axis_sort_origin = axis_sort_origin;
 	output->occluders = occluders;
 #ifndef PHYSICS_2D_DISABLED
 	// Physics
@@ -6249,12 +6249,12 @@ int TileData::get_z_index() const {
 	return z_index;
 }
 
-void TileData::set_y_sort_origin(int p_y_sort_origin) {
-	y_sort_origin = p_y_sort_origin;
+void TileData::set_axis_sort_origin(Vector2i p_axis_sort_origin) {
+	axis_sort_origin = p_axis_sort_origin;
 	emit_signal(CoreStringName(changed));
 }
-int TileData::get_y_sort_origin() const {
-	return y_sort_origin;
+Vector2i TileData::get_axis_sort_origin() const {
+	return axis_sort_origin;
 }
 
 #ifndef DISABLE_DEPRECATED
@@ -7094,8 +7094,8 @@ void TileData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_modulate"), &TileData::get_modulate);
 	ClassDB::bind_method(D_METHOD("set_z_index", "z_index"), &TileData::set_z_index);
 	ClassDB::bind_method(D_METHOD("get_z_index"), &TileData::get_z_index);
-	ClassDB::bind_method(D_METHOD("set_y_sort_origin", "y_sort_origin"), &TileData::set_y_sort_origin);
-	ClassDB::bind_method(D_METHOD("get_y_sort_origin"), &TileData::get_y_sort_origin);
+	ClassDB::bind_method(D_METHOD("set_axis_sort_origin", "axis_sort_origin"), &TileData::set_axis_sort_origin);
+	ClassDB::bind_method(D_METHOD("get_axis_sort_origin"), &TileData::get_axis_sort_origin);
 
 	ClassDB::bind_method(D_METHOD("set_occluder_polygons_count", "layer_id", "polygons_count"), &TileData::set_occluder_polygons_count);
 	ClassDB::bind_method(D_METHOD("get_occluder_polygons_count", "layer_id"), &TileData::get_occluder_polygons_count);
@@ -7161,7 +7161,7 @@ void TileData::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "modulate"), "set_modulate", "get_modulate");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "CanvasItemMaterial,ShaderMaterial"), "set_material", "get_material");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "z_index"), "set_z_index", "get_z_index");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "y_sort_origin"), "set_y_sort_origin", "get_y_sort_origin");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "axis_sort_origin"), "set_axis_sort_origin", "get_axis_sort_origin");
 
 	ADD_GROUP("Terrains", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "terrain_set"), "set_terrain_set", "get_terrain_set");

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -855,7 +855,7 @@ private:
 	Ref<Material> material;
 	Color modulate = Color(1.0, 1.0, 1.0, 1.0);
 	int z_index = 0;
-	int y_sort_origin = 0;
+	Vector2i axis_sort_origin = Vector2i(0, 0);
 	struct OcclusionLayerTileData {
 		struct PolygonOccluderTileData {
 			Ref<OccluderPolygon2D> occluder_polygon;
@@ -965,8 +965,8 @@ public:
 	Color get_modulate() const;
 	void set_z_index(int p_z_index);
 	int get_z_index() const;
-	void set_y_sort_origin(int p_y_sort_origin);
-	int get_y_sort_origin() const;
+	void set_axis_sort_origin(Vector2i p_axis_sort_origin);
+	Vector2i get_axis_sort_origin() const;
 
 #ifndef DISABLE_DEPRECATED
 	void set_occluder(int p_layer_id, Ref<OccluderPolygon2D> p_occluder_polygon);

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -172,7 +172,7 @@ int RendererCanvasCull::_count_axis_sort_children(RendererCanvasCull::Item *p_ca
 			axis_sort_children_count++;
 			if (child_items[i]->sort_axis) {
 				if (child_items[i]->axis_sort_children_count == -1) {
-					child_items[i]->axis_children_count = _count_axis_sort_children(child_items[i]);
+					child_items[i]->axis_sort_children_count = _count_axis_sort_children(child_items[i]);
 				}
 				axis_sort_children_count += child_items[i]->axis_sort_children_count;
 			}

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -455,11 +455,6 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 			sorter.compare.y_as_main = ci->sort_axis_y_as_main;
 			sorter.compare.x_ascending = ci->sort_axis_x_ascending;
 			sorter.compare.y_ascending = ci->sort_axis_y_ascending;
-			// DELETE BOFORE PULL REQUEST.
-			print_line("sorter.compare.y_as_main = " + String(sorter.compare.y_as_main ? "true" : "false"));
-			print_line("sorter.compare.x_ascending = " + String(sorter.compare.x_ascending ? "true" : "false"));
-			print_line("sorter.compare.y_ascending = " + String(sorter.compare.y_ascending ? "true" : "false"));
-			//
 			sorter.sort(child_items, child_item_count);
 
 			for (i = 0; i < child_item_count; i++) {

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1840,6 +1840,33 @@ void RendererCanvasCull::canvas_item_set_sort_children_by_axis(RID p_item, bool 
 	_mark_axis_sort_dirty(canvas_item);
 }
 
+void RendererCanvasCull::canvas_item_set_sort_children_by_axis_y_as_main(RID p_item, bool p_enable) {
+	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
+	ERR_FAIL_NULL(canvas_item);
+
+	canvas_item->sort_axis_y_as_main = p_enable;
+
+	_mark_axis_sort_dirty(canvas_item);
+}
+
+void RendererCanvasCull::canvas_item_set_sort_children_by_axis_x_ascending(RID p_item, bool p_enable) {
+	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
+	ERR_FAIL_NULL(canvas_item);
+
+	canvas_item->sort_axis_x_ascending = p_enable;
+
+	_mark_axis_sort_dirty(canvas_item);
+}
+
+void RendererCanvasCull::canvas_item_set_sort_children_by_axis_y_ascending(RID p_item, bool p_enable) {
+	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
+	ERR_FAIL_NULL(canvas_item);
+
+	canvas_item->sort_axis_y_ascending = p_enable;
+
+	_mark_axis_sort_dirty(canvas_item);
+}
+
 void RendererCanvasCull::canvas_item_set_z_index(RID p_item, int p_z) {
 	ERR_FAIL_COND(p_z < RS::CANVAS_ITEM_Z_MIN || p_z > RS::CANVAS_ITEM_Z_MAX);
 

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -455,6 +455,11 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 			sorter.compare.y_as_main = ci->sort_axis_y_as_main;
 			sorter.compare.x_ascending = ci->sort_axis_x_ascending;
 			sorter.compare.y_ascending = ci->sort_axis_y_ascending;
+			// DELETE BOFORE PULL REQUEST.
+			print_line("sorter.compare.y_as_main = " + String(sorter.compare.y_as_main ? "true" : "false"));
+			print_line("sorter.compare.x_ascending = " + String(sorter.compare.x_ascending ? "true" : "false"));
+			print_line("sorter.compare.y_ascending = " + String(sorter.compare.y_ascending ? "true" : "false"));
+			//
 			sorter.sort(child_items, child_item_count);
 
 			for (i = 0; i < child_item_count; i++) {

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -107,7 +107,7 @@ void RendererCanvasCull::_render_canvas_item_tree(RID p_to_render_target, Canvas
 	}
 }
 
-void RendererCanvasCull::_collect_ysort_children(RendererCanvasCull::Item *p_canvas_item, RendererCanvasCull::Item *p_material_owner, const Color &p_modulate, RendererCanvasCull::Item **r_items, int &r_index, int &r_ysort_children_count, int p_z, uint32_t p_canvas_cull_mask) {
+void RendererCanvasCull::_collect_axis_sort_children(RendererCanvasCull::Item *p_canvas_item, RendererCanvasCull::Item *p_material_owner, const Color &p_modulate, RendererCanvasCull::Item **r_items, int &r_index, int &r_axis_sort_children_count, int p_z, uint32_t p_canvas_cull_mask) {
 	int child_item_count = p_canvas_item->child_items.size();
 	RendererCanvasCull::Item **child_items = p_canvas_item->child_items.ptrw();
 	for (int i = 0; i < child_item_count; i++) {
@@ -128,11 +128,11 @@ void RendererCanvasCull::_collect_ysort_children(RendererCanvasCull::Item *p_can
 				}
 
 				r_items[r_index] = child_items[i];
-				child_items[i]->ysort_xform = p_canvas_item->ysort_xform * child_xform;
+				child_items[i]->axis_sort_xform = p_canvas_item->axis_sort_xform * child_xform;
 				child_items[i]->material_owner = child_items[i]->use_parent_material ? p_material_owner : nullptr;
-				child_items[i]->ysort_modulate = p_modulate;
-				child_items[i]->ysort_index = r_index;
-				child_items[i]->ysort_parent_abs_z_index = p_z;
+				child_items[i]->axis_sort_modulate = p_modulate;
+				child_items[i]->axis_sort_index = r_index;
+				child_items[i]->axis_sort_parent_abs_z_index = p_z;
 
 				if (!child_items[i]->repeat_source) {
 					child_items[i]->repeat_size = p_canvas_item->repeat_size;
@@ -151,41 +151,41 @@ void RendererCanvasCull::_collect_ysort_children(RendererCanvasCull::Item *p_can
 				r_index++;
 
 				if (child_items[i]->sort_y) {
-					_collect_ysort_children(child_items[i], child_items[i]->use_parent_material ? p_material_owner : child_items[i], p_modulate * child_items[i]->modulate, r_items, r_index, r_ysort_children_count, abs_z, p_canvas_cull_mask);
+					_collect_axis_sort_children(child_items[i], child_items[i]->use_parent_material ? p_material_owner : child_items[i], p_modulate * child_items[i]->modulate, r_items, r_index, r_axis_sort_children_count, abs_z, p_canvas_cull_mask);
 				}
 			} else {
-				r_ysort_children_count--;
+				r_axis_sort_children_count--;
 				if (child_items[i]->sort_y) {
-					r_ysort_children_count -= child_items[i]->ysort_children_count;
+					r_axis_sort_children_count -= child_items[i]->axis_sort_children_count;
 				}
 			}
 		}
 	}
 }
 
-int RendererCanvasCull::_count_ysort_children(RendererCanvasCull::Item *p_canvas_item) {
-	int ysort_children_count = 0;
+int RendererCanvasCull::_count_axis_sort_children(RendererCanvasCull::Item *p_canvas_item) {
+	int axis_sort_children_count = 0;
 	int child_item_count = p_canvas_item->child_items.size();
 	RendererCanvasCull::Item *const *child_items = p_canvas_item->child_items.ptr();
 	for (int i = 0; i < child_item_count; i++) {
 		if (child_items[i]->visible) {
-			ysort_children_count++;
-			if (child_items[i]->sort_y) {
-				if (child_items[i]->ysort_children_count == -1) {
-					child_items[i]->ysort_children_count = _count_ysort_children(child_items[i]);
+			axis_sort_children_count++;
+			if (child_items[i]->sort_axis) {
+				if (child_items[i]->axis_sort_children_count == -1) {
+					child_items[i]->axis_children_count = _count_axis_sort_children(child_items[i]);
 				}
-				ysort_children_count += child_items[i]->ysort_children_count;
+				axis_sort_children_count += child_items[i]->axis_sort_children_count;
 			}
 		}
 	}
-	return ysort_children_count;
+	return axis_sort_children_count;
 }
 
-void RendererCanvasCull::_mark_ysort_dirty(RendererCanvasCull::Item *ysort_owner) {
+void RendererCanvasCull::_mark_axis_sort_dirty(RendererCanvasCull::Item *axis_sort_owner) {
 	do {
-		ysort_owner->ysort_children_count = -1;
-		ysort_owner = canvas_item_owner.owns(ysort_owner->parent) ? canvas_item_owner.get_or_null(ysort_owner->parent) : nullptr;
-	} while (ysort_owner && ysort_owner->sort_y);
+		axis_sort_owner->axis_sort_children_count = -1;
+		axis_sort_owner = canvas_item_owner.owns(axis_sort_owner->parent) ? canvas_item_owner.get_or_null(axis_sort_owner->parent) : nullptr;
+	} while (axis_sort_owner && axis_sort_owner->sort_axis);
 }
 
 void RendererCanvasCull::_attach_canvas_item_for_draw(RendererCanvasCull::Item *ci, RendererCanvasCull::Item *p_canvas_clip, RendererCanvasRender::Item **r_z_list, RendererCanvasRender::Item **r_z_last_list, const Transform2D &p_transform, const Rect2 &p_clip_rect, Rect2 p_global_rect, const Color &p_modulate, int p_z, RendererCanvasCull::Item *p_material_owner, bool p_use_canvas_group, RendererCanvasRender::Item *r_canvas_group_from) {
@@ -434,28 +434,28 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 		p_z = ci->z_index;
 	}
 
-	if (ci->sort_y) {
-		if (!p_is_already_y_sorted) {
-			if (ci->ysort_children_count == -1) {
-				ci->ysort_children_count = _count_ysort_children(ci);
+	if (ci->sort_axis) {
+		if (!p_is_already_axis_sorted) {
+			if (ci->axis_sort_children_count == -1) {
+				ci->axis_sort_children_count = _count_axis_sort_children(ci);
 			}
 
-			child_item_count = ci->ysort_children_count + 1;
+			child_item_count = ci->axis_sort_children_count + 1;
 			child_items = (Item **)alloca(child_item_count * sizeof(Item *));
 
-			ci->ysort_xform = Transform2D();
-			ci->ysort_modulate = Color(1, 1, 1, 1) / ci->modulate;
-			ci->ysort_index = 0;
-			ci->ysort_parent_abs_z_index = parent_z;
+			ci->axis_sort_xform = Transform2D();
+			ci->axis_sort_modulate = Color(1, 1, 1, 1) / ci->modulate;
+			ci->axis_sort_index = 0;
+			ci->axis_sort_parent_abs_z_index = parent_z;
 			child_items[0] = ci;
 			int i = 1;
-			_collect_ysort_children(ci, p_material_owner, Color(1, 1, 1, 1), child_items, i, child_item_count, p_z, p_canvas_cull_mask);
+			_collect_axis_sort_children(ci, p_material_owner, Color(1, 1, 1, 1), child_items, i, child_item_count, p_z, p_canvas_cull_mask);
 
-			SortArray<Item *, ItemYSort> sorter;
+			SortArray<Item *, ItemAxisSort> sorter;
 			sorter.sort(child_items, child_item_count);
 
 			for (i = 0; i < child_item_count; i++) {
-				_cull_canvas_item(child_items[i], final_xform * child_items[i]->ysort_xform, p_clip_rect, modulate * child_items[i]->ysort_modulate, child_items[i]->ysort_parent_abs_z_index, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, (Item *)child_items[i]->material_owner, true, p_canvas_cull_mask, child_items[i]->repeat_size, child_items[i]->repeat_times, child_items[i]->repeat_source_item);
+				_cull_canvas_item(child_items[i], final_xform * child_items[i]->axis_sort_xform, p_clip_rect, modulate * child_items[i]->axis_sort_modulate, child_items[i]->axis_sort_parent_abs_z_index, r_z_list, r_z_last_list, (Item *)ci->final_clip_owner, (Item *)child_items[i]->material_owner, true, p_canvas_cull_mask, child_items[i]->repeat_size, child_items[i]->repeat_times, child_items[i]->repeat_source_item);
 			}
 		} else {
 			RendererCanvasRender::Item *canvas_group_from = nullptr;
@@ -589,7 +589,7 @@ void RendererCanvasCull::canvas_item_set_parent(RID p_item, RID p_parent) {
 			item_owner->child_items.erase(canvas_item);
 
 			if (item_owner->sort_y) {
-				_mark_ysort_dirty(item_owner);
+				_mark_axis_sort_dirty(item_owner);
 			}
 		}
 
@@ -609,7 +609,7 @@ void RendererCanvasCull::canvas_item_set_parent(RID p_item, RID p_parent) {
 			item_owner->children_order_dirty = true;
 
 			if (item_owner->sort_y) {
-				_mark_ysort_dirty(item_owner);
+				_mark_axis_sort_dirty(item_owner);
 			}
 
 		} else {
@@ -626,7 +626,7 @@ void RendererCanvasCull::canvas_item_set_visible(RID p_item, bool p_visible) {
 
 	canvas_item->visible = p_visible;
 
-	_mark_ysort_dirty(canvas_item);
+	_mark_axis_sort_dirty(canvas_item);
 }
 
 void RendererCanvasCull::canvas_item_set_light_mask(RID p_item, int p_mask) {
@@ -1834,7 +1834,7 @@ void RendererCanvasCull::canvas_item_set_sort_children_by_y(RID p_item, bool p_e
 
 	canvas_item->sort_y = p_enable;
 
-	_mark_ysort_dirty(canvas_item);
+	_mark_axis_sort_dirty(canvas_item);
 }
 
 void RendererCanvasCull::canvas_item_set_z_index(RID p_item, int p_z) {
@@ -2605,7 +2605,7 @@ bool RendererCanvasCull::free(RID p_rid) {
 				item_owner->child_items.erase(canvas_item);
 
 				if (item_owner->sort_y) {
-					_mark_ysort_dirty(item_owner);
+					_mark_axis_sort_dirty(item_owner);
 				}
 			}
 		}

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -124,6 +124,18 @@ public:
 		}
 	};
 
+	struct ItemInverseYSort {
+		_FORCE_INLINE_ bool operator()(const Item *p_left, const Item *p_right) const {
+			const real_t left_y = p_left->ysort_xform.columns[2].y;
+			const real_t right_y = p_right->ysort_xform.columns[2].y;
+			if (Math::is_equal_approx(left_y, right_y)) {
+				return p_left->ysort_index < p_right->ysort_index;
+			}
+
+			return left_y > right_y;
+		}
+	};
+
 	struct LightOccluderPolygon {
 		bool active;
 		Rect2 aabb;

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -46,15 +46,18 @@ public:
 		List<Item *>::Element *E;
 		int z_index;
 		bool z_relative;
-		bool sort_y;
+		bool sort_axis;
+		bool sort_axis_y_as_main;
+		bool sort_axis_x_ascending;
+		bool sort_axis_y_ascending;
 		Color modulate;
 		Color self_modulate;
 		bool use_parent_material;
 		int index;
 		bool children_order_dirty;
-		int ysort_children_count;
-		Color ysort_modulate;
-		Transform2D ysort_xform; // Relative to y-sorted subtree's root item (identity for such root). Its `origin.y` is used for sorting.
+		int axis_sort_children_count;
+		Color axis_sort_modulate;
+		Transform2D axis_sort_xform; // Relative to y-sorted subtree's root item (identity for such root). Its `origin.y` is used for sorting.
 		int ysort_index;
 		int ysort_parent_abs_z_index; // Absolute Z index of parent. Only populated and used when y-sorting.
 		uint32_t visibility_layer = 0xffffffff;
@@ -107,28 +110,19 @@ public:
 	SelfList<Item>::List _item_update_list;
 
 	struct ItemAxisSort {
-		private:
-			bool _y_as_main = true;
-			bool _x_ascending = false;
-			bool _y_ascending = false;
-
-		public:
-			ItemAxisSort& y_as_main() { _y_as_main = true; return *this; }
-			ItemAxisSort& x_as_main() { _y_as_main = false; return *this; }
-			ItemAxisSort& x_ascending() { _x_ascending = true; return *this; }
-			ItemAxisSort& x_descending() { _x_ascending = false; return *this; }
-			ItemAxisSort& y_ascending() { _y_ascending = true; return *this; }
-			ItemAxisSort& y_descending() { _y_ascending = false; return *this; }
+		bool y_as_main = true;
+		bool x_ascending = false;
+		bool y_ascending = false;
 
 		_FORCE_INLINE_ bool operator()(const Item *p_left, const Item *p_right) const {
 			const Vector2 left_pos = p_left->ysort_xform.columns[2];
 			const Vector2 right_pos = p_right->ysort_xform.columns[2];
-			real_t left_main = _y_as_main ? left_pos.y : left_pos.x;
-			real_t right_main = _y_as_main ? right_pos.y : right_pos.x;
-			real_t left_secondary = _y_as_main ? left_pos.x : left_pos.y;
-			real_t right_secondary = _y_as_main ? right_pos.x : right_pos.y;
-			bool main_ascending = _y_as_main ? _y_ascending : _x_ascending;
-			bool secondary_ascending = _y_as_main ? _x_ascending : _y_ascending;
+			real_t left_main = y_as_main ? left_pos.y : left_pos.x;
+			real_t right_main = y_as_main ? right_pos.y : right_pos.x;
+			real_t left_secondary = y_as_main ? left_pos.x : left_pos.y;
+			real_t right_secondary = y_as_main ? right_pos.x : right_pos.y;
+			bool main_ascending = y_as_main ? y_ascending : x_ascending;
+			bool secondary_ascending = y_as_main ? x_ascending : y_ascending;
 
 			if (Math::is_equal_approx(left_main, right_main)) {
 				if (Math::is_equal_approx(left_secondary, right_secondary)) {

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -109,6 +109,12 @@ public:
 	void _item_queue_update(Item *p_item, bool p_update_dependencies);
 	SelfList<Item>::List _item_update_list;
 
+	struct ItemIndexSort {
+		_FORCE_INLINE_ bool operator()(const Item *p_left, const Item *p_right) const {
+			return p_left->index < p_right->index;
+		}
+	};
+
 	struct ItemAxisSort {
 		bool y_as_main = true;
 		bool x_ascending = false;
@@ -217,9 +223,9 @@ private:
 	void _render_canvas_item_tree(RID p_to_render_target, Canvas::ChildItem *p_child_items, int p_child_item_count, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, uint32_t p_canvas_cull_mask, RenderingMethod::RenderInfo *r_render_info = nullptr);
 	void _cull_canvas_item(Item *p_canvas_item, const Transform2D &p_parent_xform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **r_z_list, RendererCanvasRender::Item **r_z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool p_is_already_axis_sorted, uint32_t p_canvas_cull_mask, const Point2 &p_repeat_size, int p_repeat_times, RendererCanvasRender::Item *p_repeat_source_item);
 
-	void _collect_ysort_children(RendererCanvasCull::Item *p_canvas_item, RendererCanvasCull::Item *p_material_owner, const Color &p_modulate, RendererCanvasCull::Item **r_items, int &r_index, int &r_axis_sort_children_count, int p_z, uint32_t p_canvas_cull_mask);
-	int _count_ysort_children(RendererCanvasCull::Item *p_canvas_item);
-	void _mark_ysort_dirty(RendererCanvasCull::Item *ysort_owner);
+	void _collect_axis_sort_children(RendererCanvasCull::Item *p_canvas_item, RendererCanvasCull::Item *p_material_owner, const Color &p_modulate, RendererCanvasCull::Item **r_items, int &r_index, int &r_axis_sort_children_count, int p_z, uint32_t p_canvas_cull_mask);
+	int _count_axis_sort_children(RendererCanvasCull::Item *p_canvas_item);
+	void _mark_axis_sort_dirty(RendererCanvasCull::Item *axis_sort_owner);
 
 	static constexpr int z_range = RS::CANVAS_ITEM_Z_MAX - RS::CANVAS_ITEM_Z_MIN + 1;
 

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -58,8 +58,8 @@ public:
 		int axis_sort_children_count;
 		Color axis_sort_modulate;
 		Transform2D axis_sort_xform; // Relative to y-sorted subtree's root item (identity for such root). Its `origin.y` is used for sorting.
-		int ysort_index;
-		int ysort_parent_abs_z_index; // Absolute Z index of parent. Only populated and used when y-sorting.
+		int axis_sort_index;
+		int axis_sort_parent_abs_z_index; // Absolute Z index of parent. Only populated and used when y-sorting.
 		uint32_t visibility_layer = 0xffffffff;
 
 		Vector<Item *> child_items;
@@ -91,14 +91,14 @@ public:
 			z_index = 0;
 			modulate = Color(1, 1, 1, 1);
 			self_modulate = Color(1, 1, 1, 1);
-			sort_y = false;
+			sort_axis = false;
 			use_parent_material = false;
 			z_relative = true;
 			index = 0;
-			ysort_children_count = -1;
-			ysort_xform = Transform2D();
-			ysort_index = 0;
-			ysort_parent_abs_z_index = 0;
+			axis_sort_children_count = -1;
+			axis_sort_xform = Transform2D();
+			axis_sort_index = 0;
+			axis_sort_parent_abs_z_index = 0;
 
 			dependency_tracker.userdata = this;
 			dependency_tracker.changed_callback = &RendererCanvasCull::_dependency_changed;
@@ -115,8 +115,8 @@ public:
 		bool y_ascending = false;
 
 		_FORCE_INLINE_ bool operator()(const Item *p_left, const Item *p_right) const {
-			const Vector2 left_pos = p_left->ysort_xform.columns[2];
-			const Vector2 right_pos = p_right->ysort_xform.columns[2];
+			const Vector2 left_pos = p_left->axis_sort_xform.columns[2];
+			const Vector2 right_pos = p_right->axis_sort_xform.columns[2];
 			real_t left_main = y_as_main ? left_pos.y : left_pos.x;
 			real_t right_main = y_as_main ? right_pos.y : right_pos.x;
 			real_t left_secondary = y_as_main ? left_pos.x : left_pos.y;
@@ -215,9 +215,9 @@ public:
 
 private:
 	void _render_canvas_item_tree(RID p_to_render_target, Canvas::ChildItem *p_child_items, int p_child_item_count, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, uint32_t p_canvas_cull_mask, RenderingMethod::RenderInfo *r_render_info = nullptr);
-	void _cull_canvas_item(Item *p_canvas_item, const Transform2D &p_parent_xform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **r_z_list, RendererCanvasRender::Item **r_z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool p_is_already_y_sorted, uint32_t p_canvas_cull_mask, const Point2 &p_repeat_size, int p_repeat_times, RendererCanvasRender::Item *p_repeat_source_item);
+	void _cull_canvas_item(Item *p_canvas_item, const Transform2D &p_parent_xform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **r_z_list, RendererCanvasRender::Item **r_z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool p_is_already_axis_sorted, uint32_t p_canvas_cull_mask, const Point2 &p_repeat_size, int p_repeat_times, RendererCanvasRender::Item *p_repeat_source_item);
 
-	void _collect_ysort_children(RendererCanvasCull::Item *p_canvas_item, RendererCanvasCull::Item *p_material_owner, const Color &p_modulate, RendererCanvasCull::Item **r_items, int &r_index, int &r_ysort_children_count, int p_z, uint32_t p_canvas_cull_mask);
+	void _collect_ysort_children(RendererCanvasCull::Item *p_canvas_item, RendererCanvasCull::Item *p_material_owner, const Color &p_modulate, RendererCanvasCull::Item **r_items, int &r_index, int &r_axis_sort_children_count, int p_z, uint32_t p_canvas_cull_mask);
 	int _count_ysort_children(RendererCanvasCull::Item *p_canvas_item);
 	void _mark_ysort_dirty(RendererCanvasCull::Item *ysort_owner);
 

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -286,7 +286,10 @@ public:
 	void canvas_item_add_clip_ignore(RID p_item, bool p_ignore);
 	void canvas_item_add_animation_slice(RID p_item, double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset);
 
-	void canvas_item_set_sort_children_by_y(RID p_item, bool p_enable);
+	void canvas_item_set_sort_children_by_axis(RID p_item, bool p_enable);
+	void canvas_item_set_sort_children_by_axis_y_as_main(RID p_item, bool p_enable);
+	void canvas_item_set_sort_children_by_axis_x_ascending(RID p_item, bool p_enable);
+	void canvas_item_set_sort_children_by_axis_y_ascending(RID p_item, bool p_enable);
 	void canvas_item_set_z_index(RID p_item, int p_z);
 	void canvas_item_set_z_as_relative_to_parent(RID p_item, bool p_enable);
 	void canvas_item_set_copy_to_backbuffer(RID p_item, bool p_enable, const Rect2 &p_rect);

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -117,8 +117,8 @@ public:
 
 	struct ItemAxisSort {
 		bool y_as_main = true;
-		bool x_ascending = false;
-		bool y_ascending = false;
+		bool x_ascending = true;
+		bool y_ascending = true;
 
 		_FORCE_INLINE_ bool operator()(const Item *p_left, const Item *p_right) const {
 			const Vector2 left_pos = p_left->axis_sort_xform.columns[2];

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3383,7 +3383,10 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_add_set_transform", "item", "transform"), &RenderingServer::canvas_item_add_set_transform);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_clip_ignore", "item", "ignore"), &RenderingServer::canvas_item_add_clip_ignore);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_animation_slice", "item", "animation_length", "slice_begin", "slice_end", "offset"), &RenderingServer::canvas_item_add_animation_slice, DEFVAL(0.0));
-	ClassDB::bind_method(D_METHOD("canvas_item_set_sort_children_by_y", "item", "enabled"), &RenderingServer::canvas_item_set_sort_children_by_y);
+	ClassDB::bind_method(D_METHOD("canvas_item_set_sort_children_by_axis", "item", "enabled"), &RenderingServer::canvas_item_set_sort_children_by_axis);
+	ClassDB::bind_method(D_METHOD("canvas_item_set_sort_children_by_axis_y_as_main", "item", "enabled"), &RenderingServer::canvas_item_set_sort_children_by_axis_y_as_main);
+	ClassDB::bind_method(D_METHOD("canvas_item_set_sort_children_by_axis_x_ascending", "item", "enabled"), &RenderingServer::canvas_item_set_sort_children_by_axis_x_ascending);
+	ClassDB::bind_method(D_METHOD("canvas_item_set_sort_children_by_axis_y_ascending", "item", "enabled"), &RenderingServer::canvas_item_set_sort_children_by_axis_y_ascending);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_z_index", "item", "z_index"), &RenderingServer::canvas_item_set_z_index);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_z_as_relative_to_parent", "item", "enabled"), &RenderingServer::canvas_item_set_z_as_relative_to_parent);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_copy_to_backbuffer", "item", "enabled", "rect"), &RenderingServer::canvas_item_set_copy_to_backbuffer);

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -1605,7 +1605,10 @@ public:
 	virtual void canvas_item_add_clip_ignore(RID p_item, bool p_ignore) = 0;
 	virtual void canvas_item_add_animation_slice(RID p_item, double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset) = 0;
 
-	virtual void canvas_item_set_sort_children_by_y(RID p_item, bool p_enable) = 0;
+	virtual void canvas_item_set_sort_children_by_axis(RID p_item, bool p_enable) = 0;
+	virtual void canvas_item_set_sort_children_by_axis_y_as_main(RID p_item, bool p_enable) = 0;
+	virtual void canvas_item_set_sort_children_by_axis_x_ascending(RID p_item, bool p_enable) = 0;
+	virtual void canvas_item_set_sort_children_by_axis_y_ascending(RID p_item, bool p_enable) = 0;
 	virtual void canvas_item_set_z_index(RID p_item, int p_z) = 0;
 	virtual void canvas_item_set_z_as_relative_to_parent(RID p_item, bool p_enable) = 0;
 	virtual void canvas_item_set_copy_to_backbuffer(RID p_item, bool p_enable, const Rect2 &p_rect) = 0;

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -1876,7 +1876,7 @@ public:
 
 #ifndef DISABLE_DEPRECATED
 	// Never actually used, should be removed when we can break compatibility.
-	enum Features {
+	enum Features{
 		FEATURE_SHADERS,
 		FEATURE_MULTITHREADED,
 	};

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -1876,7 +1876,7 @@ public:
 
 #ifndef DISABLE_DEPRECATED
 	// Never actually used, should be removed when we can break compatibility.
-	enum Features{
+	enum Features {
 		FEATURE_SHADERS,
 		FEATURE_MULTITHREADED,
 	};

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -1006,7 +1006,10 @@ public:
 	FUNC2(canvas_item_add_clip_ignore, RID, bool)
 	FUNC5(canvas_item_add_animation_slice, RID, double, double, double, double)
 
-	FUNC2(canvas_item_set_sort_children_by_y, RID, bool)
+	FUNC2(canvas_item_set_sort_children_by_axis, RID, bool)
+	FUNC2(canvas_item_set_sort_children_by_axis_y_as_main, RID, bool)
+	FUNC2(canvas_item_set_sort_children_by_axis_x_ascending, RID, bool)
+	FUNC2(canvas_item_set_sort_children_by_axis_y_ascending, RID, bool)
 	FUNC2(canvas_item_set_z_index, RID, int)
 	FUNC2(canvas_item_set_z_as_relative_to_parent, RID, bool)
 	FUNC3(canvas_item_set_copy_to_backbuffer, RID, bool, const Rect2 &)


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/12405

### Changes
| Original (index sort) |
|-----------------------|
|<img width="2163" height="924" alt="f93eaed1d29a51fddc72e86655c44107" src="https://github.com/user-attachments/assets/a7125f1a-6a7a-4aa8-85cb-b57d6e3e2d7a" />|

| Y sort | Custom axis sort |
|--------|-------------------|
|<img width="2162" height="923" alt="745da1c4448c5d8c7ff2dfe1229b8c4a" src="https://github.com/user-attachments/assets/d799cc1a-28c5-4eb7-9a3f-6e499ceb0fe2" />|<img width="2163" height="923" alt="04a9336e236c03ad54cc856fea7998dd" src="https://github.com/user-attachments/assets/42e4e135-2b5a-4fa4-8490-fed999c72bcf" />|

Add axis sort properties to CanvasItem, replacing the original y sort.
Developers can now choose:

- which axis to be sorted first
- whether the sorting is ascending or descending based on axis

This can be helpful for making isometric games with various camera angles.

### Performance Test
| Y sort | Axis sort |
|--------|----------|
|<img width="1076" height="403" alt="image" src="https://github.com/user-attachments/assets/9bb18f35-a3f2-4a3b-ab67-18891a19cc0d" />|<img width="1077" height="439" alt="image" src="https://github.com/user-attachments/assets/ead28529-5b4f-4695-8035-5863e2c6e95e" />|
|Around 140ms per process when enabled|Around 120ms per process when enabled|

### Note

1. I couldn't figure it out myself how comes that axis sort is running faster. Any help is appreciated to make sure the code is safe (which is probably not at current state.)
2. The current TileMapLayer `x_draw_order_reversed` property can be removed if this pull request is to be merged.

The test project I used: https://github.com/Morph317/Axis-Sort-Test-Project-Godot-

### ToDo

- [ ] Run more test cases (need help)
- [ ] Make y_sort compatible
- [ ] Remove `x_draw_order_reversed` related code from TileMapLayer
- [ ] Update Document