### PR TITLE
[TextServer] Ignore language of embedded object replacement spans when updating line breaks.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -6270,13 +6270,18 @@ bool TextServerAdvanced::_shaped_text_update_breaks(const RID &p_shaped) {
 		int i = 0;
 		int span_size = sd->spans.size();
 		while (i < span_size) {
+			bool start_with_obj = sd->spans[i].embedded_key != Variant();
 			String language = sd->spans[i].language;
 			int r_start = sd->spans[i].start;
 			if (r_start == sd->spans[i].end) {
 				i++;
 				continue;
 			}
-			while (i + 1 < span_size && (language == sd->spans[i + 1].language || sd->spans[i + 1].start == sd->spans[i + 1].end)) {
+			while (i + 1 < span_size && (language == sd->spans[i + 1].language || start_with_obj || sd->spans[i + 1].embedded_key != Variant() || sd->spans[i + 1].start == sd->spans[i + 1].end)) {
+				if (start_with_obj && sd->spans[i + 1].embedded_key == Variant()) {
+					language = sd->spans[i + 1].language;
+					start_with_obj = false;
+				}
 				i++;
 			}
 			int r_end = sd->spans[i].end;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/115898

Object replacement (e.g, RTL images and tables) always has language set to empty and should use previous span language for the purpose of line breaking.