### PR TITLE
Fix accidental write-combined memory reads in canvas renderer.

### DIFF
--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -3231,7 +3231,8 @@ RendererCanvasRenderRD::InstanceData *RendererCanvasRenderRD::new_instance_data(
 		// instance_count must be > 0 to indicate the batch has been used when calling _new_batch, so we set a flag.
 		p_current_batch.instance_count = PUSH_DATA_INSTANCE_COUNT;
 	} else {
-		instance_data = &state.instance_data[state.instance_data_index];
+		// Return the intermediary instance data to prevent the caller from accidentally reading write-combined memory pages, which has huge performance implications.
+		instance_data = &state.intermediary_instance_data;
 	}
 
 	memcpy(instance_data, &template_instance, sizeof(InstanceData));
@@ -3287,6 +3288,7 @@ void RendererCanvasRenderRD::_add_to_batch(bool &r_batch_broken, Batch *&r_curre
 			r_current_batch->command_type == Item::Command::TYPE_NINEPATCH ||
 			r_current_batch->command_type == Item::Command::TYPE_PRIMITIVE);
 	r_current_batch->instance_count++;
+	memcpy(&state.instance_data[state.instance_data_index], &state.intermediary_instance_data, sizeof(InstanceData));
 	state.instance_data_index++;
 	if (state.instance_data_index >= state.max_instances_per_buffer) {
 		RD::get_singleton()->buffer_flush(r_current_batch->instance_buffer);

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -615,6 +615,8 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		InstanceData *prev_instance_data = nullptr;
 		uint32_t prev_instance_data_index = 0;
 
+		InstanceData intermediary_instance_data;
+
 		uint32_t max_instances_per_buffer = 16384;
 		uint32_t max_instance_buffer_size = 16384 * sizeof(InstanceData);
 


### PR DESCRIPTION
Fixes #115431.

`new_instance_data` returns an `InstanceData` pointer for the caller to populate. After #111183, the pointer lives in the memory region returned by the buffer mapping function. 

On UMA systems, this is fine. However, on discrete GPUs, reading from these memory regions has a significant performance cost because the memory is write-combined.

Accumulating instance flags using the `|=` operator is affected by this, as it requires reading the existing flags from memory before applying the OR operation.

Rather than fixing each location where the flags are accumulated, I changed the function to return an intermediary instance data pointer instead. This should prevent future contributors from running into the same issue.

With this, the CPU performance returns back to how it was in 4.5.1.