### PR TITLE
Fix reflection probes using incorrect maximum roughness level

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1396,6 +1396,7 @@ void RendererSceneRenderRD::render_scene(const Ref<RenderSceneBuffers> &p_render
 			float border_size = light_storage->reflection_atlas_get_border_size(p_reflection_atlas);
 			scene_data.reflection_atlas_border_size.x = border_size;
 			scene_data.reflection_atlas_border_size.y = 1.0f - border_size * 2.0;
+			scene_data.probe_max_roughness_lod = light_storage->reflection_atlas_get_roughness_levels(p_reflection_atlas) - 1;
 		}
 
 		scene_data.time = time;

--- a/servers/rendering/renderer_rd/shaders/scene_data_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_data_inc.glsl
@@ -81,4 +81,6 @@ struct SceneData {
 	float IBL_exposure_normalization;
 	uint camera_visible_layers;
 	float pass_alpha_multiplier;
+
+	float probe_max_roughness_lod;
 };

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -958,7 +958,7 @@ void reflection_process(uint ref_index, vec3 vertex, hvec3 ref_vec, hvec3 normal
 		hvec4 reflection;
 		half reflection_blend = max(half(0.0), blend - reflection_accum.a);
 
-		float roughness_lod = sqrt(roughness) * MAX_ROUGHNESS_LOD;
+		float roughness_lod = sqrt(roughness) * scene_data_block.data.probe_max_roughness_lod;
 		vec2 reflection_uv = vec3_to_oct_with_border(local_ref_vec, border_size);
 		reflection.rgb = hvec3(textureLod(sampler2DArray(reflection_atlas, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec3(reflection_uv, reflections.data[ref_index].index), roughness_lod).rgb) * REFLECTION_MULTIPLIER;
 		reflection.rgb *= half(reflections.data[ref_index].exposure_normalization);
@@ -983,7 +983,7 @@ void reflection_process(uint ref_index, vec3 vertex, hvec3 ref_vec, hvec3 normal
 			hvec4 ambient_out;
 			half ambient_blend = max(half(0.0), blend - ambient_accum.a);
 
-			float roughness_lod = MAX_ROUGHNESS_LOD;
+			float roughness_lod = scene_data_block.data.probe_max_roughness_lod;
 			vec2 ambient_uv = vec3_to_oct_with_border(local_amb_vec, border_size);
 			ambient_out.rgb = hvec3(textureLod(sampler2DArray(reflection_atlas, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec3(ambient_uv, reflections.data[ref_index].index), roughness_lod).rgb);
 			ambient_out.rgb *= half(reflections.data[ref_index].exposure_normalization);

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1529,6 +1529,7 @@ bool LightStorage::reflection_probe_instance_begin_render(RID p_instance, RID p_
 		uint32_t padding_pixels = (1 << (mipmaps - 1));
 		atlas->reflection_texture_size = atlas->size * 2 + padding_pixels * 2;
 		atlas->uv_border_size = float(padding_pixels) / float(atlas->reflection_texture_size);
+		atlas->roughness_levels = mipmaps;
 
 		bool use_storage = !copy_effects->get_raster_effects().has_flag(CopyEffects::RASTER_EFFECT_OCTMAP);
 		{
@@ -1562,7 +1563,7 @@ bool LightStorage::reflection_probe_instance_begin_render(RID p_instance, RID p_
 		}
 		atlas->reflections.resize(atlas->count);
 		for (int i = 0; i < atlas->count; i++) {
-			atlas->reflections.write[i].data.update_reflection_data(atlas->reflection_texture_size, mipmaps, false, atlas->reflection, i, update_always, RendererSceneRenderRD::get_singleton()->get_sky()->roughness_layers, RendererSceneRenderRD::get_singleton()->_render_buffers_get_preferred_color_format(), atlas->uv_border_size);
+			atlas->reflections.write[i].data.update_reflection_data(atlas->reflection_texture_size, mipmaps, false, atlas->reflection, i, update_always, atlas->roughness_levels, RendererSceneRenderRD::get_singleton()->_render_buffers_get_preferred_color_format(), atlas->uv_border_size);
 		}
 
 		for (int i = 0; i < 6; i++) {

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -246,6 +246,7 @@ private:
 		int count = 0;
 		int size = 0;
 		int reflection_texture_size = 0;
+		int roughness_levels = 1;
 		float uv_border_size = 0.0;
 		bool update_always = false;
 
@@ -906,6 +907,12 @@ public:
 		ReflectionAtlas *atlas = reflection_atlas_owner.get_or_null(p_ref_atlas);
 		ERR_FAIL_NULL_V(atlas, 0.0);
 		return atlas->uv_border_size;
+	}
+
+	_FORCE_INLINE_ float reflection_atlas_get_roughness_levels(RID p_ref_atlas) {
+		ReflectionAtlas *atlas = reflection_atlas_owner.get_or_null(p_ref_atlas);
+		ERR_FAIL_NULL_V(atlas, 1.0);
+		return atlas->roughness_levels;
 	}
 
 	/* REFLECTION PROBE INSTANCE */

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
@@ -146,6 +146,8 @@ void RenderSceneDataRD::update_ubo(RID p_uniform_buffer, RS::ViewportDebugDraw p
 	ubo.reflection_atlas_border_size[0] = reflection_atlas_border_size.x;
 	ubo.reflection_atlas_border_size[1] = reflection_atlas_border_size.y;
 
+	ubo.probe_max_roughness_lod = probe_max_roughness_lod;
+
 	ubo.time = time;
 
 	ubo.directional_light_count = directional_light_count;

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
@@ -84,6 +84,8 @@ public:
 	float radiance_border_size;
 	Size2 reflection_atlas_border_size;
 
+	float probe_max_roughness_lod;
+
 	float time;
 	float time_step;
 
@@ -182,6 +184,9 @@ private:
 		float IBL_exposure_normalization; // Adjusts for baked exposure.
 		uint32_t camera_visible_layers;
 		float pass_alpha_multiplier;
+
+		float probe_max_roughness_lod;
+		float padding[3];
 	};
 
 	struct UBODATA {


### PR DESCRIPTION
Currently, in both the Mobile and Forward+ renderers, the scene shader is using the same `MAX_ROUGHNESS_LOD` value for both the sky reflection and local reflection probes. This mostly works fine when the `rendering/reflections/sky_reflections/roughness_layers` setting is set to 7, but for other values it breaks when switching to real-time reflection probes (which forces 7 roughness levels for the entire atlas).

This PR makes it so that the max roughness LOD value for reflection probes is passed via the scene UBO instead, and is updated in accordance with changes to the reflection atlas.

Comparison:
`rendering/reflections/sky_reflections/roughness_layers` set to 3,
reflection probe with the update mode set to real-time,
a fully rough metallic material:

| Before | After|
|---------|------|
| ![old](https://github.com/user-attachments/assets/06e0d759-986a-4c1e-82a6-53e76b239c6c) | ![new](https://github.com/user-attachments/assets/4d5ec3a7-b234-4d0c-9931-9a039f805be6) |

TODO:
- [x] Upload an MRP

MRP:
[reflection-roughness.zip](https://github.com/user-attachments/files/24420932/reflection-roughness.zip)
