### PR TITLE
LSP: Reuse stale parsers in request

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -78,10 +78,10 @@ private:
 		~LSPeer();
 
 	private:
-		// We can't cache parsers for scripts not managed by the editor since we have
-		// no way to invalidate the cache. We still need to keep track of those parsers
-		// to clean them up properly.
-		HashMap<String, ExtendGDScriptParser *> stale_parsers;
+		void clear_stale_parsers();
+		// Paths of parsers which we can't cache longterm.
+		// Can be cleared up using `clear_stale_parsers()`.
+		HashSet<String> stale_parsers;
 	};
 
 	enum LSPErrorCode {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/114729

When a parser is requested for a script which is not opened in the external editor, a new parser for the script gets created and the old parser for the script gets freed. The idea was to always refresh those from disk since we don't know when they change.

However if a pointer to the old parsers was stored and then a parser was requested for the path again, the old parser would be freed even though there still is a pointer to it.

This PR changes the cleanup logic for stale parsers to reuse them as long as we are in the same request. All stale parsers are cleaned up after the the request finished. This prevents those heap-use-after-free issues.
