### PR TITLE
GDScript: Only move root scripts in cache

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1095,7 +1095,9 @@ void GDScript::set_path(const String &p_path, bool p_take_over) {
 	String old_path = path;
 	path = p_path;
 	path_valid = true;
-	GDScriptCache::move_script(old_path, p_path);
+	if (is_root_script()) {
+		GDScriptCache::move_script(old_path, p_path);
+	}
 
 	for (KeyValue<StringName, Ref<GDScript>> &kv : subclasses) {
 		kv.value->set_path(p_path, p_take_over);


### PR DESCRIPTION
Fixes somewhat https://github.com/godotengine/godot/issues/105485

When an inner class gets to the resource saver for packed scenes it will look like a builtin resource and the resource loader will assign it a builtin id. Previously this would move the main scripts entry in the gdscript cache to this builtin path which makes the cache inconsistent and a second script could be created for the original path, leading to the duplicated script.

This PR prevents the inconsistent cache. It does not intervene when a resource safer tries to safe the inner class. So this might still cause less visible issues. But due to the strange status of builtin classes I'm not really sure how this should be handled since inner classes are just not serializable. So let's go with the ostrich algorithm for now!