### PR TITLE
[Accessibility] Force keyboard focus to the exclusive child.

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -823,6 +823,17 @@ void Window::_event_callback(DisplayServer::WindowEvent p_event) {
 			focused_window = this;
 			_propagate_window_notification(this, NOTIFICATION_WM_WINDOW_FOCUS_IN);
 			emit_signal(SceneStringName(focus_entered));
+			if (get_tree() && get_tree()->is_accessibility_enabled()) {
+				Window *w = exclusive_child;
+				while (w) {
+					if (w->exclusive_child) {
+						w = w->exclusive_child;
+					} else {
+						w->grab_focus();
+						break;
+					}
+				}
+			}
 		} break;
 		case DisplayServer::WINDOW_EVENT_FOCUS_OUT: {
 			focused = false;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109175

A workaround that should be safe. For 4.7 we probably should use system exclusive windows on all platforms, but this might change behavior.