### PR TITLE
Fix gdshader macro expansion after directives

### DIFF
--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -1300,6 +1300,7 @@ Error ShaderPreprocessor::preprocess(State *p_state, const String &p_code, Strin
 				return FAILED;
 			}
 			process_directive(&p_tokenizer);
+			last_size = output.size();
 		} else {
 			if (is_char_end(t.text)) {
 				expand_output_macros(last_size, p_tokenizer.get_line());


### PR DESCRIPTION
Fixes #101029.

Before the fix, even though `process_directive` already handles macro expansions, `preprocess` doesn't care and will go on expanding the line the directive is at. This is hard to spot, since if some text is already fully expanded, expanding it again is a noop and only wastes some time.

However, `#include` is a special case which even after preprocessing, can still contain expandable text in the enter/exit marker shown below:
```c++
void ShaderPreprocessor::process_include(Tokenizer *p_tokenizer) {
	// ...
	String result;
	processor.preprocess(state, included, result);
	add_to_output("@@>" + real_path + "\n"); // Add token for enter include path
	add_to_output(result);
	add_to_output("\n@@<" + real_path + "\n"); // Add token for exit include path.
}
```
This is what causes the "including .gdshaderinc with the same name as a defined macro" to fail.