### PR TITLE
Limit maximum luminance for elevated surfaces in modern theme

### DIFF
--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -44,7 +44,8 @@
 // Helper.
 static Color _get_base_color(EditorThemeManager::ThemeConfiguration &p_config, float p_dimness_ofs = 0.0, float p_saturation_mult = 1.0) {
 	Color color = p_config.base_color;
-	color.set_v(CLAMP(Math::lerp(color.get_v(), 0, p_config.contrast * p_dimness_ofs), 0, 1));
+	const float final_contrast = (p_dimness_ofs < 0) ? CLAMP(p_config.contrast, -0.1, 0.5) : p_config.contrast;
+	color.set_v(CLAMP(Math::lerp(color.get_v(), 0, final_contrast * p_dimness_ofs), 0, 1));
 	color.set_s(color.get_s() * p_saturation_mult);
 	return color;
 }


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/114857

In classic theme, when you increase contrast, surfaces can only deviate from the base color in one direction (darker with positive contrast), but modern theme offsets them from the base color in _both_ directions by allowing negative dimness values in `_get_base_color()`. This can make some surfaces like buttons and tree items blend with text at high contrast values.

This limits the maximum offset for negative-dimness surfaces, making it behave closer to the classic theme in that regard.

| **Master**, -1 contrast | **PR**, -1 contrast |
|--------|--------|
| ![1](https://github.com/user-attachments/assets/55c54107-4eb7-4ff8-85b3-d95e7935029c) | ![2](https://github.com/user-attachments/assets/db0c0900-c263-43b7-afa0-ee262d94f73c) |