### PR TITLE
Default 3D model importer naming versions to the latest version

### DIFF
--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
@@ -144,10 +144,4 @@ void EditorSceneFormatImporterFBX2GLTF::handle_compatibility_options(HashMap<Str
 	if (!p_import_params.has("fbx/importer")) {
 		p_import_params["fbx/importer"] = EditorSceneFormatImporterUFBX::FBX_IMPORTER_UFBX;
 	}
-	if (!p_import_params.has("fbx/naming_version")) {
-		// If a .fbx's existing import file is missing the FBX
-		// naming compatibility version, we need to use version 1.
-		// Version 1 is the behavior before this option was added.
-		p_import_params["fbx/naming_version"] = 1;
-	}
 }

--- a/modules/fbx/editor/editor_scene_importer_ufbx.cpp
+++ b/modules/fbx/editor/editor_scene_importer_ufbx.cpp
@@ -106,10 +106,4 @@ void EditorSceneFormatImporterUFBX::handle_compatibility_options(HashMap<StringN
 	if (!p_import_params.has("fbx/importer")) {
 		p_import_params["fbx/importer"] = EditorSceneFormatImporterUFBX::FBX_IMPORTER_FBX2GLTF;
 	}
-	if (!p_import_params.has("fbx/naming_version")) {
-		// If a .fbx's existing import file is missing the FBX
-		// naming compatibility version, we need to use version 1.
-		// Version 1 is the behavior before this option was added.
-		p_import_params["fbx/naming_version"] = 1;
-	}
 }

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -389,15 +389,6 @@ void EditorSceneFormatImporterBlend::get_import_options(const String &p_path, Li
 	r_options->push_back(ResourceImporterScene::ImportOption(PropertyInfo(Variant::INT, "gltf/naming_version", PROPERTY_HINT_ENUM, "Godot 4.0 or 4.1,Godot 4.2 to 4.4,Godot 4.5 or later"), 2));
 }
 
-void EditorSceneFormatImporterBlend::handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const {
-	if (!p_import_params.has("gltf/naming_version")) {
-		// If a .blend's existing import file is missing the glTF
-		// naming compatibility version, we need to use version 1.
-		// Version 1 is the behavior before this option was added.
-		p_import_params["gltf/naming_version"] = 1;
-	}
-}
-
 ///////////////////////////
 
 static bool _test_blender_path(const String &p_path, String *r_err = nullptr) {

--- a/modules/gltf/editor/editor_scene_importer_blend.h
+++ b/modules/gltf/editor/editor_scene_importer_blend.h
@@ -73,7 +73,6 @@ public:
 			List<ResourceImporter::ImportOption> *r_options) override;
 	virtual Variant get_option_visibility(const String &p_path, const String &p_scene_import_type, const String &p_option,
 			const HashMap<StringName, Variant> &p_options) override;
-	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const override;
 };
 
 class LineEdit;

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -89,14 +89,6 @@ void EditorSceneFormatImporterGLTF::get_import_options(const String &p_path,
 	}
 }
 
-void EditorSceneFormatImporterGLTF::handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const {
-	if (!p_import_params.has("gltf/naming_version")) {
-		// If an existing import file is missing the glTF
-		// compatibility version, we need to use version 0.
-		p_import_params["gltf/naming_version"] = 0;
-	}
-}
-
 Variant EditorSceneFormatImporterGLTF::get_option_visibility(const String &p_path, const String &p_scene_import_type,
 		const String &p_option, const HashMap<StringName, Variant> &p_options) {
 	return true;

--- a/modules/gltf/editor/editor_scene_importer_gltf.h
+++ b/modules/gltf/editor/editor_scene_importer_gltf.h
@@ -45,7 +45,6 @@ public:
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;
 	virtual void get_import_options(const String &p_path,
 			List<ResourceImporter::ImportOption> *r_options) override;
-	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const override;
 	virtual Variant get_option_visibility(const String &p_path, const String &p_scene_import_type,
 			const String &p_option, const HashMap<StringName, Variant> &p_options) override;
 };


### PR DESCRIPTION
This was suggested by @lyuma. Fixes #112405.

This PR defaults the naming version to the latest, removing the compatibility code. There are concerns that, long-term, this causes more problems than it solves, because a corrupt `.import` file will be treated the same as a file from Godot 4.0/4.1. This is a pure deletion of the compatibility code, resulting in the naming version using the current/latest value instead.

Note: This only affects editor imports of 3D models. Runtime imports already use the latest version by default.