### PR TITLE
Fix `MaterialStorage::material_set_shader` race condition.

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -2162,6 +2162,7 @@ RID MaterialStorage::shader_allocate() {
 
 void MaterialStorage::shader_initialize(RID p_rid, bool p_embedded) {
 	Shader shader;
+	shader.mutex = memnew(Mutex);
 	shader.data = nullptr;
 	shader.type = SHADER_TYPE_MAX;
 	shader.embedded = p_embedded;
@@ -2179,14 +2180,18 @@ void MaterialStorage::shader_free(RID p_rid) {
 	Shader *shader = shader_owner.get_or_null(p_rid);
 	ERR_FAIL_NULL(shader);
 
-	//make material unreference this
-	while (shader->owners.size()) {
-		material_set_shader((*shader->owners.begin())->self, RID());
-	}
+	{
+		MutexLock lock(*shader->mutex);
 
-	//clear data if exists
-	if (shader->data) {
-		memdelete(shader->data);
+		//make material unreference this
+		while (shader->owners.size()) {
+			material_set_shader((*shader->owners.begin())->self, RID());
+		}
+
+		//clear data if exists
+		if (shader->data) {
+			memdelete(shader->data);
+		}
 	}
 
 	if (shader->embedded) {
@@ -2195,12 +2200,16 @@ void MaterialStorage::shader_free(RID p_rid) {
 		embedded_set.erase(p_rid);
 	}
 
+	memdelete(shader->mutex);
+
 	shader_owner.free(p_rid);
 }
 
 void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
 	Shader *shader = shader_owner.get_or_null(p_shader);
 	ERR_FAIL_NULL(shader);
+
+	MutexLock lock(*shader->mutex);
 
 	shader->code = p_code;
 	String mode_string = ShaderLanguage::get_shader_type(p_code);
@@ -2322,9 +2331,14 @@ void MaterialStorage::shader_set_default_texture_parameter(RID p_shader, const S
 	if (shader->data) {
 		shader->data->set_default_texture_parameter(p_name, p_texture, p_index);
 	}
-	for (Material *E : shader->owners) {
-		Material *material = E;
-		_material_queue_update(material, false, true);
+
+	{
+		MutexLock lock(*shader->mutex);
+
+		for (Material *E : shader->owners) {
+			Material *material = E;
+			_material_queue_update(material, false, true);
+		}
 	}
 }
 
@@ -2474,7 +2488,11 @@ void MaterialStorage::material_set_shader(RID p_material, RID p_shader) {
 	}
 
 	if (material->shader) {
-		material->shader->owners.erase(material);
+		{
+			MutexLock lock(*material->shader->mutex);
+			material->shader->owners.erase(material);
+		}
+
 		material->shader = nullptr;
 		material->shader_type = SHADER_TYPE_MAX;
 	}
@@ -2487,6 +2505,9 @@ void MaterialStorage::material_set_shader(RID p_material, RID p_shader) {
 
 	Shader *shader = get_shader(p_shader);
 	ERR_FAIL_NULL(shader);
+
+	MutexLock lock(*shader->mutex);
+
 	material->shader = shader;
 	material->shader_type = shader->type;
 	material->shader_id = p_shader.get_local_index();

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.h
@@ -265,6 +265,7 @@ private:
 	struct Material;
 
 	struct Shader {
+		Mutex *mutex = nullptr;
 		ShaderData *data = nullptr;
 		String code;
 		String path_hint;


### PR DESCRIPTION
Fixes #114896.

Adds a mutex to protect the `data`, `type` and `owners` members of the `Shader` class.

I think this minimal mutex usage should be enough for the following reasons (from my understanding):

Getter and setter functions for shaders normally go through the `RenderingServer` command queue. The only exception is when a shader object is _just_ created and being set up. At that point, only the setup code references the object, so there is nothing to race against.

After the initial setup, once the shader object can be referenced by materials, `material_set_shader` may manipulate the `owners` member concurrently. For this reason, we mandate a mutex lock for all accesses to `owners`.

Besides that, `data` and `type` can be written by `shader_set_code` only in the command queue, while `material_set_shader` reads from them concurrently. So, we also add a mutex lock for these: when reading in `material_set_shader`, and when writing in `shader_set_code`.

Other getters execute only in the `RenderingServer` command queue, so they cannot race with their writers.

I'm not sure what to assume for `shader_free`. Issues can happen if a shader is being freed while `material_set_shader` is accessing it, but I believe this always has been a theoretical problem? It doesn't appear to happen in practice.