### PR TITLE
Add Drawable Texture Layered variant of TextureArrays

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1246,6 +1246,59 @@ void TextureStorage::texture_drawable_initialize(RID p_texture, int p_width, int
 	texture_set_data(p_texture, image);
 }
 
+void TextureStorage::texture_drawable_layered_initialize(RID p_texture, int p_width, int p_height, RS::TextureDrawableFormat p_format, int p_layers, RS::TextureLayeredType p_layered_type, bool p_with_mipmaps) {
+	ERR_FAIL_COND(p_layers == 0);
+
+	ERR_FAIL_COND(p_layered_type == RS::TEXTURE_LAYERED_CUBEMAP && p_layers != 6);
+	ERR_FAIL_COND_MSG(p_layered_type == RS::TEXTURE_LAYERED_CUBEMAP_ARRAY, "Cubemap Arrays are not supported in the Compatibility renderer.");
+
+	// GUARDRAIL: Bad Widths/Heights
+	ERR_FAIL_COND_MSG(p_width <= 0 || p_height <= 0, "Drawable Texture Width or Height cannot be 0");
+	ERR_FAIL_COND_MSG(p_width >= 16384 || p_height >= 16384, "Drawable Texture Width or Height cannot be greater than 16384");
+
+	Image::Format format;
+	switch (p_format) {
+		case RS::TEXTURE_DRAWABLE_FORMAT_RGBA8:
+			format = Image::FORMAT_RGBA8;
+			break;
+		case RS::TEXTURE_DRAWABLE_FORMAT_RGBA8_SRGB:
+			format = Image::FORMAT_RGBA8;
+			break;
+		case RS::TEXTURE_DRAWABLE_FORMAT_RGBAH:
+			format = Image::FORMAT_RGBAH;
+			break;
+		case RS::TEXTURE_DRAWABLE_FORMAT_RGBAF:
+			format = Image::FORMAT_RGBAF;
+			break;
+		default:
+			format = Image::FORMAT_RGBA8;
+	}
+
+	Ref<Image> image = Image::create_empty(p_width, p_height, p_with_mipmaps, format);
+	image->fill(Color(1, 1, 1, 1));
+
+	Texture texture;
+	texture.width = p_width;
+	texture.height = p_height;
+	texture.alloc_width = texture.width;
+	texture.alloc_height = texture.height;
+	texture.mipmaps = image->get_mipmap_count() + 1;
+	texture.format = image->get_format();
+	texture.type = Texture::TYPE_LAYERED;
+	texture.layered_type = p_layered_type;
+	texture.target = GL_TEXTURE_2D_ARRAY;
+	texture.layers = p_layers;
+	_get_gl_image_and_format(Ref<Image>(), texture.format, texture.real_format, texture.gl_format_cache, texture.gl_internal_format_cache, texture.gl_type_cache, texture.compressed, false);
+	texture.total_data_size = image->get_image_data_size(texture.width, texture.height, texture.format, texture.mipmaps) * texture.layers;
+	texture.active = true;
+	glGenTextures(1, &texture.tex_id);
+	GLES3::Utilities::get_singleton()->texture_allocated_data(texture.tex_id, texture.total_data_size, "Texture Layered");
+	texture_owner.initialize_rid(p_texture, texture);
+	for (int i = 0; i < p_layers; i++) {
+		_texture_set_data(p_texture, image, i, i == 0);
+	}
+}
+
 RID TextureStorage::texture_create_from_native_handle(RS::TextureType p_type, Image::Format p_format, uint64_t p_native_handle, int p_width, int p_height, int p_depth, int p_layers, RS::TextureLayeredType p_layered_type) {
 	Texture texture;
 	texture.active = true;
@@ -1465,6 +1518,130 @@ void TextureStorage::texture_drawable_blit_rect(const TypedArray<RID> &p_texture
 		case GLES3::TexBlitShaderData::BLEND_MODE_SUB:
 			glBlendEquation(GL_FUNC_REVERSE_SUBTRACT);
 			glBlendFuncSeparate(GL_ONE, GL_ONE, GL_ONE, GL_ONE);
+			break;
+
+		case GLES3::TexBlitShaderData::BLEND_MODE_MIX:
+			glBlendEquation(GL_FUNC_ADD);
+			glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+			break;
+
+		case GLES3::TexBlitShaderData::BLEND_MODE_MUL:
+			glBlendEquation(GL_FUNC_ADD);
+			glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_DST_ALPHA, GL_ZERO);
+			break;
+
+		case GLES3::TexBlitShaderData::BLEND_MODE_DISABLED:
+			glDisable(GL_BLEND);
+			break;
+	}
+
+	glDrawBuffers(draw_buffers.size(), draw_buffers.ptr());
+
+	// DRAW!!
+	glBindVertexArray(tex_blit_quad_array);
+	glDrawArrays(GL_TRIANGLES, 0, 6);
+	glBindVertexArray(0);
+
+	// Reset to system FBO
+	glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
+}
+
+void TextureStorage::texture_drawable_layered_blit_rect_layers(RID p_texture, const Vector<int> &p_layers, const Rect2i &p_rect, RID p_material, const Color &p_modulate, const TypedArray<RID> &p_source_textures, int p_to_mipmap) {
+	ERR_FAIL_COND_MSG(!tex_blit_shader.initialized, "Texture Blit shader & materials not yet initialized");
+	ERR_FAIL_COND_MSG(p_layers.size() == 0, "Blit Rect Layers layers array must contain at least 1 texture");
+	GLES3::MaterialStorage *material_storage = GLES3::MaterialStorage::get_singleton();
+
+	TexBlitMaterialData *m = static_cast<TexBlitMaterialData *>(material_storage->material_get_data(p_material, RS::SHADER_TEXTURE_BLIT));
+	if (!m) {
+		m = static_cast<TexBlitMaterialData *>(material_storage->material_get_data(tex_blit_shader.default_material, RS::SHADER_TEXTURE_BLIT));
+	}
+	// GUARDRAIL: p_material MUST BE ShaderType TextureBlit
+	ERR_FAIL_NULL(m);
+
+	TexBlitShaderGLES3::ShaderVariant variant = TexBlitShaderGLES3::MODE_DEFAULT;
+	RID version = tex_blit_shader.default_shader_version;
+	if (m->shader_data->version.is_valid() && m->shader_data->valid) {
+		// Must be called to force user ShaderMaterials to actually populate uniform buffer before binding
+		// NOTE: Not an ideal work around, maybe in the future this can only update this MaterialData and remove it from the queue, instead of processing all queued updates
+		material_storage->_update_queued_materials();
+		// Bind material uniform buffer and textures.
+		m->bind_uniforms();
+		version = m->shader_data->version;
+	}
+
+	glBindFramebuffer(GL_FRAMEBUFFER, tex_blit_fbo);
+	TightLocalVector<GLenum> draw_buffers;
+
+	Texture *tex = get_texture(p_texture);
+	ERR_FAIL_COND_MSG(!tex, "Drawable Texture target cannot be null");
+	ERR_FAIL_COND_MSG(tex->type != Texture::TYPE_LAYERED, "Drawable Texture Array Target is not Layered!");
+	ERR_FAIL_COND_MSG(p_to_mipmap >= tex->mipmaps, vformat("Drawable Texture Target does not have %s mipmap level", p_to_mipmap));
+	Texture *src_textures[4];
+
+	int i = 0;
+	uint32_t specialization = 0;
+	const int outputFlagArray[4] = { 0, TexBlitShaderGLES3::USE_OUTPUT1, TexBlitShaderGLES3::USE_OUTPUT2, TexBlitShaderGLES3::USE_OUTPUT3 };
+	while (i < 4) {
+		// Attach Targets to Framebuffer
+		if (i < p_layers.size()) {
+			specialization |= outputFlagArray[i];
+			draw_buffers.push_back(GL_COLOR_ATTACHMENT0 + i);
+			ERR_FAIL_COND_MSG(p_layers[i] >= tex->layers || p_layers[i] < 0, vformat("Drawable Texture Array Target does not have %s layer", p_layers[i]));
+			glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + i, tex->tex_id, p_to_mipmap, p_layers[i]);
+		}
+
+		// Bind Sources to buffer. Use placeholder Black Texture if source is bad.
+		if (i < p_source_textures.size()) {
+			src_textures[i] = get_texture(p_source_textures[i]);
+			if (!src_textures[i]) {
+				src_textures[i] = get_texture(default_gl_textures[DEFAULT_GL_TEXTURE_BLACK]);
+			}
+		} else {
+			src_textures[i] = get_texture(default_gl_textures[DEFAULT_GL_TEXTURE_BLACK]);
+		}
+		int shift = i == 0 ? 0 : GLES3::Config::get_singleton()->max_texture_image_units - i;
+		glActiveTexture(GL_TEXTURE0 + shift);
+		glBindTexture(GL_TEXTURE_2D, src_textures[i]->tex_id);
+
+		i += 1;
+	}
+
+	bool success = material_storage->shaders.tex_blit_shader.version_bind_shader(version, variant, specialization);
+	if (!success) {
+		return;
+	}
+
+	// Calculates the Rects Offset & Size in UV space for Shader to scale Vertex Quad correctly
+	Vector3 size = texture_get_size(p_texture);
+	Vector2 offset = Vector2(p_rect.position.x / size.x, p_rect.position.y / size.y);
+	Vector2 rect_size = Vector2(p_rect.size.x / size.x, p_rect.size.y / size.y);
+	Vector2i vp_size = Vector2i(tex->alloc_width, tex->alloc_height);
+	if (p_to_mipmap != 0) {
+		vp_size.x >>= p_to_mipmap;
+		vp_size.y >>= p_to_mipmap;
+	}
+
+	glViewport(0, 0, vp_size.x, vp_size.y);
+
+	// NOTE: Tex_blit.glsl does not have separate SRGB bools for each output, and thus either all or none are SRGB, based on Output0
+	material_storage->shaders.tex_blit_shader.version_set_uniform(TexBlitShaderGLES3::CONVERT_TO_SRGB, tex->drawable_type == RS::TEXTURE_DRAWABLE_FORMAT_RGBA8_SRGB, version, variant, specialization);
+	material_storage->shaders.tex_blit_shader.version_set_uniform(TexBlitShaderGLES3::SIZE, rect_size, version, variant, specialization);
+	material_storage->shaders.tex_blit_shader.version_set_uniform(TexBlitShaderGLES3::OFFSET, offset, version, variant, specialization);
+	material_storage->shaders.tex_blit_shader.version_set_uniform(TexBlitShaderGLES3::MODULATE, p_modulate, version, variant, specialization);
+	material_storage->shaders.tex_blit_shader.version_set_uniform(TexBlitShaderGLES3::TIME, RasterizerGLES3::get_singleton()->get_total_time(), version, variant, specialization);
+
+	// Set Blend_Mode correctly
+	GLES3::TexBlitShaderData::BlendMode blend_mode = m->shader_data->blend_mode;
+	glEnable(GL_BLEND);
+	switch (blend_mode) {
+		case GLES3::TexBlitShaderData::BLEND_MODE_ADD:
+			glBlendEquation(GL_FUNC_ADD);
+			glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_SRC_ALPHA, GL_ONE);
+			break;
+
+		case GLES3::TexBlitShaderData::BLEND_MODE_SUB:
+			glBlendEquation(GL_FUNC_REVERSE_SUBTRACT);
+			glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_SRC_ALPHA, GL_ONE);
 			break;
 
 		case GLES3::TexBlitShaderData::BLEND_MODE_MIX:

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -553,6 +553,7 @@ public:
 	virtual void texture_external_initialize(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) override;
 	virtual void texture_proxy_initialize(RID p_texture, RID p_base) override; //all slices, then all the mipmaps, must be coherent
 	virtual void texture_drawable_initialize(RID p_texture, int p_width, int p_height, RS::TextureDrawableFormat p_format, const Color &p_color, bool p_with_mipmaps) override;
