### PR TITLE
GDScript: Don't return wrong result for already completed solving state

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -68,6 +68,10 @@ Error GDScriptParserRef::raise_status(Status p_new_status) {
 	ERR_FAIL_COND_V(clearing, ERR_BUG);
 	ERR_FAIL_COND_V(parser == nullptr && status != EMPTY, ERR_BUG);
 
+	if (p_new_status < status) {
+		return OK;
+	}
+
 	while (result == OK && p_new_status > status) {
 		switch (status) {
 			case EMPTY: {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113576

The result returned from `GDScriptParserRef::raise_status` should reflect the result of raising the parser to that given status.

However the code did not account for the following sequence of events

1. `raise_status(INTERFACE_SOLVED)` result: `OK`
2. `raise_status(FULLY_SOLVED)` result: `ERR`
3. `raise_status(INTERFACE_SOLVED)`
  - expected result: `OK`, because the interface is already resolved and usable
  - actual result without this PR: the `ERR` from `FULLY_SOLVED`

In the linked issue autocompletion stops, because it thinks it can't use the resolved interface. In reality the interface is usable.

This PR returns `OK` for all solving states that are lower than the current state. This is correct since progression to a state can only happen if the previous state finished with `OK`.


