### PR TITLE
Add high priority option to `ResourceLoader.load_threaded_request`.

### DIFF
--- a/core/core_bind.compat.inc
+++ b/core/core_bind.compat.inc
@@ -61,12 +61,12 @@ void OS::_bind_compatibility_methods() {
 
 // ResourceLoader
 
-Error ResourceLoader::_load_threaded_request_115964(const String &p_path, const String &p_type_hint, bool p_use_sub_threads, CacheMode p_cache_mode) {
+Error ResourceLoader::_load_threaded_request_bind_compat_115964(const String &p_path, const String &p_type_hint, bool p_use_sub_threads, CacheMode p_cache_mode) {
 	return load_threaded_request(p_path, p_type_hint, p_use_sub_threads, p_cache_mode, false);
 }
 
 void ResourceLoader::_bind_compatibility_methods() {
-	ClassDB::bind_compatibility_method(D_METHOD("load_threaded_request", "path", "type_hint", "use_sub_threads", "cache_mode", "queue_front"), &ResourceLoader::_load_threaded_request_115964, DEFVAL(""), DEFVAL(false), DEFVAL(CACHE_MODE_REUSE), DEFVAL(false));
+	ClassDB::bind_compatibility_method(D_METHOD("load_threaded_request", "path", "type_hint", "use_sub_threads", "cache_mode"), &ResourceLoader::_load_threaded_request_bind_compat_115964, DEFVAL(""), DEFVAL(false), DEFVAL(CACHE_MODE_REUSE));
 }
 
 } // namespace CoreBind

--- a/core/core_bind.compat.inc
+++ b/core/core_bind.compat.inc
@@ -59,6 +59,16 @@ void OS::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("execute_with_pipe", "path", "arguments"), &OS::_execute_with_pipe_bind_compat_94434);
 }
 
