### PR TITLE
Update `XRCamera3D` docs to clarify what it provides and overrides

### DIFF
--- a/doc/classes/XRCamera3D.xml
+++ b/doc/classes/XRCamera3D.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="XRCamera3D" inherits="Camera3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A camera node with a few overrules for AR/VR applied, such as location tracking.
+		A camera node which automatically positions itself based on XR tracking data.
 	</brief_description>
 	<description>
-		This is a helper 3D node for our camera. Note that, if stereoscopic rendering is applicable (VR-HMD), most of the camera properties are ignored, as the HMD information overrides them. The only properties that can be trusted are the near and far planes.
-		The position and orientation of this node is automatically updated by the XR Server to represent the location of the HMD if such tracking is available and can thus be used by game logic. Note that, in contrast to the XR Controller, the render thread has access to the most up-to-date tracking data of the HMD and the location of the XRCamera3D can lag a few milliseconds behind what is used for rendering as a result.
+		A camera node which automatically positions itself based on XR tracking data.
+		In contrast to [XRController3D], the render thread has access to more up-to-date tracking data, and the location of the [XRCamera3D] node can lag a few milliseconds behind what is used for rendering.
+		[b]Note:[/b] If [member Viewport.use_xr] is [code]true[/code], most of the camera properties are overridden by the active [XRInterface]. The only properties that can be trusted are the near and far planes.
 	</description>
 	<tutorials>
 		<link title="XR documentation index">$DOCS_URL/tutorials/xr/index.html</link>


### PR DESCRIPTION
This attempts to resolve the confusion on https://github.com/godotengine/godot/issues/114013 by making it clear that all `XRCamera3D` provides on top of `Camera3D`, is that it will automatically position the camera based on XR tracking data.

There was already some information about what properties are overridden/ignored and some of the limitations, but this PR also attempts to clean that up a little bit as well.

Fixes https://github.com/godotengine/godot/issues/114013