### PR TITLE
Fix float value `NAN` still shown as 0 in the debugger and inspector.

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -167,7 +167,7 @@ void Range::set_value(double p_val) {
 	double prev_val = shared->val;
 	_set_value_no_signal(p_val);
 
-	if (shared->val != prev_val) {
+	if (shared->val != prev_val && !(Math::is_nan(shared->val) && Math::is_nan(prev_val))) {
 		shared->emit_value_changed();
 	}
 	queue_accessibility_update();
@@ -178,6 +178,10 @@ void Range::_set_value_no_signal(double p_val) {
 }
 
 double Range::_calc_value(double p_val, double p_step) const {
+	if (Math::is_nan(p_val)) {
+		return p_val;
+	}
+
 	if (p_step > 0) {
 		// Subtract min to support cases like min = 0.1, step = 0.2, snaps to 0.1, 0.3, 0.5, etc.
 		p_val = _snapped_r128(p_val - shared->min, p_step) + shared->min;


### PR DESCRIPTION
## Problem
Despite [issue #88006](https://github.com/godotengine/godot/issues/88006) being closed, `0.0` still being displayed instead of `NAN`.
This happens because while [PR #105911](https://github.com/godotengine/godot/pull/105911) allowed non-finite values, it missed handling them properly. As a result, the `_snapped_r128` function called in `Range::set_value()` returns 0 anyway when encountering them.
After adding a proper `NaN` check, everything displays correctly.

## Issue
Fixes #114996
Fixes #115525
