### PR TITLE
Fix visibility range check for Omni/Spot light shadow culling

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2433,6 +2433,13 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 							}
 						}
 
+						if (instance->array_index >= 0) {
+							int32_t vis_idx = p_scenario->instance_data[instance->array_index].visibility_index;
+							if (vis_idx != -1) {
+								continue;
+							}
+						}
+
 						shadow_data.instances.push_back(static_cast<InstanceGeometryData *>(instance->base_data)->geometry_instance);
 					}
 
@@ -2515,6 +2522,13 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 							}
 						}
 
+						if (instance->array_index >= 0) {
+							int32_t vis_idx = p_scenario->instance_data[instance->array_index].visibility_index;
+							if (vis_idx != -1) {
+								continue;
+							}
+						}
+
 						shadow_data.instances.push_back(static_cast<InstanceGeometryData *>(instance->base_data)->geometry_instance);
 					}
 
@@ -2583,6 +2597,14 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 						RSG::mesh_storage->mesh_instance_check_for_update(instance->mesh_instance);
 					}
 				}
+
+				if (instance->array_index >= 0) {
+					int32_t vis_idx = p_scenario->instance_data[instance->array_index].visibility_index;
+					if (vis_idx != -1) {
+						continue;
+					}
+				}
+
 				shadow_data.instances.push_back(static_cast<InstanceGeometryData *>(instance->base_data)->geometry_instance);
 			}
 


### PR DESCRIPTION
Description:

Fixes #98993

Omni and Spot light shadow culling in _light_instance_update_shadow() was missing the visibility range check that directional light shadows have in _scene_cull(). This caused objects to cast shadows even when hidden by visibility range.

Adds the visibility range distance check to all three shadow culling paths (omni dual paraboloid, omni cube, spot).
Example of fix:
[Example.webm](https://github.com/user-attachments/assets/83672fff-cf64-4381-a80a-02728955c3f5)

And example of 4.6-beta2 on MRP:
<img width="555" height="440" alt="Screenshot_20260106_135741" src="https://github.com/user-attachments/assets/fc2ebc48-61d7-49db-a17f-74641eccce27" />
And the fix on MRP:
<img width="653" height="538" alt="Screenshot_20260106_135829" src="https://github.com/user-attachments/assets/526ce03f-bc71-4404-b37c-6617a7eb1749" />
