### PR TITLE
LinuxBSD: Fix UI freeze when opening file manager

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -532,45 +532,38 @@ Vector<String> OS_LinuxBSD::lspci_get_device_value(Vector<String> vendor_device_
 }
 
 Error OS_LinuxBSD::shell_open(const String &p_uri) {
-	Error ok;
-	int err_code;
 	List<String> args;
 	args.push_back(p_uri);
 
-	// Agnostic
-	ok = execute("xdg-open", args, nullptr, &err_code);
-	if (ok == OK && !err_code) {
+	// Use create_process() instead of execute() to avoid blocking the main thread.
+	// This prevents the UI from freezing when opening file managers or other applications.
+	Error ok = create_process("xdg-open", args);
+	if (ok == OK) {
 		return OK;
-	} else if (err_code == 2) {
-		return ERR_FILE_NOT_FOUND;
 	}
 	// GNOME
 	args.push_front("open"); // The command is `gio open`, so we need to add it to args
-	ok = execute("gio", args, nullptr, &err_code);
-	if (ok == OK && !err_code) {
+	ok = create_process("gio", args);
+	if (ok == OK) {
 		return OK;
-	} else if (err_code == 2) {
-		return ERR_FILE_NOT_FOUND;
 	}
 	args.pop_front();
-	ok = execute("gvfs-open", args, nullptr, &err_code);
-	if (ok == OK && !err_code) {
+	ok = create_process("gvfs-open", args);
+	if (ok == OK) {
 		return OK;
-	} else if (err_code == 2) {
-		return ERR_FILE_NOT_FOUND;
 	}
 	// KDE
-	ok = execute("kde-open5", args, nullptr, &err_code);
-	if (ok == OK && !err_code) {
+	ok = create_process("kde-open5", args);
+	if (ok == OK) {
 		return OK;
 	}
-	ok = execute("kde-open", args, nullptr, &err_code);
-	if (ok == OK && !err_code) {
+	ok = create_process("kde-open", args);
+	if (ok == OK) {
 		return OK;
 	}
 	// XFCE
-	ok = execute("exo-open", args, nullptr, &err_code);
-	if (ok == OK && !err_code) {
+	ok = create_process("exo-open", args);
+	if (ok == OK) {
 		return OK;
 	}
 	return FAILED;


### PR DESCRIPTION
## Description
Use ``create_process()`` instead of ``execute()`` in ``OS_LinuxBSD::shell_open()`` to launch external applications asynchronously.

## Problem
On Linux/BSD, when using "Show in File Manager" (or any ``shell_open`` call), the Godot UI freezes and stops receiving visual updates until the file manager is closed. This happens because ``execute()`` is a blocking call that waits for the child process to complete. Tools like ``xdg-open`` may wait for the spawned application to exit before returning.

## Related Issues
Fixes #114213