### PR TITLE
[Export] Allow changing template encryption key without recompiling, add random key generation button.

### DIFF
--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -47,7 +47,7 @@ const unsigned long long GODOT_VERSION_TIMESTAMP = {git_timestamp};
 
 
 def encryption_key_builder(target, source, env):
-    src = source[0].read() or "0" * 64
+    src = source[0].read() or "47443A5343524950542D454E4352595054494F4E2D4B45592D424C4F423A4744"
     try:
         buffer = bytes.fromhex(src)
         if len(buffer) != 32:

--- a/doc/classes/EditorExportPlatform.xml
+++ b/doc/classes/EditorExportPlatform.xml
@@ -99,6 +99,14 @@
 				[b]Note:[/b] [param patches] is an optional override of the set of patches defined in the export preset. When empty the patches defined in the export preset will be used instead.
 			</description>
 		</method>
+		<method name="find_and_replace_key">
+			<return type="int" enum="Error" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="1" name="path" type="String" />
+			<description>
+				Finds and replaces the encryption key template in the [param path] with the key set in the [param preset].
+			</description>
+		</method>
 		<method name="find_export_template" qualifiers="const">
 			<return type="Dictionary" />
 			<param index="0" name="template_file_name" type="String" />

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -755,6 +755,141 @@ void EditorExportPlatform::_edit_filter_list(HashSet<String> &r_list, const Stri
 	_edit_files_with_filter(da, filters, r_list, exclude);
 }
 
