### PR TITLE
CameraFeed: Create new texture on datatype change

### DIFF
--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -189,21 +189,17 @@ void CameraFeed::set_rgb_image(const Ref<Image> &p_rgb_img) {
 		int new_width = p_rgb_img->get_width();
 		int new_height = p_rgb_img->get_height();
 
-		// Emit `format_changed` signal if feed datatype or frame size is changed.
-		// The signal is deferred to ensure:
-		// - They are emitted on Godot's main thread.
-		// - Both datatype and frame size are updated before the emission.
 		if (datatype != CameraFeed::FEED_RGB || (base_width != new_width) || (base_height != new_height)) {
-			call_deferred("emit_signal", format_changed_signal_name);
-		}
-
-		if ((base_width != new_width) || (base_height != new_height)) {
-			// We're assuming here that our camera image doesn't change around formats etc, allocate the whole lot...
 			base_width = new_width;
 			base_height = new_height;
 
 			RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_rgb_img);
 			RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_RGBA_IMAGE], new_texture);
+
+			// `format_changed` signal is deferred to ensure:
+			// - They are emitted on Godot's main thread.
+			// - Both datatype and frame size are updated before the emission.
+			call_deferred("emit_signal", format_changed_signal_name);
 		} else {
 			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_RGBA_IMAGE], p_rgb_img);
 		}
@@ -221,23 +217,19 @@ void CameraFeed::set_ycbcr_image(const Ref<Image> &p_ycbcr_img) {
 		int new_width = p_ycbcr_img->get_width();
 		int new_height = p_ycbcr_img->get_height();
 
-		// Emit `format_changed` signal if feed datatype or frame size is changed.
-		// The signal is deferred to ensure:
-		// - They are emitted on Godot's main thread.
-		// - Both datatype and frame size are updated before the emission.
 		if (datatype != CameraFeed::FEED_YCBCR || (base_width != new_width) || (base_height != new_height)) {
-			call_deferred("emit_signal", format_changed_signal_name);
-		}
-
-		if ((base_width != new_width) || (base_height != new_height)) {
-			// We're assuming here that our camera image doesn't change around formats etc, allocate the whole lot...
 			base_width = new_width;
 			base_height = new_height;
 
 			RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_ycbcr_img);
-			RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_RGBA_IMAGE], new_texture);
+			RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_YCBCR_IMAGE], new_texture);
+
+			// `format_changed` signal is deferred to ensure:
+			// - They are emitted on Godot's main thread.
+			// - Both datatype and frame size are updated before the emission.
+			call_deferred("emit_signal", format_changed_signal_name);
 		} else {
-			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_RGBA_IMAGE], p_ycbcr_img);
+			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_YCBCR_IMAGE], p_ycbcr_img);
 		}
 
 		datatype = CameraFeed::FEED_YCBCR;
@@ -258,16 +250,7 @@ void CameraFeed::set_ycbcr_images(const Ref<Image> &p_y_img, const Ref<Image> &p
 		int new_y_width = p_y_img->get_width();
 		int new_y_height = p_y_img->get_height();
 
-		// Emit `format_changed` signal if feed datatype or frame size is changed.
-		// The signal is deferred to ensure:
-		// - They are emitted on Godot's main thread.
-		// - Both datatype and frame size are updated before the emission.
 		if (datatype != CameraFeed::FEED_YCBCR_SEP || (base_width != new_y_width) || (base_height != new_y_height)) {
-			call_deferred("emit_signal", format_changed_signal_name);
-		}
-
-		if ((base_width != new_y_width) || (base_height != new_y_height)) {
-			// We're assuming here that our camera image doesn't change around formats etc, allocate the whole lot...
 			base_width = new_y_width;
 			base_height = new_y_height;
 			{
@@ -278,6 +261,11 @@ void CameraFeed::set_ycbcr_images(const Ref<Image> &p_y_img, const Ref<Image> &p
 				RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_cbcr_img);
 				RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_CBCR_IMAGE], new_texture);
 			}
