### PR TITLE
Fix the UID was not recorded in the file info when a new file was detected

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -913,6 +913,7 @@ bool EditorFileSystem::_update_scan_actions() {
 						// Re-assign the UID to file, just in case it was pulled from cache.
 						ResourceSaver::set_uid(new_file_path, existing_id);
 					}
+					ia.new_file->uid = existing_id;
 				} else if (ResourceLoader::should_create_uid_file(new_file_path)) {
 					Ref<FileAccess> f = FileAccess::open(new_file_path + ".uid", FileAccess::WRITE);
 					if (f.is_valid()) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
This is helpful for #106102. Because the files are scanned in a specific order, this solution may not completely resolve issue 106102. #113035 processes UID updates in a specific order, so it will be better.

For `ItemAction::ACTION_FILE_ADD`, the record UID is missing.

As a side note, in `EditorFileSystem::_scan_fs_changes()`, the case of file overwriting (which can be quite common when using `git checkout`) is not considered when detecting file updates. From this perspective, relying solely on timestamps to determine whether a file has been updated is insufficient. The file modification timestamp and UID might be better.

