### PR TITLE
LSP: Remove unused `ExtendGDScriptParser::get_member_completions`

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -859,30 +859,6 @@ const List<LSP::DocumentLink> &ExtendGDScriptParser::get_document_links() const 
 	return document_links;
 }
 
-const Array &ExtendGDScriptParser::get_member_completions() {
-	if (member_completions.is_empty()) {
-		for (const KeyValue<String, const LSP::DocumentSymbol *> &E : members) {
-			const LSP::DocumentSymbol *symbol = E.value;
-			LSP::CompletionItem item = symbol->make_completion_item();
-			item.data = JOIN_SYMBOLS(path, E.key);
-			member_completions.push_back(item.to_json());
-		}
-
-		for (const KeyValue<String, ClassMembers> &E : inner_classes) {
-			const ClassMembers *inner_class = &E.value;
-
-			for (const KeyValue<String, const LSP::DocumentSymbol *> &F : *inner_class) {
-				const LSP::DocumentSymbol *symbol = F.value;
-				LSP::CompletionItem item = symbol->make_completion_item();
-				item.data = JOIN_SYMBOLS(path, JOIN_SYMBOLS(E.key, F.key));
-				member_completions.push_back(item.to_json());
-			}
-		}
-	}
-
-	return member_completions;
-}
-
 Dictionary ExtendGDScriptParser::dump_function_api(const GDScriptParser::FunctionNode *p_func) const {
 	ERR_FAIL_NULL_V(p_func, Dictionary());
 	Dictionary func;

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -42,14 +42,6 @@
 #define COLUMN_NUMBER_TO_INDEX(p_column) ((p_column) - 1)
 #endif
 
-#ifndef SYMBOL_SEPARATOR
-#define SYMBOL_SEPARATOR "::"
-#endif
-
-#ifndef JOIN_SYMBOLS
-#define JOIN_SYMBOLS(p_path, name) ((p_path) + SYMBOL_SEPARATOR + (name))
-#endif
-
 typedef HashMap<String, const LSP::DocumentSymbol *> ClassMembers;
 
 /**
@@ -133,8 +125,6 @@ class ExtendGDScriptParser : public GDScriptParser {
 	Dictionary dump_class_api(const GDScriptParser::ClassNode *p_class) const;
 
 	const LSP::DocumentSymbol *search_symbol_defined_at_line(int p_line, const LSP::DocumentSymbol &p_parent, const String &p_symbol_name = "") const;
-
-	Array member_completions;
 
 public:
 	_FORCE_INLINE_ const String &get_path() const { return path; }

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -293,33 +293,6 @@ Dictionary GDScriptTextDocument::resolve(const Dictionary &p_params) {
 	if (data.get_type() == Variant::DICTIONARY) {
 		params.load(p_params["data"]);
 		symbol = GDScriptLanguageProtocol::get_singleton()->get_workspace()->resolve_symbol(params, item.label, item.kind == LSP::CompletionItemKind::Method || item.kind == LSP::CompletionItemKind::Function);
-
-	} else if (data.is_string()) {
-		String query = data;
-
-		Vector<String> param_symbols = query.split(SYMBOL_SEPARATOR, false);
-
-		if (param_symbols.size() >= 2) {
-			StringName class_name = param_symbols[0];
-			const String &member_name = param_symbols[param_symbols.size() - 1];
-			String inner_class_name;
-			if (param_symbols.size() >= 3) {
-				inner_class_name = param_symbols[1];
-			}
-
-			if (const ClassMembers *members = GDScriptLanguageProtocol::get_singleton()->get_workspace()->native_members.getptr(class_name)) {
-				if (const LSP::DocumentSymbol *const *member = members->getptr(member_name)) {
-					symbol = *member;
-				}
-			}
-
-			if (!symbol) {
-				ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_parse_result(class_name);
-				if (parser) {
-					symbol = parser->get_member_symbol(member_name, inner_class_name);
-				}
-			}
-		}
 	}
 
 	if (symbol) {


### PR DESCRIPTION
Followup to https://github.com/godotengine/godot/pull/114442 ~(also includes the commit from the PR)~

I missed another member which got unused after https://github.com/godotengine/godot/pull/96684 : `ExtendGDScriptParser::get_member_completions`. This PR removes this method as well.

After removing `ExtendGDScriptParser::get_member_completions` and `GDScriptTextDocument::native_member_completions` there is no code left which sets `CompletionItem::data` to a string. This allows use to safely remove an additional code path in `GDScriptTextDocument::resolve`. (The `data` member which the client sends to, `GDScriptTextDocument::resolve` is always a data value which was provided by the server)

