### PR TITLE
Add `intdiv()` function for explicit integer division in GDScript without warning

### DIFF
--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -639,6 +639,10 @@ double VariantUtilityFunctions::pingpong(double p_value, double p_length) {
 	return Math::pingpong(p_value, p_length);
 }
 
+int VariantUtilityFunctions::intdiv(int p_a, int p_b) {
+	return p_a / p_b;
+}
+
 Variant VariantUtilityFunctions::max(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	if (p_argcount < 2) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
@@ -1730,6 +1734,8 @@ void Variant::_register_variant_utility_functions() {
 
 	FUNCBINDR(nearest_po2, sarray("value"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(pingpong, sarray("value", "length"), Variant::UTILITY_FUNC_TYPE_MATH);
+
+	FUNCBINDR(intdiv, sarray("a", "b"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	// Random
 

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -104,6 +104,7 @@ struct VariantUtilityFunctions {
 	static int64_t wrapi(int64_t p_value, int64_t p_min, int64_t p_max);
 	static double wrapf(double p_value, double p_min, double p_max);
 	static double pingpong(double p_value, double p_length);
+	static int intdiv(int p_a, int p_b);
 	static Variant max(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 	static double maxf(double p_x, double p_y);
 	static int64_t maxi(int64_t p_x, int64_t p_y);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -518,6 +518,22 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="intdiv">
+			<return type="int" />
+			<param index="0" name="a" type="int" />
+			<param index="1" name="b" type="int" />
+			<description>
+				Performs the explicit integer division operation [param a] / [param b].
+				The expression [code]intdiv(a, b)[/code] is equivalent to [code]a / b[/code] in GDScript, but avoids raising the [code]INTEGER_DIVISION[/code] warning.
+				[codeblock]
+				# Prints "2", but also raises the INTEGER_DIVISION warning.
+				print(7 / 3)
+
+				# Prints "2" and does not raise the INTEGER_DIVISION warning.
+				print(intdiv(7, 3))
+				[/codeblock]
+			</description>
+		</method>
 		<method name="inverse_lerp" keywords="interpolate">
 			<return type="float" />
 			<param index="0" name="from" type="float" />


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11998 .

This PR adds a new GlobalScope function, `intdiv(a, b)`. It allows the user to explicitly perform integer division without raising (and then needing to silence) the `INTEGER_DIVISION` warning.

Example usage from the docs:
```gdscript
# Prints "2", but also raises the INTEGER_DIVISION warning.
print(7 / 3)

# Prints "2" and does not raise the INTEGER_DIVISION warning.
print(intdiv(7, 3))
```