### PR TITLE
Add notice about device settings for `vibrate_handheld` method

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -455,6 +455,7 @@
 				[b]Note:[/b] For iOS, specifying the duration is only supported in iOS 13 and later.
 				[b]Note:[/b] For Web, the amplitude cannot be changed.
 				[b]Note:[/b] Some web browsers such as Safari and Firefox for Android do not support [method vibrate_handheld].
+				[b]Note:[/b] Device settings such as vibration on/off, "do not disturb" mode or specific haptic feedback on/off may prevent [method vibrate_handheld] effects.
 			</description>
 		</method>
 		<method name="warp_mouse">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

This PR adds a new **Note** for the `vibrate_handheld` method to clarify device settings may bypass the desired effect. 

It closes https://github.com/godotengine/godot-docs/issues/11636 in the Godot Docs repository.