### PR TITLE
Fix TextEdit not drawing caret on setting editable

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3711,6 +3711,9 @@ void TextEdit::set_editable(bool p_editable) {
 	}
 
 	editable = p_editable;
+	if (editable) {
+		draw_caret = true;
+	}
 	queue_accessibility_update();
 	queue_redraw();
 	update_minimum_size();


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/114833

If the TextEdit isn't focused, `draw_caret` will be set to false in the draw, so it is fine to just set it to true here.