### PR TITLE
Fix non-Xinput joypads having `xinput_index` in `Input.get_joy_info()`

### DIFF
--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -161,8 +161,8 @@ void JoypadSDL::process_events() {
 
 				const int MAX_GUID_SIZE = 64;
 				char guid[MAX_GUID_SIZE] = {};
-
-				SDL_GUIDToString(SDL_GetJoystickGUID(joy), guid, MAX_GUID_SIZE);
+				SDL_GUID joy_guid = SDL_GetJoystickGUID(joy);
+				SDL_GUIDToString(joy_guid, guid, MAX_GUID_SIZE);
 				SDL_PropertiesID propertiesID = SDL_GetJoystickProperties(joy);
 
 				joypads[joy_id].attached = true;
@@ -184,11 +184,13 @@ void JoypadSDL::process_events() {
 					joypad_info["steam_input_index"] = itos(steam_handle);
 				}
 
+#ifdef WINDOWS_ENABLED
 				const int player_index = SDL_GetJoystickPlayerIndex(joy);
-				if (player_index >= 0) {
+				if (player_index >= 0 && joy_guid.data[14] == 'x') { // See also "SDL_IsJoystickXInput" in "thirdparty/sdl/joystick/SDL_joystick.c".
 					// For XInput controllers SDL_GetJoystickPlayerIndex returns the XInput user index.
 					joypad_info["xinput_index"] = itos(player_index);
 				}
+#endif
 
 				Input::get_singleton()->joy_connection_changed(
 						joy_id,


### PR DESCRIPTION
This PR fixes an inconsistency between `Input.get_joy_info()` documentation about `xinput_index` and its actual values.
Basically, as it turns out, if SDL can't get a player index from the driver, it assigns one by itself:
https://github.com/godotengine/godot/blob/76addfff12b4dd1b8258ee9f14d4d8e03647cbf0/thirdparty/sdl/joystick/SDL_joystick.c#L2155-L2166
Because of that, this key existed even on platforms that don't have XInput API, see https://github.com/godotengine/godot/pull/113873#pullrequestreview-3661655594

This PR fixes the issue for my DualShock 4:
```gdscript
	print(Input.get_joy_name(0), " ", Input.get_joy_guid(0))
	print(Input.get_joy_info(0))
```
	
```
PS4 Controller 03008fe54c050000cc09000000016800
{ "raw_name": "PS4 Controller", "vendor_id": "1356", "product_id": "2508" }
```
Here's the result of the same code in Godot 4.5:
```
PS4 Controller 03008fe54c050000cc09000000016800
{ "raw_name": "PS4 Controller", "vendor_id": "1356", "product_id": "2508", "xinput_index": "0" }
```