### PR TITLE
iOS: Allow building with `opengl3=no`

### DIFF
--- a/platform/ios/display_layer_ios.h
+++ b/platform/ios/display_layer_ios.h
@@ -32,7 +32,9 @@
 
 #include "drivers/apple_embedded/display_layer_apple_embedded.h"
 
+#if defined(GLES3_ENABLED)
 #import <OpenGLES/EAGLDrawable.h>
+#endif
 #import <QuartzCore/QuartzCore.h>
 
 // An ugly workaround for iOS simulator
@@ -48,7 +50,9 @@ API_AVAILABLE(ios(13.0))
 #endif
 @end
 
+#if defined(GLES3_ENABLED)
 API_DEPRECATED("OpenGLES is deprecated", ios(2.0, 12.0))
 @interface GDTOpenGLLayer : CAEAGLLayer <GDTDisplayLayer>
 
 @end
+#endif

--- a/platform/ios/display_layer_ios.mm
+++ b/platform/ios/display_layer_ios.mm
@@ -40,9 +40,11 @@
 
 #import <AudioToolbox/AudioServices.h>
 #import <GameController/GameController.h>
+#if defined(GLES3_ENABLED)
 #import <OpenGLES/EAGL.h>
 #import <OpenGLES/ES1/gl.h>
 #import <OpenGLES/ES1/glext.h>
+#endif
 #import <QuartzCore/QuartzCore.h>
 #import <UIKit/UIKit.h>
 
@@ -69,6 +71,7 @@
 
 @end
 
+#if defined(GLES3_ENABLED)
 @implementation GDTOpenGLLayer {
 	// The pixel dimensions of the backbuffer
 	GLint backingWidth;
@@ -189,3 +192,4 @@
 }
 
 @end
+#endif

--- a/platform/ios/godot_view_ios.mm
+++ b/platform/ios/godot_view_ios.mm
@@ -62,10 +62,12 @@ GODOT_CLANG_WARNING_POP
 #else
 		layer = [GDTMetalLayer layer];
 #endif
+#if defined(GLES3_ENABLED)
 	} else if ([driverName isEqualToString:@"opengl3"]) {
 		GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations") // OpenGL is deprecated in iOS 12.0.
 		layer = [GDTOpenGLLayer layer];
 		GODOT_CLANG_WARNING_POP
+#endif
 	} else {
 		return nil;
 	}

--- a/platform/ios/platform_gl.h
+++ b/platform/ios/platform_gl.h
@@ -30,8 +30,10 @@
 
 #pragma once
 
+#ifdef GLES3_ENABLED
 #ifndef GLES_API_ENABLED
 #define GLES_API_ENABLED // Allow using GLES.
 #endif
 
 #include <ES3/gl.h>
+#endif


### PR DESCRIPTION
This PR allows `scons platform=ios opengl3=no`

`drivers/apple_embedded` already discriminates on `GLES3_ENABLED`, and `platforms/ios/detect.py` already sets it according to the build parameters.

This isn't a real runtime advantage. It just allows iOS to work like macOS and visionOS with respect to Metal-only builds.

It also gets us ahead of a possible future where the deprecated OpenGL framework is marked a private API or removed.