### PR TITLE
Use real stack limits instead of hardcoded call depth limit when checking for GDScript stack overflow.

### DIFF
--- a/core/os/thread.cpp
+++ b/core/os/thread.cpp
@@ -96,6 +96,14 @@ Error Thread::set_name(const String &p_name) {
 	return ERR_UNAVAILABLE;
 }
 
+bool Thread::get_stack_limits(void **r_bottom, void **r_top, void **r_frame) {
+	if (platform_functions.get_stack_limits) {
+		return platform_functions.get_stack_limits(r_bottom, r_top, r_frame);
+	} else {
+		return false;
+	}
+}
+
 Thread::~Thread() {
 	if (id != UNASSIGNED_ID) {
 #ifdef DEBUG_ENABLED

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -85,6 +85,7 @@ public:
 
 	struct PlatformFunctions {
 		Error (*set_name)(const String &) = nullptr;
+		bool (*get_stack_limits)(void **r_bottom, void **r_top, void **r_frame) = nullptr;
 		void (*set_priority)(Thread::Priority) = nullptr;
 		void (*init)() = nullptr;
 		void (*wrapper)(Thread::Callback, void *) = nullptr;
@@ -132,6 +133,7 @@ public:
 	_FORCE_INLINE_ static bool is_main_thread() { return caller_id == MAIN_ID; } // Gain a tiny bit of perf here because there is no need to validate caller_id here, because only main thread will be set as 1.
 
 	static Error set_name(const String &p_name);
+	static bool get_stack_limits(void **r_bottom, void **r_top, void **r_frame);
 
 	ID start(Thread::Callback p_callback, void *p_user, const Settings &p_settings = Settings());
 	bool is_started() const;
@@ -171,6 +173,7 @@ public:
 
 	struct PlatformFunctions {
 		Error (*set_name)(const String &) = nullptr;
+		bool (*get_stack_limits)(void **r_bottom, void **r_top, void **r_frame) = nullptr;
 		void (*set_priority)(Thread::Priority) = nullptr;
 		void (*init)() = nullptr;
 		void (*wrapper)(Thread::Callback, void *) = nullptr;
@@ -195,6 +198,7 @@ public:
 	_FORCE_INLINE_ static bool is_main_thread() { return true; }
 
 	static Error set_name(const String &p_name) { return ERR_UNAVAILABLE; }
+	static bool get_stack_limits(void **r_bottom, void **r_top, void **r_frame) { return false; }
 
 	void start(Thread::Callback p_callback, void *p_user, const Settings &p_settings = Settings()) {}
 	bool is_started() const { return false; }

--- a/drivers/apple/thread_apple.cpp
+++ b/drivers/apple/thread_apple.cpp
@@ -67,6 +67,27 @@ Error Thread::set_name(const String &p_name) {
 	return err == 0 ? OK : ERR_INVALID_PARAMETER;
 }
 
+bool Thread::get_stack_limits(void **r_bottom, void **r_top, void **r_frame) {
+	pthread_t pth_self = pthread_self();
+	uint8_t *stack_addr = (uint8_t *)pthread_get_stackaddr_np(pth_self);
+	size_t stack_size = pthread_get_stacksize_np(pth_self);
+
+	if (stack_addr && stack_size) {
+		if (r_bottom) {
+			*r_bottom = stack_addr;
+		}
+		if (r_top) {
+			*r_top = stack_addr - stack_size + 16 * 1024; // Add guard page size.
+		}
+		if (r_frame) {
+			*r_frame = __builtin_frame_address(0);
+		}
+		return true;
+	} else {
+		return false;
+	}
+}
+
 Thread::ID Thread::start(Thread::Callback p_callback, void *p_user, const Settings &p_settings) {
 	ERR_FAIL_COND_V_MSG(id != UNASSIGNED_ID, UNASSIGNED_ID, "A Thread object has been re-started without wait_to_finish() having been called on it.");
 	id = id_counter.increment();

--- a/drivers/apple/thread_apple.h
+++ b/drivers/apple/thread_apple.h
@@ -98,6 +98,7 @@ public:
 	_FORCE_INLINE_ static bool is_main_thread() { return caller_id == MAIN_ID; }
 
 	static Error set_name(const String &p_name);
+	static bool get_stack_limits(void **r_bottom, void **r_top, void **r_frame);
 
 	ID start(Thread::Callback p_callback, void *p_user, const Settings &p_settings = Settings());
 	bool is_started() const { return id != UNASSIGNED_ID; }

--- a/drivers/unix/thread_posix.cpp
+++ b/drivers/unix/thread_posix.cpp
@@ -74,8 +74,44 @@ static Error set_name(const String &p_name) {
 #endif // PTHREAD_NO_RENAME
 }
 
+static bool get_stack_limits(void **r_bottom, void **r_top, void **r_frame) {
+	pthread_t pth_self = pthread_self();
+	pthread_attr_t pth_attr;
+	uint8_t *stack_addr = nullptr;
+	uint8_t *frame_addr = (uint8_t *)__builtin_frame_address(0);
+	size_t stack_size = 0;
+	size_t guard_size = 0;
+
+	if (pthread_getattr_np(pth_self, &pth_attr) == 0) {
+		pthread_attr_getstack(&pth_attr, (void **)&stack_addr, &stack_size);
+		pthread_attr_getguardsize(&pth_attr, &guard_size);
+		pthread_attr_destroy(&pth_attr);
+		if (frame_addr > stack_addr) {
+			if (r_bottom) {
+				*r_bottom = stack_addr + stack_size - MAX(guard_size, (size_t)(4 * 1024));
+			}
+			if (r_top) {
+				*r_top = stack_addr;
+			}
+		} else {
+			if (r_bottom) {
+				*r_bottom = stack_addr;
+			}
+			if (r_top) {
+				*r_top = stack_addr - stack_size + MAX(guard_size, (size_t)(4 * 1024));
+			}
+		}
+		if (r_frame) {
+			*r_frame = frame_addr;
+		}
+		return true;
+	} else {
+		return false;
+	}
+}
+
 void init_thread_posix() {
-	Thread::_set_platform_functions({ .set_name = set_name });
+	Thread::_set_platform_functions({ .set_name = set_name, .get_stack_limits = get_stack_limits });
 }
 
 #endif // PLATFORM_THREAD_OVERRIDE && __APPLE__

--- a/drivers/windows/thread_windows.cpp
+++ b/drivers/windows/thread_windows.cpp
@@ -36,6 +36,10 @@
 #include "core/string/ustring.h"
 
 #include <windows.h>
+#ifdef _MSC_VER
+#include <intrin.h>
+#pragma intrinsic(_AddressOfReturnAddress)
+#endif
 
 typedef HRESULT(WINAPI *SetThreadDescriptionPtr)(HANDLE p_thread, PCWSTR p_thread_description);
 SetThreadDescriptionPtr w10_SetThreadDescription = nullptr;
@@ -49,10 +53,37 @@ static Error set_name(const String &p_name) {
 	return SUCCEEDED(res) ? OK : ERR_INVALID_PARAMETER;
 }
 
+static bool get_stack_limits(void **r_bottom, void **r_top, void **r_frame) {
+	ULONG_PTR stack_lo = 0;
+	ULONG_PTR stack_hi = 0;
+	GetCurrentThreadStackLimits(&stack_lo, &stack_hi);
+	SYSTEM_INFO sys_info;
+	GetSystemInfo(&sys_info);
+
+	if (stack_lo && stack_hi) {
+		if (r_bottom) {
+			*r_bottom = (uint8_t *)stack_hi;
+		}
+		if (r_top) {
+			*r_top = (uint8_t *)stack_lo + sys_info.dwPageSize; // Add guard page size.
+		}
+		if (r_frame) {
+#ifdef _MSC_VER
+			*r_frame = _AddressOfReturnAddress();
+#else
+			*r_frame = __builtin_frame_address(0);
+#endif
+		}
+		return true;
+	} else {
+		return false;
+	}
+}
+
 void init_thread_win() {
 	w10_SetThreadDescription = (SetThreadDescriptionPtr)(void *)GetProcAddress(LoadLibraryW(L"kernel32.dll"), "SetThreadDescription");
 
-	Thread::_set_platform_functions({ set_name });
+	Thread::_set_platform_functions({ set_name, get_stack_limits });
 }
 
 #endif // WINDOWS_ENABLED

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2867,7 +2867,7 @@ GDScriptLanguage::GDScriptLanguage() {
 	script_frame_time = 0;
 #endif // DEBUG_ENABLED
 
-	_debug_max_call_stack = GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "debug/settings/gdscript/max_call_stack", PROPERTY_HINT_RANGE, "512," + itos(GDScriptFunction::MAX_CALL_DEPTH - 1) + ",1"), 1024);
+	_debug_max_call_stack = GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "debug/settings/gdscript/max_call_stack", PROPERTY_HINT_RANGE, "512,4096,1"), 1024);
 	track_call_stack = GLOBAL_DEF_RST("debug/settings/gdscript/always_track_call_stacks", false);
 	track_locals = GLOBAL_DEF_RST("debug/settings/gdscript/always_track_local_variables", false);
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2621,6 +2621,37 @@ void GDScriptAnalyzer::reduce_expression(GDScriptParser::ExpressionNode *p_expre
 		return;
 	}
 
+	static thread_local int call_depth = 0;
+
+	++call_depth;
+#ifdef SANITIZERS_ENABLED
+	{
+#else
+	if (unlikely(call_depth > 64)) { // Do not check stack size if call depth is small.
+#endif
+		void *bottom = nullptr;
+		void *top = nullptr;
+		void *frame = nullptr;
+		bool has_overflow = false;
+		if (Thread::get_stack_limits(&bottom, &top, &frame)) {
+#ifdef SANITIZERS_ENABLED
+			uint64_t alloc_size = 40 * 1024;
+#else
+			uint64_t alloc_size = 4 * 1024;
+#endif
+			has_overflow = ((uint64_t)frame - (uint64_t)top < alloc_size);
+		} else if (unlikely(call_depth > 2048)) { // Unable to get stack size, use hardcoded call depth limit instead.
+			bottom = nullptr;
+			top = nullptr;
+			frame = nullptr;
+			has_overflow = true;
+		}
+		if (has_overflow) {
+			call_depth--;
+			ERR_FAIL_MSG(vformat("Stack overflow. Check for infinite recursion in your script. Call depth: %d.", call_depth));
+		}
+	}
+
 	p_expression->reduced = true;
 
 	switch (p_expression->type) {
@@ -2699,6 +2730,7 @@ void GDScriptAnalyzer::reduce_expression(GDScriptParser::ExpressionNode *p_expre
 		case GDScriptParser::Node::TYPE:
 		case GDScriptParser::Node::VARIABLE:
 		case GDScriptParser::Node::WHILE:
+			call_depth--;
 			ERR_FAIL_MSG("Reaching unreachable case");
 	}
 
@@ -2709,6 +2741,7 @@ void GDScriptAnalyzer::reduce_expression(GDScriptParser::ExpressionNode *p_expre
 		dummy.kind = GDScriptParser::DataType::VARIANT;
 		p_expression->set_datatype(dummy);
 	}
+	call_depth--;
 }
 
 void GDScriptAnalyzer::reduce_array(GDScriptParser::ArrayNode *p_array) {

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -256,6 +256,39 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 		return codegen.add_constant(p_expression->reduced_value);
 	}
 
+	static thread_local int call_depth = 0;
+
+	++call_depth;
+#ifdef SANITIZERS_ENABLED
+	{
+#else
+	if (unlikely(call_depth > 64)) { // Do not check stack size if call depth is small.
+#endif
+		void *bottom = nullptr;
+		void *top = nullptr;
+		void *frame = nullptr;
+		bool has_overflow = false;
+		if (Thread::get_stack_limits(&bottom, &top, &frame)) {
+#ifdef SANITIZERS_ENABLED
+			uint64_t alloc_size = 400 * 1024;
+#else
+			uint64_t alloc_size = 42 * 1024;
+#endif
+			has_overflow = ((uint64_t)frame - (uint64_t)top < alloc_size);
+		} else if (unlikely(call_depth > 400)) { // Unable to get stack size, use hardcoded call depth limit instead.
+			bottom = nullptr;
+			top = nullptr;
+			frame = nullptr;
+			has_overflow = true;
+		}
+		if (has_overflow) {
+			_set_error(vformat("Stack overflow. Check for infinite recursion in your script. Call depth: %d.", call_depth), p_expression);
+			r_error = ERR_COMPILATION_FAILED;
+			call_depth--;
+			return GDScriptCodeGenerator::Address();
+		}
+	}
+
 	GDScriptCodeGenerator *gen = codegen.generator;
 
 	switch (p_expression->type) {
@@ -274,11 +307,13 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				case GDScriptParser::IdentifierNode::LOCAL_BIND: {
 					// Try function parameters.
 					if (codegen.parameters.has(identifier)) {
+						call_depth--;
 						return codegen.parameters[identifier];
 					}
 
 					// Try local variables and constants.
 					if (!p_initializer && codegen.locals.has(identifier)) {
+						call_depth--;
 						return codegen.locals[identifier];
 					}
 				} break;
@@ -293,6 +328,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 						// Get property.
 						GDScriptCodeGenerator::Address temp = codegen.add_temporary(_gdtype_from_datatype(p_expression->get_datatype(), codegen.script));
 						gen->write_get_member(temp, identifier);
+						call_depth--;
 						return temp;
 					}
 
@@ -305,10 +341,12 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 								GDScriptCodeGenerator::Address temp = codegen.add_temporary(codegen.script->member_indices[identifier].data_type);
 								Vector<GDScriptCodeGenerator::Address> args; // No argument needed.
 								gen->write_call_self(temp, codegen.script->member_indices[identifier].getter, args);
+								call_depth--;
 								return temp;
 							} else {
 								// No getter or inside getter: direct member access.
 								int idx = codegen.script->member_indices[identifier].index;
+								call_depth--;
 								return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::MEMBER, idx, codegen.script->get_member_type(identifier));
 							}
 						}
@@ -331,6 +369,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 									}
 
 									gen->write_get_named(temp, identifier, base);
