### PR TITLE
Core: Fix RID_Alloc Lock-Free Reads on Weakly-Ordered Architectures

### DIFF
--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -26,7 +26,7 @@ jobs:
 
       # From https://github.com/actions/runner-images/blob/main/images/macos
       - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.0.1.app
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -39,7 +39,7 @@ jobs:
 
       # From https://github.com/actions/runner-images/blob/main/images/macos
       - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.0.1.app
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore

--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -152,8 +152,8 @@ class RID_Alloc : public RID_AllocBase {
 			}
 
 			if constexpr (THREAD_SAFE) {
-				// Store atomically to avoid data race with the load in get_or_null().
-				((std::atomic<uint32_t> *)&max_alloc)->store(max_alloc + elements_in_chunk, std::memory_order_relaxed);
+				// Release ensures all chunk initialization is visible to acquire-load readers.
+				((std::atomic<uint32_t> *)&max_alloc)->store(max_alloc + elements_in_chunk, std::memory_order_release);
 			} else {
 				max_alloc += elements_in_chunk;
 			}
@@ -169,8 +169,8 @@ class RID_Alloc : public RID_AllocBase {
 		id <<= 32;
 		id |= free_index;
 
-		chunks[free_chunk][free_element].validator = validator;
-		chunks[free_chunk][free_element].validator |= 0x80000000; //mark uninitialized bit
+		// Release ensures validator is visible to acquire-load readers.
+		((std::atomic<uint32_t> *)&chunks[free_chunk][free_element].validator)->store(validator | 0x80000000, std::memory_order_release);
 
 		alloc_count++;
 
@@ -203,15 +203,12 @@ public:
 			return nullptr;
 		}
 
-		if constexpr (THREAD_SAFE) {
-			SYNC_ACQUIRE;
-		}
-
 		uint64_t id = p_rid.get_id();
 		uint32_t idx = uint32_t(id & 0xFFFFFFFF);
 		uint32_t ma;
