### PR TITLE
Fix 2D glow artifacts on Forward+ renderer (regression from 4.5) (fixes #116053)

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -577,6 +577,14 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 
 		rb->allocate_blur_textures();
 
+		// Clear glow buffers to avoid stale data from previous frames or editor redraws (fixes 2D glow
+		// artifacts on Forward+ when canvas background and glow are enabled; see GH-116053).
+		uint32_t blur_0_mipmaps = rb->get_texture_format(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0).mipmaps;
+		uint32_t blur_1_mipmaps = rb->get_texture_format(RB_SCOPE_BUFFERS, RB_TEX_BLUR_1).mipmaps;
+		uint32_t view_count = rb->get_view_count();
+		RD::get_singleton()->texture_clear(rb->get_texture(RB_SCOPE_BUFFERS, RB_TEX_BLUR_0), Color(0, 0, 0, 0), 0, blur_0_mipmaps, 0, view_count);
+		RD::get_singleton()->texture_clear(rb->get_texture(RB_SCOPE_BUFFERS, RB_TEX_BLUR_1), Color(0, 0, 0, 0), 0, blur_1_mipmaps, 0, view_count);
+
 		int mipmaps = int(rb->get_texture_format(RB_SCOPE_BUFFERS, RB_TEX_BLUR_1).mipmaps);
 		Vector<float> glow_levels = environment_get_glow_levels(p_render_data->environment);
 		bool use_debanding = rb->get_use_debanding() && !texture_storage->render_target_is_using_hdr(render_target);


### PR DESCRIPTION
### Description

This PR fixes a rendering regression in Godot 4.6 where enabling 2D glow on the Forward+ renderer produces moving white line artifacts on the left side of the viewport.

The issue:
- Appears only on **Forward+**
- Does **not** reproduce on the Mobile renderer
- Does **not** reproduce in Godot 4.5
- Is visible even in the editor and reacts to editor UI redraws
- Has been observed on Intel Iris Xe (D3D12)

This strongly suggests stale or uninitialized glow buffer data being reused between frames in the 2D canvas path.

### Fix

The fix ensures the 2D glow buffer is properly cleared / initialized before use when running on the Forward+ renderer, preventing residual data from previous frames or editor redraws from leaking into the output.

### Reproduction

1. Godot 4.6 (Forward+, D3D12)
2. Node2D root
3. ColorRect covering screen
4. WorldEnvironment with Canvas background and glow enabled
5. Observe white line artifacts on the left side of the screen
6. Move mouse over editor panels — artifacts update in real time

### Result

Artifacts are no longer visible when using 2D glow on Forward+.

### Related issue

