### PR TITLE
Restore default sky roughness levels to 8.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3231,7 +3231,7 @@
 		<member name="rendering/reflections/sky_reflections/ggx_samples.mobile" type="int" setter="" getter="" default="16">
 			Lower-end override for [member rendering/reflections/sky_reflections/ggx_samples] on mobile devices, due to performance concerns or driver support.
 		</member>
-		<member name="rendering/reflections/sky_reflections/roughness_layers" type="int" setter="" getter="" default="7">
+		<member name="rendering/reflections/sky_reflections/roughness_layers" type="int" setter="" getter="" default="8">
 			Limits the number of layers to use in radiance maps when using importance sampling. A lower number will be slightly faster and take up less VRAM.
 		</member>
 		<member name="rendering/reflections/sky_reflections/texture_array_reflections" type="bool" setter="" getter="" default="true">

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3737,7 +3737,7 @@ void RenderingServer::init() {
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/strip_debug", false);
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/strip_debug.release", true);
 
-	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/reflections/sky_reflections/roughness_layers", PROPERTY_HINT_RANGE, "1,32,1"), 7);
+	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/reflections/sky_reflections/roughness_layers", PROPERTY_HINT_RANGE, "1,32,1"), 8);
 	GLOBAL_DEF_RST("rendering/reflections/sky_reflections/texture_array_reflections", true);
 	GLOBAL_DEF("rendering/reflections/sky_reflections/texture_array_reflections.mobile", false);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/reflections/sky_reflections/ggx_samples", PROPERTY_HINT_RANGE, "0,256,1"), 32);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/116146

In 4.6 (https://github.com/godotengine/godot/pull/107902) we switched to using only 7 roughness levels by default so that we could have the same number of roughness levels when using the "update once" mode and the "update always mode". We also found it helped alleviate some artifacts along seams using our old seam blending approach. However, by the time we merged the work, we used a different approach for seam blending that didn't suffer from the same issue. 

In hindsight, we should have switched back to 8 layers. But in testing we didn't notice any issues. 

In the MRP from #116146, we have a very poorly formed HDR with 2 pixels that are 100x brighter than the next brightest handful of pixel and 10,000 times brighter than the average pixel. This causes really bad undersampling artifacts. Godot does the best it can to handle such HDRIs, but the results are not good (see https://github.com/godotengine/godot/issues/116146#issuecomment-3881106748 for example). 

In 4.5.1, this specific case looked okay because it uses full roughness and the environment map is downsampled so far (2x2 pixels per face) that the undersampling isn't visible. When using a lower roughness however, the problems are obvious. 

In 4.6, we see an issue since the lowest mip level is 10x10 (8x8 + 1 pixel padding) and thus is slightly higher frequency and is able to show off the undersampling artifacts more. 

By increasing the roughness levels by one, we decrease the final mip level to 6x6 (4x4 + 1 pixel padding) which much more closely matches the final frequency in 4.5.1. This gives the appearance of removing the artifacts in 4.6-stable. However, I want to strongly note that the generated environment map is **bad** in both cases. The particular case of a fully rough, non-metallic object looks better, but the actual result is still bad overall. 

That being said, I think we should go ahead with this for 4.7 and 4.6.2 as matching the behaviour in 4.5.1 is important and worth doing on its own since we don't want to regress. Even though it is only going from bad behaviour to worse behaviour.

_This PR_
<img width="597" height="541" alt="Screenshot from 2026-02-10 15-12-18" src="https://github.com/user-attachments/assets/d57c80ce-fd84-44d9-abc5-60b70b1c9937" />

_4.5.1_
<img width="597" height="541" alt="Screenshot from 2026-02-10 15-10-16" src="https://github.com/user-attachments/assets/9ea67901-dcdc-4d9d-a127-37c12e5274b6" />

_4.6_
<img width="597" height="541" alt="Screenshot from 2026-02-10 15-10-04" src="https://github.com/user-attachments/assets/caf7d4f6-3e48-4096-8c35-ffe80d56dc91" />

In the future https://github.com/godotengine/godot/pull/108127 will help tremendously. And should pave the way for further optimizations