+									call_depth--;
 									return temp;
 								}
 							}
@@ -353,6 +392,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 							GDScriptCodeGenerator::Address self(GDScriptCodeGenerator::Address::SELF);
 
 							gen->write_get_named(temp, identifier, self);
+							call_depth--;
 							return temp;
 						}
 					}
@@ -367,6 +407,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 						while (scr) {
 							if (scr->constants.has(identifier)) {
+								call_depth--;
 								return codegen.add_constant(scr->constants[identifier]); // TODO: Get type here.
 							}
 							if (scr->native.is_valid()) {
@@ -380,6 +421,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 							bool success = false;
 							int64_t constant = ClassDB::get_integer_constant(nc->get_name(), identifier, &success);
 							if (success) {
+								call_depth--;
 								return codegen.add_constant(constant);
 							}
 						}
@@ -398,6 +440,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 								GDScriptCodeGenerator::Address class_addr(GDScriptCodeGenerator::Address::CLASS);
 								Vector<GDScriptCodeGenerator::Address> args; // No argument needed.
 								gen->write_call(temp, class_addr, scr->static_variables_indices[identifier].getter, args);
+								call_depth--;
 								return temp;
 							} else {
 								// No getter or inside getter: direct variable access.
@@ -405,6 +448,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 								GDScriptCodeGenerator::Address _class = codegen.add_constant(scr);
 								int index = scr->static_variables_indices[identifier].index;
 								gen->write_get_static_variable(temp, _class, index);
+								call_depth--;
 								return temp;
 							}
 						}
