### PR TITLE
Fix auto-translation of EditorValidationPanel

### DIFF
--- a/editor/docks/groups_editor.cpp
+++ b/editor/docks/groups_editor.cpp
@@ -704,7 +704,7 @@ void GroupsEditor::_show_add_group_dialog() {
 		add_group_dialog->register_text_enter(add_group_description);
 
 		add_validation_panel = memnew(EditorValidationPanel);
-		add_validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Group name is valid."));
+		add_validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Group name is valid."));
 		add_validation_panel->set_update_callback(callable_mp(this, &GroupsEditor::_check_add));
 		add_validation_panel->set_accept_button(add_group_dialog->get_ok_button());
 
@@ -745,7 +745,7 @@ void GroupsEditor::_show_rename_group_dialog() {
 		rename_group_dialog->register_text_enter(rename_group);
 
 		rename_validation_panel = memnew(EditorValidationPanel);
-		rename_validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Group name is valid."));
+		rename_validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Group name is valid."));
 		rename_validation_panel->set_update_callback(callable_mp(this, &GroupsEditor::_check_rename));
 		rename_validation_panel->set_accept_button(rename_group_dialog->get_ok_button());
 
@@ -832,9 +832,9 @@ void GroupsEditor::_check_rename() {
 
 void GroupsEditor::_validate_name(const String &p_name, EditorValidationPanel *p_validation_panel) {
 	if (p_name.is_empty()) {
-		p_validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Group can't be empty."), EditorValidationPanel::MSG_ERROR);
+		p_validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Group can't be empty."), EditorValidationPanel::MSG_ERROR);
 	} else if (_has_group(p_name)) {
-		p_validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Group already exists."), EditorValidationPanel::MSG_ERROR);
+		p_validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Group already exists."), EditorValidationPanel::MSG_ERROR);
 	}
 }
 

--- a/editor/gui/directory_create_dialog.cpp
+++ b/editor/gui/directory_create_dialog.cpp
@@ -102,12 +102,12 @@ void DirectoryCreateDialog::_on_dir_path_changed() {
 	if (error.is_empty()) {
 		if (path.contains_char('/')) {
 			if (mode == MODE_DIRECTORY) {
-				validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Using slashes in folder names will create subfolders recursively."), EditorValidationPanel::MSG_OK);
+				validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Using slashes in folder names will create subfolders recursively."), EditorValidationPanel::MSG_OK);
 			} else {
-				validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Using slashes in path will create the file in subfolder, creating new subfolders if necessary."), EditorValidationPanel::MSG_OK);
+				validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Using slashes in path will create the file in subfolder, creating new subfolders if necessary."), EditorValidationPanel::MSG_OK);
 			}
 		} else if (mode == MODE_FILE) {
-			validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("File name is valid."), EditorValidationPanel::MSG_OK);
+			validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("File name is valid."), EditorValidationPanel::MSG_OK);
 		}
 	} else {
 		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, error, EditorValidationPanel::MSG_ERROR);
@@ -177,7 +177,7 @@ DirectoryCreateDialog::DirectoryCreateDialog() {
 
 	validation_panel = memnew(EditorValidationPanel);
 	vb->add_child(validation_panel);
-	validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Folder name is valid."));
+	validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Folder name is valid."));
 	validation_panel->set_update_callback(callable_mp(this, &DirectoryCreateDialog::_on_dir_path_changed));
 	validation_panel->set_accept_button(get_ok_button());
 

--- a/editor/inspector/add_metadata_dialog.cpp
+++ b/editor/inspector/add_metadata_dialog.cpp
@@ -64,7 +64,7 @@ AddMetadataDialog::AddMetadataDialog() {
 
 	validation_panel = memnew(EditorValidationPanel);
 	vbc->add_child(validation_panel);
-	validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name is valid."));
+	validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Metadata name is valid."));
 	validation_panel->set_update_callback(callable_mp(this, &AddMetadataDialog::_check_meta_name));
 	validation_panel->set_accept_button(get_ok_button());
 
@@ -104,12 +104,12 @@ void AddMetadataDialog::_check_meta_name() {
 	const String meta_name = add_meta_name->get_text();
 
 	if (meta_name.is_empty()) {
-		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name can't be empty."), EditorValidationPanel::MSG_ERROR);
+		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Metadata name can't be empty."), EditorValidationPanel::MSG_ERROR);
 	} else if (!meta_name.is_valid_ascii_identifier()) {
-		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Metadata name must be a valid identifier."), EditorValidationPanel::MSG_ERROR);
+		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Metadata name must be a valid identifier."), EditorValidationPanel::MSG_ERROR);
 	} else if (_existing_metas.find(meta_name)) {
 		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, vformat(TTR("Metadata with name \"%s\" already exists."), meta_name), EditorValidationPanel::MSG_ERROR);
 	} else if (meta_name[0] == '_') {
-		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Names starting with _ are reserved for editor-only metadata."), EditorValidationPanel::MSG_ERROR);
+		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Names starting with _ are reserved for editor-only metadata."), EditorValidationPanel::MSG_ERROR);
 	}
 }

--- a/editor/plugins/plugin_config_dialog.cpp
+++ b/editor/plugins/plugin_config_dialog.cpp
@@ -107,15 +107,15 @@ void PluginConfigDialog::_on_canceled() {
 
 void PluginConfigDialog::_on_required_text_changed() {
 	if (name_edit->get_text().is_empty()) {
-		validation_panel->set_message(MSG_ID_PLUGIN, TTR("Plugin name cannot be blank."), EditorValidationPanel::MSG_ERROR);
+		validation_panel->set_message(MSG_ID_PLUGIN, TTRC("Plugin name cannot be blank."), EditorValidationPanel::MSG_ERROR);
 	}
 	if (subfolder_edit->is_visible()) {
 		if (!subfolder_edit->get_text().is_empty() && !subfolder_edit->get_text().is_valid_filename()) {
-			validation_panel->set_message(MSG_ID_SUBFOLDER, TTR("Subfolder name is not a valid folder name."), EditorValidationPanel::MSG_ERROR);
+			validation_panel->set_message(MSG_ID_SUBFOLDER, TTRC("Subfolder name is not a valid folder name."), EditorValidationPanel::MSG_ERROR);
 		} else {
 			String path = "res://addons/" + _get_subfolder();
 			if (!_edit_mode && DirAccess::exists(path)) { // Only show this error if in "create" mode.
-				validation_panel->set_message(MSG_ID_SUBFOLDER, TTR("Subfolder cannot be one which already exists."), EditorValidationPanel::MSG_ERROR);
+				validation_panel->set_message(MSG_ID_SUBFOLDER, TTRC("Subfolder cannot be one which already exists."), EditorValidationPanel::MSG_ERROR);
 			}
 		}
 	} else {
@@ -132,7 +132,7 @@ void PluginConfigDialog::_on_required_text_changed() {
 		validation_panel->set_message(MSG_ID_SCRIPT, vformat(TTR("Script extension must match chosen language extension (.%s)."), ext), EditorValidationPanel::MSG_ERROR);
 	}
 	if (language->get_name() == "GDScript") {
-		validation_panel->set_message(MSG_ID_ENABLE_WARNINGS, TTR("Consider enabling GDScript warnings for this plugin by adding an entry for it to the project setting Debug > GDScript > Warnings > Directory Rules."), EditorValidationPanel::MSG_INFO);
+		validation_panel->set_message(MSG_ID_ENABLE_WARNINGS, TTRC("Consider enabling GDScript warnings for this plugin by adding an entry for it to the project setting Debug > GDScript > Warnings > Directory Rules."), EditorValidationPanel::MSG_INFO);
 	}
 }
 
@@ -316,11 +316,11 @@ PluginConfigDialog::PluginConfigDialog() {
 
 	validation_panel = memnew(EditorValidationPanel);
 	vbox->add_child(validation_panel);
-	validation_panel->add_line(MSG_ID_PLUGIN, TTR("Plugin name is valid."));
-	validation_panel->add_line(MSG_ID_SCRIPT, TTR("Script extension is valid."));
-	validation_panel->add_line(MSG_ID_SUBFOLDER, TTR("Subfolder name is valid."));
-	validation_panel->add_line(MSG_ID_ACTIVE, "");
-	validation_panel->add_line(MSG_ID_ENABLE_WARNINGS, "");
+	validation_panel->add_line(MSG_ID_PLUGIN, TTRC("Plugin name is valid."));
+	validation_panel->add_line(MSG_ID_SCRIPT, TTRC("Script extension is valid."));
+	validation_panel->add_line(MSG_ID_SUBFOLDER, TTRC("Subfolder name is valid."));
+	validation_panel->add_line(MSG_ID_ACTIVE);
+	validation_panel->add_line(MSG_ID_ENABLE_WARNINGS);
 	validation_panel->set_update_callback(callable_mp(this, &PluginConfigDialog::_on_required_text_changed));
 	validation_panel->set_accept_button(get_ok_button());
 

--- a/editor/scene/group_settings_editor.cpp
+++ b/editor/scene/group_settings_editor.cpp
@@ -126,9 +126,9 @@ void GroupSettingsEditor::_check_rename() {
 	}
 
 	if (new_name.is_empty()) {
-		rename_validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Group can't be empty."), EditorValidationPanel::MSG_ERROR);
+		rename_validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Group can't be empty."), EditorValidationPanel::MSG_ERROR);
 	} else if (ProjectSettings::get_singleton()->has_global_group(new_name)) {
-		rename_validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Group already exists."), EditorValidationPanel::MSG_ERROR);
+		rename_validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Group already exists."), EditorValidationPanel::MSG_ERROR);
 	}
 }
 
@@ -449,7 +449,7 @@ void GroupSettingsEditor::_show_rename_dialog() {
 		rename_group_dialog->register_text_enter(rename_group);
 
 		rename_validation_panel = memnew(EditorValidationPanel);
-		rename_validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Group name is valid."));
+		rename_validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTRC("Group name is valid."));
 		rename_validation_panel->set_update_callback(callable_mp(this, &GroupSettingsEditor::_check_rename));
 		rename_validation_panel->set_accept_button(rename_group_dialog->get_ok_button());
 

--- a/editor/scene/scene_create_dialog.cpp
+++ b/editor/scene/scene_create_dialog.cpp
@@ -103,7 +103,7 @@ void SceneCreateDialog::update_dialog() {
 	scene_name = scene_name_edit->get_text().strip_edges();
 
 	if (scene_name.is_empty()) {
-		validation_panel->set_message(MSG_ID_PATH, TTR("Scene name is empty."), EditorValidationPanel::MSG_ERROR);
+		validation_panel->set_message(MSG_ID_PATH, TTRC("Scene name is empty."), EditorValidationPanel::MSG_ERROR);
 	}
 
 	if (validation_panel->is_valid()) {
@@ -114,16 +114,16 @@ void SceneCreateDialog::update_dialog() {
 	}
 
 	if (validation_panel->is_valid() && !scene_name.is_valid_filename()) {
-		validation_panel->set_message(MSG_ID_PATH, TTR("File name invalid."), EditorValidationPanel::MSG_ERROR);
+		validation_panel->set_message(MSG_ID_PATH, TTRC("File name invalid."), EditorValidationPanel::MSG_ERROR);
 	} else if (validation_panel->is_valid() && scene_name[0] == '.') {
-		validation_panel->set_message(MSG_ID_PATH, TTR("File name begins with a dot."), EditorValidationPanel::MSG_ERROR);
+		validation_panel->set_message(MSG_ID_PATH, TTRC("File name begins with a dot."), EditorValidationPanel::MSG_ERROR);
 	}
 
 	if (validation_panel->is_valid()) {
 		scene_name = directory.path_join(scene_name);
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		if (da->file_exists(scene_name)) {
-			validation_panel->set_message(MSG_ID_PATH, TTR("File already exists."), EditorValidationPanel::MSG_ERROR);
+			validation_panel->set_message(MSG_ID_PATH, TTRC("File already exists."), EditorValidationPanel::MSG_ERROR);
 		}
 	}
 
@@ -148,9 +148,9 @@ void SceneCreateDialog::update_dialog() {
 	}
 
 	if (root_name.is_empty()) {
-		validation_panel->set_message(MSG_ID_ROOT, TTR("Invalid root node name."), EditorValidationPanel::MSG_ERROR);
+		validation_panel->set_message(MSG_ID_ROOT, TTRC("Invalid root node name."), EditorValidationPanel::MSG_ERROR);
 	} else if (root_name != root_name.validate_node_name()) {
-		validation_panel->set_message(MSG_ID_ROOT, TTR("Invalid root node name characters have been replaced."), EditorValidationPanel::MSG_WARNING);
+		validation_panel->set_message(MSG_ID_ROOT, TTRC("Invalid root node name characters have been replaced."), EditorValidationPanel::MSG_WARNING);
 	}
 }
 
@@ -303,8 +303,8 @@ SceneCreateDialog::SceneCreateDialog() {
 
 	validation_panel = memnew(EditorValidationPanel);
 	main_vb->add_child(validation_panel);
-	validation_panel->add_line(MSG_ID_PATH, TTR("Scene name is valid."));
-	validation_panel->add_line(MSG_ID_ROOT, TTR("Root node valid."));
+	validation_panel->add_line(MSG_ID_PATH, TTRC("Scene name is valid."));
+	validation_panel->add_line(MSG_ID_ROOT, TTRC("Root node valid."));
 	validation_panel->set_update_callback(callable_mp(this, &SceneCreateDialog::update_dialog));
 	validation_panel->set_accept_button(get_ok_button());
 

--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -237,28 +237,28 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 	}
 
 	if (p.is_empty()) {
-		return TTR("Path is empty.");
+		return TTRC("Path is empty.");
 	}
 	if (p.get_file().get_basename().is_empty()) {
-		return TTR("Filename is empty.");
+		return TTRC("Filename is empty.");
 	}
 
 	if (!p.get_file().get_basename().is_valid_filename()) {
-		return TTR("Filename is invalid.");
+		return TTRC("Filename is invalid.");
 	}
 	if (p.get_file().begins_with(".")) {
-		return TTR("Name begins with a dot.");
+		return TTRC("Name begins with a dot.");
 	}
 
 	p = ProjectSettings::get_singleton()->localize_path(p);
 	if (!p.begins_with("res://")) {
-		return TTR("Path is not local.");
+		return TTRC("Path is not local.");
 	}
 
 	{
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		if (da->change_dir(p.get_base_dir()) != OK) {
-			return TTR("Base path is invalid.");
+			return TTRC("Base path is invalid.");
 		}
 	}
 
@@ -266,9 +266,9 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 		// Check if file exists.
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		if (da->dir_exists(p)) {
-			return TTR("A directory with the same name exists.");
+			return TTRC("A directory with the same name exists.");
 		} else if (p_file_must_exist && !da->file_exists(p)) {
-			return TTR("File does not exist.");
+			return TTRC("File does not exist.");
 		}
 	}
 
@@ -298,10 +298,10 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 	}
 
 	if (!found) {
-		return TTR("Invalid extension.");
+		return TTRC("Invalid extension.");
 	}
 	if (!match) {
-		return TTR("Extension doesn't match chosen language.");
+		return TTRC("Extension doesn't match chosen language.");
 	}
 
 	// Let ScriptLanguage do custom validation.
@@ -619,15 +619,15 @@ void ScriptCreateDialog::_update_dialog() {
 	// Is script path/name valid (order from top to bottom)?
 
 	if (!is_built_in && !is_path_valid) {
-		validation_panel->set_message(MSG_ID_SCRIPT, TTR("Invalid path."), EditorValidationPanel::MSG_ERROR);
+		validation_panel->set_message(MSG_ID_SCRIPT, TTRC("Invalid path."), EditorValidationPanel::MSG_ERROR);
 	}
 
 	if (!is_parent_name_valid && is_new_script_created) {
-		validation_panel->set_message(MSG_ID_SCRIPT, TTR("Invalid inherited parent name or path."), EditorValidationPanel::MSG_ERROR);
+		validation_panel->set_message(MSG_ID_SCRIPT, TTRC("Invalid inherited parent name or path."), EditorValidationPanel::MSG_ERROR);
 	}
 
 	if (validation_panel->is_valid() && !is_new_script_created) {
-		validation_panel->set_message(MSG_ID_SCRIPT, TTR("File exists, it will be reused."), EditorValidationPanel::MSG_OK);
+		validation_panel->set_message(MSG_ID_SCRIPT, TTRC("File exists, it will be reused."), EditorValidationPanel::MSG_OK);
 	}
 
 	if (!is_built_in && !path_error.is_empty()) {
@@ -657,9 +657,9 @@ void ScriptCreateDialog::_update_dialog() {
 	// Is Script created or loaded from existing file?
 
 	if (is_built_in) {
-		validation_panel->set_message(MSG_ID_BUILT_IN, TTR("Note: Built-in scripts have some limitations and can't be edited using an external editor."), EditorValidationPanel::MSG_INFO, false);
+		validation_panel->set_message(MSG_ID_BUILT_IN, TTRC("Note: Built-in scripts have some limitations and can't be edited using an external editor."), EditorValidationPanel::MSG_INFO, false);
 	} else if (file_path->get_text().get_file().get_basename() == parent_name->get_text()) {
-		validation_panel->set_message(MSG_ID_BUILT_IN, TTR("Warning: Having the script name be the same as a built-in type is usually not desired."), EditorValidationPanel::MSG_WARNING, false);
+		validation_panel->set_message(MSG_ID_BUILT_IN, TTRC("Warning: Having the script name be the same as a built-in type is usually not desired."), EditorValidationPanel::MSG_WARNING, false);
 	}
 
 	path_controls[0]->set_visible(!is_built_in);
@@ -678,16 +678,16 @@ void ScriptCreateDialog::_update_dialog() {
 
 	if (is_new_file) {
 		if (is_built_in) {
-			validation_panel->set_message(MSG_ID_PATH, TTR("Built-in script (into scene file)."), EditorValidationPanel::MSG_OK);
+			validation_panel->set_message(MSG_ID_PATH, TTRC("Built-in script (into scene file)."), EditorValidationPanel::MSG_OK);
 		}
 	} else {
 		template_inactive_message = TTRC("Using existing script file.");
 		if (load_enabled) {
 			if (is_path_valid) {
-				validation_panel->set_message(MSG_ID_PATH, TTR("Will load an existing script file."), EditorValidationPanel::MSG_OK);
+				validation_panel->set_message(MSG_ID_PATH, TTRC("Will load an existing script file."), EditorValidationPanel::MSG_OK);
 			}
 		} else {
-			validation_panel->set_message(MSG_ID_PATH, TTR("Script file already exists."), EditorValidationPanel::MSG_ERROR);
+			validation_panel->set_message(MSG_ID_PATH, TTRC("Script file already exists."), EditorValidationPanel::MSG_ERROR);
 		}
 	}
 
@@ -860,8 +860,8 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	/* Information Messages Field */
 
 	validation_panel = memnew(EditorValidationPanel);
-	validation_panel->add_line(MSG_ID_SCRIPT, TTR("Script path/name is valid."));
-	validation_panel->add_line(MSG_ID_PATH, TTR("Will create a new script file."));
+	validation_panel->add_line(MSG_ID_SCRIPT, TTRC("Script path/name is valid."));
+	validation_panel->add_line(MSG_ID_PATH, TTRC("Will create a new script file."));
 	validation_panel->add_line(MSG_ID_BUILT_IN);
 	validation_panel->add_line(MSG_ID_TEMPLATE);
 	validation_panel->set_update_callback(callable_mp(this, &ScriptCreateDialog::_update_dialog));

--- a/editor/shader/shader_create_dialog.cpp
+++ b/editor/shader/shader_create_dialog.cpp
@@ -385,25 +385,25 @@ String ShaderCreateDialog::_validate_path(const String &p_path) {
 	String stripped_file_path = p_path.strip_edges();
 
 	if (stripped_file_path.is_empty()) {
-		return TTR("Path is empty.");
+		return TTRC("Path is empty.");
 	}
 	if (stripped_file_path.get_file().get_basename().is_empty()) {
-		return TTR("Filename is empty.");
+		return TTRC("Filename is empty.");
 	}
 
 	stripped_file_path = ProjectSettings::get_singleton()->localize_path(stripped_file_path);
 	if (!stripped_file_path.begins_with("res://")) {
-		return TTR("Path is not local.");
+		return TTRC("Path is not local.");
 	}
 
 	Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	if (d->change_dir(stripped_file_path.get_base_dir()) != OK) {
-		return TTR("Invalid base path.");
+		return TTRC("Invalid base path.");
 	}
 
 	Ref<DirAccess> f = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	if (f->dir_exists(stripped_file_path)) {
-		return TTR("A directory with the same name exists.");
+		return TTRC("A directory with the same name exists.");
 	}
 
 	const ShaderCreateDialog::ShaderTypeData &current_type_data = type_data.get(current_type);
@@ -415,17 +415,17 @@ String ShaderCreateDialog::_validate_path(const String &p_path) {
 		}
 	}
 
-	return TTR("Invalid extension for selected shader type.");
+	return TTRC("Invalid extension for selected shader type.");
 }
 
 void ShaderCreateDialog::_update_dialog() {
 	if (!is_built_in && !is_path_valid) {
-		validation_panel->set_message(MSG_ID_SHADER, TTR("Invalid path."), EditorValidationPanel::MSG_ERROR);
+		validation_panel->set_message(MSG_ID_SHADER, TTRC("Invalid path."), EditorValidationPanel::MSG_ERROR);
 	}
 	if (!is_built_in && !path_error.is_empty()) {
 		validation_panel->set_message(MSG_ID_PATH, path_error, EditorValidationPanel::MSG_ERROR);
 	} else if (validation_panel->is_valid() && !is_new_shader_created) {
-		validation_panel->set_message(MSG_ID_SHADER, TTR("File exists, it will be reused."), EditorValidationPanel::MSG_OK);
+		validation_panel->set_message(MSG_ID_SHADER, TTRC("File exists, it will be reused."), EditorValidationPanel::MSG_OK);
 	}
 	if (!built_in_enabled) {
 		internal->set_pressed(false);
@@ -447,22 +447,22 @@ void ShaderCreateDialog::_update_dialog() {
 	internal->set_disabled(!built_in_enabled);
 
 	if (is_built_in) {
-		validation_panel->set_message(MSG_ID_BUILT_IN, TTR("Note: Built-in shaders can't be edited using an external editor."), EditorValidationPanel::MSG_INFO, false);
+		validation_panel->set_message(MSG_ID_BUILT_IN, TTRC("Note: Built-in shaders can't be edited using an external editor."), EditorValidationPanel::MSG_INFO, false);
 	}
 
 	if (is_built_in) {
 		set_ok_button_text(TTR("Create"));
-		validation_panel->set_message(MSG_ID_PATH, TTR("Built-in shader (into scene file)."), EditorValidationPanel::MSG_OK);
+		validation_panel->set_message(MSG_ID_PATH, TTRC("Built-in shader (into scene file)."), EditorValidationPanel::MSG_OK);
 	} else if (is_new_shader_created) {
 		set_ok_button_text(TTR("Create"));
 	} else if (load_enabled) {
 		set_ok_button_text(TTR("Load"));
 		if (is_path_valid) {
-			validation_panel->set_message(MSG_ID_PATH, TTR("Will load an existing shader file."), EditorValidationPanel::MSG_OK);
+			validation_panel->set_message(MSG_ID_PATH, TTRC("Will load an existing shader file."), EditorValidationPanel::MSG_OK);
 		}
 	} else {
 		set_ok_button_text(TTR("Create"));
-		validation_panel->set_message(MSG_ID_PATH, TTR("Shader file already exists."), EditorValidationPanel::MSG_ERROR);
+		validation_panel->set_message(MSG_ID_PATH, TTRC("Shader file already exists."), EditorValidationPanel::MSG_ERROR);
 	}
 }
 
@@ -484,8 +484,8 @@ ShaderCreateDialog::ShaderCreateDialog() {
 	// Error Fields.
 
 	validation_panel = memnew(EditorValidationPanel);
-	validation_panel->add_line(MSG_ID_SHADER, TTR("Shader path/name is valid."));
-	validation_panel->add_line(MSG_ID_PATH, TTR("Will create a new shader file."));
+	validation_panel->add_line(MSG_ID_SHADER, TTRC("Shader path/name is valid."));
+	validation_panel->add_line(MSG_ID_PATH, TTRC("Will create a new shader file."));
 	validation_panel->add_line(MSG_ID_BUILT_IN);
 	validation_panel->set_update_callback(callable_mp(this, &ShaderCreateDialog::_update_dialog));
 	validation_panel->set_accept_button(get_ok_button());


### PR DESCRIPTION
Technically part of #104574

I noticed that validation panel's default messages are translated. They are assigned only once, so this makes it impossible to change their language.

I made the messages assign untranslated instead and they are translated when setting the label's text (auto-translation can't be used because of `•` prefix).

The validation dialog now uses TTRC for its messages, with the exception of `vformat`ted messages, just like other parts of the editor.