### PR TITLE
Fix drag-resizing `Control` with non-zero `pivot_offset_ratio`

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -132,8 +132,12 @@ Size2 Control::_edit_get_scale() const {
 
 void Control::_edit_set_rect(const Rect2 &p_edit_rect) {
 	ERR_FAIL_COND_MSG(!Engine::get_singleton()->is_editor_hint(), "This function can only be used from editor plugins.");
-	set_position((get_position() + get_transform().basis_xform(p_edit_rect.position)), ControlEditorToolbar::get_singleton()->is_anchors_mode_enabled());
+	// Changing the size might change the internal transform (in case of non-zero `pivot_offset_ratio`),
+	// hence `position` (which is in the parent space, and is not always equivalent to the Control's rect top-left corner)
+	// needs to be changed after `size` (which is local) and needs to account for the possibly changed internal transform.
+	Vector2 rect_new_pos_in_parent_space = get_transform().xform(p_edit_rect.position);
 	set_size(p_edit_rect.size, ControlEditorToolbar::get_singleton()->is_anchors_mode_enabled());
+	set_position(rect_new_pos_in_parent_space - _get_internal_transform().get_origin(), ControlEditorToolbar::get_singleton()->is_anchors_mode_enabled());
 }
 
 void Control::_edit_set_rotation(real_t p_rotation) {


### PR DESCRIPTION
Fixes partially #115977 (the first point reported there).

In case of non-zero `pivot_offset_ratio` changing Control's `size` affects its transform, and hence it needs to be accounted for when setting the `position`.
Specifically in `Control::_edit_set_rect` we're getting a new desired local rect `p_edit_rect`. Setting `size = p_edit_rect.size` is fine, as Control's `size` is local. On the other hand Control's `position` is in the parent space / coordinate system, and hence needs to account for the possible internal transform change caused by the `size` change.

```
# For Control:
combined_pivot == pivot_offset + pivot_offset_ratio * size
_get_internal_transform() == T(combined_pivot) * R(rotation) * S(scale) * T(-combined_pivot) // TRS are translation/rotation/scale transformations
get_transform() == T(position) * _get_internal_transform()

# This equation needs to be true:
T(new_position) * internal_transform_after_size_change * (0, 0) == transform_before_size_change * p_edit_rect.position
```

Before<br>(v4.6.stable.official [89cea1439])|After<br>(this PR)
-|-
![Godot_v4 6-stable_win64_2YtHgsvSP6](https://github.com/user-attachments/assets/1fb8f5f1-62f7-4a7f-a5a6-61b0ea06db8f)|![godot windows editor dev x86_64_EZuo8DT3f1](https://github.com/user-attachments/assets/af357b1c-3758-4faa-84a3-3fe2f5b402cf)
