### PR TITLE
Do not include `input_enums.h` and `keyboard.h` from `variant.h` and `binder_common.h`

### DIFF
--- a/core/os/midi_driver.h
+++ b/core/os/midi_driver.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/input/input_enums.h"
 #include "core/typedefs.h"
 #include "core/variant/variant.h"
 

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -30,9 +30,7 @@
 
 #pragma once
 
-#include "core/input/input_enums.h"
 #include "core/object/object.h"
-#include "core/os/keyboard.h"
 #include "core/templates/simple_type.h"
 #include "core/typedefs.h"
 #include "core/variant/method_ptrcall.h"
@@ -41,6 +39,19 @@
 #include "core/variant/variant_internal.h"
 
 #include <cstdio>
+
+enum class HatDir;
+enum class HatMask;
+enum class JoyAxis;
+enum class JoyButton;
+
+enum class MIDIMessage;
+enum class MouseButton;
+enum class MouseButtonMask;
+
+enum class Key;
+enum class KeyModifierMask;
+enum class KeyLocation;
 
 // Variant cannot define an implicit cast operator for every Object subclass, so the
 // casting is done here, to allow binding methods with parameters more specific than Object *

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "core/core_string_names.h"
-#include "core/input/input_enums.h"
 #include "core/io/ip_address.h"
 #include "core/math/aabb.h"
 #include "core/math/basis.h"
@@ -51,7 +50,6 @@
 #include "core/math/vector4.h"
 #include "core/math/vector4i.h"
 #include "core/object/object_id.h"
-#include "core/os/keyboard.h"
 #include "core/string/node_path.h"
 #include "core/string/ustring.h"
 #include "core/templates/bit_field.h"

--- a/editor/project_upgrade/project_converter_3_to_4.cpp
+++ b/editor/project_upgrade/project_converter_3_to_4.cpp
@@ -36,6 +36,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/object/ref_counted.h"
+#include "core/os/keyboard.h"
 #include "core/os/time.h"
 #include "core/templates/list.h"
 #include "editor/project_upgrade/renames_map_3_to_4.h"


### PR DESCRIPTION
- Helps address #111218 

Minor include enhancement. Since `variant.h` and `binder_common.h` are included near everywhere, these headers were also in nearly every compile unit, when they're only needed in a few handful.