+const Vector<uint8_t> EditorExportPlatform::_get_key(const Ref<EditorExportPreset> &p_preset) const {
+	Vector<uint8_t> key;
+	key.resize_initialized(32);
+
+	String script_key = _get_script_encryption_key(p_preset);
+	if (script_key.length() == 64) {
+		for (int i = 0; i < 32; i++) {
+			int v = 0;
+			if (i * 2 < script_key.length()) {
+				char32_t ct = script_key[i * 2];
+				if (is_digit(ct)) {
+					ct = ct - '0';
+				} else if (ct >= 'a' && ct <= 'f') {
+					ct = 10 + ct - 'a';
+				}
+				v |= ct << 4;
+			}
+
+			if (i * 2 + 1 < script_key.length()) {
+				char32_t ct = script_key[i * 2 + 1];
+				if (is_digit(ct)) {
+					ct = ct - '0';
+				} else if (ct >= 'a' && ct <= 'f') {
+					ct = 10 + ct - 'a';
+				}
+				v |= ct;
+			}
+			key.write[i] = v;
+		}
+	}
+	return key;
+}
+
+Error EditorExportPlatform::find_and_replace_key_file(const Ref<EditorExportPreset> &p_preset, const String &p_path) {
+	if (!p_preset->get_enc_pck()) {
+		return OK;
+	}
+
+	Error err = OK;
+	Ref<FileAccess> template_file = FileAccess::open(p_path, FileAccess::READ_WRITE, &err);
+	if (err == OK) {
+		if (_find_and_replace(template_file, key_template, _get_key(p_preset), 0) == 0) {
+			add_message(EXPORT_MESSAGE_WARNING, TTR("Export"), vformat(TTR("Unable to find ecryption key in the file \"%s\"."), p_path));
+		}
+	}
+	return err;
+}
+
+Error EditorExportPlatform::find_and_replace_key_data(const Ref<EditorExportPreset> &p_preset, PackedByteArray &r_data, const String &p_name) {
+	if (!p_preset->get_enc_pck()) {
+		return OK;
+	}
+
+	PackedByteArray key = _get_key(p_preset);
+	ERR_FAIL_COND_V(key.size() != key_template.size(), ERR_CANT_CREATE);
+
+	int find_count = 0;
+
+	const uint8_t *pat_ptr = key_template.ptr();
+	const int pat_size = key_template.size();
+
+	uint8_t *data_ptr = r_data.ptrw();
+	const int data_size = r_data.size();
+	int data_pos = 0;
+	while (data_pos < data_size - pat_size) {
+		bool found = true;
+		for (int i = 0; i < pat_size; i++) {
+			if (data_ptr[data_pos + i] != pat_ptr[i]) {
+				found = false;
+				break;
+			}
+		}
+		if (found) {
+			for (int i = 0; i < pat_size; i++) {
+				data_ptr[data_pos + i] = key[i];
+			}
+			find_count++;
+
+			data_pos += pat_size;
+		}
+		data_pos++;
+	}
+	if (find_count == 0) {
+		add_message(EXPORT_MESSAGE_WARNING, TTR("Export"), vformat(TTR("Unable to find ecryption key in the file \"%s\"."), p_name));
+	}
+	return OK;
+}
+
+int EditorExportPlatform::_find_and_replace(const Ref<FileAccess> &p_file, const PackedByteArray &p_old, const PackedByteArray &p_new, uint64_t p_start) const {
+	ERR_FAIL_COND_V(p_file.is_null(), 0);
+	ERR_FAIL_COND_V(p_old.is_empty(), 0);
+	ERR_FAIL_COND_V(p_old.size() != p_new.size(), 0);
+
+	int find_count = 0;
+
+	const uint8_t *pat_ptr = p_old.ptr();
+	const int pat_size = p_old.size();
+
+	uint64_t old_pos = p_file->get_position();
+	p_file->seek(p_start);
+	while (!p_file->eof_reached()) {
+		uint64_t segment_start = p_file->get_position();
+		PackedByteArray data = p_file->get_buffer(10 * 1024 * 1024);
+		const uint8_t *data_ptr = data.ptr();
+		uint64_t segment_end = p_file->get_position();
+		if (!p_file->eof_reached()) {
+			segment_end -= p_old.size();
+		}
+
+		const int data_size = data.size();
+		int data_pos = 0;
+		while (data_pos < data_size - pat_size) {
+			bool found = true;
+			for (int i = 0; i < pat_size; i++) {
+				if (data_ptr[data_pos + i] != pat_ptr[i]) {
+					found = false;
+					break;
+				}
+			}
+			if (found) {
+				p_file->seek(segment_start + data_pos);
+				p_file->store_buffer(p_new);
+				p_file->seek(segment_end);
+				find_count++;
+
+				data_pos += pat_size;
+			}
+			data_pos++;
+		}
+	}
+
+	p_file->seek(old_pos);
+	return find_count;
+}
+
 HashSet<String> EditorExportPlatform::get_features(const Ref<EditorExportPreset> &p_preset, bool p_debug) const {
 	Ref<EditorExportPlatform> platform = p_preset->get_platform();
 	List<String> feature_list;
@@ -2765,6 +2900,8 @@ void EditorExportPlatform::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("save_zip", "preset", "debug", "path"), &EditorExportPlatform::_save_zip);
 	ClassDB::bind_method(D_METHOD("save_pack_patch", "preset", "debug", "path"), &EditorExportPlatform::_save_pack_patch);
 	ClassDB::bind_method(D_METHOD("save_zip_patch", "preset", "debug", "path"), &EditorExportPlatform::_save_zip_patch);
+
+	ClassDB::bind_method(D_METHOD("find_and_replace_key", "preset", "path"), &EditorExportPlatform::find_and_replace_key_file);
 
 	ClassDB::bind_method(D_METHOD("gen_export_flags", "flags"), &EditorExportPlatform::gen_export_flags);
 

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -223,11 +223,16 @@ protected:
 
 	Ref<Image> _load_icon_or_splash_image(const String &p_path, Error *r_error) const;
 
+	int _find_and_replace(const Ref<FileAccess> &p_file, const PackedByteArray &p_old, const PackedByteArray &p_new, uint64_t p_start = 0) const;
+
 #ifndef DISABLE_DEPRECATED
 	Error _export_project_bind_compat_118787(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0);
 	static Vector<String> _get_forced_export_files_bind_compat_71542();
 	static void _bind_compatibility_methods();
 #endif
