### PR TITLE
Properly deprecate legacy bottom panel methods

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -636,7 +636,7 @@
 				Minimizes the bottom panel.
 			</description>
 		</method>
-		<method name="make_bottom_panel_item_visible">
+		<method name="make_bottom_panel_item_visible" deprecated="Use [method EditorDock.make_visible] instead.">
 			<return type="void" />
 			<param index="0" name="item" type="Control" />
 			<description>

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -180,17 +180,6 @@ void EditorBottomPanel::load_layout_from_config(Ref<ConfigFile> p_config_file, c
 	_update_center_split_offset();
 }
 
-void EditorBottomPanel::make_item_visible(Control *p_item, bool p_visible, bool p_ignore_lock) {
-	// Don't allow changing tabs involuntarily when tabs are locked.
-	if (!p_ignore_lock && lock_panel_switching && pin_button->is_visible()) {
-		return;
-	}
-
-	EditorDock *dock = _get_dock_from_control(p_item);
-	ERR_FAIL_NULL(dock);
-	dock->set_visible(p_visible);
-}
-
 void EditorBottomPanel::hide_bottom_panel() {
 	set_current_tab(-1);
 }
@@ -230,6 +219,7 @@ void EditorBottomPanel::_update_center_split_offset() {
 	center_split->set_split_offset(get_bottom_panel_offset());
 }
 
+#ifndef DISABLE_DEPRECATED
 EditorDock *EditorBottomPanel::_get_dock_from_control(Control *p_control) const {
 	return Object::cast_to<EditorDock>(p_control->get_parent());
 }
@@ -280,6 +270,7 @@ void EditorBottomPanel::_on_button_visibility_changed(Button *p_button, EditorDo
 		p_dock->close();
 	}
 }
+#endif
 
 EditorBottomPanel::EditorBottomPanel() :
 		DockTabContainer(EditorDock::DOCK_SLOT_BOTTOM) {
@@ -335,7 +326,9 @@ EditorBottomPanel::EditorBottomPanel() :
 }
 
 EditorBottomPanel::~EditorBottomPanel() {
+#ifndef DISABLE_DEPRECATED
 	for (Button *b : legacy_buttons) {
 		memdelete(b);
 	}
+#endif
 }

--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -49,18 +49,20 @@ class EditorBottomPanel : public DockTabContainer {
 
 	int previous_tab = -1;
 	bool lock_panel_switching = false;
-	LocalVector<EditorDock *> bottom_docks;
 	HashMap<String, int> dock_offsets;
-
-	LocalVector<Button *> legacy_buttons;
-	void _on_button_visibility_changed(Button *p_button, EditorDock *p_dock);
 
 	void _repaint();
 	void _on_tab_changed(int p_idx);
 	void _pin_button_toggled(bool p_pressed);
 	void _expand_button_toggled(bool p_pressed);
 	void _update_center_split_offset();
+#ifndef DISABLE_DEPRECATED
+	LocalVector<EditorDock *> bottom_docks;
+	LocalVector<Button *> legacy_buttons;
+	void _on_button_visibility_changed(Button *p_button, EditorDock *p_dock);
+
 	EditorDock *_get_dock_from_control(Control *p_control) const;
+#endif
 
 protected:
 	void _notification(int p_what);
@@ -76,9 +78,10 @@ public:
 	void save_layout_to_config(Ref<ConfigFile> p_config_file, const String &p_section) const;
 	void load_layout_from_config(Ref<ConfigFile> p_config_file, const String &p_section);
 
+#ifndef DISABLE_DEPRECATED
 	Button *add_item(String p_text, Control *p_item, const Ref<Shortcut> &p_shortcut = nullptr, bool p_at_front = false);
 	void remove_item(Control *p_item);
-	void make_item_visible(Control *p_item, bool p_visible = true, bool p_ignore_lock = false);
+#endif
 	void hide_bottom_panel();
 	void toggle_last_opened_bottom_panel();
 	void set_expanded(bool p_expanded);

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -120,6 +120,10 @@ void EditorPlugin::remove_control_from_bottom_panel(Control *p_control) {
 	ERR_FAIL_NULL(p_control);
 	EditorNode::get_bottom_panel()->remove_item(p_control);
 }
+
+void EditorPlugin::make_bottom_panel_item_visible(Control *p_item) {
+	EditorNode::get_bottom_panel()->make_item_visible(p_item);
+}
 #endif
 
 void EditorPlugin::add_dock(EditorDock *p_dock) {
@@ -566,10 +570,6 @@ void EditorPlugin::queue_save_layout() {
 	EditorNode::get_singleton()->save_editor_layout_delayed();
 }
 
-void EditorPlugin::make_bottom_panel_item_visible(Control *p_item) {
-	EditorNode::get_bottom_panel()->make_item_visible(p_item);
-}
-
 void EditorPlugin::hide_bottom_panel() {
 	EditorNode::get_bottom_panel()->hide_bottom_panel();
 }
@@ -636,6 +636,7 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_dock_tab_icon", "control", "icon"), &EditorPlugin::set_dock_tab_icon);
 	ClassDB::bind_method(D_METHOD("add_control_to_bottom_panel", "control", "title", "shortcut"), &EditorPlugin::add_control_to_bottom_panel, DEFVAL(Ref<Shortcut>()));
 	ClassDB::bind_method(D_METHOD("remove_control_from_bottom_panel", "control"), &EditorPlugin::remove_control_from_bottom_panel);
+	ClassDB::bind_method(D_METHOD("make_bottom_panel_item_visible", "item"), &EditorPlugin::make_bottom_panel_item_visible);
 #endif
 
 	ClassDB::bind_method(D_METHOD("add_autoload_singleton", "name", "path"), &EditorPlugin::add_autoload_singleton);
@@ -643,7 +644,6 @@ void EditorPlugin::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("update_overlays"), &EditorPlugin::update_overlays);
 
-	ClassDB::bind_method(D_METHOD("make_bottom_panel_item_visible", "item"), &EditorPlugin::make_bottom_panel_item_visible);
 	ClassDB::bind_method(D_METHOD("hide_bottom_panel"), &EditorPlugin::hide_bottom_panel);
 
 	ClassDB::bind_method(D_METHOD("get_undo_redo"), &EditorPlugin::get_undo_redo);

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -155,6 +155,8 @@ protected:
 
 	Button *add_control_to_bottom_panel(Control *p_control, const String &p_title, const Ref<Shortcut> &p_shortcut = nullptr);
 	void remove_control_from_bottom_panel(Control *p_control);
+
+	void make_bottom_panel_item_visible(Control *p_item);
 #endif
 
 public:
@@ -226,7 +228,6 @@ public:
 
 	void queue_save_layout();
 
-	void make_bottom_panel_item_visible(Control *p_item);
 	void hide_bottom_panel();
 
 	void add_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser);


### PR DESCRIPTION
The old bottom panel workflow was deprecated in #108647, but not all members of EditorBottomPanel were properly deprecated. This PR mostly adds some ifndefs, but also deprecates one exposed method and removes one unexposed.

Depends on #113396 as some of these methods are still used.