### PR TITLE
Expose the Geometry2D.segment_intersects_rect method to the scripting API.

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -905,6 +905,10 @@ bool Geometry2D::is_point_in_circle(const Vector2 &p_point, const Vector2 &p_cir
 	return ::Geometry2D::is_point_in_circle(p_point, p_circle_pos, p_circle_radius);
 }
 
+bool Geometry2D::segment_intersects_rect(const Vector2 &p_from, const Vector2 &p_to, const Rect2 &p_rect) {
+	return ::Geometry2D::segment_intersects_rect(p_from, p_to, p_rect);
+}
+
 real_t Geometry2D::segment_intersects_circle(const Vector2 &p_from, const Vector2 &p_to, const Vector2 &p_circle_pos, real_t p_circle_radius) {
 	return ::Geometry2D::segment_intersects_circle(p_from, p_to, p_circle_pos, p_circle_radius);
 }
@@ -1105,6 +1109,7 @@ TypedArray<Point2i> Geometry2D::bresenham_line(const Point2i &p_from, const Poin
 void Geometry2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_point_in_circle", "point", "circle_position", "circle_radius"), &Geometry2D::is_point_in_circle);
 	ClassDB::bind_method(D_METHOD("segment_intersects_circle", "segment_from", "segment_to", "circle_position", "circle_radius"), &Geometry2D::segment_intersects_circle);
+	ClassDB::bind_method(D_METHOD("segment_intersects_rect", "from", "to", "rect"), &Geometry2D::segment_intersects_rect);
 	ClassDB::bind_method(D_METHOD("segment_intersects_segment", "from_a", "to_a", "from_b", "to_b"), &Geometry2D::segment_intersects_segment);
 	ClassDB::bind_method(D_METHOD("line_intersects_line", "from_a", "dir_a", "from_b", "dir_b"), &Geometry2D::line_intersects_line);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -330,6 +330,7 @@ protected:
 public:
 	static Geometry2D *get_singleton();
 	Variant segment_intersects_segment(const Vector2 &p_from_a, const Vector2 &p_to_a, const Vector2 &p_from_b, const Vector2 &p_to_b);
+	bool segment_intersects_rect(const Vector2 &p_from, const Vector2 &p_to, const Rect2 &p_rect);
 	Variant line_intersects_line(const Vector2 &p_from_a, const Vector2 &p_dir_a, const Vector2 &p_from_b, const Vector2 &p_dir_b);
 	Vector<Vector2> get_closest_points_between_segments(const Vector2 &p1, const Vector2 &q1, const Vector2 &p2, const Vector2 &q2);
 	Vector2 get_closest_point_to_segment(const Vector2 &p_point, const Vector2 &p_a, const Vector2 &p_b);

--- a/doc/classes/Geometry2D.xml
+++ b/doc/classes/Geometry2D.xml
@@ -245,6 +245,16 @@
 				Given the 2D segment ([param segment_from], [param segment_to]), returns the position on the segment (as a number between 0 and 1) at which the segment hits the circle that is located at position [param circle_position] and has radius [param circle_radius]. If the segment does not intersect the circle, -1 is returned (this is also the case if the line extending the segment would intersect the circle, but the segment does not).
 			</description>
 		</method>
+		<method name="segment_intersects_rect">
+			<return type="bool" />
+			<param index="0" name="from" type="Vector2" />
+			<param index="1" name="to" type="Vector2" />
+			<param index="2" name="rect" type="Rect2" />
+			<description>
+				Returns [code]true[/code] if the 2D segment ([param from], [param to]) intersects the given [param rect], otherwise returns [code]false[/code].
+				This method checks if either endpoint of the segment is inside the rectangle, or if the segment crosses any of the rectangle's four edges.
+			</description>
+		</method>
 		<method name="segment_intersects_segment">
 			<return type="Variant" />
 			<param index="0" name="from_a" type="Vector2" />


### PR DESCRIPTION
Fixed #115250

## Overview
Expose the `Geometry2D.segment_intersects_rect` method to the scripting API, enabling script-level access to line segment vs rectangle intersection detection.

## Motivation
The `segment_intersects_rect` method is already implemented in C++ but not accessible to scripting languages (e.g. GDScript/C#). This forces users to reimplement line segment-rectangle intersection logic manually in scripts, leading to code duplication and inconsistent implementations.

## Implementation Details
### Modified Files
1. `core/core_bind.h` - Add method declaration
2. `core/core_bind.cpp` - Add method wrapper and binding

### Code Changes
#### 1. core/core_bind.h
Add the method declaration in the `CoreBind::Geometry2D` class (public section):
```cpp
static bool segment_intersects_rect(const Vector2 &p_from, const Vector2 &p_to, const Rect2 &p_rect);
```

2. core/core_bind.cpp
Add the method implementation (in Geometry2D method implementation section):
```cpp
bool CoreBind::Geometry2D::segment_intersects_rect(const Vector2 &p_from, const Vector2 &p_to, const Rect2 &p_rect) {  
    return ::Geometry2D::segment_intersects_rect(p_from, p_to, p_rect);  
}
```

Add the method binding in _bind_methods() function:
```cpp
void Geometry2D::_bind_methods() {
    //...
    ClassDB::bind_method(D_METHOD("segment_intersects_rect", "from", "to", "rect"), &Geometry2D::segment_intersects_rect);
}
```
Testing
The underlying ::Geometry2D::segment_intersects_rect method is already tested in C++ core tests
This PR only adds a scripting API wrapper with no additional logic, so no new test cases are required.