### PR TITLE
Fix error when creating PhysicalBone3D with unassigned bone_id

### DIFF
--- a/scene/3d/physics/physical_bone_simulator_3d.cpp
+++ b/scene/3d/physics/physical_bone_simulator_3d.cpp
@@ -154,6 +154,9 @@ void PhysicalBoneSimulator3D::unbind_physical_bone_from_bone(int p_bone) {
 }
 
 PhysicalBone3D *PhysicalBoneSimulator3D::get_physical_bone(int p_bone) {
+	if (p_bone < 0) {
+		return nullptr;
+	}
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX_V(p_bone, bone_size, nullptr);
 
@@ -161,6 +164,9 @@ PhysicalBone3D *PhysicalBoneSimulator3D::get_physical_bone(int p_bone) {
 }
 
 PhysicalBone3D *PhysicalBoneSimulator3D::get_physical_bone_parent(int p_bone) {
+	if (p_bone < 0) {
+		return nullptr;
+	}
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX_V(p_bone, bone_size, nullptr);
 


### PR DESCRIPTION
Fix #115922

Add early return for p_bone < 0 in get_physical_bone() and get_physical_bone_parent() to gracefully handle unassigned bone IDs.

When creating a `PhysicalBone3D` node, the `bone_id` is initialized to `-1` until a bone name is assigned. The gizmo plugin calls `get_physical_bone()` and `get_physical_bone_parent()` with this unassigned bone ID, triggering index out of bounds errors.

Added early return checks in `get_physical_bone()` and `get_physical_bone_parent()` to return `nullptr` when `p_bone < 0`, instead of proceeding to the `ERR_FAIL_INDEX_V` macro which logs an error.

This is a valid state during node creation, and the calling code (gizmo plugin) already handles `nullptr` returns correctly by checking the result before proceeding.

