### PR TITLE
Allow enabling additional Vulkan extensions for external memory sharing

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1830,6 +1830,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_RST(PropertyInfo(Variant::BOOL, "rendering/rendering_device/pipeline_cache/enable"), true);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/rendering_device/pipeline_cache/save_chunk_size_mb", PROPERTY_HINT_RANGE, "0.000001,64.0,0.001,or_greater"), 3.0);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/rendering_device/vulkan/max_descriptors_per_pool", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), 64);
+	GLOBAL_DEF(PropertyInfo(Variant::PACKED_STRING_ARRAY, "rendering/rendering_device/vulkan/additional_device_extensions"), PackedStringArray());
 
 	GLOBAL_DEF_RST("rendering/rendering_device/d3d12/max_resource_descriptors", 65536);
 	custom_prop_info["rendering/rendering_device/d3d12/max_resource_descriptors"] = PropertyInfo(Variant::INT, "rendering/rendering_device/d3d12/max_resource_descriptors", PROPERTY_HINT_RANGE, "512,1000000");

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1830,7 +1830,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_RST(PropertyInfo(Variant::BOOL, "rendering/rendering_device/pipeline_cache/enable"), true);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/rendering_device/pipeline_cache/save_chunk_size_mb", PROPERTY_HINT_RANGE, "0.000001,64.0,0.001,or_greater"), 3.0);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/rendering_device/vulkan/max_descriptors_per_pool", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), 64);
-	GLOBAL_DEF(PropertyInfo(Variant::PACKED_STRING_ARRAY, "rendering/rendering_device/vulkan/additional_device_extensions"), PackedStringArray());
+	GLOBAL_DEF_RST(PropertyInfo(Variant::PACKED_STRING_ARRAY, "rendering/rendering_device/vulkan/additional_device_extensions"), PackedStringArray());
 
 	GLOBAL_DEF_RST("rendering/rendering_device/d3d12/max_resource_descriptors", 65536);
 	custom_prop_info["rendering/rendering_device/d3d12/max_resource_descriptors"] = PropertyInfo(Variant::INT, "rendering/rendering_device/d3d12/max_resource_descriptors", PROPERTY_HINT_RANGE, "512,1000000");

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3409,6 +3409,12 @@
 			[b]Note:[/b] Changes to this setting will only be applied on startup or when the swapchain is recreated (e.g. when setting the V-Sync mode).
 			[b]Note:[/b] Some platforms may restrict the actual value.
 		</member>
+		<member name="rendering/rendering_device/vulkan/additional_device_extensions" type="PackedStringArray" setter="" getter="" default="PackedStringArray()">
+			Additional Vulkan device extensions to enable. These extensions will be requested as optional during Vulkan device creation. If an extension is not supported by the hardware, it will be silently ignored.
+			This is useful for GDExtensions that need specific Vulkan extensions for functionality like external memory sharing (e.g., [code]VK_KHR_external_memory_win32[/code] on Windows, [code]VK_EXT_metal_objects[/code] on macOS via MoltenVK, [code]VK_EXT_external_memory_dma_buf[/code] on Linux).
+			Use [method RenderingDevice.get_device_enabled_extensions] to check which extensions were successfully enabled.
+			[b]Note:[/b] Changing this property requires a restart to take effect.
+		</member>
 		<member name="rendering/rendering_device/vulkan/max_descriptors_per_pool" type="int" setter="" getter="" default="64">
 			The number of descriptors per pool. Godot's Vulkan backend uses linear pools for descriptors that will be created and destroyed within a single frame. Instead of destroying every single descriptor every frame, they all can be destroyed at once by resetting the pool they belong to.
 			A larger number is more efficient up to a limit, after that it will only waste RAM (maximum efficiency is achieved when there is no more than 1 pool per frame). A small number could end up with one pool per descriptor, which negatively impacts performance.

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -599,6 +599,14 @@
 				Returns the universally unique identifier for the pipeline cache. This is used to cache shader files on disk, which avoids shader recompilations on subsequent engine runs. This UUID varies depending on the graphics card model, but also the driver version. Therefore, updating graphics drivers will invalidate the shader cache.
 			</description>
 		</method>
