### PR TITLE
Replace `//` with `\\` before sending project path to MSBuild

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -154,7 +154,17 @@ namespace GodotTools.Build
             arguments.Add(buildInfo.OnlyClean ? "clean" : "build");
 
             // C# Project
-            arguments.Add(buildInfo.Project);
+            string projectPath = buildInfo.Project;
+            if (OperatingSystem.IsWindows())
+            {
+                // On Windows, when using a network share path, the path may start with "//"
+                // which MSBuild will treat like a switch. Convert to "\\" to make it an absolute path.
+                if (projectPath.StartsWith("//"))
+                {
+                    projectPath = "\\\\" + projectPath.Substring(2);
+                }
+            }
+            arguments.Add(projectPath);
 
             // `dotnet clean` doesn't recognize these options
             if (!buildInfo.OnlyClean)
@@ -195,7 +205,17 @@ namespace GodotTools.Build
             arguments.Add("publish"); // `dotnet publish` command
 
             // C# Project
-            arguments.Add(buildInfo.Project);
+            string projectPath = buildInfo.Project;
+            if (OperatingSystem.IsWindows())
+            {
+                // On Windows, when using a network share path, the path may start with "//"
+                // which MSBuild will treat like a switch. Convert to "\\" to make it an absolute path.
+                if (projectPath.StartsWith("//"))
+                {
+                    projectPath = "\\\\" + projectPath.Substring(2);
+                }
+            }
+            arguments.Add(projectPath);
 
             // Restore
             // `dotnet publish` restores by default, unless requested not to


### PR DESCRIPTION
Similar to #85335.

On Windows with network shares, the project path starts with `//` which MSBuild treats as a command-line switch, causing "Unknown switch" errors. For example:
```
Running:  "C:\Program Files\dotnet\dotnet.EXE" build //networkshare/path/to/project.csproj -c Debug -v normal -l:GodotTools.BuildLogger.GodotBuildLogger,D:/Godot/Godot_v4.6-stable_mono_win64/GodotSharp/Tools\GodotTools.BuildLogger.dll;C:/Users/James/AppData/Roaming/Godot/mono/build_logs\08f09efdacd19a87595123acac7446d9_Debug -p:GodotTargetPlatform=windows
MSBUILD : error MSB1001: Unknown switch.
    Full command line: 'C:\Program Files\dotnet\sdk\6.0.403\MSBuild.dll -maxcpucount -verbosity:m -nologo -restore -consoleloggerparameters:Summary --property:GodotTargetPlatform=windows -property:Configuration=Debug -verbosity:normal //networkshare/path/to/project.csproj -l:GodotTools.BuildLogger.GodotBuildLogger,D:/Godot/Godot_v4.6-stable_mono_win64/GodotSharp/Tools\GodotTools.BuildLogger.dll;C:/Users/James/AppData/Roaming/Godot/mono/build_logs\08f09efdacd19a87595123acac7446d9_Debug -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,C:\Program Files\dotnet\sdk\8.0.417\dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,C:\Program Files\dotnet\sdk\8.0.417\dotnet.dll'
  Switches appended by response files:
Switch: //networkshare/path/to/project.csproj

For switch syntax, type "MSBuild -help"
```

When on windows and the first two chars are `//`, this patch replaces the first two chars with `\\` (`\\\\` escaped) to make it a proper UNC path.

I built GodotTools.dll locally and swapped it into Godot 4.6 and it fixed the problem.
