### PR TITLE
Fix some division by zero UB issues found in tests

### DIFF
--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -439,7 +439,7 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 inline void adapt_values(int p_index_a, int p_index_b, real_t *adapted_values, const real_t *p_values, const real_t p_width, const real_t p_max_a, const real_t p_max_b) {
 	real_t value_a = p_values[p_index_a];
 	real_t value_b = p_values[p_index_b];
-	real_t factor = MIN(1.0, p_width / (value_a + value_b));
+	real_t factor = (value_a + value_b == 0.0) ? 1.0 : MIN(1.0, p_width / (value_a + value_b));
 	adapted_values[p_index_a] = MIN(MIN(value_a * factor, p_max_a), adapted_values[p_index_a]);
 	adapted_values[p_index_b] = MIN(MIN(value_b * factor, p_max_b), adapted_values[p_index_b]);
 }

--- a/tests/core/string/test_translation.cpp
+++ b/tests/core/string/test_translation.cpp
@@ -211,8 +211,10 @@ TEST_CASE("[OptimizedTranslation] Generate from Translation and read messages") 
 
 	List<StringName> messages;
 	// `get_message_list()` can't return the list of messages stored in an OptimizedTranslation.
+	ERR_PRINT_OFF;
 	optimized_translation->get_message_list(&messages);
 	CHECK(optimized_translation->get_message_count() == 0);
+	ERR_PRINT_ON;
 	CHECK(messages.size() == 0);
 }
 

