### PR TITLE
Fix `set_process_thread_group()` and transform notification of threaded-processing Node3Ds.

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1096,10 +1096,6 @@ void Node::_remove_tree_from_process_thread_group() {
 }
 
 void Node::_add_tree_to_process_thread_group(Node *p_owner) {
-	if (_is_any_processing()) {
-		_add_to_process_thread_group();
-	}
-
 	data.process_thread_group_owner = p_owner;
 	if (p_owner != nullptr) {
 		data.process_group = p_owner->data.process_group;
@@ -1107,12 +1103,16 @@ void Node::_add_tree_to_process_thread_group(Node *p_owner) {
 		data.process_group = &data.tree->default_process_group;
 	}
 
+	if (_is_any_processing()) {
+		_add_to_process_thread_group();
+	}
+
 	for (KeyValue<StringName, Node *> &K : data.children) {
 		if (K.value->data.process_thread_group != PROCESS_THREAD_GROUP_INHERIT) {
 			continue;
 		}
 
-		K.value->_add_to_process_thread_group();
+		K.value->_add_tree_to_process_thread_group(p_owner);
 	}
 }
 bool Node::is_processing_internal() const {


### PR DESCRIPTION
Fixes [issue#115999](https://github.com/godotengine/godot/issues/115999). The MRP of that issue should now have correct behavior when the commit of this PR is applied.

Behavior with this PR (in either case):

https://github.com/user-attachments/assets/b4c0bf93-785c-4099-8cc8-f28698f251df

## Explanation

Technically, there are two different problems here. But they are highly correlated in actual use cases, so I decided to make a single issue and a single PR. I am going to explain the cause and fix of the two cases described in the issue one by one:

### Case 1, Multiple Node Subtrees using Threaded Processing

When multiple node trees are using threaded processing, visual transform of the meshes randomly get stuck.

`VisualInstance3D`, along with some other `Node3D` based nodes, rely on the transform changed notification to function properly. They update transform of corresponding instances in the rendering server when notified.

Under the hood, they register their own `xform_change` field to a global registry `SceneTree::xform_change_list` when their transform is changed via code, and the `SceneTree` would scan the global registry after all processing is done for a given frame, and issue the notifications accordingly.

The problem is, `SceneTree::xform_change_list` is not thread-safe to modify. The original code checks `is_accessible_from_caller_thread()` to decide whether the operation of adding `xform_change` to `SceneTree::xform_change_list` should be deferred or not.

This would only trigger when we e.g. change the transform of a node in main thread, and it has a child in another thread. When multiple threads are running in parallel, they are free to attempt to modify `SceneTree::xform_change_list` concurrently because `is_accessible_from_caller_thread()` is true for each of them. This leads to a race condition, resulting in `SceneTree::xform_change_list`, which is a linked list, being dangerously malformed.

By checking `Thread::is_main_thread()` instead, this PR defers every attempt to modify `SceneTree::xform_change_list` from threaded nodes to the main thread, resolving the race condition.

### Case 2, Setting `process_thread_group` in Code

Setting `process_thread_group` in the code at runtime does not yield the expected behavior. Namely, the child nodes are not properly setup to reside in the same thread group.

The origin of this problem seems like a typo in the codebase, `Node::_add_tree_to_process_thread_group()` is not recursively modifying the child nodes as expected (instead of calling `_add_tree_to_process_thread_group` of its children, it called `_add_to_process_thread_group`).

This PR changed it and rearranged its code so that some internal info is properly setup before registering to the thread group.