### PR TITLE
Fix colors of code editor in modern theme

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -509,8 +509,8 @@ void EditorThemeManager::_populate_text_editor_styles(const Ref<EditorTheme> &p_
 			colors["text_editor/theme/highlighting/string_placeholder_color"] = p_config.dark_icon_and_font ? Color(1, 0.75, 0.4) : Color(0.93, 0.6, 0.33);
 
 			// Use the brightest background color on a light theme (which generally uses a negative contrast rate).
-			colors["text_editor/theme/highlighting/background_color"] = p_config.dark_icon_and_font ? p_config.dark_color_2 : p_config.dark_color_3;
-			colors["text_editor/theme/highlighting/completion_background_color"] = p_config.dark_icon_and_font ? p_config.base_color : p_config.dark_color_2;
+			colors["text_editor/theme/highlighting/background_color"] = p_config.base_color.lerp(Color(0, 0, 0), p_config.contrast * (p_config.dark_icon_and_font ? 1.2 : 1.8)).clamp();
+			colors["text_editor/theme/highlighting/completion_background_color"] = p_config.base_color.lerp(Color(0, 0, 0), p_config.contrast * 0.3).clamp();
 			colors["text_editor/theme/highlighting/completion_selected_color"] = alpha1;
 			colors["text_editor/theme/highlighting/completion_existing_color"] = alpha2;
 			// Same opacity as the scroll grabber editor icon.


### PR DESCRIPTION
Fixes 2 issues with the code editor:

1. Fixes low contrast of the background (it became low because it was tied to `dark_color_2` and modern theme set it to a semi-transparent color for 2D rulers)

2. Fixes completion popups being semi-transparent and desaturated (caused by the same as above). Closes https://github.com/godotengine/godot/issues/113907

cc @YeldhamDev 

| Master | PR |
|--------|--------|
| ![3](https://github.com/user-attachments/assets/2c3a6e21-553b-4b75-9c68-36e4232d0f8c) | ![4](https://github.com/user-attachments/assets/095c8ac8-c835-4519-89c7-b2be44f557b7) | 
| ![1](https://github.com/user-attachments/assets/d8cde2f5-85dc-4354-b224-712893f4f8f1) | ![2](https://github.com/user-attachments/assets/c7309a29-ff69-4088-8637-80920a6e7244) |