### PR TITLE
Replace some `ItemList.ensure_current_is_visible` with `center_on_current`

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1238,7 +1238,6 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 
 		if (!p_keep_selection && !file.is_empty() && fname == file) {
 			files->select(item_index, true);
-			files->ensure_current_is_visible();
 		}
 
 		// Tooltip.
@@ -1253,6 +1252,10 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 	// If we only have any selected items retained, we need to update the current idx.
 	if (!valid_selection.is_empty()) {
 		files->set_current(*valid_selection.begin());
+	}
+
+	if (!p_keep_selection) {
+		files->center_on_current();
 	}
 }
 

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -253,7 +253,7 @@ void TileMapLayerEditorTilesPlugin::_update_tile_set_sources_list() {
 			for (int i = 0; i < sources_list->get_item_count(); i++) {
 				if ((int)sources_list->get_item_metadata(i) == old_source) {
 					sources_list->set_current(i);
-					sources_list->ensure_current_is_visible();
+					sources_list->center_on_current();
 					break;
 				}
 			}
@@ -1409,7 +1409,7 @@ void TileMapLayerEditorTilesPlugin::_stop_dragging() {
 						break;
 					}
 				}
-				sources_list->ensure_current_is_visible();
+				sources_list->center_on_current();
 			}
 
 			Ref<TileMapPattern> new_selection_pattern = edited_layer->get_pattern(coords_array);

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -216,7 +216,7 @@ void TileSetEditor::_update_sources_list(int force_selected_id) {
 		for (int i = 0; i < sources_list->get_item_count(); i++) {
 			if ((int)sources_list->get_item_metadata(i) == to_select) {
 				sources_list->set_current(i);
-				sources_list->ensure_current_is_visible();
+				sources_list->center_on_current();
 				if (old_selected != to_select) {
 					sources_list->emit_signal(SceneStringName(item_selected), sources_list->get_current());
 				}

--- a/editor/scene/2d/tiles/tiles_editor_plugin.cpp
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.cpp
@@ -178,7 +178,7 @@ void TilesEditorUtils::synchronize_sources_list(Object *p_current_list, Object *
 			item_list->deselect_all();
 		} else {
 			item_list->set_current(atlas_sources_lists_current);
-			item_list->ensure_current_is_visible();
+			item_list->center_on_current();
 			item_list->emit_signal(SceneStringName(item_selected), atlas_sources_lists_current);
 		}
 	}

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -2638,7 +2638,7 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 				}
 			}
 			_update_script_names();
-			script_list->ensure_current_is_visible();
+			script_list->center_on_current();
 			return true;
 		}
 	}
@@ -4466,7 +4466,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	script_name_button->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 	script_name_button->set_h_size_flags(SIZE_EXPAND_FILL);
 	script_name_button->set_tooltip_text(TTRC("Navigate to script list."));
-	script_name_button->connect(SceneStringName(pressed), callable_mp(script_list, &ItemList::ensure_current_is_visible));
+	script_name_button->connect(SceneStringName(pressed), callable_mp(script_list, &ItemList::center_on_current).bind(true, true));
 	script_name_button_hbox->add_child(script_name_button);
 
 	script_name_button_right_spacer = memnew(Control);

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1189,6 +1189,10 @@ void ItemList::center_on_current(bool p_center_verically, bool p_center_horizont
 
 	ERR_FAIL_COND_MSG(!p_center_verically && !p_center_horizontally, "At least one of the parameters must be true.");
 
+	if (shape_changed) {
+		force_update_list_size();
+	}
+
 	Rect2 r = items[current].rect_cache;
 
 	if (p_center_verically) {


### PR DESCRIPTION
- Since #112797 has been merged, some instances of `ensure_current_is_visible()` can be replaced with `center_on_current()` to improve UX.

Two replated bugs are found and fixed:
1. About the `center_on_current()` method itself. Items' `rect_cache` may not be updated, so `force_update_list_size()` should be called first.
2. In FileSystemDock, we can't just simply replace `files->ensure_current_is_visible()` with `files->center_on_current()` because the item_list is continuously adding new items to the list, so we should call `files->center_on_current()` after the list is fully ready otherwise the center position is not calculated correctly.

BTW, for FileSystemDock, changes can only be noticed when toggled to V-split/H-split mode. Also, FileSystemDock needs a following PR when `Tree` supports `center_on_current()` (to replace `ensure_cursor_is_visible()`).