### PR TITLE
Expose `JointLimitation3D`'s virtual methods

### DIFF
--- a/doc/classes/JointLimitation3D.xml
+++ b/doc/classes/JointLimitation3D.xml
@@ -8,4 +8,25 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="_make_space" qualifiers="virtual const">
+			<return type="Quaternion" />
+			<param index="0" name="local_forward_vector" type="Vector3" />
+			<param index="1" name="local_right_vector" type="Vector3" />
+			<param index="2" name="rotation_offset" type="Quaternion" />
+			<description>
+				This method receives several vectors and a rotation offset as arguments and returns a space.
+				The [param local_forward_vector] is usually the vector pointing from the parent to the child. For the bone which is end of the chain, any axis may be selected by enum. The [param local_right_vector] is the +X vector of the bone rest.
+				If this method is not implemented, the space is determined by the default implementation. By default, a space is defined where the normalized [param local_forward_vector] is +Y, the normalized [param local_right_vector] vector projected onto the plane with the +Y axis as its normal is +X, and the cross product of these is +Z.
+			</description>
+		</method>
+		<method name="_solve" qualifiers="virtual const">
+			<return type="Vector3" />
+			<param index="0" name="direction" type="Vector3" />
+			<description>
+				This method returns a vector that has been applied limitation for the input vector.
+				The [param direction] is a normalized vector and the space is defined by [method _make_space], must return a normalized vector.
+			</description>
+		</method>
+	</methods>
 </class>

--- a/scene/resources/3d/joint_limitation_3d.cpp
+++ b/scene/resources/3d/joint_limitation_3d.cpp
@@ -32,7 +32,7 @@
 
 #include "scene/3d/skeleton_modifier_3d.h"
 
-Quaternion JointLimitation3D::make_space(const Vector3 &p_local_forward_vector, const Vector3 &p_local_right_vector, const Quaternion &p_rotation_offset) const {
+Quaternion JointLimitation3D::_make_space(const Vector3 &p_local_forward_vector, const Vector3 &p_local_right_vector, const Quaternion &p_rotation_offset) const {
 	const double ALMOST_ONE = 1.0 - CMP_EPSILON;
 	// The default is to interpret the forward vector as the +Y axis.
 	Vector3 axis_y = p_local_forward_vector.normalized();
@@ -48,14 +48,29 @@ Quaternion JointLimitation3D::make_space(const Vector3 &p_local_forward_vector, 
 	return (Basis(axis_x, axis_y, axis_z).get_rotation_quaternion() * p_rotation_offset.normalized()).normalized();
 }
 
+Quaternion JointLimitation3D::make_space(const Vector3 &p_local_forward_vector, const Vector3 &p_local_right_vector, const Quaternion &p_rotation_offset) const {
+	Quaternion space;
+	if (GDVIRTUAL_CALL(_make_space, p_local_forward_vector, p_local_right_vector, p_rotation_offset, space)) {
+		return space;
+	}
+	return _make_space(p_local_forward_vector, p_local_right_vector, p_rotation_offset);
+}
+
 Vector3 JointLimitation3D::_solve(const Vector3 &p_direction) const {
-	return p_direction;
+	Vector3 direction = p_direction;
+	GDVIRTUAL_CALL(_solve, p_direction, direction);
+	return direction;
 }
 
 Vector3 JointLimitation3D::solve(const Vector3 &p_local_forward_vector, const Vector3 &p_local_right_vector, const Quaternion &p_rotation_offset, const Vector3 &p_local_current_vector) const {
 	Quaternion space = make_space(p_local_forward_vector, p_local_right_vector, p_rotation_offset);
 	Vector3 dir = p_local_current_vector.normalized();
 	return space.xform(_solve(space.xform_inv(dir)));
+}
+
+void JointLimitation3D::_bind_methods() {
+	GDVIRTUAL_BIND(_make_space, "local_forward_vector", "local_right_vector", "rotation_offset");
+	GDVIRTUAL_BIND(_solve, "direction");
 }
 
 #ifdef TOOLS_ENABLED

--- a/scene/resources/3d/joint_limitation_3d.h
+++ b/scene/resources/3d/joint_limitation_3d.h
@@ -40,13 +40,18 @@ class JointLimitation3D : public Resource {
 	GDCLASS(JointLimitation3D, Resource);
 
 protected:
+	static void _bind_methods();
+
 	// Directions are normalized vector from Vector(0, 0, 0). Space is defined by _make_space(), must return normalized vector.
 	virtual Vector3 _solve(const Vector3 &p_direction) const;
+	GDVIRTUAL1RC(Vector3, _solve, Vector3);
+
+	// Define temporary space based on rest and forward vector.
+	virtual Quaternion _make_space(const Vector3 &p_local_forward_vector, const Vector3 &p_local_right_vector, const Quaternion &p_rotation_offset) const;
+	GDVIRTUAL3RC(Quaternion, _make_space, Vector3, Vector3, Quaternion);
 
 public:
-	// Define temporary space based on rest and forward vector.
-	virtual Quaternion make_space(const Vector3 &p_local_forward_vector, const Vector3 &p_local_right_vector, const Quaternion &p_rotation_offset) const;
-
+	Quaternion make_space(const Vector3 &p_local_forward_vector, const Vector3 &p_local_right_vector, const Quaternion &p_rotation_offset) const;
 	Vector3 solve(const Vector3 &p_local_forward_vector, const Vector3 &p_local_right_vector, const Quaternion &p_rotation_offset, const Vector3 &p_local_current_vector) const;
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
This PR expose `JointLimitation3D`'s `_solve()` and `_make_space()` to GDScript.

Regarding `_make_space()`, since it has a default implementation, so we always need to call `if (GDVIRTUAL_CALL())` to check if the virtual method is defined in GDScript. This might be a performance concern.

I'd like to hear opinions on this by @godotengine/gdscript team and @reduz.

If this is problematic, I believe we should opt for the approach of implementing a child class like `JointLimitationExtension3D` as same way with https://github.com/godotengine/godot/pull/99181.

Additionally, `JointLimitation3D` has other virtual functions in C++ that are only accessible via `#ifdef TOOLS_ENABLED` for drawing the gizmo. However, since I don't know how to correctly expose functions implemented only in the tools environment to GDScript, I won't do anything about this for now.