### PR TITLE
Fix modified editor shortcuts being erased on MacOS

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1955,7 +1955,6 @@ void EditorSettings::add_shortcut(const String &p_path, const Ref<Shortcut> &p_s
 		p_shortcut->set_name(shortcut_name);
 	}
 	shortcuts[p_path] = p_shortcut;
-	shortcuts[p_path]->set_meta("customized", true);
 }
 
 void EditorSettings::remove_shortcut(const String &p_path) {
@@ -2084,7 +2083,7 @@ void ED_SHORTCUT_OVERRIDE_ARRAY(const String &p_path, const String &p_feature, c
 	}
 
 	// Override the existing shortcut only if it wasn't customized by the user.
-	if (!sc->has_meta("customized")) {
+	if (Shortcut::is_event_array_equal(sc->get_events(), sc->get_meta("original"))) {
 		sc->set_events(events);
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fixes: https://github.com/godotengine/godot/issues/114859
Supersedes: https://github.com/godotengine/godot/pull/114836

The issue was caused by timing issues with `ED_SHORTCUT_OVERRIDE()` and when a shortcut is marked as customized. This sidesteps the issue by just comparing the data which is something already done in a few places related to shortcuts. 

I verified https://github.com/godotengine/godot/pull/112831 was not reintroduced for Windows, and this fixed the issue for @MartinDelille on their Mac: https://github.com/godotengine/godot/issues/114859#issuecomment-3738009044

