### PR TITLE
Fix create dialog recents

### DIFF
--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -499,7 +499,7 @@ void CreateDialog::_cleanup() {
 }
 
 void CreateDialog::_confirmed() {
-	String selected_item = get_selected_type();
+	String selected_item = get_selected_type_name();
 	if (selected_item.is_empty()) {
 		return;
 	}
@@ -632,6 +632,14 @@ String CreateDialog::get_selected_type() {
 	return String(selected->get_meta("_script_path", "")); // Script types
 }
 
+String CreateDialog::get_selected_type_name() {
+	TreeItem *selected = search_options->get_selected();
+	if (!selected) {
+		return String();
+	}
+	return selected->get_text(0).get_slicec(' ', 0);
+}
+
 void CreateDialog::set_base_type(const String &p_base) {
 	base_type = p_base;
 	is_base_type_node = ClassDB::is_parent_class(p_base, "Node");
@@ -669,11 +677,7 @@ Variant CreateDialog::instantiate_selected() {
 }
 
 void CreateDialog::_item_selected() {
-	String name = get_selected_type();
-	if (name.is_resource_file()) {
-		name = search_options->get_selected()->get_text(0).get_slicec(' ', 0);
-	}
-	select_type(name, false);
+	select_type(get_selected_type_name(), false);
 }
 
 void CreateDialog::_hide_requested() {
@@ -690,7 +694,7 @@ void CreateDialog::_favorite_toggled() {
 		return;
 	}
 
-	String name = item->get_text(0).get_slicec(' ', 0);
+	String name = get_selected_type_name();
 
 	if (favorite_list.has(name)) {
 		favorite_list.erase(name);

--- a/editor/gui/create_dialog.h
+++ b/editor/gui/create_dialog.h
@@ -117,6 +117,7 @@ protected:
 public:
 	Variant instantiate_selected();
 	String get_selected_type();
+	String get_selected_type_name();
 
 	void set_base_type(const String &p_base);
 	String get_base_type() const { return base_type; }


### PR DESCRIPTION
The `CreateDialog::get_selected_type()` method can return an empty string for custom types.

When `EditorNode::get_editor_data().get_custom_type_by_name()` returns `nullptr`, it relies on `_script_path`, which is only defined for global script classes. As a result, `_confirmed()` terminates prematurely (`selected_item.is_empty()`), therefore the recent history is never shown for custom types.

Returning the visible name of the selected item (`selected->get_text(0)`) corrects the problem and matches how Recent/Favorite items are already handled (based on name, not path).

See the before and after photos below:

---

![1](https://github.com/user-attachments/assets/1bdbf6d8-50af-44cb-bcf7-83a4d9809cd9)

![2](https://github.com/user-attachments/assets/d37afc8f-0ff3-4952-91c8-0513fae41fc4)

---
