### PR TITLE
check if image is compressed and decompress in set_icon

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5726,6 +5726,9 @@ void DisplayServerX11::set_icon(const Ref<Image> &p_icon) {
 		ERR_FAIL_COND(p_icon->get_width() <= 0 || p_icon->get_height() <= 0);
 
 		Ref<Image> img = p_icon->duplicate();
+		if (img->is_compressed()) {
+			img->decompress();
+		}
 		img->convert(Image::FORMAT_RGBA8);
 
 		while (true) {

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3325,6 +3325,9 @@ void DisplayServerMacOS::set_icon(const Ref<Image> &p_icon) {
 		ERR_FAIL_COND(p_icon->get_width() <= 0 || p_icon->get_height() <= 0);
 
 		Ref<Image> img = p_icon->duplicate();
+		if (img->is_compressed()) {
+			img->decompress();
+		}
 		img->convert(Image::FORMAT_RGBA8);
 
 		NSBitmapImageRep *imgrep = [[NSBitmapImageRep alloc]

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4044,6 +4044,9 @@ void DisplayServerWindows::set_icon(const Ref<Image> &p_icon) {
 		ERR_FAIL_COND(p_icon->get_width() <= 0 || p_icon->get_height() <= 0);
 
 		Ref<Image> img = p_icon->duplicate();
+		if (img->is_compressed()) {
+			img->decompress();
+		}
 		img->convert(Image::FORMAT_RGBA8);
 
 		int w = img->get_width();


### PR DESCRIPTION
The images are decompressed before formatting in platform/windows/display_server_windows.cpp, but it was not being done in the set_icon function. I believe this could be a potential future bug or this bug. 
I did the same changes in set_icon in other platforms. 
Fixes #115872

