### PR TITLE
Use more specific check for dragging wait setting

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1067,7 +1067,7 @@ void EditorNode::_notification(int p_what) {
 				recent_scenes->reset_size();
 			}
 
-			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor")) {
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/dragging_")) {
 				theme->set_constant("dragging_unfold_wait_msec", "Tree", (float)EDITOR_GET("interface/editor/dragging_hover_wait_seconds") * 1000);
 				theme->set_constant("hover_switch_wait_msec", "TabBar", (float)EDITOR_GET("interface/editor/dragging_hover_wait_seconds") * 1000);
 				editor_dock_manager->update_tab_styles();


### PR DESCRIPTION
I noticed that changing editor language takes unreasonably long. Turns out the editor was updating the dragging hover setting, which triggered updating of the editor theme, which just takes looooong time.

I made the check more specific, so the theme is not updated more than necessary.