### PR TITLE
Process system events during boot splash wait time.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4724,11 +4724,18 @@ int Main::start() {
 	GDExtensionManager::get_singleton()->startup();
 
 	if (minimum_time_msec) {
-		uint64_t minimum_time = 1000 * minimum_time_msec;
-		uint64_t elapsed_time = OS::get_singleton()->get_ticks_usec();
-		if (elapsed_time < minimum_time) {
-			OS::get_singleton()->delay_usec(minimum_time - elapsed_time);
+		int64_t minimum_time = 1000 * minimum_time_msec;
+		uint64_t prev_time = OS::get_singleton()->get_ticks_usec();
+		while (minimum_time > 0) {
+			DisplayServer::get_singleton()->process_events();
+			OS::get_singleton()->delay_usec(100);
+
+			uint64_t next_time = OS::get_singleton()->get_ticks_usec();
+			minimum_time -= (next_time - prev_time);
+			prev_time = next_time;
 		}
+	} else {
+		DisplayServer::get_singleton()->process_events();
 	}
 
 	OS::get_singleton()->benchmark_end_measure("Startup", "Main::Start");


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/112143 and also makes window responsive during splash wait.

Supersede https://github.com/godotengine/godot/pull/114782

cc @jgill88, please check if it's working in your case (Intel Mac).