### PR TITLE
Multiplayer: Fix node not found error in `process_simplify_path`

### DIFF
--- a/modules/multiplayer/scene_cache_interface.cpp
+++ b/modules/multiplayer/scene_cache_interface.cpp
@@ -106,11 +106,20 @@ void SceneCacheInterface::process_simplify_path(int p_from, const uint8_t *p_pac
 	int id = decode_uint32(&p_packet[ofs]);
 	ofs += 4;
 
-	ERR_FAIL_COND_MSG(peers_info[p_from].recv_nodes.has(id), vformat("Duplicate remote cache ID %d for peer %d", id, p_from));
+	// Might receive NETWORK_COMMAND_SIMPLIFY_PATH for the same ID more than once. If so, we just ignore them.
+	if (peers_info[p_from].recv_nodes.has(id)) {
+		return;
+	}
 
 	String paths = String::utf8((const char *)(p_packet + ofs), p_packet_len - ofs);
 
 	const NodePath path = paths;
+
+	// The node may not exist for many reasons. We can't assume this peer instantiates nodes as fast as other peers.
+	// We can simply return and wait for next NETWORK_COMMAND_SIMPLIFY_PATH.
+	if (!root_node->has_node(path)) {
+		return;
+	}
 
 	Node *node = root_node->get_node(path);
 	ERR_FAIL_NULL(node);
@@ -246,6 +255,7 @@ bool SceneCacheInterface::send_object_cache(Object *p_obj, int p_peer_id, int &r
 			peers_to_add.push_back(p_peer_id); // Need to also be notified.
 			has_all_peers = false;
 		} else if (!(*confirmed)) {
+			peers_to_add.push_back(p_peer_id); // Need to also be notified. Other peers may ignore NETWORK_COMMAND_SIMPLIFY_PATH several times for not yet having this node.
 			has_all_peers = false;
 		}
 	} else {


### PR DESCRIPTION
- Fix: #98052.

When developing a multiplayer game, "Node not found" error occurs sometimes and the synchronizer stops working.

This is because the authority peer sends the `NETWORK_COMMAND_SIMPLIFY_PATH` only once (per synchronizer) to other peers — whose corresponding nodes may not yet exist at that time — meaning those peers miss the only opportunity to execute `process_simplify_path` successfully.

This PR fixes this by having the authority peer send the `NETWORK_COMMAND_SIMPLIFY_PATH` to other peers continuously until the latter echo the `NETWORK_COMMAND_CONFIRM_PATH`.