### PR TITLE
Fix `ScriptTextEditor` resizing issue

### DIFF
--- a/doc/classes/ScriptEditorBase.xml
+++ b/doc/classes/ScriptEditorBase.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="ScriptEditorBase" inherits="Control" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="ScriptEditorBase" inherits="VBoxContainer" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Base editor for editing scripts in the [ScriptEditor].
 	</brief_description>

--- a/editor/script/script_editor_base.h
+++ b/editor/script/script_editor_base.h
@@ -31,13 +31,14 @@
 #pragma once
 
 #include "editor/gui/code_editor.h"
+#include "scene/gui/box_container.h"
 
 class EditorSyntaxHighlighter;
 class MenuButton;
 class VSplitContainer;
 
-class ScriptEditorBase : public Control {
-	GDCLASS(ScriptEditorBase, Control);
+class ScriptEditorBase : public VBoxContainer {
+	GDCLASS(ScriptEditorBase, VBoxContainer);
 
 protected:
 	Ref<Resource> edited_res;


### PR DESCRIPTION
Reverts a change which causes part of https://github.com/godotengine/godot/issues/116278. The change was only needed in the followup PR to https://github.com/godotengine/godot/pull/114917 and I found another solution for that in https://github.com/godotengine/godot/pull/115998/changes/39573cbdb110f0fb9d49e29e7ebc577fc1f1d949