### PR TITLE
Fix null values for local const in debugger

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -200,6 +200,9 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		for (const KeyValue<Variant, int> &K : constant_map) {
 			function->constants.write[K.value] = K.key;
 		}
+		for (const KeyValue<StringName, int> &K : local_constants) {
+			function->constant_map.insert(K.key, function->constants[K.value]);
+		}
 	} else {
 		function->_constants_ptr = nullptr;
 		function->_constant_count = 0;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -345,7 +345,12 @@ void GDScriptLanguage::debug_get_stack_level_locals(int p_level, List<String> *p
 	f->debug_get_stack_member_state(*cl->line, &locals);
 	for (const Pair<StringName, int> &E : locals) {
 		p_locals->push_back(E.first);
-		p_values->push_back(cl->stack[E.second]);
+
+		if (f->constant_map.has(E.first)) {
+			p_values->push_back(f->constant_map[E.first]);
+		} else {
+			p_values->push_back(cl->stack[E.second]);
+		}
 	}
 }
 

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -479,6 +479,7 @@ private:
 	Vector<int> code;
 	Vector<int> default_arguments;
 	Vector<Variant> constants;
+	HashMap<StringName, Variant> constant_map;
 	Vector<StringName> global_names;
 	Vector<Variant::ValidatedOperatorEvaluator> operator_funcs;
 	Vector<Variant::ValidatedSetter> setters;


### PR DESCRIPTION
- Fixes: https://github.com/godotengine/godot/issues/96834

## Example

| Before | After |
|---|---|
| <img width="373" height="345" alt="before_fix" src="https://github.com/user-attachments/assets/7caf2eb6-a629-4c3b-a146-62c037844bb6" /> | <img width="373" height="345" alt="after_fix" src="https://github.com/user-attachments/assets/47bed41d-d976-439f-afd4-d53ce63274e3" /> |

## Details

By default, debugger get any local variables using stack. However, constant values are not in this stack. As a result, we get `null` when trying to get a constant value from stack.

## Fix

When setup function with constant values, I also added field with mapping constant names to values. And during debug get stack locals just use this values from constant map. I'm not sure how optimal this solution is. Perhaps there's another way without additional fields that would allow pushing constant value to stack immediately...