### PR TITLE
Fix error after setting native PopupMenu item ID

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -2108,9 +2108,7 @@ void PopupMenu::set_item_id(int p_idx, int p_id) {
 
 	items.write[p_idx].id = p_id;
 
-	if (global_menu.is_valid()) {
-		NativeMenu::get_singleton()->set_item_tag(global_menu, p_idx, p_id);
-	}
+	// `global_menu` does not know about IDs so there is no need to update it.
 
 	control->queue_redraw();
 	child_controls_changed();


### PR DESCRIPTION
`set_item_id` changes the NativeMenu tag to the ID, but the tag is should always be the index.
Reproducible since at least 4.3

When clicking on an item that had its ID changed to a value outside of the index range, it will error:
`ERROR: Index p_idx = 103 is out of bounds (items.size() = 2).`

Example reproduction script:
```gdscript
	var menu := PopupMenu.new()
	menu.prefer_native_menu = true
	menu.add_item("a", 101)
	menu.add_item("b", 102)
	menu.set_item_id(1, 103)
	add_child(menu)
	menu.popup()
	# now click on item 1 ("b")
```

Added comment just in case, since most other `set_item_*` functions have something with the `global_menu` here.