### PR TITLE
Allow libgodot (mono) be loaded via Hostfxr

### DIFF
--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -22,3 +22,8 @@ env_mono.add_source_files(env.modules_sources, "utils/*.cpp")
 if env.editor_build:
     env_mono.add_source_files(env.modules_sources, "editor/*.cpp")
     SConscript("editor/script_templates/SCsub")
+elif env["library_type"] == "shared_library":
+    # For libgodot shared library builds, include hostfxr_resolver and semver
+    # to enable editor-like .NET initialization when embedding in a .NET host
+    env_mono.add_source_files(env.modules_sources, "editor/hostfxr_resolver.cpp")
+    env_mono.add_source_files(env.modules_sources, "editor/semver.cpp")

--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -20,3 +20,8 @@ def configure(env, env_mono):
         if not module_supports_tools_on(env["platform"]):
             raise RuntimeError("This module does not currently support building for this platform for editor builds.")
         env_mono.Append(CPPDEFINES=["GD_MONO_HOT_RELOAD"])
+
+    # Add LIBGODOT_HOSTFXR define for shared library builds to enable
+    # editor-like .NET initialization when embedding libgodot in a .NET host
+    if env["library_type"] == "shared_library":
+        env_mono.Append(CPPDEFINES=["LIBGODOT_HOSTFXR"])

--- a/modules/mono/glue/GodotSharp/GodotPlugins/GodotPlugins.csproj
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/GodotPlugins.csproj
@@ -9,6 +9,10 @@
     <!-- To generate the .runtimeconfig.json file-->
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <RollForward>LatestMajor</RollForward>
+
+    <!-- Trimming support for libgodot embedding scenarios -->
+    <IsTrimmable>true</IsTrimmable>
+    <VerifyReferenceTrimCompatibility>true</VerifyReferenceTrimCompatibility>
   </PropertyGroup>
 
   <ItemGroup>

