### PR TITLE
Lower directional shadow tighter culling epsilon for better performance

### DIFF
--- a/servers/rendering/rendering_light_culler.cpp
+++ b/servers/rendering/rendering_light_culler.cpp
@@ -375,7 +375,7 @@ bool RenderingLightCuller::add_light_camera_planes_directional(LightCullPlanes &
 		// Create a third point from the light direction.
 		Vector3 pt2 = pt0 - p_light_source.dir;
 
-		if (!_is_colinear_tri(pt0, pt1, pt2)) {
+		if (!_is_colinear_tri(pt0, pt1, pt2, DIRECTIONAL_LIGHT_COLINEARITY_THRESHOLD)) {
 			// Create plane from 3 points.
 			Plane p(pt0, pt1, pt2);
 			r_cull_planes.add_cull_plane(p);
@@ -393,7 +393,7 @@ bool RenderingLightCuller::add_light_camera_planes_directional(LightCullPlanes &
 		// Create a third point from the light direction.
 		Vector3 pt2 = pt0 - p_light_source.dir;
 
-		if (!_is_colinear_tri(pt0, pt1, pt2)) {
+		if (!_is_colinear_tri(pt0, pt1, pt2, DIRECTIONAL_LIGHT_COLINEARITY_THRESHOLD)) {
 			// Create plane from 3 points.
 			Plane p(pt0, pt1, pt2);
 			r_cull_planes.add_cull_plane(p);
@@ -536,7 +536,7 @@ bool RenderingLightCuller::_add_light_camera_planes(LightCullPlanes &r_cull_plan
 		const Vector3 &pt0 = frustum_points[i0];
 		const Vector3 &pt1 = frustum_points[i1];
 
-		if (!_is_colinear_tri(pt0, pt1, pt2)) {
+		if (!_is_colinear_tri(pt0, pt1, pt2, POINT_LIGHT_COLINEARITY_THRESHOLD)) {
 			// Create plane from 3 points.
 			Plane p(pt0, pt1, pt2);
 			r_cull_planes.add_cull_plane(p);
@@ -551,7 +551,7 @@ bool RenderingLightCuller::_add_light_camera_planes(LightCullPlanes &r_cull_plan
 		const Vector3 &pt0 = frustum_points[i0];
 		const Vector3 &pt1 = frustum_points[i1];
 
-		if (!_is_colinear_tri(pt0, pt1, pt2)) {
+		if (!_is_colinear_tri(pt0, pt1, pt2, POINT_LIGHT_COLINEARITY_THRESHOLD)) {
 			// Create plane from 3 points.
 			Plane p(pt0, pt1, pt2);
 			r_cull_planes.add_cull_plane(p);

--- a/servers/rendering/rendering_light_culler.h
+++ b/servers/rendering/rendering_light_culler.h
@@ -141,6 +141,20 @@ private:
 		LUT_SIZE = 64,
 	};
 
+	// Directional lights work fine with small colinearity thresholds, but omnis not so much.
+	// Using the same value as directional lights for omnis will cause omni shadows (cube & paraboloid)
+	// to flicker while their center is out of view but near the edges of the viewport.
+	// Using a larger threshold for non-directional lights fixes this.
+	// See also GH-92078 for why this value is used.
+	constexpr static float POINT_LIGHT_COLINEARITY_THRESHOLD = 0.001f;
+
+	// Long frustums are made out of significantly stretched-out triangles,
+	// so a very small threshold is needed to prevent getting large amounts of cullable but unculled meshes.
+	// For example: 0.001 fails to cull cullable meshes with camera FOV of 70 and ortho shadows at ~50m at certain view angles.
+	// 0.0001 fails to cull cullable meshes with camera FOV of 70 and ortho shadows at ~500m at certain view angles.
+	// ...These apply less to cascades since they have large near planes in comparison to far planes, unlike ortho lights.
+	constexpr static float DIRECTIONAL_LIGHT_COLINEARITY_THRESHOLD = 0.00001f;
+
 public:
 	// Before each pass with a different camera, you must call this so the culler can pre-create
 	// the camera frustum planes and corner points in world space which are used for the culling.
@@ -188,8 +202,7 @@ private:
 	// - issue GH-89702 "Tighter Shadow Caster Culling causes some object shadows to not render for a Frame"
 	// - issue GH-89560 "Directional Shadows disappear with large Camera Z Far values at some angles"
 	// - issue GH-91976 "SpotLight3D shadows exhibit flickering when moved around."
-	// - PR GH-92078 which gave it the current value.
-	bool _is_colinear_tri(const Vector3 &p_a, const Vector3 &p_b, const Vector3 &p_c) const {
+	bool _is_colinear_tri(const Vector3 &p_a, const Vector3 &p_b, const Vector3 &p_c, float p_threshold) const {
 		// Lengths of sides a, b and c.
 		float la = (p_b - p_a).length();
 		float lb = (p_c - p_b).length();
@@ -217,9 +230,7 @@ private:
 			// For example: 0.001 fails to cull cullable meshes with camera FOV of 70 and ortho shadows at ~50m at certain view angles.
 			// 0.0001 fails to cull cullable meshes with camera FOV of 70 and ortho shadows at ~500m at certain view angles.
 			// ...These apply less to cascades since they have large near planes in comparison to far planes, unlike ortho lights.
-			// If you're reading this and the value for directional lights is still 0.001f,
-			// that is fine as is and it only means GH-115176 didn't make it.
-			return ld < 0.001f;
+			return ld < p_threshold;
 		}
 
 		// Don't create planes from tiny triangles,


### PR DESCRIPTION
This PR depends on #114678 being merged first.

As suggested by @lawnjelly, the `DIRECTIONAL_LIGHT_COLINEARITY_THRESHOLD` epsilon change from `0.001f` to `0.00001f` has been moved to a separate PR (this one).

Existing information/discussion about this change is present in the main #114678 PR.