### PR TITLE
Automatically determine editor low-processor mode sleep duration by default

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -317,6 +317,14 @@ void OS::set_use_file_access_save_and_swap(bool p_enable) {
 	FileAccess::set_backup_save(p_enable);
 }
 
+void OS::set_low_processor_usage_mode_sleep_usec_mode(LowProcessorModeSleepUsecMode p_mode) {
+	::OS::get_singleton()->set_low_processor_usage_mode_sleep_usec_mode(::OS::LowProcessorModeSleepUsecMode(p_mode));
+}
+
+OS::LowProcessorModeSleepUsecMode OS::get_low_processor_usage_mode_sleep_usec_mode() const {
+	return (LowProcessorModeSleepUsecMode)::OS::get_singleton()->get_low_processor_usage_mode_sleep_usec_mode();
+}
+
 void OS::set_low_processor_usage_mode(bool p_enabled) {
 	::OS::get_singleton()->set_low_processor_usage_mode(p_enabled);
 }
@@ -767,6 +775,8 @@ void OS::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_low_processor_usage_mode_sleep_usec", "usec"), &OS::set_low_processor_usage_mode_sleep_usec);
 	ClassDB::bind_method(D_METHOD("get_low_processor_usage_mode_sleep_usec"), &OS::get_low_processor_usage_mode_sleep_usec);
+	ClassDB::bind_method(D_METHOD("set_low_processor_usage_mode_sleep_usec_mode", "mode"), &OS::set_low_processor_usage_mode_sleep_usec_mode);
+	ClassDB::bind_method(D_METHOD("get_low_processor_usage_mode_sleep_usec_mode"), &OS::get_low_processor_usage_mode_sleep_usec_mode);
 
 	ClassDB::bind_method(D_METHOD("set_delta_smoothing", "delta_smoothing_enabled"), &OS::set_delta_smoothing);
 	ClassDB::bind_method(D_METHOD("is_delta_smoothing_enabled"), &OS::is_delta_smoothing_enabled);
@@ -862,6 +872,7 @@ void OS::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "low_processor_usage_mode"), "set_low_processor_usage_mode", "is_in_low_processor_usage_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "low_processor_usage_mode_sleep_usec"), "set_low_processor_usage_mode_sleep_usec", "get_low_processor_usage_mode_sleep_usec");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "low_processor_usage_mode_sleep_usec_mode", PROPERTY_HINT_ENUM, "Automatic,Automatic (Optimized for Variable Refresh Rate),Custom"), "set_low_processor_usage_mode_sleep_usec_mode", "get_low_processor_usage_mode_sleep_usec_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "delta_smoothing"), "set_delta_smoothing", "is_delta_smoothing_enabled");
 
 	// Those default values need to be specified for the docs generator,
@@ -888,6 +899,9 @@ void OS::_bind_methods() {
 	BIND_ENUM_CONSTANT(STD_HANDLE_FILE);
 	BIND_ENUM_CONSTANT(STD_HANDLE_PIPE);
 	BIND_ENUM_CONSTANT(STD_HANDLE_UNKNOWN);
+
+	BIND_ENUM_CONSTANT(LOW_PROCESSOR_SLEEP_USEC_MODE_AUTOMATIC);
+	BIND_ENUM_CONSTANT(LOW_PROCESSOR_SLEEP_USEC_MODE_CUSTOM);
 }
 
 OS::OS() {

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -190,12 +190,20 @@ public:
 		STD_HANDLE_UNKNOWN,
 	};
 
+	enum LowProcessorModeSleepUsecMode {
+		LOW_PROCESSOR_SLEEP_USEC_MODE_AUTOMATIC,
+		LOW_PROCESSOR_SLEEP_USEC_MODE_CUSTOM,
+	};
+
 	virtual PackedStringArray get_connected_midi_inputs();
 	virtual void open_midi_inputs();
 	virtual void close_midi_inputs();
 
 	void set_low_processor_usage_mode(bool p_enabled);
 	bool is_in_low_processor_usage_mode() const;
