### PR TITLE
GDScript: Don't clean up other scripts

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -209,15 +209,11 @@ private:
 
 	bool _update_exports(bool *r_err = nullptr, bool p_recursive_call = false, PlaceHolderScriptInstance *p_instance_to_update = nullptr, bool p_base_exports_changed = false);
 
-	void _save_orphaned_subclasses(GDScript::ClearData *p_clear_data);
+	void _save_orphaned_subclasses();
 
 	void _get_script_property_list(List<PropertyInfo> *r_list, bool p_include_base) const;
 	void _get_script_method_list(List<MethodInfo> *r_list, bool p_include_base) const;
 	void _get_script_signal_list(List<MethodInfo> *r_list, bool p_include_base) const;
-
-	GDScript *_get_gdscript_from_variant(const Variant &p_variant);
-	void _collect_function_dependencies(GDScriptFunction *p_func, RBSet<GDScript *> &p_dependencies, const GDScript *p_except);
-	void _collect_dependencies(RBSet<GDScript *> &p_dependencies, const GDScript *p_except);
 
 protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
@@ -240,7 +236,7 @@ public:
 
 	_FORCE_INLINE_ StringName get_local_name() const { return local_name; }
 
-	void clear(GDScript::ClearData *p_clear_data = nullptr);
+	void clear();
 
 	// Cancels all functions of the script that are are waiting to be resumed after using await.
 	void cancel_pending_functions(bool warn);
@@ -269,10 +265,6 @@ public:
 	_FORCE_INLINE_ const GDScriptFunction *get_implicit_initializer() const { return implicit_initializer; }
 	_FORCE_INLINE_ const GDScriptFunction *get_implicit_ready() const { return implicit_ready; }
 	_FORCE_INLINE_ const GDScriptFunction *get_static_initializer() const { return static_initializer; }
-
-	RBSet<GDScript *> get_dependencies();
-	HashMap<GDScript *, RBSet<GDScript *>> get_all_dependencies();
-	RBSet<GDScript *> get_must_clear_dependencies();
 
 	virtual bool has_script_signal(const StringName &p_signal) const override;
 	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const override;


### PR DESCRIPTION
Alternative to https://github.com/godotengine/godot/pull/114651

Fixes https://github.com/godotengine/godot/issues/114420
Fixes https://github.com/godotengine/godot/issues/98141 (tested using the 4.3 MRP by myself. Not the original one.)

Might be related to: https://github.com/godotengine/godot/issues/95428 -> No MRP, but my hypothesis is, that script members were cleared from a still referenced script.

---

https://github.com/godotengine/godot/pull/114651 tries to fix the logic which cleans up dependencies. This PR in contrast removes the logic completely.

This means that GDScripts with cyclic dependencies will only be cleaned up at engine shutdown.

The approach is fine, because it's very unlikely for the dependency cleanup logic to run at all, because it is only called from the GDScript destructor. The `GDScriptCache` holds refs to all GDScripts so this destructor never runs until engine shutdown. The only exception are inner classes but they are referenced by their outer class. So for them to get freed an outer script needs to drop a ref to an inner class. This mostly happens in editor when editing scripts.

<details>
<summary>More verbose rubberducking</summary>

This whole cycle detection is located in `GDScript::clear`. There are three possible calls to `clear`
- during `GDScriptLanguage::finalize` -> irrelevant, the whole island detection is protected to not run during language shutdown
- in `GDScript::clear` -> recursion, skip
- in `~GDScript`

So for this to run the destructor of a GDScript needs to run. GDScript's are ref counted so the ref count of a GDScript needs to go to 0. `GDScriptCache::full_gdscript_cache` holds a reference to every GDScript.

(only exception are inner classes those are not referenced by the GDScript cache. But they are referenced by their outer GDScripts).

So for the refcount to drop to to 0 one of those things needs to happen:
A. The `GDScriptCache` drops it reference to a gdscript
B. An outer GDScript drops it reference to an inner gdscript

About `A`: this is very unlikely. The only easy way is `GDScriptCache::remove_script` which only gets called from `GDScript::clear` and some unused method. Some edge cases with `take_over_path` might also be able to trigger it I guess.

B: This can only really happen if the outer script gets destructed (see `A`). It also happens when editing scripts in the script editor. And maybe when messing with `reload` I guess.

And well you can force it with `RefCounted::unreference`.

All those possibilities seem so far fetched. So why even bother if all we can safe is some memory from the deps of inner classes. Which will be basically nothing because inner scripts will share most of their deps with their outer class anyway.
</details>