### PR TITLE
Optimize `core/input/input.h` header `#include`ing

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -424,12 +424,12 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 	}
 	send_message("debug_enter", msg);
 
-	Input::MouseMode mouse_mode = Input::MOUSE_MODE_VISIBLE;
+	Input::MouseMode mouse_mode = Input::MouseMode::MOUSE_MODE_VISIBLE;
 
 	if (Thread::get_caller_id() == Thread::get_main_id()) {
 		mouse_mode = Input::get_singleton()->get_mouse_mode();
-		if (mouse_mode != Input::MOUSE_MODE_VISIBLE) {
-			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+		if (mouse_mode != Input::MouseMode::MOUSE_MODE_VISIBLE) {
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
 		}
 	} else {
 		MutexLock mutex_lock(mutex);
@@ -630,7 +630,7 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 	send_message("debug_exit", Array());
 
 	if (Thread::get_caller_id() == Thread::get_main_id()) {
-		if (mouse_mode != Input::MOUSE_MODE_VISIBLE) {
+		if (mouse_mode != Input::MouseMode::MOUSE_MODE_VISIBLE) {
 			Input::get_singleton()->set_mouse_mode(mouse_mode);
 		}
 	} else {

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -118,6 +118,8 @@ bool Input::is_mouse_mode_override_enabled() {
 }
 
 void Input::_bind_methods() {
+	using namespace InputClassEnums;
+
 	ClassDB::bind_method(D_METHOD("is_anything_pressed"), &Input::is_anything_pressed);
 	ClassDB::bind_method(D_METHOD("is_key_pressed", "keycode"), &Input::is_key_pressed);
 	ClassDB::bind_method(D_METHOD("is_physical_key_pressed", "keycode"), &Input::is_physical_key_pressed);

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -40,6 +40,40 @@
 
 class GamepadMotion;
 
+namespace InputClassEnums {
+// Keep synced with "DisplayServer::MouseMode" enum.
+enum MouseMode : int {
+	MOUSE_MODE_VISIBLE,
+	MOUSE_MODE_HIDDEN,
+	MOUSE_MODE_CAPTURED,
+	MOUSE_MODE_CONFINED,
+	MOUSE_MODE_CONFINED_HIDDEN,
+	MOUSE_MODE_MAX,
+};
+
+#undef CursorShape
+enum CursorShape : int {
+	CURSOR_ARROW,
+	CURSOR_IBEAM,
+	CURSOR_POINTING_HAND,
+	CURSOR_CROSS,
+	CURSOR_WAIT,
+	CURSOR_BUSY,
+	CURSOR_DRAG,
+	CURSOR_CAN_DROP,
+	CURSOR_FORBIDDEN,
+	CURSOR_VSIZE,
+	CURSOR_HSIZE,
+	CURSOR_BDIAGSIZE,
+	CURSOR_FDIAGSIZE,
+	CURSOR_MOVE,
+	CURSOR_VSPLIT,
+	CURSOR_HSPLIT,
+	CURSOR_HELP,
+	CURSOR_MAX
+};
+} //namespace InputClassEnums
+
 class Input : public Object {
 	GDCLASS(Input, Object);
 	_THREAD_SAFE_CLASS_
@@ -49,37 +83,9 @@ class Input : public Object {
 	static constexpr uint64_t MAX_EVENT = 32;
 
 public:
-	// Keep synced with "DisplayServer::MouseMode" enum.
-	enum MouseMode {
-		MOUSE_MODE_VISIBLE,
-		MOUSE_MODE_HIDDEN,
-		MOUSE_MODE_CAPTURED,
-		MOUSE_MODE_CONFINED,
-		MOUSE_MODE_CONFINED_HIDDEN,
-		MOUSE_MODE_MAX,
-	};
-
-#undef CursorShape
-	enum CursorShape {
-		CURSOR_ARROW,
-		CURSOR_IBEAM,
-		CURSOR_POINTING_HAND,
-		CURSOR_CROSS,
-		CURSOR_WAIT,
-		CURSOR_BUSY,
-		CURSOR_DRAG,
-		CURSOR_CAN_DROP,
-		CURSOR_FORBIDDEN,
-		CURSOR_VSIZE,
-		CURSOR_HSIZE,
-		CURSOR_BDIAGSIZE,
-		CURSOR_FDIAGSIZE,
-		CURSOR_MOVE,
-		CURSOR_VSPLIT,
-		CURSOR_HSPLIT,
-		CURSOR_HELP,
-		CURSOR_MAX
-	};
+	// TODO: When we migrate to C++20, replace these with "using enum" and skip prefixing MouseMode and CursorShape in other files.
+	using MouseMode = InputClassEnums::MouseMode;
+	using CursorShape = InputClassEnums::CursorShape;
 
 	class JoypadFeatures {
 	public:
@@ -217,7 +223,7 @@ private:
 
 	int fallback_mapping = -1; // Index of the guid in map_db.
 
-	CursorShape default_shape = CURSOR_ARROW;
+	CursorShape default_shape = CursorShape::CURSOR_ARROW;
 
 	enum JoyType {
 		TYPE_BUTTON,
@@ -426,7 +432,7 @@ public:
 	CursorShape get_default_cursor_shape() const;
 	void set_default_cursor_shape(CursorShape p_shape);
 	CursorShape get_current_cursor_shape() const;
-	void set_custom_mouse_cursor(const Ref<Resource> &p_cursor, CursorShape p_shape = Input::CURSOR_ARROW, const Vector2 &p_hotspot = Vector2());
+	void set_custom_mouse_cursor(const Ref<Resource> &p_cursor, CursorShape p_shape = Input::CursorShape::CURSOR_ARROW, const Vector2 &p_hotspot = Vector2());
 
 	void parse_mapping(const String &p_mapping);
 	void joy_button(int p_device, JoyButton p_button, bool p_pressed);

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -31,6 +31,7 @@
 #include "filesystem_dock.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"

--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -115,7 +115,7 @@ void EditorSpinSlider::gui_input(const Ref<InputEvent> &p_event) {
 			grabbing_spinner_dist_cache += diff_x * grabbing_spinner_speed;
 
 			if (!grabbing_spinner && Math::abs(grabbing_spinner_dist_cache) > 4 * grabbing_spinner_speed * EDSCALE) {
-				Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);
+				Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
 				grabbing_spinner = true;
 			}
 
@@ -166,7 +166,7 @@ void EditorSpinSlider::_grab_start() {
 void EditorSpinSlider::_grab_end() {
 	if (grabbing_spinner_attempt) {
 		if (grabbing_spinner) {
-			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
 			Input::get_singleton()->warp_mouse(grabbing_spinner_mouse_pos);
 			mouse_over_grabber = true;
 			queue_redraw();
@@ -493,7 +493,7 @@ void EditorSpinSlider::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			if (grabbing_spinner) {
 				grabber->hide();
-				Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+				Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
 				Input::get_singleton()->warp_mouse(grabbing_spinner_mouse_pos);
 				grabbing_spinner = false;
 				grabbing_spinner_attempt = false;

--- a/editor/gui/editor_zoom_widget.cpp
+++ b/editor/gui/editor_zoom_widget.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_zoom_widget.h"
 
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "core/string/translation_server.h"
 #include "editor/settings/editor_settings.h"

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -31,6 +31,7 @@
 #include "editor_inspector.h"
 #include "editor_inspector.compat.inc"
 
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "editor/debugger/editor_debugger_inspector.h"
 #include "editor/doc/doc_tools.h"

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -933,7 +933,7 @@ void EditorPropertyArray::_reorder_button_down(int p_slot_index) {
 	reorder_to_index = reorder_slot.index;
 	// Ideally it'd to be able to show the mouse but I had issues with
 	// Control's `mouse_exit()`/`mouse_entered()` signals not getting called.
-	Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);
+	Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
 }
 
 void EditorPropertyArray::_reorder_button_up() {
@@ -954,7 +954,7 @@ void EditorPropertyArray::_reorder_button_up() {
 		emit_changed(get_edited_property(), array);
 	}
 
-	Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+	Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
 
 	ERR_FAIL_NULL(reorder_slot.reorder_button);
 	reorder_slot.reorder_button->warp_mouse(reorder_slot.reorder_button->get_size() / 2.0f);

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_resource_picker.h"
 
+#include "core/input/input.h"
 #include "editor/audio/audio_stream_preview.h"
 #include "editor/doc/editor_help.h"
 #include "editor/docks/filesystem_dock.h"

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -31,6 +31,7 @@
 #include "project_list.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 #include "core/io/dir_access.h"
 #include "core/os/time.h"
 #include "core/version.h"

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -31,6 +31,7 @@
 #include "project_manager.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 #include "core/io/config_file.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"

--- a/editor/run/embedded_process.cpp
+++ b/editor/run/embedded_process.cpp
@@ -31,6 +31,7 @@
 #include "embedded_process.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 #include "editor/editor_string_names.h"
 #include "scene/main/timer.h"
 #include "scene/main/window.h"

--- a/editor/scene/2d/physics/collision_shape_2d_editor_plugin.cpp
+++ b/editor/scene/2d/physics/collision_shape_2d_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "collision_shape_2d_editor_plugin.h"
 
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -45,6 +45,7 @@
 #include "scene/gui/button.h"
 #include "scene/gui/control.h"
 
+#include "core/input/input.h"
 #include "core/math/geometry_2d.h"
 #include "core/os/keyboard.h"
 

--- a/editor/scene/3d/gizmos/gizmo_3d_helper.cpp
+++ b/editor/scene/3d/gizmos/gizmo_3d_helper.cpp
@@ -30,6 +30,7 @@
 
 #include "gizmo_3d_helper.h"
 
+#include "core/input/input.h"
 #include "core/math/geometry_3d.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -195,8 +195,8 @@ void ViewportNavigationControl::_process_click(int p_index, Vector2 p_position, 
 		}
 	} else {
 		focused_index = -1;
-		if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
-			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
 			Input::get_singleton()->warp_mouse(focused_mouse_start);
 		}
 	}
@@ -204,8 +204,8 @@ void ViewportNavigationControl::_process_click(int p_index, Vector2 p_position, 
 
 void ViewportNavigationControl::_process_drag(int p_index, Vector2 p_position, Vector2 p_relative_position) {
 	if (focused_index == p_index) {
-		if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_VISIBLE) {
-			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);
+		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_VISIBLE) {
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
 			focused_mouse_start = p_position;
 		}
 		focused_pos += p_relative_position;
@@ -455,8 +455,8 @@ void ViewportRotationControl::_process_click(int p_index, Vector2 p_position, bo
 			_update_focus();
 		}
 		orbiting_index = -1;
-		if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
-			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
 			Input::get_singleton()->warp_mouse(orbiting_mouse_start);
 		}
 	}
@@ -466,8 +466,8 @@ void ViewportRotationControl::_process_drag(Ref<InputEventWithModifiers> p_event
 	Point2 mouse_pos = get_local_mouse_position();
 	const bool movement_threshold_passed = original_mouse_pos.distance_to(mouse_pos) > 4 * EDSCALE;
 	if (orbiting_index == p_index && gizmo_activated && movement_threshold_passed) {
-		if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_VISIBLE) {
-			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);
+		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_VISIBLE) {
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
 			orbiting_mouse_start = p_position;
 			viewport->previous_cursor = viewport->cursor;
 		}
@@ -485,8 +485,8 @@ void ViewportRotationControl::gui_input(const Ref<InputEvent> &p_event) {
 	const Ref<InputEventKey> k = p_event;
 
 	if (k.is_valid() && k->is_action_pressed(SNAME("ui_cancel"), false, true)) {
-		if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
-			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
 			Input::get_singleton()->warp_mouse(orbiting_mouse_start);
 			viewport->cursor = viewport->previous_cursor;
 			gizmo_activated = false;
@@ -504,8 +504,8 @@ void ViewportRotationControl::gui_input(const Ref<InputEvent> &p_event) {
 				grab_focus();
 			}
 		} else if (mb->get_button_index() == MouseButton::RIGHT) {
-			if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
-				Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+			if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
+				Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
 				Input::get_singleton()->warp_mouse(orbiting_mouse_start);
 				viewport->cursor = viewport->previous_cursor;
 				gizmo_activated = false;
@@ -1692,7 +1692,7 @@ void Node3DEditorViewport::_reset_transform(TransformType p_type) {
 }
 
 void Node3DEditorViewport::_surface_mouse_enter() {
-	if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
+	if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
 		return;
 	}
 
@@ -1804,7 +1804,7 @@ void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 
 // Helper function to redirect mouse events to the active freelook viewport
 static bool _redirect_freelook_input(const Ref<InputEvent> &p_event, Node3DEditorViewport *p_exclude_viewport = nullptr) {
-	if (Input::get_singleton()->get_mouse_mode() != Input::MOUSE_MODE_CAPTURED) {
+	if (Input::get_singleton()->get_mouse_mode() != Input::MouseMode::MOUSE_MODE_CAPTURED) {
 		return false;
 	}
 
@@ -2291,7 +2291,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 	Vector<ShortcutCheckSet> shortcut_check_sets;
 
-	if (Input::get_singleton()->get_mouse_mode() != Input::MOUSE_MODE_CAPTURED) {
+	if (Input::get_singleton()->get_mouse_mode() != Input::MouseMode::MOUSE_MODE_CAPTURED) {
 		ViewportNavMouseButton orbit_mouse_preference = (ViewportNavMouseButton)EDITOR_GET("editors/3d/navigation/orbit_mouse_button").operator int();
 		ViewportNavMouseButton pan_mouse_preference = (ViewportNavMouseButton)EDITOR_GET("editors/3d/navigation/pan_mouse_button").operator int();
 		ViewportNavMouseButton zoom_mouse_preference = (ViewportNavMouseButton)EDITOR_GET("editors/3d/navigation/zoom_mouse_button").operator int();
@@ -3009,7 +3009,7 @@ void Node3DEditorViewport::set_freelook_active(bool active_now) {
 		spatial_editor->set_freelook_viewport(this);
 
 		// Hide mouse like in an FPS (warping doesn't work)
-		Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);
+		Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
 
 	} else if (freelook_active && !active_now) {
 		// Sync camera cursor to cursor to "cut" interpolation jumps due to changing referential
@@ -3018,7 +3018,7 @@ void Node3DEditorViewport::set_freelook_active(bool active_now) {
 		spatial_editor->set_freelook_viewport(nullptr);
 
 		// Restore mouse
-		Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+		Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
 
 		// Restore the previous mouse position when leaving freelook mode.
 		// This is done because leaving `Input.MOUSE_MODE_CAPTURED` will center the cursor
@@ -6678,7 +6678,7 @@ void Node3DEditorViewportContainer::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			if (mouseover && Input::get_singleton()->get_mouse_mode() != Input::MOUSE_MODE_CAPTURED) {
+			if (mouseover && Input::get_singleton()->get_mouse_mode() != Input::MouseMode::MOUSE_MODE_CAPTURED) {
 				Ref<Texture2D> h_grabber = get_theme_icon(SNAME("grabber"), SNAME("HSplitContainer"));
 				Ref<Texture2D> v_grabber = get_theme_icon(SNAME("grabber"), SNAME("VSplitContainer"));
 

--- a/editor/scene/gradient_editor_plugin.cpp
+++ b/editor/scene/gradient_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "gradient_editor_plugin.h"
 
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "sprite_frames_editor_plugin.h"
 
+#include "core/input/input.h"
 #include "core/io/resource_loader.h"
 #include "core/os/keyboard.h"
 #include "core/string/translation_server.h"

--- a/editor/scene/texture/gradient_texture_2d_editor_plugin.cpp
+++ b/editor/scene/texture/gradient_texture_2d_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "gradient_texture_2d_editor_plugin.h"
 
+#include "core/input/input.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_spin_slider.h"
 #include "editor/themes/editor_scale.h"

--- a/editor/scene/texture/texture_layered_editor_plugin.cpp
+++ b/editor/scene/texture/texture_layered_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "texture_layered_editor_plugin.h"
 
+#include "core/input/input.h"
 #include "editor/editor_string_names.h"
 #include "editor/scene/texture/color_channel_selector.h"
 #include "editor/themes/editor_scale.h"
@@ -151,8 +152,8 @@ void TextureLayeredEditor::gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid() && mm->get_button_mask().has_flag(MouseButtonMask::RIGHT)) {
-		if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_VISIBLE) {
-			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);
+		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_VISIBLE) {
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
 		}
 
 		y_rot += mm->get_relative().x * 0.01;
@@ -163,10 +164,10 @@ void TextureLayeredEditor::gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::RIGHT) {
-		if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
-			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
 			Input::get_singleton()->warp_mouse(original_mouse_pos);
-		} else if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_VISIBLE) {
+		} else if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_VISIBLE) {
 			original_mouse_pos = mb->get_global_position();
 		}
 	}

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -31,6 +31,7 @@
 #include "script_text_editor.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 #include "core/io/dir_access.h"
 #include "core/io/json.h"
 #include "core/math/expression.h"

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -31,6 +31,7 @@
 #include "visual_shader_editor_plugin.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 #include "core/io/resource_loader.h"
 #include "core/math/math_defs.h"
 #include "core/os/keyboard.h"

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3719,7 +3719,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 				GLOBAL_GET("display/mouse_cursor/custom_image"));
 		if (cursor.is_valid()) {
 			Vector2 hotspot = GLOBAL_GET("display/mouse_cursor/custom_image_hotspot");
-			Input::get_singleton()->set_custom_mouse_cursor(cursor, Input::CURSOR_ARROW, hotspot);
+			Input::get_singleton()->set_custom_mouse_cursor(cursor, Input::CursorShape::CURSOR_ARROW, hotspot);
 		}
 	}
 

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "grid_map_editor_plugin.h"
 
+#include "core/input/input.h"
 #include "core/math/geometry_2d.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_main_screen.h"
@@ -736,7 +737,7 @@ void GridMapEditor::_show_viewports_transform_gizmo(bool p_value) {
 EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D *p_camera, const Ref<InputEvent> &p_event) {
 	// If the mouse is currently captured, we are most likely in freelook mode.
 	// In this case, disable shortcuts to avoid conflicts with freelook navigation.
-	if (!node || Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
+	if (!node || Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
 		return EditorPlugin::AFTER_GUI_INPUT_PASS;
 	}
 

--- a/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_obstacle_3d_editor_plugin.h"
 
+#include "core/input/input.h"
 #include "core/math/geometry_2d.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/platform/android/android_input_handler.cpp
+++ b/platform/android/android_input_handler.cpp
@@ -30,6 +30,8 @@
 
 #include "android_input_handler.h"
 
+#include "core/input/input.h"
+
 #include "android_keys_utils.h"
 #include "display_server_android.h"
 

--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -30,7 +30,8 @@
 
 #pragma once
 
-#include "core/input/input.h"
+#include "core/input/input_event.h"
+#include "core/templates/rb_map.h"
 
 // This class encapsulates all the handling of input events that come from the Android UI thread.
 // Remarks:

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -36,6 +36,7 @@
 #include "tts_android.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 
 #if defined(RD_ENABLED)
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/input/input_event.h"
 #include "servers/display/display_server.h"
 
 #if defined(RD_ENABLED)

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -40,6 +40,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/extension/gdextension_manager.h"
+#include "core/input/input.h"
 #include "core/io/xml_parser.h"
 #include "core/os/main_loop.h"
 #include "core/profiling/profiling.h"

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -32,7 +32,8 @@
 
 #include "crash_handler_linuxbsd.h"
 
-#include "core/input/input.h"
+#include "core/input/input_event.h"
+#include "core/templates/rb_map.h"
 #include "drivers/alsa/audio_driver_alsa.h"
 #include "drivers/alsamidi/midi_driver_alsamidi.h"
 #include "drivers/pulseaudio/audio_driver_pulseaudio.h"

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -39,6 +39,7 @@
 #define DEBUG_LOG_WAYLAND(...)
 #endif
 
+#include "core/input/input.h"
 #include "core/os/main_loop.h"
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -58,7 +58,8 @@
 #endif
 
 #include "core/config/project_settings.h"
-#include "core/input/input.h"
+#include "core/input/input_event.h"
+#include "core/templates/rb_map.h"
 #include "servers/display/display_server.h"
 
 #include <climits>

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -86,6 +86,7 @@
 #endif // SOWRAP_ENABLED
 #endif // LIBDECOR_ENABLED
 
+#include "core/input/input_event.h"
 #include "core/os/thread.h"
 #include "servers/display/display_server.h"
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -36,6 +36,7 @@
 #include "x11/key_mapping_x11.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 #include "core/io/file_access.h"
 #include "core/math/math_funcs.h"
 #include "core/os/main_loop.h"

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -32,10 +32,11 @@
 
 #ifdef X11_ENABLED
 
-#include "core/input/input.h"
+#include "core/input/input_event.h"
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
 #include "core/templates/local_vector.h"
+#include "core/templates/rb_map.h"
 #include "drivers/alsa/audio_driver_alsa.h"
 #include "drivers/alsamidi/midi_driver_alsamidi.h"
 #include "drivers/pulseaudio/audio_driver_pulseaudio.h"

--- a/platform/macos/editor/embedded_game_view_plugin.mm
+++ b/platform/macos/editor/embedded_game_view_plugin.mm
@@ -32,6 +32,7 @@
 
 #include "embedded_process_macos.h"
 
+#include "core/input/input.h"
 #include "editor/editor_node.h"
 #include "editor/gui/window_wrapper.h"
 

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -32,7 +32,8 @@
 
 #include "crash_handler_macos.h"
 
-#include "core/input/input.h"
+#include "core/input/input_event.h"
+#include "core/templates/rb_map.h"
 #import "drivers/coreaudio/audio_driver_coreaudio.h"
 #import "drivers/coremidi/midi_driver_coremidi.h"
 #include "drivers/unix/os_unix.h"

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -39,6 +39,7 @@
 #import "godot_application_delegate.h"
 
 #include "core/crypto/crypto_core.h"
+#include "core/input/input.h"
 #include "core/io/file_access.h"
 #include "core/os/main_loop.h"
 #include "core/profiling/profiling.h"

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -35,6 +35,7 @@
 #include "os_web.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 #include "core/object/callable_method_pointer.h"
 #include "core/os/main_loop.h"
 #include "servers/rendering/dummy/rasterizer_dummy.h"

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -35,7 +35,8 @@
 
 #include "godot_js.h"
 
-#include "core/input/input.h"
+#include "core/input/input_event.h"
+#include "core/templates/rb_map.h"
 #include "drivers/unix/os_unix.h"
 #include "servers/audio/audio_server.h"
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -36,6 +36,7 @@
 #include "wgl_detect_version.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 #include "core/io/file_access.h"
 #include "core/io/marshalls.h"
 #include "core/io/xml_parser.h"

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -35,9 +35,10 @@
 #include "tts_windows.h"
 
 #include "core/config/project_settings.h"
-#include "core/input/input.h"
+#include "core/input/input_event.h"
 #include "core/io/image.h"
 #include "core/os/os.h"
+#include "core/templates/rb_map.h"
 #include "drivers/wasapi/audio_driver_wasapi.h"
 #include "drivers/winmidi/midi_driver_winmidi.h"
 #include "servers/audio/audio_server.h"

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -34,8 +34,9 @@
 #include "key_mapping_windows.h"
 
 #include "core/config/project_settings.h"
-#include "core/input/input.h"
+#include "core/input/input_event.h"
 #include "core/os/os.h"
+#include "core/templates/rb_map.h"
 #include "drivers/wasapi/audio_driver_wasapi.h"
 #include "drivers/winmidi/midi_driver_winmidi.h"
 #include "servers/audio/audio_server.h"

--- a/scene/2d/physics/touch_screen_button.cpp
+++ b/scene/2d/physics/touch_screen_button.cpp
@@ -30,6 +30,7 @@
 
 #include "touch_screen_button.h"
 
+#include "core/input/input.h"
 #include "scene/main/viewport.h"
 
 void TouchScreenButton::set_texture_normal(const Ref<Texture2D> &p_texture) {

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/engine_debugger.h"
+#include "core/input/input.h"
 #include "core/io/dir_access.h"
 #include "core/io/marshalls.h"
 #include "core/io/resource_loader.h"
@@ -2965,11 +2966,11 @@ void RuntimeNodeSelect::_set_camera_freelook_enabled(bool p_enabled) {
 		previous_mouse_position = SceneTree::get_singleton()->get_root()->get_mouse_position();
 
 		// Hide mouse like in an FPS (warping doesn't work).
-		Input::get_singleton()->set_mouse_mode_override(Input::MOUSE_MODE_CAPTURED);
+		Input::get_singleton()->set_mouse_mode_override(Input::MouseMode::MOUSE_MODE_CAPTURED);
 
 	} else {
 		// Restore mouse.
-		Input::get_singleton()->set_mouse_mode_override(Input::MOUSE_MODE_VISIBLE);
+		Input::get_singleton()->set_mouse_mode_override(Input::MouseMode::MOUSE_MODE_VISIBLE);
 
 		// Restore the previous mouse position when leaving freelook mode.
 		// This is done because leaving `Input.MOUSE_MODE_CAPTURED` will center the cursor

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -32,6 +32,7 @@
 #include "code_edit.compat.inc"
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "core/string/string_builder.h"
 #include "core/string/translation_server.h"

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -30,6 +30,7 @@
 
 #include "color_picker.h"
 
+#include "core/input/input.h"
 #include "core/io/image.h"
 #include "core/math/expression.h"
 #include "scene/gui/color_mode.h"

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -30,6 +30,7 @@
 
 #include "color_picker_shape.h"
 
+#include "core/input/input.h"
 #include "scene/gui/margin_container.h"
 #include "scene/resources/material.h"
 #include "thirdparty/misc/ok_color_shader.h"

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -32,6 +32,7 @@
 #include "line_edit.compat.inc"
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 #include "core/input/input_map.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -30,6 +30,7 @@
 
 #include "slider.h"
 
+#include "core/input/input.h"
 #include "scene/theme/theme_db.h"
 
 Size2 Slider::get_minimum_size() const {

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -218,9 +218,9 @@ void SpinBox::_range_click_timeout() {
 void SpinBox::_release_mouse_from_drag_mode() {
 	if (drag.enabled) {
 		drag.enabled = false;
-		Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_HIDDEN);
+		Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_HIDDEN);
 		warp_mouse(drag.capture_pos);
-		Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+		Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
 	}
 }
 
@@ -348,7 +348,7 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 			double diff_y = -0.01 * Math::pow(Math::abs(drag.diff_y), 1.8) * SIGN(drag.diff_y);
 			set_value(CLAMP(drag.base_val + step * diff_y, get_min(), get_max()));
 		} else if (drag.allowed && drag.capture_pos.distance_to(mm->get_position()) > 2) {
-			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
 			drag.enabled = true;
 			drag.base_val = get_value();
 			drag.diff_y = 0;

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -30,6 +30,7 @@
 
 #include "tab_bar.h"
 
+#include "core/input/input.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/texture_rect.h"

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4019,7 +4019,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 					range_drag_enabled = true;
 					range_drag_capture_pos = cpos;
 					range_drag_base = popup_edited_item->get_range(popup_edited_item_col);
-					Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);
+					Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
 				}
 			} else {
 				const TreeItem::Cell &c = popup_edited_item->cells[popup_edited_item_col];
@@ -4079,7 +4079,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 				if (pressing_for_editor) {
 					if (range_drag_enabled) {
 						range_drag_enabled = false;
-						Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+						Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
 						warp_mouse(range_drag_capture_pos);
 					} else {
 						Rect2 rect = _get_item_focus_rect(get_selected());
@@ -5439,7 +5439,7 @@ void Tree::clear() {
 	if (pressing_for_editor) {
 		if (range_drag_enabled) {
 			range_drag_enabled = false;
-			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
 			warp_mouse(range_drag_capture_pos);
 		}
 		pressing_for_editor = false;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
+#include "core/input/input.h"
 #include "core/templates/pair.h"
 #include "core/templates/sort_array.h"
 #include "scene/gui/control.h"
@@ -754,7 +755,7 @@ void Viewport::_process_picking() {
 	if (!physics_object_picking) {
 		return;
 	}
-	if (Object::cast_to<Window>(this) && Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
+	if (Object::cast_to<Window>(this) && Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED) {
 		return;
 	}
 	if (!gui.mouse_in_viewport || gui.subwindow_over) {
@@ -3576,7 +3577,7 @@ void Viewport::_push_unhandled_input_internal(const Ref<InputEvent> &p_event) {
 
 #if !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)
 	if (physics_object_picking && !is_input_handled()) {
-		if (Input::get_singleton()->get_mouse_mode() != Input::MOUSE_MODE_CAPTURED &&
+		if (Input::get_singleton()->get_mouse_mode() != Input::MouseMode::MOUSE_MODE_CAPTURED &&
 				(Object::cast_to<InputEventMouse>(*p_event) ||
 						Object::cast_to<InputEventScreenDrag>(*p_event) ||
 						Object::cast_to<InputEventScreenTouch>(*p_event)

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
+#include "core/input/input.h"
 #include "scene/gui/control.h"
 #include "scene/theme/theme_db.h"
 #include "scene/theme/theme_owner.h"

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -31,6 +31,8 @@
 #include "display_server.h"
 #include "display_server.compat.inc"
 
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Input);
+
 #include "core/input/input.h"
 #include "scene/resources/texture.h"
 #include "servers/display/display_server_headless.h"
@@ -1935,20 +1937,20 @@ DisplayServer *DisplayServer::create(int p_index, const String &p_rendering_driv
 	return server_create_functions[p_index].create_function(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, p_context, p_parent_window, r_error);
 }
 
-void DisplayServer::_input_set_mouse_mode(Input::MouseMode p_mode) {
+void DisplayServer::_input_set_mouse_mode(InputClassEnums::MouseMode p_mode) {
 	singleton->mouse_set_mode(MouseMode(p_mode));
 }
 
-Input::MouseMode DisplayServer::_input_get_mouse_mode() {
-	return Input::MouseMode(singleton->mouse_get_mode());
+InputClassEnums::MouseMode DisplayServer::_input_get_mouse_mode() {
+	return InputClassEnums::MouseMode(singleton->mouse_get_mode());
 }
 
-void DisplayServer::_input_set_mouse_mode_override(Input::MouseMode p_mode) {
+void DisplayServer::_input_set_mouse_mode_override(InputClassEnums::MouseMode p_mode) {
 	singleton->mouse_set_mode_override(MouseMode(p_mode));
 }
 
-Input::MouseMode DisplayServer::_input_get_mouse_mode_override() {
-	return Input::MouseMode(singleton->mouse_get_mode_override());
+InputClassEnums::MouseMode DisplayServer::_input_get_mouse_mode_override() {
+	return InputClassEnums::MouseMode(singleton->mouse_get_mode_override());
 }
 
 void DisplayServer::_input_set_mouse_mode_override_enabled(bool p_enabled) {
@@ -1963,11 +1965,11 @@ void DisplayServer::_input_warp(const Vector2 &p_to_pos) {
 	singleton->warp_mouse(p_to_pos);
 }
 
-Input::CursorShape DisplayServer::_input_get_current_cursor_shape() {
-	return (Input::CursorShape)singleton->cursor_get_shape();
+InputClassEnums::CursorShape DisplayServer::_input_get_current_cursor_shape() {
+	return (InputClassEnums::CursorShape)singleton->cursor_get_shape();
 }
 
-void DisplayServer::_input_set_custom_mouse_cursor_func(const Ref<Resource> &p_image, Input::CursorShape p_shape, const Vector2 &p_hotspot) {
+void DisplayServer::_input_set_custom_mouse_cursor_func(const Ref<Resource> &p_image, InputClassEnums::CursorShape p_shape, const Vector2 &p_hotspot) {
 	singleton->cursor_set_custom_image(p_image, (CursorShape)p_shape, p_hotspot);
 }
 

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -30,15 +30,23 @@
 
 #pragma once
 
-#include "core/input/input.h"
+#include "core/input/input_event.h"
 #include "core/io/image.h"
 #include "core/io/resource.h"
 #include "core/os/os.h"
+#include "core/templates/rb_map.h"
+#include "core/templates/rb_set.h"
 #include "core/variant/callable.h"
+#include "core/variant/typed_array.h"
 #include "servers/display/native_menu.h"
 
 class Texture2D;
 class AccessibilityDriver;
+
+namespace InputClassEnums {
+enum MouseMode : int;
+enum CursorShape : int;
+} //namespace InputClassEnums
 
 class DisplayServer : public Object {
 	GDCLASS(DisplayServer, Object)
@@ -96,15 +104,15 @@ public:
 	typedef Vector<String> (*GetRenderingDriversFunction)();
 
 private:
-	static void _input_set_mouse_mode(Input::MouseMode p_mode);
-	static Input::MouseMode _input_get_mouse_mode();
-	static void _input_set_mouse_mode_override(Input::MouseMode p_mode);
-	static Input::MouseMode _input_get_mouse_mode_override();
+	static void _input_set_mouse_mode(InputClassEnums::MouseMode p_mode);
+	static InputClassEnums::MouseMode _input_get_mouse_mode();
+	static void _input_set_mouse_mode_override(InputClassEnums::MouseMode p_mode);
+	static InputClassEnums::MouseMode _input_get_mouse_mode_override();
 	static void _input_set_mouse_mode_override_enabled(bool p_enabled);
 	static bool _input_is_mouse_mode_override_enabled();
 	static void _input_warp(const Vector2 &p_to_pos);
-	static Input::CursorShape _input_get_current_cursor_shape();
-	static void _input_set_custom_mouse_cursor_func(const Ref<Resource> &, Input::CursorShape, const Vector2 &p_hotspot);
+	static InputClassEnums::CursorShape _input_get_current_cursor_shape();
+	static void _input_set_custom_mouse_cursor_func(const Ref<Resource> &, InputClassEnums::CursorShape, const Vector2 &p_hotspot);
 
 protected:
 	static void _bind_methods();
@@ -287,12 +295,12 @@ public:
 	static void set_early_window_clear_color_override(bool p_enabled, Color p_color = Color(0, 0, 0, 0));
 
 	enum MouseMode {
-		MOUSE_MODE_VISIBLE = Input::MOUSE_MODE_VISIBLE,
-		MOUSE_MODE_HIDDEN = Input::MOUSE_MODE_HIDDEN,
-		MOUSE_MODE_CAPTURED = Input::MOUSE_MODE_CAPTURED,
-		MOUSE_MODE_CONFINED = Input::MOUSE_MODE_CONFINED,
-		MOUSE_MODE_CONFINED_HIDDEN = Input::MOUSE_MODE_CONFINED_HIDDEN,
-		MOUSE_MODE_MAX = Input::MOUSE_MODE_MAX,
+		MOUSE_MODE_VISIBLE, // Input::MouseMode::MOUSE_MODE_VISIBLE
+		MOUSE_MODE_HIDDEN, // Input::MouseMode::MOUSE_MODE_HIDDEN
+		MOUSE_MODE_CAPTURED, // Input::MouseMode::MOUSE_MODE_CAPTURED
+		MOUSE_MODE_CONFINED, // Input::MouseMode::MOUSE_MODE_CONFINED
+		MOUSE_MODE_CONFINED_HIDDEN, // Input::MouseMode::MOUSE_MODE_CONFINED_HIDDEN
+		MOUSE_MODE_MAX, // Input::MouseMode::MOUSE_MODE_MAX
 	};
 
 	virtual void mouse_set_mode(MouseMode p_mode);

--- a/servers/display/display_server_headless.h
+++ b/servers/display/display_server_headless.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/input/input.h"
 #include "servers/display/display_server.h"
 
 #include "servers/rendering/dummy/rasterizer_dummy.h"

--- a/servers/display/native_menu.h
+++ b/servers/display/native_menu.h
@@ -30,7 +30,8 @@
 
 #pragma once
 
-#include "core/input/input.h"
+#include "core/input/input_event.h"
+#include "core/templates/rb_map.h"
 #include "core/variant/callable.h"
 
 class Texture2D;

--- a/servers/rendering/renderer_rd/pipeline_hash_map_rd.h
+++ b/servers/rendering/renderer_rd/pipeline_hash_map_rd.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/rb_set.h"
 #include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server.h"
 

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -34,6 +34,7 @@
 #include "core/os/condition_variable.h"
 #include "core/os/thread_safe.h"
 #include "core/templates/local_vector.h"
+#include "core/templates/rb_map.h"
 #include "core/templates/rid_owner.h"
 #include "core/variant/typed_array.h"
 #include "servers/display/display_server.h"


### PR DESCRIPTION
- Bugsquad edit: Helps address https://github.com/godotengine/godot/issues/111218

This PR optimizes `#include`ing of `input.h` header.
Each time I modify this header to improve an input feature I have to wait around 50 minutes (!) for the Windows editor to recompile, it's frustrating. 😅
That's why I decided to make this PR, so I (and other people that modify this file) won't have to wait too long.
I use GitHub CI to compile the engine (I think I don't have enough RAM to compile the engine on my laptop), and I think I can check the compilation times before and after this change.
I will compare between 2 CI runs, [one of them](https://github.com/Nintorch/godot/actions/runs/21329014956) was when I decided to rename the methods in my joypad motion sensors pr (`sensors` -> `motion`, so for example, `has_joy_sensors()` -> `has_joy_motion()`) and [the other one](https://github.com/Nintorch/godot/actions/runs/21332682290) is a test change just to test the compilation times after this PR.
<details>
<summary>Here are the results</summary>

<img width="712" height="821" alt="image" src="https://github.com/user-attachments/assets/28b2ae15-33cb-4715-8cf9-c1ace3ef1c4d" />
</details>

So now the engine recompiles roughly 3-5 times faster when you edit `core/input/input.h`! (Unless I'm misunderstanding something)