### PR TITLE
Improve 3D workspace environment configuration and sky horizon

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -9610,18 +9610,29 @@ void Node3DEditor::_preview_settings_changed() {
 
 	{ //preview env
 		sky_material->set_energy_multiplier(environ_energy->get_value());
-		Color hz_color = environ_sky_color->get_pick_color().lerp(environ_ground_color->get_pick_color(), 0.5);
-		float hz_lum = hz_color.get_luminance() * 3.333;
-		hz_color = hz_color.lerp(Color(hz_lum, hz_lum, hz_lum), 0.5);
+
+		const float horizon_brightness = 1.6;
+		const float horizon_saturation = 0.65;
+		Color sky_color_linear = environ_sky_color->get_pick_color().srgb_to_linear();
+		Color ground_color_linear = environ_ground_color->get_pick_color().srgb_to_linear();
+		Color horizon_color = sky_color_linear.lerp(ground_color_linear, 0.5);
+		float sky_luminance = sky_color_linear.get_luminance();
+		float ground_luminance = ground_color_linear.get_luminance();
+		float horizon_luminance = sky_luminance > ground_luminance ? sky_luminance : ground_luminance;
+		horizon_luminance *= horizon_brightness;
+		horizon_color *= horizon_luminance / horizon_color.get_luminance();
+		horizon_color = horizon_color.lerp(Color(horizon_luminance, horizon_luminance, horizon_luminance), horizon_saturation);
+		horizon_color = horizon_color.linear_to_srgb();
+
 		sky_material->set_sky_top_color(environ_sky_color->get_pick_color());
-		sky_material->set_sky_horizon_color(hz_color);
+		sky_material->set_sky_horizon_color(horizon_color);
 		sky_material->set_ground_bottom_color(environ_ground_color->get_pick_color());
-		sky_material->set_ground_horizon_color(hz_color);
+		sky_material->set_ground_horizon_color(horizon_color);
 
 		environment->set_ssao_enabled(environ_ao_button->is_pressed());
 		environment->set_glow_enabled(environ_glow_button->is_pressed());
 		environment->set_sdfgi_enabled(environ_gi_button->is_pressed());
-		environment->set_tonemapper(environ_tonemap_button->is_pressed() ? Environment::TONE_MAPPER_FILMIC : Environment::TONE_MAPPER_LINEAR);
+		environment->set_tonemapper(environ_tonemap_button->is_pressed() ? Environment::TONE_MAPPER_AGX : Environment::TONE_MAPPER_LINEAR);
 	}
 }
 
@@ -9639,13 +9650,13 @@ void Node3DEditor::_load_default_preview_settings() {
 	sun_angle_altitude->set_value_no_signal(-Math::rad_to_deg(sun_rotation.x));
 	sun_angle_azimuth->set_value_no_signal(180.0 - Math::rad_to_deg(sun_rotation.y));
 	sun_direction->queue_redraw();
-	environ_sky_color->set_pick_color(Color(0.385, 0.454, 0.55));
-	environ_ground_color->set_pick_color(Color(0.2, 0.169, 0.133));
+	environ_sky_color->set_pick_color(Color(0.408, 0.584, 0.796));
+	environ_ground_color->set_pick_color(Color(0.243, 0.2, 0.157));
 	environ_energy->set_value_no_signal(1.0);
 	if (OS::get_singleton()->get_current_rendering_method() != "gl_compatibility" && OS::get_singleton()->get_current_rendering_method() != "dummy") {
 		environ_glow_button->set_pressed_no_signal(true);
 	}
-	environ_tonemap_button->set_pressed_no_signal(true);
+	environ_tonemap_button->set_pressed_no_signal(false);
 	environ_ao_button->set_pressed_no_signal(false);
 	environ_gi_button->set_pressed_no_signal(false);
 	sun_shadow_max_distance->set_value_no_signal(100);


### PR DESCRIPTION
With the upcoming [HDR output PR](https://github.com/godotengine/godot/pull/94496), the `Environment` configuration used by the 3D workspace must be changed to use the Linear, Reinhard, or AgX tonemapper for good HDR behaviour. The Linear tonemapper makes the most sense and this change has been included in the Windows HDR output PR along with [rationale for this change](https://github.com/godotengine/godot/pull/94496#issuecomment-3444756873). As a consequence of this change to the Linear tonemapper, the default sky colours appear quite dark, so this prompts a revisiting of these default sky colours.

This PR changes the following:
1. Improves colour math for calculating the horizon colour.
2. Changes sky colour to be higher saturation.
3. Disables tonemapping by default (redundant of change made in HDR output PR).
4. Changes default tonemapper from Filmic (with `white` of `1.0`) to AgX (with default `white` of `16.29`).

This PR does not change the ground colour: this new ground colour is the same as 4.6 when the ground colour is passed through Filmic tonemapper.

**This PR only affects editor behaviour and does not change any `Environment` defaults or behaviour in existing projects.**

The horizon brightness (1.6x) and saturation (0.65% linear blend) are subjectively selected. The new sky colour is subjectively selected.

The base horizon colour is a 50% linear RGB blend of the ground and sky. There are a lot of ways to select an in-between colour, but I believe this matches the way lighting generally behaves in Godot(?)

Before | After
--|--
<img width="1152" height="648" alt="image" src="https://github.com/user-attachments/assets/1be461c9-63f6-4432-8450-386fa41605ef" /> | <img width="1152" height="648" alt="image" src="https://github.com/user-attachments/assets/da9cf18f-7049-47b3-aa03-13bf84489355" />

I've also [created a simple project](https://github.com/allenwp/godot-editor-env-sky) that helped me choose the brightness, saturation, and sky/ground colours. Feel free to play around with this if you'd like (and let me know if you have questions about usage).