### PR TITLE
Auto-release static GDTypes at exit.

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -2420,6 +2420,7 @@ void ClassDB::cleanup_defaults() {
 	default_values_cached.clear();
 }
 
+LocalVector<GDType **> ClassDB::gdtype_autorelease_pool;
 void ClassDB::cleanup() {
 	//OBJTYPE_LOCK; hah not here
 
@@ -2440,6 +2441,15 @@ void ClassDB::cleanup() {
 	resource_base_extensions.clear();
 	compat_classes.clear();
 	native_structs.clear();
+
+	for (GDType **type : gdtype_autorelease_pool) {
+		if (!type) {
+			WARN_PRINT("GDType in autorelease pool was cleaned up before being auto-released. Ignoring.");
+		}
+		memdelete(*type);
+		*type = nullptr;
+	}
+	gdtype_autorelease_pool.clear();
 }
 
 // Array to use in optional parameters on methods and the DEFVAL_ARRAY macro.

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -234,6 +234,10 @@ public:
 	static Array default_array_arg;
 	static bool is_default_array_arg(const Array &p_array);
 
+	// Types added here will be automatically cleaned up on engine shutdown.
+	// Only add types that aren't cleaned up in another way.
+	static LocalVector<GDType **> gdtype_autorelease_pool;
+
 private:
 	// Non-locking variants of get_parent_class and is_parent_class.
 	static StringName _get_parent_class(const StringName &p_class);

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2383,8 +2383,10 @@ void Object::assign_type_static(GDType **type_ptr, const char *p_name, const GDT
 		// Assigned while we were waiting.
 		return;
 	}
-	type = memnew(GDType(super_type, StringName(p_name, true)));
+	type = memnew(GDType(super_type, StringName(p_name)));
 	*type_ptr = type;
+
+	ClassDB::gdtype_autorelease_pool.push_back(type_ptr);
 }
 
 Object::~Object() {


### PR DESCRIPTION
- Fixes #113751

Currently, `GDCLASS` owned `GDType` objects are never torn down. This leads to "unclaimed StringName" warnings at engine shutdown (when `--verbose` is used). This PR fixes this by tearing down these `GDType` instances at shutdown.

### Explanation

Every compile time Object subclass (`GDCLASS`) statically owns a `GDType *`. This is allocated and initialized lazily on `get_gdtype_static` access.
Because of engine launch order, these `GDType` aren't immediately (or even necessarily) registered in `ClassDB`. The types are only registered when `GDREGISTER_CLASS` (or an alternative) is called, or when the first instance is created.

Practically, this means there may be any number of `GDType` instances hanging around that are not registered in `ClassDB`. To easily clean them up, I simply added an autorelease pool to `ClassDB`.
In the future, we might consider keeping a closer eye on static `GDType` (for example, by requiring explicit `GDREGISTER_CLASS` calls for every type, or by only creating them on explicit register), which would eliminate the need for this autorelease pool.