### PR TITLE
Scene: Fix `LineEdit.set_editable` to capture text focus when enabled.

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2573,6 +2573,12 @@ void LineEdit::set_editable(bool p_editable) {
 		unedit();
 		emit_signal(SNAME("editing_toggled"), false);
 	}
+
+	if (editable && has_focus() && !editing) {
+		edit();
+		emit_signal(SNAME("editing_toggled"), true);
+	}
+
 	_validate_caret_can_draw();
 
 	update_minimum_size();


### PR DESCRIPTION
A LineEdit instance will get Text Input focus if, when `set_editable(true)` is called, there is a UI focus on it.
Fixed #114846 (and potentially #114833)