### PR TITLE
Fix code format for `PopupMenu` after configurable shrinking

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3384,6 +3384,7 @@ void PopupMenu::_popup_base(const Rect2i &p_bounds) {
 		Popup::_popup_base(p_bounds);
 	}
 }
+
 void PopupMenu::set_shrink_height(bool p_shrink) {
 	shrink_height = p_shrink;
 }


### PR DESCRIPTION
*Since #114438, @bruvzg accidentally didn't pressed the <kbd>Enter</kbd> key twice after `_popup_base`, and instead, he pressed once.*