### PR TITLE
Add support for `Input.get_joy_info()` for web

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -130,14 +130,14 @@
 			<param index="0" name="device" type="int" />
 			<description>
 				Returns a dictionary with extra platform-specific information about the device, e.g. the raw gamepad name from the OS or the Steam Input index.
-				On Windows, Linux, and macOS, the dictionary contains the following fields:
+				On Windows, Linux, macOS, and Web the dictionary contains the following fields:
 				[code]raw_name[/code]: The name of the controller as it came from the OS, before getting renamed by the controller database.
 				[code]vendor_id[/code]: The USB vendor ID of the device.
 				[code]product_id[/code]: The USB product ID of the device.
-				[code]steam_input_index[/code]: The Steam Input gamepad index, if the device is not a Steam Input device this key won't be present.
-				On Windows, the dictionary can have an additional field:
-				[code]xinput_index[/code]: The index of the controller in the XInput system. This key won't be present for devices not handled by XInput.
-				[b]Note:[/b] The returned dictionary is always empty on Android, iOS, visionOS, and Web.
+				The dictionary can also include the following fields under selected platforms:
+				[code]steam_input_index[/code]: The Steam Input gamepad index (Windows, Linux, and macOS only). If the device is not a Steam Input device this key won't be present.
+				[code]xinput_index[/code]: The index of the controller in the XInput system (Windows only). This key won't be present for devices not handled by XInput.
+				[b]Note:[/b] The returned dictionary is always empty on Android, iOS, and visionOS.
 			</description>
 		</method>
 		<method name="get_joy_name">

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -838,21 +838,21 @@ void DisplayServerWeb::_window_blur_callback() {
 }
 
 // Gamepad
