### PR TITLE
Define `sighandler_t` only if `_GNU_SOURCE` is not defined.

### DIFF
--- a/drivers/unix/file_access_unix_pipe.cpp
+++ b/drivers/unix/file_access_unix_pipe.cpp
@@ -43,7 +43,7 @@
 #include <cerrno>
 #include <csignal>
 
-#ifndef sighandler_t
+#ifndef _GNU_SOURCE
 typedef typeof(void(int)) *sighandler_t;
 #endif
 


### PR DESCRIPTION
Might fix https://github.com/godotengine/godot/issues/115427, not sure in what conditions it is reproducible.