### PR TITLE
Improve documentation for AudioEffects

### DIFF
--- a/doc/classes/AudioEffect.xml
+++ b/doc/classes/AudioEffect.xml
@@ -5,10 +5,11 @@
 	</brief_description>
 	<description>
 		The base [Resource] for every audio effect. In the editor, an audio effect can be added to the current bus layout through the Audio panel. At run-time, it is also possible to manipulate audio effects through [method AudioServer.add_bus_effect], [method AudioServer.remove_bus_effect], and [method AudioServer.get_bus_effect].
-		When applied on a bus, an audio effect creates a corresponding [AudioEffectInstance]. The instance is directly responsible for manipulating the sound, based on the original audio effect's properties.
+		When applied on a bus, an audio effect creates a corresponding [AudioEffectInstance]. The instance is directly responsible for manipulating sound, based on the original audio effect's properties.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 		<link title="Audio Microphone Record Demo">https://godotengine.org/asset-library/asset/2760</link>
 	</tutorials>
 	<methods>

--- a/doc/classes/AudioEffectAmplify.xml
+++ b/doc/classes/AudioEffectAmplify.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectAmplify" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds an amplifying audio effect to an audio bus.
+		Adds a volume manipulation audio effect to an audio bus.
 	</brief_description>
 	<description>
 		Increases or decreases the volume being routed through the audio bus.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 	<members>
 		<member name="volume_db" type="float" setter="set_volume_db" getter="get_volume_db" default="0.0">
-			Amount of amplification in decibels. Positive values make the sound louder, negative values make it quieter. Value can range from -80 to 24.
+			Amount of amplification in dB. Positive values make the sound louder, negative values make it quieter. Value can range from -80 to 24.
 		</member>
 		<member name="volume_linear" type="float" setter="set_volume_linear" getter="get_volume_linear">
 			Amount of amplification as a linear value.

--- a/doc/classes/AudioEffectBandLimitFilter.xml
+++ b/doc/classes/AudioEffectBandLimitFilter.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectBandLimitFilter" inherits="AudioEffectFilter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a band limit filter to the audio bus.
+		Adds a band-limit filter to an audio bus.
 	</brief_description>
 	<description>
-		Limits the frequencies in a range around the [member AudioEffectFilter.cutoff_hz] and allows frequencies outside of this range to pass.
+		A "band-limit" filter attenuates the frequencies at [member AudioEffectFilter.cutoff_hz], and allows frequencies outside the frequency threshold to pass unchanged. It is a wider and weaker version of [AudioEffectNotchFilter], and is the opposite of [AudioEffectBandPassFilter].
+		This filter can be used to give more room for other sounds to play at that frequency.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectBandPassFilter.xml
+++ b/doc/classes/AudioEffectBandPassFilter.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectBandPassFilter" inherits="AudioEffectFilter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a band pass filter to the audio bus.
+		Adds a band-pass filter to an audio bus.
 	</brief_description>
 	<description>
-		Attenuates the frequencies inside of a range around the [member AudioEffectFilter.cutoff_hz] and cuts frequencies outside of this band.
+		A "band-pass" filter allows the frequencies at [member AudioEffectFilter.cutoff_hz] to pass unchanged, and attenuates frequencies outside the frequency threshold. It is the opposite of [AudioEffectBandLimitFilter] and [AudioEffectNotchFilter].
+		This filter can be used to emulate sounds coming from weak speakers.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectCapture.xml
+++ b/doc/classes/AudioEffectCapture.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectCapture" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Captures audio from an audio bus in real-time.
+		Exposes audio samples from an audio bus in real-time, such that it can be accessed as data.
 	</brief_description>
 	<description>
-		AudioEffectCapture is an AudioEffect which copies all audio frames from the attached audio effect bus into its internal ring buffer.
+		Copies all audio frames, also known as "samples" or "audio samples", from the attached audio bus into its internal ring buffer. This effect does not alter the audio. Can be used for storing real-time audio data for playback, and for creating real-time audio visualizations, like an oscilloscope.
 		Application code should consume these audio frames from this ring buffer using [method get_buffer] and process it as needed, for example to capture data from an [AudioStreamMicrophone], implement application-defined effects, or to transmit audio over the network. When capturing audio data from a microphone, the format of the samples will be stereo 32-bit floating-point PCM.
 		Unlike [AudioEffectRecord], this effect only returns the raw audio samples instead of encoding them into an [AudioStream].
 	</description>
@@ -16,7 +16,7 @@
 			<return type="bool" />
 			<param index="0" name="frames" type="int" />
 			<description>
-				Returns [code]true[/code] if at least [param frames] audio frames are available to read in the internal ring buffer.
+				Returns [code]true[/code] if at least [param frames] samples are available to read in the internal ring buffer.
 			</description>
 		</method>
 		<method name="clear_buffer">
@@ -30,39 +30,40 @@
 			<return type="PackedVector2Array" />
 			<param index="0" name="frames" type="int" />
 			<description>
-				Gets the next [param frames] audio samples from the internal ring buffer.
-				Returns a [PackedVector2Array] containing exactly [param frames] audio samples if available, or an empty [PackedVector2Array] if insufficient data was available.
+				Gets the next [param frames] samples from the internal ring buffer.
+				Returns a [PackedVector2Array] containing exactly [param frames] samples if available, or an empty [PackedVector2Array] if insufficient data was available.
 				The samples are signed floating-point PCM between [code]-1[/code] and [code]1[/code]. You will have to scale them if you want to use them as 8 or 16-bit integer samples. ([code]v = 0x7fff * samples[0].x[/code])
 			</description>
 		</method>
 		<method name="get_buffer_length_frames" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the total size of the internal ring buffer in frames.
+				Returns the total size of the internal ring buffer in number of samples.
 			</description>
 		</method>
 		<method name="get_discarded_frames" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the number of audio frames discarded from the audio bus due to full buffer.
+				Returns the number of samples discarded from the audio bus due to full buffer.
 			</description>
 		</method>
 		<method name="get_frames_available" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the number of frames available to read using [method get_buffer].
+				Returns the number of samples available to read using [method get_buffer].
 			</description>
 		</method>
 		<method name="get_pushed_frames" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the number of audio frames inserted from the audio bus.
+				Returns the number of samples inserted from the audio bus.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="buffer_length" type="float" setter="set_buffer_length" getter="get_buffer_length" default="0.1">
-			Length of the internal ring buffer, in seconds. Setting the buffer length will have no effect if already initialized.
+			Length of the internal ring buffer, in seconds. Higher values keep data around for longer, but require more memory. Value can range from 0.01 to 10.
+			[b]Note:[/b] Setting the buffer length will have no effect if already initialized.
 		</member>
 	</members>
 </class>

--- a/doc/classes/AudioEffectChorus.xml
+++ b/doc/classes/AudioEffectChorus.xml
@@ -1,49 +1,60 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectChorus" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a chorus audio effect.
+		Adds a chorus audio effect to an audio bus.
+		Gives the impression of multiple audio sources.
 	</brief_description>
 	<description>
-		Adds a chorus audio effect. The effect applies a filter with voices to duplicate the audio source and manipulate it through the filter.
+		A "chorus" effect creates multiple copies of the original audio (called "voices") with variations in pitch, and layers on top of the original, giving the impression that the sound comes from multiple sources. This creates spectral and spatial movement.
+		Each voice is played a short period of time after the original audio, controlled by [code]delay[/code]. An internal low-frequency oscillator (LFO) controls their pitch, and [code]depth[/code] controls the LFO's maximum amount.
+		In the real world, this kind of effect is found in pianos, choirs, and instrument ensembles.
+		This effect can also be used to widen mono audio and make digital sounds have a more natural or analog quality.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_voice_cutoff_hz" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="voice_idx" type="int" />
 			<description>
