### PR TITLE
Fix favorite files handling

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -409,6 +409,8 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 	}
 	if (fav_changed) {
 		EditorSettings::get_singleton()->set_favorites(favorite_paths);
+		// Setting favorites causes the tree to update, so continuing is redundant.
+		return;
 	}
 
 	Ref<Texture2D> folder_icon = get_editor_theme_icon(SNAME("Folder"));
@@ -2479,7 +2481,6 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				}
 			}
 			EditorSettings::get_singleton()->set_favorites(favorites_list);
-			_update_tree(get_uncollapsed_paths());
 		} break;
 
 		case FILE_MENU_REMOVE_FAVORITE: {
@@ -2489,10 +2490,6 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				favorites_list.erase(p_selected[i]);
 			}
 			EditorSettings::get_singleton()->set_favorites(favorites_list);
-			_update_tree(get_uncollapsed_paths());
-			if (current_path == "Favorites") {
-				_update_file_list(true);
-			}
 		} break;
 
 		case FILE_MENU_SHOW_IN_FILESYSTEM: {
@@ -4553,6 +4550,7 @@ FileSystemDock::FileSystemDock() {
 	file_list_display_mode = FILE_LIST_DISPLAY_THUMBNAILS;
 
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &FileSystemDock::_project_settings_changed));
+	EditorSettings::get_singleton()->connect("_favorites_changed", callable_mp(this, &FileSystemDock::update_all));
 	main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
 
 	add_resource_tooltip_plugin(memnew(EditorTextureTooltipPlugin));

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -275,6 +275,7 @@ private:
 	void _update_tree(const Vector<String> &p_uncollapsed_paths = Vector<String>(), bool p_uncollapse_root = false, bool p_scroll_to_selected = true);
 	void _navigate_to_path(const String &p_path, bool p_select_in_favorites = false, bool p_grab_focus = false);
 	bool _update_filtered_items(TreeItem *p_tree_item = nullptr);
+	void _append_favorite_items();
 
 	void _file_list_gui_input(Ref<InputEvent> p_event);
 	void _tree_gui_input(Ref<InputEvent> p_event);

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -180,6 +180,7 @@ public:
 	void set_favorites(const Vector<String> &p_favorites, bool p_update_file_dialog = true);
 	void set_favorites_bind(const Vector<String> &p_favorites);
 	Vector<String> get_favorites() const;
+	Vector<String> get_favorite_folders() const;
 	void set_favorite_properties(const HashMap<String, PackedStringArray> &p_favorite_properties);
 	HashMap<String, PackedStringArray> get_favorite_properties() const;
 	void set_recent_dirs(const Vector<String> &p_recent_dirs, bool p_update_file_dialog = true);

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -110,6 +110,11 @@ void FileDialog::_popup_base(const Rect2i &p_screen_rect) {
 	}
 }
 
+void FileDialog::_clear_changed_status() {
+	favorites_changed = false;
+	recents_changed = false;
+}
+
 void FileDialog::set_visible(bool p_visible) {
 	if (p_visible) {
 		_update_option_controls();
@@ -258,6 +263,8 @@ void FileDialog::_notification(int p_what) {
 				_update_favorite_list();
 				_update_recent_list();
 				invalidate(); // Put it here to preview in the editor.
+			} else {
+				callable_mp(this, &FileDialog::_clear_changed_status).call_deferred();
 			}
 		} break;
 
@@ -1680,6 +1687,7 @@ void FileDialog::_favorite_pressed() {
 	} else {
 		global_favorites.push_back(directory);
 	}
+	favorites_changed = true;
 	_update_favorite_list();
 }
 
@@ -1696,6 +1704,7 @@ void FileDialog::_favorite_move_up() {
 		return;
 	}
 	SWAP(global_favorites[a_idx], global_favorites[b_idx]);
+	favorites_changed = true;
 	_update_favorite_list();
 }
 
@@ -1712,6 +1721,7 @@ void FileDialog::_favorite_move_down() {
 		return;
 	}
 	SWAP(global_favorites[a_idx], global_favorites[b_idx]);
+	favorites_changed = true;
 	_update_favorite_list();
 }
 
@@ -1811,6 +1821,7 @@ void FileDialog::_save_to_recent() {
 		}
 	}
 	global_recents.insert(0, directory);
+	recents_changed = true;
 
 	_update_recent_list();
 }

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -366,6 +366,9 @@ private:
 protected:
 	Ref<DirAccess> dir_access;
 
+	bool favorites_changed = false;
+	bool recents_changed = false;
+
 	bool _can_use_native_popup() const;
 	virtual void _item_menu_id_pressed(int p_option);
 	virtual void _dir_contents_changed() {}
@@ -375,6 +378,7 @@ protected:
 	virtual Color _get_folder_color(const String &p_path) const { return theme_cache.folder_icon_color; }
 
 	virtual void _popup_base(const Rect2i &p_screen_rect = Rect2i()) override;
+	void _clear_changed_status();
 
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);


### PR DESCRIPTION
Fixes the recent issues mentioned in #98065 They are regressions from FileDialog changes.

- When passing favorites to FileDialog, file paths are filtered out. This prevents converting them to folders.
- When EditorFileDialog is closed, it will now properly merge its favorite list with the list stored in settings (previously it would erase all files).
  - This required some ungodly amount of array operations, so EditorFileDialog will now send favorites only when they are actually changed by the dialog.
- When favorites are changed by EditorFileDialog, FileSystem dock will properly sync the list.
  - This one is actually not a regression, but it makes the above fixes easier to verify.