### PR TITLE
Fix AudioStreamInteractive pitch scale

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -869,7 +869,7 @@ int AudioStreamPlaybackInteractive::mix(AudioFrame *p_buffer, float p_rate_scale
 
 	while (todo) {
 		int to_mix = MIN(todo, BUFFER_SIZE);
-		_mix_internal(to_mix);
+		_mix_internal(to_mix, p_rate_scale);
 		for (int i = 0; i < to_mix; i++) {
 			p_buffer[i] = mix_buffer[i];
 		}
@@ -880,7 +880,7 @@ int AudioStreamPlaybackInteractive::mix(AudioFrame *p_buffer, float p_rate_scale
 	return p_frames;
 }
 
-void AudioStreamPlaybackInteractive::_mix_internal(int p_frames) {
+void AudioStreamPlaybackInteractive::_mix_internal(int p_frames, float p_rate_scale) {
 	for (int i = 0; i < p_frames; i++) {
 		mix_buffer[i] = AudioFrame(0, 0);
 	}
@@ -890,11 +890,11 @@ void AudioStreamPlaybackInteractive::_mix_internal(int p_frames) {
 			continue;
 		}
 
-		_mix_internal_state(i, p_frames);
+		_mix_internal_state(i, p_frames, p_rate_scale);
 	}
 }
 
-void AudioStreamPlaybackInteractive::_mix_internal_state(int p_state_idx, int p_frames) {
+void AudioStreamPlaybackInteractive::_mix_internal_state(int p_state_idx, int p_frames, float p_rate_scale) {
 	State &state = states[p_state_idx];
 	double mix_rate = double(AudioServer::get_singleton()->get_mix_rate());
 	double frame_inc = 1.0 / mix_rate;
@@ -904,10 +904,10 @@ void AudioStreamPlaybackInteractive::_mix_internal_state(int p_state_idx, int p_
 
 	if (state.first_mix) {
 		// Did not start mixing yet, wait.
-		double mix_time = p_frames * frame_inc;
+		double mix_time = p_frames * frame_inc * p_rate_scale;
 		if (state.fade_wait < mix_time) {
 			// time to start!
-			from_frame = state.fade_wait * mix_rate;
+			from_frame = state.fade_wait * mix_rate / p_rate_scale;
 			state.fade_wait = 0;
 			if (state.fade_speed == 0.0) {
 				queue_next = state.auto_advance;
@@ -921,14 +921,13 @@ void AudioStreamPlaybackInteractive::_mix_internal_state(int p_state_idx, int p_
 		}
 	}
 
-	state.previous_position = state.playback->get_playback_position();
-	state.playback->mix(temp_buffer + from_frame, 1.0, p_frames - from_frame);
+	state.playback->mix(temp_buffer + from_frame, p_rate_scale, p_frames - from_frame);
 
-	double frame_fade_inc = state.fade_speed * frame_inc;
+	double frame_fade_inc = state.fade_speed * frame_inc * p_rate_scale;
 	for (int i = from_frame; i < p_frames; i++) {
 		if (state.fade_wait) {
 			// This is for fade out of existing stream;
-			state.fade_wait -= frame_inc;
+			state.fade_wait -= frame_inc * p_rate_scale;
 			if (state.fade_wait < 0.0) {
 				state.fade_wait = 0.0;
 			}
@@ -952,7 +951,7 @@ void AudioStreamPlaybackInteractive::_mix_internal_state(int p_state_idx, int p_
 		}
 
 		mix_buffer[i] += temp_buffer[i] * state.fade_volume;
-		state.previous_position += frame_inc;
+		state.previous_position += frame_inc * p_rate_scale;
 	}
 
 	if (!state.playback->is_playing()) {

--- a/modules/interactive_music/audio_stream_interactive.h
+++ b/modules/interactive_music/audio_stream_interactive.h
@@ -237,8 +237,8 @@ private:
 	bool active = false;
 	int return_memory = -1;
 
-	void _mix_internal(int p_frames);
-	void _mix_internal_state(int p_state_idx, int p_frames);
+	void _mix_internal(int p_frames, float p_rate_scale);
+	void _mix_internal_state(int p_state_idx, int p_frames, float p_rate_scale);
 
 	void _queue(int p_to_clip_index, bool p_is_auto_advance);
 


### PR DESCRIPTION
This PR corrects an issue where the pitch_scale parameter configured in the inspector did not correctly affect the playback timing of AudioStreamPlaybackInteractive.

With this fix, the pitch value is now applied consistently to the audio mixing and time progression, ensuring that playback speed, fade timing, and stream advancement behave as expected.

A side-by-side video comparison (BEFORE / FIXED) is included to demonstrate the corrected behavior:
https://www.youtube.com/watch?v=iqWAZtYS4yI