### PR TITLE
Fix opening macOS folder in Terminal spawns new process

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2281,7 +2281,9 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				// Default to PowerShell as done by Windows 10 and later.
 				terminal_emulators.push_back("powershell");
 #elif defined(MACOS_ENABLED)
-				terminal_emulators.push_back("/System/Applications/Utilities/Terminal.app");
+				// NOTE: To avoid duplicating the Terminal icon on the Dock, we will use the `open` command
+				// rather than directly launching the Terminal.app bundle.
+				terminal_emulators.push_back("open");
 #elif defined(LINUXBSD_ENABLED)
 				// Try terminal emulators that ship with common Linux distributions first.
 				terminal_emulators.push_back("gnome-terminal");
@@ -2355,6 +2357,13 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 					terminal_emulator_args.push_back("cd '{directory}' && exec $SHELL");
 					append_default_args = false;
 				}
+			}
+#endif
+
+#ifdef MACOS_ENABLED
+			if (terminal_emulator_setting.is_empty()) {
+				terminal_emulator_args.push_back("-b");
+				terminal_emulator_args.push_back("com.apple.terminal");
 			}
 #endif
 


### PR DESCRIPTION
Fixes #114810.

Instead of directly launching the `Terminal.app` bundle, this fix uses the `open -b com.apple.terminal {directory}` command in order to open a folder in terminal, which avoids process duplication, and in consequence, duplicating the Terminal icon in Dock when another instance is already running.

This aligns the behavior to be more consistent with the macOS design principles.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