+	virtual void texture_drawable_layered_initialize(RID p_texture, int p_width, int p_height, RS::TextureDrawableFormat p_format, int p_layers, RS::TextureLayeredType p_layered_type, bool p_with_mipmaps) override;
 
 	virtual RID texture_create_from_native_handle(RS::TextureType p_type, Image::Format p_format, uint64_t p_native_handle, int p_width, int p_height, int p_depth, int p_layers = 1, RS::TextureLayeredType p_layered_type = RS::TEXTURE_LAYERED_2D_ARRAY) override;
 
@@ -563,6 +564,7 @@ public:
 	void texture_remap_proxies(RID p_from_texture, RID p_to_texture);
 
 	virtual void texture_drawable_blit_rect(const TypedArray<RID> &p_textures, const Rect2i &p_rect, RID p_material, const Color &p_modulate, const TypedArray<RID> &p_source_textures, int p_to_mipmap) override;
+	virtual void texture_drawable_layered_blit_rect_layers(RID p_texture, const Vector<int> &p_layers, const Rect2i &p_rect, RID p_material, const Color &p_modulate, const TypedArray<RID> &p_source_textures, int p_to_mipmap) override;
 
 	Ref<Image> texture_2d_placeholder;
 	Vector<Ref<Image>> texture_2d_array_placeholder;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1062,6 +1062,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(CameraTexture);
 	GDREGISTER_CLASS(ExternalTexture);
 	GDREGISTER_CLASS(DrawableTexture2D);
