### PR TITLE
Fix Make Unique for external sub-resources

### DIFF
--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -1408,7 +1408,7 @@ bool EditorResourcePicker::_is_uniqueness_enabled(bool p_check_recursive) {
 	}
 	Ref<Resource> parent_resource = _has_parent_resource();
 	EditorNode *en = EditorNode::get_singleton();
-	bool internal_to_scene = en->is_resource_internal_to_scene(edited_resource);
+	bool internal_to_scene = edited_resource->is_built_in();
 	List<Node *> node_list = en->get_editor_selection()->get_full_selected_node_list();
 
 	// Todo: Implement a more elegant solution for multiple selected Nodes. This should suffice for the time being.
@@ -1417,7 +1417,7 @@ bool EditorResourcePicker::_is_uniqueness_enabled(bool p_check_recursive) {
 	}
 
 	if (!internal_to_scene) {
-		if (parent_resource.is_valid() && (!EditorNode::get_singleton()->is_resource_internal_to_scene(parent_resource) || en->get_resource_count(parent_resource) > 1)) {
+		if (parent_resource.is_valid() && parent_resource->is_built_in() && (!EditorNode::get_singleton()->is_resource_internal_to_scene(parent_resource) || en->get_resource_count(parent_resource) > 1)) {
 			return false;
 		} else if (!p_check_recursive) {
 			return true;


### PR DESCRIPTION
Fixes #113414

It's not a complete fix, the tooltips are sometimes misleading/wrong or have [weird formatting](https://github.com/user-attachments/assets/12a51513-e50a-43d8-b03a-9e00c8978ec1). The unique indicator feature will need some fixes/improvements in 4.7. For now I just restored functionality that was wrongly blocked, I tried to keep the changes minimal.