+				Returns the frequency threshold of a given [param voice_idx]'s low-pass filter in Hz. Frequencies above this value are removed from the voice.
 			</description>
 		</method>
 		<method name="get_voice_delay_ms" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="voice_idx" type="int" />
 			<description>
+				Returns the delay of a given [param voice_idx] in milliseconds, compared to the original audio.
 			</description>
 		</method>
 		<method name="get_voice_depth_ms" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="voice_idx" type="int" />
 			<description>
+				Returns the depth of a given [param voice_idx]'s low-frequency oscillator in milliseconds.
 			</description>
 		</method>
 		<method name="get_voice_level_db" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="voice_idx" type="int" />
 			<description>
+				Returns the gain of a given [param voice_idx] in dB.
 			</description>
 		</method>
 		<method name="get_voice_pan" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="voice_idx" type="int" />
 			<description>
+				Returns the pan position of a given [param voice_idx]. Negative values mean the left channel, positive mean the right.
 			</description>
 		</method>
 		<method name="get_voice_rate_hz" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="voice_idx" type="int" />
 			<description>
+				Returns the rate of a given [param voice_idx]'s low-frequency oscillator in Hz.
 			</description>
 		</method>
 		<method name="set_voice_cutoff_hz">
@@ -51,6 +62,7 @@
 			<param index="0" name="voice_idx" type="int" />
 			<param index="1" name="cutoff_hz" type="float" />
 			<description>
+				Sets the frequency threshold of a given [param voice_idx]'s low-pass filter in Hz. Frequencies above [param cutoff_hz] are removed from [param voice_idx]. Value can range from 1 to 20500.
 			</description>
 		</method>
 		<method name="set_voice_delay_ms">
@@ -58,6 +70,7 @@
 			<param index="0" name="voice_idx" type="int" />
 			<param index="1" name="delay_ms" type="float" />
 			<description>
+				Sets the delay of a given [param voice_idx] in milliseconds, compared to the original audio. Value can range from 0 to 50.
 			</description>
 		</method>
 		<method name="set_voice_depth_ms">
@@ -65,6 +78,7 @@
 			<param index="0" name="voice_idx" type="int" />
 			<param index="1" name="depth_ms" type="float" />
 			<description>
+				Sets the depth of a given [param voice_idx]'s low-frequency oscillator in milliseconds. Value can range from 0 to 20.
 			</description>
 		</method>
 		<method name="set_voice_level_db">
@@ -72,6 +86,7 @@
 			<param index="0" name="voice_idx" type="int" />
 			<param index="1" name="level_db" type="float" />
 			<description>
+				Sets the gain of a given [param voice_idx] in dB. Value can range from -60 to 24.
 			</description>
 		</method>
 		<method name="set_voice_pan">
@@ -79,6 +94,7 @@
 			<param index="0" name="voice_idx" type="int" />
 			<param index="1" name="pan" type="float" />
 			<description>
+				Sets the pan position of a given [param voice_idx]. Negative values pan the sound to the left, positive pan to the right. Value can range from -1 to 1.
 			</description>
 		</method>
 		<method name="set_voice_rate_hz">
@@ -86,90 +102,91 @@
 			<param index="0" name="voice_idx" type="int" />
 			<param index="1" name="rate_hz" type="float" />
 			<description>
+				Sets the rate of a given [param voice_idx]'s low-frequency oscillator in Hz. Value can range from 0.1 to 20.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="dry" type="float" setter="set_dry" getter="get_dry" default="1.0">
-			The effect's raw signal.
+			The volume ratio of the original audio. Value can range from 0 to 1.
 		</member>
 		<member name="voice/1/cutoff_hz" type="float" setter="set_voice_cutoff_hz" getter="get_voice_cutoff_hz" default="8000.0">
-			The voice's cutoff frequency.
+			The frequency threshold of the voice's low-pass filter in Hz.
 		</member>
 		<member name="voice/1/delay_ms" type="float" setter="set_voice_delay_ms" getter="get_voice_delay_ms" default="15.0">
-			The voice's signal delay.
+			The delay of the voice in milliseconds, compared to the original audio.
 		</member>
 		<member name="voice/1/depth_ms" type="float" setter="set_voice_depth_ms" getter="get_voice_depth_ms" default="2.0">
-			The voice filter's depth.
+			The depth of the voice's low-frequency oscillator in milliseconds.
 		</member>
 		<member name="voice/1/level_db" type="float" setter="set_voice_level_db" getter="get_voice_level_db" default="0.0">
-			The voice's volume.
+			The gain of the voice in dB.
 		</member>
 		<member name="voice/1/pan" type="float" setter="set_voice_pan" getter="get_voice_pan" default="-0.5">
-			The voice's pan level.
+			The pan position of the voice.
 		</member>
 		<member name="voice/1/rate_hz" type="float" setter="set_voice_rate_hz" getter="get_voice_rate_hz" default="0.8">
-			The voice's filter rate.
+			The rate of the voice's low-frequency oscillator in Hz.
 		</member>
 		<member name="voice/2/cutoff_hz" type="float" setter="set_voice_cutoff_hz" getter="get_voice_cutoff_hz" default="8000.0">
-			The voice's cutoff frequency.
+			The frequency threshold of the voice's low-pass filter in Hz.
 		</member>
 		<member name="voice/2/delay_ms" type="float" setter="set_voice_delay_ms" getter="get_voice_delay_ms" default="20.0">
-			The voice's signal delay.
+			The delay of the voice in milliseconds, compared to the original audio.
 		</member>
 		<member name="voice/2/depth_ms" type="float" setter="set_voice_depth_ms" getter="get_voice_depth_ms" default="3.0">
-			The voice filter's depth.
+			The depth of the voice's low-frequency oscillator in milliseconds.
 		</member>
 		<member name="voice/2/level_db" type="float" setter="set_voice_level_db" getter="get_voice_level_db" default="0.0">
-			The voice's volume.
+			The gain of the voice in dB.
 		</member>
 		<member name="voice/2/pan" type="float" setter="set_voice_pan" getter="get_voice_pan" default="0.5">
-			The voice's pan level.
+			The pan position of the voice.
 		</member>
 		<member name="voice/2/rate_hz" type="float" setter="set_voice_rate_hz" getter="get_voice_rate_hz" default="1.2">
-			The voice's filter rate.
+			The rate of the voice's low-frequency oscillator in Hz.
 		</member>
 		<member name="voice/3/cutoff_hz" type="float" setter="set_voice_cutoff_hz" getter="get_voice_cutoff_hz">
-			The voice's cutoff frequency.
+			The frequency threshold of the voice's low-pass filter in Hz.
 		</member>
 		<member name="voice/3/delay_ms" type="float" setter="set_voice_delay_ms" getter="get_voice_delay_ms">
-			The voice's signal delay.
+			The delay of the voice in milliseconds, compared to the original audio.
 		</member>
 		<member name="voice/3/depth_ms" type="float" setter="set_voice_depth_ms" getter="get_voice_depth_ms">
-			The voice filter's depth.
+			The depth of the voice's low-frequency oscillator in milliseconds.
 		</member>
 		<member name="voice/3/level_db" type="float" setter="set_voice_level_db" getter="get_voice_level_db">
-			The voice's volume.
+			The gain of the voice in dB.
 		</member>
 		<member name="voice/3/pan" type="float" setter="set_voice_pan" getter="get_voice_pan">
-			The voice's pan level.
+			The pan position of the voice.
 		</member>
 		<member name="voice/3/rate_hz" type="float" setter="set_voice_rate_hz" getter="get_voice_rate_hz">
