### PR TITLE
Display document with bilingual comparison

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1629,6 +1629,9 @@
 		<member name="text_editor/external/use_external_editor" type="bool" setter="" getter="">
 			If [code]true[/code], uses an external editor instead of the built-in Script Editor. See also [member text_editor/external/exec_path] and [member text_editor/external/exec_flags].
 		</member>
+		<member name="text_editor/help/bilingual_translation_bg_color" type="Color" setter="" getter="">
+			The translated text's background color in the class reference if [member text_editor/help/show_help_bilingual] is [code]true[/code].
+		</member>
 		<member name="text_editor/help/class_reference_examples" type="int" setter="" getter="">
 			Controls which multi-line code blocks should be displayed in the editor help. This setting does not affect single-line code literals in the editor help.
 		</member>
@@ -1640,6 +1643,12 @@
 		</member>
 		<member name="text_editor/help/help_title_font_size" type="int" setter="" getter="">
 			The font size to use for headings in the editor help (built-in class reference).
+		</member>
+		<member name="text_editor/help/show_help_bilingual" type="bool" setter="" getter="">
+			If [code]true[/code], the documentation description will be displayed alternately line by line in bilingual format if its translation is available.
+			[b]Note:[/b] If the source line is the same as its translated line (possibly due to missing translation), it will only be displayed once.
+			[b]Note:[/b] For text within code blocks and links to online tutorials, only their translations will be used when available.
+			[b]Note:[/b] Text used for online tutorials or prompts, if the translation is available, the original text and its translation will be separated using [code] - [/code] to ensure that the merged text appears on the same line.
 		</member>
 		<member name="text_editor/help/show_help_index" type="bool" setter="" getter="">
 			If [code]true[/code], displays a table of contents at the left of the editor help (at the location where the members overview would appear when editing a script).

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -535,7 +535,7 @@ void EditorHelp::_add_type_icon(const String &p_type, int p_size, const String &
 
 // Macros for displaying the deprecated/experimental info in class member descriptions.
 
-#define DEPRECATED_DOC_MSG(m_message, m_default_message) \
+#define DEPRECATED_DOC_MSG(m_message, m_is_native, m_default_prompt) \
 	Ref<Texture2D> error_icon = get_editor_theme_icon(SNAME("StatusError")); \
 	class_desc->add_image(error_icon, error_icon->get_width(), error_icon->get_height()); \
 	class_desc->add_text(nbsp); \
@@ -545,13 +545,14 @@ void EditorHelp::_add_type_icon(const String &p_type, int p_size, const String &
 	class_desc->pop(); \
 	class_desc->pop(); \
 	class_desc->add_text(" "); \
-	if ((m_message).is_empty()) { \
-		class_desc->add_text(m_default_message); \
+	const String formatted_prompt = _format_doc_desc(m_message, m_is_native); \
+	if (formatted_prompt.is_empty()) { \
+		_add_text(m_default_prompt, false); \
 	} else { \
-		_add_text(m_message); \
+		_add_text(formatted_prompt); \
 	}
 
-#define EXPERIMENTAL_DOC_MSG(m_message, m_default_message) \
+#define EXPERIMENTAL_DOC_MSG(m_message, m_is_native, m_default_prompt) \
 	Ref<Texture2D> warning_icon = get_editor_theme_icon(SNAME("NodeWarning")); \
 	class_desc->add_image(warning_icon, warning_icon->get_width(), warning_icon->get_height()); \
 	class_desc->add_text(nbsp); \
@@ -561,10 +562,11 @@ void EditorHelp::_add_type_icon(const String &p_type, int p_size, const String &
 	class_desc->pop(); \
 	class_desc->pop(); \
 	class_desc->add_text(" "); \
-	if ((m_message).is_empty()) { \
-		class_desc->add_text(m_default_message); \
+	const String formatted_prompt = _format_doc_desc(m_message, m_is_native); \
+	if (formatted_prompt.is_empty()) { \
+		_add_text(m_default_prompt, false); \
 	} else { \
-		_add_text(m_message); \
+		_add_text(formatted_prompt); \
 	}
 
 void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview, bool p_override) {
@@ -755,6 +757,75 @@ Error EditorHelp::_goto_desc(const String &p_class, bool p_can_trigger_save_hist
 	return OK;
 }
 
+String EditorHelp::_combine_to_bilingual(const String &p_string, const String &p_translation, bool p_inline) const {
+	Vector<String> source_lines = p_string.split("\n");
+	Vector<String> translation_lines = p_translation.split("\n");
+
+	ERR_FAIL_COND_V(source_lines.size() != translation_lines.size(), p_translation);
+
+	const Color bilingual_tr_bg_color = EDITOR_GET("text_editor/help/bilingual_translation_bg_color");
+	const String tr_bg_color_tag = vformat("[bgcolor=%s]", bilingual_tr_bg_color.to_html());
+
+	StringBuilder sb;
+	bool in_codeblock = false;
+
+	for (int i = 0; i < source_lines.size(); i++) {
+		if (i > 0) {
+			sb.append("\n");
+		}
+
+		const String &source_line = source_lines[i];
+		const String &translation_line = translation_lines[i];
+
+		if (source_line.begins_with("[codeblock")) {
+			in_codeblock = true;
+		} else if (source_line.begins_with("[/codeblock")) {
+			in_codeblock = false;
+		}
+
+		if (in_codeblock || (p_inline && (source_line.begins_with("https://") || source_line.begins_with("http://")))) {
+			sb.append(translation_line);
+			continue;
+		}
+
+		sb.append(source_line);
+
+		if (source_line == translation_line) {
+			continue;
+		}
+
+		sb.append(p_inline ? " - " : "\n");
+
+		sb.append(tr_bg_color_tag);
+		sb.append(translation_line);
+		sb.append("[/bgcolor]");
+	}
+	return sb.as_string();
+}
+
+String EditorHelp::_format_doc_desc(const String &p_string, bool p_is_native, bool p_inline) const {
+	if (!p_is_native) {
+		return p_string.strip_edges();
+	}
+
+	if (!bilingual) {
+		return DTR(p_string);
+	}
+
+	const String source_formatted = p_string.dedent().strip_edges().replace("$DOCS_URL", GODOT_VERSION_DOCS_URL);
+	const String translation = DTR(p_string);
+	return _combine_to_bilingual(source_formatted, translation, p_inline);
+}
+
+String EditorHelp::_format_editor_prompt(const String &p_string) const {
+	if (!bilingual) {
+		return TTRGET(p_string);
+	}
+
+	const String translation = TTRGET(p_string);
+	return _combine_to_bilingual(p_string, translation, true);
+}
+
 void EditorHelp::_update_method_list(MethodType p_method_type, const Vector<DocData::MethodDoc> &p_methods) {
 	class_desc->add_newline();
 	class_desc->add_newline();
@@ -768,7 +839,7 @@ void EditorHelp::_update_method_list(MethodType p_method_type, const Vector<DocD
 
 	section_line.push_back(Pair<String, int>(title, class_desc->get_paragraph_count() - 2));
 	_push_title_font();
-	class_desc->add_text(title);
+	_add_text(titles_by_type[p_method_type], false);
 	_pop_title_font();
 
 	class_desc->add_newline();
@@ -827,8 +898,6 @@ void EditorHelp::_update_method_list(MethodType p_method_type, const Vector<DocD
 }
 
 void EditorHelp::_update_method_descriptions(const DocData::ClassDoc &p_classdoc, MethodType p_method_type, const Vector<DocData::MethodDoc> &p_methods) {
-#define HANDLE_DOC(m_string) ((p_classdoc.is_script_doc ? (m_string) : DTR(m_string)).strip_edges())
-
 	class_desc->add_newline();
 	class_desc->add_hr(100, 2, theme_cache.primary_hr_color);
 	class_desc->add_newline();
@@ -842,7 +911,7 @@ void EditorHelp::_update_method_descriptions(const DocData::ClassDoc &p_classdoc
 
 	section_line.push_back(Pair<String, int>(title, class_desc->get_paragraph_count() - 2));
 	_push_title_font();
-	class_desc->add_text(title);
+	_add_text(titles_by_type[p_method_type], false);
 	_pop_title_font();
 
 	String link_color_text = theme_cache.title_color.to_html(false);
@@ -890,7 +959,7 @@ void EditorHelp::_update_method_descriptions(const DocData::ClassDoc &p_classdoc
 					TTRC("This constructor may be changed or removed in future versions."),
 					TTRC("This operator may be changed or removed in future versions."),
 				};
-				DEPRECATED_DOC_MSG(HANDLE_DOC(method.deprecated_message), TTRGET(messages_by_type[p_method_type]));
+				DEPRECATED_DOC_MSG(method.deprecated_message, !p_classdoc.is_script_doc, messages_by_type[p_method_type]);
 			}
 
 			if (method.is_experimental) {
@@ -904,7 +973,7 @@ void EditorHelp::_update_method_descriptions(const DocData::ClassDoc &p_classdoc
 					TTRC("This constructor may be changed or removed in future versions."),
 					TTRC("This operator may be changed or removed in future versions."),
 				};
-				EXPERIMENTAL_DOC_MSG(HANDLE_DOC(method.experimental_message), TTRGET(messages_by_type[p_method_type]));
+				EXPERIMENTAL_DOC_MSG(method.experimental_message, !p_classdoc.is_script_doc, messages_by_type[p_method_type]);
 			}
 
 			if (!method.errors_returned.is_empty()) {
@@ -913,7 +982,7 @@ void EditorHelp::_update_method_descriptions(const DocData::ClassDoc &p_classdoc
 				}
 				has_prev_text = true;
 
-				class_desc->add_text(TTR("Error codes returned:"));
+				_add_text(TTRC("Error codes returned:"), false);
 				class_desc->add_newline();
 				class_desc->push_list(1, RichTextLabel::LIST_DOTS, false);
 				for (int j = 0; j < method.errors_returned.size(); j++) {
@@ -937,7 +1006,7 @@ void EditorHelp::_update_method_descriptions(const DocData::ClassDoc &p_classdoc
 				class_desc->pop(); // list
 			}
 
-			const String descr = HANDLE_DOC(method.description);
+			const String descr = _format_doc_desc(method.description, !p_classdoc.is_script_doc, false);
 			const bool is_documented = method.is_deprecated || method.is_experimental || !descr.is_empty();
 			if (!descr.is_empty()) {
 				if (has_prev_text) {
@@ -952,27 +1021,26 @@ void EditorHelp::_update_method_descriptions(const DocData::ClassDoc &p_classdoc
 				}
 				has_prev_text = true;
 
-				String message;
+				class_desc->add_image(get_editor_theme_icon(SNAME("Error")));
+				class_desc->add_text(" ");
+				class_desc->push_color(theme_cache.comment_color);
+
 				if (p_classdoc.is_script_doc) {
 					static const char *messages_by_type[METHOD_TYPE_MAX] = {
 						TTRC("There is currently no description for this method."),
 						TTRC("There is currently no description for this constructor."),
 						TTRC("There is currently no description for this operator."),
 					};
-					message = TTRGET(messages_by_type[p_method_type]);
+					_add_text(messages_by_type[p_method_type], false);
 				} else {
 					static const char *messages_by_type[METHOD_TYPE_MAX] = {
 						TTRC("There is currently no description for this method. Please help us by [color=$color][url=$url]contributing one[/url][/color]!"),
 						TTRC("There is currently no description for this constructor. Please help us by [color=$color][url=$url]contributing one[/url][/color]!"),
 						TTRC("There is currently no description for this operator. Please help us by [color=$color][url=$url]contributing one[/url][/color]!"),
 					};
-					message = TTRGET(messages_by_type[p_method_type]).replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text);
+					class_desc->append_text(_format_editor_prompt(messages_by_type[p_method_type]).replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text));
 				}
 
-				class_desc->add_image(get_editor_theme_icon(SNAME("Error")));
-				class_desc->add_text(" ");
-				class_desc->push_color(theme_cache.comment_color);
-				class_desc->append_text(message);
 				class_desc->pop(); // color
 			}
 
@@ -981,8 +1049,6 @@ void EditorHelp::_update_method_descriptions(const DocData::ClassDoc &p_classdoc
 			class_desc->pop(); // indent
 		}
 	}
-
-#undef HANDLE_DOC
 }
 
 void EditorHelp::_update_doc() {
@@ -1001,8 +1067,6 @@ void EditorHelp::_update_doc() {
 
 	DocData::ClassDoc cd = doc->class_list[edited_class]; // Make a copy, so we can sort without worrying.
 
-#define HANDLE_DOC(m_string) ((cd.is_script_doc ? (m_string) : DTR(m_string)).strip_edges())
-
 	// Class name
 
 	_push_title_font();
@@ -1019,12 +1083,12 @@ void EditorHelp::_update_doc() {
 
 	if (cd.is_deprecated) {
 		class_desc->add_newline();
-		DEPRECATED_DOC_MSG(HANDLE_DOC(cd.deprecated_message), TTR("This class may be changed or removed in future versions."));
+		DEPRECATED_DOC_MSG(cd.deprecated_message, !cd.is_script_doc, TTRC("This class may be changed or removed in future versions."));
 	}
 
 	if (cd.is_experimental) {
 		class_desc->add_newline();
-		EXPERIMENTAL_DOC_MSG(HANDLE_DOC(cd.experimental_message), TTR("This class may be changed or removed in future versions."));
+		EXPERIMENTAL_DOC_MSG(cd.experimental_message, !cd.is_script_doc, TTRC("This class may be changed or removed in future versions."));
 	}
 
 	// Inheritance tree
@@ -1085,11 +1149,11 @@ void EditorHelp::_update_doc() {
 	section_line.push_back(Pair<String, int>(TTR("Description"), class_desc->get_paragraph_count() - 2));
 	description_line = class_desc->get_paragraph_count() - 2;
 	_push_title_font();
-	class_desc->add_text(TTR("Description"));
+	_add_text(TTRC("Description"), false);
 	_pop_title_font();
 
-	const String brief_class_descr = HANDLE_DOC(cd.brief_description);
-	const String class_descr = HANDLE_DOC(cd.description);
+	const String brief_class_descr = _format_doc_desc(cd.brief_description, !cd.is_script_doc, false);
+	const String class_descr = _format_doc_desc(cd.description, !cd.is_script_doc, false);
 	if (!brief_class_descr.is_empty() || !class_descr.is_empty()) {
 		if (!brief_class_descr.is_empty()) {
 			class_desc->add_newline();
@@ -1124,9 +1188,9 @@ void EditorHelp::_update_doc() {
 
 		class_desc->push_color(theme_cache.comment_color);
 		if (cd.is_script_doc) {
-			class_desc->add_text(TTR("There is currently no description for this class."));
+			_add_text(TTRC("There is currently no description for this class."), false);
 		} else {
-			class_desc->append_text(TTR("There is currently no description for this class. Please help us by [color=$color][url=$url]contributing one[/url][/color]!").replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text));
+			class_desc->append_text(_format_editor_prompt(TTRC("There is currently no description for this class. Please help us by [color=$color][url=$url]contributing one[/url][/color]!")).replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text));
 		}
 		class_desc->pop(); // color
 
@@ -1157,7 +1221,7 @@ void EditorHelp::_update_doc() {
 		section_line.push_back(Pair<String, int>(TTR("Online Tutorials"), class_desc->get_paragraph_count() - 2));
 		description_line = class_desc->get_paragraph_count() - 2;
 		_push_title_font();
-		class_desc->add_text(TTR("Online Tutorials"));
+		_add_text(TTRC("Online Tutorials"), false);
 		_pop_title_font();
 
 		class_desc->add_newline();
@@ -1168,9 +1232,9 @@ void EditorHelp::_update_doc() {
 
 		bool is_first_tutorial = true;
 		for (const DocData::TutorialDoc &tutorial : cd.tutorials) {
-			const String link = HANDLE_DOC(tutorial.link);
+			const String link = _format_doc_desc(tutorial.link, !cd.is_script_doc);
 
-			String link_text = HANDLE_DOC(tutorial.title);
+			String link_text = _format_doc_desc(tutorial.title, !cd.is_script_doc);
 			if (link_text.is_empty()) {
 				const int sep_pos = link.find("//");
 				if (sep_pos >= 0) {
@@ -1219,7 +1283,7 @@ void EditorHelp::_update_doc() {
 
 		section_line.push_back(Pair<String, int>(TTR("Properties"), class_desc->get_paragraph_count() - 2));
 		_push_title_font();
-		class_desc->add_text(TTR("Properties"));
+		_add_text(TTRC("Properties"), false);
 		_pop_title_font();
 
 		class_desc->add_newline();
@@ -1433,17 +1497,17 @@ void EditorHelp::_update_doc() {
 
 		section_line.push_back(Pair<String, int>(TTR("Theme Properties"), class_desc->get_paragraph_count() - 2));
 		_push_title_font();
-		class_desc->add_text(TTR("Theme Properties"));
+		_add_text(TTRC("Theme Properties"), false);
 		_pop_title_font();
 
 		String theme_data_type;
 		HashMap<String, String> data_type_names;
-		data_type_names["color"] = TTR("Colors");
-		data_type_names["constant"] = TTR("Constants");
-		data_type_names["font"] = TTR("Fonts");
-		data_type_names["font_size"] = TTR("Font Sizes");
-		data_type_names["icon"] = TTR("Icons");
-		data_type_names["style"] = TTR("Styles");
+		data_type_names["color"] = TTRC("Colors");
+		data_type_names["constant"] = TTRC("Constants");
+		data_type_names["font"] = TTRC("Fonts");
+		data_type_names["font_size"] = TTRC("Font Sizes");
+		data_type_names["icon"] = TTRC("Icons");
+		data_type_names["style"] = TTRC("Styles");
 
 		for (const DocData::ThemeItemDoc &theme_item : cd.theme_properties) {
 			if (theme_data_type != theme_item.data_type) {
@@ -1455,7 +1519,7 @@ void EditorHelp::_update_doc() {
 				_push_title_font();
 
 				if (data_type_names.has(theme_data_type)) {
-					class_desc->add_text(data_type_names[theme_data_type]);
+					_add_text(data_type_names[theme_data_type], false);
 				} else {
 					class_desc->add_text(theme_data_type);
 				}
@@ -1509,7 +1573,7 @@ void EditorHelp::_update_doc() {
 
 			if (theme_item.is_deprecated) {
 				has_prev_text = true;
-				DEPRECATED_DOC_MSG(HANDLE_DOC(theme_item.deprecated_message), TTR("This theme property may be changed or removed in future versions."));
+				DEPRECATED_DOC_MSG(theme_item.deprecated_message, !cd.is_script_doc, TTRC("This theme property may be changed or removed in future versions."));
 			}
 
 			if (theme_item.is_experimental) {
@@ -1517,10 +1581,10 @@ void EditorHelp::_update_doc() {
 					class_desc->add_newline();
 				}
 				has_prev_text = true;
-				EXPERIMENTAL_DOC_MSG(HANDLE_DOC(theme_item.experimental_message), TTR("This theme property may be changed or removed in future versions."));
+				EXPERIMENTAL_DOC_MSG(theme_item.experimental_message, !cd.is_script_doc, TTRC("This theme property may be changed or removed in future versions."));
 			}
 
-			const String descr = HANDLE_DOC(theme_item.description);
+			const String descr = _format_doc_desc(theme_item.description, !cd.is_script_doc, false);
 			if (!descr.is_empty()) {
 				if (has_prev_text) {
 					class_desc->add_newline();
@@ -1532,9 +1596,9 @@ void EditorHelp::_update_doc() {
 				class_desc->add_text(" ");
 				class_desc->push_color(theme_cache.comment_color);
 				if (cd.is_script_doc) {
-					class_desc->add_text(TTR("There is currently no description for this theme property."));
+					_add_text(TTRC("There is currently no description for this theme property."), false);
 				} else {
-					class_desc->append_text(TTR("There is currently no description for this theme property. Please help us by [color=$color][url=$url]contributing one[/url][/color]!").replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text));
+					class_desc->append_text(_format_editor_prompt(TTRC("There is currently no description for this theme property. Please help us by [color=$color][url=$url]contributing one[/url][/color]!")).replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text));
 				}
 				class_desc->pop(); // color
 			}
@@ -1571,7 +1635,7 @@ void EditorHelp::_update_doc() {
 
 				section_line.push_back(Pair<String, int>(TTR("Signals"), class_desc->get_paragraph_count() - 2));
 				_push_title_font();
-				class_desc->add_text(TTR("Signals"));
+				_add_text(TTRC("Signals"), false);
 				_pop_title_font();
 			}
 
@@ -1641,12 +1705,12 @@ void EditorHelp::_update_doc() {
 			_push_normal_font();
 			class_desc->push_color(theme_cache.comment_color);
 
-			const String descr = HANDLE_DOC(signal.description);
+			const String descr = _format_doc_desc(signal.description, !cd.is_script_doc, false);
 			bool has_prev_text = false;
 
 			if (signal.is_deprecated) {
 				has_prev_text = true;
-				DEPRECATED_DOC_MSG(HANDLE_DOC(signal.deprecated_message), TTR("This signal may be changed or removed in future versions."));
+				DEPRECATED_DOC_MSG(signal.deprecated_message, !cd.is_script_doc, TTRC("This signal may be changed or removed in future versions."));
 			}
 
 			if (signal.is_experimental) {
@@ -1654,7 +1718,7 @@ void EditorHelp::_update_doc() {
 					class_desc->add_newline();
 				}
 				has_prev_text = true;
-				EXPERIMENTAL_DOC_MSG(HANDLE_DOC(signal.experimental_message), TTR("This signal may be changed or removed in future versions."));
+				EXPERIMENTAL_DOC_MSG(signal.experimental_message, !cd.is_script_doc, TTRC("This signal may be changed or removed in future versions."));
 			}
 
 			if (!descr.is_empty()) {
@@ -1668,9 +1732,9 @@ void EditorHelp::_update_doc() {
 				class_desc->add_text(" ");
 				class_desc->push_color(theme_cache.comment_color);
 				if (cd.is_script_doc) {
-					class_desc->add_text(TTR("There is currently no description for this signal."));
+					_add_text(TTRC("There is currently no description for this signal."), false);
 				} else {
-					class_desc->append_text(TTR("There is currently no description for this signal. Please help us by [color=$color][url=$url]contributing one[/url][/color]!").replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text));
+					class_desc->append_text(_format_editor_prompt(TTRC("There is currently no description for this signal. Please help us by [color=$color][url=$url]contributing one[/url][/color]!")).replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text));
 				}
 				class_desc->pop(); // color
 			}
@@ -1721,7 +1785,7 @@ void EditorHelp::_update_doc() {
 
 			section_line.push_back(Pair<String, int>(TTR("Enumerations"), class_desc->get_paragraph_count() - 2));
 			_push_title_font();
-			class_desc->add_text(TTR("Enumerations"));
+			_add_text(TTRC("Enumerations"), false);
 			_pop_title_font();
 
 			bool is_first_enum = true;
@@ -1769,7 +1833,7 @@ void EditorHelp::_update_doc() {
 
 				// Enum description.
 				if (key != "@unnamed_enums" && cd.enums.has(key)) {
-					const String descr = HANDLE_DOC(cd.enums[key].description);
+					const String descr = _format_doc_desc(cd.enums[key].description, !cd.is_script_doc, false);
 					if (cd.enums[key].is_deprecated || cd.enums[key].is_experimental || !descr.is_empty()) {
 						class_desc->add_newline();
 
@@ -1781,7 +1845,7 @@ void EditorHelp::_update_doc() {
 
 						if (cd.enums[key].is_deprecated) {
 							has_prev_text = true;
-							DEPRECATED_DOC_MSG(HANDLE_DOC(cd.enums[key].deprecated_message), TTR("This enumeration may be changed or removed in future versions."));
+							DEPRECATED_DOC_MSG(cd.enums[key].deprecated_message, !cd.is_script_doc, TTRC("This enumeration may be changed or removed in future versions."));
 						}
 
 						if (cd.enums[key].is_experimental) {
@@ -1789,7 +1853,7 @@ void EditorHelp::_update_doc() {
 								class_desc->add_newline();
 							}
 							has_prev_text = true;
-							EXPERIMENTAL_DOC_MSG(HANDLE_DOC(cd.enums[key].experimental_message), TTR("This enumeration may be changed or removed in future versions."));
+							EXPERIMENTAL_DOC_MSG(cd.enums[key].experimental_message, !cd.is_script_doc, TTRC("This enumeration may be changed or removed in future versions."));
 						}
 
 						if (!descr.is_empty()) {
@@ -1810,7 +1874,7 @@ void EditorHelp::_update_doc() {
 				const int enum_start_line = enum_line[E.key];
 
 				for (const DocData::ConstantDoc &enum_value : E.value) {
-					const String descr = HANDLE_DOC(enum_value.description);
+					const String descr = _format_doc_desc(enum_value.description, !cd.is_script_doc, false);
 
 					class_desc->add_newline();
 
@@ -1853,7 +1917,7 @@ void EditorHelp::_update_doc() {
 
 						if (enum_value.is_deprecated) {
 							has_prev_text = true;
-							DEPRECATED_DOC_MSG(HANDLE_DOC(enum_value.deprecated_message), TTR("This constant may be changed or removed in future versions."));
+							DEPRECATED_DOC_MSG(enum_value.deprecated_message, !cd.is_script_doc, TTRC("This constant may be changed or removed in future versions."));
 						}
 
 						if (enum_value.is_experimental) {
@@ -1861,7 +1925,7 @@ void EditorHelp::_update_doc() {
 								class_desc->add_newline();
 							}
 							has_prev_text = true;
-							EXPERIMENTAL_DOC_MSG(HANDLE_DOC(enum_value.experimental_message), TTR("This constant may be changed or removed in future versions."));
+							EXPERIMENTAL_DOC_MSG(enum_value.experimental_message, !cd.is_script_doc, TTRC("This constant may be changed or removed in future versions."));
 						}
 
 						if (!descr.is_empty()) {
@@ -1894,12 +1958,12 @@ void EditorHelp::_update_doc() {
 
 			section_line.push_back(Pair<String, int>(TTR("Constants"), class_desc->get_paragraph_count() - 2));
 			_push_title_font();
-			class_desc->add_text(TTR("Constants"));
+			_add_text(TTRC("Constants"), false);
 			_pop_title_font();
 
 			bool is_first_constant = true;
 			for (const DocData::ConstantDoc &constant : constants) {
-				const String descr = HANDLE_DOC(constant.description);
+				const String descr = _format_doc_desc(constant.description, !cd.is_script_doc, false);
 
 				class_desc->add_newline();
 				if (is_first_constant) {
@@ -1952,7 +2016,7 @@ void EditorHelp::_update_doc() {
 
 					if (constant.is_deprecated) {
 						has_prev_text = true;
-						DEPRECATED_DOC_MSG(HANDLE_DOC(constant.deprecated_message), TTR("This constant may be changed or removed in future versions."));
+						DEPRECATED_DOC_MSG(constant.deprecated_message, !cd.is_script_doc, TTRC("This constant may be changed or removed in future versions."));
 					}
 
 					if (constant.is_experimental) {
@@ -1960,7 +2024,7 @@ void EditorHelp::_update_doc() {
 							class_desc->add_newline();
 						}
 						has_prev_text = true;
-						EXPERIMENTAL_DOC_MSG(HANDLE_DOC(constant.experimental_message), TTR("This constant may be changed or removed in future versions."));
+						EXPERIMENTAL_DOC_MSG(constant.experimental_message, !cd.is_script_doc, TTRC("This constant may be changed or removed in future versions."));
 					}
 
 					if (!descr.is_empty()) {
@@ -1991,7 +2055,7 @@ void EditorHelp::_update_doc() {
 
 		section_line.push_back(Pair<String, int>(TTR("Annotations"), class_desc->get_paragraph_count() - 2));
 		_push_title_font();
-		class_desc->add_text(TTR("Annotations"));
+		_add_text(TTRC("Annotations"), false);
 		_pop_title_font();
 
 		bool is_first_annotation = true;
@@ -2097,7 +2161,7 @@ void EditorHelp::_update_doc() {
 			_push_normal_font();
 			class_desc->push_color(theme_cache.comment_color);
 
-			const String descr = HANDLE_DOC(annotation.description);
+			const String descr = _format_doc_desc(annotation.description, !cd.is_script_doc, false);
 			if (!descr.is_empty()) {
 				_add_text(descr);
 			} else {
@@ -2105,9 +2169,9 @@ void EditorHelp::_update_doc() {
 				class_desc->add_text(" ");
 				class_desc->push_color(theme_cache.comment_color);
 				if (cd.is_script_doc) {
-					class_desc->add_text(TTR("There is currently no description for this annotation."));
+					_add_text(TTRC("There is currently no description for this annotation."), false);
 				} else {
-					class_desc->append_text(TTR("There is currently no description for this annotation. Please help us by [color=$color][url=$url]contributing one[/url][/color]!").replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text));
+					class_desc->append_text(_format_editor_prompt(TTRC("There is currently no description for this annotation. Please help us by [color=$color][url=$url]contributing one[/url][/color]!")).replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text));
 				}
 				class_desc->pop(); // color
 			}
@@ -2126,7 +2190,7 @@ void EditorHelp::_update_doc() {
 
 		section_line.push_back(Pair<String, int>(TTR("Property Descriptions"), class_desc->get_paragraph_count() - 2));
 		_push_title_font();
-		class_desc->add_text(TTR("Property Descriptions"));
+		_add_text(TTRC("Property Descriptions"), false);
 		_pop_title_font();
 
 		bool is_first_property = true;
@@ -2284,7 +2348,7 @@ void EditorHelp::_update_doc() {
 
 			if (prop.is_deprecated) {
 				has_prev_text = true;
-				DEPRECATED_DOC_MSG(HANDLE_DOC(prop.deprecated_message), TTR("This property may be changed or removed in future versions."));
+				DEPRECATED_DOC_MSG(prop.deprecated_message, !cd.is_script_doc, TTRC("This property may be changed or removed in future versions."));
 			}
 
 			if (prop.is_experimental) {
@@ -2292,10 +2356,10 @@ void EditorHelp::_update_doc() {
 					class_desc->add_newline();
 				}
 				has_prev_text = true;
-				EXPERIMENTAL_DOC_MSG(HANDLE_DOC(prop.experimental_message), TTR("This property may be changed or removed in future versions."));
+				EXPERIMENTAL_DOC_MSG(prop.experimental_message, !cd.is_script_doc, TTRC("This property may be changed or removed in future versions."));
 			}
 
-			const String descr = HANDLE_DOC(prop.description);
+			const String descr = _format_doc_desc(prop.description, !cd.is_script_doc, false);
 			if (!descr.is_empty()) {
 				if (has_prev_text) {
 					class_desc->add_newline();
@@ -2307,9 +2371,9 @@ void EditorHelp::_update_doc() {
 				class_desc->add_text(" ");
 				class_desc->push_color(theme_cache.comment_color);
 				if (cd.is_script_doc) {
-					class_desc->add_text(TTR("There is currently no description for this property."));
+					_add_text(TTRC("There is currently no description for this property."), false);
 				} else {
-					class_desc->append_text(TTR("There is currently no description for this property. Please help us by [color=$color][url=$url]contributing one[/url][/color]!").replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text));
+					class_desc->append_text(_format_editor_prompt(TTRC("There is currently no description for this property. Please help us by [color=$color][url=$url]contributing one[/url][/color]!")).replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text));
 				}
 				class_desc->pop(); // color
 			}
@@ -2318,7 +2382,7 @@ void EditorHelp::_update_doc() {
 			if (!cd.is_script_doc && packed_array_types.has(prop.type)) {
 				class_desc->add_newline();
 				// See also `EditorHelpBit::parse_symbol()` and `doc/tools/make_rst.py`.
-				_add_text(vformat(TTR("[b]Note:[/b] The returned array is [i]copied[/i] and any changes to it will not update the original property value. See [%s] for more details."), prop.type));
+				_add_text(_format_editor_prompt(TTRC("[b]Note:[/b] The returned array is [i]copied[/i] and any changes to it will not update the original property value. See [%s] for more details.")).replace("%s", prop.type));
 			}
 
 			class_desc->pop(); // color
@@ -2347,8 +2411,6 @@ void EditorHelp::_update_doc() {
 
 	// Free the scroll.
 	scroll_locked = false;
-
-#undef HANDLE_DOC
 }
 
 void EditorHelp::_request_help(const String &p_string) {
@@ -2957,6 +3019,13 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 
 			pos = brk_end + 1;
 			tag_stack.push_front("font");
+		} else if (tag.begins_with("bgcolor=")) {
+			const String color_str = tag.substr(tag.find_char('=') + 1).unquote();
+			Color color = Color::from_string(color_str, Color());
+			p_rt->push_bgcolor(color);
+
+			pos = brk_end + 1;
+			tag_stack.push_front("bgcolor");
 		} else {
 			p_rt->add_text("["); // Ignore.
 			pos = brk_pos + 1;
@@ -2971,8 +3040,20 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 	}
 }
 
-void EditorHelp::_add_text(const String &p_bbcode) {
-	_add_text_to_rt(p_bbcode, class_desc, this, edited_class);
+void EditorHelp::_add_text(const String &p_bbcode, bool p_from_doc) {
+	// For document description text, and dedicated prompt text. Already formatted.
+	if (p_from_doc) {
+		_add_text_to_rt(p_bbcode, class_desc, this, edited_class);
+		return;
+	}
+
+	// For general prompt text. Need to format.
+	const String formatted = _format_editor_prompt(p_bbcode);
+	if (bilingual) {
+		class_desc->append_text(formatted);
+	} else {
+		class_desc->add_text(formatted);
+	}
 }
 
 void EditorHelp::_wait_for_thread(Thread &p_thread) {
@@ -3336,6 +3417,9 @@ void EditorHelp::_notification(int p_what) {
 		}
 		case NOTIFICATION_READY: {
 			_wait_for_thread();
+
+			bilingual = EDITOR_GET("text_editor/help/show_help_bilingual");
+
 			_update_doc();
 		} break;
 

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -154,7 +154,7 @@ class EditorHelp : public VBoxContainer {
 	void _class_desc_scroll_to_paragraph(int p_line, bool p_save_history);
 	bool _need_save_new_history() const;
 
-	void _add_text(const String &p_bbcode);
+	void _add_text(const String &p_bbcode, bool p_from_doc = true);
 	bool scroll_locked = false;
 
 	//void _button_pressed(int p_idx);
@@ -178,6 +178,10 @@ class EditorHelp : public VBoxContainer {
 	void _class_desc_resized(bool p_force_update_theme);
 	int display_margin = 0;
 
+	bool bilingual = false;
+	String _combine_to_bilingual(const String &p_string, const String &p_translation, bool p_inline) const;
+	String _format_doc_desc(const String &p_string, bool p_is_native, bool p_inline = true) const;
+	String _format_editor_prompt(const String &p_string) const;
 	Error _goto_desc(const String &p_class, bool p_can_trigger_save_history);
 	//void _update_history_buttons();
 	void _update_method_list(MethodType p_method_type, const Vector<DocData::MethodDoc> &p_methods);

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -901,6 +901,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/external/exec_path", "");
 
 	// Help
+	_initial_set("text_editor/help/show_help_bilingual", false);
+	EDITOR_SETTING(Variant::COLOR, PROPERTY_HINT_NONE, "text_editor/help/bilingual_translation_bg_color", Color(0.0, 0.5, 0.5, 0.5), "")
 	_initial_set("text_editor/help/show_help_index", true);
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/help/help_font_size", 16, "8,48,1")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/help/help_source_font_size", 15, "8,48,1")


### PR DESCRIPTION
Inspired by [Immersive Translate](https://immersivetranslate.com/).

Add `text_editor/help/show_help_bilingual` to the `EditorSettings` to allow class documents to be displayed in a bilingual format when translations are available.

Add `text_editor/help/bilingual_translation_bg_color` to the `EditorSettings` to highlight the translated text.

When updating entries on [Weblate](https://hosted.weblate.org/projects/godot-engine/godot-class-reference/), some similar entries provide the similar translation as a suggestion instead of using the previous translation as a suggestion (new word changes have been introduced in the translated strings on weblate). This can lead to some oversights, especially when maintaining the translation by comparing word changes in the source text. This PR makes it easier to check for these errors. **At least you can refer to the original text when the translation is confusing.**

If you have any suggestions or corrections regarding the translation, please contribute on the [Weblate](https://hosted.weblate.org/projects/godot-engine/godot-class-reference/). 

Except in the following cases, the source text and its translation will be displayed **alternately line by line**.

- If the source line is the same as its translated line (possibly due to **missing** translation), it will only be displayed **once**.

<img width="1082" height="221" alt="1" src="https://github.com/user-attachments/assets/8a72e84a-47e4-460f-81c6-9bfe7064fca3" />

- For text within code blocks and links to online tutorials, **only** their translations will be used when available.

<img width="1090" height="395" alt="2" src="https://github.com/user-attachments/assets/e57ba093-356c-4c47-9e61-0d5279dbc95d" />

- For text in online tutorials, and text for prompts, ` - ` (3 characters instead of 1) will be used to separate the source text from its translation when its translation is available to ensure the **combined** text displays on a single line.

<img width="529" height="200" alt="3" src="https://github.com/user-attachments/assets/f642627f-7f24-49d6-b13f-e0c96673c222" />

<img width="536" height="216" alt="5" src="https://github.com/user-attachments/assets/c25d5106-d4e0-415f-9914-f2ca6f537515" />

<img width="612" height="131" alt="6" src="https://github.com/user-attachments/assets/15cba2fd-127c-4e8c-ba4f-5d53a5891dcd" />


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

-----

Translation also requires user participation to improve it. Using it in combination with #116352  might make it easier to contribute translations. 