### PR TITLE
[Editor] Generate and display documentation for the properties generated by `PropertyListHelper`.

### DIFF
--- a/doc/classes/AudioStreamRandomizer.xml
+++ b/doc/classes/AudioStreamRandomizer.xml
@@ -80,6 +80,14 @@
 		<member name="random_volume_offset_db" type="float" setter="set_random_volume_offset_db" getter="get_random_volume_offset_db" default="0.0">
 			The intensity of random volume variation. Volume will be increased or decreased by a random value up to [code skip-lint]random_volume_offset_db[/code]. A value of [code]0.0[/code] means no variation. A value of [code]3.0[/code] means volume will be randomized between [code]-3.0 dB[/code] and [code]+3.0 dB[/code].
 		</member>
+		<member name="stream_{index}/stream" type="AudioStream" setter="" getter="">
+			The [AudioStream] at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. streams_count - 1[/code] range.
+		</member>
+		<member name="stream_{index}/weight" type="float" setter="" getter="" default="1.0">
+			The probability weight of the [AudioStream] at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. streams_count - 1[/code] range.
+		</member>
 		<member name="streams_count" type="int" setter="set_streams_count" getter="get_streams_count" default="0">
 			The number of streams in the stream pool.
 		</member>

--- a/doc/classes/Curve.xml
+++ b/doc/classes/Curve.xml
@@ -175,6 +175,26 @@
 		<member name="point_count" type="int" setter="set_point_count" getter="get_point_count" default="0">
 			The number of points describing the curve.
 		</member>
+		<member name="point_{index}/left_mode" type="int" setter="" getter="" default="0">
+			The left [enum TangentMode] for the point at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. point_count - 1[/code] range.
+		</member>
+		<member name="point_{index}/left_tangent" type="float" setter="" getter="" default="0.0">
+			The left tangent angle (in degrees) for the point at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. point_count - 1[/code] range.
+		</member>
+		<member name="point_{index}/position" type="Vector2" setter="" getter="" default="Vector2(0, 0)">
+			The position of the point at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. point_count - 1[/code] range.
+		</member>
+		<member name="point_{index}/right_mode" type="int" setter="" getter="" default="0">
+			The right [enum TangentMode] for the point at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. point_count - 1[/code] range.
+		</member>
+		<member name="point_{index}/right_tangent" type="float" setter="" getter="" default="0.0">
+			The right tangent angle (in degrees) for the point at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. point_count - 1[/code] range.
+		</member>
 	</members>
 	<signals>
 		<signal name="domain_changed">

--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -177,5 +177,17 @@
 		<member name="point_count" type="int" setter="set_point_count" getter="get_point_count" default="0">
 			The number of points describing the curve.
 		</member>
+		<member name="point_{index}/in" type="Vector2" setter="" getter="" default="Vector2(0, 0)">
+			The position of the control point leading to the vertex at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. point_count - 1[/code] range.
+		</member>
+		<member name="point_{index}/out" type="Vector2" setter="" getter="" default="Vector2(0, 0)">
+			The position of the control point leading out of the vertex at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. point_count - 1[/code] range.
+		</member>
+		<member name="point_{index}/position" type="Vector2" setter="" getter="" default="Vector2(0, 0)">
+			The position of for the vertex at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. point_count - 1[/code] range.
+		</member>
 	</members>
 </class>

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -210,6 +210,22 @@
 		<member name="point_count" type="int" setter="set_point_count" getter="get_point_count" default="0">
 			The number of points describing the curve.
 		</member>
