### PR TITLE
Account for the current section when processing AnimationTracks

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1624,7 +1624,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 							}
 						} else {
 							List<int> indices;
-							a->track_get_key_indices_in_range(i, time, delta, &indices, looped_flag);
+							a->track_get_key_indices_in_range(i, time, delta, start, end, &indices, looped_flag);
 							for (int &F : indices) {
 								t->use_discrete = true;
 								Variant value = a->track_get_key_value(i, F);
@@ -1657,7 +1657,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						_call_object(t->object_id, method, params, callback_mode_method == ANIMATION_CALLBACK_MODE_METHOD_DEFERRED);
 					} else {
 						List<int> indices;
-						a->track_get_key_indices_in_range(i, time, delta, &indices, looped_flag);
+						a->track_get_key_indices_in_range(i, time, delta, start, end, &indices, looped_flag);
 						for (int &F : indices) {
 							StringName method = a->method_track_get_name(i, F);
 							Vector<Variant> params = a->method_track_get_params(i, F);
@@ -1705,7 +1705,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						}
 					} else {
 						List<int> to_play;
-						a->track_get_key_indices_in_range(i, time, delta, &to_play, looped_flag);
+						a->track_get_key_indices_in_range(i, time, delta, start, end, &to_play, looped_flag);
 						if (to_play.size()) {
 							idx = to_play.back()->get();
 						}
@@ -1820,7 +1820,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 					} else {
 						// Find stuff to play.
 						List<int> to_play;
-						a->track_get_key_indices_in_range(i, time, delta, &to_play, looped_flag);
+						a->track_get_key_indices_in_range(i, time, delta, start, end, &to_play, looped_flag);
 						if (to_play.size()) {
 							int idx = to_play.back()->get();
 							StringName anim_name = a->animation_track_get_key_animation(i, idx);

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -512,7 +512,7 @@ public:
 
 	void copy_track(int p_track, Ref<Animation> p_to_animation);
 
-	void track_get_key_indices_in_range(int p_track, double p_time, double p_delta, List<int> *p_indices, Animation::LoopedFlag p_looped_flag = Animation::LOOPED_FLAG_NONE) const;
+	void track_get_key_indices_in_range(int p_track, double p_time, double p_delta, double p_start, double p_end, List<int> *p_indices, Animation::LoopedFlag p_looped_flag = Animation::LOOPED_FLAG_NONE) const;
 
 	void add_marker(const StringName &p_name, double p_time);
 	void remove_marker(const StringName &p_name);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fixes https://github.com/godotengine/godot/issues/116002

The root cause of the issue is an oversight in the Animation class when implementing https://github.com/godotengine/godot/pull/91765. `Animation::track_get_key_indices_in_range()` does not consider Animation sections, causing AnimationMixer to mistakingly consider keys after the current section, when the current section ends.