### PR TITLE
Remove `p_` and add `r_` prefixes to argument names

### DIFF
--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -173,7 +173,7 @@ Error PacketPeerExtension::put_packet(const uint8_t *p_buffer, int p_buffer_size
 
 void PacketPeerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_packet, "r_buffer", "r_buffer_size");
-	GDVIRTUAL_BIND(_put_packet, "p_buffer", "p_buffer_size");
+	GDVIRTUAL_BIND(_put_packet, "buffer", "buffer_size");
 	GDVIRTUAL_BIND(_get_available_packet_count);
 	GDVIRTUAL_BIND(_get_max_packet_size);
 }

--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -490,8 +490,8 @@ Error StreamPeerExtension::put_partial_data(const uint8_t *p_data, int p_bytes, 
 void StreamPeerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_data, "r_buffer", "r_bytes", "r_received");
 	GDVIRTUAL_BIND(_get_partial_data, "r_buffer", "r_bytes", "r_received");
-	GDVIRTUAL_BIND(_put_data, "p_data", "p_bytes", "r_sent");
-	GDVIRTUAL_BIND(_put_partial_data, "p_data", "p_bytes", "r_sent");
+	GDVIRTUAL_BIND(_put_data, "data", "bytes", "r_sent");
+	GDVIRTUAL_BIND(_put_partial_data, "data", "bytes", "r_sent");
 	GDVIRTUAL_BIND(_get_available_bytes);
 }
 

--- a/doc/classes/AccessibilityServer.xml
+++ b/doc/classes/AccessibilityServer.xml
@@ -196,7 +196,7 @@
 		<method name="update_set_bounds">
 			<return type="void" />
 			<param index="0" name="id" type="RID" />
-			<param index="1" name="p_rect" type="Rect2" />
+			<param index="1" name="rect" type="Rect2" />
 			<description>
 				Sets element bounding box, relative to the node position.
 			</description>

--- a/doc/classes/AudioEffectInstance.xml
+++ b/doc/classes/AudioEffectInstance.xml
@@ -14,7 +14,7 @@
 		<method name="_process" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="src_buffer" type="const void*" />
-			<param index="1" name="dst_buffer" type="AudioFrame*" />
+			<param index="1" name="r_dst_buffer" type="AudioFrame*" />
 			<param index="2" name="frame_count" type="int" />
 			<description>
 				Called by the [AudioServer] to process this effect. When [method _process_silence] is not overridden or it returns [code]false[/code], this method is called only when the bus is active.

--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -216,9 +216,9 @@
 		<method name="shape_owner_set_one_way_collision_direction">
 			<return type="void" />
 			<param index="0" name="owner_id" type="int" />
-			<param index="1" name="p_direction" type="Vector2" />
+			<param index="1" name="direction" type="Vector2" />
 			<description>
-				Sets the [code]one_way_collision_direction[/code] of the shape owner identified by the given [param owner_id] to [param p_direction].
+				Sets the [code]one_way_collision_direction[/code] of the shape owner identified by the given [param owner_id] to [param direction].
 			</description>
 		</method>
 		<method name="shape_owner_set_one_way_collision_margin">

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -221,7 +221,7 @@
 		<method name="accessibility_update_set_bounds" deprecated="Use [AccessibilityServer] instead.">
 			<return type="void" />
 			<param index="0" name="id" type="RID" />
-			<param index="1" name="p_rect" type="Rect2" />
+			<param index="1" name="rect" type="Rect2" />
 			<description>
 				Sets element bounding box, relative to the node position.
 			</description>

--- a/doc/classes/MultiplayerPeerExtension.xml
+++ b/doc/classes/MultiplayerPeerExtension.xml
@@ -17,10 +17,10 @@
 		</method>
 		<method name="_disconnect_peer" qualifiers="virtual required">
 			<return type="void" />
-			<param index="0" name="p_peer" type="int" />
-			<param index="1" name="p_force" type="bool" />
+			<param index="0" name="peer" type="int" />
+			<param index="1" name="force" type="bool" />
 			<description>
-				Called when the connected [param p_peer] should be forcibly disconnected (see [method MultiplayerPeer.disconnect_peer]).
+				Called when the connected [param peer] should be forcibly disconnected (see [method MultiplayerPeer.disconnect_peer]).
 			</description>
 		</method>
 		<method name="_get_available_packet_count" qualifiers="virtual required const">
@@ -117,43 +117,43 @@
 		</method>
 		<method name="_put_packet" qualifiers="virtual">
 			<return type="int" enum="Error" />
-			<param index="0" name="p_buffer" type="const uint8_t*" />
-			<param index="1" name="p_buffer_size" type="int" />
+			<param index="0" name="buffer" type="const uint8_t*" />
+			<param index="1" name="buffer_size" type="int" />
 			<description>
-				Called when a packet needs to be sent by the [MultiplayerAPI], with [param p_buffer_size] being the size of the binary [param p_buffer] in bytes.
+				Called when a packet needs to be sent by the [MultiplayerAPI], with [param buffer_size] being the size of the binary [param buffer] in bytes.
 			</description>
 		</method>
 		<method name="_put_packet_script" qualifiers="virtual">
 			<return type="int" enum="Error" />
-			<param index="0" name="p_buffer" type="PackedByteArray" />
+			<param index="0" name="buffer" type="PackedByteArray" />
 			<description>
 				Called when a packet needs to be sent by the [MultiplayerAPI], if [method _put_packet] isn't implemented. Use this when extending this class via GDScript.
 			</description>
 		</method>
 		<method name="_set_refuse_new_connections" qualifiers="virtual">
 			<return type="void" />
-			<param index="0" name="p_enable" type="bool" />
+			<param index="0" name="enable" type="bool" />
 			<description>
 				Called when the "refuse new connections" status is set on this [MultiplayerPeer] (see [member MultiplayerPeer.refuse_new_connections]).
 			</description>
 		</method>
 		<method name="_set_target_peer" qualifiers="virtual required">
 			<return type="void" />
