### PR TITLE
C#: Prevent SourceGenerators from becoming a transitive dependency

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
@@ -25,7 +25,7 @@
 
   <!-- C# source generators -->
   <ItemGroup Condition=" '$(DisableImplicitGodotGeneratorReferences)' != 'true' ">
-    <PackageReference Include="Godot.SourceGenerators" IsImplicitlyDefined="true" Version="$(PackageVersion_Godot_SourceGenerators)" />
+    <PackageReference Include="Godot.SourceGenerators" IsImplicitlyDefined="true" Version="$(PackageVersion_Godot_SourceGenerators)" ReferenceOutputAssembly="false" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Godot API references -->


### PR DESCRIPTION
We assumed the game project would always be treated as a leaf, but users reference it as a dependency in test projects, so we must prevent the generators package from becoming a transitive dependency. Otherwise, the generators may run in a non-Godot project.

- Fixes https://github.com/godotengine/godot/issues/87753

**Note for merge maintainers**: This should be safe to merge now for 4.6, but since we're in RC phase and it's easy to workaround, I'm adding it to the 4.7 milestone.