### PR TITLE
Add visual warnings for deprecated/unrecognized settings

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1363,6 +1363,17 @@ void ProjectSettings::_add_property_info_bind(const Dictionary &p_info) {
 	set_custom_property_info(pinfo);
 }
 
+String ProjectSettings::_get_property_warning(const StringName &p_name) const {
+#ifdef TOOLS_ENABLED
+	// Return a warning for settings that are not registered.
+	if (!is_builtin_setting(p_name)) {
+		return TTR("This setting is not recognized by the engine. It may be a custom setting, a deprecated setting from a previous version, or a setting from a different build.");
+	}
+#endif // TOOLS_ENABLED
+
+	return String();
+}
+
 void ProjectSettings::set_custom_property_info(const PropertyInfo &p_info) {
 	const String &prop_name = p_info.name;
 	ERR_FAIL_COND(!props.has(prop_name));
@@ -1623,6 +1634,7 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_as_basic", "name", "basic"), &ProjectSettings::set_as_basic);
 	ClassDB::bind_method(D_METHOD("set_as_internal", "name", "internal"), &ProjectSettings::set_as_internal);
 	ClassDB::bind_method(D_METHOD("add_property_info", "hint"), &ProjectSettings::_add_property_info_bind);
+	ClassDB::bind_method(D_METHOD("_get_property_warning", "name"), &ProjectSettings::_get_property_warning);
 	ClassDB::bind_method(D_METHOD("set_restart_if_changed", "name", "restart"), &ProjectSettings::set_restart_if_changed);
 	ClassDB::bind_method(D_METHOD("clear", "name"), &ProjectSettings::clear);
 	ClassDB::bind_method(D_METHOD("localize_path", "path"), &ProjectSettings::localize_path);

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -148,6 +148,7 @@ protected:
 	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0, bool p_main_pack = false);
 
 	void _add_property_info_bind(const Dictionary &p_info);
+	String _get_property_warning(const StringName &p_name) const;
 
 	Error _setup(const String &p_path, const String &p_main_pack, bool p_upwards = false, bool p_ignore_override = false);
 

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -547,6 +547,19 @@ void EditorProperty::_notification(int p_what) {
 				check_rect = Rect2();
 			}
 
