### PR TITLE
Expose `add_inline_control` from `EditorProperty` to scripting

### DIFF
--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -29,6 +29,14 @@
 				If any of the controls added can gain keyboard focus, add it here. This ensures that focus will be restored if the inspector is refreshed.
 			</description>
 		</method>
+		<method name="add_inline_control">
+			<return type="void" />
+			<param index="0" name="control" type="Control" />
+			<param index="1" name="side" type="int" enum="EditorProperty.InlineControlSide" />
+			<description>
+				Adds a [Control] to the [param side] of the edited property.
+			</description>
+		</method>
 		<method name="deselect">
 			<return type="void" />
 			<description>
@@ -232,4 +240,12 @@
 			</description>
 		</signal>
 	</signals>
+	<constants>
+		<constant name="INLINE_CONTROL_LEFT" value="0" enum="InlineControlSide">
+			The left side of the edited property.
+		</constant>
+		<constant name="INLINE_CONTROL_RIGHT" value="1" enum="InlineControlSide">
+			The right side of the edited property
+		</constant>
+	</constants>
 </class>

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1498,6 +1498,7 @@ void EditorProperty::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_name_split_ratio", "ratio"), &EditorProperty::set_name_split_ratio);
 	ClassDB::bind_method(D_METHOD("get_name_split_ratio"), &EditorProperty::get_name_split_ratio);
 
+	ClassDB::bind_method(D_METHOD("add_inline_control", "control", "side"), &EditorProperty::add_inline_control);
 	ClassDB::bind_method(D_METHOD("deselect"), &EditorProperty::deselect);
 	ClassDB::bind_method(D_METHOD("is_selected"), &EditorProperty::is_selected);
 	ClassDB::bind_method(D_METHOD("select", "focusable"), &EditorProperty::select, DEFVAL(-1));
@@ -1537,6 +1538,9 @@ void EditorProperty::_bind_methods() {
 	GDVIRTUAL_BIND(_set_read_only, "read_only")
 
 	ClassDB::bind_method(D_METHOD("_update_editor_property_status"), &EditorProperty::update_editor_property_status);
+
+	BIND_ENUM_CONSTANT(INLINE_CONTROL_LEFT);
+	BIND_ENUM_CONSTANT(INLINE_CONTROL_RIGHT);
 }
 
 EditorProperty::EditorProperty() {

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -329,6 +329,8 @@ public:
 	EditorProperty();
 };
 
+VARIANT_ENUM_CAST(EditorProperty::InlineControlSide);
+
 class EditorInspectorPlugin : public RefCounted {
 	GDCLASS(EditorInspectorPlugin, RefCounted);
 


### PR DESCRIPTION
This PR exposes the `add_inline_control` method and the `InlineControlSide` enum from `EditorProperty` to scripting. This is a feature that was introduced in https://github.com/godotengine/godot/pull/103257 but wasn't exposed. I thought it would be useful to add for more customization of editor properties, so here it is.

Documentation might need some tweaking as English isn't my first language.