### PR TITLE
Fix use-after-free in AnimationTree (AHashMap realloc)

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -739,7 +739,8 @@ void AnimationTree::_animation_node_renamed(const ObjectID &p_oid, const String 
 	for (const PropertyInfo &E : properties) {
 		if (E.name.begins_with(old_base)) {
 			String new_name = E.name.replace_first(old_base, new_base);
-			property_map[new_name] = property_map[E.name];
+			const Pair<Variant, bool> temp_copy = property_map[E.name];
+			property_map[new_name] = temp_copy;
 			property_map.erase(E.name);
 		}
 	}


### PR DESCRIPTION
Fixes #115930.
Similar to #115919.

Looking for the same pattern of unsafe inserts, this is the only other one I was able to find besides #115919.