### PR TITLE
Add scroll switch to ScrollContainer

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -64,6 +64,10 @@
 				set_deferred("scroll_horizontal", 600)
 			[/codeblock]
 		</member>
+		<member name="scroll_horizontal_by_default" type="bool" setter="set_scroll_horizontal_by_default" getter="is_scroll_horizontal_by_default" default="false">
+			If [code]true[/code], the mouse wheel scrolls the view horizontally, and holding [kbd]Shift[/kbd] scrolls vertically.
+			If [code]false[/code] (default), the mouse wheel scrolls the view vertically, and holding [kbd]Shift[/kbd] scrolls horizontally.
+		</member>
 		<member name="scroll_horizontal_custom_step" type="float" setter="set_horizontal_custom_step" getter="get_horizontal_custom_step" default="-1.0">
 			Overrides the [member ScrollBar.custom_step] used when clicking the internal scroll bar's horizontal increment and decrement buttons or when using arrow keys when the [ScrollBar] is focused.
 		</member>

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -146,11 +146,12 @@ void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 	if (mb.is_valid()) {
 		if (mb->is_pressed()) {
 			bool scroll_value_modified = false;
+			bool swap_axes = scroll_horizontal_by_default != mb->is_shift_pressed();
 
 			bool v_scroll_hidden = !v_scroll->is_visible() && vertical_scroll_mode != SCROLL_MODE_SHOW_NEVER;
 			if (mb->get_button_index() == MouseButton::WHEEL_UP) {
 				// By default, the vertical orientation takes precedence. This is an exception.
-				if ((h_scroll_enabled && mb->is_shift_pressed()) || v_scroll_hidden) {
+				if ((h_scroll_enabled && swap_axes) || v_scroll_hidden) {
 					h_scroll->scroll(-h_scroll->get_page() / ScrollBar::PAGE_DIVISOR * mb->get_factor());
 					scroll_value_modified = true;
 				} else if (v_scroll_enabled) {
@@ -159,7 +160,7 @@ void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 				}
 			}
 			if (mb->get_button_index() == MouseButton::WHEEL_DOWN) {
-				if ((h_scroll_enabled && mb->is_shift_pressed()) || v_scroll_hidden) {
+				if ((h_scroll_enabled && swap_axes) || v_scroll_hidden) {
 					h_scroll->scroll(h_scroll->get_page() / ScrollBar::PAGE_DIVISOR * mb->get_factor());
 					scroll_value_modified = true;
 				} else if (v_scroll_enabled) {
@@ -171,7 +172,7 @@ void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 			bool h_scroll_hidden = !h_scroll->is_visible() && horizontal_scroll_mode != SCROLL_MODE_SHOW_NEVER;
 			if (mb->get_button_index() == MouseButton::WHEEL_LEFT) {
 				// By default, the horizontal orientation takes precedence. This is an exception.
-				if ((v_scroll_enabled && mb->is_shift_pressed()) || h_scroll_hidden) {
+				if ((v_scroll_enabled && swap_axes) || h_scroll_hidden) {
 					v_scroll->scroll(-v_scroll->get_page() / ScrollBar::PAGE_DIVISOR * mb->get_factor());
 					scroll_value_modified = true;
 				} else if (h_scroll_enabled) {
@@ -180,7 +181,7 @@ void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 				}
 			}
 			if (mb->get_button_index() == MouseButton::WHEEL_RIGHT) {
-				if ((v_scroll_enabled && mb->is_shift_pressed()) || h_scroll_hidden) {
+				if ((v_scroll_enabled && swap_axes) || h_scroll_hidden) {
 					v_scroll->scroll(v_scroll->get_page() / ScrollBar::PAGE_DIVISOR * mb->get_factor());
 					scroll_value_modified = true;
 				} else if (h_scroll_enabled) {
@@ -730,6 +731,14 @@ ScrollContainer::ScrollMode ScrollContainer::get_vertical_scroll_mode() const {
 	return vertical_scroll_mode;
 }
 
+void ScrollContainer::set_scroll_horizontal_by_default(bool p_enable) {
+	scroll_horizontal_by_default = p_enable;
+}
+
+bool ScrollContainer::is_scroll_horizontal_by_default() const {
+	return scroll_horizontal_by_default;
+}
+
 int ScrollContainer::get_deadzone() const {
 	return deadzone;
 }
@@ -826,6 +835,9 @@ void ScrollContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_vertical_scroll_mode", "enable"), &ScrollContainer::set_vertical_scroll_mode);
 	ClassDB::bind_method(D_METHOD("get_vertical_scroll_mode"), &ScrollContainer::get_vertical_scroll_mode);
 
+	ClassDB::bind_method(D_METHOD("set_scroll_horizontal_by_default", "enable"), &ScrollContainer::set_scroll_horizontal_by_default);
+	ClassDB::bind_method(D_METHOD("is_scroll_horizontal_by_default"), &ScrollContainer::is_scroll_horizontal_by_default);
+
 	ClassDB::bind_method(D_METHOD("set_deadzone", "deadzone"), &ScrollContainer::set_deadzone);
 	ClassDB::bind_method(D_METHOD("get_deadzone"), &ScrollContainer::get_deadzone);
 
@@ -858,6 +870,7 @@ void ScrollContainer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scroll_vertical_custom_step", PROPERTY_HINT_RANGE, "-1,4096,suffix:px"), "set_vertical_custom_step", "get_vertical_custom_step");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "horizontal_scroll_mode", PROPERTY_HINT_ENUM, "Disabled,Auto,Always Show,Never Show,Reserve"), "set_horizontal_scroll_mode", "get_horizontal_scroll_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "vertical_scroll_mode", PROPERTY_HINT_ENUM, "Disabled,Auto,Always Show,Never Show,Reserve"), "set_vertical_scroll_mode", "get_vertical_scroll_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_horizontal_by_default"), "set_scroll_horizontal_by_default", "is_scroll_horizontal_by_default");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "scroll_deadzone"), "set_deadzone", "get_deadzone");
 
 	ADD_GROUP("Scroll Hint", "");

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -87,6 +87,7 @@ private:
 	bool follow_focus = false;
 	int scroll_border = 20;
 	int scroll_speed = 12;
+	bool scroll_horizontal_by_default = false;
 
 	ScrollHintMode scroll_hint_mode = SCROLL_HINT_MODE_DISABLED;
 	bool tile_scroll_hint = false;
@@ -155,6 +156,9 @@ public:
 
 	void set_vertical_scroll_mode(ScrollMode p_mode);
 	ScrollMode get_vertical_scroll_mode() const;
+
+	void set_scroll_horizontal_by_default(bool p_enable);
+	bool is_scroll_horizontal_by_default() const;
 
 	void set_deadzone(int p_deadzone);
 	int get_deadzone() const;


### PR DESCRIPTION
Sometimes with UI related stuff, you want the scroll wheel to control the horizontal scroll by default. Right now the approach is to switch it manually through GDScript but with this PR you can "flip the switch" and have the mouse wheel scroll horizontally instead of vertically without having to hold shift. It basically swaps the axes.

A perfect use case for me personally would be for the timeline for the video editor I'm making with Godot, but I'm certain that there are other instances where being able to flip the scroll axes with a switch could be useful. So I thought this might be a good feature to add to the ScrollContainer node.

I wasn't certain about the naming of the option. Let me know if anything needs adjusting/changing. Btw, learned from my previous PR and added documentation with the first commit this time ;)

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/14294*