### PR TITLE
Fix: Sync built-in script memory before signal connection

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -2620,6 +2620,9 @@ void ScriptEditor::_add_callback(Object *p_obj, const String &p_function, const 
 		// Save the current script so the changes can be picked up by an external editor.
 		if (!scr.ptr()->is_built_in()) { // But only if it's not built-in script.
 			save_current_script();
+		} else {
+			ste->apply_code();
+			scr->reload(true);
 		}
 
 		break;


### PR DESCRIPTION
When creating both the callback function with binds and/or unbinds on a built-in script and the connection to a signal on the connections dialog, the `_add_callback` did not reload the script memory in the case of built-in scripts. Consequently, the `Object::connect` method could not find the callback, leading to a connection error.

This fix makes `_add_callback` perform an in-memory reload of the built-in script using `apply_code()` and `reload(true)`. This resolves the issue while maintaining the "user-in-control" philosophy by avoiding a forced save to disk without the user's explicit consent.

Fixes #107606