### PR TITLE
Reduce includes to rendering driver implementation headers.

### DIFF
--- a/drivers/d3d12/d3d12_hooks.h
+++ b/drivers/d3d12/d3d12_hooks.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "rendering_device_driver_d3d12.h"
+#include "godot_d3d12.h"
 
 class D3D12Hooks {
 private:

--- a/drivers/d3d12/godot_d3d12.h
+++ b/drivers/d3d12/godot_d3d12.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rendering_context_driver_vulkan_windows.cpp                           */
+/*  godot_d3d12.h                                                         */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,31 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#if defined(WINDOWS_ENABLED) && defined(VULKAN_ENABLED)
+#pragma once
 
-#include "core/os/os.h"
+#include "core/typedefs.h"
 
-#include "rendering_context_driver_vulkan_windows.h"
-#include "rendering_context_driver_vulkan_windows_public.h"
+#if !defined(_MSC_VER) && !defined(__REQUIRED_RPCNDR_H_VERSION__)
+// Match current version used by MinGW, MSVC and Direct3D 12 headers use 500.
+#define __REQUIRED_RPCNDR_H_VERSION__ 475
+#endif // !defined(_MSC_VER) && !defined(__REQUIRED_RPCNDR_H_VERSION__)
 
-#include "drivers/vulkan/godot_vulkan.h"
+GODOT_GCC_WARNING_PUSH
+GODOT_GCC_WARNING_IGNORE("-Wimplicit-fallthrough")
+GODOT_GCC_WARNING_IGNORE("-Wmissing-field-initializers")
+GODOT_GCC_WARNING_IGNORE("-Wnon-virtual-dtor")
+GODOT_GCC_WARNING_IGNORE("-Wshadow")
+GODOT_GCC_WARNING_IGNORE("-Wswitch")
+GODOT_CLANG_WARNING_PUSH
+GODOT_CLANG_WARNING_IGNORE("-Wimplicit-fallthrough")
+GODOT_CLANG_WARNING_IGNORE("-Wmissing-field-initializers")
+GODOT_CLANG_WARNING_IGNORE("-Wnon-virtual-dtor")
+GODOT_CLANG_WARNING_IGNORE("-Wstring-plus-int")
+GODOT_CLANG_WARNING_IGNORE("-Wswitch")
 
-const char *RenderingContextDriverVulkanWindows::_get_platform_surface_extension() const {
-	return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
-}
+#include <thirdparty/directx_headers/include/directx/d3dx12.h>
 
-RenderingContextDriverVulkanWindows::RenderingContextDriverVulkanWindows() {
-	// Workaround for Vulkan not working on setups with AMD integrated graphics + NVIDIA dedicated GPU (GH-57708).
-	// This prevents using AMD integrated graphics with Vulkan entirely, but it allows the engine to start
-	// even on outdated/broken driver setups.
-	OS::get_singleton()->set_environment("DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1", "1");
-}
+GODOT_GCC_WARNING_POP
+GODOT_CLANG_WARNING_POP
 
-RenderingContextDriverVulkanWindows::~RenderingContextDriverVulkanWindows() {
-	// Does nothing.
-}
-
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWindows::surface_create(const void *p_platform_data) {
-	const VulkanWindowsWindowPlatformData *wpd = (const VulkanWindowsWindowPlatformData *)(p_platform_data);
-
-	VkWin32SurfaceCreateInfoKHR create_info = {};
-	create_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
-	create_info.hinstance = (HINSTANCE)wpd->instance;
-	create_info.hwnd = (HWND)wpd->window;
-
-	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
-	VkResult err = vkCreateWin32SurfaceKHR(instance_get(), &create_info, get_allocation_callbacks(VK_OBJECT_TYPE_SURFACE_KHR), &vk_surface);
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
-
-	Surface *surface = memnew(Surface);
-	surface->vk_surface = vk_surface;
-	return SurfaceID(surface);
-}
-
-RenderingContextDriver *create_rendering_context_driver_vulkan_windows() {
-	return memnew(RenderingContextDriverVulkanWindows);
-}
-
-#endif // WINDOWS_ENABLED && VULKAN_ENABLED
+#include <wrl/client.h>

--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -29,6 +29,8 @@
 /**************************************************************************/
 
 #include "rendering_context_driver_d3d12.h"
+#include "rendering_context_driver_d3d12_public.h"
+#include "rendering_device_driver_d3d12_public.h"
 
 #include "d3d12_hooks.h"
 
@@ -37,7 +39,6 @@
 #include "core/string/ustring.h"
 #include "core/templates/local_vector.h"
 #include "core/version.h"
-#include "servers/rendering/rendering_device.h"
 
 GODOT_GCC_WARNING_PUSH
 GODOT_GCC_WARNING_IGNORE("-Wmissing-field-initializers")
@@ -248,17 +249,13 @@ bool RenderingContextDriverD3D12::device_supports_present(uint32_t p_device_inde
 }
 
 RenderingDeviceDriver *RenderingContextDriverD3D12::driver_create() {
-	return memnew(RenderingDeviceDriverD3D12(this));
-}
-
-void RenderingContextDriverD3D12::driver_free(RenderingDeviceDriver *p_driver) {
-	memdelete(p_driver);
+	return create_rendering_device_driver_d3d12(this);
 }
 
 RenderingContextDriver::SurfaceID RenderingContextDriverD3D12::surface_create(const void *p_platform_data) {
-	const WindowPlatformData *wpd = (const WindowPlatformData *)(p_platform_data);
+	const D3D12WindowPlatformData *wpd = (const D3D12WindowPlatformData *)(p_platform_data);
 	Surface *surface = memnew(Surface);
-	surface->hwnd = wpd->window;
+	surface->hwnd = (HWND)wpd->window;
 	return SurfaceID(surface);
 }
 
@@ -342,4 +339,8 @@ IDXGIFactory2 *RenderingContextDriverD3D12::dxgi_factory_get() const {
 
 bool RenderingContextDriverD3D12::get_tearing_supported() const {
 	return tearing_supported;
+}
+
+RenderingContextDriver *create_rendering_context_driver_d3d12() {
+	return memnew(RenderingContextDriverD3D12);
 }

--- a/drivers/d3d12/rendering_context_driver_d3d12.h
+++ b/drivers/d3d12/rendering_context_driver_d3d12.h
@@ -33,32 +33,10 @@
 #include "core/os/mutex.h"
 #include "core/string/ustring.h"
 #include "core/templates/rid_owner.h"
-#include "rendering_device_driver_d3d12.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_context_driver.h"
 
-#if !defined(_MSC_VER) && !defined(__REQUIRED_RPCNDR_H_VERSION__)
-// Match current version used by MinGW, MSVC and Direct3D 12 headers use 500.
-#define __REQUIRED_RPCNDR_H_VERSION__ 475
-#endif // !defined(_MSC_VER) && !defined(__REQUIRED_RPCNDR_H_VERSION__)
-
-GODOT_GCC_WARNING_PUSH
-GODOT_GCC_WARNING_IGNORE("-Wimplicit-fallthrough")
-GODOT_GCC_WARNING_IGNORE("-Wmissing-field-initializers")
-GODOT_GCC_WARNING_IGNORE("-Wnon-virtual-dtor")
-GODOT_GCC_WARNING_IGNORE("-Wshadow")
-GODOT_GCC_WARNING_IGNORE("-Wswitch")
-GODOT_CLANG_WARNING_PUSH
-GODOT_CLANG_WARNING_IGNORE("-Wimplicit-fallthrough")
-GODOT_CLANG_WARNING_IGNORE("-Wmissing-field-initializers")
-GODOT_CLANG_WARNING_IGNORE("-Wnon-virtual-dtor")
-GODOT_CLANG_WARNING_IGNORE("-Wstring-plus-int")
-GODOT_CLANG_WARNING_IGNORE("-Wswitch")
-
-#include <thirdparty/directx_headers/include/directx/d3dx12.h>
-
-GODOT_GCC_WARNING_POP
-GODOT_CLANG_WARNING_POP
+#include "godot_d3d12.h"
 
 #if defined(AS)
 #undef AS
@@ -67,8 +45,6 @@ GODOT_CLANG_WARNING_POP
 #ifdef DCOMP_ENABLED
 #include <dcomp.h>
 #endif
-
-#include <wrl/client.h>
 
 #define ARRAY_SIZE(a) std_size(a)
 
@@ -88,7 +64,6 @@ public:
 	virtual uint32_t device_get_count() const override;
 	virtual bool device_supports_present(uint32_t p_device_index, SurfaceID p_surface) const override;
 	virtual RenderingDeviceDriver *driver_create() override;
-	virtual void driver_free(RenderingDeviceDriver *p_driver) override;
 	virtual SurfaceID surface_create(const void *p_platform_data) override;
 	virtual void surface_set_size(SurfaceID p_surface, uint32_t p_width, uint32_t p_height) override;
 	virtual void surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) override;
@@ -99,11 +74,6 @@ public:
 	virtual bool surface_get_needs_resize(SurfaceID p_surface) const override;
 	virtual void surface_destroy(SurfaceID p_surface) override;
 	virtual bool is_debug_utils_enabled() const override;
-
-	// Platform-specific data for the Windows embedded in this driver.
-	struct WindowPlatformData {
-		HWND window;
-	};
 
 	// D3D12-only methods.
 	struct Surface {

--- a/drivers/d3d12/rendering_context_driver_d3d12_public.h
+++ b/drivers/d3d12/rendering_context_driver_d3d12_public.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rendering_context_driver_vulkan_windows.cpp                           */
+/*  rendering_context_driver_d3d12_public.h                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#if defined(WINDOWS_ENABLED) && defined(VULKAN_ENABLED)
+#pragma once
 
-#include "core/os/os.h"
+struct D3D12WindowPlatformData {
+	void *window; // HWND
+};
 
-#include "rendering_context_driver_vulkan_windows.h"
-#include "rendering_context_driver_vulkan_windows_public.h"
-
-#include "drivers/vulkan/godot_vulkan.h"
-
-const char *RenderingContextDriverVulkanWindows::_get_platform_surface_extension() const {
-	return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
-}
-
-RenderingContextDriverVulkanWindows::RenderingContextDriverVulkanWindows() {
-	// Workaround for Vulkan not working on setups with AMD integrated graphics + NVIDIA dedicated GPU (GH-57708).
-	// This prevents using AMD integrated graphics with Vulkan entirely, but it allows the engine to start
-	// even on outdated/broken driver setups.
-	OS::get_singleton()->set_environment("DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1", "1");
-}
-
-RenderingContextDriverVulkanWindows::~RenderingContextDriverVulkanWindows() {
-	// Does nothing.
-}
-
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWindows::surface_create(const void *p_platform_data) {
-	const VulkanWindowsWindowPlatformData *wpd = (const VulkanWindowsWindowPlatformData *)(p_platform_data);
-
-	VkWin32SurfaceCreateInfoKHR create_info = {};
-	create_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
-	create_info.hinstance = (HINSTANCE)wpd->instance;
-	create_info.hwnd = (HWND)wpd->window;
-
-	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
-	VkResult err = vkCreateWin32SurfaceKHR(instance_get(), &create_info, get_allocation_callbacks(VK_OBJECT_TYPE_SURFACE_KHR), &vk_surface);
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
-
-	Surface *surface = memnew(Surface);
-	surface->vk_surface = vk_surface;
-	return SurfaceID(surface);
-}
-
-RenderingContextDriver *create_rendering_context_driver_vulkan_windows() {
-	return memnew(RenderingContextDriverVulkanWindows);
-}
-
-#endif // WINDOWS_ENABLED && VULKAN_ENABLED
+class RenderingContextDriver *create_rendering_context_driver_d3d12();

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -6381,3 +6381,7 @@ Error RenderingDeviceDriverD3D12::initialize(uint32_t p_device_index, uint32_t p
 
 	return OK;
 }
+
+RenderingDeviceDriver *create_rendering_device_driver_d3d12(RenderingContextDriverD3D12 *p_context_driver) {
+	return memnew(RenderingDeviceDriverD3D12(p_context_driver));
+}

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -38,30 +38,7 @@
 #include "rendering_shader_container_d3d12.h"
 #include "servers/rendering/rendering_device_driver.h"
 
-#if !defined(_MSC_VER) && !defined(__REQUIRED_RPCNDR_H_VERSION__)
-// Match current version used by MinGW, MSVC and Direct3D 12 headers use 500.
-#define __REQUIRED_RPCNDR_H_VERSION__ 475
-#endif // !defined(_MSC_VER) && !defined(__REQUIRED_RPCNDR_H_VERSION__)
-
-GODOT_GCC_WARNING_PUSH
-GODOT_GCC_WARNING_IGNORE("-Wimplicit-fallthrough")
-GODOT_GCC_WARNING_IGNORE("-Wmissing-field-initializers")
-GODOT_GCC_WARNING_IGNORE("-Wnon-virtual-dtor")
-GODOT_GCC_WARNING_IGNORE("-Wshadow")
-GODOT_GCC_WARNING_IGNORE("-Wswitch")
-GODOT_CLANG_WARNING_PUSH
-GODOT_CLANG_WARNING_IGNORE("-Wimplicit-fallthrough")
-GODOT_CLANG_WARNING_IGNORE("-Wmissing-field-initializers")
-GODOT_CLANG_WARNING_IGNORE("-Wnon-virtual-dtor")
-GODOT_CLANG_WARNING_IGNORE("-Wstring-plus-int")
-GODOT_CLANG_WARNING_IGNORE("-Wswitch")
-
-#include <thirdparty/directx_headers/include/directx/d3dx12.h>
-
-GODOT_GCC_WARNING_POP
-GODOT_CLANG_WARNING_POP
-
-#include <wrl/client.h>
+#include "godot_d3d12.h"
 
 #ifdef DEV_ENABLED
 #define CUSTOM_INFO_QUEUE_ENABLED 0

--- a/drivers/d3d12/rendering_device_driver_d3d12_public.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12_public.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rendering_context_driver_vulkan_windows.cpp                           */
+/*  rendering_device_driver_d3d12_public.h                                */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#if defined(WINDOWS_ENABLED) && defined(VULKAN_ENABLED)
+#pragma once
 
-#include "core/os/os.h"
-
-#include "rendering_context_driver_vulkan_windows.h"
-#include "rendering_context_driver_vulkan_windows_public.h"
-
-#include "drivers/vulkan/godot_vulkan.h"
-
-const char *RenderingContextDriverVulkanWindows::_get_platform_surface_extension() const {
-	return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
-}
-
-RenderingContextDriverVulkanWindows::RenderingContextDriverVulkanWindows() {
-	// Workaround for Vulkan not working on setups with AMD integrated graphics + NVIDIA dedicated GPU (GH-57708).
-	// This prevents using AMD integrated graphics with Vulkan entirely, but it allows the engine to start
-	// even on outdated/broken driver setups.
-	OS::get_singleton()->set_environment("DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1", "1");
-}
-
-RenderingContextDriverVulkanWindows::~RenderingContextDriverVulkanWindows() {
-	// Does nothing.
-}
-
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWindows::surface_create(const void *p_platform_data) {
-	const VulkanWindowsWindowPlatformData *wpd = (const VulkanWindowsWindowPlatformData *)(p_platform_data);
-
-	VkWin32SurfaceCreateInfoKHR create_info = {};
-	create_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
-	create_info.hinstance = (HINSTANCE)wpd->instance;
-	create_info.hwnd = (HWND)wpd->window;
-
-	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
-	VkResult err = vkCreateWin32SurfaceKHR(instance_get(), &create_info, get_allocation_callbacks(VK_OBJECT_TYPE_SURFACE_KHR), &vk_surface);
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
-
-	Surface *surface = memnew(Surface);
-	surface->vk_surface = vk_surface;
-	return SurfaceID(surface);
-}
-
-RenderingContextDriver *create_rendering_context_driver_vulkan_windows() {
-	return memnew(RenderingContextDriverVulkanWindows);
-}
-
-#endif // WINDOWS_ENABLED && VULKAN_ENABLED
+class RenderingDeviceDriver *create_rendering_device_driver_d3d12(class RenderingContextDriverD3D12 *p_context_driver);

--- a/drivers/vulkan/rendering_context_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan.cpp
@@ -31,13 +31,13 @@
 #ifdef VULKAN_ENABLED
 
 #include "rendering_context_driver_vulkan.h"
+#include "rendering_device_driver_vulkan_public.h"
 
 #include "vk_enum_string_helper.h"
 
 #include "core/config/project_settings.h"
 #include "core/version.h"
 
-#include "rendering_device_driver_vulkan.h"
 #include "vulkan_hooks.h"
 
 #if defined(VK_TRACK_DRIVER_MEMORY)
@@ -961,11 +961,7 @@ bool RenderingContextDriverVulkan::device_supports_present(uint32_t p_device_ind
 }
 
 RenderingDeviceDriver *RenderingContextDriverVulkan::driver_create() {
-	return memnew(RenderingDeviceDriverVulkan(this));
-}
-
-void RenderingContextDriverVulkan::driver_free(RenderingDeviceDriver *p_driver) {
-	memdelete(p_driver);
+	return create_rendering_device_driver_vulkan(this);
 }
 
 RenderingContextDriver::SurfaceID RenderingContextDriverVulkan::surface_create(const void *p_platform_data) {
@@ -1052,6 +1048,10 @@ bool RenderingContextDriverVulkan::queue_family_supports_present(VkPhysicalDevic
 
 const RenderingContextDriverVulkan::Functions &RenderingContextDriverVulkan::functions_get() const {
 	return functions;
+}
+
+RenderingContextDriver *create_rendering_context_driver_vulkan() {
+	return memnew(RenderingContextDriverVulkan);
 }
 
 #endif // VULKAN_ENABLED

--- a/drivers/vulkan/rendering_context_driver_vulkan.h
+++ b/drivers/vulkan/rendering_context_driver_vulkan.h
@@ -133,7 +133,6 @@ public:
 	virtual uint32_t device_get_count() const override;
 	virtual bool device_supports_present(uint32_t p_device_index, SurfaceID p_surface) const override;
 	virtual RenderingDeviceDriver *driver_create() override;
-	virtual void driver_free(RenderingDeviceDriver *p_driver) override;
 	virtual SurfaceID surface_create(const void *p_platform_data) override;
 	virtual void surface_set_size(SurfaceID p_surface, uint32_t p_width, uint32_t p_height) override;
 	virtual void surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) override;

--- a/drivers/vulkan/rendering_context_driver_vulkan_public.h
+++ b/drivers/vulkan/rendering_context_driver_vulkan_public.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rendering_context_driver_vulkan_windows.cpp                           */
+/*  rendering_context_driver_vulkan_public.h                              */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#if defined(WINDOWS_ENABLED) && defined(VULKAN_ENABLED)
+#pragma once
 
-#include "core/os/os.h"
+#ifdef VULKAN_ENABLED
 
-#include "rendering_context_driver_vulkan_windows.h"
-#include "rendering_context_driver_vulkan_windows_public.h"
+class RenderingContextDriver *create_rendering_context_driver_vulkan();
 
-#include "drivers/vulkan/godot_vulkan.h"
-
-const char *RenderingContextDriverVulkanWindows::_get_platform_surface_extension() const {
-	return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
-}
-
-RenderingContextDriverVulkanWindows::RenderingContextDriverVulkanWindows() {
-	// Workaround for Vulkan not working on setups with AMD integrated graphics + NVIDIA dedicated GPU (GH-57708).
-	// This prevents using AMD integrated graphics with Vulkan entirely, but it allows the engine to start
-	// even on outdated/broken driver setups.
-	OS::get_singleton()->set_environment("DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1", "1");
-}
-
-RenderingContextDriverVulkanWindows::~RenderingContextDriverVulkanWindows() {
-	// Does nothing.
-}
-
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWindows::surface_create(const void *p_platform_data) {
-	const VulkanWindowsWindowPlatformData *wpd = (const VulkanWindowsWindowPlatformData *)(p_platform_data);
-
-	VkWin32SurfaceCreateInfoKHR create_info = {};
-	create_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
-	create_info.hinstance = (HINSTANCE)wpd->instance;
-	create_info.hwnd = (HWND)wpd->window;
-
-	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
-	VkResult err = vkCreateWin32SurfaceKHR(instance_get(), &create_info, get_allocation_callbacks(VK_OBJECT_TYPE_SURFACE_KHR), &vk_surface);
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
-
-	Surface *surface = memnew(Surface);
-	surface->vk_surface = vk_surface;
-	return SurfaceID(surface);
-}
-
-RenderingContextDriver *create_rendering_context_driver_vulkan_windows() {
-	return memnew(RenderingContextDriverVulkanWindows);
-}
-
-#endif // WINDOWS_ENABLED && VULKAN_ENABLED
+#endif

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -7323,3 +7323,7 @@ RenderingDeviceDriverVulkan::~RenderingDeviceDriverVulkan() {
 		vkDestroyDevice(vk_device, VKC::get_allocation_callbacks(VK_OBJECT_TYPE_DEVICE));
 	}
 }
+
+RenderingDeviceDriver *create_rendering_device_driver_vulkan(RenderingContextDriverVulkan *p_context_driver) {
+	return memnew(RenderingDeviceDriverVulkan(p_context_driver));
+}

--- a/drivers/vulkan/rendering_device_driver_vulkan_public.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan_public.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rendering_context_driver_vulkan_windows.cpp                           */
+/*  rendering_device_driver_vulkan_public.h                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#if defined(WINDOWS_ENABLED) && defined(VULKAN_ENABLED)
+#pragma once
 
-#include "core/os/os.h"
+#ifdef VULKAN_ENABLED
 
-#include "rendering_context_driver_vulkan_windows.h"
-#include "rendering_context_driver_vulkan_windows_public.h"
+class RenderingDeviceDriver *create_rendering_device_driver_vulkan(class RenderingContextDriverVulkan *p_context_driver);
 
-#include "drivers/vulkan/godot_vulkan.h"
-
-const char *RenderingContextDriverVulkanWindows::_get_platform_surface_extension() const {
-	return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
-}
-
-RenderingContextDriverVulkanWindows::RenderingContextDriverVulkanWindows() {
-	// Workaround for Vulkan not working on setups with AMD integrated graphics + NVIDIA dedicated GPU (GH-57708).
-	// This prevents using AMD integrated graphics with Vulkan entirely, but it allows the engine to start
-	// even on outdated/broken driver setups.
-	OS::get_singleton()->set_environment("DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1", "1");
-}
-
-RenderingContextDriverVulkanWindows::~RenderingContextDriverVulkanWindows() {
-	// Does nothing.
-}
-
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWindows::surface_create(const void *p_platform_data) {
-	const VulkanWindowsWindowPlatformData *wpd = (const VulkanWindowsWindowPlatformData *)(p_platform_data);
-
-	VkWin32SurfaceCreateInfoKHR create_info = {};
-	create_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
-	create_info.hinstance = (HINSTANCE)wpd->instance;
-	create_info.hwnd = (HWND)wpd->window;
-
-	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
-	VkResult err = vkCreateWin32SurfaceKHR(instance_get(), &create_info, get_allocation_callbacks(VK_OBJECT_TYPE_SURFACE_KHR), &vk_surface);
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
-
-	Surface *surface = memnew(Surface);
-	surface->vk_surface = vk_surface;
-	return SurfaceID(surface);
-}
-
-RenderingContextDriver *create_rendering_context_driver_vulkan_windows() {
-	return memnew(RenderingContextDriverVulkanWindows);
-}
-
-#endif // WINDOWS_ENABLED && VULKAN_ENABLED
+#endif

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -97,7 +97,7 @@ void BetsyCompressor::_init() {
 #endif
 #if defined(VULKAN_ENABLED)
 		if (rcd == nullptr) {
-			rcd = memnew(RenderingContextDriverVulkan);
+			rcd = create_rendering_context_driver_vulkan();
 			rd = memnew(RenderingDevice);
 		}
 #endif

--- a/modules/betsy/image_compress_betsy.h
+++ b/modules/betsy/image_compress_betsy.h
@@ -39,7 +39,7 @@
 #include "servers/rendering/rendering_server_default.h"
 
 #if defined(VULKAN_ENABLED)
-#include "drivers/vulkan/rendering_context_driver_vulkan.h"
+#include "drivers/vulkan/rendering_context_driver_vulkan_public.h"
 #endif
 #if defined(METAL_ENABLED)
 #include "drivers/metal/rendering_context_driver_metal.h"

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -45,7 +45,7 @@
 #include "servers/rendering/rendering_server_globals.h"
 
 #if defined(VULKAN_ENABLED)
-#include "drivers/vulkan/rendering_context_driver_vulkan.h"
+#include "drivers/vulkan/rendering_context_driver_vulkan_public.h"
 #endif
 #if defined(METAL_ENABLED)
 #include "drivers/metal/rendering_context_driver_metal.h"
@@ -1134,7 +1134,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 #endif
 #if defined(VULKAN_ENABLED)
 		if (rcd == nullptr) {
-			rcd = memnew(RenderingContextDriverVulkan);
+			rcd = create_rendering_context_driver_vulkan();
 			rd = memnew(RenderingDevice);
 		}
 #endif

--- a/modules/openxr/openxr_platform_inc.h
+++ b/modules/openxr/openxr_platform_inc.h
@@ -35,7 +35,7 @@
 
 #ifdef VULKAN_ENABLED
 #define XR_USE_GRAPHICS_API_VULKAN
-#include "drivers/vulkan/rendering_context_driver_vulkan.h"
+#include "drivers/vulkan/godot_vulkan.h"
 #endif // VULKAN_ENABLED
 
 #ifdef METAL_ENABLED
@@ -70,7 +70,7 @@
 
 #ifdef D3D12_ENABLED
 #define XR_USE_GRAPHICS_API_D3D12
-#include "drivers/d3d12/rendering_context_driver_d3d12.h"
+#include "drivers/d3d12/godot_d3d12.h"
 #endif // D3D12_ENABLED
 
 #ifdef X11_ENABLED

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -43,7 +43,7 @@
 #include "servers/rendering/rendering_device.h"
 
 #if defined(VULKAN_ENABLED)
-#include "rendering_context_driver_vulkan_android.h"
+#include "rendering_context_driver_vulkan_android_public.h"
 #endif
 #endif
 
@@ -683,7 +683,7 @@ bool DisplayServerAndroid::check_vulkan_global_context(bool p_vulkan_requirement
 		bool fallback_to_opengl3 = GLOBAL_GET("rendering/rendering_device/fallback_to_opengl3");
 		Error err = ERR_CANT_CREATE;
 		if (p_vulkan_requirements_met) {
-			rendering_context_global = memnew(RenderingContextDriverVulkanAndroid);
+			rendering_context_global = create_rendering_context_driver_vulkan_android();
 			err = rendering_context_global->initialize();
 		}
 
@@ -731,7 +731,7 @@ void DisplayServerAndroid::reset_window() {
 
 		union {
 #ifdef VULKAN_ENABLED
-			RenderingContextDriverVulkanAndroid::WindowPlatformData vulkan;
+			VulkanAndroidWindowPlatformData vulkan;
 #endif
 		} wpd;
 #ifdef VULKAN_ENABLED
@@ -790,7 +790,7 @@ DisplayServerAndroid::DisplayServerAndroid(const String &p_rendering_driver, Dis
 		ANativeWindow *native_window = OS_Android::get_singleton()->get_native_window();
 		ERR_FAIL_NULL(native_window);
 
-		RenderingContextDriverVulkanAndroid::WindowPlatformData wpd;
+		VulkanAndroidWindowPlatformData wpd;
 		wpd.window = native_window;
 
 		if (rendering_context_global->window_create(MAIN_WINDOW_ID, &wpd) != OK) {

--- a/platform/android/rendering_context_driver_vulkan_android.cpp
+++ b/platform/android/rendering_context_driver_vulkan_android.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "rendering_context_driver_vulkan_android.h"
+#include "rendering_context_driver_vulkan_android_public.h"
 
 #ifdef VULKAN_ENABLED
 
@@ -39,7 +40,7 @@ const char *RenderingContextDriverVulkanAndroid::_get_platform_surface_extension
 }
 
 RenderingContextDriver::SurfaceID RenderingContextDriverVulkanAndroid::surface_create(const void *p_platform_data) {
-	const WindowPlatformData *wpd = (const WindowPlatformData *)(p_platform_data);
+	const VulkanAndroidWindowPlatformData *wpd = (const VulkanAndroidWindowPlatformData *)(p_platform_data);
 
 	VkAndroidSurfaceCreateInfoKHR create_info = {};
 	create_info.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
@@ -60,6 +61,10 @@ bool RenderingContextDriverVulkanAndroid::_use_validation_layers() const {
 
 	// On Android, we use validation layers automatically if they were explicitly linked with the app.
 	return (err == OK) && !layer_names.is_empty();
+}
+
+RenderingContextDriver *create_rendering_context_driver_vulkan_android() {
+	return memnew(RenderingContextDriverVulkanAndroid);
 }
 
 #endif // VULKAN_ENABLED

--- a/platform/android/rendering_context_driver_vulkan_android.h
+++ b/platform/android/rendering_context_driver_vulkan_android.h
@@ -34,8 +34,6 @@
 
 #include "drivers/vulkan/rendering_context_driver_vulkan.h"
 
-struct ANativeWindow;
-
 class RenderingContextDriverVulkanAndroid : public RenderingContextDriverVulkan {
 private:
 	virtual const char *_get_platform_surface_extension() const override final;
@@ -45,10 +43,6 @@ protected:
 	bool _use_validation_layers() const override final;
 
 public:
-	struct WindowPlatformData {
-		ANativeWindow *window;
-	};
-
 	RenderingContextDriverVulkanAndroid() = default;
 	~RenderingContextDriverVulkanAndroid() override = default;
 };

--- a/platform/android/rendering_context_driver_vulkan_android_public.h
+++ b/platform/android/rendering_context_driver_vulkan_android_public.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rendering_context_driver_vulkan_windows.cpp                           */
+/*  rendering_context_driver_vulkan_android_public.h                      */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#if defined(WINDOWS_ENABLED) && defined(VULKAN_ENABLED)
+#pragma once
 
-#include "core/os/os.h"
+struct VulkanAndroidWindowPlatformData {
+	struct ANativeWindow *window;
+};
 
-#include "rendering_context_driver_vulkan_windows.h"
-#include "rendering_context_driver_vulkan_windows_public.h"
-
-#include "drivers/vulkan/godot_vulkan.h"
-
-const char *RenderingContextDriverVulkanWindows::_get_platform_surface_extension() const {
-	return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
-}
-
-RenderingContextDriverVulkanWindows::RenderingContextDriverVulkanWindows() {
-	// Workaround for Vulkan not working on setups with AMD integrated graphics + NVIDIA dedicated GPU (GH-57708).
-	// This prevents using AMD integrated graphics with Vulkan entirely, but it allows the engine to start
-	// even on outdated/broken driver setups.
-	OS::get_singleton()->set_environment("DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1", "1");
-}
-
-RenderingContextDriverVulkanWindows::~RenderingContextDriverVulkanWindows() {
-	// Does nothing.
-}
-
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWindows::surface_create(const void *p_platform_data) {
-	const VulkanWindowsWindowPlatformData *wpd = (const VulkanWindowsWindowPlatformData *)(p_platform_data);
-
-	VkWin32SurfaceCreateInfoKHR create_info = {};
-	create_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
-	create_info.hinstance = (HINSTANCE)wpd->instance;
-	create_info.hwnd = (HWND)wpd->window;
-
-	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
-	VkResult err = vkCreateWin32SurfaceKHR(instance_get(), &create_info, get_allocation_callbacks(VK_OBJECT_TYPE_SURFACE_KHR), &vk_surface);
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
-
-	Surface *surface = memnew(Surface);
-	surface->vk_surface = vk_surface;
-	return SurfaceID(surface);
-}
-
-RenderingContextDriver *create_rendering_context_driver_vulkan_windows() {
-	return memnew(RenderingContextDriverVulkanWindows);
-}
-
-#endif // WINDOWS_ENABLED && VULKAN_ENABLED
+class RenderingContextDriver *create_rendering_context_driver_vulkan_android();

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -63,10 +63,10 @@
 
 #if defined(VULKAN_ENABLED)
 #ifdef X11_ENABLED
-#include "x11/rendering_context_driver_vulkan_x11.h"
+#include "x11/rendering_context_driver_vulkan_x11_public.h"
 #endif
 #ifdef WAYLAND_ENABLED
-#include "wayland/rendering_context_driver_vulkan_wayland.h"
+#include "wayland/rendering_context_driver_vulkan_wayland_public.h"
 #endif
 #endif
 #if defined(GLES3_ENABLED)
@@ -1232,12 +1232,12 @@ bool OS_LinuxBSD::_test_create_rendering_device(const String &p_display_driver) 
 #if defined(VULKAN_ENABLED)
 #ifdef X11_ENABLED
 	if (p_display_driver == "x11" || p_display_driver.is_empty()) {
-		rcd = memnew(RenderingContextDriverVulkanX11);
+		rcd = create_rendering_context_driver_vulkan_x11();
 	}
 #endif
 #ifdef WAYLAND_ENABLED
 	if (p_display_driver == "wayland") {
-		rcd = memnew(RenderingContextDriverVulkanWayland);
+		rcd = create_rendering_context_driver_vulkan_wayland();
 	}
 #endif
 #endif

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -821,7 +821,7 @@ void DisplayServerWayland::show_window(WindowID p_window_id) {
 		if (rendering_context) {
 			union {
 #ifdef VULKAN_ENABLED
-				RenderingContextDriverVulkanWayland::WindowPlatformData vulkan;
+				VulkanWaylandWindowPlatformData vulkan;
 #endif
 			} wpd;
 #ifdef VULKAN_ENABLED
@@ -2068,7 +2068,7 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Win
 #ifdef RD_ENABLED
 #ifdef VULKAN_ENABLED
 	if (rendering_driver == "vulkan") {
-		rendering_context = memnew(RenderingContextDriverVulkanWayland);
+		rendering_context = create_rendering_context_driver_vulkan_wayland();
 	}
 #endif // VULKAN_ENABLED
 

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -38,7 +38,7 @@
 #include "servers/rendering/rendering_device.h"
 
 #ifdef VULKAN_ENABLED
-#include "wayland/rendering_context_driver_vulkan_wayland.h"
+#include "wayland/rendering_context_driver_vulkan_wayland_public.h"
 #endif
 
 #endif //RD_ENABLED

--- a/platform/linuxbsd/wayland/rendering_context_driver_vulkan_wayland.cpp
+++ b/platform/linuxbsd/wayland/rendering_context_driver_vulkan_wayland.cpp
@@ -31,6 +31,7 @@
 #ifdef VULKAN_ENABLED
 
 #include "rendering_context_driver_vulkan_wayland.h"
+#include "rendering_context_driver_vulkan_wayland_public.h"
 
 #include "drivers/vulkan/godot_vulkan.h"
 
@@ -39,7 +40,7 @@ const char *RenderingContextDriverVulkanWayland::_get_platform_surface_extension
 }
 
 RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWayland::surface_create(const void *p_platform_data) {
-	const WindowPlatformData *wpd = (const WindowPlatformData *)(p_platform_data);
+	const VulkanWaylandWindowPlatformData *wpd = (const VulkanWaylandWindowPlatformData *)(p_platform_data);
 
 	VkWaylandSurfaceCreateInfoKHR create_info = {};
 	create_info.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
@@ -61,6 +62,10 @@ RenderingContextDriverVulkanWayland::RenderingContextDriverVulkanWayland() {
 
 RenderingContextDriverVulkanWayland::~RenderingContextDriverVulkanWayland() {
 	// Does nothing.
+}
+
+RenderingContextDriver *create_rendering_context_driver_vulkan_wayland() {
+	return memnew(RenderingContextDriverVulkanWayland);
 }
 
 #endif // VULKAN_ENABLED

--- a/platform/linuxbsd/wayland/rendering_context_driver_vulkan_wayland.h
+++ b/platform/linuxbsd/wayland/rendering_context_driver_vulkan_wayland.h
@@ -42,11 +42,6 @@ protected:
 	SurfaceID surface_create(const void *p_platform_data) override final;
 
 public:
-	struct WindowPlatformData {
-		struct wl_display *display;
-		struct wl_surface *surface;
-	};
-
 	RenderingContextDriverVulkanWayland();
 	~RenderingContextDriverVulkanWayland();
 };

--- a/platform/linuxbsd/wayland/rendering_context_driver_vulkan_wayland_public.h
+++ b/platform/linuxbsd/wayland/rendering_context_driver_vulkan_wayland_public.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rendering_context_driver_vulkan_windows.cpp                           */
+/*  rendering_context_driver_vulkan_wayland_public.h                      */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,15 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#if defined(WINDOWS_ENABLED) && defined(VULKAN_ENABLED)
+#pragma once
 
-#include "core/os/os.h"
+#ifdef VULKAN_ENABLED
 
-#include "rendering_context_driver_vulkan_windows.h"
-#include "rendering_context_driver_vulkan_windows_public.h"
+struct VulkanWaylandWindowPlatformData {
+	struct wl_display *display;
+	struct wl_surface *surface;
+};
 
-#include "drivers/vulkan/godot_vulkan.h"
+class RenderingContextDriver *create_rendering_context_driver_vulkan_wayland();
 
-const char *RenderingContextDriverVulkanWindows::_get_platform_surface_extension() const {
-	return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
-}
-
-RenderingContextDriverVulkanWindows::RenderingContextDriverVulkanWindows() {
-	// Workaround for Vulkan not working on setups with AMD integrated graphics + NVIDIA dedicated GPU (GH-57708).
-	// This prevents using AMD integrated graphics with Vulkan entirely, but it allows the engine to start
-	// even on outdated/broken driver setups.
-	OS::get_singleton()->set_environment("DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1", "1");
-}
-
-RenderingContextDriverVulkanWindows::~RenderingContextDriverVulkanWindows() {
-	// Does nothing.
-}
-
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWindows::surface_create(const void *p_platform_data) {
-	const VulkanWindowsWindowPlatformData *wpd = (const VulkanWindowsWindowPlatformData *)(p_platform_data);
-
-	VkWin32SurfaceCreateInfoKHR create_info = {};
-	create_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
-	create_info.hinstance = (HINSTANCE)wpd->instance;
-	create_info.hwnd = (HWND)wpd->window;
-
-	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
-	VkResult err = vkCreateWin32SurfaceKHR(instance_get(), &create_info, get_allocation_callbacks(VK_OBJECT_TYPE_SURFACE_KHR), &vk_surface);
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
-
-	Surface *surface = memnew(Surface);
-	surface->vk_surface = vk_surface;
-	return SurfaceID(surface);
-}
-
-RenderingContextDriver *create_rendering_context_driver_vulkan_windows() {
-	return memnew(RenderingContextDriverVulkanWindows);
-}
-
-#endif // WINDOWS_ENABLED && VULKAN_ENABLED
+#endif

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -6574,7 +6574,7 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 		if (rendering_context) {
 			union {
 #ifdef VULKAN_ENABLED
-				RenderingContextDriverVulkanX11::WindowPlatformData vulkan;
+				VulkanX11WindowPlatformData vulkan;
 #endif
 			} wpd;
 #ifdef VULKAN_ENABLED
@@ -7033,7 +7033,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 #if defined(RD_ENABLED)
 #if defined(VULKAN_ENABLED)
 	if (rendering_driver == "vulkan") {
-		rendering_context = memnew(RenderingContextDriverVulkanX11);
+		rendering_context = create_rendering_context_driver_vulkan_x11();
 	}
 #endif // VULKAN_ENABLED
 

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -59,7 +59,7 @@
 #include "servers/rendering/rendering_device.h"
 
 #if defined(VULKAN_ENABLED)
-#include "x11/rendering_context_driver_vulkan_x11.h"
+#include "x11/rendering_context_driver_vulkan_x11_public.h"
 #endif
 #endif
 

--- a/platform/linuxbsd/x11/rendering_context_driver_vulkan_x11.cpp
+++ b/platform/linuxbsd/x11/rendering_context_driver_vulkan_x11.cpp
@@ -31,6 +31,7 @@
 #ifdef VULKAN_ENABLED
 
 #include "rendering_context_driver_vulkan_x11.h"
+#include "rendering_context_driver_vulkan_x11_public.h"
 
 #include "drivers/vulkan/godot_vulkan.h"
 
@@ -39,7 +40,7 @@ const char *RenderingContextDriverVulkanX11::_get_platform_surface_extension() c
 }
 
 RenderingContextDriver::SurfaceID RenderingContextDriverVulkanX11::surface_create(const void *p_platform_data) {
-	const WindowPlatformData *wpd = (const WindowPlatformData *)(p_platform_data);
+	const VulkanX11WindowPlatformData *wpd = (const VulkanX11WindowPlatformData *)(p_platform_data);
 
 	VkXlibSurfaceCreateInfoKHR create_info = {};
 	create_info.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
@@ -61,6 +62,10 @@ RenderingContextDriverVulkanX11::RenderingContextDriverVulkanX11() {
 
 RenderingContextDriverVulkanX11::~RenderingContextDriverVulkanX11() {
 	// Does nothing.
+}
+
+RenderingContextDriver *create_rendering_context_driver_vulkan_x11() {
+	return memnew(RenderingContextDriverVulkanX11);
 }
 
 #endif // VULKAN_ENABLED

--- a/platform/linuxbsd/x11/rendering_context_driver_vulkan_x11.h
+++ b/platform/linuxbsd/x11/rendering_context_driver_vulkan_x11.h
@@ -34,8 +34,6 @@
 
 #include "drivers/vulkan/rendering_context_driver_vulkan.h"
 
-#include <X11/Xlib.h>
-
 class RenderingContextDriverVulkanX11 : public RenderingContextDriverVulkan {
 private:
 	virtual const char *_get_platform_surface_extension() const override final;
@@ -44,11 +42,6 @@ protected:
 	SurfaceID surface_create(const void *p_platform_data) override final;
 
 public:
-	struct WindowPlatformData {
-		::Window window;
-		Display *display;
-	};
-
 	RenderingContextDriverVulkanX11();
 	~RenderingContextDriverVulkanX11();
 };

--- a/platform/linuxbsd/x11/rendering_context_driver_vulkan_x11_public.h
+++ b/platform/linuxbsd/x11/rendering_context_driver_vulkan_x11_public.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rendering_context_driver_vulkan_windows.cpp                           */
+/*  rendering_context_driver_vulkan_x11_public.h                          */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,17 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#if defined(WINDOWS_ENABLED) && defined(VULKAN_ENABLED)
+#pragma once
 
-#include "core/os/os.h"
+#ifdef VULKAN_ENABLED
 
-#include "rendering_context_driver_vulkan_windows.h"
-#include "rendering_context_driver_vulkan_windows_public.h"
+#include <X11/Xlib.h>
 
-#include "drivers/vulkan/godot_vulkan.h"
+struct VulkanX11WindowPlatformData {
+	::Window window;
+	Display *display;
+};
 
-const char *RenderingContextDriverVulkanWindows::_get_platform_surface_extension() const {
-	return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
-}
+class RenderingContextDriver *create_rendering_context_driver_vulkan_x11();
 
-RenderingContextDriverVulkanWindows::RenderingContextDriverVulkanWindows() {
-	// Workaround for Vulkan not working on setups with AMD integrated graphics + NVIDIA dedicated GPU (GH-57708).
-	// This prevents using AMD integrated graphics with Vulkan entirely, but it allows the engine to start
-	// even on outdated/broken driver setups.
-	OS::get_singleton()->set_environment("DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1", "1");
-}
-
-RenderingContextDriverVulkanWindows::~RenderingContextDriverVulkanWindows() {
-	// Does nothing.
-}
-
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWindows::surface_create(const void *p_platform_data) {
-	const VulkanWindowsWindowPlatformData *wpd = (const VulkanWindowsWindowPlatformData *)(p_platform_data);
-
-	VkWin32SurfaceCreateInfoKHR create_info = {};
-	create_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
-	create_info.hinstance = (HINSTANCE)wpd->instance;
-	create_info.hwnd = (HWND)wpd->window;
-
-	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
-	VkResult err = vkCreateWin32SurfaceKHR(instance_get(), &create_info, get_allocation_callbacks(VK_OBJECT_TYPE_SURFACE_KHR), &vk_surface);
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
-
-	Surface *surface = memnew(Surface);
-	surface->vk_surface = vk_surface;
-	return SurfaceID(surface);
-}
-
-RenderingContextDriver *create_rendering_context_driver_vulkan_windows() {
-	return memnew(RenderingContextDriverVulkanWindows);
-}
-
-#endif // WINDOWS_ENABLED && VULKAN_ENABLED
+#endif

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -53,10 +53,10 @@
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 
 #if defined(VULKAN_ENABLED)
-#include "rendering_context_driver_vulkan_windows.h"
+#include "rendering_context_driver_vulkan_windows_public.h"
 #endif
 #if defined(D3D12_ENABLED)
-#include "drivers/d3d12/rendering_context_driver_d3d12.h"
+#include "drivers/d3d12/rendering_context_driver_d3d12_public.h"
 #endif
 #if defined(GLES3_ENABLED)
 #include "drivers/gles3/rasterizer_gles3.h"
@@ -6685,10 +6685,10 @@ Error DisplayServerWindows::_create_rendering_context_window(WindowID p_window_i
 
 	union {
 #ifdef VULKAN_ENABLED
-		RenderingContextDriverVulkanWindows::WindowPlatformData vulkan;
+		VulkanWindowsWindowPlatformData vulkan;
 #endif
 #ifdef D3D12_ENABLED
-		RenderingContextDriverD3D12::WindowPlatformData d3d12;
+		D3D12WindowPlatformData d3d12;
 #endif
 	} wpd;
 #ifdef VULKAN_ENABLED
@@ -7268,13 +7268,13 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 
 #ifdef VULKAN_ENABLED
 		if (tested_rendering_driver == "vulkan") {
-			rendering_context = memnew(RenderingContextDriverVulkanWindows);
+			rendering_context = create_rendering_context_driver_vulkan_windows();
 			tested_drivers.set_flag(DRIVER_ID_RD_VULKAN);
 		}
 #endif
 #ifdef D3D12_ENABLED
 		if (tested_rendering_driver == "d3d12") {
-			rendering_context = memnew(RenderingContextDriverD3D12);
+			rendering_context = create_rendering_context_driver_d3d12();
 			tested_drivers.set_flag(DRIVER_ID_RD_D3D12);
 		}
 #endif

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -82,10 +82,10 @@ extern "C" {
 #endif
 
 #if defined(VULKAN_ENABLED)
-#include "rendering_context_driver_vulkan_windows.h"
+#include "drivers/vulkan/rendering_context_driver_vulkan_public.h"
 #endif
 #if defined(D3D12_ENABLED)
-#include "drivers/d3d12/rendering_context_driver_d3d12.h"
+#include "drivers/d3d12/rendering_context_driver_d3d12_public.h"
 #endif
 #if defined(GLES3_ENABLED)
 #include "drivers/gles3/rasterizer_gles3.h"
@@ -2673,11 +2673,11 @@ bool OS_Windows::_test_create_rendering_device(const String &p_display_driver) c
 	RenderingContextDriver *rcd = nullptr;
 
 #if defined(VULKAN_ENABLED)
-	rcd = memnew(RenderingContextDriverVulkan);
+	rcd = create_rendering_context_driver_vulkan();
 #endif
 #ifdef D3D12_ENABLED
 	if (rcd == nullptr) {
-		rcd = memnew(RenderingContextDriverD3D12);
+		rcd = create_rendering_context_driver_d3d12();
 	}
 #endif
 	if (rcd != nullptr) {

--- a/platform/windows/rendering_context_driver_vulkan_windows.h
+++ b/platform/windows/rendering_context_driver_vulkan_windows.h
@@ -34,9 +34,6 @@
 
 #include "drivers/vulkan/rendering_context_driver_vulkan.h"
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-
 class RenderingContextDriverVulkanWindows : public RenderingContextDriverVulkan {
 private:
 	const char *_get_platform_surface_extension() const override final;
@@ -45,11 +42,6 @@ protected:
 	SurfaceID surface_create(const void *p_platform_data) override final;
 
 public:
-	struct WindowPlatformData {
-		HWND window;
-		HINSTANCE instance;
-	};
-
 	RenderingContextDriverVulkanWindows();
 	~RenderingContextDriverVulkanWindows() override;
 };

--- a/platform/windows/rendering_context_driver_vulkan_windows_public.h
+++ b/platform/windows/rendering_context_driver_vulkan_windows_public.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rendering_context_driver_vulkan_windows.cpp                           */
+/*  rendering_context_driver_vulkan_windows_public.h                      */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,15 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#if defined(WINDOWS_ENABLED) && defined(VULKAN_ENABLED)
+#pragma once
 
-#include "core/os/os.h"
+#ifdef VULKAN_ENABLED
 
-#include "rendering_context_driver_vulkan_windows.h"
-#include "rendering_context_driver_vulkan_windows_public.h"
+struct VulkanWindowsWindowPlatformData {
+	void *window; // HWND
+	void *instance; // HINSTANCE
+};
 
-#include "drivers/vulkan/godot_vulkan.h"
+class RenderingContextDriver *create_rendering_context_driver_vulkan_windows();
 
-const char *RenderingContextDriverVulkanWindows::_get_platform_surface_extension() const {
-	return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
-}
-
-RenderingContextDriverVulkanWindows::RenderingContextDriverVulkanWindows() {
-	// Workaround for Vulkan not working on setups with AMD integrated graphics + NVIDIA dedicated GPU (GH-57708).
-	// This prevents using AMD integrated graphics with Vulkan entirely, but it allows the engine to start
-	// even on outdated/broken driver setups.
-	OS::get_singleton()->set_environment("DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1", "1");
-}
-
-RenderingContextDriverVulkanWindows::~RenderingContextDriverVulkanWindows() {
-	// Does nothing.
-}
-
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWindows::surface_create(const void *p_platform_data) {
-	const VulkanWindowsWindowPlatformData *wpd = (const VulkanWindowsWindowPlatformData *)(p_platform_data);
-
-	VkWin32SurfaceCreateInfoKHR create_info = {};
-	create_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
-	create_info.hinstance = (HINSTANCE)wpd->instance;
-	create_info.hwnd = (HWND)wpd->window;
-
-	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
-	VkResult err = vkCreateWin32SurfaceKHR(instance_get(), &create_info, get_allocation_callbacks(VK_OBJECT_TYPE_SURFACE_KHR), &vk_surface);
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
-
-	Surface *surface = memnew(Surface);
-	surface->vk_surface = vk_surface;
-	return SurfaceID(surface);
-}
-
-RenderingContextDriver *create_rendering_context_driver_vulkan_windows() {
-	return memnew(RenderingContextDriverVulkanWindows);
-}
-
-#endif // WINDOWS_ENABLED && VULKAN_ENABLED
+#endif

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -38,11 +38,11 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, Input);
 #include "servers/display/display_server_headless.h"
 
 #if defined(VULKAN_ENABLED)
-#include "drivers/vulkan/rendering_context_driver_vulkan.h"
+#include "drivers/vulkan/rendering_context_driver_vulkan_public.h"
 #undef CursorShape
 #endif
 #if defined(D3D12_ENABLED)
-#include "drivers/d3d12/rendering_context_driver_d3d12.h"
+#include "drivers/d3d12/rendering_context_driver_d3d12_public.h"
 #endif
 #if defined(METAL_ENABLED)
 #include "drivers/metal/rendering_context_driver_metal.h"
@@ -2011,11 +2011,11 @@ bool DisplayServer::is_rendering_device_supported() {
 	RenderingContextDriver *rcd = nullptr;
 
 #if defined(VULKAN_ENABLED)
-	rcd = memnew(RenderingContextDriverVulkan);
+	rcd = create_rendering_context_driver_vulkan();
 #endif
 #ifdef D3D12_ENABLED
 	if (rcd == nullptr) {
-		rcd = memnew(RenderingContextDriverD3D12);
+		rcd = create_rendering_context_driver_d3d12();
 	}
 #endif
 #ifdef METAL_ENABLED
@@ -2093,11 +2093,11 @@ bool DisplayServer::can_create_rendering_device() {
 	RenderingContextDriver *rcd = nullptr;
 
 #if defined(VULKAN_ENABLED)
-	rcd = memnew(RenderingContextDriverVulkan);
+	rcd = create_rendering_context_driver_vulkan();
 #endif
 #ifdef D3D12_ENABLED
 	if (rcd == nullptr) {
-		rcd = memnew(RenderingContextDriverD3D12);
+		rcd = create_rendering_context_driver_d3d12();
 	}
 #endif
 #ifdef METAL_ENABLED

--- a/servers/rendering/rendering_context_driver.h
+++ b/servers/rendering/rendering_context_driver.h
@@ -92,7 +92,7 @@ public:
 	virtual uint32_t device_get_count() const = 0;
 	virtual bool device_supports_present(uint32_t p_device_index, SurfaceID p_surface) const = 0;
 	virtual RenderingDeviceDriver *driver_create() = 0;
-	virtual void driver_free(RenderingDeviceDriver *p_driver) = 0;
+	virtual void driver_free(RenderingDeviceDriver *p_driver);
 	virtual SurfaceID surface_create(const void *p_platform_data) = 0;
 	virtual void surface_set_size(SurfaceID p_surface, uint32_t p_width, uint32_t p_height) = 0;
 	virtual void surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) = 0;

--- a/servers/rendering/rendering_device_driver.cpp
+++ b/servers/rendering/rendering_device_driver.cpp
@@ -30,6 +30,10 @@
 
 #include "rendering_device_driver.h"
 
+void RenderingContextDriver::driver_free(RenderingDeviceDriver *p_driver) {
+	memdelete(p_driver);
+}
+
 /**************/
 /**** MISC ****/
 /**************/


### PR DESCRIPTION
Creates a separate "public" header for the rendering context & device drivers, so that other files do not have to include the whole implementation header just to construct the object. As a result, when modifying the driver code, only the implementation files actually get recompiled. This saves around 10 seconds of recompilation time on my PC when working on the rendering backends.

I'm not sure about the `_public.h` suffix on the header names, I can change that if requested.
I'll do Apple/Metal parts after #114484 gets merged since I don't want to conflict with it.