### PR TITLE
Add ability to create tooltip descriptions for dynamically exported properties

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -589,6 +589,19 @@ Variant Object::property_get_revert(const StringName &p_name) const {
 	return Variant();
 }
 
+String Object::get_property_description(const StringName &p_name) const {
+	String desc = _get_property_descriptionv(p_name);
+	if (!desc.is_empty()) {
+		return desc;
+	}
+
+	if (script_instance) {
+		desc = script_instance->get_property_description(p_name);
+	}
+
+	return desc;
+}
+
 void Object::get_method_list(List<MethodInfo> *p_list) const {
 	ClassDB::get_method_list(get_class_name(), p_list);
 	if (script_instance) {
@@ -1955,6 +1968,8 @@ void Object::_bind_methods() {
 		mi.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
 		BIND_OBJ_CORE_METHOD(mi);
 	}
+
+	BIND_OBJ_CORE_METHOD(MethodInfo(Variant::STRING, "_get_property_description", PropertyInfo(Variant::STRING_NAME, "property")));
 
 	// These are actually `Variant` methods, but that doesn't matter since scripts can't inherit built-in types.
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -224,6 +224,18 @@ protected: \
 		} \
 		return m_inherits::_property_get_revertv(p_name, r_ret); \
 	} \
+	_FORCE_INLINE_ String (Object::*_get_get_property_description() const)(const StringName &) const { \
+		return (String (Object::*)(const StringName &) const) & m_class::_get_property_description; \
+	} \
+	virtual String _get_property_descriptionv(const StringName &p_name) const override { \
+		if (m_class::_get_get_property_description() != m_inherits::_get_get_property_description()) { \
+			const String desc = _get_property_description(p_name); \
+			if (!desc.is_empty()) { \
+				return desc; \
+			} \
+		} \
+		return m_inherits::_get_property_descriptionv(p_name); \
+	} \
 	_FORCE_INLINE_ void (Object::*_get_notification() const)(int) { \
 		return (void (Object::*)(int)) & m_class::_notification; \
 	} \
@@ -529,6 +541,7 @@ protected:
 	virtual void _validate_propertyv(PropertyInfo &p_property) const {}
 	virtual bool _property_can_revertv(const StringName &p_name) const { return false; }
 	virtual bool _property_get_revertv(const StringName &p_name, Variant &r_property) const { return false; }
+	virtual String _get_property_descriptionv(const StringName &p_name) const { return String(); }
 
 	void _notification_forward(int p_notification);
 	void _notification_backward(int p_notification);
@@ -544,6 +557,7 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const {}
 	bool _property_can_revert(const StringName &p_name) const { return false; }
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return false; }
+	String _get_property_description(const StringName &p_name) const { return String(); }
 	void _notification(int p_notification) {}
 
 	_FORCE_INLINE_ static void (*_get_bind_methods())() {
@@ -569,6 +583,9 @@ protected:
 	}
 	_FORCE_INLINE_ bool (Object::*_get_property_get_revert() const)(const StringName &p_name, Variant &) const {
 		return &Object::_property_get_revert;
+	}
+	_FORCE_INLINE_ String (Object::*_get_get_property_description() const)(const StringName &) const {
+		return &Object::_get_property_description;
 	}
 	_FORCE_INLINE_ void (Object::*_get_notification() const)(int) {
 		return &Object::_notification;
@@ -690,6 +707,7 @@ public:
 	void validate_property(PropertyInfo &p_property) const;
 	bool property_can_revert(const StringName &p_name) const;
 	Variant property_get_revert(const StringName &p_name) const;
+	String get_property_description(const StringName &p_name) const;
 
 	bool has_method(const StringName &p_method) const;
 	int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const;

--- a/core/object/script_instance.h
+++ b/core/object/script_instance.h
@@ -45,6 +45,7 @@ public:
 
 	virtual bool property_can_revert(const StringName &p_name) const = 0;
 	virtual bool property_get_revert(const StringName &p_name, Variant &r_ret) const = 0;
+	virtual String get_property_description(const StringName &p_name) const = 0;
 
 	virtual Object *get_owner() { return nullptr; }
 	virtual void get_property_state(List<Pair<StringName, Variant>> &state);

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -467,6 +467,7 @@ public:
 
 	virtual bool property_can_revert(const StringName &p_name) const override { return false; }
 	virtual bool property_get_revert(const StringName &p_name, Variant &r_ret) const override { return false; }
+	virtual String get_property_description(const StringName &p_name) const override { return String(); }
 
 	virtual void get_method_list(List<MethodInfo> *p_list) const override;
 	virtual bool has_method(const StringName &p_method) const override;

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -786,6 +786,9 @@ public:
 		}
 		return false;
 	}
