### PR TITLE
Add .inl files to the MSVC solution

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -1151,7 +1151,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
         sys.modules.pop("msvs")
 
     extensions = {}
-    extensions["headers"] = [".h", ".hh", ".hpp", ".hxx", ".inc"]
+    extensions["headers"] = [".h", ".hh", ".hpp", ".hxx", ".inc", ".inl"]
     extensions["sources"] = [".c", ".cc", ".cpp", ".cxx", ".m", ".mm", ".java"]
     extensions["others"] = [".natvis", ".glsl", ".rc"]
 


### PR DESCRIPTION
Several third party libraries are using .inl files which are currently not visible in the MSVC project:

```
thirdparty\jolt_physics\Jolt\Core\FixedSizeFreeList.inl 
thirdparty\jolt_physics\Jolt\Core\JobSystem.inl
thirdparty\jolt_physics\Jolt\Core\LockFreeHashMap.inl 
thirdparty\jolt_physics\Jolt\Core\Profiler.inl
thirdparty\jolt_physics\Jolt\Math\BVec16.inl
thirdparty\jolt_physics\Jolt\Math\DMat44.inl
thirdparty\jolt_physics\Jolt\Math\DVec3.inl
thirdparty\jolt_physics\Jolt\Math\Mat44.inl
thirdparty\jolt_physics\Jolt\Math\Quat.inl
thirdparty\jolt_physics\Jolt\Math\UVec4.inl
thirdparty\jolt_physics\Jolt\Math\Vec3.inl
thirdparty\jolt_physics\Jolt\Math\Vec4.inl
thirdparty\jolt_physics\Jolt\Physics\Body\Body.inl
thirdparty\jolt_physics\Jolt\Physics\Body\MotionProperties.inl 
thirdparty\libktx\external\dfdutils\dfd2vk.inl
thirdparty\libktx\external\dfdutils\vk2dfd.inl
thirdparty\libktx\lib\texture_funcs.inl
thirdparty\openxr\src\external\jsoncpp\src\lib_json\json_valueiterator.inl 
thirdparty\vhacd\inc\vhacdCircularList.inl
thirdparty\vhacd\inc\vhacdVector.inl
thirdparty\vhacd\src\FloatMath.inl
```

This change automatically adds these files to the solution (and makes my life debugging issues in Jolt easier).