### PR TITLE
Remove unused `edit_request_func` and include in `script_language.cpp`

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -45,7 +45,6 @@ thread_local bool ScriptServer::thread_entered = false;
 
 bool ScriptServer::scripting_enabled = true;
 bool ScriptServer::reload_scripts_on_save = false;
-ScriptEditRequestFunction ScriptServer::edit_request_func = nullptr;
 
 // These need to be the last static variables in this file, since we're exploiting the reverse-order destruction of static variables.
 static bool is_program_exiting = false;

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -35,7 +35,6 @@
 #include "core/object/script_backtrace.h"
 #include "core/object/script_instance.h"
 #include "core/templates/pair.h"
-#include "core/templates/safe_refcount.h"
 #include "core/variant/typed_array.h"
 
 class ScriptLanguage;
@@ -71,8 +70,6 @@ class ScriptServer {
 	static bool inheriters_cache_dirty;
 
 public:
-	static ScriptEditRequestFunction edit_request_func;
-
 	static void set_scripting_enabled(bool p_enabled);
 	static bool is_scripting_enabled();
 	_FORCE_INLINE_ static int get_language_count() { return _language_count; }

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3559,27 +3559,6 @@ void ScriptEditor::_help_search(const String &p_text) {
 	help_search_dialog->popup_dialog(p_text);
 }
 
-void ScriptEditor::_open_script_request(const String &p_path) {
-	Ref<Script> scr = ResourceLoader::load(p_path);
-	if (scr.is_valid()) {
-		script_editor->edit(scr, false);
-		return;
-	}
-
-	Ref<JSON> json = ResourceLoader::load(p_path);
-	if (json.is_valid()) {
-		script_editor->edit(json, false);
-		return;
-	}
-
-	Error err;
-	Ref<TextFile> text_file = script_editor->_load_text_file(p_path, &err);
-	if (text_file.is_valid()) {
-		script_editor->edit(text_file, false);
-		return;
-	}
-}
-
 void ScriptEditor::register_syntax_highlighter(const Ref<EditorSyntaxHighlighter> &p_syntax_highlighter) {
 	ERR_FAIL_COND(p_syntax_highlighter.is_null());
 
@@ -4140,8 +4119,6 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	trim_trailing_whitespace_on_save = EDITOR_GET("text_editor/behavior/files/trim_trailing_whitespace_on_save");
 	trim_final_newlines_on_save = EDITOR_GET("text_editor/behavior/files/trim_final_newlines_on_save");
 	convert_indent_on_save = EDITOR_GET("text_editor/behavior/files/convert_indent_on_save");
-
-	ScriptServer::edit_request_func = _open_script_request;
 
 	Ref<EditorJSONSyntaxHighlighter> json_syntax_highlighter;
 	json_syntax_highlighter.instantiate();

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -393,7 +393,6 @@ class ScriptEditor : public PanelContainer {
 
 	void _window_changed(bool p_visible);
 
-	static void _open_script_request(const String &p_path);
 	void _close_builtin_scripts_from_scene(const String &p_scene);
 
 	static ScriptEditor *script_editor;


### PR DESCRIPTION
Removes unused code from the `ScriptEditor` and `ScriptLanguage`. Tested by building the engine and running a project.