### PR TITLE
Prevent LightmapGI from baking the editor preview environment

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -9550,6 +9550,7 @@ void Node3DEditor::_update_preview_environment() {
 	if (disable_env) {
 		if (preview_environment->get_parent()) {
 			preview_environment->get_parent()->remove_child(preview_environment);
+			preview_environment->remove_from_group("_editor_preview_environment_");
 			environ_state->show();
 			environ_vb->hide();
 			preview_env_dangling = true;
@@ -9563,6 +9564,7 @@ void Node3DEditor::_update_preview_environment() {
 	} else {
 		if (!preview_environment->get_parent()) {
 			add_child(preview_environment);
+			preview_environment->add_to_group("_editor_preview_environment_");
 			environ_state->hide();
 			environ_vb->show();
 			preview_env_dangling = false;

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1237,7 +1237,12 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 			case ENVIRONMENT_MODE_SCENE: {
 				Ref<World3D> world = get_world_3d();
 				if (world.is_valid()) {
-					Ref<Environment> env = world->get_environment();
+					Ref<Environment> env;
+					if (get_tree()->get_node_count_in_group("_editor_preview_environment_") > 0) {
+						// Preview environment is enabled, ignore it
+					} else {
+						env = world->get_environment();
+					}
 					if (env.is_null()) {
 						env = world->get_fallback_environment();
 					}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/114878
