### PR TITLE
Fix FileDialog inconsistent OK button state by keeping it always enabled

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -535,26 +535,6 @@ void FileDialog::_cancel_pressed() {
 	hide();
 }
 
-bool FileDialog::_is_open_should_be_disabled() {
-	if (mode == FILE_MODE_OPEN_ANY || mode == FILE_MODE_SAVE_FILE) {
-		return false;
-	}
-
-	Vector<int> items = file_list->get_selected_items();
-	if (items.is_empty()) {
-		return mode != FILE_MODE_OPEN_DIR; // In "Open folder" mode, having nothing selected picks the current folder.
-	}
-
-	for (const int idx : items) {
-		Dictionary d = file_list->get_item_metadata(idx);
-
-		if (((mode == FILE_MODE_OPEN_FILE || mode == FILE_MODE_OPEN_FILES) && d["dir"]) || (mode == FILE_MODE_OPEN_DIR && !d["dir"])) {
-			return true;
-		}
-	}
-	return false;
-}
-
 void FileDialog::_go_up() {
 	_change_dir(get_current_dir().trim_suffix("/").get_base_dir());
 	_push_history();
@@ -589,7 +569,7 @@ void FileDialog::deselect_all() {
 	file_list->deselect_all();
 
 	// And change get_ok title.
-	get_ok_button()->set_disabled(_is_open_should_be_disabled());
+	get_ok_button()->set_disabled(false);
 
 	switch (mode) {
 		case FILE_MODE_OPEN_FILE:
@@ -622,7 +602,7 @@ void FileDialog::_file_list_multi_selected(int p_item, bool p_selected) {
 	if (p_selected) {
 		_file_list_selected(p_item);
 	} else {
-		get_ok_button()->set_disabled(_is_open_should_be_disabled());
+		get_ok_button()->set_disabled(false);
 	}
 }
 
@@ -643,7 +623,7 @@ void FileDialog::_file_list_selected(int p_item) {
 		}
 	}
 
-	get_ok_button()->set_disabled(_is_open_should_be_disabled());
+	get_ok_button()->set_disabled(false);
 }
 
 void FileDialog::_file_list_item_activated(int p_item) {
@@ -1394,7 +1374,7 @@ void FileDialog::set_file_mode(FileMode p_mode) {
 		file_list->set_select_mode(ItemList::SELECT_SINGLE);
 	}
 
-	get_ok_button()->set_disabled(_is_open_should_be_disabled());
+	get_ok_button()->set_disabled(false);
 }
 
 FileDialog::FileMode FileDialog::get_file_mode() const {

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -353,7 +353,6 @@ private:
 	void _native_dialog_cb(bool p_ok, const Vector<String> &p_files, int p_filter);
 	void _native_dialog_cb_with_options(bool p_ok, const Vector<String> &p_files, int p_filter, const Dictionary &p_selected_options);
 
-	bool _is_open_should_be_disabled();
 	void _thumbnail_callback(const Ref<Texture2D> &p_texture, const String &p_path);
 
 	TypedArray<Dictionary> _get_options() const;


### PR DESCRIPTION
Fixes #115106
This PR fixes several inconsistent and confusing states in FileDialog where the OK button (Open/Save) could be disabled even when the dialog could be accepted, or enabled when acceptance was not possible.

This resulted in contradictory situations such as:

- OK button disabled while Enter still accepts
- OK button enabled but clicking it does nothing
- No file selected but a valid path in the text field: Enter works, OK disabled

To resolve this, the OK button is now always enabled, matching the behavior of native file dialogs on Windows, macOS, and Linux.
**All validation continues to be handled in _action_pressed(), exactly as before.**

This makes the dialog consistent, predictable, and easier to use.

Why this change:

- Eliminates inconsistent UI states
- Aligns with native dialog UX
- Prevents regressions caused by mismatched validation paths
- Keeps all acceptance logic intact and unchanged

What was changed:
- Removed calls to _is_open_should_be_disabled()
- Replaced them with get_ok_button()->set_disabled(false)
- _is_open_should_be_disabled() is no longer used

Testing:  
Tested manually on Windows 11 with Godot 4.6 RC:

1. Open File
2. Open Files
3. Open Folder
4. Save File
5. Manual path entry
6. Invalid paths
7. Hidden files

All behaviors are consistent and no regressions were found.