### PR TITLE
Fix `pitch_scale` support in AudioStreamPlaylist playback

### DIFF
--- a/modules/interactive_music/audio_stream_playlist.cpp
+++ b/modules/interactive_music/audio_stream_playlist.cpp
@@ -262,6 +262,7 @@ int AudioStreamPlaybackPlaylist::mix(AudioFrame *p_buffer, float p_rate_scale, i
 	}
 
 	double time_dec = (1.0 / AudioServer::get_singleton()->get_mix_rate());
+	const double effective_time_dec = time_dec * p_rate_scale;
 	double fade_dec = (1.0 / playlist->fade_time) / AudioServer::get_singleton()->get_mix_rate();
 
 	int todo = p_frames;
@@ -269,16 +270,17 @@ int AudioStreamPlaybackPlaylist::mix(AudioFrame *p_buffer, float p_rate_scale, i
 	while (todo) {
 		int to_mix = MIN(todo, MIX_BUFFER_SIZE);
 
-		playback[play_order[play_index]]->mix(mix_buffer, 1.0, to_mix);
+		playback[play_order[play_index]]->mix(mix_buffer, p_rate_scale, to_mix);
 		if (fade_index != -1) {
-			playback[fade_index]->mix(fade_buffer, 1.0, to_mix);
+			playback[fade_index]->mix(fade_buffer, p_rate_scale, to_mix);
 		}
 
-		offset += time_dec * to_mix;
+		offset += effective_time_dec * to_mix;
 
 		for (int i = 0; i < to_mix; i++) {
 			*p_buffer = mix_buffer[i];
-			stream_todo -= time_dec;
+			stream_todo -= effective_time_dec;
+
 			if (stream_todo < 0) {
 				//find next stream.
 				int prev = play_order[play_index];
@@ -337,7 +339,7 @@ int AudioStreamPlaybackPlaylist::mix(AudioFrame *p_buffer, float p_rate_scale, i
 
 				if (restart) {
 					playback[idx]->start(0); // No loop, just cold-restart.
-					playback[idx]->mix(mix_buffer + i, 1.0, to_mix - i); // Fill rest of mix buffer
+					playback[idx]->mix(mix_buffer + i, p_rate_scale, to_mix - i); // Fill rest of mix buffer
 				}
 
 				// Update fade todo.


### PR DESCRIPTION
**AudioStreamPlaybackPlaylist** was ignoring the pitch_scale passed to mix(), always mixing child streams at **1.0** and advancing time at a **fixed rate**.

This caused **incorrect timing** and gaps when pitch_scale different from 1.0.

This change makes playback time and mixing respect p_rate_scale.

Watch the video: https://www.youtube.com/watch?v=ZcWprMLs7Kk