### PR TITLE
Fix error message when opening a scene with a script that extends an inner class

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1133,6 +1133,10 @@ Ref<Texture2D> EditorData::_load_script_icon(const String &p_path) const {
 }
 
 Ref<Texture2D> EditorData::get_script_icon(const String &p_script_path) {
+	if (p_script_path.is_empty()) {
+		return Ref<Texture2D>();
+	}
+
 	// Take from the local cache, if available.
 	{
 		Ref<Texture2D> *icon = _script_icon_cache.getptr(p_script_path);


### PR DESCRIPTION
If you add a script to a scene and this script extends an inner class, when you reopen this scene, a mysterious error message will appear:
<img width="574" height="34" alt="{E904AE6F-3B0E-4FF3-A52C-8F9B218FD437}" src="https://github.com/user-attachments/assets/0e922af5-d4da-4b74-a311-79b5cab82661" />

Upon debugging this information, it can be determined that the error occurred when attempting to obtain the class icon. Since the inner class received a null result from get_path, the processing attempt to obtain the icon will attempt to read it from a empty path:
<img width="970" height="123" alt="{AE131C1D-244F-4BB3-873C-F6DD5915201A}" src="https://github.com/user-attachments/assets/37dd28b6-35eb-401f-810b-5968bb2530b4" />

<img width="607" height="31" alt="{0FFFBD10-C5C4-4DCC-8FF6-23A37D12F56A}" src="https://github.com/user-attachments/assets/1ec71546-2d1f-48ac-bea1-e17f02d4d7d2" />

Simply returning when p_script_path is empty can solve this problem

MRP here: 
[issue-with-inner-class-icon.zip](https://github.com/user-attachments/files/24898060/issue-with-inner-class-icon.zip)
