### PR TITLE
Add a separate texture filter option for AO map.

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -111,6 +111,9 @@
 		<member name="ao_texture_channel" type="int" setter="set_ao_texture_channel" getter="get_ao_texture_channel" enum="BaseMaterial3D.TextureChannel" default="0">
 			Specifies the channel of the [member ao_texture] in which the ambient occlusion information is stored. This is useful when you store the information for multiple effects in a single texture. For example if you stored metallic in the red channel, roughness in the blue, and ambient occlusion in the green you could reduce the number of textures you use.
 		</member>
+		<member name="ao_texture_filter" type="int" setter="set_ao_texture_filter" getter="get_ao_texture_filter" enum="BaseMaterial3D.TextureFilter" default="3">
+			Filter flags for the ambient occlusion texture.
+		</member>
 		<member name="backlight" type="Color" setter="set_backlight" getter="get_backlight" default="Color(0, 0, 0, 1)">
 			The color used by the backlight effect. Represents the light passing through an object.
 		</member>

--- a/editor/export/shader_baker_export_plugin.cpp
+++ b/editor/export/shader_baker_export_plugin.cpp
@@ -344,12 +344,12 @@ Node *ShaderBakerExportPlugin::_customize_scene(Node *p_root, const String &p_pa
 			}
 
 			StandardMaterial3D::BillboardMode billboard_mode = StandardMaterial3D::BillboardMode(int(properties["billboard"]));
-			Ref<Material> sprite_3d_material = StandardMaterial3D::get_material_for_2d(bool(properties["shaded"]), mat_transparency, bool(properties["double_sided"]), billboard_mode == StandardMaterial3D::BILLBOARD_ENABLED, billboard_mode == StandardMaterial3D::BILLBOARD_FIXED_Y, false, bool(properties["no_depth_test"]), bool(properties["fixed_size"]), BaseMaterial3D::TextureFilter(int(properties["texture_filter"])), BaseMaterial3D::AlphaAntiAliasing(int(properties["alpha_antialiasing_mode"])));
+			Ref<Material> sprite_3d_material = StandardMaterial3D::get_material_for_2d(bool(properties["shaded"]), mat_transparency, bool(properties["double_sided"]), billboard_mode == StandardMaterial3D::BILLBOARD_ENABLED, billboard_mode == StandardMaterial3D::BILLBOARD_FIXED_Y, false, bool(properties["no_depth_test"]), bool(properties["fixed_size"]), BaseMaterial3D::TextureFilter(int(properties["texture_filter"])), BaseMaterial3D::TextureFilter(int(properties["ao_texture_filter"])), BaseMaterial3D::AlphaAntiAliasing(int(properties["alpha_antialiasing_mode"])));
 			_customize_resource(sprite_3d_material, String());
 
 			if (label_3d != nullptr) {
 				// Generate variants with and without MSDF support since we don't have access to the font here.
-				Ref<Material> label_3d_material = StandardMaterial3D::get_material_for_2d(bool(properties["shaded"]), mat_transparency, bool(properties["double_sided"]), billboard_mode == StandardMaterial3D::BILLBOARD_ENABLED, billboard_mode == StandardMaterial3D::BILLBOARD_FIXED_Y, true, bool(properties["no_depth_test"]), bool(properties["fixed_size"]), BaseMaterial3D::TextureFilter(int(properties["texture_filter"])), BaseMaterial3D::AlphaAntiAliasing(int(properties["alpha_antialiasing_mode"])));
+				Ref<Material> label_3d_material = StandardMaterial3D::get_material_for_2d(bool(properties["shaded"]), mat_transparency, bool(properties["double_sided"]), billboard_mode == StandardMaterial3D::BILLBOARD_ENABLED, billboard_mode == StandardMaterial3D::BILLBOARD_FIXED_Y, true, bool(properties["no_depth_test"]), bool(properties["fixed_size"]), BaseMaterial3D::TextureFilter(int(properties["texture_filter"])), BaseMaterial3D::TextureFilter(int(properties["ao_texture_filter"])), BaseMaterial3D::AlphaAntiAliasing(int(properties["alpha_antialiasing_mode"])));
 				_customize_resource(label_3d_material, String());
 			}
 		}

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -393,7 +393,7 @@ void Label3D::_generate_glyph_surfaces(const Glyph &p_glyph, Vector2 &r_offset, 
 			}
 
 			RID shader_rid;
