### PR TITLE
OpenXR: Better action map defaults for hand interaction profile

### DIFF
--- a/modules/openxr/action_map/openxr_action_map.cpp
+++ b/modules/openxr/action_map/openxr_action_map.cpp
@@ -553,17 +553,13 @@ void OpenXRActionMap::create_default_action_sets() {
 	profile->add_new_binding(grip_pose, "/user/hand/left/input/grip/pose,/user/hand/right/input/grip/pose");
 	profile->add_new_binding(palm_pose, "/user/hand/left/input/grip_surface/pose,/user/hand/right/input/grip_surface/pose");
 
-	// Use pinch as primary.
-	profile->add_new_binding(primary, "/user/hand/left/input/pinch_ext/value,/user/hand/right/input/pinch_ext/value");
-	profile->add_new_binding(primary_click, "/user/hand/left/input/pinch_ext/ready_ext,/user/hand/right/input/pinch_ext/ready_ext");
+	// Use pinch as trigger.
+	profile->add_new_binding(trigger, "/user/hand/left/input/pinch_ext/value,/user/hand/right/input/pinch_ext/value");
+	profile->add_new_binding(trigger_click, "/user/hand/left/input/pinch_ext/value,/user/hand/right/input/pinch_ext/value");
 
-	// Use activation as secondary.
-	profile->add_new_binding(secondary, "/user/hand/left/input/aim_activate_ext/value,/user/hand/right/input/aim_activate_ext/value");
-	profile->add_new_binding(secondary_click, "/user/hand/left/input/aim_activate_ext/ready_ext,/user/hand/right/input/aim_activate_ext/ready_ext");
-
-	// We link grasp to our grip.
+	// Use grasp as grip.
 	profile->add_new_binding(grip, "/user/hand/left/input/grasp_ext/value,/user/hand/right/input/grasp_ext/value");
-	profile->add_new_binding(grip_click, "/user/hand/left/input/grasp_ext/ready_ext,/user/hand/right/input/grasp_ext/ready_ext");
+	profile->add_new_binding(grip_click, "/user/hand/left/input/grasp_ext/value,/user/hand/right/input/grasp_ext/value");
 	add_interaction_profile(profile);
 }
 


### PR DESCRIPTION
While developers shouldn't necessarily use the action map defaults, the current default bindings for the hand interaction profile aren't very useful:

- Pinch (which is defined as a `1D analog input component indicating the extent which the user is bringing their finger and thumb together to perform a "pinch" gesture`) is mapped to "primary", which is usually used for a thumbstick or trackpad
- Pinch ready (which is defined as a `boolean input, where the value XR_TRUE indicates that the fingers used to perform the "pinch" gesture are properly tracked by the hand tracking device and the hand shape is observed to be ready to perform or is performing a "pinch" gesture`) is mapped to "primary_click", which is usually used for pressing in a thumbstick or trackpad
- Aim activate (which is defined as a `1D analog input component indicating that the user activated the action on the target that the user is pointing at with the aim pose`) is mapped to "secondary", which is usually used for a thumbstick or trackpad
- Aim activate ready (which is defined as `a boolean input, where the value XR_TRUE indicates that the fingers to perform the "aim_activate" gesture are properly tracked by the hand tracking device and the hand shape is observed to be ready to perform or is performing an "aim_activate" gesture`) is mapped to "secondary_click", which is usually used for pressing in a thumbstick or trackpad
- Grasp ready (which is defined as `boolean input, where the value XR_TRUE indicates that the hand performing the grasp action is properly tracked by the hand tracking device and it is observed to be ready to perform or is performing the grasp action`) is mapped to "grip_click" which is usually for pressing in the grip button

While the "ready" actions are very useful, I don't think we should map them at all in our defaults, because we don't have a good action in the default action set. They indicate that a hand is ready to perform a gesture, so it's a good time to show some indicator by the hand to let the user know that if they perform the gesture, it'll be recognized. But they really shouldn't be used as a "click"

The mapping that I personally think is the most compatible with the default action set is:

- Pinch mapped to both "trigger" and "trigger_click" ("trigger_click" is boolean, so it'll be set when the value is `1.0` - this isn't perfect, since a looser threshold would be better, but it works well enough for a default)
- Grasp mapped to both "grip" and "grip_click" (similar to the previous one)
- Aim activate not mapped to anything - while its useful, it's very system dependent and could be a surprising gesture depending on the platform

I think this will "just work" with the widest group of Godot apps that were built for controllers (using the default action map) and turn on the hand tracking interaction profile