### PR TITLE
Add enable_sse42 build option in SConstruct

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -165,6 +165,7 @@ opts.Add(
     )
 )
 opts.Add(EnumVariable("arch", "CPU architecture", "auto", ["auto"] + architectures, architecture_aliases, ignorecase=2))
+opts.Add(BoolVariable("enable_sse42", "Enable SSE4.2 instruction set as a forced baseline for x86_64 CPUs", True))
 opts.Add(BoolVariable("dev_build", "Developer build with dev-only debugging code (DEV_ENABLED)", False))
 opts.Add(
     EnumVariable(
@@ -772,15 +773,16 @@ elif env.msvc:
 
 # Set x86 CPU instruction sets to use by the compiler's autovectorization.
 if env["arch"] == "x86_64":
-    # On 64-bit x86, enable SSE 4.2 and prior instruction sets (SSE3/SSSE3/SSE4/SSE4.1) to improve performance.
-    # This is supported on most CPUs released after 2009-2011 (Intel Nehalem, AMD Bulldozer).
-    # AVX and AVX2 aren't enabled because they aren't available on more recent low-end Intel CPUs.
-    if env.msvc and not methods.using_clang(env):
-        # https://stackoverflow.com/questions/64053597/how-do-i-enable-sse4-1-and-sse3-but-not-avx-in-msvc/69328426
-        env.Append(CCFLAGS=["/d2archSSE42"])
-    else:
-        # `-msse2` is implied when compiling for x86_64.
-        env.Append(CCFLAGS=["-msse4.2", "-mpopcnt"])
+    if env["enable_sse42"]: # Force SSE4.2 baseline by default.
+        # On 64-bit x86, enable SSE 4.2 and prior instruction sets (SSE3/SSSE3/SSE4/SSE4.1) to improve performance.
+        # This is supported on most CPUs released after 2009-2011 (Intel Nehalem, AMD Bulldozer).
+        # AVX and AVX2 aren't enabled because they aren't available on more recent low-end Intel CPUs.
+        if env.msvc and not methods.using_clang(env):
+            # https://stackoverflow.com/questions/64053597/how-do-i-enable-sse4-1-and-sse3-but-not-avx-in-msvc/69328426
+            env.Append(CCFLAGS=["/d2archSSE42"])
+        else:
+            # `-msse2` is implied when compiling for x86_64.
+            env.Append(CCFLAGS=["-msse4.2", "-mpopcnt"])
 elif env["arch"] == "x86_32":
     # Be more conservative with instruction sets on 32-bit x86 to improve compatibility.
     # SSE and SSE2 are present on all CPUs that support 64-bit, even if running a 32-bit OS.


### PR DESCRIPTION
Hello! I hope that you are doing well.

As we all know, godot recently decided to force SSE4.2 as a baseline on x86_64 binary. I had opened a [discussion(13644)](https://github.com/godotengine/godot-proposals/discussions/13644) on this issue. In which I discussed how we could have kept the performance improvement of SSE4.2 and still maintain compatibility for CPUs that don't support it by implementing a build flag (The downsides of using i386 binaries can be found in the discussion).

This is a step towards that, the way this works is as follows:

- Allows users to bypass the SSE4.2 hard-requirement (obviously).
- Allows users to compile godot with custom instructions through `cflags` and `cxxflags`, for example, one could set `enable_sse42=no` and add `-msse3` to compile for the SSE3 instruction set.

I had tested the binary produced in [CI](https://github.com/asyync1024/godot-build/actions/workflows/godot-64bit-build.yml) (My system was running out of RAM on the final link, even with `lto=off` etc, wasted a good 3 hour chunk of my time), the binary did show that it didn't use anything more than SSE2 (In terms of SSE instructions, BMI etc are still present, which are present in 32-bit binaries too, for some reason.):
```
❯ elfx86exts /usr/sbin/godot
File format and CPU architecture: Elf, X86_64
MODE64 (call)
CMOV (cmovae)
SSE2 (movdqa)
SSE1 (movaps)
BMI (tzcnt)
PCLMUL (pclmulqdq)
AES (aeskeygenassist)
NOT64BITMODE (xchg)
Instruction set extensions used: AES, BMI, CMOV, MODE64, NOT64BITMODE, PCLMUL, SSE1, SSE2
CPU Generation: Unknown
```
The binary produced by setting `-msse3` was also showing SSE3 support.

But, both the binaries crashed with the usual SSE4.2 requirement error. I then tried checking where else the SSE4.2 requirement was forced etc, so I ran `grep -ri "sse4.2"`, which yielded a respectable 50 lines or so. The result was even bigger when replacing `"sse4.2"` with `"sse4"`, yielding a monstrous 702 lines.

This means SSE4.2 is hard-coded into the engine, and will take a fair amount of resources to remove. I don't have any experience with C++, I do have *some* with Rust etc, but that's not relevant.

Basically, making progress after the build system point is pretty much impossible for me. So I decided to draft this PR for now, I hope I can get some help in this.

Thanks!