### PR TITLE
Fix ShaderInclude selected in ShaderCreateDialog due to previous selection even if invalid

### DIFF
--- a/editor/shader/shader_create_dialog.cpp
+++ b/editor/shader/shader_create_dialog.cpp
@@ -333,7 +333,7 @@ void ShaderCreateDialog::config(const String &p_base_path, bool p_built_in_enabl
 	int preferred_type = -1;
 	// Select preferred type if specified.
 	for (int i = 0; i < type_menu->get_item_count(); i++) {
-		if (type_menu->get_item_text(i) == p_preferred_type) {
+		if (type_menu->get_item_text(i) == p_preferred_type && !(p_load_enabled && p_preferred_type.contains("Include"))) {
 			preferred_type = i;
 			break;
 		}
@@ -344,7 +344,7 @@ void ShaderCreateDialog::config(const String &p_base_path, bool p_built_in_enabl
 		String last_lang = EditorSettings::get_singleton()->get_project_metadata("shader_setup", "last_selected_language", "");
 		if (!last_lang.is_empty()) {
 			for (int i = 0; i < type_menu->get_item_count(); i++) {
-				if (type_menu->get_item_text(i) == last_lang) {
+				if (type_menu->get_item_text(i) == last_lang && !(p_load_enabled && last_lang.contains("Include"))) {
 					preferred_type = i;
 					break;
 				}


### PR DESCRIPTION
Fix ShaderInclude automatically selected when creating adding a Shader f.e in ShaderMaterial due to previous selection when creating a ShaderInclude from the FileSystemDock.

This fixes uses the existing load_enabled parameter to determine if the ShaderInclude type is valid and does not accept it from the last selected type if invalid.

Fixes #114618