### PR TITLE
Fix OpenXR with Vulkan on Android

### DIFF
--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -715,6 +715,7 @@ void DisplayServerAndroid::free_vulkan_global_context() {
 	if (rendering_context_global != nullptr) {
 		memdelete(rendering_context_global);
 		rendering_context_global = nullptr;
+		rendering_context_global_checked = false;
 	}
 }
 #endif
@@ -781,6 +782,7 @@ DisplayServerAndroid::DisplayServerAndroid(const String &p_rendering_driver, Dis
 
 #ifdef VULKAN_ENABLED
 	if (rendering_driver == "vulkan") {
+		check_vulkan_global_context(true);
 		if (rendering_context_global == nullptr) {
 			ERR_PRINT("Can't initialize display server with Vulkan driver because no Vulkan context is available.");
 			r_error = ERR_UNAVAILABLE;

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -515,6 +515,22 @@ JNIEXPORT jobjectArray JNICALL Java_org_godotengine_godot_GodotLib_getRendererIn
 		rendering_driver_chosen = RenderingServer::get_singleton()->get_current_rendering_driver_name();
 		rendering_method = RenderingServer::get_singleton()->get_current_rendering_method();
 	}
+#ifndef XR_DISABLED
+	// When running in XR mode, vulkan initialization must be done by the XR module, so we ensure that the vulkan
+	// global context is reset.
+	// Note: This is temporary workaround to address https://github.com/godotengine/godot/issues/115924
+	// A proper fix involves updating the Android init flow so that DisplayServerAndroid can update the Android surface
+	// type (vulkan or opengl) after it's initialized.
+	bool xr_enabled = false;
+	if (XRServer::get_xr_mode() == XRServer::XRMODE_DEFAULT) {
+		xr_enabled = GLOBAL_GET_CACHED(bool, "xr/shaders/enabled");
+	} else {
+		xr_enabled = XRServer::get_xr_mode() == XRServer::XRMODE_ON;
+	}
+	if (xr_enabled) {
+		DisplayServerAndroid::free_vulkan_global_context();
+	}
+#endif // XR_DISABLED
 #endif
 
 	String rendering_driver_source = rendering_source_to_string(OS::get_singleton()->get_current_rendering_driver_name_source());


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/114922
Fixes https://github.com/godotengine/godot/issues/115924

When running in XR mode, the fix resets the Android global vulkan context introduced in https://github.com/godotengine/godot/pull/114922 to allow the XR module to drive the initialization via vulkan hooks.

Tested on Galaxy XR and Meta Quest 3 devices.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
