### PR TITLE
GLES3: Split EGL includes in `platform_egl.h`

### DIFF
--- a/drivers/egl/egl_manager.h
+++ b/drivers/egl/egl_manager.h
@@ -35,7 +35,7 @@
 #include "core/templates/local_vector.h"
 #include "servers/display/display_server_enums.h"
 
-#include <platform_gl.h>
+#include <platform_egl.h>
 
 class EGLManager {
 private:

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -79,17 +79,20 @@
 #endif
 #endif
 
-#if !defined(IOS_ENABLED) && !defined(WEB_ENABLED)
-// We include EGL below to get debug callback on GLES2 platforms,
-// but EGL is not available on iOS or the web.
-#define CAN_DEBUG
+#include <platform_gl.h>
+
+#if defined(EGL_ENABLED) || defined(ANDROID_ENABLED)
+#include <platform_egl.h>
 #endif
 
-#include "platform_gl.h"
+#if defined(GLAD_ENABLED) || defined(EGL_ENABLED) || defined(ANDROID_ENABLED)
+// We can debug GL if we use GLAD or EGL, so not on iOS or Web.
+#define GL_DEBUG_CALLBACK
 
-#if defined(MINGW_ENABLED) || defined(_MSC_VER)
+#ifdef _WIN32
 #define strcpy strcpy_s
 #endif
+#endif // GLAD_ENABLED || EGL_ENABLED || ANDROID_ENABLED
 
 #ifdef WINDOWS_ENABLED
 bool RasterizerGLES3::screen_flipped_y = false;
@@ -126,7 +129,7 @@ void RasterizerGLES3::gl_end_frame(bool p_swap_buffers) {
 	}
 }
 
