### PR TITLE
Fix codeblocks inside docs not updating with theme changes

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -640,6 +640,14 @@ void EditorNode::_update_theme(bool p_skip_creation) {
 	if (!p_skip_creation) {
 		theme = EditorThemeManager::generate_theme(theme);
 		DisplayServer::set_early_window_clear_color_override(true, theme->get_color(SNAME("background"), EditorStringName(Editor)));
+
+#if defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)
+		if (EditorHelpHighlighter::get_singleton()) {
+			// Update syntax colors.
+			EditorHelpHighlighter::free_singleton();
+			EditorHelpHighlighter::create_singleton();
+		}
+#endif
 	}
 
 	Vector<Ref<Theme>> editor_themes;


### PR DESCRIPTION
When changing theme settings like the color, the highlight colors of codeblocks inside documentation pages wouldn't be updated, causing stuff like this to happen:

<img width="715" height="182" alt="image" src="https://github.com/user-attachments/assets/d3e03079-8337-479f-b624-fa7a25eabfb9" />