### PR TITLE
ScriptEditor: Add always-on-top toggle

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1441,6 +1441,9 @@
 		<member name="text_editor/behavior/files/trim_trailing_whitespace_on_save" type="bool" setter="" getter="">
 			If [code]true[/code], trims trailing whitespace when saving a script. Trailing whitespace refers to tab and space characters placed at the end of lines. Since these serve no practical purpose, they can and should be removed to make version control diffs less noisy.
 		</member>
+		<member name="text_editor/behavior/floating/always_on_top" type="bool" setter="" getter="">
+			If [code]true[/code], keeps the Script Editor window always on top when it is in floating mode.
+		</member>
 		<member name="text_editor/behavior/general/empty_selection_clipboard" type="bool" setter="" getter="">
 			If [code]true[/code], copying or cutting without a selection is performed on all lines with a caret. Otherwise, copy and cut require a selection.
 		</member>

--- a/editor/gui/window_wrapper.cpp
+++ b/editor/gui/window_wrapper.cpp
@@ -211,6 +211,14 @@ void WindowWrapper::set_window_enabled(bool p_enabled) {
 	_set_window_enabled_with_rect(p_enabled, _get_default_window_rect());
 }
 
+void WindowWrapper::set_always_on_top(bool p_enabled) {
+	window->set_flag(Window::FLAG_ALWAYS_ON_TOP, p_enabled);
+}
+
+bool WindowWrapper::is_always_on_top() const {
+	return window->get_flag(Window::FLAG_ALWAYS_ON_TOP);
+}
+
 Rect2i WindowWrapper::get_window_rect() const {
 	ERR_FAIL_COND_V(!get_window_enabled(), Rect2i());
 	return Rect2i(window->get_position(), window->get_size());

--- a/editor/gui/window_wrapper.h
+++ b/editor/gui/window_wrapper.h
@@ -90,6 +90,9 @@ public:
 
 	void set_override_close_request(bool p_enabled);
 
+	void set_always_on_top(bool p_enabled);
+	bool is_always_on_top() const;
+
 	WindowWrapper();
 	~WindowWrapper();
 };

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1213,6 +1213,22 @@ bool ScriptEditor::_test_script_times_on_disk(Ref<Resource> p_for_script) {
 	return need_reload;
 }
 
