### PR TITLE
Add project settings for separate/vertical JoyCons

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1838,6 +1838,8 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("collada/use_ambient", false);
 
 	// Input settings
+	GLOBAL_DEF("input_devices/joypads/treat_joycons_as_separate_joypads", false);
+	GLOBAL_DEF("input_devices/joypads/treat_joycons_as_held_vertically", false);
 	GLOBAL_DEF_BASIC("input_devices/pointing/android/enable_long_press_as_right_click", false);
 	GLOBAL_DEF_BASIC("input_devices/pointing/android/enable_pan_and_scale_gestures", false);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "input_devices/pointing/android/rotary_input_scroll_axis", PROPERTY_HINT_ENUM, "Horizontal,Vertical"), 1);

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -154,6 +154,10 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("start_joy_vibration", "device", "weak_magnitude", "strong_magnitude", "duration"), &Input::start_joy_vibration, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("stop_joy_vibration", "device"), &Input::stop_joy_vibration);
 	ClassDB::bind_method(D_METHOD("vibrate_handheld", "duration_ms", "amplitude"), &Input::vibrate_handheld, DEFVAL(500), DEFVAL(-1.0));
+	ClassDB::bind_method(D_METHOD("set_joycons_separate", "enable"), &Input::set_joycons_separate);
+	ClassDB::bind_method(D_METHOD("is_joycons_separate"), &Input::is_joycons_separate);
+	ClassDB::bind_method(D_METHOD("set_joycons_vertical", "enable"), &Input::set_joycons_vertical);
+	ClassDB::bind_method(D_METHOD("is_joycons_vertical"), &Input::is_joycons_vertical);
 	ClassDB::bind_method(D_METHOD("get_gravity"), &Input::get_gravity);
 	ClassDB::bind_method(D_METHOD("get_accelerometer"), &Input::get_accelerometer);
 	ClassDB::bind_method(D_METHOD("get_magnetometer"), &Input::get_magnetometer);
@@ -202,6 +206,8 @@ void Input::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_accumulated_input"), "set_use_accumulated_input", "is_using_accumulated_input");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emulate_mouse_from_touch"), "set_emulate_mouse_from_touch", "is_emulating_mouse_from_touch");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emulate_touch_from_mouse"), "set_emulate_touch_from_mouse", "is_emulating_touch_from_mouse");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "joycons_separate"), "set_joycons_separate", "is_joycons_separate");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "joycons_vertical"), "set_joycons_vertical", "is_joycons_vertical");
 
 	BIND_ENUM_CONSTANT(MOUSE_MODE_VISIBLE);
 	BIND_ENUM_CONSTANT(MOUSE_MODE_HIDDEN);
@@ -369,6 +375,11 @@ bool Input::is_mouse_button_pressed(MouseButton p_button) const {
 	}
 
 	return mouse_button_mask.has_flag(mouse_button_to_mask(p_button));
