### PR TITLE
Guard against non-main-thread emission of EditorFileSystem changed signal

### DIFF
--- a/editor/docks/import_dock.cpp
+++ b/editor/docks/import_dock.cpp
@@ -691,7 +691,7 @@ void ImportDock::_reimport() {
 	}
 
 	EditorFileSystem::get_singleton()->reimport_files(params->paths);
-	EditorFileSystem::get_singleton()->emit_signal(SNAME("filesystem_changed")); //it changed, so force emitting the signal
+	EditorFileSystem::get_singleton()->filesystem_changed(); // It changed, so force emitting the signal.
 
 	_set_dirty(false);
 }

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -368,7 +368,7 @@ void EditorInterface::make_scene_preview(const String &p_path, Node *p_scene, in
 	}
 
 	EditorResourcePreview::get_singleton()->check_for_invalidation(p_path);
-	EditorFileSystem::get_singleton()->emit_signal(SNAME("filesystem_changed"));
+	EditorFileSystem::get_singleton()->filesystem_changed();
 }
 
 void EditorInterface::add_root_node(Node *p_node) {

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -2552,16 +2552,16 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 		if (!is_scanning()) {
 			_process_update_pending();
 		}
-		if (!filesystem_changed_queued) {
-			filesystem_changed_queued = true;
+		if (!filesystem_changed_queued.is_set()) {
+			filesystem_changed_queued.set();
 			callable_mp(this, &EditorFileSystem::_notify_filesystem_changed).call_deferred();
 		}
 	}
 }
 
 void EditorFileSystem::_notify_filesystem_changed() {
-	emit_signal("filesystem_changed");
-	filesystem_changed_queued = false;
+	emit_signal(SNAME("filesystem_changed"));
+	filesystem_changed_queued.clear();
 }
 
 HashSet<String> EditorFileSystem::get_valid_extensions() const {
@@ -2599,6 +2599,18 @@ void EditorFileSystem::register_global_class_script(const String &p_search_path,
 		EditorFileSystem::get_singleton()->_register_global_class_script(p_search_path, p_target_path, ScriptClassInfoUpdate::from_file_info(fi));
 	} else {
 		ScriptServer::remove_global_class_by_path(p_search_path);
+	}
+}
+
+void EditorFileSystem::filesystem_changed() {
+	if (Thread::is_main_thread()) {
+		_notify_filesystem_changed();
+		return;
+	}
+	// If not already queued, queue a deferred call to notify about filesystem changes.
+	if (!filesystem_changed_queued.is_set()) {
+		filesystem_changed_queued.set();
+		callable_mp(this, &EditorFileSystem::_notify_filesystem_changed).call_deferred();
 	}
 }
 
@@ -3720,7 +3732,7 @@ void EditorFileSystem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_file_type", "path"), &EditorFileSystem::get_file_type);
 	ClassDB::bind_method(D_METHOD("reimport_files", "files"), &EditorFileSystem::reimport_files);
 
-	ADD_SIGNAL(MethodInfo("filesystem_changed"));
+	ADD_SIGNAL(MethodInfo("filesystem_changed")); // May only be emitted on the main thread.
 	ADD_SIGNAL(MethodInfo("script_classes_updated"));
 	ADD_SIGNAL(MethodInfo("sources_changed", PropertyInfo(Variant::BOOL, "exist")));
 	ADD_SIGNAL(MethodInfo("resources_reimporting", PropertyInfo(Variant::PACKED_STRING_ARRAY, "resources")));

--- a/editor/file_system/editor_file_system.h
+++ b/editor/file_system/editor_file_system.h
@@ -182,7 +182,7 @@ class EditorFileSystem : public Node {
 	EditorFileSystemDirectory *new_filesystem = nullptr;
 	static ScannedDirectory *first_scan_root_dir;
 
-	bool filesystem_changed_queued = false;
+	SafeFlag filesystem_changed_queued;
 	bool scanning = false;
 	bool importing = false;
 	bool first_scan = true;
@@ -391,6 +391,8 @@ public:
 	void update_files(const Vector<String> &p_script_paths);
 	HashSet<String> get_valid_extensions() const;
 	void register_global_class_script(const String &p_search_path, const String &p_target_path);
+
+	void filesystem_changed();
 
 	EditorFileSystemDirectory *get_filesystem_path(const String &p_path);
 	String get_file_type(const String &p_file) const;


### PR DESCRIPTION
I was looking into implementing threaded import for scenes such as glTF files. There are several problems that need to be fixed in order to make this work, so it's not enabled in this PR. However, this PR is attempting to fix one part of this.

When the editor generates a scene preview for an imported scene, it runs `EditorFileSystem::get_singleton()->emit_signal(SNAME("filesystem_changed"));`. The receivers of this signal expect to be called on the main thread. There are many other emissions of this signal within the class, which all end up being ran from the main thread. The external emissions are also ran from the main thread currently, but this is no longer the case if threading the scene importer, in which case Godot would crash.

This PR replaces those external emissions with a new function `EditorFileSystem::filesystem_changed()` that is thread-safe. If it's the main thread, it emits immediately, just like the code in master already does. However, if this isn't the main thread, then it defers this to the next frame. This is a safer "external API" for EditorFileSystem, in quotes because this is still an editor-only API that isn't exposed and is only used by Godot's own editor code, but it's still the case that such code probably shouldn't be directly messing with the signals of EditorFileSystem.

The members `filesystem_changed_queued` and `_notify_filesystem_changed` already existed in master, and were only used once. There is another mechanism which defers this signal emission, but from a short investigation I think these can't be unified because they don't do exactly the same thing.