+void ScriptEditor::_toggle_always_on_top(bool p_enabled) {
+	if (window_wrapper->is_window_available()) {
+		window_wrapper->set_always_on_top(p_enabled);
+	}
+
+	EditorSettings::get_singleton()->set("text_editor/behavior/floating/always_on_top", p_enabled);
+
+	if (p_enabled) {
+		always_on_top_button->set_button_icon(get_editor_theme_icon(SNAME("PinPressed")));
+		always_on_top_button->set_tooltip_text(TTR("Disable always-on-top for the floating script editor window."));
+	} else {
+		always_on_top_button->set_button_icon(get_editor_theme_icon(SNAME("Pin")));
+		always_on_top_button->set_tooltip_text(TTR("Keep the floating script editor window on top."));
+	}
+}
+
 void _import_text_editor_theme(const String &p_file) {
 	if (p_file.get_extension() != "tet") {
 		EditorToaster::get_singleton()->popup_str(TTR("Importing theme failed. File is not a text editor theme file (.tet)."), EditorToaster::SEVERITY_ERROR);
@@ -1845,6 +1861,10 @@ void ScriptEditor::_notification(int p_what) {
 			if (is_inside_tree()) {
 				_update_script_names();
 			}
+
+			always_on_top_button->set_button_icon(get_editor_theme_icon(is_floating ? SNAME("PinPressed") : SNAME("Pin")));
+			always_on_top_button->set_tooltip_text(is_floating ? TTR("Disable always-on-top for the floating script editor window.") : TTR("Keep the floating script editor window on top."));
+
 		} break;
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
@@ -1877,6 +1897,7 @@ void ScriptEditor::_notification(int p_what) {
 			list_split->connect("dragged", callable_mp(this, &ScriptEditor::_split_dragged));
 
 			EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &ScriptEditor::_filesystem_changed));
+
 #ifdef ANDROID_ENABLED
 			set_process(true);
 #endif
@@ -3101,6 +3122,28 @@ void ScriptEditor::_apply_editor_settings() {
 
 		se->update_settings();
 	}
+
+	_update_always_on_top_button();
+}
+
+void ScriptEditor::_update_always_on_top_button() {
+	bool is_editor_always_on_top = bool(EDITOR_GET("text_editor/behavior/floating/always_on_top"));
+
+	if (window_wrapper->is_window_available()) {
+		window_wrapper->set_always_on_top(is_editor_always_on_top);
+		always_on_top_button->set_visible(is_floating);
+		always_on_top_separator->set_visible(is_floating);
+	}
+
+	always_on_top_button->set_pressed(is_editor_always_on_top);
+
+	if (is_editor_always_on_top) {
+		always_on_top_button->set_button_icon(get_editor_theme_icon(SNAME("PinPressed")));
+		always_on_top_button->set_tooltip_text(TTR("Disable always-on-top for the floating script editor window."));
+	} else {
+		always_on_top_button->set_button_icon(get_editor_theme_icon(SNAME("Pin")));
+		always_on_top_button->set_tooltip_text(TTR("Keep the floating script editor window on top."));
+	}
 }
 
 void ScriptEditor::_filesystem_changed() {
@@ -4196,6 +4239,14 @@ void ScriptEditor::_update_code_editor_zoom_factor(CodeTextEditor *p_code_text_e
 void ScriptEditor::_window_changed(bool p_visible) {
 	make_floating->set_visible(!p_visible);
 	is_floating = p_visible;
+
+	if (always_on_top_button) {
+		always_on_top_button->set_visible(p_visible);
+	}
+
+	if (always_on_top_separator) {
+		always_on_top_separator->set_visible(p_visible);
+	}
 }
 
 void ScriptEditor::_filter_scripts_text_changed(const String &p_newtext) {
@@ -4485,6 +4536,14 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	help_search->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditor::_menu_option).bind(SEARCH_HELP));
 	menu_hb->add_child(help_search);
 	help_search->set_tooltip_text(TTRC("Search the reference documentation."));
+
+	always_on_top_separator = memnew(VSeparator);
+	menu_hb->add_child(always_on_top_separator);
+
+	always_on_top_button = memnew(Button);
+	always_on_top_button->set_toggle_mode(true);
+	always_on_top_button->connect("toggled", callable_mp(this, &ScriptEditor::_toggle_always_on_top));
+	menu_hb->add_child(always_on_top_button);
 
 	menu_hb->add_child(memnew(VSeparator));
 

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -34,6 +34,7 @@
 #include "editor/plugins/editor_plugin.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/panel_container.h"
+#include "scene/gui/separator.h"
 #include "scene/resources/syntax_highlighter.h"
 #include "scene/resources/text_file.h"
 
@@ -336,6 +337,8 @@ class ScriptEditor : public PanelContainer {
 	Button *make_floating = nullptr;
 	bool is_floating = false;
 	EditorHelpSearch *help_search_dialog = nullptr;
+	Button *always_on_top_button = nullptr;
+	VSeparator *always_on_top_separator = nullptr;
 
 	ItemList *script_list = nullptr;
 	HSplitContainer *script_split = nullptr;
@@ -566,6 +569,9 @@ class ScriptEditor : public PanelContainer {
 
 	static void _open_script_request(const String &p_path);
 	void _close_builtin_scripts_from_scene(const String &p_scene);
+
+	void _toggle_always_on_top(bool p_enabled);
+	void _update_always_on_top_button();
 
 	static ScriptEditor *script_editor;
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -817,6 +817,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/behavior/files/auto_reload_and_parse_scripts_on_save", true);
 	_initial_set("text_editor/behavior/files/open_dominant_script_on_scene_change", false, true);
 	_initial_set("text_editor/behavior/files/drop_preload_resources_as_uid", true, true);
+	_initial_set("text_editor/behavior/floating/always_on_top", false);
 
 	// Behavior: Documentation
 	_initial_set("text_editor/behavior/documentation/enable_tooltips", true, true);


### PR DESCRIPTION
When using the Script Editor in floating mode, it is common to switch frequently between the editor and other applications or editor windows.
An Always-on-Top toggle allows the floating Script Editor to remain visible and accessible, reducing window switching and improving focus during scripting.

Watch the video: https://youtu.be/w7ngFGZt4RU


---

<img width="1687" height="1017" alt="1" src="https://github.com/user-attachments/assets/6c7c3d0c-eade-4fb4-8a27-2ebc862e3727" />

---

<img width="1245" height="520" alt="2" src="https://github.com/user-attachments/assets/ed3d54a4-1616-4700-b935-8681038e0ddc" />

---

<img width="666" height="545" alt="3" src="https://github.com/user-attachments/assets/74e6bcd3-993c-4741-8ee9-6d159cbc19af" />

