### PR TITLE
Add `back()`, `pop_back()` and `remove_back()` to `LocalVector`, for stack-like access

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -87,6 +87,30 @@ public:
 		memnew_placement(&data[count++], T(std::move(p_elem)));
 	}
 
+	T &back() {
+		CRASH_COND(is_empty());
+		return data[count - 1];
+	}
+
+	const T &back() const {
+		CRASH_COND(is_empty());
+		return data[count - 1];
+	}
+
+	[[nodiscard]] T pop_back() {
+		CRASH_COND(is_empty());
+		T value = std::move(data[count - 1]);
+		count--;
+		data[count].~T();
+		return value;
+	}
+
+	void remove_back() {
+		ERR_FAIL_COND(is_empty());
+		count--;
+		data[count].~T();
+	}
+
 	void remove_at(U p_index) {
 		ERR_FAIL_UNSIGNED_INDEX(p_index, count);
 		count--;


### PR DESCRIPTION
- Alternative to #99955

This adds back access to `LocalVector`, so that it can be efficiently used as a stack.
The current prevalent class for stack-like containers is `List`, which is very inefficient.

In draft until it's actually needed.

## Discussion

I added an access method `back()` (const and non-const form), which returns a reference to the last element. This can be error prone if called when the vector is empty. In this case, we can do naught but crash.
An alternative would be returning an optional, but that would (slightly) increase the cost of the call too.

`pop_back` in `List` returns no element. This can lead to inefficient code, because elements have to be copied out of the `List` on pop.
Instead, I return the element (moved out of the list), like other languages (eg Rust and Python). This can lead to much more efficient code.
However, this can still be inefficient if the element need only be removed without fetching it. For this case, `remove_back` is added. Practically, this may not be needed because after inlining, `pop_back` might be optimized to the same standard as `remove_back`.