### PR TITLE
Take custom type of parent scripts into account when dropping onready variables

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -2442,14 +2442,13 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 
 				String variable_name = String(node->get_name()).to_snake_case().validate_unicode_identifier();
 				if (use_type) {
-					StringName class_name = node->get_class_name();
+					StringName custom_class_name;
 					Ref<Script> node_script = node->get_script();
-					if (node_script.is_valid()) {
-						StringName global_node_script_name = node_script->get_global_name();
-						if (!global_node_script_name.is_empty()) {
-							class_name = global_node_script_name;
-						}
+					while (node_script.is_valid() && custom_class_name.is_empty()) {
+						custom_class_name = node_script->get_global_name();
+						node_script = node_script->get_base_script();
 					}
+					const StringName class_name = custom_class_name.is_empty() ? node->get_class_name() : custom_class_name;
 					text_to_drop += vformat("@onready var %s: %s = %c%s", variable_name, class_name, is_unique ? '%' : '$', path);
 				} else {
 					text_to_drop += vformat("@onready var %s = %c%s", variable_name, is_unique ? '%' : '$', path);


### PR DESCRIPTION
Dropping onready variables currently only takes the script's `class_name` into account. The parent's `class_name` was not used.

For example, in the screenshot below, the child node `RC` means it uses a regular script that extends a custom type, and `RRC` means it uses a regular script that extends another regular script that extends a custom type, etc.

<img width="271" height="217" alt="image" src="https://github.com/user-attachments/assets/4cd33744-6c86-4da3-85f5-959727ac2340" />

Drag & drop them before this PR creates:

```gdscript
@onready var node_2d: Node2D = $Node2D
@onready var c: CustomNode2D = $C
@onready var rc: Node2D = $RC
@onready var r: Node2D = $R
@onready var rr: Node2D = $RR
@onready var rrc: Node2D = $RRC
```

Drag & drop them after this PR creates:

```gdscript
@onready var node_2d: Node2D = $Node2D
@onready var c: CustomNode2D = $C
@onready var rc: CustomNode2D = $RC
@onready var r: Node2D = $R
@onready var rr: Node2D = $RR
@onready var rrc: CustomNode2D = $RRC
```

Test project: [test-4.zip](https://github.com/user-attachments/files/24726736/test-4.zip)
