### PR TITLE
Make type editor start width wider in the Theme Editor

### DIFF
--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -4040,7 +4040,7 @@ ThemeEditor::ThemeEditor() {
 	main_hs->set_v_size_flags(SIZE_EXPAND_FILL);
 	content_vb->add_child(main_hs);
 
-	main_hs->set_split_offset(520 * EDSCALE);
+	main_hs->set_split_offset(-368 * EDSCALE);
 
 	VBoxContainer *preview_tabs_vb = memnew(VBoxContainer);
 	preview_tabs_vb->set_h_size_flags(SIZE_EXPAND_FILL);


### PR DESCRIPTION


| Before  | After |
| ------------- | ------------- |
|  <img width="427" height="394" alt="Screenshot_20260201_110155" src="https://github.com/user-attachments/assets/5e85285d-850a-43d9-860d-278f8e1fe921" /> |  <img width="427" height="394" alt="Screenshot_20260201_133620" src="https://github.com/user-attachments/assets/8d7bfc6d-009f-473a-931b-1d6d452c8771" /> |
|  <img width="427" height="394" alt="Screenshot_20260201_110135" src="https://github.com/user-attachments/assets/1deadb42-5096-4e91-b545-1904c79f0bec" /> |  <img width="427" height="394" alt="Screenshot_20260201_133603" src="https://github.com/user-attachments/assets/27abb6e4-d188-4a0d-baa0-2f3c12903aac" /> |
