### PR TITLE
OpenXR: Properly handle finger bones not marked as tracked

### DIFF
--- a/scene/3d/xr/xr_hand_modifier_3d.cpp
+++ b/scene/3d/xr/xr_hand_modifier_3d.cpp
@@ -256,15 +256,32 @@ void XRHandModifier3D::_process_modification(double p_delta) {
 	Transform3D *previous_relative_transforms_ptr = previous_relative_transforms.ptrw();
 
 	for (int joint = 0; joint < XRHandTracker::HAND_JOINT_MAX; joint++) {
-		// Get the skeleton bone (skip if none).
+		// Get the skeleton bone (skip if none or if we don't have tracking data).
 		const int bone = joints[joint].bone;
 		if (bone == -1) {
+			continue;
+		} else if (!has_valid_data[joint]) {
 			continue;
 		}
 
 		// Calculate the relative relationship to the parent bone joint.
 		const int parent_joint = joints[joint].parent_joint;
-		const Transform3D relative_transform = inv_transforms[parent_joint] * transforms[joint];
+		Transform3D relative_transform;
+		if (has_valid_data[parent_joint]) {
+			relative_transform = inv_transforms[parent_joint] * transforms[joint];
+		} else {
+			// Use our parents global pose, this may have been updated by updating previous bones.
+			// This only works due to the order in which we update our bones guaranteeing all parent
+			// bones have already been updated.
+			Transform3D parent_transform = skeleton->get_bone_global_pose(parent_joint);
+
+			// Note that this isn't truly global, but our bone pose in relation to our skeletons root,
+			// so we need to correct this but we use out tracking root!
+			parent_transform = transforms[XRHandTracker::HAND_JOINT_PALM] * parent_transform;
+
+			// Now we can calculate our relative transform.
+			relative_transform = parent_transform.affine_inverse() * transforms[joint];
+		}
 		previous_relative_transforms_ptr[joint] = relative_transform;
 
 		// Update the bone position if enabled by update mode.


### PR DESCRIPTION
This PR changes the hand tracking logic so it can deal with missing/untracked bones in our tracking data.

When a bone isn't tracked, we won't update its pose, so it will keep its relative position to it's parent.
For a bone that is a child of an untracked bone, we'll check the updated global position in tracking space and determine the relative position from this.

This is currently a draft PR as I do not have the ability to currently test this in the scenario where this failed. Most XR Runtimes provide valid tracking data for all bones when tracking data is available.

Potentially fixes #113752