### PR TITLE
2D Rendering Hook

### DIFF
--- a/doc/classes/Compositor2D.xml
+++ b/doc/classes/Compositor2D.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Compositor2D" inherits="Node2D" experimental="The implementation may change as more of the rendering internals are exposed over time." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		This node allows for creating custom rendering commands in 2D.
+	</brief_description>
+	<description>
+		Similar to [Compositor] feature, this node allows to customize the rendering pipeline in 2D scenes.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_render_callback" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="render_data" type="RenderCanvasDataRD" />
+			<description>
+				Implement this function with your custom rendering code. This function will be called in the drawing order of the CanvasItems in the scene tree. [param render_data] provides access to the rendering state, it is only valid during rendering and should not be stored.
+			</description>
+		</method>
+		<method name="disable_backbuffer">
+			<return type="void" />
+			<description>
+				Disables back-buffering, it's disabled by default.
+			</description>
+		</method>
+		<method name="enable_backbuffer">
+			<return type="void" />
+			<description>
+				Enables back-buffering, useful for screen effects. See also [BackBufferCopy].
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/Compositor2D.xml
+++ b/doc/classes/Compositor2D.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Compositor2D" inherits="Node2D" api_type="core" experimental="The implementation may change as more of the rendering internals are exposed over time." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		This node allows for creating custom rendering commands in 2D.
+	</brief_description>
+	<description>
+		Similar to [Compositor] feature, this node allows to customize the rendering pipeline in 2D scenes.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_render_callback" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="render_data" type="RenderCanvasDataRD" />
+			<description>
+				Implement this function with your custom rendering code. This function will be called in the drawing order of the CanvasItems in the scene tree. [param render_data] provides access to the rendering state, it is only valid during rendering and should not be stored.
+			</description>
+		</method>
+		<method name="disable_backbuffer">
+			<return type="void" />
+			<description>
+				Disables back-buffering, it's disabled by default.
+			</description>
+		</method>
+		<method name="enable_backbuffer">
+			<return type="void" />
+			<description>
+				Enables back-buffering, useful for screen effects. See also [BackBufferCopy].
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/RenderCanvasDataRD.xml
+++ b/doc/classes/RenderCanvasDataRD.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RenderCanvasDataRD" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Render data object, holds canvas data related to rendering a single frame of a viewport.
+	</brief_description>
+	<description>
+		Canvas data object, exists for the duration of rendering a single viewport.
+		[b]Note:[/b] This is an internal rendering server object. Do not instantiate this class from a script.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_backbuffer_texture" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Gets the back-buffer this viewport is being rendered on, only effective when using back-buffering, see [method RenderingServer.canvas_item_set_copy_to_backbuffer].
+			</description>
+		</method>
+		<method name="get_screen_texture" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Gets the back-buffer this viewport is being rendered on.
+			</description>
+		</method>
+		<method name="is_using_linear_colors" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when this viewport is using linear colors instead of sRGB, use this to know when to use sRGB version of textures.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/RenderCanvasDataRD.xml
+++ b/doc/classes/RenderCanvasDataRD.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RenderCanvasDataRD" inherits="Object" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Render data object, holds canvas data related to rendering a single frame of a viewport.
+	</brief_description>
+	<description>
+		Canvas data object, exists for the duration of rendering a single viewport.
+		[b]Note:[/b] This is an internal rendering server object. Do not instantiate this class from a script.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_backbuffer_texture" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Gets the back-buffer this viewport is being rendered on, only effective when using back-buffering, see [method RenderingServer.canvas_item_set_copy_to_backbuffer].
+			</description>
+		</method>
+		<method name="get_screen_texture" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Gets the back-buffer this viewport is being rendered on.
+			</description>
+		</method>
+		<method name="is_using_linear_colors" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when this viewport is using linear colors instead of sRGB, use this to know when to use sRGB version of textures.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -376,6 +376,14 @@
 				Draws a rectangle on the [CanvasItem] pointed to by the [param item] [RID]. See also [method CanvasItem.draw_rect].
 			</description>
 		</method>
+		<method name="canvas_item_add_rendering_callback">
+			<return type="void" />
+			<param index="0" name="item" type="RID" />
+			<param index="1" name="callable" type="Callable" />
+			<description>
+				Adds an rendering callback draw command for the [CanvasItem]. See also [Compositor2D].
+			</description>
+		</method>
 		<method name="canvas_item_add_set_transform">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -385,6 +385,14 @@
 				Draws a rectangle on the [CanvasItem] pointed to by the [param item] [RID]. See also [method CanvasItem.draw_rect].
 			</description>
 		</method>
+		<method name="canvas_item_add_rendering_callback">
+			<return type="void" />
+			<param index="0" name="item" type="RID" />
+			<param index="1" name="callable" type="Callable" />
+			<description>
+				Adds an rendering callback draw command for the [CanvasItem]. See also [Compositor2D].
+			</description>
+		</method>
 		<method name="canvas_item_add_set_transform">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1280,6 +1280,10 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 
 				RenderingServerDefault::redraw_request(); // animation visible means redraw request
 			} break;
