### PR TITLE
Remove unused MultiplayerPeer::is_server

### DIFF
--- a/doc/classes/MultiplayerPeerExtension.xml
+++ b/doc/classes/MultiplayerPeerExtension.xml
@@ -97,12 +97,6 @@
 				Called when the "refuse new connections" status is requested on this [MultiplayerPeer] (see [member MultiplayerPeer.refuse_new_connections]).
 			</description>
 		</method>
-		<method name="_is_server" qualifiers="virtual required const">
-			<return type="bool" />
-			<description>
-				Called when the "is server" status is requested on the [MultiplayerAPI]. See [method MultiplayerAPI.is_server].
-			</description>
-		</method>
 		<method name="_is_server_relay_supported" qualifiers="virtual const">
 			<return type="bool" />
 			<description>

--- a/misc/extension_api_validation/4.6-stable/GH-115986.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-115986.txt
@@ -1,0 +1,5 @@
+GH-115986
+---------
+Validate extension JSON: API was removed: classes/MultiplayerPeerExtension/methods/_is_server
+
+Method was unused and not intended to be called directly.

--- a/modules/enet/enet_multiplayer_peer.cpp
+++ b/modules/enet/enet_multiplayer_peer.cpp
@@ -68,7 +68,7 @@ Error ENetMultiplayerPeer::create_server(int p_port, int p_max_clients, int p_ma
 	}
 
 	active_mode = MODE_SERVER;
-	unique_id = 1;
+	unique_id = TARGET_PEER_SERVER;
 	connection_status = CONNECTION_CONNECTED;
 	hosts[0] = host;
 	return OK;
