### PR TITLE
Fix type mismatch in ADD_PROPERTY calls

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1517,6 +1517,19 @@ void ClassDB::add_property(const StringName &p_class, const PropertyInfo &p_pinf
 
 		int exp_args = 1 + (p_index >= 0 ? 1 : 0);
 		ERR_FAIL_COND_MSG(mb_set->get_argument_count() != exp_args, vformat("Invalid function for setter '%s::%s' for property '%s'.", p_class, p_setter, p_pinfo.name));
+
+		// Type of the last arg for the setter function (the value passed in).
+		Variant::Type setter_arg_type = mb_set->get_argument_type(exp_args - 1);
+
+		// If property type and setter arg type are not identical, we want feedback.
+		if (unlikely(setter_arg_type != p_pinfo.type)) {
+			// If the types are not compatible with each other, throw an error!
+			bool possibly_convertible = Variant::can_convert(setter_arg_type, p_pinfo.type) || Variant::can_convert(p_pinfo.type, setter_arg_type);
+			ERR_FAIL_COND_MSG(!possibly_convertible, vformat("Type of property '%s' : '%s' is not convertible to or from the arg type of setter '%s::%s' : '%s'.", p_pinfo.name, Variant::get_type_name(p_pinfo.type), p_class, p_setter, Variant::get_type_name(setter_arg_type)));
+
+			// If not, we want at least a warning
+			WARN_PRINT(vformat("Type of property '%s' : '%s' does not match return type of setter '%s::%s' : '%s'.", p_pinfo.name, Variant::get_type_name(p_pinfo.type), p_class, p_setter, Variant::get_type_name(setter_arg_type)));
+		}
 #endif // DEBUG_ENABLED
 	}
 
@@ -1529,6 +1542,18 @@ void ClassDB::add_property(const StringName &p_class, const PropertyInfo &p_pinf
 
 		int exp_args = 0 + (p_index >= 0 ? 1 : 0);
 		ERR_FAIL_COND_MSG(mb_get->get_argument_count() != exp_args, vformat("Invalid function for getter '%s::%s' for property '%s'.", p_class, p_getter, p_pinfo.name));
+
+		Variant::Type getter_return_type = mb_get->get_return_info().type;
+
+		// If property type and getter return type are not identical, we want feedback.
+		if (unlikely(getter_return_type != p_pinfo.type)) {
+			// If the types are not compatible with each other, throw an error!
+			bool possibly_convertible = Variant::can_convert(getter_return_type, p_pinfo.type) || Variant::can_convert(p_pinfo.type, getter_return_type);
+			ERR_FAIL_COND_MSG(!possibly_convertible, vformat("Type of property '%s' : '%s' is not convertible to or from the return type of getter '%s::%s' : '%s'.", p_pinfo.name, Variant::get_type_name(p_pinfo.type), p_class, p_getter, Variant::get_type_name(mb_get->get_return_info().type)));
+
+			// If not, we want at least a warning
+			WARN_PRINT(vformat("Type of property '%s' : '%s' does not match return type of getter '%s::%s' : '%s'.", p_pinfo.name, Variant::get_type_name(p_pinfo.type), p_class, p_getter, Variant::get_type_name(getter_return_type)));
+		}
 #endif // DEBUG_ENABLED
 	}
 

--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -731,7 +731,7 @@ void EditorSpinSlider::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "suffix"), "set_suffix", "get_suffix");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "read_only"), "set_read_only", "is_read_only");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flat"), "set_flat", "is_flat");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "control_state"), "set_control_state", "get_control_state");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "control_state"), "set_control_state", "get_control_state");
 #ifndef DISABLE_DEPRECATED
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_slider"), "set_hide_slider", "is_hiding_slider");
 #endif