+
+			// `format_changed` signal is deferred to ensure:
+			// - They are emitted on Godot's main thread.
+			// - Both datatype and frame size are updated before the emission.
+			call_deferred("emit_signal", format_changed_signal_name);
 		} else {
 			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_Y_IMAGE], p_y_img);
 			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_CBCR_IMAGE], p_cbcr_img);
@@ -291,21 +279,17 @@ void CameraFeed::set_ycbcr_images(const Ref<Image> &p_y_img, const Ref<Image> &p
 }
 
 void CameraFeed::set_external(int p_width, int p_height) {
-	// Emit `format_changed` signal if feed datatype or frame size is changed.
-	// The signal is deferred to ensure:
-	// - They are emitted on Godot's main thread.
-	// - Both datatype and frame size are updated before the emission.
 	if (datatype != CameraFeed::FEED_EXTERNAL || (base_width != p_width) || (base_height != p_height)) {
-		call_deferred("emit_signal", format_changed_signal_name);
-	}
-
-	if ((base_width != p_width) || (base_height != p_height)) {
-		// We're assuming here that our camera image doesn't change around formats etc, allocate the whole lot...
 		base_width = p_width;
 		base_height = p_height;
 
 		RID new_texture = RenderingServer::get_singleton()->texture_external_create(p_width, p_height, 0);
 		RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_YCBCR_IMAGE], new_texture);
+
+		// `format_changed` signal is deferred to ensure:
+		// - They are emitted on Godot's main thread.
+		// - Both datatype and frame size are updated before the emission.
+		call_deferred("emit_signal", format_changed_signal_name);
 	}
 
 	datatype = CameraFeed::FEED_EXTERNAL;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

This is the follow-up of #111206.

#111206 fixed `format_changed` signal not emitting when feed datatype is changed with the same frame size, but the actual update of image texture may fail when ~~the pixel size between formats~~  formats between camera feed texture and new images are different.

**Example:**

1. CameraFeed `feed` is configured to capture webcam frames at 640x480 with datatype `CameraFeed.FEED_YCBCR_SEP`.
2. `feed` is activated, camera texture at `CameraServer.FEED_Y_IMAGE` feed [is created](https://github.com/godotengine/godot/blob/5d9722e83288f33827bcad70561f0737f8cde456/servers/camera/camera_feed.cpp#L274) (usually) with image format `Image.FORMAT_R8`.
3. `feed` is deactivated, then configured again to capture frames at 640x480 with datatype `CameraFeed.FEED_RGB` this time.
4. `feed` is activated again, `format_changed` signal [is emitted](https://github.com/godotengine/godot/blob/5d9722e83288f33827bcad70561f0737f8cde456/servers/camera/camera_feed.cpp#L197) since the datatype has changed. But camera texture at `CameraServer.FEED_RGBA_IMAGE` feed is [not created](https://github.com/godotengine/godot/blob/5d9722e83288f33827bcad70561f0737f8cde456/servers/camera/camera_feed.cpp#L200) because both formats have the same frame size.
(Both `FEED_Y_IMAGE` and `FEED_RGBA_IMAGE` use the same index 0)
5. `feed` tries to [update the texture](https://github.com/godotengine/godot/blob/5d9722e83288f33827bcad70561f0737f8cde456/servers/camera/camera_feed.cpp#L208) previously created with image format `Image.FORMAT_R8` with images using format `Image.FORMAT_RGB8` (or `FORMAT_RGBA8` if the feed provides RGBA frames), texture update fails with error such as: https://github.com/godotengine/godot/blob/5d9722e83288f33827bcad70561f0737f8cde456/drivers/gles3/storage/texture_storage.cpp#L1718

This PR partially reverts #111206, and check for changes in datatype and frame size at the same time to fix the format mismatch between existing camera feed textures and newly captured camera image frames.