### PR TITLE
Tweak quick open recursion error

### DIFF
--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -238,7 +238,7 @@ void EditorQuickOpenDialog::preview_property() {
 		HashSet<Resource *> resources_found;
 		resources_found.insert(res);
 		if (EditorNode::find_recursive_resources(loaded_resource, resources_found)) {
-			EditorToaster::get_singleton()->popup_str(TTR("Recursion detected, quick preview failed."), EditorToaster::SEVERITY_ERROR);
+			EditorToaster::get_singleton()->popup_str(TTR("Recursion detected, Instant Preview failed."), EditorToaster::SEVERITY_ERROR);
 			loaded_resource = Ref<Resource>();
 		}
 	}


### PR DESCRIPTION
Addresses https://github.com/godotengine/godot/pull/114881#discussion_r2683183059

Not sure if it should say "Instant Preview" or if "instant preview" would look better.