### PR TITLE
Remove `sky.h` include from `environment.h`, to speed up compile time.

### DIFF
--- a/editor/animation/animation_library_editor.cpp
+++ b/editor/animation/animation_library_editor.cpp
@@ -30,6 +30,7 @@
 
 #include "animation_library_editor.h"
 
+#include "core/io/resource_loader.h"
 #include "core/string/ustring.h"
 #include "core/templates/vector.h"
 #include "core/variant/variant.h"

--- a/editor/animation/animation_player_editor_plugin.h
+++ b/editor/animation/animation_player_editor_plugin.h
@@ -40,6 +40,7 @@
 #include "scene/gui/spin_box.h"
 #include "scene/gui/texture_button.h"
 #include "scene/gui/tree.h"
+#include "scene/resources/material.h"
 
 class AnimationPlayerEditorPlugin;
 class ImageTexture;

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -32,6 +32,7 @@
 
 #include "core/debugger/debugger_marshalls.h"
 #include "core/io/marshalls.h"
+#include "core/io/resource_loader.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_debugger_node.h"
 
+#include "core/io/resource_loader.h"
 #include "core/object/undo_redo.h"
 #include "editor/debugger/editor_debugger_plugin.h"
 #include "editor/debugger/editor_debugger_tree.h"

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_debugger_tree.h"
 
+#include "core/io/resource_saver.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/docks/scene_tree_dock.h"
 #include "editor/editor_node.h"

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_log.h"
 
+#include "core/io/resource_loader.h"
 #include "core/object/undo_redo.h"
 #include "core/os/keyboard.h"
 #include "core/version.h"

--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -30,6 +30,7 @@
 
 #include "create_dialog.h"
 
+#include "core/io/resource_loader.h"
 #include "core/object/class_db.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -45,6 +45,7 @@
 #include "scene/gui/subviewport_container.h"
 #include "scene/main/timer.h"
 #include "scene/resources/3d/importer_mesh.h"
