### PR TITLE
Add `StringName` `&` literal syntax to `Expression`

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -844,7 +844,17 @@ Expression::ENode *Expression::_parse_expression() {
 				expression_nodes.push_back(e);
 				continue;
 			} break;
+                        case TK_OP_BIT_AND: {
+                                _get_token(tk);
+                                if (tk.type != TK_CONSTANT || Variant(tk.value).get_type() != Variant::STRING) {
+                                   _set_error("Expected string after '&'.");
+                                   return nullptr;
+                                 }
 
+                                ConstantNode *constant = alloc_node<ConstantNode>();
+                                constant->value = StringName(String(tk.value));
+                                expr = constant;
+                                } break;
 			default: {
 				_set_error("Expected expression.");
 				return nullptr;


### PR DESCRIPTION
Fixes #114696

The Expression parser was unable to parse StringName literal syntax using `&"..."`.
This PR adds support for parsing `&"SomeString"` as a StringName constant in Expression,
allowing calls such as `my_function(&"Test")` to work correctly.

Test plan:
- Windows 11
- Built Godot editor from source using SCons
- Ran editor with: --rendering-driver opengl3
- Used the reproduction script provided in the issue
- Before: Expression.parse() failed with "Expected expression."
- After: Expression parses successfully and executes the function with a StringName argument
