### PR TITLE
Prevent unnecessary memory allocations when reading UID cache

### DIFF
--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -357,18 +357,21 @@ String ResourceUID::get_path_from_cache(Ref<FileAccess> &p_cache_file, const Str
 	const int64_t uid_from_string = singleton->text_to_id(p_uid_string);
 	if (uid_from_string != INVALID_ID) {
 		const uint32_t entry_count = p_cache_file->get_32();
-		CharString cs;
 		for (uint32_t i = 0; i < entry_count; i++) {
 			int64_t id = p_cache_file->get_64();
 			int32_t len = p_cache_file->get_32();
-			cs.resize_uninitialized(len + 1);
-			ERR_FAIL_COND_V(cs.size() != len + 1, String());
-			cs[len] = 0;
-			int32_t rl = p_cache_file->get_buffer((uint8_t *)cs.ptrw(), len);
-			ERR_FAIL_COND_V(rl != len, String());
 
 			if (id == uid_from_string) {
+				CharString cs;
+				cs.resize_uninitialized(len + 1);
+				ERR_FAIL_COND_V(cs.size() != len + 1, String());
+				cs[len] = 0;
+				int32_t rl = p_cache_file->get_buffer((uint8_t *)cs.ptrw(), len);
+				ERR_FAIL_COND_V(rl != len, String());
 				return String::utf8(cs.get_data());
+			} else {
+				p_cache_file->seek(p_cache_file->get_position() + len);
+				ERR_FAIL_COND_V(p_cache_file->eof_reached(), String());
 			}
 		}
 	}


### PR DESCRIPTION
Instead of making a `CharString` and reallocate for every single UID in the file, only do a single allocation once the correct UID is found. 

This function is only used by the editor's project manager when it opens and has to read each project's UID cache to get the correct icon.

Addresses comments from #108981.