### PR TITLE
Pick the sample closer to the camera when resolving 2x MSAA.

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/resolve.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/resolve.glsl
@@ -112,7 +112,7 @@ void main() {
 	}
 
 	if (params.sample_count == 2) {
-		best_index = (pos.x & 1) ^ ((pos.y >> 1) & 1); //not much can be done here
+		best_index = (group1.x < group1.y) ? 1 : 0; // Not much can be done here. Pick the sample closer to the camera.
 	} else if (params.sample_count == 4) {
 		vec4 freq = vec4(equal(group1, vec4(group1.x)));
 		freq += vec4(equal(group1, vec4(group1.y)));


### PR DESCRIPTION
Fixes #114999.

4x and 8x MSAA pick the sample with the highest amount of occurrences. Outside edges, this almost always ends up selecting the first MSAA sample. However, 2x MSAA picks the sample based on the pixel position using a strange pattern, which makes the surfaces look spiky:

<img width="891" height="661" alt="Screenshot_20260119_131725" src="https://github.com/user-attachments/assets/1151cd75-8689-4359-bd88-7dc9fc44b486" />

~~For consistency, we can always pick the first sample for 2x MSAA as well. This matches the other MSAA levels and prevents SSR's geometric normal computation from breaking:~~

<img width="890" height="660" alt="Screenshot_20260119_131832" src="https://github.com/user-attachments/assets/449dcd74-ec5a-4aa3-8b90-1cd10048fdad" />

(Picking the closer sample now, but that still works fine!)

---

I'm not sure how acceptable this is for 4.6 in RC stage. I don't think there's a way to make a self contained fix for SSR.