### PR TITLE
Round scaled values inside theme files

### DIFF
--- a/editor/themes/editor_scale.h
+++ b/editor/themes/editor_scale.h
@@ -39,3 +39,5 @@ public:
 };
 
 #define EDSCALE (EditorScale::get_scale())
+
+#define EDSCALE_RND(m_value) (Math::round(m_value * EDSCALE))

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -247,13 +247,13 @@ void ThemeClassic::populate_shared_styles(const Ref<EditorTheme> &p_theme, Edito
 
 		// Button styles.
 		{
-			p_config.widget_margin = Vector2(p_config.increased_margin + 2, p_config.increased_margin + 1) * EDSCALE;
+			p_config.widget_margin = Vector2(EDSCALE_RND(p_config.increased_margin + 2), EDSCALE_RND(p_config.increased_margin + 1));
 
 			p_config.button_style = p_config.base_style->duplicate();
 			p_config.button_style->set_content_margin_individual(p_config.widget_margin.x, p_config.widget_margin.y, p_config.widget_margin.x, p_config.widget_margin.y);
 			p_config.button_style->set_bg_color(p_config.dark_color_1);
 			if (p_config.draw_extra_borders) {
-				p_config.button_style->set_border_width_all(Math::round(EDSCALE));
+				p_config.button_style->set_border_width_all(EDSCALE_RND(1));
 				p_config.button_style->set_border_color(p_config.extra_border_color_1);
 			} else {
 				p_config.button_style->set_border_color(p_config.dark_color_2);
@@ -290,15 +290,15 @@ void ThemeClassic::populate_shared_styles(const Ref<EditorTheme> &p_theme, Edito
 			p_config.popup_style->set_content_margin_all(p_config.popup_margin);
 			p_config.popup_style->set_border_color(p_config.contrast_color_1);
 			p_config.popup_style->set_shadow_color(p_config.shadow_color);
-			p_config.popup_style->set_shadow_size(4 * EDSCALE);
+			p_config.popup_style->set_shadow_size(EDSCALE_RND(4));
 			// Popups are separate windows by default in the editor. Windows currently don't support per-pixel transparency
 			// in 4.0, and even if it was, it may not always work in practice (e.g. running with compositing disabled).
 			p_config.popup_style->set_corner_radius_all(0);
 
 			p_config.popup_border_style = p_config.popup_style->duplicate();
-			p_config.popup_border_style->set_content_margin_all(MAX(Math::round(EDSCALE), p_config.border_width) + 2 + (p_config.base_margin * 1.5) * EDSCALE);
+			p_config.popup_border_style->set_content_margin_all(MAX(EDSCALE_RND(1), p_config.border_width) + 2 + EDSCALE_RND(p_config.base_margin * 1.5));
 			// Always display a border for popups like PopupMenus so they can be distinguished from their background.
-			p_config.popup_border_style->set_border_width_all(MAX(Math::round(EDSCALE), p_config.border_width));
+			p_config.popup_border_style->set_border_width_all(MAX(EDSCALE_RND(1), p_config.border_width));
 			if (p_config.draw_extra_borders) {
 				p_config.popup_border_style->set_border_color(p_config.extra_border_color_2);
 			} else {
@@ -307,8 +307,8 @@ void ThemeClassic::populate_shared_styles(const Ref<EditorTheme> &p_theme, Edito
 
 			p_config.window_style = p_config.popup_style->duplicate();
 			p_config.window_style->set_border_color(p_config.base_color);
-			p_config.window_style->set_border_width(SIDE_TOP, 24 * EDSCALE);
-			p_config.window_style->set_expand_margin(SIDE_TOP, 24 * EDSCALE);
+			p_config.window_style->set_border_width(SIDE_TOP, EDSCALE_RND(24));
+			p_config.window_style->set_expand_margin(SIDE_TOP, EDSCALE_RND(24));
 
 			// Prevent corner artifacts between window title and body.
 			p_config.dialog_style = p_config.base_style->duplicate();
@@ -316,7 +316,7 @@ void ThemeClassic::populate_shared_styles(const Ref<EditorTheme> &p_theme, Edito
 			p_config.dialog_style->set_corner_radius(CORNER_TOP_RIGHT, 0);
 			p_config.dialog_style->set_content_margin_all(p_config.popup_margin);
 			// Prevent visible line between window title and body.
-			p_config.dialog_style->set_expand_margin(SIDE_BOTTOM, 2 * EDSCALE);
+			p_config.dialog_style->set_expand_margin(SIDE_BOTTOM, EDSCALE_RND(2));
 		}
 
 		// Panels.
@@ -328,7 +328,7 @@ void ThemeClassic::populate_shared_styles(const Ref<EditorTheme> &p_theme, Edito
 			// Content panel for tabs and similar containers.
 
 			// Compensate for the border.
-			const int content_panel_margin = p_config.base_margin * EDSCALE + p_config.border_width;
+			const int content_panel_margin = EDSCALE_RND(p_config.base_margin) + p_config.border_width;
 
 			p_config.content_panel_style = p_config.base_style->duplicate();
 			p_config.content_panel_style->set_border_color(p_config.dark_color_3);
@@ -336,7 +336,7 @@ void ThemeClassic::populate_shared_styles(const Ref<EditorTheme> &p_theme, Edito
 			p_config.content_panel_style->set_border_width(Side::SIDE_TOP, 0);
 			p_config.content_panel_style->set_corner_radius(CORNER_TOP_LEFT, 0);
 			p_config.content_panel_style->set_corner_radius(CORNER_TOP_RIGHT, 0);
-			p_config.content_panel_style->set_content_margin_individual(content_panel_margin, 2 * EDSCALE + content_panel_margin, content_panel_margin, content_panel_margin);
+			p_config.content_panel_style->set_content_margin_individual(content_panel_margin, EDSCALE_RND(2) + content_panel_margin, content_panel_margin, content_panel_margin);
 
 			p_config.tab_container_style = p_config.content_panel_style;
 
@@ -346,7 +346,7 @@ void ThemeClassic::populate_shared_styles(const Ref<EditorTheme> &p_theme, Edito
 			// Make Trees easier to distinguish from other controls by using a darker background color.
 			p_config.tree_panel_style->set_bg_color(p_config.dark_color_1.lerp(p_config.dark_color_2, 0.5));
 			if (p_config.draw_extra_borders) {
-				p_config.tree_panel_style->set_border_width_all(Math::round(EDSCALE));
+				p_config.tree_panel_style->set_border_width_all(EDSCALE_RND(1));
 				p_config.tree_panel_style->set_border_color(p_config.extra_border_color_2);
 			} else {
 				p_config.tree_panel_style->set_border_color(p_config.dark_color_3);
@@ -374,10 +374,10 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 
 			Ref<StyleBoxFlat> style_tooltip = p_config.popup_style->duplicate();
 			style_tooltip->set_shadow_size(0);
-			style_tooltip->set_content_margin_all(p_config.base_margin * EDSCALE * 0.5);
+			style_tooltip->set_content_margin_all(EDSCALE_RND(p_config.base_margin * 0.5));
 			style_tooltip->set_bg_color(p_config.dark_color_3 * Color(0.8, 0.8, 0.8, 0.9));
 			if (p_config.draw_extra_borders) {
-				style_tooltip->set_border_width_all(Math::round(EDSCALE));
+				style_tooltip->set_border_width_all(EDSCALE_RND(1));
 				style_tooltip->set_border_color(p_config.extra_border_color_2);
 			} else {
 				style_tooltip->set_border_width_all(0);
@@ -414,7 +414,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 		p_theme->set_color("icon_pressed_color", "Button", p_config.icon_pressed_color);
 		p_theme->set_color("icon_disabled_color", "Button", p_config.icon_disabled_color);
 
-		p_theme->set_constant("h_separation", "Button", 4 * EDSCALE);
+		p_theme->set_constant("h_separation", "Button", EDSCALE_RND(4));
 		p_theme->set_constant("outline_size", "Button", 0);
 
 		p_theme->set_constant("align_to_largest_stylebox", "Button", 1); // Enabled.
@@ -442,7 +442,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 		p_theme->set_color("font_disabled_color", "MenuBar", p_config.font_disabled_color);
 		p_theme->set_color("font_outline_color", "MenuBar", p_config.font_outline_color);
 
-		p_theme->set_constant("h_separation", "MenuBar", 4 * EDSCALE);
+		p_theme->set_constant("h_separation", "MenuBar", EDSCALE_RND(4));
 		p_theme->set_constant("outline_size", "MenuBar", 0);
 
 		// OptionButton.
@@ -453,11 +453,11 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			Ref<StyleBoxFlat> option_button_pressed_style = p_config.button_style_pressed->duplicate();
 			Ref<StyleBoxFlat> option_button_disabled_style = p_config.button_style_disabled->duplicate();
 
-			option_button_focus_style->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
-			option_button_normal_style->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
-			option_button_hover_style->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
-			option_button_pressed_style->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
-			option_button_disabled_style->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
+			option_button_focus_style->set_content_margin(SIDE_RIGHT, EDSCALE_RND(4));
+			option_button_normal_style->set_content_margin(SIDE_RIGHT, EDSCALE_RND(4));
+			option_button_hover_style->set_content_margin(SIDE_RIGHT, EDSCALE_RND(4));
+			option_button_pressed_style->set_content_margin(SIDE_RIGHT, EDSCALE_RND(4));
+			option_button_disabled_style->set_content_margin(SIDE_RIGHT, EDSCALE_RND(4));
 
 			p_theme->set_stylebox("focus", "OptionButton", option_button_focus_style);
 			p_theme->set_stylebox(CoreStringName(normal), "OptionButton", p_config.button_style);
@@ -485,9 +485,9 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			p_theme->set_color("icon_disabled_color", "OptionButton", p_config.icon_disabled_color);
 
 			p_theme->set_icon("arrow", "OptionButton", p_theme->get_icon(SNAME("GuiOptionArrow"), EditorStringName(EditorIcons)));
-			p_theme->set_constant("arrow_margin", "OptionButton", p_config.widget_margin.x - 2 * EDSCALE);
+			p_theme->set_constant("arrow_margin", "OptionButton", p_config.widget_margin.x - EDSCALE_RND(2));
 			p_theme->set_constant("modulate_arrow", "OptionButton", true);
-			p_theme->set_constant("h_separation", "OptionButton", 4 * EDSCALE);
+			p_theme->set_constant("h_separation", "OptionButton", EDSCALE_RND(4));
 			p_theme->set_constant("outline_size", "OptionButton", 0);
 		}
 
@@ -523,7 +523,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 		p_theme->set_color("icon_pressed_color", "CheckButton", p_config.icon_pressed_color);
 		p_theme->set_color("icon_disabled_color", "CheckButton", p_config.icon_disabled_color);
 
-		p_theme->set_constant("h_separation", "CheckButton", 8 * EDSCALE);
+		p_theme->set_constant("h_separation", "CheckButton", EDSCALE_RND(8));
 		p_theme->set_constant("check_v_offset", "CheckButton", 0);
 		p_theme->set_constant("outline_size", "CheckButton", 0);
 
@@ -560,7 +560,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			p_theme->set_color("icon_pressed_color", "CheckBox", p_config.icon_pressed_color);
 			p_theme->set_color("icon_disabled_color", "CheckBox", p_config.icon_disabled_color);
 
-			p_theme->set_constant("h_separation", "CheckBox", 8 * EDSCALE);
+			p_theme->set_constant("h_separation", "CheckBox", EDSCALE_RND(8));
 			p_theme->set_constant("check_v_offset", "CheckBox", 0);
 			p_theme->set_constant("outline_size", "CheckBox", 0);
 		}
@@ -620,28 +620,28 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			p_theme->set_color("font_outline_color", "Tree", p_config.font_outline_color);
 			p_theme->set_color("title_button_color", "Tree", p_config.font_color);
 
-			p_theme->set_constant("v_separation", "Tree", p_config.base_margin * EDSCALE);
-			p_theme->set_constant("h_separation", "Tree", (p_config.increased_margin + 2) * EDSCALE);
+			p_theme->set_constant("v_separation", "Tree", EDSCALE_RND(p_config.base_margin));
+			p_theme->set_constant("h_separation", "Tree", EDSCALE_RND(p_config.increased_margin + 2));
 			p_theme->set_constant("guide_width", "Tree", p_config.border_width);
-			p_theme->set_constant("item_margin", "Tree", MAX(3 * p_config.increased_margin * EDSCALE, 12 * EDSCALE));
-			p_theme->set_constant("inner_item_margin_top", "Tree", p_config.base_margin * 0.75 * EDSCALE);
-			p_theme->set_constant("inner_item_margin_bottom", "Tree", p_config.base_margin * 0.75 * EDSCALE);
-			p_theme->set_constant("inner_item_margin_left", "Tree", p_config.increased_margin * EDSCALE);
-			p_theme->set_constant("inner_item_margin_right", "Tree", p_config.increased_margin * EDSCALE);
-			p_theme->set_constant("check_h_separation", "Tree", (p_config.increased_margin + 2) * EDSCALE);
-			p_theme->set_constant("icon_h_separation", "Tree", (p_config.increased_margin + 2) * EDSCALE);
-			p_theme->set_constant("button_margin", "Tree", p_config.base_margin * EDSCALE);
+			p_theme->set_constant("item_margin", "Tree", EDSCALE_RND(MAX(3 * p_config.increased_margin, 12)));
+			p_theme->set_constant("inner_item_margin_top", "Tree", EDSCALE_RND(p_config.base_margin * 0.75));
+			p_theme->set_constant("inner_item_margin_bottom", "Tree", EDSCALE_RND(p_config.base_margin * 0.75));
+			p_theme->set_constant("inner_item_margin_left", "Tree", EDSCALE_RND(p_config.increased_margin));
+			p_theme->set_constant("inner_item_margin_right", "Tree", EDSCALE_RND(p_config.increased_margin));
+			p_theme->set_constant("check_h_separation", "Tree", EDSCALE_RND(p_config.increased_margin + 2));
+			p_theme->set_constant("icon_h_separation", "Tree", EDSCALE_RND(p_config.increased_margin + 2));
+			p_theme->set_constant("button_margin", "Tree", EDSCALE_RND(p_config.base_margin));
 			p_theme->set_constant("dragging_unfold_wait_msec", "Tree", p_config.dragging_hover_wait_msec);
 			p_theme->set_constant("scroll_max_sticky_items", "Tree", p_config.max_sticky_tree_items);
-			p_theme->set_constant("scroll_border", "Tree", 40 * EDSCALE);
+			p_theme->set_constant("scroll_border", "Tree", EDSCALE_RND(40));
 			p_theme->set_constant("scroll_speed", "Tree", 12);
 			p_theme->set_constant("outline_size", "Tree", 0);
 			p_theme->set_constant("scrollbar_margin_left", "Tree", 0);
 			p_theme->set_constant("scrollbar_margin_top", "Tree", 0);
 			p_theme->set_constant("scrollbar_margin_right", "Tree", 0);
 			p_theme->set_constant("scrollbar_margin_bottom", "Tree", 0);
-			p_theme->set_constant("scrollbar_h_separation", "Tree", 1 * EDSCALE);
-			p_theme->set_constant("scrollbar_v_separation", "Tree", 1 * EDSCALE);
+			p_theme->set_constant("scrollbar_h_separation", "Tree", EDSCALE_RND(1));
+			p_theme->set_constant("scrollbar_v_separation", "Tree", EDSCALE_RND(1));
 
 			Color relationship_line_color = p_config.mono_color * Color(1, 1, 1, p_config.relationship_line_opacity);
 
@@ -739,7 +739,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			style_itemlist_bg->set_bg_color(p_config.dark_color_1);
 
 			if (p_config.draw_extra_borders) {
-				style_itemlist_bg->set_border_width_all(Math::round(EDSCALE));
+				style_itemlist_bg->set_border_width_all(EDSCALE_RND(1));
 				style_itemlist_bg->set_border_color(p_config.extra_border_color_2);
 			} else {
 				style_itemlist_bg->set_border_width_all(p_config.border_width);
@@ -748,7 +748,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 
 			Ref<StyleBoxFlat> style_itemlist_cursor = p_config.base_style->duplicate();
 			style_itemlist_cursor->set_draw_center(false);
-			style_itemlist_cursor->set_border_width_all(MAX(1 * EDSCALE, p_config.border_width));
+			style_itemlist_cursor->set_border_width_all(MAX(EDSCALE_RND(1), p_config.border_width));
 			style_itemlist_cursor->set_border_color(p_config.highlight_color);
 
 			Ref<StyleBoxFlat> style_itemlist_hover = style_tree_selected->duplicate();
@@ -774,10 +774,10 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			p_theme->set_color("font_selected_color", "ItemList", p_config.mono_color_font);
 			p_theme->set_color("font_outline_color", "ItemList", p_config.font_outline_color);
 			p_theme->set_color("guide_color", "ItemList", Color(1, 1, 1, 0));
-			p_theme->set_constant("v_separation", "ItemList", p_config.forced_even_separation * EDSCALE);
-			p_theme->set_constant("h_separation", "ItemList", (p_config.increased_margin + 2) * EDSCALE);
+			p_theme->set_constant("v_separation", "ItemList", EDSCALE_RND(p_config.forced_even_separation));
+			p_theme->set_constant("h_separation", "ItemList", EDSCALE_RND(p_config.increased_margin + 2));
 			p_theme->set_constant("scroll_bar_h_separation", "ItemList", p_config.separation_margin);
-			p_theme->set_constant("icon_margin", "ItemList", (p_config.increased_margin + 2) * EDSCALE);
+			p_theme->set_constant("icon_margin", "ItemList", EDSCALE_RND(p_config.increased_margin + 2));
 			p_theme->set_constant(SceneStringName(line_separation), "ItemList", p_config.separation_margin);
 			p_theme->set_constant("outline_size", "ItemList", 0);
 		}
@@ -796,8 +796,8 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 		// When using a border width greater than 0, visually line up the left of the selected tab with the underlying panel.
 		style_tab_base->set_expand_margin(SIDE_LEFT, -p_config.border_width);
 
-		style_tab_base->set_content_margin(SIDE_LEFT, p_config.widget_margin.x + 5 * EDSCALE);
-		style_tab_base->set_content_margin(SIDE_RIGHT, p_config.widget_margin.x + 5 * EDSCALE);
+		style_tab_base->set_content_margin(SIDE_LEFT, p_config.widget_margin.x + EDSCALE_RND(5));
+		style_tab_base->set_content_margin(SIDE_RIGHT, p_config.widget_margin.x + EDSCALE_RND(5));
 		style_tab_base->set_content_margin(SIDE_BOTTOM, p_config.widget_margin.y);
 		style_tab_base->set_content_margin(SIDE_TOP, p_config.widget_margin.y);
 
@@ -805,7 +805,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 
 		style_tab_selected->set_bg_color(p_config.base_color);
 		// Add a highlight line at the top of the selected tab.
-		style_tab_selected->set_border_width(SIDE_TOP, Math::round(2 * EDSCALE));
+		style_tab_selected->set_border_width(SIDE_TOP, Math::round(EDSCALE_RND(2)));
 		// Make the highlight line prominent, but not too prominent as to not be distracting.
 		Color tab_highlight = p_config.dark_color_2.lerp(p_config.accent_color, 0.75);
 		style_tab_selected->set_border_color(tab_highlight);
@@ -884,14 +884,14 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 
 		p_theme->set_constant("side_margin", "TabContainer", 0);
 		p_theme->set_constant("outline_size", "TabContainer", 0);
-		p_theme->set_constant("h_separation", "TabBar", 4 * EDSCALE);
+		p_theme->set_constant("h_separation", "TabBar", EDSCALE_RND(4));
 		p_theme->set_constant("outline_size", "TabBar", 0);
 		p_theme->set_constant("hover_switch_wait_msec", "TabBar", p_config.dragging_hover_wait_msec);
 	}
 
 	// Separators.
-	p_theme->set_stylebox("separator", "HSeparator", EditorThemeManager::make_line_stylebox(p_config.separator_color, MAX(Math::round(EDSCALE), p_config.border_width)));
-	p_theme->set_stylebox("separator", "VSeparator", EditorThemeManager::make_line_stylebox(p_config.separator_color, MAX(Math::round(EDSCALE), p_config.border_width), 0, 0, true));
+	p_theme->set_stylebox("separator", "HSeparator", EditorThemeManager::make_line_stylebox(p_config.separator_color, MAX(EDSCALE_RND(1), p_config.border_width)));
+	p_theme->set_stylebox("separator", "VSeparator", EditorThemeManager::make_line_stylebox(p_config.separator_color, MAX(EDSCALE_RND(1), p_config.border_width), 0, 0, true));
 
 	// LineEdit & TextEdit.
 	{
@@ -902,12 +902,12 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 		text_editor_style->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
 
 		if (p_config.draw_extra_borders) {
-			text_editor_style->set_border_width_all(Math::round(EDSCALE));
+			text_editor_style->set_border_width_all(EDSCALE_RND(1));
 			text_editor_style->set_border_color(p_config.extra_border_color_1);
 		} else {
 			// Add a bottom line to make LineEdits more visible, especially in sectioned inspectors
 			// such as the Project Settings.
-			text_editor_style->set_border_width(SIDE_BOTTOM, Math::round(2 * EDSCALE));
+			text_editor_style->set_border_width(SIDE_BOTTOM, Math::round(EDSCALE_RND(2)));
 			text_editor_style->set_border_color(p_config.dark_color_2);
 		}
 
@@ -953,7 +953,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 		p_theme->set_color("caret_color", "TextEdit", p_config.font_color);
 		p_theme->set_color("selection_color", "TextEdit", p_config.selection_color);
 
-		p_theme->set_constant("line_spacing", "TextEdit", 4 * EDSCALE);
+		p_theme->set_constant("line_spacing", "TextEdit", EDSCALE_RND(4));
 		p_theme->set_constant("outline_size", "TextEdit", 0);
 		p_theme->set_constant("caret_width", "TextEdit", 1);
 	}
@@ -987,12 +987,12 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 		p_theme->set_constant("separation", "HSplitContainer", p_config.separation_margin);
 		p_theme->set_constant("separation", "VSplitContainer", p_config.separation_margin);
 
-		p_theme->set_constant("minimum_grab_thickness", "SplitContainer", p_config.increased_margin * EDSCALE);
-		p_theme->set_constant("minimum_grab_thickness", "HSplitContainer", p_config.increased_margin * EDSCALE);
-		p_theme->set_constant("minimum_grab_thickness", "VSplitContainer", p_config.increased_margin * EDSCALE);
+		p_theme->set_constant("minimum_grab_thickness", "SplitContainer", EDSCALE_RND(p_config.increased_margin));
+		p_theme->set_constant("minimum_grab_thickness", "HSplitContainer", EDSCALE_RND(p_config.increased_margin));
+		p_theme->set_constant("minimum_grab_thickness", "VSplitContainer", EDSCALE_RND(p_config.increased_margin));
 
 		// GridContainer.
-		p_theme->set_constant("v_separation", "GridContainer", Math::round(p_config.widget_margin.y - 2 * EDSCALE));
+		p_theme->set_constant("v_separation", "GridContainer", Math::round(p_config.widget_margin.y - EDSCALE_RND(2)));
 
 		// FoldableContainer
 
@@ -1039,19 +1039,19 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 		p_theme->set_color("title_color", "Window", p_config.font_color);
 		p_theme->set_icon("close", "Window", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("close_pressed", "Window", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
-		p_theme->set_constant("close_h_offset", "Window", 22 * EDSCALE);
-		p_theme->set_constant("close_v_offset", "Window", 20 * EDSCALE);
-		p_theme->set_constant("title_height", "Window", 24 * EDSCALE);
-		p_theme->set_constant("resize_margin", "Window", 4 * EDSCALE);
+		p_theme->set_constant("close_h_offset", "Window", EDSCALE_RND(22));
+		p_theme->set_constant("close_v_offset", "Window", EDSCALE_RND(20));
+		p_theme->set_constant("title_height", "Window", EDSCALE_RND(24));
+		p_theme->set_constant("resize_margin", "Window", EDSCALE_RND(4));
 		p_theme->set_font("title_font", "Window", p_theme->get_font(SNAME("title"), EditorStringName(EditorFonts)));
 		p_theme->set_font_size("title_font_size", "Window", p_theme->get_font_size(SNAME("title_size"), EditorStringName(EditorFonts)));
 
 		// AcceptDialog.
 		p_theme->set_stylebox(SceneStringName(panel), "AcceptDialog", p_config.dialog_style);
-		p_theme->set_constant("buttons_separation", "AcceptDialog", 8 * EDSCALE);
+		p_theme->set_constant("buttons_separation", "AcceptDialog", EDSCALE_RND(8));
 		// Make buttons with short texts such as "OK" easier to click/tap.
-		p_theme->set_constant("buttons_min_width", "AcceptDialog", p_config.dialogs_buttons_min_size.x * EDSCALE);
-		p_theme->set_constant("buttons_min_height", "AcceptDialog", p_config.dialogs_buttons_min_size.y * EDSCALE);
+		p_theme->set_constant("buttons_min_width", "AcceptDialog", EDSCALE_RND(p_config.dialogs_buttons_min_size.x));
+		p_theme->set_constant("buttons_min_height", "AcceptDialog", EDSCALE_RND(p_config.dialogs_buttons_min_size.y));
 
 		// FileDialog.
 		p_theme->set_icon("folder", "FileDialog", p_theme->get_icon("Folder", EditorStringName(EditorIcons)));
@@ -1094,7 +1094,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			// Use 1 pixel for the sides, since if 0 is used, the highlight of hovered items is drawn
 			// on top of the popup border. This causes a 'gap' in the panel border when an item is highlighted,
 			// and it looks weird. 1px solves this.
-			style_popup_menu->set_content_margin_individual(Math::round(EDSCALE), 2 * EDSCALE, Math::round(EDSCALE), 2 * EDSCALE);
+			style_popup_menu->set_content_margin_individual(EDSCALE_RND(1), EDSCALE_RND(2), EDSCALE_RND(1), EDSCALE_RND(2));
 			p_theme->set_stylebox(SceneStringName(panel), "PopupMenu", style_popup_menu);
 
 			Ref<StyleBoxFlat> style_menu_hover = p_config.button_style_hover->duplicate();
@@ -1104,19 +1104,19 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 
 			Ref<StyleBoxLine> style_popup_separator(memnew(StyleBoxLine));
 			style_popup_separator->set_color(p_config.separator_color);
-			style_popup_separator->set_grow_begin(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
-			style_popup_separator->set_grow_end(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
-			style_popup_separator->set_thickness(MAX(Math::round(EDSCALE), p_config.border_width));
+			style_popup_separator->set_grow_begin(EDSCALE_RND(1) - MAX(EDSCALE_RND(1), p_config.border_width));
+			style_popup_separator->set_grow_end(EDSCALE_RND(1) - MAX(EDSCALE_RND(1), p_config.border_width));
+			style_popup_separator->set_thickness(MAX(EDSCALE_RND(1), p_config.border_width));
 
 			Ref<StyleBoxLine> style_popup_labeled_separator_left(memnew(StyleBoxLine));
-			style_popup_labeled_separator_left->set_grow_begin(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
+			style_popup_labeled_separator_left->set_grow_begin(EDSCALE_RND(1) - MAX(EDSCALE_RND(1), p_config.border_width));
 			style_popup_labeled_separator_left->set_color(p_config.separator_color);
-			style_popup_labeled_separator_left->set_thickness(MAX(Math::round(EDSCALE), p_config.border_width));
+			style_popup_labeled_separator_left->set_thickness(MAX(EDSCALE_RND(1), p_config.border_width));
 
 			Ref<StyleBoxLine> style_popup_labeled_separator_right(memnew(StyleBoxLine));
-			style_popup_labeled_separator_right->set_grow_end(Math::round(EDSCALE) - MAX(Math::round(EDSCALE), p_config.border_width));
+			style_popup_labeled_separator_right->set_grow_end(EDSCALE_RND(1) - MAX(EDSCALE_RND(1), p_config.border_width));
 			style_popup_labeled_separator_right->set_color(p_config.separator_color);
-			style_popup_labeled_separator_right->set_thickness(MAX(Math::round(EDSCALE), p_config.border_width));
+			style_popup_labeled_separator_right->set_thickness(MAX(EDSCALE_RND(1), p_config.border_width));
 
 			p_theme->set_stylebox("separator", "PopupMenu", style_popup_separator);
 			p_theme->set_stylebox("labeled_separator_left", "PopupMenu", style_popup_labeled_separator_left);
@@ -1143,7 +1143,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			p_theme->set_icon("submenu_mirrored", "PopupMenu", p_theme->get_icon(SNAME("ArrowLeft"), EditorStringName(EditorIcons)));
 			p_theme->set_icon("search", "PopupMenu", p_theme->get_icon(SNAME("Search"), EditorStringName(EditorIcons)));
 
-			p_theme->set_constant("h_separation", "PopupMenu", 4 * EDSCALE);
+			p_theme->set_constant("h_separation", "PopupMenu", EDSCALE_RND(4));
 			int v_sep = (p_config.enable_touch_optimizations ? 12 : p_config.forced_even_separation) * EDSCALE;
 			p_theme->set_constant("v_separation", "PopupMenu", v_sep);
 			p_theme->set_constant("search_bar_separation", "PopupMenu", v_sep);
@@ -1229,9 +1229,9 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 		p_theme->set_color("font_outline_color", "RichTextLabel", p_config.font_outline_color);
 		p_theme->set_color("selection_color", "RichTextLabel", p_config.selection_color);
 
-		p_theme->set_constant("shadow_offset_x", "RichTextLabel", 1 * EDSCALE);
-		p_theme->set_constant("shadow_offset_y", "RichTextLabel", 1 * EDSCALE);
-		p_theme->set_constant("shadow_outline_size", "RichTextLabel", 1 * EDSCALE);
+		p_theme->set_constant("shadow_offset_x", "RichTextLabel", EDSCALE_RND(1));
+		p_theme->set_constant("shadow_offset_y", "RichTextLabel", EDSCALE_RND(1));
+		p_theme->set_constant("shadow_outline_size", "RichTextLabel", EDSCALE_RND(1));
 		p_theme->set_constant("outline_size", "RichTextLabel", 0);
 
 		// Label.
@@ -1243,10 +1243,10 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 		p_theme->set_color("font_shadow_color", "Label", Color(0, 0, 0, 0));
 		p_theme->set_color("font_outline_color", "Label", p_config.font_outline_color);
 
-		p_theme->set_constant("shadow_offset_x", "Label", 1 * EDSCALE);
-		p_theme->set_constant("shadow_offset_y", "Label", 1 * EDSCALE);
-		p_theme->set_constant("shadow_outline_size", "Label", 1 * EDSCALE);
-		p_theme->set_constant("line_spacing", "Label", 3 * EDSCALE);
+		p_theme->set_constant("shadow_offset_x", "Label", EDSCALE_RND(1));
+		p_theme->set_constant("shadow_offset_y", "Label", EDSCALE_RND(1));
+		p_theme->set_constant("shadow_outline_size", "Label", EDSCALE_RND(1));
+		p_theme->set_constant("line_spacing", "Label", EDSCALE_RND(3));
 		p_theme->set_constant("outline_size", "Label", 0);
 
 		// Label with different margins.
@@ -1394,19 +1394,19 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			const bool high_contrast_borders = p_config.draw_extra_borders && p_config.dark_theme;
 
 			Ref<StyleBoxFlat> gn_panel_style = EditorThemeManager::make_flat_stylebox(gn_frame_bg, gn_margin_side, gn_margin_top, gn_margin_side, gn_margin_bottom, p_config.corner_radius);
-			gn_panel_style->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
-			gn_panel_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
-			gn_panel_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
+			gn_panel_style->set_border_width(SIDE_BOTTOM, EDSCALE_RND(2));
+			gn_panel_style->set_border_width(SIDE_LEFT, EDSCALE_RND(2));
+			gn_panel_style->set_border_width(SIDE_RIGHT, EDSCALE_RND(2));
 			gn_panel_style->set_border_color(high_contrast_borders ? gn_bg_color.lightened(0.2) : gn_bg_color.darkened(0.3));
-			gn_panel_style->set_corner_radius_individual(0, 0, gn_corner_radius * EDSCALE, gn_corner_radius * EDSCALE);
+			gn_panel_style->set_corner_radius_individual(0, 0, EDSCALE_RND(gn_corner_radius), EDSCALE_RND(gn_corner_radius));
 			gn_panel_style->set_anti_aliased(true);
 
 			Ref<StyleBoxFlat> gn_panel_selected_style = gn_panel_style->duplicate();
 			gn_panel_selected_style->set_bg_color(p_config.dark_theme ? gn_bg_color.lightened(0.15) : gn_bg_color.darkened(0.15));
 			gn_panel_selected_style->set_border_width(SIDE_TOP, 0);
-			gn_panel_selected_style->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
-			gn_panel_selected_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
-			gn_panel_selected_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
+			gn_panel_selected_style->set_border_width(SIDE_BOTTOM, EDSCALE_RND(2));
+			gn_panel_selected_style->set_border_width(SIDE_LEFT, EDSCALE_RND(2));
+			gn_panel_selected_style->set_border_width(SIDE_RIGHT, EDSCALE_RND(2));
 			gn_panel_selected_style->set_border_color(gn_selected_border_color);
 
 			const int gn_titlebar_margin_top = 8;
@@ -1414,20 +1414,20 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			const int gn_titlebar_margin_bottom = 8;
 
 			Ref<StyleBoxFlat> gn_titlebar_style = EditorThemeManager::make_flat_stylebox(gn_bg_color, gn_titlebar_margin_side, gn_titlebar_margin_top, gn_titlebar_margin_side, gn_titlebar_margin_bottom, p_config.corner_radius);
-			gn_titlebar_style->set_border_width(SIDE_TOP, 2 * EDSCALE);
-			gn_titlebar_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
-			gn_titlebar_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
+			gn_titlebar_style->set_border_width(SIDE_TOP, EDSCALE_RND(2));
+			gn_titlebar_style->set_border_width(SIDE_LEFT, EDSCALE_RND(2));
+			gn_titlebar_style->set_border_width(SIDE_RIGHT, EDSCALE_RND(2));
 			gn_titlebar_style->set_border_color(high_contrast_borders ? gn_bg_color.lightened(0.2) : gn_bg_color.darkened(0.3));
-			gn_titlebar_style->set_expand_margin(SIDE_TOP, 2 * EDSCALE);
-			gn_titlebar_style->set_corner_radius_individual(gn_corner_radius * EDSCALE, gn_corner_radius * EDSCALE, 0, 0);
+			gn_titlebar_style->set_expand_margin(SIDE_TOP, EDSCALE_RND(2));
+			gn_titlebar_style->set_corner_radius_individual(EDSCALE_RND(gn_corner_radius), EDSCALE_RND(gn_corner_radius), 0, 0);
 			gn_titlebar_style->set_anti_aliased(true);
 
 			Ref<StyleBoxFlat> gn_titlebar_selected_style = gn_titlebar_style->duplicate();
 			gn_titlebar_selected_style->set_border_color(gn_selected_border_color);
-			gn_titlebar_selected_style->set_border_width(SIDE_TOP, 2 * EDSCALE);
-			gn_titlebar_selected_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
-			gn_titlebar_selected_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
-			gn_titlebar_selected_style->set_expand_margin(SIDE_TOP, 2 * EDSCALE);
+			gn_titlebar_selected_style->set_border_width(SIDE_TOP, EDSCALE_RND(2));
+			gn_titlebar_selected_style->set_border_width(SIDE_LEFT, EDSCALE_RND(2));
+			gn_titlebar_selected_style->set_border_width(SIDE_RIGHT, EDSCALE_RND(2));
+			gn_titlebar_selected_style->set_expand_margin(SIDE_TOP, EDSCALE_RND(2));
 
 			Color gn_decoration_color = p_config.dark_color_1.inverted();
 
@@ -1458,7 +1458,7 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			p_theme->set_color("resizer_color", "GraphNode", gn_decoration_color);
 
 			p_theme->set_constant("port_h_offset", "GraphNode", 1);
-			p_theme->set_constant("separation", "GraphNode", 1 * EDSCALE);
+			p_theme->set_constant("separation", "GraphNode", EDSCALE_RND(1));
 
 			Ref<DPITexture> port_icon = p_theme->get_icon(SNAME("GuiGraphNodePort"), EditorStringName(EditorIcons));
 			// The true size is 24x24 This is necessary for sharp port icons at high zoom levels in GraphEdit (up to ~200%).
@@ -1472,18 +1472,18 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			p_theme->set_constant("shadow_outline_size", "GraphNodeTitleLabel", 4);
 			p_theme->set_constant("shadow_offset_x", "GraphNodeTitleLabel", 0);
 			p_theme->set_constant("shadow_offset_y", "GraphNodeTitleLabel", 1);
-			p_theme->set_constant("line_spacing", "GraphNodeTitleLabel", 3 * EDSCALE);
+			p_theme->set_constant("line_spacing", "GraphNodeTitleLabel", EDSCALE_RND(3));
 
 			// GraphFrame.
 
-			const int gf_corner_width = 7 * EDSCALE;
+			const int gf_corner_width = EDSCALE_RND(7);
 			const int gf_border_width = 2 * MAX(1, EDSCALE);
 
 			Ref<StyleBoxFlat> graphframe_sb = EditorThemeManager::make_flat_stylebox(Color(0.0, 0.0, 0.0, 0.2), gn_margin_side, gn_margin_side, gn_margin_side, gn_margin_bottom, gf_corner_width);
-			graphframe_sb->set_expand_margin(SIDE_TOP, 38 * EDSCALE);
+			graphframe_sb->set_expand_margin(SIDE_TOP, EDSCALE_RND(38));
 			graphframe_sb->set_border_width_all(gf_border_width);
 			graphframe_sb->set_border_color(high_contrast_borders ? gn_bg_color.lightened(0.2) : gn_bg_color.darkened(0.3));
-			graphframe_sb->set_shadow_size(8 * EDSCALE);
+			graphframe_sb->set_shadow_size(EDSCALE_RND(8));
 			graphframe_sb->set_shadow_color(Color(p_config.shadow_color, p_config.shadow_color.a * 0.25));
 			graphframe_sb->set_anti_aliased(true);
 
@@ -1499,22 +1499,22 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 			// GraphFrame's title Label.
 			p_theme->set_type_variation("GraphFrameTitleLabel", "Label");
 			p_theme->set_stylebox(CoreStringName(normal), "GraphFrameTitleLabel", memnew(StyleBoxEmpty));
-			p_theme->set_font_size(SceneStringName(font_size), "GraphFrameTitleLabel", 22 * EDSCALE);
+			p_theme->set_font_size(SceneStringName(font_size), "GraphFrameTitleLabel", EDSCALE_RND(22));
 			p_theme->set_color(SceneStringName(font_color), "GraphFrameTitleLabel", Color(1, 1, 1));
 			p_theme->set_color("font_shadow_color", "GraphFrameTitleLabel", Color(0, 0, 0, 0));
 			p_theme->set_color("font_outline_color", "GraphFrameTitleLabel", Color(1, 1, 1));
-			p_theme->set_constant("shadow_offset_x", "GraphFrameTitleLabel", 1 * EDSCALE);
-			p_theme->set_constant("shadow_offset_y", "GraphFrameTitleLabel", 1 * EDSCALE);
+			p_theme->set_constant("shadow_offset_x", "GraphFrameTitleLabel", EDSCALE_RND(1));
+			p_theme->set_constant("shadow_offset_y", "GraphFrameTitleLabel", EDSCALE_RND(1));
 			p_theme->set_constant("outline_size", "GraphFrameTitleLabel", 0);
-			p_theme->set_constant("shadow_outline_size", "GraphFrameTitleLabel", 1 * EDSCALE);
-			p_theme->set_constant("line_spacing", "GraphFrameTitleLabel", 3 * EDSCALE);
+			p_theme->set_constant("shadow_outline_size", "GraphFrameTitleLabel", EDSCALE_RND(1));
+			p_theme->set_constant("line_spacing", "GraphFrameTitleLabel", EDSCALE_RND(3));
 		}
 
 		// VisualShader reroute node.
 		{
 			Ref<StyleBox> vs_reroute_panel_style = EditorThemeManager::make_empty_stylebox();
 			Ref<StyleBox> vs_reroute_titlebar_style = vs_reroute_panel_style->duplicate();
-			vs_reroute_titlebar_style->set_content_margin_all(16 * EDSCALE);
+			vs_reroute_titlebar_style->set_content_margin_all(EDSCALE_RND(16));
 			p_theme->set_stylebox(SceneStringName(panel), "VSRerouteNode", vs_reroute_panel_style);
 			p_theme->set_stylebox("panel_selected", "VSRerouteNode", vs_reroute_panel_style);
 			p_theme->set_stylebox("titlebar", "VSRerouteNode", vs_reroute_titlebar_style);
@@ -1530,14 +1530,14 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 	{
 		// ColorPicker.
 		Ref<StyleBoxFlat> circle_style_focus = p_config.button_style_focus->duplicate();
-		circle_style_focus->set_corner_radius_all(256 * EDSCALE);
-		circle_style_focus->set_corner_detail(32 * EDSCALE);
+		circle_style_focus->set_corner_radius_all(EDSCALE_RND(256));
+		circle_style_focus->set_corner_detail(EDSCALE_RND(32));
 
 		p_theme->set_constant("margin", "ColorPicker", p_config.base_margin);
-		p_theme->set_constant("sv_width", "ColorPicker", 256 * EDSCALE);
-		p_theme->set_constant("sv_height", "ColorPicker", 256 * EDSCALE);
-		p_theme->set_constant("h_width", "ColorPicker", 30 * EDSCALE);
-		p_theme->set_constant("label_width", "ColorPicker", 10 * EDSCALE);
+		p_theme->set_constant("sv_width", "ColorPicker", EDSCALE_RND(256));
+		p_theme->set_constant("sv_height", "ColorPicker", EDSCALE_RND(256));
+		p_theme->set_constant("h_width", "ColorPicker", EDSCALE_RND(30));
+		p_theme->set_constant("label_width", "ColorPicker", EDSCALE_RND(10));
 		p_theme->set_constant("center_slider_grabbers", "ColorPicker", 1);
 
 		p_theme->set_stylebox("sample_focus", "ColorPicker", p_config.button_style_focus);
@@ -1582,7 +1582,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		p_theme->set_stylebox("panel_container", "ProjectManager", style_panel_container);
 		p_theme->set_stylebox("project_list", "ProjectManager", p_config.tree_panel_style);
 		p_theme->set_stylebox("quick_settings_panel", "ProjectManager", p_config.tree_panel_style);
-		p_theme->set_constant("sidebar_button_icon_separation", "ProjectManager", int(6 * EDSCALE));
+		p_theme->set_constant("sidebar_button_icon_separation", "ProjectManager", int(EDSCALE_RND(6)));
 		p_theme->set_icon("browse_folder", "ProjectManager", p_theme->get_icon(SNAME("FolderBrowse"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("browse_file", "ProjectManager", p_theme->get_icon(SNAME("FileBrowse"), EditorStringName(EditorIcons)));
 
@@ -1647,7 +1647,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 
 		// This stylebox is used in 3d and 2d viewports (no borders).
 		Ref<StyleBoxFlat> style_content_panel_vp = p_config.content_panel_style->duplicate();
-		style_content_panel_vp->set_content_margin_individual(p_config.border_width * 2, p_config.base_margin * EDSCALE, p_config.border_width * 2, p_config.border_width * 2);
+		style_content_panel_vp->set_content_margin_individual(p_config.border_width * 2, EDSCALE_RND(p_config.base_margin), p_config.border_width * 2, p_config.border_width * 2);
 		p_theme->set_stylebox("Content", EditorStringName(EditorStyles), style_content_panel_vp);
 
 		// 3D/Spatial editor.
@@ -1665,8 +1665,8 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 
 		// 2D, 3D, and Game toolbar.
 		p_theme->set_type_variation("MainToolBarMargin", "MarginContainer");
-		p_theme->set_constant("margin_left", "MainToolBarMargin", 4 * EDSCALE);
-		p_theme->set_constant("margin_right", "MainToolBarMargin", 4 * EDSCALE);
+		p_theme->set_constant("margin_left", "MainToolBarMargin", EDSCALE_RND(4));
+		p_theme->set_constant("margin_right", "MainToolBarMargin", EDSCALE_RND(4));
 
 		// 2D and 3D contextual toolbar.
 		// Use a custom stylebox to make contextual menu items stand out from the rest.
@@ -1677,9 +1677,9 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		toolbar_stylebox->set_anti_aliased(false);
 		// Add an underline to the StyleBox, but prevent its minimum vertical size from changing.
 		toolbar_stylebox->set_border_color(p_config.accent_color);
-		toolbar_stylebox->set_border_width(SIDE_BOTTOM, Math::round(2 * EDSCALE));
+		toolbar_stylebox->set_border_width(SIDE_BOTTOM, Math::round(EDSCALE_RND(2)));
 		toolbar_stylebox->set_content_margin(SIDE_BOTTOM, 0);
-		toolbar_stylebox->set_expand_margin_individual(4 * EDSCALE, 2 * EDSCALE, 4 * EDSCALE, 4 * EDSCALE);
+		toolbar_stylebox->set_expand_margin_individual(EDSCALE_RND(4), EDSCALE_RND(2), EDSCALE_RND(4), EDSCALE_RND(4));
 		p_theme->set_stylebox("ContextualToolbar", EditorStringName(EditorStyles), toolbar_stylebox);
 
 		// Script editor.
@@ -1741,7 +1741,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		// Bottom panel.
 		Ref<StyleBoxFlat> style_bottom_panel = p_config.content_panel_style->duplicate();
 		style_bottom_panel->set_border_width(SIDE_BOTTOM, 0);
-		style_bottom_panel->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		style_bottom_panel->set_corner_radius_all(EDSCALE_RND(p_config.corner_radius));
 		style_bottom_panel->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
 		style_bottom_panel->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
 
@@ -1751,8 +1751,8 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		Ref<StyleBoxFlat> style_bottom_panel_tabbar = p_config.content_panel_style->duplicate();
 		style_bottom_panel_tabbar->set_content_margin(SIDE_TOP, 0);
 		Ref<StyleBoxFlat> style_bottom_tab = menu_transparent_style->duplicate();
-		style_bottom_tab->set_content_margin(SIDE_TOP, (p_config.increased_margin + 2) * EDSCALE);
-		style_bottom_tab->set_content_margin(SIDE_BOTTOM, (p_config.increased_margin + 2) * EDSCALE);
+		style_bottom_tab->set_content_margin(SIDE_TOP, EDSCALE_RND(p_config.increased_margin + 2));
+		style_bottom_tab->set_content_margin(SIDE_BOTTOM, EDSCALE_RND(p_config.increased_margin + 2));
 
 		Ref<StyleBoxFlat> style_bottom_tab_selected = style_bottom_tab->duplicate();
 		style_bottom_tab_selected->set_bg_color(p_config.dark_color_1);
@@ -1811,33 +1811,33 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		// EditorSpinSliders with a label have more space on the left, so add an
 		// higher margin to match the location where the text begins.
 		// The margin values below were determined by empirical testing.
-		p_theme->set_constant("line_edit_margin", "EditorSpinSlider", 24 * EDSCALE);
-		p_theme->set_constant("line_edit_margin_empty", "EditorSpinSlider", 16 * EDSCALE);
+		p_theme->set_constant("line_edit_margin", "EditorSpinSlider", EDSCALE_RND(24));
+		p_theme->set_constant("line_edit_margin_empty", "EditorSpinSlider", EDSCALE_RND(16));
 
 		// Launch Pad and Play buttons.
-		Ref<StyleBoxFlat> style_launch_pad = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, 2 * EDSCALE, 0, 2 * EDSCALE, 0, p_config.corner_radius);
-		style_launch_pad->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		Ref<StyleBoxFlat> style_launch_pad = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, EDSCALE_RND(2), 0, EDSCALE_RND(2), 0, p_config.corner_radius);
+		style_launch_pad->set_corner_radius_all(EDSCALE_RND(p_config.corner_radius));
 		p_theme->set_stylebox("LaunchPadNormal", EditorStringName(EditorStyles), style_launch_pad);
 		Ref<StyleBoxFlat> style_launch_pad_movie = style_launch_pad->duplicate();
 		style_launch_pad_movie->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.1));
 		style_launch_pad_movie->set_border_color(p_config.accent_color);
-		style_launch_pad_movie->set_border_width_all(Math::round(2 * EDSCALE));
+		style_launch_pad_movie->set_border_width_all(Math::round(EDSCALE_RND(2)));
 		p_theme->set_stylebox("LaunchPadMovieMode", EditorStringName(EditorStyles), style_launch_pad_movie);
 		Ref<StyleBoxFlat> style_launch_pad_recovery_mode = style_launch_pad->duplicate();
 		style_launch_pad_recovery_mode->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.1));
 		style_launch_pad_recovery_mode->set_border_color(p_config.warning_color);
-		style_launch_pad_recovery_mode->set_border_width_all(Math::round(2 * EDSCALE));
+		style_launch_pad_recovery_mode->set_border_width_all(Math::round(EDSCALE_RND(2)));
 		p_theme->set_stylebox("LaunchPadRecoveryMode", EditorStringName(EditorStyles), style_launch_pad_recovery_mode);
 
 		p_theme->set_stylebox("MovieWriterButtonNormal", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
 		Ref<StyleBoxFlat> style_write_movie_button = p_config.button_style_pressed->duplicate();
 		style_write_movie_button->set_bg_color(p_config.accent_color);
-		style_write_movie_button->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		style_write_movie_button->set_corner_radius_all(EDSCALE_RND(p_config.corner_radius));
 		style_write_movie_button->set_content_margin(SIDE_TOP, 0);
 		style_write_movie_button->set_content_margin(SIDE_BOTTOM, 0);
 		style_write_movie_button->set_content_margin(SIDE_LEFT, 0);
 		style_write_movie_button->set_content_margin(SIDE_RIGHT, 0);
-		style_write_movie_button->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
+		style_write_movie_button->set_expand_margin(SIDE_RIGHT, EDSCALE_RND(2));
 		p_theme->set_stylebox("MovieWriterButtonPressed", EditorStringName(EditorStyles), style_write_movie_button);
 
 		// Profiler autostart indicator panel.
@@ -1851,12 +1851,12 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		// Recovery mode button style
 		Ref<StyleBoxFlat> style_recovery_mode_button = p_config.button_style_pressed->duplicate();
 		style_recovery_mode_button->set_bg_color(p_config.warning_color);
-		style_recovery_mode_button->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		style_recovery_mode_button->set_corner_radius_all(EDSCALE_RND(p_config.corner_radius));
 		style_recovery_mode_button->set_content_margin_all(0);
 		// Recovery mode button is implicitly styled from the panel's background.
 		// So, remove any existing borders. (e.g. from draw_extra_borders config)
 		style_recovery_mode_button->set_border_width_all(0);
-		style_recovery_mode_button->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
+		style_recovery_mode_button->set_expand_margin(SIDE_RIGHT, EDSCALE_RND(2));
 		p_theme->set_stylebox("RecoveryModeButton", EditorStringName(EditorStyles), style_recovery_mode_button);
 	}
 
@@ -1864,10 +1864,10 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 	{
 		// Custom theme type for MarginContainer with 4px margins.
 		p_theme->set_type_variation("MarginContainer4px", "MarginContainer");
-		p_theme->set_constant("margin_left", "MarginContainer4px", 4 * EDSCALE);
-		p_theme->set_constant("margin_top", "MarginContainer4px", 4 * EDSCALE);
-		p_theme->set_constant("margin_right", "MarginContainer4px", 4 * EDSCALE);
-		p_theme->set_constant("margin_bottom", "MarginContainer4px", 4 * EDSCALE);
+		p_theme->set_constant("margin_left", "MarginContainer4px", EDSCALE_RND(4));
+		p_theme->set_constant("margin_top", "MarginContainer4px", EDSCALE_RND(4));
+		p_theme->set_constant("margin_right", "MarginContainer4px", EDSCALE_RND(4));
+		p_theme->set_constant("margin_bottom", "MarginContainer4px", EDSCALE_RND(4));
 
 		// Header LinkButton variation.
 		p_theme->set_type_variation("HeaderSmallLink", "LinkButton");
@@ -1939,7 +1939,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			// When pressed, add a small bottom border to the buttons to better show their active state,
 			// similar to active tabs.
 			Ref<StyleBoxFlat> editor_log_button_pressed = style_flat_button_pressed->duplicate();
-			editor_log_button_pressed->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
+			editor_log_button_pressed->set_border_width(SIDE_BOTTOM, EDSCALE_RND(2));
 			editor_log_button_pressed->set_border_color(p_config.accent_color);
 			if (!p_config.dark_theme) {
 				editor_log_button_pressed->set_bg_color(flat_pressed_color.lightened(0.5));
@@ -2000,7 +2000,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		{
 			p_theme->set_type_variation("InspectorActionButton", "Button");
 
-			const float action_extra_margin = 32 * EDSCALE;
+			const float action_extra_margin = EDSCALE_RND(32);
 			p_theme->set_constant("h_separation", "InspectorActionButton", action_extra_margin);
 
 			Color color_inspector_action = p_config.dark_color_1.lerp(p_config.mono_color, 0.12);
@@ -2141,7 +2141,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 
 		// Vertical separation between inspector properties.
 		p_theme->set_type_variation("EditorPropertyContainer", "VBoxContainer");
-		p_theme->set_constant("separation", "EditorPropertyContainer", p_config.increased_margin * EDSCALE);
+		p_theme->set_constant("separation", "EditorPropertyContainer", EDSCALE_RND(p_config.increased_margin));
 
 		// EditorProperty.
 
@@ -2156,7 +2156,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		p_theme->set_stylebox("bg", "EditorProperty", memnew(StyleBoxEmpty));
 		p_theme->set_stylebox("bg_selected", "EditorProperty", style_property_bg);
 		p_theme->set_stylebox("child_bg", "EditorProperty", style_property_child_bg);
-		p_theme->set_constant("font_offset", "EditorProperty", 8 * EDSCALE);
+		p_theme->set_constant("font_offset", "EditorProperty", EDSCALE_RND(8));
 
 		const Color property_color = p_config.font_color.lerp(Color(0.5, 0.5, 0.5), 0.5);
 		const Color readonly_color = property_color.lerp(p_config.dark_icon_and_font ? Color(0, 0, 0) : Color(1, 1, 1), 0.25);
@@ -2187,10 +2187,10 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 
 		Color inspector_indent_color = p_config.accent_color;
 		inspector_indent_color.a = 0.2;
-		Ref<StyleBoxFlat> inspector_indent_style = EditorThemeManager::make_flat_stylebox(inspector_indent_color, 2.0 * EDSCALE, 0, 2.0 * EDSCALE, 0);
+		Ref<StyleBoxFlat> inspector_indent_style = EditorThemeManager::make_flat_stylebox(inspector_indent_color, EDSCALE_RND(2.0), 0, EDSCALE_RND(2.0), 0);
 		p_theme->set_stylebox("indent_box", "EditorInspectorSection", inspector_indent_style);
-		p_theme->set_constant("indent_size", "EditorInspectorSection", 6.0 * EDSCALE);
-		p_theme->set_constant("h_separation", "EditorInspectorSection", 2.0 * EDSCALE);
+		p_theme->set_constant("indent_size", "EditorInspectorSection", EDSCALE_RND(6.0));
+		p_theme->set_constant("h_separation", "EditorInspectorSection", EDSCALE_RND(2.0));
 
 		Color prop_subsection_stylebox_color = Color(1, 1, 1, 0);
 		p_theme->set_color("prop_subsection_stylebox_color", EditorStringName(Editor), prop_subsection_stylebox_color);
@@ -2219,7 +2219,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		// EditorInspectorArray.
 		p_theme->set_color("bg", "EditorInspectorArray", p_config.dark_color_1);
 
-		p_theme->set_constant("inspector_margin", EditorStringName(Editor), 12 * EDSCALE);
+		p_theme->set_constant("inspector_margin", EditorStringName(Editor), EDSCALE_RND(12));
 
 		// Colored EditorProperty.
 		for (int i = 0; i < 16; i++) {
@@ -2232,9 +2232,9 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			// Sub-inspector background.
 			Ref<StyleBoxFlat> sub_inspector_bg = p_config.base_style->duplicate();
 			sub_inspector_bg->set_bg_color(p_config.dark_color_1.lerp(si_base_color, 0.08));
-			sub_inspector_bg->set_border_width_all(2 * EDSCALE);
+			sub_inspector_bg->set_border_width_all(EDSCALE_RND(2));
 			sub_inspector_bg->set_border_color(si_base_color * Color(0.7, 0.7, 0.7, 0.8));
-			sub_inspector_bg->set_content_margin_all(4 * EDSCALE);
+			sub_inspector_bg->set_content_margin_all(EDSCALE_RND(4));
 			sub_inspector_bg->set_corner_radius(CORNER_TOP_LEFT, 0);
 			sub_inspector_bg->set_corner_radius(CORNER_TOP_RIGHT, 0);
 
@@ -2261,23 +2261,23 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			// Expand to the left and right by 4px to compensate for the dictionary editor margins.
 			Color style_dictionary_bg_color = p_config.dark_color_3.lerp(si_base_color, 0.08);
 			Ref<StyleBoxFlat> style_dictionary_add_item = EditorThemeManager::make_flat_stylebox(style_dictionary_bg_color, 0, 4, 0, 4, p_config.corner_radius);
-			style_dictionary_add_item->set_expand_margin(SIDE_LEFT, 2 * EDSCALE);
-			style_dictionary_add_item->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
+			style_dictionary_add_item->set_expand_margin(SIDE_LEFT, EDSCALE_RND(2));
+			style_dictionary_add_item->set_expand_margin(SIDE_RIGHT, EDSCALE_RND(2));
 			p_theme->set_stylebox("DictionaryAddItem" + itos(i + 1), EditorStringName(EditorStyles), style_dictionary_add_item);
 
 			// Object selector.
 			p_theme->set_type_variation("ObjectSelectorMargin", "MarginContainer");
-			p_theme->set_constant("margin_left", "ObjectSelectorMargin", 4 * EDSCALE);
-			p_theme->set_constant("margin_right", "ObjectSelectorMargin", 6 * EDSCALE);
+			p_theme->set_constant("margin_left", "ObjectSelectorMargin", EDSCALE_RND(4));
+			p_theme->set_constant("margin_right", "ObjectSelectorMargin", EDSCALE_RND(6));
 		}
 		Color si_base_color = p_config.accent_color;
 
 		// Sub-inspector background.
 		Ref<StyleBoxFlat> sub_inspector_bg = p_config.base_style->duplicate();
 		sub_inspector_bg->set_bg_color(Color(1, 1, 1, 0));
-		sub_inspector_bg->set_border_width_all(2 * EDSCALE);
+		sub_inspector_bg->set_border_width_all(EDSCALE_RND(2));
 		sub_inspector_bg->set_border_color(p_config.dark_color_1.lerp(si_base_color, 0.15));
-		sub_inspector_bg->set_content_margin_all(4 * EDSCALE);
+		sub_inspector_bg->set_content_margin_all(EDSCALE_RND(4));
 		sub_inspector_bg->set_corner_radius(CORNER_TOP_LEFT, 0);
 		sub_inspector_bg->set_corner_radius(CORNER_TOP_RIGHT, 0);
 
@@ -2286,7 +2286,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		// Sub-inspector background no border.
 
 		Ref<StyleBoxFlat> sub_inspector_bg_no_border = p_config.base_style->duplicate();
-		sub_inspector_bg_no_border->set_content_margin_all(2 * EDSCALE);
+		sub_inspector_bg_no_border->set_content_margin_all(EDSCALE_RND(2));
 		sub_inspector_bg_no_border->set_bg_color(p_config.dark_color_2.lerp(p_config.dark_color_3, 0.15));
 		p_theme->set_stylebox("sub_inspector_bg_no_border", EditorStringName(EditorStyles), sub_inspector_bg_no_border);
 
@@ -2304,8 +2304,8 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 
 		// Expand to the left and right by 4px to compensate for the dictionary editor margins.
 		Ref<StyleBoxFlat> style_dictionary_add_item = EditorThemeManager::make_flat_stylebox(prop_subsection_color, 0, 4, 0, 4, p_config.corner_radius);
-		style_dictionary_add_item->set_expand_margin(SIDE_LEFT, 2 * EDSCALE);
-		style_dictionary_add_item->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
+		style_dictionary_add_item->set_expand_margin(SIDE_LEFT, EDSCALE_RND(2));
+		style_dictionary_add_item->set_expand_margin(SIDE_RIGHT, EDSCALE_RND(2));
 		p_theme->set_stylebox("DictionaryAddItem0", EditorStringName(EditorStyles), style_dictionary_add_item);
 	}
 
@@ -2336,10 +2336,10 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 
 		p_theme->set_constant("v_line_primary_margin", "AnimationTimelineEdit", 0);
 		p_theme->set_constant("v_line_secondary_margin", "AnimationTimelineEdit", 0);
-		p_theme->set_constant("v_line_primary_width", "AnimationTimelineEdit", 1 * EDSCALE);
-		p_theme->set_constant("v_line_secondary_width", "AnimationTimelineEdit", 1 * EDSCALE);
-		p_theme->set_constant("text_primary_margin", "AnimationTimelineEdit", 3 * EDSCALE);
-		p_theme->set_constant("text_secondary_margin", "AnimationTimelineEdit", 3 * EDSCALE);
+		p_theme->set_constant("v_line_primary_width", "AnimationTimelineEdit", EDSCALE_RND(1));
+		p_theme->set_constant("v_line_secondary_width", "AnimationTimelineEdit", EDSCALE_RND(1));
+		p_theme->set_constant("text_primary_margin", "AnimationTimelineEdit", EDSCALE_RND(3));
+		p_theme->set_constant("text_secondary_margin", "AnimationTimelineEdit", EDSCALE_RND(3));
 
 		// AnimationTrackEdit.
 
@@ -2352,8 +2352,8 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 
 		p_theme->set_color("h_line_color", "AnimationTrackEdit", p_config.font_color * Color(1, 1, 1, 0.2));
 
-		p_theme->set_constant("h_separation", "AnimationTrackEdit", (p_config.increased_margin + 2) * EDSCALE);
-		p_theme->set_constant("outer_margin", "AnimationTrackEdit", p_config.increased_margin * 6 * EDSCALE);
+		p_theme->set_constant("h_separation", "AnimationTrackEdit", EDSCALE_RND(p_config.increased_margin + 2));
+		p_theme->set_constant("outer_margin", "AnimationTrackEdit", EDSCALE_RND(p_config.increased_margin * 6));
 
 		// AnimationTrackEditGroup.
 
@@ -2368,7 +2368,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		p_theme->set_color("h_line_color", "AnimationTrackEditGroup", p_config.font_color * Color(1, 1, 1, 0.2));
 		p_theme->set_color("v_line_color", "AnimationTrackEditGroup", p_config.font_color * Color(1, 1, 1, 0.2));
 
-		p_theme->set_constant("h_separation", "AnimationTrackEditGroup", (p_config.increased_margin + 2) * EDSCALE);
+		p_theme->set_constant("h_separation", "AnimationTrackEditGroup", EDSCALE_RND(p_config.increased_margin + 2));
 		p_theme->set_constant("v_separation", "AnimationTrackEditGroup", 0);
 
 		// AnimationBezierTrackEdit.
@@ -2378,8 +2378,8 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		p_theme->set_color("h_line_color", "AnimationBezierTrackEdit", p_config.font_color * Color(1, 1, 1, 0.2));
 		p_theme->set_color("v_line_color", "AnimationBezierTrackEdit", p_config.font_color * Color(1, 1, 1, 0.2));
 
-		p_theme->set_constant("h_separation", "AnimationBezierTrackEdit", (p_config.increased_margin + 2) * EDSCALE);
-		p_theme->set_constant("v_separation", "AnimationBezierTrackEdit", p_config.forced_even_separation * EDSCALE);
+		p_theme->set_constant("h_separation", "AnimationBezierTrackEdit", EDSCALE_RND(p_config.increased_margin + 2));
+		p_theme->set_constant("v_separation", "AnimationBezierTrackEdit", EDSCALE_RND(p_config.forced_even_separation));
 	}
 
 	// Editor help.
@@ -2409,12 +2409,12 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		p_theme->set_color("param_bg_color", "EditorHelp", p_config.dark_color_1);
 		p_theme->set_color("primary_hr_color", "EditorHelp", p_config.base_color.lerp(p_config.mono_color_font, p_config.dark_theme ? 0.14 : 0.24));
 		p_theme->set_color("secondary_hr_color", "EditorHelp", p_config.base_color.lerp(p_config.mono_color_font, p_config.dark_theme ? 0.12 : 0.22));
-		p_theme->set_constant(SceneStringName(line_separation), "EditorHelp", Math::round(6 * EDSCALE));
-		p_theme->set_constant(SceneStringName(paragraph_separation), "EditorHelp", Math::round(10 * EDSCALE));
-		p_theme->set_constant("table_h_separation", "EditorHelp", 16 * EDSCALE);
-		p_theme->set_constant("table_v_separation", "EditorHelp", 6 * EDSCALE);
-		p_theme->set_constant("text_highlight_h_padding", "EditorHelp", 1 * EDSCALE);
-		p_theme->set_constant("text_highlight_v_padding", "EditorHelp", 2 * EDSCALE);
+		p_theme->set_constant(SceneStringName(line_separation), "EditorHelp", EDSCALE_RND(6));
+		p_theme->set_constant(SceneStringName(paragraph_separation), "EditorHelp", EDSCALE_RND(10));
+		p_theme->set_constant("table_h_separation", "EditorHelp", EDSCALE_RND(16));
+		p_theme->set_constant("table_v_separation", "EditorHelp", EDSCALE_RND(6));
+		p_theme->set_constant("text_highlight_h_padding", "EditorHelp", EDSCALE_RND(1));
+		p_theme->set_constant("text_highlight_v_padding", "EditorHelp", EDSCALE_RND(2));
 	}
 
 	// EditorHelpBitTitle.
@@ -2499,7 +2499,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			theme_preview_picker_bg_color.a = 0.2;
 			Ref<StyleBoxFlat> theme_preview_picker_sb = EditorThemeManager::make_flat_stylebox(theme_preview_picker_bg_color, 0, 0, 0, 0);
 			theme_preview_picker_sb->set_border_color(p_config.accent_color);
-			theme_preview_picker_sb->set_border_width_all(1.0 * EDSCALE);
+			theme_preview_picker_sb->set_border_width_all(EDSCALE_RND(1.0));
 			p_theme->set_stylebox("preview_picker_overlay", "ThemeEditor", theme_preview_picker_sb);
 
 			Color theme_preview_picker_label_bg_color = p_config.accent_color;
@@ -2508,11 +2508,11 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			p_theme->set_stylebox("preview_picker_label", "ThemeEditor", theme_preview_picker_label_sb);
 
 			Ref<StyleBoxFlat> style_theme_preview_tab = p_theme->get_stylebox(SNAME("tab_selected"), SNAME("TabContainerOdd"))->duplicate();
-			style_theme_preview_tab->set_expand_margin(SIDE_BOTTOM, 5 * EDSCALE);
+			style_theme_preview_tab->set_expand_margin(SIDE_BOTTOM, EDSCALE_RND(5));
 			p_theme->set_stylebox("ThemeEditorPreviewFG", EditorStringName(EditorStyles), style_theme_preview_tab);
 
 			Ref<StyleBoxFlat> style_theme_preview_bg_tab = p_theme->get_stylebox(SNAME("tab_unselected"), SNAME("TabContainer"))->duplicate();
-			style_theme_preview_bg_tab->set_expand_margin(SIDE_BOTTOM, 2 * EDSCALE);
+			style_theme_preview_bg_tab->set_expand_margin(SIDE_BOTTOM, EDSCALE_RND(2));
 			p_theme->set_stylebox("ThemeEditorPreviewBG", EditorStringName(EditorStyles), style_theme_preview_bg_tab);
 		}
 
@@ -2525,18 +2525,18 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			p_theme->set_stylebox("error_panel", "GraphStateMachine", p_config.tree_panel_style);
 			p_theme->set_color("error_color", "GraphStateMachine", p_config.error_color);
 
-			const int sm_margin_side = 10 * EDSCALE;
+			const int sm_margin_side = EDSCALE_RND(10);
 			const int sm_margin_bottom = 2;
 			const Color sm_bg_color = p_config.dark_theme ? p_config.dark_color_3 : p_config.dark_color_1.lerp(p_config.mono_color, 0.09);
 
-			Ref<StyleBoxFlat> sm_node_style = EditorThemeManager::make_flat_stylebox(p_config.dark_color_3 * Color(1, 1, 1, 0.7), sm_margin_side, 24 * EDSCALE, sm_margin_side, sm_margin_bottom, p_config.corner_radius);
+			Ref<StyleBoxFlat> sm_node_style = EditorThemeManager::make_flat_stylebox(p_config.dark_color_3 * Color(1, 1, 1, 0.7), sm_margin_side, EDSCALE_RND(24), sm_margin_side, sm_margin_bottom, p_config.corner_radius);
 			sm_node_style->set_border_width_all(p_config.border_width);
 			sm_node_style->set_border_color(sm_bg_color);
 
-			Ref<StyleBoxFlat> sm_node_selected_style = EditorThemeManager::make_flat_stylebox(sm_bg_color * Color(1, 1, 1, 0.9), sm_margin_side, 24 * EDSCALE, sm_margin_side, sm_margin_bottom, p_config.corner_radius);
-			sm_node_selected_style->set_border_width_all(2 * EDSCALE + p_config.border_width);
+			Ref<StyleBoxFlat> sm_node_selected_style = EditorThemeManager::make_flat_stylebox(sm_bg_color * Color(1, 1, 1, 0.9), sm_margin_side, EDSCALE_RND(24), sm_margin_side, sm_margin_bottom, p_config.corner_radius);
+			sm_node_selected_style->set_border_width_all(EDSCALE_RND(2) + p_config.border_width);
 			sm_node_selected_style->set_border_color(p_config.accent_color * Color(1, 1, 1, 0.9));
-			sm_node_selected_style->set_shadow_size(8 * EDSCALE);
+			sm_node_selected_style->set_shadow_size(EDSCALE_RND(8));
 			sm_node_selected_style->set_shadow_color(p_config.shadow_color);
 
 			Ref<StyleBoxFlat> sm_node_playing_style = sm_node_selected_style->duplicate();
@@ -2549,12 +2549,12 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			p_theme->set_stylebox("node_frame_playing", "GraphStateMachine", sm_node_playing_style);
 
 			Ref<StyleBoxFlat> sm_node_start_style = sm_node_style->duplicate();
-			sm_node_start_style->set_border_width_all(1 * EDSCALE);
+			sm_node_start_style->set_border_width_all(EDSCALE_RND(1));
 			sm_node_start_style->set_border_color(p_config.success_color.lightened(0.24));
 			p_theme->set_stylebox("node_frame_start", "GraphStateMachine", sm_node_start_style);
 
 			Ref<StyleBoxFlat> sm_node_end_style = sm_node_style->duplicate();
-			sm_node_end_style->set_border_width_all(1 * EDSCALE);
+			sm_node_end_style->set_border_width_all(EDSCALE_RND(1));
 			sm_node_end_style->set_border_color(p_config.error_color);
 			p_theme->set_stylebox("node_frame_end", "GraphStateMachine", sm_node_end_style);
 

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -277,19 +277,19 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_config.base_empty_wide_style = EditorThemeManager::make_empty_stylebox();
 		// Ensure minimum margin for wide flat buttons otherwise the topbar looks broken.
 		float base_empty_wide_margin = MAX(p_config.base_margin, 3.0);
-		p_config.base_empty_wide_style->set_content_margin_individual(base_empty_wide_margin * 1.5 * EDSCALE, base_empty_wide_margin * EDSCALE, base_empty_wide_margin * 1.5 * EDSCALE, base_empty_wide_margin * EDSCALE);
+		p_config.base_empty_wide_style->set_content_margin_individual(EDSCALE_RND(base_empty_wide_margin * 1.5), EDSCALE_RND(base_empty_wide_margin), EDSCALE_RND(base_empty_wide_margin * 1.5), EDSCALE_RND(base_empty_wide_margin));
 
 		// Button styles.
 		{
-			p_config.widget_margin = Vector2(p_config.increased_margin + 2, p_config.increased_margin + 1) * EDSCALE;
+			p_config.widget_margin = Vector2(EDSCALE_RND(p_config.increased_margin + 2), EDSCALE_RND(p_config.increased_margin + 1));
 
 			p_config.button_style = p_config.base_style->duplicate();
-			p_config.button_style->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE);
+			p_config.button_style->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin * 1.5), EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin * 1.5));
 			p_config.button_style->set_bg_color(p_config.button_normal_color);
-			p_config.button_style->set_border_width_all(Math::round(EDSCALE));
+			p_config.button_style->set_border_width_all(EDSCALE_RND(1));
 			p_config.button_style->set_shadow_color(p_config.dark_theme ? Color(0, 0, 0, 0.005) : Color(1, 1, 1, 0.005));
-			p_config.button_style->set_shadow_size(Math::ceil(8 * EDSCALE));
-			p_config.button_style->set_shadow_offset(Vector2(0, 4) * EDSCALE);
+			p_config.button_style->set_shadow_size(EDSCALE_RND(8));
+			p_config.button_style->set_shadow_offset(Vector2(0, EDSCALE_RND(4)));
 			if (p_config.draw_extra_borders) {
 				p_config.button_style->set_border_color(p_config.extra_border_color_1);
 			} else {
@@ -323,7 +323,7 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_config.flat_button_hover = p_config.base_style->duplicate();
 			p_config.flat_button_hover->set_bg_color(p_config.flat_button_hover_color);
 			// This affects buttons in Tree so top and bottom margins should be kept low.
-			p_config.flat_button_hover->set_content_margin_individual(p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 0.9 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 0.9 * EDSCALE);
+			p_config.flat_button_hover->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 1.5), EDSCALE_RND(p_config.base_margin * 0.9), EDSCALE_RND(p_config.base_margin * 1.5), EDSCALE_RND(p_config.base_margin * 0.9));
 			if (p_config.draw_extra_borders) {
 				p_config.button_style_hover->set_border_color(p_config.extra_border_color_1);
 			}
@@ -349,21 +349,21 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_config.popup_panel_style = p_config.base_style->duplicate();
 			p_config.popup_panel_style->set_bg_color(p_config.surface_popup_color);
 			p_config.popup_panel_style->set_shadow_color(Color(0, 0, 0, 0.3));
-			p_config.popup_panel_style->set_shadow_size(p_config.base_margin * 0.75 * EDSCALE);
-			p_config.popup_panel_style->set_content_margin_all(p_config.popup_margin * EDSCALE);
+			p_config.popup_panel_style->set_shadow_size(EDSCALE_RND(p_config.base_margin * 0.75));
+			p_config.popup_panel_style->set_content_margin_all(EDSCALE_RND(p_config.popup_margin));
 			p_config.popup_panel_style->set_corner_radius_all(0);
 			if (p_config.draw_extra_borders) {
-				p_config.popup_panel_style->set_border_width_all(Math::round(EDSCALE));
+				p_config.popup_panel_style->set_border_width_all(EDSCALE_RND(1));
 				p_config.popup_panel_style->set_border_color(p_config.extra_border_color_2);
 			}
 
 			p_config.window_style = p_config.base_style->duplicate();
 			p_config.window_style->set_content_margin_all(p_config.popup_margin);
 			p_config.window_style->set_shadow_color(p_config.shadow_color);
-			p_config.window_style->set_shadow_size(4 * EDSCALE);
+			p_config.window_style->set_shadow_size(EDSCALE_RND(4));
 			p_config.window_style->set_border_color(p_config.base_color);
-			p_config.window_style->set_border_width(SIDE_TOP, 24 * EDSCALE);
-			p_config.window_style->set_expand_margin(SIDE_TOP, 24 * EDSCALE);
+			p_config.window_style->set_border_width(SIDE_TOP, EDSCALE_RND(24));
+			p_config.window_style->set_expand_margin(SIDE_TOP, EDSCALE_RND(24));
 			p_config.window_style->set_corner_radius_all(0);
 
 			p_config.window_complex_style = p_config.window_style->duplicate();
@@ -383,7 +383,7 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 			// Content panel for tabs and similar containers.
 
 			// Compensate for the border.
-			const int content_panel_margin = p_config.base_margin * EDSCALE + p_config.border_width;
+			const int content_panel_margin = EDSCALE_RND(p_config.base_margin) + p_config.border_width;
 
 			p_config.content_panel_style = p_config.base_style->duplicate();
 			p_config.content_panel_style->set_border_color(p_config.dark_color_3);
@@ -391,11 +391,11 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_config.content_panel_style->set_border_width(Side::SIDE_TOP, 0);
 			p_config.content_panel_style->set_corner_radius(CORNER_TOP_LEFT, 0);
 			p_config.content_panel_style->set_corner_radius(CORNER_TOP_RIGHT, 0);
-			p_config.content_panel_style->set_content_margin_individual(content_panel_margin, 2 * EDSCALE + content_panel_margin, content_panel_margin, content_panel_margin);
+			p_config.content_panel_style->set_content_margin_individual(content_panel_margin, EDSCALE_RND(2) + content_panel_margin, content_panel_margin, content_panel_margin);
 
 			p_config.tab_container_style = p_config.base_style->duplicate();
-			p_config.tab_container_style->set_content_margin_all(p_config.increased_margin * 1.5 * EDSCALE);
-			p_config.tab_container_style->set_corner_radius_individual(0, 0, p_config.corner_radius * EDSCALE, p_config.corner_radius * EDSCALE);
+			p_config.tab_container_style->set_content_margin_all(EDSCALE_RND(p_config.increased_margin * 1.5));
+			p_config.tab_container_style->set_corner_radius_individual(0, 0, EDSCALE_RND(p_config.corner_radius), EDSCALE_RND(p_config.corner_radius));
 
 			p_config.foreground_panel = p_config.tab_container_style->duplicate();
 			p_config.foreground_panel->set_corner_radius(CORNER_TOP_LEFT, p_config.tab_container_style->get_corner_radius(CORNER_BOTTOM_LEFT));
@@ -407,7 +407,7 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 			// Make Trees easier to distinguish from other controls by using a darker background color.
 			p_config.tree_panel_style->set_bg_color(p_config.dark_color_1.lerp(p_config.dark_color_2, 0.5));
 			if (p_config.draw_extra_borders) {
-				p_config.tree_panel_style->set_border_width_all(Math::round(EDSCALE));
+				p_config.tree_panel_style->set_border_width_all(EDSCALE_RND(1));
 				p_config.tree_panel_style->set_border_color(p_config.extra_border_color_2);
 			} else {
 				p_config.tree_panel_style->set_border_color(p_config.dark_color_3);
@@ -438,7 +438,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			tooltip_style->set_content_margin_all(0);
 			tooltip_style->set_corner_radius_all(0);
 			if (p_config.draw_extra_borders) {
-				tooltip_style->set_border_width_all(Math::round(EDSCALE));
+				tooltip_style->set_border_width_all(EDSCALE_RND(1));
 				tooltip_style->set_border_color(p_config.extra_border_color_2);
 			}
 			p_theme->set_stylebox(SceneStringName(panel), "TooltipPanel", tooltip_style);
@@ -448,11 +448,11 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		Ref<StyleBoxFlat> popup_panel_style = p_config.base_style->duplicate();
 		popup_panel_style->set_bg_color(p_config.surface_popup_color);
 		popup_panel_style->set_shadow_color(Color(0, 0, 0, 0.3));
-		popup_panel_style->set_shadow_size(p_config.base_margin * 0.75 * EDSCALE);
+		popup_panel_style->set_shadow_size(EDSCALE_RND(p_config.base_margin * 0.75));
 		popup_panel_style->set_content_margin_all(p_config.popup_margin);
 		popup_panel_style->set_corner_radius_all(0);
 		if (p_config.draw_extra_borders) {
-			popup_panel_style->set_border_width_all(Math::round(EDSCALE));
+			popup_panel_style->set_border_width_all(EDSCALE_RND(1));
 			popup_panel_style->set_border_color(p_config.extra_border_color_2);
 		}
 		p_theme->set_stylebox(SceneStringName(panel), "PopupPanel", p_config.popup_panel_style);
@@ -490,7 +490,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_color("icon_pressed_color", "Button", p_config.icon_pressed_color);
 		p_theme->set_color("icon_disabled_color", "Button", p_config.icon_disabled_color);
 
-		p_theme->set_constant("h_separation", "Button", 4 * EDSCALE);
+		p_theme->set_constant("h_separation", "Button", EDSCALE_RND(4));
 		p_theme->set_constant("outline_size", "Button", 0);
 
 		p_theme->set_constant("outline_size", "Button", 0);
@@ -519,15 +519,15 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_color("font_disabled_color", "MenuBar", p_config.font_disabled_color);
 		p_theme->set_color("font_outline_color", "MenuBar", p_config.font_outline_color);
 
-		p_theme->set_constant("h_separation", "MenuBar", 4 * EDSCALE);
+		p_theme->set_constant("h_separation", "MenuBar", EDSCALE_RND(4));
 		p_theme->set_constant("outline_size", "MenuBar", 0);
 
 		// OptionButton.
 
 		p_theme->set_icon("arrow", "OptionButton", p_theme->get_icon(SNAME("GuiOptionArrow"), EditorStringName(EditorIcons)));
-		p_theme->set_constant("arrow_margin", "OptionButton", p_config.base_margin * 2 * EDSCALE);
+		p_theme->set_constant("arrow_margin", "OptionButton", EDSCALE_RND(p_config.base_margin * 2));
 		p_theme->set_constant("modulate_arrow", "OptionButton", true);
-		p_theme->set_constant("h_separation", "OptionButton", 4 * EDSCALE);
+		p_theme->set_constant("h_separation", "OptionButton", EDSCALE_RND(4));
 
 		// CheckButton.
 
@@ -553,14 +553,14 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_icon("unchecked_mirrored", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOffMirrored"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("unchecked_disabled_mirrored", "CheckButton", p_theme->get_icon(SNAME("GuiToggleOffDisabledMirrored"), EditorStringName(EditorIcons)));
 
-		p_theme->set_constant("h_separation", "CheckButton", 8 * EDSCALE);
+		p_theme->set_constant("h_separation", "CheckButton", EDSCALE_RND(8));
 		p_theme->set_constant("check_v_offset", "CheckButton", 0);
 		p_theme->set_constant("outline_size", "CheckButton", 0);
 
 		// CheckBox.
 		{
 			Ref<StyleBoxFlat> checkbox_style = p_config.panel_container_style->duplicate();
-			checkbox_style->set_content_margin_individual(p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 0.75 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 0.75 * EDSCALE);
+			checkbox_style->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 1.5), EDSCALE_RND(p_config.base_margin * 0.75), EDSCALE_RND(p_config.base_margin * 1.5), EDSCALE_RND(p_config.base_margin * 0.75));
 			Ref<StyleBoxFlat> checkbox_style_normal = checkbox_style->duplicate();
 			checkbox_style_normal->set_draw_center(false);
 
@@ -586,7 +586,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_icon("radio_checked_disabled", "CheckBox", p_theme->get_icon(SNAME("GuiRadioCheckedDisabled"), EditorStringName(EditorIcons)));
 			p_theme->set_icon("radio_unchecked_disabled", "CheckBox", p_theme->get_icon(SNAME("GuiRadioUncheckedDisabled"), EditorStringName(EditorIcons)));
 
-			p_theme->set_constant("h_separation", "CheckBox", 8 * EDSCALE);
+			p_theme->set_constant("h_separation", "CheckBox", EDSCALE_RND(8));
 			p_theme->set_constant("check_v_offset", "CheckBox", 0);
 			p_theme->set_constant("outline_size", "CheckBox", 0);
 		}
@@ -612,7 +612,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		{
 			// Use empty stylebox for trees to avoid drawing unnecessary borders in docks.
 			Ref<StyleBoxEmpty> style_tree_panel = p_config.base_empty_style->duplicate();
-			style_tree_panel->set_content_margin_individual(p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 2.5 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 2.5 * EDSCALE);
+			style_tree_panel->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 1.5), EDSCALE_RND(p_config.base_margin * 2.5), EDSCALE_RND(p_config.base_margin * 1.5), EDSCALE_RND(p_config.base_margin * 2.5));
 
 			Ref<StyleBoxFlat> style_button_pressed = p_config.flat_button_pressed->duplicate();
 			style_button_pressed->set_content_margin_individual(p_config.base_margin, 0, p_config.base_margin, 0);
@@ -645,36 +645,36 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_color("font_outline_color", "Tree", p_config.font_outline_color);
 			p_theme->set_color("title_button_color", "Tree", p_config.font_color);
 
-			int tree_v_sep = p_config.enable_touch_optimizations ? (p_config.separation_margin * 0.9) : Math::pow(p_config.base_margin * 0.175 * EDSCALE, 3);
+			int tree_v_sep = p_config.enable_touch_optimizations ? (p_config.separation_margin * 0.9) : Math::pow(EDSCALE_RND(p_config.base_margin * 0.175), 3);
 			p_theme->set_constant("v_separation", "Tree", tree_v_sep);
-			p_theme->set_constant("h_separation", "Tree", (p_config.increased_margin + 2) * EDSCALE);
+			p_theme->set_constant("h_separation", "Tree", EDSCALE_RND(p_config.increased_margin + 2));
 			p_theme->set_constant("guide_width", "Tree", p_config.border_width);
-			p_theme->set_constant("item_margin", "Tree", MAX(3 * p_config.increased_margin * EDSCALE, 12 * EDSCALE));
-			p_theme->set_constant("inner_item_margin_top", "Tree", p_config.base_margin * 0.75 * EDSCALE);
-			p_theme->set_constant("inner_item_margin_bottom", "Tree", p_config.base_margin * 0.75 * EDSCALE);
-			p_theme->set_constant("inner_item_margin_left", "Tree", p_config.base_margin * EDSCALE);
-			p_theme->set_constant("inner_item_margin_right", "Tree", p_config.base_margin * EDSCALE);
-			p_theme->set_constant("check_h_separation", "Tree", p_config.base_margin * 1.5 * EDSCALE);
-			p_theme->set_constant("icon_h_separation", "Tree", p_config.base_margin * 1.5 * EDSCALE);
-			p_theme->set_constant("button_margin", "Tree", p_config.base_margin * EDSCALE);
+			p_theme->set_constant("item_margin", "Tree", EDSCALE_RND(MAX(3 * p_config.increased_margin, 12)));
+			p_theme->set_constant("inner_item_margin_top", "Tree", EDSCALE_RND(p_config.base_margin * 0.75));
+			p_theme->set_constant("inner_item_margin_bottom", "Tree", EDSCALE_RND(p_config.base_margin * 0.75));
+			p_theme->set_constant("inner_item_margin_left", "Tree", EDSCALE_RND(p_config.base_margin));
+			p_theme->set_constant("inner_item_margin_right", "Tree", EDSCALE_RND(p_config.base_margin));
+			p_theme->set_constant("check_h_separation", "Tree", EDSCALE_RND(p_config.base_margin * 1.5));
+			p_theme->set_constant("icon_h_separation", "Tree", EDSCALE_RND(p_config.base_margin * 1.5));
+			p_theme->set_constant("button_margin", "Tree", EDSCALE_RND(p_config.base_margin));
 			p_theme->set_constant("dragging_unfold_wait_msec", "Tree", p_config.dragging_hover_wait_msec);
 			p_theme->set_constant("scroll_max_sticky_items", "Tree", p_config.max_sticky_tree_items);
-			p_theme->set_constant("scroll_border", "Tree", 40 * EDSCALE);
+			p_theme->set_constant("scroll_border", "Tree", EDSCALE_RND(40));
 			p_theme->set_constant("scroll_speed", "Tree", 12);
 			p_theme->set_constant("outline_size", "Tree", 0);
 			p_theme->set_constant("scrollbar_margin_left", "Tree", 0);
 			p_theme->set_constant("scrollbar_margin_top", "Tree", 0);
 			p_theme->set_constant("scrollbar_margin_right", "Tree", 0);
 			p_theme->set_constant("scrollbar_margin_bottom", "Tree", 0);
-			p_theme->set_constant("scrollbar_h_separation", "Tree", 1 * EDSCALE);
-			p_theme->set_constant("scrollbar_v_separation", "Tree", 1 * EDSCALE);
+			p_theme->set_constant("scrollbar_h_separation", "Tree", EDSCALE_RND(1));
+			p_theme->set_constant("scrollbar_v_separation", "Tree", EDSCALE_RND(1));
 
 			Color relationship_line_color = p_config.mono_color * Color(1, 1, 1, p_config.relationship_line_opacity);
 			Color highlight_line_color = p_config.mono_color * Color(1, 1, 1, p_config.relationship_line_opacity * 2);
 
 			int draw_relationship_lines = 0;
 			int relationship_line_width = 0;
-			int highlighted_line_width = Math::ceil(EDSCALE);
+			int highlighted_line_width = MAX(1, EDSCALE_RND(1));
 			if (p_config.draw_relationship_lines == EditorThemeManager::RELATIONSHIP_ALL) {
 				draw_relationship_lines = 1;
 				relationship_line_width = 1;
@@ -724,8 +724,8 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			style_tree_title->set_bg_color(p_config.surface_lower_color);
 			// Use a transparent border to separate rounded column titles.
 			style_tree_title->set_border_color(Color(p_config.surface_lower_color, 0));
-			style_tree_title->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
-			style_tree_title->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			style_tree_title->set_border_width(SIDE_LEFT, MAX(1, EDSCALE_RND(1)));
+			style_tree_title->set_border_width(SIDE_RIGHT, MAX(1, EDSCALE_RND(1)));
 
 			p_theme->set_stylebox("cursor", "Tree", style_tree_cursor);
 			p_theme->set_stylebox("cursor_unfocused", "Tree", style_tree_cursor);
@@ -758,7 +758,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		// ItemList.
 		{
 			Ref<StyleBoxFlat> style_itemlist_bg = p_config.base_style->duplicate();
-			style_itemlist_bg->set_content_margin_all(p_config.base_margin * 2 * EDSCALE);
+			style_itemlist_bg->set_content_margin_all(EDSCALE_RND(p_config.base_margin * 2));
 			Ref<StyleBoxFlat> style_itemlist_cursor = p_config.base_style->duplicate();
 			style_itemlist_cursor->set_bg_color(p_config.mono_color * Color(1, 1, 1, 0.04));
 
@@ -778,10 +778,10 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_color("font_outline_color", "ItemList", p_config.font_outline_color);
 			p_theme->set_color("guide_color", "ItemList", Color(1, 1, 1, 0));
 			p_theme->set_color("scroll_hint_color", "ItemList", Color(0, 0, 0, p_config.dark_theme ? 1.0 : 0.5));
-			p_theme->set_constant("v_separation", "ItemList", p_config.base_margin * 1.5 * EDSCALE);
-			p_theme->set_constant("h_separation", "ItemList", (p_config.increased_margin + 2) * EDSCALE);
+			p_theme->set_constant("v_separation", "ItemList", EDSCALE_RND(p_config.base_margin * 1.5));
+			p_theme->set_constant("h_separation", "ItemList", EDSCALE_RND(p_config.increased_margin + 2));
 			p_theme->set_constant("scroll_bar_h_separation", "ItemList", style_itemlist_bg->get_margin(SIDE_RIGHT));
-			p_theme->set_constant("icon_margin", "ItemList", (p_config.increased_margin + 2) * EDSCALE);
+			p_theme->set_constant("icon_margin", "ItemList", EDSCALE_RND(p_config.increased_margin + 2));
 			p_theme->set_constant(SceneStringName(line_separation), "ItemList", p_config.separation_margin);
 			p_theme->set_constant("outline_size", "ItemList", 0);
 		}
@@ -790,8 +790,8 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 	// TabBar & TabContainer.
 	{
 		Ref<StyleBoxFlat> style_tab_selected = p_config.base_style->duplicate();
-		style_tab_selected->set_content_margin_individual(p_config.base_margin * 4 * EDSCALE, p_config.base_margin * 2.1 * EDSCALE, p_config.base_margin * 4 * EDSCALE, p_config.base_margin * 2.1 * EDSCALE);
-		style_tab_selected->set_corner_radius_individual(p_config.corner_radius * EDSCALE, p_config.corner_radius * EDSCALE, 0, 0);
+		style_tab_selected->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 4), EDSCALE_RND(p_config.base_margin * 2.1), EDSCALE_RND(p_config.base_margin * 4), EDSCALE_RND(p_config.base_margin * 2.1));
+		style_tab_selected->set_corner_radius_individual(EDSCALE_RND(p_config.corner_radius), EDSCALE_RND(p_config.corner_radius), 0, 0);
 
 		Ref<StyleBoxFlat> style_tab_focus = style_tab_selected->duplicate();
 		style_tab_focus->set_bg_color(p_config.base_color);
@@ -810,7 +810,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		style_tabbar_background->set_bg_color(p_config.surface_lowest_color);
 		style_tabbar_background->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
 		style_tabbar_background->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
-		style_tabbar_background->set_content_margin_individual(0, 0, p_config.base_margin * 0.25 * EDSCALE, 0);
+		style_tabbar_background->set_content_margin_individual(0, 0, EDSCALE_RND(p_config.base_margin * 0.25), 0);
 
 		p_theme->set_stylebox("tabbar_background", "TabContainer", style_tabbar_background);
 		p_theme->set_stylebox(SceneStringName(panel), "TabContainer", p_config.tab_container_style);
@@ -866,30 +866,30 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 
 		p_theme->set_constant("side_margin", "TabContainer", 0);
 		p_theme->set_constant("outline_size", "TabContainer", 0);
-		p_theme->set_constant("h_separation", "TabBar", 4 * EDSCALE);
+		p_theme->set_constant("h_separation", "TabBar", EDSCALE_RND(4));
 		p_theme->set_constant("outline_size", "TabBar", 0);
 		p_theme->set_constant("hover_switch_wait_msec", "TabBar", p_config.dragging_hover_wait_msec);
 	}
 
 	// Separators.
 	{
-		Ref<StyleBoxLine> style_h_separator = EditorThemeManager::make_line_stylebox(p_config.separator_color, Math::round(2 * EDSCALE), p_config.base_margin * -1 * EDSCALE, p_config.base_margin * -1 * EDSCALE);
+		Ref<StyleBoxLine> style_h_separator = EditorThemeManager::make_line_stylebox(p_config.separator_color, EDSCALE_RND(2), EDSCALE_RND(p_config.base_margin * -1), EDSCALE_RND(p_config.base_margin * -1));
 		p_theme->set_stylebox("separator", "HSeparator", style_h_separator);
 
 		Ref<StyleBoxLine> style_v_separator = style_h_separator->duplicate();
 		style_v_separator->set_vertical(true);
 		p_theme->set_stylebox("separator", "VSeparator", style_v_separator);
 
-		p_theme->set_constant("separation", "Separator", p_config.base_margin * 2 * EDSCALE);
+		p_theme->set_constant("separation", "Separator", EDSCALE_RND(p_config.base_margin * 2));
 	}
 
 	// LineEdit & TextEdit.
 	{
 		Ref<StyleBoxFlat> text_editor_style = p_config.base_style->duplicate();
 		text_editor_style->set_bg_color(p_config.surface_lower_color);
-		text_editor_style->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, ((p_config.base_margin * 0.75) + 1) * EDSCALE, p_config.base_margin * 2 * EDSCALE, ((p_config.base_margin * 0.75) + 1) * EDSCALE);
+		text_editor_style->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND((p_config.base_margin * 0.75) + 1), EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND((p_config.base_margin * 0.75) + 1));
 		if (p_config.draw_extra_borders) {
-			text_editor_style->set_border_width_all(Math::round(EDSCALE));
+			text_editor_style->set_border_width_all(EDSCALE_RND(1));
 			text_editor_style->set_border_color(p_config.extra_border_color_1);
 		}
 
@@ -935,7 +935,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_color("caret_color", "TextEdit", p_config.font_color);
 		p_theme->set_color("selection_color", "TextEdit", p_config.selection_color);
 
-		p_theme->set_constant("line_spacing", "TextEdit", 4 * EDSCALE);
+		p_theme->set_constant("line_spacing", "TextEdit", EDSCALE_RND(4));
 		p_theme->set_constant("outline_size", "TextEdit", 0);
 		p_theme->set_constant("caret_width", "TextEdit", 1);
 	}
@@ -965,20 +965,20 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_icon("grabber", "VSplitContainer", p_theme->get_icon(SNAME("GuiVsplitter"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("grabber", "HSplitContainer", p_theme->get_icon(SNAME("GuiHsplitter"), EditorStringName(EditorIcons)));
 
-		p_theme->set_constant("separation", "SplitContainer", p_config.base_margin * 0.75 * EDSCALE);
-		p_theme->set_constant("separation", "HSplitContainer", p_config.base_margin * 0.75 * EDSCALE);
-		p_theme->set_constant("separation", "VSplitContainer", p_config.base_margin * 0.75 * EDSCALE);
+		p_theme->set_constant("separation", "SplitContainer", EDSCALE_RND(p_config.base_margin * 0.75));
+		p_theme->set_constant("separation", "HSplitContainer", EDSCALE_RND(p_config.base_margin * 0.75));
+		p_theme->set_constant("separation", "VSplitContainer", EDSCALE_RND(p_config.base_margin * 0.75));
 
 		p_theme->set_constant("autohide", "SplitContainer", 1);
 		p_theme->set_constant("autohide", "HSplitContainer", 1);
 		p_theme->set_constant("autohide", "VSplitContainer", 1);
 
-		p_theme->set_constant("minimum_grab_thickness", "SplitContainer", p_config.base_margin * 2 * EDSCALE);
-		p_theme->set_constant("minimum_grab_thickness", "HSplitContainer", p_config.base_margin * 2 * EDSCALE);
-		p_theme->set_constant("minimum_grab_thickness", "VSplitContainer", p_config.base_margin * 2 * EDSCALE);
+		p_theme->set_constant("minimum_grab_thickness", "SplitContainer", EDSCALE_RND(p_config.base_margin * 2));
+		p_theme->set_constant("minimum_grab_thickness", "HSplitContainer", EDSCALE_RND(p_config.base_margin * 2));
+		p_theme->set_constant("minimum_grab_thickness", "VSplitContainer", EDSCALE_RND(p_config.base_margin * 2));
 
 		// GridContainer.
-		p_theme->set_constant("v_separation", "GridContainer", Math::round(p_config.widget_margin.y - 2 * EDSCALE));
+		p_theme->set_constant("v_separation", "GridContainer", Math::round(p_config.widget_margin.y - EDSCALE_RND(2)));
 
 		// FoldableContainer
 
@@ -1025,19 +1025,19 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_color("title_color", "Window", p_config.font_color);
 		p_theme->set_icon("close", "Window", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("close_pressed", "Window", p_theme->get_icon(SNAME("GuiClose"), EditorStringName(EditorIcons)));
-		p_theme->set_constant("close_h_offset", "Window", 22 * EDSCALE);
-		p_theme->set_constant("close_v_offset", "Window", 20 * EDSCALE);
-		p_theme->set_constant("title_height", "Window", 24 * EDSCALE);
-		p_theme->set_constant("resize_margin", "Window", 4 * EDSCALE);
+		p_theme->set_constant("close_h_offset", "Window", EDSCALE_RND(22));
+		p_theme->set_constant("close_v_offset", "Window", EDSCALE_RND(20));
+		p_theme->set_constant("title_height", "Window", EDSCALE_RND(24));
+		p_theme->set_constant("resize_margin", "Window", EDSCALE_RND(4));
 		p_theme->set_font("title_font", "Window", p_theme->get_font(SNAME("title"), EditorStringName(EditorFonts)));
 		p_theme->set_font_size("title_font_size", "Window", p_theme->get_font_size(SNAME("title_size"), EditorStringName(EditorFonts)));
 
 		// AcceptDialog.
 		p_theme->set_stylebox(SceneStringName(panel), "AcceptDialog", p_config.dialog_style);
-		p_theme->set_constant("buttons_separation", "AcceptDialog", 8 * EDSCALE);
+		p_theme->set_constant("buttons_separation", "AcceptDialog", EDSCALE_RND(8));
 		// Make buttons with short texts such as "OK" easier to click/tap.
-		p_theme->set_constant("buttons_min_width", "AcceptDialog", p_config.dialogs_buttons_min_size.x * EDSCALE);
-		p_theme->set_constant("buttons_min_height", "AcceptDialog", p_config.dialogs_buttons_min_size.y * EDSCALE);
+		p_theme->set_constant("buttons_min_width", "AcceptDialog", EDSCALE_RND(p_config.dialogs_buttons_min_size.x));
+		p_theme->set_constant("buttons_min_height", "AcceptDialog", EDSCALE_RND(p_config.dialogs_buttons_min_size.y));
 
 		// FileDialog.
 		p_theme->set_icon("folder", "FileDialog", p_theme->get_icon("Folder", EditorStringName(EditorIcons)));
@@ -1081,7 +1081,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			style_popup_menu->set_content_margin_all(p_config.popup_margin);
 			style_popup_menu->set_corner_radius_all(0);
 			if (p_config.draw_extra_borders) {
-				style_popup_menu->set_border_width_all(Math::round(EDSCALE));
+				style_popup_menu->set_border_width_all(EDSCALE_RND(1));
 				style_popup_menu->set_border_color(p_config.extra_border_color_2);
 			}
 			p_theme->set_stylebox(SceneStringName(panel), "PopupMenu", style_popup_menu);
@@ -1091,7 +1091,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 
 			p_theme->set_stylebox(SceneStringName(hover), "PopupMenu", style_popup_hover);
 
-			Ref<StyleBoxLine> style_popup_separator = EditorThemeManager::make_line_stylebox(p_config.mono_color * Color(1, 1, 1, p_config.dark_theme ? 0.075 : 0.125), Math::round(2 * EDSCALE), p_config.base_margin * -2 * EDSCALE, p_config.base_margin * -2 * EDSCALE);
+			Ref<StyleBoxLine> style_popup_separator = EditorThemeManager::make_line_stylebox(p_config.mono_color * Color(1, 1, 1, p_config.dark_theme ? 0.075 : 0.125), EDSCALE_RND(2), EDSCALE_RND(p_config.base_margin * -2), EDSCALE_RND(p_config.base_margin * -2));
 
 			p_theme->set_stylebox("separator", "PopupMenu", style_popup_separator);
 			p_theme->set_stylebox("labeled_separator_left", "PopupMenu", style_popup_separator);
@@ -1118,8 +1118,8 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_icon("submenu_mirrored", "PopupMenu", p_theme->get_icon(SNAME("ArrowLeft"), EditorStringName(EditorIcons)));
 			p_theme->set_icon("search", "PopupMenu", p_theme->get_icon(SNAME("Search"), EditorStringName(EditorIcons)));
 
-			p_theme->set_constant("h_separation", "PopupMenu", p_config.base_margin * 1.75 * EDSCALE);
-			int v_sep = (p_config.enable_touch_optimizations ? 12 : p_config.base_margin * 1.75) * EDSCALE;
+			p_theme->set_constant("h_separation", "PopupMenu", EDSCALE_RND(p_config.base_margin * 1.75));
+			int v_sep = EDSCALE_RND(p_config.enable_touch_optimizations ? 12 : p_config.base_margin * 1.75);
 			p_theme->set_constant("v_separation", "PopupMenu", v_sep);
 			p_theme->set_constant("search_bar_separation", "PopupMenu", v_sep);
 			p_theme->set_constant("outline_size", "PopupMenu", 0);
@@ -1138,7 +1138,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		Ref<StyleBoxFlat> grabber_hl_style = p_config.base_style->duplicate();
 		grabber_hl_style->set_bg_color(p_config.mono_color * Color(1, 1, 1, 0.5));
 
-		int scroll_margin = (p_config.enable_touch_optimizations ? 10 : 3) * EDSCALE;
+		int scroll_margin = EDSCALE_RND(p_config.enable_touch_optimizations ? 10 : 3);
 
 		// HScrollBar.
 
@@ -1158,8 +1158,8 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_icon("decrement_highlight", "HScrollBar", empty_icon);
 		p_theme->set_icon("decrement_pressed", "HScrollBar", empty_icon);
 
-		p_theme->set_constant("padding_top", "HScrollBar", p_config.base_margin * EDSCALE);
-		p_theme->set_constant("padding_bottom", "HScrollBar", p_config.base_margin * EDSCALE);
+		p_theme->set_constant("padding_top", "HScrollBar", EDSCALE_RND(p_config.base_margin));
+		p_theme->set_constant("padding_bottom", "HScrollBar", EDSCALE_RND(p_config.base_margin));
 
 		// VScrollBar.
 
@@ -1179,15 +1179,15 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_icon("decrement_highlight", "VScrollBar", empty_icon);
 		p_theme->set_icon("decrement_pressed", "VScrollBar", empty_icon);
 
-		p_theme->set_constant("padding_left", "VScrollBar", p_config.base_margin * EDSCALE);
-		p_theme->set_constant("padding_right", "VScrollBar", p_config.base_margin * EDSCALE);
+		p_theme->set_constant("padding_left", "VScrollBar", EDSCALE_RND(p_config.base_margin));
+		p_theme->set_constant("padding_right", "VScrollBar", EDSCALE_RND(p_config.base_margin));
 
 		// Slider
 		const int background_margin = MAX(2, p_config.base_margin / 2);
 
 		Ref<StyleBoxFlat> style_h_slider = p_config.base_style->duplicate();
 		style_h_slider->set_bg_color(p_config.mono_color_inv * Color(1, 1, 1, 0.35));
-		style_h_slider->set_content_margin_individual(0, 2 * EDSCALE, 0, 2 * EDSCALE);
+		style_h_slider->set_content_margin_individual(0, EDSCALE_RND(2), 0, EDSCALE_RND(2));
 
 		// HSlider.
 		p_theme->set_icon("grabber_highlight", "HSlider", p_theme->get_icon(SNAME("GuiSliderGrabberHl"), EditorStringName(EditorIcons)));
@@ -1199,7 +1199,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_constant("grabber_offset", "HSlider", 0);
 
 		Ref<StyleBoxFlat> style_v_slider = style_h_slider->duplicate();
-		style_v_slider->set_content_margin_individual(2 * EDSCALE, 0, 2 * EDSCALE, 0);
+		style_v_slider->set_content_margin_individual(EDSCALE_RND(2), 0, EDSCALE_RND(2), 0);
 
 		// VSlider.
 		p_theme->set_icon("grabber", "VSlider", p_theme->get_icon(SNAME("GuiSliderGrabber"), EditorStringName(EditorIcons)));
@@ -1217,7 +1217,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 
 		Ref<StyleBoxFlat> rich_text_style = p_config.base_style->duplicate();
 		rich_text_style->set_bg_color(p_config.surface_low_color);
-		rich_text_style->set_content_margin_all(p_config.base_margin * 2 * EDSCALE);
+		rich_text_style->set_content_margin_all(EDSCALE_RND(p_config.base_margin * 2));
 
 		p_theme->set_stylebox(CoreStringName(normal), "RichTextLabel", rich_text_style);
 		p_theme->set_stylebox("focus", "RichTextLabel", EditorThemeManager::make_empty_stylebox());
@@ -1227,15 +1227,15 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_color("font_outline_color", "RichTextLabel", p_config.font_outline_color);
 		p_theme->set_color("selection_color", "RichTextLabel", p_config.selection_color);
 
-		p_theme->set_constant("shadow_offset_x", "RichTextLabel", 1 * EDSCALE);
-		p_theme->set_constant("shadow_offset_y", "RichTextLabel", 1 * EDSCALE);
-		p_theme->set_constant("shadow_outline_size", "RichTextLabel", 1 * EDSCALE);
+		p_theme->set_constant("shadow_offset_x", "RichTextLabel", EDSCALE_RND(1));
+		p_theme->set_constant("shadow_offset_y", "RichTextLabel", EDSCALE_RND(1));
+		p_theme->set_constant("shadow_outline_size", "RichTextLabel", EDSCALE_RND(1));
 		p_theme->set_constant("outline_size", "RichTextLabel", 0);
 
 		// Label.
 
 		Ref<StyleBoxEmpty> label_style = p_config.base_empty_style->duplicate();
-		label_style->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * EDSCALE);
+		label_style->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin), EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin));
 
 		p_theme->set_stylebox(CoreStringName(normal), "Label", label_style);
 		p_theme->set_stylebox("focus", "Label", p_config.focus_style);
@@ -1244,10 +1244,10 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_color("font_shadow_color", "Label", Color(1, 1, 1, 0));
 		p_theme->set_color("font_outline_color", "Label", p_config.font_outline_color);
 
-		p_theme->set_constant("shadow_offset_x", "Label", 1 * EDSCALE);
-		p_theme->set_constant("shadow_offset_y", "Label", 1 * EDSCALE);
-		p_theme->set_constant("shadow_outline_size", "Label", 1 * EDSCALE);
-		p_theme->set_constant("line_spacing", "Label", 3 * EDSCALE);
+		p_theme->set_constant("shadow_offset_x", "Label", EDSCALE_RND(1));
+		p_theme->set_constant("shadow_offset_y", "Label", EDSCALE_RND(1));
+		p_theme->set_constant("shadow_outline_size", "Label", EDSCALE_RND(1));
+		p_theme->set_constant("line_spacing", "Label", EDSCALE_RND(3));
 		p_theme->set_constant("outline_size", "Label", 0);
 
 		// Label with different margins.
@@ -1308,11 +1308,11 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 
 	Ref<StyleBoxFlat> progress_bar_style = p_config.base_style->duplicate();
 	progress_bar_style->set_bg_color(p_config.surface_lowest_color);
-	progress_bar_style->set_expand_margin(SIDE_TOP, p_config.base_margin * 0.5 * EDSCALE);
-	progress_bar_style->set_expand_margin(SIDE_BOTTOM, p_config.base_margin * 0.5 * EDSCALE);
-	progress_bar_style->set_content_margin_all(p_config.base_margin * EDSCALE);
+	progress_bar_style->set_expand_margin(SIDE_TOP, EDSCALE_RND(p_config.base_margin * 0.5));
+	progress_bar_style->set_expand_margin(SIDE_BOTTOM, EDSCALE_RND(p_config.base_margin * 0.5));
+	progress_bar_style->set_content_margin_all(EDSCALE_RND(p_config.base_margin));
 	if (p_config.draw_extra_borders) {
-		progress_bar_style->set_border_width_all(Math::round(EDSCALE));
+		progress_bar_style->set_border_width_all(EDSCALE_RND(1));
 		progress_bar_style->set_border_color(p_config.extra_border_color_2);
 	}
 
@@ -1430,19 +1430,19 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			const bool high_contrast_borders = p_config.draw_extra_borders && p_config.dark_theme;
 
 			Ref<StyleBoxFlat> gn_panel_style = EditorThemeManager::make_flat_stylebox(gn_frame_bg, gn_margin_side, gn_margin_top, gn_margin_side, gn_margin_bottom, p_config.corner_radius);
-			gn_panel_style->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
-			gn_panel_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
-			gn_panel_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
+			gn_panel_style->set_border_width(SIDE_BOTTOM, EDSCALE_RND(2));
+			gn_panel_style->set_border_width(SIDE_LEFT, EDSCALE_RND(2));
+			gn_panel_style->set_border_width(SIDE_RIGHT, EDSCALE_RND(2));
 			gn_panel_style->set_border_color(high_contrast_borders ? gn_bg_color.lightened(0.2) : gn_bg_color.darkened(0.3));
-			gn_panel_style->set_corner_radius_individual(0, 0, gn_corner_radius * EDSCALE, gn_corner_radius * EDSCALE);
+			gn_panel_style->set_corner_radius_individual(0, 0, EDSCALE_RND(gn_corner_radius), EDSCALE_RND(gn_corner_radius));
 			gn_panel_style->set_anti_aliased(true);
 
 			Ref<StyleBoxFlat> gn_panel_selected_style = gn_panel_style->duplicate();
 			gn_panel_selected_style->set_bg_color(p_config.dark_theme ? gn_bg_color.lightened(0.15) : gn_bg_color.darkened(0.15));
 			gn_panel_selected_style->set_border_width(SIDE_TOP, 0);
-			gn_panel_selected_style->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
-			gn_panel_selected_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
-			gn_panel_selected_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
+			gn_panel_selected_style->set_border_width(SIDE_BOTTOM, EDSCALE_RND(2));
+			gn_panel_selected_style->set_border_width(SIDE_LEFT, EDSCALE_RND(2));
+			gn_panel_selected_style->set_border_width(SIDE_RIGHT, EDSCALE_RND(2));
 			gn_panel_selected_style->set_border_color(p_config.mono_color);
 
 			const int gn_titlebar_margin_top = 8;
@@ -1450,20 +1450,20 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			const int gn_titlebar_margin_bottom = 8;
 
 			Ref<StyleBoxFlat> gn_titlebar_style = EditorThemeManager::make_flat_stylebox(gn_bg_color, gn_titlebar_margin_side, gn_titlebar_margin_top, gn_titlebar_margin_side, gn_titlebar_margin_bottom, p_config.corner_radius);
-			gn_titlebar_style->set_border_width(SIDE_TOP, 2 * EDSCALE);
-			gn_titlebar_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
-			gn_titlebar_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
+			gn_titlebar_style->set_border_width(SIDE_TOP, EDSCALE_RND(2));
+			gn_titlebar_style->set_border_width(SIDE_LEFT, EDSCALE_RND(2));
+			gn_titlebar_style->set_border_width(SIDE_RIGHT, EDSCALE_RND(2));
 			gn_titlebar_style->set_border_color(high_contrast_borders ? gn_bg_color.lightened(0.2) : gn_bg_color.darkened(0.3));
-			gn_titlebar_style->set_expand_margin(SIDE_TOP, 2 * EDSCALE);
-			gn_titlebar_style->set_corner_radius_individual(gn_corner_radius * EDSCALE, gn_corner_radius * EDSCALE, 0, 0);
+			gn_titlebar_style->set_expand_margin(SIDE_TOP, EDSCALE_RND(2));
+			gn_titlebar_style->set_corner_radius_individual(EDSCALE_RND(gn_corner_radius), EDSCALE_RND(gn_corner_radius), 0, 0);
 			gn_titlebar_style->set_anti_aliased(true);
 
 			Ref<StyleBoxFlat> gn_titlebar_selected_style = gn_titlebar_style->duplicate();
 			gn_titlebar_selected_style->set_border_color(p_config.mono_color);
-			gn_titlebar_selected_style->set_border_width(SIDE_TOP, 2 * EDSCALE);
-			gn_titlebar_selected_style->set_border_width(SIDE_LEFT, 2 * EDSCALE);
-			gn_titlebar_selected_style->set_border_width(SIDE_RIGHT, 2 * EDSCALE);
-			gn_titlebar_selected_style->set_expand_margin(SIDE_TOP, 2 * EDSCALE);
+			gn_titlebar_selected_style->set_border_width(SIDE_TOP, EDSCALE_RND(2));
+			gn_titlebar_selected_style->set_border_width(SIDE_LEFT, EDSCALE_RND(2));
+			gn_titlebar_selected_style->set_border_width(SIDE_RIGHT, EDSCALE_RND(2));
+			gn_titlebar_selected_style->set_expand_margin(SIDE_TOP, EDSCALE_RND(2));
 
 			Color gn_decoration_color = p_config.dark_color_1.inverted();
 
@@ -1490,12 +1490,12 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_stylebox("slot_selected", "GraphNode", p_config.focus_style);
 
 			const Color gn_separator_color = gn_frame_bg.lerp(p_config.mono_color, 0.1);
-			p_theme->set_stylebox("separator", "GraphNode", EditorThemeManager::make_line_stylebox(gn_separator_color, Math::round(2 * EDSCALE)));
+			p_theme->set_stylebox("separator", "GraphNode", EditorThemeManager::make_line_stylebox(gn_separator_color, EDSCALE_RND(2)));
 
 			p_theme->set_color("resizer_color", "GraphNode", gn_decoration_color);
 
 			p_theme->set_constant("port_h_offset", "GraphNode", 1);
-			p_theme->set_constant("separation", "GraphNode", 1 * EDSCALE);
+			p_theme->set_constant("separation", "GraphNode", EDSCALE_RND(1));
 
 			Ref<DPITexture> port_icon = p_theme->get_icon(SNAME("GuiGraphNodePort"), EditorStringName(EditorIcons));
 			// The true size is 24x24 This is necessary for sharp port icons at high zoom levels in GraphEdit (up to ~200%).
@@ -1509,18 +1509,18 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			p_theme->set_constant("shadow_outline_size", "GraphNodeTitleLabel", 4);
 			p_theme->set_constant("shadow_offset_x", "GraphNodeTitleLabel", 0);
 			p_theme->set_constant("shadow_offset_y", "GraphNodeTitleLabel", 1);
-			p_theme->set_constant("line_spacing", "GraphNodeTitleLabel", 3 * EDSCALE);
+			p_theme->set_constant("line_spacing", "GraphNodeTitleLabel", EDSCALE_RND(3));
 
 			// GraphFrame.
 
-			const int gf_corner_width = 7 * EDSCALE;
+			const int gf_corner_width = EDSCALE_RND(7);
 			const int gf_border_width = 2 * MAX(1, EDSCALE);
 
 			Ref<StyleBoxFlat> graphframe_sb = EditorThemeManager::make_flat_stylebox(Color(0.0, 0.0, 0.0, 0.2), gn_margin_side, gn_margin_side, gn_margin_side, gn_margin_bottom, gf_corner_width);
-			graphframe_sb->set_expand_margin(SIDE_TOP, 38 * EDSCALE);
+			graphframe_sb->set_expand_margin(SIDE_TOP, EDSCALE_RND(38));
 			graphframe_sb->set_border_width_all(gf_border_width);
 			graphframe_sb->set_border_color(high_contrast_borders ? gn_bg_color.lightened(0.2) : gn_bg_color.darkened(0.3));
-			graphframe_sb->set_shadow_size(8 * EDSCALE);
+			graphframe_sb->set_shadow_size(EDSCALE_RND(8));
 			graphframe_sb->set_shadow_color(Color(p_config.shadow_color, p_config.shadow_color.a * 0.25));
 			graphframe_sb->set_anti_aliased(true);
 
@@ -1536,22 +1536,22 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			// GraphFrame's title Label.
 			p_theme->set_type_variation("GraphFrameTitleLabel", "Label");
 			p_theme->set_stylebox(CoreStringName(normal), "GraphFrameTitleLabel", memnew(StyleBoxEmpty));
-			p_theme->set_font_size(SceneStringName(font_size), "GraphFrameTitleLabel", 22 * EDSCALE);
+			p_theme->set_font_size(SceneStringName(font_size), "GraphFrameTitleLabel", EDSCALE_RND(22));
 			p_theme->set_color(SceneStringName(font_color), "GraphFrameTitleLabel", Color(1, 1, 1));
 			p_theme->set_color("font_shadow_color", "GraphFrameTitleLabel", Color(1, 1, 1, 0));
 			p_theme->set_color("font_outline_color", "GraphFrameTitleLabel", Color(1, 1, 1));
-			p_theme->set_constant("shadow_offset_x", "GraphFrameTitleLabel", 1 * EDSCALE);
-			p_theme->set_constant("shadow_offset_y", "GraphFrameTitleLabel", 1 * EDSCALE);
+			p_theme->set_constant("shadow_offset_x", "GraphFrameTitleLabel", EDSCALE_RND(1));
+			p_theme->set_constant("shadow_offset_y", "GraphFrameTitleLabel", EDSCALE_RND(1));
 			p_theme->set_constant("outline_size", "GraphFrameTitleLabel", 0);
-			p_theme->set_constant("shadow_outline_size", "GraphFrameTitleLabel", 1 * EDSCALE);
-			p_theme->set_constant("line_spacing", "GraphFrameTitleLabel", 3 * EDSCALE);
+			p_theme->set_constant("shadow_outline_size", "GraphFrameTitleLabel", EDSCALE_RND(1));
+			p_theme->set_constant("line_spacing", "GraphFrameTitleLabel", EDSCALE_RND(3));
 		}
 
 		// VisualShader reroute node.
 		{
 			Ref<StyleBox> vs_reroute_panel_style = EditorThemeManager::make_empty_stylebox();
 			Ref<StyleBox> vs_reroute_titlebar_style = vs_reroute_panel_style->duplicate();
-			vs_reroute_titlebar_style->set_content_margin_all(16 * EDSCALE);
+			vs_reroute_titlebar_style->set_content_margin_all(EDSCALE_RND(16));
 			p_theme->set_stylebox(SceneStringName(panel), "VSRerouteNode", vs_reroute_panel_style);
 			p_theme->set_stylebox("panel_selected", "VSRerouteNode", vs_reroute_panel_style);
 			p_theme->set_stylebox("titlebar", "VSRerouteNode", vs_reroute_titlebar_style);
@@ -1569,14 +1569,14 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		Ref<StyleBoxFlat> circle_style_focus = p_config.base_style->duplicate();
 		circle_style_focus->set_border_color(p_config.mono_color * Color(1, 1, 1, 0.3));
 		circle_style_focus->set_draw_center(false);
-		circle_style_focus->set_corner_radius_all(256 * EDSCALE);
-		circle_style_focus->set_corner_detail(32 * EDSCALE);
+		circle_style_focus->set_corner_radius_all(EDSCALE_RND(256));
+		circle_style_focus->set_corner_detail(EDSCALE_RND(32));
 
 		p_theme->set_constant("margin", "ColorPicker", p_config.base_margin);
-		p_theme->set_constant("sv_width", "ColorPicker", 256 * EDSCALE);
-		p_theme->set_constant("sv_height", "ColorPicker", 256 * EDSCALE);
-		p_theme->set_constant("h_width", "ColorPicker", 30 * EDSCALE);
-		p_theme->set_constant("label_width", "ColorPicker", 10 * EDSCALE);
+		p_theme->set_constant("sv_width", "ColorPicker", EDSCALE_RND(256));
+		p_theme->set_constant("sv_height", "ColorPicker", EDSCALE_RND(256));
+		p_theme->set_constant("h_width", "ColorPicker", EDSCALE_RND(30));
+		p_theme->set_constant("label_width", "ColorPicker", EDSCALE_RND(10));
 		p_theme->set_constant("center_slider_grabbers", "ColorPicker", 1);
 
 		p_theme->set_stylebox("sample_focus", "ColorPicker", p_config.focus_style);
@@ -1620,7 +1620,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_stylebox("panel_container", "ProjectManager", p_config.foreground_panel);
 		p_theme->set_stylebox("project_list", "ProjectManager", style_project_list);
 		p_theme->set_stylebox("quick_settings_panel", "ProjectManager", style_project_list);
-		p_theme->set_constant("sidebar_button_icon_separation", "ProjectManager", int(6 * EDSCALE));
+		p_theme->set_constant("sidebar_button_icon_separation", "ProjectManager", EDSCALE_RND(6));
 		p_theme->set_icon("browse_folder", "ProjectManager", p_theme->get_icon(SNAME("FolderBrowse"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("browse_file", "ProjectManager", p_theme->get_icon(SNAME("FileBrowse"), EditorStringName(EditorIcons)));
 
@@ -1688,7 +1688,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// This stylebox is used in 3d and 2d viewports (no borders).
 		Ref<StyleBoxFlat> style_content_panel_vp = p_config.content_panel_style->duplicate();
-		style_content_panel_vp->set_content_margin_individual(p_config.border_width * 2, p_config.base_margin * EDSCALE, p_config.border_width * 2, p_config.border_width * 2);
+		style_content_panel_vp->set_content_margin_individual(p_config.border_width * 2, EDSCALE_RND(p_config.base_margin), p_config.border_width * 2, p_config.border_width * 2);
 		p_theme->set_stylebox("Content", EditorStringName(EditorStyles), style_content_panel_vp);
 
 		// 3D/Spatial editor.
@@ -1701,15 +1701,15 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			bg_color.invert();
 		}
 		style_info_3d_viewport->set_bg_color(bg_color);
-		style_info_3d_viewport->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE);
+		style_info_3d_viewport->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin * 1.5), EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin * 1.5));
 		p_theme->set_stylebox("Information3dViewport", EditorStringName(EditorStyles), style_info_3d_viewport);
 
 		// 2D, 3D, and Game toolbar.
 		p_theme->set_type_variation("MainToolBarMargin", "MarginContainer");
