### PR TITLE
Fix pattern corruption in `TileMapLayer`

### DIFF
--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -2125,7 +2125,7 @@ void TileMapLayerEditorTilesPlugin::edit(ObjectID p_tile_map_layer_id) {
 		}
 	}
 
-	TileMapLayer *new_tile_map_layer = ObjectDB::get_instance<TileMapLayer>(edited_tile_map_layer_id);
+	TileMapLayer *new_tile_map_layer = ObjectDB::get_instance<TileMapLayer>(p_tile_map_layer_id);
 	Ref<TileSet> new_tile_set;
 	if (new_tile_map_layer) {
 		new_tile_set = new_tile_map_layer->get_tile_set();


### PR DESCRIPTION
Fixes #106289. Tested in Win 11.
As not that familiar with the project yet, it is yet a draft pull request.

Reusing previous TileMapLayer's `selection_pattern` causes the issue.
The change is to rudely call `selection_pattern.instantiate()` when the `tile_set_changed()` is called in class `TileMapLayerEditorTilesPlugin`. As `selection_pattern.instantiate()` is already there in the`_update_fix_selected_and_hovered()` function, simply get it out of the conditions.

Update:

Found that there's already a check for TileSet changes in `TileMapLayerEditorTilesPlugin::edit`. However, the `edited_layer` and `new_tile_map_layer` to be compared are pointing to the same location with given the `edited_tile_map_layer_id` both.
Changed the id of `new_tile_map_layer` to `p_tile_map_layer_id`, which it should be in context.

Many thanks to @groud 's help and advice.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
