### PR TITLE
Fix hostfxr initialization treating non-zero success codes as failure

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -34,6 +34,7 @@
 #include "../glue/runtime_interop.h"
 #include "../godotsharp_dirs.h"
 #include "../thirdparty/coreclr_delegates.h"
+#include "../thirdparty/error_codes.h"
 #include "../thirdparty/hostfxr.h"
 #include "../utils/path_utils.h"
 #include "gd_mono_cache.h"
@@ -362,7 +363,7 @@ bool load_coreclr(void *&r_coreclr_dll_handle) {
 load_assembly_and_get_function_pointer_fn initialize_hostfxr_for_config(const char_t *p_config_path) {
 	hostfxr_handle cxt = nullptr;
 	int rc = hostfxr_initialize_for_runtime_config(p_config_path, nullptr, &cxt);
-	if (rc != 0 || cxt == nullptr) {
+	if (!STATUS_CODE_SUCCEEDED(rc) || cxt == nullptr) {
 		hostfxr_close(cxt);
 		ERR_FAIL_V_MSG(nullptr, "hostfxr_initialize_for_runtime_config failed with code: " + itos(rc));
 	}
@@ -400,7 +401,7 @@ load_assembly_and_get_function_pointer_fn initialize_hostfxr_self_contained(
 	}
 
 	int rc = hostfxr_initialize_for_dotnet_command_line(argv.size(), argv.ptrw(), nullptr, &cxt);
-	if (rc != 0 || cxt == nullptr) {
+	if (!STATUS_CODE_SUCCEEDED(rc) || cxt == nullptr) {
 		hostfxr_close(cxt);
 		ERR_FAIL_V_MSG(nullptr, "hostfxr_initialize_for_dotnet_command_line failed with code: " + itos(rc));
 	}

--- a/modules/mono/thirdparty/error_codes.h
+++ b/modules/mono/thirdparty/error_codes.h
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef __ERROR_CODES_H__
+#define __ERROR_CODES_H__
+
+// These error and exit codes are documented in the host-error-codes.md
+enum StatusCode
+{
+    // Success
+    Success                             = 0,
+    Success_HostAlreadyInitialized      = 0x00000001,
+    Success_DifferentRuntimeProperties  = 0x00000002,
+
+    // Failure
+    InvalidArgFailure                   = 0x80008081,
+    CoreHostLibLoadFailure              = 0x80008082,
+    CoreHostLibMissingFailure           = 0x80008083,
+    CoreHostEntryPointFailure           = 0x80008084,
+    CoreHostCurHostFindFailure          = 0x80008085,
+    // unused                           = 0x80008086,
+    CoreClrResolveFailure               = 0x80008087,
+    CoreClrBindFailure                  = 0x80008088,
+    CoreClrInitFailure                  = 0x80008089,
+    CoreClrExeFailure                   = 0x8000808a,
+    ResolverInitFailure                 = 0x8000808b,
+    ResolverResolveFailure              = 0x8000808c,
+    LibHostCurExeFindFailure            = 0x8000808d,
+    LibHostInitFailure                  = 0x8000808e,
+    // unused                           = 0x8000808f,
+    LibHostExecModeFailure              = 0x80008090,
+    LibHostSdkFindFailure               = 0x80008091,
+    LibHostInvalidArgs                  = 0x80008092,
+    InvalidConfigFile                   = 0x80008093,
+    AppArgNotRunnable                   = 0x80008094,
+    AppHostExeNotBoundFailure           = 0x80008095,
+    FrameworkMissingFailure             = 0x80008096,
+    HostApiFailed                       = 0x80008097,
+    HostApiBufferTooSmall               = 0x80008098,
+    LibHostUnknownCommand               = 0x80008099,
+    LibHostAppRootFindFailure           = 0x8000809a,
+    SdkResolverResolveFailure           = 0x8000809b,
+    FrameworkCompatFailure              = 0x8000809c,
+    FrameworkCompatRetry                = 0x8000809d,
+    // unused                           = 0x8000809e,
+    BundleExtractionFailure             = 0x8000809f,
+    BundleExtractionIOError             = 0x800080a0,
+    LibHostDuplicateProperty            = 0x800080a1,
+    HostApiUnsupportedVersion           = 0x800080a2,
+    HostInvalidState                    = 0x800080a3,
+    HostPropertyNotFound                = 0x800080a4,
+    CoreHostIncompatibleConfig          = 0x800080a5,
+    HostApiUnsupportedScenario          = 0x800080a6,
+    HostFeatureDisabled                 = 0x800080a7,
+};
+
+#define STATUS_CODE_SUCCEEDED(status_code) ((static_cast<int>(static_cast<StatusCode>(status_code))) >= 0)
+
+#endif // __ERROR_CODES_H__


### PR DESCRIPTION
The .NET hosting API (hostfxr) defines multiple success status codes:
- 0: Success
- 1: Success_HostAlreadyInitialized
- 2: Success_DifferentRuntimeProperties

Both `hostfxr_initialize_for_runtime_config` and
`hostfxr_initialize_for_dotnet_command_line` can return these non-zero success codes (e.g. when the .NET runtime has already been initialized by a host application). The existing `rc != 0` checks incorrectly treat these as failures.

This PR adds the standard .NET hosting error_codes.h (from the .NET Foundation, MIT license, https://github.com/dotnet/runtime/blob/main/src/native/corehost/error_codes.h) and uses its `STATUS_CODE_SUCCEEDED()` macro to properly check for success (status_code >= 0), matching the documented behavior of the hosting API.

This enables libgodot with mono enabled to have a chance to be loaded from a .NET process.

*(it's part of a variety of potential checks that need to succeed for this to work seamlessly, but this one is an atomic bug fix where the hostfxr spec was violated and Godot/libgodot exhibits unexpected behaviour)*

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
