### PR TITLE
Add translation context to Controls

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1273,6 +1273,9 @@
 			[/csharp]
 			[/codeblocks]
 		</member>
+		<member name="translation_context" type="StringName" setter="set_translation_context" getter="get_translation_context" default="&amp;&quot;&quot;">
+			The translation context used when translating this control's displayed text, if it has any. Also used when generating translation templates.
+		</member>
 	</members>
 	<signals>
 		<signal name="focus_entered">

--- a/editor/translations/packed_scene_translation_parser_plugin.cpp
+++ b/editor/translations/packed_scene_translation_parser_plugin.cpp
@@ -156,6 +156,19 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 			continue;
 		}
 
+		// Handle translation context
+		String translation_context;
+		if (ClassDB::is_parent_class(node_type, "Control")) {
+			for (int j = 0; j < state->get_node_property_count(i); j++) {
+				String property_name = state->get_node_property_name(i, j);
+
+				if (property_name == "translation_context") {
+					translation_context = String(state->get_node_property_value(i, j));
+					break;
+				}
+			}
+		}
+
 		if (node_type == "TabContainer") {
 			tabcontainer_paths.push_back(String(state->get_node_path(i)));
 		}
@@ -192,7 +205,7 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 				String str_value = String(property_value);
 				// Prevent reading text containing only spaces.
 				if (!str_value.strip_edges().is_empty()) {
-					r_translations->push_back({ str_value });
+					r_translations->push_back({ str_value, translation_context });
 				}
 			}
 		}

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -4209,6 +4209,23 @@ String Control::get_tooltip_text() const {
 	return data.tooltip;
 }
 
+void Control::set_translation_context(const StringName &p_context) {
+	ERR_MAIN_THREAD_GUARD;
+	data.translation_context = p_context;
+}
+
+StringName Control::get_translation_context() const {
+	ERR_READ_THREAD_GUARD_V(StringName());
+	return data.translation_context;
+}
+
+StringName Control::_get_translation_context_with_override(const StringName &p_context) const {
+	if (p_context.is_empty()) {
+		return data.translation_context;
+	}
+	return p_context;
+}
+
 String Control::get_tooltip(const Point2 &p_pos) const {
 	ERR_READ_THREAD_GUARD_V(String());
 	String ret;
@@ -4691,6 +4708,9 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tooltip_text"), &Control::get_tooltip_text);
 	ClassDB::bind_method(D_METHOD("get_tooltip", "at_position"), &Control::get_tooltip, DEFVAL(Point2()));
 
+	ClassDB::bind_method(D_METHOD("set_translation_context", "context"), &Control::set_translation_context);
+	ClassDB::bind_method(D_METHOD("get_translation_context"), &Control::get_translation_context);
+
 	ClassDB::bind_method(D_METHOD("set_default_cursor_shape", "shape"), &Control::set_default_cursor_shape);
 	ClassDB::bind_method(D_METHOD("get_default_cursor_shape"), &Control::get_default_cursor_shape);
 	ClassDB::bind_method(D_METHOD("get_cursor_shape", "at_position"), &Control::get_cursor_shape, DEFVAL(Point2()));
@@ -4851,6 +4871,7 @@ void Control::_bind_methods() {
 	ADD_GROUP("Localization", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "localize_numeral_system"), "set_localize_numeral_system", "is_localizing_numeral_system");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "layout_direction", PROPERTY_HINT_ENUM, "Inherited,Based on Application Locale,Left-to-Right,Right-to-Left,Based on System Locale"), "set_layout_direction", "get_layout_direction");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "translation_context"), "set_translation_context", "get_translation_context");
 
 #ifndef DISABLE_DEPRECATED
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_translate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_auto_translate", "is_auto_translating");

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -333,6 +333,7 @@ private:
 		// Extra properties.
 
 		String tooltip;
+		StringName translation_context;
 		AutoTranslateMode tooltip_auto_translate_mode = AUTO_TRANSLATE_MODE_INHERIT;
 
 	} data;
@@ -418,6 +419,10 @@ protected:
 
 	bool _property_can_revert(const StringName &p_name) const;
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
+
+	// Localization
+
+	virtual StringName _get_translation_context_with_override(const StringName &p_context) const override;
 
 	// Theming.
 
@@ -836,6 +841,8 @@ public:
 
 	String get_tooltip_text() const;
 	void set_tooltip_text(const String &text);
+	StringName get_translation_context() const;
+	void set_translation_context(const StringName &p_context);
 	virtual String get_tooltip(const Point2 &p_pos) const;
 	virtual Control *make_custom_tooltip(const String &p_text) const;
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -414,6 +414,10 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	virtual String _to_string() override;
 
+	// Localization
+
+	virtual StringName _get_translation_context_with_override(const StringName &p_context) const { return p_context; }
+
 	Variant _get_node_rpc_config_bind() const {
 		return get_node_rpc_config().duplicate(true);
 	}
@@ -826,10 +830,12 @@ public:
 	virtual void set_translation_domain(const StringName &p_domain) override;
 	void set_translation_domain_inherited();
 
-	_FORCE_INLINE_ String atr(const String &p_message, const StringName &p_context = "") const { return can_auto_translate() ? tr(p_message, p_context) : p_message; }
+	_FORCE_INLINE_ String atr(const String &p_message, const StringName &p_context = "") const {
+		return can_auto_translate() ? tr(p_message, _get_translation_context_with_override(p_context)) : p_message;
+	}
 	_FORCE_INLINE_ String atr_n(const String &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const {
 		if (can_auto_translate()) {
-			return tr_n(p_message, p_message_plural, p_n, p_context);
+			return tr_n(p_message, p_message_plural, p_n, _get_translation_context_with_override(p_context));
 		}
 		return p_n == 1 ? p_message : String(p_message_plural);
 	}


### PR DESCRIPTION
I'm not the full author in here, this could easily be a sort of duplicate of https://github.com/jkirsteins/godot/pull/4 draft, but I've been using this for nearly a year now and that PR looks abandoned.

This PR adds `translation_context` to controls and can be changed in the editor for POT generation, so you don't have to exclusive rely gdscript `tr`.

<img width="361" height="199" alt="image" src="https://github.com/user-attachments/assets/8f4d3ca5-400c-4183-8d87-5415987341b9" />

I also added the Control.xml entry that I pretty much copied from https://docs.godotengine.org/en/4.4/tutorials/i18n/internationalizing_games.html#translation-contexts so let me know if I should change for anything better.