### PR TITLE
Remove unused `_get_max_packet_size`

### DIFF
--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -62,10 +62,6 @@ Error RemoteDebuggerPeerTCP::put_message(const Array &p_arr) {
 	return OK;
 }
 
-int RemoteDebuggerPeerTCP::get_max_message_size() const {
-	return 8 << 20; // 8 MiB
-}
-
 void RemoteDebuggerPeerTCP::close() {
 	running = false;
 	if (thread.is_started()) {

--- a/core/debugger/remote_debugger_peer.h
+++ b/core/debugger/remote_debugger_peer.h
@@ -45,7 +45,6 @@ protected:
 
 public:
 	virtual bool is_peer_connected() = 0;
-	virtual int get_max_message_size() const = 0;
 	virtual bool has_message() = 0;
 	virtual Error put_message(const Array &p_arr) = 0;
 	virtual Array get_message() = 0;
@@ -86,7 +85,6 @@ public:
 	static RemoteDebuggerPeer *create_unix(const String &p_uri);
 
 	bool is_peer_connected() override;
-	int get_max_message_size() const override;
 	bool has_message() override;
 	Error put_message(const Array &p_arr) override;
 	Array get_message() override;

--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -174,7 +174,6 @@ void PacketPeerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_packet, "r_buffer", "r_buffer_size");
 	GDVIRTUAL_BIND(_put_packet, "p_buffer", "p_buffer_size");
 	GDVIRTUAL_BIND(_get_available_packet_count);
-	GDVIRTUAL_BIND(_get_max_packet_size);
 }
 
 /***************/
@@ -279,10 +278,6 @@ Error PacketPeerStream::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
 	}
 
 	return peer->put_data(&output_buffer[0], p_buffer_size + 4);
-}
-
-int PacketPeerStream::get_max_packet_size() const {
-	return output_buffer.size();
 }
 
 void PacketPeerStream::set_stream_peer(const Ref<StreamPeer> &p_peer) {

--- a/core/io/packet_peer.h
+++ b/core/io/packet_peer.h
@@ -59,8 +59,6 @@ public:
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) = 0; ///< buffer is GONE after next get_packet
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) = 0;
 
-	virtual int get_max_packet_size() const = 0;
-
 	/* helpers / binders */
 
 	virtual Error get_packet_buffer(Vector<uint8_t> &r_buffer);
@@ -87,7 +85,6 @@ public:
 	GDVIRTUAL2R(Error, _put_packet, GDExtensionConstPtr<const uint8_t>, int);
 
 	EXBIND0RC(int, get_available_packet_count);
-	EXBIND0RC(int, get_max_packet_size);
 };
 
 class PacketPeerStream : public PacketPeer {
@@ -109,8 +106,6 @@ public:
 	virtual int get_available_packet_count() const override;
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override;
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
-
-	virtual int get_max_packet_size() const override;
 
 	void set_stream_peer(const Ref<StreamPeer> &p_peer);
 	Ref<StreamPeer> get_stream_peer() const;

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -169,10 +169,6 @@ Error PacketPeerUDP::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
 	return OK;
 }
 
