### PR TITLE
[macOS] Set `main` visibility to default.

### DIFF
--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -39,7 +39,7 @@
 #include <sys/resource.h>
 #endif
 
-int main(int argc, char **argv) {
+__attribute__((visibility("default"))) int main(int argc, char **argv) {
 	godot_init_profiler();
 
 #if defined(VULKAN_ENABLED)


### PR DESCRIPTION
We use `dladdr` on `main` to get ASLR load address.

*Bugsquad edit:* Follow-up to #109958.