### PR TITLE
[3.x] `Blob Shadows` - Fade is frame rate independent, and configurable

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1735,6 +1735,10 @@
 			This is typically used to ensure that shadows from an object only cast onto a nearby floor.
 			Blob shadows are not subject to occlusion, and can thus spread into areas that may be lit by a different light (for instance in a room below). Keeping their range low helps prevent this problem.
 		</member>
+		<member name="rendering/quality/blob_shadows/transition_duration" type="float" setter="" getter="" default="1.0">
+			Determines the duration (in seconds) for a shadow to fade in or out.
+			Fades will occur when the number of casters exceeds the maximum allowed, in order to prevent flickering.
+		</member>
 		<member name="rendering/quality/depth/hdr" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], allocates the root [Viewport]'s framebuffer with high dynamic range. High dynamic range allows the use of [Color] values greater than 1. This must be set to [code]true[/code] for glow rendering to work if [member Environment.glow_hdr_threshold] is greater than or equal to [code]1.0[/code].
 			[b]Note:[/b] Only available on the GLES3 backend.

--- a/servers/visual/visual_server_blob_shadows.cpp
+++ b/servers/visual/visual_server_blob_shadows.cpp
@@ -294,6 +294,16 @@ void VisualServerBlobShadows::update_focus_blobs_or_capsules(const Focus &p_focu
 	// Update existing focus casters and pending
 	FocusInfo &fi = r_focus_info;
 
+	// The multiplier determines the rate of change.
+	// Defaults to 1 (second).
+	// Capped to prevent huge numbers on rapid change.
+	real_t transition_duration_inverse = 100000;
+	if (data.transition_duration > 0.0001f) {
+		transition_duration_inverse = 1 / data.transition_duration;
+	}
+
+	real_t fraction_change = Engine::get_singleton()->get_idle_frame_step() * transition_duration_inverse;
+
 	for (uint32_t n = 0; n < fi.blobs.size(); n++) {
 		FocusCaster &fc = fi.blobs[n];
 		if (fc.last_update_frame != data.update_frame) {
@@ -302,16 +312,15 @@ void VisualServerBlobShadows::update_focus_blobs_or_capsules(const Focus &p_focu
 
 		switch (fc.state) {
 			case FocusCaster::FCS_ON: {
-				fc.fraction = 1.0f;
+				fc.fraction = 1;
 			} break;
 			case FocusCaster::FCS_ENTERING: {
-				fc.in_count++;
-				fc.fraction = (real_t)fc.in_count / 60;
+				fc.fraction += fraction_change;
 
 				// Fully faded in, change to on
-				if (fc.in_count >= 60) {
+				if (fc.fraction >= 1) {
 					fc.state = FocusCaster::FCS_ON;
-					fc.in_count = 60;
+					fc.fraction = 1;
 				}
 
 			} break;
@@ -320,9 +329,10 @@ void VisualServerBlobShadows::update_focus_blobs_or_capsules(const Focus &p_focu
 				if (fc.last_update_frame == data.update_frame) {
 					fc.state = FocusCaster::FCS_ENTERING;
 				} else {
-					fc.in_count--;
-					fc.fraction = (real_t)fc.in_count / 60;
-					if (!fc.in_count) {
+					fc.fraction -= fraction_change;
+					if (fc.fraction <= 0) {
+						fc.fraction = 0;
+
 						// Decrement ref count so we can free
 						// when no more fades.
 						if (blobs_or_capsules) {
@@ -369,8 +379,7 @@ void VisualServerBlobShadows::update_focus_blobs_or_capsules(const Focus &p_focu
 		fi.blobs_pending.pop();
 
 		fc.state = FocusCaster::FCS_ENTERING;
-		fc.in_count = 1;
-		fc.fraction = (real_t)fc.in_count / 60;
+		fc.fraction = MIN(fraction_change, (real_t)1);
 	}
 }
 
@@ -921,6 +930,8 @@ VisualServerBlobShadows::VisualServerBlobShadows() {
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/blob_shadows/gamma", PropertyInfo(Variant::REAL, "rendering/quality/blob_shadows/gamma", PROPERTY_HINT_RANGE, "0.01,10.0,0.01"));
 	data.intensity = GLOBAL_DEF("rendering/quality/blob_shadows/intensity", 0.7f);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/blob_shadows/intensity", PropertyInfo(Variant::REAL, "rendering/quality/blob_shadows/intensity", PROPERTY_HINT_RANGE, "0.0,6.0,0.01"));
+	data.transition_duration = GLOBAL_DEF("rendering/quality/blob_shadows/transition_duration", 1.0f);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/blob_shadows/transition_duration", PropertyInfo(Variant::REAL, "rendering/quality/blob_shadows/transition_duration", PROPERTY_HINT_RANGE, "0.0,5.0,0.01"));
 
 	data.frustum_planes.resize(6);
 	data.frustum_points.resize(8);

--- a/servers/visual/visual_server_blob_shadows.h
+++ b/servers/visual/visual_server_blob_shadows.h
@@ -225,10 +225,9 @@ public:
 		} state = FCS_ENTERING;
 
 		uint32_t caster_id = 0;
-
-		uint32_t in_count = 0; // The fraction in is in the in_count / transition_ticks
 		uint32_t last_update_frame = UINT32_MAX;
 
+		// Fraction faded in, between 0 and 1.
 		real_t fraction = 0;
 
 		// We only need to store lighting data for casters that are IN FOCUS.
@@ -363,6 +362,7 @@ private:
 		real_t range = 6.0f;
 		real_t gamma = 1.0f;
 		real_t intensity = 1.0f;
+		real_t transition_duration = 1.0f;
 
 		uint32_t update_frame = 0;
 		uint32_t render_focus_handle = 0;


### PR DESCRIPTION
Makes blob shadow transition fade time frame rate independent (before it the fade would be slower at low frame rates and vice versa).

The duration of the fades is configurable via project setting, defaulting to 1.0 second (same as before) and with a range 0 - 5 seconds.

Follow up to #84804 .

## Notes
* Blob shadows are already usable but this should make them more predictable for released games.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
