### PR TITLE
Fix custom importers do not work with singletons (reverted)

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -338,14 +338,15 @@ void EditorFileSystem::_first_scan_filesystem() {
 	ep.step(TTR("Verifying GDExtensions..."), 2, true);
 	GDExtensionManager::get_singleton()->ensure_extensions_loaded(extensions);
 
-	// Now that all the global class names should be loaded, create autoloads and plugins.
-	// This is done after loading the global class names because autoloads and plugins can use
-	// global class names.
-	ep.step(TTR("Creating autoload scripts..."), 3, true);
-	ProjectSettingsEditor::get_singleton()->init_autoloads();
-
-	ep.step(TTR("Initializing plugins..."), 4, true);
+	// Now that all the global class names should be loaded, create plugins.
+	// This is done after loading the global class names because plugins can use global class names.
+	ep.step(TTR("Initializing plugins..."), 3, true);
 	EditorNode::get_singleton()->init_plugins();
+
+	// Now that plugins and global class names should be loaded, create autoloads.
+	// This is done last because autoloads can use global class names and plugins.
+	ep.step(TTR("Creating autoload scripts..."), 4, true);
+	ProjectSettingsEditor::get_singleton()->init_autoloads();
 
 	ep.step(TTR("Starting file scan..."), 5, true);
 }


### PR DESCRIPTION
*Bugsquad edit:* Reverted in PR #116171

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

quoting @ydeltastar in #115618:

> This is because autoloads are initialized before addons. The preload triggers a reimport when the imported file is missing but the importer addon hasn't loaded yet so it fallback to the default one.
> 
> > [godot/editor/file_system/editor_file_system.cpp](https://github.com/godotengine/godot/blob/80a4af1cc7c97b41f819ac2ac519a12804a53b1c/editor/file_system/editor_file_system.cpp#L341-L348)
> > Lines 341 to 348 in [80a4af1](/godotengine/godot/commit/80a4af1cc7c97b41f819ac2ac519a12804a53b1c)
> 
> This order is strange since autoloads are more likely to rely on addons than the other way around.
> 
> Doesn't look like there is a good reason for this order. Even a tool autoload doesn't run any code until the addons are added and ready in the editor but since `preload()` has effects during loading/parsing of the autoload script, it causes this issue.
> 
> I have the order reversed in my custom build and it solved my issues with preloads in autoloads and addons.

[link](https://github.com/godotengine/godot/issues/115618#issuecomment-3824327324)

* *Bugsquad edit, fixes: #115618*