-			<param index="0" name="p_peer" type="int" />
+			<param index="0" name="peer" type="int" />
 			<description>
 				Called when the target peer to use is set for this [MultiplayerPeer] (see [method MultiplayerPeer.set_target_peer]).
 			</description>
 		</method>
 		<method name="_set_transfer_channel" qualifiers="virtual required">
 			<return type="void" />
-			<param index="0" name="p_channel" type="int" />
+			<param index="0" name="channel" type="int" />
 			<description>
 				Called when the channel to use is set for this [MultiplayerPeer] (see [member MultiplayerPeer.transfer_channel]).
 			</description>
 		</method>
 		<method name="_set_transfer_mode" qualifiers="virtual required">
 			<return type="void" />
-			<param index="0" name="p_mode" type="int" enum="MultiplayerPeer.TransferMode" />
+			<param index="0" name="mode" type="int" enum="MultiplayerPeer.TransferMode" />
 			<description>
 				Called when the transfer mode is set on this [MultiplayerPeer] (see [member MultiplayerPeer.transfer_mode]).
 			</description>

--- a/doc/classes/PacketPeerExtension.xml
+++ b/doc/classes/PacketPeerExtension.xml
@@ -26,8 +26,8 @@
 		</method>
 		<method name="_put_packet" qualifiers="virtual">
 			<return type="int" enum="Error" />
-			<param index="0" name="p_buffer" type="const uint8_t*" />
-			<param index="1" name="p_buffer_size" type="int" />
+			<param index="0" name="buffer" type="const uint8_t*" />
+			<param index="1" name="buffer_size" type="int" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/PhysicsDirectSpaceState2DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState2DExtension.xml
@@ -19,8 +19,8 @@
 			<param index="4" name="collision_mask" type="int" />
 			<param index="5" name="collide_with_bodies" type="bool" />
 			<param index="6" name="collide_with_areas" type="bool" />
-			<param index="7" name="closest_safe" type="float*" />
-			<param index="8" name="closest_unsafe" type="float*" />
+			<param index="7" name="r_closest_safe" type="float*" />
+			<param index="8" name="r_closest_unsafe" type="float*" />
 			<description>
 			</description>
 		</method>
@@ -33,9 +33,9 @@
 			<param index="4" name="collision_mask" type="int" />
 			<param index="5" name="collide_with_bodies" type="bool" />
 			<param index="6" name="collide_with_areas" type="bool" />
-			<param index="7" name="results" type="void*" />
+			<param index="7" name="r_results" type="void*" />
 			<param index="8" name="max_results" type="int" />
-			<param index="9" name="result_count" type="int32_t*" />
+			<param index="9" name="r_result_count" type="int32_t*" />
 			<description>
 			</description>
 		</method>
@@ -46,7 +46,7 @@
 			<param index="2" name="collision_mask" type="int" />
 			<param index="3" name="collide_with_bodies" type="bool" />
 			<param index="4" name="collide_with_areas" type="bool" />
-			<param index="5" name="results" type="PhysicsServer2DExtensionShapeResult*" />
+			<param index="5" name="r_results" type="PhysicsServer2DExtensionShapeResult*" />
 			<param index="6" name="max_results" type="int" />
 			<description>
 			</description>
@@ -59,7 +59,7 @@
 			<param index="3" name="collide_with_bodies" type="bool" />
 			<param index="4" name="collide_with_areas" type="bool" />
 			<param index="5" name="hit_from_inside" type="bool" />
-			<param index="6" name="result" type="PhysicsServer2DExtensionRayResult*" />
+			<param index="6" name="r_result" type="PhysicsServer2DExtensionRayResult*" />
 			<description>
 			</description>
 		</method>
@@ -72,7 +72,7 @@
 			<param index="4" name="collision_mask" type="int" />
 			<param index="5" name="collide_with_bodies" type="bool" />
 			<param index="6" name="collide_with_areas" type="bool" />
-			<param index="7" name="result" type="PhysicsServer2DExtensionShapeResult*" />
+			<param index="7" name="r_result" type="PhysicsServer2DExtensionShapeResult*" />
 			<param index="8" name="max_results" type="int" />
 			<description>
 			</description>
@@ -86,7 +86,7 @@
 			<param index="4" name="collision_mask" type="int" />
 			<param index="5" name="collide_with_bodies" type="bool" />
 			<param index="6" name="collide_with_areas" type="bool" />
-			<param index="7" name="rest_info" type="PhysicsServer2DExtensionShapeRestInfo*" />
+			<param index="7" name="r_rest_info" type="PhysicsServer2DExtensionShapeRestInfo*" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/PhysicsDirectSpaceState3DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState3DExtension.xml
@@ -19,9 +19,9 @@
 			<param index="4" name="collision_mask" type="int" />
 			<param index="5" name="collide_with_bodies" type="bool" />
 			<param index="6" name="collide_with_areas" type="bool" />
-			<param index="7" name="closest_safe" type="float*" />
-			<param index="8" name="closest_unsafe" type="float*" />
-			<param index="9" name="info" type="PhysicsServer3DExtensionShapeRestInfo*" />
+			<param index="7" name="r_closest_safe" type="float*" />
+			<param index="8" name="r_closest_unsafe" type="float*" />
+			<param index="9" name="r_info" type="PhysicsServer3DExtensionShapeRestInfo*" />
 			<description>
 			</description>
 		</method>
@@ -34,9 +34,9 @@
 			<param index="4" name="collision_mask" type="int" />
 			<param index="5" name="collide_with_bodies" type="bool" />
 			<param index="6" name="collide_with_areas" type="bool" />
-			<param index="7" name="results" type="void*" />
+			<param index="7" name="r_results" type="void*" />
 			<param index="8" name="max_results" type="int" />
