### PR TITLE
Create separate graphics queue instead of reusing the main queue when transfer queue family is unsupported.

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -6999,15 +6999,14 @@ Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServ
 	ERR_FAIL_COND_V(!main_queue, FAILED);
 
 	transfer_queue_family = driver->command_queue_family_get(RDD::COMMAND_QUEUE_FAMILY_TRANSFER_BIT);
-	if (transfer_queue_family) {
-		// Create the transfer queue.
-		transfer_queue = driver->command_queue_create(transfer_queue_family);
-		ERR_FAIL_COND_V(!transfer_queue, FAILED);
-	} else {
-		// Use main queue as the transfer queue.
-		transfer_queue = main_queue;
+	if (!transfer_queue_family) {
+		// Use main queue family if transfer queue family is not supported.
 		transfer_queue_family = main_queue_family;
 	}
+
+	// Create the transfer queue.
+	transfer_queue = driver->command_queue_create(transfer_queue_family);
+	ERR_FAIL_COND_V(!transfer_queue, FAILED);
 
 	if (present_queue_family) {
 		// Create the present queue.


### PR DESCRIPTION
Maybe fixes #112160 and fixes #112161. I haven't been able to reproduce the issue yet, but I'll post an update once I do.

When the device does not support transfer queues, Godot falls back to using the main graphics queue for transfer workers. This causes race conditions with the main command buffers, as they try to access and modify the vectors containing image acquisition semaphores at the same time.

I tried to resolve this more cleanly by making the semaphores part of RD, but the changes grew out of scope for a simple bug fix. In the meantime, this change makes the behavior match the case where a transfer queue family is supported.
