### PR TITLE
Use the same (Metal/D3D12 -> Vulkan) init order in the RD support checks, BetsyCompressor, and lightmap baking.

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -377,7 +377,7 @@ public:
 
 #ifdef TOOLS_ENABLED
 	// Tests OpenGL context and Rendering Device simultaneous creation. This function is expected to crash on some NVIDIA drivers.
-	virtual bool _test_create_rendering_device_and_gl(const String &p_display_driver) const { return true; }
+	virtual bool _test_create_rendering_device_and_gl(const String &p_display_driver, const String &p_gl_driver) const { return true; }
 	virtual bool _test_create_rendering_device(const String &p_display_driver) const { return true; }
 #endif
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1069,6 +1069,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #if defined(TOOLS_ENABLED) && (defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED))
 	bool test_rd_creation = false;
 	bool test_rd_support = false;
+	String test_gl_driver;
 #endif
 	bool skip_breakpoints = false;
 	bool ignore_error_breaks = false;
@@ -1840,6 +1841,13 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			test_rd_support = true;
 		} else if (arg == "--test-rd-creation") {
 			test_rd_creation = true;
+			if (N) {
+				test_gl_driver = N->get();
+				N = N->next();
+			} else {
+				OS::get_singleton()->print("Missing GL driver argument, aborting.\n");
+				goto error;
+			}
 #endif // defined(TOOLS_ENABLED) && (defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED))
 		} else if (arg == "--remote-debug") {
 #if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
@@ -2129,7 +2137,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		// Test OpenGL context and Rendering Device simultaneous creation and exit.
 
 		OS::get_singleton()->set_crash_handler_silent();
-		if (OS::get_singleton()->_test_create_rendering_device_and_gl(display_driver)) {
+		if (OS::get_singleton()->_test_create_rendering_device_and_gl(display_driver, test_gl_driver)) {
 			exit_err = ERR_HELP;
 		} else {
 			exit_err = ERR_UNAVAILABLE;

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -86,41 +86,11 @@ void BetsyCompressor::_init() {
 	}
 
 	// Create local RD.
-	RenderingContextDriver *rcd = nullptr;
-	RenderingDevice *rd = RenderingServer::get_singleton()->create_local_rendering_device();
-
-	if (rd == nullptr) {
-#if defined(RD_ENABLED)
-#if defined(METAL_ENABLED)
-		rcd = memnew(RenderingContextDriverMetal);
-		rd = memnew(RenderingDevice);
-#endif
-#if defined(VULKAN_ENABLED)
-		if (rcd == nullptr) {
-			rcd = memnew(RenderingContextDriverVulkan);
-			rd = memnew(RenderingDevice);
-		}
-#endif
-#endif
-		if (rcd != nullptr && rd != nullptr) {
-			Error err = rcd->initialize();
-			if (err == OK) {
-				err = rd->initialize(rcd);
-			}
-
-			if (err != OK) {
-				memdelete(rd);
-				memdelete(rcd);
-				rd = nullptr;
-				rcd = nullptr;
-			}
-		}
-	}
+	RenderingDevice *rd = DisplayServer::create_local_rendering_device_with_fallback();
 
 	ERR_FAIL_NULL_MSG(rd, "Unable to create a local RenderingDevice.");
 
 	compress_rd = rd;
-	compress_rcd = rcd;
 
 	// Create the sampler state.
 	RD::SamplerState src_sampler_state;
@@ -302,10 +272,6 @@ void BetsyCompressor::_thread_exit() {
 		// Free the RD (and RCD if necessary).
 		memdelete(compress_rd);
 		compress_rd = nullptr;
-		if (compress_rcd != nullptr) {
-			memdelete(compress_rcd);
-			compress_rcd = nullptr;
-		}
 	}
 }
 

--- a/modules/betsy/image_compress_betsy.h
+++ b/modules/betsy/image_compress_betsy.h
@@ -38,13 +38,6 @@
 #include "servers/rendering/rendering_device_binds.h"
 #include "servers/rendering/rendering_server_default.h"
 
-#if defined(VULKAN_ENABLED)
-#include "drivers/vulkan/rendering_context_driver_vulkan.h"
-#endif
-#if defined(METAL_ENABLED)
-#include "drivers/metal/rendering_context_driver_metal.h"
-#endif
-
 enum BetsyFormat {
 	BETSY_FORMAT_BC1,
 	BETSY_FORMAT_BC1_DITHER,
@@ -114,7 +107,6 @@ class BetsyCompressor : public Object {
 
 	// Resources shared by all compression formats.
 	RenderingDevice *compress_rd = nullptr;
-	RenderingContextDriver *compress_rcd = nullptr;
 	BetsyShader cached_shaders[BETSY_SHADER_MAX];
 	RID src_sampler;
 

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -43,13 +43,6 @@
 #include "servers/rendering/rendering_device_binds.h"
 #include "servers/rendering/rendering_server_globals.h"
 
-#if defined(VULKAN_ENABLED)
-#include "drivers/vulkan/rendering_context_driver_vulkan.h"
-#endif
-#if defined(METAL_ENABLED)
-#include "drivers/metal/rendering_context_driver_metal.h"
-#endif
-
 //uncomment this if you want to see textures from all the process saved
 //#define DEBUG_TEXTURES
 
@@ -1122,36 +1115,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	// Attempt to create a local device by requesting it from rendering server first.
 	// If that fails because the current renderer is not implemented on top of RD, we fall back to creating
 	// a local rendering device manually depending on the current platform.
-	Error err;
-	RenderingContextDriver *rcd = nullptr;
-	RenderingDevice *rd = RenderingServer::get_singleton()->create_local_rendering_device();
-	if (rd == nullptr) {
-#if defined(RD_ENABLED)
-#if defined(METAL_ENABLED)
-		rcd = memnew(RenderingContextDriverMetal);
-		rd = memnew(RenderingDevice);
-#endif
-#if defined(VULKAN_ENABLED)
-		if (rcd == nullptr) {
-			rcd = memnew(RenderingContextDriverVulkan);
-			rd = memnew(RenderingDevice);
-		}
-#endif
-#endif
-		if (rcd != nullptr && rd != nullptr) {
-			err = rcd->initialize();
-			if (err == OK) {
-				err = rd->initialize(rcd);
-			}
-
-			if (err != OK) {
-				memdelete(rd);
-				memdelete(rcd);
-				rd = nullptr;
-				rcd = nullptr;
-			}
-		}
-	}
+	RenderingDevice *rd = DisplayServer::create_local_rendering_device_with_fallback();
 
 	ERR_FAIL_NULL_V(rd, BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES);
 
@@ -1367,9 +1331,6 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 			FREE_TEXTURES
 			FREE_BUFFERS
 			memdelete(rd);
-			if (rcd != nullptr) {
-				memdelete(rcd);
-			}
 			return BAKE_ERROR_USER_ABORTED;
 		}
 	}
@@ -1377,7 +1338,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	//shaders
 	Ref<RDShaderFile> raster_shader;
 	raster_shader.instantiate();
-	err = raster_shader->parse_versions_from_text(lm_raster_shader_glsl);
+	Error err = raster_shader->parse_versions_from_text(lm_raster_shader_glsl);
 	if (err != OK) {
 		raster_shader->print_errors("raster_shader");
 
@@ -1385,10 +1346,6 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		FREE_BUFFERS
 
 		memdelete(rd);
-
-		if (rcd != nullptr) {
-			memdelete(rcd);
-		}
 	}
 	ERR_FAIL_COND_V(err != OK, BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES);
 
@@ -1567,10 +1524,6 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		FREE_RASTER_RESOURCES
 		memdelete(rd);
 
-		if (rcd != nullptr) {
-			memdelete(rcd);
-		}
-
 		compute_shader->print_errors("compute_shader");
 	}
 	ERR_FAIL_COND_V(err != OK, BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES);
@@ -1614,9 +1567,6 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 			FREE_RASTER_RESOURCES
 			FREE_COMPUTE_RESOURCES
 			memdelete(rd);
-			if (rcd != nullptr) {
-				memdelete(rcd);
-			}
 			return BAKE_ERROR_USER_ABORTED;
 		}
 	}