-			StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), mat_transparency, get_draw_flag(FLAG_DOUBLE_SIDED), get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, msdf, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE), texture_filter, alpha_antialiasing_mode, false, &shader_rid);
+			StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), mat_transparency, get_draw_flag(FLAG_DOUBLE_SIDED), get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, msdf, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE), texture_filter, texture_filter, alpha_antialiasing_mode, false, &shader_rid);
 
 			RS::get_singleton()->material_set_shader(surf.material, shader_rid);
 			RS::get_singleton()->material_set_param(surf.material, "texture_albedo", tex);

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -296,7 +296,7 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 	}
 
 	RID shader_rid;
-	StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), mat_transparency, get_draw_flag(FLAG_DOUBLE_SIDED), get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, false, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE), get_texture_filter(), alpha_antialiasing_mode, texture_repeat, &shader_rid);
+	StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), mat_transparency, get_draw_flag(FLAG_DOUBLE_SIDED), get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, false, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE), get_texture_filter(), get_texture_filter(), alpha_antialiasing_mode, texture_repeat, &shader_rid);
 
 	if (last_shader != shader_rid) {
 		RS::get_singleton()->material_set_shader(get_material(), shader_rid);

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -724,7 +724,7 @@ void BaseMaterial3D::_update_shader() {
 	// race to create the shader. The winner, which is the one found in shader_map, will be
 	// used. The losers will free their shader.
 
-	String texfilter_str;
+	String texfilter_str, texfilter_ao_str;
 	// Force linear filtering for the heightmap texture, as the heightmap effect
 	// looks broken with nearest-neighbor filtering (with and without Deep Parallax).
 	String texfilter_height_str;
@@ -757,12 +757,37 @@ void BaseMaterial3D::_update_shader() {
 			break; // Internal value, skip.
 	}
 
+	switch (ao_texture_filter) {
+		case TEXTURE_FILTER_NEAREST:
+			texfilter_ao_str = "filter_nearest";
+			break;
+		case TEXTURE_FILTER_LINEAR:
+			texfilter_ao_str = "filter_linear";
+			break;
+		case TEXTURE_FILTER_NEAREST_WITH_MIPMAPS:
+			texfilter_ao_str = "filter_nearest_mipmap";
+			break;
+		case TEXTURE_FILTER_LINEAR_WITH_MIPMAPS:
+			texfilter_ao_str = "filter_linear_mipmap";
+			break;
+		case TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC:
+			texfilter_ao_str = "filter_nearest_mipmap_anisotropic";
+			break;
+		case TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC:
+			texfilter_ao_str = "filter_linear_mipmap_anisotropic";
+			break;
+		case TEXTURE_FILTER_MAX:
+			break; // Internal value, skip.
+	}
+
 	if (flags[FLAG_USE_TEXTURE_REPEAT]) {
 		texfilter_str += ", repeat_enable";
 		texfilter_height_str += ", repeat_enable";
+		texfilter_ao_str += ", repeat_enable";
 	} else {
 		texfilter_str += ", repeat_disable";
 		texfilter_height_str += ", repeat_disable";
+		texfilter_ao_str += ", repeat_disable";
 	}
 
 	// Add a comment to describe the shader origin (useful when converting to ShaderMaterial).
@@ -1129,7 +1154,7 @@ uniform sampler2D texture_ambient_occlusion : hint_default_white, %s;
 uniform vec4 ao_texture_channel;
 uniform float ao_light_affect : hint_range(0.0, 1.0, 0.01);
 )",
-				texfilter_str);
+				texfilter_ao_str);
 	}
 
 	if (features[FEATURE_DETAIL]) {
@@ -2561,8 +2586,17 @@ void BaseMaterial3D::set_texture_filter(TextureFilter p_filter) {
 	_queue_shader_change();
 }
 
+void BaseMaterial3D::set_ao_texture_filter(TextureFilter p_filter) {
+	ao_texture_filter = p_filter;
+	_queue_shader_change();
+}
+
 BaseMaterial3D::TextureFilter BaseMaterial3D::get_texture_filter() const {
 	return texture_filter;
+}
+
+BaseMaterial3D::TextureFilter BaseMaterial3D::get_ao_texture_filter() const {
+	return ao_texture_filter;
 }
 
 void BaseMaterial3D::_validate_property(PropertyInfo &p_property) const {
@@ -3010,7 +3044,7 @@ float BaseMaterial3D::get_fov_override() const {
 	return fov_override;
 }
 
-Ref<Material> BaseMaterial3D::get_material_for_2d(bool p_shaded, Transparency p_transparency, bool p_double_sided, bool p_billboard, bool p_billboard_y, bool p_msdf, bool p_no_depth, bool p_fixed_size, TextureFilter p_filter, AlphaAntiAliasing p_alpha_antialiasing_mode, bool p_texture_repeat, RID *r_shader_rid) {
+Ref<Material> BaseMaterial3D::get_material_for_2d(bool p_shaded, Transparency p_transparency, bool p_double_sided, bool p_billboard, bool p_billboard_y, bool p_msdf, bool p_no_depth, bool p_fixed_size, TextureFilter p_filter, TextureFilter p_ao_filter, AlphaAntiAliasing p_alpha_antialiasing_mode, bool p_texture_repeat, RID *r_shader_rid) {
 	uint64_t key = 0;
 	key |= ((int8_t)p_shaded & 0x01) << 0;
 	key |= ((int8_t)p_transparency & 0x07) << 1; // Bits 1-3.
@@ -3023,6 +3057,7 @@ Ref<Material> BaseMaterial3D::get_material_for_2d(bool p_shaded, Transparency p_
 	key |= ((int8_t)p_filter & 0x07) << 10; // Bits 10-12.
 	key |= ((int8_t)p_alpha_antialiasing_mode & 0x07) << 13; // Bits 13-15.
 	key |= ((int8_t)p_texture_repeat & 0x01) << 16;
+	key |= ((int8_t)p_ao_filter & 0x07) << 17; // Bits 17-19
 
 	if (materials_for_2d.has(key)) {
 		if (r_shader_rid) {
@@ -3045,6 +3080,7 @@ Ref<Material> BaseMaterial3D::get_material_for_2d(bool p_shaded, Transparency p_
 	material->set_flag(FLAG_USE_TEXTURE_REPEAT, p_texture_repeat);
 	material->set_alpha_antialiasing(p_alpha_antialiasing_mode);
 	material->set_texture_filter(p_filter);
+	material->set_ao_texture_filter(p_ao_filter);
 	if (p_billboard || p_billboard_y) {
 		material->set_flag(FLAG_BILLBOARD_KEEP_SCALE, true);
 		material->set_billboard_mode(p_billboard_y ? BILLBOARD_FIXED_Y : BILLBOARD_ENABLED);
@@ -3447,6 +3483,9 @@ void BaseMaterial3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture_filter", "mode"), &BaseMaterial3D::set_texture_filter);
 	ClassDB::bind_method(D_METHOD("get_texture_filter"), &BaseMaterial3D::get_texture_filter);
 
+	ClassDB::bind_method(D_METHOD("set_ao_texture_filter", "mode"), &BaseMaterial3D::set_ao_texture_filter);
+	ClassDB::bind_method(D_METHOD("get_ao_texture_filter"), &BaseMaterial3D::get_ao_texture_filter);
+
 	ClassDB::bind_method(D_METHOD("set_feature", "feature", "enable"), &BaseMaterial3D::set_feature);
 	ClassDB::bind_method(D_METHOD("get_feature", "feature"), &BaseMaterial3D::get_feature);
 
@@ -3660,6 +3699,7 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "ao_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_feature", "get_feature", FEATURE_AMBIENT_OCCLUSION);
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ao_light_affect", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_ao_light_affect", "get_ao_light_affect");
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "ao_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_AMBIENT_OCCLUSION);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "ao_texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), "set_ao_texture_filter", "get_ao_texture_filter");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "ao_on_uv2"), "set_flag", "get_flag", FLAG_AO_ON_UV2);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "ao_texture_channel", PROPERTY_HINT_ENUM, "Red,Green,Blue,Alpha,Gray"), "set_ao_texture_channel", "get_ao_texture_channel");
 

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -359,6 +359,7 @@ private:
 	struct MaterialKey {
 		// enum values
 		uint64_t texture_filter : get_num_bits(TEXTURE_FILTER_MAX - 1);
+		uint64_t ao_texture_filter : get_num_bits(TEXTURE_FILTER_MAX - 1);
 		uint64_t detail_uv : get_num_bits(DETAIL_UV_MAX - 1);
 		uint64_t transparency : get_num_bits(TRANSPARENCY_MAX - 1);
 		uint64_t alpha_antialiasing_mode : get_num_bits(ALPHA_ANTIALIASING_MAX - 1);
@@ -427,6 +428,7 @@ private:
 		mk.depth_test = depth_test;
 		mk.cull_mode = cull_mode;
 		mk.texture_filter = texture_filter;
+		mk.ao_texture_filter = ao_texture_filter;
 		mk.transparency = transparency;
 		mk.shading_mode = shading_mode;
 		mk.roughness_channel = roughness_texture_channel;
@@ -571,6 +573,7 @@ private:
 	ShadingMode shading_mode = SHADING_MODE_PER_PIXEL;
 
 	TextureFilter texture_filter = TEXTURE_FILTER_LINEAR_WITH_MIPMAPS;
+	TextureFilter ao_texture_filter = TEXTURE_FILTER_LINEAR_WITH_MIPMAPS;
 
 	Vector3 uv1_scale;
 	Vector3 uv1_offset;
@@ -771,6 +774,9 @@ public:
 	void set_texture_filter(TextureFilter p_filter);
 	TextureFilter get_texture_filter() const;
 
+	void set_ao_texture_filter(TextureFilter p_filter);
+	TextureFilter get_ao_texture_filter() const;
+
 	void set_feature(Feature p_feature, bool p_enabled);
 	bool get_feature(Feature p_feature) const;
 
@@ -877,7 +883,7 @@ public:
 	static void finish_shaders();
 	static void flush_changes();
 
-	static Ref<Material> get_material_for_2d(bool p_shaded, Transparency p_transparency, bool p_double_sided, bool p_billboard = false, bool p_billboard_y = false, bool p_msdf = false, bool p_no_depth = false, bool p_fixed_size = false, TextureFilter p_filter = TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, AlphaAntiAliasing p_alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF, bool p_texture_repeat = false, RID *r_shader_rid = nullptr);
+	static Ref<Material> get_material_for_2d(bool p_shaded, Transparency p_transparency, bool p_double_sided, bool p_billboard = false, bool p_billboard_y = false, bool p_msdf = false, bool p_no_depth = false, bool p_fixed_size = false, TextureFilter p_filter = TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, TextureFilter p_ao_filter = TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, AlphaAntiAliasing p_alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF, bool p_texture_repeat = false, RID *r_shader_rid = nullptr);
 
 	virtual RID get_rid() const override;
 	virtual RID get_shader_rid() const override;


### PR DESCRIPTION
As of upstream, baked AO map follow the same sampling filtering of all other textures in a StandardMaterial. This is not always the best option since, for stylized games, one could want to use nearest neighbour filtering for albedo texture but still rely on linear filtered baked AO map for a more realistic look.

This commit adds a new option in the editor to specify the sampling filter to use specifically for AO map.
With this new option, developers can setup combination of different filtering between albedo and AO map to fit their vision (Nearest + Nearest for a full Retro look, Nearest + Linear for a stylized 3D pixel art with realistic lighting and Linear + Linear for a full realistic scenario)

Attaching two screenshots showing the new option in place:
<img width="2560" height="1440" alt="nearest" src="https://github.com/user-attachments/assets/c2e66476-3f6d-40cb-9550-5d612f50856f" />

<img width="2560" height="1440" alt="linear" src="https://github.com/user-attachments/assets/df0f96ac-678c-41c8-a0be-aa3109f6b285" />
