### PR TITLE
[TextServer] Clamp internal font rendering size to 2048.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1509,8 +1509,8 @@ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const
 		} else {
 			FT_Size_RequestRec req;
 			req.type = FT_SIZE_REQUEST_TYPE_NOMINAL;
-			req.width = sz * 64.0;
-			req.height = sz * 64.0;
+			req.width = MIN(2048.0, sz) * 64.0;
+			req.height = MIN(2048.0, sz) * 64.0;
 			req.horiResolution = 0;
 			req.vertResolution = 0;
 

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -936,8 +936,8 @@ bool TextServerFallback::_ensure_cache_for_size(FontFallback *p_font_data, const
 		} else {
 			FT_Size_RequestRec req;
 			req.type = FT_SIZE_REQUEST_TYPE_NOMINAL;
-			req.width = sz * 64.0;
-			req.height = sz * 64.0;
+			req.width = MIN(2048.0, sz) * 64.0;
+			req.height = MIN(2048.0, sz) * 64.0;
 			req.horiResolution = 0;
 			req.vertResolution = 0;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/115944 (large font with large oversampling caused by high zoom levels).
Fixes same errors when font size override is set to extremely high values.

Text can use any font size, but if it's too high it is rendered at 2048 and upscaled.
