### PR TITLE
Remove `is_discardable` flag on render target 

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -3595,7 +3595,6 @@ void TextureStorage::_update_render_target(RenderTarget *rt) {
 		if (rt->msaa != RS::VIEWPORT_MSAA_DISABLED) {
 			rd_color_attachment_format.is_resolve_buffer = true;
 		}
-		rd_color_attachment_format.is_discardable = true;
 	}
 
 	// TODO see if we can lazy create this once we actually use it as we may not need to create this if we have an overridden color buffer...


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/115522

`is_discardable` tells the ARG that we don't care about keeping this texture between frames. Then, the ARG will optimize its usage based on how the texture is used within the frame. On mobile devices, this can allow the ARG to save a lot of memory bandwidth. Basically it can avoid loading a texture if we are okay with ignoring the previous contents when beginning a render pass. It can also avoid saving a texture if the texture is never used again in the frame. 

However, we have an issue. The ARG relies on command trackers to check if a given texture was written to earlier in the frame, or is read from later in the frame. We don't use trackers in the final blit to swapchain, which is the only point the render target gets used later in the frame. This led the ARG to assume that we don't care about the contents of the render target after drawing. Which leads to the texture getting discarded before blitting to the swapchain. 

Originally I thought the solution would be to add trackers to the final blit. But in discussion with @DarioSamo I realized that:
1. We never want to discard after rendering to the render target (i.e. the texture will always be used again in the frame)
2. We never want to ignore the contents of the texture when beginning rendering (we either want to clear the texture, or keep its contents from earlier)

Which means that `is_discardable` is never desirable for the render target. 

My mistake was thinking that there were some cases where we could ignore the contents of the texture when beginning rendering. If there were such cases, then the proper solution would be to add tracking to the swapchain blit. But since there are no cases where we even want to ignore the contents of the texture when beginning rendering, its best just to not mark the texture as discardable

_Note: This won't impact the performance numbers from https://github.com/godotengine/godot/pull/113781 since those were taken in a 3D scene which will never benefit from `is_discardable` being set on the render_target_