-		if constexpr (THREAD_SAFE) { // Read atomically to avoid data race with the store in _allocate_rid().
-			ma = ((std::atomic<uint32_t> *)&max_alloc)->load(std::memory_order_relaxed);
+		if constexpr (THREAD_SAFE) {
+			// Acquire synchronizes with release-store in _allocate_rid(), ensuring chunk data is visible.
+			ma = ((std::atomic<uint32_t> *)&max_alloc)->load(std::memory_order_acquire);
 		} else {
 			ma = max_alloc;
 		}
@@ -224,50 +221,38 @@ public:
 
 		uint32_t validator = uint32_t(id >> 32);
 
+		uint32_t cur_validator;
 		if constexpr (THREAD_SAFE) {
-#ifdef TSAN_ENABLED
-			__tsan_acquire(&chunks[idx_chunk]); // We know not a race in practice.
-			__tsan_acquire(&chunks[idx_chunk][idx_element]); // We know not a race in practice.
-#endif
-		}
-
-		Chunk &c = chunks[idx_chunk][idx_element];
-
-		if constexpr (THREAD_SAFE) {
-#ifdef TSAN_ENABLED
-			__tsan_release(&chunks[idx_chunk]);
-			__tsan_release(&chunks[idx_chunk][idx_element]);
-			__tsan_acquire(&c.validator); // We know not a race in practice.
-#endif
+			// Acquire synchronizes with release-store in _allocate_rid().
+			cur_validator = ((std::atomic<uint32_t> *)&chunks[idx_chunk][idx_element].validator)->load(std::memory_order_acquire);
+		} else {
+			cur_validator = chunks[idx_chunk][idx_element].validator;
 		}
 
 		if (unlikely(p_initialize)) {
-			if (unlikely(!(c.validator & 0x80000000))) {
+			if (unlikely(!(cur_validator & 0x80000000))) {
 				ERR_FAIL_V_MSG(nullptr, "Initializing already initialized RID");
 			}
 
-			if (unlikely((c.validator & 0x7FFFFFFF) != validator)) {
+			if (unlikely((cur_validator & 0x7FFFFFFF) != validator)) {
 				ERR_FAIL_V_MSG(nullptr, "Attempting to initialize the wrong RID");
 			}
 
-			c.validator &= 0x7FFFFFFF; //initialized
+			if constexpr (THREAD_SAFE) {
+				// Release ensures initialized data is visible before clearing init bit.
+				((std::atomic<uint32_t> *)&chunks[idx_chunk][idx_element].validator)->store(cur_validator & 0x7FFFFFFF, std::memory_order_release);
+			} else {
+				chunks[idx_chunk][idx_element].validator = cur_validator & 0x7FFFFFFF;
+			}
 
-		} else if (unlikely(c.validator != validator)) {
-			if ((c.validator & 0x80000000) && c.validator != 0xFFFFFFFF) {
+		} else if (unlikely(cur_validator != validator)) {
+			if ((cur_validator & 0x80000000) && cur_validator != 0xFFFFFFFF) {
 				ERR_FAIL_V_MSG(nullptr, "Attempting to use an uninitialized RID");
 			}
 			return nullptr;
 		}
 
-		if constexpr (THREAD_SAFE) {
-#ifdef TSAN_ENABLED
-			__tsan_release(&c.validator);
-#endif
-		}
-
-		T *ptr = &c.data;
-
-		return ptr;
+		return &chunks[idx_chunk][idx_element].data;
 	}
 	void initialize_rid(RID p_rid) {
 		T *mem = get_or_null(p_rid, true);
@@ -314,15 +299,12 @@ public:
 			return false;
 		}
 
-		if constexpr (THREAD_SAFE) {
-			SYNC_ACQUIRE;
-		}
-
 		uint64_t id = p_rid.get_id();
 		uint32_t idx = uint32_t(id & 0xFFFFFFFF);
 		uint32_t ma;
 		if constexpr (THREAD_SAFE) {
-			ma = ((std::atomic<uint32_t> *)&max_alloc)->load(std::memory_order_relaxed);
+			// Acquire synchronizes with release-store in _allocate_rid(), ensuring chunk data is visible.
+			ma = ((std::atomic<uint32_t> *)&max_alloc)->load(std::memory_order_acquire);
 		} else {
 			ma = max_alloc;
 		}
@@ -336,32 +318,15 @@ public:
 
 		uint32_t validator = uint32_t(id >> 32);
 
+		uint32_t cur_validator;
 		if constexpr (THREAD_SAFE) {
-#ifdef TSAN_ENABLED
-			__tsan_acquire(&chunks[idx_chunk]); // We know not a race in practice.
-			__tsan_acquire(&chunks[idx_chunk][idx_element]); // We know not a race in practice.
-#endif
+			// Acquire synchronizes with release-store in _allocate_rid().
+			cur_validator = ((std::atomic<uint32_t> *)&chunks[idx_chunk][idx_element].validator)->load(std::memory_order_acquire);
+		} else {
+			cur_validator = chunks[idx_chunk][idx_element].validator;
 		}
 
-		Chunk &c = chunks[idx_chunk][idx_element];
-
-		if constexpr (THREAD_SAFE) {
-#ifdef TSAN_ENABLED
-			__tsan_release(&chunks[idx_chunk]);
-			__tsan_release(&chunks[idx_chunk][idx_element]);
-			__tsan_acquire(&c.validator); // We know not a race in practice.
-#endif
-		}
-
-		bool owned = (c.validator & 0x7FFFFFFF) == validator;
-
-		if constexpr (THREAD_SAFE) {
-#ifdef TSAN_ENABLED
-			__tsan_release(&c.validator);
-#endif
-		}
-
-		return owned;
+		return (cur_validator & 0x7FFFFFFF) == validator;
 	}
 
 	_FORCE_INLINE_ void free(const RID &p_rid) {


### PR DESCRIPTION
Fixes #114900

This PR fixes a memory ordering bug in `RID_Alloc` that caused data races on weakly-ordered architectures (ARM, Apple Silicon, POWER, RISC-V). The fix adds proper `memory_order_release`/`memory_order_acquire` semantics to both `max_alloc` and `validator` atomic operations.

> [!IMPORTANT]
>
> 🤖 AI disclosure
>
> I used AI to help identify and fix the issue. I also used AI to help describe the problem in detail, which I reviewed and edited. I have reviewed the code, understand it and tested a release build with the original MRP, Bistro Demo, and can confirm it works with commit 91c9e27596e99eddc2747954f4871b2de9abbe65.


## The Bug

The `RID_Alloc` class uses a lock-free read path in `get_or_null()` and `owns()` for performance. These functions read shared state without holding the mutex, but the original code used `memory_order_relaxed` which provides no ordering guarantees.

### Original Code (Broken)

```cpp
// In _allocate_rid() - writer side
chunks[chunk_count][i].validator = 0xFFFFFFFF;     // 1. Initialize chunk (rare, when growing)
((std::atomic<uint32_t> *)&max_alloc)->store(...,
    std::memory_order_relaxed);                     // 2. Publish chunk (NO ordering)
chunks[idx][elem].validator = validator | 0x80000000; // 3. Set validator (EVERY allocation)
mutex.unlock();

// In get_or_null() / owns() - reader side
SYNC_ACQUIRE;  // ← Fence BEFORE load (wrong position!)
ma = ((std::atomic<uint32_t> *)&max_alloc)->load(
    std::memory_order_relaxed);                     // ← NO ordering guarantee
// ... access validator (non-atomic read!)
```

### The Race Conditions

**Race 1: Chunk initialization (when growing)**
1. Thread A initializes chunk data, stores `max_alloc` with relaxed ordering
2. Thread B loads `max_alloc` with relaxed ordering, sees new value
3. Thread B accesses chunk but sees **stale/uninitialized data**

**Race 2: Validator (every allocation)**
1. Thread A writes `validator` (non-atomic), unlocks mutex
2. Thread B loads `max_alloc`, accesses `validator`
3. Thread B sees **stale validator** because there's no synchronization

The second race is the critical one—`max_alloc` only changes when chunks grow (rare), but `validator` changes on every allocation.

## Why `WEAK_MEMORY_ORDER 1` Didn't Fix It

The codebase had a `WEAK_MEMORY_ORDER` macro that used `atomic_thread_fence`:

```cpp
#define SYNC_ACQUIRE std::atomic_thread_fence(std::memory_order_acquire);
```

This failed for two reasons:

### Problem 1: Fence Position
```cpp
SYNC_ACQUIRE;  // Fence here...
ma = load(max_alloc, relaxed);  // ...then load (WRONG!)
```

Acquire fences must come **after** the load, not before.

### Problem 2: No Synchronization on Validator

Even with correct `max_alloc` synchronization, the `validator` field was accessed non-atomically. The `max_alloc` release/acquire only synchronizes chunk structure, not per-slot validator writes.

## The Fix

### Change 1: Release Store for Validator in `_allocate_rid()`

```cpp
// Before: two non-atomic writes
chunks[free_chunk][free_element].validator = validator;
chunks[free_chunk][free_element].validator |= 0x80000000;

// After: single atomic release store
((std::atomic<uint32_t> *)&chunks[free_chunk][free_element].validator)
    ->store(validator | 0x80000000, std::memory_order_release);
```

**What `memory_order_release` guarantees:**

A release store acts as a one-way barrier that prevents **preceding** operations from being reordered **after** it:

```
writes to chunks[n]           ─┐
writes to free_list           │  Cannot move below the release store
                              ─┘
         ▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
   store(validator, release)  [RELEASE BARRIER]
         ▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
```

This ensures that when another thread observes the validator, all initialization that preceded the store is guaranteed visible.

### Change 2: Acquire Load for Validator in `get_or_null()` and `owns()`

```cpp
// Before: non-atomic read with misplaced fence
SYNC_ACQUIRE;
// ... later ...
if (c.validator != validator) { ... }

// After: atomic acquire load
uint32_t cur_validator;
if constexpr (THREAD_SAFE) {
    cur_validator = ((std::atomic<uint32_t> *)&chunks[idx_chunk][idx_element].validator)
        ->load(std::memory_order_acquire);
} else {
    cur_validator = chunks[idx_chunk][idx_element].validator;
}
```

**What `memory_order_acquire` guarantees:**

An acquire load acts as a one-way barrier that prevents **subsequent** operations from being reordered **before** it:

```
         ▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
   load(validator, acquire)   [ACQUIRE BARRIER]
         ▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
                              ─┐
read chunk data                │  Cannot move above the acquire load
                              ─┘
```

### Change 3: Release Store in `get_or_null()` When Clearing Init Bit

```cpp
if constexpr (THREAD_SAFE) {
    ((std::atomic<uint32_t> *)&chunks[idx_chunk][idx_element].validator)
        ->store(cur_validator & 0x7FFFFFFF, std::memory_order_release);
} else {
    chunks[idx_chunk][idx_element].validator = cur_validator & 0x7FFFFFFF;
}
```

### Change 4: Retain `max_alloc` Release/Acquire

The `max_alloc` synchronization is still needed for chunk structure visibility:

```cpp
// _allocate_rid() - when growing chunks
((std::atomic<uint32_t> *)&max_alloc)->store(max_alloc + elements_in_chunk, std::memory_order_release);

// get_or_null() / owns()
ma = ((std::atomic<uint32_t> *)&max_alloc)->load(std::memory_order_acquire);
```

## Complete Synchronization Model

```
Thread A (_allocate_rid):              Thread B (get_or_null/owns):
────────────────────────              ────────────────────────────
[if growing chunks:]
  init chunk data
  store(max_alloc, release)  ────────► load(max_alloc, acquire)
                                              │
store(validator, release)    ────────────────►│
                                              ▼
                                       load(validator, acquire)
                                              │
                                              ▼
                                       access data ✓
```

Both synchronization points are necessary:
- `max_alloc`: ensures chunk structure is visible (when chunks grow)
- `validator`: ensures per-slot allocation is visible (every allocation)

## How This Works on Different Architectures

### Strongly-Ordered (x86/x64)

x86 has Total Store Order (TSO) where stores aren't reordered with stores, and loads aren't reordered with loads. The original `relaxed` operations happened to work at the hardware level, but the compiler could still reorder. With `release`/`acquire`, the compiler is constrained and hardware behavior is unchanged.

### Weakly-Ordered (ARM/Apple Silicon)

ARM permits almost any reordering unless explicitly prevented:

- **Release store** compiles to `STLR` instruction—all prior writes complete first
- **Acquire load** compiles to `LDAR` instruction—all subsequent reads wait

The C++ memory model abstracts this, making the code portable across all architectures.

## Why Lock-Free Instead of Mutex?

The lock-free read path provides:

1. **No contention**: Multiple readers proceed simultaneously
2. **No syscalls**: Mutex operations may involve kernel transitions
3. **Better scalability**: Critical for frequently-called `owns()` validation

The trade-off is complexity, but with proper acquire-release semantics on both `max_alloc` and `validator`, the code is correct and efficient.

## TSAN Annotations Removed

The previous code had `__tsan_acquire`/`__tsan_release` annotations to suppress ThreadSanitizer warnings. These are no longer needed because the atomic operations with proper memory ordering are recognized by TSAN as correct synchronization.

## References

- [C++ Memory Model](https://en.cppreference.com/w/cpp/atomic/memory_order)
- [ARM Memory Model](https://developer.arm.com/documentation/102336/0100/Memory-ordering)
- [Preshing on Programming: Acquire and Release Semantics](https://preshing.com/20120913/acquire-and-release-semantics/)
