### PR TITLE
Fix right clicking on a project draws focus outline

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -1208,7 +1208,7 @@ void ProjectList::_open_menu(const Vector2 &p_at, Control *p_hb) {
 		project_context_menu->connect(SceneStringName(id_pressed), callable_mp(this, &ProjectList::_menu_option));
 		_update_menu_icons();
 	}
-	select_project(clicked_index);
+	select_project(clicked_index, true);
 
 	for (int id : Vector<int>{
 				 MENU_EDIT,


### PR DESCRIPTION
Happens when you right click on a project after left clicking on any project once, was probably missed when the context menu was added in https://github.com/godotengine/godot/pull/112733

cc @YeldhamDev 