### PR TITLE
Remove ScriptTextEditor lazy loading

### DIFF
--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -271,6 +271,12 @@ TextEditorBase::EditMenus::EditMenus() {
 }
 
 void TextEditorBase::_make_context_menu(bool p_selection, bool p_foldable, const Vector2 &p_position, bool p_show) {
+	if (context_menu == nullptr) {
+		context_menu = memnew(PopupMenu);
+		context_menu->connect(SceneStringName(id_pressed), callable_mp(this, &TextEditorBase::_edit_option));
+		add_child(context_menu);
+	}
+
 	context_menu->clear();
 	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_EMOJI_AND_SYMBOL_PICKER)) {
 		context_menu->add_item(TTRC("Emoji & Symbols"), EDIT_EMOJI_AND_SYMBOL);
@@ -469,7 +475,7 @@ bool TextEditorBase::_edit_option(int p_op) {
 			emit_signal(SNAME("replace_in_files_requested"), selected_text);
 		} break;
 		case SEARCH_GOTO_LINE: {
-			goto_line_popup->popup_find_line(code_editor);
+			ScriptEditor::get_singleton()->get_goto_line_popup()->popup_find_line(code_editor);
 		} break;
 		case BOOKMARK_TOGGLE: {
 			code_editor->toggle_bookmark();
@@ -591,9 +597,7 @@ void TextEditorBase::reload_text() {
 	te->tag_saved_version();
 
 	code_editor->update_line_and_column();
-	if (editor_enabled) {
-		_validate_script();
-	}
+	_validate_script();
 }
 
 void TextEditorBase::enable_editor() {
@@ -641,14 +645,7 @@ TextEditorBase::TextEditorBase() {
 	code_editor->connect("load_theme_settings", callable_mp(this, &TextEditorBase::_load_theme_settings));
 	code_editor->connect("show_goto_popup", callable_mp(this, &TextEditorBase::_edit_option).bind(SEARCH_GOTO_LINE));
 
-	context_menu = memnew(PopupMenu);
-	context_menu->connect(SceneStringName(id_pressed), callable_mp(this, &TextEditorBase::_edit_option));
-	add_child(context_menu);
-
 	edit_hb = memnew(HBoxContainer);
-
-	goto_line_popup = memnew(GotoLinePopup);
-	add_child(goto_line_popup);
 
 	Ref<EditorPlainTextSyntaxHighlighter> plain_highlighter;
 	plain_highlighter.instantiate();
@@ -694,9 +691,9 @@ CodeEditorBase::CodeEditorBase() {
 	warnings_panel->connect("meta_clicked", callable_mp(this, &CodeEditorBase::_warning_clicked));
 
 	editor_box = memnew(VSplitContainer);
-	add_child(editor_box);
 	editor_box->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	editor_box->set_v_size_flags(SIZE_EXPAND_FILL);
 	editor_box->add_child(code_editor);
 	editor_box->add_child(warnings_panel);
+	add_child(editor_box);
 }

--- a/editor/script/script_editor_base.h
+++ b/editor/script/script_editor_base.h
@@ -163,8 +163,6 @@ protected:
 	CodeTextEditor *code_editor = nullptr;
 	HBoxContainer *edit_hb = nullptr;
 
-	GotoLinePopup *goto_line_popup = nullptr;
-
 	LocalVector<Ref<EditorSyntaxHighlighter>> highlighters;
 
 	PopupMenu *context_menu = nullptr;

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -71,6 +71,8 @@
 #include "editor/shader/text_shader_editor.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
+#include "scene/gui/color_picker.h"
+#include "scene/gui/grid_container.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/tab_container.h"
 #include "scene/gui/texture_rect.h"
@@ -78,13 +80,10 @@
 #include "scene/main/window.h"
 #include "servers/display/display_server.h"
 
-void ScriptEditorQuickOpen::popup_dialog(const Vector<String> &p_functions, bool p_dontclear) {
+void ScriptEditorQuickOpen::popup_dialog(const Vector<String> &p_functions, CodeTextEditor *p_text_editor) {
+	text_editor = p_text_editor;
 	popup_centered_ratio(0.6);
-	if (p_dontclear) {
-		search_box->select_all();
-	} else {
-		search_box->clear();
-	}
+	search_box->clear();
 	search_box->grab_focus();
 	functions = p_functions;
 	_update_search();
@@ -119,7 +118,7 @@ void ScriptEditorQuickOpen::_confirmed() {
 	}
 	int line = ti->get_text(0).get_slicec(':', 1).to_int();
 
-	emit_signal(SNAME("goto_line"), line - 1);
+	text_editor->goto_line_centered(line - 1);
 	hide();
 }
 
@@ -133,10 +132,6 @@ void ScriptEditorQuickOpen::_notification(int p_what) {
 			disconnect(SceneStringName(confirmed), callable_mp(this, &ScriptEditorQuickOpen::_confirmed));
 		} break;
 	}
-}
-
-void ScriptEditorQuickOpen::_bind_methods() {
-	ADD_SIGNAL(MethodInfo("goto_line", PropertyInfo(Variant::INT, "line")));
 }
 
 ScriptEditorQuickOpen::ScriptEditorQuickOpen() {
@@ -3521,6 +3516,13 @@ bool ScriptEditor::script_goto_method(Ref<Script> p_script, const String &p_meth
 	return edit(p_script, line, 0);
 }
 
+Ref<Texture2D> ScriptEditor::get_color_alpha_texture() {
+	if (color_alpha_texture.is_null()) {
+		color_alpha_texture = inline_color_picker->get_theme_icon("sample_bg", "ColorPicker");
+	}
+	return color_alpha_texture;
+}
+
 void ScriptEditor::set_live_auto_reload_running_scripts(bool p_enabled) {
 	auto_reload_running_scripts = p_enabled;
 }
@@ -3719,6 +3721,13 @@ void ScriptEditor::_update_code_editor_zoom_factor(CodeTextEditor *p_code_text_e
 void ScriptEditor::_window_changed(bool p_visible) {
 	make_floating->set_visible(!p_visible);
 	is_floating = p_visible;
+}
+
+void ScriptEditor::_picker_color_changed() {
+	ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(_get_current_editor());
+	if (ste) {
+		ste->picker_color_changed();
+	}
 }
 
 void ScriptEditor::_filter_scripts_text_changed(const String &p_newtext) {
@@ -4112,6 +4121,33 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	find_in_files->close();
 	find_in_files->connect("result_selected", callable_mp(this, &ScriptEditor::_on_find_in_files_result_selected));
 	find_in_files->connect("files_modified", callable_mp(this, &ScriptEditor::_on_find_in_files_modified_files));
+
+	inline_color_popup = memnew(PopupPanel);
+	add_child(inline_color_popup);
+
+	inline_color_picker = memnew(ColorPicker);
+	inline_color_picker->set_mouse_filter(MOUSE_FILTER_STOP);
+	inline_color_picker->set_deferred_mode(true);
+	inline_color_picker->set_hex_visible(false);
+	inline_color_picker->connect("color_changed", callable_mp(this, &ScriptEditor::_picker_color_changed).unbind(1));
+	inline_color_popup->add_child(inline_color_picker);
+
+	inline_color_options = memnew(OptionButton);
+	inline_color_options->set_h_size_flags(SIZE_FILL);
+	inline_color_options->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
+	inline_color_options->set_fit_to_longest_item(false);
+	inline_color_options->connect(SceneStringName(item_selected), callable_mp(this, &ScriptEditor::_picker_color_changed).unbind(1));
+	inline_color_picker->get_slider_container()->add_sibling(inline_color_options);
+
+	goto_line_popup = memnew(GotoLinePopup);
+	add_child(goto_line_popup);
+
+	quick_open = memnew(ScriptEditorQuickOpen);
+	quick_open->set_title(TTRC("Go to Function"));
+	add_child(quick_open);
+
+	connection_info_dialog = memnew(ConnectionInfoDialog);
+	add_child(connection_info_dialog);
 
 	history_pos = -1;
 

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -59,6 +59,7 @@ class ScriptEditorQuickOpen : public ConfirmationDialog {
 	FilterLineEdit *search_box = nullptr;
 	Tree *search_options = nullptr;
 	String function;
+	CodeTextEditor *text_editor = nullptr;
 
 	void _update_search();
 
@@ -69,16 +70,19 @@ class ScriptEditorQuickOpen : public ConfirmationDialog {
 
 protected:
 	void _notification(int p_what);
-	static void _bind_methods();
 
 public:
-	void popup_dialog(const Vector<String> &p_functions, bool p_dontclear = false);
+	void popup_dialog(const Vector<String> &p_functions, CodeTextEditor *p_text_editor);
 	ScriptEditorQuickOpen();
 };
 
 class EditorScriptCodeCompletionCache;
 class FindInFilesContainer;
 class FindInFilesDialog;
+class GotoLinePopup;
+class ConnectionInfoDialog;
+class ColorPicker;
+class OptionButton;
 
 class ScriptEditor : public PanelContainer {
 	GDCLASS(ScriptEditor, PanelContainer);
@@ -184,6 +188,15 @@ class ScriptEditor : public PanelContainer {
 	ConfirmationDialog *erase_tab_confirm = nullptr;
 	ScriptCreateDialog *script_create_dialog = nullptr;
 	FindReplaceBar *find_replace_bar = nullptr;
+
+	PopupPanel *inline_color_popup = nullptr;
+	ColorPicker *inline_color_picker = nullptr;
+	OptionButton *inline_color_options = nullptr;
+	Ref<Texture2D> color_alpha_texture;
+
+	GotoLinePopup *goto_line_popup = nullptr;
+	ScriptEditorQuickOpen *quick_open = nullptr;
+	ConnectionInfoDialog *connection_info_dialog = nullptr;
 
 	float zoom_factor = 1.0f;
 
@@ -393,6 +406,8 @@ class ScriptEditor : public PanelContainer {
 
 	void _window_changed(bool p_visible);
 
+	void _picker_color_changed();
+
 	void _close_builtin_scripts_from_scene(const String &p_scene);
 
 	static ScriptEditor *script_editor;
@@ -451,6 +466,15 @@ public:
 	void trigger_live_script_reload(const String &p_script_path);
 
 	VSplitContainer *get_left_list_split() { return list_split; }
+
+	PopupPanel *get_inline_color_popup() const { return inline_color_popup; }
+	ColorPicker *get_inline_color_picker() const { return inline_color_picker; }
+	OptionButton *get_inline_color_options() const { return inline_color_options; }
+	Ref<Texture2D> get_color_alpha_texture();
+
+	GotoLinePopup *get_goto_line_popup() const { return goto_line_popup; }
+	ScriptEditorQuickOpen *get_quick_open() const { return quick_open; }
+	ConnectionInfoDialog *get_connection_info_dialog() const { return connection_info_dialog; }
 
 	void set_live_auto_reload_running_scripts(bool p_enabled);
 

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -50,7 +50,7 @@
 #include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
-#include "scene/gui/grid_container.h"
+#include "scene/gui/color_picker.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/split_container.h"
@@ -241,21 +241,6 @@ void ScriptTextEditor::set_edited_resource(const Ref<Resource> &p_res) {
 
 	emit_signal(SNAME("name_changed"));
 	code_editor->update_line_and_column();
-}
-
-void ScriptTextEditor::enable_editor() {
-	if (editor_enabled) {
-		return;
-	}
-
-	_enable_code_editor();
-
-	if (pending_state != Variant()) {
-		code_editor->set_edit_state(pending_state);
-		pending_state = Variant();
-	}
-
-	TextEditorBase::enable_editor();
 }
 
 void ScriptTextEditor::_load_theme_settings() {
@@ -581,18 +566,18 @@ Array ScriptTextEditor::_inline_object_parse(const String &p_text) {
 void ScriptTextEditor::_inline_object_draw(const Dictionary &p_info, const Rect2 &p_rect) {
 	if (_is_valid_color_info(p_info)) {
 		Rect2 col_rect = p_rect.grow(-4);
-		if (color_alpha_texture.is_null()) {
-			color_alpha_texture = inline_color_picker->get_theme_icon("sample_bg", "ColorPicker");
-		}
 		RID text_ci = code_editor->get_text_editor()->get_text_canvas_item();
 		RS::get_singleton()->canvas_item_add_rect(text_ci, p_rect.grow(-3), Color(1, 1, 1));
-		color_alpha_texture->draw_rect(text_ci, col_rect);
+		ScriptEditor::get_singleton()->get_color_alpha_texture()->draw_rect(text_ci, col_rect);
 		RS::get_singleton()->canvas_item_add_rect(text_ci, col_rect, Color(p_info["color"]));
 	}
 }
 
 void ScriptTextEditor::_inline_object_handle_click(const Dictionary &p_info, const Rect2 &p_rect) {
 	if (_is_valid_color_info(p_info)) {
+		ColorPicker *inline_color_picker = ScriptEditor::get_singleton()->get_inline_color_picker();
+		PopupPanel *inline_color_popup = ScriptEditor::get_singleton()->get_inline_color_popup();
+
 		inline_color_picker->set_pick_color(p_info["color"]);
 		inline_color_line = p_info["line"];
 		inline_color_start = p_info["column"];
@@ -603,7 +588,7 @@ void ScriptTextEditor::_inline_object_handle_click(const Dictionary &p_info, con
 		code_editor->get_text_editor()->set_symbol_tooltip_on_hover_enabled(true);
 
 		_update_color_constructor_options();
-		inline_color_options->select(p_info["color_mode"]);
+		ScriptEditor::get_singleton()->get_inline_color_options()->select(p_info["color_mode"]);
 		EditorNode::get_singleton()->setup_color_picker(inline_color_picker);
 
 		// Move popup above the line if it's too low.
@@ -676,12 +661,14 @@ String ScriptTextEditor::_picker_color_stringify(const Color &p_color, COLOR_MOD
 	return result;
 }
 
-void ScriptTextEditor::_picker_color_changed(const Color &p_color) {
+void ScriptTextEditor::picker_color_changed() {
 	_update_color_constructor_options();
 	_update_color_text();
 }
 
 void ScriptTextEditor::_update_color_constructor_options() {
+	OptionButton *inline_color_options = ScriptEditor::get_singleton()->get_inline_color_options();
+	ColorPicker *inline_color_picker = ScriptEditor::get_singleton()->get_inline_color_picker();
 	int item_count = inline_color_options->get_item_count();
 	// Update or add each constructor as an option.
 	for (int i = 0; i < MODE_MAX; i++) {
@@ -736,6 +723,7 @@ void ScriptTextEditor::_update_color_text() {
 	if (inline_color_line < 0) {
 		return;
 	}
+	OptionButton *inline_color_options = ScriptEditor::get_singleton()->get_inline_color_options();
 	String result = inline_color_options->get_item_text(inline_color_options->get_selected_id());
 	code_editor->get_text_editor()->begin_complex_operation();
 	code_editor->get_text_editor()->remove_text(inline_color_line, inline_color_start, inline_color_line, inline_color_end + 1);
@@ -757,20 +745,8 @@ void ScriptTextEditor::update_settings() {
 	TextEditorBase::update_settings();
 }
 
-Variant ScriptTextEditor::get_edit_state() {
-	if (pending_state != Variant()) {
-		return pending_state;
-	}
-	return TextEditorBase::get_edit_state();
-}
-
 void ScriptTextEditor::set_edit_state(const Variant &p_state) {
-	if (editor_enabled) {
-		code_editor->set_edit_state(p_state);
-	} else {
-		// The editor is not fully initialized, so the state can't be loaded properly.
-		pending_state = p_state;
-	}
+	code_editor->set_edit_state(p_state);
 
 	Dictionary state = p_state;
 	if (state.has("syntax_highlighter")) {
@@ -780,12 +756,6 @@ void ScriptTextEditor::set_edit_state(const Variant &p_state) {
 				break;
 			}
 		}
-	}
-
-	if (editor_enabled) {
-#ifndef ANDROID_ENABLED
-		ensure_focus();
-#endif
 	}
 }
 
@@ -1635,7 +1605,7 @@ void ScriptTextEditor::_gutter_clicked(int p_line, int p_gutter) {
 
 		Ref<Script> script = edited_res;
 		Vector<Node *> nodes = _find_all_node_for_script(base, base, script);
-		connection_info_dialog->popup_connections(method, nodes);
+		ScriptEditor::get_singleton()->get_connection_info_dialog()->popup_connections(method, nodes);
 	} else if (type == "inherits") {
 		String base_class_raw = meta["base_class"];
 		PackedStringArray base_class_split = base_class_raw.split(":", true, 1);
@@ -1733,7 +1703,7 @@ bool ScriptTextEditor::_edit_option(int p_op) {
 			tx->end_complex_operation();
 		} break;
 		case SEARCH_LOCATE_FUNCTION: {
-			quick_open->popup_dialog(get_functions());
+			ScriptEditor::get_singleton()->get_quick_open()->popup_dialog(get_functions(), code_editor);
 		} break;
 		case DEBUG_TOGGLE_BREAKPOINT: {
 			Vector<int> sorted_carets = tx->get_sorted_carets();
@@ -1868,9 +1838,6 @@ void ScriptTextEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED:
-			if (!editor_enabled) {
-				break;
-			}
 			if (is_visible_in_tree()) {
 				_update_warnings();
 				_update_errors();
@@ -1880,6 +1847,7 @@ void ScriptTextEditor::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			code_editor->get_text_editor()->set_gutter_width(connection_gutter, code_editor->get_text_editor()->get_line_height());
 			Ref<Font> code_font = get_theme_font("font", "CodeEdit");
+			OptionButton *inline_color_options = ScriptEditor::get_singleton()->get_inline_color_options();
 			inline_color_options->add_theme_font_override("font", code_font);
 			inline_color_options->get_popup()->add_theme_font_override("font", code_font);
 		} break;
@@ -2653,9 +2621,25 @@ void ScriptTextEditor::register_editor() {
 	ScriptEditor::register_create_script_editor_function(create_editor);
 }
 
-void ScriptTextEditor::_enable_code_editor() {
+ScriptTextEditor::ScriptTextEditor() {
+	code_editor->set_code_complete_func(_code_complete_scripts, this);
+	code_editor->get_text_editor()->set_draw_breakpoints_gutter(true);
+	code_editor->get_text_editor()->set_draw_executing_lines_gutter(true);
+
+	code_editor->get_text_editor()->set_symbol_lookup_on_click_enabled(true);
+	code_editor->get_text_editor()->set_symbol_tooltip_on_hover_enabled(true);
+
+	code_editor->get_text_editor()->add_gutter(connection_gutter);
+	code_editor->get_text_editor()->set_gutter_name(connection_gutter, "connection_gutter");
+	code_editor->get_text_editor()->set_gutter_draw(connection_gutter, false);
+	code_editor->get_text_editor()->set_gutter_overwritable(connection_gutter, true);
+	code_editor->get_text_editor()->set_gutter_type(connection_gutter, TextEdit::GUTTER_TYPE_ICON);
+
+	code_editor->connect("navigation_preview_ended", callable_mp(this, &ScriptTextEditor::_on_caret_moved));
 	code_editor->connect("show_errors_panel", callable_mp(this, &ScriptTextEditor::_show_errors_panel));
 	code_editor->connect("show_warnings_panel", callable_mp(this, &ScriptTextEditor::_show_warnings_panel));
+	code_editor->get_text_editor()->connect("breakpoint_toggled", callable_mp(this, &ScriptTextEditor::_breakpoint_toggled));
+	code_editor->get_text_editor()->connect("caret_changed", callable_mp(this, &ScriptTextEditor::_on_caret_moved));
 	code_editor->get_text_editor()->connect("symbol_lookup", callable_mp(this, &ScriptTextEditor::_lookup_symbol));
 	code_editor->get_text_editor()->connect("symbol_hovered", callable_mp(this, &ScriptTextEditor::_show_symbol_tooltip).bind(false));
 	code_editor->get_text_editor()->connect("symbol_validate", callable_mp(this, &ScriptTextEditor::_validate_symbol));
@@ -2665,40 +2649,7 @@ void ScriptTextEditor::_enable_code_editor() {
 	code_editor->get_text_editor()->connect("_fold_line_updated", callable_mp(this, &ScriptTextEditor::_update_background_color));
 	_update_gutter_indexes();
 
-	editor_box->add_child(errors_panel);
-	errors_panel->connect("meta_clicked", callable_mp(this, &ScriptTextEditor::_error_clicked));
-
-	add_child(color_panel);
-
-	color_picker = memnew(ColorPicker);
-	color_picker->set_deferred_mode(true);
-	color_picker->connect("color_changed", callable_mp(this, &ScriptTextEditor::_color_changed));
-	color_panel->connect("about_to_popup", callable_mp(EditorNode::get_singleton(), &EditorNode::setup_color_picker).bind(color_picker));
-
-	color_panel->add_child(color_picker);
-
-	quick_open = memnew(ScriptEditorQuickOpen);
-	quick_open->set_title(TTRC("Go to Function"));
-	quick_open->connect("goto_line", callable_mp(this, &ScriptTextEditor::_goto_line));
-	add_child(quick_open);
-
-	add_child(connection_info_dialog);
-}
-
-ScriptTextEditor::ScriptTextEditor() {
-	code_editor->set_code_complete_func(_code_complete_scripts, this);
-	code_editor->get_text_editor()->set_draw_breakpoints_gutter(true);
-	code_editor->get_text_editor()->set_draw_executing_lines_gutter(true);
-	code_editor->get_text_editor()->connect("breakpoint_toggled", callable_mp(this, &ScriptTextEditor::_breakpoint_toggled));
-	code_editor->get_text_editor()->connect("caret_changed", callable_mp(this, &ScriptTextEditor::_on_caret_moved));
-	code_editor->connect("navigation_preview_ended", callable_mp(this, &ScriptTextEditor::_on_caret_moved));
-
-	connection_gutter = 1;
-	code_editor->get_text_editor()->add_gutter(connection_gutter);
-	code_editor->get_text_editor()->set_gutter_name(connection_gutter, "connection_gutter");
-	code_editor->get_text_editor()->set_gutter_draw(connection_gutter, false);
-	code_editor->get_text_editor()->set_gutter_overwritable(connection_gutter, true);
-	code_editor->get_text_editor()->set_gutter_type(connection_gutter, TextEdit::GUTTER_TYPE_ICON);
+	SET_DRAG_FORWARDING_GCD(code_editor->get_text_editor(), ScriptTextEditor);
 
 	errors_panel = memnew(RichTextLabel);
 	errors_panel->set_custom_minimum_size(Size2(0, 100 * EDSCALE));
@@ -2708,6 +2659,8 @@ ScriptTextEditor::ScriptTextEditor() {
 	errors_panel->set_context_menu_enabled(true);
 	errors_panel->set_focus_mode(FOCUS_CLICK);
 	errors_panel->hide();
+	errors_panel->connect("meta_clicked", callable_mp(this, &ScriptTextEditor::_error_clicked));
+	editor_box->add_child(errors_panel);
 
 	drag_info_label = memnew(Label);
 	drag_info_label->set_anchors_preset(Control::PRESET_BOTTOM_RIGHT);
@@ -2726,41 +2679,16 @@ ScriptTextEditor::ScriptTextEditor() {
 	code_editor->get_text_editor()->add_child(drag_info_label);
 	drag_info_label->hide();
 
-	code_editor->get_text_editor()->set_symbol_lookup_on_click_enabled(true);
-	code_editor->get_text_editor()->set_symbol_tooltip_on_hover_enabled(true);
-
 	color_panel = memnew(PopupPanel);
+	add_child(color_panel);
 
-	inline_color_popup = memnew(PopupPanel);
-	add_child(inline_color_popup);
-
-	inline_color_picker = memnew(ColorPicker);
-	inline_color_picker->set_mouse_filter(MOUSE_FILTER_STOP);
-	inline_color_picker->set_deferred_mode(true);
-	inline_color_picker->set_hex_visible(false);
-	inline_color_picker->connect("color_changed", callable_mp(this, &ScriptTextEditor::_picker_color_changed));
-	inline_color_popup->add_child(inline_color_picker);
-
-	inline_color_options = memnew(OptionButton);
-	inline_color_options->set_h_size_flags(SIZE_FILL);
-	inline_color_options->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
-	inline_color_options->set_fit_to_longest_item(false);
-	inline_color_options->connect("item_selected", callable_mp(this, &ScriptTextEditor::_update_color_text).unbind(1));
-	inline_color_picker->get_slider_container()->add_sibling(inline_color_options);
-
-	connection_info_dialog = memnew(ConnectionInfoDialog);
+	color_picker = memnew(ColorPicker);
+	color_picker->set_deferred_mode(true);
+	color_picker->connect("color_changed", callable_mp(this, &ScriptTextEditor::_color_changed));
+	color_panel->connect("about_to_popup", callable_mp(EditorNode::get_singleton(), &EditorNode::setup_color_picker).bind(color_picker));
+	color_panel->add_child(color_picker);
 
 	update_settings();
-
-	SET_DRAG_FORWARDING_GCD(code_editor->get_text_editor(), ScriptTextEditor);
-}
-
-ScriptTextEditor::~ScriptTextEditor() {
-	if (!editor_enabled) {
-		memdelete(errors_panel);
-		memdelete(color_panel);
-		memdelete(connection_info_dialog);
-	}
 }
 
 ScriptEditorBase *ScriptTextEditor::create_editor(const Ref<Resource> &p_resource) {

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -31,15 +31,10 @@
 #pragma once
 
 #include "editor/script/script_editor_base.h"
-#include "script_editor_plugin.h"
 
-#include "editor/gui/code_editor.h"
-#include "scene/gui/color_picker.h"
-#include "scene/gui/dialogs.h"
-#include "scene/gui/option_button.h"
-#include "scene/gui/tree.h"
-
+class ColorPicker;
 class RichTextLabel;
+class Tree;
 
 class ConnectionInfoDialog : public AcceptDialog {
 	GDCLASS(ConnectionInfoDialog, AcceptDialog);
@@ -58,7 +53,6 @@ public:
 class ScriptTextEditor : public CodeEditorBase {
 	GDCLASS(ScriptTextEditor, CodeEditorBase);
 
-	Variant pending_state;
 	bool script_is_valid = false;
 
 	RichTextLabel *errors_panel = nullptr;
@@ -75,15 +69,8 @@ class ScriptTextEditor : public CodeEditorBase {
 	int inline_color_line = -1;
 	int inline_color_start = -1;
 	int inline_color_end = -1;
-	PopupPanel *inline_color_popup = nullptr;
-	ColorPicker *inline_color_picker = nullptr;
-	OptionButton *inline_color_options = nullptr;
-	Ref<Texture2D> color_alpha_texture;
 
-	ScriptEditorQuickOpen *quick_open = nullptr;
-	ConnectionInfoDialog *connection_info_dialog = nullptr;
-
-	int connection_gutter = -1;
+	int connection_gutter = 1;
 	void _gutter_clicked(int p_line, int p_gutter);
 	void _update_gutter_indexes();
 
@@ -142,8 +129,6 @@ class ScriptTextEditor : public CodeEditorBase {
 		EditMenusSTE();
 	};
 
-	void _enable_code_editor();
-
 	struct DraggedExport {
 		ObjectID obj_id;
 		String variable_name;
@@ -181,7 +166,6 @@ protected:
 	void _inline_object_draw(const Dictionary &p_info, const Rect2 &p_rect);
 	void _inline_object_handle_click(const Dictionary &p_info, const Rect2 &p_rect);
 	String _picker_color_stringify(const Color &p_color, COLOR_MODE p_mode);
-	void _picker_color_changed(const Color &p_color);
 	void _update_color_constructor_options();
 	void _update_background_color();
 	void _update_color_text();
@@ -219,14 +203,12 @@ public:
 
 	virtual void apply_code() override;
 	virtual void set_edited_resource(const Ref<Resource> &p_res) override;
-	virtual void enable_editor() override;
 	virtual Vector<String> get_functions() override;
 
 	virtual Control *get_edit_menu() override;
 
 	virtual Ref<Texture2D> get_theme_icon() override;
 
-	virtual Variant get_edit_state() override;
 	virtual void set_edit_state(const Variant &p_state) override;
 
 	virtual PackedInt32Array get_breakpoints() override;
@@ -241,6 +223,7 @@ public:
 	Variant get_previous_state();
 	void store_previous_state();
 
+	void picker_color_changed();
+
 	ScriptTextEditor();
-	~ScriptTextEditor();
 };

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -34,7 +34,7 @@
 #include "gdscript_extend_parser.h"
 #include "gdscript_language_protocol.h"
 
-#include "editor/script/script_text_editor.h"
+#include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "servers/display/display_server.h"
 


### PR DESCRIPTION
- related https://github.com/godotengine/godot/pull/33760

ScriptTextEditor initialization was split into two parts: first in the constructor, and then when the script is enabled / first switched to. The split is currently pretty arbitrary, some things are made in the constructor and some on enable, and it is hard to tell where something needs to be until there is a problem.
There has been issues caused by the ScriptTextEditor being in this half-initialized state such as #110946. Removing it makes the code easier to work with.
This also makes ScriptTextEditor more similar to TextEditor and TextShaderEditor, since they don't have this.

However, the delayed initialization did save time when loading many scripts, in my testing it saved around 4.4 seconds when opening 200 scripts (master 728c15 at 3.1 seconds and without lazy loading at 7.5 seconds on performance build).
This slowdown was more than I wanted, so I am also reducing it in the same PR.
When profiling, it was mostly creation of various Controls used in the ScriptTextEditor that took up the most performance, such as the ColorPickers, edit menu, or the ConnectionInfoDialog. There only needs to be one each of these Controls so I moved them to ScriptEditor to reuse them among all ScriptTextEditors.

Moved GotoLinePopup, ScriptEditorQuickOpen (go to line), ConnectionInfoDialog, and the inline ColorPicker to ScriptEditor.
Made the ScriptTextEditor context menu initialize when opened (like TextEdit's context menu).

With these changes it is slightly slower than master, by 0.56 seconds with 200 scripts, which is 2.82 ms per script opened. (3.68 seconds compared to master at 3.1 seconds). Opening 200 scripts at once is a lot, so this amount isn't a big deal IMO. These tests were with scripts only, since it only affects ScriptTextEditor and not TextEditor. 
However, removing the extra color picker in ScriptTextEditor (see https://github.com/godotengine/godot/pull/109104) will improve the performance here even more (to ~2.7 seconds in my testing) and should make up any loss here anyway.

Edit:
There was a recent refactoring, so here is the updated average times that the script editor takes to open 200 scripts (on performance build):
master (3c5e561): 3.54s
PR: 3.22s

The project used to test: [se-slow-200.zip](https://github.com/user-attachments/files/25328574/se-slow-200.zip) (make sure to select all scripts and drag them to the script editor to open all of them).

Some things were moved out of the delayed initialization for the refactor, so I think that is why this PR is relatively faster than master now, even without the last color picker being removed.