### PR TITLE
Implement `project.godot` file associations for the Android editor

### DIFF
--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -52,7 +52,7 @@
             android:configChanges="layoutDirection|locale|orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
             android:exported="false"
             android:icon="@mipmap/themed_icon"
-            android:launchMode="singleTask"
+            android:launchMode="singleInstancePerTask"
             android:screenOrientation="userLandscape">
             <layout
                 android:defaultWidth="@dimen/editor_default_window_width"
@@ -84,6 +84,15 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="file" />
+                <data android:scheme="content" />
+                <data android:mimeType="*/*" />
+                <data android:host="*" />
+                <data android:pathPattern=".*\\.godot" />
             </intent-filter>
         </activity-alias>
         <activity

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotActivity.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotActivity.kt
@@ -202,7 +202,8 @@ abstract class GodotActivity : FragmentActivity(), GodotHost {
 		handleStartIntent(intent, false)
 	}
 
-	private fun handleStartIntent(intent: Intent, newLaunch: Boolean) {
+	@CallSuper
+	protected open fun handleStartIntent(intent: Intent, newLaunch: Boolean) {
 		if (!newLaunch) {
 			val newLaunchRequested = intent.getBooleanExtra(EXTRA_NEW_LAUNCH, false)
 			if (newLaunchRequested) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/6201

Tested the feature with the [Files by Google app](https://play.google.com/store/apps/details?id=com.google.android.apps.nbu.files), the [Explorer app](https://play.google.com/store/apps/details?id=com.speedsoftware.explorer) and the HorizonOS 'Files' app:


https://github.com/user-attachments/assets/ca853bf6-d617-4777-a1db-e024812cad49




<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
