### PR TITLE
Workaround crash in pipeline creation on Intel Mesa devices by avoiding using half floats in derivative functions

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1597,7 +1597,7 @@ void main() {
 		float lod;
 		half blend = half(modf(float(sqrt(roughness) * MAX_ROUGHNESS_LOD), lod));
 
-		float ref_lod = vec3_to_oct_lod(dFdx(ref_vec), dFdy(ref_vec), scene_data_block.data.radiance_pixel_size);
+		float ref_lod = vec3_to_oct_lod(dFdx(vec3(ref_vec)), dFdy(vec3(ref_vec)), scene_data_block.data.radiance_pixel_size);
 		vec2 ref_uv = vec3_to_oct_with_border(ref_vec, vec2(scene_data_block.data.radiance_border_size, 1.0 - scene_data_block.data.radiance_border_size * 2.0));
 		hvec3 indirect_sample_a = hvec3(textureLod(sampler2DArray(radiance_octmap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec3(ref_uv, float(lod)), ref_lod).rgb);
 		hvec3 indirect_sample_b = hvec3(textureLod(sampler2DArray(radiance_octmap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec3(ref_uv, float(lod) + 1.0), ref_lod).rgb);
@@ -1662,7 +1662,7 @@ void main() {
 		float lod;
 		half blend = half(modf(roughness_lod, lod));
 
-		float ref_lod = vec3_to_oct_lod(dFdx(ref_vec), dFdy(ref_vec), scene_data_block.data.radiance_pixel_size);
+		float ref_lod = vec3_to_oct_lod(dFdx(vec3(ref_vec)), dFdy(vec3(ref_vec)), scene_data_block.data.radiance_pixel_size);
 		vec2 ref_uv = vec3_to_oct_with_border(ref_vec, vec2(scene_data_block.data.radiance_border_size, 1.0 - scene_data_block.data.radiance_border_size * 2.0));
 		hvec3 clearcoat_sample_a = hvec3(textureLod(sampler2DArray(radiance_octmap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec3(ref_uv, lod), ref_lod).rgb);
 		hvec3 clearcoat_sample_b = hvec3(textureLod(sampler2DArray(radiance_octmap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec3(ref_uv, lod + 1), ref_lod).rgb);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/114743
Fixes: https://github.com/godotengine/godot/issues/114292

Functionally this shouldn't change much on any platform. `vec3_to_oct_lod` takes vec3 input so the results of dFdx and dFdy need to be promoted to vec3 anyway. I suspect that drivers typically promote to vec3 _after_ doing the derivative function, but many drivers don't support taking derivatives of half floats anyway and will implicitly convert to full float, then convert back to half float after. In that case, the result will be the same both before and after this PR. 

This is a safe workaround that should have minimal impact on performance for any device. 

**Future considerations**
It is clear from both this issue and https://github.com/godotengine/godot/pull/110363 that these classes of Intel iGPUs have very poor half float support on Mesa drivers. 

Comminux's investigation also confirms that this issue seems to have been fixed and reintroduced in later versions of Mesa https://github.com/godotengine/godot/issues/114292#issuecomment-3707296165

IMO we should go ahead with the workaround and just deal with it since we can't force end users to use the working versions of Mesa. In a few years this workaround can probably be dropped, but until then I think we are stuck with it