-			<param index="9" name="result_count" type="int32_t*" />
+			<param index="9" name="r_result_count" type="int32_t*" />
 			<description>
 			</description>
 		</method>
@@ -53,7 +53,7 @@
 			<param index="1" name="collision_mask" type="int" />
 			<param index="2" name="collide_with_bodies" type="bool" />
 			<param index="3" name="collide_with_areas" type="bool" />
-			<param index="4" name="results" type="PhysicsServer3DExtensionShapeResult*" />
+			<param index="4" name="r_results" type="PhysicsServer3DExtensionShapeResult*" />
 			<param index="5" name="max_results" type="int" />
 			<description>
 			</description>
@@ -68,7 +68,7 @@
 			<param index="5" name="hit_from_inside" type="bool" />
 			<param index="6" name="hit_back_faces" type="bool" />
 			<param index="7" name="pick_ray" type="bool" />
-			<param index="8" name="result" type="PhysicsServer3DExtensionRayResult*" />
+			<param index="8" name="r_result" type="PhysicsServer3DExtensionRayResult*" />
 			<description>
 			</description>
 		</method>
@@ -81,7 +81,7 @@
 			<param index="4" name="collision_mask" type="int" />
 			<param index="5" name="collide_with_bodies" type="bool" />
 			<param index="6" name="collide_with_areas" type="bool" />
-			<param index="7" name="result_count" type="PhysicsServer3DExtensionShapeResult*" />
+			<param index="7" name="r_result_count" type="PhysicsServer3DExtensionShapeResult*" />
 			<param index="8" name="max_results" type="int" />
 			<description>
 			</description>
@@ -95,7 +95,7 @@
 			<param index="4" name="collision_mask" type="int" />
 			<param index="5" name="collide_with_bodies" type="bool" />
 			<param index="6" name="collide_with_areas" type="bool" />
-			<param index="7" name="rest_info" type="PhysicsServer3DExtensionShapeRestInfo*" />
+			<param index="7" name="r_rest_info" type="PhysicsServer3DExtensionShapeRestInfo*" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -354,11 +354,11 @@
 			<param index="2" name="shape" type="RID" />
 			<param index="3" name="shape_xform" type="Transform2D" />
 			<param index="4" name="motion" type="Vector2" />
-			<param index="5" name="results" type="void*" />
+			<param index="5" name="r_results" type="void*" />
 			<param index="6" name="result_max" type="int" />
-			<param index="7" name="result_count" type="int32_t*" />
+			<param index="7" name="r_result_count" type="int32_t*" />
 			<description>
-				Given a [param body], a [param shape], and their respective parameters, this method should return [code]true[/code] if a collision between the two would occur, with additional details passed in [param results].
+				Given a [param body], a [param shape], and their respective parameters, this method should return [code]true[/code] if a collision between the two would occur, with additional details passed in [param r_results].
 				Overridable version of [PhysicsServer2D]'s internal [code]shape_collide[/code] method. Corresponds to [method PhysicsDirectSpaceState2D.collide_shape].
 			</description>
 		</method>
@@ -725,7 +725,7 @@
 			<param index="3" name="margin" type="float" />
 			<param index="4" name="collide_separation_ray" type="bool" />
 			<param index="5" name="recovery_as_collision" type="bool" />
-			<param index="6" name="result" type="PhysicsServer2DExtensionMotionResult*" />
+			<param index="6" name="r_result" type="PhysicsServer2DExtensionMotionResult*" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_test_motion]. Unlike the exposed implementation, this method does not receive all of the arguments inside a [PhysicsTestMotionParameters2D].
 			</description>
@@ -972,11 +972,11 @@
 			<param index="3" name="shape_B" type="RID" />
 			<param index="4" name="xform_B" type="Transform2D" />
 			<param index="5" name="motion_B" type="Vector2" />
-			<param index="6" name="results" type="void*" />
+			<param index="6" name="r_results" type="void*" />
 			<param index="7" name="result_max" type="int" />
-			<param index="8" name="result_count" type="int32_t*" />
+			<param index="8" name="r_result_count" type="int32_t*" />
 			<description>
-				Given two shapes and their parameters, should return [code]true[/code] if a collision between the two would occur, with additional details passed in [param results].
+				Given two shapes and their parameters, should return [code]true[/code] if a collision between the two would occur, with additional details passed in [param r_results].
 				Overridable version of [PhysicsServer2D]'s internal [code]shape_collide[/code] method. Corresponds to [method PhysicsDirectSpaceState2D.collide_shape].
 			</description>
 		</method>

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -610,7 +610,7 @@
 			<param index="4" name="max_collisions" type="int" />
 			<param index="5" name="collide_separation_ray" type="bool" />
 			<param index="6" name="recovery_as_collision" type="bool" />
-			<param index="7" name="result" type="PhysicsServer3DExtensionMotionResult*" />
+			<param index="7" name="r_result" type="PhysicsServer3DExtensionMotionResult*" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1554,7 +1554,7 @@
 			<param index="5" name="emission_energy" type="float" />
 			<param index="6" name="anisotropy" type="float" />
 			<param index="7" name="length" type="float" />
-			<param index="8" name="p_detail_spread" type="float" />
+			<param index="8" name="detail_spread" type="float" />
 			<param index="9" name="gi_inject" type="float" />
 			<param index="10" name="temporal_reprojection" type="bool" />
 			<param index="11" name="temporal_reprojection_amount" type="float" />
@@ -3356,7 +3356,7 @@
 		<method name="particles_set_transform_align_axis">
 			<return type="void" />
 			<param index="0" name="particles" type="RID" />
-			<param index="1" name="p_rotation_axis" type="int" enum="RenderingServer.ParticlesTransformAlignAxis" />
+			<param index="1" name="rotation_axis" type="int" enum="RenderingServer.ParticlesTransformAlignAxis" />
 			<description>
 				Sets which axis to use for transform alignment.
 			</description>

