### PR TITLE
Fix inspector draws focus on click when editing EditorPropertyTextEnum

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -445,7 +445,7 @@ void EditorPropertyTextEnum::_option_selected(int p_which) {
 void EditorPropertyTextEnum::_edit_custom_value() {
 	default_layout->hide();
 	edit_custom_layout->show();
-	custom_value_edit->grab_focus();
+	custom_value_edit->grab_focus(true);
 }
 
 void EditorPropertyTextEnum::_custom_value_submitted(const String &p_value) {


### PR DESCRIPTION
Another follow-up to https://github.com/godotengine/godot/pull/110250, this one can be reproduced by creating a new Control node and clicking on the pencil of Theme->Type Variation property in inspector. cc @YeldhamDev 