### PR TITLE
Fix double memdelete of `dummy_player`

### DIFF
--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -2473,9 +2473,6 @@ AnimationPlayerEditorPlugin::AnimationPlayerEditorPlugin() {
 }
 
 AnimationPlayerEditorPlugin::~AnimationPlayerEditorPlugin() {
-	if (dummy_player) {
-		memdelete(dummy_player);
-	}
 }
 
 // AnimationTrackKeyEditEditorPlugin


### PR DESCRIPTION
It's already deleted as a result of being part of the tree.

https://github.com/godotengine/godot/blob/56f3e2611daadb0b1894b46737ee3000e82e33f9/editor/animation/animation_player_editor_plugin.cpp#L2424

Fixes #115411.
