### PR TITLE
Use correct texture sizes for SMAA when using temporal upscaling

### DIFF
--- a/servers/rendering/renderer_rd/effects/smaa.cpp
+++ b/servers/rendering/renderer_rd/effects/smaa.cpp
@@ -147,7 +147,9 @@ SMAA::~SMAA() {
 }
 
 void SMAA::allocate_render_targets(Ref<RenderSceneBuffersRD> p_render_buffers) {
-	Size2i full_size = p_render_buffers->get_internal_size();
+	RSE::ViewportScaling3DType scaling_type = RSE::scaling_3d_mode_type(p_render_buffers->get_scaling_3d_mode());
+	bool use_upscaled_texture = p_render_buffers->has_upscaled_texture() && scaling_type == RSE::VIEWPORT_SCALING_3D_TYPE_TEMPORAL;
+	Size2i full_size = use_upscaled_texture ? p_render_buffers->get_target_size() : p_render_buffers->get_internal_size();
 
 	// As we're not clearing these, and render buffers will return the cached texture if it already exists,
 	// we don't first check has_texture here.
@@ -167,7 +169,9 @@ void SMAA::process(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_source_colo
 	memset(&smaa.weight_push_constant, 0, sizeof(SMAAWeightPushConstant));
 	memset(&smaa.blend_push_constant, 0, sizeof(SMAABlendPushConstant));
 
-	Size2i size = p_render_buffers->get_internal_size();
+	RSE::ViewportScaling3DType scaling_type = RSE::scaling_3d_mode_type(p_render_buffers->get_scaling_3d_mode());
+	bool use_upscaled_texture = p_render_buffers->has_upscaled_texture() && scaling_type == RSE::VIEWPORT_SCALING_3D_TYPE_TEMPORAL;
+	Size2i size = use_upscaled_texture ? p_render_buffers->get_target_size() : p_render_buffers->get_internal_size();
 	Size2 inv_size = Size2(1.0f / (float)size.x, 1.0f / (float)size.y);
 
 	smaa.edge_push_constant.inv_size[0] = inv_size.x;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -764,9 +764,9 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 			// If we use a spatial upscaler to upscale or SMAA to antialias we need to write our result into an intermediate buffer.
 			// Note that this is cached so we only create the texture the first time.
 			dest_fb_format = rb->get_base_data_format();
-			RID dest_texture = rb->create_texture(SNAME("Tonemapper"), SNAME("destination"), dest_fb_format, RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT, RD::TEXTURE_SAMPLES_1, Size2i(), 0, 1, true, true);
+			RID dest_texture = rb->create_texture(SNAME("Tonemapper"), SNAME("destination"), dest_fb_format, RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT, RD::TEXTURE_SAMPLES_1, color_size, 0, 1, true, true);
 			dest_fb = FramebufferCacheRD::get_singleton()->get_cache(dest_texture);
-			tonemap.dest_texture_size = rb->get_internal_size();
+			tonemap.dest_texture_size = color_size;
 		} else {
 			// If we do a bilinear upscale we just render into our render target and our shader will upscale automatically.
 			// Target size in this case is lying as we never get our real target size communicated.


### PR DESCRIPTION
This just uses the correct sizes for textures when using a color texture which has already been upscaled before post-processing.

The screenshots are using FSR2.0 + 0.33 scale + SMAA
**Before:** <img width="1339" height="836" alt="image" src="https://github.com/user-attachments/assets/51eec4ec-e3e7-4833-9c3b-40a428d2c407" />
**After:** <img width="1340" height="831" alt="image" src="https://github.com/user-attachments/assets/6eb67330-dc2f-4ee7-8b24-3c8cd39db03d" />

Fixes https://github.com/godotengine/godot/issues/111650