### PR TITLE
Implement continuous scroll in TabBars

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -248,6 +248,9 @@
 		<member name="close_with_middle_mouse" type="bool" setter="set_close_with_middle_mouse" getter="get_close_with_middle_mouse" default="true">
 			If [code]true[/code], middle-clicking on a tab will emit the [signal tab_close_pressed] signal.
 		</member>
+		<member name="continuous_scroll_enabled" type="bool" setter="set_continuous_scroll_enabled" getter="get_continuous_scroll_enabled" default="false">
+			If [code]true[/code], enables scrolling tabs continuously instead of hard stops.
+		</member>
 		<member name="current_tab" type="int" setter="set_current_tab" getter="get_current_tab" default="-1">
 			The index of the current selected tab. A value of [code]-1[/code] means that no tab is selected and can only be set when [member deselect_enabled] is [code]true[/code] or if all tabs are hidden or disabled.
 		</member>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -212,6 +212,9 @@
 		<member name="clip_tabs" type="bool" setter="set_clip_tabs" getter="get_clip_tabs" default="true">
 			If [code]true[/code], tabs overflowing this node's width will be hidden, displaying two navigation buttons instead. Otherwise, this node's minimum size is updated so that all tabs are visible.
 		</member>
+		<member name="continuous_scroll_enabled" type="bool" setter="set_continuous_scroll_enabled" getter="get_continuous_scroll_enabled" default="false">
+			If [code]true[/code], enables scrolling tabs continuously instead of hard stops.
+		</member>
 		<member name="current_tab" type="int" setter="set_current_tab" getter="get_current_tab" default="-1">
 			The current tab index. When set, this index's [Control] node's [code]visible[/code] property is set to [code]true[/code] and all others are set to [code]false[/code].
 			A value of [code]-1[/code] means that no tab is selected.

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -2123,6 +2123,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 	}
 
 	tabs = memnew(TabContainer);
+	tabs->set_continuous_scroll_enabled(true);
 	add_child(tabs);
 	tabs->connect("tab_changed", callable_mp(this, &ScriptEditorDebugger::_tab_changed));
 