+
+	void set_low_processor_usage_mode_sleep_usec_mode(LowProcessorModeSleepUsecMode p_mode);
+	LowProcessorModeSleepUsecMode get_low_processor_usage_mode_sleep_usec_mode() const;
 
 	void set_low_processor_usage_mode_sleep_usec(int p_usec);
 	int get_low_processor_usage_mode_sleep_usec() const;
@@ -703,6 +711,7 @@ VARIANT_BITFIELD_CAST(CoreBind::ResourceSaver::SaverFlags);
 VARIANT_ENUM_CAST(CoreBind::OS::RenderingDriver);
 VARIANT_ENUM_CAST(CoreBind::OS::SystemDir);
 VARIANT_ENUM_CAST(CoreBind::OS::StdHandleType);
+VARIANT_ENUM_CAST(CoreBind::OS::LowProcessorModeSleepUsecMode);
 
 VARIANT_ENUM_CAST(CoreBind::Geometry2D::PolyBooleanOperation);
 VARIANT_ENUM_CAST(CoreBind::Geometry2D::PolyJoinType);

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -162,12 +162,34 @@ bool OS::is_in_low_processor_usage_mode() const {
 	return low_processor_usage_mode;
 }
 
+void OS::set_low_processor_usage_mode_sleep_usec_mode(LowProcessorModeSleepUsecMode p_mode) {
+	low_processor_usage_mode_sleep_usec_mode = p_mode;
+}
+
+OS::LowProcessorModeSleepUsecMode OS::get_low_processor_usage_mode_sleep_usec_mode() const {
+	return LOW_PROCESSOR_SLEEP_USEC_MODE_CUSTOM;
+}
+
 void OS::set_low_processor_usage_mode_sleep_usec(int p_usec) {
 	low_processor_usage_mode_sleep_usec = p_usec;
 }
 
 int OS::get_low_processor_usage_mode_sleep_usec() const {
 	return low_processor_usage_mode_sleep_usec;
+}
+
+void OS::set_low_processor_usage_mode_sleep_usec_automatic(int p_usec) {
+	low_processor_usage_mode_sleep_usec_automatic = p_usec;
+}
+
+int OS::get_effective_low_processor_usage_mode_sleep_usec() const {
+	switch (low_processor_usage_mode_sleep_usec_mode) {
+		case LOW_PROCESSOR_SLEEP_USEC_MODE_AUTOMATIC:
+			return low_processor_usage_mode_sleep_usec_automatic;
+		case LOW_PROCESSOR_SLEEP_USEC_MODE_CUSTOM:
+		default:
+			return low_processor_usage_mode_sleep_usec;
+	}
 }
 
 void OS::set_delta_smoothing(bool p_enabled) {
@@ -694,7 +716,7 @@ uint64_t OS::get_frame_delay(bool p_can_draw) const {
 	// previous frame time into account for a smoother result.
 	uint64_t dynamic_delay = 0;
 	if (is_in_low_processor_usage_mode() || !p_can_draw) {
-		dynamic_delay = get_low_processor_usage_mode_sleep_usec();
+		dynamic_delay = get_effective_low_processor_usage_mode_sleep_usec();
 	}
 	const int max_fps = Engine::get_singleton()->get_max_fps();
 	if (max_fps > 0 && !Engine::get_singleton()->is_editor_hint()) {
@@ -719,7 +741,7 @@ void OS::add_frame_delay(bool p_can_draw, bool p_wake_for_events) {
 	// previous frame time into account for a smoother result.
 	uint64_t dynamic_delay = 0;
 	if (is_in_low_processor_usage_mode() || !p_can_draw) {
-		dynamic_delay = get_low_processor_usage_mode_sleep_usec();
+		dynamic_delay = get_effective_low_processor_usage_mode_sleep_usec();
 	}
 	const int max_fps = Engine::get_singleton()->get_max_fps();
 	if (max_fps > 0 && !Engine::get_singleton()->is_editor_hint()) {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -74,6 +74,11 @@ public:
 		PLATFORM_STRING_FILE_MANAGER_SHOW,
 	};
 
+	enum LowProcessorModeSleepUsecMode {
+		LOW_PROCESSOR_SLEEP_USEC_MODE_AUTOMATIC,
+		LOW_PROCESSOR_SLEEP_USEC_MODE_CUSTOM,
+	};
+
 private:
 	static OS *singleton;
 	static uint64_t target_ticks;
@@ -82,7 +87,9 @@ private:
 	List<String> _user_args;
 	bool _keep_screen_on = true; // set default value to true, because this had been true before godot 2.0.
 	bool low_processor_usage_mode = false;
+	LowProcessorModeSleepUsecMode low_processor_usage_mode_sleep_usec_mode = LOW_PROCESSOR_SLEEP_USEC_MODE_CUSTOM;
 	int low_processor_usage_mode_sleep_usec = 10000;
+	int low_processor_usage_mode_sleep_usec_automatic = 10000;
 	bool _delta_smoothing_enabled = false;
 	bool _verbose_stdout = false;
 	bool _debug_stdout = false;
@@ -202,8 +209,12 @@ public:
 
 	virtual void set_low_processor_usage_mode(bool p_enabled);
 	virtual bool is_in_low_processor_usage_mode() const;
+	virtual void set_low_processor_usage_mode_sleep_usec_mode(LowProcessorModeSleepUsecMode p_mode);
+	virtual LowProcessorModeSleepUsecMode get_low_processor_usage_mode_sleep_usec_mode() const;
 	virtual void set_low_processor_usage_mode_sleep_usec(int p_usec);
 	virtual int get_low_processor_usage_mode_sleep_usec() const;
+	virtual int get_effective_low_processor_usage_mode_sleep_usec() const;
+	virtual void set_low_processor_usage_mode_sleep_usec_automatic(int p_usec);
 
 	void set_delta_smoothing(bool p_enabled);
 	bool is_delta_smoothing_enabled() const;

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1116,15 +1116,21 @@
 		<member name="interface/editor/localization/ui_layout_direction" type="int" setter="" getter="">
 			Editor UI default layout direction.
 		</member>
+		<member name="interface/editor/timers/custom_low_processor_mode_max_fps" type="int" setter="" getter="">
+			The maximum frames per second that can be rendered when the editor is focused. Lower values will result in reduced CPU/GPU usage, which can improve battery life on laptops (in addition to improving the running project's performance if the editor has to redraw continuously). However, lower values also result in a less responsive editor. Only effective if [member interface/editor/timers/low_processor_mode_max_fps_mode] is [b]Custom[/b].
+			[b]Note:[/b] This setting is ignored if [member interface/editor/display/update_continuously] is [code]true[/code], as enabling that setting disables low-processor mode.
+		</member>
 		<member name="interface/editor/timers/dragging_hover_wait_seconds" type="float" setter="" getter="">
 			During a drag-and-drop, this is how long to wait over a UI element before it triggers a reaction (e.g. a section unfolds to show nested items).
 		</member>
-		<member name="interface/editor/timers/low_processor_mode_sleep_usec" type="int" setter="" getter="">
-			The amount of sleeping between frames in the editor (in microseconds). Higher values will result in lower CPU/GPU usage, which can improve battery life on laptops. However, higher values will result in a less responsive editor. The default value is set to allow for maximum smoothness on monitors up to 144 Hz. See also [member interface/editor/timers/unfocused_low_processor_mode_sleep_usec].
+		<member name="interface/editor/timers/low_processor_mode_max_fps_mode" type="int" setter="" getter="">
+			The policy to use to determine the maximum number of frames per second that can be rendered when the editor is focused.
+			- [b]Automatic:[/b] Automatically determine the sleep duration between frames using the refresh rate of the fastest display connected to the system when the editor starts.
+			- [b]Custom:[/b] The maximum FPS is determined by the value set in [member interface/editor/timers/custom_low_processor_mode_max_fps]. This can be used specify a lower value than what's automatically determined, which can reduce CPU/GPU utilization.
 			[b]Note:[/b] This setting is ignored if [member interface/editor/display/update_continuously] is [code]true[/code], as enabling that setting disables low-processor mode.
 		</member>
-		<member name="interface/editor/timers/unfocused_low_processor_mode_sleep_usec" type="int" setter="" getter="">
-			When the editor window is unfocused, the amount of sleeping between frames when the low-processor usage mode is enabled (in microseconds). Higher values will result in lower CPU/GPU usage, which can improve battery life on laptops (in addition to improving the running project's performance if the editor has to redraw continuously). However, higher values will result in a less responsive editor. The default value is set to limit the editor to 10 FPS when the editor window is unfocused. See also [member interface/editor/timers/low_processor_mode_sleep_usec].
+		<member name="interface/editor/timers/unfocused_low_processor_mode_max_fps" type="int" setter="" getter="">
+			The maximum frames per second that can be reached when the editor is unfocused. Lower values will result in reduced CPU/GPU usage, which can improve battery life on laptops (in addition to improving the running project's performance if the editor has to redraw continuously). However, lower values also result in a less responsive editor.
 			[b]Note:[/b] This setting is ignored if [member interface/editor/display/update_continuously] is [code]true[/code], as enabling that setting disables low-processor mode.
 		</member>
 		<member name="interface/editors/derive_script_globals_by_name" type="bool" setter="" getter="">

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -904,8 +904,11 @@
 			[b]Note:[/b] On start-up, this is the same as [member ProjectSettings.application/run/low_processor_mode].
 		</member>
 		<member name="low_processor_usage_mode_sleep_usec" type="int" setter="set_low_processor_usage_mode_sleep_usec" getter="get_low_processor_usage_mode_sleep_usec" default="6900">
-			The amount of sleeping between frames when the low-processor usage mode is enabled, in microseconds. Higher values will result in lower CPU usage. See also [member low_processor_usage_mode].
+			The amount of sleeping between frames when the low-processor usage mode is enabled, in microseconds. Higher values will result in lower CPU usage. See also [member low_processor_usage_mode]. Only effective if [member low_processor_usage_mode_sleep_usec_mode] is set to [constant LOW_PROCESSOR_SLEEP_USEC_MODE_CUSTOM].
 			[b]Note:[/b] On start-up, this is the same as [member ProjectSettings.application/run/low_processor_mode_sleep_usec].
+		</member>
+		<member name="low_processor_usage_mode_sleep_usec_mode" type="int" setter="set_low_processor_usage_mode_sleep_usec_mode" getter="get_low_processor_usage_mode_sleep_usec_mode" enum="OS.LowProcessorModeSleepUsecMode" default="1">
+			The policy to use to determine the sleep duration between frames when the low-processor usage mode is enabled. See also [member low_processor_usage_mode].
 		</member>
 	</members>
 	<constants>
@@ -959,6 +962,12 @@
 		</constant>
 		<constant name="STD_HANDLE_UNKNOWN" value="4" enum="StdHandleType">
 			Standard I/O device type is unknown.
+		</constant>
+		<constant name="LOW_PROCESSOR_SLEEP_USEC_MODE_AUTOMATIC" value="0" enum="LowProcessorModeSleepUsecMode">
+			Automatically determine the sleep duration between frames using the refresh rate of the fastest display connected to the system when the engine starts.
+		</constant>
+		<constant name="LOW_PROCESSOR_SLEEP_USEC_MODE_CUSTOM" value="1" enum="LowProcessorModeSleepUsecMode">
+			Use a custom sleep duration between frames, as specified by [member low_processor_usage_mode_sleep_usec].
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -412,7 +412,14 @@
 			If [code]true[/code], enables low-processor usage mode. When enabled, the engine takes longer to redraw, but only redraws the screen if necessary. This may lower power consumption, and is intended for editors or mobile applications. For most games, because the screen needs to be redrawn every frame, it is recommended to keep this setting disabled.
 		</member>
 		<member name="application/run/low_processor_mode_sleep_usec" type="int" setter="" getter="" default="6900">
-			Amount of sleeping between frames when the low-processor usage mode is enabled (in microseconds). Higher values will result in lower CPU usage.
+			Amount of sleeping between frames when the low-processor usage mode is enabled (in microseconds). Higher values will result in lower CPU/GPU usage. Only effective if [member application/run/low_processor_mode_sleep_usec_mode] is [b]Custom[/b].
+			[b]Note:[/b] This property is only read when the project starts. To change the low-processor mode sleep duration at runtime, set [member OS.low_processor_usage_mode_sleep_usec] instead.
+		</member>
+		<member name="application/run/low_processor_mode_sleep_usec_mode" type="int" setter="" getter="" default="1">
+			The policy to use to determine the sleep duration between frames when the low-processor usage mode is enabled. See also [member application/run/low_processor_mode].
+			- [b]Automatic:[/b] Automatically determine the sleep duration between frames using the refresh rate of the fastest display connected to the system when the engine starts.
+			- [b]Custom:[/b] Use a custom sleep duration between frames, as specified by [member application/run/low_processor_mode_sleep_usec].
+			[b]Note:[/b] This property is only read when the project starts. To change the low-processor mode sleep policy at runtime, set [member OS.low_processor_usage_mode_sleep_usec_mode] instead.
 		</member>
 		<member name="application/run/main_loop_type" type="String" setter="" getter="" default="&quot;SceneTree&quot;">
 			The name of the type implementing the engine's main loop.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -935,7 +935,6 @@ void EditorNode::_notification(int p_what) {
 			// Theme has already been created in the constructor, so we can skip that step.
 			_update_theme(true);
 
-			OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(int(EDITOR_GET("interface/editor/timers/low_processor_mode_sleep_usec")));
 			get_tree()->get_root()->set_as_audio_listener_3d(false);
 			get_tree()->get_root()->set_as_audio_listener_2d(false);
 			get_tree()->get_root()->set_snap_2d_transforms_to_pixel(false);
@@ -1046,7 +1045,8 @@ void EditorNode::_notification(int p_what) {
 
 		case NOTIFICATION_APPLICATION_FOCUS_IN: {
 			// Restore the original FPS cap after focusing back on the editor.
-			OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(int(EDITOR_GET("interface/editor/timers/low_processor_mode_sleep_usec")));
+			OS::get_singleton()->set_low_processor_usage_mode_sleep_usec_mode(EDITOR_GET("interface/editor/timers/low_processor_mode_max_fps_mode"));
+			OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(1'000'000.0 / int(EDITOR_GET("interface/editor/timers/custom_low_processor_mode_max_fps")));
 
 			if (_is_project_data_missing()) {
 				project_data_missing->popup_centered();
@@ -1067,7 +1067,8 @@ void EditorNode::_notification(int p_what) {
 
 			// Set a low FPS cap to decrease CPU/GPU usage while the editor is unfocused.
 			if (unfocused_low_processor_usage_mode_enabled) {
-				OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(int(EDITOR_GET("interface/editor/timers/unfocused_low_processor_mode_sleep_usec")));
+				OS::get_singleton()->set_low_processor_usage_mode_sleep_usec_mode(OS::LowProcessorModeSleepUsecMode::LOW_PROCESSOR_SLEEP_USEC_MODE_CUSTOM);
+				OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(int(1'000'000.0 / int(EDITOR_GET("interface/editor/timers/unfocused_low_processor_mode_max_fps"))));
 			}
 		} break;
 
@@ -1098,7 +1099,10 @@ void EditorNode::_notification(int p_what) {
 				print_verbose("Using \"" + DisplayServer::get_singleton()->tablet_get_current_driver() + "\" pen tablet driver...");
 			}
 
-			if (EDITOR_GET("interface/editor/behavior/import_resources_when_unfocused")) {
+			OS::get_singleton()->set_low_processor_usage_mode_sleep_usec_mode(EDITOR_GET("interface/editor/timers/low_processor_mode_max_fps_mode"));
+			OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(1'000'000.0 / int(EDITOR_GET("interface/editor/timers/custom_low_processor_mode_max_fps")));
+
+			if (EDITOR_GET("interface/editor/import_resources_when_unfocused")) {
 				scan_changes_timer->start();
 			} else {
 				scan_changes_timer->stop();

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1386,7 +1386,12 @@ ProjectManager::ProjectManager() {
 			AcceptDialog::set_swap_cancel_ok(swap_cancel_ok == 2);
 		}
 
+		const DisplayServerEnums::VSyncMode window_vsync_mode = DisplayServerEnums::VSyncMode(int(EDITOR_GET("interface/editor/vsync_mode")));
+		DisplayServer::get_singleton()->window_set_vsync_mode(window_vsync_mode);
+
 		OS::get_singleton()->set_low_processor_usage_mode(true);
+		OS::get_singleton()->set_low_processor_usage_mode_sleep_usec_mode(EDITOR_GET("interface/editor/timers/low_processor_mode_sleep_usec_mode"));
+		OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(1'000'000.0 / int(EDITOR_GET("interface/editor/timers/custom_low_processor_mode_max_fps")));
 	}
 
 #if defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -540,13 +540,15 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 #endif
 
 	_initial_set("interface/editor/display/keep_screen_on", false, true);
-	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/timers/low_processor_mode_sleep_usec", 6900, "1,100000,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
-	// Default unfocused usec sleep is for 10 FPS. Allow an unfocused FPS limit
-	// as low as 1 FPS for those who really need low power usage (but don't need
-	// to preview particles or shaders while the editor is unfocused). With very
-	// low FPS limits, the editor can take a small while to become usable after
-	// being focused again, so this should be used at the user's discretion.
-	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/timers/unfocused_low_processor_mode_sleep_usec", 100000, "1,1000000,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	// Automatic (VRR) option is not relevant for non-game applications such as the editor so it's not the default.
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/timers/low_processor_mode_max_fps_mode", OS::LowProcessorModeSleepUsecMode::LOW_PROCESSOR_SLEEP_USEC_MODE_AUTOMATIC, "Automatic,Custom")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/timers/custom_low_processor_mode_max_fps", 145, "30,1000,1")
+	// Allow an unfocused FPS limit as low as 1 FPS for those who really need
+	// low power usage (but don't need to preview particles or shaders while the
+	// editor is unfocused). With very low FPS limits, the editor can take a
+	// small while to become usable after being focused again, so this should be
+	// used at the user's discretion.
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/timers/unfocused_low_processor_mode_max_fps", 10, "1,1000,1")
 
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/behavior/import_resources_when_unfocused", false, "")
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2235,6 +2235,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	OS::get_singleton()->ensure_user_data_dir();
 
 	OS::get_singleton()->set_low_processor_usage_mode(GLOBAL_DEF("application/run/low_processor_mode", false));
+	OS::get_singleton()->set_low_processor_usage_mode_sleep_usec_mode(GLOBAL_DEF("application/run/low_processor_mode_sleep_usec_mode", OS::LowProcessorModeSleepUsecMode::LOW_PROCESSOR_SLEEP_USEC_MODE_CUSTOM));
 	OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(
 			GLOBAL_DEF(PropertyInfo(Variant::INT, "application/run/low_processor_mode_sleep_usec", PROPERTY_HINT_RANGE, "0,33200,1,or_greater"), 6900)); // Roughly 144 FPS
 
@@ -3647,6 +3648,24 @@ Error Main::setup2(bool p_show_boot_logo) {
 			if (editor) {
 				id->set_emulate_mouse_from_touch(true);
 			}
+		}
+
+		int highest_refresh_rate = 0;
+		for (int i = 0; i < DisplayServer::get_singleton()->get_screen_count(); i++) {
+			highest_refresh_rate = MAX(highest_refresh_rate, Math::ceil(DisplayServer::get_singleton()->screen_get_refresh_rate(i)));
+		}
+		print_verbose(vformat("Detected highest screen refresh rate (rounded up): %d Hz", highest_refresh_rate));
+
+		if (highest_refresh_rate >= 30) {
+			// If at least one refresh rate was successfully detected, limit the rendered framerate
+			// to (roughly) the monitor refresh rate by default. A slightly higher value is used to ensure
+			// the display is always fed with frames if the CPU and GPU can keep up, without introducing too much tearing.
+			//
+			// This is helpful to reduce power consumption, heat and noise emissions
+			// when V-Sync is disabled or fails to kick in.
+			// This can also reduce input lag in GPU-bottlenecked situations by preventing 100% GPU load
+			// (which causes pipeline stalls in most configurations).
+			OS::get_singleton()->set_low_processor_usage_mode_sleep_usec_automatic(1'000'000.0 / (highest_refresh_rate + 1));
 		}
 
 		OS::get_singleton()->benchmark_end_measure("Startup", "Setup Window and Boot");

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2637,7 +2637,7 @@ void OS_Windows::add_frame_delay(bool p_can_draw, bool p_wake_for_events) {
 	// previous frame time into account for a smoother result.
 	uint64_t dynamic_delay = 0;
 	if (is_in_low_processor_usage_mode() || !p_can_draw) {
-		dynamic_delay = get_low_processor_usage_mode_sleep_usec();
+		dynamic_delay = get_effective_low_processor_usage_mode_sleep_usec();
 	}
 	const int max_fps = Engine::get_singleton()->get_max_fps();
 	if (max_fps > 0 && !Engine::get_singleton()->is_editor_hint()) {


### PR DESCRIPTION
- Related to https://github.com/godotengine/godot/pull/66367.

Previously, the default low processor mode sleep duration was set to `6900`, which limited framerate to 145 FPS regardless of the monitor refresh rate. This had a few downsides:

- On displays faster than 144 Hz, the full potential of the display wasn't utilized, leading to higher input lag and lower motion clarity than would otherwise be possible.
- On displays slower than 144 Hz, more frames were rendered than necessary when V-Sync is disabled, leading to unnecessary CPU/GPU utilization. (This is not an issue when V-Sync is enabled.)

This makes a few changes to improve the experience in the editor:

- A new editor setting is added to choose between the automatic value (the new default) and a custom value.
- The sleep duration is now expressed as a FPS value, which is easier to understand. The editor settings were renamed accordingly.
- The unfocused value is still applied regardless of the chosen mode, but is also expressed in FPS as well.
- The lower bound of the max FPS value when focused is now 30, to prevent the editor from being unusably slow.
- All three editor settings are now effective without a restart.

This option is also available for projects, which is useful for [non-game applications](https://docs.godotengine.org/en/latest/tutorials/ui/creating_applications.html). However, in the interest of preserving the existing behavior by default, it needs to be manually chosen in the Project Settings.

## Preview

<img width="904" height="92" alt="image" src="https://github.com/user-attachments/assets/d25fa820-4889-4499-b363-d05d3bf0e5e4" />

## TODO

- [ ] Listen to display/screen changes and update the sleep duration according to the screen the main window is currently on.