### PR TITLE
Add SDFGI sky energy multiplier

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -239,6 +239,9 @@
 		<member name="sdfgi_read_sky_light" type="bool" setter="set_sdfgi_read_sky_light" getter="is_sdfgi_reading_sky_light" default="true">
 			If [code]true[/code], SDFGI takes the environment lighting into account. This should be set to [code]false[/code] for interior scenes.
 		</member>
+		<member name="sdfgi_sky_energy_multiplier" type="float" setter="set_sdfgi_sky_energy_multiplier" getter="get_sdfgi_sky_energy_multiplier" default="1.0">
+			The sky energy multiplier to use for SDFGI. See also [member sdfgi_energy].
+		</member>
 		<member name="sdfgi_use_occlusion" type="bool" setter="set_sdfgi_use_occlusion" getter="is_sdfgi_using_occlusion" default="false">
 			If [code]true[/code], SDFGI uses an occlusion detection approach to reduce light leaking. Occlusion may however introduce dark blotches in certain spots, which may be undesired in mostly outdoor scenes. [member sdfgi_use_occlusion] has a performance impact and should only be enabled when needed.
 		</member>

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -556,6 +556,15 @@ bool Environment::is_sdfgi_reading_sky_light() const {
 	return sdfgi_read_sky_light;
 }
 
+void Environment::set_sdfgi_sky_energy_multiplier(float p_sky_energy_multiplier) {
+	sdfgi_sky_energy_multiplier = p_sky_energy_multiplier;
+	_update_sdfgi();
+}
+
+float Environment::get_sdfgi_sky_energy_multiplier() const {
+	return sdfgi_sky_energy_multiplier;
+}
+
 void Environment::set_sdfgi_energy(float p_energy) {
 	sdfgi_energy = p_energy;
 	_update_sdfgi();
@@ -593,6 +602,7 @@ void Environment::_update_sdfgi() {
 			sdfgi_use_occlusion,
 			sdfgi_bounce_feedback,
 			sdfgi_read_sky_light,
+			sdfgi_sky_energy_multiplier,
 			sdfgi_energy,
 			sdfgi_normal_bias,
 			sdfgi_probe_bias);
@@ -1379,6 +1389,8 @@ void Environment::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_sdfgi_bounce_feedback"), &Environment::get_sdfgi_bounce_feedback);
 	ClassDB::bind_method(D_METHOD("set_sdfgi_read_sky_light", "enable"), &Environment::set_sdfgi_read_sky_light);
 	ClassDB::bind_method(D_METHOD("is_sdfgi_reading_sky_light"), &Environment::is_sdfgi_reading_sky_light);
+	ClassDB::bind_method(D_METHOD("set_sdfgi_sky_energy_multiplier", "amount"), &Environment::set_sdfgi_sky_energy_multiplier);
+	ClassDB::bind_method(D_METHOD("get_sdfgi_sky_energy_multiplier"), &Environment::get_sdfgi_sky_energy_multiplier);
 	ClassDB::bind_method(D_METHOD("set_sdfgi_energy", "amount"), &Environment::set_sdfgi_energy);
 	ClassDB::bind_method(D_METHOD("get_sdfgi_energy"), &Environment::get_sdfgi_energy);
 	ClassDB::bind_method(D_METHOD("set_sdfgi_normal_bias", "bias"), &Environment::set_sdfgi_normal_bias);
@@ -1398,6 +1410,7 @@ void Environment::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "sdfgi_cascade0_distance", PROPERTY_HINT_RANGE, "0.1,16384,0.1,or_greater", PROPERTY_USAGE_EDITOR), "set_sdfgi_cascade0_distance", "get_sdfgi_cascade0_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "sdfgi_max_distance", PROPERTY_HINT_RANGE, "0.1,16384,0.1,or_greater", PROPERTY_USAGE_EDITOR), "set_sdfgi_max_distance", "get_sdfgi_max_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sdfgi_y_scale", PROPERTY_HINT_ENUM, "50% (Compact),75% (Balanced),100% (Sparse)"), "set_sdfgi_y_scale", "get_sdfgi_y_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "sdfgi_sky_energy_multiplier"), "set_sdfgi_sky_energy_multiplier", "get_sdfgi_sky_energy_multiplier");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "sdfgi_energy"), "set_sdfgi_energy", "get_sdfgi_energy");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "sdfgi_normal_bias"), "set_sdfgi_normal_bias", "get_sdfgi_normal_bias");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "sdfgi_probe_bias"), "set_sdfgi_probe_bias", "get_sdfgi_probe_bias");

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -156,6 +156,7 @@ private:
 	bool sdfgi_use_occlusion = false;
 	float sdfgi_bounce_feedback = 0.5;
 	bool sdfgi_read_sky_light = true;
