### PR TITLE
Improve errors for invalid `build_profile` SCons options

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -648,8 +648,11 @@ if env["build_profile"] != "":
             dbo = ft["disabled_build_options"]
             for c in dbo:
                 env[c] = dbo[c]
-    except json.JSONDecodeError:
-        print_error(f'Failed to open feature build profile: "{env["build_profile"]}"')
+    except json.JSONDecodeError as err:
+        print_error(f'Failed to open feature build profile due to JSON decoding error: "{env["build_profile"]}"\n{err}')
+        Exit(255)
+    except FileNotFoundError:
+        print_error(f'Feature build profile not found at: "{env["build_profile"]}"')
         Exit(255)
 
 # 'dev_mode' and 'production' are aliases to set default options if they haven't been


### PR DESCRIPTION
- Use a colored print when the file isn't found.
- Mention that the file is invalid JSON in the decoding error, and mention the location of the error.

Hand-editing build profile files has shown me that one *will* eventually introduce trailing commas, and it's not valid JSON :slightly_smiling_face: 

This improves information for troubleshooting such cases.

## Preview

### File not found

```
ERROR: Feature build profile not found at: "/path/to/not_found.gdbuild"
```

### Invalid JSON

```
ERROR: Failed to open feature build profile due to JSON decoding error: "/path/to/invalid.gdbuild"
Illegal trailing comma before end of object: line 7 column 33 (char 197)
```
