### PR TITLE
Move `refuse_new_connections` to `MultiplayerAPI`

### DIFF
--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -103,6 +103,9 @@
 		<member name="multiplayer_peer" type="MultiplayerPeer" setter="set_multiplayer_peer" getter="get_multiplayer_peer">
 			The peer object to handle the RPC system (effectively enabling networking when set). Depending on the peer itself, the MultiplayerAPI will become a network server (check with [method is_server]) and will set root node's network mode to authority, or it will become a regular client peer. All child nodes are set to inherit the network mode by default. Handling of networking-related events (connection, disconnection, new clients) is done by connecting to MultiplayerAPI's signals.
 		</member>
+		<member name="refuse_new_connections" type="bool" setter="set_refuse_new_connections" getter="is_refusing_new_connections" default="false">
+			If [code]true[/code], the MultiplayerAPI's [member MultiplayerAPI.multiplayer_peer] refuses new incoming connections.
+		</member>
 	</members>
 	<signals>
 		<signal name="connected_to_server">

--- a/doc/classes/MultiplayerAPIExtension.xml
+++ b/doc/classes/MultiplayerAPIExtension.xml
@@ -106,6 +106,12 @@
 				Callback for [method MultiplayerAPI.get_unique_id].
 			</description>
 		</method>
+		<method name="_is_refusing_new_connections" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Called when [member MultiplayerAPI.refuse_new_connections] is retrieved.
+			</description>
+		</method>
 		<method name="_object_configuration_add" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="object" type="Object" />
@@ -143,6 +149,13 @@
 			<param index="0" name="multiplayer_peer" type="MultiplayerPeer" />
 			<description>
 				Called when the [member MultiplayerAPI.multiplayer_peer] is set.
+			</description>
+		</method>
+		<method name="_set_refuse_new_connections" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="refuse" type="bool" />
+			<description>
+				Called when [member MultiplayerAPI.refuse_new_connections] is set.
 			</description>
 		</method>
 	</methods>

--- a/misc/extension_api_validation/4.6-stable/GH-116028.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-116028.txt
@@ -1,0 +1,7 @@
+GH-116028
+--------------
+Validate extension JSON: API was removed: classes/SceneMultiplayer/methods/set_refuse_new_connections
+Validate extension JSON: API was removed: classes/SceneMultiplayer/methods/is_refusing_new_connections
+Validate extension JSON: API was removed: classes/SceneMultiplayer/properties/refuse_new_connections
+
+Methods have been moved to parent class, errors are false-positives.

--- a/modules/multiplayer/doc_classes/SceneMultiplayer.xml
+++ b/modules/multiplayer/doc_classes/SceneMultiplayer.xml
@@ -76,9 +76,6 @@
 		<member name="max_sync_packet_size" type="int" setter="set_max_sync_packet_size" getter="get_max_sync_packet_size" default="1350">
 			Maximum size of each synchronization packet. Higher values increase the chance of receiving full updates in a single frame, but also the chance of packet loss. See [MultiplayerSynchronizer].
 		</member>
-		<member name="refuse_new_connections" type="bool" setter="set_refuse_new_connections" getter="is_refusing_new_connections" default="false">
-			If [code]true[/code], the MultiplayerAPI's [member MultiplayerAPI.multiplayer_peer] refuses new incoming connections.
-		</member>
 		<member name="root_path" type="NodePath" setter="set_root_path" getter="get_root_path" default="NodePath(&quot;&quot;)">
 			The root path to use for RPCs and replication. Instead of an absolute path, a relative path will be used to find the node upon which the RPC should be executed.
 			This effectively allows to have different branches of the scene tree to be managed by different MultiplayerAPI, allowing for example to run both client and server in the same scene.

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -649,8 +649,6 @@ void SceneMultiplayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_auth_timeout", "timeout"), &SceneMultiplayer::set_auth_timeout);
 	ClassDB::bind_method(D_METHOD("get_auth_timeout"), &SceneMultiplayer::get_auth_timeout);
 
-	ClassDB::bind_method(D_METHOD("set_refuse_new_connections", "refuse"), &SceneMultiplayer::set_refuse_new_connections);
-	ClassDB::bind_method(D_METHOD("is_refusing_new_connections"), &SceneMultiplayer::is_refusing_new_connections);
 	ClassDB::bind_method(D_METHOD("set_allow_object_decoding", "enable"), &SceneMultiplayer::set_allow_object_decoding);
 	ClassDB::bind_method(D_METHOD("is_object_decoding_allowed"), &SceneMultiplayer::is_object_decoding_allowed);
 	ClassDB::bind_method(D_METHOD("set_server_relay_enabled", "enabled"), &SceneMultiplayer::set_server_relay_enabled);