+		<member name="point_{index}/in" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
+			The position of the control point leading to the vertex at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. point_count - 1[/code] range.
+		</member>
+		<member name="point_{index}/out" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
+			The position of the control point leading out of the vertex at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. point_count - 1[/code] range.
+		</member>
+		<member name="point_{index}/position" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
+			The position of for the vertex at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. point_count - 1[/code] range.
+		</member>
+		<member name="point_{index}/tilt" type="float" setter="" getter="" default="0.0">
+			The tilt angle in radians for the point at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. point_count - 1[/code] range.
+		</member>
 		<member name="up_vector_enabled" type="bool" setter="set_up_vector_enabled" getter="is_up_vector_enabled" default="true">
 			If [code]true[/code], the curve will bake up vectors used for orientation. This is used when [member PathFollow3D.rotation_mode] is set to [constant PathFollow3D.ROTATION_ORIENTED]. Changing it forces the cache to be recomputed.
 		</member>

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -258,6 +258,18 @@
 		<member name="option_count" type="int" setter="set_option_count" getter="get_option_count" default="0">
 			The number of additional [OptionButton]s and [CheckBox]es in the dialog.
 		</member>
+		<member name="option_{index}/default" type="int" setter="" getter="" default="0">
+			The default value for the option at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. option_count - 1[/code] range.
+		</member>
+		<member name="option_{index}/name" type="String" setter="" getter="" default="&quot;&quot;">
+			The name of the option at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. option_count - 1[/code] range.
+		</member>
+		<member name="option_{index}/values" type="PackedStringArray" setter="" getter="" default="PackedStringArray()">
+			The list of values for the option at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. option_count - 1[/code] range.
+		</member>
 		<member name="overwrite_warning_enabled" type="bool" setter="set_customization_flag_enabled" getter="is_customization_flag_enabled" default="true">
 			If [code]true[/code], the [FileDialog] will warn the user before overwriting files in save mode.
 		</member>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -417,6 +417,22 @@
 		<member name="item_count" type="int" setter="set_item_count" getter="get_item_count" default="0">
 			The number of items currently in the list.
 		</member>
+		<member name="item_{index}/disabled" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the item at [code]index[/code] is disabled.
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="item_{index}/icon" type="Texture2D" setter="" getter="">
+			The icon of the item at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="item_{index}/selectable" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], the item at [code]index[/code] is selectable.
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="item_{index}/text" type="String" setter="" getter="" default="&quot;&quot;">
+			The text of the item at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
 		<member name="max_columns" type="int" setter="set_max_columns" getter="get_max_columns" default="1">
 			Maximum columns the list will have.
 			If greater than zero, the content will be split among the specified columns.

--- a/doc/classes/LabelSettings.xml
+++ b/doc/classes/LabelSettings.xml
@@ -163,8 +163,28 @@
 		<member name="stacked_outline_count" type="int" setter="set_stacked_outline_count" getter="get_stacked_outline_count" default="0">
 			The number of stacked outlines.
 		</member>
+		<member name="stacked_outline_{index}/color" type="Color" setter="" getter="" default="Color(0, 0, 0, 1)">
+			The color of the outline at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. stacked_outline_count - 1[/code] range.
+		</member>
+		<member name="stacked_outline_{index}/size" type="int" setter="" getter="" default="0">
+			The size of the outline at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. stacked_outline_count - 1[/code] range.
+		</member>
 		<member name="stacked_shadow_count" type="int" setter="set_stacked_shadow_count" getter="get_stacked_shadow_count" default="0">
 			The number of stacked shadows.
+		</member>
+		<member name="stacked_shadow_{index}/color" type="Color" setter="" getter="" default="Color(0, 0, 0, 1)">
+			The color of the shadow at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. stacked_shadow_count - 1[/code] range.
+		</member>
+		<member name="stacked_shadow_{index}/offset" type="Vector2" setter="" getter="" default="Vector2i(1, 1)">
+			The offset of the shadow at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. stacked_shadow_count - 1[/code] range.
+		</member>
+		<member name="stacked_shadow_{index}/outline_size" type="int" setter="" getter="" default="0">
+			The size of the shadow outline at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. stacked_shadow_count - 1[/code] range.
 		</member>
 	</members>
 </class>

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -38,6 +38,34 @@
 		<member name="item_count" type="int" setter="set_item_count" getter="get_item_count" default="0">
 			The number of items currently in the list.
 		</member>
