### PR TITLE
Improve NavigationObstacle2D/3D class documentation

### DIFF
--- a/doc/classes/NavigationObstacle2D.xml
+++ b/doc/classes/NavigationObstacle2D.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="NavigationObstacle2D" inherits="Node2D" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		2D obstacle used to affect navigation mesh baking or constrain velocities of avoidance controlled agents.
+		2D obstacle used to affect navigation mesh baking or constrain velocities of avoidance-controlled agents.
 	</brief_description>
 	<description>
-		An obstacle needs a navigation map and outline [member vertices] defined to work correctly. The outlines can not cross or overlap.
-		Obstacles can be included in the navigation mesh baking process when [member affect_navigation_mesh] is enabled. They do not add walkable geometry, instead their role is to discard other source geometry inside the shape. This can be used to prevent navigation mesh from appearing in unwanted places. If [member carve_navigation_mesh] is enabled the baked shape will not be affected by offsets of the navigation mesh baking, e.g. the agent radius.
-		With [member avoidance_enabled] the obstacle can constrain the avoidance velocities of avoidance using agents. If the obstacle's vertices are wound in clockwise order, avoidance agents will be pushed in by the obstacle, otherwise, avoidance agents will be pushed out. Obstacles using vertices and avoidance can warp to a new position but should not be moved every single frame as each change requires a rebuild of the avoidance map.
+		An obstacle needs a navigation map and outline [member vertices] defined to work correctly. The outlines cannot cross or overlap.
+		Obstacles can be included in the navigation mesh baking process when [member affect_navigation_mesh] is enabled. They do not add walkable geometry; instead, their role is to discard other source geometry inside the shape. This can be used to prevent navigation mesh from appearing in unwanted places. If [member carve_navigation_mesh] is enabled, the baked shape will not be affected by offsets of the navigation mesh baking, e.g. the agent radius.
+		With [member avoidance_enabled], the obstacle can constrain the avoidance velocities of avoidance using agents. If the obstacle's vertices are wound in clockwise order, avoidance agents will be pushed in by the obstacle, otherwise, avoidance agents will be pushed out. Obstacles using vertices and avoidance can warp to a new position, but should not be moved every single frame as each change requires a rebuild of the avoidance map.
 	</description>
 	<tutorials>
 		<link title="Using NavigationObstacles">$DOCS_URL/tutorials/navigation/navigation_using_navigationobstacles.html</link>
@@ -22,7 +22,7 @@
 		<method name="get_navigation_map" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the [RID] of the navigation map for this NavigationObstacle node. This function returns always the map set on the NavigationObstacle node and not the map of the abstract obstacle on the NavigationServer. If the obstacle map is changed directly with the NavigationServer API the NavigationObstacle node will not be aware of the map change. Use [method set_navigation_map] to change the navigation map for the NavigationObstacle and also update the obstacle on the NavigationServer.
+				Returns the [RID] of the navigation map for this NavigationObstacle node. This function returns always the map set on the NavigationObstacle node, and not the map of the abstract obstacle on the NavigationServer. If the obstacle map is changed directly with the NavigationServer API, the NavigationObstacle node will not be aware of the map change. Use [method set_navigation_map] to change the navigation map for the NavigationObstacle and also update the obstacle on the NavigationServer.
 			</description>
 		</method>
 		<method name="get_rid" qualifiers="const">
@@ -49,27 +49,28 @@
 	</methods>
 	<members>
 		<member name="affect_navigation_mesh" type="bool" setter="set_affect_navigation_mesh" getter="get_affect_navigation_mesh" default="false">
-			If enabled and parsed in a navigation mesh baking process the obstacle will discard source geometry inside its [member vertices] defined shape.
+			If enabled and parsed in a navigation mesh baking process, the obstacle will discard source geometry inside its [member vertices] defined shape.
 		</member>
 		<member name="avoidance_enabled" type="bool" setter="set_avoidance_enabled" getter="get_avoidance_enabled" default="true">
-			If [code]true[/code] the obstacle affects avoidance using agents.
+			If [code]true[/code], the obstacle affects agents that are using avoidance.
 		</member>
 		<member name="avoidance_layers" type="int" setter="set_avoidance_layers" getter="get_avoidance_layers" default="1">
 			A bitfield determining the avoidance layers for this obstacle. Agents with a matching bit on the their avoidance mask will avoid this obstacle.
 		</member>
 		<member name="carve_navigation_mesh" type="bool" setter="set_carve_navigation_mesh" getter="get_carve_navigation_mesh" default="false">
