### PR TITLE
Fix viewport text not clearing after commit/cancel of custom editor gizmo handles

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -1925,6 +1925,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						// Restore.
 						_edit.gizmo->commit_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, _edit.gizmo_initial_value, true);
 						_edit.gizmo = Ref<EditorNode3DGizmo>();
+						set_message("");
 					}
 
 					if (_edit.mode == TRANSFORM_NONE) {
@@ -2242,6 +2243,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 							selected_node->update_gizmos();
 						}
 						_edit.gizmo = Ref<EditorNode3DGizmo>();
+						set_message("");
 						break;
 					}
 
@@ -2580,6 +2582,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 				// Restore.
 				_edit.gizmo->commit_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, _edit.gizmo_initial_value, true);
 				_edit.gizmo = Ref<EditorNode3DGizmo>();
+				set_message("");
 			}
 			if (k->get_keycode() == Key::ESCAPE && !cursor.region_select && !k->is_echo()) {
 				_clear_selected();
@@ -3625,6 +3628,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 				spatial_editor->get_single_selected_node()->update_gizmos();
 				_edit.gizmo = Ref<EditorNode3DGizmo>();
+				set_message("");
 			}
 		} break;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->



https://github.com/user-attachments/assets/6ae3cfc2-44d8-4da6-8792-7d8bee7c508f

