### PR TITLE
Fix returning untyped arrays or dictionaries static check

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2577,6 +2577,8 @@ void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
 			if (!is_type_compatible(result, expected_type)) {
 				push_error(vformat(R"(Cannot return value of type "%s" because the function return type is "%s".)", result.to_string(), expected_type.to_string()), p_return);
 			}
+		} else if (expected_type == result && ((expected_type.has_container_element_type(0) && !result.has_container_element_type(0)) || (expected_type.has_container_element_type(1) && !result.has_container_element_type(1)))) {
+			mark_node_unsafe(p_return);
 #ifdef DEBUG_ENABLED
 		} else if (expected_type.builtin_type == Variant::INT && result.builtin_type == Variant::FLOAT) {
 			parser->push_warning(p_return, GDScriptWarning::NARROWING_CONVERSION);


### PR DESCRIPTION
Fixes #100175
Just marking the returns as unsafe, as suggested in the issue discussion.