### PR TITLE
Fix the height of generated texture

### DIFF
--- a/editor/scene/2d/particles_2d_editor_plugin.cpp
+++ b/editor/scene/2d/particles_2d_editor_plugin.cpp
@@ -581,7 +581,7 @@ void GPUParticles2DEditorPlugin::_generate_emission_mask() {
 
 	int valid_positions_count = emission_positions.size();
 	int w = 2048;
-	int h = (valid_positions_count / 2048) + 1;
+	int h = ((valid_positions_count - 1) / 2048) + 1;
 
 	mask_texture_data.resize_initialized(w * h * 2 * sizeof(float));
 

--- a/editor/scene/3d/particles_3d_editor_plugin.cpp
+++ b/editor/scene/3d/particles_3d_editor_plugin.cpp
@@ -350,7 +350,7 @@ void GPUParticles3DEditorPlugin::_generate_emission_points() {
 	int point_count = points.size();
 
 	int w = 2048;
-	int h = (point_count / 2048) + 1;
+	int h = ((point_count - 1) / 2048) + 1;
 
 	Vector<uint8_t> point_img;
 	point_img.resize(w * h * 3 * sizeof(float));


### PR DESCRIPTION
…e 2048 x 1 not 2048 x 2.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
