### PR TITLE
Fix theming issues with the ObjectDB profiler

### DIFF
--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -2361,6 +2361,18 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 	debugger_panel_style->set_border_width(SIDE_BOTTOM, 0);
 	p_theme->set_stylebox("DebuggerPanel", EditorStringName(EditorStyles), debugger_panel_style);
 
+	// ObjectDB.
+	{
+		Ref<StyleBoxFlat> style_content_wrapper = p_config.panel_container_style->duplicate();
+		style_content_wrapper->set_draw_center(true);
+		style_content_wrapper->set_bg_color(p_config.dark_color_2);
+		p_theme->set_stylebox("ObjectDBContentWrapper", EditorStringName(EditorStyles), style_content_wrapper);
+
+		Ref<StyleBoxFlat> style_title = style_content_wrapper->duplicate();
+		style_title->set_bg_color(p_config.dark_color_3);
+		p_theme->set_stylebox("ObjectDBTitle", EditorStringName(EditorStyles), style_title);
+	}
+
 	// Resource and node editors.
 	{
 		// TextureRegion editor.

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -2513,6 +2513,18 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 	debugger_panel_style->set_border_width(SIDE_BOTTOM, 0);
 	p_theme->set_stylebox("DebuggerPanel", EditorStringName(EditorStyles), debugger_panel_style);
 
+	// ObjectDB.
+	{
+		Ref<StyleBoxFlat> style_content_wrapper = p_config.panel_container_style->duplicate();
+		style_content_wrapper->set_draw_center(true);
+		style_content_wrapper->set_bg_color(p_config.dark_color_2);
+		p_theme->set_stylebox("ObjectDBContentWrapper", EditorStringName(EditorStyles), style_content_wrapper);
+
+		Ref<StyleBoxFlat> style_title = style_content_wrapper->duplicate();
+		style_title->set_bg_color(p_config.dark_color_3);
+		p_theme->set_stylebox("ObjectDBTitle", EditorStringName(EditorStyles), style_title);
+	}
+
 	// Resource and node editors.
 	{
 		// TextureRegion editor.

--- a/modules/objectdb_profiler/editor/data_viewers/class_view.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/class_view.cpp
@@ -104,6 +104,8 @@ void SnapshotClassView::show_snapshot(GameStateSnapshot *p_data, GameStateSnapsh
 	class_tree->set_column_custom_minimum_width(0, 200 * EDSCALE);
 	class_tree->set_column_title(1, diff_data ? TTRC("A Count") : TTRC("Count"));
 	class_tree->set_column_expand(1, false);
+	class_tree->set_theme_type_variation("TreeSecondary");
+
 	if (diff_data) {
 		class_tree->set_column_title_tooltip_text(1, vformat(TTR("A: %s"), snapshot_data->name));
 		class_tree->set_column_title_tooltip_text(2, vformat(TTR("B: %s"), diff_data->name));
@@ -112,6 +114,7 @@ void SnapshotClassView::show_snapshot(GameStateSnapshot *p_data, GameStateSnapsh
 		class_tree->set_column_title(3, TTRC("Delta"));
 		class_tree->set_column_expand(3, false);
 	}
+
 	class_tree->connect(SceneStringName(item_selected), callable_mp(this, &SnapshotClassView::_class_selected));
 	class_tree->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 	class_tree->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
@@ -180,6 +183,7 @@ Tree *SnapshotClassView::_make_object_list_tree(const String &p_column_name) {
 	list->set_column_titles_visible(true);
 	list->set_column_title(0, p_column_name);
 	list->set_column_expand(0, true);
+	list->set_theme_type_variation("TreeSecondary");
 	list->connect(SceneStringName(item_selected), callable_mp(this, &SnapshotClassView::_object_selected).bind(list));
 	list->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 	list->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);

--- a/modules/objectdb_profiler/editor/data_viewers/node_view.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/node_view.cpp
@@ -103,6 +103,7 @@ NodeTreeElements SnapshotNodeView::_make_node_tree(const String &p_tree_name) {
 	elements.tree->set_column_expand(0, true);
 	elements.tree->set_column_clip_content(0, false);
 	elements.tree->set_column_custom_minimum_width(0, 150 * EDSCALE);
+	elements.tree->set_theme_type_variation("TreeSecondary");
 	elements.tree->connect(SceneStringName(item_selected), callable_mp(this, &SnapshotNodeView::_node_selected).bind(elements.tree));
 	elements.tree->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 	elements.tree->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);

--- a/modules/objectdb_profiler/editor/data_viewers/object_view.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/object_view.cpp
@@ -80,6 +80,8 @@ void SnapshotObjectView::show_snapshot(GameStateSnapshot *p_data, GameStateSnaps
 	object_list->set_hide_root(true);
 	object_list->set_columns(diff_data ? 5 : 4);
 	object_list->set_column_titles_visible(true);
+	object_list->set_theme_type_variation("TreeSecondary");
+
 	int offset = 0;
 	if (diff_data) {
 		object_list->set_column_title(0, TTRC("Snapshot"));
@@ -87,6 +89,7 @@ void SnapshotObjectView::show_snapshot(GameStateSnapshot *p_data, GameStateSnaps
 		object_list->set_column_title_tooltip_text(0, "A: " + snapshot_data->name + ", B: " + diff_data->name);
 		offset++;
 	}
+
 	object_list->set_column_title(offset + 0, TTRC("Class"));
 	object_list->set_column_expand(offset + 0, true);
 	object_list->set_column_title_tooltip_text(offset + 0, TTRC("Object's class"));

--- a/modules/objectdb_profiler/editor/data_viewers/refcounted_view.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/refcounted_view.cpp
@@ -82,6 +82,7 @@ void SnapshotRefCountedView::show_snapshot(GameStateSnapshot *p_data, GameStateS
 	refs_list->set_hide_root(true);
 	refs_list->set_columns(diff_data ? 7 : 6);
 	refs_list->set_column_titles_visible(true);
+	refs_list->set_theme_type_variation("TreeSecondary");
 
 	if (diff_data) {
 		refs_list->set_column_title(0, TTRC("Snapshot"));

--- a/modules/objectdb_profiler/editor/data_viewers/summary_view.cpp
+++ b/modules/objectdb_profiler/editor/data_viewers/summary_view.cpp
@@ -32,11 +32,11 @@
 
 #include "core/os/time.h"
 #include "editor/editor_node.h"
+#include "editor/editor_string_names.h"
 #include "scene/gui/center_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/rich_text_label.h"
-#include "scene/resources/style_box_flat.h"
 
 SnapshotSummaryView::SnapshotSummaryView() {
 	set_name(TTRC("Summary"));
@@ -44,36 +44,19 @@ SnapshotSummaryView::SnapshotSummaryView() {
 	set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 	set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 
-	MarginContainer *mc = memnew(MarginContainer);
-	mc->add_theme_constant_override("margin_left", 5);
-	mc->add_theme_constant_override("margin_right", 5);
-	mc->add_theme_constant_override("margin_top", 5);
-	mc->add_theme_constant_override("margin_bottom", 5);
-	mc->set_anchors_preset(LayoutPreset::PRESET_FULL_RECT);
-	PanelContainer *content_wrapper = memnew(PanelContainer);
+	content_wrapper = memnew(PanelContainer);
 	content_wrapper->set_anchors_preset(LayoutPreset::PRESET_FULL_RECT);
-	Ref<StyleBoxFlat> content_wrapper_sbf;
-	content_wrapper_sbf.instantiate();
-	content_wrapper_sbf->set_bg_color(EditorNode::get_singleton()->get_editor_theme()->get_color("dark_color_2", "Editor"));
-	content_wrapper->add_theme_style_override(SceneStringName(panel), content_wrapper_sbf);
-	content_wrapper->add_child(mc);
 	add_child(content_wrapper);
 
 	VBoxContainer *content = memnew(VBoxContainer);
-	mc->add_child(content);
+	content_wrapper->add_child(content);
 	content->set_anchors_preset(LayoutPreset::PRESET_FULL_RECT);
 
-	PanelContainer *pc = memnew(PanelContainer);
-	Ref<StyleBoxFlat> sbf;
-	sbf.instantiate();
-	sbf->set_bg_color(EditorNode::get_singleton()->get_editor_theme()->get_color("dark_color_3", "Editor"));
-	pc->add_theme_style_override("panel", sbf);
-	content->add_child(pc);
-	pc->set_anchors_preset(LayoutPreset::PRESET_TOP_WIDE);
-	Label *title = memnew(Label(TTRC("ObjectDB Snapshot Summary")));
-	pc->add_child(title);
+	title = memnew(Label(TTRC("ObjectDB Snapshot Summary")));
+	content->add_child(title);
 	title->set_horizontal_alignment(HorizontalAlignment::HORIZONTAL_ALIGNMENT_CENTER);
 	title->set_vertical_alignment(VerticalAlignment::VERTICAL_ALIGNMENT_CENTER);
+	title->set_anchors_preset(LayoutPreset::PRESET_TOP_WIDE);
 
 	explainer_text = memnew(CenterContainer);
 	explainer_text->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
@@ -101,6 +84,13 @@ SnapshotSummaryView::SnapshotSummaryView() {
 	sc->add_child(blurb_list);
 	blurb_list->set_v_size_flags(SizeFlags::SIZE_EXPAND_FILL);
 	blurb_list->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
+}
+
+void SnapshotSummaryView::_notification(int p_what) {
+	if (p_what == NOTIFICATION_THEME_CHANGED) {
+		content_wrapper->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("ObjectDBContentWrapper"), EditorStringName(EditorStyles)));
+		title->add_theme_style_override(SNAME("normal"), get_theme_stylebox(SNAME("ObjectDBTitle"), EditorStringName(EditorStyles)));
+	}
 }
 
 void SnapshotSummaryView::show_snapshot(GameStateSnapshot *p_data, GameStateSnapshot *p_diff_data) {

--- a/modules/objectdb_profiler/editor/data_viewers/summary_view.h
+++ b/modules/objectdb_profiler/editor/data_viewers/summary_view.h
@@ -50,7 +50,9 @@ public:
 class SnapshotSummaryView : public SnapshotView {
 	GDCLASS(SnapshotSummaryView, SnapshotView);
 
-protected:
+	PanelContainer *content_wrapper = nullptr;
+	Label *title = nullptr;
+
 	VBoxContainer *blurb_list = nullptr;
 	CenterContainer *explainer_text = nullptr;
 
@@ -58,6 +60,9 @@ protected:
 	void _push_node_blurb(const String &p_title, GameStateSnapshot *p_snapshot);
 	void _push_refcounted_blurb(const String &p_title, GameStateSnapshot *p_snapshot);
 	void _push_object_blurb(const String &p_title, GameStateSnapshot *p_snapshot);
+
+protected:
+	void _notification(int p_what);
 
 public:
 	SnapshotSummaryView();


### PR DESCRIPTION
The ObjectDB profiler did some _interesting_ stuff related to theming that ended up overcomplicating things while also making it unable to update with theme changes. This PR simplifies that while also fixing the issue.

I also took the liberty to add some missing panels (seems like those never end) as well.

Fixes #113323.