### PR TITLE
Allow editing GDExtensions from inside project settings

### DIFF
--- a/editor/settings/gdextension/gdextension_edit_dialog.cpp
+++ b/editor/settings/gdextension/gdextension_edit_dialog.cpp
@@ -1,0 +1,249 @@
+/**************************************************************************/
+/*  gdextension_edit_dialog.cpp                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdextension_edit_dialog.h"
+
+#include "core/extension/gdextension_manager.h"
+#include "core/io/config_file.h"
+#include "core/object/callable_mp.h"
+#include "core/version.h"
+#include "editor/gui/editor_validation_panel.h"
+#include "editor/inspector/editor_properties_array_dict.h"
+#include "editor/themes/editor_scale.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/grid_container.h"
+#include "scene/gui/line_edit.h"
+
+void GDExtensionEditDialog::load_gdextension_config(const String &p_path) {
+	Ref<ConfigFile> config;
+	config.instantiate();
+	Error err = config->load(p_path);
+	ERR_FAIL_COND_MSG(err != OK, "Error loading GDExtension configuration file: " + p_path);
+	gdextension_path->set_text(p_path);
+	// Get configuration keys.
+	entry_symbol_edit->set_text(config->get_value("configuration", "entry_symbol", ""));
+	compat_max_version_edit->set_text(config->get_value("configuration", "compatibility_maximum", ""));
+	compat_min_version_edit->set_text(config->get_value("configuration", "compatibility_minimum", GODOT_VERSION_BRANCH));
+	reloadable_checkbox->set_pressed(config->get_value("configuration", "reloadable", false));
+	// Update validation.
+	validation_panel->update();
+}
+
+void GDExtensionEditDialog::_clear_fields() {
+	entry_symbol_edit->clear();
+	compat_max_version_edit->clear();
+	compat_min_version_edit->clear();
+}
+
+void GDExtensionEditDialog::_on_canceled() {
+	_clear_fields();
+	emit_signal("gdextension_editor_closed");
+}
+
+void GDExtensionEditDialog::_on_confirmed() {
+	// Start with the old config to avoid erasing custom keys.
+	const String gdext_res_path = gdextension_path->get_text();
+	Ref<ConfigFile> config;
+	config.instantiate();
+	Error err = config->load(gdext_res_path);
+	ERR_FAIL_COND_MSG(err != OK, "Error loading GDExtension configuration file: " + gdext_res_path);
+	// Set configuration keys.
+	config->set_value("configuration", "entry_symbol", entry_symbol_edit->get_text());
+	config->set_value("configuration", "compatibility_minimum", compat_min_version_edit->get_text());
+	const String compat_max = compat_max_version_edit->get_text();
+	if (compat_max.is_empty()) {
+		if (config->has_section_key("configuration", "compatibility_maximum")) {
+			config->erase_section_key("configuration", "compatibility_maximum");
+		}
+	} else {
+		config->set_value("configuration", "compatibility_maximum", compat_max);
+	}
+	const bool is_reloadable = reloadable_checkbox->is_pressed();
+	config->set_value("configuration", "reloadable", is_reloadable);
+	// Save and reload.
+	config->save(gdext_res_path);
+	_clear_fields();
+	GDExtensionManager *gdext_man = GDExtensionManager::get_singleton();
+	const bool was_reloadable = gdext_man->get_extension(gdext_res_path)->is_reloadable();
+	if (is_reloadable != was_reloadable) {
+		WARN_PRINT("Saved GDExtension changes to " + gdext_res_path + " and changed reloadable from " + String(was_reloadable ? "true" : "false") + " to " + String(is_reloadable ? "true" : "false") + ". You need to restart Godot to apply the change.");
+	} else if (is_reloadable) {
+		gdext_man->reload_extension(gdext_res_path);
+	} else {
+		WARN_PRINT("Saved GDExtension changes to " + gdext_res_path + ", but the extension is not marked as reloadable. You need to restart Godot to apply the change.");
+	}
+	emit_signal("gdextension_editor_closed");
+}
+
+#define IS_BEFORE_CURRENT_GODOT_VERSION(m_parts) (m_parts[0] < GODOT_VERSION_MAJOR || (m_parts[0] == GODOT_VERSION_MAJOR && (m_parts[1] < GODOT_VERSION_MINOR || (m_parts[1] == GODOT_VERSION_MINOR && (m_parts.size() > 2 && m_parts[2] < GODOT_VERSION_PATCH)))))
+#define IS_AFTER_CURRENT_GODOT_VERSION(m_parts) (m_parts[0] > GODOT_VERSION_MAJOR || (m_parts[0] == GODOT_VERSION_MAJOR && (m_parts[1] > GODOT_VERSION_MINOR || (m_parts[1] == GODOT_VERSION_MINOR && (m_parts.size() > 2 && m_parts[2] > GODOT_VERSION_PATCH)))))
+
+void GDExtensionEditDialog::_on_required_text_changed() {
+	// Entry symbol must be a valid programming language identifier.
+	String entry_symbol = entry_symbol_edit->get_text();
+	if (!entry_symbol.is_valid_identifier()) {
+		validation_panel->set_message(MSG_ID_ENTRY_SYMBOL_NAME, TTRC("Entry symbol is not a valid identifier."), EditorValidationPanel::MSG_ERROR);
+	}
+	// Compatibility minimum is required to be at least 4.1.0.
+	String compat_min_text = compat_min_version_edit->get_text();
+	Vector<int> compat_min_parts = compat_min_text.split_ints(".");
+	if (compat_min_parts.size() < 2) {
+		validation_panel->set_message(MSG_ID_COMPAT_MIN_VERSION, TTRC("Compat min version must be in X.Y or X.Y.Z format."), EditorValidationPanel::MSG_ERROR);
+	} else if (compat_min_parts[0] < 4 || (compat_min_parts[0] == 4 && compat_min_parts[1] == 0)) {
+		validation_panel->set_message(MSG_ID_COMPAT_MIN_VERSION, TTRC("Compat min version must be at least 4.1.0."), EditorValidationPanel::MSG_ERROR);
+	} else if (IS_AFTER_CURRENT_GODOT_VERSION(compat_min_parts)) {
+		validation_panel->set_message(MSG_ID_COMPAT_MIN_VERSION, TTRC("Compat min version cannot be after the current Godot version."), EditorValidationPanel::MSG_ERROR);
+	}
+	// Compatibility maximum is optional but must be at least 4.3.0 if set.
+	String compat_max_text = compat_max_version_edit->get_text();
+	if (compat_max_text.is_empty()) {
+		validation_panel->set_message(MSG_ID_COMPAT_MAX_VERSION, TTRC("Compatibility maximum version is optional."), EditorValidationPanel::MSG_INFO);
+	} else {
+		Vector<int> compat_max_parts = compat_max_text.split_ints(".");
+		if (compat_max_parts.size() < 2) {
+			validation_panel->set_message(MSG_ID_COMPAT_MAX_VERSION, TTRC("Compat max version must be in X.Y or X.Y.Z format."), EditorValidationPanel::MSG_ERROR);
+		} else if (IS_BEFORE_CURRENT_GODOT_VERSION(compat_max_parts)) {
+			validation_panel->set_message(MSG_ID_COMPAT_MAX_VERSION, TTRC("Compat max version cannot be before the current Godot version."), EditorValidationPanel::MSG_ERROR);
+		}
+	}
+}
+
+#undef IS_BEFORE_CURRENT_GODOT_VERSION
+#undef IS_AFTER_CURRENT_GODOT_VERSION
+
+void GDExtensionEditDialog::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("gdextension_editor_closed"));
+}
+
+void GDExtensionEditDialog::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_READY: {
+			connect(SceneStringName(confirmed), callable_mp(this, &GDExtensionEditDialog::_on_confirmed));
+			connect(SceneStringName(canceled), callable_mp(this, &GDExtensionEditDialog::_on_canceled));
+		} break;
+	}
+}
+
+GDExtensionEditDialog::GDExtensionEditDialog() {
+	get_ok_button()->set_disabled(true);
+	get_ok_button()->set_text(TTRC("Save"));
+	set_hide_on_ok(true);
+	set_title(TTRC("Edit GDExtension"));
+	set_min_size(Size2(400, 300) * EDSCALE);
+
+	VBoxContainer *vbox = memnew(VBoxContainer);
+	vbox->set_custom_minimum_size(Size2(400, 150) * EDSCALE);
+	vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	add_child(vbox);
+
+	GridContainer *grid = memnew(GridContainer);
+	grid->set_columns(2);
+	grid->set_custom_minimum_size(Size2(400, 150) * EDSCALE);
+	grid->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	grid->set_v_size_flags(Control::SIZE_SHRINK_BEGIN);
+	vbox->add_child(grid);
+
+	// GDExtension file path (read-only).
+	Label *gdextension_path_label = memnew(Label);
+	gdextension_path_label->set_text(TTRC("Path:"));
+	gdextension_path_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+	grid->add_child(gdextension_path_label);
+
+	gdextension_path = memnew(Label);
+	gdextension_path->set_text("res://addons/my_extension/my_extension.gdextension");
+	gdextension_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	grid->add_child(gdextension_path);
+
+	// Entry symbol.
+	Label *entry_symbol_label = memnew(Label);
+	entry_symbol_label->set_text(TTRC("Entry Symbol:"));
+	entry_symbol_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+	grid->add_child(entry_symbol_label);
+
+	entry_symbol_edit = memnew(LineEdit);
+	entry_symbol_edit->set_placeholder("libname_library_init");
+	entry_symbol_edit->set_tooltip_text(TTRC("Required. The symbol to use as the entry point for the extension."));
+	entry_symbol_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	grid->add_child(entry_symbol_edit);
+
+	// Compatibility min version.
+	Label *compat_min_version_label = memnew(Label);
+	compat_min_version_label->set_text(TTRC("Compat Min Version:"));
+	compat_min_version_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+	grid->add_child(compat_min_version_label);
+
+	compat_min_version_edit = memnew(LineEdit);
+	compat_min_version_edit->set_placeholder(GODOT_VERSION_BRANCH);
+	compat_min_version_edit->set_tooltip_text(TTRC("Required. The minimum version of Godot that the extension is compatible with."));
+	compat_min_version_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	grid->add_child(compat_min_version_edit);
+
+	// Compatibility max version.
+	Label *compat_max_version_label = memnew(Label);
+	compat_max_version_label->set_text(TTRC("Compat Max Version:"));
+	compat_max_version_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+	grid->add_child(compat_max_version_label);
+
+	compat_max_version_edit = memnew(LineEdit);
+	compat_max_version_edit->set_placeholder("<no maximum>");
+	compat_max_version_edit->set_tooltip_text(TTRC("Optional. The maximum version of Godot that the extension is compatible with."));
+	compat_max_version_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	grid->add_child(compat_max_version_edit);
+
+	// Reloadable checkbox.
+	Label *reloadable_label = memnew(Label);
+	reloadable_label->set_text(TTRC("Reloadable:"));
+	reloadable_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+	grid->add_child(reloadable_label);
+
+	reloadable_checkbox = memnew(CheckBox);
+	reloadable_checkbox->set_tooltip_text(TTRC("Optional. Whether the extension can be reloaded at runtime. Recommended to be true for most extensions."));
+	reloadable_checkbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	grid->add_child(reloadable_checkbox);
+
+	Control *spacing = memnew(Control);
+	spacing->set_custom_minimum_size(Size2(0, 4 * EDSCALE));
+	vbox->add_child(spacing);
+
+	validation_panel = memnew(EditorValidationPanel);
+	validation_panel->set_custom_minimum_size(Size2(500, 120) * EDSCALE);
+	validation_panel->set_v_size_flags(Control::SIZE_SHRINK_END);
+	validation_panel->add_line(MSG_ID_ENTRY_SYMBOL_NAME, TTRC("Entry symbol is valid (must exist in the initialize_gdextension file)."));
+	validation_panel->add_line(MSG_ID_COMPAT_MIN_VERSION, TTRC("Compatibility minimum version is valid."));
+	validation_panel->add_line(MSG_ID_COMPAT_MAX_VERSION, TTRC("Compatibility maximum version is valid."));
+	validation_panel->set_update_callback(callable_mp(this, &GDExtensionEditDialog::_on_required_text_changed));
+	validation_panel->set_accept_button(get_ok_button());
+	vbox->add_child(validation_panel);
+
+	entry_symbol_edit->connect(SceneStringName(text_changed), callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
+	compat_min_version_edit->connect(SceneStringName(text_changed), callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
+	compat_max_version_edit->connect(SceneStringName(text_changed), callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
+}

--- a/editor/settings/gdextension/gdextension_edit_dialog.h
+++ b/editor/settings/gdextension/gdextension_edit_dialog.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  project_settings_gdextension.h                                        */
+/*  gdextension_edit_dialog.h                                             */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,33 +30,39 @@
 
 #pragma once
 
