### PR TITLE
Make `RichTextLabel`'s `text` represent the tag stack 

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2706,7 +2706,12 @@ void RichTextLabel::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			_stop_thread();
 			if (!text.is_empty()) {
-				set_text(text);
+				//set_text(text);
+				//This step discards any information added to the TagStack/ItemTree before the Node entered the Scene Tree
+				// ^ Issue #100772
+				//If sync_text is kept as an accurate BBCode mirror of the ItemTree, then we can preserve that information
+				//By collapsing all of it down to a single text value for set_text, resolving the error
+				set_text(text + sync_text);
 			}
 
 			main->first_invalid_line.store(0); // Invalidate all lines.
@@ -4304,6 +4309,7 @@ void RichTextLabel::add_text(const String &p_text) {
 				//append text condition!
 				ItemText *ti = static_cast<ItemText *>(current->subitems.back()->get());
 				ti->text += line;
+				sync_text += line;
 				current_char_ofs += line.length();
 				_invalidate_current_line(main);
 
@@ -4378,6 +4384,14 @@ void RichTextLabel::_add_item(Item *p_item, bool p_enter, bool p_ensure_newline)
 	if (fit_content) {
 		update_minimum_size();
 	}
+
+	if (p_item->type == ITEM_TEXT) {
+		ItemText *t = static_cast<ItemText *>(p_item);
+		sync_text += t->text;
+	} else if (p_item->type != ITEM_CONTEXT) {
+		sync_text += "[" + p_item->to_tag() + p_item->tag_context() + "]";
+	}
+
 	queue_accessibility_update();
 	queue_redraw();
 }
