### PR TITLE
Fix Nvidia Shield controller showing up twice on macOS

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -992,6 +992,7 @@ Patches:
 - `0004-errno-include.patch` ([GH-108354](https://github.com/godotengine/godot/pull/108354))
 - `0005-fix-libudev-dbus.patch` ([GH-108373](https://github.com/godotengine/godot/pull/108373))
 - `0006-fix-cs-environ.patch` ([GH-109283](https://github.com/godotengine/godot/pull/109283))
+- `0007-shield-duplicate-macos.patch` ([GH-115510](https://github.com/godotengine/godot/pull/115510))
 
 
 ## spirv-cross

--- a/thirdparty/sdl/joystick/apple/SDL_mfijoystick.m
+++ b/thirdparty/sdl/joystick/apple/SDL_mfijoystick.m
@@ -158,6 +158,13 @@ static bool IsControllerSwitchJoyConPair(GCController *controller)
     }
     return false;
 }
+static bool IsControllerNVIDIASHIELD(GCController *controller)
+{
+    if ([controller.vendorName hasPrefix:@"NVIDIA Controller"]) {
+        return true;
+    }
+    return false;
+}
 static bool IsControllerStadia(GCController *controller)
 {
     if ([controller.vendorName hasPrefix:@"Stadia"]) {
@@ -339,6 +346,7 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
     device->is_ps5 = IsControllerPS5(controller);
     device->is_switch_pro = IsControllerSwitchPro(controller);
     device->is_switch_joycon_pair = IsControllerSwitchJoyConPair(controller);
+    device->is_shield = IsControllerNVIDIASHIELD(controller);
     device->is_stadia = IsControllerStadia(controller);
     device->is_backbone_one = IsControllerBackboneOne(controller);
     device->is_switch_joyconL = IsControllerSwitchJoyConL(controller);
@@ -350,6 +358,7 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
         (device->is_ps5 && HIDAPI_IsDeviceTypePresent(SDL_GAMEPAD_TYPE_PS5)) ||
         (device->is_switch_pro && HIDAPI_IsDeviceTypePresent(SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_PRO)) ||
         (device->is_switch_joycon_pair && HIDAPI_IsDevicePresent(USB_VENDOR_NINTENDO, USB_PRODUCT_NINTENDO_SWITCH_JOYCON_PAIR, 0, "")) ||
+        (device->is_shield && HIDAPI_IsDevicePresent(USB_VENDOR_NVIDIA, USB_PRODUCT_NVIDIA_SHIELD_CONTROLLER_V104, 0, "")) ||
         (device->is_stadia && HIDAPI_IsDevicePresent(USB_VENDOR_GOOGLE, USB_PRODUCT_GOOGLE_STADIA_CONTROLLER, 0, "")) ||
         (device->is_switch_joyconL && HIDAPI_IsDevicePresent(USB_VENDOR_NINTENDO, USB_PRODUCT_NINTENDO_SWITCH_JOYCON_LEFT, 0, "")) ||
         (device->is_switch_joyconR && HIDAPI_IsDevicePresent(USB_VENDOR_NINTENDO, USB_PRODUCT_NINTENDO_SWITCH_JOYCON_RIGHT, 0, ""))) {
@@ -486,7 +495,7 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
         subtype = 4;
 
 #ifdef DEBUG_CONTROLLER_PROFILE
-        NSLog(@"Elements used:\n", controller.vendorName);
+        NSLog(@"Elements used:\n");
         for (id key in device->buttons) {
             NSLog(@"\tButton: %@ (%s)\n", key, elements[key].analog ? "analog" : "digital");
         }

--- a/thirdparty/sdl/joystick/apple/SDL_mfijoystick_c.h
+++ b/thirdparty/sdl/joystick/apple/SDL_mfijoystick_c.h
@@ -53,6 +53,7 @@ typedef struct joystick_hwdata
     bool is_switch_joycon_pair;
     bool is_switch_joyconL;
     bool is_switch_joyconR;
+    bool is_shield;
     bool is_stadia;
     bool is_backbone_one;
     int is_siri_remote;

--- a/thirdparty/sdl/patches/0007-shield-duplicate-macos.patch
+++ b/thirdparty/sdl/patches/0007-shield-duplicate-macos.patch
@@ -1,0 +1,55 @@
+diff --git a/thirdparty/sdl/joystick/apple/SDL_mfijoystick.m b/thirdparty/sdl/joystick/apple/SDL_mfijoystick.m
+index 48e9051798..3e8f4a8bab 100644
+--- a/thirdparty/sdl/joystick/apple/SDL_mfijoystick.m
++++ b/thirdparty/sdl/joystick/apple/SDL_mfijoystick.m
+@@ -158,6 +158,13 @@ static bool IsControllerSwitchJoyConPair(GCController *controller)
+     }
+     return false;
+ }
++static bool IsControllerNVIDIASHIELD(GCController *controller)
++{
++    if ([controller.vendorName hasPrefix:@"NVIDIA Controller"]) {
++        return true;
++    }
++    return false;
++}
+ static bool IsControllerStadia(GCController *controller)
+ {
+     if ([controller.vendorName hasPrefix:@"Stadia"]) {
+@@ -339,6 +346,7 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
+     device->is_ps5 = IsControllerPS5(controller);
+     device->is_switch_pro = IsControllerSwitchPro(controller);
+     device->is_switch_joycon_pair = IsControllerSwitchJoyConPair(controller);
++    device->is_shield = IsControllerNVIDIASHIELD(controller);
+     device->is_stadia = IsControllerStadia(controller);
+     device->is_backbone_one = IsControllerBackboneOne(controller);
+     device->is_switch_joyconL = IsControllerSwitchJoyConL(controller);
+@@ -350,6 +358,7 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
+         (device->is_ps5 && HIDAPI_IsDeviceTypePresent(SDL_GAMEPAD_TYPE_PS5)) ||
+         (device->is_switch_pro && HIDAPI_IsDeviceTypePresent(SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_PRO)) ||
+         (device->is_switch_joycon_pair && HIDAPI_IsDevicePresent(USB_VENDOR_NINTENDO, USB_PRODUCT_NINTENDO_SWITCH_JOYCON_PAIR, 0, "")) ||
++        (device->is_shield && HIDAPI_IsDevicePresent(USB_VENDOR_NVIDIA, USB_PRODUCT_NVIDIA_SHIELD_CONTROLLER_V104, 0, "")) ||
+         (device->is_stadia && HIDAPI_IsDevicePresent(USB_VENDOR_GOOGLE, USB_PRODUCT_GOOGLE_STADIA_CONTROLLER, 0, "")) ||
+         (device->is_switch_joyconL && HIDAPI_IsDevicePresent(USB_VENDOR_NINTENDO, USB_PRODUCT_NINTENDO_SWITCH_JOYCON_LEFT, 0, "")) ||
+         (device->is_switch_joyconR && HIDAPI_IsDevicePresent(USB_VENDOR_NINTENDO, USB_PRODUCT_NINTENDO_SWITCH_JOYCON_RIGHT, 0, ""))) {
+@@ -486,7 +495,7 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
+         subtype = 4;
+ 
+ #ifdef DEBUG_CONTROLLER_PROFILE
+-        NSLog(@"Elements used:\n", controller.vendorName);
++        NSLog(@"Elements used:\n");
+         for (id key in device->buttons) {
+             NSLog(@"\tButton: %@ (%s)\n", key, elements[key].analog ? "analog" : "digital");
+         }
+diff --git a/thirdparty/sdl/joystick/apple/SDL_mfijoystick_c.h b/thirdparty/sdl/joystick/apple/SDL_mfijoystick_c.h
+index 783b3f488c..dfa7615964 100644
+--- a/thirdparty/sdl/joystick/apple/SDL_mfijoystick_c.h
++++ b/thirdparty/sdl/joystick/apple/SDL_mfijoystick_c.h
+@@ -53,6 +53,7 @@ typedef struct joystick_hwdata
+     bool is_switch_joycon_pair;
+     bool is_switch_joyconL;
+     bool is_switch_joyconR;
++    bool is_shield;
+     bool is_stadia;
+     bool is_backbone_one;
+     int is_siri_remote;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/89081

This PR fixes the double detection issue for Nvidia Shield controllers on macOS reported [here](https://github.com/godotengine/godot/issues/89081#issuecomment-3775322615), see also https://github.com/libsdl-org/SDL/issues/14911 .

The original issue of the controller not registering inputs seems to happen because the controller was low on battery (see also https://github.com/libsdl-org/SDL/issues/14903 ), so it's a hardware problem that I'm not sure if we can/should document.