### PR TITLE
Fix race conditions in DirAccessWindows leading to segfaults

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -162,26 +162,25 @@ Error DirAccessWindows::change_dir(String p_dir) {
 	SetCurrentDirectoryW((LPCWSTR)(current_dir.utf16().get_data()));
 	bool worked = (SetCurrentDirectoryW((LPCWSTR)(dir.utf16().get_data())) != 0);
 
-	String base = _get_root_path();
-	if (!base.is_empty()) {
-		str_len = GetCurrentDirectoryW(0, nullptr);
-		real_current_dir_name.resize_uninitialized(str_len + 1);
-		GetCurrentDirectoryW(real_current_dir_name.size(), (LPWSTR)real_current_dir_name.ptrw());
-		String new_dir = String::utf16((const char16_t *)real_current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/');
-		if (!new_dir.begins_with(base)) {
-			worked = false;
-		}
-	}
-
+	String new_dir;
 	if (worked) {
 		str_len = GetCurrentDirectoryW(0, nullptr);
 		real_current_dir_name.resize_uninitialized(str_len + 1);
 		GetCurrentDirectoryW(real_current_dir_name.size(), (LPWSTR)real_current_dir_name.ptrw());
-		current_dir = String::utf16((const char16_t *)real_current_dir_name.get_data());
+		new_dir = String::utf16((const char16_t *)real_current_dir_name.get_data());
 	}
 
 	SetCurrentDirectoryW((LPCWSTR)(prev_dir.utf16().get_data()));
 
+	if (worked) {
+		String base = _get_root_path();
+		if (!base.is_empty() && !new_dir.trim_prefix(R"(\\?\)").replace_char('\\', '/').begins_with(base)) {
+			worked = false;
+		}
+		if (worked) {
+			current_dir = new_dir;
+		}
+	}
 	return worked ? OK : ERR_INVALID_PARAMETER;
 }
 
@@ -477,6 +476,7 @@ Error DirAccessWindows::create_link(String p_source, String p_target) {
 }
 
 DirAccessWindows::DirAccessWindows() {
+	GLOBAL_LOCK_FUNCTION
 	p = memnew(DirAccessWindowsPrivate);
 	p->h = INVALID_HANDLE_VALUE;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->


In the constructor for `DirAccessWindows()`, we use `GetCurrentDirectoryW()` without engaging the global lock function. This is a problem if you are instancing `DirAccess` objects on multiple threads, since we call `change_dir()` right after. `change_dir()` calls `SetCurrentDirectoryW()`, which changes the whole process's current dir. [Neither of these functions is thread-safe](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setcurrentdirectory#remarks), and calling `GetCurrentDirectoryW()` and `SetCurrentDirectoryW()` simultaneously leads to the return value of `GetCurrentDirectoryW()` being garbage, and I have observed at least one segfault due to this.

Calling `GLOBAL_LOCK_FUNCTION` in the constructor fixes the issue.

I've also went and cleaned up the logic in `change_dir` to minimize the amount of time we spend with the process's current dir being changed to something other than what it's supposed to be. Ideally speaking, we shouldn't be using `SetCurrentDirectoryW` at all since it changes the whole process's current directory and could potentially lead to issues, but I'm not familiar with the Windows API enough to know what kind of alternative implementation would work here.

cc @bruvzg 