### PR TITLE
Fix `Skeleton3D` Edit Mode bone buttons have priority over transform gizmo

### DIFF
--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -1515,35 +1515,10 @@ Skeleton3DEditorPlugin::Skeleton3DEditorPlugin() {
 
 EditorPlugin::AfterGUIInput Skeleton3DEditorPlugin::forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) {
 	Skeleton3DEditor *se = Skeleton3DEditor::get_singleton();
-	Node3DEditor *ne = Node3DEditor::get_singleton();
 	if (se && se->is_edit_mode()) {
 		const Ref<InputEventMouseButton> mb = p_event;
 		if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
-			Skeleton3D *skeleton = se->get_skeleton();
-			if (skeleton) {
-				int closest_idx = Skeleton3DGizmoPlugin::skeleton_intersect_ray(skeleton, p_camera, mb->get_position());
-				if (closest_idx >= 0) {
-					se->select_bone(closest_idx);
-					se->update_bone_original();
-
-					Vector<Ref<Node3DGizmo>> gizmos = skeleton->get_gizmos();
-					for (Ref<EditorNode3DGizmo> seg : gizmos) {
-						if (seg.is_valid()) {
-							Transform3D bone_xform = seg->get_subgizmo_transform(closest_idx);
-							ne->call("_set_subgizmo_selection", skeleton, seg, closest_idx, bone_xform);
-							break;
-						}
-					}
-					return EditorPlugin::AFTER_GUI_INPUT_STOP;
-				}
-			}
-		}
-		if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT) {
-			if (ne->get_tool_mode() != Node3DEditor::TOOL_MODE_SELECT) {
-				if (!ne->is_gizmo_visible()) {
-					return EditorPlugin::AFTER_GUI_INPUT_STOP;
-				}
-			}
+			se->update_bone_original();
 		}
 		return EditorPlugin::AFTER_GUI_INPUT_CUSTOM;
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fixes: https://github.com/godotengine/godot/issues/115581

Verified https://github.com/godotengine/godot/issues/114749 was not reintroduced.

https://github.com/godotengine/godot/pull/114752 added bone selection handling to `forward_3d_gui_input`, which runs before transform gizmo input processing. This caused bone buttons to intercept clicks meant for the gizmo. Bone selection is already handled correctly by `subgizmos_intersect_ray`, which runs after the transform gizmo check in `_sinput`, so this redundant.


https://github.com/user-attachments/assets/3863ef4b-cb93-4807-b81f-b1fca8944d35

