### PR TITLE
`AudioStreamWAV`: Place tag reading code together

### DIFF
--- a/scene/resources/audio/audio_stream_wav.cpp
+++ b/scene/resources/audio/audio_stream_wav.cpp
@@ -706,10 +706,9 @@ Ref<AudioStreamWAV> AudioStreamWAV::load_from_buffer(const Vector<uint8_t> &p_st
 	int64_t loop_begin = 0;
 	int64_t loop_end = 0;
 	int64_t frames = 0;
+	Dictionary tags;
 
 	Vector<float> data;
-
-	HashMap<String, String> tag_map;
 
 	while (!file->eof_reached()) {
 		/* chunk */
@@ -880,6 +879,41 @@ Ref<AudioStreamWAV> AudioStreamWAV::load_from_buffer(const Vector<uint8_t> &p_st
 			if (list_id[0] == 'I' && list_id[1] == 'N' && list_id[2] == 'F' && list_id[3] == 'O') {
 				// 'INFO' list type.
 				// The size of an entry can be arbitrary.
+
+				// Used to make the metadata tags more unified across different WAV streams.
+				// See https://www.recordingblogs.com/wiki/list-chunk-of-a-wave-file
+				// https://wiki.hydrogenaudio.org/index.php?title=Tag_Mapping#Mapping_Tables
+				static AHashMap<String, String> tag_id_remaps;
+				if (tag_id_remaps.is_empty()) {
+					tag_id_remaps.reserve(26); // Must be kept in sync with the number of entries below.
+					tag_id_remaps["IARL"] = "location";
+					tag_id_remaps["IART"] = "artist";
+					tag_id_remaps["ICMS"] = "organization";
+					tag_id_remaps["ICMT"] = "comment";
+					tag_id_remaps["ICNT"] = "releasecountry";
+					tag_id_remaps["ICOP"] = "copyright";
+					tag_id_remaps["ICRD"] = "date";
+					tag_id_remaps["IENC"] = "encodedby";
+					tag_id_remaps["IENG"] = "engineer";
+					tag_id_remaps["IFRM"] = "tracktotal";
+					tag_id_remaps["IGNR"] = "genre";
+					tag_id_remaps["IKEY"] = "keywords";
+					tag_id_remaps["ILNG"] = "language";
+					tag_id_remaps["IMED"] = "media";
+					tag_id_remaps["IMUS"] = "composer";
+					tag_id_remaps["INAM"] = "title";
+					tag_id_remaps["IPRD"] = "album";
+					tag_id_remaps["IPRO"] = "producer";
+					tag_id_remaps["IPRT"] = "tracknumber";
+					tag_id_remaps["ISBJ"] = "description";
+					tag_id_remaps["ISFT"] = "encoder";
+					tag_id_remaps["ISRF"] = "media";
+					tag_id_remaps["ITCH"] = "encodedby";
+					tag_id_remaps["ITRK"] = "tracknumber";
+					tag_id_remaps["IWRI"] = "author";
+					tag_id_remaps["TLEN"] = "length";
+				}
+
 				while (file->get_position() < end_of_chunk) {
 					ERR_BREAK_MSG(file->eof_reached(), "EOF reached while reading INFO chunk.");
 					char info_id[4];
@@ -906,7 +940,10 @@ Ref<AudioStreamWAV> AudioStreamWAV::load_from_buffer(const Vector<uint8_t> &p_st
 					String tag_value;
 					tag_value.append_utf8(&text[0], text_size);
 
-					tag_map[tag] = tag_value;
+					AHashMap<String, String>::ConstIterator remap = tag_id_remaps.find(tag);
+					if (remap != tag_id_remaps.end()) {
+						tags[remap->value] = tag_value;
+					}
 				}
 			}
 		}
@@ -1173,51 +1210,7 @@ Ref<AudioStreamWAV> AudioStreamWAV::load_from_buffer(const Vector<uint8_t> &p_st
 	sample->set_loop_begin(loop_begin);
 	sample->set_loop_end(loop_end);
 	sample->set_stereo(format_channels == 2);
-
-	if (!tag_map.is_empty()) {
-		// Used to make the metadata tags more unified across different AudioStreams.
-		// See https://www.recordingblogs.com/wiki/list-chunk-of-a-wave-file
-		// https://wiki.hydrogenaudio.org/index.php?title=Tag_Mapping#Mapping_Tables
-		HashMap<String, String> tag_id_remaps;
-		tag_id_remaps.reserve(15);
-		tag_id_remaps["IARL"] = "location";
-		tag_id_remaps["IART"] = "artist";
-		tag_id_remaps["ICMS"] = "organization";
-		tag_id_remaps["ICMT"] = "comment";
-		tag_id_remaps["ICNT"] = "releasecountry";
-		tag_id_remaps["ICOP"] = "copyright";
-		tag_id_remaps["ICRD"] = "date";
-		tag_id_remaps["IENC"] = "encodedby";
-		tag_id_remaps["IENG"] = "engineer";
-		tag_id_remaps["IFRM"] = "tracktotal";
-		tag_id_remaps["IGNR"] = "genre";
-		tag_id_remaps["IKEY"] = "keywords";
-		tag_id_remaps["ILNG"] = "language";
-		tag_id_remaps["IMED"] = "media";
-		tag_id_remaps["IMUS"] = "composer";
-		tag_id_remaps["INAM"] = "title";
-		tag_id_remaps["IPRD"] = "album";
-		tag_id_remaps["IPRO"] = "producer";
-		tag_id_remaps["IPRT"] = "tracknumber";
-		tag_id_remaps["ISBJ"] = "description";
-		tag_id_remaps["ISFT"] = "encoder";
-		tag_id_remaps["ISRF"] = "media";
-		tag_id_remaps["ITCH"] = "encodedby";
-		tag_id_remaps["ITRK"] = "tracknumber";
-		tag_id_remaps["IWRI"] = "author";
-		tag_id_remaps["TLEN"] = "length";
-		Dictionary tag_dictionary;
-		for (const KeyValue<String, String> &E : tag_map) {
-			HashMap<String, String>::ConstIterator remap = tag_id_remaps.find(E.key);
-			String tag_key = E.key;
-			if (remap) {
-				tag_key = remap->value;
-			}
-
-			tag_dictionary[tag_key] = E.value;
-		}
-		sample->set_tags(tag_dictionary);
-	}
+	sample->set_tags(tags);
 
 	return sample;
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Unscatters the code for reading WAV tags in `AudioStreamWAV::load_from_buffer()`.

This is how the code for reading tags is currently structured:
1. Fill a hashmap with raw tags found in the file.
2. Near the end of the loading code after all conversions, if tags were found, make another hashmap with "remaps".
3. Use the remaps to fill a dictionary containing the tags.
4. Set the tags.

You have one part of the code near the beginning and the other near the end, when it could be together in one place. This is what the PR changes it to:
1. Once we know a file has tags (`INFO` list found), make the remaps.
2. For each tag found, immediately use the remap and put it into the dictionary.
3. Set the tags at the end.

## Additional information

This is one of many PRs I avoided making due to optimism about #96545. I also consider this a requirement for a post-#116184 to add AIFF metadata support, as the current way hardcodes for WAV tags and would need workarounds.