### PR TITLE
Fix null reference error in Camera2DEditor causing crash

### DIFF
--- a/editor/scene/2d/camera_2d_editor_plugin.cpp
+++ b/editor/scene/2d/camera_2d_editor_plugin.cpp
@@ -244,7 +244,7 @@ void Camera2DEditor::_update_hover(const Vector2 &p_mouse_pos) {
 		}
 	}
 
-	if (hover_type == Drag::NONE && limit_rect.has_point(p_mouse_pos)) {
+	if (hover_type == Drag::NONE && limit_rect.has_point(p_mouse_pos) && selected_camera->get_viewport()) {
 		const Rect2 editor_rect = Rect2(Vector2(), CanvasItemEditor::get_singleton()->get_viewport_control()->get_size());
 		const Rect2 transformed_rect = selected_camera->get_viewport()->get_canvas_transform().xform_inv(limit_rect);
 


### PR DESCRIPTION
Occurs when creating scene from existing Camera2d node

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
