### PR TITLE
Fix extracting materials from `.gltf` and `.blend` files throws error

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1598,7 +1598,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 								post_importer_plugins.write[j]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_MATERIAL, p_root, p_node, mat, matdata);
 							}
 						}
-						if (!mat_id.is_empty() && extract_mat != 0) {
+						if (!mat_id.is_empty() && p_material_data.has(mat_id) && extract_mat != 0) {
 							String ext = material_extension[p_options.has("materials/extract_format") ? (int)p_options["materials/extract_format"] : 0];
 							String path = spath.path_join(mat_id.validate_filename() + ext);
 							String uid_path = ResourceUID::path_to_uid(path);


### PR DESCRIPTION
Fixes  #115484 

Adding a check to make sure that p_material_data has the required data corresponding to mat_id. Similar checks are present for blocks above and below this one. This avoids accessing a value in the Dictionary that is not yet defined and thereby resolves the error being thrown.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
