### PR TITLE
Fix detection of some features in Engine Compilation Configuration Editor

### DIFF
--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -628,20 +628,24 @@ EditorBuildProfile::EditorBuildProfile() {
 		{ "xr/openxr/enabled", { true } },
 	};
 	build_option_settings.insert(BUILD_OPTION_OPENXR, settings_openxr);
+
 	HashMap<String, LocalVector<Variant>> settings_wayland = {
 		{ "display/display_server/driver.linuxbsd", { "default", "wayland" } },
 	};
-	build_option_settings.insert(BUILD_OPTION_OPENXR, settings_wayland);
+	build_option_settings.insert(BUILD_OPTION_WAYLAND, settings_wayland);
+
 	HashMap<String, LocalVector<Variant>> settings_x11 = {
 		{ "display/display_server/driver.linuxbsd", { "default", "x11" } },
 	};
-	build_option_settings.insert(BUILD_OPTION_OPENXR, settings_x11);
+	build_option_settings.insert(BUILD_OPTION_X11, settings_x11);
+
 	HashMap<String, LocalVector<Variant>> settings_rd = {
 		{ "rendering/renderer/rendering_method", { "forward_plus", "mobile" } },
 		{ "rendering/renderer/rendering_method.mobile", { "forward_plus", "mobile" } },
 		{ "rendering/renderer/rendering_method.web", { "forward_plus", "mobile" } },
 	};
 	build_option_settings.insert(BUILD_OPTION_RENDERING_DEVICE, settings_rd);
+
 	HashMap<String, LocalVector<Variant>> settings_vulkan = {
 		{ "rendering/rendering_device/driver", { "vulkan" } },
 		{ "rendering/rendering_device/driver.windows", { "vulkan" } },
@@ -652,6 +656,7 @@ EditorBuildProfile::EditorBuildProfile() {
 		{ "rendering/rendering_device/fallback_to_vulkan", { true } },
 	};
 	build_option_settings.insert(BUILD_OPTION_VULKAN, settings_vulkan);
+
 	HashMap<String, LocalVector<Variant>> settings_d3d12 = {
 		{ "rendering/rendering_device/driver", { "d3d12" } },
 		{ "rendering/rendering_device/driver.windows", { "d3d12" } },
@@ -661,13 +666,15 @@ EditorBuildProfile::EditorBuildProfile() {
 		{ "rendering/rendering_device/driver.macos", { "d3d12" } },
 		{ "rendering/rendering_device/fallback_to_d3d12", { true } },
 	};
-	build_option_settings.insert(BUILD_OPTION_VULKAN, settings_vulkan);
+	build_option_settings.insert(BUILD_OPTION_D3D12, settings_d3d12);
+
 	HashMap<String, LocalVector<Variant>> settings_metal = {
 		{ "rendering/rendering_device/driver", { "metal" } },
 		{ "rendering/rendering_device/driver.ios", { "metal" } },
 		{ "rendering/rendering_device/driver.macos", { "metal" } },
 	};
 	build_option_settings.insert(BUILD_OPTION_METAL, settings_metal);
+
 	HashMap<String, LocalVector<Variant>> settings_opengl = {
 		{ "rendering/renderer/rendering_method", { "gl_compatibility" } },
 		{ "rendering/renderer/rendering_method.mobile", { "gl_compatibility" } },
@@ -675,14 +682,17 @@ EditorBuildProfile::EditorBuildProfile() {
 		{ "rendering/rendering_device/fallback_to_opengl3", { true } },
 	};
 	build_option_settings.insert(BUILD_OPTION_OPENGL, settings_opengl);
+
 	HashMap<String, LocalVector<Variant>> settings_phy_godot_3d = {
 		{ "physics/3d/physics_engine", { "DEFAULT", "GodotPhysics3D" } },
 	};
 	build_option_settings.insert(BUILD_OPTION_PHYSICS_GODOT_3D, settings_phy_godot_3d);
+
 	HashMap<String, LocalVector<Variant>> settings_jolt = {
 		{ "physics/3d/physics_engine", { "Jolt Physics" } },
 	};
 	build_option_settings.insert(BUILD_OPTION_PHYSICS_JOLT, settings_jolt);
+
 	HashMap<String, LocalVector<Variant>> settings_msdfgen = {
 		{ "gui/theme/default_font_multichannel_signed_distance_field", { true } },
 	};


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/115229 (can be merged independently).

A copy-paste error led to some incorrect feature detections, specifically for X11, Wayland and Direct3D 12.

This adds blank lines between options to reduce the risk of future typos.
