### PR TITLE
[Android Editor] Enable modifier buttons of Touch Actions Panel to work in the 3D editor

### DIFF
--- a/editor/gui/touch_actions_panel.cpp
+++ b/editor/gui/touch_actions_panel.cpp
@@ -75,16 +75,20 @@ void TouchActionsPanel::_notification(int p_what) {
 }
 
 void TouchActionsPanel::input(const Ref<InputEvent> &event) {
-	if (ctrl_btn_pressed) {
+	if (event->is_class("InputEventMouse") && ctrl_btn_pressed) {
 		event->call(SNAME("set_ctrl_pressed"), true);
+		ctrl_modifier_event->set_pressed(true);
+		Input::get_singleton()->parse_input_event(ctrl_modifier_event);
 	}
-
-	if (shift_btn_pressed) {
+	if (event->is_class("InputEventMouse") && shift_btn_pressed) {
 		event->call(SNAME("set_shift_pressed"), true);
+		shift_modifier_event->set_pressed(true);
+		Input::get_singleton()->parse_input_event(shift_modifier_event);
 	}
-
-	if (alt_btn_pressed) {
+	if (event->is_class("InputEventMouse") && alt_btn_pressed) {
 		event->call(SNAME("set_alt_pressed"), true);
+		alt_modifier_event->set_pressed(true);
+		Input::get_singleton()->parse_input_event(alt_modifier_event);
 	}
 }
 
@@ -116,12 +120,24 @@ void TouchActionsPanel::_on_modifier_button_toggled(bool p_pressed, int p_modifi
 	switch ((Modifier)p_modifier) {
 		case MODIFIER_CTRL:
 			ctrl_btn_pressed = p_pressed;
+			if (ctrl_btn_pressed == false) {
+				ctrl_modifier_event->set_pressed(false);
+				Input::get_singleton()->parse_input_event(ctrl_modifier_event);
+			}
 			break;
 		case MODIFIER_SHIFT:
 			shift_btn_pressed = p_pressed;
+			if (shift_btn_pressed == false) {
+				shift_modifier_event->set_pressed(false);
+				Input::get_singleton()->parse_input_event(shift_modifier_event);
+			}
 			break;
 		case MODIFIER_ALT:
 			alt_btn_pressed = p_pressed;
+			if (alt_btn_pressed == false) {
+				alt_modifier_event->set_pressed(false);
+				Input::get_singleton()->parse_input_event(alt_modifier_event);
+			}
 			break;
 	}
 }
@@ -146,12 +162,18 @@ void TouchActionsPanel::_add_new_modifier_button(Modifier p_modifier) {
 	switch (p_modifier) {
 		case MODIFIER_CTRL:
 			text = "Ctrl";
+			ctrl_modifier_event.instantiate();
+			ctrl_modifier_event->set_keycode(Key::CTRL);
 			break;
 		case MODIFIER_SHIFT:
 			text = "Shift";
+			shift_modifier_event.instantiate();
+			shift_modifier_event->set_keycode(Key::SHIFT);
 			break;
 		case MODIFIER_ALT:
 			text = "Alt";
+			alt_modifier_event.instantiate();
+			alt_modifier_event->set_keycode(Key::ALT);
 			break;
 	}
 	Button *toggle_button = memnew(Button);

--- a/editor/gui/touch_actions_panel.h
+++ b/editor/gui/touch_actions_panel.h
@@ -68,6 +68,10 @@ private:
 	bool shift_btn_pressed = false;
 	bool alt_btn_pressed = false;
 
+	Ref<InputEventKey> shift_modifier_event;
+	Ref<InputEventKey> ctrl_modifier_event;
+	Ref<InputEventKey> alt_modifier_event;
+
 	bool is_floating = false; // Embedded panel mode is default.
 	int embedded_panel_index = 0;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/114624

Makes orbiting and panning in 3d editor on Android Editor with touchscreen possible.

Note: in Editor Settings, Editor/3D/Navigation scheme setting should be set to 'Tablet/Trackpad' and Orbit, Pan and Zoom mouse buttons set to 'Alt/Shift/Ctrl + Left Mouse' respectively for 3D navigation on touchscreen to work.

https://github.com/user-attachments/assets/612ecb06-5026-41fa-ad57-74c2b234c2e2
