### PR TITLE
Move runnable out of export preset

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -42,13 +42,17 @@ void EditorExport::_save() {
 	Ref<ConfigFile> credentials;
 	config.instantiate();
 	credentials.instantiate();
+
+	for (const KeyValue<Ref<EditorExportPlatform>, Ref<EditorExportPreset>> &E : runnable_presets) {
+		config->set_value(RUNNABLE_SECTION_NAME, E.key->get_name(), E.value->get_name());
+	}
+
 	for (int i = 0; i < export_presets.size(); i++) {
 		Ref<EditorExportPreset> preset = export_presets[i];
 		String section = "preset." + itos(i);
 
 		config->set_value(section, "name", preset->get_name());
 		config->set_value(section, "platform", preset->get_platform()->get_name());
-		config->set_value(section, "runnable", preset->is_runnable());
 		config->set_value(section, "dedicated_server", preset->is_dedicated_server());
 		config->set_value(section, "custom_features", preset->get_custom_features());
 
@@ -221,6 +225,26 @@ Vector<Ref<EditorExportPlugin>> EditorExport::get_export_plugins() {
 	return export_plugins;
 }
 
+void EditorExport::set_runnable_preset(const Ref<EditorExportPreset> &p_preset) {
+	runnable_presets[p_preset->get_platform()] = p_preset;
+	emit_presets_runnable_changed();
+	save_presets();
+}
+
+void EditorExport::unset_runnable_preset(const Ref<EditorExportPreset> &p_preset) {
+	const Ref<EditorExportPreset> *current = runnable_presets.getptr(p_preset->get_platform());
+	if (current && *current == p_preset) {
+		runnable_presets.erase(p_preset->get_platform());
+		emit_presets_runnable_changed();
+		save_presets();
+	}
+}
+
+Ref<EditorExportPreset> EditorExport::get_runnable_preset_for_platform(const Ref<EditorExportPlatform> &p_for_platform) const {
+	const Ref<EditorExportPreset> *preset = runnable_presets.getptr(p_for_platform);
+	return preset ? *preset : Ref<EditorExportPreset>();
+}
+
 void EditorExport::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
@@ -260,6 +284,13 @@ void EditorExport::load_config() {
 		return;
 	}
 
+	HashMap<String, String> runnable_loading;
+	if (config->has_section(RUNNABLE_SECTION_NAME)) {
+		for (const String &platform_name : config->get_section_keys(RUNNABLE_SECTION_NAME)) {
+			runnable_loading[platform_name] = config->get_value(RUNNABLE_SECTION_NAME, platform_name);
+		}
+	}
+
 	block_save = true;
 
 	int index = 0;
@@ -279,9 +310,17 @@ void EditorExport::load_config() {
 
 		Ref<EditorExportPreset> preset;
 
-		for (int i = 0; i < export_platforms.size(); i++) {
-			if (export_platforms[i]->get_name() == platform) {
-				preset = export_platforms.write[i]->create_preset();
+		for (Ref<EditorExportPlatform> &export_platform : export_platforms) {
+			if (export_platform->get_name() == platform) {
+				preset = export_platform->create_preset();
+
+				const String preset_name = config->get_value(section, "name");
+				preset->set_name(preset_name);
+
+				const String *runnable_preset = runnable_loading.getptr(export_platform->get_name());
+				if (runnable_preset && *runnable_preset == preset_name) {
+					runnable_presets[export_platform] = preset;
+				}
 				break;
 			}
 		}
@@ -291,8 +330,12 @@ void EditorExport::load_config() {
 			continue; // Unknown platform, skip without error (platform might be loaded later).
 		}
 
-		preset->set_name(config->get_value(section, "name"));
-		preset->set_runnable(config->get_value(section, "runnable"));
+#ifndef DISABLE_DEPRECATED
+		bool legacy_runnable = config->get_value(section, "runnable", false);
+		if (legacy_runnable) {
+			preset->set_runnable(true);
+		}
+#endif
 		preset->set_dedicated_server(config->get_value(section, "dedicated_server", false));
 
 		if (config->has_section_key(section, "custom_features")) {

--- a/editor/export/editor_export.h
+++ b/editor/export/editor_export.h
@@ -41,6 +41,9 @@ class EditorExport : public Node {
 	Vector<Ref<EditorExportPlatform>> export_platforms;
 	Vector<Ref<EditorExportPreset>> export_presets;
 	Vector<Ref<EditorExportPlugin>> export_plugins;
+	HashMap<Ref<EditorExportPlatform>, Ref<EditorExportPreset>> runnable_presets;
+
+	static inline const String RUNNABLE_SECTION_NAME = "runnable_presets";
 
 	static inline StringName _export_presets_updated;
 	static inline StringName _export_presets_runnable_updated;
@@ -84,6 +87,10 @@ public:
 	void add_export_plugin(const Ref<EditorExportPlugin> &p_plugin);
 	void remove_export_plugin(const Ref<EditorExportPlugin> &p_plugin);
 	Vector<Ref<EditorExportPlugin>> get_export_plugins();
+
+	void set_runnable_preset(const Ref<EditorExportPreset> &p_preset);
+	void unset_runnable_preset(const Ref<EditorExportPreset> &p_preset);
+	Ref<EditorExportPreset> get_runnable_preset_for_platform(const Ref<EditorExportPlatform> &p_for_platform) const;
 
 	void load_config();
 	void update_export_presets();

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -2477,17 +2477,7 @@ void EditorExportPlatformAppleEmbedded::_check_for_changes_poll_thread(void *ud)
 }
 
 void EditorExportPlatformAppleEmbedded::_update_preset_status() {
-	const int preset_count = EditorExport::get_singleton()->get_export_preset_count();
-	bool has_runnable = false;
-
-	for (int i = 0; i < preset_count; i++) {
-		const Ref<EditorExportPreset> &preset = EditorExport::get_singleton()->get_export_preset(i);
-		if (preset->get_platform() == this && preset->is_runnable()) {
-			has_runnable = true;
-			break;
-		}
-	}
-
+	bool has_runnable = EditorExport::get_singleton()->get_runnable_preset_for_platform(this).is_valid();
 	if (has_runnable) {
 		has_runnable_preset.set();
 	} else {

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -319,13 +319,15 @@ String EditorExportPreset::get_name() const {
 }
 
 void EditorExportPreset::set_runnable(bool p_enable) {
-	runnable = p_enable;
-	EditorExport::singleton->emit_presets_runnable_changed();
-	EditorExport::singleton->save_presets();
+	if (p_enable) {
+		EditorExport::singleton->set_runnable_preset(this);
+	} else {
+		EditorExport::singleton->unset_runnable_preset(this);
+	}
 }
 
 bool EditorExportPreset::is_runnable() const {
-	return runnable;
+	return EditorExport::singleton->get_runnable_preset_for_platform(platform).ptr() == this;
 }
 
 bool EditorExportPreset::are_advanced_options_enabled() const {

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -69,7 +69,6 @@ private:
 	String exporter;
 	HashSet<String> selected_files;
 	HashMap<String, FileExportMode> customized_files;
-	bool runnable = false;
 	bool dedicated_server = false;
 
 	Vector<String> patches;

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -151,16 +151,12 @@ void ProjectExportDialog::_add_preset(int p_platform) {
 	ERR_FAIL_COND(preset.is_null());
 
 	String preset_name = EditorExport::get_singleton()->get_export_platform(p_platform)->get_name();
-	bool make_runnable = true;
 	int attempt = 1;
 	while (true) {
 		bool valid = true;
 
 		for (int i = 0; i < EditorExport::get_singleton()->get_export_preset_count(); i++) {
 			Ref<EditorExportPreset> p = EditorExport::get_singleton()->get_export_preset(i);
-			if (p->get_platform() == preset->get_platform() && p->is_runnable()) {
-				make_runnable = false;
-			}
 			if (p->get_name() == preset_name) {
 				valid = false;
 				break;
@@ -176,8 +172,8 @@ void ProjectExportDialog::_add_preset(int p_platform) {
 	}
 
 	preset->set_name(preset_name);
-	if (make_runnable) {
-		preset->set_runnable(make_runnable);
+	if (EditorExport::get_singleton()->get_runnable_preset_for_platform(preset->get_platform()).is_null()) {
+		EditorExport::get_singleton()->set_runnable_preset(preset);
 	}
 	EditorExport::get_singleton()->add_export_preset(preset);
 	_update_presets();
@@ -525,14 +521,9 @@ void ProjectExportDialog::_runnable_pressed() {
 	ERR_FAIL_COND(current.is_null());
 
 	if (runnable->is_pressed()) {
-		for (int i = 0; i < EditorExport::get_singleton()->get_export_preset_count(); i++) {
-			Ref<EditorExportPreset> p = EditorExport::get_singleton()->get_export_preset(i);
-			if (p->get_platform() == current->get_platform()) {
-				p->set_runnable(current == p);
-			}
-		}
+		EditorExport::get_singleton()->set_runnable_preset(current);
 	} else {
-		current->set_runnable(false);
+		EditorExport::get_singleton()->unset_runnable_preset(current);
 	}
 
 	_update_presets();
@@ -726,15 +717,11 @@ void ProjectExportDialog::_duplicate_preset() {
 	ERR_FAIL_COND(preset.is_null());
 
 	String preset_name = current->get_name() + " (copy)";
-	bool make_runnable = true;
 	while (true) {
 		bool valid = true;
 
 		for (int i = 0; i < EditorExport::get_singleton()->get_export_preset_count(); i++) {
 			Ref<EditorExportPreset> p = EditorExport::get_singleton()->get_export_preset(i);
-			if (p->get_platform() == preset->get_platform() && p->is_runnable()) {
-				make_runnable = false;
-			}
 			if (p->get_name() == preset_name) {
 				valid = false;
 				break;
@@ -749,8 +736,8 @@ void ProjectExportDialog::_duplicate_preset() {
 	}
 
 	preset->set_name(preset_name);
-	if (make_runnable) {
-		preset->set_runnable(make_runnable);
+	if (EditorExport::get_singleton()->get_runnable_preset_for_platform(preset->get_platform()).is_null()) {
+		EditorExport::get_singleton()->set_runnable_preset(preset);
 	}
 	preset->set_dedicated_server(current->is_dedicated_server());
 	preset->set_export_filter(current->get_export_filter());

--- a/editor/run/editor_run_native.cpp
+++ b/editor/run/editor_run_native.cpp
@@ -49,20 +49,19 @@ void EditorRunNative::_notification(int p_what) {
 				PopupMenu *popup = remote_debug->get_popup();
 				popup->clear();
 				int device_shortcut_id = 1;
-				for (int i = 0; i < EditorExport::get_singleton()->get_export_preset_count(); i++) {
-					Ref<EditorExportPreset> preset = EditorExport::get_singleton()->get_export_preset(i);
-					Ref<EditorExportPlatform> eep = preset->get_platform();
-					if (eep.is_null()) {
+				for (int i = 0; i < EditorExport::get_singleton()->get_export_platform_count(); i++) {
+					Ref<EditorExportPlatform> eep = EditorExport::get_singleton()->get_export_platform(i);
+					Ref<EditorExportPreset> preset = EditorExport::get_singleton()->get_runnable_preset_for_platform(eep);
+					if (preset.is_null()) {
 						continue;
 					}
-					const int platform_idx = EditorExport::get_singleton()->get_export_platform_index_by_name(eep->get_name());
 					const int device_count = MIN(eep->get_options_count(), 9000);
 					String error;
-					if (device_count > 0 && preset->is_runnable()) {
+					if (device_count > 0) {
 						popup->add_icon_item(eep->get_run_icon(), eep->get_name(), -1);
 						popup->set_item_disabled(-1, true);
 						for (int j = 0; j < device_count; j++) {
-							popup->add_icon_item(eep->get_option_icon(j), eep->get_option_label(j), EditorExport::encode_platform_device_id(platform_idx, j));
+							popup->add_icon_item(eep->get_option_icon(j), eep->get_option_label(j), EditorExport::encode_platform_device_id(i, j));
 							popup->set_item_tooltip(-1, eep->get_option_tooltip(j));
 							popup->set_item_indent(-1, 2);
 							if (device_shortcut_id <= 4 && eep->is_option_runnable(j)) {
@@ -106,16 +105,7 @@ Error EditorRunNative::start_run_native(int p_id) {
 	Ref<EditorExportPlatform> eep = EditorExport::get_singleton()->get_export_platform(platform);
 	ERR_FAIL_COND_V(eep.is_null(), ERR_UNAVAILABLE);
 
-	Ref<EditorExportPreset> preset;
-
-	for (int i = 0; i < EditorExport::get_singleton()->get_export_preset_count(); i++) {
-		Ref<EditorExportPreset> ep = EditorExport::get_singleton()->get_export_preset(i);
-		if (ep->is_runnable() && ep->get_platform() == eep) {
-			preset = ep;
-			break;
-		}
-	}
-
+	Ref<EditorExportPreset> preset = EditorExport::get_singleton()->get_runnable_preset_for_platform(eep);
 	if (preset.is_null()) {
 		EditorNode::get_singleton()->show_warning(TTR("No runnable export preset found for this platform.\nPlease add a runnable preset in the Export menu or define an existing preset as runnable."));
 		return ERR_UNAVAILABLE;

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -459,17 +459,7 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 }
 
 void EditorExportPlatformAndroid::_update_preset_status() {
-	const int preset_count = EditorExport::get_singleton()->get_export_preset_count();
-	bool has_runnable = false;
-
-	for (int i = 0; i < preset_count; i++) {
-		const Ref<EditorExportPreset> &preset = EditorExport::get_singleton()->get_export_preset(i);
-		if (preset->get_platform() == this && preset->is_runnable()) {
-			has_runnable = true;
-			break;
-		}
-	}
-
+	bool has_runnable = EditorExport::get_singleton()->get_runnable_preset_for_platform(this).is_valid();
 	if (has_runnable) {
 		has_runnable_preset.set();
 	} else {

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -404,15 +404,7 @@ Ref<Texture2D> EditorExportPlatformLinuxBSD::get_run_icon() const {
 }
 
 bool EditorExportPlatformLinuxBSD::poll_export() {
-	Ref<EditorExportPreset> preset;
-
-	for (int i = 0; i < EditorExport::get_singleton()->get_export_preset_count(); i++) {
-		Ref<EditorExportPreset> ep = EditorExport::get_singleton()->get_export_preset(i);
-		if (ep->is_runnable() && ep->get_platform() == this) {
-			preset = ep;
-			break;
-		}
-	}
+	Ref<EditorExportPreset> preset = EditorExport::get_singleton()->get_runnable_preset_for_platform(this);
 
 	int prev = menu_options;
 	menu_options = (preset.is_valid() && preset->get("ssh_remote_deploy/enabled").operator bool());

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -2610,15 +2610,7 @@ Ref<Texture2D> EditorExportPlatformMacOS::get_run_icon() const {
 }
 
 bool EditorExportPlatformMacOS::poll_export() {
-	Ref<EditorExportPreset> preset;
-
-	for (int i = 0; i < EditorExport::get_singleton()->get_export_preset_count(); i++) {
-		Ref<EditorExportPreset> ep = EditorExport::get_singleton()->get_export_preset(i);
-		if (ep->is_runnable() && ep->get_platform() == this) {
-			preset = ep;
-			break;
-		}
-	}
+	Ref<EditorExportPreset> preset = EditorExport::get_singleton()->get_runnable_preset_for_platform(this);
 
 	int prev = menu_options;
 	menu_options = (preset.is_valid() && preset->get("ssh_remote_deploy/enabled").operator bool());

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -614,15 +614,7 @@ Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_p
 }
 
 bool EditorExportPlatformWeb::poll_export() {
-	Ref<EditorExportPreset> preset;
-
-	for (int i = 0; i < EditorExport::get_singleton()->get_export_preset_count(); i++) {
-		Ref<EditorExportPreset> ep = EditorExport::get_singleton()->get_export_preset(i);
-		if (ep->is_runnable() && ep->get_platform() == this) {
-			preset = ep;
-			break;
-		}
-	}
+	Ref<EditorExportPreset> preset = EditorExport::get_singleton()->get_runnable_preset_for_platform(this);
 
 	RemoteDebugState prev_remote_debug_state = remote_debug_state;
 	remote_debug_state = REMOTE_DEBUG_STATE_UNAVAILABLE;

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -921,15 +921,7 @@ Ref<Texture2D> EditorExportPlatformWindows::get_run_icon() const {
 }
 
 bool EditorExportPlatformWindows::poll_export() {
-	Ref<EditorExportPreset> preset;
-
-	for (int i = 0; i < EditorExport::get_singleton()->get_export_preset_count(); i++) {
-		Ref<EditorExportPreset> ep = EditorExport::get_singleton()->get_export_preset(i);
-		if (ep->is_runnable() && ep->get_platform() == this) {
-			preset = ep;
-			break;
-		}
-	}
+	Ref<EditorExportPreset> preset = EditorExport::get_singleton()->get_runnable_preset_for_platform(this);
 
 	int prev = menu_options;
 	menu_options = (preset.is_valid() && preset->get("ssh_remote_deploy/enabled").operator bool());


### PR DESCRIPTION
Similar to #109356, this moves runnable property out of export preset. Each platform has only up to one runnable export preset. When you make a preset runnable, the previous one's status is revoked. So it does not make much sense to keep this information as part of the preset.

I added a HashMap of Platform->Preset for runnable presets. Finding a runnable preset for a platform no longer involves iterating all presets. Consequently, `runnable` is no longer stored as part of the preset, but in a new section of `export_presets.cfg` called `runnable_presets`.

There is no compatibility breakage.