### PR TITLE
Fix ColorPicker overflow on small screens

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -191,36 +191,40 @@ void ColorPicker::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_RESIZED: {
-			const Size2 viewport_size = get_viewport_rect().size;
-			const int focused_window = DisplayServer::get_singleton()->get_focused_window();
-			const Size2 window_size = DisplayServer::get_singleton()->window_get_size(focused_window);
+			if (preset_just_toggled) {
+				preset_just_toggled = false;
 
-			const int child_count = shape_container ? shape_container->get_child_count() : 0;
+				const Size2 viewport_size = get_viewport_rect().size;
+				const int focused_window = DisplayServer::get_singleton()->get_focused_window();
+				const Size2 window_size = DisplayServer::get_singleton()->window_get_size(focused_window);
 
-			if ((int)shape_child_original_mins.size() != child_count) {
-				shape_child_original_mins.clear();
-				shape_child_original_mins.reserve(child_count);
+				const int child_count = shape_container ? shape_container->get_child_count() : 0;
+
+				if ((int)shape_child_original_mins.size() != child_count) {
+					shape_child_original_mins.clear();
+					shape_child_original_mins.reserve(child_count);
+					for (int i = 0; i < child_count; i++) {
+						Control *c = Object::cast_to<Control>(shape_container->get_child(i));
+						shape_child_original_mins.push_back(c ? c->get_custom_minimum_size() : Size2());
+					}
+				}
+
+				const bool out_of_bounds = viewport_size.y >= window_size.y * 0.85f;
+
+				float scale_factor = 1.0f;
+				if (out_of_bounds) {
+					scale_factor = (window_size.y * 0.85f) / viewport_size.y;
+					scale_factor = CLAMP(scale_factor, 0.5f, 1.0f);
+				}
+
 				for (int i = 0; i < child_count; i++) {
 					Control *c = Object::cast_to<Control>(shape_container->get_child(i));
-					shape_child_original_mins.push_back(c ? c->get_custom_minimum_size() : Size2());
+					if (!c) {
+						continue;
+					}
+					const Size2 orig = shape_child_original_mins[i];
+					c->set_custom_minimum_size(orig * scale_factor);
 				}
-			}
-
-			const bool out_of_bounds = viewport_size.y >= window_size.y * 0.85f;
-
-			float scale_factor = 1.0f;
-			if (out_of_bounds) {
-				scale_factor = (window_size.y * 0.85f) / viewport_size.y;
-				scale_factor = CLAMP(scale_factor, 0.5f, 1.0f);
-			}
-
-			for (int i = 0; i < child_count; i++) {
-				Control *c = Object::cast_to<Control>(shape_container->get_child(i));
-				if (!c) {
-					continue;
-				}
-				const Size2 orig = shape_child_original_mins[i];
-				c->set_custom_minimum_size(orig * scale_factor);
 			}
 		} break;
 
@@ -1048,6 +1052,8 @@ void ColorPicker::_show_hide_preset(const bool &p_is_btn_pressed, Button *p_btn_
 		p_preset_container->hide();
 	}
 	_update_drop_down_arrow(p_is_btn_pressed, p_btn_preset);
+
+	preset_just_toggled = true;
 
 	palette_name->hide();
 	if (btn_preset->is_pressed() && !palette_name->get_text().is_empty()) {

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -190,6 +190,31 @@ void ColorPicker::_notification(int p_what) {
 			}
 		} break;
 
+		case NOTIFICATION_RESIZED: {
+			const Size2 viewport_size = get_viewport_rect().size;
+			const Size2 usable_size = DisplayServer::get_singleton()->screen_get_usable_rect(DisplayServer::SCREEN_WITH_MOUSE_FOCUS).size;
+			const bool out_of_bounds = viewport_size.y >= usable_size.y;
+
+			const int child_count = shape_container ? shape_container->get_child_count() : 0;
+			if (shape_child_original_mins.size() != child_count) {
+				shape_child_original_mins.clear();
+				shape_child_original_mins.reserve(child_count);
+				for (int i = 0; i < child_count; i++) {
+					Control *c = cast_to<Control>(shape_container->get_child(i));
+					shape_child_original_mins.push_back(c ? c->get_custom_minimum_size() : Size2());
+				}
+			}
+
+			for (int i = 0; i < child_count; i++) {
+				Control *c = cast_to<Control>(shape_container->get_child(i));
+				if (!c) {
+					continue;
+				}
+				const Size2 orig = shape_child_original_mins[i];
+				c->set_custom_minimum_size(out_of_bounds ? orig * 0.8f : orig);
+			}
+		} break;
+
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (!is_picking_color) {
 				Input *input = Input::get_singleton();

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -196,22 +196,23 @@ void ColorPicker::_notification(int p_what) {
 			const bool out_of_bounds = viewport_size.y >= usable_size.y;
 
 			const int child_count = shape_container ? shape_container->get_child_count() : 0;
-			if (shape_child_original_mins.size() != child_count) {
+
+			if ((int)shape_child_original_mins.size() != child_count) {
 				shape_child_original_mins.clear();
 				shape_child_original_mins.reserve(child_count);
 				for (int i = 0; i < child_count; i++) {
-					Control *c = cast_to<Control>(shape_container->get_child(i));
+					Control *c = Object::cast_to<Control>(shape_container->get_child(i));
 					shape_child_original_mins.push_back(c ? c->get_custom_minimum_size() : Size2());
 				}
 			}
 
 			for (int i = 0; i < child_count; i++) {
-				Control *c = cast_to<Control>(shape_container->get_child(i));
+				Control *c = Object::cast_to<Control>(shape_container->get_child(i));
 				if (!c) {
 					continue;
 				}
 				const Size2 orig = shape_child_original_mins[i];
-				c->set_custom_minimum_size(out_of_bounds ? orig * 0.8f : orig);
+				c->set_custom_minimum_size(out_of_bounds ? (orig * 0.8f) : orig);
 			}
 		} break;
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -192,8 +192,8 @@ void ColorPicker::_notification(int p_what) {
 
 		case NOTIFICATION_RESIZED: {
 			const Size2 viewport_size = get_viewport_rect().size;
-			const Size2 usable_size = DisplayServer::get_singleton()->screen_get_usable_rect(DisplayServer::SCREEN_WITH_MOUSE_FOCUS).size;
-			const bool out_of_bounds = viewport_size.y >= usable_size.y;
+			const int focused_window = DisplayServer::get_singleton()->get_focused_window();
+			const Size2 window_size = DisplayServer::get_singleton()->window_get_size(focused_window);
 
 			const int child_count = shape_container ? shape_container->get_child_count() : 0;
 
@@ -206,13 +206,21 @@ void ColorPicker::_notification(int p_what) {
 				}
 			}
 
+			const bool out_of_bounds = viewport_size.y >= window_size.y * 0.85f;
+
+			float scale_factor = 1.0f;
+			if (out_of_bounds) {
+				scale_factor = (window_size.y * 0.85f) / viewport_size.y;
+				scale_factor = CLAMP(scale_factor, 0.5f, 1.0f);
+			}
+
 			for (int i = 0; i < child_count; i++) {
 				Control *c = Object::cast_to<Control>(shape_container->get_child(i));
 				if (!c) {
 					continue;
 				}
 				const Size2 orig = shape_child_original_mins[i];
-				c->set_custom_minimum_size(out_of_bounds ? (orig * 0.8f) : orig);
+				c->set_custom_minimum_size(orig * scale_factor);
 			}
 		} break;
 

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -187,6 +187,7 @@ private:
 
 	LocalVector<ColorMode *> modes;
 	LocalVector<ColorPickerShape *> shapes;
+	LocalVector<Size2> shape_child_original_mins;
 
 	Popup *picker_window = nullptr;
 	TextureRect *picker_texture_zoom = nullptr;

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -188,6 +188,7 @@ private:
 	LocalVector<ColorMode *> modes;
 	LocalVector<ColorPickerShape *> shapes;
 	LocalVector<Size2> shape_child_original_mins;
+	bool preset_just_toggled = false;
 
 	Popup *picker_window = nullptr;
 	TextureRect *picker_texture_zoom = nullptr;


### PR DESCRIPTION
Fix: https://github.com/godotengine/godot/issues/108972

On small screens (Android), expanding Swatches/Recent can push the `ColorPicker` past the usable screen height. This updates `ColorPicker` to shrink `shape_container` children in `NOTIFICATION_RESIZED` when the picker exceeds the usable screen height, and restores the original custom minimum sizes when it fits again, preventing the swatches/recent section from extending off-screen.

Before changes:

https://github.com/user-attachments/assets/1fabf129-9b41-4290-add5-97431faafa5d

After changes:

https://github.com/user-attachments/assets/f679f76a-d3fb-4c40-8924-5f3ccaa798ee

Note, tested on standard build to ensure popup does not change size:

https://github.com/user-attachments/assets/60c439a3-2057-4507-b76c-1661097fdcde

Note: Caches each child’s `custom_minimum_size()` on first resize to restore later. If preferred, the cache can be refreshed on theme changes or captured earlier (e.g. on ready) instead of during resize.