### PR TITLE
Add missing info to some AudioStream docs

### DIFF
--- a/doc/classes/AudioStream.xml
+++ b/doc/classes/AudioStream.xml
@@ -4,7 +4,7 @@
 		Base class for audio streams.
 	</brief_description>
 	<description>
-		Base class for audio streams. Audio streams are used for sound effects and music playback, and support WAV (via [AudioStreamWAV]) and Ogg (via [AudioStreamOggVorbis]) file formats.
+		Base class for audio streams. Audio streams are used for sound effects and music playback, and support WAV (via [AudioStreamWAV]), Ogg (via [AudioStreamOggVorbis]), and MP3 (via [AudioStreamMP3]) file formats.
 	</description>
 	<tutorials>
 		<link title="Audio streams">$DOCS_URL/tutorials/audio/audio_streams.html</link>

--- a/doc/classes/AudioStreamGenerator.xml
+++ b/doc/classes/AudioStreamGenerator.xml
@@ -63,6 +63,7 @@
 		[b]Note:[/b] Due to performance constraints, this class is best used from C# or from a compiled language via GDExtension. If you still want to use this class from GDScript, consider using a lower [member mix_rate] such as 11,025 Hz or 22,050 Hz.
 	</description>
 	<tutorials>
+		<link title="Audio streams">$DOCS_URL/tutorials/audio/audio_streams.html</link>
 		<link title="Audio Generator Demo">https://godotengine.org/asset-library/asset/2759</link>
 	</tutorials>
 	<members>

--- a/doc/classes/AudioStreamMicrophone.xml
+++ b/doc/classes/AudioStreamMicrophone.xml
@@ -8,6 +8,7 @@
 		[b]Note:[/b] [member ProjectSettings.audio/driver/enable_input] must be [code]true[/code] for audio input to work. See also that setting's description for caveats related to permissions and operating system privacy settings.
 	</description>
 	<tutorials>
+		<link title="Audio streams">$DOCS_URL/tutorials/audio/audio_streams.html</link>
 		<link title="Recording with microphone">$DOCS_URL/tutorials/audio/recording_with_microphone.html</link>
 		<link title="Audio Mic Record Demo">https://github.com/godotengine/godot-demo-projects/tree/master/audio/mic_record</link>
 	</tutorials>

--- a/doc/classes/AudioStreamPlaybackResampled.xml
+++ b/doc/classes/AudioStreamPlaybackResampled.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioStreamPlaybackResampled" inherits="AudioStreamPlayback" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Playback class used for resampled [AudioStream]s.
 	</brief_description>
 	<description>
+		Playback class used to mix an [AudioStream]'s audio samples to [method AudioServer.get_mix_rate] using cubic interpolation.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +12,7 @@
 		<method name="_get_stream_sampling_rate" qualifiers="virtual required const">
 			<return type="float" />
 			<description>
+				Returns an [AudioStream]'s sample rate, in Hz. Used to perform resampling.
 			</description>
 		</method>
 		<method name="_mix_resampled" qualifiers="virtual required">
@@ -17,11 +20,13 @@
 			<param index="0" name="dst_buffer" type="AudioFrame*" />
 			<param index="1" name="frame_count" type="int" />
 			<description>
+				Called by [method begin_resample] to mix an [AudioStream] to [method AudioServer.get_mix_rate]. Uses [method _get_stream_sampling_rate] as the source sample rate. Returns the number of mixed frames.
 			</description>
 		</method>
 		<method name="begin_resample">
 			<return type="void" />
 			<description>
+				Called when an [AudioStream] is played. Clears the cubic interpolation history and starts mixing by calling [method _mix_resampled].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AudioStreamPolyphonic.xml
+++ b/doc/classes/AudioStreamPolyphonic.xml
@@ -8,6 +8,7 @@
 		Playback control is done via the [AudioStreamPlaybackPolyphonic] instance set inside the player, which can be obtained via [method AudioStreamPlayer.get_stream_playback], [method AudioStreamPlayer2D.get_stream_playback] or [method AudioStreamPlayer3D.get_stream_playback] methods. Obtaining the playback instance is only valid after the [code]stream[/code] property is set as an [AudioStreamPolyphonic] in those players.
 	</description>
 	<tutorials>
+		<link title="Audio streams">$DOCS_URL/tutorials/audio/audio_streams.html</link>
 	</tutorials>
 	<members>
 		<member name="polyphony" type="int" setter="set_polyphony" getter="get_polyphony" default="32">

