### PR TITLE
Generate translation template from Command Palette

### DIFF
--- a/editor/script/editor_script_plugin.cpp
+++ b/editor/script/editor_script_plugin.cpp
@@ -55,7 +55,7 @@ void EditorScriptPlugin::command_palette_about_to_popup() {
 	commands.clear();
 	ScriptServer::get_indirect_inheriters_list(SNAME("EditorScript"), &commands);
 	for (const StringName &command : commands) {
-		EditorInterface::get_singleton()->get_command_palette()->add_command(String(command).capitalize(), "editor_scripts/" + command, callable_mp(this, &EditorScriptPlugin::run_command), varray(command), nullptr);
+		EditorInterface::get_singleton()->get_command_palette()->add_command(String(command).capitalize(), "editor_scripts/" + command, callable_mp(this, &EditorScriptPlugin::run_command).bind(command));
 	}
 }
 

--- a/editor/settings/editor_command_palette.cpp
+++ b/editor/settings/editor_command_palette.cpp
@@ -231,16 +231,12 @@ void EditorCommandPalette::remove_command(String p_key_name) {
 	commands.erase(p_key_name);
 }
 
-void EditorCommandPalette::add_command(String p_command_name, String p_key_name, Callable p_action, Vector<Variant> arguments, const Ref<Shortcut> &p_shortcut) {
+void EditorCommandPalette::add_command(String p_command_name, String p_key_name, Callable p_action, const Ref<Shortcut> &p_shortcut) {
 	ERR_FAIL_COND_MSG(commands.has(p_key_name), "The Command '" + String(p_command_name) + "' already exists. Unable to add it.");
 
-	const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * arguments.size());
-	for (int i = 0; i < arguments.size(); i++) {
-		argptrs[i] = &arguments[i];
-	}
 	Command command;
 	command.name = p_command_name;
-	command.callable = p_action.bindp(argptrs, arguments.size());
+	command.callable = p_action;
 	if (p_shortcut.is_null()) {
 		command.shortcut_text = "None";
 	} else {
@@ -290,7 +286,7 @@ void EditorCommandPalette::register_shortcuts_as_command() {
 		Ref<InputEventShortcut> ev;
 		ev.instantiate();
 		ev->set_shortcut(shortcut);
-		add_command(command_name, E.key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_input), varray(ev, false), shortcut);
+		add_command(command_name, E.key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_input).bind(ev, false), shortcut);
 	}
 	unregistered_shortcuts.clear();
 
@@ -309,7 +305,7 @@ Ref<Shortcut> EditorCommandPalette::add_shortcut_command(const String &p_command
 		Ref<InputEventShortcut> ev;
 		ev.instantiate();
 		ev->set_shortcut(p_shortcut);
-		add_command(p_command, p_key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_input), varray(ev, false), p_shortcut);
+		add_command(p_command, p_key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_input).bind(ev, false), p_shortcut);
 	} else {
 		const String key_name = String(p_key);
 		const String command_name = String(p_command);

--- a/editor/settings/editor_command_palette.h
+++ b/editor/settings/editor_command_palette.h
@@ -92,7 +92,7 @@ protected:
 public:
 	void open_popup();
 	void get_actions_list(List<String> *p_list) const;
-	void add_command(String p_command_name, String p_key_name, Callable p_action, Vector<Variant> arguments, const Ref<Shortcut> &p_shortcut);
+	void add_command(String p_command_name, String p_key_name, Callable p_action, const Ref<Shortcut> &p_shortcut = Ref<Shortcut>());
 	void execute_command(const String &p_command_name);
 	void register_shortcuts_as_command();
 	Ref<Shortcut> add_shortcut_command(const String &p_command, const String &p_key, Ref<Shortcut> p_shortcut);

--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -35,7 +35,10 @@
 #include "editor/docks/filesystem_dock.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/gui/editor_toaster.h"
+#include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
+#include "editor/settings/project_settings_editor.h"
 #include "editor/translations/editor_translation_parser.h"
 #include "editor/translations/template_generator.h"
 #include "scene/gui/control.h"
@@ -400,6 +403,17 @@ void LocalizationEditor::_template_source_file_open() {
 
 void LocalizationEditor::_template_generate_open() {
 	template_generate_dialog->popup_file_dialog();
+}
+
+void LocalizationEditor::_template_generate_command() {
+	const String current_path = template_generate_dialog->get_current_path();
+	if (!current_path.is_empty() && current_path.get_file().is_valid_filename()) {
+		_template_generate(current_path);
+		EditorToaster::get_singleton()->popup_str(TTR("Template generated."));
+	} else {
+		ProjectSettingsEditor::get_singleton()->popup_centered();
+		_template_generate_open();
+	}
 }
 
 void LocalizationEditor::_template_add_builtin_toggled() {
@@ -897,4 +911,6 @@ LocalizationEditor::LocalizationEditor() {
 	for (Tree *tree : trees) {
 		SET_DRAG_FORWARDING_GCD(tree, LocalizationEditor);
 	}
+
+	EditorCommandPalette::get_singleton()->add_command(TTRC("Generate Translation Template"), "editor/template_generator/generate", callable_mp(this, &LocalizationEditor::_template_generate_command));
 }

--- a/editor/translations/localization_editor.h
+++ b/editor/translations/localization_editor.h
@@ -83,6 +83,7 @@ class LocalizationEditor : public VBoxContainer {
 	void _template_source_delete(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button);
 	void _template_source_file_open();
 	void _template_generate_open();
+	void _template_generate_command();
 	void _template_add_builtin_toggled();
 	void _template_generate(const String &p_file);
 	void _update_template_source_file_extensions();


### PR DESCRIPTION
This PR registers "Generate Translation Template" (formerly "Generate POT") command to Command Palette, which gives convenient access to generating POT files. The option will open the file dialog to pick target file, or if the file was picked previously, immediately run the template generator (a message is displayed via toaster to give some feedback).

Related to https://github.com/godotengine/godot-proposals/issues/10986

https://github.com/user-attachments/assets/00fa9b42-3c17-4149-a17c-b196973047b3

Unfortunately showing the file dialog is somewhat broken due to #114812 (for now I just force show the project settings dialog).

I also simplified CommandPalette's internal `add_command()` method. It was added before `bind()` was vararg.