### PR TITLE
ENet: Fix DTLS server leaking peers

### DIFF
--- a/modules/enet/enet_packet_peer.cpp
+++ b/modules/enet/enet_packet_peer.cpp
@@ -182,6 +182,9 @@ int ENetPacketPeer::get_packet_flags() const {
 
 void ENetPacketPeer::_on_disconnect() {
 	if (peer) {
+#ifdef GODOT_ENET
+		enet_peer_socket_destroy(peer);
+#endif
 		peer->data = nullptr;
 	}
 	peer = nullptr;
@@ -256,6 +259,9 @@ void ENetPacketPeer::_bind_methods() {
 ENetPacketPeer::ENetPacketPeer(ENetPeer *p_peer) {
 	peer = p_peer;
 	peer->data = this;
+#ifdef GODOT_ENET
+	enet_peer_socket_bind(peer);
+#endif
 }
 
 ENetPacketPeer::~ENetPacketPeer() {

--- a/thirdparty/enet/enet/enet_godot_ext.h
+++ b/thirdparty/enet/enet/enet_godot_ext.h
@@ -49,5 +49,7 @@ ENET_API void enet_address_set_ip(ENetAddress * address, const uint8_t * ip, siz
 ENET_API int enet_host_dtls_server_setup (ENetHost *, void *);
 ENET_API int enet_host_dtls_client_setup (ENetHost *, const char *, void *);
 ENET_API void enet_host_refuse_new_connections (ENetHost *, int);
+ENET_API void enet_peer_socket_bind (ENetPeer *);
+ENET_API void enet_peer_socket_destroy (ENetPeer *);
 
 #endif // __ENET_GODOT_EXT_H__


### PR DESCRIPTION
Our DTLS ENet implementation has always been quite hacky and experimental since ENet itself lacks a proper API for DTLS.

This commit adds two more DTLS methods to our builtin ENet to allow peer-connections lifecycle management for the DTLS server.

This means the DTLS server is now notified (by our module) when ENet accepts or disconnects a peer, allowing it to handle timeouts and higher-level disconnections.

Fixes #98358