### PR TITLE
Wayland: Only handle the current output mode

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -1287,6 +1287,10 @@ void WaylandThread::_wl_output_on_mode(void *data, struct wl_output *wl_output, 
 	ScreenState *ss = (ScreenState *)data;
 	ERR_FAIL_NULL(ss);
 
+	if (!(flags & WL_OUTPUT_MODE_CURRENT)) {
+		return;
+	}
+
 	ss->pending_data.size.width = width;
 	ss->pending_data.size.height = height;
 


### PR DESCRIPTION
Fixes #115369.

Some compositors (e.g. COSMIC) can report *all* supported output modes, not just the current mode. This is valid, albeit deprecated, so let's add a check and ignore any non-current output events.

---

This meant that, on certain compositors, `screen_get_size` could return the wrong size, even really tiny stuff like 640x480. That said, even with this fix, the way we handle screens is still a hack and we should not depend on them in the long term.