### PR TITLE
Add upload progress tracking to `HTTPClient` and `HTTPRequest`

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -151,6 +151,7 @@ void HTTPClient::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_response_headers"), &HTTPClient::_get_response_headers);
 	ClassDB::bind_method(D_METHOD("get_response_headers_as_dictionary"), &HTTPClient::_get_response_headers_as_dictionary);
 	ClassDB::bind_method(D_METHOD("get_response_body_length"), &HTTPClient::get_response_body_length);
+	ClassDB::bind_method(D_METHOD("get_request_bytes_sent"), &HTTPClient::get_request_bytes_sent);
 	ClassDB::bind_method(D_METHOD("read_response_body_chunk"), &HTTPClient::read_response_body_chunk);
 	ClassDB::bind_method(D_METHOD("set_read_chunk_size", "bytes"), &HTTPClient::set_read_chunk_size);
 	ClassDB::bind_method(D_METHOD("get_read_chunk_size"), &HTTPClient::get_read_chunk_size);

--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -183,6 +183,8 @@ public:
 	virtual Error get_response_headers(List<String> *r_response) = 0;
 	virtual int64_t get_response_body_length() const = 0;
 
+	virtual int64_t get_request_bytes_sent() const = 0;
+
 	virtual PackedByteArray read_response_body_chunk() = 0; // Can't get body as partial text because of most encodings UTF8, gzip, etc.
 
 	virtual void set_blocking_mode(bool p_enable) = 0; // Useful mostly if running in a thread

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -567,6 +567,10 @@ int64_t HTTPClientTCP::get_response_body_length() const {
 	return body_size;
 }
 
