### PR TITLE
Properly handle closing floating docks

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -578,7 +578,10 @@ void EditorDockManager::close_dock(EditorDock *p_dock) {
 	}
 
 	p_dock->is_open = false;
-	p_dock->get_parent_container()->dock_closed(p_dock);
+	DockTabContainer *parent_container = p_dock->get_parent_container();
+	if (parent_container) {
+		parent_container->dock_closed(p_dock);
+	}
 
 	// Hide before moving to remove inconsistent signals.
 	p_dock->hide();


### PR DESCRIPTION
When closing a dock, check if it belongs to a separate dock_window and close that window via _close_window. If there is no dock_window, keep the previous behavior. Fixes editor crashes by checking for null values.

* *Bugsquad edit, fixes: #115837*