### PR TITLE
TextEdit: Ensure caret is visible after paste

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7974,6 +7974,10 @@ void TextEdit::_paste_internal(int p_caret) {
 	// Paste a full line. Ignore '\r' characters that may have been added to the clipboard by the OS.
 	if (get_caret_count() == 1 && !has_selection(0) && !cut_copy_line.is_empty() && cut_copy_line == clipboard.remove_char('\r')) {
 		insert_text(clipboard, get_caret_line(), 0);
+
+		_update_scrollbars();
+		adjust_viewport_to_caret(0);
+
 		return;
 	}
 


### PR DESCRIPTION
Ensure the viewport scrolls correctly after paste so the caret remains visible.

Repro: In the script editor, paste repeatedly near the end of the file and the caret can move out of view.

The adjustment is deferred to make sure scrollbars and layout are updated before repositioning the viewport.

Fixes #115956.