-			If enabled the obstacle vertices will carve into the baked navigation mesh with the shape unaffected by additional offsets (e.g. agent radius).
+			If enabled, the obstacle vertices will carve into the baked navigation mesh with the shape unaffected by additional offsets (e.g. agent radius).
 			It will still be affected by further postprocessing of the baking process, like edge and polygon simplification.
 			Requires [member affect_navigation_mesh] to be enabled.
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.0">
 			Sets the avoidance radius for the obstacle.
+			[b]Note:[/b] This radius does not affect navigation pathfinding or navigation mesh baking.
 		</member>
 		<member name="velocity" type="Vector2" setter="set_velocity" getter="get_velocity" default="Vector2(0, 0)">
-			Sets the wanted velocity for the obstacle so other agent's can better predict the obstacle if it is moved with a velocity regularly (every frame) instead of warped to a new position. Does only affect avoidance for the obstacles [member radius]. Does nothing for the obstacles static vertices.
+			Sets the wanted velocity for the obstacle, so that other agents can better predict the obstacle if it is moved with a velocity regularly (every frame) instead of warped to a new position. Only affects avoidance for the obstacle's [member radius]. Does nothing for the obstacle's static vertices.
 		</member>
 		<member name="vertices" type="PackedVector2Array" setter="set_vertices" getter="get_vertices" default="PackedVector2Array()">
-			The outline vertices of the obstacle. If the vertices are winded in clockwise order agents will be pushed in by the obstacle, else they will be pushed out. Outlines can not be crossed or overlap. Should the vertices using obstacle be warped to a new position agent's can not predict this movement and may get trapped inside the obstacle.
+			The outline vertices of the obstacle. If the vertices are winded in clockwise order, agents will be pushed in by the obstacle, else they will be pushed out. Outlines can not be crossed or overlap. Should the vertices using obstacle be warped to a new position agent's can not predict this movement and may get trapped inside the obstacle.
 		</member>
 	</members>
 </class>

--- a/doc/classes/NavigationObstacle3D.xml
+++ b/doc/classes/NavigationObstacle3D.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="NavigationObstacle3D" inherits="Node3D" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		3D obstacle used to affect navigation mesh baking or constrain velocities of avoidance controlled agents.
+		3D obstacle used to affect navigation mesh baking or constrain velocities of avoidance-controlled agents.
 	</brief_description>
 	<description>
-		An obstacle needs a navigation map and outline [member vertices] defined to work correctly. The outlines can not cross or overlap and are restricted to a plane projection. This means the y-axis of the vertices is ignored, instead the obstacle's global y-axis position is used for placement. The projected shape is extruded by the obstacles height along the y-axis.
-		Obstacles can be included in the navigation mesh baking process when [member affect_navigation_mesh] is enabled. They do not add walkable geometry, instead their role is to discard other source geometry inside the shape. This can be used to prevent navigation mesh from appearing in unwanted places, e.g. inside "solid" geometry or on top of it. If [member carve_navigation_mesh] is enabled the baked shape will not be affected by offsets of the navigation mesh baking, e.g. the agent radius.
+		An obstacle needs a navigation map and outline [member vertices] defined to work correctly. The outlines cannot cross or overlap and are restricted to a plane projection. This means the Y axis of the vertices is ignored, instead the obstacle's global Y-axis position is used for placement. The projected shape is extruded by the obstacle's height along the Y-axis.
+		Obstacles can be included in the navigation mesh baking process when [member affect_navigation_mesh] is enabled. They do not add walkable geometry; instead, their role is to discard other source geometry inside the shape. This can be used to prevent navigation mesh from appearing in unwanted places, e.g. inside "solid" geometry or on top of it. If [member carve_navigation_mesh] is enabled, the baked shape will not be affected by offsets of the navigation mesh baking, e.g. the agent radius.
 		With [member avoidance_enabled] the obstacle can constrain the avoidance velocities of avoidance using agents. If the obstacle's vertices are wound in clockwise order, avoidance agents will be pushed in by the obstacle, otherwise, avoidance agents will be pushed out. Obstacles using vertices and avoidance can warp to a new position but should not be moved every single frame as each change requires a rebuild of the avoidance map.
 	</description>
 	<tutorials>
@@ -22,7 +22,7 @@
 		<method name="get_navigation_map" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the [RID] of the navigation map for this NavigationObstacle node. This function returns always the map set on the NavigationObstacle node and not the map of the abstract obstacle on the NavigationServer. If the obstacle map is changed directly with the NavigationServer API the NavigationObstacle node will not be aware of the map change. Use [method set_navigation_map] to change the navigation map for the NavigationObstacle and also update the obstacle on the NavigationServer.
