### PR TITLE
Rendering: Fix `fixed_size` flag for mono vs stereo rendering

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1367,7 +1367,16 @@ void vertex() {)";
 		MODELVIEW_MATRIX[2] *= sc;
 	} else {
 		// Scale by depth.
-		float sc = length((MODELVIEW_MATRIX)[3].xyz);
+		// In stereo rendering (XR), EYE_OFFSET is non-zero, and we need to use the
+		// full 3D length to account for the eye offset in the modelview matrix.
+		// In mono rendering, EYE_OFFSET is constant vec3(0), so the GPU compiler
+		// should optimize this branch away (dot(vec3(0), vec3(0)) > 0.0 is always false).
+		float sc;
+		if (dot(EYE_OFFSET, EYE_OFFSET) > 0.0) {
+			sc = length((MODELVIEW_MATRIX)[3].xyz);
+		} else {
+			sc = abs((MODELVIEW_MATRIX)[3].z);
+		}
 		MODELVIEW_MATRIX[0] *= sc;
 		MODELVIEW_MATRIX[1] *= sc;
 		MODELVIEW_MATRIX[2] *= sc;


### PR DESCRIPTION
Fixes the `fixed_size` flag regression introduced in PR #110410 where sprites would grow when moving to screen edges in mono rendering, while preserving the XR stereo rendering fix.

### Problem:

PR #110410 changed the distance calculation from `abs((MODELVIEW_MATRIX)[3].z)` to `length((MODELVIEW_MATRIX)[3].xyz)` to fix XR rendering. This fixed stereo/XR but broke mono rendering. Sprites now incorrectly scale based on their horizontal position on screen instead of maintaining constant size.

### Solution:

Detect rendering mode at runtime using `EYE_OFFSET`:
- **Mono mode** (`EYE_OFFSET == vec3(0,0,0)`): Uses `abs(z)` - depth-only scaling
- **Stereo/XR mode** (`length(EYE_OFFSET) > 0.0`): Uses `length(xyz)` - full 3D distance

This satisfies both requirements: correct behavior in mono rendering and correct behavior in stereo/XR rendering.

### Testing

-  Mono rendering: Sprite3D with `fixed_size=true` maintains constant screen size when moving to edges
-  Code logic verified for stereo mode (uses same calculation that fixed- #108188 )

### Files Changed

- `scene/resources/material.cpp` - Added runtime stereo/mono detection in fixed_size shader generation

Fixes #114995

