### PR TITLE
Fix GDScript LSP test link errors when `websocket` is disabled

### DIFF
--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -32,9 +32,7 @@
 
 #ifdef TOOLS_ENABLED
 
-#include "modules/modules_enabled.gen.h" // For jsonrpc.
-
-#ifdef MODULE_JSONRPC_ENABLED
+#ifndef GDSCRIPT_NO_LSP
 
 #include "tests/test_macros.h"
 
@@ -607,6 +605,6 @@ func f():
 
 } // namespace GDScriptTests
 
-#endif // MODULE_JSONRPC_ENABLED
+#endif // GDSCRIPT_NO_LSP
 
 #endif // TOOLS_ENABLED


### PR DESCRIPTION
When `module_websocket_enabled` is disabled, `GDSCRIPT_NO_LSP` is defined and LSP source files are not compiled.
However, `tests/test_lsp.h` only checks for `MODULE_JSONRPC_ENABLED`, causing tests to be built and resulting in link errors.
This change makes the test condition consistent with the module's build condition by using `#ifndef GDSCRIPT_NO_LSP`.