### PR TITLE
Doc: Add units to Parallax2D property descriptions

### DIFF
--- a/doc/classes/Parallax2D.xml
+++ b/doc/classes/Parallax2D.xml
@@ -21,23 +21,23 @@
 			If [code]true[/code], [Parallax2D]'s position is not affected by the position of the camera.
 		</member>
 		<member name="limit_begin" type="Vector2" setter="set_limit_begin" getter="get_limit_begin" default="Vector2(-10000000, -10000000)">
-			Top-left limits for scrolling to begin. If the camera is outside of this limit, the [Parallax2D] stops scrolling. Must be lower than [member limit_end] minus the viewport size to work.
+			Top-left limits for scrolling to begin, in pixels. If the camera is outside of this limit, the [Parallax2D] stops scrolling. Must be lower than [member limit_end] minus the viewport size to work.
 		</member>
 		<member name="limit_end" type="Vector2" setter="set_limit_end" getter="get_limit_end" default="Vector2(10000000, 10000000)">
-			Bottom-right limits for scrolling to end. If the camera is outside of this limit, the [Parallax2D] will stop scrolling. Must be higher than [member limit_begin] and the viewport size combined to work.
+			Bottom-right limits for scrolling to end, in pixels. If the camera is outside of this limit, the [Parallax2D] will stop scrolling. Must be higher than [member limit_begin] and the viewport size combined to work.
 		</member>
 		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="2" />
 		<member name="repeat_size" type="Vector2" setter="set_repeat_size" getter="get_repeat_size" default="Vector2(0, 0)">
-			Repeats the [Texture2D] of each of this node's children and offsets them by this value. When scrolling, the node's position loops, giving the illusion of an infinite scrolling background if the values are larger than the screen size. If an axis is set to [code]0[/code], the [Texture2D] will not be repeated.
+			Repeats the [Texture2D] of each of this node's children and offsets them by this value, in pixels. When scrolling, the node's position loops, giving the illusion of an infinite scrolling background if the values are larger than the screen size. If an axis is set to [code]0[/code], the [Texture2D] will not be repeated.
 		</member>
 		<member name="repeat_times" type="int" setter="set_repeat_times" getter="get_repeat_times" default="1">
 			Overrides the amount of times the texture repeats. Each texture copy spreads evenly from the original by [member repeat_size]. Useful for when zooming out with a camera.
 		</member>
 		<member name="screen_offset" type="Vector2" setter="set_screen_offset" getter="get_screen_offset" default="Vector2(0, 0)">
-			Offset used to scroll this [Parallax2D]. This value is updated automatically unless [member ignore_camera_scroll] is [code]true[/code].
+			Offset used to scroll this [Parallax2D], in pixels. This value is updated automatically unless [member ignore_camera_scroll] is [code]true[/code].
 		</member>
 		<member name="scroll_offset" type="Vector2" setter="set_scroll_offset" getter="get_scroll_offset" default="Vector2(0, 0)">
-			The [Parallax2D]'s offset. Similar to [member screen_offset] and [member Node2D.position], but will not be overridden.
+			The [Parallax2D]'s offset, in pixels. Similar to [member screen_offset] and [member Node2D.position], but will not be overridden.
 			[b]Note:[/b] Values will loop if [member repeat_size] is set higher than [code]0[/code].
 		</member>
 		<member name="scroll_scale" type="Vector2" setter="set_scroll_scale" getter="get_scroll_scale" default="Vector2(1, 1)">


### PR DESCRIPTION
## Summary
This PR adds unit specifications to `Parallax2D` property descriptions as requested in godotengine/godot-docs#9715.

## Changes
Added "in pixels" unit specification to the following properties:
- `scroll_offset`
- `repeat_size`
- `limit_begin`
- `limit_end`
- `screen_offset`

Note: `autoscroll` already specifies "pixels per second" so it was not modified.

Closes godotengine/godot-docs#9715