### PR TITLE
Ensure Project Manager shortcuts

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -1137,6 +1137,9 @@ void ProjectList::_list_item_input(const Ref<InputEvent> &p_ev, Control *p_hb) {
 	if (kev.is_valid() && kev->is_pressed()) {
 		switch (kev->get_keycode()) {
 			case Key::E: {
+				if (kev->is_command_or_control_pressed()) {
+					return; // Focus the search box by the ProjectManager.
+				}
 				_on_explore_pressed(clicked_project.path);
 				accept_event();
 			} break;

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -366,7 +366,7 @@ ProjectListItemControl::ProjectListItemControl() {
 
 	favorite_button = memnew(TextureButton);
 	favorite_button->set_name("FavoriteButton");
-	favorite_button->set_shortcut(ED_SHORTCUT("project_manager/toggle_favorite", TTRC("Toggle Favorite"), Key::F));
+	favorite_button->set_tooltip_text(TTRC("Toggle Favorite"));
 	favorite_button->set_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
 	// This makes the project's "hover" style display correctly when hovering the favorite icon.
 	favorite_button->set_mouse_filter(MOUSE_FILTER_PASS);
@@ -415,7 +415,7 @@ ProjectListItemControl::ProjectListItemControl() {
 		explore_button->set_name("ExploreButton");
 		explore_button->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
 		explore_button->set_mouse_filter(MOUSE_FILTER_PASS);
-		explore_button->set_shortcut(ED_SHORTCUT("project_manager/show_in_file_manager", TTRC("Open in File Manager"), Key::E));
+		explore_button->set_tooltip_text(TTRC("Open in file manager"));
 		explore_button->set_flat(true);
 		path_hb->add_child(explore_button);
 		explore_button->connect(SceneStringName(pressed), callable_mp(this, &ProjectListItemControl::_explore_button_pressed));
@@ -1129,29 +1129,6 @@ void ProjectList::_list_item_input(const Ref<InputEvent> &p_ev, Control *p_hb) {
 			}
 		} else if (mb->get_button_index() == MouseButton::RIGHT) {
 			_open_menu(mb->get_position(), p_hb);
-		}
-	}
-
-	Ref<InputEventKey> kev = p_ev;
-
-	if (kev.is_valid() && kev->is_pressed()) {
-		switch (kev->get_keycode()) {
-			case Key::E: {
-				if (kev->is_command_or_control_pressed()) {
-					return; // Focus the search box by the ProjectManager.
-				}
-				_on_explore_pressed(clicked_project.path);
-				accept_event();
-			} break;
-			case Key::F: {
-				if (kev->is_command_or_control_pressed()) {
-					return; // Focus the search box by the ProjectManager.
-				}
-				_on_favorite_pressed(p_hb);
-				accept_event();
-			} break;
-			default: {
-			} break;
 		}
 	}
 }

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -366,7 +366,7 @@ ProjectListItemControl::ProjectListItemControl() {
 
 	favorite_button = memnew(TextureButton);
 	favorite_button->set_name("FavoriteButton");
-	favorite_button->set_tooltip_text(TTRC("Toggle Favorite"));
+	favorite_button->set_shortcut(ED_SHORTCUT("project_manager/toggle_favorite", TTRC("Toggle Favorite"), Key::F));
 	favorite_button->set_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
 	// This makes the project's "hover" style display correctly when hovering the favorite icon.
 	favorite_button->set_mouse_filter(MOUSE_FILTER_PASS);
@@ -415,7 +415,7 @@ ProjectListItemControl::ProjectListItemControl() {
 		explore_button->set_name("ExploreButton");
 		explore_button->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
 		explore_button->set_mouse_filter(MOUSE_FILTER_PASS);
-		explore_button->set_tooltip_text(TTRC("Open in file manager"));
+		explore_button->set_shortcut(ED_SHORTCUT("project_manager/show_in_file_manager", TTRC("Open in File Manager"), Key::E));
 		explore_button->set_flat(true);
 		path_hb->add_child(explore_button);
 		explore_button->connect(SceneStringName(pressed), callable_mp(this, &ProjectListItemControl::_explore_button_pressed));

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -270,6 +270,7 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 			erase_btn->set_button_icon(get_editor_theme_icon("Remove"));
 			erase_missing_btn->set_button_icon(get_editor_theme_icon("Clear"));
 			create_tag_btn->set_button_icon(get_editor_theme_icon("Add"));
+			show_in_file_manager_btn->set_button_icon(get_editor_theme_icon("Load"));
 			donate_btn->set_button_icon(get_editor_theme_icon("Heart"));
 
 			tag_error->add_theme_color_override(SceneStringName(font_color), get_theme_color("error_color", EditorStringName(Editor)));
@@ -284,6 +285,7 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 			rename_btn->add_theme_constant_override("h_separation", h_separation);
 			duplicate_btn->add_theme_constant_override("h_separation", h_separation);
 			manage_tags_btn->add_theme_constant_override("h_separation", h_separation);
+			show_in_file_manager_btn->add_theme_constant_override("h_separation", h_separation);
 			erase_btn->add_theme_constant_override("h_separation", h_separation);
 			erase_missing_btn->add_theme_constant_override("h_separation", h_separation);
 
@@ -850,6 +852,7 @@ void ProjectManager::_update_project_buttons() {
 		}
 	}
 
+	show_in_file_manager_btn->set_disabled(empty_selection || is_missing_project_selected);
 	erase_btn->set_disabled(empty_selection);
 	open_btn->set_disabled(empty_selection || is_missing_project_selected);
 	open_options_btn->set_disabled(empty_selection || is_missing_project_selected);
@@ -1314,6 +1317,14 @@ void ProjectManager::_open_donate_page() {
 	OS::get_singleton()->shell_open("https://fund.godotengine.org/?ref=project_manager");
 }
 
+void ProjectManager::_show_selected_projects_in_file_manager() {
+	// const Vector<Item> &selected_list = project_list->get_selected_projects();
+	const HashSet<String> &selected_list = project_list->get_selected_project_keys();
+	for (const String &path : selected_list) {
+		OS::get_singleton()->shell_show_in_file_manager(path.ptr(), true);
+	}
+}
+
 // Object methods.
 
 ProjectManager::ProjectManager() {
@@ -1701,6 +1712,12 @@ ProjectManager::ProjectManager() {
 			manage_tags_btn->set_text(TTRC("Manage Tags"));
 			manage_tags_btn->set_shortcut(ED_SHORTCUT("project_manager/project_tags", TTRC("Manage Tags"), KeyModifierMask::CMD_OR_CTRL | Key::T));
 			sidebar_buttons_containter->add_child(manage_tags_btn);
+
+			show_in_file_manager_btn = memnew(Button);
+			show_in_file_manager_btn->set_text(TTRC("File Manager"));
+			show_in_file_manager_btn->set_shortcut(ED_SHORTCUT("project_manager/show_in_file_manager", TTRC("Show in File Manager"), Key::E));
+			show_in_file_manager_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_show_selected_projects_in_file_manager));
+			sidebar_buttons_containter->add_child(show_in_file_manager_btn);
 
 			erase_btn = memnew(Button);
 			erase_btn->set_text(TTRC("Remove"));

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -163,6 +163,7 @@ class ProjectManager : public Control {
 	Button *manage_tags_btn = nullptr;
 	Button *erase_btn = nullptr;
 	Button *erase_missing_btn = nullptr;
+	Button *show_in_file_manager_btn = nullptr;
 	Button *donate_btn = nullptr;
 
 	HBoxContainer *open_btn_container = nullptr;
@@ -205,6 +206,7 @@ class ProjectManager : public Control {
 	void _open_options_popup();
 	void _open_recovery_mode_ask(bool manual = false);
 	void _open_donate_page();
+	void _show_selected_projects_in_file_manager();
 
 	void _on_project_created(const String &dir, bool edit);
 	void _on_project_duplicated(const String &p_original_path, const String &p_duplicate_path, bool p_edit);


### PR DESCRIPTION
Fixes #114981 
The problem is located and fixed here c29200dbefe5466e02cfdcd9a404e372b33bd93d.

For furthur work, some advice would be really nice.
Personally, it is better to delete the shortcuts of "Show in File Manager"(E) and "Toggle Favourite"(F), There are buttons for the functionalities already, and shortcuts with one single key do not look good.
Alternatively, make the shortcuts "correct" by adding them to Project Settings and etc. Which should be something like in 8ffab2e4ea05ad8c3d4905d3a8225d2b1537569d