### PR TITLE
Forbid alternative operators via clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ Checks:
   - modernize-use-nullptr
   - readability-braces-around-statements
   - readability-redundant-member-init
+  - readability-operators-representation
 HeaderFileExtensions: ["", h, hh, hpp, hxx, inc, glsl]
 ImplementationFileExtensions: [c, cc, cpp, cxx, m, mm, java]
 HeaderFilterRegex: (core|doc|drivers|editor|main|modules|platform|scene|servers|tests)/
@@ -20,3 +21,5 @@ CheckOptions:
   modernize-use-bool-literals.IgnoreMacros: false
   modernize-use-default-member-init.IgnoreMacros: false
   modernize-use-default-member-init.UseAssignment: true
+  readability-operators-representation.BinaryOperators: "&&;&=;&;|;~;!;!=;||;|=;^;^="
+  readability-operators-representation.OverloadedOperators: "&&;&=;&;|;~;!;!=;||;|=;^;^="


### PR DESCRIPTION
I stumbled upon some usages of `not` instead of `!` over in https://github.com/godotengine/godot/pull/101091 and thought that this might be something we should just let CI handle.

I'm not sure if we have a policy for this, but I think it's better for readability to consistently use the "standard" operators.

Docs: https://clang.llvm.org/extra/clang-tidy/checks/readability/operators-representation.html
