### PR TITLE
Add support for dropping a Script file to create a new node in the 2D/3D editor.

### DIFF
--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -69,6 +69,7 @@
 #include "scene/gui/split_container.h"
 #include "scene/gui/subviewport_container.h"
 #include "scene/main/scene_tree.h"
+#include "scene/property_utils.h"
 #include "scene/resources/gradient.h"
 #include "scene/resources/immediate_mesh.h"
 #include "scene/resources/packed_scene.h"
@@ -5581,6 +5582,19 @@ void Node3DEditorViewport::_create_preview_node(const Vector<String> &files) con
 			preview_node->add_child(sprite);
 			add_preview = true;
 		}
+
+		Ref<Script> script = res;
+		if (script.is_valid()) {
+			String class_name = script->get_global_name();
+			String base_type = script->get_instance_base_type();
+			Sprite3D *sprite = memnew(Sprite3D);
+			sprite->set_texture(EditorNode::get_singleton()->get_class_icon(
+					class_name.is_empty() ? base_type : class_name));
+			sprite->set_billboard_mode(StandardMaterial3D::BILLBOARD_ENABLED);
+			sprite->set_pixel_size(0.005);
+			preview_node->add_child(sprite);
+			add_preview = true;
+		}
 	}
 	if (add_preview) {
 		EditorNode::get_singleton()->get_scene_root()->add_child(preview_node);
@@ -5833,6 +5847,59 @@ bool Node3DEditorViewport::_create_audio_node(Node *p_parent, const String &p_pa
 	return true;
 }
 
+bool Node3DEditorViewport::_create_node(Node *p_parent, const String &p_path, const Point2 &p_point) {
+	Ref<Script> script = ResourceLoader::load(p_path);
+	if (script.is_null()) { // invalid script
+		return false;
+	}
+
+	String class_name = script->get_global_name();
+	String base_type = script->get_instance_base_type();
+	Object *ob = ClassDB::instantiate(base_type);
+	Node *instantiated_node = Object::cast_to<Node>(ob);
+	if (!instantiated_node) { // Error on instantiation.
+		return false;
+	}
+	if (class_name.is_empty()) {
+		const String &node_name = Node::adjust_name_casing(p_path.get_file().get_basename());
+		if (!node_name.is_empty()) {
+			instantiated_node->set_name(node_name);
+		}
+	} else {
+		instantiated_node->set_name(class_name);
+		PropertyUtils::assign_custom_type_script(ob, script);
+	}
+	instantiated_node->set_script(script);
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->add_do_method(p_parent, "add_child", instantiated_node, true);
+	undo_redo->add_do_method(instantiated_node, "set_owner", EditorNode::get_singleton()->get_edited_scene());
+	undo_redo->add_do_reference(instantiated_node);
+	undo_redo->add_undo_method(p_parent, "remove_child", instantiated_node);
+	undo_redo->add_do_method(editor_selection, "add_node", instantiated_node);
+
+	const String new_name = p_parent->validate_child_name(instantiated_node);
+	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
+	undo_redo->add_do_method(ed, "live_debug_create_node", EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent), instantiated_node->get_class(), new_name);
+	undo_redo->add_undo_method(ed, "live_debug_remove_node", NodePath(String(EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent)) + "/" + new_name));
+
+	Transform3D parent_tf;
+	Node3D *parent_node3d = Object::cast_to<Node3D>(p_parent);
+	if (parent_node3d) {
+		parent_tf = parent_node3d->get_global_gizmo_transform();
+	}
+
+	if (ClassDB::has_property(instantiated_node->get_class(), "transform")) {
+		Transform3D new_tf = instantiated_node->get("transform");
+		new_tf.origin = parent_tf.affine_inverse().xform(preview_node_pos + instantiated_node->get("position"));
+		new_tf.basis = parent_tf.affine_inverse().basis * new_tf.basis;
+
+		undo_redo->add_do_method(instantiated_node, "set_transform", new_tf);
+	}
+
+	return true;
+}
+
 void Node3DEditorViewport::_perform_drop_data() {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	if (spatial_editor->get_preview_material_target().is_valid()) {
@@ -5879,6 +5946,13 @@ void Node3DEditorViewport::_perform_drop_data() {
 		Ref<AudioStream> audio = res;
 		if (audio.is_valid()) {
 			if (!_create_audio_node(target_node, path, drop_pos)) {
+				error_files.push_back(path.get_file());
+			}
+		}
+
+		Ref<Script> script = res;
+		if (script.is_valid()) {
+			if (!_create_node(target_node, path, drop_pos)) {
 				error_files.push_back(path.get_file());
 			}
 		}
@@ -5944,6 +6018,7 @@ bool Node3DEditorViewport::can_drop_data_fw(const Point2 &p_point, const Variant
 		AUDIO = 1 << 2,
 		MESH = 1 << 3,
 		MATERIAL = 1 << 4,
+		SCRIPT = 1 << 5,
 	};
 	int instantiate_type = 0;
 
@@ -5958,8 +6033,9 @@ bool Node3DEditorViewport::can_drop_data_fw(const Point2 &p_point, const Variant
 		bool is_material = ClassDB::is_parent_class(res_type, "Material");
 		bool is_texture = ClassDB::is_parent_class(res_type, "Texture");
 		bool is_audio = ClassDB::is_parent_class(res_type, "AudioStream");
+		bool is_script = ClassDB::is_parent_class(res_type, "Script");
 
-		if (is_mesh || is_scene || is_material || is_texture || is_audio) {
+		if (is_mesh || is_scene || is_material || is_texture || is_audio || is_script) {
 			Ref<Resource> res = ResourceLoader::load(files[i]);
 			if (res.is_null()) {
 				continue;
@@ -5969,6 +6045,7 @@ bool Node3DEditorViewport::can_drop_data_fw(const Point2 &p_point, const Variant
 			Ref<Material> mat = res;
 			Ref<Texture2D> tex = res;
 			Ref<AudioStream> audio = res;
+			Ref<Script> script = res;
 			if (scn.is_valid()) {
 				Node *instantiated_scene = scn->instantiate(PackedScene::GEN_EDIT_STATE_INSTANCE);
 				if (!instantiated_scene) {
@@ -6011,6 +6088,13 @@ bool Node3DEditorViewport::can_drop_data_fw(const Point2 &p_point, const Variant
 			} else if (!is_other_valid && audio.is_valid()) {
 				is_other_valid = true;
 				instantiate_type |= AUDIO;
+			} else if (!is_other_valid && script.is_valid()) {
+				String base_type = script->get_instance_base_type();
+				if (!ClassDB::is_parent_class(base_type, "Node") || ClassDB::is_parent_class(base_type, "CanvasItem") || ClassDB::is_parent_class(base_type, "Viewport")) {
+					continue;
+				}
+				is_other_valid = true;
+				instantiate_type |= SCRIPT;
 			} else {
 				continue;
 			}

--- a/editor/scene/3d/node_3d_editor_viewport.h
+++ b/editor/scene/3d/node_3d_editor_viewport.h
@@ -509,6 +509,7 @@ private:
 	bool _cyclical_dependency_exists(const String &p_target_scene_path, Node *p_desired_node) const;
 	bool _create_instance(Node *p_parent, const String &p_path, const Point2 &p_point);
 	bool _create_audio_node(Node *p_parent, const String &p_path, const Point2 &p_point);
+	bool _create_node(Node *p_parent, const String &p_path, const Point2 &p_point);
 	void _perform_drop_data();
 
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -76,6 +76,7 @@
 #include "scene/main/scene_tree.h"
 #include "scene/main/timer.h"
 #include "scene/main/window.h"
+#include "scene/property_utils.h"
 #include "scene/resources/packed_scene.h"
 #include "scene/resources/style_box_texture.h"
 #include "servers/rendering/rendering_server.h"
@@ -6261,6 +6262,19 @@ void CanvasItemEditorViewport::_create_preview(const Vector<String> &files) cons
 			preview_node->add_child(sprite);
 			add_preview = true;
 		}
+
+		Ref<Script> script = res;
+		if (script.is_valid()) {
+			String class_name = script->get_global_name();
+			String base_type = script->get_instance_base_type();
+			Sprite2D *sprite = memnew(Sprite2D);
+			sprite->set_texture(EditorNode::get_singleton()->get_class_icon(
+					class_name.is_empty() ? base_type : class_name));
+			sprite->set_modulate(Color(1, 1, 1, 0.7f));
+			sprite->set_position(Vector2(0, -sprite->get_texture()->get_size().height) * EDSCALE);
+			preview_node->add_child(sprite);
+			add_preview = true;
+		}
 	}
 
 	if (add_preview) {
@@ -6489,6 +6503,69 @@ bool CanvasItemEditorViewport::_create_instance(Node *p_parent, const String &p_
 	return true;
 }
 
+void CanvasItemEditorViewport::_create_node(Node *p_parent, const String &p_path, const Point2 &p_point) {
+	Ref<Script> script = ResourceLoader::load(p_path);
+	if (script.is_null()) { // invalid script
+		return;
+	}
+
+	String class_name = script->get_global_name();
+	String base_type = script->get_instance_base_type();
+	Object *ob = ClassDB::instantiate(base_type);
+	Node *instantiated_node = Object::cast_to<Node>(ob);
+	if (!instantiated_node) { // Error on instantiation.
+		return;
+	}
+	if (class_name.is_empty()) {
+		const String &node_name = Node::adjust_name_casing(p_path.get_file().get_basename());
+		if (!node_name.is_empty()) {
+			instantiated_node->set_name(node_name);
+		}
+	} else {
+		instantiated_node->set_name(class_name);
+		PropertyUtils::assign_custom_type_script(ob, script);
+	}
+	instantiated_node->set_script(script);
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+
+	if (p_parent) {
+		undo_redo->add_do_method(p_parent, "add_child", instantiated_node, true);
+		undo_redo->add_do_method(instantiated_node, "set_owner", EditorNode::get_singleton()->get_edited_scene());
+		undo_redo->add_do_reference(instantiated_node);
+		undo_redo->add_undo_method(p_parent, "remove_child", instantiated_node);
+	} else { // If no parent is selected, set as root node of the scene.
+		undo_redo->add_do_method(EditorNode::get_singleton(), "set_edited_scene", instantiated_node);
+		undo_redo->add_do_method(instantiated_node, "set_owner", EditorNode::get_singleton()->get_edited_scene());
+		undo_redo->add_do_reference(instantiated_node);
+		undo_redo->add_undo_method(EditorNode::get_singleton(), "set_edited_scene", (Object *)nullptr);
+	}
+
+	if (p_parent) {
+		String new_name = p_parent->validate_child_name(instantiated_node);
+		EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
+		undo_redo->add_do_method(ed, "live_debug_create_node", EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent), instantiated_node->get_class(), new_name);
+		undo_redo->add_undo_method(ed, "live_debug_remove_node", NodePath(String(EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent)) + "/" + new_name));
+	}
+
+	// Compute the global position
+	Transform2D xform = canvas_item_editor->get_canvas_transform();
+	Point2 target_position = xform.affine_inverse().xform(p_point);
+
+	// There's nothing to be used as source position, so snapping will work as absolute if enabled.
+	target_position = canvas_item_editor->snap_point(target_position);
+
+	CanvasItem *parent_ci = Object::cast_to<CanvasItem>(p_parent);
+	Point2 local_target_pos = parent_ci ? parent_ci->get_global_transform().affine_inverse().xform(target_position) : target_position;
+
+	if (ClassDB::has_property(instantiated_node->get_class(), "position")) {
+		undo_redo->add_do_method(instantiated_node, "set_position", local_target_pos);
+	}
+
+	EditorSelection *editor_selection = EditorNode::get_singleton()->get_editor_selection();
+	undo_redo->add_do_method(editor_selection, "add_node", instantiated_node);
+}
+
 void CanvasItemEditorViewport::_perform_drop_data() {
 	ERR_FAIL_COND(selected_files.is_empty());
 
@@ -6554,6 +6631,11 @@ void CanvasItemEditorViewport::_perform_drop_data() {
 		if (mesh.is_valid()) {
 			_create_mesh_node(target_node, path, drop_pos);
 		}
+
+		Ref<Script> script = res;
+		if (script.is_valid()) {
+			_create_node(target_node, path, drop_pos);
+		}
 	}
 
 	undo_redo->commit_action();
@@ -6598,6 +6680,7 @@ bool CanvasItemEditorViewport::can_drop_data(const Point2 &p_point, const Varian
 		TEXTURE = 1 << 1,
 		AUDIO = 1 << 2,
 		MESH = 1 << 3,
+		SCRIPT = 1 << 4,
 	};
 	int instantiate_type = 0;
 
@@ -6625,6 +6708,13 @@ bool CanvasItemEditorViewport::can_drop_data(const Point2 &p_point, const Varian
 			instantiate_type |= AUDIO;
 		} else if (ClassDB::is_parent_class(res_type, "Mesh")) {
 			instantiate_type |= MESH;
+		} else if (ClassDB::is_parent_class(res_type, "Script")) {
+			Ref<Script> script = ResourceLoader::load(path);
+			ERR_CONTINUE(script.is_null());
+			String base_type = script->get_instance_base_type();
+			if (ClassDB::is_parent_class(base_type, "Node") && !ClassDB::is_parent_class(base_type, "Node3D")) {
+				instantiate_type |= SCRIPT;
+			}
 		}
 	}
 

--- a/editor/scene/canvas_item_editor_plugin.h
+++ b/editor/scene/canvas_item_editor_plugin.h
@@ -690,6 +690,7 @@ class CanvasItemEditorViewport : public Control {
 	void _create_audio_node(Node *p_parent, const String &p_path, const Point2 &p_point);
 	bool _create_instance(Node *p_parent, const String &p_path, const Point2 &p_point);
 	void _create_mesh_node(Node *p_parent, const String &p_path, const Point2 &p_point);
+	void _create_node(Node *p_parent, const String &p_path, const Point2 &p_point);
 	void _perform_drop_data();
 	void _show_texture_node_type_selector();
 	void _update_theme();


### PR DESCRIPTION
This PR adds support for dropping a Script file to the 2D/3D editor to create a new node, similar to how you can drop a PackedScene to instantiate a scene. part of [#13902](https://github.com/godotengine/godot-proposals/issues/13902)