### PR TITLE
Add `AnimationMixer` configuration warning on conflicting track types

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -144,6 +144,59 @@ void AnimationMixer::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
+PackedStringArray AnimationMixer::get_configuration_warnings() const {
+	PackedStringArray warnings = Node::get_configuration_warnings();
+
+	if (deterministic && has_animation(SceneStringName(RESET))) {
+		Ref<Animation> reset_animation = get_animation(SceneStringName(RESET));
+		for (int i = 0; i < reset_animation->get_track_count(); ++i) {
+			if (!reset_animation->track_is_enabled(i)) {
+				continue;
+			}
+
+			NodePath property_path = reset_animation->track_get_path(i);
+			if (property_path.get_subname_count() == 0) {
+				continue;
+			}
+
+			PropertyInfo property_info;
+			Variant property_value;
+			if (!_get_property_data(property_path, &property_info, &property_value) || property_value.get_type() != Variant::FLOAT) {
+				continue;
+			}
+
+			NodePath property_parent_path = property_path.slice(0, property_path.get_total_name_count() - 1);
+			if (!_get_property_data(property_parent_path, &property_info, nullptr)) {
+				continue;
+			}
+
+			switch (property_info.type) {
+				case Variant::VECTOR2:
+				case Variant::VECTOR3:
+				case Variant::QUATERNION:
+				case Variant::COLOR:
+				case Variant::PLANE:
+					break;
+				default:
+					continue;
+			}
+
+			for (int j = 0; j < reset_animation->get_track_count(); ++j) {
+				if (!reset_animation->track_is_enabled(j)) {
+					continue;
+				}
+
+				NodePath other_property_path = reset_animation->track_get_path(j);
+				if (other_property_path == property_parent_path) {
+					warnings.push_back(vformat("Conflicting tracks found in RESET animation, \"%s\" and \"%s\".\nThis will cause unpredictable behavior during deterministic playback.\nAvoid having bezier and non-bezier tracks animate the same property.", property_path, other_property_path));
+				}
+			}
+		}
+	}
+
+	return warnings;
+}
+
 /* -------------------------------------------- */
 /* -- Data lists ------------------------------ */
 /* -------------------------------------------- */
@@ -235,6 +288,7 @@ void AnimationMixer::_animation_renamed(const StringName &p_name, const StringNa
 
 void AnimationMixer::_animation_changed(const StringName &p_name) {
 	_clear_caches();
+	update_configuration_warnings();
 }
 
 void AnimationMixer::_set_active(bool p_active) {
@@ -482,6 +536,7 @@ NodePath AnimationMixer::get_root_node() const {
 void AnimationMixer::set_deterministic(bool p_deterministic) {
 	deterministic = p_deterministic;
 	_clear_caches();
+	update_configuration_warnings();
 }
 
 bool AnimationMixer::is_deterministic() const {
@@ -980,6 +1035,40 @@ bool AnimationMixer::_update_caches() {
 	track_count = idx;
 
 	cache_valid = true;
+
+	return true;
+}
+
+bool AnimationMixer::_get_property_data(const NodePath &p_property_path, PropertyInfo *r_property_info, Variant *r_property_value) const {
+	Node *root_object = get_node_or_null(root_node);
+	ERR_FAIL_NULL_V(root_object, false);
+
+	Ref<Resource> resource;
+	Vector<StringName> property_subpath;
+	Object *object = root_object->get_node_and_resource(p_property_path, resource, property_subpath, true);
+	if (!object || property_subpath.is_empty()) {
+		return false;
+	}
+
+	if (resource.is_valid()) {
+		object = resource.ptr();
+	}
+
+	if (r_property_value != nullptr) {
+		*r_property_value = object->get_indexed(property_subpath);
+	}
+
+	List<PropertyInfo> property_infos;
+	Variant(object).get_property_list(&property_infos);
+
+	StringName property_name = property_subpath[property_subpath.size() - 1];
+	for (const PropertyInfo &property_info : property_infos) {
+		if (property_info.name == property_name) {
+			if (r_property_info != nullptr) {
+				*r_property_info = property_info;
+			}
+		}
+	}
 
 	return true;
 }

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -316,6 +316,7 @@ protected:
 	void _init_root_motion_cache();
 	bool _update_caches();
 	void _create_track_num_to_track_cache_for_animation(Ref<Animation> &p_animation);
+	bool _get_property_data(const NodePath &p_property_path, PropertyInfo *r_property_info, Variant *r_property_value) const;
 
 	/* ---- Audio ---- */
 	AudioServer::PlaybackType playback_type;
@@ -342,6 +343,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
 	virtual void _validate_property(PropertyInfo &p_property) const;
+	virtual PackedStringArray get_configuration_warnings() const override;
 
 #ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;


### PR DESCRIPTION
Resolves godotengine/godot-proposals#14208.

This pull request aims to improve the usability of `AnimationTree` and `AnimationPlayer`, by showing a node configuration warning if `deterministic` is enabled and there are two tracks in the `RESET` animation that both reset the same property, but using different `NodePath` specificity, e.g. `MyNode:position` and `MyNode:position:x`.

<img width="865" height="335" alt="image" src="https://github.com/user-attachments/assets/91a51f73-d263-4728-b78a-515d40a24f3f" />

This should hopefully help catch some of the playback/blending issues that arise from mixing bezier tracks and value tracks, which is discouraged in the documentation, as seen [here](https://docs.godotengine.org/en/4.6/tutorials/animation/animation_track_types.html#bezier-curve-track).

Note that this is a more conservative approach of a previous attempt that aimed to emit this warning for conflicts between non-`RESET` animations as well, but after seeing some questionable false positives we scaled it back to this. We'd love to hear feedback on whether there are more problematic cases we could/should include here.