### PR TITLE
Fix highlighted word style being overwritten by hover/pressed styles in find in files

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -140,6 +140,13 @@
 				Returns the column's width in pixels.
 			</description>
 		</method>
+		<method name="get_custom_drawing_canvas_item" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the internal canvas item designated for custom drawing. See [method TreeItem.set_custom_draw_callback].
+				[b]Note:[/b] This canvas item clears automatically on each Tree draw call.
+			</description>
+		</method>
 		<method name="get_custom_popup_rect" qualifiers="const">
 			<return type="Rect2" />
 			<description>

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -677,6 +677,7 @@
 			<description>
 				Sets the given column's custom draw callback. Use an empty [Callable] ([code skip-lint]Callable()[/code]) to clear the custom callback. The cell has to be in [constant CELL_MODE_CUSTOM] to use this feature.
 				The [param callback] should accept two arguments: the [TreeItem] that is drawn and its position and size as a [Rect2].
+				To draw custom content over the native style, please use [method Tree.get_custom_drawing_canvas_item].
 			</description>
 		</method>
 		<method name="set_custom_font">

--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -51,6 +51,7 @@
 #include "scene/gui/tab_container.h"
 #include "scene/gui/tree.h"
 #include "scene/main/scene_tree.h"
+#include "servers/rendering/rendering_server.h"
 
 // TODO: Would be nice in Vector and Vectors.
 template <typename T>
@@ -905,9 +906,19 @@ void FindInFilesPanel::_draw_result_text(Object *p_item_obj, const Rect2 &p_rect
 	match_rect.position.y += 1 * EDSCALE;
 	match_rect.size.y -= 2 * EDSCALE;
 
+	RID ci = item->get_tree()->get_custom_drawing_canvas_item();
+
+	Vector<Vector2> points;
+	points.resize(5);
+	points.write[0] = match_rect.position;
+	points.write[1] = match_rect.position + Vector2(match_rect.size.x, 0);
+	points.write[2] = match_rect.position + match_rect.size;
+	points.write[3] = match_rect.position + Vector2(0, match_rect.size.y);
+	points.write[4] = match_rect.position;
 	Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-	results_display->draw_rect(match_rect, Color(accent_color, 0.33), false, 2.0);
-	results_display->draw_rect(match_rect, Color(accent_color, 0.17), true);
+	Vector<Color> colors = { Color(accent_color, 0.33) };
+	RenderingServer::get_singleton()->canvas_item_add_polyline(ci, points, colors, 2.0);
+	RenderingServer::get_singleton()->canvas_item_add_rect(ci, match_rect, Color(accent_color, 0.17));
 
 	// Text is drawn by Tree already.
 }

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5230,6 +5230,10 @@ void Tree::_notification(int p_what) {
 			rendering_server->canvas_item_set_custom_rect(content_ci, !is_visibility_clip_disabled(), main_clip_rect);
 			rendering_server->canvas_item_set_clip(content_ci, true);
 
+			rendering_server->canvas_item_clear(custom_ci);
+			rendering_server->canvas_item_set_custom_rect(custom_ci, !is_visibility_clip_disabled(), main_clip_rect);
+			rendering_server->canvas_item_set_clip(custom_ci, true);
+
 			rendering_server->canvas_item_clear(drop_indicator_ci);
 			rendering_server->canvas_item_set_custom_rect(drop_indicator_ci, !is_visibility_clip_disabled(), main_clip_rect);
 			rendering_server->canvas_item_set_clip(drop_indicator_ci, true);
@@ -7179,6 +7183,8 @@ void Tree::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_column_width", "column"), &Tree::get_column_width);
 
+	ClassDB::bind_method(D_METHOD("get_custom_drawing_canvas_item"), &Tree::get_custom_drawing_canvas_item);
+
 	ClassDB::bind_method(D_METHOD("set_hide_root", "enable"), &Tree::set_hide_root);
 	ClassDB::bind_method(D_METHOD("is_root_hidden"), &Tree::is_root_hidden);
 	ClassDB::bind_method(D_METHOD("get_next_selected", "from"), &Tree::get_next_selected);
@@ -7421,6 +7427,10 @@ Tree::Tree() {
 	header_ci = rs->canvas_item_create();
 	rs->canvas_item_set_parent(header_ci, get_canvas_item());
 	rs->canvas_item_set_use_parent_material(header_ci, true);
+
+	custom_ci = rs->canvas_item_create();
+	rs->canvas_item_set_parent(custom_ci, get_canvas_item());
+	rs->canvas_item_set_use_parent_material(custom_ci, true);
 
 	drop_indicator_ci = rs->canvas_item_create();
 	rs->canvas_item_set_parent(drop_indicator_ci, get_canvas_item());

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -558,6 +558,7 @@ private:
 	RID accessibility_scroll_element;
 	RID header_ci; // Separate canvas item for drawing column headers
 	RID content_ci; // Separate canvas item for drawing tree rows
+	RID custom_ci; // Separate canvas item for drawing custom content
 	RID drop_indicator_ci;
 
 	VBoxContainer *popup_editor_vb = nullptr;
@@ -902,6 +903,8 @@ public:
 
 	void set_column_titles_visible(bool p_show);
 	bool are_column_titles_visible() const;
+
+	RID get_custom_drawing_canvas_item() const { return custom_ci; }
 
 	TreeItem *get_edited() const;
 	int get_edited_column() const;


### PR DESCRIPTION
- Close #115497
- Close #116013

Fix highlighted word style being overwritten by hover/pressed styles in find in files.

<img width="1965" height="470" alt="image" src="https://github.com/user-attachments/assets/b8f7ec84-7f29-467e-94bd-af0f4c741f04" />

v4.6.stable.official [89cea1439]:

https://github.com/user-attachments/assets/02e63c2c-e340-4fec-82b9-0582e8353a20

This PR:

https://github.com/user-attachments/assets/5a52953b-bafc-43a8-b412-a93cbaab9706 






