### PR TITLE
OpenXR: Allow using Vulkan subsampled images with foveated rendering

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3617,6 +3617,10 @@
 			Applied foveation level if supported.
 			[b]Note:[/b] On platforms other than Android, if [member rendering/anti_aliasing/quality/msaa_3d] is enabled, this feature will be disabled.
 		</member>
+		<member name="xr/openxr/foveation_with_subsampled_images" type="bool" setter="" getter="" default="false">
+			If [code]true[/code] and foveation is also enabled, subsampled images will be used on Vulkan. This can improve the performance gain from foveated rendering, especially when using high foveation levels.
+			[b]Note:[/b]: Using subsampled images is incompatible with many screen-space rendering features or post-processing effects like FXAA or glow. If any such effects are enabled, subsampled images will automatically be disabled and a warning shown in the log.
+		</member>
 		<member name="xr/openxr/reference_space" type="int" setter="" getter="" default="&quot;1&quot;">
 			Specify the default reference space.
 		</member>

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -740,6 +740,12 @@ public:
 	virtual void render_target_set_render_region(RID p_render_target, const Rect2i &p_render_region) override;
 	virtual Rect2i render_target_get_render_region(RID p_render_target) const override;
 
+	virtual void render_target_set_subsampled_enabled(RID p_render_target, bool p_enabled) override {}
+	virtual bool render_target_is_subsampled_enabled(RID p_render_target) const override { return false; }
+
+	virtual void render_target_set_subsampled_allowed(RID p_render_target, bool p_allowed) override {}
+	virtual bool render_target_is_subsampled_allowed(RID p_render_target) const override { return false; }
+
 	virtual RID render_target_get_texture(RID p_render_target) override;
 
 	virtual void render_target_set_velocity_target_size(RID p_render_target, const Size2i &p_target_size) override;

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -569,6 +569,7 @@ Error RenderingDeviceDriverVulkan::_initialize_device_extensions() {
 	_register_requested_device_extension(VK_KHR_MULTIVIEW_EXTENSION_NAME, false);
 	_register_requested_device_extension(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME, false);
 	_register_requested_device_extension(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME, false);
+	_register_requested_device_extension(VK_EXT_FRAGMENT_DENSITY_MAP_2_EXTENSION_NAME, false);
 	_register_requested_device_extension(VK_QCOM_FRAGMENT_DENSITY_MAP_OFFSET_EXTENSION_NAME, false);
 	_register_requested_device_extension(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME, false);
 	_register_requested_device_extension(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME, false);
@@ -2194,6 +2195,11 @@ RDD::TextureID RenderingDeviceDriverVulkan::texture_create(const TextureFormat &
 		create_info.flags |= VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
 	}*/
 
+	bool use_subsampled_images = VulkanHooks::get_singleton() && VulkanHooks::get_singleton()->use_subsampled_images();
+	if (fdm_capabilities.attachment_supported && use_subsampled_images && p_format.is_subsampled && (p_format.usage_bits & (TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | TEXTURE_USAGE_INPUT_ATTACHMENT_BIT | TEXTURE_USAGE_DEPTH_RESOLVE_ATTACHMENT_BIT))) {
+		create_info.flags |= VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT;
+	}
+
 	if (fdm_capabilities.offset_supported && (p_format.usage_bits & (TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | TEXTURE_USAGE_INPUT_ATTACHMENT_BIT | TEXTURE_USAGE_DEPTH_RESOLVE_ATTACHMENT_BIT | TEXTURE_USAGE_VRS_ATTACHMENT_BIT))) {
 		create_info.flags |= VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM;
 	}
@@ -2353,6 +2359,7 @@ RDD::TextureID RenderingDeviceDriverVulkan::texture_create(const TextureFormat &
 	tex_info->vk_create_info = create_info;
 	tex_info->vk_view_create_info = image_view_create_info;
 	tex_info->allocation.handle = allocation;
+	tex_info->is_subsampled = (create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) != 0;
 #ifdef DEBUG_ENABLED
 	tex_info->transient = (p_format.usage_bits & TEXTURE_USAGE_TRANSIENT_BIT) != 0;
 #endif
@@ -5107,6 +5114,11 @@ void RenderingDeviceDriverVulkan::command_clear_depth_stencil_texture(CommandBuf
 
 void RenderingDeviceDriverVulkan::command_copy_buffer_to_texture(CommandBufferID p_cmd_buffer, BufferID p_src_buffer, TextureID p_dst_texture, TextureLayout p_dst_texture_layout, VectorView<BufferTextureCopyRegion> p_regions) {
 	const TextureInfo *tex_info = (const TextureInfo *)p_dst_texture.id;
+
+	if (tex_info->is_subsampled) {
+		// Subsampled images can't be copied into, only used as attachments to a framebuffer.
+		return;
+	}
 
 	uint32_t pixel_size = get_image_format_pixel_size(tex_info->rd_format);
 	uint32_t block_size = get_compressed_image_format_block_byte_size(tex_info->rd_format);

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -275,6 +275,7 @@ public:
 			VmaAllocation handle = nullptr;
 			VmaAllocationInfo info = {};
 		} allocation; // All 0/null if just a view.
+		bool is_subsampled = false;
 #ifdef DEBUG_ENABLED
 		bool created_from_extension = false;
 		bool transient = false;

--- a/drivers/vulkan/vulkan_hooks.h
+++ b/drivers/vulkan/vulkan_hooks.h
@@ -47,5 +47,6 @@ public:
 	virtual void set_direct_queue_family_and_index(uint32_t p_queue_family_index, uint32_t p_queue_index) = 0;
 	virtual bool use_fragment_density_offsets() = 0;
 	virtual void get_fragment_density_offsets(LocalVector<VkOffset2D> &r_offsets, const Vector2i &p_granularity) = 0;
+	virtual bool use_subsampled_images() = 0;
 	static VulkanHooks *get_singleton() { return singleton; }
 };

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2827,6 +2827,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/environment_blend_mode", PROPERTY_HINT_ENUM, "Opaque,Additive,Alpha"), "0");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/foveation_level", PROPERTY_HINT_ENUM, "Off,Low,Medium,High"), "0");
 	GLOBAL_DEF_BASIC("xr/openxr/foveation_dynamic", false);
