### PR TITLE
Core: Don't strip data in `ClassDB::class_get_method_list`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1701,14 +1701,8 @@ TypedArray<Dictionary> ClassDB::class_get_method_list(const StringName &p_class,
 	::ClassDB::get_method_list(p_class, &methods, p_no_inheritance);
 	TypedArray<Dictionary> ret;
 
-	for (const MethodInfo &E : methods) {
-#ifdef DEBUG_ENABLED
-		ret.push_back(E.operator Dictionary());
-#else
-		Dictionary dict;
-		dict["name"] = E.name;
-		ret.push_back(dict);
-#endif // DEBUG_ENABLED
+	for (const MethodInfo &method : methods) {
+		ret.push_back(method.operator Dictionary());
 	}
 
 	return ret;


### PR DESCRIPTION
- Issue raised by [this RC thread](https://chat.godotengine.org/channel/core?msg=gDQ9cTBYnk5mGjpbS)

In #15337, `ClassDB::class_get_method_list` was adjusted to only return the names of the methods themselves. This was a 3.0 commit, made with the scope and constraints of `GDNative` in mind, which saw **much** less information retained in releases. However, now that we're well into 4.x with a more fully-formed `GDExtension` standard, it makes no sense to arbitrarily strip information for this specific method when that process has already occurred during the initial `MethodInfo` setup. This PR rectifies this issue by passing the data as-is uniformly, regardless of debug status