-#ifdef CAN_DEBUG
+#ifdef GL_DEBUG_CALLBACK
 static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const GLvoid *userParam) {
 	// These are ultimately annoying, so removing for now.
 	if (type == _EXT_DEBUG_TYPE_OTHER_ARB || type == _EXT_DEBUG_TYPE_PERFORMANCE_ARB || type == _EXT_DEBUG_TYPE_MARKER_ARB) {
@@ -177,7 +180,7 @@ static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GL
 
 	ERR_PRINT(output);
 }
-#endif
+#endif // GL_DEBUG_CALLBACK
 
 typedef void(GLAPIENTRY *DEBUGPROCARB)(GLenum source,
 		GLenum type,
@@ -223,7 +226,7 @@ void RasterizerGLES3::make_current(bool p_gles_over_gl) {
 
 RasterizerGLES3 *RasterizerGLES3::singleton = nullptr;
 
-#ifdef EGL_ENABLED
+#if defined(GLAD_ENABLED) && defined(EGL_ENABLED)
 void *_egl_load_function_wrapper(const char *p_name) {
 	return (void *)eglGetProcAddress(p_name);
 }
@@ -273,7 +276,12 @@ RasterizerGLES3::RasterizerGLES3() {
 	// the members of this instance are initialized, so this just makes debugging harder.  It should either crash here intentionally,
 	// or we need to actually test for this situation before constructing this.
 	ERR_FAIL_COND_MSG(!glad_loaded, "Error initializing GLAD.");
+#endif // GLAD_ENABLED
 
+#ifdef GL_DEBUG_CALLBACK
+	// Setup OpenGL debug callback, via DebugMessageCallbackARB (GLAD or EGL).
+
+#ifdef GLAD_ENABLED
 	if (RasterizerUtilGLES3::is_gles_over_gl()) {
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			if (GLAD_GL_ARB_debug_output) {
@@ -285,10 +293,7 @@ RasterizerGLES3::RasterizerGLES3() {
 			}
 		}
 	}
-#endif // GLAD_ENABLED
 
-	// For debugging
-#ifdef CAN_DEBUG
 #ifdef GL_API_ENABLED
 	if (RasterizerUtilGLES3::is_gles_over_gl()) {
 		if (OS::get_singleton()->is_stdout_verbose() && GLAD_GL_ARB_debug_output) {
@@ -301,6 +306,9 @@ RasterizerGLES3::RasterizerGLES3() {
 		}
 	}
 #endif // GL_API_ENABLED
+#endif // GLAD_ENABLED
+
+#if defined(EGL_ENABLED) || defined(ANDROID_ENABLED)
 #ifdef GLES_API_ENABLED
 	if (!RasterizerUtilGLES3::is_gles_over_gl()) {
 		if (OS::get_singleton()->is_stdout_verbose()) {
@@ -318,9 +326,13 @@ RasterizerGLES3::RasterizerGLES3() {
 		}
 	}
 #endif // GLES_API_ENABLED
-#endif // CAN_DEBUG
+#endif // EGL_ENABLED || ANDROID_ENABLED
+
+#endif // GL_DEBUG_CALLBACK
 
 	{
+		// Setup shader cache.
+
 		String shader_cache_dir = Engine::get_singleton()->get_shader_cache_path();
 		if (shader_cache_dir.is_empty()) {
 			shader_cache_dir = "user://";

--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -37,6 +37,10 @@
 #include "core/string/ustring.h"
 #include "drivers/gles3/rasterizer_util_gles3.h"
 
+#ifdef ANDROID_ENABLED
+#include <platform_egl.h>
+#endif
+
 #ifdef WEB_ENABLED
 #include <emscripten/html5_webgl.h>
 #endif

--- a/platform/android/platform_egl.h
+++ b/platform/android/platform_egl.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  platform_gl.h                                                         */
+/*  platform_egl.h                                                        */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,16 +30,7 @@
 
 #pragma once
 
-#ifndef GL_API_ENABLED
-#define GL_API_ENABLED // Allow using desktop GL.
-#endif
-
-#ifndef GLES_API_ENABLED
-#define GLES_API_ENABLED // Allow using GLES.
-#endif
-
-#ifndef GLAD_GLES2
-#define GLAD_GLES2
-#endif
-
-#include <thirdparty/glad/glad/gl.h> // IWYU pragma: export.
+// IWYU pragma: begin_exports.
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+// IWYU pragma: end_exports.

--- a/platform/android/platform_gl.h
+++ b/platform/android/platform_gl.h
@@ -35,8 +35,6 @@
 #endif
 
 // IWYU pragma: begin_exports.
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
 #include <GLES3/gl3.h>
 #include <GLES3/gl3ext.h>
 // IWYU pragma: end_exports.

--- a/platform/linuxbsd/platform_egl.h
+++ b/platform/linuxbsd/platform_egl.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  platform_gl.h                                                         */
+/*  platform_egl.h                                                        */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,16 +30,4 @@
 
 #pragma once
 
-#ifndef GL_API_ENABLED
-#define GL_API_ENABLED // Allow using desktop GL.
-#endif
-
-#ifndef GLES_API_ENABLED
-#define GLES_API_ENABLED // Allow using GLES.
-#endif
-
-#ifndef GLAD_GLES2
-#define GLAD_GLES2
-#endif
-
-#include <thirdparty/glad/glad/gl.h> // IWYU pragma: export.
+#include <thirdparty/glad/glad/egl.h> // IWYU pragma: export.

--- a/platform/linuxbsd/wayland/detect_prime_egl.cpp
+++ b/platform/linuxbsd/wayland/detect_prime_egl.cpp
@@ -38,6 +38,12 @@
 #include "core/string/ustring.h"
 #include "core/variant/variant.h" // IWYU pragma: keep. Needed for print_verbose.
 
+#ifdef GLAD_ENABLED
+#include <platform_gl.h>
+#else
+#include <GL/glcorearb.h>
+#endif
+
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>

--- a/platform/linuxbsd/wayland/detect_prime_egl.h
+++ b/platform/linuxbsd/wayland/detect_prime_egl.h
@@ -34,11 +34,10 @@
 #ifdef EGL_ENABLED
 
 #ifdef GLAD_ENABLED
-#include <platform_gl.h>
+#include <platform_egl.h>
 #else
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
-#include <GL/glcorearb.h>
 
 #define GLAD_EGL_VERSION_1_5 1
 

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -32,25 +32,7 @@
 
 #include "display_server_macos_base.h"
 
-#if defined(GLES3_ENABLED)
-#if defined(ANGLE_ENABLED)
-#include "gl_manager_macos_angle.h"
-#endif
-#include "gl_manager_macos_legacy.h"
-#endif // GLES3_ENABLED
-
 #include "core/os/process_id.h"
-
-#if defined(RD_ENABLED)
-#include "servers/rendering/rendering_device.h"
-
-#if defined(VULKAN_ENABLED)
-#import "rendering_context_driver_vulkan_macos.h"
-#endif // VULKAN_ENABLED
-#if defined(METAL_ENABLED)
-#import "drivers/metal/rendering_context_driver_metal.h"
-#endif
-#endif // RD_ENABLED
 
 #define FontVariation __FontVariation
 #define BitMap _QDBitMap // Suppress deprecated QuickDraw definition.
@@ -62,26 +44,29 @@
 #import <Foundation/Foundation.h>
 #import <IOKit/pwr_mgt/IOPMLib.h>
 
+#undef BitMap
+#undef FontVariation
+
 @class GodotWindow;
 @class GodotContentView;
 @class GodotWindowDelegate;
 @class GodotButtonView;
 @class GodotProgressView;
-#ifdef TOOLS_ENABLED
-@class GodotEmbeddedView;
-@class CALayerHost;
-#endif
 
-#undef BitMap
-#undef FontVariation
+class InputEvent;
+class InputEventWithModifiers;
+class NativeMenuMacOS;
 
 #ifdef TOOLS_ENABLED
 class EmbeddedProcessMacOS;
 #endif
 
-class InputEvent;
-class InputEventWithModifiers;
-class NativeMenuMacOS;
+#ifdef GLES3_ENABLED
+class GLManagerLegacy_MacOS;
+#ifdef ANGLE_ENABLED
+class GLManagerANGLE_MacOS;
+#endif
+#endif
 
 class DisplayServerMacOS : public DisplayServerMacOSBase {
 	GDSOFTCLASS(DisplayServerMacOS, DisplayServerMacOSBase);

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -46,10 +46,6 @@
 #import "native_menu_macos.h"
 #import "os_macos.h"
 
-#ifdef TOOLS_ENABLED
-#import "macos_quartz_core_spi.h"
-#endif
-
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/io/file_access.h"
@@ -71,13 +67,34 @@
 #import "editor/embedded_process_macos.h"
 #endif
 
+// Rendering drivers - include after general Godot deps as they imply system includes
+// which may need precise ordering.
+
 #if defined(GLES3_ENABLED)
+#if defined(ANGLE_ENABLED)
+#include "gl_manager_macos_angle.h"
+#endif
+#include "gl_manager_macos_legacy.h"
+
 #include "drivers/gles3/rasterizer_gles3.h"
 #endif
 
 #if defined(RD_ENABLED)
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
 #include "servers/rendering/rendering_device.h"
+
+#if defined(VULKAN_ENABLED)
+#import "rendering_context_driver_vulkan_macos.h"
+#endif
+#if defined(METAL_ENABLED)
+#import "drivers/metal/rendering_context_driver_metal.h"
+#endif
+#endif // RD_ENABLED
+
+// Keep Quartz after rendering includes, as it includes system GL.h
+// which clashes with GLAD.
+#ifdef TOOLS_ENABLED
+#import "macos_quartz_core_spi.h"
 #endif
 
 #include <AppKit/AppKit.h>

--- a/platform/macos/display_server_macos_embedded.h
+++ b/platform/macos/display_server_macos_embedded.h
@@ -35,10 +35,11 @@
 @class CAContext;
 @class CALayer;
 class InputEvent;
-class GLManagerEmbedded;
 class NativeMenu;
-class RenderingContextDriver;
-class RenderingDevice;
+
+#ifdef GLES3_ENABLED
+class GLManagerEmbedded;
+#endif
 
 struct DisplayServerMacOSEmbeddedState {
 	/*! Default to a scale of 2.0, which is the most common. */

--- a/platform/macos/display_server_macos_embedded.mm
+++ b/platform/macos/display_server_macos_embedded.mm
@@ -30,11 +30,23 @@
 
 #import "display_server_macos_embedded.h"
 
+#import "embedded_debugger.h"
+
+#import "core/config/project_settings.h"
+#import "core/debugger/engine_debugger.h"
+#import "core/input/input.h"
+#import "core/input/input_event.h"
+#import "core/io/marshalls.h"
+#import "core/os/main_loop.h"
+#import "core/os/os.h"
+#import "servers/display/native_menu.h"
+
 #if defined(GLES3_ENABLED)
 #import "embedded_gl_manager.h"
-#import "platform_gl.h"
 
 #import "drivers/gles3/rasterizer_gles3.h"
+
+#import <platform_gl.h>
 #endif
 
 #if defined(RD_ENABLED)
@@ -49,17 +61,9 @@
 #endif
 #endif // RD_ENABLED
 
-#import "embedded_debugger.h"
+// Keep Quartz after rendering includes, as it includes system GL.h
+// which clashes with GLAD.
 #import "macos_quartz_core_spi.h"
-
-#import "core/config/project_settings.h"
-#import "core/debugger/engine_debugger.h"
-#import "core/input/input.h"
-#import "core/input/input_event.h"
-#import "core/io/marshalls.h"
-#import "core/os/main_loop.h"
-#import "core/os/os.h"
-#import "servers/display/native_menu.h"
 
 DisplayServerMacOSEmbedded::DisplayServerMacOSEmbedded(const String &p_rendering_driver, DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, DisplayServerEnums::Context p_context, Error &r_error) {
 	EmbeddedDebugger::initialize(this);

--- a/platform/macos/platform_egl.h
+++ b/platform/macos/platform_egl.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  platform_gl.h                                                         */
+/*  platform_egl.h                                                        */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,16 +30,11 @@
 
 #pragma once
 
-#ifndef GL_API_ENABLED
-#define GL_API_ENABLED // Allow using desktop GL.
+#if defined(ANGLE_ENABLED) && defined(EGL_STATIC)
+#define KHRONOS_STATIC 1
+// IWYU pragma: begin_exports.
+#include <thirdparty/angle/include/EGL/egl.h>
+#include <thirdparty/angle/include/EGL/eglext.h>
+// IWYU pragma: end_exports.
+#undef KHRONOS_STATIC
 #endif
-
-#ifndef GLES_API_ENABLED
-#define GLES_API_ENABLED // Allow using GLES.
-#endif
-
-#ifndef GLAD_GLES2
-#define GLAD_GLES2
-#endif
-
-#include <thirdparty/glad/glad/gl.h> // IWYU pragma: export.

--- a/platform/macos/platform_gl.h
+++ b/platform/macos/platform_gl.h
@@ -42,15 +42,6 @@
 #ifndef GLAD_GLES2
 #define GLAD_GLES2
 #endif
-
-// IWYU pragma: begin_exports.
-#ifdef EGL_STATIC
-#define KHRONOS_STATIC 1
-#include <thirdparty/angle/include/EGL/egl.h>
-#include <thirdparty/angle/include/EGL/eglext.h>
-#undef KHRONOS_STATIC
-#endif
 #endif
 
-#include <thirdparty/glad/glad/gl.h>
-// IWYU pragma: end_exports.
+#include <thirdparty/glad/glad/gl.h> // IWYU pragma: export.

--- a/platform/windows/platform_egl.h
+++ b/platform/windows/platform_egl.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  platform_gl.h                                                         */
+/*  platform_egl.h                                                        */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,16 +30,13 @@
 
 #pragma once
 
-#ifndef GL_API_ENABLED
-#define GL_API_ENABLED // Allow using desktop GL.
+#if defined(ANGLE_ENABLED) && defined(EGL_STATIC)
+#define KHRONOS_STATIC 1
+#undef KHRONOS_APICALL
+#define KHRONOS_APICALL
+// IWYU pragma: begin_exports.
+#include <thirdparty/angle/include/EGL/egl.h>
+#include <thirdparty/angle/include/EGL/eglext.h>
+// IWYU pragma: end_exports.
+#undef KHRONOS_STATIC
 #endif
-
-#ifndef GLES_API_ENABLED
-#define GLES_API_ENABLED // Allow using GLES.
-#endif
-
-#ifndef GLAD_GLES2
-#define GLAD_GLES2
-#endif
-
-#include <thirdparty/glad/glad/gl.h> // IWYU pragma: export.

--- a/platform/windows/platform_gl.h
+++ b/platform/windows/platform_gl.h
@@ -42,15 +42,6 @@
 #ifndef GLAD_GLES2
 #define GLAD_GLES2
 #endif
-
-// IWYU pragma: begin_exports.
-#ifdef EGL_STATIC
-#define KHRONOS_STATIC 1
-#include <thirdparty/angle/include/EGL/egl.h>
-#include <thirdparty/angle/include/EGL/eglext.h>
-#undef KHRONOS_STATIC
-#endif
 #endif
 
-#include <thirdparty/glad/glad/gl.h>
-// IWYU pragma: end_exports.
+#include <thirdparty/glad/glad/gl.h> // IWYU pragma: export.


### PR DESCRIPTION
EGL brings in platform-specific headers such as the dreaded `windows.h`, and `platform_gl.h` is used throughout `drivers/gles3` for basic OpenGL types such as `GLuint`. We don't want `windows.h` pollution there.

Note for Android: EGL seems used explicitly only via `rasterizer_gles3.cpp` to enable GL debug printing, and some custom stuff in `config.cpp`.

Split from #115623, it helps solves an include order issue there.

Seems to work ok on Linux from a quick test, but this needs testing on Windows and macOS, with and without ANGLE.