### PR TITLE
Hide animation library properties in inspector

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -123,7 +123,7 @@ bool AnimationMixer::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 uint32_t AnimationMixer::_get_libraries_property_usage() const {
-	return PROPERTY_USAGE_DEFAULT;
+	return PROPERTY_USAGE_STORAGE;
 }
 
 void AnimationMixer::_get_property_list(List<PropertyInfo> *p_list) const {

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -902,9 +902,9 @@ void AnimationTree::_setup_animation_player() {
 // `libraries` is a dynamic property, so we can't use `_validate_property` to change it.
 uint32_t AnimationTree::_get_libraries_property_usage() const {
 	if (!animation_player.is_empty()) {
-		return PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
+		return PROPERTY_USAGE_READ_ONLY;
 	}
-	return PROPERTY_USAGE_DEFAULT;
+	return PROPERTY_USAGE_STORAGE;
 }
 
 void AnimationTree::_validate_property(PropertyInfo &p_property) const {


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot/issues/114576

The animation library should be controlled by the AnimationLibraryManager, therefore I assume it should not be displayed in the Inspector.

If UI/UX improvements were possible, adding a button like "Open AnimationLibraryManager" to the Inspector might be feasible. However, considering that this feature has not been before version 3.x and that AnimationLibraryManager has existed since 4.0, I think implementing it to that extent is unnecessary.