### PR TITLE
Refactor button height calculation for vertical icon alignment

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -512,14 +512,10 @@ Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Textu
 		}
 	}
 
-	if (!xl_text.is_empty() || !p_text.is_empty()) {
+	if ((!xl_text.is_empty() || !p_text.is_empty()) && vertical_icon_alignment == VERTICAL_ALIGNMENT_CENTER) {
 		Ref<Font> font = theme_cache.font;
 		float font_height = font->get_height(theme_cache.font_size);
-		if (vertical_icon_alignment == VERTICAL_ALIGNMENT_CENTER) {
-			minsize.height = MAX(font_height, minsize.height);
-		} else {
-			minsize.height += font_height;
-		}
+		minsize.height = MAX(font_height, minsize.height);
 	}
 
 	return (theme_cache.align_to_largest_stylebox ? _get_largest_stylebox_size() : _get_current_stylebox()->get_minimum_size()) + minsize;


### PR DESCRIPTION
Simplified the height calculation logic in get_minimum_size_for_text_and_icon by consolidating the conditional check. When vertical_icon_alignment is CENTER, the height is set to the maximum of font_height and current minsize.height. The else branch that added font_height is removed as it's not needed for non-center alignments.
fixed [115774](https://github.com/godotengine/godot/issues/115774)
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