+
+			case Item::Command::TYPE_CALLBACK: {
+				// Not supported
+			} break;
 		}
 
 		c = c->next;
@@ -1540,7 +1544,8 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index, Ren
 		} break;
 		case Item::Command::TYPE_TRANSFORM:
 		case Item::Command::TYPE_CLIP_IGNORE:
-		case Item::Command::TYPE_ANIMATION_SLICE: {
+		case Item::Command::TYPE_ANIMATION_SLICE:
+		case Item::Command::TYPE_CALLBACK: {
 			// Can ignore these as they only impact batch creation.
 		} break;
 	}

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1278,6 +1278,10 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 
 				RenderingServerDefault::redraw_request(); // animation visible means redraw request
 			} break;
+
+			case Item::Command::TYPE_CALLBACK: {
+				// Not supported
+			} break;
 		}
 
 		c = c->next;
@@ -1538,7 +1542,8 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index, Ren
 		} break;
 		case Item::Command::TYPE_TRANSFORM:
 		case Item::Command::TYPE_CLIP_IGNORE:
-		case Item::Command::TYPE_ANIMATION_SLICE: {
+		case Item::Command::TYPE_ANIMATION_SLICE:
+		case Item::Command::TYPE_CALLBACK: {
 			// Can ignore these as they only impact batch creation.
 		} break;
 	}