-			The voice's filter rate.
+			The rate of the voice's low-frequency oscillator in Hz.
 		</member>
 		<member name="voice/4/cutoff_hz" type="float" setter="set_voice_cutoff_hz" getter="get_voice_cutoff_hz">
-			The voice's cutoff frequency.
+			The frequency threshold of the voice's low-pass filter in Hz.
 		</member>
 		<member name="voice/4/delay_ms" type="float" setter="set_voice_delay_ms" getter="get_voice_delay_ms">
-			The voice's signal delay.
+			The delay of the voice in milliseconds, compared to the original audio.
 		</member>
 		<member name="voice/4/depth_ms" type="float" setter="set_voice_depth_ms" getter="get_voice_depth_ms">
-			The voice filter's depth.
+			The depth of the voice's low-frequency oscillator in milliseconds.
 		</member>
 		<member name="voice/4/level_db" type="float" setter="set_voice_level_db" getter="get_voice_level_db">
-			The voice's volume.
+			The gain of the voice in dB.
 		</member>
 		<member name="voice/4/pan" type="float" setter="set_voice_pan" getter="get_voice_pan">
-			The voice's pan level.
+			The pan position of the voice.
 		</member>
 		<member name="voice/4/rate_hz" type="float" setter="set_voice_rate_hz" getter="get_voice_rate_hz">
-			The voice's filter rate.
+			The rate of the voice's low-frequency oscillator in Hz.
 		</member>
 		<member name="voice_count" type="int" setter="set_voice_count" getter="get_voice_count" default="2">
-			The number of voices in the effect.
+			The number of voices in the effect. Value can range from 1 to 4.
 		</member>
 		<member name="wet" type="float" setter="set_wet" getter="get_wet" default="0.5">
-			The effect's processed signal.
+			The volume ratio of all voices. Value can range from 0 to 1.
 		</member>
 	</members>
 </class>

--- a/doc/classes/AudioEffectCompressor.xml
+++ b/doc/classes/AudioEffectCompressor.xml
@@ -1,41 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectCompressor" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a compressor audio effect to an audio bus.
-		Reduces sounds that exceed a certain threshold level, smooths out the dynamics and increases the overall volume.
+		Adds a downward compressor audio effect to an audio bus.
+		Allows control of the dynamic range via a volume threshold and timing controls.
 	</brief_description>
 	<description>
-		Dynamic range compressor reduces the level of the sound when the amplitude goes over a certain threshold in Decibels. One of the main uses of a compressor is to increase the dynamic range by clipping as little as possible (when sound goes over 0dB).
-		Compressor has many uses in the mix:
-		- In the Master bus to compress the whole output (although an [AudioEffectHardLimiter] is probably better).
-		- In voice channels to ensure they sound as balanced as possible.
-		- Sidechained. This can reduce the sound level sidechained with another audio bus for threshold detection. This technique is common in video game mixing to the level of music and SFX while voices are being heard.
-		- Accentuates transients by using a wider attack, making effects sound more punchy.
+		A "compressor" decreases the volume of sounds when it exceeds a certain volume threshold level.
+		A compressor can have many uses in a mix:
+		- To compress the whole volume in the Master bus (although an [AudioEffectHardLimiter] is probably better).
+		- To ensure balance of voice audio clips.
+		- To sidechain, using another bus as a trigger. This decreases the volume of the bus it is attached to, by using the volume from another audio bus for threshold detection. This technique is common in video game mixing to decrease the volume of music and SFX while voices are being heard. This effect is also known as "ducking".
+		- To accentuate transients by using a long attack, letting sounds exceed the volume threshold level for a short period before compressing them. This can be used to make SFX more punchy.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 	<members>
 		<member name="attack_us" type="float" setter="set_attack_us" getter="get_attack_us" default="20.0">
-			Compressor's reaction time when the signal exceeds the threshold, in microseconds. Value can range from 20 to 2000.
+			Compressor's reaction time when the audio exceeds the volume threshold level, in microseconds. Value can range from 20 to 2000.
 		</member>
 		<member name="gain" type="float" setter="set_gain" getter="get_gain" default="0.0">
-			Gain applied to the output signal.
+			Gain of the audio signal, in dB. Value can range from -20 to 20.
 		</member>
 		<member name="mix" type="float" setter="set_mix" getter="get_mix" default="1.0">
-			Balance between original signal and effect signal. Value can range from 0 (totally dry) to 1 (totally wet).
+			Balance between the original audio and the compressed audio. Value can range from 0 (totally dry) to 1 (totally wet).
 		</member>
 		<member name="ratio" type="float" setter="set_ratio" getter="get_ratio" default="4.0">
-			Amount of compression applied to the audio once it passes the threshold level. The higher the ratio, the more the loud parts of the audio will be compressed. Value can range from 1 to 48.
+			Amount of compression applied to the audio once it passes the volume threshold level. The higher the ratio, the stronger the compression applied to audio signals that pass the volume threshold level. Value can range from 1 to 48.
 		</member>
 		<member name="release_ms" type="float" setter="set_release_ms" getter="get_release_ms" default="250.0">
-			Compressor's delay time to stop reducing the signal after the signal level falls below the threshold, in milliseconds. Value can range from 20 to 2000.
+			Compressor's delay time to stop decreasing the volume after the it falls below the volume threshold level, in milliseconds. Value can range from 20 to 2000.
 		</member>
 		<member name="sidechain" type="StringName" setter="set_sidechain" getter="get_sidechain" default="&amp;&quot;&quot;">
-			Reduce the sound level using another audio bus for threshold detection.
+			Audio bus to use for the volume threshold detection.
 		</member>
 		<member name="threshold" type="float" setter="set_threshold" getter="get_threshold" default="0.0">
-			The level above which compression is applied to the audio. Value can range from -60 to 0.
+			The volume level above which compression is applied to the audio, in dB. Value can range from -60 to 0.
 		</member>
 	</members>
 </class>

--- a/doc/classes/AudioEffectDelay.xml
+++ b/doc/classes/AudioEffectDelay.xml
@@ -1,54 +1,56 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectDelay" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a delay audio effect to an audio bus. Plays input signal back after a period of time.
-		Two tap delay and feedback options.
+		Adds a delay audio effect to an audio bus.
+		Emulates an echo by playing the input audio back after a period of time.
 	</brief_description>
 	<description>
-		Plays input signal back after a period of time. The delayed signal may be played back multiple times to create the sound of a repeating, decaying echo. Delay effects range from a subtle echo effect to a pronounced blending of previous sounds with new sounds.
+		A "delay" effect plays the input audio signal back after a period of time. Each repetition is called a "delay tap" or simply "tap". Delay taps may be played back multiple times to create the sound of a repeating, decaying echo. Delay effects range from a subtle echo to a pronounced blending of previous sounds with new sounds.
+		See also [AudioEffectReverb] for a blurry, continuous echo.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 	<members>
 		<member name="dry" type="float" setter="set_dry" getter="get_dry" default="1.0">
-			Output percent of original sound. At 0, only delayed sounds are output. Value can range from 0 to 1.
+			The volume ratio of the original audio. Value can range from 0 to 1.
 		</member>
 		<member name="feedback_active" type="bool" setter="set_feedback_active" getter="is_feedback_active" default="false">
-			If [code]true[/code], feedback is enabled.
+			If [code]true[/code], feedback is enabled, repeating taps after they are played.
 		</member>
 		<member name="feedback_delay_ms" type="float" setter="set_feedback_delay_ms" getter="get_feedback_delay_ms" default="340.0">
-			Feedback delay time in milliseconds.
+			Feedback delay time in milliseconds. Value can range from 0 to 1500.
 		</member>
 		<member name="feedback_level_db" type="float" setter="set_feedback_level_db" getter="get_feedback_level_db" default="-6.0">
