### PR TITLE
Fix error in debugger while changing scene on button clicked with touchscreen

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -907,8 +907,7 @@ bool Node::can_process_notification(int p_what) const {
 }
 
 bool Node::can_process() const {
-	ERR_FAIL_COND_V(!is_inside_tree(), false);
-	return !data.tree->is_suspended() && _can_process(data.tree->is_paused());
+	return is_inside_tree() && !data.tree->is_suspended() && _can_process(data.tree->is_paused());
 }
 
 bool Node::_can_process(bool p_paused) const {


### PR DESCRIPTION
When changing scenes via button click with a touchscreen, nodes can be removed from the tree during input event processing. The ERR_FAIL_COND_V assertion in can_process() would trigger an error when called on nodes already removed from the tree. Changed to return false instead of asserting, which is the correct behavior for nodes not in the tree.

I modified Node::canprocess in node.cpp to return false when a node isn't in a tree rather than trying to assert it. 

This should fix #115376 