### PR TITLE
Fix `simplify_path()` mangling paths with uri schemes containing non-alphanumeric characters

### DIFF
--- a/core/string/char_utils.h
+++ b/core/string/char_utils.h
@@ -110,6 +110,11 @@ constexpr bool is_ascii_identifier_char(char32_t p_char) {
 	return (p_char >= 'a' && p_char <= 'z') || (p_char >= 'A' && p_char <= 'Z') || (p_char >= '0' && p_char <= '9') || p_char == '_';
 }
 
+// See https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+constexpr bool is_uri_scheme_char(char32_t p_char) {
+	return (p_char >= 'a' && p_char <= 'z') || (p_char >= 'A' && p_char <= 'Z') || (p_char >= '0' && p_char <= '9') || p_char == '+' || p_char == '-' || p_char == '.';
+}
+
 constexpr bool is_symbol(char32_t p_char) {
 	return p_char != '_' && ((p_char >= '!' && p_char <= '/') || (p_char >= ':' && p_char <= '@') || (p_char >= '[' && p_char <= '`') || (p_char >= '{' && p_char <= '~') || p_char == '\t' || p_char == ' ');
 }

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "ustring.h"
+#include "core/string/char_utils.h"
 
 STATIC_ASSERT_INCOMPLETE_TYPE(class, Array);
 STATIC_ASSERT_INCOMPLETE_TYPE(class, Dictionary);
@@ -4146,10 +4147,16 @@ String String::simplify_path() const {
 	bool found = false;
 	if (p > 0) {
 		bool only_chars = true;
-		for (int i = 0; i < p; i++) {
-			if (!is_ascii_alphanumeric_char(s[i])) {
-				only_chars = false;
-				break;
+		// See https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+		// The first character is technically required to be an ascii alphabet character, but we're keeping this for backwards compatibility with previous Godot versions.
+		if (!is_ascii_alphanumeric_char(s[0])) {
+			only_chars = false;
+		} else {
+			for (int i = 1; i < p; i++) {
+				if (!is_uri_scheme_char(s[i])) {
+					only_chars = false;
+					break;
+				}
 			}
 		}
 		if (only_chars) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

[The RFC spec for URI](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) states that the URI scheme should be of the pattern:
```
scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
```
However, `simplify_path()` currently assumes that the URI scheme is only alphanumeric; as a result, it currently mangles URI paths if the scheme has a non-alphanumeric character in it.
For example: `sshfs+f314g23://foo.bar` gets mangled to `sshfs+f314g23:/foo.bar`.

Changing simplify_path to check for all valid uri characters past the first character fixes this.