### PR TITLE
Android Editor: Copy keystore to temp file during export

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -3586,6 +3586,30 @@ Error EditorExportPlatformAndroid::_generate_sparse_pck_metadata(const Ref<Edito
 	return OK;
 }
 
+#ifdef ANDROID_ENABLED
+// Copies the given keystore to temp file.
+// Returns the new path on success, or an empty String on failure.
+static String _copy_keystore_to_temp(const String &p_keystore_path, const String &p_build_path, const String &p_name) {
+	Error err;
+	PackedByteArray keystore_data = FileAccess::get_file_as_bytes(p_keystore_path, &err);
+	if (err != OK) {
+		return String();
+	}
+
+	String temp_dir = p_build_path + "/.android";
+	String temp_filename = temp_dir + "/" + p_name;
+
+	DirAccess::make_dir_recursive_absolute(temp_dir);
+	Ref<FileAccess> temp_file = FileAccess::open(temp_filename, FileAccess::WRITE);
+	if (!temp_file.is_valid()) {
+		return String();
+	}
+
+	temp_file->store_buffer(keystore_data);
+	return temp_filename;
+}
+#endif
+
 Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int export_format, bool should_sign, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
@@ -3894,22 +3918,13 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 					return ERR_FILE_CANT_OPEN;
 				}
 #ifdef ANDROID_ENABLED
-				if (debug_keystore.begins_with("assets://")) {
-					// The Gradle build environment app can't access the Godot
-					// editor's assets, so we need to copy this to temp file.
-					Error err;
-					PackedByteArray keystore_data = FileAccess::get_file_as_bytes(debug_keystore, &err);
-					if (err == OK) {
-						String temp_dir = build_path + "/.android";
-						String temp_filename = temp_dir + "/debug.keystore";
-
-						DirAccess::make_dir_recursive_absolute(temp_dir);
-						Ref<FileAccess> temp_file = FileAccess::open(temp_filename, FileAccess::WRITE);
-						if (temp_file.is_valid()) {
-							temp_file->store_buffer(keystore_data);
-							debug_keystore = temp_filename;
-						}
-					}
+				// The GABE app only has access to the project directory.
+				// Since the keystore can be anywhere in the filesystem, so we need to copy this to temp file.
+				String new_debug_keystore = _copy_keystore_to_temp(debug_keystore, build_path, "debug.keystore");
+				if (new_debug_keystore.is_empty()) {
+					add_message(EXPORT_MESSAGE_ERROR, TTR("Code Signing"), TTR("Failed to copy debug keystore to temp directory."));
+				} else {
+					debug_keystore = new_debug_keystore;
 				}
 #endif
 
@@ -3928,6 +3943,16 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 					add_message(EXPORT_MESSAGE_ERROR, TTR("Code Signing"), TTR("Could not find release keystore, unable to export."));
 					return ERR_FILE_CANT_OPEN;
 				}
+#ifdef ANDROID_ENABLED
+				// The GABE app only has access to the project directory.
+				// Since the keystore can be anywhere in the filesystem, so we need to copy this to temp file.
+				String new_release_keystore = _copy_keystore_to_temp(release_keystore, build_path, "release.keystore");
+				if (new_release_keystore.is_empty()) {
+					add_message(EXPORT_MESSAGE_ERROR, TTR("Code Signing"), TTR("Failed to copy release keystore to temp directory."));
+				} else {
+					release_keystore = new_release_keystore;
+				}
+#endif
 
 				cmdline.push_back("-Prelease_keystore_file=" + release_keystore); // argument to specify the release keystore file.
 				cmdline.push_back("-Prelease_keystore_alias=" + release_username); // argument to specify the release keystore alias.


### PR DESCRIPTION
I'm working on migrating the GABE app to use SAF instead of the MANAGE_EXTERNAL_STORAGE permission. So GABE now only has access to specific project directories, while the keystore file may be located anywhere on the filesystem.

To tackle this issue, this PR copies the selected keystore to temp file at `android/build/.android` during export. GABE has access to this directory, so it can use it during the build process.