### PR TITLE
Style: Convert `*.gen.inc` to `*.gen.h` for ninja

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -75,3 +75,6 @@ e06d83860d798b6766b23d6eae48557387a7db85
 
 # Style: Don't right-align escaped newlines
 c5df0cb82bc539eff7dcfb2add99d60771fc50c5
+
+# Style: Convert `*.gen.inc` to `*.gen.h`
+7dae5da1982f4a55ba91557814905faef9ce461b

--- a/core/debugger/engine_profiler.h
+++ b/core/debugger/engine_profiler.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/object/ref_counted.h"
 
 class EngineProfiler : public RefCounted {

--- a/core/extension/SCsub
+++ b/core/extension/SCsub
@@ -7,7 +7,7 @@ import make_interface_dumper
 import make_interface_header
 import make_wrappers
 
-env.CommandNoCache(["ext_wrappers.gen.inc"], "make_wrappers.py", env.Run(make_wrappers.run))
+env.CommandNoCache("ext_wrappers.gen.h", "make_wrappers.py", env.Run(make_wrappers.run))
 env.CommandNoCache(
     "gdextension_interface_dump.gen.h",
     ["gdextension_interface.json", "make_interface_dumper.py"],

--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -34,7 +34,7 @@
 #include "core/io/file_access.h"
 #include "core/io/image.h"
 #include "core/io/resource_loader.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/string/ustring.h"
 #include "core/templates/list.h"
 #include "core/variant/binder_common.h"

--- a/core/io/packet_peer.h
+++ b/core/io/packet_peer.h
@@ -34,8 +34,8 @@
 #include "core/object/class_db.h"
 #include "core/templates/ring_buffer.h"
 
-#include "core/extension/ext_wrappers.gen.inc"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/extension/ext_wrappers.gen.h"
+#include "core/object/gdvirtual.gen.h"
 #include "core/variant/native_ptr.h"
 
 class PacketPeer : public RefCounted {

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -32,7 +32,7 @@
 
 #include "core/io/resource_uid.h"
 #include "core/object/class_db.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/object/ref_counted.h"
 #include "core/templates/safe_refcount.h"
 #include "core/templates/self_list.h"

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/io/resource.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/os/thread.h"
 

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/io/resource.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 
 class ResourceFormatSaver : public RefCounted {
 	GDCLASS(ResourceFormatSaver, RefCounted);

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -32,8 +32,8 @@
 
 #include "core/object/ref_counted.h"
 
-#include "core/extension/ext_wrappers.gen.inc"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/extension/ext_wrappers.gen.h"
+#include "core/object/gdvirtual.gen.h"
 #include "core/variant/native_ptr.h"
 
 class StreamPeer : public RefCounted {

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/object/ref_counted.h"
 #include "core/templates/a_hash_map.h"
 

--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/object/ref_counted.h"
 #include "core/templates/local_vector.h"
 

--- a/core/object/SCsub
+++ b/core/object/SCsub
@@ -5,7 +5,7 @@ Import("env")
 
 import make_virtuals
 
-env.CommandNoCache(["gdvirtual.gen.inc"], "make_virtuals.py", env.Run(make_virtuals.run))
+env.CommandNoCache("gdvirtual.gen.h", "make_virtuals.py", env.Run(make_virtuals.run))
 
 env_object = env.Clone()
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -719,7 +719,7 @@ protected:
 		return can_die;
 	}
 
-	// Used in gdvirtual.gen.inc
+	// Used in gdvirtual.gen.h
 	void _gdvirtual_init_method_ptr(uint32_t p_compat_hash, void *&r_fn_ptr, const StringName &p_fn_name, bool p_compat) const;
 
 	friend class GDExtensionMethodBind;

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -30,8 +30,8 @@
 
 #pragma once
 
-#include "core/extension/ext_wrappers.gen.inc"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/extension/ext_wrappers.gen.h"
+#include "core/object/gdvirtual.gen.h"
 #include "core/object/script_language.h"
 #include "core/variant/native_ptr.h"
 #include "core/variant/typed_array.h"

--- a/core/os/main_loop.h
+++ b/core/os/main_loop.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/object/object.h"
 
 class MainLoop : public Object {

--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/io/resource.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 
 class PluralRules;
 

--- a/editor/export/editor_export_platform_extension.h
+++ b/editor/export/editor_export_platform_extension.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/variant/typed_array.h"
 #include "editor/export/editor_export_platform.h"
 #include "editor/export/editor_export_preset.h"

--- a/editor/inspector/editor_context_menu_plugin.h
+++ b/editor/inspector/editor_context_menu_plugin.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/object/ref_counted.h"
 
 class InputEvent;

--- a/editor/inspector/editor_resource_tooltip_plugins.h
+++ b/editor/inspector/editor_resource_tooltip_plugins.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/object/ref_counted.h"
 #include "scene/gui/control.h"
 

--- a/editor/plugins/editor_resource_conversion_plugin.h
+++ b/editor/plugins/editor_resource_conversion_plugin.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/io/resource.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 
 class EditorResourceConversionPlugin : public RefCounted {
 	GDCLASS(EditorResourceConversionPlugin, RefCounted);

--- a/editor/script/editor_script.h
+++ b/editor/script/editor_script.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/object/ref_counted.h"
 
 class EditorInterface;

--- a/editor/translations/editor_translation_parser.h
+++ b/editor/translations/editor_translation_parser.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/object/ref_counted.h"
 #include "core/variant/typed_array.h"
 

--- a/editor/version_control/editor_vcs_interface.h
+++ b/editor/version_control/editor_vcs_interface.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/string/ustring.h"
 #include "core/variant/typed_array.h"
 

--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -33,7 +33,7 @@
 #include "core/error/error_macros.h"
 #include "core/math/projection.h"
 #include "core/object/class_db.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/object/ref_counted.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/rid.h"

--- a/modules/openxr/openxr_structure.h
+++ b/modules/openxr/openxr_structure.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/object/ref_counted.h"
 #include "openxr_util.h"
 #include "util.h"

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -81,7 +81,7 @@ using namespace godot;
 #elif defined(GODOT_MODULE)
 // Headers for building as built-in module.
 
-#include "core/extension/ext_wrappers.gen.inc"
+#include "core/extension/ext_wrappers.gen.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/rid_owner.h"
 #include "core/templates/safe_refcount.h"

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -79,7 +79,7 @@ using namespace godot;
 #elif defined(GODOT_MODULE)
 // Headers for building as built-in module.
 
-#include "core/extension/ext_wrappers.gen.inc"
+#include "core/extension/ext_wrappers.gen.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/rid_owner.h"

--- a/modules/webrtc/webrtc_data_channel_extension.h
+++ b/modules/webrtc/webrtc_data_channel_extension.h
@@ -32,8 +32,8 @@
 
 #include "webrtc_data_channel.h"
 
-#include "core/extension/ext_wrappers.gen.inc"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/extension/ext_wrappers.gen.h"
+#include "core/object/gdvirtual.gen.h"
 #include "core/variant/native_ptr.h"
 
 class WebRTCDataChannelExtension : public WebRTCDataChannel {

--- a/modules/webrtc/webrtc_peer_connection_extension.h
+++ b/modules/webrtc/webrtc_peer_connection_extension.h
@@ -32,8 +32,8 @@
 
 #include "webrtc_peer_connection.h"
 
-#include "core/extension/ext_wrappers.gen.inc"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/extension/ext_wrappers.gen.h"
+#include "core/object/gdvirtual.gen.h"
 
 class WebRTCPeerConnectionExtension : public WebRTCPeerConnection {
 	GDCLASS(WebRTCPeerConnectionExtension, WebRTCPeerConnection);

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/math/transform_2d.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "scene/main/canvas_item.h"
 #include "scene/resources/theme.h"
 

--- a/scene/gui/rich_text_effect.h
+++ b/scene/gui/rich_text_effect.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/io/resource.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 
 class CharFXTransform : public RefCounted {
 	GDCLASS(CharFXTransform, RefCounted);

--- a/scene/main/multiplayer_peer.h
+++ b/scene/main/multiplayer_peer.h
@@ -32,8 +32,8 @@
 
 #include "core/io/packet_peer.h"
 
-#include "core/extension/ext_wrappers.gen.inc"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/extension/ext_wrappers.gen.h"
+#include "core/object/gdvirtual.gen.h"
 #include "core/variant/native_ptr.h"
 
 class MultiplayerPeer : public PacketPeer {

--- a/scene/resources/compositor.h
+++ b/scene/resources/compositor.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/io/resource.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "servers/rendering/storage/render_data.h"
 
 /* Compositor Effect */

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/io/resource.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 
 class CanvasItem;
 

--- a/scene/resources/syntax_highlighter.h
+++ b/scene/resources/syntax_highlighter.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/io/resource.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/templates/rb_map.h"
 
 class TextEdit;

--- a/servers/audio/audio_effect.h
+++ b/servers/audio/audio_effect.h
@@ -32,7 +32,7 @@
 
 #include "core/io/resource.h"
 #include "core/math/audio_frame.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/variant/native_ptr.h"
 
 class AudioEffectInstance : public RefCounted {

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -34,7 +34,7 @@
 #include "scene/property_list_helper.h"
 #include "servers/audio/audio_server.h"
 
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/variant/native_ptr.h"
 #include "core/variant/typed_array.h"
 

--- a/servers/physics_2d/physics_server_2d_extension.h
+++ b/servers/physics_2d/physics_server_2d_extension.h
@@ -30,8 +30,8 @@
 
 #pragma once
 
-#include "core/extension/ext_wrappers.gen.inc"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/extension/ext_wrappers.gen.h"
+#include "core/object/gdvirtual.gen.h"
 #include "core/variant/native_ptr.h"
 #include "core/variant/typed_array.h"
 #include "servers/physics_2d/physics_server_2d.h"

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/io/resource.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 
 constexpr int MAX_CONTACTS_REPORTED_3D_MAX = 4096;
 

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/extension/ext_wrappers.gen.inc"
+#include "core/extension/ext_wrappers.gen.h"
 #include "core/object/script_language.h"
 #include "core/variant/native_ptr.h"
 #include "core/variant/typed_array.h"

--- a/servers/rendering/storage/render_scene_data.h
+++ b/servers/rendering/storage/render_scene_data.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/object/class_db.h"
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/object/object.h"
 #include "core/object/script_language.h"
 

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/gdvirtual.gen.inc"
+#include "core/object/gdvirtual.gen.h"
 #include "core/os/thread_safe.h"
 #include "core/variant/native_ptr.h"
 #include "core/variant/typed_array.h"


### PR DESCRIPTION
In one of the strangest goose-chases I've had debugging SCons, it turns out that `.inc` is *not* automatically recognized as a valid header dependency with the ninja backend. So while technically strictly a stylistic change, this actually made all the difference in allowing the minimal template to compile on GHA when using ninja. PR as two commits to add this change to `.git-blame-ignore-revs`

### [Before:](https://github.com/Repiteo/godot/actions/runs/21733555572/job/62693495648)
```
...
[305/1006] Compiling core/config/engine.linuxbsd.template_release.x86_64.o
FAILED: [code=1] core/config/engine.linuxbsd.template_release.x86_64.o
export PATH='/opt/hostedtoolcache/Python/3.14.2/x64/bin:/opt/hostedtoolcache/Python/3.14.2/x64:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/opt/bin';g++ "-o" "core/config/engine.linuxbsd.template_release.x86_64.o" "-c" "-std=gnu++17" "-fno-exceptions" "-Wctor-dtor-privacy" "-Wnon-virtual-dtor" "-Wplacement-new=1" "-Wvirtual-inheritance" "-ffp-contract=off" "-pipe" "-msse4.2" "-mpopcnt" "-fdiagnostics-color" "-O3" "-Wall" "-Wextra" "-Wwrite-strings" "-Wno-unused-parameter" "-Wshadow" "-Wno-misleading-indentation" "-Wenum-conversion" "-Walloc-zero" "-Wduplicated-branches" "-Wduplicated-cond" "-Wstringop-overflow=4" "-Wattribute-alias=2" "-Wlogical-op" "-Werror" "-MMD" "-MF" "core/config/engine.linuxbsd.template_release.x86_64.o.d" "-DNDEBUG" "-DDISABLE_DEPRECATED" "-DSTRICT_CHECKS" "-DSOWRAP_ENABLED" "-DTOUCH_ENABLED" "-DFONTCONFIG_ENABLED" "-DALSA_ENABLED" "-DALSAMIDI_ENABLED" "-DPULSEAUDIO_ENABLED" "-D_REENTRANT" "-DDBUS_ENABLED" "-DSPEECHD_ENABLED" "-DXKB_ENABLED" "-DUDEV_ENABLED" "-DSDL_ENABLED" "-DLINUXBSD_ENABLED" "-DUNIX_ENABLED" "-D_FILE_OFFSET_BITS=64" "-DX11_ENABLED" "-DLIBDECOR_ENABLED" "-DWAYLAND_ENABLED" "-DACCESSKIT_ENABLED" "-DVULKAN_ENABLED" "-DRD_ENABLED" "-DGLES3_ENABLED" "-DCRASH_HANDLER_ENABLED" "-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES" "-D_3D_DISABLED" "-DADVANCED_GUI_DISABLED" "-DPHYSICS_2D_DISABLED" "-DPHYSICS_3D_DISABLED" "-DNAVIGATION_3D_DISABLED" "-DXR_DISABLED" "-DOVERRIDE_ENABLED" "-DTHREADS_ENABLED" "-DCLIPPER2_ENABLED" "-DZSTD_STATIC_LINKING_ONLY" "-Ithirdparty/zstd" "-Ithirdparty/zlib" "-Ithirdparty/clipper2/include" "-Iaccesskit-c-0.18.0/include" "-Ithirdparty/linuxbsd_headers/libdecor-0" "-Ithirdparty/linuxbsd_headers/wayland" "-Ithirdparty/linuxbsd_headers" "-Iplatform/linuxbsd" "-I." "core/config/engine.cpp"
In file included from ./core/input/input_event.h:34,
from ./servers/display/display_server.h:33,
from ./servers/rendering/rendering_device.h:40,
from core/config/engine.cpp:39:
Error: ./core/io/resource.h:35:10: fatal error: core/object/gdvirtual.gen.inc: No such file or directory
35 | #include "core/object/gdvirtual.gen.inc"
|          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
...
```
### [After:](https://github.com/Repiteo/godot/actions/runs/21735445419/job/62699432189)
```
...
[34/1006] Defer to SCons to build core/io/certs_compressed.gen.h
[35/1006] Defer to SCons to build core/license.gen.h
[36/1006] Defer to SCons to build core/object/gdvirtual.gen.h
[37/1006] Defer to SCons to build core/profiling/profiling.gen.h
[38/1006] Defer to SCons to build core/version_generated.gen.h
...
```