### PR TITLE
Editor Settings: Prevent crash when viewing `filesystem/import/blender/blender_path`

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -827,12 +827,12 @@
 			To enable this feature for your specific project, use [member ProjectSettings.filesystem/import/blender/enabled].
 			If this setting is empty, Blender's default paths will be detected and used automatically if present in this order:
 			[b]Windows:[/b]
-			[codeblock]
+			[codeblock lang=text]
 			- C:\Program Files\Blender Foundation\blender.exe
 			- C:\Program Files (x86)\Blender Foundation\blender.exe
 			[/codeblock]
 			[b]macOS:[/b]
-			[codeblock]
+			[codeblock lang=text]
 			- /opt/homebrew/bin/blender
 			- /opt/local/bin/blender
 			- /usr/local/bin/blender
@@ -840,7 +840,7 @@
 			- /Applications/Blender.app/Contents/MacOS/Blender
 			[/codeblock]
 			[b]Linux/*BSD:[/b]
-			[codeblock]
+			[codeblock lang=text]
 			- /usr/bin/blender
 			- /usr/local/bin/blender
 			- /opt/blender/bin/blender


### PR DESCRIPTION
- This closes #115892

---

### Old Information (feel free to ignore)

This draft PR addresses #115892 and is to do with `[codeblock]` vs `[codeblocks]`

It looks like the only EditorSetting which uses this bbcode is `filesystem/import/blender/blender_path`. Currently in 4.6 stable the description for this setting spells it `[codeblock]`, and when the editor is running, it does show it as a codeblock.

Changing [codeblock] to [codeblocks] (as this draft PR does) means the text does _not_ render as a codeblock, and this prevents godot crashing when viewing `filesystem/import/blender/blender_path` from the project list.

So it seems like there is an issue with rendering `[codeblock] ... [/codeblock]` from within the editor settings opened from the project list.

Also, I am a little confused at the usage of `[codeblock]` vs `[codeblocks]`, as both seem to being used? But their behaviour looks to be different.
 
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
