### PR TITLE
Revert "Rearrange project loading init"

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -338,15 +338,14 @@ void EditorFileSystem::_first_scan_filesystem() {
 	ep.step(TTR("Verifying GDExtensions..."), 2, true);
 	GDExtensionManager::get_singleton()->ensure_extensions_loaded(extensions);
 
-	// Now that all the global class names should be loaded, create plugins.
-	// This is done after loading the global class names because plugins can use global class names.
-	ep.step(TTR("Initializing plugins..."), 3, true);
-	EditorNode::get_singleton()->init_plugins();
-
-	// Now that plugins and global class names should be loaded, create autoloads.
-	// This is done last because autoloads can use global class names and plugins.
-	ep.step(TTR("Creating autoload scripts..."), 4, true);
+	// Now that all the global class names should be loaded, create autoloads and plugins.
+	// This is done after loading the global class names because autoloads and plugins can use
+	// global class names.
+	ep.step(TTR("Creating autoload scripts..."), 3, true);
 	ProjectSettingsEditor::get_singleton()->init_autoloads();
+
+	ep.step(TTR("Initializing plugins..."), 4, true);
+	EditorNode::get_singleton()->init_plugins();
 
 	ep.step(TTR("Starting file scan..."), 5, true);
 }


### PR DESCRIPTION
This reverts commit f5c27569f00cc7abfed477e5610140499067be8e / #116080.

Caused far more regressions than expected, unsuitable for 4.7-dev1

- Reopens #115618