### PR TITLE
Fix editor colors reseting while the color chooser is still open

### DIFF
--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -79,7 +79,7 @@ class EditorSettingsDialog : public AcceptDialog {
 	virtual void ok_pressed() override;
 
 	void _settings_changed();
-	void _settings_property_edited(const String &p_name);
+	void _settings_property_edited();
 	void _settings_save();
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;


### PR DESCRIPTION
If one would try to change a color setting in the editor (e.g. the base color), and lingered in the color picker before closing it, the color would reset to its default value.

This happens when the color preset is not set to "Custom", which is done automatically when when the color picker is _closed_, as it makes the inspector fire the `property_edited` signal, and then the modified property is checked.

To workaround this, the check is now done when `settings_changed` is fired instead.

Fixes #113440.