### PR TITLE
Android: Add support for plugins gradle platform dependencies

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -56,8 +56,26 @@ dependencies {
     // Godot user plugins remote dependencies
     String[] remoteDeps = getGodotPluginsRemoteBinaries()
     if (remoteDeps != null && remoteDeps.size() > 0) {
+        def platformPattern = /^\s*(platform|enforcedPlatform)\s*\(\s*['"]*(\S+)['"]*\s*\)$/
         for (String dep : remoteDeps) {
-            implementation dep
+            def matcher = dep =~ platformPattern
+            if (matcher) {
+                switch (matcher[0][1]) {
+                    case "platform":
+                        implementation platform(matcher[0][2])
+                        break
+
+                    case "enforcedPlatform":
+                        implementation enforcedPlatform(matcher[0][2])
+                        break
+
+                    default:
+                        throw new GradleException("Invalid remote platform dependency: $dep")
+                        break
+                }
+            } else {
+                implementation dep
+            }
         }
     }
 


### PR DESCRIPTION
Update the logic to insert plugins dependencies to support [gradle platform dependencies](https://docs.gradle.org/current/userguide/platforms.html#sec:bom-import)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
