### PR TITLE
Add `forward+` and `compatibility` rendering method aliases to CLI for convenience

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1274,6 +1274,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (arg == "--rendering-method") {
 			if (N) {
 				rendering_method = N->get();
+				// Alias the names visible in the editor for convenience.
+				if (rendering_method == "forward+") {
+					rendering_method = "forward_plus";
+				} else if (rendering_method == "compatibility") {
+					rendering_method = "gl_compatibility";
+				}
 				N = N->next();
 			} else {
 				OS::get_singleton()->print("Missing renderer name argument, aborting.\n");


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/111047 (can be merged independently).

These are equivalent to `forward_plus` and `gl_compatibility` respectively. This does not change the name reported elsewhere (if you start with `--rendering-method compatibility`, `OS.get_current_rendering_method()` still returns `gl_compatibility`).

This makes it a bit quicker to switch renderers on the command line, which is quite common when testing rendering PRs to make sure they work correctly on all renderers.

Note that like in https://github.com/godotengine/godot/pull/111047, we could also add `get_short_name()` to each rendering method implementation, but since these can't be distributed as GDExtensions, there's less point in doing that.