### PR TITLE
Fix thread safety of physics interpolation

### DIFF
--- a/scene/main/scene_tree_fti.cpp
+++ b/scene/main/scene_tree_fti.cpp
@@ -83,7 +83,7 @@ void SceneTreeFTI::set_enabled(Node *p_root, bool p_enabled) {
 	if (data.enabled == p_enabled) {
 		return;
 	}
-	MutexLock(data.mutex);
+	MutexLock lock(data.mutex);
 
 	data.tick_xform_list[0].clear();
 	data.tick_xform_list[1].clear();
@@ -111,7 +111,7 @@ void SceneTreeFTI::tick_update() {
 	if (!data.enabled) {
 		return;
 	}
-	MutexLock(data.mutex);
+	MutexLock lock(data.mutex);
 
 	_update_request_resets();
 
@@ -221,7 +221,7 @@ void SceneTreeFTI::node_3d_request_reset(Node3D *p_node) {
 	DEV_CHECK_ONCE(data.enabled);
 	DEV_ASSERT(p_node);
 
-	MutexLock(data.mutex);
+	MutexLock lock(data.mutex);
 
 	if (!p_node->_is_physics_interpolation_reset_requested()) {
 		p_node->_set_physics_interpolation_reset_requested(true);
@@ -415,7 +415,7 @@ void SceneTreeFTI::node_3d_notify_delete(Node3D *p_node) {
 
 	ERR_FAIL_NULL(p_node);
 
-	MutexLock(data.mutex);
+	MutexLock lock(data.mutex);
 
 	// Remove from frame lists.
 	if (p_node->data.fti_on_frame_xform_list) {
@@ -605,7 +605,7 @@ void SceneTreeFTI::frame_update(Node *p_root, bool p_frame_start) {
 	if (!data.enabled || !p_root) {
 		return;
 	}
-	MutexLock(data.mutex);
+	MutexLock lock(data.mutex);
 
 	data.frame_start = p_frame_start;
 	data.in_frame = true;

--- a/scene/main/scene_tree_fti.h
+++ b/scene/main/scene_tree_fti.h
@@ -143,7 +143,7 @@ public:
 		if (!data.enabled) {
 			return;
 		}
-		MutexLock(data.mutex);
+		MutexLock lock(data.mutex);
 
 		if (p_transform_changed) {
 			_node_3d_notify_set_xform(r_node);


### PR DESCRIPTION
Fixes [issue#116191](https://github.com/godotengine/godot/issues/116191).

After applying the commit of this PR, the MRP of [issue#116191](https://github.com/godotengine/godot/issues/116191) worked as expected, no longer crashing anymore.

Considering the fact that the whole physics interpolation system is rendered thread-unsafe by the bug being squashed here, this PR *may* also fix some other issues.

## Explanation

Every use of the mutex in `scene_tree_fti.h` and `scene_tree_fti.cpp` looks like this:

```c++
MutexLock(data.mutex);
```

Looks innocent, but this only constructs a temporary and destroys it right afterwards. This is, at most, as good as an atomic load with acquire-release semantic. It did not properly setup a critical section with RAII.

The correct practice is:

```cpp
MutexLock lock(data.mutex);
```

The particular problem in [issue#116191](https://github.com/godotengine/godot/issues/116191) is caused by unprotected `LocalVector<Node3D*>::push_back()`. One thread `realloc()`-ed the container on demand but had yet to update the `data` pointer, and another thread stepped in to perform a `push_back()`. Oops, dangling pointer. (This is caught in an ASAN build of the engine).

## Notes

Maybe we should mark `MutexLock` as `[[nodiscard]]`, so that the compiler can hopefully catch this kind of errors.

Another option is to use some static checkers.

This kind of bug is easy once you noticed its existence, but is also able to catch you completely off-guard if you didn't *think in this direction*. I would say even experienced devs could let this bug slip into production, or spend hours reasoning about an impossible situation with a super slow ASAN build before correctly identifying the root cause. So I strongly suggest that we guard against it with some systematic / automated approach.