### PR TITLE
Fix EditorFileDialog icon scale in list mode

### DIFF
--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -32,8 +32,10 @@
 
 #include "core/config/project_settings.h"
 #include "editor/docks/filesystem_dock.h"
+#include "editor/editor_string_names.h"
 #include "editor/file_system/dependency_editor.h"
 #include "editor/settings/editor_settings.h"
+#include "editor/themes/editor_scale.h"
 
 void EditorFileDialog::_item_menu_id_pressed(int p_option) {
 	// Use dependency dialog to delete the entry in the editor, but only for project files.
@@ -80,6 +82,10 @@ bool EditorFileDialog::_should_hide_file(const String &p_file) const {
 
 Color EditorFileDialog::_get_folder_color(const String &p_path) const {
 	return FileSystemDock::get_dir_icon_color(p_path, FileDialog::_get_folder_color(p_path));
+}
+
+Vector2i EditorFileDialog::_get_list_mode_icon_size() const {
+	return Vector2i(1, 1) * Math::round(get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)) * EDSCALE);
 }
 
 void EditorFileDialog::_bind_methods() {

--- a/editor/gui/editor_file_dialog.h
+++ b/editor/gui/editor_file_dialog.h
@@ -46,6 +46,7 @@ protected:
 	virtual bool _should_use_native_popup() const override;
 	virtual bool _should_hide_file(const String &p_file) const override;
 	virtual Color _get_folder_color(const String &p_path) const override;
+	virtual Vector2i _get_list_mode_icon_size() const override;
 
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -95,6 +95,10 @@ bool FileDialog::_can_use_native_popup() const {
 	return DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_DIALOG_FILE);
 }
 
+Vector2i FileDialog::_get_list_mode_icon_size() const {
+	return theme_cache.file->get_size();
+}
+
 void FileDialog::_popup_base(const Rect2i &p_screen_rect) {
 #ifdef TOOLS_ENABLED
 	if (is_part_of_edited_scene()) {
@@ -825,7 +829,7 @@ void FileDialog::update_file_list() {
 		file_list->set_max_columns(1);
 		file_list->set_max_text_lines(1);
 		file_list->set_fixed_column_width(0);
-		file_list->set_fixed_icon_size(theme_cache.file->get_size());
+		file_list->set_fixed_icon_size(_get_list_mode_icon_size());
 	}
 
 	dir_access->list_dir_begin();

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -376,6 +376,7 @@ protected:
 	virtual bool _should_use_native_popup() const;
 	virtual bool _should_hide_file(const String &p_file) const { return false; }
 	virtual Color _get_folder_color(const String &p_path) const { return theme_cache.folder_icon_color; }
+	virtual Vector2i _get_list_mode_icon_size() const;
 
 	virtual void _popup_base(const Rect2i &p_screen_rect = Rect2i()) override;
 	void _clear_changed_status();


### PR DESCRIPTION
Fixes #115068

Although not sure why `theme_cache.file->get_size()` would return wrong size. The favorites/recent lists, that don't have the bug, don't have any scaling applied either, so I think the editor icons are pre-scaled based on editor scale, no?