+	float sdfgi_sky_energy_multiplier = 1.0;
 	float sdfgi_energy = 1.0;
 	float sdfgi_normal_bias = 1.1;
 	float sdfgi_probe_bias = 1.1;
@@ -341,6 +342,8 @@ public:
 	float get_sdfgi_bounce_feedback() const;
 	void set_sdfgi_read_sky_light(bool p_enabled);
 	bool is_sdfgi_reading_sky_light() const;
+	void set_sdfgi_sky_energy_multiplier(float p_sky_energy_multiplier);
+	float get_sdfgi_sky_energy_multiplier() const;
 	void set_sdfgi_energy(float p_energy);
 	float get_sdfgi_energy() const;
 	void set_sdfgi_normal_bias(float p_bias);

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -1315,7 +1315,7 @@ void GI::SDFGI::update_probes(RID p_env, SkyRD::Sky *p_sky) {
 	push_constant.y_mult = y_mult;
 
 	if (reads_sky && p_env.is_valid()) {
-		push_constant.sky_energy = RendererSceneRenderRD::get_singleton()->environment_get_bg_energy_multiplier(p_env);
+		push_constant.sky_energy = RendererSceneRenderRD::get_singleton()->environment_get_bg_energy_multiplier(p_env) * RendererSceneRenderRD::get_singleton()->environment_get_sdfgi_sky_energy_multiplier(p_env);
 
 		if (RendererSceneRenderRD::get_singleton()->environment_get_background(p_env) == RS::ENV_BG_CLEAR_COLOR) {
 			push_constant.sky_flags |= SDFGIShader::IntegratePushConstant::SKY_FLAGS_MODE_COLOR;

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1343,7 +1343,7 @@ public:
 
 	// SDFGI
 
-	PASS11(environment_set_sdfgi, RID, bool, int, float, RS::EnvironmentSDFGIYScale, bool, float, bool, float, float, float)
+	PASS12(environment_set_sdfgi, RID, bool, int, float, RS::EnvironmentSDFGIYScale, bool, float, bool, float, float, float, float)
 
 	PASS1RC(bool, environment_get_sdfgi_enabled, RID)
 	PASS1RC(int, environment_get_sdfgi_cascades, RID)
@@ -1351,6 +1351,7 @@ public:
 	PASS1RC(bool, environment_get_sdfgi_use_occlusion, RID)
 	PASS1RC(float, environment_get_sdfgi_bounce_feedback, RID)
 	PASS1RC(bool, environment_get_sdfgi_read_sky_light, RID)
+	PASS1RC(float, environment_get_sdfgi_sky_energy_multiplier, RID)
 	PASS1RC(float, environment_get_sdfgi_energy, RID)
 	PASS1RC(float, environment_get_sdfgi_normal_bias, RID)
 	PASS1RC(float, environment_get_sdfgi_probe_bias, RID)

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -661,8 +661,8 @@ float RendererSceneRender::environment_get_ssil_normal_rejection(RID p_env) cons
 
 // SDFGI
 
-void RendererSceneRender::environment_set_sdfgi(RID p_env, bool p_enable, int p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, float p_bounce_feedback, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias) {
-	environment_storage.environment_set_sdfgi(p_env, p_enable, p_cascades, p_min_cell_size, p_y_scale, p_use_occlusion, p_bounce_feedback, p_read_sky, p_energy, p_normal_bias, p_probe_bias);
+void RendererSceneRender::environment_set_sdfgi(RID p_env, bool p_enable, int p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, float p_bounce_feedback, bool p_read_sky, float p_sky_energy_multiplier, float p_energy, float p_normal_bias, float p_probe_bias) {
+	environment_storage.environment_set_sdfgi(p_env, p_enable, p_cascades, p_min_cell_size, p_y_scale, p_use_occlusion, p_bounce_feedback, p_read_sky, p_sky_energy_multiplier, p_energy, p_normal_bias, p_probe_bias);
 }
 
 bool RendererSceneRender::environment_get_sdfgi_enabled(RID p_env) const {
@@ -687,6 +687,10 @@ float RendererSceneRender::environment_get_sdfgi_bounce_feedback(RID p_env) cons
 
 bool RendererSceneRender::environment_get_sdfgi_read_sky_light(RID p_env) const {
 	return environment_storage.environment_get_sdfgi_read_sky_light(p_env);
+}
+
+float RendererSceneRender::environment_get_sdfgi_sky_energy_multiplier(RID p_env) const {
+	return environment_storage.environment_get_sdfgi_sky_energy_multiplier(p_env);
 }
 
 float RendererSceneRender::environment_get_sdfgi_energy(RID p_env) const {

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -233,13 +233,14 @@ public:
 	virtual void environment_set_ssil_quality(RS::EnvironmentSSILQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) = 0;
 
 	// SDFGI
-	void environment_set_sdfgi(RID p_env, bool p_enable, int p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, float p_bounce_feedback, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias);
+	void environment_set_sdfgi(RID p_env, bool p_enable, int p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, float p_bounce_feedback, bool p_read_sky, float p_sky_energy_multiplier, float p_energy, float p_normal_bias, float p_probe_bias);
 	bool environment_get_sdfgi_enabled(RID p_env) const;
 	int environment_get_sdfgi_cascades(RID p_env) const;
 	float environment_get_sdfgi_min_cell_size(RID p_env) const;
 	bool environment_get_sdfgi_use_occlusion(RID p_env) const;
 	float environment_get_sdfgi_bounce_feedback(RID p_env) const;
 	bool environment_get_sdfgi_read_sky_light(RID p_env) const;
+	float environment_get_sdfgi_sky_energy_multiplier(RID p_env) const;
 	float environment_get_sdfgi_energy(RID p_env) const;
 	float environment_get_sdfgi_normal_bias(RID p_env) const;
 	float environment_get_sdfgi_probe_bias(RID p_env) const;

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -292,7 +292,7 @@ public:
 	virtual void environment_set_ssil_quality(RS::EnvironmentSSILQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) = 0;
 
 	// SDFGI
-	virtual void environment_set_sdfgi(RID p_env, bool p_enable, int p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, float p_bounce_feedback, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias) = 0;
+	virtual void environment_set_sdfgi(RID p_env, bool p_enable, int p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, float p_bounce_feedback, bool p_read_sky, float p_sky_energy_multiplier, float p_energy, float p_normal_bias, float p_probe_bias) = 0;
 
 	virtual bool environment_get_sdfgi_enabled(RID p_env) const = 0;
 	virtual int environment_get_sdfgi_cascades(RID p_env) const = 0;
@@ -300,6 +300,7 @@ public:
 	virtual bool environment_get_sdfgi_use_occlusion(RID p_env) const = 0;
 	virtual float environment_get_sdfgi_bounce_feedback(RID p_env) const = 0;
 	virtual bool environment_get_sdfgi_read_sky_light(RID p_env) const = 0;
+	virtual float environment_get_sdfgi_sky_energy_multiplier(RID p_env) const = 0;
 	virtual float environment_get_sdfgi_energy(RID p_env) const = 0;
 	virtual float environment_get_sdfgi_normal_bias(RID p_env) const = 0;
 	virtual float environment_get_sdfgi_probe_bias(RID p_env) const = 0;

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -1330,7 +1330,7 @@ public:
 		ENV_SDFGI_Y_SCALE_100_PERCENT,
 	};
 
-	virtual void environment_set_sdfgi(RID p_env, bool p_enable, int p_cascades, float p_min_cell_size, EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, float p_bounce_feedback, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias) = 0;
+	virtual void environment_set_sdfgi(RID p_env, bool p_enable, int p_cascades, float p_min_cell_size, EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, float p_bounce_feedback, bool p_read_sky, float p_sky_energy_multiplier, float p_energy, float p_normal_bias, float p_probe_bias) = 0;
 
 	enum EnvironmentSDFGIRayCount {
 		ENV_SDFGI_RAY_COUNT_4,

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -843,7 +843,7 @@ public:
 	FUNC2(environment_set_volumetric_fog_volume_size, int, int)
 	FUNC1(environment_set_volumetric_fog_filter_active, bool)
 
-	FUNC11(environment_set_sdfgi, RID, bool, int, float, EnvironmentSDFGIYScale, bool, float, bool, float, float, float)
+	FUNC12(environment_set_sdfgi, RID, bool, int, float, EnvironmentSDFGIYScale, bool, float, bool, float, float, float, float)
 	FUNC1(environment_set_sdfgi_ray_count, EnvironmentSDFGIRayCount)
 	FUNC1(environment_set_sdfgi_frames_to_converge, EnvironmentSDFGIFramesToConverge)
 	FUNC1(environment_set_sdfgi_frames_to_update_light, EnvironmentSDFGIFramesToUpdateLight)

--- a/servers/rendering/storage/environment_storage.cpp
+++ b/servers/rendering/storage/environment_storage.cpp
@@ -814,7 +814,7 @@ float RendererEnvironmentStorage::environment_get_ssil_normal_rejection(RID p_en
 
 // SDFGI
 
-void RendererEnvironmentStorage::environment_set_sdfgi(RID p_env, bool p_enable, int p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, float p_bounce_feedback, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias) {
+void RendererEnvironmentStorage::environment_set_sdfgi(RID p_env, bool p_enable, int p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, float p_bounce_feedback, bool p_read_sky, float p_energy, float p_sky_energy_multiplier, float p_normal_bias, float p_probe_bias) {
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_NULL(env);
 #ifdef DEBUG_ENABLED
@@ -829,6 +829,7 @@ void RendererEnvironmentStorage::environment_set_sdfgi(RID p_env, bool p_enable,
 	env->sdfgi_bounce_feedback = p_bounce_feedback;
 	env->sdfgi_read_sky_light = p_read_sky;
 	env->sdfgi_energy = p_energy;
+	env->sdfgi_sky_energy_multiplier = p_sky_energy_multiplier;
 	env->sdfgi_normal_bias = p_normal_bias;
 	env->sdfgi_probe_bias = p_probe_bias;
 	env->sdfgi_y_scale = p_y_scale;
@@ -868,6 +869,12 @@ bool RendererEnvironmentStorage::environment_get_sdfgi_read_sky_light(RID p_env)
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_NULL_V(env, true);
 	return env->sdfgi_read_sky_light;
+}
+
+float RendererEnvironmentStorage::environment_get_sdfgi_sky_energy_multiplier(RID p_env) const {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_NULL_V(env, 1.0);
+	return env->sdfgi_sky_energy_multiplier;
 }
 
 float RendererEnvironmentStorage::environment_get_sdfgi_energy(RID p_env) const {

--- a/servers/rendering/storage/environment_storage.h
+++ b/servers/rendering/storage/environment_storage.h
@@ -166,6 +166,7 @@ private:
 		bool sdfgi_use_occlusion = false;
 		float sdfgi_bounce_feedback = 0.5;
 		bool sdfgi_read_sky_light = true;
+		float sdfgi_sky_energy_multiplier = 1.0;
 		float sdfgi_energy = 1.0;
 		float sdfgi_normal_bias = 1.1;
 		float sdfgi_probe_bias = 1.1;
@@ -311,13 +312,14 @@ public:
 	float environment_get_ssil_normal_rejection(RID p_env) const;
 
 	// SDFGI
-	void environment_set_sdfgi(RID p_env, bool p_enable, int p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, float p_bounce_feedback, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias);
+	void environment_set_sdfgi(RID p_env, bool p_enable, int p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, float p_bounce_feedback, bool p_read_sky, float p_sky_energy_multiplier, float p_energy, float p_normal_bias, float p_probe_bias);
 	bool environment_get_sdfgi_enabled(RID p_env) const;
 	int environment_get_sdfgi_cascades(RID p_env) const;
 	float environment_get_sdfgi_min_cell_size(RID p_env) const;
 	bool environment_get_sdfgi_use_occlusion(RID p_env) const;
 	float environment_get_sdfgi_bounce_feedback(RID p_env) const;
 	bool environment_get_sdfgi_read_sky_light(RID p_env) const;
+	float environment_get_sdfgi_sky_energy_multiplier(RID p_env) const;
 	float environment_get_sdfgi_energy(RID p_env) const;
 	float environment_get_sdfgi_normal_bias(RID p_env) const;
 	float environment_get_sdfgi_probe_bias(RID p_env) const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Idea came to me while working on things related to https://github.com/godotengine/godot/issues/115033 :

A case when sky contribution is too high (e.g. white clouds on bright sunny day sky etc.) sometimes arises, making everything too bright, and then no good solution exists currently if SDFGI is used. ATM, SDFGI sky contribution is multiplied by `bg_energy_multiplier` (this ain't obvious and I don't think it's explicitly documented, but it makes some sense here), and then the final result of total SDFGI ambient is multiplied by SDFGI energy. As a result, all possible attempts at fixing too bright parts of the scene give bad outcomes:
* decreasing bg energy mult affects entire scene heavily, not only the SDFGI-lit parts but everything,
* disabling sky contribution means just 0 multiplier, no way to set it to a lower-but-visible-value like 0.5, 0.2 etc., so it's just too dark for outdoor scenes,
* reducing SDFGI energy affects _all_ SDFGI effects, including those from normal lights and emissions. It also currently causes problems with alpha-blended textures.

Also, lack of possibility to change the sky contribution factor for SDFGI prevents better artistic control over SDFGI, which can have quite extreme and not really convincing lighting outcomes if no fine-tuning is allowed.

The solution is relatively simple and fully backwards compatible: adding a new float env setting that would multiply the old value. This is by default 1.0, so no effect on existing setups. The calculation is trivial and is not affecting perfomance (it is used to set a const-ish value that exists exactly how it did before, outside of shader).

ATM I'm getting some test error about `Unnamed argument in position 11 of method 'RenderingServer.environment_set_sdfgi'.` , but have troubles tracing what exactly did I miss. Would appreciate some tips on this.

CC @Calinou et al