+	GDREGISTER_CLASS(DrawableTextureArray);
 	GDREGISTER_VIRTUAL_CLASS(TextureLayered);
 	GDREGISTER_ABSTRACT_CLASS(ImageTextureLayered);
 	GDREGISTER_VIRTUAL_CLASS(Texture3D);

--- a/scene/resources/drawable_texture_2d.cpp
+++ b/scene/resources/drawable_texture_2d.cpp
@@ -239,3 +239,136 @@ void DrawableTexture2D::_bind_methods() {
 	BIND_ENUM_CONSTANT(DRAWABLE_FORMAT_RGBAH);
 	BIND_ENUM_CONSTANT(DRAWABLE_FORMAT_RGBAF);
 }
+
+Image::Format DrawableTextureArray::get_format() const {
+	Image::Format ret_format;
+	switch (format) {
+		case DrawableTexture2D::DRAWABLE_FORMAT_RGBA8:
+			ret_format = Image::FORMAT_RGBA8;
+			break;
+		case DrawableTexture2D::DRAWABLE_FORMAT_RGBA8_SRGB:
+			ret_format = Image::FORMAT_RGBA8;
+			break;
+		case DrawableTexture2D::DRAWABLE_FORMAT_RGBAH:
+			ret_format = Image::FORMAT_RGBAH;
+			break;
+		case DrawableTexture2D::DRAWABLE_FORMAT_RGBAF:
+			ret_format = Image::FORMAT_RGBAF;
+			break;
+		default:
+			ret_format = Image::FORMAT_RGBA8;
+	}
+
+	return ret_format;
+}
+
+int DrawableTextureArray::get_width() const {
+	return width;
+}
+
+int DrawableTextureArray::get_height() const {
+	return height;
+}
+
+int DrawableTextureArray::get_layers() const {
+	return layers;
+}
+
+bool DrawableTextureArray::has_mipmaps() const {
+	return mipmaps;
+}
+
+DrawableTextureArray::LayeredType DrawableTextureArray::get_layered_type() const {
+	return layered_type;
+}
+
+TypedArray<Image> DrawableTextureArray::_get_images() const {
+	TypedArray<Image> images;
+	for (int i = 0; i < layers; i++) {
+		images.push_back(get_layer_data(i));
+	}
+	return images;
+}
+
+// Setup basic parameters on the Drawable Texture
+void DrawableTextureArray::setup(int p_width, int p_height, DrawableTexture2D::DrawableFormat p_format, int p_layers, DrawableTextureArray::LayeredType p_layer_type, bool p_use_mipmaps) {
+	ERR_FAIL_COND_MSG(p_width <= 0 || p_width > 16384, "Texture dimensions have to be within 1 to 16384 range.");
+	ERR_FAIL_COND_MSG(p_height <= 0 || p_height > 16384, "Texture dimensions have to be within 1 to 16384 range.");
+	width = p_width;
+	height = p_height;
+	format = p_format;
+	layers = p_layers;
+	layered_type = p_layer_type;
+	mipmaps = p_use_mipmaps;
+	if (texture.is_valid()) {
+		RID new_texture = RS::get_singleton()->texture_drawable_layered_create(width, height, (RS::TextureDrawableFormat)format, layers, RS::TextureLayeredType(p_layer_type), mipmaps);
+		RS::get_singleton()->texture_replace(texture, new_texture);
+	} else {
+		texture = RS::get_singleton()->texture_drawable_layered_create(width, height, (RS::TextureDrawableFormat)format, layers, RS::TextureLayeredType(p_layer_type), mipmaps);
+	}
+	notify_property_list_changed();
+	emit_changed();
+}
+
+void DrawableTextureArray::blit_rect_layers(const Vector<int> &p_layers, const Rect2i p_rect, const TypedArray<Texture2D> &p_sources, const Color &p_modulate, int p_mipmap, const Ref<Material> &p_material) {
+	RID material = default_material;
+	if (!p_material.is_null()) {
+		material = p_material->get_rid();
+		if (p_material->get_shader_mode() != Shader::MODE_TEXTURE_BLIT) {
+			WARN_PRINT("ShaderMaterial passed to blit_rect() is not a texture_blit shader. Using default instead");
+		}
+	}
+
+	int i = 0;
+	Array src_textures;
+	while (i < p_sources.size()) {
+		if (Ref<AtlasTexture>(p_sources[i]).is_valid()) {
+			WARN_PRINT("AtlasTexture not supported as a source for blit_rect. Using default Black");
+			src_textures.push_back(RID());
+		} else {
+			src_textures.push_back(RID(p_sources[i]));
+		}
+		ERR_FAIL_COND_MSG(texture == RID(src_textures[i]), "Cannot use self as a source");
+		i += 1;
+	}
+
+	RS::get_singleton()->texture_drawable_layered_blit_rect_layers(texture, p_layers, p_rect, material, p_modulate, src_textures, p_mipmap);
+	notify_property_list_changed();
+}
+
+Ref<Image> DrawableTextureArray::get_layer_data(int p_layer) const {
+	ERR_FAIL_INDEX_V(p_layer, layers, Ref<Image>());
+	return RS::get_singleton()->texture_2d_layer_get(texture, p_layer);
+}
+
+RID DrawableTextureArray::get_rid() const {
+	if (texture.is_null()) {
+		texture = RS::get_singleton()->texture_2d_layered_placeholder_create(RS::TextureLayeredType(RS::TEXTURE_LAYERED_2D_ARRAY));
+	}
+	return texture;
+}
+
+void DrawableTextureArray::generate_mipmaps() {
+	if (texture.is_valid()) {
+		RS::get_singleton()->texture_drawable_generate_mipmaps(texture);
+	}
+}
+
+void DrawableTextureArray::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("setup", "width", "height", "format", "layers", "layers_type", "use_mipmaps"), &DrawableTextureArray::setup);
+	ClassDB::bind_method(D_METHOD("blit_rect_layers", "layers", "rect", "sources", "modulate", "mipmap", "material"), &DrawableTextureArray::blit_rect_layers, DEFVAL(Color(1, 1, 1)), DEFVAL(0), DEFVAL(Ref<Material>()));
+	ClassDB::bind_method(D_METHOD("generate_mipmaps"), &DrawableTextureArray::generate_mipmaps);
+
+	ClassDB::bind_method(D_METHOD("_get_images"), &DrawableTextureArray::_get_images);
+}
+
+DrawableTextureArray::DrawableTextureArray() {
+	default_material = RS::get_singleton()->texture_drawable_get_default_material();
+}
+
+DrawableTextureArray::~DrawableTextureArray() {
+	if (texture.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
+		RS::get_singleton()->free_rid(texture);
+	}
+}

