### PR TITLE
Editor: Fix CSG gizmo selection inside CSGCombiners

### DIFF
--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -417,17 +417,14 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	Ref<Material> handles_material = get_material("handles");
 
 	p_gizmo->add_lines(lines, material);
-	p_gizmo->add_collision_segments(lines);
 
-	if (cs->is_root_shape()) {
-		Array csg_meshes = cs->get_meshes();
-		if (csg_meshes.size() == 2) {
-			Ref<Mesh> csg_mesh = csg_meshes[1];
-			if (csg_mesh.is_valid()) {
-				p_gizmo->add_collision_triangles(csg_mesh->generate_triangle_mesh());
-			}
-		}
-	}
+	Ref<ArrayMesh> collision_mesh;
+	collision_mesh.instantiate();
+	Array collision_array;
+	collision_array.resize(Mesh::ARRAY_MAX);
+	collision_array[Mesh::ARRAY_VERTEX] = faces;
+	collision_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, collision_array);
+	p_gizmo->add_collision_triangles(collision_mesh->generate_triangle_mesh());
 
 	if (p_gizmo->is_selected()) {
 		// Draw a translucent representation of the CSG node


### PR DESCRIPTION
Previously, CSG nodes within the same CSGCombiner3D could not be reliably selected with the CSG gizmo due to only using line-based collision. Often, this would result in selections passing through the target node.

This PR changes the CSGShape3D gizmo to use triangle-based collision for all shapes, rather than just the root shape, thus making selections with the CSG gizmo reliably select the correct node.

This issue was originally outlined in a comment on #46037.