### PR TITLE
Fix undo/redo for adding scene tiles

### DIFF
--- a/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.h
+++ b/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.h
@@ -130,6 +130,7 @@ private:
 	void _update_tile_inspector();
 	void _update_scenes_list();
 	void _update_action_buttons();
+	void _update_all();
 
 	void _drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 	bool _can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;


### PR DESCRIPTION
To reproduce:
- Create a TileMapLayer
- Create TileSet
- In TileSet tab add a Scene Collection source
- Add a scene (an be by drag and drop)
- Undo
- The scene is not removed from list on undo