@@ -100,7 +100,7 @@ Error ENetMultiplayerPeer::create_client(const String &p_address, int p_port, in
 	// Need to wait for CONNECT event.
 	connection_status = CONNECTION_CONNECTING;
 	active_mode = MODE_CLIENT;
-	peers[1] = peer;
+	peers[TARGET_PEER_SERVER] = peer;
 	hosts[0] = host;
 
 	return OK;
@@ -170,7 +170,7 @@ void ENetMultiplayerPeer::poll() {
 
 	switch (active_mode) {
 		case MODE_CLIENT: {
-			if (!peers.has(1)) {
+			if (!peers.has(TARGET_PEER_SERVER)) {
 				close();
 				return;
 			}
@@ -179,15 +179,15 @@ void ENetMultiplayerPeer::poll() {
 			do {
 				if (ret == ENetConnection::EVENT_CONNECT) {
 					connection_status = CONNECTION_CONNECTED;
-					emit_signal(SNAME("peer_connected"), 1);
+					emit_signal(SNAME("peer_connected"), TARGET_PEER_SERVER);
 				} else if (ret == ENetConnection::EVENT_DISCONNECT) {
 					if (connection_status == CONNECTION_CONNECTED) {
 						// Client just disconnected from server.
-						emit_signal(SNAME("peer_disconnected"), 1);
+						emit_signal(SNAME("peer_disconnected"), TARGET_PEER_SERVER);
 					}
 					close();
 				} else if (ret == ENetConnection::EVENT_RECEIVE) {
-					_store_packet(1, event);
+					_store_packet(TARGET_PEER_SERVER, event);
 				} else if (ret != ENetConnection::EVENT_NONE) {
 					close(); // Error.
 				}
@@ -256,10 +256,6 @@ void ENetMultiplayerPeer::poll() {
 		default:
 			return;
 	}
-}
-
-bool ENetMultiplayerPeer::is_server() const {
-	return active_mode == MODE_SERVER;
 }
 
 bool ENetMultiplayerPeer::is_server_relay_supported() const {
@@ -334,8 +330,8 @@ Error ENetMultiplayerPeer::get_packet(const uint8_t **r_buffer, int &r_buffer_si
 Error ENetMultiplayerPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
 	ERR_FAIL_COND_V_MSG(!_is_active(), ERR_UNCONFIGURED, "The multiplayer instance isn't currently active.");
 	ERR_FAIL_COND_V_MSG(connection_status != CONNECTION_CONNECTED, ERR_UNCONFIGURED, "The multiplayer instance isn't currently connected to any server or client.");
-	ERR_FAIL_COND_V_MSG(target_peer != 0 && !peers.has(Math::abs(target_peer)), ERR_INVALID_PARAMETER, vformat("Invalid target peer: %d", target_peer));
-	ERR_FAIL_COND_V(active_mode == MODE_CLIENT && !peers.has(1), ERR_BUG);
+	ERR_FAIL_COND_V_MSG(target_peer != TARGET_PEER_BROADCAST && !peers.has(Math::abs(target_peer)), ERR_INVALID_PARAMETER, vformat("Invalid target peer: %d", target_peer));
+	ERR_FAIL_COND_V(active_mode == MODE_CLIENT && !peers.has(TARGET_PEER_SERVER), ERR_BUG);
 
 	int packet_flags = 0;
 	int channel = SYSCH_RELIABLE;
@@ -367,8 +363,8 @@ Error ENetMultiplayerPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size
 	ENetPacket *packet = enet_packet_create(nullptr, p_buffer_size, packet_flags);
 	memcpy(&packet->data[0], p_buffer, p_buffer_size);
 
-	if (is_server()) {
-		if (target_peer == 0) {
+	if (active_mode == MODE_SERVER) {
+		if (target_peer == TARGET_PEER_BROADCAST) {
 			hosts[0]->broadcast(channel, packet);
 
 		} else if (target_peer < 0) {
@@ -388,7 +384,7 @@ Error ENetMultiplayerPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size
 		hosts[0]->flush();
 
 	} else if (active_mode == MODE_CLIENT) {
-		peers[1]->send(channel, packet); // Send to server for broadcast.
+		peers[TARGET_PEER_SERVER]->send(channel, packet); // Send to server for broadcast.
 		ERR_FAIL_COND_V(!hosts.has(0), ERR_BUG);
 		hosts[0]->flush();
 
@@ -457,7 +453,7 @@ Ref<ENetConnection> ENetMultiplayerPeer::get_host() const {
 Ref<ENetPacketPeer> ENetMultiplayerPeer::get_peer(int p_id) const {
 	ERR_FAIL_COND_V(!_is_active(), nullptr);
 	ERR_FAIL_COND_V(!peers.has(p_id), nullptr);
-	ERR_FAIL_COND_V(active_mode == MODE_CLIENT && p_id != 1, nullptr);
+	ERR_FAIL_COND_V(active_mode == MODE_CLIENT && p_id != TARGET_PEER_SERVER, nullptr);
 	return peers[p_id];
 }
 

--- a/modules/enet/enet_multiplayer_peer.h
+++ b/modules/enet/enet_multiplayer_peer.h
@@ -103,7 +103,6 @@ public:
 	virtual void close() override;
 	virtual void disconnect_peer(int p_peer, bool p_force = false) override;
 
-	virtual bool is_server() const override;
 	virtual bool is_server_relay_supported() const override;
 
 	// Overridden so we can instrument the DTLSServer when needed.

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -256,14 +256,14 @@ _FORCE_INLINE_ Error SceneMultiplayer::_send(const uint8_t *p_packet, int p_pack
 #endif
 
 Error SceneMultiplayer::send_command(int p_to, const uint8_t *p_packet, int p_packet_len) {
-	if (server_relay && get_unique_id() != 1 && p_to != 1 && multiplayer_peer->is_server_relay_supported()) {
+	if (server_relay && !is_server() && p_to != MultiplayerPeer::TARGET_PEER_SERVER && multiplayer_peer->is_server_relay_supported()) {
 		// Send relay packet.
 		relay_buffer->seek(0);
 		relay_buffer->put_u8(NETWORK_COMMAND_SYS);
 		relay_buffer->put_u8(SYS_COMMAND_RELAY);
 		relay_buffer->put_32(p_to); // Set the destination.
 		relay_buffer->put_data(p_packet, p_packet_len);
-		multiplayer_peer->set_target_peer(1);
+		multiplayer_peer->set_target_peer(MultiplayerPeer::TARGET_PEER_SERVER);
 		const Vector<uint8_t> data = relay_buffer->get_data_array();
 		return _send(data.ptr(), relay_buffer->get_position());
 	}
@@ -289,11 +289,11 @@ void SceneMultiplayer::_process_sys(int p_from, const uint8_t *p_packet, int p_p
 	int32_t peer = int32_t(decode_uint32(&p_packet[2]));
 	switch (sys_cmd_type) {
 		case SYS_COMMAND_ADD_PEER: {
-			ERR_FAIL_COND(!server_relay || !multiplayer_peer->is_server_relay_supported() || get_unique_id() == 1 || p_from != 1);
+			ERR_FAIL_COND(!server_relay || !multiplayer_peer->is_server_relay_supported() || is_server() || p_from != MultiplayerPeer::TARGET_PEER_SERVER);
 			_admit_peer(peer); // Relayed peers are automatically accepted.
 		} break;
 		case SYS_COMMAND_DEL_PEER: {
-			ERR_FAIL_COND(!server_relay || !multiplayer_peer->is_server_relay_supported() || get_unique_id() == 1 || p_from != 1);
+			ERR_FAIL_COND(!server_relay || !multiplayer_peer->is_server_relay_supported() || is_server() || p_from != MultiplayerPeer::TARGET_PEER_SERVER);
 			_del_peer(peer);
 		} break;
 		case SYS_COMMAND_RELAY: {
@@ -302,7 +302,7 @@ void SceneMultiplayer::_process_sys(int p_from, const uint8_t *p_packet, int p_p
 			const uint8_t *packet = p_packet + SYS_CMD_SIZE;
 			int len = p_packet_len - SYS_CMD_SIZE;
 			bool should_process = false;
-			if (get_unique_id() == 1) { // I am the server.
+			if (is_server()) {
 				// The requested target might have disconnected while the packet was in transit.
 				if (unlikely(peer > 0 && !connected_peers.has(peer))) {
 					return;
@@ -330,14 +330,14 @@ void SceneMultiplayer::_process_sys(int p_from, const uint8_t *p_packet, int p_p
 						multiplayer_peer->set_target_peer(P);
 						_send(data.ptr(), relay_buffer->get_position());
 					}
-					if (peer != -1) {
+					if (peer != -MultiplayerPeer::TARGET_PEER_SERVER) {
 						// The server is one of the targets, process the packet with sender as source.
 						should_process = true;
 						peer = p_from;
 					}
 				}
 			} else {
-				ERR_FAIL_COND(p_from != 1); // Bug.
+				ERR_FAIL_COND(p_from != MultiplayerPeer::TARGET_PEER_SERVER); // Bug.
 				should_process = true;
 			}
 			if (should_process) {
@@ -364,7 +364,7 @@ void SceneMultiplayer::_add_peer(int p_id) {
 }
 
 void SceneMultiplayer::_admit_peer(int p_id) {
-	if (server_relay && get_unique_id() == 1 && multiplayer_peer->is_server_relay_supported()) {
+	if (server_relay && is_server() && multiplayer_peer->is_server_relay_supported()) {
 		// Notify others of connection, and send connected peers to newly connected one.
 		uint8_t buf[SYS_CMD_SIZE];
 		buf[0] = NETWORK_COMMAND_SYS;
@@ -386,7 +386,7 @@ void SceneMultiplayer::_admit_peer(int p_id) {
 	connected_peers.insert(p_id);
 	cache->on_peer_change(p_id, true);
 	replicator->on_peer_change(p_id, true);
-	if (p_id == 1) {
+	if (p_id == MultiplayerPeer::TARGET_PEER_SERVER) {
 		emit_signal(SNAME("connected_to_server"));
 	}
 	emit_signal(SNAME("peer_connected"), p_id);
@@ -401,7 +401,7 @@ void SceneMultiplayer::_del_peer(int p_id) {
 		return;
 	}
 
-	if (server_relay && get_unique_id() == 1 && multiplayer_peer->is_server_relay_supported()) {
+	if (server_relay && is_server() && multiplayer_peer->is_server_relay_supported()) {
 		// Notify others of disconnection.
 		uint8_t buf[SYS_CMD_SIZE];
 		buf[0] = NETWORK_COMMAND_SYS;

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -54,7 +54,6 @@ public:
 	virtual TransferMode get_packet_mode() const override { return TRANSFER_MODE_RELIABLE; }
 	virtual int get_packet_channel() const override { return 0; }
 	virtual void disconnect_peer(int p_peer, bool p_force = false) override {}
-	virtual bool is_server() const override { return true; }
 	virtual void poll() override {}
 	virtual void close() override {}
 	virtual int get_unique_id() const override { return TARGET_PEER_SERVER; }

--- a/modules/multiplayer/scene_rpc_interface.cpp
+++ b/modules/multiplayer/scene_rpc_interface.cpp
@@ -310,7 +310,7 @@ void SceneRPCInterface::_send_rpc(Node *p_node, int p_to, uint16_t p_rpc_id, con
 
 	ERR_FAIL_COND_MSG(p_argcount > 255, "Too many arguments (>255).");
 
-	if (p_to != 0 && !multiplayer->get_connected_peers().has(Math::abs(p_to))) {
+	if (p_to != MultiplayerPeer::TARGET_PEER_BROADCAST && !multiplayer->get_connected_peers().has(Math::abs(p_to))) {
 		ERR_FAIL_COND_MSG(p_to == multiplayer->get_unique_id(), "Attempt to call RPC on yourself! Peer unique ID: " + itos(multiplayer->get_unique_id()) + ".");
 
 		ERR_FAIL_MSG("Attempt to call RPC with unknown peer ID: " + itos(p_to) + ".");
@@ -486,7 +486,7 @@ Error SceneRPCInterface::rpcp(Object *p_obj, int p_peer_id, const StringName &p_
 
 	ERR_FAIL_COND_V_MSG(p_peer_id == caller_id && !config.call_local, ERR_INVALID_PARAMETER, "RPC '" + p_method + "' on yourself is not allowed by selected mode.");
 
-	if (p_peer_id == 0 || p_peer_id == caller_id || (p_peer_id < 0 && p_peer_id != -caller_id)) {
+	if (p_peer_id == MultiplayerPeer::TARGET_PEER_BROADCAST || p_peer_id == caller_id || (p_peer_id < 0 && p_peer_id != -caller_id)) {
 		if (rpc_id & (1 << 15)) {
 			call_local_native = config.call_local;
 		} else {

--- a/modules/webrtc/webrtc_multiplayer_peer.cpp
+++ b/modules/webrtc/webrtc_multiplayer_peer.cpp
@@ -59,10 +59,6 @@ MultiplayerPeer::TransferMode WebRTCMultiplayerPeer::get_packet_mode() const {
 	return channels_modes.get(next_packet_channel);
 }
 
-bool WebRTCMultiplayerPeer::is_server() const {
-	return unique_id == TARGET_PEER_SERVER;
-}
-
 void WebRTCMultiplayerPeer::poll() {
 	if (peer_map.is_empty()) {
 		return;
@@ -188,11 +184,11 @@ MultiplayerPeer::ConnectionStatus WebRTCMultiplayerPeer::get_connection_status()
 }
 
 Error WebRTCMultiplayerPeer::create_server(const Array &p_channels_config) {
-	return _initialize(1, MODE_SERVER, p_channels_config);
+	return _initialize(TARGET_PEER_SERVER, MODE_SERVER, p_channels_config);
 }
 
 Error WebRTCMultiplayerPeer::create_client(int p_self_id, const Array &p_channels_config) {
-	ERR_FAIL_COND_V_MSG(p_self_id == 1, ERR_INVALID_PARAMETER, "Clients cannot have ID 1.");
+	ERR_FAIL_COND_V_MSG(p_self_id == TARGET_PEER_SERVER, ERR_INVALID_PARAMETER, "Clients cannot have ID 'MultiplayerPeer.TARGET_PEER_SERVER'");
 	return _initialize(p_self_id, MODE_CLIENT, p_channels_config);
 }
 
@@ -287,8 +283,8 @@ Dictionary WebRTCMultiplayerPeer::get_peers() {
 
 Error WebRTCMultiplayerPeer::add_peer(const Ref<WebRTCPeerConnection> &p_peer, int p_peer_id, int p_unreliable_lifetime) {
 	ERR_FAIL_COND_V(network_mode == MODE_NONE, ERR_UNCONFIGURED);
-	ERR_FAIL_COND_V(network_mode == MODE_CLIENT && p_peer_id != 1, ERR_INVALID_PARAMETER);
-	ERR_FAIL_COND_V(network_mode == MODE_SERVER && p_peer_id == 1, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(network_mode == MODE_CLIENT && p_peer_id != TARGET_PEER_SERVER, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(network_mode == MODE_SERVER && p_peer_id == TARGET_PEER_SERVER, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_peer_id < 1 || p_peer_id > ~(1 << 31), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_unreliable_lifetime < 0, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(is_refusing_new_connections(), ERR_UNAUTHORIZED);
@@ -404,8 +400,8 @@ Error WebRTCMultiplayerPeer::put_packet(const uint8_t *p_buffer, int p_buffer_si
 		int exclude = -target_peer;
 
 		for (KeyValue<int, Ref<ConnectedPeer>> &F : peer_map) {
-			// Exclude packet. If target_peer == 0 then don't exclude any packets
-			if (target_peer != 0 && F.key == exclude) {
+			// Exclude packet. If target_peer == TARGET_PEER_BROADCAST then don't exclude any packets
+			if (target_peer != TARGET_PEER_BROADCAST && F.key == exclude) {
 				continue;
 			}
 

--- a/modules/webrtc/webrtc_multiplayer_peer.h
+++ b/modules/webrtc/webrtc_multiplayer_peer.h
@@ -113,7 +113,6 @@ public:
 	virtual int get_packet_channel() const override;
 	virtual TransferMode get_packet_mode() const override;
 
-	virtual bool is_server() const override;
 	virtual bool is_server_relay_supported() const override;
 
 	virtual void poll() override;

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -139,7 +139,7 @@ Error WebSocketMultiplayerPeer::get_packet(const uint8_t **r_buffer, int &r_buff
 Error WebSocketMultiplayerPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
 	ERR_FAIL_COND_V(get_connection_status() != CONNECTION_CONNECTED, ERR_UNCONFIGURED);
 
-	if (is_server()) {
+	if (tcp_server.is_valid()) { // We are server.
 		if (target_peer > 0) {
 			ERR_FAIL_COND_V_MSG(!peers_map.has(target_peer), ERR_INVALID_PARAMETER, "Peer not found: " + itos(target_peer));
 			get_peer(target_peer)->put_packet(p_buffer, p_buffer_size);
@@ -153,7 +153,7 @@ Error WebSocketMultiplayerPeer::put_packet(const uint8_t *p_buffer, int p_buffer
 		}
 		return OK;
 	} else {
-		return get_peer(1)->put_packet(p_buffer, p_buffer_size);
+		return get_peer(TARGET_PEER_SERVER)->put_packet(p_buffer, p_buffer_size);
 	}
 }
 
@@ -188,7 +188,7 @@ Error WebSocketMultiplayerPeer::create_server(int p_port, IPAddress p_bind_ip, c
 		tcp_server.unref();
 		return err;
 	}
-	unique_id = 1;
+	unique_id = TARGET_PEER_SERVER;
 	connection_status = CONNECTION_CONNECTED;
 	tls_server_options = p_options;
 	return OK;
@@ -205,20 +205,16 @@ Error WebSocketMultiplayerPeer::create_client(const String &p_url, const Ref<TLS
 	}
 	PendingPeer pending;
 	pending.time = OS::get_singleton()->get_ticks_msec();
-	pending_peers[1] = pending;
-	peers_map[1] = peer;
+	pending_peers[TARGET_PEER_SERVER] = pending;
+	peers_map[TARGET_PEER_SERVER] = peer;
 	connection_status = CONNECTION_CONNECTING;
 	return OK;
 }
 
-bool WebSocketMultiplayerPeer::is_server() const {
-	return tcp_server.is_valid();
-}
-
 void WebSocketMultiplayerPeer::_poll_client() {
 	ERR_FAIL_COND(connection_status == CONNECTION_DISCONNECTED); // Bug.
-	ERR_FAIL_COND(!peers_map.has(1) || peers_map[1].is_null()); // Bug.
-	Ref<WebSocketPeer> peer = peers_map[1];
+	ERR_FAIL_COND(!peers_map.has(TARGET_PEER_SERVER) || peers_map[TARGET_PEER_SERVER].is_null()); // Bug.
+	Ref<WebSocketPeer> peer = peers_map[TARGET_PEER_SERVER];
 	peer->poll(); // Update state and fetch packets.
 	WebSocketPeer::State ready_state = peer->get_ready_state();
 	if (ready_state == WebSocketPeer::STATE_OPEN) {
@@ -237,7 +233,7 @@ void WebSocketMultiplayerPeer::_poll_client() {
 					ERR_FAIL_MSG("Invalid ID received from server");
 				}
 				connection_status = CONNECTION_CONNECTED;
-				emit_signal("peer_connected", 1);
+				emit_signal("peer_connected", TARGET_PEER_SERVER);
 			} else {
 				return; // Still waiting for an ID.
 			}
@@ -253,21 +249,21 @@ void WebSocketMultiplayerPeer::_poll_client() {
 			packet.data = (uint8_t *)memalloc(size);
 			memcpy(packet.data, in_buffer, size);
 			packet.size = size;
-			packet.source = 1;
+			packet.source = TARGET_PEER_SERVER;
 			incoming_packets.push_back(packet);
 			pkts--;
 		}
 	} else if (peer->get_ready_state() == WebSocketPeer::STATE_CLOSED) {
 		if (connection_status == CONNECTION_CONNECTED) {
-			emit_signal(SNAME("peer_disconnected"), 1);
+			emit_signal(SNAME("peer_disconnected"), TARGET_PEER_SERVER);
 		}
 		_clear();
 		return;
 	}
 	if (connection_status == CONNECTION_CONNECTING) {
 		// Still connecting
-		ERR_FAIL_COND(!pending_peers.has(1)); // Bug.
-		if (OS::get_singleton()->get_ticks_msec() - pending_peers[1].time > handshake_timeout) {
+		ERR_FAIL_COND(!pending_peers.has(TARGET_PEER_SERVER)); // Bug.
+		if (OS::get_singleton()->get_ticks_msec() - pending_peers[TARGET_PEER_SERVER].time > handshake_timeout) {
 			print_verbose(vformat("WebSocket handshake timed out after %.3f seconds.", handshake_timeout * 0.001));
 			_clear();
 			return;
@@ -404,7 +400,7 @@ void WebSocketMultiplayerPeer::poll() {
 	if (connection_status == CONNECTION_DISCONNECTED) {
 		return;
 	}
-	if (is_server()) {
+	if (tcp_server.is_valid()) {
 		_poll_server();
 	} else {
 		_poll_client();
@@ -484,7 +480,7 @@ void WebSocketMultiplayerPeer::disconnect_peer(int p_peer_id, bool p_force) {
 	peers_map[p_peer_id]->close();
 	if (p_force) {
 		peers_map.erase(p_peer_id);
-		if (!is_server()) {
+		if (!tcp_server.is_valid()) { // We are not server.
 			_clear();
 		}
 	}

--- a/modules/websocket/websocket_multiplayer_peer.h
+++ b/modules/websocket/websocket_multiplayer_peer.h
@@ -96,7 +96,6 @@ public:
 	virtual bool is_server_relay_supported() const override { return true; }
 
 	virtual int get_max_packet_size() const override;
-	virtual bool is_server() const override;
 	virtual void poll() override;
 	virtual void close() override;
 	virtual void disconnect_peer(int p_peer_id, bool p_force = false) override;

--- a/scene/main/multiplayer_peer.cpp
+++ b/scene/main/multiplayer_peer.cpp
@@ -214,7 +214,6 @@ void MultiplayerPeerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_set_target_peer, "p_peer");
 
 	GDVIRTUAL_BIND(_get_packet_peer);
-	GDVIRTUAL_BIND(_is_server);
 	GDVIRTUAL_BIND(_poll);
 	GDVIRTUAL_BIND(_close);
 	GDVIRTUAL_BIND(_disconnect_peer, "p_peer", "p_force");

--- a/scene/main/multiplayer_peer.h
+++ b/scene/main/multiplayer_peer.h
@@ -81,8 +81,6 @@ public:
 
 	virtual void disconnect_peer(int p_peer, bool p_force = false) = 0;
 
-	virtual bool is_server() const = 0;
-
 	virtual void poll() = 0;
 	virtual void close() = 0;
 
@@ -135,7 +133,6 @@ public:
 	EXBIND0RC(int, get_packet_peer);
 	EXBIND0RC(TransferMode, get_packet_mode);
 	EXBIND0RC(int, get_packet_channel);
-	EXBIND0RC(bool, is_server);
 	EXBIND0(poll);
 	EXBIND0(close);
 	EXBIND2(disconnect_peer, int, bool);


### PR DESCRIPTION
I thought about the previous implementation I had and I now think that it doesn't make sense to expose `MultiplayerPeer::is_server`, or to even have it at all. This is because I think that `MultiplayerPeer.TARGET_PEER_SERVER` implies that a peer which is a server must have id 1 in order for multiplayer to behave correctly.

I removed `MultiplayerPeerExtension._is_server` as well, I tested an extension which implemented it and it didn't seem to break so I didn't add any compatibility method for it.

I also changed all the instances I could find (which make sense) to use `MultiplayerPeer::TARGET_PEER_SERVER` and `MultiplayerPeer::TARGET_PEER_BROADCAST`.