### PR TITLE
[Linux] Handle debug symbols with renamed executable

### DIFF
--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -31,6 +31,7 @@
 #include "crash_handler_linuxbsd.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/file_access.h"
 #include "core/object/script_language.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
@@ -66,6 +67,10 @@ static void handle_crash(int sig) {
 	void *bt_buffer[256];
 	size_t size = backtrace(bt_buffer, 256);
 	String _execpath = OS::get_singleton()->get_executable_path();
+
+	if (FileAccess::exists(_execpath + ".debugsymbols")) {
+		_execpath = _execpath + ".debugsymbols";
+	}
 
 	String msg;
 	if (ProjectSettings::get_singleton()) {


### PR DESCRIPTION
GNU debug link expects the file to have the same name as when compiled, same solution as on Windows.

Discovered while working on https://github.com/godotengine/godot/pull/114924
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
