### PR TITLE
Show shortcut path in tooltip

### DIFF
--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -439,6 +439,7 @@ TreeItem *EditorSettingsDialog::_create_shortcut_treeitem(TreeItem *p_parent, co
 	TreeItem *shortcut_item = shortcuts->create_item(p_parent);
 	shortcut_item->set_collapsed(p_is_collapsed);
 	shortcut_item->set_text(0, p_display);
+	shortcut_item->set_tooltip_text(0, p_shortcut_identifier);
 
 	Ref<InputEvent> primary = p_events.size() > 0 ? Ref<InputEvent>(p_events[0]) : Ref<InputEvent>();
 	Ref<InputEvent> secondary = p_events.size() > 1 ? Ref<InputEvent>(p_events[1]) : Ref<InputEvent>();


### PR DESCRIPTION
Editor shortcut paths are needed in code, but there is no easy way to check the exact path, especially when using non-English language.
This PR makes the tooltip of shortcuts more useful.
<img width="891" height="93" alt="image" src="https://github.com/user-attachments/assets/ef7c2613-2cb6-4d9b-a49e-0453bb95e3e9" />
