### PR TITLE
Add a method to get the last changed project/editor setting

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1414,6 +1414,15 @@ PackedStringArray ProjectSettings::get_changed_settings() const {
 	return arr;
 }
 
+String ProjectSettings::get_last_changed_setting() const {
+	String setting;
+	if (!changed_settings.is_empty()) {
+		setting = *changed_settings.last();
+	}
+
+	return setting;
+}
+
 bool ProjectSettings::check_changed_settings_in_group(const String &p_setting_prefix) const {
 	for (const StringName &setting : changed_settings) {
 		if (String(setting).begins_with(p_setting_prefix)) {
@@ -1632,8 +1641,9 @@ void ProjectSettings::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("save_custom", "file"), &ProjectSettings::_save_custom_bnd);
 
-	// Change tracking methods
+	// Change tracking methods.
 	ClassDB::bind_method(D_METHOD("get_changed_settings"), &ProjectSettings::get_changed_settings);
+	ClassDB::bind_method(D_METHOD("get_last_changed_setting"), &ProjectSettings::get_last_changed_setting);
 	ClassDB::bind_method(D_METHOD("check_changed_settings_in_group", "setting_prefix"), &ProjectSettings::check_changed_settings_in_group);
 	ADD_SIGNAL(MethodInfo("settings_changed"));
 }

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -214,8 +214,9 @@ public:
 
 	bool has_custom_feature(const String &p_feature) const;
 
-	// Change tracking methods
+	// Change tracking methods.
 	PackedStringArray get_changed_settings() const;
+	String get_last_changed_setting() const;
 	bool check_changed_settings_in_group(const String &p_setting_prefix) const;
 
 	const HashMap<StringName, AutoloadInfo> &get_autoload_list() const;

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -123,6 +123,12 @@
 				Returns the list of favorite files and directories for this project.
 			</description>
 		</method>
+		<method name="get_last_changed_setting" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the last setting that has been modified, or an empty string if there's none. See also [method get_changed_settings].
+			</description>
+		</method>
 		<method name="get_project_metadata" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="section" type="String" />

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -86,6 +86,12 @@
 				[b]Note:[/b] Both the script and the icon paths are local to the project filesystem, i.e. they start with [code]res://[/code].
 			</description>
 		</method>
+		<method name="get_last_changed_setting" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the last setting that has been modified, or an empty string if there's none. See also [method get_changed_settings].
+			</description>
+		</method>
 		<method name="get_order" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="name" type="String" />

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1417,6 +1417,15 @@ PackedStringArray EditorSettings::get_changed_settings() const {
 	return arr;
 }
 
+String EditorSettings::get_last_changed_setting() const {
+	String setting;
+	if (!changed_settings.is_empty()) {
+		setting = *changed_settings.last();
+	}
+
+	return setting;
+}
+
 bool EditorSettings::check_changed_settings_in_group(const String &p_setting_prefix) const {
 	for (const String &setting : changed_settings) {
 		if (setting.begins_with(p_setting_prefix)) {
@@ -2290,6 +2299,7 @@ void EditorSettings::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("check_changed_settings_in_group", "setting_prefix"), &EditorSettings::check_changed_settings_in_group);
 	ClassDB::bind_method(D_METHOD("get_changed_settings"), &EditorSettings::get_changed_settings);
+	ClassDB::bind_method(D_METHOD("get_last_changed_setting"), &EditorSettings::get_last_changed_setting);
 	ClassDB::bind_method(D_METHOD("mark_setting_changed", "setting"), &EditorSettings::mark_setting_changed);
 
 	ADD_SIGNAL(MethodInfo("settings_changed"));

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -167,6 +167,7 @@ public:
 	}
 	void add_property_hint(const PropertyInfo &p_hint);
 	PackedStringArray get_changed_settings() const;
+	String get_last_changed_setting() const;
 	bool check_changed_settings_in_group(const String &p_setting_prefix) const;
 	void mark_setting_changed(const String &p_setting);
 


### PR DESCRIPTION
This adds the method `get_last_changed_setting()` to both `Project/EditorSettings` singletons.

While `get_changed_settings()` exists, a lot of times you just want to check the last one, with a good example being #115197. This way of doing things also avoids an unnecessary conversion from `HashSet` to `Vector`.