### PR TITLE
Fix wrong size on `Container` nodes due to late cache update

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -3938,17 +3938,14 @@ void EditorInspector::update_tree() {
 	bool sub_inspectors_enabled = EDITOR_GET("interface/inspector/open_resources_in_current_inspector");
 
 	if (!valid_plugins.is_empty()) {
-		// Show early to avoid sizing problems.
-		begin_vbox->show();
-
 		for (Ref<EditorInspectorPlugin> &ped : valid_plugins) {
 			ped->parse_begin(object);
 			_parse_added_editors(begin_vbox, nullptr, ped);
 		}
 
-		// Hide it again if no editors were added to the beginning.
-		if (begin_vbox->get_child_count() == 0) {
-			begin_vbox->hide();
+		// Show if any of the editors were added to the beginning.
+		if (begin_vbox->get_child_count() > 0) {
+			begin_vbox->show();
 		}
 	}
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1659,10 +1659,11 @@ void Control::_update_minimum_size() {
 		return;
 	}
 
+	bool was_invalid = !data.minimum_size_valid;
 	Size2 minsize = get_combined_minimum_size();
 	data.updating_last_minimum_size = false;
 
-	if (minsize != data.last_minimum_size) {
+	if (was_invalid || minsize != data.last_minimum_size) {
 		data.last_minimum_size = minsize;
 		_size_changed();
 		emit_signal(SceneStringName(minimum_size_changed));


### PR DESCRIPTION
Fixes #109497.

Partially reverses #115041, as this was also the root cause.