+		<member name="popup/item_{index}/checkable" type="int" setter="" getter="" default="0">
+			The checkable item type of the item at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="popup/item_{index}/checked" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the item at [code]index[/code] is checked.
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="popup/item_{index}/disabled" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the item at [code]index[/code] is disabled.
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="popup/item_{index}/icon" type="Texture2D" setter="" getter="">
+			The icon of the item at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="popup/item_{index}/id" type="int" setter="" getter="" default="0">
+			The ID of the item at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="popup/item_{index}/separator" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the item at [code]index[/code] is a separator.
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="popup/item_{index}/text" type="String" setter="" getter="" default="&quot;&quot;">
+			The text of the item at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
 		<member name="switch_on_hover" type="bool" setter="set_switch_on_hover" getter="is_switch_on_hover" default="false">
 			If [code]true[/code], when the cursor hovers above another [MenuButton] within the same parent which also has [member switch_on_hover] enabled, it will close the current [MenuButton] and open the other one.
 		</member>

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -249,6 +249,26 @@
 		<member name="item_count" type="int" setter="set_item_count" getter="get_item_count" default="0">
 			The number of items to select from.
 		</member>
+		<member name="popup/item_{index}/disabled" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the item at [code]index[/code] is disabled.
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="popup/item_{index}/icon" type="Texture2D" setter="" getter="">
+			The icon of the item at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="popup/item_{index}/id" type="int" setter="" getter="" default="0">
+			The ID of the item at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="popup/item_{index}/separator" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the item at [code]index[/code] is a separator.
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="popup/item_{index}/text" type="String" setter="" getter="" default="&quot;&quot;">
+			The text of the item at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
 		<member name="selected" type="int" setter="_select_int" getter="get_selected" default="-1">
 			The index of the currently selected item, or [code]-1[/code] if no item is selected.
 		</member>

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -673,6 +673,34 @@
 		<member name="item_count" type="int" setter="set_item_count" getter="get_item_count" default="0">
 			The number of items currently in the list.
 		</member>
+		<member name="item_{index}/checkable" type="int" setter="" getter="" default="0">
+			The checkable item type of the item at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="item_{index}/checked" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the item at [code]index[/code] is checked.
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="item_{index}/disabled" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the item at [code]index[/code] is disabled.
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="item_{index}/icon" type="Texture2D" setter="" getter="">
+			The icon of the item at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="item_{index}/id" type="int" setter="" getter="" default="0">
+			The ID of the item at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="item_{index}/separator" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the item at [code]index[/code] is a separator.
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
+		<member name="item_{index}/text" type="String" setter="" getter="" default="&quot;&quot;">
+			The text of the item at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. item_count - 1[/code] range.
+		</member>
 		<member name="prefer_native_menu" type="bool" setter="set_prefer_native_menu" getter="is_prefer_native_menu" default="false">
 			If [code]true[/code], [MenuBar] will use native menu when supported.
 			[b]Note:[/b] If [PopupMenu] is linked to [StatusIndicator], [MenuBar], or another [PopupMenu] item it can use native menu regardless of this property, use [method is_native_menu] to check it.

--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -282,6 +282,22 @@
 		<member name="tab_count" type="int" setter="set_tab_count" getter="get_tab_count" default="0">
 			The number of tabs currently in the bar.
 		</member>
+		<member name="tab_{index}/disabled" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the tab at [code]index[/code] is disabled.
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. tab_count - 1[/code] range.
+		</member>
+		<member name="tab_{index}/icon" type="Texture2D" setter="" getter="">
+			If [code]true[/code], the tab at [code]index[/code] is hidden.
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. tab_count - 1[/code] range.
+		</member>
+		<member name="tab_{index}/title" type="String" setter="" getter="" default="&quot;&quot;">
+			The title text of the tab at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. tab_count - 1[/code] range.
+		</member>
+		<member name="tab_{index}/tooltip" type="String" setter="" getter="" default="&quot;&quot;">
+			The tooltip text of the tab at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. tab_count - 1[/code] range.
+		</member>
 		<member name="tabs_rearrange_group" type="int" setter="set_tabs_rearrange_group" getter="get_tabs_rearrange_group" default="-1">
 			[TabBar]s with the same rearrange group ID will allow dragging the tabs between them. Enable drag with [member drag_to_rearrange_enabled].
 			Setting this to [code]-1[/code] will disable rearranging between [TabBar]s.

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -232,6 +232,22 @@
 		<member name="tab_focus_mode" type="int" setter="set_tab_focus_mode" getter="get_tab_focus_mode" enum="Control.FocusMode" default="2">
 			The focus access mode for the internal [TabBar] node.
 		</member>
