### PR TITLE
Add StickyContainer

### DIFF
--- a/doc/classes/StickyContainer.xml
+++ b/doc/classes/StickyContainer.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="StickyContainer" inherits="Container" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A container that clamps children to the bounds of the nearest [ScrollContainer].
+	</brief_description>
+	<description>
+		A container that clamps children to the bounds of the nearest [ScrollContainer]. Children can additionally be clamped to a parent [Control]'s bounds. If there are multiple [StickyContainer]s on the same [ScrollContainer], clamped children can optionally be stacked instead of overlapping.
+		[b]Note:[/b] Children are reparented to the related [ScrollContainer].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_sticky_child">
+			<return type="Control" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns a sticky [Control] managed by this container.
+			</description>
+		</method>
+		<method name="get_sticky_child_count">
+			<return type="int" />
+			<description>
+				Returns the number of [Control]s managed by this container.
+			</description>
+		</method>
+		<method name="get_sticky_status">
+			<return type="int" enum="StickyContainer.StickyStatus" />
+			<description>
+				Returns the current sticky status depending on the scroll position of the [ScrollContainer].
+			</description>
+		</method>
+		<method name="is_side_sticky">
+			<return type="bool" />
+			<param index="0" name="side" type="int" enum="Side" />
+			<description>
+				Returns [code]true[/code] if sticking to the given [param side] is enabled.
+			</description>
+		</method>
+		<method name="set_side_sticky">
+			<return type="void" />
+			<param index="0" name="side" type="int" enum="Side" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				If [param enabled], allows children to stick to the given [param side] of the closest [ScrollContainer].
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="bounding_container" type="NodePath" setter="set_bounding_container_path" getter="get_bounding_container_path" default="NodePath(&quot;&quot;)">
+			Children will be clamped to the rect of the [Control] at this [NodePath].
+		</member>
+		<member name="stack" type="bool" setter="set_stacking" getter="is_stacking" default="false">
+			If [code]true[/code], when multiple [Control]s are sticking to the same [ScrollContainer], they will stack next to each other instead of overlapping each other.
+		</member>
+		<member name="stick_to_bottom" type="bool" setter="set_side_sticky" getter="is_side_sticky" default="false">
+			If [code]true[/code], enables sticking to the bottom side of the closest [ScrollContainer].
+		</member>
+		<member name="stick_to_left" type="bool" setter="set_side_sticky" getter="is_side_sticky" default="true">
+			If [code]true[/code], enables sticking to the left side of the closest [ScrollContainer].
+		</member>
+		<member name="stick_to_right" type="bool" setter="set_side_sticky" getter="is_side_sticky" default="false">
+			If [code]true[/code], enables sticking to the right side of the closest [ScrollContainer].
+		</member>
+		<member name="stick_to_top" type="bool" setter="set_side_sticky" getter="is_side_sticky" default="true">
+			If [code]true[/code], enables sticking to the top side of the closest [ScrollContainer].
+		</member>
+	</members>
+	<signals>
+		<signal name="sticky_status_changed">
+			<description>
+				Emitted when the [enum StickyStatus] changes.
+			</description>
+		</signal>
+	</signals>
+	<constants>
+		<constant name="STATUS_NORMAL" value="0" enum="StickyStatus">
+			The [Control] is currently in view but not sticking to a [ScrollContainer].
+		</constant>
+		<constant name="STATUS_STICKING" value="1" enum="StickyStatus">
+			The [Control] is sticking to a side of the nearest [ScrollContainer].
+		</constant>
+		<constant name="STATUS_HIDDEN" value="2" enum="StickyStatus">
+			The [Control] is currently not in view within the nearest [ScrollContainer].
+		</constant>
+	</constants>
+</class>

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "scene/gui/panel_container.h"
+#include "scene/gui/sticky_container.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/main/window.h"
 #include "scene/theme/theme_db.h"
