### PR TITLE
WIP: LightmapGI: Collection of fixes for lightmap seam issues

### DIFF
--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -739,8 +739,8 @@ void LightmapperRD::_raster_geometry(RenderingDevice *rd, Size2i atlas_size, int
 		// Half pixel offset is required so the rasterizer doesn't output face edges directly aligned into pixels.
 		// This fixes artifacts where the pixel would be traced from the edge of a face, causing half the rays to
 		// be outside of the boundaries of the geometry. See <https://github.com/godotengine/godot/issues/69126>.
-		raster_push_constant.uv_offset[0] = -0.5f / float(atlas_size.x);
-		raster_push_constant.uv_offset[1] = -0.5f / float(atlas_size.y);
+		raster_push_constant.uv_offset[0] = 0;//-0.5f / float(atlas_size.x);
+		raster_push_constant.uv_offset[1] = 0;//-0.5f / float(atlas_size.y);
 
 		RD::DrawListID draw_list = rd->draw_list_begin(framebuffers[i], RD::DRAW_CLEAR_ALL, clear_colors, 1.0f, 0, Rect2(), RDD::BreadcrumbMarker::LIGHTMAPPER_PASS);
 		//draw opaque
@@ -749,10 +749,10 @@ void LightmapperRD::_raster_geometry(RenderingDevice *rd, Size2i atlas_size, int
 		rd->draw_list_set_push_constant(draw_list, &raster_push_constant, sizeof(RasterPushConstant));
 		rd->draw_list_draw(draw_list, false, 1, slice_triangle_count[i] * 3);
 		//draw wire
-		rd->draw_list_bind_render_pipeline(draw_list, raster_pipeline_wire);
-		rd->draw_list_bind_uniform_set(draw_list, raster_base_uniform, 0);
-		rd->draw_list_set_push_constant(draw_list, &raster_push_constant, sizeof(RasterPushConstant));
-		rd->draw_list_draw(draw_list, false, 1, slice_triangle_count[i] * 3);
+		// rd->draw_list_bind_render_pipeline(draw_list, raster_pipeline_wire);
+		// rd->draw_list_bind_uniform_set(draw_list, raster_base_uniform, 0);
+		// rd->draw_list_set_push_constant(draw_list, &raster_push_constant, sizeof(RasterPushConstant));
+		// rd->draw_list_draw(draw_list, false, 1, slice_triangle_count[i] * 3);
 
 		rd->draw_list_end();
 

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -749,10 +749,10 @@ void LightmapperRD::_raster_geometry(RenderingDevice *rd, Size2i atlas_size, int
 		rd->draw_list_set_push_constant(draw_list, &raster_push_constant, sizeof(RasterPushConstant));
 		rd->draw_list_draw(draw_list, false, 1, slice_triangle_count[i] * 3);
 		//draw wire
-		// rd->draw_list_bind_render_pipeline(draw_list, raster_pipeline_wire);
-		// rd->draw_list_bind_uniform_set(draw_list, raster_base_uniform, 0);
-		// rd->draw_list_set_push_constant(draw_list, &raster_push_constant, sizeof(RasterPushConstant));
-		// rd->draw_list_draw(draw_list, false, 1, slice_triangle_count[i] * 3);
+		rd->draw_list_bind_render_pipeline(draw_list, raster_pipeline_wire);
+		rd->draw_list_bind_uniform_set(draw_list, raster_base_uniform, 0);
+		rd->draw_list_set_push_constant(draw_list, &raster_push_constant, sizeof(RasterPushConstant));
+		rd->draw_list_draw(draw_list, false, 1, slice_triangle_count[i] * 3);
 
 		rd->draw_list_end();
 

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -858,7 +858,7 @@ void main() {
 		vec3 light;
 		vec3 light_dir;
 		float shadow;
-		trace_direct_light(position, normal, i, true, light, light_dir, noise, texel_size_world_space, shadow);
+		trace_direct_light(position, normal, i, false, light, light_dir, noise, texel_size_world_space, shadow);
 
 		if (lights.data[i].static_bake) {
 			light_for_texture += light;

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1737,7 +1737,7 @@ float LightmapGI::get_bounce_indirect_energy() const {
 }
 
 void LightmapGI::set_bias(float p_bias) {
-	ERR_FAIL_COND(p_bias < 0.00001);
+	ERR_FAIL_COND(p_bias < 0.0000001);
 	bias = p_bias;
 }
 


### PR DESCRIPTION
Relevant: https://github.com/godotengine/godot/issues/85730 https://github.com/godotengine/godot/issues/90929 https://github.com/godotengine/godot/issues/98685 https://github.com/godotengine/godot/issues/107179 https://github.com/godotengine/godot/issues/56033

I already made a post about this here: https://github.com/godotengine/godot/issues/90929#issuecomment-3712467356 and figured I'd make a draft PR as well. 

It:
- Reverts https://github.com/godotengine/godot/issues/69126 which appears to be an existing hack that didn't really solve the issue (and made things worse for some people).
- ~~Turns off the conservative rasterization emulation - I'm not sure that conservative rasterization is really a good idea with lightmaps. I think making sure that every triangle has a large enough UV2 is better. I think this approach was copied from https://ndotl.wordpress.com/2018/08/29/baking-artifact-free-lightmaps?~~
- Disabled soft shadows where trace_direct_light is called - probably because it pushes the ray origin out of the mesh. This should be fixed and re-enabled. 
- Reduces the minimum allowed bias by a factor of 100x.

I still need to clean things up and add screenshots to this PR etc. I'd welcome any files/projects for testing :)