### PR TITLE
Fix GDExtension breakage in removed `AudioEffectSpectrumAnalyzer::get_tap_back_pos`

### DIFF
--- a/servers/audio/effects/audio_effect_spectrum_analyzer.compat.inc
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.compat.inc
@@ -34,7 +34,7 @@ void AudioEffectSpectrumAnalyzer::_set_tap_back_pos_bind_compat_114355(float p_s
 	WARN_PRINT_ONCE("AudioEffectSpectrumAnalyzer.set_tap_back_pos() is deprecated and the value will be discarded.");
 }
 
-float AudioEffectSpectrumAnalyzer::_get_tap_back_pos_bind_compat_114355() {
+float AudioEffectSpectrumAnalyzer::_get_tap_back_pos_bind_compat_114355() const {
 	WARN_PRINT_ONCE("AudioEffectSpectrumAnalyzer.get_tap_back_pos() is deprecated and will only return the original default value.");
 	return 0.01;
 }

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.h
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.h
@@ -88,7 +88,7 @@ protected:
 
 #ifndef DISABLE_DEPRECATED
 	void _set_tap_back_pos_bind_compat_114355(float p_seconds);
-	float _get_tap_back_pos_bind_compat_114355();
+	float _get_tap_back_pos_bind_compat_114355() const;
 	static void _bind_compatibility_methods();
 #endif
 


### PR DESCRIPTION
Pull request https://github.com/godotengine/godot/pull/114355 accidentally breaks GDExtension API.

The getter `AudioEffectSpectrumAnalyzer::get_tap_back_pos` was originally const-qualified, but the compat method wasn't.

Since const-qualification is taken into account when computing a function hash, this means that the compat method no longer matches the original one, causing breakage.