### PR TITLE
Fix SDFGI ignoring visual layers of geometry instances

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3179,7 +3179,7 @@ void RendererSceneCull::_scene_cull(CullData &cull_data, InstanceCullResult &cul
 						}
 					}
 				} else if ((1 << base_type) & RSE::INSTANCE_GEOMETRY_MASK) {
-					if (idata.flags & InstanceData::FLAG_USES_BAKED_LIGHT) {
+					if ((idata.flags & InstanceData::FLAG_USES_BAKED_LIGHT) && (cull_data.visible_layers & idata.layer_mask)) {
 						cull_result.sdfgi_region_geometry_instances[j].push_back(idata.instance_geometry);
 						mesh_visible = true;
 					}


### PR DESCRIPTION
## Description

Fixes **SDFGI** to respect visual layers (``layer_mask``) of geometry instances during culling.

## Problem

**SDFGI** ignores visual layers of `VisualInstance3D` nodes and the currently active camera. If a visual instance is not visible to the camera due to incompatible layers (e.g., setting layers to `0`), it will still be used by **SDFGI** and its contribution remains visible in the **SDFGI cascades debug view**.

## Related Issues

Fixes #114432
