### PR TITLE
Add `[JsonInclude]` and `[JsonIgnore]` attributes in C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -14,13 +15,16 @@ namespace Godot
     [StructLayout(LayoutKind.Sequential)]
     public struct Aabb : IEquatable<Aabb>
     {
+        [JsonIgnore]
         private Vector3 _position;
+        [JsonIgnore]
         private Vector3 _size;
 
         /// <summary>
         /// Beginning corner. Typically has values lower than <see cref="End"/>.
         /// </summary>
         /// <value>Directly uses a private field.</value>
+        [JsonInclude]
         public Vector3 Position
         {
             readonly get { return _position; }
@@ -32,6 +36,7 @@ namespace Godot
         /// If the size is negative, you can use <see cref="Abs"/> to fix it.
         /// </summary>
         /// <value>Directly uses a private field.</value>
+        [JsonInclude]
         public Vector3 Size
         {
             readonly get { return _size; }
@@ -46,6 +51,7 @@ namespace Godot
         /// Getting is equivalent to <paramref name="value"/> = <see cref="Position"/> + <see cref="Size"/>,
         /// setting is equivalent to <see cref="Size"/> = <paramref name="value"/> - <see cref="Position"/>
         /// </value>
+        [JsonIgnore]
         public Vector3 End
         {
             readonly get { return _position + _size; }
@@ -56,6 +62,7 @@ namespace Godot
         /// The volume of this <see cref="Aabb"/>.
         /// See also <see cref="HasVolume"/>.
         /// </summary>
+        [JsonIgnore]
         public readonly real_t Volume
         {
             get { return _size.X * _size.Y * _size.Z; }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -1,7 +1,8 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using System.ComponentModel;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -31,6 +32,7 @@ namespace Godot
         /// The basis matrix's X vector (column 0).
         /// </summary>
         /// <value>Equivalent to <see cref="Column0"/> and array index <c>[0]</c>.</value>
+        [JsonInclude]
         public Vector3 X
         {
             readonly get => Column0;
@@ -41,6 +43,7 @@ namespace Godot
         /// The basis matrix's Y vector (column 1).
         /// </summary>
         /// <value>Equivalent to <see cref="Column1"/> and array index <c>[1]</c>.</value>
+        [JsonInclude]
         public Vector3 Y
         {
             readonly get => Column1;
@@ -51,6 +54,7 @@ namespace Godot
         /// The basis matrix's Z vector (column 2).
         /// </summary>
         /// <value>Equivalent to <see cref="Column2"/> and array index <c>[2]</c>.</value>
+        [JsonInclude]
         public Vector3 Z
         {
             readonly get => Column2;
@@ -62,6 +66,7 @@ namespace Godot
         /// to the X direction. Rows are not very useful for user code,
         /// but are more efficient for some internal calculations.
         /// </summary>
+        [JsonIgnore]
         public Vector3 Row0;
 
         /// <summary>
@@ -69,6 +74,7 @@ namespace Godot
         /// to the Y direction. Rows are not very useful for user code,
         /// but are more efficient for some internal calculations.
         /// </summary>
+        [JsonIgnore]
         public Vector3 Row1;
 
         /// <summary>
@@ -76,12 +82,14 @@ namespace Godot
         /// to the Z direction. Rows are not very useful for user code,
         /// but are more efficient for some internal calculations.
         /// </summary>
+        [JsonIgnore]
         public Vector3 Row2;
 
         /// <summary>
         /// Column 0 of the basis matrix (the X vector).
         /// </summary>
         /// <value>Equivalent to <see cref="X"/> and array index <c>[0]</c>.</value>
+        [JsonIgnore]
         public Vector3 Column0
         {
             readonly get => new Vector3(Row0.X, Row1.X, Row2.X);
@@ -97,6 +105,7 @@ namespace Godot
         /// Column 1 of the basis matrix (the Y vector).
         /// </summary>
         /// <value>Equivalent to <see cref="Y"/> and array index <c>[1]</c>.</value>
+        [JsonIgnore]
         public Vector3 Column1
         {
             readonly get => new Vector3(Row0.Y, Row1.Y, Row2.Y);
@@ -112,6 +121,7 @@ namespace Godot
         /// Column 2 of the basis matrix (the Z vector).
         /// </summary>
         /// <value>Equivalent to <see cref="Z"/> and array index <c>[2]</c>.</value>
+        [JsonIgnore]
         public Vector3 Column2
         {
             readonly get => new Vector3(Row0.Z, Row1.Z, Row2.Z);
@@ -127,6 +137,7 @@ namespace Godot
         /// Assuming that the matrix is the combination of a rotation and scaling,
         /// return the absolute value of scaling factors along each axis.
         /// </summary>
+        [JsonIgnore]
         public readonly Vector3 Scale
         {
             get
@@ -149,6 +160,7 @@ namespace Godot
         /// <paramref name="column"/> is not 0, 1, 2 or 3.
         /// </exception>
         /// <value>The basis column.</value>
+        [JsonIgnore]
         public Vector3 this[int column]
         {
             readonly get
@@ -190,6 +202,7 @@ namespace Godot
         /// <param name="column">Which column, the matrix horizontal position.</param>
         /// <param name="row">Which row, the matrix vertical position.</param>
         /// <value>The matrix element.</value>
+        [JsonIgnore]
         public real_t this[int column, int row]
         {
             readonly get

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -1,8 +1,9 @@
+using Godot.NativeInterop;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
-using Godot.NativeInterop;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -25,16 +26,19 @@ namespace Godot
         /// <summary>
         /// The color's red component, typically on the range of 0 to 1.
         /// </summary>
+        [JsonInclude]
         public float R;
 
         /// <summary>
         /// The color's green component, typically on the range of 0 to 1.
         /// </summary>
+        [JsonInclude]
         public float G;
 
         /// <summary>
         /// The color's blue component, typically on the range of 0 to 1.
         /// </summary>
+        [JsonInclude]
         public float B;
 
         /// <summary>
@@ -42,12 +46,14 @@ namespace Godot
 		/// A value of 0 means that the color is fully transparent.
 		/// A value of 1 means that the color is fully opaque.
         /// </summary>
+        [JsonInclude]
         public float A;
 
         /// <summary>
         /// Wrapper for <see cref="R"/> that uses the range 0 to 255 instead of 0 to 1.
         /// </summary>
         /// <value>Getting is equivalent to multiplying by 255 and rounding. Setting is equivalent to dividing by 255.</value>
+        [JsonIgnore]
         public int R8
         {
             readonly get
@@ -64,6 +70,7 @@ namespace Godot
         /// Wrapper for <see cref="G"/> that uses the range 0 to 255 instead of 0 to 1.
         /// </summary>
         /// <value>Getting is equivalent to multiplying by 255 and rounding. Setting is equivalent to dividing by 255.</value>
+        [JsonIgnore]
         public int G8
         {
             readonly get
@@ -80,6 +87,7 @@ namespace Godot
         /// Wrapper for <see cref="B"/> that uses the range 0 to 255 instead of 0 to 1.
         /// </summary>
         /// <value>Getting is equivalent to multiplying by 255 and rounding. Setting is equivalent to dividing by 255.</value>
+        [JsonIgnore]
         public int B8
         {
             readonly get
@@ -96,6 +104,7 @@ namespace Godot
         /// Wrapper for <see cref="A"/> that uses the range 0 to 255 instead of 0 to 1.
         /// </summary>
         /// <value>Getting is equivalent to multiplying by 255 and rounding. Setting is equivalent to dividing by 255.</value>
+        [JsonIgnore]
         public int A8
         {
             readonly get
@@ -112,6 +121,7 @@ namespace Godot
         /// The HSV hue of this color, on the range 0 to 1.
         /// </summary>
         /// <value>Getting is a long process, refer to the source code for details. Setting uses <see cref="FromHsv"/>.</value>
+        [JsonIgnore]
         public float H
         {
             readonly get
@@ -160,6 +170,7 @@ namespace Godot
         /// The HSV saturation of this color, on the range 0 to 1.
         /// </summary>
         /// <value>Getting is equivalent to the ratio between the min and max RGB value. Setting uses <see cref="FromHsv"/>.</value>
+        [JsonIgnore]
         public float S
         {
             readonly get
@@ -181,6 +192,7 @@ namespace Godot
         /// The HSV value (brightness) of this color, on the range 0 to 1.
         /// </summary>
         /// <value>Getting is equivalent to using <see cref="Math.Max(float, float)"/> on the RGB components. Setting uses <see cref="FromHsv"/>.</value>
+        [JsonIgnore]
         public float V
         {
             readonly get
@@ -196,6 +208,7 @@ namespace Godot
         /// <summary>
         /// The OKHSL hue of this color, on the range 0 to 1.
         /// </summary>
+        [JsonIgnore]
         public float OkHslH
         {
             readonly get
@@ -211,6 +224,7 @@ namespace Godot
         /// <summary>
         /// The OKHSL saturation of this color, on the range 0 to 1.
         /// </summary>
+        [JsonIgnore]
         public float OkHslS
         {
             readonly get
@@ -226,6 +240,7 @@ namespace Godot
         /// <summary>
         /// The OKHSL lightness of this color, on the range 0 to 1.
         /// </summary>
+        [JsonIgnore]
         public float OkHslL
         {
             readonly get
@@ -246,6 +261,7 @@ namespace Godot
         /// return an accurate relative luminance value. If the color is in the sRGB color space
         /// use <see cref="SrgbToLinear"/> to convert it to the linear color space first.
         /// </summary>
+        [JsonIgnore]
         public readonly float Luminance
         {
             get { return 0.2126f * R + 0.7152f * G + 0.0722f * B; }
@@ -260,6 +276,7 @@ namespace Godot
         /// <c>[2]</c> is equivalent to <see cref="B"/>,
         /// <c>[3]</c> is equivalent to <see cref="A"/>.
         /// </value>
+        [JsonIgnore]
         public float this[int index]
         {
             readonly get

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -16,7 +17,9 @@ namespace Godot
     [StructLayout(LayoutKind.Sequential)]
     public struct Plane : IEquatable<Plane>
     {
+        [JsonIgnore]
         private Vector3 _normal;
+        [JsonIgnore]
         private real_t _d;
 
         /// <summary>
@@ -25,6 +28,7 @@ namespace Godot
         /// the vector <c>(a, b, c)</c>, where <c>d</c> is the <see cref="D"/> property.
         /// </summary>
         /// <value>Equivalent to <see cref="X"/>, <see cref="Y"/>, and <see cref="Z"/>.</value>
+        [JsonInclude]
         public Vector3 Normal
         {
             readonly get { return _normal; }
@@ -39,6 +43,7 @@ namespace Godot
         /// by the <see cref="Normal"/> property.
         /// </summary>
         /// <value>The plane's distance from the origin.</value>
+        [JsonInclude]
         public real_t D
         {
             readonly get { return _d; }
@@ -49,6 +54,7 @@ namespace Godot
         /// The X component of the plane's normal vector.
         /// </summary>
         /// <value>Equivalent to <see cref="Normal"/>'s X value.</value>
+        [JsonIgnore]
         public real_t X
         {
             readonly get
@@ -65,6 +71,7 @@ namespace Godot
         /// The Y component of the plane's normal vector.
         /// </summary>
         /// <value>Equivalent to <see cref="Normal"/>'s Y value.</value>
+        [JsonIgnore]
         public real_t Y
         {
             readonly get
@@ -81,6 +88,7 @@ namespace Godot
         /// The Z component of the plane's normal vector.
         /// </summary>
         /// <value>Equivalent to <see cref="Normal"/>'s Z value.</value>
+        [JsonIgnore]
         public real_t Z
         {
             readonly get

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -53,21 +54,25 @@ namespace Godot
         /// <summary>
         /// The projection's X column. Also accessible by using the index position <c>[0]</c>.
         /// </summary>
+        [JsonInclude]
         public Vector4 X;
 
         /// <summary>
         /// The projection's Y column. Also accessible by using the index position <c>[1]</c>.
         /// </summary>
+        [JsonInclude]
         public Vector4 Y;
 
         /// <summary>
         /// The projection's Z column. Also accessible by using the index position <c>[2]</c>.
         /// </summary>
+        [JsonInclude]
         public Vector4 Z;
 
         /// <summary>
         /// The projection's W column. Also accessible by using the index position <c>[3]</c>.
         /// </summary>
+        [JsonInclude]
         public Vector4 W;
 
         /// <summary>
@@ -77,6 +82,7 @@ namespace Godot
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="column"/> is not 0, 1, 2 or 3.
         /// </exception>
+        [JsonIgnore]
         public Vector4 this[int column]
         {
             readonly get
@@ -125,6 +131,7 @@ namespace Godot
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="column"/> or <paramref name="row"/> are not 0, 1, 2 or 3.
         /// </exception>
+        [JsonIgnore]
         public real_t this[int column, int row]
         {
             readonly get

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -28,24 +29,28 @@ namespace Godot
         /// X component of the quaternion (imaginary <c>i</c> axis part).
         /// Quaternion components should usually not be manipulated directly.
         /// </summary>
+        [JsonInclude]
         public real_t X;
 
         /// <summary>
         /// Y component of the quaternion (imaginary <c>j</c> axis part).
         /// Quaternion components should usually not be manipulated directly.
         /// </summary>
+        [JsonInclude]
         public real_t Y;
 
         /// <summary>
         /// Z component of the quaternion (imaginary <c>k</c> axis part).
         /// Quaternion components should usually not be manipulated directly.
         /// </summary>
+        [JsonInclude]
         public real_t Z;
 
         /// <summary>
         /// W component of the quaternion (real part).
         /// Quaternion components should usually not be manipulated directly.
         /// </summary>
+        [JsonInclude]
         public real_t W;
 
         /// <summary>
@@ -60,6 +65,7 @@ namespace Godot
         /// <c>[2]</c> is equivalent to <see cref="Z"/>,
         /// <c>[3]</c> is equivalent to <see cref="W"/>.
         /// </value>
+        [JsonIgnore]
         public real_t this[int index]
         {
             readonly get

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -14,13 +15,16 @@ namespace Godot
     [StructLayout(LayoutKind.Sequential)]
     public struct Rect2 : IEquatable<Rect2>
     {
+        [JsonIgnore]
         private Vector2 _position;
+        [JsonIgnore]
         private Vector2 _size;
 
         /// <summary>
         /// Beginning corner. Typically has values lower than <see cref="End"/>.
         /// </summary>
         /// <value>Directly uses a private field.</value>
+        [JsonInclude]
         public Vector2 Position
         {
             readonly get { return _position; }
@@ -32,6 +36,7 @@ namespace Godot
         /// If the size is negative, you can use <see cref="Abs"/> to fix it.
         /// </summary>
         /// <value>Directly uses a private field.</value>
+        [JsonInclude]
         public Vector2 Size
         {
             readonly get { return _size; }
@@ -46,6 +51,7 @@ namespace Godot
         /// Getting is equivalent to <paramref name="value"/> = <see cref="Position"/> + <see cref="Size"/>,
         /// setting is equivalent to <see cref="Size"/> = <paramref name="value"/> - <see cref="Position"/>
         /// </value>
+        [JsonIgnore]
         public Vector2 End
         {
             readonly get { return _position + _size; }
@@ -56,6 +62,7 @@ namespace Godot
         /// The area of this <see cref="Rect2"/>.
         /// See also <see cref="HasArea"/>.
         /// </summary>
+        [JsonIgnore]
         public readonly real_t Area
         {
             get { return _size.X * _size.Y; }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2I.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -14,13 +15,16 @@ namespace Godot
     [StructLayout(LayoutKind.Sequential)]
     public struct Rect2I : IEquatable<Rect2I>
     {
+        [JsonIgnore]
         private Vector2I _position;
+        [JsonIgnore]
         private Vector2I _size;
 
         /// <summary>
         /// Beginning corner. Typically has values lower than <see cref="End"/>.
         /// </summary>
         /// <value>Directly uses a private field.</value>
+        [JsonInclude]
         public Vector2I Position
         {
             readonly get { return _position; }
@@ -32,6 +36,7 @@ namespace Godot
         /// If the size is negative, you can use <see cref="Abs"/> to fix it.
         /// </summary>
         /// <value>Directly uses a private field.</value>
+        [JsonInclude]
         public Vector2I Size
         {
             readonly get { return _size; }
@@ -46,6 +51,7 @@ namespace Godot
         /// Getting is equivalent to <paramref name="value"/> = <see cref="Position"/> + <see cref="Size"/>,
         /// setting is equivalent to <see cref="Size"/> = <paramref name="value"/> - <see cref="Position"/>
         /// </value>
+        [JsonIgnore]
         public Vector2I End
         {
             readonly get { return _position + _size; }
@@ -56,6 +62,7 @@ namespace Godot
         /// The area of this <see cref="Rect2I"/>.
         /// See also <see cref="HasArea"/>.
         /// </summary>
+        [JsonIgnore]
         public readonly int Area
         {
             get { return _size.X * _size.Y; }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rid.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rid.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -20,6 +21,7 @@ namespace Godot
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct Rid : IEquatable<Rid>
     {
+        [JsonIgnore]
         private readonly ulong _id; // Default is 0
 
         internal Rid(ulong id)
@@ -37,12 +39,14 @@ namespace Godot
         /// Returns the ID of the referenced low-level resource.
         /// </summary>
         /// <returns>The ID of the referenced resource.</returns>
+        [JsonInclude]
         public ulong Id => _id;
 
         /// <summary>
         /// Returns <see langword="true"/> if the <see cref="Rid"/> is not <c>0</c>.
         /// </summary>
         /// <returns>Whether or not the ID is valid.</returns>
+        [JsonIgnore]
         public bool IsValid => _id != 0;
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -22,27 +23,32 @@ namespace Godot
         /// <summary>
         /// The basis matrix's X vector (column 0). Equivalent to array index <c>[0]</c>.
         /// </summary>
+        [JsonInclude]
         public Vector2 X;
 
         /// <summary>
         /// The basis matrix's Y vector (column 1). Equivalent to array index <c>[1]</c>.
         /// </summary>
+        [JsonInclude]
         public Vector2 Y;
 
         /// <summary>
         /// The origin vector (column 2, the third column). Equivalent to array index <c>[2]</c>.
         /// The origin vector represents translation.
         /// </summary>
+        [JsonInclude]
         public Vector2 Origin;
 
         /// <summary>
         /// Returns the transform's rotation (in radians).
         /// </summary>
+        [JsonIgnore]
         public readonly real_t Rotation => Mathf.Atan2(X.Y, X.X);
 
         /// <summary>
         /// Returns the scale.
         /// </summary>
+        [JsonIgnore]
         public readonly Vector2 Scale
         {
             get
@@ -55,6 +61,7 @@ namespace Godot
         /// <summary>
         /// Returns the transform's skew (in radians).
         /// </summary>
+        [JsonIgnore]
         public readonly real_t Skew
         {
             get
@@ -72,6 +79,7 @@ namespace Godot
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="column"/> is not 0, 1 or 2.
         /// </exception>
+        [JsonIgnore]
         public Vector2 this[int column]
         {
             readonly get
@@ -113,6 +121,7 @@ namespace Godot
         /// </summary>
         /// <param name="column">Which column, the matrix horizontal position.</param>
         /// <param name="row">Which row, the matrix vertical position.</param>
+        [JsonIgnore]
         public real_t this[int column, int row]
         {
             readonly get

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -1,7 +1,8 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using System.ComponentModel;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -24,11 +25,13 @@ namespace Godot
         /// The <see cref="Godot.Basis"/> of this transform. Contains the X, Y, and Z basis
         /// vectors (columns 0 to 2) and is responsible for rotation and scale.
         /// </summary>
+        [JsonInclude]
         public Basis Basis;
 
         /// <summary>
         /// The origin vector (column 3, the fourth column). Equivalent to array index <c>[3]</c>.
         /// </summary>
+        [JsonInclude]
         public Vector3 Origin;
 
         /// <summary>
@@ -39,6 +42,7 @@ namespace Godot
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="column"/> is not 0, 1, 2 or 3.
         /// </exception>
+        [JsonIgnore]
         public Vector3 this[int column]
         {
             readonly get
@@ -85,6 +89,7 @@ namespace Godot
         /// </summary>
         /// <param name="column">Which column, the matrix horizontal position.</param>
         /// <param name="row">Which row, the matrix vertical position.</param>
+        [JsonIgnore]
         public real_t this[int column, int row]
         {
             readonly get

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -33,11 +34,13 @@ namespace Godot
         /// <summary>
         /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
         /// </summary>
+        [JsonInclude]
         public real_t X;
 
         /// <summary>
         /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
         /// </summary>
+        [JsonInclude]
         public real_t Y;
 
         /// <summary>
@@ -50,6 +53,7 @@ namespace Godot
         /// <c>[0]</c> is equivalent to <see cref="X"/>,
         /// <c>[1]</c> is equivalent to <see cref="Y"/>.
         /// </value>
+        [JsonIgnore]
         public real_t this[int index]
         {
             readonly get

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -33,11 +34,13 @@ namespace Godot
         /// <summary>
         /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
         /// </summary>
+        [JsonInclude]
         public int X;
 
         /// <summary>
         /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
         /// </summary>
+        [JsonInclude]
         public int Y;
 
         /// <summary>
@@ -50,6 +53,7 @@ namespace Godot
         /// <c>[0]</c> is equivalent to <see cref="X"/>,
         /// <c>[1]</c> is equivalent to <see cref="Y"/>.
         /// </value>
+        [JsonIgnore]
         public int this[int index]
         {
             readonly get

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -37,16 +38,19 @@ namespace Godot
         /// <summary>
         /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
         /// </summary>
+        [JsonInclude]
         public real_t X;
 
         /// <summary>
         /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
         /// </summary>
+        [JsonInclude]
         public real_t Y;
 
         /// <summary>
         /// The vector's Z component. Also accessible by using the index position <c>[2]</c>.
         /// </summary>
+        [JsonInclude]
         public real_t Z;
 
         /// <summary>
@@ -60,6 +64,7 @@ namespace Godot
         /// <c>[1]</c> is equivalent to <see cref="Y"/>,
         /// <c>[2]</c> is equivalent to <see cref="Z"/>.
         /// </value>
+        [JsonIgnore]
         public real_t this[int index]
         {
             readonly get

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -37,16 +38,19 @@ namespace Godot
         /// <summary>
         /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
         /// </summary>
+        [JsonInclude]
         public int X;
 
         /// <summary>
         /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
         /// </summary>
+        [JsonInclude]
         public int Y;
 
         /// <summary>
         /// The vector's Z component. Also accessible by using the index position <c>[2]</c>.
         /// </summary>
+        [JsonInclude]
         public int Z;
 
         /// <summary>
@@ -60,6 +64,7 @@ namespace Godot
         /// <c>[1]</c> is equivalent to <see cref="Y"/>,
         /// <c>[2]</c> is equivalent to <see cref="Z"/>.
         /// </value>
+        [JsonIgnore]
         public int this[int index]
         {
             readonly get

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -41,21 +42,25 @@ namespace Godot
         /// <summary>
         /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
         /// </summary>
+        [JsonInclude]
         public real_t X;
 
         /// <summary>
         /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
         /// </summary>
+        [JsonInclude]
         public real_t Y;
 
         /// <summary>
         /// The vector's Z component. Also accessible by using the index position <c>[2]</c>.
         /// </summary>
+        [JsonInclude]
         public real_t Z;
 
         /// <summary>
         /// The vector's W component. Also accessible by using the index position <c>[3]</c>.
         /// </summary>
+        [JsonInclude]
         public real_t W;
 
         /// <summary>
@@ -70,6 +75,7 @@ namespace Godot
         /// <c>[2]</c> is equivalent to <see cref="Z"/>.
         /// <c>[3]</c> is equivalent to <see cref="W"/>.
         /// </value>
+        [JsonIgnore]
         public real_t this[int index]
         {
             readonly get

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 
 #nullable enable
 
@@ -41,21 +42,25 @@ namespace Godot
         /// <summary>
         /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
         /// </summary>
+        [JsonInclude]
         public int X;
 
         /// <summary>
         /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
         /// </summary>
+        [JsonInclude]
         public int Y;
 
         /// <summary>
         /// The vector's Z component. Also accessible by using the index position <c>[2]</c>.
         /// </summary>
+        [JsonInclude]
         public int Z;
 
         /// <summary>
         /// The vector's W component. Also accessible by using the index position <c>[3]</c>.
         /// </summary>
+        [JsonInclude]
         public int W;
 
         /// <summary>
@@ -70,6 +75,7 @@ namespace Godot
         /// <c>[2]</c> is equivalent to <see cref="Z"/>.
         /// <c>[3]</c> is equivalent to <see cref="W"/>.
         /// </value>
+        [JsonIgnore]
         public int this[int index]
         {
             readonly get


### PR DESCRIPTION
This pull request adds `[JsonInclude]` and `[JsonIgnore]` attributes to the serializable `struct` types Godot implements in C#, in order to assist serialization/deserialization with System.Text.Json.

Serialization with System.Text.Json already works, but it often includes unwanted properties.

## Example

```cs
GD.Print(JsonSerializer.Serialize(Colors.Red));
```

Before:
```
{"R8":255,"G8":0,"B8":0,"A8":255,"H":0,"S":1,"V":1,"OkHslH":0.08120528,"OkHslS":1,"OkHslL":0.56808466,"Luminance":0.2126}
```

After:
```
{"R":1,"G":0,"B":0,"A":1}
```

## Workarounds

### Using Godot.Json

Unfortunately, Godot.Json has two problems in comparison to System.Text.Json:
- It doesn't support custom types, which is a problem when you want to serialize a C# type that contains Godot types
- It's not generic / statically-typed, which means you have to manually convert `Variant` to your C# type

### Using wrappers / anonymous types

You can use a custom wrapper like so:

```cs
GD.Print(JsonSerializer.Serialize(new { Colors.Red.R, Colors.Red.G, Colors.Red.B, Colors.Red.A}));
```

However, this adds a lot of complexity when you want to serialize a C# type that contains Godot types.

### Using custom JsonConverterAttributes

These can be used flexibly in complex C# types, but they are very [complex](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/converters-how-to) to write.