--- a/doc/classes/StreamPeerExtension.xml
+++ b/doc/classes/StreamPeerExtension.xml
@@ -30,16 +30,16 @@
 		</method>
 		<method name="_put_data" qualifiers="virtual">
 			<return type="int" enum="Error" />
-			<param index="0" name="p_data" type="const uint8_t*" />
-			<param index="1" name="p_bytes" type="int" />
+			<param index="0" name="data" type="const uint8_t*" />
+			<param index="1" name="bytes" type="int" />
 			<param index="2" name="r_sent" type="int32_t*" />
 			<description>
 			</description>
 		</method>
 		<method name="_put_partial_data" qualifiers="virtual">
 			<return type="int" enum="Error" />
-			<param index="0" name="p_data" type="const uint8_t*" />
-			<param index="1" name="p_bytes" type="int" />
+			<param index="0" name="data" type="const uint8_t*" />
+			<param index="1" name="bytes" type="int" />
 			<param index="2" name="r_sent" type="int32_t*" />
 			<description>
 			</description>

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -1485,7 +1485,7 @@
 			<return type="void" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="position" type="int" />
-			<param index="2" name="caret" type="CaretInfo*" />
+			<param index="2" name="r_caret" type="CaretInfo*" />
 			<description>
 				Returns shapes of the carets corresponding to the character offset [param position] in the text. Returned caret shape is 1 pixel wide rectangle.
 			</description>

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -503,7 +503,7 @@
 		</method>
 		<method name="set_coords_level_tile_proxy">
 			<return type="void" />
-			<param index="0" name="p_source_from" type="int" />
+			<param index="0" name="source_from" type="int" />
 			<param index="1" name="coords_from" type="Vector2i" />
 			<param index="2" name="source_to" type="int" />
 			<param index="3" name="coords_to" type="Vector2i" />

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1925,7 +1925,7 @@ void CodeTextEditor::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("show_warnings_panel"));
 	ADD_SIGNAL(MethodInfo("show_goto_popup"));
 	ADD_SIGNAL(MethodInfo("navigation_preview_ended"));
-	ADD_SIGNAL(MethodInfo("zoomed", PropertyInfo(Variant::FLOAT, "p_zoom_factor")));
+	ADD_SIGNAL(MethodInfo("zoomed", PropertyInfo(Variant::FLOAT, "zoom_factor")));
 }
 
 void CodeTextEditor::set_code_complete_func(CodeTextEditorCodeCompleteFunc p_code_complete_func, void *p_ud) {

--- a/modules/webrtc/doc_classes/WebRTCDataChannelExtension.xml
+++ b/modules/webrtc/doc_classes/WebRTCDataChannelExtension.xml
@@ -86,14 +86,14 @@
 		</method>
 		<method name="_put_packet" qualifiers="virtual">
 			<return type="int" enum="Error" />
-			<param index="0" name="p_buffer" type="const uint8_t*" />
-			<param index="1" name="p_buffer_size" type="int" />
+			<param index="0" name="buffer" type="const uint8_t*" />
+			<param index="1" name="buffer_size" type="int" />
 			<description>
 			</description>
 		</method>
 		<method name="_set_write_mode" qualifiers="virtual required">
 			<return type="void" />
-			<param index="0" name="p_write_mode" type="int" enum="WebRTCDataChannel.WriteMode" />
+			<param index="0" name="write_mode" type="int" enum="WebRTCDataChannel.WriteMode" />
 			<description>
 			</description>
 		</method>

--- a/modules/webrtc/doc_classes/WebRTCPeerConnectionExtension.xml
+++ b/modules/webrtc/doc_classes/WebRTCPeerConnectionExtension.xml
@@ -9,9 +9,9 @@
 	<methods>
 		<method name="_add_ice_candidate" qualifiers="virtual required">
 			<return type="int" enum="Error" />
-			<param index="0" name="p_sdp_mid_name" type="String" />
-			<param index="1" name="p_sdp_mline_index" type="int" />
-			<param index="2" name="p_sdp_name" type="String" />
+			<param index="0" name="sdp_mid_name" type="String" />
+			<param index="1" name="sdp_mline_index" type="int" />
+			<param index="2" name="sdp_name" type="String" />
 			<description>
 			</description>
 		</method>
@@ -22,8 +22,8 @@
 		</method>
 		<method name="_create_data_channel" qualifiers="virtual required">
 			<return type="WebRTCDataChannel" />
-			<param index="0" name="p_label" type="String" />
-			<param index="1" name="p_config" type="Dictionary" />
+			<param index="0" name="label" type="String" />
+			<param index="1" name="config" type="Dictionary" />
 			<description>
 			</description>
 		</method>
@@ -49,7 +49,7 @@
 		</method>
 		<method name="_initialize" qualifiers="virtual required">
 			<return type="int" enum="Error" />
-			<param index="0" name="p_config" type="Dictionary" />
+			<param index="0" name="config" type="Dictionary" />
 			<description>
 			</description>
 		</method>
@@ -60,15 +60,15 @@
 		</method>
 		<method name="_set_local_description" qualifiers="virtual required">
 			<return type="int" enum="Error" />
-			<param index="0" name="p_type" type="String" />
-			<param index="1" name="p_sdp" type="String" />
+			<param index="0" name="type" type="String" />
+			<param index="1" name="sdp" type="String" />
 			<description>
 			</description>
 		</method>
 		<method name="_set_remote_description" qualifiers="virtual required">
 			<return type="int" enum="Error" />
-			<param index="0" name="p_type" type="String" />
-			<param index="1" name="p_sdp" type="String" />
+			<param index="0" name="type" type="String" />
+			<param index="1" name="sdp" type="String" />
 			<description>
 			</description>
 		</method>

--- a/modules/webrtc/webrtc_data_channel_extension.cpp
+++ b/modules/webrtc/webrtc_data_channel_extension.cpp
@@ -36,14 +36,14 @@ void WebRTCDataChannelExtension::_bind_methods() {
 	ADD_PROPERTY_DEFAULT("write_mode", WRITE_MODE_BINARY);
 
 	GDVIRTUAL_BIND(_get_packet, "r_buffer", "r_buffer_size");
-	GDVIRTUAL_BIND(_put_packet, "p_buffer", "p_buffer_size");
+	GDVIRTUAL_BIND(_put_packet, "buffer", "buffer_size");
 	GDVIRTUAL_BIND(_get_available_packet_count);
 	GDVIRTUAL_BIND(_get_max_packet_size);
 
 	GDVIRTUAL_BIND(_poll);
 	GDVIRTUAL_BIND(_close);
 
-	GDVIRTUAL_BIND(_set_write_mode, "p_write_mode");
+	GDVIRTUAL_BIND(_set_write_mode, "write_mode");
 	GDVIRTUAL_BIND(_get_write_mode);
 
 	GDVIRTUAL_BIND(_was_string_packet);

--- a/modules/webrtc/webrtc_peer_connection_extension.cpp
+++ b/modules/webrtc/webrtc_peer_connection_extension.cpp
@@ -36,12 +36,12 @@ void WebRTCPeerConnectionExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_connection_state);
 	GDVIRTUAL_BIND(_get_gathering_state);
 	GDVIRTUAL_BIND(_get_signaling_state);
-	GDVIRTUAL_BIND(_initialize, "p_config");
-	GDVIRTUAL_BIND(_create_data_channel, "p_label", "p_config");
+	GDVIRTUAL_BIND(_initialize, "config");
+	GDVIRTUAL_BIND(_create_data_channel, "label", "config");
 	GDVIRTUAL_BIND(_create_offer);
-	GDVIRTUAL_BIND(_set_remote_description, "p_type", "p_sdp");
-	GDVIRTUAL_BIND(_set_local_description, "p_type", "p_sdp");
-	GDVIRTUAL_BIND(_add_ice_candidate, "p_sdp_mid_name", "p_sdp_mline_index", "p_sdp_name");
+	GDVIRTUAL_BIND(_set_remote_description, "type", "sdp");
+	GDVIRTUAL_BIND(_set_local_description, "type", "sdp");
+	GDVIRTUAL_BIND(_add_ice_candidate, "sdp_mid_name", "sdp_mline_index", "sdp_name");
 	GDVIRTUAL_BIND(_poll);
 	GDVIRTUAL_BIND(_close);
 }

