### PR TITLE
Fix boot splash on Macos

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3319,6 +3319,9 @@ Error Main::setup2(bool p_show_boot_logo) {
 #endif
 		if (display_server->has_feature(DisplayServer::FEATURE_SUBWINDOWS)) {
 			display_server->show_window(DisplayServer::MAIN_WINDOW_ID);
+#ifdef MACOS_ENABLED
+			display_server->force_process_and_drop_events();
+#endif
 		}
 
 		if (display_server->has_feature(DisplayServer::FEATURE_ORIENTATION)) {

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3893,7 +3893,6 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 			window_set_flag(WindowFlags(i), true, main_window);
 		}
 	}
-	force_process_and_drop_events();
 
 	if (rendering_driver == "dummy") {
 		RasterizerDummy::make_current();


### PR DESCRIPTION
Fixes #112143 Mac needs `force_process_and_drop_events` after showing the window. 

The changes [here](https://github.com/godotengine/godot/pull/101980/changes#diff-26cc5f7d8ef06ac96e293f7556c6ffe89675d953086b3658cde39ae80be19e4eR3905) caused this init to happen in a different order.

Before the change:

1. DisplayServerMacOS ctor
     1. show_window
     2. force_process_and_drop_events

After #101980:

1. DisplayServerMacOS ctor 
     1.  force_process_and_drop_events
2. show_window

I'm not familiar enough with the other platforms to know if it's safe to simply call `display_server->force_process_and_drop_events()` after `display_server->show_window`, just to satisfy MacOS' needs, so I have wrapped this in `#ifdef MACOS_ENABLED`. 

I also considered adding `force_process_and_drop_events` into the `show_window` method, but as I'm new to the codebase, I am unsure if it's safe to do that everywhere that show_window is called. Since the boot splash behavior that was broken was only in the ctor of DisplayServerMacOS, it seemed safest to call `force_process_and_drop_events` in setup2, as opposed to unconditionally calling it in show_window.

It would be nice if `show_window` were safe to use without the extra `force_process_and_drop_events`, that way some platform specifics can be ignored in setup2, so would be happy to move `force_process_and_drop_events` into `show_window` if it's safe.