### PR TITLE
Fix parameter precision for `ease`/`step_decimals` function

### DIFF
--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -361,11 +361,11 @@ bool VariantUtilityFunctions::is_finite(double x) {
 	return Math::is_finite(x);
 }
 
-double VariantUtilityFunctions::ease(float x, float curve) {
+double VariantUtilityFunctions::ease(double x, double curve) {
 	return Math::ease(x, curve);
 }
 
-int VariantUtilityFunctions::step_decimals(float step) {
+int VariantUtilityFunctions::step_decimals(double step) {
 	return Math::step_decimals(step);
 }
 

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -74,8 +74,8 @@ struct VariantUtilityFunctions {
 	static bool is_equal_approx(double x, double y);
 	static bool is_zero_approx(double x);
 	static bool is_finite(double x);
-	static double ease(float x, float curve);
-	static int step_decimals(float step);
+	static double ease(double x, double curve);
+	static int step_decimals(double step);
 	static Variant snapped(const Variant &x, const Variant &step, Callable::CallError &r_error);
 	static double snappedf(double x, double step);
 	static int64_t snappedi(double x, int64_t step);


### PR DESCRIPTION
I think this will allow these functions to produce more accurate results in GDScript. (Godot uses double anywhere).