### PR TITLE
Fix debugger error log time gets trimmed.

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -654,6 +654,7 @@ void ScriptEditorDebugger::_msg_error(uint64_t p_thread_id, const Array &p_data)
 	}
 	error->set_collapsed(true);
 
+	error->set_text_overrun_behavior(0, TextServer::OVERRUN_NO_TRIMMING);
 	error->set_icon(0, get_editor_theme_icon(oe.warning ? SNAME("Warning") : SNAME("Error")));
 	error->set_text(0, time);
 	error->set_text_alignment(0, HORIZONTAL_ALIGNMENT_LEFT);
@@ -2257,7 +2258,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 
 		error_tree->set_column_expand(0, false);
 		error_tree->set_column_custom_minimum_width(0, 140);
-		error_tree->set_column_clip_content(0, true);
+		error_tree->set_column_clip_content(0, false);
 
 		error_tree->set_column_expand(1, true);
 		error_tree->set_column_clip_content(1, true);


### PR DESCRIPTION
|before|after|
|-|-|
|<img width="369" height="386" alt="Screenshot 2026-02-02 210851" src="https://github.com/user-attachments/assets/4a5d8f82-b483-4a17-b489-328429c9957d" />|<img width="328" height="402" alt="Screenshot 2026-02-02 213645" src="https://github.com/user-attachments/assets/c85d9c8a-fc3e-4f5d-90c7-eac947356f29" />|
