### PR TITLE
Add min gpu family for baking apple shaders

### DIFF
--- a/drivers/metal/metal_device_profile.cpp
+++ b/drivers/metal/metal_device_profile.cpp
@@ -96,7 +96,8 @@ const MetalDeviceProfile *MetalDeviceProfile::get_profile(Platform p_platform, G
 				case GPU::Apple6:
 				case GPU::Apple7:
 				case GPU::Apple8:
-				case GPU::Apple9: {
+				case GPU::Apple9:
+				case GPU::Apple10: {
 					res.features.use_argument_buffers = p_min_os_version >= os_version::IOS_16_0;
 					res.features.simdPermute = true;
 				} break;
@@ -114,7 +115,8 @@ const MetalDeviceProfile *MetalDeviceProfile::get_profile(Platform p_platform, G
 
 			switch (p_gpu) {
 				case GPU::Apple8:
-				case GPU::Apple9: {
+				case GPU::Apple9:
+				case GPU::Apple10: {
 					res.features.use_argument_buffers = true;
 					res.features.simdPermute = true;
 				} break;
@@ -126,4 +128,39 @@ const MetalDeviceProfile *MetalDeviceProfile::get_profile(Platform p_platform, G
 	}
 
 	return &profiles.insert(key, res)->value;
+}
+
+MetalDeviceProfile::GPU MetalDeviceProfile::string_to_gpu(const String &val) {
+	if (val == "Apple1") {
+		return GPU::Apple1;
+	}
+	if (val == "Apple2") {
+		return GPU::Apple2;
+	}
+	if (val == "Apple3") {
+		return GPU::Apple3;
+	}
+	if (val == "Apple4") {
+		return GPU::Apple4;
+	}
+	if (val == "Apple5") {
+		return GPU::Apple5;
+	}
+	if (val == "Apple6") {
+		return GPU::Apple6;
+	}
+	if (val == "Apple7") {
+		return GPU::Apple7;
+	}
+	if (val == "Apple8") {
+		return GPU::Apple8;
+	}
+	if (val == "Apple9") {
+		return GPU::Apple9;
+	}
+	if (val == "Apple10") {
+		return GPU::Apple10;
+	}
+
+	ERR_FAIL_V_MSG(GPU::Apple7, "Invalid gpu family: " + val + ". Defaulting to Apple7.");
 }

--- a/drivers/metal/metal_device_profile.h
+++ b/drivers/metal/metal_device_profile.h
@@ -104,6 +104,7 @@ struct MetalDeviceProfile {
 		Apple7 = 1007,
 		Apple8 = 1008,
 		Apple9 = 1009,
+		Apple10 = 1010,
 	};
 
 	enum class ArgumentBuffersTier : uint32_t {
@@ -123,6 +124,7 @@ struct MetalDeviceProfile {
 	Features features;
 
 	static const MetalDeviceProfile *get_profile(Platform p_platform, GPU p_gpu, MinOsVersion p_min_os_version);
+	static GPU string_to_gpu(const String &value);
 
 	MetalDeviceProfile() = default;
 

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -2786,6 +2786,9 @@ static MetalDeviceProfile device_profile_from_properties(MetalDeviceProperties *
 		case MTL::GPUFamilyApple9:
 			res.gpu = DP::GPU::Apple9;
 			break;
+		case MTL::GPUFamilyApple10:
+			res.gpu = DP::GPU::Apple10;
+			break;
 		default: {
 			// Programming error if the default case is hit.
 			CRASH_NOW_MSG("Unsupported GPU family");

--- a/editor/shader/shader_baker/shader_baker_export_plugin_platform_metal.cpp
+++ b/editor/shader/shader_baker/shader_baker_export_plugin_platform_metal.cpp
@@ -40,13 +40,13 @@ RenderingShaderContainerFormat *ShaderBakerExportPluginPlatformMetal::create_sha
 	if (os_name == U"macOS") {
 		min_os_version = (String)p_preset->get("application/min_macos_version_arm64");
 		// Godot metal doesn't support x86_64 mac so no need to worry about that version
-		profile = MetalDeviceProfile::get_profile(MetalDeviceProfile::Platform::macOS, MetalDeviceProfile::GPU::Apple7, min_os_version);
+		profile = MetalDeviceProfile::get_profile(MetalDeviceProfile::Platform::macOS, MetalDeviceProfile::string_to_gpu(p_preset->get("application/min_macos_gpu_family")), min_os_version);
 	} else if (os_name == U"iOS") {
 		min_os_version = (String)p_preset->get("application/min_ios_version");
-		profile = MetalDeviceProfile::get_profile(MetalDeviceProfile::Platform::iOS, MetalDeviceProfile::GPU::Apple7, min_os_version);
+		profile = MetalDeviceProfile::get_profile(MetalDeviceProfile::Platform::iOS, MetalDeviceProfile::string_to_gpu(p_preset->get("application/min_ios_gpu_family")), min_os_version);
 	} else if (os_name == U"visionOS") {
 		min_os_version = (String)p_preset->get("application/min_visionos_version");
-		profile = MetalDeviceProfile::get_profile(MetalDeviceProfile::Platform::visionOS, MetalDeviceProfile::GPU::Apple8, min_os_version);
+		profile = MetalDeviceProfile::get_profile(MetalDeviceProfile::Platform::iOS, MetalDeviceProfile::string_to_gpu(p_preset->get("application/min_visionos_gpu_family")), min_os_version);
 	} else {
 		ERR_FAIL_V_MSG(nullptr, vformat("Unsupported platform: %s", os_name));
 	}

--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -44,6 +44,8 @@
 		<member name="application/icon_interpolation" type="int" setter="" getter="">
 			Interpolation method used to resize application icon.
 		</member>
+		<member name="application/min_ios_gpu_family" type="String" setter="" getter="">
+		</member>
 		<member name="application/min_ios_version" type="String" setter="" getter="">
 			Minimum version of iOS required for this application to run in the [code]major.minor.patch[/code] or [code]major.minor[/code] format, can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]).
 		</member>

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -57,6 +57,7 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/targeted_device_family", PROPERTY_HINT_ENUM, "iPhone,iPad,iPhone & iPad"), 2));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_ios_version"), get_minimum_deployment_target()));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_ios_gpu_family", PROPERTY_HINT_ENUM, "Apple5,Apple6,Apple7,Apple8,Apple9,Apple10"), "Apple7"));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "storyboard/image_scale_mode", PROPERTY_HINT_ENUM, "Same as Logo,Center,Scale to Fit,Scale to Fill,Scale"), 0));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "storyboard/custom_image@2x", PROPERTY_HINT_FILE_PATH, "*.png,*.jpg,*.jpeg"), ""));

--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -43,6 +43,8 @@
 			[b]Note:[/b] Supported when exporting from macOS only, Xcode 26+ required.
 			[b]Note:[/b] Liquid Glass icons are supported on macOS 26 only, use [member application/icon] to set the icon for older macOS versions.
 		</member>
+		<member name="application/min_macos_gpu_family" type="String" setter="" getter="">
+		</member>
 		<member name="application/min_macos_version_arm64" type="String" setter="" getter="">
 			Minimum version of macOS required for this application to run on Apple Silicon Macs, in the [code]major.minor.patch[/code] or [code]major.minor[/code] format, can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]).
 		</member>

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -486,6 +486,7 @@ void EditorExportPlatformMacOS::get_export_options(List<ExportOption> *r_options
 	r_options->push_back(ExportOption(PropertyInfo(Variant::DICTIONARY, "application/copyright_localized", PROPERTY_HINT_LOCALIZABLE_STRING), Dictionary()));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_macos_version_x86_64"), "10.12"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_macos_version_arm64"), "11.00"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_macos_gpu_family", PROPERTY_HINT_ENUM, "Apple7,Apple8,Apple9,Apple10"), "Apple7"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/export_angle", PROPERTY_HINT_ENUM, "Auto,Yes,No"), 0, true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "display/high_res"), true));
 