+	GLOBAL_DEF_BASIC("xr/openxr/foveation_with_subsampled_images", false);
 
 	GLOBAL_DEF_BASIC("xr/openxr/submit_depth_buffer", false);
 	GLOBAL_DEF_BASIC("xr/openxr/startup_alert", true);

--- a/modules/openxr/doc_classes/OpenXRInterface.xml
+++ b/modules/openxr/doc_classes/OpenXRInterface.xml
@@ -176,11 +176,12 @@
 		</member>
 		<member name="foveation_dynamic" type="bool" setter="set_foveation_dynamic" getter="get_foveation_dynamic" default="false">
 			If [code]true[/code], enables dynamic foveation adjustment. The interface must be initialized before this is accessible. If enabled, foveation will automatically be adjusted between low and [member foveation_level].
-			[b]Note:[/b] Only works on the Compatibility renderer.
 		</member>
 		<member name="foveation_level" type="int" setter="set_foveation_level" getter="get_foveation_level" default="0">
 			The foveation level, from [code]0[/code] (off) to [code]3[/code] (high). The interface must be initialized before this is accessible.
-			[b]Note:[/b] Only works on the Compatibility renderer.
+		</member>
+		<member name="foveation_with_subsampled_images" type="bool" setter="set_foveation_with_subsampled_images" getter="get_foveation_with_subsampled_images" default="false">
+			If [code]true[/code], enables subsampled images with foveation, which can provide a performance boost on Vulkan.
 		</member>
 		<member name="render_target_size_multiplier" type="float" setter="set_render_target_size_multiplier" getter="get_render_target_size_multiplier" default="1.0">
 			The render size multiplier for the current HMD. Must be set before the interface has been initialized.

