### PR TITLE
Fix: CanvasLayer editor workspace not switching

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -6077,7 +6077,7 @@ void CanvasItemEditorPlugin::edit(Object *p_object) {
 }
 
 bool CanvasItemEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("CanvasItem");
+	return p_object->is_class("CanvasItem") || p_object->is_class("CanvasLayer");
 }
 
 void CanvasItemEditorPlugin::make_visible(bool p_visible) {


### PR DESCRIPTION
Fixes #115787

~~And fixes same issue with the WorldEnvironment node.~~