### PR TITLE
Add conic gradient to GradientTexture2D

### DIFF
--- a/doc/classes/GradientTexture2D.xml
+++ b/doc/classes/GradientTexture2D.xml
@@ -46,6 +46,9 @@
 		<constant name="FILL_SQUARE" value="2" enum="Fill">
 			The colors are linearly interpolated in a square pattern.
 		</constant>
+		<constant name="FILL_CONIC" value="3" enum="Fill">
+			The colors are linearly interpolated in a cone pattern.
+		</constant>
 		<constant name="REPEAT_NONE" value="0" enum="Repeat">
 			The gradient fill is restricted to the range defined by [member fill_from] to [member fill_to] offsets.
 		</constant>

--- a/scene/resources/gradient_texture.cpp
+++ b/scene/resources/gradient_texture.cpp
@@ -302,6 +302,9 @@ float GradientTexture2D::_get_gradient_offset_at(int x, int y) const {
 		ofs = (pos - fill_from).length() / (fill_to - fill_from).length();
 	} else if (fill == Fill::FILL_SQUARE) {
 		ofs = MAX(Math::abs(pos.x - fill_from.x), Math::abs(pos.y - fill_from.y)) / MAX(Math::abs(fill_to.x - fill_from.x), Math::abs(fill_to.y - fill_from.y));
+	} else if (fill == Fill::FILL_CONIC) {
+		float rel_angle = (fill_to - fill_from).angle_to(pos - fill_from);
+		ofs = Math::fposmod((double)rel_angle, Math::TAU) / Math::TAU;
 	}
 	if (repeat == Repeat::REPEAT_NONE) {
 		ofs = CLAMP(ofs, 0.0, 1.0);
@@ -442,7 +445,7 @@ void GradientTexture2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_hdr"), "set_use_hdr", "is_using_hdr");
 
 	ADD_GROUP("Fill", "fill_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "fill", PROPERTY_HINT_ENUM, "Linear,Radial,Square"), "set_fill", "get_fill");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "fill", PROPERTY_HINT_ENUM, "Linear,Radial,Square,Conic"), "set_fill", "get_fill");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "fill_from"), "set_fill_from", "get_fill_from");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "fill_to"), "set_fill_to", "get_fill_to");
 
@@ -452,6 +455,7 @@ void GradientTexture2D::_bind_methods() {
 	BIND_ENUM_CONSTANT(FILL_LINEAR);
 	BIND_ENUM_CONSTANT(FILL_RADIAL);
 	BIND_ENUM_CONSTANT(FILL_SQUARE);
+	BIND_ENUM_CONSTANT(FILL_CONIC);
 
 	BIND_ENUM_CONSTANT(REPEAT_NONE);
 	BIND_ENUM_CONSTANT(REPEAT);

--- a/scene/resources/gradient_texture.h
+++ b/scene/resources/gradient_texture.h
@@ -78,6 +78,7 @@ public:
 		FILL_LINEAR,
 		FILL_RADIAL,
 		FILL_SQUARE,
+		FILL_CONIC,
 	};
 	enum Repeat {
 		REPEAT_NONE,


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

closes https://github.com/godotengine/godot-proposals/issues/14072

Adds `FILL_CONIC` mode to GradientTexture2D

<img width="297" height="756" alt="image" src="https://github.com/user-attachments/assets/c2d3576d-14ec-4c54-8e2e-291ea14a6989" />
