### PR TITLE
Fix: Skip setting current dock when tab cannot switch [ Make EditorDocks respect panel lock ]

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -603,12 +603,13 @@ void EditorDockManager::open_dock(EditorDock *p_dock, bool p_set_current) {
 
 	// Open dock to its previous location.
 	if (p_dock->dock_slot_index != EditorDock::DOCK_SLOT_NONE) {
-		TabContainer *slot = dock_slots[p_dock->dock_slot_index];
+		DockTabContainer *slot = dock_slots[p_dock->dock_slot_index];
 		int tab_index = p_dock->previous_tab_index;
 		if (tab_index < 0) {
 			tab_index = slot->get_tab_count();
 		}
-		_move_dock(p_dock, slot, tab_index, p_set_current);
+
+		_move_dock(p_dock, slot, tab_index, p_set_current && slot->can_switch_dock());
 	} else {
 		_open_dock_in_window(p_dock, true, true);
 		return;


### PR DESCRIPTION
When opening a dock into a DockTabContainer that returns can_switch_dock() == false, avoid marking the dock as current. Previously p_set_current was passed through to _move_dock unconditionally; now we cast the slot to DockTabContainer and force set_current to false if switching is disallowed, preventing an unwanted focus/tab switch.

Revisits #115696  with a proper solution after I rethought my approach.

*Bugsquad edit:* Closes https://github.com/godotengine/godot-proposals/issues/14143