### PR TITLE
Fix erroneous use of atomic in the dirty flags of Node3D

### DIFF
--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -174,7 +174,7 @@ private:
 	NodePath visibility_parent_path;
 
 	_FORCE_INLINE_ uint32_t _read_dirty_mask() const { return is_group_processing() ? data.dirty.mt.get() : data.dirty.st; }
-	_FORCE_INLINE_ bool _test_dirty_bits(uint32_t p_bits) const { return is_group_processing() ? data.dirty.mt.bit_and(p_bits) : (data.dirty.st & p_bits); }
+	_FORCE_INLINE_ bool _test_dirty_bits(uint32_t p_bits) const { return (is_group_processing() ? data.dirty.mt.get() : data.dirty.st) & p_bits; }
 	void _replace_dirty_mask(uint32_t p_mask) const;
 	void _set_dirty_bits(uint32_t p_bits) const;
 	void _clear_dirty_bits(uint32_t p_bits) const;


### PR DESCRIPTION
Addresses [issue#116011](https://github.com/godotengine/godot/issues/116011), and potentially some other issues. The MRP of that issue should now have correct behavior when the commit of this PR is applied.

Behavior of the MRP of [issue#116011](https://github.com/godotengine/godot/issues/116011), with this PR:

https://github.com/user-attachments/assets/117079db-07c0-4b7c-8353-501c859d4048

## Explanation

Node3D simultaneously stores a `Transform3D` and a pair of euler angles and scale for some reason (documented in `node_3d.h`, right above definition of `enum TransformDirty`). Both representations are readable and writable.

It uses a dirty-flagging system to transparently handle this: when transform is set, euler angle and scale is flagged as dirty; when euler angle or scale is set, transform is flagged as dirty. As an optimization, actual update of the data is deferred until they are read.

In multi-threading mode (i.e., when thread group is set to sub), this dirty flag is implemented as a bitset based on atomic uint32 (`SafeNumeric<uint32_t>`, which is a wrapper over `std::atomic<uint32_t>`).

The problem is, when testing for certain bits in the atomic, what Node3D did is `flags.bit_and(mask)`. However, `SafeNumeric<>::bit_and` is implemented as `std::atomic<>::fetch_and`, whose semantic is "atomically set the atomic variable `v` to `v & mask`, and return the original value of `v`".

This would result in the following problem: any bit set in the dirty flag would cause a query with any mask to return true. And if the query is using a mask that *should* return false, the dirty flag will be effectively cleared.

The correct semantic should be "load the value of `v` and return `v & mask`, without modifying `v`". So it should be implemented as `flags.load() & mask`, instead.

This PR did exactly this.

- Bugsquad: Fixes #116012