### PR TITLE
Fix theme properties not being handled correctly by `MultiNodeEdit`

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -233,8 +233,27 @@ EditorDebuggerRemoteObjects *EditorDebuggerInspector::set_objects(const Array &p
 				usage[pinfo.name] = usage_dt;
 			}
 
-			// Make sure only properties with the same exact PropertyInfo data will appear.
-			if (usage[pinfo.name].prop.first == pinfo) {
+			// Make sure only properties with matching PropertyInfo data will appear.
+			if (usage[pinfo.name].prop.first.name == pinfo.name &&
+					usage[pinfo.name].prop.first.type == pinfo.type &&
+					usage[pinfo.name].prop.first.class_name == pinfo.class_name &&
+					usage[pinfo.name].prop.first.hint == pinfo.hint &&
+					usage[pinfo.name].prop.first.hint_string == pinfo.hint_string) {
+				if (usage[pinfo.name].prop.first.usage != pinfo.usage) {
+					// Checkable properties (mostly theme items) need special treatment.
+					if (usage[pinfo.name].prop.first.usage & PROPERTY_USAGE_CHECKABLE && pinfo.usage & PROPERTY_USAGE_CHECKABLE) {
+						if (usage[pinfo.name].prop.first.usage & PROPERTY_USAGE_CHECKED) {
+							pinfo.usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
+						} else {
+							pinfo.usage &= ~(PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED);
+						}
+
+						if (usage[pinfo.name].prop.first.usage != pinfo.usage) {
+							continue;
+						}
+					}
+				}
+
 				usage[pinfo.name].qty++;
 				usage[pinfo.name].values[obj.id] = prop.second;
 			}

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -787,7 +787,17 @@ StringName EditorProperty::get_edited_property() const {
 
 Variant EditorProperty::get_edited_property_display_value() const {
 	ERR_FAIL_NULL_V(object, Variant());
+
 	Control *control = Object::cast_to<Control>(object);
+	if (!control) {
+		MultiNodeEdit *multi = Object::cast_to<MultiNodeEdit>(object);
+		if (multi) {
+			Node *root = EditorNode::get_singleton()->get_edited_scene();
+			NodePath np = multi->get_node(0);
+			control = Object::cast_to<Control>(root->get_node_or_null(np));
+		}
+	}
+
 	// If checked but it's empty, it means that the set value has just been undone, and should show the default value as well.
 	if (control && checkable && (!checked || get_edited_property_value() == Variant()) && String(property).begins_with("theme_override_")) {
 		return control->get_used_theme_item(property);

--- a/editor/inspector/multi_node_edit.cpp
+++ b/editor/inspector/multi_node_edit.cpp
@@ -189,8 +189,27 @@ void MultiNodeEdit::_get_property_list(List<PropertyInfo> *p_list) const {
 				data_list.push_back(usage_data);
 			}
 
-			// Make sure only properties with the same exact PropertyInfo data will appear.
-			if (usage_data->info == F) {
+			// Make sure only properties with matching PropertyInfo data will appear.
+			if (usage_data->info.name == F.name &&
+					usage_data->info.type == F.type &&
+					usage_data->info.class_name == F.class_name &&
+					usage_data->info.hint == F.hint &&
+					usage_data->info.hint_string == F.hint_string) {
+				if (usage_data->info.usage != F.usage) {
+					// Checkable properties (mostly theme items) need special treatment.
+					if (usage_data->info.usage & PROPERTY_USAGE_CHECKABLE && F.usage & PROPERTY_USAGE_CHECKABLE) {
+						if (usage_data->info.usage & PROPERTY_USAGE_CHECKED) {
+							F.usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
+						} else {
+							F.usage &= ~(PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED);
+						}
+
+						if (usage_data->info.usage != F.usage) {
+							continue;
+						}
+					}
+				}
+
 				usage_data->uses++;
 			}
 		}


### PR DESCRIPTION
- Fix default values not appearing (fixes #115057).
- Fix properties sometimes not appearing if some are overridden and others don't.