### PR TITLE
Fix hidden `Import` tab height

### DIFF
--- a/editor/docks/import_dock.cpp
+++ b/editor/docks/import_dock.cpp
@@ -828,7 +828,8 @@ ImportDock::ImportDock() {
 	select_a_resource->set_focus_mode(FOCUS_ACCESSIBILITY);
 	select_a_resource->set_text(TTRC("Select a resource file in the filesystem or in the inspector to adjust import settings."));
 	select_a_resource->set_autowrap_mode(TextServer::AUTOWRAP_WORD);
-	select_a_resource->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+	select_a_resource->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_WORD_ELLIPSIS);
+	select_a_resource->set_custom_minimum_size(Size2(120, 80) * EDSCALE);
 	select_a_resource->set_v_size_flags(SIZE_EXPAND_FILL);
 	select_a_resource->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	select_a_resource->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);


### PR DESCRIPTION
- Fixes part of https://github.com/godotengine/godot/issues/115134 related to problems with `Filesystem` dock.
- Closes https://github.com/godotengine/godot/issues/115693

This is how I understand the problem:
In standard layout `Filesystem` dock is below `Scene` and `Import` docks. `Import` dock is not visible (i.e. not rendered to update its size), and it is excessively tall until rendered because of label text autowrapping (I suppose this is related to https://github.com/godotengine/godot/issues/83546). But it is not rendered until selected (`Scene` tab is visible by default), so upper left dock slot is too tall in default layout until `Import` dock is selected at least once. And this pushes down `Filesystem` dock.

To work this around I added text trimming and increased custom minimum size to compensate trimming effect a bit.