--- a/scene/2d/physics/collision_object_2d.cpp
+++ b/scene/2d/physics/collision_object_2d.cpp
@@ -641,7 +641,7 @@ void CollisionObject2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shape_owner_set_one_way_collision_margin", "owner_id", "margin"), &CollisionObject2D::shape_owner_set_one_way_collision_margin);
 	ClassDB::bind_method(D_METHOD("get_shape_owner_one_way_collision_margin", "owner_id"), &CollisionObject2D::get_shape_owner_one_way_collision_margin);
 	ClassDB::bind_method(D_METHOD("get_shape_owner_one_way_collision_direction", "owner_id"), &CollisionObject2D::get_shape_owner_one_way_collision_direction);
-	ClassDB::bind_method(D_METHOD("shape_owner_set_one_way_collision_direction", "owner_id", "p_direction"), &CollisionObject2D::shape_owner_set_one_way_collision_direction);
+	ClassDB::bind_method(D_METHOD("shape_owner_set_one_way_collision_direction", "owner_id", "direction"), &CollisionObject2D::shape_owner_set_one_way_collision_direction);
 	ClassDB::bind_method(D_METHOD("shape_owner_add_shape", "owner_id", "shape"), &CollisionObject2D::shape_owner_add_shape);
 	ClassDB::bind_method(D_METHOD("shape_owner_get_shape_count", "owner_id"), &CollisionObject2D::shape_owner_get_shape_count);
 	ClassDB::bind_method(D_METHOD("shape_owner_get_shape", "owner_id", "shape_id"), &CollisionObject2D::shape_owner_get_shape);

--- a/scene/2d/physics/collision_shape_2d.cpp
+++ b/scene/2d/physics/collision_shape_2d.cpp
@@ -305,7 +305,7 @@ void CollisionShape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_one_way_collision_enabled"), &CollisionShape2D::is_one_way_collision_enabled);
 	ClassDB::bind_method(D_METHOD("set_one_way_collision_margin", "margin"), &CollisionShape2D::set_one_way_collision_margin);
 	ClassDB::bind_method(D_METHOD("get_one_way_collision_margin"), &CollisionShape2D::get_one_way_collision_margin);
-	ClassDB::bind_method(D_METHOD("set_one_way_collision_direction", "p_direction"), &CollisionShape2D::set_one_way_collision_direction);
+	ClassDB::bind_method(D_METHOD("set_one_way_collision_direction", "direction"), &CollisionShape2D::set_one_way_collision_direction);
 	ClassDB::bind_method(D_METHOD("get_one_way_collision_direction"), &CollisionShape2D::get_one_way_collision_direction);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, Shape2D::get_class_static()), "set_shape", "get_shape");

--- a/scene/3d/skeleton_3d.compat.inc
+++ b/scene/3d/skeleton_3d.compat.inc
@@ -39,7 +39,7 @@ void Skeleton3D::_add_bone_bind_compat_88791(const String &p_name) {
 }
 
 void Skeleton3D::_bind_compatibility_methods() {
-	ClassDB::bind_compatibility_method(D_METHOD("add_bone", "p_name"), &Skeleton3D::_add_bone_bind_compat_88791);
+	ClassDB::bind_compatibility_method(D_METHOD("add_bone", "name"), &Skeleton3D::_add_bone_bind_compat_88791);
 }
 
 #endif // DISABLE_DEPRECATED

