### PR TITLE
Fix `AudioStreamPlaybackMicrophone` shutdown crash

### DIFF
--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -1608,6 +1608,11 @@ void AudioServer::update() {
 	for (CallbackItem *ci : update_callback_list) {
 		ci->callback(ci->userdata);
 	}
+
+	_cleanup_lists();
+}
+
+void AudioServer::_cleanup_lists() {
 	mix_callback_list.maybe_cleanup();
 	update_callback_list.maybe_cleanup();
 	listener_changed_callback_list.maybe_cleanup();
@@ -2124,6 +2129,10 @@ AudioServer::AudioServer() {
 }
 
 AudioServer::~AudioServer() {
+	// Cleanup resources while we still have an active AudioServer singleton,
+	// for resources that depend on the singleton still existing.
+	_cleanup_lists();
+
 	singleton = nullptr;
 }
 

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -315,6 +315,8 @@ private:
 	void _delete_stream_playback(Ref<AudioStreamPlayback> p_playback);
 	void _delete_stream_playback_list_node(AudioStreamPlaybackListNode *p_node);
 
+	void _cleanup_lists();
+
 	// TODO document if this is necessary.
 	SafeList<AudioStreamPlaybackBusDetails *> bus_details_graveyard_frame_old;
 


### PR DESCRIPTION
Fixed AudioStreamPlaybackMicrophone rarely attempting to use the AudioServer singleton when it is null, on shutdown.

fixes #116298