@@ -4455,6 +4469,9 @@ void RichTextLabel::add_hr(int p_width, int p_height, const Color &p_color, Hori
 
 	if (current->type == ITEM_FRAME) {
 		current_frame = static_cast<ItemFrame *>(current)->parent_frame;
+	}
+	if (current->type != ITEM_TEXT) {
+		sync_text += "[/" + current->to_tag() + "]";
 	}
 	current = current->parent;
 	if (!parsing_bbcode.load() && !tag_stack.is_empty()) {
@@ -4872,6 +4889,7 @@ void RichTextLabel::push_bold() {
 
 	ItemFont *item_font = _find_font(current);
 	_push_def_font((item_font && item_font->def_font == RTL_ITALICS_FONT) ? RTL_BOLD_ITALICS_FONT : RTL_BOLD_FONT);
+	static_cast<ItemFont *>(current)->is_bold = true;
 }
 
 void RichTextLabel::push_bold_italics() {
@@ -5267,6 +5285,10 @@ void RichTextLabel::pop() {
 	if (current->type == ITEM_FRAME) {
 		current_frame = static_cast<ItemFrame *>(current)->parent_frame;
 	}
+	if (current->type != ITEM_TEXT) {
+		sync_text += "[/" + current->to_tag() + "]";
+	}
+
 	current = current->parent;
 	if (!parsing_bbcode.load() && !tag_stack.is_empty()) {
 		tag_stack.pop_back();
@@ -5292,6 +5314,10 @@ void RichTextLabel::pop_context() {
 		if (!parsing_bbcode.load() && !tag_stack.is_empty()) {
 			tag_stack.pop_back();
 		}
+
+		if (current->type != ITEM_TEXT) {
+			sync_text += "[/" + current->to_tag() + "]";
+		}
 		current = current->parent;
 	}
 }
@@ -5300,7 +5326,13 @@ void RichTextLabel::pop_all() {
 	_stop_thread();
 	MutexLock data_lock(data_mutex);
 
-	current = main;
+	while (current->parent && current != main) {
+		if (current->type != ITEM_TEXT) {
+			sync_text += "[/" + current->to_tag() + "]";
+		}
+		current = current->parent;
+	}
+
 	current_frame = main;
 }
 
@@ -5319,6 +5351,11 @@ void RichTextLabel::clear() {
 	main->lines.resize(1);
 	main->first_invalid_line.store(0);
 	_invalidate_accessibility();
+
+	if (!internal_stack_editing) {
+		text.clear();
+		sync_text.clear();
+	}
 
 	keyboard_focus_frame = nullptr;
 	keyboard_focus_line = 0;
@@ -5532,12 +5569,23 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 
 	int pos = 0;
 
+	ItemFont *prev_font = _find_font(current);
 	bool in_bold = false;
 	bool in_italics = false;
+	// Previously append_text ignored if there was currently an unpopped Bold/Italics Tag
+	if (prev_font) {
+		in_bold = prev_font->def_font == RTL_BOLD_FONT || prev_font->def_font == RTL_BOLD_ITALICS_FONT;
+		in_italics = prev_font->def_font == RTL_ITALICS_FONT || prev_font->def_font == RTL_BOLD_ITALICS_FONT;
+	}
 	bool after_list_open_tag = false;
 	bool after_list_close_tag = false;
 
 	String bbcode = p_bbcode.replace("\r\n", "\n");
+
+	if (!internal_stack_editing) {
+		text += sync_text;
+		text += bbcode;
+	}
 
 	while (pos <= bbcode.length()) {
 		int brk_pos = bbcode.find_char('[', pos);
@@ -6765,6 +6813,8 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 		}
 	}
 
+	sync_text.clear();
+
 	parsing_bbcode.store(false);
 }
 
@@ -7383,7 +7433,7 @@ float RichTextLabel::get_selection_line_offset() const {
 
 void RichTextLabel::set_text(const String &p_bbcode) {
 	// Allow clearing the tag stack.
-	if (!p_bbcode.is_empty() && text == p_bbcode) {
+	if (!p_bbcode.is_empty() && (text + sync_text) == p_bbcode) {
 		return;
 	}
 
@@ -7416,7 +7466,7 @@ void RichTextLabel::_apply_translation() {
 }
 
 String RichTextLabel::get_text() const {
-	return text;
+	return text + sync_text;
 }
 
 void RichTextLabel::set_use_bbcode(bool p_enable) {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -227,6 +227,8 @@ private:
 				items.free(rid);
 			}
 		}
+		virtual String to_tag() { return "frame"; }
+		virtual String tag_context() { return ""; }
 	};
 
 	struct ItemFrame : public Item {
@@ -252,11 +254,15 @@ private:
 			first_invalid_font_line.store(0);
 			first_resized_line.store(0);
 		}
+
+		String to_tag() { return "cell"; }
 	};
 
 	struct ItemText : public Item {
 		String text;
 		ItemText() { type = ITEM_TEXT; }
+
+		String to_tag() { return ""; }
 	};
 
 	struct ItemDropcap : public Item {
@@ -270,6 +276,29 @@ private:
 		ObjectID owner;
 		ItemDropcap() { type = ITEM_DROPCAP; }
 		~ItemDropcap();
+
+		String to_tag() { return "dropcap"; }
+		String tag_context() {
+			String result = "";
+			if (font.is_valid()) {
+				result += vformat(" name=%s", font->get_path());
+			}
+			if (font_size != 0) {
+				result += vformat(" font_size=%s", font_size);
+			}
+			if (color.to_html() != "FFFFFFFF") {
+				result += vformat(" color=%s", color.to_html());
+			}
+			if (ol_size != 0) {
+				result += vformat(" outline_size=%s", ol_size);
+			}
+			if (ol_color.to_html() != "FFFFFFFF") {
+				result += vformat(" outline_color=%s", ol_color.to_html());
+			}
+			result += vformat(" margins=%s,%s,%s,%s", dropcap_margins.position.x, dropcap_margins.position.y, dropcap_margins.size.x, dropcap_margins.size.y);
+			result += vformat("]%s[/dropcap", text);
+			return result;
+		}
 	};
 
 	struct ItemImage : public Item {
@@ -288,10 +317,41 @@ private:
 		ObjectID owner;
 		ItemImage() { type = ITEM_IMAGE; }
 		~ItemImage();
+
+		String to_tag() { return "img"; }
+		String tag_context() {
+			String width = width_unit == IMAGE_UNIT_PERCENT ? vformat("%s%", size.x) : vformat("%s", size.x);
+			String height = height_unit == IMAGE_UNIT_PERCENT ? vformat("%s%", size.y) : vformat("%s", size.y);
+			String region_str = vformat("%s,%s,%s,%s", region.position.x, region.position.y, region.size.x, region.size.y);
+			String pad_str = pad ? "true" : "false";
+
+			String align_a = "t";
+			String align_b = "t";
+			if ((inline_align & 0b0011) == INLINE_ALIGNMENT_BASELINE_TO) {
+				align_a = "l";
+			} else if ((inline_align & 0b0011) == INLINE_ALIGNMENT_BOTTOM_TO) {
+				align_a = "b";
+			} else if ((inline_align & 0b0011) == INLINE_ALIGNMENT_CENTER_TO) {
+				align_a = "c";
+			}
+
+			if ((inline_align & 0b1100) == INLINE_ALIGNMENT_TO_BOTTOM) {
+				align_b = "b";
+			} else if ((inline_align & 0b1100) == INLINE_ALIGNMENT_TO_BASELINE) {
+				align_b = "l";
+			} else if ((inline_align & 0b1100) == INLINE_ALIGNMENT_TO_CENTER) {
+				align_b = "c";
+			}
+
+			String alignment_str = vformat("%s,%s", align_a, align_b);
+			return vformat(" color=%s height=%s width=%s region=%s pad=%s tooltip=%s valign=%s alt=%s]%s[/img",
+					color.to_html(), height, width, region_str, pad_str, tooltip, alignment_str, alt_text, image->get_path());
+		}
 	};
 
 	struct ItemFont : public Item {
 		DefaultFont def_font = RTL_CUSTOM_FONT;
+		bool is_bold;
 		Ref<Font> font;
 		bool variation = false;
 		bool def_size = false;
@@ -299,36 +359,75 @@ private:
 		ObjectID owner;
 		ItemFont() { type = ITEM_FONT; }
 		~ItemFont();
+
+		String to_tag() {
+			switch (def_font) {
+				case RTL_BOLD_FONT:
+					return "b";
+				case RTL_ITALICS_FONT:
+					return "i";
+				case RTL_MONO_FONT:
+					return "code";
+				case RTL_BOLD_ITALICS_FONT:
+					return is_bold ? "b" : "i";
+				default:
+					return "font";
+			}
+		}
+
+		String tag_context() {
+			if (def_font == RTL_CUSTOM_FONT && font.is_valid()) {
+				return vformat(" name=%s size=%s",
+						font->get_path(), font_size);
+			}
+			return "";
+		}
 	};
 
 	struct ItemFontSize : public Item {
 		int font_size = 16;
 		ItemFontSize() { type = ITEM_FONT_SIZE; }
+
+		String to_tag() { return "font_size"; }
+		String tag_context() { return vformat("=%s", font_size); }
 	};
 
 	struct ItemColor : public Item {
 		Color color;
 		ItemColor() { type = ITEM_COLOR; }
+
+		String to_tag() { return "color"; }
+		String tag_context() { return vformat("=%s", color.to_html()); }
 	};
 
 	struct ItemOutlineSize : public Item {
 		int outline_size = 0;
 		ItemOutlineSize() { type = ITEM_OUTLINE_SIZE; }
+
+		String to_tag() { return "outline_size"; }
+		String tag_context() { return vformat("=%s", outline_size); }
 	};
 
 	struct ItemOutlineColor : public Item {
 		Color color;
 		ItemOutlineColor() { type = ITEM_OUTLINE_COLOR; }
+
+		String to_tag() { return "outline_color"; }
+		String tag_context() { return vformat("=%s", color.to_html()); }
 	};
 
 	struct ItemUnderline : public Item {
 		Color color;
 		ItemUnderline() { type = ITEM_UNDERLINE; }
+
+		String to_tag() { return "u"; }
 	};
 
 	struct ItemStrikethrough : public Item {
 		Color color;
 		ItemStrikethrough() { type = ITEM_STRIKETHROUGH; }
+
+		String to_tag() { return "s"; }
 	};
 
 	struct ItemMeta : public Item {
@@ -336,16 +435,40 @@ private:
 		MetaUnderline underline = META_UNDERLINE_ALWAYS;
 		String tooltip;
 		ItemMeta() { type = ITEM_META; }
+
+		String to_tag() { return "url"; }
+		String tag_context() {
+			String result = vformat("=%s", meta);
+			if (underline != META_UNDERLINE_ALWAYS || !tooltip.is_empty()) {
+				result = " name" + result;
+				if (underline == META_UNDERLINE_NEVER) {
+					result += " underline=never";
+				} else if (underline == META_UNDERLINE_ON_HOVER) {
+					result += " underline=hover";
+				}
+
+				if (!tooltip.is_empty()) {
+					result += vformat(" tooltip=%s", tooltip);
+				}
+			}
+			return result;
+		}
 	};
 
 	struct ItemHint : public Item {
 		String description;
 		ItemHint() { type = ITEM_HINT; }
+
+		String to_tag() { return "hint"; }
+		String tag_context() { return vformat("=\"%s\"", description); }
 	};
 
 	struct ItemLanguage : public Item {
 		String language;
 		ItemLanguage() { type = ITEM_LANGUAGE; }
+
+		String to_tag() { return "lang"; }
+		String tag_context() { return vformat("=%s", language); }
 	};
 
 	struct ItemParagraph : public Item {
@@ -356,11 +479,99 @@ private:
 		BitField<TextServer::JustificationFlag> jst_flags = TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_SKIP_LAST_LINE | TextServer::JUSTIFICATION_DO_NOT_SKIP_SINGLE_LINE;
 		PackedFloat32Array tab_stops;
 		ItemParagraph() { type = ITEM_PARAGRAPH; }
+
+		String to_tag() { return "p"; }
+		String tag_context() {
+			String result = "";
+			switch (alignment) {
+				case HORIZONTAL_ALIGNMENT_LEFT:
+					result += " align=l";
+					break;
+				case HORIZONTAL_ALIGNMENT_RIGHT:
+					result += " align=r";
+					break;
+				case HORIZONTAL_ALIGNMENT_CENTER:
+					result += " align=c";
+					break;
+				case HORIZONTAL_ALIGNMENT_FILL:
+					result += " align=f";
+					break;
+			}
+			switch (direction) {
+				case Control::TEXT_DIRECTION_RTL:
+					result += " direction=r";
+					break;
+				case Control::TEXT_DIRECTION_LTR:
+					result += " direction=l";
+					break;
+				default:
+					break;
+			}
+			if (!language.is_empty()) {
+				result += vformat(" language=%s", language);
+			}
+			switch (st_parser) {
+				case TextServer::STRUCTURED_TEXT_URI:
+					result += " st=u";
+					break;
+				case TextServer::STRUCTURED_TEXT_FILE:
+					result += " st=f";
+					break;
+				case TextServer::STRUCTURED_TEXT_EMAIL:
+					result += " st=e";
+					break;
+				case TextServer::STRUCTURED_TEXT_LIST:
+					result += " st=l";
+					break;
+				case TextServer::STRUCTURED_TEXT_CUSTOM:
+					result += " st=c";
+					break;
+				default:
+					break;
+			}
+			String flags = " jst=";
+			if ((jst_flags & TextServer::JUSTIFICATION_KASHIDA) != 0) {
+				flags += "k,";
+			}
+			if ((jst_flags & TextServer::JUSTIFICATION_WORD_BOUND) != 0) {
+				flags += "w,";
+			}
+			if ((jst_flags & TextServer::JUSTIFICATION_TRIM_EDGE_SPACES) != 0) {
+				flags += "tr,";
+			}
+			if ((jst_flags & TextServer::JUSTIFICATION_AFTER_LAST_TAB) != 0) {
+				flags += "lt,";
+			}
+			if ((jst_flags & TextServer::JUSTIFICATION_SKIP_LAST_LINE) != 0) {
+				flags += "sl,";
+			}
+			if ((jst_flags & TextServer::JUSTIFICATION_SKIP_LAST_LINE_WITH_VISIBLE_CHARS) != 0) {
+				flags += "sv,";
+			}
+			if ((jst_flags & TextServer::JUSTIFICATION_DO_NOT_SKIP_SINGLE_LINE) != 0) {
+				flags += "ns,";
+			}
+			if (flags.unicode_at(flags.size() - 2) == *U",") {
+				flags.remove_at(flags.size() - 2);
+				result += flags;
+			}
+
+			if (!tab_stops.is_empty()) {
+				result += vformat(" tab_stops=%f", tab_stops[0]);
+				for (int tab = 1; tab < tab_stops.size(); tab++) {
+					result += vformat(",%f", tab_stops[tab]);
+				}
+			}
+
+			return result;
+		}
 	};
 
 	struct ItemIndent : public Item {
 		int level = 0;
 		ItemIndent() { type = ITEM_INDENT; }
+
+		String to_tag() { return "indent"; }
 	};
 
 	struct ItemList : public Item {
@@ -370,10 +581,35 @@ private:
 		String bullet = U"•";
 		float max_width = 0;
 		ItemList() { type = ITEM_LIST; }
+
+		String to_tag() {
+			if (list_type == LIST_DOTS) {
+				return "ul";
+			} else {
+				return "ol";
+			}
+		}
+		String tag_context() {
+			if (list_type == LIST_LETTERS) {
+				return " type=a";
+			}
+			if (list_type == LIST_ROMAN) {
+				return " type=i";
+			}
+			if (list_type == LIST_NUMBERS) {
+				return "";
+			}
+			if (bullet != U"•") {
+				return vformat(" bullet=%s", bullet);
+			}
+			return "";
+		}
 	};
 
 	struct ItemNewline : public Item {
 		ItemNewline() { type = ITEM_NEWLINE; }
+
+		String to_tag() { return "br"; }
 	};
 
 	struct ItemTable : public Item {
@@ -398,6 +634,40 @@ private:
 		int char_count = 0;
 		InlineAlignment inline_align = INLINE_ALIGNMENT_TOP;
 		ItemTable() { type = ITEM_TABLE; }
+
+		String to_tag() { return "table"; }
+		String tag_context() {
+			String align_a = "t";
+			String align_b = "t";
+			if ((inline_align & 0b0011) == INLINE_ALIGNMENT_BASELINE_TO) {
+				align_a = "l";
+			} else if ((inline_align & 0b0011) == INLINE_ALIGNMENT_BOTTOM_TO) {
+				align_a = "b";
+			} else if ((inline_align & 0b0011) == INLINE_ALIGNMENT_CENTER_TO) {
+				align_a = "c";
+			}
+
+			if ((inline_align & 0b1100) == INLINE_ALIGNMENT_TO_BOTTOM) {
+				align_b = "b";
+			} else if ((inline_align & 0b1100) == INLINE_ALIGNMENT_TO_BASELINE) {
+				align_b = "l";
+			} else if ((inline_align & 0b1100) == INLINE_ALIGNMENT_TO_CENTER) {
+				align_b = "c";
+			}
+
+			String alignment_str = vformat("%s,%s", align_a, align_b);
+
+			String result = vformat("=%s,%s", columns.size(), alignment_str);
+
+			if (align_to_row != -1) {
+				result += vformat(",%s", align_to_row);
+			}
+			if (!name.is_empty()) {
+				result += vformat(" name=%s", name);
+			}
+
+			return result;
+		}
 	};
 
 	struct ItemFade : public Item {
@@ -405,6 +675,11 @@ private:
 		int length = 0;
 
 		ItemFade() { type = ITEM_FADE; }
+
+		String to_tag() { return "fade"; }
+		String tag_context() {
+			return vformat(" start=%s length=%s", starting_index, length);
+		}
 	};
 
 	struct ItemFX : public Item {
@@ -435,6 +710,11 @@ private:
 			return (_previous_rng >> (p_index % 64)) |
 					(_previous_rng << (64 - (p_index % 64)));
 		}
+
+		String to_tag() { return "shake"; }
+		String tag_context() {
+			return vformat(" rate=%f level=%s", strength, rate);
+		}
 	};
 
 	struct ItemWave : public ItemFX {
@@ -443,6 +723,11 @@ private:
 		Vector2 prev_off;
 
 		ItemWave() { type = ITEM_WAVE; }
+
+		String to_tag() { return "wave"; }
+		String tag_context() {
+			return vformat(" amp=%f freq=%f", frequency, amplitude);
+		}
 	};
 
 	struct ItemTornado : public ItemFX {
@@ -451,6 +736,11 @@ private:
 		Vector2 prev_off;
 
 		ItemTornado() { type = ITEM_TORNADO; }
+
+		String to_tag() { return "tornado"; }
+		String tag_context() {
+			return vformat(" radius=%f freq=%f", radius, frequency);
+		}
 	};
 
 	struct ItemRainbow : public ItemFX {
@@ -460,6 +750,11 @@ private:
 		float speed = 1.0f;
 
 		ItemRainbow() { type = ITEM_RAINBOW; }
+
+		String to_tag() { return "rainbow"; }
+		String tag_context() {
+			return vformat(" freq=%f sat=%f val=%f speed=%f", frequency, saturation, value, speed);
+		}
 	};
 
 	struct ItemPulse : public ItemFX {
@@ -468,16 +763,27 @@ private:
 		float ease = -2.0f;
 
 		ItemPulse() { type = ITEM_PULSE; }
+
+		String to_tag() { return "pulse"; }
+		String tag_context() {
+			return vformat(" freq=%f color=%s ease=%f", frequency, color.to_html(), ease);
+		}
 	};
 
 	struct ItemBGColor : public Item {
 		Color color;
 		ItemBGColor() { type = ITEM_BGCOLOR; }
+
+		String to_tag() { return "bgcolor"; }
+		String tag_context() { return vformat("=%s", color.to_html()); }
 	};
 
 	struct ItemFGColor : public Item {
 		Color color;
 		ItemFGColor() { type = ITEM_FGCOLOR; }
+
+		String to_tag() { return "fgcolor"; }
+		String tag_context() { return vformat("=%s", color.to_html()); }
 	};
 
 	struct ItemCustomFX : public ItemFX {
@@ -487,6 +793,8 @@ private:
 		ItemCustomFX();
 
 		virtual ~ItemCustomFX();
+
+		String to_tag() { return "customfx"; }
 	};
 
 	struct ItemContext : public Item {
@@ -749,6 +1057,7 @@ private:
 #endif
 	bool use_bbcode = false;
 	String text;
+	String sync_text;
 	void _apply_translation();
 
 	bool internal_stack_editing = false;


### PR DESCRIPTION
Resolves: 
* https://github.com/godotengine/godot/issues/114639
* https://github.com/godotengine/godot/issues/105026
* https://github.com/godotengine/godot/issues/100168
* https://github.com/godotengine/godot/issues/94630
* https://github.com/godotengine/godot/issues/79420
* https://github.com/godotengine/godot/issues/61260

Also Resolves:
* https://github.com/godotengine/godot/issues/100772

Implements:
* https://github.com/godotengine/godot-proposals/issues/8739

Godot's RichTextLabels parse and convert BBCode Text into a TagStack / ItemTree. Since Godot 4.0 (?), rendering / logic is primarily driven by this Tag Stack / Item Tree; the Text Property exists mostly for inspector convenience, and the occasional hard overwrite via code. This frequently leads to confusion when scripts modify a Label via Add_text and the such, but the changes are not reflected in the Text property. See the 6 open Duplicate Issue reports linked above, and the numerous notes about the text property being out of sync in the RichTextLabel documentation.

This PR seeks to address this issue by having the RichTextLabel update the Text Property as the ItemTree is modified to keep the two in sync. I accomplish this by:
* Adding utility functions to the Item Classes that output appropriate BBCode tags, hopefully making the BBCode <-> ItemTree conversions 2-way
* Having RichTextLabel store a Sync_text, representing all of the TagStack generated by `push_*() & pop()` calls. Whenever a user interacts with the Text property, they are actually interacting with the concatenation of text + sync_text.
* User-generated BBCode is never over-written, duplicated, or regenerated. The `internal_stack_editing` flag makes it clear when the items being added are not directly from user-written text.

I have verified most simple behaviors produce correct BBCode - I may have missed some edge cases, but in the current build, every time I read the Text property it contained exactly the full BBCode I expected, and if I pasted the output back into another RichTextLabel node, they displayed identically. 

Existing Behaviors Changed:
* The Text property and the Tag Stack are functionally identical from a user perspective. There should be no way to modify one or the other that doesn't sync them together.
* Fixed a minor issue where RTL.push_bold() then RTL.append_text("[i]bi") would not correctly create a BoldItalics node in the tree.
* All other logic should remain the same, and similarly performant. No extra tree traversals are performed

Extremely open to feedback - is this the right approach? Is it performant enough? Are there edge cases that keeping Sync_Text does not account for? Should this be pursued at all? 