### PR TITLE
Recommend installing the VSCode editorconfig extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,9 +213,11 @@ cscope.po.out
 *.swp
 
 # Visual Studio Code
-.vscode/
+.vscode/*
 *.code-workspace
 .history/
+# Recommends the .editorconfig extension when setting up the workspace.
+!.vscode/extensions.json
 
 # Xcode
 xcuserdata/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"editorconfig.editorconfig",
+	]
+}


### PR DESCRIPTION
We provide an `.editorconfig` file which contains information for editors on how to e.g. indent files in the repo by default. However VSCode does not provide support for such files out of the box. Support is provided [through a plugin](https://github.com/editorconfig/editorconfig-vscode). This PR adds the necessary file to let VSCode recomend this extension for the workspace, so when setting up a dev environment with VSCode users will see a prompt like this:

<img width="445" height="97" alt="image" src="https://github.com/user-attachments/assets/a75c3bc7-8598-44cd-923d-a62a94f3c82a" />

This makes the process of setting up a dev env with VSCode a bit more streamlined. The motivation for this comes from me forgetting to install this plugin when switching to a new PC. Which means we now have a few rogue files in the GDScript tests that are space indented.