### PR TITLE
Multiplayer: Pause packet processing while waiting on SceneTree to change the current scene

### DIFF
--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -24,6 +24,13 @@
 				Returns the default MultiplayerAPI implementation class name. This is usually [code]"SceneMultiplayer"[/code] when [SceneMultiplayer] is available. See [method set_default_interface].
 			</description>
 		</method>
+		<method name="get_packet_processing_paused">
+			<return type="bool" />
+			<description>
+				Gets whether packet processing is paused or not.
+				See [method set_packet_processing_paused]
+			</description>
+		</method>
 		<method name="get_peers">
 			<return type="PackedInt32Array" />
 			<description>
@@ -96,6 +103,15 @@
 			<param index="0" name="interface_name" type="StringName" />
 			<description>
 				Sets the default MultiplayerAPI implementation class. This method can be used by modules and extensions to configure which implementation will be used by [SceneTree] when the engine starts.
+			</description>
+		</method>
+		<method name="set_packet_processing_paused">
+			<return type="void" />
+			<param index="0" name="paused" type="bool" />
+			<description>
+				Sets whether packet processing is paused, leaving sent/received data to accumulate until it is unpaused.
+				[b]Note:[/b] This is primarily used by the SceneTree to allow a client to delay processing packets until it is done changing the main scene via an RPC.
+				This will be set back to false when the scene is changed via [method SceneTree.change_scene_to_node].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/MultiplayerAPIExtension.xml
+++ b/doc/classes/MultiplayerAPIExtension.xml
@@ -88,6 +88,12 @@
 				Called when the [member MultiplayerAPI.multiplayer_peer] is retrieved.
 			</description>
 		</method>
+		<method name="_get_packet_processing_paused" qualifiers="virtual">
+			<return type="bool" />
+			<description>
+				Callback for [method MultiplayerAPI.get_packet_processing_paused]
+			</description>
+		</method>
 		<method name="_get_peer_ids" qualifiers="virtual const">
 			<return type="PackedInt32Array" />
 			<description>
@@ -143,6 +149,13 @@
 			<param index="0" name="multiplayer_peer" type="MultiplayerPeer" />
 			<description>
 				Called when the [member MultiplayerAPI.multiplayer_peer] is set.
+			</description>
+		</method>
+		<method name="_set_packet_processing_paused" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="paused" type="bool" />
+			<description>
+				Callback for [method MultiplayerAPI.set_packet_processing_paused].
 			</description>
 		</method>
 	</methods>

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -76,7 +76,7 @@ Error SceneMultiplayer::poll() {
 		return OK;
 	}
 
