### PR TITLE
Fix quit behavior and improve cmdline tool exit logging

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1728,9 +1728,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #endif // defined(OVERRIDE_PATH_ENABLED)
 		} else if (arg == "--quit") { // Auto quit at the end of the first main loop iteration
 			quit_after = 1;
-#ifdef TOOLS_ENABLED
-			wait_for_import = true;
-#endif
 		} else if (arg == "--quit-after") { // Quit after the given number of iterations
 			if (N) {
 				quit_after = N->get().to_int();
@@ -5066,8 +5063,13 @@ bool Main::iteration() {
 #endif
 
 #ifdef TOOLS_ENABLED
-	if (exit && quit_after_timeout && EditorNode::get_singleton()) {
-		EditorNode::get_singleton()->unload_editor_addons();
+	if (exit && quit_after_timeout) {
+		if (EditorNode::get_singleton()) {
+			EditorNode::get_singleton()->unload_editor_addons();
+		}
+		if (cmdline_tool) {
+			print_line("Quitting on iteration " + itos(Engine::get_singleton()->_process_frames) + ".");
+		}
 	}
 #endif
 


### PR DESCRIPTION

<p><code>--quit</code> is documented as "Quit after the first iteration," but it also set <code>wait_for_import = true</code>, which blocked quitting until the full EditorFileSystem scan and reimport cycle completed. This made <code>--quit</code> inconsistent with <code>--quit-after</code> (which never set <code>wait_for_import</code>) and caused it to behave identically to <code>--import</code> rather than as a simple iteration limiter.</p>
<p>This PR removes <code>wait_for_import = true</code> from <code>--quit</code> so it does what it says. The <code>--import</code> flag independently sets both <code>wait_for_import = true</code> and <code>quit_after = 1</code>, so any command using <code>--import --quit</code> is unaffected — the wait comes from <code>--import</code>.</p>

Command | Before | After
-- | -- | --
--quit | Waits for full scan, then quits | Quits after first iteration (as documented)
--import | Waits for import, then quits | Unchanged
--import --quit | Waits for import, then quits | Unchanged (--import provides wait_for_import)
--quit-after N | Quits after N iterations (no wait) | Unchanged


Also adds a diagnostic "Quitting on iteration N." message in <code>cmdline_tool</code> mode so CI users can distinguish between a process that exited and one that is still running.</p>
Related issues: #116084, #50839, #100465
