### PR TITLE
Add selection wrapping to ItemList

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -458,6 +458,11 @@
 		<member name="tile_scroll_hint" type="bool" setter="set_tile_scroll_hint" getter="is_scroll_hint_tiled" default="false">
 			If [code]true[/code], the scroll hint texture will be tiled instead of stretched. See [member scroll_hint_mode].
 		</member>
+		<member name="wrap_selection_mode" type="int" setter="set_wrap_selection_mode" getter="get_wrap_selection_mode" enum="ItemList.WrapSelectionMode" default="0">
+			Determines how the selection behaves when attempting to navigate beyond the boundaries of the list.
+			This controls whether the selection stops at the edges of the list, wraps back to the beginning of the next row, or loops within the current row/column.
+			See the [enum WrapSelectionMode] constants.
+		</member>
 		<member name="wraparound_items" type="bool" setter="set_wraparound_items" getter="has_wraparound_items" default="true">
 			If [code]true[/code], the control will automatically move items into a new row to fit its content. See also [HFlowContainer] for this behavior.
 			If [code]false[/code], the control will add a horizontal scrollbar to make all items visible.
@@ -529,6 +534,15 @@
 		</constant>
 		<constant name="SCROLL_HINT_MODE_BOTTOM" value="3" enum="ScrollHintMode">
 			Only the bottom scroll hint will be shown.
+		</constant>
+		<constant name="WRAP_SELECTION_NONE" value="0" enum="WrapSelectionMode">
+			The selection stops at the edges of the list.
+		</constant>
+		<constant name="WRAP_SELECTION_AROUND" value="1" enum="WrapSelectionMode">
+			The selection wraps around to the start of the next row.
+		</constant>
+		<constant name="WRAP_SELECTION_SAME_AXIS" value="2" enum="WrapSelectionMode">
+			The selection loops around the current axis (row/column).
 		</constant>
 	</constants>
 	<theme_items>

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -692,6 +692,19 @@ ItemList::IconMode ItemList::get_icon_mode() const {
 	return icon_mode;
 }
 
+void ItemList::set_wrap_selection_mode(WrapSelectionMode p_mode) {
+	ERR_FAIL_INDEX((int)p_mode, 3);
+	if (wrap_selection_mode == p_mode) {
+		return;
+	}
+
+	wrap_selection_mode = p_mode;
+}
+
+ItemList::WrapSelectionMode ItemList::get_wrap_selection_mode() const {
+	return wrap_selection_mode;
+}
+
 void ItemList::set_fixed_icon_size(const Size2i &p_size) {
 	if (fixed_icon_size == p_size) {
 		return;
@@ -956,22 +969,34 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 				}
 			}
 
-			if (current >= current_columns) {
-				int next = current - current_columns;
-				while (next >= 0 && !CAN_SELECT(next)) {
-					next = next - current_columns;
+			int column = current % current_columns;
+			int rows = Math::ceil(items.size() / (float)current_columns);
+			int next = current - current_columns;
+
+			if (current >= 0 && wrap_selection_mode == WRAP_SELECTION_SAME_AXIS) {
+				if (current < current_columns) {
+					next = column + (rows - 1) * current_columns;
+					if (next >= items.size()) {
+						next -= current_columns;
+					}
 				}
-				if (next < 0) {
-					accept_event();
-					return;
-				}
-				set_current(next);
-				ensure_current_is_visible();
-				if (select_mode == SELECT_SINGLE) {
-					emit_signal(SceneStringName(item_selected), current);
-				}
-				accept_event();
 			}
+
+			while (next >= 0 && !CAN_SELECT(next)) {
+				next = next - current_columns;
+			}
+
+			if (next < 0) {
+				accept_event();
+				return;
+			}
+
+			set_current(next);
+			ensure_current_is_visible();
+			if (select_mode == SELECT_SINGLE) {
+				emit_signal(SceneStringName(item_selected), current);
+			}
+			accept_event();
 		}
 
 		// Shift Down Selection.
@@ -1002,22 +1027,30 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 				}
 			}
 
