### PR TITLE
Skip zero values in `EditorPropertyFlags`

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1017,6 +1017,10 @@ void EditorPropertyFlags::setup(const Vector<String> &p_options) {
 		Vector<String> text_split = option.split(":");
 		if (text_split.size() != 1) {
 			current_val = text_split[1].to_int();
+			// Skip entries like "None:0" (it's not an actual flag).
+			if (current_val == 0) {
+				continue;
+			}
 		} else {
 			current_val = 1u << i;
 		}


### PR DESCRIPTION
This PR makes the EditorPropertyFlags not create a checkbox for enum entries with zero value, like `None = 0`. Such created checkboxes were broken / not usable before anyway.

Resolves https://github.com/godotengine/godot-proposals/issues/14023.

Note the above proposal is about C#, but the issue is not C# specific. In GDScript, `@export_flags` indeed prevents adding `0` value arguments:

<img width="920" height="100" alt="Godot_v4 6-rc2_win64_KXclF3Nl6F" src="https://github.com/user-attachments/assets/9406caa6-17a1-4c0f-8c76-9ecae98c67c5" />

but it could still be added manually e.g. using `_validate_property`:
```gdscript
@tool
extends Node

@export_flags("First:1", "Second:2", "Third:4") var flags: int = 0

func _validate_property(property: Dictionary) -> void:
	if property.name == "flags":
		property.hint_string += ",None:0"
```

Result for the script above:

Before<br>v4.6.rc2.official [78c6632eb]|After<br>this PR
-|-
![Godot_v4 6-rc2_win64_hgCyet6WoW](https://github.com/user-attachments/assets/f737ad9a-2096-4c8e-9503-c6666de20323)|<img width="267" height="101" alt="godot windows editor dev x86_64_P2yELM3gTW" src="https://github.com/user-attachments/assets/06a9bfa4-f56d-4451-9132-602bedf7bbe5" />
