### PR TITLE
[Metal] Remove glslang memory decorations.

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -434,6 +434,7 @@ Files extracted from upstream source:
 Patches:
 
 - `0001-apple-disable-absolute-paths.patch` ([GH-92010](https://github.com/godotengine/godot/pull/92010))
+- `0002-apple-m1-msaa-fix.patch` ([GH-115893](https://github.com/godotengine/godot/issues/115893))
 
 
 ## graphite

--- a/thirdparty/glslang/SPIRV/GlslangToSpv.cpp
+++ b/thirdparty/glslang/SPIRV/GlslangToSpv.cpp
@@ -5181,6 +5181,11 @@ spv::Id TGlslangToSpvTraverser::createSpvVariable(const glslang::TIntermSymbol* 
     glslang::TQualifier typeQualifier = node->getType().getQualifier();
     TranslateMemoryDecoration(typeQualifier, topLevelDecorations, glslangIntermediate->usingVulkanMemoryModel());
     for (auto deco : topLevelDecorations) {
+#ifdef __APPLE__
+        if (deco != spv::Decoration::Restrict &&
+            deco != spv::Decoration::RestrictPointer &&
+            deco != spv::Decoration::RestrictPointerEXT)
+#endif
         builder.addDecoration(var, deco);
     }
     return var;

--- a/thirdparty/glslang/patches/0002-apple-m1-msaa-fix.patch
+++ b/thirdparty/glslang/patches/0002-apple-m1-msaa-fix.patch
@@ -1,0 +1,16 @@
+diff --git a/thirdparty/glslang/SPIRV/GlslangToSpv.cpp b/thirdparty/glslang/SPIRV/GlslangToSpv.cpp
+index 1a5c40c53a..d4af42f70b 100644
+--- a/thirdparty/glslang/SPIRV/GlslangToSpv.cpp
++++ b/thirdparty/glslang/SPIRV/GlslangToSpv.cpp
+@@ -5181,6 +5181,11 @@ spv::Id TGlslangToSpvTraverser::createSpvVariable(const glslang::TIntermSymbol*
+     glslang::TQualifier typeQualifier = node->getType().getQualifier();
+     TranslateMemoryDecoration(typeQualifier, topLevelDecorations, glslangIntermediate->usingVulkanMemoryModel());
+     for (auto deco : topLevelDecorations) {
++#ifdef __APPLE__
++        if (deco != spv::Decoration::Restrict &&
++            deco != spv::Decoration::RestrictPointer &&
++            deco != spv::Decoration::RestrictPointerEXT)
++#endif
+         builder.addDecoration(var, deco);
+     }
+     return var;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/115893

Note: make sure to remove project shader cache (`.godot/shader_cache` folder) before testing.