### PR TITLE
CI: Ensure tests are built for all actions

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -8,7 +8,6 @@ env:
   SCONS_FLAGS: >-
     dev_mode=yes
     module_text_server_fb_enabled=yes
-    tests=no
     swappy=yes
 
 jobs:

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -8,7 +8,6 @@ env:
   SCONS_FLAGS: >-
     dev_mode=yes
     module_text_server_fb_enabled=yes
-    tests=no
     debug_symbols=no
 
 jobs:

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -7,7 +7,6 @@ on:
 env:
   SCONS_FLAGS: >-
     dev_mode=yes
-    tests=no
     debug_symbols=no
     use_closure_compiler=yes
   EM_VERSION: 4.0.11


### PR DESCRIPTION
- Related: #115933

Ensures that ALL actions are building the tests, even if they aren't run. This should prevent issues like the above PR moving forward, as those files will be compiled unconditionally in our GHA