-int PacketPeerUDP::get_max_packet_size() const {
-	return 512; // uhm maybe not
-}
-
 Error PacketPeerUDP::bind(int p_port, const IPAddress &p_bind_address, int p_recv_buffer_size) {
 	ERR_FAIL_COND_V(_sock.is_null(), ERR_UNAVAILABLE);
 	ERR_FAIL_COND_V(_sock->is_open(), ERR_ALREADY_IN_USE);

--- a/core/io/packet_peer_udp.h
+++ b/core/io/packet_peer_udp.h
@@ -88,7 +88,6 @@ public:
 	Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
 	Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override;
 	int get_available_packet_count() const override;
-	int get_max_packet_size() const override;
 	void set_broadcast_enabled(bool p_enabled);
 	Error join_multicast_group(IPAddress p_multi_address, const String &p_if_name);
 	Error leave_multicast_group(IPAddress p_multi_address, const String &p_if_name);

--- a/doc/classes/MultiplayerPeerExtension.xml
+++ b/doc/classes/MultiplayerPeerExtension.xml
@@ -35,12 +35,6 @@
 				Called when the connection status is requested on the [MultiplayerPeer] (see [method MultiplayerPeer.get_connection_status]).
 			</description>
 		</method>
-		<method name="_get_max_packet_size" qualifiers="virtual required const">
-			<return type="int" />
-			<description>
-				Called when the maximum allowed packet size (in bytes) is requested by the [MultiplayerAPI].
-			</description>
-		</method>
 		<method name="_get_packet" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="r_buffer" type="const uint8_t **" />

--- a/doc/classes/PacketPeerExtension.xml
+++ b/doc/classes/PacketPeerExtension.xml
@@ -12,11 +12,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="_get_max_packet_size" qualifiers="virtual required const">
-			<return type="int" />
-			<description>
-			</description>
-		</method>
 		<method name="_get_packet" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="r_buffer" type="const uint8_t **" />

--- a/misc/extension_api_validation/4.6-stable/GH-115991.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-115991.txt
@@ -1,0 +1,7 @@
+GH-115991
+---------
+Validate extension JSON: API was removed: classes/MultiplayerPeerExtension/methods/_get_max_packet_size
+Validate extension JSON: API was removed: classes/WebRTCDataChannelExtension/methods/_get_max_packet_size
+Validate extension JSON: API was removed: classes/PacketPeerExtension/methods/_get_max_packet_size
+
+Methods were unused and not intended to be called directly.

--- a/modules/enet/enet_multiplayer_peer.cpp
+++ b/modules/enet/enet_multiplayer_peer.cpp
@@ -414,10 +414,6 @@ Error ENetMultiplayerPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size
 	return OK;
 }
 
-int ENetMultiplayerPeer::get_max_packet_size() const {
-	return 1 << 24; // Anything is good
-}
-
 void ENetMultiplayerPeer::_pop_current_packet() {
 	if (current_packet.packet) {
 		current_packet.packet->referenceCount--;

--- a/modules/enet/enet_multiplayer_peer.h
+++ b/modules/enet/enet_multiplayer_peer.h
@@ -113,7 +113,6 @@ public:
 
 	virtual int get_unique_id() const override;
 
-	virtual int get_max_packet_size() const override;
 	virtual int get_available_packet_count() const override;
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override;
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;

--- a/modules/enet/enet_packet_peer.cpp
+++ b/modules/enet/enet_packet_peer.cpp
@@ -80,10 +80,6 @@ void ENetPacketPeer::set_timeout(int p_timeout, int p_timeout_min, int p_timeout
 	enet_peer_timeout(peer, p_timeout, p_timeout_min, p_timeout_max);
 }
 
-int ENetPacketPeer::get_max_packet_size() const {
-	return 1 << 24;
-}
-
 int ENetPacketPeer::get_available_packet_count() const {
 	return packet_queue.size();
 }

--- a/modules/enet/enet_packet_peer.h
+++ b/modules/enet/enet_packet_peer.h
@@ -94,7 +94,6 @@ public:
 		PEER_PACKET_THROTTLE_INTERVAL,
 	};
 
-	int get_max_packet_size() const override;
 	int get_available_packet_count() const override;
 	Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override; ///< buffer is GONE after next get_packet
 	Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;

--- a/modules/mbedtls/packet_peer_mbed_dtls.cpp
+++ b/modules/mbedtls/packet_peer_mbed_dtls.cpp
@@ -235,10 +235,6 @@ int PacketPeerMbedDTLS::get_available_packet_count() const {
 	return mbedtls_ssl_get_bytes_avail(&(tls_ctx->tls)) > 0 ? 1 : 0;
 }
 
-int PacketPeerMbedDTLS::get_max_packet_size() const {
-	return 488; // 512 (UDP in Godot) - 24 (DTLS header)
-}
-
 PacketPeerMbedDTLS::PacketPeerMbedDTLS() {
 	tls_ctx.instantiate();
 }

--- a/modules/mbedtls/packet_peer_mbed_dtls.h
+++ b/modules/mbedtls/packet_peer_mbed_dtls.h
@@ -74,7 +74,6 @@ public:
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size);
 
 	virtual int get_available_packet_count() const;
