### PR TITLE
Fix FileSystem dock visual separation when docked at bottom

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -523,11 +523,11 @@ void FileSystemDock::_update_display_mode(bool p_force) {
 				if (is_vertical) {
 					tree->set_theme_type_variation("");
 					tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
-					tree_mc->set_theme_type_variation("NoBorderBottomPanel");
+					tree_mc->set_theme_type_variation(horizontal ? "NoBorderBottomPanel" : "NoBorderHorizontal");
 
-					files->set_theme_type_variation("");
-					files->set_scroll_hint_mode(horizontal ? ItemList::SCROLL_HINT_MODE_BOTH : ItemList::SCROLL_HINT_MODE_TOP);
-					files_mc->set_theme_type_variation(horizontal ? "NoBorderBottomPanel" : "NoBorderHorizontalBottom");
+					files->set_theme_type_variation(horizontal ? "ItemListSecondary" : "");
+					files->set_scroll_hint_mode(horizontal ? ItemList::SCROLL_HINT_MODE_DISABLED : ItemList::SCROLL_HINT_MODE_TOP);
+					files_mc->set_theme_type_variation(horizontal ? "" : "NoBorderHorizontalBottom");
 				} else {
 					tree->set_theme_type_variation("TreeSecondary");
 					tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_DISABLED);
@@ -4154,7 +4154,7 @@ void FileSystemDock::update_layout(EditorDock::DockLayout p_layout) {
 	horizontal = new_horizontal;
 
 	if (horizontal) {
-		path_hb->reparent(toolbar_hbc, false);
+		path_hb->reparent(toolbar_hbc);
 		toolbar_hbc->move_child(path_hb, 2);
 		set_meta("_dock_display_mode", get_display_mode());
 		set_meta("_dock_file_display_mode", get_file_list_display_mode());


### PR DESCRIPTION
Fixes: #115191

This PR fixes a visual issue where the FileSystem dock panels blended together when docked at the bottom of the editor.
As noted in issue `#115191`, the lack of background panels made it difficult to distinguish between the folder tree and the file list.

Before (from Issue #115191):

<img width="906" height="468" alt="538198856-f1156364-1a71-475a-8d00-2b88714f0cbb" src="https://github.com/user-attachments/assets/23e2be0b-9c2d-4163-b57e-c7651bb8a6c2" />

<img width="417" height="699" alt="538199515-c95eb7c5-2e3f-46b2-8d50-6934775afd5f" src="https://github.com/user-attachments/assets/64f29c31-c511-4d16-bc45-f89976e96a3a" />

After:

<img width="1109" height="472" alt="Screenshot2" src="https://github.com/user-attachments/assets/18255897-1470-453c-970c-80718f33b787" />

<img width="297" height="484" alt="Screenshot1" src="https://github.com/user-attachments/assets/0d78e127-4c64-4551-8ccb-9cb7414c030f" />
