### PR TITLE
Improve the `AudioStreamPlayer2D.max_polyphony` documentation 

### DIFF
--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -70,8 +70,8 @@
 			Maximum distance from which audio is still hearable.
 		</member>
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
-			The maximum number of simultaneous sounds this node can play. 
-			Increasing this value allows multiple sounds to overlap (e.g., rapid gunfire or echoes), but at a higher CPU cost. 
+			The maximum number of simultaneous sounds this node can play.
+			Increasing this value allows multiple sounds to overlap (e.g., rapid gunfire or echoes), but at a higher CPU cost.
 			When the limit is reached, playing a new sound will instantly terminate the oldest active sound to stay within the limit.
 		</member>
 		<member name="panning_strength" type="float" setter="set_panning_strength" getter="get_panning_strength" default="1.0">

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -70,7 +70,9 @@
 			Maximum distance from which audio is still hearable.
 		</member>
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
-			The maximum number of sounds this node can play at the same time. Playing additional sounds after this value is reached will cut off the oldest sounds.
+			The maximum number of simultaneous sounds this node can play. 
+			Increasing this value allows multiple sounds to overlap (e.g., rapid gunfire or echoes), but at a higher CPU cost. 
+			When the limit is reached, playing a new sound will instantly terminate the oldest active sound to stay within the limit.
 		</member>
 		<member name="panning_strength" type="float" setter="set_panning_strength" getter="get_panning_strength" default="1.0">
 			Scales the panning strength for this node by multiplying the base [member ProjectSettings.audio/general/2d_panning_strength] with this factor. Higher values will pan audio from left to right more dramatically than lower values.

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -71,7 +71,7 @@
 		</member>
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
 			The maximum number of simultaneous sounds this node can play.
-			Increasing this value allows multiple sounds to overlap (e.g. rapid gunfire or echoes), but at a higher CPU cost.
+			Increasing this value allows multiple sounds to overlap (for example rapid gunfire or echoes), but at a higher CPU cost.
 			When the limit is reached, playing a new sound will instantly terminate the oldest active sound to stay within the limit.
 		</member>
 		<member name="panning_strength" type="float" setter="set_panning_strength" getter="get_panning_strength" default="1.0">

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -71,7 +71,7 @@
 		</member>
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
 			The maximum number of simultaneous sounds this node can play.
-			Increasing this value allows multiple sounds to overlap (e.g., rapid gunfire or echoes), but at a higher CPU cost.
+			Increasing this value allows multiple sounds to overlap (e.g. rapid gunfire or echoes), but at a higher CPU cost.
 			When the limit is reached, playing a new sound will instantly terminate the oldest active sound to stay within the limit.
 		</member>
 		<member name="panning_strength" type="float" setter="set_panning_strength" getter="get_panning_strength" default="1.0">


### PR DESCRIPTION
I have made the documentation for max_polyphony property more informational, identifying use cases and warnings.