### PR TITLE
Theme Editor: Remember split offset between editor sessions

### DIFF
--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -3962,6 +3962,18 @@ void ThemeEditor::_notification(int p_what) {
 	}
 }
 
+void ThemeEditor::save_layout_to_config(Ref<ConfigFile> &p_layout, const String &p_section) const {
+	const int split_offset = Math::round(main_hs->get_split_offset() / EDSCALE);
+	p_layout->set_value(p_section, "split_offset", split_offset);
+}
+
+void ThemeEditor::load_layout_from_config(const Ref<ConfigFile> &p_layout, const String &p_section) {
+	if (p_layout->has_section_key(p_section, "split_offset")) {
+		const int split_offset = p_layout->get_value(p_section, "split_offset");
+		main_hs->set_split_offset(split_offset * EDSCALE);
+	}
+}
+
 ThemeEditor::ThemeEditor() {
 	set_name(TTRC("Theme"));
 	set_icon_name("ThemeDock");
@@ -4026,7 +4038,7 @@ ThemeEditor::ThemeEditor() {
 	theme_edit_dialog->hide();
 	top_menu->add_child(theme_edit_dialog);
 
-	HSplitContainer *main_hs = memnew(HSplitContainer);
+	main_hs = memnew(HSplitContainer);
 	main_hs->set_v_size_flags(SIZE_EXPAND_FILL);
 	content_vb->add_child(main_hs);
 

--- a/editor/scene/gui/theme_editor_plugin.h
+++ b/editor/scene/gui/theme_editor_plugin.h
@@ -42,6 +42,7 @@ class Button;
 class CheckButton;
 class EditorFileDialog;
 class FilterLineEdit;
+class HSplitContainer;
 class ItemList;
 class Label;
 class LineEdit;
@@ -454,6 +455,7 @@ class ThemeEditor : public EditorDock {
 
 	Label *theme_name = nullptr;
 	ThemeItemEditorDialog *theme_edit_dialog = nullptr;
+	HSplitContainer *main_hs = nullptr;
 
 	void _theme_save_button_cbk(bool p_save_as);
 	void _theme_edit_button_cbk();
@@ -476,6 +478,9 @@ class ThemeEditor : public EditorDock {
 
 protected:
 	void _notification(int p_what);
+
+	virtual void save_layout_to_config(Ref<ConfigFile> &p_layout, const String &p_section) const override;
+	virtual void load_layout_from_config(const Ref<ConfigFile> &p_layout, const String &p_section) override;
 
 public:
 	void edit(const Ref<Theme> &p_theme);


### PR DESCRIPTION
Save and restore the size of the area marked on the screenshot after restarting the editor.

<img width="920" height="338" alt="" src="https://github.com/user-attachments/assets/299ba0fd-a925-4602-9c37-7b60012fbb38" />