### PR TITLE
Support older core2 processors

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -743,7 +743,7 @@ if env["arch"] == "x86_64":
         env.Append(CCFLAGS=["/d2archSSE42"])
     else:
         # `-msse2` is implied when compiling for x86_64.
-        env.Append(CCFLAGS=["-msse4.2", "-mpopcnt"])
+        env.Append(CCFLAGS=["-msse4.1"])
 elif env["arch"] == "x86_32":
     # Be more conservative with instruction sets on 32-bit x86 to improve compatibility.
     # SSE and SSE2 are present on all CPUs that support 64-bit, even if running a 32-bit OS.


### PR DESCRIPTION
Force-enabling SSE4.2 causes signal 4 (Illegal instruction) on older processors. By only enabling SSE4.1, similar performance benefits are retained while still maintaining compatibility.

Ideally, multiple code paths should be compiled into the same binary. At runtime, the most optimal path can then be selected.

This way, newer CPU features (eg. SSE4.2, AVX512) can be used on modern CPUs while simultaneously maintaining compatibility with systems that do not support them.

closes #115001, closes #113617
