### PR TITLE
Fix OptionButton PopupMenu not shrinking after item changes

### DIFF
--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -547,7 +547,7 @@ void OptionButton::show_popup() {
 		rect = xform.xform(rect);
 	}
 	rect.size.height = 0;
-	popup->set_shrink_width(false);
+	popup->set_min_size(Size2(0, 0));
 	popup->popup(rect);
 }
 
@@ -655,6 +655,7 @@ OptionButton::OptionButton(const String &p_text) :
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);
 
 	popup = memnew(PopupMenu);
+	popup->set_shrink_width(false);
 	popup->hide();
 	add_child(popup, false, INTERNAL_MODE_FRONT);
 	popup->connect("index_pressed", callable_mp(this, &OptionButton::_selected));


### PR DESCRIPTION
Fixes #114786.

Updates `OptionButton::show_popup()` to correctly handle `PopupMenu` resizing when content changes from larger to smaller items.


- Calls `popup->set_min_size(Size2(0, 0))` before opening. This is crucial because `Window::popup(rect)` clamps the size to the current `min_size`. Without resetting it, the window refuses to shrink to the new smaller content size because it's still constrained by the previous items' minimum size.
- Explicitly enables `popup->set_shrink_height(true)` to ensure the height is recalculated to fit the new content.


Verified with the MRP from the issue. The PopupMenu now immediately shrinks to the correct size when switching from long items to short items.


https://github.com/user-attachments/assets/631e104e-4a17-43d5-a56d-dc0827b7121c


https://github.com/user-attachments/assets/5a365820-04c9-49ae-b225-e186a5927908


