### PR TITLE
Add errors for meta types and custom iterators in for loop

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2255,6 +2255,41 @@ void GDScriptAnalyzer::resolve_if(GDScriptParser::IfNode *p_if) {
 	}
 }
 
+bool GDScriptAnalyzer::find_non_native_function(const GDScriptParser::DataType &p_type, const StringName &p_function_name, GDScriptParser::FunctionNode *&r_found_function) const {
+	GDScriptParser::ClassNode *base_class = p_type.class_type;
+
+	while (r_found_function == nullptr && base_class != nullptr) {
+		if (base_class->has_function(p_function_name)) {
+			r_found_function = base_class->get_member(p_function_name).function;
+			return true;
+		}
+		base_class = base_class->base_type.class_type;
+	}
+
+	return false;
+}
+
+bool GDScriptAnalyzer::is_iterable_type(const GDScriptParser::DataType &p_type, GDScriptParser::DataType &r_return_type) const {
+	GDScriptParser::FunctionNode *init_func = nullptr;
+	GDScriptParser::FunctionNode *next_func = nullptr;
+	GDScriptParser::FunctionNode *get_func = nullptr;
+	if (find_non_native_function(p_type, CoreStringName(_iter_init), init_func) && find_non_native_function(p_type, CoreStringName(_iter_next), next_func) && find_non_native_function(p_type, CoreStringName(_iter_get), get_func)) {
+		r_return_type = get_func->get_datatype();
+		r_return_type.is_meta_type = false;
+		r_return_type.is_coroutine = get_func->is_coroutine;
+		return true;
+	}
+
+	MethodInfo info;
+	if (ClassDB::get_method_info(p_type.native_type, CoreStringName(_iter_get), &info)) {
+		bool is_core_not_overriden_method = info.flags & METHOD_FLAG_OBJECT_CORE;
+		r_return_type = type_from_property(info.return_val);
+		return !is_core_not_overriden_method;
+	}
+
+	return false;
+}
+
 void GDScriptAnalyzer::resolve_for(GDScriptParser::ForNode *p_for) {
 	GDScriptParser::DataType variable_type;
 	GDScriptParser::DataType list_type;
@@ -2311,10 +2346,9 @@ void GDScriptAnalyzer::resolve_for(GDScriptParser::ForNode *p_for) {
 			variable_type.builtin_type = Variant::FLOAT;
 		} else if (list_type.builtin_type == Variant::OBJECT) {
 			GDScriptParser::DataType return_type;
-			List<GDScriptParser::DataType> par_types;
-			int default_arg_count = 0;
-			BitField<MethodFlags> method_flags = {};
-			if (get_function_signature(p_for->list, false, list_type, CoreStringName(_iter_get), return_type, par_types, default_arg_count, method_flags)) {
+			if (list_type.is_meta_type) {
+				push_error(vformat(R"(Unable to iterate on meta type "%s".)", list_type.to_string()), p_for->list);
+			} else if (is_iterable_type(list_type, return_type)) {
 				variable_type = return_type;
 				variable_type.type_source = list_type.type_source;
 			} else if (!list_type.is_hard_type()) {

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -158,6 +158,8 @@ class GDScriptAnalyzer {
 	Ref<GDScriptParserRef> find_cached_external_parser_for_class(const GDScriptParser::ClassNode *p_class, const Ref<GDScriptParserRef> &p_dependant_parser);
 	Ref<GDScriptParserRef> find_cached_external_parser_for_class(const GDScriptParser::ClassNode *p_class, GDScriptParser *p_dependant_parser);
 	Ref<GDScript> get_depended_shallow_script(const String &p_path, Error &r_error);
+	bool find_non_native_function(const GDScriptParser::DataType &p_type, const StringName &p_function, GDScriptParser::FunctionNode *&r_found_function) const;
+	bool is_iterable_type(const GDScriptParser::DataType &p_type, GDScriptParser::DataType &r_return_type) const;
 #ifdef DEBUG_ENABLED
 	void is_shadowing(GDScriptParser::IdentifierNode *p_identifier, const String &p_context, const bool p_in_local_scope);
 #endif

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_non_iterable_types.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_non_iterable_types.gd
@@ -1,0 +1,11 @@
+class Iterator:
+	func do() -> void:
+		pass
+
+func test():
+	for x in Object.new():
+		pass
+	for x in Iterator:
+		pass
+	for x in Iterator.new():
+		pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_non_iterable_types.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_non_iterable_types.out
@@ -1,0 +1,4 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 6: Unable to iterate on object of type "Object".
+>> ERROR at line 8: Unable to iterate on meta type "Iterator".
+>> ERROR at line 10: Unable to iterate on object of type "Iterator".


### PR DESCRIPTION
- Fixes: https://github.com/godotengine/godot/issues/116089

## Example

<img width="957" height="581" alt="example" src="https://github.com/user-attachments/assets/a5fd693d-2ed0-4394-93ea-daf2e0717c74" />


<details>
<summary>GDScript source code</summary>

``` gdscript
func _ready() -> void:
	for i in Object:					# native meta type
		pass
	for i in BadIterator.new():			# user type without `_iter` methods
		pass
	for i in Iterator:					# user meta type
		pass
	for i in Iterator.new():			# user type with all `_iter` methods
		pass
	for i in PartIterator.new():		# user type with only 1 `_iter` method (required 3)
		pass
	for i in ChildIterator.new():		# user type extends `Iterator`
		pass
	for i in Object.new():				# nativa type without `_iter` methods overriden
		pass
	for i in PackedDataContainer.new():	# native type with `_iter` methods overriden
		pass
	for i in CustomDataContainer.new():	# user type extends `PackedDataContainer`
		pass

class BadIterator:
	func do() -> void:
		pass

class PartIterator:
	func _iter_get(iter: Variant) -> Variant:
		return null

class Iterator:
	func _iter_get(iter: Variant) -> Variant:
		return null
	func _iter_init(iter: Array) -> bool:
		return true
	func _iter_next(iter: Array) -> bool:
		return false

class ChildIterator extends Iterator:
	func _iter_init(iter: Array) -> bool:
		print(iter)
		return super._iter_init(iter)

class CustomDataContainer extends PackedDataContainer:
	var title: String
```

</details>

## Details

To detect overridden `_iter()` methods in native types, I check `METHOD_FLAG_OBJECT_CORE` flag. It looks a bit hacky, but it works and shouldn't break in future.