### PR TITLE
Fix TranslationServer locale fallback cache not resetting on locale switch (fixes #116051)

### DIFF
--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -485,6 +485,7 @@ void TranslationServer::set_locale(const String &p_locale) {
 	}
 
 	locale = new_locale;
+	locale_compare_cache.clear(); // Invalidate so fallback resolution is re-evaluated for the new locale (fixes GH-116051).
 	ResourceLoader::reload_translation_remaps();
 
 	if (OS::get_singleton()->get_main_loop()) {
@@ -497,7 +498,10 @@ String TranslationServer::get_locale() const {
 }
 
 void TranslationServer::set_fallback_locale(const String &p_locale) {
-	fallback = p_locale;
+	if (fallback != p_locale) {
+		fallback = p_locale;
+		locale_compare_cache.clear();
+	}
 }
 
 String TranslationServer::get_fallback_locale() const {


### PR DESCRIPTION

When switching TranslationServer.locale between related locales (e.g. zh_Hans ↔ zh_Hant or en ↔ en_US), previously loaded translations could remain active even after switching back to the original locale.

This PR ensures that locale changes correctly invalidate cached translation state so that fallback resolution behaves as expected after runtime locale switches.

Tested using the provided MRP with zh_Hans / zh_Hant and en / en_US.