### PR TITLE
Fix dock tab styles not updating when changed in Editor Settings

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1070,6 +1070,9 @@ void EditorNode::_notification(int p_what) {
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/dragging_")) {
 				theme->set_constant("dragging_unfold_wait_msec", "Tree", (float)EDITOR_GET("interface/editor/dragging_hover_wait_seconds") * 1000);
 				theme->set_constant("hover_switch_wait_msec", "TabBar", (float)EDITOR_GET("interface/editor/dragging_hover_wait_seconds") * 1000);
+			}
+
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor")) {
 				editor_dock_manager->update_tab_styles();
 			}
 


### PR DESCRIPTION
After #114829, dock tab styles wouldn’t update when changed in the Editor Settings.

This PR adds a new check for changes to the tab style settings and refreshes them accordingly.