### PR TITLE
Add cull mask property to the editor camera

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -46,6 +46,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_spin_slider.h"
+#include "editor/inspector/editor_properties.h"
 #include "editor/plugins/editor_plugin_list.h"
 #include "editor/run/editor_run_bar.h"
 #include "editor/scene/3d/gizmos/audio_listener_3d_gizmo_plugin.h"
@@ -582,6 +583,12 @@ bool Node3DEditorViewport::_is_rotation_arc_visible() const {
 
 void Node3DEditorViewport::_update_camera(real_t p_interp_delta) {
 	bool is_orthogonal = camera->get_projection() == Camera3D::PROJECTION_ORTHOGONAL;
+
+	uint32_t view_mask = (1 << 20) - 1; // Layers 1-20
+	uint32_t tool_mask = ~view_mask; // Layers 21-32
+	uint32_t view_layers = view_mask & spatial_editor->get_cull_mask();
+	uint32_t tool_layers = tool_mask & camera->get_cull_mask(); // Grid and gizmo layers
+	camera->set_cull_mask(view_layers | tool_layers);
 
 	Cursor old_camera_cursor = camera_cursor;
 	camera_cursor = cursor;
@@ -6199,7 +6206,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	surface->set_clip_contents(true);
 	camera = memnew(Camera3D);
 	camera->set_disable_gizmos(true);
-	camera->set_cull_mask(((1 << 20) - 1) | (1 << (GIZMO_BASE_LAYER + p_index)) | (1 << GIZMO_EDIT_LAYER) | (1 << GIZMO_GRID_LAYER) | (1 << MISC_TOOL_LAYER));
+	camera->set_cull_mask(spatial_editor->get_cull_mask() | (1 << (GIZMO_BASE_LAYER + p_index)) | (1 << GIZMO_EDIT_LAYER) | (1 << GIZMO_GRID_LAYER) | (1 << MISC_TOOL_LAYER));
 	viewport->add_child(camera);
 	camera->make_current();
 	surface->set_focus_mode(FOCUS_ALL);
@@ -7170,6 +7177,7 @@ Dictionary Node3DEditor::get_state() const {
 	d["fov"] = get_fov();
 	d["znear"] = get_znear();
 	d["zfar"] = get_zfar();
+	d["cull_mask"] = cull_mask;
 
 	Dictionary gizmos_status;
 	for (int i = 0; i < gizmo_plugins_by_name.size(); i++) {
@@ -7279,6 +7287,12 @@ void Node3DEditor::set_state(const Dictionary &p_state) {
 	}
 	if (d.has("fov")) {
 		settings_fov->set_value(double(d["fov"]));
+	}
+	if (d.has("cull_mask")) {
+		cull_mask = uint32_t(d["cull_mask"]);
+		cull_mask_temp = cull_mask;
+		settings_cull_mask->update_property();
+		settings_cull_mask->update_editor_property_status();
 	}
 	if (d.has("show_grid")) {
 		bool use = d["show_grid"];
@@ -8969,6 +8983,21 @@ void Node3DEditor::_snap_selected_nodes_to_floor() {
 	}
 }
 
+void Node3DEditor::_view_settings_opened() {
+	cull_mask_temp = cull_mask;
+	settings_cull_mask->update_property();
+	settings_cull_mask->update_editor_property_status();
+}
+
+void Node3DEditor::_view_settings_confirmed() {
+	cull_mask = cull_mask_temp;
+}
+
+void Node3DEditor::_property_changed(const StringName &p_property, const Variant &p_value, const String &p_field, bool p_changing) {
+	_set(p_property, p_value);
+	settings_cull_mask->update_editor_property_status();
+}
+
 void Node3DEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
@@ -9550,10 +9579,46 @@ void Node3DEditor::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("item_group_status_changed"));
 }
 
+bool Node3DEditor::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "cull_mask_temp") {
+		cull_mask_temp = p_value;
+		return true;
+	}
+	return false;
+}
+
+bool Node3DEditor::_get(const StringName &p_name, Variant &r_ret) const {
+	if (p_name == "cull_mask_temp") {
+		r_ret = cull_mask_temp;
+		return true;
+	}
+	return false;
+}
+
+bool Node3DEditor::_property_can_revert(const StringName &p_name) const {
+	if (p_name == "cull_mask_temp") {
+		return true;
+	}
+	return false;
+}
+
+bool Node3DEditor::_property_get_revert(const StringName &p_name, Variant &r_property) const {
+	if (p_name == "cull_mask_temp") {
+		r_property = 0xfffff;
+		return true;
+	}
+	return false;
+}
+
 void Node3DEditor::clear() {
 	settings_fov->set_value(EDITOR_GET("editors/3d/default_fov"));
 	settings_znear->set_value(EDITOR_GET("editors/3d/default_z_near"));
 	settings_zfar->set_value(EDITOR_GET("editors/3d/default_z_far"));
+
+	cull_mask = 0xfffff;
+	cull_mask_temp = cull_mask;
+	settings_cull_mask->update_property();
+	settings_cull_mask->update_editor_property_status();
 
 	snap_translate_value = EditorSettings::get_singleton()->get_project_metadata("3d_editor", "snap_translate_value", 1);
 	snap_rotate_value = EditorSettings::get_singleton()->get_project_metadata("3d_editor", "snap_rotate_value", 15);
@@ -10239,7 +10304,7 @@ Node3DEditor::Node3DEditor() {
 	settings_dialog->set_title(TTRC("Viewport Settings"));
 	add_child(settings_dialog);
 	settings_vbc = memnew(VBoxContainer);
-	settings_vbc->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
+	settings_vbc->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
 	settings_dialog->add_child(settings_vbc);
 
 	settings_fov = memnew(SpinBox);
@@ -10270,6 +10335,17 @@ Node3DEditor::Node3DEditor() {
 	settings_zfar->set_select_all_on_focus(true);
 	settings_vbc->add_margin_child(TTRC("View Z-Far:"), settings_zfar);
 
+	settings_cull_mask = memnew(EditorPropertyLayers);
+	settings_cull_mask->setup(EditorPropertyLayers::LAYER_RENDER_3D);
+	settings_cull_mask->set_object_and_property(this, "cull_mask_temp");
+	settings_cull_mask->set_label("Cull Mask");
+	settings_cull_mask->set_selectable(false);
+	settings_cull_mask->update_property();
+	settings_cull_mask->connect("property_changed", callable_mp(this, &Node3DEditor::_property_changed));
+	settings_vbc->add_margin_child(TTRC("View Cull Mask:"), settings_cull_mask);
+
+	settings_dialog->connect("about_to_popup", callable_mp(this, &Node3DEditor::_view_settings_opened));
+	settings_dialog->connect(SceneStringName(confirmed), callable_mp(this, &Node3DEditor::_view_settings_confirmed));
 	for (uint32_t i = 0; i < VIEWPORTS_COUNT; ++i) {
 		settings_dialog->connect(SceneStringName(confirmed), callable_mp(viewports[i], &Node3DEditorViewport::_view_settings_confirmed).bind(0.0));
 	}

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -63,6 +63,7 @@ class VSplitContainer;
 class ViewportNavigationControl;
 class WorldEnvironment;
 class MeshInstance3D;
+class EditorPropertyLayers;
 
 class ViewportRotationControl : public Control {
 	GDCLASS(ViewportRotationControl, Control);
@@ -830,6 +831,9 @@ private:
 	SpinBox *settings_fov = nullptr;
 	SpinBox *settings_znear = nullptr;
 	SpinBox *settings_zfar = nullptr;
+	EditorPropertyLayers *settings_cull_mask = nullptr;
+	uint32_t cull_mask_temp = 0xfffff;
+	uint32_t cull_mask = 0xfffff;
 
 	void _snap_changed();
 	void _snap_update();
@@ -888,6 +892,10 @@ private:
 
 	bool do_snap_selected_nodes_to_floor = false;
 	void _snap_selected_nodes_to_floor();
+
+	void _property_changed(const StringName &p_property, const Variant &p_value, const String &p_field, bool p_changing);
+	void _view_settings_opened();
+	void _view_settings_confirmed();
 
 	// Preview Sun and Environment
 
@@ -978,6 +986,11 @@ protected:
 
 	static void _bind_methods();
 
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	bool _property_can_revert(const StringName &p_name) const;
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
+
 public:
 	static Node3DEditor *get_singleton() { return singleton; }
 
@@ -988,6 +1001,9 @@ public:
 	float get_znear() const { return settings_znear->get_value(); }
 	float get_zfar() const { return settings_zfar->get_value(); }
 	float get_fov() const { return settings_fov->get_value(); }
+
+	uint32_t get_cull_mask() const { return cull_mask; }
+	void set_cull_mask(uint32_t mask) { cull_mask = mask; }
 
 	Transform3D get_gizmo_transform() const { return gizmo.transform; }
 	bool is_gizmo_visible() const;


### PR DESCRIPTION
Fixes [#8988](https://github.com/godotengine/godot-proposals/issues/8988)

<img width="640" height="480" alt="Editor camera cull mask" src="https://github.com/user-attachments/assets/14fa43af-59db-4e9e-931b-94df2c8fe834" />
