### PR TITLE
[Editor] Handle spaces in paths when generating translations

### DIFF
--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -85,7 +85,7 @@ def make_translations(target, source, env):
             # msgfmt erases non-translated messages, so avoid using it if exporting the POT.
             if msgfmt and name != category:
                 mo_path = os.path.join(tempfile.gettempdir(), uuid.uuid4().hex + ".mo")
-                cmd = f"{msgfmt} {path} --no-hash -o {mo_path}"
+                cmd = f'{msgfmt} "{path}" --no-hash -o "{mo_path}"'
                 try:
                     subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE).communicate()
                     buffer = methods.get_buffer(mo_path)


### PR DESCRIPTION
Another fix brought to you by my laptop being set up with spaces in the user name (see also https://github.com/godotengine/godot/issues/101303)

For the longest time compiling the editor has complained for me about failing to use `.mo` files, and I noticed it today but when I checked that I had gettext installed I realized it was installed, but that it was once again because of that space, this ensures that paths are handled correctly

Unsure if there is some better way to ensure valid paths or escaping them but this makes things work correctly on my end
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
