### PR TITLE
Implement call_deferred_unique support

### DIFF
--- a/core/core_string_names.h
+++ b/core/core_string_names.h
@@ -80,6 +80,7 @@ public:
 
 	const StringName call = "call";
 	const StringName call_deferred = "call_deferred";
+	const StringName call_deferred_unique = "call_deferred_unique";
 	const StringName bind = "bind";
 	const StringName notification = "notification";
 	const StringName property_list_changed = "property_list_changed";

--- a/core/core_string_names.h
+++ b/core/core_string_names.h
@@ -80,7 +80,6 @@ public:
 
 	const StringName call = "call";
 	const StringName call_deferred = "call_deferred";
-	const StringName call_deferred_unique = "call_deferred_unique";
 	const StringName bind = "bind";
 	const StringName notification = "notification";
 	const StringName property_list_changed = "property_list_changed";

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -221,13 +221,12 @@ Error CallQueue::push_notification(ObjectID p_id, int p_notification) {
 }
 
 Error CallQueue::push_callable_uniquep(const Callable &p_callable, const Variant **p_args, int p_argcount, bool p_show_error) {
-	LOCK_MUTEX;
-
 	uint32_t hash = p_callable.hash();
 	for (int i = 0; i < p_argcount; ++i) {
 		hash = hash_djb2_one_32(p_args[i]->hash(), hash);
 	}
 
+	LOCK_MUTEX;
 	if (current_frame_callables.has(hash)) {
 		UNLOCK_MUTEX
 		return Error::OK;

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -91,14 +91,14 @@ Error CallQueue::push_set(Object *p_object, const StringName &p_prop, const Vari
 	return push_set(p_object->get_instance_id(), p_prop, p_value);
 }
 
-Error CallQueue::push_callablep(const Callable &p_callable, const Variant **p_args, int p_argcount, bool p_show_error, bool mutex_locked) {
+Error CallQueue::push_callablep(const Callable &p_callable, const Variant **p_args, int p_argcount, bool p_show_error, bool p_mutex_locked) {
 	uint32_t room_needed = sizeof(Message) + sizeof(Variant) * p_argcount;
 
 	ERR_FAIL_COND_V_MSG(room_needed > uint32_t(PAGE_SIZE_BYTES), ERR_INVALID_PARAMETER, "Message is too large to fit on a page (" + itos(PAGE_SIZE_BYTES) + " bytes), consider passing less arguments.");
 
-	if (!mutex_locked) {
+	if (!p_mutex_locked) {
 		LOCK_MUTEX;
-	};
+	}
 
 	_ensure_first_page();
 
@@ -106,9 +106,9 @@ Error CallQueue::push_callablep(const Callable &p_callable, const Variant **p_ar
 		if (pages_used == max_pages) {
 			fprintf(stderr, "Failed method: %s. Message queue out of memory. %s\n", String(p_callable).utf8().get_data(), error_text.utf8().get_data());
 			statistics();
-			if (!mutex_locked) {
+			if (!p_mutex_locked) {
 				UNLOCK_MUTEX;
-			};
+			}
 			return ERR_OUT_OF_MEMORY;
 		}
 		_add_page();
@@ -140,9 +140,9 @@ Error CallQueue::push_callablep(const Callable &p_callable, const Variant **p_ar
 
 	page_bytes[pages_used - 1] += room_needed;
 
-	if (!mutex_locked) {
+	if (!p_mutex_locked) {
 		UNLOCK_MUTEX
-	};
+	}
 
 	return OK;
 }
@@ -230,11 +230,11 @@ Error CallQueue::push_callable_uniquep(const Callable &p_callable, const Variant
 	if (current_frame_callables.has(hash)) {
 		UNLOCK_MUTEX
 		return Error::OK;
-	};
+	}
 
 	current_frame_callables.insert(hash);
 
-	Error result =  push_callablep(p_callable, p_args, p_argcount, p_show_error, true);
+	Error result = push_callablep(p_callable, p_args, p_argcount, p_show_error, true);
 	UNLOCK_MUTEX;
 
 	return result;
@@ -297,20 +297,17 @@ Error CallQueue::flush() {
 
 		switch (message->type & FLAG_MASK) {
 			case TYPE_CALL: {
-
 				if (target || (message->type & FLAG_NULL_IS_OK)) {
 					Variant *args = (Variant *)(message + 1);
 					_call_function(message->callable, args, message->args, message->type & FLAG_SHOW_ERROR);
 				}
 			} break;
 			case TYPE_NOTIFICATION: {
-
 				if (target) {
 					target->notification(message->notification);
 				}
 			} break;
 			case TYPE_SET: {
-
 				if (target) {
 					Variant *arg = (Variant *)(message + 1);
 					target->set(message->callable.get_method(), *arg);

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -221,18 +221,20 @@ Error CallQueue::push_notification(ObjectID p_id, int p_notification) {
 }
 
 Error CallQueue::push_callable_uniquep(const Callable &p_callable, const Variant **p_args, int p_argcount, bool p_show_error) {
-	uint32_t hash = p_callable.hash();
+	UniqueCallableCallKey call_key;
+
+	call_key.callable = p_callable;
 	for (int i = 0; i < p_argcount; ++i) {
-		hash = hash_djb2_one_32(p_args[i]->hash(), hash);
+		call_key.args.push_back(*p_args[i]);
 	}
 
 	LOCK_MUTEX;
-	if (current_frame_callables.has(hash)) {
+	if (current_frame_unique_callables.has(call_key)) {
 		UNLOCK_MUTEX
 		return Error::OK;
 	}
 
-	current_frame_callables.insert(hash);
+	current_frame_unique_callables.insert(call_key);
 
 	Error result = push_callablep(p_callable, p_args, p_argcount, p_show_error, true);
 	UNLOCK_MUTEX;
@@ -335,7 +337,7 @@ Error CallQueue::flush() {
 	pages_used = 1;
 
 	flushing = false;
-	current_frame_callables.clear();
+	current_frame_unique_callables.clear();
 	UNLOCK_MUTEX;
 	return OK;
 }

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -75,6 +75,14 @@ Error CallQueue::push_callp(Object *p_object, const StringName &p_method, const 
 	return push_callp(p_object->get_instance_id(), p_method, p_args, p_argcount, p_show_error);
 }
 
+Error CallQueue::push_call_uniquep(Object *p_object, const StringName &p_method, const Variant **p_args, int p_argcount, bool p_show_error) {
+	return push_call_uniquep(p_object->get_instance_id(), p_method, p_args, p_argcount, p_show_error);
+}
+
+Error CallQueue::push_call_uniquep(ObjectID p_id, const StringName &p_method, const Variant **p_args, int p_argcount, bool p_show_error) {
+	return push_callable_uniquep(Callable(p_id, p_method), p_args, p_argcount, p_show_error);
+}
+
 Error CallQueue::push_notification(Object *p_object, int p_notification) {
 	return push_notification(p_object->get_instance_id(), p_notification);
 }
@@ -83,12 +91,14 @@ Error CallQueue::push_set(Object *p_object, const StringName &p_prop, const Vari
 	return push_set(p_object->get_instance_id(), p_prop, p_value);
 }
 
-Error CallQueue::push_callablep(const Callable &p_callable, const Variant **p_args, int p_argcount, bool p_show_error) {
+Error CallQueue::push_callablep(const Callable &p_callable, const Variant **p_args, int p_argcount, bool p_show_error, bool mutex_locked) {
 	uint32_t room_needed = sizeof(Message) + sizeof(Variant) * p_argcount;
 
 	ERR_FAIL_COND_V_MSG(room_needed > uint32_t(PAGE_SIZE_BYTES), ERR_INVALID_PARAMETER, "Message is too large to fit on a page (" + itos(PAGE_SIZE_BYTES) + " bytes), consider passing less arguments.");
 
-	LOCK_MUTEX;
+	if (!mutex_locked) {
+		LOCK_MUTEX;
+	};
 
 	_ensure_first_page();
 
@@ -96,7 +106,9 @@ Error CallQueue::push_callablep(const Callable &p_callable, const Variant **p_ar
 		if (pages_used == max_pages) {
 			fprintf(stderr, "Failed method: %s. Message queue out of memory. %s\n", String(p_callable).utf8().get_data(), error_text.utf8().get_data());
 			statistics();
-			UNLOCK_MUTEX;
+			if (!mutex_locked) {
+				UNLOCK_MUTEX;
+			};
 			return ERR_OUT_OF_MEMORY;
 		}
 		_add_page();
@@ -128,7 +140,9 @@ Error CallQueue::push_callablep(const Callable &p_callable, const Variant **p_ar
 
 	page_bytes[pages_used - 1] += room_needed;
 
-	UNLOCK_MUTEX;
+	if (!mutex_locked) {
+		UNLOCK_MUTEX
+	};
 
 	return OK;
 }
@@ -206,6 +220,27 @@ Error CallQueue::push_notification(ObjectID p_id, int p_notification) {
 	return OK;
 }
 
+Error CallQueue::push_callable_uniquep(const Callable &p_callable, const Variant **p_args, int p_argcount, bool p_show_error) {
+	LOCK_MUTEX;
+
+	uint32_t hash = p_callable.hash();
+	for (int i = 0; i < p_argcount; ++i) {
+		hash = hash_djb2_one_32(p_args[i]->hash(), hash);
+	}
+
+	if (current_frame_callables.has(hash)) {
+		UNLOCK_MUTEX
+		return Error::OK;
+	};
+
+	current_frame_callables.insert(hash);
+
+	Error result =  push_callablep(p_callable, p_args, p_argcount, p_show_error, true);
+	UNLOCK_MUTEX;
+
+	return result;
+}
+
 void CallQueue::_call_function(const Callable &p_callable, const Variant *p_args, int p_argcount, bool p_show_error) {
 	const Variant **argptrs = nullptr;
 	if (p_argcount) {
@@ -263,17 +298,20 @@ Error CallQueue::flush() {
 
 		switch (message->type & FLAG_MASK) {
 			case TYPE_CALL: {
+
 				if (target || (message->type & FLAG_NULL_IS_OK)) {
 					Variant *args = (Variant *)(message + 1);
 					_call_function(message->callable, args, message->args, message->type & FLAG_SHOW_ERROR);
 				}
 			} break;
 			case TYPE_NOTIFICATION: {
+
 				if (target) {
 					target->notification(message->notification);
 				}
 			} break;
 			case TYPE_SET: {
+
 				if (target) {
 					Variant *arg = (Variant *)(message + 1);
 					target->set(message->callable.get_method(), *arg);
@@ -301,6 +339,7 @@ Error CallQueue::flush() {
 	pages_used = 1;
 
 	flushing = false;
+	current_frame_callables.clear();
 	UNLOCK_MUTEX;
 	return OK;
 }

--- a/core/object/message_queue.h
+++ b/core/object/message_queue.h
@@ -118,7 +118,7 @@ public:
 		return push_callp(p_id, p_method, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
 	}
 
-	Error push_callablep(const Callable &p_callable, const Variant **p_args, int p_argcount, bool p_show_error = false, bool mutex_locked = false);
+	Error push_callablep(const Callable &p_callable, const Variant **p_args, int p_argcount, bool p_show_error = false, bool p_mutex_locked = false);
 	Error push_set(ObjectID p_id, const StringName &p_prop, const Variant &p_value);
 	Error push_notification(ObjectID p_id, int p_notification);
 
@@ -156,7 +156,7 @@ public:
 
 	Error push_callp(Object *p_object, const StringName &p_method, const Variant **p_args, int p_argcount, bool p_show_error = false);
 	Error push_call_uniquep(Object *p_object, const StringName &p_method, const Variant **p_args, int p_argcount, bool p_show_error = false);
-	Error push_call_uniquep(ObjectID p_id, const StringName &p_method, const Variant **p_args, int p_argcount, bool p_show_error);
+	Error push_call_uniquep(ObjectID p_id, const StringName &p_method, const Variant **p_args, int p_argcount, bool p_show_error = false);
 
 	template <typename... VarArgs>
 	Error push_call(Object *p_object, const StringName &p_method, VarArgs... p_args) {

--- a/core/object/message_queue.h
+++ b/core/object/message_queue.h
@@ -32,6 +32,7 @@
 
 #include "core/object/object_id.h"
 #include "core/os/thread_safe.h"
+#include "core/templates/hash_set.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/paged_allocator.h"
 #include "core/variant/variant.h"
@@ -76,6 +77,8 @@ private:
 	uint32_t pages_used = 0;
 	bool flushing = false;
 
+	HashSet<uint32_t> current_frame_callables;
+
 #ifdef DEV_ENABLED
 	bool is_current_thread_override = false;
 #endif
@@ -115,9 +118,11 @@ public:
 		return push_callp(p_id, p_method, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
 	}
 
-	Error push_callablep(const Callable &p_callable, const Variant **p_args, int p_argcount, bool p_show_error = false);
+	Error push_callablep(const Callable &p_callable, const Variant **p_args, int p_argcount, bool p_show_error = false, bool mutex_locked = false);
 	Error push_set(ObjectID p_id, const StringName &p_prop, const Variant &p_value);
 	Error push_notification(ObjectID p_id, int p_notification);
+
+	Error push_callable_uniquep(const Callable &p_callable, const Variant **p_args, int p_argcount, bool p_show_error = false);
 
 	template <typename... VarArgs>
 	Error push_callable(const Callable &p_callable, VarArgs... p_args) {
@@ -129,7 +134,30 @@ public:
 		return push_callablep(p_callable, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
 	}
 
+	template <typename... VarArgs>
+	Error push_call_unique(const Callable &p_callable, VarArgs... p_args) {
+		Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
+		const Variant *argptrs[sizeof...(p_args) + 1];
+		for (uint32_t i = 0; i < sizeof...(p_args); i++) {
+			argptrs[i] = &args[i];
+		}
+		return push_call_uniquep(p_callable, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
+	}
+
+	template <typename... VarArgs>
+	Error push_call_unique(Object *p_object, const StringName &p_method, VarArgs... p_args) {
+		Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
+		const Variant *argptrs[sizeof...(p_args) + 1];
+		for (uint32_t i = 0; i < sizeof...(p_args); i++) {
+			argptrs[i] = &args[i];
+		}
+		return push_call_uniquep(p_object, p_method, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
+	}
+
 	Error push_callp(Object *p_object, const StringName &p_method, const Variant **p_args, int p_argcount, bool p_show_error = false);
+	Error push_call_uniquep(Object *p_object, const StringName &p_method, const Variant **p_args, int p_argcount, bool p_show_error = false);
+	Error push_call_uniquep(ObjectID p_id, const StringName &p_method, const Variant **p_args, int p_argcount, bool p_show_error);
+
 	template <typename... VarArgs>
 	Error push_call(Object *p_object, const StringName &p_method, VarArgs... p_args) {
 		Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.

--- a/core/object/message_queue.h
+++ b/core/object/message_queue.h
@@ -135,13 +135,13 @@ public:
 	}
 
 	template <typename... VarArgs>
-	Error push_call_unique(const Callable &p_callable, VarArgs... p_args) {
+	Error push_callable_unique(const Callable &p_callable, VarArgs... p_args) {
 		Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
 		const Variant *argptrs[sizeof...(p_args) + 1];
 		for (uint32_t i = 0; i < sizeof...(p_args); i++) {
 			argptrs[i] = &args[i];
 		}
-		return push_call_uniquep(p_callable, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
+		return push_callable_uniquep(p_callable, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
 	}
 
 	template <typename... VarArgs>

--- a/core/object/message_queue.h
+++ b/core/object/message_queue.h
@@ -39,6 +39,23 @@
 
 class Object;
 
+struct UniqueCallableCallKey {
+	Callable callable;
+	Vector<Variant> args;
+
+	bool operator==(const UniqueCallableCallKey &p_key) const {
+		return callable == p_key.callable && args == p_key.args;
+	}
+
+	uint32_t hash() const {
+		uint32_t h = callable.hash();
+		for (const Variant &arg : args) {
+			h = hash_djb2_one_32(arg.hash(), h);
+		}
+		return h;
+	}
+};
+
 class CallQueue {
 	friend class MessageQueue;
 
@@ -77,7 +94,7 @@ private:
 	uint32_t pages_used = 0;
 	bool flushing = false;
 
-	HashSet<uint32_t> current_frame_callables;
+	HashSet<UniqueCallableCallKey> current_frame_unique_callables;
 
 #ifdef DEV_ENABLED
 	bool is_current_thread_override = false;

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -755,6 +755,29 @@ Variant Object::_call_deferred_bind(const Variant **p_args, int p_argcount, Call
 	return Variant();
 }
 
+Variant Object::_call_deferred_unique_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+	if (p_argcount < 1) {
+		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
+		r_error.expected = 1;
+		return Variant();
+	}
+
+	if (!p_args[0]->is_string()) {
+		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+		r_error.argument = 0;
+		r_error.expected = Variant::STRING_NAME;
+		return Variant();
+	}
+
+	r_error.error = Callable::CallError::CALL_OK;
+
+	StringName method = *p_args[0];
+
+	MessageQueue::get_singleton()->push_call_uniquep(get_instance_id(), method, &p_args[1], p_argcount - 1, true);
+
+	return Variant();
+}
+
 bool Object::has_method(const StringName &p_method) const {
 	if (p_method == CoreStringName(free_)) {
 		return true;
@@ -1969,6 +1992,14 @@ void Object::_bind_methods() {
 		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "call_deferred", &Object::_call_deferred_bind, mi, varray(), false);
 	}
 
+	{
+		MethodInfo mi;
+		mi.name = "call_deferred_unique";
+		mi.arguments.push_back(PropertyInfo(Variant::STRING_NAME, "method"));
+
+		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "call_deferred_unique", &Object::_call_deferred_unique_bind, mi, varray(), false);
+	}
+
 	ClassDB::bind_method(D_METHOD("set_deferred", "property", "value"), &Object::set_deferred);
 
 	ClassDB::bind_method(D_METHOD("callv", "method", "arg_array"), &Object::callv);
@@ -2507,7 +2538,7 @@ void Object::get_argument_options(const StringName &p_function, int p_idx, List<
 			for (const MethodInfo &E : signals) {
 				r_options->push_back(E.name.quote());
 			}
-		} else if (pf == "call" || pf == "call_deferred" || pf == "callv" || pf == "has_method") {
+		} else if (pf == "call" || pf == "call_deferred" || pf == "callv" || pf == "has_method" || pf == "call_deferred_unique") {
 			List<MethodInfo> methods;
 			get_method_list(&methods);
 			for (const MethodInfo &E : methods) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -779,6 +779,7 @@ protected:
 
 	Variant _call_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 	Variant _call_deferred_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
+	Variant _call_deferred_unique_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
 	virtual const GDType &_get_typev() const { return get_gdtype_static(); }
 
@@ -994,6 +995,11 @@ public:
 	template <typename... VarArgs>
 	void call_deferred(const StringName &p_name, VarArgs... p_args) {
 		MessageQueue::get_singleton()->push_call(this, p_name, p_args...);
+	}
+
+	template <typename... VarArgs>
+	void call_deferred_unique(const StringName &p_name, VarArgs... p_args) {
+		MessageQueue::get_singleton()->push_call_unique(this, p_name, p_args...);
 	}
 
 	void set_deferred(const StringName &p_property, const Variant &p_value);

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -40,6 +40,10 @@ void Callable::call_deferredp(const Variant **p_arguments, int p_argcount) const
 	MessageQueue::get_singleton()->push_callablep(*this, p_arguments, p_argcount, true);
 }
 
+void Callable::call_deferred_uniquep(const Variant **p_arguments, int p_argcount) const {
+	MessageQueue::get_singleton()->push_callable_uniquep(*this, p_arguments, p_argcount, false);
+}
+
 void Callable::callp(const Variant **p_arguments, int p_argcount, Variant &r_return_value, CallError &r_call_error) const {
 	if (is_null()) {
 		r_call_error.error = CallError::CALL_ERROR_INSTANCE_IS_NULL;

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -74,6 +74,8 @@ public:
 	void call_deferredp(const Variant **p_arguments, int p_argcount) const;
 	Variant callv(const Array &p_arguments) const;
 
+	void call_deferred_uniquep(const Variant **p_arguments, int p_argcount) const;
+
 	template <typename... VarArgs>
 	void call_deferred(VarArgs... p_args) const {
 		Variant args[sizeof...(p_args) + 1] = { p_args..., 0 }; // +1 makes sure zero sized arrays are also supported.
@@ -82,6 +84,16 @@ public:
 			argptrs[i] = &args[i];
 		}
 		return call_deferredp(sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
+	}
+
+	template <typename... VarArgs>
+	void call_deferred_unique(VarArgs... p_args) const {
+		Variant args[sizeof...(p_args) + 1] = { p_args..., 0 }; // +1 makes sure zero sized arrays are also supported.
+		const Variant *argptrs[sizeof...(p_args) + 1];
+		for (uint32_t i = 0; i < sizeof...(p_args); i++) {
+			argptrs[i] = &args[i];
+		}
+		return call_deferred_uniquep(sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
 	}
 
 	Error rpcp(int p_id, const Variant **p_arguments, int p_argcount, CallError &r_call_error) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1182,7 +1182,6 @@ struct _VariantCall {
 		callable->call_deferred_uniquep(p_args, p_argcount);
 	}
 
-
 	static void func_Callable_rpc(Variant *v, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
 		Callable *callable = &VariantInternalAccessor<Callable>::get(v);
 		callable->rpcp(0, p_args, p_argcount, r_error);

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1177,6 +1177,12 @@ struct _VariantCall {
 		callable->call_deferredp(p_args, p_argcount);
 	}
 
+	static void func_Callable_call_deferred_unique(Variant *v, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
+		Callable *callable = &VariantInternalAccessor<Callable>::get(v);
+		callable->call_deferred_uniquep(p_args, p_argcount);
+	}
+
+
 	static void func_Callable_rpc(Variant *v, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
 		Callable *callable = &VariantInternalAccessor<Callable>::get(v);
 		callable->rpcp(0, p_args, p_argcount, r_error);
@@ -2487,6 +2493,7 @@ static void _register_variant_builtin_methods_misc() {
 
 	bind_custom(Callable, call, _VariantCall::func_Callable_call, true, Variant);
 	bind_custom(Callable, call_deferred, _VariantCall::func_Callable_call_deferred, false, Variant);
+	bind_custom(Callable, call_deferred_unique, _VariantCall::func_Callable_call_deferred_unique, false, Variant);
 	bind_custom(Callable, rpc, _VariantCall::func_Callable_rpc, false, Variant);
 	bind_custom1(Callable, rpc_id, _VariantCall::func_Callable_rpc_id, Variant::INT, "peer_id");
 	bind_custom(Callable, bind, _VariantCall::func_Callable_bind, true, Callable);

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -134,7 +134,7 @@
 		<method name="call_deferred_unique" qualifiers="vararg const">
 			<return type="void"/>
 			<description>
-				Same as [method Callable.call_deferred], but it guarantees that within a single tick the method will be invoked at most once with the same arguments, no matter how many times it was requested during the previous tick.				
+				Same as [method call_deferred], but it guarantees that the method will be invoked at most once in a single frame with the same arguments, no matter how many times it was requested during the current frame.
 				[codeblocks]
 				[gdscript]
 				func _ready():

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -131,6 +131,25 @@
 				See also [method Object.call_deferred].
 			</description>
 		</method>
+		<method name="call_deferred_unique" qualifiers="vararg const">
+			<return type="void"/>
+			<description>
+				Same as [method Callable.call_deferred], but it guarantees that within a single tick the method will be invoked at most once with the same arguments, no matter how many times it was requested during the previous tick.				
+				[codeblocks]
+				[gdscript]
+				func _ready():
+					grab_focus.call_deferred_unique()
+				[/gdscript]
+				[csharp]
+				public override void _Ready()
+				{
+					Callable.From(GrabFocus).CallDeferredUnique();
+				}
+				[/csharp]
+				[/codeblocks]
+				See also [method Object.call_deferred_unique].
+			</description>
+		</method>
 		<method name="callv" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="arguments" type="Array" />

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -132,7 +132,7 @@
 			</description>
 		</method>
 		<method name="call_deferred_unique" qualifiers="vararg const">
-			<return type="void"/>
+			<return type="void" />
 			<description>
 				Same as [method call_deferred], but it guarantees that the method will be invoked at most once in a single frame with the same arguments, no matter how many times it was requested during the current frame.
 				[codeblocks]

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -494,7 +494,7 @@
 			<return type="void" />
 			<param index="0" name="method" type="StringName" />
 			<description>
-				Same as [method Object.call_deferred], but it guarantees that within a single tick the method will be invoked at most once with the same arguments, no matter how many times it was requested during the previous tick.
+				Same as [method call_deferred], but it guarantees that the method will be invoked at most once in a single frame with the same arguments, no matter how many times it was requested during the current frame.
 				[codeblocks]
 				[gdscript]
 				var node = Node3D.new()

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -491,7 +491,7 @@
 			</description>
 		</method>
 		<method name="call_deferred_unique" qualifiers="vararg">
-			<return type="void" />
+			<return type="Variant" />
 			<param index="0" name="method" type="StringName" />
 			<description>
 				Same as [method call_deferred], but it guarantees that the method will be invoked at most once in a single frame with the same arguments, no matter how many times it was requested during the current frame.

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -490,6 +490,23 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="call_deferred_unique" qualifiers="vararg">
+			<return type="void" />
+			<param index="0" name="method" type="StringName" />
+			<description>
+				Same as [method Object.call_deferred], but it guarantees that within a single tick the method will be invoked at most once with the same arguments, no matter how many times it was requested during the previous tick.
+				[codeblocks]
+				[gdscript]
+				var node = Node3D.new()
+				node.call_deferred_unique("rotate", Vector3(1.0, 0.0, 0.0), 1.571)
+				[/gdscript]
+				[csharp]
+				var node = new Node3D();
+				node.CallDeferredUnique(Node3D.MethodName.Rotate, new Vector3(1f, 0f, 0f), 1.571f);
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="callv">
 			<return type="Variant" />
 			<param index="0" name="method" type="StringName" />

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -525,6 +525,169 @@ TEST_CASE("[Object] Signals") {
 	}
 }
 
+class _DeferredUniqueMockObject : public Object {
+	GDCLASS(_DeferredUniqueMockObject, Object);
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("test"), &_DeferredUniqueMockObject::test);
+		ClassDB::bind_method(D_METHOD("test_arg1", "arg1"), &_DeferredUniqueMockObject::test_arg1);
+		ClassDB::bind_method(D_METHOD("test_args", "arg1", "arg2", "arg3", "arg4"), &_DeferredUniqueMockObject::test_args);
+	}
+
+public:
+	int8_t counter = 0;
+
+	void reset() {
+		counter = 0;
+	}
+
+	void test() {
+		++counter;
+	}
+
+	void test_arg1(String arg1) {
+		++counter;
+	}
+
+	void test_args(Variant arg1, Variant arg2, Variant arg3, Variant arg4) {
+		++counter;
+	};
+};
+
+TEST_CASE("[Object] Deferred Unique") {
+	CallQueue *message_queue = MessageQueue::get_singleton();
+	_DeferredUniqueMockObject *object = memnew(_DeferredUniqueMockObject);
+
+	if (message_queue == nullptr) {
+		message_queue = memnew(MessageQueue);
+	}
+
+	SUBCASE("[Object] Breakpoints") {
+		SUBCASE("[Object] Without Arg") {
+			CHECK(!message_queue->has_messages());
+			CHECK(object->counter == 0);
+
+			object->call_deferred_unique("test");
+			object->call_deferred_unique("test");
+			object->call_deferred_unique("test");
+
+			CHECK(message_queue->has_messages());
+
+			message_queue->flush();
+
+			CHECK(object->counter == 1);
+			CHECK(!message_queue->has_messages());
+
+			object->reset();
+
+			CHECK(object->counter == 0);
+			CHECK(!message_queue->has_messages());
+
+			object->call_deferred_unique("test");
+			object->call_deferred_unique("test");
+			object->call_deferred_unique("test");
+
+			CHECK(message_queue->has_messages());
+			message_queue->flush();
+
+			CHECK(object->counter == 1);
+		}
+
+		SUBCASE("[Object] With Arg") {
+			object->reset();
+
+			CHECK(!message_queue->has_messages());
+			CHECK(object->counter == 0);
+
+			object->call_deferred_unique("test_arg1", "A");
+			object->call_deferred_unique("test_arg1", "A");
+
+			CHECK(message_queue->has_messages());
+
+			message_queue->flush();
+			CHECK(!message_queue->has_messages());
+			CHECK(object->counter == 1);
+
+			object->reset();
+			CHECK(object->counter == 0);
+
+			object->call_deferred_unique("test_arg1", "A");
+			object->call_deferred_unique("test_arg1", "B");
+			object->call_deferred_unique("test_arg1", "B");
+			object->call_deferred_unique("test_arg1", "C");
+			CHECK(message_queue->has_messages());
+
+			message_queue->flush();
+			CHECK(!message_queue->has_messages());
+			CHECK(object->counter == 3);
+
+			object->reset();
+
+			object->call_deferred_unique("test_args", "A", 1, Vector2(0, 0), Array());
+			object->call_deferred_unique("test_args", "A", 1, Vector2(1, 0), Array());
+			object->call_deferred_unique("test_args", "A", 1, Vector2(1, 0), Array());
+			object->call_deferred_unique("test_args", "A", 2, Vector2(0, 0), 1);
+
+			CHECK(message_queue->has_messages());
+			message_queue->flush();
+			CHECK(!message_queue->has_messages());
+			CHECK(object->counter == 3);
+
+			object->reset();
+		}
+
+		SUBCASE("[Object] Callable") {
+			auto callable = Callable(object, "test");
+			auto callable_with_arg = Callable(object, "test_arg1");
+
+			CHECK(!message_queue->has_messages());
+
+			callable.call_deferred_unique();
+			callable.call_deferred_unique();
+			callable.call_deferred_unique();
+
+			CHECK(message_queue->has_messages());
+			message_queue->flush();
+
+			CHECK(object->counter == 1);
+			CHECK(!message_queue->has_messages());
+
+			object->reset();
+			CHECK(object->counter == 0);
+			CHECK(!message_queue->has_messages());
+
+			callable_with_arg.call_deferred_unique("A");
+			callable_with_arg.call_deferred_unique("A");
+			callable_with_arg.call_deferred_unique("A");
+
+			CHECK(message_queue->has_messages());
+
+			message_queue->flush();
+			CHECK(object->counter == 1);
+			CHECK(!message_queue->has_messages());
+
+			object->reset();
+			CHECK(object->counter == 0);
+
+			callable_with_arg.call_deferred_unique("A");
+			callable_with_arg.call_deferred_unique("B");
+			callable_with_arg.call_deferred_unique("B");
+			CHECK(message_queue->has_messages());
+
+			message_queue->flush();
+			CHECK(object->counter == 2);
+			CHECK(!message_queue->has_messages());
+
+			object->reset();
+			CHECK(object->counter == 0);
+		}
+	}
+
+	memdelete(object);
+	memdelete(message_queue);
+}
+
 class NotificationObjectSuperclass : public Object {
 	GDCLASS(NotificationObjectSuperclass, Object);
 

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -552,7 +552,7 @@ public:
 
 	void test_args(Variant arg1, Variant arg2, Variant arg3, Variant arg4) {
 		++counter;
-	};
+	}
 };
 
 TEST_CASE("[Object] Deferred Unique") {


### PR DESCRIPTION
### Tested versions
[v4.6.stable.official](https://github.com/godotengine/godot/commit/7dac0bc3be27ee70b1bf6da561e9f14cd92224ef)

### System information
Windows 11, AMD

### Issue description
Closes [godot-proposals#3722](https://github.com/godotengine/godot-proposals/issues/3722)

### What this PR does
Add Callable.call_deferred_unique() and Object.call_deferred_unique(). This ensures the method is only enqueued if an identical call (same method with the same parameters) hasn’t already been enqueued.

### How it was tested
Added unit tests (see test/core/test_object.h:558) and ran them locally.