### PR TITLE
Fix switching visual shader type draws focus

### DIFF
--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -5684,7 +5684,7 @@ void VisualShaderEditor::_type_selected(int p_id) {
 	_update_nodes();
 	_update_graph();
 
-	graph->grab_focus();
+	graph->grab_focus(true);
 }
 
 void VisualShaderEditor::_custom_mode_toggled(bool p_enabled) {


### PR DESCRIPTION
Hides GraphEdit focus when clicking through vertex/fragment/light, follow-up to https://github.com/godotengine/godot/pull/110250 cc @yeldhamdev
