### PR TITLE
Hide signals prefixed by underscore

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -1182,6 +1182,10 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 				List<MethodInfo> signal_list;
 				ClassDB::get_signal_list(class_name, &signal_list, true);
 				for (const MethodInfo &F : signal_list) {
+					if (F.name.begins_with("_")) {
+						continue; // Hidden signal.
+					}
+
 					StringName signal_name = F.name;
 					Dictionary d2;
 					d2["name"] = String(signal_name);

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -4263,6 +4263,11 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 
 			const MethodInfo &method_info = E.value;
 
+			if (method_info.name.begins_with("_")) {
+				// Signals starting with an underscore are internal and not meant to be exposed.
+				continue;
+			}
+
 			isignal.name = method_info.name;
 			isignal.cname = method_info.name;
 


### PR DESCRIPTION
This matches the behavior of other API kinds (e.g.: [methods](https://github.com/godotengine/godot/blob/78c6632eb174aabb2790975cf83e28fee065b43d/core/extension/extension_api_dump.cpp#L1095-L1097), [properties](https://github.com/godotengine/godot/blob/78c6632eb174aabb2790975cf83e28fee065b43d/core/extension/extension_api_dump.cpp#L1229-L1231)).

- Follow-up to https://github.com/godotengine/godot/pull/112770 (which only hides them from documentation and GDScript).

This hides the only 2 signals that exist prefixed by underscore, both of which were introduced in 4.6:
- https://github.com/godotengine/godot/pull/113690 introduced a signal named `_tab_style_changed`.
- https://github.com/godotengine/godot/pull/115128 introduced a signal named `_favorites_changed`.