+		<method name="get_device_enabled_extensions" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns an array of Vulkan device extensions that are currently enabled. This is useful for GDExtensions that need to verify whether specific Vulkan extensions (such as external memory extensions) were successfully enabled.
+				Additional extensions can be requested via the [member ProjectSettings.rendering/rendering_device/vulkan/additional_device_extensions] project setting.
+				[b]Note:[/b] This method only returns meaningful results when using the Vulkan rendering backend. For other backends (D3D12, Metal), an empty array is returned.
+			</description>
+		</method>
 		<method name="get_device_total_memory" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -578,6 +578,14 @@
 				This is only used by Vulkan in debug builds and can return 0 when this information is not tracked or unknown.
 			</description>
 		</method>
+		<method name="get_device_enabled_extensions" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns an array of Vulkan device extensions that are currently enabled. This is useful for GDExtensions that need to verify whether specific Vulkan extensions (such as external memory extensions) were successfully enabled.
+				Additional extensions can be requested via the [member ProjectSettings.rendering/rendering_device/vulkan/additional_device_extensions] project setting.
+				[b]Note:[/b] This method only returns meaningful results when using the Vulkan rendering backend. For other backends (D3D12, Metal), an empty array is returned.
+			</description>
+		</method>
 		<method name="get_device_memory_by_object_type" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="type" type="int" />
@@ -597,14 +605,6 @@
 			<return type="String" />
 			<description>
 				Returns the universally unique identifier for the pipeline cache. This is used to cache shader files on disk, which avoids shader recompilations on subsequent engine runs. This UUID varies depending on the graphics card model, but also the driver version. Therefore, updating graphics drivers will invalidate the shader cache.
-			</description>
-		</method>
-		<method name="get_device_enabled_extensions" qualifiers="const">
-			<return type="PackedStringArray" />
-			<description>
-				Returns an array of Vulkan device extensions that are currently enabled. This is useful for GDExtensions that need to verify whether specific Vulkan extensions (such as external memory extensions) were successfully enabled.
-				Additional extensions can be requested via the [member ProjectSettings.rendering/rendering_device/vulkan/additional_device_extensions] project setting.
-				[b]Note:[/b] This method only returns meaningful results when using the Vulkan rendering backend. For other backends (D3D12, Metal), an empty array is returned.
 			</description>
 		</method>
 		<method name="get_device_total_memory" qualifiers="const">

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -615,6 +615,8 @@ Error RenderingDeviceDriverVulkan::_initialize_device_extensions() {
 		}
 	}
 
+	_register_requested_device_extension(VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME, false);
+
 	// Register additional device extensions from project settings.
 	{
 		PackedStringArray additional_extensions = GLOBAL_GET("rendering/rendering_device/vulkan/additional_device_extensions");
@@ -625,8 +627,6 @@ Error RenderingDeviceDriverVulkan::_initialize_device_extensions() {
 			}
 		}
 	}
-
-	_register_requested_device_extension(VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME, false);
 
 	uint32_t device_extension_count = 0;
 	VkResult err = vkEnumerateDeviceExtensionProperties(physical_device, nullptr, &device_extension_count, nullptr);

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -615,6 +615,17 @@ Error RenderingDeviceDriverVulkan::_initialize_device_extensions() {
 		}
 	}
 
+	// Register additional device extensions from project settings.
+	{
+		PackedStringArray additional_extensions = GLOBAL_GET("rendering/rendering_device/vulkan/additional_device_extensions");
+		for (int i = 0; i < additional_extensions.size(); i++) {
+			CharString extension_name = additional_extensions[i].utf8();
+			if (!requested_device_extensions.has(extension_name)) {
+				_register_requested_device_extension(extension_name, false);
+			}
+		}
+	}
+
 	_register_requested_device_extension(VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME, false);
 
 	uint32_t device_extension_count = 0;