-	while (multiplayer_peer->get_available_packet_count()) {
+	while (!packet_processing_paused && multiplayer_peer->get_available_packet_count()) {
 		int sender = multiplayer_peer->get_packet_peer();
 		const uint8_t *packet;
 		int len;
@@ -181,6 +181,14 @@ void SceneMultiplayer::set_root_path(const NodePath &p_path) {
 
 NodePath SceneMultiplayer::get_root_path() const {
 	return root_path;
+}
+
+void SceneMultiplayer::set_packet_processing_paused(bool p_paused) {
+	packet_processing_paused = p_paused;
+}
+
+bool SceneMultiplayer::get_packet_processing_paused() {
+	return packet_processing_paused;
 }
 
 void SceneMultiplayer::set_multiplayer_peer(const Ref<MultiplayerPeer> &p_peer) {

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -127,6 +127,8 @@ private:
 	Ref<SceneReplicationInterface> replicator;
 	Ref<SceneRPCInterface> rpc;
 
+	bool packet_processing_paused = false;
+
 #ifdef DEBUG_ENABLED
 	_FORCE_INLINE_ void _profile_bandwidth(const String &p_what, int p_value);
 	_FORCE_INLINE_ Error _send(const uint8_t *p_packet, int p_packet_len); // Also profiles.
@@ -149,6 +151,9 @@ protected:
 	void _update_status();
 
 public:
+	virtual void set_packet_processing_paused(bool p_paused) override;
+	virtual bool get_packet_processing_paused() override;
+
 	virtual void set_multiplayer_peer(const Ref<MultiplayerPeer> &p_peer) override;
 	virtual Ref<MultiplayerPeer> get_multiplayer_peer() override;
 

--- a/scene/main/multiplayer_api.cpp
+++ b/scene/main/multiplayer_api.cpp
@@ -284,6 +284,9 @@ Error MultiplayerAPI::_rpc_bind(int p_peer, Object *p_object, const StringName &
 }
 
 void MultiplayerAPI::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_packet_processing_paused", "paused"), &MultiplayerAPI::set_packet_processing_paused);
+	ClassDB::bind_method(D_METHOD("get_packet_processing_paused"), &MultiplayerAPI::get_packet_processing_paused);
+
 	ClassDB::bind_method(D_METHOD("has_multiplayer_peer"), &MultiplayerAPI::has_multiplayer_peer);
 	ClassDB::bind_method(D_METHOD("get_multiplayer_peer"), &MultiplayerAPI::get_multiplayer_peer);
 	ClassDB::bind_method(D_METHOD("set_multiplayer_peer", "peer"), &MultiplayerAPI::set_multiplayer_peer);
@@ -315,6 +318,16 @@ void MultiplayerAPI::_bind_methods() {
 }
 
 /// MultiplayerAPIExtension
+
+void MultiplayerAPIExtension::set_packet_processing_paused(bool p_paused) {
+	GDVIRTUAL_CALL(_set_packet_processing_paused, p_paused);
+}
+
+bool MultiplayerAPIExtension::get_packet_processing_paused() {
+	bool paused = false;
+	GDVIRTUAL_CALL(_get_packet_processing_paused, paused);
+	return paused;
+}
 
 Error MultiplayerAPIExtension::poll() {
 	Error err = OK;
@@ -376,6 +389,8 @@ Error MultiplayerAPIExtension::object_configuration_remove(Object *p_object, Var
 }
 
 void MultiplayerAPIExtension::_bind_methods() {
+	GDVIRTUAL_BIND(_set_packet_processing_paused, "paused");
+	GDVIRTUAL_BIND(_get_packet_processing_paused);
 	GDVIRTUAL_BIND(_poll);
 	GDVIRTUAL_BIND(_set_multiplayer_peer, "multiplayer_peer");
 	GDVIRTUAL_BIND(_get_multiplayer_peer);

--- a/scene/main/multiplayer_api.h
+++ b/scene/main/multiplayer_api.h
@@ -59,6 +59,9 @@ public:
 	static Error encode_and_compress_variants(const Variant **p_variants, int p_count, uint8_t *p_buffer, int &r_len, bool *r_raw = nullptr, bool p_allow_object_decoding = false);
 	static Error decode_and_decompress_variants(Vector<Variant> &r_variants, const uint8_t *p_buffer, int p_len, int &r_len, bool p_raw = false, bool p_allow_object_decoding = false);
 
+	virtual void set_packet_processing_paused(bool p_paused) = 0;
+	virtual bool get_packet_processing_paused() = 0;
+
 	virtual Error poll() = 0;
 	virtual void set_multiplayer_peer(const Ref<MultiplayerPeer> &p_peer) = 0;
 	virtual Ref<MultiplayerPeer> get_multiplayer_peer() = 0;
@@ -86,6 +89,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual void set_packet_processing_paused(bool p_paused) override;
+	virtual bool get_packet_processing_paused() override;
+
 	virtual Error poll() override;
 	virtual void set_multiplayer_peer(const Ref<MultiplayerPeer> &p_peer) override;
 	virtual Ref<MultiplayerPeer> get_multiplayer_peer() override;
@@ -99,6 +105,8 @@ public:
 	virtual Error object_configuration_remove(Object *p_object, Variant p_config) override;
 
 	// Extensions
+	GDVIRTUAL1(_set_packet_processing_paused, bool);
+	GDVIRTUAL0R(bool, _get_packet_processing_paused);
 	GDVIRTUAL0R(Error, _poll);
 	GDVIRTUAL1(_set_multiplayer_peer, Ref<MultiplayerPeer>);
 	GDVIRTUAL0R(Ref<MultiplayerPeer>, _get_multiplayer_peer);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1665,6 +1665,11 @@ void SceneTree::_flush_scene_change() {
 		// Update display for cursor instantly.
 		root->update_mouse_cursor_state();
 
+		if (multiplayer.is_valid()) {
+			// Resume packet processing
+			multiplayer->set_packet_processing_paused(false);
+		}
+
 		// Only on successful scene change.
 		emit_signal(SNAME("scene_changed"));
 	} else {
@@ -1715,6 +1720,12 @@ Error SceneTree::change_scene_to_node(RequiredParam<Node> rp_node) {
 	DEV_ASSERT(!current_scene);
 
 	pending_new_scene_id = p_node->get_instance_id();
+
+	if (multiplayer.is_valid()) {
+		// Pause packet processing until _flush_scene_change
+		multiplayer->set_packet_processing_paused(true);
+	}
+
 	return OK;
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

This PR aims to fix #68407

This adds a method to the MultiplayerAPI to set if packet processing should be paused, and the SceneTree will use this method to pause and resume packet processing between scene changes.

> The problem relies on the deferred nature of `change_scene_to_*`, and would require the multiplayer API to temporarily stop processing packets or implement some form of scene reconciliation process.

This way, the client is able to catch up before attempting to process packets for spawners or synchronizers within the target scene.

Disclosure: I'm not too familiar with the lower level networking or engine code, so if there's something odd with how I've implemented this, or if I should take a different approach, please let me know.



Testing with this MRP:
[multiplayer-nodes-4.6.zip](https://github.com/user-attachments/files/24700437/multiplayer-nodes-4.6.zip)

Before:
<img width="2982" height="2022" alt="image" src="https://github.com/user-attachments/assets/245b0f05-18e5-4856-8ddf-127c76f9a992" />
After:
<img width="2769" height="1939" alt="image" src="https://github.com/user-attachments/assets/72cb81f7-3e66-408c-af82-b6e15c4cd66e" />

