### PR TITLE
Fix LightmapGI not considering Light3D negative flag.

### DIFF
--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1189,7 +1189,9 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 			// For the lightmapper, the indirect energy represents the multiplier for the indirect bounces caused by the light, so the value is not converted when using physical units.
 			float indirect_energy = light->get_param(Light3D::PARAM_INDIRECT_ENERGY);
 			Color linear_color = light->get_color().srgb_to_linear();
-			float energy = light->get_param(Light3D::PARAM_ENERGY);
+			float sign = light->is_negative() ? -1 : 1;
+			float energy = sign * light->get_param(Light3D::PARAM_ENERGY);
+
 			if (use_physical_light_units) {
 				energy *= light->get_param(Light3D::PARAM_INTENSITY);
 				linear_color *= light->get_correlated_color().srgb_to_linear();


### PR DESCRIPTION
Fixes #114819

LightmapGI currently does not consider the negative flag from lights. This PR is a "naive" fix by inverting the lights energy, as in other parts of the code base. I did not check the light mappers code in detail to verify this is valid for this specific case.

**Results**
With the example project provided by #114819 this exhibits the following behaviour:

<img width="1118" height="713" alt="image" src="https://github.com/user-attachments/assets/ae7cc2f3-8bd3-4cef-b6af-402511bb3846" />

I also increased to baked lights energy and increased the light map size to get a similar look. With the values from the original MRP I could not visually see the baked lights at all.

