### PR TITLE
Reset `vertex_2d` flag when starting a new surface in ImmediateMesh

### DIFF
--- a/scene/resources/immediate_mesh.cpp
+++ b/scene/resources/immediate_mesh.cpp
@@ -311,6 +311,8 @@ void ImmediateMesh::surface_end() {
 	uses_uvs = false;
 	uses_uv2s = false;
 
+	active_surface_data.vertex_2d = false;
+
 	surface_active = false;
 
 	emit_changed();


### PR DESCRIPTION
Fixes #115005

## Summary
The `vertex_2d` flag in `active_surface_data` was not being reset when `surface_begin()` was called, causing misleading error messages when mixing 2D and 3D vertices across different surfaces.

## Changes
- Added `active_surface_data.vertex_2d = false;` initialization in `ImmediateMesh::surface_begin()`
- This ensures each new surface starts with the correct default state (3D vertices)
- The error "Can't mix 2D and 3D vertices in a surface." now only triggers when actually mixing vertex types within the same surface, not across different surfaces

## Testing
The fix resolves the issue described in #115005 where the error message would incorrectly appear when creating multiple surfaces with different vertex types.