@@ -424,10 +468,12 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 							GDScriptCodeGenerator::Address global = codegen.add_temporary(_gdtype_from_datatype(in->get_datatype(), codegen.script));
 							int idx = GDScriptLanguage::get_singleton()->get_global_map()[identifier];
 							gen->write_store_global(global, idx);
+							call_depth--;
 							return global;
 						} else {
 							int idx = GDScriptLanguage::get_singleton()->get_global_map()[identifier];
 							Variant global = GDScriptLanguage::get_singleton()->get_global_array()[idx];
+							call_depth--;
 							return codegen.add_constant(global);
 						}
 					}
@@ -452,6 +498,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 								if (err != OK) {
 									_set_error("Can't load global class " + String(identifier), p_expression);
 									r_error = ERR_COMPILATION_FAILED;
+									call_depth--;
 									return GDScriptCodeGenerator::Address();
 								}
 							} else {
@@ -459,11 +506,12 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 								if (res.is_null()) {
 									_set_error("Can't load global class " + String(identifier) + ", cyclic reference?", p_expression);
 									r_error = ERR_COMPILATION_FAILED;
+									call_depth--;
 									return GDScriptCodeGenerator::Address();
 								}
 							}
 						}
-
+						call_depth--;
 						return codegen.add_constant(res);
 					}
 