+
+	const Vector<uint8_t> key_template = { 0x47, 0x44, 0x3A, 0x53, 0x43, 0x52, 0x49, 0x50, 0x54, 0x2D, 0x45, 0x4E, 0x43, 0x52, 0x59, 0x50, 0x54, 0x49, 0x4F, 0x4E, 0x2D, 0x4B, 0x45, 0x59, 0x2D, 0x42, 0x4C, 0x4F, 0x42, 0x3A, 0x47, 0x44 };
+	const Vector<uint8_t> _get_key(const Ref<EditorExportPreset> &p_preset) const;
 
 public:
 	static String simplify_path(const String &p_path);
@@ -251,6 +256,9 @@ public:
 
 	virtual Ref<EditorExportPreset> create_preset();
 	virtual bool is_executable(const String &p_path) const { return false; }
+
+	Error find_and_replace_key_file(const Ref<EditorExportPreset> &p_preset, const String &p_path);
+	Error find_and_replace_key_data(const Ref<EditorExportPreset> &p_preset, PackedByteArray &r_data, const String &p_name);
 
 	virtual void clear_messages() { messages.clear(); }
 	virtual void add_message(ExportMessageType p_type, const String &p_category, const String &p_message) {

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -1928,9 +1928,7 @@ Error EditorExportPlatformAppleEmbedded::_export_project_helper(const Ref<Editor
 	int ret = unzGoToFirstFile(src_pkg_zip);
 	Vector<uint8_t> project_file_data;
 	while (ret == UNZ_OK) {
-#if defined(MACOS_ENABLED) || defined(LINUXBSD_ENABLED)
-		bool is_execute = false;
-#endif
+		bool is_executable = false;
 
 		//get filename
 		unz_file_info info;
@@ -1977,9 +1975,7 @@ Error EditorExportPlatformAppleEmbedded::_export_project_helper(const Ref<Editor
 			if (file.ends_with("Info.plist")) {
 				found_libraries++;
 			}
-#if defined(MACOS_ENABLED) || defined(LINUXBSD_ENABLED)
-			is_execute = true;
-#endif
+			is_executable = true;
 			file = file.replace(prefix_lib, suffix_lib + ".xcframework");
 		}
 
@@ -2019,9 +2015,12 @@ Error EditorExportPlatformAppleEmbedded::_export_project_helper(const Ref<Editor
 				};
 				f->store_buffer(data.ptr(), data.size());
 			}
+			if (is_executable && file.ends_with(".a")) {
+				find_and_replace_key_file(p_preset, file);
+			}
 
 #if defined(MACOS_ENABLED) || defined(LINUXBSD_ENABLED)
-			if (is_execute) {
+			if (is_executable) {
 				// we need execute rights on this file
 				chmod(file.utf8().get_data(), 0755);
 			}

--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -143,6 +143,9 @@ Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_pr
 
 	Error err = prepare_template(p_preset, p_debug, p_path, p_flags);
 	if (err == OK) {
+		find_and_replace_key_file(p_preset, p_path);
+	}
+	if (err == OK) {
 		err = modify_template(p_preset, p_debug, p_path, p_flags);
 	}
 	if (err == OK) {

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -31,6 +31,7 @@
 #include "project_export.h"
 
 #include "core/config/project_settings.h"
+#include "core/crypto/crypto_core.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
@@ -120,6 +121,7 @@ void ProjectExportDialog::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			_script_encryption_key_visibility_changed(show_script_key->is_pressed());
 			options_filter->set_right_icon(get_editor_theme_icon(SNAME("Search")));
+			pck_key_gen->set_button_icon(get_editor_theme_icon(SNAME("Random")));
 			duplicate_preset->set_button_icon(presets->get_editor_theme_icon(SNAME("Duplicate")));
 			delete_preset->set_button_icon(presets->get_editor_theme_icon(SNAME("Remove")));
 			patch_add_btn->set_button_icon(get_editor_theme_icon(SNAME("Add")));
@@ -747,6 +749,27 @@ bool ProjectExportDialog::_validate_script_encryption_key(const String &p_key) {
 		is_valid = true;
 	}
 	return is_valid;
+}
+
+void ProjectExportDialog::_script_key_gen() {
+	Vector<uint8_t> key;
+	key.resize(32);
+
+	CryptoCore::RandomGenerator rng;
+	ERR_FAIL_COND(rng.init() != OK);
+	ERR_FAIL_COND(rng.get_random_bytes((uint8_t *)key.ptrw(), 32) != OK);
+
+	String str_key = String::hex_encode_buffer((uint8_t *)key.ptr(), 32);
+	script_key->set_text(str_key);
+
+	Ref<EditorExportPreset> current = get_current_preset();
+	ERR_FAIL_COND(current.is_null());
+
+	current->set_script_encryption_key(str_key);
+
+	updating_script_key = true;
+	_update_current_preset();
+	updating_script_key = false;
 }
 
 void ProjectExportDialog::_script_export_mode_changed(EditorExportPreset::ScriptExportMode p_mode) {
@@ -1942,12 +1965,17 @@ ProjectExportDialog::ProjectExportDialog() {
 	script_key->connect(SceneStringName(text_changed), callable_mp(this, &ProjectExportDialog::_script_encryption_key_changed));
 	script_key->set_secret(true);
 
+	pck_key_gen = memnew(Button);
+	pck_key_gen->set_tooltip_text(TTR("Generate random key"));
+	pck_key_gen->connect(SceneStringName(pressed), callable_mp(this, &ProjectExportDialog::_script_key_gen));
+
 	show_script_key = memnew(Button);
 	show_script_key->set_toggle_mode(true);
 	show_script_key->connect(SceneStringName(toggled), callable_mp(this, &ProjectExportDialog::_script_encryption_key_visibility_changed));
 
 	HBoxContainer *encryption_hb = memnew(HBoxContainer);
 	encryption_hb->add_child(script_key);
+	encryption_hb->add_child(pck_key_gen);
 	encryption_hb->add_child(show_script_key);
 
 	script_key_error = memnew(Label);
@@ -1963,7 +1991,7 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	Label *sec_info = memnew(Label);
 	sec_info->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
-	sec_info->set_text(TTRC("Note: Encryption key needs to be stored in the binary,\nyou need to build the export templates from source."));
+	sec_info->set_text(TTRC("Note: Encryption key needs to be stored in the binary,\nit is recommended to build the export templates from source."));
 	sec_vb->add_child(sec_info);
 
 	LinkButton *sec_more_info = memnew(LinkButton);

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -196,6 +196,7 @@ class ProjectExportDialog : public ConfirmationDialog {
 	LineEdit *enc_in_filters = nullptr;
 	LineEdit *enc_ex_filters = nullptr;
 	LineEdit *seed_input = nullptr;
+	Button *pck_key_gen = nullptr;
 
 	OptionButton *script_mode = nullptr;
 
@@ -223,6 +224,8 @@ class ProjectExportDialog : public ConfirmationDialog {
 	void _script_encryption_key_changed(const String &p_key);
 	void _script_encryption_key_visibility_changed(bool p_visible);
 	bool _validate_script_encryption_key(const String &p_key);
+
+	void _script_key_gen();
 
 	void _script_export_mode_changed(EditorExportPreset::ScriptExportMode p_mode);
 

--- a/editor/icons/Random.svg
+++ b/editor/icons/Random.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="16" height="16"><path fill="#e0e0e0" d="M8 1C1 1 1 1 1 8s0 7 7 7 7 0 7-7 0-7-7-7M4.25 2.25a1 1 0 0 1 0 4 1 1 0 0 1 0-4M8 6a1 1 0 0 1 0 4 1 1 0 0 1 0-4m3.75 3.75a1 1 0 0 1 0 4 1 1 0 0 1 0-4"/></svg>

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -3509,6 +3509,86 @@ void EditorExportPlatformAndroid::_remove_copied_libs(String p_gdextension_libs_
 	da->remove(p_gdextension_libs_path);
 }
 
+void EditorExportPlatformAndroid::_replace_key_in_libs(const Ref<EditorExportPreset> &p_preset, String p_libs_path) {
+	Ref<DirAccess> da = DirAccess::open(p_libs_path);
+	if (da.is_null()) {
+		return;
+	}
+	da->list_dir_begin();
+	while (true) {
+		String file = da->get_next();
+		if (file.is_empty()) {
+			break;
+		}
+		if (file == "." || file == "..") {
+			continue;
+		}
+		if (da->current_is_dir()) {
+			_replace_key_in_libs(p_preset, p_libs_path.path_join(file));
+			continue;
+		}
+		if (file.begins_with("godot-lib") && file.ends_with(".aar")) {
+			String template_name = p_libs_path.path_join(file) + ".template";
+			if (!da->file_exists(template_name)) {
+				da->copy(p_libs_path.path_join(file), template_name);
+			}
+			da->remove(p_libs_path.path_join(file));
+
+			Ref<FileAccess> io_fa;
+			zlib_filefunc_def io = zipio_create_io(&io_fa);
+			unzFile pkg = unzOpen2(template_name.utf8().get_data(), &io);
+			if (!pkg) {
+				continue;
+			}
+			int ret = unzGoToFirstFile(pkg);
+			Ref<FileAccess> io2_fa;
+			zlib_filefunc_def io2 = zipio_create_io(&io2_fa);
+			zipFile dst = zipOpen2(p_libs_path.path_join(file).utf8().get_data(), APPEND_STATUS_CREATE, nullptr, &io2);
+			while (ret == UNZ_OK) {
+				unz_file_info info;
+				char fname[16384];
+				ret = unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0);
+				if (ret != UNZ_OK) {
+					break;
+				}
+				String zfile = String::utf8(fname);
+				Vector<uint8_t> data;
+				data.resize(info.uncompressed_size);
+
+				unzOpenCurrentFile(pkg);
+				unzReadCurrentFile(pkg, data.ptrw(), data.size());
+				unzCloseCurrentFile(pkg);
+				if (zfile.contains("libgodot") && zfile.ends_with(".so")) {
+					find_and_replace_key_data(p_preset, data, zfile);
+				}
+				// Respect decision on compression made by AAPT for the export template
+				const bool uncompressed = info.compression_method == 0;
+
+				zip_fileinfo zipfi = get_zip_fileinfo();
+
+				zipOpenNewFileInZip(dst,
+						zfile.utf8().get_data(),
+						&zipfi,
+						nullptr,
+						0,
+						nullptr,
+						0,
+						nullptr,
+						uncompressed ? 0 : Z_DEFLATED,
+						Z_DEFAULT_COMPRESSION);
+
+				zipWriteInFileInZip(dst, data.ptr(), data.size());
+				zipCloseFileInZip(dst);
+
+				ret = unzGoToNextFile(pkg);
+			}
+			zipClose(dst, nullptr);
+			unzClose(pkg);
+		}
+	}
+	da->list_dir_end();
+}
+
 String EditorExportPlatformAndroid::join_list(const List<String> &p_parts, const String &p_separator) {
 	String ret;
 	for (List<String>::ConstIterator itr = p_parts.begin(); itr != p_parts.end(); ++itr) {
@@ -3811,6 +3891,8 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		_clear_assets_directory(p_preset);
 		String gdextension_libs_path = gradle_build_directory.path_join(GDEXTENSION_LIBS_PATH);
 		_remove_copied_libs(gdextension_libs_path);
+		_replace_key_in_libs(p_preset, gradle_build_directory.path_join("libs"));
+
 		print_verbose("Exporting project files...");
 		CustomExportData user_data;
 		user_data.assets_directory = assets_directory;
@@ -4266,6 +4348,10 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 
 		if (!skip) {
 			print_line("ADDING: " + file);
+
+			if (file.contains("libgodot") && file.ends_with(".so")) {
+				find_and_replace_key_data(p_preset, data, file);
+			}
 
 			// Respect decision on compression made by AAPT for the export template
 			const bool uncompressed = info.compression_method == 0;

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -278,6 +278,7 @@ public:
 	void _clear_assets_directory(const Ref<EditorExportPreset> &p_preset);
 
 	void _remove_copied_libs(String p_gdextension_libs_path);
+	void _replace_key_in_libs(const Ref<EditorExportPreset> &p_preset, String p_libs_path);
 
 	static String join_list(const List<String> &p_parts, const String &p_separator);
 	static String join_abis(const Vector<ABI> &p_parts, const String &p_separator, bool p_use_arch);

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -2045,6 +2045,9 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 					err = ERR_CANT_CREATE;
 				}
 			}
+			if (err == OK && file == "Contents/MacOS/" + pkg_name) {
+				find_and_replace_key_file(p_preset, file);
+			}
 		}
 
 		ret = unzGoToNextFile(src_pkg_zip);

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -48,7 +48,7 @@
 #include "modules/modules_enabled.gen.h" // IWYU pragma: keep. For mono.
 #include "modules/svg/image_loader_svg.h"
 
-Error EditorExportPlatformWeb::_extract_template(const String &p_template, const String &p_dir, const String &p_name, bool pwa) {
+Error EditorExportPlatformWeb::_extract_template(const Ref<EditorExportPreset> &p_preset, const String &p_template, const String &p_dir, const String &p_name, bool pwa) {
 	Ref<FileAccess> io_fa;
 	zlib_filefunc_def io = zipio_create_io(&io_fa);
 	unzFile pkg = unzOpen2(p_template.utf8().get_data(), &io);
@@ -88,6 +88,10 @@ Error EditorExportPlatformWeb::_extract_template(const String &p_template, const
 		unzOpenCurrentFile(pkg);
 		unzReadCurrentFile(pkg, data.ptrw(), data.size());
 		unzCloseCurrentFile(pkg);
+
+		if (file.contains("godot") && file.ends_with(".wasm")) {
+			find_and_replace_key_data(p_preset, data, file);
+		}
 
 		//write
 		String dst = p_dir.path_join(file.replace("godot", p_name));
@@ -544,7 +548,7 @@ Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_p
 	}
 
 	// Extract templates.
-	error = _extract_template(template_path, base_dir, base_name, pwa);
+	error = _extract_template(p_preset, template_path, base_dir, base_name, pwa);
 	if (error) {
 		// Message is supplied by the subroutine method.
 		return error;

--- a/platform/web/export/export_plugin.h
+++ b/platform/web/export/export_plugin.h
@@ -100,7 +100,7 @@ class EditorExportPlatformWeb : public EditorExportPlatform {
 		return splash;
 	}
 
-	Error _extract_template(const String &p_template, const String &p_dir, const String &p_name, bool pwa);
+	Error _extract_template(const Ref<EditorExportPreset> &p_preset, const String &p_template, const String &p_dir, const String &p_name, bool pwa);
 	void _replace_strings(const HashMap<String, String> &p_replaces, Vector<uint8_t> &r_template);
 	void _fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug, BitField<EditorExportPlatform::DebugFlags> p_flags, const Vector<SharedObject> p_shared_objects, const Dictionary &p_file_sizes);
 	Error _add_manifest_icon(const Ref<EditorExportPreset> &p_preset, const String &p_path, const String &p_icon, int p_size, Array &r_arr);


### PR DESCRIPTION
- Allows changing template encryption key without recompiling, by replacing key in the exported template.
- Adds random key generation button.

<img width="739" height="97" alt="Screenshot 2026-02-01 at 19 52 17" src="https://github.com/user-attachments/assets/69f62c82-11c5-42d7-a1ba-b9d794c61f3c" />

Fixes https://github.com/godotengine/godot-proposals/issues/14120
Fixes https://github.com/godotengine/godot-proposals/issues/9340