-			Sound level for feedback.
+			Gain for feedback, in dB. Value can range from -60 to 0.
 		</member>
 		<member name="feedback_lowpass" type="float" setter="set_feedback_lowpass" getter="get_feedback_lowpass" default="16000.0">
-			Low-pass filter for feedback, in Hz. Frequencies below this value are filtered out of the source signal.
+			Low-pass filter for feedback, in Hz. Frequencies above this value are filtered out. Value can range from 1 to 16000.
 		</member>
 		<member name="tap1_active" type="bool" setter="set_tap1_active" getter="is_tap1_active" default="true">
 			If [code]true[/code], the first tap will be enabled.
 		</member>
 		<member name="tap1_delay_ms" type="float" setter="set_tap1_delay_ms" getter="get_tap1_delay_ms" default="250.0">
-			First tap delay time in milliseconds.
+			First tap delay time in milliseconds, compared to the original audio. Value can range from 0 to 1500.
 		</member>
 		<member name="tap1_level_db" type="float" setter="set_tap1_level_db" getter="get_tap1_level_db" default="-6.0">
-			Sound level for the first tap.
+			Gain for the first tap, in dB. Value can range from -60 to 0.
 		</member>
 		<member name="tap1_pan" type="float" setter="set_tap1_pan" getter="get_tap1_pan" default="0.2">
-			Pan position for the first tap. Value can range from -1 (fully left) to 1 (fully right).
+			Pan position for the first tap. Negative values pan the sound to the left, positive pan to the right. Value can range from -1 to 1.
 		</member>
 		<member name="tap2_active" type="bool" setter="set_tap2_active" getter="is_tap2_active" default="true">
 			If [code]true[/code], the second tap will be enabled.
 		</member>
 		<member name="tap2_delay_ms" type="float" setter="set_tap2_delay_ms" getter="get_tap2_delay_ms" default="500.0">
-			Second tap delay time in milliseconds.
+			Second tap delay time in milliseconds, compared to the original audio. Value can range from 0 to 1500.
 		</member>
 		<member name="tap2_level_db" type="float" setter="set_tap2_level_db" getter="get_tap2_level_db" default="-12.0">
-			Sound level for the second tap.
+			Gain for the second tap, in dB. Value can range from -60 to 0.
 		</member>
 		<member name="tap2_pan" type="float" setter="set_tap2_pan" getter="get_tap2_pan" default="-0.4">
-			Pan position for the second tap. Value can range from -1 (fully left) to 1 (fully right).
+			Pan position for the second tap. Negative values pan the sound to the left, positive pan to the right. Value can range from -1 to 1.
 		</member>
 	</members>
 </class>

--- a/doc/classes/AudioEffectDistortion.xml
+++ b/doc/classes/AudioEffectDistortion.xml
@@ -1,47 +1,53 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectDistortion" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a distortion audio effect to an Audio bus.
-		Modifies the sound to make it distorted.
+		Adds a distortion audio effect to an audio bus.
+		Remaps audio samples using a nonlinear function to achieve a distorted sound.
 	</brief_description>
 	<description>
-		Different types are available: clip, tan, lo-fi (bit crushing), overdrive, or waveshape.
-		By distorting the waveform the frequency content changes, which will often make the sound "crunchy" or "abrasive". For games, it can simulate sound coming from some saturated device or speaker very efficiently.
+		A "distortion" effect modifies the waveform via a nonlinear mathematical function (see available ones in [enum Mode]), based on the amplitude of the waveform's samples.
+		[b]Note:[/b] In a nonlinear function, an input sample at [i]x[/i] amplitude value, will either have its amplitude increased or decreased to a [i]y[/i] value, based on the function value at [i]x[/i], which is why even at the same [member drive], the output sound will vary depending on the input's volume. To change the volume while maintaining the output waveform, use [member post_gain].
+		In this effect, each type is a different nonlinear function. The different types available are: clip, atan, lofi (bitcrush), overdrive, and waveshape. Every distortion type available here is symmetric: negative amplitude values are affected the same way as positive ones.
+		Although distortion will always change frequency content, usually by introducing high harmonics, different distortion types offer a range of sound qualities; from "soft" and "warm", to "crunchy" and "abrasive".
+		For games, it can help simulate sound coming from some saturated device or speaker very efficiently. It can also help the audio stand out in a mix, by introducing higher frequencies and increasing the volume.
+		[b]Note:[/b] Although usually imperceptible, an enabled distortion effect still changes the sound even when [member drive] is set to 0. This is not a bug. If this behavior is undesirable, consider disabling the effect using [method AudioServer.set_bus_effect_enabled].
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 	<members>
 		<member name="drive" type="float" setter="set_drive" getter="get_drive" default="0.0">
-			Distortion power. Value can range from 0 to 1.
+			Distortion intensity. Controls how much of the input audio is affected by the distortion curve by moving from a linear function to a nonlinear one. Value can range from 0 to 1.
 		</member>
 		<member name="keep_hf_hz" type="float" setter="set_keep_hf_hz" getter="get_keep_hf_hz" default="16000.0">
 			High-pass filter, in Hz. Frequencies higher than this value will not be affected by the distortion. Value can range from 1 to 20000.
 		</member>
 		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="AudioEffectDistortion.Mode" default="0">
-			Distortion type.
+			Distortion type. Changes the nonlinear function used to distort the waveform. See [enum Mode].
 		</member>
 		<member name="post_gain" type="float" setter="set_post_gain" getter="get_post_gain" default="0.0">
-			Increases or decreases the volume after the effect, in decibels. Value can range from -80 to 24.
+			Gain after the effect, in dB. Value can range from -80 to 24.
 		</member>
 		<member name="pre_gain" type="float" setter="set_pre_gain" getter="get_pre_gain" default="0.0">
-			Increases or decreases the volume before the effect, in decibels. Value can range from -60 to 60.
+			Gain before the effect, in dB. Value can range from -60 to 60.
 		</member>
 	</members>
 	<constants>
 		<constant name="MODE_CLIP" value="0" enum="Mode">
-			Digital distortion effect which cuts off peaks at the top and bottom of the waveform.
+			Flattens the waveform at 0 dB in a sharp manner. [member drive] increases amplitude of samples exponentially. This mode functions as a hard clipper if [member drive] is set to 0, and is the only mode that clips audio signals at 0 dB.
 		</constant>
 		<constant name="MODE_ATAN" value="1" enum="Mode">
+			Flattens the waveform in a smooth manner, following an arctangent curve. The audio decreases in volume, before flattening peaks to [code]PI * 4.0[/code] (linear value), if it was normalized beforehand.
 		</constant>
 		<constant name="MODE_LOFI" value="2" enum="Mode">
-			Low-resolution digital distortion effect (bit depth reduction). You can use it to emulate the sound of early digital audio devices.
+			Decreases audio bit depth to achieve a low-resolution audio signal, going from 16-bit to 2-bit. Can be used to emulate the sound of early digital audio devices.
 		</constant>
 		<constant name="MODE_OVERDRIVE" value="3" enum="Mode">
-			Emulates the warm distortion produced by a field effect transistor, which is commonly used in solid-state musical instrument amplifiers. The [member drive] property has no effect in this mode.
+			Emulates the warm distortion produced by a field effect transistor, which is commonly used in solid-state musical instrument amplifiers. [member drive] has no effect in this mode.
 		</constant>
 		<constant name="MODE_WAVESHAPE" value="4" enum="Mode">
