### PR TITLE
Fix main scene highlight not updating after file rename

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1523,23 +1523,14 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 				EditorNode::get_singleton()->add_io_error(TTR("Error moving:") + "\n" + old_path + ".uid\n");
 			}
 		}
+		
+		
+        main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
+		callable_mp(this, &FileSystemDock::_update_tree).call_deferred(get_uncollapsed_paths(), false, true);
+		callable_mp(this, &FileSystemDock::_update_file_list).call_deferred(true);
 
-		// Update scene if it is open.
-		for (int i = 0; i < file_changed_paths.size(); ++i) {
-			String new_item_path = p_item.is_file ? new_path : file_changed_paths[i].replace_first(old_path, new_path);
-			if (ResourceLoader::get_resource_type(new_item_path) == "PackedScene" && EditorNode::get_singleton()->is_scene_open(file_changed_paths[i])) {
-				EditorData *ed = &EditorNode::get_editor_data();
-				for (int j = 0; j < ed->get_edited_scene_count(); j++) {
-					if (ed->get_scene_path(j) == file_changed_paths[i]) {
-						ed->get_edited_scene_root(j)->set_scene_file_path(new_item_path);
-						EditorNode::get_singleton()->save_editor_layout_delayed();
-						break;
-					}
-				}
-			}
-		}
 
