### PR TITLE
Add inner tab styling to Manage Theme Items dialog

### DIFF
--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -2130,6 +2130,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 
 	// Import Items tab.
 	TabContainer *import_tc = memnew(TabContainer);
+	import_tc->set_theme_type_variation("TabContainerInner");
 	import_tc->set_tab_alignment(TabBar::ALIGNMENT_CENTER);
 	tc->add_child(import_tc);
 	tc->set_tab_title(1, TTR("Import Items"));


### PR DESCRIPTION
Before/After


<img width="872" height="745" alt="Screenshot_20260117_143654" src="https://github.com/user-attachments/assets/694057b4-5f50-4134-80b4-cee8662b09e3" />

<img width="872" height="745" alt="Screenshot_20260117_143748" src="https://github.com/user-attachments/assets/a5c40388-1314-4ad1-8a4b-ead7a8c2599f" />
