### PR TITLE
Take lifetime randomness into account when calculating lifetime value

### DIFF
--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -950,10 +950,10 @@ void ParticleProcessMaterial::_update_shader() {
 		code += "	bool just_spawned = CUSTOM.y == 0.0;\n";
 	}
 
-	code += "	CUSTOM.y += DELTA / LIFETIME;\n";
+	code += "	CUSTOM.y += DELTA / (LIFETIME * params.lifetime);\n";
 	code += "	CUSTOM.y = mix(CUSTOM.y, 1.0, INTERPOLATE_TO_END);\n";
-	code += "	float lifetime_percent = CUSTOM.y / params.lifetime;\n";
-	code += "	if (CUSTOM.y > CUSTOM.w) {\n";
+	code += "	float lifetime_percent = CUSTOM.y;\n";
+	code += "	if (CUSTOM.y > 1.0) {\n";
 	code += "		ACTIVE = false;\n";
 	code += "	}\n\n";
 
@@ -1081,9 +1081,9 @@ void ParticleProcessMaterial::_update_shader() {
 		code += "	base_angle *= texture(angle_texture, vec2(lifetime_percent)).r;\n";
 	}
 	if (tex_parameters[PARAM_ANGULAR_VELOCITY].is_valid()) {
-		code += "	base_angle += CUSTOM.y * LIFETIME * dynamic_params.angular_velocity * texture(angular_velocity_texture, vec2(lifetime_percent)).r;\n";
+		code += "	base_angle += CUSTOM.y * LIFETIME * params.lifetime * dynamic_params.angular_velocity * texture(angular_velocity_texture, vec2(lifetime_percent)).r;\n";
 	} else {
-		code += "	base_angle += CUSTOM.y * LIFETIME * dynamic_params.angular_velocity;\n";
+		code += "	base_angle += CUSTOM.y * LIFETIME * params.lifetime * dynamic_params.angular_velocity;\n";
 	}
 	code += "	CUSTOM.x = base_angle * degree_to_rad;\n";
 	code += "	COLOR = params.color;\n\n";
@@ -1158,7 +1158,7 @@ void ParticleProcessMaterial::_update_shader() {
 		code += "	int emit_count = 0;\n";
 		switch (sub_emitter_mode) {
 			case SUB_EMITTER_CONSTANT: {
-				code += "	float interval_from = CUSTOM.y * LIFETIME - DELTA;\n";
+				code += "	float interval_from = CUSTOM.y * LIFETIME * params.lifetime - DELTA;\n";
 				code += "	float interval_rem = sub_emitter_frequency - mod(interval_from, sub_emitter_frequency);\n";
 				code += "	if (DELTA >= interval_rem) {\n";
 				code += "		emit_count = 1;\n";
@@ -1170,7 +1170,7 @@ void ParticleProcessMaterial::_update_shader() {
 				code += "	}\n";
 			} break;
 			case SUB_EMITTER_AT_END: {
-				code += "	if ((CUSTOM.y / CUSTOM.w * LIFETIME) > (LIFETIME - DELTA)) {\n";
+				code += "	if ((CUSTOM.y * LIFETIME) > (LIFETIME - DELTA)) {\n";
 				code += "		emit_count = sub_emitter_amount_at_end;\n";
 				code += "	}\n";
 			} break;
@@ -1191,7 +1191,7 @@ void ParticleProcessMaterial::_update_shader() {
 		code += "	}\n\n";
 	}
 
-	code += "	if (CUSTOM.y > CUSTOM.w) {\n";
+	code += "	if (CUSTOM.y > 1.0) {\n";
 	code += "		ACTIVE = false;\n";
 	code += "	}\n";
 	code += "}\n";


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/113321

Previous behavior: `CUSTOM.y` tracked the age relative to the system `LIFETIME`, but didn't account for the individual particle's reduced `params.lifetime` due to randomness. This meant `lifetime_percent` was incorrect for particles with randomized lifetimes.

New behavior: `CUSTOM.y` now tracks the normalized age of the particle (0.0 to 1.0), accounting for its specific randomized lifetime.

The dependent calculations were also updated to use the new normalized `CUSTOM.y` correctly.

Make sure you delete your cache before testing as the shader will need a recompile.

https://github.com/user-attachments/assets/e312c3e6-4a8f-44f9-a160-42989ed7b313


