### PR TITLE
Defer play calls until after layout update

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5345,7 +5345,11 @@ void EditorNode::_quick_opened(const String &p_file_path) {
 	load_scene_or_resource(p_file_path);
 }
 
-void EditorNode::_project_run_started() {
+// Applies editor configuration and updates editor docks that must be
+// processed before starting a run. This is intentionally separated from
+// the play_pressed signal to allow layout and state updates to complete prior to
+// executing the run logic.
+void EditorNode::open_dock_editor_config() {
 	if (bool(EDITOR_GET("run/output/always_clear_output_on_play"))) {
 		log->clear();
 	}
@@ -8853,7 +8857,6 @@ EditorNode::EditorNode() {
 	project_run_bar = memnew(EditorRunBar);
 	project_run_bar->set_mouse_filter(Control::MOUSE_FILTER_STOP);
 	title_bar->add_child(project_run_bar);
-	project_run_bar->connect("play_pressed", callable_mp(this, &EditorNode::_project_run_started));
 	project_run_bar->connect("stop_pressed", callable_mp(this, &EditorNode::_project_run_stopped));
 
 	right_menu_hb = memnew(HBoxContainer);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -605,7 +605,6 @@ private:
 	void _quick_opened(const String &p_file_path);
 	void _open_command_palette();
 
-	void _project_run_started();
 	void _project_run_stopped();
 
 	void _update_prev_closed_scenes(const String &p_scene_path, bool p_add_scene);
@@ -1047,6 +1046,8 @@ public:
 	bool ensure_main_scene(bool p_from_native);
 	bool validate_custom_directory();
 	void run_editor_script(const Ref<Script> &p_script);
+
+	void open_dock_editor_config();
 };
 
 struct EditorProgressBG {

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -401,11 +401,19 @@ void EditorRunBar::play_main_scene(bool p_from_native, const Vector<String> &p_p
 		return;
 	}
 
+	// Ensure editor configuration and layout are fully applied before running.
+	// This avoids starting the run with a partially initialized editor state.
+	EditorNode::get_singleton()->open_dock_editor_config();
+
+	// Defer execution to the next frame to ensure editor layout and configuration.
+	get_tree()->connect(SNAME("process_frame"), callable_mp(this, &EditorRunBar::_play_main_scene_deferred).bind(p_from_native, p_play_args), CONNECT_ONE_SHOT);
+}
+
+void EditorRunBar::_play_main_scene_deferred(bool p_from_native, const Vector<String> &p_play_args) {
 	if (p_from_native) {
 		run_native->resume_run_native();
 	} else {
 		stop_playing();
-
 		current_mode = RunMode::RUN_MAIN;
 		_run_scene("", p_play_args);
 	}
@@ -417,12 +425,21 @@ void EditorRunBar::play_current_scene(bool p_reload, const Vector<String> &p_pla
 		return;
 	}
 
-	String last_current_scene = run_current_filename; // This is necessary to have a copy of the string.
+	// Ensure editor configuration and layout are fully applied before running.
+	// This avoids starting the run with a partially initialized editor state.
+	EditorNode::get_singleton()->open_dock_editor_config();
 
+	// Defer execution to the next frame to ensure editor layout and configuration.
+	get_tree()->connect(SNAME("process_frame"), callable_mp(this, &EditorRunBar::_play_current_scene_deferred).bind(p_reload, p_play_args), CONNECT_ONE_SHOT);
+}
+
+void EditorRunBar::_play_current_scene_deferred(bool p_reload, const Vector<String> &p_play_args) {
+	String last_current_scene = run_current_filename; // This is necessary to have a copy of the string.
 	EditorNode::get_singleton()->save_default_environment();
 	stop_playing();
 
 	current_mode = RunMode::RUN_CURRENT;
+
 	if (p_reload) {
 		_run_scene(last_current_scene, p_play_args);
 	} else {
@@ -436,8 +453,16 @@ void EditorRunBar::play_custom_scene(const String &p_custom, const Vector<String
 		return;
 	}
 
-	stop_playing();
+	// Ensure editor configuration and layout are fully applied before running.
+	// This avoids starting the run with a partially initialized editor state.
+	EditorNode::get_singleton()->open_dock_editor_config();
 
+	// Defer execution to the next frame to ensure editor layout and configuration.
+	get_tree()->connect(SNAME("process_frame"), callable_mp(this, &EditorRunBar::_play_custom_scene_deferred).bind(p_custom, p_play_args), CONNECT_ONE_SHOT);
+}
+
+void EditorRunBar::_play_custom_scene_deferred(const String &p_custom, const Vector<String> &p_play_args) {
+	stop_playing();
 	current_mode = RunMode::RUN_CUSTOM;
 	_run_scene(p_custom, p_play_args);
 }

--- a/editor/run/editor_run_bar.h
+++ b/editor/run/editor_run_bar.h
@@ -109,6 +109,10 @@ class EditorRunBar : public MarginContainer {
 private:
 	static Vector<String> _get_xr_mode_play_args(RunXRModeMenuItem p_menu_item);
 
+	void _play_main_scene_deferred(bool p_from_native, const Vector<String> &p_play_args);
+	void _play_current_scene_deferred(bool p_reload, const Vector<String> &p_play_args);
+	void _play_custom_scene_deferred(const String &p_custom, const Vector<String> &p_play_args);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
# Fix: Defer play calls until after layout update

Fixes: #113462 #114954

## Context

When starting the project from the editor (Play, Play Current Scene, or Play Custom Scene), some editor UI elements
(bottom panel, output, debugger) were being opened **in the same frame** as the play request.

This caused the editor to sometimes start the run while the layout was still being updated, leading to partially
initialized UI state.

## Problem

Previously, editor configuration logic (clearing output, opening docks) was executed directly from the `play_pressed`
flow. Even when using `call_deferred()`, execution could still occur during the same frame, before layout updates were
fully applied.

This resulted in:

- Editor layout not fully updated before play
- Output/debugger panels opening too late or in inconsistent state
- Play starting while editor UI was still settling

## Solution

This PR introduces a clear separation between:

1. **Editor configuration/layout updates**
2. **Play execution**

The solution ensures that:

- Editor layout and configuration updates are applied first
- Play execution is deferred to the **next frame**, after the full frame is processed

### Key changes

#### 1. Extract editor configuration logic

A new method was introduced in `EditorNode` to explicitly handle editor UI configuration:

```cpp
void EditorNode::open_dock_editor_config() {
    if (bool(EDITOR_GET("run/output/always_clear_output_on_play"))) {
        log->clear();
    }

    int action_on_play = EDITOR_GET("run/bottom_panel/action_on_play");
    if (action_on_play == ACTION_ON_PLAY_OPEN_OUTPUT) {
        editor_dock_manager->open_dock(log, true);
    } else if (action_on_play == ACTION_ON_PLAY_OPEN_DEBUGGER) {
        editor_dock_manager->open_dock(EditorDebuggerNode::get_singleton(), true);
    }
}
```

This method is no longer executed directly from the play button signal, allowing it to be called at a controlled point
in the execution flow.

#### 2. Ensure editor configuration runs before play

Before starting the run, the editor configuration is explicitly applied:

```cpp
EditorNode::get_singleton()->open_dock_editor_config();
```

This guarantees that editor state changes happen **before** play is scheduled.

#### 3. Defer play execution to the next frame

Instead of using `call_deferred()`, a zero-time timer is used to defer execution to the **next full frame**:

```cpp
// Defer execution to the next frame to ensure editor layout and configuration.
get_tree()->connect(SNAME("process_frame"), callable_mp(this, &EditorRunBar::_play_main_scene_deferred).bind(p_from_native, p_play_args), CONNECT_ONE_SHOT);
```

This ensures:

- Layout updates are fully processed
- Editor docks are correctly opened
- Play starts from a stable editor state

The same approach is applied consistently to:

- Play Main Scene
- Play Current Scene
- Play Custom Scene

## Result

- Editor UI is fully configured before play
- Play execution happens from a stable state
- Removes race conditions between layout updates and run startup
- Improves consistency across all play modes

## Summary

This PR fixes a timing issue in the editor play flow by:

- Separating editor configuration from play execution
- Deferring play calls until after layout updates
- Making the execution order explicit and reliable

---

Watch the video: https://youtu.be/d4LSpbCinCw

---

![4](https://github.com/user-attachments/assets/1e61124b-4388-4c2d-87d0-7dec9f128b68)

![1](https://github.com/user-attachments/assets/eda2a5a2-d6c1-4cd9-b568-092f288581a9)

![2](https://github.com/user-attachments/assets/76907e96-b4bb-4bf0-8470-38347bf625e8)

![3](https://github.com/user-attachments/assets/90c7d9b4-707c-4740-9293-530d147fce52)

---
