### PR TITLE
Add reload_open_files() to script editor

### DIFF
--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -99,6 +99,12 @@
 				[b]Note:[/b] Does not apply to scripts that are already opened.
 			</description>
 		</method>
+		<method name="reload_open_files">
+			<return type="void" />
+			<description>
+				Reloads all currently opened files. This should be used when opened files are changed outside of the script editor. The user may be prompted to resolve file conflicts, see [member EditorSettings.text_editor/behavior/files/auto_reload_scripts_on_external_change].
+			</description>
+		</method>
 		<method name="save_all_scripts">
 			<return type="void" />
 			<description>

--- a/editor/project_upgrade/renames_map_3_to_4.cpp
+++ b/editor/project_upgrade/renames_map_3_to_4.cpp
@@ -478,6 +478,7 @@ const char *RenamesMap3To4::gdscript_function_renames[][2] = {
 	{ "region_bake_navmesh", "region_bake_navigation_mesh" }, // Navigation3DServer
 	{ "region_set_navmesh", "region_set_navigation_mesh" }, // Navigation3DServer
 	{ "region_set_navpoly", "region_set_navigation_polygon" }, // Navigation2DServer
+	{ "reload_scripts", "reload_open_files" }, // ScriptEditor
 	{ "remove_animation", "remove_animation_library" }, // AnimationPlayer
 	{ "remove_color_override", "remove_theme_color_override" }, // Control
 	{ "remove_constant_override", "remove_theme_constant_override" }, // Control

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -2348,6 +2348,11 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 	return true;
 }
 
+void ScriptEditor::reload_open_files() {
+	_test_script_times_on_disk();
+	_update_modified_scripts_for_external_editor();
+}
+
 PackedStringArray ScriptEditor::get_unsaved_scripts() const {
 	PackedStringArray unsaved_list;
 
@@ -3742,6 +3747,7 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_current_script"), &ScriptEditor::_get_current_script);
 	ClassDB::bind_method(D_METHOD("get_open_scripts"), &ScriptEditor::_get_open_scripts);
 	ClassDB::bind_method(D_METHOD("open_script_create_dialog", "base_name", "base_path"), &ScriptEditor::open_script_create_dialog);
+	ClassDB::bind_method(D_METHOD("reload_open_files"), &ScriptEditor::reload_open_files);
 
 	ClassDB::bind_method(D_METHOD("goto_help", "topic"), &ScriptEditor::goto_help);
 	ClassDB::bind_method(D_METHOD("update_docs_from_script", "script"), &ScriptEditor::update_docs_from_script);

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -423,6 +423,7 @@ public:
 	Vector<String> _get_breakpoints();
 	void get_breakpoints(List<String> *p_breakpoints);
 
+	void reload_open_files();
 	PackedStringArray get_unsaved_scripts() const;
 	void save_current_script();
 	void save_all_scripts();


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot/pull/83267

This adds `reload_open_files()` to the script editor.

Pursuant to @kitbdev 's feedback:
> This can cause unsaved changes to be lost without confirmation.
> It would be better to expose _test_script_times_on_disk (and maybe _update_modified_scripts_for_external_editor which is usually called after it?, effectively _on_find_in_files_modified_files) if needed.

I have implemented `reload_open_files()` to call `_test_script_times_on_disk()` and `_update_modified_scripts_for_external_editor()`. This will reload all the scripts if there are no unsaved scripts; if there are, the user will be prompted to save them first.

- *bugsquad edit* Closes https://github.com/godotengine/godot-proposals/issues/8111