### PR TITLE
Avoid warning when compiling on visionOS 26 SDK

### DIFF
--- a/drivers/apple_embedded/godot_view_controller.mm
+++ b/drivers/apple_embedded/godot_view_controller.mm
@@ -239,7 +239,7 @@
 
 // MARK: Orientation
 
-#if TARGET_OS_IPHONE
+#ifdef IOS_ENABLED
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
 	[super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 
@@ -255,7 +255,7 @@
 									 }
 								 }];
 }
-#endif // TARGET_OS_IPHONE
+#endif
 
 - (UIRectEdge)preferredScreenEdgesDeferringSystemGestures {
 	if (GLOBAL_GET("display/window/ios/suppress_ui_gesture")) {


### PR DESCRIPTION
Dear Godot community,

This small PR spun off https://github.com/godotengine/godot/pull/109975

It fixes a warning when compiling on visionOS 26 SDK. `#if TARGET_OS_IPHONE` applies when compiling the visionOS template, but #`ifdef IOS_ENABLED` does not.