### PR TITLE
Fix text in `ItemList` being cutoff when it shouldn't

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1550,10 +1550,10 @@ void ItemList::_notification(int p_what) {
 
 					if (icon_mode == ICON_MODE_TOP) {
 						pos.x += Math::floor((items[i].rect_cache.size.width - icon_size.width) / 2);
-						text_ofs.y = icon_size.height + theme_cache.icon_margin * 2;
+						text_ofs.y = icon_size.height + theme_cache.icon_margin;
 					} else {
 						pos.y += Math::floor((items[i].rect_cache.size.height - icon_size.height) / 2);
-						text_ofs.x = icon_size.width + theme_cache.icon_margin * 2;
+						text_ofs.x = icon_size.width + theme_cache.icon_margin;
 					}
 
 					Rect2 draw_rect = Rect2(pos, icon_size);


### PR DESCRIPTION
Fix regression caused by #114709.