### PR TITLE
Fix crash in `StorageScope.kt` on Android

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/io/StorageScope.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/io/StorageScope.kt
@@ -77,7 +77,7 @@ internal enum class StorageScope {
 		private val internalAppDir: String? = context.filesDir.canonicalPath
 		private val internalCacheDir: String? = context.cacheDir.canonicalPath
 		private val externalAppDir: String? = context.getExternalFilesDir(null)?.canonicalPath
-		private val obbDir: String? = context.obbDir.canonicalPath
+		private val obbDir: String? = context.obbDir?.canonicalPath
 		private val sharedDir : String? = Environment.getExternalStorageDirectory().canonicalPath
 		private val downloadsSharedDir: String? = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).canonicalPath
 		private val documentsSharedDir: String? = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS).canonicalPath


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/115439

[getObbDir()](https://developer.android.com/reference/android/content/Context#getObbDir()) : May return null if shared storage is not currently available.

API reference states "Shared storage may not always be available, since removable media can be ejected by the user."