-		p_theme->set_constant("margin_left", "MainToolBarMargin", 4 * EDSCALE);
-		p_theme->set_constant("margin_right", "MainToolBarMargin", 4 * EDSCALE);
-		p_theme->set_constant("margin_top", "MainToolBarMargin", p_config.base_margin * 0.5 * EDSCALE);
-		p_theme->set_constant("margin_bottom", "MainToolBarMargin", p_config.base_margin * 0.5 * EDSCALE);
+		p_theme->set_constant("margin_left", "MainToolBarMargin", EDSCALE_RND(4));
+		p_theme->set_constant("margin_right", "MainToolBarMargin", EDSCALE_RND(4));
+		p_theme->set_constant("margin_top", "MainToolBarMargin", EDSCALE_RND(p_config.base_margin * 0.5));
+		p_theme->set_constant("margin_bottom", "MainToolBarMargin", EDSCALE_RND(p_config.base_margin * 0.5));
 
 		// 2D and 3D contextual toolbar.
 		// Use a custom stylebox to make contextual menu items stand out from the rest.
@@ -1790,7 +1790,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		Ref<StyleBoxFlat> style_bottom_panel = p_config.content_panel_style->duplicate();
 		style_bottom_panel->set_content_margin_all(p_config.tab_container_style->get_content_margin(SIDE_LEFT));
 		style_bottom_panel->set_border_width(SIDE_BOTTOM, 0);
