### PR TITLE
Allow running projects without a main scene when using a custom main loop

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6323,33 +6323,46 @@ bool EditorNode::ensure_main_scene(bool p_from_native) {
 	pick_main_scene->set_meta("from_native", p_from_native); // Whether from play button or native run.
 	String main_scene = GLOBAL_GET("application/run/main_scene");
 
-	if (main_scene.is_empty()) {
-		current_menu_option = -1;
-		pick_main_scene->set_text(TTR("No main scene has ever been defined. Select one?\nYou can change it later in \"Project Settings\" under the 'application' category."));
-		pick_main_scene->popup_centered();
+	bool is_custom_loop = false;
+	String main_loop_type = GLOBAL_GET("application/run/main_loop_type");
+	if (main_loop_type != "SceneTree" && ScriptServer::is_global_class(main_loop_type)) {
+		String script_path = ScriptServer::get_global_class_path(main_loop_type);
+		Ref<Script> script_res = ResourceLoader::load(script_path);
+		if (script_res.is_valid()) {
+			StringName base_type = script_res->get_instance_base_type();
+			is_custom_loop = ClassDB::is_parent_class(base_type, "MainLoop");
+		}
+	}
 
-		if (editor_data.get_edited_scene_root()) {
-			select_current_scene_button->set_disabled(false);
-			select_current_scene_button->grab_focus();
-		} else {
-			select_current_scene_button->set_disabled(true);
+	if (!is_custom_loop) {
+		if (main_scene.is_empty()) {
+			current_menu_option = -1;
+			pick_main_scene->set_text(TTR("No main scene has ever been defined. Select one?\nYou can change it later in \"Project Settings\" under the 'application' category."));
+			pick_main_scene->popup_centered();
+
+			if (editor_data.get_edited_scene_root()) {
+				select_current_scene_button->set_disabled(false);
+				select_current_scene_button->grab_focus();
+			} else {
+				select_current_scene_button->set_disabled(true);
+			}
+
+			return false;
 		}
 
-		return false;
-	}
+		if (!FileAccess::exists(main_scene)) {
+			current_menu_option = -1;
+			pick_main_scene->set_text(vformat(TTR("Selected scene '%s' does not exist. Select a valid one?\nYou can change it later in \"Project Settings\" under the 'application' category."), main_scene));
+			pick_main_scene->popup_centered();
+			return false;
+		}
 
-	if (!FileAccess::exists(main_scene)) {
-		current_menu_option = -1;
-		pick_main_scene->set_text(vformat(TTR("Selected scene '%s' does not exist. Select a valid one?\nYou can change it later in \"Project Settings\" under the 'application' category."), main_scene));
-		pick_main_scene->popup_centered();
-		return false;
-	}
-
-	if (ResourceLoader::get_resource_type(main_scene) != "PackedScene") {
-		current_menu_option = -1;
-		pick_main_scene->set_text(vformat(TTR("Selected scene '%s' is not a scene file. Select a valid one?\nYou can change it later in \"Project Settings\" under the 'application' category."), main_scene));
-		pick_main_scene->popup_centered();
-		return false;
+		if (ResourceLoader::get_resource_type(main_scene) != "PackedScene") {
+			current_menu_option = -1;
+			pick_main_scene->set_text(vformat(TTR("Selected scene '%s' is not a scene file. Select a valid one?\nYou can change it later in \"Project Settings\" under the 'application' category."), main_scene));
+			pick_main_scene->popup_centered();
+			return false;
+		}
 	}
 
 	return true;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2263,7 +2263,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		OS::get_singleton()->add_logger(memnew(RotatedFileLogger(base_path, max_files)));
 	}
 
-	if (main_args.is_empty() && String(GLOBAL_GET("application/run/main_scene")) == "") {
+	if (main_args.is_empty() && String(GLOBAL_GET("application/run/main_scene")) == "" && String(GLOBAL_GET("application/run/main_loop_type")) == "SceneTree") {
 #ifdef TOOLS_ENABLED
 		if (!editor && !project_manager) {
 #endif
@@ -4217,17 +4217,6 @@ int Main::start() {
 		}
 	}
 
-#ifdef TOOLS_ENABLED
-	if (!editor && !project_manager && !cmdline_tool && script.is_empty() && game_path.is_empty()) {
-		// If we end up here, it means we didn't manage to detect what we want to run.
-		// Let's throw an error gently. The code leading to this is pretty brittle so
-		// this might end up triggered by valid usage, in which case we'll have to
-		// fine-tune further.
-		OS::get_singleton()->alert("Couldn't detect whether to run the editor, the project manager or a specific project. Aborting.");
-		ERR_FAIL_V_MSG(EXIT_FAILURE, "Couldn't detect whether to run the editor, the project manager or a specific project. Aborting.");
-	}
-#endif
-
 	MainLoop *main_loop = nullptr;
 	if (editor) {
 		main_loop = memnew(SceneTree);
@@ -4303,6 +4292,17 @@ int Main::start() {
 			}
 		}
 	}
+
+#ifdef TOOLS_ENABLED
+	if (!editor && !project_manager && !cmdline_tool && script.is_empty() && game_path.is_empty() && main_loop_type == "SceneTree") {
+		// If we end up here, it means we didn't manage to detect what we want to run.
+		// Let's throw an error gently. The code leading to this is pretty brittle so
+		// this might end up triggered by valid usage, in which case we'll have to
+		// fine-tune further.
+		OS::get_singleton()->alert("Couldn't detect whether to run the editor, the project manager or a specific project. Aborting.");
+		ERR_FAIL_V_MSG(EXIT_FAILURE, "Couldn't detect whether to run the editor, the project manager or a specific project. Aborting.");
+	}
+#endif
 
 	OS::get_singleton()->set_main_loop(main_loop);
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/10735
This PR will change the checking condition for the main scene a little bit, by allowing ignoring the main scene requirement when using a valid custom main loop