### PR TITLE
Implement node stashing (core part)

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -553,6 +553,25 @@
 				Returns [code]true[/code] if this node is an instance load placeholder. See [InstancePlaceholder] and [method set_scene_instance_load_placeholder].
 			</description>
 		</method>
+		<method name="get_stash_parent" qualifiers="const">
+			<return type="Node" />
+			<description>
+				Returns the parent in which this node is stashed. Prints an error and returns [code]null[/code] if the node is not stashed.
+			</description>
+		</method>
+		<method name="get_stashed_child" qualifiers="const">
+			<return type="Node" />
+			<param index="0" name="child_name" type="StringName" />
+			<description>
+				Returns the stashed child with name [param child_name]. Prints an error and returns [code]null[/code] if no such child is stashed in this node.
+			</description>
+		</method>
+		<method name="get_stashed_children" qualifiers="const">
+			<return type="Node[]" />
+			<description>
+				Returns all nodes that were stashed in this node.
+			</description>
+		</method>
 		<method name="get_tree" qualifiers="const">
 			<return type="SceneTree" />
 			<description>
@@ -613,6 +632,13 @@
 			<param index="0" name="path" type="NodePath" />
 			<description>
 				Returns [code]true[/code] if [param path] points to a valid node and its subnames point to a valid [Resource], e.g. [code]Area2D/CollisionShape2D:shape[/code]. Properties that are not [Resource] types (such as nodes or other [Variant] types) are not considered. See also [method get_node_and_resource].
+			</description>
+		</method>
+		<method name="has_stashed_child" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="child_name" type="StringName" />
+			<description>
+				Returns [code]true[/code] if a child named [param child_name] was stashed in this node.
 			</description>
 		</method>
 		<method name="is_ancestor_of" qualifiers="const">
@@ -735,6 +761,12 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the node is processing unhandled key input (see [method set_process_unhandled_key_input]).
+			</description>
+		</method>
+		<method name="is_stashed" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this node is stashed (see [method stash_child]).
 			</description>
 		</method>
 		<method name="move_child">
@@ -1027,6 +1059,45 @@
 			<description>
 				Makes this node inherit the translation domain from its parent node. If this node has no parent, the main translation domain will be used.
 				This is the default behavior for all nodes. Calling [method Object.set_translation_domain] disables this behavior.
+			</description>
+		</method>
+		<method name="stash_child">
+			<return type="void" />
+			<param index="0" name="node" type="Node" />
+			<description>
+				Stashes the specified [param node] in this node. The [param node] has to either be a child of this [Node] or have no parent.
+				Stashed children are outside the scene tree and stashing/unstashing them behaves the same as removing/adding the node from the tree. When the stash owner is freed, all stashed children are freed automatically to avoid memory leaks.
+				[b]Note:[/b] Currently the stashed children are not stored when this node is packed in [PackedScene].
+			</description>
+		</method>
+		<method name="stash_in_parent">
+			<return type="void" />
+			<description>
+				Calls [method stash_child] in the parent node. Fails if this node has no parent.
+			</description>
+		</method>
+		<method name="unstash_child">
+			<return type="void" />
+			<param index="0" name="child" type="Node" />
+			<param index="1" name="at_index" type="int" default="-1" />
+			<description>
+				Unstashes the specified [param child] and adds it as a child of this node. If [param at_index] is greater than [code]-1[/code], the child will be moved to the specified index.
+				Prints an error if the [param child] was not stashed in this node.
+			</description>
+		</method>
+		<method name="unstash_child_by_name">
+			<return type="Node" />
+			<param index="0" name="child_name" type="StringName" />
+			<param index="1" name="at_index" type="int" default="-1" />
+			<description>
+				Unstashes the child with name [param child_name]. If [param at_index] is greater than [code]-1[/code], the child will be moved to the specified index. Returns a reference to the unstashed child.
+				Prints an error and returns [code]null[/code] if no child named [param child_name] was stashed in this node.
+			</description>
+		</method>
+		<method name="unstash_from_parent">
+			<return type="void" />
+			<description>
+				Calls [method unstash_child] in the stash parent node. Fails if this node is not stashed.
 			</description>
 		</method>
 		<method name="update_configuration_warnings">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1702,7 +1702,8 @@ void Node::add_child(RequiredParam<Node> rp_child, bool p_force_readable_name, I
 	ERR_THREAD_GUARD
 	EXTRACT_PARAM_OR_FAIL(p_child, rp_child);
 	ERR_FAIL_COND_MSG(p_child == this, vformat("Can't add child '%s' to itself.", p_child->get_name())); // adding to itself!
-	ERR_FAIL_COND_MSG(p_child->data.parent, vformat("Can't add child '%s' to '%s', already has a parent '%s'.", p_child->get_name(), get_name(), p_child->data.parent->get_name())); //Fail if node has a parent
+	ERR_FAIL_COND_MSG(p_child->data.parent, vformat("Can't add child '%s' to '%s', already has a parent '%s'.", p_child->get_name(), get_name(), p_child->data.parent->get_name())); // Fail if node has a parent.
+	ERR_FAIL_COND_MSG(p_child->data.stash_parent, vformat("Can't add child '%s' to '%s', the node is stashed in node '%s'.", p_child->get_name(), get_name(), p_child->data.stash_parent->get_name())); // Fail if node was stashed.
 #ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(p_child->is_ancestor_of(this), vformat("Can't add child '%s' to '%s' as it would result in a cyclic dependency since '%s' is already a parent of '%s'.", p_child->get_name(), get_name(), p_child->get_name(), get_name()));
 #endif
@@ -1771,6 +1772,85 @@ void Node::remove_child(RequiredParam<Node> rp_child) {
 	}
 }
 
