### PR TITLE
Minor fixes for the project list item UI

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -127,8 +127,9 @@ void ProjectListItemControl::_notification(int p_what) {
 			if (pl) {
 				int idx = pl->get_index(this);
 				if (idx >= 0) {
+					// has_focus(true) is false on mouse-initiated focus, true on keyboard navigation.
+					pl->select_project(idx, !has_focus(true));
 					pl->ensure_project_visible(idx);
-					pl->select_project(idx);
 
 					pl->emit_signal(SNAME(ProjectList::SIGNAL_SELECTION_CHANGED));
 				}
@@ -356,6 +357,9 @@ ProjectListItemControl::ProjectListItemControl() {
 	set_focus_mode(FocusMode::FOCUS_ALL);
 	set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 
+	// Left spacer.
+	add_child(memnew(Control));
+
 	VBoxContainer *favorite_box = memnew(VBoxContainer);
 	favorite_box->set_alignment(BoxContainer::ALIGNMENT_CENTER);
 	add_child(favorite_box);
@@ -399,10 +403,6 @@ ProjectListItemControl::ProjectListItemControl() {
 
 		tag_container = memnew(HBoxContainer);
 		title_hb->add_child(tag_container);
-
-		Control *spacer = memnew(Control);
-		spacer->set_custom_minimum_size(Size2(10, 10));
-		title_hb->add_child(spacer);
 	}
 
 	// Bottom half, containing the path and view folder button.
@@ -414,6 +414,7 @@ ProjectListItemControl::ProjectListItemControl() {
 		explore_button = memnew(Button);
 		explore_button->set_name("ExploreButton");
 		explore_button->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
+		explore_button->set_mouse_filter(MOUSE_FILTER_PASS);
 		explore_button->set_tooltip_text(TTRC("Open in file manager"));
 		explore_button->set_flat(true);
 		path_hb->add_child(explore_button);
@@ -448,10 +449,6 @@ ProjectListItemControl::ProjectListItemControl() {
 		last_edited_info->set_tooltip_text(TTRC("Last edited timestamp"));
 		last_edited_info->set_modulate(Color(1, 1, 1, 0.5));
 		path_hb->add_child(last_edited_info);
-
-		Control *spacer = memnew(Control);
-		spacer->set_custom_minimum_size(Size2(10, 10));
-		path_hb->add_child(spacer);
 	}
 
 	if (DisplayServer::get_singleton()->is_touchscreen_available()) {
@@ -459,8 +456,12 @@ ProjectListItemControl::ProjectListItemControl() {
 		touch_menu_button->set_theme_type_variation(SceneStringName(FlatButton));
 		touch_menu_button->set_v_size_flags(SIZE_SHRINK_CENTER);
 		add_child(touch_menu_button);
+		touch_menu_button->set_mouse_filter(MOUSE_FILTER_PASS);
 		touch_menu_button->connect(SceneStringName(pressed), callable_mp(this, &ProjectListItemControl::_request_menu));
 	}
+
+	// Right spacer.
+	add_child(memnew(Control));
 }
 
 struct ProjectListComparator {

--- a/editor/project_manager/project_tag.cpp
+++ b/editor/project_manager/project_tag.cpp
@@ -63,6 +63,7 @@ ProjectTag::ProjectTag(const String &p_text, bool p_display_close) {
 	add_child(cr);
 	cr->set_custom_minimum_size(Vector2(4, 0) * EDSCALE);
 	cr->set_color(tag_color);
+	cr->set_mouse_filter(MOUSE_FILTER_PASS);
 
 	button = memnew(Button);
 	add_child(button);
@@ -72,4 +73,5 @@ ProjectTag::ProjectTag(const String &p_text, bool p_display_close) {
 	button->set_accessibility_name(vformat(TTR("Project Tag: %s"), p_text));
 	button->set_icon_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 	button->set_theme_type_variation(SNAME("ProjectTagButton"));
+	button->set_mouse_filter(MOUSE_FILTER_PASS);
 }


### PR DESCRIPTION
1. Adds missing margin to the left of the star.
2. Removes right spacers from the two rows in favor of a single spacer at the end of the project item. This gives better placement of the touch menu button on mobile.
3. Makes sure clicking on the favorite button with the mouse doesn't draw focus outline over the project item, while preserving the focus outline when navigating with keyboard.
4. Adds missing `MOUSE_FILTER_PASS` to the "Show in File Manager" button to make sure hover doesn't disapper from the project item when you hover over the button inside of it.
5. Same as above but for the project tags and the menu button on the right.

| Master | PR |
|--------|--------|
| ![1](https://github.com/user-attachments/assets/50bc96bb-5bc9-43a6-9476-d62a0a2b659e) | ![2](https://github.com/user-attachments/assets/38686357-fa64-4300-96ac-f9367850ad50) |
| ![3](https://github.com/user-attachments/assets/4a0280d0-48ef-4b0a-b3e4-8c16dbaec268) | ![4](https://github.com/user-attachments/assets/ef3ea124-de55-4acb-a4a4-6aaf5f5aeb67) |

_Note: The reason zero-size spacers work is that the project item is an `HBoxContainer` that has `separation` override set to `10`. Making spacers any bigger than `0` would result in unnecessary extra space._