--- a/misc/extension_api_validation/4.6-stable/GH-116237.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-116237.txt
@@ -1,0 +1,44 @@
+GH-116237
+--------------
+Validate extension JSON: Error: Field 'classes/TouchScreenButton/properties/action': type changed value in new API, from "StringName" to "String".
+Validate extension JSON: Error: Field 'classes/VisualShaderNodeVarying/properties/varying_name': type changed value in new API, from "StringName" to "String".
+Validate extension JSON: Error: Field 'classes/VisualShaderNodeParameterRef/properties/parameter_name': type changed value in new API, from "StringName" to "String".
+Validate extension JSON: Error: Field 'classes/VisualShaderNodeParameter/properties/parameter_name': type changed value in new API, from "StringName" to "String".
+Validate extension JSON: Error: Field 'classes/VisualShaderNodeInput/properties/input_name': type changed value in new API, from "StringName" to "String".
+Validate extension JSON: Error: Field 'classes/NavigationMesh/properties/geometry_source_group_name': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/NavigationMeshSourceGeometryData3D/properties/vertices': type changed value in new API, from "PackedVector3Array" to "PackedFloat32Array".
+Validate extension JSON: Error: Field 'classes/BoneAttachment3D/properties/bone_name': type changed value in new API, from "StringName" to "String".
+Validate extension JSON: Error: Field 'classes/XRFaceModifier3D/properties/face_tracker': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/XRHandModifier3D/properties/hand_tracker': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/XRBodyModifier3D/properties/body_tracker': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/XRNode3D/properties/tracker': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/XRNode3D/properties/pose': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/SpringBoneCollision3D/properties/bone_name': type changed value in new API, from "StringName" to "String".
+Validate extension JSON: Error: Field 'classes/GLTFObjectModelProperty/properties/json_pointers': type changed value in new API, from "PackedStringArray" to "Array".
+Validate extension JSON: Error: Field 'classes/NavigationPolygon/properties/source_geometry_group_name': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/ConvexPolygonShape3D/properties/points': type changed value in new API, from "Array" to "PackedVector3Array".
+Validate extension JSON: Error: Field 'classes/EditorSpinSlider/properties/control_state': type changed value in new API, from "bool" to "int".
+Validate extension JSON: Error: Field 'classes/RegExMatch/properties/strings': type changed value in new API, from "Array" to "PackedStringArray".
+Validate extension JSON: Error: Field 'classes/OpenXRMarkerTracker/properties/bounds_size': type changed value in new API, from "int" to "Vector2".
+Validate extension JSON: Error: Field 'classes/OpenXRPlaneTracker/properties/bounds_size': type changed value in new API, from "int" to "Vector2".
+Validate extension JSON: Error: Field 'classes/XRServer/properties/world_origin': type changed value in new API, from "Vector3" to "Transform3D".
+Validate extension JSON: Error: Field 'classes/XRPose/properties/name': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/XRPose/properties/transform': type changed value in new API, from "String" to "Transform3D".
+Validate extension JSON: Error: Field 'classes/XRPose/properties/linear_velocity': type changed value in new API, from "String" to "Vector3".
+Validate extension JSON: Error: Field 'classes/XRPose/properties/angular_velocity': type changed value in new API, from "String" to "Vector3".
+Validate extension JSON: Error: Field 'classes/XRTracker/properties/name': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/RenderSceneBuffersConfiguration/properties/fsr_sharpness': type changed value in new API, from "bool" to "float".
+Validate extension JSON: Error: Field 'classes/RenderSceneBuffersConfiguration/properties/texture_mipmap_bias': type changed value in new API, from "bool" to "float".
+Validate extension JSON: Error: Field 'classes/AudioEffectPitchShift/properties/oversampling': type changed value in new API, from "float" to "int".
+Validate extension JSON: Error: Field 'classes/Window/properties/theme_type_variation': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/WebSocketPeer/properties/heartbeat_interval': type changed value in new API, from "int" to "float".
+Validate extension JSON: Error: Field 'classes/Control/properties/theme_type_variation': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/CodeEdit/properties/line_length_guidelines': type changed value in new API, from "PackedInt32Array" to "Array".
+Validate extension JSON: Error: Field 'classes/CodeEdit/properties/delimiter_strings': type changed value in new API, from "PackedStringArray" to "Array".
+Validate extension JSON: Error: Field 'classes/CodeEdit/properties/delimiter_comments': type changed value in new API, from "PackedStringArray" to "Array".
+Validate extension JSON: Error: Field 'classes/CodeEdit/properties/code_completion_prefixes': type changed value in new API, from "PackedStringArray" to "Array".
+Validate extension JSON: Error: Field 'classes/CodeEdit/properties/indent_automatic_prefixes': type changed value in new API, from "PackedStringArray" to "Array".
+Validate extension JSON: Error: Field 'classes/AnimatedSprite3D/properties/autoplay': type changed value in new API, from "StringName" to "String".
+Validate extension JSON: Error: Field 'classes/AnimatedSprite2D/properties/autoplay': type changed value in new API, from "StringName" to "String".
+
+Type for properties modified to match the return type of getter.

