### PR TITLE
GDScript: Prevent function states from leaking into typed temporaries, when overwriting with coroutines

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -603,12 +603,15 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 		case GDScriptParser::Node::CALL: {
 			const GDScriptParser::CallNode *call = static_cast<const GDScriptParser::CallNode *>(p_expression);
 			bool is_awaited = p_expression == awaited_node;
-			GDScriptDataType type = _gdtype_from_datatype(call->get_datatype(), codegen.script);
 			GDScriptCodeGenerator::Address result;
 			if (p_root) {
 				result = GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::NIL);
+			} else if (is_awaited) {
+				// When called with await, we need to use an untyped temporary regardless of whether the base
+				// class function is a coroutine, because an inherited class could return a function state object.
+				result = codegen.add_temporary();
 			} else {
-				result = codegen.add_temporary(type);
+				result = codegen.add_temporary(_gdtype_from_datatype(call->get_datatype(), codegen.script));
 			}
 
 			Vector<GDScriptCodeGenerator::Address> arguments;

--- a/modules/gdscript/tests/scripts/runtime/features/await_with_overwritten_coroutine.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/await_with_overwritten_coroutine.gd
@@ -1,0 +1,24 @@
+class BaseClass:
+	signal release_bool
+
+	func get_bool() -> bool:
+		return true
+
+class InheritedClass extends BaseClass:
+	func get_bool() -> bool:
+		await release_bool
+		return false
+
+
+var instance: BaseClass = InheritedClass.new()
+
+func test() -> void:
+	@warning_ignore("missing_await")
+	await_with_overwritten_coroutine()
+	instance.release_bool.emit()
+
+func await_with_overwritten_coroutine():
+	var res_v := await instance.get_bool()
+	print(res_v == true)
+	var result: bool = bool(res_v)
+	print(result == true)

--- a/modules/gdscript/tests/scripts/runtime/features/await_with_overwritten_coroutine.out
+++ b/modules/gdscript/tests/scripts/runtime/features/await_with_overwritten_coroutine.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+~~ WARNING at line 21: (REDUNDANT_AWAIT) "await" keyword is unnecessary because the expression isn't a coroutine nor a signal.
+false
+false


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/112017

Here is a section of the MRP's bytecode from before this PR:
```
Function _await()
 0: line 13:    var res_v := await abstract.get_bool()
 2: call-async stack(6) = member(abstract).get_bool()
 8: await stack(6)
 10: await resume stack(5)
 12: assign stack(3) = stack(5)
 15: line 14:   print("These are the incorrect booleans")
 17: call-utility stack(7) = print(const("These are the incorrect booleans"))
 23: assign stack(7) = null
 25: line 15:   print(res_v == true)
 27: validated operator stack(6) = stack(3) == const(true)
 32: call-utility stack(7) = print(stack(6))
```

In `2` a function state object gets assigned to `stack(6)`. Later in `27` without any additional setup on `stack(6)`, it is used as target for a validated operator call between two booleans. 

Validated operator calls assume the type of the destination variant to be correct so they only set the variant data. The type stays `OBJECT` because formerly a function state was stored inside. In addition setting the data to this boolean only corrupts the variants `ObjectID`, the raw pointer stays untouched so the variant is still somewhat usable as object.

The issue happens, because `stack(6)` is a temporary which was added with a `bool` type. `get_bool` is only a coroutine in an inherited class, but the method in the base class is not a coroutine. The compiler uses the typehint from the baseclass to create the temporary, which results in a `bool` temporary.

This PR changes the compiler to always use an untyped temporary for the result of an awaited call, because we can't check whether an inherited class might have turned the sync function into a coroutine.

Another option would be to let the analyzer mark all types of expressions after an `await` with `is_coroutine`. But the compiler solution seemed less invasive to me.