### PR TITLE
Fix GDScriptCache test failing when run by itself

### DIFF
--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -86,6 +86,7 @@ func _init():
 }
 
 TEST_CASE("[Modules][GDScript] Loading keeps ResourceCache and GDScriptCache in sync") {
+	GDScriptLanguage::get_singleton()->init();
 	const String path = TestUtils::get_temp_path("gdscript_load_test.gd");
 
 	{


### PR DESCRIPTION
- From https://github.com/godotengine/godot/pull/109345
- Same as one of the cases in https://github.com/godotengine/godot/pull/106129
- Related https://github.com/godotengine/godot/pull/112484 (should help prevent this in the future)

Fixes GDScriptCache test failing when ran alone by initializing the language in the test case.

`SCRIPT ERROR: Compile Error: GDScript bug (please report): Native class "Node" not found.`

test command: `--test --tc="*[GDScript] Loading keeps ResourceCache and GDScriptCache in sync"`