-	virtual int get_max_packet_size() const;
 
 	static void initialize_dtls();
 	static void finalize_dtls();

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -47,7 +47,6 @@ public:
 		return OK;
 	}
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override { return OK; }
-	virtual int get_max_packet_size() const override { return 0; }
 
 	virtual void set_target_peer(int p_peer_id) override {}
 	virtual int get_packet_peer() const override { return 0; }

--- a/modules/webrtc/doc_classes/WebRTCDataChannelExtension.xml
+++ b/modules/webrtc/doc_classes/WebRTCDataChannelExtension.xml
@@ -37,11 +37,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="_get_max_packet_size" qualifiers="virtual required const">
-			<return type="int" />
-			<description>
-			</description>
-		</method>
 		<method name="_get_max_retransmits" qualifiers="virtual required const">
 			<return type="int" />
 			<description>

--- a/modules/webrtc/webrtc_data_channel_extension.cpp
+++ b/modules/webrtc/webrtc_data_channel_extension.cpp
@@ -36,7 +36,6 @@ void WebRTCDataChannelExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_packet, "r_buffer", "r_buffer_size");
 	GDVIRTUAL_BIND(_put_packet, "p_buffer", "p_buffer_size");
 	GDVIRTUAL_BIND(_get_available_packet_count);
-	GDVIRTUAL_BIND(_get_max_packet_size);
 
 	GDVIRTUAL_BIND(_poll);
 	GDVIRTUAL_BIND(_close);

--- a/modules/webrtc/webrtc_data_channel_extension.h
+++ b/modules/webrtc/webrtc_data_channel_extension.h
@@ -63,7 +63,6 @@ public:
 
 	/** Inherited from PacketPeer: **/
 	EXBIND0RC(int, get_available_packet_count);
-	EXBIND0RC(int, get_max_packet_size);
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override; ///< buffer is GONE after next get_packet
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
 

--- a/modules/webrtc/webrtc_data_channel_js.cpp
+++ b/modules/webrtc/webrtc_data_channel_js.cpp
@@ -140,10 +140,6 @@ Error WebRTCDataChannelJS::put_packet(const uint8_t *p_buffer, int p_buffer_size
 	return OK;
 }
 
-int WebRTCDataChannelJS::get_max_packet_size() const {
-	return 1200;
-}
-
 void WebRTCDataChannelJS::set_write_mode(WriteMode p_mode) {
 	_write_mode = p_mode;
 }

--- a/modules/webrtc/webrtc_data_channel_js.h
+++ b/modules/webrtc/webrtc_data_channel_js.h
@@ -81,8 +81,6 @@ public:
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override; ///< buffer is GONE after next get_packet
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
 
-	virtual int get_max_packet_size() const override;
-
 	WebRTCDataChannelJS();
 	WebRTCDataChannelJS(int js_id);
 	~WebRTCDataChannelJS();

--- a/modules/webrtc/webrtc_multiplayer_peer.cpp
+++ b/modules/webrtc/webrtc_multiplayer_peer.cpp
@@ -433,10 +433,6 @@ int WebRTCMultiplayerPeer::get_available_packet_count() const {
 	return size;
 }
 
-int WebRTCMultiplayerPeer::get_max_packet_size() const {
-	return 1200;
-}
-
 void WebRTCMultiplayerPeer::close() {
 	peer_map.clear();
 	channels_config.clear();

--- a/modules/webrtc/webrtc_multiplayer_peer.h
+++ b/modules/webrtc/webrtc_multiplayer_peer.h
@@ -103,7 +103,6 @@ public:
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override; ///< buffer is GONE after next get_packet
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
 	virtual int get_available_packet_count() const override;
-	virtual int get_max_packet_size() const override;
 
 	// MultiplayerPeer
 	virtual void set_target_peer(int p_peer_id) override;

--- a/modules/websocket/emws_peer.h
+++ b/modules/websocket/emws_peer.h
@@ -82,7 +82,6 @@ public:
 	virtual int get_available_packet_count() const override;
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override;
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
-	virtual int get_max_packet_size() const override { return packet_buffer.size(); }
 
 	// WebSocketPeer
 	virtual Error send(const uint8_t *p_buffer, int p_buffer_size, WriteMode p_mode) override;

--- a/modules/websocket/remote_debugger_peer_websocket.cpp
+++ b/modules/websocket/remote_debugger_peer_websocket.cpp
@@ -81,11 +81,6 @@ void RemoteDebuggerPeerWebSocket::poll() {
 	}
 }
 
