### PR TITLE
Define own theme items for `CodeEdit`, `FileDialog` and `RichTextLabel`

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -710,6 +710,9 @@
 		<theme_item name="folded_code_region_color" data_type="color" type="Color" default="Color(0.68, 0.46, 0.77, 0.2)">
 			[Color] of background line highlight for folded code region.
 		</theme_item>
+		<theme_item name="hint_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
+			Sets font [Color] of the code hint popup.
+		</theme_item>
 		<theme_item name="line_length_guideline_color" data_type="color" type="Color" default="Color(0.3, 0.5, 0.8, 0.1)">
 			[Color] of the main line length guideline, secondary guidelines will have 50% alpha applied.
 		</theme_item>
@@ -724,6 +727,9 @@
 		</theme_item>
 		<theme_item name="completion_scroll_width" data_type="constant" type="int" default="6">
 			Width of the scrollbar in the code completion popup.
+		</theme_item>
+		<theme_item name="h_separation" data_type="constant" type="int" default="4">
+			The horizontal spacing between icons and option items in the code completion popup.
 		</theme_item>
 		<theme_item name="bookmark" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] to draw in the bookmark gutter for bookmarked lines.
@@ -754,6 +760,9 @@
 		</theme_item>
 		<theme_item name="completion" data_type="style" type="StyleBox">
 			[StyleBox] for the code completion popup.
+		</theme_item>
+		<theme_item name="hint" data_type="style" type="StyleBox">
+			[StyleBox] for the code hint popup.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -387,6 +387,18 @@
 		<theme_item name="folder_icon_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The color modulation applied to the folder icon.
 		</theme_item>
+		<theme_item name="icon_focus_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			Icon modulate [Color] used when the icon buttons are focused.
+		</theme_item>
+		<theme_item name="icon_hover_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			Icon modulate [Color] used when the icon buttons are being hovered.
+		</theme_item>
+		<theme_item name="icon_normal_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			Default icon modulate [Color] of the icon buttons.
+		</theme_item>
+		<theme_item name="icon_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			Icon modulate [Color] used when the icon buttons are being pressed
+		</theme_item>
 		<theme_item name="thumbnail_size" data_type="constant" type="int" default="64">
 			The size of thumbnail icons when [constant DISPLAY_THUMBNAILS] is enabled.
 		</theme_item>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -1000,6 +1000,12 @@
 		<theme_item name="horizontal_rule" data_type="icon" type="Texture2D">
 			The horizontal rule texture.
 		</theme_item>
