### PR TITLE
Preserve winding order for transformed tiles' navigation polygons

### DIFF
--- a/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
@@ -444,10 +444,10 @@ void NavMeshGenerator2D::generator_bake_from_source_geometry_data(Ref<Navigation
 	if (baking_rect.has_area() && border_size > 0.0) {
 		Vector2 baking_rect_offset = p_navigation_mesh->get_baking_rect_offset();
 
-		const int rect_begin_x = baking_rect.position[0] + baking_rect_offset.x + border_size;
-		const int rect_begin_y = baking_rect.position[1] + baking_rect_offset.y + border_size;
-		const int rect_end_x = baking_rect.position[0] + baking_rect.size[0] + baking_rect_offset.x - border_size;
-		const int rect_end_y = baking_rect.position[1] + baking_rect.size[1] + baking_rect_offset.y - border_size;
+		const double rect_begin_x = baking_rect.position[0] + baking_rect_offset.x + border_size;
+		const double rect_begin_y = baking_rect.position[1] + baking_rect_offset.y + border_size;
+		const double rect_end_x = baking_rect.position[0] + baking_rect.size[0] + baking_rect_offset.x - border_size;
+		const double rect_end_y = baking_rect.position[1] + baking_rect.size[1] + baking_rect_offset.y - border_size;
 
 		RectD clipper_rect = RectD(rect_begin_x, rect_begin_y, rect_end_x, rect_end_y);
 

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -3565,16 +3565,7 @@ void TileMapLayer::navmesh_parse_source_geometry(const Ref<NavigationPolygon> &p
 						continue;
 					}
 
-					Vector<Vector2> traversable_outline;
-					traversable_outline.resize(navigation_polygon_outline.size());
-
-					const Vector2 *navigation_polygon_outline_ptr = navigation_polygon_outline.ptr();
-					Vector2 *traversable_outline_ptrw = traversable_outline.ptrw();
-
-					for (int traversable_outline_index = 0; traversable_outline_index < traversable_outline.size(); traversable_outline_index++) {
-						traversable_outline_ptrw[traversable_outline_index] = tile_transform_offset.xform(navigation_polygon_outline_ptr[traversable_outline_index]);
-					}
-
+					Vector<Vector2> traversable_outline = tile_transform_offset.xform(navigation_polygon_outline);
 					p_source_geometry_data->_add_traversable_outline(traversable_outline);
 				}
 			}
@@ -3598,16 +3589,7 @@ void TileMapLayer::navmesh_parse_source_geometry(const Ref<NavigationPolygon> &p
 						collision_polygon_points = TileData::get_transformed_vertices(collision_polygon_points, flip_h, flip_v, transpose);
 					}
 
-					Vector<Vector2> obstruction_outline;
-					obstruction_outline.resize(collision_polygon_points.size());
-
-					const Vector2 *collision_polygon_points_ptr = collision_polygon_points.ptr();
-					Vector2 *obstruction_outline_ptrw = obstruction_outline.ptrw();
-
-					for (int obstruction_outline_index = 0; obstruction_outline_index < obstruction_outline.size(); obstruction_outline_index++) {
-						obstruction_outline_ptrw[obstruction_outline_index] = tile_transform_offset.xform(collision_polygon_points_ptr[obstruction_outline_index]);
-					}
-
+					Vector<Vector2> obstruction_outline = tile_transform_offset.xform(collision_polygon_points);
 					p_source_geometry_data->_add_obstruction_outline(obstruction_outline);
 				}
 			}

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -1029,7 +1029,7 @@ public:
 	Variant get_custom_data_by_layer_id(int p_layer_id) const;
 
 	// Polygons.
-	static PackedVector2Array get_transformed_vertices(const PackedVector2Array &p_vertices, bool p_flip_h, bool p_flip_v, bool p_transpose);
+	static PackedVector2Array get_transformed_vertices(const PackedVector2Array &p_vertices, bool p_flip_h, bool p_flip_v, bool p_transpose, bool p_preserve_winding_order = false);
 };
 
 VARIANT_ENUM_CAST(TileSet::CellNeighbor);


### PR DESCRIPTION
Makes tile navigation polygons vertex winding order be preserved for tiles transformed within TileMapLayer cells. As noted in https://github.com/godotengine/godot/issues/109641#issuecomment-3724104779, this still can result in the tiles creating holes in the outer outline, but at least now it's consistent for the given tile regardless of its per-cell transform flags.

Not sure if this resolves fully #109641.

(example below from https://github.com/godotengine/godot/issues/109641#issuecomment-3719832136)
Before|After
-|-
<img width="989" height="606" alt="ShareX_nemC8pwgXn" src="https://github.com/user-attachments/assets/3d6843d7-f9d0-455d-a739-4806ebd2abae" />|<img width="989" height="606" alt="QXwYGgINwx" src="https://github.com/user-attachments/assets/f38a3496-3fed-4f70-8369-36ff83853cdd" />
<img width="989" height="606" alt="zRZFWmiivZ" src="https://github.com/user-attachments/assets/0da73bdc-e8cd-45bd-afce-95156f0371ba" />|<img width="989" height="606" alt="1kiu0lghfH" src="https://github.com/user-attachments/assets/a1c30e75-9f51-45b2-b490-ee6c2e082a7b" />