--- a/modules/gltf/structures/gltf_object_model_property.cpp
+++ b/modules/gltf/structures/gltf_object_model_property.cpp
@@ -69,7 +69,7 @@ void GLTFObjectModelProperty::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "godot_to_gltf_expression", PROPERTY_HINT_RESOURCE_TYPE, Expression::get_class_static()), "set_godot_to_gltf_expression", "get_godot_to_gltf_expression"); // Ref<Expression>
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "node_paths", PROPERTY_HINT_TYPE_STRING, "NodePath"), "set_node_paths", "get_node_paths"); // TypedArray<NodePath>
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "object_model_type"), "set_object_model_type", "get_object_model_type"); // GLTFObjectModelType
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "json_pointers"), "set_json_pointers", "get_json_pointers"); // TypedArray<PackedStringArray>
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "json_pointers"), "set_json_pointers", "get_json_pointers"); // TypedArray<PackedStringArray>
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "variant_type"), "set_variant_type", "get_variant_type"); // Variant::Type
 }
 

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
@@ -373,7 +373,7 @@ Variant OpenXRSpatialComponentMarkerList::get_marker_data(RID p_snapshot, int64_
 void OpenXRMarkerTracker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bounds_size", "bounds_size"), &OpenXRMarkerTracker::set_bounds_size);
 	ClassDB::bind_method(D_METHOD("get_bounds_size"), &OpenXRMarkerTracker::get_bounds_size);
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "bounds_size"), "set_bounds_size", "get_bounds_size");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "bounds_size"), "set_bounds_size", "get_bounds_size");
 
 	ClassDB::bind_method(D_METHOD("set_marker_type", "marker_type"), &OpenXRMarkerTracker::set_marker_type);
 	ClassDB::bind_method(D_METHOD("get_marker_type"), &OpenXRMarkerTracker::get_marker_type);

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
@@ -264,7 +264,7 @@ OpenXRSpatialComponentPlaneSemanticLabelList::PlaneSemanticLabel OpenXRSpatialCo
 void OpenXRPlaneTracker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bounds_size", "bounds_size"), &OpenXRPlaneTracker::set_bounds_size);
 	ClassDB::bind_method(D_METHOD("get_bounds_size"), &OpenXRPlaneTracker::get_bounds_size);
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "bounds_size"), "set_bounds_size", "get_bounds_size");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "bounds_size"), "set_bounds_size", "get_bounds_size");
 
 	ClassDB::bind_method(D_METHOD("set_plane_alignment", "plane_alignment"), &OpenXRPlaneTracker::set_plane_alignment);
 	ClassDB::bind_method(D_METHOD("get_plane_alignment"), &OpenXRPlaneTracker::get_plane_alignment);

--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -155,7 +155,7 @@ void RegExMatch::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "subject"), "", "get_subject");
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "names"), "", "get_names");
-	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "strings"), "", "get_strings");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "strings"), "", "get_strings");
 }
 
 void RegEx::_pattern_info(uint32_t what, void *where) const {

--- a/modules/websocket/websocket_peer.cpp
+++ b/modules/websocket/websocket_peer.cpp
@@ -81,7 +81,7 @@ void WebSocketPeer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_queued_packets"), "set_max_queued_packets", "get_max_queued_packets");
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "heartbeat_interval"), "set_heartbeat_interval", "get_heartbeat_interval");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "heartbeat_interval"), "set_heartbeat_interval", "get_heartbeat_interval");
 
 	BIND_ENUM_CONSTANT(WRITE_MODE_TEXT);
 	BIND_ENUM_CONSTANT(WRITE_MODE_BINARY);

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -670,7 +670,7 @@ void AnimatedSprite2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "sprite_frames", PROPERTY_HINT_RESOURCE_TYPE, SpriteFrames::get_class_static()), "set_sprite_frames", "get_sprite_frames");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "animation", PROPERTY_HINT_ENUM, ""), "set_animation", "get_animation");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "autoplay", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_autoplay", "get_autoplay");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "autoplay", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_autoplay", "get_autoplay");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "frame"), "set_frame", "get_frame");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "frame_progress", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_frame_progress", "get_frame_progress");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale"), "set_speed_scale", "get_speed_scale");

--- a/scene/2d/physics/touch_screen_button.cpp
+++ b/scene/2d/physics/touch_screen_button.cpp
@@ -439,7 +439,7 @@ void TouchScreenButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shape_centered"), "set_shape_centered", "is_shape_centered");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shape_visible"), "set_shape_visible", "is_shape_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "passby_press"), "set_passby_press", "is_passby_press_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "action", PROPERTY_HINT_INPUT_NAME, "show_builtin,loose_mode"), "set_action", "get_action");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "action", PROPERTY_HINT_INPUT_NAME, "show_builtin,loose_mode"), "set_action", "get_action");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "visibility_mode", PROPERTY_HINT_ENUM, "Always,TouchScreen Only"), "set_visibility_mode", "get_visibility_mode");
 
 	ADD_SIGNAL(MethodInfo("pressed"));

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -375,7 +375,7 @@ void BoneAttachment3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_external_skeleton", "external_skeleton"), &BoneAttachment3D::set_external_skeleton);
 	ClassDB::bind_method(D_METHOD("get_external_skeleton"), &BoneAttachment3D::get_external_skeleton);
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "bone_name"), "set_bone_name", "get_bone_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "bone_name"), "set_bone_name", "get_bone_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bone_idx"), "set_bone_idx", "get_bone_idx");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "override_pose"), "set_override_pose", "get_override_pose");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_external_skeleton"), "set_use_external_skeleton", "get_use_external_skeleton");

