### PR TITLE
Fix AnimationPlayer ghost dependency on resource deletion

### DIFF
--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -2332,15 +2332,15 @@ void AnimationPlayerEditorPlugin::_notification(int p_what) {
 			InspectorDock::get_inspector_singleton()->connect(SNAME("property_keyed"), callable_mp(this, &AnimationPlayerEditorPlugin::_property_keyed));
 			anim_editor->get_track_editor()->connect(SNAME("keying_changed"), callable_mp(this, &AnimationPlayerEditorPlugin::_update_keying));
 			InspectorDock::get_inspector_singleton()->connect(SNAME("edited_object_changed"), callable_mp(anim_editor->get_track_editor(), &AnimationTrackEditor::update_keying));
-			if (!EditorNode::get_singleton()->is_headless()) {
-				EditorNode::get_singleton()->get_filesystem_dock()->connect("file_removed", callable_mp(this, &AnimationPlayerEditorPlugin::_file_removed));
+			if (FileSystemDock::get_singleton()) {
+				FileSystemDock::get_singleton()->connect("file_removed", callable_mp(this, &AnimationPlayerEditorPlugin::_file_removed));
 			}
 			set_force_draw_over_forwarding_enabled();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			if (!EditorNode::get_singleton()->is_headless()) {
-				EditorNode::get_singleton()->get_filesystem_dock()->disconnect("file_removed", callable_mp(this, &AnimationPlayerEditorPlugin::_file_removed));
+			if (FileSystemDock::get_singleton()) {
+				FileSystemDock::get_singleton()->disconnect("file_removed", callable_mp(this, &AnimationPlayerEditorPlugin::_file_removed));
 			}
 		} break;
 	}
@@ -2361,7 +2361,8 @@ void AnimationPlayerEditorPlugin::_file_removed(const String &p_file) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 
 	// Clear history for all animations in the player, as any of them might have referencing undo history.
-	List<StringName> anim_list = player->get_animation_list();
+	List<StringName> anim_list;
+	player->get_animation_list(&anim_list);
 	for (const StringName &anim_name : anim_list) {
 		Ref<Animation> anim = player->get_animation(anim_name);
 		if (anim.is_valid()) {

--- a/editor/animation/animation_player_editor_plugin.h
+++ b/editor/animation/animation_player_editor_plugin.h
@@ -296,6 +296,7 @@ class AnimationPlayerEditorPlugin : public EditorPlugin {
 protected:
 	void _notification(int p_what);
 
+	void _file_removed(const String &p_file);
 	void _property_keyed(const String &p_keyed, const Variant &p_value, bool p_advance);
 	void _transform_key_request(Object *sp, const String &p_sub, const Transform3D &p_key);
 	void _update_keying();


### PR DESCRIPTION
Problem
When a resource (like a Texture2D) used in an AnimationPlayer keyframe is deleted, the `UndoRedo` history retains a reference to the deleted resource. This causes "Unable to open file" errors and "ghost dependencies" preventing proper cleanup, as the resource remains alive in the cache due to the strong reference in the undo history.

Solution
This PR implements a handler for `FileSystemDock::file_removed` in [AnimationPlayerEditorPlugin](cci:1://file:///c:/User/dev/godot/editor/animation/animation_player_editor_plugin.cpp:2506:0-2509:1). 

When a resource file is deleted from the file system, the handler:
1. Checks if the deleted file is a resource type.
2. Clears the undo history for the currently assigned [Animation](cci:1://file:///c:/User/dev/godot/editor/animation/animation_track_editor.cpp:3765:0-3773:1) and the [AnimationTrackEditor](cci:1://file:///c:/User/dev/godot/editor/animation/animation_track_editor.h:1009:1-1009:24).
This ensures that stale references are released, allowing the resource to be properly destroyed.

This change does not alter any public API behavior, and ensures correct cleanup of editor-side resource references.

### Testing
- Validated that `FileSystemDock::file_removed` signal is correctly connected.
- Verified logic to clear history on specific resource types.

1. Reproduce ghost dependency issue using attached MRP.
2. Delete a Texture2D referenced in AnimationPlayer.
3. Ensure no UndoRedo retains that reference.
4. Confirm no error dialogs appear.

Fixes #114637