@@ -471,6 +519,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					if (GDScriptLanguage::get_singleton()->get_named_globals_map().has(identifier)) {
 						GDScriptCodeGenerator::Address global = codegen.add_temporary(); // TODO: Get type.
 						gen->write_store_named_global(global, identifier);
+						call_depth--;
 						return global;
 					}
 #endif
@@ -481,12 +530,13 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			// Not found, error.
 			_set_error("Identifier not found: " + String(identifier), p_expression);
 			r_error = ERR_COMPILATION_FAILED;
+			call_depth--;
 			return GDScriptCodeGenerator::Address();
 		} break;
 		case GDScriptParser::Node::LITERAL: {
 			// Return constant.
 			const GDScriptParser::LiteralNode *cn = static_cast<const GDScriptParser::LiteralNode *>(p_expression);
-
+			call_depth--;
 			return codegen.add_constant(cn->value);
 		} break;
 		case GDScriptParser::Node::SELF: {
@@ -494,8 +544,10 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			if (codegen.function_node && codegen.function_node->is_static) {
 				_set_error("'self' not present in static function.", p_expression);
 				r_error = ERR_COMPILATION_FAILED;
+				call_depth--;
 				return GDScriptCodeGenerator::Address();
 			}
+			call_depth--;
 			return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::SELF);
 		} break;
 		case GDScriptParser::Node::ARRAY: {
@@ -509,6 +561,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			for (int i = 0; i < an->elements.size(); i++) {
 				GDScriptCodeGenerator::Address val = _parse_expression(codegen, r_error, an->elements[i]);
 				if (r_error) {
+					call_depth--;
 					return GDScriptCodeGenerator::Address();
 				}
 				values.push_back(val);
@@ -525,7 +578,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					gen->pop_temporary();
 				}
 			}
