### PR TITLE
GDExtension: Ensure `LIBGODOT_API` is always defined

### DIFF
--- a/core/extension/libgodot.h
+++ b/core/extension/libgodot.h
@@ -34,14 +34,16 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif // __cplusplus
 
 // Export macros for DLL visibility
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #define LIBGODOT_API __declspec(dllexport)
 #elif defined(__GNUC__) || defined(__clang__)
 #define LIBGODOT_API __attribute__((visibility("default")))
-#endif // if defined(_MSC_VER)
+#else
+#define LIBGODOT_API
+#endif
 
 /**
  * @name libgodot_create_godot_instance
@@ -70,4 +72,4 @@ LIBGODOT_API void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_i
 
 #ifdef __cplusplus
 }
-#endif
+#endif // __cplusplus


### PR DESCRIPTION
Fixes a small oversight in `libgodot.h`, where the `LIBGODOT_API` lacked a fallback define for potentially unsupported compilers. Also adds `#endif` comments to the `__cplusplus` wrappers, and removes the incorrect `#endif` comment from the `LIBGODOT_API` wrapper