### PR TITLE
Fix `ScriptTextEditor` not loading editor settings on initialization

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -2674,6 +2674,8 @@ ScriptTextEditor::ScriptTextEditor() {
 
 	connection_info_dialog = memnew(ConnectionInfoDialog);
 
+	update_settings();
+
 	SET_DRAG_FORWARDING_GCD(code_editor->get_text_editor(), ScriptTextEditor);
 }
 


### PR DESCRIPTION
- Resolves https://github.com/godotengine/godot/issues/115826