### PR TITLE
Show expected indentation level in GDScript unindent error message

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -1271,7 +1271,8 @@ void GDScriptTokenizerText::check_indent() {
 			}
 			if ((indent_level() > 0 && indent_stack.back()->get() != indent_count) || (indent_level() == 0 && indent_count != 0)) {
 				// Mismatched indentation alignment.
-				Token error = make_error("Unindent doesn't match the previous indentation level.");
+				const int expected_indent = indent_level() > 0 ? (indent_stack.back()->get() - 1) : 0;
+				Token error = make_error(vformat("Unindent to %d doesn't match the previous indentation level of %d.", indent_count, expected_indent));
 				error.start_line = line;
 				error.start_column = 1;
 				error.end_column = column + 1;


### PR DESCRIPTION
This helps troubleshoot indentation errors in code. The measurement is done in indentation levels, not tabs/spaces.

- This closes https://github.com/godotengine/godot-proposals/issues/14185.

## Preview

Using the code from https://github.com/godotengine/godot/issues/116093 for testing. Note that the detected 12 levels of indentation are incorrect here, due to a bug in GDScript.

<img width="982" height="152" alt="image" src="https://github.com/user-attachments/assets/708814b2-a6d3-4db3-9add-1fb3ab47acfd" />