--- a/scene/3d/spring_bone_collision_3d.cpp
+++ b/scene/3d/spring_bone_collision_3d.cpp
@@ -175,7 +175,7 @@ void SpringBoneCollision3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_rotation_offset", "offset"), &SpringBoneCollision3D::set_rotation_offset);
 	ClassDB::bind_method(D_METHOD("get_rotation_offset"), &SpringBoneCollision3D::get_rotation_offset);
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "bone_name"), "set_bone_name", "get_bone_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "bone_name"), "set_bone_name", "get_bone_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bone", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_bone", "get_bone");
 
 	ADD_GROUP("Offset", "");

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1538,7 +1538,7 @@ void AnimatedSprite3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "sprite_frames", PROPERTY_HINT_RESOURCE_TYPE, SpriteFrames::get_class_static()), "set_sprite_frames", "get_sprite_frames");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "animation", PROPERTY_HINT_ENUM, ""), "set_animation", "get_animation");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "autoplay", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_autoplay", "get_autoplay");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "autoplay", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_autoplay", "get_autoplay");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "frame"), "set_frame", "get_frame");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "frame_progress", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_frame_progress", "get_frame_progress");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale"), "set_speed_scale", "get_speed_scale");

--- a/scene/3d/xr/xr_body_modifier_3d.cpp
+++ b/scene/3d/xr/xr_body_modifier_3d.cpp
@@ -43,7 +43,7 @@ void XRBodyModifier3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bone_update", "bone_update"), &XRBodyModifier3D::set_bone_update);
 	ClassDB::bind_method(D_METHOD("get_bone_update"), &XRBodyModifier3D::get_bone_update);
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "body_tracker", PROPERTY_HINT_ENUM_SUGGESTION, "/user/body_tracker"), "set_body_tracker", "get_body_tracker");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "body_tracker", PROPERTY_HINT_ENUM_SUGGESTION, "/user/body_tracker"), "set_body_tracker", "get_body_tracker");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "body_update", PROPERTY_HINT_FLAGS, "Upper Body,Lower Body,Hands"), "set_body_update", "get_body_update");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bone_update", PROPERTY_HINT_ENUM, "Full,Rotation Only"), "set_bone_update", "get_bone_update");
 

--- a/scene/3d/xr/xr_face_modifier_3d.cpp
+++ b/scene/3d/xr/xr_face_modifier_3d.cpp
@@ -495,7 +495,7 @@ static void remove_driven_unified_blend_shapes(RBMap<int, int> &p_blend_mapping)
 void XRFaceModifier3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_face_tracker", "tracker_name"), &XRFaceModifier3D::set_face_tracker);
 	ClassDB::bind_method(D_METHOD("get_face_tracker"), &XRFaceModifier3D::get_face_tracker);
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "face_tracker", PROPERTY_HINT_ENUM_SUGGESTION, "/user/face_tracker"), "set_face_tracker", "get_face_tracker");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "face_tracker", PROPERTY_HINT_ENUM_SUGGESTION, "/user/face_tracker"), "set_face_tracker", "get_face_tracker");
 
 	ClassDB::bind_method(D_METHOD("set_target", "target"), &XRFaceModifier3D::set_target);
 	ClassDB::bind_method(D_METHOD("get_target"), &XRFaceModifier3D::get_target);

--- a/scene/3d/xr/xr_hand_modifier_3d.cpp
+++ b/scene/3d/xr/xr_hand_modifier_3d.cpp
@@ -40,7 +40,7 @@ void XRHandModifier3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bone_update", "bone_update"), &XRHandModifier3D::set_bone_update);
 	ClassDB::bind_method(D_METHOD("get_bone_update"), &XRHandModifier3D::get_bone_update);
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "hand_tracker", PROPERTY_HINT_ENUM_SUGGESTION, "/user/hand_tracker/left,/user/hand_tracker/right"), "set_hand_tracker", "get_hand_tracker");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "hand_tracker", PROPERTY_HINT_ENUM_SUGGESTION, "/user/hand_tracker/left,/user/hand_tracker/right"), "set_hand_tracker", "get_hand_tracker");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bone_update", PROPERTY_HINT_ENUM, "Full,Rotation Only"), "set_bone_update", "get_bone_update");
 
 	BIND_ENUM_CONSTANT(BONE_UPDATE_FULL);

