### PR TITLE
Add anti-aliasing to transform gizmo rotation arc

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -3802,14 +3802,10 @@ void Node3DEditorViewport::_draw() {
 			}
 
 			Color circle_color = (_edit.plane == TRANSFORM_VIEW) ? Color(1.0, 1.0, 1.0, 0.8) : handle_color.from_hsv(handle_color.get_h(), 0.6, 1.0, 0.8);
-			for (int i = 0; i < circle_points.size() - 1; i++) {
-				RenderingServer::get_singleton()->canvas_item_add_line(
-						ci,
-						circle_points[i],
-						circle_points[i + 1],
-						circle_color,
-						Math::round(2 * EDSCALE));
-			}
+			Vector<Color> circle_colors;
+			circle_colors.resize(circle_points.size());
+			circle_colors.fill(circle_color);
+			RenderingServer::get_singleton()->canvas_item_add_polyline(ci, circle_points, circle_colors, Math::round(2 * EDSCALE), true);
 
 			const int segments = 64;
 			float display_angle = _edit.display_rotation_angle;
@@ -3866,7 +3862,8 @@ void Node3DEditorViewport::_draw() {
 					center,
 					start_point_2d,
 					edge_color,
-					Math::round(2 * EDSCALE));
+					Math::round(2 * EDSCALE),
+					true);
 
 			Vector3 end_point_3d = _edit.center + gizmo_scale * rotation_radius * (right * Math::cos(_edit.accumulated_rotation_angle) + forward * Math::sin(_edit.accumulated_rotation_angle));
 			Point2 end_point_2d = point_to_screen(end_point_3d);
@@ -3875,7 +3872,8 @@ void Node3DEditorViewport::_draw() {
 					center,
 					end_point_2d,
 					edge_color,
-					Math::round(2 * EDSCALE));
+					Math::round(2 * EDSCALE),
+					true);
 		}
 
 		if (_edit.show_rotation_line) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

The transform gizmo is 3D mesh geometry and therefor affected by the `rendering/anti_aliasing/quality/msaa_3d` setting, but the arc is a 2D canvas circle since it's purely informational, simple and not meant to be interacted with, so it has its own AA settings.

Arguably the transform gizmo should be on its own sub viewport with its own AA settings as well, but that is beside the point for now, and possibly a separate PR in the future. 


https://github.com/user-attachments/assets/6fd28f21-a69e-4259-be63-bf95c1f1b74c


