### PR TITLE
Add an example helper for chmod flags in `DirAccess.copy()` documentation

### DIFF
--- a/doc/classes/DirAccess.xml
+++ b/doc/classes/DirAccess.xml
@@ -82,8 +82,43 @@
 			<param index="2" name="chmod_flags" type="int" default="-1" />
 			<description>
 				Copies the [param from] file to the [param to] destination. Both arguments should be paths to files, either relative or absolute. If the destination file exists and is not access-protected, it will be overwritten.
-				If [param chmod_flags] is different than [code]-1[/code], the Unix permissions for the destination path will be set to the provided value, if available on the current operating system.
+				If [param chmod_flags] is different than [code]-1[/code], the Unix permissions for the destination path will be set to the provided value, if available on the current operating system. [param chmod_flags] is normally expressed in octal form, with each number representing the user, group, and others permissions (e.g. [code]644[/code] means the owner can read and write, the group can only read, and others can only read). See also [method FileAccess.set_unix_permissions] and [method FileAccess.get_unix_permissions] to set or query permissions of existing files.
 				Returns one of the [enum Error] code constants ([constant OK] on success).
+				Binary operations can be used to compute chmod values:
+				[codeblocks]
+				[gdscript]
+				func _ready():
+					# The `%o` format specifier is used to print the permissions in octal form,
+					# which is the standard way to represent UNIX permissions.
+					const FORMAT = "%04o"
+
+					var permissions_owner_only = (
+							FileAccess.UNIX_READ_OWNER | FileAccess.UNIX_WRITE_OWNER
+					) # 384 in decimal form (600 in octal form)
+					print(FORMAT % permissions_owner_only)
+
+					# Default UNIX permissions are 644 on files, 755 on folders.
+					# On folders, the "execute" permission determines whether the user can list files in the folder.
+					var permissions_default_file = (
+							FileAccess.UNIX_READ_OWNER | FileAccess.UNIX_WRITE_OWNER |
+							FileAccess.UNIX_READ_GROUP |
+							FileAccess.UNIX_READ_OTHER
+					) # 420 in decimal form (644 in octal form)
+					print(FORMAT % permissions_default_file)
+
+					var all_permissions_for_everyone = (
+							FileAccess.UNIX_READ_OWNER | FileAccess.UNIX_WRITE_OWNER | FileAccess.UNIX_EXECUTE_OWNER |
+							FileAccess.UNIX_READ_GROUP | FileAccess.UNIX_WRITE_GROUP | FileAccess.UNIX_EXECUTE_GROUP |
+							FileAccess.UNIX_READ_OTHER | FileAccess.UNIX_WRITE_OTHER | FileAccess.UNIX_EXECUTE_OTHER
+					) # 511 in decimal form (777 in octal form)
+					print(FORMAT % all_permissions_for_everyone)
+
+					var da = DirAccess.open("res://")
+					da.copy("res://source.txt", "res://600.txt", permissions_owner_only)
+					da.copy("res://source.txt", "res://644.txt", permissions_default_file)
+					da.copy("res://source.txt", "res://777.txt", all_permissions_for_everyone)
+				[/gdscript]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="copy_absolute" qualifiers="static">

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -333,7 +333,7 @@
 			<return type="int" enum="FileAccess.UnixPermissionFlags" is_bitfield="true" />
 			<param index="0" name="file" type="String" />
 			<description>
-				Returns the UNIX permissions of the file at the given path.
+				Returns the UNIX permissions of the file at the given path. See also [method set_unix_permissions].
 				[b]Note:[/b] This method is implemented on iOS, Linux/BSD, and macOS.
 			</description>
 		</method>
@@ -477,7 +477,7 @@
 			<param index="0" name="file" type="String" />
 			<param index="1" name="permissions" type="int" enum="FileAccess.UnixPermissionFlags" is_bitfield="true" />
 			<description>
-				Sets file UNIX permissions.
+				Sets file UNIX permissions. See also [method DirAccess.copy], which can change flags directly when copying a file.
 				[b]Note:[/b] This method is implemented on iOS, Linux/BSD, and macOS.
 			</description>
 		</method>


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot-docs/issues/11720.
