### PR TITLE
Add `span_index` to `TextServer.shaped_text_get_glyphs` and related methods when accessed from GDScript.

### DIFF
--- a/servers/text/text_server.cpp
+++ b/servers/text/text_server.cpp
@@ -2310,6 +2310,7 @@ TypedArray<Dictionary> TextServer::_shaped_text_get_glyphs_wrapper(const RID &p_
 		glyph["font_rid"] = glyphs[i].font_rid;
 		glyph["font_size"] = glyphs[i].font_size;
 		glyph["index"] = glyphs[i].index;
+		glyph["span_index"] = glyphs[i].span_index;
 
 		ret.push_back(glyph);
 	}
@@ -2335,6 +2336,7 @@ TypedArray<Dictionary> TextServer::_shaped_text_sort_logical_wrapper(const RID &
 		glyph["font_rid"] = glyphs[i].font_rid;
 		glyph["font_size"] = glyphs[i].font_size;
 		glyph["index"] = glyphs[i].index;
+		glyph["span_index"] = glyphs[i].span_index;
 
 		ret.push_back(glyph);
 	}
@@ -2360,6 +2362,7 @@ TypedArray<Dictionary> TextServer::_shaped_text_get_ellipsis_glyphs_wrapper(cons
 		glyph["font_rid"] = glyphs[i].font_rid;
 		glyph["font_size"] = glyphs[i].font_size;
 		glyph["index"] = glyphs[i].index;
+		glyph["span_index"] = glyphs[i].span_index;
 
 		ret.push_back(glyph);
 	}


### PR DESCRIPTION
Add `span_index` to `TextServer` methods that wrap `Glyph` for gdscript. (or gdextension)
~~Use `StringName` keys in the dictionaries for a small performance boost.~~ (removed for simplicity, but it is worth doing)

This is something I need to make a lightweight version of `RichTextLabel` for my card game (avoiding the overhead of nodes and theming).

I'm going to use the span meta object to keep track of text effects that should be applied to a particular glyph.