### PR TITLE
Add note about physics interpolation in Camera2D.reset_smoothing

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -79,6 +79,7 @@
 			<description>
 				Sets the camera's position immediately to its current smoothing destination.
 				This method has no effect if [member position_smoothing_enabled] is [code]false[/code].
+				[b]Note:[/b] If [url=$DOCS_URL/tutorials/physics/interpolation/index.html]physics interpolation[/url] is enabled, you should call [method Node.reset_physics_interpolation] on the camera [i]before[/i] this method.
 			</description>
 		</method>
 		<method name="set_drag_margin">


### PR DESCRIPTION
If you have physics interpolation enabled, updating a Camera2D's position and calling `reset_smoothing` is insufficient to instantly move the viewport to the new position in the world. It will still smoothly transition, which looks bad if you're teleporting or setting the player's initial position. It's documented elsewhere that you should call `reset_physics_interpolation` on a node after teleporting it, however as a beginner to Godot myself I interpreted this to mean that you should call it on the player (since that's what you're teleporting, if the camera is its child). As such, I spent quite a while trying various combinations of method calls to instantly transition to the new position. It turns out you have to call `reset_physics_interpolation` on the Camera2D directly, as opposed to its parent, and it has to be before you call `reset_smoothing` instead of after. I think this note on `reset_smoothing` will make this clearer and hopefully prevent others from making the same mistake.