### PR TITLE
Fix `mark_scene_as_unsaved()` not working with `Reload Saved Screen`

### DIFF
--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -389,6 +389,7 @@ void EditorUndoRedoManager::set_history_as_saved(int p_id) {
 void EditorUndoRedoManager::set_history_as_unsaved(int p_id) {
 	History &history = get_or_create_history(p_id);
 	history.saved_version = UNSAVED_VERSION;
+	emit_signal(SNAME("history_changed"));
 }
 
 bool EditorUndoRedoManager::is_history_unsaved(int p_id) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fixes: https://github.com/godotengine/godot/issues/115698