### PR TITLE
Fix TLS handshake fail preventing AssetLib use with `builtin_certs=no`

### DIFF
--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -78,7 +78,7 @@ def make_certs_header(target, source, env):
 
     with methods.generated_wrapper(str(target[0])) as file:
         # System certs path. Editor will use them if defined. (for package maintainers)
-        file.write(f'#define _SYSTEM_CERTS_PATH "{source[2]}"\n')
+        file.write('#define _SYSTEM_CERTS_PATH "{}"\n'.format(source[2].read() or ""))
         if source[1].read():
             # Defined here and not in env so changing it does not trigger a full rebuild.
             file.write(f"""\


### PR DESCRIPTION
Fix "Editor TLS Certificates" having an invalid (False) default value.

Fixes:
> ERROR: Cannot open X509CertificateMbedTLS file 'False'.

Fixes [#454608](https://github.com/NixOS/nixpkgs/issues/454608)