--- a/scene/3d/xr/xr_nodes.cpp
+++ b/scene/3d/xr/xr_nodes.cpp
@@ -246,11 +246,11 @@ XRCamera3D::~XRCamera3D() {
 void XRNode3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_tracker", "tracker_name"), &XRNode3D::set_tracker);
 	ClassDB::bind_method(D_METHOD("get_tracker"), &XRNode3D::get_tracker);
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "tracker", PROPERTY_HINT_ENUM_SUGGESTION), "set_tracker", "get_tracker");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "tracker", PROPERTY_HINT_ENUM_SUGGESTION), "set_tracker", "get_tracker");
 
 	ClassDB::bind_method(D_METHOD("set_pose_name", "pose"), &XRNode3D::set_pose_name);
 	ClassDB::bind_method(D_METHOD("get_pose_name"), &XRNode3D::get_pose_name);
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "pose", PROPERTY_HINT_ENUM_SUGGESTION), "set_pose_name", "get_pose_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "pose", PROPERTY_HINT_ENUM_SUGGESTION), "set_pose_name", "get_pose_name");
 
 	ClassDB::bind_method(D_METHOD("set_show_when_tracked", "show"), &XRNode3D::set_show_when_tracked);
 	ClassDB::bind_method(D_METHOD("get_show_when_tracked"), &XRNode3D::get_show_when_tracked);

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2979,7 +2979,7 @@ void CodeEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "symbol_tooltip_on_hover"), "set_symbol_tooltip_on_hover_enabled", "is_symbol_tooltip_on_hover_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "line_folding"), "set_line_folding_enabled", "is_line_folding_enabled");
 
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "line_length_guidelines"), "set_line_length_guidelines", "get_line_length_guidelines");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "line_length_guidelines"), "set_line_length_guidelines", "get_line_length_guidelines");
 
 	ADD_GROUP("Gutters", "gutters_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gutters_draw_breakpoints_gutter"), "set_draw_breakpoints_gutter", "is_drawing_breakpoints_gutter");
@@ -2995,18 +2995,18 @@ void CodeEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gutters_draw_fold_gutter"), "set_draw_fold_gutter", "is_drawing_fold_gutter");
 
 	ADD_GROUP("Delimiters", "delimiter_");
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "delimiter_strings"), "set_string_delimiters", "get_string_delimiters");
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "delimiter_comments"), "set_comment_delimiters", "get_comment_delimiters");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "delimiter_strings"), "set_string_delimiters", "get_string_delimiters");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "delimiter_comments"), "set_comment_delimiters", "get_comment_delimiters");
 
 	ADD_GROUP("Code Completion", "code_completion_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "code_completion_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_code_completion_enabled", "is_code_completion_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "code_completion_prefixes"), "set_code_completion_prefixes", "get_code_completion_prefixes");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "code_completion_prefixes"), "set_code_completion_prefixes", "get_code_completion_prefixes");
 
 	ADD_GROUP("Indentation", "indent_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "indent_size"), "set_indent_size", "get_indent_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "indent_use_spaces"), "set_indent_using_spaces", "is_indent_using_spaces");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "indent_automatic"), "set_auto_indent_enabled", "is_auto_indent_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "indent_automatic_prefixes"), "set_auto_indent_prefixes", "get_auto_indent_prefixes");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "indent_automatic_prefixes"), "set_auto_indent_prefixes", "get_auto_indent_prefixes");
 
 	ADD_GROUP("Auto Brace Completion", "auto_brace_completion_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_brace_completion_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_auto_brace_completion_enabled", "is_auto_brace_completion_enabled");

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -4318,7 +4318,7 @@ void Control::_bind_methods() {
 
 	ADD_GROUP("Theme", "theme_");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "theme", PROPERTY_HINT_RESOURCE_TYPE, Theme::get_class_static()), "set_theme", "get_theme");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "theme_type_variation", PROPERTY_HINT_ENUM_SUGGESTION), "set_theme_type_variation", "get_theme_type_variation");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "theme_type_variation", PROPERTY_HINT_ENUM_SUGGESTION), "set_theme_type_variation", "get_theme_type_variation");
 
 	BIND_ENUM_CONSTANT(FOCUS_NONE);
 	BIND_ENUM_CONSTANT(FOCUS_CLICK);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -3504,7 +3504,7 @@ void Window::_bind_methods() {
 
 	ADD_GROUP("Theme", "theme_");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "theme", PROPERTY_HINT_RESOURCE_TYPE, Theme::get_class_static()), "set_theme", "get_theme");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "theme_type_variation", PROPERTY_HINT_ENUM_SUGGESTION), "set_theme_type_variation", "get_theme_type_variation");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "theme_type_variation", PROPERTY_HINT_ENUM_SUGGESTION), "set_theme_type_variation", "get_theme_type_variation");
 
 	ADD_SIGNAL(MethodInfo("window_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, InputEvent::get_class_static())));
 	ADD_SIGNAL(MethodInfo("nonclient_window_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, InputEvent::get_class_static())));

--- a/scene/resources/2d/navigation_polygon.cpp
+++ b/scene/resources/2d/navigation_polygon.cpp
@@ -595,7 +595,7 @@ void NavigationPolygon::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "parsed_collision_mask", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_parsed_collision_mask", "get_parsed_collision_mask");
 	ADD_PROPERTY_DEFAULT("parsed_collision_mask", 0xFFFFFFFF);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "source_geometry_mode", PROPERTY_HINT_ENUM, "Root Node Children,Group With Children,Group Explicit"), "set_source_geometry_mode", "get_source_geometry_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_geometry_group_name"), "set_source_geometry_group_name", "get_source_geometry_group_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "source_geometry_group_name"), "set_source_geometry_group_name", "get_source_geometry_group_name");
 	ADD_PROPERTY_DEFAULT("source_geometry_group_name", StringName("navigation_polygon_source_geometry_group"));
 	ADD_GROUP("Cells", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell_size", PROPERTY_HINT_RANGE, "1.0,50.0,1.0,or_greater,suffix:px"), "set_cell_size", "get_cell_size");

--- a/scene/resources/3d/convex_polygon_shape_3d.cpp
+++ b/scene/resources/3d/convex_polygon_shape_3d.cpp
@@ -121,7 +121,7 @@ void ConvexPolygonShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_points", "points"), &ConvexPolygonShape3D::set_points);
 	ClassDB::bind_method(D_METHOD("get_points"), &ConvexPolygonShape3D::get_points);
 
-	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "points"), "set_points", "get_points");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR3_ARRAY, "points"), "set_points", "get_points");
 }
 
 ConvexPolygonShape3D::ConvexPolygonShape3D() :

