### PR TITLE
Add `TextureFunc` node(textureSize/QueryLevel/Lod) to visual shaders

### DIFF
--- a/doc/classes/VisualShaderNodeTextureFunc.xml
+++ b/doc/classes/VisualShaderNodeTextureFunc.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="VisualShaderNodeTextureFunc" inherits="VisualShaderNode" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Function to be applied on texture sampler.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeTextureFunc.Function" default="0">
+			A function to be applied to the texture sampler.
+		</member>
+		<member name="sampler_type" type="int" setter="set_sampler_type" getter="get_sampler_type" enum="VisualShaderNodeTextureFunc.SamplerType" default="0">
+			A type of sampler.
+		</member>
+	</members>
+	<constants>
+		<constant name="FUNC_SIZE" value="0" enum="Function">
+			A function to retrieve the dimensions of a level of a texture.
+		</constant>
+		<constant name="FUNC_QUERY_LEVELS" value="1" enum="Function">
+			A function to compute the number of accessible mipmap levels of a texture.
+		</constant>
+		<constant name="FUNC_QUERY_LOD" value="2" enum="Function">
+			A function to compute the level-of-detail that would be used to sample from a texture.
+		</constant>
+		<constant name="FUNC_MAX" value="3" enum="Function">
+			Represents the size of the [enum Function] enum.
+		</constant>
+		<constant name="SAMPLER_TYPE_2D" value="0" enum="SamplerType">
+			2D sampler type.
+		</constant>
+		<constant name="SAMPLER_TYPE_2D_ARRAY" value="1" enum="SamplerType">
+			2D-array sampler type.
+		</constant>
+		<constant name="SAMPLER_TYPE_3D" value="2" enum="SamplerType">
+			3D sampler type.
+		</constant>
+		<constant name="SAMPLER_TYPE_CUBE" value="3" enum="SamplerType">
+			Cubemap sampler type.
+		</constant>
+		<constant name="SAMPLER_TYPE_MAX" value="4" enum="SamplerType">
+			Represents the size of the [enum SamplerType] enum.
+		</constant>
+	</constants>
+</class>

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
@@ -3622,6 +3622,17 @@ void VisualShaderEditor::_setup_node(VisualShaderNode *p_node, const Vector<Vari
 		}
 	}
 
+	// TEXTURE_FUNC
+	{
+		VisualShaderNodeTextureFunc *tex_func = Object::cast_to<VisualShaderNodeTextureFunc>(p_node);
+
+		if (tex_func) {
+			ERR_FAIL_COND(p_ops[0].get_type() != Variant::INT);
+			tex_func->set_function((VisualShaderNodeTextureFunc::Function)(int)p_ops[0]);
+			return;
+		}
+	}
+
 	// VECTOR_COMPOSE
 	{
 		VisualShaderNodeVectorCompose *vec_compose = Object::cast_to<VisualShaderNodeVectorCompose>(p_node);
@@ -7515,7 +7526,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	}
 
 	// TEXTURES
-
+	add_options.push_back(AddOption("TextureFunc", "Textures/Common", "VisualShaderNodeTextureFunc", TTR("Function to be applied on texture sampler.")));
 	add_options.push_back(AddOption("UVFunc", "Textures/Common", "VisualShaderNodeUVFunc", TTR("Function to be applied on texture coordinates."), {}, VisualShaderNode::PORT_TYPE_VECTOR_2D));
 	add_options.push_back(AddOption("UVPolarCoord", "Textures/Common", "VisualShaderNodeUVPolarCoord", TTR("Polar coordinates conversion applied on texture coordinates."), {}, VisualShaderNode::PORT_TYPE_VECTOR_2D));
 
