### PR TITLE
Manual physics stepping

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -430,6 +430,17 @@ bool Engine::is_embedded_in_editor() const {
 	return embedded_in_editor;
 }
 
+void Engine::set_physics_iteration_callback(PhysicsIterationCallback p_callback) {
+	physics_iteration_callback = p_callback;
+}
+
+bool Engine::physics_iteration(double p_delta) {
+	if (physics_iteration_callback) {
+		return physics_iteration_callback(p_delta);
+	}
+	return false;
+}
+
 Engine::Engine() {
 	singleton = this;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -44,6 +44,7 @@ class Engine {
 	// Called by main loop when built-in stepping is disabled. Set from main.cpp.
 	using PhysicsIterationCallback = bool (*)(double);
 	PhysicsIterationCallback physics_iteration_callback = nullptr;
+
 public:
 	struct Singleton {
 		StringName name;

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -41,6 +41,9 @@ template <typename T>
 class TypedArray;
 
 class Engine {
+	// Called by main loop when built-in stepping is disabled. Set from main.cpp.
+	using PhysicsIterationCallback = bool (*)(double);
+	PhysicsIterationCallback physics_iteration_callback = nullptr;
 public:
 	struct Singleton {
 		StringName name;
@@ -223,6 +226,11 @@ public:
 	void set_freeze_time_scale(bool p_frozen);
 	void set_embedded_in_editor(bool p_enabled);
 	bool is_embedded_in_editor() const;
+
+	// Manual physics stepping: call once per physics step when built-in stepping is disabled.
+	// Returns true if the main loop should exit (e.g. scene tree requested quit).
+	void set_physics_iteration_callback(PhysicsIterationCallback p_callback);
+	bool physics_iteration(double p_delta);
 
 	Engine();
 	virtual ~Engine();

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2050,6 +2050,10 @@ bool Engine::is_embedded_in_editor() const {
 	return ::Engine::get_singleton()->is_embedded_in_editor();
 }
 
+bool Engine::physics_iteration(double p_delta) {
+	return ::Engine::get_singleton()->physics_iteration(p_delta);
+}
+
 String Engine::get_write_movie_path() const {
 	return ::Engine::get_singleton()->get_write_movie_path();
 }
@@ -2129,6 +2133,8 @@ void Engine::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_editor_hint"), &Engine::is_editor_hint);
 	ClassDB::bind_method(D_METHOD("is_embedded_in_editor"), &Engine::is_embedded_in_editor);
+
+	ClassDB::bind_method(D_METHOD("physics_iteration", "delta"), &Engine::physics_iteration);
 
 	ClassDB::bind_method(D_METHOD("get_write_movie_path"), &Engine::get_write_movie_path);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -624,6 +624,9 @@ public:
 
 	bool is_embedded_in_editor() const;
 
+	// Run one physics step (sync, physics_process, navigation, step). Use when built-in physics stepping is disabled.
+	bool physics_iteration(double p_delta);
+
 	// `set_write_movie_path()` is not exposed to the scripting API as changing it at run-time has no effect.
 	String get_write_movie_path() const;
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -624,7 +624,6 @@ public:
 
 	bool is_embedded_in_editor() const;
 
-	// Run one physics step (sync, physics_process, navigation, step). Use when built-in physics stepping is disabled.
 	bool physics_iteration(double p_delta);
 
 	// `set_write_movie_path()` is not exposed to the scripting API as changing it at run-time has no effect.

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -113,16 +113,6 @@
 				Returns the fraction through the current physics tick we are at the time of rendering the frame. This can be used to implement fixed timestep interpolation.
 			</description>
 		</method>
-		<method name="physics_iteration">
-			<return type="bool" />
-			<param index="0" name="delta" type="float" />
-			<description>
-				Runs one physics step: synchronizes the physics servers, calls [method Node._physics_process] on the scene tree, runs navigation and physics stepping, then flushes the message queue. Use this when [member ProjectSettings.physics/common/use_builtin_physics_stepping] is [code]false[/code] to drive physics manually (e.g. for rollback netcode or custom tick rates).
-				[param delta] should typically be the fixed physics step in seconds, e.g. [code]1.0 / Engine.physics_ticks_per_second[/code].
-				Returns [code]true[/code] if the main loop should exit (e.g. the scene tree requested quit during [method Node._physics_process]); otherwise returns [code]false[/code].
-				[b]Note:[/b] When built-in physics stepping is disabled, you must call this method yourself each time you want to advance the physics simulation. Calling it from [method Node._process] is a common approach.
-			</description>
-		</method>
 		<method name="get_process_frames" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -282,6 +272,16 @@
 				func _physics_process(delta):
 					print(Engine.is_in_physics_frame()) # Prints true
 				[/codeblock]
+			</description>
+		</method>
+		<method name="physics_iteration">
+			<return type="bool" />
+			<param index="0" name="delta" type="float" />
+			<description>
+				Runs one physics step: synchronizes the physics servers, calls [method Node._physics_process] on the scene tree, runs navigation and physics stepping, then flushes the message queue. Use this when [member ProjectSettings.physics/common/use_builtin_physics_stepping] is [code]false[/code] to drive physics manually (e.g. for rollback netcode or custom tick rates).
+				[param delta] should typically be the fixed physics step in seconds, e.g. [code]1.0 / Engine.physics_ticks_per_second[/code].
+				Returns [code]true[/code] if the main loop should exit (e.g. the scene tree requested quit during [method Node._physics_process]); otherwise returns [code]false[/code].
+				[b]Note:[/b] When built-in physics stepping is disabled, you must call this method yourself each time you want to advance the physics simulation. Calling it from [method Node._process] is a common approach.
 			</description>
 		</method>
 		<method name="register_script_language">

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -113,6 +113,16 @@
 				Returns the fraction through the current physics tick we are at the time of rendering the frame. This can be used to implement fixed timestep interpolation.
 			</description>
 		</method>
+		<method name="physics_iteration">
+			<return type="bool" />
+			<param index="0" name="delta" type="float" />
+			<description>
+				Runs one physics step: synchronizes the physics servers, calls [method Node._physics_process] on the scene tree, runs navigation and physics stepping, then flushes the message queue. Use this when [member ProjectSettings.physics/common/use_builtin_physics_stepping] is [code]false[/code] to drive physics manually (e.g. for rollback netcode or custom tick rates).
+				[param delta] should typically be the fixed physics step in seconds, e.g. [code]1.0 / Engine.physics_ticks_per_second[/code].
+				Returns [code]true[/code] if the main loop should exit (e.g. the scene tree requested quit during [method Node._physics_process]); otherwise returns [code]false[/code].
+				[b]Note:[/b] When built-in physics stepping is disabled, you must call this method yourself each time you want to advance the physics simulation. Calling it from [method Node._process] is a common approach.
+			</description>
+		</method>
 		<method name="get_process_frames" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2682,6 +2682,11 @@
 			[b]Note:[/b] Only [member physics/common/max_physics_steps_per_frame] physics ticks may be simulated per rendered frame at most. If more physics ticks have to be simulated per rendered frame to keep up with rendering, the project will appear to slow down (even if [code]delta[/code] is used consistently in physics calculations). Therefore, it is recommended to also increase [member physics/common/max_physics_steps_per_frame] if increasing [member physics/common/physics_ticks_per_second] significantly above its default value.
 			[b]Note:[/b] Consider enabling [url=$DOCS_URL/tutorials/physics/interpolation/index.html]physics interpolation[/url] if you change [member physics/common/physics_ticks_per_second] to a value that is not a multiple of [code]60[/code]. Using physics interpolation will avoid jittering when the monitor refresh rate and physics update rate don't exactly match.
 		</member>
+		<member name="physics/common/use_builtin_physics_stepping" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], the main loop runs physics automatically each frame (sync, [method Node._physics_process], navigation, and physics step) according to [member physics/common/physics_ticks_per_second] and [member physics/common/max_physics_steps_per_frame]. This is the default behavior.
+			If [code]false[/code], the main loop does not run physics. You must advance physics manually by calling [method Engine.physics_iteration] (e.g. from [method Node._process]) with the desired [code]delta[/code] (typically [code]1.0 / Engine.physics_ticks_per_second[/code]). Use this for custom physics control such as rollback netcode or deterministic replay.
+			[b]Note:[/b] This property is only read when the project starts. Changing it at runtime has no effect until the next run.
+		</member>
 		<member name="physics/jolt_physics_3d/collisions/active_edge_threshold" type="float" setter="" getter="" default="0.87266463">
 			The maximum angle, in radians, between two adjacent triangles in a [ConcavePolygonShape3D] or [HeightMapShape3D] for which the edge between those triangles is considered inactive.
 			Collisions against an inactive edge will have its normal overridden to instead be the surface normal of the triangle. This can help alleviate ghost collisions.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2176,6 +2176,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	Engine::get_singleton()->set_physics_ticks_per_second(GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "physics/common/physics_ticks_per_second", PROPERTY_HINT_RANGE, "1,1000,1"), 60));
 	Engine::get_singleton()->set_max_physics_steps_per_frame(GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "physics/common/max_physics_steps_per_frame", PROPERTY_HINT_RANGE, "1,100,1"), 8));
