### PR TITLE
Fix incorrect margin variations for group editors

### DIFF
--- a/editor/docks/groups_editor.cpp
+++ b/editor/docks/groups_editor.cpp
@@ -912,7 +912,7 @@ GroupsEditor::GroupsEditor() {
 	hbc->add_child(filter);
 
 	MarginContainer *mc = memnew(MarginContainer);
-	mc->set_theme_type_variation("NoBorderHorizontalBottomWide");
+	mc->set_theme_type_variation("NoBorderHorizontalBottom");
 	mc->set_v_size_flags(SIZE_EXPAND_FILL);
 	holder->add_child(mc);
 

--- a/editor/scene/group_settings_editor.cpp
+++ b/editor/scene/group_settings_editor.cpp
@@ -523,6 +523,11 @@ GroupSettingsEditor::GroupSettingsEditor() {
 	add_button->connect(SceneStringName(pressed), callable_mp(this, &GroupSettingsEditor::_add_group));
 	hbc->add_child(add_button);
 
+	MarginContainer *mc = memnew(MarginContainer);
+	mc->set_theme_type_variation("NoBorderHorizontalBottomWide");
+	mc->set_v_size_flags(SIZE_EXPAND_FILL);
+	add_child(mc);
+
 	tree = memnew(Tree);
 	tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	tree->set_hide_root(true);
@@ -539,9 +544,8 @@ GroupSettingsEditor::GroupSettingsEditor() {
 	tree->connect("item_edited", callable_mp(this, &GroupSettingsEditor::_item_edited));
 	tree->connect("item_activated", callable_mp(this, &GroupSettingsEditor::_show_rename_dialog));
 	tree->connect("button_clicked", callable_mp(this, &GroupSettingsEditor::_item_button_pressed));
-	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 
-	add_child(tree, true);
+	mc->add_child(tree, true);
 
 	message = memnew(AcceptDialog);
 	add_child(message);


### PR DESCRIPTION
Regression from #114634, I mixed up the two group editors. :no_mouth: