### PR TITLE
Add VideoStreamPlayer UpdateMode to not process the invisible

### DIFF
--- a/doc/classes/VideoStreamPlayer.xml
+++ b/doc/classes/VideoStreamPlayer.xml
@@ -73,6 +73,9 @@
 		<member name="paused" type="bool" setter="set_paused" getter="is_paused" default="false">
 			If [code]true[/code], the video is paused.
 		</member>
+		<member name="playback_update_mode" type="int" setter="set_update_mode" getter="get_update_mode" enum="VideoStreamPlayer.UpdateMode" default="1">
+			The update mode for advancing the video playback.
+		</member>
 		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
 			The stream's current speed scale. [code]1.0[/code] is the normal speed, while [code]2.0[/code] is double speed and [code]0.5[/code] is half speed. A speed scale of [code]0.0[/code] pauses the video, similar to setting [member paused] to [code]true[/code].
 		</member>
@@ -96,4 +99,15 @@
 			</description>
 		</signal>
 	</signals>
+	<constants>
+		<constant name="UPDATE_DISABLED" value="0" enum="UpdateMode">
+			Do not update the video stream player. Acts similar to [member paused] but keeps the current playback state without changing any playback properties.
+		</constant>
+		<constant name="UPDATE_WHEN_VISIBLE" value="1" enum="UpdateMode">
+			Only update and advance the video playback state while the video stream player is visible. Visibility is determined by the [CanvasItem] visibility notifier and [SceneTree] node visibility. Effectively the video will automatically act as if paused while off-screen or hidden saving performance and resuming when it becomes visible again.
+		</constant>
+		<constant name="UPDATE_ALWAYS" value="2" enum="UpdateMode">
+			Always update the video stream player even while hidden and off-screen.
+		</constant>
+	</constants>
 </class>

--- a/scene/gui/video_stream_player.h
+++ b/scene/gui/video_stream_player.h
@@ -70,6 +70,20 @@ class VideoStreamPlayer : public Control {
 	static int _audio_mix_callback(void *p_udata, const float *p_data, int p_frames);
 	static void _mix_audios(void *p_self);
 
+public:
+	enum UpdateMode {
+		UPDATE_DISABLED,
+		UPDATE_WHEN_VISIBLE,
+		UPDATE_ALWAYS
+	};
+
+private:
+	UpdateMode update_mode = UPDATE_WHEN_VISIBLE;
+
+	bool on_screen = false;
+	void _visibility_enter();
+	void _visibility_exit();
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_notification);
@@ -121,5 +135,10 @@ public:
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;
 
+	void set_update_mode(UpdateMode p_mode);
+	UpdateMode get_update_mode() const;
+
 	~VideoStreamPlayer();
 };
+
+VARIANT_ENUM_CAST(VideoStreamPlayer::UpdateMode);


### PR DESCRIPTION
Adds UpdateMode to VideoStreamPlayer for better performance and control in gui heavy setups with lots of small video streams.

### Performance

<img width="874" height="355" alt="videoplayer_profiler" src="https://github.com/user-attachments/assets/b01625b5-a500-4b2e-b473-354c8d281266" />

These performance spikes seen here are with 10+ smaller video stream players active that are all from different gui elements off-screen and not visible on a 144 hz monitor with uncapped frame rate. Part of the big jump is also caused by running into a physics death spiral due to all the senseless processing for invisible videos going on behind the scene.

The changes in this PR with visibility check is what causes the performance to reset to manageable levels because it stops processing all the videos that are in hidden menus or off-screen automatically (in this example case when the graph is at its lowest just 1 or zero videos are processing because those can actually be seen). There are other performance issues with the VideoStreamPlayer node for other PRs to fix but this is a first step. 

### Update modes

- UPDATE_DISABLED
Same as paused but without changing properties that would cause unwanted side effects in code.
- UPDATE_WHEN_VISIBLE
The recommended winner mode that only processes what can actually be seen on screen. Works by using the node visibility and the CanvasItem visibility notifier.
- UPDATE_ALWAYS
The current default that updates and processes everything all the time no matter what.

While UPDATE_ALWAYS would match with the current way the VideoStreamPlayer is behaving I recommend using the UPDATE_WHEN_VISIBLE as the new default.

It commonly does not make that much sense to process videos while not at all visible. That situation frequently is found in Control based gui menus where users park menus with video backdrops for later use. Since the video player has no dedicated debugger all users see is an increased process() time not understanding what is causing it.

I encountered these performance issues many times over in Godot projects where users would never free their menu backdrop movies because it would cause stutters when loading the (quick) menu at runtime so they entire gameplay time they would just process in the background movies that no one sees wasting performance. Sure they could add scripts to pause and un-set the Stream but they are commonly not doing that and it would be better to do it automatically.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
