### PR TITLE
Support dragging & dropping folders into `@export_dir` variables and other similar hints

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -777,7 +777,7 @@ void EditorPropertyPath::_drop_data_fw(const Point2 &p_point, const Variant &p_d
 	if (!drag_data.has("type")) {
 		return;
 	}
-	if (String(drag_data["type"]) != "files") {
+	if (String(drag_data["type"]) != (folder ? "files_and_dirs" : "files")) {
 		return;
 	}
 	const Vector<String> filesPaths = drag_data["files"];
@@ -785,7 +785,16 @@ void EditorPropertyPath::_drop_data_fw(const Point2 &p_point, const Variant &p_d
 		return;
 	}
 
-	_path_selected(filesPaths[0]);
+	if (folder) {
+		for (const String &file_path : filesPaths) {
+			if (file_path.ends_with("/")) {
+				_path_selected(file_path);
+				break;
+			}
+		}
+	} else {
+		_path_selected(filesPaths[0]);
+	}
 }
 
 bool EditorPropertyPath::_can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
@@ -793,7 +802,7 @@ bool EditorPropertyPath::_can_drop_data_fw(const Point2 &p_point, const Variant 
 	if (!drag_data.has("type")) {
 		return false;
 	}
-	if (String(drag_data["type"]) != "files") {
+	if (String(drag_data["type"]) != (folder ? "files_and_dirs" : "files")) {
 		return false;
 	}
 	const Vector<String> filesPaths = drag_data["files"];
@@ -801,9 +810,17 @@ bool EditorPropertyPath::_can_drop_data_fw(const Point2 &p_point, const Variant 
 		return false;
 	}
 
-	for (const String &extension : extensions) {
-		if (filesPaths[0].ends_with(extension.substr(1))) {
-			return true;
+	if (folder) {
+		for (const String &file_path : filesPaths) {
+			if (file_path.ends_with("/")) {
+				return true;
+			}
+		}
+	} else {
+		for (const String &extension : extensions) {
+			if (filesPaths[0].ends_with(extension.substr(1))) {
+				return true;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
previously when trying to drag & drop a folder into an export variable using something like `@export_dir` (`PROPERTY_HINT_DIR`), it would disallow it and only allow dragging in files. this seems unusual in usage (you'd expect an exported **directory** to only have a directory as its input) and means you must write workarounds in your own code to account for that

this fix allows you to drag folders into inputs marked for folders now (and has a small extra check to make sure that file paths aren't accidentally put in there if you drag both files and folders in at the same time)

there might be potential for another PR at some point relating to global directories or files as both seem a little broken when dragging & dropping from the editor *(namely, they put in the local project paths, as well as not being able to drag from outside of the editor at least on macOS, but i think that sounds a little out of scope for just this PR)*

## before:
<img width="1512" height="655" alt="screenshot showing mouse cursor dragging folder onto export_dir variable with the disallowed icon, making it clear you can't drag the folder into that input" src="https://github.com/user-attachments/assets/64f27dbd-7032-40f2-b2df-6c902b970714" />

## after:
<img width="1512" height="655" alt="screenshot showing mouse cursor dragging folder onto export_dir variable with the dropping icon, making it clear you can now drag the folder into that input" src="https://github.com/user-attachments/assets/d042710f-1907-4f80-b1f1-1ea34729076c" />
<img width="408" height="66" alt="screenshot showing the input with the folder now inside after the drag & drop completed" src="https://github.com/user-attachments/assets/d6a80ff5-bfad-40af-8722-7a664c2e9095" />