+			if (draw_prop_warning && theme_cache.warning_icon.is_valid()) {
+				const Ref<Texture2D> &warn_icon = theme_cache.warning_icon;
+				int y = (size.height - warn_icon->get_height()) / 2;
+				if (rtl) {
+					draw_texture(warn_icon, Vector2(size.width - ofs - warn_icon->get_width(), y), color);
+				} else {
+					draw_texture(warn_icon, Vector2(ofs, y), color);
+				}
+				int icon_ofs = warn_icon->get_width() + theme_cache.horizontal_separation;
+				ofs += icon_ofs;
+				text_limit -= icon_ofs;
+			}
+
 			if (can_revert && !is_read_only()) {
 				const Ref<Texture2D> &reload_icon = theme_cache.revert_icon;
 				text_limit -= reload_icon->get_width() + half_padding + theme_cache.horizontal_separation;
@@ -858,6 +871,27 @@ void EditorProperty::update_editor_property_status() {
 	bool new_warning = false;
 	if (object->has_method("_get_property_warning")) {
 		new_warning = !String(object->call("_get_property_warning", property)).is_empty();
+	}
+
+	// Also check if the property is deprecated or experimental via doc data.
+	if (!new_warning) {
+		EditorInspector *inspector = get_parent_inspector();
+		if (inspector) {
+			const String classname = inspector->get_object_class();
+			const String property_prefix = inspector->get_property_prefix();
+			const String propname = property_prefix + property;
+			DocData::ClassDoc *cd = EditorHelp::get_doc(classname);
+			if (cd) {
+				for (const DocData::PropertyDoc &prop : cd->properties) {
+					if (prop.name == propname) {
+						if (prop.is_deprecated || prop.is_experimental) {
+							new_warning = true;
+						}
+						break;
+					}
+				}
+			}
+		}
 	}
 
 	Variant current = object->get(_get_revert_property());
@@ -3658,6 +3692,7 @@ void EditorInspector::initialize_property_theme(EditorProperty::ThemeCache &p_ca
 	p_cache.override_icon = p_control->get_editor_theme_icon(SNAME("Override"));
 	p_cache.remove_icon = p_control->get_editor_theme_icon(SNAME("Remove"));
 	p_cache.help_icon = p_control->get_editor_theme_icon(SNAME("Help"));
+	p_cache.warning_icon = p_control->get_editor_theme_icon(SNAME("NodeWarning"));
 
 	p_cache.font_size = p_control->get_theme_font_size(SceneStringName(font_size), SNAME("Tree"));
 	p_cache.font_offset = p_control->get_theme_constant(SNAME("font_offset"), SNAME("EditorProperty"));

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -96,6 +96,7 @@ class EditorProperty : public Container {
 		Ref<Texture2D> override_icon;
 		Ref<Texture2D> remove_icon;
 		Ref<Texture2D> help_icon;
+		Ref<Texture2D> warning_icon;
 
 		int font_size = 0;
 		int font_offset = 0;

--- a/editor/inspector/editor_sectioned_inspector.cpp
+++ b/editor/inspector/editor_sectioned_inspector.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_sectioned_inspector.h"
 
+#include "editor/doc/editor_help.h"
 #include "editor/editor_string_names.h"
 #include "editor/inspector/editor_inspector.h"
 #include "editor/inspector/editor_property_name_processor.h"
@@ -58,6 +59,11 @@ class SectionedInspectorFilter : public Object {
 	Object *edited = nullptr;
 	String section;
 	bool allow_sub = false;
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("_get_property_warning", "name"), &SectionedInspectorFilter::_get_property_warning);
+	}
 
 	bool _set(const StringName &p_name, const Variant &p_value) {
 		if (!edited) {
@@ -124,6 +130,17 @@ class SectionedInspectorFilter : public Object {
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const {
 		r_property = edited->property_get_revert(section + "/" + p_name);
 		return true;
+	}
+
+	String _get_property_warning(const StringName &p_name) const {
+		if (!edited || !edited->has_method("_get_property_warning")) {
+			return String();
+		}
+		String name = p_name;
+		if (!section.is_empty()) {
+			name = section + "/" + name;
+		}
+		return edited->call("_get_property_warning", name);
 	}
 
 public:

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -350,6 +350,15 @@ void EditorSettings::_add_property_info_bind(const Dictionary &p_info) {
 	add_property_hint(pinfo);
 }
 
+String EditorSettings::_get_property_warning(const StringName &p_name) const {
+	// Return a warning for settings that are not registered.
+	if (!has_default_value(p_name)) {
+		return TTR("This setting is not recognized by the editor. It may be a custom setting, a deprecated setting from a previous version, or a setting from a different build.");
+	}
+
+	return String();
+}
+
 // Default configs
 bool EditorSettings::has_default_value(const String &p_setting) const {
 	_THREAD_SAFE_METHOD_
@@ -2269,6 +2278,7 @@ void EditorSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("erase", "property"), &EditorSettings::erase);
 	ClassDB::bind_method(D_METHOD("set_initial_value", "name", "value", "update_current"), &EditorSettings::set_initial_value);
 	ClassDB::bind_method(D_METHOD("add_property_info", "info"), &EditorSettings::_add_property_info_bind);
+	ClassDB::bind_method(D_METHOD("_get_property_warning", "name"), &EditorSettings::_get_property_warning);
 
 	ClassDB::bind_method(D_METHOD("set_project_metadata", "section", "key", "data"), &EditorSettings::set_project_metadata);
 	ClassDB::bind_method(D_METHOD("get_project_metadata", "section", "key", "default"), &EditorSettings::get_project_metadata, DEFVAL(Variant()));

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -115,6 +115,7 @@ private:
 	void _initial_set(const StringName &p_name, const Variant &p_value, bool p_basic = false);
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _add_property_info_bind(const Dictionary &p_info);
+	String _get_property_warning(const StringName &p_name) const;
 	bool _property_can_revert(const StringName &p_name) const;
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
 


### PR DESCRIPTION
Adds visual warnings for deprecated, experimental, and unrecognized settings in the project and editor settings dialogs.

- Reuses the `_get_property_warning` system implemented by https://github.com/godotengine/godot/pull/74644 to add warnings to `ProjectSettings` and `EditorSettings`.
    - Fixes https://github.com/godotengine/godot-proposals/issues/3526.
- Add a warning icon to the inspector, besides the yellow tint. I thought just the color wasn't intuitive enough, but this is somewhat subjective so I'm happy to remove if there's no consensus.

<img width="1140" height="744" alt="Editor Settings dialog showing an unrecognized setting" src="https://github.com/user-attachments/assets/fe30017b-ad98-45b2-bd53-7608b6f77d83" />

> [!NOTE]
> Export editor settings (i.e., "export/windows/osslsigncode") show as unrecognized when opening the EditorSettings from the Project Manager, because the ExportPlugins aren't registered.
