### PR TITLE
Fix mouse cursor shape change interrupting input events

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2889,8 +2889,8 @@ void Control::set_default_cursor_shape(CursorShape p_shape) {
 		return;
 	}
 
-	// Display the new cursor shape instantly.
-	get_viewport()->update_mouse_cursor_state();
+	// Defer to avoid interrupting the current input event flow.
+	get_viewport()->call_deferred("update_mouse_cursor_state");
 }
 
 Control::CursorShape Control::get_default_cursor_shape() const {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2890,7 +2890,7 @@ void Control::set_default_cursor_shape(CursorShape p_shape) {
 	}
 
 	// Defer to avoid interrupting the current input event flow.
-	get_viewport()->call_deferred("update_mouse_cursor_state");
+	callable_mp(get_viewport(), &Viewport::update_mouse_cursor_state).call_deferred();
 }
 
 Control::CursorShape Control::get_default_cursor_shape() const {


### PR DESCRIPTION
Fixes #116253

Description:
Changing mouse_default_cursor_shape inside gui_input was causing an immediate call to update_mouse_cursor_state(). This immediate update interrupted the event propagation flow, preventing subsequent signals like pressed from being emitted.

Changes:

Modified Control::set_default_cursor_shape to use call_deferred for the cursor state update.

This ensures the cursor change happens at the end of the frame, allowing the current input event to complete its life cycle naturally.

Verification:
Tested with the MRP provided in the issue. Before the fix, the pressed signal was never triggered. After the fix, the signal fires correctly for every click while the cursor still updates as expected.