### PR TITLE
Fix warnings relating to case mismatch in file path for windows

### DIFF
--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -141,7 +141,7 @@ Error FileAccessWindows::open_internal(const String &p_path, int p_mode_flags) {
 	// platforms), we only check for relative paths, or paths in res:// or user://,
 	// other paths aren't likely to be portable anyway.
 	if (p_mode_flags == READ && (p_path.is_relative_path() || get_access_type() != ACCESS_FILESYSTEM)) {
-		String base_path = p_path;
+		String base_path = FileAccess::fix_path(p_path);
 		String working_path;
 		String proper_path;
 


### PR DESCRIPTION
- Fixes: https://github.com/godotengine/godot/issues/115901

## Details

It use `p_path`, that has relative form like `res://something`, so after trying get `path_to_file` in next operation with absolute resource path, it get nothing. 

Before it use `path`, that already fixed by `fix_path`, but now `FileAccessWindows::fix_path` working with large paths and return string like `\\?\E:\Projects\something` and `string.path_to_file()` can't work with it, so I use default `FileAccess::fix_path()`.