-			Waveshaper distortions are used mainly by electronic musicians to achieve an extra-abrasive sound.
+			Flattens the waveform in a smooth manner, until it reaches a sharp peak at [code]drive = 1[/code], following a generic absolute sigmoid function.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/AudioEffectEQ.xml
+++ b/doc/classes/AudioEffectEQ.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectEQ" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Base class for audio equalizers. Gives you control over frequencies.
-		Use it to create a custom equalizer if [AudioEffectEQ6], [AudioEffectEQ10] or [AudioEffectEQ21] don't fit your needs.
+		Base class for audio equalizers (EQ). Gives you control over frequencies.
+		Use it to create a custom equalizer if [AudioEffectEQ6], [AudioEffectEQ10], or [AudioEffectEQ21] don't fit your needs.
 	</brief_description>
 	<description>
-		AudioEffectEQ gives you control over frequencies. Use it to compensate for existing deficiencies in audio. AudioEffectEQs are useful on the Master bus to completely master a mix and give it more character. They are also useful when a game is run on a mobile device, to adjust the mix to that kind of speakers (it can be added but disabled when headphones are plugged).
+		An "equalizer" gives you control over the gain of frequencies in the entire spectrum, by allowing their adjustment through bands. A band is a point in the frequency spectrum, and each band means a division of the spectrum that can be adjusted.
+		Use equalizers to compensate for existing deficiencies in the audio, make room for other elements, or remove undesirable frequencies. AudioEffectEQs are useful on the Master bus to balance the entire mix or give it more character. They are also useful when a game is run on a mobile device, to adjust the mix to that kind of speakers (it can be disabled when headphones are plugged in).
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_band_count" qualifiers="const">

--- a/doc/classes/AudioEffectEQ10.xml
+++ b/doc/classes/AudioEffectEQ10.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectEQ10" inherits="AudioEffectEQ" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a 10-band equalizer audio effect to an Audio bus. Gives you control over frequencies from 31 Hz to 16000 Hz.
-		Each frequency can be modulated between -60/+24 dB.
+		Adds a 10-band equalizer audio effect to an audio bus.
+		Gives you control over frequencies from 31 Hz to 16000 Hz. Each frequency can be modulated between -60/+24 dB.
 	</brief_description>
 	<description>
 		Frequency bands:
@@ -20,5 +20,6 @@
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectEQ21.xml
+++ b/doc/classes/AudioEffectEQ21.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectEQ21" inherits="AudioEffectEQ" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a 21-band equalizer audio effect to an Audio bus. Gives you control over frequencies from 22 Hz to 22000 Hz.
-		Each frequency can be modulated between -60/+24 dB.
+		Adds a 21-band equalizer audio effect to an audio bus.
+		Gives you control over frequencies from 22 Hz to 22000 Hz. Each frequency can be modulated between -60/+24 dB.
 	</brief_description>
 	<description>
 		Frequency bands:
@@ -31,5 +31,6 @@
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectEQ6.xml
+++ b/doc/classes/AudioEffectEQ6.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectEQ6" inherits="AudioEffectEQ" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a 6-band equalizer audio effect to an audio bus. Gives you control over frequencies from 32 Hz to 10000 Hz.
-		Each frequency can be modulated between -60/+24 dB.
+		Adds a 6-band equalizer audio effect to an audio bus.
+		Gives you control over frequencies from 32 Hz to 10000 Hz. Each frequency can be modulated between -60/+24 dB.
 	</brief_description>
 	<description>
 		Frequency bands:
@@ -16,5 +16,6 @@
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectFilter.xml
+++ b/doc/classes/AudioEffectFilter.xml
@@ -1,40 +1,49 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectFilter" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a filter to the audio bus.
+		Base class for filters. Use effects that inherit this class instead of using it directly.
 	</brief_description>
 	<description>
-		Allows frequencies other than the [member cutoff_hz] to pass.
+		A "filter" controls the gain of frequencies, using [member cutoff_hz] as a frequency threshold. Filters can help to give room for each sound, and create interesting effects.
+		There are different types of filter that inherit this class:
+		Shelf filters: [AudioEffectLowShelfFilter] and [AudioEffectHighShelfFilter]
+		Band-pass and notch filters: [AudioEffectBandPassFilter], [AudioEffectBandLimitFilter], and [AudioEffectNotchFilter]
+		Low/high-pass filters: [AudioEffectLowPassFilter] and [AudioEffectHighPassFilter]
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 	<members>
 		<member name="cutoff_hz" type="float" setter="set_cutoff" getter="get_cutoff" default="2000.0">
-			Threshold frequency for the filter, in Hz.
+			Frequency threshold for the filter, in Hz. Value can range from 1 to 20500.
 		</member>
 		<member name="db" type="int" setter="set_db" getter="get_db" enum="AudioEffectFilter.FilterDB" default="0">
-			Steepness of the cutoff curve in dB per octave, also known as the order of the filter. Higher orders have a more aggressive cutoff.
+			Steepness of the cutoff curve in dB per octave (twice the frequency above [member cutoff_hz], or half the frequency below [member cutoff_hz]), also known as the "order" of the filter. Higher orders have a more aggressive cutoff.
 		</member>
 		<member name="gain" type="float" setter="set_gain" getter="get_gain" default="1.0">
-			Gain amount of the frequencies after the filter.
+			Gain of the frequencies affected by the filter. This property is only available for [AudioEffectLowShelfFilter] and [AudioEffectHighShelfFilter]. Value can range from 0 to 4.
 		</member>
 		<member name="resonance" type="float" setter="set_resonance" getter="get_resonance" default="0.5">
-			Amount of boost in the frequency range near the cutoff frequency.
+			Gain at or directly next to the [member cutoff_hz] frequency threshold. Value can range from 0 to 1.
+			Its exact behavior depends on the selected filter type:
+			- For shelf filters, it accentuates or masks the order by increasing frequencies right next to the [member cutoff_hz] frequency and decreasing frequencies on the opposite side.
+			- For the band-pass and notch filters, it widens or narrows the filter at the [member cutoff_hz] frequency threshold.
+			- For low/high-pass filters, it increases or decreases frequencies at the [member cutoff_hz] frequency threshold.
 		</member>
 	</members>
 	<constants>
 		<constant name="FILTER_6DB" value="0" enum="FilterDB">
-			Cutting off at 6dB per octave.
+			Cutting off at 6 dB per octave. One octave is twice the frequency above [member cutoff_hz], or half the frequency below [member cutoff_hz].
 		</constant>
 		<constant name="FILTER_12DB" value="1" enum="FilterDB">
-			Cutting off at 12dB per octave.
+			Cutting off at 12 dB per octave. One octave is twice the frequency above [member cutoff_hz], or half the frequency below [member cutoff_hz].
 		</constant>
 		<constant name="FILTER_18DB" value="2" enum="FilterDB">
-			Cutting off at 18dB per octave.
+			Cutting off at 18 dB per octave. One octave is twice the frequency above [member cutoff_hz], or half the frequency below [member cutoff_hz].
 		</constant>
 		<constant name="FILTER_24DB" value="3" enum="FilterDB">
-			Cutting off at 24dB per octave.
+			Cutting off at 24 dB per octave. One octave is twice the frequency above [member cutoff_hz], or half the frequency below [member cutoff_hz].
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/AudioEffectHardLimiter.xml
+++ b/doc/classes/AudioEffectHardLimiter.xml
@@ -1,24 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectHardLimiter" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a hard limiter audio effect to an Audio bus.
+		Adds a limiter audio effect to an audio bus.
+		Prevents audio signals from exceeding a specified volume level.
 	</brief_description>
 	<description>
