### PR TITLE
Add reverse sorting to `BoxContainer`

### DIFF
--- a/doc/classes/BoxContainer.xml
+++ b/doc/classes/BoxContainer.xml
@@ -22,6 +22,9 @@
 		<member name="alignment" type="int" setter="set_alignment" getter="get_alignment" enum="BoxContainer.AlignmentMode" default="0">
 			The alignment of the container's children (must be one of [constant ALIGNMENT_BEGIN], [constant ALIGNMENT_CENTER], or [constant ALIGNMENT_END]).
 		</member>
+		<member name="reverse_sort" type="bool" setter="set_reverse_sort" getter="is_reverse_sort" default="false">
+			If [code]true[/code], the [BoxContainer] will arrange its children in reverse order.
+		</member>
 		<member name="vertical" type="bool" setter="set_vertical" getter="is_vertical" default="false">
 			If [code]true[/code], the [BoxContainer] will arrange its children vertically, rather than horizontally.
 			Can't be changed when using [HBoxContainer] and [VBoxContainer].

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -227,14 +227,15 @@ void BoxContainer::_resort() {
 	int start;
 	int end;
 	int delta;
-	if (!rtl || vertical) {
-		start = 0;
-		end = get_child_count();
-		delta = +1;
-	} else {
+
+	if ((rtl && !vertical) != reverse_sort) {
 		start = get_child_count() - 1;
 		end = -1;
 		delta = -1;
+	} else {
+		start = 0;
+		end = get_child_count();
+		delta = +1;
 	}
 
 	int accumulated_size = 0;
@@ -380,6 +381,18 @@ bool BoxContainer::is_vertical() const {
 	return vertical;
 }
 
+void BoxContainer::set_reverse_sort(bool p_reverse_sort) {
+	if (reverse_sort == p_reverse_sort) {
+		return;
+	}
+	reverse_sort = p_reverse_sort;
+	queue_sort();
+}
+
+bool BoxContainer::is_reverse_sort() const {
+	return reverse_sort;
+}
+
 Control *BoxContainer::add_spacer(bool p_begin) {
 	Control *c = memnew(Control);
 	c->set_mouse_filter(MOUSE_FILTER_PASS); //allow spacer to pass mouse events
@@ -432,6 +445,8 @@ void BoxContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_alignment"), &BoxContainer::get_alignment);
 	ClassDB::bind_method(D_METHOD("set_vertical", "vertical"), &BoxContainer::set_vertical);
 	ClassDB::bind_method(D_METHOD("is_vertical"), &BoxContainer::is_vertical);
+	ClassDB::bind_method(D_METHOD("set_reverse_sort", "reverse_sort"), &BoxContainer::set_reverse_sort);
+	ClassDB::bind_method(D_METHOD("is_reverse_sort"), &BoxContainer::is_reverse_sort);
 
 	BIND_ENUM_CONSTANT(ALIGNMENT_BEGIN);
 	BIND_ENUM_CONSTANT(ALIGNMENT_CENTER);
@@ -439,6 +454,7 @@ void BoxContainer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alignment", PROPERTY_HINT_ENUM, "Begin,Center,End"), "set_alignment", "get_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "vertical"), "set_vertical", "is_vertical");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reverse_sort"), "set_reverse_sort", "is_reverse_sort");
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, BoxContainer, separation);
 }

--- a/scene/gui/box_container.h
+++ b/scene/gui/box_container.h
@@ -50,6 +50,8 @@ private:
 		int separation = 0;
 	} theme_cache;
 
+	bool reverse_sort = false;
+
 	void _resort();
 	Size2 _get_minimum_size(bool p_use_desired_sizes) const;
 
@@ -68,6 +70,9 @@ public:
 
 	void set_vertical(bool p_vertical);
 	bool is_vertical() const;
+
+	void set_reverse_sort(bool p_reverse_sort);
+	bool is_reverse_sort() const;
 
 	virtual Size2 get_minimum_size() const override;
 	virtual Size2 get_desired_size() const override;


### PR DESCRIPTION
Closes [#804](https://github.com/godotengine/godot-proposals/issues/804)

This adds a property to set the inverse sorting for a BoxContainer. The logic is already there from RtL and Vertical.