+void Node::stash_child(Node *p_node) {
+	ERR_FAIL_NULL(p_node);
+	ERR_FAIL_COND_MSG(p_node->data.parent && p_node->data.parent != this, vformat("Can't stash: Node \"%s\" is not a child of this node.", p_node->get_name()));
+
+	if (p_node->data.parent) {
+		remove_child(p_node);
+	}
+	data.stashed_children.push_back(p_node);
+	p_node->data.stash_parent = this;
+}
+
+void Node::unstash_child(Node *p_node, int p_at_index) {
+	ERR_FAIL_NULL(p_node);
+	ERR_FAIL_NULL_MSG(p_node->data.stash_parent, vformat("Node \"%s\" is not stashed.", p_node->get_name()));
+	ERR_FAIL_COND_MSG(p_node->data.stash_parent != this, vformat("Node \"%s\" was not stashed by this node (%s).", p_node->get_name(), get_name()));
+
+	data.stashed_children.erase(p_node);
+	p_node->data.stash_parent = nullptr;
+
+	add_child(p_node);
+	if (p_at_index > -1) {
+		move_child(p_node, p_at_index);
+	}
+}
+
+Node *Node::unstash_child_by_name(const StringName &p_child_name, int p_at_index) {
+	Node *stashed_child = _find_stashed_child(p_child_name);
+	ERR_FAIL_NULL_V_MSG(stashed_child, nullptr, vformat("Stashed child \"%s\" not found.", p_child_name));
+
+	data.stashed_children.erase(stashed_child);
+	stashed_child->data.stash_parent = nullptr;
+
+	add_child(stashed_child);
+	if (p_at_index > -1) {
+		move_child(stashed_child, p_at_index);
+	}
+	return stashed_child;
+}
+
+TypedArray<Node> Node::get_stashed_children() const {
+	TypedArray<Node> ret;
+	if (data.stashed_children.is_empty()) {
+		return ret;
+	}
+	ret.resize(data.stashed_children.size());
+
+	int i = 0;
+	for (const Node *child : data.stashed_children) {
+		ret[i] = child;
+		i++;
+	}
+	return ret;
+}
+
+bool Node::has_stashed_child(const StringName &p_child_name) const {
+	return _find_stashed_child(p_child_name) != nullptr;
+}
+
+Node *Node::get_stashed_child(const StringName &p_child_name) const {
+	Node *stashed_child = _find_stashed_child(p_child_name);
+	ERR_FAIL_NULL_V_MSG(stashed_child, nullptr, vformat("Stashed child \"%s\" not found.", p_child_name));
+	return stashed_child;
+}
+
+void Node::stash_in_parent() {
+	ERR_FAIL_NULL_MSG(data.parent, "Can't stash: Node has no parent.");
+	data.parent->stash_child(this);
+}
+
+void Node::unstash_from_parent() {
+	ERR_FAIL_NULL_MSG(data.stash_parent, "Node is not stashed.");
+	data.stash_parent->unstash_child(this);
+}
+
+Node *Node::get_stash_parent() const {
+	ERR_FAIL_NULL_V_MSG(data.stash_parent, nullptr, "Node is not stashed.");
+	return data.stash_parent;
+}
+
 void Node::_update_children_cache_impl() const {
 	// Assign children
 	data.children_cache.resize(data.children.size());
@@ -1800,6 +1880,15 @@ void Node::_update_children_cache_impl() const {
 		}
 	}
 	data.children_cache_dirty = false;
+}
+
+Node *Node::_find_stashed_child(const StringName &p_name) const {
+	for (Node *child : data.stashed_children) {
+		if (child->get_name() == p_name) {
+			return child;
+		}
+	}
+	return nullptr;
 }
 
 template <bool p_include_internal>
