### PR TITLE
Fix inconsistent SSR blurriness on rough surfaces.

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
@@ -311,7 +311,11 @@ void main() {
 				blur_radius = (a * (sqrt(a2 + fh2) - a)) / (4.0 * h);
 			}
 
-			mip_level = clamp(log2(blur_radius * max(params.screen_size.x, params.screen_size.y) / 16.0), 0, params.mipmaps - 1);
+			// We approximate the integration in world space with a blur in screen space,
+			// and use a mip bias, `log2(/* screen_space_blur_radius */ + 1.0)`, to approximate the screen space blur.
+			// This + 1.0 is needed because mip level is logarithmic to the diameter (in pixels) of sampling region,
+			// which is 1 pixel when no blur is applied (log2(1) = 0).
+			mip_level = clamp(log2(blur_radius * max(params.screen_size.x, params.screen_size.y) / 16.0 + 1.0), 0, params.mipmaps - 1);
 		}
 
 		// Because we still write mip level for invalid pixels to allow for smooth roughness transitions,


### PR DESCRIPTION
### Description

The existing implementation of SSR has a subtle visual artifact: reflections on rough surfaces have inconsistent look at different distances. Specifically, they become more glossy as the camera moves away.

This PR fixed this issue with minor code changes and performance hit (literally just an additional `+ 1.0` in the shader). The comparison between existing implementation and this PR looks like this:

![ssr_enhancement](https://github.com/user-attachments/assets/e93bd202-2459-4015-b9c2-81593fdcdb55)

### Explanation

The problem of existing implementation is that it computes the mip level as `log2(/*screen_space_blur_amout*/)`, but mip level is, strictly speaking, logarithmic to the diameter of sampling region in the texture. When the blur amount is 0, this value should be 1 (because we are sampling from a single pixel). But the computed blur amount is derived from the screen space length of reflected light and a roughness-derived cone radius. This term is 0 when no blur should be applied. Adding 1 to it before taking log2 fixes the math.

### Note

You may have noticed that even with this PR, the look of reflection is still slightly shifted as the distance to camera increases. This is to be expected since we are approximating a real low pass filter with the mipmaps. Mip 0 is always sharp, so mixing it with mip 1 would always produce slight visual artifacts.

EDIT: I just realized that I used Lanczos3 when upscaling the 4.0m and 10.0m images, this makes them sharper than perceived. If you take a closer look at the un-zoomed images (or simply open the test project with a patched engine), you will see that they are fairly consistent with the commit from this PR.

### Test Project

The project used to generate the above comparison is here: [ssr_enhancement_demo.zip](https://github.com/user-attachments/files/25096315/ssr_enhancement_demo.zip)

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/115906*