### PR TITLE
Add C# Vector Swizzling from Source Generator

### DIFF
--- a/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/VectorSwizzlingGenerator.cs
+++ b/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/VectorSwizzlingGenerator.cs
@@ -69,7 +69,7 @@ namespace Godot.SourceGenerators.Internal
             {
                 for (int j = 0; j < numMembers; j++)
                 {
-                    permutations.Add(new[]{ _members[i], _members[j] });
+                    permutations.Add(new[] { _members[i], _members[j] });
                 }
             }
             for (int i = 0; i < numMembers; i++)

--- a/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/VectorSwizzlingGenerator.cs
+++ b/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/VectorSwizzlingGenerator.cs
@@ -69,7 +69,7 @@ namespace Godot.SourceGenerators.Internal
             {
                 for (int j = 0; j < numMembers; j++)
                 {
-                    permutations.Add(new []{ _members[i], _members[j] });
+                    permutations.Add(new[]{ _members[i], _members[j] });
                 }
             }
             for (int i = 0; i < numMembers; i++)

--- a/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/VectorSwizzlingGenerator.cs
+++ b/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/VectorSwizzlingGenerator.cs
@@ -1,0 +1,101 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Godot.SourceGenerators.Internal
+{
+    [Generator]
+    internal class VectorSwizzlingGenerator : ISourceGenerator
+    {
+        private readonly char[] _members = new char[] { 'X', 'Y', 'Z', 'W' };
+
+        public void Execute(GeneratorExecutionContext context)
+        {
+            // Vector Dimensions
+            for (int d = 2; d <= 4; d++)
+            {
+                GenerateStruct(context, d, string.Empty);
+                GenerateStruct(context, d, "I");
+            }
+        }
+
+        private void GenerateStruct(GeneratorExecutionContext context, int d, string suffix)
+        {
+            StringBuilder sb = new();
+            sb.AppendLine("using System.ComponentModel;");
+            sb.AppendLine("using System.Diagnostics;");
+            sb.AppendLine("");
+            sb.AppendLine("namespace Godot");
+            sb.AppendLine("{");
+            sb.AppendLine($"\tpublic partial struct Vector{d}{suffix}");
+            sb.AppendLine("\t{");
+            foreach (char[] per in GetPermutations(d))
+            {
+                string name = new string(per);
+                int retrLength = per.Length;
+                string components = string.Join(", ", per);
+                sb.AppendLine("\t\t/// <summary>");
+                sb.AppendLine($"\t\t/// Swizzle operator returning a <see cref=\"Vector{retrLength}{suffix}\"/> with components {components} from this vector");
+                sb.AppendLine("\t\t/// </summary>");
+                sb.AppendLine("\t\t[EditorBrowsable(EditorBrowsableState.Never)]");
+                sb.AppendLine("\t\t[DebuggerBrowsable(DebuggerBrowsableState.Never)]");
+                sb.Append($"\t\tpublic readonly Vector{retrLength}{suffix} {name} => new");
+                sb.Append("(");
+                for (int i = 0; i < retrLength; i++)
+                {
+                    sb.Append($"{per[i]}");
+                    if (i != retrLength - 1)
+                    {
+                        sb.Append(", ");
+                    }
+                }
+                sb.AppendLine(");");
+                sb.AppendLine();
+            }
+            sb.AppendLine("\t}");
+            sb.AppendLine("}");
+            context.AddSource($"Vector{d}{suffix}.Swizzling.generator", SourceText.From(sb.ToString(), Encoding.UTF8));
+        }
+
+        public void Initialize(GeneratorInitializationContext context)
+        {
+        }
+
+        private List<char[]> GetPermutations(int numMembers)
+        {
+            List<char[]> permutations = new();
+            for (int i = 0; i < numMembers; i++)
+            {
+                for (int j = 0; j < numMembers; j++)
+                {
+                    permutations.Add(new []{ _members[i], _members[j] });
+                }
+            }
+            for (int i = 0; i < numMembers; i++)
+            {
+                for (int j = 0; j < numMembers; j++)
+                {
+                    for (int k = 0; k < numMembers; k++)
+                    {
+                        permutations.Add(new[] { _members[i], _members[j], _members[k] });
+                    }
+                }
+            }
+            for (int i = 0; i < numMembers; i++)
+            {
+                for (int j = 0; j < numMembers; j++)
+                {
+                    for (int k = 0; k < numMembers; k++)
+                    {
+                        for (int l = 0; l < numMembers; l++)
+                        {
+                            permutations.Add(new[] { _members[i], _members[j], _members[k], _members[l] });
+                        }
+                    }
+                }
+            }
+            return permutations;
+        }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp.SourceGenerators/GodotSharp.SourceGenerators.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp.SourceGenerators/GodotSharp.SourceGenerators.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>10</LangVersion>
+    <Nullable>enable</Nullable>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/modules/mono/glue/GodotSharp/GodotSharp.SourceGenerators/VectorSwizzlingGenerator.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp.SourceGenerators/VectorSwizzlingGenerator.cs
@@ -3,7 +3,7 @@ using Microsoft.CodeAnalysis.Text;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Godot.SourceGenerators.Internal
+namespace GodotSharp.SourceGenerators
 {
     [Generator]
     internal class VectorSwizzlingGenerator : ISourceGenerator
@@ -55,7 +55,7 @@ namespace Godot.SourceGenerators.Internal
             }
             sb.AppendLine("\t}");
             sb.AppendLine("}");
-            context.AddSource($"Vector{d}{suffix}.Swizzling.generator", SourceText.From(sb.ToString(), Encoding.UTF8));
+            context.AddSource($"Vector{d}{suffix}.Swizzling.generated", SourceText.From(sb.ToString(), Encoding.UTF8));
         }
 
         public void Initialize(GeneratorInitializationContext context)

--- a/modules/mono/glue/GodotSharp/GodotSharp.SourceGenerators/VectorSwizzlingGenerator.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp.SourceGenerators/VectorSwizzlingGenerator.cs
@@ -32,26 +32,35 @@ namespace GodotSharp.SourceGenerators
             sb.AppendLine("\t{");
             foreach (char[] per in GetPermutations(d))
             {
+                bool produceSetter = IsSetterLegal(per);
                 string name = new string(per);
                 int retrLength = per.Length;
                 string components = string.Join(", ", per);
                 sb.AppendLine("\t\t/// <summary>");
-                sb.AppendLine($"\t\t/// Swizzle operator returning a <see cref=\"Vector{retrLength}{suffix}\"/> with components {components} from this vector");
+                sb.Append($"\t\t/// Swizzle operator, gets a <see cref=\"Vector{retrLength}{suffix}\"/> with components {components} from this vector");
+                if (produceSetter)
+                    sb.Append($" or sets the components in this vector in the order of {components} from the given vector");
+                sb.AppendLine(".");
                 sb.AppendLine("\t\t/// </summary>");
-                sb.AppendLine("\t\t[EditorBrowsable(EditorBrowsableState.Never)]");
-                sb.AppendLine("\t\t[DebuggerBrowsable(DebuggerBrowsableState.Never)]");
-                sb.Append($"\t\tpublic readonly Vector{retrLength}{suffix} {name} => new");
-                sb.Append("(");
-                for (int i = 0; i < retrLength; i++)
+                sb.AppendLine("\t\t[EditorBrowsable(EditorBrowsableState.Never), DebuggerBrowsable(DebuggerBrowsableState.Never)]");
+                if (produceSetter)
                 {
-                    sb.Append($"{per[i]}");
-                    if (i != retrLength - 1)
+                    sb.AppendLine($"\t\tpublic Vector{retrLength}{suffix} {name}");
+                    sb.AppendLine("\t\t{");
+                    sb.AppendLine($"\t\t\treadonly get => new({components});");
+                    sb.AppendLine("\t\t\tset");
+                    sb.AppendLine("\t\t\t{");
+                    for (int i = 0; i < retrLength; i++)
                     {
-                        sb.Append(", ");
+                        sb.AppendLine($"\t\t\t\t{per[i]} = value.{_members[i]};");
                     }
+                    sb.AppendLine("\t\t\t}");
+                    sb.AppendLine("\t\t}");
                 }
-                sb.AppendLine(");");
-                sb.AppendLine();
+                else
+                {
+                    sb.AppendLine($"\t\tpublic readonly Vector{retrLength}{suffix} {name} => new({components});");
+                }
             }
             sb.AppendLine("\t}");
             sb.AppendLine("}");
@@ -60,6 +69,13 @@ namespace GodotSharp.SourceGenerators
 
         public void Initialize(GeneratorInitializationContext context)
         {
+        }
+
+        private bool IsSetterLegal(char[] per)
+        {
+            // Swizzling is not allowed when we have duplicate members to avoid undefined behavior
+            HashSet<char> distinct = new(per);
+            return per.Length == distinct.Count;
         }
 
         private List<char[]> GetPermutations(int numMembers)

--- a/modules/mono/glue/GodotSharp/GodotSharp.sln
+++ b/modules/mono/glue/GodotSharp/GodotSharp.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GodotPlugins", "GodotPlugin
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Godot.SourceGenerators.Internal", "Godot.SourceGenerators.Internal\Godot.SourceGenerators.Internal.csproj", "{7749662B-E30C-419A-B745-13852573360A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GodotSharp.SourceGenerators", "GodotSharp.SourceGenerators\GodotSharp.SourceGenerators.csproj", "{03EA49A9-4775-4DCD-ABFC-6EDAFC12D025}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{7749662B-E30C-419A-B745-13852573360A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7749662B-E30C-419A-B745-13852573360A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7749662B-E30C-419A-B745-13852573360A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03EA49A9-4775-4DCD-ABFC-6EDAFC12D025}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03EA49A9-4775-4DCD-ABFC-6EDAFC12D025}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03EA49A9-4775-4DCD-ABFC-6EDAFC12D025}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03EA49A9-4775-4DCD-ABFC-6EDAFC12D025}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -12,7 +12,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector2 : IEquatable<Vector2>
+    public partial struct Vector2 : IEquatable<Vector2>
     {
         /// <summary>
         /// Enumerated index values for the axes.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
@@ -12,7 +12,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector2I : IEquatable<Vector2I>
+    public partial struct Vector2I : IEquatable<Vector2I>
     {
         /// <summary>
         /// Enumerated index values for the axes.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -12,7 +12,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector3 : IEquatable<Vector3>
+    public partial struct Vector3 : IEquatable<Vector3>
     {
         /// <summary>
         /// Enumerated index values for the axes.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
@@ -12,7 +12,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector3I : IEquatable<Vector3I>
+    public partial struct Vector3I : IEquatable<Vector3I>
     {
         /// <summary>
         /// Enumerated index values for the axes.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
@@ -12,7 +12,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector4 : IEquatable<Vector4>
+    public partial struct Vector4 : IEquatable<Vector4>
     {
         /// <summary>
         /// Enumerated index values for the axes.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
@@ -12,7 +12,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector4I : IEquatable<Vector4I>
+    public partial struct Vector4I : IEquatable<Vector4I>
     {
         /// <summary>
         /// Enumerated index values for the axes.

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -50,6 +50,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Godot.SourceGenerators.Internal\Godot.SourceGenerators.Internal.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\GodotSharp.SourceGenerators\GodotSharp.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <!-- Sources -->


### PR DESCRIPTION
This PR adds a source generator to GodotSharp which generates swizzling properties for all vector structs.
All properties generated are not EditorBrowsable nor DebuggerBrowsable.
~Only getters are generated, but the source generator can easily be extended to generate setters as well.~

This way of implementing this feature was already discussed in #93012 and discussed in [this proposal](https://github.com/godotengine/godot-proposals/issues/727) and circumvents the down-side of having hardcoded properties.

Example of usage:
```C#
Vector3 vec3 = new Vector3(1, 2, 3);
Vector4 vec4 = vec3.ZYXZ;
Print(vec4); // [3, 2, 1, 3]
Vector2 vec2 = vec3.XY;
Print(vec2); // [1, 2]
vec2.YX = new Vector2(5, 6);
Print(vec2); // [6, 5]
```