### PR TITLE
Reduction of TAA jitter positions for better motion clarity and reduced ghosting.

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/taa_resolve.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/taa_resolve.glsl
@@ -36,8 +36,8 @@
 #define GROUP_SIZE 8
 #define FLT_MIN 0.00000001
 #define FLT_MAX 32767.0
+#define RPC_2 0.5
 #define RPC_9 0.11111111111
-#define RPC_16 0.0625
 
 #define DISOCCLUSION_SCALE 0.01 // Scale the weight of this pixel calculated as (change in velocity - threshold) * scale.
 
@@ -330,7 +330,7 @@ vec3 temporal_antialiasing(uvec2 pos_group_top_left, uvec2 pos_group, uvec2 pos_
 	color_history = clip_history_3x3(pos_group, color_history, velocity_closest);
 
 	// Compute blend factor
-	float blend_factor = RPC_16; // We want to be able to accumulate as many jitter samples as we generated, that is, 16.
+	float blend_factor = RPC_2; // We want to be able to accumulate as many jitter samples as we generated, that is, 16.
 	{
 		// If re-projected UV is out of screen, converge to current color immediately.
 		float factor_screen = any(lessThan(uv_reprojected, vec2(0.0))) || any(greaterThan(uv_reprojected, vec2(1.0))) ? 1.0 : 0.0;

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2597,19 +2597,18 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 
 	Vector2 jitter;
 	float taa_frame_count = 0.0f;
+
 	if (p_jitter_phase_count > 0) {
 		uint32_t current_jitter_count = camera_jitter_array.size();
 		if (p_jitter_phase_count != current_jitter_count) {
-			// Resize the jitter array and fill it with the pre-computed Halton sequence.
 			camera_jitter_array.resize(p_jitter_phase_count);
-
-			for (uint32_t i = current_jitter_count; i < p_jitter_phase_count; i++) {
-				camera_jitter_array[i].x = get_halton_value(i, 2);
-				camera_jitter_array[i].y = get_halton_value(i, 3);
-			}
 		}
+		static const Vector2 flip2[2] = {
+			Vector2( 0.03f, -0.03f),
+			Vector2(-0.03f,  0.03f),
+		};
 
-		jitter = camera_jitter_array[RSG::rasterizer->get_frame_number() % p_jitter_phase_count] / p_viewport_size;
+		jitter = flip2[RSG::rasterizer->get_frame_number() % p_jitter_phase_count] / p_viewport_size;
 		taa_frame_count = float(RSG::rasterizer->get_frame_number() % p_jitter_phase_count);
 	}
 

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -259,7 +259,7 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 				jitter_phase_count = uint32_t(8.0f * std::pow(float(target_width) / render_width, 2.0f));
 			} else if (use_taa) {
 				// Default jitter count for TAA.
-				jitter_phase_count = 16;
+				jitter_phase_count = 2;
 			}
 
 			p_viewport->internal_size = Size2(render_width, render_height);


### PR DESCRIPTION
This is a basic 2 jitter position implementation that doesn't do any major changes to the current TAA implementation for now. In the scenes I was able to test, most of the issues present with the current TAA implementation are gone.

Here are some examples:
Videos:
Light ball test ([#68343](https://github.com/godotengine/godot/issues/68343)):
Master: https://github.com/user-attachments/assets/5be4bfd3-4d3d-488a-bfe9-fe47f847a7bb
My fork: https://github.com/user-attachments/assets/8d42003e-906f-4c76-80c1-e00f63a5c572
There is an improvement to the artifacting around the movable sphere, but there is an increase in aliasing since there is way less jitter positions.

FSR test ([#111631](https://github.com/godotengine/godot/pull/111631#issuecomment-3402282988)):
Master: https://github.com/user-attachments/assets/4f3d1ca8-d6c6-4e49-bd69-f9508177963e
My fork: https://github.com/user-attachments/assets/dc911f9c-c411-4126-9513-ab0fbc6199f5
Less jitter is noticeable in certain areas of the scene.

Thin geometry test:
Master: https://github.com/user-attachments/assets/23efbdb2-41fb-4cc8-b5ec-3e8e4ad9f4b
My fork: https://github.com/user-attachments/assets/9bb9b66f-30a8-4aec-84cb-a50b828765a2
The thin object is a lot less blurry and ghosting is almost non existent.

Screenshots:
Light ball test ([#68343](https://github.com/godotengine/godot/issues/68343)):
Master:
<img width="537" height="506" alt="Screenshot 2026-01-06 033003" src="https://github.com/user-attachments/assets/3461b6ea-85b5-420e-ab45-b5c070c6a2da" />
My fork:
<img width="506" height="522" alt="Screenshot 2026-01-06 033131" src="https://github.com/user-attachments/assets/c5788862-e474-49b4-8db5-6e5d5f038ad7" />
Even when I'm not moving the ball around the scene, I get an improvement in sharpness.

FSR test ([#111631](https://github.com/godotengine/godot/pull/111631#issuecomment-3402282988)):
Motion is needed to see the difference, no screenshots needed.

Thin geometry test:
Master:
<img width="494" height="877" alt="Screenshot 2026-01-06 032722" src="https://github.com/user-attachments/assets/bcd50e1a-1f9b-4f3e-8f45-e1b14f1fe9b1" />
My fork:
<img width="449" height="885" alt="Screenshot 2026-01-06 032757" src="https://github.com/user-attachments/assets/a53c0c5b-8b03-4635-a52d-b5222a5eb27c" />
The ghosting is barely noticeable if not completely gone and the object looks less blurry.

There is a caveat to all of this. There is a loss in anti-aliasing capability, but with the combination of other anti-aliasing techniques such as SMAA or FXAA, that issue can be mitigated. If someone wants to keep the previous TAA implementation, it might be possible to keep it when no other anti-aliasing solutions are turned on.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
