### PR TITLE
Combine dock focus methods to prevent inconsistencies

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -846,16 +846,7 @@ void EditorDockManager::open_dock(EditorDock *p_dock, bool p_set_current) {
 	if (p_dock->is_open) {
 		// Show the dock if it is already open.
 		if (p_set_current) {
-			if (p_dock->dock_window) {
-				p_dock->get_window()->grab_focus();
-				return;
-			}
-
-			TabContainer *dock_tab_container = get_dock_tab_container(p_dock);
-			if (dock_tab_container) {
-				int tab_index = dock_tab_container->get_tab_idx_from_control(p_dock);
-				dock_tab_container->set_current_tab(tab_index);
-			}
+			_make_dock_visible(p_dock, false);
 		}
 		return;
 	}
@@ -891,20 +882,11 @@ TabContainer *EditorDockManager::get_dock_tab_container(Control *p_dock) const {
 	return Object::cast_to<TabContainer>(p_dock->get_parent());
 }
 
-void EditorDockManager::focus_dock(EditorDock *p_dock) {
-	ERR_FAIL_NULL(p_dock);
-	ERR_FAIL_COND_MSG(!all_docks.has(p_dock), vformat("Cannot focus unknown dock '%s'.", p_dock->get_display_title()));
-
-	if (!p_dock->enabled) {
-		return;
-	}
-
-	if (!p_dock->is_open) {
-		open_dock(p_dock, false);
-	}
-
+void EditorDockManager::_make_dock_visible(EditorDock *p_dock, bool p_grab_focus) {
 	if (p_dock->dock_window) {
-		p_dock->get_window()->grab_focus();
+		if (p_grab_focus) {
+			p_dock->get_window()->grab_focus();
+		}
 		return;
 	}
 
@@ -917,12 +899,29 @@ void EditorDockManager::focus_dock(EditorDock *p_dock) {
 	}
 
 	TabContainer *tab_container = get_dock_tab_container(p_dock);
-	if (!tab_container) {
+	if (tab_container) {
+		if (p_grab_focus) {
+			tab_container->get_tab_bar()->grab_focus();
+		}
+
+		int tab_index = tab_container->get_tab_idx_from_control(p_dock);
+		tab_container->set_current_tab(tab_index);
+	}
+}
+
+void EditorDockManager::focus_dock(EditorDock *p_dock) {
+	ERR_FAIL_NULL(p_dock);
+	ERR_FAIL_COND_MSG(!all_docks.has(p_dock), vformat("Cannot focus unknown dock '%s'.", p_dock->get_display_title()));
+
+	if (!p_dock->enabled) {
 		return;
 	}
-	int tab_index = tab_container->get_tab_idx_from_control(p_dock);
-	tab_container->get_tab_bar()->grab_focus();
-	tab_container->set_current_tab(tab_index);
+
+	if (!p_dock->is_open) {
+		open_dock(p_dock, false);
+	}
+
+	_make_dock_visible(p_dock, true);
 }
 
 void EditorDockManager::add_dock(EditorDock *p_dock) {

--- a/editor/docks/editor_dock_manager.h
+++ b/editor/docks/editor_dock_manager.h
@@ -121,6 +121,7 @@ private:
 	void _open_dock_in_window(EditorDock *p_dock, bool p_show_window = true, bool p_reset_size = false);
 	void _restore_dock_to_saved_window(EditorDock *p_dock, const Dictionary &p_window_dump);
 
+	void _make_dock_visible(EditorDock *p_dock, bool p_grab_focus);
 	void _move_dock_tab_index(EditorDock *p_dock, int p_tab_index, bool p_set_current);
 	void _move_dock(EditorDock *p_dock, Control *p_target, int p_tab_index = -1, bool p_set_current = true);
 


### PR DESCRIPTION
Fixes #115060

Combines the two methods for making docks visible into one, to prevent future inconsistencies and incorrect behavior from surfacing due to modifying only one of the two.

The bug was caused by `EditorDockManager::open`  not considering the pin, while `EditorDockManager::focus` did, so by unifying the two into one method, this should prevent future cases of this bug happening.