### PR TITLE
Make sure that sky reflections update in real-time mode

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -693,6 +693,11 @@ void RasterizerSceneGLES3::_setup_sky(const RenderDataGLES3 *p_render_data, cons
 			sky->prev_position = p_transform.origin;
 			sky->reflection_dirty = true;
 		}
+
+		// Trigger updating radiance buffers every frame when in real-time mode.
+		if (sky->mode == RS::SKY_MODE_REALTIME) {
+			sky->reflection_dirty = true;
+		}
 	}
 
 	bool sun_scatter_enabled = environment_get_fog_enabled(p_render_data->environment) && environment_get_fog_sun_scatter(p_render_data->environment) > 0.001;

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -1022,6 +1022,11 @@ void SkyRD::setup_sky(const RenderDataRD *p_render_data, const Size2i p_screen_s
 			sky->prev_position = p_render_data->scene_data->cam_transform.origin;
 			sky->reflection.dirty = true;
 		}
+
+		// Trigger updating radiance buffers every frame when in real-time mode.
+		if (sky->mode == RS::SKY_MODE_REALTIME) {
+			sky->reflection.dirty = true;
+		}
 	}
 
 	bool sun_scatter_enabled = RendererSceneRenderRD::get_singleton()->environment_get_fog_enabled(p_render_data->environment) && RendererSceneRenderRD::get_singleton()->environment_get_fog_sun_scatter(p_render_data->environment) > 0.001;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Partially solves #68302 by giving the user an option to update the environment map every frame. I was surprised to find that setting process_mode to PROCESS_MODE_REALTIME did not already do this.

My reasoning is that PROCESS_MODE_REALTIME should behave like UPDATE_ALWAYS does for SubViewports.