+}
+
+void Input::_project_settings_changed() {
+	joycons_separate = GLOBAL_GET("input_devices/joypads/treat_joycons_as_separate_joypads");
+	joycons_vertical = GLOBAL_GET("input_devices/joypads/treat_joycons_as_held_vertically");
 }
 
 static JoyAxis _combine_device(JoyAxis p_value, int p_device) {
@@ -1253,6 +1264,22 @@ void Input::stop_joy_vibration(int p_device) {
 
 void Input::vibrate_handheld(int p_duration_ms, float p_amplitude) {
 	OS::get_singleton()->vibrate_handheld(p_duration_ms, p_amplitude);
+}
+
+void Input::set_joycons_separate(bool p_enable) {
+	joycons_separate = p_enable;
+}
+
+bool Input::is_joycons_separate() const {
+	return joycons_separate;
+}
+
+void Input::set_joycons_vertical(bool p_enable) {
+	joycons_vertical = p_enable;
+}
+
+bool Input::is_joycons_vertical() const {
+	return joycons_vertical;
 }
 
 void Input::set_gravity(const Vector3 &p_gravity) {
@@ -2240,6 +2267,8 @@ Input::Input() {
 	gravity_enabled = GLOBAL_DEF_RST_BASIC("input_devices/sensors/enable_gravity", false);
 	gyroscope_enabled = GLOBAL_DEF_RST_BASIC("input_devices/sensors/enable_gyroscope", false);
 	magnetometer_enabled = GLOBAL_DEF_RST_BASIC("input_devices/sensors/enable_magnetometer", false);
+
+	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Input::_project_settings_changed));
 }
 
 Input::~Input() {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -123,6 +123,8 @@ private:
 	int64_t mouse_window = 0;
 	bool legacy_just_pressed_behavior = false;
 	bool disable_input = false;
+	bool joycons_separate = false;
+	bool joycons_vertical = false;
 
 	struct ActionState {
 		uint64_t pressed_physics_frame = UINT64_MAX;
@@ -317,6 +319,8 @@ private:
 
 	EventDispatchFunc event_dispatch_function = nullptr;
 
+	void _project_settings_changed();
+
 #ifndef DISABLE_DEPRECATED
 	void _vibrate_handheld_bind_compat_91143(int p_duration_ms = 500);
 	static void _bind_compatibility_methods();
@@ -416,6 +420,12 @@ public:
 	void start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration = 0);
 	void stop_joy_vibration(int p_device);
 	void vibrate_handheld(int p_duration_ms = 500, float p_amplitude = -1.0);
+
+	void set_joycons_separate(bool p_enable);
+	bool is_joycons_separate() const;
+
+	void set_joycons_vertical(bool p_enable);
+	bool is_joycons_vertical() const;
 
 	void set_mouse_position(const Point2 &p_posf);
 

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -718,6 +718,14 @@
 		<member name="emulate_touch_from_mouse" type="bool" setter="set_emulate_touch_from_mouse" getter="is_emulating_touch_from_mouse">
 			If [code]true[/code], sends touch input events when clicking or dragging the mouse. See also [member ProjectSettings.input_devices/pointing/emulate_touch_from_mouse].
 		</member>
+		<member name="joycons_separate" type="bool" setter="set_joycons_separate" getter="is_joycons_separate">
+			If [code]true[/code], each JoyCon pair will be treated as 2 separate joypads.
+			[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
+		</member>
+		<member name="joycons_vertical" type="bool" setter="set_joycons_vertical" getter="is_joycons_vertical">
+			If [code]true[/code], separate JoyCons will have their natural button layout as if they were held vertically instead of horizontally.
+			[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
+		</member>
 		<member name="mouse_mode" type="int" setter="set_mouse_mode" getter="get_mouse_mode" enum="Input.MouseMode">
 			Controls the mouse mode.
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1657,6 +1657,14 @@
 			If [code]false[/code], no input will be lost.
 			[b]Note:[/b] You should in nearly all cases prefer the [code]false[/code] setting. The legacy behavior is to enable supporting old projects that rely on the old logic, without changes to script.
 		</member>
+		<member name="input_devices/joypads/treat_joycons_as_held_vertically" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], separate JoyCons will have their natural button layout as if they were held vertically instead of horizontally.
+			[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
+		</member>
+		<member name="input_devices/joypads/treat_joycons_as_separate_joypads" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], each JoyCon pair will be treated as 2 separate joypads.
+			[b]Note:[/b] This feature is only supported on Windows, Linux, and macOS.
+		</member>
 		<member name="input_devices/pen_tablet/driver" type="String" setter="" getter="">
 			Specifies the tablet driver to use. If left empty, the default driver will be used.
 			[b]Note:[/b] The driver in use can be overridden at runtime via the [code]--tablet-driver[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url].

--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -32,6 +32,7 @@
 
 #ifdef SDL_ENABLED
 
+#include "core/config/project_settings.h"
 #include "core/input/default_controller_mappings.h"
 #include "core/os/time.h"
 #include "core/variant/dictionary.h"
@@ -64,6 +65,17 @@ JoypadSDL::~JoypadSDL() {
 Error JoypadSDL::initialize() {
 	SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
 	SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
+
+	if (GLOBAL_GET("input_devices/joypads/treat_joycons_as_separate_joypads")) {
+		SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_COMBINE_JOY_CONS, "0");
+		joycons_separate = true;
+	}
+
+	if (GLOBAL_GET("input_devices/joypads/treat_joycons_as_held_vertically")) {
+		SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_VERTICAL_JOY_CONS, "1");
+		joycons_vertical = true;
+	}
+
 	ERR_FAIL_COND_V_MSG(!SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_GAMEPAD), FAILED, SDL_GetError());
 
 	// Add Godot's mapping database from memory
@@ -118,98 +130,13 @@ void JoypadSDL::process_events() {
 	while (SDL_PollEvent(&sdl_event)) {
 		// A new joypad was attached
 		if (sdl_event.type == SDL_EVENT_JOYSTICK_ADDED) {
-			int joy_id = Input::get_singleton()->get_unused_joy_id();
-			if (joy_id == -1) {
-				// There is no space for more joypads...
-				print_error("A new joypad was attached but couldn't allocate a new id for it because joypad limit was reached.");
-			} else {
-				SDL_Joystick *joy = nullptr;
-				SDL_Gamepad *gamepad = nullptr;
-				String device_name;
-
-				// Gamepads must be opened with SDL_OpenGamepad to get their special remapped events
-				if (SDL_IsGamepad(sdl_event.jdevice.which)) {
-					gamepad = SDL_OpenGamepad(sdl_event.jdevice.which);
-
-					ERR_CONTINUE_MSG(!gamepad,
-							vformat("Error opening gamepad at index %d: %s", sdl_event.jdevice.which, SDL_GetError()));
-
-					device_name = SDL_GetGamepadName(gamepad);
-					joy = SDL_GetGamepadJoystick(gamepad);
-
-					print_verbose(vformat("SDL: Gamepad %s connected", SDL_GetGamepadName(gamepad)));
-				} else {
-					joy = SDL_OpenJoystick(sdl_event.jdevice.which);
-					ERR_CONTINUE_MSG(!joy,
-							vformat("Error opening joystick at index %d: %s", sdl_event.jdevice.which, SDL_GetError()));
-
-					device_name = SDL_GetJoystickName(joy);
-
-					print_verbose(vformat("SDL: Joystick %s connected", SDL_GetJoystickName(joy)));
-				}
-
-				const int MAX_GUID_SIZE = 64;
-				char guid[MAX_GUID_SIZE] = {};
-				SDL_GUID joy_guid = SDL_GetJoystickGUID(joy);
-				SDL_GUIDToString(joy_guid, guid, MAX_GUID_SIZE);
-				SDL_PropertiesID propertiesID = SDL_GetJoystickProperties(joy);
-
-				joypads[joy_id].attached = true;
-				joypads[joy_id].sdl_instance_idx = sdl_event.jdevice.which;
-				joypads[joy_id].supports_force_feedback = SDL_GetBooleanProperty(propertiesID, SDL_PROP_JOYSTICK_CAP_RUMBLE_BOOLEAN, false);
-				joypads[joy_id].guid = StringName(String(guid));
-				joypads[joy_id].supports_motion_sensors = SDL_GamepadHasSensor(gamepad, SDL_SENSOR_ACCEL) || SDL_GamepadHasSensor(gamepad, SDL_SENSOR_GYRO);
-
-				sdl_instance_id_to_joypad_id.insert(sdl_event.jdevice.which, joy_id);
-
-				Dictionary joypad_info;
-				// Skip Godot's mapping system if SDL already handles the joypad's mapping.
-				joypad_info["mapping_handled"] = SDL_IsGamepad(sdl_event.jdevice.which);
-				joypad_info["raw_name"] = String::utf8(SDL_GetJoystickName(joy));
-				joypad_info["vendor_id"] = itos(SDL_GetJoystickVendor(joy));
-				joypad_info["product_id"] = itos(SDL_GetJoystickProduct(joy));
-
-				const String serial = String(SDL_GetJoystickSerial(joy));
-				if (!serial.is_empty()) {
-					joypad_info["serial_number"] = serial;
-				}
-
-#if defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED) || defined(MACOS_ENABLED)
-				const uint64_t steam_handle = SDL_GetGamepadSteamHandle(gamepad);
-				if (steam_handle != 0) {
-					joypad_info["steam_input_index"] = itos(steam_handle);
-				}
-#endif
-
-#ifdef WINDOWS_ENABLED
-				const int player_index = SDL_GetJoystickPlayerIndex(joy);
-				if (player_index >= 0 && joy_guid.data[14] == 'x') { // See also "SDL_IsJoystickXInput" in "thirdparty/sdl/joystick/SDL_joystick.c".
-					// For XInput controllers SDL_GetJoystickPlayerIndex returns the XInput user index.
-					joypad_info["xinput_index"] = itos(player_index);
-				}
-#endif
-
-				Input::get_singleton()->joy_connection_changed(
-						joy_id,
-						true,
-						device_name,
-						joypads[joy_id].guid,
-						joypad_info);
-
-				Input::get_singleton()->set_joy_features(joy_id, &joypads[joy_id]);
-
-				if (joypads[joy_id].supports_motion_sensors) {
-					// Data rate for all sensors should be the same.
-					Input::get_singleton()->set_joy_motion_sensors_rate(joy_id, SDL_GetGamepadSensorDataRate(gamepad, SDL_SENSOR_ACCEL));
-				}
-			}
-			// An event for an attached joypad
+			open_joypad(sdl_event.jdevice.which);
 		} else if (sdl_event.type >= SDL_EVENT_JOYSTICK_AXIS_MOTION && sdl_event.type < SDL_EVENT_FINGER_DOWN && sdl_instance_id_to_joypad_id.has(sdl_event.jdevice.which)) {
+			// An event for an attached joypad
 			int joy_id = sdl_instance_id_to_joypad_id.get(sdl_event.jdevice.which);
 
 			switch (sdl_event.type) {
 				case SDL_EVENT_JOYSTICK_REMOVED:
-					Input::get_singleton()->joy_connection_changed(joy_id, false, "");
 					close_joypad(joy_id);
 					break;
 
@@ -295,13 +222,115 @@ void JoypadSDL::process_events() {
 				Vector3(-accel_data[0], -accel_data[1], -accel_data[2]),
 				Vector3(gyro_data[0], gyro_data[1], gyro_data[2]));
 	}
+
+	if (joycons_count > 0) {
+		check_joycon_config();
+	}
+}
+
+void JoypadSDL::open_joypad(SDL_JoystickID p_sdl_instance_idx) {
+	int joy_id = Input::get_singleton()->get_unused_joy_id();
+	if (joy_id == -1) {
+		// There is no space for more joypads...
+		print_error("A new joypad was attached but couldn't allocate a new id for it because joypad limit was reached.");
+	} else {
+		SDL_Joystick *joy = nullptr;
+		SDL_Gamepad *gamepad = nullptr;
+		String device_name;
+
+		// Gamepads must be opened with SDL_OpenGamepad to get their special remapped events
+		if (SDL_IsGamepad(p_sdl_instance_idx)) {
+			gamepad = SDL_OpenGamepad(p_sdl_instance_idx);
+
+			ERR_FAIL_COND_MSG(!gamepad,
+					vformat("Error opening gamepad at index %d: %s", p_sdl_instance_idx, SDL_GetError()));
+
+			device_name = SDL_GetGamepadName(gamepad);
+			joy = SDL_GetGamepadJoystick(gamepad);
+
+			print_verbose(vformat("SDL: Gamepad %s connected", SDL_GetGamepadName(gamepad)));
+		} else {
+			joy = SDL_OpenJoystick(p_sdl_instance_idx);
+			ERR_FAIL_COND_MSG(!joy,
+					vformat("Error opening joystick at index %d: %s", p_sdl_instance_idx, SDL_GetError()));
+
+			device_name = SDL_GetJoystickName(joy);
+
+			print_verbose(vformat("SDL: Joystick %s connected", SDL_GetJoystickName(joy)));
+		}
+
+		const int MAX_GUID_SIZE = 64;
+		char guid[MAX_GUID_SIZE] = {};
+		SDL_GUID joy_guid = SDL_GetJoystickGUID(joy);
+		SDL_GUIDToString(joy_guid, guid, MAX_GUID_SIZE);
+		SDL_PropertiesID propertiesID = SDL_GetJoystickProperties(joy);
+
+		joypads[joy_id].attached = true;
+		joypads[joy_id].sdl_instance_idx = p_sdl_instance_idx;
+		joypads[joy_id].supports_force_feedback = SDL_GetBooleanProperty(propertiesID, SDL_PROP_JOYSTICK_CAP_RUMBLE_BOOLEAN, false);
+		joypads[joy_id].guid = StringName(String(guid));
+		joypads[joy_id].supports_motion_sensors = SDL_GamepadHasSensor(gamepad, SDL_SENSOR_ACCEL) || SDL_GamepadHasSensor(gamepad, SDL_SENSOR_GYRO);
+
+		sdl_instance_id_to_joypad_id.insert(p_sdl_instance_idx, joy_id);
+
+		Dictionary joypad_info;
+		// Skip Godot's mapping system if SDL already handles the joypad's mapping.
+		joypad_info["mapping_handled"] = SDL_IsGamepad(p_sdl_instance_idx);
+		joypad_info["raw_name"] = String::utf8(SDL_GetJoystickName(joy));
+		joypad_info["vendor_id"] = itos(SDL_GetJoystickVendor(joy));
+		joypad_info["product_id"] = itos(SDL_GetJoystickProduct(joy));
+
+		const String serial = String(SDL_GetJoystickSerial(joy));
+		if (!serial.is_empty()) {
+			joypad_info["serial_number"] = serial;
+		}
+
+#if defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED) || defined(MACOS_ENABLED)
+		const uint64_t steam_handle = SDL_GetGamepadSteamHandle(gamepad);
+		if (steam_handle != 0) {
+			joypad_info["steam_input_index"] = itos(steam_handle);
+		}
+#endif
+
+#ifdef WINDOWS_ENABLED
+		const int player_index = SDL_GetJoystickPlayerIndex(joy);
+		if (player_index >= 0 && joy_guid.data[14] == 'x') { // See also "SDL_IsJoystickXInput" in "thirdparty/sdl/joystick/SDL_joystick.c".
+			// For XInput controllers SDL_GetJoystickPlayerIndex returns the XInput user index.
+			joypad_info["xinput_index"] = itos(player_index);
+		}
+#endif
+
+		Input::get_singleton()->joy_connection_changed(
+				joy_id,
+				true,
+				device_name,
+				joypads[joy_id].guid,
+				joypad_info);
+
+		Input::get_singleton()->set_joy_features(joy_id, &joypads[joy_id]);
+
+		if (joypads[joy_id].supports_motion_sensors) {
+			// Data rate for all sensors should be the same.
+			Input::get_singleton()->set_joy_motion_sensors_rate(joy_id, SDL_GetGamepadSensorDataRate(gamepad, SDL_SENSOR_ACCEL));
+		}
+
+		if (joypads[joy_id].is_joycons()) {
+			joycons_count++;
+		}
+	}
 }
 
 void JoypadSDL::close_joypad(int p_pad_idx) {
 	int sdl_instance_idx = joypads[p_pad_idx].sdl_instance_idx;
 
+	Input::get_singleton()->joy_connection_changed(p_pad_idx, false, "");
+
 	joypads[p_pad_idx].attached = false;
 	sdl_instance_id_to_joypad_id.erase(sdl_instance_idx);
+
+	if (joypads[p_pad_idx].is_joycons()) {
+		joycons_count--;
+	}
 
 	if (SDL_IsGamepad(sdl_instance_idx)) {
 		SDL_Gamepad *gamepad = SDL_GetGamepadFromID(sdl_instance_idx);
@@ -309,6 +338,41 @@ void JoypadSDL::close_joypad(int p_pad_idx) {
 	} else {
 		SDL_Joystick *joy = SDL_GetJoystickFromID(sdl_instance_idx);
 		SDL_CloseJoystick(joy);
+	}
+}
+
+void JoypadSDL::check_joycon_config() {
+	bool new_joycons_separate = Input::get_singleton()->is_joycons_separate();
+	bool new_joycons_vertical = Input::get_singleton()->is_joycons_vertical();
+	bool reconnect_joycons = false;
+
+	if (joycons_separate != new_joycons_separate) {
+		joycons_separate = new_joycons_separate;
+		reconnect_joycons = true;
+		SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_COMBINE_JOY_CONS, joycons_separate ? "0" : "1");
+	}
+	if (joycons_vertical != new_joycons_vertical) {
+		joycons_vertical = new_joycons_vertical;
+		reconnect_joycons = true;
+		SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_VERTICAL_JOY_CONS, joycons_vertical ? "1" : "0");
+	}
+
+	if (reconnect_joycons) {
+		int joycons[Input::JOYPADS_MAX];
+		int joycons_count_check = 0;
+
+		for (int i = 0; i < Input::JOYPADS_MAX; i++) {
+			if (joypads[i].is_joycons()) {
+				joycons[joycons_count_check++] = i;
+			}
+		}
+
+		for (int i = 0; i < joycons_count_check; i++) {
+			int joypad_id = joycons[i];
+			SDL_JoystickID sdl_instance_idx = joypads[joypad_id].sdl_instance_idx;
+			close_joypad(joypad_id);
+			open_joypad(sdl_instance_idx);
+		}
 	}
 }
 
@@ -333,6 +397,17 @@ void JoypadSDL::Joypad::set_joy_motion_sensors_enabled(bool p_enable) {
 	SDL_Gamepad *gamepad = get_sdl_gamepad();
 	SDL_SetGamepadSensorEnabled(gamepad, SDL_SENSOR_ACCEL, p_enable);
 	SDL_SetGamepadSensorEnabled(gamepad, SDL_SENSOR_GYRO, p_enable);
+}
+
+bool JoypadSDL::Joypad::is_joycons() const {
+	switch (SDL_GetGamepadTypeForID(sdl_instance_idx)) {
+		case SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_JOYCON_LEFT:
+		case SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_JOYCON_RIGHT:
+		case SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_JOYCON_PAIR:
+			return true;
+		default:
+			return false;
+	}
 }
 
 SDL_Joystick *JoypadSDL::Joypad::get_sdl_joystick() const {

--- a/drivers/sdl/joypad_sdl.h
+++ b/drivers/sdl/joypad_sdl.h
@@ -62,6 +62,8 @@ private:
 		virtual bool has_joy_motion_sensors() const override;
 		virtual void set_joy_motion_sensors_enabled(bool p_enable) override;
 
+		bool is_joycons() const;
+
 		SDL_Joystick *get_sdl_joystick() const;
 		SDL_Gamepad *get_sdl_gamepad() const;
 	};
@@ -69,5 +71,12 @@ private:
 	Joypad joypads[Input::JOYPADS_MAX];
 	HashMap<SDL_JoystickID, int> sdl_instance_id_to_joypad_id;
 
+	bool joycons_separate = false;
+	bool joycons_vertical = false;
+	uint8_t joycons_count = 0;
+
+	void open_joypad(SDL_JoystickID p_sdl_instance_idx);
 	void close_joypad(int p_pad_idx);
+
+	void check_joycon_config();
 };

--- a/thirdparty/sdl/joystick/SDL_gamepad.c
+++ b/thirdparty/sdl/joystick/SDL_gamepad.c
@@ -55,7 +55,11 @@
 #define SDL_GAMEPAD_SDKLE_FIELD         "sdk<=:"
 #define SDL_GAMEPAD_SDKLE_FIELD_SIZE    SDL_strlen(SDL_GAMEPAD_SDKLE_FIELD)
 
+#define SDL_GAMEPAD_JOYCON_GUID_COUNT	16
+
 static bool SDL_gamepads_initialized;
+static SDL_GUID SDL_joycons_guids[SDL_GAMEPAD_JOYCON_GUID_COUNT] = { 0 };
+static int SDL_joycon_guids_last = 0;
 static SDL_Gamepad *SDL_gamepads SDL_GUARDED_BY(SDL_joystick_lock) = NULL;
 
 // The face button style of a gamepad
@@ -742,6 +746,7 @@ static GamepadMapping_t *SDL_CreateMappingForHIDAPIGamepad(SDL_GUID guid)
     char mapping_string[1024];
     Uint16 vendor;
     Uint16 product;
+    int i;
 
     SDL_strlcpy(mapping_string, "none,*,", sizeof(mapping_string));
 
@@ -814,6 +819,16 @@ static GamepadMapping_t *SDL_CreateMappingForHIDAPIGamepad(SDL_GUID guid)
                 } else {
                     SDL_strlcat(mapping_string, "a:b0,b:b1,guide:b5,leftshoulder:b9,leftstick:b7,leftx:a0,lefty:a1,rightshoulder:b10,start:b6,x:b2,y:b3,paddle1:b12,paddle3:b14,", sizeof(mapping_string));
                 }
+            }
+
+            for (i = 0; i < SDL_joycon_guids_last; i++) {
+                if (memcmp(&guid, &SDL_joycons_guids[i], sizeof(SDL_GUID)) == 0) {
+                    break;
+                }
+            }
+
+            if (i == SDL_joycon_guids_last && SDL_joycon_guids_last < SDL_GAMEPAD_JOYCON_GUID_COUNT) {
+                SDL_joycons_guids[SDL_joycon_guids_last++] = guid;
             }
             break;
         }
