### PR TITLE
[4.6] Allow `SoftBody3D` to have a `total_mass` of 0 again

### DIFF
--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -165,6 +165,7 @@
 		</member>
 		<member name="total_mass" type="float" setter="set_total_mass" getter="get_total_mass" default="1.0">
 			The SoftBody3D's mass.
+			[b]Note:[/b] When using Jolt Physics, the default value of this property will instead be [code]0.0[/code], which will cause the body to automatically calculate the mass to 1 kg per point. This is a bug, which will be fixed in Godot 4.7.
 		</member>
 	</members>
 	<constants>

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -383,7 +383,7 @@ void SoftBody3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "parent_collision_ignore", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "CollisionObject3D"), "set_parent_collision_ignore", "get_parent_collision_ignore");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "simulation_precision", PROPERTY_HINT_RANGE, "1,100,1"), "set_simulation_precision", "get_simulation_precision");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "total_mass", PROPERTY_HINT_RANGE, "0.001,1000,0.001,or_greater,exp,suffix:kg"), "set_total_mass", "get_total_mass");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "total_mass", PROPERTY_HINT_RANGE, "0,1000,0.001,or_greater,exp,suffix:kg"), "set_total_mass", "get_total_mass");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "linear_stiffness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_linear_stiffness", "get_linear_stiffness");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "shrinking_factor", PROPERTY_HINT_RANGE, "-1,1,0.01,or_less,or_greater"), "set_shrinking_factor", "get_shrinking_factor");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pressure_coefficient"), "set_pressure_coefficient", "get_pressure_coefficient");


### PR DESCRIPTION
*(This is the same as #116067, but targeting the `4.6` branch instead, since that one doesn't make much sense to merge to `master`, with #116041 being the more proper fix there.)*

Fixes #116050.

This restores the lower bound of the `total_mass` property of `SoftBody3D` back from the new value of `0.001`, as changed in #108758, to the old value of `0`.

Note that this is mostly a hack, to accommodate for the [questionable](https://github.com/godotengine/godot/issues/116076) implementation of `total_mass` found in the Jolt Physics integration, where it will default to 0 no matter what the inspector says, and which results in the total mass being automatically calculated to 1 kg per point.