### PR TITLE
Fix documentation for `get_velocity_at_local_position`

### DIFF
--- a/doc/classes/PhysicsDirectBodyState2D.xml
+++ b/doc/classes/PhysicsDirectBodyState2D.xml
@@ -196,7 +196,8 @@
 			<return type="Vector2" />
 			<param index="0" name="local_position" type="Vector2" />
 			<description>
-				Returns the body's velocity at the given relative position, including both translation and rotation.
+				Returns the body's velocity at the given relative position.
+				[param local_position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="integrate_forces">

--- a/doc/classes/PhysicsDirectBodyState3D.xml
+++ b/doc/classes/PhysicsDirectBodyState3D.xml
@@ -196,7 +196,8 @@
 			<return type="Vector3" />
 			<param index="0" name="local_position" type="Vector3" />
 			<description>
-				Returns the body's velocity at the given relative position, including both translation and rotation.
+				Returns the body's velocity at the given relative position.
+				[param local_position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="integrate_forces">


### PR DESCRIPTION
Resolves godotengine/godot-docs#7110

There is a misleading description of the expected space of `local_position` parameter of `get_velocity_at_local_position` function of both `PhysicsDirectBodyState2D` and `PhysicsDirectBodyState3D` classes.

See the docs issue, but briefly, by passing an vector in local space of the body (both translation and rotation), gives incorrect values, by passing an vector in local translation, but global rotation (meaning an offset product of `global_point` - `body.transform.origin`) it returns the correct velocity value in global space.

The function has the same behaviour of `apply_force` for the parameter, expecting an vector in local translation space, but global rotation space.

It's ideal to rename the function to something like `get_velocity_at_offset`, but this goes outside the scope of this PR and the docs update is more urgent.