### PR TITLE
LSP: Handle clients that do not support `CompletionContext`

### DIFF
--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -1438,7 +1438,7 @@ struct CompletionContext {
 	/**
 	 * How the completion was triggered.
 	 */
-	int triggerKind = CompletionTriggerKind::TriggerCharacter;
+	int triggerKind = CompletionTriggerKind::Invoked;
 
 	/**
 	 * The trigger character (a single character) that has trigger code complete.
@@ -1461,7 +1461,10 @@ struct CompletionParams : public TextDocumentPositionParams {
 
 	void load(const Dictionary &p_params) {
 		TextDocumentPositionParams::load(p_params);
-		context.load(p_params["context"]);
+
+		if (p_params.has("context")) {
+			context.load(p_params["context"]);
+		}
 	}
 
 	Dictionary to_json() {


### PR DESCRIPTION
Fixes the error spam from https://github.com/godotengine/godot/issues/115631

The whole completion context member is not mandatory and clients do not need to implement it. Previously we would implicitly fallback through invalid dictionary lookups. Since this now throws errors this PR adds an explicit fallback.

The default value of `triggerKind` has been changed to `Invoked` this makes sense, because for `TriggerCharacter` the `triggerCharacter` member should contain the character, but it defaults to an empty string.

Quick link to the relevant specification: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionTriggerKind