### PR TITLE
Load editor layout file only once

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -164,10 +164,7 @@ void EditorLog::_start_state_save_timer() {
 }
 
 void EditorLog::_save_state() {
-	Ref<ConfigFile> config;
-	config.instantiate();
-	// Load and amend existing config if it exists.
-	config->load(EditorPaths::get_singleton()->get_project_settings_dir().path_join("editor_layout.cfg"));
+	Ref<ConfigFile> config = EditorNode::get_singleton()->get_editor_layout_file();
 
 	const String section = "editor_log";
 	for (const KeyValue<MessageType, LogFilter *> &E : type_filter_map) {
@@ -177,15 +174,13 @@ void EditorLog::_save_state() {
 	config->set_value(section, "collapse", collapse);
 	config->set_value(section, "show_search", search_box->is_visible());
 
-	config->save(EditorPaths::get_singleton()->get_project_settings_dir().path_join("editor_layout.cfg"));
+	EditorNode::get_singleton()->save_editor_layout_file();
 }
 
 void EditorLog::_load_state() {
 	is_loading_state = true;
 
-	Ref<ConfigFile> config;
-	config.instantiate();
-	config->load(EditorPaths::get_singleton()->get_project_settings_dir().path_join("editor_layout.cfg"));
+	const Ref<ConfigFile> config = EditorNode::get_singleton()->get_editor_layout_file();
 
 	// Run the below code even if config->load returns an error, since we want the defaults to be set even if the file does not exist yet.
 	const String section = "editor_log";

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5497,6 +5497,16 @@ bool EditorNode::is_scene_in_use(const String &p_path) {
 	return false;
 }
 
+Ref<ConfigFile> EditorNode::get_editor_layout_file() {
+	_ensure_editor_layout();
+	return main_editor_layout;
+}
+
+void EditorNode::save_editor_layout_file() {
+	ERR_FAIL_COND_MSG(main_editor_layout.is_null(), "Editor layout isn't loaded.");
+	main_editor_layout->save(EditorPaths::get_singleton()->get_project_settings_dir().path_join("editor_layout.cfg"));
+}
+
 OS::ProcessID EditorNode::has_child_process(OS::ProcessID p_pid) const {
 	return project_run_bar->has_child_process(p_pid);
 }
@@ -6112,22 +6122,28 @@ void EditorNode::_copy_warning(const String &p_str) {
 	DisplayServer::get_singleton()->clipboard_set(warning->get_text());
 }
 
+void EditorNode::_ensure_editor_layout() {
+	if (main_editor_layout.is_valid()) {
+		return;
+	}
+	main_editor_layout.instantiate();
+	Error err = main_editor_layout->load(EditorPaths::get_singleton()->get_project_settings_dir().path_join("editor_layout.cfg"));
+	new_layout_created = (err != OK);
+}
+
 void EditorNode::_save_editor_layout() {
 	if (!load_editor_layout_done) {
 		return;
 	}
-	Ref<ConfigFile> config;
-	config.instantiate();
-	// Load and amend existing config if it exists.
-	config->load(EditorPaths::get_singleton()->get_project_settings_dir().path_join("editor_layout.cfg"));
+	_ensure_editor_layout();
 
-	editor_dock_manager->save_docks_to_config(config, "docks");
-	_save_open_scenes_to_config(config);
-	_save_central_editor_layout_to_config(config);
-	_save_window_settings_to_config(config, "EditorWindow");
-	editor_data.get_plugin_window_layout(config);
+	editor_dock_manager->save_docks_to_config(main_editor_layout, "docks");
+	_save_open_scenes_to_config(main_editor_layout);
+	_save_central_editor_layout_to_config(main_editor_layout);
+	_save_window_settings_to_config(main_editor_layout, "EditorWindow");
+	editor_data.get_plugin_window_layout(main_editor_layout);
 
-	config->save(EditorPaths::get_singleton()->get_project_settings_dir().path_join("editor_layout.cfg"));
+	save_editor_layout_file();
 }
 
 void EditorNode::_save_open_scenes_to_config(Ref<ConfigFile> p_layout) {
@@ -6152,10 +6168,8 @@ void EditorNode::save_editor_layout_delayed() {
 void EditorNode::_load_editor_layout() {
 	EditorProgress ep("loading_editor_layout", TTR("Loading editor"), 5);
 	ep.step(TTR("Loading editor layout..."), 0, true);
-	Ref<ConfigFile> config;
-	config.instantiate();
-	Error err = config->load(EditorPaths::get_singleton()->get_project_settings_dir().path_join("editor_layout.cfg"));
-	if (err != OK) { // No config.
+	_ensure_editor_layout();
+	if (new_layout_created) {
 		// If config is not found, expand the res:// folder and favorites by default.
 		TreeItem *root = FileSystemDock::get_singleton()->get_tree_control()->get_item_with_metadata("res://", 0);
 		if (root) {
@@ -6174,18 +6188,19 @@ void EditorNode::_load_editor_layout() {
 			// Initialize some default values.
 			bottom_panel->load_layout_from_config(default_layout, EDITOR_NODE_CONFIG_SECTION);
 		}
+		new_layout_created = false;
 	} else {
 		ep.step(TTR("Loading docks..."), 1, true);
-		editor_dock_manager->load_docks_from_config(config, "docks", true);
+		editor_dock_manager->load_docks_from_config(main_editor_layout, "docks", true);
 
 		ep.step(TTR("Reopening scenes..."), 2, true);
-		_load_open_scenes_from_config(config);
+		_load_open_scenes_from_config(main_editor_layout);
 
 		ep.step(TTR("Loading central editor layout..."), 3, true);
-		_load_central_editor_layout_from_config(config);
+		_load_central_editor_layout_from_config(main_editor_layout);
 
 		ep.step(TTR("Loading plugin window layout..."), 4, true);
-		editor_data.set_plugin_window_layout(config);
+		editor_data.set_plugin_window_layout(main_editor_layout);
 
 		ep.step(TTR("Editor layout ready."), 5, true);
 	}
@@ -6298,16 +6313,11 @@ bool EditorNode::has_scenes_in_session() {
 	if (!bool(EDITOR_GET("interface/scene_tabs/restore_scenes_on_load"))) {
 		return false;
 	}
-	Ref<ConfigFile> config;
-	config.instantiate();
-	Error err = config->load(EditorPaths::get_singleton()->get_project_settings_dir().path_join("editor_layout.cfg"));
-	if (err != OK) {
+	_ensure_editor_layout();
+	if (!main_editor_layout->has_section(EDITOR_NODE_CONFIG_SECTION) || !main_editor_layout->has_section_key(EDITOR_NODE_CONFIG_SECTION, "open_scenes")) {
 		return false;
 	}
-	if (!config->has_section(EDITOR_NODE_CONFIG_SECTION) || !config->has_section_key(EDITOR_NODE_CONFIG_SECTION, "open_scenes")) {
-		return false;
-	}
-	Array scenes = config->get_value(EDITOR_NODE_CONFIG_SECTION, "open_scenes");
+	Array scenes = main_editor_layout->get_value(EDITOR_NODE_CONFIG_SECTION, "open_scenes");
 	return !scenes.is_empty();
 }
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -390,6 +390,9 @@ private:
 	PopupMenu *editor_layouts = nullptr;
 	EditorLayoutsDialog *layout_dialog = nullptr;
 
+	Ref<ConfigFile> main_editor_layout;
+	bool new_layout_created = false;
+
 	ConfirmationDialog *gradle_build_manage_templates = nullptr;
 	ConfirmationDialog *install_android_build_template = nullptr;
 	ConfirmationDialog *remove_android_build_template = nullptr;
@@ -659,6 +662,7 @@ private:
 	Dictionary _get_main_scene_state();
 	void _set_main_scene_state(Dictionary p_state, Node *p_for_scene);
 
+	void _ensure_editor_layout();
 	void _save_editor_layout();
 	void _load_editor_layout();
 
@@ -989,6 +993,8 @@ public:
 
 	bool is_scene_in_use(const String &p_path);
 
+	Ref<ConfigFile> get_editor_layout_file();
+	void save_editor_layout_file();
 	void save_editor_layout_delayed();
 	void save_default_environment();
 


### PR DESCRIPTION
Similar to #79785
Makes `editor_layout.cfg` loaded only once, instead of every time it's going to be saved.