### PR TITLE
a11y: Expose menu shortcuts.

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1299,6 +1299,7 @@ void PopupMenu::_notification(int p_what) {
 					DisplayServer::get_singleton()->accessibility_update_set_name(item.accessibility_item_element, item.xl_text);
 					DisplayServer::get_singleton()->accessibility_update_set_flag(item.accessibility_item_element, DisplayServer::AccessibilityFlags::FLAG_DISABLED, item.disabled);
 					DisplayServer::get_singleton()->accessibility_update_set_tooltip(item.accessibility_item_element, item.tooltip);
+					DisplayServer::get_singleton()->accessibility_update_set_shortcut(item.accessibility_item_element, _get_accel_text(item));
 
 					DisplayServer::get_singleton()->accessibility_update_set_bounds(item.accessibility_item_element, Rect2(item_ofs, Size2(display_width, h + theme_cache.v_separation)));
 
@@ -2511,6 +2512,7 @@ void PopupMenu::set_item_shortcut(int p_idx, const Ref<Shortcut> &p_shortcut, bo
 	items.write[p_idx].shortcut = p_shortcut;
 	items.write[p_idx].shortcut_is_global = p_global;
 	items.write[p_idx].dirty = true;
+	items.write[p_idx].accessibility_item_dirty = true;
 
 	if (items[p_idx].shortcut.is_valid()) {
 		_ref_shortcut(items[p_idx].shortcut);
@@ -2535,6 +2537,7 @@ void PopupMenu::set_item_shortcut(int p_idx, const Ref<Shortcut> &p_shortcut, bo
 		}
 	}
 
+	queue_accessibility_update();
 	control->queue_redraw();
 	_menu_changed();
 }


### PR DESCRIPTION
This exposes menu accelerator shortcuts to AccessKit so they're read along with their associated menu items. Unfortunately support isn't fully wired up in AccessKit yet--this just does the right thing on Godot's end for now.