### PR TITLE
Fix reflection probe rendering with low roughness

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3232,6 +3232,7 @@
 		</member>
 		<member name="rendering/reflections/sky_reflections/roughness_layers" type="int" setter="" getter="" default="7">
 			Limits the number of layers to use in radiance maps when using importance sampling. A lower number will be slightly faster and take up less VRAM.
+			[b]Note:[/b] Values less than 2 are not allowed because they cause significant lighting artifacts.
 		</member>
 		<member name="rendering/reflections/sky_reflections/texture_array_reflections" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], uses texture arrays instead of mipmaps for reflection probes and panorama backgrounds (sky). This reduces jitter noise and upscaling artifacts on reflections, but is significantly slower to compute and uses [member rendering/reflections/sky_reflections/roughness_layers] times more memory.

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4490,7 +4490,7 @@ void fragment() {
 
 	{
 		// Initialize Sky stuff
-		sky_globals.roughness_layers = GLOBAL_GET("rendering/reflections/sky_reflections/roughness_layers");
+		sky_globals.roughness_layers = MAX(2, (int)GLOBAL_GET("rendering/reflections/sky_reflections/roughness_layers"));
 
 		String global_defines;
 		global_defines += "#define MAX_GLOBAL_SHADER_UNIFORMS 256\n"; // TODO: this is arbitrary for now

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -340,7 +340,7 @@ void SkyRD::ReflectionData::update_reflection_data(int p_size, int p_mipmaps, bo
 	tf.format = p_texture_format;
 	tf.width = p_low_quality ? 160 : p_size >> 1; // Always 160x160 when using REALTIME.
 	tf.height = p_low_quality ? 160 : p_size >> 1;
-	tf.mipmaps = p_low_quality ? 5 : mipmaps - 1;
+	tf.mipmaps = p_low_quality ? 5 : MAX(mipmaps - 1, 1);
 	tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
 	if (!use_raster_effect) {
 		tf.usage_bits |= RD::TEXTURE_USAGE_STORAGE_BIT;

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -340,7 +340,7 @@ void SkyRD::ReflectionData::update_reflection_data(int p_size, int p_mipmaps, bo
 	tf.format = p_texture_format;
 	tf.width = p_low_quality ? 160 : p_size >> 1; // Always 160x160 when using REALTIME.
 	tf.height = p_low_quality ? 160 : p_size >> 1;
-	tf.mipmaps = p_low_quality ? 5 : MAX(mipmaps - 1, 1);
+	tf.mipmaps = p_low_quality ? 5 : mipmaps - 1;
 	tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
 	if (!use_raster_effect) {
 		tf.usage_bits |= RD::TEXTURE_USAGE_STORAGE_BIT;
@@ -693,7 +693,7 @@ RendererRD::MaterialStorage::MaterialData *SkyRD::_create_sky_material_funcs(Ren
 }
 
 SkyRD::SkyRD() {
-	roughness_layers = GLOBAL_GET("rendering/reflections/sky_reflections/roughness_layers");
+	roughness_layers = MAX(2, (int)GLOBAL_GET("rendering/reflections/sky_reflections/roughness_layers"));
 	sky_ggx_samples_quality = GLOBAL_GET("rendering/reflections/sky_reflections/ggx_samples");
 	sky_use_octmap_array = GLOBAL_GET("rendering/reflections/sky_reflections/texture_array_reflections");
 }

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1658,7 +1658,7 @@ bool LightStorage::reflection_probe_instance_postprocess_step(RID p_instance) {
 		return true;
 	}
 
-	// Roughness layers are too low, skip processing
+	// Roughness layers are too few, skip processing.
 	int mipmap_count = (int)atlas->reflections[rpi->atlas_index].data.layers[0].mipmaps.size();
 	if (rpi->processing_layer >= mipmap_count) {
 		rpi->rendering = false;

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1658,6 +1658,14 @@ bool LightStorage::reflection_probe_instance_postprocess_step(RID p_instance) {
 		return true;
 	}
 
+	// Roughness layers are too low, skip processing
+	int mipmap_count = (int)atlas->reflections[rpi->atlas_index].data.layers[0].mipmaps.size();
+	if (rpi->processing_layer >= mipmap_count) {
+		rpi->rendering = false;
+		rpi->processing_layer = 1;
+		return true;
+	}
+
 	atlas->reflections.write[rpi->atlas_index].data.create_reflection_importance_sample(false, rpi->processing_layer, RendererSceneRenderRD::get_singleton()->get_sky()->sky_ggx_samples_quality);
 
 	rpi->processing_layer++;

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3724,7 +3724,7 @@ void RenderingServer::init() {
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/strip_debug", false);
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/strip_debug.release", true);
 
-	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/reflections/sky_reflections/roughness_layers", PROPERTY_HINT_RANGE, "1,32,1"), 7);
+	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/reflections/sky_reflections/roughness_layers", PROPERTY_HINT_RANGE, "2,32,1"), 7);
 	GLOBAL_DEF_RST("rendering/reflections/sky_reflections/texture_array_reflections", true);
 	GLOBAL_DEF("rendering/reflections/sky_reflections/texture_array_reflections.mobile", false);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/reflections/sky_reflections/ggx_samples", PROPERTY_HINT_RANGE, "0,256,1"), 32);


### PR DESCRIPTION
Addresses https://github.com/godotengine/godot/issues/115216.

My understanding is: for projects with low `reflections/sky_reflections/roughness_layers`, not enough mipmaps are available to generate multiple layers of lighting reflections. This change prevents attempting to generate additional lighting layers when the layer count has surpassed the mipmap count.

After confirming this bug locally and applying this fix, I confirmed it seems to work on the surface. Would appreciate some extra eyes!

I was able to confirm + fix this in Forward+, but I was not able to reproduce in Mobile.

Based on https://github.com/godotengine/godot/pull/104302, I also wonder if this should show a warning somewhere? 

Recording of it working:
[Screencast_20260121_235020.webm](https://github.com/user-attachments/assets/9d773c46-bb8f-4488-8605-86a1ef9a6fec)

