### PR TITLE
More scroll hint work around the editor

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -5568,6 +5568,8 @@ void AnimationTrackEditor::_notification(int p_what) {
 			bezier_key_mode->set_item_icon(bezier_key_mode->get_item_index(Animation::HANDLE_MODE_LINEAR), get_editor_theme_icon(SNAME("BezierHandlesLinear")));
 			bezier_key_mode->set_item_icon(bezier_key_mode->get_item_index(Animation::HANDLE_MODE_BALANCED), get_editor_theme_icon(SNAME("BezierHandlesBalanced")));
 			bezier_key_mode->set_item_icon(bezier_key_mode->get_item_index(Animation::HANDLE_MODE_MIRRORED), get_editor_theme_icon(SNAME("BezierHandlesMirror")));
+
+			_update_timeline_margins();
 		} break;
 
 		case NOTIFICATION_READY: {
@@ -7880,14 +7882,17 @@ float AnimationTrackEditor::get_snap_unit() {
 	return snap_unit;
 }
 
-void AnimationTrackEditor::_update_timeline_rtl_spacer() {
+void AnimationTrackEditor::_update_timeline_margins() {
+	int margin_left = timeline_mc->get_theme_constant(SNAME("margin_left"), SNAME("AnimationTrackMargins"));
+	int margin_right = timeline_mc->get_theme_constant(SNAME("margin_right"), SNAME("AnimationTrackMargins"));
+
+	// Prevent the timeline cursor from misaligning with the tracks on the right-to-left layout.
 	if (scroll->get_v_scroll_bar()->is_visible() && is_layout_rtl()) {
-		int spacer_width = scroll->get_v_scroll_bar()->get_minimum_size().width;
-		timeline_rtl_spacer->set_custom_minimum_size(Size2(spacer_width, 0));
-		timeline_rtl_spacer->show();
-	} else {
-		timeline_rtl_spacer->hide();
+		margin_left += scroll->get_v_scroll_bar()->get_minimum_size().width;
 	}
+
+	timeline_mc->add_theme_constant_override(SNAME("margin_left"), margin_left);
+	timeline_mc->add_theme_constant_override(SNAME("margin_right"), margin_right);
 }
 
 void AnimationTrackEditor::_add_animation_player() {
@@ -8067,13 +8072,12 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	add_animation_player->set_h_size_flags(SIZE_SHRINK_CENTER);
 	add_animation_player->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_add_animation_player));
 
-	HBoxContainer *hbox = memnew(HBoxContainer);
-	hbox->add_theme_constant_override(SNAME("separation"), 0);
-	timeline_vbox->add_child(hbox);
+	timeline_mc = memnew(MarginContainer);
+	timeline_mc->set_h_size_flags(SIZE_EXPAND_FILL);
+	timeline_vbox->add_child(timeline_mc);
 
 	timeline = memnew(AnimationTimelineEdit);
-	timeline->set_h_size_flags(SIZE_EXPAND_FILL);
-	hbox->add_child(timeline);
+	timeline_mc->add_child(timeline);
 	timeline->set_editor(this);
 	timeline->connect("timeline_changed", callable_mp(this, &AnimationTrackEditor::_timeline_changed));
 	timeline->connect("name_limit_changed", callable_mp(this, &AnimationTrackEditor::_name_limit_changed));
@@ -8081,11 +8085,6 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	timeline->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_timeline_value_changed));
 	timeline->connect("length_changed", callable_mp(this, &AnimationTrackEditor::_update_length));
 	timeline->connect("filter_changed", callable_mp(this, &AnimationTrackEditor::_update_tracks));
-
-	// If the animation editor is changed to take right-to-left into account, this won't be needed anymore.
-	timeline_rtl_spacer = memnew(Control);
-	timeline_rtl_spacer->hide();
-	hbox->add_child(timeline_rtl_spacer);
 
 	panner.instantiate();
 	panner->set_scroll_zoom_factor(AnimationTimelineEdit::SCROLL_ZOOM_FACTOR_IN);
@@ -8125,8 +8124,8 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	scroll->connect(SceneStringName(focus_exited), callable_mp(panner.ptr(), &ViewPanner::release_pan_key));
 
 	// Must be updated from here, so it guarantees that the scrollbar theme has already changed.
