### PR TITLE
Split `EmbeddedProcess::reset` to allow stopping timers without full reset.

### DIFF
--- a/editor/run/embedded_process.cpp
+++ b/editor/run/embedded_process.cpp
@@ -220,11 +220,15 @@ void EmbeddedProcess::reset() {
 	embedding_completed = false;
 	start_embedding_time = 0;
 	embedding_grab_focus = false;
-	timer_embedding->stop();
-	timer_update_embedded_process->stop();
+	reset_timers();
 	set_process(false);
 	set_notify_transform(false);
 	queue_redraw();
+}
+
+void EmbeddedProcess::reset_timers() {
+	timer_embedding->stop();
+	timer_update_embedded_process->stop();
 }
 
 void EmbeddedProcess::request_close() {

--- a/editor/run/embedded_process.h
+++ b/editor/run/embedded_process.h
@@ -66,6 +66,7 @@ public:
 	virtual void embed_process(OS::ProcessID p_pid) = 0;
 	virtual int get_embedded_pid() const = 0;
 	virtual void reset() = 0;
+	virtual void reset_timers() = 0;
 	virtual void request_close() = 0;
 	virtual void queue_update_embedded_process() = 0;
 
@@ -119,6 +120,7 @@ public:
 	void embed_process(OS::ProcessID p_pid) override;
 	int get_embedded_pid() const override;
 	void reset() override;
+	void reset_timers() override;
 	void request_close() override;
 	void queue_update_embedded_process() override;
 

--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -1163,7 +1163,7 @@ void GameView::_window_close_request() {
 	if (window_wrapper->get_window_enabled()) {
 		// Stop the embedded process timer before closing the window wrapper,
 		// so the signal to focus EDITOR_GAME isn't sent when the window is not enabled.
-		embedded_process->reset();
+		embedded_process->reset_timers();
 		window_wrapper->set_window_enabled(false);
 	}
 
@@ -1175,6 +1175,7 @@ void GameView::_window_close_request() {
 		if (paused || embedded_process->is_embedding_in_progress()) {
 			// Call deferred to prevent the _stop_pressed callback to be executed before the wrapper window
 			// actually closes.
+			embedded_process->reset();
 			callable_mp(EditorRunBar::get_singleton(), &EditorRunBar::stop_playing).call_deferred();
 		} else {
 			// Try to gracefully close the window. That way, the NOTIFICATION_WM_CLOSE_REQUEST

--- a/platform/macos/editor/embedded_process_macos.h
+++ b/platform/macos/editor/embedded_process_macos.h
@@ -118,6 +118,7 @@ public:
 	void embed_process(OS::ProcessID p_pid) override;
 	int get_embedded_pid() const override { return current_process_id; }
 	void reset() override;
+	void reset_timers() override {}
 	void request_close() override;
 	void queue_update_embedded_process() override { update_embedded_process(); }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/114973
