### PR TITLE
Reword OpenXR initialization failure alert message

### DIFF
--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -240,9 +240,13 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 			if (!openxr_api->initialize(Main::get_rendering_driver_name())) {
 				const char *init_error_message =
 						"OpenXR was requested but failed to start.\n"
-						"Please check if your HMD is connected.\n"
+						"HMD was not detected or a required feature was not supported.\n\n"
+#ifdef TOOLS_ENABLED
+						// Editor only message - this is useful for app developer, but not user
+						"Check logged errors in debugger for more details.\n\n"
+#endif
 #ifdef WINDOWS_ENABLED
-						"When using Windows Mixed Reality, note that WMR only has DirectX support. Make sure SteamVR is your default OpenXR runtime.\n"
+						"When using Windows Mixed Reality, note that WMR only has DirectX support. Make sure SteamVR is your default OpenXR runtime.\n\n"
 #endif
 						"Godot will start in normal mode.\n";
 


### PR DESCRIPTION
Changes account for the following
1. OpenXR initialization can fail if a required extension is unsupported.
2. Logs contain more detailed info regarding failure.
3. Add additional newlines to separate message into 4 sections Error encountered Editor specific hint to developer WMR specific hint Consequence
