### PR TITLE
Add support for custom `RandomNumberGenerator` in functions `pick_random` and `pop_random` in `Array` 

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -36,6 +36,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, String);
 
 #include "container_type_validate.h"
 #include "core/math/math_funcs.h"
+#include "core/math/random_number_generator.h"
 #include "core/object/script_language.h"
 #include "core/templates/hashfuncs.h"
 #include "core/templates/vector.h"
@@ -361,9 +362,20 @@ Variant Array::back() const {
 	return operator[](_p->array.size() - 1);
 }
 
-Variant Array::pick_random() const {
-	ERR_FAIL_COND_V_MSG(_p->array.is_empty(), Variant(), "Can't take value from empty array.");
-	return operator[](Math::rand() % _p->array.size());
+Variant Array::pick_random(const Ref<RandomNumberGenerator> &p_rng) const {
+	if (_p->array.is_empty()) {
+		return Variant();
+	}
+
+	int idx;
+
+	if (p_rng.is_valid()) {
+		idx = p_rng->randi_range(0, _p->array.size() - 1);
+	} else {
+		idx = Math::rand() % _p->array.size();
+	}
+
+	return _p->array.get(idx);
 }
 
 int Array::find(const Variant &p_value, int p_from) const {
@@ -822,6 +834,27 @@ Variant Array::pop_at(int p_pos) {
 
 	const Variant ret = _p->array.get(p_pos);
 	_p->array.remove_at(p_pos);
+	return ret;
+}
+
+Variant Array::pop_random(const Ref<RandomNumberGenerator> &p_rng) {
+	ERR_FAIL_COND_V_MSG(_p->read_only, Variant(), "Array is in read-only state.");
+
+	if (_p->array.is_empty()) {
+		return Variant();
+	}
+
+	int idx;
+
+	if (p_rng.is_valid()) {
+		idx = p_rng->randi_range(0, _p->array.size() - 1);
+	} else {
+		idx = Math::rand() % _p->array.size();
+	}
+
+	const Variant ret = _p->array.get(idx);
+	_p->array.remove_at(idx);
+
 	return ret;
 }
 

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -40,6 +40,9 @@
 class Callable;
 class StringName;
 class Variant;
+class RandomNumberGenerator;
+template <typename T>
+class Ref;
 
 struct ArrayPrivate;
 struct ContainerType;
@@ -130,7 +133,7 @@ public:
 
 	Variant front() const;
 	Variant back() const;
-	Variant pick_random() const;
+	Variant pick_random(const Ref<RandomNumberGenerator> &p_rng) const;
 
 	void sort();
 	void sort_custom(const Callable &p_callable);
@@ -152,6 +155,7 @@ public:
 	Variant pop_back();
 	Variant pop_front();
 	Variant pop_at(int p_pos);
+	Variant pop_random(const Ref<RandomNumberGenerator> &p_rng);
 
 	Array duplicate(bool p_deep = false) const;
 	Array duplicate_deep(ResourceDeepDuplicateMode p_deep_subresources_mode = RESOURCE_DEEP_DUPLICATE_INTERNAL) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -34,6 +34,7 @@
 #include "core/debugger/engine_debugger.h"
 #include "core/io/compression.h"
 #include "core/io/marshalls.h"
+#include "core/math/random_number_generator.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/templates/a_hash_map.h"
@@ -2691,7 +2692,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(Array, erase, sarray("value"), varray());
 	bind_method(Array, front, sarray(), varray());
 	bind_method(Array, back, sarray(), varray());
-	bind_method(Array, pick_random, sarray(), varray());
+	bind_method(Array, pick_random, sarray("rng"), varray(Variant()));
 	bind_method(Array, find, sarray("what", "from"), varray(0));
 	bind_method(Array, find_custom, sarray("method", "from"), varray(0));
 	bind_method(Array, rfind, sarray("what", "from"), varray(-1));
@@ -2701,6 +2702,7 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(Array, pop_back, sarray(), varray());
 	bind_method(Array, pop_front, sarray(), varray());
 	bind_method(Array, pop_at, sarray("position"), varray());
+	bind_method(Array, pop_random, sarray("rng"), varray(Variant()));
 	bind_method(Array, sort, sarray(), varray());
 	bind_method(Array, sort_custom, sarray("func"), varray());
 	bind_method(Array, shuffle, sarray(), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -584,6 +584,7 @@
 		</method>
 		<method name="pick_random" qualifiers="const">
 			<return type="Variant" />
+			<param index="0" name="rng" type="Variant" default="null" />
 			<description>
 				Returns a random element from the array. Generates an error and returns [code]null[/code] if the array is empty.
 				[codeblocks]
@@ -618,6 +619,27 @@
 			<description>
 				Removes and returns the first element of the array. Returns [code]null[/code] if the array is empty, without generating an error. See also [method pop_back].
 				[b]Note:[/b] This method shifts every other element's index back, which may have a noticeable performance cost, especially on larger arrays.
+			</description>
+		</method>
+		<method name="pop_random">
+			<return type="Variant" />
+			<param index="0" name="rng" type="Variant" default="null" />
+			<description>
+				Removes and returns a random element from the array. Generates an error and returns [code]null[/code] if the array is empty.
+				[codeblocks]
+				[gdscript]
+				var arr = [1, 2, 3.25, "Hi"]
+				print(arr.pop_random()) # May print 1, 2, 3.25, or "Hi".
+				print(arr) # Prints the array with the previously printed element removed.
+				[/gdscript]
+				[csharp]
+				Godot.Collections.Array array = [1, 2, 3.25f, "Hi"];
+				GD.Print(array.PopRandom()); // May print 1, 2, 3.25, or "Hi".
+				GD.Print(array); // Prints the array with the previously printed element removed.
+				[/csharp]
+				[/codeblocks]
+				[b]Note:[/b] Like many similar functions in the engine (such as [method @GlobalScope.randi] or [method shuffle]), this method uses a common, global random seed. To get a predictable outcome from this method, see [method @GlobalScope.seed].
+				[b]Note:[/b] This method shifts every element's index after the removed element back, which may have a noticeable performance cost, especially on larger arrays.
 			</description>
 		</method>
 		<method name="push_back">

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -290,18 +290,46 @@ namespace Godot.Collections
         /// <summary>
         /// Returns a random value from the target array.
         /// </summary>
+        /// <param name="rng">Optional random number generator to use. If null, uses the default RNG.</param>
         /// <example>
         /// <code>
         /// var array = new Godot.Collections.Array { 1, 2, 3, 4 };
         /// GD.Print(array.PickRandom()); // Prints either of the four numbers.
+        ///
+        /// // Or with a custom RNG:
+        /// var rng = new RandomNumberGenerator();
+        /// rng.Seed = 12345;
+        /// GD.Print(array.PickRandom(rng)); // Prints a deterministic random number.
         /// </code>
         /// </example>
         /// <returns>A random element from the array.</returns>
-        public Variant PickRandom()
+        public Variant PickRandom(RandomNumberGenerator rng = null)
         {
             godot_variant resVariant;
             var self = (godot_array)NativeValue;
-            NativeFuncs.godotsharp_array_pick_random(ref self, out resVariant);
+            NativeFuncs.godotsharp_array_pick_random(ref self, rng, out resVariant);
+            return Variant.CreateTakingOwnershipOfDisposableValue(resVariant);
+        }
+
+        /// <summary>
+        /// Removes and returns a random value from the target array.
+        /// </summary>
+        /// <param name="rng">Optional random number generator to use. If null, uses the default RNG.</param>
+        /// <example>
+        /// <code>
+        /// var array = new Godot.Collections.Array { 1, 2, 3, 4 };
+        /// GD.Print(array.Count); // Prints 4
+        /// var item = array.PopRandom();
+        /// GD.Print(array.Count); // Prints 3
+        /// GD.Print(item); // Prints the removed item
+        /// </code>
+        /// </example>
+        /// <returns>The removed element.</returns>
+        public Variant PopRandom(RandomNumberGenerator rng = null)
+        {
+            godot_variant resVariant;
+            var self = (godot_array)NativeValue;
+            NativeFuncs.godotsharp_array_pop_random(ref self, rng, out resVariant);
             return Variant.CreateTakingOwnershipOfDisposableValue(resVariant);
         }
 
@@ -1242,18 +1270,46 @@ namespace Godot.Collections
         /// <summary>
         /// Returns a random value from the target array.
         /// </summary>
+        /// <param name="rng">Optional random number generator to use. If null, uses the default RNG.</param>
         /// <example>
         /// <code>
         /// var array = new Godot.Collections.Array&lt;int&gt; { 1, 2, 3, 4 };
         /// GD.Print(array.PickRandom()); // Prints either of the four numbers.
+        ///
+        /// // Or with a custom RNG:
+        /// var rng = new RandomNumberGenerator();
+        /// rng.Seed = 12345;
+        /// GD.Print(array.PickRandom(rng)); // Prints a deterministic random number.
         /// </code>
         /// </example>
         /// <returns>A random element from the array.</returns>
-        public T PickRandom()
+        public T PickRandom(RandomNumberGenerator rng = null)
         {
             godot_variant resVariant;
             var self = (godot_array)_underlyingArray.NativeValue;
-            NativeFuncs.godotsharp_array_pick_random(ref self, out resVariant);
+            NativeFuncs.godotsharp_array_pick_random(ref self, rng, out resVariant);
+            return VariantUtils.ConvertTo<T>(resVariant);
+        }
+
+        /// <summary>
+        /// Removes and returns a random value from the target array.
+        /// </summary>
+        /// <param name="rng">Optional random number generator to use. If null, uses the default RNG.</param>
+        /// <example>
+        /// <code>
+        /// var array = new Godot.Collections.Array&lt;int&gt; { 1, 2, 3, 4 };
+        /// GD.Print(array.Count); // Prints 4
+        /// var item = array.PopRandom();
+        /// GD.Print(array.Count); // Prints 3
+        /// GD.Print(item); // Prints the removed item
+        /// </code>
+        /// </example>
+        /// <returns>The removed element.</returns>
+        public T PopRandom(RandomNumberGenerator? rng = null)
+        {
+            godot_variant resVariant;
+            var self = (godot_array)_underlyingArray.NativeValue;
+            NativeFuncs.godotsharp_array_pop_random(ref self, rng, out resVariant);
             return VariantUtils.ConvertTo<T>(resVariant);
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -414,7 +414,9 @@ namespace Godot.NativeInterop
 
         public static partial void godotsharp_array_min(scoped ref godot_array p_self, out godot_variant r_value);
 
-        public static partial void godotsharp_array_pick_random(scoped ref godot_array p_self, out godot_variant r_value);
+        public static partial void godotsharp_array_pick_random(scoped ref godot_array p_self, IntPtr p_rng, out godot_variant r_value);
+
+        public static partial void godotsharp_array_pop_random(scoped ref godot_array p_self, IntPtr p_rng, out godot_variant r_value);
 
         public static partial godot_bool godotsharp_array_recursive_equal(ref godot_array p_self, in godot_array p_other);
 

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1137,8 +1137,12 @@ void godotsharp_array_min(const Array *p_self, Variant *r_value) {
 	*r_value = p_self->min();
 }
 
-void godotsharp_array_pick_random(const Array *p_self, Variant *r_value) {
-	*r_value = p_self->pick_random();
+void godotsharp_array_pick_random(const Array *p_self, const Ref<RandomNumberGenerator> *p_rng, Variant *r_value) {
+	*r_value = p_self->pick_random(*p_rng);
+}
+
+void godotsharp_array_pop_random(Array *p_self, const Ref<RandomNumberGenerator> *p_rng, Variant *r_value) {
+	*r_value = p_self->pop_random(*p_rng);
 }
 
 bool godotsharp_array_recursive_equal(const Array *p_self, const Array *p_other) {
@@ -1769,6 +1773,7 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_array_max,
 	(void *)godotsharp_array_min,
 	(void *)godotsharp_array_pick_random,
+	(void *)godotsharp_array_pop_random,
 	(void *)godotsharp_array_recursive_equal,
 	(void *)godotsharp_array_remove_at,
 	(void *)godotsharp_array_resize,


### PR DESCRIPTION
This PR implements the `pick_random` and `pop_random` functions in `Array` supporting a custom `RandomNumberGenerator`, as mentioned in [Godot Proposal Issue #14115](https://github.com/godotengine/godot-proposals/issues/14115).