### PR TITLE
GDScript: Reuse scripts from `ResourceCache`

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -310,8 +310,13 @@ Ref<GDScript> GDScriptCache::get_shallow_script(const String &p_path, Error &r_e
 
 	const String remapped_path = ResourceLoader::path_remap(p_path);
 
-	Ref<GDScript> script;
-	script.instantiate();
+	// HACK: When this code runs there should not be an entry in the resource cache. However some bug with cyclic references
+	// can lead to a partially destructed script in the cache: GH-98141. We reconstruct the script in the same place
+	// to prevent the creation of a duplicate.
+	Ref<GDScript> script = ResourceCache::get_ref(p_path);
+	if (script.is_null()) {
+		script.instantiate();
+	}
 
 	script->set_path_cache(p_path);
 	if (remapped_path.has_extension("gdc")) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/114420
Fixes https://github.com/godotengine/godot/issues/98141 (tested using the 4.3 MRP by myself. Not the original one.)

This code originally assumed that if a script object was present for a certain path it would be in either `GDScriptCache::shallow_gdscript_cache` or `GDScriptCache::full_gdscript_cache`. However in the linked issues an edge case occurs, were the script object is not in them anymore. This PR also looks into the `ResourceCache` to handle that edge case correctly.

Idk whether the edge case occurring in the first place is also a bug. But this is the least invasive fix I could think of without opening the whole cyclic ref topic.