### PR TITLE
Fix the table is too wide when using indentation in `RichTextLabel`

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -514,7 +514,7 @@ float RichTextLabel::_resize_line(ItemFrame *p_frame, int p_line, const Ref<Font
 					table->columns[i].width = 0;
 				}
 
-				const int available_width = p_width - theme_cache.table_h_separation * (col_count - 1);
+				const int available_width = p_width - l.offset.x - theme_cache.table_h_separation * (col_count - 1);
 				int base_column_width = available_width / col_count;
 
 				for (Item *E : table->subitems) {
@@ -698,7 +698,7 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 					table->columns[i].width = 0;
 				}
 				// Compute minimum width for each cell.
-				const int available_width = p_width - theme_cache.table_h_separation * (col_count - 1);
+				const int available_width = p_width - l.offset.x - theme_cache.table_h_separation * (col_count - 1);
 				int base_column_width = available_width / col_count;
 				int idx = 0;
 				for (Item *E : table->subitems) {


### PR DESCRIPTION
Line indentation (offset) is not taken into account when calculating the available width of the table.

However, when drawing a table, its offset takes into account line indentation.

<img width="1919" height="437" alt="1" src="https://github.com/user-attachments/assets/ba9fb0b4-0b45-486f-aa1d-decd803e9a23" />

[rich-text-label-issues.zip](https://github.com/user-attachments/files/25233870/rich-text-label-issues.zip)

Cell `padding` increases the width of the table, which is a separate issue.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
