### PR TITLE
Fix Home Indicator not hiding on old iOS versions

### DIFF
--- a/drivers/apple_embedded/app.swift
+++ b/drivers/apple_embedded/app.swift
@@ -52,7 +52,7 @@ struct SwiftUIApp: App {
 
 	var body: some Scene {
 		WindowGroup {
-			GodotSwiftUIViewController()
+			let viewController = GodotSwiftUIViewController()
 				.ignoresSafeArea()
 				// UIViewControllerRepresentable does not call viewWillDisappear() nor viewDidDisappear() when
 				// backgrounding the app, or closing the app's main window, update the renderer here.
@@ -74,6 +74,17 @@ struct SwiftUIApp: App {
 						print("unknown default")
 					}
 				}
+			
+			// For some reason early iOS versions do not respect the prefersHomeIndicatorAutoHidden override flag,
+			// and the Home Indicator is always displayed.
+			// We use the SwiftUI modifier to enforce the override flag we want.
+			// Not a perfect solution since there are still some devices that do not have access to this modifier.
+			if #available(iOS 16.0, *) {
+				let hideHomeIndictor = GDTAppDelegateService.viewController?.prefersHomeIndicatorAutoHidden ?? true
+				viewController.persistentSystemOverlays(hideHomeIndictor ? .hidden : .visible)
+			} else {
+				viewController
+			}
 		}
 	}
 }

--- a/drivers/apple_embedded/app.swift
+++ b/drivers/apple_embedded/app.swift
@@ -74,7 +74,7 @@ struct SwiftUIApp: App {
 						print("unknown default")
 					}
 				}
-			
+
 			// For some reason early iOS versions do not respect the prefersHomeIndicatorAutoHidden override flag,
 			// and the Home Indicator is always displayed.
 			// We use the SwiftUI modifier to enforce the override flag we want.


### PR DESCRIPTION
Fixes #115552 

Note that this isn't a 100% perfect solution, but I'm not sure if one exists. I believe this might be a bug in iOS/SwiftUI, given that behavior changes in newer iOS versions.
iOS versions older than iOS 16 will still have the Home Indicator setting ignored, but this at least should fix it for all other affected versions.

All iOS devices from 2017 and onwards can upgrade to iOS 16: https://iosref.com/ios