+		<member name="tab_{index}/disabled" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the tab at [code]index[/code] is disabled.
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. get_tab_count() - 1[/code] range.
+		</member>
+		<member name="tab_{index}/hidden" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the tab at [code]index[/code] is hidden.
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. get_tab_count() - 1[/code] range.
+		</member>
+		<member name="tab_{index}/icon" type="Texture2D" setter="" getter="">
+			The title text of the tab at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. get_tab_count() - 1[/code] range.
+		</member>
+		<member name="tab_{index}/title" type="String" setter="" getter="" default="&quot;&quot;">
+			The tooltip text of the tab at [code]index[/code].
+			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. get_tab_count() - 1[/code] range.
+		</member>
 		<member name="tabs_position" type="int" setter="set_tabs_position" getter="get_tabs_position" enum="TabContainer.TabPosition" default="0">
 			The horizontal alignment of the tabs.
 		</member>

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -43,6 +43,7 @@
 #include "core/string/translation_server.h"
 #include "editor/export/editor_export_platform.h"
 #include "editor/settings/editor_settings.h"
+#include "scene/property_list_helper.h"
 #include "scene/resources/theme.h"
 #include "scene/theme/theme_db.h"
 
@@ -408,6 +409,16 @@ static Variant get_documentation_default_value(const StringName &p_class_name, c
 	return default_value;
 }
 
