### PR TITLE
Fix `ColorPicker` not respecting theme overrides

### DIFF
--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -230,5 +230,17 @@
 		<theme_item name="sample_focus" data_type="style" type="StyleBox">
 			The [StyleBox] used for the old color sample part when it is focused. Displayed [i]over[/i] the sample, so a partially transparent [StyleBox] should be used to ensure the picker shape remains visible. A [StyleBox] that represents an outline or an underline works well for this purpose. To disable the focus visual effect, assign a [StyleBoxEmpty] resource. Note that disabling the focus visual effect will harm keyboard/controller navigation usability, so this is not recommended for accessibility reasons.
 		</theme_item>
+		<theme_item name="tab_hover_selected" data_type="style" type="StyleBox">
+			The [StyleBox] used when the tab is being pressed and hovered at the same time.
+		</theme_item>
+		<theme_item name="tab_hovered" data_type="style" type="StyleBox">
+			The [StyleBox] used when the tab is being hovered.
+		</theme_item>
+		<theme_item name="tab_selected" data_type="style" type="StyleBox">
+			The style of the currently selected tab.
+		</theme_item>
+		<theme_item name="tab_unselected" data_type="style" type="StyleBox">
+			The style of the other, unselected tabs.
+		</theme_item>
 	</theme_items>
 </class>

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2057,10 +2057,10 @@ void ColorPicker::_bind_methods() {
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPicker, color_script);
 
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_normal, "tab_unselected", "TabContainer");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_pressed, "tab_selected", "TabContainer");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_hover, "tab_selected", "TabContainer");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_hover_pressed, "tab_selected", "TabContainer");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_pressed, "tab_selected");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_normal, "tab_unselected");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_hover, "tab_hovered");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_hover_pressed, "tab_hover_selected");
 
 	ADD_CLASS_DEPENDENCY("LineEdit");
 	ADD_CLASS_DEPENDENCY("MenuButton");

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -1083,6 +1083,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("sample_focus", "ColorPicker", focus);
 	theme->set_stylebox("picker_focus_rectangle", "ColorPicker", focus);
 	theme->set_stylebox("picker_focus_circle", "ColorPicker", focus_circle);
+	theme->set_stylebox("tab_selected", "ColorPicker", style_tab_selected);
+	theme->set_stylebox("tab_unselected", "ColorPicker", style_tab_unselected);
+	theme->set_stylebox("tab_hovered", "ColorPicker", style_tab_hovered);
+	theme->set_stylebox("tab_hover_selected", "ColorPicker", style_tab_selected);
 	theme->set_color("focused_not_editing_cursor_color", "ColorPicker", Color(1, 1, 1, 0.275f));
 
 	theme->set_icon("menu_option", "ColorPicker", icons["tabs_menu_hl"]);


### PR DESCRIPTION
- Resolves https://github.com/godotengine/godot/issues/115059 via adding relevant `StyleBox` slots.