### PR TITLE
Use luminance multiplier for sky background when using mobile renderer with HDR2D

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1245,7 +1245,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 
 			// Note, sky.setup should have been called up above and setup stuff we need.
 
-			sky.draw_sky(draw_list, rb, p_render_data->environment, framebuffer, time, sky_luminance_multiplier, sky_brightness_multiplier);
+			sky.draw_sky(draw_list, rb, p_render_data->environment, framebuffer, time, inverse_luminance_multiplier, sky_brightness_multiplier);
 
 			RD::get_singleton()->draw_command_end_label(); // Draw Sky
 		}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/113597

The `sky_luminance_multiplier` is fixed at `0.5` since the radiance map will always use an LDR format. When rendering to the viewport directly, we should use `inverse_luminance_multiplier` which changes between `1.0` and `0.5` depending on if HDR2D is enabled or not.

The rest of the sky update functions render to LDR textures always, so they need to use the `sky_luminance_multiplier`