### PR TITLE
Separate settings for syntax highlighting of built-in and custom class members, and property access

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1748,6 +1748,11 @@
 		<member name="text_editor/theme/highlighting/current_line_color" type="Color" setter="" getter="">
 			The script editor's background color for the line the caret is currently on. This should be set to a translucent color so that it can display on top of other line color modifiers such as [member text_editor/theme/highlighting/mark_color].
 		</member>
+		<member name="text_editor/theme/highlighting/custom_member_variable_color" type="Color" setter="" getter="">
+			The script editor's color for custom class members (variables, constants, signals, etc.).
+			[b]Note:[/b] This color is not used built-in class members, see [member text_editor/theme/highlighting/member_variable_color] instead.
+			[b]Note:[/b] This color is not used for local declarations and access.
+		</member>
 		<member name="text_editor/theme/highlighting/doc_comment_color" type="Color" setter="" getter="">
 			The script editor's documentation comment color. In GDScript, this is used for comments starting with [code]##[/code]. In C#, this is used for comments starting with [code]///[/code] or [code]/**[/code].
 		</member>
@@ -1795,11 +1800,15 @@
 			The script editor's background color for lines with errors. This should be set to a translucent color so that it can display on top of other line color modifiers such as [member text_editor/theme/highlighting/current_line_color].
 		</member>
 		<member name="text_editor/theme/highlighting/member_variable_color" type="Color" setter="" getter="">
-			The script editor's color for member variables on objects (e.g. [code]self.some_property[/code]).
-			[b]Note:[/b] This color is not used for local variable declaration and access.
+			The script editor's color for built-in class members (variables, constants, signals, etc.).
+			[b]Note:[/b] This color is not used custom class members, see [member text_editor/theme/highlighting/custom_member_variable_color] instead.
+			[b]Note:[/b] This color is not used for local declarations and access.
 		</member>
 		<member name="text_editor/theme/highlighting/number_color" type="Color" setter="" getter="">
 			The script editor's color for numbers (integer and floating-point).
+		</member>
+		<member name="text_editor/theme/highlighting/property_access_color" type="Color" setter="" getter="">
+			The script editor's color for a property name in the property access syntax (e.g. [code]some_property[/code] in [code]object.some_property[/code]).
 		</member>
 		<member name="text_editor/theme/highlighting/safe_line_number_color" type="Color" setter="" getter="">
 			The script editor's color for type-safe line numbers. See also [member text_editor/theme/highlighting/line_number_color].

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1923,7 +1923,9 @@ HashMap<StringName, Color> EditorSettings::get_godot2_text_editor_theme() {
 	colors["text_editor/theme/highlighting/word_highlighted_color"] = Color(0.8, 0.9, 0.9, 0.15);
 	colors["text_editor/theme/highlighting/number_color"] = Color(0.92, 0.58, 0.2);
 	colors["text_editor/theme/highlighting/function_color"] = Color(0.4, 0.64, 0.81);
-	colors["text_editor/theme/highlighting/member_variable_color"] = Color(0.9, 0.31, 0.35);
+	colors["text_editor/theme/highlighting/property_access_color"] = Color(0.9, 0.31, 0.35);
+	colors["text_editor/theme/highlighting/member_variable_color"] = colors["text_editor/theme/highlighting/property_access_color"];
+	colors["text_editor/theme/highlighting/custom_member_variable_color"] = colors["text_editor/theme/highlighting/property_access_color"];
 	colors["text_editor/theme/highlighting/mark_color"] = Color(1.0, 0.4, 0.4, 0.4);
 	colors["text_editor/theme/highlighting/warning_color"] = Color(1.0, 0.8, 0.4, 0.1);
 	colors["text_editor/theme/highlighting/bookmark_color"] = Color(0.08, 0.49, 0.98);
@@ -1933,13 +1935,14 @@ HashMap<StringName, Color> EditorSettings::get_godot2_text_editor_theme() {
 	colors["text_editor/theme/highlighting/folded_code_region_color"] = Color(0.68, 0.46, 0.77, 0.2);
 	colors["text_editor/theme/highlighting/search_result_color"] = Color(0.05, 0.25, 0.05, 1);
 	colors["text_editor/theme/highlighting/search_result_border_color"] = Color(0.41, 0.61, 0.91, 0.38);
-	colors["text_editor/theme/highlighting/gdscript/function_definition_color"] = Color(0.4, 0.9, 1.0);
 
+	colors["text_editor/theme/highlighting/gdscript/function_definition_color"] = Color(0.4, 0.9, 1.0);
 	colors["text_editor/theme/highlighting/gdscript/global_function_color"] = Color(0.64, 0.64, 0.96);
 	colors["text_editor/theme/highlighting/gdscript/node_path_color"] = Color(0.72, 0.77, 0.49);
 	colors["text_editor/theme/highlighting/gdscript/node_reference_color"] = Color(0.39, 0.76, 0.35);
 	colors["text_editor/theme/highlighting/gdscript/annotation_color"] = Color(1.0, 0.7, 0.45);
 	colors["text_editor/theme/highlighting/gdscript/string_name_color"] = Color(1.0, 0.76, 0.65);
+
 	colors["text_editor/theme/highlighting/comment_markers/critical_color"] = Color(0.77, 0.35, 0.35);
 	colors["text_editor/theme/highlighting/comment_markers/warning_color"] = Color(0.72, 0.61, 0.48);
 	colors["text_editor/theme/highlighting/comment_markers/notice_color"] = Color(0.56, 0.67, 0.51);

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -476,6 +476,7 @@ void _load_text_editor_theme() {
 			settings->set_manually(setting_key, color_value);
 		}
 	}
+
 	// If it doesn't load a setting just use what is currently loaded.
 }
 