-		style_bottom_panel->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		style_bottom_panel->set_corner_radius_all(EDSCALE_RND(p_config.corner_radius));
 		style_bottom_panel->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
 		style_bottom_panel->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
 
@@ -1800,13 +1800,13 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		style_bottom_panel_tabbar->set_content_margin(SIDE_TOP, 0);
 
 		Ref<StyleBoxEmpty> style_bottom_tab = p_config.base_empty_style->duplicate();
-		style_bottom_tab->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.2 * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.2 * EDSCALE);
+		style_bottom_tab->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin * 1.2), EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin * 1.2));
 
 		Ref<StyleBoxFlat> bottom_panel_button_pressed = p_config.flat_button_pressed->duplicate();
-		bottom_panel_button_pressed->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.2 * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.2 * EDSCALE);
+		bottom_panel_button_pressed->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin * 1.2), EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin * 1.2));
 
 		Ref<StyleBoxFlat> bottom_panel_button_hover = p_config.flat_button_hover->duplicate();
-		bottom_panel_button_hover->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.2 * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.2 * EDSCALE);
+		bottom_panel_button_hover->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin * 1.2), EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin * 1.2));
 
 		p_theme->set_stylebox("BottomPanel", EditorStringName(EditorStyles), style_bottom_panel);
 		p_theme->set_type_variation("BottomPanel", "TabContainer");
