### PR TITLE
Fix missing tree_exited signals

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -794,6 +794,37 @@ bool EditorNode::_is_project_data_missing() {
 	return false;
 }
 
+void EditorNode::_scene_tree_finalizing() {
+	singleton->active_plugins.clear();
+
+	if (progress_dialog) {
+		progress_dialog->queue_free();
+	}
+	if (load_error_dialog) {
+		load_error_dialog->queue_free();
+	}
+	if (execute_output_dialog) {
+		execute_output_dialog->queue_free();
+	}
+	if (warning) {
+		warning->queue_free();
+	}
+	if (accept) {
+		accept->queue_free();
+	}
+	if (save_accept) {
+		save_accept->queue_free();
+	}
+	EditorHelp::save_script_doc_cache();
+	editor_data.save_editor_external_data();
+	EditorSettings::get_singleton()->save_project_metadata();
+	FileAccess::set_file_close_fail_notify_callback(nullptr);
+	log->deinit(); // Do not get messages anymore.
+	SceneTree::get_singleton()->set_edited_scene_root(nullptr);
+	editor_data.clear_edited_scenes();
+	get_viewport()->disconnect("size_changed", callable_mp(this, &EditorNode::_viewport_resized));
+}
+
 void EditorNode::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -904,37 +935,16 @@ void EditorNode::_notification(int p_what) {
 
 			get_viewport()->connect("size_changed", callable_mp(this, &EditorNode::_viewport_resized));
 
+			get_tree()->connect("_finalizing", callable_mp(this, &EditorNode::_scene_tree_finalizing), CONNECT_ONE_SHOT);
+
 			/* DO NOT LOAD SCENES HERE, WAIT FOR FILE SCANNING AND REIMPORT TO COMPLETE */
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			singleton->active_plugins.clear();
-
-			if (progress_dialog) {
-				progress_dialog->queue_free();
+			if (get_tree()->is_connected("_finalizing", callable_mp(this, &EditorNode::_scene_tree_finalizing))) {
+				get_tree()->disconnect("_finalizing", callable_mp(this, &EditorNode::_scene_tree_finalizing));
+				_scene_tree_finalizing();
 			}
-			if (load_error_dialog) {
-				load_error_dialog->queue_free();
-			}
-			if (execute_output_dialog) {
-				execute_output_dialog->queue_free();
-			}
-			if (warning) {
-				warning->queue_free();
-			}
-			if (accept) {
-				accept->queue_free();
-			}
-			if (save_accept) {
-				save_accept->queue_free();
-			}
-			EditorHelp::save_script_doc_cache();
-			editor_data.save_editor_external_data();
-			EditorSettings::get_singleton()->save_project_metadata();
-			FileAccess::set_file_close_fail_notify_callback(nullptr);
-			log->deinit(); // Do not get messages anymore.
-			editor_data.clear_edited_scenes();
-			get_viewport()->disconnect("size_changed", callable_mp(this, &EditorNode::_viewport_resized));
 		} break;
 
 		case NOTIFICATION_READY: {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -710,6 +710,8 @@ private:
 
 	bool _is_project_data_missing();
 
+	void _scene_tree_finalizing();
+
 	enum MenuType {
 		MENU_TYPE_NONE,
 		MENU_TYPE_GLOBAL,

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -842,6 +842,8 @@ void SceneTree::process_tweens(double p_delta, bool p_physics) {
 }
 
 void SceneTree::finalize() {
+	emit_signal("_finalizing");
+
 	_flush_delete_queue();
 
 	_flush_ugc();
@@ -1951,6 +1953,7 @@ void SceneTree::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "multiplayer_poll"), "set_multiplayer_poll_enabled", "is_multiplayer_poll_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "physics_interpolation"), "set_physics_interpolation_enabled", "is_physics_interpolation_enabled");
 
+	ADD_SIGNAL(MethodInfo("_finalizing"));
 	ADD_SIGNAL(MethodInfo("tree_changed"));
 	ADD_SIGNAL(MethodInfo("scene_changed"));
 	ADD_SIGNAL(MethodInfo("tree_process_mode_changed")); //editor only signal, but due to API hash it can't be removed in run-time
@@ -2210,9 +2213,10 @@ SceneTree::~SceneTree() {
 		}
 		pending_new_scene_id = ObjectID();
 	}
+
 	if (root) {
-		root->_set_tree(nullptr);
-		root->_propagate_after_exit_tree();
+		// If root is inside the tree then `finalize` was not called.
+		DEV_ASSERT(!root->is_inside_tree());
 		memdelete(root);
 	}
 


### PR DESCRIPTION
Nodes in the edited scene and the inspector are not sending `tree_exited` when the editor is shutting down, even though they have sent `tree_entered` before.

Suppose the editor is editing a scene and the inspector is displaying a TextEdit from the edited scene.

1 The editor is about to quit.

2 `SceneTree.finalize` calls `_propagate_exit_tree` manually for all nodes.

2.1 `_propagate_exit_tree` is called on the EditorInspector and its subnodes.

2.2 `_propagate_exit_tree` is called on the TextEdit of the edited scene.  Since the inspector is displaying the TextEdit, `EditorInspector._node_removed` is called, which sets the displaying object to nullptr, which remove all subnodes and delete them. As they have been not in the tree since Step 2.1, `_propagate_after_exit_tree` will not be called and `tree_exited` will not be triggered.

2.3 `_propagate_exit_tree` is called on the other subnode of the edited scene and the scene itself. 

2.4 `_propagate_exit_tree` is called on the EditorNode. Its NOTIFICATION_EXIT_TREE handler deletes the edited scene. None of the nodes in the edited scene will trigger `tree_exited` since they have been not in the tree since Step 2.3.

3 `SceneTree.finalize` finishs calling `_propagate_exit_tree`. Then it calls `_propagate_after_exit_tree` (which will trigger `tree_exited`) on all the nodes. However, subnodes mentioned above have been deleted already.

A simple solution is letting SceneTree send a signal before finalization so the EditorNode and the inspector has a chance to remove those subnodes using the standard `Node.remove_child` method.

For convenience, here is a patch that shows the problem.

```diff
diff --git a/scene/main/node.cpp b/scene/main/node.cpp
index 7218287e23..934525dfd6 100644
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -57,6 +57,8 @@ SafeNumeric<uint64_t> Node::total_node_count{ 0 };
 
 thread_local Node *Node::current_process_thread_group = nullptr;
 
+static HashMap<Node *, String> Nodes;
+
 void Node::_notification(int p_notification) {
 	switch (p_notification) {
 		case NOTIFICATION_ACCESSIBILITY_INVALIDATE: {
@@ -351,6 +353,16 @@ void Node::_propagate_enter_tree() {
 		E.value.group = data.tree->add_to_group(E.key, this);
 	}
 
+	{
+		HashMap<Node *, String>::Iterator it = Nodes.find(this);
+		if (it == Nodes.end()) {
+			Nodes.insert(this, get_path().get_concatenated_names());
+		}
+		else {
+			WARN_PRINT(vformat("missing tree_exited.  (path: %s)", get_path().get_concatenated_names()));
+		}
+	}
+
 	notification(NOTIFICATION_ENTER_TREE);
 
 	GDVIRTUAL_CALL(_enter_tree);
@@ -398,6 +410,15 @@ void Node::_propagate_after_exit_tree() {
 
 	data.blocked--;
 
+	{
+		HashMap<Node *, String>::Iterator it = Nodes.find(this);
+		if (it != Nodes.end()) {
+			Nodes.remove(it);
+		}
+		else {
+			WARN_PRINT(vformat("missing tree_entered. (name: %s)", get_name()));
+		}
+	}
 	emit_signal(SceneStringName(tree_exited));
 }
 
@@ -4129,6 +4150,13 @@ Node::Node() {
 }
 
 Node::~Node() {
+	{
+		HashMap<Node *, String>::Iterator it = Nodes.find(this);
+		if (it != Nodes.end()) {
+			WARN_PRINT(vformat("missing tree_exited.  (path: %s)", it->value));
+		}
+	}
+
 	data.grouped.clear();
 	data.owned.clear();
 	data.children.clear();
```