### PR TITLE
Use property array in MeshLibrary

### DIFF
--- a/scene/property_list_helper.cpp
+++ b/scene/property_list_helper.cpp
@@ -135,20 +135,25 @@ bool PropertyListHelper::is_property_valid(const String &p_property, int *r_inde
 	return property_list.has(components[1]);
 }
 
+void PropertyListHelper::add_properties_for_index(int p_index, List<PropertyInfo> *p_list) const {
+	for (const KeyValue<String, Property> &E : property_list) {
+		const Property &property = E.value;
+
+		PropertyInfo info = property.info;
+		if (!(info.usage & PROPERTY_USAGE_STORE_IF_NULL) && _call_getter(&property, p_index) == property.default_value) {
+			info.usage &= (~PROPERTY_USAGE_STORAGE);
+		}
+
+		info.name = vformat("%s%d/%s", prefix, p_index, info.name);
+		p_list->push_back(info);
+	}
+}
+
 void PropertyListHelper::get_property_list(List<PropertyInfo> *p_list) const {
+	DEV_ASSERT(array_length_getter);
 	const int property_count = _call_array_length_getter();
 	for (int i = 0; i < property_count; i++) {
-		for (const KeyValue<String, Property> &E : property_list) {
-			const Property &property = E.value;
-
-			PropertyInfo info = property.info;
-			if (!(info.usage & PROPERTY_USAGE_STORE_IF_NULL) && _call_getter(&property, i) == property.default_value) {
-				info.usage &= (~PROPERTY_USAGE_STORAGE);
-			}
-
-			info.name = vformat("%s%d/%s", prefix, i, info.name);
-			p_list->push_back(info);
-		}
+		add_properties_for_index(i, p_list);
 	}
 }
 

--- a/scene/property_list_helper.h
+++ b/scene/property_list_helper.h
@@ -82,6 +82,7 @@ public:
 	bool is_initialized() const;
 	void setup_for_instance(const PropertyListHelper &p_base, Object *p_object);
 	bool is_property_valid(const String &p_property, int *r_index = nullptr) const;
+	void add_properties_for_index(int p_index, List<PropertyInfo> *p_list) const;
 
 	void get_property_list(List<PropertyInfo> *p_list) const;
 	bool property_get_value(const String &p_property, Variant &r_ret) const;

--- a/scene/resources/3d/mesh_library.cpp
+++ b/scene/resources/3d/mesh_library.cpp
@@ -34,124 +34,75 @@
 #include "box_shape_3d.h"
 #endif // PHYSICS_3D_DISABLED
 
+bool MeshLibrary::_validate_index(int p_idx) {
+	if (unlikely(!item_map.has(p_idx))) {
+		if (!loading_property) {
+			ERR_FAIL_V_MSG(false, vformat("Requested for nonexistent MeshLibrary item '%d'.", p_idx));
+		}
+		create_item(p_idx);
+	}
+	return true;
+}
+
 bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
-	String prop_name = p_name;
-	if (prop_name.begins_with("item/")) {
-		int idx = prop_name.get_slicec('/', 1).to_int();
-		String what = prop_name.get_slicec('/', 2);
-		if (!item_map.has(idx)) {
-			create_item(idx);
-		}
-
-		if (what == "name") {
-			set_item_name(idx, p_value);
-		} else if (what == "mesh") {
-			set_item_mesh(idx, p_value);
-		} else if (what == "mesh_transform") {
-			set_item_mesh_transform(idx, p_value);
-		} else if (what == "mesh_cast_shadow") {
-			switch ((int)p_value) {
-				case 0: {
-					set_item_mesh_cast_shadow(idx, RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_OFF);
-				} break;
-				case 1: {
-					set_item_mesh_cast_shadow(idx, RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_ON);
-				} break;
-				case 2: {
-					set_item_mesh_cast_shadow(idx, RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_DOUBLE_SIDED);
-				} break;
-				case 3: {
-					set_item_mesh_cast_shadow(idx, RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_SHADOWS_ONLY);
-				} break;
-				default: {
-					set_item_mesh_cast_shadow(idx, RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_ON);
-				} break;
-			}
-#ifndef PHYSICS_3D_DISABLED
-		} else if (what == "shape") {
-			Vector<ShapeData> shapes;
-			ShapeData sd;
-			sd.shape = p_value;
-			shapes.push_back(sd);
-			set_item_shapes(idx, shapes);
-		} else if (what == "shapes") {
-			_set_item_shapes(idx, p_value);
-#endif // PHYSICS_3D_DISABLED
-		} else if (what == "preview") {
-			set_item_preview(idx, p_value);
-		} else if (what == "navigation_mesh") {
-			set_item_navigation_mesh(idx, p_value);
-		} else if (what == "navigation_mesh_transform") {
-			set_item_navigation_mesh_transform(idx, p_value);
-#ifndef DISABLE_DEPRECATED
-		} else if (what == "navmesh") { // Renamed in 4.0 beta 9.
-			set_item_navigation_mesh(idx, p_value);
-		} else if (what == "navmesh_transform") { // Renamed in 4.0 beta 9.
-			set_item_navigation_mesh_transform(idx, p_value);
-#endif // DISABLE_DEPRECATED
-		} else if (what == "navigation_layers") {
-			set_item_navigation_layers(idx, p_value);
-		} else {
-			return false;
-		}
-
+	loading_property = true;
+	if (property_helper.property_set_value(p_name, p_value)) {
 		return true;
 	}
+	loading_property = false;
+#ifndef DISABLE_DEPRECATED
+	const String sname = p_name;
+	if (!sname.begins_with("item/")) {
+		return false;
+	}
 
+	Vector<String> components = sname.split("/", true, 2);
+	if (components.size() < 2 || !components[1].is_valid_int()) {
+		return false;
+	}
+
+	int index = components[1].to_int();
+	if (components[2] == "navmesh") { // Renamed in 4.0 beta 9.
+		set_item_navigation_mesh(index, p_value);
+		return true;
+	} else if (components[2] == "navmesh_transform") { // Renamed in 4.0 beta 9.
+		set_item_navigation_mesh_transform(index, p_value);
+		return true;
+	}
+#endif // DISABLE_DEPRECATED
 	return false;
 }
 
 bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
