### PR TITLE
Revert "Always stop script debugger when stopping game"

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -322,7 +322,9 @@ void EditorDebuggerNode::stop(bool p_force) {
 
 	// Also close all debugging sessions.
 	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
-		dbg->_stop_and_notify();
+		if (dbg->is_session_active()) {
+			dbg->_stop_and_notify();
+		}
 	});
 	_break_state_changed();
 	breakpoints.clear();


### PR DESCRIPTION
This reverts commit d1a5d9da3e8bd32adf6fbcb8f7734bcedf70176f / #114457.

This unfortunately breaks the DAP.

Fixes #115188.