### PR TITLE
Fix script list hot color/main scene name color

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1634,14 +1634,14 @@ void ItemList::_notification(int p_what) {
 
 				if (!items[i].text.is_empty()) {
 					Color txt_modulate;
-					if (items[i].selected && hovered == i) {
+					if (items[i].custom_fg != Color()) {
+						txt_modulate = items[i].custom_fg;
+					} else if (items[i].selected && hovered == i) {
 						txt_modulate = theme_cache.font_hovered_selected_color;
 					} else if (items[i].selected) {
 						txt_modulate = theme_cache.font_selected_color;
 					} else if (hovered == i) {
 						txt_modulate = theme_cache.font_hovered_color;
-					} else if (items[i].custom_fg != Color()) {
-						txt_modulate = items[i].custom_fg;
 					} else {
 						txt_modulate = theme_cache.font_color;
 					}


### PR DESCRIPTION
Fix main scene file name color get overwritten by hover/pressed style.
Fix script name hot color get overwritten by hover/pressed style.

The user-customized foreground color should take higher priority in ItemList.

before:

https://github.com/user-attachments/assets/03f17f59-be34-4ba3-90c0-b78ebd0fdff0

after:

https://github.com/user-attachments/assets/05c7e6af-5aa5-403f-9353-5f1ecb503b26

