### PR TITLE
Ensure debug features get cleared after use

### DIFF
--- a/editor/run/editor_run.cpp
+++ b/editor/run/editor_run.cpp
@@ -189,7 +189,8 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 	if (!p_scene.is_empty()) {
 		running_scene = p_scene;
 	}
-
+	// Clear debug features in environment
+	OS::get_singleton()->unset_environment("GODOT_EDITOR_CUSTOM_FEATURES");
 	return OK;
 }
 


### PR DESCRIPTION
Fixes #109252 

Clear debug features stored in a environment variable after debug instances are created.

It could also be done here, but personally it makes more sense clearing after creating debug instances.

https://github.com/godotengine/godot/blob/741fb8a30687d0662ab6b5c04a2a531440dd29d9/editor/editor_node.cpp#L4102-L4103