### PR TITLE
[Tests] Add string format tests for editor translations.

### DIFF
--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -314,6 +314,11 @@ Vector<String> OptimizedTranslation::get_translated_message_list() const {
 	return msgs;
 }
 
+HashMap<StringName, Vector<StringName>> OptimizedTranslation::get_translated_message_map() const {
+	WARN_PRINT_ONCE("OptimizedTranslation does not store the message texts to be translated.");
+	return HashMap<StringName, Vector<StringName>>();
+}
+
 StringName OptimizedTranslation::get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context) const {
 	// The use of plurals translation is not yet supported in OptimizedTranslation.
 	return get_message(p_src_text, p_context);

--- a/core/string/optimized_translation.h
+++ b/core/string/optimized_translation.h
@@ -101,6 +101,7 @@ public:
 	virtual StringName get_message(const StringName &p_src_text, const StringName &p_context = "") const override; //overridable for other implementations
 	virtual StringName get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const override;
 	virtual Vector<String> get_translated_message_list() const override;
+	virtual HashMap<StringName, Vector<StringName>> get_translated_message_map() const override;
 	bool generate(const Ref<Translation> &p_from);
 
 	virtual void get_message_list(List<StringName> *r_messages) const override;

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -57,6 +57,14 @@ void _check_for_incompatibility(const String &p_msgctxt, const String &p_msgid) 
 	}
 }
 