@@ -3778,6 +3867,18 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_node_and_resource", "path"), &Node::has_node_and_resource);
 	ClassDB::bind_method(D_METHOD("get_node_and_resource", "path"), &Node::_get_node_and_resource);
 
+	ClassDB::bind_method(D_METHOD("stash_child", "node"), &Node::stash_child);
+	ClassDB::bind_method(D_METHOD("unstash_child", "child", "at_index"), &Node::unstash_child, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("unstash_child_by_name", "child_name", "at_index"), &Node::unstash_child_by_name, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("get_stashed_children"), &Node::get_stashed_children);
+	ClassDB::bind_method(D_METHOD("has_stashed_child", "child_name"), &Node::has_stashed_child);
+	ClassDB::bind_method(D_METHOD("get_stashed_child", "child_name"), &Node::get_stashed_child);
+
+	ClassDB::bind_method(D_METHOD("stash_in_parent"), &Node::stash_in_parent);
+	ClassDB::bind_method(D_METHOD("unstash_from_parent"), &Node::unstash_from_parent);
+	ClassDB::bind_method(D_METHOD("is_stashed"), &Node::is_stashed);
+	ClassDB::bind_method(D_METHOD("get_stash_parent"), &Node::get_stash_parent);
+
 	ClassDB::bind_method(D_METHOD("is_inside_tree"), &Node::is_inside_tree);
 	ClassDB::bind_method(D_METHOD("is_part_of_edited_scene"), &Node::is_part_of_edited_scene);
 	ClassDB::bind_method(D_METHOD("is_ancestor_of", "node"), &Node::is_ancestor_of);
@@ -4133,6 +4234,16 @@ Node::~Node() {
 	data.owned.clear();
 	data.children.clear();
 	data.children_cache.clear();
+
+	if (data.stash_parent) {
+		data.stash_parent->data.stashed_children.erase(this);
+		data.stash_parent = nullptr;
+	}
+
+	for (Node *child : data.stashed_children) {
+		memdelete(child);
+	}
+	data.stashed_children.clear();
 
 	ERR_FAIL_COND(data.parent);
 	ERR_FAIL_COND(data.children_cache.size());

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -198,8 +198,10 @@ private:
 		Ref<SceneState> inherited_state;
 
 		Node *parent = nullptr;
+		Node *stash_parent = nullptr;
 		Node *owner = nullptr;
 		HashMap<StringName, Node *> children;
+		LocalVector<Node *> stashed_children;
 		mutable bool children_cache_dirty = false;
 		mutable LocalVector<Node *> children_cache;
 		HashMap<StringName, Node *> owned_unique_nodes;
@@ -348,6 +350,7 @@ private:
 	}
 
 	void _update_children_cache_impl() const;
+	Node *_find_stashed_child(const StringName &p_name) const;
 
 	// Process group management
 	void _add_process_group();
@@ -515,6 +518,18 @@ public:
 	void add_child(RequiredParam<Node> rp_child, bool p_force_readable_name = false, InternalMode p_internal = INTERNAL_MODE_DISABLED);
 	void add_sibling(RequiredParam<Node> rp_sibling, bool p_force_readable_name = false);
 	void remove_child(RequiredParam<Node> rp_child);
+
+	void stash_child(Node *p_node);
+	void unstash_child(Node *p_node, int p_at_index = -1);
+	Node *unstash_child_by_name(const StringName &p_child_name, int p_at_index = -1);
+	TypedArray<Node> get_stashed_children() const;
+	bool has_stashed_child(const StringName &p_child_name) const;
+	Node *get_stashed_child(const StringName &p_child_name) const;
+
+	void stash_in_parent();
+	void unstash_from_parent();
+	bool is_stashed() const { return data.stash_parent; }
+	Node *get_stash_parent() const;
 
 	/// Optimal way to iterate the children of this node.
 	/// The caller is responsible to ensure:


### PR DESCRIPTION
Implements the core part of https://github.com/godotengine/godot-proposals/issues/10212
The API is as suggested, with the exception that `unstash_by_name` is named `unstash_child_by_name` and returns the unstashed child (for convenience).

Note that _for now_:
- Stashed nodes are not saved in PackedScene
- No editor changes

The above is still planned, but the proposal does not really provide details how it's supposed to work 😅 I can figure out PackedScene changes, but how stashing is supposed to be handled in the editor? Like, when you stash a node, it disappears from scene tree, so either the editor needs to do an exception or some workaround, so the node is still displayed in the Scene dock. How the stashed status should be tracked in the editor? Also what about the node index? I assume it has to be stored in the PackedScene somehow.