### PR TITLE
Fit simple collision shapes to imported meshes automatically

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -242,6 +242,11 @@ void EditorScenePostImportPlugin::_bind_methods() {
 
 /////////////////////////////////////////////////////////
 
+void ResourceImporterScene::_fit_primitive_to_mesh() {
+	SceneImportSettingsDialog::get_singleton()->request_generate_collider();
+	SceneImportSettingsDialog::get_singleton()->regenerate_collisions(SceneImportSettingsDialog::get_singleton()->get_selected_id(), true);
+}
+
 const String ResourceImporterScene::material_extension[3] = { ".tres", ".res", ".material" };
 
 String ResourceImporterScene::get_importer_name() const {
@@ -1678,9 +1683,10 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 						shapes = collision_map[m];
 					} else {
 						shapes = get_collision_shapes(
-								m,
+								m->get_mesh(),
 								node_settings,
-								p_applied_root_scale);
+								p_applied_root_scale,
+								false);
 					}
 
 					if (shapes.size()) {
@@ -2165,6 +2171,7 @@ void ResourceImporterScene::get_internal_import_options(InternalImportCategory p
 			r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "primitive/radius", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT), 1.0));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::VECTOR3, "primitive/position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT), Vector3()));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::VECTOR3, "primitive/rotation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT), Vector3()));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::CALLABLE, "primitive/fit_to_mesh", PROPERTY_HINT_TOOL_BUTTON, "Fit To Mesh,KeepAspect", PROPERTY_USAGE_EDITOR), _fit_mesh_callable));
 
 			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "generate/occluder", PROPERTY_HINT_ENUM, "Disabled,Mesh + Occluder,Occluder Only", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), 0));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "occluder/simplification_distance", PROPERTY_HINT_RANGE, "0.0,2.0,0.01", PROPERTY_USAGE_DEFAULT), 0.1f));
@@ -2295,6 +2302,13 @@ bool ResourceImporterScene::get_internal_option_visibility(InternalImportCategor
 				}
 
 				return false;
