### PR TITLE
Fix SplitContainer set desired size infinite loop

### DIFF
--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -290,14 +290,14 @@ void TileMapLayerEditorTilesPlugin::_update_source_display() {
 		TileSetScenesCollectionSource *scenes_collection_source = Object::cast_to<TileSetScenesCollectionSource>(source);
 
 		if (atlas_source) {
-			tile_atlas_view->show();
 			scene_tiles_list->hide();
 			invalid_source_label->hide();
+			tile_atlas_view->show();
 			_update_atlas_view();
 		} else if (scenes_collection_source) {
 			tile_atlas_view->hide();
-			scene_tiles_list->show();
 			invalid_source_label->hide();
+			scene_tiles_list->show();
 			_update_scenes_collection_view();
 		} else {
 			tile_atlas_view->hide();

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -410,6 +410,7 @@ void SplitContainer::_set_desired_sizes(const PackedInt32Array &p_desired_sizes,
 		if (Math::is_zero_approx(shrink_amount)) {
 			break;
 		}
+		const real_t prev_available_space = available_space;
 		for (StretchData &sdata : stretch_data) {
 			if (sdata.stretch_ratio <= 0 || sdata.final_size <= sdata.min_size) {
 				continue;
@@ -418,6 +419,10 @@ void SplitContainer::_set_desired_sizes(const PackedInt32Array &p_desired_sizes,
 			sdata.final_size = CLAMP(prev_size - shrink_amount * sdata.stretch_ratio, sdata.min_size, sdata.final_size);
 			const real_t size_diff = prev_size - sdata.final_size;
 			available_space += size_diff;
+		}
+		if (Math::is_equal_approx(available_space, prev_available_space)) {
+			// Shrinking can fail due to values being too small to have an effect but too large for `is_zero_approx`.
+			break;
 		}
 	}
 
@@ -454,6 +459,7 @@ void SplitContainer::_set_desired_sizes(const PackedInt32Array &p_desired_sizes,
 		}
 		// Don't shrink smaller than needed.
 		target_size = MAX(target_size, largest_size + available_space / largest_count);
+		const real_t prev_available_space = available_space;
 		for (StretchData &sdata : stretch_data) {
 			if (sdata.final_size <= sdata.min_size || (skip_priority_child && sdata.priority)) {
 				continue;
@@ -465,7 +471,7 @@ void SplitContainer::_set_desired_sizes(const PackedInt32Array &p_desired_sizes,
 				available_space += size_diff;
 			}
 		}
-		if (Math::is_zero_approx(available_space)) {
+		if (Math::is_zero_approx(available_space) || Math::is_equal_approx(available_space, prev_available_space)) {
 			break;
 		}
 	}


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/114523
- The infinite loop in general is actually caused by https://github.com/godotengine/godot/pull/90411,
	- #113822 just makes it easier to trigger

The checks in `SplitContainer::_set_desired_sizes` fixes the infinite loop. 
The problem was the available space / shrink amount  got to a small number like `1.2e-5` where `is_zero_approx` didn't catch it but subtracting it resulted in no change. There is now a check to make sure that the available space changes. There is another check in the similar loop below it since it can have the same issue.

Unrelated to the inf loop, the split offset was being changed when changing from a scene collection source to an atlas source. 
This happened because the atlas was being shown before the scene collection was hidden, which made the SplitContainer try fit all 3 children, shrinking them, before it went down to 2 visible children. Since the order matters now I changed it to show only after hiding.