### PR TITLE
Avoid reading from sky pointer when rendering background without sky

### DIFF
--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -1500,13 +1500,15 @@ void SkyRD::draw_sky(RD::DrawListID p_draw_list, Ref<RenderSceneBuffersRD> p_ren
 	PipelineCacheRD *pipeline = &shader_data->pipelines[sky_scene_state.view_count > 1 ? SKY_VERSION_BACKGROUND_MULTIVIEW : SKY_VERSION_BACKGROUND];
 
 	RID texture_uniform_set;
+	float border_size = 0.0;
 	if (sky) {
 		texture_uniform_set = sky->get_textures(SKY_TEXTURE_SET_BACKGROUND, sky_shader.default_shader_rd, p_render_buffers);
+		border_size = sky->uv_border_size;
 	} else {
 		texture_uniform_set = sky_scene_state.fog_only_texture_uniform_set;
 	}
 
-	_render_sky(p_draw_list, p_time, p_fb, pipeline, material->uniform_set, texture_uniform_set, projection, sky_transform, sky_scene_state.cam_transform.origin, p_luminance_multiplier, p_brightness_multiplier, sky->uv_border_size);
+	_render_sky(p_draw_list, p_time, p_fb, pipeline, material->uniform_set, texture_uniform_set, projection, sky_transform, sky_scene_state.cam_transform.origin, p_luminance_multiplier, p_brightness_multiplier, border_size);
 }
 
 void SkyRD::invalidate_sky(Sky *p_sky) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/115861

Regression from https://github.com/godotengine/godot/pull/115606

The sky render function can be called with a dummy sky material in a few cases, so we need to check for the existence of the sky.

For people who want to test this, the repro steps in #115861 aren't enough to cause the crash. You need to enable "fog" in the Environment and you need the background mode to be set to clear color.

Flagging for cherrypicking so we can add https://github.com/godotengine/godot/pull/115606 to 4.6.1