### PR TITLE
Remove link for consoles in EditorExportPlatform

### DIFF
--- a/doc/classes/EditorExportPlatform.xml
+++ b/doc/classes/EditorExportPlatform.xml
@@ -8,7 +8,6 @@
 		Used in scripting by [EditorExportPlugin] to configure platform-specific customization of scenes and resources. See [method EditorExportPlugin._begin_customize_scenes] and [method EditorExportPlugin._begin_customize_resources] for more details.
 	</description>
 	<tutorials>
-		<link title="Console support in Godot">$DOCS_URL/tutorials/platform/consoles.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_message">


### PR DESCRIPTION
As we're looking to drop the old docs page about console support in favor of the page on the website (see docs PR https://github.com/godotengine/godot-docs/pull/11611), this link will become outdated (and cause docs build errors).

We could update it to link to the new website page instead, but I'm not really sure it makes much sense to have that link here.