### PR TITLE
Remove unused `JoypadSDL::singleton`

### DIFF
--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -43,18 +43,12 @@
 #include <SDL3/SDL_iostream.h>
 #include <SDL3/SDL_joystick.h>
 
-JoypadSDL *JoypadSDL::singleton = nullptr;
-
 // Macro to skip the SDL joystick event handling if the device is an SDL gamepad, because
 // there are separate events for SDL gamepads
 #define SKIP_EVENT_FOR_GAMEPAD \
 	if (SDL_IsGamepad(sdl_event.jdevice.which)) { \
 		continue; \
 	}
-
-JoypadSDL::JoypadSDL() {
-	singleton = this;
-}
 
 JoypadSDL::~JoypadSDL() {
 	// Process any remaining input events
@@ -65,11 +59,6 @@ JoypadSDL::~JoypadSDL() {
 		}
 	}
 	SDL_Quit();
-	singleton = nullptr;
-}
-
-JoypadSDL *JoypadSDL::get_singleton() {
-	return singleton;
 }
 
 Error JoypadSDL::initialize() {

--- a/drivers/sdl/joypad_sdl.h
+++ b/drivers/sdl/joypad_sdl.h
@@ -39,10 +39,7 @@ typedef struct SDL_Gamepad SDL_Gamepad;
 
 class JoypadSDL {
 public:
-	JoypadSDL();
 	~JoypadSDL();
-
-	static JoypadSDL *get_singleton();
 
 	Error initialize();
 	void process_events();
@@ -68,8 +65,6 @@ private:
 		SDL_Joystick *get_sdl_joystick() const;
 		SDL_Gamepad *get_sdl_gamepad() const;
 	};
-
-	static JoypadSDL *singleton;
 
 	Joypad joypads[Input::JOYPADS_MAX];
 	HashMap<SDL_JoystickID, int> sdl_instance_id_to_joypad_id;


### PR DESCRIPTION
Singleton functionality for `JoypadSDL` was added in https://github.com/godotengine/godot/pull/106218 and it seems to be a leftover from [xsellier's commit](https://github.com/xsellier/godot/commit/2139868a5c6f986d0ce05235b0f506551c3a725b#diff-c526f2312abbd32869958fe50defe36d42d633419be61a64a47ad2871f8c6363) (I'm not sure what was its purpose there and I didn't think about deleting it in my PR).

Since it's unused and it can not be used in `Input` class (because it would break encapsulation), I think it should be removed.
