### PR TITLE
[Linux/BSD] Prefer `gimli-rs/addr2line` or `llvm-addr2line` over binutils.

### DIFF
--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -103,7 +103,31 @@ static void handle_crash(int sig) {
 	uintptr_t relocation = 0;
 #endif //__GLIBC__
 	if (strings) {
+		int ret;
+		String output;
+
 		List<String> args;
+		args.push_back("--version");
+		String exe_name;
+
+		if (exe_name.is_empty()) {
+			// Faster implementation from gimli-rs/addr2line.
+			Error err = OS::get_singleton()->execute(OS::get_singleton()->get_environment("HOME").path_join(String("/.cargo/bin/addr2line")), args, &output, &ret);
+			if (err == OK && ret == 0) {
+				exe_name = OS::get_singleton()->get_environment("HOME").path_join(String("/.cargo/bin/addr2line"));
+			}
+		}
+		if (exe_name.is_empty()) {
+			Error err = OS::get_singleton()->execute(String("llvm-addr2line"), args, &output, &ret);
+			if (err == OK && ret == 0) {
+				exe_name = String("llvm-addr2line");
+			}
+		}
+		if (exe_name.is_empty()) {
+			exe_name = String("addr2line");
+		}
+
+		args.clear();
 		for (size_t i = 0; i < size; i++) {
 			char str[1024];
 			snprintf(str, 1024, "%p", (void *)((uintptr_t)bt_buffer[i] - relocation));
@@ -113,9 +137,7 @@ static void handle_crash(int sig) {
 		args.push_back(_execpath);
 
 		// Try to get the file/line number using addr2line
-		int ret;
-		String output = "";
-		Error err = OS::get_singleton()->execute(String("addr2line"), args, &output, &ret);
+		Error err = OS::get_singleton()->execute(exe_name, args, &output, &ret);
 		Vector<String> addr2line_results;
 		if (err == OK) {
 			addr2line_results = output.substr(0, output.length() - 1).split("\n", false);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/115508
