### PR TITLE
Don't filter EditorFileDialog files with global access

### DIFF
--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -71,7 +71,7 @@ bool EditorFileDialog::_should_use_native_popup() const {
 }
 
 bool EditorFileDialog::_should_hide_file(const String &p_file) const {
-	if (Engine::get_singleton()->is_project_manager_hint()) {
+	if (get_access() != FileDialog::ACCESS_RESOURCES) {
 		return false;
 	}
 	const String full_path = dir_access->get_current_dir().path_join(p_file);


### PR DESCRIPTION
EditorFileDialog will hide some folders, like when there is another project or a `.gdignore` file. While it makes sense when browsing project's files, it does not make much sense to filter it when browsing global filesystem (e.g. when picking export path).