--- a/scene/resources/drawable_texture_2d.h
+++ b/scene/resources/drawable_texture_2d.h
@@ -92,4 +92,45 @@ public:
 	~DrawableTexture2D();
 };
 
+class DrawableTextureArray : public TextureLayered {
+	GDCLASS(DrawableTextureArray, TextureLayered);
+
+	LayeredType layered_type;
+
+	mutable RID texture;
+	DrawableTexture2D::DrawableFormat format = DrawableTexture2D::DRAWABLE_FORMAT_RGBA8;
+
+	RID default_material;
+
+	int width = 0;
+	int height = 0;
+	int layers = 0;
+	bool mipmaps = false;
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual Image::Format get_format() const override;
+	virtual int get_width() const override;
+	virtual int get_height() const override;
+	virtual int get_layers() const override;
+	virtual bool has_mipmaps() const override;
+	virtual LayeredType get_layered_type() const override;
+
+	TypedArray<Image> _get_images() const;
+	virtual Ref<Image> get_layer_data(int p_layer) const override;
+
+	virtual RID get_rid() const override;
+
+	void setup(int p_width, int p_height, DrawableTexture2D::DrawableFormat p_format, int p_layers, LayeredType p_layer_type, bool p_use_mipmaps = false);
+
+	void blit_rect_layers(const Vector<int> &p_layers, const Rect2i p_rect, const TypedArray<Texture2D> &p_sources, const Color &p_modulate = Color(1, 1, 1), int p_mipmap = 0, const Ref<Material> &p_material = Ref<Material>());
+
+	void generate_mipmaps();
+
+	DrawableTextureArray();
+	~DrawableTextureArray();
+};
+
 VARIANT_ENUM_CAST(DrawableTexture2D::DrawableFormat)

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -89,6 +89,7 @@ public:
 	virtual void texture_external_initialize(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) override {}
 	virtual void texture_proxy_initialize(RID p_texture, RID p_base) override {} //all slices, then all the mipmaps, must be coherent
 	virtual void texture_drawable_initialize(RID p_texture, int p_width, int p_height, RS::TextureDrawableFormat p_format, const Color &p_color, bool p_with_mipmaps) override {}
+	virtual void texture_drawable_layered_initialize(RID p_texture, int p_width, int p_height, RS::TextureDrawableFormat p_format, int p_layers, RS::TextureLayeredType p_layered_type, bool p_with_mipmaps) override {}
 
 	virtual RID texture_create_from_native_handle(RS::TextureType p_type, Image::Format p_format, uint64_t p_native_handle, int p_width, int p_height, int p_depth, int p_layers = 1, RS::TextureLayeredType p_layered_type = RS::TEXTURE_LAYERED_2D_ARRAY) override { return RID(); }
 
@@ -98,6 +99,7 @@ public:
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) override {}
 
 	virtual void texture_drawable_blit_rect(const TypedArray<RID> &p_textures, const Rect2i &p_rect, RID p_material, const Color &p_modulate, const TypedArray<RID> &p_source_textures, int p_to_mipmap) override {}
+	virtual void texture_drawable_layered_blit_rect_layers(RID p_texture, const Vector<int> &p_layers, const Rect2i &p_rect, RID p_material, const Color &p_modulate, const TypedArray<RID> &p_source_textures, int p_to_mipmap = 0) override {}
 
 	//these two APIs can be used together or in combination with the others.
 	virtual void texture_2d_placeholder_initialize(RID p_texture) override {}

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1352,6 +1352,125 @@ void TextureStorage::texture_drawable_initialize(RID p_texture, int p_width, int
 	texture_owner.initialize_rid(p_texture, texture);
 }
 
