### PR TITLE
Improve spacing in trees showing table data in modern theme

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -582,6 +582,9 @@
 		<theme_item name="button_margin" data_type="constant" type="int" default="4">
 			The horizontal space between each button in a cell.
 		</theme_item>
+		<theme_item name="check_h_separation" data_type="constant" type="int" default="4">
+			The horizontal space between the checkbox and the text in a [constant TreeItem.CELL_MODE_CHECK] mode cell.
+		</theme_item>
 		<theme_item name="children_hl_line_width" data_type="constant" type="int" default="1">
 			The width of the relationship lines between the selected [TreeItem] and its children.
 		</theme_item>
@@ -596,6 +599,9 @@
 		</theme_item>
 		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal space between item cells. This is also used as the margin at the start of an item when folding is disabled.
+		</theme_item>
+		<theme_item name="icon_h_separation" data_type="constant" type="int" default="4">
+			The horizontal space between the icon and the text in item's cells.
 		</theme_item>
 		<theme_item name="icon_max_width" data_type="constant" type="int" default="0">
 			The maximum allowed width of the icon in item's cells. This limit is applied on top of the default size of the icon, but before the value set with [method TreeItem.set_icon_max_width]. The height is adjusted according to the icon's ratio.

--- a/editor/animation/animation_library_editor.cpp
+++ b/editor/animation/animation_library_editor.cpp
@@ -1054,6 +1054,7 @@ AnimationLibraryEditor::AnimationLibraryEditor() {
 	vb->add_child(tree);
 
 	tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	tree->set_theme_type_variation("TreeTable");
 	tree->set_columns(2);
 	tree->set_column_titles_visible(true);
 	tree->set_column_title(0, TTR("Resource"));

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -268,6 +268,8 @@ DependencyEditor::DependencyEditor() {
 
 	tree = memnew(Tree);
 	tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	tree->set_theme_type_variation("TreeTable");
+	tree->set_hide_folding(true);
 	tree->set_columns(2);
 	tree->set_column_titles_visible(true);
 	tree->set_column_title(0, TTR("Resource"));
@@ -1079,6 +1081,7 @@ OrphanResourcesDialog::OrphanResourcesDialog() {
 
 	files = memnew(Tree);
 	files->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	files->set_theme_type_variation("TreeTable");
 	files->set_columns(2);
 	files->set_column_titles_visible(true);
 	files->set_column_custom_minimum_width(1, 100 * EDSCALE);

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -1246,6 +1246,7 @@ DynamicFontImportSettingsDialog::DynamicFontImportSettingsDialog() {
 	glyph_table = memnew(Tree);
 	glyph_table->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	glyph_table->set_custom_minimum_size(Size2((30 * 16 + 100) * EDSCALE, 0));
+	glyph_table->set_theme_type_variation("TreeTable");
 	glyph_table->set_columns(17);
 	glyph_table->set_column_expand(0, false);
 	glyph_table->set_hide_root(true);

--- a/editor/plugins/editor_plugin_settings.cpp
+++ b/editor/plugins/editor_plugin_settings.cpp
@@ -248,6 +248,8 @@ EditorPluginSettings::EditorPluginSettings() {
 
 	plugin_list = memnew(Tree);
 	plugin_list->set_v_size_flags(SIZE_EXPAND_FILL);
+	plugin_list->set_theme_type_variation("TreeTable");
+	plugin_list->set_hide_folding(true);
 	plugin_list->set_columns(COLUMN_MAX);
 	plugin_list->set_column_titles_visible(true);
 	plugin_list->set_column_title(COLUMN_STATUS, TTRC("Enabled"));

--- a/editor/run/run_instances_dialog.cpp
+++ b/editor/run/run_instances_dialog.cpp
@@ -378,6 +378,8 @@ RunInstancesDialog::RunInstancesDialog() {
 
 	instance_tree = memnew(Tree);
 	instance_tree->set_h_scroll_enabled(false);
+	instance_tree->set_theme_type_variation("TreeTable");
+	instance_tree->set_hide_folding(true);
 	instance_tree->set_columns(4);
 	instance_tree->set_column_titles_visible(true);
 	instance_tree->set_column_title(COLUMN_OVERRIDE_ARGS, TTR("Override Main Run Args"));

--- a/editor/scene/group_settings_editor.cpp
+++ b/editor/scene/group_settings_editor.cpp
@@ -534,6 +534,8 @@ GroupSettingsEditor::GroupSettingsEditor() {
 	tree->set_select_mode(Tree::SELECT_SINGLE);
 	tree->set_allow_reselect(true);
 
+	tree->set_theme_type_variation("TreeTable");
+	tree->set_hide_folding(true);
 	tree->set_columns(3);
 	tree->set_column_titles_visible(true);
 

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -112,6 +112,8 @@ ConnectionInfoDialog::ConnectionInfoDialog() {
 
 	tree = memnew(Tree);
 	tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	tree->set_theme_type_variation("TreeTable");
+	tree->set_hide_folding(true);
 	tree->set_columns(3);
 	tree->set_hide_root(true);
 	tree->set_column_titles_visible(true);

--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -609,6 +609,7 @@ ActionMapEditor::ActionMapEditor() {
 	// Action Editor Tree
 	action_tree = memnew(Tree);
 	action_tree->set_accessibility_name(TTRC("Action Map"));
+	action_tree->set_theme_type_variation("TreeTable");
 	action_tree->set_columns(3);
 	action_tree->set_hide_root(true);
 	action_tree->set_column_titles_visible(true);

--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -958,6 +958,8 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 	SET_DRAG_FORWARDING_GCD(tree, EditorAutoloadSettings);
 
+	tree->set_theme_type_variation("TreeTable");
+	tree->set_hide_folding(true);
 	tree->set_columns(4);
 	tree->set_column_titles_visible(true);
 

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -1015,6 +1015,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 
 	shortcuts = memnew(Tree);
 	shortcuts->set_accessibility_name(TTRC("Shortcuts"));
+	shortcuts->set_theme_type_variation("TreeTable");
 	shortcuts->set_columns(2);
 	shortcuts->set_hide_root(true);
 	shortcuts->set_column_titles_visible(true);

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -620,6 +620,8 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			p_theme->set_constant("inner_item_margin_bottom", "Tree", p_config.base_margin * 0.75 * EDSCALE);
 			p_theme->set_constant("inner_item_margin_left", "Tree", p_config.increased_margin * EDSCALE);
 			p_theme->set_constant("inner_item_margin_right", "Tree", p_config.increased_margin * EDSCALE);
+			p_theme->set_constant("check_h_separation", "Tree", (p_config.increased_margin + 2) * EDSCALE);
+			p_theme->set_constant("icon_h_separation", "Tree", (p_config.increased_margin + 2) * EDSCALE);
 			p_theme->set_constant("button_margin", "Tree", p_config.base_margin * EDSCALE);
 			p_theme->set_constant("dragging_unfold_wait_msec", "Tree", p_config.dragging_hover_wait_msec);
 			p_theme->set_constant("scroll_border", "Tree", 40 * EDSCALE);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -634,6 +634,8 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_constant("inner_item_margin_bottom", "Tree", p_config.base_margin * 0.75 * EDSCALE);
 			p_theme->set_constant("inner_item_margin_left", "Tree", p_config.base_margin * EDSCALE);
 			p_theme->set_constant("inner_item_margin_right", "Tree", p_config.base_margin * EDSCALE);
+			p_theme->set_constant("check_h_separation", "Tree", p_config.base_margin * 1.5 * EDSCALE);
+			p_theme->set_constant("icon_h_separation", "Tree", p_config.base_margin * 1.5 * EDSCALE);
 			p_theme->set_constant("button_margin", "Tree", p_config.base_margin * EDSCALE);
 			p_theme->set_constant("dragging_unfold_wait_msec", "Tree", p_config.dragging_hover_wait_msec);
 			p_theme->set_constant("scroll_border", "Tree", 40 * EDSCALE);
@@ -2141,6 +2143,81 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_stylebox(SceneStringName(panel), "PanelForeground", p_config.foreground_panel);
 			p_theme->set_stylebox(SceneStringName(panel), "EditorInspectorForeground", p_config.foreground_panel);
 		}
+
+		// TreeTable.
+		{
+			p_theme->set_type_variation("TreeTable", "Tree");
+
+			p_theme->set_constant("h_separation", "TreeTable", 0);
+			p_theme->set_constant("inner_item_margin_top", "TreeTable", p_config.base_margin * EDSCALE);
+			p_theme->set_constant("inner_item_margin_bottom", "TreeTable", p_config.base_margin * EDSCALE);
+			p_theme->set_constant("inner_item_margin_left", "TreeTable", p_config.base_margin * 3 * EDSCALE);
+			p_theme->set_constant("inner_item_margin_right", "TreeTable", p_config.base_margin * 3 * EDSCALE);
+			p_theme->set_constant("item_margin", "TreeTable", 16 * EDSCALE);
+			p_theme->set_constant("button_margin", "TreeTable", 0);
+
+			Ref<StyleBoxEmpty> style_tree_panel = p_config.base_empty_style->duplicate();
+			style_tree_panel->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 0.75 * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 0.75 * EDSCALE);
+			p_theme->set_stylebox(SceneStringName(panel), "TreeTable", style_tree_panel);
+
+			const Ref<StyleBoxFlat> style_tree_title = p_theme->get_stylebox("title_button_normal", "Tree")->duplicate();
+			style_tree_title->set_content_margin_individual(p_config.base_margin * 3 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 3 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE);
+			p_theme->set_stylebox("title_button_normal", "TreeTable", style_tree_title);
+			p_theme->set_stylebox("title_button_hover", "TreeTable", style_tree_title);
+			p_theme->set_stylebox("title_button_pressed", "TreeTable", style_tree_title);
+
+			const Ref<StyleBoxFlat> style_tree_selected = p_theme->get_stylebox("selected", "Tree")->duplicate();
+			style_tree_selected->set_border_color(Color(style_tree_selected->get_bg_color(), 0));
+			style_tree_selected->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
+			style_tree_selected->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			p_theme->set_stylebox("selected", "TreeTable", style_tree_selected);
+
+			const Ref<StyleBoxFlat> style_tree_hover = p_theme->get_stylebox("hovered", "Tree")->duplicate();
+			style_tree_hover->set_border_color(Color(style_tree_hover->get_bg_color(), 0));
+			style_tree_hover->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
+			style_tree_hover->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			p_theme->set_stylebox("hovered", "TreeTable", style_tree_hover);
+
+			const Ref<StyleBoxFlat> style_tree_hovered_selected = p_theme->get_stylebox("hovered_selected", "Tree")->duplicate();
+			style_tree_hovered_selected->set_border_color(Color(style_tree_hovered_selected->get_bg_color(), 0));
+			style_tree_hovered_selected->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
+			style_tree_hovered_selected->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			p_theme->set_stylebox("hovered_selected", "TreeTable", style_tree_hovered_selected);
+
+			const Ref<StyleBoxFlat> style_tree_dimmed = p_theme->get_stylebox("hovered_dimmed", "Tree")->duplicate();
+			style_tree_dimmed->set_border_color(Color(style_tree_dimmed->get_bg_color(), 0));
+			style_tree_dimmed->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
+			style_tree_dimmed->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			p_theme->set_stylebox("hovered_dimmed", "TreeTable", p_theme->get_stylebox("hovered_dimmed", "Tree"));
+
+			const Ref<StyleBoxFlat> style_button_pressed = p_theme->get_stylebox("button_pressed", "Tree")->duplicate();
+			style_button_pressed->set_content_margin_individual(p_config.base_margin * EDSCALE, 0, p_config.base_margin * EDSCALE, 0);
+			style_button_pressed->set_border_color(Color(style_button_pressed->get_bg_color(), 0));
+			style_button_pressed->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
+			style_button_pressed->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			p_theme->set_stylebox("button_pressed", "TreeTable", style_button_pressed);
+			p_theme->set_stylebox("custom_button_pressed", "TreeTable", style_button_pressed);
+
+			const Ref<StyleBoxFlat> style_button_hover = p_theme->get_stylebox("button_hover", "Tree")->duplicate();
+			style_button_hover->set_content_margin_individual(p_config.base_margin * EDSCALE, 0, p_config.base_margin * EDSCALE, 0);
+			style_button_hover->set_border_color(Color(style_button_hover->get_bg_color(), 0));
+			style_button_hover->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
+			style_button_hover->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			p_theme->set_stylebox("button_hover", "TreeTable", style_button_hover);
+			p_theme->set_stylebox("custom_button_hover", "TreeTable", style_button_hover);
+
+			const Ref<StyleBoxFlat> style_cursor = p_theme->get_stylebox("cursor", "Tree")->duplicate();
+			style_cursor->set_border_color(Color(style_cursor->get_bg_color(), 0));
+			style_cursor->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
+			style_cursor->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			p_theme->set_stylebox("cursor", "TreeTable", style_cursor);
+
+			const Ref<StyleBoxFlat> style_cursor_unfocused = p_theme->get_stylebox("cursor_unfocused", "Tree")->duplicate();
+			style_cursor_unfocused->set_border_color(Color(style_cursor_unfocused->get_bg_color(), 0));
+			style_cursor_unfocused->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
+			style_cursor_unfocused->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			p_theme->set_stylebox("cursor_unfocused", "TreeTable", style_cursor_unfocused);
+		}
 	}
 
 	// Editor inspector.
@@ -2210,17 +2287,20 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		Ref<StyleBoxFlat> prop_subsection_stylebox = p_config.base_style->duplicate();
 		prop_subsection_stylebox->set_bg_color(p_theme->get_color("prop_subsection_stylebox_color", EditorStringName(Editor)));
+		prop_subsection_stylebox->set_border_color(Color(prop_subsection_stylebox_color, 0));
 		prop_subsection_stylebox->set_corner_radius_all(p_config.corner_radius * EDSCALE);
 		p_theme->set_stylebox("prop_subsection_stylebox", EditorStringName(Editor), prop_subsection_stylebox);
 
 		Ref<StyleBoxFlat> prop_subsection_stylebox_left = prop_subsection_stylebox->duplicate();
 		prop_subsection_stylebox_left->set_corner_radius(CORNER_TOP_RIGHT, 0);
 		prop_subsection_stylebox_left->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
+		prop_subsection_stylebox_left->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
 		p_theme->set_stylebox("prop_subsection_stylebox_left", EditorStringName(Editor), prop_subsection_stylebox_left);
 
 		Ref<StyleBoxFlat> prop_subsection_stylebox_right = prop_subsection_stylebox->duplicate();
 		prop_subsection_stylebox_right->set_corner_radius(CORNER_TOP_LEFT, 0);
 		prop_subsection_stylebox_right->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		prop_subsection_stylebox_right->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
 		p_theme->set_stylebox("prop_subsection_stylebox_right", EditorStringName(Editor), prop_subsection_stylebox_right);
 
 		p_theme->set_color("prop_subsection", EditorStringName(Editor), Color(1, 1, 1, 0));

--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -825,6 +825,8 @@ LocalizationEditor::LocalizationEditor() {
 
 		translation_remap_options = memnew(Tree);
 		translation_remap_options->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		translation_remap_options->set_theme_type_variation("TreeTable");
+		translation_remap_options->set_hide_folding(true);
 		translation_remap_options->set_columns(2);
 		translation_remap_options->set_column_title(0, TTRC("Path"));
 		translation_remap_options->set_column_title(1, TTRC("Locale"));

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1730,7 +1730,7 @@ Size2 TreeItem::get_minimum_size(int p_column) {
 		}
 		if (cell.icon.is_valid()) {
 			Size2i icon_size = parent_tree->_get_cell_icon_size(cell);
-			size.width += icon_size.width + parent_tree->theme_cache.h_separation;
+			size.width += icon_size.width + parent_tree->theme_cache.icon_h_separation;
 			content_height = MAX(content_height, icon_size.height);
 		}
 
@@ -2088,7 +2088,7 @@ void Tree::draw_item_rect(const TreeItem::Cell &p_cell, const Rect2i &p_rect, co
 
 	int displayed_width = 0;
 	if (p_cell.icon.is_valid()) {
-		displayed_width += icon_size.width + theme_cache.h_separation;
+		displayed_width += icon_size.width + theme_cache.icon_h_separation;
 	}
 	if (displayed_width + ts.width > rect.size.width) {
 		ts.width = rect.size.width - displayed_width;
@@ -2125,12 +2125,12 @@ void Tree::draw_item_rect(const TreeItem::Cell &p_cell, const Rect2i &p_rect, co
 			}
 			p_cell.text_buf->draw(ci, draw_pos, p_color);
 		}
-		rect.position.x += ts.width + theme_cache.h_separation;
+		rect.position.x += ts.width + theme_cache.icon_h_separation;
 	}
 
 	if (p_cell.icon.is_valid()) {
 		p_cell.draw_icon(ci, rect.position + Size2i(0, Math::floor((real_t)(rect.size.y - icon_size.y) / 2)), icon_size, p_icon_color);
-		rect.position.x += icon_size.x + theme_cache.h_separation;
+		rect.position.x += icon_size.x + theme_cache.icon_h_separation;
 	}
 
 	if (!rtl && ts.width > 0) {
@@ -2353,7 +2353,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 			int text_width = item_width - theme_cache.inner_item_margin_left - theme_cache.inner_item_margin_right;
 			if (p_item->cells[i].icon.is_valid()) {
-				text_width -= _get_cell_icon_size(p_item->cells[i]).x + theme_cache.h_separation;
+				text_width -= _get_cell_icon_size(p_item->cells[i]).x + theme_cache.icon_h_separation;
 			}
 
 			p_item->cells.write[i].text_buf->set_width(text_width);
@@ -2548,7 +2548,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 						}
 					}
 
-					int check_w = theme_cache.checked->get_width() + theme_cache.h_separation;
+					int check_w = theme_cache.checked->get_width() + theme_cache.check_h_separation;
 
 					text_pos.x += check_w;
 
@@ -4438,7 +4438,7 @@ bool Tree::edit_selected(bool p_force_edit) {
 		// Account for icon.
 		real_t icon_ofs = 0;
 		if (c.icon.is_valid()) {
-			icon_ofs = _get_cell_icon_size(c).x * popup_scale + theme_cache.h_separation;
+			icon_ofs = _get_cell_icon_size(c).x * popup_scale + theme_cache.icon_h_separation;
 		}
 
 		popup_rect.size = rect.size + Vector2(-icon_ofs, value_editor_height);
@@ -6883,6 +6883,8 @@ void Tree::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Tree, inner_item_margin_right);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Tree, inner_item_margin_top);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Tree, item_margin);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Tree, check_h_separation);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Tree, icon_h_separation);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Tree, button_margin);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, Tree, icon_max_width);
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -658,6 +658,8 @@ private:
 		int inner_item_margin_right = 0;
 		int inner_item_margin_top = 0;
 		int item_margin = 0;
