### PR TITLE
Process events during splash on macOS only.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4725,6 +4725,8 @@ int Main::start() {
 
 	GDExtensionManager::get_singleton()->startup();
 
+#ifdef MACOS_ENABLED
+	// TODO: Used to fix full-screen splash drawing on macOS, processing events before main loop is fully initialized cause issues on Wayland, and has no effect on other platforms.
 	if (minimum_time_msec) {
 		int64_t minimum_time = 1000 * minimum_time_msec;
 		uint64_t prev_time = OS::get_singleton()->get_ticks_usec();
@@ -4739,6 +4741,15 @@ int Main::start() {
 	} else {
 		DisplayServer::get_singleton()->process_events();
 	}
+#else
+	if (minimum_time_msec) {
+		uint64_t minimum_time = 1000 * minimum_time_msec;
+		uint64_t elapsed_time = OS::get_singleton()->get_ticks_usec();
+		if (elapsed_time < minimum_time) {
+			OS::get_singleton()->delay_usec(minimum_time - elapsed_time);
+		}
+	}
+#endif
 
 	OS::get_singleton()->benchmark_end_measure("Startup", "Main::Start");
 	OS::get_singleton()->benchmark_dump();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/115246