### PR TITLE
Preserve Unix file attributes when downloading assets

### DIFF
--- a/editor/asset_library/editor_asset_installer.cpp
+++ b/editor/asset_library/editor_asset_installer.cpp
@@ -560,6 +560,10 @@ void EditorAssetInstaller::_install_asset() {
 			Ref<FileAccess> f = FileAccess::open(target_path, FileAccess::WRITE);
 			if (f.is_valid()) {
 				f->store_buffer(uncomp_data.ptr(), uncomp_data.size());
+				f.unref(); // close file.
+#ifndef WINDOWS_ENABLED
+				FileAccess::set_unix_permissions(target_path, (info.external_fa >> 16) & 0x01FF);
+#endif
 			} else {
 				failed_files.push_back(target_path);
 			}


### PR DESCRIPTION
From the Godot Editor on Linux, downloading a ZIP archive asset extension works, but while the asset is correctly extracted, the extracted files lose their file attributes