-
+			call_depth--;
 			return result;
 		} break;
 		case GDScriptParser::Node::DICTIONARY: {
@@ -544,6 +597,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 						// Python-style: key is any expression.
 						element = _parse_expression(codegen, r_error, dn->elements[i].key);
 						if (r_error) {
+							call_depth--;
 							return GDScriptCodeGenerator::Address();
 						}
 						break;
@@ -558,6 +612,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 				element = _parse_expression(codegen, r_error, dn->elements[i].value);
 				if (r_error) {
+					call_depth--;
 					return GDScriptCodeGenerator::Address();
 				}
 
@@ -575,7 +630,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					gen->pop_temporary();
 				}
 			}
-
+			call_depth--;
 			return result;
 		} break;
 		case GDScriptParser::Node::CAST: {
@@ -597,7 +652,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			} else {
 				result = _parse_expression(codegen, r_error, cn->operand);
 			}
-
+			call_depth--;
 			return result;
 		} break;
 		case GDScriptParser::Node::CALL: {
@@ -615,6 +670,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			for (int i = 0; i < call->arguments.size(); i++) {
 				GDScriptCodeGenerator::Address arg = _parse_expression(codegen, r_error, call->arguments[i]);
 				if (r_error) {
+					call_depth--;
 					return GDScriptCodeGenerator::Address();
 				}
 				arguments.push_back(arg);
@@ -688,6 +744,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 							} else {
 								GDScriptCodeGenerator::Address base = _parse_expression(codegen, r_error, subscript->base);
 								if (r_error) {
+									call_depth--;
 									return GDScriptCodeGenerator::Address();
 								}
 								if (is_awaited) {
@@ -724,11 +781,13 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 						} else {
 							_set_error("Cannot call something that isn't a function.", call->callee);
 							r_error = ERR_COMPILATION_FAILED;
+							call_depth--;
 							return GDScriptCodeGenerator::Address();
 						}
 					} else {
 						_set_error("Compiler bug (please report): incorrect callee type in call node.", call->callee);
 						r_error = ERR_COMPILATION_FAILED;
+						call_depth--;
 						return GDScriptCodeGenerator::Address();
 					}
 				}
@@ -739,6 +798,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					gen->pop_temporary();
 				}
 			}
+			call_depth--;
 			return result;
 		} break;
 		case GDScriptParser::Node::GET_NODE: {
@@ -751,13 +811,14 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 			MethodBind *get_node_method = ClassDB::get_method("Node", "get_node");
 			gen->write_call_method_bind_validated(result, GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::SELF), get_node_method, args);