-int RemoteDebuggerPeerWebSocket::get_max_message_size() const {
-	ERR_FAIL_COND_V(ws_peer.is_null(), 0);
-	return ws_peer->get_max_packet_size();
-}
-
 bool RemoteDebuggerPeerWebSocket::has_message() {
 	return in_queue.size() > 0;
 }

--- a/modules/websocket/remote_debugger_peer_websocket.h
+++ b/modules/websocket/remote_debugger_peer_websocket.h
@@ -49,7 +49,6 @@ public:
 	Error connect_to_host(const String &p_uri);
 
 	bool is_peer_connected() override;
-	int get_max_message_size() const override;
 	bool has_message() override;
 	Error put_message(const Array &p_arr) override;
 	Array get_message() override;

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -174,10 +174,6 @@ int WebSocketMultiplayerPeer::get_unique_id() const {
 	return unique_id;
 }
 
-int WebSocketMultiplayerPeer::get_max_packet_size() const {
-	return get_outbound_buffer_size() - PROTO_SIZE;
-}
-
 Error WebSocketMultiplayerPeer::create_server(int p_port, IPAddress p_bind_ip, const Ref<TLSOptions> &p_options) {
 	ERR_FAIL_COND_V(get_connection_status() != CONNECTION_DISCONNECTED, ERR_ALREADY_IN_USE);
 	ERR_FAIL_COND_V(p_options.is_valid() && !p_options->is_server(), ERR_INVALID_PARAMETER);

--- a/modules/websocket/websocket_multiplayer_peer.h
+++ b/modules/websocket/websocket_multiplayer_peer.h
@@ -95,7 +95,6 @@ public:
 	virtual int get_unique_id() const override;
 	virtual bool is_server_relay_supported() const override { return true; }
 
-	virtual int get_max_packet_size() const override;
 	virtual bool is_server() const override;
 	virtual void poll() override;
 	virtual void close() override;

--- a/modules/websocket/wsl_peer.h
+++ b/modules/websocket/wsl_peer.h
@@ -139,7 +139,6 @@ public:
 	virtual int get_available_packet_count() const override;
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override;
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
-	virtual int get_max_packet_size() const override { return packet_buffer.size(); }
 
 	// WebSocketPeer
 	virtual Error send(const uint8_t *p_buffer, int p_buffer_size, WriteMode p_mode) override;

--- a/scene/main/multiplayer_peer.cpp
+++ b/scene/main/multiplayer_peer.cpp
@@ -197,7 +197,6 @@ void MultiplayerPeerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_packet, "r_buffer", "r_buffer_size");
 	GDVIRTUAL_BIND(_put_packet, "p_buffer", "p_buffer_size");
 	GDVIRTUAL_BIND(_get_available_packet_count);
-	GDVIRTUAL_BIND(_get_max_packet_size);
 
 	GDVIRTUAL_BIND(_get_packet_script)
 	GDVIRTUAL_BIND(_put_packet_script, "p_buffer");

--- a/scene/main/multiplayer_peer.h
+++ b/scene/main/multiplayer_peer.h
@@ -115,7 +115,6 @@ public:
 	GDVIRTUAL1R(Error, _put_packet_script, PackedByteArray); // For GDScript.
 
 	EXBIND0RC(int, get_available_packet_count);
-	EXBIND0RC(int, get_max_packet_size);
 
 	/* MultiplayerPeer extension */
 	virtual void set_refuse_new_connections(bool p_enable) override;


### PR DESCRIPTION
`get_max_packet_size()` and one method that calls it are not used anywhere in the engine, and are not exposed. `_get_max_packet_size()` is currently required to be implemented in a few `*Extension` classes even though it is never used and you can't get it from any other implementations of said classes because `get_max_packet_size()` is not exposed anywhere.

I tried using an extension which implements `MultiplayerPeerExtension` and it didn't seem to break after removing the methods so I didn't add a compatibility method.