### PR TITLE
Reset drag unfold timer when mouse exits Tree

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5001,6 +5001,9 @@ void Tree::_notification(int p_what) {
 
 		case NOTIFICATION_MOUSE_EXIT: {
 			is_mouse_hovering = false;
+			if (enable_drag_unfolding && drop_mode_over) {
+				_reset_drop_mode_over();
+			}
 			// Clear hovered item cache.
 			if (cache.hover_header_row || cache.hover_item != nullptr) {
 				cache.hover_header_row = false;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
Fixes: #115271
Kind of a regression fix of #110904 , since it was introduced during the dev phase of 4.6

Using `_reset_drop_mode_over()` on `NOTIFICATION_MOUSE_EXIT`, if `enable_drag_unfolding` and `drop_mode_over` (user is dragging TreeItem) are true. Originally, the timer for unfolding would start, but not stop if mouse had exited the tree. `drop_mode_over` is not `nullptr`, even after the mouse leaves Tree, and this variable is used for conditional instead `drop_mode_flags`, because the latter already resets to 0 through other means, meanwhile I only found `drop_mode_over` to reset inside `_reset_drop_mode_over()`, which originally is only called when `drop_mode_flags` = 0 during `NOTIFICATION_DRAG_END`.
`drop_mode_over` is reassigned once mouse enters Tree again, and `_reset_drop_mode_over()` already checks if the timer is running.