### PR TITLE
Expose `get_max_packet_size` and `is_server` of MultiplayerPeer

### DIFF
--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -144,6 +144,8 @@ void PacketPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_packet_error"), &PacketPeer::_get_packet_error);
 	ClassDB::bind_method(D_METHOD("get_available_packet_count"), &PacketPeer::get_available_packet_count);
 
+	ClassDB::bind_method(D_METHOD("get_max_packet_size"), &PacketPeer::get_max_packet_size);
+
 	ClassDB::bind_method(D_METHOD("get_encode_buffer_max_size"), &PacketPeer::get_encode_buffer_max_size);
 	ClassDB::bind_method(D_METHOD("set_encode_buffer_max_size", "max_size"), &PacketPeer::set_encode_buffer_max_size);
 

--- a/doc/classes/MultiplayerPeer.xml
+++ b/doc/classes/MultiplayerPeer.xml
@@ -62,6 +62,12 @@
 				Returns the ID of this [MultiplayerPeer].
 			</description>
 		</method>
+		<method name="is_server" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the multiplayer peer is in server mode (listening for connections).
+			</description>
+		</method>
 		<method name="is_server_relay_supported" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/doc/classes/PacketPeer.xml
+++ b/doc/classes/PacketPeer.xml
@@ -16,6 +16,12 @@
 				Returns the number of packets currently available in the ring-buffer.
 			</description>
 		</method>
+		<method name="get_max_packet_size" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the the maximum allowed packet size in bytes.
+			</description>
+		</method>
 		<method name="get_packet">
 			<return type="PackedByteArray" />
 			<description>

--- a/scene/main/multiplayer_peer.cpp
+++ b/scene/main/multiplayer_peer.cpp
@@ -106,6 +106,8 @@ void MultiplayerPeer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_server_relay_supported"), &MultiplayerPeer::is_server_relay_supported);
 
+	ClassDB::bind_method(D_METHOD("is_server"), &MultiplayerPeer::is_server);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "refuse_new_connections"), "set_refuse_new_connections", "is_refusing_new_connections");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "transfer_mode", PROPERTY_HINT_ENUM, "Unreliable,Unreliable Ordered,Reliable"), "set_transfer_mode", "get_transfer_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "transfer_channel", PROPERTY_HINT_RANGE, "0,255,1"), "set_transfer_channel", "get_transfer_channel");


### PR DESCRIPTION
These should be exposed because of the case where you want to internally use an existing MultiplayerPeer / PacketPeer implementation in a MultiplayerPeerExtension / PacketPeerExtension. They are required to be implemented in the extension (`_is_server` for MultiplayerPeerExtension and `_get_max_packet_size` for both).