### PR TITLE
Apply flip correctly when render region is used in OpenGL

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2597,7 +2597,8 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 		//pre z pass
 
 		if (render_data.render_region != Rect2i()) {
-			glViewport(render_data.render_region.position.x, render_data.render_region.position.y, render_data.render_region.size.width, render_data.render_region.size.height);
+			int32_t start_y = flip_y ? render_data.render_region.position.y : (rb->internal_size.y - (render_data.render_region.position.y + render_data.render_region.size.height));
+			glViewport(render_data.render_region.position.x, start_y, render_data.render_region.size.width, render_data.render_region.size.height);
 		}
 
 		scene_state.enable_gl_depth_test(true);
@@ -2685,7 +2686,8 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	uint64_t spec_constant_base_flags = 0;
 
 	if (render_data.render_region != Rect2i()) {
-		glViewport(render_data.render_region.position.x, render_data.render_region.position.y, render_data.render_region.size.width, render_data.render_region.size.height);
+		int32_t start_y = flip_y ? render_data.render_region.position.y : (rb->internal_size.y - (render_data.render_region.position.y + render_data.render_region.size.height));
+		glViewport(render_data.render_region.position.x, start_y, render_data.render_region.size.width, render_data.render_region.size.height);
 	}
 
 	{


### PR DESCRIPTION
When rendering for OpenXR in the compatibility renderer and using render region, we weren't adjusting the start offset correctly resulting in incorrect projection of the image:

<img width="1265" height="1387" alt="image" src="https://github.com/user-attachments/assets/719206d2-335e-45a7-8481-35329f9e7064" />

As you can see in the image above, we're correctly rendering "upside down" but we'd expect in this layout that the image would be in the bottom left corner, instead of the upper left corner. This PR adjusts this.

This was confirmed on SteamVR where dynamic resolution support was recently added. I have not been able to confirm whether the same issue exists on Quest 3 though it makes sense that it would. So far it seems however that dynamic render resolution on Quest may only be available on Vulkan where this issue does not apply.

Fixes: https://github.com/GodotVR/godot_openxr_vendors/issues/408