+#include "scene/resources/sky.h"
 #include "scene/resources/surface_tool.h"
 
 class SceneImportSettingsData : public Object {

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -59,6 +59,7 @@
 #include "scene/main/window.h"
 #include "scene/resources/font.h"
 #include "scene/resources/mesh.h"
+#include "scene/resources/sky.h"
 #include "scene/resources/visual_shader_nodes.h"
 
 ///////////////////// NIL /////////////////////////

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -104,6 +104,7 @@
 #include "scene/gui/subviewport_container.h"
 #include "scene/resources/3d/sky_material.h"
 #include "scene/resources/packed_scene.h"
+#include "scene/resources/sky.h"
 #include "scene/resources/surface_tool.h"
 
 constexpr real_t DISTANCE_DEFAULT = 4;

--- a/editor/scene/3d/voxel_gi_editor_plugin.cpp
+++ b/editor/scene/3d/voxel_gi_editor_plugin.cpp
@@ -30,6 +30,8 @@
 
 #include "voxel_gi_editor_plugin.h"
 
+#include "core/io/resource_loader.h"
+#include "core/io/resource_saver.h"
 #include "editor/editor_interface.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -31,6 +31,7 @@
 #include "editor_scene_tabs.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/resource_loader.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -44,6 +44,7 @@
 #include "scene/main/viewport.h"
 #include "scene/resources/canvas_item_material.h"
 #include "scene/resources/particle_process_material.h"
+#include "scene/resources/sky.h"
 
 // 3D.
 #include "scene/3d/camera_3d.h"

--- a/editor/scene/scene_create_dialog.cpp
+++ b/editor/scene/scene_create_dialog.cpp
@@ -31,6 +31,7 @@
 #include "scene_create_dialog.h"
 
 #include "core/io/dir_access.h"
+#include "core/io/resource_saver.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/create_dialog.h"

--- a/editor/scene/texture/texture_3d_editor_plugin.h
+++ b/editor/scene/texture/texture_3d_editor_plugin.h
@@ -33,6 +33,7 @@
 #include "editor/inspector/editor_inspector.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/gui/spin_box.h"
+#include "scene/resources/material.h"
 #include "scene/resources/shader.h"
 #include "scene/resources/texture.h"
 

--- a/editor/scene/texture/texture_editor_plugin.cpp
+++ b/editor/scene/texture/texture_editor_plugin.cpp
@@ -42,6 +42,7 @@
 #include "scene/resources/compressed_texture.h"
 #include "scene/resources/dpi_texture.h"
 #include "scene/resources/image_texture.h"
+#include "scene/resources/material.h"
 #include "scene/resources/portable_compressed_texture.h"
 
 constexpr const char *texture_2d_shader_code = R"(

--- a/editor/scene/texture/texture_layered_editor_plugin.h
+++ b/editor/scene/texture/texture_layered_editor_plugin.h
@@ -33,6 +33,7 @@
 #include "editor/inspector/editor_inspector.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/gui/spin_box.h"
+#include "scene/resources/material.h"
 #include "scene/resources/shader.h"
 #include "scene/resources/texture.h"
 

--- a/editor/script/editor_script_plugin.cpp
+++ b/editor/script/editor_script_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_script_plugin.h"
 
+#include "core/io/resource_loader.h"
 #include "editor/editor_interface.h"
 #include "editor/script/editor_script.h"
 #include "editor/settings/editor_command_palette.h"

--- a/editor/shader/shader_editor_plugin.h
+++ b/editor/shader/shader_editor_plugin.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "editor/plugins/editor_plugin.h"
+#include "scene/resources/shader.h"
 
 class CodeTextEditor;
 class EditorDock;

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -69,6 +69,7 @@
 #include "scene/gui/view_panner.h"
 #include "scene/main/window.h"
 #include "scene/resources/curve_texture.h"
+#include "scene/resources/sky.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/resources/visual_shader_nodes.h"
 #include "scene/resources/visual_shader_particle_nodes.h"

--- a/editor/shader/visual_shader_editor_plugin.h
+++ b/editor/shader/visual_shader_editor_plugin.h
@@ -35,6 +35,7 @@
 #include "editor/plugins/editor_resource_conversion_plugin.h"
 #include "editor/shader/shader_editor.h"
 #include "scene/gui/graph_edit.h"
+#include "scene/resources/material.h"
 #include "scene/resources/syntax_highlighter.h"
 #include "scene/resources/visual_shader.h"
 

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -32,6 +32,8 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/io/resource_loader.h"
+#include "core/io/resource_saver.h"
 #include "editor/editor_node.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/settings/editor_command_palette.h"

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -31,6 +31,8 @@
 #include "bone_attachment_3d.h"
 #include "bone_attachment_3d.compat.inc"
 
+#include "core/config/engine.h"
+
 void BoneAttachment3D::_validate_property(PropertyInfo &p_property) const {
 	if (Engine::get_singleton()->is_editor_hint() && p_property.name == "bone_name") {
 		// Because it is a constant function, we cannot use the get_skeleton function.

--- a/scene/3d/ik_modifier_3d.cpp
+++ b/scene/3d/ik_modifier_3d.cpp
@@ -30,6 +30,8 @@
 
 #include "ik_modifier_3d.h"
 
+#include "core/config/engine.h"
+
 void IKModifier3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -32,6 +32,7 @@
 
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/resources/font.h"
+#include "scene/resources/material.h"
 
 #include "servers/text/text_server.h"
 

--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "look_at_modifier_3d.h"
 
+#include "core/config/engine.h"
 #include "scene/resources/animation.h"
 
 void LookAtModifier3D::_validate_property(PropertyInfo &p_property) const {

--- a/scene/3d/modifier_bone_target_3d.cpp
+++ b/scene/3d/modifier_bone_target_3d.cpp
@@ -30,6 +30,8 @@
 
 #include "modifier_bone_target_3d.h"
 
+#include "core/config/engine.h"
+
 void ModifierBoneTarget3D::_validate_bone_names() {
 	// Prior bone name.
 	if (!bone_name.is_empty()) {

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -32,6 +32,7 @@
 
 #include "scene/3d/node_3d.h"
 #include "scene/resources/curve.h"
+#include "scene/resources/material.h"
 
 class Path3D : public Node3D {
 	GDCLASS(Path3D, Node3D);

--- a/scene/3d/physics/ray_cast_3d.h
+++ b/scene/3d/physics/ray_cast_3d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/3d/node_3d.h"
+#include "scene/resources/material.h"
 
 class CollisionObject3D;
 

--- a/scene/3d/physics/shape_cast_3d.h
+++ b/scene/3d/physics/shape_cast_3d.h
@@ -32,6 +32,7 @@
 
 #include "scene/3d/node_3d.h"
 #include "scene/resources/3d/shape_3d.h"
+#include "scene/resources/material.h"
 
 class CollisionObject3D;
 

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -35,6 +35,7 @@
 #if !defined(DISABLE_DEPRECATED) && !defined(PHYSICS_3D_DISABLED)
 #include "scene/3d/physics/physical_bone_simulator_3d.h"
 #endif // _DISABLE_DEPRECATED && PHYSICS_3D_DISABLED
+#include "servers/rendering/rendering_server.h"
 
 void SkinReference::_skin_changed() {
 	if (skeleton_node) {

--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -30,6 +30,8 @@
 
 #include "skeleton_ik_3d.h"
 
+#include "core/config/engine.h"
+
 FabrikInverseKinematic::ChainItem *FabrikInverseKinematic::ChainItem::find_child(const BoneId p_bone_id) {
 	for (int i = children.size() - 1; 0 <= i; --i) {
 		if (p_bone_id == children[i].bone) {

--- a/scene/3d/spring_bone_collision_3d.cpp
+++ b/scene/3d/spring_bone_collision_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "spring_bone_collision_3d.h"
 
+#include "core/config/engine.h"
 #include "scene/3d/spring_bone_simulator_3d.h"
 
 PackedStringArray SpringBoneCollision3D::get_configuration_warnings() const {

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -31,6 +31,7 @@
 #include "spring_bone_simulator_3d.h"
 #include "spring_bone_simulator_3d.compat.inc"
 
+#include "core/config/engine.h"
 #include "scene/3d/spring_bone_collision_3d.h"
 
 // Original VRM Spring Bone movement logic was distributed by (c) VRM Consortium. Licensed under the MIT license.

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/3d/visual_instance_3d.h"
+#include "scene/resources/material.h"
 #include "scene/resources/sprite_frames.h"
 
 class SpriteBase3D : public GeometryInstance3D {

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -31,6 +31,7 @@
 #include "visual_instance_3d.h"
 
 #include "core/config/project_settings.h"
+#include "scene/resources/material.h"
 
 AABB VisualInstance3D::get_aabb() const {
 	AABB ret;

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/3d/node_3d.h"
+#include "servers/rendering/rendering_server.h"
 
 class TriangleMesh;
 

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "scene/resources/gradient_texture.h"
+#include "scene/resources/sky.h"
 #include "servers/rendering/rendering_server.h"
 
 RID Environment::get_rid() const {

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -31,8 +31,9 @@
 #pragma once
 
 #include "core/io/resource.h"
-#include "scene/resources/sky.h"
 #include "scene/resources/texture.h"
+
+class Sky;
 
 class Environment : public Resource {
 	GDCLASS(Environment, Resource);


### PR DESCRIPTION
- Helps address #111218 

Removes `sky.h` include from `environment.h`, opting to forward-declare `Sky`.

Turns out this include was doing a lot of heavy lifting, so includes for `engine.h`, `material.h`, `resource_loader.h` and `rendering_server.h` have to be forwarded a few times as well. In tandem, this landed a bunch of these headers in the #111218 top 50.

All in all, this should make it noticeably easier to work on any headers mentioned above.