### PR TITLE
Add RGSS supersampling option to `BaseMaterial3D`, `Sprite3D` and `Label3D`

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -346,6 +346,9 @@
 		<member name="refraction_texture_channel" type="int" setter="set_refraction_texture_channel" getter="get_refraction_texture_channel" enum="BaseMaterial3D.TextureChannel" default="0">
 			Specifies the channel of the [member refraction_texture] in which the refraction information is stored. This is useful when you store the information for multiple effects in a single texture. For example if you stored refraction in the red channel, roughness in the blue, and ambient occlusion in the green you could reduce the number of textures you use.
 		</member>
+		<member name="rgss_use_supersampling" type="bool" setter="set_flag" getter="get_flag" default="false">
+			If [code]true[/code], enables RGSS (Rotated Grid Super Sampling) for texture sampling. RGSS reduces aliasing by sampling the texture at four rotated grid positions and averaging the results. This is particularly useful for 2D elements rendered in 3D space like [Sprite3D] and [Label3D].
+		</member>
 		<member name="rim" type="float" setter="set_rim" getter="get_rim" default="1.0">
 			Sets the strength of the rim lighting effect.
 		</member>
@@ -775,7 +778,10 @@
 		<constant name="FLAG_USE_FOV_OVERRIDE" value="24" enum="Flags">
 			Enables using [member fov_override].
 		</constant>
-		<constant name="FLAG_MAX" value="25" enum="Flags">
+		<constant name="FLAG_USE_RGSS_SUPERSAMPLING" value="25" enum="Flags">
+			Enables RGSS (Rotated Grid Super Sampling) for texture sampling to reduce aliasing.
+		</constant>
+		<constant name="FLAG_MAX" value="26" enum="Flags">
 			Represents the size of the [enum Flags] enum.
 		</constant>
 		<constant name="DIFFUSE_BURLEY" value="0" enum="DiffuseMode">

--- a/doc/classes/Label3D.xml
+++ b/doc/classes/Label3D.xml
@@ -112,6 +112,9 @@
 			[b]Note:[/b] This only applies if [member alpha_cut] is set to [constant ALPHA_CUT_DISABLED] (default value).
 			[b]Note:[/b] This only applies to sorting of transparent objects. This will not impact how transparent objects are sorted relative to opaque objects. This is because opaque objects are not sorted, while transparent objects are sorted from back to front (subject to priority).
 		</member>
+		<member name="rgss_supersampling" type="bool" setter="set_use_rgss_supersampling" getter="get_use_rgss_supersampling" default="false">
+			If [code]true[/code], enables RGSS (Rotated Grid Super Sampling) for the label's texture. RGSS reduces aliasing by sampling the texture at four rotated grid positions and averaging the results. This improves visual quality but may have a performance impact.
+		</member>
 		<member name="shaded" type="bool" setter="set_draw_flag" getter="get_draw_flag" default="false">
 			If [code]true[/code], the [Light3D] in the [Environment] has effects on the label.
 		</member>

--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -95,6 +95,9 @@
 			[b]Note:[/b] This only applies if [member alpha_cut] is set to [constant ALPHA_CUT_DISABLED] (default value).
 			[b]Note:[/b] This only applies to sorting of transparent objects. This will not impact how transparent objects are sorted relative to opaque objects. This is because opaque objects are not sorted, while transparent objects are sorted from back to front (subject to priority).
 		</member>
+		<member name="rgss_supersampling" type="bool" setter="set_use_rgss_supersampling" getter="get_use_rgss_supersampling" default="false">
+			If [code]true[/code], enables RGSS (Rotated Grid Super Sampling) for the sprite's texture. RGSS reduces aliasing by sampling the texture at four rotated grid positions and averaging the results. This improves visual quality but may have a performance impact.
+		</member>
 		<member name="shaded" type="bool" setter="set_draw_flag" getter="get_draw_flag" default="false">
 			If [code]true[/code], the [Light3D] in the [Environment] has effects on the sprite.
 		</member>

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -128,6 +128,9 @@ void Label3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("generate_triangle_mesh"), &Label3D::generate_triangle_mesh);
 
+	ClassDB::bind_method(D_METHOD("set_use_rgss_supersampling", "flag"), &Label3D::set_use_rgss_supersampling);
+	ClassDB::bind_method(D_METHOD("get_use_rgss_supersampling"), &Label3D::get_use_rgss_supersampling);
+
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pixel_size", PROPERTY_HINT_RANGE, "0.0001,128,0.0001,suffix:m"), "set_pixel_size", "get_pixel_size");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset", PROPERTY_HINT_NONE, "suffix:px"), "set_offset", "get_offset");
 
