### PR TITLE
Optimize Shape3D triangle parsing

### DIFF
--- a/doc/classes/Shape3D.xml
+++ b/doc/classes/Shape3D.xml
@@ -17,6 +17,13 @@
 				Returns the [ArrayMesh] used to draw the debug collision for this [Shape3D].
 			</description>
 		</method>
+		<method name="get_triangles" qualifiers="const">
+			<return type="PackedVector3Array" />
+			<description>
+				Returns the shape as an array of vertices to form triangles. Useful for shape parsers and geometry tests. The array (with a length divisible by three) is naturally divided into triples; each triple of vertices defines a triangle. The triangles will be created on the first call to this function and cached. Further calls to this functions without changes to the shape will return the cached copy.
+				[b]Note:[/b] For shapes with rounded elements (e.g. circles or capsules) this will create very coarse geometry with limited roundness. If more detail is needed consider using an actual [Mesh].
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="custom_solver_bias" type="float" setter="set_custom_solver_bias" getter="get_custom_solver_bias" default="0.0">

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -1499,69 +1499,90 @@ void GridMap::navmesh_parse_source_geometry(const Ref<NavigationMesh> &p_navigat
 	}
 #ifndef PHYSICS_3D_DISABLED
 	else if ((parsed_geometry_type == NavigationMesh::PARSED_GEOMETRY_STATIC_COLLIDERS || parsed_geometry_type == NavigationMesh::PARSED_GEOMETRY_BOTH) && (gridmap->get_collision_layer() & parsed_collision_mask)) {
+		AHashMap<RID, Vector<Vector3>> shape_triangles_cache;
+
 		Array shapes = gridmap->get_collision_shapes();
 		for (int i = 0; i < shapes.size(); i += 2) {
+			const Transform3D &shape_transform = shapes[i];
 			RID shape = shapes[i + 1];
+
+			Vector<Vector3> *cached_triangles = shape_triangles_cache.getptr(shape);
+			if (cached_triangles) {
+				p_source_geometry_data->add_faces(*cached_triangles, shape_transform);
+				continue;
+			}
+
 			PhysicsServer3D::ShapeType type = PhysicsServer3D::get_singleton()->shape_get_type(shape);
 			Variant data = PhysicsServer3D::get_singleton()->shape_get_data(shape);
 
 			switch (type) {
 				case PhysicsServer3D::SHAPE_SPHERE: {
 					real_t radius = data;
-					Array arr;
-					arr.resize(RS::ARRAY_MAX);
-					SphereMesh::create_mesh_array(arr, radius, radius * 2.0);
-					p_source_geometry_data->add_mesh_array(arr, shapes[i]);
+
+					int radial_segments = 16;
+					int rings = 8;
+
+					Vector<Vector3> triangles = SphereShape3D::create_triangles(radius, radial_segments, rings);
+					shape_triangles_cache.insert(shape, triangles);
+					if (!triangles.is_empty()) {
+						p_source_geometry_data->add_faces(triangles, shape_transform);
+					}
 				} break;
 				case PhysicsServer3D::SHAPE_BOX: {
 					Vector3 extents = data;
-					Array arr;
-					arr.resize(RS::ARRAY_MAX);
-					BoxMesh::create_mesh_array(arr, extents * 2.0);
-					p_source_geometry_data->add_mesh_array(arr, shapes[i]);
+
+					Vector3 box_size = extents * 2.0;
+
+					Vector<Vector3> triangles = BoxShape3D::create_triangles(box_size);
+					shape_triangles_cache.insert(shape, triangles);
+					if (!triangles.is_empty()) {
+						p_source_geometry_data->add_faces(triangles, shape_transform);
+					}
 				} break;
 				case PhysicsServer3D::SHAPE_CAPSULE: {
 					Dictionary dict = data;
 					real_t radius = dict["radius"];
 					real_t height = dict["height"];
-					Array arr;
-					arr.resize(RS::ARRAY_MAX);
-					CapsuleMesh::create_mesh_array(arr, radius, height);
-					p_source_geometry_data->add_mesh_array(arr, shapes[i]);
+
+					int radial_segments = 16;
+					int rings = 4; // top&bottom hemisphere and cylinder all loop over rings.
+
+					Vector<Vector3> triangles = CapsuleShape3D::create_triangles(radius, height, radial_segments, rings);
+					shape_triangles_cache.insert(shape, triangles);
+					if (!triangles.is_empty()) {
+						p_source_geometry_data->add_faces(triangles, shape_transform);
+					}
 				} break;
 				case PhysicsServer3D::SHAPE_CYLINDER: {
 					Dictionary dict = data;
 					real_t radius = dict["radius"];
 					real_t height = dict["height"];
-					Array arr;
-					arr.resize(RS::ARRAY_MAX);
-					CylinderMesh::create_mesh_array(arr, radius, radius, height);
-					p_source_geometry_data->add_mesh_array(arr, shapes[i]);
+
+					int radial_segments = 16;
+
+					Vector<Vector3> triangles = CylinderShape3D::create_triangles(radius, height, radial_segments);
+					shape_triangles_cache.insert(shape, triangles);
+					if (!triangles.is_empty()) {
+						p_source_geometry_data->add_faces(triangles, shape_transform);
+					}
 				} break;
 				case PhysicsServer3D::SHAPE_CONVEX_POLYGON: {
-					PackedVector3Array vertices = data;
-					Geometry3D::MeshData md;
+					Vector<Vector3> points = data;
 
-					Error err = ConvexHullComputer::convex_hull(vertices, md);
+					Vector<Vector3> triangles = ConvexPolygonShape3D::create_triangles(points);
 
-					if (err == OK) {
-						PackedVector3Array faces;
-
-						for (const Geometry3D::MeshData::Face &face : md.faces) {
-							for (uint32_t k = 2; k < face.indices.size(); ++k) {
-								faces.push_back(md.vertices[face.indices[0]]);
-								faces.push_back(md.vertices[face.indices[k - 1]]);
-								faces.push_back(md.vertices[face.indices[k]]);
-							}
-						}
-
-						p_source_geometry_data->add_faces(faces, shapes[i]);
+					if (!triangles.is_empty()) {
+						p_source_geometry_data->add_faces(triangles, shape_transform);
 					}
 				} break;
 				case PhysicsServer3D::SHAPE_CONCAVE_POLYGON: {
 					Dictionary dict = data;
-					PackedVector3Array faces = Variant(dict["faces"]);
-					p_source_geometry_data->add_faces(faces, shapes[i]);
+
+					Vector<Vector3> triangles = Variant(dict["faces"]);
+					shape_triangles_cache.insert(shape, triangles);
+					if (!triangles.is_empty()) {
+						p_source_geometry_data->add_faces(triangles, shape_transform);
+					}
 				} break;
 				case PhysicsServer3D::SHAPE_HEIGHTMAP: {
 					Dictionary dict = data;
@@ -1572,28 +1593,10 @@ void GridMap::navmesh_parse_source_geometry(const Ref<NavigationMesh> &p_navigat
 					if (heightmap_depth >= 2 && heightmap_width >= 2) {
 						const Vector<real_t> &map_data = dict["heights"];
 
-						Vector2 heightmap_gridsize(heightmap_width - 1, heightmap_depth - 1);
-						Vector3 start = Vector3(heightmap_gridsize.x, 0, heightmap_gridsize.y) * -0.5;
-
-						Vector<Vector3> vertex_array;
-						vertex_array.resize((heightmap_depth - 1) * (heightmap_width - 1) * 6);
-						Vector3 *vertex_array_ptrw = vertex_array.ptrw();
-						const real_t *map_data_ptr = map_data.ptr();
-						int vertex_index = 0;
-
-						for (int d = 0; d < heightmap_depth - 1; d++) {
-							for (int w = 0; w < heightmap_width - 1; w++) {
-								vertex_array_ptrw[vertex_index] = start + Vector3(w, map_data_ptr[(heightmap_width * d) + w], d);
-								vertex_array_ptrw[vertex_index + 1] = start + Vector3(w + 1, map_data_ptr[(heightmap_width * d) + w + 1], d);
-								vertex_array_ptrw[vertex_index + 2] = start + Vector3(w, map_data_ptr[(heightmap_width * d) + heightmap_width + w], d + 1);
-								vertex_array_ptrw[vertex_index + 3] = start + Vector3(w + 1, map_data_ptr[(heightmap_width * d) + w + 1], d);
-								vertex_array_ptrw[vertex_index + 4] = start + Vector3(w + 1, map_data_ptr[(heightmap_width * d) + heightmap_width + w + 1], d + 1);
-								vertex_array_ptrw[vertex_index + 5] = start + Vector3(w, map_data_ptr[(heightmap_width * d) + heightmap_width + w], d + 1);
-								vertex_index += 6;
-							}
-						}
-						if (vertex_array.size() > 0) {
-							p_source_geometry_data->add_faces(vertex_array, shapes[i]);
+						Vector<Vector3> triangles = HeightMapShape3D::create_triangles(heightmap_depth, heightmap_depth, map_data);
+						shape_triangles_cache.insert(shape, triangles);
+						if (!triangles.is_empty()) {
+							p_source_geometry_data->add_faces(triangles, shape_transform);
 						}
 					}
 				} break;

--- a/scene/3d/physics/static_body_3d.cpp
+++ b/scene/3d/physics/static_body_3d.cpp
@@ -135,94 +135,57 @@ void StaticBody3D::navmesh_parse_source_geometry(const Ref<NavigationMesh> &p_na
 
 				BoxShape3D *box = Object::cast_to<BoxShape3D>(*s);
 				if (box) {
-					Array arr;
-					arr.resize(RS::ARRAY_MAX);
-					BoxMesh::create_mesh_array(arr, box->get_size());
-					p_source_geometry_data->add_mesh_array(arr, transform);
+					Vector<Vector3> triangles = box->get_triangles();
+					if (!triangles.is_empty()) {
+						p_source_geometry_data->add_faces(triangles, transform);
+					}
 				}
 
 				CapsuleShape3D *capsule = Object::cast_to<CapsuleShape3D>(*s);
 				if (capsule) {
-					Array arr;
-					arr.resize(RS::ARRAY_MAX);
-					CapsuleMesh::create_mesh_array(arr, capsule->get_radius(), capsule->get_height());
-					p_source_geometry_data->add_mesh_array(arr, transform);
+					Vector<Vector3> triangles = capsule->get_triangles();
+					if (!triangles.is_empty()) {
+						p_source_geometry_data->add_faces(triangles, transform);
+					}
 				}
 
 				CylinderShape3D *cylinder = Object::cast_to<CylinderShape3D>(*s);
 				if (cylinder) {
-					Array arr;
-					arr.resize(RS::ARRAY_MAX);
-					CylinderMesh::create_mesh_array(arr, cylinder->get_radius(), cylinder->get_radius(), cylinder->get_height());
-					p_source_geometry_data->add_mesh_array(arr, transform);
+					Vector<Vector3> triangles = cylinder->get_triangles();
+					if (!triangles.is_empty()) {
+						p_source_geometry_data->add_faces(triangles, transform);
+					}
 				}
 
 				SphereShape3D *sphere = Object::cast_to<SphereShape3D>(*s);
 				if (sphere) {
-					Array arr;
-					arr.resize(RS::ARRAY_MAX);
-					SphereMesh::create_mesh_array(arr, sphere->get_radius(), sphere->get_radius() * 2.0);
-					p_source_geometry_data->add_mesh_array(arr, transform);
+					Vector<Vector3> triangles = sphere->get_triangles();
+					if (!triangles.is_empty()) {
+						p_source_geometry_data->add_faces(triangles, transform);
+					}
 				}
 
 				ConcavePolygonShape3D *concave_polygon = Object::cast_to<ConcavePolygonShape3D>(*s);
 				if (concave_polygon) {
-					p_source_geometry_data->add_faces(concave_polygon->get_faces(), transform);
+					Vector<Vector3> triangles = concave_polygon->get_triangles();
+					if (!triangles.is_empty()) {
+						p_source_geometry_data->add_faces(triangles, transform);
+					}
 				}
 
 				ConvexPolygonShape3D *convex_polygon = Object::cast_to<ConvexPolygonShape3D>(*s);
 				if (convex_polygon) {
-					Vector<Vector3> varr = Variant(convex_polygon->get_points());
-					Geometry3D::MeshData md;
-
-					Error err = ConvexHullComputer::convex_hull(varr, md);
-
-					if (err == OK) {
-						PackedVector3Array faces;
-
-						for (const Geometry3D::MeshData::Face &face : md.faces) {
-							for (uint32_t k = 2; k < face.indices.size(); ++k) {
-								faces.push_back(md.vertices[face.indices[0]]);
-								faces.push_back(md.vertices[face.indices[k - 1]]);
-								faces.push_back(md.vertices[face.indices[k]]);
-							}
-						}
-
-						p_source_geometry_data->add_faces(faces, transform);
+					Vector<Vector3> triangles = convex_polygon->get_triangles();
+					if (!triangles.is_empty()) {
+						p_source_geometry_data->add_faces(triangles, transform);
 					}
 				}
 
 				HeightMapShape3D *heightmap_shape = Object::cast_to<HeightMapShape3D>(*s);
 				if (heightmap_shape) {
-					int heightmap_depth = heightmap_shape->get_map_depth();
-					int heightmap_width = heightmap_shape->get_map_width();
-
-					if (heightmap_depth >= 2 && heightmap_width >= 2) {
-						const Vector<real_t> &map_data = heightmap_shape->get_map_data();
-
-						Vector2 heightmap_gridsize(heightmap_width - 1, heightmap_depth - 1);
-						Vector3 start = Vector3(heightmap_gridsize.x, 0, heightmap_gridsize.y) * -0.5;
-
-						Vector<Vector3> vertex_array;
-						vertex_array.resize((heightmap_depth - 1) * (heightmap_width - 1) * 6);
-						Vector3 *vertex_array_ptrw = vertex_array.ptrw();
-						const real_t *map_data_ptr = map_data.ptr();
-						int vertex_index = 0;
-
-						for (int d = 0; d < heightmap_depth - 1; d++) {
-							for (int w = 0; w < heightmap_width - 1; w++) {
-								vertex_array_ptrw[vertex_index] = start + Vector3(w, map_data_ptr[(heightmap_width * d) + w], d);
-								vertex_array_ptrw[vertex_index + 1] = start + Vector3(w + 1, map_data_ptr[(heightmap_width * d) + w + 1], d);
-								vertex_array_ptrw[vertex_index + 2] = start + Vector3(w, map_data_ptr[(heightmap_width * d) + heightmap_width + w], d + 1);
-								vertex_array_ptrw[vertex_index + 3] = start + Vector3(w + 1, map_data_ptr[(heightmap_width * d) + w + 1], d);
-								vertex_array_ptrw[vertex_index + 4] = start + Vector3(w + 1, map_data_ptr[(heightmap_width * d) + heightmap_width + w + 1], d + 1);
-								vertex_array_ptrw[vertex_index + 5] = start + Vector3(w, map_data_ptr[(heightmap_width * d) + heightmap_width + w], d + 1);
-								vertex_index += 6;
-							}
-						}
-						if (vertex_array.size() > 0) {
-							p_source_geometry_data->add_faces(vertex_array, transform);
-						}
+					Vector<Vector3> triangles = heightmap_shape->get_triangles();
+					if (!triangles.is_empty()) {
+						p_source_geometry_data->add_faces(triangles, transform);
 					}
 				}
 			}

--- a/scene/resources/3d/box_shape_3d.cpp
+++ b/scene/resources/3d/box_shape_3d.cpp
@@ -107,6 +107,85 @@ Vector3 BoxShape3D::get_size() const {
 	return size;
 }
 
+Vector<Vector3> BoxShape3D::get_triangles() const {
+	if (!triangle_cache_dirty) {
+		return triangle_cache;
+	}
+	triangle_cache = BoxShape3D::create_triangles(size);
+	triangle_cache_dirty = false;
+	return triangle_cache;
+}
+
+Vector<Vector3> BoxShape3D::create_triangles(Vector3 p_size) {
+	float extend_x = p_size.x / 2.0;
+	float extend_y = p_size.y / 2.0;
+	float extend_z = p_size.z / 2.0;
+
+	LocalVector<Vector3> vertices;
+	vertices.resize(8);
+	vertices[0] = Vector3(-extend_x, extend_y, extend_z); // front-top-left
+	vertices[1] = Vector3(extend_x, extend_y, extend_z); // front-top-right
+	vertices[2] = Vector3(extend_x, -extend_y, extend_z); // front-bottom-right
+	vertices[3] = Vector3(-extend_x, -extend_y, extend_z); // front-bottom-left
+	vertices[4] = Vector3(-extend_x, extend_y, -extend_z); // back-top-left
+	vertices[5] = Vector3(extend_x, extend_y, -extend_z); // back-top-right
+	vertices[6] = Vector3(extend_x, -extend_y, -extend_z); // back-bottom-right
+	vertices[7] = Vector3(-extend_x, -extend_y, -extend_z); // back-bottom-left
+
+	LocalVector<int> face_indices = {
+		0,
+		1,
+		3,
+		2, // front
+		5,
+		4,
+		6,
+		7, // back
+		1,
+		5,
+		2,
+		6, // right
+		4,
+		0,
+		7,
+		3, // left
+		0,
+		4,
+		1,
+		5, // top
+		3,
+		2,
+		7,
+		6, // bottom
+	};
+
+	Vector<Vector3> triangles;
+	triangles.resize(36);
+	Vector3 *triangles_ptrw = triangles.ptrw();
+
+	const Vector3 *vertices_ptr = vertices.ptr();
+	const int *face_indices_ptr = face_indices.ptr();
+
+	int vertex_index = 0;
+
+	for (uint32_t i = 0; i < face_indices.size() / 4; i++) {
+		int a = face_indices_ptr[i * 4 + 0];
+		int b = face_indices_ptr[i * 4 + 1];
+		int c = face_indices_ptr[i * 4 + 2];
+		int d = face_indices_ptr[i * 4 + 3];
+
+		triangles_ptrw[vertex_index++] = vertices_ptr[a];
+		triangles_ptrw[vertex_index++] = vertices_ptr[b];
+		triangles_ptrw[vertex_index++] = vertices_ptr[c];
+
+		triangles_ptrw[vertex_index++] = vertices_ptr[b];
+		triangles_ptrw[vertex_index++] = vertices_ptr[d];
+		triangles_ptrw[vertex_index++] = vertices_ptr[c];
+	}
+
+	return triangles;
+}
+
 void BoxShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_size", "size"), &BoxShape3D::set_size);
 	ClassDB::bind_method(D_METHOD("get_size"), &BoxShape3D::get_size);

--- a/scene/resources/3d/box_shape_3d.h
+++ b/scene/resources/3d/box_shape_3d.h
@@ -53,5 +53,8 @@ public:
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
 	virtual real_t get_enclosing_radius() const override;
 
+	virtual Vector<Vector3> get_triangles() const override;
+	static Vector<Vector3> create_triangles(Vector3 p_size);
+
 	BoxShape3D();
 };

--- a/scene/resources/3d/capsule_shape_3d.h
+++ b/scene/resources/3d/capsule_shape_3d.h
@@ -56,5 +56,8 @@ public:
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
 	virtual real_t get_enclosing_radius() const override;
 
+	virtual Vector<Vector3> get_triangles() const override;
+	static Vector<Vector3> create_triangles(float p_radius, float p_height, int p_segments, int p_rings);
+
 	CapsuleShape3D();
 };

--- a/scene/resources/3d/concave_polygon_shape_3d.cpp
+++ b/scene/resources/3d/concave_polygon_shape_3d.cpp
@@ -119,6 +119,10 @@ bool ConcavePolygonShape3D::is_backface_collision_enabled() const {
 	return backface_collision;
 }
 
+Vector<Vector3> ConcavePolygonShape3D::get_triangles() const {
+	return get_faces();
+}
+
 void ConcavePolygonShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_faces", "faces"), &ConcavePolygonShape3D::set_faces);
 	ClassDB::bind_method(D_METHOD("get_faces"), &ConcavePolygonShape3D::get_faces);

--- a/scene/resources/3d/concave_polygon_shape_3d.h
+++ b/scene/resources/3d/concave_polygon_shape_3d.h
@@ -76,5 +76,7 @@ public:
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
 	virtual real_t get_enclosing_radius() const override;
 
+	virtual Vector<Vector3> get_triangles() const override;
+
 	ConcavePolygonShape3D();
 };

--- a/scene/resources/3d/convex_polygon_shape_3d.h
+++ b/scene/resources/3d/convex_polygon_shape_3d.h
@@ -51,5 +51,8 @@ public:
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
 	virtual real_t get_enclosing_radius() const override;
 
+	virtual Vector<Vector3> get_triangles() const override;
+	static Vector<Vector3> create_triangles(const Vector<Vector3> &p_points);
+
 	ConvexPolygonShape3D();
 };

--- a/scene/resources/3d/cylinder_shape_3d.cpp
+++ b/scene/resources/3d/cylinder_shape_3d.cpp
@@ -113,6 +113,74 @@ float CylinderShape3D::get_height() const {
 	return height;
 }
 
+Vector<Vector3> CylinderShape3D::get_triangles() const {
+	if (!triangle_cache_dirty) {
+		return triangle_cache;
+	}
+
+	int radial_segments = 32;
+
+	triangle_cache = CylinderShape3D::create_triangles(radius, height, radial_segments);
+	triangle_cache_dirty = false;
+	return triangle_cache;
+}
+
+Vector<Vector3> CylinderShape3D::create_triangles(float p_radius, float p_height, int p_segments) {
+	Vector<Vector3> triangles;
+
+	float radius = p_radius;
+	float height = p_height;
+	int segments = p_segments;
+
+	float half_height = height * 0.5;
+	float step = 2.0 * Math::PI / segments;
+
+	triangles.resize(segments * 12);
+	Vector3 *triangles_ptrw = triangles.ptrw();
+
+	int vertex_index = 0;
+
+	const Vector3 top_center = Vector3(0.0, half_height, 0.0);
+	const Vector3 bottom_center = Vector3(0.0, -half_height, 0.0);
+
+	for (int i = 0; i < segments; i++) {
+		float a1 = i * step;
+		float a2 = (i + 1) * step;
+
+		float x1 = Math::cos(a1) * radius;
+		float z1 = Math::sin(a1) * radius;
+
+		float x2 = Math::cos(a2) * radius;
+		float z2 = Math::sin(a2) * radius;
+
+		Vector3 top_left = Vector3(x1, half_height, z1);
+		Vector3 bottom_left = Vector3(x1, -half_height, z1);
+		Vector3 top_right = Vector3(x2, half_height, z2);
+		Vector3 bottom_right = Vector3(x2, -half_height, z2);
+
+		// Sidequad.
+		triangles_ptrw[vertex_index++] = top_left;
+		triangles_ptrw[vertex_index++] = bottom_left;
+		triangles_ptrw[vertex_index++] = top_right;
+
+		triangles_ptrw[vertex_index++] = top_right;
+		triangles_ptrw[vertex_index++] = bottom_left;
+		triangles_ptrw[vertex_index++] = bottom_right;
+
+		// Top.
+		triangles_ptrw[vertex_index++] = top_center;
+		triangles_ptrw[vertex_index++] = top_left;
+		triangles_ptrw[vertex_index++] = top_right;
+
+		// Bottom.
+		triangles_ptrw[vertex_index++] = bottom_center;
+		triangles_ptrw[vertex_index++] = bottom_right;
+		triangles_ptrw[vertex_index++] = bottom_left;
+	}
+
+	return triangles;
+}
+
 void CylinderShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &CylinderShape3D::set_radius);
 	ClassDB::bind_method(D_METHOD("get_radius"), &CylinderShape3D::get_radius);

--- a/scene/resources/3d/cylinder_shape_3d.h
+++ b/scene/resources/3d/cylinder_shape_3d.h
@@ -53,5 +53,8 @@ public:
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
 	virtual real_t get_enclosing_radius() const override;
 
+	virtual Vector<Vector3> get_triangles() const override;
+	static Vector<Vector3> create_triangles(float p_radius, float p_height, int p_segments);
+
 	CylinderShape3D();
 };

--- a/scene/resources/3d/height_map_shape_3d.h
+++ b/scene/resources/3d/height_map_shape_3d.h
@@ -65,5 +65,8 @@ public:
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
 	virtual real_t get_enclosing_radius() const override;
 
+	virtual Vector<Vector3> get_triangles() const override;
+	static Vector<Vector3> create_triangles(int p_width, int p_depth, const Vector<real_t> &p_heights);
+
 	HeightMapShape3D();
 };

--- a/scene/resources/3d/shape_3d.cpp
+++ b/scene/resources/3d/shape_3d.cpp
@@ -141,6 +141,7 @@ Ref<ArrayMesh> Shape3D::get_debug_mesh() {
 void Shape3D::_update_shape() {
 	emit_changed();
 	debug_mesh_cache.unref();
+	triangle_cache_dirty = true;
 }
 
 void Shape3D::_bind_methods() {
@@ -151,6 +152,7 @@ void Shape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_margin"), &Shape3D::get_margin);
 
 	ClassDB::bind_method(D_METHOD("get_debug_mesh"), &Shape3D::get_debug_mesh);
+	ClassDB::bind_method(D_METHOD("get_triangles"), &Shape3D::get_triangles);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "custom_solver_bias", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_custom_solver_bias", "get_custom_solver_bias");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "margin", PROPERTY_HINT_RANGE, "0,10,0.001,or_greater,suffix:m"), "set_margin", "get_margin");

--- a/scene/resources/3d/shape_3d.h
+++ b/scene/resources/3d/shape_3d.h
@@ -58,6 +58,9 @@ protected:
 	_FORCE_INLINE_ RID get_shape() const { return shape; }
 	Shape3D(RID p_shape);
 
+	mutable Vector<Vector3> triangle_cache;
+	mutable bool triangle_cache_dirty = true;
+
 	virtual void _update_shape();
 
 public:
@@ -82,6 +85,8 @@ public:
 
 	void set_debug_fill(bool p_fill);
 	bool get_debug_fill() const;
+
+	virtual Vector<Vector3> get_triangles() const { return Vector<Vector3>(); }
 
 #ifdef DEBUG_ENABLED
 	_FORCE_INLINE_ bool are_debug_properties_edited() const { return debug_properties_edited; }

--- a/scene/resources/3d/sphere_shape_3d.h
+++ b/scene/resources/3d/sphere_shape_3d.h
@@ -51,5 +51,8 @@ public:
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
 	virtual real_t get_enclosing_radius() const override;
 
+	virtual Vector<Vector3> get_triangles() const override;
+	static Vector<Vector3> create_triangles(float p_radius, int p_segments, int p_rings);
+
 	SphereShape3D();
 };


### PR DESCRIPTION
Parsing `Shape3D` geometry at scale is surprisingly costly in Godot.

- Most shapes only store simple properties and compute the actual geometry on the fly. For some shape types with more complex geometry that is a very costly thing to do at runtime.
- There is no geometry cache so even entire static objects compute everything fresh all the time.

There are engine internal or user custom uses for Shape3D parsing but predominantly this creates a very noticeable performance bottlenecks for navmesh baking at runtime that heavily relies on shape geometry.

For navmesh baking we already have only a very tiny time window to parse those objects due to the single-threaded nature of Nodes and the SceneTree. Without nodes involve and PhysicsServer-only we still have a problem because the physics engine does not allow us to query all object states outside the physics step. So in either way it is rather easy for users to trigger frame drops and physics step death spirals with shape parsing operations.

We can't do much about all the Node, SceneTree, and physics limitations but what we can do is make the actual shape parsing a lot faster with less wasteful computations.

This PR
- Adds a `triangle_cache` to Shape3D that creates the geometry only when the function is actually called. Similar to the cache that `Mesh` resources use for trimesh collision.
- Adds resource local function `Shape3D::get_triangles()` that calculates the triangles only once and returns a cached version afterward.
- Adds a static version `Shape3D::create_triangles()` so systems can create geometry with detail parameters and without spawning many dummy Resource objects.
- Replaces all the highly inefficient `Mesh::create_mesh_array()` calls for various shapes with simpler functions (those functions created like 80-90% computational waste for the purpose of parsing geometry. No one needs UV, normal, tangent and bone array data for this).
- Removes the more or less duplicated parse code that `StaticBody3D` and `GridMap` had.
- Adds a shape RID cache for the GridMap parser. As it uses the `PhysicsServer3D` directly it can't make use of the Resource cache like the StaticBody3D parser does.

On larger production projects this was tested with navmesh runtime rebaking the performance gain for parsing was immense. Mind you that parsing is only one tiny but critical part of a navmesh process. This will not affect anything at all about baking performance. If that is your performance problem you need to cut down on geometry size and detail.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
