### PR TITLE
Document hyphens being replaced with spaces in `String.capitalize()`

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -92,17 +92,19 @@
 		<method name="capitalize" qualifiers="const">
 			<return type="String" />
 			<description>
-				Changes the appearance of the string: replaces underscores ([code]_[/code]) with spaces, adds spaces before uppercase letters in the middle of a word, converts all letters to lowercase, then converts the first one and each one following a space to uppercase.
+				Returns a copy of the string with changed appearance. Replaces underscores ([code]_[/code]) and hyphens ([code]-[/code]) with spaces, adds spaces before uppercase letters in the middle of a word, converts all letters to lowercase, then converts the first one and each one following a space to uppercase.
 				[codeblocks]
 				[gdscript]
 				"move_local_x".capitalize()   # Returns "Move Local X"
 				"sceneFile_path".capitalize() # Returns "Scene File Path"
 				"2D, FPS, PNG".capitalize()   # Returns "2d, Fps, Png"
+				"example-name".capitalize()   # Returns "Example Name"
 				[/gdscript]
 				[csharp]
 				"move_local_x".Capitalize();   // Returns "Move Local X"
 				"sceneFile_path".Capitalize(); // Returns "Scene File Path"
 				"2D, FPS, PNG".Capitalize();   // Returns "2d, Fps, Png"
+				"example-name".Capitalize();   // Returns "Example Name"
 				[/csharp]
 				[/codeblocks]
 			</description>


### PR DESCRIPTION
This behavior occurs since 4.5 following the merge of https://github.com/godotengine/godot/pull/94883.

- This closes https://github.com/godotengine/godot-docs/issues/11648.
