### PR TITLE
Stop `RemoteDebugger` from improperly flushing messages during break

### DIFF
--- a/core/debugger/remote_debugger.h
+++ b/core/debugger/remote_debugger.h
@@ -86,6 +86,7 @@ private:
 	};
 
 	HashMap<Thread::ID, List<Message>> messages;
+	HashSet<Thread::ID> threads_in_break;
 
 	void _poll_messages();
 	bool _has_messages();
@@ -106,9 +107,6 @@ private:
 
 	Error _profiler_capture(const String &p_cmd, const Array &p_data, bool &r_captured);
 	Error _core_capture(const String &p_cmd, const Array &p_data, bool &r_captured);
-
-	template <typename T>
-	void _bind_profiler(const String &p_name, T *p_prof);
 	Error _try_capture(const String &p_name, const Array &p_data, bool &r_captured);
 
 public:


### PR DESCRIPTION
Fixes #115477.

As seen in #115477, there are times when `RemoteDebugger` ends up having `RemoteDebugger::poll_events` called during the message polling loop in `RemoteDebugger::debug`, which leads to messages from the editor being improperly flushed and effectively discarded, causing a number of issues on macOS in particular.

This seemingly fixes that by having `RemoteDebugger::poll_events` early-out if we're already in `RemoteDebugger::debug`.

(I also threw in some minor refactoring/cleanup.)