### PR TITLE
Remove `AudioStreamRandomPitch` reference from `AudioStream` docs

### DIFF
--- a/doc/classes/AudioStream.xml
+++ b/doc/classes/AudioStream.xml
@@ -97,7 +97,7 @@
 		<method name="instantiate_playback">
 			<return type="AudioStreamPlayback" />
 			<description>
-				Returns a newly created [AudioStreamPlayback] intended to play this audio stream. Useful for when you want to extend [method _instantiate_playback] but call [method instantiate_playback] from an internally held AudioStream subresource. An example of this can be found in the source code for [code]AudioStreamRandomPitch::instantiate_playback[/code].
+				Returns a newly created [AudioStreamPlayback] intended to play this audio stream. Useful for when you want to extend [method _instantiate_playback] but call [method instantiate_playback] from an internally held AudioStream subresource.
 			</description>
 		</method>
 		<method name="is_meta_stream" qualifiers="const">


### PR DESCRIPTION
This is a leftover from Godot 3.x I stumbled upon while making a custom AudioStream.
