### PR TITLE
Standardize paths used under drag and drop action in Windows platform specfically

### DIFF
--- a/platform/windows/drop_target_windows.cpp
+++ b/platform/windows/drop_target_windows.cpp
@@ -47,7 +47,7 @@ static String create_temp_dir() {
 		return "";
 	}
 
-	String tmp_dir = String::utf16((const char16_t *)buf.ptr());
+	String tmp_dir = String::utf16((const char16_t *)buf.ptr()).simplify_path();
 	RandomPCG gen(Time::get_singleton()->get_ticks_usec());
 
 	const int attempts = 4;
@@ -165,7 +165,7 @@ HRESULT DropTargetWindows::handle_hdrop_format(Vector<String> *p_files, IDataObj
 			goto cleanup;
 		}
 		String file = String::utf16((const char16_t *)buf.ptr());
-		p_files->push_back(file);
+		p_files->push_back(file.simplify_path());
 	}
 
 cleanup:


### PR DESCRIPTION
The paths of files/directories under drag-n-drop action from system file explorer to godot assets dock in Windows are standardized now.

It fixes the check here:
https://github.com/godotengine/godot/blob/f0aeea26fb9d930be42f1cdc5cb55b3acf9589bf/core/io/dir_access.cpp#L413-L414

This also fixes the freeze of godot editor and duplicated tmp files after dragging and dropping files(assets) from OS File Explorer to where they already are, as is described here: 
https://github.com/godotengine/godot/issues/114218#issuecomment-3677105631

Additionally, `create_temp_dir`, which is used by `handle_filedescriptor_format`, also returns a standardized path string.

---
<details><summary>Update(Incapable)</summary>
<p>
The `DirAccessWindows::is_equivalent(a, b)` function compared hard driver information of paths, namely volume serial number, LowPart, HighPart. 
Only `DirAcessUnix` and `DirAccessWindows` implement the `is_equivalent(a, b)` function.
`DirAcessUnix::is_equivalent(a, b)` is **NOT** tested yet, though it seems to work as it returns string comparison result if it failed checking file system ID.

Marked the PR as draft, before a Unix test or approval.

And though the `DirAccessWindows::is_equivalent(a, b)` formats both the given path arguements with `fix_path(p_path)` function, the calling of `simplify_path()` should remain as they should be standardized.
</p>
</details> 

