### PR TITLE
Add resource counting limit

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1919,6 +1919,10 @@ void EditorNode::gather_resources(const Variant &p_variant, List<Ref<Resource>> 
 			if (Object::cast_to<Node>(v) == nullptr) {
 				gather_resources(v, r_list, r_scanned_objects, p_subresources, p_allow_external);
 			}
+
+			if (r_list.size() > RESOURCE_GATHER_LIMIT) {
+				return;
+			}
 		}
 		return;
 	}
@@ -1947,6 +1951,10 @@ void EditorNode::gather_resources(const Variant &p_variant, List<Ref<Resource>> 
 			}
 			if (Object::cast_to<Node>(kv.value) == nullptr) {
 				gather_resources(kv.value, r_list, r_scanned_objects, p_subresources, p_allow_external);
+			}
+
+			if (r_list.size() > RESOURCE_GATHER_LIMIT) {
+				return;
 			}
 		}
 		return;
@@ -1989,6 +1997,10 @@ void EditorNode::gather_resources(const Variant &p_variant, List<Ref<Resource>> 
 		if (p_subresources) {
 			gather_resources(res, r_list, r_scanned_objects, p_subresources, p_allow_external);
 		}
+
+		if (r_list.size() > RESOURCE_GATHER_LIMIT) {
+			return;
+		}
 	}
 }
 
@@ -2000,6 +2012,7 @@ void EditorNode::update_resource_count(Node *p_node, bool p_remove) {
 	List<Ref<Resource>> res_list;
 	HashSet<Object *> scanned_objects;
 	gather_resources(p_node, res_list, scanned_objects, true);
+	resource_limit_warning(res_list.size());
 
 	for (Ref<Resource> &R : res_list) {
 		List<Node *>::Element *E = resource_count[R].find(p_node);
@@ -2023,6 +2036,12 @@ int EditorNode::get_resource_count(Ref<Resource> p_res) {
 List<Node *> EditorNode::get_resource_node_list(Ref<Resource> p_res) {
 	List<Node *> *L = resource_count.getptr(p_res);
 	return L == nullptr ? List<Node *>() : List<Node *>(*L);
+}
+
+void EditorNode::resource_limit_warning(int p_resource_count) const {
+	if (p_resource_count > RESOURCE_GATHER_LIMIT) {
+		WARN_PRINT(vformat("Resource count limit (%d) exceeded. Uniqueness indicator will be unreliable.", RESOURCE_GATHER_LIMIT));
+	}
 }
 
 void EditorNode::update_node_reference(const Variant &p_value, Node *p_node, bool p_remove) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -240,6 +240,8 @@ public:
 private:
 	friend class EditorSceneTabs;
 
+	static constexpr int RESOURCE_GATHER_LIMIT = 500;
+
 	enum {
 		MAX_INIT_CALLBACKS = 128,
 		MAX_BUILD_CALLBACKS = 128,
@@ -832,6 +834,7 @@ public:
 	void clear_node_reference(Ref<Resource> p_res);
 	int get_resource_count(Ref<Resource> p_res);
 	List<Node *> get_resource_node_list(Ref<Resource> p_res);
+	void resource_limit_warning(int p_resource_count) const;
 
 	void show_about() { _menu_option_confirm(HELP_ABOUT, false); }
 

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -43,6 +43,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_quick_open_dialog.h"
+#include "editor/gui/editor_toaster.h"
 #include "editor/inspector/editor_inspector.h"
 #include "editor/inspector/editor_resource_preview.h"
 #include "editor/plugins/editor_resource_conversion_plugin.h"
@@ -1435,6 +1436,7 @@ bool EditorResourcePicker::_is_uniqueness_enabled(bool p_check_recursive) {
 		List<Ref<Resource>> nested_resources;
 		HashSet<Object *> scanned_objects;
 		en->gather_resources(edited_resource, nested_resources, scanned_objects, true, true);
+		en->resource_limit_warning(nested_resources.size());
 
 		for (Ref<Resource> R : nested_resources) {
 			// Take into account Nested External Resources.


### PR DESCRIPTION
Fixes #115420

The issue basically boils down to the scene having an unreasonably huge number of Resources. The editor needs to check all of them to properly display unique indicator. I noticed the counting methods are called more than necessary, but even in ideal conditions where everything is only counted once per scene, it would still take too long with that many resources.

My solution for now is adding an annoying warning when the counting method exceeds some threshold (I set it to 500). When the list of gathered resources is bigger than that, the method returns early and then a warning is printed in the parent method. There are a couple of problems:
- For whatever reason the parent method (the one that initiates gathering) seems to be called 10-50 times in a row when testing the MRP, resulting in corresponding number of warnings.
- The parent method only checks whether resource count exceeds limits. If you have exactly 501 resources, you'll get false-positive.
- The unique indicator should probably disappear or show a different icon/tooltip when the limit is exceeded.

That said, most users won't exceed 500 resources in a single scene, so I think this works as a _temporary_ solution. It's better than freezing the editor.