### PR TITLE
Last Input Device Tracker

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -206,7 +206,6 @@ void Input::_bind_methods() {
 	BIND_ENUM_CONSTANT(CURSOR_VSPLIT);
 	BIND_ENUM_CONSTANT(CURSOR_HSPLIT);
 	BIND_ENUM_CONSTANT(CURSOR_HELP);
-	BIND_ENUM_CONSTANT(CURSOR_MAX);
 
 	BIND_ENUM_CONSTANT(LAST_INPUT_KEYBOARD_MOUSE);
 	BIND_ENUM_CONSTANT(LAST_INPUT_JOYPAD);
@@ -737,6 +736,14 @@ Vector3 Input::get_magnetometer() const {
 	return magnetometer;
 }
 
+void Input::_set_last_input_type(LastInputType p_type) {
+	if (last_input_type == p_type) {
+		return;
+	}
+	last_input_type = p_type;
+	emit_signal(SNAME("last_input_device_changed"), (int)last_input_type);
+}
+
 Vector3 Input::get_gyroscope() const {
 	_THREAD_SAFE_METHOD_
 
@@ -761,32 +768,9 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 	// - Emulated touch events are handed right to the main loop (i.e., the SceneTree) because they don't
 	//   require additional handling by this class.
 
-	// Track last input device type
-	LastInputType new_input_type = last_input_type;
-
-	if (Object::cast_to<InputEventKey>(p_event.ptr())) {
-		new_input_type = LAST_INPUT_KEYBOARD_MOUSE;
-	} else if (Object::cast_to<InputEventMouseButton>(p_event.ptr()) && !p_is_emulated) {
-		new_input_type = LAST_INPUT_KEYBOARD_MOUSE;
-	} else if (Object::cast_to<InputEventMouseMotion>(p_event.ptr()) && !p_is_emulated) {
-		new_input_type = LAST_INPUT_KEYBOARD_MOUSE;
-	} else if (Object::cast_to<InputEventJoypadButton>(p_event.ptr())) {
-		new_input_type = LAST_INPUT_JOYPAD;
-	} else if (Object::cast_to<InputEventJoypadMotion>(p_event.ptr())) {
-		new_input_type = LAST_INPUT_JOYPAD;
-	} else if (Object::cast_to<InputEventScreenTouch>(p_event.ptr())) {
-		new_input_type = LAST_INPUT_TOUCH;
-	} else if (Object::cast_to<InputEventScreenDrag>(p_event.ptr())) {
-		new_input_type = LAST_INPUT_TOUCH;
-	}
-
-	if (new_input_type != last_input_type) {
-		last_input_type = new_input_type;
-		emit_signal(SNAME("last_input_device_changed"), (int)last_input_type);
-	}
-
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && !k->is_echo() && k->get_keycode() != Key::NONE) {
+		_set_last_input_type(LAST_INPUT_KEYBOARD_MOUSE);
 		if (k->is_pressed()) {
 			keys_pressed.insert(k->get_keycode());
 		} else {
@@ -811,6 +795,9 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 	Ref<InputEventMouseButton> mb = p_event;
 
 	if (mb.is_valid()) {
+		if (!p_is_emulated) {
+			_set_last_input_type(LAST_INPUT_KEYBOARD_MOUSE);
+		}
 		if (mb->is_pressed()) {
 			mouse_button_mask.set_flag(mouse_button_to_mask(mb->get_button_index()));
 		} else {
@@ -840,6 +827,9 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 	Ref<InputEventMouseMotion> mm = p_event;
 
 	if (mm.is_valid()) {
+		if (!p_is_emulated) {
+			_set_last_input_type(LAST_INPUT_KEYBOARD_MOUSE);
+		}
 		Point2 position = mm->get_global_position();
 		if (mouse_pos != position) {
 			set_mouse_position(position);
@@ -871,6 +861,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 	Ref<InputEventScreenTouch> st = p_event;
 
 	if (st.is_valid()) {
+		_set_last_input_type(LAST_INPUT_TOUCH);
 		if (st->is_pressed()) {
 			VelocityTrack &track = touch_velocity_track[st->get_index()];
 			track.reset();
@@ -923,6 +914,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 	Ref<InputEventScreenDrag> sd = p_event;
 
 	if (sd.is_valid()) {
+		_set_last_input_type(LAST_INPUT_TOUCH);
 		VelocityTrack &track = touch_velocity_track[sd->get_index()];
 		track.update(sd->get_relative(), sd->get_relative_screen_position());
 		sd->set_velocity(track.velocity);
@@ -952,6 +944,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 	Ref<InputEventJoypadButton> jb = p_event;
 
 	if (jb.is_valid()) {
+		_set_last_input_type(LAST_INPUT_JOYPAD);
 		JoyButton c = _combine_device(jb->get_button_index(), jb->get_device());
 
 		if (jb->is_pressed()) {
@@ -964,6 +957,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 	Ref<InputEventJoypadMotion> jm = p_event;
 
 	if (jm.is_valid()) {
+		_set_last_input_type(LAST_INPUT_JOYPAD);
 		set_joy_axis(jm->get_device(), jm->get_axis(), jm->get_axis_value());
 	}
 

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -173,10 +173,14 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emulate_touch_from_mouse", "enable"), &Input::set_emulate_touch_from_mouse);
 	ClassDB::bind_method(D_METHOD("is_emulating_touch_from_mouse"), &Input::is_emulating_touch_from_mouse);
 
+	ClassDB::bind_method(D_METHOD("get_last_input_type"), &Input::get_last_input_type);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_mode"), "set_mouse_mode", "get_mouse_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_accumulated_input"), "set_use_accumulated_input", "is_using_accumulated_input");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emulate_mouse_from_touch"), "set_emulate_mouse_from_touch", "is_emulating_mouse_from_touch");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emulate_touch_from_mouse"), "set_emulate_touch_from_mouse", "is_emulating_touch_from_mouse");
+
+	ADD_SIGNAL(MethodInfo("last_input_device_changed", PropertyInfo(Variant::INT, "type")));
 
 	BIND_ENUM_CONSTANT(MOUSE_MODE_VISIBLE);
 	BIND_ENUM_CONSTANT(MOUSE_MODE_HIDDEN);
@@ -202,6 +206,12 @@ void Input::_bind_methods() {
 	BIND_ENUM_CONSTANT(CURSOR_VSPLIT);
 	BIND_ENUM_CONSTANT(CURSOR_HSPLIT);
 	BIND_ENUM_CONSTANT(CURSOR_HELP);
+	BIND_ENUM_CONSTANT(CURSOR_MAX);
+
+	BIND_ENUM_CONSTANT(LAST_INPUT_KEYBOARD_MOUSE);
+	BIND_ENUM_CONSTANT(LAST_INPUT_JOYPAD);
+	BIND_ENUM_CONSTANT(LAST_INPUT_TOUCH);
+	BIND_ENUM_CONSTANT(LAST_INPUT_UNKNOWN);
 
 	ADD_SIGNAL(MethodInfo("joy_connection_changed", PropertyInfo(Variant::INT, "device"), PropertyInfo(Variant::BOOL, "connected")));
 }
@@ -751,6 +761,30 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 	// - Emulated touch events are handed right to the main loop (i.e., the SceneTree) because they don't
 	//   require additional handling by this class.
 
+	// Track last input device type
+	LastInputType new_input_type = last_input_type;
+
+	if (Object::cast_to<InputEventKey>(p_event.ptr())) {
+		new_input_type = LAST_INPUT_KEYBOARD_MOUSE;
+	} else if (Object::cast_to<InputEventMouseButton>(p_event.ptr()) && !p_is_emulated) {
+		new_input_type = LAST_INPUT_KEYBOARD_MOUSE;
+	} else if (Object::cast_to<InputEventMouseMotion>(p_event.ptr()) && !p_is_emulated) {
+		new_input_type = LAST_INPUT_KEYBOARD_MOUSE;
+	} else if (Object::cast_to<InputEventJoypadButton>(p_event.ptr())) {
+		new_input_type = LAST_INPUT_JOYPAD;
+	} else if (Object::cast_to<InputEventJoypadMotion>(p_event.ptr())) {
+		new_input_type = LAST_INPUT_JOYPAD;
+	} else if (Object::cast_to<InputEventScreenTouch>(p_event.ptr())) {
+		new_input_type = LAST_INPUT_TOUCH;
+	} else if (Object::cast_to<InputEventScreenDrag>(p_event.ptr())) {
+		new_input_type = LAST_INPUT_TOUCH;
+	}
+
+	if (new_input_type != last_input_type) {
+		last_input_type = new_input_type;
+		emit_signal(SNAME("last_input_device_changed"), (int)last_input_type);
+	}
+
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && !k->is_echo() && k->get_keycode() != Key::NONE) {
 		if (k->is_pressed()) {
@@ -1084,6 +1118,10 @@ Point2 Input::get_last_mouse_velocity() {
 Point2 Input::get_last_mouse_screen_velocity() {
 	mouse_velocity_track.update(Vector2(), Vector2());
 	return mouse_velocity_track.screen_velocity;
+}
+
+Input::LastInputType Input::get_last_input_type() const {
+	return last_input_type;
 }
 
 BitField<MouseButtonMask> Input::get_mouse_button_mask() const {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -79,6 +79,13 @@ public:
 		CURSOR_MAX
 	};
 
+	enum LastInputType {
+		LAST_INPUT_KEYBOARD_MOUSE,
+		LAST_INPUT_JOYPAD,
+		LAST_INPUT_TOUCH,
+		LAST_INPUT_UNKNOWN,
+	};
+
 	class JoypadFeatures {
 	public:
 		virtual ~JoypadFeatures() {}
@@ -112,6 +119,8 @@ private:
 	int64_t mouse_window = 0;
 	bool legacy_just_pressed_behavior = false;
 	bool disable_input = false;
+
+	LastInputType last_input_type = LAST_INPUT_UNKNOWN;
 
 	struct ActionState {
 		uint64_t pressed_physics_frame = UINT64_MAX;
@@ -367,6 +376,8 @@ public:
 	void stop_joy_vibration(int p_device);
 	void vibrate_handheld(int p_duration_ms = 500, float p_amplitude = -1.0);
 
+	LastInputType get_last_input_type() const;
+
 	void set_mouse_position(const Point2 &p_posf);
 
 	void action_press(const StringName &p_action, float p_strength = 1.f);
@@ -422,3 +433,4 @@ public:
 
 VARIANT_ENUM_CAST(Input::MouseMode);
 VARIANT_ENUM_CAST(Input::CursorShape);
+VARIANT_ENUM_CAST(Input::LastInputType);

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -121,6 +121,7 @@ private:
 	bool disable_input = false;
 
 	LastInputType last_input_type = LAST_INPUT_UNKNOWN;
+	void _set_last_input_type(LastInputType p_type);
 
 	struct ActionState {
 		uint64_t pressed_physics_frame = UINT64_MAX;

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -173,6 +173,13 @@
 				Returns the last mouse velocity. To provide a precise and jitter-free velocity, mouse velocity is only calculated every 0.1s. Therefore, mouse velocity will lag mouse movements.
 			</description>
 		</method>
+		<method name="get_last_input_type" qualifiers="const">
+			<return type="int" enum="Input.LastInputType" />
+			<description>
+				Returns the type of the last input device used. This can be used to dynamically adapt the UI (e.g., showing keyboard prompts vs. gamepad button icons) or to automatically show/hide virtual controls on touch devices.
+				The return value is one of the [enum LastInputType] constants.
+			</description>
+		</method>
 		<method name="get_magnetometer" qualifiers="const">
 			<return type="Vector3" />
 			<description>
@@ -491,6 +498,13 @@
 				Emitted when a joypad device has been connected or disconnected.
 			</description>
 		</signal>
+		<signal name="last_input_device_changed">
+			<param index="0" name="type" type="int" />
+			<description>
+				Emitted when the user switches between input device categories (keyboard/mouse, gamepad, or touch). The [param type] parameter is one of the [enum LastInputType] constants.
+				This signal is useful for dynamically updating UI elements, such as showing keyboard prompts when the user switches from a gamepad to keyboard, or automatically showing virtual controls when touch input is detected.
+			</description>
+		</signal>
 	</signals>
 	<constants>
 		<constant name="MOUSE_MODE_VISIBLE" value="0" enum="MouseMode">
@@ -563,6 +577,18 @@
 		</constant>
 		<constant name="CURSOR_HELP" value="16" enum="CursorShape">
 			Help cursor. Usually a question mark.
+		</constant>
+		<constant name="LAST_INPUT_KEYBOARD_MOUSE" value="0" enum="LastInputType">
+			Last input was from keyboard or mouse (non-emulated).
+		</constant>
+		<constant name="LAST_INPUT_JOYPAD" value="1" enum="LastInputType">
+			Last input was from a gamepad/joypad.
+		</constant>
+		<constant name="LAST_INPUT_TOUCH" value="2" enum="LastInputType">
+			Last input was from a touch screen.
+		</constant>
+		<constant name="LAST_INPUT_UNKNOWN" value="3" enum="LastInputType">
+			Last input type is unknown or not yet determined.
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
I'm working on another engine implementation focused on virtual devices, similar to https://github.com/godotengine/godot/pull/110933, but instead of focusing on just one device, I'm implementing a series of virtual devices. These extend an abstracted class called `VirtualDevice` which has properties like multitouch, device index, and visibility functionality (always or touchscreen only). For this to work, I need the engine to have a user-friendly way of telling me the last device used.

I don't know how to write documents, that's why I asked for an LLM, but since the use of LLM is prohibited, I'm here rewriting the document in the dumbest way possible, but it's the only way I know how to write. I know how to program, not write documents.

To do this, what I did was add some return functions directly to the input, as well as a signal output whenever the value changes.

Sorry for not providing a detailed and explanatory text, but due to rules against the use of AI, this is all I can say about the system (I'm neurodivergent, I didn't want to randomly include this in a pull request, but I'm being forced to since people keep complaining about my communication).