### PR TITLE
Fix applying ProjectSettings debug color changes to CollisionShape2D

### DIFF
--- a/scene/2d/physics/collision_shape_2d.cpp
+++ b/scene/2d/physics/collision_shape_2d.cpp
@@ -30,6 +30,7 @@
 
 #include "collision_shape_2d.h"
 
+#include "core/config/project_settings.h"
 #include "scene/2d/physics/area_2d.h"
 #include "scene/2d/physics/collision_object_2d.h"
 #include "scene/resources/2d/concave_polygon_shape_2d.h"
@@ -95,7 +96,7 @@ void CollisionShape2D::_notification(int p_what) {
 
 			rect = Rect2();
 
-			Color draw_col = debug_color;
+			Color draw_col = get_debug_color();
 			if (disabled) {
 				float g = draw_col.get_v();
 				draw_col.r = g;
@@ -238,10 +239,14 @@ void CollisionShape2D::set_debug_color(const Color &p_color) {
 	}
 
 	debug_color = p_color;
+	used_default_debug_color = debug_color == _get_default_debug_color();
 	queue_redraw();
 }
 
 Color CollisionShape2D::get_debug_color() const {
+	if (used_default_debug_color) {
+		return _get_default_debug_color();
+	}
 	return debug_color;
 }
 
@@ -264,11 +269,17 @@ bool CollisionShape2D::_property_get_revert(const StringName &p_name, Variant &r
 
 void CollisionShape2D::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name == "debug_color") {
-		if (debug_color == _get_default_debug_color()) {
+		if (used_default_debug_color) {
 			p_property.usage = PROPERTY_USAGE_DEFAULT & ~PROPERTY_USAGE_STORAGE;
 		} else {
 			p_property.usage = PROPERTY_USAGE_DEFAULT;
 		}
+	}
+}
+
+void CollisionShape2D::_settings_changed() {
+	if (ProjectSettings::get_singleton()->check_changed_settings_in_group("debug/shapes/collision/shape_color")) {
+		queue_redraw();
 	}
 }
 
@@ -302,4 +313,8 @@ CollisionShape2D::CollisionShape2D() {
 	set_notify_local_transform(true);
 	set_hide_clip_children(true);
 	debug_color = _get_default_debug_color();
+
+#ifdef DEBUG_ENABLED
+	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &CollisionShape2D::_settings_changed));
+#endif
 }

--- a/scene/2d/physics/collision_shape_2d.h
+++ b/scene/2d/physics/collision_shape_2d.h
@@ -50,6 +50,7 @@ class CollisionShape2D : public Node2D {
 
 	// Not wrapped in `#ifdef DEBUG_ENABLED` as it is used for rendering.
 	Color debug_color = Color(0.0, 0.0, 0.0, 0.0);
+	bool used_default_debug_color = true;
 
 	Color _get_default_debug_color() const;
 
@@ -60,6 +61,7 @@ protected:
 	bool _property_can_revert(const StringName &p_name) const;
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
 	void _validate_property(PropertyInfo &p_property) const;
+	void _settings_changed();
 #endif // DEBUG_ENABLED
 
 	static void _bind_methods();

--- a/scene/3d/physics/collision_polygon_3d.cpp
+++ b/scene/3d/physics/collision_polygon_3d.cpp
@@ -70,7 +70,7 @@ void CollisionPolygon3D::_build_polygon() {
 
 		convex->set_points(cp);
 		convex->set_margin(margin);
-		convex->set_debug_color(debug_color);
+		convex->set_debug_color(get_debug_color());
 		convex->set_debug_fill(debug_fill);
 		collision_object->shape_owner_add_shape(owner_id, convex);
 		collision_object->shape_owner_set_disabled(owner_id, disabled);
@@ -170,11 +170,15 @@ void CollisionPolygon3D::set_debug_color(const Color &p_color) {
 	}
 
 	debug_color = p_color;
+	used_default_debug_color = debug_color == _get_default_debug_color();
 
 	update_gizmos();
 }
 
 Color CollisionPolygon3D::get_debug_color() const {
+	if (used_default_debug_color) {
+		return _get_default_debug_color();
+	}
 	return debug_color;
 }
 
@@ -211,7 +215,7 @@ bool CollisionPolygon3D::_property_get_revert(const StringName &p_name, Variant 
 
 void CollisionPolygon3D::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name == "debug_color") {
-		if (debug_color == _get_default_debug_color()) {
+		if (used_default_debug_color) {
 			p_property.usage = PROPERTY_USAGE_DEFAULT & ~PROPERTY_USAGE_STORAGE;
 		} else {
 			p_property.usage = PROPERTY_USAGE_DEFAULT;

--- a/scene/3d/physics/collision_polygon_3d.h
+++ b/scene/3d/physics/collision_polygon_3d.h
@@ -47,6 +47,7 @@ protected:
 
 	Color debug_color;
 	bool debug_fill = true;
+	bool used_default_debug_color = true;
 
 	Color _get_default_debug_color() const;
 

--- a/scene/3d/physics/collision_shape_3d.cpp
+++ b/scene/3d/physics/collision_shape_3d.cpp
@@ -203,7 +203,7 @@ void CollisionShape3D::set_shape(const Ref<Shape3D> &p_shape) {
 			set_debug_color(shape->get_debug_color());
 			set_debug_fill_enabled(shape->get_debug_fill());
 		} else {
-			shape->set_debug_color(debug_color);
+			shape->set_debug_color(get_debug_color());
 			shape->set_debug_fill(debug_fill);
 		}
 #endif // DEBUG_ENABLED
@@ -255,13 +255,17 @@ void CollisionShape3D::set_debug_color(const Color &p_color) {
 	}
 
 	debug_color = p_color;
+	used_default_debug_color = debug_color == _get_default_debug_color();
 
 	if (shape.is_valid()) {
-		shape->set_debug_color(p_color);
+		shape->set_debug_color(get_debug_color());
 	}
 }
 
 Color CollisionShape3D::get_debug_color() const {
+	if (used_default_debug_color) {
+		return _get_default_debug_color();
+	}
 	return debug_color;
 }
 
@@ -300,7 +304,7 @@ bool CollisionShape3D::_property_get_revert(const StringName &p_name, Variant &r
 
 void CollisionShape3D::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name == "debug_color") {
-		if (debug_color == _get_default_debug_color()) {
+		if (used_default_debug_color) {
 			p_property.usage = PROPERTY_USAGE_DEFAULT & ~PROPERTY_USAGE_STORAGE;
 		} else {
 			p_property.usage = PROPERTY_USAGE_DEFAULT;

--- a/scene/3d/physics/collision_shape_3d.h
+++ b/scene/3d/physics/collision_shape_3d.h
@@ -44,6 +44,7 @@ class CollisionShape3D : public Node3D {
 
 	Color debug_color;
 	bool debug_fill = true;
+	bool used_default_debug_color = true;
 
 	Color _get_default_debug_color() const;
 


### PR DESCRIPTION
- Closes: https://github.com/godotengine/godot/issues/90965


This also fixes similar bug in `CollisionShape3D` and `CollisionPolygon3D`.