### PR TITLE
jpg: Add quick and dirty conversion of CMYK/YCCK colorspaces to RGB

### DIFF
--- a/modules/jpg/image_loader_libjpeg_turbo.cpp
+++ b/modules/jpg/image_loader_libjpeg_turbo.cpp
@@ -30,6 +30,7 @@
 
 #include "image_loader_libjpeg_turbo.h"
 
+#include <cmyk.h>
 #include <turbojpeg.h>
 
 Error jpeg_turbo_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p_buffer_len) {
@@ -48,33 +49,83 @@ Error jpeg_turbo_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer,
 	const TJCS colorspace = (TJCS)tj3Get(tj_instance, TJPARAM_COLORSPACE);
 
 	if (tj3Get(tj_instance, TJPARAM_PRECISION) > 8) {
-		// Proceed anyway and convert to rgb8?
+		// TODO: Proceed anyway and convert to rgb8?
+		ERR_PRINT("JPEGTurbo: JPEG files with precision > 8 are not currently supported.");
 		tj3Destroy(tj_instance);
 		return ERR_UNAVAILABLE;
 	}
 
 	TJPF tj_pixel_format;
 	Image::Format gd_pixel_format;
+
 	if (colorspace == TJCS_GRAY) {
 		tj_pixel_format = TJPF_GRAY;
 		gd_pixel_format = Image::FORMAT_L8;
+		Vector<uint8_t> data;
+		data.resize(width * height * tjPixelSize[tj_pixel_format]);
+
+		if (tj3Decompress8(tj_instance, p_buffer, p_buffer_len, data.ptrw(), 0, tj_pixel_format) < 0) {
+			tj3Destroy(tj_instance);
+			return ERR_FILE_CORRUPT;
+		}
+
+		tj3Destroy(tj_instance);
+		p_image->set_data(width, height, false, gd_pixel_format, data);
+		return OK;
+	} else if (colorspace == TJCS_CMYK || colorspace == TJCS_YCCK) {
+		// Decompress into CMYK (4 components) then convert to RGB with TJ's cmyk.h helper.
+		// This function is clearly documented as quick and dirty, but this is a best effort
+		// conversion anyway, and results on game assets might be serviceable.
+		tj_pixel_format = TJPF_CMYK; // TJ automatically converts YCCK to CMYK.
+		gd_pixel_format = Image::FORMAT_RGB8;
+
+		Vector<uint8_t> cmyk_data;
+		cmyk_data.resize(width * height * tjPixelSize[tj_pixel_format]);
+
+		if (tj3Decompress8(tj_instance, p_buffer, p_buffer_len, cmyk_data.ptrw(), 0, tj_pixel_format) < 0) {
+			tj3Destroy(tj_instance);
+			return ERR_FILE_CORRUPT;
+		}
+
+		tj3Destroy(tj_instance);
+
+		Vector<uint8_t> rgb_data;
+		rgb_data.resize(width * height * 3);
+		uint8_t *rgb_data_w = rgb_data.ptrw();
+
+		for (unsigned int i = 0; i < width * height; i++) {
+			uint8_t c = cmyk_data[i * 4 + 0];
+			uint8_t m = cmyk_data[i * 4 + 1];
+			uint8_t y = cmyk_data[i * 4 + 2];
+			uint8_t k = cmyk_data[i * 4 + 3];
+
+			_JSAMPLE rr, gg, bb;
+			cmyk_to_rgb(255, c, m, y, k, &rr, &gg, &bb);
+
+			rgb_data_w[i * 3 + 0] = (uint8_t)rr;
+			rgb_data_w[i * 3 + 1] = (uint8_t)gg;
+			rgb_data_w[i * 3 + 2] = (uint8_t)bb;
+		}
+
+		p_image->set_data(width, height, false, gd_pixel_format, rgb_data);
+		return OK;
 	} else {
-		// Force everything else (RGB, CMYK etc) into RGB8.
+		// Other color spaces should be RGB.
 		tj_pixel_format = TJPF_RGB;
 		gd_pixel_format = Image::FORMAT_RGB8;
-	}
 
-	Vector<uint8_t> data;
-	data.resize(width * height * tjPixelSize[tj_pixel_format]);
+		Vector<uint8_t> data;
+		data.resize(width * height * tjPixelSize[tj_pixel_format]);
 
-	if (tj3Decompress8(tj_instance, p_buffer, p_buffer_len, data.ptrw(), 0, tj_pixel_format) < 0) {
+		if (tj3Decompress8(tj_instance, p_buffer, p_buffer_len, data.ptrw(), 0, tj_pixel_format) < 0) {
+			tj3Destroy(tj_instance);
+			return ERR_FILE_CORRUPT;
+		}
+
 		tj3Destroy(tj_instance);
-		return ERR_FILE_CORRUPT;
+		p_image->set_data(width, height, false, gd_pixel_format, data);
+		return OK;
 	}
-
-	tj3Destroy(tj_instance);
-	p_image->set_data(width, height, false, gd_pixel_format, data);
-	return OK;
 }
 
 Error ImageLoaderLibJPEGTurbo::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {


### PR DESCRIPTION
This relies on a helper function from TurboJPEG which is labeled as quick and dirty and for testing purposes.

It might be good enough for badly prepared game assets (e.g. JPGs downloaded from the web) and better than outright failing.

- Fixes #115668.
- Alternative to #115674.

<img width="1354" height="628" alt="image" src="https://github.com/user-attachments/assets/5b243cb5-8408-471c-9f8b-d9fe851a463c" />

---

### AI disclosure

This was partially coded with the help of AI agents. I first used ChatGPT (GPT-5.2) to rubberduck the issue, which utterly failed at providing me code that would actually work, but helped me understand the problem space better.

I also read some of TurboJPEG's code myself and found its `cmyk.h` helper functions, though I didn't go in depth to see how it's being used exactly (there's several levels of abstraction and a mix between TJ and jpeglib APIs which makes it a bit convoluted).

Then I fed this initial research to Copilot in VS Code with access to my local Git clone (GPT-5 mini), and it came up with a working branch for CMYK, which I tested to fix support for the file in #115668.

Vibe coding like this isn't something I intend to do frequently, but I was mostly curious to see how well it would work for something pretty "standard" like this. I have mixed feelings, but did get a working solution.

The final code was edited by me and is pretty much how I would have written this if I was already familiar with TurboJPEG. I don't believe these few lines of effective code pose any copyright challenge.

### Notes

- I still need to test the conversion for YCCK because this is mostly something Copilot took from ChatGPT's bad code, and I need to validate that it's actually correct.
- Would be good to test more complex CMYK files (photos, etc.) and see if the quick and dirty conversion does yield good enough results.
- It could be good to let users know that they imported CMYK/YCCK files and that we recommend converting them properly to RGB colorspace, so we don't rely on our subpar conversion. I could put a `print_verbose` where it detects CMYK/YCCK, but at this point we only have a buffer so no file name to give. Passing it to the calling site as a new function argument feels a bit dirty.