### PR TITLE
Fix Android export with multiple architectures failing when GDExtension includes native dependencies

### DIFF
--- a/editor/export/gdextension_export_plugin.h
+++ b/editor/export/gdextension_export_plugin.h
@@ -151,7 +151,8 @@ void GDExtensionExportPlugin::_export_file(const String &p_path, const String &p
 			}
 		}
 
-		Vector<SharedObject> dependencies_shared_objects = GDExtensionLibraryLoader::find_extension_dependencies(p_path, config, [p_features](String p_feature) { return p_features.has(p_feature); });
+		Vector<SharedObject> dependencies_shared_objects = GDExtensionLibraryLoader::find_extension_dependencies(
+				p_path, config, [features_wo_arch, arch_tag](String p_feature) { return features_wo_arch.has(p_feature) || (p_feature == arch_tag); });
 		for (const SharedObject &shared_object : dependencies_shared_objects) {
 			_add_shared_object(shared_object);
 		}


### PR DESCRIPTION
Fixes #111407

## Root Cause

The dependency lookup is defined in a lambda using `p_features` which contains all architectures, so dependencies for every architecture were being added during each architecture's pass and thus causing duplicates.

## Solution

This PR uses `features_wo_arch` and the current `arch_tag` instead, so dependencies are only resolved for the architecture being processed.

## Tested

Built Godot locally for macOS, exported w/ Android preset and `armeabi-v7a` (`arm32`), `arm64-v8a` (`arm64`) target architectures selected, and built an `.apk` successfully.

Relevant logs captured:


```
ADDING: kotlin/reflect/reflect.kotlin_builtins
Signing binary using: 
/Users/ed/Library/Android/sdk/build-tools/35.0.0/apksigner sign --verbose --ks <REDACTED> --ks-pass pass:<REDACTED> --ks-key-alias <REDACTED> /Users/ed/Downloads/test0/test.apk
Signed
```