### PR TITLE
[C#] Allow inspector to restrict selection with PropertHint.NodeType

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -4095,7 +4095,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				return editor;
 			} else {
 				EditorPropertyNodePath *editor = memnew(EditorPropertyNodePath);
-        		editor->setup(Vector<StringName>(), false, false);
+        			editor->setup(Vector<StringName>(), false, false);
 				return editor;
 			}
 		} break;

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -4087,14 +4087,18 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 			}
 		} break;
 		case Variant::NODE_PATH: {
-			EditorPropertyNodePath *editor = memnew(EditorPropertyNodePath);
-			if (p_hint == PROPERTY_HINT_NODE_PATH_VALID_TYPES && !p_hint_text.is_empty()) {
+			if (p_hint == PROPERTY_HINT_NODE_TYPE) {
+				EditorPropertyNodePath *editor = memnew(EditorPropertyNodePath);
 				Vector<String> types = p_hint_text.split(",", false);
-				Vector<StringName> sn = Variant(types); //convert via variant
-				editor->setup(sn, (p_usage & PROPERTY_USAGE_NODE_PATH_FROM_SCENE_ROOT));
+				Vector<StringName> sn = Variant(types);
+				editor->setup(sn, false, true);
+				return editor;
 			}
-			return editor;
-
+			else {
+				EditorPropertyNodePath *editor = memnew(EditorPropertyNodePath);
+        		editor->setup(Vector<StringName>(), false, false);
+				return editor;
+			}
 		} break;
 		case Variant::RID: {
 			EditorPropertyRID *editor = memnew(EditorPropertyRID);

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -4093,8 +4093,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				Vector<StringName> sn = Variant(types);
 				editor->setup(sn, false, true);
 				return editor;
-			}
-			else {
+			} else {
 				EditorPropertyNodePath *editor = memnew(EditorPropertyNodePath);
         		editor->setup(Vector<StringName>(), false, false);
 				return editor;

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -4095,6 +4095,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				return editor;
 			} else {
 				EditorPropertyNodePath *editor = memnew(EditorPropertyNodePath);
+				
         			editor->setup(Vector<StringName>(), false, false);
 				return editor;
 			}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -733,6 +733,30 @@ namespace Godot.SourceGenerators
                 }
             }
 
+            if (variantType == VariantType.Object && exportAttr != null)
+            {
+                var constructorArguments = exportAttr.ConstructorArguments;
+                if (constructorArguments.Length > 0)
+                {
+                    var presetHintValue = constructorArguments[0].Value;
+                    PropertyHint presetHint = presetHintValue switch
+                    {
+                        null => PropertyHint.None,
+                        int intValue => (PropertyHint)intValue,
+                        _ => (PropertyHint)(long)presetHintValue
+                    };
+
+                    if (presetHint == PropertyHint.NodeType)
+                    {
+                        hint = PropertyHint.NodeType;
+                        hintString = constructorArguments.Length > 1
+                            ? exportAttr.ConstructorArguments[1].Value?.ToString()
+                            : null;
+                        return true;
+                    }
+                }
+            }
+
             static bool TryGetNodeOrResourceType(AttributeData exportAttr, out PropertyHint hint, out string? hintString)
             {
                 hint = PropertyHint.None;


### PR DESCRIPTION
Allows the inspector to restrict the node selection to certain types if PropertyHint.NodeType is used, basically achieving the same result as @export_node_path in gdscript.

<img width="585" height="1138" alt="image" src="https://github.com/user-attachments/assets/ae13b813-a415-4966-a02c-31b4c90d5f38" />

I don't _think_ this messes up anything else as far as I can tell? And I couldn't find any other pull requests that tackle this, but someone more experienced should definitely review this just in case.