### PR TITLE
Add fuzzy search to file system and scene tree docks

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -688,6 +688,24 @@
 		</member>
 		<member name="editors/bone_mapper/handle_colors/unset" type="Color" setter="" getter="">
 		</member>
+		<member name="editors/fuzzy_matching/enable_for/filesystem_dock" type="bool" setter="" getter="">
+			If [code]true[/code], together with exact matches of a filename, the file system search bar includes approximate matches.
+			This is useful for finding the correct files even when there are typos in the search query; for example, searching "nprmal" will find "normal". Additionally, it allows you to write shorter search queries; for example, searching "nml" will also find "normal".
+			See also [member editors/fuzzy_matching/max_fuzzy_misses].
+		</member>
+		<member name="editors/fuzzy_matching/enable_for/quick_open_dialog" type="bool" setter="" getter="">
+			If [code]true[/code], together with exact matches of a filename, the dialog includes approximate matches.
+			This is useful for finding the correct files even when there are typos in the search query; for example, searching "nprmal" will find "normal". Additionally, it allows you to write shorter search queries; for example, searching "nml" will also find "normal".
+			See also [member editors/fuzzy_matching/max_fuzzy_misses].
+		</member>
+		<member name="editors/fuzzy_matching/enable_for/scene_tree_dock" type="bool" setter="" getter="">
+			If [code]true[/code], together with exact matches of a node name, the scene tree search bar includes approximate matches.
+			This is useful for finding the correct nodes even when there are typos in the search query; for example, searching "enmy" will find "enemy". Additionally, it allows you to write shorter search queries; for example, searching "camcon" will also find "camera_controller".
+			See also [member editors/fuzzy_matching/max_fuzzy_misses].
+		</member>
+		<member name="editors/fuzzy_matching/max_fuzzy_misses" type="int" setter="" getter="">
+			The number of missed query characters allowed in a match when fuzzy matching is enabled. For example, with the default value of [code]2[/code], [code]"normal"[/code] would match [code]"narmal"[/code] and [code]"norma"[/code] but not [code]"nor"[/code].
+		</member>
 		<member name="editors/grid_map/pick_distance" type="float" setter="" getter="">
 			The maximum distance at which tiles can be placed on a GridMap, relative to the camera position (in 3D units).
 		</member>
@@ -914,19 +932,11 @@
 		<member name="filesystem/quick_open_dialog/default_display_mode" type="int" setter="" getter="">
 			If set to [code]Adaptive[/code], the dialog opens in list view or grid view depending on the requested type. If set to [code]Last Used[/code], the display mode will always open the way you last used it.
 		</member>
-		<member name="filesystem/quick_open_dialog/enable_fuzzy_matching" type="bool" setter="" getter="">
-			If [code]true[/code], together with exact matches of a filename, the dialog includes approximate matches.
-			This is useful for finding the correct files even when there are typos in the search query; for example, searching "nprmal" will find "normal". Additionally, it allows you to write shorter search queries; for example, searching "nml" will also find "normal".
-			See also [member filesystem/quick_open_dialog/max_fuzzy_misses].
-		</member>
 		<member name="filesystem/quick_open_dialog/include_addons" type="bool" setter="" getter="">
 			If [code]true[/code], results will include files located in the [code]addons[/code] folder.
 		</member>
 		<member name="filesystem/quick_open_dialog/instant_preview" type="bool" setter="" getter="">
 			If [code]true[/code], highlighting a resource will preview it quickly without confirming the selection or closing the dialog.
-		</member>
-		<member name="filesystem/quick_open_dialog/max_fuzzy_misses" type="int" setter="" getter="">
-			The number of missed query characters allowed in a match when fuzzy matching is enabled. For example, with the default value of [code]2[/code], [code]"normal"[/code] would match [code]"narmal"[/code] and [code]"norma"[/code] but not [code]"nor"[/code].
 		</member>
 		<member name="filesystem/quick_open_dialog/max_results" type="int" setter="" getter="">
 			Maximum number of matches to show in dialog.

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2859,6 +2859,12 @@ void FileSystemDock::_search_changed(const String &p_text, const Control *p_from
 	}
 
 	searched_tokens = searched_string.split(" ", false);
