### PR TITLE
Fix stale reference bug in FramebufferCache.

### DIFF
--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -670,7 +670,6 @@ private:
 	HashMap<FramebufferFormatID, FramebufferFormat> framebuffer_formats;
 
 	struct Framebuffer {
-		RenderingDevice *rendering_device = nullptr;
 		FramebufferFormatID format_id;
 		uint32_t storage_mask = 0;
 		Vector<RID> texture_ids;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/115284.

In an attempt to get the key for the framebuffer format ID associated to the framebuffer, a pointer to it was stored. However, RID Owner was effectively freeing and assigning this space to a new framebuffer, causing a stale reference issue. It seems the higher level problem is that the related Reflection Probe code is creating a framebuffer, drawing to it, and then immediately deleted it. While this is allowed and RenderingDevice should work properly with it, this is probably something worth looking into. However, it seems this situation doesn't really repeat itself after the first initialization frame on the MRP posted on the issue.

To fix this instead, we rely on the fact that the HashMap will not move the address of items that have already been inserted, and we're also guaranteed they'll remain alive for the remainder of RenderingDevice's life, as the framebuffer format cache is not cleared until shutdown.

Thanks to @blueskythlikesclouds for help on debugging this issue.