### PR TITLE
Don't force list icon size in EditorFileDialog

### DIFF
--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -85,7 +85,7 @@ Color EditorFileDialog::_get_folder_color(const String &p_path) const {
 }
 
 Vector2i EditorFileDialog::_get_list_mode_icon_size() const {
-	return Vector2i(1, 1) * Math::round(get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)) * EDSCALE);
+	return Vector2i();
 }
 
 void EditorFileDialog::_bind_methods() {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -824,6 +824,7 @@ void FileDialog::update_file_list() {
 		file_list->set_max_text_lines(2);
 		file_list->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 		file_list->set_fixed_icon_size(Size2(thumbnail_size, thumbnail_size));
+		file_list->set_fixed_tag_icon_size(_get_list_mode_icon_size());
 	} else {
 		file_list->set_icon_mode(ItemList::ICON_MODE_LEFT);
 		file_list->set_max_columns(1);


### PR DESCRIPTION
Removes fixed icon size from list mode in EditorFileDialog. This restores it to the state it was before 4.6, so it should fix #115310 (I can't reproduce it this time).

The reason fixed size was added in the first place is that FileDialog supports custom icons now, which brings the usual problem
<img width="959" height="473" alt="image" src="https://github.com/user-attachments/assets/11faeb19-4f78-4f50-ba52-b580b9fb042a" />
It's not a problem in the editor for now, because EditorFileDialog does not display icons of custom Resources 🤷‍♂️

I also fixed a problem with tag icons appearing with wrong size when using custom icons.