### PR TITLE
Fix DirectionalLight3D soft shadows large coordinate imprecision

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -84,6 +84,7 @@ void axis_angle_to_tbn(vec3 axis, float angle, out vec3 tangent, out vec3 binorm
 /* Varyings */
 
 layout(location = 0) out vec3 vertex_interp;
+layout(location = 14) out vec3 vertex_interp_cam_relative;
 
 #ifdef NORMAL_USED
 layout(location = 1) out vec3 normal_interp;
@@ -481,6 +482,12 @@ void vertex_shader(vec3 vertex_input,
 
 	vertex_interp = vertex;
 
+	// Store camera-relative world position for soft shadow calculations.
+	// This avoids precision issues when world coordinates are large.
+	vec3 world_vertex = (scene_data.inv_view_matrix * vec4(vertex, 1.0)).xyz;
+	vec3 camera_pos = scene_data.inv_view_matrix[3].xyz;
+	vertex_interp_cam_relative = world_vertex - camera_pos;
+
 	// Normalize TBN vectors before interpolation, per MikkTSpace.
 	// See: http://www.mikktspace.com/
 #ifdef NORMAL_USED
@@ -871,6 +878,7 @@ void main() {
 /* Varyings */
 
 layout(location = 0) in vec3 vertex_interp;
+layout(location = 14) in vec3 vertex_interp_cam_relative;
 
 #ifdef NORMAL_USED
 layout(location = 1) in vec3 normal_interp;
@@ -2293,6 +2301,8 @@ void fragment_shader(in SceneData scene_data) {
 						uint blend_count = 0;
 						const uint blend_max = directional_lights.data[i].blend_splits ? 2 : 1;
 
+						vec3 light_dir_world = normalize((scene_data.inv_view_matrix * vec4(light_dir, 0.0)).xyz);
+
 						if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
 							vec4 v = vec4(vertex, 1.0);
 
@@ -2301,8 +2311,9 @@ void fragment_shader(in SceneData scene_data) {
 							vec4 pssm_coord = (directional_lights.data[i].shadow_matrix1 * v);
 							pssm_coord /= pssm_coord.w;
 
-							float range_pos = dot(directional_lights.data[i].direction, v.xyz);
-							float range_begin = directional_lights.data[i].shadow_range_begin.x;
+							vec3 v_world_camera_rel = vertex_interp_cam_relative + (v.xyz - vertex);
+							float range_pos = dot(light_dir_world, v_world_camera_rel);
+							float range_begin = directional_lights.data[i].shadow_range_begin.x - dot(light_dir_world, scene_data.inv_view_matrix[3].xyz);
 							float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
 							vec2 tex_scale = directional_lights.data[i].uv_scale1 * test_radius;
 							shadow = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale, scene_data.taa_frame_count);
@@ -2317,8 +2328,9 @@ void fragment_shader(in SceneData scene_data) {
 							vec4 pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
 							pssm_coord /= pssm_coord.w;
 
-							float range_pos = dot(directional_lights.data[i].direction, v.xyz);
-							float range_begin = directional_lights.data[i].shadow_range_begin.y;
+							vec3 v_world_camera_rel = vertex_interp_cam_relative + (v.xyz - vertex);
+							float range_pos = dot(light_dir_world, v_world_camera_rel);
+							float range_begin = directional_lights.data[i].shadow_range_begin.y - dot(light_dir_world, scene_data.inv_view_matrix[3].xyz);
 							float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
 							vec2 tex_scale = directional_lights.data[i].uv_scale2 * test_radius;
 							float s = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale, scene_data.taa_frame_count);
@@ -2342,8 +2354,9 @@ void fragment_shader(in SceneData scene_data) {
 							vec4 pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
 							pssm_coord /= pssm_coord.w;
 
-							float range_pos = dot(directional_lights.data[i].direction, v.xyz);
-							float range_begin = directional_lights.data[i].shadow_range_begin.z;
+							vec3 v_world_camera_rel = vertex_interp_cam_relative + (v.xyz - vertex);
+							float range_pos = dot(light_dir_world, v_world_camera_rel);
+							float range_begin = directional_lights.data[i].shadow_range_begin.z - dot(light_dir_world, scene_data.inv_view_matrix[3].xyz);
 							float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
 							vec2 tex_scale = directional_lights.data[i].uv_scale3 * test_radius;
 							float s = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale, scene_data.taa_frame_count);
@@ -2367,8 +2380,9 @@ void fragment_shader(in SceneData scene_data) {
 							vec4 pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
 							pssm_coord /= pssm_coord.w;
 
-							float range_pos = dot(directional_lights.data[i].direction, v.xyz);
-							float range_begin = directional_lights.data[i].shadow_range_begin.w;
+							vec3 v_world_camera_rel = vertex_interp_cam_relative + (v.xyz - vertex);
+							float range_pos = dot(light_dir_world, v_world_camera_rel);
+							float range_begin = directional_lights.data[i].shadow_range_begin.w - dot(light_dir_world, scene_data.inv_view_matrix[3].xyz);
 							float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
 							vec2 tex_scale = directional_lights.data[i].uv_scale4 * test_radius;
 							float s = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale, scene_data.taa_frame_count);


### PR DESCRIPTION
Fixes #86536 and possibly #63610.

Directional light soft shadow penumbras depend on the distance between shadow caster and shadow receiver.
This distance was previously calculated using world space coordinates, which led to imprecise results further from the origin.
This PR changes that calculation to be based on coordinates relative to the camera position.

The picture on the left shows the shadow near the origin, the right one show it at ~320 units away from 0. It gets worse the further you go.

Before:
<img width="1097" height="619" alt="image" src="https://github.com/user-attachments/assets/9627f051-e954-4ed4-869e-ff45ed0c1f0f" />

After:
<img width="1146" height="642" alt="image" src="https://github.com/user-attachments/assets/f79bcdc5-8f26-4218-a3ea-0c6a7257da48" />

([Captured using this issue's MRP](https://github.com/godotengine/godot/issues/86536))

Higher shadow cascades (further from camera) still show some artifacts:
<img width="379" height="269" alt="image" src="https://github.com/user-attachments/assets/098108ac-b60d-4151-9c26-739057f88ffa" />
Not yet quite sure what's causing these.