### PR TITLE
GLTF Physics material export & import

### DIFF
--- a/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
+++ b/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
@@ -30,6 +30,8 @@
 
 #include "gltf_document_extension_physics.h"
 
+#include "gltf_physics_material.h"
+
 #include "scene/3d/physics/area_3d.h"
 #include "scene/3d/physics/rigid_body_3d.h"
 #include "scene/3d/physics/static_body_3d.h"
@@ -44,6 +46,20 @@ Error GLTFDocumentExtensionPhysics::import_preflight(Ref<GLTFState> p_state, con
 	Dictionary state_json = p_state->get_json();
 	if (state_json.has("extensions")) {
 		Dictionary state_extensions = state_json["extensions"];
+		if (state_extensions.has("OMI_physics_body")) {
+			Dictionary omi_physics_body_ext = state_extensions["OMI_physics_body"];
+			// Import physics materials.
+			if (omi_physics_body_ext.has("physicsMaterials")) {
+				Array material_dicts = omi_physics_body_ext["physicsMaterials"];
+				if (material_dicts.size() > 0) {
+					Array physics_materials;
+					for (int i = 0; i < material_dicts.size(); i++) {
+						physics_materials.push_back(GLTFPhysicsMaterial::from_dictionary(material_dicts[i]));
+					}
+					p_state->set_additional_data(StringName("GLTFPhysicsMaterials"), physics_materials);
+				}
+			}
+		}
 		if (state_extensions.has("OMI_physics_shape")) {
 			Dictionary omi_physics_shape_ext = state_extensions["OMI_physics_shape"];
 			if (omi_physics_shape_ext.has("shapes")) {
@@ -113,6 +129,16 @@ Error GLTFDocumentExtensionPhysics::parse_node_extensions(Ref<GLTFState> p_state
 				// If this node is a collider but does not have a collider
 				// shape, then it only serves to combine together shapes.
 				p_gltf_node->set_additional_data(StringName("GLTFPhysicsCompoundCollider"), true);
+			}
+			// Handle physics material index.
+			int material_index = node_collider.get("physicsMaterial", -1);
+			if (material_index != -1) {
+				Array physics_materials = p_state->get_additional_data(StringName("GLTFPhysicsMaterials"));
+				if (physics_materials.size() > 0) {
+					ERR_FAIL_INDEX_V_MSG(material_index, physics_materials.size(), Error::ERR_FILE_CORRUPT, "glTF Physics: On node " + p_gltf_node->get_name() + ", the physics material index " + itos(material_index) + " is not in the state physics materials (size: " + itos(physics_materials.size()) + ").");
+					p_gltf_node->set_additional_data(StringName("GLTFPhysicsMaterial"), physics_materials[material_index]);
+					p_gltf_node->set_additional_data(StringName("GLTFPhysicsMaterialIndex"), material_index);
+				}
 			}
 		}
 		if (physics_body_ext.has("trigger")) {
@@ -435,6 +461,16 @@ Node3D *GLTFDocumentExtensionPhysics::generate_scene_node(Ref<GLTFState> p_state
 	if (gltf_physics_body.is_valid()) {
 		ancestor_col_obj = gltf_physics_body->to_node();
 		ret = ancestor_col_obj;
+		// Apply physics material if present.
+		Ref<GLTFPhysicsMaterial> gltf_physics_material = p_gltf_node->get_additional_data(StringName("GLTFPhysicsMaterial"));
+		if (gltf_physics_material.is_valid()) {
+			Ref<PhysicsMaterial> physics_material = gltf_physics_material->to_resource();
+			if (StaticBody3D *static_body = Object::cast_to<StaticBody3D>(ancestor_col_obj)) {
+				static_body->set_physics_material_override(physics_material);
+			} else if (RigidBody3D *rigid_body = Object::cast_to<RigidBody3D>(ancestor_col_obj)) {
+				rigid_body->set_physics_material_override(physics_material);
+			}
+		}
 	} else {
 		ancestor_col_obj = _get_ancestor_collision_object(p_scene_parent);
 		if (Object::cast_to<Area3D>(ancestor_col_obj) && gltf_physics_trigger_shape.is_valid()) {
@@ -456,6 +492,12 @@ Node3D *GLTFDocumentExtensionPhysics::generate_scene_node(Ref<GLTFState> p_state
 				// and there is no parent body, we need to create a static body.
 				ancestor_col_obj = memnew(StaticBody3D);
 				ret = ancestor_col_obj;
+				// Apply physics material if present.
+				Ref<GLTFPhysicsMaterial> gltf_physics_material = p_gltf_node->get_additional_data(StringName("GLTFPhysicsMaterial"));
+				if (gltf_physics_material.is_valid()) {
+					Ref<PhysicsMaterial> physics_material = gltf_physics_material->to_resource();
+					static_cast<StaticBody3D *>(ancestor_col_obj)->set_physics_material_override(physics_material);
+				}
 			}
 		}
 	}
@@ -550,6 +592,17 @@ void GLTFDocumentExtensionPhysics::convert_scene_node(Ref<GLTFState> p_state, Re
 	} else if (cast_to<CollisionObject3D>(p_scene_node)) {
 		CollisionObject3D *godot_body = Object::cast_to<CollisionObject3D>(p_scene_node);
 		p_gltf_node->set_additional_data(StringName("GLTFPhysicsBody"), GLTFPhysicsBody::from_node(godot_body));
+		// Extract physics material if present.
+		Ref<PhysicsMaterial> physics_material;
+		if (StaticBody3D *static_body = Object::cast_to<StaticBody3D>(godot_body)) {
+			physics_material = static_body->get_physics_material_override();
+		} else if (RigidBody3D *rigid_body = Object::cast_to<RigidBody3D>(godot_body)) {
+			physics_material = rigid_body->get_physics_material_override();
+		}
+		if (physics_material.is_valid()) {
+			Ref<GLTFPhysicsMaterial> gltf_material = GLTFPhysicsMaterial::from_resource(physics_material);
+			p_gltf_node->set_additional_data(StringName("GLTFPhysicsMaterial"), gltf_material);
+		}
 	}
 }
 
@@ -595,10 +648,57 @@ GLTFShapeIndex _export_node_shape(const Ref<GLTFState> &p_state, const Ref<GLTFP
 	return size;
 }
 
+Array _get_or_create_physics_materials_in_state(const Ref<GLTFState> &p_state) {
+	Dictionary state_json = p_state->get_json();
+	Dictionary state_extensions;
+	if (state_json.has("extensions")) {
+		state_extensions = state_json["extensions"];
+	} else {
+		state_json["extensions"] = state_extensions;
+	}
+	Dictionary omi_physics_body_ext;
+	if (state_extensions.has("OMI_physics_body")) {
+		omi_physics_body_ext = state_extensions["OMI_physics_body"];
+	} else {
+		state_extensions["OMI_physics_body"] = omi_physics_body_ext;
+	}
+	Array physics_materials;
+	if (omi_physics_body_ext.has("physicsMaterials")) {
+		physics_materials = omi_physics_body_ext["physicsMaterials"];
+	} else {
+		omi_physics_body_ext["physicsMaterials"] = physics_materials;
+	}
+	return physics_materials;
+}
+
+int64_t _export_physics_material(const Ref<GLTFState> &p_state, const Ref<GLTFPhysicsMaterial> &p_material) {
+	Array physics_materials = _get_or_create_physics_materials_in_state(p_state);
+	int64_t size = physics_materials.size();
+	Dictionary material_dict = p_material->to_dictionary();
+	for (int64_t i = 0; i < size; i++) {
+		Dictionary other = physics_materials[i];
+		if (other == material_dict) {
+			// De-duplication: If we already have an identical material,
+			// return the existing index.
+			return i;
+		}
+	}
+	// If we don't have an identical material, add it to the array.
+	physics_materials.push_back(material_dict);
+	return size;
+}
+
 Error GLTFDocumentExtensionPhysics::export_preserialize(Ref<GLTFState> p_state) {
 	// Note: Need to do _export_node_shape before exporting animations, so export_node is too late.
 	const Vector<Ref<GLTFNode>> &state_gltf_nodes = p_state->get_nodes();
 	for (Ref<GLTFNode> gltf_node : state_gltf_nodes) {
+		// Export physics materials.
+		const Ref<GLTFPhysicsMaterial> physics_material = gltf_node->get_additional_data(StringName("GLTFPhysicsMaterial"));
+		if (physics_material.is_valid()) {
+			int64_t material_index = _export_physics_material(p_state, physics_material);
+			gltf_node->set_additional_data(StringName("GLTFPhysicsMaterialIndex"), material_index);
+		}
+		// Export shapes.
 		const Ref<GLTFPhysicsShape> collider_shape = gltf_node->get_additional_data(StringName("GLTFPhysicsColliderShape"));
 		if (collider_shape.is_valid()) {
 			GLTFShapeIndex collider_shape_index = _export_node_shape(p_state, collider_shape);
@@ -714,6 +814,11 @@ Error GLTFDocumentExtensionPhysics::export_node(Ref<GLTFState> p_state, Ref<GLTF
 	if (collider_shape_index.get_type() == Variant::INT) {
 		Dictionary collider_dict;
 		collider_dict["shape"] = collider_shape_index;
+		// Add physics material index if present.
+		Variant material_index = p_gltf_node->get_additional_data(StringName("GLTFPhysicsMaterialIndex"));
+		if (material_index.get_type() == Variant::INT) {
+			collider_dict["physicsMaterial"] = material_index;
+		}
 		physics_body_ext["collider"] = collider_dict;
 	}
 	Variant trigger_shape_index = p_gltf_node->get_additional_data(StringName("GLTFPhysicsTriggerShapeIndex"));

--- a/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
+++ b/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
@@ -814,8 +814,19 @@ Error GLTFDocumentExtensionPhysics::export_node(Ref<GLTFState> p_state, Ref<GLTF
 	if (collider_shape_index.get_type() == Variant::INT) {
 		Dictionary collider_dict;
 		collider_dict["shape"] = collider_shape_index;
-		// Add physics material index if present.
+		// Add physics material index if present on this node or parent body node.
 		Variant material_index = p_gltf_node->get_additional_data(StringName("GLTFPhysicsMaterialIndex"));
+		if (material_index.get_type() != Variant::INT) {
+			// If not on this node, check the parent node (body nodes have the material).
+			GLTFNodeIndex parent_index = p_gltf_node->get_parent();
+			if (parent_index != -1) {
+				const Vector<Ref<GLTFNode>> &state_nodes = p_state->get_nodes();
+				if (parent_index < state_nodes.size()) {
+					const Ref<GLTFNode> &parent_node = state_nodes[parent_index];
+					material_index = parent_node->get_additional_data(StringName("GLTFPhysicsMaterialIndex"));
+				}
+			}
+		}
 		if (material_index.get_type() == Variant::INT) {
 			collider_dict["physicsMaterial"] = material_index;
 		}

--- a/modules/gltf/extensions/physics/gltf_physics_material.cpp
+++ b/modules/gltf/extensions/physics/gltf_physics_material.cpp
@@ -1,0 +1,239 @@
+/**************************************************************************/
+/*  gltf_physics_material.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gltf_physics_material.h"
+
+void GLTFPhysicsMaterial::_bind_methods() {
+	ClassDB::bind_static_method("GLTFPhysicsMaterial", D_METHOD("from_resource", "material"), &GLTFPhysicsMaterial::from_resource);
+	ClassDB::bind_method(D_METHOD("to_resource"), &GLTFPhysicsMaterial::to_resource);
+
+	ClassDB::bind_static_method("GLTFPhysicsMaterial", D_METHOD("from_dictionary", "dictionary"), &GLTFPhysicsMaterial::from_dictionary);
+	ClassDB::bind_method(D_METHOD("to_dictionary"), &GLTFPhysicsMaterial::to_dictionary);
+
+	ClassDB::bind_method(D_METHOD("get_static_friction"), &GLTFPhysicsMaterial::get_static_friction);
+	ClassDB::bind_method(D_METHOD("set_static_friction", "static_friction"), &GLTFPhysicsMaterial::set_static_friction);
+	ClassDB::bind_method(D_METHOD("get_dynamic_friction"), &GLTFPhysicsMaterial::get_dynamic_friction);
+	ClassDB::bind_method(D_METHOD("set_dynamic_friction", "dynamic_friction"), &GLTFPhysicsMaterial::set_dynamic_friction);
+	ClassDB::bind_method(D_METHOD("get_restitution"), &GLTFPhysicsMaterial::get_restitution);
+	ClassDB::bind_method(D_METHOD("set_restitution", "restitution"), &GLTFPhysicsMaterial::set_restitution);
+	ClassDB::bind_method(D_METHOD("get_friction_combine"), &GLTFPhysicsMaterial::get_friction_combine);
+	ClassDB::bind_method(D_METHOD("set_friction_combine", "friction_combine"), &GLTFPhysicsMaterial::set_friction_combine);
+	ClassDB::bind_method(D_METHOD("get_restitution_combine"), &GLTFPhysicsMaterial::get_restitution_combine);
+	ClassDB::bind_method(D_METHOD("set_restitution_combine", "restitution_combine"), &GLTFPhysicsMaterial::set_restitution_combine);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "static_friction"), "set_static_friction", "get_static_friction");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dynamic_friction"), "set_dynamic_friction", "get_dynamic_friction");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "restitution"), "set_restitution", "get_restitution");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "friction_combine"), "set_friction_combine", "get_friction_combine");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "restitution_combine"), "set_restitution_combine", "get_restitution_combine");
+
+	BIND_ENUM_CONSTANT(COMBINE_AVERAGE);
+	BIND_ENUM_CONSTANT(COMBINE_MINIMUM);
+	BIND_ENUM_CONSTANT(COMBINE_MAXIMUM);
+	BIND_ENUM_CONSTANT(COMBINE_MULTIPLY);
+}
+
+real_t GLTFPhysicsMaterial::get_static_friction() const {
+	return static_friction;
+}
+
+void GLTFPhysicsMaterial::set_static_friction(real_t p_static_friction) {
+	static_friction = p_static_friction;
+}
+
+real_t GLTFPhysicsMaterial::get_dynamic_friction() const {
+	return dynamic_friction;
+}
+
+void GLTFPhysicsMaterial::set_dynamic_friction(real_t p_dynamic_friction) {
+	dynamic_friction = p_dynamic_friction;
+}
+
+real_t GLTFPhysicsMaterial::get_restitution() const {
+	return restitution;
+}
+
+void GLTFPhysicsMaterial::set_restitution(real_t p_restitution) {
+	restitution = p_restitution;
+}
+
+GLTFPhysicsMaterial::CombineMode GLTFPhysicsMaterial::get_friction_combine() const {
+	return friction_combine;
+}
+
+void GLTFPhysicsMaterial::set_friction_combine(CombineMode p_friction_combine) {
+	friction_combine = p_friction_combine;
+}
+
+GLTFPhysicsMaterial::CombineMode GLTFPhysicsMaterial::get_restitution_combine() const {
+	return restitution_combine;
+}
+
+void GLTFPhysicsMaterial::set_restitution_combine(CombineMode p_restitution_combine) {
+	restitution_combine = p_restitution_combine;
+}
+
+Ref<GLTFPhysicsMaterial> GLTFPhysicsMaterial::from_resource(const Ref<PhysicsMaterial> &p_material) {
+	Ref<GLTFPhysicsMaterial> gltf_material;
+	gltf_material.instantiate();
+	
+	if (p_material.is_null()) {
+		return gltf_material;
+	}
+
+	// Godot's PhysicsMaterial has:
+	// - friction (real_t) with rough boolean flag
+	// - bounce (real_t) with absorbent boolean flag
+	// We map these to glTF's static/dynamic friction and restitution.
+	
+	real_t godot_friction = p_material->get_friction();
+	gltf_material->set_static_friction(godot_friction);
+	gltf_material->set_dynamic_friction(godot_friction);
+	
+	real_t godot_bounce = p_material->get_bounce();
+	gltf_material->set_restitution(godot_bounce);
+	
+	// Godot doesn't have combine modes, so we use the default "average"
+	gltf_material->set_friction_combine(COMBINE_AVERAGE);
+	gltf_material->set_restitution_combine(COMBINE_AVERAGE);
+	
+	return gltf_material;
+}
+
+Ref<PhysicsMaterial> GLTFPhysicsMaterial::to_resource() const {
+	Ref<PhysicsMaterial> material;
+	material.instantiate();
+	
+	// Use dynamic friction as it's more commonly used
+	material->set_friction(dynamic_friction);
+	material->set_rough(false);
+	
+	material->set_bounce(restitution);
+	material->set_absorbent(false);
+	
+	return material;
+}
+
+Ref<GLTFPhysicsMaterial> GLTFPhysicsMaterial::from_dictionary(const Dictionary &p_dictionary) {
+	Ref<GLTFPhysicsMaterial> gltf_material;
+	gltf_material.instantiate();
+	
+	if (p_dictionary.has("staticFriction")) {
+		gltf_material->set_static_friction(p_dictionary["staticFriction"]);
+	}
+	if (p_dictionary.has("dynamicFriction")) {
+		gltf_material->set_dynamic_friction(p_dictionary["dynamicFriction"]);
+	}
+	if (p_dictionary.has("restitution")) {
+		gltf_material->set_restitution(p_dictionary["restitution"]);
+	}
+	if (p_dictionary.has("frictionCombine")) {
+		String combine_str = p_dictionary["frictionCombine"];
+		if (combine_str == "average") {
+			gltf_material->set_friction_combine(COMBINE_AVERAGE);
+		} else if (combine_str == "minimum") {
+			gltf_material->set_friction_combine(COMBINE_MINIMUM);
+		} else if (combine_str == "maximum") {
+			gltf_material->set_friction_combine(COMBINE_MAXIMUM);
+		} else if (combine_str == "multiply") {
+			gltf_material->set_friction_combine(COMBINE_MULTIPLY);
+		}
+	}
+	if (p_dictionary.has("restitutionCombine")) {
+		String combine_str = p_dictionary["restitutionCombine"];
+		if (combine_str == "average") {
+			gltf_material->set_restitution_combine(COMBINE_AVERAGE);
+		} else if (combine_str == "minimum") {
+			gltf_material->set_restitution_combine(COMBINE_MINIMUM);
+		} else if (combine_str == "maximum") {
+			gltf_material->set_restitution_combine(COMBINE_MAXIMUM);
+		} else if (combine_str == "multiply") {
+			gltf_material->set_restitution_combine(COMBINE_MULTIPLY);
+		}
+	}
+	
+	return gltf_material;
+}
+
+Dictionary GLTFPhysicsMaterial::to_dictionary() const {
+	Dictionary dict;
+	
+	dict["staticFriction"] = static_friction;
+	dict["dynamicFriction"] = dynamic_friction;
+	dict["restitution"] = restitution;
+	
+	String friction_combine_str;
+	switch (friction_combine) {
+		case COMBINE_AVERAGE:
+			friction_combine_str = "average";
+			break;
+		case COMBINE_MINIMUM:
+			friction_combine_str = "minimum";
+			break;
+		case COMBINE_MAXIMUM:
+			friction_combine_str = "maximum";
+			break;
+		case COMBINE_MULTIPLY:
+			friction_combine_str = "multiply";
+			break;
+	}
+	dict["frictionCombine"] = friction_combine_str;
+	
+	String restitution_combine_str;
+	switch (restitution_combine) {
+		case COMBINE_AVERAGE:
+			restitution_combine_str = "average";
+			break;
+		case COMBINE_MINIMUM:
+			restitution_combine_str = "minimum";
+			break;
+		case COMBINE_MAXIMUM:
+			restitution_combine_str = "maximum";
+			break;
+		case COMBINE_MULTIPLY:
+			restitution_combine_str = "multiply";
+			break;
+	}
+	dict["restitutionCombine"] = restitution_combine_str;
+	
+	return dict;
+}
+
+bool GLTFPhysicsMaterial::operator==(const GLTFPhysicsMaterial &p_other) const {
+	return static_friction == p_other.static_friction &&
+			dynamic_friction == p_other.dynamic_friction &&
+			restitution == p_other.restitution &&
+			friction_combine == p_other.friction_combine &&
+			restitution_combine == p_other.restitution_combine;
+}
+
+bool GLTFPhysicsMaterial::operator!=(const GLTFPhysicsMaterial &p_other) const {
+	return !(*this == p_other);
+}

--- a/modules/gltf/extensions/physics/gltf_physics_material.h
+++ b/modules/gltf/extensions/physics/gltf_physics_material.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  gltf_document_extension_physics.h                                     */
+/*  gltf_physics_material.h                                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,24 +30,55 @@
 
 #pragma once
 
-#include "../gltf_document_extension.h"
-#include "gltf_physics_body.h"
-#include "gltf_physics_material.h"
-#include "gltf_physics_shape.h"
+#include "scene/resources/physics_material.h"
 
-class GLTFDocumentExtensionPhysics : public GLTFDocumentExtension {
-	GDCLASS(GLTFDocumentExtensionPhysics, GLTFDocumentExtension);
+// GLTFPhysicsMaterial is an intermediary between Godot's PhysicsMaterial
+// and the OMI_physics_body extension's physicsMaterial property.
+// https://github.com/omigroup/gltf-extensions/tree/main/extensions/2.0/OMI_physics_body
+
+class GLTFPhysicsMaterial : public Resource {
+	GDCLASS(GLTFPhysicsMaterial, Resource)
 
 public:
-	// Import process.
-	Error import_preflight(Ref<GLTFState> p_state, const Vector<String> &p_extensions) override;
-	Vector<String> get_supported_extensions() override;
-	Error parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, const Dictionary &p_extensions) override;
-	Ref<GLTFObjectModelProperty> import_object_model_property(Ref<GLTFState> p_state, const PackedStringArray &p_split_json_pointer, const TypedArray<NodePath> &p_partial_paths) override;
-	Node3D *generate_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_parent) override;
-	// Export process.
-	void convert_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_node) override;
-	Error export_preserialize(Ref<GLTFState> p_state) override;
-	Ref<GLTFObjectModelProperty> export_object_model_property(Ref<GLTFState> p_state, const NodePath &p_node_path, const Node *p_godot_node, GLTFNodeIndex p_gltf_node_index, const Object *p_target_object, int p_target_depth) override;
-	Error export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_node_json, Node *p_scene_node) override;
+	enum CombineMode {
+		COMBINE_AVERAGE,
+		COMBINE_MINIMUM,
+		COMBINE_MAXIMUM,
+		COMBINE_MULTIPLY,
+	};
+
+protected:
+	static void _bind_methods();
+
+private:
+	real_t static_friction = 0.6;
+	real_t dynamic_friction = 0.6;
+	real_t restitution = 0.0;
+	CombineMode friction_combine = COMBINE_AVERAGE;
+	CombineMode restitution_combine = COMBINE_AVERAGE;
+
+public:
+	real_t get_static_friction() const;
+	void set_static_friction(real_t p_static_friction);
+
+	real_t get_dynamic_friction() const;
+	void set_dynamic_friction(real_t p_dynamic_friction);
+
+	real_t get_restitution() const;
+	void set_restitution(real_t p_restitution);
+
+	CombineMode get_friction_combine() const;
+	void set_friction_combine(CombineMode p_friction_combine);
+
+	CombineMode get_restitution_combine() const;
+	void set_restitution_combine(CombineMode p_restitution_combine);
+
+	static Ref<GLTFPhysicsMaterial> from_resource(const Ref<PhysicsMaterial> &p_material);
+	Ref<PhysicsMaterial> to_resource() const;
+
+	static Ref<GLTFPhysicsMaterial> from_dictionary(const Dictionary &p_dictionary);
+	Dictionary to_dictionary() const;
+
+	bool operator==(const GLTFPhysicsMaterial &p_other) const;
+	bool operator!=(const GLTFPhysicsMaterial &p_other) const;
 };

--- a/modules/gltf/extensions/physics/gltf_physics_material.h
+++ b/modules/gltf/extensions/physics/gltf_physics_material.h
@@ -82,3 +82,5 @@ public:
 	bool operator==(const GLTFPhysicsMaterial &p_other) const;
 	bool operator!=(const GLTFPhysicsMaterial &p_other) const;
 };
+
+VARIANT_ENUM_CAST(GLTFPhysicsMaterial::CombineMode);

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -119,6 +119,7 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(GLTFObjectModelProperty);
 #ifndef PHYSICS_3D_DISABLED
 		GDREGISTER_CLASS(GLTFPhysicsBody);
+		GDREGISTER_CLASS(GLTFPhysicsMaterial);
 		GDREGISTER_CLASS(GLTFPhysicsShape);
 #endif // PHYSICS_3D_DISABLED
 		GDREGISTER_CLASS(GLTFSkeleton);


### PR DESCRIPTION


## Changes:
- Added `GLTFPhysicsMaterial` class to handle physics material conversion between Godot and glTF
- Added document-level `physicsMaterials` array export with de-duplication
- Collider nodes now properly reference physics materials via `physicsMaterial` index
- Import support for physics materials from glTF files
- Physics materials are automatically applied to StaticBody3D and RigidBody3D nodes

## Features:
- Supports all OMI_physics_body material properties: staticFriction, dynamicFriction, restitution, frictionCombine, restitutionCombine
- Automatic material propagation from body nodes to their collision shape children
- Compatible with existing physics body and shape export/import

