### PR TITLE
Core: Fix ClassDB class list sorting regression

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -255,7 +255,7 @@ void ClassDB::get_class_list(LocalVector<StringName> &p_classes) {
 		p_classes.push_back(cls.key);
 	}
 
-	SortArray<StringName> sorter;
+	SortArray<StringName, StringName::AlphCompare> sorter;
 	sorter.sort(&p_classes[p_classes.size() - classes.size()], classes.size());
 }
 
@@ -279,7 +279,7 @@ void ClassDB::get_extensions_class_list(LocalVector<StringName> &p_classes) {
 		return;
 	}
 
-	SortArray<StringName> sorter;
+	SortArray<StringName, StringName::AlphCompare> sorter;
 	sorter.sort(&p_classes[original_size], p_classes.size() - original_size);
 }
 

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -527,7 +527,7 @@ void ScriptServer::get_global_class_list(LocalVector<StringName> &r_global_class
 	for (const KeyValue<StringName, GlobalScriptClass> &global_class : global_classes) {
 		r_global_classes.push_back(global_class.key);
 	}
-	SortArray<StringName> sorter;
+	SortArray<StringName, StringName::AlphCompare> sorter;
 	sorter.sort(&r_global_classes[r_global_classes.size() - global_classes.size()], global_classes.size());
 }
 


### PR DESCRIPTION
Fixes #115914

Regression in 4.6 where ClassDB::get_class_list() and ClassDB::get_extensions_class_list()
no longer return an alphabetically sorted list, as they did in 4.5.1.

This restores the intended alphabetical ordering by using StringName::AlphCompare for
the SortArray comparator.

Testing: Built editor (linuxbsd) and ran the reproduction script from the issue; got "Sorted? True".

No functional changes beyond restoring deterministic sort order.

<img width="1162" height="675" alt="Screenshot 2026-02-05 224306" src="https://github.com/user-attachments/assets/60c0d8ec-a2b6-4550-8b87-ff91174ab9b5" />
