### PR TITLE
Fix signal-related crash

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2443,10 +2443,10 @@ Object::~Object() {
 		// Disconnect signals that connect to this object.
 		while (connections.size()) {
 			Connection c = connections.front()->get();
-			Object *obj = c.callable.get_object();
+			Object *obj = c.signal.get_object();
 			bool disconnected = false;
 			if (likely(obj)) {
-				disconnected = c.signal.get_object()->_disconnect(c.signal.get_name(), c.callable, true);
+				disconnected = obj->_disconnect(c.signal.get_name(), c.callable, true);
 			}
 			if (unlikely(!disconnected)) {
 				// If the disconnect has failed, abandon the connection to avoid getting trapped in an infinite loop here.


### PR DESCRIPTION
Related to: https://github.com/godotengine/godot/pull/94666

While we're also not able to track down the exact root cause of the crash, nor produce an MRP, we have seen it in the wild. The dump file produced shows that `c.signal.get_object()` returns `NULL`, and then when `disconnect` is called on it, the crash occurs.

The code looks obviously wrong - it checks for the existence of one object, then proceeds to call a function on another.

-------

Although we didn't find a root cause, here is a little more information on our investigation, in case it helps someone in the future. Here is the stack trace of our crash:

<img width="847" height="248" alt="image" src="https://github.com/user-attachments/assets/aaf87c02-0362-4489-bdc5-81dfe8b1952c" />

And here is the threads view:

<img width="915" height="294" alt="image" src="https://github.com/user-attachments/assets/36d1aa94-441b-4c01-851b-7f3bc28aeb0c" />

Interestingly, the crash is taking place on a .NET finalizer thread, meaning it occurs when a .NET wrapper object is disposing of a Godot `Object`. That leads me to believe there is a subtle race condition somewhere, but there's not much more information on what that would be.