### PR TITLE
Overhaul compute shader based environment roughness calculation to improve performance and quality

### DIFF
--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -1375,7 +1375,7 @@ void CopyEffects::octmap_roughness(RID p_source_rd_texture, RID p_dest_texture, 
 
 	// Remap to perceptual-roughness^2 to create more detail in lower mips and match the mapping of octmap_filter.
 	roughness.push_constant.roughness = p_roughness * p_roughness;
-	roughness.push_constant.sample_count = p_sample_count;
+	roughness.push_constant.sample_count = MIN(p_sample_count, 64u);
 	roughness.push_constant.source_size = p_source_size;
 	roughness.push_constant.dest_size = p_dest_size;
 	roughness.push_constant.use_direct_write = p_roughness == 0.0;
@@ -1432,7 +1432,7 @@ void CopyEffects::octmap_roughness_raster(RID p_source_rd_texture, RID p_dest_fr
 	memset(&roughness.push_constant, 0, sizeof(OctmapRoughnessPushConstant));
 
 	roughness.push_constant.roughness = p_roughness * p_roughness; // Shader expects roughness, not perceptual roughness, so multiply before passing in.
-	roughness.push_constant.sample_count = p_sample_count;
+	roughness.push_constant.sample_count = MAX(uint32_t(float(p_sample_count * 4u) * roughness.push_constant.roughness), 4u);
 	roughness.push_constant.source_size = p_source_size;
 	roughness.push_constant.dest_size = p_dest_size;
 	roughness.push_constant.use_direct_write = p_roughness == 0.0;

--- a/servers/rendering/renderer_rd/shaders/effects/octmap_roughness.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_roughness.glsl
@@ -8,6 +8,8 @@
 
 layout(local_size_x = GROUP_SIZE, local_size_y = GROUP_SIZE, local_size_z = 1) in;
 
+shared vec4 samples[GROUP_SIZE * GROUP_SIZE * 4]; // Up to 256 samples supported. Should never need more than that.
+
 layout(set = 0, binding = 0) uniform sampler2D source_oct;
 
 layout(OCTMAP_FORMAT, set = 1, binding = 0) uniform restrict writeonly image2D dest_octmap;
@@ -17,44 +19,64 @@ layout(OCTMAP_FORMAT, set = 1, binding = 0) uniform restrict writeonly image2D d
 
 void main() {
 	uvec2 id = gl_GlobalInvocationID.xy;
-	if (id.x < params.dest_size && id.y < params.dest_size) {
-		vec2 inv_source_size = 1.0 / vec2(params.source_size);
-		vec2 inv_dest_size = 1.0 / vec2(params.dest_size);
-		vec2 uv = (vec2(id.xy) + 0.5) * inv_dest_size;
-		if (params.use_direct_write) {
+	vec2 inv_source_size = 1.0 / vec2(params.source_size);
+	vec2 inv_dest_size = 1.0 / vec2(params.dest_size);
+	vec2 uv = (vec2(id.xy) + 0.5) * inv_dest_size;
+	if (params.use_direct_write) {
+		if (id.x < params.dest_size && id.y < params.dest_size) {
 			imageStore(dest_octmap, ivec2(id), vec4(texture(source_oct, uv).rgb, 1.0));
-		} else {
+		}
+	} else {
+		float solid_angle_texel = 4.0 * M_PI / float(params.dest_size * params.dest_size);
+		float roughness2 = params.roughness * params.roughness;
+		float roughness4 = roughness2 * roughness2;
+
+		uint scaled_samples = max(uint(float(params.sample_count * 4) * params.roughness), 4);
+
+		// This effectively rounds the sample count up to the nearest (GROUP_SIZE * GROUP_SIZE).
+		uint samples_per_thread = max(1, ((scaled_samples) / (GROUP_SIZE * GROUP_SIZE)));
+		uint total_samples = samples_per_thread * (GROUP_SIZE * GROUP_SIZE);
+
+		for (uint local_sample = 0; local_sample < samples_per_thread; local_sample++) {
+			uint sample_idx = local_sample * (GROUP_SIZE * GROUP_SIZE) + gl_LocalInvocationIndex;
+			vec2 xi = Hammersley(sample_idx, total_samples);
+			vec3 H_local = ImportanceSampleGGX(xi, roughness4);
+			float NdotH = H_local.z;
+			vec3 L_local = 2.0 * NdotH * H_local - vec3(0.0, 0.0, 1.0);
+
+			float ndotl = L_local.z;
+			if (ndotl > 0.0) {
+				float D = DistributionGGX(NdotH, roughness4);
+				float pdf = D * NdotH / (4.0 * NdotH) + 0.0001;
+
+				float solid_angle_sample = 1.0 / (float(total_samples) * pdf + 0.0001);
+
+				float mipLevel = 0.5 * log2(solid_angle_sample / solid_angle_texel);
+				samples[sample_idx] = vec4(L_local, mipLevel);
+			} else {
+				samples[sample_idx] = vec4(-1.0);
+			}
+		}
+
+		memoryBarrierShared();
+		barrier();
+
+		if (id.x < params.dest_size && id.y < params.dest_size) {
 			vec3 N = oct_to_vec3_with_border(uv, params.border_size.y);
 			vec4 sum = vec4(0.0, 0.0, 0.0, 0.0);
-			float solid_angle_texel = 4.0 * M_PI / float(params.dest_size * params.dest_size);
-			float roughness2 = params.roughness * params.roughness;
-			float roughness4 = roughness2 * roughness2;
-
-			vec3 UpVector = abs(N.y) < 0.999 ? vec3(0.0, 1.0, 0.0) : vec3(0.0, 0.0, 1.0);
+			vec3 UpVector = abs(N.y) < 0.99999 ? vec3(0.0, 1.0, 0.0) : vec3(0.0, 0.0, 1.0);
 			mat3 T;
 			T[0] = normalize(cross(UpVector, N));
 			T[1] = cross(N, T[0]);
 			T[2] = N;
 
-			for (uint sampleNum = 0u; sampleNum < params.sample_count; sampleNum++) {
-				vec2 xi = Hammersley(sampleNum, params.sample_count);
-
-				vec3 H = T * ImportanceSampleGGX(xi, roughness4);
-				float NdotH = dot(N, H);
-				vec3 L = (2.0 * NdotH * H - N);
-
-				float ndotl = clamp(dot(N, L), 0.0, 1.0);
-
+			for (uint i = 0; i < total_samples; i++) {
+				vec4 s = samples[i];
+				float ndotl = s.z;
 				if (ndotl > 0.0) {
-					float D = DistributionGGX(NdotH, roughness4);
-					float pdf = D * NdotH / (4.0 * NdotH) + 0.0001;
-
-					float solid_angle_sample = 1.0 / (float(params.sample_count) * pdf + 0.0001);
-
-					float mipLevel = params.roughness == 0.0 ? 0.0 : 0.5 * log2(solid_angle_sample / solid_angle_texel);
-
-					vec2 sample_uv = vec3_to_oct_with_border(L, params.border_size);
-					sum.rgb += textureLod(source_oct, sample_uv, mipLevel).rgb * ndotl;
+					vec3 L_world = T * s.xyz;
+					vec2 sample_uv = vec3_to_oct_with_border(L_world, params.border_size);
+					sum.rgb += textureLod(source_oct, sample_uv, s.w).rgb * ndotl;
 					sum.a += ndotl;
 				}
 			}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/114750

I still can't figure out exactly why the switch to octahedral coordinates seems to overall lower the quality of the environment prefiltering code. The artifacts seen in https://github.com/godotengine/godot/issues/114750 are undersampling artifacts that come from taking too few samples when doing the specular prefilter. The artifacts are present in 4.5.1 (see below), but they are more subtle. For some reason https://github.com/godotengine/godot/pull/107902 made the artifacts much worse, and then https://github.com/godotengine/godot/pull/114279 made them worse for this specific MRP. 

A note about the MRP. The sky used is absolutely the worst case for environment prefiltering. It has a single pixel of brightness 60000 while everything around it is around 30-40. These bad HDRIs tend to make the environment maps explode. Its amazing that Godot 4.5.1 looks as acceptable as it does. It is owing to a lot of work done by us to handle such garbage HDRIs floating around. _At any rate, the visual quality shouldn't degrade between versions, so there is something here for us to solve_

As I mentioned above, I never figured out exactly why the quality is reduced with octahedral maps. I have two theories:
1. Pixel density is lower, so you are in essence taking fewer samples overall
2. The pixel distribution of octahedral maps just simply makes the singularity worse (cubemaps have the lowest pixel density at the poles while octahedral maps have the highest pixel density at the poles)

At any rate, I have been meaning to do this optimization to improve the performance of the environment prefiltering. The optimization is twofold:
1. Precompute the sample directions in local space before sampling. We can share the samples in group shared memory so each thread only has to compute 1 sample position instead of all 32. 
2. Distribute samples more to the rough layers that need more samples. 

The first couple of layers only need a few samples, so there is no point in doing the full 32 for them. Whereas the rougher layers can benefit from having more. We can improve quality without changing the performance cost by taking more samples at the rough levels and fewer samples on the smooth levels. 

With these two changes, we have both improved quality and improved performance!

_Note: performance measurements are taken from my intel iGPU and are pretty rough, but they show that performance is relatively unchanged with this PR despite an increase in quality compared to 4.5.1 and master_


**_4.5.1: ~ 14 ms_**

<img width="747" height="764" alt="Screenshot from 2026-01-12 21-29-46" src="https://github.com/user-attachments/assets/d73c9fb4-feb4-4885-9c98-ef83c7918083" />

![oct-singularity-45](https://github.com/user-attachments/assets/1e39b629-3ab2-4922-8b56-dc6a234aae8d) _range adjusted so you can see the shape better_

**_Master: ~ 12 ms_**
<img width="640" height="640" alt="oct-singularity-before" src="https://github.com/user-attachments/assets/8a3005d1-2f42-4342-a013-758f53ec8ee4" />
<img width="747" height="764" alt="Screenshot from 2026-01-12 21-30-31" src="https://github.com/user-attachments/assets/5e63c2ab-1f5d-41f9-ba0c-0c9d20554df9" />

**_This PR: ~12 ms_**
<img width="747" height="764" alt="Screenshot from 2026-01-12 21-28-49" src="https://github.com/user-attachments/assets/fad8bf52-cab7-40a8-8473-e41ed26fa20f" />
<img width="640" height="640" alt="oct-singularity-after" src="https://github.com/user-attachments/assets/102d1638-e84f-49f7-b3bf-b9e3484d17b5" />
_The remaining stretching here is just the natural shape of the ocahedral encoding. It isn't visible when viewed over the surface of the sphere_