-
+			call_depth--;
 			return result;
 		} break;
 		case GDScriptParser::Node::PRELOAD: {
 			const GDScriptParser::PreloadNode *preload = static_cast<const GDScriptParser::PreloadNode *>(p_expression);
 
 			// Add resource as constant.
+			call_depth--;
 			return codegen.add_constant(preload->resource);
 		} break;
 		case GDScriptParser::Node::AWAIT: {
@@ -769,6 +830,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			GDScriptCodeGenerator::Address argument = _parse_expression(codegen, r_error, await->to_await);
 			awaited_node = previous_awaited_node;
 			if (r_error) {
+				call_depth--;
 				return GDScriptCodeGenerator::Address();
 			}
 
@@ -778,6 +840,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				gen->pop_temporary();
 			}
 
+			call_depth--;
 			return result;
 		} break;
 		// Indexing operator.
@@ -787,6 +850,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 			GDScriptCodeGenerator::Address base = _parse_expression(codegen, r_error, subscript->base);
 			if (r_error) {
+				call_depth--;
 				return GDScriptCodeGenerator::Address();
 			}
 
@@ -803,6 +867,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 						String n = identifier->name;
 						_set_error("Must use '" + n + "' instead of 'self." + n + "' in getter.", identifier);
 						r_error = ERR_COMPILATION_FAILED;
+						call_depth--;
 						return GDScriptCodeGenerator::Address();
 					}
 #endif
@@ -811,6 +876,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 						// Remove result temp as we don't need it.
 						gen->pop_temporary();
 						// Faster than indexing self (as if no self. had been used).
+						call_depth--;
 						return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::MEMBER, MI->value.index, _gdtype_from_datatype(subscript->get_datatype(), codegen.script));
 					}
 				}
@@ -826,6 +892,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					// Regular indexing.
 					index = _parse_expression(codegen, r_error, subscript->index);
 					if (r_error) {
+						call_depth--;
 						return GDScriptCodeGenerator::Address();
 					}
 				}
@@ -843,7 +910,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			if (base.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
 				gen->pop_temporary();
 			}
-
+			call_depth--;
 			return result;
 		} break;
 		case GDScriptParser::Node::UNARY_OPERATOR: {
@@ -853,6 +920,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 			GDScriptCodeGenerator::Address operand = _parse_expression(codegen, r_error, unary->operand);
 			if (r_error) {
+				call_depth--;
 				return GDScriptCodeGenerator::Address();
 			}
 
@@ -861,7 +929,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			if (operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
 				gen->pop_temporary();
 			}
-
+			call_depth--;
 			return result;
 		}
 		case GDScriptParser::Node::BINARY_OPERATOR: {
@@ -916,6 +984,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					}
 				}
 			}
+			call_depth--;
 			return result;
 		} break;
 		case GDScriptParser::Node::TERNARY_OPERATOR: {
@@ -927,6 +996,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 			GDScriptCodeGenerator::Address condition = _parse_expression(codegen, r_error, ternary->condition);
 			if (r_error) {
+				call_depth--;
 				return GDScriptCodeGenerator::Address();
 			}
 			gen->write_ternary_condition(condition);
@@ -937,6 +1007,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 			GDScriptCodeGenerator::Address true_expr = _parse_expression(codegen, r_error, ternary->true_expr);
 			if (r_error) {
+				call_depth--;
 				return GDScriptCodeGenerator::Address();
 			}
 			gen->write_ternary_true_expr(true_expr);
@@ -946,6 +1017,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 			GDScriptCodeGenerator::Address false_expr = _parse_expression(codegen, r_error, ternary->false_expr);
 			if (r_error) {
+				call_depth--;
 				return GDScriptCodeGenerator::Address();
 			}
 			gen->write_ternary_false_expr(false_expr);
@@ -954,7 +1026,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			}
 
 			gen->write_end_ternary();
