### PR TITLE
Add icon hint for `@icon()` annotation to the script editor

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1366,6 +1366,9 @@
 		<member name="text_editor/appearance/enable_inline_color_picker" type="bool" setter="" getter="">
 			If [code]true[/code], displays a colored button before any [Color] constructor in the script editor. Clicking on them allows the color to be modified through a color picker.
 		</member>
+		<member name="text_editor/appearance/enable_inline_icon_hint" type="bool" setter="" getter="">
+			If [code]true[/code], displays an icon hint inside [annotation @GDScript.@icon] in the script editor.
+		</member>
 		<member name="text_editor/appearance/guidelines/line_length_guideline_hard_column" type="int" setter="" getter="">
 			The column at which to display a subtle line as a line length guideline for scripts. This should generally be greater than [member text_editor/appearance/guidelines/line_length_guideline_soft_column].
 		</member>

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -446,6 +446,55 @@ void ScriptTextEditor::add_callback(const String &p_function, const PackedString
 	code_editor->get_text_editor()->end_complex_operation();
 }
 
+bool ScriptTextEditor::_is_valid_icon_info(const Dictionary &p_info) {
+	if (p_info.get_valid("icon_path").get_type() != Variant::STRING) {
+		return false;
+	}
+
+	return true;
+}
+
+Array ScriptTextEditor::_inline_icon_parse(const String &p_text) {
+	Array result;
+	int icon_start = p_text.find("@icon");
+	if (icon_start == -1) {
+		return result;
+	}
+
+	int path_start = p_text.find_char('(', icon_start + 5);
+	if (path_start == -1) {
+		return result;
+	}
+
+	int path_end = p_text.find_char(')', path_start);
+	if (path_end == -1) {
+		return result;
+	}
+
+	const String path_argument = p_text.substr(path_start + 1, path_end - path_start - 1);
+	const String stripped = path_argument.strip_edges(true, true);
+	if (stripped.length() < 2 && (stripped[0] != '"' || stripped[0] != '\'')) {
+		return result;
+	}
+
+	const char32_t string_delimiter = stripped[0];
+	if (stripped[stripped.length() - 1] != string_delimiter) {
+		return result;
+	}
+
+	const String path_string = stripped.substr(1, stripped.length() - 2);
+	if (!ResourceLoader::exists(path_string)) {
+		return result;
+	}
+
+	Dictionary icon_info;
+	icon_info["icon_path"] = path_string;
+	icon_info["column"] = path_start + 1;
+	icon_info["width_ratio"] = 1.0;
+	result.push_back(icon_info);
+	return result;
+}
+
 bool ScriptTextEditor::_is_valid_color_info(const Dictionary &p_info) {
 	if (p_info.get_valid("color").get_type() != Variant::COLOR) {
 		return false;
@@ -456,7 +505,7 @@ bool ScriptTextEditor::_is_valid_color_info(const Dictionary &p_info) {
 	return true;
 }
 
-Array ScriptTextEditor::_inline_object_parse(const String &p_text) {
+Array ScriptTextEditor::_inline_color_parse(const String &p_text) {
 	Array result;
 	int i_end_previous = 0;
 	int i_start = p_text.find("Color");
@@ -481,6 +530,7 @@ Array ScriptTextEditor::_inline_object_parse(const String &p_text) {
 		color_info["column"] = i_start;
 		color_info["width_ratio"] = 1.0;
 		color_info["color_end"] = i_par_end;
+		color_info["picking"] = true;
 
 		const String fn_name = p_text.substr(i_start + 5, i_par_start - i_start - 5);
 		const String s_params = p_text.substr(i_par_start + 1, i_par_end - i_par_start - 1);
@@ -564,6 +614,20 @@ Array ScriptTextEditor::_inline_object_parse(const String &p_text) {
 	return result;
 }
 
+Array ScriptTextEditor::_inline_object_parse(const String &p_text) {
+	Array result;
+
+	if (result.is_empty() && EDITOR_GET("text_editor/appearance/enable_inline_color_picker")) {
+		result = _inline_color_parse(p_text);
+	}
+
+	if (result.is_empty() && EDITOR_GET("text_editor/appearance/enable_inline_icon_hint")) {
+		result = _inline_icon_parse(p_text);
+	}
+
+	return result;
+}
+
 void ScriptTextEditor::_inline_object_draw(const Dictionary &p_info, const Rect2 &p_rect) {
 	if (_is_valid_color_info(p_info)) {
 		Rect2 col_rect = p_rect.grow(-4);
@@ -574,6 +638,18 @@ void ScriptTextEditor::_inline_object_draw(const Dictionary &p_info, const Rect2
 		RS::get_singleton()->canvas_item_add_rect(text_ci, p_rect.grow(-3), Color(1, 1, 1));
 		color_alpha_texture->draw_rect(text_ci, col_rect);
 		RS::get_singleton()->canvas_item_add_rect(text_ci, col_rect, Color(p_info["color"]));
+	} else if (_is_valid_icon_info(p_info)) {
+		const String icon_path = p_info["icon_path"];
+		Ref<Texture2D> texture;
+		if (!inline_textures.has(icon_path)) {
+			texture = ResourceLoader::load(icon_path);
+			inline_textures.insert(icon_path, texture);
+		} else {
+			texture = inline_textures.get(icon_path);
+		}
+		Rect2 tex_rect = p_rect.grow(-4);
+		RID text_ci = code_editor->get_text_editor()->get_text_canvas_item();
+		RS::get_singleton()->canvas_item_add_texture_rect(text_ci, tex_rect, texture->get_rid());
 	}
 }
 
@@ -732,7 +808,10 @@ void ScriptTextEditor::_update_color_text() {
 
 void ScriptTextEditor::update_settings() {
 	code_editor->get_text_editor()->set_gutter_draw(connection_gutter, EDITOR_GET("text_editor/appearance/gutters/show_info_gutter"));
-	if (EDITOR_GET("text_editor/appearance/enable_inline_color_picker")) {
+
+	bool is_inline_tools_enabled = EDITOR_GET("text_editor/appearance/enable_inline_color_picker") || EDITOR_GET("text_editor/appearance/enable_inline_icon_hint");
+
+	if (is_inline_tools_enabled) {
 		code_editor->get_text_editor()->set_inline_object_handlers(
 				callable_mp(this, &ScriptTextEditor::_inline_object_parse),
 				callable_mp(this, &ScriptTextEditor::_inline_object_draw),
@@ -823,6 +902,7 @@ void ScriptTextEditor::_validate_script() {
 	errors.clear();
 	depended_errors.clear();
 	safe_lines.clear();
+	inline_textures.clear();
 
 	Ref<Script> script = edited_res;
 	if (!script->get_language()->validate(text, script->get_path(), &fnc, &errors, &warnings, &safe_lines)) {

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -78,6 +78,7 @@ class ScriptTextEditor : public CodeEditorBase {
 	ColorPicker *inline_color_picker = nullptr;
 	OptionButton *inline_color_options = nullptr;
 	Ref<Texture2D> color_alpha_texture;
+	HashMap<String, Ref<Texture2D>> inline_textures;
 
 	ScriptEditorQuickOpen *quick_open = nullptr;
 	ConnectionInfoDialog *connection_info_dialog = nullptr;
@@ -173,15 +174,20 @@ protected:
 	void _error_clicked(const Variant &p_line);
 	virtual bool _warning_clicked(const Variant &p_line) override;
 
-	bool _is_valid_color_info(const Dictionary &p_info);
 	Array _inline_object_parse(const String &p_text);
 	void _inline_object_draw(const Dictionary &p_info, const Rect2 &p_rect);
 	void _inline_object_handle_click(const Dictionary &p_info, const Rect2 &p_rect);
+
+	bool _is_valid_color_info(const Dictionary &p_info);
+	Array _inline_color_parse(const String &p_text);
 	String _picker_color_stringify(const Color &p_color, COLOR_MODE p_mode);
 	void _picker_color_changed(const Color &p_color);
 	void _update_color_constructor_options();
 	void _update_background_color();
 	void _update_color_text();
+
+	bool _is_valid_icon_info(const Dictionary &p_info);
+	Array _inline_icon_parse(const String &p_text);
 
 	void _notification(int p_what);
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -753,6 +753,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Appearance
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/appearance/enable_inline_color_picker", true, "");
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/appearance/enable_inline_icon_hint", true, "");
 
 	// Appearance: Caret
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/appearance/caret/type", 0, "Line,Block")

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -261,6 +261,17 @@ inline bool is_inline_info_valid(const Variant &p_info) {
 	return true;
 }
 
+inline bool is_picking_inline_object(const Variant &p_info) {
+	if (p_info.get_type() != Variant::DICTIONARY) {
+		return false;
+	}
+	Dictionary info = p_info;
+	if (info.get_valid("picking").get_type() == Variant::BOOL && info["picking"]) {
+		return true;
+	}
+	return false;
+}
+
 void TextEdit::Text::invalidate_cache(int p_line, bool p_text_changed) {
 	ERR_FAIL_INDEX(p_line, text.size());
 
@@ -3620,7 +3631,7 @@ Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
 
 		Ref<TextParagraph> ldata = text.get_line_data(pos.y);
 		for (Variant k : ldata->get_line_objects(wrap_i)) {
-			if (!is_inline_info_valid(k)) {
+			if (!is_inline_info_valid(k) || !is_picking_inline_object(k)) {
 				continue;
 			}
 			Rect2 obj_rect = ldata->get_line_object_rect(wrap_i, k);


### PR DESCRIPTION
- Closes: https://github.com/godotengine/godot-proposals/issues/14131

## Example

| Before | After |
|-------|-----|
| <img width="197" height="111" alt="before_fix" src="https://github.com/user-attachments/assets/6213d05f-0f73-4fb5-98d0-2c8861ecea6e" /> | <img width="197" height="111" alt="after_fix" src="https://github.com/user-attachments/assets/0b05b04e-5899-411e-9ca9-b6b1b640161e" /> |