+		int check_h_separation = 0;
+		int icon_h_separation = 0;
 		int button_margin = 0;
 		int icon_max_width = 0;
 		Point2 offset;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -918,6 +918,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("inner_item_margin_left", "Tree", 0);
 	theme->set_constant("inner_item_margin_right", "Tree", 0);
 	theme->set_constant("inner_item_margin_top", "Tree", 0);
+	theme->set_constant("check_h_separation", "Tree", Math::round(4 * scale));
+	theme->set_constant("icon_h_separation", "Tree", Math::round(4 * scale));
 	theme->set_constant("button_margin", "Tree", Math::round(4 * scale));
 	theme->set_constant("draw_relationship_lines", "Tree", 0);
 	theme->set_constant("relationship_line_width", "Tree", 1);


### PR DESCRIPTION
Improves spacing in settings trees:

1. Aligns cell text to title text
2. Removes the unnecessary gap on top of the tree
3. Slightly increases cell height
4. Hides unnecessary folding gaps from flat trees that don't have any nesting
5. Adds missing horizontal gaps between cells on hover, pressed, hover-pressed, etc
6. Adds theme constants for separation between text and checkbox/icon

| Master | PR |
|--------|--------|
| ![1](https://github.com/user-attachments/assets/0577c6d5-d1e2-45eb-a6a1-4565a16d1e32) | ![2](https://github.com/user-attachments/assets/f8cdd67c-3213-44f8-9dba-0508bef13224) |
| ![3](https://github.com/user-attachments/assets/c7edccb6-5ac0-4b2e-b2cf-34d689c29672) | ![4](https://github.com/user-attachments/assets/439dc812-dcd6-46f9-9d09-6e3bb5982558) |

It adds a new `TreeTable` variation for tables with moderate amount of data that are mostly drawn outside of the main editor window where they can have more space than regular trees, i.e Autoloads, Plugins, Groups.

Together with changes in https://github.com/godotengine/godot/pull/114392 this closes https://github.com/godotengine/godot/issues/113910. The issue of hover highlight being drawn over empty cells happens in both themes and should be addressed separately.