### PR TITLE
LSP: When supported use snippet insert mode to add closing braces

### DIFF
--- a/modules/gdscript/doc_classes/GDScriptLanguageProtocol.xml
+++ b/modules/gdscript/doc_classes/GDScriptLanguageProtocol.xml
@@ -23,7 +23,7 @@
 			</description>
 		</method>
 		<method name="initialize" deprecated="Accessing LSP endpoints directly might lead to unwanted side effects. Connect to the server via TCP, like a regular language server client.">
-			<return type="Dictionary" />
+			<return type="Variant" />
 			<param index="0" name="params" type="Dictionary" />
 			<description>
 			</description>

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -192,7 +192,26 @@ void GDScriptLanguageProtocol::_bind_methods() {
 #endif // !DISABLE_DEPRECATED
 }
 
-Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
+template <typename T>
+Variant get_deep(Variant p_dict, Variant p_default, T p_key) {
+	if (p_dict.get_type() != Variant::DICTIONARY) {
+		return p_default;
+	}
+	return p_dict.operator Dictionary().get(p_key, p_default);
+}
+
+template <typename T1, typename... T2>
+Variant get_deep(Variant p_dict, Variant p_default, T1 p_key1, T2... p_key2) {
+	if (p_dict.get_type() != Variant::DICTIONARY || !p_dict.operator Dictionary().has(p_key1)) {
+		return p_default;
+	}
+
+	return get_deep(p_dict.operator Dictionary()[p_key1], p_default, p_key2...);
+}
+
+Variant GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
+	LSP_CLIENT_V(Variant());
+
 	LSP::InitializeResult ret;
 
 	{
@@ -251,6 +270,11 @@ Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 		workspace->initialize();
 		_initialized = true;
 	}
+
+	// Handle client capabilities.
+	Dictionary capabilities = p_params["capabilities"];
+	client->behavior.use_snippets_for_brace_completion = get_deep(capabilities, false,
+			"textDocument", "completion", "completionItem", "snippetSupport");
 
 	return ret.to_json();
 }