@@ -145,6 +148,7 @@ void Label3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), "set_texture_filter", "get_texture_filter");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_priority", PROPERTY_HINT_RANGE, itos(RS::MATERIAL_RENDER_PRIORITY_MIN) + "," + itos(RS::MATERIAL_RENDER_PRIORITY_MAX) + ",1"), "set_render_priority", "get_render_priority");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "outline_render_priority", PROPERTY_HINT_RANGE, itos(RS::MATERIAL_RENDER_PRIORITY_MIN) + "," + itos(RS::MATERIAL_RENDER_PRIORITY_MAX) + ",1"), "set_outline_render_priority", "get_outline_render_priority");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rgss_supersampling"), "set_use_rgss_supersampling", "get_use_rgss_supersampling");
 
 	ADD_GROUP("Text", "");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "modulate"), "set_modulate", "get_modulate");
@@ -393,7 +397,7 @@ void Label3D::_generate_glyph_surfaces(const Glyph &p_glyph, Vector2 &r_offset, 
 			}
 
 			RID shader_rid;
-			StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), mat_transparency, get_draw_flag(FLAG_DOUBLE_SIDED), get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, msdf, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE), texture_filter, alpha_antialiasing_mode, false, &shader_rid);
+			StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), mat_transparency, get_draw_flag(FLAG_DOUBLE_SIDED), get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, msdf, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE), texture_filter, alpha_antialiasing_mode, false, rgss_use_supersampling, &shader_rid);
 
 			RS::get_singleton()->material_set_shader(surf.material, shader_rid);
 			RS::get_singleton()->material_set_param(surf.material, "texture_albedo", tex);
@@ -1075,6 +1079,17 @@ void Label3D::set_alpha_antialiasing_edge(float p_edge) {
 
 float Label3D::get_alpha_antialiasing_edge() const {
 	return alpha_antialiasing_edge;
+}
+
+void Label3D::set_use_rgss_supersampling(bool p_flag) {
+	if (rgss_use_supersampling != p_flag) {
+		rgss_use_supersampling = p_flag;
+		_queue_update();
+	}
+}
+
+bool Label3D::get_use_rgss_supersampling() const {
+	return rgss_use_supersampling;
 }
 
 Label3D::Label3D() {

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -147,6 +147,8 @@ private:
 
 	void _generate_glyph_surfaces(const Glyph &p_glyph, Vector2 &r_offset, const Color &p_modulate, int p_priority = 0, int p_outline_size = 0);
 
+	bool rgss_use_supersampling = false;
+
 protected:
 	GDVIRTUAL2RC(TypedArray<Vector3i>, _structured_text_parser, Array, String)
 
@@ -256,6 +258,9 @@ public:
 
 	virtual AABB get_aabb() const override;
 	virtual Ref<TriangleMesh> generate_triangle_mesh() const override;
+
+	void set_use_rgss_supersampling(bool p_flag);
+	bool get_use_rgss_supersampling() const;
 
 	Label3D();
 	~Label3D();

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -31,6 +31,7 @@
 #include "sprite_3d.h"
 
 #include "scene/resources/atlas_texture.h"
+#include "scene/resources/material.h"
 #include "scene/resources/mesh.h"
 
 Color SpriteBase3D::_get_color_accum() {
@@ -292,7 +293,7 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 	}
 
 	RID shader_rid;
-	StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), mat_transparency, get_draw_flag(FLAG_DOUBLE_SIDED), get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, false, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE), get_texture_filter(), alpha_antialiasing_mode, texture_repeat, &shader_rid);
+	StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), mat_transparency, get_draw_flag(FLAG_DOUBLE_SIDED), get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, false, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE), get_texture_filter(), alpha_antialiasing_mode, texture_repeat, use_rgss_supersampling, &shader_rid);
 
 	if (last_shader != shader_rid) {
 		RS::get_singleton()->material_set_shader(get_material(), shader_rid);
@@ -618,6 +619,20 @@ StandardMaterial3D::TextureFilter SpriteBase3D::get_texture_filter() const {
 	return texture_filter;
 }
 
+bool SpriteBase3D::get_use_rgss_supersampling() const {
+	return use_rgss_supersampling;
+}
+
+void SpriteBase3D::set_use_rgss_supersampling(bool p_flag) {
+	if (use_rgss_supersampling == p_flag) {
+		return;
+	}
+
+	use_rgss_supersampling = p_flag;
+
+	_queue_redraw();
+}
+
 void SpriteBase3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_centered", "centered"), &SpriteBase3D::set_centered);
 	ClassDB::bind_method(D_METHOD("is_centered"), &SpriteBase3D::is_centered);
@@ -670,6 +685,9 @@ void SpriteBase3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_rect"), &SpriteBase3D::get_item_rect);
 	ClassDB::bind_method(D_METHOD("generate_triangle_mesh"), &SpriteBase3D::generate_triangle_mesh);
 
+	ClassDB::bind_method(D_METHOD("set_use_rgss_supersampling", "flag"), &SpriteBase3D::set_use_rgss_supersampling);
+	ClassDB::bind_method(D_METHOD("get_use_rgss_supersampling"), &SpriteBase3D::get_use_rgss_supersampling);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "centered"), "set_centered", "is_centered");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset", PROPERTY_HINT_NONE, "suffix:px"), "set_offset", "get_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_h"), "set_flip_h", "is_flipped_h");
@@ -691,6 +709,8 @@ void SpriteBase3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "alpha_antialiasing_edge", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_alpha_antialiasing_edge", "get_alpha_antialiasing_edge");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), "set_texture_filter", "get_texture_filter");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_priority", PROPERTY_HINT_RANGE, itos(RS::MATERIAL_RENDER_PRIORITY_MIN) + "," + itos(RS::MATERIAL_RENDER_PRIORITY_MAX) + ",1"), "set_render_priority", "get_render_priority");
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rgss_supersampling"), "set_use_rgss_supersampling", "get_use_rgss_supersampling");
 
 	BIND_ENUM_CONSTANT(FLAG_TRANSPARENT);
 	BIND_ENUM_CONSTANT(FLAG_SHADED);

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -94,6 +94,7 @@ private:
 	StandardMaterial3D::TextureFilter texture_filter = StandardMaterial3D::TEXTURE_FILTER_LINEAR_WITH_MIPMAPS;
 	bool redraw_needed = false;
 	bool pending_update = false;
