### PR TITLE
Fix `SpinBox` buttons not updating when using `set_value_no_signal()`

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -158,6 +158,8 @@ void Range::Shared::redraw_owners() {
 		if (!r->is_inside_tree()) {
 			continue;
 		}
+
+		r->_value_changed(val);
 		r->queue_accessibility_update();
 		r->queue_redraw();
 	}


### PR DESCRIPTION
Fixes #109865.