### PR TITLE
VisualShader: Fix nodes not attaching to new Frame on duplication

### DIFF
--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -5560,6 +5560,11 @@ void VisualShaderEditor::_dup_paste_nodes(int p_type, List<CopyItem> &r_items, c
 
 		int new_node_id = connection_remap[item.id];
 		int new_frame_id = node->get_frame();
+
+		if (connection_remap.has(new_frame_id)) {
+			new_frame_id = connection_remap[new_frame_id];
+		}
+
 		undo_redo->add_do_method(visual_shader.ptr(), "attach_node_to_frame", type, new_node_id, new_frame_id);
 		undo_redo->add_do_method(graph_plugin.ptr(), "attach_node_to_frame", type, new_node_id, new_frame_id);
 	}


### PR DESCRIPTION
Fixes: #115107

This PR fixes a bug in the VisualShader editor where duplicating a "Frame" node along with its contents would cause the duplicated content nodes to remain attached to the original frame, instead of the newly created one.

The Fix: In `VisualShaderEditor::_dup_paste_nodes`, I added a check during the node-to-frame attachment loop. It now uses the connection_remap map to verify if the parent frame ID was also part of the duplication operation. If it was, the code now correctly re-parents the new nodes to the new frame ID.

Before (from issue #115107): 

https://github.com/user-attachments/assets/ec70c8e6-f90c-49de-9a5f-e3f1e9ecb470

After (Fix applied):

https://github.com/user-attachments/assets/8a54f81c-0c90-477e-a06b-75195219a6f6