@@ -666,12 +664,9 @@ void SceneMultiplayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::CALLABLE, "auth_callback"), "set_auth_callback", "get_auth_callback");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "auth_timeout", PROPERTY_HINT_RANGE, "0,30,0.1,or_greater,suffix:s"), "set_auth_timeout", "get_auth_timeout");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_object_decoding"), "set_allow_object_decoding", "is_object_decoding_allowed");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "refuse_new_connections"), "set_refuse_new_connections", "is_refusing_new_connections");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "server_relay"), "set_server_relay_enabled", "is_server_relay_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_sync_packet_size"), "set_max_sync_packet_size", "get_max_sync_packet_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_delta_packet_size"), "set_max_delta_packet_size", "get_max_delta_packet_size");
-
-	ADD_PROPERTY_DEFAULT("refuse_new_connections", false);
 
 	ADD_SIGNAL(MethodInfo("peer_authenticating", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("peer_authentication_failed", PropertyInfo(Variant::INT, "id")));

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -185,8 +185,8 @@ public:
 	const HashSet<int> get_connected_peers() const { return connected_peers; }
 
 	void set_remote_sender_override(int p_id) { remote_sender_override = p_id; }
-	void set_refuse_new_connections(bool p_refuse);
-	bool is_refusing_new_connections() const;
+	void set_refuse_new_connections(bool p_refuse) override;
+	bool is_refusing_new_connections() const override;
 
 	void set_allow_object_decoding(bool p_enable);
 	bool is_object_decoding_allowed() const;

--- a/scene/main/multiplayer_api.cpp
+++ b/scene/main/multiplayer_api.cpp
@@ -294,10 +294,15 @@ void MultiplayerAPI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("rpc", "peer", "object", "method", "arguments"), &MultiplayerAPI::_rpc_bind, DEFVAL(Array()));
 	ClassDB::bind_method(D_METHOD("object_configuration_add", "object", "configuration"), &MultiplayerAPI::object_configuration_add);
 	ClassDB::bind_method(D_METHOD("object_configuration_remove", "object", "configuration"), &MultiplayerAPI::object_configuration_remove);
+	ClassDB::bind_method(D_METHOD("set_refuse_new_connections", "refuse"), &MultiplayerAPI::set_refuse_new_connections);
+	ClassDB::bind_method(D_METHOD("is_refusing_new_connections"), &MultiplayerAPI::is_refusing_new_connections);
 
 	ClassDB::bind_method(D_METHOD("get_peers"), &MultiplayerAPI::get_peer_ids);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "multiplayer_peer", PROPERTY_HINT_RESOURCE_TYPE, MultiplayerPeer::get_class_static(), PROPERTY_USAGE_NONE), "set_multiplayer_peer", "get_multiplayer_peer");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "refuse_new_connections"), "set_refuse_new_connections", "is_refusing_new_connections");
+
+	ADD_PROPERTY_DEFAULT("refuse_new_connections", false);
 
 	ClassDB::bind_static_method("MultiplayerAPI", D_METHOD("set_default_interface", "interface_name"), &MultiplayerAPI::set_default_interface);
 	ClassDB::bind_static_method("MultiplayerAPI", D_METHOD("get_default_interface"), &MultiplayerAPI::get_default_interface);
@@ -375,6 +380,16 @@ Error MultiplayerAPIExtension::object_configuration_remove(Object *p_object, Var
 	return err;
 }
 
+void MultiplayerAPIExtension::set_refuse_new_connections(bool p_refuse) {
+	GDVIRTUAL_CALL(_set_refuse_new_connections, p_refuse);
+}
+
+bool MultiplayerAPIExtension::is_refusing_new_connections() const {
+	bool is_peer_refusing = false;
+	GDVIRTUAL_CALL(_is_refusing_new_connections, is_peer_refusing);
+	return is_peer_refusing;
+}
+
 void MultiplayerAPIExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_poll);
 	GDVIRTUAL_BIND(_set_multiplayer_peer, "multiplayer_peer");
@@ -385,4 +400,6 @@ void MultiplayerAPIExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_remote_sender_id);
 	GDVIRTUAL_BIND(_object_configuration_add, "object", "configuration");
 	GDVIRTUAL_BIND(_object_configuration_remove, "object", "configuration");
+	GDVIRTUAL_BIND(_set_refuse_new_connections, "refuse");
+	GDVIRTUAL_BIND(_is_refusing_new_connections);
 }

--- a/scene/main/multiplayer_api.h
+++ b/scene/main/multiplayer_api.h
@@ -71,6 +71,9 @@ public:
 	virtual Error object_configuration_add(Object *p_object, Variant p_config) = 0;
 	virtual Error object_configuration_remove(Object *p_object, Variant p_config) = 0;
 
+	virtual void set_refuse_new_connections(bool p_refuse) = 0;
+	virtual bool is_refusing_new_connections() const = 0;
+
 	bool has_multiplayer_peer() { return get_multiplayer_peer().is_valid(); }
 	bool is_server() { return get_unique_id() == MultiplayerPeer::TARGET_PEER_SERVER; }
 
@@ -98,6 +101,9 @@ public:
 	virtual Error object_configuration_add(Object *p_object, Variant p_config) override;
 	virtual Error object_configuration_remove(Object *p_object, Variant p_config) override;
 
+	virtual void set_refuse_new_connections(bool p_refuse) override;
+	virtual bool is_refusing_new_connections() const override;
+
 	// Extensions
 	GDVIRTUAL0R(Error, _poll);
 	GDVIRTUAL1(_set_multiplayer_peer, Ref<MultiplayerPeer>);
@@ -108,4 +114,6 @@ public:
 	GDVIRTUAL0RC(int, _get_remote_sender_id);
 	GDVIRTUAL2R(Error, _object_configuration_add, Object *, Variant);
 	GDVIRTUAL2R(Error, _object_configuration_remove, Object *, Variant);
+	GDVIRTUAL1(_set_refuse_new_connections, bool);
+	GDVIRTUAL0RC(bool, _is_refusing_new_connections)
 };


### PR DESCRIPTION
It doesn't really make sense that this is exclusive to `SceneMultiplayer`, given that it just forwards it to `MultiplayerPeer.refuse_new_connections` and `MultiplayerAPI` is already dependent on `MultiplayerPeer`.

I've also added `_is_refusing_new_connections` and `_set_refuse_new_connections` to `MultiplayerAPIExtension` to be overridden.