### PR TITLE
Fix broken nodes after pasted into editable children

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4417,7 +4417,8 @@ List<Node *> SceneTreeDock::paste_nodes(bool p_paste_as_sibling) {
 			// and added to the node_clipboard_edited_scene_owned list.
 			if (d != dup && E2.key->get_owner() == nullptr) {
 				if (node_clipboard_edited_scene_owned.find(const_cast<Node *>(E2.key))) {
-					ur->add_do_method(d, "set_owner", owner);
+					Node *new_owner = edited_scene == nullptr ? owner : edited_scene;
+					ur->add_do_method(d, "set_owner", new_owner);
 				}
 			}
 		}


### PR DESCRIPTION
- Fixes: https://github.com/godotengine/godot/issues/115894

## Details

Looks like it's broke after https://github.com/godotengine/godot/pull/103769. So I added extra check for new scene. 