### PR TITLE
Improve usage of textfile extensions

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -4504,8 +4504,7 @@ void EditorHelpBit::parse_symbol(const String &p_symbol, const String &p_prologu
 		if (da->file_exists(path)) {
 			help_data.doc_type.type = ResourceLoader::get_resource_type(path);
 			if (help_data.doc_type.type.is_empty()) {
-				const Vector<String> textfile_ext = ((String)(EDITOR_GET("docks/filesystem/textfile_extensions"))).split(",", false);
-				symbol_type = textfile_ext.has(path.get_extension()) ? TTR("Text File") : TTR("File");
+				symbol_type = EditorSettings::get_singleton()->get_textfile_extensions().has(path.get_extension()) ? TTR("Text File") : TTR("File");
 			} else {
 				symbol_type = TTR("Resource");
 				symbol_hint = SYMBOL_HINT_ASSIGNABLE;

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -242,9 +242,8 @@ void InspectorDock::_load_resource(const String &p_type) {
 		load_resource_dialog->add_filter("*." + extension, extension.to_upper());
 	}
 
-	const Vector<String> textfile_ext = ((String)(EDITOR_GET("docks/filesystem/textfile_extensions"))).split(",", false);
-	for (int i = 0; i < textfile_ext.size(); i++) {
-		load_resource_dialog->add_filter("*." + textfile_ext[i], textfile_ext[i].to_upper());
+	for (const String &ext : EditorSettings::get_singleton()->get_textfile_extensions()) {
+		load_resource_dialog->add_filter("*." + ext, ext.to_upper());
 	}
 
 	load_resource_dialog->popup_file_dialog();
@@ -255,8 +254,7 @@ void InspectorDock::_resource_file_selected(const String &p_file) {
 	if (ResourceLoader::exists(p_file, "")) {
 		res = ResourceLoader::load(p_file);
 	} else {
-		const Vector<String> textfile_ext = ((String)(EDITOR_GET("docks/filesystem/textfile_extensions"))).split(",", false);
-		if (textfile_ext.has(p_file.get_extension())) {
+		if (EditorSettings::get_singleton()->get_textfile_extensions().has(p_file.get_extension())) {
 			res = ScriptEditor::get_singleton()->open_file(p_file);
 		}
 	}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1070,21 +1070,19 @@ void EditorNode::_notification(int p_what) {
 			}
 
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("docks/filesystem")) {
-				HashSet<String> updated_textfile_extensions;
-				HashSet<String> updated_other_file_extensions;
+				const HashSet<String> updated_textfile_extensions = EditorSettings::get_singleton()->get_textfile_extensions();
+				const HashSet<String> updated_other_file_extensions = EditorSettings::get_singleton()->get_other_file_extensions();
 				bool extensions_match = true;
-				const Vector<String> textfile_ext = ((String)(EDITOR_GET("docks/filesystem/textfile_extensions"))).split(",", false);
-				for (const String &E : textfile_ext) {
-					updated_textfile_extensions.insert(E);
+				for (const String &E : updated_textfile_extensions) {
 					if (extensions_match && !textfile_extensions.has(E)) {
 						extensions_match = false;
+						break;
 					}
 				}
-				const Vector<String> other_file_ext = ((String)(EDITOR_GET("docks/filesystem/other_file_extensions"))).split(",", false);
-				for (const String &E : other_file_ext) {
-					updated_other_file_extensions.insert(E);
+				for (const String &E : updated_other_file_extensions) {
 					if (extensions_match && !other_file_extensions.has(E)) {
 						extensions_match = false;
+						break;
 					}
 				}
 
@@ -8379,14 +8377,8 @@ EditorNode::EditorNode() {
 
 	ED_SHORTCUT("canvas_item_editor/pan_view", TTRC("Pan View"), Key::SPACE);
 
-	const Vector<String> textfile_ext = ((String)(EDITOR_GET("docks/filesystem/textfile_extensions"))).split(",", false);
-	for (const String &E : textfile_ext) {
-		textfile_extensions.insert(E);
-	}
-	const Vector<String> other_file_ext = ((String)(EDITOR_GET("docks/filesystem/other_file_extensions"))).split(",", false);
-	for (const String &E : other_file_ext) {
-		other_file_extensions.insert(E);
-	}
+	textfile_extensions = EditorSettings::get_singleton()->get_textfile_extensions();
+	other_file_extensions = EditorSettings::get_singleton()->get_other_file_extensions();
 
 	force_textfile_extensions.insert("csv"); // CSV translation source, has `Translation` resource type, but not loadable as resource.
 

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -3707,16 +3707,14 @@ void EditorFileSystem::_update_extensions() {
 		valid_extensions.insert(E);
 	}
 
-	const Vector<String> textfile_ext = ((String)(EDITOR_GET("docks/filesystem/textfile_extensions"))).split(",", false);
-	for (const String &E : textfile_ext) {
+	for (const String &E : EditorSettings::get_singleton()->get_textfile_extensions()) {
 		if (valid_extensions.has(E)) {
 			continue;
 		}
 		valid_extensions.insert(E);
 		textfile_extensions.insert(E);
 	}
-	const Vector<String> other_file_ext = ((String)(EDITOR_GET("docks/filesystem/other_file_extensions"))).split(",", false);
-	for (const String &E : other_file_ext) {
+	for (const String &E : EditorSettings::get_singleton()->get_other_file_extensions()) {
 		if (valid_extensions.has(E)) {
 			continue;
 		}

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3061,11 +3061,7 @@ void ScriptEditor::_editor_settings_changed() {
 }
 
 void ScriptEditor::_apply_editor_settings() {
-	textfile_extensions.clear();
-	const Vector<String> textfile_ext = ((String)(EDITOR_GET("docks/filesystem/textfile_extensions"))).split(",", false);
-	for (const String &E : textfile_ext) {
-		textfile_extensions.insert(E);
-	}
+	textfile_extensions = EditorSettings::get_singleton()->get_textfile_extensions();
 
 	trim_trailing_whitespace_on_save = EDITOR_GET("text_editor/behavior/files/trim_trailing_whitespace_on_save");
 	trim_final_newlines_on_save = EDITOR_GET("text_editor/behavior/files/trim_final_newlines_on_save");

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -78,6 +78,8 @@ bool EditorSettings::_set(const StringName &p_name, const Variant &p_value) {
 			if (!exec_args_value.is_empty() && _set_only(exec_args_name, exec_args_value)) {
 				changed_settings.insert(exec_args_name);
 			}
+		} else if (p_name == SNAME("docks/filesystem/textfile_extensions") || p_name == SNAME("docks/filesystem/other_file_extensions")) {
+			text_file_extensions_dirty = true;
 		}
 		emit_signal(SNAME("settings_changed"));
 
@@ -1229,6 +1231,22 @@ void EditorSettings::_remove_deprecated_settings() {
 }
 #endif
 
+void EditorSettings::_update_textfile_extensions_cache() {
+	if (!text_file_extensions_dirty) {
+		return;
+	}
+	text_file_extensions_dirty = false;
+
+	text_file_extensions.clear();
+	for (const String &ext : get_setting("docks/filesystem/textfile_extensions").operator String().split(",", 0)) {
+		text_file_extensions.insert(ext);
+	}
+	other_file_extensions.clear();
+	for (const String &ext : get_setting("docks/filesystem/other_file_extensions").operator String().split(",", 0)) {
+		other_file_extensions.insert(ext);
+	}
+}
+
 // PUBLIC METHODS
 
 EditorSettings *EditorSettings::get_singleton() {
@@ -2207,6 +2225,16 @@ const Array EditorSettings::get_builtin_action_overrides(const String &p_name) c
 	}
 
 	return Array();
+}
+
+const HashSet<String> EditorSettings::get_textfile_extensions() {
+	_update_textfile_extensions_cache();
+	return text_file_extensions;
+}
+
+const HashSet<String> EditorSettings::get_other_file_extensions() {
+	_update_textfile_extensions_cache();
+	return other_file_extensions;
 }
 
 void EditorSettings::notify_changes() {

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -105,6 +105,10 @@ private:
 	HashMap<String, PackedStringArray> favorite_properties;
 	Vector<String> recent_dirs;
 
+	bool text_file_extensions_dirty = true;
+	HashSet<String> text_file_extensions;
+	HashSet<String> other_file_extensions;
+
 	bool save_changed_setting = true;
 	bool optimize_save = true; //do not save stuff that came from config but was not set from engine
 	bool initialized = false;
@@ -126,6 +130,8 @@ private:
 #ifndef DISABLE_DEPRECATED
 	void _remove_deprecated_settings();
 #endif
+
+	void _update_textfile_extensions_cache();
 
 	// Bind helpers.
 	Vector<String> _get_shortcut_list();
@@ -206,6 +212,9 @@ public:
 
 	void set_builtin_action_override(const String &p_name, const TypedArray<InputEvent> &p_events);
 	const Array get_builtin_action_overrides(const String &p_name) const;
+
+	const HashSet<String> get_textfile_extensions();
+	const HashSet<String> get_other_file_extensions();
 
 	void notify_changes();
 


### PR DESCRIPTION
`textfile_extensions` is a comma-separated string of extensions for text files. I noticed the editor likes to fetch it and split in many places and sometimes repeatedly. Ugh.

This PR makes the setting cached, i.e. when you modify the string, EditorSettings will split it into a reusable HashSet. If you don't modify the setting, it's only split once per editor session (when loading).