+void TextureStorage::texture_drawable_layered_initialize(RID p_texture, int p_width, int p_height, RS::TextureDrawableFormat p_format, int p_layers, RS::TextureLayeredType p_layered_type, bool p_with_mipmaps) {
+	ERR_FAIL_COND(p_layers == 0);
+
+	ERR_FAIL_COND(p_layered_type == RS::TEXTURE_LAYERED_CUBEMAP && p_layers != 6);
+	ERR_FAIL_COND(p_layered_type == RS::TEXTURE_LAYERED_CUBEMAP_ARRAY && (p_layers < 6 || (p_layers % 6) != 0));
+
+	// GUARDRAIL: Bad Widths/Heights
+	ERR_FAIL_COND_MSG(p_width <= 0 || p_height <= 0, "Drawable Texture Width or Height cannot be less than 1.");
+	ERR_FAIL_COND_MSG(p_width >= 16384 || p_height >= 16384, "Drawable Texture Width or Height cannot be greater than 16383.");
+
+	TextureToRDFormat ret_format;
+
+	Image::Format format;
+	switch (p_format) {
+		case RS::TEXTURE_DRAWABLE_FORMAT_RGBA8:
+			format = Image::FORMAT_RGBA8;
+			break;
+		case RS::TEXTURE_DRAWABLE_FORMAT_RGBA8_SRGB:
+			format = Image::FORMAT_RGBA8;
+			break;
+		case RS::TEXTURE_DRAWABLE_FORMAT_RGBAH:
+			format = Image::FORMAT_RGBAH;
+			break;
+		case RS::TEXTURE_DRAWABLE_FORMAT_RGBAF:
+			format = Image::FORMAT_RGBAF;
+			break;
+		default:
+			format = Image::FORMAT_RGBA8;
+	}
+
+	Ref<Image> image = Image::create_empty(p_width, p_height, p_with_mipmaps, format);
+	image->fill(Color(1, 1, 1, 1));
+	Ref<Image> valid_image = _validate_texture_format(image, ret_format);
+
+	Texture texture;
+
+	texture.type = TextureStorage::TYPE_LAYERED;
+	texture.layered_type = p_layered_type;
+	switch (p_layered_type) {
+		case RS::TEXTURE_LAYERED_2D_ARRAY: {
+			texture.rd_type = RD::TEXTURE_TYPE_2D_ARRAY;
+		} break;
+		case RS::TEXTURE_LAYERED_CUBEMAP: {
+			texture.rd_type = RD::TEXTURE_TYPE_CUBE;
+		} break;
+		case RS::TEXTURE_LAYERED_CUBEMAP_ARRAY: {
+			texture.rd_type = RD::TEXTURE_TYPE_CUBE_ARRAY;
+		} break;
+		default:
+			ERR_FAIL(); // Shouldn't happen, silence warnings.
+	}
+
+	texture.width = p_width;
+	texture.height = p_height;
+	texture.layers = p_layers;
+	texture.mipmaps = image->get_mipmap_count() + 1;
+	texture.depth = 1;
+	texture.format = image->get_format();
+	texture.validated_format = image->get_format();
+
+	texture.rd_format = ret_format.format;
+	texture.rd_format_srgb = ret_format.format_srgb;
+
+	RD::TextureFormat rd_format;
+	RD::TextureView rd_view;
+	{ //attempt register
+		rd_format.format = texture.rd_format;
+		rd_format.width = texture.width;
+		rd_format.height = texture.height;
+		rd_format.depth = 1;
+		rd_format.array_layers = texture.layers;
+		rd_format.mipmaps = texture.mipmaps;
+		rd_format.texture_type = texture.rd_type;
+		rd_format.samples = RD::TEXTURE_SAMPLES_1;
+		rd_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;
+		if (texture.rd_format_srgb != RD::DATA_FORMAT_MAX) {
+			rd_format.shareable_formats.push_back(texture.rd_format);
+			rd_format.shareable_formats.push_back(texture.rd_format_srgb);
+		}
+	}
+	{
+		rd_view.swizzle_r = ret_format.swizzle_r;
+		rd_view.swizzle_g = ret_format.swizzle_g;
+		rd_view.swizzle_b = ret_format.swizzle_b;
+		rd_view.swizzle_a = ret_format.swizzle_a;
+	}
+	Vector<Vector<uint8_t>> data_slices;
+	for (int i = 0; i < p_layers; i++) {
+		Vector<uint8_t> data = image->get_data(); //use image data
+		data_slices.push_back(data);
+	}
+	texture.rd_texture = RD::get_singleton()->texture_create(rd_format, rd_view, data_slices);
+	ERR_FAIL_COND(texture.rd_texture.is_null());
+	if (texture.rd_format_srgb != RD::DATA_FORMAT_MAX) {
+		rd_view.format_override = texture.rd_format_srgb;
+		texture.rd_texture_srgb = RD::get_singleton()->texture_create_shared(rd_view, texture.rd_texture);
+		if (texture.rd_texture_srgb.is_null()) {
+			RD::get_singleton()->free_rid(texture.rd_texture);
+			ERR_FAIL_COND(texture.rd_texture_srgb.is_null());
+		}
+	}
+
+	// Used for Drawable Textures.
+	for (int l = 0; l < texture.layers; l++) {
+		for (int m = 0; m < texture.mipmaps; m++) {
+			texture.cached_rd_slices.append(RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), texture.rd_texture, l, m));
+		}
+	}
+
+	//used for 2D, overridable
+	texture.width_2d = texture.width;
+	texture.height_2d = texture.height;
+	texture.is_render_target = false;
+	texture.rd_view = rd_view;
+	texture.is_proxy = false;
+
+	texture_owner.initialize_rid(p_texture, texture);
+}
+
 // Note: We make some big assumptions about format and usage. If developers need more control,
 // they should use RD::texture_create_from_extension() instead.
 RID TextureStorage::texture_create_from_native_handle(RS::TextureType p_type, Image::Format p_format, uint64_t p_native_handle, int p_width, int p_height, int p_depth, int p_layers, RS::TextureLayeredType p_layered_type) {
@@ -1801,6 +1920,141 @@ void TextureStorage::texture_drawable_blit_rect(const TypedArray<RID> &p_texture
 	RD::get_singleton()->draw_command_end_label();
 }
 
+void TextureStorage::texture_drawable_layered_blit_rect_layers(RID p_texture, const Vector<int> &p_layers, const Rect2i &p_rect, RID p_material, const Color &p_modulate, const TypedArray<RID> &p_source_textures, int p_to_mipmap) {
+	ERR_FAIL_COND_MSG(!tex_blit_shader.initialized, "Texture Blit shader & materials not yet initialized");
+	ERR_FAIL_COND_MSG(p_layers.size() == 0, "Blit Rect Layers layer array must contain at least 1 texture");
+	const RID default_tex_rid = texture_rd_get_default(DEFAULT_RD_TEXTURE_BLACK);
+	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
+
+	RendererRD::MaterialStorage::TexBlitMaterialData *m = static_cast<RendererRD::MaterialStorage::TexBlitMaterialData *>(material_storage->material_get_data(p_material, RendererRD::MaterialStorage::SHADER_TYPE_TEXTURE_BLIT));
+	if (!m) {
+		m = static_cast<RendererRD::MaterialStorage::TexBlitMaterialData *>(material_storage->material_get_data(tex_blit_shader.default_material, RendererRD::MaterialStorage::SHADER_TYPE_TEXTURE_BLIT));
+	}
+	// GUARDRAIL:: p_material MUST BE ShaderType TextureBlit
+	ERR_FAIL_NULL(m);
+
+	RendererRD::MaterialStorage::TexBlitShaderData *shader_data = m->shader_data;
+	ERR_FAIL_NULL(shader_data);
+	material_storage->_update_queued_materials();
+	RID shaderRD = tex_blit_shader.shader.version_get_shader(shader_data->version, p_source_textures.size() - 1);
+
+	RID tar_textures[4];
+	Texture *src_textures[4];
+
+	RID uniform_texture_set;
+	int TEX_BLIT_MATERIAL_SET = 1;
+	int TEX_BLIT_TEXTURE_SET = 0;
+	LocalVector<RD::Uniform> texture_uniforms;
+	texture_uniforms.clear();
+	Texture *tex = get_texture(p_texture);
+	ERR_FAIL_COND_MSG(!tex, "Drawable Texture target cannot be null");
+	ERR_FAIL_COND_MSG(tex->type != TextureType::TYPE_LAYERED, "Drawable Texture Array Target is not Layered!");
+	ERR_FAIL_COND_MSG(p_to_mipmap >= tex->mipmaps, vformat("Drawable Texture Target does not have %s mipmap level", p_to_mipmap));
+
+	int i = 0;
+	while (i < 4) {
+		// Load Target Textures
+		if (i < p_layers.size()) {
+			ERR_FAIL_COND_MSG(p_layers[i] >= tex->layers || p_layers[i] < 0, vformat("Drawable Texture Array Target does not have %s layer", p_layers[i]));
+			tar_textures[i] = tex->cached_rd_slices[i * tex->mipmaps + p_to_mipmap];
+		}
+
+		// Load and bind source textures, load default Black if source is bad.
+		RD::Uniform u;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+		u.binding = i;
+		if (i < p_source_textures.size()) {
+			src_textures[i] = get_texture(p_source_textures[i]);
+			if (!src_textures[i]) {
+				u.append_id(default_tex_rid);
+			} else {
+				u.append_id(src_textures[i]->rd_texture);
+			}
+		} else {
+			u.append_id(default_tex_rid);
+		}
+		texture_uniforms.push_back(u);
+
+		i += 1;
+	}
+
+	// Calculates the Rects Offset & Size in UV space for Shader to scale Vertex Quad correctly
+	Vector2i size = texture_2d_get_size(p_texture);
+	Vector2 offset = Vector2(float(p_rect.position.x) / size.x, float(p_rect.position.y) / size.y);
+	Vector2 rect_size = Vector2(float(p_rect.size.x) / size.x, float(p_rect.size.y) / size.y);
+
+	// Select Pipeline based on # of targets.
+	RID tex_blit_fb;
+	PipelineCacheRD *pipeline;
+	switch (p_layers.size()) {
+		case 1:
+			tex_blit_fb = FramebufferCacheRD::get_singleton()->get_cache(tar_textures[0]);
+			pipeline = &shader_data->pipelines[0];
+			break;
+		case 2:
+			tex_blit_fb = FramebufferCacheRD::get_singleton()->get_cache(tar_textures[0], tar_textures[1]);
+			pipeline = &shader_data->pipelines[1];
+			break;
+		case 3:
+			tex_blit_fb = FramebufferCacheRD::get_singleton()->get_cache(tar_textures[0], tar_textures[1], tar_textures[2]);
+			pipeline = &shader_data->pipelines[2];
+			break;
+		case 4:
+			tex_blit_fb = FramebufferCacheRD::get_singleton()->get_cache(tar_textures[0], tar_textures[1], tar_textures[2], tar_textures[3]);
+			pipeline = &shader_data->pipelines[3];
+			break;
+		default:
+			tex_blit_fb = FramebufferCacheRD::get_singleton()->get_cache(tar_textures[0], tar_textures[1], tar_textures[2], tar_textures[3]);
+			pipeline = &shader_data->pipelines[3];
+	}
+
+	// Bind uniforms via push_constant
+	TexBlitPushConstant push_constant;
+	memset(&push_constant, 0, sizeof(TexBlitPushConstant));
+
+	push_constant.offset[0] = offset.x;
+	push_constant.offset[1] = offset.y;
+	push_constant.size[0] = rect_size.x;
+	push_constant.size[1] = rect_size.y;
+	push_constant.modulate[0] = p_modulate.r;
+	push_constant.modulate[1] = p_modulate.g;
+	push_constant.modulate[2] = p_modulate.b;
+	push_constant.modulate[3] = p_modulate.a;
+	push_constant.convert_to_srgb = tex->drawable_type == RS::TEXTURE_DRAWABLE_FORMAT_RGBA8_SRGB;
+	push_constant.time = RSG::rasterizer->get_total_time();
+
+	Rect2i tex_blit_rr = Rect2i();
+
+	RD::get_singleton()->draw_command_begin_label("Blit Rect");
+	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(tex_blit_fb, RD::DRAW_DEFAULT_ALL, Vector<Color>(), 1.0f, 0u, tex_blit_rr);
+
+	RD::FramebufferFormatID fb_format = RD::get_singleton()->framebuffer_get_format(tex_blit_fb);
+	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, pipeline->get_render_pipeline(RD::INVALID_ID, fb_format, false, 0));
+
+	material_storage->samplers_rd_get_default().append_uniforms(texture_uniforms, 4);
+
+	uniform_texture_set = UniformSetCacheRD::get_singleton()->get_cache_vec(shaderRD, TEX_BLIT_TEXTURE_SET, texture_uniforms);
+
+	{
+		// Push Constants
+		RD::get_singleton()->draw_list_set_push_constant(draw_list, &push_constant, sizeof(TexBlitPushConstant));
+
+		// Material Uniforms
+		if (m->uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(m->uniform_set)) { // Material may not have a uniform set.
+			RD::get_singleton()->draw_list_bind_uniform_set(draw_list, m->uniform_set, TEX_BLIT_MATERIAL_SET);
+		}
+
+		// Texture Uniforms
+		RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uniform_texture_set, TEX_BLIT_TEXTURE_SET);
+	}
+
+	// DRAW!!
+	RD::get_singleton()->draw_list_draw(draw_list, false, 1u, 6u);
+
+	RD::get_singleton()->draw_list_end();
+	RD::get_singleton()->draw_command_end_label();
+}
+
 //these two APIs can be used together or in combination with the others.
 void TextureStorage::texture_2d_placeholder_initialize(RID p_texture) {
 	texture_2d_initialize(p_texture, texture_2d_placeholder);
@@ -1932,23 +2186,28 @@ void TextureStorage::texture_drawable_generate_mipmaps(RID p_texture) {
 	ERR_FAIL_NULL(copy_effects);
 
 	uint32_t mipmaps = tex->mipmaps;
+	uint32_t layers = tex->layers;
 	int width = tex->width;
 	int height = tex->height;
 
-	RID source = tex->rd_texture;
-	RID dest = tex->cached_rd_slices[0];
+	int curr_cache = 0;
+	for (uint32_t l = 0; l < layers; l++) {
+		RID source = tex->rd_texture;
+		RID dest = tex->cached_rd_slices[curr_cache];
 
-	for (uint32_t m = 1; m < mipmaps; m++) {
-		width = MAX(1, width >> 1);
-		height = MAX(1, height >> 1);
+		for (uint32_t m = 1; m < mipmaps; m++) {
+			width = MAX(1, width >> 1);
+			height = MAX(1, height >> 1);
 
-		source = dest;
-		dest = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), source, 0, m, 1, RD::TEXTURE_SLICE_2D);
+			source = dest;
+			curr_cache += 1;
+			dest = tex->cached_rd_slices[curr_cache];
 
-		if (copy_effects->get_raster_effects().has_flag(CopyEffects::RASTER_EFFECT_COPY)) {
-			copy_effects->make_mipmap_raster(source, dest, Size2i(width, height));
-		} else {
-			copy_effects->make_mipmap(source, dest, Size2i(width, height));
+			if (copy_effects->get_raster_effects().has_flag(CopyEffects::RASTER_EFFECT_COPY)) {
+				copy_effects->make_mipmap_raster(source, dest, Size2i(width, height));
+			} else {
+				copy_effects->make_mipmap(source, dest, Size2i(width, height));
+			}
 		}
 	}
 }

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -553,6 +553,7 @@ public:
 	virtual void texture_external_initialize(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) override;
 	virtual void texture_proxy_initialize(RID p_texture, RID p_base) override; //all slices, then all the mipmaps, must be coherent
 	virtual void texture_drawable_initialize(RID p_texture, int p_width, int p_height, RS::TextureDrawableFormat p_format, const Color &p_color, bool p_with_mipmaps) override;
+	virtual void texture_drawable_layered_initialize(RID p_texture, int p_width, int p_height, RS::TextureDrawableFormat p_format, int p_layers, RS::TextureLayeredType p_layered_type, bool p_with_mipmaps) override;
 
 	virtual RID texture_create_from_native_handle(RS::TextureType p_type, Image::Format p_format, uint64_t p_native_handle, int p_width, int p_height, int p_depth, int p_layers = 1, RS::TextureLayeredType p_layered_type = RS::TEXTURE_LAYERED_2D_ARRAY) override;
 
@@ -562,6 +563,7 @@ public:
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) override;
 
 	virtual void texture_drawable_blit_rect(const TypedArray<RID> &p_textures, const Rect2i &p_rect, RID p_material, const Color &p_modulate, const TypedArray<RID> &p_source_textures, int p_to_mipmap) override;