--- a/scene/main/multiplayer_peer.cpp
+++ b/scene/main/multiplayer_peer.cpp
@@ -196,31 +196,31 @@ bool MultiplayerPeerExtension::is_server_relay_supported() const {
 
 void MultiplayerPeerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_packet, "r_buffer", "r_buffer_size");
-	GDVIRTUAL_BIND(_put_packet, "p_buffer", "p_buffer_size");
+	GDVIRTUAL_BIND(_put_packet, "buffer", "buffer_size");
 	GDVIRTUAL_BIND(_get_available_packet_count);
 	GDVIRTUAL_BIND(_get_max_packet_size);
 
 	GDVIRTUAL_BIND(_get_packet_script)
-	GDVIRTUAL_BIND(_put_packet_script, "p_buffer");
+	GDVIRTUAL_BIND(_put_packet_script, "buffer");
 
 	GDVIRTUAL_BIND(_get_packet_channel);
 	GDVIRTUAL_BIND(_get_packet_mode);
 
-	GDVIRTUAL_BIND(_set_transfer_channel, "p_channel");
+	GDVIRTUAL_BIND(_set_transfer_channel, "channel");
 	GDVIRTUAL_BIND(_get_transfer_channel);
 
-	GDVIRTUAL_BIND(_set_transfer_mode, "p_mode");
+	GDVIRTUAL_BIND(_set_transfer_mode, "mode");
 	GDVIRTUAL_BIND(_get_transfer_mode);
 
-	GDVIRTUAL_BIND(_set_target_peer, "p_peer");
+	GDVIRTUAL_BIND(_set_target_peer, "peer");
 
 	GDVIRTUAL_BIND(_get_packet_peer);
 	GDVIRTUAL_BIND(_is_server);
 	GDVIRTUAL_BIND(_poll);
 	GDVIRTUAL_BIND(_close);
-	GDVIRTUAL_BIND(_disconnect_peer, "p_peer", "p_force");
+	GDVIRTUAL_BIND(_disconnect_peer, "peer", "force");
 	GDVIRTUAL_BIND(_get_unique_id);
-	GDVIRTUAL_BIND(_set_refuse_new_connections, "p_enable");
+	GDVIRTUAL_BIND(_set_refuse_new_connections, "enable");
 	GDVIRTUAL_BIND(_is_refusing_new_connections);
 	GDVIRTUAL_BIND(_is_server_relay_supported);
 	GDVIRTUAL_BIND(_get_connection_status);

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -4357,7 +4357,7 @@ void TileSet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_source_level_tile_proxy", "source_from"), &TileSet::has_source_level_tile_proxy);
 	ClassDB::bind_method(D_METHOD("remove_source_level_tile_proxy", "source_from"), &TileSet::remove_source_level_tile_proxy);
 
-	ClassDB::bind_method(D_METHOD("set_coords_level_tile_proxy", "p_source_from", "coords_from", "source_to", "coords_to"), &TileSet::set_coords_level_tile_proxy);
+	ClassDB::bind_method(D_METHOD("set_coords_level_tile_proxy", "source_from", "coords_from", "source_to", "coords_to"), &TileSet::set_coords_level_tile_proxy);
 	ClassDB::bind_method(D_METHOD("get_coords_level_tile_proxy", "source_from", "coords_from"), &TileSet::get_coords_level_tile_proxy);
 	ClassDB::bind_method(D_METHOD("has_coords_level_tile_proxy", "source_from", "coords_from"), &TileSet::has_coords_level_tile_proxy);
 	ClassDB::bind_method(D_METHOD("remove_coords_level_tile_proxy", "source_from", "coords_from"), &TileSet::remove_coords_level_tile_proxy);

--- a/servers/audio/audio_effect.cpp
+++ b/servers/audio/audio_effect.cpp
@@ -42,7 +42,7 @@ bool AudioEffectInstance::process_silence() const {
 }
 
 void AudioEffectInstance::_bind_methods() {
-	GDVIRTUAL_BIND(_process, "src_buffer", "dst_buffer", "frame_count");
+	GDVIRTUAL_BIND(_process, "src_buffer", "r_dst_buffer", "frame_count");
 	GDVIRTUAL_BIND(_process_silence);
 }
 

--- a/servers/audio/effects/audio_effect_hard_limiter.cpp
+++ b/servers/audio/effects/audio_effect_hard_limiter.cpp
@@ -150,10 +150,10 @@ void AudioEffectHardLimiter::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_ceiling_db", "ceiling"), &AudioEffectHardLimiter::set_ceiling_db);
 	ClassDB::bind_method(D_METHOD("get_ceiling_db"), &AudioEffectHardLimiter::get_ceiling_db);
 
-	ClassDB::bind_method(D_METHOD("set_pre_gain_db", "p_pre_gain"), &AudioEffectHardLimiter::set_pre_gain_db);
+	ClassDB::bind_method(D_METHOD("set_pre_gain_db", "pre_gain"), &AudioEffectHardLimiter::set_pre_gain_db);
 	ClassDB::bind_method(D_METHOD("get_pre_gain_db"), &AudioEffectHardLimiter::get_pre_gain_db);
 
-	ClassDB::bind_method(D_METHOD("set_release", "p_release"), &AudioEffectHardLimiter::set_release);
+	ClassDB::bind_method(D_METHOD("set_release", "release"), &AudioEffectHardLimiter::set_release);
 	ClassDB::bind_method(D_METHOD("get_release"), &AudioEffectHardLimiter::get_release);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pre_gain_db", PROPERTY_HINT_RANGE, "-24,24,0.01,suffix:dB"), "set_pre_gain_db", "get_pre_gain_db");