+	virtual String get_property_description(const StringName &p_name) const override {
+		return String();
+	}
 
 	virtual Object *get_owner() override {
 		if (native_info->get_owner_func) {

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -76,6 +76,30 @@
 				[b]Note:[/b] Unlike other virtual methods, this method is called automatically for every script that overrides it. This means that the base implementation should not be called via [code]super[/code] in GDScript or its equivalents in other languages. The bottom-most sub-class will be called first, with subsequent calls ascending the class hierarchy. The call chain will stop on the first class that returns a non-[code]null[/code] value.
 			</description>
 		</method>
+		<method name="_get_property_description" qualifiers="virtual">
+			<return type="String" />
+			<param index="0" name="property" type="StringName" />
+			<description>
+				Override this method to provide a custom description for the given [param property]. The description is displayed as a tooltip in the Inspector dock when hovering over the property. The description supports [url=$DOCS_URL/tutorials/ui/bbcode_in_richtextlabel.html]BBCode[/url] formatting.
+				This is particularly useful for dynamically exported properties (via [method _get_property_list]) which cannot be documented using the standard documentation system. It also works for property groups and subgroups, in which case [param property] receives the group/subgroup name (e.g. [code]"My Group"[/code]).
+				[codeblocks]
+				[gdscript]
+				func _get_property_description(property):
+					if property == "my_dynamic_property":
+						return "A dynamically exported property with a custom tooltip."
+					return ""
+				[/gdscript]
+				[csharp]
+				public override string _GetPropertyDescription(StringName property)
+				{
+					if (property == "my_dynamic_property")
+						return "A dynamically exported property with a custom tooltip.";
+					return "";
+				}
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="_get_property_list" qualifiers="virtual">
 			<return type="Dictionary[]" />
 			<description>

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1426,6 +1426,16 @@ Control *EditorProperty::make_custom_tooltip(const String &p_text) const {
 		}
 	}
 
+	{
+		const String custom_description = object->get_property_description(property);
+		if (!custom_description.is_empty()) {
+			if (!prologue.is_empty()) {
+				prologue += '\n';
+			}
+			prologue += custom_description;
+		}
+	}
+
 	if (!symbol.is_empty() || !prologue.is_empty()) {
 		return EditorHelpBitTooltip::make_tooltip(const_cast<EditorProperty *>(this), symbol, prologue);
 	}
@@ -2432,25 +2442,34 @@ EditorInspector *EditorInspectorSection::_get_parent_inspector() const {
 }
 
 Control *EditorInspectorSection::make_custom_tooltip(const String &p_text) const {
-	if (!checkable) {
-		return Container::make_custom_tooltip(p_text);
-	}
-
 	String symbol;
 	String prologue;
 
-	if (object->has_method("_get_property_warning")) {
-		const String custom_warning = object->call("_get_property_warning", related_enable_property);
-		if (!custom_warning.is_empty()) {
-			prologue = "[b][color=" + theme_cache.warning_color.to_html(false) + "]" + custom_warning + "[/color][/b]";
+	if (checkable) {
+		if (object->has_method("_get_property_warning")) {
+			const String custom_warning = object->call("_get_property_warning", related_enable_property);
+			if (!custom_warning.is_empty()) {
+				prologue = "[b][color=" + theme_cache.warning_color.to_html(false) + "]" + custom_warning + "[/color][/b]";
+			}
+		}
+
+		symbol = p_text;
+
+		const EditorInspector *inspector = _get_parent_inspector();
+		if (inspector) {
+			const String custom_description = inspector->get_custom_property_description(p_text);
+			if (!custom_description.is_empty()) {
+				if (!prologue.is_empty()) {
+					prologue += '\n';
+				}
+				prologue += custom_description;
+			}
 		}
 	}
 
-	symbol = p_text;
-
-	const EditorInspector *inspector = _get_parent_inspector();
-	if (inspector) {
-		const String custom_description = inspector->get_custom_property_description(p_text);
+	{
+		const String description_key = checkable ? related_enable_property : section;
+		const String custom_description = object->get_property_description(description_key);
 		if (!custom_description.is_empty()) {
 			if (!prologue.is_empty()) {
 				prologue += '\n';
@@ -2463,7 +2482,7 @@ Control *EditorInspectorSection::make_custom_tooltip(const String &p_text) const
 		return EditorHelpBitTooltip::make_tooltip(const_cast<EditorInspectorSection *>(this), symbol, prologue);
 	}
 
-	return nullptr;
+	return checkable ? nullptr : Container::make_custom_tooltip(p_text);
 }
 
 void EditorInspectorSection::setup(const String &p_inspector_path, const String &p_section, const String &p_label, Object *p_object, const Color &p_bg_color, bool p_foldable, int p_indent_depth, int p_level) {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1851,6 +1851,28 @@ bool GDScriptInstance::property_get_revert(const StringName &p_name, Variant &r_
 	return false;
 }
 
+String GDScriptInstance::get_property_description(const StringName &p_name) const {
+	Variant name = p_name;
+	const Variant *args[1] = { &name };
+
+	const GDScript *sptr = script.ptr();
+	while (sptr) {
+		if (likely(sptr->valid)) {
+			HashMap<StringName, GDScriptFunction *>::ConstIterator E = sptr->member_functions.find(GDScriptLanguage::get_singleton()->strings._get_property_description);
+			if (E) {
+				Callable::CallError err;
+				Variant ret = E->value->call(const_cast<GDScriptInstance *>(this), args, 1, err);
+				if (err.error == Callable::CallError::CALL_OK && ret.get_type() == Variant::STRING) {
+					return ret;
+				}
+			}
+		}
+		sptr = sptr->base.ptr();
+	}
+
+	return String();
+}
+
 void GDScriptInstance::get_method_list(List<MethodInfo> *p_list) const {
 	const GDScript *sptr = script.ptr();
 	while (sptr) {
@@ -2818,6 +2840,7 @@ GDScriptLanguage::GDScriptLanguage() {
 	strings._validate_property = StringName("_validate_property");
 	strings._property_can_revert = StringName("_property_can_revert");
 	strings._property_get_revert = StringName("_property_get_revert");
+	strings._get_property_description = StringName("_get_property_description");
 	strings._script_source = StringName("script/source");
 	_debug_parse_err_line = -1;
 	_debug_parse_err_file = "";

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -379,6 +379,7 @@ public:
 
 	virtual bool property_can_revert(const StringName &p_name) const;
 	virtual bool property_get_revert(const StringName &p_name, Variant &r_ret) const;
+	virtual String get_property_description(const StringName &p_name) const;
 
 	virtual void get_method_list(List<MethodInfo> *p_list) const;
 	virtual bool has_method(const StringName &p_method) const;
@@ -564,6 +565,7 @@ public:
 		StringName _validate_property;
 		StringName _property_can_revert;
 		StringName _property_get_revert;
+		StringName _get_property_description;
 		StringName _script_source;
 
 	} strings;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1653,6 +1653,24 @@ bool CSharpInstance::property_get_revert(const StringName &p_name, Variant &r_re
 	return true;
 }
 
+String CSharpInstance::get_property_description(const StringName &p_name) const {
+	ERR_FAIL_COND_V(script.is_null(), String());
+
+	Variant name_arg = p_name;
+	const Variant *args[1] = { &name_arg };
+
+	Variant ret;
+	Callable::CallError call_error;
+	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
+			gchandle.get_intptr(), &SNAME("_get_property_description"), args, 1, &call_error, &ret);
+
+	if (call_error.error != Callable::CallError::CALL_OK) {
+		return String();
+	}
+
+	return ret;
+}
+
 void CSharpInstance::get_method_list(List<MethodInfo> *p_list) const {
 	if (!script->is_valid() || !script->valid) {
 		return;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -350,6 +350,7 @@ public:
 
 	bool property_can_revert(const StringName &p_name) const override;
 	bool property_get_revert(const StringName &p_name, Variant &r_ret) const override;
+	String get_property_description(const StringName &p_name) const override;
 
 	void get_method_list(List<MethodInfo> *p_list) const override;
 	bool has_method(const StringName &p_method) const override;

--- a/tests/core/object/test_object.cpp
+++ b/tests/core/object/test_object.cpp
@@ -87,6 +87,9 @@ public:
 	bool property_get_revert(const StringName &p_name, Variant &r_ret) const override {
 		return false;
 	}
+	String get_property_description(const StringName &p_name) const override {
+		return String();
+	}
 	void get_method_list(List<MethodInfo> *p_list) const override {
 	}
 	bool has_method(const StringName &p_method) const override {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Implements: https://github.com/godotengine/godot-proposals/issues/8531

Example:

```gdscript
func _get_property_description(property: StringName) -> String:
	if property.begins_with("Light "):
		var index_str := property.trim_prefix("Light ")
		if index_str.is_valid_int():
			var index := index_str.to_int()
			if index == 1:
				return "Bottom segment of the stack light."
			elif index == segments:
				return "Top segment of the stack light."
			else:
				return "Middle segment %d of the stack light." % index
	return ""
```

https://github.com/user-attachments/assets/51857771-3634-4f90-a9e6-acc72c69ff91