-
+			call_depth--;
 			return result;
 		} break;
 		case GDScriptParser::Node::TYPE_TEST: {
@@ -964,6 +1036,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			GDScriptCodeGenerator::Address operand = _parse_expression(codegen, r_error, type_test->operand);
 			GDScriptDataType test_type = _gdtype_from_datatype(type_test->test_datatype, codegen.script, false);
 			if (r_error) {
+				call_depth--;
 				return GDScriptCodeGenerator::Address();
 			}
 
@@ -976,7 +1049,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			if (operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
 				gen->pop_temporary();
 			}
-
+			call_depth--;
 			return result;
 		} break;
 		case GDScriptParser::Node::ASSIGNMENT: {
@@ -992,6 +1065,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 						String n = subscript->attribute->name;
 						_set_error("Must use '" + n + "' instead of 'self." + n + "' in setter.", subscript);
 						r_error = ERR_COMPILATION_FAILED;
+						call_depth--;
 						return GDScriptCodeGenerator::Address();
 					}
 				}
@@ -1071,6 +1145,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				const bool base_is_shared = Variant::is_type_shared(base.type.builtin_type);
 
 				if (r_error) {
+					call_depth--;
 					return GDScriptCodeGenerator::Address();
 				}
 
@@ -1110,6 +1185,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					} else {
 						key = _parse_expression(codegen, r_error, subscript_elem->index);
 						if (r_error) {
+							call_depth--;
 							return GDScriptCodeGenerator::Address();
 						}
 						gen->write_get(value, key, prev_base);
@@ -1123,6 +1199,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				// Get value to assign.
 				GDScriptCodeGenerator::Address assigned = _parse_expression(codegen, r_error, assignment->assigned_value);
 				if (r_error) {
+					call_depth--;
 					return GDScriptCodeGenerator::Address();
 				}
 				// Get the key if needed.
@@ -1133,6 +1210,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				} else {
 					key = _parse_expression(codegen, r_error, subscript->index);
 					if (r_error) {
+						call_depth--;
 						return GDScriptCodeGenerator::Address();
 					}
 				}
@@ -1251,6 +1329,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				// Assignment to member property.
 				GDScriptCodeGenerator::Address assigned_value = _parse_expression(codegen, r_error, assignment->assigned_value);
 				if (r_error) {
+					call_depth--;
 					return GDScriptCodeGenerator::Address();
 				}
 
@@ -1281,6 +1360,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				if (assignment->assignee->type != GDScriptParser::Node::IDENTIFIER) {
 					_set_error("Compiler bug (please report): Expected the assignee to be an identifier here.", assignment->assignee);
 					r_error = ERR_COMPILATION_FAILED;
+					call_depth--;
 					return GDScriptCodeGenerator::Address();
 				}
 				GDScriptCodeGenerator::Address member;
@@ -1332,12 +1412,14 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				} else {
 					target = _parse_expression(codegen, r_error, assignment->assignee);
 					if (r_error) {
+						call_depth--;
 						return GDScriptCodeGenerator::Address();
 					}
 				}
 
 				GDScriptCodeGenerator::Address assigned_value = _parse_expression(codegen, r_error, assignment->assigned_value);
 				if (r_error) {
+					call_depth--;
 					return GDScriptCodeGenerator::Address();
 				}
 
@@ -1391,6 +1473,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					gen->pop_temporary(); // Pop the target to assignment.
 				}
 			}
+			call_depth--;
 			return GDScriptCodeGenerator::Address(); // Assignment does not return a value.
 		} break;
 		case GDScriptParser::Node::LAMBDA: {
@@ -1402,12 +1485,14 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			for (int i = 0; i < lambda->captures.size(); i++) {
 				captures.write[i] = _parse_expression(codegen, r_error, lambda->captures[i]);
 				if (r_error) {
+					call_depth--;
 					return GDScriptCodeGenerator::Address();
 				}
 			}
 
 			GDScriptFunction *function = _parse_function(r_error, codegen.script, codegen.class_node, lambda->function, false, true);
 			if (r_error) {
+				call_depth--;
 				return GDScriptCodeGenerator::Address();
 			}
 
@@ -1419,12 +1504,13 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					gen->pop_temporary();
 				}
 			}
-
+			call_depth--;
 			return result;
 		} break;
 		default: {
 			_set_error("Compiler bug (please report): Unexpected node in parse tree while parsing expression.", p_expression); // Unreachable code.
 			r_error = ERR_COMPILATION_FAILED;
+			call_depth--;
 			return GDScriptCodeGenerator::Address();
 		} break;
 	}

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -456,8 +456,6 @@ private:
 	Variant _get_default_variant_for_data_type(const GDScriptDataType &p_data_type);
 
 public:
