### PR TITLE
Fix deleting words with backspace doesn't hide autocompletion popup

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -600,7 +600,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			accept_event();
 			return;
 		}
-		if (k->is_action("ui_text_caret_line_start", true) || k->is_action("ui_text_caret_line_end", true)) {
+		if (k->is_action("ui_text_caret_line_start", true) || k->is_action("ui_text_caret_line_end", true) || k->is_action("ui_text_backspace_word", true)) {
 			cancel_code_completion();
 		}
 		if (k->is_action("ui_text_completion_replace", true) || k->is_action("ui_text_completion_accept", true)) {


### PR DESCRIPTION
Fixes #114250 
Using `Ctrl` + `Backspace` to delete words will cancel code complete popup now.
and it's tested on Win11.