### PR TITLE
[4.5] pcre2: Update to 10.46

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -892,7 +892,7 @@ Exclude:
 ## pcre2
 
 - Upstream: http://www.pcre.org
-- Version: 10.45 (2dce7761b1831fd3f82a9c2bd5476259d945da4d, 2025)
+- Version: 10.46 (b2bd4254b379b9d7dc9a3dda060a7e27009ccdff, 2025)
 - License: BSD-3-Clause
 
 Files extracted from upstream source:
@@ -904,6 +904,11 @@ Files extracted from upstream source:
 - `src/pcre2_ucptables.c`
 - `deps/sljit/sljit_src`
 - `AUTHORS.md` and `LICENCE.md`
+
+Patches:
+
+- `0001-fix-format-enumerate.patch` (GH-114766)
+- `0002-fix-duplicate-symbols.patch` (GH-114766)
 
 
 ## recastnavigation

--- a/thirdparty/pcre2/patches/0001-fix-format-enumerate.patch
+++ b/thirdparty/pcre2/patches/0001-fix-format-enumerate.patch
@@ -1,0 +1,14 @@
+diff --git a/thirdparty/pcre2/src/pcre2_pattern_info.c b/thirdparty/pcre2/src/pcre2_pattern_info.c
+index fe4d3c661a..c49eaf69b2 100644
+--- a/thirdparty/pcre2/src/pcre2_pattern_info.c
++++ b/thirdparty/pcre2/src/pcre2_pattern_info.c
+@@ -292,8 +292,7 @@ if (re->magic_number != MAGIC_NUMBER) return PCRE2_ERROR_BADMAGIC;
+ if ((re->flags & (PCRE2_CODE_UNIT_WIDTH/8)) == 0) return PCRE2_ERROR_BADMODE;
+ 
+ cb.version = 0;
+-cc = (PCRE2_SPTR)((const uint8_t *)re + sizeof(pcre2_real_code))
+-     + re->name_count * re->name_entry_size;
++cc = (PCRE2_SPTR)((uint8_t *)re + re->code_start);
+ 
+ while (TRUE)
+   {

--- a/thirdparty/pcre2/patches/0002-fix-duplicate-symbols.patch
+++ b/thirdparty/pcre2/patches/0002-fix-duplicate-symbols.patch
@@ -1,0 +1,12 @@
+diff --git a/thirdparty/pcre2/src/pcre2_internal.h b/thirdparty/pcre2/src/pcre2_internal.h
+index 6e0a5e05d0..f04832e56b 100644
+--- a/thirdparty/pcre2/src/pcre2_internal.h
++++ b/thirdparty/pcre2/src/pcre2_internal.h
+@@ -2165,6 +2165,7 @@ is available. */
+ 
+ #define _pcre2_auto_possessify       PCRE2_SUFFIX(_pcre2_auto_possessify_)
+ #define _pcre2_check_escape          PCRE2_SUFFIX(_pcre2_check_escape_)
++#define _pcre2_ckd_smul              PCRE2_SUFFIX(_pcre2_ckd_smul_)
+ #define _pcre2_extuni                PCRE2_SUFFIX(_pcre2_extuni_)
+ #define _pcre2_find_bracket          PCRE2_SUFFIX(_pcre2_find_bracket_)
+ #define _pcre2_is_newline            PCRE2_SUFFIX(_pcre2_is_newline_)

--- a/thirdparty/pcre2/src/config.h
+++ b/thirdparty/pcre2/src/config.h
@@ -255,7 +255,7 @@ sure both macros are undefined; an emulation function will then be used. */
 #define PACKAGE_NAME "PCRE2"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "PCRE2 10.45"
+#define PACKAGE_STRING "PCRE2 10.46"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "pcre2"
@@ -264,7 +264,7 @@ sure both macros are undefined; an emulation function will then be used. */
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "10.45"
+#define PACKAGE_VERSION "10.46"
 
 /* The value of PARENS_NEST_LIMIT specifies the maximum depth of nested
    parentheses (of any kind) in a pattern. This limits the amount of system
@@ -464,7 +464,7 @@ sure both macros are undefined; an emulation function will then be used. */
 #endif
 
 /* Version number of package */
-#define VERSION "10.45"
+#define VERSION "10.46"
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 /* #undef _FILE_OFFSET_BITS */

--- a/thirdparty/pcre2/src/pcre2.h
+++ b/thirdparty/pcre2/src/pcre2.h
@@ -42,9 +42,9 @@ POSSIBILITY OF SUCH DAMAGE.
 /* The current PCRE version information. */
 
 #define PCRE2_MAJOR           10
-#define PCRE2_MINOR           45
+#define PCRE2_MINOR           46
 #define PCRE2_PRERELEASE      
-#define PCRE2_DATE            2025-02-05
+#define PCRE2_DATE            2025-08-27
 
 /* When an application links to a PCRE DLL in Windows, the symbols that are
 imported have to be identified as such. When building PCRE2, the appropriate

--- a/thirdparty/pcre2/src/pcre2_internal.h
+++ b/thirdparty/pcre2/src/pcre2_internal.h
@@ -2165,6 +2165,7 @@ is available. */
 
 #define _pcre2_auto_possessify       PCRE2_SUFFIX(_pcre2_auto_possessify_)
 #define _pcre2_check_escape          PCRE2_SUFFIX(_pcre2_check_escape_)
+#define _pcre2_ckd_smul              PCRE2_SUFFIX(_pcre2_ckd_smul_)
 #define _pcre2_extuni                PCRE2_SUFFIX(_pcre2_extuni_)
 #define _pcre2_find_bracket          PCRE2_SUFFIX(_pcre2_find_bracket_)
 #define _pcre2_is_newline            PCRE2_SUFFIX(_pcre2_is_newline_)

--- a/thirdparty/pcre2/src/pcre2_match.c
+++ b/thirdparty/pcre2/src/pcre2_match.c
@@ -5824,6 +5824,9 @@ fprintf(stderr, "++ %2ld op=%3d %s\n", Fecode - mb->start_code, *Fecode,
               assert_accept_frame->offset_top * sizeof(PCRE2_SIZE));
         Foffset_top = assert_accept_frame->offset_top;
         Fmark = assert_accept_frame->mark;
+        mb->end_subject = Lsaved_end_subject;
+        mb->true_end_subject = mb->end_subject + Ltrue_end_extra;
+        mb->moptions = Lsaved_moptions;
         break;
         }
 

--- a/thirdparty/pcre2/src/pcre2_pattern_info.c
+++ b/thirdparty/pcre2/src/pcre2_pattern_info.c
@@ -292,8 +292,7 @@ if (re->magic_number != MAGIC_NUMBER) return PCRE2_ERROR_BADMAGIC;
 if ((re->flags & (PCRE2_CODE_UNIT_WIDTH/8)) == 0) return PCRE2_ERROR_BADMODE;
 
 cb.version = 0;
-cc = (PCRE2_SPTR)((const uint8_t *)re + sizeof(pcre2_real_code))
-     + re->name_count * re->name_entry_size;
+cc = (PCRE2_SPTR)((uint8_t *)re + re->code_start);
 
 while (TRUE)
   {


### PR DESCRIPTION
Security update. Not going all the way to 10.47 like in #113967 as that one is a feature update, not necessarily suitable for older stable branches.

Backports another security adjacent fix from 10.47, and a fix for duplicate symbols (supersedes #108685).