+HashMap<StringName, Vector<StringName>> Translation::get_translated_message_map() const {
+	HashMap<StringName, Vector<StringName>> map;
+	for (const KeyValue<MessageKey, Vector<StringName>> &E : translation_map) {
+		map[E.key.msgid] = E.value;
+	}
+	return map;
+}
+
 Dictionary Translation::_get_messages() const {
 	Dictionary d;
 	for (const KeyValue<MessageKey, Vector<StringName>> &E : translation_map) {

--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -89,6 +89,7 @@ public:
 	virtual void get_message_list(List<StringName> *r_messages) const;
 	virtual int get_message_count() const;
 	virtual Vector<String> get_translated_message_list() const;
+	virtual HashMap<StringName, Vector<StringName>> get_translated_message_map() const;
 
 	void set_plural_rules_override(const String &p_rules);
 	String get_plural_rules_override() const;

--- a/tests/editor/test_editor_translation.cpp
+++ b/tests/editor/test_editor_translation.cpp
@@ -1,0 +1,283 @@
+/**************************************************************************/
+/*  test_editor_translation.cpp                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_editor_translation)
+
+#include "core/io/compression.h"
+#include "core/io/file_access_memory.h"
+#include "core/io/translation_loader_po.h"
+#include "core/string/translation.h"
+#include "editor/translations/doc_translations.gen.h"
+#include "editor/translations/editor_translations.gen.h"
+#include "editor/translations/extractable_translations.gen.h"
+#include "editor/translations/property_translations.gen.h"
+
+namespace TestEditorTranslation {
+
+Vector<int> _util_sprintf_extract_arg_types(const StringName &p_str) {
+	static const String ZERO("0");
+	static const String SPACE(" ");
+	static const String MINUS("-");
+	static const String PLUS("+");
+
+	Vector<int> value_types;
+	char32_t *self = (char32_t *)p_str.get_data();
+	int selected_index = -1;
+	int pending_index = 0;
+	bool in_decimals = false;
+	int value_index = 0;
+	bool in_format = false;
+
+	for (; *self; self++) {
+		const char32_t c = *self;
+
+		if (in_format) { // We have % - let's see what else we get.
+			switch (c) {
+				case '%': { // Replace %% with %
+					in_format = false;
+					break;
+				}
+				case 'd': // Integer (signed)
+				case 'o': // Octal
+				case 'x': // Hexadecimal (lowercase)
+				case 'X': { // Hexadecimal (uppercase)
+					int64_t index = (selected_index >= 0 ? selected_index : value_index);
+					if (index >= value_types.size()) {
+						for (int i = value_types.size(); i < index + 1; i++) {
+							value_types.push_back(-1);
+						}
+					}
+					value_types.write[index] = Variant::Type::INT;
+					if (selected_index == -1) {
+						++value_index;
+					}
+					in_format = false;
+					break;
+				}
+				case 'f': { // Float
+					int64_t index = (selected_index >= 0 ? selected_index : value_index);
+					if (index >= value_types.size()) {
+						for (int i = value_types.size(); i < index + 1; i++) {
+							value_types.push_back(-1);
+						}
+					}
+					value_types.write[index] = Variant::Type::FLOAT;
+					if (selected_index == -1) {
+						++value_index;
+					}
+					in_format = false;
+					break;
+				}
+				case 'v': { // Vector2/3/4/2i/3i/4i
+					int64_t index = (selected_index >= 0 ? selected_index : value_index);
+					if (index >= value_types.size()) {
+						for (int i = value_types.size(); i < index + 1; i++) {
+							value_types.push_back(-1);
+						}
+					}
+					value_types.write[index] = Variant::Type::VECTOR2;
+					if (selected_index == -1) {
+						++value_index;
+					}
+					in_format = false;
+					break;
+				}
+				case 'c':
+				case 's': { // String
+					int64_t index = (selected_index >= 0 ? selected_index : value_index);
+					if (index >= value_types.size()) {
+						for (int i = value_types.size(); i < index + 1; i++) {
+							value_types.push_back(-1);
+						}
+					}
+					value_types.write[index] = Variant::Type::STRING;
+					if (selected_index == -1) {
+						++value_index;
+					}
+					in_format = false;
+					break;
+				}
+				case '-': // Left justify
+				case '+': // Show + if positive.
+				case 'u': { // Treat as unsigned (for int/hex).
+					break;
+				}
+				case '0':
+				case '1':
+				case '2':
+				case '3':
+				case '4':
+				case '5':
+				case '6':
+				case '7':
+				case '8':
+				case '9': {
+					int n = c - '0';
+					if (!in_decimals) {
+						if (c != '0' || pending_index != 0) {
+							pending_index *= 10;
+							pending_index += n;
+						}
+					}
+					break;
+				}
+				case '$': {
+					if (pending_index > 0) {
+						selected_index = pending_index - 1;
+					}
+					pending_index = 0;
+					break;
+				}
+				case '.': { // Float/Vector separator.
+					in_decimals = true;
+					break;
+				}
+				case '*': { // Dynamic width, based on value.
+					int64_t index = (selected_index >= 0 ? selected_index : value_index);
+					if (index >= value_types.size()) {
+						for (int i = value_types.size(); i < index + 1; i++) {
+							value_types.push_back(-1);
+						}
+					}
+					value_types.write[index] = Variant::Type::NIL;
+					if (selected_index == -1) {
+						++value_index;
+					}
+					break;
+				}
+
+				default: {
+					in_format = false;
+					break;
+				}
+			}
+		} else { // Not in format string.
+			if (c == '%') {
+				in_format = true;
+				selected_index = -1;
+				pending_index = 0;
+				in_decimals = false;
+			}
+		}
+	}
+
+	return value_types;
+}
+
+bool _check_string_formats(const Ref<Translation> &p_translation, String &r_errors) {
+	HashMap<StringName, Vector<StringName>> map = p_translation->get_translated_message_map();
+	bool ok = true;
+	for (const KeyValue<StringName, Vector<StringName>> &E : map) {
+		const Vector<int> fmt = _util_sprintf_extract_arg_types(E.key);
+		for (const StringName &s : E.value) {
+			const Vector<int> sfmt = _util_sprintf_extract_arg_types(s);
+			if (fmt != sfmt) {
+				r_errors += vformat("[%s] Translated string format mismatch:\n.     %s\n.     %s\n", p_translation->get_locale(), String(E.key).replace("\n", "\\n"), String(s).replace("\n", "\\n"));
+				ok = false;
+			}
+		}
+	}
+	return ok;
+}
+
+Ref<Translation> _load_ed_tr(const EditorTranslationList *p_etl) {
+	LocalVector<uint8_t> data;
+	data.resize_uninitialized(p_etl->uncomp_size);
+	const int64_t ret = Compression::decompress(data.ptr(), p_etl->uncomp_size, p_etl->data, p_etl->comp_size, Compression::MODE_DEFLATE);
+	if (ret == -1) {
+		return Ref<Translation>();
+	}
+
+	Ref<FileAccessMemory> fa;
+	fa.instantiate();
+	fa->open_custom(data.ptr(), data.size());
+
+	Ref<Translation> tr = TranslationLoaderPO::load_translation(fa);
+	if (tr.is_valid()) {
+		tr->set_locale(p_etl->lang);
+	}
+	return tr;
+}
+
+TEST_CASE("[EditorTranslation] Editor translations string format") {
+	for (const EditorTranslationList *etl = _editor_translations; etl->data; etl++) {
+		if (String(etl->lang) == "source") {
+			continue;
+		}
+		Ref<Translation> tr = _load_ed_tr(etl);
+		if (tr.is_valid()) {
+			String errors;
+			CHECK(_check_string_formats(tr, errors));
+			if (!errors.is_empty()) {
+				print_line(errors);
+			}
+		}
+	}
+}
+
+TEST_CASE("[EditorTranslation] Editor extractable translations string format") {
+	for (const EditorTranslationList *etl = _extractable_translations; etl->data; etl++) {
+		if (String(etl->lang) == "source") {
+			continue;
+		}
+		Ref<Translation> tr = _load_ed_tr(etl);
+		if (tr.is_valid()) {
+			String errors;
+			CHECK(_check_string_formats(tr, errors));
+			if (!errors.is_empty()) {
+				print_line(errors);
+			}
+		}
+	}
+}
+
+TEST_CASE("[EditorTranslation] Editor property translations string format") {
+	for (const EditorTranslationList *etl = _property_translations; etl->data; etl++) {
+		if (String(etl->lang) == "source") {
+			continue;
+		}
+		Ref<Translation> tr = _load_ed_tr(etl);
+		if (tr.is_valid()) {
+			String errors;
+			CHECK(_check_string_formats(tr, errors));
+			if (!errors.is_empty()) {
+				print_line(errors);
+			}
+		}
+	}
+}
+
+} // namespace TestEditorTranslation
+
+#endif // TOOLS_ENABLED


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/116243#issuecomment-3897468218

We have a bunch of translated strings with broken format, so this is expected to fail tests.

Some string have format arguments in a different order (which is likely grammatically correct in a lot of cases), so it depends on https://github.com/godotengine/godot/pull/116261 to allow fixing it, e.g.,:

```
[ta] Translated string format mismatch:
.     Set %s on %d nodes
.     %d முனைகளில் %s ஐ அமைக்கவும்
```

Can be fixed by updating translation to `%2$d முனைகளில் %1$s ஐ அமைக்கவும்`, without changing source string or related code.