+			}
+
+			if (p_option == "primitive/fit_to_mesh") {
+				const ShapeType physics_shape = (ShapeType)p_options["physics/shape_type"].operator int();
+				return generate_physics &&
+						physics_shape >= SHAPE_TYPE_BOX &&
+						physics_shape < SHAPE_TYPE_AUTOMATIC;
 			}
 
 			if (p_option == "primitive/position" || p_option == "primitive/rotation") {
@@ -3380,6 +3394,7 @@ void ResourceImporterScene::show_advanced_options(const String &p_path) {
 
 ResourceImporterScene::ResourceImporterScene(const String &p_scene_import_type) {
 	_scene_import_type = p_scene_import_type;
+	_fit_mesh_callable = callable_mp(this, &ResourceImporterScene::_fit_primitive_to_mesh);
 }
 
 void ResourceImporterScene::add_scene_importer(Ref<EditorSceneFormatImporter> p_importer, bool p_first_priority) {

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -573,96 +573,14 @@ void SceneImportSettingsDialog::_update_view_gizmos() {
 		open_settings(base_path);
 		return;
 	}
-	for (const KeyValue<String, NodeData> &e : node_map) {
+	for (KeyValue<String, NodeData> &e : node_map) {
 		// Skip import nodes that aren't MeshInstance3D.
 		const MeshInstance3D *mesh_node = Object::cast_to<MeshInstance3D>(e.value.node);
 		if (mesh_node == nullptr || mesh_node->get_mesh().is_null()) {
 			continue;
 		}
-
-		// Determine if the mesh collider should be visible.
-		bool show_collider_view = false;
-		if (e.value.settings.has(SNAME("generate/physics"))) {
-			show_collider_view = e.value.settings[SNAME("generate/physics")];
-		}
-
-		// Get the collider_view MeshInstance3D.
-		TypedArray<Node> descendants = mesh_node->find_children("collider_view", "MeshInstance3D");
-		CRASH_COND_MSG(descendants.is_empty(), "This is unreachable, since the collider view is always created even when the collision is not used! If this is triggered there is a bug on the function `_fill_scene`.");
-		MeshInstance3D *collider_view = Object::cast_to<MeshInstance3D>(descendants[0].operator Object *());
-
-		// Regenerate the physics collider for this MeshInstance3D if either:
-		// - A regeneration is requested for the selected import node.
-		// - The collider is being made visible.
-		if ((generate_collider && e.key == selected_id) || (show_collider_view && !collider_view->is_visible())) {
-			// This collider_view doesn't have a mesh so we need to generate a new one.
-			Ref<ImporterMesh> mesh;
-			mesh.instantiate();
-			// ResourceImporterScene::get_collision_shapes() expects ImporterMesh, not Mesh.
-			// TODO: Duplicate code with EditorSceneFormatImporterESCN::import_scene()
-			// Consider making a utility function to convert from Mesh to ImporterMesh.
-			Ref<Mesh> mesh_3d_mesh = mesh_node->get_mesh();
-			Ref<ArrayMesh> array_mesh_3d_mesh = mesh_3d_mesh;
-			if (array_mesh_3d_mesh.is_valid()) {
-				// For the MeshInstance3D nodes, we need to convert the ArrayMesh to an ImporterMesh specially.
-				mesh->set_name(array_mesh_3d_mesh->get_name());
-				for (int32_t blend_i = 0; blend_i < array_mesh_3d_mesh->get_blend_shape_count(); blend_i++) {
-					mesh->add_blend_shape(array_mesh_3d_mesh->get_blend_shape_name(blend_i));
-				}
-				for (int32_t surface_i = 0; surface_i < array_mesh_3d_mesh->get_surface_count(); surface_i++) {
-					mesh->add_surface(array_mesh_3d_mesh->surface_get_primitive_type(surface_i),
-							array_mesh_3d_mesh->surface_get_arrays(surface_i),
-							array_mesh_3d_mesh->surface_get_blend_shape_arrays(surface_i),
-							array_mesh_3d_mesh->surface_get_lods(surface_i),
-							array_mesh_3d_mesh->surface_get_material(surface_i),
-							array_mesh_3d_mesh->surface_get_name(surface_i),
-							array_mesh_3d_mesh->surface_get_format(surface_i));
-				}
-				mesh->set_blend_shape_mode(array_mesh_3d_mesh->get_blend_shape_mode());
-			} else if (mesh_3d_mesh.is_valid()) {
-				// For the MeshInstance3D nodes, we need to convert the Mesh to an ImporterMesh specially.
-				mesh->set_name(mesh_3d_mesh->get_name());
-				for (int32_t surface_i = 0; surface_i < mesh_3d_mesh->get_surface_count(); surface_i++) {
-					mesh->add_surface(mesh_3d_mesh->surface_get_primitive_type(surface_i),
-							mesh_3d_mesh->surface_get_arrays(surface_i),
-							Array(),
-							mesh_3d_mesh->surface_get_lods(surface_i),
-							mesh_3d_mesh->surface_get_material(surface_i),
-							mesh_3d_mesh->surface_get_material(surface_i).is_valid() ? mesh_3d_mesh->surface_get_material(surface_i)->get_name() : String(),
-							mesh_3d_mesh->surface_get_format(surface_i));
-				}
-			}
-
-			// Generate the mesh collider.
-			Vector<Ref<Shape3D>> shapes = ResourceImporterScene::get_collision_shapes(mesh, e.value.settings, 1.0);
-			const Transform3D transform = ResourceImporterScene::get_collision_shapes_transform(e.value.settings);
-
-			Ref<ArrayMesh> collider_view_mesh;
-			collider_view_mesh.instantiate();
-			for (Ref<Shape3D> shape : shapes) {
-				Ref<ArrayMesh> debug_shape_mesh;
-				if (shape.is_valid()) {
-					debug_shape_mesh = shape->get_debug_mesh();
-				}
-				if (debug_shape_mesh.is_valid()) {
-					collider_view_mesh->add_surface_from_arrays(
-							debug_shape_mesh->surface_get_primitive_type(0),
-							debug_shape_mesh->surface_get_arrays(0));
-
-					collider_view_mesh->surface_set_material(
-							collider_view_mesh->get_surface_count() - 1,
-							collider_mat);
-				}
-			}
-
-			collider_view->set_mesh(collider_view_mesh);
-			collider_view->set_transform(transform);
-		}
-
-		// Set the collider visibility.
-		collider_view->set_visible(show_collider_view);
+		regenerate_collisions(e.key);
 	}
-
 	generate_collider = false;
 }
 
@@ -845,6 +763,96 @@ Node *SceneImportSettingsDialog::get_selected_node() {
 		return nullptr;
 	}
 	return node_map[selected_id].node;
+}
+
+const String &SceneImportSettingsDialog::get_selected_id() const {
+	return selected_id;
+}
+
+void SceneImportSettingsDialog::regenerate_collisions(const String &p_node_id, bool p_fit_to_mesh) {
+	MeshInstance3D *mesh_node = cast_to<MeshInstance3D>(node_map.get(p_node_id).node);
+	if (!mesh_node || !node_map.has(p_node_id)) {
+		return;
+	}
+
+	TypedArray<Node> descendants = mesh_node->find_children("collider_view", "MeshInstance3D");
+	CRASH_COND_MSG(descendants.is_empty(), "This is unreachable, since the collider view is always created even when the collision is not used! If this is triggered there is a bug on the function `_fill_scene`.");
+	MeshInstance3D *collider_view = Object::cast_to<MeshInstance3D>(descendants[0].operator Object *());
+
+	// Determine if the mesh collider should be visible.
+	bool show_collider_view = false;
+	if (node_map[p_node_id].settings.has(SNAME("generate/physics"))) {
+		show_collider_view = node_map[p_node_id].settings[SNAME("generate/physics")];
+	}
+
+	// Regenerate the physics collider for this MeshInstance3D if either:
+	// - A regeneration is requested for the selected import node.
+	// - The collider is being made visible.
+	if ((generate_collider && get_selected_node() == mesh_node) || (show_collider_view && !collider_view->is_visible())) {
+		// This collider_view doesn't have a mesh so we need to generate a new one.
+		Ref<ImporterMesh> mesh;
+		mesh.instantiate();
+		// ResourceImporterScene::get_collision_shapes() expects ImporterMesh, not Mesh.
+		// TODO: Duplicate code with EditorSceneFormatImporterESCN::import_scene()
+		// Consider making a utility function to convert from Mesh to ImporterMesh.
+		Ref<Mesh> mesh_3d_mesh = mesh_node->get_mesh();
+		Ref<ArrayMesh> array_mesh_3d_mesh = mesh_3d_mesh;
+		if (array_mesh_3d_mesh.is_valid()) {
+			// For the MeshInstance3D nodes, we need to convert the ArrayMesh to an ImporterMesh specially.
+			mesh->set_name(array_mesh_3d_mesh->get_name());
+			for (int32_t blend_i = 0; blend_i < array_mesh_3d_mesh->get_blend_shape_count(); blend_i++) {
+				mesh->add_blend_shape(array_mesh_3d_mesh->get_blend_shape_name(blend_i));
+			}
+			for (int32_t surface_i = 0; surface_i < array_mesh_3d_mesh->get_surface_count(); surface_i++) {
+				mesh->add_surface(array_mesh_3d_mesh->surface_get_primitive_type(surface_i),
+						array_mesh_3d_mesh->surface_get_arrays(surface_i),
+						array_mesh_3d_mesh->surface_get_blend_shape_arrays(surface_i),
+						array_mesh_3d_mesh->surface_get_lods(surface_i),
+						array_mesh_3d_mesh->surface_get_material(surface_i),
+						array_mesh_3d_mesh->surface_get_name(surface_i),
+						array_mesh_3d_mesh->surface_get_format(surface_i));
+			}
+			mesh->set_blend_shape_mode(array_mesh_3d_mesh->get_blend_shape_mode());
+		} else if (mesh_3d_mesh.is_valid()) {
+			// For the MeshInstance3D nodes, we need to convert the Mesh to an ImporterMesh specially.
+			mesh->set_name(mesh_3d_mesh->get_name());
+			for (int32_t surface_i = 0; surface_i < mesh_3d_mesh->get_surface_count(); surface_i++) {
+				mesh->add_surface(mesh_3d_mesh->surface_get_primitive_type(surface_i),
+						mesh_3d_mesh->surface_get_arrays(surface_i),
+						Array(),
+						mesh_3d_mesh->surface_get_lods(surface_i),
+						mesh_3d_mesh->surface_get_material(surface_i),
+						mesh_3d_mesh->surface_get_material(surface_i).is_valid() ? mesh_3d_mesh->surface_get_material(surface_i)->get_name() : String(),
+						mesh_3d_mesh->surface_get_format(surface_i));
+			}
+		}
+		// Generate the mesh collider.
+		Vector<Ref<Shape3D>> shapes = ResourceImporterScene::get_collision_shapes(mesh_node->get_mesh(), node_map[p_node_id].settings, 1.0, p_fit_to_mesh);
+		const Transform3D transform = ResourceImporterScene::get_collision_shapes_transform(node_map[p_node_id].settings);
+
+		Ref<ArrayMesh> collider_view_mesh;
+		collider_view_mesh.instantiate();
+		for (Ref<Shape3D> shape : shapes) {
+			Ref<ArrayMesh> debug_shape_mesh;
+			if (shape.is_valid()) {
+				debug_shape_mesh = shape->get_debug_mesh();
+			}
+			if (debug_shape_mesh.is_valid()) {
+				collider_view_mesh->add_surface_from_arrays(
+						debug_shape_mesh->surface_get_primitive_type(0),
+						debug_shape_mesh->surface_get_arrays(0));
+
+				collider_view_mesh->surface_set_material(
+						collider_view_mesh->get_surface_count() - 1,
+						collider_mat);
+			}
+		}
+		collider_view->set_mesh(collider_view_mesh);
+		collider_view->set_transform(transform);
+	}
+
+	// Set the collider visibility.
+	collider_view->set_visible(show_collider_view);
 }
 
 void SceneImportSettingsDialog::_select(Tree *p_from, const String &p_type, const String &p_id) {

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -770,7 +770,7 @@ const String &SceneImportSettingsDialog::get_selected_id() const {
 }
 
 void SceneImportSettingsDialog::regenerate_collisions(const String &p_node_id, bool p_fit_to_mesh) {
-	MeshInstance3D *mesh_node = cast_to<MeshInstance3D>(node_map.get(p_node_id).node);
+	MeshInstance3D *mesh_node = Object::cast_to<MeshInstance3D>(node_map.get(p_node_id).node);
 	if (!mesh_node || !node_map.has(p_node_id)) {
 		return;
 	}

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -246,10 +246,12 @@ protected:
 public:
 	ResourceImporterScene *get_resource_importer_scene() const { return _resource_importer_scene; }
 	void request_generate_collider();
+	void regenerate_collisions(const String &p_node_id, bool p_fit_to_mesh = false);
 	void update_view();
 	void open_settings(const String &p_path, const String &p_scene_import_type = "PackedScene");
 	static SceneImportSettingsDialog *get_singleton();
 	Node *get_selected_node();
+	const String &get_selected_id() const;
 	SceneImportSettingsDialog();
 	~SceneImportSettingsDialog();
 };

--- a/editor/scene/3d/mesh_instance_3d_editor_plugin.h
+++ b/editor/scene/3d/mesh_instance_3d_editor_plugin.h
@@ -36,8 +36,12 @@
 
 class AcceptDialog;
 class AspectRatioContainer;
+class BoxShape3D;
+class CapsuleShape3D;
 class ConfirmationDialog;
+class CylinderShape3D;
 class MenuButton;
+class SphereShape3D;
 class SpinBox;
 
 class MeshInstance3DEditor : public Control {
@@ -68,13 +72,6 @@ class MeshInstance3DEditor : public Control {
 		SHAPE_TYPE_CYLINDER,
 		SHAPE_TYPE_SPHERE,
 		SHAPE_TYPE_PRIMITIVE,
-	};
-
-	enum ShapeAxis {
-		SHAPE_AXIS_X,
-		SHAPE_AXIS_Y,
-		SHAPE_AXIS_Z,
-		SHAPE_AXIS_LONGEST,
 	};
 
 	MeshInstance3D *node = nullptr;
@@ -119,7 +116,19 @@ protected:
 	void _notification(int p_what);
 
 public:
+	enum ShapeAxis {
+		SHAPE_AXIS_X,
+		SHAPE_AXIS_Y,
+		SHAPE_AXIS_Z,
+		SHAPE_AXIS_LONGEST,
+	};
+
 	void edit(MeshInstance3D *p_mesh);
+	static Ref<BoxShape3D> create_box_shape(const Ref<Mesh> &p_mesh, Transform3D &r_transform);
+	static Ref<CapsuleShape3D> create_capsule_shape(const Ref<Mesh> &p_mesh, Transform3D &r_transform, ShapeAxis p_axis);
+	static Ref<SphereShape3D> create_sphere_shape(const Ref<Mesh> &p_mesh, Transform3D &r_transform);
+	static Ref<CylinderShape3D> create_cylinder_shape(const Ref<Mesh> &p_mesh, Transform3D &r_transform, ShapeAxis p_axis);
+
 	MeshInstance3DEditor();
 };
 


### PR DESCRIPTION
On first generation of physics shapes of imported scene meshes, fit the shape to the mesh based on the mesh's AABB.

Button added to UI to allow the user to call this behaviour whenever.

Create physics shape functions made static to be usable outside of the MeshInstance3DEditor UI and avoiding duplicate code.


Related proposal  - https://github.com/godotengine/godot-proposals/issues/13941

> (This was important enough for my current project to go ahead and implement personally)

<hr></hr>
The small size of the example mesh here exaggerates the problem, but is a frequent kind of size I'm working with on my project. You can see defaults before expand beyond the clipping plane, which is less than ideal.

**Before:**

<video src="https://github.com/user-attachments/assets/09c8d047-ddbd-4fe7-adb2-14fe9ff2e1f4"></video>


**After:**
<video src="https://github.com/user-attachments/assets/24e6eaf9-a1b1-4622-9763-bcee7724fbd4"></video>

Note that capsule and cylinder radius does not encompass the mesh, but I have created a separate bug report for this existing engine behaviour **https://github.com/godotengine/godot/issues/114542**