### PR TITLE
Add device IDs to keyboard and mouse input events

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -131,6 +131,8 @@ void InputEvent::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "device"), "set_device", "get_device");
 
 	BIND_CONSTANT(DEVICE_ID_EMULATION);
+	BIND_CONSTANT(DEVICE_ID_KEYBOARD);
+	BIND_CONSTANT(DEVICE_ID_MOUSE);
 }
 
 ///////////////////////////////////
@@ -662,6 +664,10 @@ void InputEventKey::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "echo"), "set_echo", "is_echo");
 }
 
+InputEventKey::InputEventKey() {
+	set_device(DEVICE_ID_KEYBOARD);
+}
+
 ///////////////////////////////////
 
 void InputEventMouse::set_button_mask(BitField<MouseButtonMask> p_mask) {
@@ -702,6 +708,10 @@ void InputEventMouse::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_mask"), "set_button_mask", "get_button_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position", PROPERTY_HINT_NONE, "suffix:px"), "set_position", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_position", PROPERTY_HINT_NONE, "suffix:px"), "set_global_position", "get_global_position");
+}
+
+InputEventMouse::InputEventMouse() {
+	set_device(DEVICE_ID_MOUSE);
 }
 
 ///////////////////////////////////

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -63,6 +63,8 @@ protected:
 public:
 	static constexpr int DEVICE_ID_EMULATION = -1;
 	static constexpr int DEVICE_ID_INTERNAL = -2;
+	static constexpr int DEVICE_ID_KEYBOARD = 16; // IDs 0-15 are reserved for joypads.
+	static constexpr int DEVICE_ID_MOUSE = 32; // IDs 17-31 are reserved for multiple keyboard support in the future.
 
 	void set_device(int p_device);
 	int get_device() const;
@@ -199,6 +201,8 @@ public:
 	static Ref<InputEventKey> create_reference(Key p_keycode_with_modifier_masks, bool p_physical = false);
 
 	InputEventType get_type() const final override { return InputEventType::KEY; }
+
+	InputEventKey();
 };
 
 class InputEventMouse : public InputEventWithModifiers {
@@ -221,6 +225,8 @@ public:
 
 	void set_global_position(const Vector2 &p_global_pos);
 	Vector2 get_global_position() const;
+
+	InputEventMouse();
 };
 
 class InputEventMouseButton : public InputEventMouse {

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -126,5 +126,11 @@
 		<constant name="DEVICE_ID_EMULATION" value="-1">
 			Device ID used for emulated mouse input from a touchscreen, or for emulated touch input from a mouse. This can be used to distinguish emulated mouse input from physical mouse input, or emulated touch input from physical touch input.
 		</constant>
+		<constant name="DEVICE_ID_KEYBOARD" value="16">
+			Device ID used for input from a keyboard. This can be used to distinguish keyboard input events from joypad input events.
+		</constant>
+		<constant name="DEVICE_ID_MOUSE" value="32">
+			Device ID used for input from a mouse. This can be used to distinguish mouse input events from joypad input events.
+		</constant>
 	</constants>
 </class>

--- a/doc/classes/InputEventGesture.xml
+++ b/doc/classes/InputEventGesture.xml
@@ -10,6 +10,7 @@
 		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<members>
+		<member name="device" type="int" setter="set_device" getter="get_device" overrides="InputEvent" default="0" />
 		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
 			The local gesture position relative to the [Viewport]. If used in [method Control._gui_input], the position is relative to the current [Control] that received this gesture.
 		</member>

--- a/doc/classes/InputEventMouse.xml
+++ b/doc/classes/InputEventMouse.xml
@@ -13,6 +13,7 @@
 		<member name="button_mask" type="int" setter="set_button_mask" getter="get_button_mask" enum="MouseButtonMask" is_bitfield="true" default="0">
 			The mouse button mask identifier, one of or a bitwise combination of the [enum MouseButton] button masks.
 		</member>
+		<member name="device" type="int" setter="set_device" getter="get_device" overrides="InputEvent" default="32" />
 		<member name="global_position" type="Vector2" setter="set_global_position" getter="get_global_position" default="Vector2(0, 0)">
 			When received in [method Node._input] or [method Node._unhandled_input], returns the mouse's position in the root [Viewport] using the coordinate system of the root [Viewport].
 			When received in [method Control._gui_input], returns the mouse's position in the [CanvasLayer] that the [Control] is in using the coordinate system of the [CanvasLayer].

--- a/doc/classes/InputEventWithModifiers.xml
+++ b/doc/classes/InputEventWithModifiers.xml
@@ -35,6 +35,7 @@
 		<member name="ctrl_pressed" type="bool" setter="set_ctrl_pressed" getter="is_ctrl_pressed" default="false">
 			State of the [kbd]Ctrl[/kbd] modifier.
 		</member>
+		<member name="device" type="int" setter="set_device" getter="get_device" overrides="InputEvent" default="16" />
 		<member name="meta_pressed" type="bool" setter="set_meta_pressed" getter="is_meta_pressed" default="false">
 			State of the [kbd]Meta[/kbd] modifier. On Windows and Linux, this represents the Windows key (sometimes called "meta" or "super" on Linux). On macOS, this represents the Command key.
 		</member>


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/7161
Closes https://github.com/godotengine/godot/issues/23439
Supersedes https://github.com/godotengine/godot/pull/114377 (if this PR doesn't break compatibility)

And as pointed out by Calinou in https://github.com/godotengine/godot-proposals/issues/7161#issuecomment-1606969263 , this PR also reserves IDs for multiple keyboard/mice support in the future, if we ever plan to support that.