### PR TITLE
Editor setting for autoswitching workspace when selecting nodes in scene tree.

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -299,9 +299,6 @@
 		<member name="docks/scene_tree/accessibility_warnings" type="bool" setter="" getter="">
 			If [code]true[/code], accessibility related warnings are displayed alongside other configuration warnings.
 		</member>
-		<member name="docks/scene_tree/auto_switch_workspace_on_node_selected" type="bool" setter="" getter="">
-			If [code]true[/code], when selecting a 2D or 3D node in the Scene Tree, automatically switches the workspace to the 2D or 3D workspace depending on the node's type.
-		</member>
 		<member name="docks/scene_tree/ask_before_deleting_related_animation_tracks" type="bool" setter="" getter="">
 			If [code]true[/code], when a node is deleted with animation tracks referencing it, a confirmation dialog appears before the tracks are deleted. The dialog will appear even when using the "Delete (No Confirm)" shortcut.
 		</member>
@@ -310,6 +307,9 @@
 		</member>
 		<member name="docks/scene_tree/auto_expand_to_selected" type="bool" setter="" getter="">
 			If [code]true[/code], the scene tree dock will automatically unfold nodes when a node that has folded parents is selected.
+		</member>
+		<member name="docks/scene_tree/auto_switch_workspace_on_node_selected" type="bool" setter="" getter="">
+			If [code]true[/code], when selecting a 2D or 3D node in the Scene Tree, automatically switches the workspace to the 2D or 3D workspace depending on the node's type.
 		</member>
 		<member name="docks/scene_tree/center_node_on_reparent" type="bool" setter="" getter="">
 			If [code]true[/code], new node created when reparenting node(s) will be positioned at the average position of the selected node(s).

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -299,6 +299,9 @@
 		<member name="docks/scene_tree/accessibility_warnings" type="bool" setter="" getter="">
 			If [code]true[/code], accessibility related warnings are displayed alongside other configuration warnings.
 		</member>
+		<member name="docks/scene_tree/auto_switch_workspace_on_node_selected" type="bool" setter="" getter="">
+			If [code]true[/code], when selecting a 2D or 3D node in the Scene Tree, automatically switches the workspace to the 2D or 3D workspace depending on the node's type.
+		</member>
 		<member name="docks/scene_tree/ask_before_deleting_related_animation_tracks" type="bool" setter="" getter="">
 			If [code]true[/code], when a node is deleted with animation tracks referencing it, a confirmation dialog appears before the tracks are deleted. The dialog will appear even when using the "Delete (No Confirm)" shortcut.
 		</member>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3067,6 +3067,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 	bool is_resource = current_obj->is_class("Resource");
 	bool is_node = current_obj->is_class("Node");
 	bool stay_in_script_editor_on_node_selected = bool(EDITOR_GET("text_editor/behavior/navigation/stay_in_script_editor_on_node_selected"));
+	bool auto_switch_workspace_on_node_selected = bool(EDITOR_GET("docks/scene_tree/auto_switch_workspace_on_node_selected"));
 	bool skip_main_plugin = false;
 
 	String editable_info; // None by default.
@@ -3217,7 +3218,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 
 					main_plugin->edit(current_script);
 				}
-			} else if (main_plugin != editor_plugin_screen) {
+			} else if (main_plugin != editor_plugin_screen && (auto_switch_workspace_on_node_selected || !is_node)) {
 				// Unedit previous plugin.
 				editor_plugin_screen->edit(nullptr);
 				active_plugins[editor_owner_id].erase(editor_plugin_screen);
@@ -4510,7 +4511,8 @@ void EditorNode::_set_main_scene_state(Dictionary p_state, Node *p_for_scene) {
 	changing_scene = false;
 
 	if (get_edited_scene()) {
-		if (editor_main_screen->can_auto_switch_screens()) {
+		bool auto_switch_workspace_on_node_selected = bool(EDITOR_GET("docks/scene_tree/auto_switch_workspace_on_node_selected"));
+		if (editor_main_screen->can_auto_switch_screens() && auto_switch_workspace_on_node_selected) {
 			// Switch between 2D and 3D if currently in 2D or 3D.
 			Node *selected_node = SceneTreeDock::get_singleton()->get_tree_editor()->get_selected();
 			if (!selected_node) {

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -693,6 +693,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("docks/scene_tree/center_node_on_reparent", false);
 	_initial_set("docks/scene_tree/hide_filtered_out_parents", true);
 	_initial_set("docks/scene_tree/accessibility_warnings", false);
+	_initial_set("docks/scene_tree/auto_switch_workspace_on_node_selected", true);
 
 	// FileSystem
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "docks/filesystem/thumbnail_size", 64, "32,128,16")


### PR DESCRIPTION
Adds an editor setting for automatically switching workspace from 2D/3D (this is the current behavior) based on the selected nodes type in the Scene Tree; it defaults to true/toggled but allows users the option to uncheck/ not switch the workspace based on whether you have selected 2d or 3d node in the scene tree. This is useful if you are working on scenes that are mixed 2d/3d like with Viewports and TextureRects etc... as it can be quite disorientating when it auto switches the workspace.

Note this would likely be for Godot 4.7; I cant see a proposal for this, however this proposal is very similar https://github.com/godotengine/godot-proposals/issues/13379 

And some forum discussions:
https://godotforums.org/d/42970-how-to-disable-the-auto-tab-switching-when-click-a-node3d-in-scene-tree/3
https://godotforums.org/d/36666-editor-view-changes-from-2d-to-3d-when-i-select-a-3d-node

Video of feature:

https://github.com/user-attachments/assets/339c7e08-accd-4b4c-8a89-5d36c4f41772
