### PR TITLE
Fix color picker mode tabs in modern theme

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -152,6 +152,7 @@ void ColorPicker::_notification(int p_what) {
 			for (int i = 0; i < MODE_BUTTON_COUNT; i++) {
 				mode_btns[i]->begin_bulk_theme_override();
 				mode_btns[i]->add_theme_style_override(SceneStringName(pressed), theme_cache.mode_button_pressed);
+				mode_btns[i]->add_theme_style_override("hover_pressed", theme_cache.mode_button_hover_pressed);
 				mode_btns[i]->add_theme_style_override(CoreStringName(normal), theme_cache.mode_button_normal);
 				mode_btns[i]->add_theme_style_override(SceneStringName(hover), theme_cache.mode_button_hover);
 				mode_btns[i]->end_bulk_theme_override();
@@ -2059,6 +2060,7 @@ void ColorPicker::_bind_methods() {
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_normal, "tab_unselected", "TabContainer");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_pressed, "tab_selected", "TabContainer");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_hover, "tab_selected", "TabContainer");
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_hover_pressed, "tab_selected", "TabContainer");
 
 	ADD_CLASS_DEPENDENCY("LineEdit");
 	ADD_CLASS_DEPENDENCY("MenuButton");

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -345,6 +345,7 @@ private:
 		Ref<StyleBox> mode_button_normal;
 		Ref<StyleBox> mode_button_pressed;
 		Ref<StyleBox> mode_button_hover;
+		Ref<StyleBox> mode_button_hover_pressed;
 	} theme_cache;
 
 	void _copy_normalized_to_hsv_okhsl();


### PR DESCRIPTION
While working on https://github.com/godotengine/godot/pull/114392 I found a bug with `ColorPicker` where a `pressed` button looks like a tab while `hover_pressed` looks like a regular rounded button:

https://github.com/user-attachments/assets/f4164951-7f4e-44b5-b3d7-f6f52c2736c2

That's because they aren't tabs but `Button`s that use some of `TabContainer` styleboxes. They however didn't override the hover-pressed state, which became a problem in the modern theme. Classic theme got away with it because it's missing `hover_pressed` on `Button` altogether.

This PR fixes the issue by using the `tab_selected` style for `hover_pressed` on those buttons to match the behavior of classic theme.