-	String prop_name = p_name;
-	int idx = prop_name.get_slicec('/', 1).to_int();
-	ERR_FAIL_COND_V(!item_map.has(idx), false);
-	String what = prop_name.get_slicec('/', 2);
-
-	if (what == "name") {
-		r_ret = get_item_name(idx);
-	} else if (what == "mesh") {
-		r_ret = get_item_mesh(idx);
-	} else if (what == "mesh_transform") {
-		r_ret = get_item_mesh_transform(idx);
-	} else if (what == "mesh_cast_shadow") {
-		r_ret = (int)get_item_mesh_cast_shadow(idx);
-#ifndef PHYSICS_3D_DISABLED
-	} else if (what == "shapes") {
-		r_ret = _get_item_shapes(idx);
-#endif // PHYSICS_3D_DISABLED
-	} else if (what == "navigation_mesh") {
-		r_ret = get_item_navigation_mesh(idx);
-	} else if (what == "navigation_mesh_transform") {
-		r_ret = get_item_navigation_mesh_transform(idx);
+	if (property_helper.property_get_value(p_name, r_ret)) {
+		return true;
+	}
 #ifndef DISABLE_DEPRECATED
-	} else if (what == "navmesh") { // Renamed in 4.0 beta 9.
-		r_ret = get_item_navigation_mesh(idx);
-	} else if (what == "navmesh_transform") { // Renamed in 4.0 beta 9.
-		r_ret = get_item_navigation_mesh_transform(idx);
-#endif // DISABLE_DEPRECATED
-	} else if (what == "navigation_layers") {
-		r_ret = get_item_navigation_layers(idx);
-	} else if (what == "preview") {
-		r_ret = get_item_preview(idx);
-	} else {
+	const String sname = p_name;
+	if (!sname.begins_with("item/")) {
 		return false;
 	}
 
-	return true;
+	Vector<String> components = sname.split("/", true, 2);
+	if (components.size() < 2 || !components[1].is_valid_int()) {
+		return false;
+	}
+
+	int index = components[1].to_int();
+	if (components[2] == "navmesh") { // Renamed in 4.0 beta 9.
+		r_ret = get_item_navigation_mesh(index);
+		return true;
+	} else if (components[2] == "navmesh_transform") { // Renamed in 4.0 beta 9.
+		r_ret = get_item_navigation_mesh_transform(index);
+		return true;
+	}
+#endif // DISABLE_DEPRECATED
+	return false;
 }
 
 void MeshLibrary::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (const KeyValue<int, Item> &E : item_map) {
-		String prop_name = vformat("%s/%d/", PNAME("item"), E.key);
-		p_list->push_back(PropertyInfo(Variant::STRING, prop_name + PNAME("name")));
-		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("mesh"), PROPERTY_HINT_RESOURCE_TYPE, "Mesh"));
-		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prop_name + PNAME("mesh_transform"), PROPERTY_HINT_NONE, "suffix:m"));
-		p_list->push_back(PropertyInfo(Variant::INT, prop_name + PNAME("mesh_cast_shadow"), PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only"));
-		p_list->push_back(PropertyInfo(Variant::ARRAY, prop_name + PNAME("shapes")));
-		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("navigation_mesh"), PROPERTY_HINT_RESOURCE_TYPE, "NavigationMesh"));
-		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prop_name + PNAME("navigation_mesh_transform"), PROPERTY_HINT_NONE, "suffix:m"));
-		p_list->push_back(PropertyInfo(Variant::INT, prop_name + PNAME("navigation_layers"), PROPERTY_HINT_LAYERS_3D_NAVIGATION));
-		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("preview"), PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", PROPERTY_USAGE_DEFAULT));
+		property_helper.add_properties_for_index(E.key, p_list);
 	}
 }
 