@@ -1675,9 +1625,6 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 			FREE_RASTER_RESOURCES
 			FREE_COMPUTE_RESOURCES
 			memdelete(rd);
-			if (rcd != nullptr) {
-				memdelete(rcd);
-			}
 			return BAKE_ERROR_USER_ABORTED;
 		}
 	}
@@ -1792,9 +1739,6 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 							FREE_RASTER_RESOURCES
 							FREE_COMPUTE_RESOURCES
 							memdelete(rd);
-							if (rcd != nullptr) {
-								memdelete(rcd);
-							}
 							return BAKE_ERROR_USER_ABORTED;
 						}
 					}
@@ -1883,9 +1827,6 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 				FREE_RASTER_RESOURCES
 				FREE_COMPUTE_RESOURCES
 				memdelete(rd);
-				if (rcd != nullptr) {
-					memdelete(rcd);
-				}
 				return BAKE_ERROR_USER_ABORTED;
 			}
 		}
@@ -1932,9 +1873,6 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 								FREE_RASTER_RESOURCES
 								FREE_COMPUTE_RESOURCES
 								memdelete(rd);
-								if (rcd != nullptr) {
-									memdelete(rcd);
-								}
 								return BAKE_ERROR_USER_ABORTED;
 							}
 						}
@@ -1961,9 +1899,6 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 					rd->free_rid(light_probe_buffer);
 				}
 				memdelete(rd);
