### PR TITLE
Fix testing motion when faces have normals orthogonal to motion

### DIFF
--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -339,7 +339,7 @@ bool JoltPhysicsDirectSpaceState3D::_body_motion_collide(const JoltBody3D &p_bod
 		if (p_motion.length_squared() > 0) {
 			const Vector3 direction = p_motion.normalized();
 
-			if (direction.dot(normal) >= -CMP_EPSILON) {
+			if (direction.dot(normal) >= CMP_EPSILON) {
 				continue;
 			}
 		}


### PR DESCRIPTION
I believe this is the correct fix for the linked issue. I'm not sure if this breaks collisions in other scenarios. I explained the issue a bit more in https://github.com/godotengine/godot/issues/114605#issuecomment-3708742861

Fixes https://github.com/godotengine/godot/issues/114605