### PR TITLE
Fix undo applying to global editor settings when not in settings dialogs

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6319,6 +6319,14 @@ void EditorNode::redo() {
 	_menu_option_confirm(SCENE_REDO, true);
 }
 
+bool EditorNode::is_focus_in_global_settings_context() const {
+	Control *focus = get_viewport() ? get_viewport()->gui_get_focus_owner() : nullptr;
+	if (!focus) {
+		return false;
+	}
+	return editor_settings_dialog->is_ancestor_of(focus) || project_settings_editor->is_ancestor_of(focus);
+}
+
 bool EditorNode::ensure_main_scene(bool p_from_native) {
 	pick_main_scene->set_meta("from_native", p_from_native); // Whether from play button or native run.
 	String main_scene = GLOBAL_GET("application/run/main_scene");

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -1031,6 +1031,7 @@ public:
 
 	bool has_scenes_in_session();
 
+	bool is_focus_in_global_settings_context() const;
 	void undo();
 	void redo();
 

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -337,7 +337,7 @@ bool EditorUndoRedoManager::redo() {
 	double global_timestamp = Math::INF;
 
 	// Pick the history with lowest last action timestamp (either global or current scene).
-	{
+	if (EditorNode::get_singleton()->is_focus_in_global_settings_context()) {
 		History &history = get_or_create_history(GLOBAL_HISTORY);
 		if (!history.redo_stack.is_empty()) {
 			selected_history = history.id;
@@ -510,7 +510,7 @@ EditorUndoRedoManager::History *EditorUndoRedoManager::_get_newest_undo() {
 	double global_timestamp = 0;
 
 	// Pick the history with greatest last action timestamp (either global or current scene).
-	{
+	if (EditorNode::get_singleton()->is_focus_in_global_settings_context()) {
 		History &history = get_or_create_history(GLOBAL_HISTORY);
 		if (!history.undo_stack.is_empty()) {
 			selected_history = &history;


### PR DESCRIPTION
Fix undo applying to global editor settings (fixes #116094)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
