### PR TITLE
Document Line2D antialiasing being currently unimplemented

### DIFF
--- a/doc/classes/Line2D.xml
+++ b/doc/classes/Line2D.xml
@@ -60,7 +60,7 @@
 	<members>
 		<member name="antialiased" type="bool" setter="set_antialiased" getter="get_antialiased" default="false">
 			If [code]true[/code], the polyline's border will be anti-aliased.
-			[b]Note:[/b] [Line2D] is not accelerated by batching when being anti-aliased.
+			[b]Note:[/b] This property is currently unimplemented and has no effect when enabled. On the Forward+ and Mobile renderers, you can use 2D MSAA instead (see [member ProjectSettings.rendering/anti_aliasing/quality/msaa_2d]). Alternatively, you can use the [url=https://github.com/godot-extended-libraries/godot-antialiased-line2d]AntialiasedLine2D[/url] add-on with all renderers.
 		</member>
 		<member name="begin_cap_mode" type="int" setter="set_begin_cap_mode" getter="get_begin_cap_mode" enum="Line2D.LineCapMode" default="0">
 			The style of the beginning of the polyline, if [member closed] is [code]false[/code].

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -264,6 +264,7 @@ int Line2D::get_round_precision() const {
 void Line2D::set_antialiased(bool p_antialiased) {
 	_antialiased = p_antialiased;
 	queue_redraw();
+	update_configuration_warnings();
 }
 
 bool Line2D::get_antialiased() const {
@@ -337,7 +338,16 @@ void Line2D::_curve_changed() {
 	queue_redraw();
 }
 
-// static
+PackedStringArray Line2D::get_configuration_warnings() const {
+	PackedStringArray warnings = Node2D::get_configuration_warnings();
+
+	if (_antialiased) {
+		warnings.push_back(RTR("The Antialiased property is currently unimplemented and has no effect when enabled.\nOn the Forward+ and Mobile renderers, you can use 2D MSAA instead (ProjectSettings > Rendering > Anti Aliasing > Quality > MSAA 2D)."));
+	}
+
+	return warnings;
+}
+
 void Line2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_points", "points"), &Line2D::set_points);
 	ClassDB::bind_method(D_METHOD("get_points"), &Line2D::get_points);

--- a/scene/2d/line_2d.h
+++ b/scene/2d/line_2d.h
@@ -119,6 +119,8 @@ protected:
 	void _notification(int p_what);
 	void _draw();
 
+	virtual PackedStringArray get_configuration_warnings() const override;
+
 	static void _bind_methods();
 
 private:


### PR DESCRIPTION
- Add a node configuration warning when Line2D antialiasing is enabled.

___

- See https://github.com/godotengine/godot/issues/62954.