@@ -7536,6 +7547,10 @@ VisualShaderEditor::VisualShaderEditor() {
 	add_options.push_back(AddOption("Texture2DArray", "Textures/Functions", "VisualShaderNodeTexture2DArray", TTR("Perform the 2D-array texture lookup."), {}, VisualShaderNode::PORT_TYPE_VECTOR_4D));
 	texture3d_node_option_idx = add_options.size();
 	add_options.push_back(AddOption("Texture3D", "Textures/Functions", "VisualShaderNodeTexture3D", TTR("Perform the 3D texture lookup."), {}, VisualShaderNode::PORT_TYPE_VECTOR_4D));
+	add_options.push_back(AddOption("TextureQueryLevels", "Textures/Functions", "VisualShaderNodeTextureFunc", TTR("Compute the number of accessible mipmap levels of a texture."), { VisualShaderNodeTextureFunc::FUNC_QUERY_LEVELS }, VisualShaderNode::PORT_TYPE_SCALAR_INT, -1, -1, true));
+	add_options.push_back(AddOption("TextureQueryLod", "Textures/Functions", "VisualShaderNodeTextureFunc", TTR("Compute the level-of-detail that would be used to sample from a texture."), { VisualShaderNodeTextureFunc::FUNC_QUERY_LOD }, VisualShaderNode::PORT_TYPE_VECTOR_2D, TYPE_FLAGS_FRAGMENT | TYPE_FLAGS_LIGHT, -1, true));
+	add_options.push_back(AddOption("TextureQueryLod", "Textures/Functions", "VisualShaderNodeTextureFunc", TTR("Compute the level-of-detail that would be used to sample from a texture."), { VisualShaderNodeTextureFunc::FUNC_QUERY_LOD }, VisualShaderNode::PORT_TYPE_VECTOR_2D, TYPE_FLAGS_SKY, Shader::MODE_SKY, true));
+	add_options.push_back(AddOption("TextureSize", "Textures/Functions", "VisualShaderNodeTextureFunc", TTR("Retrieve the dimensions of a level of a texture."), { VisualShaderNodeTextureFunc::FUNC_SIZE }));
 	add_options.push_back(AddOption("UVPanning", "Textures/Functions", "VisualShaderNodeUVFunc", TTR("Apply panning function on texture coordinates."), { VisualShaderNodeUVFunc::FUNC_PANNING }, VisualShaderNode::PORT_TYPE_VECTOR_2D));
 	add_options.push_back(AddOption("UVScaling", "Textures/Functions", "VisualShaderNodeUVFunc", TTR("Apply scaling function on texture coordinates."), { VisualShaderNodeUVFunc::FUNC_SCALING }, VisualShaderNode::PORT_TYPE_VECTOR_2D));
 

--- a/modules/visual_shader/register_types.cpp
+++ b/modules/visual_shader/register_types.cpp
@@ -113,6 +113,7 @@ void initialize_visual_shader_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(VisualShaderNodeVectorDecompose);
 		GDREGISTER_CLASS(VisualShaderNodeTransformDecompose);
 		GDREGISTER_CLASS(VisualShaderNodeTexture);
+		GDREGISTER_CLASS(VisualShaderNodeTextureFunc);
 		GDREGISTER_CLASS(VisualShaderNodeCurveTexture);
 		GDREGISTER_CLASS(VisualShaderNodeCurveXYZTexture);
 		GDREGISTER_ABSTRACT_CLASS(VisualShaderNodeSample3D);

--- a/modules/visual_shader/vs_nodes/visual_shader_nodes.cpp
+++ b/modules/visual_shader/vs_nodes/visual_shader_nodes.cpp
@@ -1225,6 +1225,267 @@ VisualShaderNodeCurveXYZTexture::VisualShaderNodeCurveXYZTexture() {
 	allow_v_resize = false;
 }
 
+////////////// Texture Func
+
+String VisualShaderNodeTextureFunc::get_caption() const {
+	return "TextureFunc";
+}
+
+int VisualShaderNodeTextureFunc::get_input_port_count() const {
+	if (func == FUNC_SIZE || func == FUNC_QUERY_LOD) {
+		return 2;
+	}
+	return 1;
+}
+
+VisualShaderNodeTextureFunc::PortType VisualShaderNodeTextureFunc::get_input_port_type(int p_port) const {
+	if (p_port == 0) {
+		return PORT_TYPE_SAMPLER;
+	} else if (p_port == 1) {
+		switch (func) {
+			case FUNC_SIZE:
+				return PORT_TYPE_SCALAR_INT;
+			case FUNC_QUERY_LEVELS:
+				break;
+			case FUNC_QUERY_LOD: {
+				switch (sampler_type) {
+					case SAMPLER_TYPE_2D:
+						return PORT_TYPE_VECTOR_2D;
+					case SAMPLER_TYPE_2D_ARRAY:
+						return PORT_TYPE_VECTOR_2D;
+					case SAMPLER_TYPE_3D:
+						return PORT_TYPE_VECTOR_3D;
+					case SAMPLER_TYPE_CUBE:
+						return PORT_TYPE_VECTOR_3D;
+					case SAMPLER_TYPE_MAX:
+						break;
+				}
+			} break;
+			case FUNC_MAX:
+				break;
+		}
+	}
+	return PORT_TYPE_SCALAR;
+}
+
+String VisualShaderNodeTextureFunc::get_input_port_name(int p_port) const {
+	if (p_port == 0) {
+		switch (sampler_type) {
+			case SAMPLER_TYPE_2D:
+				return "sampler2D";
+			case SAMPLER_TYPE_2D_ARRAY:
+				return "sampler2DArray";
+			case SAMPLER_TYPE_3D:
+				return "sampler3D";
+			case SAMPLER_TYPE_CUBE:
+				return "samplerCube";
+			case SAMPLER_TYPE_MAX:
+				break;
+		}
+	} else if (p_port == 1) {
+		switch (func) {
+			case FUNC_SIZE:
+				return "lod";
+			case FUNC_QUERY_LEVELS:
+				break;
+			case FUNC_QUERY_LOD:
+				return "coords";
+			case FUNC_MAX:
+				break;
+		}
+	}
+	return String();
+}
+
+int VisualShaderNodeTextureFunc::get_output_port_count() const {
+	return 1;
+}
+
+VisualShaderNodeTextureFunc::PortType VisualShaderNodeTextureFunc::get_output_port_type(int p_port) const {
+	if (p_port == 0) {
+		switch (func) {
+			case FUNC_SIZE:
+				switch (sampler_type) {
+					case SAMPLER_TYPE_2D:
+						return PORT_TYPE_VECTOR_2D;
+					case SAMPLER_TYPE_2D_ARRAY:
+						return PORT_TYPE_VECTOR_3D;
+					case SAMPLER_TYPE_3D:
+						return PORT_TYPE_VECTOR_3D;
+					case SAMPLER_TYPE_CUBE:
+						return PORT_TYPE_VECTOR_2D;
+					case SAMPLER_TYPE_MAX:
+						return PORT_TYPE_SCALAR;
+				}
+				break;
+			case FUNC_QUERY_LEVELS:
+				return PORT_TYPE_SCALAR_INT;
+			case FUNC_QUERY_LOD:
+				return PORT_TYPE_VECTOR_2D;
+			case FUNC_MAX:
+				break;
+		}
+	}
+	return PORT_TYPE_SCALAR;
+}
+
+String VisualShaderNodeTextureFunc::get_output_port_name(int p_port) const {
+	if (p_port == 0) {
+		switch (func) {
+			case FUNC_SIZE:
+				return "size";
+			case FUNC_QUERY_LEVELS:
+				return "levels";
+			case FUNC_QUERY_LOD:
+				return "lod";
+			case FUNC_MAX:
+				break;
+		}
+	}
+	return String();
+}
+
+void VisualShaderNodeTextureFunc::set_sampler_type(SamplerType p_sampler_type) {
+	ERR_FAIL_INDEX(int(p_sampler_type), int(SAMPLER_TYPE_MAX));
+	if (sampler_type == p_sampler_type) {
+		return;
+	}
+	sampler_type = p_sampler_type;
+	emit_changed();
+}
+
+VisualShaderNodeTextureFunc::SamplerType VisualShaderNodeTextureFunc::get_sampler_type() const {
+	return sampler_type;
+}
+
+void VisualShaderNodeTextureFunc::set_function(Function p_func) {
+	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	if (func == p_func) {
+		return;
+	}
+
+	func = p_func;
+	emit_changed();
+}
+
+VisualShaderNodeTextureFunc::Function VisualShaderNodeTextureFunc::get_function() const {
+	return func;
+}
+
+String VisualShaderNodeTextureFunc::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
+	switch (func) {
+		case FUNC_SIZE: {
+			String lod;
+			if (p_input_vars[1].is_empty()) {
+				lod = "0";
+			} else {
+				lod = p_input_vars[1];
+			}
+
+			switch (sampler_type) {
+				case SAMPLER_TYPE_CUBE:
+				case SAMPLER_TYPE_2D:
+					if (p_input_vars[0].is_empty()) {
+						return "	" + p_output_vars[0] + " = vec2(0.0);";
+					}
+					return "	" + p_output_vars[0] + " = vec2(textureSize(" + p_input_vars[0] + ", " + lod + "));\n";
+				case SAMPLER_TYPE_2D_ARRAY:
+				case SAMPLER_TYPE_3D:
+					if (p_input_vars[0].is_empty()) {
+						return "	" + p_output_vars[0] + " = vec3(0.0);";
+					}
+					return "	" + p_output_vars[0] + " = vec3(textureSize(" + p_input_vars[0] + ", " + lod + "));\n";
+				case SAMPLER_TYPE_MAX:
+					break;
+			}
+		} break;
+		case FUNC_QUERY_LEVELS: {
+			if (p_input_vars[0].is_empty()) {
+				return "	" + p_output_vars[0] + " = 0;";
+			}
+			return "	" + p_output_vars[0] + " = textureQueryLevels(" + p_input_vars[0] + ");\n";
+		} break;
+		case FUNC_QUERY_LOD: {
+			if (p_input_vars[0].is_empty() || (p_type == VisualShader::Type::TYPE_VERTEX || (p_mode != Shader::MODE_CANVAS_ITEM && p_mode != Shader::MODE_SPATIAL && p_mode != Shader::MODE_SKY))) {
+				return "	" + p_output_vars[0] + " = vec2(0.0);";
+			}
+
+			String coords;
+			if (p_input_vars[1].is_empty()) {
+				if (sampler_type == SAMPLER_TYPE_3D || sampler_type == SAMPLER_TYPE_CUBE) {
+					coords = "vec3(0.0)";
+				} else {
+					coords = "vec2(0.0)";
+				}
+			} else {
+				coords = p_input_vars[1];
+			}
+			return "	" + p_output_vars[0] + " = textureQueryLod(" + p_input_vars[0] + ", " + coords + ");\n";
+		} break;
+		case FUNC_MAX:
+			break;
+	}
+	return String();
+}
+
+String VisualShaderNodeTextureFunc::get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const {
+	String warning;
+
+	if (!is_input_port_connected(0)) {
+		warning += RTR("Texture must be connected in order this node work correctly.");
+	}
+
+	if (func == FUNC_QUERY_LOD) {
+		if (p_mode != Shader::MODE_CANVAS_ITEM && p_mode != Shader::MODE_SPATIAL && p_mode != Shader::MODE_SKY) {
+			if (!warning.is_empty()) {
+				warning += "\n";
+			}
+			warning += vformat(RTR("`QueryLod` function is available only on `%s`, `%s` and `%s` shader modes."), "canvas_item", "spatial", "sky");
+		}
+
+		if (!warning.is_empty()) {
+			warning += "\n";
+		}
+
+		if (p_type == VisualShader::TYPE_VERTEX) {
+			warning += RTR("`QueryLod` function is unavailable in vertex shader graph.");
+		}
+	}
+	return warning;
+}
+
+void VisualShaderNodeTextureFunc::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_function", "func"), &VisualShaderNodeTextureFunc::set_function);
+	ClassDB::bind_method(D_METHOD("get_function"), &VisualShaderNodeTextureFunc::get_function);
+
+	ClassDB::bind_method(D_METHOD("set_sampler_type", "sampler_type"), &VisualShaderNodeTextureFunc::set_sampler_type);
+	ClassDB::bind_method(D_METHOD("get_sampler_type"), &VisualShaderNodeTextureFunc::get_sampler_type);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "function", PROPERTY_HINT_ENUM, "Size,QueryLevels,QueryLod"), "set_function", "get_function");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "sampler_type", PROPERTY_HINT_ENUM, "2D,2DArray,3D,Cube"), "set_sampler_type", "get_sampler_type");
+
+	BIND_ENUM_CONSTANT(FUNC_SIZE);
+	BIND_ENUM_CONSTANT(FUNC_QUERY_LEVELS);
+	BIND_ENUM_CONSTANT(FUNC_QUERY_LOD);
+	BIND_ENUM_CONSTANT(FUNC_MAX);
+
+	BIND_ENUM_CONSTANT(SAMPLER_TYPE_2D);
+	BIND_ENUM_CONSTANT(SAMPLER_TYPE_2D_ARRAY);
+	BIND_ENUM_CONSTANT(SAMPLER_TYPE_3D);
+	BIND_ENUM_CONSTANT(SAMPLER_TYPE_CUBE);
+	BIND_ENUM_CONSTANT(SAMPLER_TYPE_MAX);
+}
+
+Vector<StringName> VisualShaderNodeTextureFunc::get_editable_properties() const {
+	Vector<StringName> props;
+	props.push_back("function");
+	props.push_back("sampler_type");
+	return props;
+}
+
+VisualShaderNodeTextureFunc::VisualShaderNodeTextureFunc() {
+}
+
 ////////////// Sample3D
 
 int VisualShaderNodeSample3D::get_input_port_count() const {

--- a/modules/visual_shader/vs_nodes/visual_shader_nodes.h
+++ b/modules/visual_shader/vs_nodes/visual_shader_nodes.h
@@ -524,6 +524,63 @@ public:
 
 ///////////////////////////////////////
 
+class VisualShaderNodeTextureFunc : public VisualShaderNode {
+	GDCLASS(VisualShaderNodeTextureFunc, VisualShaderNode);
+
+public:
+	enum SamplerType {
+		SAMPLER_TYPE_2D,
+		SAMPLER_TYPE_2D_ARRAY,
+		SAMPLER_TYPE_3D,
+		SAMPLER_TYPE_CUBE,
+		SAMPLER_TYPE_MAX,
+	};
+
+	enum Function {
+		FUNC_SIZE,
+		FUNC_QUERY_LEVELS,
+		FUNC_QUERY_LOD,
+		FUNC_MAX,
+	};
+
+private:
+	SamplerType sampler_type = SAMPLER_TYPE_2D;
+	Function func = FUNC_SIZE;
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual String get_caption() const override;
+
+	virtual int get_input_port_count() const override;
+	virtual PortType get_input_port_type(int p_port) const override;
+	virtual String get_input_port_name(int p_port) const override;
+
+	virtual int get_output_port_count() const override;
+	virtual PortType get_output_port_type(int p_port) const override;
+	virtual String get_output_port_name(int p_port) const override;
+
+	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
+	virtual String get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const override;
+
+	virtual Category get_category() const override { return CATEGORY_TEXTURES; }
+
+	void set_sampler_type(SamplerType p_sampler_type);
+	SamplerType get_sampler_type() const;
+
+	void set_function(Function p_func);
+	Function get_function() const;
+
+	virtual Vector<StringName> get_editable_properties() const override;
+	VisualShaderNodeTextureFunc();
+};
+
+VARIANT_ENUM_CAST(VisualShaderNodeTextureFunc::SamplerType)
+VARIANT_ENUM_CAST(VisualShaderNodeTextureFunc::Function)
+
+///////////////////////////////////////
+
 class VisualShaderNodeSample3D : public VisualShaderNode {
 	GDCLASS(VisualShaderNodeSample3D, VisualShaderNode);
 


### PR DESCRIPTION
This will easy up access to `textureSize`, `textureQueryLevels`, `textureQueryLod` functions in visual shaders by using unified `TextureFunc` node.

<details>
<summary>Details</summary>

<img width="2310" height="1384" alt="изображение" src="https://github.com/user-attachments/assets/fe41e034-d159-49b9-9695-94ffa32c6e88" />

<img width="456" height="856" alt="изображение" src="https://github.com/user-attachments/assets/9c4e8503-79e2-4854-8dde-ea34a52817f6" />

</details>