@@ -509,6 +533,81 @@ void GDScriptLanguageProtocol::lsp_did_close(const Dictionary &p_params) {
 	ERR_FAIL_COND_MSG(!was_opened, "LSP: Client is closing file without opening it.");
 
 	scene_cache.unload(path);
+}
+
+Array GDScriptLanguageProtocol::lsp_completion(const Dictionary &p_params) {
+	Array arr;
+	LSP_CLIENT_V(arr);
+
+	LSP::CompletionParams params;
+	params.load(p_params);
+	Dictionary request_data = params.to_json();
+
+	List<ScriptLanguage::CodeCompletionOption> options;
+	get_workspace()->completion(params, &options);
+
+	if (!options.is_empty()) {
+		int i = 0;
+		arr.resize(options.size());
+
+		for (const ScriptLanguage::CodeCompletionOption &option : options) {
+			LSP::CompletionItem item;
+			item.label = option.display;
+			item.data = request_data;
+			item.insertText = option.insert_text;
+
+			// LSP clients won't autoclose brackets.
+			if (client->behavior.use_snippets_for_brace_completion) {
+				// Use snippet insert mode to insert closing brace as well.
+				if (item.insertText.ends_with("(")) {
+					item.insertText += "$1)";
+					item.insertTextFormat = LSP::InsertTextFormat::Snippet;
+				}
+			} else {
+				// Trim braces.
+				item.insertText = item.insertText.trim_suffix("(");
+			}
+
+			switch (option.kind) {
+				case ScriptLanguage::CODE_COMPLETION_KIND_ENUM:
+					item.kind = LSP::CompletionItemKind::Enum;
+					break;
+				case ScriptLanguage::CODE_COMPLETION_KIND_CLASS:
+					item.kind = LSP::CompletionItemKind::Class;
+					break;
+				case ScriptLanguage::CODE_COMPLETION_KIND_MEMBER:
+					item.kind = LSP::CompletionItemKind::Property;
+					break;
+				case ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION:
+					item.kind = LSP::CompletionItemKind::Method;
+					break;
+				case ScriptLanguage::CODE_COMPLETION_KIND_SIGNAL:
+					item.kind = LSP::CompletionItemKind::Event;
+					break;
+				case ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT:
+					item.kind = LSP::CompletionItemKind::Constant;
+					break;
+				case ScriptLanguage::CODE_COMPLETION_KIND_VARIABLE:
+					item.kind = LSP::CompletionItemKind::Variable;
+					break;
+				case ScriptLanguage::CODE_COMPLETION_KIND_FILE_PATH:
+					item.kind = LSP::CompletionItemKind::File;
+					break;
+				case ScriptLanguage::CODE_COMPLETION_KIND_NODE_PATH:
+					item.kind = LSP::CompletionItemKind::Snippet;
+					break;
+				case ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT:
+					item.kind = LSP::CompletionItemKind::Text;
+					break;
+				default: {
+				}
+			}
+
+			arr[i] = item.to_json();
+			i++;
+		}
+	}
+	return arr;
 }
 
 void GDScriptLanguageProtocol::resolve_related_symbols(const LSP::TextDocumentPositionParams &p_doc_pos, List<const LSP::DocumentSymbol *> &r_list) {

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -49,6 +49,12 @@ class GDScriptLanguageProtocol : public JSONRPC {
 
 	friend class TestGDScriptLanguageProtocolInitializer;
 
+public:
+	struct ClientBehavior {
+		/** If `true` use snippet insert mode to position the cursor between braces of completion options. If `false` strip braces from completion options since we can't provide good UX for them. */
+		bool use_snippets_for_brace_completion = false;
+	};
+
 private:
 	struct LSPeer : RefCounted {
 		Ref<StreamPeerTCP> connection;
@@ -63,6 +69,12 @@ private:
 
 		Error handle_data();
 		Error send_data();
+
+		/**
+		 * Represents how the server should behave towards this client in certain situations.
+		 * This gets derived from client capabilities so the configured behavior is guaranteed to be supported by the client.
+		 */
+		ClientBehavior behavior;
 
 		/**
 		 * Tracks all files that the client claimed, however for files deemed not relevant
@@ -112,7 +124,7 @@ private:
 protected:
 	static void _bind_methods();
 
-	Dictionary initialize(const Dictionary &p_params);
+	Variant initialize(const Dictionary &p_params);
 	void initialized(const Variant &p_params);
 
 public:
@@ -137,6 +149,9 @@ public:
 	void lsp_did_open(const Dictionary &p_params);
 	void lsp_did_change(const Dictionary &p_params);
 	void lsp_did_close(const Dictionary &p_params);
+
+	// Completion
+	Array lsp_completion(const Dictionary &p_params);
 
 	/**
 	 * Returns a list of symbols that might be related to the document position.

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -175,65 +175,7 @@ Array GDScriptTextDocument::documentHighlight(const Dictionary &p_params) {
 }
 
 Array GDScriptTextDocument::completion(const Dictionary &p_params) {
-	Array arr;
-
-	LSP::CompletionParams params;
-	params.load(p_params);
-	Dictionary request_data = params.to_json();
-
-	List<ScriptLanguage::CodeCompletionOption> options;
-	GDScriptLanguageProtocol::get_singleton()->get_workspace()->completion(params, &options);
-
-	if (!options.is_empty()) {
-		int i = 0;
-		arr.resize(options.size());
-
-		for (const ScriptLanguage::CodeCompletionOption &option : options) {
-			LSP::CompletionItem item;
-			item.label = option.display;
-			item.data = request_data;
-			item.insertText = option.insert_text;
-
-			switch (option.kind) {
-				case ScriptLanguage::CODE_COMPLETION_KIND_ENUM:
-					item.kind = LSP::CompletionItemKind::Enum;
-					break;
-				case ScriptLanguage::CODE_COMPLETION_KIND_CLASS:
-					item.kind = LSP::CompletionItemKind::Class;
-					break;
-				case ScriptLanguage::CODE_COMPLETION_KIND_MEMBER:
-					item.kind = LSP::CompletionItemKind::Property;
-					break;
-				case ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION:
-					item.kind = LSP::CompletionItemKind::Method;
-					break;
-				case ScriptLanguage::CODE_COMPLETION_KIND_SIGNAL:
-					item.kind = LSP::CompletionItemKind::Event;
-					break;
-				case ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT:
-					item.kind = LSP::CompletionItemKind::Constant;
-					break;
-				case ScriptLanguage::CODE_COMPLETION_KIND_VARIABLE:
-					item.kind = LSP::CompletionItemKind::Variable;
-					break;
-				case ScriptLanguage::CODE_COMPLETION_KIND_FILE_PATH:
-					item.kind = LSP::CompletionItemKind::File;
-					break;
-				case ScriptLanguage::CODE_COMPLETION_KIND_NODE_PATH:
-					item.kind = LSP::CompletionItemKind::Snippet;
-					break;
-				case ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT:
-					item.kind = LSP::CompletionItemKind::Text;
-					break;
-				default: {
-				}
-			}
-
-			arr[i] = item.to_json();
-			i++;
-		}
-	}
-	return arr;
+	return GDScriptLanguageProtocol::get_singleton()->lsp_completion(p_params);
 }
 
 Dictionary GDScriptTextDocument::rename(const Dictionary &p_params) {

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -1076,6 +1076,9 @@ struct CompletionItem {
 		if (!insertText.is_empty()) {
 			dict["insertText"] = insertText;
 		}
+		if (insertTextFormat) {
+			dict["insertTextFormat"] = insertTextFormat;
+		}
 		if (resolved) {
 			if (!detail.is_empty()) {
 				dict["detail"] = detail;
@@ -1135,6 +1138,7 @@ struct CompletionItem {
 		if (p_dict.has("insertText")) {
 			insertText = p_dict["insertText"];
 		}
+		insertTextFormat = p_dict.get("insertTextFormat", 0);
 		if (p_dict.has("data")) {
 			data = p_dict["data"];
 		}


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot/pull/96726 -> same idea but this time with client capability safeguards

Fixes https://github.com/godotengine/godot/issues/84549
Fixes https://github.com/godotengine/godot-vscode-plugin/issues/997

LSP clients don't auto-close braces from insert texts (seems like unspecified territory). We can instead close them in the server and use the snippet insert mode to place the caret between the braces:

[Screencast From 2026-01-04 16-15-13.webm](https://github.com/user-attachments/assets/ac68a752-227c-4152-99ce-74a476b836d8)

If the client does not support snippet mode we fall back to this behaviour:

[Screencast From 2026-01-04 16-13-45.webm](https://github.com/user-attachments/assets/be128e48-c111-46e5-ad17-6d08405c8364)

---

Implementation wise I moved the endpoint implementation from `GDScriptTextDocument` to `GDScriptLanguageProtocol` because access to the client is more convenient from there and this whole structure is something we should flatten out eventually anyway.

The implementation also contains a utility template `get_deep` to safely get a deeply nested value from a dictionary with the necessary safeguards. If we already have something like this somewhere feel free to tell me!



