### PR TITLE
Allow editing multiple materials from FileSystem dock

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -55,6 +55,7 @@
 #include "editor/inspector/editor_context_menu_plugin.h"
 #include "editor/inspector/editor_resource_preview.h"
 #include "editor/inspector/editor_resource_tooltip_plugins.h"
+#include "editor/inspector/multi_resource_edit.h"
 #include "editor/plugins/editor_resource_conversion_plugin.h"
 #include "editor/scene/editor_scene_tabs.h"
 #include "editor/scene/scene_create_dialog.h"
@@ -719,6 +720,8 @@ void FileSystemDock::_tree_multi_selected(Object *p_item, int p_column, bool p_s
 	// Display the current path.
 	_set_current_path_line_edit_text(current_path);
 	_push_to_history();
+
+	_try_multi_edit_resources();
 
 	// Update the file list.
 	if (!updating_tree && display_mode != DISPLAY_MODE_TREE_ONLY) {
@@ -3787,6 +3790,36 @@ void FileSystemDock::_file_multi_selected(int p_index, bool p_selected) {
 	// Update the import dock.
 	import_dock_needs_update = true;
 	callable_mp(this, &FileSystemDock::_update_import_dock).call_deferred();
+
+	_try_multi_edit_resources();
+}
+
+void FileSystemDock::_try_multi_edit_resources() {
+	Vector<String> selected = get_selected_paths();
+	if (selected.size() <= 1) {
+		return;
+	}
+
+	LocalVector<String> resource_paths;
+	for (const String &path : selected) {
+		if (path.ends_with("/")) {
+			continue;
+		}
+		String type = EditorFileSystem::get_singleton()->get_file_type(path);
+		if (!ClassDB::is_parent_class(type, "Resource")) {
+			return;
+		}
+		resource_paths.push_back(path);
+	}
+
+	if (resource_paths.size() > 1) {
+		Ref<MultiResourceEdit> mre;
+		mre.instantiate();
+		for (const String &path : resource_paths) {
+			mre->add_resource(path);
+		}
+		EditorNode::get_singleton()->push_item(mre.ptr());
+	}
 }
 
 void FileSystemDock::_update_selection_changed() {

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -295,6 +295,7 @@ private:
 	void _file_list_activate_file(int p_idx);
 	void _file_multi_selected(int p_index, bool p_selected);
 	void _tree_multi_selected(Object *p_item, int p_column, bool p_selected);
+	void _try_multi_edit_resources();
 
 	bool _get_imported_files(const String &p_path, String &r_extension, Vector<String> &r_files) const;
 	void _update_import_dock();

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -51,6 +51,7 @@
 #include "editor/inspector/editor_property_name_processor.h"
 #include "editor/inspector/editor_resource_picker.h"
 #include "editor/inspector/multi_node_edit.h"
+#include "editor/inspector/multi_resource_edit.h"
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_feature_profile.h"
 #include "editor/settings/editor_settings.h"
@@ -1951,6 +1952,24 @@ void EditorInspectorCategory::_handle_menu_option(int p_option) {
 				}
 
 				ur->commit_action();
+			} else if (const MultiResourceEdit *multi_resource_edit = Object::cast_to<MultiResourceEdit>(object)) {
+				const String action_name = vformat(TTR("Set category %s on %d resources"), category_name, multi_resource_edit->get_resource_count());
+				ur->create_action(action_name);
+
+				for (int i = 0; i < multi_resource_edit->get_resource_count(); i++) {
+					Ref<Resource> r = multi_resource_edit->get_resource(i);
+					if (r.is_null()) {
+						continue;
+					}
+
+					for (const KeyValue<Variant, Variant> &pair : clipboard) {
+						String property_name = pair.key;
+						ur->add_do_property(r.ptr(), property_name, pair.value);
+						ur->add_undo_property(r.ptr(), property_name, r->get(property_name));
+					}
+				}
+
+				ur->commit_action();
 			} else if (EditorDebuggerRemoteObjects *remote_objects = Object::cast_to<EditorDebuggerRemoteObjects>(object)) {
 				const int size = remote_objects->remote_object_ids.size();
 				ur->create_action(size == 1 ? vformat(TTR("Set category %s"), category_name) : vformat(TTR("Set %s on %d objects"), category_name, size), UndoRedo::MERGE_ENDS);
@@ -2805,6 +2824,23 @@ void EditorInspectorSection::menu_option(int p_option) const {
 					for (const String &property_name : properties) {
 						ur->add_do_property(n, property_name, clipboard[property_name]);
 						ur->add_undo_property(n, property_name, n->get(property_name));
+					}
+				}
+
+				ur->commit_action();
+			} else if (const MultiResourceEdit *multi_resource_edit = Object::cast_to<MultiResourceEdit>(object)) {
+				const String action_name = vformat(TTR("Set section %s on %d resources"), section_path, multi_resource_edit->get_resource_count());
+				ur->create_action(action_name);
+
+				for (int i = 0; i < multi_resource_edit->get_resource_count(); i++) {
+					Ref<Resource> r = multi_resource_edit->get_resource(i);
+					if (r.is_null()) {
+						continue;
+					}
+
+					for (const String &property_name : properties) {
+						ur->add_do_property(r.ptr(), property_name, clipboard[property_name]);
+						ur->add_undo_property(r.ptr(), property_name, r->get(property_name));
 					}
 				}
 
@@ -4343,8 +4379,9 @@ void EditorInspector::update_tree() {
 				continue;
 			}
 
-			// Hide the "MultiNodeEdit" category for MultiNodeEdit.
-			if (Object::cast_to<MultiNodeEdit>(object) && p.name == "MultiNodeEdit") {
+			// Hide the "MultiNodeEdit"/"MultiResourceEdit" category for multi-edit objects.
+			if ((Object::cast_to<MultiNodeEdit>(object) && p.name == "MultiNodeEdit") ||
+					(Object::cast_to<MultiResourceEdit>(object) && p.name == "MultiResourceEdit")) {
 				continue;
 			}
 
@@ -4698,6 +4735,8 @@ void EditorInspector::update_tree() {
 				classname = object_class;
 			} else if (Object::cast_to<MultiNodeEdit>(object)) {
 				classname = Object::cast_to<MultiNodeEdit>(object)->get_edited_class_name();
+			} else if (Object::cast_to<MultiResourceEdit>(object)) {
+				classname = Object::cast_to<MultiResourceEdit>(object)->get_edited_class_name();
 			} else if (classname == "") {
 				classname = object->get_class_name();
 				Resource *res = Object::cast_to<Resource>(object);
@@ -5238,7 +5277,7 @@ void EditorInspector::edit(Object *p_object) {
 		}
 		object->connect(CoreStringName(property_list_changed), callable_mp(this, &EditorInspector::_changed_callback));
 
-		can_favorite = Object::cast_to<Node>(object) || Object::cast_to<Resource>(object) || Object::cast_to<MultiNodeEdit>(object);
+		can_favorite = Object::cast_to<Node>(object) || Object::cast_to<Resource>(object) || Object::cast_to<MultiNodeEdit>(object) || Object::cast_to<MultiResourceEdit>(object);
 		_update_current_favorites();
 
 		update_tree();
@@ -5485,6 +5524,10 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		emit_signal(_prop_edited, p_name);
 	} else if (Object::cast_to<MultiNodeEdit>(object)) {
 		Object::cast_to<MultiNodeEdit>(object)->set_property_field(p_name, p_value, p_changed_field);
+		_edit_request_change(object, p_name);
+		emit_signal(_prop_edited, p_name);
+	} else if (Object::cast_to<MultiResourceEdit>(object)) {
+		Object::cast_to<MultiResourceEdit>(object)->set_property_field(p_name, p_value, p_changed_field);
 		_edit_request_change(object, p_name);
 		emit_signal(_prop_edited, p_name);
 	} else if (Object::cast_to<EditorDebuggerRemoteObjects>(object)) {
@@ -5835,7 +5878,9 @@ void EditorInspector::_update_current_favorites() {
 
 	// Fetch built-in properties.
 	const MultiNodeEdit *multi_node_edit = Object::cast_to<MultiNodeEdit>(object);
-	StringName class_name = multi_node_edit ? multi_node_edit->get_edited_class_name() : object->get_class_name();
+	const MultiResourceEdit *multi_resource_edit = Object::cast_to<MultiResourceEdit>(object);
+	StringName class_name = multi_node_edit ? multi_node_edit->get_edited_class_name()
+											: (multi_resource_edit ? multi_resource_edit->get_edited_class_name() : object->get_class_name());
 	for (const KeyValue<String, PackedStringArray> &KV : favorites) {
 		if (ClassDB::is_parent_class(class_name, KV.key)) {
 			current_favorites.append_array(KV.value);
@@ -5849,7 +5894,9 @@ void EditorInspector::_set_property_favorited(const String &p_path, bool p_favor
 	}
 
 	const MultiNodeEdit *mne = Object::cast_to<MultiNodeEdit>(object);
-	StringName validate_name = mne ? mne->get_edited_class_name() : object->get_class_name();
+	const MultiResourceEdit *mre = Object::cast_to<MultiResourceEdit>(object);
+	StringName validate_name = mne ? mne->get_edited_class_name()
+								   : (mre ? mre->get_edited_class_name() : object->get_class_name());
 	StringName class_name;
 
 	String theme_property;

--- a/editor/inspector/multi_resource_edit.cpp
+++ b/editor/inspector/multi_resource_edit.cpp
@@ -1,0 +1,264 @@
+/**************************************************************************/
+/*  multi_resource_edit.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "multi_resource_edit.h"
+
+#include "core/io/resource_loader.h"
+#include "core/math/math_fieldwise.h"
+#include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
+#include "core/object/script_language.h"
+#include "editor/editor_node.h"
+#include "editor/editor_undo_redo_manager.h"
+
+void MultiResourceEdit::_ensure_resources_loaded() const {
+	if (resources_loaded) {
+		return;
+	}
+	resources_loaded = true;
+	loaded_resources.clear();
+	for (const String &path : resource_paths) {
+		Ref<Resource> r = ResourceLoader::load(path);
+		if (r.is_valid()) {
+			r->connect(CoreStringName(property_list_changed), callable_mp(const_cast<MultiResourceEdit *>(this), &MultiResourceEdit::_queue_notify_property_list_changed));
+			loaded_resources.push_back(r);
+		}
+	}
+}
+
+bool MultiResourceEdit::_set(const StringName &p_name, const Variant &p_value) {
+	return _set_impl(p_name, p_value, "");
+}
+
+bool MultiResourceEdit::_set_impl(const StringName &p_name, const Variant &p_value, const String &p_field, bool p_undo_redo) {
+	String name = p_name;
+	if (name == "scripts") { // Script set is intercepted at object level (check Variant Object::get()), so use a different name.
+		name = "script";
+	} else if (name.begins_with("Metadata/")) {
+		name = name.replace_first("Metadata/", "metadata/");
+	}
+
+	_ensure_resources_loaded();
+
+	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+
+	if (p_undo_redo) {
+		ur->create_action(vformat(TTR("Set %s on %d resources"), name, get_resource_count()), UndoRedo::MERGE_ENDS);
+	}
+
+	for (Ref<Resource> &r : loaded_resources) {
+		Variant new_value;
+		if (p_field.is_empty()) {
+			new_value = p_value;
+		} else {
+			new_value = fieldwise_assign(r->get(name), p_value, p_field);
+		}
+
+		if (p_undo_redo) {
+			ur->add_do_property(r.ptr(), name, new_value);
+			ur->add_undo_property(r.ptr(), name, r->get(name));
+		} else {
+			r->set(name, new_value);
+		}
+	}
+
+	if (p_undo_redo) {
+		ur->commit_action();
+	}
+
+	return true;
+}
+
+bool MultiResourceEdit::_get(const StringName &p_name, Variant &r_ret) const {
+	String name = p_name;
+	if (name == "scripts") { // Script set is intercepted at object level (check Variant Object::get()), so use a different name.
+		name = "script";
+	} else if (name.begins_with("Metadata/")) {
+		name = name.replace_first("Metadata/", "metadata/");
+	}
+
+	_ensure_resources_loaded();
+
+	for (const Ref<Resource> &r : loaded_resources) {
+		bool found;
+		r_ret = r->get(name, &found);
+		if (found) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void MultiResourceEdit::_get_property_list(List<PropertyInfo> *p_list) const {
+	HashMap<String, PLData> usage;
+	int rc = 0;
+	List<PLData *> data_list;
+
+	_ensure_resources_loaded();
+
+	for (const Ref<Resource> &r : loaded_resources) {
+		List<PropertyInfo> plist;
+		r->get_property_list(&plist, true);
+
+		for (PropertyInfo F : plist) {
+			if (F.name == "script") {
+				continue; // Added later manually, since this is intercepted before being set (check Variant Object::get()).
+			} else if (F.name.begins_with("metadata/")) {
+				F.name = F.name.replace_first("metadata/", "Metadata/"); // Trick to not get actual metadata edited from MultiResourceEdit.
+			}
+
+			PLData *usage_data = usage.getptr(F.name);
+			if (!usage_data) {
+				PLData pld;
+				pld.uses = 0;
+				pld.info = F;
+				pld.info.name = F.name;
+				HashMap<String, MultiResourceEdit::PLData>::Iterator I = usage.insert(F.name, pld);
+				usage_data = &I->value;
+				data_list.push_back(usage_data);
+			}
+
+			if (usage_data->info == F) {
+				usage_data->uses++;
+			}
+		}
+
+		rc++;
+	}
+
+	for (const PLData *E : data_list) {
+		if (rc == E->uses) {
+			p_list->push_back(E->info);
+		}
+	}
+
+	p_list->push_back(PropertyInfo(Variant::OBJECT, "scripts", PROPERTY_HINT_RESOURCE_TYPE, Script::get_class_static()));
+}
+
+String MultiResourceEdit::_get_editor_name() const {
+	return vformat(TTR("%s (%d Selected)"), get_edited_class_name(), get_resource_count());
+}
+
+bool MultiResourceEdit::_property_can_revert(const StringName &p_name) const {
+	if (ClassDB::has_property(get_edited_class_name(), p_name)) {
+		_ensure_resources_loaded();
+		return loaded_resources.size() > 0;
+	}
+	return false;
+}
+
+bool MultiResourceEdit::_property_get_revert(const StringName &p_name, Variant &r_property) const {
+	_ensure_resources_loaded();
+	for (const Ref<Resource> &r : loaded_resources) {
+		r_property = ClassDB::class_get_default_property_value(r->get_class_name(), p_name);
+		return true;
+	}
+	return false;
+}
+
+void MultiResourceEdit::_queue_notify_property_list_changed() {
+	if (notify_property_list_changed_pending) {
+		return;
+	}
+	notify_property_list_changed_pending = true;
+	callable_mp(this, &MultiResourceEdit::_notify_property_list_changed).call_deferred();
+}
+
+void MultiResourceEdit::_notify_property_list_changed() {
+	notify_property_list_changed_pending = false;
+	notify_property_list_changed();
+}
+
+void MultiResourceEdit::add_resource(const String &p_path) {
+	resource_paths.push_back(p_path);
+}
+
+int MultiResourceEdit::get_resource_count() const {
+	return resource_paths.size();
+}
+
+String MultiResourceEdit::get_resource_path(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, get_resource_count(), String());
+	return resource_paths[p_index];
+}
+
+Ref<Resource> MultiResourceEdit::get_resource(int p_index) const {
+	_ensure_resources_loaded();
+	ERR_FAIL_INDEX_V(p_index, loaded_resources.size(), Ref<Resource>());
+	return loaded_resources[p_index];
+}
+
+StringName MultiResourceEdit::get_edited_class_name() const {
+	_ensure_resources_loaded();
+
+	if (loaded_resources.is_empty()) {
+		return SNAME("Resource");
+	}
+
+	StringName class_name = loaded_resources[0]->get_class_name();
+
+	bool check_again = true;
+	while (check_again) {
+		check_again = false;
+
+		if (class_name.is_empty() || class_name == SNAME("Resource")) {
+			return SNAME("Resource");
+		}
+
+		for (const Ref<Resource> &r : loaded_resources) {
+			const StringName resource_class_name = r->get_class_name();
+			if (class_name == resource_class_name || ClassDB::is_parent_class(resource_class_name, class_name)) {
+				continue;
+			}
+
+			class_name = ClassDB::get_parent_class(class_name);
+			check_again = true;
+			break;
+		}
+	}
+
+	return class_name;
+}
+
+void MultiResourceEdit::set_property_field(const StringName &p_property, const Variant &p_value, const String &p_field) {
+	Variant::Type type = p_value.get_type();
+	if (type == Variant::ARRAY || type == Variant::DICTIONARY) {
+		_set_impl(p_property, p_value, "");
+	} else {
+		_set_impl(p_property, p_value, p_field);
+	}
+}
+
+void MultiResourceEdit::_bind_methods() {
+	ClassDB::bind_method("_hide_script_from_inspector", &MultiResourceEdit::_hide_script_from_inspector);
+	ClassDB::bind_method("_hide_metadata_from_inspector", &MultiResourceEdit::_hide_metadata_from_inspector);
+	ClassDB::bind_method("_get_editor_name", &MultiResourceEdit::_get_editor_name);
+}

--- a/editor/inspector/multi_resource_edit.h
+++ b/editor/inspector/multi_resource_edit.h
@@ -1,0 +1,92 @@
+/**************************************************************************/
+/*  multi_resource_edit.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/resource.h"
+
+class MultiResourceEdit : public RefCounted {
+	GDCLASS(MultiResourceEdit, RefCounted);
+
+	LocalVector<String> resource_paths;
+	mutable Vector<Ref<Resource>> loaded_resources;
+	mutable bool resources_loaded = false;
+
+	void _ensure_resources_loaded() const;
+	bool notify_property_list_changed_pending = false;
+	struct PLData {
+		int uses = 0;
+		PropertyInfo info;
+	};
+
+	bool _set_impl(const StringName &p_name, const Variant &p_value, const String &p_field, bool p_undo_redo = true);
+	void _queue_notify_property_list_changed();
+	void _notify_property_list_changed();
+
+protected:
+	static void _bind_methods();
+
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
+public:
+	bool _hide_script_from_inspector() { return true; }
+	bool _hide_metadata_from_inspector() { return true; }
+
+	bool _property_can_revert(const StringName &p_name) const;
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
+	String _get_editor_name() const;
+
+	void add_resource(const String &p_path);
+
+	int get_resource_count() const;
+	String get_resource_path(int p_index) const;
+	Ref<Resource> get_resource(int p_index) const;
+	StringName get_edited_class_name() const;
+
+	void set_property_field(const StringName &p_property, const Variant &p_value, const String &p_field);
+
+	bool is_same_selection(const MultiResourceEdit *p_other) const {
+		if (get_resource_count() != p_other->get_resource_count()) {
+			return false;
+		}
+		HashSet<String> paths_in_selection;
+		for (const String &path : p_other->resource_paths) {
+			paths_in_selection.insert(path);
+		}
+		for (const String &path : resource_paths) {
+			if (!paths_in_selection.has(path)) {
+				return false;
+			}
+		}
+		return true;
+	}
+};


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/13961

Implements multi-resource editing from the FileSystem dock. Selecting multiple resources of the same type opens a shared inspector like multi-node editing in the scene tree

- adds `MultiResourceEdit` class (modeled after MultiNodeEdit) that aggregates shared properties across selected resources
- property changes go through EditorUndoRedoManager for undo/redo support
- handles script and metadata/ property name translation
- connects property_list_changed to refresh the inspector when resource properties change
- EditorInspector handles MultiResourceEdit alongside MultiNodeEdit for category/section paste, favorites, doc hints, fieldwise editing etc
- works with any Resource type, not just materials
- hooks into both tree and file list multi-selection in FileSystemDock


