### PR TITLE
Fix `AudioStreamPlayer.get_playback_position()` with `AudioStreamPlaylist` returns 0 regardless of start time

### DIFF
--- a/modules/interactive_music/audio_stream_playlist.cpp
+++ b/modules/interactive_music/audio_stream_playlist.cpp
@@ -247,6 +247,7 @@ void AudioStreamPlaybackPlaylist::start(double p_from_pos) {
 	playback[play_order[play_index]]->start(play_ofs);
 	fade_index = -1;
 	loop_count = 0;
+	offset = p_from_pos;
 
 	active = true;
 }


### PR DESCRIPTION
## Problem
`AudioStreamPlayer.get_playback_position()` with `AudioStreamPlaylist` returned the time elapsed since playback started,
not the actual playback position.

The issue was that, on start,
the initial start time was not added to the `offset` (the variable responsible for the playback position).

## Issue
Fixes #104222