--- a/tests/scene/test_primitives.cpp
+++ b/tests/scene/test_primitives.cpp
@@ -130,9 +130,9 @@ TEST_CASE("[SceneTree][Primitive][Capsule] Capsule Primitive") {
 		SUBCASE("[Primitive][Capsule] If normal.y == 0, then mesh makes a cylinder.") {
 			Vector<Vector3> normals = data[RSE::ARRAY_NORMAL];
 			for (int ii = 0; ii < points.size(); ++ii) {
-				float point_dist_from_yaxis = Math::sqrt(points[ii].x * points[ii].x + points[ii].z * points[ii].z);
-				Vector3 yaxis_to_point{ points[ii].x / point_dist_from_yaxis, 0.f, points[ii].z / point_dist_from_yaxis };
 				if (normals[ii].y == 0.f) {
+					float point_dist_from_yaxis = Math::sqrt(points[ii].x * points[ii].x + points[ii].z * points[ii].z);
+					Vector3 yaxis_to_point(points[ii].x / point_dist_from_yaxis, 0.f, points[ii].z / point_dist_from_yaxis);
 					float mag_of_normal = Math::sqrt(normals[ii].x * normals[ii].x + normals[ii].z * normals[ii].z);
 					Vector3 normalized_normal = normals[ii] / mag_of_normal;
 					CHECK_MESSAGE(point_dist_from_yaxis == doctest::Approx(radius),


### PR DESCRIPTION
Fixes a couple of division by zero undefined behavior issues. These were found with CI, see master for example https://github.com/godotengine/godot/actions/runs/20756409729/job/59599652489#step:20:153

<details><summary>Copy of the errors in case it expires:</summary>

```
core/string/ustring.cpp:225:8: runtime error: null pointer passed as argument 2, which is declared to never be null
core/templates/span.h:41:16: runtime error: null pointer passed as argument 1, which is declared to never be null
core/templates/span.h:41:16: runtime error: null pointer passed as argument 2, which is declared to never be null
modules/gdscript/gdscript_vm.cpp:799:13: runtime error: store to misaligned address 0x511000511dbc for type '<unknown> *', which requires 8 byte alignment
0x511000511dbc: note: pointer points here
  02 00 00 00 00 00 00 00  00 00 00 00 15 00 00 00  03 00 00 00 04 00 00 00  16 00 00 00 04 00 00 00
              ^ 
modules/gdscript/gdscript_vm.cpp:806:42: runtime error: load of misaligned address 0x518000293a0c for type '<unknown> *', which requires 8 byte alignment
0x518000293a0c: note: pointer points here
  02 00 00 00 5d 66 49 6f  26 56 00 00 3d 00 00 00  0c 00 00 00 a2 00 00 00  16 00 00 00 0d 00 00 00
              ^ 
core/templates/span.h:41:16: runtime error: null pointer passed as argument 1, which is declared to never be null
core/templates/span.h:41:16: runtime error: null pointer passed as argument 2, which is declared to never be null
ERROR: Connection to remote host failed!
   at: connect_to_host (./core/io/stream_peer_uds.cpp:86)
core/variant/variant_op.h:125:82: runtime error: division by zero
core/string/optimized_translation.cpp:261:20: runtime error: index 1 out of bounds for type 'Elem [1]'
core/string/optimized_translation.cpp:271:21: runtime error: index 1 out of bounds for type 'Elem [1]'
core/string/optimized_translation.cpp:271:51: runtime error: index 1 out of bounds for type 'Elem [1]'
core/string/optimized_translation.cpp:272:74: runtime error: index 1 out of bounds for type 'Elem [1]'
core/string/optimized_translation.cpp:272:44: runtime error: index 1 out of bounds for type 'Elem [1]'
WARNING: OptimizedTranslation does not store the message texts to be translated.
     at: get_message_list (./core/string/optimized_translation.cpp:323)
WARNING: OptimizedTranslation does not store the message texts to be translated.
     at: get_message_count (./core/string/optimized_translation.cpp:327)
core/templates/span.h:41:16: runtime error: null pointer passed as argument 1, which is declared to never be null
core/templates/span.h:41:16: runtime error: null pointer passed as argument 2, which is declared to never be null
core/templates/span.h:41:16: runtime error: null pointer passed as argument 1, which is declared to never be null
core/templates/span.h:41:16: runtime error: null pointer passed as argument 2, which is declared to never be null
core/templates/span.h:41:16: runtime error: null pointer passed as argument 1, which is declared to never be null
core/templates/span.h:41:16: runtime error: null pointer passed as argument 2, which is declared to never be null
core/templates/span.h:41:16: runtime error: null pointer passed as argument 1, which is declared to never be null
core/templates/span.h:41:16: runtime error: null pointer passed as argument 2, which is declared to never be null
scene/resources/style_box_flat.cpp:439:35: runtime error: division by zero
thirdparty/harfbuzz/src/OT/Layout/Common/CoverageFormat2.hh:197:36: runtime error: index 1 out of bounds for type 'RangeRecord [1]'
thirdparty/harfbuzz/src/OT/Layout/Common/CoverageFormat2.hh:197:36: runtime error: index 1 out of bounds for type 'RangeRecord [1]'
thirdparty/harfbuzz/src/OT/Layout/Common/CoverageFormat2.hh:198:43: runtime error: index 1 out of bounds for type 'RangeRecord [1]'
thirdparty/harfbuzz/src/OT/Layout/Common/CoverageFormat2.hh:198:43: runtime error: index 1 out of bounds for type 'RangeRecord [1]'
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
tests/scene/test_primitives.h:132:42: runtime error: division by zero
tests/scene/test_primitives.h:132:85: runtime error: division by zero
scene/gui/split_container.cpp:382:46: runtime error: division by zero
```
</details> 



This only fixes a couple of them:
```
scene/resources/style_box_flat.cpp:439:35: runtime error: division by zero
tests/scene/test_primitives.h:132:42: runtime error: division by zero
tests/scene/test_primitives.h:132:85: runtime error: division by zero
scene/gui/split_container.cpp:382:46: runtime error: division by zero
```

Also silences the warnings in `OptimizedTranslation` test, it looks like it is expected behavior and it is new (since #112073): 
```
WARNING: OptimizedTranslation does not store the message texts to be translated.
     at: get_message_list (./core/string/optimized_translation.cpp:323)
WARNING: OptimizedTranslation does not store the message texts to be translated.
     at: get_message_count (./core/string/optimized_translation.cpp:327)
```

The other division by zero in `variant_op.h` is `OperatorEvaluatorDiv` from the `[Expression] Unusual expressions` test case, and it expects infinity, so I'm not sure how to handle it.

There are other errors (and even more in the `Linux / Editor with clang sanitizers` check) that are more complex or performance sensitive.
The `core/templates/span.h:41` nullptr error seems to happen when comparing a String with an empty String, which is why it happens so much.

I'm considering this as a bug, though it doesn't seem to cause issues.