-	scroll->connect(SceneStringName(theme_changed), callable_mp(this, &AnimationTrackEditor::_update_timeline_rtl_spacer), CONNECT_DEFERRED);
-	scroll->get_v_scroll_bar()->connect(SceneStringName(visibility_changed), callable_mp(this, &AnimationTrackEditor::_update_timeline_rtl_spacer));
+	scroll->connect(SceneStringName(theme_changed), callable_mp(this, &AnimationTrackEditor::_update_timeline_margins), CONNECT_DEFERRED);
+	scroll->get_v_scroll_bar()->connect(SceneStringName(visibility_changed), callable_mp(this, &AnimationTrackEditor::_update_timeline_margins));
 	scroll->get_v_scroll_bar()->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_v_scroll_changed));
 	scroll->get_h_scroll_bar()->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_h_scroll_changed));
 
@@ -8139,9 +8138,13 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	timeline_vbox->add_child(hscroll);
 	timeline->set_hscroll(hscroll);
 
+	mc = memnew(MarginContainer);
+	mc->set_h_size_flags(SIZE_EXPAND_FILL);
+	mc->set_theme_type_variation("AnimationTrackMargins");
+	scroll->add_child(mc);
+
 	track_vbox = memnew(VBoxContainer);
-	scroll->add_child(track_vbox);
-	track_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
+	mc->add_child(track_vbox);
 	scroll->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 
 	HFlowContainer *bottom_hf = memnew(HFlowContainer);

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -617,8 +617,8 @@ class AnimationTrackEditor : public VBoxContainer {
 	AnimationBezierTrackEdit *bezier_edit = nullptr;
 	VBoxContainer *timeline_vbox = nullptr;
 
-	Control *timeline_rtl_spacer = nullptr;
-	void _update_timeline_rtl_spacer();
+	MarginContainer *timeline_mc = nullptr;
+	void _update_timeline_margins();
 
 	VBoxContainer *info_message_vbox = nullptr;
 	Label *info_message = nullptr;
@@ -896,7 +896,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _pick_track_filter_text_changed(const String &p_newtext);
 	void _pick_track_select_recursive(TreeItem *p_item, const String &p_filter, Vector<Node *> &p_select_candidates);
 
-	double snap_unit;
+	double snap_unit = 0;
 	bool fps_compatible = true;
 	int nearest_fps = 0;
 	void _update_snap_unit();

--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -736,7 +736,7 @@ void EditorAssetLibrary::_notification(int p_what) {
 			if (no_downloads == downloads_scroll->is_visible()) {
 				downloads_scroll->set_visible(!no_downloads);
 
-				library_mc->set_theme_type_variation(no_downloads ? "NoBorderHorizontalBottom" : "NoBorderHorizontal");
+				library_mc->set_theme_type_variation(no_downloads ? (Engine::get_singleton()->is_project_manager_hint() ? "NoBorderAssetLibProjectManager" : "NoBorderAssetLib") : "NoBorderHorizontal");
 				library_scroll->set_scroll_hint_mode(no_downloads ? ScrollContainer::SCROLL_HINT_MODE_TOP_AND_LEFT : ScrollContainer::SCROLL_HINT_MODE_ALL);
 			}
 
@@ -1735,7 +1735,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	/////////
 
 	library_mc = memnew(MarginContainer);
-	library_mc->set_theme_type_variation("NoBorderHorizontalBottom");
+	library_mc->set_theme_type_variation(Engine::get_singleton()->is_project_manager_hint() ? "NoBorderAssetLibProjectManager" : "NoBorderAssetLib");
 	library_mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	library_main->add_child(library_mc);
 

--- a/editor/docks/groups_editor.cpp
+++ b/editor/docks/groups_editor.cpp
@@ -912,7 +912,7 @@ GroupsEditor::GroupsEditor() {
 	hbc->add_child(filter);
 
 	MarginContainer *mc = memnew(MarginContainer);
-	mc->set_theme_type_variation("NoBorderHorizontalBottom");
+	mc->set_theme_type_variation("NoBorderHorizontalBottomWide");
 	mc->set_v_size_flags(SIZE_EXPAND_FILL);
 	holder->add_child(mc);
 

--- a/editor/inspector/property_selector.cpp
+++ b/editor/inspector/property_selector.cpp
@@ -34,6 +34,7 @@
 #include "editor/editor_node.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/line_edit.h"
+#include "scene/gui/margin_container.h"
 #include "scene/gui/tree.h"
 
 void PropertySelector::_text_changed(const String &p_newtext) {
@@ -668,19 +669,20 @@ void PropertySelector::_bind_methods() {
 PropertySelector::PropertySelector() {
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
+
 	search_box = memnew(LineEdit);
 	search_box->set_accessibility_name(TTRC("Search:"));
 	search_box->set_clear_button_enabled(true);
 	search_box->connect(SceneStringName(text_changed), callable_mp(this, &PropertySelector::_text_changed));
 	search_box->connect(SceneStringName(gui_input), callable_mp(this, &PropertySelector::_sbox_input));
 	vbc->add_margin_child(TTRC("Search:"), search_box);
+
 	search_options = memnew(Tree);
 	search_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	vbc->add_margin_child(TTRC("Matches:"), search_options, true);
-	set_ok_button_text(TTRC("Open"));
-	get_ok_button()->set_disabled(true);
-	register_text_enter(search_box);
-	set_hide_on_ok(false);
+	search_options->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
+	MarginContainer *mc = vbc->add_margin_child(TTRC("Matches:"), search_options, true);
+	mc->set_theme_type_variation("NoBorderHorizontalWindow");
+
 	search_options->connect("item_activated", callable_mp(this, &PropertySelector::_confirmed));
 	search_options->connect("cell_selected", callable_mp(this, &PropertySelector::_item_selected));
 	search_options->set_hide_root(true);
@@ -689,4 +691,9 @@ PropertySelector::PropertySelector() {
 	help_bit->set_content_height_limits(80 * EDSCALE, 80 * EDSCALE);
 	help_bit->connect("request_hide", callable_mp(this, &PropertySelector::_hide_requested));
 	vbc->add_margin_child(TTRC("Description:"), help_bit);
+
+	set_ok_button_text(TTRC("Open"));
+	get_ok_button()->set_disabled(true);
+	register_text_enter(search_box);
+	set_hide_on_ok(false);
 }

--- a/editor/inspector/property_selector.h
+++ b/editor/inspector/property_selector.h
@@ -54,7 +54,7 @@ class PropertySelector : public ConfirmationDialog {
 
 	bool properties = false;
 	String selected;
-	Variant::Type type;
+	Variant::Type type = Variant::NIL;
 	String base_type;
 	ObjectID script;
 	Object *instance = nullptr;

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -296,7 +296,7 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 		migration_guide_button->set_button_icon(get_editor_theme_icon("ExternalLink"));
 
 		// Asset library popup.
-		if (asset_library) {
+		if (asset_library && EDITOR_GET("interface/theme/style") == "Classic") {
 			// Removes extra border margins.
 			asset_library->add_theme_style_override(SceneStringName(panel), memnew(StyleBoxEmpty));
 		}

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -2398,14 +2398,19 @@ SceneTreeDialog::SceneTreeDialog() {
 	show_all_nodes->hide();
 	filter_hbc->add_child(show_all_nodes);
 
+	MarginContainer *mc = memnew(MarginContainer);
+	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	mc->set_theme_type_variation("NoBorderHorizontalWindow");
+	content->add_child(mc);
+
 	tree = memnew(SceneTreeEditor(false, false, true));
 	tree->set_update_when_invisible(false);
-	tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	tree->get_scene_tree()->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
 	tree->get_scene_tree()->connect("item_activated", callable_mp(this, &SceneTreeDialog::_select));
 	// Initialize button state, must be done after the tree has been created to update its 'show_all_nodes' flag.
 	// This is also done before adding the tree to the content to avoid triggering unnecessary tree filtering.
 	show_all_nodes->set_pressed(EditorSettings::get_singleton()->get_project_metadata("editor_metadata", "show_all_nodes_for_node_selection", false));
-	content->add_child(tree);
+	mc->add_child(tree);
 
 	// Disable the OK button when no node is selected.
 	get_ok_button()->set_disabled(!tree->get_selected());

--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -37,6 +37,7 @@
 #include "editor/settings/input_event_configuration_dialog.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/check_button.h"
+#include "scene/gui/margin_container.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/tree.h"
 
@@ -600,9 +601,13 @@ ActionMapEditor::ActionMapEditor() {
 
 	main_vbox->add_child(add_hbox);
 
+	MarginContainer *mc = memnew(MarginContainer);
+	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	mc->set_theme_type_variation("NoBorderHorizontalBottom");
+	main_vbox->add_child(mc);
+
 	// Action Editor Tree
 	action_tree = memnew(Tree);
-	action_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	action_tree->set_accessibility_name(TTRC("Action Map"));
 	action_tree->set_columns(3);
 	action_tree->set_hide_root(true);
@@ -617,7 +622,7 @@ ActionMapEditor::ActionMapEditor() {
 	action_tree->connect("item_edited", callable_mp(this, &ActionMapEditor::_action_edited), CONNECT_DEFERRED);
 	action_tree->connect("item_activated", callable_mp(this, &ActionMapEditor::_tree_item_activated));
 	action_tree->connect("button_clicked", callable_mp(this, &ActionMapEditor::_tree_button_pressed));
-	main_vbox->add_child(action_tree);
+	mc->add_child(action_tree);
 
 	SET_DRAG_FORWARDING_GCD(action_tree, ActionMapEditor);
 

--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -945,6 +945,11 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	add_autoload->set_disabled(true);
 	hbc->add_child(add_autoload);
 
+	MarginContainer *mc = memnew(MarginContainer);
+	mc->set_v_size_flags(SIZE_EXPAND_FILL);
+	mc->set_theme_type_variation("NoBorderHorizontalBottomWide");
+	add_child(mc);
+
 	tree = memnew(Tree);
 	tree->set_accessibility_name(TTRC("Autoloads"));
 	tree->set_hide_root(true);
@@ -976,9 +981,8 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	tree->connect("item_edited", callable_mp(this, &EditorAutoloadSettings::_autoload_edited));
 	tree->connect("button_clicked", callable_mp(this, &EditorAutoloadSettings::_autoload_button_pressed));
 	tree->connect("item_activated", callable_mp(this, &EditorAutoloadSettings::_autoload_activated));
-	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 
-	add_child(tree, true);
+	mc->add_child(tree, true);
 }
 
 EditorAutoloadSettings::~EditorAutoloadSettings() {

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -1008,9 +1008,13 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	shortcut_search_bar->connect(SceneStringName(value_changed), callable_mp(this, &EditorSettingsDialog::_update_shortcuts));
 	tab_shortcuts->add_child(shortcut_search_bar);
 
+	MarginContainer *mc = memnew(MarginContainer);
+	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	mc->set_theme_type_variation("NoBorderHorizontalBottom");
+	tab_shortcuts->add_child(mc);
+
 	shortcuts = memnew(Tree);
 	shortcuts->set_accessibility_name(TTRC("Shortcuts"));
-	shortcuts->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	shortcuts->set_columns(2);
 	shortcuts->set_hide_root(true);
 	shortcuts->set_column_titles_visible(true);
@@ -1018,7 +1022,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	shortcuts->set_column_title(1, TTRC("Binding"));
 	shortcuts->connect("button_clicked", callable_mp(this, &EditorSettingsDialog::_shortcut_button_pressed));
 	shortcuts->connect("item_activated", callable_mp(this, &EditorSettingsDialog::_shortcut_cell_double_clicked));
-	tab_shortcuts->add_child(shortcuts);
+	mc->add_child(shortcuts);
 
 	SET_DRAG_FORWARDING_GCD(shortcuts, EditorSettingsDialog);
 

--- a/editor/shader/shader_globals_editor.cpp
+++ b/editor/shader/shader_globals_editor.cpp
@@ -489,7 +489,7 @@ ShaderGlobalsEditor::ShaderGlobalsEditor() {
 	variable_add->connect(SceneStringName(pressed), callable_mp(this, &ShaderGlobalsEditor::_variable_added));
 
 	MarginContainer *mc = memnew(MarginContainer);
-	mc->set_theme_type_variation("NoBorderHorizontalBottom");
+	mc->set_theme_type_variation("NoBorderHorizontalBottomWide");
 	mc->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(mc);
 

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1937,10 +1937,31 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_constant("margin_left", "NoBorderHorizontal", margin);
 			p_theme->set_constant("margin_right", "NoBorderHorizontal", margin);
 
-			p_theme->set_type_variation("NoBorderHorizontalBottom", "MarginContainer");
-			p_theme->set_constant("margin_left", "NoBorderHorizontalBottom", margin);
-			p_theme->set_constant("margin_right", "NoBorderHorizontalBottom", margin);
+			p_theme->set_type_variation("NoBorderHorizontalBottom", "NoBorderHorizontal");
 			p_theme->set_constant("margin_bottom", "NoBorderHorizontalBottom", margin);
+
+			margin *= 2;
+
+			// Used in nested containers.
+			p_theme->set_type_variation("NoBorderHorizontalWide", "MarginContainer");
+			p_theme->set_constant("margin_left", "NoBorderHorizontalWide", margin);
+			p_theme->set_constant("margin_right", "NoBorderHorizontalWide", margin);
+
+			// Same as above, including the bottom.
+			p_theme->set_type_variation("NoBorderHorizontalBottomWide", "NoBorderHorizontalWide");
+			p_theme->set_constant("margin_bottom", "NoBorderHorizontalBottomWide", margin);
+
+			// Used in the asset library. Specifically, the ("bg", "AssetLib") stylebox.
+			p_theme->set_type_variation("NoBorderAssetLib", "NoBorderHorizontal");
+			p_theme->set_constant("margin_bottom", "NoBorderAssetLib", -p_config.base_margin);
+
+			margin = -panel_margin - p_config.base_margin;
+
+			// Same as above, but with the margins adapted for the project manager.
+			p_theme->set_type_variation("NoBorderAssetLibProjectManager", "NoBorderHorizontal");
+			p_theme->set_constant("margin_left", "NoBorderAssetLibProjectManager", margin);
+			p_theme->set_constant("margin_right", "NoBorderAssetLibProjectManager", margin);
+			p_theme->set_constant("margin_bottom", "NoBorderAssetLibProjectManager", margin);
 
 			int bottom_margin = p_theme->get_stylebox(SNAME("BottomPanel"), EditorStringName(EditorStyles))->get_content_margin(SIDE_LEFT);
 			margin = -bottom_margin;
@@ -2354,8 +2375,15 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 	// Animation Editor.
 	{
 		// Timeline general.
+
 		p_theme->set_constant("timeline_v_separation", "AnimationTrackEditor", 0);
 		p_theme->set_constant("track_v_separation", "AnimationTrackEditor", 0);
+
+		int margin = p_theme->get_stylebox(SceneStringName(panel), SNAME("PanelContainer"))->get_content_margin(SIDE_LEFT);
+
+		p_theme->set_type_variation("AnimationTrackMargins", "MarginContainer");
+		p_theme->set_constant("margin_left", "AnimationTrackMargins", margin);
+		p_theme->set_constant("margin_right", "AnimationTrackMargins", margin);
 
 		// AnimationTimelineEdit.
 		// "primary" is used for integer timeline values, "secondary" for decimals.

--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -753,7 +753,7 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_child(addtr);
 
 		MarginContainer *mc = memnew(MarginContainer);
-		mc->set_theme_type_variation("NoBorderHorizontalBottom");
+		mc->set_theme_type_variation("NoBorderHorizontalBottomWide");
 		mc->set_v_size_flags(SIZE_EXPAND_FILL);
 		tvb->add_child(mc);
 
@@ -791,7 +791,7 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_child(addtr);
 
 		MarginContainer *mc = memnew(MarginContainer);
-		mc->set_theme_type_variation("NoBorderHorizontal");
+		mc->set_theme_type_variation("NoBorderHorizontalWide");
 		mc->set_v_size_flags(SIZE_EXPAND_FILL);
 		tvb->add_child(mc);
 
@@ -819,7 +819,7 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_child(addtr);
 
 		mc = memnew(MarginContainer);
-		mc->set_theme_type_variation("NoBorderHorizontalBottom");
+		mc->set_theme_type_variation("NoBorderHorizontalBottomWide");
 		mc->set_v_size_flags(SIZE_EXPAND_FILL);
 		tvb->add_child(mc);
 
@@ -866,7 +866,7 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_child(template_generate_button);
 
 		MarginContainer *mc = memnew(MarginContainer);
-		mc->set_theme_type_variation("NoBorderHorizontal");
+		mc->set_theme_type_variation("NoBorderHorizontalWide");
 		mc->set_v_size_flags(SIZE_EXPAND_FILL);
 		tvb->add_child(mc);
 


### PR DESCRIPTION
- Add missing scroll hints for the property selector and scene tree editor.
- Fix scroll hints in nested containers not touching the borders.
- Fix missing padding in the animation editor in the modern theme.