### PR TITLE
Fix TileSet dock becoming focused when switching TileMapLayers

### DIFF
--- a/editor/scene/2d/tiles/tiles_editor_plugin.cpp
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.cpp
@@ -411,7 +411,7 @@ void TileMapEditorPlugin::_edit_tile_map_layer(TileMapLayer *p_tile_map_layer, b
 	Ref<TileSet> tile_set = p_tile_map_layer->get_tile_set();
 	if (tile_set.is_valid()) {
 		tile_set_plugin_singleton->edit(tile_set.ptr());
-		tile_set_plugin_singleton->make_visible(true);
+		tile_set_plugin_singleton->open_editor();
 		tile_set_id = tile_set->get_instance_id();
 	} else {
 		tile_set_plugin_singleton->edit(nullptr);
@@ -538,6 +538,10 @@ void TileSetEditorPlugin::make_visible(bool p_visible) {
 	} else {
 		editor->close();
 	}
+}
+
+void TileSetEditorPlugin::open_editor() {
+	editor->open();
 }
 
 ObjectID TileSetEditorPlugin::get_edited_tileset() const {

--- a/editor/scene/2d/tiles/tiles_editor_plugin.h
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.h
@@ -164,6 +164,7 @@ public:
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
+	void open_editor();
 
 	ObjectID get_edited_tileset() const;
 


### PR DESCRIPTION
1. Select a TileMapLayer with a TileSet assigned
2. Click another TileMapLayer
3. The bottom panel switches to TileSet, disrupting editing the tiles

This makes TileMapLayer almost unusable right now .-.