### PR TITLE
Don't remove internal nodes in `Node::replace_by`

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3245,16 +3245,14 @@ void Node::replace_by(RequiredParam<Node> rp_node, bool p_keep_groups) {
 
 	emit_signal(SNAME("replacing_by"), p_node);
 
-	while (get_child_count()) {
-		Node *child = get_child(0);
+	// Move non-internal children to `p_node`.
+	while (get_child_count(false)) {
+		Node *child = get_child(0, false);
 		remove_child(child);
-		if (!child->is_internal()) {
-			// Add the custom children to the p_node.
-			Node *child_owner = child->get_owner() == this ? p_node : child->get_owner();
-			child->set_owner(nullptr);
-			p_node->add_child(child);
-			child->set_owner(child_owner);
-		}
+		Node *child_owner = child->get_owner() == this ? p_node : child->get_owner();
+		child->set_owner(nullptr);
+		p_node->add_child(child);
+		child->set_owner(child_owner);
 	}
 
 	p_node->set_owner(owner);


### PR DESCRIPTION
Fixes #116281.

`Node::replace_by` was removing internal nodes of the node being replaced, and was leaving them orphaned / not freed. Now internal nodes are left in place / are not removed at all.

```gdscript
extends Node

func _ready() -> void:
	var sc := ScrollContainer.new()
	add_child(sc)
	print(get_orphan_node_ids())

	sc.replace_by(Node.new())
	print(get_orphan_node_ids())
	
	sc.free()
	print(get_orphan_node_ids())
```
Example output:
- v4.6.stable.official [89cea1439]:
```
[]
[34611398093, 34644952527, 34678506961, 34712061395, 34745615829, 34779170263]
[34644952527, 34678506961, 34712061395, 34745615829, 34779170263]
```
- This PR:
```
[]
[34728838609, 34762393043, 34795947477, 34829501911, 34863056345, 34896610779]
[]
```