### PR TITLE
X11: Fix double click returning true after clicking a mouse button after scrolling up/down

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5253,6 +5253,8 @@ void DisplayServerX11::process_events() {
 
 					} else if (mb->get_button_index() < MouseButton::WHEEL_UP || mb->get_button_index() > MouseButton::WHEEL_RIGHT) {
 						last_click_button_index = mb->get_button_index();
+					} else {
+						last_click_button_index = MouseButton::NONE;
 					}
 
 					if (!mb->is_double_click()) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/115812

Not familiar with this code or sure if this is the correct/best way to fix this. 