### PR TITLE
Fix updating Dictionary while editing not yet added entry

### DIFF
--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -1024,9 +1024,10 @@ void EditorPropertyDictionary::_property_changed(const String &p_property, Varia
 
 	object->set(p_property, p_value);
 	bool new_item_or_key = !p_property.begins_with("indices");
-	emit_changed(get_edited_property(), object->get_dict(), p_name, p_changing || new_item_or_key);
 	if (new_item_or_key) {
 		update_property();
+	} else {
+		emit_changed(get_edited_property(), object->get_dict(), p_name, p_changing);
 	}
 }
 


### PR DESCRIPTION
- Fixes: https://github.com/godotengine/godot/issues/115818

I think, it's regression, because issue unreproducible in 4.2 version. Also In 4.2 new-key and new-value not emit changed too:

https://github.com/godotengine/godot/blob/4c512045b39efad5add92e3dc929945f24275f2d/editor/editor_properties_array_dict.cpp#L737-L750