### PR TITLE
Fix documentation for arrays in shaders not showing in inspector 

### DIFF
--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -183,7 +183,7 @@ void Shader::get_shader_uniform_list(List<PropertyInfo> *p_params, bool p_get_gr
 			if (generate_doc) {
 				DocData::PropertyDoc prop_doc;
 				prop_doc.name = "shader_parameter/" + pi.name;
-				const RegEx pattern("/\\*\\*\\s([^*]|[\\r\\n]|(\\*+([^*/]|[\\r\\n])))*\\*+/\\s*uniform\\s+\\w+\\s+" + pi.name + "(?=[\\s:;=])");
+				const RegEx pattern("/\\*\\*\\s([^*]|[\\r\\n]|(\\*+([^*/]|[\\r\\n])))*\\*+/\\s*uniform\\s+\\w+\\s+" + pi.name + "(?=[\\s:;=\\[])");
 				Ref<RegExMatch> pattern_ref = pattern.search(code);
 				if (pattern_ref.is_valid()) {
 					RegExMatch *match = pattern_ref.ptr();


### PR DESCRIPTION
Fixes #114573

This fix addresses the issue where shader documentation comments were not being extracted for array uniforms. The regex pattern used to find uniform declarations with documentation was only looking for whitespace, colons, semicolons, or equals signs after the uniform name, but array uniforms have square brackets '[' after the name. By adding '\[' to the character class in the lookahead assertion, the pattern now correctly matches both regular uniforms and array uniforms.