+	virtual void texture_drawable_layered_blit_rect_layers(RID p_texture, const Vector<int> &p_layers, const Rect2i &p_rect, RID p_material, const Color &p_modulate, const TypedArray<RID> &p_source_textures, int p_to_mipmap) override;
 
 	Ref<Image> texture_2d_placeholder;
 	Vector<Ref<Image>> texture_2d_array_placeholder;

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2330,12 +2330,14 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("texture_proxy_create", "base"), &RenderingServer::texture_proxy_create);
 	ClassDB::bind_method(D_METHOD("texture_create_from_native_handle", "type", "format", "native_handle", "width", "height", "depth", "layers", "layered_type"), &RenderingServer::texture_create_from_native_handle, DEFVAL(1), DEFVAL(TEXTURE_LAYERED_2D_ARRAY));
 	ClassDB::bind_method(D_METHOD("texture_drawable_create", "width", "height", "format", "color", "with_mipmaps"), &RenderingServer::texture_drawable_create, DEFVAL(Color(1, 1, 1, 1)), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("texture_drawable_layered_create", "width", "height", "format", "layers", "layered_type", "with_mipmaps"), &RenderingServer::texture_drawable_layered_create, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("texture_2d_update", "texture", "image", "layer"), &RenderingServer::texture_2d_update);
 	ClassDB::bind_method(D_METHOD("texture_3d_update", "texture", "data"), &RenderingServer::_texture_3d_update);
 	ClassDB::bind_method(D_METHOD("texture_proxy_update", "texture", "proxy_to"), &RenderingServer::texture_proxy_update);
 
 	ClassDB::bind_method(D_METHOD("texture_drawable_blit_rect", "textures", "rect", "material", "modulate", "source_textures", "to_mipmap"), &RenderingServer::texture_drawable_blit_rect, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("texture_drawable_layered_blit_rect_layers", "texture", "layers", "rect", "material", "modulate", "source_textures", "to_mipmap"), &RenderingServer::texture_drawable_layered_blit_rect_layers, DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("texture_2d_placeholder_create"), &RenderingServer::texture_2d_placeholder_create);
 	ClassDB::bind_method(D_METHOD("texture_2d_layered_placeholder_create", "layered_type"), &RenderingServer::texture_2d_layered_placeholder_create);

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -149,6 +149,7 @@ public:
 	virtual RID texture_external_create(int p_width, int p_height, uint64_t p_external_buffer = 0) = 0;
 	virtual RID texture_proxy_create(RID p_base) = 0;
 	virtual RID texture_drawable_create(int p_width, int p_height, TextureDrawableFormat p_format, const Color &p_color = Color(1, 1, 1, 1), bool p_with_mipmaps = false) = 0;
