### PR TITLE
Don't process invisible tile editors

### DIFF
--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -3675,6 +3675,7 @@ void TileMapLayerEditor::_notification(int p_what) {
 			if (is_visible()) {
 				CanvasItemEditor::get_singleton()->set_current_tool(CanvasItemEditor::TOOL_SELECT);
 			}
+			set_process_internal(is_visible_in_tree());
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
@@ -3689,7 +3690,7 @@ void TileMapLayerEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			if (is_visible_in_tree() && tile_map_layer_changed_needs_update) {
+			if (tile_map_layer_changed_needs_update) {
 				_update_bottom_panel();
 				_update_layers_selector();
 				tabs_plugins[tabs_bar->get_current_tab()]->tile_set_changed();
@@ -4460,7 +4461,6 @@ void TileMapLayerEditor::update_layout(DockLayout p_layout) {
 }
 
 TileMapLayerEditor::TileMapLayerEditor() {
-	set_process_internal(true);
 	set_name(TTRC("TileMap"));
 	set_icon_name("TileMapDock");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_tile_map_bottom_panel", TTRC("Open TileMap Dock")));

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -2507,6 +2507,10 @@ void TileSetAtlasSourceEditor::_notification(int p_what) {
 				}
 			}
 		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			set_process_internal(is_visible_in_tree());
+		} break;
 	}
 }
 
@@ -2520,7 +2524,6 @@ void TileSetAtlasSourceEditor::_bind_methods() {
 TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	set_shortcut_context(this);
 	set_process_shortcut_input(true);
-	set_process_internal(true);
 	TileSetEditor::get_singleton()->register_split(this);
 
 	// Middle panel.

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -401,6 +401,7 @@ void TileSetEditor::_notification(int p_what) {
 			if (!is_visible_in_tree()) {
 				remove_expanded_editor();
 			}
+			set_process_internal(is_visible_in_tree());
 		} break;
 	}
 }
@@ -815,8 +816,6 @@ TileSetEditor::TileSetEditor() {
 	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
 	set_global(false);
 	set_transient(true);
-
-	set_process_internal(true);
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);


### PR DESCRIPTION
Makes tile editors only enable internal processing when visible, instead of always processing.