### PR TITLE
Fix import not recognising files created in new subdirectories

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -1870,7 +1870,7 @@ bool EditorFileSystem::_find_file(const String &p_file, EditorFileSystemDirector
 	String f = ProjectSettings::get_singleton()->localize_path(p_file);
 
 	// Note: Only checks if base directory is case sensitive.
-	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	bool fs_case_sensitive = dir->is_case_sensitive("res://");
 
 	if (!f.begins_with("res://")) {


### PR DESCRIPTION
Fixes #101240

Creating new files from inside editor import plugins is still a little clunky, but previously it was almost impossible to save resources into a new folder and have the editor recognise them without requiring a full scan.
You can use a mix of `EditorFileSystem::update_file()` and `EditorImportPlugin::append_import_external_resource()` to have the editor detect newly created files, but they fail when new folders are involved.


This PR fixes `EditorFileSystem::update_file()` to correctly identify files inside newly created subdirectories.


The issue occurs on line 1914 where the function attempts to check a newly discovered directory, but due to the `DirAccess` configuration it checks the current `res://...` filepath as if it were a real filesystem path and always fails.
The `DirAccess` is otherwise only used for case sensitivity checking so changing it shouldn't have much of an impact.


Note: Calling `update_file` on new empty directories still doesn't work with this fix, but that's less important and would be a nice minor improvement for another PR.

Note: Deleting a folder containing dependent extracted assets (i.e. ones added to an EditorImportPlugin's `gen_files`) now ttriggers the source asset to immediately reimport and recreate the just deleted folder and files.  I'm not entirely sure why it happens but it's probably fine since the same behaviour previously occurred when unfocusing and refocusing the editor.