### PR TITLE
Improve source-generated `EmitSignal{...}` performance in C#

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/EventSignals_ScriptSignals.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/EventSignals_ScriptSignals.generated.cs
@@ -34,7 +34,7 @@ partial class EventSignals
 }
     protected void EmitSignalMySignal(string @str, int @num)
     {
-        EmitSignal(SignalName.MySignal, @str, @num);
+        EmitSignal(SignalName.MySignal, [@str, @num]);
     }
     /// <inheritdoc/>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -303,20 +303,25 @@ namespace Godot.SourceGenerators
                 }
                 source.Append(")\n");
                 source.Append("    {\n");
-                source.Append($"        EmitSignal(SignalName.{signalName}");
+                source.Append($"        EmitSignal(SignalName.{signalName}, [");
                 foreach (var paramSymbol in invokeMethodSymbol.Parameters)
                 {
+                    if (paramSymbol.Ordinal != 0)
+                    {
+                        source.Append(", ");
+                    }
+
                     // Enums must be converted to the underlying type before they can be implicitly converted to Variant
                     if (paramSymbol.Type.TypeKind == TypeKind.Enum)
                     {
                         var underlyingType = ((INamedTypeSymbol)paramSymbol.Type).EnumUnderlyingType!;
-                        source.Append($", ({underlyingType.FullQualifiedNameIncludeGlobal()})@{paramSymbol.Name}");
+                        source.Append($"({underlyingType.FullQualifiedNameIncludeGlobal()})@{paramSymbol.Name}");
                         continue;
                     }
 
-                    source.Append($", @{paramSymbol.Name}");
+                    source.Append($"@{paramSymbol.Name}");
                 }
-                source.Append(");\n");
+                source.Append("]);\n");
                 source.Append("    }\n");
             }
 


### PR DESCRIPTION
There are two `EmitSignal()` overloads:
- `public Error EmitSignal(StringName signal, params Variant[] @args)`
- `public Error EmitSignal(StringName signal, ReadOnlySpan<Variant> @args)` (added in #96329 by DE-YU)

Calling the first one (using `params`) is not ideal since it allocates an array (unless no arguments passed). Calling the second one allows a stack-allocated span. Using `[]` allows the second one to be called, which is prioritised by C#.