### PR TITLE
Editor Help: Change the default icon for inheritance hierarchy to `Object`

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -1010,7 +1010,7 @@ void EditorHelp::_update_doc() {
 
 		String inherits = cd.inherits;
 		while (!inherits.is_empty()) {
-			_add_type_icon(inherits, theme_cache.doc_font_size, "ArrowRight");
+			_add_type_icon(inherits, theme_cache.doc_font_size, "Object");
 			class_desc->add_text(nbsp); // Otherwise icon borrows hyperlink from `_add_type()`.
 			_add_type(inherits);
 
@@ -1039,7 +1039,7 @@ void EditorHelp::_update_doc() {
 				class_desc->add_text(" , ");
 			}
 
-			_add_type_icon(itr->get(), theme_cache.doc_font_size, "ArrowRight");
+			_add_type_icon(itr->get(), theme_cache.doc_font_size, "Object");
 			class_desc->add_text(nbsp); // Otherwise icon borrows hyperlink from `_add_type()`.
 			_add_type(itr->get());
 		}


### PR DESCRIPTION
- Closes godotengine/godot-docs/issues/11684

Changes the default from being a right arrow to a cube. This aligns with the header section in the in editor docs, and prevents having 2 opposite facing arrows next to each other.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
