### PR TITLE
jpg: Explicitly reject unsupported CMYK and YCCK colorspaces

### DIFF
--- a/modules/jpg/image_loader_libjpeg_turbo.cpp
+++ b/modules/jpg/image_loader_libjpeg_turbo.cpp
@@ -48,7 +48,8 @@ Error jpeg_turbo_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer,
 	const TJCS colorspace = (TJCS)tj3Get(tj_instance, TJPARAM_COLORSPACE);
 
 	if (tj3Get(tj_instance, TJPARAM_PRECISION) > 8) {
-		// Proceed anyway and convert to rgb8?
+		// TODO: Proceed anyway and convert to rgb8?
+		ERR_PRINT("JPEGTurbo: JPEG files with precision > 8 are not currently supported.");
 		tj3Destroy(tj_instance);
 		return ERR_UNAVAILABLE;
 	}
@@ -58,8 +59,12 @@ Error jpeg_turbo_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer,
 	if (colorspace == TJCS_GRAY) {
 		tj_pixel_format = TJPF_GRAY;
 		gd_pixel_format = Image::FORMAT_L8;
+	} else if (colorspace == TJCS_CMYK || colorspace == TJCS_YCCK) {
+		ERR_PRINT("JPEGTurbo: JPEG files with CMYK or YCCK colorspaces are not currently supported.");
+		tj3Destroy(tj_instance);
+		return ERR_UNAVAILABLE;
 	} else {
-		// Force everything else (RGB, CMYK etc) into RGB8.
+		// Other color spaces should be RGB.
 		tj_pixel_format = TJPF_RGB;
 		gd_pixel_format = Image::FORMAT_RGB8;
 	}


### PR DESCRIPTION
- See #115668 (doesn't fix it).
- Alternative if we want to support CMYK and YCCK: #115688.