### PR TITLE
Clarify `align()` behavior regarding `force_update_scroll()`

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -18,6 +18,7 @@
 			<return type="void" />
 			<description>
 				Aligns the camera to the tracked node.
+				[b]Note:[/b] Calling [method force_update_scroll] after this method is not required.
 			</description>
 		</method>
 		<method name="force_update_scroll">


### PR DESCRIPTION
As noted in [this docs issue](https://github.com/godotengine/godot-docs/issues/7307), the Camera2D source code shows that align() calls _update_scroll(), which is also called by force_update_scroll(). This adds a note to the documentation to clarify that calling force_update_scroll() separately is not required.