### PR TITLE
Remove dead definition `get_animation_libraries()` from AnimationMixer

### DIFF
--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -399,8 +399,6 @@ protected:
 
 public:
 	/* ---- Data lists ---- */
-	Dictionary *get_animation_libraries();
-
 	void get_animation_library_list(List<StringName> *p_animations) const;
 	Ref<AnimationLibrary> get_animation_library(const StringName &p_name) const;
 	bool has_animation_library(const StringName &p_name) const;


### PR DESCRIPTION
This function has not been implemented. The animation library handled by retrieving a list of names and the animation list within it.