### PR TITLE
Fix typos in WebXRInterface documentation

### DIFF
--- a/modules/webxr/doc_classes/WebXRInterface.xml
+++ b/modules/webxr/doc_classes/WebXRInterface.xml
@@ -160,10 +160,10 @@
 		<member name="enabled_features" type="String" setter="" getter="get_enabled_features">
 			A comma-separated list of features that were successfully enabled by [method XRInterface.initialize] when setting up the WebXR session.
 			This may include features requested by setting [member required_features] and [member optional_features], and will only be available after [signal session_started] has been emitted.
-			[b]Note:[/b] This may not be support by all web browsers, in which case it will be an empty string.
+			[b]Note:[/b] This may not be supported by all web browsers, in which case it will be an empty string.
 		</member>
 		<member name="optional_features" type="String" setter="set_optional_features" getter="get_optional_features">
-			A comma-seperated list of optional features used by [method XRInterface.initialize] when setting up the WebXR session.
+			A comma-separated list of optional features used by [method XRInterface.initialize] when setting up the WebXR session.
 			If a user's browser or device doesn't support one of the given features, initialization will continue, but you won't be able to use the requested feature.
 			This doesn't have any effect on the interface when already initialized.
 			See the MDN documentation on [url=https://developer.mozilla.org/en-US/docs/Web/API/XRSystem/requestSession#session_features]WebXR's session features[/url] for a list of possible values.
@@ -173,13 +173,13 @@
 			Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpaceType]WebXR's XRReferenceSpaceType[/url]. If you want to use a particular reference space type, it must be listed in either [member required_features] or [member optional_features].
 		</member>
 		<member name="requested_reference_space_types" type="String" setter="set_requested_reference_space_types" getter="get_requested_reference_space_types">
-			A comma-seperated list of reference space types used by [method XRInterface.initialize] when setting up the WebXR session.
+			A comma-separated list of reference space types used by [method XRInterface.initialize] when setting up the WebXR session.
 			The reference space types are requested in order, and the first one supported by the user's device or browser will be used. The [member reference_space_type] property contains the reference space type that was ultimately selected.
 			This doesn't have any effect on the interface when already initialized.
 			Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpaceType]WebXR's XRReferenceSpaceType[/url]. If you want to use a particular reference space type, it must be listed in either [member required_features] or [member optional_features].
 		</member>
 		<member name="required_features" type="String" setter="set_required_features" getter="get_required_features">
-			A comma-seperated list of required features used by [method XRInterface.initialize] when setting up the WebXR session.
+			A comma-separated list of required features used by [method XRInterface.initialize] when setting up the WebXR session.
 			If a user's browser or device doesn't support one of the given features, initialization will fail and [signal session_failed] will be emitted.
 			This doesn't have any effect on the interface when already initialized.
 			See the MDN documentation on [url=https://developer.mozilla.org/en-US/docs/Web/API/XRSystem/requestSession#session_features]WebXR's session features[/url] for a list of possible values.


### PR DESCRIPTION
- Fix 'comma-seperated' -> 'comma-separated' (3 instances)
- Fix 'may not be support' -> 'may not be supported'

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
