### PR TITLE
Clear fade-out on request firing in AnimationNodeOneShot

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -644,6 +644,9 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(const AnimationMixer:
 		set_parameter(request, ONE_SHOT_REQUEST_NONE);
 		set_parameter(internal_active, true);
 		set_parameter(active, true);
+		// Clear fade-out.
+		is_fading_out = false;
+		cur_fade_out_remaining = 0;
 	}
 
 	real_t blend = 1.0;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/115095

While changing the `if` block for fade-in/fade-out blending to `else if` would also solve issue #115095, but doing so causes an issue where fade-out is no longer prioritized when the fade-in/fade-out duration exceeds the animation length. Therefore, removing fade-out during the fire event should be the correct approach.