-		// Only treat as a changed dependency if it was successfully moved.
+		
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
 			p_file_renames[file_changed_paths[i]] = file_changed_paths[i].replace_first(old_path, new_path);
 			print_verbose("  Remap: " + file_changed_paths[i] + " -> " + p_file_renames[file_changed_paths[i]]);

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -4076,6 +4076,7 @@ void FileSystemDock::_feature_profile_changed() {
 
 void FileSystemDock::_project_settings_changed() {
 	assigned_folder_colors = ProjectSettings::get_singleton()->get_setting("file_customization/folder_colors");
+
 	const String &current_main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
 	if (main_scene_path != current_main_scene_path) {
 		main_scene_path = current_main_scene_path;

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1539,12 +1539,6 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 			}
 		}
 
-		// Refresh the tree and file list.
-
-		main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
-		callable_mp(this, &FileSystemDock::_update_tree).call_deferred(get_uncollapsed_paths(), false, true);
-		callable_mp(this, &FileSystemDock::_update_file_list).call_deferred(true);
-
 		// Only treat as a changed dependency if it was successfully moved.
 
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
@@ -4079,11 +4073,11 @@ void FileSystemDock::_feature_profile_changed() {
 
 void FileSystemDock::_project_settings_changed() {
 	assigned_folder_colors = ProjectSettings::get_singleton()->get_setting("file_customization/folder_colors");
-
-	const String &current_main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
-	if (main_scene_path != current_main_scene_path) {
-		main_scene_path = current_main_scene_path;
-		update_all();
+	const String new_main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
+	if (new_main_scene_path != main_scene_path) {
+		main_scene_path = new_main_scene_path;
+		_update_tree(get_uncollapsed_paths(), false, false);
+		_update_file_list(true);
 	}
 }
 

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1524,11 +1524,29 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 			}
 		}
 		
+		// Update scene if it is open.
+		for (int i = 0; i < file_changed_paths.size(); ++i) {
+			String new_item_path = p_item.is_file ? new_path : file_changed_paths[i].replace_first(old_path, new_path);
+			if (ResourceLoader::get_resource_type(new_item_path) == "PackedScene" && EditorNode::get_singleton()->is_scene_open(file_changed_paths[i])) {
+				EditorData *ed = &EditorNode::get_editor_data();
+				for (int j = 0; j < ed->get_edited_scene_count(); j++) {
+					if (ed->get_scene_path(j) == file_changed_paths[i]) {
+						ed->get_edited_scene_root(j)->set_scene_file_path(new_item_path);
+						EditorNode::get_singleton()->save_editor_layout_delayed();
+						break;
+					}
+				}
+			}
+		}
+
+		
+		// Refresh the tree and file list.
 		
         main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
 		callable_mp(this, &FileSystemDock::_update_tree).call_deferred(get_uncollapsed_paths(), false, true);
 		callable_mp(this, &FileSystemDock::_update_file_list).call_deferred(true);
 
+		// Only treat as a changed dependency if it was successfully moved.
 
 		
 		for (int i = 0; i < file_changed_paths.size(); ++i) {

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2054,7 +2054,6 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 
 			main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
 
-			
 			_update_dependencies_after_move(file_renames, file_owners);
 			_update_project_settings_after_move(file_renames, folder_renames);
 			_update_favorites_after_move(file_renames, folder_renames);
@@ -4075,19 +4074,10 @@ void FileSystemDock::_feature_profile_changed() {
 	_update_display_mode(true);
 }
 
-<<<<<<< HEAD
 void FileSystemDock::_project_settings_changed() {
 	assigned_folder_colors = ProjectSettings::get_singleton()->get_setting("file_customization/folder_colors");
-
-	const String &current_main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
-	if (main_scene_path != current_main_scene_path) {
-		main_scene_path = current_main_scene_path;
-		update_all();
-	}
 }
 
-=======
->>>>>>> 98db196c9d ( Update main scene highlight on settings change)
 void FileSystemDock::set_file_sort(FileSortOption p_file_sort) {
 	for (int i = 0; i != (int)FileSortOption::FILE_SORT_MAX; i++) {
 		tree_button_sort->get_popup()->set_item_checked(i, (i == (int)p_file_sort));

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2052,10 +2052,8 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 			int current_tab = EditorSceneTabs::get_singleton()->get_current_tab();
 			_update_resource_paths_after_move(file_renames, uids);
 
-			const String resolved_main = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
-			if (main_scene_path != resolved_main) {
-				main_scene_path = resolved_main;
-			}
+			// Update main scene path in case the file was moved.
+			main_scene_path  = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
 			_update_dependencies_after_move(file_renames, file_owners);
 			_update_project_settings_after_move(file_renames, folder_renames);
 			_update_favorites_after_move(file_renames, folder_renames);

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2052,8 +2052,9 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 			int current_tab = EditorSceneTabs::get_singleton()->get_current_tab();
 			_update_resource_paths_after_move(file_renames, uids);
 
-			// Update main scene path in case the file was moved.
-			main_scene_path  = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
+			main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
+
+			
 			_update_dependencies_after_move(file_renames, file_owners);
 			_update_project_settings_after_move(file_renames, folder_renames);
 			_update_favorites_after_move(file_renames, folder_renames);
@@ -4074,6 +4075,7 @@ void FileSystemDock::_feature_profile_changed() {
 	_update_display_mode(true);
 }
 
+<<<<<<< HEAD
 void FileSystemDock::_project_settings_changed() {
 	assigned_folder_colors = ProjectSettings::get_singleton()->get_setting("file_customization/folder_colors");
 
@@ -4084,6 +4086,8 @@ void FileSystemDock::_project_settings_changed() {
 	}
 }
 
+=======
+>>>>>>> 98db196c9d ( Update main scene highlight on settings change)
 void FileSystemDock::set_file_sort(FileSortOption p_file_sort) {
 	for (int i = 0; i != (int)FileSortOption::FILE_SORT_MAX; i++) {
 		tree_button_sort->get_popup()->set_item_checked(i, (i == (int)p_file_sort));

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -4073,6 +4073,12 @@ void FileSystemDock::_feature_profile_changed() {
 
 void FileSystemDock::_project_settings_changed() {
 	assigned_folder_colors = ProjectSettings::get_singleton()->get_setting("file_customization/folder_colors");
+	const String &current_main_scene_path =
+			ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
+	if (main_scene_path != current_main_scene_path) {
+		main_scene_path = current_main_scene_path;
+		update_all();
+	}
 }
 
 void FileSystemDock::set_file_sort(FileSortOption p_file_sort) {

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1540,7 +1540,6 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 		}
 
 		// Only treat as a changed dependency if it was successfully moved.
-
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
 			p_file_renames[file_changed_paths[i]] = file_changed_paths[i].replace_first(old_path, new_path);
 			print_verbose("  Remap: " + file_changed_paths[i] + " -> " + p_file_renames[file_changed_paths[i]]);
@@ -2051,9 +2050,7 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 
 			int current_tab = EditorSceneTabs::get_singleton()->get_current_tab();
 			_update_resource_paths_after_move(file_renames, uids);
-
 			main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
-
 			_update_dependencies_after_move(file_renames, file_owners);
 			_update_project_settings_after_move(file_renames, folder_renames);
 			_update_favorites_after_move(file_renames, folder_renames);

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1523,7 +1523,7 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 				EditorNode::get_singleton()->add_io_error(TTR("Error moving:") + "\n" + old_path + ".uid\n");
 			}
 		}
-		
+
 		// Update scene if it is open.
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
 			String new_item_path = p_item.is_file ? new_path : file_changed_paths[i].replace_first(old_path, new_path);
@@ -1539,16 +1539,14 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 			}
 		}
 
-		
 		// Refresh the tree and file list.
-		
-        main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
+
+		main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
 		callable_mp(this, &FileSystemDock::_update_tree).call_deferred(get_uncollapsed_paths(), false, true);
 		callable_mp(this, &FileSystemDock::_update_file_list).call_deferred(true);
 
 		// Only treat as a changed dependency if it was successfully moved.
 
-		
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
 			p_file_renames[file_changed_paths[i]] = file_changed_paths[i].replace_first(old_path, new_path);
 			print_verbose("  Remap: " + file_changed_paths[i] + " -> " + p_file_renames[file_changed_paths[i]]);

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2051,6 +2051,11 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 
 			int current_tab = EditorSceneTabs::get_singleton()->get_current_tab();
 			_update_resource_paths_after_move(file_renames, uids);
+
+			const String resolved_main = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
+			if (main_scene_path != resolved_main) {
+				main_scene_path = resolved_main;
+			}
 			_update_dependencies_after_move(file_renames, file_owners);
 			_update_project_settings_after_move(file_renames, folder_renames);
 			_update_favorites_after_move(file_renames, folder_renames);
@@ -4073,11 +4078,10 @@ void FileSystemDock::_feature_profile_changed() {
 
 void FileSystemDock::_project_settings_changed() {
 	assigned_folder_colors = ProjectSettings::get_singleton()->get_setting("file_customization/folder_colors");
-	const String new_main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
-	if (new_main_scene_path != main_scene_path) {
-		main_scene_path = new_main_scene_path;
-		_update_tree(get_uncollapsed_paths(), false, false);
-		_update_file_list(true);
+	const String &current_main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
+	if (main_scene_path != current_main_scene_path) {
+		main_scene_path = current_main_scene_path;
+		update_all();
 	}
 }
 


### PR DESCRIPTION
-When renaming the main scene file from the FileSystem dock, the blue highlight does not move to the renamed file, even though when looking at "Project Settings" it updates accordingly. 

-This PR solves the issue by refreshing the cached 'main_scene_path' as well as rebuilds the file system tree and file list. 

-Fixes #115168 