+	fuzzy_search.set_query(searched_string);
+
+	bool use_fuzzy_search = EDITOR_GET("editors/fuzzy_matching/enable_for/filesystem_dock");
+	int max_fuzzy_misses = EDITOR_GET("editors/fuzzy_matching/max_fuzzy_misses");
+	fuzzy_search.allow_subsequences = use_fuzzy_search;
+	fuzzy_search.max_misses = (use_fuzzy_search && searched_string.length() > max_fuzzy_misses) ? max_fuzzy_misses : 0;
 
 	if (p_from == tree_search_box) {
 		file_list_search_box->set_text(searched_string);
@@ -2879,6 +2885,13 @@ bool FileSystemDock::_matches_all_search_tokens(const String &p_text) {
 	if (searched_tokens.is_empty()) {
 		return false;
 	}
+
+	bool use_fuzzy_search = EDITOR_GET("editors/fuzzy_matching/enable_for/filesystem_dock");
+	if (use_fuzzy_search) {
+		FuzzySearchResult result;
+		return fuzzy_search.search(p_text, result);
+	}
+
 	const String s = p_text.to_lower();
 	for (const String &t : searched_tokens) {
 		if (!s.contains(t)) {

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/string/fuzzy_search.h"
 #include "editor/docks/editor_dock.h"
 #include "editor/file_system/dependency_editor.h"
 #include "editor/file_system/editor_file_system.h"
@@ -177,6 +178,7 @@ private:
 	LineEdit *file_list_search_box = nullptr;
 	MenuButton *file_list_button_sort = nullptr;
 
+	FuzzySearch fuzzy_search;
 	PackedStringArray searched_tokens;
 	Vector<String> uncollapsed_paths_before_search;
 

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -522,7 +522,7 @@ void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
 	}
 
 	const bool do_instant_preview = EDITOR_GET("filesystem/quick_open_dialog/instant_preview");
-	const bool fuzzy_matching = EDITOR_GET("filesystem/quick_open_dialog/enable_fuzzy_matching");
+	const bool fuzzy_matching = EDITOR_GET("editors/fuzzy_matching/enable_for/quick_open_dialog");
 	const bool include_addons = EDITOR_GET("filesystem/quick_open_dialog/include_addons");
 	instant_preview_toggle->set_pressed_no_signal(do_instant_preview);
 	fuzzy_search_toggle->set_pressed_no_signal(fuzzy_matching);
@@ -811,10 +811,10 @@ void QuickOpenResultContainer::_update_fuzzy_search_results() {
 	fuzzy_search.start_offset = 6; // Don't match against "res://" at the start of each filepath.
 	fuzzy_search.set_query(query);
 	fuzzy_search.max_results = max_total_results;
-	bool fuzzy_matching = EDITOR_GET("filesystem/quick_open_dialog/enable_fuzzy_matching");
-	int max_misses = EDITOR_GET("filesystem/quick_open_dialog/max_fuzzy_misses");
+	bool fuzzy_matching = EDITOR_GET("editors/fuzzy_matching/enable_for/quick_open_dialog");
+	int max_misses = EDITOR_GET("editors/fuzzy_matching/max_fuzzy_misses");
 	fuzzy_search.allow_subsequences = fuzzy_matching;
-	fuzzy_search.max_misses = fuzzy_matching ? max_misses : 0;
+	fuzzy_search.max_misses = (fuzzy_matching && query.length() > max_misses) ? max_misses : 0;
 
 	PackedStringArray paths;
 	paths.reserve_exact(uids.size());
@@ -1000,7 +1000,7 @@ void QuickOpenResultContainer::_toggle_instant_preview(bool p_pressed) {
 }
 
 void QuickOpenResultContainer::_toggle_fuzzy_search(bool p_pressed) {
-	EditorSettings::get_singleton()->set("filesystem/quick_open_dialog/enable_fuzzy_matching", p_pressed);
+	EditorSettings::get_singleton()->set("editors/fuzzy_matching/enable_for/quick_open_dialog", p_pressed);
 	update_results();
 }
 

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -1188,6 +1188,7 @@ bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, const PackedStri
 		return true;
 	}
 
+	bool use_fuzzy_search = EDITOR_GET("editors/fuzzy_matching/enable_for/scene_tree_dock");
 	for (int i = 0; i < p_terms.size(); i++) {
 		const String &term = p_terms[i];
 
@@ -1235,10 +1236,15 @@ bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, const PackedStri
 			}
 		} else {
 			// Default.
-			if (!p_item->get_text(0).to_lower().contains(term)) {
+			if (!use_fuzzy_search && !p_item->get_text(0).to_lower().contains(term)) {
 				return false;
 			}
 		}
+	}
+
+	if (use_fuzzy_search) {
+		FuzzySearchResult result;
+		return fuzzy_search.search(p_item->get_text(0), result);
 	}
 
 	return true;
@@ -1740,6 +1746,23 @@ void SceneTreeEditor::set_marked(Node *p_marked, bool p_selectable, bool p_child
 
 void SceneTreeEditor::set_filter(const String &p_filter) {
 	filter = p_filter;
+
+	String fuzzy_query = "";
+	for (const String &term : filter.to_lower().split_spaces()) {
+		if (!(term.contains_char(':') && !term.get_slicec(':', 0).is_empty())) {
+			if (!fuzzy_query.is_empty()) {
+				fuzzy_query += " ";
+			}
+			fuzzy_query += term;
+		}
+	}
+
+	fuzzy_search.set_query(fuzzy_query);
+	bool use_fuzzy_search = EDITOR_GET("editors/fuzzy_matching/enable_for/scene_tree_dock");
+	int max_fuzzy_misses = EDITOR_GET("editors/fuzzy_matching/max_fuzzy_misses");
+	fuzzy_search.allow_subsequences = use_fuzzy_search;
+	fuzzy_search.max_misses = (use_fuzzy_search && fuzzy_query.length() > max_fuzzy_misses) ? max_fuzzy_misses : 0;
+
 	_update_filter(nullptr, true);
 }
 

--- a/editor/scene/scene_tree_editor.h
+++ b/editor/scene/scene_tree_editor.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/string/fuzzy_search.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/tree.h"
 
@@ -114,6 +115,7 @@ class SceneTreeEditor : public Control {
 	Tree *tree = nullptr;
 	Node *selected = nullptr;
 
+	FuzzySearch fuzzy_search;
 	String filter;
 	String filter_term_warning;
 	bool show_all_nodes = false;

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -687,10 +687,14 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_RANGE, "filesystem/quick_open_dialog/max_results", 100, "0,10000,1", PROPERTY_USAGE_DEFAULT)
 	_initial_set("filesystem/quick_open_dialog/instant_preview", false);
 	_initial_set("filesystem/quick_open_dialog/show_search_highlight", true);
-	_initial_set("filesystem/quick_open_dialog/enable_fuzzy_matching", true);
-	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_RANGE, "filesystem/quick_open_dialog/max_fuzzy_misses", 2, "0,10,1", PROPERTY_USAGE_DEFAULT)
 	_initial_set("filesystem/quick_open_dialog/include_addons", false);
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "filesystem/quick_open_dialog/default_display_mode", 0, "Adaptive,Last Used")
+
+	// Fuzzy Matching
+	_initial_set("editors/fuzzy_matching/enable_for/filesystem_dock", true);
+	_initial_set("editors/fuzzy_matching/enable_for/quick_open_dialog", true);
+	_initial_set("editors/fuzzy_matching/enable_for/scene_tree_dock", true);
+	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_RANGE, "editors/fuzzy_matching/max_fuzzy_misses", 2, "0,10,1", PROPERTY_USAGE_DEFAULT)
 
 	// Import (for glft module)
 	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "filesystem/import/blender/blender_path", "", "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED | PROPERTY_USAGE_EDITOR_BASIC_SETTING)
