### PR TITLE
Fix crash in LineEdit when theme font is missing

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2446,6 +2446,10 @@ Size2 LineEdit::get_minimum_size() const {
 
 	Size2 min_size;
 
+	if (font.is_null()) {
+		return Size2();
+	}
+
 	// Minimum size of text.
 	// W is wider than M in most fonts, Using M may result in hiding the last digit when using float values in SpinBox, ie. ColorPicker RAW values.
 	float em_space_size = font->get_char_size('W', font_size).x;


### PR DESCRIPTION
## Issue description
Godot crashes when opening a scene that contains a LineEdit control with a missing/deleted font resource from its theme.

### Steps to reproduce
1. Create a scene with a LineEdit control
2. Assign a custom font resource to the LineEdit's theme
3. Save the scene
4. Delete the font resource file from the filesystem
5. Restart the editor and attempt to open the scene again
6. **Result**: Editor crashes

### Crash details
The crash occurs in `LineEdit::get_minimum_size()` when dereferencing a null font pointer:

```
[0] LineEdit::get_minimum_size (scene/gui/line_edit.cpp:2451)
...
[23] EditorNode::set_edited_scene_root (editor/editor_node.cpp:4464)
[24] EditorNode::set_edited_scene (editor/editor_node.cpp:4443)
[25] EditorNode::load_scene (editor/editor_node.cpp:4803)
```

## Root cause
In `LineEdit::get_minimum_size()`, the code directly accesses the font from theme cache without null validation:

```cpp
float em_space_size = font->get_char_size('W', font_size).x; // Crash if font is null
```

When a font resource is missing, `theme_cache.font` is null, causing a null pointer dereference.

## Solution
Add a defensive null check at the beginning of the function. If the font is missing, return a safe default minimum size:

```cpp
if (font.is_null()) {
    return Size2(); // Return zero size if font is missing
}
```

This follows the same defensive pattern used in other UI controls and prevents the crash while allowing the editor to gracefully handle missing resources.

## Testing
- Reproduced the original crash by deleting a dependent font resource
- Applied the fix and verified the editor no longer crashes when opening the scene