### PR TITLE
LSP: Remove boilerplate for some unimplemented methods

### DIFF
--- a/modules/gdscript/doc_classes/GDScriptTextDocument.xml
+++ b/modules/gdscript/doc_classes/GDScriptTextDocument.xml
@@ -9,18 +9,6 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="codeLens" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
-			<return type="Array" />
-			<param index="0" name="params" type="Dictionary" />
-			<description>
-			</description>
-		</method>
-		<method name="colorPresentation" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
-			<return type="Array" />
-			<param index="0" name="params" type="Dictionary" />
-			<description>
-			</description>
-		</method>
 		<method name="completion" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
 			<return type="Array" />
 			<param index="0" name="params" type="Dictionary" />
@@ -70,12 +58,6 @@
 			</description>
 		</method>
 		<method name="documentSymbol" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
-			<return type="Array" />
-			<param index="0" name="params" type="Dictionary" />
-			<description>
-			</description>
-		</method>
-		<method name="foldingRange" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
 			<return type="Array" />
 			<param index="0" name="params" type="Dictionary" />
 			<description>

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -687,10 +687,7 @@ GDScriptLanguageProtocol::GDScriptLanguageProtocol() {
 	SET_DOCUMENT_METHOD(rename);
 	SET_DOCUMENT_METHOD(prepareRename);
 	SET_DOCUMENT_METHOD(references);
-	SET_DOCUMENT_METHOD(foldingRange);
-	SET_DOCUMENT_METHOD(codeLens);
 	SET_DOCUMENT_METHOD(documentLink);
-	SET_DOCUMENT_METHOD(colorPresentation);
 	SET_DOCUMENT_METHOD(hover);
 	SET_DOCUMENT_METHOD(definition);
 	SET_DOCUMENT_METHOD(declaration);

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -57,10 +57,7 @@ void GDScriptTextDocument::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("rename", "params"), &GDScriptTextDocument::rename);
 	ClassDB::bind_method(D_METHOD("prepareRename", "params"), &GDScriptTextDocument::prepareRename);
 	ClassDB::bind_method(D_METHOD("references", "params"), &GDScriptTextDocument::references);
-	ClassDB::bind_method(D_METHOD("foldingRange", "params"), &GDScriptTextDocument::foldingRange);
-	ClassDB::bind_method(D_METHOD("codeLens", "params"), &GDScriptTextDocument::codeLens);
 	ClassDB::bind_method(D_METHOD("documentLink", "params"), &GDScriptTextDocument::documentLink);
-	ClassDB::bind_method(D_METHOD("colorPresentation", "params"), &GDScriptTextDocument::colorPresentation);
 	ClassDB::bind_method(D_METHOD("hover", "params"), &GDScriptTextDocument::hover);
 	ClassDB::bind_method(D_METHOD("definition", "params"), &GDScriptTextDocument::definition);
 	ClassDB::bind_method(D_METHOD("declaration", "params"), &GDScriptTextDocument::declaration);
@@ -266,14 +263,6 @@ Dictionary GDScriptTextDocument::resolve(const Dictionary &p_params) {
 	return item.to_json(true);
 }
 
-Array GDScriptTextDocument::foldingRange(const Dictionary &p_params) {
-	return Array();
-}
-
-Array GDScriptTextDocument::codeLens(const Dictionary &p_params) {
-	return Array();
-}
-
 Array GDScriptTextDocument::documentLink(const Dictionary &p_params) {
 	Array ret;
 
@@ -286,10 +275,6 @@ Array GDScriptTextDocument::documentLink(const Dictionary &p_params) {
 		ret.push_back(E.to_json());
 	}
 	return ret;
-}
-
-Array GDScriptTextDocument::colorPresentation(const Dictionary &p_params) {
-	return Array();
 }
 
 Variant GDScriptTextDocument::hover(const Dictionary &p_params) {

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -66,10 +66,7 @@ public:
 	Dictionary rename(const Dictionary &p_params);
 	Variant prepareRename(const Dictionary &p_params);
 	Array references(const Dictionary &p_params);
-	Array foldingRange(const Dictionary &p_params);
-	Array codeLens(const Dictionary &p_params);
 	Array documentLink(const Dictionary &p_params);
-	Array colorPresentation(const Dictionary &p_params);
 	Variant hover(const Dictionary &p_params);
 	Array definition(const Dictionary &p_params);
 	Variant declaration(const Dictionary &p_params);

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -514,22 +514,6 @@ struct SignatureHelpOptions {
 };
 
 /**
- * Code Lens options.
- */
-struct CodeLensOptions {
-	/**
-	 * Code lens has a resolve provider as well.
-	 */
-	bool resolveProvider = false;
-
-	Dictionary to_json() {
-		Dictionary dict;
-		dict["resolveProvider"] = resolveProvider;
-		return dict;
-	}
-};
-
-/**
  * Rename options
  */
 struct RenameOptions {
@@ -590,24 +574,6 @@ struct SaveOptions {
 		Dictionary dict;
 		dict["includeText"] = includeText;
 		return dict;
-	}
-};
-
-/**
- * Color provider options.
- */
-struct ColorProviderOptions {
-	Dictionary to_json() {
-		return Dictionary();
-	}
-};
-
-/**
- * Folding range provider options.
- */
-struct FoldingRangeProviderOptions {
-	Dictionary to_json() {
-		return Dictionary();
 	}
 };
 
@@ -1783,11 +1749,6 @@ struct ServerCapabilities {
 	bool codeActionProvider = false;
 
 	/**
-	 * The server provides code lens.
-	 */
-	CodeLensOptions codeLensProvider;
-
-	/**
 	 * The server provides document formatting.
 	 */
 	bool documentFormattingProvider = false;
@@ -1815,20 +1776,6 @@ struct ServerCapabilities {
 	DocumentLinkOptions documentLinkProvider;
 
 	/**
-	 * The server provides color provider support.
-	 *
-	 * Since 3.6.0
-	 */
-	ColorProviderOptions colorProvider;
-
-	/**
-	 * The server provides folding provider support.
-	 *
-	 * Since 3.10.0
-	 */
-	FoldingRangeProviderOptions foldingRangeProvider;
-
-	/**
 	 * The server provides go to declaration support.
 	 *
 	 * Since 3.14.0
@@ -1847,12 +1794,9 @@ struct ServerCapabilities {
 		signatureHelpProvider.triggerCharacters.push_back(",");
 		signatureHelpProvider.triggerCharacters.push_back("(");
 		dict["signatureHelpProvider"] = signatureHelpProvider.to_json();
-		//dict["codeLensProvider"] = codeLensProvider.to_json();
 		dict["documentOnTypeFormattingProvider"] = documentOnTypeFormattingProvider.to_json();
 		dict["renameProvider"] = renameProvider.to_json();
 		dict["documentLinkProvider"] = documentLinkProvider.to_json();
-		dict["colorProvider"] = false; // colorProvider.to_json();
-		dict["foldingRangeProvider"] = false; //foldingRangeProvider.to_json();
 		dict["executeCommandProvider"] = executeCommandProvider.to_json();
 		dict["hoverProvider"] = hoverProvider;
 		dict["definitionProvider"] = definitionProvider;


### PR DESCRIPTION
Removes some dummy implementations for endpoints that are optional.

I did not add compat bindings for the removed methods, since I do not consider the LSP interfaces stable.