### PR TITLE
Prevent non-expression identifiers from incrementing the use count of variables

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2788,7 +2788,9 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_expression(bool p_can_assi
 }
 
 GDScriptParser::IdentifierNode *GDScriptParser::parse_identifier() {
+	identifier_is_expression = false;
 	IdentifierNode *identifier = static_cast<IdentifierNode *>(parse_identifier(nullptr, false));
+	identifier_is_expression = true;
 #ifdef DEBUG_ENABLED
 	// Check for spoofing here (if available in TextServer) since this isn't called inside expressions. This is only relevant for declarations.
 	if (identifier && TS->has_feature(TextServer::FEATURE_UNICODE_SECURITY) && TS->spoof_check(identifier->name)) {
@@ -2810,7 +2812,7 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_identifier(ExpressionNode 
 	}
 	identifier->suite = current_suite;
 
-	if (current_suite != nullptr && current_suite->has_local(identifier->name)) {
+	if (identifier_is_expression && current_suite != nullptr && current_suite->has_local(identifier->name)) {
 		const SuiteNode::Local &declaration = current_suite->get_local(identifier->name);
 
 		identifier->source_function = declaration.source_function;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1395,6 +1395,8 @@ private:
 	bool in_lambda = false;
 	bool lambda_ended = false; // Marker for when a lambda ends, to apply an end of statement if needed.
 
+	bool identifier_is_expression = true;
+
 	typedef bool (GDScriptParser::*AnnotationAction)(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	struct AnnotationInfo {
 		enum TargetKind {

--- a/modules/gdscript/tests/scripts/parser/warnings/unused_variable_2.gd
+++ b/modules/gdscript/tests/scripts/parser/warnings/unused_variable_2.gd
@@ -1,0 +1,3 @@
+func test():
+	var unused
+	var _t = {'unused': 123}.unused

--- a/modules/gdscript/tests/scripts/parser/warnings/unused_variable_2.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/unused_variable_2.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+~~ WARNING at line 2: (UNUSED_VARIABLE) The local variable "unused" is declared but never used in the block. If this is intended, prefix it with an underscore: "_unused".


### PR DESCRIPTION
Fixes #113624

The `parse_identifier(ExpressionNode, bool)` function kinda assumes the identifier is an expression, so it increments `usage` counts (among other things). As a result, mid-attribute identifiers, lambda parameter identifiers etc. can cause unused variables to be treated as used.

Almost none of the identifiers parsed with `parse_identifier(void)` are expressions. The only exception is the property setget pointer identifiers, but they aren't relevant to the existing logic anyway.

I don't like that I added a new member for this logic, but it also doesn't seem possible to communicate this intent to `parse_identifier(ExpressionNode, bool)` another way without doing hacky stuff like using a dummy ExpressionNode pointer as the first argument etc.