@@ -364,7 +365,7 @@ void ScrollContainer::_reposition_children() {
 
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *c = as_sortable_control(get_child(i));
-		if (!c || c == h_scroll || c == v_scroll || c == focus_panel || c == scroll_hint_top_left || c == scroll_hint_bottom_right) {
+		if (!c || c == h_scroll || c == v_scroll || c == focus_panel || c == scroll_hint_top_left || c == scroll_hint_bottom_right || c == stuck_controls_container) {
 			continue;
 		}
 
@@ -381,6 +382,85 @@ void ScrollContainer::_reposition_children() {
 		r.position += ofs;
 		r.position = r.position.floor();
 		fit_child_in_rect(c, r);
+	}
+
+	int side_ofs[4] = { 0, 0, 0, 0 };
+	for (int i = stuck_controls_container->get_child_count() - 1; i >= 0; i--) {
+		Control *c = Object::cast_to<Control>(stuck_controls_container->get_child(i));
+		if (!c || !c->is_visible()) {
+			continue;
+		}
+		if (!sticky_map.has(c->get_instance_id())) {
+			continue;
+		}
+		StickyContainer *sc = sticky_map[c->get_instance_id()];
+		if (!sc) {
+			continue;
+		}
+
+		Rect2 rect = sc->get_global_rect();
+		Rect2 old_rect = rect;
+		Rect2 scroll_rect = get_global_rect();
+		Rect2 bound_rect;
+		Point2 pos = rect.position;
+		bool stacking = sc->is_stacking();
+		bool bounding = sc->get_bounding_container();
+
+		if (bounding) {
+			bound_rect = sc->get_bounding_container()->get_global_rect();
+		}
+
+		if (sc->is_side_sticky(SIDE_LEFT)) {
+			real_t stick_pos = scroll_rect.position.x + (stacking ? side_ofs[SIDE_LEFT] : 0);
+			pos.x = MAX(rect.position.x, stick_pos);
+			if (bounding) {
+				pos.x = MIN(bound_rect.get_end().x, pos.x + rect.size.x) - rect.size.x;
+			}
+			if (stacking) {
+				side_ofs[SIDE_LEFT] += MAX(rect.size.x - Math::abs(pos.x - stick_pos), 0);
+			}
+		}
+		if (sc->is_side_sticky(SIDE_TOP)) {
+			real_t stick_pos = scroll_rect.position.y + (stacking ? side_ofs[SIDE_TOP] : 0);
+			pos.y = MAX(rect.position.y, stick_pos);
+			if (bounding) {
+				pos.y = MIN(bound_rect.get_end().y, pos.y + rect.size.y) - rect.size.y;
+			}
+			if (stacking) {
+				side_ofs[SIDE_TOP] += MAX(rect.size.y - Math::abs(pos.y - stick_pos), 0);
+			}
+		}
+		if (sc->is_side_sticky(SIDE_RIGHT)) {
+			real_t stick_pos = scroll_rect.get_end().x - rect.size.x - (stacking ? side_ofs[SIDE_RIGHT] : 0);
+			pos.x = MIN(rect.position.x, stick_pos);
+			if (bounding) {
+				pos.x = MAX(bound_rect.position.x, pos.x);
+			}
+			if (stacking) {
+				side_ofs[SIDE_RIGHT] += MAX(rect.size.x - Math::abs(pos.x - stick_pos), 0);
+			}
+		}
+		if (sc->is_side_sticky(SIDE_BOTTOM)) {
+			real_t stick_pos = scroll_rect.get_end().y - rect.size.y - (stacking ? side_ofs[SIDE_BOTTOM] : 0);
+			pos.y = MIN(rect.position.y, stick_pos);
+			if (bounding) {
+				pos.y = MAX(bound_rect.position.y, pos.y);
+			}
+			if (stacking) {
+				side_ofs[SIDE_BOTTOM] += MAX(rect.size.y - Math::abs(pos.y - stick_pos), 0);
+			}
+		}
+		rect.position = pos;
+		if (!rect.intersects(scroll_rect, true)) {
+			sc->set_sticky_status(StickyContainer::STATUS_HIDDEN);
+		} else if (!pos.is_equal_approx(old_rect.position)) {
+			sc->set_sticky_status(StickyContainer::STATUS_STICKING);
+		} else {
+			sc->set_sticky_status(StickyContainer::STATUS_NORMAL);
+		}
+
+		rect.position -= stuck_controls_container->get_global_position();
+		stuck_controls_container->fit_child_in_rect(c, rect);
 	}
 
 	if (draw_focus_border) {
@@ -787,6 +867,24 @@ void ScrollContainer::set_scroll_on_drag_hover(bool p_scroll) {
 	scroll_on_drag_hover = p_scroll;
 }
 
+void ScrollContainer::_register_sticky_control(ObjectID p_id, StickyContainer *p_sticky) {
+	Control *p_control = Object::cast_to<Control>(ObjectDB::get_instance(p_id));
+	if (!p_sticky || !p_control) {
+		return;
+	}
+	p_control->call_deferred("reparent", stuck_controls_container);
+	if (p_sticky->is_side_sticky(SIDE_LEFT) || p_sticky->is_side_sticky(SIDE_TOP)) {
+		stuck_controls_container->call_deferred("move_child", p_control, 0);
+	}
+	sticky_map[p_id] = p_sticky;
+}
+
+void ScrollContainer::_unregister_sticky_control(Control *p_control) {
+	if (p_control) {
+		sticky_map.erase(p_control->get_instance_id());
+	}
+}
+
 HScrollBar *ScrollContainer::get_h_scroll_bar() {
 	return h_scroll;
 }
@@ -895,6 +993,13 @@ bool ScrollContainer::child_has_focus() {
 }
 
 ScrollContainer::ScrollContainer() {
+	stuck_controls_container = memnew(Container);
+	stuck_controls_container->set_mouse_filter(MOUSE_FILTER_IGNORE);
+	stuck_controls_container->set_focus_mode(FOCUS_NONE);
+	stuck_controls_container->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+	add_child(stuck_controls_container, false, INTERNAL_MODE_BACK);
+	stuck_controls_container->connect("child_exiting_tree", callable_mp(this, &ScrollContainer::_unregister_sticky_control));
+
 	scroll_hint_top_left = memnew(TextureRect);
 	scroll_hint_top_left->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
 	scroll_hint_top_left->set_mouse_filter(MOUSE_FILTER_IGNORE);

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -36,9 +36,11 @@
 
 class PanelContainer;
 class TextureRect;
+class StickyContainer;
 
 class ScrollContainer : public Container {
 	GDCLASS(ScrollContainer, Container);
+	friend class StickyContainer;
 
 public:
 	enum ScrollMode {
@@ -60,6 +62,7 @@ private:
 	HScrollBar *h_scroll = nullptr;
 	VScrollBar *v_scroll = nullptr;
 	PanelContainer *focus_panel = nullptr;
+	Container *stuck_controls_container = nullptr;
 
 	mutable Size2 largest_child_min_size; // The largest one among the min sizes of all available child controls.
 
@@ -90,6 +93,11 @@ private:
 
 	ScrollHintMode scroll_hint_mode = SCROLL_HINT_MODE_DISABLED;
 	bool tile_scroll_hint = false;
+
+	HashMap<ObjectID, StickyContainer *> sticky_map;
+
+	void _register_sticky_control(ObjectID p_id, StickyContainer *p_sticky);
+	void _unregister_sticky_control(Control *p_control);
 
 	struct ThemeCache {
 		Ref<StyleBox> panel_style;

--- a/scene/gui/sticky_container.cpp
+++ b/scene/gui/sticky_container.cpp
@@ -1,0 +1,194 @@
+/**************************************************************************/
+/*  sticky_container.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "sticky_container.h"
+
+#include "scene/gui/scroll_container.h"
+
+void StickyContainer::_reparent_children() {
+	if (is_part_of_edited_scene()) {
+		return;
+	}
+
+	if (!is_inside_tree()) {
+		return;
+	}
+
+	if (!scroll_container) {
+		return;
+	}
+
+	for (int c = 0; c < get_child_count(); c++) {
+		Control *child = Object::cast_to<Control>(get_child(c));
+		if (child) {
+			managed_children.push_back(child->get_instance_id());
+			scroll_container->_register_sticky_control(child->get_instance_id(), this);
+		}
+	}
+}
+
+Size2 StickyContainer::get_minimum_size() const {
+	Size2 mins;
+	if (is_part_of_edited_scene()) {
+		for (int i = 0; i < get_child_count(); i++) {
+			Control *child = as_sortable_control(get_child(i));
+			if (child) {
+				mins = mins.max(child->get_combined_minimum_size());
+			}
+		}
+		return mins;
+	}
+
+	for (int i = 0; i < managed_children.size(); i++) {
+		Control *child = Object::cast_to<Control>(ObjectDB::get_instance(managed_children[i]));
+		if (child) {
+			mins = mins.max(child->get_combined_minimum_size());
+		}
+	}
+	return mins;
+}
+
+void StickyContainer::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			Control *node = this;
+			while (node->get_parent_control()) {
+				node = node->get_parent_control();
+				if (Object::cast_to<ScrollContainer>(node)) {
+					scroll_container = Object::cast_to<ScrollContainer>(node);
+					_reparent_children();
+					break;
+				}
+			}
+			set_bounding_container_path(bounding_path);
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			if (scroll_container) {
+				for (ObjectID oid : managed_children) {
+					Control *child = Object::cast_to<Control>(ObjectDB::get_instance(oid));
+					if (child && child->get_parent() != this) {
+						child->reparent(this);
+					}
+				}
+			}
+		} break;
+
+		case NOTIFICATION_CHILD_ORDER_CHANGED: {
+			_reparent_children();
+		} break;
+	}
+}
+
+void StickyContainer::set_side_sticky(Side p_side, bool p_sticky) {
+	if (p_sticky) {
+		sticky_sides.set_flag(1 << p_side);
+	} else {
+		sticky_sides.clear_flag(1 << p_side);
+	}
+}
+
+bool StickyContainer::is_side_sticky(Side p_side) {
+	return sticky_sides.has_flag(1 << p_side);
+}
+
+void StickyContainer::set_stacking(bool p_enabled) {
+	stacking = p_enabled;
+}
+
+bool StickyContainer::is_stacking() {
+	return stacking;
+}
+
+void StickyContainer::set_sticky_status(StickyStatus p_status) {
+	if (sticky_status != p_status) {
+		sticky_status = p_status;
+		emit_signal("sticky_status_changed");
+	}
+}
+
+StickyContainer::StickyStatus StickyContainer::get_sticky_status() {
+	return sticky_status;
+}
+
+void StickyContainer::set_bounding_container_path(const NodePath &p_path) {
+	bounding_path = p_path;
+	if (is_inside_tree() && !p_path.is_empty()) {
+		bounding_container = Object::cast_to<Control>(get_node_or_null(p_path));
+		if (scroll_container) {
+			scroll_container->call("queue_sort");
+		}
+	}
+}
+
+NodePath StickyContainer::get_bounding_container_path() {
+	return bounding_path;
+}
+
+Control *StickyContainer::get_bounding_container() {
+	return bounding_container;
+}
+
+int StickyContainer::get_sticky_child_count() {
+	return managed_children.size();
+}
+
+Control *StickyContainer::get_sticky_child(int p_i) {
+	ERR_FAIL_INDEX_V(p_i, managed_children.size(), nullptr);
+	Control *child = Object::cast_to<Control>(ObjectDB::get_instance(managed_children[p_i]));
+	return child;
+}
+
+void StickyContainer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_side_sticky", "side", "enabled"), &StickyContainer::set_side_sticky);
+	ClassDB::bind_method(D_METHOD("is_side_sticky", "side"), &StickyContainer::is_side_sticky);
+	ClassDB::bind_method(D_METHOD("set_stacking", "enabled"), &StickyContainer::set_stacking);
+	ClassDB::bind_method(D_METHOD("is_stacking"), &StickyContainer::is_stacking);
+	ClassDB::bind_method(D_METHOD("set_bounding_container_path", "container_path"), &StickyContainer::set_bounding_container_path);
+	ClassDB::bind_method(D_METHOD("get_bounding_container_path"), &StickyContainer::get_bounding_container_path);
+	ClassDB::bind_method(D_METHOD("get_sticky_status"), &StickyContainer::get_sticky_status);
+	ClassDB::bind_method(D_METHOD("get_sticky_child_count"), &StickyContainer::get_sticky_child_count);
+	ClassDB::bind_method(D_METHOD("get_sticky_child", "index"), &StickyContainer::get_sticky_child);
+
+	ADD_SIGNAL(MethodInfo("sticky_status_changed"));
+
+	BIND_ENUM_CONSTANT(STATUS_NORMAL);
+	BIND_ENUM_CONSTANT(STATUS_STICKING);
+	BIND_ENUM_CONSTANT(STATUS_HIDDEN);
+
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "stick_to_left"), "set_side_sticky", "is_side_sticky", SIDE_LEFT);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "stick_to_top"), "set_side_sticky", "is_side_sticky", SIDE_TOP);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "stick_to_right"), "set_side_sticky", "is_side_sticky", SIDE_RIGHT);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "stick_to_bottom"), "set_side_sticky", "is_side_sticky", SIDE_BOTTOM);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stack"), "set_stacking", "is_stacking");
+	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "bounding_container"), "set_bounding_container_path", "get_bounding_container_path");
+}
+
+StickyContainer::StickyContainer() {}

--- a/scene/gui/sticky_container.h
+++ b/scene/gui/sticky_container.h
@@ -1,0 +1,85 @@
+/**************************************************************************/
+/*  sticky_container.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/gui/container.h"
+
+class ScrollContainer;
+
+class StickyContainer : public Container {
+	GDCLASS(StickyContainer, Container);
+
+public:
+	enum StickyStatus {
+		STATUS_NORMAL,
+		STATUS_STICKING,
+		STATUS_HIDDEN,
+	};
+
+private:
+	ScrollContainer *scroll_container = nullptr;
+	Control *bounding_container = nullptr;
+	NodePath bounding_path;
+	Vector<ObjectID> managed_children;
+	StickyStatus sticky_status = STATUS_NORMAL;
+
+	BitField<Side> sticky_sides = (1 << SIDE_LEFT) + (1 << SIDE_TOP);
+	bool stacking = false;
+
+	void _reparent_children();
+
+protected:
+	Size2 get_minimum_size() const override;
+
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	void set_side_sticky(Side p_side, bool p_sticky);
+	bool is_side_sticky(Side p_side);
+
+	void set_stacking(bool p_enabled);
+	bool is_stacking();
+
+	void set_sticky_status(StickyStatus p_status);
+	StickyStatus get_sticky_status();
+
+	void set_bounding_container_path(const NodePath &p_path);
+	NodePath get_bounding_container_path();
+	Control *get_bounding_container();
+
+	int get_sticky_child_count();
+	Control *get_sticky_child(int p_i);
+
+	StickyContainer();
+};
+
+VARIANT_ENUM_CAST(StickyContainer::StickyStatus);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -85,6 +85,7 @@
 #include "scene/gui/slider.h"
 #include "scene/gui/spin_box.h"
 #include "scene/gui/split_container.h"
+#include "scene/gui/sticky_container.h"
 #include "scene/gui/subviewport_container.h"
 #include "scene/gui/tab_bar.h"
 #include "scene/gui/tab_container.h"
@@ -502,6 +503,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(GridContainer);
 	GDREGISTER_CLASS(CenterContainer);
 	GDREGISTER_CLASS(ScrollContainer);
+	GDREGISTER_CLASS(StickyContainer);
 	GDREGISTER_CLASS(PanelContainer);
 	GDREGISTER_CLASS(FlowContainer);
 	GDREGISTER_CLASS(HFlowContainer);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
closes https://github.com/godotengine/godot-proposals/issues/5599

https://github.com/user-attachments/assets/138c1dc3-3d4f-40fa-93b6-2f2efb0885a1

Adds `StickyContainer`. It allows sticking any children of StickyContainer to the bounds of the nearest ScrollContainer. 

At runtime (not in the edited scene), when a child is added to StickyContainer, it gets reparented to the ScrollContainer, so that the controls appear above the normal scroll content and receive input first. The StickyContainer's rect is used to track where the sticky nodes would normally be, and then ScrollContainer handles actually positioning them, keeping it within its global rect

There's an optional `bounding_container`, which is a NodePath. If its set, the sticky control will also be limited to the bounds of that control, enabling those section headers. 

Finally there's an optional `stacked` property, enabling the last example in the video. 

There's a signal for "status_changed", telling when a sticky node is stuck, unstuck but out of view, or unstuck but in view. I'm not sure about these states, but it was what the linked proposal was mainly requesting