### PR TITLE
Fix `TestColor` build failure on Windows

### DIFF
--- a/tests/core/math/test_color.h
+++ b/tests/core/math/test_color.h
@@ -61,7 +61,7 @@ TEST_CASE("[Color] Constructor methods") {
 			"Creation with invalid HTML notation should result in a Color with the default values.");
 
 	constexpr Color green_rgba = Color(0, 1, 0, 0.25);
-	const Color green_hsva = Color(0, 0, 0).from_hsv(120 / 360.0, 1, 1, 0.25);
+	const Color green_hsva = Color::from_hsv(120 / 360.0, 1, 1, 0.25);
 
 	CHECK_MESSAGE(
 			green_rgba.is_equal_approx(green_hsva),


### PR DESCRIPTION
Fix the following build failure when building for Android.

```
ERROR: In file included from tests\test_main.cpp:72:
./tests/core/math/test_color.h:64:27: error: ignoring temporary of type 'Color' declared with 'nodiscard' attribute [-Werror,-Wunused-value]
   64 |         const Color green_hsva = Color(0, 0, 0).from_hsv(120 / 360.0, 1, 1, 0.25);
      |                                  ^~~~~~~~~~~~~~
1 error generated.
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