-#include "scene/gui/box_container.h"
+#include "scene/gui/dialogs.h"
 
-class GDExtensionEditDialog;
-class Tree;
+class CheckBox;
+class EditorPropertyDictionary;
+class EditorValidationPanel;
+class LineEdit;
 
-class ProjectSettingsGDExtension : public VBoxContainer {
-	GDCLASS(ProjectSettingsGDExtension, VBoxContainer);
+class GDExtensionEditDialog : public ConfirmationDialog {
+	GDCLASS(GDExtensionEditDialog, ConfirmationDialog);
 
 	enum {
-		COLUMN_PATH,
-		COLUMN_MIN_VERSION,
-		COLUMN_MAX_VERSION,
-		COLUMN_EDIT,
-		COLUMN_RELOAD,
-		COLUMN_MAX,
+		MSG_ID_ENTRY_SYMBOL_NAME,
+		MSG_ID_COMPAT_MIN_VERSION,
+		MSG_ID_COMPAT_MAX_VERSION,
 	};
 
-	GDExtensionEditDialog *edit_dialog = nullptr;
-	Tree *extension_list = nullptr;
+	Label *gdextension_path = nullptr;
+	LineEdit *entry_symbol_edit = nullptr;
+	LineEdit *compat_max_version_edit = nullptr;
+	LineEdit *compat_min_version_edit = nullptr;
+	CheckBox *reloadable_checkbox = nullptr;
+	EditorValidationPanel *validation_panel = nullptr;
 
-	void _cell_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
-	void _on_item_activated();
-	void _update_extension_tree();
+	void _clear_fields();
+	void _on_canceled();
+	void _on_confirmed();
+	void _on_required_text_changed();
 
 protected:
+	static void _bind_methods();
 	void _notification(int p_what);
 
 public:
-	ProjectSettingsGDExtension();
+	void load_gdextension_config(const String &p_path);
+	GDExtensionEditDialog();
 };

--- a/editor/settings/gdextension/project_settings_gdextension.cpp
+++ b/editor/settings/gdextension/project_settings_gdextension.cpp
@@ -35,6 +35,7 @@
 #include "core/io/config_file.h"
 #include "core/object/callable_mp.h"
 #include "core/os/os.h"
+#include "editor/settings/gdextension/gdextension_edit_dialog.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/label.h"
 #include "scene/gui/tree.h"
@@ -50,6 +51,7 @@ void ProjectSettingsGDExtension::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_READY: {
+			edit_dialog->connect("gdextension_editor_closed", callable_mp(this, &ProjectSettingsGDExtension::_update_extension_tree));
 			extension_list->connect("button_clicked", callable_mp(this, &ProjectSettingsGDExtension::_cell_button_pressed));
 			extension_list->connect("item_activated", callable_mp(this, &ProjectSettingsGDExtension::_on_item_activated));
 		} break;
@@ -64,7 +66,11 @@ void ProjectSettingsGDExtension::_cell_button_pressed(Object *p_item, int p_colu
 	if (item == nullptr) {
 		return;
 	}
-	if (p_id == COLUMN_RELOAD) {
+	if (p_id == COLUMN_EDIT) {
+		const String path = item->get_metadata(COLUMN_PATH);
+		edit_dialog->load_gdextension_config(path);
+		edit_dialog->popup_centered(Size2(400, 300) * EDSCALE);
+	} else if (p_id == COLUMN_RELOAD) {
 		const String path = item->get_metadata(COLUMN_PATH);
 		GDExtensionManager::get_singleton()->reload_extension(path);
 		_update_extension_tree();
@@ -96,6 +102,7 @@ void ProjectSettingsGDExtension::_update_extension_tree() {
 		ERR_CONTINUE(err != OK);
 		item->set_text(COLUMN_MIN_VERSION, gdext_config->get_value("configuration", "compatibility_minimum", ""));
 		item->set_text(COLUMN_MAX_VERSION, gdext_config->get_value("configuration", "compatibility_maximum", ""));
+		item->add_button(COLUMN_EDIT, get_editor_theme_icon(SNAME("Edit")), COLUMN_EDIT, false, TTRC("Edit Extension"));
 		if (gdextension->is_reloadable()) {
 			item->add_button(COLUMN_RELOAD, get_editor_theme_icon(SNAME("Reload")), COLUMN_RELOAD, false, TTRC("Reload Extension"));
 		}
@@ -104,6 +111,8 @@ void ProjectSettingsGDExtension::_update_extension_tree() {
 }
 
 ProjectSettingsGDExtension::ProjectSettingsGDExtension() {
+	edit_dialog = memnew(GDExtensionEditDialog);
+	add_child(edit_dialog);
 	// Create the title label.
 	HBoxContainer *title_hb = memnew(HBoxContainer);
 	Label *label = memnew(Label(TTRC("Installed GDExtensions:")));
@@ -123,22 +132,27 @@ ProjectSettingsGDExtension::ProjectSettingsGDExtension() {
 	extension_list->set_column_title(COLUMN_PATH, TTRC("Path"));
 	extension_list->set_column_title(COLUMN_MIN_VERSION, TTRC("Min Version"));
 	extension_list->set_column_title(COLUMN_MAX_VERSION, TTRC("Max Version"));
+	extension_list->set_column_title(COLUMN_EDIT, TTRC("Edit"));
 	extension_list->set_column_title(COLUMN_RELOAD, TTRC("Reload"));
 	extension_list->set_column_title_alignment(COLUMN_PATH, HORIZONTAL_ALIGNMENT_LEFT);
 	extension_list->set_column_title_alignment(COLUMN_MIN_VERSION, HORIZONTAL_ALIGNMENT_LEFT);
 	extension_list->set_column_title_alignment(COLUMN_MAX_VERSION, HORIZONTAL_ALIGNMENT_LEFT);
+	extension_list->set_column_title_alignment(COLUMN_EDIT, HORIZONTAL_ALIGNMENT_LEFT);
 	extension_list->set_column_title_alignment(COLUMN_RELOAD, HORIZONTAL_ALIGNMENT_LEFT);
 	extension_list->set_column_expand(COLUMN_PATH, true);
 	extension_list->set_column_expand(COLUMN_MIN_VERSION, false);
 	extension_list->set_column_expand(COLUMN_MAX_VERSION, false);
+	extension_list->set_column_expand(COLUMN_EDIT, false);
 	extension_list->set_column_expand(COLUMN_RELOAD, false);
 	extension_list->set_column_clip_content(COLUMN_PATH, true);
 	extension_list->set_column_clip_content(COLUMN_MIN_VERSION, true);
 	extension_list->set_column_clip_content(COLUMN_MAX_VERSION, true);
+	extension_list->set_column_clip_content(COLUMN_EDIT, true);
 	extension_list->set_column_clip_content(COLUMN_RELOAD, true);
 	extension_list->set_column_custom_minimum_width(COLUMN_PATH, 300 * EDSCALE);
 	extension_list->set_column_custom_minimum_width(COLUMN_MIN_VERSION, 100 * EDSCALE);
 	extension_list->set_column_custom_minimum_width(COLUMN_MAX_VERSION, 100 * EDSCALE);
+	extension_list->set_column_custom_minimum_width(COLUMN_EDIT, 40 * EDSCALE);
 	extension_list->set_column_custom_minimum_width(COLUMN_RELOAD, 40 * EDSCALE);
 	add_child(extension_list);
 }

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -145,6 +145,7 @@ public:
 	const StringName panel = "panel";
 	const StringName item_selected = "item_selected";
 	const StringName confirmed = "confirmed";
+	const StringName canceled = "canceled";
 
 	const StringName text_changed = "text_changed";
 	const StringName text_submitted = "text_submitted";


### PR DESCRIPTION
This PR adds a GUI to view and edit GDExtensions from inside the Project Settings dialog.

<img width="1200" height="722" alt="Screenshot 2026-02-03 at 2 36 23 PM" src="https://github.com/user-attachments/assets/525cca87-62b3-4d33-bfe4-7faceb2677f7" />

This code was originally in PR #90979, but I separate it out by request. This would need to be merged first before PR #90979 is ready to merge, because this is a subset of PR #90979.

See this proposal https://github.com/godotengine/godot-proposals/issues/13518 note that in a previous version of PR #90979 I included the ability to edit libraries and icons as requested by this proposal but I was told to remove it because it had bad UX, this is something that can be added in later if someone figures out good UX for it.