### PR TITLE
Fix sky radiance texunit in compatibility renderer

### DIFF
--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -40,7 +40,7 @@ in vec2 uv_interp;
 
 /* clang-format on */
 
-uniform samplerCube radiance; //texunit:-1
+uniform samplerCube radiance; //texunit:-2
 #ifdef USE_CUBEMAP_PASS
 uniform samplerCube half_res; //texunit:-2
 uniform samplerCube quarter_res; //texunit:-3


### PR DESCRIPTION
Fixes #114606: Reading radiance in sky shader in compatibility mode does not work

Aligned texunit in shader to binding. See drivers/gles3/rasterizer_scene_gles3.cpp / _render_list_template:

```
glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 2);
(...)
texture_to_bind = sky->radiance;
(...)
glBindTexture(GL_TEXTURE_CUBE_MAP, texture_to_bind);
```

Please note that I did not know what to do with half_res and quarter_res -- most likely they are also wrong or even not available in compatibility.