### PR TITLE
Fix Control node's reset issue when using "Save Branch as Scene..."

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -467,6 +467,14 @@ void SceneTreeDock::_replace_with_branch_scene(const String &p_file, Node *p_bas
 		copy_2d->set_scale(base_2d->get_scale());
 	}
 
+	Control *copy_control = Object::cast_to<Control>(instantiated_scene);
+	Control *base_control = Object::cast_to<Control>(p_base);
+	if (copy_control && base_control) {
+		copy_control->set_position(base_control->get_position());
+		copy_control->set_rotation(base_control->get_rotation());
+		copy_control->set_scale(base_control->get_scale());
+	}
+
 	Node3D *copy_3d = Object::cast_to<Node3D>(instantiated_scene);
 	Node3D *base_3d = Object::cast_to<Node3D>(p_base);
 	if (copy_3d && base_3d) {
@@ -3489,6 +3497,18 @@ void SceneTreeDock::_new_scene_from(const String &p_file) {
 			}
 			if (reset_scale) {
 				copy_2d->set_scale(Size2(1, 1));
+			}
+		}
+		Control *copy_control = Object::cast_to<Control>(copy);
+		if (copy_control != nullptr) {
+			if (reset_position) {
+				copy_control->set_position(Vector2(0, 0));
+			}
+			if (reset_rotation) {
+				copy_control->set_rotation(0);
+			}
+			if (reset_scale) {
+				copy_control->set_scale(Size2(1, 1));
 			}
 		}
 		Node3D *copy_3d = Object::cast_to<Node3D>(copy);


### PR DESCRIPTION
Fix #114945.

This is my first code contribution outside of documentation work. As a C++ novice, I might have missed something—please let me know if so. Thank you!
﻿
This PR only fills in the missing Control node part for the previous Reset functionality. However, upon closer consideration, resetting properties for Control nodes actually involves more factors—such as anchors, among others. But addressing those is outside the scope of this PR.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
