### PR TITLE
Change godot-cpp to godot-headers for the reference GDExtensions files.

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -35,8 +35,7 @@ jobs:
             build-mono: true
             doc-test: true
             proj-conv: true
-            # FIXME: New versioning of godot-cpp breaks the logic for this test.
-            #api-compat: true
+            api-compat: true
             artifact: true
             # Validate godot-cpp compatibility on one arbitrary editor build.
             godot-cpp: true

--- a/misc/scripts/validate_extension_api.sh
+++ b/misc/scripts/validate_extension_api.sh
@@ -69,7 +69,7 @@ while read -r dir; do
     get_expected_output "$dir"
 
     # Download the reference extension_api.json
-    wget -nv --retry-on-http-error=503 --tries=5 --timeout=60 -cO "$reference_file" "https://raw.githubusercontent.com/godotengine/godot-cpp/godot-$reference_tag/gdextension/extension_api.json" || has_problems=1
+    wget -nv --retry-on-http-error=503 --tries=5 --timeout=60 -cO "$reference_file" "https://raw.githubusercontent.com/godotengine/godot-headers/godot-$reference_tag/extension_api.json" || has_problems=1
     # Validate the current API against the reference
     "$1" --headless --validate-extension-api "$reference_file" 2>&1 | tee "$validate" | awk '!/^Validate extension JSON:/' - || true
     # Collect the expected and actual validation errors


### PR DESCRIPTION
Supersede https://github.com/godotengine/godot/pull/109420

Re-enables GDExtensions API CI checks.