+	virtual RID texture_drawable_layered_create(int p_width, int p_height, TextureDrawableFormat p_format, int p_layers, TextureLayeredType p_layered_type, bool p_with_mipmaps = false) = 0;
 
 	virtual RID texture_create_from_native_handle(TextureType p_type, Image::Format p_format, uint64_t p_native_handle, int p_width, int p_height, int p_depth, int p_layers = 1, TextureLayeredType p_layered_type = TEXTURE_LAYERED_2D_ARRAY) = 0;
 
@@ -158,6 +159,7 @@ public:
 	virtual void texture_proxy_update(RID p_texture, RID p_proxy_to) = 0;
 
 	virtual void texture_drawable_blit_rect(const TypedArray<RID> &p_textures, const Rect2i &p_rect, RID p_material, const Color &p_modulate, const TypedArray<RID> &p_source_textures, int p_to_mipmap = 0) = 0;
+	virtual void texture_drawable_layered_blit_rect_layers(RID p_texture, const Vector<int> &p_layers, const Rect2i &p_rect, RID p_material, const Color &p_modulate, const TypedArray<RID> &p_source_textures, int p_to_mipmap = 0) = 0;
 
 	// These two APIs can be used together or in combination with the others.
 	virtual RID texture_2d_placeholder_create() = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -214,6 +214,7 @@ public:
 	FUNCRIDTEX3(texture_external, int, int, uint64_t)
 	FUNCRIDTEX1(texture_proxy, RID)
 	FUNCRIDTEX5(texture_drawable, int, int, TextureDrawableFormat, const Color &, bool)
