### PR TITLE
Don't use cached lightmap when rebaking

### DIFF
--- a/editor/scene/2d/tiles/atlas_merging_dialog.cpp
+++ b/editor/scene/2d/tiles/atlas_merging_dialog.cpp
@@ -236,7 +236,7 @@ void AtlasMergingDialog::_merge_confirmed(const String &p_path) {
 
 	ResourceLoader::import(p_path);
 
-	Ref<Texture2D> new_texture_resource = ResourceLoader::load(p_path, "Texture2D");
+	Ref<Texture2D> new_texture_resource = ResourceLoader::load(p_path, "Texture2D", ResourceFormatLoader::CACHE_MODE_REPLACE);
 	merged->set_texture(new_texture_resource);
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();

--- a/editor/scene/3d/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/scene/3d/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -167,7 +167,7 @@ void GPUParticlesCollisionSDF3DEditorPlugin::_sdf_save_path_and_bake(const Strin
 		Error err = bake_img->save_exr(p_path, false);
 		ERR_FAIL_COND(err);
 		ResourceLoader::import(p_path);
-		Ref<Texture> t = ResourceLoader::load(p_path); //if already loaded, it will be updated on refocus?
+		Ref<Texture> t = ResourceLoader::load(p_path, "", ResourceFormatLoader::CACHE_MODE_REPLACE);
 		ERR_FAIL_COND(t.is_null());
 
 		col_sdf->set_texture(t);

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -884,7 +884,8 @@ LightmapGI::BakeError LightmapGI::_save_and_reimport_atlas_textures(const Ref<Li
 
 		// Reimport the file.
 		ResourceLoader::import(atlas_path);
-		Ref<TextureLayered> t = ResourceLoader::load(atlas_path); // If already loaded, it will be updated on refocus?
+		// Use CACHE_MODE_REPLACE to ensure we get the newly imported texture, not a cached stale version.
+		Ref<TextureLayered> t = ResourceLoader::load(atlas_path, "", ResourceFormatLoader::CACHE_MODE_REPLACE);
 		ERR_FAIL_COND_V(t.is_null(), LightmapGI::BAKE_ERROR_CANT_CREATE_IMAGE);
 
 		// Store the atlas in the array.


### PR DESCRIPTION
The light map rebake was unsuccessful because it was reloading cached stale version.
Added CACHE_MODE_REPLACE to replace the stale with the new lightning. 
Fix for #115803