-	static constexpr int MAX_CALL_DEPTH = 2048; // Limit to try to avoid crash because of a stack overflow.
-
 	struct CallState {
 		Signal completed;
 		GDScript *script = nullptr;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -508,28 +508,59 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 	r_err.error = Callable::CallError::CALL_OK;
 
 	static thread_local int call_depth = 0;
-	if (unlikely(++call_depth > MAX_CALL_DEPTH)) {
-		call_depth--;
-#ifdef DEBUG_ENABLED
-		String err_file;
-		if (p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid() && !p_instance->script->path.is_empty()) {
-			err_file = p_instance->script->path;
-		} else if (_script) {
-			err_file = _script->path;
-		}
-		if (err_file.is_empty()) {
-			err_file = "<built-in>";
-		}
-		String err_func = name;
-		if (p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid() && p_instance->script->local_name != StringName()) {
-			err_func = p_instance->script->local_name.operator String() + "." + err_func;
-		}
-		int err_line = _initial_line;
-		const char *err_text = "Stack overflow. Check for infinite recursion in your script.";
-		_err_print_error(err_func.utf8().get_data(), err_file.utf8().get_data(), err_line, err_text, false, ERR_HANDLER_SCRIPT);
-		GDScriptLanguage::get_singleton()->debug_break(err_text, false);
+
+	++call_depth;
+#ifdef SANITIZERS_ENABLED
+	{
+#else
+	if (unlikely(call_depth > 64)) { // Do not check stack size if call depth is small.
 #endif
-		return _get_default_variant_for_data_type(return_type);
+		void *bottom = nullptr;
+		void *top = nullptr;
+		void *frame = nullptr;
+		bool has_overflow = false;
+		if (Thread::get_stack_limits(&bottom, &top, &frame)) {
+			uint64_t alloc_size = sizeof(Variant *) * FIXED_ADDRESSES_MAX + sizeof(Variant *) * _instruction_args_size + sizeof(Variant) * _stack_size;
+#ifdef SANITIZERS_ENABLED
+			alloc_size += 300 * 1024;
+#else
+			alloc_size += 32 * 1024;
+#endif
+			has_overflow = ((uint64_t)frame - (uint64_t)top < alloc_size);
+		} else if (unlikely(call_depth > 2048)) { // Unable to get stack size, use hardcoded call depth limit instead.
+			bottom = nullptr;
+			top = nullptr;
+			frame = nullptr;
+			has_overflow = true;
+		}
+		if (has_overflow) {
+			call_depth--;
+#ifdef DEBUG_ENABLED
+			String err_file;
+			if (p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid() && !p_instance->script->path.is_empty()) {
+				err_file = p_instance->script->path;
+			} else if (_script) {
+				err_file = _script->path;
+			}
+			if (err_file.is_empty()) {
+				err_file = "<built-in>";
+			}
+			String err_func = name;
+			if (p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid() && p_instance->script->local_name != StringName()) {
+				err_func = p_instance->script->local_name.operator String() + "." + err_func;
+			}
+			int err_line = _initial_line;
+			String err_text;
+			if (frame && top && bottom) {
+				err_text = vformat("Stack overflow. Check for infinite recursion in your script. Free stack: %d, used stack: %d, call depth: %d.", (uint64_t)frame - (uint64_t)top, (uint64_t)bottom - (uint64_t)frame, call_depth);
+			} else {
+				err_text = vformat("Stack overflow. Check for infinite recursion in your script. Call depth: %d.", call_depth);
+			}
+			_err_print_error(err_func.utf8().get_data(), err_file.utf8().get_data(), err_line, err_text.utf8().get_data(), false, ERR_HANDLER_SCRIPT);
+			GDScriptLanguage::get_singleton()->debug_break(err_text, false);
+#endif
+			return _get_default_variant_for_data_type(return_type);
+		}
 	}
 
 	Variant retvalue;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/115311
Fixes https://github.com/godotengine/godot/issues/118937

Instead of using arbitrary 2K limit, which is only valid for main thread on release builds, use real stack limits for the check.

Depending on platform and build config, real call depth limits varies from ~100 to 7000.

Tested on macOS, Windows and Linux.