### PR TITLE
Inspector property control (`Range`): Keep NaNs as is

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -178,6 +178,10 @@ void Range::_set_value_no_signal(double p_val) {
 }
 
 double Range::_calc_value(double p_val, double p_step) const {
+	if (Math::is_nan(p_val)) {
+		return p_val;
+	}
+
 	if (p_step > 0) {
 		// Subtract min to support cases like min = 0.1, step = 0.2, snaps to 0.1, 0.3, 0.5, etc.
 		p_val = _snapped_r128(p_val - shared->min, p_step) + shared->min;


### PR DESCRIPTION
Fixes #115525.