### PR TITLE
Remove Compatibility RenderTarget backbuffer size limit

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2489,57 +2489,57 @@ void TextureStorage::_update_render_target_velocity(RenderTarget *rt) {
 
 void TextureStorage::_create_render_target_backbuffer(RenderTarget *rt) {
 	ERR_FAIL_COND_MSG(rt->backbuffer_fbo != 0, "Cannot allocate RenderTarget backbuffer: already initialized.");
+	ERR_FAIL_COND_MSG(rt->size.x <= 0 || rt->size.y <= 0, "Cannot allocate RenderTarget backbuffer: invalid size.");
 	ERR_FAIL_COND(rt->direct_to_screen);
+
 	// Allocate mipmap chains for full screen blur
 	// Limit mipmaps so smallest is 32x32 to avoid unnecessary framebuffer switches
 	int count = MAX(1, Image::get_image_required_mipmaps(rt->size.x, rt->size.y, Image::FORMAT_RGBA8) - 4);
-	if (rt->size.x > 40 && rt->size.y > 40) {
-		GLsizei width = rt->size.x;
-		GLsizei height = rt->size.y;
+	GLsizei width = rt->size.x;
+	GLsizei height = rt->size.y;
 
-		rt->mipmap_count = count;
+	rt->mipmap_count = count;
 
-		glGenTextures(1, &rt->backbuffer);
-		glBindTexture(GL_TEXTURE_2D, rt->backbuffer);
-		uint32_t texture_size_bytes = 0;
+	glGenTextures(1, &rt->backbuffer);
+	glBindTexture(GL_TEXTURE_2D, rt->backbuffer);
+	uint32_t texture_size_bytes = 0;
 
-		for (int l = 0; l < count; l++) {
-			texture_size_bytes += width * height * 4;
-			glTexImage2D(GL_TEXTURE_2D, l, rt->color_internal_format, width, height, 0, rt->color_format, rt->color_type, nullptr);
-			width = MAX(1, (width / 2));
-			height = MAX(1, (height / 2));
-		}
-
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, count - 1);
-
-		glGenFramebuffers(1, &rt->backbuffer_fbo);
-		glBindFramebuffer(GL_FRAMEBUFFER, rt->backbuffer_fbo);
-
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->backbuffer, 0);
-
-		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-		if (status != GL_FRAMEBUFFER_COMPLETE) {
-			WARN_PRINT_ONCE("Cannot allocate mipmaps for canvas screen blur. Status: " + get_framebuffer_error(status));
-			glBindFramebuffer(GL_FRAMEBUFFER, system_fbo);
-			return;
-		}
-		GLES3::Utilities::get_singleton()->texture_allocated_data(rt->backbuffer, texture_size_bytes, "Render target backbuffer color texture");
-
-		// Initialize all levels to clear black.
-		for (int j = 0; j < count; j++) {
-			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->backbuffer, j);
-			glClearColor(0.0, 0.0, 0.0, 0.0);
-			glClear(GL_COLOR_BUFFER_BIT);
-		}
-
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->backbuffer, 0);
-
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	for (int l = 0; l < count; l++) {
+		texture_size_bytes += width * height * 4;
+		glTexImage2D(GL_TEXTURE_2D, l, rt->color_internal_format, width, height, 0, rt->color_format, rt->color_type, nullptr);
+		width = MAX(1, (width / 2));
+		height = MAX(1, (height / 2));
 	}
+
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, count - 1);
+
+	glGenFramebuffers(1, &rt->backbuffer_fbo);
+	glBindFramebuffer(GL_FRAMEBUFFER, rt->backbuffer_fbo);
+
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->backbuffer, 0);
+
+	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+	if (status != GL_FRAMEBUFFER_COMPLETE) {
+		WARN_PRINT_ONCE("Cannot allocate RenderTarget backbuffer. Status: " + get_framebuffer_error(status));
+		glBindFramebuffer(GL_FRAMEBUFFER, system_fbo);
+		return;
+	}
+	GLES3::Utilities::get_singleton()->texture_allocated_data(rt->backbuffer, texture_size_bytes, "Render target backbuffer color texture");
+
+	// Initialize all levels to clear black.
+	for (int j = 0; j < count; j++) {
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->backbuffer, j);
+		glClearColor(0.0, 0.0, 0.0, 0.0);
+		glClear(GL_COLOR_BUFFER_BIT);
+	}
+
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->backbuffer, 0);
+
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 }
 
 void TextureStorage::_clear_render_target(RenderTarget *rt) {


### PR DESCRIPTION
Fixes #114899

**The Issue:**
The Compatibility Renders Texture Storage imposes a size limit of 41x41 when creating the back buffer for a RenderTarget. According to https://github.com/godotengine/godot/issues/114899#issuecomment-3750058511 this is intended to ensure no mipmaps are generated for these small buffers, however the base level is also not generated.

**The Fix:**
The limit is removed, as the function already correctly accounts for the case where only the base level is generated. Additionally an error is instead thrown at the top of the method is the RenderTargets size is invalid. This case should not happen.

**For the MRP linked in the issue this is the result:**
<img width="1920" height="1038" alt="image" src="https://github.com/user-attachments/assets/49106bb7-9a0f-4bdb-8489-548bb78264a3" />

Is is possible to reduce the SubViewports size up to 2x2 with correct rendering. I assume this is the limit imposed by the size property but did not investigate further.