### PR TITLE
Fix crash when selecting "Unwrap UV2 for Lightmap/AO" after undo

### DIFF
--- a/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
@@ -550,11 +550,8 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 				ur->create_action(TTR("Unwrap UV2"));
 
 				ur->add_do_method(node, "set_mesh", unwrapped_mesh);
-				ur->add_do_reference(node);
-				ur->add_do_reference(array_mesh.ptr());
-
+				ur->add_do_reference(unwrapped_mesh.ptr());
 				ur->add_undo_method(node, "set_mesh", array_mesh);
-				ur->add_undo_reference(unwrapped_mesh.ptr());
 
 				ur->commit_action();
 			}


### PR DESCRIPTION
## Description

Removes incorrect `add_do_reference` and `add_undo_reference` calls in the UV2 unwrap action for ArrayMesh.

## Problem

Using "Unwrap UV2 for Lightmap/AO" a second time after undoing crashes Godot with signal 11 (SIGSEGV).

## Related Issues

Fixes #114428

