### PR TITLE
Rework updating editor viewport HDR

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -476,6 +476,7 @@ private:
 	HashSet<String> textfile_extensions;
 	HashSet<String> other_file_extensions;
 	HashSet<FileDialog *> file_dialogs;
+	LocalVector<ObjectID> hdr_viewports;
 
 	Vector<Ref<EditorResourceConversionPlugin>> resource_conversion_plugins;
 	PrintHandlerList print_handler;
@@ -940,6 +941,7 @@ public:
 	bool is_multi_window_enabled() const;
 
 	void setup_color_picker(ColorPicker *p_picker);
+	void register_hdr_viewport(Viewport *p_viewport);
 
 	void request_instantiate_scene(const String &p_path);
 	void request_instantiate_scenes(const Vector<String> &p_files);

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1995,14 +1995,7 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	update_view_timer->connect("timeout", callable_mp(this, &SceneImportSettingsDialog::_update_view_gizmos));
 	add_child(update_view_timer);
 
-	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &SceneImportSettingsDialog::_project_settings_changed));
-	_project_settings_changed();
-}
-
-void SceneImportSettingsDialog::_project_settings_changed() {
-	const bool hdr_requested = GLOBAL_GET("display/window/hdr/request_hdr_output");
-	const bool hdr_2d_enabled = GLOBAL_GET("rendering/viewport/hdr_2d");
-	base_viewport->set_use_hdr_2d(hdr_2d_enabled || hdr_requested);
+	EditorNode::get_singleton()->register_hdr_viewport(base_viewport);
 }
 
 SceneImportSettingsDialog::~SceneImportSettingsDialog() {

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -207,7 +207,6 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 	ResourceImporterScene *_resource_importer_scene = nullptr;
 
 	void _re_import();
-	void _project_settings_changed();
 
 	String base_path;
 

--- a/editor/scene/3d/camera_3d_editor_plugin.cpp
+++ b/editor/scene/3d/camera_3d_editor_plugin.cpp
@@ -31,6 +31,7 @@
 #include "camera_3d_editor_plugin.h"
 
 #include "core/config/project_settings.h"
+#include "editor/editor_node.h"
 #include "node_3d_editor_plugin.h"
 #include "scene/gui/aspect_ratio_container.h"
 #include "scene/gui/foldable_container.h"
@@ -115,16 +116,16 @@ Camera3DPreview::Camera3DPreview(Camera3D *p_camera) {
 
 	RenderingServer::get_singleton()->viewport_attach_camera(sub_viewport->get_viewport_rid(), camera->get_camera());
 
+	EditorNode::get_singleton()->register_hdr_viewport(sub_viewport);
+
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Camera3DPreview::_project_settings_changed));
-	_project_settings_changed();
+	_update_sub_viewport_size();
 }
 
 void Camera3DPreview::_project_settings_changed() {
-	_update_sub_viewport_size();
-
-	const bool hdr_requested = GLOBAL_GET("display/window/hdr/request_hdr_output");
-	const bool use_hdr_2d = GLOBAL_GET("rendering/viewport/hdr_2d");
-	sub_viewport->set_use_hdr_2d(use_hdr_2d || hdr_requested);
+	if (ProjectSettings::get_singleton()->check_changed_settings_in_group("display/window/size")) {
+		_update_sub_viewport_size();
+	}
 }
 
 bool EditorInspectorPluginCamera3DPreview::can_handle(Object *p_object) {

--- a/editor/scene/3d/mesh_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_editor_plugin.cpp
@@ -31,6 +31,7 @@
 #include "mesh_editor_plugin.h"
 
 #include "core/config/project_settings.h"
+#include "editor/editor_node.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/button.h"
 #include "scene/main/viewport.h"
@@ -69,12 +70,6 @@ void MeshEditor::_update_rotation() {
 	t.basis.rotate(Vector3(0, 1, 0), -rot_y);
 	t.basis.rotate(Vector3(1, 0, 0), -rot_x);
 	rotation->set_transform(t);
-}
-
-void MeshEditor::_project_settings_changed() {
-	const bool hdr_requested = GLOBAL_GET("display/window/hdr/request_hdr_output");
-	const bool use_hdr_2d = GLOBAL_GET("rendering/viewport/hdr_2d");
-	viewport->set_use_hdr_2d(use_hdr_2d || hdr_requested);
 }
 
 void MeshEditor::edit(Ref<Mesh> p_mesh) {
@@ -170,8 +165,7 @@ MeshEditor::MeshEditor() {
 	rot_x = 0;
 	rot_y = 0;
 
-	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &MeshEditor::_project_settings_changed));
-	_project_settings_changed();
+	EditorNode::get_singleton()->register_hdr_viewport(viewport);
 }
 
 ///////////////////////

