### PR TITLE
Docs: Clarify that min() and max() require at least 2 arguments

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -689,7 +689,7 @@
 		<method name="max" qualifiers="vararg">
 			<return type="Variant" />
 			<description>
-				Returns the maximum of the given numeric values. This function can take any number of arguments.
+				Returns the maximum of the given numeric values. This function takes at least 2 arguments.
 				[codeblock]
 				max(1, 7, 3, -6, 5) # Returns 7
 				[/codeblock]
@@ -723,7 +723,7 @@
 		<method name="min" qualifiers="vararg">
 			<return type="Variant" />
 			<description>
-				Returns the minimum of the given numeric values. This function can take any number of arguments.
+				Returns the minimum of the given numeric values. This function takes at least 2 arguments.
 				[codeblock]
 				min(1, 7, 3, -6, 5) # Returns -6
 				[/codeblock]


### PR DESCRIPTION
Fixes #114522

Clarifies the documentation for `min()` and `max()` functions to specify that they require at least 2 arguments, rather than the imprecise "any number of arguments" which could incorrectly suggest 0 or 1 arguments are valid.

- Updated `@GlobalScope.xml` to state both functions "take at least 2 arguments"