### PR TITLE
Add start/end build timestamps

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -361,6 +361,9 @@ opts.Add("cpp_compiler_launcher", "C++ compiler launcher (e.g. `ccache`)")
 # in following code (especially platform and custom_modules).
 opts.Update(env)
 
+if not env.GetOption("clean") and not env.GetOption("help"):
+    methods.print_started_at()
+
 # Setup caching logic early to catch everything.
 methods.prepare_cache(env)
 

--- a/SConstruct
+++ b/SConstruct
@@ -357,12 +357,22 @@ opts.Add("rcflags", "Custom flags for Windows resource compiler")
 opts.Add("c_compiler_launcher", "C compiler launcher (e.g. `ccache`)")
 opts.Add("cpp_compiler_launcher", "C++ compiler launcher (e.g. `ccache`)")
 
+opts.Add(
+    EnumVariable(
+        "build_timestamp_timezone",
+        "Determines which timezone to use to print build timestamps in SCons terminal output. Defaults to `utc`",
+        "utc",
+        ["utc", "system"],
+        {"local": "system"},
+    )
+)
+
 # Update the environment to have all above options defined
 # in following code (especially platform and custom_modules).
 opts.Update(env)
 
 if not env.GetOption("clean") and not env.GetOption("help"):
-    methods.print_started_at()
+    methods.print_started_at(env)
 
 # Setup caching logic early to catch everything.
 methods.prepare_cache(env)
@@ -1235,4 +1245,4 @@ if not env.GetOption("clean") and not env.GetOption("help"):
     methods.dump(env)
     methods.show_progress(env)
     methods.prepare_purge(env)
-    methods.prepare_timer()
+    methods.prepare_timer(env)

--- a/SConstruct
+++ b/SConstruct
@@ -372,7 +372,7 @@ opts.Add(
 opts.Update(env)
 
 if not env.GetOption("clean") and not env.GetOption("help"):
-    methods.print_started_at(env)
+    methods.print_started_at(methods.get_build_timezone(env))
 
 # Setup caching logic early to catch everything.
 methods.prepare_cache(env)
@@ -1245,4 +1245,4 @@ if not env.GetOption("clean") and not env.GetOption("help"):
     methods.dump(env)
     methods.show_progress(env)
     methods.prepare_purge(env)
-    methods.prepare_timer(env)
+    methods.prepare_timer(methods.get_build_timezone(env))

--- a/methods.py
+++ b/methods.py
@@ -968,6 +968,7 @@ def prepare_purge(env):
 
 
 def prepare_timer():
+    import datetime
     import time
 
     def print_elapsed_time(time_at_start: float):
@@ -976,7 +977,43 @@ def prepare_timer():
         time_centiseconds = (time_elapsed % 1) * 100
         print_info(f"Time elapsed: {time_formatted}.{time_centiseconds:02.0f}")
 
+    def print_ended_at():
+        time_now_utc = datetime.datetime.now(datetime.timezone.utc)
+        time_now_local = time_now_utc.astimezone(datetime.datetime.now().astimezone().tzinfo)
+
+        timestamp_local = time_now_local.isoformat()
+        timestamp_utc = time_now_utc.isoformat()
+
+        info_string = "\n".join(
+            [
+                "Time at end: ",
+                f"{timestamp_utc} ({time_now_utc.tzname()})",
+                f"{timestamp_local} ({time_now_local.tzname()})",
+            ]
+        )
+        print_info(info_string)
+
+    atexit.register(print_ended_at)
     atexit.register(print_elapsed_time, time.time())
+
+
+def print_started_at():
+    import datetime
+
+    time_now_utc = datetime.datetime.now(datetime.timezone.utc)
+    time_now_local = time_now_utc.astimezone(datetime.datetime.now().astimezone().tzinfo)
+
+    timestamp_local = time_now_local.isoformat()
+    timestamp_utc = time_now_utc.isoformat()
+
+    info_string = "\n".join(
+        [
+            "Time at start: ",
+            f"{timestamp_utc} ({time_now_utc.tzname()})",
+            f"{timestamp_local} ({time_now_local.tzname()})",
+        ]
+    )
+    print_info(info_string)
 
 
 def dump(env):

--- a/methods.py
+++ b/methods.py
@@ -967,7 +967,7 @@ def prepare_purge(env):
     atexit.register(purge_flaky_files)
 
 
-def prepare_timer(env):
+def get_build_timezone(env):
     import datetime
 
     build_timestamp_timezone = env["build_timestamp_timezone"]  # type: str
@@ -976,6 +976,12 @@ def prepare_timer(env):
         system_tzinfo = datetime.datetime.now().astimezone().tzinfo
         if system_tzinfo is not None and isinstance(system_tzinfo, datetime.timezone):
             timezone = system_tzinfo
+
+    return timezone
+
+
+def prepare_timer(timezone):
+    import datetime
 
     # cs: centisecond 0.01
     # us: microsecond 0.000001
@@ -1004,15 +1010,8 @@ def prepare_timer(env):
     atexit.register(print_elapsed_time, now())
 
 
-def print_started_at(env):
+def print_started_at(timezone):
     import datetime
-
-    build_timestamp_timezone = env["build_timestamp_timezone"]  # type: str
-    timezone = datetime.timezone.utc  # type: datetime.timezone
-    if build_timestamp_timezone == "system":
-        system_tzinfo = datetime.datetime.now().astimezone().tzinfo
-        if system_tzinfo is not None and isinstance(system_tzinfo, datetime.timezone):
-            timezone = system_tzinfo
 
     time_at_start = datetime.datetime.now(timezone)
     print_info(f"(build started at {time_at_start.strftime('%Y-%m-%d %H:%M:%S')} {timezone.tzname(time_at_start)})")


### PR DESCRIPTION
This PR adds a timestamp at the beginning of builds, and at the end also.

So many times, I trigger a build again because I cannot differentiate an old build from a new in my terminal.

> [!NOTE]
> Updated my PR following @Calinou's suggestion.

Features:
- New build option: 
  - ``build_timestamp_timezone: Determines which timezone to use to print build timestamps in SCons terminal output. Defaults to `utc` (utc|system)``
- Uses `datetime` for all timestamp calculation (including the build time)

### Start of the build
#### Plain text
```plain
❯ scons
scons: Reading SConscript files ...
INFO: (build started at 2026-01-08 20:02:16 UTC)
```
#### Picture
<img width="434" height="131" alt="Capture d’écran, le 2026-01-08 à 15 02 44" src="https://github.com/user-attachments/assets/83688fa0-02d3-432f-8a6c-c6c8d3a81bb7" />

### End of the build
#### Plain text
```plain
[100%] scons: done building targets.
INFO: Time elapsed: 0:00:14.90 (build ended at 2026-01-08 20:02:31 UTC)
```
#### Picture
<img width="602" height="109" alt="Capture d’écran, le 2026-01-08 à 15 05 08" src="https://github.com/user-attachments/assets/f32c3745-fca9-4d77-83ca-14e12a8116ae" />