--- a/modules/openxr/extensions/openxr_fb_foveation_extension.cpp
+++ b/modules/openxr/extensions/openxr_fb_foveation_extension.cpp
@@ -51,8 +51,12 @@ OpenXRFBFoveationExtension::OpenXRFBFoveationExtension(const String &p_rendering
 	if (fov_level >= 0 && fov_level < 4) {
 		foveation_level = XrFoveationLevelFB(fov_level);
 	}
+
 	bool fov_dyn = GLOBAL_GET("xr/openxr/foveation_dynamic");
 	foveation_dynamic = fov_dyn ? XR_FOVEATION_DYNAMIC_LEVEL_ENABLED_FB : XR_FOVEATION_DYNAMIC_DISABLED_FB;
+
+	foveation_with_subsampled_images_enabled = GLOBAL_GET("xr/openxr/foveation_with_subsampled_images");
+	foveation_with_subsampled_images_active = foveation_with_subsampled_images_enabled;
 
 	swapchain_create_info_foveation_fb.type = XR_TYPE_SWAPCHAIN_CREATE_INFO_FOVEATION_FB;
 	swapchain_create_info_foveation_fb.next = nullptr;
@@ -69,7 +73,7 @@ OpenXRFBFoveationExtension::OpenXRFBFoveationExtension(const String &p_rendering
 #ifdef VULKAN_ENABLED
 	meta_vulkan_swapchain_create_info.type = XR_TYPE_VULKAN_SWAPCHAIN_CREATE_INFO_META;
 	meta_vulkan_swapchain_create_info.next = nullptr;
-	meta_vulkan_swapchain_create_info.additionalCreateFlags = VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM;
+	meta_vulkan_swapchain_create_info.additionalCreateFlags = 0;
 	meta_vulkan_swapchain_create_info.additionalUsageFlags = 0;
 #endif
 
@@ -150,7 +154,15 @@ void *OpenXRFBFoveationExtension::set_swapchain_create_info_and_get_next_pointer
 		next = &swapchain_create_info_foveation_fb;
 
 #ifdef VULKAN_ENABLED
-		if (meta_foveation_eye_tracked_ext && meta_vulkan_swapchain_create_info_ext && meta_foveation_eye_tracked_properties.supportsFoveationEyeTracked) {
+		if (meta_vulkan_swapchain_create_info_ext) {
+			meta_vulkan_swapchain_create_info.additionalCreateFlags = 0;
+			if (meta_foveation_eye_tracked_ext && meta_foveation_eye_tracked_properties.supportsFoveationEyeTracked) {
+				meta_vulkan_swapchain_create_info.additionalCreateFlags |= VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM;
+			}
+			if (foveation_with_subsampled_images_enabled && foveation_with_subsampled_images_active) {
+				meta_vulkan_swapchain_create_info.additionalCreateFlags |= VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT;
+			}
+
 			meta_vulkan_swapchain_create_info.next = next;
 			next = &meta_vulkan_swapchain_create_info;
 		}
@@ -224,6 +236,18 @@ void OpenXRFBFoveationExtension::get_fragment_density_offsets(LocalVector<Vector
 		const XrVector2f &xr_center = state.foveationCenter[i];
 		r_offsets.push_back(Vector2i((int)(xr_center.x * dims.x), (int)(xr_center.y * dims.y)));
 	}
+}
+
+void OpenXRFBFoveationExtension::set_foveation_with_subsampled_images_enabled(bool p_enabled) {
+	foveation_with_subsampled_images_enabled = p_enabled;
+}
+
+bool OpenXRFBFoveationExtension::is_foveation_with_subsampled_images_enabled() const {
+	return is_enabled() && meta_vulkan_swapchain_create_info_ext && foveation_with_subsampled_images_enabled;
+}
+
+void OpenXRFBFoveationExtension::set_foveation_with_subsampled_images_active(bool p_active) {
+	foveation_with_subsampled_images_active = p_active;
 }
 
 void OpenXRFBFoveationExtension::_update_profile_rt() {

--- a/modules/openxr/extensions/openxr_fb_foveation_extension.h
+++ b/modules/openxr/extensions/openxr_fb_foveation_extension.h
@@ -75,6 +75,11 @@ public:
 	bool is_foveation_eye_tracked_enabled() const;
 	void get_fragment_density_offsets(LocalVector<Vector2i> &r_offsets);
 
+	void set_foveation_with_subsampled_images_enabled(bool p_enabled);
+	bool is_foveation_with_subsampled_images_enabled() const;
+
+	void set_foveation_with_subsampled_images_active(bool p_active);
+
 private:
 	static OpenXRFBFoveationExtension *singleton;
 
@@ -89,6 +94,8 @@ private:
 	// Configuration
 	XrFoveationLevelFB foveation_level = XR_FOVEATION_LEVEL_NONE_FB;
 	XrFoveationDynamicFB foveation_dynamic = XR_FOVEATION_DYNAMIC_DISABLED_FB;
+	bool foveation_with_subsampled_images_enabled = false;
+	bool foveation_with_subsampled_images_active = false;
 
 	void _update_profile_rt();
 

--- a/modules/openxr/extensions/platform/openxr_vulkan_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_vulkan_extension.cpp
@@ -229,6 +229,15 @@ void OpenXRVulkanExtension::get_fragment_density_offsets(LocalVector<VkOffset2D>
 	}
 }
 
+bool OpenXRVulkanExtension::use_subsampled_images() {
+	OpenXRFBFoveationExtension *fb_foveation = OpenXRFBFoveationExtension::get_singleton();
+	if (fb_foveation == nullptr) {
+		return false;
+	}
+
+	return fb_foveation->is_foveation_with_subsampled_images_enabled();
+}
+
 XrGraphicsBindingVulkanKHR OpenXRVulkanExtension::graphics_binding_vulkan;
 
 void *OpenXRVulkanExtension::set_session_create_and_get_next_pointer(void *p_next_pointer) {

--- a/modules/openxr/extensions/platform/openxr_vulkan_extension.h
+++ b/modules/openxr/extensions/platform/openxr_vulkan_extension.h
@@ -54,6 +54,7 @@ public:
 	virtual bool get_physical_device(VkPhysicalDevice *r_device) override final;
 	virtual bool create_vulkan_device(const VkDeviceCreateInfo *p_device_create_info, VkDevice *r_device) override final;
 	virtual void set_direct_queue_family_and_index(uint32_t p_queue_family_index, uint32_t p_queue_index) override final;
+	virtual bool use_subsampled_images() override final;
 	virtual bool use_fragment_density_offsets() override final;
 	virtual void get_fragment_density_offsets(LocalVector<VkOffset2D> &r_offets, const Vector2i &p_granularity) override final;
 

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -41,6 +41,7 @@
 #include "core/profiling/profiling.h"
 #include "core/version.h"
 #include "servers/rendering/rendering_server.h"
+#include "servers/rendering/rendering_server_globals.h"
 
 #include "openxr_platform_inc.h"
 
@@ -2430,15 +2431,6 @@ void OpenXRAPI::pre_render() {
 	// Process any swapchains that were queued to be freed
 	OpenXRSwapChainInfo::free_queued();
 
-	Size2i swapchain_size = get_recommended_target_size();
-	if (swapchain_size != render_state.main_swapchain_size) {
-		// Out with the old.
-		free_main_swapchains();
-
-		// In with the new.
-		create_main_swapchains(swapchain_size);
-	}
-
 	void *view_locate_info_next_pointer = nullptr;
 	for (OpenXRExtensionWrapper *extension : frame_info_extensions) {
 		void *np = extension->set_view_locate_info_and_get_next_pointer(view_locate_info_next_pointer);
@@ -2524,6 +2516,39 @@ bool OpenXRAPI::pre_draw_viewport(RID p_render_target) {
 
 	if (instance == XR_NULL_HANDLE || session == XR_NULL_HANDLE || !render_state.running || !render_state.view_pose_valid || !render_state.should_render) {
 		return false;
+	}
+
+	Size2i swapchain_size = get_recommended_target_size();
+	bool should_recreate_swapchain = (swapchain_size != render_state.main_swapchain_size);
+
+	OpenXRFBFoveationExtension *fov_ext = OpenXRFBFoveationExtension::get_singleton();
+	if (fov_ext) {
+		bool subsampled_images_enabled = fov_ext->is_foveation_with_subsampled_images_enabled();
+
+		// Mark subsampled images as enabled on the render target (so we try to use them).
+		RSG::texture_storage->render_target_set_subsampled_enabled(p_render_target, subsampled_images_enabled);
+
+		// But check if they are "allowed", because they may not work if we are using
+		// any incompatible rendering features.
+		bool subsampled_images_allowed = RSG::texture_storage->render_target_is_subsampled_allowed(p_render_target);
+		fov_ext->set_foveation_with_subsampled_images_active(subsampled_images_allowed);
+
+		bool use_subsampled_images = subsampled_images_enabled && subsampled_images_allowed;
+		if (render_state.use_subsampled_images != use_subsampled_images) {
+			render_state.use_subsampled_images = use_subsampled_images;
+			if (!subsampled_images_allowed) {
+				WARN_PRINT("Foveation with subsampled images was enabled, but rendering features are in use that have forced it to be disabled.");
+			}
+			should_recreate_swapchain = true;
+		}
+	}
+
+	if (should_recreate_swapchain) {
+		// Out with the old.
+		free_main_swapchains();
+
+		// In with the new.
+		create_main_swapchains(swapchain_size);
 	}
 
 	// Acquire our images
@@ -2876,6 +2901,21 @@ void OpenXRAPI::set_foveation_dynamic(bool p_foveation_dynamic) {
 	OpenXRFBFoveationExtension *fov_ext = OpenXRFBFoveationExtension::get_singleton();
 	if (fov_ext != nullptr && fov_ext->is_enabled()) {
 		fov_ext->set_foveation_dynamic(p_foveation_dynamic ? XR_FOVEATION_DYNAMIC_LEVEL_ENABLED_FB : XR_FOVEATION_DYNAMIC_DISABLED_FB);
+	}
+}
+
+bool OpenXRAPI::get_foveation_with_subsampled_images() const {
+	OpenXRFBFoveationExtension *fov_ext = OpenXRFBFoveationExtension::get_singleton();
+	if (fov_ext != nullptr) {
+		return fov_ext->is_foveation_with_subsampled_images_enabled();
+	}
+	return false;
+}
+
+void OpenXRAPI::set_foveation_with_subsampled_images(bool p_enabled) {
+	OpenXRFBFoveationExtension *fov_ext = OpenXRFBFoveationExtension::get_singleton();
+	if (fov_ext != nullptr) {
+		fov_ext->set_foveation_with_subsampled_images_enabled(p_enabled);
 	}
 }
 

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -364,6 +364,7 @@ private:
 		LocalVector<XrCompositionLayerProjectionView> projection_views;
 		LocalVector<XrCompositionLayerDepthInfoKHR> depth_views; // Only used by Composition Layer Depth Extension if available
 		bool submit_depth_buffer = false; // if set to true we submit depth buffers to OpenXR if a suitable extension is enabled.
+		bool use_subsampled_images = true; // We need to default to true for the warning to be shown if we fallback immediately at startup.
 		bool view_pose_valid = false;
 
 		double z_near = 0.0;
@@ -523,6 +524,9 @@ public:
 
 	bool get_foveation_dynamic() const;
 	void set_foveation_dynamic(bool p_foveation_dynamic);
+
+	bool get_foveation_with_subsampled_images() const;
+	void set_foveation_with_subsampled_images(bool p_enabled);
 
 	// Play space.
 	Size2 get_play_space_bounds() const;

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -89,6 +89,10 @@ void OpenXRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_foveation_dynamic", "foveation_dynamic"), &OpenXRInterface::set_foveation_dynamic);
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "foveation_dynamic"), "set_foveation_dynamic", "get_foveation_dynamic");
 
+	ClassDB::bind_method(D_METHOD("get_foveation_with_subsampled_images"), &OpenXRInterface::get_foveation_with_subsampled_images);
+	ClassDB::bind_method(D_METHOD("set_foveation_with_subsampled_images", "enabled"), &OpenXRInterface::set_foveation_with_subsampled_images);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "foveation_with_subsampled_images"), "set_foveation_with_subsampled_images", "get_foveation_with_subsampled_images");
+
 	// Action sets
 	ClassDB::bind_method(D_METHOD("is_action_set_active", "name"), &OpenXRInterface::is_action_set_active);
 	ClassDB::bind_method(D_METHOD("set_action_set_active", "name", "active"), &OpenXRInterface::set_action_set_active);
@@ -1022,6 +1026,22 @@ void OpenXRInterface::set_foveation_dynamic(bool p_foveation_dynamic) {
 		return;
 	} else {
 		openxr_api->set_foveation_dynamic(p_foveation_dynamic);
+	}
+}
+
+bool OpenXRInterface::get_foveation_with_subsampled_images() const {
+	if (openxr_api == nullptr) {
+		return false;
+	} else {
+		return openxr_api->get_foveation_with_subsampled_images();
+	}
+}
+
+void OpenXRInterface::set_foveation_with_subsampled_images(bool p_enabled) {
+	if (openxr_api == nullptr) {
+		return;
+	} else {
+		openxr_api->set_foveation_with_subsampled_images(p_enabled);
 	}
 }
 

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -171,6 +171,9 @@ public:
 	bool get_foveation_dynamic() const;
 	void set_foveation_dynamic(bool p_foveation_dynamic);
 
+	bool get_foveation_with_subsampled_images() const;
+	void set_foveation_with_subsampled_images(bool p_enabled);
+
 	float get_vrs_min_radius() const;
 	void set_vrs_min_radius(float p_vrs_min_radius);
 

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -215,6 +215,12 @@ public:
 	virtual void render_target_set_render_region(RID p_render_target, const Rect2i &p_render_region) override {}
 	virtual Rect2i render_target_get_render_region(RID p_render_target) const override { return Rect2i(); }
 
+	virtual void render_target_set_subsampled_enabled(RID p_render_target, bool p_enabled) override {}
+	virtual bool render_target_is_subsampled_enabled(RID p_render_target) const override { return false; }
+
+	virtual void render_target_set_subsampled_allowed(RID p_render_target, bool p_allowed) override {}
+	virtual bool render_target_is_subsampled_allowed(RID p_render_target) const override { return false; }
+
 	virtual RID render_target_get_texture(RID p_render_target) override { return RID(); }
 
 	virtual void render_target_set_velocity_target_size(RID p_render_target, const Size2i &p_target_size) override {}

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -232,8 +232,13 @@ RID RenderForwardMobile::RenderBufferDataForwardMobile::get_color_fbs(Framebuffe
 	Vector<RID> textures;
 	int color_buffer_id = 0;
 	int depth_buffer_id = 1;
-	textures.push_back(use_msaa ? render_buffers->get_color_msaa() : render_buffers->get_internal_texture()); // 0 - color buffer.
-	textures.push_back(use_msaa ? render_buffers->get_depth_msaa() : render_buffers->get_depth_texture()); // 1 - depth buffer.
+	if (p_config_type == FB_CONFIG_RENDER_AND_POST_PASS && vrs_texture.is_valid() && texture_storage->render_target_is_subsampled_enabled(render_buffers->get_render_target())) {
+		textures.push_back(use_msaa ? render_buffers->get_color_msaa_subsampled() : render_buffers->get_color_subsampled()); // 0 - color buffer.
+		textures.push_back(use_msaa ? render_buffers->get_depth_msaa_subsampled() : render_buffers->get_depth_subsampled()); // 1 - depth buffer.
+	} else {
+		textures.push_back(use_msaa ? render_buffers->get_color_msaa() : render_buffers->get_internal_texture()); // 0 - color buffer.
+		textures.push_back(use_msaa ? render_buffers->get_depth_msaa() : render_buffers->get_depth_texture()); // 1 - depth buffer.
+	}
 	if (vrs_texture.is_valid()) {
 		textures.push_back(vrs_texture); // 2 - vrs texture.
 	}
@@ -996,6 +1001,9 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 	} else {
 		ERR_FAIL(); //bug?
 	}
+
+	// Set subsampled images as not allowed on this render target, if we are using incompatible rendering features.
+	texture_storage->render_target_set_subsampled_allowed(render_target, using_subpass_post_process);
 
 	if (p_render_data->scene_data->view_count > 1) {
 		global_pipeline_data_required.use_multiview = true;

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -641,6 +641,80 @@ RID RenderSceneBuffersRD::get_depth_texture(const uint32_t p_layer) {
 	}
 }
 
+// Subsampled textures.
+
+RID RenderSceneBuffersRD::get_color_subsampled() {
+	const bool use_msaa = (msaa_3d != RSE::VIEWPORT_MSAA_DISABLED);
+
+	RD::TextureFormat tf;
+	tf.format = get_base_data_format();
+	if (view_count > 1) {
+		tf.texture_type = RD::TEXTURE_TYPE_2D_ARRAY;
+	}
+	tf.width = internal_size.x;
+	tf.height = internal_size.y;
+	tf.array_layers = view_count;
+	tf.usage_bits = get_color_usage_bits(use_msaa, false, can_be_storage);
+	tf.is_subsampled = true;
+
+	return create_texture_from_format(RB_SCOPE_BUFFERS, RB_TEX_COLOR_SUBSAMPLED, tf);
+}
+
+RID RenderSceneBuffersRD::get_color_msaa_subsampled() {
+	ERR_FAIL_COND_V(msaa_3d == RSE::VIEWPORT_MSAA_DISABLED, RID());
+
+	RD::TextureFormat tf;
+	tf.format = get_base_data_format();
+	if (view_count > 1) {
+		tf.texture_type = RD::TEXTURE_TYPE_2D_ARRAY;
+	}
+	tf.width = internal_size.x;
+	tf.height = internal_size.y;
+	tf.array_layers = view_count;
+	tf.samples = msaa_to_samples(msaa_3d);
+	tf.usage_bits = get_color_usage_bits(false, true, can_be_storage);
+	tf.is_discardable = true;
+	tf.is_subsampled = true;
+
+	return create_texture_from_format(RB_SCOPE_BUFFERS, RB_TEX_COLOR_MSAA_SUBSAMPLED, tf);
+}
+
+RID RenderSceneBuffersRD::get_depth_subsampled() {
+	const bool use_msaa = (msaa_3d != RSE::VIEWPORT_MSAA_DISABLED);
+
+	RD::TextureFormat tf;
+	tf.format = get_depth_format(use_msaa, false, can_be_storage);
+	if (view_count > 1) {
+		tf.texture_type = RD::TEXTURE_TYPE_2D_ARRAY;
+	}
+	tf.width = internal_size.x;
+	tf.height = internal_size.y;
+	tf.array_layers = view_count;
+	tf.usage_bits = get_depth_usage_bits(use_msaa, false, can_be_storage);
+	tf.is_subsampled = true;
+
+	return create_texture_from_format(RB_SCOPE_BUFFERS, RB_TEX_DEPTH_SUBSAMPLED, tf);
+}
+
+RID RenderSceneBuffersRD::get_depth_msaa_subsampled() {
+	ERR_FAIL_COND_V(msaa_3d == RSE::VIEWPORT_MSAA_DISABLED, RID());
+
+	RD::TextureFormat tf;
+	tf.format = get_depth_format(false, true, can_be_storage);
+	if (view_count > 1) {
+		tf.texture_type = RD::TEXTURE_TYPE_2D_ARRAY;
+	}
+	tf.width = internal_size.x;
+	tf.height = internal_size.y;
+	tf.array_layers = view_count;
+	tf.samples = msaa_to_samples(msaa_3d);
+	tf.usage_bits = get_depth_usage_bits(false, true, can_be_storage);
+	tf.is_discardable = true;
+	tf.is_subsampled = true;
+
+	return create_texture_from_format(RB_SCOPE_BUFFERS, RB_TEX_DEPTH_MSAA_SUBSAMPLED, tf);
+}
+
 // Upscaled texture.
 
 void RenderSceneBuffersRD::ensure_upscaled() {

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h
@@ -48,8 +48,12 @@
 #define RB_TEX_COLOR SNAME("color")
 #define RB_TEX_COLOR_MSAA SNAME("color_msaa")
 #define RB_TEX_COLOR_UPSCALED SNAME("color_upscaled")
+#define RB_TEX_COLOR_SUBSAMPLED SNAME("color_subsampled")
+#define RB_TEX_COLOR_MSAA_SUBSAMPLED SNAME("color_msaa_subsampled")
 #define RB_TEX_DEPTH SNAME("depth")
 #define RB_TEX_DEPTH_MSAA SNAME("depth_msaa")
+#define RB_TEX_DEPTH_SUBSAMPLED SNAME("depth_subsampled")
+#define RB_TEX_DEPTH_MSAA_SUBSAMPLED SNAME("depth_msaa_subsampled")
 #define RB_TEX_VELOCITY SNAME("velocity")
 #define RB_TEX_VELOCITY_MSAA SNAME("velocity_msaa")
 
@@ -281,6 +285,11 @@ public:
 	RID get_depth_msaa(uint32_t p_layer) {
 		return get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_DEPTH_MSAA, p_layer, 0);
 	}
+
+	RID get_color_subsampled();
+	RID get_color_msaa_subsampled();
+	RID get_depth_subsampled();
+	RID get_depth_msaa_subsampled();
 
 	// back buffer (color)
 	RID get_back_buffer_texture() const {

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -4220,6 +4220,34 @@ Rect2i RendererRD::TextureStorage::render_target_get_render_region(RID p_render_
 	return rt->render_region;
 }
 
+void RendererRD::TextureStorage::render_target_set_subsampled_enabled(RID p_render_target, bool p_enabled) {
+	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
+	ERR_FAIL_NULL(rt);
+
+	rt->subsampled_enabled = p_enabled;
+}
+
+bool RendererRD::TextureStorage::render_target_is_subsampled_enabled(RID p_render_target) const {
+	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
+	ERR_FAIL_NULL_V(rt, false);
+
+	return rt->subsampled_enabled;
+}
+
+void RendererRD::TextureStorage::render_target_set_subsampled_allowed(RID p_render_target, bool p_allowed) {
+	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
+	ERR_FAIL_NULL(rt);
+
+	rt->subsampled_allowed = p_allowed;
+}
+
+bool RendererRD::TextureStorage::render_target_is_subsampled_allowed(RID p_render_target) const {
+	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
+	ERR_FAIL_NULL_V(rt, false);
+
+	return rt->subsampled_allowed;
+}
+
 void TextureStorage::render_target_set_transparent(RID p_render_target, bool p_is_transparent) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL(rt);

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -404,6 +404,8 @@ private:
 		RID vrs_texture;
 
 		Rect2i render_region;
+		bool subsampled_enabled = false;
+		bool subsampled_allowed = true;
 
 		// overridden textures
 		struct RTOverridden {
@@ -838,6 +840,12 @@ public:
 
 	virtual void render_target_set_render_region(RID p_render_target, const Rect2i &p_render_region) override;
 	virtual Rect2i render_target_get_render_region(RID p_render_target) const override;
+
+	virtual void render_target_set_subsampled_enabled(RID p_render_target, bool p_enabled) override;
+	virtual bool render_target_is_subsampled_enabled(RID p_render_target) const override;
+
+	virtual void render_target_set_subsampled_allowed(RID p_render_target, bool p_allowed) override;
+	virtual bool render_target_is_subsampled_allowed(RID p_render_target) const override;
 
 	virtual RID render_target_get_texture(RID p_render_target) override;
 

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -1332,6 +1332,7 @@ RID RenderingDevice::texture_create(const TextureFormat &p_format, const Texture
 	texture.base_layer = 0;
 	texture.is_resolve_buffer = format.is_resolve_buffer;
 	texture.is_discardable = format.is_discardable;
+	texture.is_subsampled = format.is_subsampled;
 	texture.usage_flags = format.usage_bits & ~forced_usage_bits;
 	texture.samples = format.samples;
 	texture.allowed_shared_formats = format.shareable_formats;

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -356,6 +356,7 @@ public:
 
 		bool is_resolve_buffer = false;
 		bool is_discardable = false;
+		bool is_subsampled = false;
 		bool has_initial_data = false;
 		bool pending_clear = false;
 

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -444,6 +444,7 @@ public:
 		Vector<DataFormat> shareable_formats;
 		bool is_resolve_buffer = false;
 		bool is_discardable = false;
+		bool is_subsampled = false;
 
 		bool operator==(const TextureFormat &b) const {
 			if (format != b.format) {

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -195,6 +195,12 @@ public:
 	virtual void render_target_set_render_region(RID p_render_target, const Rect2i &p_render_region) = 0;
 	virtual Rect2i render_target_get_render_region(RID p_render_target) const = 0;
 
+	virtual void render_target_set_subsampled_enabled(RID p_render_target, bool p_enabled) = 0;
+	virtual bool render_target_is_subsampled_enabled(RID p_render_target) const = 0;
+
+	virtual void render_target_set_subsampled_allowed(RID p_render_target, bool p_allowed) = 0;
+	virtual bool render_target_is_subsampled_allowed(RID p_render_target) const = 0;
+
 	// get textures
 	virtual RID render_target_get_texture(RID p_render_target) = 0;
 


### PR DESCRIPTION
When using foveated rendering on Vulkan, we are using a fragment density map (FDM) from OpenXR that tells the GPU to render some parts of the frame in a lower resolution (generally the parts around the edge, or outside of the area the player's eye is looking at when eye-tracking is available).

However, as far as I understand it, in Godot's current implementation all of the output pixels in the low resolution areas still get set (perhaps by copying the pixels multiple times to fill in the lower resolution areas?).

But if we switch to rendering to Vulkan subsampled images, it'll store the data in a such a way that it doesn't store all the output pixels, and is somehow better optimized for tile memory. Or, something - I'm not a rendering expert :-)

**This has been shown to produce a nice performance boost on both Meta Quest 3 and Samsung Galaxy XR in [my fork of the GDQuest TPS demo](https://github.com/dsnopek/gdquest-tps-demo/tree/standalone-vr-benchmark).**

## Benchmarks

My benchmarks fix the camera at 3 specific spots in the scene and gather some stats. 

As you can see below, there is a reproducible ~1ms improvement in frame times!

### Meta Quest 3

#### Before

| Marker  | Frame Time (ms) | FPS |
| ------- | --------------- | --- |
| Marker1 | 14.64           | 68  |
| Marker2 | 17.36           | 57  |
| Marker3 | 13.89           | 72  |

#### After

| Marker  | Frame Time (ms) | FPS |
| ------- | --------------- | --- |
| Marker1 | 13.89           | 72  |
| Marker2 | 15.79           | 64  |
| Marker3 | 13.89           | 72  |

### Samsung Galaxy XR

I ran the Meta Quest tests at 72fps, but the FDM provided by OpenXR on Samsung Galaxy XR is much more extreme than on Quest, so I had to run them at 90fps in order to show the difference.

#### Before

| Marker  | Frame Time (ms) | FPS |
| ------- | --------------- | --- |
| Marker1 | 12.28           | 82  |
| Marker2 | 13.66           | 73  |
| Marker3 | 11.13           | 90  |

#### After

| Marker  | Frame Time (ms) | FPS |
| ------- | --------------- | --- |
| Marker1 | 11.17           | 90  |
| Marker2 | 12.54           | 80  |
| Marker3 | 11.11           | 90  |

## Issues

### ~~Meta Quest~~

~~Unfortunately, this PR doesn't work on Meta Quest: instead of rendering correctly, the full frame is a blurry gradient of color that changes subtly depending on the direction you are looking.~~

~~There is a variant of this PR that _does_ work on Meta Quest, and that's where only Godot's render buffers use subsampled images but the OpenXR swapchain doesn't (see the `@todo` comments in the PR). This runs fine!~~

~~However, in that variant, I don't see any performance improvement on either Meta Quest or Samsung Galaxy XR, so it wouldn't be worth doing.~~

**UPDATE:** Meta Quest is working now!

### ~~Sampling the color or depth texture~~

~~Everything works fine if we never sample the color or depth texture, either in a custom shader, or by using an effect or feature that will cause Godot to switch from using a subpass for tonemapping to using a normal render pass (which will happen if you enabled FXAA or glow, for example).~~

~~I think this could be fixed by using a sampler that's created with the `VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT` flag, but I haven't figured out a good way to do that in Godot's renderer yet.~~

~~One option, is we just say we don't support subsampled images in that case (which is what's currently documented in this PR). However, it would be great to allow all features to work.~~

**UPDATE:** Now, subsampled images will be automatically disabled if any incompatible rendering features are enabled.