### PR TITLE
Add support for the Home LED on NS Controllers

### DIFF
--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -292,7 +292,8 @@ void JoypadSDL::close_joypad(int p_pad_idx) {
 }
 
 bool JoypadSDL::Joypad::has_joy_light() const {
-	SDL_PropertiesID properties_id = SDL_GetJoystickProperties(get_sdl_joystick());
+	SDL_Joystick *joystick = get_sdl_joystick();
+	SDL_PropertiesID properties_id = SDL_GetJoystickProperties(joystick);
 	if (properties_id == 0) {
 		return false;
 	}

--- a/thirdparty/sdl/joystick/hidapi/SDL_hidapi_switch.c
+++ b/thirdparty/sdl/joystick/hidapi/SDL_hidapi_switch.c
@@ -1780,16 +1780,24 @@ static Uint32 HIDAPI_DriverSwitch_GetJoystickCapabilities(SDL_HIDAPI_Device *dev
     if (ctx->m_eControllerType == k_eSwitchDeviceInfoControllerType_ProController && !ctx->m_bInputOnly) {
         // Doesn't have an RGB LED, so don't return SDL_JOYSTICK_CAP_RGB_LED here
         result |= SDL_JOYSTICK_CAP_RUMBLE;
+		// But has the HOME LED, so
+		result |= SDL_JOYSTICK_CAP_MONO_LED;
     } else if (ctx->m_eControllerType == k_eSwitchDeviceInfoControllerType_JoyConLeft ||
                ctx->m_eControllerType == k_eSwitchDeviceInfoControllerType_JoyConRight) {
         result |= SDL_JOYSTICK_CAP_RUMBLE;
+		if (ctx->m_eControllerType == k_eSwitchDeviceInfoControllerType_JoyConRight) {
+			result |= SDL_JOYSTICK_CAP_MONO_LED; // Those types of controllers also have the Home LED.
+		}
     }
+
     return result;
 }
 
 static bool HIDAPI_DriverSwitch_SetJoystickLED(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, Uint8 red, Uint8 green, Uint8 blue)
 {
-    return SDL_Unsupported();
+	SDL_DriverSwitch_Context *ctx = (SDL_DriverSwitch_Context *)device->context;
+	int value = (int)((SDL_max(red, SDL_max(green, blue)) / 255.0f) * 100.0f); // The colors are received between 0-255 and we need them to be 0-100.
+	return SetHomeLED(ctx, (Uint8)value);
 }
 
 static bool HIDAPI_DriverSwitch_SendJoystickEffect(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, const void *data, int size)


### PR DESCRIPTION
With the addition of `Input.set_joy_light()` from [#111681](https://github.com/godotengine/godot/pull/111681), I wondered if the LED around the Home Button in some Nintendo Switch controllers could be adjusted. I discovered they could not, because its implementation uses the `SDL_SetJoystickLED` function while the Home LED uses the `SDL_JOYSTICK_HIDAPI_SWITCH_HOME_LED` hint.

This PR aims to add support for this LED mentioned.

I only changed the `drivers/sdl/joypad_sdl.cpp` file:

- Added an if condition on `close_joypad` to check if it's a NS controller and turn the LED off if true:
  - Sets the `SDL_JOYSTICK_HIDAPI_SWITCH_HOME_LED` hint to `"0.0"`;
- Added an if condition on `has_joy_light` to make NS controllers `return true`;
- Added logic to set up the brightness of the NS controller LED:
  - It gets the max rgb value of the Color provided;
  - Sets the `SDL_JOYSTICK_HIDAPI_SWITCH_HOME_LED` hint with the `char *` of the maximum value.

I've tested on Windows and it seems to work. I don't know if there are other controllers that use the same hint and are not mentioned in the if statements. If so, feel free to change or improve it.