-		A limiter is an effect designed to disallow sound from going over a given dB threshold. Hard limiters predict volume peaks, and will smoothly apply gain reduction when a peak crosses the ceiling threshold to prevent clipping and distortion. It preserves the waveform and prevents it from crossing the ceiling threshold. Adding one in the Master bus is recommended as a safety measure to prevent sudden volume peaks from occurring, and to prevent distortion caused by clipping.
+		A "limiter" disallows audio signals from exceeding a given volume threshold level in dB. Hard limiters predict volume peaks, and will smoothly apply gain reduction when a peak crosses the ceiling threshold level to prevent clipping. It preserves the waveform and prevents it from crossing the ceiling threshold level. Adding one in the Master bus is recommended as a safety measure to prevent sudden volume peaks from occurring, and to prevent distortion caused by clipping, when the volume exceeds 0 dB.
+		If clipping is desired, consider [constant AudioEffectDistortion.MODE_CLIP].
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 	<members>
 		<member name="ceiling_db" type="float" setter="set_ceiling_db" getter="get_ceiling_db" default="-0.3">
-			The waveform's maximum allowed value, in decibels. This value can range from [code]-24.0[/code] to [code]0.0[/code].
-			The default value of [code]-0.3[/code] prevents potential inter-sample peaks (ISP) from crossing over 0 dB, which can cause slight distortion on some older hardware.
+			The waveform's maximum allowed value, in dB. This value can range from -24 to 0.
+			The default value of -0.3 prevents potential inter-sample peaks (ISP) from crossing over 0 dB, which can cause slight distortion on some older hardware.
 		</member>
 		<member name="pre_gain_db" type="float" setter="set_pre_gain_db" getter="get_pre_gain_db" default="0.0">
-			Gain to apply before limiting, in decibels.
+			Gain before limiting, in dB. Value can range from -24 to 24.
 		</member>
 		<member name="release" type="float" setter="set_release" getter="get_release" default="0.1">
-			Time it takes in seconds for the gain reduction to fully release.
+			Time it takes in seconds for the gain reduction to fully release. Value can range from 0.01 to 3.
 		</member>
 	</members>
 </class>

--- a/doc/classes/AudioEffectHighPassFilter.xml
+++ b/doc/classes/AudioEffectHighPassFilter.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectHighPassFilter" inherits="AudioEffectFilter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a high-pass filter to the audio bus.
+		Adds a high-pass filter to an audio bus.
 	</brief_description>
 	<description>
-		Cuts frequencies lower than the [member AudioEffectFilter.cutoff_hz] and allows higher frequencies to pass.
+		A "high-pass" filter attenuates frequencies lower than [member AudioEffectFilter.cutoff_hz] and allows higher frequencies to pass unchanged.
+		This filter can be used to remove "strength" from a sound, and give low-end space for basses and impact sounds.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectHighShelfFilter.xml
+++ b/doc/classes/AudioEffectHighShelfFilter.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectHighShelfFilter" inherits="AudioEffectFilter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a high-shelf filter to the audio bus.
+		Adds a high-shelf filter to an audio bus.
 	</brief_description>
 	<description>
-		Reduces all frequencies above the [member AudioEffectFilter.cutoff_hz].
+		A "high-shelf" filter controls the gain of all frequencies above [member AudioEffectFilter.cutoff_hz].
+		This filter can be used to increase or decrease clarity of a sound.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectInstance.xml
+++ b/doc/classes/AudioEffectInstance.xml
@@ -8,6 +8,7 @@
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 	<methods>
 		<method name="_process" qualifiers="virtual required">

--- a/doc/classes/AudioEffectLimiter.xml
+++ b/doc/classes/AudioEffectLimiter.xml
@@ -1,26 +1,29 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectLimiter" inherits="AudioEffect" deprecated="Use [AudioEffectHardLimiter] instead." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a soft-clip limiter audio effect to an Audio bus.
+		Adds a soft-clip limiter audio effect to an audio bus.
 	</brief_description>
 	<description>
-		A limiter is similar to a compressor, but it's less flexible and designed to disallow sound going over a given dB threshold. Adding one in the Master bus is always recommended to reduce the effects of clipping.
-		Soft clipping starts to reduce the peaks a little below the threshold level and progressively increases its effect as the input level increases such that the threshold is never exceeded.
+		A "limiter" is an audio effect designed to stop audio signals from exceeding a specified volume threshold level, and usually works by decreasing the volume or soft-clipping the audio. Adding one in the Master bus is always recommended to prevent clipping when the volume goes above 0 dB.
+		Soft clipping starts to decrease the peaks a little below the volume threshold level and progressively increases its effect as the input volume increases such that the threshold level is never exceeded.
+		If hard clipping is desired, consider [constant AudioEffectDistortion.MODE_CLIP].
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 	<members>
 		<member name="ceiling_db" type="float" setter="set_ceiling_db" getter="get_ceiling_db" default="-0.1">
-			The waveform's maximum allowed value, in decibels. Value can range from -20 to -0.1.
+			The waveform's maximum allowed value, in dB. Value can range from -20 to -0.1.
 		</member>
 		<member name="soft_clip_db" type="float" setter="set_soft_clip_db" getter="get_soft_clip_db" default="2.0">
-			Applies a gain to the limited waves, in decibels. Value can range from 0 to 6.
+			Modifies the volume of the limited waves, in dB. Value can range from 0 to 6.
 		</member>
 		<member name="soft_clip_ratio" type="float" setter="set_soft_clip_ratio" getter="get_soft_clip_ratio" default="10.0">
+			This property has no effect on the audio. Use [AudioEffectHardLimiter] instead, as this Limiter effect is deprecated.
 		</member>
 		<member name="threshold_db" type="float" setter="set_threshold_db" getter="get_threshold_db" default="0.0">
-			Threshold from which the limiter begins to be active, in decibels. Value can range from -30 to 0.
+			The volume threshold level from which the limiter begins to be active, in dB. Value can range from -30 to 0.
 		</member>
 	</members>
 </class>

--- a/doc/classes/AudioEffectLowPassFilter.xml
+++ b/doc/classes/AudioEffectLowPassFilter.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectLowPassFilter" inherits="AudioEffectFilter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a low-pass filter to the audio bus.
+		Adds a low-pass filter to an audio bus.
 	</brief_description>
 	<description>
-		Cuts frequencies higher than the [member AudioEffectFilter.cutoff_hz] and allows lower frequencies to pass.
+		A "low-pass" filter attenuates frequencies higher than [member AudioEffectFilter.cutoff_hz] and allows lower frequencies to pass unchanged.
+		This filter can be used to muffle sounds.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectLowShelfFilter.xml
+++ b/doc/classes/AudioEffectLowShelfFilter.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectLowShelfFilter" inherits="AudioEffectFilter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a low-shelf filter to the audio bus.
+		Adds a low-shelf filter to an audio bus.
 	</brief_description>
 	<description>
-		Reduces all frequencies below the [member AudioEffectFilter.cutoff_hz].
+		A "low-shelf" filter controls the gain of all frequencies below [member AudioEffectFilter.cutoff_hz].
+		This filter can be used to adjust the "strength" of a sound, by increasing or decreasing its low-end.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectNotchFilter.xml
+++ b/doc/classes/AudioEffectNotchFilter.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectNotchFilter" inherits="AudioEffectFilter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a notch filter to the Audio bus.
+		Adds a notch filter to an audio bus.
 	</brief_description>
 	<description>
-		Attenuates frequencies in a narrow band around the [member AudioEffectFilter.cutoff_hz] and cuts frequencies outside of this range.
+		A "notch" filter attenuates frequencies at [member AudioEffectFilter.cutoff_hz] and allows frequencies outside the frequency threshold to pass unchanged. It is a narrower and stronger version of [AudioEffectBandLimitFilter], and is the opposite of [AudioEffectBandPassFilter].
+		This filter can be used to give more room for other sounds to play at that frequency. Because of how much it attenuates frequencies, it can also be used to completely remove undesired frequencies.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectPanner.xml
+++ b/doc/classes/AudioEffectPanner.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectPanner" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a panner audio effect to an audio bus. Pans sound left or right.
+		Adds a panner audio effect to an audio bus.
+		Pans the sound left or right.
 	</brief_description>
 	<description>
