### PR TITLE
LSP: Log startup errors

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_server.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_server.cpp
@@ -80,11 +80,14 @@ void DebugAdapterServer::_notification(int p_what) {
 
 void DebugAdapterServer::start() {
 	remote_port = (DebugAdapterServer::port_override > -1) ? DebugAdapterServer::port_override : (int)_EDITOR_GET("network/debug_adapter/remote_port");
-	if (protocol.start(remote_port, IPAddress("127.0.0.1")) == OK) {
-		EditorNode::get_log()->add_message("--- Debug adapter server started on port " + itos(remote_port) + " ---", EditorLog::MSG_TYPE_EDITOR);
-		set_process_internal(true);
-		started = true;
+	const Error status = protocol.start(remote_port, IPAddress("127.0.0.1"));
+	if (status != OK) {
+		EditorNode::get_log()->add_message("--- Failed to start Debug adapter server on port " + itos(remote_port) + ": " + error_names[status] + " ---", EditorLog::MSG_TYPE_EDITOR);
+		return;
 	}
+	EditorNode::get_log()->add_message("--- Debug adapter server started on port " + itos(remote_port) + " ---", EditorLog::MSG_TYPE_EDITOR);
+	set_process_internal(true);
+	started = true;
 }
 
 void DebugAdapterServer::stop() {

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -90,15 +90,18 @@ void GDScriptLanguageServer::start() {
 	port = (GDScriptLanguageServer::port_override > -1) ? GDScriptLanguageServer::port_override : (int)_EDITOR_GET("network/language_server/remote_port");
 	use_thread = (bool)_EDITOR_GET("network/language_server/use_thread");
 	poll_limit_usec = (int)_EDITOR_GET("network/language_server/poll_limit_usec");
-	if (GDScriptLanguageProtocol::get_singleton()->start(port, IPAddress(host)) == OK) {
-		EditorNode::get_log()->add_message("--- GDScript language server started on port " + itos(port) + " ---", EditorLog::MSG_TYPE_EDITOR);
-		if (use_thread) {
-			thread_running = true;
-			thread.start(GDScriptLanguageServer::thread_main, this);
-		}
-		set_process_internal(!use_thread);
-		started = true;
+	const Error status = GDScriptLanguageProtocol::get_singleton()->start(port, IPAddress(host));
+	if (status != OK) {
+		EditorNode::get_log()->add_message("--- Failed to start GDScript language server on port " + itos(port) + ": " + error_names[status] + " ---", EditorLog::MSG_TYPE_EDITOR);
+		return;
 	}
+	EditorNode::get_log()->add_message("--- GDScript language server started on port " + itos(port) + " ---", EditorLog::MSG_TYPE_EDITOR);
+	if (use_thread) {
+		thread_running = true;
+		thread.start(GDScriptLanguageServer::thread_main, this);
+	}
+	set_process_internal(!use_thread);
+	started = true;
 }
 
 void GDScriptLanguageServer::stop() {


### PR DESCRIPTION
fixes: https://github.com/godotengine/godot/issues/115722
Add check to LSP startup to log why it is not starting, to make it easier to find a potential cause for issues with the LSP