+	GLOBAL_DEF(PropertyInfo(Variant::BOOL, "physics/common/use_builtin_physics_stepping", PROPERTY_HINT_NONE, ""), true);
 	Engine::get_singleton()->set_physics_jitter_fix(GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/common/physics_jitter_fix", PROPERTY_HINT_RANGE, "0,2,0.001,or_greater"), 0.5));
 	Engine::get_singleton()->set_max_fps(GLOBAL_DEF(PropertyInfo(Variant::INT, "application/run/max_fps", PROPERTY_HINT_RANGE, "0,1000,1"), 0));
 	if (max_fps >= 0) {
@@ -2846,6 +2847,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	Engine::get_singleton()->set_frame_delay(frame_delay);
 
 	message_queue = memnew(MessageQueue);
+
+	Engine::get_singleton()->set_physics_iteration_callback(Main::physics_iteration);
 
 	Thread::release_main_thread(); // If setup2() is called from another thread, that one will become main thread, so preventively release this one.
 	set_current_thread_safe_for_nodes(false);
@@ -4792,6 +4795,97 @@ static uint64_t physics_process_max = 0;
 static uint64_t process_max = 0;
 static uint64_t navigation_process_max = 0;
 
+// Last physics_iteration() tick counts; read by Main::iteration() to update local profiling vars.
+static uint64_t s_physics_iteration_ticks = 0;
+#if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
+static uint64_t s_navigation_iteration_ticks = 0;
+#endif
+
+bool Main::physics_iteration(double delta) {
+	GodotProfileZone("Physics Step");
+	GodotProfileZoneGroupedFirst(_physics_zone, "setup");
+	if (Input::get_singleton()->is_agile_input_event_flushing()) {
+		Input::get_singleton()->flush_buffered_events();
+	}
+
+	Engine::get_singleton()->_in_physics = true;
+	Engine::get_singleton()->_physics_frames++;
+
+	uint64_t physics_begin = OS::get_singleton()->get_ticks_usec();
+
+	// Prepare the fixed timestep interpolated nodes BEFORE they are updated
+	// by the physics server, otherwise the current and previous transforms
+	// may be the same, and no interpolation takes place.
+	GodotProfileZoneGrouped(_physics_zone, "main loop iteration prepare");
+	OS::get_singleton()->get_main_loop()->iteration_prepare();
+
+#ifndef PHYSICS_3D_DISABLED
+	GodotProfileZoneGrouped(_physics_zone, "PhysicsServer3D::sync");
+	PhysicsServer3D::get_singleton()->sync();
+	PhysicsServer3D::get_singleton()->flush_queries();
+#endif // PHYSICS_3D_DISABLED
+
+#ifndef PHYSICS_2D_DISABLED
+	GodotProfileZoneGrouped(_physics_zone, "PhysicsServer2D::sync");
+	PhysicsServer2D::get_singleton()->sync();
+	PhysicsServer2D::get_singleton()->flush_queries();
+#endif // PHYSICS_2D_DISABLED
+
+	GodotProfileZoneGrouped(_physics_zone, "physics_process");
+	if (OS::get_singleton()->get_main_loop()->physics_process(delta)) {
+#ifndef PHYSICS_3D_DISABLED
+		PhysicsServer3D::get_singleton()->end_sync();
+#endif // PHYSICS_3D_DISABLED
+#ifndef PHYSICS_2D_DISABLED
+		PhysicsServer2D::get_singleton()->end_sync();
+#endif // PHYSICS_2D_DISABLED
+
+		Engine::get_singleton()->_in_physics = false;
+		return true;
+	}
+
+#if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
+	uint64_t navigation_begin = OS::get_singleton()->get_ticks_usec();
+
+#ifndef NAVIGATION_2D_DISABLED
+	GodotProfileZoneGrouped(_profile_zone, "NavigationServer2D::physics_process");
+	NavigationServer2D::get_singleton()->physics_process(delta);
+#endif // NAVIGATION_2D_DISABLED
+#ifndef NAVIGATION_3D_DISABLED
+	GodotProfileZoneGrouped(_profile_zone, "NavigationServer3D::physics_process");
+	NavigationServer3D::get_singleton()->physics_process(delta);
+#endif // NAVIGATION_3D_DISABLED
+
+	s_navigation_iteration_ticks = OS::get_singleton()->get_ticks_usec() - navigation_begin;
+	navigation_process_max = MAX(s_navigation_iteration_ticks, navigation_process_max);
+
+	message_queue->flush();
+#endif // !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
+
+#ifndef PHYSICS_3D_DISABLED
+	GodotProfileZoneGrouped(_profile_zone, "3D physics");
+	PhysicsServer3D::get_singleton()->end_sync();
+	PhysicsServer3D::get_singleton()->step(delta);
+#endif // PHYSICS_3D_DISABLED
+
+#ifndef PHYSICS_2D_DISABLED
+	GodotProfileZoneGrouped(_profile_zone, "2D physics");
+	PhysicsServer2D::get_singleton()->end_sync();
+	PhysicsServer2D::get_singleton()->step(delta);
+#endif // PHYSICS_2D_DISABLED
+
+	message_queue->flush();
+
+	GodotProfileZoneGrouped(_profile_zone, "main loop iteration end");
+	OS::get_singleton()->get_main_loop()->iteration_end();
+
+	s_physics_iteration_ticks = OS::get_singleton()->get_ticks_usec() - physics_begin;
+	physics_process_max = MAX(s_physics_iteration_ticks, physics_process_max);
+
+	Engine::get_singleton()->_in_physics = false;
+	return false;
+}
+
 // Return false means iterating further, returning true means `OS::run`
 // will terminate the program. In case of failure, the OS exit code needs
 // to be set explicitly here (defaults to EXIT_SUCCESS).
@@ -4844,89 +4938,17 @@ bool Main::iteration() {
 #endif // XR_DISABLED
 
 	GodotProfileZoneGrouped(_profile_zone, "physics");
-	for (int iters = 0; iters < advance.physics_steps; ++iters) {
-		GodotProfileZone("Physics Step");
-		GodotProfileZoneGroupedFirst(_physics_zone, "setup");
-		if (Input::get_singleton()->is_agile_input_event_flushing()) {
-			Input::get_singleton()->flush_buffered_events();
-		}
-
-		Engine::get_singleton()->_in_physics = true;
-		Engine::get_singleton()->_physics_frames++;
-
-		uint64_t physics_begin = OS::get_singleton()->get_ticks_usec();
-
-		// Prepare the fixed timestep interpolated nodes BEFORE they are updated
-		// by the physics server, otherwise the current and previous transforms
-		// may be the same, and no interpolation takes place.
-		GodotProfileZoneGrouped(_physics_zone, "main loop iteration prepare");
-		OS::get_singleton()->get_main_loop()->iteration_prepare();
-
-#ifndef PHYSICS_3D_DISABLED
-		GodotProfileZoneGrouped(_physics_zone, "PhysicsServer3D::sync");
-		PhysicsServer3D::get_singleton()->sync();
-		PhysicsServer3D::get_singleton()->flush_queries();
-#endif // PHYSICS_3D_DISABLED
-
-#ifndef PHYSICS_2D_DISABLED
-		GodotProfileZoneGrouped(_physics_zone, "PhysicsServer2D::sync");
-		PhysicsServer2D::get_singleton()->sync();
-		PhysicsServer2D::get_singleton()->flush_queries();
-#endif // PHYSICS_2D_DISABLED
-
-		GodotProfileZoneGrouped(_physics_zone, "physics_process");
-		if (OS::get_singleton()->get_main_loop()->physics_process(physics_step * time_scale)) {
-#ifndef PHYSICS_3D_DISABLED
-			PhysicsServer3D::get_singleton()->end_sync();
-#endif // PHYSICS_3D_DISABLED
-#ifndef PHYSICS_2D_DISABLED
-			PhysicsServer2D::get_singleton()->end_sync();
-#endif // PHYSICS_2D_DISABLED
-
-			Engine::get_singleton()->_in_physics = false;
-			exit = true;
-			break;
-		}
-
+	if (GLOBAL_GET_CACHED(bool, "physics/common/use_builtin_physics_stepping")) {
+		for (int iters = 0; iters < advance.physics_steps; ++iters) {
+			if (Main::physics_iteration(physics_step * time_scale)) {
+				exit = true;
+				break;
+			}
+			physics_process_ticks = MAX(physics_process_ticks, s_physics_iteration_ticks);
 #if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
-		uint64_t navigation_begin = OS::get_singleton()->get_ticks_usec();
-
-#ifndef NAVIGATION_2D_DISABLED
-		GodotProfileZoneGrouped(_profile_zone, "NavigationServer2D::physics_process");
-		NavigationServer2D::get_singleton()->physics_process(physics_step * time_scale);
-#endif // NAVIGATION_2D_DISABLED
-#ifndef NAVIGATION_3D_DISABLED
-		GodotProfileZoneGrouped(_profile_zone, "NavigationServer3D::physics_process");
-		NavigationServer3D::get_singleton()->physics_process(physics_step * time_scale);
-#endif // NAVIGATION_3D_DISABLED
-
-		navigation_process_ticks = MAX(navigation_process_ticks, OS::get_singleton()->get_ticks_usec() - navigation_begin); // keep the largest one for reference
-		navigation_process_max = MAX(OS::get_singleton()->get_ticks_usec() - navigation_begin, navigation_process_max);
-
-		message_queue->flush();
-#endif // !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
-
-#ifndef PHYSICS_3D_DISABLED
-		GodotProfileZoneGrouped(_profile_zone, "3D physics");
-		PhysicsServer3D::get_singleton()->end_sync();
-		PhysicsServer3D::get_singleton()->step(physics_step * time_scale);
-#endif // PHYSICS_3D_DISABLED
-
-#ifndef PHYSICS_2D_DISABLED
-		GodotProfileZoneGrouped(_profile_zone, "2D physics");
-		PhysicsServer2D::get_singleton()->end_sync();
-		PhysicsServer2D::get_singleton()->step(physics_step * time_scale);
-#endif // PHYSICS_2D_DISABLED
-
-		message_queue->flush();
-
-		GodotProfileZoneGrouped(_profile_zone, "main loop iteration end");
-		OS::get_singleton()->get_main_loop()->iteration_end();
-
-		physics_process_ticks = MAX(physics_process_ticks, OS::get_singleton()->get_ticks_usec() - physics_begin); // keep the largest one for reference
-		physics_process_max = MAX(OS::get_singleton()->get_ticks_usec() - physics_begin, physics_process_max);
-
-		Engine::get_singleton()->_in_physics = false;
+			navigation_process_ticks = MAX(navigation_process_ticks, s_navigation_iteration_ticks);
+#endif
+		}
 	}
 
 	if (Input::get_singleton()->is_agile_input_event_flushing()) {
@@ -4987,6 +5009,12 @@ bool Main::iteration() {
 
 	GodotProfileZoneGrouped(_profile_zone, "AudioServer::update");
 	AudioServer::get_singleton()->update();
+
+	// Include physics ticks from manual Engine.physics_iteration() calls (when use_builtin_physics_stepping is false).
+	physics_process_ticks = MAX(physics_process_ticks, s_physics_iteration_ticks);
+#if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
+	navigation_process_ticks = MAX(navigation_process_ticks, s_navigation_iteration_ticks);
+#endif
 
 	if (EngineDebugger::is_active()) {
 		EngineDebugger::get_singleton()->iteration(frame_time, process_ticks, physics_process_ticks, physics_step);

--- a/main/main.h
+++ b/main/main.h
@@ -80,7 +80,6 @@ public:
 	static int start();
 
 	static bool iteration();
-	// One physics step (sync, physics_process, navigation, step). Used when use_builtin_physics_stepping is true or via Engine.physics_iteration().
 	static bool physics_iteration(double delta);
 	static void force_redraw();
 

--- a/main/main.h
+++ b/main/main.h
@@ -80,6 +80,8 @@ public:
 	static int start();
 
 	static bool iteration();
+	// One physics step (sync, physics_process, navigation, step). Used when use_builtin_physics_stepping is true or via Engine.physics_iteration().
+	static bool physics_iteration(double delta);
 	static void force_redraw();
 
 	static bool is_iterating();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/2821.

This PR presents two user-facing changes:
1. A Physics → Common → Use Builtin Physics Stepping setting that defaults to `true`.
2. The `Engine.physics_iteration(delta: float) -> bool` method of the Engine global.

I hope that this is a less impactful change than https://github.com/godotengine/godot/pull/76462 which, without a Godot physics lead, the maintainers have been understandably cautious of merging. The changes herein are purely internal to the engine, use existing behaviour wherever possible, and have no effect on the external PhysicsServer2/3D API, thereby avoiding the need for external adoption.

> [!NOTE]  
> This PR does not, on its own, enable physics rollback. That is a complex and nuanced operation. Refer to the conversation in https://github.com/godotengine/godot/pull/76462 for more context.

## Implementation

The [`bool Main::iteration(double delta)`](https://github.com/godotengine/godot/blob/20d58a38c67b956d007e594c551dab39bd68efc1/main/main.cpp#L4793) method has been split in two. All physics-related logic is now performed in `bool Main::physics_iteration(double delta)`. Determined by the Physics → Common → Use Builtin Physics Stepping setting, the main loop `Main::iteration` calls the physics loop `Main::physics_iteration`. As this setting defaults to `true`, default behaviour remains unchanged.

The `Engine` global now registers a `physics_iteration_callback` function pointer property that can be invoked, if set, using `bool Engine::physics_iteration(double p_delta)`. This callback is set by the main loop in `Main::setup` and points to `Main::physics_iteration`.

The `Engine` global exposes its `physics_iteration` method in [`core_bind`](https://github.com/godotengine/godot/blob/20d58a38c67b956d007e594c551dab39bd68efc1/core/core_bind.cpp), following the pattern set by other global singleton methods. This can be invoked in GDScript via `Engine.physics_iteration(delta: float)`.

## Alternatives

This exposes similar functionality to the contentious [PhysicsServer2/3D::space_step() PR#76462](https://github.com/godotengine/godot/pull/76462). However, it differs in several key ways. I'll include some criticisms of the aforementioned PR below, although I believe @Daylily-Zeleen has done an incredible job and has dutifully updated the PR over many years 👏👏👏

The key differences between this PR and PR#76462 are:
1. This PR does not enable manually stepping a single physics space.
2. This PR allows for the complete disabling of main loop physics iteration. With PR#76462, the physics server is still stepped each typical physics frame.
4. This PR triggers all side effects typically triggered by Godot. This includes the [`SceneTree.physics_frame`](https://docs.godotengine.org/en/stable/classes/class_scenetree.html#class-scenetree-signal-physics-frame) signal being fired and [`Node.physics_process`](https://docs.godotengine.org/en/stable/classes/class_node.html#class-node-private-method-physics-process) methods being called.

With the utmost respect, I believe PR#76462 is lacking in the following ways:
1. PR#76462 requires the cooperation of all physics server implementations while this PR is more encapsulated, albeit higher level, as it targets the core engine loop rather than PhysicsServer2/3D.
2. PR#76462 does not align with intuition in that `physics_process` no longer reflects when the processing of physics has occurred. This PR rights that in an attempt to be more intuitive.
4. Documentation and comments in PR#76462 are lacking and, where present, lack clarity. I've strived to include adequate documentation in this PR.
5. PR#76462 exposes `PhysicsServer2/3D.space_flush_queries` to the user. This is an implementation detail that, unfortunately, has been exposed by the PR and is required, depending on the situation, to receive physics notifications e.g. `Area2D.body_entered` when manually stepping physics. The details of flushing queries should be the concern of physics server implementors and the ambiguity of when it's called should be the concern of the engine maintainers. This ambiguity is reflected in the documentation of `PhysicsServer2/3D.space_flush_queries` and `PhysicsServer2/3D.space_step`, can be seen in many comments on the PR, and has made it's way to other libraries including the excellent Rapier Godot plugin. The Godot engine calls `flush_queries` _before_ `step` while many examples of manual stepping reverse this order. I believe the exposure of such a method is a footgun.
6. Finally, it seems counter-intuitive in PR#76462 that e.g. `PhysicsServer2D.step` does not call `PhysicsServer2D.space_step`. In my opinion, stepping the server should merely iterate all active spaces and call `space_step`. This decoupling may result in unexpected discrepancies in behaviour between two seemingly related methods.

## Questions & Concerns

Feedback very welcome on the following:
- When Physics → Common → Use Builtin Physics Stepping is disabled, it effectively renders Physics → Common → Physics Ticks per Second moot. Perhaps the behaviour of this PR when builtin physics stepping is disabled should be triggered when physics frequency is set to 0.
- This has implications for profiling physics timing. The main loop uses a simple `1 / physics_ticks_per_second` that's passed to `EngineDebugger::get_singleton()->iteration` ([source](https://github.com/godotengine/godot/blob/20d58a38c67b956d007e594c551dab39bd68efc1/main/main.cpp#L4987)). Untested and I'm not sure what the solution is here.
- This has small implications for `MainTimerSync` which is passed a physics step in its `advance` method. Ultimately, the calculated physics frame count passed back (in a `MainFrameTime` struct) is ignored if Physics → Common → Use Builtin Physics Stepping is disabled, so this may be a nonissue.
- How does this play with a physics server running on its own thread? I haven't the foggiest and have yet to test. That said, the engines default locking of the physics server (via e.g. `PhysicsServer2D::sync`) remains unchanged, so this may be a nonissue.
- How does this interact with internal tracking of the current physics frame? For example, how does `Input.is_action_just_pressed` behave?
