### PR TITLE
Fix the `NodePath` hash function to not yield the same value for similar paths

### DIFF
--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -33,20 +33,11 @@
 #include "core/variant/variant.h"
 
 void NodePath::_update_hash_cache() const {
-	uint32_t h = data->absolute ? 1 : 0;
-	int pc = data->path.size();
-	const StringName *sn = data->path.ptr();
-	for (int i = 0; i < pc; i++) {
-		h = h ^ sn[i].hash();
-	}
-	int spc = data->subpath.size();
-	const StringName *ssn = data->subpath.ptr();
-	for (int i = 0; i < spc; i++) {
-		h = h ^ ssn[i].hash();
-	}
-
+	StringName path = get_concatenated_names();
+	StringName subpath = get_concatenated_subnames();
+	uint32_t hash = HashMapHasherDefault::hash(Pair<const StringName &, const StringName &>(path, subpath));
+	data->hash_cache = is_absolute() ? hash : ~hash;
 	data->hash_cache_valid = true;
-	data->hash_cache = h;
 }
 
 void NodePath::prepend_period() {


### PR DESCRIPTION
- Should fix #115407

xor-ing consecutive elements is not a valid hashing strategy. In the current implementation, `A/B` results in the same hash as `B/A`.

The new implementation simply hashes the full path and subpath separately, then combines them using a valid hashing strategy. Since the resulting hash is well-formed, the `is_absolute` can be used to flip bits, since the bit-flipped version of a well distributed hash is still a well distributed hash.

It's probably not the best strategy ever, but it should be good enough.
The new implementation is more expensive to compute the hash for a completely new `NodePath` than before, but it utilizes the concatenated caches, so it will speed up other operations (and itself be cheap to compute if the caches already exist).