### PR TITLE
Minimize includes from `gdvirtual.gen.inc` / `script_instance.h`, to improve compile time

### DIFF
--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -197,6 +197,7 @@ def run(target, source, env):
 #pragma once
 
 #include "core/object/script_instance.h"
+#include "core/variant/binder_common.h"
 
 inline constexpr uintptr_t _INVALID_GDVIRTUAL_FUNC_ADDR = static_cast<uintptr_t>(-1);
 

--- a/core/object/script_instance.h
+++ b/core/object/script_instance.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/ref_counted.h"
+#include "core/variant/variant.h"
 
 class Script;
 class ScriptLanguage;

--- a/core/os/main_loop.cpp
+++ b/core/os/main_loop.cpp
@@ -30,6 +30,8 @@
 
 #include "main_loop.h"
 
+#include "core/object/class_db.h"
+
 void MainLoop::_bind_methods() {
 	BIND_CONSTANT(NOTIFICATION_OS_MEMORY_WARNING);
 	BIND_CONSTANT(NOTIFICATION_TRANSLATION_CHANGED);

--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -34,6 +34,7 @@
 #include "core/math/projection.h"
 #include "core/object/class_db.h"
 #include "core/object/gdvirtual.gen.inc"
+#include "core/object/ref_counted.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/rid.h"
 #include "core/variant/native_ptr.h"

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/ref_counted.h"
 #include "core/os/main_loop.h"
 #include "core/os/thread_safe.h"
 #include "core/templates/paged_allocator.h"


### PR DESCRIPTION
- Helps address #111218 

`gdvirtual.gen.inc` is widely included, which gets it, `script_instance.h`, and `ref_counted.h` a top spot in #111218.
It is not actually necessary to include `ref_counted.h`, which is currently a pretty expensive include through `class_db.h`.
Therefore, I'm reducing includes to only those necessary.

`binder_common.h` was also previously included through `ref_counted.h` > `class_db.h` > `method_bind.h`.