### PR TITLE
Change EditorDockManger to Control

### DIFF
--- a/editor/docks/editor_dock_manager.h
+++ b/editor/docks/editor_dock_manager.h
@@ -61,26 +61,15 @@ public:
 	DockSplitContainer();
 };
 
-class DockShortcutHandler : public Node {
-	GDCLASS(DockShortcutHandler, Node);
-
-protected:
-	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
-
-public:
-	DockShortcutHandler() { set_process_shortcut_input(true); }
-};
-
 class DockContextPopup;
 class EditorDockDragHint;
 
-class EditorDockManager : public Object {
-	GDCLASS(EditorDockManager, Object);
+class EditorDockManager : public Control {
+	GDCLASS(EditorDockManager, Control);
 
 private:
 	friend class DockContextPopup;
 	friend class EditorDockDragHint;
-	friend class DockShortcutHandler;
 
 	static inline EditorDockManager *singleton = nullptr;
 
@@ -127,6 +116,11 @@ private:
 	void _queue_update_tab_style(EditorDock *p_dock);
 	void _update_dirty_dock_tabs();
 	void _update_tab_style(EditorDock *p_dock);
+
+protected:
+	void _notification(int p_notification);
+
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 public:
 	static EditorDockManager *get_singleton() { return singleton; }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8505,6 +8505,7 @@ EditorNode::EditorNode() {
 	right_r_vsplit->add_child(dock_slot[DockConstants::DOCK_SLOT_RIGHT_BR]);
 
 	editor_dock_manager = memnew(EditorDockManager);
+	gui_base->add_child(editor_dock_manager);
 
 	// Save the splits for easier access.
 	editor_dock_manager->add_vsplit(left_l_vsplit);
@@ -9327,7 +9328,6 @@ EditorNode::~EditorNode() {
 	memdelete(editor_plugins_force_input_forwarding);
 	memdelete(progress_hb);
 	memdelete(project_upgrade_tool);
-	memdelete(editor_dock_manager);
 
 	EditorSettings::destroy();
 	EditorThemeManager::finalize();


### PR DESCRIPTION
This PR changes EditorDockManger from Object to Control (I originally wanted to use Node2D, but this simplifies includes). This allows to simplify the code a bit:
- Separate `closed_dock_parent` is no longer needed, the dock manager is used for that (it's hidden)
- DockShortcutHandler is removed and the manager now directly handles shortcuts
- Theme changes are handled with notification instead of signal connected from somewhere
- The dock manager now correctly reacts to language changes (previous it was not possible, as there is no dedicated signal)
  - This affects only some tooltips
- Some operations previously done by EditorNode or related are now handled directly by the dock manager