### PR TITLE
Fix AnimationPlayerEditor failed to fetch AnimationTree's libraries

### DIFF
--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -2440,6 +2440,13 @@ void AnimationPlayerEditorPlugin::_update_dummy_player(AnimationMixer *p_mixer) 
 	}
 	memdelete(default_node);
 
+	// Library list is dynamically added to property list, should be copied explicitly.
+	List<StringName> libraries;
+	p_mixer->get_animation_library_list(&libraries);
+	for (const StringName &K : libraries) {
+		dummy_player->add_animation_library(K, p_mixer->get_animation_library(K));
+	}
+
 	if (anim_editor) {
 		anim_editor->_update_player();
 	}


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/114475

When transferring properties to a dummy AnimationMixer, we relied on a hack that fetched the property list from the default state of the newly created class (although it is the same way with change type option in SceneDock).

However, since the AnimationLibrary list is now dynamically generated, it's better to copy from the actual objects via the correct API.