--- a/scene/resources/3d/navigation_mesh_source_geometry_data_3d.cpp
+++ b/scene/resources/3d/navigation_mesh_source_geometry_data_3d.cpp
@@ -419,7 +419,7 @@ void NavigationMeshSourceGeometryData3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_bounds"), &NavigationMeshSourceGeometryData3D::get_bounds);
 
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR3_ARRAY, "vertices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_vertices", "get_vertices");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT32_ARRAY, "vertices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_vertices", "get_vertices");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "indices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_indices", "get_indices");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "projected_obstructions", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_projected_obstructions", "get_projected_obstructions");
 }

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -635,9 +635,9 @@ void Curve::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_domain", PROPERTY_HINT_RANGE, "-1024,1024,0.01,or_greater,or_less", PROPERTY_USAGE_EDITOR), "set_max_domain", "get_max_domain");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "min_value", PROPERTY_HINT_RANGE, "-1024,1024,0.01,or_greater,or_less", PROPERTY_USAGE_EDITOR), "set_min_value", "get_min_value");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_value", PROPERTY_HINT_RANGE, "-1024,1024,0.01,or_greater,or_less", PROPERTY_USAGE_EDITOR), "set_max_value", "get_max_value");
-	ADD_PROPERTY(PropertyInfo(Variant::NIL, "_limits", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_limits", "_get_limits");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "_limits", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_limits", "_get_limits");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bake_resolution", PROPERTY_HINT_RANGE, "1,1000,1"), "set_bake_resolution", "get_bake_resolution");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
 	ADD_ARRAY_COUNT("Points", "point_count", "set_point_count", "get_point_count", "point_");
 
 	ADD_SIGNAL(MethodInfo(SIGNAL_RANGE_CHANGED));
@@ -1329,7 +1329,7 @@ void Curve2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_data", "data"), &Curve2D::_set_data);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bake_interval", PROPERTY_HINT_RANGE, "0.01,512,0.01"), "set_bake_interval", "get_bake_interval");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
 	ADD_ARRAY_COUNT("Points", "point_count", "set_point_count", "get_point_count", "point_");
 
 	Point defaults;
