### PR TITLE
[GDScript] Fix inconsistent unary minus handling with literals.

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -430,15 +430,6 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 		} else if (str[j] == '.' && !is_binary_op && is_digit(str[j + 1]) && (j == 0 || (j > 0 && str[j - 1] != '.'))) {
 			// Start number highlighting from leading decimal points (like .42)
 			in_number = true;
-		} else if ((str[j] == '-' || str[j] == '+' || str[j] == '~') && !is_binary_op) {
-			// Only start number highlighting on unary operators if a digit follows them.
-			int non_op = j + 1;
-			while (str[non_op] == '-' || str[non_op] == '+' || str[non_op] == '~') {
-				non_op++;
-			}
-			if (is_digit(str[non_op]) || (str[non_op] == '.' && non_op < line_length && is_digit(str[non_op + 1]))) {
-				in_number = true;
-			}
 		}
 
 		if (!in_word && is_unicode_identifier_start(str[j]) && !in_number) {

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -174,24 +174,6 @@ String GDScriptTokenizer::Token::get_debug_name() const {
 	}
 }
 
-bool GDScriptTokenizer::Token::can_precede_bin_op() const {
-	switch (type) {
-		case IDENTIFIER:
-		case LITERAL:
-		case SELF:
-		case BRACKET_CLOSE:
-		case BRACE_CLOSE:
-		case PARENTHESIS_CLOSE:
-		case CONST_PI:
-		case CONST_TAU:
-		case CONST_INF:
-		case CONST_NAN:
-			return true;
-		default:
-			return false;
-	}
-}
-
 bool GDScriptTokenizer::Token::is_identifier() const {
 	// Note: Most keywords should not be recognized as identifiers.
 	// These are only exceptions for stuff that already is on the engine's API.
@@ -402,7 +384,6 @@ GDScriptTokenizer::Token GDScriptTokenizerText::make_token(Token::Type p_type) {
 			}
 		}
 	}
-
 	last_token = token;
 	return token;
 }
@@ -675,11 +656,6 @@ GDScriptTokenizer::Token GDScriptTokenizerText::number() {
 	bool need_digits = false;
 	bool (*digit_check_func)(char32_t) = is_digit;
 
-	// Sign before hexadecimal or binary.
-	if ((_peek(-1) == '+' || _peek(-1) == '-') && _peek() == '0') {
-		_advance();
-	}
-
 	if (_peek(-1) == '.') {
 		has_decimal = true;
 	} else if (_peek(-1) == '0') {
@@ -832,8 +808,13 @@ GDScriptTokenizer::Token GDScriptTokenizerText::number() {
 
 	// Convert to the appropriate literal type.
 	if (base == 16) {
-		int64_t value = number.hex_to_int();
-		return make_literal(value);
+		if (unlikely((last_token.type == Token::MINUS || last_token.type == Token::MINUS_EQUAL) && (number.substr(2, -1) == "8000000000000000"))) {
+			uint64_t value = 9223372036854775808ULL;
+			return make_literal(value);
+		} else {
+			int64_t value = number.hex_to_int();
+			return make_literal(value);
+		}
 	} else if (base == 2) {
 		int64_t value = number.bin_to_int();
 		return make_literal(value);
@@ -841,8 +822,13 @@ GDScriptTokenizer::Token GDScriptTokenizerText::number() {
 		double value = number.to_float();
 		return make_literal(value);
 	} else {
-		int64_t value = number.to_int();
-		return make_literal(value);
+		if (unlikely((last_token.type == Token::MINUS || last_token.type == Token::MINUS_EQUAL) && (number == "9223372036854775808"))) {
+			uint64_t value = 9223372036854775808ULL;
+			return make_literal(value);
+		} else {
+			int64_t value = number.to_int();
+			return make_literal(value);
+		}
 	}
 }
 
@@ -1507,9 +1493,6 @@ GDScriptTokenizer::Token GDScriptTokenizerText::scan() {
 			if (_peek() == '=') {
 				_advance();
 				return make_token(Token::PLUS_EQUAL);
-			} else if (is_digit(_peek()) && !last_token.can_precede_bin_op()) {
-				// Number starting with '+'.
-				return number();
 			} else {
 				return make_token(Token::PLUS);
 			}
@@ -1517,9 +1500,6 @@ GDScriptTokenizer::Token GDScriptTokenizerText::scan() {
 			if (_peek() == '=') {
 				_advance();
 				return make_token(Token::MINUS_EQUAL);
-			} else if (is_digit(_peek()) && !last_token.can_precede_bin_op()) {
-				// Number starting with '-'.
-				return number();
 			} else if (_peek() == '>') {
 				_advance();
 				return make_token(Token::FORWARD_ARROW);

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -174,7 +174,6 @@ public:
 
 		const char *get_name() const;
 		String get_debug_name() const;
-		bool can_precede_bin_op() const;
 		bool is_identifier() const;
 		bool is_node_name() const;
 		StringName get_identifier() const { return literal; }

--- a/modules/gdscript/tests/scripts/parser/features/number_literals_with_sign.gd
+++ b/modules/gdscript/tests/scripts/parser/features/number_literals_with_sign.gd
@@ -1,5 +1,7 @@
 func test():
 	print(-9223372036854775808 == (1 << 63))
+	print(-0x8000000000000000 == (1 << 63))
+	print(-0X8000000000000000 == (1 << 63))
 	print(-2)
 	print(- 2)
 	print(---2)
@@ -15,3 +17,7 @@ func test():
 	print(-0xFF)
 	print(1--0xFF)
 	print(floor(PI-1))
+	print(-5**0 == -1)
+	print(-(5**0) == -1)
+	print((-5)**0 == 1)
+	print(5**0 == 1)

--- a/modules/gdscript/tests/scripts/parser/features/number_literals_with_sign.out
+++ b/modules/gdscript/tests/scripts/parser/features/number_literals_with_sign.out
@@ -1,5 +1,7 @@
 GDTEST_OK
 true
+true
+true
 -2
 -2
 -2
@@ -14,3 +16,7 @@ true
 -255
 256
 2.0
+true
+true
+true
+true


### PR DESCRIPTION
Fixes https://chat.godotengine.org/channel/general?msg=NSMo3wzo5QSaEwAVn

Reverts https://github.com/godotengine/godot/pull/73363, adds special case to handle `9223372036854775808` as `uint64_t` instead.