@@ -1825,7 +1825,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// Use bigger margin for buttons in bottom panel to make them easier to press.
 		Ref<StyleBoxEmpty> bottom_panel_button = p_config.base_empty_style->duplicate();
-		bottom_panel_button->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.2 * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 1.2 * EDSCALE);
+		bottom_panel_button->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin * 1.2), EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin * 1.2));
 		p_theme->set_stylebox(CoreStringName(normal), "BottomPanelButton", bottom_panel_button);
 
 		p_theme->set_stylebox(SceneStringName(hover), "BottomPanelButton", bottom_panel_button_hover);
@@ -1860,7 +1860,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		Ref<StyleBoxFlat> editor_spin_label_bg = p_config.base_style->duplicate();
 		editor_spin_label_bg->set_bg_color(p_config.surface_lower_color);
-		editor_spin_label_bg->set_content_margin_all(p_config.base_margin * EDSCALE);
+		editor_spin_label_bg->set_content_margin_all(EDSCALE_RND(p_config.base_margin));
 		p_theme->set_stylebox("label_bg", "EditorSpinSlider", editor_spin_label_bg);
 
 		// TODO: Use separate arrows instead like on SpinBox. Planned for a different PR.
@@ -1870,15 +1870,15 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		// EditorSpinSliders with a label have more space on the left, so add an
 		// higher margin to match the location where the text begins.
 		// The margin values below were determined by empirical testing.
