### PR TITLE
Allow debugger dock to float

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -67,9 +67,7 @@ EditorDebuggerNode::EditorDebuggerNode() {
 	set_layout_key("Debugger");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_debugger_bottom_panel", TTRC("Toggle Debugger Dock"), KeyModifierMask::ALT | Key::D));
 	set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
-	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL);
-	set_global(false);
-	set_transient(true);
+	set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
 
 	_update_margins();
 

--- a/editor/debugger/editor_debugger_plugin.cpp
+++ b/editor/debugger/editor_debugger_plugin.cpp
@@ -113,17 +113,11 @@ void EditorDebuggerSession::detach_debugger() {
 	debugger->disconnect("started", callable_mp(this, &EditorDebuggerSession::_started));
 	debugger->disconnect("stopped", callable_mp(this, &EditorDebuggerSession::_stopped));
 	debugger->disconnect("breaked", callable_mp(this, &EditorDebuggerSession::_breaked));
-	debugger->disconnect(SceneStringName(tree_exited), callable_mp(this, &EditorDebuggerSession::_debugger_gone_away));
 	for (Control *tab : tabs) {
 		debugger->remove_debugger_tab(tab);
 	}
 	tabs.clear();
 	debugger = nullptr;
-}
-
-void EditorDebuggerSession::_debugger_gone_away() {
-	debugger = nullptr;
-	tabs.clear();
 }
 
 EditorDebuggerSession::EditorDebuggerSession(ScriptEditorDebugger *p_debugger) {
@@ -132,7 +126,6 @@ EditorDebuggerSession::EditorDebuggerSession(ScriptEditorDebugger *p_debugger) {
 	debugger->connect("started", callable_mp(this, &EditorDebuggerSession::_started));
 	debugger->connect("stopped", callable_mp(this, &EditorDebuggerSession::_stopped));
 	debugger->connect("breaked", callable_mp(this, &EditorDebuggerSession::_breaked));
-	debugger->connect(SceneStringName(tree_exited), callable_mp(this, &EditorDebuggerSession::_debugger_gone_away), CONNECT_ONE_SHOT);
 }
 
 EditorDebuggerSession::~EditorDebuggerSession() {

--- a/editor/debugger/editor_debugger_plugin.h
+++ b/editor/debugger/editor_debugger_plugin.h
@@ -45,7 +45,6 @@ private:
 	void _breaked(bool p_really_did, bool p_can_debug, const String &p_message, bool p_has_stackdump);
 	void _started();
 	void _stopped();
-	void _debugger_gone_away();
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

https://github.com/godotengine/godot/pull/113133 added the debugger to the new dock system but disabled the ability to float due to the debugger being set to nullptr on exiting the tree, which happens during a reparent (which happens when making the dock float). 

I don't really see the purpose of `_debugger_gone_away()`. There isn't a way to remove it under any normal conditions that I can find, and if something were to be implemented for some reason, it probably shouldn't be done via the tree exiting due to the things mentioned above that trigger `tree_exited`. 

*bugsquad edit:*
- Fixes: https://github.com/godotengine/godot/issues/117243