### PR TITLE
Wayland: Update popup scale information on creation

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -1197,7 +1197,7 @@ void WaylandThread::_wl_surface_on_enter(void *data, struct wl_surface *wl_surfa
 	WindowState *ws = (WindowState *)data;
 	ERR_FAIL_NULL(ws);
 
-	DEBUG_LOG_WAYLAND_THREAD(vformat("Window entered output %x.\n", (size_t)wl_output));
+	DEBUG_LOG_WAYLAND_THREAD(vformat("Window entered output %x.", (size_t)wl_output));
 
 	ws->wl_outputs.insert(wl_output);
 
@@ -3912,6 +3912,12 @@ void WaylandThread::window_create_popup(DisplayServer::WindowID p_window_id, Dis
 
 	p_rect.position = scale_vector2i(p_rect.position, 1.0 / parent_scale);
 	p_rect.size = scale_vector2i(p_rect.size, 1.0 / parent_scale);
+
+	// We manually scaled based on the parent. If we don't set the relevant fields,
+	// the resizing routines will get confused and scale once more.
+	ws.preferred_fractional_scale = parent.preferred_fractional_scale;
+	ws.fractional_scale = parent.fractional_scale;
+	ws.buffer_scale = parent.buffer_scale;
 
 	ws.id = p_window_id;
 	ws.parent_id = p_parent_id;

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -305,6 +305,9 @@ public:
 		// NOTE: The preferred buffer scale is currently only dynamically calculated.
 		// It can be accessed by calling `window_state_get_preferred_buffer_scale`.
 
+		// NOTE: Popups manually inherit the parent's scale on creation. Make sure to
+		// sync them up with any new fields.
+
 		// Override used by the fractional scale add-on object. If less or equal to 0
 		// (default) then the normal output-based scale is used instead.
 		double fractional_scale = 0;


### PR DESCRIPTION
Fixes #115221.

Popups start with their size and position already scaled based on the parent. We forgot to update the popup's scale itself, leading to a double-scale.

---

This is somewhat manual but it's arguably the simplest solution. I added a note to sync the method so that hopefully this won't bite us in the future.

Also removes an extra newline in a debug string.