### PR TITLE
Add connect flag to call immediately

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1638,6 +1638,9 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, ui
 	if (p_flags & CONNECT_REFERENCE_COUNTED) {
 		slot.reference_count = 1;
 	}
+	if (p_flags & CONNECT_AND_CALL) {
+		p_callable.call();
+	}
 
 	//use callable version as key, so binds can be ignored
 	s->slot_map[*p_callable.get_base_comparator()] = slot;
@@ -2050,6 +2053,7 @@ void Object::_bind_methods() {
 	BIND_ENUM_CONSTANT(CONNECT_ONE_SHOT);
 	BIND_ENUM_CONSTANT(CONNECT_REFERENCE_COUNTED);
 	BIND_ENUM_CONSTANT(CONNECT_APPEND_SOURCE_OBJECT);
+	BIND_ENUM_CONSTANT(CONNECT_AND_CALL);
 }
 
 void Object::set_deferred(const StringName &p_property, const Variant &p_value) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -578,6 +578,7 @@ public:
 		CONNECT_REFERENCE_COUNTED = 8,
 		CONNECT_APPEND_SOURCE_OBJECT = 16,
 		CONNECT_INHERITED = 32, // Used in editor builds.
+		CONNECT_AND_CALL = 64,
 	};
 
 	// Store on each object a bitfield to quickly test whether it is derived from some "key" classes

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -1053,5 +1053,8 @@
 		<constant name="CONNECT_APPEND_SOURCE_OBJECT" value="16" enum="ConnectFlags">
 			The source object is automatically bound when a [PackedScene] is instantiated. If this flag bit is enabled, the source object will be appended right after the original arguments of the signal.
 		</constant>
+		<constant name="CONNECT_AND_CALL" value="64" enum="ConnectFlags">
+			The callable is called immediately upon connecting.
+		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
A very common pattern, especially when working with many GUI components, is to connect to a callable and immediately call the same callable. This new ConnectFlag enum value allows users to do both in a single line of code.

Closes https://github.com/godotengine/godot-proposals/issues/13927
