### PR TITLE
Document joypad vibration support over USB on macOS

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -433,7 +433,7 @@
 			<description>
 				Starts to vibrate the joypad. Joypads usually come with two rumble motors, a strong and a weak one. [param weak_magnitude] is the strength of the weak motor (between 0 and 1) and [param strong_magnitude] is the strength of the strong motor (between 0 and 1). [param duration] is the duration of the effect in seconds (a duration of 0 will try to play the vibration indefinitely). The vibration can be stopped early by calling [method stop_joy_vibration].
 				[b]Note:[/b] Not every hardware is compatible with long effect durations; it is recommended to restart an effect if it has to be played for more than a few seconds.
-				[b]Note:[/b] For macOS, vibration is only supported in macOS 11 and later.
+				[b]Note:[/b] For macOS, vibration is only supported in macOS 11 and later. When connected via USB, vibration is only supported for major brand controllers (except Xbox One and Xbox Series X/S controllers) due to macOS limitations.
 			</description>
 		</method>
 		<method name="stop_joy_vibration">


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/114822

Apparently, it's not possible to use HIDAPI for wired Xbox controllers on macOS:
https://github.com/godotengine/godot/blob/50277787eacaf4bc4d8683a706fe54dc65762020/thirdparty/sdl/joystick/hidapi/SDL_hidapi_xbox360.c#L62-L95
https://github.com/godotengine/godot/blob/50277787eacaf4bc4d8683a706fe54dc65762020/thirdparty/sdl/joystick/hidapi/SDL_hidapi_xboxone.c#L351-L362
And [Game Controller framework doesn't support vibration over USB](https://github.com/libsdl-org/SDL/issues/14800#issuecomment-3740168485).

As for the issue of Xbox Series X controller reporting itself as an Xbox One controller, both of them report "Xbox One" in their `productCategory` property, and GCController doesn't provide a way to retrieve a controller's vendor/product IDs other than relying on its name (see also [IOS_AddMFIJoystickDevice](https://github.com/godotengine/godot/blob/50277787eacaf4bc4d8683a706fe54dc65762020/thirdparty/sdl/joystick/apple/SDL_mfijoystick.m#L286)), so there's no way to differentiate them using GCController :(