### PR TITLE
Document rotation methods being clockwise in 2D, counter-clockwise in 3D

### DIFF
--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -250,7 +250,7 @@
 			<param index="1" name="angle" type="float" />
 			<description>
 				Returns a copy of this basis rotated around the given [param axis] by the given [param angle] (in radians).
-				The [param axis] must be a normalized vector (see [method Vector3.normalized]). If [param angle] is positive, the basis is rotated counter-clockwise around the axis.
+				The [param axis] must be a normalized vector (see [method Vector3.normalized]). If [param angle] is positive, the basis is rotated counter-clockwise when looking against the axis.
 				[codeblocks]
 				[gdscript]
 				var my_basis = Basis.IDENTITY

--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -69,7 +69,7 @@
 			<return type="void" />
 			<param index="0" name="radians" type="float" />
 			<description>
-				Applies a rotation to the node, in radians, starting from its current rotation. This is equivalent to [code]rotation += radians[/code].
+				Applies a clockwise rotation to the node, in radians, starting from its current rotation. This is equivalent to [code]rotation += radians[/code].
 			</description>
 		</method>
 		<method name="to_global" qualifiers="const">

--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -158,7 +158,7 @@
 			<param index="0" name="axis" type="Vector3" />
 			<param index="1" name="angle" type="float" />
 			<description>
-				Rotates this node's [member basis] around the [param axis] by the given [param angle], in radians. This operation is calculated in parent space (relative to the parent) and preserves the [member position].
+				Rotates this node's [member basis] around the [param axis] by the given [param angle], in radians. This operation is calculated in parent space (relative to the parent) and preserves the [member position]. The rotation angle is specified counter-clockwise when looking against the axis.
 			</description>
 		</method>
 		<method name="rotate_object_local">

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -192,8 +192,7 @@
 			<return type="Transform2D" />
 			<param index="0" name="angle" type="float" />
 			<description>
-				Returns a copy of this transform rotated by the given [param angle] (in radians).
-				If [param angle] is positive, the transform is rotated clockwise.
+				Returns a copy of this transform rotated by the given [param angle] (in radians). If [param angle] is positive, the transform is rotated clockwise.
 				This method is an optimized version of multiplying the given transform [code]X[/code] with a corresponding rotation transform [code]R[/code] from the left, i.e., [code]R * X[/code].
 				This can be seen as transforming with respect to the global/parent frame.
 			</description>

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -119,7 +119,7 @@
 			<param index="1" name="angle" type="float" />
 			<description>
 				Returns a copy of this transform rotated around the given [param axis] by the given [param angle] (in radians).
-				The [param axis] must be a normalized vector (see [method Vector3.normalized]). If [param angle] is positive, the basis is rotated counter-clockwise around the axis.
+				The [param axis] must be a normalized vector (see [method Vector3.normalized]). If [param angle] is positive, the basis is rotated counter-clockwise when looking against the axis.
 				This method is an optimized version of multiplying the given transform [code]X[/code] with a corresponding rotation transform [code]R[/code] from the left, i.e., [code]R * X[/code].
 				This can be seen as transforming with respect to the global/parent frame.
 			</description>

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -370,7 +370,7 @@
 			<return type="Vector2" />
 			<param index="0" name="angle" type="float" />
 			<description>
-				Returns the result of rotating this vector by [param angle] (in radians). See also [method @GlobalScope.deg_to_rad].
+				Returns the result of rotating this vector clockwise by [param angle] (in radians). See also [method @GlobalScope.deg_to_rad].
 			</description>
 		</method>
 		<method name="round" qualifiers="const">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -354,7 +354,7 @@
 			<param index="0" name="axis" type="Vector3" />
 			<param index="1" name="angle" type="float" />
 			<description>
-				Returns the result of rotating this vector around a given axis by [param angle] (in radians). The axis must be a normalized vector. See also [method @GlobalScope.deg_to_rad].
+				Returns the result of rotating this vector around a given axis by [param angle] (in radians). The axis must be a normalized vector. See also [method @GlobalScope.deg_to_rad]. The rotation angle is specified counter-clockwise when looking against the axis.
 			</description>
 		</method>
 		<method name="round" qualifiers="const">


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot-docs/issues/11727.
