### PR TITLE
Prevent 2D editor camera from recentering when toggling node visibility (fixes #116048)

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4199,7 +4199,18 @@ void SceneTreeDock::save_branch_to_file(const String &p_directory) {
 	_tool_selected(TOOL_NEW_SCENE_FROM);
 }
 
+void SceneTreeDock::_on_visibility_toggle_clicked() {
+	// Toggling visibility from the SceneTree eye icon should not recenter the 2D/3D viewport (fixes GH-116048).
+	skip_next_focus_node = true;
+}
+
 void SceneTreeDock::_focus_node() {
+	// Do not recenter view when the user just toggled visibility via the eye icon.
+	if (skip_next_focus_node) {
+		skip_next_focus_node = false;
+		return;
+	}
+
 	Node *node = scene_tree->get_selected();
 	// This method handles the item_icon_double_clicked signal and there is no guarantee anything is actually selected.
 	if (!node) {
@@ -4944,6 +4955,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 
 	scene_tree->get_scene_tree()->connect(SceneStringName(gui_input), callable_mp(this, &SceneTreeDock::_scene_tree_gui_input));
 	scene_tree->get_scene_tree()->connect("item_icon_double_clicked", callable_mp(this, &SceneTreeDock::_focus_node));
+	scene_tree->connect("visibility_toggle_clicked", callable_mp(this, &SceneTreeDock::_on_visibility_toggle_clicked));
 
 	editor_selection->connect("selection_changed", callable_mp(this, &SceneTreeDock::_selection_changed));
 

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -183,6 +183,7 @@ class SceneTreeDock : public EditorDock {
 	Node *edited_scene = nullptr;
 	Node *pending_click_select = nullptr;
 	bool tree_clicked = false;
+	bool skip_next_focus_node = false; // Skip centering 2D/3D view when SceneTree eye icon was just toggled (fixes GH-116048).
 
 	VBoxContainer *create_root_dialog = nullptr;
 	String selected_favorite_root;
@@ -208,6 +209,7 @@ class SceneTreeDock : public EditorDock {
 	void _script_open_request(const Ref<Script> &p_script);
 	void _push_item(Object *p_object);
 	void _handle_select(Node *p_node);
+	void _on_visibility_toggle_clicked();
 
 	bool _cyclical_dependency_exists(const String &p_target_scene_path, Node *p_desired_node);
 	bool _track_inherit(const String &p_target_scene_path, Node *p_desired_node);

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -133,6 +133,8 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 			}
 		}
 		undo_redo->commit_action();
+		// Notify dock so it can skip focusing 2D/3D view on the next item_icon_double_clicked (fixes GH-116048).
+		emit_signal(SNAME("visibility_toggle_clicked"));
 	} else if (p_id == BUTTON_LOCK) {
 		undo_redo->create_action(TTR("Unlock Node"));
 		undo_redo->add_do_method(n, "remove_meta", "_edit_lock_");
@@ -2153,6 +2155,7 @@ void SceneTreeEditor::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("open"));
 	ADD_SIGNAL(MethodInfo("open_script"));
+	ADD_SIGNAL(MethodInfo("visibility_toggle_clicked"));
 }
 
 SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_open_instance) :


### PR DESCRIPTION


Toggling node visibility from the SceneTree eye icon should not affect the 2D editor camera position.

Previously, quickly hiding and unhiding a node could cause the 2D viewport to automatically recenter on that node, disrupting workflow when comparing or arranging multiple nodes.

This PR ensures that visibility toggles do not trigger camera centering unless explicitly requested by the user.