### PR TITLE
Revert "Improve performance of `CSharpLanguage::reload_assemblies`"

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -534,10 +534,6 @@ void CSharpLanguage::frame() {
 	if (gdmono && gdmono->is_runtime_initialized() && GDMonoCache::godot_api_cache_updated) {
 		GDMonoCache::managed_callbacks.ScriptManagerBridge_FrameCallback();
 	}
-
-#ifdef TOOLS_ENABLED
-	_flush_filesystem_updates();
-#endif
 }
 
 struct CSharpScriptDepSort {
@@ -1072,47 +1068,6 @@ bool CSharpLanguage::debug_break(const String &p_error, bool p_allow_continue) {
 }
 
 #ifdef TOOLS_ENABLED
-void CSharpLanguage::_queue_for_filesystem_update(String p_script_path) {
-	if (!Engine::get_singleton()->is_editor_hint()) {
-		return;
-	}
-
-	if (p_script_path.is_empty()) {
-		return;
-	}
-
-	pending_file_system_update_paths.push_back(p_script_path);
-}
-
-void CSharpLanguage::_flush_filesystem_updates() {
-	if (!Engine::get_singleton()->is_editor_hint()) {
-		return;
-	}
-
-	if (pending_file_system_update_paths.is_empty()) {
-		return;
-	}
-
-	// If the EditorFileSystem singleton is available, update the files;
-	// otherwise, the files will be updated when the singleton becomes available.
-	EditorFileSystem *efs = EditorFileSystem::get_singleton();
-	if (!efs) {
-		pending_file_system_update_paths.clear();
-		return;
-	}
-
-	// Required to prevent EditorProgress within EditorFileSystem from calling this while it is already flushing
-	if (is_flushing_filesystem_updates) {
-		return;
-	}
-	is_flushing_filesystem_updates = true;
-
-	efs->update_files(pending_file_system_update_paths);
-
-	is_flushing_filesystem_updates = false;
-	pending_file_system_update_paths.clear();
-}
-
 void CSharpLanguage::_editor_init_callback() {
 	// Load GodotTools and initialize GodotSharpEditor
 
@@ -2284,7 +2239,12 @@ void CSharpScript::reload_registered_script(Ref<CSharpScript> p_script) {
 	p_script->_update_exports();
 
 #ifdef TOOLS_ENABLED
-	CSharpLanguage::get_singleton()->_queue_for_filesystem_update(p_script->get_path());
+	// If the EditorFileSystem singleton is available, update the file;
+	// otherwise, the file will be updated when the singleton becomes available.
+	EditorFileSystem *efs = EditorFileSystem::get_singleton();
+	if (efs && !p_script->get_path().is_empty()) {
+		efs->update_file(p_script->get_path());
+	}
 #endif
 }
 
@@ -2657,7 +2617,12 @@ Error CSharpScript::reload(bool p_keep_state) {
 		_update_exports();
 
 #ifdef TOOLS_ENABLED
-		CSharpLanguage::get_singleton()->_queue_for_filesystem_update(script_path);
+		// If the EditorFileSystem singleton is available, update the file;
+		// otherwise, the file will be updated when the singleton becomes available.
+		EditorFileSystem *efs = EditorFileSystem::get_singleton();
+		if (efs) {
+			efs->update_file(script_path);
+		}
 #endif
 	}
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -434,11 +434,6 @@ class CSharpLanguage : public ScriptLanguage {
 	friend class GDMono;
 
 #ifdef TOOLS_ENABLED
-	Vector<String> pending_file_system_update_paths;
-	bool is_flushing_filesystem_updates = false;
-	void _queue_for_filesystem_update(String p_script_path);
-	void _flush_filesystem_updates();
-
 	EditorPlugin *godotsharp_editor = nullptr;
 
 	static void _editor_init_callback();


### PR DESCRIPTION
This reverts commit f68bf2f54538c5252a4bba506971b1a8d4e99049 / #106299.

This seems to trigger occasional editor crashes.

- Fixes #115460.

FYI @Ryan-000 - might be worth another attempt at this optimization that ensures it doesn't trigger the issues in #115460.