-		p_theme->set_constant("line_edit_margin", "EditorSpinSlider", 28 * EDSCALE);
-		p_theme->set_constant("line_edit_margin_empty", "EditorSpinSlider", 20 * EDSCALE);
+		p_theme->set_constant("line_edit_margin", "EditorSpinSlider", EDSCALE_RND(28));
+		p_theme->set_constant("line_edit_margin_empty", "EditorSpinSlider", EDSCALE_RND(20));
 
 		// Launch Pad and Play buttons.
 		Ref<StyleBoxFlat> style_launch_pad_movie = p_config.base_style->duplicate();
-		style_launch_pad_movie->set_content_margin_all(p_config.base_margin * EDSCALE);
+		style_launch_pad_movie->set_content_margin_all(EDSCALE_RND(p_config.base_margin));
 		style_launch_pad_movie->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.2));
 		style_launch_pad_movie->set_border_color(p_config.accent_color * Color(1, 1, 1, 0.8));
-		style_launch_pad_movie->set_border_width_all(Math::round(2 * EDSCALE));
+		style_launch_pad_movie->set_border_width_all(EDSCALE_RND(2));
 		p_theme->set_stylebox("LaunchPadMovieMode", EditorStringName(EditorStyles), style_launch_pad_movie);
 
 		int pad_normal_margin = style_launch_pad_movie->get_minimum_size().width / 2;
