### PR TITLE
Fix JSON reformatting ints as floats

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -390,10 +390,44 @@ Error JSON::_get_token(const char32_t *p_str, int &r_index, int p_len, Token &r_
 				if (p_str[r_index] == '-' || is_digit(p_str[r_index])) {
 					//a number
 					const char32_t *rptr;
-					double number = String::to_float(&p_str[r_index], &rptr);
-					r_index += (rptr - &p_str[r_index]);
+					const double number = String::to_float(&p_str[r_index], &rptr);
+					const int len = rptr - &p_str[r_index];
+					const int64_t number_int = String::to_int(&p_str[r_index], len, true);
+
+					// Treat the number as an int if it is formatted as an int.
+					bool is_int = true;
+					for (int i = r_index; i < r_index + len; i++) {
+						const char32_t c = p_str[i];
+						if (c == '.' || c == 'e' || c == 'E') {
+							is_int = false;
+							break;
+						}
+					}
+					// Only allow ints within [INT64_MIN, INT64_MAX].
+					if (is_int && (number_int == INT64_MAX || number_int == INT64_MIN)) {
+						if (number > (double)INT64_MAX || number < (double)INT64_MIN) {
+							is_int = false;
+						} else if (number == (double)INT64_MAX) {
+							// `String::to_int` clamps and double precision isn't enough to know if the value is out of the bounds, so compare the number without the first digit.
+							const int64_t number_no_first_digit = String::to_int(&p_str[r_index + 1], len, true);
+							if (number_no_first_digit != 223372036854775807) {
+								is_int = false;
+							}
+						} else if (number == (double)INT64_MIN) {
+							const int64_t number_no_first_digit = String::to_int(&p_str[r_index + 2], len, true);
+							if (number_no_first_digit != 223372036854775808) {
+								is_int = false;
+							}
+						}
+					}
+
+					r_index += len;
 					r_token.type = TK_NUMBER;
-					r_token.value = number;
+					if (is_int) {
+						r_token.value = number_int;
+					} else {
+						r_token.value = number;
+					}
 					return OK;
 
 				} else if (is_ascii_alphabet_char(p_str[r_index])) {

--- a/doc/classes/JSON.xml
+++ b/doc/classes/JSON.xml
@@ -28,10 +28,10 @@
 		[codeblock]
 		var data = JSON.parse_string(json_string) # Returns null if parsing failed.
 		[/codeblock]
-		[b]Note:[/b] Both parse methods do not fully comply with the JSON specification:
+		[b]Note:[/b] Both parse methods are less strict the JSON specification:
 		- Trailing commas in arrays or objects are ignored, instead of causing a parser error.
 		- New line and tab characters are accepted in string literals, and are treated like their corresponding escape sequences [code]\n[/code] and [code]\t[/code].
-		- Numbers are parsed using [method String.to_float] which is generally more lax than the JSON specification.
+		- Numbers are parsed using [method String.to_float] or [method String.to_int] which are generally more lax than the JSON specification. For example, numbers such as [code]-01[/code], [code]-2.[/code], [code]2.e+3[/code], and [code]-.123[/code] are considered valid.
 		- Certain errors, such as invalid Unicode sequences, do not cause a parser error. Instead, the string is cleaned up and an error is logged to the console.
 	</description>
 	<tutorials>
@@ -78,6 +78,7 @@
 				Returns an [enum Error]. If the parse was successful, it returns [constant OK] and the result can be retrieved using [member data]. If unsuccessful, use [method get_error_line] and [method get_error_message] to identify the source of the failure.
 				Non-static variant of [method parse_string], if you want custom error handling.
 				The optional [param keep_text] argument instructs the parser to keep a copy of the original text. This text can be obtained later by using the [method get_parsed_text] function and is used when saving the resource (instead of generating new text from [member data]).
+				[b]Note:[/b] Numbers with only the integer component are parsed as integers when possible, and as floats otherwise.
 			</description>
 		</method>
 		<method name="parse_string" qualifiers="static">
@@ -96,7 +97,6 @@
 			<description>
 				Converts a [Variant] var to JSON text and returns the result. Useful for serializing data to store or send over the network.
 				If [param sort_keys] is [code]true[/code], the keys of any [Dictionary]s are sorted alphabetically when converting to JSON. If [param full_precision] is [code]true[/code], when stringifying floats, the unreliable digits are stringified in addition to the reliable digits to guarantee exact decoding.
-				[b]Note:[/b] The JSON specification does not define integer or float types, but only a [i]number[/i] type. Therefore, converting a Variant to JSON text will convert all numerical values to [float] types.
 				The [param indent] parameter controls if and how something is indented; its contents will be used where there should be an indent in the output. Even spaces like [code]"   "[/code] will work. [code]\t[/code] and [code]\n[/code] can also be used for a tab indent, or to make a newline for each indent respectively. If set to an empty string, the JSON will be on a single line with no spacing, which allows for smaller file sizes.
 				[b]Warning:[/b] Non-finite numbers are not supported in JSON. Any occurrences of [constant @GDScript.INF] will be replaced with [code]1e99999[/code], and negative [constant @GDScript.INF] will be replaced with [code]-1e99999[/code], but they will be interpreted correctly as infinity by most JSON parsers. [constant @GDScript.NAN] will be replaced with [code]null[/code], and it will not be interpreted as NaN in JSON parsers. If you expect non-finite numbers, consider passing your data through [method from_native] first.
 				[b]Example output:[/b]

--- a/misc/extension_api_validation/4.7-stable/GH-114872.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-114872.txt
@@ -1,0 +1,16 @@
+GH-114872
+--------
+Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/BarrierMask/values/BARRIER_MASK_ALL_BARRIERS': value changed value in new API, from 7 to 32767.
+Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/BarrierMask/values/BARRIER_MASK_NO_BARRIER': value changed value in new API, from 8 to 32768.
+Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/BarrierMask/values/BARRIER_MASK_RASTER': value changed value in new API, from 1 to 9.
+Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/FinalAction/values/FINAL_ACTION_CONTINUE': value changed value in new API, from 2 to 0.
+Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/FinalAction/values/FINAL_ACTION_MAX': value changed value in new API, from 3 to 2.
+Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/InitialAction/values/INITIAL_ACTION_CLEAR': value changed value in new API, from 0 to 1.
+Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/InitialAction/values/INITIAL_ACTION_CLEAR_REGION_CONTINUE': value changed value in new API, from 2 to 1.
+Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/InitialAction/values/INITIAL_ACTION_CONTINUE': value changed value in new API, from 5 to 0.
+Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/InitialAction/values/INITIAL_ACTION_DROP': value changed value in new API, from 4 to 2.
+Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/InitialAction/values/INITIAL_ACTION_KEEP': value changed value in new API, from 3 to 0.
+Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/InitialAction/values/INITIAL_ACTION_MAX': value changed value in new API, from 6 to 3.
+Validate extension JSON: Error: Field 'global_enums/KeyModifierMask/values/KEY_MODIFIER_MASK': value changed value in new API, from 532676608 to 2130706432.
+
+JSON parsing changed to use ints, the extension api validation now correctly uses int for formatting enums. No compatibility methods needed.

--- a/tests/core/io/test_json.cpp
+++ b/tests/core/io/test_json.cpp
@@ -170,6 +170,9 @@ TEST_CASE("[JSON] Parsing single data types") {
 	CHECK_MESSAGE(
 			json.get_data() == Variant(),
 			"Parsing a double quoted string as JSON should return the expected value.");
+	CHECK_MESSAGE(
+			json.get_data().get_type() == Variant::NIL,
+			"Parsing a null value as JSON should return the correct type.");
 
 	json.parse("true");
 	CHECK_MESSAGE(
@@ -178,6 +181,9 @@ TEST_CASE("[JSON] Parsing single data types") {
 	CHECK_MESSAGE(
 			json.get_data(),
 			"Parsing boolean `true` as JSON should return the expected value.");
+	CHECK_MESSAGE(
+			json.get_data().get_type() == Variant::BOOL,
+			"Parsing a boolean value as JSON should return the correct type.");
 
 	json.parse("false");
 	CHECK_MESSAGE(
@@ -186,6 +192,9 @@ TEST_CASE("[JSON] Parsing single data types") {
 	CHECK_MESSAGE(
 			!json.get_data(),
 			"Parsing boolean `false` as JSON should return the expected value.");
+	CHECK_MESSAGE(
+			json.get_data().get_type() == Variant::BOOL,
+			"Parsing a boolean value as JSON should return the correct type.");
 
 	json.parse("123456");
 	CHECK_MESSAGE(
@@ -194,6 +203,9 @@ TEST_CASE("[JSON] Parsing single data types") {
 	CHECK_MESSAGE(
 			(int)(json.get_data()) == 123456,
 			"Parsing an integer number as JSON should return the expected value.");
+	CHECK_MESSAGE(
+			json.get_data().get_type() == Variant::INT,
+			"Parsing an integer number as JSON should return the correct type.");
 
 	json.parse("0.123456");
 	CHECK_MESSAGE(
@@ -202,6 +214,9 @@ TEST_CASE("[JSON] Parsing single data types") {
 	CHECK_MESSAGE(
 			double(json.get_data()) == doctest::Approx(0.123456),
 			"Parsing a floating-point number as JSON should return the expected value.");
+	CHECK_MESSAGE(
+			json.get_data().get_type() == Variant::FLOAT,
+			"Parsing a floating-point number as JSON should return the correct type.");
 
 	json.parse("\"hello\"");
 	CHECK_MESSAGE(
@@ -210,6 +225,9 @@ TEST_CASE("[JSON] Parsing single data types") {
 	CHECK_MESSAGE(
 			json.get_data() == "hello",
 			"Parsing a double quoted string as JSON should return the expected value.");
+	CHECK_MESSAGE(
+			json.get_data().get_type() == Variant::STRING,
+			"Parsing a string as JSON should return the correct type.");
 }
 
 TEST_CASE("[JSON] Parsing arrays") {
@@ -388,6 +406,7 @@ TEST_CASE("[JSON] Serialization") {
 		{ 1.0 / 3.0, "0.3333333333333333" },
 		{ 0.9999999999999999, "0.9999999999999999" },
 		{ 1.0000000000000001, "1.0" },
+		{ 5e+200, "5e+200" },
 	};
 
 	static IntTestCase int_tests[] = {
@@ -403,6 +422,14 @@ TEST_CASE("[JSON] Serialization") {
 			CHECK_MESSAGE(
 					json_value == test.json,
 					vformat("Serializing `%.20d` to JSON should return the expected value.", test.number));
+
+			json.parse(test.json);
+			CHECK_MESSAGE(
+					(double)json.get_data() == test.json.to_float(),
+					vformat("Deserializing `%s` with JSON should return the expected value.", test.json));
+			CHECK_MESSAGE(
+					json.get_data().get_type() == Variant::FLOAT,
+					vformat("Deserializing `%s` with JSON should return the expected type.", test.json));
 		}
 	}
 
@@ -413,6 +440,14 @@ TEST_CASE("[JSON] Serialization") {
 			CHECK_MESSAGE(
 					json_value == test.json,
 					vformat("Serializing `%20f` to JSON should return the expected value.", test.number));
+
+			json.parse(test.json);
+			CHECK_MESSAGE(
+					double(json.get_data()) == test.json.to_float(),
+					vformat("Deserializing `%s` with JSON should return the expected value.", test.json));
+			CHECK_MESSAGE(
+					json.get_data().get_type() == Variant::FLOAT,
+					vformat("Deserializing `%s` with JSON should return the expected type.", test.json));
 		}
 	}
 
@@ -423,7 +458,47 @@ TEST_CASE("[JSON] Serialization") {
 			CHECK_MESSAGE(
 					json_value == test.json,
 					vformat("Serializing `%d` to JSON should return the expected value.", test.number));
+
+			json.parse(test.json);
+			CHECK_MESSAGE(
+					(int64_t)(json.get_data()) == test.json.to_int(),
+					vformat("Deserializing `%s` with JSON should return the expected value.", test.json));
+			CHECK_MESSAGE(
+					json.get_data().get_type() == Variant::INT,
+					vformat("Deserializing `%s` with JSON should return the expected type.", test.json));
 		}
+	}
+
+	SUBCASE("Parsing floating-point values") {
+		// No decimal point but still a double.
+		String json_value = "5e2";
+		json.parse(json_value);
+		CHECK_MESSAGE(
+				double(json.get_data()) == 5e2,
+				vformat("Parsing `%s` with JSON should return the expected value.", json_value));
+		CHECK_MESSAGE(
+				json.get_data().get_type() == Variant::FLOAT,
+				vformat("Parsing `%s` with JSON should return the expected type.", json_value));
+
+		// Too large to be an int.
+		json_value = "9223372036854775808";
+		json.parse(json_value);
+		CHECK_MESSAGE(
+				double(json.get_data()) == (double)INT64_MAX + 1.0,
+				vformat("Parsing `%s` with JSON should return the expected value.", json_value));
+		CHECK_MESSAGE(
+				json.get_data().get_type() == Variant::FLOAT,
+				vformat("Parsing `%s` with JSON should return the expected type.", json_value));
+
+		// Too small to be an int.
+		json_value = "-9223372036854775809";
+		json.parse(json_value);
+		CHECK_MESSAGE(
+				double(json.get_data()) == (double)INT64_MIN - 1.0,
+				vformat("Parsing `%s` with JSON should return the expected value.", json_value));
+		CHECK_MESSAGE(
+				json.get_data().get_type() == Variant::FLOAT,
+				vformat("Parsing `%s` with JSON should return the expected type.", json_value));
 	}
 }
 


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/105160
- Closes https://github.com/godotengine/godot/issues/24119
- Supersedes https://github.com/godotengine/godot/pull/112256 (sorry, didn't see this)
- Closes https://github.com/godotengine/godot-proposals/issues/8830

I have seen arguments that technically it's fine to treat all numbers as floats since the JSON spec only has a number type, and arguments that say the numbers should be left in the same format since it is just a sequence of digits and the decimal part is optional so they are technically different values if it has a decimal or not.
It seems the spec is debatable here, but it doesn't matter since reformatting all numbers as floats is causing issues. Using integers isn't against the spec so there is no issue.

This fixes it by parsing the json number as an int if it can. The JSON class is otherwise already set up to handle int Variants. Since ints can be implicitly casted to floats, the only real change should be stringifying after parsing won't add a `.0` if there wasn't already one.

Now if a number is formatted as an int (no decimal or exponent) and it can fit within an int64, then it will be parsed as an int, and then be saved as an int.

For the indentation changing to tabs, this is a separate issue and will take more to fix it. See  #86092

Added tests to cover this behavior and its edge cases.
The documentation said "converting a Variant to JSON text will convert all numerical values to [float] types." but this is incorrect since it did not convert ints to floats in stringify.
I also changed the wording of the section on non-compliance, it is only describing how the parser is less strict than the JSON specification, which is allowed so it is compliant `A JSON parser MAY accept non-JSON forms or extensions.`.

Note: Opening a json file in the ScriptEditor after editing it in the inspector may fail, this is a separate unrelated problem.

The validation api error prints had values for enums being treated as a float when they should be ints. It was only the from value as well. Added an expected file.