### PR TITLE
Add 'Find in Folder...' to FileSystem context menu

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2299,6 +2299,20 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			}
 		} break;
 
+		case FILE_MENU_FIND_IN_FOLDER: {
+			String fpath = current_path;
+			if (current_path == "Favorites") {
+				if (p_selected.is_empty()) {
+					return;
+				}
+				fpath = p_selected[0];
+			} else if (!p_selected.is_empty()) {
+				fpath = p_selected[0];
+			}
+
+			ScriptEditor::get_singleton()->open_find_in_files_dialog("", false, fpath.trim_prefix("res://").trim_suffix("/"));
+		} break;
+
 		case FILE_MENU_OPEN_IN_TERMINAL: {
 			String fpath = current_path;
 			if (current_path == "Favorites") {
@@ -3485,6 +3499,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 		if (foldernames.size() == 1) {
 			p_popup->add_icon_item(get_editor_theme_icon(SNAME("GuiTreeArrowDown")), TTRC("Expand Hierarchy"), FILE_MENU_EXPAND_ALL);
 			p_popup->add_icon_item(get_editor_theme_icon(SNAME("GuiTreeArrowRight")), TTRC("Collapse Hierarchy"), FILE_MENU_COLLAPSE_ALL);
+			p_popup->add_icon_item(get_editor_theme_icon(SNAME("Search")), TTRC("Find in Folder..."), FILE_MENU_FIND_IN_FOLDER);
 		}
 
 		p_popup->add_separator();

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -137,6 +137,7 @@ private:
 		FILE_MENU_NEW_SCRIPT,
 		FILE_MENU_NEW_SCENE,
 		FILE_MENU_RUN_SCRIPT,
+		FILE_MENU_FIND_IN_FOLDER,
 		FILE_MENU_MAX,
 		// Extra shortcuts that don't exist in the menu.
 		EXTRA_FOCUS_PATH,

--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -1364,6 +1364,10 @@ void FindInFilesContainer::_files_modified() {
 	emit_signal(SNAME("files_modified"));
 }
 
+void FindInFilesDialog::set_folder(const String &folder) {
+	folder_line_edit->set_text(folder);
+}
+
 void FindInFilesContainer::_close_panel(FindInFilesPanel *p_panel) {
 	ERR_FAIL_COND_MSG(p_panel->get_parent() != tabs, "This panel is not a child!");
 	tabs->remove_child(p_panel);
@@ -1526,12 +1530,13 @@ void FindInFiles::_start_search(bool p_with_replace) {
 	container->make_visible();
 }
 
-void FindInFiles::open_dialog(const String &p_initial_text, bool p_replace) {
+void FindInFiles::open_dialog(const String &p_initial_text, bool p_replace, const String &p_folder) {
 	dialog->set_replace_mode(p_replace);
 	dialog->set_search_text(p_initial_text);
 	if (p_replace) {
 		dialog->set_replace_text(String());
 	}
+	dialog->set_folder(p_folder);
 	dialog->popup_centered();
 }
 

--- a/editor/script/find_in_files.h
+++ b/editor/script/find_in_files.h
@@ -130,6 +130,7 @@ protected:
 public:
 	void set_search_text(const String &p_text);
 	void set_replace_text(const String &p_text);
+	void set_folder(const String &folder);
 
 	void set_replace_mode(bool p_replace);
 
@@ -290,7 +291,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void open_dialog(const String &p_initial_text, bool p_replace = false);
+	void open_dialog(const String &p_initial_text, bool p_replace = false, const String &p_folder = "");
 
 	FindInFiles();
 };

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -2675,8 +2675,8 @@ void ScriptEditor::_auto_format_text(ScriptEditorBase *p_seb) {
 	}
 }
 
-void ScriptEditor::open_find_in_files_dialog(const String &p_initial_text, bool p_replace) {
-	find_in_files->open_dialog(p_initial_text, p_replace);
+void ScriptEditor::open_find_in_files_dialog(const String &p_initial_text, bool p_replace, const String &p_folder) {
+	find_in_files->open_dialog(p_initial_text, p_replace, p_folder);
 }
 
 void ScriptEditor::open_script_create_dialog(const String &p_base_name, const String &p_base_path) {

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -406,7 +406,7 @@ public:
 	bool is_files_panel_toggled();
 	void apply_scripts() const;
 	void reload_scripts(bool p_refresh_only = false);
-	void open_find_in_files_dialog(const String &p_initial_text = "", bool p_replace = false);
+	void open_find_in_files_dialog(const String &p_initial_text = "", bool p_replace = false, const String &p_folder = "");
 	void open_script_create_dialog(const String &p_base_name, const String &p_base_path);
 	void open_text_file_create_dialog(const String &p_base_path, const String &p_base_name = "");
 	Ref<Resource> open_file(const String &p_file);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/11291

This PR simply opens the existing 'Find in Files' popup with the folder field pre-populated. 

<img width="828" height="985" alt="image" src="https://github.com/user-attachments/assets/f79e6f47-fcce-48a6-8104-6c31f1fa9a81" />