### PR TITLE
Fix icon size for items in show list of selectable nodes menu

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -1731,6 +1731,7 @@ void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 	} else if (!selection_results.is_empty()) {
 		NodePath root_path = get_tree()->get_edited_scene_root()->get_path();
 		StringName root_name = root_path.get_name(root_path.get_name_count() - 1);
+		int icon_max_width = EditorNode::get_singleton()->get_editor_theme()->get_constant(SNAME("class_icon_size"), EditorStringName(Editor));
 
 		for (int i = 0; i < selection_results.size(); i++) {
 			Node3D *spat = selection_results[i];
@@ -1763,6 +1764,7 @@ void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 			}
 			selection_menu->add_item((String)spat->get_name() + suffix);
 			selection_menu->set_item_icon(i, icon);
+			selection_menu->set_item_icon_max_width(i, icon_max_width);
 			selection_menu->set_item_metadata(i, node_path);
 			selection_menu->set_item_tooltip(i, String(spat->get_name()) + "\nType: " + spat->get_class() + "\nPath: " + node_path);
 		}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/115446

This was done for the "Show list of selectable nodes at position clicked" in the 2d editor in https://github.com/godotengine/godot/pull/82728/changes#diff-eb4ce61def40bf37d0fba218d92fa230c11f78e3a56f2849cdfe0045512acc3b

So did same fix here for 3d editor

After

<img width="796" height="808" alt="Screenshot_20260127_122922" src="https://github.com/user-attachments/assets/e684694f-b215-4a75-bcf6-e52d10c39b84" />
