### PR TITLE
Fix inconsistent usage of `localization_changed` signal variable

### DIFF
--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -484,7 +484,7 @@ void LocalizationEditor::_filesystem_files_moved(const String &p_old_file, const
 	if (remaps_changed) {
 		ProjectSettings::get_singleton()->set_setting("internationalization/locale/translation_remaps", remaps);
 		update_translations();
-		emit_signal("localization_changed");
+		emit_signal(localization_changed);
 	}
 }
 
@@ -524,7 +524,7 @@ void LocalizationEditor::_filesystem_file_removed(const String &p_file) {
 
 	if (remaps_changed) {
 		update_translations();
-		emit_signal("localization_changed");
+		emit_signal(localization_changed);
 	}
 }
 

--- a/editor/translations/localization_editor.h
+++ b/editor/translations/localization_editor.h
@@ -58,7 +58,7 @@ class LocalizationEditor : public VBoxContainer {
 	Button *template_generate_button = nullptr;
 
 	bool updating_translations = false;
-	String localization_changed;
+	StringName localization_changed;
 
 	LocalVector<Tree *> trees;
 	HashMap<Tree *, String> tree_data_types;


### PR DESCRIPTION
Closes #37604

Only one signal from that list was still unused. I noticed there are some signals emitted indirectly (using a dedicated variable, like the one I fixed in LocalizationEditor), so they were probably false-positives in the tracker.