### PR TITLE
Improve warnings when occlusion culling is disabled at build-time

### DIFF
--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -30,6 +30,8 @@
 
 #include "occluder_instance_3d.h"
 
+#include "modules/modules_enabled.gen.h" // For raycast.
+
 #include "core/config/project_settings.h"
 #include "core/io/marshalls.h"
 #include "core/math/geometry_2d.h"
@@ -693,6 +695,15 @@ OccluderInstance3D::BakeError OccluderInstance3D::bake_scene(Node *p_from_node, 
 PackedStringArray OccluderInstance3D::get_configuration_warnings() const {
 	PackedStringArray warnings = VisualInstance3D::get_configuration_warnings();
 
+#ifndef MODULE_RAYCAST_ENABLED
+#ifdef WEB_ENABLED
+	warnings.push_back(RTR("Occlusion culling support is disabled on the web platform due to binary size and memory usage constraints."));
+#else
+	warnings.push_back(RTR("Occlusion culling is disabled at build-time.\nTo resolve this, use the `module_raycast_enabled=yes` SCons option when compiling Godot."));
+#endif // WEB_ENABLED
+	return warnings;
+#else
+
 	if (!bool(GLOBAL_GET_CACHED(bool, "rendering/occlusion_culling/use_occlusion_culling"))) {
 		warnings.push_back(RTR("Occlusion culling is disabled in the Project Settings, which means occlusion culling won't be performed in the root viewport.\nTo resolve this, open the Project Settings and enable Rendering > Occlusion Culling > Use Occlusion Culling."));
 	}
@@ -717,6 +728,7 @@ PackedStringArray OccluderInstance3D::get_configuration_warnings() const {
 	}
 
 	return warnings;
+#endif // !MODULE_RAYCAST_ENABLED
 }
 
 bool OccluderInstance3D::_is_editable_3d_polygon() const {

--- a/servers/rendering/renderer_scene_occlusion_cull.h
+++ b/servers/rendering/renderer_scene_occlusion_cull.h
@@ -205,7 +205,16 @@ public:
 	static RendererSceneOcclusionCull *get_singleton() { return singleton; }
 
 	void _print_warning() {
-		WARN_PRINT_ONCE("Occlusion culling is disabled at build-time.");
+		// Only print the warning when not in the editor, as OccluderInstance3D
+		// already has a node configuration warning when occlusion culling is disabled
+		// at build-time.
+		if (!Engine::get_singleton()->is_editor_hint()) {
+#ifdef WEB_ENABLED
+			WARN_PRINT_ONCE("Occlusion culling support is disabled on the web platform due to binary size and memory usage constraints.");
+#else
+			WARN_PRINT_ONCE("Occlusion culling is disabled at build-time. To be able to use it, use the `module_raycast_enabled=yes` SCons option when compiling Godot.");
+#endif
+		}
 	}
 
 	virtual bool is_occluder(RID p_rid) { return false; }


### PR DESCRIPTION
- Add a node configuration warning in the editor.
- Only print the low-level rendering message when not in the editor. It's printed too early to be visible in the editor Output panel, so it only appears in terminal output. Besides, the new node configuration warning already informs the user that occlusion culling won't work due to being disabled at build-time.

The message varies depending on whether we're on the web platform or not. While it is possible to explicitly enable occlusion culling support on the web platform using `module_raycast_enabled=no`, it's not recommended due to the large binary size increase and memory utilization. This often makes it perform worse than if no occlusion culling was used, especially on mobile devices with limited memory.
