### PR TITLE
Fix MSAA crashing Mali GPUs when using subpasses.

### DIFF
--- a/servers/rendering/renderer_rd/effects/tone_mapper.cpp
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.cpp
@@ -280,19 +280,19 @@ void ToneMapper::tonemapper_mobile(RID p_source_color, RID p_dst_framebuffer, co
 
 	RD::Uniform u_glow_texture;
 	u_glow_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
-	u_glow_texture.binding = 0;
+	u_glow_texture.binding = 1;
 	u_glow_texture.append_id(default_mipmap_sampler);
 	u_glow_texture.append_id(p_settings.glow_texture);
 
 	RD::Uniform u_glow_map;
 	u_glow_map.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
-	u_glow_map.binding = 1;
+	u_glow_map.binding = 2;
 	u_glow_map.append_id(default_mipmap_sampler);
 	u_glow_map.append_id(p_settings.glow_map);
 
 	RD::Uniform u_color_correction_texture;
 	u_color_correction_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
-	u_color_correction_texture.binding = 0;
+	u_color_correction_texture.binding = 3;
 	u_color_correction_texture.append_id(default_sampler);
 	u_color_correction_texture.append_id(p_settings.color_correction_texture);
 
@@ -301,10 +301,7 @@ void ToneMapper::tonemapper_mobile(RID p_source_color, RID p_dst_framebuffer, co
 
 	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(p_dst_framebuffer);
 	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, tonemap_mobile.pipelines[mode].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(p_dst_framebuffer), false, RD::get_singleton()->draw_list_get_current_pass(), spec_constant));
-	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 0, u_source_color), 0);
-	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 1, u_glow_texture, u_glow_map), 1);
-	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 2, u_color_correction_texture), 2);
-
+	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_set_cache->get_cache(shader, 0, u_source_color, u_glow_texture, u_glow_map, u_color_correction_texture), 0);
 	RD::get_singleton()->draw_list_set_push_constant(draw_list, &tonemap_mobile.push_constant, sizeof(TonemapPushConstantMobile));
 	RD::get_singleton()->draw_list_draw(draw_list, false, 1u, 3u);
 	RD::get_singleton()->draw_list_end();
@@ -373,19 +370,19 @@ void ToneMapper::tonemapper_subpass(RD::DrawListID p_subpass_draw_list, RID p_so
 
 	RD::Uniform u_glow_texture;
 	u_glow_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
-	u_glow_texture.binding = 0;
+	u_glow_texture.binding = 1;
 	u_glow_texture.append_id(default_mipmap_sampler);
 	u_glow_texture.append_id(p_settings.glow_texture);
 
 	RD::Uniform u_glow_map;
 	u_glow_map.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
-	u_glow_map.binding = 1;
+	u_glow_map.binding = 2;
 	u_glow_map.append_id(default_mipmap_sampler);
 	u_glow_map.append_id(p_settings.glow_map);
 
 	RD::Uniform u_color_correction_texture;
 	u_color_correction_texture.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
-	u_color_correction_texture.binding = 0;
+	u_color_correction_texture.binding = 3;
 	u_color_correction_texture.append_id(default_sampler);
 	u_color_correction_texture.append_id(p_settings.color_correction_texture);
 
@@ -393,10 +390,7 @@ void ToneMapper::tonemapper_subpass(RD::DrawListID p_subpass_draw_list, RID p_so
 	ERR_FAIL_COND(shader.is_null());
 
 	RD::get_singleton()->draw_list_bind_render_pipeline(p_subpass_draw_list, tonemap_mobile.pipelines[mode].get_render_pipeline(RD::INVALID_ID, p_dst_format_id, false, RD::get_singleton()->draw_list_get_current_pass(), spec_constant));
-	RD::get_singleton()->draw_list_bind_uniform_set(p_subpass_draw_list, uniform_set_cache->get_cache(shader, 0, u_source_color), 0);
-	RD::get_singleton()->draw_list_bind_uniform_set(p_subpass_draw_list, uniform_set_cache->get_cache(shader, 1, u_glow_texture, u_glow_map), 1); // should be set to a default texture, it's ignored
-	RD::get_singleton()->draw_list_bind_uniform_set(p_subpass_draw_list, uniform_set_cache->get_cache(shader, 2, u_color_correction_texture), 2);
-
+	RD::get_singleton()->draw_list_bind_uniform_set(p_subpass_draw_list, uniform_set_cache->get_cache(shader, 0, u_source_color, u_glow_texture, u_glow_map, u_color_correction_texture), 0);
 	RD::get_singleton()->draw_list_set_push_constant(p_subpass_draw_list, &tonemap_mobile.push_constant, sizeof(TonemapPushConstantMobile));
 	RD::get_singleton()->draw_list_draw(p_subpass_draw_list, false, 1u, 3u);
 }

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap_mobile.glsl
@@ -44,19 +44,20 @@ layout(location = 0) in vec2 uv_interp;
 #define SAMPLER_FORMAT sampler2D
 #endif
 
+// All uniforms must be on set 0 to prevent MSAA from crashing Mali GPUs. See GH-114785.
 #ifdef SUBPASS
 layout(input_attachment_index = 0, set = 0, binding = 0) uniform subpassInput input_color;
 #else
 layout(set = 0, binding = 0) uniform SAMPLER_FORMAT source_color;
 #endif
 
-layout(set = 1, binding = 0) uniform SAMPLER_FORMAT source_glow;
-layout(set = 1, binding = 1) uniform sampler2D glow_map;
+layout(set = 0, binding = 1) uniform SAMPLER_FORMAT source_glow;
+layout(set = 0, binding = 2) uniform sampler2D glow_map;
 
 #ifdef USE_1D_LUT
-layout(set = 2, binding = 0) uniform sampler2D source_color_correction;
+layout(set = 0, binding = 3) uniform sampler2D source_color_correction;
 #else
-layout(set = 2, binding = 0) uniform sampler3D source_color_correction;
+layout(set = 0, binding = 3) uniform sampler3D source_color_correction;
 #endif
 
 layout(constant_id = 0) const bool use_bcs = false;


### PR DESCRIPTION
Fixes #112530, at least on the Mali-G76 phone I have.

I was just randomly trying things hoping it shows different behavior and this somehow fixed the crash. Before this, I tried spreading the uniforms to 4 sets to match the old layout, but that was still crashing. It seems specifically only one set fixes it. Unfortunately, I don't have the slightest clue why.

Needs testing to see if it also fixes it for other Mali GPUs.