### PR TITLE
Fix UAF in destructor of VisualShaderEditor

### DIFF
--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -5397,6 +5397,10 @@ void VisualShaderEditor::_notification(int p_what) {
 		case NOTIFICATION_DRAG_END: {
 			members->set_drop_mode_flags(0);
 		} break;
+
+		case NOTIFICATION_PREDELETE: {
+			save_editor_layout();
+		} break;
 	}
 }
 
@@ -7827,7 +7831,6 @@ VisualShaderEditor::VisualShaderEditor() {
 }
 
 VisualShaderEditor::~VisualShaderEditor() {
-	save_editor_layout();
 }
 
 class VisualShaderNodePluginInputEditor : public OptionButton {


### PR DESCRIPTION
Address Sanitizer found another use-after-free that seems to happen when closing the editor and there exists a VisualShaderEditor in the tree.

https://github.com/godotengine/godot/blob/56f3e2611daadb0b1894b46737ee3000e82e33f9/editor/shader/visual_shader_editor_plugin.cpp#L7829-L7831

https://github.com/godotengine/godot/blob/56f3e2611daadb0b1894b46737ee3000e82e33f9/editor/shader/visual_shader_editor_plugin.cpp#L1601

`graph` is already freed by this point. So I relocated the `save_editor_layout` call from the destructor to `_notification` (predelete).