--- a/modules/mono/glue/GodotSharp/GodotPlugins/Main.cs
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/Main.cs
@@ -12,6 +12,30 @@ namespace GodotPlugins
 {
     public static class Main
     {
+        // Flag to track if initialization has already been completed (for embedding scenarios)
+        private static bool _isInitialized = false;
+        private static readonly object _initLock = new object();
+
+        /// <summary>
+        /// Safely attempts to set a DllImportResolver for an assembly.
+        /// Returns true if the resolver was set, false if one was already registered.
+        /// </summary>
+        private static bool TrySetDllImportResolver(Assembly assembly, DllImportResolver resolver)
+        {
+            try
+            {
+                NativeLibrary.SetDllImportResolver(assembly, resolver);
+                return true;
+            }
+            catch (InvalidOperationException)
+            {
+                // A resolver is already registered for this assembly.
+                // This can happen when running in an embedding scenario where
+                // the host application has already set up resolvers.
+                Console.WriteLine($"GodotPlugins: DllImportResolver already set for {assembly.GetName().Name}, skipping.");
+                return false;
+            }
+        }
         // IMPORTANT:
         // Keeping strong references to the AssemblyLoadContext (our PluginLoadContext) prevents
         // it from being unloaded. To avoid issues, we wrap the reference in this class, and mark
@@ -93,21 +117,54 @@ namespace GodotPlugins
         {
             try
             {
+                // Check if already initialized (embedding scenario protection)
+                lock (_initLock)
+                {
+                    if (_isInitialized)
+                    {
+                        Console.WriteLine("GodotPlugins: Already initialized, skipping re-initialization.");
+                        // Still need to provide the callbacks
+                        *pluginsCallbacks = new()
+                        {
+                            LoadProjectAssemblyCallback = &LoadProjectAssembly,
+                            LoadToolsAssemblyCallback = &LoadToolsAssembly,
+                            UnloadProjectPluginCallback = &UnloadProjectPlugin,
+                        };
+                        *managedCallbacks = ManagedCallbacks.Create();
+                        return godot_bool.True;
+                    }
+                }
+
+                Console.WriteLine("GodotPlugins: Initializing from engine...");
+
                 _editorHint = editorHint.ToBool();
 
                 _dllImportResolver = new GodotDllImportResolver(godotDllHandle).OnResolveDllImport;
 
                 SharedAssemblies.Add(CoreApiAssembly.GetName());
-                NativeLibrary.SetDllImportResolver(CoreApiAssembly, _dllImportResolver);
+                
+                // Use safe resolver registration for embedding scenarios
+                TrySetDllImportResolver(CoreApiAssembly, _dllImportResolver);
 
                 AlcReloadCfg.Configure(alcReloadEnabled: _editorHint);
-                NativeFuncs.Initialize(unmanagedCallbacks, unmanagedCallbacksSize);
+                
+                // Wrap NativeFuncs.Initialize in try-catch for embedding scenarios
+                // where it might already be initialized by the host
+                try
+                {
+                    NativeFuncs.Initialize(unmanagedCallbacks, unmanagedCallbacksSize);
+                    Console.WriteLine("GodotPlugins: NativeFuncs initialized.");
+                }
+                catch (InvalidOperationException ex) when (ex.Message.Contains("Already initialized"))
+                {
+                    Console.WriteLine("GodotPlugins: NativeFuncs already initialized (embedding scenario).");
+                }
 
                 if (_editorHint)
                 {
                     _editorApiAssembly = Assembly.Load("GodotSharpEditor");
                     SharedAssemblies.Add(_editorApiAssembly.GetName());
-                    NativeLibrary.SetDllImportResolver(_editorApiAssembly, _dllImportResolver);
+                    TrySetDllImportResolver(_editorApiAssembly, _dllImportResolver);
                 }
 
                 *pluginsCallbacks = new()
@@ -119,11 +176,17 @@ namespace GodotPlugins
 
                 *managedCallbacks = ManagedCallbacks.Create();
 
+                lock (_initLock)
+                {
+                    _isInitialized = true;
+                }
+
+                Console.WriteLine("GodotPlugins: Initialization complete.");
                 return godot_bool.True;
             }
             catch (Exception e)
             {
-                Console.Error.WriteLine(e);
+                Console.Error.WriteLine($"GodotPlugins: Initialization failed: {e}");
                 return godot_bool.False;
             }
         }
@@ -175,7 +238,7 @@ namespace GodotPlugins
 
                 var (assembly, _) = LoadPlugin(assemblyPath, isCollectible: false);
 
-                NativeLibrary.SetDllImportResolver(assembly, _dllImportResolver!);
+                TrySetDllImportResolver(assembly, _dllImportResolver!);
 
                 var method = assembly.GetType("GodotTools.GodotSharpEditor")?
                     .GetMethod("InternalCreateInstance",

--- a/modules/mono/glue/GodotSharp/GodotPlugins/PluginLoadContext.cs
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/PluginLoadContext.cs
@@ -51,6 +51,17 @@ namespace GodotPlugins
             if (_sharedAssemblies.Contains(assemblyName.Name))
                 return _mainLoadContext.LoadFromAssemblyName(assemblyName);
 
+            // Check if the assembly is already loaded in the Default context.
+            // This prevents double-loading in embedding scenarios where libgodot
+            // is loaded into an existing .NET host application.
+            foreach (var loadedAssembly in AssemblyLoadContext.Default.Assemblies)
+            {
+                if (loadedAssembly.GetName().Name == assemblyName.Name)
+                {
+                    return loadedAssembly;
+                }
+            }
+
             string? assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
             if (assemblyPath != null)
             {

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -12,6 +12,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <AnalysisMode>Recommended</AnalysisMode>
+
+    <!-- Trimming support for libgodot embedding scenarios -->
+    <IsTrimmable>true</IsTrimmable>
+    <VerifyReferenceTrimCompatibility>true</VerifyReferenceTrimCompatibility>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -150,35 +150,48 @@ private:
 		String exe_dir = OS::get_singleton()->get_executable_path().get_base_dir();
 		String res_dir = OS::get_singleton()->get_bundle_resource_dir();
 
+		// HIGHEST PRIORITY: Check GODOT_ASSEMBLY_DIR environment variable first.
+		// This is critical for libgodot embedding scenarios where the host application
+		// (e.g., a .NET test runner) sets this variable to point to the assembly directory.
+		// NOTE: We use DirAccess::open() instead of FileAccess::exists() because
+		// FileAccess uses Godot's VFS which may not be fully initialized at this point.
+		String env_assembly_dir = OS::get_singleton()->get_environment("GODOT_ASSEMBLY_DIR");
+		print_line(".NET DEBUG: GODOT_ASSEMBLY_DIR = '" + env_assembly_dir + "'");
+		if (!env_assembly_dir.is_empty()) {
+			Ref<DirAccess> da = DirAccess::open(env_assembly_dir);
+			print_line(".NET DEBUG: DirAccess::open() valid = " + String(da.is_valid() ? "true" : "false"));
+			if (da.is_valid()) {
+				bool has_plugins = da->file_exists("GodotPlugins.dll");
+				print_line(".NET DEBUG: file_exists('GodotPlugins.dll') = " + String(has_plugins ? "true" : "false"));
+				if (has_plugins) {
+					api_assemblies_dir = env_assembly_dir;
+					print_verbose(".NET: Using GODOT_ASSEMBLY_DIR environment variable (highest priority): " + env_assembly_dir);
+				}
+			}
+		}
+
 #ifdef TOOLS_ENABLED
-		String data_dir_root = exe_dir.path_join("GodotSharp");
-		data_editor_tools_dir = data_dir_root.path_join("Tools");
-		String api_assemblies_base_dir = data_dir_root.path_join("Api");
-		build_logs_dir = mono_user_dir.path_join("build_logs");
+		// Only use default paths if GODOT_ASSEMBLY_DIR wasn't set or was invalid
+		if (api_assemblies_dir.is_empty()) {
+			String data_dir_root = exe_dir.path_join("GodotSharp");
+			data_editor_tools_dir = data_dir_root.path_join("Tools");
+			String api_assemblies_base_dir = data_dir_root.path_join("Api");
+			build_logs_dir = mono_user_dir.path_join("build_logs");
 #ifdef MACOS_ENABLED
-		if (!DirAccess::exists(data_editor_tools_dir)) {
-			data_editor_tools_dir = res_dir.path_join("GodotSharp").path_join("Tools");
-		}
-		if (!DirAccess::exists(api_assemblies_base_dir)) {
-			api_assemblies_base_dir = res_dir.path_join("GodotSharp").path_join("Api");
-		}
+			if (!DirAccess::exists(data_editor_tools_dir)) {
+				data_editor_tools_dir = res_dir.path_join("GodotSharp").path_join("Tools");
+			}
+			if (!DirAccess::exists(api_assemblies_base_dir)) {
+				api_assemblies_base_dir = res_dir.path_join("GodotSharp").path_join("Api");
+			}
 #endif
-		api_assemblies_dir = api_assemblies_base_dir.path_join(GDMono::get_expected_api_build_config());
-#else // TOOLS_ENABLED
+			api_assemblies_dir = api_assemblies_base_dir.path_join(GDMono::get_expected_api_build_config());
+		}
+#elif !defined(LIBGODOT_HOSTFXR) // Not TOOLS_ENABLED and not LIBGODOT_HOSTFXR - template builds
 		String platform = _get_platform_name();
 		String arch = Engine::get_singleton()->get_architecture_name();
 		String appname_safe = Path::get_csharp_project_name();
 		String packed_path = "res://.godot/mono/publish/" + arch;
-		
-		// HIGHEST PRIORITY: Check GODOT_ASSEMBLY_DIR environment variable first.
-		// This is critical for libgodot embedding scenarios where the host application
-		// (e.g., a .NET test runner) sets this variable to point to the assembly directory.
-		// Must be checked before any other path resolution to ensure it takes effect.
-		String env_assembly_dir = OS::get_singleton()->get_environment("GODOT_ASSEMBLY_DIR");
-		if (!env_assembly_dir.is_empty() && FileAccess::exists(env_assembly_dir.path_join("GodotPlugins.dll"))) {
-			api_assemblies_dir = env_assembly_dir;
-			print_verbose(".NET: Using GODOT_ASSEMBLY_DIR environment variable (highest priority): " + env_assembly_dir);
-		}
 #ifdef ANDROID_ENABLED
 		else {
 			api_assemblies_dir = packed_path;

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -45,7 +45,7 @@
 namespace GodotSharpDirs {
 
 String _get_expected_build_config() {
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 	return "Debug";
 #else
 
@@ -216,6 +216,44 @@ private:
 				data_dir_root = res_dir.path_join("data_" + appname_safe + "_" + platform + "_" + arch);
 			}
 #endif
+			// Fallback paths for libgodot embedding scenarios.
+			// When Godot is embedded via libgodot in a .NET host application,
+			// the assemblies may be in simpler locations.
+			if (!DirAccess::exists(data_dir_root) || !FileAccess::exists(data_dir_root.path_join("GodotPlugins.dll"))) {
+				// Get the current working directory - when running via dotnet test,
+				// exe_dir points to dotnet's location but cwd is the test output dir
+				String cwd = OS::get_singleton()->get_cwd();
+				
+				// Also check GODOT_ASSEMBLY_DIR environment variable for explicit override
+				String env_assembly_dir = OS::get_singleton()->get_environment("GODOT_ASSEMBLY_DIR");
+				
+				// Try GodotSharp/Api/Debug/ structure (like editor builds) - first in exe_dir, then cwd
+				String api_debug_path = exe_dir.path_join("GodotSharp").path_join("Api").path_join("Debug");
+				String cwd_api_debug_path = cwd.path_join("GodotSharp").path_join("Api").path_join("Debug");
+				
+				if (!env_assembly_dir.is_empty() && FileAccess::exists(env_assembly_dir.path_join("GodotPlugins.dll"))) {
+					// Environment variable override takes priority
+					data_dir_root = env_assembly_dir;
+					print_verbose(".NET: Using GODOT_ASSEMBLY_DIR environment variable: " + env_assembly_dir);
+				} else if (FileAccess::exists(cwd.path_join("GodotPlugins.dll"))) {
+					// Try flat structure in cwd first - this is the most common case for NuGet package consumers
+					// where MSBuild copies GodotPlugins.dll to the output directory
+					data_dir_root = cwd;
+					print_verbose(".NET: Using flat cwd for assemblies (libgodot embedding): " + cwd);
+				} else if (FileAccess::exists(cwd_api_debug_path.path_join("GodotPlugins.dll"))) {
+					// Try nested structure in cwd
+					data_dir_root = cwd_api_debug_path;
+					print_verbose(".NET: Using cwd GodotSharp/Api/Debug/ path for assemblies (libgodot embedding)");
+				} else if (FileAccess::exists(api_debug_path.path_join("GodotPlugins.dll"))) {
+					// Try nested structure in exe_dir
+					data_dir_root = api_debug_path;
+					print_verbose(".NET: Using GodotSharp/Api/Debug/ path for assemblies (libgodot embedding)");
+				} else if (FileAccess::exists(exe_dir.path_join("GodotPlugins.dll"))) {
+					// Try flat structure in exe_dir
+					data_dir_root = exe_dir;
+					print_verbose(".NET: Using flat exe directory for assemblies (libgodot embedding)");
+				}
+			}
 			api_assemblies_dir = data_dir_root;
 		}
 #endif // ANDROID_ENABLED

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -169,11 +169,23 @@ private:
 		String arch = Engine::get_singleton()->get_architecture_name();
 		String appname_safe = Path::get_csharp_project_name();
 		String packed_path = "res://.godot/mono/publish/" + arch;
+		
+		// HIGHEST PRIORITY: Check GODOT_ASSEMBLY_DIR environment variable first.
+		// This is critical for libgodot embedding scenarios where the host application
+		// (e.g., a .NET test runner) sets this variable to point to the assembly directory.
+		// Must be checked before any other path resolution to ensure it takes effect.
+		String env_assembly_dir = OS::get_singleton()->get_environment("GODOT_ASSEMBLY_DIR");
+		if (!env_assembly_dir.is_empty() && FileAccess::exists(env_assembly_dir.path_join("GodotPlugins.dll"))) {
+			api_assemblies_dir = env_assembly_dir;
+			print_verbose(".NET: Using GODOT_ASSEMBLY_DIR environment variable (highest priority): " + env_assembly_dir);
+		}
 #ifdef ANDROID_ENABLED
-		api_assemblies_dir = packed_path;
-		print_verbose(".NET: Android platform detected. Setting api_assemblies_dir directly to pck path: " + api_assemblies_dir);
+		else {
+			api_assemblies_dir = packed_path;
+			print_verbose(".NET: Android platform detected. Setting api_assemblies_dir directly to pck path: " + api_assemblies_dir);
+		}
 #else
-		if (DirAccess::exists(packed_path)) {
+		else if (DirAccess::exists(packed_path)) {
 			// The dotnet publish data is packed in the pck/zip.
 			String data_dir_root = OS::get_singleton()->get_cache_path().path_join("data_" + appname_safe + "_" + platform + "_" + arch);
 			bool has_data = false;
@@ -224,18 +236,11 @@ private:
 				// exe_dir points to dotnet's location but cwd is the test output dir
 				String cwd = OS::get_singleton()->get_cwd();
 				
-				// Also check GODOT_ASSEMBLY_DIR environment variable for explicit override
-				String env_assembly_dir = OS::get_singleton()->get_environment("GODOT_ASSEMBLY_DIR");
-				
 				// Try GodotSharp/Api/Debug/ structure (like editor builds) - first in exe_dir, then cwd
 				String api_debug_path = exe_dir.path_join("GodotSharp").path_join("Api").path_join("Debug");
 				String cwd_api_debug_path = cwd.path_join("GodotSharp").path_join("Api").path_join("Debug");
 				
-				if (!env_assembly_dir.is_empty() && FileAccess::exists(env_assembly_dir.path_join("GodotPlugins.dll"))) {
-					// Environment variable override takes priority
-					data_dir_root = env_assembly_dir;
-					print_verbose(".NET: Using GODOT_ASSEMBLY_DIR environment variable: " + env_assembly_dir);
-				} else if (FileAccess::exists(cwd.path_join("GodotPlugins.dll"))) {
+				if (FileAccess::exists(cwd.path_join("GodotPlugins.dll"))) {
 					// Try flat structure in cwd first - this is the most common case for NuGet package consumers
 					// where MSBuild copies GodotPlugins.dll to the output directory
 					data_dir_root = cwd;

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -537,13 +537,8 @@ godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime
 			initialize_hostfxr_for_config(get_data(config_path));
 
 	if (load_assembly_and_get_function_pointer == nullptr) {
-		// Show a message box to the user to make the problem explicit (and explain a potential crash).
-#ifdef TOOLS_ENABLED
-		OS::get_singleton()->alert(TTR("Unable to load .NET runtime, no compatible version was found.\nAttempting to create/edit a project will lead to a crash.\n\nPlease install the .NET SDK 8.0 or later from https://get.dot.net and restart Godot."), TTR("Failed to load .NET runtime"));
-#else
-		OS::get_singleton()->alert("Unable to load .NET runtime, no compatible version was found.\n\nPlease install the .NET SDK 8.0 or later from https://get.dot.net and restart.", "Failed to load .NET runtime");
-#endif
-		ERR_FAIL_V_MSG(nullptr, ".NET: Failed to load compatible .NET runtime");
+		// Log the error and fail - no modal dialog to avoid blocking in headless/test scenarios
+		ERR_FAIL_V_MSG(nullptr, ".NET: Failed to load compatible .NET runtime. Please install the .NET SDK 8.0 or later from https://get.dot.net");
 	}
 
 	r_runtime_initialized = true;
@@ -747,8 +742,8 @@ void GDMono::initialize() {
 #if !defined(APPLE_EMBEDDED_ENABLED)
 	// Check that the .NET assemblies directory exists before trying to use it.
 	if (!DirAccess::exists(GodotSharpDirs::get_api_assemblies_dir())) {
-		OS::get_singleton()->alert(vformat(RTR("Unable to find the .NET assemblies directory.\nMake sure the '%s' directory exists and contains the .NET assemblies."), GodotSharpDirs::get_api_assemblies_dir()), RTR(".NET assemblies not found"));
-		ERR_FAIL_MSG(".NET: Assemblies not found");
+		// Log the error and fail - no modal dialog to avoid blocking in headless/test scenarios
+		ERR_FAIL_MSG(".NET: Assemblies not found. Make sure the '" + GodotSharpDirs::get_api_assemblies_dir() + "' directory exists and contains the .NET assemblies.");
 	}
 #endif
 
@@ -771,13 +766,11 @@ void GDMono::initialize() {
 			ERR_FAIL_MSG(".NET: Failed to load hostfxr");
 		}
 #elif defined(LIBGODOT_HOSTFXR)
-		// Show a message box for libgodot builds (non-editor)
-		OS::get_singleton()->alert("Unable to load .NET runtime, specifically hostfxr.\n\nPlease install the .NET SDK 8.0 or later from https://get.dot.net and restart.", "Failed to load .NET runtime");
-		ERR_FAIL_MSG(".NET: Failed to load hostfxr");
+		// Log the error and fail - no modal dialog to avoid blocking in headless/test scenarios
+		ERR_FAIL_MSG(".NET: Failed to load hostfxr. Please install the .NET SDK 8.0 or later from https://get.dot.net");
 #else
-		// Show a message box to the user to make the problem explicit (and explain a potential crash).
-		OS::get_singleton()->alert(TTR("Unable to load .NET runtime, specifically hostfxr.\nAttempting to create/edit a project will lead to a crash.\n\nPlease install the .NET SDK 8.0 or later from https://get.dot.net and restart Godot."), TTR("Failed to load .NET runtime"));
-		ERR_FAIL_MSG(".NET: Failed to load hostfxr");
+		// Log the error and fail - no modal dialog to avoid blocking in headless/test scenarios
+		ERR_FAIL_MSG(".NET: Failed to load hostfxr. Please install the .NET SDK 8.0 or later from https://get.dot.net");
 #endif
 	}
 

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -38,7 +38,7 @@
 #include "../utils/path_utils.h"
 #include "gd_mono_cache.h"
 
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 #include "../editor/hostfxr_resolver.h"
 #include "../editor/semver.h"
 #endif
@@ -63,6 +63,22 @@
 GDMono *GDMono::singleton = nullptr;
 
 namespace {
+
+// hostfxr success return codes
+// See: https://github.com/dotnet/runtime/blob/main/docs/design/features/native-hosting.md
+constexpr int32_t HOSTFXR_SUCCESS = 0;
+constexpr int32_t HOSTFXR_SUCCESS_HOST_ALREADY_INITIALIZED = 1;
+constexpr int32_t HOSTFXR_SUCCESS_DIFFERENT_RUNTIME_PROPERTIES = 2;
+
+// Helper function to check if a hostfxr return code indicates success.
+// This is important for embedding scenarios where a .NET runtime may already be running
+// (e.g., when libgodot is loaded into an existing .NET host application).
+bool is_hostfxr_success(int32_t rc) {
+	return rc == HOSTFXR_SUCCESS ||
+		   rc == HOSTFXR_SUCCESS_HOST_ALREADY_INITIALIZED ||
+		   rc == HOSTFXR_SUCCESS_DIFFERENT_RUNTIME_PROPERTIES;
+}
+
 hostfxr_initialize_for_dotnet_command_line_fn hostfxr_initialize_for_dotnet_command_line = nullptr;
 hostfxr_initialize_for_runtime_config_fn hostfxr_initialize_for_runtime_config = nullptr;
 hostfxr_get_runtime_delegate_fn hostfxr_get_runtime_delegate = nullptr;
@@ -106,7 +122,7 @@ const char_t *get_data(const HostFxrCharString &p_char_str) {
 	return (const char_t *)p_char_str.get_data();
 }
 
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 bool try_get_dotnet_root_from_command_line(String &r_dotnet_root) {
 	String pipe;
 	List<String> args;
@@ -161,7 +177,7 @@ bool try_get_dotnet_root_from_command_line(String &r_dotnet_root) {
 #endif
 
 String find_hostfxr() {
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 	String dotnet_root;
 	String fxr_path;
 	if (godotsharp::hostfxr_resolver::try_get_path(dotnet_root, fxr_path)) {
@@ -202,7 +218,7 @@ String find_hostfxr() {
 
 	return String();
 
-#endif
+#endif // defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 }
 
 #ifndef TOOLS_ENABLED
@@ -358,28 +374,71 @@ bool load_coreclr(void *&r_coreclr_dll_handle) {
 }
 #endif
 
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 load_assembly_and_get_function_pointer_fn initialize_hostfxr_for_config(const char_t *p_config_path) {
 	hostfxr_handle cxt = nullptr;
 	int rc = hostfxr_initialize_for_runtime_config(p_config_path, nullptr, &cxt);
-	if (rc != 0 || cxt == nullptr) {
-		hostfxr_close(cxt);
+
+	if (!is_hostfxr_success(rc)) {
+		if (cxt != nullptr) {
+			hostfxr_close(cxt);
+		}
 		ERR_FAIL_V_MSG(nullptr, "hostfxr_initialize_for_runtime_config failed with code: " + itos(rc));
 	}
 
-	void *load_assembly_and_get_function_pointer = nullptr;
+	// Track if we're in an embedding scenario where the .NET runtime is already running
+	// (e.g., libgodot loaded into an existing .NET host application like `dotnet run`)
+	bool host_already_initialized = (rc == HOSTFXR_SUCCESS_HOST_ALREADY_INITIALIZED ||
+									  rc == HOSTFXR_SUCCESS_DIFFERENT_RUNTIME_PROPERTIES);
 
-	rc = hostfxr_get_runtime_delegate(cxt,
-			hdt_load_assembly_and_get_function_pointer, &load_assembly_and_get_function_pointer);
-	if (rc != 0 || load_assembly_and_get_function_pointer == nullptr) {
-		ERR_FAIL_V_MSG(nullptr, "hostfxr_get_runtime_delegate failed with code: " + itos(rc));
+	if (rc == HOSTFXR_SUCCESS_HOST_ALREADY_INITIALIZED) {
+		print_verbose(".NET: Detected existing .NET runtime (host already initialized) - embedding mode");
+	} else if (rc == HOSTFXR_SUCCESS_DIFFERENT_RUNTIME_PROPERTIES) {
+		print_verbose(".NET: Detected existing .NET runtime (different runtime properties) - embedding mode");
 	}
 
-	hostfxr_close(cxt);
+	void *load_assembly_and_get_function_pointer = nullptr;
+	int delegate_rc = 0;
+
+	if (host_already_initialized) {
+		// When the host is already initialized, try using nullptr to get delegates from
+		// the active host context first. This is the recommended approach for embedding scenarios.
+		print_verbose(".NET: Trying to get runtime delegate from active host context (nullptr)");
+		delegate_rc = hostfxr_get_runtime_delegate(nullptr,
+				hdt_load_assembly_and_get_function_pointer, &load_assembly_and_get_function_pointer);
+		
+		if (delegate_rc != 0 || load_assembly_and_get_function_pointer == nullptr) {
+			// Fallback: try with the returned context handle
+			print_verbose(".NET: Active context failed (code: " + itos(delegate_rc) + "), trying returned context handle");
+			if (cxt != nullptr) {
+				delegate_rc = hostfxr_get_runtime_delegate(cxt,
+						hdt_load_assembly_and_get_function_pointer, &load_assembly_and_get_function_pointer);
+			}
+		}
+	} else {
+		// Normal initialization: we created the runtime, use the context handle
+		delegate_rc = hostfxr_get_runtime_delegate(cxt,
+				hdt_load_assembly_and_get_function_pointer, &load_assembly_and_get_function_pointer);
+	}
+
+	if (delegate_rc != 0 || load_assembly_and_get_function_pointer == nullptr) {
+		if (cxt != nullptr && !host_already_initialized) {
+			hostfxr_close(cxt);
+		}
+		ERR_FAIL_V_MSG(nullptr, "hostfxr_get_runtime_delegate failed with code: " + itos(delegate_rc));
+	}
+
+	// Only close the context if we created the runtime ourselves.
+	// In embedding scenarios, we don't own the runtime context.
+	if (cxt != nullptr && !host_already_initialized) {
+		hostfxr_close(cxt);
+	}
 
 	return (load_assembly_and_get_function_pointer_fn)load_assembly_and_get_function_pointer;
 }
-#else
+#endif // defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
+
+#if !defined(TOOLS_ENABLED) && !defined(LIBGODOT_HOSTFXR)
 load_assembly_and_get_function_pointer_fn initialize_hostfxr_self_contained(
 		const char_t *p_main_assembly_path) {
 	hostfxr_handle cxt = nullptr;
@@ -400,32 +459,71 @@ load_assembly_and_get_function_pointer_fn initialize_hostfxr_self_contained(
 	}
 
 	int rc = hostfxr_initialize_for_dotnet_command_line(argv.size(), argv.ptrw(), nullptr, &cxt);
-	if (rc != 0 || cxt == nullptr) {
-		hostfxr_close(cxt);
+	if (!is_hostfxr_success(rc)) {
+		if (cxt != nullptr) {
+			hostfxr_close(cxt);
+		}
 		ERR_FAIL_V_MSG(nullptr, "hostfxr_initialize_for_dotnet_command_line failed with code: " + itos(rc));
 	}
 
-	void *load_assembly_and_get_function_pointer = nullptr;
+	// Track if we're in an embedding scenario where the .NET runtime is already running
+	bool host_already_initialized = (rc == HOSTFXR_SUCCESS_HOST_ALREADY_INITIALIZED ||
+									  rc == HOSTFXR_SUCCESS_DIFFERENT_RUNTIME_PROPERTIES);
 
-	rc = hostfxr_get_runtime_delegate(cxt,
-			hdt_load_assembly_and_get_function_pointer, &load_assembly_and_get_function_pointer);
-	if (rc != 0 || load_assembly_and_get_function_pointer == nullptr) {
-		ERR_FAIL_V_MSG(nullptr, "hostfxr_get_runtime_delegate failed with code: " + itos(rc));
+	if (rc == HOSTFXR_SUCCESS_HOST_ALREADY_INITIALIZED) {
+		print_verbose(".NET: Detected existing .NET runtime (host already initialized) - embedding mode");
+	} else if (rc == HOSTFXR_SUCCESS_DIFFERENT_RUNTIME_PROPERTIES) {
+		print_verbose(".NET: Detected existing .NET runtime (different runtime properties) - embedding mode");
 	}
 
-	hostfxr_close(cxt);
+	void *load_assembly_and_get_function_pointer = nullptr;
+	int delegate_rc = 0;
+
+	if (host_already_initialized) {
+		// When the host is already initialized, try using nullptr to get delegates from
+		// the active host context first. This is the recommended approach for embedding scenarios.
+		print_verbose(".NET: Trying to get runtime delegate from active host context (nullptr)");
+		delegate_rc = hostfxr_get_runtime_delegate(nullptr,
+				hdt_load_assembly_and_get_function_pointer, &load_assembly_and_get_function_pointer);
+		
+		if (delegate_rc != 0 || load_assembly_and_get_function_pointer == nullptr) {
+			// Fallback: try with the returned context handle
+			print_verbose(".NET: Active context failed (code: " + itos(delegate_rc) + "), trying returned context handle");
+			if (cxt != nullptr) {
+				delegate_rc = hostfxr_get_runtime_delegate(cxt,
+						hdt_load_assembly_and_get_function_pointer, &load_assembly_and_get_function_pointer);
+			}
+		}
+	} else {
+		// Normal initialization: we created the runtime, use the context handle
+		delegate_rc = hostfxr_get_runtime_delegate(cxt,
+				hdt_load_assembly_and_get_function_pointer, &load_assembly_and_get_function_pointer);
+	}
+
+	if (delegate_rc != 0 || load_assembly_and_get_function_pointer == nullptr) {
+		if (cxt != nullptr && !host_already_initialized) {
+			hostfxr_close(cxt);
+		}
+		ERR_FAIL_V_MSG(nullptr, "hostfxr_get_runtime_delegate failed with code: " + itos(delegate_rc));
+	}
+
+	// Only close the context if we created the runtime ourselves.
+	// In embedding scenarios, we don't own the runtime context.
+	if (cxt != nullptr && !host_already_initialized) {
+		hostfxr_close(cxt);
+	}
 
 	return (load_assembly_and_get_function_pointer_fn)load_assembly_and_get_function_pointer;
 }
-#endif
+#endif // !defined(TOOLS_ENABLED) && !defined(LIBGODOT_HOSTFXR)
 
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 using godot_plugins_initialize_fn = bool (*)(void *, bool, gdmono::PluginCallbacks *, GDMonoCache::ManagedCallbacks *, const void **, int32_t);
 #else
 using godot_plugins_initialize_fn = bool (*)(void *, GDMonoCache::ManagedCallbacks *, const void **, int32_t);
 #endif
 
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime_initialized) {
 	godot_plugins_initialize_fn godot_plugins_initialize = nullptr;
 
@@ -440,7 +538,11 @@ godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime
 
 	if (load_assembly_and_get_function_pointer == nullptr) {
 		// Show a message box to the user to make the problem explicit (and explain a potential crash).
+#ifdef TOOLS_ENABLED
 		OS::get_singleton()->alert(TTR("Unable to load .NET runtime, no compatible version was found.\nAttempting to create/edit a project will lead to a crash.\n\nPlease install the .NET SDK 8.0 or later from https://get.dot.net and restart Godot."), TTR("Failed to load .NET runtime"));
+#else
+		OS::get_singleton()->alert("Unable to load .NET runtime, no compatible version was found.\n\nPlease install the .NET SDK 8.0 or later from https://get.dot.net and restart.", "Failed to load .NET runtime");
+#endif
 		ERR_FAIL_V_MSG(nullptr, ".NET: Failed to load compatible .NET runtime");
 	}
 
@@ -458,7 +560,9 @@ godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime
 
 	return godot_plugins_initialize;
 }
-#else
+#endif // defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
+
+#if !defined(TOOLS_ENABLED) && !defined(LIBGODOT_HOSTFXR)
 godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime_initialized) {
 	godot_plugins_initialize_fn godot_plugins_initialize = nullptr;
 
@@ -517,7 +621,7 @@ godot_plugins_initialize_fn try_load_native_aot_library(void *&r_aot_dll_handle)
 }
 #endif
 
-#ifndef TOOLS_ENABLED
+#if !defined(TOOLS_ENABLED) && !defined(LIBGODOT_HOSTFXR)
 #ifdef ANDROID_ENABLED
 MonoAssembly *load_assembly_from_pck(MonoAssemblyName *p_assembly_name, char **p_assemblies_path, void *p_user_data) {
 	constexpr bool ref_only = false;
@@ -603,13 +707,13 @@ godot_plugins_initialize_fn initialize_coreclr_and_godot_plugins(bool &r_runtime
 
 	return godot_plugins_initialize;
 }
-#endif
+#endif // !defined(TOOLS_ENABLED) && !defined(LIBGODOT_HOSTFXR)
 
 } // namespace
 
 bool GDMono::should_initialize() {
-#ifdef TOOLS_ENABLED
-	// The editor always needs to initialize the .NET module for now.
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
+	// The editor and libgodot shared library builds always need to initialize the .NET module.
 	return true;
 #else
 	return OS::get_singleton()->has_feature("dotnet");
@@ -652,7 +756,7 @@ void GDMono::initialize() {
 		godot_plugins_initialize = initialize_hostfxr_and_godot_plugins(runtime_initialized);
 		ERR_FAIL_NULL(godot_plugins_initialize);
 	} else {
-#if !defined(TOOLS_ENABLED)
+#if !defined(TOOLS_ENABLED) && !defined(LIBGODOT_HOSTFXR)
 		if (load_coreclr(coreclr_dll_handle)) {
 			godot_plugins_initialize = initialize_coreclr_and_godot_plugins(runtime_initialized);
 		} else {
@@ -666,8 +770,11 @@ void GDMono::initialize() {
 		if (godot_plugins_initialize == nullptr) {
 			ERR_FAIL_MSG(".NET: Failed to load hostfxr");
 		}
+#elif defined(LIBGODOT_HOSTFXR)
+		// Show a message box for libgodot builds (non-editor)
+		OS::get_singleton()->alert("Unable to load .NET runtime, specifically hostfxr.\n\nPlease install the .NET SDK 8.0 or later from https://get.dot.net and restart.", "Failed to load .NET runtime");
+		ERR_FAIL_MSG(".NET: Failed to load hostfxr");
 #else
-
 		// Show a message box to the user to make the problem explicit (and explain a potential crash).
 		OS::get_singleton()->alert(TTR("Unable to load .NET runtime, specifically hostfxr.\nAttempting to create/edit a project will lead to a crash.\n\nPlease install the .NET SDK 8.0 or later from https://get.dot.net and restart Godot."), TTR("Failed to load .NET runtime"));
 		ERR_FAIL_MSG(".NET: Failed to load hostfxr");
@@ -686,7 +793,7 @@ void GDMono::initialize() {
 	godot_dll_handle = dlopen(nullptr, RTLD_NOW);
 #endif
 
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 	gdmono::PluginCallbacks plugin_callbacks_res;
 	bool init_ok = godot_plugins_initialize(godot_dll_handle,
 			Engine::get_singleton()->is_editor_hint(),
@@ -707,14 +814,14 @@ void GDMono::initialize() {
 
 	_on_core_api_assembly_loaded();
 
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 	_try_load_project_assembly();
 #endif
 
 	initialized = true;
 }
 
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 void GDMono::_try_load_project_assembly() {
 	if (Engine::get_singleton()->is_project_manager_hint()) {
 		return;
@@ -741,7 +848,7 @@ void GDMono::_init_godot_api_hashes() {
 #endif // DEBUG_ENABLED
 }
 
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 bool GDMono::_load_project_assembly() {
 	String assembly_name = Path::get_csharp_project_name();
 

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -44,7 +44,7 @@
 
 namespace gdmono {
 
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 struct PluginCallbacks {
 	using FuncLoadProjectAssemblyCallback = bool(GD_CLR_STDCALL *)(const char16_t *, String *);
 	using FuncLoadToolsAssemblyCallback = Object *(GD_CLR_STDCALL *)(const char16_t *, const void **, int32_t);
@@ -53,7 +53,7 @@ struct PluginCallbacks {
 	FuncLoadToolsAssemblyCallback LoadToolsAssemblyCallback = nullptr;
 	FuncUnloadProjectPluginCallback UnloadProjectPluginCallback = nullptr;
 };
-#endif
+#endif // defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 
 } // namespace gdmono
 
@@ -71,7 +71,7 @@ class GDMono {
 	int project_load_failure_count = 0;
 #endif
 
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 	bool _load_project_assembly();
 	void _try_load_project_assembly();
 #endif
@@ -84,7 +84,7 @@ class GDMono {
 #endif
 	void _init_godot_api_hashes();
 
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 	gdmono::PluginCallbacks plugin_callbacks;
 #endif
 
@@ -110,7 +110,7 @@ public:
 #endif // DEBUG_ENABLED
 
 	_FORCE_INLINE_ static String get_expected_api_build_config() {
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 		return "Debug";
 #else
 #ifdef DEBUG_ENABLED
@@ -142,7 +142,7 @@ public:
 		return project_assembly_modified_time;
 	}
 
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) || defined(LIBGODOT_HOSTFXR)
 	const gdmono::PluginCallbacks &get_plugin_callbacks() {
 		return plugin_callbacks;
 	}

--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -42,6 +42,12 @@
 #undef CRASH_HANDLER_ENABLED
 #endif
 
+// Disable crash handler when libgodot is enabled, as Godot's signal handlers
+// conflict with .NET runtime requirements in embedding scenarios.
+#ifdef LIBGODOT_ENABLED
+#undef CRASH_HANDLER_ENABLED
+#endif
+
 #ifdef CRASH_HANDLER_ENABLED
 #include <cxxabi.h>
 #include <dlfcn.h>

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -44,6 +44,12 @@
 #define CRASH_HANDLER_ENABLED 1
 #endif
 
+// Disable crash handler when libgodot is enabled, as Godot's signal handlers
+// conflict with .NET runtime requirements in embedding scenarios.
+#ifdef LIBGODOT_ENABLED
+#undef CRASH_HANDLER_ENABLED
+#endif
+
 #ifdef CRASH_HANDLER_ENABLED
 #include <cxxabi.h>
 #include <dlfcn.h>

--- a/platform/windows/crash_handler_windows_seh.cpp
+++ b/platform/windows/crash_handler_windows_seh.cpp
@@ -40,6 +40,15 @@
 
 #ifdef CRASH_HANDLER_EXCEPTION
 
+// Disable crash handler when libgodot is enabled, as Godot's exception handlers
+// conflict with .NET runtime requirements in embedding scenarios.
+#ifdef LIBGODOT_ENABLED
+#undef CRASH_HANDLER_EXCEPTION
+#endif
+#endif
+
+#ifdef CRASH_HANDLER_EXCEPTION
+
 // Backtrace code based on: https://stackoverflow.com/questions/6205981/windows-c-stack-trace-from-a-running-app
 
 #include <algorithm>


### PR DESCRIPTION
## Preface
This is a work in progress set of changes, this PR should serve as the basis for discussion.
I hope it is ok to do it in the form of a draft PR.

Ideally, we can cut down the required changes in this before this can become a proper PR.

## Goal
Goal is to load libgodot from C#, using .NET Core [hostfxr](https://learn.microsoft.com/en-us/dotnet/core/tutorials/netcore-hosting), and to load it in all 3 main targets: `template_release`, `template_debug`, and `editor`.

Typical build  parameters would be: `scons target=[editor|template_release|template_debug] module_mono_enabled=yes library_type=shared_library`

## Use Case
I call this backwards way of running godot [2dog](https://2dog.dev), and it would be used to:
- run full games and apps
- embed godot
- embed the editor (e.g. in CI tools)
- run unit tests (e.g. via xunit fixtures, see 2dog.xunit)

## Major Challenges
The problems encountered trying to build and load `libgodot` (and are):
- this PR feels _way too extensive_, I must be doing something fundamentally wrong?
- it appears like each configuration tries to load the .NET assemblies from a different location. this is a considerable pain point and should perhaps be cleaned up regardless. I'm currently pulling an optional search location from the environment just to make the behaviour more uniform.
- GodotPlugins.dll is not part of any of the official .NET SDK or GodotSharp nuget packages, making it difficult to build against the editor toolchain. (might circumvent this with a path to locally installed godot? but if I install godot via my linux package manager, I haven't found the GodotSharp directory at all)... maybe make GodotPlugins a nuget package?
- making the "host" project's C# classes visible to the twodog assemblies (which loaded libgodot) requires some extra handling
- and vice versa
- (somewhat of an MSBuild problem) paths are extremely sensitive; meaning it often matters painfully where the current working directory is whether all, some, or none of the components of a project are found, resulting in irritating error messages (e.g. the ".NET assemblies not found" popup can come from both the actual Godot project, as well as the 2dog assemblies.
- it's hard to lazy-initialize things such as Node constructors due to the reversed order of loading things (i.e. static stuff in the 2dog assembly runs before libgodot get a chance).

## Minor Pain points
- some methods, like `Stop()` aren't exposed, so we're stuck with `libgodot_destroy_godot_instance` and it's not clear what the repercussions are
- godot not finding the .NET assemblies creates a modal popup and does not kill the process, this means the process will hang pending user input, AND if user input is given to acknowledge the messagebox, no error is picked up by test runners in a variety of cases. There should be no modal popups, or they should be disabled, and the process should terminate with a nonzero exit code.
- can't (easily) relaunch Godot in same process, huge issue for 2dog.xunit, the xuint fixtures I want to provide as part of the project that uses libgodot).
- uid cache and importing is still a complete mess (nontrivial godot-mono projects don't like to run they haven't previously been opened in a proper editor and had its script uids created? though admittedly, other imports also need to be run; absence of the uid files however can make the scripts invisible from the twodog assembly, no idea why)
- code generation barfs warnings a lot, I think the source generators are also not set up for this kind of operation / have no sensible defaults
- lack of an official libgodot distribution means users have to compile their own, or I need to distribute libgodot as a set of custom nuget packages (which I currently do with my fork, e.g. `2dog_libgodot_linux-x64_release.nupkg`, especially the `editor` version is sort of a chonky boi though, but still legal even on nuget)
- the dependency on an existing godot project is a nuisance, would love to be able to run just an empty one with out having to ship and shimmy one in place with my packages)

## Alternatives
- maybe it's overall a better idea to just support GDExtension, but the status of GDExtension-GodotSharp is nebulous, and I have lost track of which is the latest repo that does it. Apart from a bindings generator still from the days of the gdextension.h, I haven't seen much there for .NET, also not in the docs.
- cross-functionality of any GDExtension port with "classic" godot-mono is dubious, but kind of a key requirement for my main use case, 2dog.dev, which is supposed to be a drop-in way to embed any godot game into a C# process :) The real idea here is that 2dog has nothing to do with GDextension, GDnative, GodotSharp, or anything; just uses whatever libgodot you feed it, and tries to provide as much interop as possible if there's any C# in the mix.
- I'd personally prefer clean static or dynamic linkage instead of having a manual build step parse megabytes of json and spin the function hash slot machine to successfully or unsucessfully use GDExtension; with user-side failures often coming late at runtime. (i.e. `extern C` all the way for proper, fast interop and linker warnings)