### PR TITLE
Remove leftover "hello there" debug text in core/typedef.h

### DIFF
--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -468,6 +468,6 @@ constexpr bool is_fully_defined_v = is_fully_defined<T>::value;
 #endif
 
 #define _GD_VARNAME_CONCAT_B_(m_ignore, m_name) m_name
-#define _GD_VARNAME_CONCAT_A_(m_a, m_b, m_c) _GD_VARNAME_CONCAT_B_(hello there, m_a##m_b##m_c)
+#define _GD_VARNAME_CONCAT_A_(m_a, m_b, m_c) _GD_VARNAME_CONCAT_B_(_, m_a##m_b##m_c)
 #define _GD_VARNAME_CONCAT_(m_a, m_b, m_c) _GD_VARNAME_CONCAT_A_(m_a, m_b, m_c)
 #define GD_UNIQUE_NAME(m_name) _GD_VARNAME_CONCAT_(m_name, _, __COUNTER__)


### PR DESCRIPTION
Remove leftover "hello there" debug text from _GD_VARNAME_CONCAT_A_ macro in core/typedefs.h

Noticed this while poking around, thought I might as well PR it.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