@@ -530,7 +531,9 @@ void EditorThemeManager::_populate_text_editor_styles(const Ref<EditorTheme> &p_
 			colors["text_editor/theme/highlighting/word_highlighted_color"] = alpha1;
 			colors["text_editor/theme/highlighting/number_color"] = p_config.dark_icon_and_font ? Color(0.63, 1, 0.88) : Color(0, 0.55, 0.28, 1);
 			colors["text_editor/theme/highlighting/function_color"] = p_config.dark_icon_and_font ? Color(0.34, 0.7, 1.0) : Color(0, 0.225, 0.9, 1);
-			colors["text_editor/theme/highlighting/member_variable_color"] = p_config.dark_icon_and_font ? Color(0.34, 0.7, 1.0).lerp(p_config.mono_color, 0.6) : Color(0, 0.4, 0.68, 1);
+			colors["text_editor/theme/highlighting/property_access_color"] = p_config.dark_icon_and_font ? Color(0.34, 0.7, 1.0).lerp(p_config.mono_color, 0.6) : Color(0, 0.4, 0.68, 1);
+			colors["text_editor/theme/highlighting/member_variable_color"] = colors["text_editor/theme/highlighting/property_access_color"];
+			colors["text_editor/theme/highlighting/custom_member_variable_color"] = colors["text_editor/theme/highlighting/property_access_color"];
 			colors["text_editor/theme/highlighting/mark_color"] = Color(p_config.error_color.r, p_config.error_color.g, p_config.error_color.b, 0.3);
 			colors["text_editor/theme/highlighting/warning_color"] = Color(p_config.warning_color.r, p_config.warning_color.g, p_config.warning_color.b, 0.15);
 			colors["text_editor/theme/highlighting/bookmark_color"] = Color(0.08, 0.49, 0.98);
@@ -548,6 +551,7 @@ void EditorThemeManager::_populate_text_editor_styles(const Ref<EditorTheme> &p_
 				colors["text_editor/theme/highlighting/gdscript/node_reference_color"] = Color(0.39, 0.76, 0.35);
 				colors["text_editor/theme/highlighting/gdscript/annotation_color"] = Color(1.0, 0.7, 0.45);
 				colors["text_editor/theme/highlighting/gdscript/string_name_color"] = Color(1.0, 0.76, 0.65);
+
 				colors["text_editor/theme/highlighting/comment_markers/critical_color"] = Color(0.77, 0.35, 0.35);
 				colors["text_editor/theme/highlighting/comment_markers/warning_color"] = Color(0.72, 0.61, 0.48);
 				colors["text_editor/theme/highlighting/comment_markers/notice_color"] = Color(0.56, 0.67, 0.51);
@@ -558,6 +562,7 @@ void EditorThemeManager::_populate_text_editor_styles(const Ref<EditorTheme> &p_
 				colors["text_editor/theme/highlighting/gdscript/node_reference_color"] = Color(0.0, 0.5, 0);
 				colors["text_editor/theme/highlighting/gdscript/annotation_color"] = Color(0.8, 0.37, 0);
 				colors["text_editor/theme/highlighting/gdscript/string_name_color"] = Color(0.8, 0.56, 0.45);
+
 				colors["text_editor/theme/highlighting/comment_markers/critical_color"] = Color(0.8, 0.14, 0.14);
 				colors["text_editor/theme/highlighting/comment_markers/warning_color"] = Color(0.75, 0.39, 0.03);
 				colors["text_editor/theme/highlighting/comment_markers/notice_color"] = Color(0.24, 0.54, 0.09);

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -77,6 +77,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 	int in_type_params = 0; // The number of opened `[` after type name.
 
 	Color keyword_color;
+	Color current_member_variable_color;
 	Color color;
 
 	color_region_cache[p_line] = -1;
@@ -481,6 +482,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			} else if (member_keywords.has(word)) {
 				col = member_keywords[word];
 				in_member_variable = true;
+				current_member_variable_color = col;
 			}
 
 			if (col != Color()) {
@@ -539,7 +541,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			}
 		}
 
-		if (!in_function_name && !in_member_variable && !in_keyword && !in_number && in_word) {
+		if (!in_function_name && !in_keyword && !in_number && in_word) {
 			int k = j;
 			while (k > 0 && !is_symbol(str[k]) && !is_whitespace(str[k])) {
 				k--;
@@ -547,6 +549,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 
 			if (str[k] == '.' && (k < 1 || str[k - 1] != '.')) {
 				in_member_variable = true;
+				current_member_variable_color = property_access_color;
 			}
 		}
 
@@ -680,7 +683,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			color = keyword_color;
 		} else if (in_signal_declaration) {
 			next_type = SIGNAL;
-			color = member_variable_color;
+			color = custom_member_variable_color;
 		} else if (in_function_name) {
 			next_type = FUNCTION;
 			if (!in_lambda && in_function_declaration) {
@@ -699,7 +702,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			color = type_color;
 		} else if (in_member_variable) {
 			next_type = MEMBER;
-			color = member_variable_color;
+			color = current_member_variable_color;
 		} else {
 			next_type = IDENTIFIER;
 		}
@@ -760,17 +763,20 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 
 	font_color = text_edit->get_theme_color(SceneStringName(font_color));
 	symbol_color = EDITOR_GET("text_editor/theme/highlighting/symbol_color");
+	type_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
 	function_color = EDITOR_GET("text_editor/theme/highlighting/function_color");
 	number_color = EDITOR_GET("text_editor/theme/highlighting/number_color");
+	property_access_color = EDITOR_GET("text_editor/theme/highlighting/property_access_color");
 	member_variable_color = EDITOR_GET("text_editor/theme/highlighting/member_variable_color");
+	custom_member_variable_color = EDITOR_GET("text_editor/theme/highlighting/custom_member_variable_color");
 
 	/* Engine types. */
-	const Color types_color = EDITOR_GET("text_editor/theme/highlighting/engine_type_color");
+	const Color engine_type_color = EDITOR_GET("text_editor/theme/highlighting/engine_type_color");
 	LocalVector<StringName> types;
 	ClassDB::get_class_list(types);
 	for (const StringName &type : types) {
 		if (ClassDB::is_class_exposed(type)) {
-			class_names[type] = types_color;
+			class_names[type] = engine_type_color;
 		}
 	}
 
@@ -778,40 +784,40 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	List<StringName> global_enums;
 	CoreConstants::get_global_enums(&global_enums);
 	for (const StringName &enum_name : global_enums) {
-		class_names[enum_name] = types_color;
+		class_names[enum_name] = engine_type_color;
 	}
 
 	/* User types. */
-	const Color usertype_color = EDITOR_GET("text_editor/theme/highlighting/user_type_color");
+	const Color user_type_color = EDITOR_GET("text_editor/theme/highlighting/user_type_color");
 	LocalVector<StringName> global_classes;
 	ScriptServer::get_global_class_list(global_classes);
 	for (const StringName &class_name : global_classes) {
-		class_names[class_name] = usertype_color;
+		class_names[class_name] = user_type_color;
 	}
 
 	/* Autoloads. */
 	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : ProjectSettings::get_singleton()->get_autoload_list()) {
 		const ProjectSettings::AutoloadInfo &info = E.value;
 		if (info.is_singleton) {
-			class_names[info.name] = usertype_color;
+			class_names[info.name] = user_type_color;
 		}
 	}
 
 	const GDScriptLanguage *gdscript = GDScriptLanguage::get_singleton();
 
 	/* Core types. */
-	const Color basetype_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
+	const Color base_type_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
 	List<String> core_types;
 	gdscript->get_core_type_words(&core_types);
 	for (const String &E : core_types) {
-		class_names[StringName(E)] = basetype_color;
+		class_names[StringName(E)] = base_type_color;
 	}
-	class_names[SNAME("Variant")] = basetype_color;
-	class_names[SNAME("void")] = basetype_color;
+	class_names[SNAME("Variant")] = base_type_color;
+	class_names[SNAME("void")] = base_type_color;
 	// `get_core_type_words()` doesn't return primitive types.
-	class_names[SNAME("bool")] = basetype_color;
-	class_names[SNAME("int")] = basetype_color;
-	class_names[SNAME("float")] = basetype_color;
+	class_names[SNAME("bool")] = base_type_color;
+	class_names[SNAME("int")] = base_type_color;
+	class_names[SNAME("float")] = base_type_color;
 
 	/* Reserved words. */
 	const Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
@@ -873,7 +879,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	add_color_region(ColorRegion::TYPE_MULTILINE_STRING, "'''", "'''", string_color, false, true);
 
 	/* Members. */
-	Ref<Script> scr = _get_edited_resource();
+	const Ref<Script> scr = _get_edited_resource();
 	if (scr.is_valid()) {
 		StringName instance_base = scr->get_instance_base_type();
 		if (instance_base != StringName()) {
@@ -912,7 +918,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 			List<StringName> builtin_enums;
 			ClassDB::get_enum_list(instance_base, &builtin_enums);
 			for (const StringName &E : builtin_enums) {
-				member_keywords[E] = types_color;
+				member_keywords[E] = engine_type_color;
 			}
 		}
 
@@ -926,20 +932,20 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 			if (prop_name.contains_char('/')) {
 				continue;
 			}
-			member_keywords[prop_name] = member_variable_color;
+			member_keywords[prop_name] = custom_member_variable_color;
 		}
 
 		List<MethodInfo> scr_signal_list;
 		scr->get_script_signal_list(&scr_signal_list);
 		for (const MethodInfo &E : scr_signal_list) {
-			member_keywords[E.name] = member_variable_color;
+			member_keywords[E.name] = custom_member_variable_color;
 		}
 
 		// For callables.
 		List<MethodInfo> scr_method_list;
 		scr->get_script_method_list(&scr_method_list);
 		for (const MethodInfo &E : scr_method_list) {
-			member_keywords[E.name] = member_variable_color;
+			member_keywords[E.name] = custom_member_variable_color;
 		}
 
 		Ref<Script> scr_class = scr;
@@ -947,19 +953,21 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 			HashMap<StringName, Variant> scr_constant_list;
 			scr_class->get_constants(&scr_constant_list);
 			for (const KeyValue<StringName, Variant> &E : scr_constant_list) {
-				member_keywords[E.key.string()] = member_variable_color;
+				member_keywords[E.key.string()] = custom_member_variable_color;
 			}
 			scr_class = scr_class->get_base_script();
 		}
 	}
 
