### PR TITLE
GDScript: Fix enum documentation tooltips by correctly identifying parent class

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3584,7 +3584,7 @@ EditorHelpBit::HelpData EditorHelpBit::_get_enum_help_data(const StringName &p_c
 	return result;
 }
 
-EditorHelpBit::HelpData EditorHelpBit::_get_constant_help_data(const StringName &p_class_name, const StringName &p_constant_name) {
+EditorHelpBit::HelpData EditorHelpBit::_get_constant_help_data(const StringName &p_class_name, const StringName &p_constant_name, const StringName &p_enum_name) {
 	if (doc_constant_cache.has(p_class_name) && doc_constant_cache[p_class_name].has(p_constant_name)) {
 		return doc_constant_cache[p_class_name][p_constant_name];
 	}
@@ -3619,6 +3619,9 @@ EditorHelpBit::HelpData EditorHelpBit::_get_constant_help_data(const StringName 
 			}
 
 			if (constant.name == p_constant_name) {
+				if (p_enum_name != StringName() && constant.enumeration != p_enum_name) {
+					continue;
+				}
 				result = current;
 
 				if (!is_native) {
@@ -4408,7 +4411,8 @@ void EditorHelpBit::parse_symbol(const String &p_symbol, const String &p_prologu
 		symbol_doc_link = vformat("@constant %s.%s", class_name, item_name);
 		symbol_type = TTR("Constant");
 		symbol_hint = SYMBOL_HINT_ASSIGNABLE;
-		help_data = _get_constant_help_data(class_name, item_name);
+		String enum_name = item_data.get("enumeration", "").operator String();
+		help_data = _get_constant_help_data(class_name, item_name, enum_name);
 	} else if (item_type == "property") {
 		if (item_name.begins_with("metadata/")) {
 			symbol_type = TTR("Metadata");

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3664,7 +3664,7 @@ EditorHelpBit::HelpData EditorHelpBit::_get_enum_help_data(const StringName &p_c
 	return result;
 }
 
-EditorHelpBit::HelpData EditorHelpBit::_get_constant_help_data(const StringName &p_class_name, const StringName &p_constant_name) {
+EditorHelpBit::HelpData EditorHelpBit::_get_constant_help_data(const StringName &p_class_name, const StringName &p_constant_name, const StringName &p_enum_name) {
 	if (doc_constant_cache.has(p_class_name) && doc_constant_cache[p_class_name].has(p_constant_name)) {
 		return doc_constant_cache[p_class_name][p_constant_name];
 	}
@@ -3699,6 +3699,13 @@ EditorHelpBit::HelpData EditorHelpBit::_get_constant_help_data(const StringName 
 			}
 
 			if (constant.name == p_constant_name) {
+				if (p_enum_name != StringName()) {
+					if (constant.enumeration != p_enum_name) {
+						continue;
+					}
+				} else if (!constant.enumeration.is_empty() && constant.enumeration != "@unnamed_enums") {
+					continue;
+				}
 				result = current;
 
 				if (!is_native) {
@@ -4761,7 +4768,8 @@ void EditorHelpBit::parse_symbol(const String &p_symbol, const String &p_prologu
 		symbol_doc_link = vformat("@constant %s.%s", class_name, item_name);
 		symbol_type = TTR("Constant");
 		symbol_hint = SYMBOL_HINT_ASSIGNABLE;
-		help_data = _get_constant_help_data(class_name, item_name);
+		String enum_name = item_data.get("enumeration", "").operator String();
+		help_data = _get_constant_help_data(class_name, item_name, enum_name);
 	} else if (item_type == "property") {
 		if (item_name.begins_with("metadata/")) {
 			symbol_type = TTR("Metadata");

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -330,7 +330,7 @@ class EditorHelpBit : public VBoxContainer {
 
 	static HelpData _get_class_help_data(const StringName &p_class_name);
 	static HelpData _get_enum_help_data(const StringName &p_class_name, const StringName &p_enum_name);
-	static HelpData _get_constant_help_data(const StringName &p_class_name, const StringName &p_constant_name);
+	static HelpData _get_constant_help_data(const StringName &p_class_name, const StringName &p_constant_name, const StringName &p_enum_name = StringName());
 	static HelpData _get_property_help_data(const StringName &p_class_name, const StringName &p_property_name);
 	static HelpData _get_theme_item_help_data(const StringName &p_class_name, const StringName &p_theme_item_name);
 	static HelpData _get_method_help_data(const StringName &p_class_name, const StringName &p_method_name);

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -339,7 +339,7 @@ class EditorHelpBit : public VBoxContainer {
 
 	static HelpData _get_class_help_data(const StringName &p_class_name);
 	static HelpData _get_enum_help_data(const StringName &p_class_name, const StringName &p_enum_name);
-	static HelpData _get_constant_help_data(const StringName &p_class_name, const StringName &p_constant_name);
+	static HelpData _get_constant_help_data(const StringName &p_class_name, const StringName &p_constant_name, const StringName &p_enum_name = StringName());
 	static HelpData _get_property_help_data(const StringName &p_class_name, const StringName &p_property_name);
 	static HelpData _get_theme_item_help_data(const StringName &p_class_name, const StringName &p_theme_item_name);
 	static HelpData _get_method_help_data(const StringName &p_class_name, const StringName &p_method_name);

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1335,7 +1335,13 @@ void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, i
 					}
 					cname = ClassDB::get_parent_class(cname);
 				}
-				doc_symbol = "constant|" + result.class_name + "|" + result.class_member;
+				if (!result.enumeration.is_empty()) {
+					Dictionary d;
+					d["enumeration"] = result.enumeration;
+					doc_symbol = "constant|" + result.class_name + "|" + result.class_member + "|" + JSON::stringify(d);
+				} else {
+					doc_symbol = "constant|" + result.class_name + "|" + result.class_member;
+				}
 			} break;
 			case ScriptLanguage::LOOKUP_RESULT_CLASS_PROPERTY: {
 				StringName cname = result.class_name;

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1416,7 +1416,13 @@ void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, i
 					}
 					cname = ClassDB::get_parent_class(cname);
 				}
-				doc_symbol = "constant|" + result.class_name + "|" + result.class_member;
+				if (!result.enumeration.is_empty()) {
+					Dictionary d;
+					d["enumeration"] = result.enumeration;
+					doc_symbol = "constant|" + result.class_name + "|" + result.class_member + "|" + JSON::stringify(d);
+				} else {
+					doc_symbol = "constant|" + result.class_name + "|" + result.class_member;
+				}
 			} break;
 			case EditorLanguage::LookupResult::Type::CLASS_PROPERTY: {
 				StringName cname = result.class_name;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -4226,15 +4226,16 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						} else {
 							const int dot_pos = doc_enum_name.rfind_char('.');
 							if (dot_pos >= 0) {
+								const String enum_name = doc_enum_name.substr(dot_pos + 1);
 								Error err = OK;
 								r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
 								if (base_type.class_type != nullptr) {
 									// For script enums the value isn't accessible as class constant so we need the full enum name.
-									r_result.class_name = doc_enum_name;
+									r_result.class_name = doc_enum_name.left(dot_pos);
+									r_result.enumeration = enum_name;
 									r_result.class_member = p_symbol;
 									r_result.script = GDScriptCache::get_shallow_script(base_type.script_path, err);
 									r_result.script_path = base_type.script_path;
-									const String enum_name = doc_enum_name.substr(dot_pos + 1);
 									if (base_type.class_type->has_member(enum_name)) {
 										const GDScriptParser::ClassNode::Member member = base_type.class_type->get_member(enum_name);
 										if (member.type == GDScriptParser::ClassNode::Member::ENUM) {
@@ -4248,7 +4249,8 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 									}
 								} else if (base_type.script_type.is_valid()) {
 									// For script enums the value isn't accessible as class constant so we need the full enum name.
-									r_result.class_name = doc_enum_name;
+									r_result.class_name = doc_enum_name.left(dot_pos);
+									r_result.enumeration = enum_name;
 									r_result.class_member = p_symbol;
 									r_result.script = base_type.script_type;
 									r_result.script_path = base_type.script_path;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -4245,14 +4245,15 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						} else {
 							const int dot_pos = doc_enum_name.rfind_char('.');
 							if (dot_pos >= 0) {
+								const String enum_name = doc_enum_name.substr(dot_pos + 1);
 								Error err = OK;
 								r_result.type = EditorLanguage::LookupResult::Type::CLASS_CONSTANT;
 								if (base_type.class_type != nullptr) {
 									// For script enums the value isn't accessible as class constant so we need the full enum name.
-									r_result.class_name = doc_enum_name;
+									r_result.class_name = doc_enum_name.left(dot_pos);
+									r_result.enumeration = enum_name;
 									r_result.class_member = p_symbol;
 									r_result.script_path = base_type.script_path;
-									const String enum_name = doc_enum_name.substr(dot_pos + 1);
 									if (base_type.class_type->has_member(enum_name)) {
 										const GDScriptParser::ClassNode::Member member = base_type.class_type->get_member(enum_name);
 										if (member.type == GDScriptParser::ClassNode::Member::ENUM) {
@@ -4266,7 +4267,8 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 									}
 								} else if (base_type.script_type.is_valid()) {
 									// For script enums the value isn't accessible as class constant so we need the full enum name.
-									r_result.class_name = doc_enum_name;
+									r_result.class_name = doc_enum_name.left(dot_pos);
+									r_result.enumeration = enum_name;
 									r_result.class_member = p_symbol;
 									r_result.script_path = base_type.script_path;
 									// TODO: Find a way to obtain enum value location for a script


### PR DESCRIPTION
FIXES: #115925 and #122737

When hovering over an enum value (such as TestEnum.ONE), the editor tried to find the documentation for the symbol ONE. The issue was that the editor incorrectly identified the class of this symbol.

The editor resolved the symbol as having the base int type instead of associating it with the script class.

<img width="1693" height="803" alt="Screenshot from 2026-02-06 06-51-13" src="https://github.com/user-attachments/assets/28e4d93c-884d-4aa9-9401-70a6ab42c89f" />