--- a/servers/display/accessibility_server.cpp
+++ b/servers/display/accessibility_server.cpp
@@ -65,7 +65,7 @@ void AccessibilityServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("update_set_description", "id", "description"), &AccessibilityServer::update_set_description);
 	ClassDB::bind_method(D_METHOD("update_set_value", "id", "value"), &AccessibilityServer::update_set_value);
 	ClassDB::bind_method(D_METHOD("update_set_tooltip", "id", "tooltip"), &AccessibilityServer::update_set_tooltip);
-	ClassDB::bind_method(D_METHOD("update_set_bounds", "id", "p_rect"), &AccessibilityServer::update_set_bounds);
+	ClassDB::bind_method(D_METHOD("update_set_bounds", "id", "rect"), &AccessibilityServer::update_set_bounds);
 	ClassDB::bind_method(D_METHOD("update_set_transform", "id", "transform"), &AccessibilityServer::update_set_transform);
 	ClassDB::bind_method(D_METHOD("update_add_child", "id", "child_id"), &AccessibilityServer::update_add_child);
 	ClassDB::bind_method(D_METHOD("update_add_related_controls", "id", "related_id"), &AccessibilityServer::update_add_related_controls);

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -1604,7 +1604,7 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("accessibility_update_set_description", "id", "description"), &DisplayServer::accessibility_update_set_description);
 	ClassDB::bind_method(D_METHOD("accessibility_update_set_value", "id", "value"), &DisplayServer::accessibility_update_set_value);
 	ClassDB::bind_method(D_METHOD("accessibility_update_set_tooltip", "id", "tooltip"), &DisplayServer::accessibility_update_set_tooltip);
-	ClassDB::bind_method(D_METHOD("accessibility_update_set_bounds", "id", "p_rect"), &DisplayServer::accessibility_update_set_bounds);
+	ClassDB::bind_method(D_METHOD("accessibility_update_set_bounds", "id", "rect"), &DisplayServer::accessibility_update_set_bounds);
 	ClassDB::bind_method(D_METHOD("accessibility_update_set_transform", "id", "transform"), &DisplayServer::accessibility_update_set_transform);
 	ClassDB::bind_method(D_METHOD("accessibility_update_add_child", "id", "child_id"), &DisplayServer::accessibility_update_add_child);
 	ClassDB::bind_method(D_METHOD("accessibility_update_add_related_controls", "id", "related_id"), &DisplayServer::accessibility_update_add_related_controls);

--- a/servers/physics_2d/physics_server_2d_extension.cpp
+++ b/servers/physics_2d/physics_server_2d_extension.cpp
@@ -41,12 +41,12 @@ thread_local const HashSet<RID> *PhysicsDirectSpaceState2DExtension::exclude = n
 void PhysicsDirectSpaceState2DExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_body_excluded_from_query", "body"), &PhysicsDirectSpaceState2DExtension::is_body_excluded_from_query);
 
