### PR TITLE
Rename glow structs in Compatibility renderer to match code style guidelines

### DIFF
--- a/drivers/gles3/effects/glow.cpp
+++ b/drivers/gles3/effects/glow.cpp
@@ -88,7 +88,7 @@ void Glow::_draw_screen_triangle() {
 	glBindVertexArray(0);
 }
 
-void Glow::process_glow(GLuint p_source_color, Size2i p_size, const Glow::GLOWLEVEL *p_glow_buffers, uint32_t p_view, bool p_use_multiview) {
+void Glow::process_glow(GLuint p_source_color, Size2i p_size, const Glow::Level *p_glow_buffers, uint32_t p_view, bool p_use_multiview) {
 	ERR_FAIL_COND(p_source_color == 0);
 	ERR_FAIL_COND(p_glow_buffers[3].color == 0);
 

--- a/drivers/gles3/effects/glow.h
+++ b/drivers/gles3/effects/glow.h
@@ -40,7 +40,7 @@ class Glow {
 private:
 	static Glow *singleton;
 
-	struct GLOW {
+	struct GlowShader {
 		GlowShaderGLES3 shader;
 		RID shader_version;
 	} glow;
@@ -60,7 +60,7 @@ private:
 	void _draw_screen_triangle();
 
 public:
-	struct GLOWLEVEL {
+	struct Level {
 		Size2i size;
 		GLuint color = 0;
 		GLuint fbo = 0;
@@ -78,7 +78,7 @@ public:
 	void set_glow_hdr_bleed_scale(float p_scale) { glow_hdr_bleed_scale = p_scale; }
 	void set_glow_hdr_luminance_cap(float p_cap) { glow_hdr_luminance_cap = p_cap; }
 
-	void process_glow(GLuint p_source_color, Size2i p_size, const GLOWLEVEL *p_glow_buffers, uint32_t p_view = 0, bool p_use_multiview = false);
+	void process_glow(GLuint p_source_color, Size2i p_size, const Level *p_glow_buffers, uint32_t p_view = 0, bool p_use_multiview = false);
 };
 
 } //namespace GLES3

--- a/drivers/gles3/effects/post_effects.cpp
+++ b/drivers/gles3/effects/post_effects.cpp
@@ -90,7 +90,7 @@ void PostEffects::_draw_screen_triangle() {
 void PostEffects::post_copy(
 		GLuint p_dest_framebuffer, Size2i p_dest_size, GLuint p_source_color,
 		GLuint p_source_depth, bool p_ssao_enabled, int p_ssao_quality_level, float p_ssao_strength, float p_ssao_radius,
-		Size2i p_source_size, float p_luminance_multiplier, const Glow::GLOWLEVEL *p_glow_buffers, float p_glow_intensity,
+		Size2i p_source_size, float p_luminance_multiplier, const Glow::Level *p_glow_buffers, float p_glow_intensity,
 		float p_srgb_white, uint32_t p_view, bool p_use_multiview, uint64_t p_spec_constants) {
 	glDisable(GL_DEPTH_TEST);
 	glDepthMask(GL_FALSE);

--- a/drivers/gles3/effects/post_effects.h
+++ b/drivers/gles3/effects/post_effects.h
@@ -60,7 +60,7 @@ public:
 
 	void post_copy(GLuint p_dest_framebuffer, Size2i p_dest_size, GLuint p_source_color,
 			GLuint p_source_depth, bool p_ssao_enabled, int p_ssao_quality_level, float p_ssao_strength, float p_ssao_radius,
-			Size2i p_source_size, float p_luminance_multiplier, const Glow::GLOWLEVEL *p_glow_buffers, float p_glow_intensity,
+			Size2i p_source_size, float p_luminance_multiplier, const Glow::Level *p_glow_buffers, float p_glow_intensity,
 			float p_srgb_white, uint32_t p_view = 0, bool p_use_multiview = false, uint64_t p_spec_constants = 0);
 };
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2929,7 +2929,7 @@ void RasterizerSceneGLES3::_render_post_processing(const RenderDataGLES3 *p_rend
 			// We need to pass this in for SSAO.
 			GLuint depth_buffer = fbo_int != 0 ? rb->get_internal_depth() : texture_storage->render_target_get_depth(render_target);
 
-			const GLES3::Glow::GLOWLEVEL *glow_buffers = nullptr;
+			const GLES3::Glow::Level *glow_buffers = nullptr;
 			if (glow_enabled) {
 				glow_buffers = rb->get_glow_buffers();
 
@@ -2992,7 +2992,7 @@ void RasterizerSceneGLES3::_render_post_processing(const RenderDataGLES3 *p_rend
 		// Rendered to intermediate buffer, must copy to our render target
 		if (fbo_int != 0) {
 			// Apply glow/bloom if requested? then populate our glow buffers
-			const GLES3::Glow::GLOWLEVEL *glow_buffers = nullptr;
+			const GLES3::Glow::Level *glow_buffers = nullptr;
 			GLuint source_color = fbo_int != 0 ? rb->get_internal_color() : texture_storage->render_target_get_color(render_target);
 
 			// Moved this up so SSAO could use it too.

--- a/drivers/gles3/storage/render_scene_buffers_gles3.h
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.h
@@ -83,7 +83,7 @@ public:
 
 	// Buffers for our glow implementation
 	struct GLOW {
-		GLES3::Glow::GLOWLEVEL levels[4];
+		GLES3::Glow::Level levels[4];
 	} glow;
 
 private:
@@ -146,7 +146,7 @@ public:
 	GLuint get_backbuffer() const { return backbuffer3d.color; }
 	GLuint get_backbuffer_depth() const { return backbuffer3d.depth; }
 
-	const GLES3::Glow::GLOWLEVEL *get_glow_buffers() const { return &glow.levels[0]; }
+	const GLES3::Glow::Level *get_glow_buffers() const { return &glow.levels[0]; }
 
 	// Getters
 


### PR DESCRIPTION
cc @BastiaanOlij, as he implemented glow in Compatibility in https://github.com/godotengine/godot/pull/87360.
