### PR TITLE
[Buildsystem] Fix non-3D builds

### DIFF
--- a/scene/debugger/runtime_node_select.h
+++ b/scene/debugger/runtime_node_select.h
@@ -37,6 +37,7 @@
 #include "scene/resources/mesh.h"
 #endif // _3D_DISABLED
 
+class Node;
 class PopupMenu;
 
 class RuntimeNodeSelect : public Object {


### PR DESCRIPTION
Restructure of the debugger caused `Node` to be undeclared in non-3D builds (normally declared in `resource.h`, non-3D builds don't include `mesh.h` so no include path declares `Node`)

Regression from:
* https://github.com/godotengine/godot/pull/115551

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