-	GDVIRTUAL_BIND(_intersect_ray, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "result");
-	GDVIRTUAL_BIND(_intersect_point, "position", "canvas_instance_id", "collision_mask", "collide_with_bodies", "collide_with_areas", "results", "max_results");
-	GDVIRTUAL_BIND(_intersect_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "result", "max_results");
-	GDVIRTUAL_BIND(_cast_motion, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "closest_safe", "closest_unsafe");
-	GDVIRTUAL_BIND(_collide_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "results", "max_results", "result_count");
-	GDVIRTUAL_BIND(_rest_info, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "rest_info");
+	GDVIRTUAL_BIND(_intersect_ray, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "r_result");
+	GDVIRTUAL_BIND(_intersect_point, "position", "canvas_instance_id", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_results", "max_results");
+	GDVIRTUAL_BIND(_intersect_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_result", "max_results");
+	GDVIRTUAL_BIND(_cast_motion, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_closest_safe", "r_closest_unsafe");
+	GDVIRTUAL_BIND(_collide_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_results", "max_results", "r_result_count");
+	GDVIRTUAL_BIND(_rest_info, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_rest_info");
 }
 
 PhysicsDirectSpaceState2DExtension::PhysicsDirectSpaceState2DExtension() {
@@ -152,7 +152,7 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_shape_get_type, "shape");
 	GDVIRTUAL_BIND(_shape_get_data, "shape");
 	GDVIRTUAL_BIND(_shape_get_custom_solver_bias, "shape");
-	GDVIRTUAL_BIND(_shape_collide, "shape_A", "xform_A", "motion_A", "shape_B", "xform_B", "motion_B", "results", "result_max", "result_count");
+	GDVIRTUAL_BIND(_shape_collide, "shape_A", "xform_A", "motion_A", "shape_B", "xform_B", "motion_B", "r_results", "result_max", "r_result_count");
 
 	/* SPACE API */
 
@@ -301,13 +301,13 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_body_set_state_sync_callback, "body", "callable");
 	GDVIRTUAL_BIND(_body_set_force_integration_callback, "body", "callable", "userdata");
 
-	GDVIRTUAL_BIND(_body_collide_shape, "body", "body_shape", "shape", "shape_xform", "motion", "results", "result_max", "result_count");
+	GDVIRTUAL_BIND(_body_collide_shape, "body", "body_shape", "shape", "shape_xform", "motion", "r_results", "result_max", "r_result_count");
 
 	GDVIRTUAL_BIND(_body_set_pickable, "body", "pickable");
 
 	GDVIRTUAL_BIND(_body_get_direct_state, "body");
 
-	GDVIRTUAL_BIND(_body_test_motion, "body", "from", "motion", "margin", "collide_separation_ray", "recovery_as_collision", "result");
+	GDVIRTUAL_BIND(_body_test_motion, "body", "from", "motion", "margin", "collide_separation_ray", "recovery_as_collision", "r_result");
 
 	/* JOINT API */
 

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -41,12 +41,12 @@ thread_local const HashSet<RID> *PhysicsDirectSpaceState3DExtension::exclude = n
 void PhysicsDirectSpaceState3DExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_body_excluded_from_query", "body"), &PhysicsDirectSpaceState3DExtension::is_body_excluded_from_query);
 
-	GDVIRTUAL_BIND(_intersect_ray, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "hit_back_faces", "pick_ray", "result");
-	GDVIRTUAL_BIND(_intersect_point, "position", "collision_mask", "collide_with_bodies", "collide_with_areas", "results", "max_results");
-	GDVIRTUAL_BIND(_intersect_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "result_count", "max_results");
-	GDVIRTUAL_BIND(_cast_motion, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "closest_safe", "closest_unsafe", "info");
-	GDVIRTUAL_BIND(_collide_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "results", "max_results", "result_count");
-	GDVIRTUAL_BIND(_rest_info, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "rest_info");
+	GDVIRTUAL_BIND(_intersect_ray, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "hit_back_faces", "pick_ray", "r_result");
+	GDVIRTUAL_BIND(_intersect_point, "position", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_results", "max_results");
+	GDVIRTUAL_BIND(_intersect_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_result_count", "max_results");
+	GDVIRTUAL_BIND(_cast_motion, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_closest_safe", "r_closest_unsafe", "r_info");
+	GDVIRTUAL_BIND(_collide_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_results", "max_results", "r_result_count");
+	GDVIRTUAL_BIND(_rest_info, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_rest_info");
 	GDVIRTUAL_BIND(_get_closest_point_to_object_volume, "object", "point");
 }
 
@@ -307,7 +307,7 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_body_set_ray_pickable, "body", "enable");
 
-	GDVIRTUAL_BIND(_body_test_motion, "body", "from", "motion", "margin", "max_collisions", "collide_separation_ray", "recovery_as_collision", "result");
+	GDVIRTUAL_BIND(_body_test_motion, "body", "from", "motion", "margin", "max_collisions", "collide_separation_ray", "recovery_as_collision", "r_result");
 
 	GDVIRTUAL_BIND(_body_get_direct_state, "body");
 

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2730,7 +2730,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("particles_set_collision_base_size", "particles", "size"), &RenderingServer::particles_set_collision_base_size);
 	ClassDB::bind_method(D_METHOD("particles_set_transform_align", "particles", "align"), &RenderingServer::particles_set_transform_align);
 	ClassDB::bind_method(D_METHOD("particles_set_transform_align_channel_filter", "particles", "channel_filter"), &RenderingServer::particles_set_transform_align_channel_filter);
-	ClassDB::bind_method(D_METHOD("particles_set_transform_align_axis", "particles", "p_rotation_axis"), &RenderingServer::particles_set_transform_align_axis);
+	ClassDB::bind_method(D_METHOD("particles_set_transform_align_axis", "particles", "rotation_axis"), &RenderingServer::particles_set_transform_align_axis);
 	ClassDB::bind_method(D_METHOD("particles_set_trails", "particles", "enable", "length_sec"), &RenderingServer::particles_set_trails);
 	ClassDB::bind_method(D_METHOD("particles_set_trail_bind_poses", "particles", "bind_poses"), &RenderingServer::_particles_set_trail_bind_poses);
 
@@ -3078,7 +3078,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("environment_set_fog", "env", "enable", "light_color", "light_energy", "sun_scatter", "density", "height", "height_density", "aerial_perspective", "sky_affect", "fog_mode"), &RenderingServer::environment_set_fog, DEFVAL(RSE::ENV_FOG_MODE_EXPONENTIAL));
 	ClassDB::bind_method(D_METHOD("environment_set_fog_depth", "env", "curve", "begin", "end"), &RenderingServer::environment_set_fog_depth);
 	ClassDB::bind_method(D_METHOD("environment_set_sdfgi", "env", "enable", "cascades", "min_cell_size", "y_scale", "use_occlusion", "bounce_feedback", "read_sky", "energy", "normal_bias", "probe_bias"), &RenderingServer::environment_set_sdfgi);
-	ClassDB::bind_method(D_METHOD("environment_set_volumetric_fog", "env", "enable", "density", "albedo", "emission", "emission_energy", "anisotropy", "length", "p_detail_spread", "gi_inject", "temporal_reprojection", "temporal_reprojection_amount", "ambient_inject", "sky_affect"), &RenderingServer::environment_set_volumetric_fog);
+	ClassDB::bind_method(D_METHOD("environment_set_volumetric_fog", "env", "enable", "density", "albedo", "emission", "emission_energy", "anisotropy", "length", "detail_spread", "gi_inject", "temporal_reprojection", "temporal_reprojection_amount", "ambient_inject", "sky_affect"), &RenderingServer::environment_set_volumetric_fog);
 
 	ClassDB::bind_method(D_METHOD("environment_glow_set_use_bicubic_upscale", "enable"), &RenderingServer::environment_glow_set_use_bicubic_upscale);
 	ClassDB::bind_method(D_METHOD("environment_set_ssr_half_size", "half_size"), &RenderingServer::environment_set_ssr_half_size);

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -355,7 +355,7 @@ void TextServerExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_shaped_text_get_dominant_direction_in_range, "shaped", "start", "end");
 
-	GDVIRTUAL_BIND(_shaped_text_get_carets, "shaped", "position", "caret");
+	GDVIRTUAL_BIND(_shaped_text_get_carets, "shaped", "position", "r_caret");
 	GDVIRTUAL_BIND(_shaped_text_get_selection, "shaped", "start", "end");
 
 	GDVIRTUAL_BIND(_shaped_text_hit_test_grapheme, "shaped", "coord");


### PR DESCRIPTION
I believe this is all of them. I noticed that autocomplete will insert these prefixes if you complete the functions, and they also show up in the docs. My assumption is that this goes against the style for gdscript.