### PR TITLE
Fix Go To Line crash

### DIFF
--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -645,6 +645,9 @@ TextEditorBase::TextEditorBase() {
 
 	edit_hb = memnew(HBoxContainer);
 
+	goto_line_popup = memnew(GotoLinePopup);
+	add_child(goto_line_popup);
+
 	Ref<EditorPlainTextSyntaxHighlighter> plain_highlighter;
 	plain_highlighter.instantiate();
 	add_syntax_highlighter(plain_highlighter);

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3395,10 +3395,9 @@ void ScriptEditor::update_docs_from_script(const Ref<Script> &p_script) {
 }
 
 void ScriptEditor::_update_selected_editor_menu() {
-	if (TextEditorBase *current_editor = Object::cast_to<TextEditorBase>(_get_current_editor())) {
-		for (Control *editor_menu : editor_menus) {
-			editor_menu->set_visible(current_editor && editor_menu == current_editor->get_edit_menu());
-		}
+	TextEditorBase *current_editor = Object::cast_to<TextEditorBase>(_get_current_editor());
+	for (Control *editor_menu : editor_menus) {
+		editor_menu->set_visible(current_editor && editor_menu == current_editor->get_edit_menu());
 	}
 
 	PopupMenu *search_popup = script_search_menu->get_popup();


### PR DESCRIPTION
I missed these when https://github.com/godotengine/godot/pull/114917 was rebased.

Opening Go To Line crashed since the popup wasn't created.

Also opening an EditorHelp documentation didn't hide the TextEditor's edit menus: 

<img width="538" height="51" alt="image" src="https://github.com/user-attachments/assets/0fae448d-da20-4252-8da4-5c3e047d2d64" />