-		Determines how much of an audio signal is sent to the left and right buses.
+		Determines how much of the audio signal is sent to the left and right channels. This helps with audio spatialization, giving sounds distinct places in a mix.
+		[AudioStreamPlayer2D] and [AudioStreamPlayer3D] handle panning automatically, following where the source of the sound is on the screen.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 	<members>
 		<member name="pan" type="float" setter="set_pan" getter="get_pan" default="0.0">
-			Pan position. Value can range from -1 (fully left) to 1 (fully right).
+			Pan position. Negative values pan the sound to the left, positive pan to the right. Value can range from -1 to 1.
 		</member>
 	</members>
 </class>

--- a/doc/classes/AudioEffectPhaser.xml
+++ b/doc/classes/AudioEffectPhaser.xml
@@ -2,29 +2,31 @@
 <class name="AudioEffectPhaser" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Adds a phaser audio effect to an audio bus.
-		Combines the original signal with a copy that is slightly out of phase with the original.
+		Creates several notch and peak filters that sweep across the spectrum.
 	</brief_description>
 	<description>
-		Combines phase-shifted signals with the original signal. The movement of the phase-shifted signals is controlled using a low-frequency oscillator.
+		A "phaser" effect creates a copy of the original audio that phase-rotates differently across the entire frequency spectrum, with the use of a series of all-pass filter stages (6 in this effect). This copy modulates with a low-frequency oscillator and combines with the original audio, resulting in peaks and troughs that sweep across the spectrum.
+		This effect can be used to create a "glassy" or "bubbly" sound.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 	<members>
 		<member name="depth" type="float" setter="set_depth" getter="get_depth" default="1.0">
-			Determines how high the filter frequencies sweep. Low value will primarily affect bass frequencies. High value can sweep high into the treble. Value can range from [code]0.1[/code] to [code]4.0[/code].
+			Intensity of the effect. Value can range from 0.1 to 4.0.
 		</member>
 		<member name="feedback" type="float" setter="set_feedback" getter="get_feedback" default="0.7">
-			Output percent of modified sound. Value can range from 0.1 to 0.9.
+			The volume ratio of the filtered audio that is fed back to the all-pass filters. The higher the value, the sharper and louder the peak filters created by the effect. Value can range from 0.1 to 0.9.
 		</member>
 		<member name="range_max_hz" type="float" setter="set_range_max_hz" getter="get_range_max_hz" default="1600.0">
-			Determines the maximum frequency affected by the LFO modulations, in Hz. Value can range from 10 to 10000.
+			Determines the maximum frequency affected by the low-frequency oscillator modulations, in Hz. Value can range from 10 to 10000.
 		</member>
 		<member name="range_min_hz" type="float" setter="set_range_min_hz" getter="get_range_min_hz" default="440.0">
-			Determines the minimum frequency affected by the LFO modulations, in Hz. Value can range from 10 to 10000.
+			Determines the minimum frequency affected by the low-frequency oscillator modulations, in Hz. Value can range from 10 to 10000.
 		</member>
 		<member name="rate_hz" type="float" setter="set_rate_hz" getter="get_rate_hz" default="0.5">
-			Adjusts the rate in Hz at which the effect sweeps up and down across the frequency range.
+			Adjusts the rate in Hz at which the effect sweeps up and down across the frequency range. Value can range from 0.01 to 20.
 		</member>
 	</members>
 </class>

--- a/doc/classes/AudioEffectPitchShift.xml
+++ b/doc/classes/AudioEffectPitchShift.xml
@@ -2,23 +2,24 @@
 <class name="AudioEffectPitchShift" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Adds a pitch-shifting audio effect to an audio bus.
-		Raises or lowers the pitch of original sound.
+		Raises or lowers the pitch of the input audio.
 	</brief_description>
 	<description>
-		Allows modulation of pitch independently of tempo. All frequencies can be increased/decreased with minimal effect on transients.
+		Allows modulation of pitch without modifying speed. All frequencies can be raised or lowered with minimal effect on transients.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 	<members>
 		<member name="fft_size" type="int" setter="set_fft_size" getter="get_fft_size" enum="AudioEffectPitchShift.FFTSize" default="3">