-				if (rcd != nullptr) {
-					memdelete(rcd);
-				}
 				return BAKE_ERROR_USER_ABORTED;
 			}
 		}
@@ -2042,9 +1977,6 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 						rd->free_rid(light_probe_buffer);
 					}
 					memdelete(rd);
-					if (rcd != nullptr) {
-						memdelete(rcd);
-					}
 					return BAKE_ERROR_USER_ABORTED;
 				}
 			}
@@ -2085,9 +2017,6 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 					rd->free_rid(light_probe_buffer);
 				}
 				memdelete(rd);
-				if (rcd != nullptr) {
-					memdelete(rcd);
-				}
 				return BAKE_ERROR_USER_ABORTED;
 			}
 		}
@@ -2161,10 +2090,6 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		FREE_RASTER_RESOURCES
 		FREE_COMPUTE_RESOURCES
 		memdelete(rd);
-
-		if (rcd != nullptr) {
-			memdelete(rcd);
-		}
 
 		blendseams_shader->print_errors("blendseams_shader");
 	}
@@ -2349,10 +2274,6 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	FREE_BLENDSEAMS_RESOURCES
 
 	memdelete(rd);
-
-	if (rcd != nullptr) {
-		memdelete(rcd);
-	}
 
 	return BAKE_OK;
 }

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -1259,7 +1259,7 @@ bool OS_LinuxBSD::_test_create_rendering_device(const String &p_display_driver) 
 	return ok;
 }
 
