### PR TITLE
Remove checkbox icon tint in Create Scene popup

### DIFF
--- a/editor/scene/scene_create_dialog.cpp
+++ b/editor/scene/scene_create_dialog.cpp
@@ -212,6 +212,7 @@ SceneCreateDialog::SceneCreateDialog() {
 		node_type_2d = memnew(CheckBox);
 		vb->add_child(node_type_2d);
 		node_type_2d->set_text(TTR("2D Scene"));
+		node_type_2d->set_theme_type_variation("CheckBoxNoIconTint");
 		node_type_2d->set_button_group(node_type_group);
 		node_type_2d->set_meta(type_meta, ROOT_2D_SCENE);
 		node_type_2d->set_pressed(true);
@@ -219,12 +220,14 @@ SceneCreateDialog::SceneCreateDialog() {
 		node_type_3d = memnew(CheckBox);
 		vb->add_child(node_type_3d);
 		node_type_3d->set_text(TTR("3D Scene"));
+		node_type_3d->set_theme_type_variation("CheckBoxNoIconTint");
 		node_type_3d->set_button_group(node_type_group);
 		node_type_3d->set_meta(type_meta, ROOT_3D_SCENE);
 
 		node_type_gui = memnew(CheckBox);
 		vb->add_child(node_type_gui);
 		node_type_gui->set_text(TTR("User Interface"));
+		node_type_gui->set_theme_type_variation("CheckBoxNoIconTint");
 		node_type_gui->set_button_group(node_type_group);
 		node_type_gui->set_meta(type_meta, ROOT_USER_INTERFACE);
 
@@ -234,6 +237,7 @@ SceneCreateDialog::SceneCreateDialog() {
 		node_type_other = memnew(CheckBox);
 		hb->add_child(node_type_other);
 		node_type_other->set_accessibility_name(TTRC("Other Type"));
+		node_type_other->set_theme_type_variation("CheckBoxNoIconTint");
 		node_type_other->set_button_group(node_type_group);
 		node_type_other->set_meta(type_meta, ROOT_OTHER);
 

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1892,6 +1892,14 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			p_theme->set_stylebox(SceneStringName(pressed), "EditorLogFilterButton", editor_log_button_pressed);
 		}
 
+		// Checkbox.
+		{
+			p_theme->set_type_variation("CheckBoxNoIconTint", "CheckBox");
+			p_theme->set_color("icon_pressed_color", "CheckBoxNoIconTint", p_config.icon_normal_color);
+			p_theme->set_color("icon_hover_color", "CheckBoxNoIconTint", p_config.mono_color);
+			p_theme->set_color("icon_hover_pressed_color", "CheckBoxNoIconTint", p_config.mono_color);
+		}
+
 		// Buttons styles that stand out against the panel background (e.g. AssetLib).
 		{
 			p_theme->set_type_variation("PanelBackgroundButton", "Button");

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1947,6 +1947,14 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_stylebox("hover_pressed", "EditorLogFilterButton", p_config.flat_button_hover_pressed);
 		}
 
+		// Checkbox.
+		{
+			p_theme->set_type_variation("CheckBoxNoIconTint", "CheckBox");
+			p_theme->set_color("icon_pressed_color", "CheckBoxNoIconTint", p_config.icon_normal_color);
+			p_theme->set_color("icon_hover_color", "CheckBoxNoIconTint", p_config.mono_color);
+			p_theme->set_color("icon_hover_pressed_color", "CheckBoxNoIconTint", p_config.mono_color);
+		}
+
 		// Buttons styles that stand out against the panel background (e.g. AssetLib).
 		{
 			p_theme->set_type_variation("PanelBackgroundButton", "Button");


### PR DESCRIPTION
Fixes an issue [reported on bluesky](https://bsky.app/profile/clemidev.itch.io/post/3mcfpbwedss2d), both themes.

| Master | PR |
|--------|--------|
| ![1](https://github.com/user-attachments/assets/614695ff-9191-4505-bb65-ef49f7af81ee) | ![2](https://github.com/user-attachments/assets/60c01a60-4e35-4be4-9362-0af37e0c9bfe) |