### PR TITLE
Fix `AudioStreamPlayer.play()` ignores `get_tree().paused`

### DIFF
--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -121,6 +121,10 @@ void AudioStreamPlayer::play(float p_from_pos) {
 
 		AudioServer::get_singleton()->start_sample_playback(sample_playback);
 	}
+
+	if (!can_process()) {
+		_notification(NOTIFICATION_PAUSED);
+	}
 }
 
 void AudioStreamPlayer::seek(float p_seconds) {

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -44,8 +44,17 @@ void AudioStreamPlayer::_notification(int p_what) {
 		ERR_FAIL_COND(ae.is_null());
 
 		AccessibilityServer::get_singleton()->update_set_role(ae, AccessibilityServerEnums::AccessibilityRole::ROLE_AUDIO);
-	} else {
-		internal->notification(p_what);
+		return;
+	}
+
+	internal->notification(p_what);
+
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_UNPAUSED:
+		case NOTIFICATION_UNSUSPENDED: {
+			_flush_deferred_plays();
+		} break;
 	}
 }
 
@@ -108,22 +117,12 @@ int AudioStreamPlayer::get_max_polyphony() const {
 }
 
 void AudioStreamPlayer::play(float p_from_pos) {
-	Ref<AudioStreamPlayback> stream_playback = internal->play_basic();
-	if (stream_playback.is_null()) {
+	if (is_inside_tree() && !can_process()) {
+		deferred_plays.push_back(p_from_pos);
 		return;
 	}
-	AudioServer::get_singleton()->start_playback_stream(stream_playback, internal->bus, _get_volume_vector(), p_from_pos, internal->pitch_scale);
-	internal->ensure_playback_limit();
 
-	// Sample handling.
-	if (stream_playback->get_is_sample() && stream_playback->get_sample_playback().is_valid()) {
-		Ref<AudioSamplePlayback> sample_playback = stream_playback->get_sample_playback();
-		sample_playback->offset = p_from_pos;
-		sample_playback->volume_vector = _get_volume_vector();
-		sample_playback->bus = get_bus();
-
-		AudioServer::get_singleton()->start_sample_playback(sample_playback);
-	}
+	_play(p_from_pos);
 }
 
 void AudioStreamPlayer::seek(float p_seconds) {
@@ -131,6 +130,7 @@ void AudioStreamPlayer::seek(float p_seconds) {
 }
 
 void AudioStreamPlayer::stop() {
+	deferred_plays.clear();
 	internal->stop_basic();
 }
 
@@ -167,6 +167,36 @@ void AudioStreamPlayer::set_mix_target(MixTarget p_target) {
 
 AudioStreamPlayer::MixTarget AudioStreamPlayer::get_mix_target() const {
 	return mix_target;
+}
+
+void AudioStreamPlayer::_play(float p_from_pos) {
+	Ref<AudioStreamPlayback> stream_playback = internal->play_basic();
+	if (stream_playback.is_null()) {
+		return;
+	}
+	AudioServer::get_singleton()->start_playback_stream(stream_playback, internal->bus, _get_volume_vector(), p_from_pos, internal->pitch_scale);
+	internal->ensure_playback_limit();
+
+	// Sample handling.
+	if (stream_playback->get_is_sample() && stream_playback->get_sample_playback().is_valid()) {
+		Ref<AudioSamplePlayback> sample_playback = stream_playback->get_sample_playback();
+		sample_playback->offset = p_from_pos;
+		sample_playback->volume_vector = _get_volume_vector();
+		sample_playback->bus = get_bus();
+
+		AudioServer::get_singleton()->start_sample_playback(sample_playback);
+	}
+}
+
+void AudioStreamPlayer::_flush_deferred_plays() {
+	if (deferred_plays.is_empty() || !can_process()) {
+		return;
+	}
+	const Vector<float> pending = deferred_plays;
+	deferred_plays.clear();
+	for (const float &from_pos : pending) {
+		_play(from_pos);
+	}
 }
 
 void AudioStreamPlayer::_set_playing(bool p_enable) {

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -53,8 +53,13 @@ private:
 
 	MixTarget mix_target = MIX_TARGET_STEREO;
 
+	Vector<float> deferred_plays;
+
 	void _set_playing(bool p_enable);
 	bool _is_active() const;
+
+	void _play(float p_from_pos);
+	void _flush_deferred_plays();
 
 	Vector<AudioFrame> _get_volume_vector();
 

--- a/scene/audio/audio_stream_player_internal.cpp
+++ b/scene/audio/audio_stream_player_internal.cpp
@@ -139,6 +139,9 @@ Ref<AudioStreamPlayback> AudioStreamPlayerInternal::play_basic() {
 		return stream_playback;
 	}
 	ERR_FAIL_COND_V_MSG(!node->is_inside_tree(), stream_playback, "Playback can only happen when a node is inside the scene tree");
+	if (!node->can_process()) {
+		return stream_playback;
+	}
 	if (stream->is_monophonic() && is_playing()) {
 		stop_callable.call();
 	}

--- a/scene/audio/audio_stream_player_internal.cpp
+++ b/scene/audio/audio_stream_player_internal.cpp
@@ -139,9 +139,6 @@ Ref<AudioStreamPlayback> AudioStreamPlayerInternal::play_basic() {
 		return stream_playback;
 	}
 	ERR_FAIL_COND_V_MSG(!node->is_inside_tree(), stream_playback, "Playback can only happen when a node is inside the scene tree");
-	if (!node->can_process()) {
-		return stream_playback;
-	}
 	if (stream->is_monophonic() && is_playing()) {
 		stop_callable.call();
 	}


### PR DESCRIPTION
## Problem
`AudioStreamPlayerInternal::play_basic()` does not respect Node pause mode.
As a result, a `AudioStreamPlayer` can start playback while the SceneTree is paused.

This change prevents play from starting when `node->can_process()` is false.

## Issue
Fixes #114694