### PR TITLE
Fix animation editor sometimes not processing on scene change

### DIFF
--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -70,7 +70,9 @@ void AnimationPlayerEditor::_find_player() {
 	TypedArray<Node> players = edited_scene->find_children("", "AnimationPlayer");
 
 	if (players.size() == 1) {
+		// Replicating EditorNode::_plugin_over_edit to ensure an identical setup as when selecting manually.
 		plugin->edit(players.front());
+		plugin->make_visible(true);
 	}
 }
 


### PR DESCRIPTION
When implementing https://github.com/godotengine/godot/pull/103416, I missed the case that if the AnimationPlayer was not selected when swapping back to the scene, then `make_visible(true)` would not be called on the `AnimationPlayerEditorPlugin`, meaning that `set_process(true)` would not be called on `AnimationPlayerEditor`, which meant the UI would not update. This fixes the issue by calling `plugin->make_visible(true)` just after the call to `edit`, which ensures the state is identical as when we select the node in the Scene Tree panel (see [`EditorNode::_plugin_over_edit`](https://github.com/godotengine/godot/blob/4036e90a4349740cb86e6245b9e11f38bb436897/editor/editor_node.cpp#L1195-L1205)).

I also tested and considered just calling `set_process(true)`, but this approach avoids any other potential inconsistencies in how the editor is activated, so I thought it was the more reliable option. Open to thoughts/comments though.

Fixes https://github.com/godotengine/godot/issues/114443