### PR TITLE
Immediately update transform gizmo handle highlight when changing tool modes

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -7567,6 +7567,9 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 			tool_mode = (ToolMode)p_option;
 			update_transform_gizmo();
 
+			for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
+				viewports[i]->update_transform_gizmo_highlight();
+			}
 		} break;
 		case MENU_TRANSFORM_CONFIGURE_SNAP: {
 			snap_dialog->popup_centered(Size2(200, 180));


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

~~Requires and Includes: https://github.com/godotengine/godot/pull/115992~~ (merged)

Sometimes it would change before this PR but with a delay after the gizmo is rebuilt, but other times it wouldn't work at all. 

Before:

https://github.com/user-attachments/assets/92a28903-6aec-48d5-b4ad-00fe88833b7e

After:

https://github.com/user-attachments/assets/dfe01f3c-939a-4c95-9b36-af396dfcee6f


