### PR TITLE
Fix Unique Resources from Inherited Scenes

### DIFF
--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -1399,17 +1399,17 @@ bool EditorResourcePicker::_is_uniqueness_enabled(bool p_check_recursive) {
 	}
 	Ref<Resource> parent_resource = _has_parent_resource();
 	EditorNode *en = EditorNode::get_singleton();
-	bool internal_to_scene = edited_resource->is_built_in();
+	bool internal_to_scene = en->is_resource_internal_to_scene(edited_resource);
 	List<Node *> node_list = en->get_editor_selection()->get_full_selected_node_list();
 
 	// Todo: Implement a more elegant solution for multiple selected Nodes. This should suffice for the time being.
 	if (node_list.size() > 1 && !p_check_recursive) {
-		return node_list.size() != EditorNode::get_singleton()->get_resource_count(edited_resource) || !internal_to_scene;
+		return node_list.size() != en->get_resource_count(edited_resource) || !internal_to_scene;
 	}
 
 	if (!internal_to_scene) {
-		if (parent_resource.is_valid() && parent_resource->is_built_in() && (!EditorNode::get_singleton()->is_resource_internal_to_scene(parent_resource) || en->get_resource_count(parent_resource) > 1)) {
-			return false;
+		if (parent_resource.is_valid() && (!en->is_resource_internal_to_scene(parent_resource) || en->get_resource_count(parent_resource) > 1)) {
+			return !parent_resource->is_built_in();
 		} else if (!p_check_recursive) {
 			return true;
 		}


### PR DESCRIPTION
Using the analysis by @skyace65 (https://github.com/godotengine/godot/issues/115416#issuecomment-3815261908) I took the original commit from the PR: #114901 and reverted it, then added the special case for if it's an external resource.

This might allow other scenarios that I'm not aware of, but at least doesn't break inherited scenes or external resources.

Additionally it looks like `en->` was not being used consistently throughout the method so I partially updated that.

I would recommend this fix as a candidate for 4.6.1, my understanding is that inherited scenes and unique resources is a fairly common workflow.

Fixes:

- fixes https://github.com/godotengine/godot/issues/115416
- fixes https://github.com/godotengine/godot/issues/115645