-			if (current < items.size() - current_columns) {
-				int next = current + current_columns;
-				while (next < items.size() && !CAN_SELECT(next)) {
-					next = next + current_columns;
+			int column = current % current_columns;
+			int next = current + current_columns;
+
+			if (current >= 0 && wrap_selection_mode == WRAP_SELECTION_SAME_AXIS) {
+				if (current >= items.size() - current_columns) {
+					next = column;
 				}
-				if (next >= items.size()) {
-					accept_event();
-					return;
-				}
-				set_current(next);
-				ensure_current_is_visible();
-				if (select_mode == SELECT_SINGLE) {
-					emit_signal(SceneStringName(item_selected), current);
-				}
-				accept_event();
 			}
+
+			while (next < items.size() && !CAN_SELECT(next)) {
+				next = next + current_columns;
+			}
+
+			if (next >= items.size()) {
+				accept_event();
+				return;
+			}
+
+			set_current(next);
+			ensure_current_is_visible();
+			if (select_mode == SELECT_SINGLE) {
+				emit_signal(SceneStringName(item_selected), current);
+			}
+			accept_event();
 		} else if (p_event->is_action("ui_page_up", true)) {
 			search_string = ""; //any mousepress cancels
 
@@ -1061,23 +1094,30 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 		else if (p_event->is_action("ui_left", true)) {
 			search_string = ""; //any mousepress cancels
 
-			if (current % current_columns != 0) {
-				int current_row = current / current_columns;
-				int next = current - 1;
-				while (next >= 0 && !CAN_SELECT(next)) {
-					next = next - 1;
+			int current_row = current / current_columns;
+			int next = current - 1;
+
+			if (current >= 0 && wrap_selection_mode == WRAP_SELECTION_SAME_AXIS) {
+				if (current % current_columns == 0) {
+					next = MIN((current_row + 1) * current_columns - 1, items.size() - 1);
 				}
-				if (next < 0 || !IS_SAME_ROW(next, current_row)) {
-					accept_event();
-					return;
-				}
-				set_current(next);
-				ensure_current_is_visible();
-				if (select_mode == SELECT_SINGLE) {
-					emit_signal(SceneStringName(item_selected), current);
-				}
-				accept_event();
 			}
+
+			while (next >= 0 && !CAN_SELECT(next)) {
+				next = next - 1;
+			}
+
+			if (next < 0 || (!IS_SAME_ROW(next, current_row) && wrap_selection_mode != WRAP_SELECTION_AROUND)) {
+				accept_event();
+				return;
+			}
+
+			set_current(next);
+			ensure_current_is_visible();
+			if (select_mode == SELECT_SINGLE) {
+				emit_signal(SceneStringName(item_selected), current);
+			}
+			accept_event();
 		}
 
 		// Shift Right Selection.
@@ -1090,23 +1130,30 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 		else if (p_event->is_action("ui_right", true)) {
 			search_string = ""; //any mousepress cancels
 
-			if (current % current_columns != (current_columns - 1) && current + 1 < items.size()) {
-				int current_row = current / current_columns;
-				int next = current + 1;
-				while (next < items.size() && !CAN_SELECT(next)) {
-					next = next + 1;
+			int current_row = current / current_columns;
+			int next = current + 1;
+
+			if (current >= 0 && wrap_selection_mode == WRAP_SELECTION_SAME_AXIS) {
+				if (current % current_columns == (current_columns - 1) || current == items.size() - 1) {
+					next = current_row * current_columns;
 				}
-				if (items.size() <= next || !IS_SAME_ROW(next, current_row)) {
-					accept_event();
-					return;
-				}
-				set_current(next);
-				ensure_current_is_visible();
-				if (select_mode == SELECT_SINGLE) {
-					emit_signal(SceneStringName(item_selected), current);
-				}
-				accept_event();
 			}
+
+			while (next < items.size() && !CAN_SELECT(next)) {
+				next = next + 1;
+			}
+
+			if (next >= items.size() || (!IS_SAME_ROW(next, current_row) && wrap_selection_mode != WRAP_SELECTION_AROUND)) {
+				accept_event();
+				return;
+			}
+
+			set_current(next);
+			ensure_current_is_visible();
+			if (select_mode == SELECT_SINGLE) {
+				emit_signal(SceneStringName(item_selected), current);
+			}
+			accept_event();
 		} else if (p_event->is_action("ui_cancel", true)) {
 			search_string = "";
 		} else if (p_event->is_action("ui_select", true) && (select_mode == SELECT_MULTI || select_mode == SELECT_TOGGLE)) {
@@ -2387,6 +2434,9 @@ void ItemList::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_icon_mode", "mode"), &ItemList::set_icon_mode);
 	ClassDB::bind_method(D_METHOD("get_icon_mode"), &ItemList::get_icon_mode);
 
+	ClassDB::bind_method(D_METHOD("set_wrap_selection_mode", "mode"), &ItemList::set_wrap_selection_mode);
+	ClassDB::bind_method(D_METHOD("get_wrap_selection_mode"), &ItemList::get_wrap_selection_mode);
+
 	ClassDB::bind_method(D_METHOD("set_fixed_icon_size", "size"), &ItemList::set_fixed_icon_size);
 	ClassDB::bind_method(D_METHOD("get_fixed_icon_size"), &ItemList::get_fixed_icon_size);
 
@@ -2441,6 +2491,7 @@ void ItemList::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_height"), "set_auto_height", "has_auto_height");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_overrun_behavior", PROPERTY_HINT_ENUM, "Trim Nothing,Trim Characters,Trim Words,Ellipsis (6+ Characters),Word Ellipsis (6+ Characters),Ellipsis (Always),Word Ellipsis (Always)"), "set_text_overrun_behavior", "get_text_overrun_behavior");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "wraparound_items"), "set_wraparound_items", "has_wraparound_items");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "wrap_selection_mode", PROPERTY_HINT_ENUM, "None,Around,Same Axis"), "set_wrap_selection_mode", "get_wrap_selection_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "scroll_hint_mode", PROPERTY_HINT_ENUM, "Disabled,Both,Top,Bottom"), "set_scroll_hint_mode", "get_scroll_hint_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tile_scroll_hint"), "set_tile_scroll_hint", "is_scroll_hint_tiled");
 	ADD_ARRAY_COUNT("Items", "item_count", "set_item_count", "get_item_count", "item_");
@@ -2464,6 +2515,10 @@ void ItemList::_bind_methods() {
 	BIND_ENUM_CONSTANT(SCROLL_HINT_MODE_BOTH);
 	BIND_ENUM_CONSTANT(SCROLL_HINT_MODE_TOP);
 	BIND_ENUM_CONSTANT(SCROLL_HINT_MODE_BOTTOM);
+
+	BIND_ENUM_CONSTANT(WRAP_SELECTION_NONE);
+	BIND_ENUM_CONSTANT(WRAP_SELECTION_AROUND);
+	BIND_ENUM_CONSTANT(WRAP_SELECTION_SAME_AXIS);
 
 	ADD_SIGNAL(MethodInfo("item_selected", PropertyInfo(Variant::INT, "index")));
 	ADD_SIGNAL(MethodInfo("empty_clicked", PropertyInfo(Variant::VECTOR2, "at_position"), PropertyInfo(Variant::INT, "mouse_button_index")));

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -57,6 +57,12 @@ public:
 		SCROLL_HINT_MODE_BOTTOM,
 	};
 
+	enum WrapSelectionMode {
+		WRAP_SELECTION_NONE,
+		WRAP_SELECTION_AROUND,
+		WRAP_SELECTION_SAME_AXIS,
+	};
+
 private:
 	struct Item {
 		mutable RID accessibility_item_element;
@@ -126,6 +132,7 @@ private:
 
 	SelectMode select_mode = SELECT_SINGLE;
 	IconMode icon_mode = ICON_MODE_LEFT;
+	WrapSelectionMode wrap_selection_mode = WRAP_SELECTION_NONE;
 	VScrollBar *scroll_bar_v = nullptr;
 	HScrollBar *scroll_bar_h = nullptr;
 	TextServer::OverrunBehavior text_overrun_behavior = TextServer::OVERRUN_TRIM_ELLIPSIS;
@@ -304,6 +311,9 @@ public:
 	void set_icon_mode(IconMode p_mode);
 	IconMode get_icon_mode() const;
 
+	void set_wrap_selection_mode(WrapSelectionMode p_mode);
+	WrapSelectionMode get_wrap_selection_mode() const;
+
 	void set_fixed_icon_size(const Size2i &p_size);
 	Size2i get_fixed_icon_size() const;
 
@@ -363,3 +373,4 @@ public:
 VARIANT_ENUM_CAST(ItemList::SelectMode);
 VARIANT_ENUM_CAST(ItemList::IconMode);
 VARIANT_ENUM_CAST(ItemList::ScrollHintMode);
+VARIANT_ENUM_CAST(ItemList::WrapSelectionMode);


### PR DESCRIPTION
https://github.com/user-attachments/assets/ad54d538-6742-4533-afd7-aec389056cc5

Partially implements https://github.com/godotengine/godot-proposals/issues/12886

# Motivation
Currently, the ItemList node has a fixed navigation behavior: when a user reaches the end of a row or column of the list, the selection simply stops.

Changing this behaviour currently requires manual script overrides using `_gui_input`, which is redundant for such a common UI pattern.

# Overview
This PR adds a new property `wrap_selection_mode` to the `ItemList` control node. This allows you to customize how the selection behaves when attempting to navigate beyond the boundaries of the list.

`wrap_selection_mode` may have one of three values:
- **WRAP_SELECTION_NONE:** The selection stops at the edges of the list. **[The old behaviour, still the default]**
- **WRAP_SELECTION_AROUND:** The selection wraps around to the start of the next row.
- **WRAP_SELECTION_SAME_AXIS:** The selection loops around current axis (row/column).

