### PR TITLE
[Input] Handle invalid `input/` settings correctly

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -317,6 +317,11 @@ void InputMap::load_from_project_settings() {
 		String name = pi.name.substr(pi.name.find_char('/') + 1);
 
 		Dictionary action = GLOBAL_GET(pi.name);
+
+		if (!action.has("events")) {
+			continue;
+		}
+
 		float deadzone = action.has("deadzone") ? (float)action["deadzone"] : DEFAULT_DEADZONE;
 		Array events = action["events"];
 

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -613,6 +613,11 @@ void ProjectSettingsEditor::_update_action_map_editor() {
 		String display_name = property_name.substr(String("input/").size() - 1);
 		Dictionary action = GLOBAL_GET(property_name);
 
+		if (!action.has("events")) {
+			WARN_PRINT_ONCE_ED(vformat("Attempted to load invalid input action from setting at \"%s\". The `input/` prefix should only be used for input actions, and cannot be changed in the settings editor. Consider changing the category.", property_name));
+			continue;
+		}
+
 		ActionMapEditor::ActionInfo action_info;
 		action_info.action = action;
 		action_info.editable = true;


### PR DESCRIPTION
This prefix is reserved for events

Could fully filter out invalid entries in the project settings, but keeping this as small scale as possible, I think these invalid settings also show up in autocompletion, which would be annoying

Only a noisy issue when manually adding invalid settings to the `input/`, the bug doesn't seem to have any practical impact (though the invalid entries do show up in the action map editor)

* Fixes: https://github.com/godotengine/godot/issues/115624

Edit: Added an optional commit to error in the editor, see the review comment below for some context

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