+	bool use_rgss_supersampling = false;
 	void _im_update();
 
 	void _propagate_color_changed();
@@ -167,6 +168,9 @@ public:
 
 	void set_texture_filter(StandardMaterial3D::TextureFilter p_filter);
 	StandardMaterial3D::TextureFilter get_texture_filter() const;
+
+	bool get_use_rgss_supersampling() const;
+	void set_use_rgss_supersampling(bool p_flag);
 
 	virtual Rect2 get_item_rect() const = 0;
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
+#include "core/object/object.h"
 #include "core/version.h"
 #include "scene/main/scene_tree.h"
 
@@ -1495,6 +1496,36 @@ vec4 triplanar_texture(sampler2D p_sampler, vec3 p_weights, vec3 p_triplanar_pos
 )";
 	}
 
+	if (flags[FLAG_USE_RGSS_SUPERSAMPLING]) {
+		code += R"(
+vec4 texture_rgss(sampler2D p_sampler, vec2 p_uv) {
+	// Get per-pixel partial derivatives.
+	vec2 dx = dFdx(p_uv);
+	vec2 dy = dFdy(p_uv);
+
+	// Rotated grid UV offsets.
+	const vec2 UV_OFFSETS = vec2(0.125, 0.375);
+	vec2 offset_uv = vec2(0.0);
+
+	// Supersample using 2×2 rotated grid.
+	vec4 samp = vec4(0.0);
+
+	float lod = 0.5 * log2(max(dot(dx, dx), dot(dy, dy)));
+	lod += -1.0;
+
+	offset_uv.xy = p_uv + UV_OFFSETS.x * dx + UV_OFFSETS.y * dy;
+	samp += textureLod(p_sampler, offset_uv, lod);
+	offset_uv.xy = p_uv - UV_OFFSETS.x * dx - UV_OFFSETS.y * dy;
+	samp += textureLod(p_sampler, offset_uv, lod);
+	offset_uv.xy = p_uv + UV_OFFSETS.y * dx - UV_OFFSETS.x * dy;
+	samp += textureLod(p_sampler, offset_uv, lod);
+	offset_uv.xy = p_uv - UV_OFFSETS.y * dx + UV_OFFSETS.x * dy;
+	samp += textureLod(p_sampler, offset_uv, lod);
+
+	return samp * 0.25;
+})";
+	}
+
 	// Generate fragment shader.
 	code += R"(
 void fragment() {)";
@@ -1605,6 +1636,10 @@ void fragment() {)";
 		code += R"(
 	// Use Point Size: Enabled
 	vec4 albedo_tex = texture(texture_albedo, POINT_COORD);
