### PR TITLE
Use transmittance instead of opacity in the early-out branch when calculating volumetric fog

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1091,7 +1091,7 @@ layout(location = 2) out vec2 motion_vector;
 vec4 volumetric_fog_process(vec2 screen_uv, float z) {
 	vec3 fog_pos = vec3(screen_uv, z * implementation_data.volumetric_fog_inv_length);
 	if (fog_pos.z < 0.0) {
-		return vec4(0.0);
+		return vec4(0.0, 0.0, 0.0, 1.0);
 	} else if (fog_pos.z < 1.0) {
 		fog_pos.z = pow(fog_pos.z, implementation_data.volumetric_fog_detail_spread);
 	}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/116045

This fixes one more case that was implicitly using opacity in the volumetric fog calculations. When we switched to consistently use transmittance in https://github.com/godotengine/godot/pull/112494, the result of this early-out became  opaque black instead of a fully transparent black. This is because transmittance is `1-opacity`. 

This fix is totally safe and should be backported. The situations where this branch is triggered are quite rare, but should be fixed quickly since it is affecting real projects.

The MRP in https://github.com/godotengine/godot/issues/116045 uses a vertex shader to lock a QuadMesh to the near plane of the camera. For some reason that QuadMesh has Volumetric Fog applied to it as well despite being used for post-processing effects. Due to precision issues, fog_pos.z ends up slightly less than `0.0` on one corner. Which leads to a large section of the screen being less than `0.0` due to interpolation. This triggers this branch which, due to https://github.com/godotengine/godot/pull/112494, returns a fully opaque black fog. The fully opaque black fog overwrites the color calculated in the shader. And since this shader is actually an opaque QuadMesh, it overwrites the final pixel colour as well. 

While I think the MRP is a bit silly, the current behaviour is incorrect and avoidable and the MRP should be able to function correctly.