### PR TITLE
Update re-spirv with more derivative operations.

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -929,7 +929,7 @@ Files extracted from upstream source:
 ## re-spirv
 
 - Upstream: https://github.com/renderbag/re-spirv
-- Version: git (5af3b606e6aaf11bae8dc7b5cd236c943e24865e, 2025)
+- Version: git (c1853b0221cd43866b792406f55c4ab10a0b4503, 2026)
 - License: MIT
 
 Files extracted from upstream source:

--- a/thirdparty/re-spirv/re-spirv.cpp
+++ b/thirdparty/re-spirv/re-spirv.cpp
@@ -182,6 +182,12 @@ namespace respv {
         case SpvOpDPdx:
         case SpvOpDPdy:
         case SpvOpFwidth:
+        case SpvOpDPdxFine:
+        case SpvOpDPdyFine:
+        case SpvOpFwidthFine:
+        case SpvOpDPdxCoarse:
+        case SpvOpDPdyCoarse:
+        case SpvOpFwidthCoarse:
         case SpvOpControlBarrier:
         case SpvOpMemoryBarrier:
         case SpvOpAtomicLoad:
@@ -359,6 +365,12 @@ namespace respv {
         case SpvOpDPdx:
         case SpvOpDPdy:
         case SpvOpFwidth:
+        case SpvOpDPdxFine:
+        case SpvOpDPdyFine:
+        case SpvOpFwidthFine:
+        case SpvOpDPdxCoarse:
+        case SpvOpDPdyCoarse:
+        case SpvOpFwidthCoarse:
         case SpvOpGroupNonUniformElect:
         case SpvOpCopyLogical:
             rOperandWordStart = 3;


### PR DESCRIPTION
Should fix the error spam from https://github.com/godotengine/godot/issues/115918.

For future reference, the error spam is harmless and re-spirv falls back to not optimizing the shader in these cases. The errors are so we're notified about fixing this as soon as possible so it doesn't silently stop doing what it should be doing.

- *Bugsquad edit:* Fixes #115918.