### PR TITLE
[FileDialog] Respect "exclusive" flag when using native dialog.

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -445,14 +445,12 @@ Error DisplayServerWayland::file_dialog_show(const String &p_title, const String
 	MutexLock mutex_lock(wayland_thread.mutex);
 
 	DisplayServerEnums::WindowID window_id = p_window_id;
-	if (!windows.has(window_id) || window_get_flag(DisplayServerEnums::WINDOW_FLAG_POPUP_WM_HINT, window_id)) {
-		window_id = DisplayServerEnums::MAIN_WINDOW_ID;
+	while (windows.has(window_id) && window_get_flag(DisplayServerEnums::WINDOW_FLAG_POPUP_WM_HINT, window_id)) {
+		window_id = windows[window_id].parent_id;
 	}
 
 	WaylandThread::WindowState *ws = wayland_thread.window_get_state(window_id);
-	ERR_FAIL_NULL_V(ws, ERR_BUG);
-
-	return portal_desktop->file_dialog_show(window_id, (ws ? ws->exported_handle : String()), p_title, p_current_directory, String(), p_filename, p_mode, p_filters, TypedArray<Dictionary>(), p_callback, false);
+	return portal_desktop->file_dialog_show(p_window_id, (ws ? ws->exported_handle : String()), p_title, p_current_directory, String(), p_filename, p_mode, p_filters, TypedArray<Dictionary>(), p_callback, false);
 }
 
 Error DisplayServerWayland::file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) {
@@ -460,14 +458,12 @@ Error DisplayServerWayland::file_dialog_with_options_show(const String &p_title,
 	MutexLock mutex_lock(wayland_thread.mutex);
 
 	DisplayServerEnums::WindowID window_id = p_window_id;
-	if (!windows.has(window_id) || window_get_flag(DisplayServerEnums::WINDOW_FLAG_POPUP_WM_HINT, window_id)) {
-		window_id = DisplayServerEnums::MAIN_WINDOW_ID;
+	while (windows.has(window_id) && window_get_flag(DisplayServerEnums::WINDOW_FLAG_POPUP_WM_HINT, window_id)) {
+		window_id = windows[window_id].parent_id;
 	}
 
 	WaylandThread::WindowState *ws = wayland_thread.window_get_state(window_id);
-	ERR_FAIL_NULL_V(ws, ERR_BUG);
-
-	return portal_desktop->file_dialog_show(window_id, (ws ? ws->exported_handle : String()), p_title, p_current_directory, p_root, p_filename, p_mode, p_filters, p_options, p_callback, true);
+	return portal_desktop->file_dialog_show(p_window_id, (ws ? ws->exported_handle : String()), p_title, p_current_directory, p_root, p_filename, p_mode, p_filters, p_options, p_callback, true);
 }
 
 #endif

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -507,11 +507,7 @@ Error DisplayServerX11::file_dialog_show(const String &p_title, const String &p_
 	ERR_FAIL_COND_V(!portal_desktop, ERR_UNAVAILABLE);
 	DisplayServerEnums::WindowID window_id = p_window_id;
 
-	if (!windows.has(window_id) || windows[window_id].is_popup) {
-		window_id = DisplayServerEnums::MAIN_WINDOW_ID;
-	}
-
-	String xid = vformat("x11:%x", (uint64_t)windows[window_id].x11_window);
+	String xid = (window_id != DisplayServerEnums::INVALID_WINDOW_ID) ? vformat("x11:%x", (uint64_t)windows[window_id].x11_window) : String();
 	return portal_desktop->file_dialog_show(p_window_id, xid, p_title, p_current_directory, String(), p_filename, p_mode, p_filters, TypedArray<Dictionary>(), p_callback, false);
 }
 
@@ -519,11 +515,7 @@ Error DisplayServerX11::file_dialog_with_options_show(const String &p_title, con
 	ERR_FAIL_COND_V(!portal_desktop, ERR_UNAVAILABLE);
 	DisplayServerEnums::WindowID window_id = p_window_id;
 
-	if (!windows.has(window_id) || windows[window_id].is_popup) {
-		window_id = DisplayServerEnums::MAIN_WINDOW_ID;
-	}
-
-	String xid = vformat("x11:%x", (uint64_t)windows[window_id].x11_window);
+	String xid = (window_id != DisplayServerEnums::INVALID_WINDOW_ID) ? vformat("x11:%x", (uint64_t)windows[window_id].x11_window) : String();
 	return portal_desktop->file_dialog_show(p_window_id, xid, p_title, p_current_directory, p_root, p_filename, p_mode, p_filters, p_options, p_callback, true);
 }
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -587,34 +587,37 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 	int64_t w = fd->wrect.size.x;
 	int64_t h = fd->wrect.size.y;
 
-	WNDCLASSW wc = {};
-	wc.lpfnWndProc = (WNDPROC)::WndProcFileDialog;
-	wc.hInstance = GetModuleHandle(nullptr);
-	wc.lpszClassName = L"Engine File Dialog";
-	RegisterClassW(&wc);
+	HWND hwnd_dialog = 0;
+	if (!fd->hwnd_owner) {
+		WNDCLASSW wc = {};
+		wc.lpfnWndProc = (WNDPROC)::WndProcFileDialog;
+		wc.hInstance = GetModuleHandle(nullptr);
+		wc.lpszClassName = L"Engine File Dialog";
+		RegisterClassW(&wc);
 
-	HWND hwnd_dialog = CreateWindowExW(WS_EX_APPWINDOW, L"Engine File Dialog", L"", WS_OVERLAPPEDWINDOW, x, y, w, h, nullptr, nullptr, GetModuleHandle(nullptr), nullptr);
-	if (hwnd_dialog) {
-		{
-			MutexLock lock(ds->file_dialog_mutex);
-			ds->file_dialog_wnd[hwnd_dialog] = fd;
-		}
+		hwnd_dialog = CreateWindowExW(WS_EX_APPWINDOW, L"Engine File Dialog", L"", WS_OVERLAPPEDWINDOW, x, y, w, h, nullptr, nullptr, GetModuleHandle(nullptr), nullptr);
+		if (hwnd_dialog) {
+			{
+				MutexLock lock(ds->file_dialog_mutex);
+				ds->file_dialog_wnd[hwnd_dialog] = fd;
+			}
 
-		HICON w_icon = (HICON)SendMessage(fd->hwnd_owner, WM_GETICON, ICON_SMALL, 0);
-		if (w_icon) {
-			SendMessage(hwnd_dialog, WM_SETICON, ICON_SMALL, (LPARAM)w_icon);
-		}
-		w_icon = (HICON)SendMessage(fd->hwnd_owner, WM_GETICON, ICON_BIG, 0);
-		if (w_icon) {
-			SendMessage(hwnd_dialog, WM_SETICON, ICON_BIG, (LPARAM)w_icon);
-		}
-		IPropertyStore *prop_store;
-		HRESULT hr = SHGetPropertyStoreForWindow(hwnd_dialog, IID_IPropertyStore, (void **)&prop_store);
-		if (hr == S_OK) {
-			PROPVARIANT val;
-			InitPropVariantFromString((PCWSTR)fd->appid.utf16().get_data(), &val);
-			prop_store->SetValue(PKEY_AppUserModel_ID, val);
-			prop_store->Release();
+			HICON mainwindow_icon = (HICON)SendMessage(ds->windows[DisplayServerEnums::MAIN_WINDOW_ID].hWnd, WM_GETICON, ICON_SMALL, 0);
+			if (mainwindow_icon) {
+				SendMessage(hwnd_dialog, WM_SETICON, ICON_SMALL, (LPARAM)mainwindow_icon);
+			}
+			mainwindow_icon = (HICON)SendMessage(ds->windows[DisplayServerEnums::MAIN_WINDOW_ID].hWnd, WM_GETICON, ICON_BIG, 0);
+			if (mainwindow_icon) {
+				SendMessage(hwnd_dialog, WM_SETICON, ICON_BIG, (LPARAM)mainwindow_icon);
+			}
+			IPropertyStore *prop_store;
+			HRESULT hr = SHGetPropertyStoreForWindow(hwnd_dialog, IID_IPropertyStore, (void **)&prop_store);
+			if (hr == S_OK) {
+				PROPVARIANT val;
+				InitPropVariantFromString((PCWSTR)fd->appid.utf16().get_data(), &val);
+				prop_store->SetValue(PKEY_AppUserModel_ID, val);
+				prop_store->Release();
+			}
 		}
 	}
 
@@ -727,7 +730,11 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 		pfd->SetFileTypes(filters.size(), filters.ptr());
 		pfd->SetFileTypeIndex(0);
 
-		hr = pfd->Show(hwnd_dialog);
+		if (fd->hwnd_owner) {
+			hr = pfd->Show(fd->hwnd_owner);
+		} else {
+			hr = pfd->Show(hwnd_dialog);
+		}
 		pfd->Unadvise(cookie);
 
 		Dictionary options = event_handler->get_selected();

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -83,12 +83,19 @@ void FileDialog::_native_popup() {
 	while (w && w->get_flag(FLAG_POPUP) && w->get_parent_visible_window()) {
 		w = w->get_parent_visible_window();
 	}
-	DisplayServerEnums::WindowID wid = w ? w->get_window_id() : DisplayServerEnums::INVALID_WINDOW_ID;
+	DisplayServerEnums::WindowID wid = (w && is_exclusive()) ? w->get_window_id() : DisplayServerEnums::INVALID_WINDOW_ID;
 
+	Error dlg_err = OK;
 	if (DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_NATIVE_DIALOG_FILE_EXTRA)) {
-		DisplayServer::get_singleton()->file_dialog_with_options_show(get_displayed_title(), ProjectSettings::get_singleton()->globalize_path(full_dir), root, filename_edit->get_text().get_file(), show_hidden_files, DisplayServerEnums::FileDialogMode(mode), processed_filters, _get_options(), callable_mp(this, &FileDialog::_native_dialog_cb_with_options), wid);
+		dlg_err = DisplayServer::get_singleton()->file_dialog_with_options_show(get_displayed_title(), ProjectSettings::get_singleton()->globalize_path(full_dir), root, filename_edit->get_text().get_file(), show_hidden_files, DisplayServerEnums::FileDialogMode(mode), processed_filters, _get_options(), callable_mp(this, &FileDialog::_native_dialog_cb_with_options), wid);
 	} else {
-		DisplayServer::get_singleton()->file_dialog_show(get_displayed_title(), ProjectSettings::get_singleton()->globalize_path(full_dir), filename_edit->get_text().get_file(), show_hidden_files, DisplayServerEnums::FileDialogMode(mode), processed_filters, callable_mp(this, &FileDialog::_native_dialog_cb), wid);
+		dlg_err = DisplayServer::get_singleton()->file_dialog_show(get_displayed_title(), ProjectSettings::get_singleton()->globalize_path(full_dir), filename_edit->get_text().get_file(), show_hidden_files, DisplayServerEnums::FileDialogMode(mode), processed_filters, callable_mp(this, &FileDialog::_native_dialog_cb), wid);
+	}
+	if (is_exclusive() && dlg_err == OK) {
+		get_parent_visible_window()->_set_block_input(true);
+	}
+	if (dlg_err != OK) { // Fallback to built-in.
+		ConfirmationDialog::set_visible(true);
 	}
 }
 
@@ -149,6 +156,8 @@ void FileDialog::_native_dialog_cb(bool p_ok, const Vector<String> &p_files, int
 }
 
 void FileDialog::_native_dialog_cb_with_options(bool p_ok, const Vector<String> &p_files, int p_filter, const Dictionary &p_selected_options) {
+	get_parent_visible_window()->_set_block_input(false);
+
 	if (!p_ok) {
 		filename_edit->set_text("");
 		emit_signal(SNAME("canceled"));

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2010,9 +2010,16 @@ bool Window::_can_consume_input_events() const {
 	return exclusive_child == nullptr;
 }
 
+void Window::_set_block_input(bool p_block) {
+	block_input = p_block;
+}
+
 void Window::_window_input(const Ref<InputEvent> &p_ev) {
 	ERR_MAIN_THREAD_GUARD;
 
+	if (block_input) {
+		return;
+	}
 	if (exclusive_child != nullptr) {
 		if (nonclient_area.has_area() && is_inside_tree()) {
 			Ref<InputEventMouse> me = p_ev;

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -148,6 +148,7 @@ private:
 	bool clamp_to_embedder = false;
 	bool unparent_when_invisible = false;
 	bool keep_title_visible = false;
+	bool block_input = false;
 
 	LayoutDirection layout_dir = LAYOUT_DIRECTION_INHERITED;
 
@@ -302,6 +303,8 @@ public:
 	};
 
 	PackedStringArray get_accessibility_configuration_warnings() const override;
+
+	void _set_block_input(bool p_block);
 
 	static void set_root_layout_direction(int p_root_dir);
 	static Window *get_from_id(DisplayServerEnums::WindowID p_window_id);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/104670
Fixes https://github.com/godotengine/godot/issues/121230

Notes:
- on macOS: exclusive dialog is displayed as sheet, non-exclusive as a separate window.
- on Linux: input to the parent window is always blocked, but it depends on DE whether it will stay on top of parent.