### PR TITLE
[TextServer] Fix numeric keycap emoji sequence rendering

### DIFF
--- a/modules/text_server_adv/script_iterator.cpp
+++ b/modules/text_server_adv/script_iterator.cpp
@@ -35,6 +35,7 @@
 inline constexpr UChar32 ZERO_WIDTH_JOINER = 0x200d;
 inline constexpr UChar32 VARIATION_SELECTOR_15 = 0xfe0e;
 inline constexpr UChar32 VARIATION_SELECTOR_16 = 0xfe0f;
+inline constexpr UChar32 COMBINING_ENCLOSING_KEYCAP = 0x20e3;
 
 inline bool ScriptIterator::same_script(int32_t p_script_one, int32_t p_script_two) {
 	return p_script_one <= USCRIPT_INHERITED || p_script_two <= USCRIPT_INHERITED || p_script_one == p_script_two;
@@ -107,7 +108,7 @@ ScriptIterator::ScriptIterator(const String &p_string, int p_start, int p_length
 					emoji_stack[emoji_sp].start = script_end;
 					emoji_stack[emoji_sp].end = script_end;
 				}
-			} else if (emoji_run && ch != ZERO_WIDTH_JOINER && ch != VARIATION_SELECTOR_16 && !(u_hasBinaryProperty(ch, UCHAR_EXTENDED_PICTOGRAPHIC) && n != VARIATION_SELECTOR_15)) {
+			} else if (emoji_run && ch != ZERO_WIDTH_JOINER && ch != VARIATION_SELECTOR_16 && ch != COMBINING_ENCLOSING_KEYCAP && !(u_hasBinaryProperty(ch, UCHAR_EXTENDED_PICTOGRAPHIC) && n != VARIATION_SELECTOR_15)) {
 				emoji_run = false;
 				emoji_stack[emoji_sp].end = script_end;
 			}


### PR DESCRIPTION
Fixes #115686 (invisible numeric keycap emoji).

Under the hood, numeric keycap emoji (0️⃣-9️⃣, #️⃣, *️⃣) have 3 components:
1) A plain text character (e.g. `0`-`9`,  `#`, or `*`)
2) A VS16 [Unicode variation selector](https://en.wikipedia.org/wiki/Variation_Selectors_\(Unicode_block\)) (`U+FE0F`), which requests the preceding character be rendered as an emoji.
3) A [Combining Enclosing Keycap](https://en.wiktionary.org/wiki/%E2%97%8C%E2%83%A3) character (`U+20E3`), which has special-case behavior for the 12 keycap emojis to request their whole sequence be rendered as 0️⃣-9️⃣, #️⃣, or *️⃣.

In `script_iterator.cpp`, there's a bug causing Godot to stop rendering an emoji after only the first 2/3 components. This PR fixes that by flagging `U+20E3` as a character that should not stop an emoji run.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