+				Returns the [RID] of the navigation map for this NavigationObstacle node. This function returns always the map set on the NavigationObstacle node, and not the map of the abstract obstacle on the NavigationServer. If the obstacle map is changed directly with the NavigationServer API, the NavigationObstacle node will not be aware of the map change. Use [method set_navigation_map] to change the navigation map for the NavigationObstacle and also update the obstacle on the NavigationServer.
 			</description>
 		</method>
 		<method name="get_rid" qualifiers="const">
@@ -49,10 +49,10 @@
 	</methods>
 	<members>
 		<member name="affect_navigation_mesh" type="bool" setter="set_affect_navigation_mesh" getter="get_affect_navigation_mesh" default="false">
-			If enabled and parsed in a navigation mesh baking process the obstacle will discard source geometry inside its [member vertices] and [member height] defined shape.
+			If enabled and parsed in a navigation mesh baking process, the obstacle will discard source geometry inside its [member vertices] and [member height] defined shape.
 		</member>
 		<member name="avoidance_enabled" type="bool" setter="set_avoidance_enabled" getter="get_avoidance_enabled" default="true">
-			If [code]true[/code] the obstacle affects avoidance using agents.
+			If [code]true[/code], the obstacle affects using agents that are using avoidance.
 		</member>
 		<member name="avoidance_layers" type="int" setter="set_avoidance_layers" getter="get_avoidance_layers" default="1">
 			A bitfield determining the avoidance layers for this obstacle. Agents with a matching bit on the their avoidance mask will avoid this obstacle.
@@ -63,20 +63,21 @@
 			Requires [member affect_navigation_mesh] to be enabled.
 		</member>
 		<member name="height" type="float" setter="set_height" getter="get_height" default="1.0">
-			Sets the obstacle height used in 2D avoidance. 2D avoidance using agent's ignore obstacles that are below or above them.
+			Sets the obstacle height used in 2D avoidance. 2D avoidance using agents ignore obstacles that are below or above them.
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.0">
 			Sets the avoidance radius for the obstacle.
+			[b]Note:[/b] This radius does not affect navigation pathfinding or navigation mesh baking.
 		</member>
 		<member name="use_3d_avoidance" type="bool" setter="set_use_3d_avoidance" getter="get_use_3d_avoidance" default="false">
-			If [code]true[/code] the obstacle affects 3D avoidance using agent's with obstacle [member radius].
-			If [code]false[/code] the obstacle affects 2D avoidance using agent's with both obstacle [member vertices] as well as obstacle [member radius].
+			If [code]true[/code], the obstacle affects 3D avoidance using agents with obstacle [member radius].
+			If [code]false[/code], the obstacle affects 2D avoidance using agents with both obstacle [member vertices] as well as obstacle [member radius].
 		</member>
 		<member name="velocity" type="Vector3" setter="set_velocity" getter="get_velocity" default="Vector3(0, 0, 0)">
-			Sets the wanted velocity for the obstacle so other agent's can better predict the obstacle if it is moved with a velocity regularly (every frame) instead of warped to a new position. Does only affect avoidance for the obstacles [member radius]. Does nothing for the obstacles static vertices.
+			Sets the wanted velocity for the obstacle, so that other agents can better predict the obstacle if it is moved with a velocity regularly (every frame) instead of warped to a new position. Only affects avoidance for the obstacle's [member radius]. Does nothing for the obstacle's static vertices.
 		</member>
 		<member name="vertices" type="PackedVector3Array" setter="set_vertices" getter="get_vertices" default="PackedVector3Array()">
-			The outline vertices of the obstacle. If the vertices are winded in clockwise order agents will be pushed in by the obstacle, else they will be pushed out. Outlines can not be crossed or overlap. Should the vertices using obstacle be warped to a new position agent's can not predict this movement and may get trapped inside the obstacle.
+			The outline vertices of the obstacle. If the vertices are winded in clockwise order, agents will be pushed in by the obstacle, else they will be pushed out. Outlines can not be crossed or overlap. Should the vertices using obstacle be warped to a new position, agents cannot predict this movement and may get trapped inside the obstacle.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
- Clarify the fact `radius` does not affect navigation pathfinding or navigation mesh baking.

___

- See https://github.com/godotengine/godot-docs-user-notes/discussions/130#discussioncomment-15576071.