### PR TITLE
Open previously active dock when closing active dock

### DIFF
--- a/editor/docks/dock_tab_container.cpp
+++ b/editor/docks/dock_tab_container.cpp
@@ -227,7 +227,7 @@ void DockTabContainer::move_dock_index(EditorDock *p_dock, int p_to_index, bool 
 	int target_index = CLAMP(p_to_index, 0, get_tab_count() - 1);
 	move_child(p_dock, get_dock(target_index)->get_index(false));
 
-	if (p_set_current) {
+	if (p_set_current && !p_dock->is_visible_in_tree()) {
 		set_current_tab(target_index);
 	}
 	set_block_signals(false);

--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -322,6 +322,11 @@ void EditorDockManager::_move_dock(EditorDock *p_dock, Control *p_target, int p_
 			DockTabContainer *parent_tabs = Object::cast_to<DockTabContainer>(parent);
 			if (parent_tabs) {
 				p_dock->previous_tab_index = parent_tabs->get_tab_idx_from_control(p_dock);
+
+				// Swap to previous tab when closing current tab.
+				if (parent_tabs->get_current_tab() == p_dock->previous_tab_index) {
+					parent_tabs->set_current_tab(parent_tabs->get_previous_tab());
+				}
 			}
 			parent->set_block_signals(true);
 			parent->remove_child(p_dock);
@@ -336,6 +341,9 @@ void EditorDockManager::_move_dock(EditorDock *p_dock, Control *p_target, int p_
 		p_dock->is_open = false;
 		return;
 	}
+
+	// Prevent extra visibility signals from firing.
+	p_dock->hide();
 
 	DockTabContainer *dock_tab_container = Object::cast_to<DockTabContainer>(p_target);
 	if (p_target != closed_dock_parent) {
@@ -584,8 +592,6 @@ void EditorDockManager::close_dock(EditorDock *p_dock) {
 		parent_container->dock_closed(p_dock);
 	}
 
-	// Hide before moving to remove inconsistent signals.
-	p_dock->hide();
 	_move_dock(p_dock, closed_dock_parent);
 
 	_update_layout();
@@ -648,8 +654,10 @@ void EditorDockManager::_make_dock_visible(EditorDock *p_dock, bool p_grab_focus
 		tab_container->get_tab_bar()->grab_focus();
 	}
 
-	int tab_index = tab_container->get_tab_idx_from_control(p_dock);
-	tab_container->set_current_tab(tab_index);
+	if (!p_dock->is_visible_in_tree()) {
+		int tab_index = tab_container->get_tab_idx_from_control(p_dock);
+		tab_container->set_current_tab(tab_index);
+	}
 }
 
 void EditorDockManager::focus_dock(EditorDock *p_dock) {


### PR DESCRIPTION
When a transient dock like the TileMap dock is on the vertical orientation and is closed while active, the TabContainer opens the adjacent dock to it, instead of the dock that was open before the TileMap was selected. 

This PR makes it so that after closing a dock, the previous dock is opened instead of an adjacent dock.

I moved the `hide()` that reduced signals because the previous location updated the `TabContainer`'s `current` and `previous` values, preventing the fix from working. The main fix is three lines, the rest is just making sure that the `TabContainer`'s `previous` is accurate.

*Bugsquad edit:* Fixes #114352