### PR TITLE
Android: Fail instrumented tests when test function doesn't complete

### DIFF
--- a/platform/android/java/app/src/instrumented/assets/test/base_test.gd
+++ b/platform/android/java/app/src/instrumented/assets/test/base_test.gd
@@ -9,8 +9,9 @@ var _test_assert_failures := 0
 
 func __exec_test(test_func: Callable):
 	_test_started += 1
-	test_func.call()
-	_test_completed += 1
+	var ret = test_func.call()
+	if ret == true:
+		_test_completed += 1
 
 func __reset_tests():
 	_test_started = 0

--- a/platform/android/java/app/src/instrumented/assets/test/file_access/file_access_tests.gd
+++ b/platform/android/java/app/src/instrumented/assets/test/file_access/file_access_tests.gd
@@ -12,7 +12,7 @@ func run_tests():
 	__exec_test(test_downloads_dir_access)
 	__exec_test(test_documents_dir_access)
 
-func _test_dir_access(dir_path: String, data_file_content: String) -> void:
+func _test_dir_access(dir_path: String, data_file_content: String) -> bool:
 	print("Testing access to " + dir_path)
 	var data_file_path = dir_path.path_join("data.dat")
 
@@ -29,45 +29,52 @@ func _test_dir_access(dir_path: String, data_file_content: String) -> void:
 
 	var deletion_result = DirAccess.remove_absolute(data_file_path)
 	assert_equal(deletion_result, OK)
+	return true
 
-func test_obb_dir_access() -> void:
+func test_obb_dir_access() -> bool:
 	var android_runtime = Engine.get_singleton("AndroidRuntime")
 	assert_true(android_runtime != null)
 
 	var app_context = android_runtime.getApplicationContext()
 	var obb_dir: String = app_context.getObbDir().getCanonicalPath()
 	_test_dir_access(obb_dir, FILE_CONTENT + "obb dir.")
+	return true
 
-func test_internal_app_dir_access() -> void:
+func test_internal_app_dir_access() -> bool:
 	var android_runtime = Engine.get_singleton("AndroidRuntime")
 	assert_true(android_runtime != null)
 
 	var app_context = android_runtime.getApplicationContext()
 	var internal_app_dir: String = app_context.getFilesDir().getCanonicalPath()
 	_test_dir_access(internal_app_dir, FILE_CONTENT + "internal app dir.")
+	return true
 
-func test_internal_cache_dir_access() -> void:
+func test_internal_cache_dir_access() -> bool:
 	var android_runtime = Engine.get_singleton("AndroidRuntime")
 	assert_true(android_runtime != null)
 
 	var app_context = android_runtime.getApplicationContext()
 	var internal_cache_dir: String = app_context.getCacheDir().getCanonicalPath()
 	_test_dir_access(internal_cache_dir, FILE_CONTENT + "internal cache dir.")
+	return true
 
-func test_external_app_dir_access() -> void:
+func test_external_app_dir_access() -> bool:
 	var android_runtime = Engine.get_singleton("AndroidRuntime")
 	assert_true(android_runtime != null)
 
 	var app_context = android_runtime.getApplicationContext()
 	var external_app_dir: String = app_context.getExternalFilesDir("").getCanonicalPath()
 	_test_dir_access(external_app_dir, FILE_CONTENT + "external app dir.")
+	return true
 
-func test_downloads_dir_access() -> void:
+func test_downloads_dir_access() -> bool:
 	var EnvironmentClass = JavaClassWrapper.wrap("android.os.Environment")
 	var downloads_dir = EnvironmentClass.getExternalStoragePublicDirectory(EnvironmentClass.DIRECTORY_DOWNLOADS).getCanonicalPath()
 	_test_dir_access(downloads_dir, FILE_CONTENT + "downloads dir.")
+	return true
 
-func test_documents_dir_access() -> void:
+func test_documents_dir_access() -> bool:
 	var EnvironmentClass = JavaClassWrapper.wrap("android.os.Environment")
 	var documents_dir = EnvironmentClass.getExternalStoragePublicDirectory(EnvironmentClass.DIRECTORY_DOCUMENTS).getCanonicalPath()
 	_test_dir_access(documents_dir, FILE_CONTENT + "documents dir.")
+	return true

--- a/platform/android/java/app/src/instrumented/assets/test/javaclasswrapper/java_class_wrapper_tests.gd
+++ b/platform/android/java/app/src/instrumented/assets/test/javaclasswrapper/java_class_wrapper_tests.gd
@@ -25,7 +25,7 @@ func run_tests():
 	print("Tests completed: " + str(_test_completed))
 
 
-func test_exceptions() -> void:
+func test_exceptions() -> bool:
 	var TestClass: JavaClass = JavaClassWrapper.wrap('com.godot.game.test.javaclasswrapper.TestClass')
 	#print(TestClass.get_java_method_list())
 
@@ -36,7 +36,9 @@ func test_exceptions() -> void:
 
 	assert_equal(JavaClassWrapper.get_exception(), null)
 
