### PR TITLE
Create custom Material types by extending ShaderMaterial

### DIFF
--- a/doc/classes/ShaderMaterial.xml
+++ b/doc/classes/ShaderMaterial.xml
@@ -12,6 +12,18 @@
 		<link title="Shaders documentation index">$DOCS_URL/tutorials/shaders/index.html</link>
 	</tutorials>
 	<methods>
+		<method name="_can_use_shader" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Only exposed for the purpose of overriding. You cannot call this function directly. Used internally to determine if [member shader] should be shown in the editor or not.
+			</description>
+		</method>
+		<method name="_can_use_shader_parameters" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Only exposed for the purpose of overriding. You cannot call this function directly. Used internally to determine if shader uniforms should be shown in the editor or not.
+			</description>
+		</method>
 		<method name="get_shader_parameter" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="param" type="StringName" />

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -241,7 +241,7 @@ bool ShaderMaterial::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
-	if (shader.is_valid()) {
+	if (_can_use_shader_parameters() && shader.is_valid()) {
 		List<PropertyInfo> list;
 		shader->get_shader_uniform_list(&list, true);
 
@@ -525,6 +525,27 @@ void ShaderMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_shader_parameter", "param"), &ShaderMaterial::get_shader_parameter);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shader", PROPERTY_HINT_RESOURCE_TYPE, Shader::get_class_static()), "set_shader", "get_shader");
+
+	GDVIRTUAL_BIND(_can_use_shader);
+	GDVIRTUAL_BIND(_can_use_shader_parameters);
+}
+
+bool ShaderMaterial::_can_use_shader() const {
+	bool ret = true;
+	GDVIRTUAL_CALL(_can_use_shader, ret);
+	return ret;
+}
+
+bool ShaderMaterial::_can_use_shader_parameters() const {
+	bool ret = true;
+	GDVIRTUAL_CALL(_can_use_shader_parameters, ret);
+	return ret;
+}
+
+void ShaderMaterial::_validate_property(PropertyInfo &p_property) const {
+	if (!_can_use_shader() && p_property.name == "shader") {
+		p_property.usage = PROPERTY_USAGE_NONE;
+	}
 }
 
 #ifdef TOOLS_ENABLED
