### PR TITLE
RD: Use `LocalVector` for directional lights in `SDFGI` update data and pre-allocate light vectors in scene culling

### DIFF
--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -1890,12 +1890,12 @@ void GI::SDFGI::pre_process_gi(const Transform3D &p_transform, RenderDataRD *p_r
 
 		SDFGIShader::Light lights[SDFGI::MAX_DYNAMIC_LIGHTS];
 		uint32_t idx = 0;
-		for (uint32_t j = 0; j < (uint32_t)p_render_data->sdfgi_update_data->directional_lights->size(); j++) {
+		for (uint32_t j = 0; j < p_render_data->sdfgi_update_data->directional_light_count; j++) {
 			if (idx == SDFGI::MAX_DYNAMIC_LIGHTS) {
 				break;
 			}
 
-			RID light_instance = p_render_data->sdfgi_update_data->directional_lights->get(j);
+			RID light_instance = p_render_data->sdfgi_update_data->directional_light_instances[j];
 			ERR_CONTINUE(!light_storage->owns_light_instance(light_instance));
 
 			RID light = light_storage->light_instance_get_base_light(light_instance);

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3156,19 +3156,19 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 	Vector<Plane> planes = p_camera_data->main_projection.get_projection_planes(p_camera_data->main_transform);
 	cull.frustum = Frustum(planes);
 
-	Vector<RID> directional_lights;
+	directional_light_instances.clear();
+	lights_with_shadow.clear();
+
 	// directional lights
 	{
 		cull.shadow_count = 0;
-
-		Vector<Instance *> lights_with_shadow;
 
 		for (Instance *E : scenario->directional_lights) {
 			if (!E->visible || !(E->layer_mask & p_visible_layers)) {
 				continue;
 			}
 
-			if (directional_lights.size() >= RendererSceneRender::MAX_DIRECTIONAL_LIGHTS) {
+			if (directional_light_instances.size() >= RendererSceneRender::MAX_DIRECTIONAL_LIGHTS) {
 				break;
 			}
 
@@ -3181,13 +3181,13 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 					lights_with_shadow.push_back(E);
 				}
 				//add to list
-				directional_lights.push_back(light->instance);
+				directional_light_instances.push_back(light->instance);
 			}
 		}
 
 		RSG::light_storage->set_directional_shadow_count(lights_with_shadow.size());
 
-		for (int i = 0; i < lights_with_shadow.size(); i++) {
+		for (uint32_t i = 0; i < lights_with_shadow.size(); i++) {
 			_light_instance_setup_directional_shadow(i, lights_with_shadow[i], p_camera_data->main_transform, p_camera_data->main_projection, p_camera_data->is_orthogonal, p_camera_data->vaspect);
 		}
 	}
@@ -3456,15 +3456,16 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 		}
 
 		if (p_reflection_probe.is_null()) {
-			sdfgi_update_data.directional_lights = &directional_lights;
+			sdfgi_update_data.directional_light_instances = directional_light_instances.ptr();
+			sdfgi_update_data.directional_light_count = directional_light_instances.size();
 			sdfgi_update_data.positional_light_instances = scenario->dynamic_lights.ptr();
 			sdfgi_update_data.positional_light_count = scenario->dynamic_lights.size();
 		}
 	}
 
-	//append the directional lights to the lights culled
-	for (int i = 0; i < directional_lights.size(); i++) {
-		scene_cull_result.light_instances.push_back(directional_lights[i]);
+	// Append the directional lights to the lights culled.
+	for (uint32_t i = 0; i < directional_light_instances.size(); i++) {
+		scene_cull_result.light_instances.push_back(directional_light_instances[i]);
 	}
 
 	RID camera_attributes;

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1002,6 +1002,9 @@ public:
 	InstanceCullResult scene_cull_result;
 	LocalVector<InstanceCullResult> scene_cull_result_threads;
 
+	LocalVector<RID> directional_light_instances;
+	LocalVector<Instance *> lights_with_shadow;
+
 	RendererSceneRender::RenderShadowData render_shadow_data[MAX_UPDATE_SHADOWS];
 	uint32_t max_shadows_used = 0;
 

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -293,7 +293,8 @@ public:
 		uint32_t *static_cascade_indices = nullptr;
 		PagedArray<RID> *static_positional_lights;
 
-		const Vector<RID> *directional_lights;
+		const RID *directional_light_instances;
+		uint32_t directional_light_count;
 		const RID *positional_light_instances;
 		uint32_t positional_light_count;
 	};


### PR DESCRIPTION
Improved version of #114329.

This PR uses `LocalVector` for `directional_light_instances`, both in `renderer_scene_cull.h` and `RenderSDFGIUpdateData` (renamed from `directional_lights`),  and `lights_with_shadow` in `renderer_scene_cull`.