### PR TITLE
CI: Enable Ruff preview options; bump version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,13 +41,14 @@ repos:
         stages: [manual] # Not automatically triggered, invoked via `pre-commit run --hook-stage manual clang-tidy`
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.7
+    rev: v0.15.0
     hooks:
       - id: ruff-check
-        args: [--fix]
+        args: [--color=always]
         files: (\.py|SConstruct|SCsub)$
         types_or: [text]
       - id: ruff-format
+        args: [--color=always]
         files: (\.py|SConstruct|SCsub)$
         types_or: [text]
 

--- a/methods.py
+++ b/methods.py
@@ -673,7 +673,8 @@ def is_apple_clang(env):
         return False
     try:
         version = (
-            subprocess.check_output(shlex.split(env.subst(env["CXX"]), posix=False) + ["--version"])
+            subprocess
+            .check_output(shlex.split(env.subst(env["CXX"]), posix=False) + ["--version"])
             .strip()
             .decode("utf-8")
         )

--- a/modules/modules_builders.py
+++ b/modules/modules_builders.py
@@ -15,24 +15,20 @@ def modules_enabled_builder(target, source, env):
 def register_module_types_builder(target, source, env):
     modules = source[0].read()
     mod_inc = "\n".join([f'#include "{value}/register_types.h"' for value in modules.values()])
