### PR TITLE
Add thread-safety note to `AStarGrid2D::get_id_path`

### DIFF
--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -81,7 +81,8 @@
 				Returns an array with the IDs of the points that form the path found by AStar2D between the given points. The array is ordered from the starting point to the ending point of the path.
 				If [param from_id] point is disabled, returns an empty array (even if [code]from_id == to_id[/code]).
 				If [param from_id] point is not disabled, there is no valid path to the target, and [param allow_partial_path] is [code]true[/code], returns a path to the point closest to the target that can be reached.
-				[b]Note:[/b] When [param allow_partial_path] is [code]true[/code] and [param to_id] is solid the search may take an unusually long time to finish.
+				[b]Note:[/b] This method is not thread-safe; it can only be used from a single [Thread] at a given time. Consider using [Mutex] to ensure exclusive access to one thread to avoid race conditions.
+				Additionally, when [param allow_partial_path] is [code]true[/code] and [param to_id] is solid the search may take an unusually long time to finish.
 			</description>
 		</method>
 		<method name="get_point_data_in_region" qualifiers="const">


### PR DESCRIPTION
Copied thread-safety note over from `get_point_path`, since `get_id_path` has similar logic.  This was mentioned in a comment on the docs at https://docs.godotengine.org/en/stable/classes/class_astargrid2d.html.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