--- a/doc/classes/AudioStreamRandomizer.xml
+++ b/doc/classes/AudioStreamRandomizer.xml
@@ -7,6 +7,7 @@
 		Picks a random AudioStream from the pool, depending on the playback mode, and applies random pitch shifting and volume shifting during playback.
 	</description>
 	<tutorials>
+		<link title="Audio streams">$DOCS_URL/tutorials/audio/audio_streams.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_stream">

--- a/doc/classes/AudioStreamWAV.xml
+++ b/doc/classes/AudioStreamWAV.xml
@@ -8,6 +8,7 @@
 		This class can also be used to store dynamically-generated PCM audio data. See also [AudioStreamGenerator] for procedural audio generation.
 	</description>
 	<tutorials>
+		<link title="Audio streams">$DOCS_URL/tutorials/audio/audio_streams.html</link>
 		<link title="Runtime file loading and saving">$DOCS_URL/tutorials/io/runtime_file_loading_and_saving.html</link>
 	</tutorials>
 	<methods>

--- a/modules/interactive_music/doc_classes/AudioStreamInteractive.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamInteractive.xml
@@ -8,6 +8,7 @@
 		The way this is used is by filling a number of clips, then configuring the transition table. From there, clips are selected for playback and the music will smoothly go from the current to the new one while using the corresponding transition rule defined in the transition table.
 	</description>
 	<tutorials>
+		<link title="Audio streams">$DOCS_URL/tutorials/audio/audio_streams.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_transition">

--- a/modules/interactive_music/doc_classes/AudioStreamPlaybackPlaylist.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaybackPlaylist.xml
@@ -4,6 +4,7 @@
 		Playback class used for [AudioStreamPlaylist].
 	</brief_description>
 	<description>
+		Playback component of [AudioStreamPlaylist]. Handles the playback of multiple [AudioStream]s in sequence.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/interactive_music/doc_classes/AudioStreamPlaybackSynchronized.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaybackSynchronized.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioStreamPlaybackSynchronized" inherits="AudioStreamPlayback" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
+		Playback class used for [AudioStreamSynchronized].
 	</brief_description>
 	<description>
+		Playback component of [AudioStreamSynchronized]. Handles the playback of multiple [AudioStream]s in synchrony.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/interactive_music/doc_classes/AudioStreamPlaylist.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaylist.xml
@@ -4,8 +4,10 @@
 		[AudioStream] that includes sub-streams and plays them back like a playlist.
 	</brief_description>
 	<description>
+		An audio stream that can play back sub-streams in sequence. Streams can be added to the Playlist with [method set_list_stream], and shuffled with [member shuffle].
 	</description>
 	<tutorials>
+		<link title="Audio streams">$DOCS_URL/tutorials/audio/audio_streams.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_bpm" qualifiers="const">

--- a/modules/interactive_music/doc_classes/AudioStreamSynchronized.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamSynchronized.xml
@@ -7,6 +7,7 @@
 		This is a stream that can be fitted with sub-streams, which will be played in-sync. The streams begin at exactly the same time when play is pressed, and will end when the last of them ends. If one of the sub-streams loops, then playback will continue.
 	</description>
 	<tutorials>
+		<link title="Audio streams">$DOCS_URL/tutorials/audio/audio_streams.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_sync_stream" qualifiers="const">

--- a/modules/mp3/doc_classes/AudioStreamMP3.xml
+++ b/modules/mp3/doc_classes/AudioStreamMP3.xml
@@ -4,10 +4,12 @@
 		MP3 audio stream driver.
 	</brief_description>
 	<description>
-		MP3 audio stream driver. See [member data] if you want to load an MP3 file at run-time.
+		MP3 audio stream driver. See [member data] if you want to load an MP3 file at run-time. More info can be found in [ResourceImporterMP3].
 		[b]Note:[/b] This class can optionally support legacy MP1 and MP2 formats, provided that the engine is compiled with the [code]minimp3_extra_formats=yes[/code] SCons option. These extra formats are not enabled by default.
 	</description>
 	<tutorials>
+		<link title="Audio streams">$DOCS_URL/tutorials/audio/audio_streams.html</link>
+		<link title="Runtime file loading and saving">$DOCS_URL/tutorials/io/runtime_file_loading_and_saving.html</link>
 	</tutorials>
 	<methods>
 		<method name="load_from_buffer" qualifiers="static">
@@ -27,10 +29,13 @@
 	</methods>
 	<members>
 		<member name="bar_beats" type="int" setter="set_bar_beats" getter="get_bar_beats" default="4">
+			The number of beats within a single bar in the audio track.
 		</member>
 		<member name="beat_count" type="int" setter="set_beat_count" getter="get_beat_count" default="0">