@@ -1886,11 +1886,11 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		style_launch_pad->set_content_margin_all(pad_normal_margin);
 		p_theme->set_stylebox("LaunchPadNormal", EditorStringName(EditorStyles), style_launch_pad);
 
-		Ref<StyleBoxFlat> style_launch_pad_recovery_mode = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, 2 * EDSCALE, 0, 2 * EDSCALE, 0, p_config.corner_radius);
+		Ref<StyleBoxFlat> style_launch_pad_recovery_mode = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, EDSCALE_RND(2), 0, EDSCALE_RND(2), 0, p_config.corner_radius);
 		style_launch_pad_recovery_mode->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.1));
 		style_launch_pad_recovery_mode->set_border_color(p_config.warning_color);
-		style_launch_pad_recovery_mode->set_border_width_all(Math::round(2 * EDSCALE));
-		style_launch_pad_recovery_mode->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		style_launch_pad_recovery_mode->set_border_width_all(EDSCALE_RND(2));
+		style_launch_pad_recovery_mode->set_corner_radius_all(EDSCALE_RND(p_config.corner_radius));
 		p_theme->set_stylebox("LaunchPadRecoveryMode", EditorStringName(EditorStyles), style_launch_pad_recovery_mode);
 
 		p_theme->set_stylebox("MovieWriterButtonNormal", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
@@ -1900,9 +1900,9 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_stylebox("MovieWriterButtonPressed", EditorStringName(EditorStyles), style_write_movie_button);
 
 		// Profiler autostart indicator panel.
-		Ref<StyleBoxFlat> style_profiler_autostart = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, 2 * EDSCALE, 0, 2 * EDSCALE, 0, p_config.corner_radius);
+		Ref<StyleBoxFlat> style_profiler_autostart = EditorThemeManager::make_flat_stylebox(p_config.dark_color_1, EDSCALE_RND(2), 0, EDSCALE_RND(2), 0, p_config.corner_radius);
 		style_profiler_autostart->set_bg_color(Color(1, 0.867, 0.396));