-    mod_init = "\n".join(
-        [
-            f"""\
+    mod_init = "\n".join([
+        f"""\
 #ifdef MODULE_{key.upper()}_ENABLED
 	initialize_{key}_module(p_level);
 #endif"""
-            for key in modules.keys()
-        ]
-    )
-    mod_uninit = "\n".join(
-        [
-            f"""\
+        for key in modules.keys()
+    ])
+    mod_uninit = "\n".join([
+        f"""\
 #ifdef MODULE_{key.upper()}_ENABLED
 	uninitialize_{key}_module(p_level);
 #endif"""
-            for key in modules.keys()
-        ]
-    )
+        for key in modules.keys()
+    ])
     with methods.generated_wrapper(str(target[0])) as file:
         file.write(
             f"""\

--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -183,13 +183,11 @@ def run_msbuild(tools: ToolsLocation, sln: str, chdir_to: str, msbuild_args: lis
         # The (Csc/Vbc/Fsc)ToolExe environment variables are required when
         # building with Mono's MSBuild. They must point to the batch files
         # in Mono's bin directory to make sure they are executed with Mono.
-        msbuild_env.update(
-            {
-                "CscToolExe": os.path.join(tools.mono_bin_dir, "csc.bat"),
-                "VbcToolExe": os.path.join(tools.mono_bin_dir, "vbc.bat"),
-                "FscToolExe": os.path.join(tools.mono_bin_dir, "fsharpc.bat"),
-            }
-        )
+        msbuild_env.update({
+            "CscToolExe": os.path.join(tools.mono_bin_dir, "csc.bat"),
+            "VbcToolExe": os.path.join(tools.mono_bin_dir, "vbc.bat"),
+            "FscToolExe": os.path.join(tools.mono_bin_dir, "fsharpc.bat"),
+        })
 
     # We want to control cwd when running msbuild, because that's where the search for global.json begins.
     return subprocess.call(args, env=msbuild_env, cwd=chdir_to)

--- a/platform/linuxbsd/wayland/SCsub
+++ b/platform/linuxbsd/wayland/SCsub
@@ -123,13 +123,11 @@ source_files = generated_sources + [
 ]
 
 if env["use_sowrap"]:
-    source_files.append(
-        [
-            File("dynwrappers/wayland-cursor-so_wrap.c"),
-            File("dynwrappers/wayland-client-core-so_wrap.c"),
-            File("dynwrappers/wayland-egl-core-so_wrap.c"),
-        ]
-    )
+    source_files.append([
+        File("dynwrappers/wayland-cursor-so_wrap.c"),
+        File("dynwrappers/wayland-client-core-so_wrap.c"),
+        File("dynwrappers/wayland-egl-core-so_wrap.c"),
+    ])
 
     if env["libdecor"]:
         source_files.append(File("dynwrappers/libdecor-so_wrap.c"))

--- a/platform/linuxbsd/x11/SCsub
+++ b/platform/linuxbsd/x11/SCsub
@@ -11,30 +11,26 @@ source_files = [
 ]
 
 if env["use_sowrap"]:
-    source_files.append(
-        [
-            File("dynwrappers/xlib-so_wrap.c"),
-            File("dynwrappers/xcursor-so_wrap.c"),
-            File("dynwrappers/xinerama-so_wrap.c"),
-            File("dynwrappers/xinput2-so_wrap.c"),
-            File("dynwrappers/xrandr-so_wrap.c"),
-            File("dynwrappers/xrender-so_wrap.c"),
-            File("dynwrappers/xext-so_wrap.c"),
-        ]
-    )
+    source_files.append([
+        File("dynwrappers/xlib-so_wrap.c"),
+        File("dynwrappers/xcursor-so_wrap.c"),
+        File("dynwrappers/xinerama-so_wrap.c"),
+        File("dynwrappers/xinput2-so_wrap.c"),
+        File("dynwrappers/xrandr-so_wrap.c"),
+        File("dynwrappers/xrender-so_wrap.c"),
+        File("dynwrappers/xext-so_wrap.c"),
+    ])
 
 if env["vulkan"]:
     source_files.append(File("rendering_context_driver_vulkan_x11.cpp"))
 
 if env["opengl3"]:
     env.Append(CPPDEFINES=["GLAD_GLX_NO_X11"])
-    source_files.append(
-        [
-            File("gl_manager_x11_egl.cpp"),
-            File("gl_manager_x11.cpp"),
-            File("detect_prime_x11.cpp"),
-            File("#thirdparty/glad/glx.c"),
-        ]
-    )
+    source_files.append([
+        File("gl_manager_x11_egl.cpp"),
+        File("gl_manager_x11.cpp"),
+        File("detect_prime_x11.cpp"),
+        File("#thirdparty/glad/glx.c"),
+    ])
 
 Return("source_files")

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -34,30 +34,24 @@ if env["target"] == "editor":
     env.add_source_files(web_files, "editor/*.cpp")
 
 sys_env = env.Clone()
-sys_env.AddJSLibraries(
-    [
-        "js/libs/library_godot_audio.js",
-        "js/libs/library_godot_display.js",
-        "js/libs/library_godot_emscripten.js",
-        "js/libs/library_godot_fetch.js",
-        "js/libs/library_godot_webmidi.js",
-        "js/libs/library_godot_os.js",
-        "js/libs/library_godot_runtime.js",
-        "js/libs/library_godot_input.js",
-        "js/libs/library_godot_webgl2.js",
-    ]
-)
-sys_env.AddJSExterns(
-    [
-        "js/libs/library_godot_webgl2.externs.js",
-    ]
-)
+sys_env.AddJSLibraries([
+    "js/libs/library_godot_audio.js",
+    "js/libs/library_godot_display.js",
+    "js/libs/library_godot_emscripten.js",
+    "js/libs/library_godot_fetch.js",
+    "js/libs/library_godot_webmidi.js",
+    "js/libs/library_godot_os.js",
+    "js/libs/library_godot_runtime.js",
+    "js/libs/library_godot_input.js",
+    "js/libs/library_godot_webgl2.js",
+])
+sys_env.AddJSExterns([
+    "js/libs/library_godot_webgl2.externs.js",
+])
 
-sys_env.AddJSPost(
-    [
-        "js/patches/patch_em_gl.js",
-    ]
-)
+sys_env.AddJSPost([
+    "js/patches/patch_em_gl.js",
+])
 
 if env["javascript_eval"]:
     sys_env.AddJSLibraries(["js/libs/library_godot_javascript_singleton.js"])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -527,7 +527,8 @@ def get_ar_version(env):
     }
     try:
         output = (
-            subprocess.check_output([env.subst(env["AR"]), "--version"], shell=(os.name == "nt"))
+            subprocess
+            .check_output([env.subst(env["AR"]), "--version"], shell=(os.name == "nt"))
             .strip()
             .decode("utf-8")
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,10 @@ python_version = "3.8"
 [tool.ruff]
 extend-exclude = ["thirdparty"]
 extend-include = ["*SConstruct", "*SCsub"]
-line-length = 120
 target-version = "py38"
+line-length = 120
+preview = true
+fix = true
 
 [tool.ruff.lint]
 extend-select = [


### PR DESCRIPTION
- Enables preview options for Ruff, slightly expanding the functionality of our given ruleset
- Bumps pre-commit Ruff version (1.14.7 → 1.15.0)
- Enabled fixing files by default in the config
- Enabled color output for Ruff in pre-commit
