### PR TITLE
Fix CSV translation files not reimporting when changed

### DIFF
--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -260,5 +260,10 @@ Error ResourceImporterCSVTranslation::import(ResourceUID::ID p_source_id, const 
 		}
 	}
 
+	if (r_metadata) {
+		// Store the MD5 hash of the source file to allow the editor to detect changes and trigger reimports.
+		*r_metadata = FileAccess::get_md5(p_source_file);
+	}
+
 	return OK;
 }


### PR DESCRIPTION
Fixes #115486.

## Issue
CSV translation files were not reimported after being modified externally. Changes in translations were only reflected after a manual reimport or an editor restart.

## Cause
The CSV translation importer was not assigning an MD5 hash to the metadata. The EditorFileSystem relies on this hash to detect if a source file's content has changed.

## Solution
Added MD5 hash calculation to the importer logic in resource_importer_csv_translation.cpp. This allows the engine to correctly identify modifications and trigger an automatic reimport.

## How to test
1. Create or import a .csv file with translations.
2. Select one of the generated .translation files and observe its content in the Inspector.
3. Open the .csv file in an external editor.
4. Change a translation value and save the file.
5. Return to Godot. The Inspector should now automatically update to show the new value without any manual intervention.