### PR TITLE
Change copy constructor of `LocalVector` from implicit to explicit

### DIFF
--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -158,7 +158,7 @@ void AStarGrid2D::update() {
 			solid_mask.push_back(false);
 		}
 		solid_mask.push_back(true);
-		points.push_back(line);
+		points.push_back(std::move(line));
 	}
 
 	for (int32_t x = region.position.x; x < end_x + 2; x++) {

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1018,7 +1018,7 @@ void ClassDB::get_method_list_with_compatibility(const StringName &p_class, List
 #endif // DEBUG_ENABLED
 
 		for (const KeyValue<StringName, LocalVector<MethodBind *, unsigned int, false, false>> &E : type->method_map_compatibility) {
-			LocalVector<MethodBind *> compat = E.value;
+			LocalVector<MethodBind *> compat(E.value);
 			for (MethodBind *method : compat) {
 				MethodInfo minfo = info_from_bind(method);
 

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -350,7 +350,7 @@ public:
 			push_back(element);
 		}
 	}
-	_FORCE_INLINE_ LocalVector(const LocalVector &p_from) {
+	_FORCE_INLINE_ explicit LocalVector(const LocalVector &p_from) {
 		resize(p_from.size());
 		for (U i = 0; i < p_from.count; i++) {
 			data[i] = p_from.data[i];

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1223,7 +1223,7 @@ void TextureStorage::texture_remap_proxies(RID p_from_texture, RID p_to_texture)
 	}
 
 	// Make a local copy, we're about to change the content of the original.
-	thread_local LocalVector<RID> proxies = from_tex->proxies;
+	thread_local LocalVector<RID> proxies(from_tex->proxies);
 
 	// Now change them to our new texture.
 	for (RID &proxy : proxies) {

--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -457,7 +457,7 @@ EditorBuildProfile::BuildOptionCategory EditorBuildProfile::get_build_option_cat
 
 LocalVector<EditorBuildProfile::BuildOption> EditorBuildProfile::get_build_option_dependencies(BuildOption p_build_option) {
 	ERR_FAIL_INDEX_V(p_build_option, BUILD_OPTION_MAX, LocalVector<EditorBuildProfile::BuildOption>());
-	return build_option_dependencies.has(p_build_option) ? build_option_dependencies[p_build_option] : LocalVector<EditorBuildProfile::BuildOption>();
+	return build_option_dependencies.has(p_build_option) ? LocalVector<EditorBuildProfile::BuildOption>(build_option_dependencies[p_build_option]) : LocalVector<EditorBuildProfile::BuildOption>();
 }
 
 HashMap<String, LocalVector<Variant>> EditorBuildProfile::get_build_option_settings(BuildOption p_build_option) {
@@ -467,7 +467,7 @@ HashMap<String, LocalVector<Variant>> EditorBuildProfile::get_build_option_setti
 
 LocalVector<String> EditorBuildProfile::get_build_option_classes(BuildOption p_build_option) {
 	ERR_FAIL_INDEX_V(p_build_option, BUILD_OPTION_MAX, LocalVector<String>());
-	return build_option_classes.has(p_build_option) ? build_option_classes[p_build_option] : LocalVector<String>();
+	return build_option_classes.has(p_build_option) ? LocalVector<String>(build_option_classes[p_build_option]) : LocalVector<String>();
 }
 
 String EditorBuildProfile::get_build_option_category_name(BuildOptionCategory p_build_option_category) {

--- a/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
@@ -82,7 +82,7 @@ void GodotNavigationServer2D::init() {
 	navmesh_generator_2d = memnew(NavMeshGenerator2D);
 	ERR_FAIL_NULL_MSG(navmesh_generator_2d, "Failed to init NavMeshGenerator2D.");
 	RWLockRead read_lock(geometry_parser_rwlock);
-	navmesh_generator_2d->set_generator_parsers(generator_parsers);
+	navmesh_generator_2d->set_generator_parsers(LocalVector<NavMeshGeometryParser2D *>(generator_parsers));
 #endif // CLIPPER2_ENABLED
 	// TODO
 }
@@ -251,7 +251,7 @@ TypedArray<RID> GodotNavigationServer2D::map_get_obstacles(RID p_map) const {
 	TypedArray<RID> obstacles_rids;
 	const NavMap2D *map = map_owner.get_or_null(p_map);
 	ERR_FAIL_NULL_V(map, obstacles_rids);
-	const LocalVector<NavObstacle2D *> obstacles = map->get_obstacles();
+	const LocalVector<NavObstacle2D *> obstacles(map->get_obstacles());
 	obstacles_rids.resize(obstacles.size());
 	for (uint32_t i = 0; i < obstacles.size(); i++) {
 		obstacles_rids[i] = obstacles[i]->get_self();

--- a/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
@@ -240,7 +240,7 @@ void NavMeshGenerator2D::generator_parse_geometry_node(Ref<NavigationPolygon> p_
 	}
 }
 
-void NavMeshGenerator2D::set_generator_parsers(LocalVector<NavMeshGeometryParser2D *> p_parsers) {
+void NavMeshGenerator2D::set_generator_parsers(const LocalVector<NavMeshGeometryParser2D *> &p_parsers) {
 	RWLockWrite write_lock(generator_parsers_rwlock);
 	generator_parsers = p_parsers;
 }

--- a/modules/navigation_2d/2d/nav_mesh_generator_2d.h
+++ b/modules/navigation_2d/2d/nav_mesh_generator_2d.h
@@ -91,7 +91,7 @@ public:
 	static void cleanup();
 	static void finish();
 
-	static void set_generator_parsers(LocalVector<NavMeshGeometryParser2D *> p_parsers);
+	static void set_generator_parsers(const LocalVector<NavMeshGeometryParser2D *> &p_parsers);
 
 	static void parse_source_geometry_data(Ref<NavigationPolygon> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData2D> p_source_geometry_data, Node *p_root_node, const Callable &p_callback = Callable());
 	static void bake_from_source_geometry_data(Ref<NavigationPolygon> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData2D> p_source_geometry_data, const Callable &p_callback = Callable());

--- a/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
@@ -333,7 +333,7 @@ TypedArray<RID> GodotNavigationServer3D::map_get_obstacles(RID p_map) const {
 	TypedArray<RID> obstacles_rids;
 	const NavMap3D *map = map_owner.get_or_null(p_map);
 	ERR_FAIL_NULL_V(map, obstacles_rids);
-	const LocalVector<NavObstacle3D *> obstacles = map->get_obstacles();
+	const LocalVector<NavObstacle3D *> obstacles(map->get_obstacles());
 	obstacles_rids.resize(obstacles.size());
 	for (uint32_t i = 0; i < obstacles.size(); i++) {
 		obstacles_rids[i] = obstacles[i]->get_self();

--- a/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
+++ b/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
@@ -272,7 +272,7 @@ void NavMeshGenerator3D::generator_parse_geometry_node(const Ref<NavigationMesh>
 	}
 }
 
-void NavMeshGenerator3D::set_generator_parsers(LocalVector<NavMeshGeometryParser3D *> p_parsers) {
+void NavMeshGenerator3D::set_generator_parsers(const LocalVector<NavMeshGeometryParser3D *> &p_parsers) {
 	RWLockWrite write_lock(generator_parsers_rwlock);
 	generator_parsers = p_parsers;
 }

--- a/modules/navigation_3d/3d/nav_mesh_generator_3d.h
+++ b/modules/navigation_3d/3d/nav_mesh_generator_3d.h
@@ -110,7 +110,7 @@ public:
 	static void cleanup();
 	static void finish();
 
-	static void set_generator_parsers(LocalVector<NavMeshGeometryParser3D *> p_parsers);
+	static void set_generator_parsers(const LocalVector<NavMeshGeometryParser3D *> &p_parsers);
 
 	static void parse_source_geometry_data(Ref<NavigationMesh> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData3D> p_source_geometry_data, Node *p_root_node, const Callable &p_callback = Callable());
 	static void bake_from_source_geometry_data(Ref<NavigationMesh> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData3D> p_source_geometry_data, const Callable &p_callback = Callable());

--- a/modules/navigation_3d/editor/navigation_region_3d_editor_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_region_3d_editor_plugin.cpp
@@ -265,7 +265,7 @@ void NavigationRegion3DEditorPlugin::edit(Object *p_object) {
 		NavigationRegion3D *region = Object::cast_to<NavigationRegion3D>(p_object);
 		if (region) {
 			regions.push_back(region);
-			navigation_region_editor->edit(regions);
+			navigation_region_editor->edit(std::move(regions));
 			return;
 		}
 	}
@@ -281,7 +281,7 @@ void NavigationRegion3DEditorPlugin::edit(Object *p_object) {
 		}
 	}
 
-	navigation_region_editor->edit(regions);
+	navigation_region_editor->edit(std::move(regions));
 }
 
 bool NavigationRegion3DEditorPlugin::handles(Object *p_object) const {

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -1206,7 +1206,7 @@ LocalVector<ObjectID> SpringBoneSimulator3D::get_valid_collision_instance_ids(in
 	if (collisions_dirty) {
 		_find_collisions();
 	}
-	return settings[p_index]->cached_collisions;
+	return LocalVector<ObjectID>(settings[p_index]->cached_collisions);
 }
 
 void SpringBoneSimulator3D::set_external_force(const Vector3 &p_force) {

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -478,7 +478,7 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, Array p_bone_transf
 		const float max_mesh_error = 1.0f; // We only need LODs that can be selected by error threshold.
 		const unsigned min_target_indices = 12;
 
-		LocalVector<int> current_indices = merged_indices;
+		LocalVector<int> current_indices(merged_indices);
 		float current_error = 0.0f;
 		bool allow_prune = true;
 

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -776,7 +776,7 @@ void SurfaceTool::deindex() {
 		return; //nothing to deindex
 	}
 
-	LocalVector<Vertex> old_vertex_array = vertex_array;
+	LocalVector<Vertex> old_vertex_array(vertex_array);
 	vertex_array.clear();
 	for (const int &index : index_array) {
 		ERR_FAIL_COND(uint32_t(index) >= old_vertex_array.size());
@@ -1289,7 +1289,7 @@ void SurfaceTool::optimize_indices_for_cache() {
 	ERR_FAIL_COND(primitive != Mesh::PRIMITIVE_TRIANGLES);
 	ERR_FAIL_COND(index_array.size() % 3 != 0);
 
-	LocalVector old_index_array = index_array;
+	LocalVector<int> old_index_array(index_array);
 	memset(index_array.ptr(), 0, index_array.size() * sizeof(int));
 	optimize_vertex_cache_func((unsigned int *)index_array.ptr(), (unsigned int *)old_index_array.ptr(), old_index_array.size(), vertex_array.size());
 }

--- a/servers/rendering/renderer_rd/effects/fsr2.cpp
+++ b/servers/rendering/renderer_rd/effects/fsr2.cpp
@@ -267,7 +267,7 @@ static FfxErrorCode register_resource_rd(FfxFsr2Interface *p_backend_interface, 
 
 static FfxErrorCode unregister_resources_rd(FfxFsr2Interface *p_backend_interface) {
 	FSR2Context::Scratch &scratch = *reinterpret_cast<FSR2Context::Scratch *>(p_backend_interface->scratchBuffer);
-	LocalVector<uint32_t> dynamic_list_copy = scratch.resources.dynamic_list;
+	LocalVector<uint32_t> dynamic_list_copy(scratch.resources.dynamic_list);
 	for (uint32_t i : dynamic_list_copy) {
 		scratch.resources.remove(i);
 	}


### PR DESCRIPTION
- Supersedes part of https://github.com/godotengine/godot/pull/111372
- `LocalVector` equivalent of #115093

This change makes it harder to accidentally copy `LocalVector` instances. This decreases the chance of performance problems and regressions.

Programmers will be forced to take a reference, move, otherwise avoid the copy, or explicitly make the copy:

```c++
LocalVector<int> vector;

LocalVector<int> other = vector; // implicit copy, now impossible 

LocalVector<int> other(vector); // explicit copy
LocalVector<int> other = LocalVector(vector); // explicit copy
LocalVector<int> &other = vector; // reference
LocalVector<int> other = std::move(vector); // move
```

This PR is mostly performance agnostic; that is, if a copy was happening beforehand, there will be a copy afterwards (just explicit instead of implicit). There are a few minor exceptions that I'm very sure are safe.