--- a/scene/2d/compositor_2d.cpp
+++ b/scene/2d/compositor_2d.cpp
@@ -1,0 +1,66 @@
+/**************************************************************************/
+/*  compositor_2d.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "compositor_2d.h"
+
+void Compositor2D::_render_callback(RenderCanvasDataRD *p_data) {
+	GDVIRTUAL_CALL(_render_callback, p_data);
+}
+
+void Compositor2D::_notification(int p_what) {
+	if (p_what == NOTIFICATION_DRAW) {
+		RenderingServer::get_singleton()->canvas_item_add_rendering_callback(get_canvas_item(), callable_mp(this, &Compositor2D::_render_callback));
+	}
+}
+
+void Compositor2D::enable_backbuffer() {
+	RenderingServer::get_singleton()->canvas_item_set_copy_to_backbuffer(get_canvas_item(), true, Rect2());
+}
+
+void Compositor2D::disable_backbuffer() {
+	RenderingServer::get_singleton()->canvas_item_set_copy_to_backbuffer(get_canvas_item(), false, Rect2());
+}
+
+PackedStringArray Compositor2D::get_configuration_warnings() const {
+	PackedStringArray warnings = Node2D::get_configuration_warnings();
+
+	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility" || OS::get_singleton()->get_current_rendering_method() == "dummy") {
+		warnings.push_back(RTR("Compositor2D only works when using the Forward+ or Mobile renderer."));
+	}
+
+	return warnings;
+}
+
+void Compositor2D::_bind_methods() {
+	GDVIRTUAL_BIND(_render_callback, "render_data");
+
+	ClassDB::bind_method(D_METHOD("enable_backbuffer"), &Compositor2D::enable_backbuffer);
+	ClassDB::bind_method(D_METHOD("disable_backbuffer"), &Compositor2D::disable_backbuffer);
+}

--- a/scene/2d/compositor_2d.cpp
+++ b/scene/2d/compositor_2d.cpp
@@ -1,0 +1,71 @@
+/**************************************************************************/
+/*  compositor_2d.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "compositor_2d.h"
+
+#include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
+#include "core/os/os.h"
+#include "servers/rendering/rendering_server.h"
+
+void Compositor2D::_render_callback(RenderCanvasDataRD *p_data) {
+	GDVIRTUAL_CALL(_render_callback, p_data);
+}
+
+void Compositor2D::_notification(int p_what) {
+	if (p_what == NOTIFICATION_DRAW) {
+		RenderingServer::get_singleton()->canvas_item_add_rendering_callback(get_canvas_item(), callable_mp(this, &Compositor2D::_render_callback));
+	}
+}
+
+void Compositor2D::enable_backbuffer() {
+	RenderingServer::get_singleton()->canvas_item_set_copy_to_backbuffer(get_canvas_item(), true, Rect2());
+}
+
+void Compositor2D::disable_backbuffer() {
+	RenderingServer::get_singleton()->canvas_item_set_copy_to_backbuffer(get_canvas_item(), false, Rect2());
+}
+
+PackedStringArray Compositor2D::get_configuration_warnings() const {
+	PackedStringArray warnings = Node2D::get_configuration_warnings();
+
+	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility" || OS::get_singleton()->get_current_rendering_method() == "dummy") {
+		warnings.push_back(RTR("Compositor2D only works when using the Forward+ or Mobile renderer."));
+	}
+
+	return warnings;
+}
+
+void Compositor2D::_bind_methods() {
+	GDVIRTUAL_BIND(_render_callback, "render_data");
+
+	ClassDB::bind_method(D_METHOD("enable_backbuffer"), &Compositor2D::enable_backbuffer);
+	ClassDB::bind_method(D_METHOD("disable_backbuffer"), &Compositor2D::disable_backbuffer);
+}

--- a/scene/2d/compositor_2d.h
+++ b/scene/2d/compositor_2d.h
@@ -1,0 +1,54 @@
+/**************************************************************************/
+/*  compositor_2d.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/2d/node_2d.h"
+#include "servers/rendering/renderer_rd/storage_rd/render_canvas_data_rd.h"
+
+class Compositor2D : public Node2D {
+	GDCLASS(Compositor2D, Node2D);
+
+private:
+	void _render_callback(RenderCanvasDataRD *p_data);
+
+protected:
+	static void _bind_methods();
+
+	void _notification(int p_notification);
+
+	GDVIRTUAL1(_render_callback, RequiredParam<RenderCanvasDataRD>)
+
+public:
+	void enable_backbuffer();
+	void disable_backbuffer();
+
+	PackedStringArray get_configuration_warnings() const override;
+};

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -176,6 +176,7 @@
 #include "scene/2d/camera_2d.h"
 #include "scene/2d/canvas_group.h"
 #include "scene/2d/canvas_modulate.h"
+#include "scene/2d/compositor_2d.h"
 #include "scene/2d/cpu_particles_2d.h"
 #include "scene/2d/gpu_particles_2d.h"
 #include "scene/2d/light_2d.h"
@@ -935,6 +936,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(LightOccluder2D);
 	GDREGISTER_CLASS(OccluderPolygon2D);
 	GDREGISTER_CLASS(BackBufferCopy);
+	GDREGISTER_CLASS(Compositor2D);
 	GDREGISTER_CLASS(CanvasModulate);
 
 	OS::get_singleton()->yield(); // may take time to init

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -187,6 +187,7 @@
 #include "scene/2d/camera_2d.h"
 #include "scene/2d/canvas_group.h"
 #include "scene/2d/canvas_modulate.h"
+#include "scene/2d/compositor_2d.h"
 #include "scene/2d/cpu_particles_2d.h"
 #include "scene/2d/gpu_particles_2d.h"
 #include "scene/2d/light_2d.h"
@@ -849,6 +850,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(LightOccluder2D);
 	GDREGISTER_CLASS(OccluderPolygon2D);
 	GDREGISTER_CLASS(BackBufferCopy);
+	GDREGISTER_CLASS(Compositor2D);
 	GDREGISTER_CLASS(CanvasModulate);
 
 	OS::get_singleton()->yield(); // may take time to init

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -61,6 +61,7 @@
 #include "movie_writer/movie_writer.h"
 #include "movie_writer/movie_writer_pngwav.h"
 #include "rendering/renderer_rd/framebuffer_cache_rd.h"
+#include "rendering/renderer_rd/storage_rd/render_canvas_data_rd.h"
 #include "rendering/renderer_rd/storage_rd/render_data_rd.h"
 #include "rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h"
 #include "rendering/renderer_rd/storage_rd/render_scene_data_rd.h"
@@ -245,6 +246,8 @@ void register_server_types() {
 	GDREGISTER_ABSTRACT_CLASS(RenderSceneData);
 	GDREGISTER_CLASS(RenderSceneDataExtension);
 	GDREGISTER_CLASS(RenderSceneDataRD);
+
+	GDREGISTER_CLASS(RenderCanvasDataRD);
 
 	GDREGISTER_CLASS(RenderSceneBuffersConfiguration);
 	GDREGISTER_ABSTRACT_CLASS(RenderSceneBuffers);

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -64,6 +64,7 @@
 #include "servers/movie_writer/movie_writer_pngwav.h"
 #ifdef RD_ENABLED
 #include "servers/rendering/renderer_rd/framebuffer_cache_rd.h"
+#include "servers/rendering/renderer_rd/storage_rd/render_canvas_data_rd.h"
 #include "servers/rendering/renderer_rd/storage_rd/render_data_rd.h"
 #include "servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h"
 #include "servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h"
@@ -265,6 +266,8 @@ void register_server_types() {
 
 	GDREGISTER_CLASS(RenderDataRD);
 	GDREGISTER_CLASS(RenderSceneDataRD);
+
+	GDREGISTER_CLASS(RenderCanvasDataRD);
 
 	GDREGISTER_CLASS(RenderSceneBuffersRD);
 	GDREGISTER_CLASS(FramebufferCacheRD);

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1828,6 +1828,15 @@ void RendererCanvasCull::canvas_item_add_animation_slice(RID p_item, double p_an
 	as->offset = p_offset;
 }
 
+void RendererCanvasCull::canvas_item_add_rendering_callback(RID p_item, const Callable &p_callback) {
+	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
+	ERR_FAIL_NULL(canvas_item);
+
+	Item::CommandCallback *callback = canvas_item->alloc_command<Item::CommandCallback>();
+	ERR_FAIL_NULL(callback);
+	callback->callback = p_callback;
+}
+
 void RendererCanvasCull::canvas_item_set_sort_children_by_y(RID p_item, bool p_enable) {
 	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
 	ERR_FAIL_NULL(canvas_item);

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1871,6 +1871,15 @@ void RendererCanvasCull::canvas_item_add_animation_slice(RID p_item, double p_an
 	as->offset = p_offset;
 }
 
+void RendererCanvasCull::canvas_item_add_rendering_callback(RID p_item, const Callable &p_callback) {
+	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
+	ERR_FAIL_NULL(canvas_item);
+
+	Item::CommandCallback *callback = canvas_item->alloc_command<Item::CommandCallback>();
+	ERR_FAIL_NULL(callback);
+	callback->callback = p_callback;
+}
+
 void RendererCanvasCull::canvas_item_set_sort_children_by_y(RID p_item, bool p_enable) {
 	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
 	ERR_FAIL_NULL(canvas_item);

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -275,6 +275,7 @@ public:
 	void canvas_item_add_set_transform(RID p_item, const Transform2D &p_transform);
 	void canvas_item_add_clip_ignore(RID p_item, bool p_ignore);
 	void canvas_item_add_animation_slice(RID p_item, double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset);
+	void canvas_item_add_rendering_callback(RID p_item, const Callable &p_callback);
 
 	void canvas_item_set_sort_children_by_y(RID p_item, bool p_enable);
 	void canvas_item_set_z_index(RID p_item, int p_z);

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -279,6 +279,7 @@ public:
 	void canvas_item_add_set_transform(RID p_item, const Transform2D &p_transform);
 	void canvas_item_add_clip_ignore(RID p_item, bool p_ignore);
 	void canvas_item_add_animation_slice(RID p_item, double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset);
+	void canvas_item_add_rendering_callback(RID p_item, const Callable &p_callback);
 
 	void canvas_item_set_sort_children_by_y(RID p_item, bool p_enable);
 	void canvas_item_set_z_index(RID p_item, int p_z);

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -188,6 +188,7 @@ public:
 				TYPE_TRANSFORM,
 				TYPE_CLIP_IGNORE,
 				TYPE_ANIMATION_SLICE,
+				TYPE_CALLBACK
 			};
 
 			Command *next = nullptr;
@@ -302,6 +303,14 @@ public:
 
 			CommandAnimationSlice() {
 				type = TYPE_ANIMATION_SLICE;
+			}
+		};
+
+		struct CommandCallback : public Command {
+			Callable callback;
+			CommandCallback() {
+				type = TYPE_CALLBACK;
+				callback = Callable();
 			}
 		};
 

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -190,6 +190,7 @@ public:
 				TYPE_TRANSFORM,
 				TYPE_CLIP_IGNORE,
 				TYPE_ANIMATION_SLICE,
+				TYPE_CALLBACK
 			};
 
 			Command *next = nullptr;
@@ -304,6 +305,14 @@ public:
 
 			CommandAnimationSlice() {
 				type = TYPE_ANIMATION_SLICE;
+			}
+		};
+
+		struct CommandCallback : public Command {
+			Callable callback;
+			CommandCallback() {
+				type = TYPE_CALLBACK;
+				callback = Callable();
 			}
 		};
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -738,6 +738,10 @@ void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p
 
 	Item *ci = p_item_list;
 
+	RenderCanvasDataRD data;
+	data.use_linear_colors = use_linear_colors;
+	render_data = &data;
+
 	//fill the list until rendering is possible.
 	bool material_screen_texture_cached = false;
 	bool material_screen_texture_mipmaps_cached = false;
@@ -2301,9 +2305,44 @@ void RendererCanvasRenderRD::_render_batch_items(RenderTarget p_to_render_target
 
 	for (uint32_t i = 0; i <= state.current_batch_index; i++) {
 		Batch *current_batch = &state.canvas_instance_batches[i];
+
+		// Custom callback
+		if (current_batch->command_type == Item::Command::TYPE_CALLBACK) {
+			// Finish previous draw list as a custom one may be issued
+			if (draw_list != 0) {
+				RD::get_singleton()->draw_list_end();
+				draw_list = 0;
+			}
+
+			RID screen, backbuffer;
+			screen = texture_storage->render_target_get_rd_texture(p_to_render_target.render_target);
+			backbuffer = texture_storage->render_target_get_rd_backbuffer(p_to_render_target.render_target);
+			if (backbuffer.is_null()) { //unallocated backbuffer
+				backbuffer = RendererRD::TextureStorage::get_singleton()->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_WHITE);
+			}
+
+			render_data->screen = screen;
+			render_data->backbuffer = backbuffer;
+			render_data->use_linear_colors = p_to_render_target.use_linear_colors;
+
+			const Item::CommandCallback *cb = static_cast<const Item::CommandCallback *>(current_batch->command);
+			cb->callback.call(render_data);
+			continue;
+		}
+
 		// Skipping when there is no instances.
 		if (current_batch->instance_count == 0) {
 			continue;
+		}
+
+		// Create draw list
+		if (draw_list == 0) {
+			draw_list = RD::get_singleton()->draw_list_begin(framebuffer, RD::DRAW_DEFAULT_ALL);
+			RD::get_singleton()->draw_list_bind_uniform_set(draw_list, fb_uniform_set, BASE_UNIFORM_SET);
+			RD::get_singleton()->draw_list_bind_uniform_set(draw_list, state.default_transforms_uniform_set, TRANSFORMS_UNIFORM_SET);
+
+			current_clip = nullptr;
+			state.current_batch_uniform_set = RID();
 		}
 
 		//setup clip
@@ -2333,7 +2372,11 @@ void RendererCanvasRenderRD::_render_batch_items(RenderTarget p_to_render_target
 		_render_batch(draw_list, shader_data, fb_format, p_lights, current_batch, r_render_info);
 	}
 
-	RD::get_singleton()->draw_list_end();
+	// Finish previous draw list
+	if (draw_list != 0) {
+		RD::get_singleton()->draw_list_end();
+		draw_list = 0;
+	}
 
 	state.current_batch_index = 0;
 	state.canvas_instance_batches.clear();
@@ -2651,6 +2694,14 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 				instance_data->modulation[1] = color.g;
 				instance_data->modulation[2] = color.b;
 				instance_data->modulation[3] = color.a;
+			} break;
+
+			case Item::Command::TYPE_CALLBACK: {
+				// Callback rendering commands are unknown, always create a new batch
+				r_current_batch = _new_batch(r_batch_broken);
+				r_current_batch->command_type = Item::Command::TYPE_CALLBACK;
+				r_current_batch->command = c;
+				_add_to_batch(r_batch_broken, r_current_batch);
 			} break;
 
 			case Item::Command::TYPE_PRIMITIVE: {
@@ -3220,7 +3271,8 @@ void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasSha
 		} break;
 		case Item::Command::TYPE_TRANSFORM:
 		case Item::Command::TYPE_CLIP_IGNORE:
-		case Item::Command::TYPE_ANIMATION_SLICE: {
+		case Item::Command::TYPE_ANIMATION_SLICE:
+		case Item::Command::TYPE_CALLBACK: {
 			// Can ignore these as they only impact batch creation.
 		} break;
 	}
@@ -3289,7 +3341,8 @@ RendererCanvasRenderRD::Batch *RendererCanvasRenderRD::_new_batch(bool &r_batch_
 void RendererCanvasRenderRD::_add_to_batch(bool &r_batch_broken, Batch *&r_current_batch) {
 	DEV_ASSERT(r_current_batch->command_type == Item::Command::TYPE_RECT ||
 			r_current_batch->command_type == Item::Command::TYPE_NINEPATCH ||
-			r_current_batch->command_type == Item::Command::TYPE_PRIMITIVE);
+			r_current_batch->command_type == Item::Command::TYPE_PRIMITIVE ||
+			r_current_batch->command_type == Item::Command::TYPE_CALLBACK);
 	r_current_batch->instance_count++;
 	memcpy(&state.instance_data[state.instance_data_index], &state.intermediary_instance_data, sizeof(InstanceData));
 	state.instance_data_index++;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -739,6 +739,10 @@ void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p
 
 	Item *ci = p_item_list;
 
+	RenderCanvasDataRD data;
+	data.use_linear_colors = use_linear_colors;
+	render_data = &data;
+
 	//fill the list until rendering is possible.
 	bool material_screen_texture_cached = false;
 	bool material_screen_texture_mipmaps_cached = false;
@@ -2303,9 +2307,44 @@ void RendererCanvasRenderRD::_render_batch_items(RenderTarget p_to_render_target
 
 	for (uint32_t i = 0; i <= state.current_batch_index; i++) {
 		Batch *current_batch = &state.canvas_instance_batches[i];
+
+		// Custom callback
+		if (current_batch->command_type == Item::Command::TYPE_CALLBACK) {
+			// Finish previous draw list as a custom one may be issued
+			if (draw_list != 0) {
+				RD::get_singleton()->draw_list_end();
+				draw_list = 0;
+			}
+
+			RID screen, backbuffer;
+			screen = texture_storage->render_target_get_rd_texture(p_to_render_target.render_target);
+			backbuffer = texture_storage->render_target_get_rd_backbuffer(p_to_render_target.render_target);
+			if (backbuffer.is_null()) { //unallocated backbuffer
+				backbuffer = RendererRD::TextureStorage::get_singleton()->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_WHITE);
+			}
+
+			render_data->screen = screen;
+			render_data->backbuffer = backbuffer;
+			render_data->use_linear_colors = p_to_render_target.use_linear_colors;
+
+			const Item::CommandCallback *cb = static_cast<const Item::CommandCallback *>(current_batch->command);
+			cb->callback.call(render_data);
+			continue;
+		}
+
 		// Skipping when there is no instances.
 		if (current_batch->instance_count == 0) {
 			continue;
+		}
+
+		// Create draw list
+		if (draw_list == 0) {
+			draw_list = RD::get_singleton()->draw_list_begin(framebuffer, RD::DRAW_DEFAULT_ALL);
+			RD::get_singleton()->draw_list_bind_uniform_set(draw_list, fb_uniform_set, BASE_UNIFORM_SET);
+			RD::get_singleton()->draw_list_bind_uniform_set(draw_list, state.default_transforms_uniform_set, TRANSFORMS_UNIFORM_SET);
+
+			current_clip = nullptr;
+			state.current_batch_uniform_set = RID();
 		}
 
 		//setup clip
@@ -2335,7 +2374,11 @@ void RendererCanvasRenderRD::_render_batch_items(RenderTarget p_to_render_target
 		_render_batch(draw_list, shader_data, fb_format, p_lights, current_batch, r_render_info);
 	}
 
-	RD::get_singleton()->draw_list_end();
+	// Finish previous draw list
+	if (draw_list != 0) {
+		RD::get_singleton()->draw_list_end();
+		draw_list = 0;
+	}
 
 	state.current_batch_index = 0;
 	state.canvas_instance_batches.clear();
@@ -2653,6 +2696,14 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 				instance_data->modulation[1] = color.g;
 				instance_data->modulation[2] = color.b;
 				instance_data->modulation[3] = color.a;
+			} break;
+
+			case Item::Command::TYPE_CALLBACK: {
+				// Callback rendering commands are unknown, always create a new batch
+				r_current_batch = _new_batch(r_batch_broken);
+				r_current_batch->command_type = Item::Command::TYPE_CALLBACK;
+				r_current_batch->command = c;
+				_add_to_batch(r_batch_broken, r_current_batch);
 			} break;
 
 			case Item::Command::TYPE_PRIMITIVE: {
@@ -3222,7 +3273,8 @@ void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasSha
 		} break;
 		case Item::Command::TYPE_TRANSFORM:
 		case Item::Command::TYPE_CLIP_IGNORE:
-		case Item::Command::TYPE_ANIMATION_SLICE: {
+		case Item::Command::TYPE_ANIMATION_SLICE:
+		case Item::Command::TYPE_CALLBACK: {
 			// Can ignore these as they only impact batch creation.
 		} break;
 	}
@@ -3291,7 +3343,8 @@ RendererCanvasRenderRD::Batch *RendererCanvasRenderRD::_new_batch(bool &r_batch_
 void RendererCanvasRenderRD::_add_to_batch(bool &r_batch_broken, Batch *&r_current_batch) {
 	DEV_ASSERT(r_current_batch->command_type == Item::Command::TYPE_RECT ||
 			r_current_batch->command_type == Item::Command::TYPE_NINEPATCH ||
-			r_current_batch->command_type == Item::Command::TYPE_PRIMITIVE);
+			r_current_batch->command_type == Item::Command::TYPE_PRIMITIVE ||
+			r_current_batch->command_type == Item::Command::TYPE_CALLBACK);
 	r_current_batch->instance_count++;
 	memcpy(&state.instance_data[state.instance_data_index], &state.intermediary_instance_data, sizeof(InstanceData));
 	state.instance_data_index++;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -37,6 +37,7 @@
 #include "servers/rendering/renderer_rd/shaders/canvas.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/canvas_occlusion.glsl.gen.h"
 #include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
+#include "servers/rendering/renderer_rd/storage_rd/render_canvas_data_rd.h"
 #include "servers/rendering/rendering_device.h"
 #include "servers/rendering/shader_compiler.h"
 
@@ -644,6 +645,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 	} state;
 
 	Item *items[MAX_RENDER_ITEMS];
+	RenderCanvasDataRD *render_data = nullptr;
 
 	TextureInfo default_texture_info;
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -37,6 +37,7 @@
 #include "servers/rendering/renderer_rd/shaders/canvas.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/canvas_occlusion.glsl.gen.h"
 #include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
+#include "servers/rendering/renderer_rd/storage_rd/render_canvas_data_rd.h"
 #include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server_types.h"
 #include "servers/rendering/shader_compiler.h"
@@ -645,6 +646,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 	} state;
 
 	Item *items[MAX_RENDER_ITEMS];
+	RenderCanvasDataRD *render_data = nullptr;
 
 	TextureInfo default_texture_info;
 

--- a/servers/rendering/renderer_rd/storage_rd/render_canvas_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_canvas_data_rd.cpp
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  render_canvas_data_rd.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "render_canvas_data_rd.h"
+#include "servers/rendering/renderer_rd/renderer_canvas_render_rd.h"
+
+RID RenderCanvasDataRD::get_screen_texture() const {
+	return screen;
+}
+
+RID RenderCanvasDataRD::get_backbuffer_texture() const {
+	return backbuffer;
+}
+
+bool RenderCanvasDataRD::is_using_linear_colors() const {
+	return use_linear_colors;
+}
+
+void RenderCanvasDataRD::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_screen_texture"), &RenderCanvasDataRD::get_screen_texture);
+	ClassDB::bind_method(D_METHOD("get_backbuffer_texture"), &RenderCanvasDataRD::get_backbuffer_texture);
+	ClassDB::bind_method(D_METHOD("is_using_linear_colors"), &RenderCanvasDataRD::is_using_linear_colors);
+}

--- a/servers/rendering/renderer_rd/storage_rd/render_canvas_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_canvas_data_rd.cpp
@@ -1,0 +1,52 @@
+/**************************************************************************/
+/*  render_canvas_data_rd.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "render_canvas_data_rd.h"
+
+#include "core/object/class_db.h"
+#include "servers/rendering/renderer_rd/renderer_canvas_render_rd.h"
+
+RID RenderCanvasDataRD::get_screen_texture() const {
+	return screen;
+}
+
+RID RenderCanvasDataRD::get_backbuffer_texture() const {
+	return backbuffer;
+}
+
+bool RenderCanvasDataRD::is_using_linear_colors() const {
+	return use_linear_colors;
+}
+
+void RenderCanvasDataRD::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_screen_texture"), &RenderCanvasDataRD::get_screen_texture);
+	ClassDB::bind_method(D_METHOD("get_backbuffer_texture"), &RenderCanvasDataRD::get_backbuffer_texture);
+	ClassDB::bind_method(D_METHOD("is_using_linear_colors"), &RenderCanvasDataRD::is_using_linear_colors);
+}

--- a/servers/rendering/renderer_rd/storage_rd/render_canvas_data_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_canvas_data_rd.h
@@ -1,0 +1,54 @@
+/**************************************************************************/
+/*  render_canvas_data_rd.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/object.h"
+#include "core/templates/rid.h"
+
+class RendererCanvasRenderRD;
+
+class RenderCanvasDataRD : public Object {
+	GDCLASS(RenderCanvasDataRD, Object);
+
+	friend class RendererCanvasRenderRD;
+
+	RID screen;
+	RID backbuffer;
+	bool use_linear_colors;
+
+protected:
+	static void _bind_methods();
+
+public:
+	RID get_screen_texture() const;
+	RID get_backbuffer_texture() const;
+	bool is_using_linear_colors() const;
+};

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3397,6 +3397,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_add_set_transform", "item", "transform"), &RenderingServer::canvas_item_add_set_transform);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_clip_ignore", "item", "ignore"), &RenderingServer::canvas_item_add_clip_ignore);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_animation_slice", "item", "animation_length", "slice_begin", "slice_end", "offset"), &RenderingServer::canvas_item_add_animation_slice, DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("canvas_item_add_rendering_callback", "item", "callable"), &RenderingServer::canvas_item_add_rendering_callback);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_sort_children_by_y", "item", "enabled"), &RenderingServer::canvas_item_set_sort_children_by_y);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_z_index", "item", "z_index"), &RenderingServer::canvas_item_set_z_index);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_z_as_relative_to_parent", "item", "enabled"), &RenderingServer::canvas_item_set_z_as_relative_to_parent);

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3363,6 +3363,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_add_set_transform", "item", "transform"), &RenderingServer::canvas_item_add_set_transform);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_clip_ignore", "item", "ignore"), &RenderingServer::canvas_item_add_clip_ignore);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_animation_slice", "item", "animation_length", "slice_begin", "slice_end", "offset"), &RenderingServer::canvas_item_add_animation_slice, DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("canvas_item_add_rendering_callback", "item", "callable"), &RenderingServer::canvas_item_add_rendering_callback);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_sort_children_by_y", "item", "enabled"), &RenderingServer::canvas_item_set_sort_children_by_y);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_z_index", "item", "z_index"), &RenderingServer::canvas_item_set_z_index);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_z_as_relative_to_parent", "item", "enabled"), &RenderingServer::canvas_item_set_z_as_relative_to_parent);

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -1623,6 +1623,7 @@ public:
 	virtual void canvas_item_add_set_transform(RID p_item, const Transform2D &p_transform) = 0;
 	virtual void canvas_item_add_clip_ignore(RID p_item, bool p_ignore) = 0;
 	virtual void canvas_item_add_animation_slice(RID p_item, double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset) = 0;
+	virtual void canvas_item_add_rendering_callback(RID p_item, const Callable &p_callback) = 0;
 
 	virtual void canvas_item_set_sort_children_by_y(RID p_item, bool p_enable) = 0;
 	virtual void canvas_item_set_z_index(RID p_item, int p_z) = 0;

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -851,6 +851,7 @@ public:
 	virtual void canvas_item_add_set_transform(RID p_item, const Transform2D &p_transform) = 0;
 	virtual void canvas_item_add_clip_ignore(RID p_item, bool p_ignore) = 0;
 	virtual void canvas_item_add_animation_slice(RID p_item, double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset) = 0;
+	virtual void canvas_item_add_rendering_callback(RID p_item, const Callable &p_callback) = 0;
 
 	virtual void canvas_item_set_sort_children_by_y(RID p_item, bool p_enable) = 0;
 	virtual void canvas_item_set_z_index(RID p_item, int p_z) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -1033,6 +1033,7 @@ public:
 	FUNC2(canvas_item_add_set_transform, RID, const Transform2D &)
 	FUNC2(canvas_item_add_clip_ignore, RID, bool)
 	FUNC5(canvas_item_add_animation_slice, RID, double, double, double, double)
+	FUNC2(canvas_item_add_rendering_callback, RID, const Callable &)
 
 	FUNC2(canvas_item_set_sort_children_by_y, RID, bool)
 	FUNC2(canvas_item_set_z_index, RID, int)

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -1054,6 +1054,7 @@ public:
 	FUNC2(canvas_item_add_set_transform, RID, const Transform2D &)
 	FUNC2(canvas_item_add_clip_ignore, RID, bool)
 	FUNC5(canvas_item_add_animation_slice, RID, double, double, double, double)
+	FUNC2(canvas_item_add_rendering_callback, RID, const Callable &)
 
 	FUNC2(canvas_item_set_sort_children_by_y, RID, bool)
 	FUNC2(canvas_item_set_z_index, RID, int)


### PR DESCRIPTION
- Closes godotengine/godot-proposals#14092

This PR implements rendering hooks like the [Compositor](https://docs.godotengine.org/en/stable/tutorials/rendering/compositor.html) in 2D, as the Compositor feature only supports 3D.

For this, a new draw command is added to the CanvasItem rendering, used by calling:
- `CanvasItem::draw_add_callback(callback: Callable)`, inside `_draw` or `NOTIFICATION_DRAW` events;
- `RenderingServer::canvas_item_add_callback(item: RID, callback: Callable)`, for direct access using RenderingServer.

When this command is used, it always create a new batch (as the actual drawing commands is unknown, it's better to always break current batch).

With this, a batch with a single command of the custom callback is created, which is simply handled and calls the passed callback with extra data (created RenderCanvasDataRD class for passing some parameters).

From there, the callback works as similar to the Compositor callbacks, it's called in a deterministic order, in the same order as the CanvasItem in the hierarchy tree.

This feature has potential to be more customizable than Compositor in 3D, as you can insert any CanvasItem in any part of the tree and create the callback. So it's not limited to a particular rendering stage (sky, transparent, opaque, etc. in 3D).

While this can be used for more advanced post-process effects, it can also be used for even more advanced drawing features, like multiple shaders in the same CanvasItem, scissoring and compute shaders.

Here's some prints of the minimal project demonstrating the feature, notice how some nodes were unaffected by the shader used in the callback, which are the nodes which are drawn after the effect:
<img width="1366" height="728" alt="image" src="https://github.com/user-attachments/assets/3377de24-2b17-4f48-a8d1-3b5b0b372479" />
<img width="1366" height="728" alt="image" src="https://github.com/user-attachments/assets/6da2eb4c-7173-4bc0-beea-c194376c2667" />
<img width="1111" height="625" alt="image" src="https://github.com/user-attachments/assets/7a6af96a-7685-4015-a48a-248abe111054" />

Some acknowledgements:
1. Similar to the Compositor, it's only supported on Forward+ and Mobile rendering backends, as it uses direct access to the RenderingDevice;
2. As granular this feature can be, it's advisable to use it with as few instances as possible, with the same performance concerns as the Compositor.

Some points that needs improving that I'm working on:
- [X] (~The call to `RendererCanvasRenderRD::_render_batch_items` can contain multiple items which currently (master branch) uses a single draw list for all of then, the callback may need to create another draw list, so for now I simply track the current draw list ID, if a `TYPE_CALLBACK` command is handled, it ends the current draw list, for other draw commands it creates a new draw list if there is none active~) For now I think it's the best option, it doesn't seem to impact performance if not using callback commands;
- [X] (~Currently, I'm passing a Dictionary with the rendering data, for now it's only the screen framebuffer and screen texture (handling backbuffering), but I would like to make it a separate class like RenderData~) Partially done, created RenderCanvasDataRD class, only having screen and backbuffer textures, and a flag to check if the viewport uses linear colors;
- [x] (~Needs to improve screen texture resolving, as if I don't enable back buffering in the CanvasItem, it resolves to a black texture~) Done, needed to indicate that the Item uses screen texture, while needing to explicitly enable back-buffering, having similar behaviour to other CanvasItem's nodes. 

Minimal project used for initial tests of the feature:
[render-compositor-2d.zip](https://github.com/user-attachments/files/25524721/render-compositor-2d.zip)

More tests are being made on ghsoares/Godot-RmlUi#8