### PR TITLE
Restore accent color text for main screen buttons in the modern theme

### DIFF
--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1687,7 +1687,21 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_stylebox("hover_pressed", "MainScreenButton", p_config.base_empty_wide_style);
 		p_theme->set_stylebox("hover_pressed_mirrored", "MainScreenButton", p_config.base_empty_wide_style);
 
-		p_theme->set_color("font_pressed_color", "MainScreenButton", p_config.mono_color_font);
+		// Main screen buttons.
+		const Color mb_font_color = p_config.font_color * Color(1, 1, 1, 0.95);
+		const Color mb_font_hover_color = p_config.font_hover_color * Color(1, 1, 1, 0.95);
+		const Color mb_font_hover_pressed_color = p_config.accent_color.lerp(p_config.mono_color, 0.2);
+
+		p_theme->set_color(SceneStringName(font_color), "MainScreenButton", mb_font_color);
+		p_theme->set_color("font_hover_color", "MainScreenButton", mb_font_hover_color);
+		p_theme->set_color("font_pressed_color", "MainScreenButton", p_config.accent_color);
+		p_theme->set_color("font_hover_pressed_color", "MainScreenButton", mb_font_hover_pressed_color);
+
+		const Color mb_icon_normal_color = p_config.icon_normal_color * Color(1, 1, 1, 0.95);
+		const Color mb_icon_hover_color = p_config.icon_hover_color * Color(1, 1, 1, 0.95);
+
+		p_theme->set_color("icon_normal_color", "MainScreenButton", mb_icon_normal_color);
+		p_theme->set_color("icon_hover_color", "MainScreenButton", mb_icon_hover_color);
 
 		p_theme->set_type_variation("MainMenuBar", "FlatMenuButton");
 		p_theme->set_stylebox(CoreStringName(normal), "MainMenuBar", p_config.flat_button);


### PR DESCRIPTION
**PR:**

![mb](https://github.com/user-attachments/assets/c34f13d8-1de6-4005-beb1-a9cf285be550)

These were changed to monochrome a long time ago in the minimal theme on accident when I was working on unrelated buttons because they just inherit the default button look, but I believe they should be accent color like in the classic theme. This way they both stand out more and look simpler at the same time, so it's a better design overall. Most buttons in the new theme don't do that to avoid sensory overload, but these are a good exception.

I also toned down the unpressed ones a tiny bit because the default font color is a bit too bright against the dark top bar.