+bool helpers_has_property(const String &p_class_name, const String &p_name) {
+	const Vector<PropertyListHelper *> helpers = PropertyListHelper::get_helpers_for_class(p_class_name);
+	for (const PropertyListHelper *helper : helpers) {
+		if (helper->documentation_has_property(p_name)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 void DocTools::generate(BitField<GenerateFlags> p_flags) {
 	// This may involve instantiating classes that are only usable from the main thread
 	// (which is in fact the case of the core API).
@@ -448,6 +459,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 
 			List<PropertyInfo> properties;
 			List<PropertyInfo> own_properties;
+			Vector<PropertyListHelper *> helpers = PropertyListHelper::get_helpers_for_class(name);
 
 			// Special cases for editor/project settings, and ResourceImporter classes,
 			// we have to rely on Object's property list to get settings and import options.
@@ -492,6 +504,11 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 				properties_from_instance = false;
 				ClassDB::get_property_list(name, &properties);
 				ClassDB::get_property_list(name, &own_properties, true);
+
+				for (const PropertyListHelper *helper : helpers) {
+					helper->documentation_get_property_list(&properties);
+					helper->documentation_get_property_list(&own_properties);
+				}
 			}
 
 			// Sort is still needed here to handle inherited properties, even though it is done below, do not remove.
@@ -517,14 +534,22 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 					continue;
 				}
 
+				bool from_helper = E.name.contains("{index}");
+
 				DocData::PropertyDoc prop;
 				prop.name = E.name;
 				prop.overridden = inherited;
 
 				if (inherited) {
 					String parent = ClassDB::get_parent_class(c.name);
-					while (!ClassDB::has_property(parent, prop.name, true)) {
-						parent = ClassDB::get_parent_class(parent);
+					if (from_helper) {
+						while (!helpers_has_property(parent, prop.name)) {
+							parent = ClassDB::get_parent_class(parent);
+						}
+					} else {
+						while (!ClassDB::has_property(parent, prop.name, true)) {
+							parent = ClassDB::get_parent_class(parent);
+						}
 					}
 					prop.overrides = parent;
 				}
@@ -549,12 +574,22 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 					default_value = import_options_default[E.name];
 					default_value_valid = true;
 				} else {
-					default_value = get_documentation_default_value(name, E.name, default_value_valid);
-					if (inherited) {
-						bool base_default_value_valid = false;
-						Variant base_default_value = get_documentation_default_value(ClassDB::get_parent_class(name), E.name, base_default_value_valid);
-						if (!default_value_valid || !base_default_value_valid || default_value == base_default_value) {
-							continue;
+					if (from_helper) {
+						for (const PropertyListHelper *helper : helpers) {
+							if (helper->documentation_has_property(E.name)) {
+								default_value = helper->documentation_get_default_value(E.name);
+								default_value_valid = true;
+								break;
+							}
+						}
+					} else {
+						default_value = get_documentation_default_value(name, E.name, default_value_valid);
+						if (inherited) {
+							bool base_default_value_valid = false;
+							Variant base_default_value = get_documentation_default_value(ClassDB::get_parent_class(name), E.name, base_default_value_valid);
+							if (!default_value_valid || !base_default_value_valid || default_value == base_default_value) {
+								continue;
+							}
 						}
 					}
 				}

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -72,6 +72,8 @@
 #include "modules/mono/csharp_script.h"
 #endif
 
+#include "modules/regex/regex.h"
+
 #define CONTRIBUTE_URL "https://contributing.godotengine.org/en/latest/documentation/class_reference.html"
 
 #ifdef MODULE_MONO_ENABLED
@@ -3693,6 +3695,18 @@ EditorHelpBit::HelpData EditorHelpBit::_get_property_help_data(const StringName 
 
 				if (!is_native) {
 					break;
+				}
+			}
+
+			if (property.name.contains("{index}")) {
+				RegEx reg_index = RegEx(property.name.replace("{index}", "\\d*"));
+				Ref<RegExMatch> match = reg_index.search(p_property_name);
+				if (match.is_valid()) {
+					result = current;
+
+					if (!is_native) {
+						break;
+					}
 				}
 			}
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1041,7 +1041,7 @@ TileMap::TileMap() {
 		base_property_helper.register_property(PropertyInfo(Variant::BOOL, "navigation_enabled"), defaults->is_navigation_enabled(), &TileMap::set_layer_navigation_enabled, &TileMap::is_layer_navigation_enabled);
 #endif // NAVIGATION_2D_DISABLED
 		base_property_helper.register_property(PropertyInfo(Variant::PACKED_INT32_ARRAY, "tile_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), Vector<int>(), &TileMap::_set_layer_tile_data, &TileMap::_get_tile_map_data_using_compatibility_format);
-		PropertyListHelper::register_base_helper(&base_property_helper);
+		PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 
 		memdelete(defaults);
 	}

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -2229,7 +2229,7 @@ void FileDialog::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::STRING, "name"), defaults.name, &FileDialog::set_option_name, &FileDialog::get_option_name);
 	base_property_helper.register_property(PropertyInfo(Variant::PACKED_STRING_ARRAY, "values"), defaults.values, &FileDialog::set_option_values, &FileDialog::get_option_values);
 	base_property_helper.register_property(PropertyInfo(Variant::INT, "default"), defaults.default_idx, &FileDialog::set_option_default, &FileDialog::get_option_default);
-	PropertyListHelper::register_base_helper(&base_property_helper);
+	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 
 	ADD_CLASS_DEPENDENCY("Button");
 	ADD_CLASS_DEPENDENCY("ConfirmationDialog");

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -2498,7 +2498,7 @@ void ItemList::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.icon, &ItemList::set_item_icon, &ItemList::get_item_icon);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "selectable"), defaults.selectable, &ItemList::set_item_selectable, &ItemList::is_item_selectable);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &ItemList::set_item_disabled, &ItemList::is_item_disabled);
-	PropertyListHelper::register_base_helper(&base_property_helper);
+	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 
 ItemList::ItemList() {

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -224,7 +224,7 @@ void MenuButton::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::INT, "id", PROPERTY_HINT_RANGE, "0,10,1,or_greater", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL), defaults.id);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "separator"), defaults.separator);
-	PropertyListHelper::register_base_helper(&base_property_helper);
+	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 
 void MenuButton::set_disable_shortcuts(bool p_disabled) {

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -649,7 +649,7 @@ void OptionButton::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::INT, "id", PROPERTY_HINT_RANGE, "0,10,1,or_greater", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL), defaults.id, &OptionButton::_dummy_setter, &OptionButton::get_item_id);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &OptionButton::_dummy_setter, &OptionButton::is_item_disabled);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "separator"), defaults.separator, &OptionButton::_dummy_setter, &OptionButton::is_item_separator);
-	PropertyListHelper::register_base_helper(&base_property_helper);
+	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 
 	ADD_CLASS_DEPENDENCY("PopupMenu");
 }

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3482,7 +3482,7 @@ void PopupMenu::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::INT, "id", PROPERTY_HINT_RANGE, "0,10,1,or_greater", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL), defaults.id, &PopupMenu::set_item_id, &PopupMenu::get_item_id);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &PopupMenu::set_item_disabled, &PopupMenu::is_item_disabled);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "separator"), defaults.separator, &PopupMenu::set_item_as_separator, &PopupMenu::is_item_separator);
-	PropertyListHelper::register_base_helper(&base_property_helper);
+	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 
 void PopupMenu::_native_popup(const Rect2i &p_rect) {

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -2197,7 +2197,7 @@ void TabBar::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::STRING, "tooltip"), defaults.tooltip, &TabBar::set_tab_tooltip, &TabBar::get_tab_tooltip);
 	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.icon, &TabBar::set_tab_icon, &TabBar::get_tab_icon);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &TabBar::set_tab_disabled, &TabBar::is_tab_disabled);
