### PR TITLE
Uniformize LinkButton and MenuButton behavior to that of other buttons

### DIFF
--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -13,7 +13,6 @@
 		<member name="ellipsis_char" type="String" setter="set_ellipsis_char" getter="get_ellipsis_char" default="&quot;…&quot;">
 			Ellipsis character used for text clipping.
 		</member>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="3" />
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms. If left empty, the current locale is used instead.
 		</member>

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -34,7 +34,6 @@
 	<members>
 		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" overrides="BaseButton" enum="BaseButton.ActionMode" default="0" />
 		<member name="flat" type="bool" setter="set_flat" getter="is_flat" overrides="Button" default="true" />
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="3" />
 		<member name="item_count" type="int" setter="set_item_count" getter="get_item_count" default="0">
 			The number of items currently in the list.
 		</member>

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -385,7 +385,6 @@ void LinkButton::_bind_methods() {
 
 LinkButton::LinkButton(const String &p_text) {
 	text_buf.instantiate();
-	set_focus_mode(FOCUS_ACCESSIBILITY);
 	set_default_cursor_shape(CURSOR_POINTING_HAND);
 
 	set_text(p_text);

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -245,7 +245,6 @@ MenuButton::MenuButton(const String &p_text) :
 	set_toggle_mode(true);
 	set_disable_shortcuts(false);
 	set_process_shortcut_input(true);
-	set_focus_mode(FOCUS_ACCESSIBILITY);
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);
 
 	popup = memnew(PopupMenu);


### PR DESCRIPTION
LinkButton and MenuButton have overrides that change the value of 2 (FOCUS_ALL) present in BaseButton to one of 3 (FOCUS_ACCESSIBILITY), as these are buttons they should be able to grab focus.

This PR removes this override so that the buttons use the default value specified in BaseButton.

This addresses one part of #116108 
