### PR TITLE
Change all hardcode problems relative to SceneTree node group

### DIFF
--- a/scene/3d/world_environment.cpp
+++ b/scene/3d/world_environment.cpp
@@ -38,17 +38,17 @@ void WorldEnvironment::_notification(int p_what) {
 		case Node3D::NOTIFICATION_ENTER_WORLD:
 		case Node3D::NOTIFICATION_ENTER_TREE: {
 			if (environment.is_valid()) {
-				add_to_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+				add_to_group(get_viewport()->get_world_environment_group_name());
 				_update_current_environment();
 			}
 
 			if (camera_attributes.is_valid()) {
-				add_to_group("_world_camera_attributes_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+				add_to_group(get_viewport()->get_world_camera_attributes_group_name());
 				_update_current_camera_attributes();
 			}
 
 			if (compositor.is_valid()) {
-				add_to_group("_world_compositor_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+				add_to_group(get_viewport()->get_world_compositor_group_name());
 				_update_current_compositor();
 			}
 		} break;
@@ -56,17 +56,17 @@ void WorldEnvironment::_notification(int p_what) {
 		case Node3D::NOTIFICATION_EXIT_WORLD:
 		case Node3D::NOTIFICATION_EXIT_TREE: {
 			if (environment.is_valid()) {
-				remove_from_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+				remove_from_group(get_viewport()->get_world_environment_group_name());
 				_update_current_environment();
 			}
 
 			if (camera_attributes.is_valid()) {
-				remove_from_group("_world_camera_attributes_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+				remove_from_group(get_viewport()->get_world_camera_attributes_group_name());
 				_update_current_camera_attributes();
 			}
 
 			if (compositor.is_valid()) {
-				remove_from_group("_world_compositor_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+				remove_from_group(get_viewport()->get_world_compositor_group_name());
 				_update_current_compositor();
 			}
 		} break;
@@ -74,36 +74,36 @@ void WorldEnvironment::_notification(int p_what) {
 }
 
 void WorldEnvironment::_update_current_environment() {
-	WorldEnvironment *first = Object::cast_to<WorldEnvironment>(get_tree()->get_first_node_in_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id())));
+	WorldEnvironment *first = Object::cast_to<WorldEnvironment>(get_tree()->get_first_node_in_group(get_viewport()->get_world_environment_group_name()));
 
 	if (first) {
 		get_viewport()->find_world_3d()->set_environment(first->environment);
 	} else {
 		get_viewport()->find_world_3d()->set_environment(Ref<Environment>());
 	}
-	get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, "_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()), "update_configuration_warnings");
+	get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, get_viewport()->get_world_environment_group_name(), "update_configuration_warnings");
 }
 
 void WorldEnvironment::_update_current_camera_attributes() {
-	WorldEnvironment *first = Object::cast_to<WorldEnvironment>(get_tree()->get_first_node_in_group("_world_camera_attributes_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id())));
+	WorldEnvironment *first = Object::cast_to<WorldEnvironment>(get_tree()->get_first_node_in_group(get_viewport()->get_world_camera_attributes_group_name()));
 	if (first) {
 		get_viewport()->find_world_3d()->set_camera_attributes(first->camera_attributes);
 	} else {
 		get_viewport()->find_world_3d()->set_camera_attributes(Ref<CameraAttributes>());
 	}
 
-	get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, "_world_camera_attributes_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()), "update_configuration_warnings");
+	get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, get_viewport()->get_world_camera_attributes_group_name(), "update_configuration_warnings");
 }
 
 void WorldEnvironment::_update_current_compositor() {
-	WorldEnvironment *first = Object::cast_to<WorldEnvironment>(get_tree()->get_first_node_in_group("_world_compositor_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id())));
+	WorldEnvironment *first = Object::cast_to<WorldEnvironment>(get_tree()->get_first_node_in_group(get_viewport()->get_world_compositor_group_name()));
 	if (first) {
 		get_viewport()->find_world_3d()->set_compositor(first->compositor);
 	} else {
 		get_viewport()->find_world_3d()->set_compositor(Ref<Compositor>());
 	}
 
-	get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, "_world_compositor_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()), "update_configuration_warnings");
+	get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, get_viewport()->get_world_compositor_group_name(), "update_configuration_warnings");
 }
 
 void WorldEnvironment::set_environment(const Ref<Environment> &p_environment) {
@@ -111,13 +111,13 @@ void WorldEnvironment::set_environment(const Ref<Environment> &p_environment) {
 		return;
 	}
 	if (is_inside_tree() && environment.is_valid()) {
-		remove_from_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+		remove_from_group(get_viewport()->get_world_environment_group_name());
 	}
 
 	environment = p_environment;
 
 	if (is_inside_tree() && environment.is_valid()) {
-		add_to_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+		add_to_group(get_viewport()->get_world_environment_group_name());
 	}
 
 	if (is_inside_tree()) {
@@ -137,12 +137,12 @@ void WorldEnvironment::set_camera_attributes(const Ref<CameraAttributes> &p_came
 	}
 
 	if (is_inside_tree() && camera_attributes.is_valid() && get_viewport()->find_world_3d()->get_camera_attributes() == camera_attributes) {
-		remove_from_group("_world_camera_attributes_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+		remove_from_group(get_viewport()->get_world_camera_attributes_group_name());
 	}
 
 	camera_attributes = p_camera_attributes;
 	if (is_inside_tree() && camera_attributes.is_valid()) {
-		add_to_group("_world_camera_attributes_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+		add_to_group(get_viewport()->get_world_camera_attributes_group_name());
 	}
 
 	if (is_inside_tree()) {
@@ -161,13 +161,13 @@ void WorldEnvironment::set_compositor(const Ref<Compositor> &p_compositor) {
 		return;
 	}
 	if (is_inside_tree() && compositor.is_valid()) {
-		remove_from_group("_world_compositor_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+		remove_from_group(get_viewport()->get_world_compositor_group_name());
 	}
 
 	compositor = p_compositor;
 
 	if (is_inside_tree() && compositor.is_valid()) {
-		add_to_group("_world_compositor_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+		add_to_group(get_viewport()->get_world_compositor_group_name());
 	}
 
 	if (is_inside_tree()) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -161,16 +161,16 @@ void Node::_notification(int p_notification) {
 			data.is_translation_domain_dirty = true;
 
 			if (data.input) {
-				add_to_group("_vp_input" + itos(get_viewport()->get_instance_id()));
+				add_to_group(get_viewport()->get_input_group_name());
 			}
 			if (data.shortcut_input) {
-				add_to_group("_vp_shortcut_input" + itos(get_viewport()->get_instance_id()));
+				add_to_group(get_viewport()->get_shortcut_input_group_name());
 			}
 			if (data.unhandled_input) {
-				add_to_group("_vp_unhandled_input" + itos(get_viewport()->get_instance_id()));
+				add_to_group(get_viewport()->get_unhandled_input_group_name());
 			}
 			if (data.unhandled_key_input) {
-				add_to_group("_vp_unhandled_key_input" + itos(get_viewport()->get_instance_id()));
+				add_to_group(get_viewport()->get_unhandled_key_input_group_name());
 			}
 
 			data.tree->nodes_in_tree_count++;
@@ -203,16 +203,16 @@ void Node::_notification(int p_notification) {
 			data.tree->nodes_in_tree_count--;
 
 			if (data.input) {
-				remove_from_group("_vp_input" + itos(get_viewport()->get_instance_id()));
+				remove_from_group(get_viewport()->get_input_group_name());
 			}
 			if (data.shortcut_input) {
-				remove_from_group("_vp_shortcut_input" + itos(get_viewport()->get_instance_id()));
+				remove_from_group(get_viewport()->get_shortcut_input_group_name());
 			}
 			if (data.unhandled_input) {
-				remove_from_group("_vp_unhandled_input" + itos(get_viewport()->get_instance_id()));
+				remove_from_group(get_viewport()->get_unhandled_input_group_name());
 			}
 			if (data.unhandled_key_input) {
-				remove_from_group("_vp_unhandled_key_input" + itos(get_viewport()->get_instance_id()));
+				remove_from_group(get_viewport()->get_unhandled_key_input_group_name());
 			}
 
 			// Remove from processing first.
@@ -1255,9 +1255,9 @@ void Node::set_process_input(bool p_enable) {
 	}
 
 	if (p_enable) {
-		add_to_group("_vp_input" + itos(get_viewport()->get_instance_id()));
+		add_to_group(get_viewport()->get_shortcut_input_group_name());
 	} else {
-		remove_from_group("_vp_input" + itos(get_viewport()->get_instance_id()));
+		remove_from_group(get_viewport()->get_shortcut_input_group_name());
 	}
 }
 
@@ -1276,9 +1276,9 @@ void Node::set_process_shortcut_input(bool p_enable) {
 	}
 
 	if (p_enable) {
-		add_to_group("_vp_shortcut_input" + itos(get_viewport()->get_instance_id()));
+		add_to_group(get_viewport()->get_shortcut_input_group_name());
 	} else {
-		remove_from_group("_vp_shortcut_input" + itos(get_viewport()->get_instance_id()));
+		remove_from_group(get_viewport()->get_shortcut_input_group_name());
 	}
 }
 
@@ -1297,9 +1297,9 @@ void Node::set_process_unhandled_input(bool p_enable) {
 	}
 
 	if (p_enable) {
-		add_to_group("_vp_unhandled_input" + itos(get_viewport()->get_instance_id()));
+		add_to_group(get_viewport()->get_unhandled_input_group_name());
 	} else {
-		remove_from_group("_vp_unhandled_input" + itos(get_viewport()->get_instance_id()));
+		remove_from_group(get_viewport()->get_unhandled_input_group_name());
 	}
 }
 
@@ -1318,9 +1318,9 @@ void Node::set_process_unhandled_key_input(bool p_enable) {
 	}
 
 	if (p_enable) {
-		add_to_group("_vp_unhandled_key_input" + itos(get_viewport()->get_instance_id()));
+		add_to_group(get_viewport()->get_unhandled_key_input_group_name());
 	} else {
-		remove_from_group("_vp_unhandled_key_input" + itos(get_viewport()->get_instance_id()));
+		remove_from_group(get_viewport()->get_unhandled_key_input_group_name());
 	}
 }
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -638,7 +638,7 @@ bool SceneTree::physics_process(double p_time) {
 	emit_signal(SNAME("physics_frame"));
 
 #if !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)
-	call_group(SNAME("_picking_viewports"), SNAME("_process_picking"));
+	call_group(Viewport::get_picking_viewports_group_name(), SNAME("_process_picking"));
 #endif // !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)
 
 	_process(true);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -591,7 +591,7 @@ void Viewport::_notification(int p_what) {
 			_update_audio_listener_3d();
 #endif // _3D_DISABLED
 
-			add_to_group("_viewports");
+			add_to_group(get_viewports_group_name());
 #if !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)
 			if (get_tree()->is_debugging_collisions_hint()) {
 #ifndef PHYSICS_2D_DISABLED
@@ -667,7 +667,7 @@ void Viewport::_notification(int p_what) {
 			}
 #endif // PHYSICS_3D_DISABLED
 
-			remove_from_group("_viewports");
+			remove_from_group(get_viewports_group_name());
 			set_physics_process_internal(false);
 
 			RS::get_singleton()->viewport_set_active(viewport, false);
@@ -2706,7 +2706,7 @@ void Viewport::_gui_control_grab_focus(Control *p_control, bool p_hide_focus) {
 		return;
 	}
 
-	get_tree()->call_group("_viewports", "_gui_remove_focus_for_window", get_base_window());
+	get_tree()->call_group(get_viewports_group_name(), "_gui_remove_focus_for_window", get_base_window());
 	if (p_control->is_inside_tree() && p_control->get_viewport() == this) {
 		gui.key_focus = p_control;
 		if (_can_hide_focus_state()) {
@@ -3610,11 +3610,11 @@ void Viewport::set_physics_object_picking(bool p_enable) {
 	ERR_MAIN_THREAD_GUARD;
 	physics_object_picking = p_enable;
 	if (physics_object_picking) {
-		add_to_group("_picking_viewports");
+		add_to_group(get_picking_viewports_group_name());
 	} else {
 		physics_picking_events.clear();
-		if (is_in_group("_picking_viewports")) {
-			remove_from_group("_picking_viewports");
+		if (is_in_group(get_picking_viewports_group_name())) {
+			remove_from_group(get_picking_viewports_group_name());
 		}
 	}
 }
@@ -4951,6 +4951,43 @@ void Viewport::_propagate_world_2d_changed(Node *p_node) {
 		_propagate_world_2d_changed(p_node->get_child(i));
 	}
 }
+
+StringName Viewport::get_viewports_group_name() {
+	return SNAME("_viewports");
+}
+
+StringName Viewport::get_picking_viewports_group_name() {
+	return SNAME("_picking_viewports");
+}
+
+StringName Viewport::get_input_group_name() {
+	return input_group;
+}
+StringName Viewport::get_shortcut_input_group_name() {
+	return shortcut_input_group;
+}
+
+StringName Viewport::get_unhandled_input_group_name() {
+	return unhandled_input_group;
+}
+
+StringName Viewport::get_unhandled_key_input_group_name() {
+	return unhandled_key_input_group;
+}
+
+#ifndef _3D_DISABLED
+StringName Viewport::get_world_environment_group_name() {
+	return "_world_environment_" + itos(find_world_3d()->get_scenario().get_id());
+}
+
+StringName Viewport::get_world_camera_attributes_group_name() {
+	return "_world_camera_attributes_" + itos(find_world_3d()->get_scenario().get_id());
+}
+
+StringName Viewport::get_world_compositor_group_name() {
+	return "_world_compositor_" + itos(find_world_3d()->get_scenario().get_id());
+}
+#endif // _3D_DISABLED
 
 void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_world_2d", "world_2d"), &Viewport::set_world_2d);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -516,6 +516,20 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:
+	static StringName get_viewports_group_name();
+	static StringName get_picking_viewports_group_name();
+
+	StringName get_input_group_name();
+	StringName get_shortcut_input_group_name();
+	StringName get_unhandled_input_group_name();
+	StringName get_unhandled_key_input_group_name();
+
+#ifndef _3D_DISABLED
+	StringName get_world_environment_group_name();
+	StringName get_world_camera_attributes_group_name();
+	StringName get_world_compositor_group_name();
+#endif // _3D_DISABLED
+
 	void canvas_parent_mark_dirty(Node *p_node);
 	void canvas_item_top_level_changed();
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2072,7 +2072,7 @@ void Window::_popup_base(const Rect2i &p_screen_rect) {
 		// Send a focus-out notification when opening a Window Manager Popup.
 		SceneTree *scene_tree = get_tree();
 		if (scene_tree) {
-			scene_tree->notify_group_flags(SceneTree::GROUP_CALL_DEFERRED, "_viewports", NOTIFICATION_WM_WINDOW_FOCUS_OUT);
+			scene_tree->notify_group_flags(SceneTree::GROUP_CALL_DEFERRED, get_viewports_group_name(), NOTIFICATION_WM_WINDOW_FOCUS_OUT);
 		}
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
Currently many usages of SceneTree node group name are hardcode like `"_vp_input" + itos(get_viewport()->get_instance_id())` string. This is not conducive to maintenance. This pr adds reasonable getter functions to solve this