### PR TITLE
Adjust the accuracy of time comparison in Animation

### DIFF
--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -560,19 +560,19 @@ public:
 	static Variant cubic_interpolate_in_time_variant(const Variant &pre_a, const Variant &a, const Variant &b, const Variant &post_b, float c, real_t p_pre_a_t, real_t p_b_t, real_t p_post_b_t, bool p_snap_array_element = false);
 
 	static bool is_less_or_equal_approx(double a, double b) {
-		return a < b || Math::is_equal_approx(a, b);
+		return a < b || Math::is_equal_approx(a, b, 0.001);
 	}
 
 	static bool is_less_approx(double a, double b) {
-		return a < b && !Math::is_equal_approx(a, b);
+		return a < b && !Math::is_equal_approx(a, b, 0.001);
 	}
 
 	static bool is_greater_or_equal_approx(double a, double b) {
-		return a > b || Math::is_equal_approx(a, b);
+		return a > b || Math::is_equal_approx(a, b, 0.001);
 	}
 
 	static bool is_greater_approx(double a, double b) {
-		return a > b && !Math::is_equal_approx(a, b);
+		return a > b && !Math::is_equal_approx(a, b, 0.001);
 	}
 
 	static TrackType get_cache_type(TrackType p_type);


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/112860

As I wrote there, we should probably consider whether this should be done. If we can improve the dictionary, I think we need to supersedes this with that.