### PR TITLE
Fix dock names in menu tooltips not translated

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -350,9 +350,9 @@ void EditorDockManager::update_docks_menu() {
 		docks_menu->set_item_icon(id, icon.is_valid() ? icon : default_icon);
 		if (!dock->is_open) {
 			docks_menu->set_item_icon_modulate(id, closed_icon_color_mod);
-			docks_menu->set_item_tooltip(id, vformat(TTR("Open the %s dock."), dock->get_display_title()));
+			docks_menu->set_item_tooltip(id, vformat(TTR("Open the %s dock."), TTR(dock->get_display_title())));
 		} else {
-			docks_menu->set_item_tooltip(id, vformat(TTR("Focus on the %s dock."), dock->get_display_title()));
+			docks_menu->set_item_tooltip(id, vformat(TTR("Focus on the %s dock."), TTR(dock->get_display_title())));
 		}
 		docks_menu_docks.push_back(dock);
 		id++;


### PR DESCRIPTION
#113688 for dock menu.

<img width="409" height="62" alt="image" src="https://github.com/user-attachments/assets/fb72468a-8d87-4c73-873b-015801d7d8f2" />