-void DisplayServerWeb::gamepad_callback(int p_index, int p_connected, const char *p_id, const char *p_guid) {
+void DisplayServerWeb::gamepad_callback(int p_index, int p_connected, const char *p_id, const char *p_guid, int p_vendor_id, int p_product_id) {
 	String id = p_id;
 	String guid = p_guid;
 
 #ifdef PROXY_TO_PTHREAD_ENABLED
 	if (!Thread::is_main_thread()) {
-		callable_mp_static(DisplayServerWeb::_gamepad_callback).call_deferred(p_index, p_connected, id, guid);
+		callable_mp_static(DisplayServerWeb::_gamepad_callback).call_deferred(p_index, p_connected, id, guid, p_vendor_id, p_product_id);
 		return;
 	}
 #endif
 
-	_gamepad_callback(p_index, p_connected, id, guid);
+	_gamepad_callback(p_index, p_connected, id, guid, p_vendor_id, p_product_id);
 }
 
-void DisplayServerWeb::_gamepad_callback(int p_index, int p_connected, const String &p_id, const String &p_guid) {
+void DisplayServerWeb::_gamepad_callback(int p_index, int p_connected, const String &p_id, const String &p_guid, int p_vendor_id, int p_product_id) {
 	if (p_connected) {
 		DisplayServerWeb::get_singleton()->gamepad_count += 1;
 	} else {
@@ -861,7 +861,12 @@ void DisplayServerWeb::_gamepad_callback(int p_index, int p_connected, const Str
 
 	Input *input = Input::get_singleton();
 	if (p_connected) {
-		input->joy_connection_changed(p_index, true, p_id, p_guid);
+		Dictionary joypad_info;
+		joypad_info["raw_name"] = p_id;
+		joypad_info["vendor_id"] = itos(p_vendor_id);
+		joypad_info["product_id"] = itos(p_product_id);
+
+		input->joy_connection_changed(p_index, true, p_id, p_guid, joypad_info);
 	} else {
 		input->joy_connection_changed(p_index, false, "");
 	}

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -130,8 +130,8 @@ private:
 	static void _key_callback(const String &p_key_event_code, const String &p_key_event_key, int p_pressed, int p_repeat, int p_modifiers);
 	WASM_EXPORT static void vk_input_text_callback(const char *p_text, int p_cursor);
 	static void _vk_input_text_callback(const String &p_text, int p_cursor);
-	WASM_EXPORT static void gamepad_callback(int p_index, int p_connected, const char *p_id, const char *p_guid);
-	static void _gamepad_callback(int p_index, int p_connected, const String &p_id, const String &p_guid);
+	WASM_EXPORT static void gamepad_callback(int p_index, int p_connected, const char *p_id, const char *p_guid, int p_vendor_id, int p_product_id);
+	static void _gamepad_callback(int p_index, int p_connected, const String &p_id, const String &p_guid, int p_vendor_id, int p_product_id);
 	WASM_EXPORT static void js_utterance_callback(int p_event, int64_t p_id, int p_pos);
 	static void _js_utterance_callback(int p_event, int64_t p_id, int p_pos);
 	WASM_EXPORT static void ime_callback(int p_type, const char *p_text);

--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -72,7 +72,7 @@ extern void godot_js_set_ime_cb(void (*p_input)(int p_type, const char *p_text),
 extern int godot_js_is_ime_focused();
 
 // Input gamepad
-extern void godot_js_input_gamepad_cb(void (*p_on_change)(int p_index, int p_connected, const char *p_id, const char *p_guid));
+extern void godot_js_input_gamepad_cb(void (*p_on_change)(int p_index, int p_connected, const char *p_id, const char *p_guid, int p_vendor_id, int p_product_id));
 extern int godot_js_input_gamepad_sample();
 extern int godot_js_input_gamepad_sample_count();
 extern int godot_js_input_gamepad_sample_get(int p_idx, float r_btns[16], int32_t *r_btns_num, float r_axes[10], int32_t *r_axes_num, int32_t *r_standard);

--- a/platform/web/js/libs/library_godot_input.js
+++ b/platform/web/js/libs/library_godot_input.js
@@ -232,9 +232,17 @@ const GodotInputGamepads = {
 			GodotInputGamepads.samples = [];
 			function add(pad) {
 				const guid = GodotInputGamepads.get_guid(pad);
+				const vendor_str = GodotInputGamepads.get_vendor_str(pad);
+				const product_str = GodotInputGamepads.get_product_str(pad);
+				let vendor_id = 0;
+				let product_id = 0;
+				if (vendor_str && product_str) {
+					vendor_id = parseInt(vendor_str, 16);
+					product_id = parseInt(product_str, 16);
+				}
 				const c_id = GodotRuntime.allocString(pad.id);
 				const c_guid = GodotRuntime.allocString(guid);
-				onchange(pad.index, 1, c_id, c_guid);
+				onchange(pad.index, 1, c_id, c_guid, vendor_id, product_id);
 				GodotRuntime.free(c_id);
 				GodotRuntime.free(c_guid);
 			}
@@ -257,6 +265,40 @@ const GodotInputGamepads = {
 			}, false);
 		},
 
+		get_vendor_str: function (pad) {
+			const id = pad.id;
+			// Chrom* style: NAME (Vendor: xxxx Product: xxxx).
+			const exp1 = /vendor: ([0-9a-f]{4}) product: ([0-9a-f]{4})/i;
+			// Firefox/Safari style (Safari may remove leading zeroes).
+			const exp2 = /^([0-9a-f]+)-([0-9a-f]+)-/i;
+			let vendor = '';
+			if (exp1.test(id)) {
+				const match = exp1.exec(id);
+				vendor = match[1].padStart(4, '0');
+			} else if (exp2.test(id)) {
+				const match = exp2.exec(id);
+				vendor = match[1].padStart(4, '0');
+			}
+			return vendor;
+		},
+
+		get_product_str: function (pad) {
+			const id = pad.id;
+			// Chrom* style: NAME (Vendor: xxxx Product: xxxx).
+			const exp1 = /vendor: ([0-9a-f]{4}) product: ([0-9a-f]{4})/i;
+			// Firefox/Safari style (Safari may remove leading zeroes).
+			const exp2 = /^([0-9a-f]+)-([0-9a-f]+)-/i;
+			let product = '';
+			if (exp1.test(id)) {
+				const match = exp1.exec(id);
+				product = match[2].padStart(4, '0');
+			} else if (exp2.test(id)) {
+				const match = exp2.exec(id);
+				product = match[2].padStart(4, '0');
+			}
+			return product;
+		},
+
 		get_guid: function (pad) {
 			if (pad.mapping) {
 				return pad.mapping;
@@ -276,22 +318,9 @@ const GodotInputGamepads = {
 				os = 'Windows';
 			}
 
-			const id = pad.id;
-			// Chrom* style: NAME (Vendor: xxxx Product: xxxx).
-			const exp1 = /vendor: ([0-9a-f]{4}) product: ([0-9a-f]{4})/i;
-			// Firefox/Safari style (Safari may remove leading zeroes).
-			const exp2 = /^([0-9a-f]+)-([0-9a-f]+)-/i;
-			let vendor = '';
-			let product = '';
-			if (exp1.test(id)) {
-				const match = exp1.exec(id);
-				vendor = match[1].padStart(4, '0');
-				product = match[2].padStart(4, '0');
-			} else if (exp2.test(id)) {
-				const match = exp2.exec(id);
-				vendor = match[1].padStart(4, '0');
-				product = match[2].padStart(4, '0');
-			}
+			const vendor = GodotInputGamepads.get_vendor_str(pad);
+			const product = GodotInputGamepads.get_product_str(pad);
+
 			if (!vendor || !product) {
 				return `${os}Unknown`;
 			}


### PR DESCRIPTION
This PR doesn't close any issues, but it will serve as a base for the (partial) web support for https://github.com/godotengine/godot/pull/112680

This PR adds support for `Input.get_joy_info()` for the web platform, and now combined with other PRs like https://github.com/godotengine/godot/pull/114338 and https://github.com/godotengine/godot/pull/114316, `Input.get_joy_info()` will be supported for all platforms Godot supports!