### PR TITLE
[Import] Automatically disable hinting for pixel fonts.

### DIFF
--- a/doc/classes/ResourceImporterDynamicFont.xml
+++ b/doc/classes/ResourceImporterDynamicFont.xml
@@ -38,11 +38,13 @@
 			If [code]true[/code], this font will have mipmaps generated. This prevents text from looking grainy when a [Control] is scaled down, or when a [Label3D] is viewed from a long distance (if [member Label3D.texture_filter] is set to a mode that displays mipmaps).
 			Enabling [member generate_mipmaps] increases font generation time and memory usage. Only enable this setting if you actually need it.
 		</member>
-		<member name="hinting" type="int" setter="" getter="" default="1">
+		<member name="hinting" type="int" setter="" getter="" default="3">
 			The hinting mode to use. This controls how aggressively glyph edges should be snapped to pixels when rasterizing the font. Depending on personal preference, you may prefer using one hinting mode over the other. Hinting modes other than [b]None[/b] are only effective if the font contains hinting data (see [member force_autohinter]).
 			[b]None:[/b] Smoothest appearance, which can make the font look blurry at small sizes.
 			[b]Light:[/b] Sharp result by snapping glyph edges to pixels on the Y axis only.
 			[b]Normal:[/b] Sharpest by snapping glyph edges to pixels on both X and Y axes.
+			[b]Light (Except Pixel Fonts):[/b] [b]Disabled[/b] for pixel style fonts (each glyph's contours contain only straight horizontal and vertical lines), [b]Light[/b] for other fonts.
+			[b]Normal (Except Pixel Fonts):[/b] [b]Disabled[/b] for pixel style fonts (each glyph's contours contain only straight horizontal and vertical lines), [b]Normal[/b] for other fonts.
 		</member>
 		<member name="keep_rounding_remainders" type="bool" setter="" getter="" default="true">
 			If set to [code]true[/code], when aligning glyphs to the pixel boundaries rounding remainders are accumulated to ensure more uniform glyph distribution. This setting has no effect if subpixel positioning is enabled.
@@ -81,7 +83,7 @@
 			[b]Auto:[/b] Use subpixel positioning at small font sizes (the chosen quality varies depending on font size). Large fonts will not use subpixel positioning. This is a good tradeoff between performance and quality.
 			[b]One Half of a Pixel:[/b] Always perform intermediate subpixel positioning regardless of font size. High quality, slow rendering.
 			[b]One Quarter of a Pixel:[/b] Always perform precise subpixel positioning regardless of font size. Highest quality, slowest rendering.
-			[b]Auto (Except Pixel Fonts):[/b] [b]Disabled[/b] for the pixel style fonts (each glyph contours contain only straight horizontal and vertical lines), [b]Auto[/b] for the other fonts.
+			[b]Auto (Except Pixel Fonts):[/b] [b]Disabled[/b] for pixel style fonts (each glyph's contours contain only straight horizontal and vertical lines), [b]Auto[/b] for other fonts.
 		</member>
 	</members>
 </class>

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -144,7 +144,21 @@ void DynamicFontImportSettingsDialog::_main_prop_changed(const String &p_edited_
 		} else if (p_edited_property == "modulate_color_glyphs") {
 			font_preview->set_modulate_color_glyphs(import_settings_data->get("modulate_color_glyphs"));
 		} else if (p_edited_property == "hinting") {
-			font_preview->set_hinting((TextServer::Hinting)import_settings_data->get("hinting").operator int());
+			int hinting = import_settings_data->get("hinting").operator int();
+			if (hinting == 3) { // Light (Except Pixel Fonts)
+				if (is_pixel) {
+					hinting = TextServer::HINTING_NONE;
+				} else {
+					hinting = TextServer::HINTING_LIGHT;
+				}
+			} else if (hinting == 4) { // Normal (Except Pixel Fonts)
+				if (is_pixel) {
+					hinting = TextServer::HINTING_NONE;
+				} else {
+					hinting = TextServer::HINTING_NORMAL;
+				}
+			}
+			font_preview->set_hinting((TextServer::Hinting)hinting);
 		} else if (p_edited_property == "subpixel_positioning") {
 			int font_subpixel_positioning = import_settings_data->get("subpixel_positioning").operator int();
 			if (font_subpixel_positioning == 4 /* Auto (Except Pixel Fonts) */) {
@@ -939,7 +953,21 @@ void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 		font_preview->set_allow_system_fallback(import_settings_data->get("allow_system_fallback"));
 		font_preview->set_force_autohinter(import_settings_data->get("force_autohinter"));
 		font_preview->set_modulate_color_glyphs(import_settings_data->get("modulate_color_glyphs"));
-		font_preview->set_hinting((TextServer::Hinting)import_settings_data->get("hinting").operator int());
+		int hinting = import_settings_data->get("hinting").operator int();
+		if (hinting == 3) { // Light (Except Pixel Fonts)
+			if (is_pixel) {
+				hinting = TextServer::HINTING_NONE;
+			} else {
+				hinting = TextServer::HINTING_LIGHT;
+			}
+		} else if (hinting == 4) { // Normal (Except Pixel Fonts)
+			if (is_pixel) {
+				hinting = TextServer::HINTING_NONE;
+			} else {
+				hinting = TextServer::HINTING_NORMAL;
+			}
+		}
+		font_preview->set_hinting((TextServer::Hinting)hinting);
 		int font_subpixel_positioning = import_settings_data->get("subpixel_positioning").operator int();
 		if (font_subpixel_positioning == 4 /* Auto (Except Pixel Fonts) */) {
 			if (is_pixel) {
@@ -981,7 +1009,7 @@ DynamicFontImportSettingsDialog::DynamicFontImportSettingsDialog() {
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, "allow_system_fallback"), true));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, "force_autohinter"), false));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, "modulate_color_glyphs"), false));
-	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal"), 1));
+	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal,Light (Except Pixel Fonts),Normal (Except Pixel Fonts)"), 3));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::INT, "subpixel_positioning", PROPERTY_HINT_ENUM, "Disabled,Auto,One Half of a Pixel,One Quarter of a Pixel,Auto (Except Pixel Fonts)"), 4));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, "keep_rounding_remainders"), true));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::FLOAT, "oversampling", PROPERTY_HINT_RANGE, "0,10,0.1"), 0.0));


### PR DESCRIPTION
Disables hinting when pseudo pixel font is detected (same detection as used for disabling subpixel rendering).

Should prevent issues like https://github.com/godotengine/godot/issues/115365 for new imports.