### PR TITLE
Change return type for `Input.set_joy_light()` from `bool` to `void`

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1004,12 +1004,13 @@ void Input::set_joy_features(int p_device, JoypadFeatures *p_features) {
 	_update_joypad_features(p_device);
 }
 
-bool Input::set_joy_light(int p_device, const Color &p_color) {
+void Input::set_joy_light(int p_device, const Color &p_color) {
 	Joypad *joypad = joy_names.getptr(p_device);
-	if (!joypad || joypad->features == nullptr) {
-		return false;
+	if (!joypad || !joypad->has_light || joypad->features == nullptr) {
+		return;
 	}
-	return joypad->features->set_joy_light(p_color);
+	Color linear = p_color.srgb_to_linear();
+	joypad->features->set_joy_light(linear);
 }
 
 bool Input::has_joy_light(int p_device) const {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -84,7 +84,7 @@ public:
 		virtual ~JoypadFeatures() {}
 
 		virtual bool has_joy_light() const { return false; }
-		virtual bool set_joy_light(const Color &p_color) { return false; }
+		virtual void set_joy_light(const Color &p_color) {}
 	};
 
 	static constexpr int32_t JOYPADS_MAX = 16;
@@ -360,7 +360,7 @@ public:
 
 	void set_joy_features(int p_device, JoypadFeatures *p_features);
 
-	bool set_joy_light(int p_device, const Color &p_color);
+	void set_joy_light(int p_device, const Color &p_color);
 	bool has_joy_light(int p_device) const;
 
 	void start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration = 0);

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -398,11 +398,11 @@
 			</description>
 		</method>
 		<method name="set_joy_light">
-			<return type="bool" />
+			<return type="void" />
 			<param index="0" name="device" type="int" />
 			<param index="1" name="color" type="Color" />
 			<description>
-				Sets the joypad's LED light, if available, to the specified color. Returns [code]true[/code] if the operation was successful. See also [method has_joy_light].
+				Sets the joypad's LED light, if available, to the specified color. See also [method has_joy_light].
 				[b]Note:[/b] There is no way to get the color of the light from a joypad. If you need to know the assigned color, store it separately.
 				[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
 			</description>

--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -297,9 +297,8 @@ bool JoypadSDL::Joypad::has_joy_light() const {
 	return SDL_GetBooleanProperty(properties_id, SDL_PROP_JOYSTICK_CAP_RGB_LED_BOOLEAN, false) || SDL_GetBooleanProperty(properties_id, SDL_PROP_JOYSTICK_CAP_MONO_LED_BOOLEAN, false);
 }
 
-bool JoypadSDL::Joypad::set_joy_light(const Color &p_color) {
-	Color linear = p_color.srgb_to_linear();
-	return SDL_SetJoystickLED(get_sdl_joystick(), linear.get_r8(), linear.get_g8(), linear.get_b8());
+void JoypadSDL::Joypad::set_joy_light(const Color &p_color) {
+	SDL_SetJoystickLED(get_sdl_joystick(), p_color.get_r8(), p_color.get_g8(), p_color.get_b8());
 }
 
 SDL_Joystick *JoypadSDL::Joypad::get_sdl_joystick() const {

--- a/drivers/sdl/joypad_sdl.h
+++ b/drivers/sdl/joypad_sdl.h
@@ -59,7 +59,7 @@ private:
 		uint64_t ff_effect_timestamp = 0;
 
 		virtual bool has_joy_light() const override;
-		virtual bool set_joy_light(const Color &p_color) override;
+		virtual void set_joy_light(const Color &p_color) override;
 
 		SDL_Joystick *get_sdl_joystick() const;
 		SDL_Gamepad *get_sdl_gamepad() const;


### PR DESCRIPTION
A PR for discussion :D

I was wondering if `Input.set_joy_light()` introduced in https://github.com/godotengine/godot/pull/111681 should have the `void` return type instead of `bool` (that's used to indicate if the operation was successful) to match other Input setter/action functions, for example:
https://github.com/godotengine/godot/blob/e9bb99a3bbf69e117d8e8aafba70db31aefc34f5/core/input/input.h#L385
https://github.com/godotengine/godot/blob/e9bb99a3bbf69e117d8e8aafba70db31aefc34f5/core/input/input.h#L366-L368
https://github.com/godotengine/godot/blob/e9bb99a3bbf69e117d8e8aafba70db31aefc34f5/core/input/input.h#L301-L305

Other methods don't return `bool` to indicate if the operation was successful, so I'm not sure `Input.set_joy_light()` should either.
I'm not sure this is compatibility-breaking, since this method was introduced in 4.6, which doesn't have a stable release yet.

This PR also moves the linear color calculation for that method from `JoypadSDL` class to the `Input.set_joy_light()` method, I think it makes more sense, it would also be a better option in the future when we introduce this feature for Android or custom platforms.

May I ask what are your thoughts?

TODO:
- [x] Make sure this PR doesn't make a regression (tested on Windows, seems to be working fine)