### PR TITLE
Fix glTF physics shape creation hang when importing from thread

### DIFF
--- a/modules/gltf/extensions/physics/gltf_physics_shape.cpp
+++ b/modules/gltf/extensions/physics/gltf_physics_shape.cpp
@@ -33,6 +33,7 @@
 #include "../../gltf_state.h"
 
 #include "core/math/convex_hull.h"
+#include "core/os/thread.h"
 #include "scene/3d/physics/area_3d.h"
 #include "scene/resources/3d/box_shape_3d.h"
 #include "scene/resources/3d/capsule_shape_3d.h"
@@ -253,10 +254,12 @@ Ref<Shape3D> GLTFPhysicsShape::to_resource(bool p_cache_shapes) {
 			sphere->set_radius(radius);
 			_shape_cache = sphere;
 		} else if (shape_type == "convex") {
+			ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), _shape_cache, "GLTFPhysicsShape: Convex hull shapes must be created on the main thread. Creating collision shapes from a thread may cause a deadlock.");
 			ERR_FAIL_COND_V_MSG(importer_mesh.is_null(), _shape_cache, "GLTFPhysicsShape: Error converting convex hull shape to a shape resource: The mesh resource is null.");
 			Ref<ConvexPolygonShape3D> convex = importer_mesh->get_mesh()->create_convex_shape();
 			_shape_cache = convex;
 		} else if (shape_type == "trimesh") {
+			ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), _shape_cache, "GLTFPhysicsShape: Concave mesh shapes must be created on the main thread. Creating collision shapes from a thread may cause a deadlock.");
 			ERR_FAIL_COND_V_MSG(importer_mesh.is_null(), _shape_cache, "GLTFPhysicsShape: Error converting concave mesh shape to a shape resource: The mesh resource is null.");
 			Ref<ConcavePolygonShape3D> concave = importer_mesh->create_trimesh_shape();
 			_shape_cache = concave;


### PR DESCRIPTION
Fixes #115081


This PR adds a main thread check for convex and trimesh shape creation in `GLTFPhysicsShape::to_resource()` to prevent a deadlock when importing glTF files with mesh-based physics shapes from a background thread at runtime.

When importing glTF files with convex or trimesh collision shapes from a thread (not the main thread), Godot hangs indefinitely. This happens because of thread-safety inconsistency in `PhysicsServer3DWrapMT`:

1. `*_shape_create()` functions use `FUNCRID` macro → **direct call** (thread-safe, no queue)
2. `shape_set_data()` uses `FUNC2` macro → **command queue** and waits for physics thread

This causes a deadlock:

1. User thread → creates `ConvexPolygonShape3D` → `shape_create()` direct call (OK)
2. User thread → `set_points()` → `shape_set_data()` → push to command queue, **wait for physics thread**
4. Main thread → `thread.wait_to_finish()` → **wait for user thread**
5. **DEADLOCK**: User thread waits for physics (processed on main), main waits for user thread

Add `ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), ...)` checks before creating convex and trimesh shapes. This provides a clear error message instead of a silent hang, informing developers that these shapes must be created on the main thread.

Tested with the reproduction case from #115081 - glTF with convex/trimesh physics shapes imported via `ResourceLoader.load_threaded_request()`.

Platform: MacOS 26.0