### PR TITLE
Android: Fix JavaClassWrapper test crashes on API 26 and lower

### DIFF
--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -44,6 +44,11 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 	ERR_FAIL_NULL_V(env, false);
 
 	env->PushLocalFrame(p_argcount);
+	if (env->ExceptionCheck()) {
+		env->ExceptionDescribe();
+		env->ExceptionClear();
+		return false;
+	}
 
 	MethodInfo *method = nullptr;
 	for (MethodInfo &E : M->value) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/115764

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
