### PR TITLE
Zero out padding in `NodePath` serialization

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1519,7 +1519,9 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 					encode_uint32(utf8.length(), buf);
 					buf += 4;
 					memcpy(buf, utf8.get_data(), utf8.length());
-					buf += pad + utf8.length();
+					buf += utf8.length();
+					memset(buf, 0, pad);
+					buf += pad;
 				}
 
 				r_len += 4 + utf8.length() + pad;


### PR DESCRIPTION
Fixes #116104.

`encode_variant` does not currently zero out the padding bytes that are added to align a serialized `NodePath` to a 4-byte boundary, potentially leading to random bytes from uninitialized memory being left in the written to buffer.

This adds that zeroing.