### PR TITLE
Change 2d shapes drawing color when RigidBody2D sleeping

### DIFF
--- a/scene/2d/physics/collision_polygon_2d.cpp
+++ b/scene/2d/physics/collision_polygon_2d.cpp
@@ -135,8 +135,19 @@ void CollisionPolygon2D::_notification(int p_what) {
 					Vector<Vector<Vector2>> decomp = _decompose_in_convex();
 
 					Color c(0.4, 0.9, 0.1);
+
+					if (disabled) {
+						float g = c.get_v();
+						c.r = g;
+						c.g = g;
+						c.b = g;
+						c.a *= 0.5;
+					} else if (sleeping) {
+						c.a *= 0.5;
+					}
+
 					for (int i = 0; i < decomp.size(); i++) {
-						c.set_hsv(Math::fmod(c.get_h() + 0.738, 1), c.get_s(), c.get_v(), 0.5);
+						c.set_hsv(Math::fmod(c.get_h() + 0.738, 1), c.get_s(), c.get_v(), 0.5 * c.a);
 						draw_colored_polygon(decomp[i], c);
 					}
 				}
@@ -266,6 +277,18 @@ void CollisionPolygon2D::set_disabled(bool p_disabled) {
 
 bool CollisionPolygon2D::is_disabled() const {
 	return disabled;
+}
+
+void CollisionPolygon2D::set_sleeping(bool p_sleeping) {
+	if (sleeping == p_sleeping) {
+		return;
+	}
+	sleeping = p_sleeping;
+	queue_redraw();
+}
+
+bool CollisionPolygon2D::is_sleeping() const {
+	return sleeping;
 }
 
 void CollisionPolygon2D::set_one_way_collision(bool p_enable) {

--- a/scene/2d/physics/collision_polygon_2d.h
+++ b/scene/2d/physics/collision_polygon_2d.h
@@ -53,6 +53,8 @@ protected:
 	bool one_way_collision = false;
 	real_t one_way_collision_margin = 1.0;
 
+	bool sleeping = false;
+
 	Vector<Vector<Vector2>> _decompose_in_convex();
 
 	void _build_polygon();
@@ -86,6 +88,9 @@ public:
 
 	void set_one_way_collision_margin(real_t p_margin);
 	real_t get_one_way_collision_margin() const;
+
+	void set_sleeping(bool p_sleeping);
+	bool is_sleeping() const;
 
 	CollisionPolygon2D();
 };

--- a/scene/2d/physics/collision_shape_2d.cpp
+++ b/scene/2d/physics/collision_shape_2d.cpp
@@ -102,6 +102,8 @@ void CollisionShape2D::_notification(int p_what) {
 				draw_col.g = g;
 				draw_col.b = g;
 				draw_col.a *= 0.5;
+			} else if (sleeping) {
+				draw_col.a *= 0.5;
 			}
 			shape->draw(get_canvas_item(), draw_col);
 
@@ -201,6 +203,18 @@ void CollisionShape2D::set_disabled(bool p_disabled) {
 
 bool CollisionShape2D::is_disabled() const {
 	return disabled;
+}
+
+void CollisionShape2D::set_sleeping(bool p_sleeping) {
+	if (sleeping == p_sleeping) {
+		return;
+	}
+	sleeping = p_sleeping;
+	queue_redraw();
+}
+
+bool CollisionShape2D::is_sleeping() const {
+	return sleeping;
 }
 
 void CollisionShape2D::set_one_way_collision(bool p_enable) {

--- a/scene/2d/physics/collision_shape_2d.h
+++ b/scene/2d/physics/collision_shape_2d.h
@@ -50,6 +50,7 @@ class CollisionShape2D : public Node2D {
 
 	// Not wrapped in `#ifdef DEBUG_ENABLED` as it is used for rendering.
 	Color debug_color = Color(0.0, 0.0, 0.0, 0.0);
+	bool sleeping = false;
 
 	Color _get_default_debug_color() const;
 
@@ -85,6 +86,9 @@ public:
 
 	void set_debug_color(const Color &p_color);
 	Color get_debug_color() const;
+
+	void set_sleeping(bool p_sleeping);
+	bool is_sleeping() const;
 
 	PackedStringArray get_configuration_warnings() const override;
 

--- a/scene/2d/physics/rigid_body_2d.cpp
+++ b/scene/2d/physics/rigid_body_2d.cpp
@@ -30,6 +30,9 @@
 
 #include "rigid_body_2d.h"
 
+#include "scene/2d/physics/collision_polygon_2d.h"
+#include "scene/2d/physics/collision_shape_2d.h"
+
 void RigidBody2D::_body_enter_tree(ObjectID p_id) {
 	Object *obj = ObjectDB::get_instance(p_id);
 	Node *node = Object::cast_to<Node>(obj);
@@ -157,6 +160,26 @@ void RigidBody2D::_sync_body_state(PhysicsDirectBodyState2D *p_state) {
 	if (sleeping != p_state->is_sleeping()) {
 		sleeping = p_state->is_sleeping();
 		emit_signal(SceneStringName(sleeping_state_changed));
+
+		if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) {
+			return;
+		}
+
+		List<uint32_t> shape_owners;
+		get_shape_owners(&shape_owners);
+		for (uint32_t owner_id : shape_owners) {
+			Object *owner = shape_owner_get_owner(owner_id);
+
+			CollisionShape2D *shape = Object::cast_to<CollisionShape2D>(owner);
+			if (shape) {
+				shape->set_sleeping(sleeping);
+			}
+
+			CollisionPolygon2D *polygon = Object::cast_to<CollisionPolygon2D>(owner);
+			if (polygon) {
+				polygon->set_sleeping(sleeping);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
- Closes (Partially): https://github.com/godotengine/godot-proposals/issues/3667 (for 2D)

## Example

https://github.com/user-attachments/assets/62b0b875-2616-41e6-955e-3ccf8db24e81

Also I added color for disabled state PolygonShape2D (like at CollisionShake2D, for consistency).