### PR TITLE
Fix InputEventKey test using incorrect equality logic

### DIFF
--- a/tests/core/input/test_input_event_key.h
+++ b/tests/core/input/test_input_event_key.h
@@ -76,6 +76,23 @@ TEST_CASE("[InputEventKey] Key correctly stores and retrieves keycode with modif
 	CHECK(key.get_physical_keycode_with_modifiers() != Key::SPACE);
 }
 
+TEST_CASE("[InputEventKey] Modifiers persist after physical key change") {
+	InputEventKey key;
+
+	key.set_keycode(Key::ENTER);
+	key.set_ctrl_pressed(true);
+
+	CHECK(key.get_keycode_with_modifiers() == (Key::ENTER | KeyModifierMask::CTRL));
+	CHECK(key.get_keycode_with_modifiers() != Key::ENTER);
+
+	// Change key while modifier is active
+	key.set_physical_keycode(Key::SPACE);
+
+	// Modifier must persist
+	CHECK(key.get_physical_keycode_with_modifiers() == (Key::SPACE | KeyModifierMask::CTRL));
+	CHECK(key.get_physical_keycode_with_modifiers() != Key::SPACE);
+}
+
 TEST_CASE("[InputEventKey] Key correctly stores and retrieves unicode") {
 	InputEventKey key;
 

--- a/tests/core/input/test_shortcut.h
+++ b/tests/core/input/test_shortcut.h
@@ -103,7 +103,7 @@ TEST_CASE("[Shortcut] 'set_events_list' should result in the same events as the 
 	CHECK(result2->get_keycode() == k2->get_keycode());
 }
 
-TEST_CASE("[Shortcut] 'matches_event' should correctly match the same events") {
+TEST_CASE("[Shortcut] 'matches_event' should correctly match the same event") {
 	Ref<InputEventKey> original; // The one we compare with.
 	Ref<InputEventKey> similar_but_not_equal; // Same keycode, different event.
 	Ref<InputEventKey> different; // Different event, different keycode.

--- a/tests/core/input/test_shortcut.h
+++ b/tests/core/input/test_shortcut.h
@@ -103,7 +103,7 @@ TEST_CASE("[Shortcut] 'set_events_list' should result in the same events as the 
 	CHECK(result2->get_keycode() == k2->get_keycode());
 }
 
-TEST_CASE("[Shortcut] 'matches_event' should correctly match the same event") {
+TEST_CASE("[Shortcut] 'matches_event' should correctly match the same events") {
 	Ref<InputEventKey> original; // The one we compare with.
 	Ref<InputEventKey> similar_but_not_equal; // Same keycode, different event.
 	Ref<InputEventKey> different; // Different event, different keycode.
@@ -116,10 +116,10 @@ TEST_CASE("[Shortcut] 'matches_event' should correctly match the same event") {
 
 	original->set_keycode(Key::ENTER);
 	similar_but_not_equal->set_keycode(Key::ENTER);
-	similar_but_not_equal->set_keycode(Key::ESCAPE);
+	different->set_keycode(Key::ESCAPE);
 	copy = original;
 
-	// Only the copy is really the same, so only that one should match.
+	// Every instance that has the same keycode should match.
 	// The rest should not match.
 
 	Ref<InputEvent> e_original = original;
@@ -132,7 +132,7 @@ TEST_CASE("[Shortcut] 'matches_event' should correctly match the same event") {
 	Shortcut s;
 	s.set_events(a);
 
-	CHECK(s.matches_event(e_similar_but_not_equal) == false);
+	CHECK(s.matches_event(e_similar_but_not_equal) == true);
 	CHECK(s.matches_event(e_different) == false);
 
 	CHECK(s.matches_event(e_copy) == true);


### PR DESCRIPTION
## Commit 1 :
### Summary
Fixes an incorrect InputEventKey test that passed despite testing the wrong
behavior, due to using instance equality instead of keycode matching.

### Details
- `InputEventKey::is_match()` compares keycodes, not object instances
- The previous test set one variable twice and left the other unset
- This caused the test to pass while validating the wrong condition

### Tests
- Fixed the existing incorrect test


## Commit 2 :
- Added an edge case test ensuring modifiers remain unchanged when the
  physical key changes
