### PR TITLE
Add errors for empty return in non-void functions and return value in void functions

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2539,9 +2539,12 @@ void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
 				parser->push_warning(p_return, GDScriptWarning::UNSAFE_VOID_RETURN, function_name, called_function_name);
 #endif // DEBUG_ENABLED
 				mark_node_unsafe(p_return);
-			} else if (!is_call) {
+			}
+
+			if (!is_call || (is_call && return_type.builtin_type != Variant::NIL)) {
 				push_error("A void function cannot return a value.", p_return);
 			}
+
 			result.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
 			result.kind = GDScriptParser::DataType::BUILTIN;
 			result.builtin_type = Variant::NIL;
@@ -2559,6 +2562,10 @@ void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
 			result = p_return->return_value->get_datatype();
 		}
 	} else {
+		if (has_expected_type && expected_type.builtin_type != Variant::NIL) {
+			push_error("Non-void function should return a value.", p_return);
+		}
+
 		// Return type is null by default.
 		result.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
 		result.kind = GDScriptParser::DataType::BUILTIN;

--- a/modules/gdscript/tests/scripts/analyzer/errors/return_object_in_void_func.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/return_object_in_void_func.gd
@@ -1,0 +1,2 @@
+func test() -> void:
+	return Resource.new()

--- a/modules/gdscript/tests/scripts/analyzer/errors/return_object_in_void_func.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/return_object_in_void_func.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 2: A void function cannot return a value.

--- a/modules/gdscript/tests/scripts/analyzer/errors/return_void_in_not_void_func.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/return_void_in_not_void_func.gd
@@ -1,0 +1,2 @@
+func test() -> Object:
+	return

--- a/modules/gdscript/tests/scripts/analyzer/errors/return_void_in_not_void_func.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/return_void_in_not_void_func.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 2: Non-void function should return a value.

--- a/modules/gdscript/tests/scripts/analyzer/features/return_call_void_func_in_void_func.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/return_call_void_func_in_void_func.gd
@@ -1,0 +1,8 @@
+func main_void_function() -> void:
+	return child_void_function()
+
+func child_void_function() -> void:
+	print("ok");
+
+func test():
+	main_void_function()

--- a/modules/gdscript/tests/scripts/analyzer/features/return_call_void_func_in_void_func.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/return_call_void_func_in_void_func.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/106501

## Example

| Before | After |
| ------------- | ------------- |
| <img width="500" height="455" alt="before_fix" src="https://github.com/user-attachments/assets/63f3b9cb-fb78-4cf9-95d3-3eb3ba46cd90" />| <img width="500" height="455" alt="after_fix" src="https://github.com/user-attachments/assets/47e31e4a-0190-4094-9325-96e5ab93983f" /> |

<details>
<summary>GDScript source code</summary>

```gdscript
extends Node

func new_obj() -> Object:
	return

func create_obj() -> void:
	return Resource.new()

var _cached_resource: Resource
func get_res() -> Resource:
	if _cached_resource != null: return
	var r: Resource = Resource.new()
	# load_res(r)
	_cached_resource = r
	return r

```

</details>

## Discussion

A void function can still return a call to another void function. And it might not be good for someone. But I like it. However, I added a specific test for this case just to highlight it.

<details>
<summary>GDScript discussion example</summary>

```gdscript
func discussion() -> void:
	return example()

func example() -> void:
	pass
```

</details>