+)";
+	} else if (flags[FLAG_USE_RGSS_SUPERSAMPLING]) {
+		code += R"(
+	vec4 albedo_tex = texture_rgss(texture_albedo, base_uv);
 )";
 	} else {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
@@ -2495,7 +2530,8 @@ void BaseMaterial3D::set_flag(Flags p_flag, bool p_enabled) {
 			p_flag == FLAG_UV2_USE_TRIPLANAR ||
 			p_flag == FLAG_USE_Z_CLIP_SCALE ||
 			p_flag == FLAG_USE_FOV_OVERRIDE ||
-			p_flag == FLAG_DISABLE_DEPTH_TEST) {
+			p_flag == FLAG_DISABLE_DEPTH_TEST ||
+			p_flag == FLAG_USE_RGSS_SUPERSAMPLING) {
 		notify_property_list_changed();
 	}
 
@@ -3010,7 +3046,7 @@ float BaseMaterial3D::get_fov_override() const {
 	return fov_override;
 }
 
-Ref<Material> BaseMaterial3D::get_material_for_2d(bool p_shaded, Transparency p_transparency, bool p_double_sided, bool p_billboard, bool p_billboard_y, bool p_msdf, bool p_no_depth, bool p_fixed_size, TextureFilter p_filter, AlphaAntiAliasing p_alpha_antialiasing_mode, bool p_texture_repeat, RID *r_shader_rid) {
+Ref<Material> BaseMaterial3D::get_material_for_2d(bool p_shaded, Transparency p_transparency, bool p_double_sided, bool p_billboard, bool p_billboard_y, bool p_msdf, bool p_no_depth, bool p_fixed_size, TextureFilter p_filter, AlphaAntiAliasing p_alpha_antialiasing_mode, bool p_texture_repeat, bool p_use_rgss, RID *r_shader_rid) {
 	uint64_t key = 0;
 	key |= ((int8_t)p_shaded & 0x01) << 0;
 	key |= ((int8_t)p_transparency & 0x07) << 1; // Bits 1-3.
@@ -3023,6 +3059,7 @@ Ref<Material> BaseMaterial3D::get_material_for_2d(bool p_shaded, Transparency p_
 	key |= ((int8_t)p_filter & 0x07) << 10; // Bits 10-12.
 	key |= ((int8_t)p_alpha_antialiasing_mode & 0x07) << 13; // Bits 13-15.
 	key |= ((int8_t)p_texture_repeat & 0x01) << 16;
+	key |= ((int8_t)p_use_rgss & 0x01) << 17;
 
 	if (materials_for_2d.has(key)) {
 		if (r_shader_rid) {
@@ -3043,6 +3080,7 @@ Ref<Material> BaseMaterial3D::get_material_for_2d(bool p_shaded, Transparency p_
 	material->set_flag(FLAG_DISABLE_DEPTH_TEST, p_no_depth);
 	material->set_flag(FLAG_FIXED_SIZE, p_fixed_size);
 	material->set_flag(FLAG_USE_TEXTURE_REPEAT, p_texture_repeat);
+	material->set_flag(FLAG_USE_RGSS_SUPERSAMPLING, p_use_rgss);
 	material->set_alpha_antialiasing(p_alpha_antialiasing_mode);
 	material->set_texture_filter(p_filter);
 	if (p_billboard || p_billboard_y) {
@@ -3772,6 +3810,9 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "stencil_color", PROPERTY_HINT_NONE), "set_stencil_effect_color", "get_stencil_effect_color");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "stencil_outline_thickness", PROPERTY_HINT_RANGE, "0,1,0.001,or_greater,suffix:m"), "set_stencil_effect_outline_thickness", "get_stencil_effect_outline_thickness");
 
+	ADD_GROUP("Supersampling", "rgss_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "rgss_use_supersampling"), "set_flag", "get_flag", FLAG_USE_RGSS_SUPERSAMPLING);
+
 	BIND_ENUM_CONSTANT(TEXTURE_ALBEDO);
 	BIND_ENUM_CONSTANT(TEXTURE_METALLIC);
 	BIND_ENUM_CONSTANT(TEXTURE_ROUGHNESS);
@@ -3877,6 +3918,7 @@ void BaseMaterial3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(FLAG_DISABLE_SPECULAR_OCCLUSION);
 	BIND_ENUM_CONSTANT(FLAG_USE_Z_CLIP_SCALE);
 	BIND_ENUM_CONSTANT(FLAG_USE_FOV_OVERRIDE);
+	BIND_ENUM_CONSTANT(FLAG_USE_RGSS_SUPERSAMPLING);
 	BIND_ENUM_CONSTANT(FLAG_MAX);
 
 	BIND_ENUM_CONSTANT(DIFFUSE_BURLEY);

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -279,6 +279,7 @@ public:
 		FLAG_DISABLE_SPECULAR_OCCLUSION,
 		FLAG_USE_Z_CLIP_SCALE,
 		FLAG_USE_FOV_OVERRIDE,
+		FLAG_USE_RGSS_SUPERSAMPLING,
 		FLAG_MAX
 	};
 
@@ -877,7 +878,7 @@ public:
 	static void finish_shaders();
 	static void flush_changes();
 
-	static Ref<Material> get_material_for_2d(bool p_shaded, Transparency p_transparency, bool p_double_sided, bool p_billboard = false, bool p_billboard_y = false, bool p_msdf = false, bool p_no_depth = false, bool p_fixed_size = false, TextureFilter p_filter = TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, AlphaAntiAliasing p_alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF, bool p_texture_repeat = false, RID *r_shader_rid = nullptr);
+	static Ref<Material> get_material_for_2d(bool p_shaded, Transparency p_transparency, bool p_double_sided, bool p_billboard = false, bool p_billboard_y = false, bool p_msdf = false, bool p_no_depth = false, bool p_fixed_size = false, TextureFilter p_filter = TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, AlphaAntiAliasing p_alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF, bool p_texture_repeat = false, bool p_use_rgss = false, RID *r_shader_rid = nullptr);
 
 	virtual RID get_rid() const override;
 	virtual RID get_shader_rid() const override;


### PR DESCRIPTION
# Add texture supersampling in `BaseMaterial3D`, `Label3D` and `Sprite3D`

## Description
Implements proposal: Adds an option to use RGSS (Rotated Grid Super Sampling) texture supersampling in BaseMaterial3D, Sprite3D, and Label3D nodes.

**Closes godotengine/godot-proposals#10096**

## Problem
When Label3Ds or Sprite3Ds are viewed at a distance, they become either pixelated (without mipmaps) or blurry (with mipmaps). This is particularly problematic for:
- GUIs in XR applications
- Text readability in 3D space

## Solution
Adds a new material flag `FLAG_USE_RGSS_SUPERSAMPLING` that implements Rotated Grid Super Sampling with a mipmap bias of -1.0. The technique samples the texture at four rotated grid positions and averages the results, providing better sharpness than default sampling while reducing aliasing.

## Key Features
- New flag `FLAG_USE_RGSS_SUPERSAMPLING` in BaseMaterial3D
- Property `rgss_supersampling` in Sprite3D and Label3D (disabled by default)
- Property `rgss_use_supersampling` in BaseMaterial3D materials
- Integrated through `get_material_for_2d()` for 2D-in-3D rendering
- Appropriate documentation added to class XML files
- Added a function taken from [this prototype](https://github.com/godotengine/godot/commit/422c301454e8b74ad46e77df941ac3f6431f2432) to the shader generation

## Testing
- Manual testing with Label3D at various distances
- Manual testing with Sprite3D textures
- Comparison with/without RGSS enabled

## Performance Notes
RGSS has a moderate performance cost (4 texture samples instead of 1), so it's disabled by default and should be enabled selectively where needed.

## Screenshots
<img width="1155" height="650" alt="изображение" src="https://github.com/user-attachments/assets/98858fda-f379-4ff8-bd47-ad058153091f" />
The image on the left is without RGSS enabled, and the image on the right is with it enabled. The distance is 50 meters from the camera.

## Questions for Discussion


~~Scope of implementation~~
~~This PR currently implements RGSS only for the albedo texture. Should we:~~
~~a) Extend RGSS to all PBR textures in this PR?~~
~~b) Keep it albedo-only for now and extend in future PRs?~~
~~c) Make it configurable per texture channel?~~

~~Cross-platform compatibility issue~~
~~The implementation uses `texture(sampler, uv, -1.0)` with explicit mipmap bias, which is:~~
~~**Required** for RGSS to work correctly (tested: RGSS without bias produces no noticeable improvement)~~
~~**Unavailable** on WebGL/GLES2 platforms (`texture()` function doesn't support bias parameter)~~

~~**Options to consider:**~~
~~a) Document this as a platform limitation (RGSS disabled/ineffective on WebGL)~~
~~b) Implement fallback sampling without bias (but with reduced effectiveness)~~
~~c) Use different bias mechanism if available (textureLod with computed LOD)~~
~~d) Make RGSS a desktop-only feature~~

### 3. Performance considerations
RGSS performs 4 texture samples instead of 1. Should we:
a) Add performance warnings in documentation?
b) Consider making sample count configurable (2x2, 4x4)?
c) Add benchmarking results to this PR?
