### PR TITLE
JSON.stringify: Don't add unnecessary empty lines on empty dicts

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -155,6 +155,11 @@ void JSON::_stringify(String &r_result, const Variant &p_var, const String &p_in
 				ERR_FAIL_MSG("Converting circular structure to JSON.");
 			}
 
+			if (d.is_empty()) {
+				r_result += "{}";
+				return;
+			}
+
 			r_result += '{';
 			r_result += end_statement;
 			p_markers.insert(d.id());


### PR DESCRIPTION
When serializing empty dictionaries don't include extra empty lines.

Would close #115882.