### PR TITLE
Fix right clicking an item in filesystem `ItemList` draws focus

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -3697,7 +3697,7 @@ void FileSystemDock::_file_list_item_clicked(int p_item, const Vector2 &p_pos, M
 	if (p_mouse_button_index != MouseButton::RIGHT) {
 		return;
 	}
-	files->grab_focus();
+	files->grab_focus(true);
 
 	// Right click is pressed in the file list.
 	Vector<String> paths;


### PR DESCRIPTION
Fixes this when right clicking an item  
<img width="1338" height="240" alt="image" src="https://github.com/user-attachments/assets/36e31882-035d-45ac-81cb-69f0cea485e8" />
