### PR TITLE
Revert "Fix modified editor shortcuts being erased"

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -102,7 +102,7 @@ bool EditorSettings::_set_only(const StringName &p_name, const Variant &p_value)
 			Ref<Shortcut> sc;
 			sc.instantiate();
 			sc->set_events(shortcut_events);
-			_add_shortcut_default(shortcut_name, sc);
+			add_shortcut(shortcut_name, sc);
 		}
 
 		return false;


### PR DESCRIPTION
This reverts commit 9fadd0d99e581c83484c56c256af1029b44a4d8e.

I noticed that the previous change caused the issue it was supposed to fix.

After it was made, I observed it is not possible to change the shortcut like for example: "Script Text Editor > Contextual Help" from "Option+Shift+Space" to "F1". It works fine but if I restart, the shortcut goes back to "Option+Shift+Space".

Ping @ryevdokimov

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
