### PR TITLE
LSP: Add `godot` to known language ids

### DIFF
--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -695,10 +695,12 @@ struct TextDocumentItem {
 		version = p_dict["version"];
 		text = p_dict["text"];
 
-		// Clients should use "gdscript" as language id, but we can't enforce it. The Rider integration
-		// in particular uses "gd" at the time of writing. We normalize the id to make it easier to work with.
+		// Clients should use "gdscript" as language id, but we can't enforce it.
+		// We normalize some known ids to make them easier to work with:
+		// Rider < 2026.1: "gd"
+		// Kate: "godot"
 		String rawLanguageId = p_dict["languageId"];
-		if (rawLanguageId == "gdscript" || rawLanguageId == "gd") {
+		if (rawLanguageId == "gdscript" || rawLanguageId == "gd" || rawLanguageId == "godot") {
 			languageId = LanguageId::GDSCRIPT;
 		} else {
 			languageId = LanguageId::OTHER;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/115631 (not the error spam though)

Kate currently uses `godot` as language id for GDScript. I will probably try to upstream a change to `gdscript` at some point but for now we just handle this id like GDScript.
