### PR TITLE
Set Forward+ as default rendering method for project manager on macOS

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2416,6 +2416,13 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	default_renderer_mobile = "mobile";
 #endif
 
+#ifdef MACOS_ENABLED
+	// Default to Forward+ when using the project manager on macOS, since OpenGL will crash in virtual machines (GH-115580).
+	if (rendering_method.is_empty() && project_manager) {
+		rendering_method = "forward_plus";
+	}
+#endif
+
 	// And Compatibility next, or first if Vulkan is disabled.
 #ifdef GLES3_ENABLED
 	if (!renderer_hints.is_empty()) {


### PR DESCRIPTION
Fixes #115580 (at least the project manager part of it).

Since the Apple Software Renderer (as used for OpenGL in virtual machines) now (as of macOS 26) crashes the project manager on startup, and with OpenGL being long since deprecated by Apple, it seems better to have Forward+ be the default rendering method for the project manager on macOS, since that would use Metal instead, which seems to work/perform just fine in virtual machines.

(Note that this is not about the default for newly created projects. It's about what rendering method the project manager uses to render itself.)