### PR TITLE
Fix inconsistent lighting with rotated meshes (normals enabled) in Forward+ Renderer

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1439,7 +1439,9 @@ void fragment_shader(in SceneData scene_data) {
 
 	// Tangent-space transformation is performed using unnormalized TBN vectors, per MikkTSpace.
 	// See: http://www.mikktspace.com/
-	normal = normalize(mix(normal, tangent * normal_map.x + binormal * normal_map.y + normal * normal_map.z, normal_map_depth));
+	if (length(normal_map.xy) > 0.001) {
+		normal = normalize(mix(normal, tangent * normal_map.x + binormal * normal_map.y + normal * normal_map.z, normal_map_depth));
+	}
 #elif defined(NORMAL_USED)
 	normal = geo_normal;
 #endif // NORMAL_MAP_USED


### PR DESCRIPTION
Fixes #116025 

Added an if check that skips the tangent/binormal calculation when normal_map.xy is essentially zero. This prevents lighting inconsistencies on rotated meshes with flat or mostly-flat normal maps.

<img width="2418" height="1371" alt="Screenshot 2026-02-07 181006" src="https://github.com/user-attachments/assets/7c1b6b63-a21c-4d83-9756-875d6cab3913" />
