### PR TITLE
Shader editor: Fix color-conversion-disabled autocomplete

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -12102,7 +12102,10 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 				if (current_uniform_hint == ShaderNode::Uniform::HINT_NONE) {
 					ScriptLanguage::CodeCompletionOption option("source_color", ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
 					r_options->push_back(option);
-					r_options->push_back({ "color_conversion_disabled", ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT });
+				}
+				if (current_uniform_hint == ShaderNode::Uniform::HINT_SOURCE_COLOR) {
+					ScriptLanguage::CodeCompletionOption option("color_conversion_disabled", ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
+					r_options->push_back(option);
 				}
 			} else if ((completion_base == DataType::TYPE_INT || completion_base == DataType::TYPE_FLOAT) && !completion_base_array) {
 				if (current_uniform_hint == ShaderNode::Uniform::HINT_NONE) {


### PR DESCRIPTION
Autocomplete only recognizes `color_conversion_disabled` before `source_color` is typed, but not after. This causes confusion because `source_color` must be written first, followed by `color_conversion_disabled`; otherwise, it triggers the error: "**Hint color_conversion_disabled should be preceded by source_color.**"

|Before|After|
|--------|--------|
|<video src=https://github.com/user-attachments/assets/467db70c-e25f-4166-8703-27e2d9e6b8c2></video>|<video src=https://github.com/user-attachments/assets/fd082b1f-bbcf-4a22-9aab-5ecb1ed20573></video>|
