### PR TITLE
Add editor setting to enable or disable selecting tilemaplayer via click

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -679,6 +679,9 @@
 		<member name="editors/shader_editor/behavior/files/restore_shaders_on_load" type="bool" setter="" getter="">
 			If [code]true[/code], reopens shader files that were open in the shader editor when the project was last closed.
 		</member>
+		<member name="editors/tiles_editor/click_to_select_tilemap" type="bool" setter="" getter="">
+			If [code]true[/code] clicking a tile in a scene will select the TileMapLayer it belongs to.
+		</member>
 		<member name="editors/tiles_editor/display_grid" type="bool" setter="" getter="">
 			If [code]true[/code], displays a grid while the TileMap editor is active. See also [member editors/tiles_editor/grid_color].
 		</member>
@@ -688,9 +691,6 @@
 		</member>
 		<member name="editors/tiles_editor/highlight_selected_layer" type="bool" setter="" getter="">
 			Highlight the currently selected TileMapLayer by dimming the other ones in the scene.
-		</member>
-		<member name="editors/tiles_editor/click_to_select_tilemap" type="bool" setter="" getter="">
-			If [code]true[/code] clicking a tile in a scene will select the TileMapLayer it belongs to.
 		</member>
 		<member name="editors/visual_editors/category_colors/color_color" type="Color" setter="" getter="">
 			The color of a graph node's header when it belongs to the "Color" category.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -689,6 +689,9 @@
 		<member name="editors/tiles_editor/highlight_selected_layer" type="bool" setter="" getter="">
 			Highlight the currently selected TileMapLayer by dimming the other ones in the scene.
 		</member>
+		<member name="editors/tiles_editor/click_to_select_tilemap" type="bool" setter="" getter="">
+			If [code]true[/code] clicking a tile in a scene will select the TileMapLayer it belongs to.
+		</member>
 		<member name="editors/visual_editors/category_colors/color_color" type="Color" setter="" getter="">
 			The color of a graph node's header when it belongs to the "Color" category.
 		</member>

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1004,6 +1004,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/tiles_editor/display_grid", true);
 	_initial_set("editors/tiles_editor/highlight_selected_layer", true);
 	_initial_set("editors/tiles_editor/grid_color", Color(1.0, 0.5, 0.2, 0.5));
+	_initial_set("editors/tiles_editor/click_to_select_tilemap", true);
 
 	// Polygon editor
 	_initial_set("editors/polygon_editor/point_grab_radius", has_touchscreen_ui ? 32 : 8);

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -50,6 +50,10 @@ Callable TileMapLayer::_navmesh_source_geometry_parsing_callback;
 RID TileMapLayer::_navmesh_source_geometry_parser;
 #endif // NAVIGATION_2D_DISABLED
 
+#ifdef TOOLS_ENABLED
+#include "editor/settings/editor_settings.h"
+#endif // TOOLS_ENABLED
+
 Vector2i TileMapLayer::_coords_to_quadrant_coords(const Vector2i &p_coords, const int p_quadrant_size) const {
 	return Vector2i(
 			p_coords.x > 0 ? p_coords.x / p_quadrant_size : (p_coords.x - (p_quadrant_size - 1)) / p_quadrant_size,
@@ -2326,6 +2330,9 @@ void TileMapLayer::_update_self_texture_repeat(RS::CanvasItemTextureRepeat p_tex
 
 #ifdef TOOLS_ENABLED
 bool TileMapLayer::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	if (!EDITOR_GET("editors/tiles_editor/click_to_select_tilemap")) {
+		return false;
+	}
 	return tile_set.is_valid() && get_cell_source_id(local_to_map(p_point)) != TileSet::INVALID_SOURCE;
 }
 #endif


### PR DESCRIPTION
# Summary of Changes
Add an editor setting to allow the user to configure whether clicking a tile in the scene should select the associated TileMapLayer in the SceneTree.

# Motivation
Makes it possible to opt-out of the behaviour introduced in #92016.
 
With a TileMapLayer selected, the left mouse button's behaviour is dictated by the active tool in the Tile editor e.g. Paint Tool, Rect Tool, Bucket Tool. While this is expected and indeed necessary for the Tile editor to work, this creates a "one-way street" when clicking on an element in the scene may put you into this context as it is no longer possible to click on any other element in the scene to exit it. The ~~only~~ way to return to Select mode is to manually click any non-TileMapLayer node in the Scene Tree *(or press the Escape key!)*. 

This issue is compounded by the nature of TileMapLayers typically taking up the majority of the clickable surface in scenes where they are used, resulting in slight misclicks of sprites or other scene elements necessitating another click on the SceneTree to fix Select behaviour, and then re-finding and clicking the element one was originally intending to select. 

While it is possible to "work around" this behaviour by locking and un-locking TileMapLayer nodes as you edit them, I find this a bit tedious when iterating and it's easy to forget to lock or unlock a node every time you're done using it.

I have personally found this to be a cause of frustration and lost productivity, and there may be others that feel the same. Allowing a simple checkbox to return the behaviour present in 4.2 and earlier for those that prefer it seems to me a good solution for all parties. 

# Testing
1. Create or open a scene containing TileMapLayer node(s)
2. Locate the editor setting `Editors -> Tiles Editor -> Click to Select Tilemap` (requires Advanced Settings checkbox)
3. With the setting checked, observe that clicking on a tile in Select mode selects a TileMapLayer in the scene tree.
4. With the setting unchecked, observe that clicking on a tile in Select mode does not select anything (but clicking on other nodes still selects them as usual).