### PR TITLE
Add separate popup methods for CreateDialog

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -778,7 +778,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			if (selected) {
-				create_dialog->popup_create(false, true, selected->get_class(), selected->get_name());
+				create_dialog->popup_replace(selected->get_class(), selected->get_name());
 			}
 		} break;
 		case TOOL_EXTEND_SCRIPT: {

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -578,8 +578,13 @@ void EditorInterface::popup_create_dialog(const Callable &p_callback, const Stri
 	}
 
 	create_dialog->set_base_type(safe_base_type);
-	create_dialog->popup_create(false, true, p_current_type, "");
-	create_dialog->set_title(p_dialog_title.is_empty() ? vformat(TTR("Create New %s"), p_base_type) : p_dialog_title);
+	create_dialog->popup_create(false);
+	if (!p_current_type.is_empty()) {
+		create_dialog->set_search_type(p_current_type);
+	}
+	if (!p_dialog_title.is_empty()) {
+		create_dialog->set_title(p_dialog_title);
+	}
 
 	const Callable callback = callable_mp(this, &EditorInterface::_create_dialog_item_selected);
 	create_dialog->connect(SNAME("create"), callback.bind(false, p_callback), CONNECT_DEFERRED);

--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -38,31 +38,54 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 
-void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const String &p_current_type, const String &p_current_name) {
-	_fill_type_list();
-
-	icon_fallback = search_options->has_theme_icon(base_type, EditorStringName(EditorIcons)) ? base_type : "Object";
-
+void CreateDialog::popup_create(bool p_dont_clear) {
 	if (p_dont_clear) {
 		search_box->select_all();
 	} else {
 		search_box->clear();
 	}
 
-	if (p_replace_mode) {
-		search_box->set_text(p_current_type);
+	set_title(vformat(TTR("Create New %s"), base_type));
+	set_ok_button_text(TTR("Create"));
+
+	allow_abstract_scripts = false;
+
+	_popup_common();
+}
+
+void CreateDialog::popup_replace(const String &p_current_type, const String &p_current_name) {
+	search_box->set_text(p_current_type);
+
+	set_title(vformat(TTR("Change Type of \"%s\""), p_current_name));
+	set_ok_button_text(TTR("Change"));
+
+	allow_abstract_scripts = false;
+
+	_popup_common();
+}
+
+void CreateDialog::popup_inherit(bool p_dont_clear) {
+	if (p_dont_clear) {
+		search_box->select_all();
+	} else {
+		search_box->clear();
 	}
+
+	set_title(vformat(TTR("Inherit %s"), base_type));
+	set_ok_button_text(TTR("Inherit"));
+
+	allow_abstract_scripts = true;
+
+	_popup_common();
+}
+
+void CreateDialog::_popup_common() {
+	_fill_type_list();
+
+	icon_fallback = search_options->has_theme_icon(base_type, EditorStringName(EditorIcons)) ? base_type : "Object";
 
 	search_box->grab_focus();
 	_update_search();
-
-	if (p_replace_mode) {
-		set_title(vformat(TTR("Change Type of \"%s\""), p_current_name));
-		set_ok_button_text(TTR("Change"));
-	} else {
-		set_title(vformat(TTR("Create New %s"), base_type));
-		set_ok_button_text(TTR("Create"));
-	}
 
 	_load_favorites_and_history();
 	_save_and_update_favorite_list();
@@ -76,8 +99,9 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 	}
 }
 
-void CreateDialog::for_inherit() {
-	allow_abstract_scripts = true;
+void CreateDialog::set_search_type(const String &p_search) {
+	search_box->set_text(p_search);
+	_update_search();
 }
 
 void CreateDialog::_fill_type_list() {

--- a/editor/gui/create_dialog.h
+++ b/editor/gui/create_dialog.h
@@ -73,6 +73,7 @@ class CreateDialog : public ConfirmationDialog {
 	HashSet<StringName> type_blacklist;
 	HashSet<StringName> custom_type_blocklist;
 
+	void _popup_common();
 	void _update_search();
 	bool _should_hide_type(const StringName &p_type) const;
 	void _add_type(const StringName &p_type, TypeCategory p_type_category, const String &p_match_keyword);
@@ -125,8 +126,11 @@ public:
 	void set_type_blocklist(const HashSet<StringName> &p_blocklist) { custom_type_blocklist = p_blocklist; }
 	void set_preferred_search_result_type(const String &p_preferred_type) { preferred_search_result_type = p_preferred_type; }
 
-	void popup_create(bool p_dont_clear, bool p_replace_mode = false, const String &p_current_type = "", const String &p_current_name = "");
-	void for_inherit();
+	void set_search_type(const String &p_search);
+
+	void popup_create(bool p_dont_clear);
+	void popup_replace(const String &p_current_type = "", const String &p_current_name = "");
+	void popup_inherit(bool p_dont_clear);
 
 	CreateDialog();
 };

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -859,7 +859,7 @@ void EditorPropertyClassName::update_property() {
 }
 
 void EditorPropertyClassName::_property_selected() {
-	dialog->popup_create(true, true, get_edited_property_value(), get_edited_property());
+	dialog->popup_replace(get_edited_property_value(), get_edited_property());
 }
 
 void EditorPropertyClassName::_dialog_created() {

--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -498,9 +498,7 @@ void ScriptCreateDialog::_create() {
 
 void ScriptCreateDialog::_browse_class_in_tree() {
 	select_class->set_base_type(base_type);
-	select_class->popup_create(true);
-	select_class->set_title(vformat(TTR("Inherit %s"), base_type));
-	select_class->set_ok_button_text(TTR("Inherit"));
+	select_class->popup_inherit(true);
 }
 
 void ScriptCreateDialog::_path_changed(const String &p_path) {
@@ -995,7 +993,6 @@ ScriptCreateDialog::ScriptCreateDialog() {
 
 	select_class = memnew(CreateDialog);
 	select_class->connect("create", callable_mp(this, &ScriptCreateDialog::_create));
-	select_class->for_inherit();
 	add_child(select_class);
 
 	file_browse = memnew(EditorFileDialog);


### PR DESCRIPTION
Different usages of the dialog can now call separate methods depending on purpose, i.e. `popup_create` for creating new objects, `popup_replace` for replacing the type, `popup_inherit` for inheriting (enables inheriting abstract script classes).
This cleanly separates settings for different purposes of the dialog instead of handling all of them in the single method.
It also allows new uses to be added, for example, extending `EditorPropertyClassName` to allow selecting abstract classes.

I've also noticed some files violating the rule of using forward declarations instead of headers. Should those be addressed in separate commits or PRs, or can I change them as I encounter them?