### PR TITLE
Fix icon padding causing big_icon null error on custom icons when running scene

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4049,8 +4049,11 @@ void DisplayServerWindows::set_icon(const Ref<Image> &p_icon) {
 		int w = img->get_width();
 		int h = img->get_height();
 
+		int mask_pitch = ((w + 31) / 32) * 4;
+		int mask_size = mask_pitch * h;
+
 		// Create temporary bitmap buffer.
-		int icon_len = 40 + h * w * 4;
+		int icon_len = 40 + (h * w * 4) + mask_size;
 		icon_buffer_big.resize(icon_len);
 		BYTE *icon_bmp = icon_buffer_big.ptrw();
 
@@ -4078,6 +4081,11 @@ void DisplayServerWindows::set_icon(const Ref<Image> &p_icon) {
 				wpx[2] = rpx[0];
 				wpx[3] = rpx[3];
 			}
+		}
+
+		uint8_t *mask_ptr = &icon_bmp[40 + (w * h * 4)];
+		for (int i = 0; i < mask_size; i++) {
+			mask_ptr[i] = 0x00;
 		}
 		icon_big = CreateIconFromResourceEx(icon_bmp, icon_len, TRUE, 0x00030000, 0, 0, LR_DEFAULTSIZE);
 		ERR_FAIL_NULL(icon_big);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/115872
Regression caused by: https://github.com/godotengine/godot/pull/114525 due to changing how icons are created.
_Probably due to change from CreateIconFromResource to CreateIconFromResourceEx_

When using a **custom icon on Windows 10**. Win32 API expects a transparency mask after the color data or it'll return null due to invalid size in some cases.

Not 100% why this only happens when using custom icons and not with the default icon generated by the .svg.
But this fixes the problem with custom icons causing errors on play.

This is the error mentioned:

https://github.com/user-attachments/assets/210aa02c-c937-4f51-94b2-4f3f4a03bab1

