### PR TITLE
Fix incorrect position of icons in `ItemList` when on top mode

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1550,11 +1550,10 @@ void ItemList::_notification(int p_what) {
 
 					if (icon_mode == ICON_MODE_TOP) {
 						pos.x += Math::floor((items[i].rect_cache.size.width - icon_size.width) / 2);
-						pos.y += theme_cache.icon_margin;
 						text_ofs.y = icon_size.height + theme_cache.icon_margin * 2;
 					} else {
 						pos.y += Math::floor((items[i].rect_cache.size.height - icon_size.height) / 2);
-						text_ofs.x = icon_size.width + theme_cache.icon_margin;
+						text_ofs.x = icon_size.width + theme_cache.icon_margin * 2;
 					}
 
 					Rect2 draw_rect = Rect2(pos, icon_size);


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="518" height="169" alt="Screenshot_20260107_203946" src="https://github.com/user-attachments/assets/dacea08f-3878-4d25-bc3e-b5b6cb2bc698" />|<img width="518" height="169" alt="Screenshot_20260107_204141" src="https://github.com/user-attachments/assets/88aee4c7-a62e-4556-aa4f-aa084ba45869" />|