### PR TITLE
Fix crash when trying to open Favorites externally

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2214,6 +2214,9 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			// Show the file/folder in the OS explorer.
 			String fpath = current_path;
 			if (current_path == "Favorites") {
+				if (p_selected.is_empty()) {
+					return;
+				}
 				fpath = p_selected[0];
 			}
 
@@ -2224,6 +2227,9 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		case FILE_MENU_OPEN_EXTERNAL: {
 			String fpath = current_path;
 			if (current_path == "Favorites") {
+				if (p_selected.is_empty()) {
+					return;
+				}
 				fpath = p_selected[0];
 			}
 
@@ -2261,6 +2267,9 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		case FILE_MENU_OPEN_IN_TERMINAL: {
 			String fpath = current_path;
 			if (current_path == "Favorites") {
+				if (p_selected.is_empty()) {
+					return;
+				}
 				fpath = p_selected[0];
 			}
 


### PR DESCRIPTION
Updated `FileSystemDock` logic for opening selection in terminal/external program/file manager to return early when only Favorites is selected.

Fixes #114629

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
