### PR TITLE
Fix `Joint3D` gizmos being visible when they shouldn't

### DIFF
--- a/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
@@ -292,17 +292,25 @@ Joint3DGizmoPlugin::Joint3DGizmoPlugin() {
 }
 
 void Joint3DGizmoPlugin::incremental_update_gizmos() {
-	if (!current_gizmos.is_empty()) {
-		HashSet<EditorNode3DGizmo *>::Iterator E = current_gizmos.find(last_drawn);
-		if (E) {
-			++E;
-		}
-		if (!E) {
-			E = current_gizmos.begin();
-		}
-		redraw(*E);
-		last_drawn = *E;
+	if (current_gizmos.is_empty()) {
+		return;
 	}
+
+	HashSet<EditorNode3DGizmo *>::Iterator E = current_gizmos.find(last_drawn);
+	if (E) {
+		++E;
+	}
+	if (!E) {
+		E = current_gizmos.begin();
+	}
+
+	EditorNode3DGizmo *next_gizmo = *E;
+	Node3D *node = next_gizmo->get_node_3d();
+	if (node->is_visible_in_tree()) {
+		redraw(next_gizmo);
+	}
+
+	last_drawn = next_gizmo;
 }
 
 bool Joint3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {


### PR DESCRIPTION
Fixes #113555.

There could be an preexisting PR that tackles this (according to the issue's OP), if it's found and it's in a mergeable state, I will close this one.