-bool OS_LinuxBSD::_test_create_rendering_device_and_gl(const String &p_display_driver) const {
+bool OS_LinuxBSD::_test_create_rendering_device_and_gl(const String &p_display_driver, const String &p_gl_driver) const {
 	// Tests OpenGL context and Rendering Device simultaneous creation. This function is expected to crash on some drivers.
 
 #ifdef GLES3_ENABLED

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -139,7 +139,7 @@ public:
 	virtual String get_system_ca_certificates() override;
 
 #ifdef TOOLS_ENABLED
-	virtual bool _test_create_rendering_device_and_gl(const String &p_display_driver) const override;
+	virtual bool _test_create_rendering_device_and_gl(const String &p_display_driver, const String &p_gl_driver) const override;
 	virtual bool _test_create_rendering_device(const String &p_display_driver) const override;
 #endif
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -70,6 +70,7 @@
 #endif
 
 #if defined(GLES3_ENABLED)
+#include "gl_manager_windows_angle.h"
 #include "gl_manager_windows_native.h"
 #endif
 
@@ -2664,12 +2665,12 @@ bool OS_Windows::_test_create_rendering_device(const String &p_display_driver) c
 	Error err;
 	RenderingContextDriver *rcd = nullptr;
 
-#if defined(VULKAN_ENABLED)
-	rcd = memnew(RenderingContextDriverVulkan);
-#endif
 #ifdef D3D12_ENABLED
+	rcd = memnew(RenderingContextDriverD3D12);
+#endif
+#if defined(VULKAN_ENABLED)
 	if (rcd == nullptr) {
-		rcd = memnew(RenderingContextDriverD3D12);
+		rcd = memnew(RenderingContextDriverVulkan);
 	}
 #endif
 	if (rcd != nullptr) {
@@ -2691,7 +2692,7 @@ bool OS_Windows::_test_create_rendering_device(const String &p_display_driver) c
 	return ok;
 }
 
-bool OS_Windows::_test_create_rendering_device_and_gl(const String &p_display_driver) const {
+bool OS_Windows::_test_create_rendering_device_and_gl(const String &p_display_driver, const String &p_gl_driver) const {
 	// Tests OpenGL context and Rendering Device simultaneous creation. This function is expected to crash on some NVIDIA drivers.
 
 	WNDCLASSEXW wc_probe;
@@ -2720,11 +2721,22 @@ bool OS_Windows::_test_create_rendering_device_and_gl(const String &p_display_dr
 
 	bool ok = true;
 #ifdef GLES3_ENABLED
-	GLManagerNative_Windows *test_gl_manager_native = memnew(GLManagerNative_Windows);
-	if (test_gl_manager_native->window_create(DisplayServer::MAIN_WINDOW_ID, hWnd, GetModuleHandle(nullptr), 800, 600) == OK) {
-		RasterizerGLES3::make_current(true);
+	GLManagerANGLE_Windows *test_gl_manager_angle = nullptr;
+	GLManagerNative_Windows *test_gl_manager_native = nullptr;
+	if (p_gl_driver == "opengl3_angle") {
+		test_gl_manager_angle = memnew(GLManagerANGLE_Windows);
+		if (test_gl_manager_angle->window_create(DisplayServer::MAIN_WINDOW_ID, nullptr, hWnd, 800, 600) == OK) {
+			RasterizerGLES3::make_current(true);
+		} else {
+			ok = false;
+		}
 	} else {
-		ok = false;
+		test_gl_manager_native = memnew(GLManagerNative_Windows);
+		if (test_gl_manager_native->window_create(DisplayServer::MAIN_WINDOW_ID, hWnd, GetModuleHandle(nullptr), 800, 600) == OK) {
+			RasterizerGLES3::make_current(true);
+		} else {
+			ok = false;
+		}
 	}
 #endif
 
@@ -2739,6 +2751,9 @@ bool OS_Windows::_test_create_rendering_device_and_gl(const String &p_display_dr
 	}
 
 #ifdef GLES3_ENABLED
+	if (test_gl_manager_angle) {
+		memdelete(test_gl_manager_angle);
+	}
 	if (test_gl_manager_native) {
 		memdelete(test_gl_manager_native);
 	}

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -268,7 +268,7 @@ public:
 	void set_main_window(HWND p_main_window) { main_window = p_main_window; }
 
 #ifdef TOOLS_ENABLED
-	virtual bool _test_create_rendering_device_and_gl(const String &p_display_driver) const override;
+	virtual bool _test_create_rendering_device_and_gl(const String &p_display_driver, const String &p_gl_driver) const override;
 	virtual bool _test_create_rendering_device(const String &p_display_driver) const override;
 #endif
 

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -47,6 +47,7 @@
 #endif
 
 DisplayServer *DisplayServer::singleton = nullptr;
+RenderingContextDriver *DisplayServer::local_rcd = nullptr;
 
 DisplayServer::AccessibilityMode DisplayServer::accessibility_mode = DisplayServer::AccessibilityMode::ACCESSIBILITY_AUTO;
 
@@ -1968,6 +1969,58 @@ void DisplayServer::_input_set_custom_mouse_cursor_func(const Ref<Resource> &p_i
 	singleton->cursor_set_custom_image(p_image, (CursorShape)p_shape, p_hotspot);
 }
 
+RenderingDevice *DisplayServer::create_local_rendering_device_with_fallback() {
+	RenderingDevice *rd = RenderingServer::get_singleton()->create_local_rendering_device();
+	if (rd == nullptr) {
+#ifdef METAL_ENABLED
+		if (local_rcd == nullptr) {
+			GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunguarded-availability")
+			// Eliminate "RenderingContextDriverMetal is only available on iOS 14.0 or newer".
+			local_rcd = memnew(RenderingContextDriverMetal);
+			if (local_rcd) {
+				if (local_rcd->initialize() != OK) {
+					memdelete(local_rcd);
+					local_rcd = nullptr;
+				}
+			}
+			GODOT_CLANG_WARNING_POP
+		}
+#endif
+#ifdef D3D12_ENABLED
+		if (local_rcd == nullptr) {
+			local_rcd = memnew(RenderingContextDriverD3D12);
+			if (local_rcd) {
+				if (local_rcd->initialize() != OK) {
+					memdelete(local_rcd);
+					local_rcd = nullptr;
+				}
+			}
+		}
+#endif
+#if defined(VULKAN_ENABLED)
+		if (local_rcd == nullptr) {
+			local_rcd = memnew(RenderingContextDriverVulkan);
+			if (local_rcd) {
+				if (local_rcd->initialize() != OK) {
+					memdelete(local_rcd);
+					local_rcd = nullptr;
+				}
+			}
+		}
+#endif
+		if (local_rcd != nullptr) {
+			rd = memnew(RenderingDevice);
+			if (rd != nullptr) {
+				if (rd->initialize(local_rcd) != OK) {
+					memdelete(rd);
+					rd = nullptr;
+				}
+			}
+		}
+	}
+	return rd;
+}
+
 bool DisplayServer::is_rendering_device_supported() {
 #if defined(RD_ENABLED)
 	RenderingDevice *device = RenderingDevice::get_singleton();
@@ -1981,8 +2034,6 @@ bool DisplayServer::is_rendering_device_supported() {
 		return false;
 	}
 
-	Error err;
-
 #if defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED)
 	// On some drivers combining OpenGL and RenderingDevice can result in crash, offload the check to the subprocess.
 	List<String> arguments;
@@ -1994,58 +2045,25 @@ bool DisplayServer::is_rendering_device_supported() {
 
 	String pipe;
 	int exitcode = 0;
-	err = OS::get_singleton()->execute(OS::get_singleton()->get_executable_path(), arguments, &pipe, &exitcode);
+	Error err = OS::get_singleton()->execute(OS::get_singleton()->get_executable_path(), arguments, &pipe, &exitcode);
 	if (err == OK && exitcode == 0) {
 		supported_rendering_device = RenderingDeviceCreationStatus::SUCCESS;
 		return true;
 	} else {
 		supported_rendering_device = RenderingDeviceCreationStatus::FAILURE;
 	}
-#else // WINDOWS_ENABLED
+#else // defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED)
 
-	RenderingContextDriver *rcd = nullptr;
-
-#if defined(VULKAN_ENABLED)
-	rcd = memnew(RenderingContextDriverVulkan);
-#endif
-#ifdef D3D12_ENABLED
-	if (rcd == nullptr) {
-		rcd = memnew(RenderingContextDriverD3D12);
-	}
-#endif
-#ifdef METAL_ENABLED
-	if (rcd == nullptr) {
-		GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunguarded-availability")
-		// Eliminate "RenderingContextDriverMetal is only available on iOS 14.0 or newer".
-		rcd = memnew(RenderingContextDriverMetal);
-		GODOT_CLANG_WARNING_POP
-	}
-#endif
-
-	if (rcd != nullptr) {
-		err = rcd->initialize();
-		if (err == OK) {
-			RenderingDevice *rd = memnew(RenderingDevice);
-			err = rd->initialize(rcd);
-			memdelete(rd);
-			rd = nullptr;
-			if (err == OK) {
-				// Creating a RenderingDevice is quite slow.
-				// Cache the result for future usage, so that it's much faster on subsequent calls.
-				supported_rendering_device = RenderingDeviceCreationStatus::SUCCESS;
-				memdelete(rcd);
-				rcd = nullptr;
-				return true;
-			} else {
-				supported_rendering_device = RenderingDeviceCreationStatus::FAILURE;
-			}
-		}
-
-		memdelete(rcd);
-		rcd = nullptr;
+	RenderingDevice *rd = create_local_rendering_device_with_fallback();
+	if (rd) {
+		memdelete(rd);
+		supported_rendering_device = RenderingDeviceCreationStatus::SUCCESS;
+		return true;
+	} else {
+		supported_rendering_device = RenderingDeviceCreationStatus::FAILURE;
 	}
 
-#endif // WINDOWS_ENABLED
+#endif // defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED)
 #endif // RD_ENABLED
 	return false;
 }
@@ -2067,16 +2085,15 @@ bool DisplayServer::can_create_rendering_device() {
 		return false;
 	}
 
-	Error err;
-
 #ifdef WINDOWS_ENABLED
 	// On some NVIDIA drivers combining OpenGL and RenderingDevice can result in crash, offload the check to the subprocess.
 	List<String> arguments;
 	arguments.push_back("--test-rd-creation");
+	arguments.push_back(OS::get_singleton()->get_current_rendering_driver_name());
 
 	String pipe;
 	int exitcode = 0;
-	err = OS::get_singleton()->execute(OS::get_singleton()->get_executable_path(), arguments, &pipe, &exitcode);
+	Error err = OS::get_singleton()->execute(OS::get_singleton()->get_executable_path(), arguments, &pipe, &exitcode);
 	if (err == OK && exitcode == 0) {
 		created_rendering_device = RenderingDeviceCreationStatus::SUCCESS;
 		return true;
@@ -2085,48 +2102,14 @@ bool DisplayServer::can_create_rendering_device() {
 	}
 #else // WINDOWS_ENABLED
 
-	RenderingContextDriver *rcd = nullptr;
-
-#if defined(VULKAN_ENABLED)
-	rcd = memnew(RenderingContextDriverVulkan);
-#endif
-#ifdef D3D12_ENABLED
-	if (rcd == nullptr) {
-		rcd = memnew(RenderingContextDriverD3D12);
+	RenderingDevice *rd = create_local_rendering_device_with_fallback();
+	if (rd) {
+		memdelete(rd);
+		created_rendering_device = RenderingDeviceCreationStatus::SUCCESS;
+		return true;
+	} else {
+		created_rendering_device = RenderingDeviceCreationStatus::FAILURE;
 	}
-#endif
-#ifdef METAL_ENABLED
-	if (rcd == nullptr) {
-		GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wunguarded-availability")
-		// Eliminate "RenderingContextDriverMetal is only available on iOS 14.0 or newer".
-		rcd = memnew(RenderingContextDriverMetal);
-		GODOT_CLANG_WARNING_POP
-	}
-#endif
-
-	if (rcd != nullptr) {
-		err = rcd->initialize();
-		if (err == OK) {
-			RenderingDevice *rd = memnew(RenderingDevice);
-			err = rd->initialize(rcd);
-			memdelete(rd);
-			rd = nullptr;
-			if (err == OK) {
-				// Creating a RenderingDevice is quite slow.
-				// Cache the result for future usage, so that it's much faster on subsequent calls.
-				created_rendering_device = RenderingDeviceCreationStatus::SUCCESS;
-				memdelete(rcd);
-				rcd = nullptr;
-				return true;
-			} else {
-				created_rendering_device = RenderingDeviceCreationStatus::FAILURE;
-			}
-		}
-
-		memdelete(rcd);
-		rcd = nullptr;
-	}
-
 #endif // WINDOWS_ENABLED
 #endif // RD_ENABLED
 	return false;
@@ -2147,4 +2130,8 @@ DisplayServer::DisplayServer() {
 
 DisplayServer::~DisplayServer() {
 	singleton = nullptr;
+	if (local_rcd != nullptr) {
+		memdelete(local_rcd);
+		local_rcd = nullptr;
+	}
 }

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -39,6 +39,8 @@
 
 class Texture2D;
 class AccessibilityDriver;
+class RenderingDevice;
+class RenderingContextDriver;
 
 class DisplayServer : public Object {
 	GDCLASS(DisplayServer, Object)
@@ -898,8 +900,13 @@ public:
 	static inline RenderingDeviceCreationStatus created_rendering_device = RenderingDeviceCreationStatus::UNKNOWN;
 	static bool can_create_rendering_device();
 
+private:
+	static RenderingContextDriver *local_rcd;
+
+public:
 	static inline RenderingDeviceCreationStatus supported_rendering_device = RenderingDeviceCreationStatus::UNKNOWN;
 	static bool is_rendering_device_supported();
+	static RenderingDevice *create_local_rendering_device_with_fallback();
 
 	DisplayServer();
 	~DisplayServer();


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/114067