### PR TITLE
Fix camera focus triggered by double-clicking Tree buttons

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4160,7 +4160,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 					if (rtl) {
 						pressing_pos.x = get_size().width - pressing_pos.x;
 					}
-				} else if (mb->is_double_click() && get_item_at_position(mb->get_position()) != nullptr) {
+				} else if (mb->is_double_click() && cache.click_type != Cache::CLICK_BUTTON && get_item_at_position(mb->get_position()) != nullptr) {
 					emit_signal(SNAME("item_icon_double_clicked"));
 				}
 


### PR DESCRIPTION
## Description

This prevents the `item_icon_double_clicked` signal from being emitted when double-clicking on **Tree** item buttons (such as *Toggle Visibility*, *Lock*, *Group*, etc.).

## Problem

When rapidly clicking the **Toggle Visibility** button in the **Scene Tree dock**, the camera would unexpectedly focus on the selected node. This happened because double-clicking on any part of a **Tree** item (including buttons) would emit the `item_icon_double_clicked` signal, which in turn triggered `_focus_node()` in the **Scene Tree dock**.

This behavior was disruptive when users wanted to quickly toggle visibility to compare how something looks before/after, as the camera would jump to focus on the node.

## Related Issues

Fixes #114514