### PR TITLE
Jolt SoftBody3D: Make default mass 1 kg and fix stiffness conversion

### DIFF
--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -51,7 +51,7 @@ class JoltSoftBody3D final : public JoltObject3D {
 
 	JPH::SoftBodyCreationSettings *jolt_settings = new JPH::SoftBodyCreationSettings();
 
-	float mass = 0.0f;
+	float mass = 1.0f;
 	float pressure = 0.0f;
 	float linear_damping = 0.01f;
 	float stiffness_coefficient = 0.5f;


### PR DESCRIPTION
Before this change, the default SoftBody3D mass was 0 which would set the mass of every vertex to 1 kg. The SoftBody3D UI in this case shows 0.001 kg, while for a cloth with a reasonable number of subdivisions the actual weight would be in the order of 1000 kg. This weight is likely to be much more than the weight of other RigidBody3D's in the scene (their default weight is 1) causing unrealistic interactions.

* Changed the default mass for a soft body to 1 kg, this mass is distributed uniformly across all soft body vertices. This matches what Godot Physics does.
* Added a missing call to _update_mass() so that calling set_mass after creation actually updates the mass now.
* Added an error check to set_mass() so that it no longer accepts zero mass as input.
* Fixed the conversion from godot stiffness to Jolt's compliance with a formula that was derived from the XPBD vs PBD equations. The previous conversion routine was determined experimentally and did not account for vertex mass. This meant that when the vertex mass became really low, the simulation became unstable.

Note that this breaks compatibility but makes the behavior in line with what Godot Physics does. I would consider the previous behavior a bug, so it's probably best to get this into 4.6 as soon as possible to avoid people creating content/tweaking numbers based on broken behavior.

See discussion at #111993

_Edit by @mihe:_
- Fixes #116058
- Fixes #116062
- Fixes #116076