### PR TITLE
Fix and improve the theme editor

### DIFF
--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -961,6 +961,7 @@ ThemeItemImportTree::ThemeItemImportTree() {
 	ScrollContainer *import_bulk_sc = memnew(ScrollContainer);
 	import_bulk_sc->set_custom_minimum_size(Size2(260.0, 0.0) * EDSCALE);
 	import_bulk_sc->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+	import_bulk_sc->set_theme_type_variation("ScrollContainerSecondary");
 	import_main_hb->add_child(import_bulk_sc);
 	VBoxContainer *import_bulk_vb = memnew(VBoxContainer);
 	import_bulk_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -1168,8 +1169,6 @@ ThemeItemImportTree::ThemeItemImportTree() {
 			select_icons_warning_hb->add_child(select_icons_warning);
 		}
 	}
-
-	add_child(memnew(HSeparator));
 
 	HBoxContainer *import_buttons = memnew(HBoxContainer);
 	add_child(import_buttons);
@@ -2095,6 +2094,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 	edit_items_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	edit_items_tree->set_hide_root(true);
 	edit_items_tree->set_columns(1);
+	edit_items_tree->set_theme_type_variation("TreeSecondary");
 	edit_items_vb->add_child(edit_items_tree);
 	edit_items_tree->connect("button_clicked", callable_mp(this, &ThemeItemEditorDialog::_item_tree_button_pressed));
 
@@ -2130,7 +2130,6 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 
 	// Import Items tab.
 	TabContainer *import_tc = memnew(TabContainer);
-	import_tc->set_theme_type_variation("TabContainerInner");
 	import_tc->set_tab_alignment(TabBar::ALIGNMENT_CENTER);
 	tc->add_child(import_tc);
 	tc->set_tab_title(1, TTR("Import Items"));
@@ -2322,10 +2321,15 @@ ThemeTypeDialog::ThemeTypeDialog() {
 	add_type_options_label->set_text(TTR("Available Node-based types:"));
 	add_type_vb->add_child(add_type_options_label);
 
+	MarginContainer *mc = memnew(MarginContainer);
+	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	mc->set_theme_type_variation("NoBorderHorizontalWindow");
+	add_type_vb->add_child(mc);
+
 	add_type_options = memnew(ItemList);
 	add_type_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	add_type_options->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	add_type_vb->add_child(add_type_options);
+	add_type_options->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_BOTH);
+	mc->add_child(add_type_options);
 	add_type_options->connect(SceneStringName(item_selected), callable_mp(this, &ThemeTypeDialog::_add_type_options_cbk));
 	add_type_options->connect("item_activated", callable_mp(this, &ThemeTypeDialog::_add_type_dialog_activated));
 
@@ -2351,6 +2355,7 @@ VBoxContainer *ThemeTypeEditor::_create_item_list(Theme::DataType p_data_type) {
 	ScrollContainer *items_sc = memnew(ScrollContainer);
 	items_sc->set_v_size_flags(SIZE_EXPAND_FILL);
 	items_sc->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+	items_sc->set_theme_type_variation("ScrollContainerSecondary");
 	items_tab->add_child(items_sc);
 	VBoxContainer *items_list = memnew(VBoxContainer);
 	items_list->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -3065,6 +3070,11 @@ void ThemeTypeEditor::_item_add_lineedit_cbk(String p_value, int p_data_type, Co
 }
 
 void ThemeTypeEditor::_item_override_cbk(int p_data_type, String p_item_name) {
+	// Avoid errors if the action is triggered multiple times.
+	if (edited_theme->has_theme_item((Theme::DataType)p_data_type, p_item_name, edited_type)) {
+		return;
+	}
+
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 	ur->create_action(TTR("Override Theme Item"));
 
@@ -3104,6 +3114,11 @@ void ThemeTypeEditor::_item_override_cbk(int p_data_type, String p_item_name) {
 }
 
 void ThemeTypeEditor::_item_remove_cbk(int p_data_type, String p_item_name) {
+	// Avoid errors if the action is triggered multiple times.
+	if (!edited_theme->has_theme_item((Theme::DataType)p_data_type, p_item_name, edited_type)) {
+		return;
+	}
+
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 	ur->create_action(TTR("Remove Theme Item"));
 
@@ -3936,9 +3951,11 @@ void ThemeEditor::_notification(int p_what) {
 			theme_edit_button->set_button_icon(get_editor_theme_icon(SNAME("Tools")));
 			theme_close_button->set_button_icon(get_editor_theme_icon(SNAME("Close")));
 
-			preview_tabs->add_theme_style_override("tab_selected", get_theme_stylebox(SNAME("ThemeEditorPreviewFG"), EditorStringName(EditorStyles)));
-			preview_tabs->add_theme_style_override("tab_unselected", get_theme_stylebox(SNAME("ThemeEditorPreviewBG"), EditorStringName(EditorStyles)));
-			preview_tabs_content->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("TabContainerOdd")));
+			if (EDITOR_GET("interface/theme/style") == "Classic") {
+				preview_tabs->add_theme_style_override("tab_selected", get_theme_stylebox(SNAME("ThemeEditorPreviewFG"), EditorStringName(EditorStyles)));
+				preview_tabs->add_theme_style_override("tab_unselected", get_theme_stylebox(SNAME("ThemeEditorPreviewBG"), EditorStringName(EditorStyles)));
+				preview_tabs_content->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("TabContainerOdd")));
+			}
 
 			add_preview_button->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 			add_preview_button_ph->set_custom_minimum_size(add_preview_button->get_minimum_size());
@@ -4028,8 +4045,15 @@ ThemeEditor::ThemeEditor() {
 	preview_tabs_vb->set_h_size_flags(SIZE_EXPAND_FILL);
 	preview_tabs_vb->add_theme_constant_override("separation", 2 * EDSCALE);
 	main_hs->add_child(preview_tabs_vb);
+
+	PanelContainer *tabs_panel = memnew(PanelContainer);
+	tabs_panel->set_h_size_flags(SIZE_EXPAND_FILL);
+	tabs_panel->set_theme_type_variation("PanelContainerTabbarInner");
+	preview_tabs_vb->add_child(tabs_panel);
+
 	HBoxContainer *preview_tabbar_hb = memnew(HBoxContainer);
-	preview_tabs_vb->add_child(preview_tabbar_hb);
+	tabs_panel->add_child(preview_tabbar_hb);
+
 	preview_tabs_content = memnew(PanelContainer);
 	preview_tabs_content->set_v_size_flags(SIZE_EXPAND_FILL);
 	preview_tabs_content->set_draw_behind_parent(true);
@@ -4037,6 +4061,7 @@ ThemeEditor::ThemeEditor() {
 
 	preview_tabs = memnew(TabBar);
 	preview_tabs->set_h_size_flags(SIZE_EXPAND_FILL);
+	preview_tabs->set_theme_type_variation("TabContainerInner");
 	preview_tabbar_hb->add_child(preview_tabs);
 	preview_tabs->connect("tab_changed", callable_mp(this, &ThemeEditor::_change_preview_tab));
 	preview_tabs->connect("tab_button_pressed", callable_mp(this, &ThemeEditor::_remove_preview_tab));


### PR DESCRIPTION
- Add inner tab styling to preview tabs.
- Add scroll hints/panels to the appropriate places.
- Fix errors and bogus actions when rapidly clicking the override and delete item theme buttons.