### PR TITLE
Fix project manager drawing focus on right click

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -1295,6 +1295,9 @@ void ProjectList::_select_project_range(int p_begin, int p_end) {
 void ProjectList::select_project(int p_index, bool p_hide_focus) {
 	// This method keeps only one project selected.
 	_clear_project_selection();
+
+	Item &item = _projects.write[p_index];
+	item.control->grab_focus(p_hide_focus);
 	_select_project_nocheck(p_index, p_hide_focus);
 }
 


### PR DESCRIPTION
Fixes this: (video became choppy for some reason)

https://github.com/user-attachments/assets/7a9525a2-776c-4e7b-b926-01328818b749

Investigating this was very confusing, the problem comes from item selection via right click not grabbing focus and leaving it on the previously focused and now unselected item, which violates assumptions made by the stylebox drawing logic.

I believe this to be the least intrusive fix - this method leaves only a single item selected, as mentioned by the comment, and was changed to handle focus hiding in #112895, so make it grab focus on the single selected item.

