### PR TITLE
Wayland: Fix IME

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -3035,10 +3035,6 @@ void WaylandThread::_wp_text_input_on_enter(void *data, struct zwp_text_input_v3
 		return;
 	}
 
-	if (ss->ime_window_id == DisplayServer::INVALID_WINDOW_ID) {
-		return;
-	}
-
 	WindowState *ws = wl_surface_get_window_state(surface);
 	if (!ws) {
 		return;


### PR DESCRIPTION
Fixes #115088.

The spec tells us to ignore certain events if we didn't get an `enter` event first. Certainly we need to at least acknowledge the `enter` event itself :sweat_smile:
