### PR TITLE
Android: Fix XR build regression when vendor plugin overrides the same feature

### DIFF
--- a/modules/openxr/editor/openxr_editor_plugin.cpp
+++ b/modules/openxr/editor/openxr_editor_plugin.cpp
@@ -122,9 +122,22 @@ String OpenXRExportPlugin::get_android_manifest_element_contents(const Ref<Edito
         </intent>
 
     </queries>
-
-    <uses-feature android:name="android.hardware.vr.headtracking" android:required="false" android:version="1" />
 )n";
+
+#ifndef DISABLE_DEPRECATED
+	// This logic addresses the issue from https://github.com/GodotVR/godot_openxr_vendors/issues/429.
+	// The issue is caused by this plugin and the vendors plugin adding the same `uses-feature` tag to the generated
+	// manifest, causing a duplicate error at build time.
+	// In order to maintain backward compatibility, we fix the issue by disabling the addition of the `uses-feature`
+	// tag from this plugin when specific conditions are met.
+	bool meta_plugin_enabled = get_option("xr_features/enable_meta_plugin");
+	int meta_boundary_mode = get_option("meta_xr_features/boundary_mode");
+	if (!meta_plugin_enabled || meta_boundary_mode != 1 /* BOUNDARY_DISABLED_VALUE */) {
+#endif // DISABLE_DEPRECATED
+		contents += "    <uses-feature android:name=\"android.hardware.vr.headtracking\" android:required=\"false\" android:version=\"1\" />\n";
+#ifndef DISABLE_DEPRECATED
+	}
+#endif // DISABLE_DEPRECATED
 
 	return contents;
 }

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1037,8 +1037,11 @@ void EditorExportPlatformAndroid::_write_tmp_manifest(const Ref<EditorExportPres
 		if (export_plugins[i]->supports_platform(Ref<EditorExportPlatform>(this))) {
 			const String contents = export_plugins[i]->get_android_manifest_element_contents(Ref<EditorExportPlatform>(this), p_debug);
 			if (!contents.is_empty()) {
+				const String export_plugin_name = export_plugins[i]->get_name();
+				manifest_text += "<!-- Start of manifest element contents from " + export_plugin_name + " -->\n";
 				manifest_text += contents;
 				manifest_text += "\n";
+				manifest_text += "<!-- End of manifest element contents from " + export_plugin_name + " -->\n";
 			}
 		}
 	}

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -291,8 +291,11 @@ String _get_activity_tag(const Ref<EditorExportPlatform> &p_export_platform, con
 		if (export_plugins[i]->supports_platform(p_export_platform)) {
 			const String contents = export_plugins[i]->get_android_manifest_activity_element_contents(p_export_platform, p_debug);
 			if (!contents.is_empty()) {
+				const String export_plugin_name = export_plugins[i]->get_name();
+				export_plugins_activity_element_contents += "<!-- Start of manifest activity element contents from " + export_plugin_name + " -->\n";
 				export_plugins_activity_element_contents += contents;
 				export_plugins_activity_element_contents += "\n";
+				export_plugins_activity_element_contents += "<!-- End of manifest activity element contents from " + export_plugin_name + " -->\n";
 			}
 		}
 	}
@@ -387,8 +390,11 @@ String _get_application_tag(const Ref<EditorExportPlatform> &p_export_platform, 
 		if (export_plugins[i]->supports_platform(p_export_platform)) {
 			const String contents = export_plugins[i]->get_android_manifest_application_element_contents(p_export_platform, p_debug);
 			if (!contents.is_empty()) {
+				const String export_plugin_name = export_plugins[i]->get_name();
+				manifest_application_text += "<!-- Start of manifest application element contents from " + export_plugin_name + " -->\n";
 				manifest_application_text += contents;
 				manifest_application_text += "\n";
+				manifest_application_text += "<!-- End of manifest application element contents from " + export_plugin_name + " -->\n";
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/GodotVR/godot_openxr_vendors/issues/429

The issue is caused by the `OpenXRExportPlugin` plugin and the `GodotOpenXR` plugin adding the same `uses-feature` tag to the generated manifest, causing a duplicate error at build time.
	 In order to maintain backward compatibility, we fix the issue by disabling the addition of the `uses-feature`
	 tag from the `OpenXRExportPlugin` plugin when specific conditions are met.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