+		<theme_item name="background" data_type="style" type="StyleBox">
+			The background [StyleBox] used for the loading progress bar.
+		</theme_item>
+		<theme_item name="fill" data_type="style" type="StyleBox">
+			The [StyleBox] used for the progress of the loading progress bar.
+		</theme_item>
 		<theme_item name="focus" data_type="style" type="StyleBox">
 			The background used when the [RichTextLabel] is focused. The [theme_item focus] [StyleBox] is displayed [i]over[/i] the base [StyleBox], so a partially transparent [StyleBox] should be used to ensure the base [StyleBox] remains visible. A [StyleBox] that represents an outline or an underline works well for this purpose. To disable the focus visual effect, assign a [StyleBoxEmpty] resource. Note that disabling the focus visual effect will harm keyboard/controller navigation usability, so this is not recommended for accessibility reasons.
 		</theme_item>

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -2007,56 +2007,56 @@ void AnimationNodeStateMachineEditor::_bind_methods() {
 	ClassDB::bind_method("_update_graph", &AnimationNodeStateMachineEditor::_update_graph);
 	ClassDB::bind_method("_select_transition", &AnimationNodeStateMachineEditor::_select_transition);
 
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, panel_style, "panel", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, error_panel_style, "error_panel", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, error_color, "error_color", "GraphStateMachine");
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, panel_style);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, error_panel_style);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, error_color);
 
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, tool_icon_select, "ToolSelect", "EditorIcons");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, tool_icon_create, "ToolAddNode", "EditorIcons");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, tool_icon_connect, "ToolConnect", "EditorIcons");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, tool_icon_erase, "Remove", "EditorIcons");
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, tool_icon_select);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, tool_icon_create);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, tool_icon_connect);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, tool_icon_erase);
 
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icon_immediate, "TransitionImmediate", "EditorIcons");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icon_sync, "TransitionSync", "EditorIcons");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icon_end, "TransitionEnd", "EditorIcons");
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icon_immediate);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icon_sync);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icon_end);
 
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, play_icon_start, "Play", "EditorIcons");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, play_icon_travel, "PlayTravel", "EditorIcons");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, play_icon_auto, "AutoPlay", "EditorIcons");
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, play_icon_start);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, play_icon_travel);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, play_icon_auto);
 
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, animation_icon, "Animation", "EditorIcons");
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, animation_icon);
 
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, node_frame, "node_frame", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, node_frame_selected, "node_frame_selected", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, node_frame_playing, "node_frame_playing", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, node_frame_start, "node_frame_start", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, node_frame_end, "node_frame_end", "GraphStateMachine");
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, node_frame);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, node_frame_selected);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, node_frame_playing);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, node_frame_start);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, node_frame_end);
 
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_FONT, AnimationNodeStateMachineEditor, node_title_font, "node_title_font", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_FONT_SIZE, AnimationNodeStateMachineEditor, node_title_font_size, "node_title_font_size", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, node_title_font_color, "node_title_font_color", "GraphStateMachine");
+	BIND_THEME_ITEM(Theme::DATA_TYPE_FONT, AnimationNodeStateMachineEditor, node_title_font);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_FONT_SIZE, AnimationNodeStateMachineEditor, node_title_font_size);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, node_title_font_color);
 
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, play_node, "Play", "EditorIcons");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, edit_node, "Edit", "EditorIcons");
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, play_node);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, edit_node);
 
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, transition_color, "transition_color", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, transition_disabled_color, "transition_disabled_color", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, transition_icon_color, "transition_icon_color", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, transition_icon_disabled_color, "transition_icon_disabled_color", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, highlight_color, "highlight_color", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, highlight_disabled_color, "highlight_disabled_color", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, focus_color, "focus_color", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, guideline_color, "guideline_color", "GraphStateMachine");
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, transition_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, transition_disabled_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, transition_icon_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, transition_icon_disabled_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, highlight_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, highlight_disabled_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, focus_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, guideline_color);
 
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icons[0], "TransitionImmediateBig", "EditorIcons");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icons[1], "TransitionSyncBig", "EditorIcons");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icons[2], "TransitionEndBig", "EditorIcons");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icons[3], "TransitionImmediateAutoBig", "EditorIcons");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icons[4], "TransitionSyncAutoBig", "EditorIcons");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icons[5], "TransitionEndAutoBig", "EditorIcons");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icons[0], "transition_immediate_big");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icons[1], "transition_sync_big");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icons[2], "transition_end_big");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icons[3], "transition_immediate_auto_big");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icons[4], "transition_sync_auto_big");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, transition_icons[5], "transition_end_auto_big");
 
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, playback_color, "playback_color", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, playback_background_color, "playback_background_color", "GraphStateMachine");
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, playback_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, playback_background_color);
 }
 
 AnimationNodeStateMachineEditor *AnimationNodeStateMachineEditor::singleton = nullptr;

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -2439,9 +2439,24 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 
 		// StateMachine graph.
 		{
-			p_theme->set_stylebox(SceneStringName(panel), "GraphStateMachine", p_config.tree_panel_style);
-			p_theme->set_stylebox("error_panel", "GraphStateMachine", p_config.tree_panel_style);
-			p_theme->set_color("error_color", "GraphStateMachine", p_config.error_color);
+			p_theme->set_stylebox("panel_style", "AnimationNodeStateMachineEditor", p_config.tree_panel_style);
+			p_theme->set_stylebox("error_panel", "AnimationNodeStateMachineEditor", p_config.tree_panel_style);
+			p_theme->set_color("error_color", "AnimationNodeStateMachineEditor", p_config.error_color);
+
+			p_theme->set_icon("tool_icon_select", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("ToolSelect"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("tool_icon_create", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("ToolAddNode"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("tool_icon_connect", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("ToolConnect"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("tool_icon_erase", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("Remove"), EditorStringName(EditorIcons)));
+
+			p_theme->set_icon("transition_icon_immediate", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionImmediate"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("transition_icon_sync", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionSync"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("transition_icon_end", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionEnd"), EditorStringName(EditorIcons)));
+
+			p_theme->set_icon("play_icon_start", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("Play"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("play_icon_travel", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("PlayTravel"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("play_icon_auto", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("AutoPlay"), EditorStringName(EditorIcons)));
+
+			p_theme->set_icon("animation_icon", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("Animation"), EditorStringName(EditorIcons)));
 
 			const int sm_margin_side = 10 * EDSCALE;
 			const int sm_margin_bottom = 2;
@@ -2462,35 +2477,42 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			sm_node_playing_style->set_shadow_color(p_config.warning_color * Color(1, 1, 1, 0.2));
 			sm_node_playing_style->set_draw_center(false);
 
-			p_theme->set_stylebox("node_frame", "GraphStateMachine", sm_node_style);
-			p_theme->set_stylebox("node_frame_selected", "GraphStateMachine", sm_node_selected_style);
-			p_theme->set_stylebox("node_frame_playing", "GraphStateMachine", sm_node_playing_style);
+			p_theme->set_stylebox("node_frame", "AnimationNodeStateMachineEditor", sm_node_style);
+			p_theme->set_stylebox("node_frame_selected", "AnimationNodeStateMachineEditor", sm_node_selected_style);
+			p_theme->set_stylebox("node_frame_playing", "AnimationNodeStateMachineEditor", sm_node_playing_style);
 
 			Ref<StyleBoxFlat> sm_node_start_style = sm_node_style->duplicate();
 			sm_node_start_style->set_border_width_all(1 * EDSCALE);
 			sm_node_start_style->set_border_color(p_config.success_color.lightened(0.24));
-			p_theme->set_stylebox("node_frame_start", "GraphStateMachine", sm_node_start_style);
+			p_theme->set_stylebox("node_frame_start", "AnimationNodeStateMachineEditor", sm_node_start_style);
 
 			Ref<StyleBoxFlat> sm_node_end_style = sm_node_style->duplicate();
 			sm_node_end_style->set_border_width_all(1 * EDSCALE);
 			sm_node_end_style->set_border_color(p_config.error_color);
-			p_theme->set_stylebox("node_frame_end", "GraphStateMachine", sm_node_end_style);
+			p_theme->set_stylebox("node_frame_end", "AnimationNodeStateMachineEditor", sm_node_end_style);
 
-			p_theme->set_font("node_title_font", "GraphStateMachine", p_theme->get_font(SceneStringName(font), SNAME("Label")));
-			p_theme->set_font_size("node_title_font_size", "GraphStateMachine", p_theme->get_font_size(SceneStringName(font_size), SNAME("Label")));
-			p_theme->set_color("node_title_font_color", "GraphStateMachine", p_config.font_color);
+			p_theme->set_font("node_title_font", "AnimationNodeStateMachineEditor", p_theme->get_font(SceneStringName(font), SNAME("Label")));
+			p_theme->set_font_size("node_title_font_size", "AnimationNodeStateMachineEditor", p_theme->get_font_size(SceneStringName(font_size), SNAME("Label")));
+			p_theme->set_color("node_title_font_color", "AnimationNodeStateMachineEditor", p_config.font_color);
 
-			p_theme->set_color("transition_color", "GraphStateMachine", p_config.font_color);
-			p_theme->set_color("transition_disabled_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.2));
-			p_theme->set_color("transition_icon_color", "GraphStateMachine", Color(1, 1, 1));
-			p_theme->set_color("transition_icon_disabled_color", "GraphStateMachine", Color(1, 1, 1, 0.2));
-			p_theme->set_color("highlight_color", "GraphStateMachine", p_config.accent_color);
-			p_theme->set_color("highlight_disabled_color", "GraphStateMachine", p_config.accent_color * Color(1, 1, 1, 0.6));
-			p_theme->set_color("focus_color", "GraphStateMachine", p_config.accent_color);
-			p_theme->set_color("guideline_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.3));
+			p_theme->set_color("transition_color", "AnimationNodeStateMachineEditor", p_config.font_color);
+			p_theme->set_color("transition_disabled_color", "AnimationNodeStateMachineEditor", p_config.font_color * Color(1, 1, 1, 0.2));
+			p_theme->set_color("transition_icon_color", "AnimationNodeStateMachineEditor", Color(1, 1, 1));
+			p_theme->set_color("transition_icon_disabled_color", "AnimationNodeStateMachineEditor", Color(1, 1, 1, 0.2));
+			p_theme->set_color("highlight_color", "AnimationNodeStateMachineEditor", p_config.accent_color);
+			p_theme->set_color("highlight_disabled_color", "AnimationNodeStateMachineEditor", p_config.accent_color * Color(1, 1, 1, 0.6));
+			p_theme->set_color("focus_color", "AnimationNodeStateMachineEditor", p_config.accent_color);
+			p_theme->set_color("guideline_color", "AnimationNodeStateMachineEditor", p_config.font_color * Color(1, 1, 1, 0.3));
 
-			p_theme->set_color("playback_color", "GraphStateMachine", p_config.font_color);
-			p_theme->set_color("playback_background_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.3));
+			p_theme->set_icon("transition_immediate_big", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionImmediateBig"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("transition_sync_big", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionSyncBig"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("transition_end_big", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionEndBig"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("transition_immediate_auto_big", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionImmediateAutoBig"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("transition_sync_auto_big", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionSyncAutoBig"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("transition_end_auto_big", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionEndAutoBig"), EditorStringName(EditorIcons)));
+
+			p_theme->set_color("playback_color", "AnimationNodeStateMachineEditor", p_config.font_color);
+			p_theme->set_color("playback_background_color", "AnimationNodeStateMachineEditor", p_config.font_color * Color(1, 1, 1, 0.3));
 		}
 	}
 

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -2770,9 +2770,24 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// StateMachine graph.
 		{
-			p_theme->set_stylebox(SceneStringName(panel), "GraphStateMachine", p_config.tree_panel_style);
-			p_theme->set_stylebox("error_panel", "GraphStateMachine", p_config.tree_panel_style);
-			p_theme->set_color("error_color", "GraphStateMachine", p_config.error_color);
+			p_theme->set_stylebox("panel_style", "AnimationNodeStateMachineEditor", p_config.tree_panel_style);
+			p_theme->set_stylebox("error_panel", "AnimationNodeStateMachineEditor", p_config.tree_panel_style);
+			p_theme->set_color("error_color", "AnimationNodeStateMachineEditor", p_config.error_color);
+
+			p_theme->set_icon("tool_icon_select", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("ToolSelect"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("tool_icon_create", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("ToolAddNode"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("tool_icon_connect", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("ToolConnect"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("tool_icon_erase", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("Remove"), EditorStringName(EditorIcons)));
+
+			p_theme->set_icon("transition_icon_immediate", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionImmediate"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("transition_icon_sync", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionSync"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("transition_icon_end", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionEnd"), EditorStringName(EditorIcons)));
+
+			p_theme->set_icon("play_icon_start", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("Play"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("play_icon_travel", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("PlayTravel"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("play_icon_auto", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("AutoPlay"), EditorStringName(EditorIcons)));
+
+			p_theme->set_icon("animation_icon", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("Animation"), EditorStringName(EditorIcons)));
 
 			const int sm_margin_side = 10 * EDSCALE;
 			const int sm_margin_bottom = 2;
@@ -2793,35 +2808,45 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			sm_node_playing_style->set_shadow_color(p_config.warning_color * Color(1, 1, 1, 0.2));
 			sm_node_playing_style->set_draw_center(false);
 
-			p_theme->set_stylebox("node_frame", "GraphStateMachine", sm_node_style);
-			p_theme->set_stylebox("node_frame_selected", "GraphStateMachine", sm_node_selected_style);
-			p_theme->set_stylebox("node_frame_playing", "GraphStateMachine", sm_node_playing_style);
+			p_theme->set_stylebox("node_frame", "AnimationNodeStateMachineEditor", sm_node_style);
+			p_theme->set_stylebox("node_frame_selected", "AnimationNodeStateMachineEditor", sm_node_selected_style);
+			p_theme->set_stylebox("node_frame_playing", "AnimationNodeStateMachineEditor", sm_node_playing_style);
 
 			Ref<StyleBoxFlat> sm_node_start_style = sm_node_style->duplicate();
 			sm_node_start_style->set_border_width_all(1 * EDSCALE);
 			sm_node_start_style->set_border_color(p_config.success_color.lightened(0.24));
-			p_theme->set_stylebox("node_frame_start", "GraphStateMachine", sm_node_start_style);
+			p_theme->set_stylebox("node_frame_start", "AnimationNodeStateMachineEditor", sm_node_start_style);
 
 			Ref<StyleBoxFlat> sm_node_end_style = sm_node_style->duplicate();
 			sm_node_end_style->set_border_width_all(1 * EDSCALE);
 			sm_node_end_style->set_border_color(p_config.error_color);
-			p_theme->set_stylebox("node_frame_end", "GraphStateMachine", sm_node_end_style);
+			p_theme->set_stylebox("node_frame_end", "AnimationNodeStateMachineEditor", sm_node_end_style);
 
-			p_theme->set_font("node_title_font", "GraphStateMachine", p_theme->get_font(SceneStringName(font), SNAME("Label")));
-			p_theme->set_font_size("node_title_font_size", "GraphStateMachine", p_theme->get_font_size(SceneStringName(font_size), SNAME("Label")));
-			p_theme->set_color("node_title_font_color", "GraphStateMachine", p_config.font_color);
+			p_theme->set_font("node_title_font", "AnimationNodeStateMachineEditor", p_theme->get_font(SceneStringName(font), SNAME("Label")));
+			p_theme->set_font_size("node_title_font_size", "AnimationNodeStateMachineEditor", p_theme->get_font_size(SceneStringName(font_size), SNAME("Label")));
+			p_theme->set_color("node_title_font_color", "AnimationNodeStateMachineEditor", p_config.font_color);
 
-			p_theme->set_color("transition_color", "GraphStateMachine", p_config.font_color);
-			p_theme->set_color("transition_disabled_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.2));
-			p_theme->set_color("transition_icon_color", "GraphStateMachine", Color(1, 1, 1));
-			p_theme->set_color("transition_icon_disabled_color", "GraphStateMachine", Color(1, 1, 1, 0.2));
-			p_theme->set_color("highlight_color", "GraphStateMachine", p_config.accent_color);
-			p_theme->set_color("highlight_disabled_color", "GraphStateMachine", p_config.accent_color * Color(1, 1, 1, 0.6));
-			p_theme->set_color("focus_color", "GraphStateMachine", p_config.accent_color * Color(1, 1, 1, 0.8));
-			p_theme->set_color("guideline_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.3));
+			p_theme->set_icon("play_node", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("Play"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("edit_node", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("Edit"), EditorStringName(EditorIcons)));
 
-			p_theme->set_color("playback_color", "GraphStateMachine", p_config.font_color);
-			p_theme->set_color("playback_background_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.3));
+			p_theme->set_color("transition_color", "AnimationNodeStateMachineEditor", p_config.font_color);
+			p_theme->set_color("transition_disabled_color", "AnimationNodeStateMachineEditor", p_config.font_color * Color(1, 1, 1, 0.2));
+			p_theme->set_color("transition_icon_color", "AnimationNodeStateMachineEditor", Color(1, 1, 1));
+			p_theme->set_color("transition_icon_disabled_color", "AnimationNodeStateMachineEditor", Color(1, 1, 1, 0.2));
+			p_theme->set_color("highlight_color", "AnimationNodeStateMachineEditor", p_config.accent_color);
+			p_theme->set_color("highlight_disabled_color", "AnimationNodeStateMachineEditor", p_config.accent_color * Color(1, 1, 1, 0.6));
+			p_theme->set_color("focus_color", "AnimationNodeStateMachineEditor", p_config.accent_color * Color(1, 1, 1, 0.8));
+			p_theme->set_color("guideline_color", "AnimationNodeStateMachineEditor", p_config.font_color * Color(1, 1, 1, 0.3));
+
+			p_theme->set_icon("transition_immediate_big", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionImmediateBig"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("transition_sync_big", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionSyncBig"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("transition_end_big", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionEndBig"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("transition_immediate_auto_big", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionImmediateAutoBig"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("transition_sync_auto_big", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionSyncAutoBig"), EditorStringName(EditorIcons)));
+			p_theme->set_icon("transition_end_auto_big", "AnimationNodeStateMachineEditor", p_theme->get_icon(SNAME("TransitionEndAutoBig"), EditorStringName(EditorIcons)));
+
+			p_theme->set_color("playback_color", "AnimationNodeStateMachineEditor", p_config.font_color);
+			p_theme->set_color("playback_background_color", "AnimationNodeStateMachineEditor", p_config.font_color * Color(1, 1, 1, 0.3));
 		}
 	}
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -3050,7 +3050,7 @@ void CodeEdit::_bind_methods() {
 
 	/* Code Completion */
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, CodeEdit, code_completion_style, "completion");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_CONSTANT, CodeEdit, code_completion_icon_separation, "h_separation", "ItemList");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_CONSTANT, CodeEdit, code_completion_icon_separation, "h_separation");
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_CONSTANT, CodeEdit, code_completion_max_width, "completion_max_width");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_CONSTANT, CodeEdit, code_completion_max_lines, "completion_lines");
@@ -3062,8 +3062,8 @@ void CodeEdit::_bind_methods() {
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_COLOR, CodeEdit, code_completion_existing_color, "completion_existing_color");
 
 	/* Code hint */
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, CodeEdit, code_hint_style, "panel", "TooltipPanel");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, CodeEdit, code_hint_color, "font_color", "TooltipLabel");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, CodeEdit, code_hint_style, "hint");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_COLOR, CodeEdit, code_hint_color, "hint_color");
 
 	/* Line length guideline */
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, CodeEdit, line_length_guideline_color);

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -2187,11 +2187,10 @@ void FileDialog::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, FileDialog, file_icon_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, FileDialog, file_disabled_color);
 
-	// TODO: Define own colors?
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, FileDialog, icon_normal_color, "font_color", "Button");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, FileDialog, icon_hover_color, "font_hover_color", "Button");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, FileDialog, icon_focus_color, "font_focus_color", "Button");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, FileDialog, icon_pressed_color, "font_pressed_color", "Button");
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, FileDialog, icon_normal_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, FileDialog, icon_hover_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, FileDialog, icon_focus_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, FileDialog, icon_pressed_color);
 
 	Option defaults;
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -7810,8 +7810,8 @@ void RichTextLabel::_bind_methods() {
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, RichTextLabel, normal_style, "normal");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, RichTextLabel, focus_style, "focus");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, RichTextLabel, progress_bg_style, "background", "ProgressBar");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, RichTextLabel, progress_fg_style, "fill", "ProgressBar");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, RichTextLabel, progress_bg_style, "background");
+	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, RichTextLabel, progress_fg_style, "fill");
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, RichTextLabel, horizontal_rule, "horizontal_rule");
 

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -487,6 +487,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("focus", "CodeEdit", focus);
 	theme->set_stylebox("read_only", "CodeEdit", style_line_edit_read_only);
 	theme->set_stylebox("completion", "CodeEdit", make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
+	theme->set_stylebox("hint", "CodeEdit", make_flat_stylebox(style_normal_color));
 
 	theme->set_icon("tab", "CodeEdit", icons["text_edit_tab"]);
 	theme->set_icon("space", "CodeEdit", icons["text_edit_space"]);
@@ -531,12 +532,14 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("line_length_guideline_color", "CodeEdit", Color(0.3, 0.5, 0.8, 0.1));
 	theme->set_color("search_result_color", "CodeEdit", Color(0.3, 0.3, 0.3));
 	theme->set_color("search_result_border_color", "CodeEdit", Color(0.3, 0.3, 0.3, 0.4));
+	theme->set_color("hint_color", "CodeEdit", control_font_color);
 
 	theme->set_constant("completion_lines", "CodeEdit", 7);
 	theme->set_constant("completion_max_width", "CodeEdit", 50);
 	theme->set_constant("completion_scroll_width", "CodeEdit", 6);
 	theme->set_constant("line_spacing", "CodeEdit", Math::round(4 * scale));
 	theme->set_constant("outline_size", "CodeEdit", 0);
+	theme->set_constant("h_separation", "CodeEdit", Math::round(4 * scale));
 
 	Ref<Texture2D> empty_icon = memnew(ImageTexture);
 
@@ -720,6 +723,11 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("folder_icon_color", "FileDialog", Color(1, 1, 1));
 	theme->set_color("file_icon_color", "FileDialog", Color(1, 1, 1));
 	theme->set_color("file_disabled_color", "FileDialog", Color(1, 1, 1, 0.25));
+
+	theme->set_color("icon_normal_color", "FileDialog", Color(1, 1, 1, 1));
+	theme->set_color("icon_hover_color", "FileDialog", Color(1, 1, 1, 1));
+	theme->set_color("icon_focus_color", "FileDialog", Color(1, 1, 1, 1));
+	theme->set_color("icon_pressed_color", "FileDialog", Color(1, 1, 1, 1));
 
 	// Popup
 
@@ -1230,6 +1238,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_constant("underline_alpha", "RichTextLabel", 50);
 	theme->set_constant("strikethrough_alpha", "RichTextLabel", 50);
+
+	theme->set_stylebox("background", "RichTextLabel", make_flat_stylebox(style_disabled_color, 2, 2, 2, 2, 6));
+	theme->set_stylebox("fill", "RichTextLabel", make_flat_stylebox(style_progress_color, 2, 2, 2, 2, 6));
 
 	// Containers
 


### PR DESCRIPTION
Addresses [#115091 (Comment)](https://github.com/godotengine/godot/pull/115091#issuecomment-3768864899)
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