+	FUNCRIDTEX6(texture_drawable_layered, int, int, TextureDrawableFormat, int, TextureLayeredType, bool)
 
 	// Called directly, not through the command queue.
 	virtual RID texture_create_from_native_handle(TextureType p_type, Image::Format p_format, uint64_t p_native_handle, int p_width, int p_height, int p_depth, int p_layers = 1, TextureLayeredType p_layered_type = TEXTURE_LAYERED_2D_ARRAY) override {
@@ -227,6 +228,7 @@ public:
 	FUNC2(texture_proxy_update, RID, RID)
 
 	FUNC6(texture_drawable_blit_rect, const TypedArray<RID> &, const Rect2i &, RID, const Color &, const TypedArray<RID> &, int)
+	FUNC7(texture_drawable_layered_blit_rect_layers, RID, const Vector<int> &, const Rect2i &, RID, const Color &, const TypedArray<RID> &, int)
 
 	//these also go pass-through
 	FUNCRIDTEX0(texture_2d_placeholder)

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -70,6 +70,7 @@ public:
 	virtual void texture_external_initialize(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) = 0;
 	virtual void texture_proxy_initialize(RID p_texture, RID p_base) = 0; //all slices, then all the mipmaps, must be coherent
 	virtual void texture_drawable_initialize(RID p_texture, int p_width, int p_height, RS::TextureDrawableFormat p_format, const Color &p_color, bool p_with_mipmaps) = 0;
+	virtual void texture_drawable_layered_initialize(RID p_texture, int p_width, int p_height, RS::TextureDrawableFormat p_format, int p_layers, RS::TextureLayeredType p_layered_type, bool p_with_mipmaps) = 0;
 
 	virtual RID texture_create_from_native_handle(RS::TextureType p_type, Image::Format p_format, uint64_t p_native_handle, int p_width, int p_height, int p_depth, int p_layers = 1, RS::TextureLayeredType p_layered_type = RS::TEXTURE_LAYERED_2D_ARRAY) = 0;
 
@@ -79,6 +80,7 @@ public:
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) = 0;
 
 	virtual void texture_drawable_blit_rect(const TypedArray<RID> &p_textures, const Rect2i &p_rect, RID p_material, const Color &p_modulate, const TypedArray<RID> &p_source_textures, int p_to_mipmap) = 0;
+	virtual void texture_drawable_layered_blit_rect_layers(RID p_texture, const Vector<int> &p_layers, const Rect2i &p_rect, RID p_material, const Color &p_modulate, const TypedArray<RID> &p_source_textures, int p_to_mipmap) = 0;
 
 	//these two APIs can be used together or in combination with the others.
 	virtual void texture_2d_placeholder_initialize(RID p_texture) = 0;


### PR DESCRIPTION
This is a feature enhancement for Drawable Textures based on the desired functionality described by @TokisanGames 

> We also need drawable textures for texture arrays, which are heavily used in Terrain3D. The current PR is lacking them, and shouldn't close this until there is a complete implementation.

As @clayjohn suggested in the discussion on the Proposal Thread

> I think we could create a Drawable texture array class with basically the same API we have now (just with specifying the target layer)

This PR adds a variant of TextureLayered, DrawableTextureArray with appropriate API in both the Rendering Server, and exposed as a high-level resource. DrawableTextureLayered is setup very similarly Drawable Texture, and uses "blit_rect_layers" which takes an array of the indexes of up to 4 layers as targets to blit to, and the same array of RIDs of up to 4 sources to blit from.

```gdscript
var imageLayered = DrawableTextureArray.new()
	imageLayered.setup(128, 128, DrawableTexture2D.DRAWABLE_FORMAT_RGBA8, 6, TextureLayered.LAYERED_TYPE_2D_ARRAY, true)
	imageLayered.blit_rect_layers([0, 1], Rect2i(32,32,64,64), [load("res://iconA.svg"), load("res://icon.svg")])
	texture = ImageTexture.create_from_image( imageLayered.get_layer_data(1) )
```

I verified basic functionality running this GDScript attached to a Texture Rect, and did indeed see that the layer data was updated appropriately by the Blit_Rect_Layers call. Highly open to feedback from more technical users, like Tokisan, who will be making use of this feature.

