### PR TITLE
Fix UPNP code sample using `OK` constant incorrectly

### DIFF
--- a/modules/upnp/doc_classes/UPNP.xml
+++ b/modules/upnp/doc_classes/UPNP.xml
@@ -29,7 +29,7 @@
 			var upnp = UPNP.new()
 			var err = upnp.discover()
 
-			if err != OK:
+			if err != UPNP.UPNP_RESULT_SUCCESS:
 				push_error(str(err))
 				upnp_completed.emit(err)
 				return
@@ -37,7 +37,7 @@
 			if upnp.get_gateway() and upnp.get_gateway().is_valid_gateway():
 				upnp.add_port_mapping(server_port, server_port, ProjectSettings.get_setting("application/config/name"), "UDP")
 				upnp.add_port_mapping(server_port, server_port, ProjectSettings.get_setting("application/config/name"), "TCP")
-				upnp_completed.emit(OK)
+				upnp_completed.emit(UPNP.UPNP_RESULT_SUCCESS)
 
 		func _ready():
 			thread = Thread.new()


### PR DESCRIPTION
The returned value is an UPNPResult, not an Error. Both `UPNP.UPNP_RESULT_SUCCESS` and `OK` are equal to 0, so it will behave the same, but it's not identical from a static typing perspective.

- This closes https://github.com/godotengine/godot-docs/issues/11671.

There is an issue I'm running into when running the code locally: https://github.com/godotengine/godot-docs/issues/11671#issuecomment-3814722181

```
E 0:00:02:637   node_2d.gd:23 @ _upnp_setup(): /root/Node2D: The caller thread can't call the function `emit_signalp()` on this node. Use `call_deferred()` or `call_deferred_thread_group()` instead.
  <C++ Error>   Condition "!is_accessible_from_caller_thread()" is true. Returning: (ERR_INVALID_PARAMETER)
  <C++ Source>  scene/main/node.cpp:4188 @ emit_signalp()
  <Stack Trace> node_2d.gd:23 @ _upnp_setup()
```

I have the script attached to a Node2D in an empty project. Should we update anything else?
