### PR TITLE
Fix Font's documentation for `ascent`/`get_descent`

### DIFF
--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -133,7 +133,7 @@
 			<return type="float" />
 			<param index="0" name="font_size" type="int" default="16" />
 			<description>
-				Returns the average font ascent (number of pixels above the baseline).
+				Returns the maximum font ascent (number of pixels above the baseline) of this font and all fallback fonts.
 				[b]Note:[/b] Real ascent of the string is context-dependent and can be significantly different from the value returned by this function. Use it only as rough estimate (e.g. as the ascent of empty line).
 			</description>
 		</method>
@@ -150,7 +150,7 @@
 			<return type="float" />
 			<param index="0" name="font_size" type="int" default="16" />
 			<description>
-				Returns the average font descent (number of pixels below the baseline).
+				Returns the maximum font descent (number of pixels below the baseline) of this font and all fallback fonts.
 				[b]Note:[/b] Real descent of the string is context-dependent and can be significantly different from the value returned by this function. Use it only as rough estimate (e.g. as the descent of empty line).
 			</description>
 		</method>


### PR DESCRIPTION
Now they're more accurate to what they actually return (the maximum, not the average).

Closes #116087 