### PR TITLE
Add option for CreateDialog to choose an abstract class

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2856,6 +2856,7 @@
 			If a property is [String], hints that the property represents a particular type (class). This allows to select a type from the create dialog. The property will store the selected type as a string.
 			If a property is [Array], hints the editor how to show elements. The [code]hint_string[/code] must encode nested types using [code]":"[/code] and [code]"/"[/code].
 			If a property is [Dictionary], hints the editor how to show elements. The [code]hint_string[/code] is the same as [Array], with a [code]";"[/code] separating the key and value.
+			Additional hints may be placed after the base class name, in the form [code]"ClassName,hint1,hint2"[/code]. Allowed hints are: [code]"allow_abstract"[/code] to include non-instantiatiable/abstract classes, and [code]"allow_script_abstract"[/code] to only include abstract classes from scripts.
 			[codeblocks]
 			[gdscript]
 			# Array of elem_type.

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -778,7 +778,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			if (selected) {
-				create_dialog->popup_create(false, true, selected->get_class(), selected->get_name());
+				create_dialog->popup_replace(selected->get_class(), selected->get_name());
 			}
 		} break;
 		case TOOL_EXTEND_SCRIPT: {

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -578,8 +578,13 @@ void EditorInterface::popup_create_dialog(const Callable &p_callback, const Stri
 	}
 
 	create_dialog->set_base_type(safe_base_type);
-	create_dialog->popup_create(false, true, p_current_type, "");
-	create_dialog->set_title(p_dialog_title.is_empty() ? vformat(TTR("Create New %s"), p_base_type) : p_dialog_title);
+	create_dialog->popup_create(false);
+	if (!p_current_type.is_empty()) {
+		create_dialog->set_search_type(p_current_type);
+	}
+	if (!p_dialog_title.is_empty()) {
+		create_dialog->set_title(p_dialog_title);
+	}
 
 	const Callable callback = callable_mp(this, &EditorInterface::_create_dialog_item_selected);
 	create_dialog->connect(SNAME("create"), callback.bind(false, p_callback), CONNECT_DEFERRED);

--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -38,31 +38,54 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 
-void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const String &p_current_type, const String &p_current_name) {
-	_fill_type_list();
-
-	icon_fallback = search_options->has_theme_icon(base_type, EditorStringName(EditorIcons)) ? base_type : "Object";
-
+void CreateDialog::popup_create(bool p_dont_clear) {
 	if (p_dont_clear) {
 		search_box->select_all();
 	} else {
 		search_box->clear();
 	}
 
-	if (p_replace_mode) {
-		search_box->set_text(p_current_type);
+	set_title(vformat(TTR("Create New %s"), base_type));
+	set_ok_button_text(TTR("Create"));
+
+	allow_abstract_scripts = false;
+
+	_popup_common();
+}
+
+void CreateDialog::popup_replace(const String &p_current_type, const String &p_current_name) {
+	search_box->set_text(p_current_type);
+
+	set_title(vformat(TTR("Change Type of \"%s\""), p_current_name));
+	set_ok_button_text(TTR("Change"));
+
+	allow_abstract_scripts = false;
+
+	_popup_common();
+}
+
+void CreateDialog::popup_inherit(bool p_dont_clear) {
+	if (p_dont_clear) {
+		search_box->select_all();
+	} else {
+		search_box->clear();
 	}
+
+	set_title(vformat(TTR("Inherit %s"), base_type));
+	set_ok_button_text(TTR("Inherit"));
+
+	allow_abstract_scripts = true;
+
+	_popup_common();
+}
+
+void CreateDialog::_popup_common() {
+	_fill_type_list();
+
+	icon_fallback = search_options->has_theme_icon(base_type, EditorStringName(EditorIcons)) ? base_type : "Object";
 
 	search_box->grab_focus();
 	_update_search();
-
-	if (p_replace_mode) {
-		set_title(vformat(TTR("Change Type of \"%s\""), p_current_name));
-		set_ok_button_text(TTR("Change"));
-	} else {
-		set_title(vformat(TTR("Create New %s"), base_type));
-		set_ok_button_text(TTR("Create"));
-	}
 
 	_load_favorites_and_history();
 	_save_and_update_favorite_list();
@@ -76,8 +99,9 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 	}
 }
 
-void CreateDialog::for_inherit() {
-	allow_abstract_scripts = true;
+void CreateDialog::set_search_type(const String &p_search) {
+	search_box->set_text(p_search);
+	_update_search();
 }
 
 void CreateDialog::_fill_type_list() {

--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -48,7 +48,7 @@ void CreateDialog::popup_create(bool p_dont_clear) {
 	set_title(vformat(TTR("Create New %s"), base_type));
 	set_ok_button_text(TTR("Create"));
 
-	allow_abstract_scripts = false;
+	type_filter = TYPE_FILTER_ALLOW_CONCRETE;
 
 	_popup_common();
 }
@@ -59,7 +59,7 @@ void CreateDialog::popup_replace(const String &p_current_type, const String &p_c
 	set_title(vformat(TTR("Change Type of \"%s\""), p_current_name));
 	set_ok_button_text(TTR("Change"));
 
-	allow_abstract_scripts = false;
+	type_filter = TYPE_FILTER_ALLOW_CONCRETE;
 
 	_popup_common();
 }
@@ -74,7 +74,18 @@ void CreateDialog::popup_inherit(bool p_dont_clear) {
 	set_title(vformat(TTR("Inherit %s"), base_type));
 	set_ok_button_text(TTR("Inherit"));
 
-	allow_abstract_scripts = true;
+	type_filter = TYPE_FILTER_ALLOW_SCRIPT_ABSTRACT;
+
+	_popup_common();
+}
+
+void CreateDialog::popup_choose_type(const String &p_current_type, const String &p_prop_name, TypeFilter p_type_filter) {
+	search_box->set_text(p_current_type);
+
+	set_title(vformat(TTR("Choose Object Type for \"%s\""), p_prop_name));
+	set_ok_button_text(TTR("Choose"));
+
+	type_filter = p_type_filter;
 
 	_popup_common();
 }
@@ -198,7 +209,9 @@ bool CreateDialog::_should_hide_type(const StringName &p_type) const {
 
 	if (ClassDB::class_exists(p_type)) {
 		if (!ClassDB::can_instantiate(p_type) || ClassDB::is_virtual(p_type)) {
-			return true; // Can't create abstract or virtual class.
+			if (type_filter != TYPE_FILTER_ALLOW_ALL) {
+				return true; // Can't create abstract or virtual class.
+			}
 		}
 
 		if (!ClassDB::is_parent_class(p_type, base_type)) {
@@ -250,7 +263,7 @@ bool CreateDialog::_should_hide_type(const StringName &p_type) const {
 		// Abstract scripts cannot be instantiated.
 		String path = ScriptServer::get_global_class_path(p_type);
 		Ref<Script> scr = ResourceLoader::load(path, "Script");
-		return scr.is_null() || (!allow_abstract_scripts && scr->is_abstract());
+		return scr.is_null() || (type_filter == TYPE_FILTER_ALLOW_CONCRETE && scr->is_abstract());
 	}
 
 	return false;
@@ -391,7 +404,7 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringN
 		type_name = p_type;
 		text = p_type;
 
-		if (!allow_abstract_scripts) {
+		if (type_filter == TYPE_FILTER_ALLOW_CONCRETE) {
 			is_abstract = ScriptServer::is_global_class_abstract(p_type);
 		}
 
@@ -424,8 +437,8 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringN
 	r_item->set_metadata(0, meta);
 
 	bool can_instantiate = (p_type_category == TypeCategory::CPP_TYPE && ClassDB::can_instantiate(p_type)) ||
-			(p_type_category == TypeCategory::OTHER_TYPE && !(!allow_abstract_scripts && is_abstract));
-	bool instantiable = can_instantiate && !(ClassDB::class_exists(p_type) && ClassDB::is_virtual(p_type));
+			(p_type_category == TypeCategory::OTHER_TYPE && !(type_filter == TYPE_FILTER_ALLOW_CONCRETE && is_abstract));
+	bool instantiable = type_filter == TYPE_FILTER_ALLOW_ALL || (can_instantiate && !(ClassDB::class_exists(p_type) && ClassDB::is_virtual(p_type)));
 
 	r_item->set_meta(SNAME("__instantiable"), instantiable);
 

--- a/editor/gui/create_dialog.h
+++ b/editor/gui/create_dialog.h
@@ -40,6 +40,14 @@
 class CreateDialog : public ConfirmationDialog {
 	GDCLASS(CreateDialog, ConfirmationDialog);
 
+public:
+	enum TypeFilter {
+		TYPE_FILTER_ALLOW_CONCRETE,
+		TYPE_FILTER_ALLOW_SCRIPT_ABSTRACT,
+		TYPE_FILTER_ALLOW_ALL,
+	};
+
+private:
 	enum TypeCategory {
 		CPP_TYPE,
 		PATH_TYPE,
@@ -56,7 +64,7 @@ class CreateDialog : public ConfirmationDialog {
 
 	String base_type;
 	bool is_base_type_node = false;
-	bool allow_abstract_scripts = false;
+	TypeFilter type_filter = TYPE_FILTER_ALLOW_CONCRETE;
 	String icon_fallback;
 	String preferred_search_result_type;
 
@@ -131,6 +139,7 @@ public:
 	void popup_create(bool p_dont_clear);
 	void popup_replace(const String &p_current_type = "", const String &p_current_name = "");
 	void popup_inherit(bool p_dont_clear);
+	void popup_choose_type(const String &p_current_type = "", const String &p_prop_name = "", TypeFilter p_type_filter = TYPE_FILTER_ALLOW_CONCRETE);
 
 	CreateDialog();
 };

--- a/editor/gui/create_dialog.h
+++ b/editor/gui/create_dialog.h
@@ -73,6 +73,7 @@ class CreateDialog : public ConfirmationDialog {
 	HashSet<StringName> type_blacklist;
 	HashSet<StringName> custom_type_blocklist;
 
+	void _popup_common();
 	void _update_search();
 	bool _should_hide_type(const StringName &p_type) const;
 	void _add_type(const StringName &p_type, TypeCategory p_type_category, const String &p_match_keyword);
@@ -125,8 +126,11 @@ public:
 	void set_type_blocklist(const HashSet<StringName> &p_blocklist) { custom_type_blocklist = p_blocklist; }
 	void set_preferred_search_result_type(const String &p_preferred_type) { preferred_search_result_type = p_preferred_type; }
 
-	void popup_create(bool p_dont_clear, bool p_replace_mode = false, const String &p_current_type = "", const String &p_current_name = "");
-	void for_inherit();
+	void set_search_type(const String &p_search);
+
+	void popup_create(bool p_dont_clear);
+	void popup_replace(const String &p_current_type = "", const String &p_current_name = "");
+	void popup_inherit(bool p_dont_clear);
 
 	CreateDialog();
 };

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -859,7 +859,7 @@ void EditorPropertyClassName::update_property() {
 }
 
 void EditorPropertyClassName::_property_selected() {
-	dialog->popup_create(true, true, get_edited_property_value(), get_edited_property());
+	dialog->popup_replace(get_edited_property_value(), get_edited_property());
 }
 
 void EditorPropertyClassName::_dialog_created() {

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -845,11 +845,12 @@ void EditorPropertyClassName::_set_read_only(bool p_read_only) {
 	property->set_disabled(p_read_only);
 }
 
-void EditorPropertyClassName::setup(const String &p_base_type, const String &p_selected_type) {
+void EditorPropertyClassName::setup(const String &p_base_type, const String &p_selected_type, TypeFilter p_type_filter) {
 	base_type = p_base_type;
 	dialog->set_base_type(base_type);
 	selected_type = p_selected_type;
 	property->set_text(selected_type);
+	type_filter = p_type_filter;
 }
 
 void EditorPropertyClassName::update_property() {
@@ -859,7 +860,7 @@ void EditorPropertyClassName::update_property() {
 }
 
 void EditorPropertyClassName::_property_selected() {
-	dialog->popup_replace(get_edited_property_value(), get_edited_property());
+	dialog->popup_choose_type(get_edited_property_value(), get_edited_property(), static_cast<CreateDialog::TypeFilter>(type_filter));
 }
 
 void EditorPropertyClassName::_dialog_created() {
@@ -3994,7 +3995,18 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				return editor;
 			} else if (p_hint == PROPERTY_HINT_TYPE_STRING) {
 				EditorPropertyClassName *editor = memnew(EditorPropertyClassName);
-				editor->setup(p_hint_text, p_hint_text);
+				Vector<String> hints = p_hint_text.split(",");
+				String type_name = hints[0];
+				hints.remove_at(0);
+				using CN = EditorPropertyClassName;
+				CN::TypeFilter type_filter = CN::TYPE_FILTER_ALLOW_CONCRETE;
+				if (hints.has("allow_script_abstract")) {
+					type_filter = CN::TYPE_FILTER_ALLOW_SCRIPT_ABSTRACT;
+				}
+				if (hints.has("allow_abstract")) {
+					type_filter = CN::TYPE_FILTER_ALLOW_ALL;
+				}
+				editor->setup(type_name, type_name, type_filter);
 				return editor;
 			} else if (p_hint == PROPERTY_HINT_LOCALE_ID) {
 				EditorPropertyLocale *editor = memnew(EditorPropertyLocale);

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -245,11 +245,19 @@ public:
 class EditorPropertyClassName : public EditorProperty {
 	GDCLASS(EditorPropertyClassName, EditorProperty);
 
+public:
+	enum TypeFilter {
+		TYPE_FILTER_ALLOW_CONCRETE,
+		TYPE_FILTER_ALLOW_SCRIPT_ABSTRACT,
+		TYPE_FILTER_ALLOW_ALL,
+	};
+
 private:
 	CreateDialog *dialog = nullptr;
 	Button *property = nullptr;
 	String selected_type;
 	String base_type;
+	TypeFilter type_filter = TYPE_FILTER_ALLOW_CONCRETE;
 	void _property_selected();
 	void _dialog_created();
 
@@ -257,7 +265,7 @@ protected:
 	virtual void _set_read_only(bool p_read_only) override;
 
 public:
-	void setup(const String &p_base_type, const String &p_selected_type);
+	void setup(const String &p_base_type, const String &p_selected_type, TypeFilter p_type_filter = TYPE_FILTER_ALLOW_CONCRETE);
 	virtual void update_property() override;
 	EditorPropertyClassName();
 };

--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -498,9 +498,7 @@ void ScriptCreateDialog::_create() {
 
 void ScriptCreateDialog::_browse_class_in_tree() {
 	select_class->set_base_type(base_type);
-	select_class->popup_create(true);
-	select_class->set_title(vformat(TTR("Inherit %s"), base_type));
-	select_class->set_ok_button_text(TTR("Inherit"));
+	select_class->popup_inherit(true);
 }
 
 void ScriptCreateDialog::_path_changed(const String &p_path) {
@@ -995,7 +993,6 @@ ScriptCreateDialog::ScriptCreateDialog() {
 
 	select_class = memnew(CreateDialog);
 	select_class->connect("create", callable_mp(this, &ScriptCreateDialog::_create));
-	select_class->for_inherit();
 	add_child(select_class);
 
 	file_browse = memnew(EditorFileDialog);


### PR DESCRIPTION
Closes godotengine/godot-proposals#13971
Depends on #114679

This allows `CreateDialog` to select an abstract class by specifying a `TypeFilter`, allows setting this `TypeFilter` in `EditorPropertyClassName`, and adds hint strings for `PROPERTY_HINT_TYPE_STRING` to customize the behavior.

In order to avoid header dependency, I duplicated the definitions of `TypeFilter` across `editor_properties.h` and `create_dialog.h`. If there's a more appropiate place to put both of them, let me know.