### PR TITLE
Fix use-after-free in Animation Blend Tree

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1590,7 +1590,8 @@ void AnimationNodeBlendTree::rename_node(const StringName &p_name, const StringN
 
 	nodes[p_name].node->disconnect_changed(callable_mp(this, &AnimationNodeBlendTree::_node_changed));
 
-	nodes[p_new_name] = nodes[p_name];
+	const Node temp_copy = nodes[p_name];
+	nodes[p_new_name] = temp_copy; // might realloc
 	nodes.erase(p_name);
 
 	// Rename connections.


### PR DESCRIPTION
caused by unsafe usage of AHashMap.

Fixes #115912.

A safe insert API for `AHashMap` might be preferable for the future maybe :thinking: 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
