### PR TITLE
Fix crash on removing Windows PopupMenu submenu

### DIFF
--- a/platform/windows/native_menu_windows.cpp
+++ b/platform/windows/native_menu_windows.cpp
@@ -996,15 +996,15 @@ void NativeMenuWindows::set_item_submenu(const RID &p_rid, int p_idx, const RID 
 	int count = GetMenuItemCount(md->menu);
 	ERR_FAIL_COND(p_idx >= count);
 
-	MenuData *md_sub = menus.get_or_null(p_submenu_rid);
-	ERR_FAIL_COND_MSG(md->menu == md_sub->menu, "Can't set submenu to self!");
-
 	MENUITEMINFOW item;
 	ZeroMemory(&item, sizeof(item));
 	item.cbSize = sizeof(item);
 	item.fMask = MIIM_SUBMENU;
 	if (GetMenuItemInfoW(md->menu, p_idx, true, &item)) {
 		if (p_submenu_rid.is_valid()) {
+			MenuData *md_sub = menus.get_or_null(p_submenu_rid);
+			ERR_FAIL_NULL(md_sub);
+			ERR_FAIL_COND_MSG(md->menu == md_sub->menu, "Can't set submenu to self!");
 			item.hSubMenu = md_sub->menu;
 		} else {
 			item.hSubMenu = nullptr;


### PR DESCRIPTION
When freeing a node that has a native Windows PopupMenu with a submenu, it crashes.
This happens since 4.3 as far as I can tell.

Reproduction example script:
```gdscript
func _ready() -> void:
	var submenu := PopupMenu.new()
	submenu.add_item("b")
	var menu := PopupMenu.new()
	menu.prefer_native_menu = true
	menu.add_submenu_node_item("a", submenu)
	add_child(menu)
	queue_free() # also happens on exit without this line
```

`p_submenu_rid` does not need to be valid, so I put the code that uses it into the if statement.