### PR TITLE
Fix missing tooltip for panel with shortcuts without configurated keys

### DIFF
--- a/editor/docks/editor_dock.cpp
+++ b/editor/docks/editor_dock.cpp
@@ -295,8 +295,12 @@ void EditorDock::update_tab_style() {
 		} break;
 	}
 
-	if (shortcut.is_valid() && shortcut->has_valid_event()) {
-		tooltip += (tooltip.is_empty() ? "" : "\n") + TTR(shortcut->get_name()) + " (" + shortcut->get_as_text() + ")";
+	if (shortcut.is_valid()) {
+		tooltip += (tooltip.is_empty() ? "" : "\n") + TTR(shortcut->get_name());
+
+		if (shortcut->has_valid_event()) {
+			tooltip += " (" + shortcut->get_as_text() + ")";
+		}
 	}
 	parent_dock_container->set_tab_tooltip(index, tooltip);
 


### PR DESCRIPTION
- Fixes: https://github.com/godotengine/godot/issues/115950

## Details:

Tooltip is missing because AnimationTree doesn't configure keys for shortcuts by default. Tooltip is only created if keys are configured. Solution: always create a tooltip based on shortcut name and add keys if they exist.