### PR TITLE
Fix child window popup crash when parent is invisible

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1945,7 +1945,8 @@ void Window::popup_centered_clamped(const Size2i &p_size, float p_fallback_ratio
 	if (is_embedded()) {
 		parent_rect = get_embedder()->get_visible_rect();
 	} else {
-		DisplayServer::WindowID parent_id = get_parent_visible_window()->get_window_id();
+		Window *parent_window = get_parent_visible_window();
+		DisplayServer::WindowID parent_id = parent_window ? parent_window->get_window_id() : DisplayServer::MAIN_WINDOW_ID;
 		int parent_screen = DisplayServer::get_singleton()->window_get_current_screen(parent_id);
 		parent_rect.position = DisplayServer::get_singleton()->screen_get_position(parent_screen);
 		parent_rect.size = DisplayServer::get_singleton()->screen_get_size(parent_screen);
@@ -1987,7 +1988,8 @@ void Window::popup_centered(const Size2i &p_minsize) {
 	if (is_embedded()) {
 		parent_rect = get_embedder()->get_visible_rect();
 	} else {
-		DisplayServer::WindowID parent_id = get_parent_visible_window()->get_window_id();
+		Window *parent_window = get_parent_visible_window();
+		DisplayServer::WindowID parent_id = parent_window ? parent_window->get_window_id() : DisplayServer::MAIN_WINDOW_ID;
 		int parent_screen = DisplayServer::get_singleton()->window_get_current_screen(parent_id);
 		parent_rect.position = DisplayServer::get_singleton()->screen_get_position(parent_screen);
 		parent_rect.size = DisplayServer::get_singleton()->screen_get_size(parent_screen);
@@ -2024,7 +2026,8 @@ void Window::popup_centered_ratio(float p_ratio) {
 	if (is_embedded()) {
 		parent_rect = get_embedder()->get_visible_rect();
 	} else {
-		DisplayServer::WindowID parent_id = get_parent_visible_window()->get_window_id();
+		Window *parent_window = get_parent_visible_window();
+		DisplayServer::WindowID parent_id = parent_window ? parent_window->get_window_id() : DisplayServer::MAIN_WINDOW_ID;
 		int parent_screen = DisplayServer::get_singleton()->window_get_current_screen(parent_id);
 		parent_rect.position = DisplayServer::get_singleton()->screen_get_position(parent_screen);
 		parent_rect.size = DisplayServer::get_singleton()->screen_get_size(parent_screen);

--- a/tests/scene/test_window.h
+++ b/tests/scene/test_window.h
@@ -88,6 +88,33 @@ TEST_CASE("[SceneTree][Window]") {
 		memdelete(c);
 		memdelete(w);
 	}
+
+	SUBCASE("Child window popup should work when parent window is invisible") {
+		// GH-114812: When a parent Window is invisible and embed_subwindows is disabled,
+		// child dialogs should still be able to popup without crashing.
+		Window *parent_window = memnew(Window);
+		root->add_child(parent_window);
+		parent_window->set_visible(false); // Parent is invisible
+		parent_window->set_force_native(true); // Force non-embedded mode
+
+		Window *child_window = memnew(Window);
+		parent_window->add_child(child_window);
+
+		// These should not crash even though parent is invisible and get_parent_visible_window() returns nullptr
+		child_window->popup_centered(Size2i(200, 200));
+		CHECK(child_window->is_visible());
+
+		child_window->hide();
+		child_window->popup_centered_ratio(0.5);
+		CHECK(child_window->is_visible());
+
+		child_window->hide();
+		child_window->popup_centered_clamped(Size2i(300, 300), 0.75);
+		CHECK(child_window->is_visible());
+
+		memdelete(child_window);
+		memdelete(parent_window);
+	}
 }
 
 } // namespace TestWindow


### PR DESCRIPTION
 ## Summary
 When a parent Window is invisible and `embed_subwindows` is disabled, child dialogs would crash when attempting to popup because `get_parent_visible_window()` returns `nullptr`.

## Changes
 - Added null check in `popup_centered()`, `popup_centered_ratio()`, and `popup_centered_clamped()`
 - Falls back to `DisplayServer::MAIN_WINDOW_ID` when no visible parent is found
 - Added unit test to prevent regressions

 ## Testing
 Added test case in `tests/scene/test_window.h` that verifies child windows can popup correctly even when parent is invisible.

<i>Bugsquad edit:</i>
- Fixes https://github.com/godotengine/godot/issues/114812