### PR TITLE
[MSVC] Use relative debug paths, disable MBEDTLS debug prints in release builds.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -830,6 +830,10 @@ if env.msvc:
             env.AppendUnique(CPPDEFINES=["SIZE_EXTRA"])
     elif env["optimize"] == "debug" or env["optimize"] == "none":
         env["OPTIMIZELEVEL"] = "/Od"
+    if not env["use_llvm"] and (env["debug_paths_relative"] or not env["debug_symbols"]):
+        # Remap absolute paths to relative paths for debug symbols and __FILE__.
+        project_path = Dir("#").abspath
+        env.Prepend(CXXFLAGS=["/d1trimfile:" + project_path])
 else:
     if env["debug_symbols"]:
         if env["platform"] == "windows":

--- a/thirdparty/mbedtls/include/godot_module_mbedtls_config.h
+++ b/thirdparty/mbedtls/include/godot_module_mbedtls_config.h
@@ -48,6 +48,9 @@
 #undef MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
 #undef MBEDTLS_DES_C
 #undef MBEDTLS_DHM_C
+#ifndef DEBUG_ENABLED
+#undef MBEDTLS_DEBUG_C
+#endif
 
 #ifdef THREADS_ENABLED
 // In mbedTLS 3, the PSA subsystem has an implicit shared context, MBEDTLS_THREADING_C is required to make it thread safe.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/116163

- Use relative path if `debug_paths_relative` is set or debug symbols disabled.
- Disable MBEDTLS debug prints in release builds (for some reason it's still using full path regardless of the flag, no idea why).

Release builds should no longer have any full paths, builds with debug symbols always contain link to PDB which is full path.