### PR TITLE
Reduce includes to rendering device.

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -555,7 +555,7 @@ public:
 };
 
 #define BIND_ENUM_CONSTANT(m_constant) \
-	::ClassDB::bind_integer_constant(get_class_static(), __constant_get_enum_name(m_constant), #m_constant, m_constant);
+	::ClassDB::bind_integer_constant(get_class_static(), __constant_get_enum_name(m_constant), __constant_get_enum_value_name(#m_constant), m_constant);
 
 #define BIND_BITFIELD_FLAG(m_constant) \
 	::ClassDB::bind_integer_constant(get_class_static(), __constant_get_bitfield_name(m_constant), #m_constant, m_constant, true);

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -92,8 +92,11 @@ struct VariantCaster<const T &> {
 	}
 };
 
-#define VARIANT_ENUM_CAST(m_enum) MAKE_ENUM_TYPE_INFO(m_enum)
+#define VARIANT_ENUM_CAST(m_enum) MAKE_ENUM_TYPE_INFO(m_enum, m_enum)
 #define VARIANT_BITFIELD_CAST(m_enum) MAKE_BITFIELD_TYPE_INFO(m_enum)
+
+// Use only for backwards compatibility when the location of an enum changes.
+#define VARIANT_ENUM_CAST_EXT(m_enum, m_bound_name) MAKE_ENUM_TYPE_INFO(m_enum, m_bound_name)
 
 // Object enum casts must go here
 VARIANT_ENUM_CAST(Object::ConnectFlags);

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -234,20 +234,24 @@ inline String enum_qualified_name_to_class_info_name(const String &p_qualified_n
 } // namespace Internal
 } // namespace GodotTypeInfo
 
-#define MAKE_ENUM_TYPE_INFO(m_enum) \
+#define MAKE_ENUM_TYPE_INFO(m_enum, m_bound_name) \
 	template <> \
 	struct GetTypeInfo<m_enum> { \
 		static const Variant::Type VARIANT_TYPE = Variant::INT; \
 		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
 		static inline PropertyInfo get_class_info() { \
 			return PropertyInfo(Variant::INT, String(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_ENUM, \
-					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_enum))); \
+					GodotTypeInfo::Internal::enum_qualified_name_to_class_info_name(String(#m_bound_name))); \
 		} \
 	};
 
 template <typename T>
 inline StringName __constant_get_enum_name(T param) {
 	return GetTypeInfo<T>::get_class_info().class_name;
+}
+
+inline StringName __constant_get_enum_value_name(const char *p_name) {
+	return String(p_name).get_slice("::", 1);
 }
 
 #define MAKE_BITFIELD_TYPE_INFO(m_enum) \

--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -37,7 +37,6 @@
 #include "core/string/ustring.h"
 #include "core/templates/local_vector.h"
 #include "core/version.h"
-#include "servers/rendering/rendering_device.h"
 
 GODOT_GCC_WARNING_PUSH
 GODOT_GCC_WARNING_IGNORE("-Wmissing-field-initializers")

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -34,7 +34,6 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/marshalls.h"
-#include "servers/rendering/rendering_device.h"
 #include "thirdparty/zlib/zlib.h"
 
 #include "d3d12_godot_nir_bridge.h"
@@ -470,7 +469,7 @@ void RenderingDeviceDriverD3D12::CPUDescriptorHeapPool::free(const Allocation &p
 	}
 }
 
-static const D3D12_COMPARISON_FUNC RD_TO_D3D12_COMPARE_OP[RD::COMPARE_OP_MAX] = {
+static const D3D12_COMPARISON_FUNC RD_TO_D3D12_COMPARE_OP[RDD::COMPARE_OP_MAX] = {
 	D3D12_COMPARISON_FUNC_NEVER,
 	D3D12_COMPARISON_FUNC_LESS,
 	D3D12_COMPARISON_FUNC_EQUAL,
@@ -484,8 +483,8 @@ static const D3D12_COMPARISON_FUNC RD_TO_D3D12_COMPARE_OP[RD::COMPARE_OP_MAX] = 
 uint32_t RenderingDeviceDriverD3D12::SubgroupCapabilities::supported_stages_flags_rd() const {
 	// If there's a way to check exactly which are supported, I have yet to find it.
 	return (
-			RenderingDevice::ShaderStage::SHADER_STAGE_FRAGMENT_BIT |
-			RenderingDevice::ShaderStage::SHADER_STAGE_COMPUTE_BIT);
+			RenderingDeviceCommons::ShaderStage::SHADER_STAGE_FRAGMENT_BIT |
+			RenderingDeviceCommons::ShaderStage::SHADER_STAGE_COMPUTE_BIT);
 }
 
 uint32_t RenderingDeviceDriverD3D12::SubgroupCapabilities::supported_operations_flags_rd() const {
@@ -493,14 +492,14 @@ uint32_t RenderingDeviceDriverD3D12::SubgroupCapabilities::supported_operations_
 		return 0;
 	} else {
 		return (
-				RenderingDevice::SubgroupOperations::SUBGROUP_BASIC_BIT |
-				RenderingDevice::SubgroupOperations::SUBGROUP_BALLOT_BIT |
-				RenderingDevice::SubgroupOperations::SUBGROUP_VOTE_BIT |
-				RenderingDevice::SubgroupOperations::SUBGROUP_SHUFFLE_BIT |
-				RenderingDevice::SubgroupOperations::SUBGROUP_SHUFFLE_RELATIVE_BIT |
-				RenderingDevice::SubgroupOperations::SUBGROUP_QUAD_BIT |
-				RenderingDevice::SubgroupOperations::SUBGROUP_ARITHMETIC_BIT |
-				RenderingDevice::SubgroupOperations::SUBGROUP_CLUSTERED_BIT);
+				RenderingDeviceCommons::SubgroupOperations::SUBGROUP_BASIC_BIT |
+				RenderingDeviceCommons::SubgroupOperations::SUBGROUP_BALLOT_BIT |
+				RenderingDeviceCommons::SubgroupOperations::SUBGROUP_VOTE_BIT |
+				RenderingDeviceCommons::SubgroupOperations::SUBGROUP_SHUFFLE_BIT |
+				RenderingDeviceCommons::SubgroupOperations::SUBGROUP_SHUFFLE_RELATIVE_BIT |
+				RenderingDeviceCommons::SubgroupOperations::SUBGROUP_QUAD_BIT |
+				RenderingDeviceCommons::SubgroupOperations::SUBGROUP_ARITHMETIC_BIT |
+				RenderingDeviceCommons::SubgroupOperations::SUBGROUP_CLUSTERED_BIT);
 	}
 }
 
@@ -570,7 +569,7 @@ void RenderingDeviceDriverD3D12::_debug_message_func(D3D12_MESSAGE_CATEGORY p_ca
 /**** RESOURCE ****/
 /******************/
 
-static const D3D12_RESOURCE_DIMENSION RD_TEXTURE_TYPE_TO_D3D12_RESOURCE_DIMENSION[RD::TEXTURE_TYPE_MAX] = {
+static const D3D12_RESOURCE_DIMENSION RD_TEXTURE_TYPE_TO_D3D12_RESOURCE_DIMENSION[RDD::TEXTURE_TYPE_MAX] = {
 	D3D12_RESOURCE_DIMENSION_TEXTURE1D,
 	D3D12_RESOURCE_DIMENSION_TEXTURE2D,
 	D3D12_RESOURCE_DIMENSION_TEXTURE3D,
@@ -1070,7 +1069,7 @@ uint64_t RenderingDeviceDriverD3D12::buffer_get_device_address(BufferID p_buffer
 /**** TEXTURE ****/
 /*****************/
 
-static const D3D12_SRV_DIMENSION RD_TEXTURE_TYPE_TO_D3D12_VIEW_DIMENSION_FOR_SRV[RD::TEXTURE_TYPE_MAX] = {
+static const D3D12_SRV_DIMENSION RD_TEXTURE_TYPE_TO_D3D12_VIEW_DIMENSION_FOR_SRV[RDD::TEXTURE_TYPE_MAX] = {
 	D3D12_SRV_DIMENSION_TEXTURE1D,
 	D3D12_SRV_DIMENSION_TEXTURE2D,
 	D3D12_SRV_DIMENSION_TEXTURE3D,
@@ -1080,7 +1079,7 @@ static const D3D12_SRV_DIMENSION RD_TEXTURE_TYPE_TO_D3D12_VIEW_DIMENSION_FOR_SRV
 	D3D12_SRV_DIMENSION_TEXTURECUBEARRAY,
 };
 
-static const D3D12_SRV_DIMENSION RD_TEXTURE_TYPE_TO_D3D12_VIEW_DIMENSION_FOR_SRV_MS[RD::TEXTURE_TYPE_MAX] = {
+static const D3D12_SRV_DIMENSION RD_TEXTURE_TYPE_TO_D3D12_VIEW_DIMENSION_FOR_SRV_MS[RDD::TEXTURE_TYPE_MAX] = {
 	D3D12_SRV_DIMENSION_UNKNOWN,
 	D3D12_SRV_DIMENSION_TEXTURE2DMS,
 	D3D12_SRV_DIMENSION_UNKNOWN,
@@ -1090,7 +1089,7 @@ static const D3D12_SRV_DIMENSION RD_TEXTURE_TYPE_TO_D3D12_VIEW_DIMENSION_FOR_SRV
 	D3D12_SRV_DIMENSION_UNKNOWN,
 };
 
-static const D3D12_UAV_DIMENSION RD_TEXTURE_TYPE_TO_D3D12_VIEW_DIMENSION_FOR_UAV[RD::TEXTURE_TYPE_MAX] = {
+static const D3D12_UAV_DIMENSION RD_TEXTURE_TYPE_TO_D3D12_VIEW_DIMENSION_FOR_UAV[RDD::TEXTURE_TYPE_MAX] = {
 	D3D12_UAV_DIMENSION_TEXTURE1D,
 	D3D12_UAV_DIMENSION_TEXTURE2D,
 	D3D12_UAV_DIMENSION_TEXTURE3D,

--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -454,8 +454,8 @@ String Utilities::get_video_adapter_vendor() const {
 	return rendering_device_vendor.trim_suffix(" Corporation");
 }
 
-RenderingDevice::DeviceType Utilities::get_video_adapter_type() const {
-	return RenderingDevice::DeviceType::DEVICE_TYPE_OTHER;
+RenderingDeviceEnums::DeviceType Utilities::get_video_adapter_type() const {
+	return RenderingDeviceEnums::DeviceType::DEVICE_TYPE_OTHER;
 }
 
 String Utilities::get_video_adapter_api_version() const {

--- a/drivers/gles3/storage/utilities.h
+++ b/drivers/gles3/storage/utilities.h
@@ -32,6 +32,8 @@
 
 #ifdef GLES3_ENABLED
 
+#include "core/templates/rid_owner.h"
+
 #include "servers/rendering/storage/utilities.h"
 
 #include "platform_gl.h"
@@ -221,7 +223,7 @@ public:
 	virtual uint64_t get_rendering_info(RS::RenderingInfo p_info) override;
 	virtual String get_video_adapter_name() const override;
 	virtual String get_video_adapter_vendor() const override;
-	virtual RenderingDevice::DeviceType get_video_adapter_type() const override;
+	virtual RenderingDeviceEnums::DeviceType get_video_adapter_type() const override;
 	virtual String get_video_adapter_api_version() const override;
 
 	virtual Size2i get_maximum_viewport_size() const override;

--- a/drivers/metal/metal_device_properties.cpp
+++ b/drivers/metal/metal_device_properties.cpp
@@ -272,20 +272,20 @@ void MetalDeviceProperties::init_limits(MTL::Device *p_device) {
 	}
 	limits.subgroupSupportedShaderStages.set_flag(RDD::ShaderStage::SHADER_STAGE_FRAGMENT_BIT);
 
-	limits.subgroupSupportedOperations.set_flag(RD::SubgroupOperations::SUBGROUP_BASIC_BIT);
+	limits.subgroupSupportedOperations.set_flag(RDD::SubgroupOperations::SUBGROUP_BASIC_BIT);
 	if (features.simdPermute || features.quadPermute) {
-		limits.subgroupSupportedOperations.set_flag(RD::SubgroupOperations::SUBGROUP_VOTE_BIT);
-		limits.subgroupSupportedOperations.set_flag(RD::SubgroupOperations::SUBGROUP_BALLOT_BIT);
-		limits.subgroupSupportedOperations.set_flag(RD::SubgroupOperations::SUBGROUP_SHUFFLE_BIT);
-		limits.subgroupSupportedOperations.set_flag(RD::SubgroupOperations::SUBGROUP_SHUFFLE_RELATIVE_BIT);
+		limits.subgroupSupportedOperations.set_flag(RDD::SubgroupOperations::SUBGROUP_VOTE_BIT);
+		limits.subgroupSupportedOperations.set_flag(RDD::SubgroupOperations::SUBGROUP_BALLOT_BIT);
+		limits.subgroupSupportedOperations.set_flag(RDD::SubgroupOperations::SUBGROUP_SHUFFLE_BIT);
+		limits.subgroupSupportedOperations.set_flag(RDD::SubgroupOperations::SUBGROUP_SHUFFLE_RELATIVE_BIT);
 	}
 
 	if (features.simdReduction) {
-		limits.subgroupSupportedOperations.set_flag(RD::SubgroupOperations::SUBGROUP_ARITHMETIC_BIT);
+		limits.subgroupSupportedOperations.set_flag(RDD::SubgroupOperations::SUBGROUP_ARITHMETIC_BIT);
 	}
 
 	if (features.quadPermute) {
-		limits.subgroupSupportedOperations.set_flag(RD::SubgroupOperations::SUBGROUP_QUAD_BIT);
+		limits.subgroupSupportedOperations.set_flag(RDD::SubgroupOperations::SUBGROUP_QUAD_BIT);
 	}
 
 	limits.maxBufferLength = p_device->maxBufferLength();
@@ -364,7 +364,7 @@ MetalDeviceProperties::MetalDeviceProperties(MTL::Device *p_device) {
 MetalDeviceProperties::~MetalDeviceProperties() {
 }
 
-SampleCount MetalDeviceProperties::find_nearest_supported_sample_count(RenderingDevice::TextureSamples p_samples) const {
+SampleCount MetalDeviceProperties::find_nearest_supported_sample_count(RenderingDeviceCommons::TextureSamples p_samples) const {
 	SampleCount supported = features.supportedSampleCounts;
 	if (supported & sample_count[p_samples]) {
 		return sample_count[p_samples];
@@ -384,7 +384,7 @@ SampleCount MetalDeviceProperties::find_nearest_supported_sample_count(Rendering
 
 // region static members
 
-const SampleCount MetalDeviceProperties::sample_count[RenderingDevice::TextureSamples::TEXTURE_SAMPLES_MAX] = {
+const SampleCount MetalDeviceProperties::sample_count[RenderingDeviceCommons::TextureSamples::TEXTURE_SAMPLES_MAX] = {
 	SampleCount1,
 	SampleCount2,
 	SampleCount4,

--- a/drivers/metal/metal_device_properties.h
+++ b/drivers/metal/metal_device_properties.h
@@ -50,7 +50,7 @@
 /* permissions and limitations under the License.                         */
 /**************************************************************************/
 
-#include "servers/rendering/rendering_device.h"
+#include "servers/rendering/rendering_device_driver.h"
 
 #include <Metal/Metal.hpp>
 #include <cstddef>
@@ -172,7 +172,7 @@ struct MetalLimits {
 	uint32_t minSubgroupSize; /**< The minimum number of threads in a SIMD-group. */
 	uint32_t maxSubgroupSize; /**< The maximum number of threads in a SIMD-group. */
 	BitField<RDD::ShaderStage> subgroupSupportedShaderStages;
-	BitField<RD::SubgroupOperations> subgroupSupportedOperations; /**< The subgroup operations supported by the device. */
+	BitField<RDD::SubgroupOperations> subgroupSupportedOperations; /**< The subgroup operations supported by the device. */
 };
 
 class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MetalDeviceProperties {
@@ -188,11 +188,11 @@ public:
 	// maj * 10000 + min * 100 + patch
 	uint32_t os_version;
 
-	SampleCount find_nearest_supported_sample_count(RenderingDevice::TextureSamples p_samples) const;
+	SampleCount find_nearest_supported_sample_count(RDD::TextureSamples p_samples) const;
 
 	MetalDeviceProperties(MTL::Device *p_device);
 	~MetalDeviceProperties();
 
 private:
-	static const SampleCount sample_count[RenderingDevice::TextureSamples::TEXTURE_SAMPLES_MAX];
+	static const SampleCount sample_count[RDD::TextureSamples::TEXTURE_SAMPLES_MAX];
 };

--- a/drivers/metal/metal_objects_shared.cpp
+++ b/drivers/metal/metal_objects_shared.cpp
@@ -632,11 +632,11 @@ void MDCommandBufferBase::encode_push_constant_data(RDD::ShaderID p_shader, Vect
 #pragma mark - Metal Library
 
 static const char *SHADER_STAGE_NAMES[] = {
-	[RD::SHADER_STAGE_VERTEX] = "vert",
-	[RD::SHADER_STAGE_FRAGMENT] = "frag",
-	[RD::SHADER_STAGE_TESSELATION_CONTROL] = "tess_ctrl",
-	[RD::SHADER_STAGE_TESSELATION_EVALUATION] = "tess_eval",
-	[RD::SHADER_STAGE_COMPUTE] = "comp",
+	[RDC::SHADER_STAGE_VERTEX] = "vert",
+	[RDC::SHADER_STAGE_FRAGMENT] = "frag",
+	[RDC::SHADER_STAGE_TESSELATION_CONTROL] = "tess_ctrl",
+	[RDC::SHADER_STAGE_TESSELATION_EVALUATION] = "tess_eval",
+	[RDC::SHADER_STAGE_COMPUTE] = "comp",
 };
 
 void ShaderCacheEntry::notify_free() const {

--- a/drivers/metal/metal_objects_shared.h
+++ b/drivers/metal/metal_objects_shared.h
@@ -883,7 +883,7 @@ struct ShaderCacheEntry {
 	/// A hash of the Metal shader source code.
 	SHA256Digest key;
 	CharString name;
-	RD::ShaderStage stage = RD::SHADER_STAGE_VERTEX;
+	RDC::ShaderStage stage = RDC::SHADER_STAGE_VERTEX;
 	/// Weak reference to the library; allows cache lookup without preventing cleanup.
 	std::weak_ptr<MDLibrary> library;
 

--- a/drivers/metal/pixel_formats.cpp
+++ b/drivers/metal/pixel_formats.cpp
@@ -150,14 +150,14 @@ MTL::PixelFormat PixelFormats::getMTLPixelFormat(DataFormat p_format) {
 
 	// If the MTL::PixelFormat is not supported but DataFormat is valid,
 	// attempt to substitute a different format.
-	if (mtlPixFmt == MTL::PixelFormatInvalid && p_format != RD::DATA_FORMAT_MAX && dfDesc.chromaSubsamplingPlaneCount <= 1) {
+	if (mtlPixFmt == MTL::PixelFormatInvalid && p_format != RDC::DATA_FORMAT_MAX && dfDesc.chromaSubsamplingPlaneCount <= 1) {
 		mtlPixFmt = dfDesc.mtlPixelFormatSubstitute;
 	}
 
 	return mtlPixFmt;
 }
 
-RD::DataFormat PixelFormats::getDataFormat(MTL::PixelFormat p_format) {
+RDC::DataFormat PixelFormats::getDataFormat(MTL::PixelFormat p_format) {
 	return getMTLPixelFormatDesc(p_format).dataFormat;
 }
 
@@ -283,10 +283,10 @@ PixelFormats::~PixelFormats() {
 }
 
 #define addDataFormatDescFull(DATA_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT, MTL_VTX_FMT_ALT, CSPC, CSCB, BLK_W, BLK_H, BLK_BYTE_CNT, MVK_FMT_TYPE, SWIZ_R, SWIZ_G, SWIZ_B, SWIZ_A) \
-	dfFmt = RD::DATA_FORMAT_##DATA_FMT; \
+	dfFmt = RDC::DATA_FORMAT_##DATA_FMT; \
 	_data_format_descs[dfFmt] = { dfFmt, MTL::PixelFormat##MTL_FMT, MTL::PixelFormat##MTL_FMT_ALT, MTL::VertexFormat##MTL_VTX_FMT, MTL::VertexFormat##MTL_VTX_FMT_ALT, \
 		CSPC, CSCB, { BLK_W, BLK_H }, BLK_BYTE_CNT, MTLFormatType::MVK_FMT_TYPE, \
-		{ RD::TEXTURE_SWIZZLE_##SWIZ_R, RD::TEXTURE_SWIZZLE_##SWIZ_G, RD::TEXTURE_SWIZZLE_##SWIZ_B, RD::TEXTURE_SWIZZLE_##SWIZ_A }, \
+		{ RDC::TEXTURE_SWIZZLE_##SWIZ_R, RDC::TEXTURE_SWIZZLE_##SWIZ_G, RDC::TEXTURE_SWIZZLE_##SWIZ_B, RDC::TEXTURE_SWIZZLE_##SWIZ_A }, \
 		"DATA_FORMAT_" #DATA_FMT, false }
 
 #define addDataFormatDesc(VK_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT, MTL_VTX_FMT_ALT, BLK_W, BLK_H, BLK_BYTE_CNT, MVK_FMT_TYPE) \
@@ -299,7 +299,7 @@ PixelFormats::~PixelFormats() {
 	addDataFormatDescFull(DATA_FMT, MTL_FMT, Invalid, Invalid, Invalid, CSPC, CSCB, BLK_W, BLK_H, BLK_BYTE_CNT, ColorFloat, IDENTITY, IDENTITY, IDENTITY, IDENTITY)
 
 void PixelFormats::initDataFormatCapabilities() {
-	_data_format_descs.reserve(RD::DATA_FORMAT_MAX + 1); // reserve enough space to avoid reallocs
+	_data_format_descs.reserve(RDC::DATA_FORMAT_MAX + 1); // reserve enough space to avoid reallocs
 	DataFormat dfFmt;
 
 	addDataFormatDesc(R4G4_UNORM_PACK8, Invalid, Invalid, Invalid, Invalid, 1, 1, 1, ColorFloat);
@@ -787,7 +787,7 @@ void PixelFormats::addMTLVertexFormatDescImpl(MTL::VertexFormat mtlVtxFmt, MTLFm
 	if (mtlVtxFmt >= _mtl_vertex_format_descs.size()) {
 		_mtl_vertex_format_descs.resize(mtlVtxFmt + 1);
 	}
-	_mtl_vertex_format_descs[mtlVtxFmt] = { .mtlVertexFormat = mtlVtxFmt, RD::DATA_FORMAT_MAX, vtxCap, MTLViewClass::None, MTL::PixelFormatInvalid, name };
+	_mtl_vertex_format_descs[mtlVtxFmt] = { .mtlVertexFormat = mtlVtxFmt, RDC::DATA_FORMAT_MAX, vtxCap, MTLViewClass::None, MTL::PixelFormatInvalid, name };
 }
 
 // Check mtlVtx exists on platform, to avoid overwriting the MTL::VertexFormatInvalid entry.
@@ -1021,7 +1021,7 @@ void PixelFormats::buildDFFormatMaps() {
 		// in the Godot format if not supported.
 		if (dfDesc.mtlPixelFormat) {
 			MTLFormatDesc &mtlDesc = getMTLPixelFormatDesc(dfDesc.mtlPixelFormat);
-			if (mtlDesc.dataFormat == RD::DATA_FORMAT_MAX) {
+			if (mtlDesc.dataFormat == RDC::DATA_FORMAT_MAX) {
 				mtlDesc.dataFormat = dfDesc.dataFormat;
 			}
 			if (!mtlDesc.isSupported()) {
@@ -1036,7 +1036,7 @@ void PixelFormats::buildDFFormatMaps() {
 		}
 		if (dfDesc.mtlVertexFormat) {
 			MTLFormatDesc &mtlDesc = getMTLVertexFormatDesc(dfDesc.mtlVertexFormat);
-			if (mtlDesc.dataFormat == RD::DATA_FORMAT_MAX) {
+			if (mtlDesc.dataFormat == RDC::DATA_FORMAT_MAX) {
 				mtlDesc.dataFormat = dfDesc.dataFormat;
 			}
 			if (!mtlDesc.isSupported()) {

--- a/drivers/metal/pixel_formats.h
+++ b/drivers/metal/pixel_formats.h
@@ -57,7 +57,7 @@ GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations")
 #include "inflection_map.h"
 #include "metal_device_properties.h"
 
-#include "servers/rendering/rendering_device.h"
+#include "servers/rendering/rendering_device_commons.h"
 
 #ifdef __OBJC__
 #include <Metal/Metal.h>
@@ -67,6 +67,8 @@ GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations")
 
 #pragma mark -
 #pragma mark Metal format capabilities
+
+using RDC = RenderingDeviceCommons;
 
 typedef enum : uint16_t {
 
@@ -191,15 +193,15 @@ struct Extent2D {
 };
 
 struct ComponentMapping {
-	RD::TextureSwizzle r = RD::TEXTURE_SWIZZLE_IDENTITY;
-	RD::TextureSwizzle g = RD::TEXTURE_SWIZZLE_IDENTITY;
-	RD::TextureSwizzle b = RD::TEXTURE_SWIZZLE_IDENTITY;
-	RD::TextureSwizzle a = RD::TEXTURE_SWIZZLE_IDENTITY;
+	RDC::TextureSwizzle r = RDC::TEXTURE_SWIZZLE_IDENTITY;
+	RDC::TextureSwizzle g = RDC::TEXTURE_SWIZZLE_IDENTITY;
+	RDC::TextureSwizzle b = RDC::TEXTURE_SWIZZLE_IDENTITY;
+	RDC::TextureSwizzle a = RDC::TEXTURE_SWIZZLE_IDENTITY;
 };
 
 /** Describes the properties of a DataFormat, including the corresponding Metal pixel and vertex format. */
 struct DataFormatDesc {
-	RD::DataFormat dataFormat;
+	RDC::DataFormat dataFormat;
 	MTL::PixelFormat mtlPixelFormat;
 	MTL::PixelFormat mtlPixelFormatSubstitute;
 	MTL::VertexFormat mtlVertexFormat;
@@ -222,10 +224,10 @@ struct DataFormatDesc {
 	inline bool vertexIsSupportedOrSubstitutable() const { return vertexIsSupported() || (mtlVertexFormatSubstitute != MTL::VertexFormatInvalid); }
 
 	bool needsSwizzle() const {
-		return (componentMapping.r != RD::TEXTURE_SWIZZLE_IDENTITY ||
-				componentMapping.g != RD::TEXTURE_SWIZZLE_IDENTITY ||
-				componentMapping.b != RD::TEXTURE_SWIZZLE_IDENTITY ||
-				componentMapping.a != RD::TEXTURE_SWIZZLE_IDENTITY);
+		return (componentMapping.r != RDC::TEXTURE_SWIZZLE_IDENTITY ||
+				componentMapping.g != RDC::TEXTURE_SWIZZLE_IDENTITY ||
+				componentMapping.b != RDC::TEXTURE_SWIZZLE_IDENTITY ||
+				componentMapping.a != RDC::TEXTURE_SWIZZLE_IDENTITY);
 	}
 };
 
@@ -235,7 +237,7 @@ struct MTLFormatDesc {
 		MTL::PixelFormat mtlPixelFormat;
 		MTL::VertexFormat mtlVertexFormat;
 	};
-	RD::DataFormat dataFormat = RD::DATA_FORMAT_MAX;
+	RDC::DataFormat dataFormat = RDC::DATA_FORMAT_MAX;
 	MTLFmtCaps mtlFmtCaps;
 	MTLViewClass mtlViewClass;
 	MTL::PixelFormat mtlPixelFormatLinear;
@@ -245,7 +247,7 @@ struct MTLFormatDesc {
 };
 
 class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) PixelFormats {
-	using DataFormat = RD::DataFormat;
+	using DataFormat = RDC::DataFormat;
 
 public:
 	/** Returns whether the DataFormat is supported by the GPU bound to this instance. */
@@ -408,7 +410,7 @@ protected:
 	void addMTLVertexFormatDescImpl(MTL::VertexFormat p_vert_fmt, MTLFmtCaps p_vert_caps, const char *name);
 
 	MTL::Device *device;
-	InflectionMap<DataFormat, DataFormatDesc, RD::DATA_FORMAT_MAX> _data_format_descs;
+	InflectionMap<DataFormat, DataFormatDesc, RDC::DATA_FORMAT_MAX> _data_format_descs;
 	InflectionMap<uint16_t, MTLFormatDesc, MTL::PixelFormatX32_Stencil8 + 2> _mtl_pixel_format_descs; // The actual last enum value is not available on iOS.
 	TightLocalVector<MTLFormatDesc> _mtl_vertex_format_descs;
 };

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -210,7 +210,7 @@ uint64_t RenderingDeviceDriverMetal::buffer_get_device_address(BufferID p_buffer
 
 #pragma mark - Format Conversions
 
-static const MTL::TextureType TEXTURE_TYPE[RD::TEXTURE_TYPE_MAX] = {
+static const MTL::TextureType TEXTURE_TYPE[RDD::TEXTURE_TYPE_MAX] = {
 	MTL::TextureType1D,
 	MTL::TextureType2D,
 	MTL::TextureType3D,
@@ -645,7 +645,7 @@ bool RenderingDeviceDriverMetal::texture_can_make_shared_with_format(TextureID p
 
 #pragma mark - Sampler
 
-static const MTL::CompareFunction COMPARE_OPERATORS[RD::COMPARE_OP_MAX] = {
+static const MTL::CompareFunction COMPARE_OPERATORS[RDD::COMPARE_OP_MAX] = {
 	MTL::CompareFunctionNever,
 	MTL::CompareFunctionLess,
 	MTL::CompareFunctionEqual,
@@ -656,7 +656,7 @@ static const MTL::CompareFunction COMPARE_OPERATORS[RD::COMPARE_OP_MAX] = {
 	MTL::CompareFunctionAlways,
 };
 
-static const MTL::StencilOperation STENCIL_OPERATIONS[RD::STENCIL_OP_MAX] = {
+static const MTL::StencilOperation STENCIL_OPERATIONS[RDD::STENCIL_OP_MAX] = {
 	MTL::StencilOperationKeep,
 	MTL::StencilOperationZero,
 	MTL::StencilOperationReplace,
@@ -667,7 +667,7 @@ static const MTL::StencilOperation STENCIL_OPERATIONS[RD::STENCIL_OP_MAX] = {
 	MTL::StencilOperationDecrementWrap,
 };
 
-static const MTL::BlendFactor BLEND_FACTORS[RD::BLEND_FACTOR_MAX] = {
+static const MTL::BlendFactor BLEND_FACTORS[RDD::BLEND_FACTOR_MAX] = {
 	MTL::BlendFactorZero,
 	MTL::BlendFactorOne,
 	MTL::BlendFactorSourceColor,
@@ -688,7 +688,7 @@ static const MTL::BlendFactor BLEND_FACTORS[RD::BLEND_FACTOR_MAX] = {
 	MTL::BlendFactorSource1Alpha,
 	MTL::BlendFactorOneMinusSource1Alpha,
 };
-static const MTL::BlendOperation BLEND_OPERATIONS[RD::BLEND_OP_MAX] = {
+static const MTL::BlendOperation BLEND_OPERATIONS[RDD::BLEND_OP_MAX] = {
 	MTL::BlendOperationAdd,
 	MTL::BlendOperationSubtract,
 	MTL::BlendOperationReverseSubtract,
@@ -696,7 +696,7 @@ static const MTL::BlendOperation BLEND_OPERATIONS[RD::BLEND_OP_MAX] = {
 	MTL::BlendOperationMax,
 };
 
-static const MTL::SamplerAddressMode ADDRESS_MODES[RD::SAMPLER_REPEAT_MODE_MAX] = {
+static const MTL::SamplerAddressMode ADDRESS_MODES[RDD::SAMPLER_REPEAT_MODE_MAX] = {
 	MTL::SamplerAddressModeRepeat,
 	MTL::SamplerAddressModeMirrorRepeat,
 	MTL::SamplerAddressModeClampToEdge,
@@ -704,7 +704,7 @@ static const MTL::SamplerAddressMode ADDRESS_MODES[RD::SAMPLER_REPEAT_MODE_MAX] 
 	MTL::SamplerAddressModeMirrorClampToEdge,
 };
 
-static const MTL::SamplerBorderColor SAMPLER_BORDER_COLORS[RD::SAMPLER_BORDER_COLOR_MAX] = {
+static const MTL::SamplerBorderColor SAMPLER_BORDER_COLORS[RDD::SAMPLER_BORDER_COLOR_MAX] = {
 	MTL::SamplerBorderColorTransparentBlack,
 	MTL::SamplerBorderColorTransparentBlack,
 	MTL::SamplerBorderColorOpaqueBlack,
@@ -1056,7 +1056,7 @@ RDD::ShaderID RenderingDeviceDriverMetal::shader_create_from_container(const Ref
 		options->setEnableLogging(mtl_reflection_data.needs_debug_logging());
 	}
 
-	HashMap<RD::ShaderStage, std::shared_ptr<MDLibrary>> libraries;
+	HashMap<RDD::ShaderStage, std::shared_ptr<MDLibrary>> libraries;
 
 	PipelineType pipeline_type = PIPELINE_TYPE_RASTERIZATION;
 	Vector<uint8_t> decompressed_code;
@@ -1064,7 +1064,7 @@ RDD::ShaderID RenderingDeviceDriverMetal::shader_create_from_container(const Ref
 		const RenderingShaderContainer::Shader &shader = shaders[shader_index];
 		const RSCM::StageData &shader_data = mtl_shaders[shader_index];
 
-		if (shader.shader_stage == RD::ShaderStage::SHADER_STAGE_COMPUTE) {
+		if (shader.shader_stage == RDD::ShaderStage::SHADER_STAGE_COMPUTE) {
 			pipeline_type = PIPELINE_TYPE_COMPUTE;
 		}
 
@@ -1179,7 +1179,7 @@ RDD::ShaderID RenderingDeviceDriverMetal::shader_create_from_container(const Ref
 				shader_name,
 				uniform_sets,
 				mtl_reflection_data.uses_argument_buffers(),
-				libraries[RD::ShaderStage::SHADER_STAGE_COMPUTE]);
+				libraries[RDD::ShaderStage::SHADER_STAGE_COMPUTE]);
 
 		cs->local = MTL::Size(refl.compute_local_size[0], refl.compute_local_size[1], refl.compute_local_size[2]);
 		shader = cs;
@@ -1189,8 +1189,8 @@ RDD::ShaderID RenderingDeviceDriverMetal::shader_create_from_container(const Ref
 				uniform_sets,
 				mtl_reflection_data.needs_view_mask_buffer(),
 				mtl_reflection_data.uses_argument_buffers(),
-				libraries[RD::ShaderStage::SHADER_STAGE_VERTEX],
-				libraries[RD::ShaderStage::SHADER_STAGE_FRAGMENT]);
+				libraries[RDD::ShaderStage::SHADER_STAGE_VERTEX],
+				libraries[RDD::ShaderStage::SHADER_STAGE_FRAGMENT]);
 		shader = rs;
 	}
 

--- a/drivers/metal/rendering_shader_container_metal.cpp
+++ b/drivers/metal/rendering_shader_container_metal.cpp
@@ -35,7 +35,6 @@
 #include "core/io/file_access.h"
 #include "core/io/marshalls.h"
 #include "core/templates/fixed_vector.h"
-#include "servers/rendering/rendering_device.h"
 
 #include "thirdparty/spirv-reflect/spirv_reflect.h"
 
@@ -425,7 +424,7 @@ bool RenderingShaderContainerMetal::_set_code_from_spirv(const ReflectShader &p_
 
 				found->active_stages = uniform.stages;
 
-				RD::UniformType type = RD::UniformType(uniform.type);
+				RDC::UniformType type = RDC::UniformType(uniform.type);
 				uint32_t binding_stride = 1; // If this is an array, stride will be the length of the array.
 				if (uniform.length > 1) {
 					switch (type) {
@@ -619,13 +618,13 @@ bool RenderingShaderContainerMetal::_set_code_from_spirv(const ReflectShader &p_
 	for (uint32_t i = 0; i < p_spirv.size(); i++) {
 		StageData &stage_data = mtl_shaders.write[i];
 		const ReflectShaderStage &v = p_spirv[i];
-		RD::ShaderStage stage = v.shader_stage;
+		RDC::ShaderStage stage = v.shader_stage;
 		Span<uint32_t> spirv = v.spirv();
 		Parser parser(spirv.ptr(), spirv.size());
 		try {
 			parser.parse();
 		} catch (CompilerError &e) {
-			ERR_FAIL_V_MSG(false, "Failed to parse IR at stage " + String(RD::SHADER_STAGE_NAMES[stage]) + ": " + e.what());
+			ERR_FAIL_V_MSG(false, "Failed to parse IR at stage " + String(RDC::SHADER_STAGE_NAMES[stage]) + ": " + e.what());
 		}
 
 		CompilerMSL compiler(std::move(parser.get_parsed_ir()));
@@ -651,7 +650,7 @@ bool RenderingShaderContainerMetal::_set_code_from_spirv(const ReflectShader &p_
 		try {
 			source = compiler.compile();
 		} catch (CompilerError &e) {
-			ERR_FAIL_V_MSG(false, "Failed to compile stage " + String(RD::SHADER_STAGE_NAMES[stage]) + ": " + e.what());
+			ERR_FAIL_V_MSG(false, "Failed to compile stage " + String(RDC::SHADER_STAGE_NAMES[stage]) + ": " + e.what());
 		}
 
 		ERR_FAIL_COND_V_MSG(compiler.get_entry_points_and_stages().size() != 1, false, "Expected a single entry point and stage.");

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5870,23 +5870,23 @@ String EditorNode::_get_system_info() const {
 
 	const String rendering_device_name = RenderingServer::get_singleton()->get_video_adapter_name();
 
-	RenderingDevice::DeviceType device_type = RenderingServer::get_singleton()->get_video_adapter_type();
+	RenderingDeviceEnums::DeviceType device_type = RenderingServer::get_singleton()->get_video_adapter_type();
 	String device_type_string;
 	switch (device_type) {
-		case RenderingDevice::DeviceType::DEVICE_TYPE_INTEGRATED_GPU:
+		case RenderingDeviceEnums::DeviceType::DEVICE_TYPE_INTEGRATED_GPU:
 			device_type_string = "integrated";
 			break;
-		case RenderingDevice::DeviceType::DEVICE_TYPE_DISCRETE_GPU:
+		case RenderingDeviceEnums::DeviceType::DEVICE_TYPE_DISCRETE_GPU:
 			device_type_string = "dedicated";
 			break;
-		case RenderingDevice::DeviceType::DEVICE_TYPE_VIRTUAL_GPU:
+		case RenderingDeviceEnums::DeviceType::DEVICE_TYPE_VIRTUAL_GPU:
 			device_type_string = "virtual";
 			break;
-		case RenderingDevice::DeviceType::DEVICE_TYPE_CPU:
+		case RenderingDeviceEnums::DeviceType::DEVICE_TYPE_CPU:
 			device_type_string = "(software emulation on CPU)";
 			break;
-		case RenderingDevice::DeviceType::DEVICE_TYPE_OTHER:
-		case RenderingDevice::DeviceType::DEVICE_TYPE_MAX:
+		case RenderingDeviceEnums::DeviceType::DEVICE_TYPE_OTHER:
+		case RenderingDeviceEnums::DeviceType::DEVICE_TYPE_MAX:
 			break; // Can't happen, but silences warning for DEVICE_TYPE_MAX
 	}
 

--- a/editor/export/shader_baker_export_plugin.h
+++ b/editor/export/shader_baker_export_plugin.h
@@ -30,9 +30,14 @@
 
 #pragma once
 
-#include "editor/export/editor_export_plugin.h"
-#include "servers/rendering/renderer_rd/shader_rd.h"
+#include "core/object/object.h"
+#include "core/object/worker_thread_pool.h"
+#include "core/os/condition_variable.h"
+#include "core/templates/rb_set.h"
 
+#include "editor/export/editor_export_plugin.h"
+
+class ShaderRD;
 class RenderingShaderContainerFormat;
 
 class ShaderBakerExportPluginPlatform : public RefCounted {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -74,6 +74,7 @@
 #include "servers/display/display_server.h"
 #include "servers/movie_writer/movie_writer.h"
 #include "servers/register_server_types.h"
+#include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server_default.h"
 #include "servers/text/text_server.h"
 #include "servers/text/text_server_dummy.h"

--- a/modules/lightmapper_rd/lightmapper_rd.h
+++ b/modules/lightmapper_rd/lightmapper_rd.h
@@ -33,9 +33,10 @@
 #include "core/templates/local_vector.h"
 #include "scene/3d/lightmapper.h"
 #include "scene/resources/mesh.h"
-#include "servers/rendering/rendering_device.h"
 
+class RenderingDevice;
 class RDShaderFile;
+
 class LightmapperRD : public Lightmapper {
 	GDCLASS(LightmapperRD, Lightmapper)
 

--- a/modules/openxr/extensions/platform/openxr_d3d12_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_d3d12_extension.cpp
@@ -34,6 +34,7 @@
 
 #include "../../openxr_util.h"
 
+#include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server.h"
 #include "servers/rendering/rendering_server_globals.h"
 

--- a/modules/openxr/extensions/platform/openxr_metal_extension.mm
+++ b/modules/openxr/extensions/platform/openxr_metal_extension.mm
@@ -33,6 +33,7 @@
 #include "../../openxr_util.h"
 
 #import "drivers/metal/rendering_device_driver_metal.h"
+#include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server_globals.h"
 
 HashMap<String, bool *> OpenXRMetalExtension::get_requested_extensions(XrVersion p_version) {

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -35,7 +35,7 @@
 #include "wayland/wayland_thread.h"
 
 #ifdef RD_ENABLED
-#include "servers/rendering/rendering_device.h"
+class RenderingDevice;
 
 #ifdef VULKAN_ENABLED
 #include "wayland/rendering_context_driver_vulkan_wayland.h"

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -56,7 +56,6 @@
 #endif
 
 #if defined(RD_ENABLED)
-#include "servers/rendering/rendering_device.h"
 
 #if defined(VULKAN_ENABLED)
 #include "x11/rendering_context_driver_vulkan_x11.h"

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -45,10 +45,6 @@
 #include "drivers/xaudio2/audio_driver_xaudio2.h"
 #endif
 
-#if defined(RD_ENABLED)
-#include "servers/rendering/rendering_device.h"
-#endif
-
 #include <io.h>
 #include <shellapi.h>
 #include <cstdio>

--- a/scene/resources/texture_rd.cpp
+++ b/scene/resources/texture_rd.cpp
@@ -30,6 +30,7 @@
 
 #include "texture_rd.h"
 
+#include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server.h"
 
 ////////////////////////////////////////////////////////////////////////////

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -37,6 +37,10 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, Input);
 #include "scene/resources/texture.h"
 #include "servers/display/display_server_headless.h"
 
+#if defined(RD_ENABLED)
+#include "servers/rendering/rendering_device.h"
+#endif
+
 #if defined(VULKAN_ENABLED)
 #include "drivers/vulkan/rendering_context_driver_vulkan.h"
 #undef CursorShape

--- a/servers/navigation_2d/navigation_server_2d.h
+++ b/servers/navigation_2d/navigation_server_2d.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/object/class_db.h"
-#include "core/templates/rid.h"
+#include "core/templates/rid_owner.h"
 
 #include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h"
 #include "scene/resources/2d/navigation_polygon.h"

--- a/servers/navigation_3d/navigation_server_3d.h
+++ b/servers/navigation_3d/navigation_server_3d.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/object/class_db.h"
-#include "core/templates/rid.h"
+#include "core/templates/rid_owner.h"
 
 #include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h"
 #include "scene/resources/navigation_mesh.h"

--- a/servers/rendering/dummy/storage/light_storage.h
+++ b/servers/rendering/dummy/storage/light_storage.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "core/templates/rid_owner.h"
+
 #include "servers/rendering/storage/light_storage.h"
 
 namespace RendererDummy {

--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "core/templates/rid_owner.h"
+
 #include "servers/rendering/shader_compiler.h"
 #include "servers/rendering/shader_language.h"
 #include "servers/rendering/storage/material_storage.h"

--- a/servers/rendering/dummy/storage/utilities.h
+++ b/servers/rendering/dummy/storage/utilities.h
@@ -89,7 +89,7 @@ public:
 	virtual uint64_t get_rendering_info(RS::RenderingInfo p_info) override { return 0; }
 	virtual String get_video_adapter_name() const override { return String(); }
 	virtual String get_video_adapter_vendor() const override { return String(); }
-	virtual RenderingDevice::DeviceType get_video_adapter_type() const override { return RenderingDevice::DeviceType::DEVICE_TYPE_OTHER; }
+	virtual RenderingDeviceEnums::DeviceType get_video_adapter_type() const override { return RenderingDeviceEnums::DeviceType::DEVICE_TYPE_OTHER; }
 	virtual String get_video_adapter_api_version() const override { return String(); }
 
 	virtual Size2i get_maximum_viewport_size() const override { return Size2i(); }

--- a/servers/rendering/multi_uma_buffer.h
+++ b/servers/rendering/multi_uma_buffer.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "servers/rendering/rendering_server.h"
+#include "servers/rendering/rendering_device.h"
 
 class MultiUmaBufferBase {
 protected:

--- a/servers/rendering/renderer_rd/effects/metal_fx.h
+++ b/servers/rendering/renderer_rd/effects/metal_fx.h
@@ -40,6 +40,7 @@
 
 #include "core/templates/paged_allocator.h"
 #include "servers/rendering/renderer_scene_render.h"
+#include "servers/rendering/rendering_device_driver.h"
 
 namespace MTLFX {
 class SpatialScalerBase;
@@ -81,8 +82,8 @@ public:
 	struct CreateParams {
 		Vector2i input_size;
 		Vector2i output_size;
-		RD::DataFormat input_format;
-		RD::DataFormat output_format;
+		RDD::DataFormat input_format;
+		RDD::DataFormat output_format;
 	};
 
 	MFXSpatialContext *create_context(CreateParams p_params) const;
@@ -148,11 +149,11 @@ public:
 	struct CreateParams {
 		Vector2i input_size;
 		Vector2i output_size;
-		RD::DataFormat input_format;
-		RD::DataFormat depth_format;
-		RD::DataFormat motion_format;
-		RD::DataFormat reactive_format;
-		RD::DataFormat output_format;
+		RDD::DataFormat input_format;
+		RDD::DataFormat depth_format;
+		RDD::DataFormat motion_format;
+		RDD::DataFormat reactive_format;
+		RDD::DataFormat output_format;
 		Vector2 motion_vector_scale;
 	};
 

--- a/servers/rendering/renderer_rd/pipeline_hash_map_rd.h
+++ b/servers/rendering/renderer_rd/pipeline_hash_map_rd.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "core/templates/rb_set.h"
-#include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server.h"
 
 #define PRINT_PIPELINE_COMPILATION_KEYS 0

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -36,6 +36,7 @@
 #include "core/templates/local_vector.h"
 #include "core/templates/rid_owner.h"
 #include "core/templates/self_list.h"
+#include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server.h"
 
 class ShaderRD {

--- a/servers/rendering/renderer_rd/storage_rd/utilities.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/utilities.cpp
@@ -318,7 +318,7 @@ String Utilities::get_video_adapter_vendor() const {
 	return RenderingDevice::get_singleton()->get_device_vendor_name();
 }
 
-RenderingDevice::DeviceType Utilities::get_video_adapter_type() const {
+RenderingDeviceEnums::DeviceType Utilities::get_video_adapter_type() const {
 	return RenderingDevice::get_singleton()->get_device_type();
 }
 

--- a/servers/rendering/renderer_rd/storage_rd/utilities.h
+++ b/servers/rendering/renderer_rd/storage_rd/utilities.h
@@ -112,7 +112,7 @@ public:
 
 	virtual String get_video_adapter_name() const override;
 	virtual String get_video_adapter_vendor() const override;
-	virtual RenderingDevice::DeviceType get_video_adapter_type() const override;
+	virtual RenderingDeviceEnums::DeviceType get_video_adapter_type() const override;
 	virtual String get_video_adapter_api_version() const override;
 
 	virtual Size2i get_maximum_viewport_size() const override;

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -36,6 +36,7 @@
 #include "core/profiling/profiling.h"
 #include "renderer_canvas_cull.h"
 #include "renderer_scene_cull.h"
+#include "rendering_device.h"
 #include "rendering_server_globals.h"
 #include "storage/texture_storage.h"
 

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -7107,8 +7107,8 @@ String RenderingDevice::get_device_name() const {
 	return device.name;
 }
 
-RenderingDevice::DeviceType RenderingDevice::get_device_type() const {
-	return DeviceType(device.type);
+RenderingDeviceEnums::DeviceType RenderingDevice::get_device_type() const {
+	return RenderingDeviceEnums::DeviceType(device.type);
 }
 
 String RenderingDevice::get_device_api_name() const {
@@ -8468,12 +8468,12 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_device_memory_by_object_type", "type"), &RenderingDevice::get_device_memory_by_object_type);
 	ClassDB::bind_method(D_METHOD("get_device_allocs_by_object_type", "type"), &RenderingDevice::get_device_allocs_by_object_type);
 
-	BIND_ENUM_CONSTANT(DEVICE_TYPE_OTHER);
-	BIND_ENUM_CONSTANT(DEVICE_TYPE_INTEGRATED_GPU);
-	BIND_ENUM_CONSTANT(DEVICE_TYPE_DISCRETE_GPU);
-	BIND_ENUM_CONSTANT(DEVICE_TYPE_VIRTUAL_GPU);
-	BIND_ENUM_CONSTANT(DEVICE_TYPE_CPU);
-	BIND_ENUM_CONSTANT(DEVICE_TYPE_MAX);
+	BIND_ENUM_CONSTANT(RenderingDeviceEnums::DEVICE_TYPE_OTHER);
+	BIND_ENUM_CONSTANT(RenderingDeviceEnums::DEVICE_TYPE_INTEGRATED_GPU);
+	BIND_ENUM_CONSTANT(RenderingDeviceEnums::DEVICE_TYPE_DISCRETE_GPU);
+	BIND_ENUM_CONSTANT(RenderingDeviceEnums::DEVICE_TYPE_VIRTUAL_GPU);
+	BIND_ENUM_CONSTANT(RenderingDeviceEnums::DEVICE_TYPE_CPU);
+	BIND_ENUM_CONSTANT(RenderingDeviceEnums::DEVICE_TYPE_MAX);
 
 	BIND_ENUM_CONSTANT(DRIVER_RESOURCE_LOGICAL_DEVICE);
 	BIND_ENUM_CONSTANT(DRIVER_RESOURCE_PHYSICAL_DEVICE);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -40,6 +40,7 @@
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_device_commons.h"
 #include "servers/rendering/rendering_device_driver.h"
+#include "servers/rendering/rendering_device_enums.h"
 #include "servers/rendering/rendering_device_graph.h"
 
 class RDTextureFormat;
@@ -1834,7 +1835,7 @@ public:
 
 	String get_device_vendor_name() const;
 	String get_device_name() const;
-	DeviceType get_device_type() const;
+	RenderingDeviceEnums::DeviceType get_device_type() const;
 	String get_device_api_name() const;
 	String get_device_api_version() const;
 	String get_device_pipeline_cache_uuid() const;
@@ -1907,7 +1908,7 @@ private:
 	void _raytracing_list_set_push_constant(RaytracingListID p_list, const Vector<uint8_t> &p_data, uint32_t p_data_size);
 };
 
-VARIANT_ENUM_CAST(RenderingDevice::DeviceType)
+VARIANT_ENUM_CAST_EXT(RenderingDeviceEnums::DeviceType, RenderingDevice::DeviceType)
 VARIANT_ENUM_CAST(RenderingDevice::DriverResource)
 VARIANT_ENUM_CAST(RenderingDevice::ShaderStage)
 VARIANT_ENUM_CAST(RenderingDevice::ShaderLanguage)

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -887,17 +887,6 @@ public:
 	/**** MISC ****/
 	/**************/
 
-	// This enum matches VkPhysicalDeviceType (except for `DEVICE_TYPE_MAX`).
-	// Unlike VkPhysicalDeviceType, DeviceType is exposed to the scripting API.
-	enum DeviceType {
-		DEVICE_TYPE_OTHER,
-		DEVICE_TYPE_INTEGRATED_GPU,
-		DEVICE_TYPE_DISCRETE_GPU,
-		DEVICE_TYPE_VIRTUAL_GPU,
-		DEVICE_TYPE_CPU,
-		DEVICE_TYPE_MAX
-	};
-
 	// Defined in an API-agnostic way.
 	// Some may not make sense for the underlying API; in that case, 0 is returned.
 	enum DriverResource {

--- a/servers/rendering/rendering_device_enums.h
+++ b/servers/rendering/rendering_device_enums.h
@@ -1,0 +1,46 @@
+/**************************************************************************/
+/*  rendering_device_enums.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+namespace RenderingDeviceEnums {
+
+// This enum matches VkPhysicalDeviceType (except for `DEVICE_TYPE_MAX`).
+// Unlike VkPhysicalDeviceType, DeviceType is exposed to the scripting API.
+enum DeviceType {
+	DEVICE_TYPE_OTHER,
+	DEVICE_TYPE_INTEGRATED_GPU,
+	DEVICE_TYPE_DISCRETE_GPU,
+	DEVICE_TYPE_VIRTUAL_GPU,
+	DEVICE_TYPE_CPU,
+	DEVICE_TYPE_MAX
+};
+
+} //namespace RenderingDeviceEnums

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -34,6 +34,7 @@
 #include "core/config/project_settings.h"
 #include "core/math/geometry_3d.h"
 #include "core/variant/typed_array.h"
+#include "servers/rendering/rendering_device.h"
 #include "servers/rendering/shader_language.h"
 #include "servers/rendering/shader_warnings.h"
 

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -36,7 +36,7 @@
 #include "core/variant/typed_array.h"
 #include "core/variant/variant.h"
 #include "servers/display/display_server.h"
-#include "servers/rendering/rendering_device.h"
+#include "servers/rendering/rendering_device_enums.h"
 
 namespace Geometry3D {
 struct MeshData;
@@ -57,6 +57,8 @@ struct MeshData;
 #define ERR_NOT_ON_RENDER_THREAD
 #define ERR_NOT_ON_RENDER_THREAD_V(m_ret)
 #endif
+
+class RenderingDevice;
 
 class RenderingServer : public Object {
 	GDCLASS(RenderingServer, Object);
@@ -1837,7 +1839,7 @@ public:
 	virtual uint64_t get_rendering_info(RenderingInfo p_info) = 0;
 	virtual String get_video_adapter_name() const = 0;
 	virtual String get_video_adapter_vendor() const = 0;
-	virtual RenderingDevice::DeviceType get_video_adapter_type() const = 0;
+	virtual RenderingDeviceEnums::DeviceType get_video_adapter_type() const = 0;
 	virtual String get_video_adapter_api_version() const = 0;
 
 	struct FrameProfileArea {

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -34,6 +34,7 @@
 #include "core/profiling/profiling.h"
 #include "renderer_canvas_cull.h"
 #include "renderer_scene_cull.h"
+#include "rendering_device.h"
 #include "rendering_server_globals.h"
 
 // careful, these may run in different threads than the rendering server
@@ -318,7 +319,7 @@ uint64_t RenderingServerDefault::get_rendering_info(RenderingInfo p_info) {
 	return RSG::utilities->get_rendering_info(p_info);
 }
 
-RenderingDevice::DeviceType RenderingServerDefault::get_video_adapter_type() const {
+RenderingDeviceEnums::DeviceType RenderingServerDefault::get_video_adapter_type() const {
 	return RSG::utilities->get_video_adapter_type();
 }
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -1163,7 +1163,7 @@ public:
 #endif
 
 	virtual uint64_t get_rendering_info(RenderingInfo p_info) override;
-	virtual RenderingDevice::DeviceType get_video_adapter_type() const override;
+	virtual RenderingDeviceEnums::DeviceType get_video_adapter_type() const override;
 
 	virtual void set_frame_profiling_enabled(bool p_enable) override;
 	virtual Vector<FrameProfileArea> get_frame_profile() override;

--- a/servers/rendering/storage/utilities.h
+++ b/servers/rendering/storage/utilities.h
@@ -180,7 +180,7 @@ public:
 	virtual uint64_t get_rendering_info(RS::RenderingInfo p_info) = 0;
 	virtual String get_video_adapter_name() const = 0;
 	virtual String get_video_adapter_vendor() const = 0;
-	virtual RenderingDevice::DeviceType get_video_adapter_type() const = 0;
+	virtual RenderingDeviceEnums::DeviceType get_video_adapter_type() const = 0;
 	virtual String get_video_adapter_api_version() const = 0;
 
 	virtual Size2i get_maximum_viewport_size() const = 0;

--- a/servers/xr/xr_vrs.cpp
+++ b/servers/xr/xr_vrs.cpp
@@ -31,6 +31,7 @@
 #include "xr_vrs.h"
 
 #include "servers/rendering/renderer_scene_render.h"
+#include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server.h"
 
 void XRVRS::_bind_methods() {


### PR DESCRIPTION
- Bugsquad edit: Helps address https://github.com/godotengine/godot/issues/111218

Removes `rendering_device.h` from `rendering_server.h` and moves the `DeviceType` enumeration to a separate file, so nearly all of the code base doesn't need to include `rendering_device.h` just to use that.

I also tried to remove `rendering_device.h` from as many files as possible.

When editing `rendering_device.h` without `scu_build=yes`, this brings the recompilation time from 4 minutes to 38 seconds on my PC.

Since the `DeviceType` enumeration got moved, we had to make a separate macro for `ClassDB` that binds it with the old name for backwards compatibility.