### PR TITLE
Clarify `Camera3D.set_frustum()` size parameter

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -119,7 +119,7 @@
 			<param index="2" name="z_near" type="float" />
 			<param index="3" name="z_far" type="float" />
 			<description>
-				Sets the camera projection to frustum mode (see [constant PROJECTION_FRUSTUM]), by specifying a [param size], an [param offset], and the [param z_near] and [param z_far] clip planes in world space units. See also [member frustum_offset].
+				Sets the camera projection to frustum mode (see [constant PROJECTION_FRUSTUM]), by specifying a [param size], an [param offset], and the [param z_near] and [param z_far] clip planes in world space units. The [param size] parameter represents the size of the near plane, either its width or height depending on the value of [member keep_aspect]. See also [member frustum_offset].
 			</description>
 		</method>
 		<method name="set_orthogonal">


### PR DESCRIPTION
This PR adds a short clarification to the documentation explaining what the `size` parameter refers to in `Camera3D.set_frustum()`.

Fixes godotengine/godot-docs#11497


