### PR TITLE
Add functions for parity with shading language

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -211,11 +211,25 @@ _ALWAYS_INLINE_ float log2(float p_x) {
 	return std::log2(p_x);
 }
 
+_ALWAYS_INLINE_ double log10(double p_x) {
+	return std::log10(p_x);
+}
+_ALWAYS_INLINE_ float log10(float p_x) {
+	return std::log10(p_x);
+}
+
 _ALWAYS_INLINE_ double exp(double p_x) {
 	return std::exp(p_x);
 }
 _ALWAYS_INLINE_ float exp(float p_x) {
 	return std::exp(p_x);
+}
+
+_ALWAYS_INLINE_ double exp2(double p_x) {
+	return std::exp2(p_x);
+}
+_ALWAYS_INLINE_ float exp2(float p_x) {
+	return std::exp2(p_x);
 }
 
 _ALWAYS_INLINE_ bool is_nan(double p_val) {

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -337,8 +337,20 @@ double VariantUtilityFunctions::log(double x) {
 	return Math::log(x);
 }
 
+double VariantUtilityFunctions::log2(double x) {
+	return Math::log2(x);
+}
+
+double VariantUtilityFunctions::log10(double x) {
+	return Math::log10(x);
+}
+
 double VariantUtilityFunctions::exp(double x) {
 	return Math::exp(x);
+}
+
+double VariantUtilityFunctions::exp2(double x) {
+	return Math::exp2(x);
 }
 
 bool VariantUtilityFunctions::is_nan(double x) {
@@ -1679,7 +1691,10 @@ void Variant::_register_variant_utility_functions() {
 
 	FUNCBINDR(pow, sarray("base", "exp"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(log, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(log2, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(log10, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(exp, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(exp2, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDR(is_nan, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(is_inf, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -68,7 +68,10 @@ struct VariantUtilityFunctions {
 	static int64_t signi(int64_t x);
 	static double pow(double x, double y);
 	static double log(double x);
+	static double log2(double x);
+	static double log10(double x);
 	static double exp(double x);
+	static double exp2(double x);
 	static bool is_nan(double x);
 	static bool is_inf(double x);
 	static bool is_equal_approx(double x, double y);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -406,6 +406,17 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="exp2">
+			<return type="float" />
+			<param index="0" name="x" type="float" />
+			<description>
+				Returns 2 raised to the power of [param x]. This is often faster and more precise than [code]pow(2, x)[/code] for base-2 exponential calculations.
+				[codeblock]
+				var a = exp2(3) # Returns 8.0
+				var b = exp2(-1) # Returns 0.5
+				[/codeblock]
+			</description>
+		</method>
 		<method name="floor">
 			<return type="Variant" />
 			<param index="0" name="x" type="Variant" />
@@ -679,11 +690,35 @@
 			<param index="0" name="x" type="float" />
 			<description>
 				Returns the [url=https://en.wikipedia.org/wiki/Natural_logarithm]natural logarithm[/url] of [param x] (base [url=https://en.wikipedia.org/wiki/E_(mathematical_constant)][i]e[/i][/url], with [i]e[/i] being approximately 2.71828). This is the amount of time needed to reach a certain level of continuous growth.
-				[b]Note:[/b] This is not the same as the "log" function on most calculators, which uses a base 10 logarithm. To use base 10 logarithm, use [code]log(x) / log(10)[/code].
+				[b]Note:[/b] This is not the same as the "log" function on most calculators, which uses a base 10 logarithm. To use base 10 logarithm, use [method log10]. For logarithms to other bases, use the method [method log] with the formula [code]log(x) / log(base)[/code].
 				[codeblock]
 				log(10) # Returns 2.302585
 				[/codeblock]
 				[b]Note:[/b] The logarithm of [code]0[/code] returns [code]-inf[/code], while negative values return [code]-nan[/code].
+			</description>
+		</method>
+		<method name="log2">
+			<return type="float" />
+			<param index="0" name="x" type="float" />
+			<description>
+				Returns the binary logarithm of [param x] (base-2 logarithm). This is effectively the inverse of [method exp2].
+				For logarithms to other bases, use the method [method log] with the formula [code]log(x) / log(base)[/code].
+				[codeblock]
+				var a = log2(8) # Returns 3.0
+				var b = log2(1) # Returns 0.0
+				[/codeblock]
+			</description>
+		</method>
+		<method name="log10">
+			<return type="float" />
+			<param index="0" name="x" type="float" />
+			<description>
+				Returns the common logarithm of [param x] (base-10 logarithm).
+				For logarithms to other bases, use the method [method log] with the formula [code]log(x) / log(base)[/code].
+				[codeblock]
+				var a = log10(100) # Returns 2.0
+				var b = log10(0.1) # Returns -1.0
+				[/codeblock]
 			</description>
 		</method>
 		<method name="max" qualifiers="vararg">

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -886,6 +886,30 @@ namespace Godot
         }
 
         /// <summary>
+        /// The base 2 exponential function. It raises the value 2
+        /// to the power of <paramref name="s"/> and returns it.
+        /// </summary>
+        /// <param name="s">The exponent to raise 2 to.</param>
+        /// <returns>2 raised to the power of <paramref name="s"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Exp2(float s)
+        {
+            return float.Exp2(s);
+        }
+
+        /// <summary>
+        /// The base 2 exponential function. It raises the value 2
+        /// to the power of <paramref name="s"/> and returns it.
+        /// </summary>
+        /// <param name="s">The exponent to raise 2 to.</param>
+        /// <returns>2 raised to the power of <paramref name="s"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Exp2(double s)
+        {
+            return double.Exp2(s);
+        }
+
+        /// <summary>
         /// Rounds <paramref name="s"/> downward (towards negative infinity).
         /// </summary>
         /// <param name="s">The number to floor.</param>
@@ -1207,6 +1231,55 @@ namespace Godot
         public static double Log(double s)
         {
             return Math.Log(s);
+        }
+
+        /// <summary>
+        /// Base 2 logarithm. Computes the exponent to which the number 2 must be raised to produce a given value s.
+        /// </summary>
+        /// <param name="s">The input value.</param>
+        /// <returns>The base 2 log of <paramref name="s"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Log2(float s)
+        {
+            return MathF.Log2(s);
+        }
+
+        /// <summary>
+        /// Base 2 logarithm. Computes the exponent to which the number 2 must be raised to produce a given value s.
+        /// </summary>
+        /// <param name="s">The input value.</param>
+        /// <returns>The base 2 log of <paramref name="s"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Log2(double s)
+        {
+            return Math.Log2(s);
+        }
+
+
+        /// <summary>
+        /// Base 10 logarithm. Computes the exponent to which the number 10 must be raised to produce a given value s.
+        ///
+        /// Note: This IS the same as the "log" function on most calculators, which uses a base 10 logarithm.
+        /// </summary>
+        /// <param name="s">The input value.</param>
+        /// <returns>The base 10 log of <paramref name="s"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Log10(float s)
+        {
+            return MathF.Log10(s);
+        }
+
+        /// <summary>
+        /// Base 10 logarithm. Computes the exponent to which the number 10 must be raised to produce a given value s.
+        ///
+        /// Note: This IS the same as the "log" function on most calculators, which uses a base 10 logarithm.
+        /// </summary>
+        /// <param name="s">The input value.</param>
+        /// <returns>The base 10 log of <paramref name="s"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Log10(double s)
+        {
+            return Math.Log10(s);
         }
 
         /// <summary>

--- a/tests/core/math/test_math_funcs.h
+++ b/tests/core/math/test_math_funcs.h
@@ -276,11 +276,24 @@ TEST_CASE_TEMPLATE("[Math] pow/log/log2/exp/sqrt", T, float, double) {
 	CHECK(Math::log2((T)1.5) == doctest::Approx((T)0.5849625007));
 	CHECK(Math::log2((T)450.0) == doctest::Approx((T)8.8137811912));
 
+	CHECK(Math::is_nan(Math::log10((T)-0.1)));
+	CHECK(Math::log10((T)0.1) == doctest::Approx((T)-1.0));
+	CHECK(Math::log10((T)0.5) == doctest::Approx((T)-0.30102999566));
+	CHECK(Math::log10((T)1.0) == doctest::Approx((T)0.0));
+	CHECK(Math::log10((T)1.5) == doctest::Approx((T)0.17609125905));
+	CHECK(Math::log10((T)450.0) == doctest::Approx((T)2.65321251378));
+
 	CHECK(Math::exp((T)-0.1) == doctest::Approx((T)0.904837418));
 	CHECK(Math::exp((T)0.1) == doctest::Approx((T)1.1051709181));
 	CHECK(Math::exp((T)0.5) == doctest::Approx((T)1.6487212707));
 	CHECK(Math::exp((T)1.0) == doctest::Approx((T)2.7182818285));
 	CHECK(Math::exp((T)1.5) == doctest::Approx((T)4.4816890703));
+
+	CHECK(Math::exp2((T)-0.1) == doctest::Approx((T)0.93303299153));
+	CHECK(Math::exp2((T)0.1) == doctest::Approx((T)1.07177346254));
+	CHECK(Math::exp2((T)0.5) == doctest::Approx((T)1.41421356237));
+	CHECK(Math::exp2((T)1.0) == doctest::Approx((T)2.0));
+	CHECK(Math::exp2((T)1.5) == doctest::Approx((T)2.82842712475));
 
 	CHECK(Math::is_nan(Math::sqrt((T)-0.1)));
 	CHECK(Math::sqrt((T)0.1) == doctest::Approx((T)0.316228));


### PR DESCRIPTION
This PR exposes log2(), log10(), and exp2() to the GDScript @GlobalScope. Currently, these functions are available in the Godot Shading Language but are missing from GDScript, requiring developers to use manual workarounds.

Developers often port logic between CPU (GDScript) and GPU (Shaders). Providing these functions ensures a consistent API across the engine and reduces friction when moving math-heavy code between scripts and materials. It also makes porting over code from other languages more straight forward. Most major languages used alongside Godot—such as Python, C++, and C#—provide these as standard library functions. Adding them makes Godot more intuitive for newcomers and reduces the need for "boilerplate" helper functions in every project.

While these can be calculated using the change-of-base formula (e.g., log(x) / log(2)), this PR maps them directly to the underlying C++ Math:: functions.

#113736  Adds support for any base, but it as proposed introduces division for every base, which could be fixed, but I still think explicit mappings to log2, log10, exp2 are more straight forward. Expecially when switching between the shading langauge and gdscript and having to switch between log2(x) and log(x) / log(2) or exp2(x) and 2**x / pow(2, x)

But if this functionality is not desired I will not cry, simply smother this pr with a pillow and I shall not fight.