### PR TITLE
Delegate `Script::reload_from_file` to `ScriptLanguage`

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -189,27 +189,12 @@ void Script::_bind_methods() {
 
 void Script::reload_from_file() {
 #ifdef TOOLS_ENABLED
-	// Replicates how the ScriptEditor reloads script resources, which generally handles it.
-	// However, when scripts are to be reloaded but aren't open in the internal editor, we go through here instead.
-	const Ref<Script> rel = ResourceLoader::load(ResourceLoader::path_remap(get_path()), get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
-	if (rel.is_null()) {
-		return;
+	if (Engine::get_singleton()->is_editor_hint() && is_tool()) {
+		get_language()->reload_tool_script(this, true);
+	} else {
+		Array scripts = { this };
+		get_language()->reload_scripts(scripts, true);
 	}
-
-	set_source_code(rel->get_source_code());
-	set_last_modified_time(rel->get_last_modified_time());
-
-	// Only reload the script when there are no compilation errors to prevent printing the error messages twice.
-	if (rel->is_valid()) {
-		if (Engine::get_singleton()->is_editor_hint() && is_tool()) {
-			get_language()->reload_tool_script(this, true);
-		} else {
-			// It's important to set p_keep_state to true in order to manage reloading scripts
-			// that are currently instantiated.
-			reload(true);
-		}
-	}
-
 #else
 	Resource::reload_from_file();
 #endif

--- a/doc/classes/ScriptLanguageExtension.xml
+++ b/doc/classes/ScriptLanguageExtension.xml
@@ -319,6 +319,7 @@
 			<param index="0" name="scripts" type="Array" />
 			<param index="1" name="soft_reload" type="bool" />
 			<description>
+				Reloads all [param scripts] from disk and the specifics of how that happens is [ScriptLanguageExtension] specific.
 			</description>
 		</method>
 		<method name="_reload_tool_script" qualifiers="virtual required">
@@ -326,6 +327,7 @@
 			<param index="0" name="script" type="Script" />
 			<param index="1" name="soft_reload" type="bool" />
 			<description>
+				Reloads the given [param script] from disk and the specifics of how that happens is [ScriptLanguageExtension] specific.
 			</description>
 		</method>
 		<method name="_remove_named_global_constant" qualifiers="virtual required">


### PR DESCRIPTION
When a `ScriptLanguage` supports documentation, the `EditorFileSystem` will call `Script::reload_from_file` to reload the source code automatically. The problem is that the default behavior of `Script::reload_from_file` assumes the script's source is text-based. While this works for GDScript and C #, it will not work for any language that uses non-text-based storage.

One way to circumvent the issue here is to allow a `ScriptExtension` to override the default behavior of the `reload_from_file` method, enabling the implementation to use language-specific methods to read and set the source code.

The other alternative is to switch `set_source_code` and `get_source_code` to use `Variant`, which I felt was a bit more invasive, but is certainly an alternative to consider if the Godot team would prefer. I would say this change would make far more sense if it also included exposing a way for third-party plugins to register `ScriptEditor`(s), but this is currently something that is only exposed on the engine side.

This PR for now approaches this from the least invasive first option.