@@ -7457,6 +7468,14 @@ const RDD::Capabilities &RenderingDeviceDriverVulkan::get_capabilities() const {
 
 const RenderingShaderContainerFormat &RenderingDeviceDriverVulkan::get_shader_container_format() const {
 	return shader_container_format;
+}
+
+PackedStringArray RenderingDeviceDriverVulkan::get_enabled_device_extensions() const {
+	PackedStringArray extensions;
+	for (const CharString &extension_name : enabled_device_extension_names) {
+		extensions.push_back(String::utf8(extension_name));
+	}
+	return extensions;
 }
 
 bool RenderingDeviceDriverVulkan::is_composite_alpha_supported(CommandQueueID p_queue) const {

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -618,8 +618,8 @@ Error RenderingDeviceDriverVulkan::_initialize_device_extensions() {
 	// Register additional device extensions from project settings.
 	{
 		PackedStringArray additional_extensions = GLOBAL_GET("rendering/rendering_device/vulkan/additional_device_extensions");
-		for (int i = 0; i < additional_extensions.size(); i++) {
-			CharString extension_name = additional_extensions[i].utf8();
+		for (const String &additional_extension : additional_extensions) {
+			CharString extension_name = additional_extension.utf8();
 			if (!requested_device_extensions.has(extension_name)) {
 				_register_requested_device_extension(extension_name, false);
 			}

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -803,6 +803,7 @@ public:
 	virtual String get_pipeline_cache_uuid() const override final;
 	virtual const Capabilities &get_capabilities() const override final;
 	virtual const RenderingShaderContainerFormat &get_shader_container_format() const override final;
+	virtual PackedStringArray get_enabled_device_extensions() const override final;
 
 	virtual bool is_composite_alpha_supported(CommandQueueID p_queue) const override final;
 

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -7866,6 +7866,10 @@ RenderingDevice::DriverWorkarounds RenderingDevice::get_driver_workarounds() con
 	return driver->get_driver_workarounds();
 }
 
+PackedStringArray RenderingDevice::get_device_enabled_extensions() const {
+	return driver->get_enabled_device_extensions();
+}
+
 void RenderingDevice::swap_buffers(bool p_present) {
 	ERR_RENDER_THREAD_GUARD();
 
@@ -9215,6 +9219,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_device_vendor_name"), &RenderingDevice::get_device_vendor_name);
 	ClassDB::bind_method(D_METHOD("get_device_name"), &RenderingDevice::get_device_name);
 	ClassDB::bind_method(D_METHOD("get_device_pipeline_cache_uuid"), &RenderingDevice::get_device_pipeline_cache_uuid);
+	ClassDB::bind_method(D_METHOD("get_device_enabled_extensions"), &RenderingDevice::get_device_enabled_extensions);
 
 	ClassDB::bind_method(D_METHOD("get_memory_usage", "type"), &RenderingDevice::get_memory_usage);
 

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1947,6 +1947,7 @@ public:
 	String get_device_api_name() const;
 	String get_device_api_version() const;
 	String get_device_pipeline_cache_uuid() const;
+	PackedStringArray get_device_enabled_extensions() const;
 
 	DriverWorkarounds get_driver_workarounds() const;
 

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -947,6 +947,7 @@ public:
 	virtual String get_pipeline_cache_uuid() const = 0;
 	virtual const Capabilities &get_capabilities() const = 0;
 	virtual const RenderingShaderContainerFormat &get_shader_container_format() const = 0;
+	virtual PackedStringArray get_enabled_device_extensions() const { return PackedStringArray(); }
 
 	virtual bool is_composite_alpha_supported(CommandQueueID p_queue) const { return false; }
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

This PR adds a project setting that allows developers to specify additional Vulkan device extensions to enable at runtime, along with an API to query which extensions are currently enabled.

## Solution

This PR introduces:

1. New project setting: `rendering/rendering_device/vulkan/additional_device_extensions`
    - A PackedStringArray of Vulkan extension names to request
    - Extensions are registered as optional, so unsupported extensions won't cause initialization failures
2. New API method: `RenderingDevice.get_device_enabled_extensions()`
    - Returns all currently enabled Vulkan device extensions
    - Allows GDExtensions to verify whether their requested extensions were successfully enabled
    - Returns empty array for non-Vulkan backends (D3D12, Metal)

## Usage Example

project.godot:

```ini
[rendering]
rendering_device/vulkan/additional_device_extensions=PackedStringArray("VK_KHR_external_memory_win32")
```

GDScript:
```gdscript
var rd = RenderingServer.get_rendering_device()
var extensions = rd.get_device_enabled_extensions()
if "VK_KHR_external_memory_win32" in extensions:
  # Extension is available, can use external memory features
  pass
```

## Implementation Details
- Extensions specified in the project setting are registered as optional (not required), so if hardware doesn't support them, Godot will continue to work normally
- The setting is read during `_initialize_device_extensions()` in the Vulkan driver
- D3D12 and Metal backends use the default implementation returning an empty array

Related Issues:
- Closes https://github.com/godotengine/godot-proposals/issues/13969

