### PR TITLE
Add Always-on-Top option to the floating Script Editor to improve multi-window workflows.

### DIFF
--- a/editor/gui/window_wrapper.cpp
+++ b/editor/gui/window_wrapper.cpp
@@ -211,6 +211,14 @@ void WindowWrapper::set_window_enabled(bool p_enabled) {
 	_set_window_enabled_with_rect(p_enabled, _get_default_window_rect());
 }
 
+void WindowWrapper::set_always_on_top(bool p_enabled) { // TODO: Saulo
+	window->set_flag(Window::FLAG_ALWAYS_ON_TOP, p_enabled);
+}
+
+bool WindowWrapper::is_always_on_top() const { // TODO: Saulo
+	return window->get_flag(Window::FLAG_ALWAYS_ON_TOP);
+}
+
 Rect2i WindowWrapper::get_window_rect() const {
 	ERR_FAIL_COND_V(!get_window_enabled(), Rect2i());
 	return Rect2i(window->get_position(), window->get_size());

--- a/editor/gui/window_wrapper.h
+++ b/editor/gui/window_wrapper.h
@@ -90,6 +90,9 @@ public:
 
 	void set_override_close_request(bool p_enabled);
 
+	void set_always_on_top(bool p_enabled);
+	bool is_always_on_top() const;
+
 	WindowWrapper();
 	~WindowWrapper();
 };

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1213,6 +1213,12 @@ bool ScriptEditor::_test_script_times_on_disk(Ref<Resource> p_for_script) {
 	return need_reload;
 }
 
+void ScriptEditor::_toggle_always_on_top() { // TODO: Saulo
+	print_line("saulo priscilla");
+	bool enabled = !window_wrapper->is_always_on_top();
+	window_wrapper->set_always_on_top(enabled);
+}
+
 void _import_text_editor_theme(const String &p_file) {
 	if (p_file.get_extension() != "tet") {
 		EditorToaster::get_singleton()->popup_str(TTR("Importing theme failed. File is not a text editor theme file (.tet)."), EditorToaster::SEVERITY_ERROR);
@@ -4472,6 +4478,12 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	script_name_button_right_spacer = memnew(Control);
 	script_name_button_right_spacer->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	script_name_button_hbox->add_child(script_name_button_right_spacer);
+
+	// TODO: Saulo
+	Button *btn = memnew(Button);
+	btn->set_text("Always On Top");
+	btn->connect("button_down", callable_mp(this, &ScriptEditor::_toggle_always_on_top));
+	menu_hb->add_child(btn);
 
 	site_search = memnew(Button);
 	site_search->set_theme_type_variation(SceneStringName(FlatButton));

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -567,6 +567,8 @@ class ScriptEditor : public PanelContainer {
 	static void _open_script_request(const String &p_path);
 	void _close_builtin_scripts_from_scene(const String &p_scene);
 
+	void _toggle_always_on_top(); // TODO: Saulo
+
 	static ScriptEditor *script_editor;
 
 protected:


### PR DESCRIPTION
When using the Script Editor in floating mode, it is common to switch frequently between the editor and other applications or editor windows.
An Always-on-Top toggle allows the floating Script Editor to remain visible and accessible, reducing window switching and improving focus during scripting.

Watch the video: https://youtu.be/w7ngFGZt4RU


<img width="1245" height="520" alt="1" src="https://github.com/user-attachments/assets/b82703cb-fec7-4ce1-bea8-7ee5f37f7985" />

<img width="1687" height="1017" alt="2" src="https://github.com/user-attachments/assets/504ba64b-9db9-4f78-9aa8-0a5cc980aa07" />

<img width="666" height="545" alt="3" src="https://github.com/user-attachments/assets/b81fa3c4-b1b7-487c-a36f-10f036650481" />


