### PR TITLE
Simplify and expand smooth scrolling to other scrollable nodes

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1218,6 +1218,9 @@
 		<member name="gui/common/default_scroll_deadzone" type="int" setter="" getter="" default="0">
 			Default value for [member ScrollContainer.scroll_deadzone], which will be used for all [ScrollContainer]s unless overridden.
 		</member>
+		<member name="gui/common/default_scroll_smooth_time" type="float" setter="" getter="" default="0.0">
+			The approximate duration (in seconds) it takes for [ScrollBar]s to smoothly scroll to its target position. A value of 0 disables smooth scrolling.
+		</member>
 		<member name="gui/common/drag_threshold" type="int" setter="" getter="" default="10">
 			The minimum distance the mouse cursor must move while pressed before a drag operation begins in the default viewport. For custom viewports see [member Viewport.gui_drag_threshold].
 		</member>

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1165,8 +1165,8 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventPanGesture> pan_gesture = p_event;
 	if (pan_gesture.is_valid()) {
-		scroll_bar_v->set_value(scroll_bar_v->get_value() + scroll_bar_v->get_page() * pan_gesture->get_delta().y / 8);
-		scroll_bar_h->set_value(scroll_bar_h->get_value() + scroll_bar_h->get_page() * pan_gesture->get_delta().x / 8);
+		scroll_bar_v->set_value(scroll_bar_v->get_target_value() + scroll_bar_v->get_page() * pan_gesture->get_delta().y / 8);
+		scroll_bar_h->set_value(scroll_bar_h->get_target_value() + scroll_bar_h->get_page() * pan_gesture->get_delta().x / 8);
 	}
 
 	if (scroll_value_modified && (scroll_bar_v->get_value() != prev_scroll_v || scroll_bar_h->get_value() != prev_scroll_h)) {
@@ -2468,10 +2468,12 @@ void ItemList::_bind_methods() {
 
 ItemList::ItemList() {
 	scroll_bar_v = memnew(VScrollBar);
+	scroll_bar_v->set_use_default_smooth_time();
 	add_child(scroll_bar_v, false, INTERNAL_MODE_FRONT);
 	scroll_bar_v->connect(SceneStringName(value_changed), callable_mp(this, &ItemList::_scroll_changed));
 
 	scroll_bar_h = memnew(HScrollBar);
+	scroll_bar_h->set_use_default_smooth_time();
 	add_child(scroll_bar_h, false, INTERNAL_MODE_FRONT);
 	scroll_bar_h->connect(SceneStringName(value_changed), callable_mp(this, &ItemList::_scroll_changed));
 

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "scene/animation/tween.h"
 #include "scene/gui/control.h"
 
 class Range : public Control {
@@ -41,6 +42,8 @@ class Range : public Control {
 		double max = 100.0;
 		double step = 1.0;
 		double page = 0.0;
+		double target_val = 0.0;
+		double smooth_time = 0.0;
 		bool exp_ratio = false;
 		bool allow_greater = false;
 		bool allow_lesser = false;
@@ -51,6 +54,9 @@ class Range : public Control {
 	};
 
 	Shared *shared = nullptr;
+	Ref<Tween> tween;
+
+	void smooth_frame_call(double);
 
 	void _ref_shared(Shared *p_shared);
 	void _unref_shared();
@@ -86,6 +92,7 @@ public:
 	void set_step(double p_step);
 	void set_page(double p_page);
 	void set_as_ratio(double p_value);
+	void set_smooth_time(double p_smoothing);
 
 	double get_value() const;
 	double get_min() const;
@@ -93,6 +100,10 @@ public:
 	double get_step() const;
 	double get_page() const;
 	double get_as_ratio() const;
+	double get_target_value() const;
+	double get_smooth_time() const;
+
+	void set_use_default_smooth_time(bool p_enable = true);
 
 	void set_use_rounded_values(bool p_enable);
 	bool is_using_rounded_values() const;

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -517,7 +517,7 @@ Size2 ScrollBar::get_minimum_size() const {
 }
 
 void ScrollBar::scroll(double p_amount) {
-	scroll_to(get_value() + p_amount);
+	scroll_to(get_target_value() + p_amount);
 }
 
 void ScrollBar::scroll_to(double p_position) {
@@ -637,7 +637,9 @@ void ScrollBar::set_drag_node_enabled(bool p_enable) {
 }
 
 void ScrollBar::set_smooth_scroll_enabled(bool p_enable) {
-	smooth_scroll_enabled = p_enable;
+	//smooth_scroll_enabled = p_enable;
+	set_use_default_smooth_time(p_enable);
+	//set_smooth_time(p_enable ? GLOBAL_GET_CACHED(double, "gui/common/default_scroll_smooth_time") : 0);
 }
 
 bool ScrollBar::is_smooth_scroll_enabled() const {

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -909,11 +909,13 @@ ScrollContainer::ScrollContainer() {
 
 	h_scroll = memnew(HScrollBar);
 	h_scroll->set_name("_h_scroll");
+	h_scroll->set_use_default_smooth_time();
 	add_child(h_scroll, false, INTERNAL_MODE_BACK);
 	h_scroll->connect(SceneStringName(value_changed), callable_mp(this, &ScrollContainer::_scroll_moved));
 
 	v_scroll = memnew(VScrollBar);
 	v_scroll->set_name("_v_scroll");
+	v_scroll->set_use_default_smooth_time();
 	add_child(v_scroll, false, INTERNAL_MODE_BACK);
 	v_scroll->connect(SceneStringName(value_changed), callable_mp(this, &ScrollContainer::_scroll_moved));
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -680,36 +680,36 @@ void TextEdit::_accessibility_action_menu(const Variant &p_data) {
 
 void TextEdit::_accessibility_scroll_down(const Variant &p_data) {
 	if ((DisplayServer::AccessibilityScrollUnit)p_data == DisplayServer::SCROLL_UNIT_ITEM) {
-		v_scroll->set_value(v_scroll->get_value() + v_scroll->get_page() / 4);
+		v_scroll->set_value(v_scroll->get_target_value() + v_scroll->get_page() / 4);
 	} else {
-		v_scroll->set_value(v_scroll->get_value() + v_scroll->get_page());
+		v_scroll->set_value(v_scroll->get_target_value() + v_scroll->get_page());
 	}
 	queue_accessibility_update();
 }
 
 void TextEdit::_accessibility_scroll_left(const Variant &p_data) {
 	if ((DisplayServer::AccessibilityScrollUnit)p_data == DisplayServer::SCROLL_UNIT_ITEM) {
-		h_scroll->set_value(h_scroll->get_value() - h_scroll->get_page() / 4);
+		h_scroll->set_value(h_scroll->get_target_value() - h_scroll->get_page() / 4);
 	} else {
-		h_scroll->set_value(h_scroll->get_value() - h_scroll->get_page());
+		h_scroll->set_value(h_scroll->get_target_value() - h_scroll->get_page());
 	}
 	queue_accessibility_update();
 }
 
 void TextEdit::_accessibility_scroll_right(const Variant &p_data) {
 	if ((DisplayServer::AccessibilityScrollUnit)p_data == DisplayServer::SCROLL_UNIT_ITEM) {
-		h_scroll->set_value(h_scroll->get_value() + h_scroll->get_page() / 4);
+		h_scroll->set_value(h_scroll->get_target_value() + h_scroll->get_page() / 4);
 	} else {
-		h_scroll->set_value(h_scroll->get_value() + h_scroll->get_page());
+		h_scroll->set_value(h_scroll->get_target_value() + h_scroll->get_page());
 	}
 	queue_accessibility_update();
 }
 
 void TextEdit::_accessibility_scroll_up(const Variant &p_data) {
 	if ((DisplayServer::AccessibilityScrollUnit)p_data == DisplayServer::SCROLL_UNIT_ITEM) {
-		v_scroll->set_value(v_scroll->get_value() - v_scroll->get_page() / 4);
+		v_scroll->set_value(v_scroll->get_target_value() - v_scroll->get_page() / 4);
 	} else {
-		v_scroll->set_value(v_scroll->get_value() - v_scroll->get_page());
+		v_scroll->set_value(v_scroll->get_target_value() - v_scroll->get_page());
 	}
 	queue_accessibility_update();
 }
@@ -722,7 +722,7 @@ void TextEdit::_accessibility_scroll_set(const Variant &p_data) {
 }
 
 void TextEdit::_accessibility_action_scroll_into_view(const Variant &p_data, int p_line, int p_wrap) {
-	double delta = get_scroll_pos_for_line(p_line, p_wrap) - get_v_scroll();
+	double delta = get_scroll_pos_for_line(p_line, p_wrap) - v_scroll->get_target_value();
 	if (delta < 0) {
 		_scroll_up(-delta, false);
 	} else {
@@ -875,8 +875,8 @@ void TextEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			if (scrolling && get_v_scroll() != target_v_scroll) {
-				double target_y = target_v_scroll - get_v_scroll();
+			if (scrolling && get_v_scroll() != target_v_scroll) { //
+				double target_y = target_v_scroll - get_v_scroll(); //
 				double dist = std::abs(target_y);
 				// To ensure minimap is responsive override the speed setting.
 				double vel = ((target_y / dist) * ((minimap_clicked) ? 3000 : v_scroll_speed)) * get_process_delta_time();
@@ -892,7 +892,7 @@ void TextEdit::_notification(int p_what) {
 					minimap_clicked = false;
 					set_process_internal(false);
 				} else {
-					set_v_scroll(get_v_scroll() + vel);
+					set_v_scroll(v_scroll->get_value() + vel); //
 				}
 			} else {
 				scrolling = false;
@@ -927,7 +927,7 @@ void TextEdit::_notification(int p_what) {
 				draw_caret = false;
 			}
 
-			_update_scrollbars();
+			_update_scrollbars(); //
 
 			RS::get_singleton()->canvas_item_clear(text_ci);
 			RS::get_singleton()->canvas_item_set_custom_rect(text_ci, !is_visibility_clip_disabled(), Rect2(Point2(0, 0), size));
@@ -2231,8 +2231,8 @@ bool TextEdit::alt_input(const Ref<InputEvent> &p_gui_input) {
 void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	ERR_FAIL_COND(p_gui_input.is_null());
 
-	double prev_v_scroll = v_scroll->get_value();
-	double prev_h_scroll = h_scroll->get_value();
+	double prev_v_scroll = v_scroll->get_target_value();
+	double prev_h_scroll = h_scroll->get_target_value();
 
 	Ref<InputEventMouseButton> mb = p_gui_input;
 
@@ -2245,7 +2245,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		if (mb->is_pressed()) {
 			if (mb->get_button_index() == MouseButton::WHEEL_UP && !mb->is_command_or_control_pressed()) {
 				if (mb->is_shift_pressed()) {
-					h_scroll->set_value(h_scroll->get_value() - (100 * mb->get_factor()));
+					h_scroll->set_value(h_scroll->get_target_value() - (100 * mb->get_factor()));
 					queue_accessibility_update();
 				} else if (mb->is_alt_pressed()) {
 					// Scroll 5 times as fast as normal (like in Visual Studio Code).
@@ -2257,7 +2257,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			}
 			if (mb->get_button_index() == MouseButton::WHEEL_DOWN && !mb->is_command_or_control_pressed()) {
 				if (mb->is_shift_pressed()) {
-					h_scroll->set_value(h_scroll->get_value() + (100 * mb->get_factor()));
+					h_scroll->set_value(h_scroll->get_target_value() + (100 * mb->get_factor()));
 					queue_accessibility_update();
 				} else if (mb->is_alt_pressed()) {
 					// Scroll 5 times as fast as normal (like in Visual Studio Code).
@@ -2268,11 +2268,11 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				}
 			}
 			if (mb->get_button_index() == MouseButton::WHEEL_LEFT) {
-				h_scroll->set_value(h_scroll->get_value() - (100 * mb->get_factor()));
+				h_scroll->set_value(h_scroll->get_target_value() - (100 * mb->get_factor()));
 				queue_accessibility_update();
 			}
 			if (mb->get_button_index() == MouseButton::WHEEL_RIGHT) {
-				h_scroll->set_value(h_scroll->get_value() + (100 * mb->get_factor()));
+				h_scroll->set_value(h_scroll->get_target_value() + (100 * mb->get_factor()));
 				queue_accessibility_update();
 			}
 
@@ -2500,8 +2500,8 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		} else {
 			_scroll_down(delta, false);
 		}
-		h_scroll->set_value(h_scroll->get_value() + pan_gesture->get_delta().x * 100);
-		if (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll) {
+		h_scroll->set_value(h_scroll->get_target_value() + pan_gesture->get_delta().x * 100);
+		if (v_scroll->get_target_value() != prev_v_scroll || h_scroll->get_target_value() != prev_h_scroll) {
 			accept_event(); // Accept event if scroll changed.
 		}
 		queue_accessibility_update();
@@ -6425,7 +6425,7 @@ Vector<String> TextEdit::get_line_wrapped_text(int p_line) const {
 // Scrolling.
 void TextEdit::set_smooth_scroll_enabled(bool p_enabled) {
 	v_scroll->set_smooth_scroll_enabled(p_enabled);
-	smooth_scroll_enabled = p_enabled;
+	//smooth_scroll_enabled = p_enabled;
 }
 
 bool TextEdit::is_smooth_scroll_enabled() const {
@@ -6461,7 +6461,7 @@ void TextEdit::set_v_scroll(double p_scroll) {
 	v_scroll->set_value(p_scroll);
 	int max_v_scroll = v_scroll->get_max() - v_scroll->get_page();
 	if (p_scroll >= max_v_scroll - 1.0) {
-		_scroll_moved(v_scroll->get_value());
+		_scroll_moved(v_scroll->get_value()); //
 	}
 	queue_accessibility_update();
 }
@@ -8619,7 +8619,7 @@ void TextEdit::_update_scrollbars() {
 		v_scroll->show();
 		v_scroll->set_max(total_rows);
 		v_scroll->set_page(visible_rows + fractional_visible_rows);
-		set_v_scroll(get_v_scroll());
+		//set_v_scroll(v_scroll->get_target_value());
 	} else {
 		first_visible_line = 0;
 		first_visible_line_wrap_ofs = 0;
@@ -8674,7 +8674,7 @@ void TextEdit::_scroll_moved(double p_to_val) {
 		// Set line ofs and wrap ofs.
 		bool draw_placeholder = _using_placeholder();
 
-		int v_scroll_i = std::floor(get_v_scroll());
+		int v_scroll_i = std::floor(get_v_scroll()); //
 		int sc = 0;
 		int n_line;
 		for (n_line = 0; n_line < text.size(); n_line++) {
@@ -8720,7 +8720,7 @@ void TextEdit::_scroll_up(real_t p_delta, bool p_animate) {
 	if (scrolling) {
 		target_v_scroll = (target_v_scroll - p_delta);
 	} else {
-		target_v_scroll = (get_v_scroll() - p_delta);
+		target_v_scroll = (v_scroll->get_target_value() - p_delta);
 	}
 
 	if (smooth_scroll_enabled) {
@@ -8748,7 +8748,7 @@ void TextEdit::_scroll_down(real_t p_delta, bool p_animate) {
 	if (scrolling) {
 		target_v_scroll = (target_v_scroll + p_delta);
 	} else {
-		target_v_scroll = (get_v_scroll() + p_delta);
+		target_v_scroll = (v_scroll->get_target_value() + p_delta);
 	}
 
 	if (smooth_scroll_enabled) {
@@ -8773,7 +8773,7 @@ void TextEdit::_scroll_lines_up() {
 	minimap_clicked = false;
 
 	// Adjust the vertical scroll.
-	set_v_scroll(get_v_scroll() - 1);
+	set_v_scroll(v_scroll->get_target_value() - 1);
 
 	// Adjust the caret to viewport.
 	for (int i = 0; i < carets.size(); i++) {
@@ -8795,7 +8795,7 @@ void TextEdit::_scroll_lines_down() {
 	minimap_clicked = false;
 
 	// Adjust the vertical scroll.
-	set_v_scroll(get_v_scroll() + 1);
+	set_v_scroll(v_scroll->get_target_value() + 1);
 
 	// Adjust the caret to viewport.
 	for (int i = 0; i < carets.size(); i++) {
@@ -8927,7 +8927,7 @@ void TextEdit::_update_minimap_click() {
 
 	Point2i next_line = get_next_visible_line_index_offset_from(row, 0, -get_visible_line_count() / 2);
 	int first_line = MAX(0, row - next_line.x + 1);
-	double delta = get_scroll_pos_for_line(first_line, next_line.y) - get_v_scroll();
+	double delta = get_scroll_pos_for_line(first_line, next_line.y) - v_scroll->get_target_value(); //
 	if (delta < 0) {
 		_scroll_up(-delta, true);
 	} else {
@@ -9281,6 +9281,9 @@ TextEdit::TextEdit(const String &p_placeholder) {
 
 	h_scroll = memnew(HScrollBar);
 	v_scroll = memnew(VScrollBar);
+
+	h_scroll->set_use_default_smooth_time();
+	v_scroll->set_use_default_smooth_time();
 
 	add_child(h_scroll, false, INTERNAL_MODE_FRONT);
 	add_child(v_scroll, false, INTERNAL_MODE_FRONT);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3702,7 +3702,7 @@ bool Tree::_scroll(bool p_horizontal, float p_pages) {
 	ScrollBar *scroll = p_horizontal ? (ScrollBar *)h_scroll : (ScrollBar *)v_scroll;
 
 	double prev_value = scroll->get_value();
-	scroll->set_value(scroll->get_value() + scroll->get_page() * p_pages);
+	scroll->set_value(scroll->get_target_value() + scroll->get_page() * p_pages);
 
 	bool scroll_happened = scroll->get_value() != prev_value;
 	if (scroll_happened) {
@@ -4236,17 +4236,17 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventPanGesture> pan_gesture = p_event;
 	if (pan_gesture.is_valid()) {
-		double prev_v = v_scroll->get_value();
-		v_scroll->set_value(v_scroll->get_value() + v_scroll->get_page() * pan_gesture->get_delta().y / 8);
+		double prev_v = v_scroll->get_target_value();
+		v_scroll->set_value(v_scroll->get_target_value() + v_scroll->get_page() * pan_gesture->get_delta().y / 8);
 
-		double prev_h = h_scroll->get_value();
+		double prev_h = h_scroll->get_target_value();
 		if (is_layout_rtl()) {
-			h_scroll->set_value(h_scroll->get_value() + h_scroll->get_page() * -pan_gesture->get_delta().x / 8);
+			h_scroll->set_value(h_scroll->get_target_value() + h_scroll->get_page() * -pan_gesture->get_delta().x / 8);
 		} else {
-			h_scroll->set_value(h_scroll->get_value() + h_scroll->get_page() * pan_gesture->get_delta().x / 8);
+			h_scroll->set_value(h_scroll->get_target_value() + h_scroll->get_page() * pan_gesture->get_delta().x / 8);
 		}
 
-		if (v_scroll->get_value() != prev_v || h_scroll->get_value() != prev_h) {
+		if (v_scroll->get_target_value() != prev_v || h_scroll->get_target_value() != prev_h) {
 			accept_event();
 		}
 	}
@@ -6901,6 +6901,9 @@ Tree::Tree() {
 
 	h_scroll = memnew(HScrollBar);
 	v_scroll = memnew(VScrollBar);
+
+	h_scroll->set_use_default_smooth_time();
+	v_scroll->set_use_default_smooth_time();
 
 	add_child(h_scroll, false, INTERNAL_MODE_FRONT);
 	add_child(v_scroll, false, INTERNAL_MODE_FRONT);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
Related to https://github.com/godotengine/godot-proposals/issues/5386

https://github.com/user-attachments/assets/5a5feef0-4268-4744-8bfc-6993305d1a47

I'm not too sure if this implementation is ok, but this is how it works. It relies on a tween method, exponentially approaching a target value every frame. I wanted to avoid _process notifications because inherited classes use it and it would interfere with them.

Any constant scrolling action, like a wheel scroll or pan gesture, should use the `get_target_value()` instead of `get_value()` when doing relative scrolls, to keep the scroll feeling as responsive as your input.

This also relies on a ProjectSettings setting instead of a normal property because scrollbars are never inspectable. So every node would otherwise have to individually expose the property. Even then, it would still be very tedious to set the same smoothing duration every time for every scrollable node, so setting it once in ProjectSettings made more sense. 