@@ -2369,7 +2369,7 @@ void Curve3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "closed"), "set_closed", "is_closed");
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bake_interval", PROPERTY_HINT_RANGE, "0.01,512,0.01"), "set_bake_interval", "get_bake_interval");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
 	ADD_ARRAY_COUNT("Points", "point_count", "set_point_count", "get_point_count", "point_");
 
 	ADD_GROUP("Up Vector", "up_vector_");

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -579,7 +579,7 @@ void NavigationMesh::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "geometry_collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY_DEFAULT("geometry_collision_mask", 0xFFFFFFFF);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "geometry_source_geometry_mode", PROPERTY_HINT_ENUM, "Root Node Children,Group With Children,Group Explicit"), "set_source_geometry_mode", "get_source_geometry_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "geometry_source_group_name"), "set_source_group_name", "get_source_group_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "geometry_source_group_name"), "set_source_group_name", "get_source_group_name");
 	ADD_PROPERTY_DEFAULT("geometry_source_group_name", StringName("navigation_mesh_source_group"));
 	ADD_GROUP("Cells", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell_size", PROPERTY_HINT_RANGE, "0.01,500.0,0.01,or_greater,suffix:m"), "set_cell_size", "get_cell_size");

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -3904,7 +3904,7 @@ void VisualShaderNodeInput::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_input_name"), &VisualShaderNodeInput::get_input_name);
 	ClassDB::bind_method(D_METHOD("get_input_real_name"), &VisualShaderNodeInput::get_input_real_name);
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "input_name", PROPERTY_HINT_ENUM, ""), "set_input_name", "get_input_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "input_name", PROPERTY_HINT_ENUM, ""), "set_input_name", "get_input_name");
 	ADD_SIGNAL(MethodInfo("input_type_changed"));
 }
 
@@ -4172,7 +4172,7 @@ void VisualShaderNodeParameterRef::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_parameter_type", "type"), &VisualShaderNodeParameterRef::_set_parameter_type);
 	ClassDB::bind_method(D_METHOD("_get_parameter_type"), &VisualShaderNodeParameterRef::_get_parameter_type);
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "parameter_name", PROPERTY_HINT_ENUM, ""), "set_parameter_name", "get_parameter_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "parameter_name", PROPERTY_HINT_ENUM, ""), "set_parameter_name", "get_parameter_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "param_type", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_parameter_type", "_get_parameter_type");
 }
 
@@ -4470,7 +4470,7 @@ void VisualShaderNodeParameter::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_instance_index", "instance_index"), &VisualShaderNodeParameter::set_instance_index);
 	ClassDB::bind_method(D_METHOD("get_instance_index"), &VisualShaderNodeParameter::get_instance_index);
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "parameter_name"), "set_parameter_name", "get_parameter_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "parameter_name"), "set_parameter_name", "get_parameter_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "qualifier", PROPERTY_HINT_ENUM, "None,Global,Instance,Instance + Index"), "set_qualifier", "get_qualifier");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "instance_index", PROPERTY_HINT_RANGE, "0,15,1"), "set_instance_index", "get_instance_index");
 
@@ -5467,7 +5467,7 @@ void VisualShaderNodeVarying::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_varying_type", "type"), &VisualShaderNodeVarying::set_varying_type);
 	ClassDB::bind_method(D_METHOD("get_varying_type"), &VisualShaderNodeVarying::get_varying_type);
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "varying_name"), "set_varying_name", "get_varying_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "varying_name"), "set_varying_name", "get_varying_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "varying_type", PROPERTY_HINT_ENUM, "Float,Int,Vector2,Vector3,Vector4,Boolean,Transform"), "set_varying_type", "get_varying_type");
 }
 

--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -359,7 +359,7 @@ void AudioEffectPitchShift::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_fft_size"), &AudioEffectPitchShift::get_fft_size);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_pitch_scale", "get_pitch_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "oversampling", PROPERTY_HINT_RANGE, "4,32,1"), "set_oversampling", "get_oversampling");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "oversampling", PROPERTY_HINT_RANGE, "4,32,1"), "set_oversampling", "get_oversampling");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "fft_size", PROPERTY_HINT_ENUM, "256,512,1024,2048,4096"), "set_fft_size", "get_fft_size");
 
 	BIND_ENUM_CONSTANT(FFT_SIZE_256);