--- a/editor/docks/dock_tab_container.cpp
+++ b/editor/docks/dock_tab_container.cpp
@@ -337,6 +337,7 @@ DockTabContainer::DockTabContainer(int p_slot) {
 	ERR_FAIL_INDEX(p_slot, EditorDock::DOCK_SLOT_MAX);
 	dock_slot = p_slot;
 
+	set_continuous_scroll_enabled(true);
 	set_drag_to_rearrange_enabled(true);
 	set_tabs_rearrange_group(1);
 	hide();

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -470,6 +470,7 @@ EditorSceneTabs::EditorSceneTabs() {
 
 	scene_tabs = memnew(TabBar);
 	scene_tabs->add_tab("unsaved");
+	scene_tabs->set_continuous_scroll_enabled(true);
 	scene_tabs->set_tab_close_display_policy((TabBar::CloseButtonDisplayPolicy)EDITOR_GET("interface/scene_tabs/display_close_button").operator int());
 	scene_tabs->set_max_tab_width(int(EDITOR_GET("interface/scene_tabs/maximum_width")) * EDSCALE);
 	scene_tabs->set_drag_to_rearrange_enabled(true);

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -40,6 +40,7 @@
 #include "scene/main/viewport.h"
 #include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"
+#include "servers/rendering/rendering_server.h"
 
 #include <cfloat> // FLT_MAX
 
@@ -202,7 +203,11 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid()) {
 		if (mb->is_pressed() && (mb->get_button_index() == MouseButton::WHEEL_UP || (is_layout_rtl() ? mb->get_button_index() == MouseButton::WHEEL_RIGHT : mb->get_button_index() == MouseButton::WHEEL_LEFT)) && !mb->is_command_or_control_pressed()) {
 			if (scrolling_enabled && buttons_visible) {
-				if (offset > 0) {
+				if (continuous_scroll_enabled) {
+					scroll_offset -= get_size().width / 8 * mb->get_factor();
+					_update_cache();
+					queue_redraw();
+				} else if (offset > 0) {
 					offset--;
 					_update_cache();
 					queue_redraw();
@@ -212,7 +217,11 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (mb->is_pressed() && (mb->get_button_index() == MouseButton::WHEEL_DOWN || mb->get_button_index() == (is_layout_rtl() ? MouseButton::WHEEL_LEFT : MouseButton::WHEEL_RIGHT)) && !mb->is_command_or_control_pressed()) {
 			if (scrolling_enabled && buttons_visible) {
-				if (missing_right && offset < tabs.size()) {
+				if (continuous_scroll_enabled) {
+					scroll_offset += get_size().width / 8 * mb->get_factor();
+					_update_cache();
+					queue_redraw();
+				} else if (missing_right && offset < tabs.size()) {
 					offset++;
 					_update_cache();
 					queue_redraw();
@@ -253,13 +262,19 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 					if (pos.x < theme_cache.decrement_icon->get_width()) {
 						if (missing_right) {
 							offset++;
+							if (continuous_scroll_enabled && !tabs.is_empty()) {
+								scroll_offset = tabs[MIN(tabs.size() - 1, offset)].ofs_cache + scroll_offset;
+							}
 							_update_cache();
 							queue_redraw();
 						}
 						return;
 					} else if (pos.x < theme_cache.increment_icon->get_width() + theme_cache.decrement_icon->get_width()) {
-						if (offset > 0) {
+						if (offset > 0 || (continuous_scroll_enabled && scroll_offset > 0)) {
 							offset--;
+							if (continuous_scroll_enabled && tabs.size() > 0) {
+								scroll_offset = tabs[MAX(0, offset)].ofs_cache + scroll_offset;
+							}
 							_update_cache();
 							queue_redraw();
 						}
@@ -270,13 +285,19 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 					if (pos.x > limit + theme_cache.decrement_icon->get_width()) {
 						if (missing_right) {
 							offset++;
+							if (continuous_scroll_enabled && tabs.size() > 0) {
+								scroll_offset = tabs[MIN(tabs.size() - 1, offset)].ofs_cache + scroll_offset;
+							}
 							_update_cache();
 							queue_redraw();
 						}
 						return;
 					} else if (pos.x > limit) {
-						if (offset > 0) {
+						if (offset > 0 || (continuous_scroll_enabled && scroll_offset > 0)) {
 							offset--;
+							if (continuous_scroll_enabled && tabs.size() > 0) {
+								scroll_offset = tabs[MAX(0, offset)].ofs_cache + scroll_offset;
+							}
 							_update_cache();
 							queue_redraw();
 						}
@@ -555,6 +576,10 @@ void TabBar::_notification(int p_what) {
 			}
 
 			int limit_minus_buttons = size.width - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
+			if (continuous_scroll_enabled) {
+				int max_w = buttons_visible ? limit_minus_buttons : size.width;
+				RenderingServer::get_singleton()->canvas_item_set_custom_rect(get_canvas_item(), true, Rect2(rtl ? size.width - max_w : 0, 0, max_w, size.y));
+			}
 
 			// Draw unselected tabs in the back.
 			for (int i = offset; i <= max_drawn_tab; i++) {
@@ -593,6 +618,9 @@ void TabBar::_notification(int p_what) {
 				_draw_tab(sb, col, theme_cache.icon_selected_color, current, rtl ? (size.width - tabs[current].ofs_cache - tabs[current].size_cache) : tabs[current].ofs_cache, has_focus(true));
 			}
 
+			if (continuous_scroll_enabled) {
+				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), true);
+			}
 			if (buttons_visible) {
 				int vofs = (size.height - theme_cache.increment_icon->get_size().height) / 2;
 
@@ -603,13 +631,13 @@ void TabBar::_notification(int p_what) {
 						draw_texture(theme_cache.decrement_icon, Point2(0, vofs), Color(1, 1, 1, 0.5));
 					}
 
-					if (offset > 0) {
+					if (offset > 0 || (continuous_scroll_enabled && scroll_offset > 0)) {
 						draw_texture(highlight_arrow == 0 ? theme_cache.increment_hl_icon : theme_cache.increment_icon, Point2(theme_cache.increment_icon->get_size().width, vofs));
 					} else {
 						draw_texture(theme_cache.increment_icon, Point2(theme_cache.increment_icon->get_size().width, vofs), Color(1, 1, 1, 0.5));
 					}
 				} else {
-					if (offset > 0) {
+					if (offset > 0 || (continuous_scroll_enabled && scroll_offset > 0)) {
 						draw_texture(highlight_arrow == 0 ? theme_cache.decrement_hl_icon : theme_cache.decrement_icon, Point2(limit_minus_buttons, vofs));
 					} else {
 						draw_texture(theme_cache.decrement_icon, Point2(limit_minus_buttons, vofs), Color(1, 1, 1, 0.5));
@@ -625,6 +653,10 @@ void TabBar::_notification(int p_what) {
 
 			if (dragging_valid_tab) {
 				_draw_tab_drop(get_canvas_item());
+			}
+
+			if (continuous_scroll_enabled) {
+				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), false);
 			}
 		} break;
 	}
@@ -1310,6 +1342,12 @@ void TabBar::_update_cache(bool p_update_hover) {
 
 	int w = 0;
 	int visible_index = 0;
+	if (continuous_scroll_enabled) {
+		total_base_width = tab_sizing == TAB_SIZING_UNIFORM ? uniform_width * visible_count : total_base_width;
+		scroll_offset = CLAMP(scroll_offset, 0, MAX(0, total_base_width - limit_minus_buttons));
+		w = -scroll_offset;
+		offset = 0;
+	}
 
 	max_drawn_tab = tabs.size() - 1;
 
@@ -1366,7 +1404,8 @@ void TabBar::_update_cache(bool p_update_hover) {
 		w += tabs[i].size_cache;
 
 		// Check if all tabs would fit inside the area.
-		if (clip_tabs && i > offset && (w > limit || (offset > 0 && w > limit_minus_buttons))) {
+		bool too_large = clip_tabs && i > offset && (w > limit || (offset > 0 && w > limit_minus_buttons));
+		if (!continuous_scroll_enabled && too_large) {
 			tabs.write[i].ofs_cache = 0;
 
 			w -= tabs[i].size_cache;
@@ -1390,10 +1429,17 @@ void TabBar::_update_cache(bool p_update_hover) {
 		}
 	}
 
-	missing_right = max_drawn_tab < tabs.size() - 1;
-	buttons_visible = offset > 0 || missing_right;
+	if (continuous_scroll_enabled) {
+		buttons_visible = total_base_width > limit;
+		missing_right = buttons_visible && scroll_offset < total_base_width - limit_minus_buttons;
+	} else {
+		missing_right = max_drawn_tab < tabs.size() - 1;
+		buttons_visible = offset > 0 || missing_right;
+	}
 
-	if (tab_alignment == ALIGNMENT_LEFT) {
+	bool skip_continuous_alignment = continuous_scroll_enabled && buttons_visible;
+
+	if (tab_alignment == ALIGNMENT_LEFT || skip_continuous_alignment) {
 		if (p_update_hover) {
 			_update_hover();
 		}
@@ -2093,7 +2139,29 @@ void TabBar::ensure_tab_visible(int p_idx) {
 	}
 	ERR_FAIL_INDEX(p_idx, tabs.size());
 
-	if (tabs[p_idx].hidden || (p_idx >= offset && p_idx <= max_drawn_tab)) {
+	int limit_minus_buttons = get_size().width - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
+
+	if (tabs[p_idx].hidden) {
+		return;
+	}
+
+	if (continuous_scroll_enabled) {
+		int tofs = tabs[p_idx].ofs_cache;
+		if (tofs < 0) {
+			scroll_offset += tofs;
+			_update_cache();
+			queue_redraw();
+			return;
+		}
+		if ((tofs + tabs[p_idx].size_cache) > limit_minus_buttons) {
+			scroll_offset += tofs + tabs[p_idx].size_cache - limit_minus_buttons;
+			_update_cache();
+			queue_redraw();
+			return;
+		}
+	}
+
+	if (p_idx >= offset && p_idx <= max_drawn_tab) {
 		return;
 	}
 
@@ -2104,8 +2172,6 @@ void TabBar::ensure_tab_visible(int p_idx) {
 
 		return;
 	}
-
-	int limit_minus_buttons = get_size().width - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
 
 	int total_w = tabs[max_drawn_tab].ofs_cache - tabs[offset].ofs_cache;
 	for (int i = max_drawn_tab; i <= p_idx; i++) {
@@ -2207,6 +2273,20 @@ void TabBar::set_scrolling_enabled(bool p_enabled) {
 
 bool TabBar::get_scrolling_enabled() const {
 	return scrolling_enabled;
+}
+
+void TabBar::set_continuous_scroll_enabled(bool p_enabled) {
+	if (continuous_scroll_enabled == p_enabled) {
+		return;
+	}
+	continuous_scroll_enabled = p_enabled;
+	set_clip_contents(p_enabled);
+	_update_cache();
+	queue_redraw();
+}
+
+bool TabBar::get_continuous_scroll_enabled() {
+	return continuous_scroll_enabled;
 }
 
 void TabBar::set_drag_to_rearrange_enabled(bool p_enabled) {
@@ -2316,6 +2396,8 @@ void TabBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_max_tab_width"), &TabBar::get_max_tab_width);
 	ClassDB::bind_method(D_METHOD("set_scrolling_enabled", "enabled"), &TabBar::set_scrolling_enabled);
 	ClassDB::bind_method(D_METHOD("get_scrolling_enabled"), &TabBar::get_scrolling_enabled);
+	ClassDB::bind_method(D_METHOD("set_continuous_scroll_enabled", "enabled"), &TabBar::set_continuous_scroll_enabled);
+	ClassDB::bind_method(D_METHOD("get_continuous_scroll_enabled"), &TabBar::get_continuous_scroll_enabled);
 	ClassDB::bind_method(D_METHOD("set_drag_to_rearrange_enabled", "enabled"), &TabBar::set_drag_to_rearrange_enabled);
 	ClassDB::bind_method(D_METHOD("get_drag_to_rearrange_enabled"), &TabBar::get_drag_to_rearrange_enabled);
 	ClassDB::bind_method(D_METHOD("set_switch_on_drag_hover", "enabled"), &TabBar::set_switch_on_drag_hover);
@@ -2347,6 +2429,7 @@ void TabBar::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tab_close_display_policy", PROPERTY_HINT_ENUM, "Show Never,Show Active Only,Show Always"), "set_tab_close_display_policy", "get_tab_close_display_policy");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_tab_width", PROPERTY_HINT_RANGE, "0,99999,1,suffix:px"), "set_max_tab_width", "get_max_tab_width");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scrolling_enabled"), "set_scrolling_enabled", "get_scrolling_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "continuous_scroll_enabled"), "set_continuous_scroll_enabled", "get_continuous_scroll_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_to_rearrange_enabled"), "set_drag_to_rearrange_enabled", "get_drag_to_rearrange_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "switch_on_drag_hover"), "set_switch_on_drag_hover", "get_switch_on_drag_hover");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tabs_rearrange_group"), "set_tabs_rearrange_group", "get_tabs_rearrange_group");

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -40,6 +40,7 @@
 #include "scene/main/viewport.h"
 #include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"
+#include "servers/rendering/rendering_server.h"
 
 #include <cfloat> // FLT_MAX
 
@@ -202,7 +203,11 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid()) {
 		if (mb->is_pressed() && (mb->get_button_index() == MouseButton::WHEEL_UP || (is_layout_rtl() ? mb->get_button_index() == MouseButton::WHEEL_RIGHT : mb->get_button_index() == MouseButton::WHEEL_LEFT)) && !mb->is_command_or_control_pressed()) {
 			if (scrolling_enabled && buttons_visible) {
-				if (offset > 0) {
+				if (continuous_scroll_enabled) {
+					scroll_offset -= get_size().width / 8 * mb->get_factor();
+					_update_cache();
+					queue_redraw();
+				} else if (offset > 0) {
 					offset--;
 					_update_cache();
 					queue_redraw();
@@ -212,7 +217,11 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (mb->is_pressed() && (mb->get_button_index() == MouseButton::WHEEL_DOWN || mb->get_button_index() == (is_layout_rtl() ? MouseButton::WHEEL_LEFT : MouseButton::WHEEL_RIGHT)) && !mb->is_command_or_control_pressed()) {
 			if (scrolling_enabled && buttons_visible) {
-				if (missing_right && offset < tabs.size()) {
+				if (continuous_scroll_enabled) {
+					scroll_offset += get_size().width / 8 * mb->get_factor();
+					_update_cache();
+					queue_redraw();
+				} else if (missing_right && offset < tabs.size()) {
 					offset++;
 					_update_cache();
 					queue_redraw();
@@ -253,13 +262,19 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 					if (pos.x < theme_cache.decrement_icon->get_width()) {
 						if (missing_right) {
 							offset++;
+							if (continuous_scroll_enabled && tabs.size() > 0) {
+								scroll_offset = tabs[MIN(tabs.size() - 1, offset)].ofs_cache + scroll_offset;
+							}
 							_update_cache();
 							queue_redraw();
 						}
 						return;
 					} else if (pos.x < theme_cache.increment_icon->get_width() + theme_cache.decrement_icon->get_width()) {
-						if (offset > 0) {
+						if (offset > 0 || (continuous_scroll_enabled && scroll_offset > 0)) {
 							offset--;
+							if (continuous_scroll_enabled && tabs.size() > 0) {
+								scroll_offset = tabs[MAX(0, offset)].ofs_cache + scroll_offset;
+							}
 							_update_cache();
 							queue_redraw();
 						}
@@ -270,13 +285,19 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 					if (pos.x > limit + theme_cache.decrement_icon->get_width()) {
 						if (missing_right) {
 							offset++;
+							if (continuous_scroll_enabled && tabs.size() > 0) {
+								scroll_offset = tabs[MIN(tabs.size() - 1, offset)].ofs_cache + scroll_offset;
+							}
 							_update_cache();
 							queue_redraw();
 						}
 						return;
 					} else if (pos.x > limit) {
-						if (offset > 0) {
+						if (offset > 0 || (continuous_scroll_enabled && scroll_offset > 0)) {
 							offset--;
+							if (continuous_scroll_enabled && tabs.size() > 0) {
+								scroll_offset = tabs[MAX(0, offset)].ofs_cache + scroll_offset;
+							}
 							_update_cache();
 							queue_redraw();
 						}
@@ -555,6 +576,10 @@ void TabBar::_notification(int p_what) {
 			}
 
 			int limit_minus_buttons = size.width - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
+			if (continuous_scroll_enabled) {
+				int max_w = buttons_visible ? limit_minus_buttons : size.width;
+				RenderingServer::get_singleton()->canvas_item_set_custom_rect(get_canvas_item(), true, Rect2(rtl ? size.width - max_w : 0, 0, max_w, size.y));
+			}
 
 			// Draw unselected tabs in the back.
 			for (int i = offset; i <= max_drawn_tab; i++) {
@@ -593,6 +618,9 @@ void TabBar::_notification(int p_what) {
 				_draw_tab(sb, col, theme_cache.icon_selected_color, current, rtl ? (size.width - tabs[current].ofs_cache - tabs[current].size_cache) : tabs[current].ofs_cache, has_focus(true));
 			}
 
+			if (continuous_scroll_enabled) {
+				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), true);
+			}
 			if (buttons_visible) {
 				int vofs = (size.height - theme_cache.increment_icon->get_size().height) / 2;
 
@@ -603,13 +631,13 @@ void TabBar::_notification(int p_what) {
 						draw_texture(theme_cache.decrement_icon, Point2(0, vofs), Color(1, 1, 1, 0.5));
 					}
 
-					if (offset > 0) {
+					if (offset > 0 || (continuous_scroll_enabled && scroll_offset > 0)) {
 						draw_texture(highlight_arrow == 0 ? theme_cache.increment_hl_icon : theme_cache.increment_icon, Point2(theme_cache.increment_icon->get_size().width, vofs));
 					} else {
 						draw_texture(theme_cache.increment_icon, Point2(theme_cache.increment_icon->get_size().width, vofs), Color(1, 1, 1, 0.5));
 					}
 				} else {
-					if (offset > 0) {
+					if (offset > 0 || (continuous_scroll_enabled && scroll_offset > 0)) {
 						draw_texture(highlight_arrow == 0 ? theme_cache.decrement_hl_icon : theme_cache.decrement_icon, Point2(limit_minus_buttons, vofs));
 					} else {
 						draw_texture(theme_cache.decrement_icon, Point2(limit_minus_buttons, vofs), Color(1, 1, 1, 0.5));
@@ -625,6 +653,10 @@ void TabBar::_notification(int p_what) {
 
 			if (dragging_valid_tab) {
 				_draw_tab_drop(get_canvas_item());
+			}
+
+			if (continuous_scroll_enabled) {
+				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), false);
 			}
 		} break;
 	}
@@ -1310,6 +1342,12 @@ void TabBar::_update_cache(bool p_update_hover) {
 
 	int w = 0;
 	int visible_index = 0;
+	if (continuous_scroll_enabled) {
+		total_base_width = tab_sizing == TAB_SIZING_UNIFORM ? uniform_width * visible_count : total_base_width;
+		scroll_offset = CLAMP(scroll_offset, 0, MAX(0, total_base_width - limit_minus_buttons));
+		w = -scroll_offset;
+		offset = 0;
+	}
 
 	max_drawn_tab = tabs.size() - 1;
 
@@ -1366,7 +1404,8 @@ void TabBar::_update_cache(bool p_update_hover) {
 		w += tabs[i].size_cache;
 
 		// Check if all tabs would fit inside the area.
-		if (clip_tabs && i > offset && (w > limit || (offset > 0 && w > limit_minus_buttons))) {
+		bool too_large = clip_tabs && i > offset && (w > limit || (offset > 0 && w > limit_minus_buttons));
+		if (!continuous_scroll_enabled && too_large) {
 			tabs.write[i].ofs_cache = 0;
 
 			w -= tabs[i].size_cache;
@@ -1390,10 +1429,17 @@ void TabBar::_update_cache(bool p_update_hover) {
 		}
 	}
 
-	missing_right = max_drawn_tab < tabs.size() - 1;
-	buttons_visible = offset > 0 || missing_right;
+	if (continuous_scroll_enabled) {
+		buttons_visible = total_base_width > limit;
+		missing_right = buttons_visible && scroll_offset < total_base_width - limit_minus_buttons;
+	} else {
+		missing_right = max_drawn_tab < tabs.size() - 1;
+		buttons_visible = offset > 0 || missing_right;
+	}
 
-	if (tab_alignment == ALIGNMENT_LEFT) {
+	bool skip_continuous_alignment = continuous_scroll_enabled && buttons_visible;
+
+	if (tab_alignment == ALIGNMENT_LEFT || skip_continuous_alignment) {
 		if (p_update_hover) {
 			_update_hover();
 		}
@@ -2093,7 +2139,29 @@ void TabBar::ensure_tab_visible(int p_idx) {
 	}
 	ERR_FAIL_INDEX(p_idx, tabs.size());
 
-	if (tabs[p_idx].hidden || (p_idx >= offset && p_idx <= max_drawn_tab)) {
+	int limit_minus_buttons = get_size().width - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
+
+	if (tabs[p_idx].hidden) {
+		return;
+	}
+
+	if (continuous_scroll_enabled) {
+		int tofs = tabs[p_idx].ofs_cache;
+		if (tofs < 0) {
+			scroll_offset += tofs;
+			_update_cache();
+			queue_redraw();
+			return;
+		}
+		if ((tofs + tabs[p_idx].size_cache) > limit_minus_buttons) {
+			scroll_offset += tofs + tabs[p_idx].size_cache - limit_minus_buttons;
+			_update_cache();
+			queue_redraw();
+			return;
+		}
+	}
+
+	if (p_idx >= offset && p_idx <= max_drawn_tab) {
 		return;
 	}
 
@@ -2104,8 +2172,6 @@ void TabBar::ensure_tab_visible(int p_idx) {
 
 		return;
 	}
-
-	int limit_minus_buttons = get_size().width - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
 
 	int total_w = tabs[max_drawn_tab].ofs_cache - tabs[offset].ofs_cache;
 	for (int i = max_drawn_tab; i <= p_idx; i++) {
@@ -2207,6 +2273,21 @@ void TabBar::set_scrolling_enabled(bool p_enabled) {
 
 bool TabBar::get_scrolling_enabled() const {
 	return scrolling_enabled;
+}
+
+void TabBar::set_continuous_scroll_enabled(bool p_enabled) {
+	if (continuous_scroll_enabled != p_enabled) {
+		continuous_scroll_enabled = p_enabled;
+		if (p_enabled) {
+			set_clip_contents(p_enabled);
+		}
+		_update_cache();
+		queue_redraw();
+	}
+}
+
+bool TabBar::get_continuous_scroll_enabled() {
+	return continuous_scroll_enabled;
 }
 
 void TabBar::set_drag_to_rearrange_enabled(bool p_enabled) {
@@ -2316,6 +2397,8 @@ void TabBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_max_tab_width"), &TabBar::get_max_tab_width);
 	ClassDB::bind_method(D_METHOD("set_scrolling_enabled", "enabled"), &TabBar::set_scrolling_enabled);
 	ClassDB::bind_method(D_METHOD("get_scrolling_enabled"), &TabBar::get_scrolling_enabled);
+	ClassDB::bind_method(D_METHOD("set_continuous_scroll_enabled", "enabled"), &TabBar::set_continuous_scroll_enabled);
+	ClassDB::bind_method(D_METHOD("get_continuous_scroll_enabled"), &TabBar::get_continuous_scroll_enabled);
 	ClassDB::bind_method(D_METHOD("set_drag_to_rearrange_enabled", "enabled"), &TabBar::set_drag_to_rearrange_enabled);
 	ClassDB::bind_method(D_METHOD("get_drag_to_rearrange_enabled"), &TabBar::get_drag_to_rearrange_enabled);
 	ClassDB::bind_method(D_METHOD("set_switch_on_drag_hover", "enabled"), &TabBar::set_switch_on_drag_hover);
@@ -2347,6 +2430,7 @@ void TabBar::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tab_close_display_policy", PROPERTY_HINT_ENUM, "Show Never,Show Active Only,Show Always"), "set_tab_close_display_policy", "get_tab_close_display_policy");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_tab_width", PROPERTY_HINT_RANGE, "0,99999,1,suffix:px"), "set_max_tab_width", "get_max_tab_width");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scrolling_enabled"), "set_scrolling_enabled", "get_scrolling_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "continuous_scroll_enabled"), "set_continuous_scroll_enabled", "get_continuous_scroll_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_to_rearrange_enabled"), "set_drag_to_rearrange_enabled", "get_drag_to_rearrange_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "switch_on_drag_hover"), "set_switch_on_drag_hover", "get_switch_on_drag_hover");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tabs_rearrange_group"), "set_tabs_rearrange_group", "get_tabs_rearrange_group");

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -144,6 +144,9 @@ private:
 	int tabs_rearrange_group = -1;
 	bool switch_on_drag_hover = true;
 
+	bool continuous_scroll_enabled = false;
+	double scroll_offset = 0.0;
+
 	static const int CURRENT_TAB_UNINITIALIZED = -2;
 	bool initialized = false;
 	int queued_current = CURRENT_TAB_UNINITIALIZED;
@@ -319,6 +322,9 @@ public:
 
 	void set_scrolling_enabled(bool p_enabled);
 	bool get_scrolling_enabled() const;
+
+	void set_continuous_scroll_enabled(bool p_enabled);
+	bool get_continuous_scroll_enabled();
 
 	void set_drag_to_rearrange_enabled(bool p_enabled);
 	bool get_drag_to_rearrange_enabled() const;

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -1167,6 +1167,14 @@ bool TabContainer::get_switch_on_drag_hover() const {
 	return tab_bar->get_switch_on_drag_hover();
 }
 
+void TabContainer::set_continuous_scroll_enabled(bool p_enabled) {
+	tab_bar->set_continuous_scroll_enabled(p_enabled);
+}
+
+bool TabContainer::get_continuous_scroll_enabled() {
+	return tab_bar->get_continuous_scroll_enabled();
+}
+
 void TabContainer::set_drag_to_rearrange_enabled(bool p_enabled) {
 	drag_to_rearrange_enabled = p_enabled;
 }
@@ -1251,6 +1259,8 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tab_idx_from_control", "control"), &TabContainer::get_tab_idx_from_control);
 	ClassDB::bind_method(D_METHOD("set_popup", "popup"), &TabContainer::set_popup);
 	ClassDB::bind_method(D_METHOD("get_popup"), &TabContainer::get_popup);
+	ClassDB::bind_method(D_METHOD("set_continuous_scroll_enabled", "enabled"), &TabContainer::set_continuous_scroll_enabled);
+	ClassDB::bind_method(D_METHOD("get_continuous_scroll_enabled"), &TabContainer::get_continuous_scroll_enabled);
 	ClassDB::bind_method(D_METHOD("set_switch_on_drag_hover", "enabled"), &TabContainer::set_switch_on_drag_hover);
 	ClassDB::bind_method(D_METHOD("get_switch_on_drag_hover"), &TabContainer::get_switch_on_drag_hover);
 	ClassDB::bind_method(D_METHOD("set_drag_to_rearrange_enabled", "enabled"), &TabContainer::set_drag_to_rearrange_enabled);
@@ -1281,6 +1291,7 @@ void TabContainer::_bind_methods() {
 #ifndef DISABLE_DEPRECATED
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "all_tabs_in_front", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_all_tabs_in_front", "is_all_tabs_in_front");
 #endif
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "continuous_scroll_enabled"), "set_continuous_scroll_enabled", "get_continuous_scroll_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "switch_on_drag_hover"), "set_switch_on_drag_hover", "get_switch_on_drag_hover");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_to_rearrange_enabled"), "set_drag_to_rearrange_enabled", "get_drag_to_rearrange_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tabs_rearrange_group"), "set_tabs_rearrange_group", "get_tabs_rearrange_group");

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -247,6 +247,8 @@ public:
 
 	void set_switch_on_drag_hover(bool p_enabled);
 	bool get_switch_on_drag_hover() const;
+	void set_continuous_scroll_enabled(bool p_enabled);
+	bool get_continuous_scroll_enabled();
 	void set_drag_to_rearrange_enabled(bool p_enabled);
 	bool get_drag_to_rearrange_enabled() const;
 	void set_tabs_rearrange_group(int p_group_id);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
Closes https://github.com/godotengine/godot-proposals/issues/8198 and https://github.com/godotengine/godot-proposals/issues/13955 (I'm surprised this was just proposed lol. There was another proposal this was based on but can't find it anymore)

https://github.com/user-attachments/assets/1d3df908-a65f-4103-8416-a6085f123234

Also adds an editor setting to enable or disable this for all editor TabBars
