### PR TITLE
GLTF: Fix getting animation track path

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6379,7 +6379,9 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> p_state, AnimationPlayer *p
 		}
 		// Get the Godot node and the glTF node index for the animation track.
 		const NodePath track_path = animation->track_get_path(track_index);
-		const Node *anim_player_parent = p_animation_player->get_parent();
+		const NodePath root_node = p_animation_player->get_root_node();
+		const Node *anim_player_parent = p_animation_player->get_node_or_null(root_node);
+		ERR_CONTINUE_MSG(!anim_player_parent, "glTF: Cannot get root node for animation player: " + String(root_node));
 		const Node *animated_node = anim_player_parent->get_node_or_null(track_path);
 		ERR_CONTINUE_MSG(!animated_node, "glTF: Cannot get node for animated track using path: " + String(track_path));
 		const GLTFAnimation::Interpolation gltf_interpolation = GLTFAnimation::godot_to_gltf_interpolation(animation, track_index);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

When attempting to get the animation node via the track path in `_convert_animation()`, we previously assumed that the root node for the animation player was always the parent. While `root_node` for the AnimationPlayer defaults to `..`, i.e. the parent, if the `root_node` is set to something else, getting the animation node will fail. 

Changing getting the anim_player_parent according to the path set in `root_node` fixes the issue. 