### PR TITLE
Select RESET animation by default when opening a scene in the editor

### DIFF
--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -1027,6 +1027,7 @@ void AnimationPlayerEditor::_update_player() {
 	player->get_animation_library_list(&libraries);
 
 	int active_idx = -1;
+	int reset_index = -1;
 	bool no_anims_found = true;
 	bool global_animation_library_is_readonly = false;
 	bool all_animation_libraries_are_readonly = libraries.size() > 0;
@@ -1056,6 +1057,9 @@ void AnimationPlayerEditor::_update_player() {
 				path += "/";
 			}
 			path += E;
+			if (E == SceneStringName(RESET)) {
+				reset_index = animation->get_item_count();
+			}
 			animation->add_item(path);
 			if (player->get_assigned_animation() == path) {
 				active_idx = animation->get_selectable_item(true);
@@ -1075,7 +1079,10 @@ void AnimationPlayerEditor::_update_player() {
 		autoplay->set_pressed(animation->get_item_text(active_idx) == player->get_autoplay());
 		_animation_selected(active_idx);
 	} else if (animation->has_selectable_items()) {
-		int item = animation->get_selectable_item();
+		int item = reset_index;
+		if (item == -1) {
+			item = animation->get_selectable_item();
+		}
 		animation->select(item);
 		autoplay->set_pressed(animation->get_item_text(item) == player->get_autoplay());
 		_animation_selected(item);


### PR DESCRIPTION
Currently, when opening a scene in the editor with an animation, and the animation editor is focused, the animation player editor plugin will auto-select the first animation alphabetically, and apply its paused T=0 state to the current scene immediately. This means that Godot immediately shows the scene not as it is in the original file.

This PR changes the logic so that the RESET animation, if it exists, will be selected by default in the editor. This only affects the editor, there is still no autoplay behavior or anything, it just means that the scene will be displayed in its default unanimated state as the RESET animation describes it to be.