@@ -544,11 +565,19 @@ void ShaderMaterial::get_argument_options(const StringName &p_function, int p_id
 #endif
 
 bool ShaderMaterial::_can_do_next_pass() const {
-	return shader.is_valid() && shader->get_mode() == Shader::MODE_SPATIAL;
+	bool ret = shader.is_valid() && shader->get_mode() == Shader::MODE_SPATIAL;
+	if (ret) {
+		GDVIRTUAL_CALL(_can_do_next_pass, ret);
+	}
+	return ret;
 }
 
 bool ShaderMaterial::_can_use_render_priority() const {
-	return shader.is_valid() && shader->get_mode() == Shader::MODE_SPATIAL;
+	bool ret = shader.is_valid() && shader->get_mode() == Shader::MODE_SPATIAL;
+	if (ret) {
+		GDVIRTUAL_CALL(_can_use_render_priority, ret);
+	}
+	return ret;
 }
 
 Shader::Mode ShaderMaterial::get_shader_mode() const {

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -109,6 +109,11 @@ protected:
 
 	static void _bind_methods();
 
+	virtual bool _can_use_shader() const;
+	virtual bool _can_use_shader_parameters() const;
+
+	void _validate_property(PropertyInfo &p_property) const;
+
 #ifdef TOOLS_ENABLED
 	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 #endif
@@ -118,6 +123,9 @@ protected:
 
 	void _shader_changed();
 	void _check_material_rid() const;
+
+	GDVIRTUAL0RC(bool, _can_use_shader);
+	GDVIRTUAL0RC(bool, _can_use_shader_parameters);
 
 public:
 	void set_shader(const Ref<Shader> &p_shader);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
This PR adds a few virtual methods which make it possible for scripts to extend `ShaderMaterial`, allowing developers to make their own types of materials in the same vein as `StandardMaterial3D`.
Note that although `Material` should also be revised to support full implementations via scripts and GDExtension—its documentation suggests that it should be possible, but some required methods are missing—extending `ShaderMaterial` would still make more sense in the vast majority of cases as it doesn’t require the user to interface with `RenderingServer`. Usage is much simpler, and most projects would not be affected by the performance cost.

The core change required to make this PR work is the addition of the `_can_use_shader_parameters` virtual method; although `_validate_property` could be overriden for `shader`, `render_priority`, and `next_pass`, shader parameters bypass `_validate_property` because they’re added via `_get_property_list`.

Example GDScript implementing a custom type of material:

```GDScript
@tool
class_name SurfaceMaterial3D
extends ShaderMaterial


enum BlendMode {
	MIX,
	ADD,
	SUB,
	MUL,
	PREMULT_ALPHA,
}

enum Filter {
	PIXEL = 0,
	LINEAR = 1,
	LINEAR_MIPMAP = 2,
	NEAREST = 3,
	NEAREST_MIPMAP = 4,
}

enum Transparency {
	DISABLED = 0,
	ALPHA = 1,
	ALPHA_SCISSOR = 2,
}

enum CullMode {
	BACK = 0,
	FRONT = 1,
	DISABLED = 2,
}

enum ShadingMode {
	UNSHADED = 0,
	PER_PIXEL = 1,
	PER_VERTEX = 2,
}

enum Repeat {
	DISABLED,
	ENABLED,
}


@export var blend_mode := BlendMode.MIX:
	set(value):
		if value != blend_mode:
			blend_mode = value
			_notify_rebuild_shader()
			emit_changed()

@export var transparency := Transparency.DISABLED:
	set(value):
		if value != transparency:
			transparency = value
			_notify_rebuild_shader()
			emit_changed()

@export var cull_mode := CullMode.BACK:
	set(value):
		if value != cull_mode:
			cull_mode = value
			_notify_rebuild_shader()
			emit_changed()

@export var shading_mode := ShadingMode.PER_VERTEX:
	set(value):
		if value != shading_mode:
			shading_mode = value
			_notify_rebuild_shader()
			emit_changed()

@export var filter := Filter.PIXEL:
	set(value):
		if value != filter:
			filter = value
			_notify_rebuild_shader()
			emit_changed()

@export var color := Color.WHITE:
	set(value):
		if value != color:
			color = value
			_notify_update_shader_param()
			emit_changed()

@export var texture: Texture2D = null:
	set(res):
		if res != texture:
			texture = res
			_notify_update_shader_param()
			emit_changed()

@export var repeat := Repeat.ENABLED:
	set(value):
		if value != repeat:
			repeat = value
			_notify_rebuild_shader()
			emit_changed()

@export var uv_offset := Vector2.ZERO:
	set(value):
		if value != uv_offset:
			uv_offset = value
			_notify_update_shader_param()
			emit_changed()

@export var uv_scale := Vector2.ONE:
	set(value):
		if value != uv_scale:
			uv_scale = value
			_notify_update_shader_param()
			emit_changed()

@export_range(0.0, 1.0) var vertex_color_intensity: float = 1.0:
	set(value):
		if value != vertex_color_intensity:
			vertex_color_intensity = value
			_notify_update_shader_param()
			emit_changed()


# Static map of shader code to shaders
static var _map_shader_resource: Dictionary[String, Shader]


var _shader_param_update_queued: bool = false
var _shader_cache_dirty: bool = false


func _init() -> void:
	render_priority = RENDER_PRIORITY_MIN
	_shader_cache_dirty = true
	_update_shader_cache()


func _can_do_next_pass() -> bool:
	return false


func _can_use_render_priority() -> bool:
	return false


func _can_use_shader() -> bool:
	return false


func _can_use_shader_parameters() -> bool:
	return false


func _notify_rebuild_shader() -> void:
	if not _shader_cache_dirty:
		_shader_cache_dirty = true
		_update_shader_cache.call_deferred()
	_notify_update_shader_param()


func _notify_update_shader_param() -> void:
	if not _shader_param_update_queued:
		_shader_param_update_queued = true
		_update_shader_param.call_deferred()


func _update_shader_cache() -> void:
	if not _shader_cache_dirty:
		return

	var new_shader_code: String = _gen_shader_code()
	print_debug(new_shader_code)

	var new_shader: Shader

	if new_shader_code in _map_shader_resource:
		new_shader = _map_shader_resource[new_shader_code]
	else:
		new_shader = Shader.new()
		new_shader.code = new_shader_code
		_map_shader_resource[new_shader_code] = new_shader

	shader = new_shader
	_shader_cache_dirty = false
	emit_changed()


func _update_shader_param() -> void:
	_update_shader_cache()

	if shader:
		set_shader_parameter(&"albedo_color", color)
		set_shader_parameter(&"albedo_texture", texture)
		set_shader_parameter(&"uv_offset", uv_offset)
		set_shader_parameter(&"uv_scale", uv_scale)
		set_shader_parameter(&"vertex_color_intensity", vertex_color_intensity)

	_shader_param_update_queued = false
	emit_changed()


func _gen_shader_code() -> String:
	var code: String = "shader_type spatial;\nrender_mode "

	match blend_mode:
		BlendMode.MIX:
			code += "blend_mix, "
		BlendMode.ADD:
			code += "blend_add, "
		BlendMode.SUB:
			code += "blend_sub, "
		BlendMode.MUL:
			code += "blend_mul, "
		BlendMode.PREMULT_ALPHA:
			code += "blend_premul_alpha, "

	match cull_mode:
		CullMode.BACK:
			code += "cull_back, "
		CullMode.FRONT:
			code += "cull_front, "
		CullMode.DISABLED:
			code += "cull_disabled, "

	match shading_mode:
		ShadingMode.UNSHADED:
			code += "unshaded, "
		ShadingMode.PER_VERTEX:
			code += "vertex_lighting, "

	code += """specular_disabled;

instance uniform vec4 modulate: source_color = vec4(1.0f, 1.0f, 1.0f, 1.0f);

uniform float vertex_color_intensity: hint_range(0.0f, 1.0f) = 1.0f;
uniform vec2 uv_offset = vec2(0.0f, 0.0f);
uniform vec2 uv_scale = vec2(1.0f, 1.0f);
uniform vec4 albedo_color: source_color = vec4(1.0f, 1.0f, 1.0f, 1.0f);

"""

	code += "uniform sampler2D albedo_texture: "

	match filter:
		Filter.PIXEL:
			code += "filter_linear, "
		Filter.LINEAR:
			code += "filter_linear, "
		Filter.LINEAR_MIPMAP:
			code += "filter_linear_mipmap_anisotropic, "
		Filter.NEAREST:
			code += "filter_nearest, "
		Filter.NEAREST_MIPMAP:
			code += "filter_nearest_mipmap_anisotropic, "

	match repeat:
		Repeat.DISABLED:
			code += "repeat_disable, "
		Repeat.ENABLED:
			code += "repeat_enable, "

	code += "source_color;"

	if filter == Filter.PIXEL:
		code += """
vec4 texture_point_smooth(sampler2D sample_texture, vec2 uv, vec2 pixel_size)
{
	vec2 ddx = dFdx( uv );
	vec2 ddy = dFdy( uv );
	vec2 lxy = sqrt( ddx * ddx + ddy * ddy );

	vec2 uv_pixels = uv / pixel_size;

	vec2 uv_pixels_floor = round( uv_pixels ) - vec2( 0.5f );
	vec2 uv_dxy_pixels = uv_pixels - uv_pixels_floor;

	uv_dxy_pixels = clamp( (uv_dxy_pixels - vec2(0.5f)) * pixel_size / lxy + vec2(0.5f), 0.0f, 1.0f );
	uv = uv_pixels_floor * pixel_size;

	return textureGrad( sample_texture, uv + uv_dxy_pixels * pixel_size, ddx, ddy );
}
"""
	# Account for difference in vertex color handling between renderers.
	if RenderingServer.get_current_rendering_method() == "gl_compatibility":
		code += """
void vertex()
{
	COLOR.rgb = mix(
					(pow(COLOR.rgb, vec3(1.0 / 2.4)) * (1.0 + 0.055)) - vec3(0.055),
					COLOR.rgb * 12.92,
					lessThan(COLOR.rgb, vec3(0.0031308))
	);
}
"""

	code += """
void fragment()
{
	vec4 vertex_color = mix(vec4(1.0f, 1.0f, 1.0f, 1.0f), COLOR, vertex_color_intensity);

	vec2 uv = (UV + uv_offset) * uv_scale;
"""
	if filter == Filter.PIXEL:
		code += """
	vec2 texel_size = 1.0f / vec2(textureSize(albedo_texture, 0));
	vec4 pixel_color = texture_point_smooth(albedo_texture, uv, texel_size);
"""
	else:
		code += """
	vec4 pixel_color = texture(albedo_texture, uv);
"""
	code += """
	vec4 color = vertex_color * pixel_color * albedo_color * modulate;
	ALBEDO = color.rgb;
"""

	match transparency:
		Transparency.ALPHA:
			code += """
	ALPHA = color.a;
"""
		Transparency.ALPHA_SCISSOR:
			code += """
	ALPHA_SCISSOR_THRESHOLD = 0.5f;
	ALPHA = color.a;
"""
	code += "\n}"

	return code
```

Result:
<img width="292" height="688" alt="Screenshot 2026-02-14 at 15 30 38" src="https://github.com/user-attachments/assets/bf23d491-965a-4f55-b799-789fc2e55436" />
