### PR TITLE
Use RawInput + Windows.Gaming.Input on Windows

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -185,8 +185,6 @@
 				[code]product_id[/code]: The USB product ID of the device.
 				[code]serial_number[/code]: The serial number of the device. This key won't be present if the serial number is unavailable.
 				[code]steam_input_index[/code]: The Steam Input gamepad index, if the device is not a Steam Input device this key won't be present.
-				On Windows, the dictionary can have an additional field:
-				[code]xinput_index[/code]: The index of the controller in the XInput system. This key won't be present for devices not handled by XInput.
 				[b]Note:[/b] The returned dictionary is always empty on Android, iOS, visionOS, and Web.
 			</description>
 		</method>

--- a/drivers/sdl/SDL_build_config_private.h
+++ b/drivers/sdl/SDL_build_config_private.h
@@ -59,13 +59,11 @@
 #define HAVE_LIBC 1
 #define HAVE_DINPUT_H 1
 #define HAVE_XINPUT_H 1
-#if defined(_WIN32_MAXVER) && _WIN32_MAXVER >= 0x0A00 /* Windows 10 SDK */
 #define HAVE_WINDOWS_GAMING_INPUT_H 1
-#define SDL_JOYSTICK_WGI 1
-#endif
 #define SDL_JOYSTICK_DINPUT 1
 #define SDL_JOYSTICK_HIDAPI 1
 #define SDL_JOYSTICK_RAWINPUT 1
+//#define SDL_JOYSTICK_WGI 1 // This driver causes compilation issues.
 #define SDL_JOYSTICK_XINPUT 1
 #define SDL_HAPTIC_DINPUT 1
 #define SDL_THREAD_GENERIC_COND_SUFFIX 1

--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -63,6 +63,7 @@ JoypadSDL::~JoypadSDL() {
 
 Error JoypadSDL::initialize() {
 	SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
+	SDL_SetHint(SDL_HINT_JOYSTICK_RAWINPUT, "1");
 	SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
 	ERR_FAIL_COND_V_MSG(!SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_GAMEPAD), FAILED, SDL_GetError());
 
@@ -178,14 +179,6 @@ void JoypadSDL::process_events() {
 				if (steam_handle != 0) {
 					joypad_info["steam_input_index"] = itos(steam_handle);
 				}
-
-#ifdef WINDOWS_ENABLED
-				const int player_index = SDL_GetJoystickPlayerIndex(joy);
-				if (player_index >= 0 && joy_guid.data[14] == 'x') { // See also "SDL_IsJoystickXInput" in "thirdparty/sdl/joystick/SDL_joystick.c".
-					// For XInput controllers SDL_GetJoystickPlayerIndex returns the XInput user index.
-					joypad_info["xinput_index"] = itos(player_index);
-				}
-#endif
 
 				Input::get_singleton()->joy_connection_changed(
 						joy_id,


### PR DESCRIPTION
Alternative to https://github.com/godotengine/godot/pull/116055
Closes https://github.com/godotengine/godot-proposals/issues/8620

Instead of possibly doing a lot of work to introduce GameInput and remove DirectInput/XInput, this PR enables the RawInput backend for SDL that also uses "Windows.Gaming.Input" API to better handle more than 4 XInput controllers without removing previous drivers in the short term.

Advantages:
- We can (or should be able to) use more than 4 XInput controllers on Windows
- XInput is still working inside of RawInput backend, so there shouldn't be any regressions for the first 4 connected XInput controllers
- Compared to the GameInput solution, this PR shouldn't have any conflicts with https://github.com/godotengine/godot/pull/114642 since DirectInput is still supported and RawInput/WGI don't handle DirectInput-only controllers (I tested it)
- Compared to the GameInput solution, RawInput and WGI seem to be available in MinGW by default (because GCC Windows template compiles just fine)

Small disadvantages:
- For XInput controllers above the 4 controller limit, triggers, trigger rumble and joypad vibration won't work if the application is unfocused since WGI ignores devices in this case and RawInput doesn't support these features at all or properly. Trigger rumble won't work for any controllers in an unfocused application.
- Since XInput is now mostly only available through RawInput backend, `xinput_index` field of `Input.get_joy_info()` won't be available unless we explicitly disable RawInput through [SDL_JOYSTICK_RAWINPUT](https://wiki.libsdl.org/SDL3/SDL_HINT_JOYSTICK_RAWINPUT) environment variable
- ~~Compared to the GameInput solution, this one doesn't allow Godot games to be published in Microsoft Store 😅(note that it's a small/negligible disadvantage)~~ No longer the case.

TODO:
- [ ] Fix `xinput_index` being missing