-			The size of the [url=https://en.wikipedia.org/wiki/Fast_Fourier_transform]Fast Fourier transform[/url] buffer. Higher values smooth out the effect over time, but have greater latency. The effects of this higher latency are especially noticeable on sounds that have sudden amplitude changes.
+			The size of the [url=https://en.wikipedia.org/wiki/Fast_Fourier_transform]Fast Fourier transform[/url] buffer. Higher values smooth out the effect over time, but have greater latency. The effects of this higher latency are especially noticeable on audio signals that have sudden amplitude changes.
 		</member>
 		<member name="oversampling" type="int" setter="set_oversampling" getter="get_oversampling" default="4">
 			The oversampling factor to use. Higher values result in better quality, but are more demanding on the CPU and may cause audio cracking if the CPU can't keep up.
 		</member>
 		<member name="pitch_scale" type="float" setter="set_pitch_scale" getter="get_pitch_scale" default="1.0">
-			The pitch scale to use. [code]1.0[/code] is the default pitch and plays sounds unaffected. [member pitch_scale] can range from [code]0.0[/code] (infinitely low pitch, inaudible) to [code]16[/code] (16 times higher than the initial pitch).
+			The pitch scale to use. [code]1.0[/code] is the default pitch and plays sounds unaffected. [member pitch_scale] can range from 0 (infinitely low pitch, inaudible) to 16 (16 times higher than the initial pitch).
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/AudioEffectRecord.xml
+++ b/doc/classes/AudioEffectRecord.xml
@@ -4,7 +4,7 @@
 		Audio effect used for recording the sound from an audio bus.
 	</brief_description>
 	<description>
-		Allows the user to record the sound from an audio bus into an [AudioStreamWAV]. When used on the "Master" audio bus, this includes all audio output by Godot.
+		Allows the user to record the sound from an audio bus into an [AudioStreamWAV]. When used on the Master audio bus, this includes all audio output by Godot.
 		Unlike [AudioEffectCapture], this effect encodes the recording with the given format (8-bit, 16-bit, or compressed) instead of giving access to the raw audio samples.
 		Can be used (with an [AudioStreamMicrophone]) to record from a microphone.
 		[b]Note:[/b] [member ProjectSettings.audio/driver/enable_input] must be [code]true[/code] for audio input to work. See also that setting's description for caveats related to permissions and operating system privacy settings.

--- a/doc/classes/AudioEffectReverb.xml
+++ b/doc/classes/AudioEffectReverb.xml
@@ -1,39 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectReverb" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a reverberation audio effect to an Audio bus.
+		Adds a reverberation audio effect to an audio bus.
+		Emulates an echo by playing a blurred version of the input audio.
 	</brief_description>
 	<description>
-		Simulates the sound of acoustic environments such as rooms, concert halls, caverns, or an open spaces.
+		A "reverb" effect plays the input audio back continuously, decaying over a period of time. It simulates sounds in different kinds of spaces, ranging from small rooms, to big caverns.
+		See also [AudioEffectDelay] for a non-blurry type of echo.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 		<link title="Third Person Shooter (TPS) Demo">https://godotengine.org/asset-library/asset/2710</link>
 	</tutorials>
 	<members>
 		<member name="damping" type="float" setter="set_damping" getter="get_damping" default="0.5">
-			Defines how reflective the imaginary room's walls are. Value can range from 0 to 1.
+			Defines how reflective the imaginary room's walls are. The more reflective, the more high frequency content the reverb has. Value can range from 0 to 1.
 		</member>
 		<member name="dry" type="float" setter="set_dry" getter="get_dry" default="1.0">
-			Output percent of original sound. At 0, only modified sound is outputted. Value can range from 0 to 1.
+			The volume ratio of the original audio. At 0, only the modified audio is outputted. Value can range from 0 to 1.
 		</member>
 		<member name="hipass" type="float" setter="set_hpf" getter="get_hpf" default="0.0">
-			High-pass filter passes signals with a frequency higher than a certain cutoff frequency and attenuates signals with frequencies lower than the cutoff frequency. Value can range from 0 to 1.
+			High-pass filter allows frequencies higher than a certain cutoff threshold and attenuates frequencies lower than the cutoff threshold. Value can range from 0 to 1.
 		</member>
 		<member name="predelay_feedback" type="float" setter="set_predelay_feedback" getter="get_predelay_feedback" default="0.4">
-			Output percent of predelay. Value can range from 0 to 1.
+			Gain of early reflection copies. At higher values, early reflection copies are louder and ring out for longer. Value can range from 0 to 1.
 		</member>
 		<member name="predelay_msec" type="float" setter="set_predelay_msec" getter="get_predelay_msec" default="150.0">
-			Time between the original signal and the early reflections of the reverb signal, in milliseconds.
+			Time between the original audio and the early reflections of the reverb signal, in milliseconds. Value can range from 20 to 500.
 		</member>
 		<member name="room_size" type="float" setter="set_room_size" getter="get_room_size" default="0.8">
 			Dimensions of simulated room. Bigger means more echoes. Value can range from 0 to 1.
 		</member>
 		<member name="spread" type="float" setter="set_spread" getter="get_spread" default="1.0">
-			Widens or narrows the stereo image of the reverb tail. 1 means fully widens. Value can range from 0 to 1.
+			Widens or narrows the stereo image of the reverb tail. At 1, it fully widens. Value can range from 0 to 1.
 		</member>
 		<member name="wet" type="float" setter="set_wet" getter="get_wet" default="0.5">
-			Output percent of modified sound. At 0, only original sound is outputted. Value can range from 0 to 1.
+			The volume ratio of the modified audio. At 0, only the original audio is outputted. Value can range from 0 to 1.
 		</member>
 	</members>
 </class>

--- a/doc/classes/AudioEffectSpectrumAnalyzer.xml
+++ b/doc/classes/AudioEffectSpectrumAnalyzer.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectSpectrumAnalyzer" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Audio effect that can be used for real-time audio visualizations.
+		Creates an [AudioEffectInstance] which performs frequency analysis and exposes results to be accessed in real-time.
 	</brief_description>
 	<description>
-		This audio effect does not affect sound output, but can be used for real-time audio visualizations.
-		This resource configures an [AudioEffectSpectrumAnalyzerInstance], which performs the actual analysis at runtime. An instance can be obtained with [method AudioServer.get_bus_effect_instance].
-		See also [AudioStreamGenerator] for procedurally generating sounds.
+		Calculates a Fourier Transform of the audio signal. This effect does not alter the audio. Can be used for creating real-time audio visualizations, like a spectrogram.
+		This resource configures an [AudioEffectSpectrumAnalyzerInstance], which performs the actual analysis at runtime. An instance should be obtained with [method AudioServer.get_bus_effect_instance] to make use of this effect.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 		<link title="Audio Spectrum Visualizer Demo">https://godotengine.org/asset-library/asset/2762</link>
 	</tutorials>
 	<members>
 		<member name="buffer_length" type="float" setter="set_buffer_length" getter="get_buffer_length" default="2.0">
-			The length of the buffer to keep (in seconds). Higher values keep data around for longer, but require more memory.
+			The length of the buffer to keep, in seconds. Higher values keep data around for longer, but require more memory. Value can range from 0.1 to 4.
 		</member>
 		<member name="fft_size" type="int" setter="set_fft_size" getter="get_fft_size" enum="AudioEffectSpectrumAnalyzer.FFTSize" default="2">
 			The size of the [url=https://en.wikipedia.org/wiki/Fast_Fourier_transform]Fast Fourier transform[/url] buffer. Higher values smooth out the spectrum analysis over time, but have greater latency. The effects of this higher latency are especially noticeable with sudden amplitude changes.

--- a/doc/classes/AudioEffectSpectrumAnalyzerInstance.xml
+++ b/doc/classes/AudioEffectSpectrumAnalyzerInstance.xml
@@ -8,6 +8,8 @@
 		An instance of this class can be obtained with [method AudioServer.get_bus_effect_instance].
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 		<link title="Audio Spectrum Visualizer Demo">https://godotengine.org/asset-library/asset/2762</link>
 	</tutorials>
 	<methods>

--- a/doc/classes/AudioEffectStereoEnhance.xml
+++ b/doc/classes/AudioEffectStereoEnhance.xml
@@ -1,23 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectStereoEnhance" inherits="AudioEffect" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		An audio effect that can be used to adjust the intensity of stereo panning.
+		Adds a stereo manipulation audio effect to an audio bus.
+		Controls gain of the side channels, and widens the stereo image.
 	</brief_description>
 	<description>
-		An audio effect that can be used to adjust the intensity of stereo panning.
+		Adjusts gain of the left and right channels, and makes mono sounds stereo through phase shifting.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
 	</tutorials>
 	<members>
 		<member name="pan_pullout" type="float" setter="set_pan_pullout" getter="get_pan_pullout" default="1.0">
-			Amplifies the difference between stereo channels, increasing or decreasing existing panning. A value of 0.0 will downmix stereo to mono. Does not affect a mono signal.
+			Gain of the side channels, if they exist. A value of 0 will downmix stereo to mono. Value can range from 0 to 4.
 		</member>
 		<member name="surround" type="float" setter="set_surround" getter="get_surround" default="0.0">
-			Widens sound stage through phase shifting in conjunction with [member time_pullout_ms]. Just pans sound to the left channel if [member time_pullout_ms] is 0.
+			Widens the stereo image through phase shifting in conjunction with [member time_pullout_ms]. Just pans sound to the left channel if [member time_pullout_ms] is 0. Value can range from 0 to 1.
 		</member>
 		<member name="time_pullout_ms" type="float" setter="set_time_pullout" getter="get_time_pullout" default="0.0">
-			Widens sound stage through phase shifting in conjunction with [member surround]. Just delays the right channel if [member surround] is 0.
+			Widens the stereo image through phase shifting in conjunction with [member surround]. Just delays the right channel if [member surround] is 0. Value is in milliseconds, and can range from 0 to 50.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
Making improvements to several class reference files for AudioEffects. Mostly adding missing info and changing wording, but also describing some effects in more depth, while not making it too verbose, so that it could be helpful to someone who's not familiar with them, and let people experienced with audio know their tools in detail.

Here's what I did:

- [x] Added missing info to `AudioEffectDistortion`
- [x] Added missing info to `AudioEffectLimiter`
- [x] Added missing info to `AudioEffectChorus`
- [x] Polish other audio effects (explanations, fixing mistakes, etc.)

There are some weird things about some effects, but I documented them as they exist.

I'm very interested about audio and I know a couple of things. Unfortunately, I see that this area of the engine is really lacking, so I'm doing my best to improve it. There were some things that lacked descriptions or were not explained properly; the user is left to guess how things work, or searching a lot outside of the engine.

Challenges:
I am an experienced music producer, not an audio developer. As stated, I don't have much idea how these things work in code. I did my best to understand by researching online, reading Godot's code, and running tests.
I'm also not a technical writer, and English isn't my first language. While I'm confident in day-to-day communication, writing easy-to-understand documentation is not my strong suit. I did my best to follow the guidelines.