+int64_t HTTPClientTCP::get_request_bytes_sent() const {
+	return request_buffer->get_position();
+}
+
 PackedByteArray HTTPClientTCP::read_response_body_chunk() {
 	ERR_FAIL_COND_V(status != STATUS_BODY, PackedByteArray());
 

--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -91,6 +91,7 @@ public:
 	int get_response_code() const override;
 	Error get_response_headers(List<String> *r_response) override;
 	int64_t get_response_body_length() const override;
+	int64_t get_request_bytes_sent() const override;
 	PackedByteArray read_response_body_chunk() override;
 	void set_blocking_mode(bool p_enable) override;
 	bool is_blocking_mode_enabled() const override;

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -36,6 +36,38 @@
 				If no [param port] is specified (or [code]-1[/code] is used), it is automatically set to 80 for HTTP and 443 for HTTPS. You can pass the optional [param tls_options] parameter to customize the trusted certification authorities, or the common name verification when using HTTPS. See [method TLSOptions.client] and [method TLSOptions.client_unsafe].
 			</description>
 		</method>
+		<method name="get_request_bytes_sent" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of bytes sent so far in the current request, including both headers and body. Can be used to track upload progress.
+				[b]Note:[/b] On the Web platform, this function always returns [code]-1[/code] due to browser limitations.
+				[b]Note:[/b] Once the buffer is sent, and while waiting for the response from the server, this function will return [code]0[/code].
+				[codeblocks]
+				[gdscript]
+				while http.get_status() == HTTPClient.STATUS_REQUESTING:
+					http.poll()
+					var sent := http.get_request_bytes_sent()
+					if sent &gt; 0:
+						var percent := (sent * 100.0) / total_bytes
+						print("Uploading: %.1f%%" % percent)
+					await get_tree().process_frame
+				[/gdscript]
+				[csharp]
+				while (http.GetStatus() == HttpClient.Status.Requesting)
+				{
+					http.Poll();
+					long sent = http.GetRequestBytesSent();
+					if (sent &gt; 0)
+					{
+						double percent = (sent * 100.0) / totalBytes;
+						GD.Print($"Uploading: {percent:0.0}%");
+					}
+					await ToSignal(GetTree(), SceneTree.SignalName.ProcessFrame);
+				}
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="get_response_body_length" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -182,6 +182,13 @@
 				Returns the current status of the underlying [HTTPClient].
 			</description>
 		</method>
+		<method name="get_uploaded_bytes" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of bytes this HTTPRequest uploaded. See [method HTTPClient.get_request_bytes_sent] for more details.
+				[b]Note:[/b] On the Web platform, this function always returns [code]-1[/code] due to browser limitations.
+			</description>
+		</method>
 		<method name="request">
 			<return type="int" enum="Error" />
 			<param index="0" name="url" type="String" />

--- a/platform/web/http_client_web.cpp
+++ b/platform/web/http_client_web.cpp
@@ -160,6 +160,11 @@ int64_t HTTPClientWeb::get_response_body_length() const {
 	return -1;
 }
 
+int64_t HTTPClientWeb::get_request_bytes_sent() const {
+	// Upload progress tracking is not available on the web platform.
+	return -1;
+}
+
 PackedByteArray HTTPClientWeb::read_response_body_chunk() {
 	ERR_FAIL_COND_V(status != STATUS_BODY, PackedByteArray());
 

--- a/platform/web/http_client_web.h
+++ b/platform/web/http_client_web.h
@@ -94,6 +94,7 @@ public:
 	int get_response_code() const override;
 	Error get_response_headers(List<String> *r_response) override;
 	int64_t get_response_body_length() const override;
+	int64_t get_request_bytes_sent() const override;
 	PackedByteArray read_response_body_chunk() override;
 	void set_blocking_mode(bool p_enable) override;
 	bool is_blocking_mode_enabled() const override;

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -600,6 +600,10 @@ int HTTPRequest::get_downloaded_bytes() const {
 	return downloaded.get();
 }
 
+int HTTPRequest::get_uploaded_bytes() const {
+	return client->get_request_bytes_sent();
+}
+
 int HTTPRequest::get_body_size() const {
 	return body_len;
 }
@@ -655,6 +659,7 @@ void HTTPRequest::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_download_file"), &HTTPRequest::get_download_file);
 
 	ClassDB::bind_method(D_METHOD("get_downloaded_bytes"), &HTTPRequest::get_downloaded_bytes);
+	ClassDB::bind_method(D_METHOD("get_uploaded_bytes"), &HTTPRequest::get_uploaded_bytes);
 	ClassDB::bind_method(D_METHOD("get_body_size"), &HTTPRequest::get_body_size);
 
 	ClassDB::bind_method(D_METHOD("set_timeout", "timeout"), &HTTPRequest::set_timeout);

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -159,6 +159,7 @@ public:
 	void _timeout();
 
 	int get_downloaded_bytes() const;
+	int get_uploaded_bytes() const;
 	int get_body_size() const;
 
 	void set_http_proxy(const String &p_host, int p_port);


### PR DESCRIPTION
This is to resolve https://github.com/godotengine/godot-proposals/issues/1221

# What's changed:

- Added a `get_request_bytes_sent` method on `HTTPClient` which returns bytes sent so far during a request
- Added a `get_uploaded_bytes` method on `HTTPRequest` which exposes the `get_request_bytes_sent` on the underlying `HTTPClient`
- Documentation for both new methods including an example

A note about the implmentation - `request_buffer->get_position()` resets to 0 as soon as we have finished sending to the server - but before the request is completed - this is because the internal buffer is cleared and we are still waiting for a response from the server.

Because of this nuance, I have included an example (gdscript and c#) in the documentation

```gdscript
while http.get_status() == HTTPClient.STATUS_REQUESTING:
    http.poll()
    var sent := http.get_request_bytes_sent()
    if sent > 0:
        var percent := (sent * 100.0) / total_bytes
        print("Uploading: %.1f%%" % percent)
    await get_tree().process_frame
```

For the Web platform, the methods return `-1` - I have looked into implementing this for the `fetch` based web version of the `HTTPClient` - there are some browser compatibility issues https://stackoverflow.com/a/69400632/2779152 

This is my first contribution to Godot  - very happy to hear feedback and make changes.

