### PR TITLE
Allow null Resource default values in EditorImportPlugins

### DIFF
--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -128,7 +128,12 @@ void EditorImportPlugin::get_import_options(const String &p_path, List<ResourceI
 			usage = d["usage"];
 		}
 
-		ImportOption option(PropertyInfo(default_value.get_type(), name, hint, hint_string, usage), default_value);
+		Variant::Type type = default_value.get_type();
+		if (type == Variant::NIL && hint == PROPERTY_HINT_RESOURCE_TYPE) {
+			type = Variant::OBJECT;
+		}
+
+		ImportOption option(PropertyInfo(type, name, hint, hint_string, usage), default_value);
 		r_options->push_back(option);
 	}
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
Fixes https://github.com/godotengine/godot/issues/99267

Supercedes https://github.com/godotengine/godot/pull/99418

This PR basically looks at the specified property hint, and automatically infers the import option's type as an `Object` if the hint is `PROPERTY_HINT_RESOURCE_TYPE` and the default value is null.

Compared to the other (closed) PR, this PR does not introduce an additional type key and "just works" without any modification on the user's end.

It's also worth mentioning that the only time you'd ever want to specify the Variant type is with Resources anyway, since other types have non-null "empty" values available (e.g., empty arrays, dictionaries) already.