### PR TITLE
Fix icon size in AnimationPlayer tracks

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -2228,7 +2228,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 					Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(node);
 					const Vector2 icon_size = Vector2(1, 1) * get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
 
-					icon_rect = Rect2(Point2(ofs, (get_size().height - check->get_height()) / 2).round(), icon->get_size());
+					icon_rect = Rect2(Point2(ofs, (get_size().height - check->get_height()) / 2).round(), icon_size);
 					draw_texture_rect(icon, icon_rect);
 					icon_cache = icon;
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/115573

Before/After


<img width="639" height="306" alt="Screenshot_20260129_140214" src="https://github.com/user-attachments/assets/3c033dbc-41fc-441e-b7c9-116a5bdb9a0d" />

<img width="639" height="306" alt="Screenshot_20260129_140200" src="https://github.com/user-attachments/assets/f81995f5-998b-4ef9-a4a4-1c1ded9f5564" />
