### PR TITLE
[String] Allow using Java style `%[arg$]` prefix in `sprintf`.

### DIFF
--- a/tests/core/string/test_string.cpp
+++ b/tests/core/string/test_string.cpp
@@ -1296,6 +1296,15 @@ TEST_CASE("[String] sprintf") {
 	REQUIRE(error == false);
 	CHECK(output == String("fish     99.990 frog"));
 
+	///// Argument indices.
+	format = "fish %2$d frog %1$s xx";
+	args.clear();
+	args.push_back("test");
+	args.push_back(5);
+	output = format.sprintf(args, &error);
+	REQUIRE(error == false);
+	CHECK(output == String("fish 5 frog test xx"));
+
 	///// Errors
 
 	// More formats than arguments.


### PR DESCRIPTION
Adds optional `[arg$]` prefix to reorder format string arguments.

e.g., `vformat("test %2$d test %1$s end", "str", 333)` → `test 333 test str end`.

Part of https://github.com/godotengine/godot/pull/116262

Implements https://github.com/godotengine/godot-proposals/issues/7399 (except argument as precision part, but not sure when it's useful).