### PR TITLE
Allow `ONE_SHOT_REQUEST_FIRE` to override OneShot abortion

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -590,7 +590,7 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(const AnimationMixer:
 	}
 
 	bool is_abort = cur_request == ONE_SHOT_REQUEST_ABORT;
-	if (is_reset && (is_fading_out || (abort_on_reset && cur_active))) {
+	if (is_reset && !do_start && (is_fading_out || (abort_on_reset && cur_active))) {
 		is_abort = true;
 	}
 


### PR DESCRIPTION
Testing my project against 4.6 RC1, I think we may have overlooked some changes made to `animation_blend_tree.cpp` via #112450 and #112054:

Currently, when ONE_SHOT_REQUEST_FIRE is re-requested on a OneShot that's being resumed,
- If `abort_on_reset` is enabled, we see it aborted and it doesn't play. **So, the fire request is ignored.**
- If `abort_on_reset` is disabled, and it was fading out when interrupted, we see it aborted and it doesn't resume. **Again, the fire request is ignored.**
- Only if `abort_on_reset` is disabled, and it wasn't fading out when interrupted, do we see it seek to 0 and restart.

This leads to fairly unpredictable behavior, where there is no way to forcefully refire a OneShot without also using a TimeSeek before it, and is basically a regression in functionality versus 4.5.

With this PR, a new fire request overrides all of the above, and always results in no abortion, in addition to a seek to start when resetting.

Hoping this makes sense @TokageItLab