### PR TITLE
Improve DampedSpringJoint2D docs, heed zero rest length

### DIFF
--- a/doc/classes/DampedSpringJoint2D.xml
+++ b/doc/classes/DampedSpringJoint2D.xml
@@ -13,7 +13,7 @@
 			The spring joint's damping ratio. A value between [code]0[/code] and [code]1[/code]. When the two bodies move into different directions the system tries to align them to the spring axis again. A high [member damping] value forces the attached bodies to align faster.
 		</member>
 		<member name="length" type="float" setter="set_length" getter="get_length" default="50.0">
-			The spring joint's initial length. The spring will attach to [member node_b] at the joint origin offset by this length on the spring axis. The spring may stretch beyond this length.
+			The spring joint's initial length. The spring will attach to [member Joint2D.node_b] at the joint origin offset by this length on the spring axis. The spring may stretch beyond this length.
 		</member>
 		<member name="rest_length" type="float" setter="set_rest_length" getter="get_rest_length" default="0.0">
 			When the bodies attached to the spring joint move they stretch or squash it. The joint always tries to resize towards this length.

--- a/doc/classes/DampedSpringJoint2D.xml
+++ b/doc/classes/DampedSpringJoint2D.xml
@@ -13,7 +13,7 @@
 			The spring joint's damping ratio. A value between [code]0[/code] and [code]1[/code]. When the two bodies move into different directions the system tries to align them to the spring axis again. A high [member damping] value forces the attached bodies to align faster.
 		</member>
 		<member name="length" type="float" setter="set_length" getter="get_length" default="50.0">
-			The spring joint's maximum length. The two attached bodies cannot stretch it past this value.
+			The spring joint's initial length. The spring will attach to [member node_b] at the joint origin offset by this length on the spring axis. The spring may stretch beyond this length.
 		</member>
 		<member name="rest_length" type="float" setter="set_rest_length" getter="get_rest_length" default="0.0">
 			When the bodies attached to the spring joint move they stretch or squash it. The joint always tries to resize towards this length.

--- a/scene/2d/physics/joints/damped_spring_joint_2d.cpp
+++ b/scene/2d/physics/joints/damped_spring_joint_2d.cpp
@@ -74,7 +74,7 @@ void DampedSpringJoint2D::set_rest_length(real_t p_rest_length) {
 	rest_length = p_rest_length;
 	queue_redraw();
 	if (is_configured()) {
-		PhysicsServer2D::get_singleton()->damped_spring_joint_set_param(get_rid(), PhysicsServer2D::DAMPED_SPRING_REST_LENGTH, p_rest_length ? p_rest_length : length);
+		PhysicsServer2D::get_singleton()->damped_spring_joint_set_param(get_rid(), PhysicsServer2D::DAMPED_SPRING_REST_LENGTH, p_rest_length);
 	}
 }
 

--- a/scene/2d/physics/joints/damped_spring_joint_2d.cpp
+++ b/scene/2d/physics/joints/damped_spring_joint_2d.cpp
@@ -56,9 +56,7 @@ void DampedSpringJoint2D::_configure_joint(RID p_joint, PhysicsBody2D *body_a, P
 	Vector2 anchor_B = gt.xform(Vector2(0, length));
 
 	PhysicsServer2D::get_singleton()->joint_make_damped_spring(p_joint, anchor_A, anchor_B, body_a->get_rid(), body_b->get_rid());
-	if (rest_length) {
-		PhysicsServer2D::get_singleton()->damped_spring_joint_set_param(p_joint, PhysicsServer2D::DAMPED_SPRING_REST_LENGTH, rest_length);
-	}
+	PhysicsServer2D::get_singleton()->damped_spring_joint_set_param(p_joint, PhysicsServer2D::DAMPED_SPRING_REST_LENGTH, rest_length);
 	PhysicsServer2D::get_singleton()->damped_spring_joint_set_param(p_joint, PhysicsServer2D::DAMPED_SPRING_STIFFNESS, stiffness);
 	PhysicsServer2D::get_singleton()->damped_spring_joint_set_param(p_joint, PhysicsServer2D::DAMPED_SPRING_DAMPING, damping);
 }


### PR DESCRIPTION
Fixes #74720.

This clarifies an often confusing bit of documentation falsely claiming that DampedSpringJoint2D can not be stretched beyond its `length` property.

This also removes a `rest_length` value of 0 as a sentinel indicating using `length`. 0 is a valid (and I'd argue common) rest length for a spring joint. Whether or not to default `rest_length` to the same default as `length` (50.0) is another question.