--- a/platform/visionos/doc_classes/EditorExportPlatformVisionOS.xml
+++ b/platform/visionos/doc_classes/EditorExportPlatformVisionOS.xml
@@ -44,6 +44,8 @@
 		<member name="application/icon_interpolation" type="int" setter="" getter="">
 			Interpolation method used to resize application icon.
 		</member>
+		<member name="application/min_visionos_gpu_family" type="String" setter="" getter="">
+		</member>
 		<member name="application/min_visionos_version" type="String" setter="" getter="">
 		</member>
 		<member name="application/provisioning_profile_specifier_debug" type="String" setter="" getter="">

--- a/platform/visionos/export/export_plugin.cpp
+++ b/platform/visionos/export/export_plugin.cpp
@@ -56,6 +56,7 @@ void EditorExportPlatformVisionOS::get_export_options(List<ExportOption> *r_opti
 	EditorExportPlatformAppleEmbedded::get_export_options(r_options);
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_visionos_version"), get_minimum_deployment_target()));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_visionos_gpu_family", PROPERTY_HINT_ENUM, "Apple8,Apple10"), "Apple8"));
 }
 
 Vector<EditorExportPlatformAppleEmbedded::IconInfo> EditorExportPlatformVisionOS::get_icon_infos() const {


### PR DESCRIPTION
This adds the ability to specify the minimum gpu family to bake apple shaders against.  Currently our MacOS version has a higher gpu family than the iPhone XR supports.  Hence when we bake our shaders, they don't run on the iPhone XR.  This gives more granular support in the shader baking process and allows users to target older devices than their current Mac.