@@ -2426,6 +2441,14 @@ static bool SDL_GetGamepadMappingFilePath(char *path, size_t size)
 #endif
 }
 
+static void SDLCALL SDL_GamepadHintChanged(void *userdata, const char *name, const char *oldValue, const char *hint) {
+    for (int i = 0; i < SDL_joycon_guids_last; i++) {
+        if (SDL_joycons_guids[i].data[0] != 0) {
+            SDL_CreateMappingForHIDAPIGamepad(SDL_joycons_guids[i]);
+        }
+    }
+}
+
 /*
  * Initialize the gamepad system, mostly load our DB of gamepad config mappings
  */
@@ -2456,6 +2479,8 @@ bool SDL_InitGamepadMappings(void)
 
     SDL_LoadVIDPIDList(&SDL_allowed_gamepads);
     SDL_LoadVIDPIDList(&SDL_ignored_gamepads);
+
+    SDL_AddHintCallback(SDL_HINT_JOYSTICK_HIDAPI_VERTICAL_JOY_CONS, SDL_GamepadHintChanged, NULL);
 
     PopMappingChangeTracking();
 


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot-proposals/issues/14100

This PR adds 2 new project settings that allow the developers to treat each JoyCon pair as 2 separate joypads and treat separate JoyCons as held vertically.

TODO:
- [ ] A PR for SDL
- [x] Mark as only available for desktop platforms
- [x] Since JoypadSDL doesn't depend on project settings anymore, there's no reason to inherit from Object