### PR TITLE
Improve texture_replace performance

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1970,10 +1970,10 @@ void TextureStorage::texture_replace(RID p_texture, RID p_by_texture) {
 		return;
 	}
 
-	if (tex->rd_texture_srgb.is_valid()) {
-		RD::get_singleton()->free_rid(tex->rd_texture_srgb);
-	}
-	RD::get_singleton()->free_rid(tex->rd_texture);
+	RID old_rd_texture = tex->rd_texture;
+	RID old_rd_texture_srgb = tex->rd_texture_srgb;
+	RID new_rd_texture = by_tex->rd_texture;
+	RID new_rd_texture_srgb = by_tex->rd_texture_srgb;
 
 	if (tex->canvas_texture) {
 		memdelete(tex->canvas_texture);
@@ -1997,6 +1997,19 @@ void TextureStorage::texture_replace(RID p_texture, RID p_by_texture) {
 	for (int i = 0; i < proxies_to_redirect.size(); i++) {
 		texture_proxy_update(proxies_to_redirect[i], p_texture);
 	}
+
+	// Replace RD-level textures: patches uniform sets and defers old resources.
+	if (old_rd_texture_srgb.is_valid() && old_rd_texture_srgb != new_rd_texture_srgb) {
+		if (new_rd_texture_srgb.is_valid()) {
+			RD::get_singleton()->texture_replace_rid(old_rd_texture_srgb, new_rd_texture_srgb);
+		} else {
+			RD::get_singleton()->free_rid(old_rd_texture_srgb);
+		}
+	}
+	if (old_rd_texture != new_rd_texture) {
+		RD::get_singleton()->texture_replace_rid(old_rd_texture, new_rd_texture);
+	}
+
 	//delete last, so proxies can be updated
 	texture_owner.free(p_by_texture);
 

--- a/servers/rendering/renderer_rd/uniform_set_cache_rd.cpp
+++ b/servers/rendering/renderer_rd/uniform_set_cache_rd.cpp
@@ -50,7 +50,7 @@ RID UniformSetCacheRD::get_cache_array(RID p_shader, uint32_t p_set, const Typed
 	return UniformSetCacheRD::get_singleton()->get_cache_vec(p_shader, p_set, uniforms);
 }
 
-void UniformSetCacheRD::_invalidate(Cache *p_cache) {
+void UniformSetCacheRD::_remove(Cache *p_cache) {
 	if (p_cache->prev) {
 		p_cache->prev->next = p_cache->next;
 	} else {
@@ -62,12 +62,57 @@ void UniformSetCacheRD::_invalidate(Cache *p_cache) {
 	if (p_cache->next) {
 		p_cache->next->prev = p_cache->prev;
 	}
+}
+
+void UniformSetCacheRD::_invalidate(Cache *p_cache) {
+	_remove(p_cache);
 
 	cache_allocator.free(p_cache);
 	cache_instances_used--;
 }
 void UniformSetCacheRD::_uniform_set_invalidation_callback(void *p_userdata) {
 	singleton->_invalidate(reinterpret_cast<Cache *>(p_userdata));
+}
+
+void UniformSetCacheRD::texture_replaced_in_uniform_set(void *p_cache_userdata, RID p_old_texture, RID p_new_texture) {
+	if (!p_cache_userdata) {
+		// Not a cache-managed uniform set, nothing to do.
+		return;
+	}
+
+	Cache *found = reinterpret_cast<Cache *>(p_cache_userdata);
+
+	// Remove from old hash bucket.
+	_remove(found);
+
+	// Patch the uniforms: replace old texture RID with new.
+	for (uint32_t i = 0; i < found->uniforms.size(); i++) {
+		RD::Uniform &u = found->uniforms[i];
+		uint32_t id_count = u.get_id_count();
+		for (uint32_t j = 0; j < id_count; j++) {
+			if (u.get_id(j) == p_old_texture) {
+				u.set_id(j, p_new_texture);
+			}
+		}
+	}
+
+	// Recompute hash.
+	uint32_t h = hash_murmur3_one_64(found->shader.get_id());
+	h = hash_murmur3_one_32(found->set, h);
+	for (uint32_t i = 0; i < found->uniforms.size(); i++) {
+		h = _hash_uniform(found->uniforms[i], h);
+	}
+	h = hash_fmix32(h);
+	found->hash = h;
+
+	// Insert into new hash bucket.
+	uint32_t new_table_idx = h % HASH_TABLE_SIZE;
+	found->prev = nullptr;
+	found->next = hash_table[new_table_idx];
+	if (hash_table[new_table_idx]) {
+		hash_table[new_table_idx]->prev = found;
+	}
+	hash_table[new_table_idx] = found;
 }
 
 UniformSetCacheRD::UniformSetCacheRD() {

--- a/servers/rendering/renderer_rd/uniform_set_cache_rd.h
+++ b/servers/rendering/renderer_rd/uniform_set_cache_rd.h
@@ -111,6 +111,7 @@ class UniformSetCacheRD : public Object {
 
 	uint32_t cache_instances_used = 0;
 
+	void _remove(Cache *p_cache);
 	void _invalidate(Cache *p_cache);
 	static void _uniform_set_invalidation_callback(void *p_userdata);
 
@@ -206,6 +207,14 @@ public:
 	}
 
 	static RID get_cache_array(RID p_shader, uint32_t p_set, const TypedArray<RDUniform> &p_uniforms);
+
+	// Re-keys a cache entry after a texture RID was replaced in its uniforms.
+	void texture_replaced_in_uniform_set(void *p_cache_userdata, RID p_old_texture, RID p_new_texture);
+
+	// Returns true if the given callback is the one used by this cache.
+	bool is_cache_invalidation_callback(void (*p_callback)(void *)) const {
+		return p_callback == _uniform_set_invalidation_callback;
+	}
 
 	static UniformSetCacheRD *get_singleton() { return singleton; }
 

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -31,6 +31,7 @@
 #include "rendering_device.h"
 #include "rendering_device.compat.inc"
 
+#include "renderer_rd/uniform_set_cache_rd.h"
 #include "rendering_device_binds.h"
 #include "shader_include_db.h"
 
@@ -190,6 +191,27 @@ void RenderingDevice::_free_dependencies(RID p_id) {
 
 		reverse_dependency_map.remove(E);
 	}
+}
+
+void RenderingDevice::_replace_dependency(RID p_dependent, RID p_old_dependency, RID p_new_dependency) {
+	// Remove the edge: p_old_dependency -> p_dependent.
+	{
+		HashSet<RID> *set = dependency_map.getptr(p_old_dependency);
+		if (set) {
+			set->erase(p_dependent);
+		}
+	}
+
+	// Remove the reverse edge: p_dependent -> p_old_dependency.
+	{
+		HashSet<RID> *set = reverse_dependency_map.getptr(p_dependent);
+		if (set) {
+			set->erase(p_old_dependency);
+		}
+	}
+
+	// Add the new edge: p_new_dependency -> p_dependent.
+	_add_dependency(p_dependent, p_new_dependency);
 }
 
 /*******************************/
@@ -4367,6 +4389,13 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 	uniform_set.pending_clear_textures = pending_clear_textures;
 	uniform_set.shader_set = p_shader_set;
 	uniform_set.shader_id = p_shader;
+	uniform_set.is_linear_pool = p_linear_pool;
+
+	// Store the original uniforms so the set can be re-created if a texture is replaced.
+	uniform_set.bound_uniforms.resize(uniform_count);
+	for (uint32_t i = 0; i < uniform_count; i++) {
+		uniform_set.bound_uniforms[i] = uniforms[i];
+	}
 
 	RID id = uniform_set_owner.make_rid(uniform_set);
 #ifdef DEV_ENABLED
@@ -7010,6 +7039,138 @@ void RenderingDevice::_free_internal(RID p_id) {
 		ERR_PRINT("Attempted to free invalid ID: " + itos(p_id.get_id()));
 #endif
 	}
+
+	frames_pending_resources_for_processing = uint32_t(frames.size());
+}
+
+void RenderingDevice::texture_replace_rid(RID p_old_texture, RID p_new_texture) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(p_old_texture == p_new_texture);
+
+	Texture *old_texture = texture_owner.get_or_null(p_old_texture);
+	ERR_FAIL_NULL(old_texture);
+	Texture *new_texture = texture_owner.get_or_null(p_new_texture);
+	ERR_FAIL_NULL(new_texture);
+
+	// Collect all uniform sets that depend on the old texture.
+	// We must snapshot the set because we'll be mutating the dependency map.
+	LocalVector<RID> dependent_uniform_sets;
+	{
+		HashSet<RID> *deps = dependency_map.getptr(p_old_texture);
+		if (deps) {
+			for (const RID &dep : *deps) {
+				if (uniform_set_owner.owns(dep)) {
+					dependent_uniform_sets.push_back(dep);
+				}
+			}
+		}
+	}
+
+	// For each dependent uniform set, re-create its driver-level descriptor set
+	// with the new texture, then queue the old descriptor set for deferred deletion.
+	for (const RID &us_rid : dependent_uniform_sets) {
+		UniformSet *us = uniform_set_owner.get_or_null(us_rid);
+		ERR_CONTINUE(!us);
+
+		if (us->bound_uniforms.is_empty()) {
+			// This uniform set wasn't created with stored bindings (shouldn't happen
+			// for non-linear pools). Fall back to the cascade path by freeing it.
+			free_rid(us_rid);
+			continue;
+		}
+
+		Shader *shader = shader_owner.get_or_null(us->shader_id);
+		if (!shader || !shader->driver_id) {
+			// Shader is gone; the uniform set is orphaned. Let it cascade.
+			free_rid(us_rid);
+			continue;
+		}
+
+		// Patch the bound uniforms: replace occurrences of old texture RID with new.
+		bool patched = false;
+		for (uint32_t i = 0; i < us->bound_uniforms.size(); i++) {
+			Uniform &u = us->bound_uniforms[i];
+			uint32_t id_count = u.get_id_count();
+			for (uint32_t j = 0; j < id_count; j++) {
+				if (u.get_id(j) == p_old_texture) {
+					u.set_id(j, p_new_texture);
+					patched = true;
+				}
+			}
+		}
+
+		if (!patched) {
+			// This set didn't actually reference the old texture in its bindings
+			// (dependency might have been from something else). Skip.
+			continue;
+		}
+
+		// Re-create the uniform set through the normal path. This validates
+		// all bindings and builds new driver uniforms, draw trackers, etc.
+		// Use a VectorView over the patched bound_uniforms.
+		VectorView<Uniform> uniforms_view(us->bound_uniforms.ptr(), us->bound_uniforms.size());
+		RID new_us_rid = uniform_set_create(uniforms_view, us->shader_id, us->shader_set, us->is_linear_pool);
+
+		if (new_us_rid.is_null()) {
+			ERR_PRINT("Failed to re-create uniform set during texture replacement.");
+			continue;
+		}
+
+		// Swap the internals: move the new uniform set's data into the old RID's slot,
+		// so that all external references (caches, materials) remain valid.
+		UniformSet *new_us = uniform_set_owner.get_or_null(new_us_rid);
+		ERR_CONTINUE(!new_us);
+
+		// Queue the OLD driver descriptor set for deferred deletion.
+		// We create a temporary UniformSet with only the driver_id so it gets freed.
+		UniformSet old_us_for_disposal;
+		old_us_for_disposal.driver_id = us->driver_id;
+		frames[frame].uniform_sets_to_dispose_of.push_back(old_us_for_disposal);
+
+		// Copy new data in.
+		us->driver_id = new_us->driver_id;
+		us->format = new_us->format;
+		us->attachable_textures = new_us->attachable_textures;
+		us->draw_trackers = new_us->draw_trackers;
+		us->draw_trackers_usage = new_us->draw_trackers_usage;
+		us->untracked_usage = new_us->untracked_usage;
+		us->shared_textures_to_update = new_us->shared_textures_to_update;
+		us->pending_clear_textures = new_us->pending_clear_textures;
+		us->bound_uniforms = new_us->bound_uniforms;
+
+		// Replace old texture dependency with new.
+		_replace_dependency(us_rid, p_old_texture, p_new_texture);
+
+		// Update the UniformSetCacheRD entry if this set was created through the cache.
+		UniformSetCacheRD *const uniform_set_cache = UniformSetCacheRD::get_singleton();
+		if (uniform_set_cache->is_cache_invalidation_callback(us->invalidated_callback)) {
+			uniform_set_cache->texture_replaced_in_uniform_set(us->invalidated_callback_userdata, p_old_texture, p_new_texture);
+		}
+
+		// Since the real driver id is used by the original set, clear the temporary set's driver id.
+		new_us->driver_id = RDD::UniformSetID();
+
+		// Remove its dependency entries and free the temporary RID.
+		HashMap<RID, HashSet<RID>>::Iterator rev_it = reverse_dependency_map.find(new_us_rid);
+		if (rev_it) {
+			for (const RID &dep_on : rev_it->value) {
+				HashSet<RID> *fwd = dependency_map.getptr(dep_on);
+				if (fwd) {
+					fwd->erase(new_us_rid);
+				}
+			}
+			reverse_dependency_map.remove(rev_it);
+		}
+		HashMap<RID, HashSet<RID>>::Iterator fwd_it = dependency_map.find(new_us_rid);
+		if (fwd_it) {
+			dependency_map.remove(fwd_it);
+		}
+
+		uniform_set_owner.free(new_us_rid);
+	}
+
+	free_rid(p_old_texture);
 
 	frames_pending_resources_for_processing = uint32_t(frames.size());
 }

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -117,6 +117,7 @@ private:
 
 	void _add_dependency(RID p_id, RID p_depends_on);
 	void _free_dependencies(RID p_id);
+	void _replace_dependency(RID p_dependent, RID p_old_dependency, RID p_new_dependency);
 
 private:
 	/***************************/
@@ -1155,6 +1156,10 @@ private:
 		LocalVector<RID> pending_clear_textures;
 		InvalidationCallback invalidated_callback = nullptr;
 		void *invalidated_callback_userdata = nullptr;
+
+		// Stored for uniform set re-creation during texture replacement.
+		LocalVector<Uniform> bound_uniforms;
+		bool is_linear_pool = false;
 	};
 
 	RID_Owner<UniformSet, true> uniform_set_owner;
@@ -1786,6 +1791,7 @@ public:
 	void _set_max_fps(int p_max_fps);
 
 	void free_rid(RID p_rid);
+	void texture_replace_rid(RID p_old_texture, RID p_new_texture);
 #ifndef DISABLE_DEPRECATED
 	[[deprecated("Use `free_rid()` instead.")]] void free(RID p_rid) {
 		free_rid(p_rid);


### PR DESCRIPTION
This modifies TextureStorage::texture_replace to perform better.

Currently, texture_replace deletes the old texture.  The side effect of this is the uniform set gets deleted and all instances using it get marked dirty so they can make a new uniform set for the new texture.  This works, but under various scenarios this causes big rendering delays when many instances suddenly need do a bunch of work.  This can be important if you are trying to implement texture streaming :stuck_out_tongue_winking_eye:  (see #113429).

This PR modifies texture_replace so instead of destroying the uniform set and triggering all instances to recreate the uniform set, we essentially duplicate the uniform set using the new texture and splice it in.  In flight draws can continue to use the old uniform set (it gets queued for deletion after its not in use).  New draws reference the new set.

This has removed a large delay I would occasionally see when large amounts of instances would appear or disappear.  There may be corner cases that aren't handled yet but a least for the 2d test case I made and my texture streaming this has worked well so far.  

I've only test Vulkan and d3d12 but since its at the RenderDevice level I suspect it will be fine.