@@ -1326,6 +1330,8 @@ void EditorSettings::_handle_setting_compatibility() {
 	_rename_setting("interface/editor/update_continuously", "interface/editor/display/update_continuously");
 	_rename_setting("interface/editor/collapse_main_menu", "interface/editor/appearance/collapse_main_menu");
 	_rename_setting("asset_library/use_threads", "asset_store/use_threads");
+	_rename_setting("filesystem/quick_open_dialog/enable_fuzzy_matching", "editors/fuzzy_matching/enable_for/quick_open_dialog");
+	_rename_setting("filesystem/quick_open_dialog/max_fuzzy_misses", "editors/fuzzy_matching/max_fuzzy_misses");
 }
 
 void EditorSettings::_rename_setting(const String &p_old_name, const String &p_new_name) {


### PR DESCRIPTION
Adding fuzzy search to the file system dock and the scene tree dock. There's also the option to disable the fuzzy searching from the editor settings under docks. I created this PR since I got frustrated navigating my scripts, files, and nodes inside of the docks as fuzzy searching is something I rely on in my script editor. Thought it would be a nice feature to have inside of the editor and I'm certain that some people will like this. For the people who don't, it's a simple switch in the editor settings.

|**Scene tree dock without fuzzy search:**|**Scene tree dock with fuzzy search:**
|---|---|
|<img width="269" height="145" alt="image" src="https://github.com/user-attachments/assets/99f1519b-5994-4adf-afab-c934a9a11d82" />|<img width="290" height="118" alt="image" src="https://github.com/user-attachments/assets/01102c13-951e-4e94-a735-f6870abb6fd5" />|

|**File system dock without fuzzy search:**|**File system dock with fuzzy search:**|
|---|---|
|<img width="308" height="193" alt="image" src="https://github.com/user-attachments/assets/bca05c66-6fa0-44ce-b65e-1af4114fcbd2" />|<img width="320" height="243" alt="image" src="https://github.com/user-attachments/assets/9b0c3422-9bec-438a-967f-d4997be32813" />|

**Fuzzy search editor setting for docks:**
<img width="686" height="257" alt="image" src="https://github.com/user-attachments/assets/5d0ae6e0-2f80-4af5-92e0-c335b9ac79b5" />


Let me know if any changes are required ^^

Closes https://github.com/godotengine/godot-proposals/issues/14295