### PR TITLE
Fix WindowWrapper leaking all key inputs to parent

### DIFF
--- a/editor/gui/window_wrapper.cpp
+++ b/editor/gui/window_wrapper.cpp
@@ -46,36 +46,6 @@
 
 // WindowWrapper
 
-// Capture all shortcut events not handled by other nodes.
-class ShortcutBin : public Node {
-	GDCLASS(ShortcutBin, Node);
-
-	virtual void _notification(int what) {
-		switch (what) {
-			case NOTIFICATION_READY:
-				set_process_shortcut_input(true);
-				break;
-		}
-	}
-
-	virtual void shortcut_input(const Ref<InputEvent> &p_event) override {
-		if (!get_window()->is_visible()) {
-			return;
-		}
-		Window *grandparent_window = get_window()->get_parent_visible_window();
-		ERR_FAIL_NULL(grandparent_window);
-
-		if (Object::cast_to<InputEventKey>(p_event.ptr()) || Object::cast_to<InputEventShortcut>(p_event.ptr())) {
-			// HACK: Propagate the window input to the editor main window to handle global shortcuts.
-			grandparent_window->push_input(p_event);
-
-			if (grandparent_window->is_input_handled()) {
-				get_viewport()->set_input_as_handled();
-			}
-		}
-	}
-};
-
 Rect2 WindowWrapper::_get_default_window_rect() const {
 	// Assume that the control rect is the desired one for the window.
 	return wrapped_control->get_screen_rect();
@@ -372,19 +342,17 @@ WindowWrapper::WindowWrapper() {
 	window = memnew(Window);
 	window_id = window->get_instance_id();
 	window->set_wrap_controls(true);
-
-	add_child(window);
+	window->set_propagate_shortcuts_to_parent(true);
 	window->hide();
 
 	window->connect("close_requested", callable_mp(this, &WindowWrapper::_window_close_request));
 	window->connect("size_changed", callable_mp(this, &WindowWrapper::_window_size_changed));
 
-	ShortcutBin *capturer = memnew(ShortcutBin);
-	window->add_child(capturer);
-
 	window_background = memnew(Panel);
 	window_background->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
 	window->add_child(window_background);
+
+	add_child(window);
 
 	ProgressDialog::get_singleton()->add_host_window(window_id);
 }

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2328,7 +2328,7 @@ bool Control::is_focus_owner_in_shortcut_context() const {
 	}
 
 	const Node *ctx_node = get_shortcut_context();
-	const Control *vp_focus = get_viewport() ? get_viewport()->gui_get_focus_owner() : nullptr;
+	const Control *vp_focus = (get_viewport() && get_viewport()->gui_shortcut_use_focus_owner()) ? get_viewport()->gui_get_focus_owner() : nullptr;
 
 	// If the context is valid and the viewport focus is valid, check if the context is the focus or is a parent of it.
 	return ctx_node && vp_focus && (ctx_node == vp_focus || ctx_node->is_ancestor_of(vp_focus));

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3589,12 +3589,46 @@ void Viewport::push_unhandled_input(RequiredParam<InputEvent> rp_event, bool p_l
 }
 #endif // DISABLE_DEPRECATED
 
+void Viewport::_push_shortcut_input_internal(const Ref<InputEvent> &p_event) {
+	if (Object::cast_to<InputEventKey>(*p_event) == nullptr && Object::cast_to<InputEventShortcut>(*p_event) == nullptr && Object::cast_to<InputEventJoypadButton>(*p_event) == nullptr) {
+		return;
+	}
+	ERR_FAIL_COND(!is_inside_tree());
+	get_tree()->_call_input_pause(shortcut_input_group, SceneTree::CALL_INPUT_TYPE_SHORTCUT_INPUT, p_event, this);
+
+	if (!propagate_shortcuts_to_parent || is_input_handled()) {
+		return;
+	}
+
+	Viewport *parent_viewport = get_parent_viewport();
+	if (!parent_viewport) {
+		return;
+	}
+	if (parent_viewport->disable_input || parent_viewport->disable_input_override) {
+		return;
+	}
+	if (Engine::get_singleton()->is_editor_hint() && get_tree()->get_edited_scene_root() && get_tree()->get_edited_scene_root()->is_ancestor_of(parent_viewport)) {
+		return;
+	}
+	if (!parent_viewport->handle_input_locally || parent_viewport->is_embedding_subwindows()) {
+		return;
+	}
+	if (!parent_viewport->_can_consume_input_events()) {
+		return;
+	}
+
+	parent_viewport->local_input_handled = false;
+	parent_viewport->shortcut_use_focus_owner = false;
+	parent_viewport->_push_shortcut_input_internal(p_event);
+	parent_viewport->shortcut_use_focus_owner = true;
+	if (parent_viewport->is_input_handled()) {
+		set_input_as_handled();
+	}
+}
+
 void Viewport::_push_unhandled_input_internal(const Ref<InputEvent> &p_event) {
 	// Shortcut Input.
-	if (Object::cast_to<InputEventKey>(*p_event) != nullptr || Object::cast_to<InputEventShortcut>(*p_event) != nullptr || Object::cast_to<InputEventJoypadButton>(*p_event) != nullptr) {
-		ERR_FAIL_COND(!is_inside_tree());
-		get_tree()->_call_input_pause(shortcut_input_group, SceneTree::CALL_INPUT_TYPE_SHORTCUT_INPUT, p_event, this);
-	}
+	_push_shortcut_input_internal(p_event);
 
 	// Unhandled key Input - Used for performance reasons - This is called a lot less than _unhandled_input since it ignores MouseMotion, and to handle Unicode input with Alt / Ctrl modifiers after handling shortcuts.
 	if (!is_input_handled() && (Object::cast_to<InputEventKey>(*p_event) != nullptr)) {
@@ -3995,6 +4029,16 @@ void Viewport::set_handle_input_locally(bool p_enable) {
 bool Viewport::is_handling_input_locally() const {
 	ERR_READ_THREAD_GUARD_V(false);
 	return handle_input_locally;
+}
+
+void Viewport::set_propagate_shortcuts_to_parent(bool p_enable) {
+	ERR_MAIN_THREAD_GUARD;
+	propagate_shortcuts_to_parent = p_enable;
+}
+
+bool Viewport::gui_shortcut_use_focus_owner() const {
+	ERR_READ_THREAD_GUARD_V(false);
+	return shortcut_use_focus_owner;
 }
 
 void Viewport::_refresh_texture_filter_cache() const {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -286,6 +286,8 @@ private:
 
 	bool handle_input_locally = true;
 	bool local_input_handled = false;
+	bool propagate_shortcuts_to_parent = false;
+	bool shortcut_use_focus_owner = true;
 
 	Ref<World2D> world_2d;
 
@@ -441,6 +443,7 @@ private:
 	void _perform_drop(Control *p_control = nullptr);
 	void _gui_cleanup_internal_state(Ref<InputEvent> p_event);
 
+	void _push_shortcut_input_internal(const Ref<InputEvent> &p_event);
 	void _push_unhandled_input_internal(const Ref<InputEvent> &p_event);
 
 	Ref<InputEvent> _make_input_local(const Ref<InputEvent> &ev);
@@ -683,6 +686,9 @@ public:
 
 	void set_handle_input_locally(bool p_enable);
 	bool is_handling_input_locally() const;
+
+	void set_propagate_shortcuts_to_parent(bool p_enable);
+	bool gui_shortcut_use_focus_owner() const;
 
 	bool gui_is_dragging() const;
 	bool gui_is_drag_successful() const;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/104758
- Fixes https://github.com/godotengine/godot/issues/108594
- Fixes partially https://github.com/godotengine/godot/issues/106285 - the script editor no longer takes the events, but the game doesn't either

This happened with any floating window that didn't accept the input and any node that used key input or non-global shortcuts in the parent window.
The cause was this hack in WindowWrapper:

https://github.com/godotengine/godot/blob/56f3e2611daadb0b1894b46737ee3000e82e33f9/editor/gui/window_wrapper.cpp#L66-L67

WindowWrapper's ShortcutBin was pushing inputs to parent windows for global shortcuts, but this was being treated as normal input for TextEdit and all other nodes. Only shortcuts should be sent to the parent window, and we can't just filter to InputEventShortcut, since InputEventKey is also used for shortcuts.
I added a parameter to Viewport to handle this and logic just for shortcuts. It is not exposed for now, but may be useful generally.
We may also want to use this for popup menus in the future, so global shortcuts can still work when they are open.

I ignore the parent viewport if it doesn't use `handle_input_locally`, since it isn't needed in the Editor.