### PR TITLE
Fix mouse_entered/exited signals not being fired when a Control node has its visibility changed

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3926,6 +3926,9 @@ void Control::_notification(int p_notification) {
 		} break;
 
 		case NOTIFICATION_CHILD_ORDER_CHANGED: {
+			if (get_viewport() != nullptr && !get_viewport()->gui_is_dragging()) {
+				get_viewport()->_update_mouse_over(get_viewport()->get_mouse_position());
+			}
 			// Some parents need to know the order of the children to draw (like TabContainer),
 			// so we update them just in case.
 			queue_redraw();
@@ -3970,6 +3973,9 @@ void Control::_notification(int p_notification) {
 			} else {
 				update_minimum_size();
 				_size_changed();
+				if (get_viewport() != nullptr && !get_viewport()->gui_is_dragging()) {
+					get_viewport()->_update_mouse_over(get_viewport()->get_mouse_position());
+				}
 			}
 		} break;
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2533,6 +2533,7 @@ void Viewport::_gui_hide_control(Control *p_control) {
 	ObjectID over_id = p_control ? p_control->get_instance_id() : ObjectID();
 	if (gui.mouse_over == over_id || gui.mouse_over_hierarchy.has(over_id)) {
 		_drop_mouse_over(p_control->get_parent_control());
+		_update_mouse_over(get_mouse_position());
 	}
 	if (gui.drag_mouse_over == p_control) {
 		gui.drag_mouse_over = nullptr;

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -1035,10 +1035,10 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 			SIGNAL_CHECK(SceneStringName(mouse_entered), signal_args);
 			SIGNAL_CHECK_FALSE(SceneStringName(mouse_exited));
 
-			// Remove node_i from the tree. node_i and node_j should receive Mouse Exit. node_h should not receive any new signals.
+			// Remove node_i from the tree. node_i and node_j should receive Mouse Exit. node_h should receive Mouse Enter.
 			node_h->remove_child(node_i);
 			CHECK(node_h->mouse_over);
-			CHECK_FALSE(node_h->mouse_over_self);
+			CHECK(node_h->mouse_over_self);
 			CHECK_FALSE(node_i->mouse_over);
 			CHECK_FALSE(node_i->mouse_over_self);
 			CHECK_FALSE(node_j->mouse_over);
@@ -1088,10 +1088,10 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 			SIGNAL_CHECK(SceneStringName(mouse_entered), signal_args);
 			SIGNAL_CHECK_FALSE(SceneStringName(mouse_exited));
 
-			// Hide node_i. node_i and node_j should receive Mouse Exit. node_h should not receive any new signals.
+			// Hide node_i. node_i and node_j should receive Mouse Exit. node_h should receive Mouse Enter.
 			node_i->hide();
 			CHECK(node_h->mouse_over);
-			CHECK_FALSE(node_h->mouse_over_self);
+			CHECK(node_h->mouse_over_self);
 			CHECK_FALSE(node_i->mouse_over);
 			CHECK_FALSE(node_i->mouse_over_self);
 			CHECK_FALSE(node_j->mouse_over);


### PR DESCRIPTION
Closes #112513 by adding _update_mouse_over calls when visibility is changed.

As can be seen, the mouse_entered and mouse_exited signals for the two squares are now fired when appropriate.
![](https://imgur.com/zliROag.gif)