-		style_profiler_autostart->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		style_profiler_autostart->set_corner_radius_all(EDSCALE_RND(p_config.corner_radius));
 		p_theme->set_type_variation("ProfilerAutostartIndicator", "Button");
 		p_theme->set_stylebox(CoreStringName(normal), "ProfilerAutostartIndicator", style_profiler_autostart);
 		p_theme->set_stylebox(SceneStringName(pressed), "ProfilerAutostartIndicator", style_profiler_autostart);
@@ -1911,12 +1911,12 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		// Recovery mode button style
 		Ref<StyleBoxFlat> style_recovery_mode_button = p_config.button_style_pressed->duplicate();
 		style_recovery_mode_button->set_bg_color(p_config.warning_color);
-		style_recovery_mode_button->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		style_recovery_mode_button->set_corner_radius_all(EDSCALE_RND(p_config.corner_radius));
 		style_recovery_mode_button->set_content_margin_all(0);
 		// Recovery mode button is implicitly styled from the panel's background.
 		// So, remove any existing borders. (e.g. from draw_extra_borders config)
 		style_recovery_mode_button->set_border_width_all(0);
-		style_recovery_mode_button->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
+		style_recovery_mode_button->set_expand_margin(SIDE_RIGHT, EDSCALE_RND(2));
 		p_theme->set_stylebox("RecoveryModeButton", EditorStringName(EditorStyles), style_recovery_mode_button);
 	}
 
@@ -1924,10 +1924,10 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 	{
 		// Custom theme type for MarginContainer with 4px margins.
 		p_theme->set_type_variation("MarginContainer4px", "MarginContainer");
-		p_theme->set_constant("margin_left", "MarginContainer4px", 4 * EDSCALE);
-		p_theme->set_constant("margin_top", "MarginContainer4px", 4 * EDSCALE);
-		p_theme->set_constant("margin_right", "MarginContainer4px", 4 * EDSCALE);
-		p_theme->set_constant("margin_bottom", "MarginContainer4px", 4 * EDSCALE);
+		p_theme->set_constant("margin_left", "MarginContainer4px", EDSCALE_RND(4));
+		p_theme->set_constant("margin_top", "MarginContainer4px", EDSCALE_RND(4));
+		p_theme->set_constant("margin_right", "MarginContainer4px", EDSCALE_RND(4));
+		p_theme->set_constant("margin_bottom", "MarginContainer4px", EDSCALE_RND(4));
 
 		// Header LinkButton variation.
 		p_theme->set_type_variation("HeaderSmallLink", "LinkButton");
@@ -2156,8 +2156,8 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_type_variation("PanelContainerTabbarInner", "PanelContainer");
 
 			Ref<StyleBoxFlat> style_tab_selected_inner = p_theme->get_stylebox(SNAME("tab_selected"), SNAME("TabContainer"))->duplicate();
-			style_tab_selected_inner->set_content_margin_individual(p_config.base_margin * 4 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 4 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE);
-			style_tab_selected_inner->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+			style_tab_selected_inner->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 4), EDSCALE_RND(p_config.base_margin * 1.5), EDSCALE_RND(p_config.base_margin * 4), EDSCALE_RND(p_config.base_margin * 1.5));
+			style_tab_selected_inner->set_corner_radius_all(EDSCALE_RND(p_config.corner_radius));
 			p_theme->set_stylebox("tab_selected", "TabContainerInner", style_tab_selected_inner);
 			p_theme->set_stylebox("tab_selected", "TabBarInner", style_tab_selected_inner);
 
@@ -2179,8 +2179,8 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_stylebox("tab_disabled", "TabBarInner", style_tab_disabled_inner);
 
 			Ref<StyleBoxFlat> style_tabbar_background_inner = p_theme->get_stylebox(SNAME("tabbar_background"), SNAME("TabContainer"))->duplicate();
-			style_tabbar_background_inner->set_content_margin_all(p_config.base_margin * EDSCALE);
-			style_tabbar_background_inner->set_corner_radius_all(p_config.corner_radius > 0 ? (p_config.corner_radius + p_config.base_margin) * EDSCALE : 0);
+			style_tabbar_background_inner->set_content_margin_all(EDSCALE_RND(p_config.base_margin));
+			style_tabbar_background_inner->set_corner_radius_all(p_config.corner_radius > 0 ? EDSCALE_RND(p_config.corner_radius + p_config.base_margin) : 0);
 			style_tabbar_background_inner->set_bg_color(background_color);
 
 			p_theme->set_stylebox("tabbar_background", "TabContainerInner", style_tabbar_background_inner);
@@ -2219,7 +2219,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		// EditorValidationPanel.
 		Ref<StyleBoxFlat> editor_validation_panel = p_config.base_style->duplicate();
 		editor_validation_panel->set_bg_color(p_config.surface_low_color);
-		editor_validation_panel->set_content_margin_individual(p_config.base_margin * EDSCALE, p_config.base_margin * 0.5 * EDSCALE, p_config.base_margin * EDSCALE, p_config.base_margin * 0.5 * EDSCALE);
+		editor_validation_panel->set_content_margin_individual(EDSCALE_RND(p_config.base_margin), EDSCALE_RND(p_config.base_margin * 0.5), EDSCALE_RND(p_config.base_margin), EDSCALE_RND(p_config.base_margin * 0.5));
 		p_theme->set_stylebox(SceneStringName(panel), "EditorValidationPanel", editor_validation_panel);
 
 		// Sidebars.
@@ -2233,7 +2233,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			Ref<StyleBoxFlat> style_sidebar = p_config.base_style->duplicate();
 			style_sidebar->set_bg_color(p_config.surface_low_color);
 			if (p_config.draw_extra_borders) {
-				style_sidebar->set_border_width_all(1 * EDSCALE);
+				style_sidebar->set_border_width_all(EDSCALE_RND(1));
 				style_sidebar->set_border_color(p_config.extra_border_color_2);
 			}
 
@@ -2250,8 +2250,8 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			Color secondary_title_color = _get_base_color(p_config, 1.6, 0.9);
 			style_tree_title_secondary->set_bg_color(secondary_title_color);
 			style_tree_title_secondary->set_border_color(Color(secondary_title_color, 0));
-			style_tree_title_secondary->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
-			style_tree_title_secondary->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			style_tree_title_secondary->set_border_width(SIDE_LEFT, MAX(1, EDSCALE_RND(1)));
+			style_tree_title_secondary->set_border_width(SIDE_RIGHT, MAX(1, EDSCALE_RND(1)));
 
 			p_theme->set_stylebox("title_button_normal", "TreeSecondary", style_tree_title_secondary);
 			p_theme->set_stylebox("title_button_hover", "TreeSecondary", style_tree_title_secondary);
@@ -2261,7 +2261,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			Ref<StyleBoxFlat> style_audio_bus_effect_tree = p_config.base_style->duplicate();
 			style_audio_bus_effect_tree->set_bg_color(_get_base_color(p_config, 0.3));
 			if (p_config.draw_extra_borders) {
-				style_audio_bus_effect_tree->set_border_width_all(1 * EDSCALE);
+				style_audio_bus_effect_tree->set_border_width_all(EDSCALE_RND(1));
 				style_audio_bus_effect_tree->set_border_color(p_config.extra_border_color_2);
 			}
 			p_theme->set_stylebox(SceneStringName(panel), "EditorAudioBusEffectsTree", style_audio_bus_effect_tree);
@@ -2284,73 +2284,73 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_type_variation("TreeTable", "Tree");
 
 			p_theme->set_constant("h_separation", "TreeTable", 0);
-			p_theme->set_constant("inner_item_margin_top", "TreeTable", p_config.base_margin * EDSCALE);
-			p_theme->set_constant("inner_item_margin_bottom", "TreeTable", p_config.base_margin * EDSCALE);
-			p_theme->set_constant("inner_item_margin_left", "TreeTable", p_config.base_margin * 3 * EDSCALE);
-			p_theme->set_constant("inner_item_margin_right", "TreeTable", p_config.base_margin * 3 * EDSCALE);
-			p_theme->set_constant("item_margin", "TreeTable", 16 * EDSCALE);
+			p_theme->set_constant("inner_item_margin_top", "TreeTable", EDSCALE_RND(p_config.base_margin));
+			p_theme->set_constant("inner_item_margin_bottom", "TreeTable", EDSCALE_RND(p_config.base_margin));
+			p_theme->set_constant("inner_item_margin_left", "TreeTable", EDSCALE_RND(p_config.base_margin * 3));
+			p_theme->set_constant("inner_item_margin_right", "TreeTable", EDSCALE_RND(p_config.base_margin * 3));
+			p_theme->set_constant("item_margin", "TreeTable", EDSCALE_RND(16));
 			p_theme->set_constant("button_margin", "TreeTable", 0);
 
 			Ref<StyleBoxEmpty> style_tree_panel = p_config.base_empty_style->duplicate();
-			style_tree_panel->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 0.75 * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * 0.75 * EDSCALE);
+			style_tree_panel->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin * 0.75), EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin * 0.75));
 			p_theme->set_stylebox(SceneStringName(panel), "TreeTable", style_tree_panel);
 
 			const Ref<StyleBoxFlat> style_tree_title = p_theme->get_stylebox("title_button_normal", "Tree")->duplicate();
-			style_tree_title->set_content_margin_individual(p_config.base_margin * 3 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * 3 * EDSCALE, p_config.base_margin * 1.5 * EDSCALE);
+			style_tree_title->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 3), EDSCALE_RND(p_config.base_margin * 1.5), EDSCALE_RND(p_config.base_margin * 3), EDSCALE_RND(p_config.base_margin * 1.5));
 			p_theme->set_stylebox("title_button_normal", "TreeTable", style_tree_title);
 			p_theme->set_stylebox("title_button_hover", "TreeTable", style_tree_title);
 			p_theme->set_stylebox("title_button_pressed", "TreeTable", style_tree_title);
 
 			const Ref<StyleBoxFlat> style_tree_selected = p_theme->get_stylebox("selected", "Tree")->duplicate();
 			style_tree_selected->set_border_color(Color(style_tree_selected->get_bg_color(), 0));
-			style_tree_selected->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
-			style_tree_selected->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			style_tree_selected->set_border_width(SIDE_LEFT, MAX(1, EDSCALE_RND(1)));
+			style_tree_selected->set_border_width(SIDE_RIGHT, MAX(1, EDSCALE_RND(1)));
 			p_theme->set_stylebox("selected", "TreeTable", style_tree_selected);
 
 			const Ref<StyleBoxFlat> style_tree_hover = p_theme->get_stylebox("hovered", "Tree")->duplicate();
 			style_tree_hover->set_border_color(Color(style_tree_hover->get_bg_color(), 0));
-			style_tree_hover->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
-			style_tree_hover->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			style_tree_hover->set_border_width(SIDE_LEFT, MAX(1, EDSCALE_RND(1)));
+			style_tree_hover->set_border_width(SIDE_RIGHT, MAX(1, EDSCALE_RND(1)));
 			p_theme->set_stylebox("hovered", "TreeTable", style_tree_hover);
 
 			const Ref<StyleBoxFlat> style_tree_hovered_selected = p_theme->get_stylebox("hovered_selected", "Tree")->duplicate();
 			style_tree_hovered_selected->set_border_color(Color(style_tree_hovered_selected->get_bg_color(), 0));
-			style_tree_hovered_selected->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
-			style_tree_hovered_selected->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			style_tree_hovered_selected->set_border_width(SIDE_LEFT, MAX(1, EDSCALE_RND(1)));
+			style_tree_hovered_selected->set_border_width(SIDE_RIGHT, MAX(1, EDSCALE_RND(1)));
 			p_theme->set_stylebox("hovered_selected", "TreeTable", style_tree_hovered_selected);
 
 			const Ref<StyleBoxFlat> style_tree_dimmed = p_theme->get_stylebox("hovered_dimmed", "Tree")->duplicate();
 			style_tree_dimmed->set_border_color(Color(style_tree_dimmed->get_bg_color(), 0));
-			style_tree_dimmed->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
-			style_tree_dimmed->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			style_tree_dimmed->set_border_width(SIDE_LEFT, MAX(1, EDSCALE_RND(1)));
+			style_tree_dimmed->set_border_width(SIDE_RIGHT, MAX(1, EDSCALE_RND(1)));
 			p_theme->set_stylebox("hovered_dimmed", "TreeTable", p_theme->get_stylebox("hovered_dimmed", "Tree"));
 
 			const Ref<StyleBoxFlat> style_button_pressed = p_theme->get_stylebox("button_pressed", "Tree")->duplicate();
-			style_button_pressed->set_content_margin_individual(p_config.base_margin * EDSCALE, 0, p_config.base_margin * EDSCALE, 0);
+			style_button_pressed->set_content_margin_individual(EDSCALE_RND(p_config.base_margin), 0, EDSCALE_RND(p_config.base_margin), 0);
 			style_button_pressed->set_border_color(Color(style_button_pressed->get_bg_color(), 0));
-			style_button_pressed->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
-			style_button_pressed->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			style_button_pressed->set_border_width(SIDE_LEFT, MAX(1, EDSCALE_RND(1)));
+			style_button_pressed->set_border_width(SIDE_RIGHT, MAX(1, EDSCALE_RND(1)));
 			p_theme->set_stylebox("button_pressed", "TreeTable", style_button_pressed);
 			p_theme->set_stylebox("custom_button_pressed", "TreeTable", style_button_pressed);
 
 			const Ref<StyleBoxFlat> style_button_hover = p_theme->get_stylebox("button_hover", "Tree")->duplicate();
-			style_button_hover->set_content_margin_individual(p_config.base_margin * EDSCALE, 0, p_config.base_margin * EDSCALE, 0);
+			style_button_hover->set_content_margin_individual(EDSCALE_RND(p_config.base_margin), 0, EDSCALE_RND(p_config.base_margin), 0);
 			style_button_hover->set_border_color(Color(style_button_hover->get_bg_color(), 0));
-			style_button_hover->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
-			style_button_hover->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			style_button_hover->set_border_width(SIDE_LEFT, MAX(1, EDSCALE_RND(1)));
+			style_button_hover->set_border_width(SIDE_RIGHT, MAX(1, EDSCALE_RND(1)));
 			p_theme->set_stylebox("button_hover", "TreeTable", style_button_hover);
 			p_theme->set_stylebox("custom_button_hover", "TreeTable", style_button_hover);
 
 			const Ref<StyleBoxFlat> style_cursor = p_theme->get_stylebox("cursor", "Tree")->duplicate();
 			style_cursor->set_border_color(Color(style_cursor->get_bg_color(), 0));
-			style_cursor->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
-			style_cursor->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			style_cursor->set_border_width(SIDE_LEFT, MAX(1, EDSCALE_RND(1)));
+			style_cursor->set_border_width(SIDE_RIGHT, MAX(1, EDSCALE_RND(1)));
 			p_theme->set_stylebox("cursor", "TreeTable", style_cursor);
 
 			const Ref<StyleBoxFlat> style_cursor_unfocused = p_theme->get_stylebox("cursor_unfocused", "Tree")->duplicate();
 			style_cursor_unfocused->set_border_color(Color(style_cursor_unfocused->get_bg_color(), 0));
-			style_cursor_unfocused->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
-			style_cursor_unfocused->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+			style_cursor_unfocused->set_border_width(SIDE_LEFT, MAX(1, EDSCALE_RND(1)));
+			style_cursor_unfocused->set_border_width(SIDE_RIGHT, MAX(1, EDSCALE_RND(1)));
 			p_theme->set_stylebox("cursor_unfocused", "TreeTable", style_cursor_unfocused);
 		}
 	}
@@ -2362,15 +2362,15 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// Vertical separation between inspector areas.
 		p_theme->set_type_variation("EditorInspectorContainer", "VBoxContainer");
-		p_theme->set_constant("separation", "EditorInspectorContainer", Math::ceil(p_config.base_margin * EDSCALE));
+		p_theme->set_constant("separation", "EditorInspectorContainer", Math::ceil(EDSCALE_RND(p_config.base_margin)));
 
 		// Vertical separation between inspector sections.
 		p_theme->set_type_variation("EditorSectionContainer", "VBoxContainer");
-		p_theme->set_constant("separation", "EditorSectionContainer", p_config.base_margin * 0.5 * EDSCALE);
+		p_theme->set_constant("separation", "EditorSectionContainer", EDSCALE_RND(p_config.base_margin * 0.5));
 
 		// Vertical separation between inspector properties.
 		p_theme->set_type_variation("EditorPropertyContainer", "VBoxContainer");
-		p_theme->set_constant("separation", "EditorPropertyContainer", p_config.base_margin * 0.5 * EDSCALE);
+		p_theme->set_constant("separation", "EditorPropertyContainer", EDSCALE_RND(p_config.base_margin * 0.5));
 
 		// EditorProperty.
 
@@ -2379,12 +2379,12 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		Ref<StyleBoxFlat> style_property_child_bg = p_config.base_style->duplicate();
 		style_property_child_bg->set_bg_color(p_config.surface_lower_color);
-		style_property_child_bg->set_content_margin_all(p_config.base_margin * EDSCALE);
+		style_property_child_bg->set_content_margin_all(EDSCALE_RND(p_config.base_margin));
 
 		p_theme->set_stylebox("bg", "EditorProperty", p_config.base_empty_style);
 		p_theme->set_stylebox("bg_selected", "EditorProperty", style_property_bg_selected);
 		p_theme->set_stylebox("child_bg", "EditorProperty", style_property_child_bg);
-		p_theme->set_constant("font_offset", "EditorProperty", 8 * EDSCALE);
+		p_theme->set_constant("font_offset", "EditorProperty", EDSCALE_RND(8));
 
 		const Color property_color = p_config.font_color.lerp(Color(0.5, 0.5, 0.5), 0.5);
 		const Color readonly_color = property_color.lerp(p_config.dark_icon_and_font ? Color(0, 0, 0) : Color(1, 1, 1), 0.25);
@@ -2408,10 +2408,10 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		Color inspector_indent_color = p_config.accent_color;
 		inspector_indent_color.a = 0.2;
-		Ref<StyleBoxFlat> inspector_indent_style = EditorThemeManager::make_flat_stylebox(inspector_indent_color, 2.0 * EDSCALE, 0, 2.0 * EDSCALE, 0);
+		Ref<StyleBoxFlat> inspector_indent_style = EditorThemeManager::make_flat_stylebox(inspector_indent_color, EDSCALE_RND(2.0), 0, EDSCALE_RND(2.0), 0);
 		p_theme->set_stylebox("indent_box", "EditorInspectorSection", inspector_indent_style);
-		p_theme->set_constant("indent_size", "EditorInspectorSection", 6.0 * EDSCALE);
-		p_theme->set_constant("h_separation", "EditorInspectorSection", p_config.base_margin * EDSCALE);
+		p_theme->set_constant("indent_size", "EditorInspectorSection", EDSCALE_RND(6.0));
+		p_theme->set_constant("h_separation", "EditorInspectorSection", EDSCALE_RND(p_config.base_margin));
 
 		Color prop_subsection_stylebox_color = p_config.button_disabled_color.lerp(p_config.base_color, 0.48);
 		p_theme->set_color("prop_subsection_stylebox_color", EditorStringName(Editor), prop_subsection_stylebox_color);
@@ -2419,19 +2419,19 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		Ref<StyleBoxFlat> prop_subsection_stylebox = p_config.base_style->duplicate();
 		prop_subsection_stylebox->set_bg_color(p_theme->get_color("prop_subsection_stylebox_color", EditorStringName(Editor)));
 		prop_subsection_stylebox->set_border_color(Color(prop_subsection_stylebox_color, 0));
-		prop_subsection_stylebox->set_corner_radius_all(p_config.corner_radius * EDSCALE);
+		prop_subsection_stylebox->set_corner_radius_all(EDSCALE_RND(p_config.corner_radius));
 		p_theme->set_stylebox("prop_subsection_stylebox", EditorStringName(Editor), prop_subsection_stylebox);
 
 		Ref<StyleBoxFlat> prop_subsection_stylebox_left = prop_subsection_stylebox->duplicate();
 		prop_subsection_stylebox_left->set_corner_radius(CORNER_TOP_RIGHT, 0);
 		prop_subsection_stylebox_left->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
-		prop_subsection_stylebox_left->set_border_width(SIDE_LEFT, Math::ceil(EDSCALE));
+		prop_subsection_stylebox_left->set_border_width(SIDE_LEFT, MAX(1, EDSCALE_RND(1)));
 		p_theme->set_stylebox("prop_subsection_stylebox_left", EditorStringName(Editor), prop_subsection_stylebox_left);
 
 		Ref<StyleBoxFlat> prop_subsection_stylebox_right = prop_subsection_stylebox->duplicate();
 		prop_subsection_stylebox_right->set_corner_radius(CORNER_TOP_LEFT, 0);
 		prop_subsection_stylebox_right->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
-		prop_subsection_stylebox_right->set_border_width(SIDE_RIGHT, Math::ceil(EDSCALE));
+		prop_subsection_stylebox_right->set_border_width(SIDE_RIGHT, MAX(1, EDSCALE_RND(1)));
 		p_theme->set_stylebox("prop_subsection_stylebox_right", EditorStringName(Editor), prop_subsection_stylebox_right);
 
 		p_theme->set_color("prop_subsection", EditorStringName(Editor), Color(1, 1, 1, 0));
@@ -2443,7 +2443,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		Ref<StyleBoxFlat> category_bg = p_config.base_style->duplicate();
 		category_bg->set_bg_color(p_config.surface_high_color);
