### PR TITLE
Change `List` copy constructor from implicit to explicit.

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -204,7 +204,7 @@ public:
 	const HashMap<StringName, PropertyInfo> &get_custom_property_info() const;
 	uint64_t get_last_saved_time() { return last_save_time; }
 
-	List<String> get_input_presets() const { return input_presets; }
+	List<String> get_input_presets() const { return List<String>(input_presets); }
 
 	Variant get_setting_with_override(const StringName &p_name) const;
 	Variant get_setting_with_override_and_custom_features(const StringName &p_name, const Vector<String> &p_features) const;

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -950,7 +950,7 @@ void GDExtension::prepare_reload() {
 				state.push_back(Pair<String, Variant>(P.name, value));
 			}
 			E.value.instance_state[obj_id] = {
-				state, // List<Pair<String, Variant>> properties;
+				std::move(state), // List<Pair<String, Variant>> properties;
 				obj->is_extension_placeholder(), // bool is_placeholder;
 			};
 		}

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -205,7 +205,7 @@ IPAddress IP::get_resolve_item_address(ResolverID p_id) const {
 		return IPAddress();
 	}
 
-	List<IPAddress> res = resolver->queue[p_id].response;
+	List<IPAddress> res(resolver->queue[p_id].response);
 
 	for (const IPAddress &E : res) {
 		if (E.is_valid()) {
@@ -224,7 +224,7 @@ Array IP::get_resolve_item_addresses(ResolverID p_id) const {
 		return Array();
 	}
 
-	List<IPAddress> res = resolver->queue[p_id].response;
+	List<IPAddress> res(resolver->queue[p_id].response);
 
 	Array result;
 	for (const IPAddress &E : res) {

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -654,7 +654,7 @@ bool OS::is_restart_on_exit_set() const {
 }
 
 List<String> OS::get_restart_on_exit_arguments() const {
-	return restart_commandline;
+	return List<String>(restart_commandline);
 }
 
 PackedStringArray OS::get_connected_midi_inputs() {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -235,8 +235,8 @@ public:
 	virtual String get_distribution_name() const = 0;
 	virtual String get_version() const = 0;
 	virtual String get_version_alias() const { return get_version(); }
-	virtual List<String> get_cmdline_args() const { return _cmdline; }
-	virtual List<String> get_cmdline_user_args() const { return _user_args; }
+	virtual List<String> get_cmdline_args() const { return List<String>(_cmdline); }
+	virtual List<String> get_cmdline_user_args() const { return List<String>(_user_args); }
 	virtual List<String> get_cmdline_platform_args() const { return List<String>(); }
 	virtual String get_model_name() const;
 

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -685,10 +685,7 @@ public:
 		return (void *)_data;
 	}
 
-	/**
-	 * copy constructor for the list
-	 */
-	List(const List &p_list) {
+	explicit List(const List &p_list) {
 		const Element *it = p_list.front();
 		while (it) {
 			push_back(it->get());

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4450,7 +4450,7 @@ List<Node *> SceneTreeDock::paste_nodes(bool p_paste_as_sibling) {
 }
 
 List<Node *> SceneTreeDock::get_node_clipboard() const {
-	return node_clipboard;
+	return List<Node *>(node_clipboard);
 }
 
 void SceneTreeDock::add_remote_tree_editor(Tree *p_remote) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1939,7 +1939,7 @@ int EditorNode::get_resource_count(Ref<Resource> p_res) {
 
 List<Node *> EditorNode::get_resource_node_list(Ref<Resource> p_res) {
 	List<Node *> *L = resource_count.getptr(p_res);
-	return L == nullptr ? List<Node *>() : *L;
+	return L == nullptr ? List<Node *>() : List<Node *>(*L);
 }
 
 void EditorNode::update_node_reference(const Variant &p_value, Node *p_node, bool p_remove) {

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -482,7 +482,7 @@ void EditorExport::update_export_presets() {
 			export_presets_updated = true;
 
 			bool update_value_overrides = false;
-			List<EditorExportPlatform::ExportOption> options = platform_options[preset->get_platform()->get_name()];
+			List<EditorExportPlatform::ExportOption> options(platform_options[preset->get_platform()->get_name()]);
 
 			// Clear the preset properties prior to reloading, keep the values to preserve options from plugins that may be currently disabled.
 			preset->properties.clear();

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -239,7 +239,7 @@ List<String> DependencyEditor::_filter_deps(const List<String> &p_deps) {
 	const String filter_text = filter->get_text();
 
 	if (filter_text.is_empty()) {
-		return p_deps;
+		return List<String>(p_deps);
 	}
 
 	List<String> filtered;

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -360,7 +360,7 @@ void CanvasItemEditor::_snap_other_nodes(
 		}
 	}
 	for (int i = 0; i < p_current->get_child_count(); i++) {
-		_snap_other_nodes(p_value, p_transform_to_snap, r_current_snap, r_current_snap_target, p_snap_target, p_exceptions, p_current->get_child(i));
+		_snap_other_nodes(p_value, p_transform_to_snap, r_current_snap, r_current_snap_target, p_snap_target, List<const CanvasItem *>(p_exceptions), p_current->get_child(i));
 	}
 }
 
@@ -447,7 +447,7 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 				p_target, to_snap_transform,
 				output, snap_target,
 				SNAP_TARGET_OTHER_NODE,
-				exceptions,
+				List<const CanvasItem *>(exceptions),
 				get_tree()->get_edited_scene_root());
 	}
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -203,7 +203,7 @@ bool EditorSettings::_get(const StringName &p_name, Variant &r_ret) const {
 				continue;
 			}
 
-			List<Ref<InputEvent>> events = action_override.value;
+			List<Ref<InputEvent>> events(action_override.value);
 
 			Dictionary action_dict;
 			action_dict["name"] = action_override.key;
@@ -2208,7 +2208,7 @@ const Array EditorSettings::get_builtin_action_overrides(const String &p_name) c
 	if (AO) {
 		Array event_array;
 
-		List<Ref<InputEvent>> events_list = AO->value;
+		List<Ref<InputEvent>> events_list(AO->value);
 		for (const Ref<InputEvent> &E : events_list) {
 			event_array.push_back(E);
 		}

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -350,7 +350,7 @@ bool EditorSettingsDialog::_is_in_project_manager() const {
 void EditorSettingsDialog::_update_builtin_action(const String &p_name, const Array &p_events) {
 	Array old_input_array = EditorSettings::get_singleton()->get_builtin_action_overrides(p_name);
 	if (old_input_array.is_empty()) {
-		List<Ref<InputEvent>> defaults = InputMap::get_singleton()->get_builtins_with_feature_overrides_applied()[current_edited_identifier];
+		List<Ref<InputEvent>> defaults(InputMap::get_singleton()->get_builtins_with_feature_overrides_applied()[current_edited_identifier]);
 		old_input_array = _event_list_to_array_helper(defaults);
 	}
 
@@ -730,7 +730,7 @@ void EditorSettingsDialog::_shortcut_button_pressed(Object *p_item, int p_column
 		case EditorSettingsDialog::SHORTCUT_REVERT: {
 			// Only for "shortcut" types
 			if (is_editing_action) {
-				List<Ref<InputEvent>> defaults = InputMap::get_singleton()->get_builtins_with_feature_overrides_applied()[current_edited_identifier];
+				List<Ref<InputEvent>> defaults(InputMap::get_singleton()->get_builtins_with_feature_overrides_applied()[current_edited_identifier]);
 				Array events = _event_list_to_array_helper(defaults);
 
 				_update_builtin_action(current_edited_identifier, events);

--- a/editor/shader/shader_create_dialog.cpp
+++ b/editor/shader/shader_create_dialog.cpp
@@ -265,7 +265,7 @@ void ShaderCreateDialog::_browse_path() {
 	file_browse->set_customization_flag_enabled(FileDialog::CUSTOMIZATION_OVERWRITE_WARNING, false);
 	file_browse->clear_filters();
 
-	List<String> extensions = type_data.get(type_menu->get_selected()).extensions;
+	List<String> extensions(type_data.get(type_menu->get_selected()).extensions);
 
 	for (const String &E : extensions) {
 		file_browse->add_filter("*." + E);

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -6531,7 +6531,7 @@ void GDScriptAnalyzer::resolve_pending_lambda_bodies() {
 	GDScriptParser::LambdaNode *previous_lambda = current_lambda;
 	bool previous_static_context = static_context;
 
-	List<GDScriptParser::LambdaNode *> lambdas = pending_body_resolution_lambdas;
+	List<GDScriptParser::LambdaNode *> lambdas = std::move(pending_body_resolution_lambdas);
 	pending_body_resolution_lambdas.clear();
 
 	for (GDScriptParser::LambdaNode *lambda : lambdas) {

--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -372,7 +372,7 @@ void MultiplayerSynchronizer::set_multiplayer_authority(int p_peer_id, bool p_re
 
 Error MultiplayerSynchronizer::_watch_changes(uint64_t p_usec) {
 	ERR_FAIL_COND_V(replication_config.is_null(), FAILED);
-	const List<NodePath> props = replication_config->get_watch_properties();
+	const List<NodePath> props(replication_config->get_watch_properties());
 	if (props.size() != watchers.size()) {
 		watchers.resize(props.size());
 	}
@@ -436,7 +436,7 @@ List<Variant> MultiplayerSynchronizer::get_delta_state(uint64_t p_cur_usec, uint
 List<NodePath> MultiplayerSynchronizer::get_delta_properties(uint64_t p_indexes) {
 	List<NodePath> out;
 	ERR_FAIL_COND_V(replication_config.is_null(), out);
-	const List<NodePath> watch_props = replication_config->get_watch_properties();
+	const List<NodePath> watch_props(replication_config->get_watch_properties());
 	int idx = 0;
 	for (const NodePath &prop : watch_props) {
 		if ((p_indexes & (1ULL << idx++)) == 0) {

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -249,7 +249,7 @@ Error SceneReplicationInterface::on_replication_start(Object *p_obj, Variant p_c
 		if (pending_buffer_size > 0) {
 			ERR_FAIL_COND_V(!node || !sync->get_replication_config_ptr(), ERR_UNCONFIGURED);
 			int consumed = 0;
-			const List<NodePath> props = sync->get_replication_config_ptr()->get_spawn_properties();
+			const List<NodePath> props(sync->get_replication_config_ptr()->get_spawn_properties());
 			Vector<Variant> vars;
 			vars.resize(props.size());
 			Error err = MultiplayerAPI::decode_and_decompress_variants(vars, pending_buffer, pending_buffer_size, consumed);
@@ -823,7 +823,7 @@ void SceneReplicationInterface::_send_sync(int p_peer, const HashSet<ObjectID> &
 		int size;
 		Vector<Variant> vars;
 		Vector<const Variant *> varp;
-		const List<NodePath> props = sync->get_replication_config_ptr()->get_sync_properties();
+		const List<NodePath> props(sync->get_replication_config_ptr()->get_sync_properties());
 		Error err = MultiplayerSynchronizer::get_state(props, node, vars, varp);
 		ERR_CONTINUE_MSG(err != OK, "Unable to retrieve sync state.");
 		err = MultiplayerAPI::encode_and_compress_variants(varp.ptrw(), varp.size(), nullptr, size);
@@ -882,7 +882,7 @@ Error SceneReplicationInterface::on_sync_receive(int p_from, const uint8_t *p_bu
 			ofs += size;
 			continue;
 		}
-		const List<NodePath> props = sync->get_replication_config_ptr()->get_sync_properties();
+		const List<NodePath> props(sync->get_replication_config_ptr()->get_sync_properties());
 		Vector<Variant> vars;
 		vars.resize(props.size());
 		int consumed;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -274,7 +274,7 @@ void OS_MacOS::set_cmdline_platform_args(const List<String> &p_args) {
 }
 
 List<String> OS_MacOS::get_cmdline_platform_args() const {
-	return launch_service_args;
+	return List<String>(launch_service_args);
 }
 
 void OS_MacOS::load_shell_environment() const {
@@ -869,7 +869,7 @@ Error OS_MacOS::create_instance(const List<String> &p_arguments, ProcessID *r_ch
 			// Project started from the editor, inject "path" argument to set instance working directory.
 			char cwd[PATH_MAX];
 			if (::getcwd(cwd, sizeof(cwd)) != nullptr) {
-				List<String> arguments = p_arguments;
+				List<String> arguments(p_arguments);
 				arguments.push_back("--path");
 				arguments.push_back(String::utf8(cwd));
 				return create_process(path, arguments, r_child_id, false);

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -2590,7 +2590,7 @@ TypedArray<Dictionary> GraphEdit::_get_connections_intersecting_with_rect(const 
 TypedArray<Dictionary> GraphEdit::_get_connection_list_from_node(const StringName &p_node) const {
 	ERR_FAIL_COND_V(!connection_map.has(p_node), TypedArray<Dictionary>());
 
-	List<Ref<GraphEdit::Connection>> connections_from_node = connection_map.get(p_node);
+	List<Ref<GraphEdit::Connection>> connections_from_node(connection_map.get(p_node));
 	TypedArray<Dictionary> connections_from_node_dict;
 
 	for (const Ref<Connection> &conn : connections_from_node) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3211,7 +3211,7 @@ void Node::replace_by(RequiredParam<Node> rp_node, bool p_keep_groups) {
 	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
 	ERR_FAIL_COND(p_node->data.parent);
 
-	List<Node *> owned = data.owned;
+	List<Node *> owned(data.owned);
 	List<Node *> owned_by_owner;
 	Node *owner = (data.owner == this) ? p_node : data.owner;
 


### PR DESCRIPTION
- Similar to #115093 
- Similar to #115309 
- Supersedes part of https://github.com/godotengine/godot/pull/111372

This change makes it harder to accidentally copy `List` instances. This decreases the chance of performance problems and regressions.

Programmers will be forced to take a reference, move, otherwise avoid the copy, or explicitly make the copy:

```c++
List<int> list;

List<int> other = list; // implicit copy, now impossible 

List<int> other(list); // explicit copy
List<int> other = List(list); // explicit copy
List<int> &other = list; // reference
List<int> other = std::move(list); // move
```

This PR is mostly performance agnostic; that is, if a copy was happening beforehand, there will be a copy afterwards (just explicit instead of implicit). There are a few minor exceptions that I'm very sure are safe.