### PR TITLE
Suppress convex-decompose error spam for < 3 point polygons

### DIFF
--- a/editor/scene/2d/abstract_polygon_2d_editor.cpp
+++ b/editor/scene/2d/abstract_polygon_2d_editor.cpp
@@ -136,6 +136,9 @@ Vector2 AbstractPolygon2DEditor::_get_geometric_center() const {
 	int n_subs = 0;
 	for (int i = 0; i < n_polygons; i++) {
 		const Vector<Vector2> &vertices = _get_polygon(i);
+		if (vertices.size() < 3) {
+			continue;
+		}
 		Vector<Vector<Point2>> decomp = ::Geometry2D::decompose_polygon_in_convex(vertices);
 		if (decomp.is_empty()) {
 			continue;


### PR DESCRIPTION
While looping through the polygons, a new counter is introduced that tracks total number of points. If that number ends up being less than 3, then do not produce an error. This gets rid of error spam when a CollisionPolygon2D node is first added in the editor.

I could easily add a check to see if this method is running inside editor or runtime, but I just left that out for now.
