### PR TITLE
Fix crash when selecting SplineIK3D

### DIFF
--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -290,7 +290,7 @@ void BonePropertiesEditor::_property_keyed(const String &p_path, bool p_advance)
 }
 
 void BonePropertiesEditor::_update_properties() {
-	if (!skeleton) {
+	if (!skeleton || !Skeleton3DEditor::get_singleton()) {
 		return;
 	}
 	int selected = Skeleton3DEditor::get_singleton()->get_selected_bone();


### PR DESCRIPTION
- related: https://github.com/godotengine/godot/issues/114643

## Issue Description

First, select `Skeleton3D`, then select `SplineIK3D`, cause crash.

We could use MRP from https://github.com/godotengine/godot/issues/114643 to reproduce the crash.

Should check whether `Skeleton3DEditor::get_singleton()` exists.

[ik.webm](https://github.com/user-attachments/assets/53efeaec-4731-4947-aea1-cc9ab69a8a2f)