-func test_multiple_signatures() -> void:
+	return true
+
+func test_multiple_signatures() -> bool:
 	var TestClass: JavaClass = JavaClassWrapper.wrap('com.godot.game.test.javaclasswrapper.TestClass')
 
 	var ai := [1, 2]
@@ -55,7 +57,9 @@ func test_multiple_signatures() -> void:
 	]
 	assert_equal(TestClass.testMethod(3, aobjl), "testObjects: 27 135")
 
-func test_array_arguments() -> void:
+	return true
+
+func test_array_arguments() -> bool:
 	var TestClass: JavaClass = JavaClassWrapper.wrap('com.godot.game.test.javaclasswrapper.TestClass')
 
 	assert_equal(TestClass.testArgBoolArray([true, false, true]), "[true, false, true]")
@@ -72,7 +76,9 @@ func test_array_arguments() -> void:
 	assert_equal(TestClass.testArgDoubleArray(PackedFloat64Array([37.1, 38.2, 39.3])), "[37.1, 38.2, 39.3]")
 	assert_equal(TestClass.testArgDoubleArray([37.1, 38.2, 39.3]), "[37.1, 38.2, 39.3]")
 
-func test_array_return() -> void:
+	return true
+
+func test_array_return() -> bool:
 	var TestClass: JavaClass = JavaClassWrapper.wrap('com.godot.game.test.javaclasswrapper.TestClass')
 	#print(TestClass.get_java_method_list())
 
@@ -107,14 +113,17 @@ func test_array_return() -> void:
 	assert_equal(TestClass.testRetStringArray(), PackedStringArray(["I", "am", "String"]))
 	assert_equal(TestClass.testRetCharSequenceArray(), PackedStringArray(["I", "am", "CharSequence"]))
 
-func test_dictionary():
+	return true
+
+func test_dictionary() -> bool:
 	var TestClass: JavaClass = JavaClassWrapper.wrap('com.godot.game.test.javaclasswrapper.TestClass')
 	assert_equal(TestClass.testDictionary({a = 1, b = 2}), "{a=1, b=2}")
 	assert_equal(TestClass.testRetDictionary(), {a = 1, b = 2})
 	assert_equal(TestClass.testRetDictionaryArray(), [{a = 1, b = 2}])
 	assert_equal(TestClass.testDictionaryNested({a = 1, b = [2, 3], c = 4}), "{a: 1, b: [2, 3], c: 4}")
+	return true
 
-func test_object_overload():
+func test_object_overload() -> bool:
 	var TestClass: JavaClass = JavaClassWrapper.wrap('com.godot.game.test.javaclasswrapper.TestClass')
 	var TestClass2: JavaClass = JavaClassWrapper.wrap('com.godot.game.test.javaclasswrapper.TestClass2')
 	var TestClass3: JavaClass = JavaClassWrapper.wrap('com.godot.game.test.javaclasswrapper.TestClass3')
@@ -130,22 +139,25 @@ func test_object_overload():
 
 	assert_equal(TestClass.testObjectOverloadArray(arr_of_t2), "TestClass2: [33, 34]")
 	assert_equal(TestClass.testObjectOverloadArray(arr_of_t3), "TestClass3: [thirty three, thirty four]")
+	return true
 
-func test_variant_conversion_safe_from_stack_overflow():
+func test_variant_conversion_safe_from_stack_overflow() -> bool:
 	var TestClass: JavaClass = JavaClassWrapper.wrap('com.godot.game.test.javaclasswrapper.TestClass')
 	var arr: Array = [42]
 	var dict: Dictionary = {"arr": arr}
 	arr.append(dict)
 	# The following line will crash with stack overflow if not handled property:
 	TestClass.testDictionary(dict)
+	return true
 
-func test_big_integers():
+func test_big_integers() -> bool:
 	var TestClass: JavaClass = JavaClassWrapper.wrap('com.godot.game.test.javaclasswrapper.TestClass')
 	assert_equal(TestClass.testArgLong(4242424242), "4242424242")
 	assert_equal(TestClass.testArgLong(-4242424242), "-4242424242")
 	assert_equal(TestClass.testDictionary({a = 4242424242, b = -4242424242}), "{a=4242424242, b=-4242424242}")
+	return true
 
-func test_callable():
+func test_callable() -> bool:
 	var android_runtime = Engine.get_singleton("AndroidRuntime")
 	assert_true(android_runtime != null)
 
@@ -155,3 +167,5 @@ func test_callable():
 		return null
 	android_runtime.createRunnableFromGodotCallable(cb1).run()
 	assert_equal(cb1_data['called'], true)
+
+	return true


### PR DESCRIPTION
On https://github.com/godotengine/godot/pull/115685#issuecomment-3829536072, it was discovered that we already have an instrumented test that's failing for https://github.com/godotengine/godot/issues/115669, but the tests are reporting success anyway

This PR changes all the GDScript test functions to return `bool` and requires that they return `true` to be considered complete

This catches the failure related to https://github.com/godotengine/godot/issues/115669 for me. If I comment out the failing part, then the tests pass