--- a/servers/rendering/storage/render_scene_buffers.cpp
+++ b/servers/rendering/storage/render_scene_buffers.cpp
@@ -61,11 +61,11 @@ void RenderSceneBuffersConfiguration::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_fsr_sharpness"), &RenderSceneBuffersConfiguration::get_fsr_sharpness);
 	ClassDB::bind_method(D_METHOD("set_fsr_sharpness", "fsr_sharpness"), &RenderSceneBuffersConfiguration::set_fsr_sharpness);
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fsr_sharpness"), "set_fsr_sharpness", "get_fsr_sharpness");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fsr_sharpness"), "set_fsr_sharpness", "get_fsr_sharpness");
 
 	ClassDB::bind_method(D_METHOD("get_texture_mipmap_bias"), &RenderSceneBuffersConfiguration::get_texture_mipmap_bias);
 	ClassDB::bind_method(D_METHOD("set_texture_mipmap_bias", "texture_mipmap_bias"), &RenderSceneBuffersConfiguration::set_texture_mipmap_bias);
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "texture_mipmap_bias"), "set_texture_mipmap_bias", "get_texture_mipmap_bias");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "texture_mipmap_bias"), "set_texture_mipmap_bias", "get_texture_mipmap_bias");
 
 	ClassDB::bind_method(D_METHOD("get_anisotropic_filtering_level"), &RenderSceneBuffersConfiguration::get_anisotropic_filtering_level);
 	ClassDB::bind_method(D_METHOD("set_anisotropic_filtering_level", "anisotropic_filtering_level"), &RenderSceneBuffersConfiguration::set_anisotropic_filtering_level);

--- a/servers/xr/xr_pose.cpp
+++ b/servers/xr/xr_pose.cpp
@@ -43,20 +43,20 @@ void XRPose::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_name", "name"), &XRPose::set_name);
 	ClassDB::bind_method(D_METHOD("get_name"), &XRPose::get_name);
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "name"), "set_name", "get_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "name"), "set_name", "get_name");
 
 	ClassDB::bind_method(D_METHOD("set_transform", "transform"), &XRPose::set_transform);
 	ClassDB::bind_method(D_METHOD("get_transform"), &XRPose::get_transform);
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "transform"), "set_transform", "get_transform");
+	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM3D, "transform"), "set_transform", "get_transform");
 	ClassDB::bind_method(D_METHOD("get_adjusted_transform"), &XRPose::get_adjusted_transform);
 
 	ClassDB::bind_method(D_METHOD("set_linear_velocity", "velocity"), &XRPose::set_linear_velocity);
 	ClassDB::bind_method(D_METHOD("get_linear_velocity"), &XRPose::get_linear_velocity);
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "linear_velocity"), "set_linear_velocity", "get_linear_velocity");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "linear_velocity"), "set_linear_velocity", "get_linear_velocity");
 
 	ClassDB::bind_method(D_METHOD("set_angular_velocity", "velocity"), &XRPose::set_angular_velocity);
 	ClassDB::bind_method(D_METHOD("get_angular_velocity"), &XRPose::get_angular_velocity);
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "angular_velocity"), "set_angular_velocity", "get_angular_velocity");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "angular_velocity"), "set_angular_velocity", "get_angular_velocity");
 
 	ClassDB::bind_method(D_METHOD("set_tracking_confidence", "tracking_confidence"), &XRPose::set_tracking_confidence);
 	ClassDB::bind_method(D_METHOD("get_tracking_confidence"), &XRPose::get_tracking_confidence);

--- a/servers/xr/xr_server.cpp
+++ b/servers/xr/xr_server.cpp
@@ -64,7 +64,7 @@ void XRServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_camera_locked_to_origin"), &XRServer::is_camera_locked_to_origin);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "world_scale"), "set_world_scale", "get_world_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "world_origin"), "set_world_origin", "get_world_origin");
+	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM3D, "world_origin"), "set_world_origin", "get_world_origin");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "camera_locked_to_origin"), "set_camera_locked_to_origin", "is_camera_locked_to_origin");
 
 	ClassDB::bind_method(D_METHOD("add_interface", "interface"), &XRServer::add_interface);

--- a/servers/xr/xr_tracker.cpp
+++ b/servers/xr/xr_tracker.cpp
@@ -37,7 +37,7 @@ void XRTracker::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_tracker_name"), &XRTracker::get_tracker_name);
 	ClassDB::bind_method(D_METHOD("set_tracker_name", "name"), &XRTracker::set_tracker_name);
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "name"), "set_tracker_name", "get_tracker_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "name"), "set_tracker_name", "get_tracker_name");
 
 	ClassDB::bind_method(D_METHOD("get_tracker_desc"), &XRTracker::get_tracker_desc);
 	ClassDB::bind_method(D_METHOD("set_tracker_desc", "description"), &XRTracker::set_tracker_desc);


### PR DESCRIPTION
ADD_PROPERTY call requires a type to be specified.
But during document generation, the member's type is inferred from the
getter's return type.

The first patch adds an error log to indicate mismatch during document generation.
The second patch fixes the issues detected in the current code.