### PR TITLE
Fix multithreaded load status progress

### DIFF
--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -188,6 +188,7 @@ private:
 		ResourceFormatLoader::CacheMode cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE;
 		Error error = OK;
 		Ref<Resource> resource;
+		ThreadLoadTask *parent_task = nullptr;
 		HashSet<String> sub_tasks;
 
 		bool awaited : 1; // If it's in the pool, this helps not awaiting from more than one dependent thread.
@@ -213,7 +214,6 @@ private:
 	static thread_local bool import_thread;
 	static thread_local int load_nesting;
 	static thread_local HashMap<int, HashMap<String, Ref<Resource>>> res_ref_overrides; // Outermost key is nesting level.
-	static thread_local Vector<String> load_paths_stack;
 	static thread_local ThreadLoadTask *curr_load_task;
 
 	static SafeBinaryMutex<BINARY_MUTEX_TAG> thread_load_mutex;


### PR DESCRIPTION
When performing a multithreaded load (load_threaded_request with use_sub_threads == true), the reported progress ratio is evolving weirdly. 

I found out that the way we build hierarchy between load tasks is wrong: instead of linking a new load task to the task that requested it, we link it instead to the current task on the current thread **once the task is started**. It works well when use_sub_threads is false, because everyting is done on a same thread, but it doesn't work with multiple threads, because a new task can be ran on another thread than the one which requested it. 

To fix the issue, I linked a new task to to the current one at the moment we build the task, so we are still on the requester thread. Without my fix the same was done but at the moment the task starts, most likely on a different thread. 

Before the fix:

https://github.com/user-attachments/assets/09f31f98-81be-45c5-b796-93a6822d0b32

After the fix:

https://github.com/user-attachments/assets/59aef888-a3ca-405d-b0ca-5ee8e0e0da25

