### PR TITLE
BasisUniversal: Disable strict aliasing to fix GCC optimization issue

### DIFF
--- a/modules/basis_universal/SCsub
+++ b/modules/basis_universal/SCsub
@@ -56,6 +56,10 @@ if env["builtin_zstd"]:
 env_thirdparty = env_basisu.Clone()
 env_thirdparty.disable_warnings()
 
+if not env.msvc:
+    # Required by upstream for GCC. Enabling also for LLVM-based compilers to be consistent.
+    env_thirdparty.Append(CCFLAGS=["-fno-strict-aliasing"])
+
 # Disable unneeded features to reduce binary size.
 # <https://github.com/BinomialLLC/basis_universal/wiki/How-to-Use-and-Configure-the-Transcoder>
 env_thirdparty.Append(


### PR DESCRIPTION
This is flagged by upstream as something important in `basisu.h`. And indeed, we've now seen why with a regression appearing with mingw-gcc 15.

Fixes #114803.