### PR TITLE
Resize Output/Debugger icons to be consistent with other docks

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -413,7 +413,7 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 			Ref<Texture2D> icon = theme_cache.error_icon;
 			log->add_image(icon);
 			log->push_bold();
-			log->add_text(" ERROR: ");
+			log->add_text(U" ERROR: ");
 			log->pop(); // bold
 			_set_dock_tab_icon(icon);
 		} break;
@@ -422,7 +422,7 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 			Ref<Texture2D> icon = theme_cache.warning_icon;
 			log->add_image(icon);
 			log->push_bold();
-			log->add_text(" WARNING: ");
+			log->add_text(U" WARNING: ");
 			log->pop(); // bold
 			_set_dock_tab_icon(icon);
 		} break;

--- a/editor/icons/Error.svg
+++ b/editor/icons/Error.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><circle cx="4" cy="4" r="4" fill="#ff5f5f"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="4" fill="#ff5f5f"/></svg>

--- a/editor/icons/ErrorWarning.svg
+++ b/editor/icons/ErrorWarning.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><path fill="#ff5f5f" d="M4 8a1 1 0 0 1 0-8z"/><path fill="#ffdd65" d="M4 0a1 1 0 0 1 0 8z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#ff5f5f" d="M8 12a1 1 0 0 1 0-8z"/><path fill="#ffdd65" d="M8 4a1 1 0 0 1 0 8z"/></svg>

--- a/editor/icons/Output.svg
+++ b/editor/icons/Output.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><circle cx="4" cy="4" r="4" fill="#e0e0e0"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="4" fill="#e0e0e0"/></svg>

--- a/editor/icons/Warning.svg
+++ b/editor/icons/Warning.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><circle cx="4" cy="4" r="4" fill="#ffdd65"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="4" fill="#ffdd65"/></svg>


### PR DESCRIPTION
Resizes the SVG viewport size to be 16x16.
The circle's radius is unchanged

| Master | PR |
|--------|--------|
| <img width="197" height="58" alt="image" src="https://github.com/user-attachments/assets/8179b0b5-5789-4372-9e83-e64c444cfba8" /> | <img width="197" height="58" alt="image" src="https://github.com/user-attachments/assets/fca96a75-c67f-4814-b571-a48f4df5d6c6" /> | 