### PR TITLE
Increase precision of ninepatch source rect to ensure pixel perfect alignment

### DIFF
--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1840,7 +1840,7 @@ RendererCanvasRenderRD::RendererCanvasRenderRD() {
 		actions.base_uniform_string = "material.";
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR;
 		actions.default_repeat = ShaderLanguage::REPEAT_DISABLE;
-		actions.base_varying_index = 8;
+		actions.base_varying_index = 9;
 
 		actions.global_buffer_array_variable = "global_shader_uniforms.data";
 		actions.instance_uniform_index_variable = "read_draw_data_instance_offset";

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -36,7 +36,8 @@ layout(location = 4) out flat uvec4 varying_C;
 #ifdef USE_NINEPATCH
 layout(location = 5) out flat vec4 varying_D;
 layout(location = 6) out flat vec4 varying_E;
-layout(location = 7) out vec2 pixel_size_interp;
+layout(location = 7) out flat vec4 varying_F;
+layout(location = 8) out vec2 pixel_size_interp;
 #endif // USE_NINEPATCH
 #endif // !USE_ATTRIBUTES
 
@@ -131,6 +132,7 @@ void main() {
 #ifdef USE_NINEPATCH
 	varying_D = read_draw_data_ninepatch_margins;
 	varying_E = vec4(read_draw_data_dst_rect.z, read_draw_data_dst_rect.w, read_draw_data_ninepatch_pixel_size.x, read_draw_data_ninepatch_pixel_size.y);
+	varying_F = read_draw_data_src_rect;
 #endif // USE_NINEPATCH
 #endif // !USE_ATTRIBUTES
 
@@ -339,11 +341,14 @@ layout(location = 4) in flat uvec4 varying_C;
 #ifdef USE_NINEPATCH
 layout(location = 5) in flat vec4 varying_D;
 layout(location = 6) in flat vec4 varying_E;
-layout(location = 7) in vec2 pixel_size_interp;
+layout(location = 7) in flat vec4 varying_F;
+layout(location = 8) in vec2 pixel_size_interp;
 #define read_draw_data_ninepatch_margins varying_D
 #define read_draw_data_dst_rect_z varying_E.x
 #define read_draw_data_dst_rect_w varying_E.y
 #define read_draw_data_ninepatch_pixel_size (varying_E.zw)
+#define read_draw_data_src_rect_ninepatch (varying_F);
+
 #endif // USE_NINEPATCH
 
 #endif // USE_ATTRIBUTES
@@ -586,7 +591,9 @@ void main() {
 		color.a = 0.0;
 	}
 
-	uv = uv * src_rect.zw + src_rect.xy; //apply region if needed
+	vec4 ninepatch_src_rect = read_draw_data_src_rect_ninepatch;
+
+	uv = uv * ninepatch_src_rect.zw + ninepatch_src_rect.xy; //apply region if needed
 
 #endif
 	if (bool(read_draw_data_flags & INSTANCE_FLAGS_CLIP_RECT_UV)) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/115117

In https://github.com/godotengine/godot/pull/112481 the `src_rect` was compressed into 4 half floats. But, as it turns out, ninepatch is really sensitive to precision, even at normal range numers which leads to small misalignment artifacts. 

Since passing another varying has a very real cost, this code path is limited to ninepatches
