### PR TITLE
Add the option to hold CTRL before dragging to add prefix in code 

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -565,6 +565,7 @@ void ItemList::remove_item(int p_idx) {
 	queue_redraw();
 	shape_changed = true;
 	defer_select_single = -1;
+	defer_select_multi = -1;
 	notify_property_list_changed();
 }
 
@@ -582,6 +583,7 @@ void ItemList::clear() {
 	queue_redraw();
 	shape_changed = true;
 	defer_select_single = -1;
+	defer_select_multi = -1;
 	notify_property_list_changed();
 }
 
@@ -742,8 +744,9 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 	bool scroll_value_modified = false;
 
 	Ref<InputEventMouseMotion> mm = p_event;
-	if (defer_select_single >= 0 && mm.is_valid()) {
+	if ((defer_select_single >= 0 || defer_select_multi >= 0) && mm.is_valid()) {
 		defer_select_single = -1;
+		defer_select_multi = -1;
 		return;
 	}
 
@@ -759,6 +762,18 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 
 		emit_signal(SNAME("multi_selected"), defer_select_single, true);
 		defer_select_single = -1;
+		return;
+	}
+
+	if (defer_select_multi >= 0 && mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && !mb->is_pressed()) {
+		if (items[defer_select_multi].selected) {
+			deselect(defer_select_multi);
+			emit_signal(SNAME("multi_selected"), defer_select_multi, false);
+		} else {
+			select(defer_select_multi, false);
+			emit_signal(SNAME("multi_selected"), defer_select_multi, true);
+		}
+		defer_select_multi = -1;
 		return;
 	}
 
@@ -785,9 +800,9 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 				return;
 			}
 
-			if (select_mode == SELECT_MULTI && items[i].selected && mb->is_command_or_control_pressed()) {
-				deselect(i);
-				emit_signal(SNAME("multi_selected"), i, false);
+			if (select_mode == SELECT_MULTI && mb->is_command_or_control_pressed()) {
+				defer_select_multi = i;
+				return;
 
 			} else if (select_mode == SELECT_MULTI && mb->is_shift_pressed() && current >= 0 && current < items.size() && current != i) {
 				// Range selection.

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -145,6 +145,7 @@ private:
 	Size2 fixed_tag_icon_size;
 
 	int defer_select_single = -1;
+	int defer_select_multi = -1;
 	bool allow_rmb_select = false;
 	bool allow_reselect = false;
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -147,6 +147,10 @@ void TreeItem::_change_tree(Tree *p_tree) {
 			tree->single_select_defer = nullptr;
 		}
 
+		if (tree->multi_select_defer == this) {
+			tree->multi_select_defer = nullptr;
+		}
+
 		if (tree->edited_item == this) {
 			tree->edited_item = nullptr;
 			tree->pressing_for_editor = false;
@@ -3236,14 +3240,8 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 
 			if (c.selectable) {
 				if (select_mode == SELECT_MULTI && p_mod->is_command_or_control_pressed()) {
-					if (c.selected && p_button == MouseButton::LEFT) {
-						p_item->deselect(col);
-						emit_signal(SNAME("multi_selected"), p_item, col, false);
-					} else {
-						p_item->select(col);
-						emit_signal(SNAME("multi_selected"), p_item, col, true);
-						emit_signal(SNAME("item_mouse_selected"), get_local_mouse_position(), p_button);
-					}
+					multi_select_defer = p_item;
+					multi_select_defer_column = col;
 				} else {
 					if (select_mode == SELECT_MULTI && p_mod->is_shift_pressed() && selected_item && selected_item != p_item) {
 						bool inrange = false;
@@ -3273,8 +3271,8 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 			}
 		}
 
-		if (!c.editable) {
-			return -1; // If cell is not editable, don't bother.
+		if (!c.editable || multi_select_defer) {
+			return -1; // If cell is not editable or multi-select is deferred, don't bother.
 		}
 
 		// Editing.
@@ -4121,6 +4119,20 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 				if (single_select_defer) {
 					select_single_item(single_select_defer, root, single_select_defer_column);
 					single_select_defer = nullptr;
+				}
+
+				else if (multi_select_defer) {
+					const TreeItem::Cell &c = multi_select_defer->cells[multi_select_defer_column];
+					if (c.selected) {
+						multi_select_defer->deselect(multi_select_defer_column);
+						emit_signal(SNAME("multi_selected"), multi_select_defer, multi_select_defer_column, false);
+					} else {
+						multi_select_defer->select(multi_select_defer_column);
+						emit_signal(SNAME("multi_selected"), multi_select_defer, multi_select_defer_column, true);
+						emit_signal(SNAME("item_mouse_selected"), get_local_mouse_position(), mb->get_button_index());
+					}
+					multi_select_defer = nullptr;
+					multi_select_defer_column = 0;
 				}
 
 				range_click_timer->stop();
@@ -5079,6 +5091,7 @@ void Tree::_notification(int p_what) {
 
 		case NOTIFICATION_DRAG_BEGIN: {
 			single_select_defer = nullptr;
+			multi_select_defer = nullptr;
 			if (theme_cache.scroll_speed > 0) {
 				scrolling = true;
 				set_process_internal(true);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -495,6 +495,9 @@ private:
 	TreeItem *single_select_defer = nullptr;
 	int single_select_defer_column = 0;
 
+	TreeItem *multi_select_defer = nullptr;
+	int multi_select_defer_column = 0;
+
 	int pressed_button = -1;
 	bool pressing_for_editor = false;
 	Vector2 pressing_pos;


### PR DESCRIPTION
Closes : https://github.com/godotengine/godot-proposals/issues/14230
Closes: https://github.com/godotengine/godot/issues/76358

Add the option to hold CTRL before dragging to add prefix in code, implemented for both tree and item list.
CTRL is hold in both of these exemples :
![workinglist](https://github.com/user-attachments/assets/224bbc0e-6639-4b1e-b2c5-049e078118f4)
![workingtree](https://github.com/user-attachments/assets/f1c3a4d2-4350-4453-8573-47737e1d23ae)

Deffered multi selection in both tree and item list to differentiate between dragging and Select / Deselect.

First PR, I tried to follow the same syntax as current single select defer to add it in both ItemList and Tree. 