### PR TITLE
Remove a few includes of `curve.h`, `texture.h` and `resource_loader.h` + `resource_saver.h`

### DIFF
--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/2d/node_2d.h"
+#include "scene/resources/curve.h"
 #include "scene/resources/gradient.h"
 
 class RandomNumberGenerator;

--- a/scene/2d/line_2d.h
+++ b/scene/2d/line_2d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/2d/node_2d.h"
+#include "scene/resources/curve.h"
 #include "scene/resources/gradient.h"
 
 class Line2D : public Node2D {

--- a/scene/3d/bone_twist_disperser_3d.h
+++ b/scene/3d/bone_twist_disperser_3d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/3d/skeleton_modifier_3d.h"
+#include "scene/resources/curve.h"
 
 class BoneTwistDisperser3D : public SkeletonModifier3D {
 	GDCLASS(BoneTwistDisperser3D, SkeletonModifier3D);

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/3d/visual_instance_3d.h"
+#include "scene/resources/curve.h"
 #include "scene/resources/gradient.h"
 
 class RandomNumberGenerator;

--- a/scene/3d/spring_bone_simulator_3d.h
+++ b/scene/3d/spring_bone_simulator_3d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/3d/skeleton_modifier_3d.h"
+#include "scene/resources/curve.h"
 
 #ifndef DISABLE_DEPRECATED
 namespace compat::SpringBoneSimulator3D {

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -32,6 +32,8 @@
 
 #include "core/config/project_settings.h"
 #include "core/math/geometry_3d.h"
+#include "scene/resources/curve.h"
+#include "scene/resources/texture.h"
 
 static _FORCE_INLINE_ void get_uv_and_normal(const Vector3 &p_pos, const Vector3 *p_vtx, const Vector2 *p_uv, const Vector3 *p_normal, Vector2 &r_uv, Vector3 &r_normal) {
 	if (p_pos.is_equal_approx(p_vtx[0])) {

--- a/scene/resources/3d/fog_material.h
+++ b/scene/resources/3d/fog_material.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/resources/material.h"
+#include "scene/resources/texture.h"
 
 class FogMaterial : public Material {
 	GDCLASS(FogMaterial, Material);

--- a/scene/resources/3d/mesh_library.cpp
+++ b/scene/resources/3d/mesh_library.cpp
@@ -30,6 +30,8 @@
 
 #include "mesh_library.h"
 
+#include "scene/resources/texture.h"
+
 #ifndef PHYSICS_3D_DISABLED
 #include "box_shape_3d.h"
 #endif // PHYSICS_3D_DISABLED

--- a/scene/resources/3d/primitive_meshes.h
+++ b/scene/resources/3d/primitive_meshes.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "scene/resources/curve.h"
 #include "scene/resources/font.h"
 #include "scene/resources/mesh.h"
 #include "servers/text/text_server.h"

--- a/scene/resources/3d/sky_material.cpp
+++ b/scene/resources/3d/sky_material.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/version.h"
+#include "scene/resources/texture.h"
 
 Mutex ProceduralSkyMaterial::shader_mutex;
 RID ProceduralSkyMaterial::shader_cache[4];

--- a/scene/resources/curve_texture.h
+++ b/scene/resources/curve_texture.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "scene/resources/curve.h"
 #include "scene/resources/texture.h"
 
 class CurveTexture : public Texture2D {

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -35,6 +35,7 @@
 #include "core/error/error_macros.h"
 #include "core/version.h"
 #include "scene/main/scene_tree.h"
+#include "scene/resources/texture.h"
 
 void Material::set_next_pass(const Ref<Material> &p_pass) {
 	for (Ref<Material> pass_child = p_pass; pass_child.is_valid(); pass_child = pass_child->get_next_pass()) {

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -33,7 +33,6 @@
 #include "core/io/resource.h"
 #include "core/templates/self_list.h"
 #include "scene/resources/shader.h"
-#include "scene/resources/texture.h"
 #include "servers/rendering/rendering_server.h"
 
 class Material : public Resource {

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -31,10 +31,10 @@
 #pragma once
 
 #include "core/io/resource.h"
-#include "core/io/resource_loader.h"
-#include "core/io/resource_saver.h"
-#include "scene/resources/texture.h"
 #include "shader_include.h"
+
+class Texture;
+class Texture2D;
 
 class Shader : public Resource {
 	GDCLASS(Shader, Resource);

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -33,7 +33,6 @@
 #include "core/io/image.h"
 #include "core/io/resource.h"
 #include "core/variant/typed_array.h"
-#include "scene/resources/curve.h"
 
 class Texture : public Resource {
 	GDCLASS(Texture, Resource);


### PR DESCRIPTION
- Helps address #111218 

Not much to say, except `texture.h` and `material.h` are hubs and should be minimal with their includes (appearing in #111218 top 50).