### PR TITLE
Fix unsafe access during multithreaded loading of TileSet

### DIFF
--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -68,7 +68,7 @@
 			<description>
 				Adds a [TileSetSource] to the TileSet. If [param atlas_source_id_override] is not -1, also set its source ID. Otherwise, a unique identifier is automatically generated.
 				The function returns the added source ID or -1 if the source could not be added.
-				[b]Warning:[/b] A source cannot belong to two TileSets at the same time. If the added source was attached to another [TileSet], it will be removed from that one.
+				[b]Warning:[/b] A source cannot belong to two TileSets at the same time. If the added source was attached to another [TileSet], it will be duplicated.
 			</description>
 		</method>
 		<method name="add_terrain">

--- a/doc/classes/TileSetSource.xml
+++ b/doc/classes/TileSetSource.xml
@@ -8,7 +8,7 @@
 		Tiles in a source are indexed with two IDs, coordinates ID (of type Vector2i) and an alternative ID (of type int), named according to their use in the [TileSetAtlasSource] class.
 		Depending on the TileSet source type, those IDs might have restrictions on their values, this is why the base [TileSetSource] class only exposes getters for them.
 		You can iterate over all tiles exposed by a TileSetSource by first iterating over coordinates IDs using [method get_tiles_count] and [method get_tile_id], then over alternative IDs using [method get_alternative_tiles_count] and [method get_alternative_tile_id].
-		[b]Warning:[/b] [TileSetSource] can only be added to one TileSet at the same time. Calling [method TileSet.add_source] on a second [TileSet] will remove the source from the first one.
+		[b]Warning:[/b] [TileSetSource] can only be added to one TileSet at the same time. Calling [method TileSet.add_source] on a second [TileSet] will duplicate the source.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -480,7 +480,7 @@ int TileSet::add_source(Ref<TileSetSource> p_tile_set_source, int p_atlas_source
 
 	TileSet *owning_tileset = p_tile_set_source->get_tile_set();
 	if (owning_tileset != this && owning_tileset != nullptr) {
-		// If the source is already in a TileSet (might happen when duplicating or during multithreaded loadin), duplicate it
+		// If the source is already in a TileSet (might happen when duplicating or during multithreaded loading), duplicate it
 		p_tile_set_source = p_tile_set_source->duplicate();
 	}
 

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -478,15 +478,16 @@ int TileSet::add_source(Ref<TileSetSource> p_tile_set_source, int p_atlas_source
 	ERR_FAIL_COND_V_MSG(p_atlas_source_id_override >= 0 && (sources.has(p_atlas_source_id_override)), TileSet::INVALID_SOURCE, vformat("Cannot create TileSet atlas source. Another atlas source exists with id %d.", p_atlas_source_id_override));
 	ERR_FAIL_COND_V_MSG(p_atlas_source_id_override < 0 && p_atlas_source_id_override != TileSet::INVALID_SOURCE, TileSet::INVALID_SOURCE, vformat("Provided source ID %d is not valid. Negative source IDs are not allowed.", p_atlas_source_id_override));
 
+	TileSet *owning_tileset = p_tile_set_source->get_tile_set();
+	if (owning_tileset != this && owning_tileset != nullptr) {
+		// If the source is already in a TileSet (might happen when duplicating or during multithreaded loadin), duplicate it
+		p_tile_set_source = p_tile_set_source->duplicate();
+	}
+
 	int new_source_id = p_atlas_source_id_override >= 0 ? p_atlas_source_id_override : next_source_id;
 	sources[new_source_id] = p_tile_set_source;
 	source_ids.push_back(new_source_id);
 	source_ids.sort();
-	TileSet *old_tileset = p_tile_set_source->get_tile_set();
-	if (old_tileset != this && old_tileset != nullptr) {
-		// If the source is already in a TileSet (might happen when duplicating), remove it from the other TileSet.
-		old_tileset->remove_source_ptr(p_tile_set_source.ptr());
-	}
 	p_tile_set_source->set_tile_set(this);
 	_compute_next_source_id();
 
@@ -510,16 +511,6 @@ void TileSet::remove_source(int p_source_id) {
 
 	terrains_cache_dirty = true;
 	emit_changed();
-}
-
-void TileSet::remove_source_ptr(TileSetSource *p_tile_set_source) {
-	for (const KeyValue<int, Ref<TileSetSource>> &kv : sources) {
-		if (kv.value.ptr() == p_tile_set_source) {
-			remove_source(kv.key);
-			return;
-		}
-	}
-	ERR_FAIL_MSG(vformat("Attempting to remove source from a tileset, but the tileset doesn't have it: %s", p_tile_set_source));
 }
 
 void TileSet::set_source_id(int p_source_id, int p_new_source_id) {

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -427,7 +427,6 @@ public:
 	int add_source(Ref<TileSetSource> p_tile_set_source, int p_source_id_override = -1);
 	void set_source_id(int p_source_id, int p_new_id);
 	void remove_source(int p_source_id);
-	void remove_source_ptr(TileSetSource *p_tile_set_source); // Not exposed
 	bool has_source(int p_source_id) const;
 	Ref<TileSetSource> get_source(int p_source_id) const;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/115069

During multithreaded loading of resources (load_threaded_request with use_sub_threads == true), sometimes we load a same resource two times to avoid deadlock. When this happen to a TileSet, it can lead to a corrupted resources or a crash. The faulty behavior is that a TileSetSource (subresource of TileSet) can be bound to only one TileSet at once (see https://github.com/godotengine/godot/pull/78477). If we add an already assigned TileSetSource to a TileSet, the TileSetSource will be automatically removed from the original TileSet (possibly while it's accessed by another thread). And, in some case, the original TileSet is the one being kept and the other one (which now have the TileSetSource) is discarded.

To fix the issue, when adding a source to a TileSet, instead of removing the source from the original TileSet I duplicate the source in the new TileSet. Then we don't have any unsafe access or sourceless TileSet anymore.