### PR TITLE
Scene tree dock: Don't log error if there is no selection upon handling `item_icon_double_clicked` signal

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4199,7 +4199,10 @@ void SceneTreeDock::save_branch_to_file(const String &p_directory) {
 
 void SceneTreeDock::_focus_node() {
 	Node *node = scene_tree->get_selected();
-	ERR_FAIL_NULL(node);
+	// This method handles the item_icon_double_clicked signal and there is no guarantee anything is actually selected.
+	if (!node) {
+		return;
+	}
 
 	if (node->is_class("CanvasItem")) {
 		CanvasItemEditorPlugin *editor = Object::cast_to<CanvasItemEditorPlugin>(editor_data->get_editor_by_name("2D"));


### PR DESCRIPTION
This fixes #113332, specifically https://github.com/godotengine/godot/issues/113332#issuecomment-3791733754 by removing the error logging.
I don't think it's an error when the handler of an item_icon_double_clicked signal finds no selection. Seems fine to just ignore the event and not cause user confusion by logging an error.