+			The length of the audio track, in beats. The actual duration of the audio file might be longer than what is indicated by this property. It defines the end of the audio for looping, [AudioStreamPlaylist], and [AudioStreamInteractive].
 		</member>
 		<member name="bpm" type="float" setter="set_bpm" getter="get_bpm" default="0.0">
+			The tempo of the audio track, measured in beats per minute.
 		</member>
 		<member name="data" type="PackedByteArray" setter="set_data" getter="get_data" default="PackedByteArray()">
 			Contains the audio data in bytes.
@@ -55,7 +60,7 @@
 			[/codeblocks]
 		</member>
 		<member name="loop" type="bool" setter="set_loop" getter="has_loop" default="false">
-			If [code]true[/code], the stream will automatically loop when it reaches the end.
+			If [code]true[/code], the stream will play again from the specified [member loop_offset] once it reaches the end of the audio track, or once it reaches the end of the last beat according to the amount specified in [member beat_count]. Useful for ambient sounds and background music.
 		</member>
 		<member name="loop_offset" type="float" setter="set_loop_offset" getter="get_loop_offset" default="0.0">
 			Time in seconds at which the stream starts after being looped.

--- a/modules/vorbis/doc_classes/AudioStreamOggVorbis.xml
+++ b/modules/vorbis/doc_classes/AudioStreamOggVorbis.xml
@@ -4,9 +4,11 @@
 		A class representing an Ogg Vorbis audio stream.
 	</brief_description>
 	<description>
-		The AudioStreamOggVorbis class is a specialized [AudioStream] for handling Ogg Vorbis file formats. It offers functionality for loading and playing back Ogg Vorbis files, as well as managing looping and other playback properties. This class is part of the audio stream system, which also supports WAV files through the [AudioStreamWAV] class.
+		The AudioStreamOggVorbis class is a specialized [AudioStream] for handling Ogg Vorbis file formats. It offers functionality for loading and playing back Ogg Vorbis files, as well as managing looping and other playback properties. More info can be found in [ResourceImporterOggVorbis].
+		This class is part of the audio stream system, which also supports WAV files through the [AudioStreamWAV] class, and MP3 files through the [AudioStreamMP3] class.
 	</description>
 	<tutorials>
+		<link title="Audio streams">$DOCS_URL/tutorials/audio/audio_streams.html</link>
 		<link title="Runtime file loading and saving">$DOCS_URL/tutorials/io/runtime_file_loading_and_saving.html</link>
 	</tutorials>
 	<methods>
@@ -27,13 +29,16 @@
 	</methods>
 	<members>
 		<member name="bar_beats" type="int" setter="set_bar_beats" getter="get_bar_beats" default="4">
+			The number of beats within a single bar in the audio track.
 		</member>
 		<member name="beat_count" type="int" setter="set_beat_count" getter="get_beat_count" default="0">
+			The length of the audio track, in beats. The actual duration of the audio file might be longer than what is indicated by this property. It defines the end of the audio for looping, [AudioStreamPlaylist], and [AudioStreamInteractive].
 		</member>
 		<member name="bpm" type="float" setter="set_bpm" getter="get_bpm" default="0.0">
+			The tempo of the audio track, measured in beats per minute.
 		</member>
 		<member name="loop" type="bool" setter="set_loop" getter="has_loop" default="false">
-			If [code]true[/code], the audio will play again from the specified [member loop_offset] once it is done playing. Useful for ambient sounds and background music.
+			If [code]true[/code], the stream will play again from the specified [member loop_offset] once it reaches the end of the audio track, or once it reaches the end of the last beat according to the amount specified in [member beat_count]. Useful for ambient sounds and background music.
 		</member>
 		<member name="loop_offset" type="float" setter="set_loop_offset" getter="get_loop_offset" default="0.0">
 			Time in seconds at which the stream starts after being looped.

--- a/modules/vorbis/doc_classes/AudioStreamPlaybackOggVorbis.xml
+++ b/modules/vorbis/doc_classes/AudioStreamPlaybackOggVorbis.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioStreamPlaybackOggVorbis" inherits="AudioStreamPlaybackResampled" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
+		Playback class used for [AudioStreamOggVorbis].
 	</brief_description>
 	<description>
+		Playback component of [AudioStreamOggVorbis]. Uses [OggPacketSequencePlayback] for playback data.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
Closes: https://github.com/godotengine/godot-docs/issues/3998

Adding missing info to some `AudioStream` classes. For a few of them, it's just relevant manual links that is added.

Kind of related to #116597