### PR TITLE
Tweak IKModifier3D docs and comment

### DIFF
--- a/doc/classes/FABRIK3D.xml
+++ b/doc/classes/FABRIK3D.xml
@@ -9,5 +9,6 @@
 		[b]Note:[/b] When the target is close to the root, it tends to produce zig-zag patterns, resulting in unnatural visual movement.
 	</description>
 	<tutorials>
+		<link title="Inverse Kinematics Returns to Godot 4.6 - IKModifier3D">https://godotengine.org/article/inverse-kinematics-returns-to-godot-4-6/#ikmodifier3d-and-7-child-classes</link>
 	</tutorials>
 </class>

--- a/doc/classes/IKModifier3D.xml
+++ b/doc/classes/IKModifier3D.xml
@@ -7,6 +7,7 @@
 		Base class of [SkeletonModifier3D]s that has some joint lists and applies inverse kinematics. This class has some structs, enums, and helper methods which are useful to solve inverse kinematics.
 	</description>
 	<tutorials>
+		<link title="Inverse Kinematics Returns to Godot 4.6 - IKModifier3D">https://godotengine.org/article/inverse-kinematics-returns-to-godot-4-6/#ikmodifier3d-and-7-child-classes</link>
 	</tutorials>
 	<methods>
 		<method name="clear_settings">

--- a/scene/3d/two_bone_ik_3d.cpp
+++ b/scene/3d/two_bone_ik_3d.cpp
@@ -770,7 +770,6 @@ void TwoBoneIK3D::_process_ik(Skeleton3D *p_skeleton, double p_delta) {
 }
 
 void TwoBoneIK3D::_process_joints(double p_delta, Skeleton3D *p_skeleton, TwoBoneIK3DSetting *p_setting, const Vector3 &p_destination, const Vector3 &p_pole_destination) {
-	// Solve the IK for this iteration.
 	Vector3 destination = p_destination;
 
 	// Make vector from root to destination.


### PR DESCRIPTION
As the minimum tutorial currently available, links to the article.

These links are placed only for the docs of the base class IKModifier and FABRIK. This is because the article provides an overview of the entire IKModifier, while the demo project actually available within the article pertains solely to FABRIK.

Also, removed incorrect comments from the TwoBoneIK code. Since IterateIK was used as the base when creating the TwoBoneIK class, comments from IterateIK had been mistakenly included.