### PR TITLE
Core: Forbid implicit `Variant` comparison

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -639,7 +639,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 			d["is_keyed"] = Variant::is_keyed(type);
 
 			DocData::ClassDoc *builtin_doc = nullptr;
-			if (p_include_docs && d["name"] != "Nil") {
+			if (p_include_docs && String(d["name"]) != "Nil") {
 				builtin_doc = EditorHelp::get_doc_data()->class_list.getptr(d["name"]);
 				CRASH_COND_MSG(!builtin_doc, vformat("Could not find '%s' in DocData.", d["name"]));
 			}
@@ -1362,7 +1362,7 @@ static bool compare_value(const String &p_path, const String &p_field, const Var
 				print_error(vformat("Validate extension JSON: Error: Field '%s': %s was removed.", p_path, kv.key));
 				continue;
 			}
-			if (p_allow_name_change && kv.key == "name") {
+			if (p_allow_name_change && String(kv.key) == "name") {
 				continue;
 			}
 			if (!compare_value(path, kv.key, kv.value, new_dict[kv.key], p_allow_name_change)) {

--- a/core/extension/gdextension_interface_header_generator.cpp
+++ b/core/extension/gdextension_interface_header_generator.cpp
@@ -133,7 +133,7 @@ void GDExtensionInterfaceHeaderGenerator::write_doc(const Ref<FileAccess> &p_fa,
 			p_fa->store_string(p_indent + " *");
 		}
 
-		if (line == "") {
+		if (String(line) == "") {
 			p_fa->store_string("\n");
 		} else {
 			p_fa->store_line(String(" ") + (String)line);

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -838,6 +838,20 @@ public:
 	bool operator==(const Variant &p_variant) const;
 	bool operator!=(const Variant &p_variant) const;
 	bool operator<(const Variant &p_variant) const;
+
+	template <typename T>
+	bool operator==(const T &p_value) const = delete;
+	template <typename T>
+	bool operator!=(const T &p_value) const = delete;
+	template <typename T>
+	bool operator<(const T &p_value) const = delete;
+	template <typename T>
+	bool operator<=(const T &p_value) const = delete;
+	template <typename T>
+	bool operator>(const T &p_value) const = delete;
+	template <typename T>
+	bool operator>=(const T &p_value) const = delete;
+
 	uint32_t hash() const;
 	uint32_t recursive_hash(int recursion_count) const;
 

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1213,11 +1213,11 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			bool got_comma_token = false;
 			if (builtin_types.has(token.value)) {
 				key_type = builtin_types.get(token.value);
-			} else if (token.value == "Resource" || token.value == "SubResource" || token.value == "ExtResource") {
+			} else if (String(token.value) == "Resource" || String(token.value) == "SubResource" || String(token.value) == "ExtResource") {
 				Variant resource;
 				err = parse_value(token, resource, p_stream, line, r_err_str, p_res_parser);
 				if (err) {
-					if (token.value == "Resource" && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && token.type == TK_COMMA) {
+					if (String(token.value) == "Resource" && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && token.type == TK_COMMA) {
 						err = OK;
 						r_err_str = String();
 						key_type = Variant::OBJECT;
@@ -1259,11 +1259,11 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			bool got_bracket_token = false;
 			if (builtin_types.has(token.value)) {
 				value_type = builtin_types.get(token.value);
-			} else if (token.value == "Resource" || token.value == "SubResource" || token.value == "ExtResource") {
+			} else if (String(token.value) == "Resource" || String(token.value) == "SubResource" || String(token.value) == "ExtResource") {
 				Variant resource;
 				err = parse_value(token, resource, p_stream, line, r_err_str, p_res_parser);
 				if (err) {
-					if (token.value == "Resource" && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && token.type == TK_BRACKET_CLOSE) {
+					if (String(token.value) == "Resource" && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && token.type == TK_BRACKET_CLOSE) {
 						err = OK;
 						r_err_str = String();
 						value_type = Variant::OBJECT;
@@ -1350,11 +1350,11 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			bool got_bracket_token = false;
 			if (builtin_types.has(token.value)) {
 				array.set_typed(builtin_types.get(token.value), StringName(), Variant());
-			} else if (token.value == "Resource" || token.value == "SubResource" || token.value == "ExtResource") {
+			} else if (String(token.value) == "Resource" || String(token.value) == "SubResource" || String(token.value) == "ExtResource") {
 				Variant resource;
 				err = parse_value(token, resource, p_stream, line, r_err_str, p_res_parser);
 				if (err) {
-					if (token.value == "Resource" && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && token.type == TK_BRACKET_CLOSE) {
+					if (String(token.value) == "Resource" && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && token.type == TK_BRACKET_CLOSE) {
 						err = OK;
 						r_err_str = String();
 						array.set_typed(Variant::OBJECT, token.value, Variant());

--- a/editor/animation/animation_library_editor.cpp
+++ b/editor/animation/animation_library_editor.cpp
@@ -863,7 +863,7 @@ Vector<String> AnimationLibraryEditor::_load_mixer_libs_folding() {
 		String current_mixer_signature = _get_mixer_signature();
 
 		for (const String &section : config->get_sections()) {
-			if (config->get_value(section, "mixer_signature") == current_mixer_signature) {
+			if (String(config->get_value(section, "mixer_signature")) == current_mixer_signature) {
 				config->set_value(md, "mixer_signature", current_mixer_signature);
 				config->set_value(md, "folding", config->get_value(section, "folding"));
 

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -3551,7 +3551,7 @@ bool AnimationTrackEdit::can_drop_data(const Point2 &p_point, const Variant &p_d
 	if (get_editor()->is_grouping_tracks()) {
 		String base_path = String(animation->track_get_path(track));
 		base_path = base_path.get_slicec(':', 0); // Remove sub-path.
-		if (d["group"] != base_path) {
+		if (String(d["group"]) != base_path) {
 			return false;
 		}
 	}
@@ -3582,7 +3582,7 @@ void AnimationTrackEdit::drop_data(const Point2 &p_point, const Variant &p_data)
 	if (get_editor()->is_grouping_tracks()) {
 		String base_path = String(animation->track_get_path(track));
 		base_path = base_path.get_slicec(':', 0); // Remove sub-path.
-		if (d["group"] != base_path) {
+		if (String(d["group"]) != base_path) {
 			return;
 		}
 	}

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3040,7 +3040,7 @@ void EditorHelp::remove_class(const String &p_class) {
 void EditorHelp::_load_doc_thread(void *p_udata) {
 	bool use_script_cache = (bool)p_udata;
 	Ref<Resource> cache_res = ResourceLoader::load(get_cache_full_path());
-	if (cache_res.is_valid() && cache_res->get_meta("version_hash", "") == doc_version_hash) {
+	if (cache_res.is_valid() && String(cache_res->get_meta("version_hash", "")) == doc_version_hash) {
 		Array classes = cache_res->get_meta("classes", Array());
 		for (int i = 0; i < classes.size(); i++) {
 			doc->add_doc(DocData::ClassDoc::from_dict(classes[i]));

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -862,7 +862,7 @@ void FileSystemDock::navigate_to_path(const String &p_path) {
 
 void FileSystemDock::_file_list_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_index, const String &p_filename) {
 	if (p_preview.is_valid()) {
-		if (p_index < files->get_item_count() && files->get_item_text(p_index) == p_filename && files->get_item_metadata(p_index) == p_path) {
+		if (p_index < files->get_item_count() && files->get_item_text(p_index) == p_filename && String(files->get_item_metadata(p_index)) == p_path) {
 			Ref<Texture2D> thumbnail;
 
 			if (file_list_display_mode == FILE_LIST_DISPLAY_LIST) {
@@ -1369,7 +1369,7 @@ void FileSystemDock::_tree_activate_file() {
 	if (selected) {
 		String file_path = selected->get_metadata(0);
 		TreeItem *parent = selected->get_parent();
-		bool is_favorite = parent != nullptr && parent->get_metadata(0) == "Favorites";
+		bool is_favorite = parent != nullptr && String(parent->get_metadata(0)) == "Favorites";
 		bool is_folder = file_path.ends_with("/");
 
 		if ((!is_favorite && is_folder) || file_path == "Favorites") {
@@ -1388,7 +1388,7 @@ void FileSystemDock::_file_list_activate_file(int p_idx) {
 void FileSystemDock::_preview_invalidated(const String &p_path) {
 	if (file_list_display_mode == FILE_LIST_DISPLAY_THUMBNAILS && p_path.get_base_dir() == current_path && searched_tokens.is_empty() && file_list_vb->is_visible_in_tree()) {
 		for (int i = 0; i < files->get_item_count(); i++) {
-			if (files->get_item_metadata(i) == p_path) {
+			if (String(files->get_item_metadata(i)) == p_path) {
 				// Re-request preview.
 				EditorResourcePreview::get_singleton()->queue_resource_preview(p_path, callable_mp(this, &FileSystemDock::_file_list_thumbnail_done).bind(i, files->get_item_text(i)));
 				break;

--- a/editor/docks/import_dock.cpp
+++ b/editor/docks/import_dock.cpp
@@ -213,7 +213,7 @@ void ImportDock::_update_options(const String &p_path, const Ref<ConfigFile> &p_
 	params->update();
 	_update_preset_menu();
 
-	bool was_imported = p_config.is_valid() && p_config->get_value("remap", "importer") != "skip" && p_config->get_value("remap", "importer") != "keep";
+	bool was_imported = p_config.is_valid() && String(p_config->get_value("remap", "importer")) != "skip" && String(p_config->get_value("remap", "importer")) != "keep";
 	if (was_imported && params->importer.is_valid() && params->paths.size() == 1 && params->importer->has_advanced_options()) {
 		advanced->show();
 		advanced_spacer->show();
@@ -640,7 +640,7 @@ void ImportDock::_reimport() {
 		if (params->importer.is_valid()) {
 			String importer_name = params->importer->get_importer_name();
 
-			if (params->checking && config->get_value("remap", "importer") == params->importer->get_importer_name()) {
+			if (params->checking && String(config->get_value("remap", "importer")) == params->importer->get_importer_name()) {
 				//update only what is edited (checkboxes) if the importer is the same
 				for (const PropertyInfo &E : params->properties) {
 					if (params->checked.has(E.name)) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7594,7 +7594,7 @@ void EditorNode::_renderer_selected(int p_index) {
 
 	// Don't change selection.
 	for (int i = 0; i < renderer->get_item_count(); i++) {
-		if (renderer->get_item_metadata(i) == current_renderer) {
+		if (String(renderer->get_item_metadata(i)) == current_renderer) {
 			renderer->select(i);
 			break;
 		}

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -814,7 +814,7 @@ bool EditorExportPlatform::_export_customize_object(Object *p_object, LocalVecto
 			case Variant::DICTIONARY: {
 				Dictionary d = p_object->get(E.name);
 				if (_export_customize_dictionary(d, customize_resources_plugins)) {
-					if (p_object->get(E.name) != d) {
+					if (Dictionary(p_object->get(E.name)) != d) {
 						p_object->set(E.name, d);
 					}
 
@@ -824,7 +824,7 @@ bool EditorExportPlatform::_export_customize_object(Object *p_object, LocalVecto
 			case Variant::ARRAY: {
 				Array a = p_object->get(E.name);
 				if (_export_customize_array(a, customize_resources_plugins)) {
-					if (p_object->get(E.name) != a) {
+					if (Array(p_object->get(E.name)) != a) {
 						p_object->set(E.name, a);
 					}
 
@@ -1031,9 +1031,9 @@ Dictionary EditorExportPlatform::get_internal_export_files(const Ref<EditorExpor
 				} else {
 					String current_version = GODOT_VERSION_FULL_CONFIG;
 					String template_path = EditorPaths::get_singleton()->get_export_templates_dir().path_join(current_version);
-					if (p_debug && p_preset->has("custom_template/debug") && p_preset->get("custom_template/debug") != "") {
+					if (p_debug && p_preset->has("custom_template/debug") && String(p_preset->get("custom_template/debug")) != "") {
 						template_path = p_preset->get("custom_template/debug").operator String().get_base_dir();
-					} else if (!p_debug && p_preset->has("custom_template/release") && p_preset->get("custom_template/release") != "") {
+					} else if (!p_debug && p_preset->has("custom_template/release") && String(p_preset->get("custom_template/release")) != "") {
 						template_path = p_preset->get("custom_template/release").operator String().get_base_dir();
 					}
 					String data_file_name = template_path.path_join(ts_name);

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -2164,13 +2164,13 @@ bool EditorExportPlatformAppleEmbedded::has_valid_export_configuration(const Ref
 	bool dvalid = exists_export_template(get_platform_name() + ".zip", &err);
 	bool rvalid = dvalid; // Both in the same ZIP.
 
-	if (p_preset->get("custom_template/debug") != "") {
+	if (String(p_preset->get("custom_template/debug")) != "") {
 		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
 		if (!dvalid) {
 			err += TTR("Custom debug template not found.") + "\n";
 		}
 	}
-	if (p_preset->get("custom_template/release") != "") {
+	if (String(p_preset->get("custom_template/release")) != "") {
 		rvalid = FileAccess::exists(p_preset->get("custom_template/release"));
 		if (!rvalid) {
 			err += TTR("Custom release template not found.") + "\n";
@@ -2385,12 +2385,12 @@ void EditorExportPlatformAppleEmbedded::_check_for_changes_poll_thread(void *ud)
 						Array devices = data["devices"];
 						for (int i = 0; i < devices.size(); i++) {
 							Dictionary device_event = devices[i];
-							if (device_event["Event"] == "DeviceDetected") {
+							if (String(device_event["Event"]) == "DeviceDetected") {
 								Dictionary device_info = device_event["Device"];
 								Device nd;
 								nd.id = device_info["DeviceIdentifier"];
-								nd.name = device_info["DeviceName"].operator String() + " (ios_deploy, " + ((device_event["Interface"] == "WIFI") ? "network" : "wired") + ")";
-								nd.wifi = device_event["Interface"] == "WIFI";
+								nd.name = device_info["DeviceName"].operator String() + " (ios_deploy, " + ((String(device_event["Interface"]) == "WIFI") ? "network" : "wired") + ")";
+								nd.wifi = String(device_event["Interface"]) == "WIFI";
 								nd.use_ios_deploy = true;
 								ldevices.push_back(nd);
 							}
@@ -2429,11 +2429,11 @@ void EditorExportPlatformAppleEmbedded::_check_for_changes_poll_thread(void *ud)
 						const Dictionary &device_info = devices[i];
 						const Dictionary &conn_props = device_info["connectionProperties"];
 						const Dictionary &dev_props = device_info["deviceProperties"];
-						if (dev_props.has("developerModeStatus") && conn_props.has("pairingState") && conn_props.has("transportType") && conn_props["pairingState"] == "paired" && dev_props["developerModeStatus"] == "enabled") {
+						if (dev_props.has("developerModeStatus") && conn_props.has("pairingState") && conn_props.has("transportType") && String(conn_props["pairingState"]) == "paired" && String(dev_props["developerModeStatus"]) == "enabled") {
 							Device nd;
 							nd.id = device_info["identifier"];
-							nd.name = dev_props["name"].operator String() + " (devicectl, " + ((conn_props["transportType"] == "localNetwork") ? "network" : "wired") + ")";
-							nd.wifi = conn_props["transportType"] == "localNetwork";
+							nd.name = dev_props["name"].operator String() + " (devicectl, " + ((String(conn_props["transportType"]) == "localNetwork") ? "network" : "wired") + ")";
+							nd.wifi = String(conn_props["transportType"]) == "localNetwork";
 							ldevices.push_back(nd);
 						}
 					}

--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -102,13 +102,13 @@ bool EditorExportPlatformPC::has_valid_export_configuration(const Ref<EditorExpo
 	bool dvalid = exists_export_template(get_template_file_name("debug", arch), &err);
 	bool rvalid = exists_export_template(get_template_file_name("release", arch), &err);
 
-	if (p_preset->get("custom_template/debug") != "") {
+	if (String(p_preset->get("custom_template/debug")) != "") {
 		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
 		if (!dvalid) {
 			err += TTR("Custom debug template not found.") + "\n";
 		}
 	}
-	if (p_preset->get("custom_template/release") != "") {
+	if (String(p_preset->get("custom_template/release")) != "") {
 		rvalid = FileAccess::exists(p_preset->get("custom_template/release"));
 		if (!rvalid) {
 			err += TTR("Custom release template not found.") + "\n";

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -864,7 +864,7 @@ bool ProjectExportDialog::can_drop_data_fw(const Point2 &p_point, const Variant 
 		}
 	} else if (p_from == patches) {
 		Dictionary d = p_data;
-		if (d.get("type", "") != "export_patch") {
+		if (String(d.get("type", "")) != "export_patch") {
 			return false;
 		}
 

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -3239,7 +3239,7 @@ bool EditorInspectorArray::can_drop_data_fw(const Point2 &p_point, const Variant
 	}
 	Dictionary dict = p_data;
 	int drop_position = (p_point == Vector2(Math::INF, Math::INF)) ? selected : _drop_position();
-	if (!dict.has("type") || dict["type"] != "property_array_element" || String(dict["property_array_prefix"]) != array_element_prefix || drop_position < 0) {
+	if (!dict.has("type") || String(dict["type"]) != "property_array_element" || String(dict["property_array_prefix"]) != array_element_prefix || drop_position < 0) {
 		return false;
 	}
 
@@ -3320,7 +3320,7 @@ void EditorInspectorArray::_notification(int p_what) {
 
 		case NOTIFICATION_DRAG_BEGIN: {
 			Dictionary dict = get_viewport()->gui_get_drag_data();
-			if (dict.has("type") && dict["type"] == "property_array_element" && String(dict["property_array_prefix"]) == array_element_prefix) {
+			if (dict.has("type") && String(dict["type"]) == "property_array_element" && String(dict["property_array_prefix"]) == array_element_prefix) {
 				dropping = true;
 				control_dropping->queue_redraw();
 			}
@@ -3451,10 +3451,10 @@ void EditorPaginator::_page_line_edit_text_submitted(const String &p_text) {
 	if (p_text.is_valid_int()) {
 		int new_page = p_text.to_int() - 1;
 		new_page = MIN(MAX(0, new_page), max_page);
-		page_line_edit->set_text(Variant(new_page));
+		page_line_edit->set_text(itos(new_page));
 		emit_signal("page_changed", new_page);
 	} else {
-		page_line_edit->set_text(Variant(page));
+		page_line_edit->set_text(itos(page));
 	}
 }
 

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3111,7 +3111,7 @@ void EditorPropertyNodePath::drop_data_fw(const Point2 &p_point, const Variant &
 }
 
 bool EditorPropertyNodePath::is_drop_valid(const Dictionary &p_drag_data) const {
-	if (!p_drag_data.has("type") || p_drag_data["type"] != "nodes") {
+	if (!p_drag_data.has("type") || String(p_drag_data["type"]) != "nodes") {
 		return false;
 	}
 	Array nodes = p_drag_data["nodes"];

--- a/editor/inspector/multi_node_edit.cpp
+++ b/editor/inspector/multi_node_edit.cpp
@@ -53,7 +53,7 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 	}
 
 	Node *node_path_target = nullptr;
-	if (p_value.get_type() == Variant::NODE_PATH && p_value != NodePath()) {
+	if (p_value.get_type() == Variant::NODE_PATH && !NodePath(p_value).is_empty()) {
 		node_path_target = es->get_node(p_value);
 	}
 

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -923,7 +923,7 @@ void ProjectDialog::show_dialog(bool p_reset_name, bool p_is_confirmed) {
 					List<BaseButton *> buttons;
 					renderer_button_group->get_buttons(&buttons);
 					for (BaseButton *button : buttons) {
-						if (button->get_meta(SNAME("rendering_method")) == "gl_compatibility") {
+						if (String(button->get_meta(SNAME("rendering_method"))) == "gl_compatibility") {
 							button->set_pressed(true);
 							break;
 						}

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -297,7 +297,7 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 		migration_guide_button->set_button_icon(get_editor_theme_icon("ExternalLink"));
 
 		// Asset library popup.
-		if (asset_library && EDITOR_GET("interface/theme/style") == "Classic") {
+		if (asset_library && String(EDITOR_GET("interface/theme/style")) == "Classic") {
 			// Removes extra border margins.
 			asset_library->add_theme_style_override(SceneStringName(panel), memnew(StyleBoxEmpty));
 		}

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -353,7 +353,7 @@ void TileMapLayerEditorTilesPlugin::_patterns_item_list_gui_input(const Ref<Inpu
 void TileMapLayerEditorTilesPlugin::_pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Texture2D> p_texture) {
 	// TODO optimize ?
 	for (int i = 0; i < patterns_item_list->get_item_count(); i++) {
-		if (patterns_item_list->get_item_metadata(i) == p_pattern) {
+		if (Ref<TileMapPattern>(patterns_item_list->get_item_metadata(i)) == p_pattern) {
 			patterns_item_list->set_item_icon(i, p_texture);
 			break;
 		}

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -429,7 +429,7 @@ void TileSetEditor::_patterns_item_list_gui_input(const Ref<InputEvent> &p_event
 void TileSetEditor::_pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Texture2D> p_texture) {
 	// TODO optimize ?
 	for (int i = 0; i < patterns_item_list->get_item_count(); i++) {
-		if (patterns_item_list->get_item_metadata(i) == p_pattern) {
+		if (Ref<TileMapPattern>(patterns_item_list->get_item_metadata(i)) == p_pattern) {
 			patterns_item_list->set_item_icon(i, p_texture);
 			break;
 		}

--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -3952,7 +3952,7 @@ void ThemeEditor::_notification(int p_what) {
 			theme_edit_button->set_button_icon(get_editor_theme_icon(SNAME("Tools")));
 			theme_close_button->set_button_icon(get_editor_theme_icon(SNAME("Close")));
 
-			if (EDITOR_GET("interface/theme/style") == "Classic") {
+			if (String(EDITOR_GET("interface/theme/style")) == "Classic") {
 				preview_tabs->add_theme_style_override("tab_selected", get_theme_stylebox(SNAME("ThemeEditorPreviewFG"), EditorStringName(EditorStyles)));
 				preview_tabs->add_theme_style_override("tab_unselected", get_theme_stylebox(SNAME("ThemeEditorPreviewBG"), EditorStringName(EditorStyles)));
 				preview_tabs_content->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("TabContainerOdd")));

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -708,7 +708,7 @@ void SceneTreeEditor::_node_visibility_changed(Node *p_node) {
 	}
 
 	TreeItem *item;
-	if (I->value.item && I->value.item->get_metadata(0) == p_node->get_path()) {
+	if (I->value.item && NodePath(I->value.item->get_metadata(0)) == p_node->get_path()) {
 		item = I->value.item;
 	} else {
 		item = _find(tree->get_root(), p_node->get_path());

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -2214,7 +2214,7 @@ bool ScriptTextEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_
 }
 
 static Node *_find_script_node(Node *p_current_node, const Ref<Script> &script) {
-	if (p_current_node->get_script() == script) {
+	if (Ref<Script>(p_current_node->get_script()) == script) {
 		return p_current_node;
 	}
 
@@ -2560,7 +2560,7 @@ Vector<ObjectID> ScriptTextEditor::_get_objects_for_export_assignment() const {
 		MultiNodeEdit *multi_node_edit = Object::cast_to<MultiNodeEdit>(edited_object);
 
 		if (node_edit != nullptr) {
-			if (node_edit->get_script() == script) {
+			if (Ref<Script>(node_edit->get_script()) == script) {
 				objects.push_back(node_edit->get_instance_id());
 			}
 		} else if (multi_node_edit != nullptr) {
@@ -2568,7 +2568,7 @@ Vector<ObjectID> ScriptTextEditor::_get_objects_for_export_assignment() const {
 			for (int i = 0; i < multi_node_edit->get_node_count(); i++) {
 				NodePath np = multi_node_edit->get_node(i);
 				Node *node = es->get_node(np);
-				if (node->get_script() == script) {
+				if (Ref<Script>(node->get_script()) == script) {
 					objects.push_back(node->get_instance_id());
 				}
 			}

--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -295,12 +295,12 @@ bool ActionMapEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 	}
 
 	// Don't allow moving an action in-between events.
-	if (d["input_type"] == "action" && item->has_meta("__event")) {
+	if (String(d["input_type"]) == "action" && item->has_meta("__event")) {
 		return false;
 	}
 
 	// Don't allow moving an event to a different action.
-	if (d["input_type"] == "event" && item->get_parent() != selected->get_parent()) {
+	if (String(d["input_type"]) == "event" && item->get_parent() != selected->get_parent()) {
 		return false;
 	}
 
@@ -321,13 +321,13 @@ void ActionMapEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 	bool drop_above = ((p_point == Vector2(Math::INF, Math::INF)) ? action_tree->get_drop_section_at_position(action_tree->get_item_rect(target).position) : action_tree->get_drop_section_at_position(p_point)) == -1;
 
 	Dictionary d = p_data;
-	if (d["input_type"] == "action") {
+	if (String(d["input_type"]) == "action") {
 		// Change action order.
 		String relative_to = target->get_meta("__name");
 		String action_name = selected->get_meta("__name");
 		emit_signal(SNAME("action_reordered"), action_name, relative_to, drop_above);
 
-	} else if (d["input_type"] == "event") {
+	} else if (String(d["input_type"]) == "event") {
 		// Change event order
 		int current_index = selected->get_meta("__index");
 		int target_index = target->get_meta("__index");

--- a/editor/settings/editor_feature_profile.cpp
+++ b/editor/settings/editor_feature_profile.cpp
@@ -906,7 +906,7 @@ void EditorFeatureProfileManager::set_current_profile(const String &p_profile_na
 		// Change profile selection to emulate the UI interaction. Otherwise, the wrong profile would get activated.
 		// FIXME: Ideally, _update_selected_profile() should not rely on the user interface state to function properly.
 		for (int i = 0; i < profile_list->get_item_count(); i++) {
-			if (profile_list->get_item_metadata(i) == p_profile_name) {
+			if (String(profile_list->get_item_metadata(i)) == p_profile_name) {
 				profile_list->select(i);
 				break;
 			}

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -1820,7 +1820,7 @@ void VisualShaderEditor::_update_custom_script(const Ref<Script> &p_script) {
 						continue;
 					}
 					Ref<VisualShaderNodeCustom> custom_node = vsnode;
-					if (custom_node.is_null() || custom_node->get_script() != p_script) {
+					if (custom_node.is_null() || Ref<Script>(custom_node->get_script()) != p_script) {
 						continue;
 					}
 					need_rebuild = true;
@@ -1932,7 +1932,7 @@ void VisualShaderEditor::_resources_removed() {
 								continue;
 							}
 							Ref<VisualShaderNodeCustom> custom_node = vsnode;
-							if (custom_node.is_null() || custom_node->get_script() != scr) {
+							if (custom_node.is_null() || Ref<Script>(custom_node->get_script()) != scr) {
 								continue;
 							}
 							visual_shader->remove_node(type, node_id);
@@ -2275,7 +2275,7 @@ void VisualShaderEditor::_update_options_menu() {
 	Color unsupported_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
 	Color supported_color = get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
 
-	static bool low_driver = GLOBAL_GET("rendering/renderer/rendering_method") == "gl_compatibility";
+	static bool low_driver = String(GLOBAL_GET("rendering/renderer/rendering_method")) == "gl_compatibility";
 
 	HashMap<String, TreeItem *> folders;
 

--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -558,7 +558,7 @@ bool LocalizationEditor::can_drop_data_fw(const Point2 &p_point, const Variant &
 	ERR_FAIL_COND_V(trees.find(tree) == -1, false);
 
 	Dictionary drop_data = p_data;
-	return drop_data.get("type", "") == tree_data_types[tree];
+	return String(drop_data.get("type", "")) == tree_data_types[tree];
 }
 
 void LocalizationEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2084,7 +2084,7 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 							if (!_guess_expression_type(c, dn->elements[i].key, key)) {
 								continue;
 							}
-							if (key.value == String(subscript->attribute->name)) {
+							if (String(key.value) == subscript->attribute->name) {
 								r_type.assigned_expression = dn->elements[i].value;
 								found = _guess_expression_type(c, dn->elements[i].value, r_type);
 								break;

--- a/modules/gdscript/tests/test_completion.h
+++ b/modules/gdscript/tests/test_completion.h
@@ -53,16 +53,16 @@
 namespace GDScriptTests {
 
 static bool match_option(const Dictionary p_expected, const ScriptLanguage::CodeCompletionOption p_got) {
-	if (p_expected.get("display", p_got.display) != p_got.display) {
+	if (String(p_expected.get("display", p_got.display)) != p_got.display) {
 		return false;
 	}
-	if (p_expected.get("insert_text", p_got.insert_text) != p_got.insert_text) {
+	if (String(p_expected.get("insert_text", p_got.insert_text)) != p_got.insert_text) {
 		return false;
 	}
-	if (p_expected.get("kind", p_got.kind) != Variant(p_got.kind)) {
+	if (ScriptLanguage::CodeCompletionKind(p_expected.get("kind", p_got.kind)) != p_got.kind) {
 		return false;
 	}
-	if (p_expected.get("location", p_got.location) != Variant(p_got.location)) {
+	if (int(p_expected.get("location", p_got.location)) != p_got.location) {
 		return false;
 	}
 	return true;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4992,7 +4992,7 @@ NodePath GLTFDocument::_find_material_node_path(Ref<GLTFState> p_state, const Re
 	for (Ref<GLTFMesh> gltf_mesh : p_state->meshes) {
 		TypedArray<Material> materials = gltf_mesh->get_instance_materials();
 		for (int mat_index = 0; mat_index < materials.size(); mat_index++) {
-			if (materials[mat_index] == p_material) {
+			if (Ref<Material>(materials[mat_index]) == p_material) {
 				for (Ref<GLTFNode> gltf_node : p_state->nodes) {
 					if (gltf_node->mesh == mesh_index) {
 						NodePath node_path = gltf_node->get_scene_node_path(p_state);

--- a/modules/gltf/tests/test_gltf_extras.h
+++ b/modules/gltf/tests/test_gltf_extras.h
@@ -92,20 +92,20 @@ TEST_CASE("[SceneTree][Node] GLTF test mesh and material meta export and import"
 	// Compare the results.
 	CHECK(loaded->get_name() == "node3d");
 	CHECK(Dictionary(loaded->get_meta("extras")).size() == 1);
-	CHECK(Dictionary(loaded->get_meta("extras"))["node_type"] == "node3d");
+	CHECK(String(Dictionary(loaded->get_meta("extras"))["node_type"]) == "node3d");
 	CHECK_FALSE(loaded->has_meta("meta_not_nested_under_extras"));
 	CHECK_FALSE(Dictionary(loaded->get_meta("extras")).has("meta_not_nested_under_extras"));
 
 	MeshInstance3D *mesh_instance_3d = Object::cast_to<MeshInstance3D>(loaded->find_child("mesh_instance_3d", false, true));
 	CHECK(mesh_instance_3d->get_name() == "mesh_instance_3d");
-	CHECK(Dictionary(mesh_instance_3d->get_meta("extras"))["node_type"] == "mesh_instance_3d");
+	CHECK(String(Dictionary(mesh_instance_3d->get_meta("extras"))["node_type"]) == "mesh_instance_3d");
 
 	Ref<Mesh> mesh = mesh_instance_3d->get_mesh();
-	CHECK(Dictionary(mesh->get_meta("extras"))["node_type"] == "planemesh");
+	CHECK(String(Dictionary(mesh->get_meta("extras"))["node_type"]) == "planemesh");
 
 	Ref<Material> material = mesh->surface_get_material(0);
 	CHECK(material->get_name() == "material");
-	CHECK(Dictionary(material->get_meta("extras"))["node_type"] == "material");
+	CHECK(String(Dictionary(material->get_meta("extras"))["node_type"]) == "material");
 
 	memdelete(original_mesh_instance);
 	memdelete(original);
@@ -161,9 +161,9 @@ TEST_CASE("[SceneTree][Node] GLTF test skeleton and bone export and import") {
 	CHECK(loaded->get_name() == "node3d");
 	Skeleton3D *result = Object::cast_to<Skeleton3D>(loaded->find_child("Skeleton3D", false, true));
 	CHECK(result->get_bone_name(0) == "parent");
-	CHECK(Dictionary(result->get_bone_meta(0, "extras"))["bone"] == "i_am_parent_bone");
+	CHECK(String(Dictionary(result->get_bone_meta(0, "extras"))["bone"]) == "i_am_parent_bone");
 	CHECK(result->get_bone_name(1) == "child");
-	CHECK(Dictionary(result->get_bone_meta(1, "extras"))["bone"] == "i_am_child_bone");
+	CHECK(String(Dictionary(result->get_bone_meta(1, "extras"))["bone"]) == "i_am_child_bone");
 
 	memdelete(skeleton);
 	memdelete(mesh);

--- a/modules/jsonrpc/tests/test_jsonrpc.cpp
+++ b/modules/jsonrpc/tests/test_jsonrpc.cpp
@@ -35,7 +35,7 @@
 namespace TestJSONRPC {
 
 void check_error_code(const Dictionary &p_dict, const JSONRPC::ErrorCode &p_code) {
-	CHECK(p_dict["jsonrpc"] == "2.0");
+	CHECK(String(p_dict["jsonrpc"]) == "2.0");
 	REQUIRE(p_dict.has("error"));
 	const Dictionary &err_body = p_dict["error"];
 	const int &code = err_body["code"];

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
@@ -877,7 +877,7 @@ void OpenXRSpatialAnchorCapability::_process_discovery_snapshot(RID p_snapshot) 
 	se_extension->free_spatial_snapshot(p_snapshot);
 
 	// And if this was our discovery snapshot, let's reset it.
-	if (discovery_query_result.is_valid() && discovery_query_result->get_result_value() == p_snapshot) {
+	if (discovery_query_result.is_valid() && RID(discovery_query_result->get_result_value()) == p_snapshot) {
 		discovery_query_result.unref();
 	}
 }

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
@@ -782,7 +782,7 @@ void OpenXRSpatialMarkerTrackingCapability::_process_snapshot(RID p_snapshot, bo
 	se_extension->free_spatial_snapshot(p_snapshot);
 
 	// And if this was our discovery snapshot, let's reset it.
-	if (p_is_discovery && discovery_query_result.is_valid() && discovery_query_result->get_result_value() == p_snapshot) {
+	if (p_is_discovery && discovery_query_result.is_valid() && RID(discovery_query_result->get_result_value()) == p_snapshot) {
 		discovery_query_result.unref();
 	}
 }

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
@@ -873,7 +873,7 @@ void OpenXRSpatialPlaneTrackingCapability::_process_snapshot(RID p_snapshot) {
 	se_extension->free_spatial_snapshot(p_snapshot);
 
 	// And if this was our discovery snapshot, lets reset it
-	if (discovery_query_result.is_valid() && discovery_query_result->get_result_value() == p_snapshot) {
+	if (discovery_query_result.is_valid() && RID(discovery_query_result->get_result_value()) == p_snapshot) {
 		discovery_query_result.unref();
 	}
 }

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -5417,7 +5417,7 @@ bool TextServerAdvanced::_shape_substr(ShapedTextDataAdvanced *p_new_sd, const S
 							if (index == 0) { // Try other fonts in the span.
 								const ShapedTextDataAdvanced::Span &span = p_sd->spans[gl.span_index + p_new_sd->first_span];
 								for (int k = 0; k < span.fonts.size(); k++) {
-									if (span.fonts[k] != gl.font_rid) {
+									if (RID(span.fonts[k]) != gl.font_rid) {
 										index = font_get_glyph_index(span.fonts[k], gl.font_size, 0x00ad, 0);
 										if (index != 0) {
 											gl.font_rid = span.fonts[k];

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2872,7 +2872,7 @@ bool EditorExportPlatformAndroid::has_valid_export_configuration(const Ref<Edito
 		bool rvalid = false;
 		bool has_export_templates = false;
 
-		if (p_preset->get("custom_template/debug") != "") {
+		if (String(p_preset->get("custom_template/debug")) != "") {
 			dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
 			if (!dvalid) {
 				template_err += TTR("Custom debug template not found.") + "\n";
@@ -2882,7 +2882,7 @@ bool EditorExportPlatformAndroid::has_valid_export_configuration(const Ref<Edito
 			has_export_templates |= exists_export_template("android_debug.apk", &template_err);
 		}
 
-		if (p_preset->get("custom_template/release") != "") {
+		if (String(p_preset->get("custom_template/release")) != "") {
 			rvalid = FileAccess::exists(p_preset->get("custom_template/release"));
 			if (!rvalid) {
 				template_err += TTR("Custom release template not found.") + "\n";

--- a/platform/ios/display_layer_ios.mm
+++ b/platform/ios/display_layer_ios.mm
@@ -93,7 +93,7 @@
 			nil];
 
 	// Create GL ES 3 context
-	if (GLOBAL_GET("rendering/renderer/rendering_method") == "gl_compatibility") {
+	if (String(GLOBAL_GET("rendering/renderer/rendering_method")) == "gl_compatibility") {
 		context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
 		NSLog(@"Setting up an OpenGL ES 3.0 context.");
 		if (!context) {

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -3499,7 +3499,7 @@ void DisplayServerX11::cursor_set_custom_image(const Ref<Resource> &p_cursor, Cu
 		HashMap<CursorShape, Vector<Variant>>::Iterator cursor_c = cursors_cache.find(p_shape);
 
 		if (cursor_c) {
-			if (cursor_c->value[0] == p_cursor && cursor_c->value[1] == p_hotspot) {
+			if (Ref<Resource>(cursor_c->value[0]) == p_cursor && Vector2(cursor_c->value[1]) == p_hotspot) {
 				cursor_set_shape(p_shape);
 				return;
 			}

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3020,7 +3020,7 @@ void DisplayServerMacOS::cursor_set_custom_image(const Ref<Resource> &p_cursor, 
 		HashMap<CursorShape, Vector<Variant>>::Iterator cursor_c = cursors_cache.find(p_shape);
 
 		if (cursor_c) {
-			if (cursor_c->value[0] == p_cursor && cursor_c->value[1] == p_hotspot) {
+			if (Ref<Resource>(cursor_c->value[0]) == p_cursor && Vector2(cursor_c->value[1]) == p_hotspot) {
 				cursor_set_shape(p_shape);
 				return;
 			}

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -89,7 +89,7 @@ String EditorExportPlatformMacOS::get_export_option_warning(const EditorExportPr
 			} break;
 #ifdef MACOS_ENABLED
 			case 3: { // "codesign"
-				ad_hoc = (p_preset->get("codesign/identity") == "" || p_preset->get("codesign/identity") == "-");
+				ad_hoc = (String(p_preset->get("codesign/identity")) == "" || String(p_preset->get("codesign/identity")) == "-");
 			} break;
 #endif
 			default: {
@@ -1040,11 +1040,11 @@ Error EditorExportPlatformMacOS::_notarize(const Ref<EditorExportPreset> &p_pres
 
 			args.push_back("notary-submit");
 
-			if (p_preset->get_or_env("notarization/api_uuid", ENV_MAC_NOTARIZATION_UUID) == "") {
+			if (String(p_preset->get_or_env("notarization/api_uuid", ENV_MAC_NOTARIZATION_UUID)) == "") {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Notarization"), TTR("App Store Connect issuer ID name not specified."));
 				return Error::FAILED;
 			}
-			if (p_preset->get_or_env("notarization/api_key", ENV_MAC_NOTARIZATION_KEY) == "") {
+			if (String(p_preset->get_or_env("notarization/api_key", ENV_MAC_NOTARIZATION_KEY)) == "") {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Notarization"), TTR("App Store Connect API key ID not specified."));
 				return Error::FAILED;
 			}
@@ -1104,17 +1104,17 @@ Error EditorExportPlatformMacOS::_notarize(const Ref<EditorExportPreset> &p_pres
 
 			args.push_back(p_path);
 
-			if (p_preset->get_or_env("notarization/apple_id_name", ENV_MAC_NOTARIZATION_APPLE_ID) == "" && p_preset->get_or_env("notarization/api_uuid", ENV_MAC_NOTARIZATION_UUID) == "") {
+			if (String(p_preset->get_or_env("notarization/apple_id_name", ENV_MAC_NOTARIZATION_APPLE_ID)) == "" && p_preset->get_or_env("notarization/api_uuid", ENV_MAC_NOTARIZATION_UUID) == Variant("")) {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Notarization"), TTR("Neither Apple ID name nor App Store Connect issuer ID name not specified."));
 				return Error::FAILED;
 			}
-			if (p_preset->get_or_env("notarization/apple_id_name", ENV_MAC_NOTARIZATION_APPLE_ID) != "" && p_preset->get_or_env("notarization/api_uuid", ENV_MAC_NOTARIZATION_UUID) != "") {
+			if (String(p_preset->get_or_env("notarization/apple_id_name", ENV_MAC_NOTARIZATION_APPLE_ID)) != "" && p_preset->get_or_env("notarization/api_uuid", ENV_MAC_NOTARIZATION_UUID) != Variant("")) {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Notarization"), TTR("Both Apple ID name and App Store Connect issuer ID name are specified, only one should be set at the same time."));
 				return Error::FAILED;
 			}
 
-			if (p_preset->get_or_env("notarization/apple_id_name", ENV_MAC_NOTARIZATION_APPLE_ID) != "") {
-				if (p_preset->get_or_env("notarization/apple_id_password", ENV_MAC_NOTARIZATION_APPLE_PASS) == "") {
+			if (String(p_preset->get_or_env("notarization/apple_id_name", ENV_MAC_NOTARIZATION_APPLE_ID)) != "") {
+				if (String(p_preset->get_or_env("notarization/apple_id_password", ENV_MAC_NOTARIZATION_APPLE_PASS)) == "") {
 					add_message(EXPORT_MESSAGE_ERROR, TTR("Notarization"), TTR("Apple ID password not specified."));
 					return Error::FAILED;
 				}
@@ -1124,7 +1124,7 @@ Error EditorExportPlatformMacOS::_notarize(const Ref<EditorExportPreset> &p_pres
 				args.push_back("--password");
 				args.push_back(p_preset->get_or_env("notarization/apple_id_password", ENV_MAC_NOTARIZATION_APPLE_PASS));
 			} else {
-				if (p_preset->get_or_env("notarization/api_key_id", ENV_MAC_NOTARIZATION_KEY_ID) == "") {
+				if (String(p_preset->get_or_env("notarization/api_key_id", ENV_MAC_NOTARIZATION_KEY_ID)) == "") {
 					add_message(EXPORT_MESSAGE_ERROR, TTR("Notarization"), TTR("App Store Connect API key ID not specified."));
 					return Error::FAILED;
 				}
@@ -1257,7 +1257,7 @@ void EditorExportPlatformMacOS::_code_sign(const Ref<EditorExportPreset> &p_pres
 				return;
 			}
 
-			bool ad_hoc = (p_preset->get("codesign/identity") == "" || p_preset->get("codesign/identity") == "-");
+			bool ad_hoc = (String(p_preset->get("codesign/identity")) == "" || String(p_preset->get("codesign/identity")) == "-");
 
 			List<String> args;
 			if (!ad_hoc) {
@@ -1985,9 +1985,9 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		if (file == "Contents/Resources/icon.icns") {
 			// See if there is an icon.
 			String icon_path;
-			if (p_preset->get("application/icon") != "") {
+			if (String(p_preset->get("application/icon")) != "") {
 				icon_path = p_preset->get("application/icon");
-			} else if (get_project_setting(p_preset, "application/config/macos_native_icon") != "") {
+			} else if (String(get_project_setting(p_preset, "application/config/macos_native_icon")) != "") {
 				icon_path = get_project_setting(p_preset, "application/config/macos_native_icon");
 			} else {
 				icon_path = get_project_setting(p_preset, "application/config/icon");
@@ -2087,7 +2087,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 			} break;
 #ifdef MACOS_ENABLED
 			case 3: { // "codesign"
-				ad_hoc = (p_preset->get("codesign/identity") == "" || p_preset->get("codesign/identity") == "-");
+				ad_hoc = (String(p_preset->get("codesign/identity")) == "" || String(p_preset->get("codesign/identity")) == "-");
 			} break;
 #endif
 			default: {
@@ -2461,13 +2461,13 @@ bool EditorExportPlatformMacOS::has_valid_export_configuration(const Ref<EditorE
 	bool dvalid = exists_export_template("macos.zip", &err);
 	bool rvalid = dvalid; // Both in the same ZIP.
 
-	if (p_preset->get("custom_template/debug") != "") {
+	if (p_preset->get("custom_template/debug") != Variant("")) {
 		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
 		if (!dvalid) {
 			err += TTR("Custom debug template not found.") + "\n";
 		}
 	}
-	if (p_preset->get("custom_template/release") != "") {
+	if (p_preset->get("custom_template/release") != Variant("")) {
 		rvalid = FileAccess::exists(p_preset->get("custom_template/release"));
 		if (!rvalid) {
 			err += TTR("Custom release template not found.") + "\n";
@@ -2518,7 +2518,7 @@ bool EditorExportPlatformMacOS::has_valid_project_configuration(const Ref<Editor
 		} break;
 #ifdef MACOS_ENABLED
 		case 3: { // "codesign"
-			ad_hoc = (p_preset->get("codesign/identity") == "" || p_preset->get("codesign/identity") == "-");
+			ad_hoc = (p_preset->get("codesign/identity") == Variant("") || p_preset->get("codesign/identity") == Variant("-"));
 		} break;
 #endif
 		default: {

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -435,13 +435,13 @@ bool EditorExportPlatformWeb::has_valid_export_configuration(const Ref<EditorExp
 	bool dvalid = exists_export_template(_get_template_name(extensions, thread_support, true), &err);
 	bool rvalid = exists_export_template(_get_template_name(extensions, thread_support, false), &err);
 
-	if (p_preset->get("custom_template/debug") != "") {
+	if (String(p_preset->get("custom_template/debug")) != "") {
 		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
 		if (!dvalid) {
 			err += TTR("Custom debug template not found.") + "\n";
 		}
 	}
-	if (p_preset->get("custom_template/release") != "") {
+	if (String(p_preset->get("custom_template/release")) != "") {
 		rvalid = FileAccess::exists(p_preset->get("custom_template/release"));
 		if (!rvalid) {
 			err += TTR("Custom release template not found.") + "\n";

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3051,7 +3051,7 @@ void DisplayServerWindows::cursor_set_custom_image(const Ref<Resource> &p_cursor
 		RBMap<CursorShape, Vector<Variant>>::Element *cursor_c = cursors_cache.find(p_shape);
 
 		if (cursor_c) {
-			if (cursor_c->get()[0] == p_cursor && cursor_c->get()[1] == p_hotspot) {
+			if (Ref<Resource>(cursor_c->get()[0]) == p_cursor && Vector2(cursor_c->get()[1]) == p_hotspot) {
 				cursor_set_shape(p_shape);
 				return;
 			}

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -507,9 +507,9 @@ void EditorExportPlatformWindows::get_export_options(List<ExportOption> *r_optio
 
 Error EditorExportPlatformWindows::_add_data(const Ref<EditorExportPreset> &p_preset, const String &p_path, bool p_console_icon) {
 	String icon_path;
-	if (p_preset->get("application/icon") != "") {
+	if (String(p_preset->get("application/icon")) != "") {
 		icon_path = p_preset->get("application/icon");
-	} else if (get_project_setting(p_preset, "application/config/windows_native_icon") != "") {
+	} else if (String(get_project_setting(p_preset, "application/config/windows_native_icon")) != "") {
 		icon_path = get_project_setting(p_preset, "application/config/windows_native_icon");
 	} else {
 		icon_path = get_project_setting(p_preset, "application/config/icon");
@@ -571,7 +571,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 	if (id_type == 0) { //auto select
 		args.push_back("/a");
 	} else if (id_type == 1) { //pkcs12
-		if (p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID) != "") {
+		if (String(p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID)) != "") {
 			args.push_back("/f");
 			args.push_back(p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID));
 		} else {
@@ -579,7 +579,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 			return FAILED;
 		}
 	} else if (id_type == 2) { //Windows certificate store
-		if (p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID) != "") {
+		if (String(p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID)) != "") {
 			args.push_back("/sha1");
 			args.push_back(p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID));
 		} else {
@@ -592,7 +592,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 	}
 #else
 	int id_type = 1;
-	if (p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID) != "") {
+	if (String(p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID)) != "") {
 		args.push_back("-pkcs12");
 		args.push_back(p_preset->get_or_env("codesign/identity", ENV_WIN_CODESIGN_ID));
 	} else {
@@ -602,7 +602,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 #endif
 
 	//password
-	if ((id_type == 1) && (p_preset->get_or_env("codesign/password", ENV_WIN_CODESIGN_PASS) != "")) {
+	if (id_type == 1 && String(p_preset->get_or_env("codesign/password", ENV_WIN_CODESIGN_PASS)) != "") {
 #ifdef WINDOWS_ENABLED
 		args.push_back("/p");
 #else
@@ -613,7 +613,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 
 	//timestamp
 	if (p_preset->get("codesign/timestamp")) {
-		if (p_preset->get("codesign/timestamp_server") != "") {
+		if (String(p_preset->get("codesign/timestamp_server")) != "") {
 #ifdef WINDOWS_ENABLED
 			args.push_back("/tr");
 			args.push_back(p_preset->get("codesign/timestamp_server_url"));
@@ -646,7 +646,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 	}
 
 	//description
-	if (p_preset->get("codesign/description") != "") {
+	if (String(p_preset->get("codesign/description")) != "") {
 #ifdef WINDOWS_ENABLED
 		args.push_back("/d");
 #else

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1724,7 +1724,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 							start_ofs += time - a->track_get_key_time(i, idx);
 						}
 
-						if (t_obj->call(SNAME("get_stream")) != t->audio_stream) {
+						if (Ref<AudioStreamPolyphonic>(t_obj->call(SNAME("get_stream"))) != t->audio_stream) {
 							t_obj->call(SNAME("set_stream"), t->audio_stream);
 							t->audio_stream_playback.unref();
 							if (!playing_audio_stream_players.has(asp)) {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -467,7 +467,7 @@ void FileDialog::_action_pressed() {
 		int selected = _get_selected_file_idx();
 		if (selected > -1) {
 			Dictionary d = file_list->get_item_metadata(selected);
-			if (d["dir"] && d["name"] != "..") {
+			if (d["dir"] && String(d["name"]) != "..") {
 				path = path.path_join(d["name"]);
 			}
 		}

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -8113,7 +8113,7 @@ Ref<RichTextEffect> RichTextLabel::_get_custom_effect_by_code(String p_bbcode_id
 			continue;
 		}
 
-		if (effect->get_bbcode() == p_bbcode_identifier) {
+		if (String(effect->get_bbcode()) == p_bbcode_identifier) {
 			return effect;
 		}
 	}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6847,7 +6847,7 @@ void TextEdit::merge_gutters(int p_from_line, int p_to_line) {
 			text.set_line_gutter_item_color(p_to_line, i, text.get_line_gutter_item_color(p_from_line, i));
 		}
 
-		if (text.get_line_gutter_metadata(p_from_line, i) != "") {
+		if (String(text.get_line_gutter_metadata(p_from_line, i)) != "") {
 			text.set_line_gutter_metadata(p_to_line, i, text.get_line_gutter_metadata(p_from_line, i));
 		}
 

--- a/scene/main/scene_tree_fti.cpp
+++ b/scene/main/scene_tree_fti.cpp
@@ -762,7 +762,7 @@ SceneTreeFTI::SceneTreeFTI() {
 	_tests = memnew(SceneTreeFTITests(*this));
 #endif
 
-	Variant traversal_mode_string = GLOBAL_DEF("physics/3d/physics_interpolation/scene_traversal", "DEFAULT");
+	String traversal_mode_string = GLOBAL_DEF("physics/3d/physics_interpolation/scene_traversal", "DEFAULT");
 	ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, "physics/3d/physics_interpolation/scene_traversal", PROPERTY_HINT_ENUM, "DEFAULT,Legacy,Debug"));
 
 	data.traversal_mode = TM_DEFAULT;

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -49,7 +49,7 @@ bool PropertyUtils::is_property_value_different(const Object *p_object, const Va
 		const Node *base_node = Object::cast_to<Node>(p_object);
 		const Node *target_node = Object::cast_to<Node>(p_b);
 		if (base_node && target_node) {
-			return p_a != base_node->get_path_to(target_node);
+			return NodePath(p_a) != base_node->get_path_to(target_node);
 		}
 	}
 
@@ -62,7 +62,7 @@ bool PropertyUtils::is_property_value_different(const Object *p_object, const Va
 			// Like above, but NodePaths/Nodes are inside arrays.
 			for (int i = 0; i < array1.size(); i++) {
 				const Node *target_node = Object::cast_to<Node>(array2[i]);
-				if (!target_node || array1[i] != base_node->get_path_to(target_node)) {
+				if (!target_node || NodePath(array1[i]) != base_node->get_path_to(target_node)) {
 					return true;
 				}
 			}

--- a/servers/xr/xr_server.cpp
+++ b/servers/xr/xr_server.cpp
@@ -331,7 +331,7 @@ void XRServer::add_tracker(const Ref<XRTracker> &p_tracker) {
 
 	StringName tracker_name = p_tracker->get_tracker_name();
 	if (trackers.has(tracker_name)) {
-		if (trackers[tracker_name] != p_tracker) {
+		if (Ref<XRTracker>(trackers[tracker_name]) != p_tracker) {
 			// We already have a tracker with this name, we're going to replace it
 			trackers[tracker_name] = p_tracker;
 			emit_signal(SNAME("tracker_updated"), tracker_name, p_tracker->get_tracker_type());

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -83,8 +83,8 @@ TEST_CASE("[JSON] Stringify arrays") {
 	CHECK(JSON::stringify(non_finite_array) == "[1e99999,-1e99999,null]");
 
 	Array non_finite_round_trip = JSON::parse_string(JSON::stringify(non_finite_array));
-	CHECK(non_finite_round_trip[0] == Variant(Math::INF));
-	CHECK(non_finite_round_trip[1] == Variant(-Math::INF));
+	CHECK(double(non_finite_round_trip[0]) == Math::INF);
+	CHECK(double(non_finite_round_trip[1]) == -Math::INF);
 	CHECK(non_finite_round_trip[2].get_type() == Variant::NIL);
 
 	Array self_array;
@@ -132,8 +132,8 @@ TEST_CASE("[JSON] Stringify dictionaries") {
 	CHECK(JSON::stringify(non_finite_dictionary) == "{\"-inf\":-1e99999,\"inf\":1e99999,\"nan\":null}");
 
 	Dictionary non_finite_round_trip = JSON::parse_string(JSON::stringify(non_finite_dictionary));
-	CHECK(non_finite_round_trip["-inf"] == Variant(-Math::INF));
-	CHECK(non_finite_round_trip["inf"] == Variant(Math::INF));
+	CHECK(double(non_finite_round_trip["-inf"]) == -Math::INF);
+	CHECK(double(non_finite_round_trip["inf"]) == Math::INF);
 	CHECK(non_finite_round_trip["nan"].get_type() == Variant::NIL);
 
 	Dictionary self_dictionary;
@@ -205,7 +205,7 @@ TEST_CASE("[JSON] Parsing single data types") {
 			json.get_error_line() == 0,
 			"Parsing a double quoted string as JSON should parse successfully.");
 	CHECK_MESSAGE(
-			json.get_data() == "hello",
+			String(json.get_data()) == "hello",
 			"Parsing a double quoted string as JSON should return the expected value.");
 }
 
@@ -220,21 +220,21 @@ TEST_CASE("[JSON] Parsing arrays") {
 			json.get_error_line() == 0,
 			"Parsing a JSON array should parse successfully.");
 	CHECK_MESSAGE(
-			array[0] == "Hello",
+			String(array[0]) == "Hello",
 			"The parsed JSON should contain the expected values.");
 	const Array sub_array = array[3];
 	CHECK_MESSAGE(
 			sub_array.size() == 4,
 			"The parsed JSON should contain the expected values.");
 	CHECK_MESSAGE(
-			sub_array[1] == "json",
+			String(sub_array[1]) == "json",
 			"The parsed JSON should contain the expected values.");
 	CHECK_MESSAGE(
 			sub_array[3].hash() == Array().hash(),
 			"The parsed JSON should contain the expected values.");
 	const Array deep_array = Array(Array(array[5])[0])[0];
 	CHECK_MESSAGE(
-			deep_array[0] == "Gotcha!",
+			String(deep_array[0]) == "Gotcha!",
 			"The parsed JSON should contain the expected values.");
 }
 
@@ -245,7 +245,7 @@ TEST_CASE("[JSON] Parsing objects (dictionaries)") {
 
 	const Dictionary dictionary = json.get_data();
 	CHECK_MESSAGE(
-			dictionary["name"] == "Godot Engine",
+			String(dictionary["name"]) == "Godot Engine",
 			"The parsed JSON should contain the expected values.");
 	CHECK_MESSAGE(
 			dictionary["is_free"],

--- a/tests/core/io/test_resource.h
+++ b/tests/core/io/test_resource.h
@@ -524,8 +524,8 @@ TEST_CASE("[Resource] Duplication") {
 		}
 
 		// Ensure all the usages are of the same resource.
-		CHECK(((Dictionary)dupe_a[1]).get_key_at_index(0) == dupe_res);
-		CHECK(((Dictionary)dupe_a[1]).get_value_at_index(0) == dupe_res);
+		CHECK(Ref<Resource>(((Dictionary)dupe_a[1]).get_key_at_index(0)) == dupe_res);
+		CHECK(Ref<Resource>(((Dictionary)dupe_a[1]).get_value_at_index(0)) == dupe_res);
 	}
 }
 
@@ -547,10 +547,10 @@ TEST_CASE("[Resource] Saving and loading") {
 			loaded_resource_binary->get_name() == "Hello world",
 			"The loaded resource name should be equal to the expected value.");
 	CHECK_MESSAGE(
-			loaded_resource_binary->get_meta("ExampleMetadata") == Vector2i(40, 80),
+			Vector2i(loaded_resource_binary->get_meta("ExampleMetadata")) == Vector2i(40, 80),
 			"The loaded resource metadata should be equal to the expected value.");
 	CHECK_MESSAGE(
-			loaded_resource_binary->get_meta("string") == "The\nstring\nwith\nunnecessary\nline\n\t\\\nbreaks",
+			String(loaded_resource_binary->get_meta("string")) == "The\nstring\nwith\nunnecessary\nline\n\t\\\nbreaks",
 			"The loaded resource metadata should be equal to the expected value.");
 	const Ref<Resource> &loaded_child_resource_binary = loaded_resource_binary->get_meta("other_resource");
 	CHECK_MESSAGE(
@@ -562,10 +562,10 @@ TEST_CASE("[Resource] Saving and loading") {
 			loaded_resource_text->get_name() == "Hello world",
 			"The loaded resource name should be equal to the expected value.");
 	CHECK_MESSAGE(
-			loaded_resource_text->get_meta("ExampleMetadata") == Vector2i(40, 80),
+			Vector2i(loaded_resource_text->get_meta("ExampleMetadata")) == Vector2i(40, 80),
 			"The loaded resource metadata should be equal to the expected value.");
 	CHECK_MESSAGE(
-			loaded_resource_text->get_meta("string") == "The\nstring\nwith\nunnecessary\nline\n\t\\\nbreaks",
+			String(loaded_resource_text->get_meta("string")) == "The\nstring\nwith\nunnecessary\nline\n\t\\\nbreaks",
 			"The loaded resource metadata should be equal to the expected value.");
 	const Ref<Resource> &loaded_child_resource_text = loaded_resource_text->get_meta("other_resource");
 	CHECK_MESSAGE(

--- a/tests/core/io/test_stream_peer.h
+++ b/tests/core/io/test_stream_peer.h
@@ -186,7 +186,7 @@ TEST_CASE("[StreamPeer] Get and sets through StreamPeerBuffer") {
 		spb->put_var(value);
 		spb->seek(0);
 
-		CHECK_EQ(spb->get_var(), value);
+		CHECK_EQ(Array(spb->get_var()), value);
 	}
 }
 

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -191,7 +191,7 @@ TEST_CASE("[Object] Metadata") {
 			"Not conflicting meta on destination should be kept intact.");
 
 	CHECK_MESSAGE(
-			object.get_meta("other_meta", String()) == "other",
+			String(object.get_meta("other_meta")) == "other",
 			"Not conflicting meta name on source should merged.");
 
 	List<StringName> meta_list3;

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -1129,7 +1129,7 @@ TEST_CASE("[String] sprintf") {
 	// Vector2
 	format = "fish %v frog";
 	args.clear();
-	args.push_back(Variant(Vector2(19.99, 1.00)));
+	args.push_back(Vector2(19.99, 1.00));
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish (19.990000, 1.000000) frog"));
@@ -1137,7 +1137,7 @@ TEST_CASE("[String] sprintf") {
 	// Vector3
 	format = "fish %v frog";
 	args.clear();
-	args.push_back(Variant(Vector3(19.99, 1.00, -2.05)));
+	args.push_back(Vector3(19.99, 1.00, -2.05));
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish (19.990000, 1.000000, -2.050000) frog"));
@@ -1145,7 +1145,7 @@ TEST_CASE("[String] sprintf") {
 	// Vector4
 	format = "fish %v frog";
 	args.clear();
-	args.push_back(Variant(Vector4(19.99, 1.00, -2.05, 5.5)));
+	args.push_back(Vector4(19.99, 1.00, -2.05, 5.5));
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish (19.990000, 1.000000, -2.050000, 5.500000) frog"));
@@ -1153,7 +1153,7 @@ TEST_CASE("[String] sprintf") {
 	// Vector with negative values.
 	format = "fish %v frog";
 	args.clear();
-	args.push_back(Variant(Vector2(-19.99, -1.00)));
+	args.push_back(Vector2(-19.99, -1.00));
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish (-19.990000, -1.000000) frog"));
@@ -1161,7 +1161,7 @@ TEST_CASE("[String] sprintf") {
 	// Vector left-padded.
 	format = "fish %11v frog";
 	args.clear();
-	args.push_back(Variant(Vector3(19.99, 1.00, -2.05)));
+	args.push_back(Vector3(19.99, 1.00, -2.05));
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish (  19.990000,    1.000000,   -2.050000) frog"));
@@ -1169,7 +1169,7 @@ TEST_CASE("[String] sprintf") {
 	// Vector left-padded with inf/nan
 	format = "fish %11v frog";
 	args.clear();
-	args.push_back(Variant(Vector2(Math::INF, Math::NaN)));
+	args.push_back(Vector2(Math::INF, Math::NaN));
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish (        inf,         nan) frog"));
@@ -1177,7 +1177,7 @@ TEST_CASE("[String] sprintf") {
 	// Vector right-padded.
 	format = "fish %-11v frog";
 	args.clear();
-	args.push_back(Variant(Vector3(19.99, 1.00, -2.05)));
+	args.push_back(Vector3(19.99, 1.00, -2.05));
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish (19.990000  , 1.000000   , -2.050000  ) frog"));
@@ -1185,7 +1185,7 @@ TEST_CASE("[String] sprintf") {
 	// Vector left-padded with zeros.
 	format = "fish %011v frog";
 	args.clear();
-	args.push_back(Variant(Vector3(19.99, 1.00, -2.05)));
+	args.push_back(Vector3(19.99, 1.00, -2.05));
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish (0019.990000, 0001.000000, -002.050000) frog"));
@@ -1193,7 +1193,7 @@ TEST_CASE("[String] sprintf") {
 	// Vector given Vector3i.
 	format = "fish %v frog";
 	args.clear();
-	args.push_back(Variant(Vector3i(19, 1, -2)));
+	args.push_back(Vector3i(19, 1, -2));
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish (19.000000, 1.000000, -2.000000) frog"));
@@ -1201,7 +1201,7 @@ TEST_CASE("[String] sprintf") {
 	// Vector with 1 decimal.
 	format = "fish %.1v frog";
 	args.clear();
-	args.push_back(Variant(Vector3(19.99, 1.00, -2.05)));
+	args.push_back(Vector3(19.99, 1.00, -2.05));
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish (20.0, 1.0, -2.0) frog"));
@@ -1209,7 +1209,7 @@ TEST_CASE("[String] sprintf") {
 	// Vector with 12 decimals.
 	format = "fish %.12v frog";
 	args.clear();
-	args.push_back(Variant(Vector3(19.00, 1.00, -2.00)));
+	args.push_back(Vector3(19.00, 1.00, -2.00));
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish (19.000000000000, 1.000000000000, -2.000000000000) frog"));
@@ -1217,7 +1217,7 @@ TEST_CASE("[String] sprintf") {
 	// Vector with no decimals.
 	format = "fish %.v frog";
 	args.clear();
-	args.push_back(Variant(Vector3(19.99, 1.00, -2.05)));
+	args.push_back(Vector3(19.99, 1.00, -2.05));
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish (20, 1, -2) frog"));
@@ -2131,7 +2131,7 @@ TEST_CASE("[String] Variant validated indexed get") {
 	getter(&s, 1, &r, &oob);
 
 	CHECK_FALSE(oob);
-	CHECK_EQ(r, String("b"));
+	CHECK_EQ(String(r), "b");
 }
 
 TEST_CASE("[String] Variant ptr indexed get") {
@@ -2154,7 +2154,7 @@ TEST_CASE("[String] Variant indexed set") {
 
 	CHECK(valid);
 	CHECK_FALSE(oob);
-	CHECK_EQ(s, String("azcd"));
+	CHECK_EQ(String(s), "azcd");
 }
 
 TEST_CASE("[String] Variant validated indexed set") {
@@ -2167,7 +2167,7 @@ TEST_CASE("[String] Variant validated indexed set") {
 	setter(&s, 1, &v, &oob);
 
 	CHECK_FALSE(oob);
-	CHECK_EQ(s, String("azcd"));
+	CHECK_EQ(String(s), "azcd");
 }
 
 TEST_CASE("[String] Variant ptr indexed set") {

--- a/tests/core/templates/test_fixed_vector.h
+++ b/tests/core/templates/test_fixed_vector.h
@@ -94,8 +94,8 @@ TEST_CASE("[FixedVector] Basic Checks") {
 	vector_variant[1] = 1;
 	CHECK_EQ(vector_variant.capacity(), 3);
 	CHECK_EQ(vector_variant.size(), 3);
-	CHECK_EQ(vector_variant[0], "Test");
-	CHECK_EQ(vector_variant[1], Variant(1));
+	CHECK_EQ(String(vector_variant[0]), "Test");
+	CHECK_EQ(int32_t(vector_variant[1]), 1);
 	CHECK_EQ(vector_variant[2].get_type(), Variant::NIL);
 
 	// Test that move-only types are transferred.

--- a/tests/core/templates/test_list.h
+++ b/tests/core/templates/test_list.h
@@ -519,13 +519,13 @@ TEST_CASE("[List] Swap front and back (values check)") {
 	Variant color = Color(0, 0, 1);
 	List<Variant>::Element *n_color = list.push_back(color);
 
-	CHECK(list.front()->get() == "Godot");
-	CHECK(list.back()->get() == Color(0, 0, 1));
+	CHECK(String(list.front()->get()) == "Godot");
+	CHECK(Color(list.back()->get()) == Color(0, 0, 1));
 
 	list.swap(n_str, n_color);
 
-	CHECK(list.front()->get() == Color(0, 0, 1));
-	CHECK(list.back()->get() == "Godot");
+	CHECK(Color(list.front()->get()) == Color(0, 0, 1));
+	CHECK(String(list.back()->get()) == "Godot");
 }
 
 TEST_CASE("[List] Swap adjacent back and front (reverse order of elements)") {

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -82,17 +82,17 @@ TEST_CASE("[Dictionary] List init") {
 		{ Vector2(), "v2" },
 	};
 	CHECK(dict.size() == 4);
-	CHECK(dict[0] == "int");
+	CHECK(String(dict[0]) == "int");
 	CHECK(PackedStringArray(dict["packed_string_array"])[2] == "values");
 	CHECK(Dictionary(dict["key"])["nested"] == Variant(200));
-	CHECK(dict[Vector2()] == "v2");
+	CHECK(String(dict[Vector2()]) == "v2");
 
 	TypedDictionary<double, double> tdict{
 		{ 0.0, 1.0 },
 		{ 5.0, 2.0 },
 	};
-	CHECK_EQ(tdict[0.0], Variant(1.0));
-	CHECK_EQ(tdict[5.0], Variant(2.0));
+	CHECK_EQ(double(tdict[0.0]), 1.0);
+	CHECK_EQ(double(tdict[5.0]), 2.0);
 }
 
 TEST_CASE("[Dictionary] get_key_list()") {
@@ -594,7 +594,7 @@ TEST_CASE("[Dictionary] Order and find") {
 	Array keys = { 4, 8, 12, "4" };
 
 	CHECK_EQ(d.keys(), keys);
-	CHECK_EQ(d.find_key("four"), Variant(4));
+	CHECK_EQ(int32_t(d.find_key("four")), 4);
 	CHECK_EQ(d.find_key("does not exist"), Variant());
 }
 
@@ -661,17 +661,17 @@ TEST_CASE("[Dictionary] Typed copying") {
 	d4[0] = 3;
 
 	// Same typed TypedDictionary should be shared.
-	CHECK_EQ(d1[0], Variant(3));
-	CHECK_EQ(d3[0], Variant(3));
-	CHECK_EQ(d4[0], Variant(3));
+	CHECK_EQ(int(d1[0]), 3);
+	CHECK_EQ(int(d3[0]), 3);
+	CHECK_EQ(int(d4[0]), 3);
 
 	d5[0] = 2.0;
 	d6[0] = 3.0;
 
 	// Different typed TypedDictionary should not be shared.
-	CHECK_EQ(d2[0], Variant(2.0));
-	CHECK_EQ(d5[0], Variant(2.0));
-	CHECK_EQ(d6[0], Variant(3.0));
+	CHECK_EQ(double(d2[0]), 2.0);
+	CHECK_EQ(double(d5[0]), 2.0);
+	CHECK_EQ(double(d6[0]), 3.0);
 
 	d1.clear();
 	d2.clear();
@@ -730,8 +730,8 @@ TEST_CASE("[Dictionary] Object value init") {
 		{ 0.0, a },
 		{ 5.0, b },
 	};
-	CHECK_EQ(tdict[0.0], Variant(a));
-	CHECK_EQ(tdict[5.0], Variant(b));
+	CHECK_EQ(tdict[0.0].get_validated_object(), a);
+	CHECK_EQ(tdict[5.0].get_validated_object(), b);
 	memdelete(a);
 	memdelete(b);
 }
@@ -743,8 +743,8 @@ TEST_CASE("[Dictionary] RefCounted value init") {
 		{ 0.0, a },
 		{ 5.0, b },
 	};
-	CHECK_EQ(tdict[0.0], Variant(a));
-	CHECK_EQ(tdict[5.0], Variant(b));
+	CHECK_EQ(Ref<RefCounted>(tdict[0.0]), a);
+	CHECK_EQ(Ref<RefCounted>(tdict[5.0]), b);
 }
 
 } // namespace TestDictionary

--- a/tests/core/variant/test_variant_utility.h
+++ b/tests/core/variant/test_variant_utility.h
@@ -80,11 +80,11 @@ TEST_CASE("[VariantUtility] Type conversion") {
 
 		converted = VariantUtilityFunctions::type_convert(transform, Variant::Type::BASIS);
 		CHECK(converted.get_type() == Variant::Type::BASIS);
-		CHECK(converted == basis);
+		CHECK(converted == Variant(basis));
 
 		converted = VariantUtilityFunctions::type_convert(basis, Variant::Type::TRANSFORM3D);
 		CHECK(converted.get_type() == Variant::Type::TRANSFORM3D);
-		CHECK(converted == transform);
+		CHECK(converted == Variant(transform));
 
 		converted = VariantUtilityFunctions::type_convert(basis, Variant::Type::STRING);
 		CHECK(converted.get_type() == Variant::Type::STRING);
@@ -97,11 +97,11 @@ TEST_CASE("[VariantUtility] Type conversion") {
 
 		converted = VariantUtilityFunctions::type_convert(arr, Variant::Type::PACKED_FLOAT64_ARRAY);
 		CHECK(converted.get_type() == Variant::Type::PACKED_FLOAT64_ARRAY);
-		CHECK(converted == packed);
+		CHECK(converted == Variant(packed));
 
 		converted = VariantUtilityFunctions::type_convert(packed, Variant::Type::ARRAY);
 		CHECK(converted.get_type() == Variant::Type::ARRAY);
-		CHECK(converted == arr);
+		CHECK(converted == Variant(arr));
 	}
 
 	{

--- a/tests/scene/test_animation.h
+++ b/tests/scene/test_animation.h
@@ -58,12 +58,12 @@ TEST_CASE("[Animation] Create value track") {
 	CHECK(int(animation->track_get_key_value(0, 0)) == 0);
 	CHECK(int(animation->track_get_key_value(0, 1)) == 100);
 
-	CHECK(animation->value_track_interpolate(0, -0.2) == doctest::Approx(0.0));
-	CHECK(animation->value_track_interpolate(0, 0.0) == doctest::Approx(0.0));
-	CHECK(animation->value_track_interpolate(0, 0.2) == doctest::Approx(40.0));
-	CHECK(animation->value_track_interpolate(0, 0.4) == doctest::Approx(80.0));
-	CHECK(animation->value_track_interpolate(0, 0.5) == doctest::Approx(100.0));
-	CHECK(animation->value_track_interpolate(0, 0.6) == doctest::Approx(100.0));
+	CHECK((double)animation->value_track_interpolate(0, -0.2) == doctest::Approx(0.0));
+	CHECK((double)animation->value_track_interpolate(0, 0.0) == doctest::Approx(0.0));
+	CHECK((double)animation->value_track_interpolate(0, 0.2) == doctest::Approx(40.0));
+	CHECK((double)animation->value_track_interpolate(0, 0.4) == doctest::Approx(80.0));
+	CHECK((double)animation->value_track_interpolate(0, 0.5) == doctest::Approx(100.0));
+	CHECK((double)animation->value_track_interpolate(0, 0.6) == doctest::Approx(100.0));
 
 	CHECK(animation->track_get_key_transition(0, 0) == doctest::Approx(real_t(1.0)));
 	CHECK(animation->track_get_key_transition(0, 1) == doctest::Approx(real_t(1.0)));

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -3741,10 +3741,10 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 		auto_brace_completion_pairs["'''"] = "'''";
 		code_edit->set_auto_brace_completion_pairs(auto_brace_completion_pairs);
 		CHECK(code_edit->get_auto_brace_completion_pairs().size() == 4);
-		CHECK(code_edit->get_auto_brace_completion_pairs()["["] == "]");
-		CHECK(code_edit->get_auto_brace_completion_pairs()["'"] == "'");
-		CHECK(code_edit->get_auto_brace_completion_pairs()[";"] == "'");
-		CHECK(code_edit->get_auto_brace_completion_pairs()["'''"] == "'''");
+		CHECK((String)code_edit->get_auto_brace_completion_pairs()["["] == "]");
+		CHECK((String)code_edit->get_auto_brace_completion_pairs()["'"] == "'");
+		CHECK((String)code_edit->get_auto_brace_completion_pairs()[";"] == "'");
+		CHECK((String)code_edit->get_auto_brace_completion_pairs()["'''"] == "'''");
 
 		ERR_PRINT_OFF;
 
@@ -4081,11 +4081,11 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			/* Check data. */
 			Dictionary option = code_edit->get_code_completion_option(0);
 			CHECK((int)option["kind"] == (int)CodeEdit::CodeCompletionKind::KIND_CLASS);
-			CHECK(option["display_text"] == "item_0.");
-			CHECK(option["insert_text"] == "item_0");
-			CHECK(option["font_color"] == Color(1, 0, 0));
-			CHECK(option["icon"] == Ref<Resource>());
-			CHECK(option["default_value"] == Color(1, 0, 0));
+			CHECK((String)option["display_text"] == "item_0.");
+			CHECK((String)option["insert_text"] == "item_0");
+			CHECK((Color)option["font_color"] == Color(1, 0, 0));
+			CHECK((Ref<Resource>)option["icon"] == Ref<Resource>());
+			CHECK((Color)option["default_value"] == Color(1, 0, 0));
 
 			/* Set size for mouse input. */
 			code_edit->set_size(Size2(100, 100));

--- a/tests/scene/test_gltf_document.h
+++ b/tests/scene/test_gltf_document.h
@@ -169,8 +169,8 @@ void test_gltf_document_values(Ref<GLTFDocument> &p_gltf_document, Ref<GLTFState
 	}
 
 	CHECK(p_gltf_state->get_copyright() == p_test_case.copyright);
-	CHECK(((Dictionary)p_gltf_state->get_json()["asset"])["generator"] == p_test_case.generator);
-	CHECK(((Dictionary)p_gltf_state->get_json()["asset"])["version"] == p_test_case.version);
+	CHECK(String(((Dictionary)p_gltf_state->get_json()["asset"])["generator"]) == p_test_case.generator);
+	CHECK(String(((Dictionary)p_gltf_state->get_json()["asset"])["version"]) == p_test_case.version);
 }
 
 void test_gltf_save(Node *p_node) {

--- a/tests/scene/test_option_button.h
+++ b/tests/scene/test_option_button.h
@@ -142,7 +142,7 @@ TEST_CASE("[SceneTree][OptionButton] Many items") {
 		m["bool"] = true;
 		m["String"] = "yes";
 		test_opt->set_item_metadata(1, m);
-		CHECK(test_opt->get_item_metadata(1) == m);
+		CHECK(Dictionary(test_opt->get_item_metadata(1)) == m);
 
 		// item_tooltip.
 		test_opt->set_item_tooltip(0, "tooltip guide");

--- a/tests/scene/test_skeleton_3d.h
+++ b/tests/scene/test_skeleton_3d.h
@@ -44,13 +44,13 @@ TEST_CASE("[Skeleton3D] Test per-bone meta") {
 	// Adding meta to bone.
 	skeleton->set_bone_meta(0, "key1", "value1");
 	skeleton->set_bone_meta(0, "key2", 12345);
-	CHECK_MESSAGE(skeleton->get_bone_meta(0, "key1") == "value1", "Bone meta missing.");
-	CHECK_MESSAGE(skeleton->get_bone_meta(0, "key2") == Variant(12345), "Bone meta missing.");
+	CHECK_MESSAGE(String(skeleton->get_bone_meta(0, "key1")) == "value1", "Bone meta missing.");
+	CHECK_MESSAGE(int(skeleton->get_bone_meta(0, "key2")) == 12345, "Bone meta missing.");
 
 	// Rename bone and check if meta persists.
 	skeleton->set_bone_name(0, "renamed_root");
-	CHECK_MESSAGE(skeleton->get_bone_meta(0, "key1") == "value1", "Bone meta missing.");
-	CHECK_MESSAGE(skeleton->get_bone_meta(0, "key2") == Variant(12345), "Bone meta missing.");
+	CHECK_MESSAGE(String(skeleton->get_bone_meta(0, "key1")) == "value1", "Bone meta missing.");
+	CHECK_MESSAGE(int(skeleton->get_bone_meta(0, "key2")) == 12345, "Bone meta missing.");
 
 	// Retrieve list of keys.
 	List<StringName> keys;

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -2461,7 +2461,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
+			CHECK(String(text_edit->get_viewport()->gui_get_drag_data()) == "drag");
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 4);
@@ -2501,7 +2501,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "'drag'");
+			CHECK(String(text_edit->get_viewport()->gui_get_drag_data()) == "'drag'");
 			CHECK(text_edit->has_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 0).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			SEND_GUI_KEY_EVENT(Key::CMD_OR_CTRL);
@@ -2524,7 +2524,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection(true, 1));
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 12).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "test\nop");
+			CHECK(String(text_edit->get_viewport()->gui_get_drag_data()) == "test\nop");
 			// Carets aren't removed from dragging, only dropping.
 			CHECK(text_edit->get_caret_count() == 3);
 			CHECK(text_edit->has_selection(0));
@@ -2557,7 +2557,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "here");
+			CHECK(String(text_edit->get_viewport()->gui_get_drag_data()) == "here");
 			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "'drag' \ndr heretest\nop 'drag'");
@@ -2591,7 +2591,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
+			CHECK(String(text_edit->get_viewport()->gui_get_drag_data()) == "drag");
 			SEND_GUI_KEY_EVENT(Key::ESCAPE);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "'drag' \ndr heretest\nop 'drag'");
@@ -2607,7 +2607,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
+			CHECK(String(text_edit->get_viewport()->gui_get_drag_data()) == "drag");
 			SEND_GUI_KEY_EVENT(Key::RIGHT);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "'drag' \ndr heretest\nop 'drag'");
@@ -2621,7 +2621,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 1).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
+			CHECK(String(text_edit->get_viewport()->gui_get_drag_data()) == "drag");
 			SEND_GUI_KEY_EVENT(Key::A);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "'A' \ndr heretest\nop 'drag'");
@@ -2655,7 +2655,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(0, 7).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag me");
+			CHECK(String(text_edit->get_viewport()->gui_get_drag_data()) == "drag me");
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 7);
@@ -2742,7 +2742,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection(true, 0));
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 6).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "d\nte");
+			CHECK(String(text_edit->get_viewport()->gui_get_drag_data()) == "d\nte");
 			CHECK(text_edit->has_selection());
 			SEND_GUI_KEY_EVENT(Key::CMD_OR_CTRL);
 			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 6).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
@@ -2774,7 +2774,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection(true, 0));
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center(), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "test");
+			CHECK(String(text_edit->get_viewport()->gui_get_drag_data()) == "test");
 			CHECK(text_edit->has_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -2801,7 +2801,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == " ");
+			CHECK(String(text_edit->get_viewport()->gui_get_drag_data()) == " ");
 			CHECK(text_edit->has_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 7).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -2826,7 +2826,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "rag");
+			CHECK(String(text_edit->get_viewport()->gui_get_drag_data()) == "rag");
 			CHECK(text_edit->has_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 2).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -2844,7 +2844,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->is_mouse_over_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 7).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
-			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag");
+			CHECK(String(text_edit->get_viewport()->gui_get_drag_data()) == "drag");
 			CHECK(text_edit->has_selection());
 			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 4).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
 			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit->get_position() + target_text_edit->get_rect_at_line_column(0, 4).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
@@ -8222,11 +8222,11 @@ TEST_CASE("[SceneTree][TextEdit] gutters") {
 		text_edit->set_line_gutter_metadata(2, 0, "test");
 		text_edit->set_line_gutter_metadata(-1, 0, "test");
 
-		CHECK(text_edit->get_line_gutter_metadata(1, 0) == "test");
-		CHECK(text_edit->get_line_gutter_metadata(0, -1) == "");
-		CHECK(text_edit->get_line_gutter_metadata(0, 2) == "");
-		CHECK(text_edit->get_line_gutter_metadata(2, 0) == "");
-		CHECK(text_edit->get_line_gutter_metadata(-1, 0) == "");
+		CHECK(String(text_edit->get_line_gutter_metadata(1, 0)) == "test");
+		CHECK(String(text_edit->get_line_gutter_metadata(0, -1)) == "");
+		CHECK(String(text_edit->get_line_gutter_metadata(0, 2)) == "");
+		CHECK(String(text_edit->get_line_gutter_metadata(2, 0)) == "");
+		CHECK(String(text_edit->get_line_gutter_metadata(-1, 0)) == "");
 
 		text_edit->set_line_gutter_text(1, 0, "test");
 		text_edit->set_line_gutter_text(0, -1, "test");

--- a/tests/servers/test_navigation_server_2d.h
+++ b/tests/servers/test_navigation_server_2d.h
@@ -392,7 +392,7 @@ TEST_SUITE("[Navigation2D]") {
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 0);
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 1);
-		CHECK_NE(agent_avoidance_callback_mock.function1_latest_arg0, Vector2(0, 0));
+		CHECK_NE(Vector2(agent_avoidance_callback_mock.function1_latest_arg0), Vector2(0, 0));
 
 		navigation_server->free_rid(agent);
 		navigation_server->free_rid(map);

--- a/tests/servers/test_navigation_server_3d.h
+++ b/tests/servers/test_navigation_server_3d.h
@@ -367,7 +367,7 @@ TEST_SUITE("[Navigation3D]") {
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 0);
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 1);
-		CHECK_NE(agent_avoidance_callback_mock.function1_latest_arg0, Vector3(0, 0, 0));
+		CHECK_NE(Vector3(agent_avoidance_callback_mock.function1_latest_arg0), Vector3(0, 0, 0));
 
 		navigation_server->free_rid(agent);
 		navigation_server->free_rid(map);


### PR DESCRIPTION
- Alternative to #112224

A more extreme implementation of the above. Instead of simply wrapping everything in `Variant` to preserve existing behavior, this makes the casts **from** `Variant`. This was the original implementation of the above, but was changed due to concerns of causing conflicts and needing to revert the PR in bulk. I've since spent an unhealthy amount of time looking through `Variant` conversion logic, so I'm confident in revisiting the original approach given how early into the dev cycle we currently are.

The other major difference is the removal of the `STRICT_CHECKS` macro wrapper. Now the conversions are forbidden outright, regardless of CI argument. Given we're already hoping to make internals more explicit over time and none of those are using `STRICT_CHECKS`, it felt out-of-place to apply the same here.