-		category_bg->set_content_margin_individual(0, p_config.base_margin * EDSCALE, 0, p_config.base_margin * EDSCALE);
+		category_bg->set_content_margin_individual(0, EDSCALE_RND(p_config.base_margin), 0, EDSCALE_RND(p_config.base_margin));
 		if (p_config.draw_extra_borders) {
 			category_bg->set_border_width_all(1);
 			category_bg->set_border_color(p_config.extra_border_color_2);
@@ -2453,7 +2453,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		// EditorInspectorArray.
 		p_theme->set_color("bg", "EditorInspectorArray", p_config.surface_base_color);
 
-		p_theme->set_constant("inspector_margin", EditorStringName(Editor), 12 * EDSCALE);
+		p_theme->set_constant("inspector_margin", EditorStringName(Editor), EDSCALE_RND(12));
 
 		// Colored EditorProperty and EditorInspectorCategory.
 		for (int i = 0; i < 16; i++) {
@@ -2466,9 +2466,9 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			// Sub-inspector background.
 			Ref<StyleBoxFlat> sub_inspector_bg = p_config.base_style->duplicate();
 			sub_inspector_bg->set_bg_color(p_config.dark_color_1.lerp(si_base_color, 0.08));
-			sub_inspector_bg->set_border_width_all(2 * EDSCALE);
+			sub_inspector_bg->set_border_width_all(EDSCALE_RND(2));
 			sub_inspector_bg->set_border_color(si_base_color * Color(0.7, 0.7, 0.7, 0.8));
-			sub_inspector_bg->set_content_margin_all(4 * EDSCALE);
+			sub_inspector_bg->set_content_margin_all(EDSCALE_RND(4));
 			sub_inspector_bg->set_corner_radius(CORNER_TOP_LEFT, 0);
 			sub_inspector_bg->set_corner_radius(CORNER_TOP_RIGHT, 0);
 
@@ -2499,8 +2499,8 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 			Color style_dictionary_bg_color = p_config.dark_color_3.lerp(si_base_color, 0.08);
 			Ref<StyleBoxFlat> style_dictionary_add_item = EditorThemeManager::make_flat_stylebox(style_dictionary_bg_color, 0, 4, 0, 4, p_config.corner_radius);
-			style_dictionary_add_item->set_expand_margin(SIDE_LEFT, 2 * EDSCALE);
-			style_dictionary_add_item->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
+			style_dictionary_add_item->set_expand_margin(SIDE_LEFT, EDSCALE_RND(2));
+			style_dictionary_add_item->set_expand_margin(SIDE_RIGHT, EDSCALE_RND(2));
 			p_theme->set_stylebox("DictionaryAddItem" + itos(i + 1), EditorStringName(EditorStyles), style_dictionary_add_item);
 		}
 		Color si_base_color = p_config.accent_color;
@@ -2508,9 +2508,9 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		// Sub-inspector background.
 		Ref<StyleBoxFlat> sub_inspector_bg = p_config.base_style->duplicate();
 		sub_inspector_bg->set_bg_color(Color(1, 1, 1, 0));
-		sub_inspector_bg->set_border_width_all(2 * EDSCALE);
+		sub_inspector_bg->set_border_width_all(EDSCALE_RND(2));
 		sub_inspector_bg->set_border_color(p_config.dark_color_1.lerp(si_base_color, 0.15));
-		sub_inspector_bg->set_content_margin_all(4 * EDSCALE);
+		sub_inspector_bg->set_content_margin_all(EDSCALE_RND(4));
 		sub_inspector_bg->set_corner_radius(CORNER_TOP_LEFT, 0);
 		sub_inspector_bg->set_corner_radius(CORNER_TOP_RIGHT, 0);
 
@@ -2519,7 +2519,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		// Sub-inspector background no border.
 
 		Ref<StyleBoxFlat> sub_inspector_bg_no_border = p_config.base_style->duplicate();
-		sub_inspector_bg_no_border->set_content_margin_all(2 * EDSCALE);
+		sub_inspector_bg_no_border->set_content_margin_all(EDSCALE_RND(2));
 		sub_inspector_bg_no_border->set_bg_color(p_config.dark_color_2.lerp(p_config.dark_color_3, 0.15));
 		p_theme->set_stylebox("sub_inspector_bg_no_border", EditorStringName(EditorStyles), sub_inspector_bg_no_border);
 
@@ -2540,8 +2540,8 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// Object selector.
 		p_theme->set_type_variation("ObjectSelectorMargin", "MarginContainer");
-		p_theme->set_constant("margin_left", "ObjectSelectorMargin", p_config.base_margin * 2 * EDSCALE);
-		p_theme->set_constant("margin_right", "ObjectSelectorMargin", p_config.base_margin * 2.5 * EDSCALE);
+		p_theme->set_constant("margin_left", "ObjectSelectorMargin", EDSCALE_RND(p_config.base_margin * 2));
+		p_theme->set_constant("margin_right", "ObjectSelectorMargin", EDSCALE_RND(p_config.base_margin * 2.5));
 
 		// EditorInspectorButton.
 
@@ -2604,14 +2604,14 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// InspectorActionButton.
 		p_theme->set_type_variation("InspectorActionButton", "Button");
-		p_theme->set_constant("h_separation", "InspectorActionButton", p_config.base_margin * 2 * EDSCALE);
+		p_theme->set_constant("h_separation", "InspectorActionButton", EDSCALE_RND(p_config.base_margin * 2));
 	}
 
 	// Animation Editor.
 	{
 		// Timeline general.
 
-		p_theme->set_constant("timeline_v_separation", "AnimationTrackEditor", p_config.base_margin * EDSCALE);
+		p_theme->set_constant("timeline_v_separation", "AnimationTrackEditor", EDSCALE_RND(p_config.base_margin));
 		p_theme->set_constant("track_v_separation", "AnimationTrackEditor", 0);
 
 		int margin = p_theme->get_stylebox(SceneStringName(panel), SNAME("PanelContainer"))->get_content_margin(SIDE_LEFT);
@@ -2629,7 +2629,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		Ref<StyleBoxFlat> style_time_available = p_config.base_style->duplicate();
 		style_time_available->set_bg_color(p_config.dark_theme ? p_config.surface_highest_color : p_config.surface_high_color);
 		if (p_config.draw_extra_borders) {
-			style_time_available->set_border_width_all(Math::round(EDSCALE));
+			style_time_available->set_border_width_all(EDSCALE_RND(1));
 			style_time_available->set_border_color(p_config.extra_border_color_2);
 		}
 
@@ -2645,12 +2645,12 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_color("font_primary_color", "AnimationTimelineEdit", p_config.font_color);
 		p_theme->set_color("font_secondary_color", "AnimationTimelineEdit", p_config.font_disabled_color);
 
-		p_theme->set_constant("v_line_primary_margin", "AnimationTimelineEdit", p_config.base_margin * EDSCALE);
-		p_theme->set_constant("v_line_secondary_margin", "AnimationTimelineEdit", p_config.base_margin * 1.5 * EDSCALE);
-		p_theme->set_constant("v_line_primary_width", "AnimationTimelineEdit", Math::ceil(2 * EDSCALE));
-		p_theme->set_constant("v_line_secondary_width", "AnimationTimelineEdit", Math::ceil(EDSCALE));
-		p_theme->set_constant("text_primary_margin", "AnimationTimelineEdit", p_config.base_margin * 0.75 * EDSCALE);
-		p_theme->set_constant("text_secondary_margin", "AnimationTimelineEdit", p_config.base_margin * 0.5 * EDSCALE);
+		p_theme->set_constant("v_line_primary_margin", "AnimationTimelineEdit", EDSCALE_RND(p_config.base_margin));
+		p_theme->set_constant("v_line_secondary_margin", "AnimationTimelineEdit", EDSCALE_RND(p_config.base_margin * 1.5));
+		p_theme->set_constant("v_line_primary_width", "AnimationTimelineEdit", EDSCALE_RND(2));
+		p_theme->set_constant("v_line_secondary_width", "AnimationTimelineEdit", EDSCALE_RND(1));
+		p_theme->set_constant("text_primary_margin", "AnimationTimelineEdit", EDSCALE_RND(p_config.base_margin * 0.75));
+		p_theme->set_constant("text_secondary_margin", "AnimationTimelineEdit", EDSCALE_RND(p_config.base_margin * 0.5));
 
 		// AnimationTrackEdit.
 
@@ -2661,7 +2661,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		style_animation_track_hover->set_bg_color(p_config.surface_high_color);
 
 		Ref<StyleBoxFlat> style_animation_track_focus = p_config.base_style->duplicate();
-		style_animation_track_focus->set_content_margin_individual(p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * EDSCALE, p_config.base_margin * 1.5 * EDSCALE, p_config.base_margin * EDSCALE);
+		style_animation_track_focus->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 1.5), EDSCALE_RND(p_config.base_margin), EDSCALE_RND(p_config.base_margin * 1.5), EDSCALE_RND(p_config.base_margin));
 		style_animation_track_focus->set_border_width_all(2);
 		style_animation_track_focus->set_border_color(p_config.surface_high_color);
 		style_animation_track_focus->set_draw_center(false);
@@ -2672,14 +2672,14 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		p_theme->set_color("h_line_color", "AnimationTrackEdit", Color(1, 1, 1, 0));
 
-		p_theme->set_constant("h_separation", "AnimationTrackEdit", p_config.base_margin * 1.5 * EDSCALE);
-		p_theme->set_constant("outer_margin", "AnimationTrackEdit", p_config.increased_margin * 6 * EDSCALE);
+		p_theme->set_constant("h_separation", "AnimationTrackEdit", EDSCALE_RND(p_config.base_margin * 1.5));
+		p_theme->set_constant("outer_margin", "AnimationTrackEdit", EDSCALE_RND(p_config.increased_margin * 6));
 
 		// AnimationTrackEditGroup.
 
 		Ref<StyleBoxFlat> style_animation_track_header = p_config.base_style->duplicate();
 		style_animation_track_header->set_bg_color(p_config.surface_low_color);
-		style_animation_track_header->set_content_margin_individual(p_config.base_margin * 4 * EDSCALE, p_config.base_margin * EDSCALE, 0, p_config.base_margin * EDSCALE);
+		style_animation_track_header->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 4), EDSCALE_RND(p_config.base_margin), 0, EDSCALE_RND(p_config.base_margin));
 
 		p_theme->set_stylebox("header", "AnimationTrackEditGroup", style_animation_track_header);
 
@@ -2691,7 +2691,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_color("h_line_color", "AnimationTrackEditGroup", Color(1, 1, 1, 0));
 		p_theme->set_color("v_line_color", "AnimationTrackEditGroup", Color(1, 1, 1, 0));
 
-		p_theme->set_constant("h_separation", "AnimationTrackEditGroup", p_config.base_margin * 2 * EDSCALE);
+		p_theme->set_constant("h_separation", "AnimationTrackEditGroup", EDSCALE_RND(p_config.base_margin * 2));
 		p_theme->set_constant("v_separation", "AnimationTrackEditGroup", 0);
 
 		// AnimationBezierTrackEdit.
@@ -2701,8 +2701,8 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_color("h_line_color", "AnimationBezierTrackEdit", p_config.mono_color * Color(1, 1, 1, 0.12));
 		p_theme->set_color("v_line_color", "AnimationBezierTrackEdit", Color(1, 1, 1, 0));
 
-		p_theme->set_constant("h_separation", "AnimationBezierTrackEdit", (p_config.increased_margin + 2) * EDSCALE);
-		p_theme->set_constant("v_separation", "AnimationBezierTrackEdit", p_config.forced_even_separation * EDSCALE);
+		p_theme->set_constant("h_separation", "AnimationBezierTrackEdit", EDSCALE_RND(p_config.increased_margin + 2));
+		p_theme->set_constant("v_separation", "AnimationBezierTrackEdit", EDSCALE_RND(p_config.forced_even_separation));
 	}
 
 	// Editor help.
@@ -2732,22 +2732,22 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_color("param_bg_color", "EditorHelp", p_config.dark_color_1);
 		p_theme->set_color("primary_hr_color", "EditorHelp", p_config.base_color.lerp(p_config.mono_color_font, p_config.dark_theme ? 0.14 : 0.24));
 		p_theme->set_color("secondary_hr_color", "EditorHelp", p_config.base_color.lerp(p_config.mono_color_font, p_config.dark_theme ? 0.12 : 0.22));
-		p_theme->set_constant(SceneStringName(line_separation), "EditorHelp", Math::round(6 * EDSCALE));
-		p_theme->set_constant(SceneStringName(paragraph_separation), "EditorHelp", Math::round(10 * EDSCALE));
-		p_theme->set_constant("table_h_separation", "EditorHelp", 16 * EDSCALE);
-		p_theme->set_constant("table_v_separation", "EditorHelp", 6 * EDSCALE);
-		p_theme->set_constant("text_highlight_h_padding", "EditorHelp", 1 * EDSCALE);
-		p_theme->set_constant("text_highlight_v_padding", "EditorHelp", 2 * EDSCALE);
+		p_theme->set_constant(SceneStringName(line_separation), "EditorHelp", EDSCALE_RND(6));
+		p_theme->set_constant(SceneStringName(paragraph_separation), "EditorHelp", EDSCALE_RND(10));
+		p_theme->set_constant("table_h_separation", "EditorHelp", EDSCALE_RND(16));
+		p_theme->set_constant("table_v_separation", "EditorHelp", EDSCALE_RND(6));
+		p_theme->set_constant("text_highlight_h_padding", "EditorHelp", EDSCALE_RND(1));
+		p_theme->set_constant("text_highlight_v_padding", "EditorHelp", EDSCALE_RND(2));
 	}
 
 	// EditorHelpBitTitle.
 	{
 		Ref<StyleBoxFlat> editor_help_title_style = p_config.base_style->duplicate();
 		editor_help_title_style->set_bg_color(_get_base_color(p_config, 1.25, 0.75));
-		editor_help_title_style->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * EDSCALE);
-		editor_help_title_style->set_corner_radius_individual(p_config.corner_radius * EDSCALE, p_config.corner_radius * EDSCALE, 0, 0);
+		editor_help_title_style->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin), EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin));
+		editor_help_title_style->set_corner_radius_individual(EDSCALE_RND(p_config.corner_radius), EDSCALE_RND(p_config.corner_radius), 0, 0);
 		if (p_config.draw_extra_borders) {
-			editor_help_title_style->set_border_width_all(Math::round(EDSCALE));
+			editor_help_title_style->set_border_width_all(EDSCALE_RND(1));
 			editor_help_title_style->set_border_color(p_config.extra_border_color_2);
 		}
 
@@ -2759,10 +2759,10 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 	{
 		Ref<StyleBoxFlat> editor_help_content_style = p_config.base_style->duplicate();
 		editor_help_content_style->set_bg_color(p_config.surface_low_color);
-		editor_help_content_style->set_content_margin_individual(p_config.base_margin * 2 * EDSCALE, p_config.base_margin * EDSCALE, p_config.base_margin * 2 * EDSCALE, p_config.base_margin * EDSCALE);
-		editor_help_content_style->set_corner_radius_individual(0, 0, p_config.corner_radius * EDSCALE, p_config.corner_radius * EDSCALE);
+		editor_help_content_style->set_content_margin_individual(EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin), EDSCALE_RND(p_config.base_margin * 2), EDSCALE_RND(p_config.base_margin));
+		editor_help_content_style->set_corner_radius_individual(0, 0, EDSCALE_RND(p_config.corner_radius), EDSCALE_RND(p_config.corner_radius));
 		if (p_config.draw_extra_borders) {
-			editor_help_content_style->set_border_width_all(Math::round(EDSCALE));
+			editor_help_content_style->set_border_width_all(EDSCALE_RND(1));
 			editor_help_content_style->set_border_color(p_config.extra_border_color_2);
 		}
 
@@ -2775,7 +2775,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		Ref<StyleBoxFlat> style = p_theme->get_stylebox(CoreStringName(normal), "EditorHelpBitTitle")->duplicate();
 		style->set_bg_color(style->get_bg_color().lerp(p_config.mono_color_inv, 0.25));
 		if (!p_config.dark_theme) {
-			style->set_border_width_all(Math::round(2 * EDSCALE));
+			style->set_border_width_all(EDSCALE_RND(2));
 			style->set_border_color(p_config.mono_color * Color(1, 1, 1, 0.15));
 		}
 		style->set_corner_radius_all(0);
@@ -2789,7 +2789,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		Ref<StyleBoxFlat> style = p_theme->get_stylebox(CoreStringName(normal), "EditorHelpBitContent")->duplicate();
 		style->set_bg_color(style->get_bg_color().lerp(p_config.mono_color_inv, 0.25));
 		if (!p_config.dark_theme) {
-			style->set_border_width_all(Math::round(2 * EDSCALE));
+			style->set_border_width_all(EDSCALE_RND(2));
 			style->set_border_width(SIDE_TOP, 0);
 			style->set_border_color(p_config.mono_color * Color(1, 1, 1, 0.15));
 		}
@@ -2846,7 +2846,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			theme_preview_picker_bg_color.a = 0.2;
 			Ref<StyleBoxFlat> theme_preview_picker_sb = EditorThemeManager::make_flat_stylebox(theme_preview_picker_bg_color, 0, 0, 0, 0);
 			theme_preview_picker_sb->set_border_color(p_config.accent_color);
-			theme_preview_picker_sb->set_border_width_all(1.0 * EDSCALE);
+			theme_preview_picker_sb->set_border_width_all(EDSCALE_RND(1.0));
 			p_theme->set_stylebox("preview_picker_overlay", "ThemeEditor", theme_preview_picker_sb);
 
 			Color theme_preview_picker_label_bg_color = p_config.accent_color;
@@ -2855,11 +2855,11 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_stylebox("preview_picker_label", "ThemeEditor", theme_preview_picker_label_sb);
 
 			Ref<StyleBoxFlat> style_theme_preview_tab = p_theme->get_stylebox(SNAME("tab_selected"), SNAME("TabContainer"))->duplicate();
-			style_theme_preview_tab->set_expand_margin(SIDE_BOTTOM, 5 * EDSCALE);
+			style_theme_preview_tab->set_expand_margin(SIDE_BOTTOM, EDSCALE_RND(5));
 			p_theme->set_stylebox("ThemeEditorPreviewFG", EditorStringName(EditorStyles), style_theme_preview_tab);
 
 			Ref<StyleBoxFlat> style_theme_preview_bg_tab = p_theme->get_stylebox(SNAME("tab_unselected"), SNAME("TabContainer"))->duplicate();
-			style_theme_preview_bg_tab->set_expand_margin(SIDE_BOTTOM, 2 * EDSCALE);
+			style_theme_preview_bg_tab->set_expand_margin(SIDE_BOTTOM, EDSCALE_RND(2));
 			p_theme->set_stylebox("ThemeEditorPreviewBG", EditorStringName(EditorStyles), style_theme_preview_bg_tab);
 		}
 
@@ -2872,18 +2872,18 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_stylebox("error_panel", "GraphStateMachine", p_config.tree_panel_style);
 			p_theme->set_color("error_color", "GraphStateMachine", p_config.error_color);
 
-			const int sm_margin_side = 10 * EDSCALE;
+			const int sm_margin_side = EDSCALE_RND(10);
 			const int sm_margin_bottom = 2;
 			const Color sm_bg_color = p_config.dark_theme ? p_config.dark_color_3 : p_config.dark_color_1.lerp(p_config.mono_color, 0.09);
 
-			Ref<StyleBoxFlat> sm_node_style = EditorThemeManager::make_flat_stylebox(p_config.dark_color_3 * Color(1, 1, 1, 0.7), sm_margin_side, 24 * EDSCALE, sm_margin_side, sm_margin_bottom, p_config.corner_radius);
+			Ref<StyleBoxFlat> sm_node_style = EditorThemeManager::make_flat_stylebox(p_config.dark_color_3 * Color(1, 1, 1, 0.7), sm_margin_side, EDSCALE_RND(24), sm_margin_side, sm_margin_bottom, p_config.corner_radius);
 			sm_node_style->set_border_width_all(p_config.border_width);
 			sm_node_style->set_border_color(sm_bg_color);
 
-			Ref<StyleBoxFlat> sm_node_selected_style = EditorThemeManager::make_flat_stylebox(sm_bg_color * Color(1, 1, 1, 0.9), sm_margin_side, 24 * EDSCALE, sm_margin_side, sm_margin_bottom, p_config.corner_radius);
-			sm_node_selected_style->set_border_width_all(2 * EDSCALE + p_config.border_width);
+			Ref<StyleBoxFlat> sm_node_selected_style = EditorThemeManager::make_flat_stylebox(sm_bg_color * Color(1, 1, 1, 0.9), sm_margin_side, EDSCALE_RND(24), sm_margin_side, sm_margin_bottom, p_config.corner_radius);
+			sm_node_selected_style->set_border_width_all(EDSCALE_RND(2) + p_config.border_width);
 			sm_node_selected_style->set_border_color(p_config.accent_color * Color(1, 1, 1, 0.9));
-			sm_node_selected_style->set_shadow_size(8 * EDSCALE);
+			sm_node_selected_style->set_shadow_size(EDSCALE_RND(8));
 			sm_node_selected_style->set_shadow_color(p_config.shadow_color);
 
 			Ref<StyleBoxFlat> sm_node_playing_style = sm_node_selected_style->duplicate();
@@ -2896,12 +2896,12 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_stylebox("node_frame_playing", "GraphStateMachine", sm_node_playing_style);
 
 			Ref<StyleBoxFlat> sm_node_start_style = sm_node_style->duplicate();
-			sm_node_start_style->set_border_width_all(1 * EDSCALE);
+			sm_node_start_style->set_border_width_all(EDSCALE_RND(1));
 			sm_node_start_style->set_border_color(p_config.success_color.lightened(0.24));
 			p_theme->set_stylebox("node_frame_start", "GraphStateMachine", sm_node_start_style);
 
 			Ref<StyleBoxFlat> sm_node_end_style = sm_node_style->duplicate();
-			sm_node_end_style->set_border_width_all(1 * EDSCALE);
+			sm_node_end_style->set_border_width_all(EDSCALE_RND(1));
 			sm_node_end_style->set_border_color(p_config.error_color);
 			p_theme->set_stylebox("node_frame_end", "GraphStateMachine", sm_node_end_style);
 


### PR DESCRIPTION
This PR creates the new `EDSCALE_RND()` define, which is a shortcut for `Math::round(value * EDSCALE)` and uses it for all values inside the theme files that are multiplied by `EDSCALE`.

Fixes #114976, and probably some other issues too.