### PR TITLE
Fix non-static variable autocompletion in class body

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1534,7 +1534,7 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 	}
 
 	if (p_context.current_class) {
-		_find_identifiers_in_class(p_context.current_class, p_only_functions, false, (!p_context.current_function || p_context.current_function->is_static), false, p_add_braces, r_result, p_recursion_depth);
+		_find_identifiers_in_class(p_context.current_class, p_only_functions, false, p_context.is_static(), false, p_add_braces, r_result, p_recursion_depth);
 	}
 
 	List<StringName> functions;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -333,6 +333,7 @@ void GDScriptParser::override_completion_context(const Node *p_for_node, Complet
 	context.type = p_type;
 	context.current_class = current_class;
 	context.current_function = current_function;
+	context.current_variable = current_variable;
 	context.current_suite = current_suite;
 	context.current_line = tokenizer->get_cursor_line();
 	context.current_argument = p_argument;
@@ -355,6 +356,7 @@ void GDScriptParser::make_completion_context(CompletionType p_type, Node *p_node
 	context.type = p_type;
 	context.current_class = current_class;
 	context.current_function = current_function;
+	context.current_variable = current_variable;
 	context.current_suite = current_suite;
 	context.current_line = tokenizer->get_cursor_line();
 	context.current_argument = p_argument;
@@ -377,6 +379,7 @@ void GDScriptParser::make_completion_context(CompletionType p_type, Variant::Typ
 	context.type = p_type;
 	context.current_class = current_class;
 	context.current_function = current_function;
+	context.current_variable = current_variable;
 	context.current_suite = current_suite;
 	context.current_line = tokenizer->get_cursor_line();
 	context.builtin_type = p_builtin_type;
@@ -1222,6 +1225,7 @@ GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static, b
 	variable->identifier = parse_identifier();
 	variable->export_info.name = variable->identifier->name;
 	variable->is_static = p_is_static;
+	current_variable = variable;
 
 	if (match(GDScriptTokenizer::Token::COLON)) {
 		if (check(GDScriptTokenizer::Token::NEWLINE)) {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1317,6 +1317,7 @@ public:
 		CompletionType type = COMPLETION_NONE;
 		ClassNode *current_class = nullptr;
 		FunctionNode *current_function = nullptr;
+		VariableNode *current_variable = nullptr;
 		SuiteNode *current_suite = nullptr;
 		int current_line = -1;
 		union {
@@ -1328,6 +1329,10 @@ public:
 		Object *base = nullptr;
 		GDScriptParser *parser = nullptr;
 		CompletionCall call;
+
+		bool is_static() const {
+			return (current_function && current_function->is_static) || (current_variable && current_variable->is_static);
+		}
 	};
 
 private:
@@ -1387,6 +1392,7 @@ private:
 
 	ClassNode *current_class = nullptr;
 	FunctionNode *current_function = nullptr;
+	VariableNode *current_variable = nullptr;
 	LambdaNode *current_lambda = nullptr;
 	SuiteNode *current_suite = nullptr;
 

--- a/modules/gdscript/tests/scripts/completion/common/static_variable_in_class_body.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/static_variable_in_class_body.cfg
@@ -1,0 +1,7 @@
+[output]
+include=[
+    {"display": "static_variable"},
+]
+exclude=[
+    {"display": "variable"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/static_variable_in_class_body.gd
+++ b/modules/gdscript/tests/scripts/completion/common/static_variable_in_class_body.gd
@@ -1,0 +1,6 @@
+extends Node
+
+var variable := 10
+static var static_variable := 5
+
+static var example := ➡

--- a/modules/gdscript/tests/scripts/completion/common/variable_in_class_body.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/variable_in_class_body.cfg
@@ -1,0 +1,4 @@
+[output]
+include=[
+    {"display": "variable"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/variable_in_class_body.gd
+++ b/modules/gdscript/tests/scripts/completion/common/variable_in_class_body.gd
@@ -1,0 +1,4 @@
+extends Node
+
+var variable := 10
+var example := ➡


### PR DESCRIPTION
- Fixes: https://github.com/godotengine/godot/issues/103221

## Example

| Before | After |
|---|---|
| <img width="380" height="217" alt="before_fix" src="https://github.com/user-attachments/assets/3e4947cf-6374-42a0-a922-ffc14b75dd55" /> | <img width="380" height="217" alt="after_fix" src="https://github.com/user-attachments/assets/bc4a24f9-6aca-44ce-a593-d7eeeb10f946" /> |

## Details

Bug was in incomplete definition of static. Before expression was as follows:

```cpp
bool is_static = !p_context.current_function || p_context.current_function->is_static;
```

https://github.com/godotengine/godot/blob/80a4af1cc7c97b41f819ac2ac519a12804a53b1c/modules/gdscript/gdscript_editor.cpp#L1532-L1534

When work with variable (not a function), we immediately get true in expression. Therefore, autocomplete didn't work for non-static variables outside of functions in class body.

## Fix

I additionally add a current variable in context during parsing and expression:

```cpp
bool is_static = (current_function && current_function->is_static) || (current_variable && current_variable->is_static);
```