### PR TITLE
Fix incorrect reading of joypad UTF8 `raw_name` in `Input.get_joy_info()`

### DIFF
--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -175,7 +175,7 @@ void JoypadSDL::process_events() {
 				Dictionary joypad_info;
 				// Skip Godot's mapping system if SDL already handles the joypad's mapping.
 				joypad_info["mapping_handled"] = SDL_IsGamepad(sdl_event.jdevice.which);
-				joypad_info["raw_name"] = String(SDL_GetJoystickName(joy));
+				joypad_info["raw_name"] = String::utf8(SDL_GetJoystickName(joy));
 				joypad_info["vendor_id"] = itos(SDL_GetJoystickVendor(joy));
 				joypad_info["product_id"] = itos(SDL_GetJoystickProduct(joy));
 


### PR DESCRIPTION
I didn't know that `SDL_GetJoystickName()` can return a UTF8 string, but I just tried one of my DirectInput controllers and in Godot 4.5 it returns a partially garbled `raw_name`:
```gdscript
	print(Input.get_joy_name(0), " ", Input.get_joy_guid(0))
	print(Input.get_joy_info(0))
```
```
NEXT SNES Controller 0300c1871008000001e5000000000000
{ "raw_name": "(Ð¡ÑÐ°Ð½Ð´Ð°ÑÑÐ½ÑÐµ ÑÐ¸ÑÑÐµÐ¼Ð½ÑÐµ ÑÑÑÑÐ¾Ð¹ÑÑÐ²Ð°) usb gamepad", "vendor_id": "2064", "product_id": "58625", "xinput_index": "0" }
```
With this fix `raw_name` is now readable (in this case, to a Russian speaker):
```
NEXT SNES Controller 0300c1871008000001e5000000000000
{ "raw_name": "(Стандартные системные устройства) usb gamepad", "vendor_id": "2064", "product_id": "58625", "xinput_index": "0" }
```
(For anyone curious, the text in parentheses reads "Standard system devices")
