### PR TITLE
Don't tint menu button icons in context toolbar

### DIFF
--- a/editor/scene/2d/camera_2d_editor_plugin.cpp
+++ b/editor/scene/2d/camera_2d_editor_plugin.cpp
@@ -304,6 +304,8 @@ Camera2DEditor::Camera2DEditor(EditorPlugin *p_plugin) {
 
 	options = memnew(MenuButton);
 	options->set_text(TTRC("Camera2D"));
+	options->set_flat(false);
+	options->set_theme_type_variation("FlatMenuButtonNoIconTint");
 	options->get_popup()->add_item(TTRC("Snap the Limits to the Viewport"), MENU_SNAP_LIMITS_TO_VIEWPORT);
 	options->set_switch_on_hover(true);
 	options->hide();

--- a/editor/scene/2d/skeleton_2d_editor_plugin.cpp
+++ b/editor/scene/2d/skeleton_2d_editor_plugin.cpp
@@ -97,7 +97,7 @@ Skeleton2DEditor::Skeleton2DEditor() {
 	options->set_text(TTR("Skeleton2D"));
 	options->set_button_icon(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("Skeleton2D"), EditorStringName(EditorIcons)));
 	options->set_flat(false);
-	options->set_theme_type_variation("FlatMenuButton");
+	options->set_theme_type_variation("FlatMenuButtonNoIconTint");
 
 	options->get_popup()->add_item(TTR("Reset to Rest Pose"), MENU_OPTION_SET_REST);
 	options->get_popup()->add_separator();

--- a/editor/scene/2d/sprite_2d_editor_plugin.cpp
+++ b/editor/scene/2d/sprite_2d_editor_plugin.cpp
@@ -624,7 +624,7 @@ Sprite2DEditor::Sprite2DEditor() {
 
 	options->set_text(TTR("Sprite2D"));
 	options->set_flat(false);
-	options->set_theme_type_variation("FlatMenuButton");
+	options->set_theme_type_variation("FlatMenuButtonNoIconTint");
 
 	options->get_popup()->add_item(TTR("Convert to MeshInstance2D"), MENU_OPTION_CONVERT_TO_MESH_2D);
 	options->get_popup()->add_item(TTR("Convert to Polygon2D"), MENU_OPTION_CONVERT_TO_POLYGON_2D);

--- a/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
@@ -798,7 +798,7 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 	options->set_text(TTR("Mesh"));
 	options->set_switch_on_hover(true);
 	options->set_flat(false);
-	options->set_theme_type_variation("FlatMenuButton");
+	options->set_theme_type_variation("FlatMenuButtonNoIconTint");
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(options);
 
 	options->get_popup()->add_item(TTR("Create Collision Shape..."), MENU_OPTION_CREATE_COLLISION_SHAPE);

--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -279,7 +279,7 @@ MeshLibraryEditor::MeshLibraryEditor() {
 	menu->set_text(TTR("MeshLibrary"));
 	menu->set_button_icon(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("MeshLibrary"), EditorStringName(EditorIcons)));
 	menu->set_flat(false);
-	menu->set_theme_type_variation("FlatMenuButton");
+	menu->set_theme_type_variation("FlatMenuButtonNoIconTint");
 	menu->get_popup()->add_item(TTR("Add Item"), MENU_OPTION_ADD_ITEM);
 	menu->get_popup()->add_item(TTR("Remove Selected Item"), MENU_OPTION_REMOVE_ITEM);
 	menu->get_popup()->add_separator();

--- a/editor/scene/3d/multimesh_editor_plugin.cpp
+++ b/editor/scene/3d/multimesh_editor_plugin.cpp
@@ -274,7 +274,7 @@ MultiMeshEditor::MultiMeshEditor() {
 	options->set_text("MultiMesh");
 	options->set_button_icon(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("MultiMeshInstance3D"), EditorStringName(EditorIcons)));
 	options->set_flat(false);
-	options->set_theme_type_variation("FlatMenuButton");
+	options->set_theme_type_variation("FlatMenuButtonNoIconTint");
 
 	options->get_popup()->add_item(TTR("Populate Surface"));
 	options->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &MultiMeshEditor::_menu_option));

--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -1042,7 +1042,7 @@ void Skeleton3DEditor::create_editors() {
 	// Create Skeleton Option in Top Menu Bar.
 	skeleton_options = memnew(MenuButton);
 	skeleton_options->set_flat(false);
-	skeleton_options->set_theme_type_variation("FlatMenuButton");
+	skeleton_options->set_theme_type_variation("FlatMenuButtonNoIconTint");
 	topmenu_bar->add_child(skeleton_options);
 
 	skeleton_options->set_text(TTR("Skeleton3D"));

--- a/editor/scene/particles_editor_plugin.cpp
+++ b/editor/scene/particles_editor_plugin.cpp
@@ -108,7 +108,7 @@ ParticlesEditorPlugin::ParticlesEditorPlugin() {
 	menu = memnew(MenuButton);
 	menu->set_switch_on_hover(true);
 	menu->set_flat(false);
-	menu->set_theme_type_variation("FlatMenuButton");
+	menu->set_theme_type_variation("FlatMenuButtonNoIconTint");
 	toolbar->add_child(menu);
 	menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &ParticlesEditorPlugin::_menu_callback));
 }

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1854,6 +1854,11 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			p_theme->set_color("icon_hover_color", "FlatButtonNoIconTint", p_config.mono_color);
 			p_theme->set_color("icon_hover_pressed_color", "FlatButtonNoIconTint", p_config.mono_color);
 
+			p_theme->set_type_variation("FlatMenuButtonNoIconTint", "FlatMenuButton");
+			p_theme->set_color("icon_pressed_color", "FlatMenuButtonNoIconTint", p_config.icon_normal_color);
+			p_theme->set_color("icon_hover_color", "FlatMenuButtonNoIconTint", p_config.mono_color);
+			p_theme->set_color("icon_hover_pressed_color", "FlatMenuButtonNoIconTint", p_config.mono_color);
+
 			// Variation for Editor Log filter buttons.
 			p_theme->set_type_variation("EditorLogFilterButton", "Button");
 			// When pressed, don't tint the icons with the accent color, just leave them normal.

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1878,6 +1878,11 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_color("icon_hover_color", "FlatButtonNoIconTint", p_config.mono_color);
 			p_theme->set_color("icon_hover_pressed_color", "FlatButtonNoIconTint", p_config.mono_color);
 
+			p_theme->set_type_variation("FlatMenuButtonNoIconTint", "FlatMenuButton");
+			p_theme->set_color("icon_pressed_color", "FlatMenuButtonNoIconTint", p_config.icon_normal_color);
+			p_theme->set_color("icon_hover_color", "FlatMenuButtonNoIconTint", p_config.mono_color);
+			p_theme->set_color("icon_hover_pressed_color", "FlatMenuButtonNoIconTint", p_config.mono_color);
+
 			// Variation for Editor Log filter buttons.
 
 			p_theme->set_type_variation("EditorLogFilterButton", "Button");


### PR DESCRIPTION
Removes accent color icon tint from pressed colored icons

| Master | PR |
|--------|--------|
| ![old](https://github.com/user-attachments/assets/c795314b-c5c9-41e1-a586-d053179a36c1) | ![new](https://github.com/user-attachments/assets/810ac1c5-a8ea-4893-95cb-de1642626f7e) |