--- a/editor/scene/3d/mesh_editor_plugin.h
+++ b/editor/scene/3d/mesh_editor_plugin.h
@@ -68,7 +68,6 @@ class MeshEditor : public SubViewportContainer {
 	void _on_light_1_switch_pressed();
 	void _on_light_2_switch_pressed();
 	void _update_rotation();
-	void _project_settings_changed();
 
 protected:
 	virtual void _update_theme_item_cache() override;

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -3225,10 +3225,6 @@ void Node3DEditorViewport::_project_settings_changed() {
 	const bool transparent_background = GLOBAL_GET("rendering/viewport/transparent_background");
 	viewport->set_transparent_background(transparent_background);
 
-	const bool hdr_requested = GLOBAL_GET("display/window/hdr/request_hdr_output");
-	const bool use_hdr_2d = GLOBAL_GET("rendering/viewport/hdr_2d");
-	viewport->set_use_hdr_2d(use_hdr_2d || hdr_requested);
-
 	const bool use_debanding = GLOBAL_GET("rendering/anti_aliasing/quality/use_debanding");
 	viewport->set_use_debanding(use_debanding);
 
@@ -6620,6 +6616,8 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 
 	view_type = VIEW_TYPE_USER;
 	_update_name();
+
+	EditorNode::get_singleton()->register_hdr_viewport(viewport);
 }
 
 Node3DEditorViewport::~Node3DEditorViewport() {

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -154,13 +154,6 @@ void MaterialEditor::_update_rotation() {
 	rotation->set_transform(t);
 }
 
-void MaterialEditor::_project_settings_changed() {
-	const bool hdr_requested = GLOBAL_GET("display/window/hdr/request_hdr_output");
-	const bool use_hdr_2d = GLOBAL_GET("rendering/viewport/hdr_2d");
-	viewport->set_use_hdr_2d(use_hdr_2d || hdr_requested);
-	viewport_2d->set_use_hdr_2d(use_hdr_2d || hdr_requested);
-}
-
 void MaterialEditor::edit(Ref<Material> p_material, const Ref<Environment> &p_env) {
 	material = p_material;
 	camera->set_environment(p_env);
@@ -406,8 +399,8 @@ MaterialEditor::MaterialEditor() {
 	Vector2 stored_rot = EditorSettings::get_singleton()->get_project_metadata("inspector_options", "material_preview_rotation", Vector2());
 	_set_rotation(stored_rot.x, stored_rot.y);
 
-	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &MaterialEditor::_project_settings_changed));
-	_project_settings_changed();
+	EditorNode::get_singleton()->register_hdr_viewport(viewport);
+	EditorNode::get_singleton()->register_hdr_viewport(viewport_2d);
 }
 
 ///////////////////////

--- a/editor/scene/material_editor_plugin.h
+++ b/editor/scene/material_editor_plugin.h
@@ -102,7 +102,6 @@ class MaterialEditor : public Control {
 	void _set_rotation(real_t p_x_degrees, real_t p_y_degrees);
 	void _store_rotation_metadata();
 	void _update_rotation();
-	void _project_settings_changed();
 
 protected:
 	virtual void _update_theme_item_cache() override;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/94496#pullrequestreview-3733417259
Replaces manual updating of viewport's HDR on setting change with a method that allows registering relevant viewports in EditorNode, so it's handled automatically.

Could use some testing, but it should work the same as before.