### PR TITLE
Fix PopupMenu size scaling again

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3415,8 +3415,9 @@ void PopupMenu::_pre_popup() {
 		p = p->get_parent();
 	}
 
-	if (scale_with_parent && p) {
-		Size2 scale = get_force_native() ? get_parent_viewport()->get_popup_base_transform_native().get_scale() : get_parent_viewport()->get_popup_base_transform().get_scale();
+	Viewport *vp = get_parent_viewport();
+	if (scale_with_parent && vp) {
+		Size2 scale = is_embedded() ? vp->get_popup_base_transform().get_scale() : vp->get_popup_base_transform_native().get_scale();
 		CanvasItem *c = Object::cast_to<CanvasItem>(get_parent());
 		if (c) {
 			scale *= c->get_global_transform_with_canvas().get_scale();


### PR DESCRIPTION
Fixed again #98672
Supersedes #114187

master:
<img width="1920" height="1080" alt="屏幕截图_20260108_231444" src="https://github.com/user-attachments/assets/1228cfc3-f1f8-4d03-8182-ad59b2db58fd" />

this pr:
<img width="1920" height="1080" alt="屏幕截图_20260108_234933" src="https://github.com/user-attachments/assets/eae423f6-0c19-4c90-bab5-0f5be4cc951f" />
