### PR TITLE
Fix AHashMap realloc cause AnimationPlayer crash, second try

### DIFF
--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -65,20 +65,22 @@ private:
 	bool is_stopping = false;
 
 	struct PlaybackData {
-		AnimationData *from = nullptr;
+		bool is_enabled = false;
+		String animation_name;
+		double animation_length = 0.0;
 		double pos = 0.0;
 		float speed_scale = 1.0;
 		double start_time = 0.0;
 		double end_time = 0.0;
 		double get_start_time() const {
-			if (from && (Animation::is_less_approx(start_time, 0) || Animation::is_greater_approx(start_time, from->animation->get_length()))) {
+			if (is_enabled && (Animation::is_less_approx(start_time, 0) || Animation::is_greater_approx(start_time, animation_length))) {
 				return 0;
 			}
 			return start_time;
 		}
 		double get_end_time() const {
-			if (from && (Animation::is_less_approx(end_time, 0) || Animation::is_greater_approx(end_time, from->animation->get_length()))) {
-				return from->animation->get_length();
+			if (is_enabled && (Animation::is_less_approx(end_time, 0) || Animation::is_greater_approx(end_time, animation_length))) {
+				return animation_length;
 			}
 			return end_time;
 		}


### PR DESCRIPTION
- Fixes: https://github.com/godotengine/godot/issues/112038
- Related: https://github.com/godotengine/godot/pull/113039
- Related: https://github.com/godotengine/godot/issues/113165

# Issue Description

As mentioned in #113039, It is possible to rellocate memory when auto growing using `AHashMap`. So we shouldnot using `AHashMap` to store reference.

And as metioned in  [the comments of #113039](https://github.com/godotengine/godot/pull/113039#pullrequestreview-3503262891). We decided to keep `AHashMap` to improve performance and let `AHashMap` store `animation_name` except the reference of animation.

# Test Cases

https://github.com/godotengine/godot/issues/112038#issuecomment-3541837783

[anim-map-crash-1.webm](https://github.com/user-attachments/assets/894d1176-01ad-4fbf-96d0-d090152583f1)

https://github.com/godotengine/godot/issues/113165#issue-3664653936

[anim-map-crash-2.webm](https://github.com/user-attachments/assets/2c5f8f93-1e85-4707-b90e-aeda9a822403)

# Etc

After testing some projects, I find we need not check `animation_name` equals `stop`.  Please give me some suggestions. @TokageItLab 