### PR TITLE
Use class name instead of Object ID in remote scene view

### DIFF
--- a/scene/debugger/scene_debugger_object.cpp
+++ b/scene/debugger/scene_debugger_object.cpp
@@ -75,9 +75,15 @@ SceneDebuggerObject::SceneDebuggerObject(Object *p_obj) {
 	// Add base object properties.
 	List<PropertyInfo> pinfo;
 	p_obj->get_property_list(&pinfo, true);
-	for (const PropertyInfo &E : pinfo) {
+	for (PropertyInfo &E : pinfo) {
+		const Variant &m = p_obj->get(E.name);
+
+		if (!m.is_null() && E.type == Variant::OBJECT && E.hint == PROPERTY_HINT_NODE_TYPE && E.usage & PROPERTY_USAGE_EDITOR) {
+			E.hint_string = _parse_type_from_remote_object(m);
+		}
+
 		if (E.usage & (PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CATEGORY)) {
-			properties.push_back(SceneDebuggerProperty(E, p_obj->get(E.name)));
+			properties.push_back(SceneDebuggerProperty(E, m));
 		}
 	}
 }
@@ -139,28 +145,31 @@ void SceneDebuggerObject::_parse_script_properties(Script *p_script, ScriptInsta
 			Variant m;
 			if (p_instance->get(E, m)) {
 				const String script_path = sm.key == p_script ? "" : sm.key->get_path().get_file() + "/";
-
-				PropertyInfo pi;
-				const PropertyInfo *pi_ptr = non_exported_members.getptr(E);
-				if (pi_ptr == nullptr) {
-					pi.type = m.get_type();
+				if (!m.is_null() && m.get_type() == Variant::OBJECT) {
+					PropertyInfo pi(m.get_type(), "Members/" + script_path + E, PROPERTY_HINT_OBJECT_ID, _parse_type_from_remote_object(m));
+					properties.push_back(SceneDebuggerProperty(pi, m));
 				} else {
-					pi = *pi_ptr;
-				}
-				pi.name = "Members/" + script_path + E;
+					PropertyInfo pi;
+					const PropertyInfo *pi_ptr = non_exported_members.getptr(E);
+					if (pi_ptr == nullptr) {
+						pi.type = m.get_type();
+					} else {
+						pi = *pi_ptr;
+					}
+					pi.name = "Members/" + script_path + E;
 
-				properties.push_back(SceneDebuggerProperty(pi, m));
+					properties.push_back(SceneDebuggerProperty(pi, m));
+				}
 			}
 		}
 	}
 	// Constants
 	for (KeyValue<const Script *, HashMap<StringName, Variant>> &sc : constants) {
 		for (const KeyValue<StringName, Variant> &E : sc.value) {
-			String script_path = sc.key == p_script ? "" : sc.key->get_path().get_file() + "/";
-			if (E.value.get_type() == Variant::OBJECT) {
-				Variant inst_id = ((Object *)E.value)->get_instance_id();
-				PropertyInfo pi(inst_id.get_type(), "Constants/" + E.key, PROPERTY_HINT_OBJECT_ID, "Object", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY);
-				properties.push_back(SceneDebuggerProperty(pi, inst_id));
+			const String script_path = sc.key == p_script ? "" : sc.key->get_path().get_file() + "/";
+			if (!E.value.is_null() && E.value.get_type() == Variant::OBJECT) {
+				PropertyInfo pi(E.value.get_type(), "Constants/" + E.key, PROPERTY_HINT_OBJECT_ID, _parse_type_from_remote_object(E.value), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY);
+				properties.push_back(SceneDebuggerProperty(pi, E.value));
 			} else {
 				PropertyInfo pi(E.value.get_type(), "Constants/" + script_path + E.key);
 				pi.usage |= PROPERTY_USAGE_READ_ONLY;
@@ -169,6 +178,29 @@ void SceneDebuggerObject::_parse_script_properties(Script *p_script, ScriptInsta
 			}
 		}
 	}
+}
+String SceneDebuggerObject::_parse_type_from_remote_object(const Variant &p_variant) {
+	String name;
+
+	if (p_variant.get_type() == Variant::OBJECT) {
+		const Object *obj = p_variant.get_validated_object();
+		if (obj) {
+			const ScriptInstance *script_instance = obj->get_script_instance();
+
+			if (script_instance) {
+				Ref<Script> script = script_instance->get_script();
+				if (script.is_valid()) {
+					name = script->get_global_name();
+				}
+			}
+
+			if (name.is_empty()) {
+				return obj->get_class();
+			}
+		}
+	}
+
+	return name;
 }
 
 void SceneDebuggerObject::serialize(Array &r_arr, int p_max_size) {
@@ -250,7 +282,9 @@ void SceneDebuggerObject::deserialize(uint64_t p_id, const String &p_class_name,
 					var = Object::cast_to<EncodedObjectAsID>(var)->get_object_id();
 					pinfo.type = var.get_type();
 					pinfo.hint = PROPERTY_HINT_OBJECT_ID;
-					pinfo.hint_string = "Object";
+					if (pinfo.hint_string.is_empty()) {
+						pinfo.hint_string = "Object";
+					}
 				}
 			}
 		}

--- a/scene/debugger/scene_debugger_object.h
+++ b/scene/debugger/scene_debugger_object.h
@@ -43,6 +43,7 @@ class Script;
 class SceneDebuggerObject {
 private:
 	void _parse_script_properties(Script *p_script, ScriptInstance *p_instance);
+	static String _parse_type_from_remote_object(const Variant &p_variant);
 
 public:
 	typedef Pair<PropertyInfo, Variant> SceneDebuggerProperty;


### PR DESCRIPTION
This changes the remote scene view to use an Object's script/class name instead of displaying as "Object ID: XXXXXX". 
Works with `@export`, `@onready`.
~~**NOTE:** These will still display as "Object ID: XXXXXX" in the debugger.~~ Fixed in: https://github.com/godotengine/godot/pull/117892.

Tackles (![#c600ff](https://placehold.co/15x15/c600ff/c600ff.png)) and closes https://github.com/godotengine/godot-proposals/issues/11736, closes https://github.com/godotengine/godot/issues/85712, closes https://github.com/godotengine/godot/issues/79476.

Salvages https://github.com/godotengine/godot/pull/113984 (last one's PR was messed up)

--


| Before | After |
| ------------- | ------------- |
|  ![image](https://github.com/user-attachments/assets/72acd494-23db-47f9-901e-5d66412e6d0f) | ![image](https://github.com/user-attachments/assets/e4978175-d7e0-432b-a03a-0e9161ea7d16) |