-	PropertyListHelper::register_base_helper(&base_property_helper);
+	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 
 TabBar::TabBar() {

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -1252,7 +1252,7 @@ void TabContainer::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.icon, &TabContainer::set_tab_icon, &TabContainer::get_tab_icon);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &TabContainer::set_tab_disabled, &TabContainer::is_tab_disabled);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "hidden"), defaults.hidden, &TabContainer::set_tab_hidden, &TabContainer::is_tab_hidden);
-	PropertyListHelper::register_base_helper(&base_property_helper);
+	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 
 TabContainer::TabContainer() {

--- a/scene/property_list_helper.cpp
+++ b/scene/property_list_helper.cpp
@@ -30,17 +30,27 @@
 
 #include "property_list_helper.h"
 
-Vector<PropertyListHelper *> PropertyListHelper::base_helpers; // static
+HashMap<StringName, Vector<PropertyListHelper *>> PropertyListHelper::base_helpers; // static
 
 void PropertyListHelper::clear_base_helpers() { // static
-	for (PropertyListHelper *helper : base_helpers) {
-		helper->clear();
+	for (KeyValue<StringName, Vector<PropertyListHelper *>> &E : base_helpers) {
+		for (PropertyListHelper *helper : E.value) {
+			helper->clear();
+		}
 	}
 	base_helpers.clear();
 }
 
-void PropertyListHelper::register_base_helper(PropertyListHelper *p_helper) { // static
-	base_helpers.push_back(p_helper);
+void PropertyListHelper::register_base_helper(const StringName &p_class_name, PropertyListHelper *p_helper) { // static
+	base_helpers[p_class_name].push_back(p_helper);
+}
+
+Vector<PropertyListHelper *> PropertyListHelper::get_helpers_for_class(const StringName &p_class_name) {
+	if (base_helpers.has(p_class_name)) {
+		return base_helpers[p_class_name];
+	} else {
+		return Vector<PropertyListHelper *>();
+	}
 }
 
 const PropertyListHelper::Property *PropertyListHelper::_get_property(const String &p_property, int *r_index, bool p_allow_oob) const {
@@ -162,6 +172,33 @@ void PropertyListHelper::get_property_list(List<PropertyInfo> *p_list) const {
 		}
 	}
 }
+
+#ifdef TOOLS_ENABLED
+
+void PropertyListHelper::documentation_get_property_list(List<PropertyInfo> *r_list) const {
+	for (const KeyValue<String, Property> &E : property_list) {
+		const Property &property = E.value;
+
+		PropertyInfo info = property.info;
+		info.name = vformat("%s{index}/%s", prefix, info.name);
+		r_list->push_back(info);
+	}
+}
+bool PropertyListHelper::documentation_has_property(const String &p_property) const {
+	String name = p_property.trim_prefix(vformat("%s{index}/", prefix));
+	return property_list.has(name);
+}
+
+Variant PropertyListHelper::documentation_get_default_value(const String &p_property) const {
+	String name = p_property.trim_prefix(vformat("%s{index}/", prefix));
+	if (property_list.has(name)) {
+		return property_list[name].default_value;
+	} else {
+		return Variant();
+	}
+}
+
+#endif
 
 bool PropertyListHelper::property_get_value(const String &p_property, Variant &r_ret) const {
 	int index;

--- a/scene/property_list_helper.h
+++ b/scene/property_list_helper.h
@@ -41,7 +41,7 @@ class PropertyListHelper {
 		MethodBind *getter = nullptr;
 	};
 
-	static Vector<PropertyListHelper *> base_helpers;
+	static HashMap<StringName, Vector<PropertyListHelper *>> base_helpers;
 
 	String prefix;
 	MethodBind *array_length_getter = nullptr;
@@ -58,7 +58,9 @@ class PropertyListHelper {
 
 public:
 	static void clear_base_helpers();
-	static void register_base_helper(PropertyListHelper *p_helper);
+	static void register_base_helper(const StringName &p_class_name, PropertyListHelper *p_helper);
+
+	static Vector<PropertyListHelper *> get_helpers_for_class(const StringName &p_class_name);
 
 	void set_prefix(const String &p_prefix);
 	template <typename G>
@@ -93,6 +95,12 @@ public:
 	bool property_set_value(const String &p_property, const Variant &p_value) const;
 	bool property_can_revert(const String &p_property) const;
 	bool property_get_revert(const String &p_property, Variant &r_value) const;
+
+#ifdef TOOLS_ENABLED
+	void documentation_get_property_list(List<PropertyInfo> *r_list) const;
+	bool documentation_has_property(const String &p_property) const;
+	Variant documentation_get_default_value(const String &p_property) const;
+#endif
 
 	void enable_out_of_bounds_assign() { allow_oob_assign = true; }
 

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -662,7 +662,7 @@ void Curve::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::INT, "left_mode", PROPERTY_HINT_ENUM, mode_hint, PROPERTY_USAGE_EDITOR), defaults.left_mode, &Curve::set_point_left_mode, &Curve::get_point_left_mode);
 	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, "right_tangent", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.right_tangent, &Curve::set_point_right_tangent, &Curve::get_point_right_tangent);
 	base_property_helper.register_property(PropertyInfo(Variant::INT, "right_mode", PROPERTY_HINT_ENUM, mode_hint, PROPERTY_USAGE_EDITOR), defaults.right_mode, &Curve::set_point_right_mode, &Curve::get_point_right_mode);
-	PropertyListHelper::register_base_helper(&base_property_helper);
+	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 
 int Curve2D::get_point_count() const {
@@ -1344,7 +1344,7 @@ void Curve2D::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.position, &Curve2D::set_point_position, &Curve2D::get_point_position);
 	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "in", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.in, &Curve2D::set_point_in, &Curve2D::get_point_in);
 	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "out", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.out, &Curve2D::set_point_out, &Curve2D::get_point_out);
