### PR TITLE
Audio: Check if on tree before calling `can_process()`.

### DIFF
--- a/scene/audio/audio_stream_player_internal.cpp
+++ b/scene/audio/audio_stream_player_internal.cpp
@@ -114,7 +114,8 @@ void AudioStreamPlayerInternal::notification(int p_what) {
 
 		case Node::NOTIFICATION_SUSPENDED:
 		case Node::NOTIFICATION_PAUSED: {
-			if (!node->can_process()) {
+			bool can_process = node->is_inside_tree() && node->can_process();
+			if (!can_process) {
 				// Node can't process so we start fading out to silence
 				set_stream_paused(true);
 			}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fixes: https://github.com/godotengine/godot/issues/112477
Fixes: https://github.com/godotengine/godot/issues/112614
Fixes: https://github.com/godotengine/godot/issues/100320

All of these issues are caused by an AudioStreamHandler2D calling can_process() before being added to the tree.  This is caused by a VisableOnScreenEnabler2D added to the tree before the AudioStreamHandler2D. 

The solution is to have the AudioStreamHandler2D explicitly check if its on the tree before relying on the engine and calling can_process().