### PR TITLE
Fix crash when passing `null` return pointer to GDExtension call methods

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -331,9 +331,11 @@ static void gdextension_variant_call(GDExtensionVariantPtr p_self, GDExtensionCo
 	const StringName method = *reinterpret_cast<const StringName *>(p_method);
 	const Variant **args = (const Variant **)p_args;
 	Callable::CallError error;
-	memnew_placement(r_return, Variant);
-	Variant *ret = reinterpret_cast<Variant *>(r_return);
-	self->callp(method, args, p_argcount, *ret, error);
+	Variant ret;
+	self->callp(method, args, p_argcount, ret, error);
+	if (r_return != nullptr) {
+		memnew_placement(r_return, Variant(ret));
+	}
 
 	if (r_error) {
 		r_error->error = (GDExtensionCallErrorType)(error.error);
@@ -347,9 +349,11 @@ static void gdextension_variant_call_static(GDExtensionVariantType p_type, GDExt
 	const StringName method = *reinterpret_cast<const StringName *>(p_method);
 	const Variant **args = (const Variant **)p_args;
 	Callable::CallError error;
-	memnew_placement(r_return, Variant);
-	Variant *ret = reinterpret_cast<Variant *>(r_return);
-	Variant::call_static(type, method, args, p_argcount, *ret, error);
+	Variant ret;
+	Variant::call_static(type, method, args, p_argcount, ret, error);
+	if (r_return != nullptr) {
+		memnew_placement(r_return, Variant(ret));
+	}
 
 	if (r_error) {
 		r_error->error = (GDExtensionCallErrorType)error.error;
@@ -1333,7 +1337,10 @@ static void gdextension_object_method_bind_call(GDExtensionMethodBindPtr p_metho
 	const Variant **args = (const Variant **)p_args;
 	Callable::CallError error;
 
-	memnew_placement(r_return, Variant(mb->call(o, args, p_arg_count, error)));
+	Variant ret = mb->call(o, args, p_arg_count, error);
+	if (r_return != nullptr) {
+		memnew_placement(r_return, Variant(ret));
+	}
 
 	if (r_error) {
 		r_error->error = (GDExtensionCallErrorType)(error.error);
@@ -1426,8 +1433,10 @@ static void gdextension_object_call_script_method(GDExtensionObjectPtr p_object,
 	const Variant **args = (const Variant **)p_args;
 
 	Callable::CallError error; // TODO: Check `error`?
-	memnew_placement(r_return, Variant);
-	*(Variant *)r_return = o->callp(method, args, p_argument_count, error);
+	Variant ret = o->callp(method, args, p_argument_count, error);
+	if (r_return != nullptr) {
+		memnew_placement(r_return, Variant(ret));
+	}
 
 	if (r_error) {
 		r_error->error = (GDExtensionCallErrorType)(error.error);

--- a/core/extension/gdextension_interface.json
+++ b/core/extension/gdextension_interface.json
@@ -4094,7 +4094,7 @@
                     "name": "r_return",
                     "type": "GDExtensionUninitializedVariantPtr",
                     "description": [
-                        "A pointer a Variant which will be assigned the return value."
+                        "A pointer to a Variant which will be assigned the return value, or NULL to discard the return value."
                     ]
                 },
                 {
@@ -4148,7 +4148,7 @@
                     "name": "r_return",
                     "type": "GDExtensionUninitializedVariantPtr",
                     "description": [
-                        "A pointer a Variant which will be assigned the return value."
+                        "A pointer to a Variant which will be assigned the return value, or NULL to discard the return value."
                     ]
                 },
                 {
@@ -4195,7 +4195,7 @@
                     "name": "r_return",
                     "type": "GDExtensionUninitializedVariantPtr",
                     "description": [
-                        "A pointer a Variant which will be assigned the return value."
+                        "A pointer to a Variant which will be assigned the return value."
                     ]
                 },
                 {
@@ -7463,7 +7463,7 @@
                     "name": "r_ret",
                     "type": "GDExtensionUninitializedVariantPtr",
                     "description": [
-                        "A pointer to Variant which will receive the return value."
+                        "A pointer to a Variant which will receive the return value, or NULL to discard the return value."
                     ]
                 },
                 {
@@ -7856,7 +7856,7 @@
                     "name": "r_return",
                     "type": "GDExtensionUninitializedVariantPtr",
                     "description": [
-                        "A pointer a Variant which will be assigned the return value."
+                        "A pointer to a Variant which will be assigned the return value, or NULL to discard the return value."
                     ]
                 },
                 {


### PR DESCRIPTION
Added null checking for the return argument in the following methods:

- `gdextension_variant_call`
- `gdextension_variant_call_static`
- `gdextension_object_call_script_method`
- `gdextension_object_method_bind_call`

When the return pointer is `null`, these functions now ignore it. This allows callers to discard return values when calling void-returning methods or when the return value is not needed.

My main motivation for this change is that in the C# bindings we pass a `null` pointer when calling void-returning methods, I don't really care about discarding the return for non-void-returning methods.

The documentation for these methods in `gdextension_interface.json` was also updated to explicitly mention what happens if NULL is used as the return argument.

- I used all uppercase "NULL" because it seems to be what we used elsewhere, but I also saw some instances of lowercase "null".

---

It was also suggested making the changes to `object_method_bind_ptrcall` for consistency, but I found it to be a different case:

- All other methods use `GDExtensionUninitializedVariantPtr` for the return argument, whereas this function uses `GDExtensionTypePtr`.
- The `ptrcall` implementation for void-returning methods already ignores null return arguments, which is my main motivation for this change.
- Non-void-returning methods still require a non-null return argument, but I think that's fine.
    
---

### Alternatives

- Close this PR as "working as intended" and make GDExtension language authors handle it by always passing a non-null pointer for the return argument even for void-returning methods.