### PR TITLE
Fix animation track group hover color in modern theme

### DIFF
--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -2452,7 +2452,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_stylebox("header", "AnimationTrackEditGroup", style_animation_track_header);
 
 		Ref<StyleBoxFlat> style_animation_track_group_hover = p_config.base_style->duplicate();
-		style_animation_track_group_hover->set_bg_color(p_config.highlight_color);
+		style_animation_track_group_hover->set_bg_color(p_config.surface_high_color);
 		p_theme->set_stylebox(SceneStringName(hover), "AnimationTrackEditGroup", style_animation_track_group_hover);
 
 		p_theme->set_color("bg_color", "AnimationTrackEditGroup", p_config.surface_base_color);


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/112148 added hover to animation groups but `highlight_color` is accent color and modern theme doesn't use accent color for hover anywhere else. I think in the [video](https://github.com/godotengine/godot/pull/112148#issuecomment-3474132693) godot has monochrome accent color set in editor settings