### PR TITLE
LSP: Optimize `find_usages_in_file`

### DIFF
--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -433,7 +433,7 @@ bool GDScriptWorkspace::can_rename(const LSP::TextDocumentPositionParams &p_doc_
 Vector<LSP::Location> GDScriptWorkspace::find_usages_in_file(const LSP::DocumentSymbol &p_symbol, const String &p_file_path) {
 	Vector<LSP::Location> usages;
 
-	String identifier = p_symbol.name;
+	const String &identifier = p_symbol.name;
 	const ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_parse_result(p_file_path);
 	if (parser) {
 		const PackedStringArray &content = parser->get_lines();
@@ -451,18 +451,23 @@ Vector<LSP::Location> GDScriptWorkspace::find_usages_in_file(const LSP::Document
 				params.position.line = i;
 				params.position.character = character;
 
-				const LSP::DocumentSymbol *other_symbol = resolve_symbol(params);
+				LSP::Range range;
+				String identifier_under_cursor = parser->get_identifier_under_position(params.position, range);
 
-				if (other_symbol == &p_symbol) {
-					LSP::Location loc;
-					loc.uri = text_doc.uri;
-					loc.range.start = params.position;
-					loc.range.end.line = params.position.line;
-					loc.range.end.character = params.position.character + identifier.length();
-					usages.append(loc);
+				if (identifier_under_cursor == identifier) {
+					const LSP::DocumentSymbol *other_symbol = resolve_symbol(params);
+
+					if (other_symbol == &p_symbol) {
+						LSP::Location loc;
+						loc.uri = text_doc.uri;
+						loc.range.start = params.position;
+						loc.range.end.line = params.position.line;
+						loc.range.end.character = params.position.character + identifier.length();
+						usages.append(loc);
+					}
 				}
 
-				character = line.find(identifier, character + 1);
+				character = line.find(identifier, range.end.character);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/114729 
It's closed since we used it to track a 4.6 regression. However the issue also mentions a hang which was present before and still is. This PR addresses this slowdown.

---

`resolve_symbol` is very expensive since it parses and analyzes the script, without any caching. For very short variable names this becomes a bottleneck, since a single char identifier like `a` can occur hundreds of times in a script.

This PR adds a cheaper intermediate check, which just tokenizes the identifier at that pos to filter false positives:

Example: Find references to `a` in `var my_variable = a`

Before this PR:
Four occurrences of `a` -> four calls to `resolve_symbol`

With this PR:
identifier for first occurrence is `var`, no call to `resolve_symbol`
identifier for second occurrence is `my_variable`,  no call to `resolve_symbol`
third occurrence is skipped since search is continued after `my_variable`
identifier for fourth occurrence is `a` -> call `resolve_symbol`

This significantly cuts down the time it takes to find references to such short identifiers in projects. (Can't give accurate times, since I did not fully wait for the search to finish before this PR.)

---

In theory this PR might have a negative impact for long identifier names because they are not prone to false positives from the fulltext search. However I think that's negligible because `get_identifier_under_position` is faster then `resolve_symbol` by a very large margin (in reasonably complex projects).