@@ -164,32 +115,42 @@ void MeshLibrary::create_item(int p_item) {
 }
 
 void MeshLibrary::set_item_name(int p_item, const String &p_name) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	if (!_validate_index(p_item)) {
+		return;
+	}
 	item_map[p_item].name = p_name;
 	emit_changed();
 }
 
 void MeshLibrary::set_item_mesh(int p_item, const Ref<Mesh> &p_mesh) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	if (!_validate_index(p_item)) {
+		return;
+	}
 	item_map[p_item].mesh = p_mesh;
 	emit_changed();
 }
 
 void MeshLibrary::set_item_mesh_transform(int p_item, const Transform3D &p_transform) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	if (!_validate_index(p_item)) {
+		return;
+	}
 	item_map[p_item].mesh_transform = p_transform;
 	emit_changed();
 }
 
 void MeshLibrary::set_item_mesh_cast_shadow(int p_item, RS::ShadowCastingSetting p_shadow_casting_setting) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	if (!_validate_index(p_item)) {
+		return;
+	}
 	item_map[p_item].mesh_cast_shadow = p_shadow_casting_setting;
 	emit_changed();
 }
 
 #ifndef PHYSICS_3D_DISABLED
 void MeshLibrary::set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	if (!_validate_index(p_item)) {
+		return;
+	}
 	item_map[p_item].shapes = p_shapes;
 	emit_changed();
 	notify_property_list_changed();
@@ -197,25 +158,33 @@ void MeshLibrary::set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes)
 #endif // PHYSICS_3D_DISABLED
 
 void MeshLibrary::set_item_navigation_mesh(int p_item, const Ref<NavigationMesh> &p_navigation_mesh) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	if (!_validate_index(p_item)) {
+		return;
+	}
 	item_map[p_item].navigation_mesh = p_navigation_mesh;
 	emit_changed();
 }
 
 void MeshLibrary::set_item_navigation_mesh_transform(int p_item, const Transform3D &p_transform) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	if (!_validate_index(p_item)) {
+		return;
+	}
 	item_map[p_item].navigation_mesh_transform = p_transform;
 	emit_changed();
 }
 
 void MeshLibrary::set_item_navigation_layers(int p_item, uint32_t p_navigation_layers) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	if (!_validate_index(p_item)) {
+		return;
+	}
 	item_map[p_item].navigation_layers = p_navigation_layers;
 	emit_changed();
 }
 
 void MeshLibrary::set_item_preview(int p_item, const Ref<Texture2D> &p_preview) {
-	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	if (!_validate_index(p_item)) {
+		return;
+	}
 	item_map[p_item].preview = p_preview;
 	emit_changed();
 }
