### PR TITLE
Add `has_script_method` to `Script` for scripting access

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -172,6 +172,7 @@ void Script::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_global_name"), &Script::get_global_name);
 
+	ClassDB::bind_method(D_METHOD("has_script_method", "method_name"), &Script::has_method);
 	ClassDB::bind_method(D_METHOD("has_script_signal", "signal_name"), &Script::has_script_signal);
 
 	ClassDB::bind_method(D_METHOD("get_script_property_list"), &Script::_get_script_property_list);

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -91,6 +91,13 @@
 				[b]Note:[/b] The dictionaries returned by this method are formatted identically to those returned by [method Object.get_signal_list].
 			</description>
 		</method>
+		<method name="has_script_method" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="method_name" type="StringName" />
+			<description>
+				Returns [code]true[/code] if the script, or a base class, defines a method with the given name.
+			</description>
+		</method>
 		<method name="has_script_signal" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="signal_name" type="StringName" />


### PR DESCRIPTION
This addresses a longstanding TODO around the use of `Script::has_method` versus `Object::has_method`.

In the `Script` class, the method `has_method` was introduced as a way to identify whether a specific script declares a specific method, since `get_script_method_list` returns all methods from the given script instance up through all its non-native ancestors' script classes. 

On the Engine side, this reimplementation does not cause any issues; however, it presents an issue from GDExtension, as the call to `Script::has_method` delegates to the `Object::has_method` binding, and not the virtual redeclaration of the same method on `Script`.

With the closing of 4.6 and 4.7 around the corner, it made sense to go ahead and address this. This PR aligns both `has_method` and `has_static_method` methods on the `Script` class with the _script_ moniker prefix, aligning them with other methods like `has_script_signal`.

With this change, GDExtension code can now call `Script::has_script_method` on a GDScript instance, and it will invoke the `GScript::has_script_method` call rather than delegating to `Object` as it did previously.