-	PropertyListHelper::register_base_helper(&base_property_helper);
+	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 
 Curve2D::Curve2D() {
@@ -2388,7 +2388,7 @@ void Curve3D::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::VECTOR3, "in", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.in, &Curve3D::set_point_in, &Curve3D::get_point_in);
 	base_property_helper.register_property(PropertyInfo(Variant::VECTOR3, "out", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.out, &Curve3D::set_point_out, &Curve3D::get_point_out);
 	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, "tilt", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.tilt, &Curve3D::set_point_tilt, &Curve3D::get_point_tilt);
-	PropertyListHelper::register_base_helper(&base_property_helper);
+	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 
 Curve3D::Curve3D() {

--- a/scene/resources/label_settings.cpp
+++ b/scene/resources/label_settings.cpp
@@ -119,7 +119,7 @@ void LabelSettings::_bind_methods() {
 	stacked_outline_base_property_helper.set_array_length_getter(&LabelSettings::get_stacked_outline_count);
 	stacked_outline_base_property_helper.register_property(PropertyInfo(Variant::INT, "size", PROPERTY_HINT_NONE, "0,127,1,or_greater,suffix:px"), stacked_outline_defaults.size, &LabelSettings::set_stacked_outline_size, &LabelSettings::get_stacked_outline_size);
 	stacked_outline_base_property_helper.register_property(PropertyInfo(Variant::COLOR, "color"), stacked_outline_defaults.color, &LabelSettings::set_stacked_outline_color, &LabelSettings::get_stacked_outline_color);
-	PropertyListHelper::register_base_helper(&stacked_outline_base_property_helper);
+	PropertyListHelper::register_base_helper(get_class_static(), &stacked_outline_base_property_helper);
 
 	constexpr StackedShadowData stacked_shadow_defaults;
 
@@ -128,7 +128,7 @@ void LabelSettings::_bind_methods() {
 	stacked_shadow_base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "offset", PROPERTY_HINT_NONE, "suffix:px"), stacked_shadow_defaults.offset, &LabelSettings::set_stacked_shadow_offset, &LabelSettings::get_stacked_shadow_offset);
 	stacked_shadow_base_property_helper.register_property(PropertyInfo(Variant::COLOR, "color"), stacked_shadow_defaults.color, &LabelSettings::set_stacked_shadow_color, &LabelSettings::get_stacked_shadow_color);
 	stacked_shadow_base_property_helper.register_property(PropertyInfo(Variant::INT, "outline_size", PROPERTY_HINT_NONE, "0,127,1,or_greater,suffix:px"), stacked_shadow_defaults.outline_size, &LabelSettings::set_stacked_shadow_outline_size, &LabelSettings::get_stacked_shadow_outline_size);
-	PropertyListHelper::register_base_helper(&stacked_shadow_base_property_helper);
+	PropertyListHelper::register_base_helper(get_class_static(), &stacked_shadow_base_property_helper);
 }
 
 void LabelSettings::set_line_spacing(real_t p_spacing) {

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -782,7 +782,7 @@ void AudioStreamRandomizer::_bind_methods() {
 	base_property_helper.set_array_length_getter(&AudioStreamRandomizer::get_streams_count);
 	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, AudioStream::get_class_static()), defaults.stream, &AudioStreamRandomizer::set_stream, &AudioStreamRandomizer::get_stream);
 	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, "weight", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), defaults.weight, &AudioStreamRandomizer::set_stream_probability_weight, &AudioStreamRandomizer::get_stream_probability_weight);
-	PropertyListHelper::register_base_helper(&base_property_helper);
+	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 
 AudioStreamRandomizer::AudioStreamRandomizer() {


### PR DESCRIPTION
Adds documentation for the dynamic properties generated by `PropertyListHelper` (e.g, menu items).

<img width="1170" height="521" alt="Screenshot 2026-01-22 at 12 18 50" src="https://github.com/user-attachments/assets/eadc2506-a1db-4da9-b9ac-5c05e594ee95" />