@@ -269,6 +238,10 @@ Ref<Texture2D> MeshLibrary::get_item_preview(int p_item) const {
 
 bool MeshLibrary::has_item(int p_item) const {
 	return item_map.has(p_item);
+}
+
+int MeshLibrary::get_item_count() const {
+	return item_map.size();
 }
 
 void MeshLibrary::remove_item(int p_item) {
@@ -367,6 +340,7 @@ Array MeshLibrary::_get_item_shapes(int p_item) const {
 void MeshLibrary::reset_state() {
 	clear();
 }
+
 void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_item", "id"), &MeshLibrary::create_item);
 	ClassDB::bind_method(D_METHOD("set_item_name", "id", "name"), &MeshLibrary::set_item_name);
@@ -397,10 +371,30 @@ void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear"), &MeshLibrary::clear);
 	ClassDB::bind_method(D_METHOD("get_item_list"), &MeshLibrary::get_item_list);
 	ClassDB::bind_method(D_METHOD("get_last_unused_item_id"), &MeshLibrary::get_last_unused_item_id);
+
+	ClassDB::bind_method(D_METHOD("get_item_count"), &MeshLibrary::get_item_count);
+
+	ADD_ARRAY_COUNT_WITH_USAGE_FLAGS("Item", "item_count", "", "get_item_count", "item/", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_READ_ONLY);
+
+	Item defaults;
+
+	base_property_helper.set_prefix("item/");
+	base_property_helper.set_array_length_getter(&MeshLibrary::get_item_count);
+	base_property_helper.register_property(PropertyInfo(Variant::STRING, PNAME("name")), defaults.name, &MeshLibrary::set_item_name, &MeshLibrary::get_item_name);
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, PNAME("mesh"), PROPERTY_HINT_RESOURCE_TYPE, "Mesh"), defaults.mesh, &MeshLibrary::set_item_mesh, &MeshLibrary::get_item_mesh);
+	base_property_helper.register_property(PropertyInfo(Variant::TRANSFORM3D, PNAME("mesh_transform"), PROPERTY_HINT_NONE, "suffix:m"), defaults.mesh_transform, &MeshLibrary::set_item_mesh_transform, &MeshLibrary::get_item_mesh_transform);
+	base_property_helper.register_property(PropertyInfo(Variant::INT, PNAME("mesh_cast_shadow"), PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only"), defaults.mesh_cast_shadow, &MeshLibrary::set_item_mesh_cast_shadow, &MeshLibrary::get_item_mesh_cast_shadow);
+#ifndef PHYSICS_3D_DISABLED
+	base_property_helper.register_property(PropertyInfo(Variant::ARRAY, PNAME("shapes")), Array(), &MeshLibrary::_set_item_shapes, &MeshLibrary::_get_item_shapes);
+#endif // PHYSICS_3D_DISABLED
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, PNAME("navigation_mesh"), PROPERTY_HINT_RESOURCE_TYPE, "NavigationMesh"), defaults.navigation_mesh, &MeshLibrary::set_item_navigation_mesh, &MeshLibrary::get_item_navigation_mesh);
+	base_property_helper.register_property(PropertyInfo(Variant::TRANSFORM3D, PNAME("navigation_mesh_transform"), PROPERTY_HINT_NONE, "suffix:m"), defaults.navigation_mesh_transform, &MeshLibrary::set_item_mesh_transform, &MeshLibrary::get_item_mesh_transform);
+	base_property_helper.register_property(PropertyInfo(Variant::INT, PNAME("navigation_layers"), PROPERTY_HINT_LAYERS_3D_NAVIGATION), defaults.navigation_layers, &MeshLibrary::set_item_navigation_layers, &MeshLibrary::get_item_navigation_layers);
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, PNAME("preview"), PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), defaults.preview, &MeshLibrary::set_item_preview, &MeshLibrary::get_item_preview);
+	PropertyListHelper::register_base_helper(&base_property_helper);
 }
 
 MeshLibrary::MeshLibrary() {
-}
-
-MeshLibrary::~MeshLibrary() {
+	property_helper.setup_for_instance(base_property_helper, this);
+	property_helper.enable_out_of_bounds_assign();
 }

--- a/scene/resources/3d/mesh_library.h
+++ b/scene/resources/3d/mesh_library.h
@@ -32,6 +32,7 @@
 
 #include "core/io/resource.h"
 #include "core/templates/rb_map.h"
+#include "scene/property_list_helper.h"
 #include "scene/resources/mesh.h"
 #include "scene/resources/navigation_mesh.h"
 #include "servers/rendering/rendering_server.h"
@@ -72,10 +73,19 @@ public:
 	Array _get_item_shapes(int p_item) const;
 #endif // PHYSICS_3D_DISABLED
 
+	static inline PropertyListHelper base_property_helper;
+	PropertyListHelper property_helper;
+
+	bool loading_property = false;
+
+	bool _validate_index(int p_idx);
+
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	bool _property_can_revert(const StringName &p_name) const { return property_helper.property_can_revert(p_name); }
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return property_helper.property_get_revert(p_name, r_property); }
 
 	virtual void reset_state() override;
 	static void _bind_methods();
@@ -108,6 +118,8 @@ public:
 	void remove_item(int p_item);
 	bool has_item(int p_item) const;
 
+	int get_item_count() const;
+
 	void clear();
 
 	int find_item_by_name(const String &p_name) const;
@@ -116,5 +128,4 @@ public:
 	int get_last_unused_item_id() const;
 
 	MeshLibrary();
-	~MeshLibrary();
 };


### PR DESCRIPTION
I found #52463 in my saved bookmarks and though "why not add property array to MeshLibrary". Uh 💀

It works

<img width="365" height="759" alt="image" src="https://github.com/user-attachments/assets/6136f7ec-9f76-4dfe-add2-62ce833bd4a0" />

but the MeshLibrary uses sparse array for its items. I don't know how items get deleted, probably when library is merged while saving? Property array does not support it, the indices are expected to have no holes. Thus this will probably break in some cases. I already wrote the code though, maybe it's fixable, idk. Or maybe the "sparse array" is just for show and can be replaced with LocalVector.