+	/* GDScript specific */
 	function_definition_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/function_definition_color");
 	global_function_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/global_function_color");
 	node_path_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/node_path_color");
 	node_ref_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/node_reference_color");
 	annotation_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/annotation_color");
 	string_name_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/string_name_color");
-	type_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
+
+	/* Comment markers */
 	comment_marker_colors[COMMENT_MARKER_CRITICAL] = EDITOR_GET("text_editor/theme/highlighting/comment_markers/critical_color");
 	comment_marker_colors[COMMENT_MARKER_WARNING] = EDITOR_GET("text_editor/theme/highlighting/comment_markers/warning_color");
 	comment_marker_colors[COMMENT_MARKER_NOTICE] = EDITOR_GET("text_editor/theme/highlighting/comment_markers/notice_color");

--- a/modules/gdscript/editor/gdscript_highlighter.h
+++ b/modules/gdscript/editor/gdscript_highlighter.h
@@ -87,7 +87,9 @@ private:
 	Color function_definition_color;
 	Color built_in_type_color;
 	Color number_color;
+	Color property_access_color;
 	Color member_variable_color;
+	Color custom_member_variable_color;
 	Color string_color;
 	Color placeholder_color;
 	Color node_path_color;


### PR DESCRIPTION
* Closes https://github.com/godotengine/godot-proposals/issues/14135.
* Depends on https://github.com/godotengine/godot/pull/115814 (a commit preceding #114917 is chosen as the parent to bypass the regression #115810).

Proposal https://github.com/godotengine/godot-proposals/issues/6428 and PR #74393 were received quite warmly, as many wanted to distinguish class members (not only native but also custom ones) from local variables. However, it seems not all users like the current behavior (especially due to limitations of the current system, which requires saving the script for class member information to be updated). Also, the editor setting mixes class members and property access (`property` in `x.property`, regardless of what `x` is).

To address these issues, I propose splitting this setting into three: native members, custom members, and property access. By default, all three have the same value.

<img width="822" height="652" alt="" src="https://github.com/user-attachments/assets/9bc99457-07ea-4b74-83c4-e743a7887372" />