### PR TITLE
[TextServer] Reuse `FT_Face` and data for all font sizes.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1265,7 +1265,7 @@ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i
 
 #ifdef MODULE_FREETYPE_ENABLED
 	FontGlyph gl;
-	if (fd->face) {
+	if (p_font_data->face) {
 		FT_Int32 flags = FT_LOAD_DEFAULT;
 
 		bool outline = p_size.y > 0;
@@ -1283,17 +1283,17 @@ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i
 		if (p_font_data->force_autohinter) {
 			flags |= FT_LOAD_FORCE_AUTOHINT;
 		}
-		if (outline || (p_font_data->disable_embedded_bitmaps && !FT_HAS_COLOR(fd->face))) {
+		if (outline || (p_font_data->disable_embedded_bitmaps && !FT_HAS_COLOR(p_font_data->face))) {
 			flags |= FT_LOAD_NO_BITMAP;
-		} else if (FT_HAS_COLOR(fd->face)) {
+		} else if (FT_HAS_COLOR(p_font_data->face)) {
 			flags |= FT_LOAD_COLOR;
 		}
 
 		FT_Fixed v, h;
-		FT_Get_Advance(fd->face, glyph_index, flags, &h);
-		FT_Get_Advance(fd->face, glyph_index, flags | FT_LOAD_VERTICAL_LAYOUT, &v);
+		FT_Get_Advance(p_font_data->face, glyph_index, flags, &h);
+		FT_Get_Advance(p_font_data->face, glyph_index, flags | FT_LOAD_VERTICAL_LAYOUT, &v);
 
-		int error = FT_Load_Glyph(fd->face, glyph_index, flags);
+		int error = FT_Load_Glyph(p_font_data->face, glyph_index, flags);
 		if (error) {
 			E = fd->glyph_map.insert(p_glyph, FontGlyph());
 			r_glyph = E->value;
@@ -1303,21 +1303,21 @@ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i
 		if (!p_font_data->msdf) {
 			if ((p_font_data->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (p_font_data->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && p_size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
 				FT_Pos xshift = (int)((p_glyph >> 27) & 3) << 4;
-				FT_Outline_Translate(&fd->face->glyph->outline, xshift, 0);
+				FT_Outline_Translate(&p_font_data->face->glyph->outline, xshift, 0);
 			} else if ((p_font_data->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (p_font_data->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && p_size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
 				FT_Pos xshift = (int)((p_glyph >> 27) & 3) << 5;
-				FT_Outline_Translate(&fd->face->glyph->outline, xshift, 0);
+				FT_Outline_Translate(&p_font_data->face->glyph->outline, xshift, 0);
 			}
 		}
 
 		if (p_font_data->embolden != 0.f) {
 			FT_Pos strength = p_font_data->embolden * p_size.x / 16; // 26.6 fractional units (1 / 64).
-			FT_Outline_Embolden(&fd->face->glyph->outline, strength);
+			FT_Outline_Embolden(&p_font_data->face->glyph->outline, strength);
 		}
 
 		if (p_font_data->transform != Transform2D()) {
 			FT_Matrix mat = { FT_Fixed(p_font_data->transform[0][0] * 65536), FT_Fixed(p_font_data->transform[0][1] * 65536), FT_Fixed(p_font_data->transform[1][0] * 65536), FT_Fixed(p_font_data->transform[1][1] * 65536) }; // 16.16 fractional units (1 / 65536).
-			FT_Outline_Transform(&fd->face->glyph->outline, &mat);
+			FT_Outline_Transform(&p_font_data->face->glyph->outline, &mat);
 		}
 
 		FT_Render_Mode aa_mode = FT_RENDER_MODE_NORMAL;
@@ -1355,7 +1355,7 @@ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i
 			} break;
 		}
 
-		FT_GlyphSlot slot = fd->face->glyph;
+		FT_GlyphSlot slot = p_font_data->face->glyph;
 		bool from_svg = (slot->format == FT_GLYPH_FORMAT_SVG); // Need to check before FT_Render_Glyph as it will change format to bitmap.
 		if (!outline) {
 			if (!p_font_data->msdf) {
@@ -1384,7 +1384,7 @@ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i
 			FT_Glyph glyph;
 			FT_BitmapGlyph glyph_bitmap;
 
-			if (FT_Get_Glyph(fd->face->glyph, &glyph) != 0) {
+			if (FT_Get_Glyph(p_font_data->face->glyph, &glyph) != 0) {
 				goto cleanup_stroker;
 			}
 			if (FT_Glyph_Stroke(&glyph, stroker, 1) != 0) {
@@ -1417,6 +1417,11 @@ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const
 
 	HashMap<Vector2i, FontForSizeAdvanced *>::Iterator E = p_font_data->cache.find(p_size);
 	if (E) {
+#ifdef MODULE_FREETYPE_ENABLED
+		if (E->value->fsize != nullptr) {
+			FT_Activate_Size(E->value->fsize);
+		}
+#endif
 		r_cache_for_size = E->value;
 		// Size used directly, remove from oversampling list.
 		if (p_oversampling == 0 && E->value->viewport_oversampling != 0) {
@@ -1451,31 +1456,36 @@ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const
 #endif
 			}
 
-			memset(&fd->stream, 0, sizeof(FT_StreamRec));
-			fd->stream.base = (unsigned char *)p_font_data->data_ptr;
-			fd->stream.size = p_font_data->data_size;
-			fd->stream.pos = 0;
+			if (p_font_data->face == nullptr) {
+				memset(&p_font_data->stream, 0, sizeof(FT_StreamRec));
+				p_font_data->stream.base = (unsigned char *)p_font_data->data_ptr;
+				p_font_data->stream.size = p_font_data->data_size;
+				p_font_data->stream.pos = 0;
 
-			FT_Open_Args fargs;
-			memset(&fargs, 0, sizeof(FT_Open_Args));
-			fargs.memory_base = (unsigned char *)p_font_data->data_ptr;
-			fargs.memory_size = p_font_data->data_size;
-			fargs.flags = FT_OPEN_MEMORY;
-			fargs.stream = &fd->stream;
+				FT_Open_Args fargs;
+				memset(&fargs, 0, sizeof(FT_Open_Args));
+				fargs.memory_base = (unsigned char *)p_font_data->data_ptr;
+				fargs.memory_size = p_font_data->data_size;
+				fargs.flags = FT_OPEN_MEMORY;
+				fargs.stream = &p_font_data->stream;
 
-			error = FT_Open_Face(ft_library, &fargs, p_font_data->face_index, &fd->face);
-			if (error) {
-				if (fd->face) {
-					FT_Done_Face(fd->face);
-					fd->face = nullptr;
-				}
-				memdelete(fd);
-				if (p_silent) {
-					return false;
-				} else {
-					ERR_FAIL_V_MSG(false, "FreeType: Error loading font: '" + String(FT_Error_String(error)) + "' (face_index=" + String::num_int64(p_font_data->face_index) + ").");
+				error = FT_Open_Face(ft_library, &fargs, p_font_data->face_index, &p_font_data->face);
+				if (error) {
+					if (p_font_data->face) {
+						FT_Done_Face(p_font_data->face);
+						p_font_data->face = nullptr;
+					}
+					memdelete(fd);
+					if (p_silent) {
+						return false;
+					} else {
+						ERR_FAIL_V_MSG(false, "FreeType: Error loading font: '" + String(FT_Error_String(error)) + "' (face_index=" + String::num_int64(p_font_data->face_index) + ").");
+					}
 				}
 			}
+
+			FT_New_Size(p_font_data->face, &fd->fsize);
+			FT_Activate_Size(fd->fsize);
 		}
 
 		double sz = double(fd->size.x) / 64.0;
@@ -1483,19 +1493,19 @@ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const
 			sz = p_font_data->msdf_source_size;
 		}
 
-		if (FT_HAS_COLOR(fd->face) && fd->face->num_fixed_sizes > 0) {
+		if (FT_HAS_COLOR(p_font_data->face) && p_font_data->face->num_fixed_sizes > 0) {
 			int best_match = 0;
-			int diff = Math::abs(sz - ((int64_t)fd->face->available_sizes[0].width));
-			fd->scale = sz / fd->face->available_sizes[0].width;
-			for (int i = 1; i < fd->face->num_fixed_sizes; i++) {
-				int ndiff = Math::abs(sz - ((int64_t)fd->face->available_sizes[i].width));
+			int diff = Math::abs(sz - ((int64_t)p_font_data->face->available_sizes[0].width));
+			fd->scale = sz / p_font_data->face->available_sizes[0].width;
+			for (int i = 1; i < p_font_data->face->num_fixed_sizes; i++) {
+				int ndiff = Math::abs(sz - ((int64_t)p_font_data->face->available_sizes[i].width));
 				if (ndiff < diff) {
 					best_match = i;
 					diff = ndiff;
-					fd->scale = sz / fd->face->available_sizes[i].width;
+					fd->scale = sz / p_font_data->face->available_sizes[i].width;
 				}
 			}
-			FT_Select_Size(fd->face, best_match);
+			FT_Select_Size(p_font_data->face, best_match);
 		} else {
 			FT_Size_RequestRec req;
 			req.type = FT_SIZE_REQUEST_TYPE_NOMINAL;
@@ -1504,18 +1514,18 @@ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const
 			req.horiResolution = 0;
 			req.vertResolution = 0;
 
-			FT_Request_Size(fd->face, &req);
-			if (fd->face->size->metrics.y_ppem != 0) {
-				fd->scale = sz / (double)fd->face->size->metrics.y_ppem;
+			FT_Request_Size(p_font_data->face, &req);
+			if (p_font_data->face->size->metrics.y_ppem != 0) {
+				fd->scale = sz / (double)p_font_data->face->size->metrics.y_ppem;
 			}
 		}
 
-		fd->hb_handle = hb_ft_font_create(fd->face, nullptr);
+		fd->hb_handle = hb_ft_font_create(p_font_data->face, nullptr);
 
-		fd->ascent = (fd->face->size->metrics.ascender / 64.0) * fd->scale;
-		fd->descent = (-fd->face->size->metrics.descender / 64.0) * fd->scale;
-		fd->underline_position = (-FT_MulFix(fd->face->underline_position, fd->face->size->metrics.y_scale) / 64.0) * fd->scale;
-		fd->underline_thickness = (FT_MulFix(fd->face->underline_thickness, fd->face->size->metrics.y_scale) / 64.0) * fd->scale;
+		fd->ascent = (p_font_data->face->size->metrics.ascender / 64.0) * fd->scale;
+		fd->descent = (-p_font_data->face->size->metrics.descender / 64.0) * fd->scale;
+		fd->underline_position = (-FT_MulFix(p_font_data->face->underline_position, p_font_data->face->size->metrics.y_scale) / 64.0) * fd->scale;
+		fd->underline_thickness = (FT_MulFix(p_font_data->face->underline_thickness, p_font_data->face->size->metrics.y_scale) / 64.0) * fd->scale;
 
 #if HB_VERSION_ATLEAST(3, 3, 0)
 		hb_font_set_synthetic_slant(fd->hb_handle, p_font_data->transform[0][1]);
@@ -1544,22 +1554,22 @@ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const
 				p_font_data->font_name.resize_uninitialized(text_size);
 				hb_ot_name_get_utf32(hb_face, names[i].name_id, names[i].language, &text_size, (uint32_t *)p_font_data->font_name.ptrw());
 			}
-			if (p_font_data->font_name.is_empty() && fd->face->family_name != nullptr) {
-				p_font_data->font_name = String::utf8((const char *)fd->face->family_name);
+			if (p_font_data->font_name.is_empty() && p_font_data->face->family_name != nullptr) {
+				p_font_data->font_name = String::utf8((const char *)p_font_data->face->family_name);
 			}
-			if (fd->face->style_name != nullptr) {
-				p_font_data->style_name = String::utf8((const char *)fd->face->style_name);
+			if (p_font_data->face->style_name != nullptr) {
+				p_font_data->style_name = String::utf8((const char *)p_font_data->face->style_name);
 			}
 			p_font_data->weight = _font_get_weight_by_name(p_font_data->style_name.to_lower());
 			p_font_data->stretch = _font_get_stretch_by_name(p_font_data->style_name.to_lower());
 			p_font_data->style_flags = 0;
-			if ((fd->face->style_flags & FT_STYLE_FLAG_BOLD) || p_font_data->weight >= 700) {
+			if ((p_font_data->face->style_flags & FT_STYLE_FLAG_BOLD) || p_font_data->weight >= 700) {
 				p_font_data->style_flags.set_flag(FONT_BOLD);
 			}
-			if ((fd->face->style_flags & FT_STYLE_FLAG_ITALIC) || _is_ital_style(p_font_data->style_name.to_lower())) {
+			if ((p_font_data->face->style_flags & FT_STYLE_FLAG_ITALIC) || _is_ital_style(p_font_data->style_name.to_lower())) {
 				p_font_data->style_flags.set_flag(FONT_ITALIC);
 			}
-			if (fd->face->face_flags & FT_FACE_FLAG_FIXED_WIDTH) {
+			if (p_font_data->face->face_flags & FT_FACE_FLAG_FIXED_WIDTH) {
 				p_font_data->style_flags.set_flag(FONT_FIXED_WIDTH);
 			}
 
@@ -1585,7 +1595,7 @@ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const
 			}
 
 			// Get supported scripts from OS2 table.
-			TT_OS2 *os2 = (TT_OS2 *)FT_Get_Sfnt_Table(fd->face, FT_SFNT_OS2);
+			TT_OS2 *os2 = (TT_OS2 *)FT_Get_Sfnt_Table(p_font_data->face, FT_SFNT_OS2);
 			if (os2) {
 				if ((os2->ulUnicodeRange1 & 1L << 4) || (os2->ulUnicodeRange1 & 1L << 5) || (os2->ulUnicodeRange1 & 1L << 6) || (os2->ulUnicodeRange1 & 1L << 31) || (os2->ulUnicodeRange2 & 1L << 0) || (os2->ulUnicodeRange2 & 1L << 1) || (os2->ulUnicodeRange2 & 1L << 2) || (os2->ulUnicodeRange2 & 1L << 3) || (os2->ulUnicodeRange2 & 1L << 4) || (os2->ulUnicodeRange2 & 1L << 5) || (os2->ulUnicodeRange2 & 1L << 6) || (os2->ulUnicodeRange2 & 1L << 7) || (os2->ulUnicodeRange2 & 1L << 8) || (os2->ulUnicodeRange2 & 1L << 9) || (os2->ulUnicodeRange2 & 1L << 10) || (os2->ulUnicodeRange2 & 1L << 11) || (os2->ulUnicodeRange2 & 1L << 12) || (os2->ulUnicodeRange2 & 1L << 13) || (os2->ulUnicodeRange2 & 1L << 14) || (os2->ulUnicodeRange2 & 1L << 15) || (os2->ulUnicodeRange2 & 1L << 30) || (os2->ulUnicodeRange3 & 1L << 0) || (os2->ulUnicodeRange3 & 1L << 1) || (os2->ulUnicodeRange3 & 1L << 2) || (os2->ulUnicodeRange3 & 1L << 4) || (os2->ulUnicodeRange3 & 1L << 5) || (os2->ulUnicodeRange3 & 1L << 18) || (os2->ulUnicodeRange3 & 1L << 24) || (os2->ulUnicodeRange3 & 1L << 25) || (os2->ulUnicodeRange3 & 1L << 26) || (os2->ulUnicodeRange3 & 1L << 27) || (os2->ulUnicodeRange3 & 1L << 28) || (os2->ulUnicodeRange4 & 1L << 3) || (os2->ulUnicodeRange4 & 1L << 6) || (os2->ulUnicodeRange4 & 1L << 15) || (os2->ulUnicodeRange4 & 1L << 23) || (os2->ulUnicodeRange4 & 1L << 24) || (os2->ulUnicodeRange4 & 1L << 26)) {
 					p_font_data->supported_scripts.insert(HB_SCRIPT_COMMON);
@@ -1814,7 +1824,7 @@ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const
 					if (U_SUCCESS(icu_err) && len > 0) {
 						String sample = String::utf16(sample_buf.ptr(), len);
 						for (int ch = 0; ch < sample.length(); ch++) {
-							if (FT_Get_Char_Index(fd->face, sample[ch]) == 0) {
+							if (FT_Get_Char_Index(p_font_data->face, sample[ch]) == 0) {
 								failed_scripts.push_back(scr_tag);
 								break;
 							}
@@ -1889,9 +1899,9 @@ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const
 
 			// Read OpenType variations.
 			p_font_data->supported_varaitions.clear();
-			if (fd->face->face_flags & FT_FACE_FLAG_MULTIPLE_MASTERS) {
+			if (p_font_data->face->face_flags & FT_FACE_FLAG_MULTIPLE_MASTERS) {
 				FT_MM_Var *amaster;
-				FT_Get_MM_Var(fd->face, &amaster);
+				FT_Get_MM_Var(p_font_data->face, &amaster);
 				for (FT_UInt i = 0; i < amaster->num_axis; i++) {
 					p_font_data->supported_varaitions[(int32_t)amaster->axis[i].tag] = Vector3i(amaster->axis[i].minimum / 65536, amaster->axis[i].maximum / 65536, amaster->axis[i].def / 65536);
 				}
@@ -1904,8 +1914,8 @@ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const
 		if (p_font_data->font_name == ".Apple Color Emoji UI" || p_font_data->font_name == "Apple Color Emoji") {
 			// The baseline offset is missing from the Apple Color Emoji UI font data, so add it manually.
 			// This issue doesn't occur with other system emoji fonts.
-			if (!FT_Load_Glyph(fd->face, FT_Get_Char_Index(fd->face, 0x1F92E), FT_LOAD_DEFAULT | FT_LOAD_COLOR)) {
-				if (fd->face->glyph->metrics.horiBearingY == fd->face->glyph->metrics.height) {
+			if (!FT_Load_Glyph(p_font_data->face, FT_Get_Char_Index(p_font_data->face, 0x1F92E), FT_LOAD_DEFAULT | FT_LOAD_COLOR)) {
+				if (p_font_data->face->glyph->metrics.horiBearingY == p_font_data->face->glyph->metrics.height) {
 					p_font_data->baseline_offset = 0.15;
 				}
 			}
@@ -1913,16 +1923,16 @@ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const
 #endif
 
 		// Write variations.
-		if (fd->face->face_flags & FT_FACE_FLAG_MULTIPLE_MASTERS) {
+		if (p_font_data->face->face_flags & FT_FACE_FLAG_MULTIPLE_MASTERS) {
 			FT_MM_Var *amaster;
 
-			FT_Get_MM_Var(fd->face, &amaster);
+			FT_Get_MM_Var(p_font_data->face, &amaster);
 
 			Vector<hb_variation_t> hb_vars;
 			Vector<FT_Fixed> coords;
 			coords.resize(amaster->num_axis);
 
-			FT_Get_Var_Design_Coordinates(fd->face, coords.size(), coords.ptrw());
+			FT_Get_Var_Design_Coordinates(p_font_data->face, coords.size(), coords.ptrw());
 
 			for (FT_UInt i = 0; i < amaster->num_axis; i++) {
 				hb_variation_t var;
@@ -1945,7 +1955,7 @@ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const
 				hb_vars.push_back(var);
 			}
 
-			FT_Set_Var_Design_Coordinates(fd->face, coords.size(), coords.ptrw());
+			FT_Set_Var_Design_Coordinates(p_font_data->face, coords.size(), coords.ptrw());
 			hb_font_set_variations(fd->hb_handle, hb_vars.is_empty() ? nullptr : &hb_vars[0], hb_vars.size());
 			FT_Done_MM_Var(ft_library, amaster);
 		}
@@ -2047,7 +2057,7 @@ bool TextServerAdvanced::_font_is_color(const RID &p_font_rid) const {
 	FontForSizeAdvanced *ffsd = nullptr;
 	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), false);
 #ifdef MODULE_FREETYPE_ENABLED
-	return ffsd->face && FT_HAS_COLOR(ffsd->face);
+	return fd->face && FT_HAS_COLOR(fd->face);
 #else
 	return false;
 #endif
@@ -2063,7 +2073,7 @@ hb_font_t *TextServerAdvanced::_font_get_hb_handle(const RID &p_font_rid, int64_
 	FontForSizeAdvanced *ffsd = nullptr;
 	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), nullptr);
 #ifdef MODULE_FREETYPE_ENABLED
-	r_is_color = ffsd->face && FT_HAS_COLOR(ffsd->face);
+	r_is_color = fd->face && FT_HAS_COLOR(fd->face);
 #else
 	r_is_color = false;
 #endif
@@ -3030,7 +3040,7 @@ void TextServerAdvanced::_font_set_scale(const RID &p_font_rid, int64_t p_size, 
 	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 
 #ifdef MODULE_FREETYPE_ENABLED
-	if (ffsd->face) {
+	if (fd->face) {
 		return; // Do not override scale for dynamic fonts, it's calculated automatically.
 	}
 #endif
@@ -3610,17 +3620,17 @@ Dictionary TextServerAdvanced::_font_get_glyph_contours(const RID &p_font_rid, i
 
 	int32_t index = p_index & 0xffffff; // Remove subpixel shifts.
 
-	int error = FT_Load_Glyph(ffsd->face, index, FT_LOAD_NO_BITMAP | (fd->force_autohinter ? FT_LOAD_FORCE_AUTOHINT : 0));
+	int error = FT_Load_Glyph(fd->face, index, FT_LOAD_NO_BITMAP | (fd->force_autohinter ? FT_LOAD_FORCE_AUTOHINT : 0));
 	ERR_FAIL_COND_V(error, Dictionary());
 
 	if (fd->embolden != 0.f) {
 		FT_Pos strength = fd->embolden * size.x / 16; // 26.6 fractional units (1 / 64).
-		FT_Outline_Embolden(&ffsd->face->glyph->outline, strength);
+		FT_Outline_Embolden(&fd->face->glyph->outline, strength);
 	}
 
 	if (fd->transform != Transform2D()) {
 		FT_Matrix mat = { FT_Fixed(fd->transform[0][0] * 65536), FT_Fixed(fd->transform[0][1] * 65536), FT_Fixed(fd->transform[1][0] * 65536), FT_Fixed(fd->transform[1][1] * 65536) }; // 16.16 fractional units (1 / 65536).
-		FT_Outline_Transform(&ffsd->face->glyph->outline, &mat);
+		FT_Outline_Transform(&fd->face->glyph->outline, &mat);
 	}
 
 	double scale = (1.0 / 64.0) * ffsd->scale;
@@ -3633,13 +3643,13 @@ Dictionary TextServerAdvanced::_font_get_glyph_contours(const RID &p_font_rid, i
 			scale = scale * Math::round((double)p_size / (double)fd->fixed_size);
 		}
 	}
-	for (short i = 0; i < ffsd->face->glyph->outline.n_points; i++) {
-		points.push_back(Vector3(ffsd->face->glyph->outline.points[i].x * scale, -ffsd->face->glyph->outline.points[i].y * scale, FT_CURVE_TAG(ffsd->face->glyph->outline.tags[i])));
+	for (short i = 0; i < fd->face->glyph->outline.n_points; i++) {
+		points.push_back(Vector3(fd->face->glyph->outline.points[i].x * scale, -fd->face->glyph->outline.points[i].y * scale, FT_CURVE_TAG(fd->face->glyph->outline.tags[i])));
 	}
-	for (short i = 0; i < ffsd->face->glyph->outline.n_contours; i++) {
-		contours.push_back(ffsd->face->glyph->outline.contours[i]);
+	for (short i = 0; i < fd->face->glyph->outline.n_contours; i++) {
+		contours.push_back(fd->face->glyph->outline.contours[i]);
 	}
-	bool orientation = (FT_Outline_Get_Orientation(&ffsd->face->glyph->outline) == FT_ORIENTATION_FILL_RIGHT);
+	bool orientation = (FT_Outline_Get_Orientation(&fd->face->glyph->outline) == FT_ORIENTATION_FILL_RIGHT);
 
 	Dictionary out;
 	out["points"] = points;
@@ -3730,9 +3740,9 @@ Vector2 TextServerAdvanced::_font_get_kerning(const RID &p_font_rid, int64_t p_s
 		}
 	} else {
 #ifdef MODULE_FREETYPE_ENABLED
-		if (ffsd->face) {
+		if (fd->face) {
 			FT_Vector delta;
-			FT_Get_Kerning(ffsd->face, p_glyph_pair.x, p_glyph_pair.y, FT_KERNING_DEFAULT, &delta);
+			FT_Get_Kerning(fd->face, p_glyph_pair.x, p_glyph_pair.y, FT_KERNING_DEFAULT, &delta);
 			if (fd->msdf) {
 				return Vector2(delta.x, delta.y) * (double)p_size / (double)fd->msdf_source_size;
 			} else if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size * 64) {
@@ -3762,11 +3772,11 @@ int64_t TextServerAdvanced::_font_get_glyph_index(const RID &p_font_rid, int64_t
 	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), 0);
 
 #ifdef MODULE_FREETYPE_ENABLED
-	if (ffsd->face) {
+	if (fd->face) {
 		if (p_variation_selector) {
-			return FT_Face_GetCharVariantIndex(ffsd->face, p_char, p_variation_selector);
+			return FT_Face_GetCharVariantIndex(fd->face, p_char, p_variation_selector);
 		} else {
-			return FT_Get_Char_Index(ffsd->face, p_char);
+			return FT_Get_Char_Index(fd->face, p_char);
 		}
 	} else {
 		return (int64_t)p_char;
@@ -3787,7 +3797,7 @@ int64_t TextServerAdvanced::_font_get_char_from_glyph_index(const RID &p_font_ri
 
 #ifdef MODULE_FREETYPE_ENABLED
 	if (ffsd->inv_glyph_map.is_empty()) {
-		FT_Face face = ffsd->face;
+		FT_Face face = fd->face;
 		FT_UInt gindex;
 		FT_ULong charcode = FT_Get_First_Char(face, &gindex);
 		while (gindex != 0) {
@@ -3824,8 +3834,8 @@ bool TextServerAdvanced::_font_has_char(const RID &p_font_rid, int64_t p_char) c
 	}
 
 #ifdef MODULE_FREETYPE_ENABLED
-	if (ffsd->face) {
-		return FT_Get_Char_Index(ffsd->face, p_char) != 0;
+	if (fd->face) {
+		return FT_Get_Char_Index(fd->face, p_char) != 0;
 	}
 #endif
 	return ffsd->glyph_map.has((int32_t)p_char);
@@ -3845,14 +3855,14 @@ String TextServerAdvanced::_font_get_supported_chars(const RID &p_font_rid) cons
 
 	String chars;
 #ifdef MODULE_FREETYPE_ENABLED
-	if (ffsd->face) {
+	if (fd->face) {
 		FT_UInt gindex;
-		FT_ULong charcode = FT_Get_First_Char(ffsd->face, &gindex);
+		FT_ULong charcode = FT_Get_First_Char(fd->face, &gindex);
 		while (gindex != 0) {
 			if (charcode != 0) {
 				chars = chars + String::chr(charcode);
 			}
-			charcode = FT_Get_Next_Char(ffsd->face, charcode, &gindex);
+			charcode = FT_Get_Next_Char(fd->face, charcode, &gindex);
 		}
 		return chars;
 	}
@@ -3878,12 +3888,12 @@ PackedInt32Array TextServerAdvanced::_font_get_supported_glyphs(const RID &p_fon
 
 	PackedInt32Array glyphs;
 #ifdef MODULE_FREETYPE_ENABLED
-	if (at_size && at_size->face) {
+	if (fd->face) {
 		FT_UInt gindex;
-		FT_ULong charcode = FT_Get_First_Char(at_size->face, &gindex);
+		FT_ULong charcode = FT_Get_First_Char(fd->face, &gindex);
 		while (gindex != 0) {
 			glyphs.push_back(gindex);
-			charcode = FT_Get_Next_Char(at_size->face, charcode, &gindex);
+			charcode = FT_Get_Next_Char(fd->face, charcode, &gindex);
 		}
 		return glyphs;
 	}
@@ -3909,8 +3919,8 @@ void TextServerAdvanced::_font_render_range(const RID &p_font_rid, const Vector2
 	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 	for (int64_t i = p_start; i <= p_end; i++) {
 #ifdef MODULE_FREETYPE_ENABLED
-		int32_t idx = FT_Get_Char_Index(ffsd->face, i);
-		if (ffsd->face) {
+		int32_t idx = FT_Get_Char_Index(fd->face, i);
+		if (fd->face) {
 			FontGlyph fgl;
 			if (fd->msdf) {
 				_ensure_glyph(fd, size, (int32_t)idx, fgl);
@@ -3944,7 +3954,7 @@ void TextServerAdvanced::_font_render_glyph(const RID &p_font_rid, const Vector2
 	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 #ifdef MODULE_FREETYPE_ENABLED
 	int32_t idx = p_index & 0xffffff; // Remove subpixel shifts.
-	if (ffsd->face) {
+	if (fd->face) {
 		FontGlyph fgl;
 		if (fd->msdf) {
 			_ensure_glyph(fd, size, (int32_t)idx, fgl);
@@ -4011,7 +4021,7 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 	bool lcd_aa = false;
 
 #ifdef MODULE_FREETYPE_ENABLED
-	if (!fd->msdf && ffsd->face) {
+	if (!fd->msdf && fd->face) {
 		// LCD layout, bits 24, 25, 26
 		if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
 			TextServer::FontLCDSubpixelLayout layout = lcd_subpixel_layout.get();
@@ -4042,7 +4052,7 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 		if (fgl.texture_idx != -1) {
 			Color modulate = p_color;
 #ifdef MODULE_FREETYPE_ENABLED
-			if (!fd->modulate_color_glyphs && ffsd->face && ffsd->textures[fgl.texture_idx].image.is_valid() && (ffsd->textures[fgl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
+			if (!fd->modulate_color_glyphs && fd->face && ffsd->textures[fgl.texture_idx].image.is_valid() && (ffsd->textures[fgl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
 				modulate.r = modulate.g = modulate.b = 1.0;
 			}
 #endif
@@ -4157,7 +4167,7 @@ void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const R
 	bool lcd_aa = false;
 
 #ifdef MODULE_FREETYPE_ENABLED
-	if (!fd->msdf && ffsd->face) {
+	if (!fd->msdf && fd->face) {
 		// LCD layout, bits 24, 25, 26
 		if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
 			TextServer::FontLCDSubpixelLayout layout = lcd_subpixel_layout.get();
@@ -4188,7 +4198,7 @@ void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const R
 		if (fgl.texture_idx != -1) {
 			Color modulate = p_color;
 #ifdef MODULE_FREETYPE_ENABLED
-			if (ffsd->face && fd->cache[size]->textures[fgl.texture_idx].image.is_valid() && (ffsd->textures[fgl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
+			if (fd->face && fd->cache[size]->textures[fgl.texture_idx].image.is_valid() && (ffsd->textures[fgl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
 				modulate.r = modulate.g = modulate.b = 1.0;
 			}
 #endif
@@ -5874,7 +5884,7 @@ RID TextServerAdvanced::_find_sys_font_for_text(const RID &p_fdef, const String 
 					Vector2i size = _get_size(fd, 16);
 					FontForSizeAdvanced *ffsd = nullptr;
 					if (_ensure_cache_for_size(fd, size, ffsd)) {
-						if (ffsd && (FT_HAS_COLOR(ffsd->face) || !FT_IS_SCALABLE(ffsd->face))) {
+						if (ffsd && (FT_HAS_COLOR(fd->face) || !FT_IS_SCALABLE(fd->face))) {
 							fb_use_msdf = false;
 						}
 					}

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -125,6 +125,7 @@ GODOT_CLANG_WARNING_POP
 #include FT_ADVANCES_H
 #include FT_MULTIPLE_MASTERS_H
 #include FT_BBOX_H
+#include FT_SIZES_H
 #include FT_MODULE_H
 #include FT_CONFIG_OPTIONS_H
 #if !defined(FT_CONFIG_OPTION_USE_BROTLI) && !defined(_MSC_VER)
@@ -296,8 +297,7 @@ class TextServerAdvanced : public TextServerExtension {
 		hb_font_t *hb_handle = nullptr;
 
 #ifdef MODULE_FREETYPE_ENABLED
-		FT_Face face = nullptr;
-		FT_StreamRec stream;
+		FT_Size fsize = nullptr;
 #endif
 
 		~FontForSizeAdvanced() {
@@ -305,8 +305,8 @@ class TextServerAdvanced : public TextServerExtension {
 				hb_font_destroy(hb_handle);
 			}
 #ifdef MODULE_FREETYPE_ENABLED
-			if (face != nullptr) {
-				FT_Done_Face(face);
+			if (fsize != nullptr) {
+				FT_Done_Size(fsize);
 			}
 #endif
 		}
@@ -372,11 +372,21 @@ class TextServerAdvanced : public TextServerExtension {
 		size_t data_size;
 		int face_index = 0;
 
+#ifdef MODULE_FREETYPE_ENABLED
+		FT_Face face = nullptr;
+		FT_StreamRec stream;
+#endif
+
 		~FontAdvanced() {
 			for (const KeyValue<Vector2i, FontForSizeAdvanced *> &E : cache) {
 				memdelete(E.value);
 			}
 			cache.clear();
+#ifdef MODULE_FREETYPE_ENABLED
+			if (face != nullptr) {
+				FT_Done_Face(face);
+			}
+#endif
 		}
 	};
 

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -681,7 +681,7 @@ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data, const Vector2i
 
 #ifdef MODULE_FREETYPE_ENABLED
 	FontGlyph gl;
-	if (fd->face) {
+	if (p_font_data->face) {
 		FT_Int32 flags = FT_LOAD_DEFAULT;
 
 		bool outline = p_size.y > 0;
@@ -699,19 +699,19 @@ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data, const Vector2i
 		if (p_font_data->force_autohinter) {
 			flags |= FT_LOAD_FORCE_AUTOHINT;
 		}
-		if (outline || (p_font_data->disable_embedded_bitmaps && !FT_HAS_COLOR(fd->face))) {
+		if (outline || (p_font_data->disable_embedded_bitmaps && !FT_HAS_COLOR(p_font_data->face))) {
 			flags |= FT_LOAD_NO_BITMAP;
-		} else if (FT_HAS_COLOR(fd->face)) {
+		} else if (FT_HAS_COLOR(p_font_data->face)) {
 			flags |= FT_LOAD_COLOR;
 		}
 
-		glyph_index = FT_Get_Char_Index(fd->face, glyph_index);
+		glyph_index = FT_Get_Char_Index(p_font_data->face, glyph_index);
 
 		FT_Fixed v, h;
-		FT_Get_Advance(fd->face, glyph_index, flags, &h);
-		FT_Get_Advance(fd->face, glyph_index, flags | FT_LOAD_VERTICAL_LAYOUT, &v);
+		FT_Get_Advance(p_font_data->face, glyph_index, flags, &h);
+		FT_Get_Advance(p_font_data->face, glyph_index, flags | FT_LOAD_VERTICAL_LAYOUT, &v);
 
-		int error = FT_Load_Glyph(fd->face, glyph_index, flags);
+		int error = FT_Load_Glyph(p_font_data->face, glyph_index, flags);
 		if (error) {
 			E = fd->glyph_map.insert(p_glyph, FontGlyph());
 			r_glyph = E->value;
@@ -721,21 +721,21 @@ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data, const Vector2i
 		if (!p_font_data->msdf) {
 			if ((p_font_data->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (p_font_data->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && p_size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
 				FT_Pos xshift = (int)((p_glyph >> 27) & 3) << 4;
-				FT_Outline_Translate(&fd->face->glyph->outline, xshift, 0);
+				FT_Outline_Translate(&p_font_data->face->glyph->outline, xshift, 0);
 			} else if ((p_font_data->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (p_font_data->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && p_size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
 				FT_Pos xshift = (int)((p_glyph >> 27) & 3) << 5;
-				FT_Outline_Translate(&fd->face->glyph->outline, xshift, 0);
+				FT_Outline_Translate(&p_font_data->face->glyph->outline, xshift, 0);
 			}
 		}
 
 		if (p_font_data->embolden != 0.f) {
 			FT_Pos strength = p_font_data->embolden * p_size.x / 16; // 26.6 fractional units (1 / 64).
-			FT_Outline_Embolden(&fd->face->glyph->outline, strength);
+			FT_Outline_Embolden(&p_font_data->face->glyph->outline, strength);
 		}
 
 		if (p_font_data->transform != Transform2D()) {
 			FT_Matrix mat = { FT_Fixed(p_font_data->transform[0][0] * 65536), FT_Fixed(p_font_data->transform[0][1] * 65536), FT_Fixed(p_font_data->transform[1][0] * 65536), FT_Fixed(p_font_data->transform[1][1] * 65536) }; // 16.16 fractional units (1 / 65536).
-			FT_Outline_Transform(&fd->face->glyph->outline, &mat);
+			FT_Outline_Transform(&p_font_data->face->glyph->outline, &mat);
 		}
 
 		FT_Render_Mode aa_mode = FT_RENDER_MODE_NORMAL;
@@ -773,7 +773,7 @@ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data, const Vector2i
 			} break;
 		}
 
-		FT_GlyphSlot slot = fd->face->glyph;
+		FT_GlyphSlot slot = p_font_data->face->glyph;
 		bool from_svg = (slot->format == FT_GLYPH_FORMAT_SVG); // Need to check before FT_Render_Glyph as it will change format to bitmap.
 		if (!outline) {
 			if (!p_font_data->msdf) {
@@ -802,7 +802,7 @@ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data, const Vector2i
 			FT_Glyph glyph;
 			FT_BitmapGlyph glyph_bitmap;
 
-			if (FT_Get_Glyph(fd->face->glyph, &glyph) != 0) {
+			if (FT_Get_Glyph(p_font_data->face->glyph, &glyph) != 0) {
 				goto cleanup_stroker;
 			}
 			if (FT_Glyph_Stroke(&glyph, stroker, 1) != 0) {
@@ -835,6 +835,11 @@ bool TextServerFallback::_ensure_cache_for_size(FontFallback *p_font_data, const
 
 	HashMap<Vector2i, FontForSizeFallback *>::Iterator E = p_font_data->cache.find(p_size);
 	if (E) {
+#ifdef MODULE_FREETYPE_ENABLED
+		if (E->value->fsize != nullptr) {
+			FT_Activate_Size(E->value->fsize);
+		}
+#endif
 		r_cache_for_size = E->value;
 		// Size used directly, remove from oversampling list.
 		if (p_oversampling == 0 && E->value->viewport_oversampling != 0) {
@@ -870,39 +875,44 @@ bool TextServerFallback::_ensure_cache_for_size(FontFallback *p_font_data, const
 #endif
 			}
 
-			memset(&fd->stream, 0, sizeof(FT_StreamRec));
-			fd->stream.base = (unsigned char *)p_font_data->data_ptr;
-			fd->stream.size = p_font_data->data_size;
-			fd->stream.pos = 0;
+			if (p_font_data->face == nullptr) {
+				memset(&p_font_data->stream, 0, sizeof(FT_StreamRec));
+				p_font_data->stream.base = (unsigned char *)p_font_data->data_ptr;
+				p_font_data->stream.size = p_font_data->data_size;
+				p_font_data->stream.pos = 0;
 
-			FT_Open_Args fargs;
-			memset(&fargs, 0, sizeof(FT_Open_Args));
-			fargs.memory_base = (unsigned char *)p_font_data->data_ptr;
-			fargs.memory_size = p_font_data->data_size;
-			fargs.flags = FT_OPEN_MEMORY;
-			fargs.stream = &fd->stream;
+				FT_Open_Args fargs;
+				memset(&fargs, 0, sizeof(FT_Open_Args));
+				fargs.memory_base = (unsigned char *)p_font_data->data_ptr;
+				fargs.memory_size = p_font_data->data_size;
+				fargs.flags = FT_OPEN_MEMORY;
+				fargs.stream = &p_font_data->stream;
 
-			int max_index = 0;
-			FT_Face tmp_face = nullptr;
-			error = FT_Open_Face(ft_library, &fargs, -1, &tmp_face);
-			if (tmp_face && error == 0) {
-				max_index = tmp_face->num_faces - 1;
-			}
-			if (tmp_face) {
-				FT_Done_Face(tmp_face);
-			}
+				int max_index = 0;
+				FT_Face tmp_face = nullptr;
+				error = FT_Open_Face(ft_library, &fargs, -1, &tmp_face);
+				if (tmp_face && error == 0) {
+					max_index = tmp_face->num_faces - 1;
+				}
+				if (tmp_face) {
+					FT_Done_Face(tmp_face);
+				}
 
-			error = FT_Open_Face(ft_library, &fargs, CLAMP(p_font_data->face_index, 0, max_index), &fd->face);
-			if (error) {
-				FT_Done_Face(fd->face);
-				fd->face = nullptr;
-				memdelete(fd);
-				if (p_silent) {
-					return false;
-				} else {
-					ERR_FAIL_V_MSG(false, "FreeType: Error loading font: '" + String(FT_Error_String(error)) + "'.");
+				error = FT_Open_Face(ft_library, &fargs, CLAMP(p_font_data->face_index, 0, max_index), &p_font_data->face);
+				if (error) {
+					FT_Done_Face(p_font_data->face);
+					p_font_data->face = nullptr;
+					memdelete(fd);
+					if (p_silent) {
+						return false;
+					} else {
+						ERR_FAIL_V_MSG(false, "FreeType: Error loading font: '" + String(FT_Error_String(error)) + "'.");
+					}
 				}
 			}
+
+			FT_New_Size(p_font_data->face, &fd->fsize);
+			FT_Activate_Size(fd->fsize);
 		}
 
 		double sz = double(fd->size.x) / 64.0;
@@ -910,19 +920,19 @@ bool TextServerFallback::_ensure_cache_for_size(FontFallback *p_font_data, const
 			sz = p_font_data->msdf_source_size;
 		}
 
-		if (FT_HAS_COLOR(fd->face) && fd->face->num_fixed_sizes > 0) {
+		if (FT_HAS_COLOR(p_font_data->face) && p_font_data->face->num_fixed_sizes > 0) {
 			int best_match = 0;
-			int diff = Math::abs(sz - ((int64_t)fd->face->available_sizes[0].width));
-			fd->scale = sz / fd->face->available_sizes[0].width;
-			for (int i = 1; i < fd->face->num_fixed_sizes; i++) {
-				int ndiff = Math::abs(sz - ((int64_t)fd->face->available_sizes[i].width));
+			int diff = Math::abs(sz - ((int64_t)p_font_data->face->available_sizes[0].width));
+			fd->scale = sz / p_font_data->face->available_sizes[0].width;
+			for (int i = 1; i < p_font_data->face->num_fixed_sizes; i++) {
+				int ndiff = Math::abs(sz - ((int64_t)p_font_data->face->available_sizes[i].width));
 				if (ndiff < diff) {
 					best_match = i;
 					diff = ndiff;
-					fd->scale = sz / fd->face->available_sizes[i].width;
+					fd->scale = sz / p_font_data->face->available_sizes[i].width;
 				}
 			}
-			FT_Select_Size(fd->face, best_match);
+			FT_Select_Size(p_font_data->face, best_match);
 		} else {
 			FT_Size_RequestRec req;
 			req.type = FT_SIZE_REQUEST_TYPE_NOMINAL;
@@ -931,26 +941,26 @@ bool TextServerFallback::_ensure_cache_for_size(FontFallback *p_font_data, const
 			req.horiResolution = 0;
 			req.vertResolution = 0;
 
-			FT_Request_Size(fd->face, &req);
-			if (fd->face->size->metrics.y_ppem != 0) {
-				fd->scale = sz / (double)fd->face->size->metrics.y_ppem;
+			FT_Request_Size(p_font_data->face, &req);
+			if (p_font_data->face->size->metrics.y_ppem != 0) {
+				fd->scale = sz / (double)p_font_data->face->size->metrics.y_ppem;
 			}
 		}
 
-		fd->ascent = (fd->face->size->metrics.ascender / 64.0) * fd->scale;
-		fd->descent = (-fd->face->size->metrics.descender / 64.0) * fd->scale;
-		fd->underline_position = (-FT_MulFix(fd->face->underline_position, fd->face->size->metrics.y_scale) / 64.0) * fd->scale;
-		fd->underline_thickness = (FT_MulFix(fd->face->underline_thickness, fd->face->size->metrics.y_scale) / 64.0) * fd->scale;
+		fd->ascent = (p_font_data->face->size->metrics.ascender / 64.0) * fd->scale;
+		fd->descent = (-p_font_data->face->size->metrics.descender / 64.0) * fd->scale;
+		fd->underline_position = (-FT_MulFix(p_font_data->face->underline_position, p_font_data->face->size->metrics.y_scale) / 64.0) * fd->scale;
+		fd->underline_thickness = (FT_MulFix(p_font_data->face->underline_thickness, p_font_data->face->size->metrics.y_scale) / 64.0) * fd->scale;
 
 		if (!p_font_data->face_init) {
 			// When a font does not provide a `family_name`, FreeType tries to synthesize one based on other names.
 			// FreeType automatically converts non-ASCII characters to "?" in the synthesized name.
 			// To avoid that behavior, use the format-specific name directly if available.
-			if (FT_IS_SFNT(fd->face)) {
-				int name_count = FT_Get_Sfnt_Name_Count(fd->face);
+			if (FT_IS_SFNT(p_font_data->face)) {
+				int name_count = FT_Get_Sfnt_Name_Count(p_font_data->face);
 				for (int i = 0; i < name_count; i++) {
 					FT_SfntName sfnt_name;
-					if (FT_Get_Sfnt_Name(fd->face, i, &sfnt_name) != 0) {
+					if (FT_Get_Sfnt_Name(p_font_data->face, i, &sfnt_name) != 0) {
 						continue;
 					}
 					if (sfnt_name.name_id != TT_NAME_ID_FONT_FAMILY && sfnt_name.name_id != TT_NAME_ID_TYPOGRAPHIC_FAMILY) {
@@ -975,29 +985,29 @@ bool TextServerFallback::_ensure_cache_for_size(FontFallback *p_font_data, const
 					}
 				}
 			}
-			if (p_font_data->font_name.is_empty() && fd->face->family_name != nullptr) {
-				p_font_data->font_name = String::utf8((const char *)fd->face->family_name);
+			if (p_font_data->font_name.is_empty() && p_font_data->face->family_name != nullptr) {
+				p_font_data->font_name = String::utf8((const char *)p_font_data->face->family_name);
 			}
-			if (fd->face->style_name != nullptr) {
-				p_font_data->style_name = String::utf8((const char *)fd->face->style_name);
+			if (p_font_data->face->style_name != nullptr) {
+				p_font_data->style_name = String::utf8((const char *)p_font_data->face->style_name);
 			}
 			p_font_data->weight = _font_get_weight_by_name(p_font_data->style_name.to_lower());
 			p_font_data->stretch = _font_get_stretch_by_name(p_font_data->style_name.to_lower());
 			p_font_data->style_flags = 0;
-			if ((fd->face->style_flags & FT_STYLE_FLAG_BOLD) || p_font_data->weight >= 700) {
+			if ((p_font_data->face->style_flags & FT_STYLE_FLAG_BOLD) || p_font_data->weight >= 700) {
 				p_font_data->style_flags.set_flag(FONT_BOLD);
 			}
-			if ((fd->face->style_flags & FT_STYLE_FLAG_ITALIC) || _is_ital_style(p_font_data->style_name.to_lower())) {
+			if ((p_font_data->face->style_flags & FT_STYLE_FLAG_ITALIC) || _is_ital_style(p_font_data->style_name.to_lower())) {
 				p_font_data->style_flags.set_flag(FONT_ITALIC);
 			}
-			if (fd->face->face_flags & FT_FACE_FLAG_FIXED_WIDTH) {
+			if (p_font_data->face->face_flags & FT_FACE_FLAG_FIXED_WIDTH) {
 				p_font_data->style_flags.set_flag(FONT_FIXED_WIDTH);
 			}
 			// Read OpenType variations.
 			p_font_data->supported_varaitions.clear();
-			if (fd->face->face_flags & FT_FACE_FLAG_MULTIPLE_MASTERS) {
+			if (p_font_data->face->face_flags & FT_FACE_FLAG_MULTIPLE_MASTERS) {
 				FT_MM_Var *amaster;
-				FT_Get_MM_Var(fd->face, &amaster);
+				FT_Get_MM_Var(p_font_data->face, &amaster);
 				for (FT_UInt i = 0; i < amaster->num_axis; i++) {
 					p_font_data->supported_varaitions[(int32_t)amaster->axis[i].tag] = Vector3i(amaster->axis[i].minimum / 65536, amaster->axis[i].maximum / 65536, amaster->axis[i].def / 65536);
 				}
@@ -1010,8 +1020,8 @@ bool TextServerFallback::_ensure_cache_for_size(FontFallback *p_font_data, const
 		if (p_font_data->font_name == ".Apple Color Emoji UI" || p_font_data->font_name == "Apple Color Emoji") {
 			// The baseline offset is missing from the Apple Color Emoji UI font data, so add it manually.
 			// This issue doesn't occur with other system emoji fonts.
-			if (!FT_Load_Glyph(fd->face, FT_Get_Char_Index(fd->face, 0x1F92E), FT_LOAD_DEFAULT | FT_LOAD_COLOR)) {
-				if (fd->face->glyph->metrics.horiBearingY == fd->face->glyph->metrics.height) {
+			if (!FT_Load_Glyph(p_font_data->face, FT_Get_Char_Index(p_font_data->face, 0x1F92E), FT_LOAD_DEFAULT | FT_LOAD_COLOR)) {
+				if (p_font_data->face->glyph->metrics.horiBearingY == p_font_data->face->glyph->metrics.height) {
 					p_font_data->baseline_offset = 0.15;
 				}
 			}
@@ -1019,15 +1029,15 @@ bool TextServerFallback::_ensure_cache_for_size(FontFallback *p_font_data, const
 #endif
 
 		// Write variations.
-		if (fd->face->face_flags & FT_FACE_FLAG_MULTIPLE_MASTERS) {
+		if (p_font_data->face->face_flags & FT_FACE_FLAG_MULTIPLE_MASTERS) {
 			FT_MM_Var *amaster;
 
-			FT_Get_MM_Var(fd->face, &amaster);
+			FT_Get_MM_Var(p_font_data->face, &amaster);
 
 			Vector<FT_Fixed> coords;
 			coords.resize(amaster->num_axis);
 
-			FT_Get_Var_Design_Coordinates(fd->face, coords.size(), coords.ptrw());
+			FT_Get_Var_Design_Coordinates(p_font_data->face, coords.size(), coords.ptrw());
 
 			for (FT_UInt i = 0; i < amaster->num_axis; i++) {
 				// Reset to default.
@@ -1046,7 +1056,7 @@ bool TextServerFallback::_ensure_cache_for_size(FontFallback *p_font_data, const
 				}
 			}
 
-			FT_Set_Var_Design_Coordinates(fd->face, coords.size(), coords.ptrw());
+			FT_Set_Var_Design_Coordinates(p_font_data->face, coords.size(), coords.ptrw());
 			FT_Done_MM_Var(ft_library, amaster);
 		}
 #else
@@ -1977,7 +1987,7 @@ void TextServerFallback::_font_set_scale(const RID &p_font_rid, int64_t p_size, 
 	FontForSizeFallback *ffsd = nullptr;
 	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 #ifdef MODULE_FREETYPE_ENABLED
-	if (ffsd->face) {
+	if (fd->face) {
 		return; // Do not override scale for dynamic fonts, it's calculated automatically.
 	}
 #endif
@@ -2543,17 +2553,17 @@ Dictionary TextServerFallback::_font_get_glyph_contours(const RID &p_font_rid, i
 
 	int32_t index = p_index & 0xffffff; // Remove subpixel shifts.
 
-	int error = FT_Load_Glyph(ffsd->face, FT_Get_Char_Index(ffsd->face, index), FT_LOAD_NO_BITMAP | (fd->force_autohinter ? FT_LOAD_FORCE_AUTOHINT : 0));
+	int error = FT_Load_Glyph(fd->face, FT_Get_Char_Index(fd->face, index), FT_LOAD_NO_BITMAP | (fd->force_autohinter ? FT_LOAD_FORCE_AUTOHINT : 0));
 	ERR_FAIL_COND_V(error, Dictionary());
 
 	if (fd->embolden != 0.f) {
 		FT_Pos strength = fd->embolden * size.x / 16; // 26.6 fractional units (1 / 64).
-		FT_Outline_Embolden(&ffsd->face->glyph->outline, strength);
+		FT_Outline_Embolden(&fd->face->glyph->outline, strength);
 	}
 
 	if (fd->transform != Transform2D()) {
 		FT_Matrix mat = { FT_Fixed(fd->transform[0][0] * 65536), FT_Fixed(fd->transform[0][1] * 65536), FT_Fixed(fd->transform[1][0] * 65536), FT_Fixed(fd->transform[1][1] * 65536) }; // 16.16 fractional units (1 / 65536).
-		FT_Outline_Transform(&ffsd->face->glyph->outline, &mat);
+		FT_Outline_Transform(&fd->face->glyph->outline, &mat);
 	}
 
 	double scale = (1.0 / 64.0) * ffsd->scale;
@@ -2566,13 +2576,13 @@ Dictionary TextServerFallback::_font_get_glyph_contours(const RID &p_font_rid, i
 			scale = scale * Math::round((double)p_size / (double)fd->fixed_size);
 		}
 	}
-	for (short i = 0; i < ffsd->face->glyph->outline.n_points; i++) {
-		points.push_back(Vector3(ffsd->face->glyph->outline.points[i].x * scale, -ffsd->face->glyph->outline.points[i].y * scale, FT_CURVE_TAG(ffsd->face->glyph->outline.tags[i])));
+	for (short i = 0; i < fd->face->glyph->outline.n_points; i++) {
+		points.push_back(Vector3(fd->face->glyph->outline.points[i].x * scale, -fd->face->glyph->outline.points[i].y * scale, FT_CURVE_TAG(fd->face->glyph->outline.tags[i])));
 	}
-	for (short i = 0; i < ffsd->face->glyph->outline.n_contours; i++) {
-		contours.push_back(ffsd->face->glyph->outline.contours[i]);
+	for (short i = 0; i < fd->face->glyph->outline.n_contours; i++) {
+		contours.push_back(fd->face->glyph->outline.contours[i]);
 	}
-	bool orientation = (FT_Outline_Get_Orientation(&ffsd->face->glyph->outline) == FT_ORIENTATION_FILL_RIGHT);
+	bool orientation = (FT_Outline_Get_Orientation(&fd->face->glyph->outline) == FT_ORIENTATION_FILL_RIGHT);
 
 	Dictionary out;
 	out["points"] = points;
@@ -2663,11 +2673,11 @@ Vector2 TextServerFallback::_font_get_kerning(const RID &p_font_rid, int64_t p_s
 		}
 	} else {
 #ifdef MODULE_FREETYPE_ENABLED
-		if (ffsd->face) {
+		if (fd->face) {
 			FT_Vector delta;
-			int32_t glyph_a = FT_Get_Char_Index(ffsd->face, p_glyph_pair.x);
-			int32_t glyph_b = FT_Get_Char_Index(ffsd->face, p_glyph_pair.y);
-			FT_Get_Kerning(ffsd->face, glyph_a, glyph_b, FT_KERNING_DEFAULT, &delta);
+			int32_t glyph_a = FT_Get_Char_Index(fd->face, p_glyph_pair.x);
+			int32_t glyph_b = FT_Get_Char_Index(fd->face, p_glyph_pair.y);
+			FT_Get_Kerning(fd->face, glyph_a, glyph_b, FT_KERNING_DEFAULT, &delta);
 			if (fd->msdf) {
 				return Vector2(delta.x, delta.y) * (double)p_size / (double)fd->msdf_source_size;
 			} else if (fd->fixed_size > 0 && fd->fixed_size_scale_mode != FIXED_SIZE_SCALE_DISABLE && size.x != p_size * 64) {
@@ -2710,8 +2720,8 @@ bool TextServerFallback::_font_has_char(const RID &p_font_rid, int64_t p_char) c
 	}
 
 #ifdef MODULE_FREETYPE_ENABLED
-	if (ffsd->face) {
-		return FT_Get_Char_Index(ffsd->face, p_char) != 0;
+	if (fd->face) {
+		return FT_Get_Char_Index(fd->face, p_char) != 0;
 	}
 #endif
 	return ffsd->glyph_map.has((int32_t)p_char);
@@ -2731,14 +2741,14 @@ String TextServerFallback::_font_get_supported_chars(const RID &p_font_rid) cons
 
 	String chars;
 #ifdef MODULE_FREETYPE_ENABLED
-	if (ffsd->face) {
+	if (fd->face) {
 		FT_UInt gindex;
-		FT_ULong charcode = FT_Get_First_Char(ffsd->face, &gindex);
+		FT_ULong charcode = FT_Get_First_Char(fd->face, &gindex);
 		while (gindex != 0) {
 			if (charcode != 0) {
 				chars = chars + String::chr(charcode);
 			}
-			charcode = FT_Get_Next_Char(ffsd->face, charcode, &gindex);
+			charcode = FT_Get_Next_Char(fd->face, charcode, &gindex);
 		}
 		return chars;
 	}
@@ -2764,12 +2774,12 @@ PackedInt32Array TextServerFallback::_font_get_supported_glyphs(const RID &p_fon
 
 	PackedInt32Array glyphs;
 #ifdef MODULE_FREETYPE_ENABLED
-	if (at_size && at_size->face) {
+	if (fd->face) {
 		FT_UInt gindex;
-		FT_ULong charcode = FT_Get_First_Char(at_size->face, &gindex);
+		FT_ULong charcode = FT_Get_First_Char(fd->face, &gindex);
 		while (gindex != 0) {
 			glyphs.push_back(gindex);
-			charcode = FT_Get_Next_Char(at_size->face, charcode, &gindex);
+			charcode = FT_Get_Next_Char(fd->face, charcode, &gindex);
 		}
 		return glyphs;
 	}
@@ -2796,7 +2806,7 @@ void TextServerFallback::_font_render_range(const RID &p_font_rid, const Vector2
 	for (int64_t i = p_start; i <= p_end; i++) {
 #ifdef MODULE_FREETYPE_ENABLED
 		int32_t idx = i;
-		if (ffsd->face) {
+		if (fd->face) {
 			FontGlyph fgl;
 			if (fd->msdf) {
 				_ensure_glyph(fd, size, (int32_t)idx, fgl);
@@ -2830,7 +2840,7 @@ void TextServerFallback::_font_render_glyph(const RID &p_font_rid, const Vector2
 	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size, ffsd));
 #ifdef MODULE_FREETYPE_ENABLED
 	int32_t idx = p_index & 0xffffff; // Remove subpixel shifts.
-	if (ffsd->face) {
+	if (fd->face) {
 		FontGlyph fgl;
 		if (fd->msdf) {
 			_ensure_glyph(fd, size, (int32_t)idx, fgl);
@@ -2897,7 +2907,7 @@ void TextServerFallback::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 	bool lcd_aa = false;
 
 #ifdef MODULE_FREETYPE_ENABLED
-	if (!fd->msdf && ffsd->face) {
+	if (!fd->msdf && fd->face) {
 		// LCD layout, bits 24, 25, 26
 		if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
 			TextServer::FontLCDSubpixelLayout layout = lcd_subpixel_layout.get();
@@ -2928,7 +2938,7 @@ void TextServerFallback::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 		if (fgl.texture_idx != -1) {
 			Color modulate = p_color;
 #ifdef MODULE_FREETYPE_ENABLED
-			if (!fd->modulate_color_glyphs && ffsd->face && ffsd->textures[fgl.texture_idx].image.is_valid() && (ffsd->textures[fgl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
+			if (!fd->modulate_color_glyphs && fd->face && ffsd->textures[fgl.texture_idx].image.is_valid() && (ffsd->textures[fgl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
 				modulate.r = modulate.g = modulate.b = 1.0;
 			}
 #endif
@@ -3043,7 +3053,7 @@ void TextServerFallback::_font_draw_glyph_outline(const RID &p_font_rid, const R
 	bool lcd_aa = false;
 
 #ifdef MODULE_FREETYPE_ENABLED
-	if (!fd->msdf && ffsd->face) {
+	if (!fd->msdf && fd->face) {
 		// LCD layout, bits 24, 25, 26
 		if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
 			TextServer::FontLCDSubpixelLayout layout = lcd_subpixel_layout.get();
@@ -3074,7 +3084,7 @@ void TextServerFallback::_font_draw_glyph_outline(const RID &p_font_rid, const R
 		if (fgl.texture_idx != -1) {
 			Color modulate = p_color;
 #ifdef MODULE_FREETYPE_ENABLED
-			if (ffsd->face && ffsd->textures[fgl.texture_idx].image.is_valid() && (ffsd->textures[fgl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
+			if (fd->face && ffsd->textures[fgl.texture_idx].image.is_valid() && (ffsd->textures[fgl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
 				modulate.r = modulate.g = modulate.b = 1.0;
 			}
 #endif
@@ -4560,7 +4570,7 @@ RID TextServerFallback::_find_sys_font_for_text(const RID &p_fdef, const String 
 						Vector2i size = _get_size(fd, 16);
 						FontForSizeFallback *ffsd = nullptr;
 						if (_ensure_cache_for_size(fd, size, ffsd)) {
-							if (ffsd && (FT_HAS_COLOR(ffsd->face) || !FT_IS_SCALABLE(ffsd->face))) {
+							if (ffsd && (FT_HAS_COLOR(fd->face) || !FT_IS_SCALABLE(fd->face))) {
 								fb_use_msdf = false;
 							}
 						}

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -101,6 +101,7 @@ using namespace godot;
 #include FT_ADVANCES_H
 #include FT_MULTIPLE_MASTERS_H
 #include FT_BBOX_H
+#include FT_SIZES_H
 #include FT_MODULE_H
 #include FT_CONFIG_OPTIONS_H
 #if !defined(FT_CONFIG_OPTION_USE_BROTLI) && !defined(_MSC_VER)
@@ -239,14 +240,13 @@ class TextServerFallback : public TextServerExtension {
 		HashMap<Vector2i, Vector2> kerning_map;
 
 #ifdef MODULE_FREETYPE_ENABLED
-		FT_Face face = nullptr;
-		FT_StreamRec stream;
+		FT_Size fsize = nullptr;
 #endif
 
 		~FontForSizeFallback() {
 #ifdef MODULE_FREETYPE_ENABLED
-			if (face != nullptr) {
-				FT_Done_Face(face);
+			if (fsize != nullptr) {
+				FT_Done_Size(fsize);
 			}
 #endif
 		}
@@ -310,11 +310,21 @@ class TextServerFallback : public TextServerExtension {
 		size_t data_size;
 		int face_index = 0;
 
+#ifdef MODULE_FREETYPE_ENABLED
+		FT_Face face = nullptr;
+		FT_StreamRec stream;
+#endif
+
 		~FontFallback() {
 			for (const KeyValue<Vector2i, FontForSizeFallback *> &E : cache) {
 				memdelete(E.value);
 			}
 			cache.clear();
+#ifdef MODULE_FREETYPE_ENABLED
+			if (face != nullptr) {
+				FT_Done_Face(face);
+			}
+#endif
 		}
 	};
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/115731

Should improve new font size creation speed and memory usage by reusing `FT_Face`, and only creating `FT_Size` for each size (e.g, window resizing with "canvas_item" scaling and enabled oversampling).