### PR TITLE
Prevent infinite loop with large world positions

### DIFF
--- a/servers/rendering/renderer_rd/shaders/environment/gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/gi.glsl
@@ -399,7 +399,10 @@ void sdfgi_process(vec3 vertex, vec3 normal, vec3 reflection, float roughness, o
 			float softness = 0.2 + min(1.0, roughness * 5.0) * 4.0; //approximation to roughness so it does not seem like a hard fade
 			uint i = 0;
 			bool found = false;
-			while (true) {
+			uint iteration_count = 0;
+			const uint MAX_ITERATIONS = 256;
+			while (iteration_count < MAX_ITERATIONS) {
+				iteration_count++;
 				if (length(ray_pos) >= max_distance || light_accum.a > 0.99) {
 					break;
 				}

--- a/servers/rendering/rendering_light_culler.cpp
+++ b/servers/rendering/rendering_light_culler.cpp
@@ -541,7 +541,9 @@ bool RenderingLightCuller::prepare_camera(const Transform3D &p_cam_transform, co
 		bool res = data.frustum_planes[intersections[i][0]].intersect_3(data.frustum_planes[intersections[i][1]], data.frustum_planes[intersections[i][2]], &data.frustum_points[i]);
 
 		// What happens with a zero frustum? NYI - deal with this.
-		ERR_FAIL_COND_V(!res, false);
+		if (!res) {
+			return false;
+		}
 
 #ifdef LIGHT_CULLER_DEBUG_LOGGING
 		if (is_logging()) {


### PR DESCRIPTION
## Description

Added iteration limit to SDFGI ray marching loop in `gi.glsl` to prevent potential infinite loops that could cause GPU hangs or driver timeouts.

## Problem

The `while(true)` loop in `sdfgi_process()` function relies on internal break conditions (`ray_pos >= max_distance` or `light_accum.a > 0.99`) to terminate. In edge cases with specific geometry or camera positions, these conditions may never be met, causing the shader to hang indefinitely.

## Related issues

Fixes #114677

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/119933*