### PR TITLE
Geometry2D: Remove `arc_tolerance` scaling and the comment related to that.

### DIFF
--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -38,7 +38,6 @@ GODOT_GCC_WARNING_POP
 #include "thirdparty/misc/stb_rect_pack.h"
 
 const int clipper_precision = 5; // Based on CMP_EPSILON.
-const double clipper_scale = Math::pow(10.0, clipper_precision);
 
 void Geometry2D::merge_many_polygons(const Vector<Vector<Vector2>> &p_polygons, Vector<Vector<Vector2>> &r_out_polygons, Vector<Vector<Vector2>> &r_out_holes) {
 	using namespace Clipper2Lib;
@@ -351,10 +350,7 @@ Vector<Vector<Point2>> Geometry2D::_polypath_offset(const Vector<Point2> &p_poly
 	}
 
 	// Inflate/deflate.
-	PathsD paths = InflatePaths({ polypath }, p_delta, jt, et, 2.0, clipper_precision, 0.25 * clipper_scale);
-	// Here the points are scaled up internally and
-	// the arc_tolerance is scaled accordingly
-	// to attain the desired precision.
+	PathsD paths = InflatePaths({ polypath }, p_delta, jt, et, 2.0, clipper_precision, 0.25);
 
 	Vector<Vector<Point2>> polypaths;
 	polypaths.resize(paths.size());


### PR DESCRIPTION
Fixes #113263

This broke with the upgrade to clipper2 1.5.3 which does the arc_tolerance scaling internally.

See [commit](https://github.com/godotengine/godot/commit/256fa39e512c00478421979052765c9a2a54e35f#diff-884c38fe6788a5a8a4215385eddd288c4e37208439bff6dd9c40278667bc8ba1R153)
