### PR TITLE
Fix `script_language_extension.cpp` compilation with `deprecated=no`

### DIFF
--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -104,8 +104,8 @@ void ScriptLanguageExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_validate, "script", "path", "validate_functions", "validate_errors", "validate_warnings", "validate_safe_lines");
 
 	GDVIRTUAL_BIND(_validate_path, "path");
-	GDVIRTUAL_BIND(_create_script);
 #ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND(_create_script);
 	GDVIRTUAL_BIND(_has_named_classes);
 #endif
 	GDVIRTUAL_BIND(_supports_builtin_mode);


### PR DESCRIPTION
Fixes compilation error in `script_language_extension.cpp` when building with `deprecated=no`.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/115556*