### PR TITLE
Add node path validation & tweak warning in SkeletonModifier3D

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1742,6 +1742,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("display/window/hdr/request_hdr_output", false);
 
 	GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);
+	GLOBAL_DEF("animation/warnings/check_invalid_skeleton_modifier_node_paths", true);
 	GLOBAL_DEF("animation/warnings/check_invalid_track_paths", true);
 	GLOBAL_DEF("animation/warnings/check_angle_interpolation_type_conflicting", true);
 #ifndef DISABLE_DEPRECATED

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -294,6 +294,9 @@
 		<member name="animation/warnings/check_angle_interpolation_type_conflicting" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], [AnimationMixer] prints the warning of interpolation being forced to choose the shortest rotation path due to multiple angle interpolation types being mixed in the [AnimationMixer] cache.
 		</member>
+		<member name="animation/warnings/check_invalid_skeleton_modifier_node_paths" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], [SkeletonModifier3D] prints a warning if there's no matching object for the track path in the scene when assigning.
+		</member>
 		<member name="animation/warnings/check_invalid_track_paths" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], [AnimationMixer] prints the warning of no matching object of the track path in the scene.
 		</member>

--- a/scene/3d/bone_constraint_3d.cpp
+++ b/scene/3d/bone_constraint_3d.cpp
@@ -193,7 +193,7 @@ void BoneConstraint3D::set_apply_bone(int p_index, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (settings[p_index]->apply_bone <= -1 || settings[p_index]->apply_bone >= sk->get_bone_count()) {
-			WARN_PRINT("Apply bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + ": Apply bone index '" + itos(p_bone) + "' is out of range!");
 			settings[p_index]->apply_bone = -1;
 		} else {
 			settings[p_index]->apply_bone_name = sk->get_bone_name(settings[p_index]->apply_bone);
@@ -237,7 +237,7 @@ void BoneConstraint3D::set_reference_bone(int p_index, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (settings[p_index]->reference_bone <= -1 || settings[p_index]->reference_bone >= sk->get_bone_count()) {
-			WARN_PRINT("reference bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + ": Reference bone index '" + itos(p_bone) + "' is out of range!");
 			settings[p_index]->reference_bone = -1;
 		} else {
 			settings[p_index]->reference_bone_name = sk->get_bone_name(settings[p_index]->reference_bone);
@@ -253,6 +253,9 @@ int BoneConstraint3D::get_reference_bone(int p_index) const {
 void BoneConstraint3D::set_reference_node(int p_index, const NodePath &p_node) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	settings[p_index]->reference_node = p_node;
+	if (should_check_node_path() && !p_node.is_empty() && !Object::cast_to<Node3D>(get_node_or_null(p_node))) {
+		WARN_PRINT_ED("Setting: " + itos(p_index) + ": Reference node '" + String(p_node) + "' not found.");
+	}
 }
 
 NodePath BoneConstraint3D::get_reference_node(int p_index) const {

--- a/scene/3d/bone_twist_disperser_3d.cpp
+++ b/scene/3d/bone_twist_disperser_3d.cpp
@@ -267,7 +267,7 @@ void BoneTwistDisperser3D::set_root_bone(int p_index, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (settings[p_index]->root_bone.bone <= -1 || settings[p_index]->root_bone.bone >= sk->get_bone_count()) {
-			WARN_PRINT("Root bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + ": Root bone index '" + itos(p_bone) + "' is out of range!");
 			settings[p_index]->root_bone.bone = -1;
 		} else {
 			settings[p_index]->root_bone.name = sk->get_bone_name(settings[p_index]->root_bone.bone);
@@ -304,7 +304,7 @@ void BoneTwistDisperser3D::set_end_bone(int p_index, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (settings[p_index]->end_bone.bone <= -1 || settings[p_index]->end_bone.bone >= sk->get_bone_count()) {
-			WARN_PRINT("End bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + ": End bone index '" + itos(p_bone) + "' is out of range!");
 			settings[p_index]->end_bone.bone = -1;
 		} else {
 			settings[p_index]->end_bone.name = sk->get_bone_name(settings[p_index]->end_bone.bone);
@@ -470,7 +470,7 @@ void BoneTwistDisperser3D::_set_joint_bone(int p_index, int p_joint, int p_bone)
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (joints[p_joint].joint.bone <= -1 || joints[p_joint].joint.bone >= sk->get_bone_count()) {
-			WARN_PRINT("Joint bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + " : Joint: " + itos(p_joint) + ": bone index '" + itos(p_bone) + "' is out of range!");
 			joints[p_joint].joint.bone = -1;
 		} else {
 			joints[p_joint].joint.name = sk->get_bone_name(joints[p_joint].joint.bone);

--- a/scene/3d/chain_ik_3d.cpp
+++ b/scene/3d/chain_ik_3d.cpp
@@ -186,7 +186,7 @@ void ChainIK3D::set_root_bone(int p_index, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (chain_settings[p_index]->root_bone.bone <= -1 || chain_settings[p_index]->root_bone.bone >= sk->get_bone_count()) {
-			WARN_PRINT("Root bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + ": Root bone index '" + itos(p_bone) + "' is out of range!");
 			chain_settings[p_index]->root_bone.bone = -1;
 		} else {
 			chain_settings[p_index]->root_bone.name = sk->get_bone_name(chain_settings[p_index]->root_bone.bone);
@@ -223,7 +223,7 @@ void ChainIK3D::set_end_bone(int p_index, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (chain_settings[p_index]->end_bone.bone <= -1 || chain_settings[p_index]->end_bone.bone >= sk->get_bone_count()) {
-			WARN_PRINT("End bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + ": End bone index '" + itos(p_bone) + "' is out of range!");
 			chain_settings[p_index]->end_bone.bone = -1;
 		} else {
 			chain_settings[p_index]->end_bone.name = sk->get_bone_name(chain_settings[p_index]->end_bone.bone);
@@ -315,7 +315,7 @@ void ChainIK3D::_set_joint_bone(int p_index, int p_joint, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (joints[p_joint].bone <= -1 || joints[p_joint].bone >= sk->get_bone_count()) {
-			WARN_PRINT("Joint bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + " : Joint: " + itos(p_joint) + ": bone index '" + itos(p_bone) + "' is out of range!");
 			joints[p_joint].bone = -1;
 		} else {
 			joints[p_joint].name = sk->get_bone_name(joints[p_joint].bone);

--- a/scene/3d/iterate_ik_3d.cpp
+++ b/scene/3d/iterate_ik_3d.cpp
@@ -206,6 +206,9 @@ bool IterateIK3D::is_deterministic() const {
 void IterateIK3D::set_target_node(int p_index, const NodePath &p_node_path) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	iterate_settings[p_index]->target_node = p_node_path;
+	if (should_check_node_path() && !p_node_path.is_empty() && !Object::cast_to<Node3D>(get_node_or_null(p_node_path))) {
+		WARN_PRINT_ED("Setting: " + itos(p_index) + ": Target node '" + String(p_node_path) + "' not found.");
+	}
 	update_configuration_warnings();
 }
 

--- a/scene/3d/limit_angular_velocity_modifier_3d.cpp
+++ b/scene/3d/limit_angular_velocity_modifier_3d.cpp
@@ -150,7 +150,7 @@ void LimitAngularVelocityModifier3D::set_root_bone(int p_index, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (chains[p_index].root_bone.bone <= -1 || chains[p_index].root_bone.bone >= sk->get_bone_count()) {
-			WARN_PRINT("Root bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + ": Root bone index '" + itos(p_bone) + "' is out of range!");
 			chains[p_index].root_bone.bone = -1;
 		} else {
 			chains[p_index].root_bone.name = sk->get_bone_name(chains[p_index].root_bone.bone);
@@ -187,7 +187,7 @@ void LimitAngularVelocityModifier3D::set_end_bone(int p_index, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (chains[p_index].end_bone.bone <= -1 || chains[p_index].end_bone.bone >= sk->get_bone_count()) {
-			WARN_PRINT("End bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + ": End bone index '" + itos(p_bone) + "' is out of range!");
 			chains[p_index].end_bone.bone = -1;
 		} else {
 			chains[p_index].end_bone.name = sk->get_bone_name(chains[p_index].end_bone.bone);

--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -108,7 +108,7 @@ void LookAtModifier3D::set_bone(int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (bone <= -1 || bone >= sk->get_bone_count()) {
-			WARN_PRINT("Bone index out of range!");
+			WARN_PRINT_ED("Bone index '" + itos(p_bone) + "' is out of range!");
 			bone = -1;
 		} else {
 			bone_name = sk->get_bone_name(bone);
@@ -159,6 +159,9 @@ void LookAtModifier3D::set_target_node(const NodePath &p_target_node) {
 	if (target_node != p_target_node) {
 		init_transition();
 	}
+	if (should_check_node_path() && !p_target_node.is_empty() && !Object::cast_to<Node3D>(get_node_or_null(p_target_node))) {
+		WARN_PRINT_ED("Target node '" + String(p_target_node) + "' not found.");
+	}
 	target_node = p_target_node;
 }
 
@@ -194,7 +197,7 @@ void LookAtModifier3D::set_origin_bone(int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (origin_bone <= -1 || origin_bone >= sk->get_bone_count()) {
-			WARN_PRINT("Bone index out of range!");
+			WARN_PRINT_ED("Origin bone index '" + itos(p_bone) + "' is out of range!");
 			origin_bone = -1;
 		} else {
 			origin_bone_name = sk->get_bone_name(origin_bone);
@@ -207,6 +210,9 @@ int LookAtModifier3D::get_origin_bone() const {
 }
 
 void LookAtModifier3D::set_origin_external_node(const NodePath &p_external_node) {
+	if (should_check_node_path() && !p_external_node.is_empty() && !Object::cast_to<Node3D>(get_node_or_null(p_external_node))) {
+		WARN_PRINT_ED("Origin node '" + String(p_external_node) + "' not found.");
+	}
 	origin_external_node = p_external_node;
 }
 

--- a/scene/3d/modifier_bone_target_3d.cpp
+++ b/scene/3d/modifier_bone_target_3d.cpp
@@ -59,7 +59,7 @@ void ModifierBoneTarget3D::set_bone(int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (bone <= -1 || bone >= sk->get_bone_count()) {
-			WARN_PRINT("Bone index out of range!");
+			WARN_PRINT_ED("Bone index '" + itos(p_bone) + "' is out of range!");
 			bone = -1;
 		} else {
 			bone_name = sk->get_bone_name(bone);

--- a/scene/3d/skeleton_modifier_3d.cpp
+++ b/scene/3d/skeleton_modifier_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "skeleton_modifier_3d.h"
 
+#include "core/config/project_settings.h"
 #include "core/object/class_db.h"
 
 PackedStringArray SkeletonModifier3D::get_configuration_warnings() const {
@@ -89,6 +90,10 @@ void SkeletonModifier3D::_force_update_skeleton_skin() {
 		return;
 	}
 	skeleton->force_update_deferred();
+}
+
+bool SkeletonModifier3D::should_check_node_path() {
+	return (bool)GLOBAL_GET_CACHED(bool, "animation/warnings/check_invalid_skeleton_modifier_node_paths") && is_inside_tree();
 }
 
 /* Process */

--- a/scene/3d/skeleton_modifier_3d.h
+++ b/scene/3d/skeleton_modifier_3d.h
@@ -114,6 +114,8 @@ protected:
 	GDVIRTUAL0(_process_modification);
 #endif
 
+	bool should_check_node_path();
+
 public:
 	virtual PackedStringArray get_configuration_warnings() const override;
 	virtual bool has_process() const { return false; } // Return true if modifier needs to modify bone pose without external animation such as physics, jiggle and etc.

--- a/scene/3d/spline_ik_3d.cpp
+++ b/scene/3d/spline_ik_3d.cpp
@@ -125,6 +125,9 @@ PackedStringArray SplineIK3D::get_configuration_warnings() const {
 void SplineIK3D::set_path_3d(int p_index, const NodePath &p_path_3d) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	sp_settings[p_index]->path_3d = p_path_3d;
+	if (should_check_node_path() && !p_path_3d.is_empty() && !Object::cast_to<Path3D>(get_node_or_null(p_path_3d))) {
+		WARN_PRINT_ED("Setting: " + itos(p_index) + ": Path3D '" + String(p_path_3d) + "' not found.");
+	}
 	notify_property_list_changed();
 	update_configuration_warnings();
 }

--- a/scene/3d/spring_bone_collision_3d.cpp
+++ b/scene/3d/spring_bone_collision_3d.cpp
@@ -95,7 +95,7 @@ void SpringBoneCollision3D::set_bone(int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (bone <= -1 || bone >= sk->get_bone_count()) {
-			WARN_PRINT("Bone index out of range! Cannot connect BoneAttachment to node!");
+			WARN_PRINT("Bone index '" + itos(p_bone) + "' is out of range! Cannot connect BoneAttachment to node!");
 			bone = -1;
 		} else {
 			bone_name = sk->get_bone_name(bone);

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -461,7 +461,7 @@ void SpringBoneSimulator3D::set_root_bone(int p_index, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (settings[p_index]->root_bone <= -1 || settings[p_index]->root_bone >= sk->get_bone_count()) {
-			WARN_PRINT("Root bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + ": Root bone index '" + itos(p_bone) + "' is out of range!");
 			settings[p_index]->root_bone = -1;
 		} else {
 			settings[p_index]->root_bone_name = sk->get_bone_name(settings[p_index]->root_bone);
@@ -498,7 +498,7 @@ void SpringBoneSimulator3D::set_end_bone(int p_index, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (settings[p_index]->end_bone <= -1 || settings[p_index]->end_bone >= sk->get_bone_count()) {
-			WARN_PRINT("End bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + ": End bone index '" + itos(p_bone) + "' is out of range!");
 			settings[p_index]->end_bone = -1;
 		} else {
 			settings[p_index]->end_bone_name = sk->get_bone_name(settings[p_index]->end_bone);
@@ -594,6 +594,9 @@ SpringBoneSimulator3D::CenterFrom SpringBoneSimulator3D::get_center_from(int p_i
 void SpringBoneSimulator3D::set_center_node(int p_index, const NodePath &p_node_path) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	bool center_changed = settings[p_index]->center_node != p_node_path;
+	if (should_check_node_path() && !p_node_path.is_empty() && !Object::cast_to<Node3D>(get_node_or_null(p_node_path))) {
+		WARN_PRINT_ED("Setting: " + itos(p_index) + ": Center node '" + String(p_node_path) + "' not found.");
+	}
 	settings[p_index]->center_node = p_node_path;
 	if (center_changed) {
 		reset();
@@ -626,7 +629,7 @@ void SpringBoneSimulator3D::set_center_bone(int p_index, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (settings[p_index]->center_bone <= -1 || settings[p_index]->center_bone >= sk->get_bone_count()) {
-			WARN_PRINT("Center bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + ": Center bone index '" + itos(p_bone) + "' is out of range!");
 			settings[p_index]->center_bone = -1;
 		} else {
 			settings[p_index]->center_bone_name = sk->get_bone_name(settings[p_index]->center_bone);
@@ -897,7 +900,7 @@ void SpringBoneSimulator3D::_set_joint_bone(int p_index, int p_joint, int p_bone
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (joints[p_joint]->bone <= -1 || joints[p_joint]->bone >= sk->get_bone_count()) {
-			WARN_PRINT("Joint bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + " : Joint: " + itos(p_joint) + ": bone index '" + itos(p_bone) + "' is out of range!");
 			joints[p_joint]->bone = -1;
 		} else {
 			joints[p_joint]->bone_name = sk->get_bone_name(joints[p_joint]->bone);

--- a/scene/3d/two_bone_ik_3d.cpp
+++ b/scene/3d/two_bone_ik_3d.cpp
@@ -231,7 +231,7 @@ void TwoBoneIK3D::set_root_bone(int p_index, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (tb_settings[p_index]->root_bone.bone <= -1 || tb_settings[p_index]->root_bone.bone >= sk->get_bone_count()) {
-			WARN_PRINT("Root bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + ": Root bone index '" + itos(p_bone) + "' is out of range!");
 			tb_settings[p_index]->root_bone.bone = -1;
 		} else {
 			tb_settings[p_index]->root_bone.name = sk->get_bone_name(tb_settings[p_index]->root_bone.bone);
@@ -268,7 +268,7 @@ void TwoBoneIK3D::set_middle_bone(int p_index, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (tb_settings[p_index]->middle_bone.bone <= -1 || tb_settings[p_index]->middle_bone.bone >= sk->get_bone_count()) {
-			WARN_PRINT("Middle bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + ": Middle bone index '" + itos(p_bone) + "' is out of range!");
 			tb_settings[p_index]->middle_bone.bone = -1;
 			tb_settings[p_index]->use_virtual_end = false; // To sync inspector.
 		} else {
@@ -307,7 +307,7 @@ void TwoBoneIK3D::set_end_bone(int p_index, int p_bone) {
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
 		if (tb_settings[p_index]->end_bone.bone <= -1 || tb_settings[p_index]->end_bone.bone >= sk->get_bone_count()) {
-			WARN_PRINT("End bone index out of range!");
+			WARN_PRINT_ED("Setting: " + itos(p_index) + ": End bone index '" + itos(p_bone) + "' is out of range!");
 			tb_settings[p_index]->end_bone.bone = -1;
 		} else {
 			tb_settings[p_index]->end_bone.name = sk->get_bone_name(tb_settings[p_index]->end_bone.bone);
@@ -405,6 +405,9 @@ float TwoBoneIK3D::get_end_bone_length(int p_index) const {
 void TwoBoneIK3D::set_target_node(int p_index, const NodePath &p_node_path) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	tb_settings[p_index]->target_node = p_node_path;
+	if (should_check_node_path() && !p_node_path.is_empty() && !Object::cast_to<Node3D>(get_node_or_null(p_node_path))) {
+		WARN_PRINT_ED("Setting: " + itos(p_index) + ": Target node '" + String(p_node_path) + "' not found.");
+	}
 	update_configuration_warnings();
 }
 
@@ -416,6 +419,9 @@ NodePath TwoBoneIK3D::get_target_node(int p_index) const {
 void TwoBoneIK3D::set_pole_node(int p_index, const NodePath &p_node_path) {
 	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	tb_settings[p_index]->pole_node = p_node_path;
+	if (should_check_node_path() && !p_node_path.is_empty() && !Object::cast_to<Node3D>(get_node_or_null(p_node_path))) {
+		WARN_PRINT_ED("Setting: " + itos(p_index) + ": Pole node '" + String(p_node_path) + "' not found.");
+	}
 	update_configuration_warnings();
 }
 


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot/issues/115318
- Supersedes / Closes https://github.com/godotengine/godot/pull/115354

For NodePath properties, if a path is assigned and the Modifier is in the scene tree, it will perform a check once via the setter and print a warning. But this can impact performance when paths are intentionally assigned to non-existent elements in the scene, so an option to disable this behavior will be added in Project Settings as same way with the AnimationMixer.

Also, index is now included and printed in bone index validation.