### PR TITLE
Add alpha to coverage support for the compatibility renderer

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3284,7 +3284,11 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 
 						} break;
 						case GLES3::SceneShaderData::BLEND_MODE_ALPHA_TO_COVERAGE: {
-							// Do nothing for now.
+							scene_state.enable_gl_sample_alpha_to_coverage(true);
+							if (shader->uses_alpha_to_coverage_and_one) {
+								scene_state.enable_gl_blend(false);
+							}
+
 						} break;
 					}
 					scene_state.current_blend_mode = desired_blend_mode;

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -486,6 +486,7 @@ private:
 		bool current_depth_draw_enabled = false;
 		bool current_depth_test_enabled = false;
 		bool current_scissor_test_enabled = false;
+		bool current_sample_alpha_to_coverage_enable = false;
 
 		void reset_gl_state() {
 			glDisable(GL_BLEND);
@@ -508,6 +509,9 @@ private:
 
 			glDisable(GL_STENCIL_TEST);
 			current_stencil_test_enabled = false;
+
+			glDisable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+			current_sample_alpha_to_coverage_enable = false;
 			glStencilMask(255);
 			current_stencil_write_mask = 255;
 			glStencilFunc(GL_ALWAYS, 0, 255);
@@ -586,6 +590,17 @@ private:
 					glDisable(GL_STENCIL_TEST);
 				}
 				current_stencil_test_enabled = p_enabled;
+			}
+		}
+
+		void enable_gl_sample_alpha_to_coverage(bool p_enabled) {
+			if (current_sample_alpha_to_coverage_enable != p_enabled) {
+				if (p_enabled) {
+					glEnable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+				} else {
+					glDisable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+				}
+				current_sample_alpha_to_coverage_enable = p_enabled;
 			}
 		}
 

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1980,6 +1980,23 @@ vec4 textureArray_bicubic(sampler2DArray tex, vec3 uv, vec2 texture_size) {
 #endif //LIGHTMAP_BICUBIC_FILTER
 #endif // RENDER_MOTION_VECTORS
 
+#ifdef ALPHA_ANTIALIASING_EDGE_USED
+
+float calc_mip_level(vec2 texture_coord) {
+	vec2 dx = dFdx(texture_coord);
+	vec2 dy = dFdy(texture_coord);
+	float delta_max_sqr = max(dot(dx, dx), dot(dy, dy));
+	return max(0.0, 0.5 * log2(delta_max_sqr));
+}
+
+float compute_alpha_antialiasing_edge(float input_alpha, vec2 texture_coord, float alpha_edge) {
+	input_alpha *= 1.0 + max(0, calc_mip_level(texture_coord)) * 0.25; // 0.25 mip scale, magic number
+	input_alpha = (input_alpha - alpha_edge) / max(fwidth(input_alpha), 0.0001) + 0.5;
+	return clamp(input_alpha, 0.0, 1.0);
+}
+
+#endif // ALPHA_ANTIALIASING_EDGE_USED
+
 void main() {
 #ifndef RENDER_MOTION_VECTORS
 	//lay out everything, whatever is unused is optimized away anyway
@@ -2130,9 +2147,22 @@ void main() {
 	if (alpha < alpha_scissor_threshold) {
 		discard;
 	}
-	alpha = 1.0;
 #endif // RENDER_MATERIAL
-#else
+#endif // ALPHA_SCISSOR_USED
+
+// If we are not edge antialiasing, we need to remove the output alpha channel from scissor and hash
+#if defined(ALPHA_SCISSOR_USED) && !defined(ALPHA_ANTIALIASING_EDGE_USED) && !defined(RENDER_MATERIAL)
+	alpha = 1.0;
+#endif
+
+#ifdef ALPHA_ANTIALIASING_EDGE_USED
+// If alpha scissor is used, we must further the edge threshold, otherwise we wont get any edge feather
+#ifdef ALPHA_SCISSOR_USED
+	alpha_antialiasing_edge = clamp(alpha_scissor_threshold + alpha_antialiasing_edge, 0.0, 1.0);
+#endif
+	alpha = compute_alpha_antialiasing_edge(alpha, alpha_texture_coordinate, alpha_antialiasing_edge);
+#endif // ALPHA_ANTIALIASING_EDGE_USED
+
 #ifdef MODE_RENDER_DEPTH
 #ifdef USE_OPAQUE_PREPASS
 
@@ -2141,7 +2171,6 @@ void main() {
 	}
 #endif // USE_OPAQUE_PREPASS
 #endif // MODE_RENDER_DEPTH
-#endif // !ALPHA_SCISSOR_USED
 
 #endif // !USE_SHADOW_TO_OPACITY
 

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -2156,7 +2156,7 @@ void main() {
 #endif
 
 #ifdef ALPHA_ANTIALIASING_EDGE_USED
-// If alpha scissor is used, we must further the edge threshold, otherwise we wont get any edge feather
+// If alpha scissor is used, we must further the edge threshold, otherwise we won't get any edge feather
 #ifdef ALPHA_SCISSOR_USED
 	alpha_antialiasing_edge = clamp(alpha_scissor_threshold + alpha_antialiasing_edge, 0.0, 1.0);
 #endif

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2928,6 +2928,7 @@ void SceneShaderData::set_code(const String &p_code) {
 	uses_alpha_clip = false;
 	uses_blend_alpha = false;
 	uses_depth_prepass_alpha = false;
+	uses_alpha_to_coverage_and_one = false;
 	uses_discard = false;
 	uses_roughness = false;
 	uses_normal = false;
@@ -3016,6 +3017,7 @@ void SceneShaderData::set_code(const String &p_code) {
 	// This prevents sorting issues inherent to alpha blending and allows such materials to cast shadows.
 	actions.usage_flag_pointers["ALPHA_HASH_SCALE"] = &uses_alpha_clip;
 	actions.render_mode_flags["depth_prepass_alpha"] = &uses_depth_prepass_alpha;
+	actions.render_mode_flags["alpha_to_coverage_and_one"] = &uses_alpha_to_coverage_and_one;
 
 	actions.usage_flag_pointers["SSS_STRENGTH"] = &uses_sss;
 	actions.usage_flag_pointers["SSS_TRANSMITTANCE_DEPTH"] = &uses_transmittance;

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -313,6 +313,7 @@ struct SceneShaderData : public ShaderData {
 	bool uses_alpha_clip;
 	bool uses_blend_alpha;
 	bool uses_depth_prepass_alpha;
+	bool uses_alpha_to_coverage_and_one;
 	bool uses_discard;
 	bool uses_roughness;
 	bool uses_normal;


### PR DESCRIPTION
fixes #98173

This PR adds alpha to coverage (and alpha to one) support for the compatibility renderer.

Works for regular materials, label3D and sprite3D.