### PR TITLE
MovieWriter: Check disk space in output directory

### DIFF
--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -102,15 +102,17 @@ void MovieWriter::begin(const Size2i &p_movie_size, uint32_t p_fps, const String
 	print_line(vformat(U"Movie Maker mode enabled, recording movie in %s×%s @ %d FPS...", movie_size.width, movie_size.height, p_fps));
 
 	// Check for available disk space and warn the user if needed.
-	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	String path = p_base_path.get_base_dir();
 	if (path.is_relative_path()) {
 		path = "res://" + path;
 	}
-	dir->open(path);
-	if (dir->get_space_left() < 10 * Math::pow(1024.0, 3.0)) {
-		// Less than 10 GiB available.
-		WARN_PRINT(vformat("Current available space on disk is low (%s). MovieWriter will fail during movie recording if the disk runs out of available space.", String::humanize_size(dir->get_space_left())));
+	Ref<DirAccess> dir = DirAccess::open(path);
+	if (dir.is_valid()) {
+		const uint64_t space_left = dir->get_space_left();
+		if (space_left < 10 * Math::pow(1024.0, 3.0)) {
+			// Less than 10 GiB available.
+			WARN_PRINT(vformat("Current available space on disk is low (%s). MovieWriter will fail during movie recording if the disk runs out of available space.", String::humanize_size(space_left)));
+		}
 	}
 
 	cpu_time = 0.0f;


### PR DESCRIPTION
Fixes #113391

## Summary
<img width="1948" height="518" alt="WindowsTerminal_Db0ef1vZhK" src="https://github.com/user-attachments/assets/8b95090c-b407-443a-aed8-958c779d3b6d" />

MovieWriter now opens the output directory directly when checking free space, so the warning reflects the target filesystem instead of the current working directory.

In the attached screen it can be seen that while `CWR` is set to `V`, which has less than 6GB available, no warning is output as the movie is written to `C` with over 1TB available.

## Why the previous code didn’t work
The old code created a `DirAccess` instance and then called the static `DirAccess::open()` (via `dir->open(path)`), which returns a new object but doesn’t modify the existing one. As a result, `get_space_left()` still ran on the default current directory.
