### PR TITLE
Fix frame keying increment for AnimatedSprite2D/3D

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1107,9 +1107,27 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 					if (new_coords.x < int64_t(object->get("hframes")) && new_coords.y < int64_t(object->get("vframes"))) {
 						callable_mp(this, &EditorProperty::emit_changed).call_deferred(property, new_coords, "", false);
 					}
-				} else {
+				} else if (property == "frame" && (object->is_class("AnimatedSprite2D") || object->is_class("AnimatedSprite3D"))) {
+					Ref<Resource> sprite_frames = object->get("sprite_frames");
+					if (sprite_frames.is_valid()) {
+						StringName animation = object->get("animation");
+						int frame_count = sprite_frames->call("get_frame_count", animation);
+						int64_t current_frame = object->get(property);
+						if (current_frame + 1 < frame_count) {
+							callable_mp(this, &EditorProperty::emit_changed).call_deferred(property, current_frame + 1, "", false);
+						}
+					}
+				} else if (object->is_class("Sprite2D") || object->is_class("Sprite3D")) {
 					if (int64_t(object->get(property)) + 1 < (int64_t(object->get("hframes")) * int64_t(object->get("vframes")))) {
 						callable_mp(this, &EditorProperty::emit_changed).call_deferred(property, object->get(property).operator int64_t() + 1, "", false);
+					}
+				} else {
+					// Generic fallback for any property with PROPERTY_USAGE_KEYING_INCREMENTS.
+					Variant current_value = object->get(property);
+					if (current_value.get_type() == Variant::INT) {
+						callable_mp(this, &EditorProperty::emit_changed).call_deferred(property, current_value.operator int64_t() + 1, "", false);
+					} else if (current_value.get_type() == Variant::FLOAT) {
+						callable_mp(this, &EditorProperty::emit_changed).call_deferred(property, current_value.operator double() + 1.0, "", false);
 					}
 				}
 				callable_mp(this, &EditorProperty::update_property).call_deferred();

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1117,7 +1117,7 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 							callable_mp(this, &EditorProperty::emit_changed).call_deferred(property, current_frame + 1, "", false);
 						}
 					}
-				} else if (object->is_class("Sprite2D") || object->is_class("Sprite3D")) {
+				} else if (property == "frame" && object->is_class("Sprite2D") || object->is_class("Sprite3D")) {
 					if (int64_t(object->get(property)) + 1 < (int64_t(object->get("hframes")) * int64_t(object->get("vframes")))) {
 						callable_mp(this, &EditorProperty::emit_changed).call_deferred(property, object->get(property).operator int64_t() + 1, "", false);
 					}

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1117,7 +1117,7 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 							callable_mp(this, &EditorProperty::emit_changed).call_deferred(property, current_frame + 1, "", false);
 						}
 					}
-				} else if ((property == "frame" && object->is_class("Sprite2D")) || object->is_class("Sprite3D")) {
+				} else if (property == "frame" && (object->is_class("Sprite2D") || object->is_class("Sprite3D"))) {
 					if (int64_t(object->get(property)) + 1 < (int64_t(object->get("hframes")) * int64_t(object->get("vframes")))) {
 						callable_mp(this, &EditorProperty::emit_changed).call_deferred(property, object->get(property).operator int64_t() + 1, "", false);
 					}

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1117,7 +1117,7 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 							callable_mp(this, &EditorProperty::emit_changed).call_deferred(property, current_frame + 1, "", false);
 						}
 					}
-				} else if (property == "frame" && object->is_class("Sprite2D") || object->is_class("Sprite3D")) {
+				} else if ((property == "frame" && object->is_class("Sprite2D")) || object->is_class("Sprite3D")) {
 					if (int64_t(object->get(property)) + 1 < (int64_t(object->get("hframes")) * int64_t(object->get("vframes")))) {
 						callable_mp(this, &EditorProperty::emit_changed).call_deferred(property, object->get(property).operator int64_t() + 1, "", false);
 					}


### PR DESCRIPTION
## Description

Fixes the frame property keying increment functionality for `AnimatedSprite2D` and `AnimatedSprite3D` nodes.

## Problem

When attempting to keyframe the frame property on `AnimatedSprite2D` or `AnimatedSprite3D`, the increment feature (clicking the key icon with the arrow) causes errors:

```c
ERROR: scene/resources/animation.cpp:1547 - Index (uint32_t)p_track = 4294967295 is out of bounds (tracks.size() = 1).
ERROR: scene/resources/animation.cpp:1901 - Index (uint32_t)p_track = 4294967295 is out of bounds (tracks.size() = 1).
ERROR: Animation '<null>' doesn't exist.
```

The issue occurs because the existing code assumes all sprite nodes have `hframes` and `vframes` properties, but `AnimatedSprite2D`/`3D` use `SpriteFrames` resource with animations instead.

## Related Issues

Closes #114450
Closes #114565