### PR TITLE
Fix .NET editor settings showing as numbers in Project Manager

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -317,6 +317,27 @@
 		<member name="docks/scene_tree/start_create_dialog_fully_expanded" type="bool" setter="" getter="">
 			If [code]true[/code], the Create dialog (Create New Node/Create New Resource) will start with all its sections expanded. Otherwise, sections will be collapsed until the user starts searching (which will automatically expand sections as needed).
 		</member>
+		<member name="dotnet/build/create_binary_log" type="bool" setter="" getter="">
+			If [code]true[/code], creates a binary log file for the .NET build.
+		</member>
+		<member name="dotnet/build/no_console_logging" type="bool" setter="" getter="">
+			If [code]true[/code], disables console logging for .NET builds.
+		</member>
+		<member name="dotnet/build/problems_layout" type="int" setter="" getter="">
+			The layout to use for displaying build problems. [code]0[/code] is List view, [code]1[/code] is Tree view.
+		</member>
+		<member name="dotnet/build/verbosity_level" type="int" setter="" getter="">
+			The verbosity level for .NET builds. [code]0[/code] is Quiet, [code]1[/code] is Minimal, [code]2[/code] is Normal, [code]3[/code] is Detailed, [code]4[/code] is Diagnostic.
+		</member>
+		<member name="dotnet/editor/custom_exec_path" type="String" setter="" getter="">
+			The path to the custom external editor executable for .NET scripts. Used when [member dotnet/editor/external_editor] is set to Custom.
+		</member>
+		<member name="dotnet/editor/custom_exec_path_args" type="String" setter="" getter="">
+			The arguments to pass to the custom external editor. The [code]{file}[/code] placeholder is replaced with the file path.
+		</member>
+		<member name="dotnet/editor/external_editor" type="int" setter="" getter="">
+			The external editor to use for .NET scripts. Options vary by platform and include Visual Studio, VS Code, JetBrains Rider, and others.
+		</member>
 		<member name="editors/2d/auto_resample_delay" type="float" setter="" getter="">
 			Delay time for automatic resampling in the 2D editor (in seconds).
 		</member>

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1136,6 +1136,34 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 #endif
 	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_ENUM, "project_manager/default_renderer", default_renderer, "forward_plus,mobile,gl_compatibility")
 
+	// .NET settings.
+	// The enum values must be kept in sync with their C# counterparts:
+	// - ExternalEditorId in GodotTools/ExternalEditorId.cs
+	// - VerbosityLevelId in GodotTools/VerbosityLevelId.cs
+	// - ProblemsLayout in GodotTools/Build/BuildProblemsView.cs
+
+	// ExternalEditorId: None=0, VisualStudio=1, VisualStudioForMac=2,
+	// MonoDevelop=3, VsCode=4, Rider=5, CustomEditor=6, Fleet=7
+#if defined(WINDOWS_ENABLED)
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "dotnet/editor/external_editor", 0, "Disabled:0,Visual Studio:1,MonoDevelop:3,Visual Studio Code and VSCodium:4,JetBrains Rider:5,JetBrains Fleet:7,Custom:6")
+#elif defined(MACOS_ENABLED)
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "dotnet/editor/external_editor", 0, "Disabled:0,Visual Studio:2,MonoDevelop:3,Visual Studio Code and VSCodium:4,JetBrains Rider:5,JetBrains Fleet:7,Custom:6")
+#elif defined(UNIX_ENABLED)
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "dotnet/editor/external_editor", 0, "Disabled:0,MonoDevelop:3,Visual Studio Code and VSCodium:4,JetBrains Rider:5,JetBrains Fleet:7,Custom:6")
+#else
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "dotnet/editor/external_editor", 0, "Disabled:0")
+#endif
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "dotnet/editor/custom_exec_path", "", "")
+	_initial_set("dotnet/editor/custom_exec_path_args", "{file}");
+
+	// VerbosityLevelId: Quiet=0, Minimal=1, Normal=2, Detailed=3, Diagnostic=4
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "dotnet/build/verbosity_level", 2, "Quiet:0,Minimal:1,Normal:2,Detailed:3,Diagnostic:4")
+	_initial_set("dotnet/build/no_console_logging", false);
+	_initial_set("dotnet/build/create_binary_log", false);
+
+	// ProblemsLayout: List=0, Tree=1
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "dotnet/build/problems_layout", 1, "View as List:0,View as Tree:1")
+
 #undef EDITOR_SETTING
 #undef EDITOR_SETTING_BASIC
 #undef EDITOR_SETTING_USAGE

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildProblemsView.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildProblemsView.cs
@@ -30,6 +30,7 @@ namespace GodotTools.Build
         private PopupMenu _problemsContextMenu;
 #nullable enable
 
+        // Keep in sync with editor/settings/editor_settings.cpp.
         public enum ProblemsLayout { List, Tree }
         private ProblemsLayout _layout = ProblemsLayout.Tree;
 

--- a/modules/mono/editor/GodotTools/GodotTools/ExternalEditorId.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/ExternalEditorId.cs
@@ -1,9 +1,10 @@
 namespace GodotTools
 {
+    // Keep in sync with editor/settings/editor_settings.cpp.
     public enum ExternalEditorId : long
     {
         None,
-        VisualStudio, // TODO (Windows-only)
+        VisualStudio, // Windows-only
         VisualStudioForMac, // Mac-only
         MonoDevelop,
         VsCode,

--- a/modules/mono/editor/GodotTools/GodotTools/VerbosityLevelId.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/VerbosityLevelId.cs
@@ -1,5 +1,6 @@
 namespace GodotTools
 {
+    // Keep in sync with editor/settings/editor_settings.cpp.
     public enum VerbosityLevelId : long
     {
         Quiet,


### PR DESCRIPTION
Fixes #113994

## Problem

In Project Selector screen, drop-down with enum values were not displaying their text equivalents. Instead it show numbers per option.

Root cause was that the enums these dropdown were displaying are registered when C# is loaded, which only happens during the game editor and NOT the earlier Project Selector screen.

## Solution

Go with the simple approach, in the C++ code for Project Selector settings menu hardcode these values and make a note in the .cs files to keep these enum values in sync. This is straightforward and although we have duplication, alternatives were too heavy. Also, these enum values are hardly ever going to change.

## Tested

https://github.com/user-attachments/assets/9071eb3e-bb2a-470c-a8a1-5429928c6ad3

> [!NOTE]
> Built on macOS `15.7.1 ` with `1.4 GHz Quad-Core Intel Core i5` processor  and `Intel Iris Plus Graphics 645 1536 MB` graphics card.
