### PR TITLE
Don't allow duplicate events in input actions editor

### DIFF
--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -170,7 +170,7 @@ void ActionMapEditor::_tree_button_pressed(Object *p_item, int p_column, int p_i
 			current_action_name = item->get_meta("__name");
 			current_action_event_index = -1;
 
-			event_config_dialog->popup_and_configure(Ref<InputEvent>(), current_action_name);
+			event_config_dialog->popup_and_configure(Ref<InputEvent>(), current_action_name, current_action);
 		} break;
 		case ActionMapEditor::BUTTON_EDIT_EVENT: {
 			// Action and Action name is located on the parent of the event.
@@ -181,7 +181,7 @@ void ActionMapEditor::_tree_button_pressed(Object *p_item, int p_column, int p_i
 
 			Ref<InputEvent> ie = item->get_meta("__event");
 			if (ie.is_valid()) {
-				event_config_dialog->popup_and_configure(ie, current_action_name);
+				event_config_dialog->popup_and_configure(ie, current_action_name, current_action);
 			}
 		} break;
 		case ActionMapEditor::BUTTON_REMOVE_ACTION: {

--- a/editor/settings/input_event_configuration_dialog.h
+++ b/editor/settings/input_event_configuration_dialog.h
@@ -51,6 +51,7 @@ private:
 
 	Ref<InputEvent> event;
 	Ref<InputEvent> original_event;
+	Array action_events;
 
 	bool in_tree_update = false;
 
@@ -106,6 +107,8 @@ private:
 	HBoxContainer *location_container = nullptr;
 	OptionButton *key_location = nullptr;
 
+	Label *event_exists = nullptr;
+
 	void _set_event(const Ref<InputEvent> &p_event, const Ref<InputEvent> &p_original_event, bool p_update_input_list_selection = true);
 	void _on_listen_input_changed(const Ref<InputEvent> &p_event);
 
@@ -129,7 +132,7 @@ protected:
 public:
 	// Pass an existing event to configure it. Alternatively, pass no event to start with a blank configuration.
 	// An action name can be passed for descriptive purposes.
-	void popup_and_configure(const Ref<InputEvent> &p_event = Ref<InputEvent>(), const String &p_current_action_name = "");
+	void popup_and_configure(const Ref<InputEvent> &p_event = Ref<InputEvent>(), const String &p_current_action_name = "", const Dictionary &p_current_action = Dictionary());
 	Ref<InputEvent> get_event() const;
 
 	void set_allowed_input_types(int p_type_masks);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/87707
Fixes https://github.com/godotengine/godot/issues/95283

This PR checks if the `InputEvent` the user is trying to add to an action already exists in that action, and if it does, the user is not allowed to add it again. Previously, it was allowed.

https://github.com/user-attachments/assets/4200d551-3953-45af-bfa9-3dacb9133b34

* *Bugsquad edit, supersedes: https://github.com/godotengine/godot/pull/97673*