+// ResourceLoader
+
+Error ResourceLoader::_load_threaded_request_115964(const String &p_path, const String &p_type_hint, bool p_use_sub_threads, CacheMode p_cache_mode) {
+	return load_threaded_request(p_path, p_type_hint, p_use_sub_threads, p_cache_mode, false);
+}
+
+void ResourceLoader::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("load_threaded_request", "path", "type_hint", "use_sub_threads", "cache_mode", "queue_front"), &ResourceLoader::_load_threaded_request_115964, DEFVAL(""), DEFVAL(false), DEFVAL(CACHE_MODE_REUSE), DEFVAL(false));
+}
+
 } // namespace CoreBind
 
 #endif // DISABLE_DEPRECATED

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -48,8 +48,8 @@ namespace CoreBind {
 
 ////// ResourceLoader //////
 
-Error ResourceLoader::load_threaded_request(const String &p_path, const String &p_type_hint, bool p_use_sub_threads, CacheMode p_cache_mode) {
-	return ::ResourceLoader::load_threaded_request(p_path, p_type_hint, p_use_sub_threads, ResourceFormatLoader::CacheMode(p_cache_mode));
+Error ResourceLoader::load_threaded_request(const String &p_path, const String &p_type_hint, bool p_use_sub_threads, CacheMode p_cache_mode, bool p_queue_front) {
+	return ::ResourceLoader::load_threaded_request(p_path, p_type_hint, p_use_sub_threads, ResourceFormatLoader::CacheMode(p_cache_mode), p_queue_front);
 }
 
 ResourceLoader::ThreadLoadStatus ResourceLoader::load_threaded_get_status(const String &p_path, Array r_progress) {
@@ -137,7 +137,7 @@ Vector<String> ResourceLoader::list_directory(const String &p_directory) {
 }
 
 void ResourceLoader::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("load_threaded_request", "path", "type_hint", "use_sub_threads", "cache_mode"), &ResourceLoader::load_threaded_request, DEFVAL(""), DEFVAL(false), DEFVAL(CACHE_MODE_REUSE));
+	ClassDB::bind_method(D_METHOD("load_threaded_request", "path", "type_hint", "use_sub_threads", "cache_mode", "queue_front"), &ResourceLoader::load_threaded_request, DEFVAL(""), DEFVAL(false), DEFVAL(CACHE_MODE_REUSE), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("load_threaded_get_status", "path", "progress"), &ResourceLoader::load_threaded_get_status, DEFVAL_ARRAY);
 	ClassDB::bind_method(D_METHOD("load_threaded_get", "path"), &ResourceLoader::load_threaded_get);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -86,6 +86,12 @@ public:
 	Vector<String> list_directory(const String &p_directory);
 
 	ResourceLoader() { singleton = this; }
+
+#ifndef DISABLE_DEPRECATED
+protected:
+	Error _load_threaded_request_115964(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	static void _bind_compatibility_methods();
+#endif
 };
 
 class ResourceSaver : public Object {

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -68,7 +68,7 @@ public:
 
 	static ResourceLoader *get_singleton() { return singleton; }
 
-	Error load_threaded_request(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	Error load_threaded_request(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false, CacheMode p_cache_mode = CACHE_MODE_REUSE, bool p_queue_front = false);
 	ThreadLoadStatus load_threaded_get_status(const String &p_path, Array r_progress = ClassDB::default_array_arg);
 	Ref<Resource> load_threaded_get(const String &p_path);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -89,7 +89,7 @@ public:
 
 #ifndef DISABLE_DEPRECATED
 protected:
-	Error _load_threaded_request_115964(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	Error _load_threaded_request_bind_compat_115964(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	static void _bind_compatibility_methods();
 #endif
 };

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1108,7 +1108,7 @@ static int64_t gdextension_worker_thread_pool_add_native_group_task(GDExtensionO
 static int64_t gdextension_worker_thread_pool_add_native_task(GDExtensionObjectPtr p_instance, void (*p_func)(void *), void *p_userdata, GDExtensionBool p_high_priority, GDExtensionConstStringPtr p_description) {
 	WorkerThreadPool *p = (WorkerThreadPool *)p_instance;
 	const String *description = (const String *)p_description;
-	return (int64_t)p->add_native_task(p_func, p_userdata, static_cast<bool>(p_high_priority), *description);
+	return (int64_t)p->add_native_task(p_func, p_userdata, static_cast<bool>(p_high_priority), false, *description);
 }
 
 /* Packed array functions */

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -696,7 +696,7 @@ Error ResourceLoaderBinary::load() {
 		}
 
 		external_resources.write[i].path = path; //remap happens here, not on load because on load it can actually be used for filesystem dock resource remap
-		external_resources.write[i].load_token = ResourceLoader::_load_start(path, external_resources[i].type, use_sub_threads ? ResourceLoader::LOAD_THREAD_DISTRIBUTE : ResourceLoader::LOAD_THREAD_FROM_CURRENT, false, cache_mode_for_external);
+		external_resources.write[i].load_token = ResourceLoader::_load_start(path, external_resources[i].type, use_sub_threads ? ResourceLoader::LOAD_THREAD_DISTRIBUTE : ResourceLoader::LOAD_THREAD_FROM_CURRENT, cache_mode_for_external, false);
 		if (external_resources[i].load_token.is_null()) {
 			if (!ResourceLoader::get_abort_on_missing_resources()) {
 				ResourceLoader::notify_dependency_error(local_path, path, external_resources[i].type);

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -696,7 +696,7 @@ Error ResourceLoaderBinary::load() {
 		}
 
 		external_resources.write[i].path = path; //remap happens here, not on load because on load it can actually be used for filesystem dock resource remap
-		external_resources.write[i].load_token = ResourceLoader::_load_start(path, external_resources[i].type, use_sub_threads ? ResourceLoader::LOAD_THREAD_DISTRIBUTE : ResourceLoader::LOAD_THREAD_FROM_CURRENT, cache_mode_for_external);
+		external_resources.write[i].load_token = ResourceLoader::_load_start(path, external_resources[i].type, use_sub_threads ? ResourceLoader::LOAD_THREAD_DISTRIBUTE : ResourceLoader::LOAD_THREAD_FROM_CURRENT, false, cache_mode_for_external);
 		if (external_resources[i].load_token.is_null()) {
 			if (!ResourceLoader::get_abort_on_missing_resources()) {
 				ResourceLoader::notify_dependency_error(local_path, path, external_resources[i].type);

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -514,7 +514,7 @@ String ResourceLoader::_validate_local_path(const String &p_path) {
 }
 
 Error ResourceLoader::load_threaded_request(const String &p_path, const String &p_type_hint, bool p_use_sub_threads, ResourceFormatLoader::CacheMode p_cache_mode, bool p_queue_front) {
-	Ref<ResourceLoader::LoadToken> token = _load_start(p_path, p_type_hint, p_use_sub_threads ? LOAD_THREAD_DISTRIBUTE : LOAD_THREAD_SPAWN_SINGLE, p_queue_front, p_cache_mode, true);
+	Ref<ResourceLoader::LoadToken> token = _load_start(p_path, p_type_hint, p_use_sub_threads ? LOAD_THREAD_DISTRIBUTE : LOAD_THREAD_SPAWN_SINGLE, p_cache_mode, p_queue_front, true);
 	return token.is_valid() ? OK : FAILED;
 }
 
@@ -551,7 +551,7 @@ Ref<Resource> ResourceLoader::load(const String &p_path, const String &p_type_hi
 		// cyclic load detection and awaiting.
 		thread_mode = LOAD_THREAD_SPAWN_SINGLE;
 	}
-	Ref<LoadToken> load_token = _load_start(p_path, p_type_hint, thread_mode, false, p_cache_mode);
+	Ref<LoadToken> load_token = _load_start(p_path, p_type_hint, thread_mode, p_cache_mode, false);
 	if (load_token.is_null()) {
 		if (r_error) {
 			*r_error = FAILED;
@@ -563,7 +563,7 @@ Ref<Resource> ResourceLoader::load(const String &p_path, const String &p_type_hi
 	return res;
 }
 
-Ref<ResourceLoader::LoadToken> ResourceLoader::_load_start(const String &p_path, const String &p_type_hint, LoadThreadMode p_thread_mode, bool p_queue_front, ResourceFormatLoader::CacheMode p_cache_mode, bool p_for_user) {
+Ref<ResourceLoader::LoadToken> ResourceLoader::_load_start(const String &p_path, const String &p_type_hint, LoadThreadMode p_thread_mode, ResourceFormatLoader::CacheMode p_cache_mode, bool p_queue_front, bool p_for_user) {
 	String local_path = _validate_local_path(p_path);
 	ERR_FAIL_COND_V(local_path.is_empty(), Ref<ResourceLoader::LoadToken>());
 

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -513,8 +513,8 @@ String ResourceLoader::_validate_local_path(const String &p_path) {
 	}
 }
 
-Error ResourceLoader::load_threaded_request(const String &p_path, const String &p_type_hint, bool p_use_sub_threads, ResourceFormatLoader::CacheMode p_cache_mode) {
-	Ref<ResourceLoader::LoadToken> token = _load_start(p_path, p_type_hint, p_use_sub_threads ? LOAD_THREAD_DISTRIBUTE : LOAD_THREAD_SPAWN_SINGLE, p_cache_mode, true);
+Error ResourceLoader::load_threaded_request(const String &p_path, const String &p_type_hint, bool p_use_sub_threads, ResourceFormatLoader::CacheMode p_cache_mode, bool p_queue_front) {
+	Ref<ResourceLoader::LoadToken> token = _load_start(p_path, p_type_hint, p_use_sub_threads ? LOAD_THREAD_DISTRIBUTE : LOAD_THREAD_SPAWN_SINGLE, p_queue_front, p_cache_mode, true);
 	return token.is_valid() ? OK : FAILED;
 }
 
@@ -551,7 +551,7 @@ Ref<Resource> ResourceLoader::load(const String &p_path, const String &p_type_hi
 		// cyclic load detection and awaiting.
 		thread_mode = LOAD_THREAD_SPAWN_SINGLE;
 	}
-	Ref<LoadToken> load_token = _load_start(p_path, p_type_hint, thread_mode, p_cache_mode);
+	Ref<LoadToken> load_token = _load_start(p_path, p_type_hint, thread_mode, false, p_cache_mode);
 	if (load_token.is_null()) {
 		if (r_error) {
 			*r_error = FAILED;
@@ -563,7 +563,7 @@ Ref<Resource> ResourceLoader::load(const String &p_path, const String &p_type_hi
 	return res;
 }
 
-Ref<ResourceLoader::LoadToken> ResourceLoader::_load_start(const String &p_path, const String &p_type_hint, LoadThreadMode p_thread_mode, ResourceFormatLoader::CacheMode p_cache_mode, bool p_for_user) {
+Ref<ResourceLoader::LoadToken> ResourceLoader::_load_start(const String &p_path, const String &p_type_hint, LoadThreadMode p_thread_mode, bool p_queue_front, ResourceFormatLoader::CacheMode p_cache_mode, bool p_for_user) {
 	String local_path = _validate_local_path(p_path);
 	ERR_FAIL_COND_V(local_path.is_empty(), Ref<ResourceLoader::LoadToken>());
 
@@ -652,7 +652,7 @@ Ref<ResourceLoader::LoadToken> ResourceLoader::_load_start(const String &p_path,
 				load_task_ptr->thread_id = Thread::get_caller_id();
 			}
 		} else {
-			load_task_ptr->task_id = WorkerThreadPool::get_singleton()->add_native_task(&ResourceLoader::_run_load_task, load_task_ptr);
+			load_task_ptr->task_id = WorkerThreadPool::get_singleton()->add_native_task(&ResourceLoader::_run_load_task, load_task_ptr, p_queue_front, true);
 		}
 	} // MutexLock(thread_load_mutex).
 

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -139,7 +139,7 @@ public:
 
 	static const int BINARY_MUTEX_TAG = 1;
 
-	static Ref<LoadToken> _load_start(const String &p_path, const String &p_type_hint, LoadThreadMode p_thread_mode, bool p_queue_front, ResourceFormatLoader::CacheMode p_cache_mode, bool p_for_user = false);
+	static Ref<LoadToken> _load_start(const String &p_path, const String &p_type_hint, LoadThreadMode p_thread_mode, ResourceFormatLoader::CacheMode p_cache_mode, bool p_queue_front, bool p_for_user = false);
 	static Ref<Resource> _load_complete(LoadToken &p_load_token, Error *r_error);
 
 private:

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -139,7 +139,7 @@ public:
 
 	static const int BINARY_MUTEX_TAG = 1;
 
-	static Ref<LoadToken> _load_start(const String &p_path, const String &p_type_hint, LoadThreadMode p_thread_mode, ResourceFormatLoader::CacheMode p_cache_mode, bool p_for_user = false);
+	static Ref<LoadToken> _load_start(const String &p_path, const String &p_type_hint, LoadThreadMode p_thread_mode, bool p_queue_front, ResourceFormatLoader::CacheMode p_cache_mode, bool p_for_user = false);
 	static Ref<Resource> _load_complete(LoadToken &p_load_token, Error *r_error);
 
 private:
@@ -231,7 +231,7 @@ private:
 	static String _validate_local_path(const String &p_path);
 
 public:
-	static Error load_threaded_request(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false, ResourceFormatLoader::CacheMode p_cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE);
+	static Error load_threaded_request(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false, ResourceFormatLoader::CacheMode p_cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE, bool p_queue_front = false);
 	static ThreadLoadStatus load_threaded_get_status(const String &p_path, float *r_progress = nullptr);
 	static Ref<Resource> load_threaded_get(const String &p_path, Error *r_error = nullptr);
 

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -219,7 +219,7 @@ void WorkerThreadPool::_thread_function(void *p_user) {
 	}
 }
 
-void WorkerThreadPool::_post_tasks(Task **p_tasks, uint32_t p_count, bool p_high_priority, MutexLock<BinaryMutex> &p_lock, bool p_pump_task) {
+void WorkerThreadPool::_post_tasks(Task **p_tasks, uint32_t p_count, bool p_high_priority, bool p_enqueue_as_low_priority, MutexLock<BinaryMutex> &p_lock, bool p_pump_task) {
 	// Fall back to processing on the calling thread if there are no worker threads.
 	// Separated into its own variable to make it easier to extend this logic
 	// in custom builds.
@@ -245,16 +245,20 @@ void WorkerThreadPool::_post_tasks(Task **p_tasks, uint32_t p_count, bool p_high
 	ThreadData *caller_pool_thread = thread_ids.has(Thread::get_caller_id()) ? &threads[thread_ids[Thread::get_caller_id()]] : nullptr;
 
 	for (uint32_t i = 0; i < p_count; i++) {
-		p_tasks[i]->low_priority = !p_high_priority;
-		if (p_high_priority || low_priority_threads_used < max_low_priority_threads) {
+		p_tasks[i]->low_priority = p_enqueue_as_low_priority || !p_high_priority;
+		if ((p_high_priority && !p_enqueue_as_low_priority) || low_priority_threads_used < max_low_priority_threads) {
 			task_queue.add_last(&p_tasks[i]->task_elem);
-			if (!p_high_priority) {
+			if (p_tasks[i]->low_priority) {
 				low_priority_threads_used++;
 			}
 			to_process++;
 		} else {
 			// Too many threads using low priority, must go to queue.
-			low_priority_task_queue.add_last(&p_tasks[i]->task_elem);
+			if (p_high_priority && p_enqueue_as_low_priority) {
+				low_priority_task_queue.add(&p_tasks[i]->task_elem);
+			} else {
+				low_priority_task_queue.add_last(&p_tasks[i]->task_elem);
+			}
 			to_promote++;
 		}
 	}
@@ -338,11 +342,11 @@ bool WorkerThreadPool::_try_promote_low_priority_task() {
 	}
 }
 
-WorkerThreadPool::TaskID WorkerThreadPool::add_native_task(void (*p_func)(void *), void *p_userdata, bool p_high_priority, const String &p_description) {
-	return _add_task(Callable(), p_func, p_userdata, nullptr, p_high_priority, p_description);
+WorkerThreadPool::TaskID WorkerThreadPool::add_native_task(void (*p_func)(void *), void *p_userdata, bool p_high_priority, bool p_enqueue_as_low_priority, const String &p_description) {
+	return _add_task(Callable(), p_func, p_userdata, nullptr, p_high_priority, p_enqueue_as_low_priority, p_description);
 }
 
-WorkerThreadPool::TaskID WorkerThreadPool::_add_task(const Callable &p_callable, void (*p_func)(void *), void *p_userdata, BaseTemplateUserdata *p_template_userdata, bool p_high_priority, const String &p_description, bool p_pump_task) {
+WorkerThreadPool::TaskID WorkerThreadPool::_add_task(const Callable &p_callable, void (*p_func)(void *), void *p_userdata, BaseTemplateUserdata *p_template_userdata, bool p_high_priority, bool p_enqueue_as_low_priority, const String &p_description, bool p_pump_task) {
 	MutexLock<BinaryMutex> lock(task_mutex);
 
 	// Get a free task
@@ -375,17 +379,17 @@ WorkerThreadPool::TaskID WorkerThreadPool::_add_task(const Callable &p_callable,
 	}
 #endif
 
-	_post_tasks(&task, 1, p_high_priority, lock, p_pump_task);
+	_post_tasks(&task, 1, p_high_priority, p_enqueue_as_low_priority, lock, p_pump_task);
 
 	return id;
 }
 
 WorkerThreadPool::TaskID WorkerThreadPool::add_task(const Callable &p_action, bool p_high_priority, const String &p_description, bool p_pump_task) {
-	return _add_task(p_action, nullptr, nullptr, nullptr, p_high_priority, p_description, p_pump_task);
+	return _add_task(p_action, nullptr, nullptr, nullptr, p_high_priority, false, p_description, p_pump_task);
 }
 
 WorkerThreadPool::TaskID WorkerThreadPool::add_task_bind(const Callable &p_action, bool p_high_priority, const String &p_description) {
-	return _add_task(p_action, nullptr, nullptr, nullptr, p_high_priority, p_description, false);
+	return _add_task(p_action, nullptr, nullptr, nullptr, p_high_priority, false, p_description, false);
 }
 
 bool WorkerThreadPool::is_task_completed(TaskID p_task_id) const {
@@ -692,7 +696,7 @@ WorkerThreadPool::GroupID WorkerThreadPool::_add_group_task(const Callable &p_ca
 
 	groups[id] = group;
 
-	_post_tasks(tasks_posted, p_tasks, p_high_priority, lock, false);
+	_post_tasks(tasks_posted, p_tasks, p_high_priority, false, lock, false);
 
 	return id;
 }

--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -178,7 +178,7 @@ private:
 
 	void _process_task(Task *task);
 
-	void _post_tasks(Task **p_tasks, uint32_t p_count, bool p_high_priority, MutexLock<BinaryMutex> &p_lock, bool p_pump_task);
+	void _post_tasks(Task **p_tasks, uint32_t p_count, bool p_high_priority, bool p_enqueue_as_low_priority, MutexLock<BinaryMutex> &p_lock, bool p_pump_task);
 	void _notify_threads(const ThreadData *p_current_thread_data, uint32_t p_process_count, uint32_t p_promote_count);
 
 	bool _try_promote_low_priority_task();
@@ -194,7 +194,7 @@ private:
 	static thread_local UnlockableLocks unlockable_locks[MAX_UNLOCKABLE_LOCKS];
 #endif
 
-	TaskID _add_task(const Callable &p_callable, void (*p_func)(void *), void *p_userdata, BaseTemplateUserdata *p_template_userdata, bool p_high_priority, const String &p_description, bool p_pump_task = false);
+	TaskID _add_task(const Callable &p_callable, void (*p_func)(void *), void *p_userdata, BaseTemplateUserdata *p_template_userdata, bool p_high_priority, bool p_enqueue_as_low_priority, const String &p_description, bool p_pump_task = false);
 	GroupID _add_group_task(const Callable &p_callable, void (*p_func)(void *, uint32_t), void *p_userdata, BaseTemplateUserdata *p_template_userdata, int p_elements, int p_tasks, bool p_high_priority, const String &p_description);
 
 	template <typename C, typename M, typename U>
@@ -240,9 +240,9 @@ public:
 		ud->instance = p_instance;
 		ud->method = p_method;
 		ud->userdata = p_userdata;
-		return _add_task(Callable(), nullptr, nullptr, ud, p_high_priority, p_description);
+		return _add_task(Callable(), nullptr, nullptr, ud, p_high_priority, false, p_description);
 	}
-	TaskID add_native_task(void (*p_func)(void *), void *p_userdata, bool p_high_priority = false, const String &p_description = String());
+	TaskID add_native_task(void (*p_func)(void *), void *p_userdata, bool p_high_priority = false, bool p_enqueue_as_low_priority = false, const String &p_description = String());
 	TaskID add_task(const Callable &p_action, bool p_high_priority = false, const String &p_description = String(), bool p_pump_task = false);
 	TaskID add_task_bind(const Callable &p_action, bool p_high_priority = false, const String &p_description = String());
 

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -132,9 +132,11 @@
 			<param index="1" name="type_hint" type="String" default="&quot;&quot;" />
 			<param index="2" name="use_sub_threads" type="bool" default="false" />
 			<param index="3" name="cache_mode" type="int" enum="ResourceLoader.CacheMode" default="1" />
+			<param index="4" name="queue_front" type="bool" default="false" />
 			<description>
 				Loads the resource using threads. If [param use_sub_threads] is [code]true[/code], multiple threads will be used to load the resource, which makes loading faster, but may affect the main thread (and thus cause game slowdowns).
 				The [param cache_mode] parameter defines whether and how the cache should be used or updated when loading the resource.
+				If [param queue_front] is [code]true[/code], the request will be put at the head of the queue of pending requests, prioritizing it.
 			</description>
 		</method>
 		<method name="remove_resource_format_loader">

--- a/misc/extension_api_validation/4.6-stable/GH-115964.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-115964.txt
@@ -1,0 +1,6 @@
+GH-115964
+---------
+Validate extension JSON: Error: Field 'classes/ResourceLoader/methods/load_threaded_request/arguments': size changed value in new API, from 4 to 5.
+
+Added a new argument to push the request on top of the current queue.
+Compatibility methods registered.

--- a/modules/jolt_physics/spaces/jolt_job_system.cpp
+++ b/modules/jolt_physics/spaces/jolt_job_system.cpp
@@ -104,7 +104,7 @@ void JoltJobSystem::Job::queue() {
 	// thread-safe lookup every time we create/queue a task. So instead we use the same cached description for all of them.
 	static const String task_name("Jolt Physics");
 
-	task_id = WorkerThreadPool::get_singleton()->add_native_task(&_execute, this, true, task_name);
+	task_id = WorkerThreadPool::get_singleton()->add_native_task(&_execute, this, true, false, task_name);
 }
 
 int JoltJobSystem::GetMaxConcurrency() const {

--- a/modules/navigation_2d/nav_map_2d.cpp
+++ b/modules/navigation_2d/nav_map_2d.cpp
@@ -336,7 +336,7 @@ void NavMap2D::_build_iteration() {
 	iteration_build.map_iteration = &next_map_iteration;
 
 	if (use_async_iterations) {
-		iteration_build_thread_task_id = WorkerThreadPool::get_singleton()->add_native_task(&NavMap2D::_build_iteration_threaded, &iteration_build, true, SNAME("NavMapBuilder2D"));
+		iteration_build_thread_task_id = WorkerThreadPool::get_singleton()->add_native_task(&NavMap2D::_build_iteration_threaded, &iteration_build, true, false, SNAME("NavMapBuilder2D"));
 	} else {
 		NavMapBuilder2D::build_navmap_iteration(iteration_build);
 

--- a/modules/navigation_2d/nav_region_2d.cpp
+++ b/modules/navigation_2d/nav_region_2d.cpp
@@ -254,7 +254,7 @@ void NavRegion2D::_build_iteration() {
 	iteration_build.region_iteration = new_iteration;
 
 	if (use_async_iterations) {
-		iteration_build_thread_task_id = WorkerThreadPool::get_singleton()->add_native_task(&NavRegion2D::_build_iteration_threaded, &iteration_build, true, SNAME("NavRegionBuilder2D"));
+		iteration_build_thread_task_id = WorkerThreadPool::get_singleton()->add_native_task(&NavRegion2D::_build_iteration_threaded, &iteration_build, true, false, SNAME("NavRegionBuilder2D"));
 		request_async_thread_join();
 	} else {
 		NavRegionBuilder2D::build_iteration(iteration_build);

--- a/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
+++ b/modules/navigation_3d/3d/nav_mesh_generator_3d.cpp
@@ -226,7 +226,7 @@ void NavMeshGenerator3D::bake_from_source_geometry_data_async(Ref<NavigationMesh
 	generator_task->source_geometry_data = p_source_geometry_data;
 	generator_task->callback = p_callback;
 	generator_task->status = NavMeshGeneratorTask3D::TaskStatus::BAKING_STARTED;
-	generator_task->thread_task_id = WorkerThreadPool::get_singleton()->add_native_task(&NavMeshGenerator3D::generator_thread_bake, generator_task, NavMeshGenerator3D::baking_use_high_priority_threads, SNAME("NavMeshGeneratorBake3D"));
+	generator_task->thread_task_id = WorkerThreadPool::get_singleton()->add_native_task(&NavMeshGenerator3D::generator_thread_bake, generator_task, NavMeshGenerator3D::baking_use_high_priority_threads, false, SNAME("NavMeshGeneratorBake3D"));
 	MutexLock generator_task_lock(generator_task_mutex);
 	generator_tasks.insert(generator_task->thread_task_id, generator_task);
 }

--- a/modules/navigation_3d/nav_map_3d.cpp
+++ b/modules/navigation_3d/nav_map_3d.cpp
@@ -392,7 +392,7 @@ void NavMap3D::_build_iteration() {
 	iteration_build.map_iteration = &next_map_iteration;
 
 	if (use_async_iterations) {
-		iteration_build_thread_task_id = WorkerThreadPool::get_singleton()->add_native_task(&NavMap3D::_build_iteration_threaded, &iteration_build, true, SNAME("NavMapBuilder3D"));
+		iteration_build_thread_task_id = WorkerThreadPool::get_singleton()->add_native_task(&NavMap3D::_build_iteration_threaded, &iteration_build, true, false, SNAME("NavMapBuilder3D"));
 	} else {
 		NavMapBuilder3D::build_navmap_iteration(iteration_build);
 

--- a/modules/navigation_3d/nav_region_3d.cpp
+++ b/modules/navigation_3d/nav_region_3d.cpp
@@ -272,7 +272,7 @@ void NavRegion3D::_build_iteration() {
 	iteration_build.region_iteration = new_iteration;
 
 	if (use_async_iterations) {
-		iteration_build_thread_task_id = WorkerThreadPool::get_singleton()->add_native_task(&NavRegion3D::_build_iteration_threaded, &iteration_build, true, SNAME("NavRegionBuilder3D"));
+		iteration_build_thread_task_id = WorkerThreadPool::get_singleton()->add_native_task(&NavRegion3D::_build_iteration_threaded, &iteration_build, true, false, SNAME("NavRegionBuilder3D"));
 		request_async_thread_join();
 	} else {
 		NavRegionBuilder3D::build_iteration(iteration_build);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -516,7 +516,7 @@ Error ResourceLoaderText::load() {
 
 		ext_resources[id].path = path;
 		ext_resources[id].type = type;
-		ext_resources[id].load_token = ResourceLoader::_load_start(path, type, use_sub_threads ? ResourceLoader::LOAD_THREAD_DISTRIBUTE : ResourceLoader::LOAD_THREAD_FROM_CURRENT, cache_mode_for_external);
+		ext_resources[id].load_token = ResourceLoader::_load_start(path, type, use_sub_threads ? ResourceLoader::LOAD_THREAD_DISTRIBUTE : ResourceLoader::LOAD_THREAD_FROM_CURRENT, false, cache_mode_for_external);
 		if (ext_resources[id].load_token.is_null()) {
 			if (ResourceLoader::get_abort_on_missing_resources()) {
 				error = ERR_FILE_CORRUPT;

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -516,7 +516,7 @@ Error ResourceLoaderText::load() {
 
 		ext_resources[id].path = path;
 		ext_resources[id].type = type;
-		ext_resources[id].load_token = ResourceLoader::_load_start(path, type, use_sub_threads ? ResourceLoader::LOAD_THREAD_DISTRIBUTE : ResourceLoader::LOAD_THREAD_FROM_CURRENT, false, cache_mode_for_external);
+		ext_resources[id].load_token = ResourceLoader::_load_start(path, type, use_sub_threads ? ResourceLoader::LOAD_THREAD_DISTRIBUTE : ResourceLoader::LOAD_THREAD_FROM_CURRENT, cache_mode_for_external, false);
 		if (ext_resources[id].load_token.is_null()) {
 			if (ResourceLoader::get_abort_on_missing_resources()) {
 				error = ERR_FILE_CORRUPT;


### PR DESCRIPTION
This PR adds a new parameter `high_priority` to `ResourceLoader.load_threaded_request`.

As of upstream, if you're in a situation in which you have a lot of enqueued asynchronous resource loading requests and you want to add new ones, you're forced to push it at the end of the queue, resulting in any new request to be processed only after all the previous one ends but in real case scenarios, you might need resources to be delivered as soon as possible in contrast to other kind of resources (an example would be a background resource loader that preloads assets for the game vs a game screen you open that has lazy load for images that would need to have priority over the background loader).

When high_priority is specified, load_threaded_request will insert those requests at the head of the low_prority_task queue, resulting in them being processed as soon as a thread for low priority tasks is available, resulting in overtaking priority on any resource that got requested without high_priority being set.
