### PR TITLE
C#: Optimize C++ to .NET calls with function pointers

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1784,6 +1784,7 @@ Variant CSharpInstance::_callp(const StringName &p_method, const Variant **p_arg
 	}
 
 	if (likely(!script->should_fallback_to_legacy_trampolines)) {
+		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
 		return Variant();
 	}
 
@@ -1817,6 +1818,7 @@ void CSharpInstance::raise_event_signal(const StringName &p_event_signal_name, c
 	}
 
 	if (likely(!script->should_fallback_to_legacy_trampolines)) {
+		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
 		return;
 	}
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1495,10 +1495,11 @@ bool CSharpInstance::set(const StringName &p_name, const Variant &p_value) {
 
 	const CSharpScript::PropertyTrampolines *trampolines = script->property_trampolines.getptr(p_name);
 	if (trampolines) {
-		if (trampolines->setter == nullptr) {
+		if (trampolines->setter.function_pointer == nullptr) {
 			return false;
 		}
-		return trampolines->setter(gchandle.get_intptr(), &p_value);
+		return GDMonoCache::managed_callbacks.CSharpInstanceBridge_SetViaTrampoline(
+				trampolines->setter, gchandle.get_intptr(), &p_value);
 	}
 
 	if (has_method(SNAME("_set"))) {
@@ -1527,12 +1528,13 @@ bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 
 	const CSharpScript::PropertyTrampolines *trampolines = script->property_trampolines.getptr(p_name);
 	if (trampolines) {
-		if (trampolines->getter == nullptr) {
+		if (trampolines->getter.function_pointer == nullptr) {
 			return false;
 		}
 
 		Variant ret_value;
-		if (likely(trampolines->getter(gchandle.get_intptr(), &ret_value))) {
+		if (likely(GDMonoCache::managed_callbacks.CSharpInstanceBridge_GetViaTrampoline(
+					trampolines->getter, gchandle.get_intptr(), &ret_value))) {
 			r_ret = ret_value;
 			return true;
 		}
@@ -1540,7 +1542,7 @@ bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 		return false;
 	}
 
-	for (const KeyValue<CSharpScript::SignalKey, RaiseSignalTrampoline> &kvp : script->raise_signal_trampolines) {
+	for (const KeyValue<CSharpScript::SignalKey, godotsharp::RaiseSignalTrampoline> &kvp : script->raise_signal_trampolines) {
 		if (kvp.key.name == p_name) {
 			r_ret = Signal(owner->get_instance_id(), p_name);
 			return true;
@@ -1770,10 +1772,11 @@ Variant CSharpInstance::_callp(const StringName &p_method, const Variant **p_arg
 		return _callp(*proxy_name, p_args, p_argcount, r_error);
 	}
 
-	const MethodTrampoline *trampoline = script->method_trampolines.getptr(method_key);
+	const godotsharp::MethodTrampoline *trampoline = script->method_trampolines.getptr(method_key);
 	if (trampoline != nullptr) {
 		Variant ret;
-		(*trampoline)(gchandle.get_intptr(), p_args, p_argcount, &r_error, &ret);
+		GDMonoCache::managed_callbacks.CSharpInstanceBridge_CallViaTrampoline(
+				*trampoline, gchandle.get_intptr(), p_args, p_argcount, &r_error, &ret);
 		if (likely(r_error.error == Callable::CallError::CALL_OK)) {
 			return ret;
 		}
@@ -1798,10 +1801,11 @@ Variant CSharpInstance::callp(const StringName &p_method, const Variant **p_args
 void CSharpInstance::raise_event_signal(const StringName &p_event_signal_name, const Variant **p_args, int p_argcount, Callable::CallError &r_error) const {
 	bool owner_is_null = false;
 
-	const RaiseSignalTrampoline *trampoline = script->raise_signal_trampolines.getptr(
+	const godotsharp::RaiseSignalTrampoline *trampoline = script->raise_signal_trampolines.getptr(
 			CSharpScript::SignalKey{ p_event_signal_name, p_argcount });
 	if (trampoline) {
-		(*trampoline)(gchandle.get_intptr(), p_args, p_argcount, &owner_is_null);
+		GDMonoCache::managed_callbacks.ScriptManagerBridge_RaiseEventSignalViaTrampoline(
+				*trampoline, gchandle.get_intptr(), p_args, p_argcount, &owner_is_null);
 
 		if (unlikely(owner_is_null)) {
 			r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
@@ -2383,7 +2387,7 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 		}
 	};
 
-	auto try_add_method_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, MethodTrampoline p_trampoline) {
+	auto try_add_method_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, godotsharp::MethodTrampoline p_trampoline) {
 		MethodKey method_key{ *p_name, p_argc };
 		if (!p_scr->method_trampolines.has(method_key)) {
 			p_scr->method_trampolines.insert_new(method_key, p_trampoline);
@@ -2391,14 +2395,14 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 	};
 
 	auto try_add_property_tramp = [](CSharpScript *p_scr, const StringName *p_name,
-										  PropertyGetterTrampoline p_getter_trampoline,
-										  PropertySetterTrampoline p_setter_trampoline) {
+										  godotsharp::PropertyGetterTrampoline p_getter_trampoline,
+										  godotsharp::PropertySetterTrampoline p_setter_trampoline) {
 		if (!p_scr->property_trampolines.has(*p_name)) {
 			p_scr->property_trampolines.insert_new(*p_name, { p_getter_trampoline, p_setter_trampoline });
 		}
 	};
 
-	auto try_add_raise_signal_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, RaiseSignalTrampoline p_trampoline) {
+	auto try_add_raise_signal_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, godotsharp::RaiseSignalTrampoline p_trampoline) {
 		SignalKey signal_key{ *p_name, p_argc };
 		if (!p_scr->raise_signal_trampolines.has(signal_key)) {
 			p_scr->raise_signal_trampolines.insert_new(signal_key, p_trampoline);
@@ -2685,7 +2689,7 @@ bool CSharpScript::_has_method_mapping_to_proxy_include_base(const StringName &p
 		}
 	}
 
-	for (const KeyValue<MethodKey, MethodTrampoline> &kvp : method_trampolines) {
+	for (const KeyValue<MethodKey, godotsharp::MethodTrampoline> &kvp : method_trampolines) {
 		if (kvp.key.name == p_name) {
 			return true;
 		}

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1493,6 +1493,31 @@ Object *CSharpInstance::get_owner() {
 bool CSharpInstance::set(const StringName &p_name, const Variant &p_value) {
 	ERR_FAIL_COND_V(script.is_null(), false);
 
+	const CSharpScript::PropertyTrampolines *trampolines = script->property_trampolines.getptr(p_name);
+	if (trampolines) {
+		if (trampolines->setter == nullptr) {
+			return false;
+		}
+		return trampolines->setter(gchandle.get_intptr(), &p_value);
+	}
+
+	if (has_method(SNAME("_set"))) {
+		Callable::CallError call_error;
+		const Variant name_arg = p_name;
+		const Variant *args[2]{ &name_arg, &p_value };
+		const Variant ret = _callp(SNAME("_set"), args, 2, call_error);
+
+		if (ret.get_type() == Variant::NIL || call_error.error != Callable::CallError::CALL_OK) {
+			return false;
+		}
+
+		return true;
+	}
+
+	if (likely(!script->should_fallback_to_legacy_trampolines)) {
+		return false;
+	}
+
 	return GDMonoCache::managed_callbacks.CSharpInstanceBridge_Set(
 			gchandle.get_intptr(), &p_name, &p_value);
 }
@@ -1500,12 +1525,54 @@ bool CSharpInstance::set(const StringName &p_name, const Variant &p_value) {
 bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 	ERR_FAIL_COND_V(script.is_null(), false);
 
+	const CSharpScript::PropertyTrampolines *trampolines = script->property_trampolines.getptr(p_name);
+	if (trampolines) {
+		if (trampolines->getter == nullptr) {
+			return false;
+		}
+
+		Variant ret_value;
+		if (likely(trampolines->getter(gchandle.get_intptr(), &ret_value))) {
+			r_ret = ret_value;
+			return true;
+		}
+
+		return false;
+	}
+
+	for (const KeyValue<CSharpScript::SignalKey, RaiseSignalTrampoline> &kvp : script->raise_signal_trampolines) {
+		if (kvp.key.name == p_name) {
+			r_ret = Signal(owner->get_instance_id(), p_name);
+			return true;
+		}
+	}
+
+	if (script->_has_method_mapping_to_proxy_include_base(p_name)) {
+		r_ret = Callable(owner->get_instance_id(), p_name);
+		return true;
+	}
+
+	if (has_method(SNAME("_get"))) {
+		Callable::CallError call_error;
+		const Variant name_arg = p_name;
+		const Variant *args[1]{ &name_arg };
+		const Variant ret = _callp(SNAME("_get"), args, 1, call_error);
+
+		if (ret.get_type() == Variant::NIL || call_error.error != Callable::CallError::CALL_OK) {
+			r_ret = Variant();
+			return false;
+		}
+
+		r_ret = ret;
+		return true;
+	}
+
+	if (likely(!script->should_fallback_to_legacy_trampolines)) {
+		return false;
+	}
+
 	Variant ret_value;
-
-	bool ret = GDMonoCache::managed_callbacks.CSharpInstanceBridge_Get(
-			gchandle.get_intptr(), &p_name, &ret_value);
-
-	if (ret) {
+	if (GDMonoCache::managed_callbacks.CSharpInstanceBridge_Get(gchandle.get_intptr(), &p_name, &ret_value)) {
 		r_ret = ret_value;
 		return true;
 	}
@@ -1535,17 +1602,13 @@ void CSharpInstance::get_property_list(List<PropertyInfo> *p_properties) const {
 
 	StringName method = SNAME("_get_property_list");
 
-	Variant ret;
 	Callable::CallError call_error;
-	bool ok = GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
-			gchandle.get_intptr(), &method, nullptr, 0, &call_error, &ret);
+	Variant ret = _callp(method, nullptr, 0, call_error);
 
 	// CALL_ERROR_INVALID_METHOD would simply mean it was not overridden
 	if (call_error.error != Callable::CallError::CALL_ERROR_INVALID_METHOD) {
 		if (call_error.error != Callable::CallError::CALL_OK) {
 			ERR_PRINT("Error calling '_get_property_list': " + Variant::get_call_error_text(method, nullptr, 0, call_error));
-		} else if (!ok) {
-			ERR_PRINT("Unexpected error calling '_get_property_list'");
 		} else {
 			Array array = ret;
 			for (int i = 0, size = array.size(); i < size; i++) {
@@ -1597,16 +1660,14 @@ bool CSharpInstance::property_can_revert(const StringName &p_name) const {
 	Variant name_arg = p_name;
 	const Variant *args[1] = { &name_arg };
 
-	Variant ret;
 	Callable::CallError call_error;
-	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
-			gchandle.get_intptr(), &SNAME("_property_can_revert"), args, 1, &call_error, &ret);
+	Variant ret = _callp(SNAME("_property_can_revert"), args, 1, call_error);
 
 	if (call_error.error != Callable::CallError::CALL_OK) {
 		return false;
 	}
 
-	return (bool)ret;
+	return ret;
 }
 
 void CSharpInstance::validate_property(PropertyInfo &p_property) const {
@@ -1615,10 +1676,8 @@ void CSharpInstance::validate_property(PropertyInfo &p_property) const {
 	Variant property_arg = (Dictionary)p_property;
 	const Variant *args[1] = { &property_arg };
 
-	Variant ret;
 	Callable::CallError call_error;
-	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
-			gchandle.get_intptr(), &SNAME("_validate_property"), args, 1, &call_error, &ret);
+	Variant ret = _callp(SNAME("_validate_property"), args, 1, call_error);
 
 	if (call_error.error != Callable::CallError::CALL_OK) {
 		return;
@@ -1633,10 +1692,8 @@ bool CSharpInstance::property_get_revert(const StringName &p_name, Variant &r_re
 	Variant name_arg = p_name;
 	const Variant *args[1] = { &name_arg };
 
-	Variant ret;
 	Callable::CallError call_error;
-	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
-			gchandle.get_intptr(), &SNAME("_property_get_revert"), args, 1, &call_error, &ret);
+	Variant ret = _callp(SNAME("_property_get_revert"), args, 1, call_error);
 
 	if (call_error.error != Callable::CallError::CALL_OK) {
 		return false;
@@ -1660,6 +1717,14 @@ bool CSharpInstance::has_method(const StringName &p_method) const {
 	}
 
 	if (!GDMonoCache::godot_api_cache_updated) {
+		return false;
+	}
+
+	if (script->_has_method_mapping_to_proxy_include_base(p_method)) {
+		return true;
+	}
+
+	if (likely(!script->should_fallback_to_legacy_trampolines)) {
 		return false;
 	}
 
@@ -1695,14 +1760,71 @@ int CSharpInstance::get_method_argument_count(const StringName &p_method, bool *
 	return 0;
 }
 
-Variant CSharpInstance::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+Variant CSharpInstance::_callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) const {
 	ERR_FAIL_COND_V(script.is_null(), Variant());
+
+	const CSharpScript::MethodKey method_key{ p_method, p_argcount };
+
+	const StringName *proxy_name = script->name_to_proxy_name_map.getptr(method_key);
+	if (proxy_name != nullptr) {
+		return _callp(*proxy_name, p_args, p_argcount, r_error);
+	}
+
+	const MethodTrampoline *trampoline = script->method_trampolines.getptr(method_key);
+	if (trampoline != nullptr) {
+		Variant ret;
+		(*trampoline)(gchandle.get_intptr(), p_args, p_argcount, &r_error, &ret);
+		if (likely(r_error.error == Callable::CallError::CALL_OK)) {
+			return ret;
+		}
+		return Variant();
+	}
+
+	if (likely(!script->should_fallback_to_legacy_trampolines)) {
+		return Variant();
+	}
 
 	Variant ret;
 	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
 			gchandle.get_intptr(), &p_method, p_args, p_argcount, &r_error, &ret);
 
 	return ret;
+}
+
+Variant CSharpInstance::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+	return _callp(p_method, p_args, p_argcount, r_error);
+}
+
+void CSharpInstance::raise_event_signal(const StringName &p_event_signal_name, const Variant **p_args, int p_argcount, Callable::CallError &r_error) const {
+	bool owner_is_null = false;
+
+	const RaiseSignalTrampoline *trampoline = script->raise_signal_trampolines.getptr(
+			CSharpScript::SignalKey{ p_event_signal_name, p_argcount });
+	if (trampoline) {
+		(*trampoline)(gchandle.get_intptr(), p_args, p_argcount, &owner_is_null);
+
+		if (unlikely(owner_is_null)) {
+			r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
+		} else {
+			r_error.error = Callable::CallError::CALL_OK;
+		}
+
+		return;
+	}
+
+	if (likely(!script->should_fallback_to_legacy_trampolines)) {
+		return;
+	}
+
+	GDMonoCache::managed_callbacks.ScriptManagerBridge_RaiseEventSignal(
+			gchandle.get_intptr(), &p_event_signal_name,
+			p_args, p_argcount, &owner_is_null);
+
+	if (unlikely(owner_is_null)) {
+		r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
+	} else {
+		r_error.error = Callable::CallError::CALL_OK;
+	}
 }
 
 bool CSharpInstance::_reference_owner_unsafe() {
@@ -1953,14 +2075,12 @@ void CSharpInstance::notification(int p_notification, bool p_reversed) {
 	_call_notification(p_notification, p_reversed);
 }
 
-void CSharpInstance::_call_notification(int p_notification, bool p_reversed) {
+void CSharpInstance::_call_notification(int p_notification, bool p_reversed) const {
 	Variant arg = p_notification;
 	const Variant *args[1] = { &arg };
 
-	Variant ret;
 	Callable::CallError call_error;
-	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
-			gchandle.get_intptr(), &SNAME("_notification"), args, 1, &call_error, &ret);
+	_callp(SNAME("_notification"), args, 1, call_error);
 }
 
 String CSharpInstance::to_string(bool *r_valid) {
@@ -2252,6 +2372,43 @@ void CSharpScript::reload_registered_script(Ref<CSharpScript> p_script) {
 
 // Extract information about the script using the mono class.
 void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
+	p_script->method_trampolines.clear();
+	p_script->property_trampolines.clear();
+	p_script->raise_signal_trampolines.clear();
+
+	auto try_add_name_to_proxy_name_map = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, const StringName *p_proxy_name) {
+		MethodKey method_key{ *p_name, p_argc };
+		if (!p_scr->name_to_proxy_name_map.has(method_key)) {
+			p_scr->name_to_proxy_name_map.insert_new(method_key, *p_proxy_name);
+		}
+	};
+
+	auto try_add_method_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, MethodTrampoline p_trampoline) {
+		MethodKey method_key{ *p_name, p_argc };
+		if (!p_scr->method_trampolines.has(method_key)) {
+			p_scr->method_trampolines.insert_new(method_key, p_trampoline);
+		}
+	};
+
+	auto try_add_property_tramp = [](CSharpScript *p_scr, const StringName *p_name,
+										  PropertyGetterTrampoline p_getter_trampoline,
+										  PropertySetterTrampoline p_setter_trampoline) {
+		if (!p_scr->property_trampolines.has(*p_name)) {
+			p_scr->property_trampolines.insert_new(*p_name, { p_getter_trampoline, p_setter_trampoline });
+		}
+	};
+
+	auto try_add_raise_signal_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, RaiseSignalTrampoline p_trampoline) {
+		SignalKey signal_key{ *p_name, p_argc };
+		if (!p_scr->raise_signal_trampolines.has(signal_key)) {
+			p_scr->raise_signal_trampolines.insert_new(signal_key, p_trampoline);
+		}
+	};
+
+	GDMonoCache::managed_callbacks.ScriptManagerBridge_UpdateScriptTrampolines(
+			p_script.ptr(), &p_script->should_fallback_to_legacy_trampolines, try_add_name_to_proxy_name_map,
+			try_add_method_tramp, try_add_property_tramp, try_add_raise_signal_tramp);
+
 	TypeInfo type_info;
 
 	// TODO: Use GDExtension godot_dictionary
@@ -2521,9 +2678,44 @@ void CSharpScript::get_script_method_list(List<MethodInfo> *p_list) const {
 	}
 }
 
+bool CSharpScript::_has_method_mapping_to_proxy_include_base(const StringName &p_name) const {
+	for (const KeyValue<MethodKey, StringName> &kvp : name_to_proxy_name_map) {
+		if (kvp.key.name == p_name) {
+			return true;
+		}
+	}
+
+	for (const KeyValue<MethodKey, MethodTrampoline> &kvp : method_trampolines) {
+		if (kvp.key.name == p_name) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 bool CSharpScript::has_method(const StringName &p_method) const {
 	if (!valid) {
 		return false;
+	}
+
+	// TODO: This is a behavior change, which might cause regressions.
+	//       Previously it would return 'false' for names like '_process' and 'true' for '_Process'.
+	//       Now it checks both. This feels correct, but is it worth risking regressions?
+
+	for (const KeyValue<MethodKey, StringName> &kvp : name_to_proxy_name_map) {
+		if (kvp.key.name == p_method) {
+			const StringName &proxy_name = kvp.value;
+			// Name to proxy name map found, but it may be from an inherited script.
+			// We don't want that here, so make sure it's in 'methods' (which excludes inherited ones).
+			for (const CSharpMethodInfo &E : methods) {
+				if (E.name == proxy_name) {
+					return true;
+				}
+			}
+			// Break instead of returning false. The script still contain a method with the non-proxy name.
+			break;
+		}
 	}
 
 	for (const CSharpMethodInfo &E : methods) {
@@ -2694,7 +2886,7 @@ void CSharpScript::_get_script_signal_list(List<MethodInfo> *r_signals, bool p_i
 }
 
 void CSharpScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
-	_get_script_signal_list(r_signals, true);
+	_get_script_signal_list(r_signals, /* include_base */ true);
 }
 
 bool CSharpScript::inherits_script(const Ref<Script> &p_script) const {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1767,11 +1767,6 @@ Variant CSharpInstance::_callp(const StringName &p_method, const Variant **p_arg
 
 	const CSharpScript::MethodKey method_key{ p_method, p_argcount };
 
-	const StringName *proxy_name = script->name_to_proxy_name_map.getptr(method_key);
-	if (proxy_name != nullptr) {
-		return _callp(*proxy_name, p_args, p_argcount, r_error);
-	}
-
 	const godotsharp::MethodTrampoline *trampoline = script->method_trampolines.getptr(method_key);
 	if (trampoline != nullptr) {
 		Variant ret;
@@ -2381,13 +2376,6 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 	p_script->property_trampolines.clear();
 	p_script->raise_signal_trampolines.clear();
 
-	auto try_add_name_to_proxy_name_map = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, const StringName *p_proxy_name) {
-		MethodKey method_key{ *p_name, p_argc };
-		if (!p_scr->name_to_proxy_name_map.has(method_key)) {
-			p_scr->name_to_proxy_name_map.insert_new(method_key, *p_proxy_name);
-		}
-	};
-
 	auto try_add_method_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc,
 										godotsharp::MethodTrampoline p_trampoline, bool p_is_static) {
 		MethodKey method_key{ *p_name, p_argc };
@@ -2431,7 +2419,7 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 	};
 
 	GDMonoCache::managed_callbacks.ScriptManagerBridge_UpdateScriptTrampolines(
-			p_script.ptr(), &p_script->should_fallback_to_legacy_trampolines, try_add_name_to_proxy_name_map,
+			p_script.ptr(), &p_script->should_fallback_to_legacy_trampolines,
 			try_add_method_tramp, try_add_property_tramp, try_add_raise_signal_tramp);
 
 	TypeInfo type_info;
@@ -2704,12 +2692,6 @@ void CSharpScript::get_script_method_list(List<MethodInfo> *p_list) const {
 }
 
 bool CSharpScript::_has_method_mapping_to_proxy_include_base(const StringName &p_name) const {
-	for (const KeyValue<MethodKey, StringName> &kvp : name_to_proxy_name_map) {
-		if (kvp.key.name == p_name) {
-			return true;
-		}
-	}
-
 	for (const KeyValue<MethodKey, godotsharp::MethodTrampoline> &kvp : method_trampolines) {
 		if (kvp.key.name == p_name) {
 			return true;
@@ -2722,25 +2704,6 @@ bool CSharpScript::_has_method_mapping_to_proxy_include_base(const StringName &p
 bool CSharpScript::has_method(const StringName &p_method) const {
 	if (!valid) {
 		return false;
-	}
-
-	// TODO: This is a behavior change, which might cause regressions.
-	//       Previously it would return 'false' for names like '_process' and 'true' for '_Process'.
-	//       Now it checks both. This feels correct, but is it worth risking regressions?
-
-	for (const KeyValue<MethodKey, StringName> &kvp : name_to_proxy_name_map) {
-		if (kvp.key.name == p_method) {
-			const StringName &proxy_name = kvp.value;
-			// Name to proxy name map found, but it may be from an inherited script.
-			// We don't want that here, so make sure it's in 'methods' (which excludes inherited ones).
-			for (const CSharpMethodInfo &E : methods) {
-				if (E.name == proxy_name) {
-					return true;
-				}
-			}
-			// Break instead of returning false. The script still contain a method with the non-proxy name.
-			break;
-		}
 	}
 
 	for (const CSharpMethodInfo &E : methods) {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2397,7 +2397,22 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 	auto try_add_property_tramp = [](CSharpScript *p_scr, const StringName *p_name,
 										  godotsharp::PropertyGetterTrampoline p_getter_trampoline,
 										  godotsharp::PropertySetterTrampoline p_setter_trampoline) {
-		if (!p_scr->property_trampolines.has(*p_name)) {
+		DEV_ASSERT(p_getter_trampoline.function_pointer != nullptr || p_setter_trampoline.function_pointer != nullptr);
+
+		PropertyTrampolines *found = p_scr->property_trampolines.getptr(*p_name);
+		if (found) {
+			// Could not have added an entry where both are null.
+			DEV_ASSERT(found->getter.function_pointer != nullptr || found->setter.function_pointer != nullptr);
+
+			// If an entry already exists, we still replace one of the trampolines if it's null.
+			// This matches the behavior of Get/SetGodotClassPropertyValue, which will continue
+			// looking in base classes if the property in the current class is readonly/writeonly.
+			if (p_getter_trampoline.function_pointer && !found->getter.function_pointer) {
+				found->getter = p_getter_trampoline;
+			} else if (p_setter_trampoline.function_pointer && !found->setter.function_pointer) {
+				found->setter = p_setter_trampoline;
+			}
+		} else {
 			p_scr->property_trampolines.insert_new(*p_name, { p_getter_trampoline, p_setter_trampoline });
 		}
 	};

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2376,6 +2376,7 @@ void CSharpScript::reload_registered_script(Ref<CSharpScript> p_script) {
 
 // Extract information about the script using the mono class.
 void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
+	p_script->static_method_trampolines.clear();
 	p_script->method_trampolines.clear();
 	p_script->property_trampolines.clear();
 	p_script->raise_signal_trampolines.clear();
@@ -2387,10 +2388,14 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 		}
 	};
 
-	auto try_add_method_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, godotsharp::MethodTrampoline p_trampoline) {
+	auto try_add_method_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc,
+										godotsharp::MethodTrampoline p_trampoline, bool p_is_static) {
 		MethodKey method_key{ *p_name, p_argc };
 		if (!p_scr->method_trampolines.has(method_key)) {
 			p_scr->method_trampolines.insert_new(method_key, p_trampoline);
+		}
+		if (p_is_static) {
+			p_scr->static_method_trampolines.insert_new(method_key, p_trampoline);
 		}
 	};
 
@@ -2417,7 +2422,8 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 		}
 	};
 
-	auto try_add_raise_signal_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, godotsharp::RaiseSignalTrampoline p_trampoline) {
+	auto try_add_raise_signal_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc,
+											  godotsharp::RaiseSignalTrampoline p_trampoline) {
 		SignalKey signal_key{ *p_name, p_argc };
 		if (!p_scr->raise_signal_trampolines.has(signal_key)) {
 			p_scr->raise_signal_trampolines.insert_new(signal_key, p_trampoline);
@@ -2790,13 +2796,37 @@ MethodInfo CSharpScript::get_method_info(const StringName &p_method) const {
 	return mi;
 }
 
-Variant CSharpScript::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
-	if (valid) {
-		Variant ret;
-		bool ok = GDMonoCache::managed_callbacks.ScriptManagerBridge_CallStatic(this, &p_method, p_args, p_argcount, &r_error, &ret);
-		if (ok) {
-			return ret;
+bool CSharpScript::_callp_static(const CSharpScript *p_script, const StringName &p_method,
+		const Variant **p_args, int p_argcount, Callable::CallError &r_error, Variant &r_ret) {
+	if (!p_script->valid) {
+		return false;
+	}
+
+	const MethodKey method_key{ p_method, p_argcount };
+
+	const godotsharp::MethodTrampoline *trampoline = p_script->static_method_trampolines.getptr(method_key);
+	if (trampoline != nullptr) {
+		GDMonoCache::managed_callbacks.ScriptManagerBridge_CallStaticWithTrampoline(
+				*trampoline, p_args, p_argcount, &r_error, &r_ret);
+		if (likely(r_error.error == Callable::CallError::CALL_OK)) {
+			return true;
 		}
+		return false;
+	}
+
+	if (likely(!p_script->should_fallback_to_legacy_trampolines)) {
+		return false;
+	}
+
+	Variant ret;
+	return GDMonoCache::managed_callbacks.ScriptManagerBridge_CallStatic(
+			p_script, &p_method, p_args, p_argcount, &r_error, &ret);
+}
+
+Variant CSharpScript::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+	Variant ret;
+	if (_callp_static(this, p_method, p_args, p_argcount, r_error, ret)) {
+		return ret;
 	}
 
 	return Script::callp(p_method, p_args, p_argcount, r_error);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1502,6 +1502,13 @@ bool CSharpInstance::set(const StringName &p_name, const Variant &p_value) {
 				trampolines->setter, gchandle.get_intptr(), &p_value);
 	}
 
+	if (unlikely(script->should_fallback_to_legacy_trampolines)) {
+		// The legacy CSharpInstanceBridge.Set already calls "_set" as a last resort,
+		// so don't continue after this branch.
+		return GDMonoCache::managed_callbacks.CSharpInstanceBridge_Set(
+				gchandle.get_intptr(), &p_name, &p_value);
+	}
+
 	if (has_method(SNAME("_set"))) {
 		Callable::CallError call_error;
 		const Variant name_arg = p_name;
@@ -1515,12 +1522,7 @@ bool CSharpInstance::set(const StringName &p_name, const Variant &p_value) {
 		return true;
 	}
 
-	if (likely(!script->should_fallback_to_legacy_trampolines)) {
-		return false;
-	}
-
-	return GDMonoCache::managed_callbacks.CSharpInstanceBridge_Set(
-			gchandle.get_intptr(), &p_name, &p_value);
+	return false;
 }
 
 bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
@@ -1535,6 +1537,19 @@ bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 		Variant ret_value;
 		if (likely(GDMonoCache::managed_callbacks.CSharpInstanceBridge_GetViaTrampoline(
 					trampolines->getter, gchandle.get_intptr(), &ret_value))) {
+			r_ret = ret_value;
+			return true;
+		}
+
+		return false;
+	}
+
+	if (unlikely(script->should_fallback_to_legacy_trampolines)) {
+		// The legacy CSharpInstanceBridge.Get already handles signal and method objects,
+		// and calls "_get" as a last resort, so don't continue after this branch.
+
+		Variant ret_value;
+		if (GDMonoCache::managed_callbacks.CSharpInstanceBridge_Get(gchandle.get_intptr(), &p_name, &ret_value)) {
 			r_ret = ret_value;
 			return true;
 		}
@@ -1566,16 +1581,6 @@ bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 		}
 
 		r_ret = ret;
-		return true;
-	}
-
-	if (likely(!script->should_fallback_to_legacy_trampolines)) {
-		return false;
-	}
-
-	Variant ret_value;
-	if (GDMonoCache::managed_callbacks.CSharpInstanceBridge_Get(gchandle.get_intptr(), &p_name, &ret_value)) {
-		r_ret = ret_value;
 		return true;
 	}
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1489,6 +1489,31 @@ Object *CSharpInstance::get_owner() {
 bool CSharpInstance::set(const StringName &p_name, const Variant &p_value) {
 	ERR_FAIL_COND_V(script.is_null(), false);
 
+	const CSharpScript::PropertyTrampolines *trampolines = script->property_trampolines.getptr(p_name);
+	if (trampolines) {
+		if (trampolines->setter == nullptr) {
+			return false;
+		}
+		return trampolines->setter(gchandle.get_intptr(), &p_value);
+	}
+
+	if (has_method(SNAME("_set"))) {
+		Callable::CallError call_error;
+		const Variant name_arg = p_name;
+		const Variant *args[2]{ &name_arg, &p_value };
+		const Variant ret = _callp(SNAME("_set"), args, 2, call_error);
+
+		if (ret.get_type() == Variant::NIL || call_error.error != Callable::CallError::CALL_OK) {
+			return false;
+		}
+
+		return true;
+	}
+
+	if (likely(!script->should_fallback_to_legacy_trampolines)) {
+		return false;
+	}
+
 	return GDMonoCache::managed_callbacks.CSharpInstanceBridge_Set(
 			gchandle.get_intptr(), &p_name, &p_value);
 }
@@ -1496,12 +1521,54 @@ bool CSharpInstance::set(const StringName &p_name, const Variant &p_value) {
 bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 	ERR_FAIL_COND_V(script.is_null(), false);
 
+	const CSharpScript::PropertyTrampolines *trampolines = script->property_trampolines.getptr(p_name);
+	if (trampolines) {
+		if (trampolines->getter == nullptr) {
+			return false;
+		}
+
+		Variant ret_value;
+		if (likely(trampolines->getter(gchandle.get_intptr(), &ret_value))) {
+			r_ret = ret_value;
+			return true;
+		}
+
+		return false;
+	}
+
+	for (const KeyValue<CSharpScript::SignalKey, RaiseSignalTrampoline> &kvp : script->raise_signal_trampolines) {
+		if (kvp.key.name == p_name) {
+			r_ret = Signal(owner->get_instance_id(), p_name);
+			return true;
+		}
+	}
+
+	if (script->_has_method_mapping_to_proxy_include_base(p_name)) {
+		r_ret = Callable(owner->get_instance_id(), p_name);
+		return true;
+	}
+
+	if (has_method(SNAME("_get"))) {
+		Callable::CallError call_error;
+		const Variant name_arg = p_name;
+		const Variant *args[1]{ &name_arg };
+		const Variant ret = _callp(SNAME("_get"), args, 1, call_error);
+
+		if (ret.get_type() == Variant::NIL || call_error.error != Callable::CallError::CALL_OK) {
+			r_ret = Variant();
+			return false;
+		}
+
+		r_ret = ret;
+		return true;
+	}
+
+	if (likely(!script->should_fallback_to_legacy_trampolines)) {
+		return false;
+	}
+
 	Variant ret_value;
-
-	bool ret = GDMonoCache::managed_callbacks.CSharpInstanceBridge_Get(
-			gchandle.get_intptr(), &p_name, &ret_value);
-
-	if (ret) {
+	if (GDMonoCache::managed_callbacks.CSharpInstanceBridge_Get(gchandle.get_intptr(), &p_name, &ret_value)) {
 		r_ret = ret_value;
 		return true;
 	}
@@ -1531,17 +1598,13 @@ void CSharpInstance::get_property_list(List<PropertyInfo> *p_properties) const {
 
 	StringName method = SNAME("_get_property_list");
 
-	Variant ret;
 	Callable::CallError call_error;
-	bool ok = GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
-			gchandle.get_intptr(), &method, nullptr, 0, &call_error, &ret);
+	Variant ret = _callp(method, nullptr, 0, call_error);
 
 	// CALL_ERROR_INVALID_METHOD would simply mean it was not overridden
 	if (call_error.error != Callable::CallError::CALL_ERROR_INVALID_METHOD) {
 		if (call_error.error != Callable::CallError::CALL_OK) {
 			ERR_PRINT("Error calling '_get_property_list': " + Variant::get_call_error_text(method, nullptr, 0, call_error));
-		} else if (!ok) {
-			ERR_PRINT("Unexpected error calling '_get_property_list'");
 		} else {
 			Array array = ret;
 			for (int i = 0, size = array.size(); i < size; i++) {
@@ -1593,16 +1656,14 @@ bool CSharpInstance::property_can_revert(const StringName &p_name) const {
 	Variant name_arg = p_name;
 	const Variant *args[1] = { &name_arg };
 
-	Variant ret;
 	Callable::CallError call_error;
-	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
-			gchandle.get_intptr(), &SNAME("_property_can_revert"), args, 1, &call_error, &ret);
+	Variant ret = _callp(SNAME("_property_can_revert"), args, 1, call_error);
 
 	if (call_error.error != Callable::CallError::CALL_OK) {
 		return false;
 	}
 
-	return (bool)ret;
+	return ret;
 }
 
 void CSharpInstance::validate_property(PropertyInfo &p_property) const {
@@ -1611,10 +1672,8 @@ void CSharpInstance::validate_property(PropertyInfo &p_property) const {
 	Variant property_arg = (Dictionary)p_property;
 	const Variant *args[1] = { &property_arg };
 
-	Variant ret;
 	Callable::CallError call_error;
-	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
-			gchandle.get_intptr(), &SNAME("_validate_property"), args, 1, &call_error, &ret);
+	_callp(SNAME("_validate_property"), args, 1, call_error);
 
 	if (call_error.error != Callable::CallError::CALL_OK) {
 		return;
@@ -1629,10 +1688,8 @@ bool CSharpInstance::property_get_revert(const StringName &p_name, Variant &r_re
 	Variant name_arg = p_name;
 	const Variant *args[1] = { &name_arg };
 
-	Variant ret;
 	Callable::CallError call_error;
-	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
-			gchandle.get_intptr(), &SNAME("_property_get_revert"), args, 1, &call_error, &ret);
+	Variant ret = _callp(SNAME("_property_get_revert"), args, 1, call_error);
 
 	if (call_error.error != Callable::CallError::CALL_OK) {
 		return false;
@@ -1656,6 +1713,14 @@ bool CSharpInstance::has_method(const StringName &p_method) const {
 	}
 
 	if (!GDMonoCache::godot_api_cache_updated) {
+		return false;
+	}
+
+	if (script->_has_method_mapping_to_proxy_include_base(p_method)) {
+		return true;
+	}
+
+	if (likely(!script->should_fallback_to_legacy_trampolines)) {
 		return false;
 	}
 
@@ -1691,14 +1756,71 @@ int CSharpInstance::get_method_argument_count(const StringName &p_method, bool *
 	return 0;
 }
 
-Variant CSharpInstance::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+Variant CSharpInstance::_callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) const {
 	ERR_FAIL_COND_V(script.is_null(), Variant());
+
+	const CSharpScript::MethodKey method_key{ p_method, p_argcount };
+
+	const StringName *proxy_name = script->name_to_proxy_name_map.getptr(method_key);
+	if (proxy_name != nullptr) {
+		return _callp(*proxy_name, p_args, p_argcount, r_error);
+	}
+
+	const MethodTrampoline *trampoline = script->method_trampolines.getptr(method_key);
+	if (trampoline != nullptr) {
+		Variant ret;
+		(*trampoline)(gchandle.get_intptr(), p_args, p_argcount, &r_error, &ret);
+		if (likely(r_error.error == Callable::CallError::CALL_OK)) {
+			return ret;
+		}
+		return Variant();
+	}
+
+	if (likely(!script->should_fallback_to_legacy_trampolines)) {
+		return Variant();
+	}
 
 	Variant ret;
 	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
 			gchandle.get_intptr(), &p_method, p_args, p_argcount, &r_error, &ret);
 
 	return ret;
+}
+
+Variant CSharpInstance::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+	return _callp(p_method, p_args, p_argcount, r_error);
+}
+
+void CSharpInstance::raise_event_signal(const StringName &p_event_signal_name, const Variant **p_args, int p_argcount, Callable::CallError &r_error) const {
+	bool owner_is_null = false;
+
+	const RaiseSignalTrampoline *trampoline = script->raise_signal_trampolines.getptr(
+			CSharpScript::SignalKey{ p_event_signal_name, p_argcount });
+	if (trampoline) {
+		(*trampoline)(gchandle.get_intptr(), p_args, p_argcount, &owner_is_null);
+
+		if (unlikely(owner_is_null)) {
+			r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
+		} else {
+			r_error.error = Callable::CallError::CALL_OK;
+		}
+
+		return;
+	}
+
+	if (likely(!script->should_fallback_to_legacy_trampolines)) {
+		return;
+	}
+
+	GDMonoCache::managed_callbacks.ScriptManagerBridge_RaiseEventSignal(
+			gchandle.get_intptr(), &p_event_signal_name,
+			p_args, p_argcount, &owner_is_null);
+
+	if (unlikely(owner_is_null)) {
+		r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
+	} else {
+		r_error.error = Callable::CallError::CALL_OK;
+	}
 }
 
 bool CSharpInstance::_reference_owner_unsafe() {
@@ -1949,14 +2071,12 @@ void CSharpInstance::notification(int p_notification, bool p_reversed) {
 	_call_notification(p_notification, p_reversed);
 }
 
-void CSharpInstance::_call_notification(int p_notification, bool p_reversed) {
+void CSharpInstance::_call_notification(int p_notification, bool p_reversed) const {
 	Variant arg = p_notification;
 	const Variant *args[1] = { &arg };
 
-	Variant ret;
 	Callable::CallError call_error;
-	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
-			gchandle.get_intptr(), &SNAME("_notification"), args, 1, &call_error, &ret);
+	_callp(SNAME("_notification"), args, 1, call_error);
 }
 
 String CSharpInstance::to_string(bool *r_valid) {
@@ -2248,6 +2368,43 @@ void CSharpScript::reload_registered_script(Ref<CSharpScript> p_script) {
 
 // Extract information about the script using the mono class.
 void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
+	p_script->method_trampolines.clear();
+	p_script->property_trampolines.clear();
+	p_script->raise_signal_trampolines.clear();
+
+	auto try_add_name_to_proxy_name_map = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, const StringName *p_proxy_name) {
+		MethodKey method_key{ *p_name, p_argc };
+		if (!p_scr->name_to_proxy_name_map.has(method_key)) {
+			p_scr->name_to_proxy_name_map.insert_new(method_key, *p_proxy_name);
+		}
+	};
+
+	auto try_add_method_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, MethodTrampoline p_trampoline) {
+		MethodKey method_key{ *p_name, p_argc };
+		if (!p_scr->method_trampolines.has(method_key)) {
+			p_scr->method_trampolines.insert_new(method_key, p_trampoline);
+		}
+	};
+
+	auto try_add_property_tramp = [](CSharpScript *p_scr, const StringName *p_name,
+										  PropertyGetterTrampoline p_getter_trampoline,
+										  PropertySetterTrampoline p_setter_trampoline) {
+		if (!p_scr->property_trampolines.has(*p_name)) {
+			p_scr->property_trampolines.insert_new(*p_name, { p_getter_trampoline, p_setter_trampoline });
+		}
+	};
+
+	auto try_add_raise_signal_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, RaiseSignalTrampoline p_trampoline) {
+		SignalKey signal_key{ *p_name, p_argc };
+		if (!p_scr->raise_signal_trampolines.has(signal_key)) {
+			p_scr->raise_signal_trampolines.insert_new(signal_key, p_trampoline);
+		}
+	};
+
+	GDMonoCache::managed_callbacks.ScriptManagerBridge_UpdateScriptTrampolines(
+			p_script.ptr(), &p_script->should_fallback_to_legacy_trampolines, try_add_name_to_proxy_name_map,
+			try_add_method_tramp, try_add_property_tramp, try_add_raise_signal_tramp);
+
 	TypeInfo type_info;
 
 	// TODO: Use GDExtension godot_dictionary
@@ -2517,9 +2674,44 @@ void CSharpScript::get_script_method_list(List<MethodInfo> *p_list) const {
 	}
 }
 
+bool CSharpScript::_has_method_mapping_to_proxy_include_base(const StringName &p_name) const {
+	for (const KeyValue<MethodKey, StringName> &kvp : name_to_proxy_name_map) {
+		if (kvp.key.name == p_name) {
+			return true;
+		}
+	}
+
+	for (const KeyValue<MethodKey, MethodTrampoline> &kvp : method_trampolines) {
+		if (kvp.key.name == p_name) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 bool CSharpScript::has_method(const StringName &p_method) const {
 	if (!valid) {
 		return false;
+	}
+
+	// TODO: This is a behavior change, which might cause regressions.
+	//       Previously it would return 'false' for names like '_process' and 'true' for '_Process'.
+	//       Now it checks both. This feels correct, but is it worth risking regressions?
+
+	for (const KeyValue<MethodKey, StringName> &kvp : name_to_proxy_name_map) {
+		if (kvp.key.name == p_method) {
+			const StringName &proxy_name = kvp.value;
+			// Name to proxy name map found, but it may be from an inherited script.
+			// We don't want that here, so make sure it's in 'methods' (which excludes inherited ones).
+			for (const CSharpMethodInfo &E : methods) {
+				if (E.name == proxy_name) {
+					return true;
+				}
+			}
+			// Break instead of returning false. The script still contain a method with the non-proxy name.
+			break;
+		}
 	}
 
 	for (const CSharpMethodInfo &E : methods) {
@@ -2690,7 +2882,7 @@ void CSharpScript::_get_script_signal_list(List<MethodInfo> *r_signals, bool p_i
 }
 
 void CSharpScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
-	_get_script_signal_list(r_signals, true);
+	_get_script_signal_list(r_signals, /* include_base */ true);
 }
 
 bool CSharpScript::inherits_script(const Ref<Script> &p_script) const {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1491,10 +1491,11 @@ bool CSharpInstance::set(const StringName &p_name, const Variant &p_value) {
 
 	const CSharpScript::PropertyTrampolines *trampolines = script->property_trampolines.getptr(p_name);
 	if (trampolines) {
-		if (trampolines->setter == nullptr) {
+		if (trampolines->setter.function_pointer == nullptr) {
 			return false;
 		}
-		return trampolines->setter(gchandle.get_intptr(), &p_value);
+		return GDMonoCache::managed_callbacks.CSharpInstanceBridge_SetViaTrampoline(
+				trampolines->setter, gchandle.get_intptr(), &p_value);
 	}
 
 	if (has_method(SNAME("_set"))) {
@@ -1523,12 +1524,13 @@ bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 
 	const CSharpScript::PropertyTrampolines *trampolines = script->property_trampolines.getptr(p_name);
 	if (trampolines) {
-		if (trampolines->getter == nullptr) {
+		if (trampolines->getter.function_pointer == nullptr) {
 			return false;
 		}
 
 		Variant ret_value;
-		if (likely(trampolines->getter(gchandle.get_intptr(), &ret_value))) {
+		if (likely(GDMonoCache::managed_callbacks.CSharpInstanceBridge_GetViaTrampoline(
+					trampolines->getter, gchandle.get_intptr(), &ret_value))) {
 			r_ret = ret_value;
 			return true;
 		}
@@ -1536,7 +1538,7 @@ bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 		return false;
 	}
 
-	for (const KeyValue<CSharpScript::SignalKey, RaiseSignalTrampoline> &kvp : script->raise_signal_trampolines) {
+	for (const KeyValue<CSharpScript::SignalKey, godotsharp::RaiseSignalTrampoline> &kvp : script->raise_signal_trampolines) {
 		if (kvp.key.name == p_name) {
 			r_ret = Signal(owner->get_instance_id(), p_name);
 			return true;
@@ -1766,10 +1768,11 @@ Variant CSharpInstance::_callp(const StringName &p_method, const Variant **p_arg
 		return _callp(*proxy_name, p_args, p_argcount, r_error);
 	}
 
-	const MethodTrampoline *trampoline = script->method_trampolines.getptr(method_key);
+	const godotsharp::MethodTrampoline *trampoline = script->method_trampolines.getptr(method_key);
 	if (trampoline != nullptr) {
 		Variant ret;
-		(*trampoline)(gchandle.get_intptr(), p_args, p_argcount, &r_error, &ret);
+		GDMonoCache::managed_callbacks.CSharpInstanceBridge_CallViaTrampoline(
+				*trampoline, gchandle.get_intptr(), p_args, p_argcount, &r_error, &ret);
 		if (likely(r_error.error == Callable::CallError::CALL_OK)) {
 			return ret;
 		}
@@ -1794,10 +1797,11 @@ Variant CSharpInstance::callp(const StringName &p_method, const Variant **p_args
 void CSharpInstance::raise_event_signal(const StringName &p_event_signal_name, const Variant **p_args, int p_argcount, Callable::CallError &r_error) const {
 	bool owner_is_null = false;
 
-	const RaiseSignalTrampoline *trampoline = script->raise_signal_trampolines.getptr(
+	const godotsharp::RaiseSignalTrampoline *trampoline = script->raise_signal_trampolines.getptr(
 			CSharpScript::SignalKey{ p_event_signal_name, p_argcount });
 	if (trampoline) {
-		(*trampoline)(gchandle.get_intptr(), p_args, p_argcount, &owner_is_null);
+		GDMonoCache::managed_callbacks.ScriptManagerBridge_RaiseEventSignalViaTrampoline(
+				*trampoline, gchandle.get_intptr(), p_args, p_argcount, &owner_is_null);
 
 		if (unlikely(owner_is_null)) {
 			r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
@@ -2379,7 +2383,7 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 		}
 	};
 
-	auto try_add_method_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, MethodTrampoline p_trampoline) {
+	auto try_add_method_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, godotsharp::MethodTrampoline p_trampoline) {
 		MethodKey method_key{ *p_name, p_argc };
 		if (!p_scr->method_trampolines.has(method_key)) {
 			p_scr->method_trampolines.insert_new(method_key, p_trampoline);
@@ -2387,14 +2391,14 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 	};
 
 	auto try_add_property_tramp = [](CSharpScript *p_scr, const StringName *p_name,
-										  PropertyGetterTrampoline p_getter_trampoline,
-										  PropertySetterTrampoline p_setter_trampoline) {
+										  godotsharp::PropertyGetterTrampoline p_getter_trampoline,
+										  godotsharp::PropertySetterTrampoline p_setter_trampoline) {
 		if (!p_scr->property_trampolines.has(*p_name)) {
 			p_scr->property_trampolines.insert_new(*p_name, { p_getter_trampoline, p_setter_trampoline });
 		}
 	};
 
-	auto try_add_raise_signal_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, RaiseSignalTrampoline p_trampoline) {
+	auto try_add_raise_signal_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, godotsharp::RaiseSignalTrampoline p_trampoline) {
 		SignalKey signal_key{ *p_name, p_argc };
 		if (!p_scr->raise_signal_trampolines.has(signal_key)) {
 			p_scr->raise_signal_trampolines.insert_new(signal_key, p_trampoline);
@@ -2681,7 +2685,7 @@ bool CSharpScript::_has_method_mapping_to_proxy_include_base(const StringName &p
 		}
 	}
 
-	for (const KeyValue<MethodKey, MethodTrampoline> &kvp : method_trampolines) {
+	for (const KeyValue<MethodKey, godotsharp::MethodTrampoline> &kvp : method_trampolines) {
 		if (kvp.key.name == p_name) {
 			return true;
 		}

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1780,6 +1780,7 @@ Variant CSharpInstance::_callp(const StringName &p_method, const Variant **p_arg
 	}
 
 	if (likely(!script->should_fallback_to_legacy_trampolines)) {
+		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
 		return Variant();
 	}
 
@@ -1813,6 +1814,7 @@ void CSharpInstance::raise_event_signal(const StringName &p_event_signal_name, c
 	}
 
 	if (likely(!script->should_fallback_to_legacy_trampolines)) {
+		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
 		return;
 	}
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2393,7 +2393,22 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 	auto try_add_property_tramp = [](CSharpScript *p_scr, const StringName *p_name,
 										  godotsharp::PropertyGetterTrampoline p_getter_trampoline,
 										  godotsharp::PropertySetterTrampoline p_setter_trampoline) {
-		if (!p_scr->property_trampolines.has(*p_name)) {
+		DEV_ASSERT(p_getter_trampoline.function_pointer != nullptr || p_setter_trampoline.function_pointer != nullptr);
+
+		PropertyTrampolines *found = p_scr->property_trampolines.getptr(*p_name);
+		if (found) {
+			// Could not have added an entry where both are null.
+			DEV_ASSERT(found->getter.function_pointer != nullptr || found->setter.function_pointer != nullptr);
+
+			// If an entry already exists, we still replace one of the trampolines if it's null.
+			// This matches the behavior of Get/SetGodotClassPropertyValue, which will continue
+			// looking in base classes if the property in the current class is readonly/writeonly.
+			if (p_getter_trampoline.function_pointer && !found->getter.function_pointer) {
+				found->getter = p_getter_trampoline;
+			} else if (p_setter_trampoline.function_pointer && !found->setter.function_pointer) {
+				found->setter = p_setter_trampoline;
+			}
+		} else {
 			p_scr->property_trampolines.insert_new(*p_name, { p_getter_trampoline, p_setter_trampoline });
 		}
 	};

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2372,6 +2372,7 @@ void CSharpScript::reload_registered_script(Ref<CSharpScript> p_script) {
 
 // Extract information about the script using the mono class.
 void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
+	p_script->static_method_trampolines.clear();
 	p_script->method_trampolines.clear();
 	p_script->property_trampolines.clear();
 	p_script->raise_signal_trampolines.clear();
@@ -2383,10 +2384,14 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 		}
 	};
 
-	auto try_add_method_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, godotsharp::MethodTrampoline p_trampoline) {
+	auto try_add_method_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc,
+										godotsharp::MethodTrampoline p_trampoline, bool p_is_static) {
 		MethodKey method_key{ *p_name, p_argc };
 		if (!p_scr->method_trampolines.has(method_key)) {
 			p_scr->method_trampolines.insert_new(method_key, p_trampoline);
+		}
+		if (p_is_static) {
+			p_scr->static_method_trampolines.insert_new(method_key, p_trampoline);
 		}
 	};
 
@@ -2413,7 +2418,8 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 		}
 	};
 
-	auto try_add_raise_signal_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, godotsharp::RaiseSignalTrampoline p_trampoline) {
+	auto try_add_raise_signal_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc,
+											  godotsharp::RaiseSignalTrampoline p_trampoline) {
 		SignalKey signal_key{ *p_name, p_argc };
 		if (!p_scr->raise_signal_trampolines.has(signal_key)) {
 			p_scr->raise_signal_trampolines.insert_new(signal_key, p_trampoline);
@@ -2786,13 +2792,37 @@ MethodInfo CSharpScript::get_method_info(const StringName &p_method) const {
 	return mi;
 }
 
-Variant CSharpScript::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
-	if (valid) {
-		Variant ret;
-		bool ok = GDMonoCache::managed_callbacks.ScriptManagerBridge_CallStatic(this, &p_method, p_args, p_argcount, &r_error, &ret);
-		if (ok) {
-			return ret;
+bool CSharpScript::_callp_static(const CSharpScript *p_script, const StringName &p_method,
+		const Variant **p_args, int p_argcount, Callable::CallError &r_error, Variant &r_ret) {
+	if (!p_script->valid) {
+		return false;
+	}
+
+	const MethodKey method_key{ p_method, p_argcount };
+
+	const godotsharp::MethodTrampoline *trampoline = p_script->static_method_trampolines.getptr(method_key);
+	if (trampoline != nullptr) {
+		GDMonoCache::managed_callbacks.ScriptManagerBridge_CallStaticWithTrampoline(
+				*trampoline, p_args, p_argcount, &r_error, &r_ret);
+		if (likely(r_error.error == Callable::CallError::CALL_OK)) {
+			return true;
 		}
+		return false;
+	}
+
+	if (likely(!p_script->should_fallback_to_legacy_trampolines)) {
+		return false;
+	}
+
+	Variant ret;
+	return GDMonoCache::managed_callbacks.ScriptManagerBridge_CallStatic(
+			p_script, &p_method, p_args, p_argcount, &r_error, &ret);
+}
+
+Variant CSharpScript::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+	Variant ret;
+	if (_callp_static(this, p_method, p_args, p_argcount, r_error, ret)) {
+		return ret;
 	}
 
 	return Script::callp(p_method, p_args, p_argcount, r_error);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1498,6 +1498,13 @@ bool CSharpInstance::set(const StringName &p_name, const Variant &p_value) {
 				trampolines->setter, gchandle.get_intptr(), &p_value);
 	}
 
+	if (unlikely(script->should_fallback_to_legacy_trampolines)) {
+		// The legacy CSharpInstanceBridge.Set already calls "_set" as a last resort,
+		// so don't continue after this branch.
+		return GDMonoCache::managed_callbacks.CSharpInstanceBridge_Set(
+				gchandle.get_intptr(), &p_name, &p_value);
+	}
+
 	if (has_method(SNAME("_set"))) {
 		Callable::CallError call_error;
 		const Variant name_arg = p_name;
@@ -1511,12 +1518,7 @@ bool CSharpInstance::set(const StringName &p_name, const Variant &p_value) {
 		return true;
 	}
 
-	if (likely(!script->should_fallback_to_legacy_trampolines)) {
-		return false;
-	}
-
-	return GDMonoCache::managed_callbacks.CSharpInstanceBridge_Set(
-			gchandle.get_intptr(), &p_name, &p_value);
+	return false;
 }
 
 bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
@@ -1531,6 +1533,19 @@ bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 		Variant ret_value;
 		if (likely(GDMonoCache::managed_callbacks.CSharpInstanceBridge_GetViaTrampoline(
 					trampolines->getter, gchandle.get_intptr(), &ret_value))) {
+			r_ret = ret_value;
+			return true;
+		}
+
+		return false;
+	}
+
+	if (unlikely(script->should_fallback_to_legacy_trampolines)) {
+		// The legacy CSharpInstanceBridge.Get already handles signal and method objects,
+		// and calls "_get" as a last resort, so don't continue after this branch.
+
+		Variant ret_value;
+		if (GDMonoCache::managed_callbacks.CSharpInstanceBridge_Get(gchandle.get_intptr(), &p_name, &ret_value)) {
 			r_ret = ret_value;
 			return true;
 		}
@@ -1562,16 +1577,6 @@ bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 		}
 
 		r_ret = ret;
-		return true;
-	}
-
-	if (likely(!script->should_fallback_to_legacy_trampolines)) {
-		return false;
-	}
-
-	Variant ret_value;
-	if (GDMonoCache::managed_callbacks.CSharpInstanceBridge_Get(gchandle.get_intptr(), &p_name, &ret_value)) {
-		r_ret = ret_value;
 		return true;
 	}
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1763,11 +1763,6 @@ Variant CSharpInstance::_callp(const StringName &p_method, const Variant **p_arg
 
 	const CSharpScript::MethodKey method_key{ p_method, p_argcount };
 
-	const StringName *proxy_name = script->name_to_proxy_name_map.getptr(method_key);
-	if (proxy_name != nullptr) {
-		return _callp(*proxy_name, p_args, p_argcount, r_error);
-	}
-
 	const godotsharp::MethodTrampoline *trampoline = script->method_trampolines.getptr(method_key);
 	if (trampoline != nullptr) {
 		Variant ret;
@@ -2377,13 +2372,6 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 	p_script->property_trampolines.clear();
 	p_script->raise_signal_trampolines.clear();
 
-	auto try_add_name_to_proxy_name_map = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc, const StringName *p_proxy_name) {
-		MethodKey method_key{ *p_name, p_argc };
-		if (!p_scr->name_to_proxy_name_map.has(method_key)) {
-			p_scr->name_to_proxy_name_map.insert_new(method_key, *p_proxy_name);
-		}
-	};
-
 	auto try_add_method_tramp = [](CSharpScript *p_scr, const StringName *p_name, int32_t p_argc,
 										godotsharp::MethodTrampoline p_trampoline, bool p_is_static) {
 		MethodKey method_key{ *p_name, p_argc };
@@ -2427,7 +2415,7 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 	};
 
 	GDMonoCache::managed_callbacks.ScriptManagerBridge_UpdateScriptTrampolines(
-			p_script.ptr(), &p_script->should_fallback_to_legacy_trampolines, try_add_name_to_proxy_name_map,
+			p_script.ptr(), &p_script->should_fallback_to_legacy_trampolines,
 			try_add_method_tramp, try_add_property_tramp, try_add_raise_signal_tramp);
 
 	TypeInfo type_info;
@@ -2700,12 +2688,6 @@ void CSharpScript::get_script_method_list(List<MethodInfo> *p_list) const {
 }
 
 bool CSharpScript::_has_method_mapping_to_proxy_include_base(const StringName &p_name) const {
-	for (const KeyValue<MethodKey, StringName> &kvp : name_to_proxy_name_map) {
-		if (kvp.key.name == p_name) {
-			return true;
-		}
-	}
-
 	for (const KeyValue<MethodKey, godotsharp::MethodTrampoline> &kvp : method_trampolines) {
 		if (kvp.key.name == p_name) {
 			return true;
@@ -2718,25 +2700,6 @@ bool CSharpScript::_has_method_mapping_to_proxy_include_base(const StringName &p
 bool CSharpScript::has_method(const StringName &p_method) const {
 	if (!valid) {
 		return false;
-	}
-
-	// TODO: This is a behavior change, which might cause regressions.
-	//       Previously it would return 'false' for names like '_process' and 'true' for '_Process'.
-	//       Now it checks both. This feels correct, but is it worth risking regressions?
-
-	for (const KeyValue<MethodKey, StringName> &kvp : name_to_proxy_name_map) {
-		if (kvp.key.name == p_method) {
-			const StringName &proxy_name = kvp.value;
-			// Name to proxy name map found, but it may be from an inherited script.
-			// We don't want that here, so make sure it's in 'methods' (which excludes inherited ones).
-			for (const CSharpMethodInfo &E : methods) {
-				if (E.name == proxy_name) {
-					return true;
-				}
-			}
-			// Break instead of returning false. The script still contain a method with the non-proxy name.
-			break;
-		}
 	}
 
 	for (const CSharpMethodInfo &E : methods) {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -230,6 +230,9 @@ private:
 	/// Also includes methods declared in inherited scripts.
 	AHashMap<MethodKey, StringName> name_to_proxy_name_map;
 
+	/// Only includes methods declared in this exact script, not inherited ones.
+	AHashMap<MethodKey, godotsharp::MethodTrampoline> static_method_trampolines;
+
 	/// Also includes methods declared in inherited scripts.
 	AHashMap<MethodKey, godotsharp::MethodTrampoline> method_trampolines;
 	/// Also includes properties declared in inherited scripts.
@@ -272,6 +275,9 @@ private:
 	static void update_script_class_info(Ref<CSharpScript> p_script);
 
 	void _get_script_signal_list(List<MethodInfo> *r_signals, bool p_include_base) const;
+
+	static bool _callp_static(const CSharpScript *p_script, const StringName &p_method,
+			const Variant **p_args, int p_argcount, Callable::CallError &r_error, Variant &r_ret);
 
 protected:
 	static void _bind_methods();

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -225,11 +225,6 @@ private:
 
 	using SignalKey = MethodKey;
 
-	/// This maps contains mapping of engine names to proxy names registered in \ref method_trampolines.
-	/// { MethodKey("_get", 0), "_Get" }
-	/// Also includes methods declared in inherited scripts.
-	AHashMap<MethodKey, StringName> name_to_proxy_name_map;
-
 	/// Only includes methods declared in this exact script, not inherited ones.
 	AHashMap<MethodKey, godotsharp::MethodTrampoline> static_method_trampolines;
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -42,11 +42,20 @@
 #include "editor/plugins/editor_plugin.h"
 #endif
 
-using MethodTrampoline = void(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, const Variant **p_args, int32_t p_argc,
-		Callable::CallError *r_ref_call_error, Variant *r_ret);
-using PropertyGetterTrampoline = bool(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, Variant *r_args);
-using PropertySetterTrampoline = bool(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, const Variant *p_args);
-using RaiseSignalTrampoline = void(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, const Variant **p_args, int32_t p_argc, bool *r_owner_is_null);
+namespace godotsharp {
+struct MethodTrampoline {
+	void *function_pointer;
+};
+struct PropertyGetterTrampoline {
+	void *function_pointer;
+};
+struct PropertySetterTrampoline {
+	void *function_pointer;
+};
+struct RaiseSignalTrampoline {
+	void *function_pointer;
+};
+} //namespace godotsharp
 
 class CSharpScript;
 class CSharpInstance;
@@ -196,8 +205,8 @@ private:
 	Vector<CSharpMethodInfo> methods;
 
 	struct PropertyTrampolines {
-		PropertyGetterTrampoline getter;
-		PropertySetterTrampoline setter;
+		godotsharp::PropertyGetterTrampoline getter;
+		godotsharp::PropertySetterTrampoline setter;
 	};
 
 	struct MethodKey {
@@ -222,11 +231,11 @@ private:
 	AHashMap<MethodKey, StringName> name_to_proxy_name_map;
 
 	/// Also includes methods declared in inherited scripts.
-	AHashMap<MethodKey, MethodTrampoline> method_trampolines;
+	AHashMap<MethodKey, godotsharp::MethodTrampoline> method_trampolines;
 	/// Also includes properties declared in inherited scripts.
 	AHashMap<StringName, PropertyTrampolines> property_trampolines;
 	/// Also includes event signals declared in inherited scripts.
-	AHashMap<SignalKey, RaiseSignalTrampoline> raise_signal_trampolines;
+	AHashMap<SignalKey, godotsharp::RaiseSignalTrampoline> raise_signal_trampolines;
 	bool should_fallback_to_legacy_trampolines = true;
 
 	bool _has_method_mapping_to_proxy_include_base(const StringName &p_name) const;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -42,6 +42,12 @@
 #include "editor/plugins/editor_plugin.h"
 #endif
 
+using MethodTrampoline = void(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, const Variant **p_args, int32_t p_argc,
+		Callable::CallError *r_ref_call_error, Variant *r_ret);
+using PropertyGetterTrampoline = bool(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, Variant *r_args);
+using PropertySetterTrampoline = bool(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, const Variant *p_args);
+using RaiseSignalTrampoline = void(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, const Variant **p_args, int32_t p_argc, bool *r_owner_is_null);
+
 class CSharpScript;
 class CSharpInstance;
 class CSharpLanguage;
@@ -184,8 +190,46 @@ private:
 		MethodInfo method_info;
 	};
 
+	/// Only includes event signals declared in this exact script, not inherited ones.
 	Vector<EventSignalInfo> event_signals;
+	/// Only includes methods declared in this exact script, not inherited ones.
 	Vector<CSharpMethodInfo> methods;
+
+	struct PropertyTrampolines {
+		PropertyGetterTrampoline getter;
+		PropertySetterTrampoline setter;
+	};
+
+	struct MethodKey {
+		StringName name;
+		int32_t arg_count;
+
+		bool operator==(const MethodKey &p_other) const {
+			return name == p_other.name && arg_count == p_other.arg_count;
+		}
+
+		uint32_t hash() const {
+			const uint32_t hash = name.hash();
+			return hash_murmur3_one_32(arg_count, hash);
+		}
+	};
+
+	using SignalKey = MethodKey;
+
+	/// This maps contains mapping of engine names to proxy names registered in \ref method_trampolines.
+	/// { MethodKey("_get", 0), "_Get" }
+	/// Also includes methods declared in inherited scripts.
+	AHashMap<MethodKey, StringName> name_to_proxy_name_map;
+
+	/// Also includes methods declared in inherited scripts.
+	AHashMap<MethodKey, MethodTrampoline> method_trampolines;
+	/// Also includes properties declared in inherited scripts.
+	AHashMap<StringName, PropertyTrampolines> property_trampolines;
+	/// Also includes event signals declared in inherited scripts.
+	AHashMap<SignalKey, RaiseSignalTrampoline> raise_signal_trampolines;
+	bool should_fallback_to_legacy_trampolines = true;
+
+	bool _has_method_mapping_to_proxy_include_base(const StringName &p_name) const;
 
 #ifdef TOOLS_ENABLED
 	List<PropertyInfo> exported_members_cache; // members_cache
@@ -332,6 +376,10 @@ class CSharpInstance : public ScriptInstance {
 	// Do not use unless you know what you are doing
 	static CSharpInstance *create_for_managed_type(Object *p_owner, CSharpScript *p_script, const MonoGCHandleData &p_gchandle);
 
+	Variant _callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) const;
+
+	void _call_notification(int p_notification, bool p_reversed = false) const;
+
 public:
 	_FORCE_INLINE_ bool is_destructing_script_instance() { return destructing_script_instance; }
 
@@ -353,6 +401,8 @@ public:
 	virtual int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const override;
 	Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
 
+	void raise_event_signal(const StringName &p_event_signal_name, const Variant **p_args, int p_argcount, Callable::CallError &r_error) const;
+
 	void mono_object_disposed(GCHandleIntPtr p_gchandle_to_free);
 
 	/*
@@ -370,7 +420,6 @@ public:
 	const Variant get_rpc_config() const override;
 
 	void notification(int p_notification, bool p_reversed = false) override;
-	void _call_notification(int p_notification, bool p_reversed = false);
 
 	String to_string(bool *r_valid) override;
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -43,11 +43,20 @@
 #include "editor/plugins/editor_plugin.h"
 #endif
 
-using MethodTrampoline = void(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, const Variant **p_args, int32_t p_argc,
-		Callable::CallError *r_ref_call_error, Variant *r_ret);
-using PropertyGetterTrampoline = bool(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, Variant *r_args);
-using PropertySetterTrampoline = bool(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, const Variant *p_args);
-using RaiseSignalTrampoline = void(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, const Variant **p_args, int32_t p_argc, bool *r_owner_is_null);
+namespace godotsharp {
+struct MethodTrampoline {
+	void *function_pointer;
+};
+struct PropertyGetterTrampoline {
+	void *function_pointer;
+};
+struct PropertySetterTrampoline {
+	void *function_pointer;
+};
+struct RaiseSignalTrampoline {
+	void *function_pointer;
+};
+} //namespace godotsharp
 
 class CSharpScript;
 class CSharpInstance;
@@ -197,8 +206,8 @@ private:
 	Vector<CSharpMethodInfo> methods;
 
 	struct PropertyTrampolines {
-		PropertyGetterTrampoline getter;
-		PropertySetterTrampoline setter;
+		godotsharp::PropertyGetterTrampoline getter;
+		godotsharp::PropertySetterTrampoline setter;
 	};
 
 	struct MethodKey {
@@ -223,11 +232,11 @@ private:
 	AHashMap<MethodKey, StringName> name_to_proxy_name_map;
 
 	/// Also includes methods declared in inherited scripts.
-	AHashMap<MethodKey, MethodTrampoline> method_trampolines;
+	AHashMap<MethodKey, godotsharp::MethodTrampoline> method_trampolines;
 	/// Also includes properties declared in inherited scripts.
 	AHashMap<StringName, PropertyTrampolines> property_trampolines;
 	/// Also includes event signals declared in inherited scripts.
-	AHashMap<SignalKey, RaiseSignalTrampoline> raise_signal_trampolines;
+	AHashMap<SignalKey, godotsharp::RaiseSignalTrampoline> raise_signal_trampolines;
 	bool should_fallback_to_legacy_trampolines = true;
 
 	bool _has_method_mapping_to_proxy_include_base(const StringName &p_name) const;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -226,11 +226,6 @@ private:
 
 	using SignalKey = MethodKey;
 
-	/// This maps contains mapping of engine names to proxy names registered in \ref method_trampolines.
-	/// { MethodKey("_get", 0), "_Get" }
-	/// Also includes methods declared in inherited scripts.
-	AHashMap<MethodKey, StringName> name_to_proxy_name_map;
-
 	/// Only includes methods declared in this exact script, not inherited ones.
 	AHashMap<MethodKey, godotsharp::MethodTrampoline> static_method_trampolines;
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -43,6 +43,12 @@
 #include "editor/plugins/editor_plugin.h"
 #endif
 
+using MethodTrampoline = void(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, const Variant **p_args, int32_t p_argc,
+		Callable::CallError *r_ref_call_error, Variant *r_ret);
+using PropertyGetterTrampoline = bool(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, Variant *r_args);
+using PropertySetterTrampoline = bool(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, const Variant *p_args);
+using RaiseSignalTrampoline = void(GD_CLR_STDCALL *)(GCHandleIntPtr p_obj_gchandle, const Variant **p_args, int32_t p_argc, bool *r_owner_is_null);
+
 class CSharpScript;
 class CSharpInstance;
 class CSharpLanguage;
@@ -185,8 +191,46 @@ private:
 		MethodInfo method_info;
 	};
 
+	/// Only includes event signals declared in this exact script, not inherited ones.
 	Vector<EventSignalInfo> event_signals;
+	/// Only includes methods declared in this exact script, not inherited ones.
 	Vector<CSharpMethodInfo> methods;
+
+	struct PropertyTrampolines {
+		PropertyGetterTrampoline getter;
+		PropertySetterTrampoline setter;
+	};
+
+	struct MethodKey {
+		StringName name;
+		int32_t arg_count;
+
+		bool operator==(const MethodKey &p_other) const {
+			return name == p_other.name && arg_count == p_other.arg_count;
+		}
+
+		uint32_t hash() const {
+			const uint32_t hash = name.hash();
+			return hash_murmur3_one_32(arg_count, hash);
+		}
+	};
+
+	using SignalKey = MethodKey;
+
+	/// This maps contains mapping of engine names to proxy names registered in \ref method_trampolines.
+	/// { MethodKey("_get", 0), "_Get" }
+	/// Also includes methods declared in inherited scripts.
+	AHashMap<MethodKey, StringName> name_to_proxy_name_map;
+
+	/// Also includes methods declared in inherited scripts.
+	AHashMap<MethodKey, MethodTrampoline> method_trampolines;
+	/// Also includes properties declared in inherited scripts.
+	AHashMap<StringName, PropertyTrampolines> property_trampolines;
+	/// Also includes event signals declared in inherited scripts.
+	AHashMap<SignalKey, RaiseSignalTrampoline> raise_signal_trampolines;
+	bool should_fallback_to_legacy_trampolines = true;
+
+	bool _has_method_mapping_to_proxy_include_base(const StringName &p_name) const;
 
 #ifdef TOOLS_ENABLED
 	List<PropertyInfo> exported_members_cache; // members_cache
@@ -333,6 +377,10 @@ class CSharpInstance : public ScriptInstance {
 	// Do not use unless you know what you are doing
 	static CSharpInstance *create_for_managed_type(Object *p_owner, CSharpScript *p_script, const MonoGCHandleData &p_gchandle);
 
+	Variant _callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) const;
+
+	void _call_notification(int p_notification, bool p_reversed = false) const;
+
 public:
 	_FORCE_INLINE_ bool is_destructing_script_instance() { return destructing_script_instance; }
 
@@ -354,6 +402,8 @@ public:
 	virtual int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const override;
 	Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
 
+	void raise_event_signal(const StringName &p_event_signal_name, const Variant **p_args, int p_argcount, Callable::CallError &r_error) const;
+
 	void mono_object_disposed(GCHandleIntPtr p_gchandle_to_free);
 
 	/*
@@ -371,7 +421,6 @@ public:
 	const Variant get_rpc_config() const override;
 
 	void notification(int p_notification, bool p_reversed = false) override;
-	void _call_notification(int p_notification, bool p_reversed = false);
 
 	String to_string(bool *r_valid) override;
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -231,6 +231,9 @@ private:
 	/// Also includes methods declared in inherited scripts.
 	AHashMap<MethodKey, StringName> name_to_proxy_name_map;
 
+	/// Only includes methods declared in this exact script, not inherited ones.
+	AHashMap<MethodKey, godotsharp::MethodTrampoline> static_method_trampolines;
+
 	/// Also includes methods declared in inherited scripts.
 	AHashMap<MethodKey, godotsharp::MethodTrampoline> method_trampolines;
 	/// Also includes properties declared in inherited scripts.
@@ -273,6 +276,9 @@ private:
 	static void update_script_class_info(Ref<CSharpScript> p_script);
 
 	void _get_script_signal_list(List<MethodInfo> *r_signals, bool p_include_base) const;
+
+	static bool _callp_static(const CSharpScript *p_script, const StringName &p_method,
+			const Variant **p_args, int p_argcount, Callable::CallError &r_error, Variant &r_ret);
 
 protected:
 	static void _bind_methods();

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -43,6 +43,15 @@
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+    This is required for trampolines, which are passed as unmanaged delegate pointers.
+    We could wrap pointer parameters in structs to work with them from safe contexts
+    but ultimately, taking the address of the function requires unsafe blocks.
+    -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
   <!--
   The Microsoft.NET.Sdk only understands of the Debug and Release configurations.
   We need to set the following properties manually for ExportDebug and ExportRelease.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -43,15 +43,6 @@
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!--
-    This is required for trampolines, which are passed as unmanaged delegate pointers.
-    We could wrap pointer parameters in structs to work with them from safe contexts
-    but ultimately, taking the address of the function requires unsafe blocks.
-    -->
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
   <!--
   The Microsoft.NET.Sdk only understands of the Debug and Release configurations.
   We need to set the following properties manually for ExportDebug and ExportRelease.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>12</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -31,5 +32,11 @@
   <!-- This file is imported automatically when using PackageReference to
   reference Godot.SourceGenerators, but not when using ProjectReference -->
   <Import Project="..\Godot.SourceGenerators\Godot.SourceGenerators.props" />
+
+  <ItemGroup>
+    <Compile Remove="Generic.cs"/>
+    <Compile Remove="Generic1T.cs"/>
+    <Compile Remove="Generic2T.cs"/>
+  </ItemGroup>
 
 </Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>12</LangVersion>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
@@ -33,10 +33,4 @@
   reference Godot.SourceGenerators, but not when using ProjectReference -->
   <Import Project="..\Godot.SourceGenerators\Godot.SourceGenerators.props" />
 
-  <ItemGroup>
-    <Compile Remove="Generic.cs"/>
-    <Compile Remove="Generic1T.cs"/>
-    <Compile Remove="Generic2T.cs"/>
-  </ItemGroup>
-
 </Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Methods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Methods.cs
@@ -28,4 +28,8 @@ public partial class Methods : GodotObject
     private void GenericMethod<T>(T t)
     {
     }
+
+    private static void StaticMethod()
+    {
+    }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/AbstractGenericNode(Of T)_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/AbstractGenericNode(Of T)_ScriptProperties.generated.cs
@@ -13,25 +13,21 @@ partial class AbstractGenericNode<T>
         /// </summary>
         public new static readonly global::Godot.StringName @MyArray = "MyArray";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@MyArray) {
-            this.@MyArray = global::Godot.NativeInterop.VariantUtils.ConvertToArray<T>(value);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static godot_variant trampoline_get_MyArray(object godotObject)
+            {
+                var ret = ((global::AbstractGenericNode<T>)godotObject).@MyArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFromArray(ret);
+            }
+            static void trampoline_set_MyArray(object godotObject, in godot_variant value)
+            {
+                ((global::AbstractGenericNode<T>)godotObject).@MyArray = global::Godot.NativeInterop.VariantUtils.ConvertToArray<T>(value);
+            }
+            collector.TryAdd(PropertyName.@MyArray, (new(&trampoline_get_MyArray), new(&trampoline_set_MyArray)));
         }
-        return base.SetGodotClassPropertyValue(name, value);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
-    {
-        if (name == PropertyName.@MyArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFromArray(this.@MyArray);
-            return true;
-        }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/AllReadOnly_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/AllReadOnly_ScriptProperties.generated.cs
@@ -25,27 +25,35 @@ partial class AllReadOnly
         /// </summary>
         public new static readonly global::Godot.StringName @ReadOnlyField = "ReadOnlyField";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@ReadOnlyAutoProperty) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@ReadOnlyAutoProperty);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static godot_variant trampoline_get_ReadOnlyAutoProperty(object godotObject)
+            {
+                var ret = ((global::AllReadOnly)godotObject).@ReadOnlyAutoProperty;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static godot_variant trampoline_get_ReadOnlyProperty(object godotObject)
+            {
+                var ret = ((global::AllReadOnly)godotObject).@ReadOnlyProperty;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static godot_variant trampoline_get_InitOnlyAutoProperty(object godotObject)
+            {
+                var ret = ((global::AllReadOnly)godotObject).@InitOnlyAutoProperty;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static godot_variant trampoline_get_ReadOnlyField(object godotObject)
+            {
+                var ret = ((global::AllReadOnly)godotObject).@ReadOnlyField;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            collector.TryAdd(PropertyName.@ReadOnlyAutoProperty, (new(&trampoline_get_ReadOnlyAutoProperty), new(null)));
+            collector.TryAdd(PropertyName.@ReadOnlyProperty, (new(&trampoline_get_ReadOnlyProperty), new(null)));
+            collector.TryAdd(PropertyName.@InitOnlyAutoProperty, (new(&trampoline_get_InitOnlyAutoProperty), new(null)));
+            collector.TryAdd(PropertyName.@ReadOnlyField, (new(&trampoline_get_ReadOnlyField), new(null)));
         }
-        if (name == PropertyName.@ReadOnlyProperty) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@ReadOnlyProperty);
-            return true;
-        }
-        if (name == PropertyName.@InitOnlyAutoProperty) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@InitOnlyAutoProperty);
-            return true;
-        }
-        if (name == PropertyName.@ReadOnlyField) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@ReadOnlyField);
-            return true;
-        }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/AllWriteOnly_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/AllWriteOnly_ScriptProperties.generated.cs
@@ -17,29 +17,26 @@ partial class AllWriteOnly
         /// </summary>
         public new static readonly global::Godot.StringName @_writeOnlyBackingField = "_writeOnlyBackingField";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@WriteOnlyProperty) {
-            this.@WriteOnlyProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static void trampoline_set_WriteOnlyProperty(object godotObject, in godot_variant value)
+            {
+                ((global::AllWriteOnly)godotObject).@WriteOnlyProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            }
+            static godot_variant trampoline_get__writeOnlyBackingField(object godotObject)
+            {
+                var ret = ((global::AllWriteOnly)godotObject).@_writeOnlyBackingField;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(ret);
+            }
+            static void trampoline_set__writeOnlyBackingField(object godotObject, in godot_variant value)
+            {
+                ((global::AllWriteOnly)godotObject).@_writeOnlyBackingField = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            }
+            collector.TryAdd(PropertyName.@WriteOnlyProperty, (new(null), new(&trampoline_set_WriteOnlyProperty)));
+            collector.TryAdd(PropertyName.@_writeOnlyBackingField, (new(&trampoline_get__writeOnlyBackingField), new(&trampoline_set__writeOnlyBackingField)));
         }
-        if (name == PropertyName.@_writeOnlyBackingField) {
-            this.@_writeOnlyBackingField = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
-            return true;
-        }
-        return base.SetGodotClassPropertyValue(name, value);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
-    {
-        if (name == PropertyName.@_writeOnlyBackingField) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.@_writeOnlyBackingField);
-            return true;
-        }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/EventSignals_ScriptSignals.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/EventSignals_ScriptSignals.generated.cs
@@ -25,34 +25,29 @@ partial class EventSignals
         signals.Add(new(name: SignalName.@MySignal, returnVal: new(type: (global::Godot.Variant.Type)0, name: "", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), flags: (global::Godot.MethodFlags)1, arguments: new() { new(type: (global::Godot.Variant.Type)4, name: "str", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), new(type: (global::Godot.Variant.Type)2, name: "num", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false),  }, defaultArguments: null));
         return signals;
     }
+    protected internal new static partial class GodotInternal
+    {
+        internal new static unsafe void GetGodotRaiseSignalTrampolines(global::Godot.Bridge.RaiseSignalTrampolineCollector collector)
+        {
+            static void trampoline_2_MySignal(object godotObject, NativeVariantPtrArgs args)
+            {
+                if (args.Count != 2) {
+                    return;
+                }
+                ((global::EventSignals)godotObject).backing_MySignal?.Invoke(global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(args[0]), global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[1]));
+            }
+            collector.TryAdd(new(SignalName.@MySignal, 2), new(&trampoline_2_MySignal));
+        }
+    }
 #pragma warning restore CS0109
     private global::EventSignals.MySignalEventHandler backing_MySignal;
     /// <inheritdoc cref="global::EventSignals.MySignalEventHandler"/>
     public event global::EventSignals.MySignalEventHandler @MySignal {
         add => backing_MySignal += value;
         remove => backing_MySignal -= value;
-}
+    }
     protected void EmitSignalMySignal(string @str, int @num)
     {
         EmitSignal(SignalName.MySignal, [@str, @num]);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override void RaiseGodotClassSignalCallbacks(in godot_string_name signal, NativeVariantPtrArgs args)
-    {
-        if (signal == SignalName.@MySignal && args.Count == 2) {
-            backing_MySignal?.Invoke(global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(args[0]), global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[1]));
-            return;
-        }
-        base.RaiseGodotClassSignalCallbacks(signal, args);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool HasGodotClassSignal(in godot_string_name signal)
-    {
-        if (signal == SignalName.@MySignal) {
-           return true;
-        }
-        return base.HasGodotClassSignal(signal);
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportDiagnostics_GD0108_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportDiagnostics_GD0108_ScriptProperties.generated.cs
@@ -13,15 +13,17 @@ partial class ExportDiagnostics_GD0108
         /// </summary>
         public new static readonly global::Godot.StringName @MyButton = "MyButton";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@MyButton) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@MyButton);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static godot_variant trampoline_get_MyButton(object godotObject)
+            {
+                var ret = ((global::ExportDiagnostics_GD0108)godotObject).@MyButton;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            collector.TryAdd(PropertyName.@MyButton, (new(&trampoline_get_MyButton), new(null)));
         }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportDiagnostics_GD0109_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportDiagnostics_GD0109_ScriptProperties.generated.cs
@@ -13,15 +13,17 @@ partial class ExportDiagnostics_GD0109
         /// </summary>
         public new static readonly global::Godot.StringName @MyButton = "MyButton";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@MyButton) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@MyButton);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static godot_variant trampoline_get_MyButton(object godotObject)
+            {
+                var ret = ((global::ExportDiagnostics_GD0109)godotObject).@MyButton;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            collector.TryAdd(PropertyName.@MyButton, (new(&trampoline_get_MyButton), new(null)));
         }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportDiagnostics_GD0110_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportDiagnostics_GD0110_ScriptProperties.generated.cs
@@ -13,15 +13,17 @@ partial class ExportDiagnostics_GD0110
         /// </summary>
         public new static readonly global::Godot.StringName @MyButton = "MyButton";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@MyButton) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this.@MyButton);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static godot_variant trampoline_get_MyButton(object godotObject)
+            {
+                var ret = ((global::ExportDiagnostics_GD0110)godotObject).@MyButton;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(ret);
+            }
+            collector.TryAdd(PropertyName.@MyButton, (new(&trampoline_get_MyButton), new(null)));
         }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportDiagnostics_GD0111_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportDiagnostics_GD0111_ScriptProperties.generated.cs
@@ -41,61 +41,71 @@ partial class ExportDiagnostics_GD0111
         /// </summary>
         public new static readonly global::Godot.StringName @_backingField = "_backingField";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@MyButtonGetSet) {
-            this.@MyButtonGetSet = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static godot_variant trampoline_get_MyButtonGet(object godotObject)
+            {
+                var ret = ((global::ExportDiagnostics_GD0111)godotObject).@MyButtonGet;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            static godot_variant trampoline_get_MyButtonGetSet(object godotObject)
+            {
+                var ret = ((global::ExportDiagnostics_GD0111)godotObject).@MyButtonGetSet;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            static void trampoline_set_MyButtonGetSet(object godotObject, in godot_variant value)
+            {
+                ((global::ExportDiagnostics_GD0111)godotObject).@MyButtonGetSet = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
+            }
+            static godot_variant trampoline_get_MyButtonGetWithBackingField(object godotObject)
+            {
+                var ret = ((global::ExportDiagnostics_GD0111)godotObject).@MyButtonGetWithBackingField;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            static godot_variant trampoline_get_MyButtonGetSetWithBackingField(object godotObject)
+            {
+                var ret = ((global::ExportDiagnostics_GD0111)godotObject).@MyButtonGetSetWithBackingField;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            static void trampoline_set_MyButtonGetSetWithBackingField(object godotObject, in godot_variant value)
+            {
+                ((global::ExportDiagnostics_GD0111)godotObject).@MyButtonGetSetWithBackingField = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
+            }
+            static godot_variant trampoline_get_MyButtonOkWithCallableCreationExpression(object godotObject)
+            {
+                var ret = ((global::ExportDiagnostics_GD0111)godotObject).@MyButtonOkWithCallableCreationExpression;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            static godot_variant trampoline_get_MyButtonOkWithImplicitCallableCreationExpression(object godotObject)
+            {
+                var ret = ((global::ExportDiagnostics_GD0111)godotObject).@MyButtonOkWithImplicitCallableCreationExpression;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            static godot_variant trampoline_get_MyButtonOkWithCallableFromExpression(object godotObject)
+            {
+                var ret = ((global::ExportDiagnostics_GD0111)godotObject).@MyButtonOkWithCallableFromExpression;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            static godot_variant trampoline_get__backingField(object godotObject)
+            {
+                var ret = ((global::ExportDiagnostics_GD0111)godotObject).@_backingField;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            static void trampoline_set__backingField(object godotObject, in godot_variant value)
+            {
+                ((global::ExportDiagnostics_GD0111)godotObject).@_backingField = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
+            }
+            collector.TryAdd(PropertyName.@MyButtonGet, (new(&trampoline_get_MyButtonGet), new(null)));
+            collector.TryAdd(PropertyName.@MyButtonGetSet, (new(&trampoline_get_MyButtonGetSet), new(&trampoline_set_MyButtonGetSet)));
+            collector.TryAdd(PropertyName.@MyButtonGetWithBackingField, (new(&trampoline_get_MyButtonGetWithBackingField), new(null)));
+            collector.TryAdd(PropertyName.@MyButtonGetSetWithBackingField, (new(&trampoline_get_MyButtonGetSetWithBackingField), new(&trampoline_set_MyButtonGetSetWithBackingField)));
+            collector.TryAdd(PropertyName.@MyButtonOkWithCallableCreationExpression, (new(&trampoline_get_MyButtonOkWithCallableCreationExpression), new(null)));
+            collector.TryAdd(PropertyName.@MyButtonOkWithImplicitCallableCreationExpression, (new(&trampoline_get_MyButtonOkWithImplicitCallableCreationExpression), new(null)));
+            collector.TryAdd(PropertyName.@MyButtonOkWithCallableFromExpression, (new(&trampoline_get_MyButtonOkWithCallableFromExpression), new(null)));
+            collector.TryAdd(PropertyName.@_backingField, (new(&trampoline_get__backingField), new(&trampoline_set__backingField)));
         }
-        if (name == PropertyName.@MyButtonGetSetWithBackingField) {
-            this.@MyButtonGetSetWithBackingField = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
-            return true;
-        }
-        if (name == PropertyName.@_backingField) {
-            this.@_backingField = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
-            return true;
-        }
-        return base.SetGodotClassPropertyValue(name, value);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
-    {
-        if (name == PropertyName.@MyButtonGet) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@MyButtonGet);
-            return true;
-        }
-        if (name == PropertyName.@MyButtonGetSet) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@MyButtonGetSet);
-            return true;
-        }
-        if (name == PropertyName.@MyButtonGetWithBackingField) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@MyButtonGetWithBackingField);
-            return true;
-        }
-        if (name == PropertyName.@MyButtonGetSetWithBackingField) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@MyButtonGetSetWithBackingField);
-            return true;
-        }
-        if (name == PropertyName.@MyButtonOkWithCallableCreationExpression) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@MyButtonOkWithCallableCreationExpression);
-            return true;
-        }
-        if (name == PropertyName.@MyButtonOkWithImplicitCallableCreationExpression) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@MyButtonOkWithImplicitCallableCreationExpression);
-            return true;
-        }
-        if (name == PropertyName.@MyButtonOkWithCallableFromExpression) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@MyButtonOkWithCallableFromExpression);
-            return true;
-        }
-        if (name == PropertyName.@_backingField) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@_backingField);
-            return true;
-        }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptProperties.generated.cs
@@ -257,513 +257,631 @@ partial class ExportedFields
         /// </summary>
         public new static readonly global::Godot.StringName @_fieldEmptyInt64Array = "_fieldEmptyInt64Array";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@_fieldBoolean) {
-            this.@_fieldBoolean = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static godot_variant trampoline_get__fieldBoolean(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldBoolean;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(ret);
+            }
+            static void trampoline_set__fieldBoolean(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldBoolean = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            }
+            static godot_variant trampoline_get__fieldChar(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldChar;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<char>(ret);
+            }
+            static void trampoline_set__fieldChar(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldChar = global::Godot.NativeInterop.VariantUtils.ConvertTo<char>(value);
+            }
+            static godot_variant trampoline_get__fieldSByte(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldSByte;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<sbyte>(ret);
+            }
+            static void trampoline_set__fieldSByte(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldSByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<sbyte>(value);
+            }
+            static godot_variant trampoline_get__fieldInt16(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldInt16;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<short>(ret);
+            }
+            static void trampoline_set__fieldInt16(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<short>(value);
+            }
+            static godot_variant trampoline_get__fieldInt32(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldInt32;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(ret);
+            }
+            static void trampoline_set__fieldInt32(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
+            }
+            static godot_variant trampoline_get__fieldInt64(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldInt64;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<long>(ret);
+            }
+            static void trampoline_set__fieldInt64(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<long>(value);
+            }
+            static godot_variant trampoline_get__fieldByte(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldByte;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<byte>(ret);
+            }
+            static void trampoline_set__fieldByte(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte>(value);
+            }
+            static godot_variant trampoline_get__fieldUInt16(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldUInt16;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<ushort>(ret);
+            }
+            static void trampoline_set__fieldUInt16(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldUInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ushort>(value);
+            }
+            static godot_variant trampoline_get__fieldUInt32(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldUInt32;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<uint>(ret);
+            }
+            static void trampoline_set__fieldUInt32(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldUInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<uint>(value);
+            }
+            static godot_variant trampoline_get__fieldUInt64(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldUInt64;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<ulong>(ret);
+            }
+            static void trampoline_set__fieldUInt64(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldUInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ulong>(value);
+            }
+            static godot_variant trampoline_get__fieldSingle(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldSingle;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set__fieldSingle(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldSingle = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get__fieldDouble(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldDouble;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<double>(ret);
+            }
+            static void trampoline_set__fieldDouble(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldDouble = global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(value);
+            }
+            static godot_variant trampoline_get__fieldString(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set__fieldString(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get__fieldStaticImport(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldStaticImport;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set__fieldStaticImport(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get__fieldVector2(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector2;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2>(ret);
+            }
+            static void trampoline_set__fieldVector2(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2>(value);
+            }
+            static godot_variant trampoline_get__fieldVector2I(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector2I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2I>(ret);
+            }
+            static void trampoline_set__fieldVector2I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2I>(value);
+            }
+            static godot_variant trampoline_get__fieldRect2(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldRect2;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2>(ret);
+            }
+            static void trampoline_set__fieldRect2(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldRect2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2>(value);
+            }
+            static godot_variant trampoline_get__fieldRect2I(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldRect2I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2I>(ret);
+            }
+            static void trampoline_set__fieldRect2I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldRect2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2I>(value);
+            }
+            static godot_variant trampoline_get__fieldTransform2D(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldTransform2D;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform2D>(ret);
+            }
+            static void trampoline_set__fieldTransform2D(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldTransform2D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform2D>(value);
+            }
+            static godot_variant trampoline_get__fieldVector3(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector3;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3>(ret);
+            }
+            static void trampoline_set__fieldVector3(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector3 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3>(value);
+            }
+            static godot_variant trampoline_get__fieldVector3I(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector3I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3I>(ret);
+            }
+            static void trampoline_set__fieldVector3I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector3I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3I>(value);
+            }
+            static godot_variant trampoline_get__fieldBasis(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldBasis;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Basis>(ret);
+            }
+            static void trampoline_set__fieldBasis(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldBasis = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Basis>(value);
+            }
+            static godot_variant trampoline_get__fieldQuaternion(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldQuaternion;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Quaternion>(ret);
+            }
+            static void trampoline_set__fieldQuaternion(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldQuaternion = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Quaternion>(value);
+            }
+            static godot_variant trampoline_get__fieldTransform3D(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldTransform3D;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform3D>(ret);
+            }
+            static void trampoline_set__fieldTransform3D(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldTransform3D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform3D>(value);
+            }
+            static godot_variant trampoline_get__fieldVector4(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector4;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4>(ret);
+            }
+            static void trampoline_set__fieldVector4(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector4 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4>(value);
+            }
+            static godot_variant trampoline_get__fieldVector4I(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector4I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4I>(ret);
+            }
+            static void trampoline_set__fieldVector4I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector4I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4I>(value);
+            }
+            static godot_variant trampoline_get__fieldProjection(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldProjection;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Projection>(ret);
+            }
+            static void trampoline_set__fieldProjection(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldProjection = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Projection>(value);
+            }
+            static godot_variant trampoline_get__fieldAabb(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldAabb;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Aabb>(ret);
+            }
+            static void trampoline_set__fieldAabb(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldAabb = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Aabb>(value);
+            }
+            static godot_variant trampoline_get__fieldColor(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldColor;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color>(ret);
+            }
+            static void trampoline_set__fieldColor(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldColor = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color>(value);
+            }
+            static godot_variant trampoline_get__fieldPlane(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldPlane;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Plane>(ret);
+            }
+            static void trampoline_set__fieldPlane(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldPlane = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Plane>(value);
+            }
+            static godot_variant trampoline_get__fieldCallable(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldCallable;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            static void trampoline_set__fieldCallable(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldCallable = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
+            }
+            static godot_variant trampoline_get__fieldSignal(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldSignal;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Signal>(ret);
+            }
+            static void trampoline_set__fieldSignal(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldSignal = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Signal>(value);
+            }
+            static godot_variant trampoline_get__fieldEnum(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldEnum;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedFields.MyEnum>(ret);
+            }
+            static void trampoline_set__fieldEnum(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedFields.MyEnum>(value);
+            }
+            static godot_variant trampoline_get__fieldFlagsEnum(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldFlagsEnum;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedFields.MyFlagsEnum>(ret);
+            }
+            static void trampoline_set__fieldFlagsEnum(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldFlagsEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedFields.MyFlagsEnum>(value);
+            }
+            static godot_variant trampoline_get__fieldByteArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldByteArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<byte[]>(ret);
+            }
+            static void trampoline_set__fieldByteArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldByteArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte[]>(value);
+            }
+            static godot_variant trampoline_get__fieldInt32Array(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldInt32Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(ret);
+            }
+            static void trampoline_set__fieldInt32Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldInt32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
+            }
+            static godot_variant trampoline_get__fieldInt64Array(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldInt64Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(ret);
+            }
+            static void trampoline_set__fieldInt64Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldInt64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
+            }
+            static godot_variant trampoline_get__fieldSingleArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldSingleArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float[]>(ret);
+            }
+            static void trampoline_set__fieldSingleArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldSingleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<float[]>(value);
+            }
+            static godot_variant trampoline_get__fieldDoubleArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldDoubleArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<double[]>(ret);
+            }
+            static void trampoline_set__fieldDoubleArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldDoubleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<double[]>(value);
+            }
+            static godot_variant trampoline_get__fieldStringArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldStringArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(ret);
+            }
+            static void trampoline_set__fieldStringArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldStringArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
+            }
+            static godot_variant trampoline_get__fieldStringArrayEnum(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldStringArrayEnum;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(ret);
+            }
+            static void trampoline_set__fieldStringArrayEnum(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldStringArrayEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
+            }
+            static godot_variant trampoline_get__fieldVector2Array(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector2Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2[]>(ret);
+            }
+            static void trampoline_set__fieldVector2Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector2Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2[]>(value);
+            }
+            static godot_variant trampoline_get__fieldVector3Array(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector3Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3[]>(ret);
+            }
+            static void trampoline_set__fieldVector3Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector3Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3[]>(value);
+            }
+            static godot_variant trampoline_get__fieldColorArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldColorArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color[]>(ret);
+            }
+            static void trampoline_set__fieldColorArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldColorArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color[]>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotObjectOrDerivedArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotObjectOrDerivedArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFromSystemArrayOfGodotObject(ret);
+            }
+            static void trampoline_set__fieldGodotObjectOrDerivedArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotObjectOrDerivedArray = global::Godot.NativeInterop.VariantUtils.ConvertToSystemArrayOfGodotObject<global::Godot.GodotObject>(value);
+            }
+            static godot_variant trampoline_get__fieldStringNameArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldStringNameArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName[]>(ret);
+            }
+            static void trampoline_set__fieldStringNameArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldStringNameArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName[]>(value);
+            }
+            static godot_variant trampoline_get__fieldNodePathArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldNodePathArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath[]>(ret);
+            }
+            static void trampoline_set__fieldNodePathArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldNodePathArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath[]>(value);
+            }
+            static godot_variant trampoline_get__fieldRidArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldRidArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid[]>(ret);
+            }
+            static void trampoline_set__fieldRidArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldRidArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid[]>(value);
+            }
+            static godot_variant trampoline_get__fieldEmptyInt32Array(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldEmptyInt32Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(ret);
+            }
+            static void trampoline_set__fieldEmptyInt32Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldEmptyInt32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
+            }
+            static godot_variant trampoline_get__fieldArrayFromList(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldArrayFromList;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(ret);
+            }
+            static void trampoline_set__fieldArrayFromList(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldArrayFromList = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
+            }
+            static godot_variant trampoline_get__fieldVariant(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVariant;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Variant>(ret);
+            }
+            static void trampoline_set__fieldVariant(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVariant = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Variant>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotObjectOrDerived(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotObjectOrDerived;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.GodotObject>(ret);
+            }
+            static void trampoline_set__fieldGodotObjectOrDerived(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotObjectOrDerived = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.GodotObject>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotResourceTexture(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotResourceTexture;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(ret);
+            }
+            static void trampoline_set__fieldGodotResourceTexture(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotResourceTexture = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotResourceTextureWithInitializer(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotResourceTextureWithInitializer;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(ret);
+            }
+            static void trampoline_set__fieldGodotResourceTextureWithInitializer(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotResourceTextureWithInitializer = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
+            }
+            static godot_variant trampoline_get__fieldStringName(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldStringName;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName>(ret);
+            }
+            static void trampoline_set__fieldStringName(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldStringName = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(value);
+            }
+            static godot_variant trampoline_get__fieldNodePath(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldNodePath;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(ret);
+            }
+            static void trampoline_set__fieldNodePath(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldNodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
+            }
+            static godot_variant trampoline_get__fieldRid(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldRid;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid>(ret);
+            }
+            static void trampoline_set__fieldRid(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldRid = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotDictionary(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotDictionary;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Dictionary>(ret);
+            }
+            static void trampoline_set__fieldGodotDictionary(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotDictionary = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Dictionary>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Array>(ret);
+            }
+            static void trampoline_set__fieldGodotArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Array>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotGenericDictionary(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotGenericDictionary;
+                return global::Godot.NativeInterop.VariantUtils.CreateFromDictionary(ret);
+            }
+            static void trampoline_set__fieldGodotGenericDictionary(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotGenericDictionary = global::Godot.NativeInterop.VariantUtils.ConvertToDictionary<string, bool>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotGenericArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotGenericArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFromArray(ret);
+            }
+            static void trampoline_set__fieldGodotGenericArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotGenericArray = global::Godot.NativeInterop.VariantUtils.ConvertToArray<int>(value);
+            }
+            static godot_variant trampoline_get__fieldEmptyInt64Array(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldEmptyInt64Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(ret);
+            }
+            static void trampoline_set__fieldEmptyInt64Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldEmptyInt64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
+            }
+            collector.TryAdd(PropertyName.@_fieldBoolean, (new(&trampoline_get__fieldBoolean), new(&trampoline_set__fieldBoolean)));
+            collector.TryAdd(PropertyName.@_fieldChar, (new(&trampoline_get__fieldChar), new(&trampoline_set__fieldChar)));
+            collector.TryAdd(PropertyName.@_fieldSByte, (new(&trampoline_get__fieldSByte), new(&trampoline_set__fieldSByte)));
+            collector.TryAdd(PropertyName.@_fieldInt16, (new(&trampoline_get__fieldInt16), new(&trampoline_set__fieldInt16)));
+            collector.TryAdd(PropertyName.@_fieldInt32, (new(&trampoline_get__fieldInt32), new(&trampoline_set__fieldInt32)));
+            collector.TryAdd(PropertyName.@_fieldInt64, (new(&trampoline_get__fieldInt64), new(&trampoline_set__fieldInt64)));
+            collector.TryAdd(PropertyName.@_fieldByte, (new(&trampoline_get__fieldByte), new(&trampoline_set__fieldByte)));
+            collector.TryAdd(PropertyName.@_fieldUInt16, (new(&trampoline_get__fieldUInt16), new(&trampoline_set__fieldUInt16)));
+            collector.TryAdd(PropertyName.@_fieldUInt32, (new(&trampoline_get__fieldUInt32), new(&trampoline_set__fieldUInt32)));
+            collector.TryAdd(PropertyName.@_fieldUInt64, (new(&trampoline_get__fieldUInt64), new(&trampoline_set__fieldUInt64)));
+            collector.TryAdd(PropertyName.@_fieldSingle, (new(&trampoline_get__fieldSingle), new(&trampoline_set__fieldSingle)));
+            collector.TryAdd(PropertyName.@_fieldDouble, (new(&trampoline_get__fieldDouble), new(&trampoline_set__fieldDouble)));
+            collector.TryAdd(PropertyName.@_fieldString, (new(&trampoline_get__fieldString), new(&trampoline_set__fieldString)));
+            collector.TryAdd(PropertyName.@_fieldStaticImport, (new(&trampoline_get__fieldStaticImport), new(&trampoline_set__fieldStaticImport)));
+            collector.TryAdd(PropertyName.@_fieldVector2, (new(&trampoline_get__fieldVector2), new(&trampoline_set__fieldVector2)));
+            collector.TryAdd(PropertyName.@_fieldVector2I, (new(&trampoline_get__fieldVector2I), new(&trampoline_set__fieldVector2I)));
+            collector.TryAdd(PropertyName.@_fieldRect2, (new(&trampoline_get__fieldRect2), new(&trampoline_set__fieldRect2)));
+            collector.TryAdd(PropertyName.@_fieldRect2I, (new(&trampoline_get__fieldRect2I), new(&trampoline_set__fieldRect2I)));
+            collector.TryAdd(PropertyName.@_fieldTransform2D, (new(&trampoline_get__fieldTransform2D), new(&trampoline_set__fieldTransform2D)));
+            collector.TryAdd(PropertyName.@_fieldVector3, (new(&trampoline_get__fieldVector3), new(&trampoline_set__fieldVector3)));
+            collector.TryAdd(PropertyName.@_fieldVector3I, (new(&trampoline_get__fieldVector3I), new(&trampoline_set__fieldVector3I)));
+            collector.TryAdd(PropertyName.@_fieldBasis, (new(&trampoline_get__fieldBasis), new(&trampoline_set__fieldBasis)));
+            collector.TryAdd(PropertyName.@_fieldQuaternion, (new(&trampoline_get__fieldQuaternion), new(&trampoline_set__fieldQuaternion)));
+            collector.TryAdd(PropertyName.@_fieldTransform3D, (new(&trampoline_get__fieldTransform3D), new(&trampoline_set__fieldTransform3D)));
+            collector.TryAdd(PropertyName.@_fieldVector4, (new(&trampoline_get__fieldVector4), new(&trampoline_set__fieldVector4)));
+            collector.TryAdd(PropertyName.@_fieldVector4I, (new(&trampoline_get__fieldVector4I), new(&trampoline_set__fieldVector4I)));
+            collector.TryAdd(PropertyName.@_fieldProjection, (new(&trampoline_get__fieldProjection), new(&trampoline_set__fieldProjection)));
+            collector.TryAdd(PropertyName.@_fieldAabb, (new(&trampoline_get__fieldAabb), new(&trampoline_set__fieldAabb)));
+            collector.TryAdd(PropertyName.@_fieldColor, (new(&trampoline_get__fieldColor), new(&trampoline_set__fieldColor)));
+            collector.TryAdd(PropertyName.@_fieldPlane, (new(&trampoline_get__fieldPlane), new(&trampoline_set__fieldPlane)));
+            collector.TryAdd(PropertyName.@_fieldCallable, (new(&trampoline_get__fieldCallable), new(&trampoline_set__fieldCallable)));
+            collector.TryAdd(PropertyName.@_fieldSignal, (new(&trampoline_get__fieldSignal), new(&trampoline_set__fieldSignal)));
+            collector.TryAdd(PropertyName.@_fieldEnum, (new(&trampoline_get__fieldEnum), new(&trampoline_set__fieldEnum)));
+            collector.TryAdd(PropertyName.@_fieldFlagsEnum, (new(&trampoline_get__fieldFlagsEnum), new(&trampoline_set__fieldFlagsEnum)));
+            collector.TryAdd(PropertyName.@_fieldByteArray, (new(&trampoline_get__fieldByteArray), new(&trampoline_set__fieldByteArray)));
+            collector.TryAdd(PropertyName.@_fieldInt32Array, (new(&trampoline_get__fieldInt32Array), new(&trampoline_set__fieldInt32Array)));
+            collector.TryAdd(PropertyName.@_fieldInt64Array, (new(&trampoline_get__fieldInt64Array), new(&trampoline_set__fieldInt64Array)));
+            collector.TryAdd(PropertyName.@_fieldSingleArray, (new(&trampoline_get__fieldSingleArray), new(&trampoline_set__fieldSingleArray)));
+            collector.TryAdd(PropertyName.@_fieldDoubleArray, (new(&trampoline_get__fieldDoubleArray), new(&trampoline_set__fieldDoubleArray)));
+            collector.TryAdd(PropertyName.@_fieldStringArray, (new(&trampoline_get__fieldStringArray), new(&trampoline_set__fieldStringArray)));
+            collector.TryAdd(PropertyName.@_fieldStringArrayEnum, (new(&trampoline_get__fieldStringArrayEnum), new(&trampoline_set__fieldStringArrayEnum)));
+            collector.TryAdd(PropertyName.@_fieldVector2Array, (new(&trampoline_get__fieldVector2Array), new(&trampoline_set__fieldVector2Array)));
+            collector.TryAdd(PropertyName.@_fieldVector3Array, (new(&trampoline_get__fieldVector3Array), new(&trampoline_set__fieldVector3Array)));
+            collector.TryAdd(PropertyName.@_fieldColorArray, (new(&trampoline_get__fieldColorArray), new(&trampoline_set__fieldColorArray)));
+            collector.TryAdd(PropertyName.@_fieldGodotObjectOrDerivedArray, (new(&trampoline_get__fieldGodotObjectOrDerivedArray), new(&trampoline_set__fieldGodotObjectOrDerivedArray)));
+            collector.TryAdd(PropertyName.@_fieldStringNameArray, (new(&trampoline_get__fieldStringNameArray), new(&trampoline_set__fieldStringNameArray)));
+            collector.TryAdd(PropertyName.@_fieldNodePathArray, (new(&trampoline_get__fieldNodePathArray), new(&trampoline_set__fieldNodePathArray)));
+            collector.TryAdd(PropertyName.@_fieldRidArray, (new(&trampoline_get__fieldRidArray), new(&trampoline_set__fieldRidArray)));
+            collector.TryAdd(PropertyName.@_fieldEmptyInt32Array, (new(&trampoline_get__fieldEmptyInt32Array), new(&trampoline_set__fieldEmptyInt32Array)));
+            collector.TryAdd(PropertyName.@_fieldArrayFromList, (new(&trampoline_get__fieldArrayFromList), new(&trampoline_set__fieldArrayFromList)));
+            collector.TryAdd(PropertyName.@_fieldVariant, (new(&trampoline_get__fieldVariant), new(&trampoline_set__fieldVariant)));
+            collector.TryAdd(PropertyName.@_fieldGodotObjectOrDerived, (new(&trampoline_get__fieldGodotObjectOrDerived), new(&trampoline_set__fieldGodotObjectOrDerived)));
+            collector.TryAdd(PropertyName.@_fieldGodotResourceTexture, (new(&trampoline_get__fieldGodotResourceTexture), new(&trampoline_set__fieldGodotResourceTexture)));
+            collector.TryAdd(PropertyName.@_fieldGodotResourceTextureWithInitializer, (new(&trampoline_get__fieldGodotResourceTextureWithInitializer), new(&trampoline_set__fieldGodotResourceTextureWithInitializer)));
+            collector.TryAdd(PropertyName.@_fieldStringName, (new(&trampoline_get__fieldStringName), new(&trampoline_set__fieldStringName)));
+            collector.TryAdd(PropertyName.@_fieldNodePath, (new(&trampoline_get__fieldNodePath), new(&trampoline_set__fieldNodePath)));
+            collector.TryAdd(PropertyName.@_fieldRid, (new(&trampoline_get__fieldRid), new(&trampoline_set__fieldRid)));
+            collector.TryAdd(PropertyName.@_fieldGodotDictionary, (new(&trampoline_get__fieldGodotDictionary), new(&trampoline_set__fieldGodotDictionary)));
+            collector.TryAdd(PropertyName.@_fieldGodotArray, (new(&trampoline_get__fieldGodotArray), new(&trampoline_set__fieldGodotArray)));
+            collector.TryAdd(PropertyName.@_fieldGodotGenericDictionary, (new(&trampoline_get__fieldGodotGenericDictionary), new(&trampoline_set__fieldGodotGenericDictionary)));
+            collector.TryAdd(PropertyName.@_fieldGodotGenericArray, (new(&trampoline_get__fieldGodotGenericArray), new(&trampoline_set__fieldGodotGenericArray)));
+            collector.TryAdd(PropertyName.@_fieldEmptyInt64Array, (new(&trampoline_get__fieldEmptyInt64Array), new(&trampoline_set__fieldEmptyInt64Array)));
         }
-        if (name == PropertyName.@_fieldChar) {
-            this.@_fieldChar = global::Godot.NativeInterop.VariantUtils.ConvertTo<char>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSByte) {
-            this.@_fieldSByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<sbyte>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt16) {
-            this.@_fieldInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<short>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt32) {
-            this.@_fieldInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt64) {
-            this.@_fieldInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<long>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldByte) {
-            this.@_fieldByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldUInt16) {
-            this.@_fieldUInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ushort>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldUInt32) {
-            this.@_fieldUInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<uint>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldUInt64) {
-            this.@_fieldUInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ulong>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSingle) {
-            this.@_fieldSingle = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldDouble) {
-            this.@_fieldDouble = global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldString) {
-            this.@_fieldString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStaticImport) {
-            this.@_fieldStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector2) {
-            this.@_fieldVector2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector2I) {
-            this.@_fieldVector2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2I>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRect2) {
-            this.@_fieldRect2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRect2I) {
-            this.@_fieldRect2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2I>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldTransform2D) {
-            this.@_fieldTransform2D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform2D>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector3) {
-            this.@_fieldVector3 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector3I) {
-            this.@_fieldVector3I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3I>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldBasis) {
-            this.@_fieldBasis = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Basis>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldQuaternion) {
-            this.@_fieldQuaternion = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Quaternion>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldTransform3D) {
-            this.@_fieldTransform3D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform3D>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector4) {
-            this.@_fieldVector4 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector4I) {
-            this.@_fieldVector4I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4I>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldProjection) {
-            this.@_fieldProjection = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Projection>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldAabb) {
-            this.@_fieldAabb = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Aabb>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldColor) {
-            this.@_fieldColor = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldPlane) {
-            this.@_fieldPlane = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Plane>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldCallable) {
-            this.@_fieldCallable = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSignal) {
-            this.@_fieldSignal = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Signal>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldEnum) {
-            this.@_fieldEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedFields.MyEnum>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldFlagsEnum) {
-            this.@_fieldFlagsEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedFields.MyFlagsEnum>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldByteArray) {
-            this.@_fieldByteArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt32Array) {
-            this.@_fieldInt32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt64Array) {
-            this.@_fieldInt64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSingleArray) {
-            this.@_fieldSingleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<float[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldDoubleArray) {
-            this.@_fieldDoubleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<double[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringArray) {
-            this.@_fieldStringArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringArrayEnum) {
-            this.@_fieldStringArrayEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector2Array) {
-            this.@_fieldVector2Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector3Array) {
-            this.@_fieldVector3Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldColorArray) {
-            this.@_fieldColorArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotObjectOrDerivedArray) {
-            this.@_fieldGodotObjectOrDerivedArray = global::Godot.NativeInterop.VariantUtils.ConvertToSystemArrayOfGodotObject<global::Godot.GodotObject>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringNameArray) {
-            this.@_fieldStringNameArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldNodePathArray) {
-            this.@_fieldNodePathArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRidArray) {
-            this.@_fieldRidArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldEmptyInt32Array) {
-            this.@_fieldEmptyInt32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldArrayFromList) {
-            this.@_fieldArrayFromList = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVariant) {
-            this.@_fieldVariant = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Variant>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotObjectOrDerived) {
-            this.@_fieldGodotObjectOrDerived = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.GodotObject>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotResourceTexture) {
-            this.@_fieldGodotResourceTexture = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotResourceTextureWithInitializer) {
-            this.@_fieldGodotResourceTextureWithInitializer = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringName) {
-            this.@_fieldStringName = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldNodePath) {
-            this.@_fieldNodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRid) {
-            this.@_fieldRid = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotDictionary) {
-            this.@_fieldGodotDictionary = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Dictionary>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotArray) {
-            this.@_fieldGodotArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Array>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotGenericDictionary) {
-            this.@_fieldGodotGenericDictionary = global::Godot.NativeInterop.VariantUtils.ConvertToDictionary<string, bool>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotGenericArray) {
-            this.@_fieldGodotGenericArray = global::Godot.NativeInterop.VariantUtils.ConvertToArray<int>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldEmptyInt64Array) {
-            this.@_fieldEmptyInt64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
-            return true;
-        }
-        return base.SetGodotClassPropertyValue(name, value);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
-    {
-        if (name == PropertyName.@_fieldBoolean) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.@_fieldBoolean);
-            return true;
-        }
-        if (name == PropertyName.@_fieldChar) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<char>(this.@_fieldChar);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSByte) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<sbyte>(this.@_fieldSByte);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt16) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<short>(this.@_fieldInt16);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt32) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this.@_fieldInt32);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt64) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long>(this.@_fieldInt64);
-            return true;
-        }
-        if (name == PropertyName.@_fieldByte) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte>(this.@_fieldByte);
-            return true;
-        }
-        if (name == PropertyName.@_fieldUInt16) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ushort>(this.@_fieldUInt16);
-            return true;
-        }
-        if (name == PropertyName.@_fieldUInt32) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<uint>(this.@_fieldUInt32);
-            return true;
-        }
-        if (name == PropertyName.@_fieldUInt64) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ulong>(this.@_fieldUInt64);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSingle) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@_fieldSingle);
-            return true;
-        }
-        if (name == PropertyName.@_fieldDouble) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double>(this.@_fieldDouble);
-            return true;
-        }
-        if (name == PropertyName.@_fieldString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@_fieldString);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStaticImport) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@_fieldStaticImport);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector2) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2>(this.@_fieldVector2);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector2I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2I>(this.@_fieldVector2I);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRect2) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2>(this.@_fieldRect2);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRect2I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2I>(this.@_fieldRect2I);
-            return true;
-        }
-        if (name == PropertyName.@_fieldTransform2D) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform2D>(this.@_fieldTransform2D);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector3) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3>(this.@_fieldVector3);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector3I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3I>(this.@_fieldVector3I);
-            return true;
-        }
-        if (name == PropertyName.@_fieldBasis) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Basis>(this.@_fieldBasis);
-            return true;
-        }
-        if (name == PropertyName.@_fieldQuaternion) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Quaternion>(this.@_fieldQuaternion);
-            return true;
-        }
-        if (name == PropertyName.@_fieldTransform3D) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform3D>(this.@_fieldTransform3D);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector4) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4>(this.@_fieldVector4);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector4I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4I>(this.@_fieldVector4I);
-            return true;
-        }
-        if (name == PropertyName.@_fieldProjection) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Projection>(this.@_fieldProjection);
-            return true;
-        }
-        if (name == PropertyName.@_fieldAabb) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Aabb>(this.@_fieldAabb);
-            return true;
-        }
-        if (name == PropertyName.@_fieldColor) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color>(this.@_fieldColor);
-            return true;
-        }
-        if (name == PropertyName.@_fieldPlane) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Plane>(this.@_fieldPlane);
-            return true;
-        }
-        if (name == PropertyName.@_fieldCallable) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@_fieldCallable);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSignal) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Signal>(this.@_fieldSignal);
-            return true;
-        }
-        if (name == PropertyName.@_fieldEnum) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedFields.MyEnum>(this.@_fieldEnum);
-            return true;
-        }
-        if (name == PropertyName.@_fieldFlagsEnum) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedFields.MyFlagsEnum>(this.@_fieldFlagsEnum);
-            return true;
-        }
-        if (name == PropertyName.@_fieldByteArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte[]>(this.@_fieldByteArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt32Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this.@_fieldInt32Array);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt64Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(this.@_fieldInt64Array);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSingleArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float[]>(this.@_fieldSingleArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldDoubleArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double[]>(this.@_fieldDoubleArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this.@_fieldStringArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringArrayEnum) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this.@_fieldStringArrayEnum);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector2Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2[]>(this.@_fieldVector2Array);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector3Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3[]>(this.@_fieldVector3Array);
-            return true;
-        }
-        if (name == PropertyName.@_fieldColorArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color[]>(this.@_fieldColorArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotObjectOrDerivedArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFromSystemArrayOfGodotObject(this.@_fieldGodotObjectOrDerivedArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringNameArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName[]>(this.@_fieldStringNameArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldNodePathArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath[]>(this.@_fieldNodePathArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRidArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid[]>(this.@_fieldRidArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldEmptyInt32Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this.@_fieldEmptyInt32Array);
-            return true;
-        }
-        if (name == PropertyName.@_fieldArrayFromList) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this.@_fieldArrayFromList);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVariant) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Variant>(this.@_fieldVariant);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotObjectOrDerived) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.GodotObject>(this.@_fieldGodotObjectOrDerived);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotResourceTexture) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this.@_fieldGodotResourceTexture);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotResourceTextureWithInitializer) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this.@_fieldGodotResourceTextureWithInitializer);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringName) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName>(this.@_fieldStringName);
-            return true;
-        }
-        if (name == PropertyName.@_fieldNodePath) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(this.@_fieldNodePath);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRid) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid>(this.@_fieldRid);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotDictionary) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Dictionary>(this.@_fieldGodotDictionary);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Array>(this.@_fieldGodotArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotGenericDictionary) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFromDictionary(this.@_fieldGodotGenericDictionary);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotGenericArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFromArray(this.@_fieldGodotGenericArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldEmptyInt64Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(this.@_fieldEmptyInt64Array);
-            return true;
-        }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedFields_ScriptProperties.generated.cs
@@ -261,521 +261,641 @@ partial class ExportedFields
         /// </summary>
         public new static readonly global::Godot.StringName @_fieldEmptyInt64Array = "_fieldEmptyInt64Array";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@_fieldBoolean) {
-            this.@_fieldBoolean = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static godot_variant trampoline_get__fieldBoolean(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldBoolean;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(ret);
+            }
+            static void trampoline_set__fieldBoolean(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldBoolean = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            }
+            static godot_variant trampoline_get__fieldChar(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldChar;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<char>(ret);
+            }
+            static void trampoline_set__fieldChar(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldChar = global::Godot.NativeInterop.VariantUtils.ConvertTo<char>(value);
+            }
+            static godot_variant trampoline_get__fieldSByte(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldSByte;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<sbyte>(ret);
+            }
+            static void trampoline_set__fieldSByte(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldSByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<sbyte>(value);
+            }
+            static godot_variant trampoline_get__fieldInt16(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldInt16;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<short>(ret);
+            }
+            static void trampoline_set__fieldInt16(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<short>(value);
+            }
+            static godot_variant trampoline_get__fieldInt32(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldInt32;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(ret);
+            }
+            static void trampoline_set__fieldInt32(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
+            }
+            static godot_variant trampoline_get__fieldInt64(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldInt64;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<long>(ret);
+            }
+            static void trampoline_set__fieldInt64(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<long>(value);
+            }
+            static godot_variant trampoline_get__fieldByte(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldByte;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<byte>(ret);
+            }
+            static void trampoline_set__fieldByte(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte>(value);
+            }
+            static godot_variant trampoline_get__fieldUInt16(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldUInt16;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<ushort>(ret);
+            }
+            static void trampoline_set__fieldUInt16(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldUInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ushort>(value);
+            }
+            static godot_variant trampoline_get__fieldUInt32(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldUInt32;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<uint>(ret);
+            }
+            static void trampoline_set__fieldUInt32(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldUInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<uint>(value);
+            }
+            static godot_variant trampoline_get__fieldUInt64(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldUInt64;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<ulong>(ret);
+            }
+            static void trampoline_set__fieldUInt64(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldUInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ulong>(value);
+            }
+            static godot_variant trampoline_get__fieldSingle(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldSingle;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set__fieldSingle(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldSingle = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get__fieldDouble(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldDouble;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<double>(ret);
+            }
+            static void trampoline_set__fieldDouble(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldDouble = global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(value);
+            }
+            static godot_variant trampoline_get__fieldString(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set__fieldString(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get__fieldStaticImport(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldStaticImport;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set__fieldStaticImport(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get__fieldVector2(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector2;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2>(ret);
+            }
+            static void trampoline_set__fieldVector2(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2>(value);
+            }
+            static godot_variant trampoline_get__fieldVector2I(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector2I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2I>(ret);
+            }
+            static void trampoline_set__fieldVector2I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2I>(value);
+            }
+            static godot_variant trampoline_get__fieldRect2(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldRect2;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2>(ret);
+            }
+            static void trampoline_set__fieldRect2(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldRect2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2>(value);
+            }
+            static godot_variant trampoline_get__fieldRect2I(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldRect2I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2I>(ret);
+            }
+            static void trampoline_set__fieldRect2I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldRect2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2I>(value);
+            }
+            static godot_variant trampoline_get__fieldTransform2D(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldTransform2D;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform2D>(ret);
+            }
+            static void trampoline_set__fieldTransform2D(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldTransform2D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform2D>(value);
+            }
+            static godot_variant trampoline_get__fieldVector3(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector3;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3>(ret);
+            }
+            static void trampoline_set__fieldVector3(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector3 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3>(value);
+            }
+            static godot_variant trampoline_get__fieldVector3I(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector3I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3I>(ret);
+            }
+            static void trampoline_set__fieldVector3I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector3I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3I>(value);
+            }
+            static godot_variant trampoline_get__fieldBasis(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldBasis;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Basis>(ret);
+            }
+            static void trampoline_set__fieldBasis(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldBasis = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Basis>(value);
+            }
+            static godot_variant trampoline_get__fieldQuaternion(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldQuaternion;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Quaternion>(ret);
+            }
+            static void trampoline_set__fieldQuaternion(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldQuaternion = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Quaternion>(value);
+            }
+            static godot_variant trampoline_get__fieldTransform3D(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldTransform3D;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform3D>(ret);
+            }
+            static void trampoline_set__fieldTransform3D(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldTransform3D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform3D>(value);
+            }
+            static godot_variant trampoline_get__fieldVector4(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector4;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4>(ret);
+            }
+            static void trampoline_set__fieldVector4(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector4 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4>(value);
+            }
+            static godot_variant trampoline_get__fieldVector4I(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector4I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4I>(ret);
+            }
+            static void trampoline_set__fieldVector4I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector4I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4I>(value);
+            }
+            static godot_variant trampoline_get__fieldProjection(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldProjection;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Projection>(ret);
+            }
+            static void trampoline_set__fieldProjection(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldProjection = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Projection>(value);
+            }
+            static godot_variant trampoline_get__fieldAabb(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldAabb;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Aabb>(ret);
+            }
+            static void trampoline_set__fieldAabb(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldAabb = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Aabb>(value);
+            }
+            static godot_variant trampoline_get__fieldColor(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldColor;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color>(ret);
+            }
+            static void trampoline_set__fieldColor(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldColor = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color>(value);
+            }
+            static godot_variant trampoline_get__fieldPlane(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldPlane;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Plane>(ret);
+            }
+            static void trampoline_set__fieldPlane(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldPlane = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Plane>(value);
+            }
+            static godot_variant trampoline_get__fieldCallable(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldCallable;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            static void trampoline_set__fieldCallable(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldCallable = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
+            }
+            static godot_variant trampoline_get__fieldSignal(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldSignal;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Signal>(ret);
+            }
+            static void trampoline_set__fieldSignal(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldSignal = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Signal>(value);
+            }
+            static godot_variant trampoline_get__fieldEnum(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldEnum;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedFields.MyEnum>(ret);
+            }
+            static void trampoline_set__fieldEnum(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedFields.MyEnum>(value);
+            }
+            static godot_variant trampoline_get__fieldFlagsEnum(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldFlagsEnum;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedFields.MyFlagsEnum>(ret);
+            }
+            static void trampoline_set__fieldFlagsEnum(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldFlagsEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedFields.MyFlagsEnum>(value);
+            }
+            static godot_variant trampoline_get__fieldByteArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldByteArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<byte[]>(ret);
+            }
+            static void trampoline_set__fieldByteArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldByteArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte[]>(value);
+            }
+            static godot_variant trampoline_get__fieldInt32Array(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldInt32Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(ret);
+            }
+            static void trampoline_set__fieldInt32Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldInt32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
+            }
+            static godot_variant trampoline_get__fieldInt64Array(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldInt64Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(ret);
+            }
+            static void trampoline_set__fieldInt64Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldInt64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
+            }
+            static godot_variant trampoline_get__fieldSingleArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldSingleArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float[]>(ret);
+            }
+            static void trampoline_set__fieldSingleArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldSingleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<float[]>(value);
+            }
+            static godot_variant trampoline_get__fieldDoubleArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldDoubleArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<double[]>(ret);
+            }
+            static void trampoline_set__fieldDoubleArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldDoubleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<double[]>(value);
+            }
+            static godot_variant trampoline_get__fieldStringArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldStringArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(ret);
+            }
+            static void trampoline_set__fieldStringArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldStringArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
+            }
+            static godot_variant trampoline_get__fieldStringArrayEnum(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldStringArrayEnum;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(ret);
+            }
+            static void trampoline_set__fieldStringArrayEnum(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldStringArrayEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
+            }
+            static godot_variant trampoline_get__fieldVector2Array(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector2Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2[]>(ret);
+            }
+            static void trampoline_set__fieldVector2Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector2Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2[]>(value);
+            }
+            static godot_variant trampoline_get__fieldVector3Array(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVector3Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3[]>(ret);
+            }
+            static void trampoline_set__fieldVector3Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVector3Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3[]>(value);
+            }
+            static godot_variant trampoline_get__fieldColorArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldColorArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color[]>(ret);
+            }
+            static void trampoline_set__fieldColorArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldColorArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color[]>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotObjectOrDerivedArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotObjectOrDerivedArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFromSystemArrayOfGodotObject(ret);
+            }
+            static void trampoline_set__fieldGodotObjectOrDerivedArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotObjectOrDerivedArray = global::Godot.NativeInterop.VariantUtils.ConvertToSystemArrayOfGodotObject<global::Godot.GodotObject>(value);
+            }
+            static godot_variant trampoline_get__fieldStringNameArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldStringNameArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName[]>(ret);
+            }
+            static void trampoline_set__fieldStringNameArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldStringNameArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName[]>(value);
+            }
+            static godot_variant trampoline_get__fieldNodePathArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldNodePathArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath[]>(ret);
+            }
+            static void trampoline_set__fieldNodePathArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldNodePathArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath[]>(value);
+            }
+            static godot_variant trampoline_get__fieldRidArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldRidArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid[]>(ret);
+            }
+            static void trampoline_set__fieldRidArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldRidArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid[]>(value);
+            }
+            static godot_variant trampoline_get__fieldEmptyInt32Array(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldEmptyInt32Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(ret);
+            }
+            static void trampoline_set__fieldEmptyInt32Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldEmptyInt32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
+            }
+            static godot_variant trampoline_get__fieldArrayFromList(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldArrayFromList;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(ret);
+            }
+            static void trampoline_set__fieldArrayFromList(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldArrayFromList = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
+            }
+            static godot_variant trampoline_get__fieldVariant(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldVariant;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Variant>(ret);
+            }
+            static void trampoline_set__fieldVariant(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldVariant = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Variant>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotObjectOrDerived(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotObjectOrDerived;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.GodotObject>(ret);
+            }
+            static void trampoline_set__fieldGodotObjectOrDerived(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotObjectOrDerived = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.GodotObject>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotResourceTexture(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotResourceTexture;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(ret);
+            }
+            static void trampoline_set__fieldGodotResourceTexture(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotResourceTexture = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotResourceTextureWithInitializer(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotResourceTextureWithInitializer;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(ret);
+            }
+            static void trampoline_set__fieldGodotResourceTextureWithInitializer(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotResourceTextureWithInitializer = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
+            }
+            static godot_variant trampoline_get__fieldStringName(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldStringName;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName>(ret);
+            }
+            static void trampoline_set__fieldStringName(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldStringName = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(value);
+            }
+            static godot_variant trampoline_get__fieldNodePath(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldNodePath;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(ret);
+            }
+            static void trampoline_set__fieldNodePath(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldNodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
+            }
+            static godot_variant trampoline_get__fieldRid(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldRid;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid>(ret);
+            }
+            static void trampoline_set__fieldRid(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldRid = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotDictionary(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotDictionary;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Dictionary>(ret);
+            }
+            static void trampoline_set__fieldGodotDictionary(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotDictionary = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Dictionary>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Array>(ret);
+            }
+            static void trampoline_set__fieldGodotArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Array>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotGenericDictionary(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotGenericDictionary;
+                return global::Godot.NativeInterop.VariantUtils.CreateFromDictionary(ret);
+            }
+            static void trampoline_set__fieldGodotGenericDictionary(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotGenericDictionary = global::Godot.NativeInterop.VariantUtils.ConvertToDictionary<string, bool>(value);
+            }
+            static godot_variant trampoline_get__fieldGodotGenericArray(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldGodotGenericArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFromArray(ret);
+            }
+            static void trampoline_set__fieldGodotGenericArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldGodotGenericArray = global::Godot.NativeInterop.VariantUtils.ConvertToArray<int>(value);
+            }
+            static godot_variant trampoline_get__notIgnoredField(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_notIgnoredField;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(ret);
+            }
+            static void trampoline_set__notIgnoredField(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_notIgnoredField = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
+            }
+            static godot_variant trampoline_get__fieldEmptyInt64Array(object godotObject)
+            {
+                var ret = ((global::ExportedFields)godotObject).@_fieldEmptyInt64Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(ret);
+            }
+            static void trampoline_set__fieldEmptyInt64Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedFields)godotObject).@_fieldEmptyInt64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
+            }
+            collector.TryAdd(PropertyName.@_fieldBoolean, (new(&trampoline_get__fieldBoolean), new(&trampoline_set__fieldBoolean)));
+            collector.TryAdd(PropertyName.@_fieldChar, (new(&trampoline_get__fieldChar), new(&trampoline_set__fieldChar)));
+            collector.TryAdd(PropertyName.@_fieldSByte, (new(&trampoline_get__fieldSByte), new(&trampoline_set__fieldSByte)));
+            collector.TryAdd(PropertyName.@_fieldInt16, (new(&trampoline_get__fieldInt16), new(&trampoline_set__fieldInt16)));
+            collector.TryAdd(PropertyName.@_fieldInt32, (new(&trampoline_get__fieldInt32), new(&trampoline_set__fieldInt32)));
+            collector.TryAdd(PropertyName.@_fieldInt64, (new(&trampoline_get__fieldInt64), new(&trampoline_set__fieldInt64)));
+            collector.TryAdd(PropertyName.@_fieldByte, (new(&trampoline_get__fieldByte), new(&trampoline_set__fieldByte)));
+            collector.TryAdd(PropertyName.@_fieldUInt16, (new(&trampoline_get__fieldUInt16), new(&trampoline_set__fieldUInt16)));
+            collector.TryAdd(PropertyName.@_fieldUInt32, (new(&trampoline_get__fieldUInt32), new(&trampoline_set__fieldUInt32)));
+            collector.TryAdd(PropertyName.@_fieldUInt64, (new(&trampoline_get__fieldUInt64), new(&trampoline_set__fieldUInt64)));
+            collector.TryAdd(PropertyName.@_fieldSingle, (new(&trampoline_get__fieldSingle), new(&trampoline_set__fieldSingle)));
+            collector.TryAdd(PropertyName.@_fieldDouble, (new(&trampoline_get__fieldDouble), new(&trampoline_set__fieldDouble)));
+            collector.TryAdd(PropertyName.@_fieldString, (new(&trampoline_get__fieldString), new(&trampoline_set__fieldString)));
+            collector.TryAdd(PropertyName.@_fieldStaticImport, (new(&trampoline_get__fieldStaticImport), new(&trampoline_set__fieldStaticImport)));
+            collector.TryAdd(PropertyName.@_fieldVector2, (new(&trampoline_get__fieldVector2), new(&trampoline_set__fieldVector2)));
+            collector.TryAdd(PropertyName.@_fieldVector2I, (new(&trampoline_get__fieldVector2I), new(&trampoline_set__fieldVector2I)));
+            collector.TryAdd(PropertyName.@_fieldRect2, (new(&trampoline_get__fieldRect2), new(&trampoline_set__fieldRect2)));
+            collector.TryAdd(PropertyName.@_fieldRect2I, (new(&trampoline_get__fieldRect2I), new(&trampoline_set__fieldRect2I)));
+            collector.TryAdd(PropertyName.@_fieldTransform2D, (new(&trampoline_get__fieldTransform2D), new(&trampoline_set__fieldTransform2D)));
+            collector.TryAdd(PropertyName.@_fieldVector3, (new(&trampoline_get__fieldVector3), new(&trampoline_set__fieldVector3)));
+            collector.TryAdd(PropertyName.@_fieldVector3I, (new(&trampoline_get__fieldVector3I), new(&trampoline_set__fieldVector3I)));
+            collector.TryAdd(PropertyName.@_fieldBasis, (new(&trampoline_get__fieldBasis), new(&trampoline_set__fieldBasis)));
+            collector.TryAdd(PropertyName.@_fieldQuaternion, (new(&trampoline_get__fieldQuaternion), new(&trampoline_set__fieldQuaternion)));
+            collector.TryAdd(PropertyName.@_fieldTransform3D, (new(&trampoline_get__fieldTransform3D), new(&trampoline_set__fieldTransform3D)));
+            collector.TryAdd(PropertyName.@_fieldVector4, (new(&trampoline_get__fieldVector4), new(&trampoline_set__fieldVector4)));
+            collector.TryAdd(PropertyName.@_fieldVector4I, (new(&trampoline_get__fieldVector4I), new(&trampoline_set__fieldVector4I)));
+            collector.TryAdd(PropertyName.@_fieldProjection, (new(&trampoline_get__fieldProjection), new(&trampoline_set__fieldProjection)));
+            collector.TryAdd(PropertyName.@_fieldAabb, (new(&trampoline_get__fieldAabb), new(&trampoline_set__fieldAabb)));
+            collector.TryAdd(PropertyName.@_fieldColor, (new(&trampoline_get__fieldColor), new(&trampoline_set__fieldColor)));
+            collector.TryAdd(PropertyName.@_fieldPlane, (new(&trampoline_get__fieldPlane), new(&trampoline_set__fieldPlane)));
+            collector.TryAdd(PropertyName.@_fieldCallable, (new(&trampoline_get__fieldCallable), new(&trampoline_set__fieldCallable)));
+            collector.TryAdd(PropertyName.@_fieldSignal, (new(&trampoline_get__fieldSignal), new(&trampoline_set__fieldSignal)));
+            collector.TryAdd(PropertyName.@_fieldEnum, (new(&trampoline_get__fieldEnum), new(&trampoline_set__fieldEnum)));
+            collector.TryAdd(PropertyName.@_fieldFlagsEnum, (new(&trampoline_get__fieldFlagsEnum), new(&trampoline_set__fieldFlagsEnum)));
+            collector.TryAdd(PropertyName.@_fieldByteArray, (new(&trampoline_get__fieldByteArray), new(&trampoline_set__fieldByteArray)));
+            collector.TryAdd(PropertyName.@_fieldInt32Array, (new(&trampoline_get__fieldInt32Array), new(&trampoline_set__fieldInt32Array)));
+            collector.TryAdd(PropertyName.@_fieldInt64Array, (new(&trampoline_get__fieldInt64Array), new(&trampoline_set__fieldInt64Array)));
+            collector.TryAdd(PropertyName.@_fieldSingleArray, (new(&trampoline_get__fieldSingleArray), new(&trampoline_set__fieldSingleArray)));
+            collector.TryAdd(PropertyName.@_fieldDoubleArray, (new(&trampoline_get__fieldDoubleArray), new(&trampoline_set__fieldDoubleArray)));
+            collector.TryAdd(PropertyName.@_fieldStringArray, (new(&trampoline_get__fieldStringArray), new(&trampoline_set__fieldStringArray)));
+            collector.TryAdd(PropertyName.@_fieldStringArrayEnum, (new(&trampoline_get__fieldStringArrayEnum), new(&trampoline_set__fieldStringArrayEnum)));
+            collector.TryAdd(PropertyName.@_fieldVector2Array, (new(&trampoline_get__fieldVector2Array), new(&trampoline_set__fieldVector2Array)));
+            collector.TryAdd(PropertyName.@_fieldVector3Array, (new(&trampoline_get__fieldVector3Array), new(&trampoline_set__fieldVector3Array)));
+            collector.TryAdd(PropertyName.@_fieldColorArray, (new(&trampoline_get__fieldColorArray), new(&trampoline_set__fieldColorArray)));
+            collector.TryAdd(PropertyName.@_fieldGodotObjectOrDerivedArray, (new(&trampoline_get__fieldGodotObjectOrDerivedArray), new(&trampoline_set__fieldGodotObjectOrDerivedArray)));
+            collector.TryAdd(PropertyName.@_fieldStringNameArray, (new(&trampoline_get__fieldStringNameArray), new(&trampoline_set__fieldStringNameArray)));
+            collector.TryAdd(PropertyName.@_fieldNodePathArray, (new(&trampoline_get__fieldNodePathArray), new(&trampoline_set__fieldNodePathArray)));
+            collector.TryAdd(PropertyName.@_fieldRidArray, (new(&trampoline_get__fieldRidArray), new(&trampoline_set__fieldRidArray)));
+            collector.TryAdd(PropertyName.@_fieldEmptyInt32Array, (new(&trampoline_get__fieldEmptyInt32Array), new(&trampoline_set__fieldEmptyInt32Array)));
+            collector.TryAdd(PropertyName.@_fieldArrayFromList, (new(&trampoline_get__fieldArrayFromList), new(&trampoline_set__fieldArrayFromList)));
+            collector.TryAdd(PropertyName.@_fieldVariant, (new(&trampoline_get__fieldVariant), new(&trampoline_set__fieldVariant)));
+            collector.TryAdd(PropertyName.@_fieldGodotObjectOrDerived, (new(&trampoline_get__fieldGodotObjectOrDerived), new(&trampoline_set__fieldGodotObjectOrDerived)));
+            collector.TryAdd(PropertyName.@_fieldGodotResourceTexture, (new(&trampoline_get__fieldGodotResourceTexture), new(&trampoline_set__fieldGodotResourceTexture)));
+            collector.TryAdd(PropertyName.@_fieldGodotResourceTextureWithInitializer, (new(&trampoline_get__fieldGodotResourceTextureWithInitializer), new(&trampoline_set__fieldGodotResourceTextureWithInitializer)));
+            collector.TryAdd(PropertyName.@_fieldStringName, (new(&trampoline_get__fieldStringName), new(&trampoline_set__fieldStringName)));
+            collector.TryAdd(PropertyName.@_fieldNodePath, (new(&trampoline_get__fieldNodePath), new(&trampoline_set__fieldNodePath)));
+            collector.TryAdd(PropertyName.@_fieldRid, (new(&trampoline_get__fieldRid), new(&trampoline_set__fieldRid)));
+            collector.TryAdd(PropertyName.@_fieldGodotDictionary, (new(&trampoline_get__fieldGodotDictionary), new(&trampoline_set__fieldGodotDictionary)));
+            collector.TryAdd(PropertyName.@_fieldGodotArray, (new(&trampoline_get__fieldGodotArray), new(&trampoline_set__fieldGodotArray)));
+            collector.TryAdd(PropertyName.@_fieldGodotGenericDictionary, (new(&trampoline_get__fieldGodotGenericDictionary), new(&trampoline_set__fieldGodotGenericDictionary)));
+            collector.TryAdd(PropertyName.@_fieldGodotGenericArray, (new(&trampoline_get__fieldGodotGenericArray), new(&trampoline_set__fieldGodotGenericArray)));
+            collector.TryAdd(PropertyName.@_notIgnoredField, (new(&trampoline_get__notIgnoredField), new(&trampoline_set__notIgnoredField)));
+            collector.TryAdd(PropertyName.@_fieldEmptyInt64Array, (new(&trampoline_get__fieldEmptyInt64Array), new(&trampoline_set__fieldEmptyInt64Array)));
         }
-        if (name == PropertyName.@_fieldChar) {
-            this.@_fieldChar = global::Godot.NativeInterop.VariantUtils.ConvertTo<char>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSByte) {
-            this.@_fieldSByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<sbyte>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt16) {
-            this.@_fieldInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<short>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt32) {
-            this.@_fieldInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt64) {
-            this.@_fieldInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<long>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldByte) {
-            this.@_fieldByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldUInt16) {
-            this.@_fieldUInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ushort>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldUInt32) {
-            this.@_fieldUInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<uint>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldUInt64) {
-            this.@_fieldUInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ulong>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSingle) {
-            this.@_fieldSingle = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldDouble) {
-            this.@_fieldDouble = global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldString) {
-            this.@_fieldString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStaticImport) {
-            this.@_fieldStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector2) {
-            this.@_fieldVector2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector2I) {
-            this.@_fieldVector2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2I>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRect2) {
-            this.@_fieldRect2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRect2I) {
-            this.@_fieldRect2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2I>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldTransform2D) {
-            this.@_fieldTransform2D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform2D>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector3) {
-            this.@_fieldVector3 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector3I) {
-            this.@_fieldVector3I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3I>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldBasis) {
-            this.@_fieldBasis = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Basis>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldQuaternion) {
-            this.@_fieldQuaternion = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Quaternion>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldTransform3D) {
-            this.@_fieldTransform3D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform3D>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector4) {
-            this.@_fieldVector4 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector4I) {
-            this.@_fieldVector4I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4I>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldProjection) {
-            this.@_fieldProjection = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Projection>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldAabb) {
-            this.@_fieldAabb = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Aabb>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldColor) {
-            this.@_fieldColor = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldPlane) {
-            this.@_fieldPlane = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Plane>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldCallable) {
-            this.@_fieldCallable = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSignal) {
-            this.@_fieldSignal = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Signal>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldEnum) {
-            this.@_fieldEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedFields.MyEnum>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldFlagsEnum) {
-            this.@_fieldFlagsEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedFields.MyFlagsEnum>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldByteArray) {
-            this.@_fieldByteArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt32Array) {
-            this.@_fieldInt32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt64Array) {
-            this.@_fieldInt64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSingleArray) {
-            this.@_fieldSingleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<float[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldDoubleArray) {
-            this.@_fieldDoubleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<double[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringArray) {
-            this.@_fieldStringArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringArrayEnum) {
-            this.@_fieldStringArrayEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector2Array) {
-            this.@_fieldVector2Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector3Array) {
-            this.@_fieldVector3Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldColorArray) {
-            this.@_fieldColorArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotObjectOrDerivedArray) {
-            this.@_fieldGodotObjectOrDerivedArray = global::Godot.NativeInterop.VariantUtils.ConvertToSystemArrayOfGodotObject<global::Godot.GodotObject>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringNameArray) {
-            this.@_fieldStringNameArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldNodePathArray) {
-            this.@_fieldNodePathArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRidArray) {
-            this.@_fieldRidArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldEmptyInt32Array) {
-            this.@_fieldEmptyInt32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldArrayFromList) {
-            this.@_fieldArrayFromList = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVariant) {
-            this.@_fieldVariant = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Variant>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotObjectOrDerived) {
-            this.@_fieldGodotObjectOrDerived = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.GodotObject>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotResourceTexture) {
-            this.@_fieldGodotResourceTexture = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotResourceTextureWithInitializer) {
-            this.@_fieldGodotResourceTextureWithInitializer = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringName) {
-            this.@_fieldStringName = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldNodePath) {
-            this.@_fieldNodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRid) {
-            this.@_fieldRid = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotDictionary) {
-            this.@_fieldGodotDictionary = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Dictionary>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotArray) {
-            this.@_fieldGodotArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Array>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotGenericDictionary) {
-            this.@_fieldGodotGenericDictionary = global::Godot.NativeInterop.VariantUtils.ConvertToDictionary<string, bool>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotGenericArray) {
-            this.@_fieldGodotGenericArray = global::Godot.NativeInterop.VariantUtils.ConvertToArray<int>(value);
-            return true;
-        }
-        if (name == PropertyName.@_notIgnoredField) {
-            this.@_notIgnoredField = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fieldEmptyInt64Array) {
-            this.@_fieldEmptyInt64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
-            return true;
-        }
-        return base.SetGodotClassPropertyValue(name, value);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
-    {
-        if (name == PropertyName.@_fieldBoolean) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.@_fieldBoolean);
-            return true;
-        }
-        if (name == PropertyName.@_fieldChar) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<char>(this.@_fieldChar);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSByte) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<sbyte>(this.@_fieldSByte);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt16) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<short>(this.@_fieldInt16);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt32) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this.@_fieldInt32);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt64) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long>(this.@_fieldInt64);
-            return true;
-        }
-        if (name == PropertyName.@_fieldByte) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte>(this.@_fieldByte);
-            return true;
-        }
-        if (name == PropertyName.@_fieldUInt16) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ushort>(this.@_fieldUInt16);
-            return true;
-        }
-        if (name == PropertyName.@_fieldUInt32) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<uint>(this.@_fieldUInt32);
-            return true;
-        }
-        if (name == PropertyName.@_fieldUInt64) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ulong>(this.@_fieldUInt64);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSingle) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@_fieldSingle);
-            return true;
-        }
-        if (name == PropertyName.@_fieldDouble) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double>(this.@_fieldDouble);
-            return true;
-        }
-        if (name == PropertyName.@_fieldString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@_fieldString);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStaticImport) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@_fieldStaticImport);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector2) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2>(this.@_fieldVector2);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector2I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2I>(this.@_fieldVector2I);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRect2) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2>(this.@_fieldRect2);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRect2I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2I>(this.@_fieldRect2I);
-            return true;
-        }
-        if (name == PropertyName.@_fieldTransform2D) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform2D>(this.@_fieldTransform2D);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector3) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3>(this.@_fieldVector3);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector3I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3I>(this.@_fieldVector3I);
-            return true;
-        }
-        if (name == PropertyName.@_fieldBasis) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Basis>(this.@_fieldBasis);
-            return true;
-        }
-        if (name == PropertyName.@_fieldQuaternion) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Quaternion>(this.@_fieldQuaternion);
-            return true;
-        }
-        if (name == PropertyName.@_fieldTransform3D) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform3D>(this.@_fieldTransform3D);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector4) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4>(this.@_fieldVector4);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector4I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4I>(this.@_fieldVector4I);
-            return true;
-        }
-        if (name == PropertyName.@_fieldProjection) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Projection>(this.@_fieldProjection);
-            return true;
-        }
-        if (name == PropertyName.@_fieldAabb) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Aabb>(this.@_fieldAabb);
-            return true;
-        }
-        if (name == PropertyName.@_fieldColor) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color>(this.@_fieldColor);
-            return true;
-        }
-        if (name == PropertyName.@_fieldPlane) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Plane>(this.@_fieldPlane);
-            return true;
-        }
-        if (name == PropertyName.@_fieldCallable) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@_fieldCallable);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSignal) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Signal>(this.@_fieldSignal);
-            return true;
-        }
-        if (name == PropertyName.@_fieldEnum) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedFields.MyEnum>(this.@_fieldEnum);
-            return true;
-        }
-        if (name == PropertyName.@_fieldFlagsEnum) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedFields.MyFlagsEnum>(this.@_fieldFlagsEnum);
-            return true;
-        }
-        if (name == PropertyName.@_fieldByteArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte[]>(this.@_fieldByteArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt32Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this.@_fieldInt32Array);
-            return true;
-        }
-        if (name == PropertyName.@_fieldInt64Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(this.@_fieldInt64Array);
-            return true;
-        }
-        if (name == PropertyName.@_fieldSingleArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float[]>(this.@_fieldSingleArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldDoubleArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double[]>(this.@_fieldDoubleArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this.@_fieldStringArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringArrayEnum) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this.@_fieldStringArrayEnum);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector2Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2[]>(this.@_fieldVector2Array);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVector3Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3[]>(this.@_fieldVector3Array);
-            return true;
-        }
-        if (name == PropertyName.@_fieldColorArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color[]>(this.@_fieldColorArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotObjectOrDerivedArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFromSystemArrayOfGodotObject(this.@_fieldGodotObjectOrDerivedArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringNameArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName[]>(this.@_fieldStringNameArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldNodePathArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath[]>(this.@_fieldNodePathArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRidArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid[]>(this.@_fieldRidArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldEmptyInt32Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this.@_fieldEmptyInt32Array);
-            return true;
-        }
-        if (name == PropertyName.@_fieldArrayFromList) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this.@_fieldArrayFromList);
-            return true;
-        }
-        if (name == PropertyName.@_fieldVariant) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Variant>(this.@_fieldVariant);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotObjectOrDerived) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.GodotObject>(this.@_fieldGodotObjectOrDerived);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotResourceTexture) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this.@_fieldGodotResourceTexture);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotResourceTextureWithInitializer) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this.@_fieldGodotResourceTextureWithInitializer);
-            return true;
-        }
-        if (name == PropertyName.@_fieldStringName) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName>(this.@_fieldStringName);
-            return true;
-        }
-        if (name == PropertyName.@_fieldNodePath) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(this.@_fieldNodePath);
-            return true;
-        }
-        if (name == PropertyName.@_fieldRid) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid>(this.@_fieldRid);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotDictionary) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Dictionary>(this.@_fieldGodotDictionary);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Array>(this.@_fieldGodotArray);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotGenericDictionary) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFromDictionary(this.@_fieldGodotGenericDictionary);
-            return true;
-        }
-        if (name == PropertyName.@_fieldGodotGenericArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFromArray(this.@_fieldGodotGenericArray);
-            return true;
-        }
-        if (name == PropertyName.@_notIgnoredField) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this.@_notIgnoredField);
-            return true;
-        }
-        if (name == PropertyName.@_fieldEmptyInt64Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(this.@_fieldEmptyInt64Array);
-            return true;
-        }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
@@ -321,641 +321,791 @@ partial class ExportedProperties
         /// </summary>
         public new static readonly global::Godot.StringName @_lambdaPropertyStaticImport = "_lambdaPropertyStaticImport";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@NotGenerateComplexLamdaProperty) {
-            this.@NotGenerateComplexLamdaProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static godot_variant trampoline_get_NotGenerateComplexLamdaProperty(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@NotGenerateComplexLamdaProperty;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_NotGenerateComplexLamdaProperty(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@NotGenerateComplexLamdaProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_NotGenerateLamdaNoFieldProperty(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@NotGenerateLamdaNoFieldProperty;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_NotGenerateLamdaNoFieldProperty(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@NotGenerateLamdaNoFieldProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_NotGenerateComplexReturnProperty(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@NotGenerateComplexReturnProperty;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_NotGenerateComplexReturnProperty(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@NotGenerateComplexReturnProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_NotGenerateReturnsProperty(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@NotGenerateReturnsProperty;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_NotGenerateReturnsProperty(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@NotGenerateReturnsProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_FullPropertyString(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@FullPropertyString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_FullPropertyString(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@FullPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_FullPropertyString_Complex(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@FullPropertyString_Complex;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_FullPropertyString_Complex(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@FullPropertyString_Complex = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_FullPropertyStaticImport(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@FullPropertyStaticImport;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set_FullPropertyStaticImport(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@FullPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get_LamdaPropertyString(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@LamdaPropertyString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_LamdaPropertyString(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@LamdaPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_LambdaPropertyStaticImport(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@LambdaPropertyStaticImport;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set_LambdaPropertyStaticImport(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@LambdaPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get_PrimaryCtorParameter(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PrimaryCtorParameter;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_PrimaryCtorParameter(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PrimaryCtorParameter = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_ConstantMath(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@ConstantMath;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set_ConstantMath(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@ConstantMath = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get_ConstantMathStaticImport(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@ConstantMathStaticImport;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set_ConstantMathStaticImport(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@ConstantMathStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get_StaticStringAddition(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@StaticStringAddition;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_StaticStringAddition(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@StaticStringAddition = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_PropertyBoolean(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyBoolean;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(ret);
+            }
+            static void trampoline_set_PropertyBoolean(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyBoolean = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            }
+            static godot_variant trampoline_get_PropertyChar(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyChar;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<char>(ret);
+            }
+            static void trampoline_set_PropertyChar(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyChar = global::Godot.NativeInterop.VariantUtils.ConvertTo<char>(value);
+            }
+            static godot_variant trampoline_get_PropertySByte(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertySByte;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<sbyte>(ret);
+            }
+            static void trampoline_set_PropertySByte(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertySByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<sbyte>(value);
+            }
+            static godot_variant trampoline_get_PropertyInt16(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyInt16;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<short>(ret);
+            }
+            static void trampoline_set_PropertyInt16(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<short>(value);
+            }
+            static godot_variant trampoline_get_PropertyInt32(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyInt32;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(ret);
+            }
+            static void trampoline_set_PropertyInt32(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
+            }
+            static godot_variant trampoline_get_PropertyInt64(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyInt64;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<long>(ret);
+            }
+            static void trampoline_set_PropertyInt64(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<long>(value);
+            }
+            static godot_variant trampoline_get_PropertyByte(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyByte;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<byte>(ret);
+            }
+            static void trampoline_set_PropertyByte(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte>(value);
+            }
+            static godot_variant trampoline_get_PropertyUInt16(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyUInt16;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<ushort>(ret);
+            }
+            static void trampoline_set_PropertyUInt16(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyUInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ushort>(value);
+            }
+            static godot_variant trampoline_get_PropertyUInt32(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyUInt32;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<uint>(ret);
+            }
+            static void trampoline_set_PropertyUInt32(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyUInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<uint>(value);
+            }
+            static godot_variant trampoline_get_PropertyUInt64(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyUInt64;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<ulong>(ret);
+            }
+            static void trampoline_set_PropertyUInt64(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyUInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ulong>(value);
+            }
+            static godot_variant trampoline_get_PropertySingle(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertySingle;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set_PropertySingle(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertySingle = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get_PropertyDouble(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyDouble;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<double>(ret);
+            }
+            static void trampoline_set_PropertyDouble(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyDouble = global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(value);
+            }
+            static godot_variant trampoline_get_PropertyString(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_PropertyString(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector2(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector2;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2>(ret);
+            }
+            static void trampoline_set_PropertyVector2(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector2I(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector2I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2I>(ret);
+            }
+            static void trampoline_set_PropertyVector2I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2I>(value);
+            }
+            static godot_variant trampoline_get_PropertyRect2(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyRect2;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2>(ret);
+            }
+            static void trampoline_set_PropertyRect2(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyRect2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2>(value);
+            }
+            static godot_variant trampoline_get_PropertyRect2I(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyRect2I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2I>(ret);
+            }
+            static void trampoline_set_PropertyRect2I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyRect2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2I>(value);
+            }
+            static godot_variant trampoline_get_PropertyTransform2D(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyTransform2D;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform2D>(ret);
+            }
+            static void trampoline_set_PropertyTransform2D(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyTransform2D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform2D>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector3(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector3;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3>(ret);
+            }
+            static void trampoline_set_PropertyVector3(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector3 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector3I(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector3I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3I>(ret);
+            }
+            static void trampoline_set_PropertyVector3I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector3I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3I>(value);
+            }
+            static godot_variant trampoline_get_PropertyBasis(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyBasis;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Basis>(ret);
+            }
+            static void trampoline_set_PropertyBasis(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyBasis = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Basis>(value);
+            }
+            static godot_variant trampoline_get_PropertyQuaternion(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyQuaternion;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Quaternion>(ret);
+            }
+            static void trampoline_set_PropertyQuaternion(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyQuaternion = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Quaternion>(value);
+            }
+            static godot_variant trampoline_get_PropertyTransform3D(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyTransform3D;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform3D>(ret);
+            }
+            static void trampoline_set_PropertyTransform3D(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyTransform3D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform3D>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector4(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector4;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4>(ret);
+            }
+            static void trampoline_set_PropertyVector4(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector4 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector4I(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector4I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4I>(ret);
+            }
+            static void trampoline_set_PropertyVector4I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector4I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4I>(value);
+            }
+            static godot_variant trampoline_get_PropertyProjection(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyProjection;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Projection>(ret);
+            }
+            static void trampoline_set_PropertyProjection(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyProjection = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Projection>(value);
+            }
+            static godot_variant trampoline_get_PropertyAabb(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyAabb;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Aabb>(ret);
+            }
+            static void trampoline_set_PropertyAabb(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyAabb = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Aabb>(value);
+            }
+            static godot_variant trampoline_get_PropertyColor(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyColor;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color>(ret);
+            }
+            static void trampoline_set_PropertyColor(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyColor = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color>(value);
+            }
+            static godot_variant trampoline_get_PropertyPlane(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyPlane;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Plane>(ret);
+            }
+            static void trampoline_set_PropertyPlane(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyPlane = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Plane>(value);
+            }
+            static godot_variant trampoline_get_PropertyCallable(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyCallable;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            static void trampoline_set_PropertyCallable(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyCallable = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
+            }
+            static godot_variant trampoline_get_PropertySignal(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertySignal;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Signal>(ret);
+            }
+            static void trampoline_set_PropertySignal(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertySignal = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Signal>(value);
+            }
+            static godot_variant trampoline_get_PropertyEnum(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyEnum;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedProperties.MyEnum>(ret);
+            }
+            static void trampoline_set_PropertyEnum(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedProperties.MyEnum>(value);
+            }
+            static godot_variant trampoline_get_PropertyFlagsEnum(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyFlagsEnum;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedProperties.MyFlagsEnum>(ret);
+            }
+            static void trampoline_set_PropertyFlagsEnum(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyFlagsEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedProperties.MyFlagsEnum>(value);
+            }
+            static godot_variant trampoline_get_PropertyByteArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyByteArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<byte[]>(ret);
+            }
+            static void trampoline_set_PropertyByteArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyByteArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyInt32Array(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyInt32Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(ret);
+            }
+            static void trampoline_set_PropertyInt32Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyInt32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyInt64Array(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyInt64Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(ret);
+            }
+            static void trampoline_set_PropertyInt64Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyInt64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
+            }
+            static godot_variant trampoline_get_PropertySingleArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertySingleArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float[]>(ret);
+            }
+            static void trampoline_set_PropertySingleArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertySingleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<float[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyDoubleArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyDoubleArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<double[]>(ret);
+            }
+            static void trampoline_set_PropertyDoubleArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyDoubleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<double[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyStringArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyStringArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(ret);
+            }
+            static void trampoline_set_PropertyStringArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyStringArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyStringArrayEnum(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyStringArrayEnum;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(ret);
+            }
+            static void trampoline_set_PropertyStringArrayEnum(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyStringArrayEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector2Array(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector2Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2[]>(ret);
+            }
+            static void trampoline_set_PropertyVector2Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector2Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector3Array(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector3Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3[]>(ret);
+            }
+            static void trampoline_set_PropertyVector3Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector3Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyColorArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyColorArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color[]>(ret);
+            }
+            static void trampoline_set_PropertyColorArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyColorArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotObjectOrDerivedArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotObjectOrDerivedArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFromSystemArrayOfGodotObject(ret);
+            }
+            static void trampoline_set_PropertyGodotObjectOrDerivedArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotObjectOrDerivedArray = global::Godot.NativeInterop.VariantUtils.ConvertToSystemArrayOfGodotObject<global::Godot.GodotObject>(value);
+            }
+            static godot_variant trampoline_get_field_StringNameArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@field_StringNameArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName[]>(ret);
+            }
+            static void trampoline_set_field_StringNameArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@field_StringNameArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName[]>(value);
+            }
+            static godot_variant trampoline_get_field_NodePathArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@field_NodePathArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath[]>(ret);
+            }
+            static void trampoline_set_field_NodePathArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@field_NodePathArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath[]>(value);
+            }
+            static godot_variant trampoline_get_field_RidArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@field_RidArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid[]>(ret);
+            }
+            static void trampoline_set_field_RidArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@field_RidArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyVariant(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVariant;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Variant>(ret);
+            }
+            static void trampoline_set_PropertyVariant(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVariant = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Variant>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotObjectOrDerived(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotObjectOrDerived;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.GodotObject>(ret);
+            }
+            static void trampoline_set_PropertyGodotObjectOrDerived(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotObjectOrDerived = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.GodotObject>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotResourceTexture(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotResourceTexture;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(ret);
+            }
+            static void trampoline_set_PropertyGodotResourceTexture(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotResourceTexture = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotResourceTextureWithInitializer(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotResourceTextureWithInitializer;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(ret);
+            }
+            static void trampoline_set_PropertyGodotResourceTextureWithInitializer(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotResourceTextureWithInitializer = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
+            }
+            static godot_variant trampoline_get_PropertyStringName(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyStringName;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName>(ret);
+            }
+            static void trampoline_set_PropertyStringName(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyStringName = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(value);
+            }
+            static godot_variant trampoline_get_PropertyNodePath(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyNodePath;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(ret);
+            }
+            static void trampoline_set_PropertyNodePath(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyNodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
+            }
+            static godot_variant trampoline_get_PropertyRid(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyRid;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid>(ret);
+            }
+            static void trampoline_set_PropertyRid(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyRid = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotDictionary(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotDictionary;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Dictionary>(ret);
+            }
+            static void trampoline_set_PropertyGodotDictionary(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotDictionary = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Dictionary>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Array>(ret);
+            }
+            static void trampoline_set_PropertyGodotArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Array>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotGenericDictionary(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotGenericDictionary;
+                return global::Godot.NativeInterop.VariantUtils.CreateFromDictionary(ret);
+            }
+            static void trampoline_set_PropertyGodotGenericDictionary(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotGenericDictionary = global::Godot.NativeInterop.VariantUtils.ConvertToDictionary<string, bool>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotGenericArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotGenericArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFromArray(ret);
+            }
+            static void trampoline_set_PropertyGodotGenericArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotGenericArray = global::Godot.NativeInterop.VariantUtils.ConvertToArray<int>(value);
+            }
+            static godot_variant trampoline_get__notGeneratePropertyString(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@_notGeneratePropertyString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set__notGeneratePropertyString(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@_notGeneratePropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get__notGeneratePropertyInt(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@_notGeneratePropertyInt;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(ret);
+            }
+            static void trampoline_set__notGeneratePropertyInt(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@_notGeneratePropertyInt = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
+            }
+            static godot_variant trampoline_get__fullPropertyString(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@_fullPropertyString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set__fullPropertyString(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@_fullPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get__fullPropertyStringComplex(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@_fullPropertyStringComplex;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set__fullPropertyStringComplex(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@_fullPropertyStringComplex = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get__fullPropertyStaticImport(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@_fullPropertyStaticImport;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set__fullPropertyStaticImport(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@_fullPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get__lamdaPropertyString(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@_lamdaPropertyString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set__lamdaPropertyString(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@_lamdaPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get__lambdaPropertyStaticImport(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@_lambdaPropertyStaticImport;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set__lambdaPropertyStaticImport(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@_lambdaPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            collector.TryAdd(PropertyName.@NotGenerateComplexLamdaProperty, (new(&trampoline_get_NotGenerateComplexLamdaProperty), new(&trampoline_set_NotGenerateComplexLamdaProperty)));
+            collector.TryAdd(PropertyName.@NotGenerateLamdaNoFieldProperty, (new(&trampoline_get_NotGenerateLamdaNoFieldProperty), new(&trampoline_set_NotGenerateLamdaNoFieldProperty)));
+            collector.TryAdd(PropertyName.@NotGenerateComplexReturnProperty, (new(&trampoline_get_NotGenerateComplexReturnProperty), new(&trampoline_set_NotGenerateComplexReturnProperty)));
+            collector.TryAdd(PropertyName.@NotGenerateReturnsProperty, (new(&trampoline_get_NotGenerateReturnsProperty), new(&trampoline_set_NotGenerateReturnsProperty)));
+            collector.TryAdd(PropertyName.@FullPropertyString, (new(&trampoline_get_FullPropertyString), new(&trampoline_set_FullPropertyString)));
+            collector.TryAdd(PropertyName.@FullPropertyString_Complex, (new(&trampoline_get_FullPropertyString_Complex), new(&trampoline_set_FullPropertyString_Complex)));
+            collector.TryAdd(PropertyName.@FullPropertyStaticImport, (new(&trampoline_get_FullPropertyStaticImport), new(&trampoline_set_FullPropertyStaticImport)));
+            collector.TryAdd(PropertyName.@LamdaPropertyString, (new(&trampoline_get_LamdaPropertyString), new(&trampoline_set_LamdaPropertyString)));
+            collector.TryAdd(PropertyName.@LambdaPropertyStaticImport, (new(&trampoline_get_LambdaPropertyStaticImport), new(&trampoline_set_LambdaPropertyStaticImport)));
+            collector.TryAdd(PropertyName.@PrimaryCtorParameter, (new(&trampoline_get_PrimaryCtorParameter), new(&trampoline_set_PrimaryCtorParameter)));
+            collector.TryAdd(PropertyName.@ConstantMath, (new(&trampoline_get_ConstantMath), new(&trampoline_set_ConstantMath)));
+            collector.TryAdd(PropertyName.@ConstantMathStaticImport, (new(&trampoline_get_ConstantMathStaticImport), new(&trampoline_set_ConstantMathStaticImport)));
+            collector.TryAdd(PropertyName.@StaticStringAddition, (new(&trampoline_get_StaticStringAddition), new(&trampoline_set_StaticStringAddition)));
+            collector.TryAdd(PropertyName.@PropertyBoolean, (new(&trampoline_get_PropertyBoolean), new(&trampoline_set_PropertyBoolean)));
+            collector.TryAdd(PropertyName.@PropertyChar, (new(&trampoline_get_PropertyChar), new(&trampoline_set_PropertyChar)));
+            collector.TryAdd(PropertyName.@PropertySByte, (new(&trampoline_get_PropertySByte), new(&trampoline_set_PropertySByte)));
+            collector.TryAdd(PropertyName.@PropertyInt16, (new(&trampoline_get_PropertyInt16), new(&trampoline_set_PropertyInt16)));
+            collector.TryAdd(PropertyName.@PropertyInt32, (new(&trampoline_get_PropertyInt32), new(&trampoline_set_PropertyInt32)));
+            collector.TryAdd(PropertyName.@PropertyInt64, (new(&trampoline_get_PropertyInt64), new(&trampoline_set_PropertyInt64)));
+            collector.TryAdd(PropertyName.@PropertyByte, (new(&trampoline_get_PropertyByte), new(&trampoline_set_PropertyByte)));
+            collector.TryAdd(PropertyName.@PropertyUInt16, (new(&trampoline_get_PropertyUInt16), new(&trampoline_set_PropertyUInt16)));
+            collector.TryAdd(PropertyName.@PropertyUInt32, (new(&trampoline_get_PropertyUInt32), new(&trampoline_set_PropertyUInt32)));
+            collector.TryAdd(PropertyName.@PropertyUInt64, (new(&trampoline_get_PropertyUInt64), new(&trampoline_set_PropertyUInt64)));
+            collector.TryAdd(PropertyName.@PropertySingle, (new(&trampoline_get_PropertySingle), new(&trampoline_set_PropertySingle)));
+            collector.TryAdd(PropertyName.@PropertyDouble, (new(&trampoline_get_PropertyDouble), new(&trampoline_set_PropertyDouble)));
+            collector.TryAdd(PropertyName.@PropertyString, (new(&trampoline_get_PropertyString), new(&trampoline_set_PropertyString)));
+            collector.TryAdd(PropertyName.@PropertyVector2, (new(&trampoline_get_PropertyVector2), new(&trampoline_set_PropertyVector2)));
+            collector.TryAdd(PropertyName.@PropertyVector2I, (new(&trampoline_get_PropertyVector2I), new(&trampoline_set_PropertyVector2I)));
+            collector.TryAdd(PropertyName.@PropertyRect2, (new(&trampoline_get_PropertyRect2), new(&trampoline_set_PropertyRect2)));
+            collector.TryAdd(PropertyName.@PropertyRect2I, (new(&trampoline_get_PropertyRect2I), new(&trampoline_set_PropertyRect2I)));
+            collector.TryAdd(PropertyName.@PropertyTransform2D, (new(&trampoline_get_PropertyTransform2D), new(&trampoline_set_PropertyTransform2D)));
+            collector.TryAdd(PropertyName.@PropertyVector3, (new(&trampoline_get_PropertyVector3), new(&trampoline_set_PropertyVector3)));
+            collector.TryAdd(PropertyName.@PropertyVector3I, (new(&trampoline_get_PropertyVector3I), new(&trampoline_set_PropertyVector3I)));
+            collector.TryAdd(PropertyName.@PropertyBasis, (new(&trampoline_get_PropertyBasis), new(&trampoline_set_PropertyBasis)));
+            collector.TryAdd(PropertyName.@PropertyQuaternion, (new(&trampoline_get_PropertyQuaternion), new(&trampoline_set_PropertyQuaternion)));
+            collector.TryAdd(PropertyName.@PropertyTransform3D, (new(&trampoline_get_PropertyTransform3D), new(&trampoline_set_PropertyTransform3D)));
+            collector.TryAdd(PropertyName.@PropertyVector4, (new(&trampoline_get_PropertyVector4), new(&trampoline_set_PropertyVector4)));
+            collector.TryAdd(PropertyName.@PropertyVector4I, (new(&trampoline_get_PropertyVector4I), new(&trampoline_set_PropertyVector4I)));
+            collector.TryAdd(PropertyName.@PropertyProjection, (new(&trampoline_get_PropertyProjection), new(&trampoline_set_PropertyProjection)));
+            collector.TryAdd(PropertyName.@PropertyAabb, (new(&trampoline_get_PropertyAabb), new(&trampoline_set_PropertyAabb)));
+            collector.TryAdd(PropertyName.@PropertyColor, (new(&trampoline_get_PropertyColor), new(&trampoline_set_PropertyColor)));
+            collector.TryAdd(PropertyName.@PropertyPlane, (new(&trampoline_get_PropertyPlane), new(&trampoline_set_PropertyPlane)));
+            collector.TryAdd(PropertyName.@PropertyCallable, (new(&trampoline_get_PropertyCallable), new(&trampoline_set_PropertyCallable)));
+            collector.TryAdd(PropertyName.@PropertySignal, (new(&trampoline_get_PropertySignal), new(&trampoline_set_PropertySignal)));
+            collector.TryAdd(PropertyName.@PropertyEnum, (new(&trampoline_get_PropertyEnum), new(&trampoline_set_PropertyEnum)));
+            collector.TryAdd(PropertyName.@PropertyFlagsEnum, (new(&trampoline_get_PropertyFlagsEnum), new(&trampoline_set_PropertyFlagsEnum)));
+            collector.TryAdd(PropertyName.@PropertyByteArray, (new(&trampoline_get_PropertyByteArray), new(&trampoline_set_PropertyByteArray)));
+            collector.TryAdd(PropertyName.@PropertyInt32Array, (new(&trampoline_get_PropertyInt32Array), new(&trampoline_set_PropertyInt32Array)));
+            collector.TryAdd(PropertyName.@PropertyInt64Array, (new(&trampoline_get_PropertyInt64Array), new(&trampoline_set_PropertyInt64Array)));
+            collector.TryAdd(PropertyName.@PropertySingleArray, (new(&trampoline_get_PropertySingleArray), new(&trampoline_set_PropertySingleArray)));
+            collector.TryAdd(PropertyName.@PropertyDoubleArray, (new(&trampoline_get_PropertyDoubleArray), new(&trampoline_set_PropertyDoubleArray)));
+            collector.TryAdd(PropertyName.@PropertyStringArray, (new(&trampoline_get_PropertyStringArray), new(&trampoline_set_PropertyStringArray)));
+            collector.TryAdd(PropertyName.@PropertyStringArrayEnum, (new(&trampoline_get_PropertyStringArrayEnum), new(&trampoline_set_PropertyStringArrayEnum)));
+            collector.TryAdd(PropertyName.@PropertyVector2Array, (new(&trampoline_get_PropertyVector2Array), new(&trampoline_set_PropertyVector2Array)));
+            collector.TryAdd(PropertyName.@PropertyVector3Array, (new(&trampoline_get_PropertyVector3Array), new(&trampoline_set_PropertyVector3Array)));
+            collector.TryAdd(PropertyName.@PropertyColorArray, (new(&trampoline_get_PropertyColorArray), new(&trampoline_set_PropertyColorArray)));
+            collector.TryAdd(PropertyName.@PropertyGodotObjectOrDerivedArray, (new(&trampoline_get_PropertyGodotObjectOrDerivedArray), new(&trampoline_set_PropertyGodotObjectOrDerivedArray)));
+            collector.TryAdd(PropertyName.@field_StringNameArray, (new(&trampoline_get_field_StringNameArray), new(&trampoline_set_field_StringNameArray)));
+            collector.TryAdd(PropertyName.@field_NodePathArray, (new(&trampoline_get_field_NodePathArray), new(&trampoline_set_field_NodePathArray)));
+            collector.TryAdd(PropertyName.@field_RidArray, (new(&trampoline_get_field_RidArray), new(&trampoline_set_field_RidArray)));
+            collector.TryAdd(PropertyName.@PropertyVariant, (new(&trampoline_get_PropertyVariant), new(&trampoline_set_PropertyVariant)));
+            collector.TryAdd(PropertyName.@PropertyGodotObjectOrDerived, (new(&trampoline_get_PropertyGodotObjectOrDerived), new(&trampoline_set_PropertyGodotObjectOrDerived)));
+            collector.TryAdd(PropertyName.@PropertyGodotResourceTexture, (new(&trampoline_get_PropertyGodotResourceTexture), new(&trampoline_set_PropertyGodotResourceTexture)));
+            collector.TryAdd(PropertyName.@PropertyGodotResourceTextureWithInitializer, (new(&trampoline_get_PropertyGodotResourceTextureWithInitializer), new(&trampoline_set_PropertyGodotResourceTextureWithInitializer)));
+            collector.TryAdd(PropertyName.@PropertyStringName, (new(&trampoline_get_PropertyStringName), new(&trampoline_set_PropertyStringName)));
+            collector.TryAdd(PropertyName.@PropertyNodePath, (new(&trampoline_get_PropertyNodePath), new(&trampoline_set_PropertyNodePath)));
+            collector.TryAdd(PropertyName.@PropertyRid, (new(&trampoline_get_PropertyRid), new(&trampoline_set_PropertyRid)));
+            collector.TryAdd(PropertyName.@PropertyGodotDictionary, (new(&trampoline_get_PropertyGodotDictionary), new(&trampoline_set_PropertyGodotDictionary)));
+            collector.TryAdd(PropertyName.@PropertyGodotArray, (new(&trampoline_get_PropertyGodotArray), new(&trampoline_set_PropertyGodotArray)));
+            collector.TryAdd(PropertyName.@PropertyGodotGenericDictionary, (new(&trampoline_get_PropertyGodotGenericDictionary), new(&trampoline_set_PropertyGodotGenericDictionary)));
+            collector.TryAdd(PropertyName.@PropertyGodotGenericArray, (new(&trampoline_get_PropertyGodotGenericArray), new(&trampoline_set_PropertyGodotGenericArray)));
+            collector.TryAdd(PropertyName.@_notGeneratePropertyString, (new(&trampoline_get__notGeneratePropertyString), new(&trampoline_set__notGeneratePropertyString)));
+            collector.TryAdd(PropertyName.@_notGeneratePropertyInt, (new(&trampoline_get__notGeneratePropertyInt), new(&trampoline_set__notGeneratePropertyInt)));
+            collector.TryAdd(PropertyName.@_fullPropertyString, (new(&trampoline_get__fullPropertyString), new(&trampoline_set__fullPropertyString)));
+            collector.TryAdd(PropertyName.@_fullPropertyStringComplex, (new(&trampoline_get__fullPropertyStringComplex), new(&trampoline_set__fullPropertyStringComplex)));
+            collector.TryAdd(PropertyName.@_fullPropertyStaticImport, (new(&trampoline_get__fullPropertyStaticImport), new(&trampoline_set__fullPropertyStaticImport)));
+            collector.TryAdd(PropertyName.@_lamdaPropertyString, (new(&trampoline_get__lamdaPropertyString), new(&trampoline_set__lamdaPropertyString)));
+            collector.TryAdd(PropertyName.@_lambdaPropertyStaticImport, (new(&trampoline_get__lambdaPropertyStaticImport), new(&trampoline_set__lambdaPropertyStaticImport)));
         }
-        if (name == PropertyName.@NotGenerateLamdaNoFieldProperty) {
-            this.@NotGenerateLamdaNoFieldProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@NotGenerateComplexReturnProperty) {
-            this.@NotGenerateComplexReturnProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@NotGenerateReturnsProperty) {
-            this.@NotGenerateReturnsProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@FullPropertyString) {
-            this.@FullPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@FullPropertyString_Complex) {
-            this.@FullPropertyString_Complex = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@FullPropertyStaticImport) {
-            this.@FullPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@LamdaPropertyString) {
-            this.@LamdaPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@LambdaPropertyStaticImport) {
-            this.@LambdaPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@PrimaryCtorParameter) {
-            this.@PrimaryCtorParameter = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@ConstantMath) {
-            this.@ConstantMath = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@ConstantMathStaticImport) {
-            this.@ConstantMathStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@StaticStringAddition) {
-            this.@StaticStringAddition = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyBoolean) {
-            this.@PropertyBoolean = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyChar) {
-            this.@PropertyChar = global::Godot.NativeInterop.VariantUtils.ConvertTo<char>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertySByte) {
-            this.@PropertySByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<sbyte>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt16) {
-            this.@PropertyInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<short>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt32) {
-            this.@PropertyInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt64) {
-            this.@PropertyInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<long>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyByte) {
-            this.@PropertyByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyUInt16) {
-            this.@PropertyUInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ushort>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyUInt32) {
-            this.@PropertyUInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<uint>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyUInt64) {
-            this.@PropertyUInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ulong>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertySingle) {
-            this.@PropertySingle = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyDouble) {
-            this.@PropertyDouble = global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyString) {
-            this.@PropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector2) {
-            this.@PropertyVector2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector2I) {
-            this.@PropertyVector2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2I>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyRect2) {
-            this.@PropertyRect2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyRect2I) {
-            this.@PropertyRect2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2I>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyTransform2D) {
-            this.@PropertyTransform2D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform2D>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector3) {
-            this.@PropertyVector3 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector3I) {
-            this.@PropertyVector3I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3I>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyBasis) {
-            this.@PropertyBasis = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Basis>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyQuaternion) {
-            this.@PropertyQuaternion = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Quaternion>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyTransform3D) {
-            this.@PropertyTransform3D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform3D>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector4) {
-            this.@PropertyVector4 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector4I) {
-            this.@PropertyVector4I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4I>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyProjection) {
-            this.@PropertyProjection = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Projection>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyAabb) {
-            this.@PropertyAabb = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Aabb>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyColor) {
-            this.@PropertyColor = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyPlane) {
-            this.@PropertyPlane = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Plane>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyCallable) {
-            this.@PropertyCallable = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertySignal) {
-            this.@PropertySignal = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Signal>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyEnum) {
-            this.@PropertyEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedProperties.MyEnum>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyFlagsEnum) {
-            this.@PropertyFlagsEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedProperties.MyFlagsEnum>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyByteArray) {
-            this.@PropertyByteArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt32Array) {
-            this.@PropertyInt32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt64Array) {
-            this.@PropertyInt64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertySingleArray) {
-            this.@PropertySingleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<float[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyDoubleArray) {
-            this.@PropertyDoubleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<double[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyStringArray) {
-            this.@PropertyStringArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyStringArrayEnum) {
-            this.@PropertyStringArrayEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector2Array) {
-            this.@PropertyVector2Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector3Array) {
-            this.@PropertyVector3Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyColorArray) {
-            this.@PropertyColorArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotObjectOrDerivedArray) {
-            this.@PropertyGodotObjectOrDerivedArray = global::Godot.NativeInterop.VariantUtils.ConvertToSystemArrayOfGodotObject<global::Godot.GodotObject>(value);
-            return true;
-        }
-        if (name == PropertyName.@field_StringNameArray) {
-            this.@field_StringNameArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@field_NodePathArray) {
-            this.@field_NodePathArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@field_RidArray) {
-            this.@field_RidArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVariant) {
-            this.@PropertyVariant = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Variant>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotObjectOrDerived) {
-            this.@PropertyGodotObjectOrDerived = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.GodotObject>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotResourceTexture) {
-            this.@PropertyGodotResourceTexture = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotResourceTextureWithInitializer) {
-            this.@PropertyGodotResourceTextureWithInitializer = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyStringName) {
-            this.@PropertyStringName = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyNodePath) {
-            this.@PropertyNodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyRid) {
-            this.@PropertyRid = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotDictionary) {
-            this.@PropertyGodotDictionary = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Dictionary>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotArray) {
-            this.@PropertyGodotArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Array>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotGenericDictionary) {
-            this.@PropertyGodotGenericDictionary = global::Godot.NativeInterop.VariantUtils.ConvertToDictionary<string, bool>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotGenericArray) {
-            this.@PropertyGodotGenericArray = global::Godot.NativeInterop.VariantUtils.ConvertToArray<int>(value);
-            return true;
-        }
-        if (name == PropertyName.@_notGeneratePropertyString) {
-            this.@_notGeneratePropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@_notGeneratePropertyInt) {
-            this.@_notGeneratePropertyInt = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fullPropertyString) {
-            this.@_fullPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fullPropertyStringComplex) {
-            this.@_fullPropertyStringComplex = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fullPropertyStaticImport) {
-            this.@_fullPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@_lamdaPropertyString) {
-            this.@_lamdaPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@_lambdaPropertyStaticImport) {
-            this.@_lambdaPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        return base.SetGodotClassPropertyValue(name, value);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
-    {
-        if (name == PropertyName.@NotGenerateComplexLamdaProperty) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@NotGenerateComplexLamdaProperty);
-            return true;
-        }
-        if (name == PropertyName.@NotGenerateLamdaNoFieldProperty) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@NotGenerateLamdaNoFieldProperty);
-            return true;
-        }
-        if (name == PropertyName.@NotGenerateComplexReturnProperty) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@NotGenerateComplexReturnProperty);
-            return true;
-        }
-        if (name == PropertyName.@NotGenerateReturnsProperty) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@NotGenerateReturnsProperty);
-            return true;
-        }
-        if (name == PropertyName.@FullPropertyString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@FullPropertyString);
-            return true;
-        }
-        if (name == PropertyName.@FullPropertyString_Complex) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@FullPropertyString_Complex);
-            return true;
-        }
-        if (name == PropertyName.@FullPropertyStaticImport) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@FullPropertyStaticImport);
-            return true;
-        }
-        if (name == PropertyName.@LamdaPropertyString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@LamdaPropertyString);
-            return true;
-        }
-        if (name == PropertyName.@LambdaPropertyStaticImport) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@LambdaPropertyStaticImport);
-            return true;
-        }
-        if (name == PropertyName.@PrimaryCtorParameter) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@PrimaryCtorParameter);
-            return true;
-        }
-        if (name == PropertyName.@ConstantMath) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@ConstantMath);
-            return true;
-        }
-        if (name == PropertyName.@ConstantMathStaticImport) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@ConstantMathStaticImport);
-            return true;
-        }
-        if (name == PropertyName.@StaticStringAddition) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@StaticStringAddition);
-            return true;
-        }
-        if (name == PropertyName.@PropertyBoolean) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.@PropertyBoolean);
-            return true;
-        }
-        if (name == PropertyName.@PropertyChar) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<char>(this.@PropertyChar);
-            return true;
-        }
-        if (name == PropertyName.@PropertySByte) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<sbyte>(this.@PropertySByte);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt16) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<short>(this.@PropertyInt16);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt32) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this.@PropertyInt32);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt64) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long>(this.@PropertyInt64);
-            return true;
-        }
-        if (name == PropertyName.@PropertyByte) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte>(this.@PropertyByte);
-            return true;
-        }
-        if (name == PropertyName.@PropertyUInt16) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ushort>(this.@PropertyUInt16);
-            return true;
-        }
-        if (name == PropertyName.@PropertyUInt32) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<uint>(this.@PropertyUInt32);
-            return true;
-        }
-        if (name == PropertyName.@PropertyUInt64) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ulong>(this.@PropertyUInt64);
-            return true;
-        }
-        if (name == PropertyName.@PropertySingle) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@PropertySingle);
-            return true;
-        }
-        if (name == PropertyName.@PropertyDouble) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double>(this.@PropertyDouble);
-            return true;
-        }
-        if (name == PropertyName.@PropertyString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@PropertyString);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector2) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2>(this.@PropertyVector2);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector2I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2I>(this.@PropertyVector2I);
-            return true;
-        }
-        if (name == PropertyName.@PropertyRect2) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2>(this.@PropertyRect2);
-            return true;
-        }
-        if (name == PropertyName.@PropertyRect2I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2I>(this.@PropertyRect2I);
-            return true;
-        }
-        if (name == PropertyName.@PropertyTransform2D) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform2D>(this.@PropertyTransform2D);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector3) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3>(this.@PropertyVector3);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector3I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3I>(this.@PropertyVector3I);
-            return true;
-        }
-        if (name == PropertyName.@PropertyBasis) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Basis>(this.@PropertyBasis);
-            return true;
-        }
-        if (name == PropertyName.@PropertyQuaternion) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Quaternion>(this.@PropertyQuaternion);
-            return true;
-        }
-        if (name == PropertyName.@PropertyTransform3D) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform3D>(this.@PropertyTransform3D);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector4) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4>(this.@PropertyVector4);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector4I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4I>(this.@PropertyVector4I);
-            return true;
-        }
-        if (name == PropertyName.@PropertyProjection) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Projection>(this.@PropertyProjection);
-            return true;
-        }
-        if (name == PropertyName.@PropertyAabb) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Aabb>(this.@PropertyAabb);
-            return true;
-        }
-        if (name == PropertyName.@PropertyColor) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color>(this.@PropertyColor);
-            return true;
-        }
-        if (name == PropertyName.@PropertyPlane) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Plane>(this.@PropertyPlane);
-            return true;
-        }
-        if (name == PropertyName.@PropertyCallable) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@PropertyCallable);
-            return true;
-        }
-        if (name == PropertyName.@PropertySignal) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Signal>(this.@PropertySignal);
-            return true;
-        }
-        if (name == PropertyName.@PropertyEnum) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedProperties.MyEnum>(this.@PropertyEnum);
-            return true;
-        }
-        if (name == PropertyName.@PropertyFlagsEnum) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedProperties.MyFlagsEnum>(this.@PropertyFlagsEnum);
-            return true;
-        }
-        if (name == PropertyName.@PropertyByteArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte[]>(this.@PropertyByteArray);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt32Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this.@PropertyInt32Array);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt64Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(this.@PropertyInt64Array);
-            return true;
-        }
-        if (name == PropertyName.@PropertySingleArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float[]>(this.@PropertySingleArray);
-            return true;
-        }
-        if (name == PropertyName.@PropertyDoubleArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double[]>(this.@PropertyDoubleArray);
-            return true;
-        }
-        if (name == PropertyName.@PropertyStringArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this.@PropertyStringArray);
-            return true;
-        }
-        if (name == PropertyName.@PropertyStringArrayEnum) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this.@PropertyStringArrayEnum);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector2Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2[]>(this.@PropertyVector2Array);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector3Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3[]>(this.@PropertyVector3Array);
-            return true;
-        }
-        if (name == PropertyName.@PropertyColorArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color[]>(this.@PropertyColorArray);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotObjectOrDerivedArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFromSystemArrayOfGodotObject(this.@PropertyGodotObjectOrDerivedArray);
-            return true;
-        }
-        if (name == PropertyName.@field_StringNameArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName[]>(this.@field_StringNameArray);
-            return true;
-        }
-        if (name == PropertyName.@field_NodePathArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath[]>(this.@field_NodePathArray);
-            return true;
-        }
-        if (name == PropertyName.@field_RidArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid[]>(this.@field_RidArray);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVariant) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Variant>(this.@PropertyVariant);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotObjectOrDerived) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.GodotObject>(this.@PropertyGodotObjectOrDerived);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotResourceTexture) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this.@PropertyGodotResourceTexture);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotResourceTextureWithInitializer) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this.@PropertyGodotResourceTextureWithInitializer);
-            return true;
-        }
-        if (name == PropertyName.@PropertyStringName) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName>(this.@PropertyStringName);
-            return true;
-        }
-        if (name == PropertyName.@PropertyNodePath) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(this.@PropertyNodePath);
-            return true;
-        }
-        if (name == PropertyName.@PropertyRid) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid>(this.@PropertyRid);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotDictionary) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Dictionary>(this.@PropertyGodotDictionary);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Array>(this.@PropertyGodotArray);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotGenericDictionary) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFromDictionary(this.@PropertyGodotGenericDictionary);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotGenericArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFromArray(this.@PropertyGodotGenericArray);
-            return true;
-        }
-        if (name == PropertyName.@_notGeneratePropertyString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@_notGeneratePropertyString);
-            return true;
-        }
-        if (name == PropertyName.@_notGeneratePropertyInt) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this.@_notGeneratePropertyInt);
-            return true;
-        }
-        if (name == PropertyName.@_fullPropertyString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@_fullPropertyString);
-            return true;
-        }
-        if (name == PropertyName.@_fullPropertyStringComplex) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@_fullPropertyStringComplex);
-            return true;
-        }
-        if (name == PropertyName.@_fullPropertyStaticImport) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@_fullPropertyStaticImport);
-            return true;
-        }
-        if (name == PropertyName.@_lamdaPropertyString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@_lamdaPropertyString);
-            return true;
-        }
-        if (name == PropertyName.@_lambdaPropertyStaticImport) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@_lambdaPropertyStaticImport);
-            return true;
-        }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedProperties_ScriptProperties.generated.cs
@@ -325,649 +325,801 @@ partial class ExportedProperties
         /// </summary>
         public new static readonly global::Godot.StringName @_lambdaPropertyStaticImport = "_lambdaPropertyStaticImport";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@NotGenerateComplexLamdaProperty) {
-            this.@NotGenerateComplexLamdaProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static godot_variant trampoline_get_NotGenerateComplexLamdaProperty(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@NotGenerateComplexLamdaProperty;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_NotGenerateComplexLamdaProperty(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@NotGenerateComplexLamdaProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_NotGenerateLamdaNoFieldProperty(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@NotGenerateLamdaNoFieldProperty;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_NotGenerateLamdaNoFieldProperty(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@NotGenerateLamdaNoFieldProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_NotGenerateComplexReturnProperty(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@NotGenerateComplexReturnProperty;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_NotGenerateComplexReturnProperty(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@NotGenerateComplexReturnProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_NotGenerateReturnsProperty(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@NotGenerateReturnsProperty;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_NotGenerateReturnsProperty(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@NotGenerateReturnsProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_FullPropertyString(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@FullPropertyString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_FullPropertyString(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@FullPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_FullPropertyString_Complex(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@FullPropertyString_Complex;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_FullPropertyString_Complex(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@FullPropertyString_Complex = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_FullPropertyStaticImport(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@FullPropertyStaticImport;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set_FullPropertyStaticImport(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@FullPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get_LamdaPropertyString(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@LamdaPropertyString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_LamdaPropertyString(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@LamdaPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_LambdaPropertyStaticImport(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@LambdaPropertyStaticImport;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set_LambdaPropertyStaticImport(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@LambdaPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get_PrimaryCtorParameter(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PrimaryCtorParameter;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_PrimaryCtorParameter(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PrimaryCtorParameter = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_ConstantMath(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@ConstantMath;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set_ConstantMath(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@ConstantMath = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get_ConstantMathStaticImport(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@ConstantMathStaticImport;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set_ConstantMathStaticImport(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@ConstantMathStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get_StaticStringAddition(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@StaticStringAddition;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_StaticStringAddition(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@StaticStringAddition = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_PropertyBoolean(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyBoolean;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(ret);
+            }
+            static void trampoline_set_PropertyBoolean(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyBoolean = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            }
+            static godot_variant trampoline_get_PropertyChar(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyChar;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<char>(ret);
+            }
+            static void trampoline_set_PropertyChar(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyChar = global::Godot.NativeInterop.VariantUtils.ConvertTo<char>(value);
+            }
+            static godot_variant trampoline_get_PropertySByte(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertySByte;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<sbyte>(ret);
+            }
+            static void trampoline_set_PropertySByte(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertySByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<sbyte>(value);
+            }
+            static godot_variant trampoline_get_PropertyInt16(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyInt16;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<short>(ret);
+            }
+            static void trampoline_set_PropertyInt16(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<short>(value);
+            }
+            static godot_variant trampoline_get_PropertyInt32(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyInt32;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(ret);
+            }
+            static void trampoline_set_PropertyInt32(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
+            }
+            static godot_variant trampoline_get_PropertyInt64(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyInt64;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<long>(ret);
+            }
+            static void trampoline_set_PropertyInt64(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<long>(value);
+            }
+            static godot_variant trampoline_get_PropertyByte(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyByte;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<byte>(ret);
+            }
+            static void trampoline_set_PropertyByte(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte>(value);
+            }
+            static godot_variant trampoline_get_PropertyUInt16(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyUInt16;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<ushort>(ret);
+            }
+            static void trampoline_set_PropertyUInt16(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyUInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ushort>(value);
+            }
+            static godot_variant trampoline_get_PropertyUInt32(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyUInt32;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<uint>(ret);
+            }
+            static void trampoline_set_PropertyUInt32(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyUInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<uint>(value);
+            }
+            static godot_variant trampoline_get_PropertyUInt64(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyUInt64;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<ulong>(ret);
+            }
+            static void trampoline_set_PropertyUInt64(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyUInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ulong>(value);
+            }
+            static godot_variant trampoline_get_PropertySingle(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertySingle;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set_PropertySingle(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertySingle = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get_PropertyDouble(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyDouble;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<double>(ret);
+            }
+            static void trampoline_set_PropertyDouble(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyDouble = global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(value);
+            }
+            static godot_variant trampoline_get_PropertyString(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_PropertyString(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector2(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector2;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2>(ret);
+            }
+            static void trampoline_set_PropertyVector2(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector2I(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector2I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2I>(ret);
+            }
+            static void trampoline_set_PropertyVector2I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2I>(value);
+            }
+            static godot_variant trampoline_get_PropertyRect2(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyRect2;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2>(ret);
+            }
+            static void trampoline_set_PropertyRect2(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyRect2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2>(value);
+            }
+            static godot_variant trampoline_get_PropertyRect2I(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyRect2I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2I>(ret);
+            }
+            static void trampoline_set_PropertyRect2I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyRect2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2I>(value);
+            }
+            static godot_variant trampoline_get_PropertyTransform2D(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyTransform2D;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform2D>(ret);
+            }
+            static void trampoline_set_PropertyTransform2D(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyTransform2D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform2D>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector3(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector3;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3>(ret);
+            }
+            static void trampoline_set_PropertyVector3(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector3 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector3I(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector3I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3I>(ret);
+            }
+            static void trampoline_set_PropertyVector3I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector3I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3I>(value);
+            }
+            static godot_variant trampoline_get_PropertyBasis(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyBasis;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Basis>(ret);
+            }
+            static void trampoline_set_PropertyBasis(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyBasis = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Basis>(value);
+            }
+            static godot_variant trampoline_get_PropertyQuaternion(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyQuaternion;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Quaternion>(ret);
+            }
+            static void trampoline_set_PropertyQuaternion(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyQuaternion = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Quaternion>(value);
+            }
+            static godot_variant trampoline_get_PropertyTransform3D(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyTransform3D;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform3D>(ret);
+            }
+            static void trampoline_set_PropertyTransform3D(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyTransform3D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform3D>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector4(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector4;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4>(ret);
+            }
+            static void trampoline_set_PropertyVector4(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector4 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector4I(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector4I;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4I>(ret);
+            }
+            static void trampoline_set_PropertyVector4I(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector4I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4I>(value);
+            }
+            static godot_variant trampoline_get_PropertyProjection(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyProjection;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Projection>(ret);
+            }
+            static void trampoline_set_PropertyProjection(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyProjection = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Projection>(value);
+            }
+            static godot_variant trampoline_get_PropertyAabb(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyAabb;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Aabb>(ret);
+            }
+            static void trampoline_set_PropertyAabb(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyAabb = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Aabb>(value);
+            }
+            static godot_variant trampoline_get_PropertyColor(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyColor;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color>(ret);
+            }
+            static void trampoline_set_PropertyColor(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyColor = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color>(value);
+            }
+            static godot_variant trampoline_get_PropertyPlane(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyPlane;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Plane>(ret);
+            }
+            static void trampoline_set_PropertyPlane(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyPlane = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Plane>(value);
+            }
+            static godot_variant trampoline_get_PropertyCallable(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyCallable;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            static void trampoline_set_PropertyCallable(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyCallable = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
+            }
+            static godot_variant trampoline_get_PropertySignal(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertySignal;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Signal>(ret);
+            }
+            static void trampoline_set_PropertySignal(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertySignal = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Signal>(value);
+            }
+            static godot_variant trampoline_get_PropertyEnum(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyEnum;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedProperties.MyEnum>(ret);
+            }
+            static void trampoline_set_PropertyEnum(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedProperties.MyEnum>(value);
+            }
+            static godot_variant trampoline_get_PropertyFlagsEnum(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyFlagsEnum;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedProperties.MyFlagsEnum>(ret);
+            }
+            static void trampoline_set_PropertyFlagsEnum(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyFlagsEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedProperties.MyFlagsEnum>(value);
+            }
+            static godot_variant trampoline_get_PropertyByteArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyByteArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<byte[]>(ret);
+            }
+            static void trampoline_set_PropertyByteArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyByteArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyInt32Array(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyInt32Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(ret);
+            }
+            static void trampoline_set_PropertyInt32Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyInt32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyInt64Array(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyInt64Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(ret);
+            }
+            static void trampoline_set_PropertyInt64Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyInt64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
+            }
+            static godot_variant trampoline_get_PropertySingleArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertySingleArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float[]>(ret);
+            }
+            static void trampoline_set_PropertySingleArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertySingleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<float[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyDoubleArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyDoubleArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<double[]>(ret);
+            }
+            static void trampoline_set_PropertyDoubleArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyDoubleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<double[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyStringArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyStringArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(ret);
+            }
+            static void trampoline_set_PropertyStringArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyStringArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyStringArrayEnum(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyStringArrayEnum;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(ret);
+            }
+            static void trampoline_set_PropertyStringArrayEnum(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyStringArrayEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector2Array(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector2Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2[]>(ret);
+            }
+            static void trampoline_set_PropertyVector2Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector2Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyVector3Array(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVector3Array;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3[]>(ret);
+            }
+            static void trampoline_set_PropertyVector3Array(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVector3Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyColorArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyColorArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color[]>(ret);
+            }
+            static void trampoline_set_PropertyColorArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyColorArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotObjectOrDerivedArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotObjectOrDerivedArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFromSystemArrayOfGodotObject(ret);
+            }
+            static void trampoline_set_PropertyGodotObjectOrDerivedArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotObjectOrDerivedArray = global::Godot.NativeInterop.VariantUtils.ConvertToSystemArrayOfGodotObject<global::Godot.GodotObject>(value);
+            }
+            static godot_variant trampoline_get_field_StringNameArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@field_StringNameArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName[]>(ret);
+            }
+            static void trampoline_set_field_StringNameArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@field_StringNameArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName[]>(value);
+            }
+            static godot_variant trampoline_get_field_NodePathArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@field_NodePathArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath[]>(ret);
+            }
+            static void trampoline_set_field_NodePathArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@field_NodePathArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath[]>(value);
+            }
+            static godot_variant trampoline_get_field_RidArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@field_RidArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid[]>(ret);
+            }
+            static void trampoline_set_field_RidArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@field_RidArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid[]>(value);
+            }
+            static godot_variant trampoline_get_PropertyVariant(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyVariant;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Variant>(ret);
+            }
+            static void trampoline_set_PropertyVariant(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyVariant = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Variant>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotObjectOrDerived(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotObjectOrDerived;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.GodotObject>(ret);
+            }
+            static void trampoline_set_PropertyGodotObjectOrDerived(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotObjectOrDerived = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.GodotObject>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotResourceTexture(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotResourceTexture;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(ret);
+            }
+            static void trampoline_set_PropertyGodotResourceTexture(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotResourceTexture = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotResourceTextureWithInitializer(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotResourceTextureWithInitializer;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(ret);
+            }
+            static void trampoline_set_PropertyGodotResourceTextureWithInitializer(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotResourceTextureWithInitializer = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
+            }
+            static godot_variant trampoline_get_PropertyStringName(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyStringName;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName>(ret);
+            }
+            static void trampoline_set_PropertyStringName(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyStringName = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(value);
+            }
+            static godot_variant trampoline_get_PropertyNodePath(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyNodePath;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(ret);
+            }
+            static void trampoline_set_PropertyNodePath(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyNodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
+            }
+            static godot_variant trampoline_get_PropertyRid(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyRid;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid>(ret);
+            }
+            static void trampoline_set_PropertyRid(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyRid = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotDictionary(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotDictionary;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Dictionary>(ret);
+            }
+            static void trampoline_set_PropertyGodotDictionary(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotDictionary = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Dictionary>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Array>(ret);
+            }
+            static void trampoline_set_PropertyGodotArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Array>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotGenericDictionary(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotGenericDictionary;
+                return global::Godot.NativeInterop.VariantUtils.CreateFromDictionary(ret);
+            }
+            static void trampoline_set_PropertyGodotGenericDictionary(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotGenericDictionary = global::Godot.NativeInterop.VariantUtils.ConvertToDictionary<string, bool>(value);
+            }
+            static godot_variant trampoline_get_PropertyGodotGenericArray(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@PropertyGodotGenericArray;
+                return global::Godot.NativeInterop.VariantUtils.CreateFromArray(ret);
+            }
+            static void trampoline_set_PropertyGodotGenericArray(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@PropertyGodotGenericArray = global::Godot.NativeInterop.VariantUtils.ConvertToArray<int>(value);
+            }
+            static godot_variant trampoline_get_NotIgnoredProperty(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@NotIgnoredProperty;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(ret);
+            }
+            static void trampoline_set_NotIgnoredProperty(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@NotIgnoredProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
+            }
+            static godot_variant trampoline_get__notGeneratePropertyString(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@_notGeneratePropertyString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set__notGeneratePropertyString(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@_notGeneratePropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get__notGeneratePropertyInt(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@_notGeneratePropertyInt;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(ret);
+            }
+            static void trampoline_set__notGeneratePropertyInt(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@_notGeneratePropertyInt = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
+            }
+            static godot_variant trampoline_get__fullPropertyString(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@_fullPropertyString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set__fullPropertyString(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@_fullPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get__fullPropertyStringComplex(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@_fullPropertyStringComplex;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set__fullPropertyStringComplex(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@_fullPropertyStringComplex = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get__fullPropertyStaticImport(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@_fullPropertyStaticImport;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set__fullPropertyStaticImport(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@_fullPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            static godot_variant trampoline_get__lamdaPropertyString(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@_lamdaPropertyString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set__lamdaPropertyString(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@_lamdaPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get__lambdaPropertyStaticImport(object godotObject)
+            {
+                var ret = ((global::ExportedProperties)godotObject).@_lambdaPropertyStaticImport;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(ret);
+            }
+            static void trampoline_set__lambdaPropertyStaticImport(object godotObject, in godot_variant value)
+            {
+                ((global::ExportedProperties)godotObject).@_lambdaPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
+            }
+            collector.TryAdd(PropertyName.@NotGenerateComplexLamdaProperty, (new(&trampoline_get_NotGenerateComplexLamdaProperty), new(&trampoline_set_NotGenerateComplexLamdaProperty)));
+            collector.TryAdd(PropertyName.@NotGenerateLamdaNoFieldProperty, (new(&trampoline_get_NotGenerateLamdaNoFieldProperty), new(&trampoline_set_NotGenerateLamdaNoFieldProperty)));
+            collector.TryAdd(PropertyName.@NotGenerateComplexReturnProperty, (new(&trampoline_get_NotGenerateComplexReturnProperty), new(&trampoline_set_NotGenerateComplexReturnProperty)));
+            collector.TryAdd(PropertyName.@NotGenerateReturnsProperty, (new(&trampoline_get_NotGenerateReturnsProperty), new(&trampoline_set_NotGenerateReturnsProperty)));
+            collector.TryAdd(PropertyName.@FullPropertyString, (new(&trampoline_get_FullPropertyString), new(&trampoline_set_FullPropertyString)));
+            collector.TryAdd(PropertyName.@FullPropertyString_Complex, (new(&trampoline_get_FullPropertyString_Complex), new(&trampoline_set_FullPropertyString_Complex)));
+            collector.TryAdd(PropertyName.@FullPropertyStaticImport, (new(&trampoline_get_FullPropertyStaticImport), new(&trampoline_set_FullPropertyStaticImport)));
+            collector.TryAdd(PropertyName.@LamdaPropertyString, (new(&trampoline_get_LamdaPropertyString), new(&trampoline_set_LamdaPropertyString)));
+            collector.TryAdd(PropertyName.@LambdaPropertyStaticImport, (new(&trampoline_get_LambdaPropertyStaticImport), new(&trampoline_set_LambdaPropertyStaticImport)));
+            collector.TryAdd(PropertyName.@PrimaryCtorParameter, (new(&trampoline_get_PrimaryCtorParameter), new(&trampoline_set_PrimaryCtorParameter)));
+            collector.TryAdd(PropertyName.@ConstantMath, (new(&trampoline_get_ConstantMath), new(&trampoline_set_ConstantMath)));
+            collector.TryAdd(PropertyName.@ConstantMathStaticImport, (new(&trampoline_get_ConstantMathStaticImport), new(&trampoline_set_ConstantMathStaticImport)));
+            collector.TryAdd(PropertyName.@StaticStringAddition, (new(&trampoline_get_StaticStringAddition), new(&trampoline_set_StaticStringAddition)));
+            collector.TryAdd(PropertyName.@PropertyBoolean, (new(&trampoline_get_PropertyBoolean), new(&trampoline_set_PropertyBoolean)));
+            collector.TryAdd(PropertyName.@PropertyChar, (new(&trampoline_get_PropertyChar), new(&trampoline_set_PropertyChar)));
+            collector.TryAdd(PropertyName.@PropertySByte, (new(&trampoline_get_PropertySByte), new(&trampoline_set_PropertySByte)));
+            collector.TryAdd(PropertyName.@PropertyInt16, (new(&trampoline_get_PropertyInt16), new(&trampoline_set_PropertyInt16)));
+            collector.TryAdd(PropertyName.@PropertyInt32, (new(&trampoline_get_PropertyInt32), new(&trampoline_set_PropertyInt32)));
+            collector.TryAdd(PropertyName.@PropertyInt64, (new(&trampoline_get_PropertyInt64), new(&trampoline_set_PropertyInt64)));
+            collector.TryAdd(PropertyName.@PropertyByte, (new(&trampoline_get_PropertyByte), new(&trampoline_set_PropertyByte)));
+            collector.TryAdd(PropertyName.@PropertyUInt16, (new(&trampoline_get_PropertyUInt16), new(&trampoline_set_PropertyUInt16)));
+            collector.TryAdd(PropertyName.@PropertyUInt32, (new(&trampoline_get_PropertyUInt32), new(&trampoline_set_PropertyUInt32)));
+            collector.TryAdd(PropertyName.@PropertyUInt64, (new(&trampoline_get_PropertyUInt64), new(&trampoline_set_PropertyUInt64)));
+            collector.TryAdd(PropertyName.@PropertySingle, (new(&trampoline_get_PropertySingle), new(&trampoline_set_PropertySingle)));
+            collector.TryAdd(PropertyName.@PropertyDouble, (new(&trampoline_get_PropertyDouble), new(&trampoline_set_PropertyDouble)));
+            collector.TryAdd(PropertyName.@PropertyString, (new(&trampoline_get_PropertyString), new(&trampoline_set_PropertyString)));
+            collector.TryAdd(PropertyName.@PropertyVector2, (new(&trampoline_get_PropertyVector2), new(&trampoline_set_PropertyVector2)));
+            collector.TryAdd(PropertyName.@PropertyVector2I, (new(&trampoline_get_PropertyVector2I), new(&trampoline_set_PropertyVector2I)));
+            collector.TryAdd(PropertyName.@PropertyRect2, (new(&trampoline_get_PropertyRect2), new(&trampoline_set_PropertyRect2)));
+            collector.TryAdd(PropertyName.@PropertyRect2I, (new(&trampoline_get_PropertyRect2I), new(&trampoline_set_PropertyRect2I)));
+            collector.TryAdd(PropertyName.@PropertyTransform2D, (new(&trampoline_get_PropertyTransform2D), new(&trampoline_set_PropertyTransform2D)));
+            collector.TryAdd(PropertyName.@PropertyVector3, (new(&trampoline_get_PropertyVector3), new(&trampoline_set_PropertyVector3)));
+            collector.TryAdd(PropertyName.@PropertyVector3I, (new(&trampoline_get_PropertyVector3I), new(&trampoline_set_PropertyVector3I)));
+            collector.TryAdd(PropertyName.@PropertyBasis, (new(&trampoline_get_PropertyBasis), new(&trampoline_set_PropertyBasis)));
+            collector.TryAdd(PropertyName.@PropertyQuaternion, (new(&trampoline_get_PropertyQuaternion), new(&trampoline_set_PropertyQuaternion)));
+            collector.TryAdd(PropertyName.@PropertyTransform3D, (new(&trampoline_get_PropertyTransform3D), new(&trampoline_set_PropertyTransform3D)));
+            collector.TryAdd(PropertyName.@PropertyVector4, (new(&trampoline_get_PropertyVector4), new(&trampoline_set_PropertyVector4)));
+            collector.TryAdd(PropertyName.@PropertyVector4I, (new(&trampoline_get_PropertyVector4I), new(&trampoline_set_PropertyVector4I)));
+            collector.TryAdd(PropertyName.@PropertyProjection, (new(&trampoline_get_PropertyProjection), new(&trampoline_set_PropertyProjection)));
+            collector.TryAdd(PropertyName.@PropertyAabb, (new(&trampoline_get_PropertyAabb), new(&trampoline_set_PropertyAabb)));
+            collector.TryAdd(PropertyName.@PropertyColor, (new(&trampoline_get_PropertyColor), new(&trampoline_set_PropertyColor)));
+            collector.TryAdd(PropertyName.@PropertyPlane, (new(&trampoline_get_PropertyPlane), new(&trampoline_set_PropertyPlane)));
+            collector.TryAdd(PropertyName.@PropertyCallable, (new(&trampoline_get_PropertyCallable), new(&trampoline_set_PropertyCallable)));
+            collector.TryAdd(PropertyName.@PropertySignal, (new(&trampoline_get_PropertySignal), new(&trampoline_set_PropertySignal)));
+            collector.TryAdd(PropertyName.@PropertyEnum, (new(&trampoline_get_PropertyEnum), new(&trampoline_set_PropertyEnum)));
+            collector.TryAdd(PropertyName.@PropertyFlagsEnum, (new(&trampoline_get_PropertyFlagsEnum), new(&trampoline_set_PropertyFlagsEnum)));
+            collector.TryAdd(PropertyName.@PropertyByteArray, (new(&trampoline_get_PropertyByteArray), new(&trampoline_set_PropertyByteArray)));
+            collector.TryAdd(PropertyName.@PropertyInt32Array, (new(&trampoline_get_PropertyInt32Array), new(&trampoline_set_PropertyInt32Array)));
+            collector.TryAdd(PropertyName.@PropertyInt64Array, (new(&trampoline_get_PropertyInt64Array), new(&trampoline_set_PropertyInt64Array)));
+            collector.TryAdd(PropertyName.@PropertySingleArray, (new(&trampoline_get_PropertySingleArray), new(&trampoline_set_PropertySingleArray)));
+            collector.TryAdd(PropertyName.@PropertyDoubleArray, (new(&trampoline_get_PropertyDoubleArray), new(&trampoline_set_PropertyDoubleArray)));
+            collector.TryAdd(PropertyName.@PropertyStringArray, (new(&trampoline_get_PropertyStringArray), new(&trampoline_set_PropertyStringArray)));
+            collector.TryAdd(PropertyName.@PropertyStringArrayEnum, (new(&trampoline_get_PropertyStringArrayEnum), new(&trampoline_set_PropertyStringArrayEnum)));
+            collector.TryAdd(PropertyName.@PropertyVector2Array, (new(&trampoline_get_PropertyVector2Array), new(&trampoline_set_PropertyVector2Array)));
+            collector.TryAdd(PropertyName.@PropertyVector3Array, (new(&trampoline_get_PropertyVector3Array), new(&trampoline_set_PropertyVector3Array)));
+            collector.TryAdd(PropertyName.@PropertyColorArray, (new(&trampoline_get_PropertyColorArray), new(&trampoline_set_PropertyColorArray)));
+            collector.TryAdd(PropertyName.@PropertyGodotObjectOrDerivedArray, (new(&trampoline_get_PropertyGodotObjectOrDerivedArray), new(&trampoline_set_PropertyGodotObjectOrDerivedArray)));
+            collector.TryAdd(PropertyName.@field_StringNameArray, (new(&trampoline_get_field_StringNameArray), new(&trampoline_set_field_StringNameArray)));
+            collector.TryAdd(PropertyName.@field_NodePathArray, (new(&trampoline_get_field_NodePathArray), new(&trampoline_set_field_NodePathArray)));
+            collector.TryAdd(PropertyName.@field_RidArray, (new(&trampoline_get_field_RidArray), new(&trampoline_set_field_RidArray)));
+            collector.TryAdd(PropertyName.@PropertyVariant, (new(&trampoline_get_PropertyVariant), new(&trampoline_set_PropertyVariant)));
+            collector.TryAdd(PropertyName.@PropertyGodotObjectOrDerived, (new(&trampoline_get_PropertyGodotObjectOrDerived), new(&trampoline_set_PropertyGodotObjectOrDerived)));
+            collector.TryAdd(PropertyName.@PropertyGodotResourceTexture, (new(&trampoline_get_PropertyGodotResourceTexture), new(&trampoline_set_PropertyGodotResourceTexture)));
+            collector.TryAdd(PropertyName.@PropertyGodotResourceTextureWithInitializer, (new(&trampoline_get_PropertyGodotResourceTextureWithInitializer), new(&trampoline_set_PropertyGodotResourceTextureWithInitializer)));
+            collector.TryAdd(PropertyName.@PropertyStringName, (new(&trampoline_get_PropertyStringName), new(&trampoline_set_PropertyStringName)));
+            collector.TryAdd(PropertyName.@PropertyNodePath, (new(&trampoline_get_PropertyNodePath), new(&trampoline_set_PropertyNodePath)));
+            collector.TryAdd(PropertyName.@PropertyRid, (new(&trampoline_get_PropertyRid), new(&trampoline_set_PropertyRid)));
+            collector.TryAdd(PropertyName.@PropertyGodotDictionary, (new(&trampoline_get_PropertyGodotDictionary), new(&trampoline_set_PropertyGodotDictionary)));
+            collector.TryAdd(PropertyName.@PropertyGodotArray, (new(&trampoline_get_PropertyGodotArray), new(&trampoline_set_PropertyGodotArray)));
+            collector.TryAdd(PropertyName.@PropertyGodotGenericDictionary, (new(&trampoline_get_PropertyGodotGenericDictionary), new(&trampoline_set_PropertyGodotGenericDictionary)));
+            collector.TryAdd(PropertyName.@PropertyGodotGenericArray, (new(&trampoline_get_PropertyGodotGenericArray), new(&trampoline_set_PropertyGodotGenericArray)));
+            collector.TryAdd(PropertyName.@NotIgnoredProperty, (new(&trampoline_get_NotIgnoredProperty), new(&trampoline_set_NotIgnoredProperty)));
+            collector.TryAdd(PropertyName.@_notGeneratePropertyString, (new(&trampoline_get__notGeneratePropertyString), new(&trampoline_set__notGeneratePropertyString)));
+            collector.TryAdd(PropertyName.@_notGeneratePropertyInt, (new(&trampoline_get__notGeneratePropertyInt), new(&trampoline_set__notGeneratePropertyInt)));
+            collector.TryAdd(PropertyName.@_fullPropertyString, (new(&trampoline_get__fullPropertyString), new(&trampoline_set__fullPropertyString)));
+            collector.TryAdd(PropertyName.@_fullPropertyStringComplex, (new(&trampoline_get__fullPropertyStringComplex), new(&trampoline_set__fullPropertyStringComplex)));
+            collector.TryAdd(PropertyName.@_fullPropertyStaticImport, (new(&trampoline_get__fullPropertyStaticImport), new(&trampoline_set__fullPropertyStaticImport)));
+            collector.TryAdd(PropertyName.@_lamdaPropertyString, (new(&trampoline_get__lamdaPropertyString), new(&trampoline_set__lamdaPropertyString)));
+            collector.TryAdd(PropertyName.@_lambdaPropertyStaticImport, (new(&trampoline_get__lambdaPropertyStaticImport), new(&trampoline_set__lambdaPropertyStaticImport)));
         }
-        if (name == PropertyName.@NotGenerateLamdaNoFieldProperty) {
-            this.@NotGenerateLamdaNoFieldProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@NotGenerateComplexReturnProperty) {
-            this.@NotGenerateComplexReturnProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@NotGenerateReturnsProperty) {
-            this.@NotGenerateReturnsProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@FullPropertyString) {
-            this.@FullPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@FullPropertyString_Complex) {
-            this.@FullPropertyString_Complex = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@FullPropertyStaticImport) {
-            this.@FullPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@LamdaPropertyString) {
-            this.@LamdaPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@LambdaPropertyStaticImport) {
-            this.@LambdaPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@PrimaryCtorParameter) {
-            this.@PrimaryCtorParameter = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@ConstantMath) {
-            this.@ConstantMath = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@ConstantMathStaticImport) {
-            this.@ConstantMathStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@StaticStringAddition) {
-            this.@StaticStringAddition = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyBoolean) {
-            this.@PropertyBoolean = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyChar) {
-            this.@PropertyChar = global::Godot.NativeInterop.VariantUtils.ConvertTo<char>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertySByte) {
-            this.@PropertySByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<sbyte>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt16) {
-            this.@PropertyInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<short>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt32) {
-            this.@PropertyInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt64) {
-            this.@PropertyInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<long>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyByte) {
-            this.@PropertyByte = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyUInt16) {
-            this.@PropertyUInt16 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ushort>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyUInt32) {
-            this.@PropertyUInt32 = global::Godot.NativeInterop.VariantUtils.ConvertTo<uint>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyUInt64) {
-            this.@PropertyUInt64 = global::Godot.NativeInterop.VariantUtils.ConvertTo<ulong>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertySingle) {
-            this.@PropertySingle = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyDouble) {
-            this.@PropertyDouble = global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyString) {
-            this.@PropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector2) {
-            this.@PropertyVector2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector2I) {
-            this.@PropertyVector2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2I>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyRect2) {
-            this.@PropertyRect2 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyRect2I) {
-            this.@PropertyRect2I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rect2I>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyTransform2D) {
-            this.@PropertyTransform2D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform2D>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector3) {
-            this.@PropertyVector3 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector3I) {
-            this.@PropertyVector3I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3I>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyBasis) {
-            this.@PropertyBasis = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Basis>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyQuaternion) {
-            this.@PropertyQuaternion = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Quaternion>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyTransform3D) {
-            this.@PropertyTransform3D = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Transform3D>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector4) {
-            this.@PropertyVector4 = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector4I) {
-            this.@PropertyVector4I = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector4I>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyProjection) {
-            this.@PropertyProjection = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Projection>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyAabb) {
-            this.@PropertyAabb = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Aabb>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyColor) {
-            this.@PropertyColor = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyPlane) {
-            this.@PropertyPlane = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Plane>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyCallable) {
-            this.@PropertyCallable = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Callable>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertySignal) {
-            this.@PropertySignal = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Signal>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyEnum) {
-            this.@PropertyEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedProperties.MyEnum>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyFlagsEnum) {
-            this.@PropertyFlagsEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::ExportedProperties.MyFlagsEnum>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyByteArray) {
-            this.@PropertyByteArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<byte[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt32Array) {
-            this.@PropertyInt32Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<int[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt64Array) {
-            this.@PropertyInt64Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<long[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertySingleArray) {
-            this.@PropertySingleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<float[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyDoubleArray) {
-            this.@PropertyDoubleArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<double[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyStringArray) {
-            this.@PropertyStringArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyStringArrayEnum) {
-            this.@PropertyStringArrayEnum = global::Godot.NativeInterop.VariantUtils.ConvertTo<string[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector2Array) {
-            this.@PropertyVector2Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector2[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector3Array) {
-            this.@PropertyVector3Array = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Vector3[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyColorArray) {
-            this.@PropertyColorArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Color[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotObjectOrDerivedArray) {
-            this.@PropertyGodotObjectOrDerivedArray = global::Godot.NativeInterop.VariantUtils.ConvertToSystemArrayOfGodotObject<global::Godot.GodotObject>(value);
-            return true;
-        }
-        if (name == PropertyName.@field_StringNameArray) {
-            this.@field_StringNameArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@field_NodePathArray) {
-            this.@field_NodePathArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@field_RidArray) {
-            this.@field_RidArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid[]>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVariant) {
-            this.@PropertyVariant = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Variant>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotObjectOrDerived) {
-            this.@PropertyGodotObjectOrDerived = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.GodotObject>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotResourceTexture) {
-            this.@PropertyGodotResourceTexture = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotResourceTextureWithInitializer) {
-            this.@PropertyGodotResourceTextureWithInitializer = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Texture>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyStringName) {
-            this.@PropertyStringName = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyNodePath) {
-            this.@PropertyNodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyRid) {
-            this.@PropertyRid = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Rid>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotDictionary) {
-            this.@PropertyGodotDictionary = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Dictionary>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotArray) {
-            this.@PropertyGodotArray = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Collections.Array>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotGenericDictionary) {
-            this.@PropertyGodotGenericDictionary = global::Godot.NativeInterop.VariantUtils.ConvertToDictionary<string, bool>(value);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotGenericArray) {
-            this.@PropertyGodotGenericArray = global::Godot.NativeInterop.VariantUtils.ConvertToArray<int>(value);
-            return true;
-        }
-        if (name == PropertyName.@NotIgnoredProperty) {
-            this.@NotIgnoredProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
-            return true;
-        }
-        if (name == PropertyName.@_notGeneratePropertyString) {
-            this.@_notGeneratePropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@_notGeneratePropertyInt) {
-            this.@_notGeneratePropertyInt = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fullPropertyString) {
-            this.@_fullPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fullPropertyStringComplex) {
-            this.@_fullPropertyStringComplex = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@_fullPropertyStaticImport) {
-            this.@_fullPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        if (name == PropertyName.@_lamdaPropertyString) {
-            this.@_lamdaPropertyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
-        }
-        if (name == PropertyName.@_lambdaPropertyStaticImport) {
-            this.@_lambdaPropertyStaticImport = global::Godot.NativeInterop.VariantUtils.ConvertTo<float>(value);
-            return true;
-        }
-        return base.SetGodotClassPropertyValue(name, value);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
-    {
-        if (name == PropertyName.@NotGenerateComplexLamdaProperty) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@NotGenerateComplexLamdaProperty);
-            return true;
-        }
-        if (name == PropertyName.@NotGenerateLamdaNoFieldProperty) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@NotGenerateLamdaNoFieldProperty);
-            return true;
-        }
-        if (name == PropertyName.@NotGenerateComplexReturnProperty) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@NotGenerateComplexReturnProperty);
-            return true;
-        }
-        if (name == PropertyName.@NotGenerateReturnsProperty) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@NotGenerateReturnsProperty);
-            return true;
-        }
-        if (name == PropertyName.@FullPropertyString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@FullPropertyString);
-            return true;
-        }
-        if (name == PropertyName.@FullPropertyString_Complex) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@FullPropertyString_Complex);
-            return true;
-        }
-        if (name == PropertyName.@FullPropertyStaticImport) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@FullPropertyStaticImport);
-            return true;
-        }
-        if (name == PropertyName.@LamdaPropertyString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@LamdaPropertyString);
-            return true;
-        }
-        if (name == PropertyName.@LambdaPropertyStaticImport) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@LambdaPropertyStaticImport);
-            return true;
-        }
-        if (name == PropertyName.@PrimaryCtorParameter) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@PrimaryCtorParameter);
-            return true;
-        }
-        if (name == PropertyName.@ConstantMath) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@ConstantMath);
-            return true;
-        }
-        if (name == PropertyName.@ConstantMathStaticImport) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@ConstantMathStaticImport);
-            return true;
-        }
-        if (name == PropertyName.@StaticStringAddition) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@StaticStringAddition);
-            return true;
-        }
-        if (name == PropertyName.@PropertyBoolean) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.@PropertyBoolean);
-            return true;
-        }
-        if (name == PropertyName.@PropertyChar) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<char>(this.@PropertyChar);
-            return true;
-        }
-        if (name == PropertyName.@PropertySByte) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<sbyte>(this.@PropertySByte);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt16) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<short>(this.@PropertyInt16);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt32) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this.@PropertyInt32);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt64) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long>(this.@PropertyInt64);
-            return true;
-        }
-        if (name == PropertyName.@PropertyByte) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte>(this.@PropertyByte);
-            return true;
-        }
-        if (name == PropertyName.@PropertyUInt16) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ushort>(this.@PropertyUInt16);
-            return true;
-        }
-        if (name == PropertyName.@PropertyUInt32) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<uint>(this.@PropertyUInt32);
-            return true;
-        }
-        if (name == PropertyName.@PropertyUInt64) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<ulong>(this.@PropertyUInt64);
-            return true;
-        }
-        if (name == PropertyName.@PropertySingle) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@PropertySingle);
-            return true;
-        }
-        if (name == PropertyName.@PropertyDouble) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double>(this.@PropertyDouble);
-            return true;
-        }
-        if (name == PropertyName.@PropertyString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@PropertyString);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector2) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2>(this.@PropertyVector2);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector2I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2I>(this.@PropertyVector2I);
-            return true;
-        }
-        if (name == PropertyName.@PropertyRect2) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2>(this.@PropertyRect2);
-            return true;
-        }
-        if (name == PropertyName.@PropertyRect2I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rect2I>(this.@PropertyRect2I);
-            return true;
-        }
-        if (name == PropertyName.@PropertyTransform2D) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform2D>(this.@PropertyTransform2D);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector3) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3>(this.@PropertyVector3);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector3I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3I>(this.@PropertyVector3I);
-            return true;
-        }
-        if (name == PropertyName.@PropertyBasis) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Basis>(this.@PropertyBasis);
-            return true;
-        }
-        if (name == PropertyName.@PropertyQuaternion) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Quaternion>(this.@PropertyQuaternion);
-            return true;
-        }
-        if (name == PropertyName.@PropertyTransform3D) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Transform3D>(this.@PropertyTransform3D);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector4) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4>(this.@PropertyVector4);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector4I) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector4I>(this.@PropertyVector4I);
-            return true;
-        }
-        if (name == PropertyName.@PropertyProjection) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Projection>(this.@PropertyProjection);
-            return true;
-        }
-        if (name == PropertyName.@PropertyAabb) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Aabb>(this.@PropertyAabb);
-            return true;
-        }
-        if (name == PropertyName.@PropertyColor) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color>(this.@PropertyColor);
-            return true;
-        }
-        if (name == PropertyName.@PropertyPlane) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Plane>(this.@PropertyPlane);
-            return true;
-        }
-        if (name == PropertyName.@PropertyCallable) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@PropertyCallable);
-            return true;
-        }
-        if (name == PropertyName.@PropertySignal) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Signal>(this.@PropertySignal);
-            return true;
-        }
-        if (name == PropertyName.@PropertyEnum) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedProperties.MyEnum>(this.@PropertyEnum);
-            return true;
-        }
-        if (name == PropertyName.@PropertyFlagsEnum) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::ExportedProperties.MyFlagsEnum>(this.@PropertyFlagsEnum);
-            return true;
-        }
-        if (name == PropertyName.@PropertyByteArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<byte[]>(this.@PropertyByteArray);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt32Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int[]>(this.@PropertyInt32Array);
-            return true;
-        }
-        if (name == PropertyName.@PropertyInt64Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<long[]>(this.@PropertyInt64Array);
-            return true;
-        }
-        if (name == PropertyName.@PropertySingleArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float[]>(this.@PropertySingleArray);
-            return true;
-        }
-        if (name == PropertyName.@PropertyDoubleArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<double[]>(this.@PropertyDoubleArray);
-            return true;
-        }
-        if (name == PropertyName.@PropertyStringArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this.@PropertyStringArray);
-            return true;
-        }
-        if (name == PropertyName.@PropertyStringArrayEnum) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string[]>(this.@PropertyStringArrayEnum);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector2Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector2[]>(this.@PropertyVector2Array);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVector3Array) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Vector3[]>(this.@PropertyVector3Array);
-            return true;
-        }
-        if (name == PropertyName.@PropertyColorArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Color[]>(this.@PropertyColorArray);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotObjectOrDerivedArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFromSystemArrayOfGodotObject(this.@PropertyGodotObjectOrDerivedArray);
-            return true;
-        }
-        if (name == PropertyName.@field_StringNameArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName[]>(this.@field_StringNameArray);
-            return true;
-        }
-        if (name == PropertyName.@field_NodePathArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath[]>(this.@field_NodePathArray);
-            return true;
-        }
-        if (name == PropertyName.@field_RidArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid[]>(this.@field_RidArray);
-            return true;
-        }
-        if (name == PropertyName.@PropertyVariant) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Variant>(this.@PropertyVariant);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotObjectOrDerived) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.GodotObject>(this.@PropertyGodotObjectOrDerived);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotResourceTexture) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this.@PropertyGodotResourceTexture);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotResourceTextureWithInitializer) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Texture>(this.@PropertyGodotResourceTextureWithInitializer);
-            return true;
-        }
-        if (name == PropertyName.@PropertyStringName) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.StringName>(this.@PropertyStringName);
-            return true;
-        }
-        if (name == PropertyName.@PropertyNodePath) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(this.@PropertyNodePath);
-            return true;
-        }
-        if (name == PropertyName.@PropertyRid) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Rid>(this.@PropertyRid);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotDictionary) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Dictionary>(this.@PropertyGodotDictionary);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Collections.Array>(this.@PropertyGodotArray);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotGenericDictionary) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFromDictionary(this.@PropertyGodotGenericDictionary);
-            return true;
-        }
-        if (name == PropertyName.@PropertyGodotGenericArray) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFromArray(this.@PropertyGodotGenericArray);
-            return true;
-        }
-        if (name == PropertyName.@NotIgnoredProperty) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this.@NotIgnoredProperty);
-            return true;
-        }
-        if (name == PropertyName.@_notGeneratePropertyString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@_notGeneratePropertyString);
-            return true;
-        }
-        if (name == PropertyName.@_notGeneratePropertyInt) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this.@_notGeneratePropertyInt);
-            return true;
-        }
-        if (name == PropertyName.@_fullPropertyString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@_fullPropertyString);
-            return true;
-        }
-        if (name == PropertyName.@_fullPropertyStringComplex) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@_fullPropertyStringComplex);
-            return true;
-        }
-        if (name == PropertyName.@_fullPropertyStaticImport) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@_fullPropertyStaticImport);
-            return true;
-        }
-        if (name == PropertyName.@_lamdaPropertyString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@_lamdaPropertyString);
-            return true;
-        }
-        if (name == PropertyName.@_lambdaPropertyStaticImport) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<float>(this.@_lambdaPropertyStaticImport);
-            return true;
-        }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedToolButtons_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportedToolButtons_ScriptProperties.generated.cs
@@ -17,19 +17,23 @@ partial class ExportedToolButtons
         /// </summary>
         public new static readonly global::Godot.StringName @MyButton2 = "MyButton2";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@MyButton1) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@MyButton1);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static godot_variant trampoline_get_MyButton1(object godotObject)
+            {
+                var ret = ((global::ExportedToolButtons)godotObject).@MyButton1;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            static godot_variant trampoline_get_MyButton2(object godotObject)
+            {
+                var ret = ((global::ExportedToolButtons)godotObject).@MyButton2;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(ret);
+            }
+            collector.TryAdd(PropertyName.@MyButton1, (new(&trampoline_get_MyButton1), new(null)));
+            collector.TryAdd(PropertyName.@MyButton2, (new(&trampoline_get_MyButton2), new(null)));
         }
-        if (name == PropertyName.@MyButton2) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Callable>(this.@MyButton2);
-            return true;
-        }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/GenericClass(Of T).NestedClass_ScriptMethods.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/GenericClass(Of T).NestedClass_ScriptMethods.generated.cs
@@ -11,6 +11,12 @@ partial class NestedClass
     /// </summary>
     public new class MethodName : global::Godot.GodotObject.MethodName {
     }
+    protected internal new static partial class GodotInternal
+    {
+        public new static unsafe void GetGodotMethodTrampolines(global::Godot.Bridge.MethodTrampolineCollector collector)
+        {
+        }
+    }
 #pragma warning restore CS0109
 }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/InheritanceBase_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/InheritanceBase_ScriptProperties.generated.cs
@@ -17,33 +17,31 @@ partial class InheritanceBase
         /// </summary>
         public new static readonly global::Godot.StringName @MyInteger = "MyInteger";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@MyString) {
-            this.@MyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static godot_variant trampoline_get_MyString(object godotObject)
+            {
+                var ret = ((global::InheritanceBase)godotObject).@MyString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_MyString(object godotObject, in godot_variant value)
+            {
+                ((global::InheritanceBase)godotObject).@MyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_MyInteger(object godotObject)
+            {
+                var ret = ((global::InheritanceBase)godotObject).@MyInteger;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(ret);
+            }
+            static void trampoline_set_MyInteger(object godotObject, in godot_variant value)
+            {
+                ((global::InheritanceBase)godotObject).@MyInteger = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
+            }
+            collector.TryAdd(PropertyName.@MyString, (new(&trampoline_get_MyString), new(&trampoline_set_MyString)));
+            collector.TryAdd(PropertyName.@MyInteger, (new(&trampoline_get_MyInteger), new(&trampoline_set_MyInteger)));
         }
-        if (name == PropertyName.@MyInteger) {
-            this.@MyInteger = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
-            return true;
-        }
-        return base.SetGodotClassPropertyValue(name, value);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
-    {
-        if (name == PropertyName.@MyString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@MyString);
-            return true;
-        }
-        if (name == PropertyName.@MyInteger) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this.@MyInteger);
-            return true;
-        }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/InheritanceChild_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/InheritanceChild_ScriptProperties.generated.cs
@@ -17,33 +17,31 @@ partial class InheritanceChild
         /// </summary>
         public new static readonly global::Godot.StringName @MyInteger = "MyInteger";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@MyString) {
-            this.@MyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static godot_variant trampoline_get_MyString(object godotObject)
+            {
+                var ret = ((global::InheritanceChild)godotObject).@MyString;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_MyString(object godotObject, in godot_variant value)
+            {
+                ((global::InheritanceChild)godotObject).@MyString = global::Godot.NativeInterop.VariantUtils.ConvertTo<string>(value);
+            }
+            static godot_variant trampoline_get_MyInteger(object godotObject)
+            {
+                var ret = ((global::InheritanceChild)godotObject).@MyInteger;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(ret);
+            }
+            static void trampoline_set_MyInteger(object godotObject, in godot_variant value)
+            {
+                ((global::InheritanceChild)godotObject).@MyInteger = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
+            }
+            collector.TryAdd(PropertyName.@MyString, (new(&trampoline_get_MyString), new(&trampoline_set_MyString)));
+            collector.TryAdd(PropertyName.@MyInteger, (new(&trampoline_get_MyInteger), new(&trampoline_set_MyInteger)));
         }
-        if (name == PropertyName.@MyInteger) {
-            this.@MyInteger = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
-            return true;
-        }
-        return base.SetGodotClassPropertyValue(name, value);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
-    {
-        if (name == PropertyName.@MyString) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@MyString);
-            return true;
-        }
-        if (name == PropertyName.@MyInteger) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this.@MyInteger);
-            return true;
-        }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/Methods_ScriptMethods.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/Methods_ScriptMethods.generated.cs
@@ -27,35 +27,41 @@ partial class Methods
         methods.Add(new(name: MethodName.@MethodWithOverload, returnVal: new(type: (global::Godot.Variant.Type)0, name: "", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), flags: (global::Godot.MethodFlags)1, arguments: new() { new(type: (global::Godot.Variant.Type)2, name: "a", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), new(type: (global::Godot.Variant.Type)2, name: "b", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false),  }, defaultArguments: null));
         return methods;
     }
+    protected internal new static partial class GodotInternal
+    {
+        public new static unsafe void GetGodotMethodTrampolines(global::Godot.Bridge.MethodTrampolineCollector collector)
+        {
+            static godot_variant trampoline_0_MethodWithOverload(object godotObject, NativeVariantPtrArgs args, ref godot_variant_call_error callError)
+            {
+                if (args.Count != 0) {
+                    callError = godot_variant_call_error.CreateInvalidArgumentCountError(expected: 0, provided: args.Count);
+                    return default;
+                }
+                ((global::Methods)godotObject).@MethodWithOverload();
+                return default;
+            }
+            collector.TryAdd(new(MethodName.@MethodWithOverload, 0), new(&trampoline_0_MethodWithOverload, isStatic: false));
+            static godot_variant trampoline_1_MethodWithOverload(object godotObject, NativeVariantPtrArgs args, ref godot_variant_call_error callError)
+            {
+                if (args.Count != 1) {
+                    callError = godot_variant_call_error.CreateInvalidArgumentCountError(expected: 1, provided: args.Count);
+                    return default;
+                }
+                ((global::Methods)godotObject).@MethodWithOverload(global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[0]));
+                return default;
+            }
+            collector.TryAdd(new(MethodName.@MethodWithOverload, 1), new(&trampoline_1_MethodWithOverload, isStatic: false));
+            static godot_variant trampoline_2_MethodWithOverload(object godotObject, NativeVariantPtrArgs args, ref godot_variant_call_error callError)
+            {
+                if (args.Count != 2) {
+                    callError = godot_variant_call_error.CreateInvalidArgumentCountError(expected: 2, provided: args.Count);
+                    return default;
+                }
+                ((global::Methods)godotObject).@MethodWithOverload(global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[0]), global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[1]));
+                return default;
+            }
+            collector.TryAdd(new(MethodName.@MethodWithOverload, 2), new(&trampoline_2_MethodWithOverload, isStatic: false));
+        }
+    }
 #pragma warning restore CS0109
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool InvokeGodotClassMethod(in godot_string_name method, NativeVariantPtrArgs args, out godot_variant ret)
-    {
-        if (method == MethodName.@MethodWithOverload && args.Count == 0) {
-            @MethodWithOverload();
-            ret = default;
-            return true;
-        }
-        if (method == MethodName.@MethodWithOverload && args.Count == 1) {
-            @MethodWithOverload(global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[0]));
-            ret = default;
-            return true;
-        }
-        if (method == MethodName.@MethodWithOverload && args.Count == 2) {
-            @MethodWithOverload(global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[0]), global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(args[1]));
-            ret = default;
-            return true;
-        }
-        return base.InvokeGodotClassMethod(method, args, out ret);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool HasGodotClassMethod(in godot_string_name method)
-    {
-        if (method == MethodName.@MethodWithOverload) {
-           return true;
-        }
-        return base.HasGodotClassMethod(method);
-    }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/MixedReadOnlyWriteOnly_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/MixedReadOnlyWriteOnly_ScriptProperties.generated.cs
@@ -33,45 +33,50 @@ partial class MixedReadOnlyWriteOnly
         /// </summary>
         public new static readonly global::Godot.StringName @_writeOnlyBackingField = "_writeOnlyBackingField";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@WriteOnlyProperty) {
-            this.@WriteOnlyProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static godot_variant trampoline_get_ReadOnlyAutoProperty(object godotObject)
+            {
+                var ret = ((global::MixedReadOnlyWriteOnly)godotObject).@ReadOnlyAutoProperty;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static godot_variant trampoline_get_ReadOnlyProperty(object godotObject)
+            {
+                var ret = ((global::MixedReadOnlyWriteOnly)godotObject).@ReadOnlyProperty;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static godot_variant trampoline_get_InitOnlyAutoProperty(object godotObject)
+            {
+                var ret = ((global::MixedReadOnlyWriteOnly)godotObject).@InitOnlyAutoProperty;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static void trampoline_set_WriteOnlyProperty(object godotObject, in godot_variant value)
+            {
+                ((global::MixedReadOnlyWriteOnly)godotObject).@WriteOnlyProperty = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            }
+            static godot_variant trampoline_get_ReadOnlyField(object godotObject)
+            {
+                var ret = ((global::MixedReadOnlyWriteOnly)godotObject).@ReadOnlyField;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(ret);
+            }
+            static godot_variant trampoline_get__writeOnlyBackingField(object godotObject)
+            {
+                var ret = ((global::MixedReadOnlyWriteOnly)godotObject).@_writeOnlyBackingField;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(ret);
+            }
+            static void trampoline_set__writeOnlyBackingField(object godotObject, in godot_variant value)
+            {
+                ((global::MixedReadOnlyWriteOnly)godotObject).@_writeOnlyBackingField = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            }
+            collector.TryAdd(PropertyName.@ReadOnlyAutoProperty, (new(&trampoline_get_ReadOnlyAutoProperty), new(null)));
+            collector.TryAdd(PropertyName.@ReadOnlyProperty, (new(&trampoline_get_ReadOnlyProperty), new(null)));
+            collector.TryAdd(PropertyName.@InitOnlyAutoProperty, (new(&trampoline_get_InitOnlyAutoProperty), new(null)));
+            collector.TryAdd(PropertyName.@WriteOnlyProperty, (new(null), new(&trampoline_set_WriteOnlyProperty)));
+            collector.TryAdd(PropertyName.@ReadOnlyField, (new(&trampoline_get_ReadOnlyField), new(null)));
+            collector.TryAdd(PropertyName.@_writeOnlyBackingField, (new(&trampoline_get__writeOnlyBackingField), new(&trampoline_set__writeOnlyBackingField)));
         }
-        if (name == PropertyName.@_writeOnlyBackingField) {
-            this.@_writeOnlyBackingField = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
-            return true;
-        }
-        return base.SetGodotClassPropertyValue(name, value);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
-    {
-        if (name == PropertyName.@ReadOnlyAutoProperty) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@ReadOnlyAutoProperty);
-            return true;
-        }
-        if (name == PropertyName.@ReadOnlyProperty) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@ReadOnlyProperty);
-            return true;
-        }
-        if (name == PropertyName.@InitOnlyAutoProperty) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@InitOnlyAutoProperty);
-            return true;
-        }
-        if (name == PropertyName.@ReadOnlyField) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<string>(this.@ReadOnlyField);
-            return true;
-        }
-        if (name == PropertyName.@_writeOnlyBackingField) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.@_writeOnlyBackingField);
-            return true;
-        }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/OuterClass.NestedClass_ScriptMethods.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/OuterClass.NestedClass_ScriptMethods.generated.cs
@@ -27,26 +27,23 @@ partial class NestedClass
         methods.Add(new(name: MethodName.@_Get, returnVal: new(type: (global::Godot.Variant.Type)0, name: "", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)131078, exported: false), flags: (global::Godot.MethodFlags)1, arguments: new() { new(type: (global::Godot.Variant.Type)21, name: "property", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false),  }, defaultArguments: null));
         return methods;
     }
+    protected internal new static partial class GodotInternal
+    {
+        public new static unsafe void GetGodotMethodTrampolines(global::Godot.Bridge.MethodTrampolineCollector collector)
+        {
+            static godot_variant trampoline_1__Get(object godotObject, NativeVariantPtrArgs args, ref godot_variant_call_error callError)
+            {
+                if (args.Count != 1) {
+                    callError = godot_variant_call_error.CreateInvalidArgumentCountError(expected: 1, provided: args.Count);
+                    return default;
+                }
+                var callRet = ((global::Godot.GodotObject)godotObject).@_Get(global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(args[0]));
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Variant>(callRet);
+            }
+            collector.TryAdd(new(MethodName.@_Get, 1), new(&trampoline_1__Get, isStatic: false));
+            collector.TryAdd(new(global::Godot.GodotObject.MethodName.@_Get, 1), new(&trampoline_1__Get, isStatic: false));
+        }
+    }
 #pragma warning restore CS0109
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool InvokeGodotClassMethod(in godot_string_name method, NativeVariantPtrArgs args, out godot_variant ret)
-    {
-        if (method == MethodName.@_Get && args.Count == 1) {
-            var callRet = @_Get(global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(args[0]));
-            ret = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.Variant>(callRet);
-            return true;
-        }
-        return base.InvokeGodotClassMethod(method, args, out ret);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool HasGodotClassMethod(in godot_string_name method)
-    {
-        if (method == MethodName.@_Get) {
-           return true;
-        }
-        return base.HasGodotClassMethod(method);
-    }
 }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/OuterClass.NestedClass_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/OuterClass.NestedClass_ScriptProperties.generated.cs
@@ -11,5 +11,12 @@ partial class NestedClass
     /// </summary>
     public new class PropertyName : global::Godot.RefCounted.PropertyName {
     }
+    protected internal new static partial class GodotInternal
+    {
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+        }
+    }
+#pragma warning restore CS0109
 }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptMethods.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptMethods.generated.cs
@@ -30,33 +30,32 @@ partial class ScriptBoilerplate
         methods.Add(new(name: MethodName.@Bazz, returnVal: new(type: (global::Godot.Variant.Type)2, name: "", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false), flags: (global::Godot.MethodFlags)1, arguments: new() { new(type: (global::Godot.Variant.Type)21, name: "name", hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)6, exported: false),  }, defaultArguments: null));
         return methods;
     }
+    protected internal new static partial class GodotInternal
+    {
+        public new static unsafe void GetGodotMethodTrampolines(global::Godot.Bridge.MethodTrampolineCollector collector)
+        {
+            static godot_variant trampoline_1__Process(object godotObject, NativeVariantPtrArgs args, ref godot_variant_call_error callError)
+            {
+                if (args.Count != 1) {
+                    callError = godot_variant_call_error.CreateInvalidArgumentCountError(expected: 1, provided: args.Count);
+                    return default;
+                }
+                ((global::Godot.Node)godotObject).@_Process(global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(args[0]));
+                return default;
+            }
+            collector.TryAdd(new(MethodName.@_Process, 1), new(&trampoline_1__Process, isStatic: false));
+            collector.TryAdd(new(global::Godot.Node.MethodName.@_Process, 1), new(&trampoline_1__Process, isStatic: false));
+            static godot_variant trampoline_1_Bazz(object godotObject, NativeVariantPtrArgs args, ref godot_variant_call_error callError)
+            {
+                if (args.Count != 1) {
+                    callError = godot_variant_call_error.CreateInvalidArgumentCountError(expected: 1, provided: args.Count);
+                    return default;
+                }
+                var callRet = ((global::ScriptBoilerplate)godotObject).@Bazz(global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(args[0]));
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(callRet);
+            }
+            collector.TryAdd(new(MethodName.@Bazz, 1), new(&trampoline_1_Bazz, isStatic: false));
+        }
+    }
 #pragma warning restore CS0109
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool InvokeGodotClassMethod(in godot_string_name method, NativeVariantPtrArgs args, out godot_variant ret)
-    {
-        if (method == MethodName.@_Process && args.Count == 1) {
-            @_Process(global::Godot.NativeInterop.VariantUtils.ConvertTo<double>(args[0]));
-            ret = default;
-            return true;
-        }
-        if (method == MethodName.@Bazz && args.Count == 1) {
-            var callRet = @Bazz(global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.StringName>(args[0]));
-            ret = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(callRet);
-            return true;
-        }
-        return base.InvokeGodotClassMethod(method, args, out ret);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool HasGodotClassMethod(in godot_string_name method)
-    {
-        if (method == MethodName.@_Process) {
-           return true;
-        }
-        if (method == MethodName.@Bazz) {
-           return true;
-        }
-        return base.HasGodotClassMethod(method);
-    }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ScriptBoilerplate_ScriptProperties.generated.cs
@@ -17,33 +17,31 @@ partial class ScriptBoilerplate
         /// </summary>
         public new static readonly global::Godot.StringName @_velocity = "_velocity";
     }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    protected internal new static partial class GodotInternal
     {
-        if (name == PropertyName.@_nodePath) {
-            this.@_nodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
-            return true;
+        internal new static unsafe void GetGodotPropertyTrampolines(global::Godot.Bridge.PropertyTrampolineCollector collector)
+        {
+            static godot_variant trampoline_get__nodePath(object godotObject)
+            {
+                var ret = ((global::ScriptBoilerplate)godotObject).@_nodePath;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(ret);
+            }
+            static void trampoline_set__nodePath(object godotObject, in godot_variant value)
+            {
+                ((global::ScriptBoilerplate)godotObject).@_nodePath = global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.NodePath>(value);
+            }
+            static godot_variant trampoline_get__velocity(object godotObject)
+            {
+                var ret = ((global::ScriptBoilerplate)godotObject).@_velocity;
+                return global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(ret);
+            }
+            static void trampoline_set__velocity(object godotObject, in godot_variant value)
+            {
+                ((global::ScriptBoilerplate)godotObject).@_velocity = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
+            }
+            collector.TryAdd(PropertyName.@_nodePath, (new(&trampoline_get__nodePath), new(&trampoline_set__nodePath)));
+            collector.TryAdd(PropertyName.@_velocity, (new(&trampoline_get__velocity), new(&trampoline_set__velocity)));
         }
-        if (name == PropertyName.@_velocity) {
-            this.@_velocity = global::Godot.NativeInterop.VariantUtils.ConvertTo<int>(value);
-            return true;
-        }
-        return base.SetGodotClassPropertyValue(name, value);
-    }
-    /// <inheritdoc/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
-    {
-        if (name == PropertyName.@_nodePath) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<global::Godot.NodePath>(this.@_nodePath);
-            return true;
-        }
-        if (name == PropertyName.@_velocity) {
-            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<int>(this.@_velocity);
-            return true;
-        }
-        return base.GetGodotClassPropertyValue(name, out value);
     }
     /// <summary>
     /// Get the property information for all the properties declared in this class.

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/namespace.class_ScriptMethods.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/namespace.class_ScriptMethods.generated.cs
@@ -11,6 +11,12 @@ partial class @class
     /// </summary>
     public new class MethodName : global::Godot.GodotObject.MethodName {
     }
+    protected internal new static partial class GodotInternal
+    {
+        public new static unsafe void GetGodotMethodTrampolines(global::Godot.Bridge.MethodTrampolineCollector collector)
+        {
+        }
+    }
 #pragma warning restore CS0109
 }
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -54,7 +54,7 @@ namespace Godot.SourceGenerators
 
             while (symbol != null)
             {
-                if (symbol.ContainingAssembly?.Name == "GodotSharp")
+                if (symbol.ContainingAssembly is { Name: "GodotSharp" or "GodotSharpEditor" })
                     return symbol;
 
                 symbol = symbol.BaseType;
@@ -393,5 +393,46 @@ namespace Godot.SourceGenerators
         public static int StartLine(this Location location)
             => location.SourceTree?.GetLineSpan(location.SourceSpan).StartLinePosition.Line
                ?? location.GetLineSpan().StartLinePosition.Line;
+
+        public static INamedTypeSymbol? GetClosestBaseTypeDeclaringGodotInternalMethod(
+            this INamedTypeSymbol classTypeSymbol, string godotInternalMethod)
+        {
+            var top = classTypeSymbol;
+
+            do
+            {
+                top = top.BaseType;
+
+                if (top == null ||
+                    SymbolEqualityComparer.Default.Equals(top, classTypeSymbol.GetGodotScriptNativeClass()))
+                {
+                    // Reached a native class, stop looking.
+                    return null;
+                }
+            } while (
+                // Ignore while the type is extern AND...
+                top.IsExtern && (
+                    // not accessible from a derived class in this project OR...
+                    !IsExternSymbolAccessibleFromDerivedClass(top) ||
+                    // doesn't contain a GodotInternal type THAT IS...
+                    !top.GetTypeMembers("GodotInternal").Any(t =>
+                        // accessible from a derived class in this project AND...
+                        IsExternSymbolAccessibleFromDerivedClass(t)
+                        // has the method we're looking for.
+                        && t.MemberNames.Contains(godotInternalMethod)
+                    )
+                )
+            );
+
+            return top;
+
+            static bool IsExternSymbolAccessibleFromDerivedClass(INamedTypeSymbol externSymbol) =>
+                externSymbol.DeclaredAccessibility
+                    is not (Accessibility.NotApplicable
+                    or Accessibility.Private
+                    // C#'s 'private protected'. Access is granted derived classes BUT only within the same assembly.
+                    or Accessibility.ProtectedAndInternal or Accessibility.ProtectedAndFriend
+                    or Accessibility.Internal);
+        }
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -54,7 +54,7 @@ namespace Godot.SourceGenerators
 
             while (symbol != null)
             {
-                if (symbol.ContainingAssembly?.Name == "GodotSharp")
+                if (symbol.ContainingAssembly is { Name: "GodotSharp" or "GodotSharpEditor" })
                     return symbol;
 
                 symbol = symbol.BaseType;
@@ -405,6 +405,47 @@ namespace Godot.SourceGenerators
         public static IMethodSymbol? SetMethodOrBaseSetMethod(this IPropertySymbol symbol)
         {
             return symbol.SetMethod ?? symbol.OverriddenProperty?.SetMethodOrBaseSetMethod();
+        }
+
+        public static INamedTypeSymbol? GetClosestBaseTypeDeclaringGodotInternalMethod(
+            this INamedTypeSymbol classTypeSymbol, string godotInternalMethod)
+        {
+            var top = classTypeSymbol;
+
+            do
+            {
+                top = top.BaseType;
+
+                if (top == null ||
+                    SymbolEqualityComparer.Default.Equals(top, classTypeSymbol.GetGodotScriptNativeClass()))
+                {
+                    // Reached a native class, stop looking.
+                    return null;
+                }
+            } while (
+                // Ignore while the type is extern AND...
+                top.IsExtern && (
+                    // not accessible from a derived class in this project OR...
+                    !IsExternSymbolAccessibleFromDerivedClass(top) ||
+                    // doesn't contain a GodotInternal type THAT IS...
+                    !top.GetTypeMembers("GodotInternal").Any(t =>
+                        // accessible from a derived class in this project AND...
+                        IsExternSymbolAccessibleFromDerivedClass(t)
+                        // has the method we're looking for.
+                        && t.MemberNames.Contains(godotInternalMethod)
+                    )
+                )
+            );
+
+            return top;
+
+            static bool IsExternSymbolAccessibleFromDerivedClass(INamedTypeSymbol externSymbol) =>
+                externSymbol.DeclaredAccessibility
+                    is not (Accessibility.NotApplicable
+                    or Accessibility.Private
+                    // C#'s 'private protected'. Access is granted derived classes BUT only within the same assembly.
+                    or Accessibility.ProtectedAndInternal or Accessibility.ProtectedAndFriend
+                    or Accessibility.Internal);
         }
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalUtils.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalUtils.cs
@@ -227,13 +227,13 @@ namespace Godot.SourceGenerators
                                     return type switch
                                     {
                                         { Name: "Dictionary" } =>
-                                            type is INamedTypeSymbol { IsGenericType: false } ?
-                                                MarshalType.GodotDictionary :
-                                                MarshalType.GodotGenericDictionary,
+                                            type is INamedTypeSymbol { IsGenericType: false }
+                                                ? MarshalType.GodotDictionary
+                                                : MarshalType.GodotGenericDictionary,
                                         { Name: "Array" } =>
-                                            type is INamedTypeSymbol { IsGenericType: false } ?
-                                                MarshalType.GodotArray :
-                                                MarshalType.GodotGenericArray,
+                                            type is INamedTypeSymbol { IsGenericType: false }
+                                                ? MarshalType.GodotArray
+                                                : MarshalType.GodotGenericArray,
                                         _ => null
                                     };
                             }
@@ -308,10 +308,14 @@ namespace Godot.SourceGenerators
             string c, string d, string e, string f, string g, string h)
             => source.Append(a).Append(b).Append(c).Append(d).Append(e).Append(f).Append(g).Append(h);
 
+        private static StringBuilder Append(this StringBuilder source, string a, string b,
+            string c, string d, string e, string f, string g, string h, string i)
+            => source.Append(a).Append(b).Append(c).Append(d).Append(e).Append(f).Append(g).Append(h).Append(i);
+
         private const string VariantUtils = "global::Godot.NativeInterop.VariantUtils";
 
         public static StringBuilder AppendNativeVariantToManagedExpr(this StringBuilder source,
-            string inputExpr, ITypeSymbol typeSymbol, MarshalType marshalType)
+            (string firstHalf, string secondHalf) inputExpr, ITypeSymbol typeSymbol, MarshalType marshalType)
         {
             return marshalType switch
             {
@@ -319,38 +323,52 @@ namespace Godot.SourceGenerators
                 MarshalType.GodotObjectOrDerivedArray =>
                     source.Append(VariantUtils, ".ConvertToSystemArrayOfGodotObject<",
                         ((IArrayTypeSymbol)typeSymbol).ElementType.FullQualifiedNameIncludeGlobal(), ">(",
-                        inputExpr, ")"),
+                        inputExpr.firstHalf, inputExpr.secondHalf, ")"),
                 // We need a special case for generic Godot collections and GodotObjectOrDerived[], because VariantUtils.ConvertTo<T> is slower
                 MarshalType.GodotGenericDictionary =>
                     source.Append(VariantUtils, ".ConvertToDictionary<",
                         ((INamedTypeSymbol)typeSymbol).TypeArguments[0].FullQualifiedNameIncludeGlobal(), ", ",
                         ((INamedTypeSymbol)typeSymbol).TypeArguments[1].FullQualifiedNameIncludeGlobal(), ">(",
-                        inputExpr, ")"),
+                        inputExpr.firstHalf, inputExpr.secondHalf, ")"),
                 MarshalType.GodotGenericArray =>
                     source.Append(VariantUtils, ".ConvertToArray<",
                         ((INamedTypeSymbol)typeSymbol).TypeArguments[0].FullQualifiedNameIncludeGlobal(), ">(",
-                        inputExpr, ")"),
+                        inputExpr.firstHalf, inputExpr.secondHalf, ")"),
                 _ => source.Append(VariantUtils, ".ConvertTo<",
-                    typeSymbol.FullQualifiedNameIncludeGlobal(), ">(", inputExpr, ")"),
+                    typeSymbol.FullQualifiedNameIncludeGlobal(), ">(", inputExpr.firstHalf, inputExpr.secondHalf, ")"),
+            };
+        }
+
+        public static StringBuilder AppendNativeVariantToManagedExpr(this StringBuilder source,
+            string inputExpr, ITypeSymbol typeSymbol, MarshalType marshalType)
+        {
+            return AppendNativeVariantToManagedExpr(source, ("", inputExpr), typeSymbol, marshalType);
+        }
+
+        public static StringBuilder AppendManagedToNativeVariantExpr(this StringBuilder source,
+            (string firstHalf, string secondHalf) inputExpr, ITypeSymbol typeSymbol, MarshalType marshalType)
+        {
+            return marshalType switch
+            {
+                // We need a special case for GodotObjectOrDerived[], because it's not supported by VariantUtils.CreateFrom<T>
+                MarshalType.GodotObjectOrDerivedArray =>
+                    source.Append(VariantUtils, ".CreateFromSystemArrayOfGodotObject(",
+                        inputExpr.firstHalf, inputExpr.secondHalf, ")"),
+                // We need a special case for generic Godot collections and GodotObjectOrDerived[], because VariantUtils.CreateFrom<T> is slower
+                MarshalType.GodotGenericDictionary =>
+                    source.Append(VariantUtils, ".CreateFromDictionary(",
+                        inputExpr.firstHalf, inputExpr.secondHalf, ")"),
+                MarshalType.GodotGenericArray =>
+                    source.Append(VariantUtils, ".CreateFromArray(", inputExpr.firstHalf, inputExpr.secondHalf, ")"),
+                _ => source.Append(VariantUtils, ".CreateFrom<",
+                    typeSymbol.FullQualifiedNameIncludeGlobal(), ">(", inputExpr.firstHalf, inputExpr.secondHalf, ")"),
             };
         }
 
         public static StringBuilder AppendManagedToNativeVariantExpr(this StringBuilder source,
             string inputExpr, ITypeSymbol typeSymbol, MarshalType marshalType)
         {
-            return marshalType switch
-            {
-                // We need a special case for GodotObjectOrDerived[], because it's not supported by VariantUtils.CreateFrom<T>
-                MarshalType.GodotObjectOrDerivedArray =>
-                    source.Append(VariantUtils, ".CreateFromSystemArrayOfGodotObject(", inputExpr, ")"),
-                // We need a special case for generic Godot collections and GodotObjectOrDerived[], because VariantUtils.CreateFrom<T> is slower
-                MarshalType.GodotGenericDictionary =>
-                    source.Append(VariantUtils, ".CreateFromDictionary(", inputExpr, ")"),
-                MarshalType.GodotGenericArray =>
-                    source.Append(VariantUtils, ".CreateFromArray(", inputExpr, ")"),
-                _ => source.Append(VariantUtils, ".CreateFrom<",
-                    typeSymbol.FullQualifiedNameIncludeGlobal(), ">(", inputExpr, ")"),
-            };
+            return AppendManagedToNativeVariantExpr(source, ("", inputExpr), typeSymbol, marshalType);
         }
 
         public static StringBuilder AppendVariantToManagedExpr(this StringBuilder source,

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -167,7 +167,7 @@ namespace Godot.SourceGenerators
                 source.Append("\";\n");
             }
 
-            source.Append("    }\n"); // class GodotInternal
+            source.Append("    }\n"); // end of class MethodName
 
             // Generate GetGodotMethodList
 
@@ -213,7 +213,7 @@ namespace Godot.SourceGenerators
 
                 source.Append(
                     "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static unsafe ")
+                source.Append("    internal new static ")
                     .Append(DictType)
                     .Append(" GetGodotMethodNameToProxyNameMap()\n    {\n");
 
@@ -226,8 +226,8 @@ namespace Godot.SourceGenerators
                 foreach (var method in godotClassMethods)
                 {
                     if (method.Method is { IsOverride: true, OverriddenMethod: not null } &&
-                        method.Method.OverriddenMethod.ContainingType.ContainingAssembly is
-                            { Name: "GodotSharp" or "GodotSharpEditor" })
+                        method.Method.OverriddenMethod.ContainingType
+                            .ContainingAssembly is { Name: "GodotSharp" or "GodotSharpEditor" })
                     {
                         // Only do this for native virtual methods by checking that it is also in MethodName.
                         if (method.Method.OverriddenMethod.ContainingType.GetTypeMembers()
@@ -461,7 +461,7 @@ namespace Godot.SourceGenerators
 
             source.Append("        trampolines.Add(new(MethodName.@")
                 .Append(methodName).Append(", ").Append(parameterCount)
-                .Append("), new global::Godot.Bridge.MethodTrampoline(&trampoline_")
+                .Append("), new(&trampoline_")
                 .Append(parameterCount).Append("_").Append(methodName)
                 .Append("));\n");
         }
@@ -483,8 +483,8 @@ namespace Godot.SourceGenerators
             // These two will behave differently if the derived class hides the method
             // (with the 'new' keyword) instead of overriding it.
             if (method.Method is { IsOverride: true, OverriddenMethod: not null } &&
-                method.Method.OverriddenMethod.ContainingType.ContainingAssembly is
-                    { Name: "GodotSharp" or "GodotSharpEditor" })
+                method.Method.OverriddenMethod.ContainingType
+                    .ContainingAssembly is { Name: "GodotSharp" or "GodotSharpEditor" })
             {
                 // Only do this for native virtual methods by checking that it is also in MethodName.
                 // This is not only for correctness, but to also avoid issues with protected functions like Dispose(bool).
@@ -498,38 +498,20 @@ namespace Godot.SourceGenerators
 
             bool isStaticMethod = method.Method.IsStatic;
 
-            source.Append("        [global::System.Runtime.InteropServices.UnmanagedCallersOnly]\n");
-            source.Append("        static void trampoline_")
-                .Append(parameterCount).Append("_").Append(methodName);
+            source
+                .Append("        static godot_variant trampoline_")
+                .Append(parameterCount).Append("_").Append(methodName)
+                .Append("(object godotObject, NativeVariantPtrArgs args, ")
+                .Append("ref godot_variant_call_error callError)\n        {\n");
 
-            source.Append("(global::System.IntPtr godotObjectGCHandle, godot_variant** args, int argCount, ");
-            source.Append("godot_variant_call_error* outRefCallError, godot_variant* outRet)\n        {\n");
-
-            source.Append("          try {\n");
-
-            source.Append("            if (argCount != ");
+            source.Append("            if (args.Count != ");
             source.Append(parameterCount);
             source.Append(") {\n");
-            source.Append("                *outRet = default;\n");
-            source.Append("                *outRefCallError = ")
+            source.Append("                callError = ")
                 .Append("godot_variant_call_error.CreateInvalidArgumentCountError(expected: ")
-                .Append(parameterCount).Append(", provided: argCount);\n");
-            source.Append("                return;\n");
+                .Append(parameterCount).Append(", provided: args.Count);\n");
+            source.Append("                return default;\n");
             source.Append("            }\n");
-
-            if (!isStaticMethod)
-            {
-                source
-                    .Append("            var godotObject = (").Append(castClassSymbol.FullQualifiedNameIncludeGlobal())
-                    .Append(
-                        ")global::System.Runtime.InteropServices.GCHandle.FromIntPtr(godotObjectGCHandle).Target;\n")
-                    .Append("            if (godotObject == null) {\n")
-                    .Append("                *outRet = default;\n")
-                    .Append("                (*outRefCallError).Error = godot_variant_call_error_error.")
-                    .Append("GODOT_CALL_ERROR_CALL_ERROR_INSTANCE_IS_NULL;\n")
-                    .Append("                return;\n")
-                    .Append("            }\n");
-            }
 
             if (method.RetType != null)
                 source.Append("            var callRet = ");
@@ -537,7 +519,7 @@ namespace Godot.SourceGenerators
                 source.Append("            ");
 
             if (!isStaticMethod)
-                source.Append("godotObject.");
+                source.Append("((").Append(castClassSymbol.FullQualifiedNameIncludeGlobal()).Append(")godotObject).");
             source.Append("@");
             source.Append(methodName);
             source.Append("(");
@@ -547,7 +529,7 @@ namespace Godot.SourceGenerators
                 if (i != 0)
                     source.Append(", ");
 
-                source.AppendNativeVariantToManagedExpr(string.Concat("*(args[", i.ToString(), "])"),
+                source.AppendNativeVariantToManagedExpr(string.Concat("args[", i.ToString(), "]"),
                     method.ParamTypeSymbols[i], method.ParamTypes[i]);
             }
 
@@ -555,20 +537,15 @@ namespace Godot.SourceGenerators
 
             if (method.RetType != null)
             {
-                source.Append("            *outRet = ");
-
+                source.Append("            return ");
                 source.AppendManagedToNativeVariantExpr("callRet",
                     method.RetType.Value.TypeSymbol, method.RetType.Value.MarshalType);
                 source.Append(";\n");
             }
             else
             {
-                source.Append("            *outRet = default;\n");
+                source.Append("            return default;\n");
             }
-
-            source.Append("          } catch (global::System.Exception e) {\n");
-            source.Append("              global::Godot.NativeInterop.ExceptionUtils.LogException(e);\n");
-            source.Append("          }\n");
 
             source.Append("        }\n");
         }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -207,16 +207,14 @@ namespace Godot.SourceGenerators
                 source.Append("    }\n");
             }
 
-            // Generate GetGodotMethodNameToProxyNameMap
+            source.Append("    private static partial class GodotInternal\n    {\n");
 
-            if (godotClassMethods.Length > 0)
+            // Generate GetGodotMethodNameToProxyNameMap
             {
                 const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.NameToProxyNameMapCollector";
 
-                source.Append(
-                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static void GetGodotMethodNameToProxyNameMap(")
-                    .Append(CollectorType).Append(" collector)\n    {\n");
+                source.Append("        public new static void GetGodotMethodNameToProxyNameMap(")
+                    .Append(CollectorType).Append(" collector)\n        {\n");
 
                 foreach (var method in godotClassMethods)
                 {
@@ -232,7 +230,7 @@ namespace Godot.SourceGenerators
                             INamedTypeSymbol castClassSymbol = method.Method.OverriddenMethod.ContainingType;
                             int parameterCount = method.ParamTypes.Length;
 
-                            source.Append("        collector.TryAdd(new(")
+                            source.Append("            collector.TryAdd(new(")
                                 .Append(castClassSymbol.FullQualifiedNameIncludeGlobal())
                                 .Append(".MethodName.@").Append(method.Method.Name)
                                 .Append(", ").Append(parameterCount)
@@ -243,21 +241,17 @@ namespace Godot.SourceGenerators
                     }
                 }
 
-                source.Append("    }\n");
+                source.Append("        }\n");
             }
 
             // Generate GetGodotMethodTrampolines
-
-            if (godotClassMethods.Length > 0)
             {
                 const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.MethodTrampolineCollector";
 
-                source.Append(
-                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static ")
+                source.Append("        public new static ")
                     .Append(isUnsafeAllowed ? "unsafe " : "")
                     .Append("void GetGodotMethodTrampolines(")
-                    .Append(CollectorType).Append(" collector)\n    {\n");
+                    .Append(CollectorType).Append(" collector)\n        {\n");
 
                 foreach (var method in godotClassMethods)
                 {
@@ -265,8 +259,10 @@ namespace Godot.SourceGenerators
                     AppendMethodTrampoline(source, method, isUnsafeAllowed);
                 }
 
-                source.Append("    }\n");
+                source.Append("        }\n");
             }
+
+            source.Append("    }\n"); // partial class GodotInternal
 
             source.Append("#pragma warning restore CS0109\n");
 
@@ -423,7 +419,7 @@ namespace Godot.SourceGenerators
 
             if (!isUnsafeAllowed)
             {
-                source.Append("        var aux_delegate_")
+                source.Append("            var aux_delegate_")
                     .Append(parameterCount).Append("_").Append(methodName)
                     .Append(" = ")
                     .Append("trampoline_")
@@ -431,7 +427,7 @@ namespace Godot.SourceGenerators
                     .Append(";\n");
             }
 
-            source.Append("        collector.TryAdd(new(MethodName.@")
+            source.Append("            collector.TryAdd(new(MethodName.@")
                 .Append(methodName).Append(", ").Append(parameterCount)
                 .Append("), new(");
 
@@ -486,24 +482,24 @@ namespace Godot.SourceGenerators
             bool isStaticMethod = method.Method.IsStatic;
 
             source
-                .Append("        static godot_variant trampoline_")
+                .Append("            static godot_variant trampoline_")
                 .Append(parameterCount).Append("_").Append(methodName)
                 .Append("(object godotObject, NativeVariantPtrArgs args, ")
-                .Append("ref godot_variant_call_error callError)\n        {\n");
+                .Append("ref godot_variant_call_error callError)\n            {\n");
 
-            source.Append("            if (args.Count != ");
+            source.Append("                if (args.Count != ");
             source.Append(parameterCount);
             source.Append(") {\n");
-            source.Append("                callError = ")
+            source.Append("                    callError = ")
                 .Append("godot_variant_call_error.CreateInvalidArgumentCountError(expected: ")
                 .Append(parameterCount).Append(", provided: args.Count);\n");
-            source.Append("                return default;\n");
-            source.Append("            }\n");
+            source.Append("                    return default;\n");
+            source.Append("                }\n");
 
             if (method.RetType != null)
-                source.Append("            var callRet = ");
+                source.Append("                var callRet = ");
             else
-                source.Append("            ");
+                source.Append("                ");
 
             if (!isStaticMethod)
                 source.Append("((").Append(castClassSymbol.FullQualifiedNameIncludeGlobal()).Append(")godotObject).");
@@ -524,17 +520,17 @@ namespace Godot.SourceGenerators
 
             if (method.RetType != null)
             {
-                source.Append("            return ");
+                source.Append("                return ");
                 source.AppendManagedToNativeVariantExpr("callRet",
                     method.RetType.Value.TypeSymbol, method.RetType.Value.MarshalType);
                 source.Append(";\n");
             }
             else
             {
-                source.Append("            return default;\n");
+                source.Append("                return default;\n");
             }
 
-            source.Append("        }\n");
+            source.Append("            }\n");
         }
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -270,31 +270,6 @@ namespace Godot.SourceGenerators
 
             source.Append("#pragma warning restore CS0109\n");
 
-            // Generate InvokeGodotClassStaticMethod
-
-            var godotClassStaticMethods = godotClassMethods.Where(m => m.Method.IsStatic).ToArray();
-
-            if (godotClassStaticMethods.Length > 0)
-            {
-                source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
-                source.Append(
-                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append(
-                    "    internal new static bool InvokeGodotClassStaticMethod(in godot_string_name method, ");
-                source.Append("NativeVariantPtrArgs args, out godot_variant ret)\n    {\n");
-
-                foreach (var method in godotClassStaticMethods)
-                {
-                    GenerateMethodInvoker(method, source);
-                }
-
-                source.Append("        ret = default;\n");
-                source.Append("        return false;\n");
-                source.Append("    }\n");
-
-                source.Append("#pragma warning restore CS0109\n");
-            }
-
             source.Append("}\n"); // partial class
 
             if (isInnerClass)
@@ -474,6 +449,7 @@ namespace Godot.SourceGenerators
                     .Append(".Method.MethodHandle.GetFunctionPointer()");
             }
 
+            source.Append(", isStatic: ").Append(method.Method.IsStatic ? "true" : "false");
             source.Append("));\n");
         }
 
@@ -556,58 +532,6 @@ namespace Godot.SourceGenerators
             else
             {
                 source.Append("            return default;\n");
-            }
-
-            source.Append("        }\n");
-        }
-
-        private static void GenerateMethodInvoker(
-            GodotMethodData method,
-            StringBuilder source
-        )
-        {
-            string methodName = method.Method.Name;
-
-            source.Append("        if (method == MethodName.@");
-            source.Append(methodName);
-            source.Append(" && args.Count == ");
-            source.Append(method.ParamTypes.Length);
-            source.Append(") {\n");
-
-            if (method.RetType != null)
-                source.Append("            var callRet = ");
-            else
-                source.Append("            ");
-
-            source.Append("@");
-            source.Append(methodName);
-            source.Append("(");
-
-            for (int i = 0; i < method.ParamTypes.Length; i++)
-            {
-                if (i != 0)
-                    source.Append(", ");
-
-                source.AppendNativeVariantToManagedExpr(string.Concat("args[", i.ToString(), "]"),
-                    method.ParamTypeSymbols[i], method.ParamTypes[i]);
-            }
-
-            source.Append(");\n");
-
-            if (method.RetType != null)
-            {
-                source.Append("            ret = ");
-
-                source.AppendManagedToNativeVariantExpr("callRet",
-                    method.RetType.Value.TypeSymbol, method.RetType.Value.MarshalType);
-                source.Append(";\n");
-
-                source.Append("            return true;\n");
-            }
-            else
-            {
-                source.Append("            ret = default;\n");
-                source.Append("            return true;\n");
             }
 
             source.Append("        }\n");

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -76,6 +76,9 @@ namespace Godot.SourceGenerators
             INamedTypeSymbol symbol
         )
         {
+            var options = context.Compilation.Options as Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions;
+            bool isUnsafeAllowed = options?.AllowUnsafe ?? false;
+
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
             string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace
                 ? namespaceSymbol.FullQualifiedNameOmitGlobal()
@@ -251,13 +254,15 @@ namespace Godot.SourceGenerators
 
                 source.Append(
                     "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static unsafe void GetGodotMethodTrampolines(")
+                source.Append("    internal new static ")
+                    .Append(isUnsafeAllowed ? "unsafe " : "")
+                    .Append("void GetGodotMethodTrampolines(")
                     .Append(CollectorType).Append(" collector)\n    {\n");
 
                 foreach (var method in godotClassMethods)
                 {
                     GenerateMethodTrampoline(symbol, method, source);
-                    AppendMethodTrampoline(source, method);
+                    AppendMethodTrampoline(source, method, isUnsafeAllowed);
                 }
 
                 source.Append("    }\n");
@@ -436,16 +441,40 @@ namespace Godot.SourceGenerators
                 PropertyHint.None, string.Empty, propUsage, className, exported: false);
         }
 
-        private static void AppendMethodTrampoline(StringBuilder source, GodotMethodData method)
+        private static void AppendMethodTrampoline(StringBuilder source, GodotMethodData method, bool isUnsafeAllowed)
         {
             string methodName = method.Method.Name;
             int parameterCount = method.ParamTypes.Length;
 
+            if (!isUnsafeAllowed)
+            {
+                source.Append("        var aux_delegate_")
+                    .Append(parameterCount).Append("_").Append(methodName)
+                    .Append(" = ")
+                    .Append("trampoline_")
+                    .Append(parameterCount).Append("_").Append(methodName)
+                    .Append(";\n");
+            }
+
             source.Append("        collector.TryAdd(new(MethodName.@")
                 .Append(methodName).Append(", ").Append(parameterCount)
-                .Append("), new(&trampoline_")
-                .Append(parameterCount).Append("_").Append(methodName)
-                .Append("));\n");
+                .Append("), new(");
+
+            if (isUnsafeAllowed)
+            {
+                source
+                    .Append("&trampoline_")
+                    .Append(parameterCount).Append("_").Append(methodName);
+            }
+            else
+            {
+                source
+                    .Append("aux_delegate_")
+                    .Append(parameterCount).Append("_").Append(methodName)
+                    .Append(".Method.MethodHandle.GetFunctionPointer()");
+            }
+
+            source.Append("));\n");
         }
 
         private static void GenerateMethodTrampoline(

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -209,41 +209,6 @@ namespace Godot.SourceGenerators
 
             source.Append("    private static partial class GodotInternal\n    {\n");
 
-            // Generate GetGodotMethodNameToProxyNameMap
-            {
-                const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.NameToProxyNameMapCollector";
-
-                source.Append("        public new static void GetGodotMethodNameToProxyNameMap(")
-                    .Append(CollectorType).Append(" collector)\n        {\n");
-
-                foreach (var method in godotClassMethods)
-                {
-                    if (method.Method is { IsOverride: true, OverriddenMethod: not null } &&
-                        method.Method.OverriddenMethod.ContainingType
-                            .ContainingAssembly is { Name: "GodotSharp" or "GodotSharpEditor" })
-                    {
-                        // Only do this for native virtual methods by checking that it is also in MethodName.
-                        if (method.Method.OverriddenMethod.ContainingType.GetTypeMembers()
-                                .FirstOrDefault(s => s.Name == "MethodName")?
-                                .MemberNames.Any(name => name == method.Method.Name) ?? false)
-                        {
-                            INamedTypeSymbol castClassSymbol = method.Method.OverriddenMethod.ContainingType;
-                            int parameterCount = method.ParamTypes.Length;
-
-                            source.Append("            collector.TryAdd(new(")
-                                .Append(castClassSymbol.FullQualifiedNameIncludeGlobal())
-                                .Append(".MethodName.@").Append(method.Method.Name)
-                                .Append(", ").Append(parameterCount)
-                                .Append("), MethodName.@")
-                                .Append(method.Method.Name)
-                                .Append(");\n");
-                        }
-                    }
-                }
-
-                source.Append("        }\n");
-            }
-
             // Generate GetGodotMethodTrampolines
             {
                 const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.MethodTrampolineCollector";
@@ -416,6 +381,7 @@ namespace Godot.SourceGenerators
         {
             string methodName = method.Method.Name;
             int parameterCount = method.ParamTypes.Length;
+            bool isStatic = method.Method.IsStatic;
 
             if (!isUnsafeAllowed)
             {
@@ -427,26 +393,56 @@ namespace Godot.SourceGenerators
                     .Append(";\n");
             }
 
-            source.Append("            collector.TryAdd(new(MethodName.@")
-                .Append(methodName).Append(", ").Append(parameterCount)
-                .Append("), new(");
+            DoAppendTrampoline(source, methodName, parameterCount, isStatic, isUnsafeAllowed);
 
-            if (isUnsafeAllowed)
+            if (method.Method is { IsOverride: true, OverriddenMethod: not null } &&
+                method.Method.OverriddenMethod.ContainingType
+                    .ContainingAssembly is { Name: "GodotSharp" or "GodotSharpEditor" })
             {
-                source
-                    .Append("&trampoline_")
-                    .Append(parameterCount).Append("_").Append(methodName);
-            }
-            else
-            {
-                source
-                    .Append("aux_delegate_")
-                    .Append(parameterCount).Append("_").Append(methodName)
-                    .Append(".Method.MethodHandle.GetFunctionPointer()");
+                // Only do this for native virtual methods by checking that it is also in MethodName.
+                if (method.Method.OverriddenMethod.ContainingType.GetTypeMembers()
+                        .FirstOrDefault(s => s.Name == "MethodName")?
+                        .MemberNames.Any(name => name == method.Method.Name) ?? false)
+                {
+                    INamedTypeSymbol overriddenContainingType =
+                        method.Method.OverriddenMethod.ContainingType;
+
+                    DoAppendTrampoline(source, methodName, parameterCount,
+                        isStatic, isUnsafeAllowed, overriddenContainingType);
+                }
             }
 
-            source.Append(", isStatic: ").Append(method.Method.IsStatic ? "true" : "false");
-            source.Append("));\n");
+            static void DoAppendTrampoline(StringBuilder source,
+                string methodName, int parameterCount,
+                bool isStatic, bool isUnsafeAllowed,
+                INamedTypeSymbol? overriddenContainingType = null)
+            {
+                source.Append("            collector.TryAdd(new(");
+
+                if (overriddenContainingType != null)
+                    source.Append(overriddenContainingType.FullQualifiedNameIncludeGlobal()).Append(".");
+
+                source.Append("MethodName.@")
+                    .Append(methodName).Append(", ").Append(parameterCount)
+                    .Append("), new(");
+
+                if (isUnsafeAllowed)
+                {
+                    source
+                        .Append("&trampoline_")
+                        .Append(parameterCount).Append("_").Append(methodName);
+                }
+                else
+                {
+                    source
+                        .Append("aux_delegate_")
+                        .Append(parameterCount).Append("_").Append(methodName)
+                        .Append(".Method.MethodHandle.GetFunctionPointer()");
+                }
+
+                source.Append(", isStatic: ").Append(isStatic ? "true" : "false");
+                source.Append("));\n");
+            }
         }
 
         private static void GenerateMethodTrampoline(

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -208,20 +208,12 @@ namespace Godot.SourceGenerators
 
             if (godotClassMethods.Length > 0)
             {
-                const string DictType =
-                    "global::System.Collections.Generic.Dictionary<global::Godot.Bridge.MethodKey, global::Godot.StringName>";
+                const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.NameToProxyNameMapCollector";
 
                 source.Append(
                     "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static ")
-                    .Append(DictType)
-                    .Append(" GetGodotMethodNameToProxyNameMap()\n    {\n");
-
-                source.Append("        var nameToProxyNameMap = new ")
-                    .Append(DictType)
-                    .Append("(")
-                    .Append(godotClassMethods.Length)
-                    .Append(");\n");
+                source.Append("    internal new static void GetGodotMethodNameToProxyNameMap(")
+                    .Append(CollectorType).Append(" collector)\n    {\n");
 
                 foreach (var method in godotClassMethods)
                 {
@@ -237,7 +229,7 @@ namespace Godot.SourceGenerators
                             INamedTypeSymbol castClassSymbol = method.Method.OverriddenMethod.ContainingType;
                             int parameterCount = method.ParamTypes.Length;
 
-                            source.Append("        nameToProxyNameMap.Add(new(")
+                            source.Append("        collector.TryAdd(new(")
                                 .Append(castClassSymbol.FullQualifiedNameIncludeGlobal())
                                 .Append(".MethodName.@").Append(method.Method.Name)
                                 .Append(", ").Append(parameterCount)
@@ -248,7 +240,6 @@ namespace Godot.SourceGenerators
                     }
                 }
 
-                source.Append("        return nameToProxyNameMap;\n");
                 source.Append("    }\n");
             }
 
@@ -256,20 +247,12 @@ namespace Godot.SourceGenerators
 
             if (godotClassMethods.Length > 0)
             {
-                const string DictType =
-                    "global::System.Collections.Generic.Dictionary<global::Godot.Bridge.MethodKey, global::Godot.Bridge.MethodTrampoline>";
+                const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.MethodTrampolineCollector";
 
                 source.Append(
                     "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static unsafe ")
-                    .Append(DictType)
-                    .Append(" GetGodotMethodTrampolines()\n    {\n");
-
-                source.Append("        var trampolines = new ")
-                    .Append(DictType)
-                    .Append("(")
-                    .Append(godotClassMethods.Length)
-                    .Append(");\n");
+                source.Append("    internal new static unsafe void GetGodotMethodTrampolines(")
+                    .Append(CollectorType).Append(" collector)\n    {\n");
 
                 foreach (var method in godotClassMethods)
                 {
@@ -277,7 +260,6 @@ namespace Godot.SourceGenerators
                     AppendMethodTrampoline(source, method);
                 }
 
-                source.Append("        return trampolines;\n");
                 source.Append("    }\n");
             }
 
@@ -459,7 +441,7 @@ namespace Godot.SourceGenerators
             string methodName = method.Method.Name;
             int parameterCount = method.ParamTypes.Length;
 
-            source.Append("        trampolines.Add(new(MethodName.@")
+            source.Append("        collector.TryAdd(new(MethodName.@")
                 .Append(methodName).Append(", ").Append(parameterCount)
                 .Append("), new(&trampoline_")
                 .Append(parameterCount).Append("_").Append(methodName)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -37,6 +37,7 @@ namespace Godot.SourceGenerators
 
                                 return true;
                             }
+
                             return false;
                         })
                         .Select(x => x.symbol)
@@ -76,9 +77,9 @@ namespace Godot.SourceGenerators
         )
         {
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
-            string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace ?
-                namespaceSymbol.FullQualifiedNameOmitGlobal() :
-                string.Empty;
+            string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace
+                ? namespaceSymbol.FullQualifiedNameOmitGlobal()
+                : string.Empty;
             bool hasNamespace = classNs.Length != 0;
 
             bool isInnerClass = symbol.ContainingType != null;
@@ -140,8 +141,9 @@ namespace Godot.SourceGenerators
                 .Append("    /// Cached StringNames for the methods contained in this class, for fast lookup.\n")
                 .Append("    /// </summary>\n");
 
-            source.Append(
-                $"    public new class MethodName : {symbol.BaseType!.FullQualifiedNameIncludeGlobal()}.MethodName {{\n");
+            source.Append("    public new class MethodName : ")
+                .Append(symbol.BaseType!.FullQualifiedNameIncludeGlobal())
+                .Append(".MethodName {\n");
 
             // Generate cached StringNames for methods and properties, for fast lookup
 
@@ -179,7 +181,8 @@ namespace Godot.SourceGenerators
                     .Append("    /// Do not call this method.\n")
                     .Append("    /// </summary>\n");
 
-                source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+                source.Append(
+                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
 
                 source.Append("    internal new static ")
                     .Append(ListType)
@@ -201,26 +204,84 @@ namespace Godot.SourceGenerators
                 source.Append("    }\n");
             }
 
-            source.Append("#pragma warning restore CS0109\n");
-
-            // Generate InvokeGodotClassMethod
+            // Generate GetGodotMethodNameToProxyNameMap
 
             if (godotClassMethods.Length > 0)
             {
-                source.Append("    /// <inheritdoc/>\n");
-                source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    protected override bool InvokeGodotClassMethod(in godot_string_name method, ");
-                source.Append("NativeVariantPtrArgs args, out godot_variant ret)\n    {\n");
+                const string DictType =
+                    "global::System.Collections.Generic.Dictionary<global::Godot.Bridge.MethodKey, global::Godot.StringName>";
+
+                source.Append(
+                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+                source.Append("    internal new static unsafe ")
+                    .Append(DictType)
+                    .Append(" GetGodotMethodNameToProxyNameMap()\n    {\n");
+
+                source.Append("        var nameToProxyNameMap = new ")
+                    .Append(DictType)
+                    .Append("(")
+                    .Append(godotClassMethods.Length)
+                    .Append(");\n");
 
                 foreach (var method in godotClassMethods)
                 {
-                    GenerateMethodInvoker(method, source);
+                    if (method.Method is { IsOverride: true, OverriddenMethod: not null } &&
+                        method.Method.OverriddenMethod.ContainingType.ContainingAssembly is
+                            { Name: "GodotSharp" or "GodotSharpEditor" })
+                    {
+                        // Only do this for native virtual methods by checking that it is also in MethodName.
+                        if (method.Method.OverriddenMethod.ContainingType.GetTypeMembers()
+                                .FirstOrDefault(s => s.Name == "MethodName")?
+                                .MemberNames.Any(name => name == method.Method.Name) ?? false)
+                        {
+                            INamedTypeSymbol castClassSymbol = method.Method.OverriddenMethod.ContainingType;
+                            int parameterCount = method.ParamTypes.Length;
+
+                            source.Append("        nameToProxyNameMap.Add(new(")
+                                .Append(castClassSymbol.FullQualifiedNameIncludeGlobal())
+                                .Append(".MethodName.@").Append(method.Method.Name)
+                                .Append(", ").Append(parameterCount)
+                                .Append("), MethodName.@")
+                                .Append(method.Method.Name)
+                                .Append(");\n");
+                        }
+                    }
                 }
 
-                source.Append("        return base.InvokeGodotClassMethod(method, args, out ret);\n");
-
+                source.Append("        return nameToProxyNameMap;\n");
                 source.Append("    }\n");
             }
+
+            // Generate GetGodotMethodTrampolines
+
+            if (godotClassMethods.Length > 0)
+            {
+                const string DictType =
+                    "global::System.Collections.Generic.Dictionary<global::Godot.Bridge.MethodKey, global::Godot.Bridge.MethodTrampoline>";
+
+                source.Append(
+                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+                source.Append("    internal new static unsafe ")
+                    .Append(DictType)
+                    .Append(" GetGodotMethodTrampolines()\n    {\n");
+
+                source.Append("        var trampolines = new ")
+                    .Append(DictType)
+                    .Append("(")
+                    .Append(godotClassMethods.Length)
+                    .Append(");\n");
+
+                foreach (var method in godotClassMethods)
+                {
+                    GenerateMethodTrampoline(symbol, method, source);
+                    AppendMethodTrampoline(source, method);
+                }
+
+                source.Append("        return trampolines;\n");
+                source.Append("    }\n");
+            }
+
+            source.Append("#pragma warning restore CS0109\n");
 
             // Generate InvokeGodotClassStaticMethod
 
@@ -229,8 +290,10 @@ namespace Godot.SourceGenerators
             if (godotClassStaticMethods.Length > 0)
             {
                 source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
-                source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static bool InvokeGodotClassStaticMethod(in godot_string_name method, ");
+                source.Append(
+                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+                source.Append(
+                    "    internal new static bool InvokeGodotClassStaticMethod(in godot_string_name method, ");
                 source.Append("NativeVariantPtrArgs args, out godot_variant ret)\n    {\n");
 
                 foreach (var method in godotClassStaticMethods)
@@ -243,24 +306,6 @@ namespace Godot.SourceGenerators
                 source.Append("    }\n");
 
                 source.Append("#pragma warning restore CS0109\n");
-            }
-
-            // Generate HasGodotClassMethod
-
-            if (distinctMethodNames.Length > 0)
-            {
-                source.Append("    /// <inheritdoc/>\n");
-                source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    protected override bool HasGodotClassMethod(in godot_string_name method)\n    {\n");
-
-                foreach (string methodName in distinctMethodNames)
-                {
-                    GenerateHasMethodEntry(methodName, source);
-                }
-
-                source.Append("        return base.HasGodotClassMethod(method);\n");
-
-                source.Append("    }\n");
             }
 
             source.Append("}\n"); // partial class
@@ -339,6 +384,7 @@ namespace Godot.SourceGenerators
                     .Append(propertyInfo.ClassName)
                     .Append("\")");
             }
+
             source.Append(")");
         }
 
@@ -408,15 +454,123 @@ namespace Godot.SourceGenerators
                 PropertyHint.None, string.Empty, propUsage, className, exported: false);
         }
 
-        private static void GenerateHasMethodEntry(
-            string methodName,
+        private static void AppendMethodTrampoline(StringBuilder source, GodotMethodData method)
+        {
+            string methodName = method.Method.Name;
+            int parameterCount = method.ParamTypes.Length;
+
+            source.Append("        trampolines.Add(new(MethodName.@")
+                .Append(methodName).Append(", ").Append(parameterCount)
+                .Append("), new global::Godot.Bridge.MethodTrampoline(&trampoline_")
+                .Append(parameterCount).Append("_").Append(methodName)
+                .Append("));\n");
+        }
+
+        private static void GenerateMethodTrampoline(
+            INamedTypeSymbol classSymbol,
+            GodotMethodData method,
             StringBuilder source
         )
         {
-            source.Append("        ");
-            source.Append("if (method == MethodName.@");
+            string methodName = method.Method.Name;
+            int parameterCount = method.ParamTypes.Length;
+
+            INamedTypeSymbol castClassSymbol = classSymbol;
+
+            // To match the behavior of InvokeGodotClassMethod, native virtual methods must
+            // be invoked on a variable of the method declaring type, not the overriding type.
+            // e.g.: '((Node)obj)._EnterTree' vs '((DerivedScriptClass)obj)._EnterTree'.
+            // These two will behave differently if the derived class hides the method
+            // (with the 'new' keyword) instead of overriding it.
+            if (method.Method is { IsOverride: true, OverriddenMethod: not null } &&
+                method.Method.OverriddenMethod.ContainingType.ContainingAssembly is
+                    { Name: "GodotSharp" or "GodotSharpEditor" })
+            {
+                // Only do this for native virtual methods by checking that it is also in MethodName.
+                // This is not only for correctness, but to also avoid issues with protected functions like Dispose(bool).
+                if (method.Method.OverriddenMethod.ContainingType.GetTypeMembers()
+                        .FirstOrDefault(s => s.Name == "MethodName")?
+                        .MemberNames.Any(name => name == method.Method.Name) ?? false)
+                {
+                    castClassSymbol = method.Method.OverriddenMethod.ContainingType;
+                }
+            }
+
+            bool isStaticMethod = method.Method.IsStatic;
+
+            source.Append("        [global::System.Runtime.InteropServices.UnmanagedCallersOnly]\n");
+            source.Append("        static void trampoline_")
+                .Append(parameterCount).Append("_").Append(methodName);
+
+            source.Append("(global::System.IntPtr godotObjectGCHandle, godot_variant** args, int argCount, ");
+            source.Append("godot_variant_call_error* outRefCallError, godot_variant* outRet)\n        {\n");
+
+            source.Append("          try {\n");
+
+            source.Append("            if (argCount != ");
+            source.Append(parameterCount);
+            source.Append(") {\n");
+            source.Append("                *outRet = default;\n");
+            source.Append("                *outRefCallError = ")
+                .Append("godot_variant_call_error.CreateInvalidArgumentCountError(expected: ")
+                .Append(parameterCount).Append(", provided: argCount);\n");
+            source.Append("                return;\n");
+            source.Append("            }\n");
+
+            if (!isStaticMethod)
+            {
+                source
+                    .Append("            var godotObject = (").Append(castClassSymbol.FullQualifiedNameIncludeGlobal())
+                    .Append(
+                        ")global::System.Runtime.InteropServices.GCHandle.FromIntPtr(godotObjectGCHandle).Target;\n")
+                    .Append("            if (godotObject == null) {\n")
+                    .Append("                *outRet = default;\n")
+                    .Append("                (*outRefCallError).Error = godot_variant_call_error_error.")
+                    .Append("GODOT_CALL_ERROR_CALL_ERROR_INSTANCE_IS_NULL;\n")
+                    .Append("                return;\n")
+                    .Append("            }\n");
+            }
+
+            if (method.RetType != null)
+                source.Append("            var callRet = ");
+            else
+                source.Append("            ");
+
+            if (!isStaticMethod)
+                source.Append("godotObject.");
+            source.Append("@");
             source.Append(methodName);
-            source.Append(") {\n           return true;\n        }\n");
+            source.Append("(");
+
+            for (int i = 0; i < method.ParamTypes.Length; i++)
+            {
+                if (i != 0)
+                    source.Append(", ");
+
+                source.AppendNativeVariantToManagedExpr(string.Concat("*(args[", i.ToString(), "])"),
+                    method.ParamTypeSymbols[i], method.ParamTypes[i]);
+            }
+
+            source.Append(");\n");
+
+            if (method.RetType != null)
+            {
+                source.Append("            *outRet = ");
+
+                source.AppendManagedToNativeVariantExpr("callRet",
+                    method.RetType.Value.TypeSymbol, method.RetType.Value.MarshalType);
+                source.Append(";\n");
+            }
+            else
+            {
+                source.Append("            *outRet = default;\n");
+            }
+
+            source.Append("          } catch (global::System.Exception e) {\n");
+            source.Append("              global::Godot.NativeInterop.ExceptionUtils.LogException(e);\n");
+            source.Append("          }\n");
+
+            source.Append("        }\n");
         }
 
         private static void GenerateMethodInvoker(

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -207,11 +207,12 @@ namespace Godot.SourceGenerators
                 source.Append("    }\n");
             }
 
-            source.Append("    private static partial class GodotInternal\n    {\n");
+            source.Append("    ").Append(symbol.IsSealed ? "" : "protected ")
+                .Append("internal new static partial class GodotInternal\n    {\n");
 
             // Generate GetGodotMethodTrampolines
             {
-                const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.MethodTrampolineCollector";
+                const string CollectorType = "global::Godot.Bridge.MethodTrampolineCollector";
 
                 source.Append("        public new static ")
                     .Append(isUnsafeAllowed ? "unsafe " : "")

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -211,41 +211,6 @@ namespace Godot.SourceGenerators
 
             source.Append("    private static partial class GodotInternal\n    {\n");
 
-            // Generate GetGodotMethodNameToProxyNameMap
-            {
-                const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.NameToProxyNameMapCollector";
-
-                source.Append("        public new static void GetGodotMethodNameToProxyNameMap(")
-                    .Append(CollectorType).Append(" collector)\n        {\n");
-
-                foreach (var method in godotClassMethods)
-                {
-                    if (method.Method is { IsOverride: true, OverriddenMethod: not null } &&
-                        method.Method.OverriddenMethod.ContainingType
-                            .ContainingAssembly is { Name: "GodotSharp" or "GodotSharpEditor" })
-                    {
-                        // Only do this for native virtual methods by checking that it is also in MethodName.
-                        if (method.Method.OverriddenMethod.ContainingType.GetTypeMembers()
-                                .FirstOrDefault(s => s.Name == "MethodName")?
-                                .MemberNames.Any(name => name == method.Method.Name) ?? false)
-                        {
-                            INamedTypeSymbol castClassSymbol = method.Method.OverriddenMethod.ContainingType;
-                            int parameterCount = method.ParamTypes.Length;
-
-                            source.Append("            collector.TryAdd(new(")
-                                .Append(castClassSymbol.FullQualifiedNameIncludeGlobal())
-                                .Append(".MethodName.@").Append(method.Method.Name)
-                                .Append(", ").Append(parameterCount)
-                                .Append("), MethodName.@")
-                                .Append(method.Method.Name)
-                                .Append(");\n");
-                        }
-                    }
-                }
-
-                source.Append("        }\n");
-            }
-
             // Generate GetGodotMethodTrampolines
             {
                 const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.MethodTrampolineCollector";
@@ -418,6 +383,7 @@ namespace Godot.SourceGenerators
         {
             string methodName = method.Method.Name;
             int parameterCount = method.ParamTypes.Length;
+            bool isStatic = method.Method.IsStatic;
 
             if (!isUnsafeAllowed)
             {
@@ -429,26 +395,56 @@ namespace Godot.SourceGenerators
                     .Append(";\n");
             }
 
-            source.Append("            collector.TryAdd(new(MethodName.@")
-                .Append(methodName).Append(", ").Append(parameterCount)
-                .Append("), new(");
+            DoAppendTrampoline(source, methodName, parameterCount, isStatic, isUnsafeAllowed);
 
-            if (isUnsafeAllowed)
+            if (method.Method is { IsOverride: true, OverriddenMethod: not null } &&
+                method.Method.OverriddenMethod.ContainingType
+                    .ContainingAssembly is { Name: "GodotSharp" or "GodotSharpEditor" })
             {
-                source
-                    .Append("&trampoline_")
-                    .Append(parameterCount).Append("_").Append(methodName);
-            }
-            else
-            {
-                source
-                    .Append("aux_delegate_")
-                    .Append(parameterCount).Append("_").Append(methodName)
-                    .Append(".Method.MethodHandle.GetFunctionPointer()");
+                // Only do this for native virtual methods by checking that it is also in MethodName.
+                if (method.Method.OverriddenMethod.ContainingType.GetTypeMembers()
+                        .FirstOrDefault(s => s.Name == "MethodName")?
+                        .MemberNames.Any(name => name == method.Method.Name) ?? false)
+                {
+                    INamedTypeSymbol overriddenContainingType =
+                        method.Method.OverriddenMethod.ContainingType;
+
+                    DoAppendTrampoline(source, methodName, parameterCount,
+                        isStatic, isUnsafeAllowed, overriddenContainingType);
+                }
             }
 
-            source.Append(", isStatic: ").Append(method.Method.IsStatic ? "true" : "false");
-            source.Append("));\n");
+            static void DoAppendTrampoline(StringBuilder source,
+                string methodName, int parameterCount,
+                bool isStatic, bool isUnsafeAllowed,
+                INamedTypeSymbol? overriddenContainingType = null)
+            {
+                source.Append("            collector.TryAdd(new(");
+
+                if (overriddenContainingType != null)
+                    source.Append(overriddenContainingType.FullQualifiedNameIncludeGlobal()).Append(".");
+
+                source.Append("MethodName.@")
+                    .Append(methodName).Append(", ").Append(parameterCount)
+                    .Append("), new(");
+
+                if (isUnsafeAllowed)
+                {
+                    source
+                        .Append("&trampoline_")
+                        .Append(parameterCount).Append("_").Append(methodName);
+                }
+                else
+                {
+                    source
+                        .Append("aux_delegate_")
+                        .Append(parameterCount).Append("_").Append(methodName)
+                        .Append(".Method.MethodHandle.GetFunctionPointer()");
+                }
+
+                source.Append(", isStatic: ").Append(isStatic ? "true" : "false");
+                source.Append("));\n");
+            }
         }
 
         private static void GenerateMethodTrampoline(

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -272,31 +272,6 @@ namespace Godot.SourceGenerators
 
             source.Append("#pragma warning restore CS0109\n");
 
-            // Generate InvokeGodotClassStaticMethod
-
-            var godotClassStaticMethods = godotClassMethods.Where(m => m.Method.IsStatic).ToArray();
-
-            if (godotClassStaticMethods.Length > 0)
-            {
-                source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
-                source.Append(
-                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append(
-                    "    internal new static bool InvokeGodotClassStaticMethod(in godot_string_name method, ");
-                source.Append("NativeVariantPtrArgs args, out godot_variant ret)\n    {\n");
-
-                foreach (var method in godotClassStaticMethods)
-                {
-                    GenerateMethodInvoker(method, source);
-                }
-
-                source.Append("        ret = default;\n");
-                source.Append("        return false;\n");
-                source.Append("    }\n");
-
-                source.Append("#pragma warning restore CS0109\n");
-            }
-
             source.Append("}\n"); // partial class
 
             if (isInnerClass)
@@ -476,6 +451,7 @@ namespace Godot.SourceGenerators
                     .Append(".Method.MethodHandle.GetFunctionPointer()");
             }
 
+            source.Append(", isStatic: ").Append(method.Method.IsStatic ? "true" : "false");
             source.Append("));\n");
         }
 
@@ -558,58 +534,6 @@ namespace Godot.SourceGenerators
             else
             {
                 source.Append("            return default;\n");
-            }
-
-            source.Append("        }\n");
-        }
-
-        private static void GenerateMethodInvoker(
-            GodotMethodData method,
-            StringBuilder source
-        )
-        {
-            string methodName = method.Method.Name;
-
-            source.Append("        if (method == MethodName.@");
-            source.Append(methodName);
-            source.Append(" && args.Count == ");
-            source.Append(method.ParamTypes.Length);
-            source.Append(") {\n");
-
-            if (method.RetType != null)
-                source.Append("            var callRet = ");
-            else
-                source.Append("            ");
-
-            source.Append("@");
-            source.Append(methodName);
-            source.Append("(");
-
-            for (int i = 0; i < method.ParamTypes.Length; i++)
-            {
-                if (i != 0)
-                    source.Append(", ");
-
-                source.AppendNativeVariantToManagedExpr(string.Concat("args[", i.ToString(), "]"),
-                    method.ParamTypeSymbols[i], method.ParamTypes[i]);
-            }
-
-            source.Append(");\n");
-
-            if (method.RetType != null)
-            {
-                source.Append("            ret = ");
-
-                source.AppendManagedToNativeVariantExpr("callRet",
-                    method.RetType.Value.TypeSymbol, method.RetType.Value.MarshalType);
-                source.Append(";\n");
-
-                source.Append("            return true;\n");
-            }
-            else
-            {
-                source.Append("            ret = default;\n");
-                source.Append("            return true;\n");
             }
 
             source.Append("        }\n");

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -37,6 +37,7 @@ namespace Godot.SourceGenerators
 
                                 return true;
                             }
+
                             return false;
                         })
                         .Select(x => x.symbol)
@@ -76,9 +77,9 @@ namespace Godot.SourceGenerators
         )
         {
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
-            string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace ?
-                namespaceSymbol.FullQualifiedNameOmitGlobal() :
-                string.Empty;
+            string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace
+                ? namespaceSymbol.FullQualifiedNameOmitGlobal()
+                : string.Empty;
             bool hasNamespace = classNs.Length != 0;
 
             bool isInnerClass = symbol.ContainingType != null;
@@ -142,8 +143,9 @@ namespace Godot.SourceGenerators
                 .Append("    /// Cached StringNames for the methods contained in this class, for fast lookup.\n")
                 .Append("    /// </summary>\n");
 
-            source.Append(
-                $"    public new class MethodName : {symbol.BaseType!.FullQualifiedNameIncludeGlobal()}.MethodName {{\n");
+            source.Append("    public new class MethodName : ")
+                .Append(symbol.BaseType!.FullQualifiedNameIncludeGlobal())
+                .Append(".MethodName {\n");
 
             // Generate cached StringNames for methods and properties, for fast lookup
 
@@ -181,7 +183,8 @@ namespace Godot.SourceGenerators
                     .Append("    /// Do not call this method.\n")
                     .Append("    /// </summary>\n");
 
-                source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+                source.Append(
+                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
 
                 source.Append("    internal new static ")
                     .Append(ListType)
@@ -203,26 +206,84 @@ namespace Godot.SourceGenerators
                 source.Append("    }\n");
             }
 
-            source.Append("#pragma warning restore CS0109\n");
-
-            // Generate InvokeGodotClassMethod
+            // Generate GetGodotMethodNameToProxyNameMap
 
             if (godotClassMethods.Length > 0)
             {
-                source.Append("    /// <inheritdoc/>\n");
-                source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    protected override bool InvokeGodotClassMethod(in godot_string_name method, ");
-                source.Append("NativeVariantPtrArgs args, out godot_variant ret)\n    {\n");
+                const string DictType =
+                    "global::System.Collections.Generic.Dictionary<global::Godot.Bridge.MethodKey, global::Godot.StringName>";
+
+                source.Append(
+                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+                source.Append("    internal new static unsafe ")
+                    .Append(DictType)
+                    .Append(" GetGodotMethodNameToProxyNameMap()\n    {\n");
+
+                source.Append("        var nameToProxyNameMap = new ")
+                    .Append(DictType)
+                    .Append("(")
+                    .Append(godotClassMethods.Length)
+                    .Append(");\n");
 
                 foreach (var method in godotClassMethods)
                 {
-                    GenerateMethodInvoker(method, source);
+                    if (method.Method is { IsOverride: true, OverriddenMethod: not null } &&
+                        method.Method.OverriddenMethod.ContainingType.ContainingAssembly is
+                            { Name: "GodotSharp" or "GodotSharpEditor" })
+                    {
+                        // Only do this for native virtual methods by checking that it is also in MethodName.
+                        if (method.Method.OverriddenMethod.ContainingType.GetTypeMembers()
+                                .FirstOrDefault(s => s.Name == "MethodName")?
+                                .MemberNames.Any(name => name == method.Method.Name) ?? false)
+                        {
+                            INamedTypeSymbol castClassSymbol = method.Method.OverriddenMethod.ContainingType;
+                            int parameterCount = method.ParamTypes.Length;
+
+                            source.Append("        nameToProxyNameMap.Add(new(")
+                                .Append(castClassSymbol.FullQualifiedNameIncludeGlobal())
+                                .Append(".MethodName.@").Append(method.Method.Name)
+                                .Append(", ").Append(parameterCount)
+                                .Append("), MethodName.@")
+                                .Append(method.Method.Name)
+                                .Append(");\n");
+                        }
+                    }
                 }
 
-                source.Append("        return base.InvokeGodotClassMethod(method, args, out ret);\n");
-
+                source.Append("        return nameToProxyNameMap;\n");
                 source.Append("    }\n");
             }
+
+            // Generate GetGodotMethodTrampolines
+
+            if (godotClassMethods.Length > 0)
+            {
+                const string DictType =
+                    "global::System.Collections.Generic.Dictionary<global::Godot.Bridge.MethodKey, global::Godot.Bridge.MethodTrampoline>";
+
+                source.Append(
+                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+                source.Append("    internal new static unsafe ")
+                    .Append(DictType)
+                    .Append(" GetGodotMethodTrampolines()\n    {\n");
+
+                source.Append("        var trampolines = new ")
+                    .Append(DictType)
+                    .Append("(")
+                    .Append(godotClassMethods.Length)
+                    .Append(");\n");
+
+                foreach (var method in godotClassMethods)
+                {
+                    GenerateMethodTrampoline(symbol, method, source);
+                    AppendMethodTrampoline(source, method);
+                }
+
+                source.Append("        return trampolines;\n");
+                source.Append("    }\n");
+            }
+
+            source.Append("#pragma warning restore CS0109\n");
 
             // Generate InvokeGodotClassStaticMethod
 
@@ -231,8 +292,10 @@ namespace Godot.SourceGenerators
             if (godotClassStaticMethods.Length > 0)
             {
                 source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
-                source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static bool InvokeGodotClassStaticMethod(in godot_string_name method, ");
+                source.Append(
+                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+                source.Append(
+                    "    internal new static bool InvokeGodotClassStaticMethod(in godot_string_name method, ");
                 source.Append("NativeVariantPtrArgs args, out godot_variant ret)\n    {\n");
 
                 foreach (var method in godotClassStaticMethods)
@@ -245,24 +308,6 @@ namespace Godot.SourceGenerators
                 source.Append("    }\n");
 
                 source.Append("#pragma warning restore CS0109\n");
-            }
-
-            // Generate HasGodotClassMethod
-
-            if (distinctMethodNames.Length > 0)
-            {
-                source.Append("    /// <inheritdoc/>\n");
-                source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    protected override bool HasGodotClassMethod(in godot_string_name method)\n    {\n");
-
-                foreach (string methodName in distinctMethodNames)
-                {
-                    GenerateHasMethodEntry(methodName, source);
-                }
-
-                source.Append("        return base.HasGodotClassMethod(method);\n");
-
-                source.Append("    }\n");
             }
 
             source.Append("}\n"); // partial class
@@ -341,6 +386,7 @@ namespace Godot.SourceGenerators
                     .Append(propertyInfo.ClassName)
                     .Append("\")");
             }
+
             source.Append(")");
         }
 
@@ -410,15 +456,123 @@ namespace Godot.SourceGenerators
                 PropertyHint.None, string.Empty, propUsage, className, exported: false);
         }
 
-        private static void GenerateHasMethodEntry(
-            string methodName,
+        private static void AppendMethodTrampoline(StringBuilder source, GodotMethodData method)
+        {
+            string methodName = method.Method.Name;
+            int parameterCount = method.ParamTypes.Length;
+
+            source.Append("        trampolines.Add(new(MethodName.@")
+                .Append(methodName).Append(", ").Append(parameterCount)
+                .Append("), new global::Godot.Bridge.MethodTrampoline(&trampoline_")
+                .Append(parameterCount).Append("_").Append(methodName)
+                .Append("));\n");
+        }
+
+        private static void GenerateMethodTrampoline(
+            INamedTypeSymbol classSymbol,
+            GodotMethodData method,
             StringBuilder source
         )
         {
-            source.Append("        ");
-            source.Append("if (method == MethodName.@");
+            string methodName = method.Method.Name;
+            int parameterCount = method.ParamTypes.Length;
+
+            INamedTypeSymbol castClassSymbol = classSymbol;
+
+            // To match the behavior of InvokeGodotClassMethod, native virtual methods must
+            // be invoked on a variable of the method declaring type, not the overriding type.
+            // e.g.: '((Node)obj)._EnterTree' vs '((DerivedScriptClass)obj)._EnterTree'.
+            // These two will behave differently if the derived class hides the method
+            // (with the 'new' keyword) instead of overriding it.
+            if (method.Method is { IsOverride: true, OverriddenMethod: not null } &&
+                method.Method.OverriddenMethod.ContainingType.ContainingAssembly is
+                    { Name: "GodotSharp" or "GodotSharpEditor" })
+            {
+                // Only do this for native virtual methods by checking that it is also in MethodName.
+                // This is not only for correctness, but to also avoid issues with protected functions like Dispose(bool).
+                if (method.Method.OverriddenMethod.ContainingType.GetTypeMembers()
+                        .FirstOrDefault(s => s.Name == "MethodName")?
+                        .MemberNames.Any(name => name == method.Method.Name) ?? false)
+                {
+                    castClassSymbol = method.Method.OverriddenMethod.ContainingType;
+                }
+            }
+
+            bool isStaticMethod = method.Method.IsStatic;
+
+            source.Append("        [global::System.Runtime.InteropServices.UnmanagedCallersOnly]\n");
+            source.Append("        static void trampoline_")
+                .Append(parameterCount).Append("_").Append(methodName);
+
+            source.Append("(global::System.IntPtr godotObjectGCHandle, godot_variant** args, int argCount, ");
+            source.Append("godot_variant_call_error* outRefCallError, godot_variant* outRet)\n        {\n");
+
+            source.Append("          try {\n");
+
+            source.Append("            if (argCount != ");
+            source.Append(parameterCount);
+            source.Append(") {\n");
+            source.Append("                *outRet = default;\n");
+            source.Append("                *outRefCallError = ")
+                .Append("godot_variant_call_error.CreateInvalidArgumentCountError(expected: ")
+                .Append(parameterCount).Append(", provided: argCount);\n");
+            source.Append("                return;\n");
+            source.Append("            }\n");
+
+            if (!isStaticMethod)
+            {
+                source
+                    .Append("            var godotObject = (").Append(castClassSymbol.FullQualifiedNameIncludeGlobal())
+                    .Append(
+                        ")global::System.Runtime.InteropServices.GCHandle.FromIntPtr(godotObjectGCHandle).Target;\n")
+                    .Append("            if (godotObject == null) {\n")
+                    .Append("                *outRet = default;\n")
+                    .Append("                (*outRefCallError).Error = godot_variant_call_error_error.")
+                    .Append("GODOT_CALL_ERROR_CALL_ERROR_INSTANCE_IS_NULL;\n")
+                    .Append("                return;\n")
+                    .Append("            }\n");
+            }
+
+            if (method.RetType != null)
+                source.Append("            var callRet = ");
+            else
+                source.Append("            ");
+
+            if (!isStaticMethod)
+                source.Append("godotObject.");
+            source.Append("@");
             source.Append(methodName);
-            source.Append(") {\n           return true;\n        }\n");
+            source.Append("(");
+
+            for (int i = 0; i < method.ParamTypes.Length; i++)
+            {
+                if (i != 0)
+                    source.Append(", ");
+
+                source.AppendNativeVariantToManagedExpr(string.Concat("*(args[", i.ToString(), "])"),
+                    method.ParamTypeSymbols[i], method.ParamTypes[i]);
+            }
+
+            source.Append(");\n");
+
+            if (method.RetType != null)
+            {
+                source.Append("            *outRet = ");
+
+                source.AppendManagedToNativeVariantExpr("callRet",
+                    method.RetType.Value.TypeSymbol, method.RetType.Value.MarshalType);
+                source.Append(";\n");
+            }
+            else
+            {
+                source.Append("            *outRet = default;\n");
+            }
+
+            source.Append("          } catch (global::System.Exception e) {\n");
+            source.Append("              global::Godot.NativeInterop.ExceptionUtils.LogException(e);\n");
+            source.Append("          }\n");
+
+            source.Append("        }\n");
         }
 
         private static void GenerateMethodInvoker(

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -209,16 +209,14 @@ namespace Godot.SourceGenerators
                 source.Append("    }\n");
             }
 
-            // Generate GetGodotMethodNameToProxyNameMap
+            source.Append("    private static partial class GodotInternal\n    {\n");
 
-            if (godotClassMethods.Length > 0)
+            // Generate GetGodotMethodNameToProxyNameMap
             {
                 const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.NameToProxyNameMapCollector";
 
-                source.Append(
-                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static void GetGodotMethodNameToProxyNameMap(")
-                    .Append(CollectorType).Append(" collector)\n    {\n");
+                source.Append("        public new static void GetGodotMethodNameToProxyNameMap(")
+                    .Append(CollectorType).Append(" collector)\n        {\n");
 
                 foreach (var method in godotClassMethods)
                 {
@@ -234,7 +232,7 @@ namespace Godot.SourceGenerators
                             INamedTypeSymbol castClassSymbol = method.Method.OverriddenMethod.ContainingType;
                             int parameterCount = method.ParamTypes.Length;
 
-                            source.Append("        collector.TryAdd(new(")
+                            source.Append("            collector.TryAdd(new(")
                                 .Append(castClassSymbol.FullQualifiedNameIncludeGlobal())
                                 .Append(".MethodName.@").Append(method.Method.Name)
                                 .Append(", ").Append(parameterCount)
@@ -245,21 +243,17 @@ namespace Godot.SourceGenerators
                     }
                 }
 
-                source.Append("    }\n");
+                source.Append("        }\n");
             }
 
             // Generate GetGodotMethodTrampolines
-
-            if (godotClassMethods.Length > 0)
             {
                 const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.MethodTrampolineCollector";
 
-                source.Append(
-                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static ")
+                source.Append("        public new static ")
                     .Append(isUnsafeAllowed ? "unsafe " : "")
                     .Append("void GetGodotMethodTrampolines(")
-                    .Append(CollectorType).Append(" collector)\n    {\n");
+                    .Append(CollectorType).Append(" collector)\n        {\n");
 
                 foreach (var method in godotClassMethods)
                 {
@@ -267,8 +261,10 @@ namespace Godot.SourceGenerators
                     AppendMethodTrampoline(source, method, isUnsafeAllowed);
                 }
 
-                source.Append("    }\n");
+                source.Append("        }\n");
             }
+
+            source.Append("    }\n"); // partial class GodotInternal
 
             source.Append("#pragma warning restore CS0109\n");
 
@@ -425,7 +421,7 @@ namespace Godot.SourceGenerators
 
             if (!isUnsafeAllowed)
             {
-                source.Append("        var aux_delegate_")
+                source.Append("            var aux_delegate_")
                     .Append(parameterCount).Append("_").Append(methodName)
                     .Append(" = ")
                     .Append("trampoline_")
@@ -433,7 +429,7 @@ namespace Godot.SourceGenerators
                     .Append(";\n");
             }
 
-            source.Append("        collector.TryAdd(new(MethodName.@")
+            source.Append("            collector.TryAdd(new(MethodName.@")
                 .Append(methodName).Append(", ").Append(parameterCount)
                 .Append("), new(");
 
@@ -488,24 +484,24 @@ namespace Godot.SourceGenerators
             bool isStaticMethod = method.Method.IsStatic;
 
             source
-                .Append("        static godot_variant trampoline_")
+                .Append("            static godot_variant trampoline_")
                 .Append(parameterCount).Append("_").Append(methodName)
                 .Append("(object godotObject, NativeVariantPtrArgs args, ")
-                .Append("ref godot_variant_call_error callError)\n        {\n");
+                .Append("ref godot_variant_call_error callError)\n            {\n");
 
-            source.Append("            if (args.Count != ");
+            source.Append("                if (args.Count != ");
             source.Append(parameterCount);
             source.Append(") {\n");
-            source.Append("                callError = ")
+            source.Append("                    callError = ")
                 .Append("godot_variant_call_error.CreateInvalidArgumentCountError(expected: ")
                 .Append(parameterCount).Append(", provided: args.Count);\n");
-            source.Append("                return default;\n");
-            source.Append("            }\n");
+            source.Append("                    return default;\n");
+            source.Append("                }\n");
 
             if (method.RetType != null)
-                source.Append("            var callRet = ");
+                source.Append("                var callRet = ");
             else
-                source.Append("            ");
+                source.Append("                ");
 
             if (!isStaticMethod)
                 source.Append("((").Append(castClassSymbol.FullQualifiedNameIncludeGlobal()).Append(")godotObject).");
@@ -526,17 +522,17 @@ namespace Godot.SourceGenerators
 
             if (method.RetType != null)
             {
-                source.Append("            return ");
+                source.Append("                return ");
                 source.AppendManagedToNativeVariantExpr("callRet",
                     method.RetType.Value.TypeSymbol, method.RetType.Value.MarshalType);
                 source.Append(";\n");
             }
             else
             {
-                source.Append("            return default;\n");
+                source.Append("                return default;\n");
             }
 
-            source.Append("        }\n");
+            source.Append("            }\n");
         }
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -210,20 +210,12 @@ namespace Godot.SourceGenerators
 
             if (godotClassMethods.Length > 0)
             {
-                const string DictType =
-                    "global::System.Collections.Generic.Dictionary<global::Godot.Bridge.MethodKey, global::Godot.StringName>";
+                const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.NameToProxyNameMapCollector";
 
                 source.Append(
                     "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static ")
-                    .Append(DictType)
-                    .Append(" GetGodotMethodNameToProxyNameMap()\n    {\n");
-
-                source.Append("        var nameToProxyNameMap = new ")
-                    .Append(DictType)
-                    .Append("(")
-                    .Append(godotClassMethods.Length)
-                    .Append(");\n");
+                source.Append("    internal new static void GetGodotMethodNameToProxyNameMap(")
+                    .Append(CollectorType).Append(" collector)\n    {\n");
 
                 foreach (var method in godotClassMethods)
                 {
@@ -239,7 +231,7 @@ namespace Godot.SourceGenerators
                             INamedTypeSymbol castClassSymbol = method.Method.OverriddenMethod.ContainingType;
                             int parameterCount = method.ParamTypes.Length;
 
-                            source.Append("        nameToProxyNameMap.Add(new(")
+                            source.Append("        collector.TryAdd(new(")
                                 .Append(castClassSymbol.FullQualifiedNameIncludeGlobal())
                                 .Append(".MethodName.@").Append(method.Method.Name)
                                 .Append(", ").Append(parameterCount)
@@ -250,7 +242,6 @@ namespace Godot.SourceGenerators
                     }
                 }
 
-                source.Append("        return nameToProxyNameMap;\n");
                 source.Append("    }\n");
             }
 
@@ -258,20 +249,12 @@ namespace Godot.SourceGenerators
 
             if (godotClassMethods.Length > 0)
             {
-                const string DictType =
-                    "global::System.Collections.Generic.Dictionary<global::Godot.Bridge.MethodKey, global::Godot.Bridge.MethodTrampoline>";
+                const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.MethodTrampolineCollector";
 
                 source.Append(
                     "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static unsafe ")
-                    .Append(DictType)
-                    .Append(" GetGodotMethodTrampolines()\n    {\n");
-
-                source.Append("        var trampolines = new ")
-                    .Append(DictType)
-                    .Append("(")
-                    .Append(godotClassMethods.Length)
-                    .Append(");\n");
+                source.Append("    internal new static unsafe void GetGodotMethodTrampolines(")
+                    .Append(CollectorType).Append(" collector)\n    {\n");
 
                 foreach (var method in godotClassMethods)
                 {
@@ -279,7 +262,6 @@ namespace Godot.SourceGenerators
                     AppendMethodTrampoline(source, method);
                 }
 
-                source.Append("        return trampolines;\n");
                 source.Append("    }\n");
             }
 
@@ -461,7 +443,7 @@ namespace Godot.SourceGenerators
             string methodName = method.Method.Name;
             int parameterCount = method.ParamTypes.Length;
 
-            source.Append("        trampolines.Add(new(MethodName.@")
+            source.Append("        collector.TryAdd(new(MethodName.@")
                 .Append(methodName).Append(", ").Append(parameterCount)
                 .Append("), new(&trampoline_")
                 .Append(parameterCount).Append("_").Append(methodName)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -169,7 +169,7 @@ namespace Godot.SourceGenerators
                 source.Append("\";\n");
             }
 
-            source.Append("    }\n"); // class GodotInternal
+            source.Append("    }\n"); // end of class MethodName
 
             // Generate GetGodotMethodList
 
@@ -215,7 +215,7 @@ namespace Godot.SourceGenerators
 
                 source.Append(
                     "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static unsafe ")
+                source.Append("    internal new static ")
                     .Append(DictType)
                     .Append(" GetGodotMethodNameToProxyNameMap()\n    {\n");
 
@@ -228,8 +228,8 @@ namespace Godot.SourceGenerators
                 foreach (var method in godotClassMethods)
                 {
                     if (method.Method is { IsOverride: true, OverriddenMethod: not null } &&
-                        method.Method.OverriddenMethod.ContainingType.ContainingAssembly is
-                            { Name: "GodotSharp" or "GodotSharpEditor" })
+                        method.Method.OverriddenMethod.ContainingType
+                            .ContainingAssembly is { Name: "GodotSharp" or "GodotSharpEditor" })
                     {
                         // Only do this for native virtual methods by checking that it is also in MethodName.
                         if (method.Method.OverriddenMethod.ContainingType.GetTypeMembers()
@@ -463,7 +463,7 @@ namespace Godot.SourceGenerators
 
             source.Append("        trampolines.Add(new(MethodName.@")
                 .Append(methodName).Append(", ").Append(parameterCount)
-                .Append("), new global::Godot.Bridge.MethodTrampoline(&trampoline_")
+                .Append("), new(&trampoline_")
                 .Append(parameterCount).Append("_").Append(methodName)
                 .Append("));\n");
         }
@@ -485,8 +485,8 @@ namespace Godot.SourceGenerators
             // These two will behave differently if the derived class hides the method
             // (with the 'new' keyword) instead of overriding it.
             if (method.Method is { IsOverride: true, OverriddenMethod: not null } &&
-                method.Method.OverriddenMethod.ContainingType.ContainingAssembly is
-                    { Name: "GodotSharp" or "GodotSharpEditor" })
+                method.Method.OverriddenMethod.ContainingType
+                    .ContainingAssembly is { Name: "GodotSharp" or "GodotSharpEditor" })
             {
                 // Only do this for native virtual methods by checking that it is also in MethodName.
                 // This is not only for correctness, but to also avoid issues with protected functions like Dispose(bool).
@@ -500,38 +500,20 @@ namespace Godot.SourceGenerators
 
             bool isStaticMethod = method.Method.IsStatic;
 
-            source.Append("        [global::System.Runtime.InteropServices.UnmanagedCallersOnly]\n");
-            source.Append("        static void trampoline_")
-                .Append(parameterCount).Append("_").Append(methodName);
+            source
+                .Append("        static godot_variant trampoline_")
+                .Append(parameterCount).Append("_").Append(methodName)
+                .Append("(object godotObject, NativeVariantPtrArgs args, ")
+                .Append("ref godot_variant_call_error callError)\n        {\n");
 
-            source.Append("(global::System.IntPtr godotObjectGCHandle, godot_variant** args, int argCount, ");
-            source.Append("godot_variant_call_error* outRefCallError, godot_variant* outRet)\n        {\n");
-
-            source.Append("          try {\n");
-
-            source.Append("            if (argCount != ");
+            source.Append("            if (args.Count != ");
             source.Append(parameterCount);
             source.Append(") {\n");
-            source.Append("                *outRet = default;\n");
-            source.Append("                *outRefCallError = ")
+            source.Append("                callError = ")
                 .Append("godot_variant_call_error.CreateInvalidArgumentCountError(expected: ")
-                .Append(parameterCount).Append(", provided: argCount);\n");
-            source.Append("                return;\n");
+                .Append(parameterCount).Append(", provided: args.Count);\n");
+            source.Append("                return default;\n");
             source.Append("            }\n");
-
-            if (!isStaticMethod)
-            {
-                source
-                    .Append("            var godotObject = (").Append(castClassSymbol.FullQualifiedNameIncludeGlobal())
-                    .Append(
-                        ")global::System.Runtime.InteropServices.GCHandle.FromIntPtr(godotObjectGCHandle).Target;\n")
-                    .Append("            if (godotObject == null) {\n")
-                    .Append("                *outRet = default;\n")
-                    .Append("                (*outRefCallError).Error = godot_variant_call_error_error.")
-                    .Append("GODOT_CALL_ERROR_CALL_ERROR_INSTANCE_IS_NULL;\n")
-                    .Append("                return;\n")
-                    .Append("            }\n");
-            }
 
             if (method.RetType != null)
                 source.Append("            var callRet = ");
@@ -539,7 +521,7 @@ namespace Godot.SourceGenerators
                 source.Append("            ");
 
             if (!isStaticMethod)
-                source.Append("godotObject.");
+                source.Append("((").Append(castClassSymbol.FullQualifiedNameIncludeGlobal()).Append(")godotObject).");
             source.Append("@");
             source.Append(methodName);
             source.Append("(");
@@ -549,7 +531,7 @@ namespace Godot.SourceGenerators
                 if (i != 0)
                     source.Append(", ");
 
-                source.AppendNativeVariantToManagedExpr(string.Concat("*(args[", i.ToString(), "])"),
+                source.AppendNativeVariantToManagedExpr(string.Concat("args[", i.ToString(), "]"),
                     method.ParamTypeSymbols[i], method.ParamTypes[i]);
             }
 
@@ -557,20 +539,15 @@ namespace Godot.SourceGenerators
 
             if (method.RetType != null)
             {
-                source.Append("            *outRet = ");
-
+                source.Append("            return ");
                 source.AppendManagedToNativeVariantExpr("callRet",
                     method.RetType.Value.TypeSymbol, method.RetType.Value.MarshalType);
                 source.Append(";\n");
             }
             else
             {
-                source.Append("            *outRet = default;\n");
+                source.Append("            return default;\n");
             }
-
-            source.Append("          } catch (global::System.Exception e) {\n");
-            source.Append("              global::Godot.NativeInterop.ExceptionUtils.LogException(e);\n");
-            source.Append("          }\n");
 
             source.Append("        }\n");
         }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -76,6 +76,9 @@ namespace Godot.SourceGenerators
             INamedTypeSymbol symbol
         )
         {
+            var options = context.Compilation.Options as Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions;
+            bool isUnsafeAllowed = options?.AllowUnsafe ?? false;
+
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
             string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace
                 ? namespaceSymbol.FullQualifiedNameOmitGlobal()
@@ -253,13 +256,15 @@ namespace Godot.SourceGenerators
 
                 source.Append(
                     "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static unsafe void GetGodotMethodTrampolines(")
+                source.Append("    internal new static ")
+                    .Append(isUnsafeAllowed ? "unsafe " : "")
+                    .Append("void GetGodotMethodTrampolines(")
                     .Append(CollectorType).Append(" collector)\n    {\n");
 
                 foreach (var method in godotClassMethods)
                 {
                     GenerateMethodTrampoline(symbol, method, source);
-                    AppendMethodTrampoline(source, method);
+                    AppendMethodTrampoline(source, method, isUnsafeAllowed);
                 }
 
                 source.Append("    }\n");
@@ -438,16 +443,40 @@ namespace Godot.SourceGenerators
                 PropertyHint.None, string.Empty, propUsage, className, exported: false);
         }
 
-        private static void AppendMethodTrampoline(StringBuilder source, GodotMethodData method)
+        private static void AppendMethodTrampoline(StringBuilder source, GodotMethodData method, bool isUnsafeAllowed)
         {
             string methodName = method.Method.Name;
             int parameterCount = method.ParamTypes.Length;
 
+            if (!isUnsafeAllowed)
+            {
+                source.Append("        var aux_delegate_")
+                    .Append(parameterCount).Append("_").Append(methodName)
+                    .Append(" = ")
+                    .Append("trampoline_")
+                    .Append(parameterCount).Append("_").Append(methodName)
+                    .Append(";\n");
+            }
+
             source.Append("        collector.TryAdd(new(MethodName.@")
                 .Append(methodName).Append(", ").Append(parameterCount)
-                .Append("), new(&trampoline_")
-                .Append(parameterCount).Append("_").Append(methodName)
-                .Append("));\n");
+                .Append("), new(");
+
+            if (isUnsafeAllowed)
+            {
+                source
+                    .Append("&trampoline_")
+                    .Append(parameterCount).Append("_").Append(methodName);
+            }
+            else
+            {
+                source
+                    .Append("aux_delegate_")
+                    .Append(parameterCount).Append("_").Append(methodName)
+                    .Append(".Method.MethodHandle.GetFunctionPointer()");
+            }
+
+            source.Append("));\n");
         }
 
         private static void GenerateMethodTrampoline(

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -209,11 +209,12 @@ namespace Godot.SourceGenerators
                 source.Append("    }\n");
             }
 
-            source.Append("    private static partial class GodotInternal\n    {\n");
+            source.Append("    ").Append(symbol.IsSealed ? "" : "protected ")
+                .Append("internal new static partial class GodotInternal\n    {\n");
 
             // Generate GetGodotMethodTrampolines
             {
-                const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.MethodTrampolineCollector";
+                const string CollectorType = "global::Godot.Bridge.MethodTrampolineCollector";
 
                 source.Append("        public new static ")
                     .Append(isUnsafeAllowed ? "unsafe " : "")

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -64,6 +64,9 @@ namespace Godot.SourceGenerators
             INamedTypeSymbol symbol
         )
         {
+            var options = context.Compilation.Options as Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions;
+            bool isUnsafeAllowed = options?.AllowUnsafe ?? false;
+
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
             string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace
                 ? namespaceSymbol.FullQualifiedNameOmitGlobal()
@@ -183,7 +186,9 @@ namespace Godot.SourceGenerators
 
                     source.Append(
                         "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                    source.Append("    internal new static unsafe void GetGodotPropertyTrampolines(")
+                    source.Append("    internal new static ")
+                        .Append(isUnsafeAllowed ? "unsafe " : "")
+                        .Append("void GetGodotPropertyTrampolines(")
                         .Append(CollectorType).Append(" collector)\n    {\n");
 
                     // Generate trampolines
@@ -219,7 +224,7 @@ namespace Godot.SourceGenerators
 
                     foreach (var property in godotClassProperties)
                     {
-                        AppendPropertyTrampolines(source, property.PropertySymbol.Name,
+                        AppendPropertyTrampolines(source, property.PropertySymbol.Name, isUnsafeAllowed,
                             hasGetter: !property.PropertySymbol.IsWriteOnly,
                             hasSetter: !property.PropertySymbol.IsReadOnly &&
                                        !property.PropertySymbol.SetMethod!.IsInitOnly);
@@ -227,7 +232,7 @@ namespace Godot.SourceGenerators
 
                     foreach (var field in godotClassFields)
                     {
-                        AppendPropertyTrampolines(source, field.FieldSymbol.Name,
+                        AppendPropertyTrampolines(source, field.FieldSymbol.Name, isUnsafeAllowed,
                             hasGetter: true,
                             hasSetter: !field.FieldSymbol.IsReadOnly);
                     }
@@ -319,23 +324,66 @@ namespace Godot.SourceGenerators
         }
 
         private static void AppendPropertyTrampolines(StringBuilder source,
-            string propertyMemberName, bool hasGetter, bool hasSetter)
+            string propertyMemberName, bool isUnsafeAllowed, bool hasGetter, bool hasSetter)
         {
+            if (!isUnsafeAllowed)
+            {
+                if (hasGetter)
+                {
+                    source.Append("        var aux_delegate_get_").Append(propertyMemberName)
+                        .Append(" = ")
+                        .Append("trampoline_get_").Append(propertyMemberName)
+                        .Append(";\n");
+                }
+
+                if (hasSetter)
+                {
+                    source.Append("        var aux_delegate_set_").Append(propertyMemberName)
+                        .Append(" = ")
+                        .Append("trampoline_set_").Append(propertyMemberName)
+                        .Append(";\n");
+                }
+            }
+
             source.Append("        collector.TryAdd(PropertyName.@")
                 .Append(propertyMemberName)
                 .Append(", (new(");
 
             if (hasGetter)
-                source.Append("&trampoline_get_").Append(propertyMemberName);
+            {
+                if (isUnsafeAllowed)
+                {
+                    source.Append("&trampoline_get_").Append(propertyMemberName);
+                }
+                else
+                {
+                    source.Append("aux_delegate_get_").Append(propertyMemberName)
+                        .Append(".Method.MethodHandle.GetFunctionPointer()");
+                }
+            }
             else
-                source.Append("null");
+            {
+                source.Append(isUnsafeAllowed ? "null" : "global::System.IntPtr.Zero");
+            }
 
             source.Append("), new(");
 
             if (hasSetter)
-                source.Append("&trampoline_set_").Append(propertyMemberName);
+            {
+                if (isUnsafeAllowed)
+                {
+                    source.Append("&trampoline_set_").Append(propertyMemberName);
+                }
+                else
+                {
+                    source.Append("aux_delegate_set_").Append(propertyMemberName)
+                        .Append(".Method.MethodHandle.GetFunctionPointer()");
+                }
+            }
             else
-                source.Append("null");
+            {
+                source.Append(isUnsafeAllowed ? "null" : "global::System.IntPtr.Zero");
+            }
 
             source.Append(")));\n");
         }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -137,8 +137,9 @@ namespace Godot.SourceGenerators
                     "    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.\n")
                 .Append("    /// </summary>\n");
 
-            source.Append(
-                $"    public new class PropertyName : {symbol.BaseType!.FullQualifiedNameIncludeGlobal()}.PropertyName {{\n");
+            source.Append("    public new class PropertyName : ")
+                .Append(symbol.BaseType!.FullQualifiedNameIncludeGlobal())
+                .Append(".PropertyName {\n");
 
             // Generate cached StringNames for methods and properties, for fast lookup
 
@@ -178,68 +179,70 @@ namespace Godot.SourceGenerators
 
             source.Append("    }\n"); // end of class PropertyName
 
-            if (godotClassProperties.Length > 0 || godotClassFields.Length > 0)
+            source.Append("    private static partial class GodotInternal\n    {\n");
+
+            // Generate GetGodotMethodTrampolines
             {
-                // Generate GetGodotMethodTrampolines
+                const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.PropertyTrampolineCollector";
+
+                source.Append("        internal new static ")
+                    .Append(isUnsafeAllowed ? "unsafe " : "")
+                    .Append("void GetGodotPropertyTrampolines(")
+                    .Append(CollectorType).Append(" collector)\n        {\n");
+
+                // Generate trampolines
+
+                foreach (var property in godotClassProperties)
                 {
-                    const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.PropertyTrampolineCollector";
-
-                    source.Append(
-                        "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                    source.Append("    internal new static ")
-                        .Append(isUnsafeAllowed ? "unsafe " : "")
-                        .Append("void GetGodotPropertyTrampolines(")
-                        .Append(CollectorType).Append(" collector)\n    {\n");
-
-                    // Generate trampolines
-
-                    foreach (var property in godotClassProperties)
+                    if (!property.PropertySymbol.IsWriteOnly)
                     {
-                        if (!property.PropertySymbol.IsWriteOnly)
-                        {
-                            GeneratePropertyGetterTrampoline(symbol, property.PropertySymbol.Name,
-                                property.PropertySymbol.Type, property.Type, source);
-                        }
-
-                        if (!property.PropertySymbol.IsReadOnly && !property.PropertySymbol.SetMethod!.IsInitOnly)
-                        {
-                            GeneratePropertySetterTrampoline(symbol, property.PropertySymbol.Name,
-                                property.PropertySymbol.Type, property.Type, source);
-                        }
+                        GeneratePropertyGetterTrampoline(symbol, property.PropertySymbol.Name,
+                            property.PropertySymbol.Type, property.Type, source);
                     }
 
-                    foreach (var field in godotClassFields)
+                    if (!property.PropertySymbol.IsReadOnly && !property.PropertySymbol.SetMethod!.IsInitOnly)
                     {
-                        GeneratePropertyGetterTrampoline(symbol, field.FieldSymbol.Name,
-                            field.FieldSymbol.Type, field.Type, source);
-
-                        if (!field.FieldSymbol.IsReadOnly)
-                        {
-                            GeneratePropertySetterTrampoline(symbol, field.FieldSymbol.Name,
-                                field.FieldSymbol.Type, field.Type, source);
-                        }
+                        GeneratePropertySetterTrampoline(symbol, property.PropertySymbol.Name,
+                            property.PropertySymbol.Type, property.Type, source);
                     }
-
-                    // Append trampolines
-
-                    foreach (var property in godotClassProperties)
-                    {
-                        AppendPropertyTrampolines(source, property.PropertySymbol.Name, isUnsafeAllowed,
-                            hasGetter: !property.PropertySymbol.IsWriteOnly,
-                            hasSetter: !property.PropertySymbol.IsReadOnly &&
-                                       !property.PropertySymbol.SetMethod!.IsInitOnly);
-                    }
-
-                    foreach (var field in godotClassFields)
-                    {
-                        AppendPropertyTrampolines(source, field.FieldSymbol.Name, isUnsafeAllowed,
-                            hasGetter: true,
-                            hasSetter: !field.FieldSymbol.IsReadOnly);
-                    }
-
-                    source.Append("    }\n");
                 }
 
+                foreach (var field in godotClassFields)
+                {
+                    GeneratePropertyGetterTrampoline(symbol, field.FieldSymbol.Name,
+                        field.FieldSymbol.Type, field.Type, source);
+
+                    if (!field.FieldSymbol.IsReadOnly)
+                    {
+                        GeneratePropertySetterTrampoline(symbol, field.FieldSymbol.Name,
+                            field.FieldSymbol.Type, field.Type, source);
+                    }
+                }
+
+                // Append trampolines
+
+                foreach (var property in godotClassProperties)
+                {
+                    AppendPropertyTrampolines(source, property.PropertySymbol.Name, isUnsafeAllowed,
+                        hasGetter: !property.PropertySymbol.IsWriteOnly,
+                        hasSetter: !property.PropertySymbol.IsReadOnly &&
+                                   !property.PropertySymbol.SetMethod!.IsInitOnly);
+                }
+
+                foreach (var field in godotClassFields)
+                {
+                    AppendPropertyTrampolines(source, field.FieldSymbol.Name, isUnsafeAllowed,
+                        hasGetter: true,
+                        hasSetter: !field.FieldSymbol.IsReadOnly);
+                }
+
+                source.Append("        }\n");
+            }
+
+            source.Append("    }\n"); // partial class GodotInternal
+
+            if (godotClassProperties.Length > 0 || godotClassFields.Length > 0)
+            {
                 // Generate GetGodotPropertyList
 
                 const string DictionaryType =
@@ -297,9 +300,9 @@ namespace Godot.SourceGenerators
 
                 source.Append("        return properties;\n");
                 source.Append("    }\n");
-
-                source.Append("#pragma warning restore CS0109\n");
             }
+
+            source.Append("#pragma warning restore CS0109\n");
 
             source.Append("}\n"); // partial class
 
@@ -330,7 +333,7 @@ namespace Godot.SourceGenerators
             {
                 if (hasGetter)
                 {
-                    source.Append("        var aux_delegate_get_").Append(propertyMemberName)
+                    source.Append("            var aux_delegate_get_").Append(propertyMemberName)
                         .Append(" = ")
                         .Append("trampoline_get_").Append(propertyMemberName)
                         .Append(";\n");
@@ -338,14 +341,14 @@ namespace Godot.SourceGenerators
 
                 if (hasSetter)
                 {
-                    source.Append("        var aux_delegate_set_").Append(propertyMemberName)
+                    source.Append("            var aux_delegate_set_").Append(propertyMemberName)
                         .Append(" = ")
                         .Append("trampoline_set_").Append(propertyMemberName)
                         .Append(";\n");
                 }
             }
 
-            source.Append("        collector.TryAdd(PropertyName.@")
+            source.Append("            collector.TryAdd(PropertyName.@")
                 .Append(propertyMemberName)
                 .Append(", (new(");
 
@@ -397,19 +400,19 @@ namespace Godot.SourceGenerators
         )
         {
             source
-                .Append("        static godot_variant trampoline_get_").Append(propertyMemberName)
-                .Append("(object godotObject)\n        {\n");
+                .Append("            static godot_variant trampoline_get_").Append(propertyMemberName)
+                .Append("(object godotObject)\n            {\n");
 
             source
-                .Append("            var ret = ((").Append(classSymbol.FullQualifiedNameIncludeGlobal())
+                .Append("                var ret = ((").Append(classSymbol.FullQualifiedNameIncludeGlobal())
                 .Append(")godotObject).@")
                 .Append(propertyMemberName).Append(";\n");
             source
-                .Append("            return ")
+                .Append("                return ")
                 .AppendManagedToNativeVariantExpr("ret", propertyTypeSymbol, propertyMarshalType)
                 .Append(";\n");
 
-            source.Append("        }\n");
+            source.Append("            }\n");
         }
 
         private static void GeneratePropertySetterTrampoline(
@@ -421,18 +424,18 @@ namespace Godot.SourceGenerators
         )
         {
             source
-                .Append("        static void trampoline_set_").Append(propertyMemberName)
-                .Append("(object godotObject, in godot_variant value)\n        {\n");
+                .Append("            static void trampoline_set_").Append(propertyMemberName)
+                .Append("(object godotObject, in godot_variant value)\n            {\n");
 
             source
-                .Append("            ((").Append(classSymbol.FullQualifiedNameIncludeGlobal())
+                .Append("                ((").Append(classSymbol.FullQualifiedNameIncludeGlobal())
                 .Append(")godotObject).@")
                 .Append(propertyMemberName)
                 .Append(" = ")
                 .AppendNativeVariantToManagedExpr("value", propertyTypeSymbol, propertyMarshalType)
                 .Append(";\n");
 
-            source.Append("        }\n");
+            source.Append("            }\n");
         }
 
         private static void AppendGroupingPropertyInfo(StringBuilder source, PropertyInfo propertyInfo)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -179,20 +179,12 @@ namespace Godot.SourceGenerators
             {
                 // Generate GetGodotMethodTrampolines
                 {
-                    const string DictType =
-                        "global::System.Collections.Generic.Dictionary<global::Godot.StringName, (global::Godot.Bridge.PropertyGetterTrampoline getterTramp, global::Godot.Bridge.PropertySetterTrampoline setterTramp)>";
+                    const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.PropertyTrampolineCollector";
 
                     source.Append(
                         "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                    source.Append("    internal new static unsafe ")
-                        .Append(DictType)
-                        .Append(" GetGodotPropertyTrampolines()\n    {\n");
-
-                    source.Append("        var trampolines = new ")
-                        .Append(DictType)
-                        .Append("(")
-                        .Append(godotClassProperties.Length + godotClassFields.Length)
-                        .Append(");\n");
+                    source.Append("    internal new static unsafe void GetGodotPropertyTrampolines(")
+                        .Append(CollectorType).Append(" collector)\n    {\n");
 
                     // Generate trampolines
 
@@ -240,7 +232,6 @@ namespace Godot.SourceGenerators
                             hasSetter: !field.FieldSymbol.IsReadOnly);
                     }
 
-                    source.Append("        return trampolines;\n");
                     source.Append("    }\n");
                 }
 
@@ -330,7 +321,7 @@ namespace Godot.SourceGenerators
         private static void AppendPropertyTrampolines(StringBuilder source,
             string propertyMemberName, bool hasGetter, bool hasSetter)
         {
-            source.Append("        trampolines.Add(PropertyName.@")
+            source.Append("        collector.TryAdd(PropertyName.@")
                 .Append(propertyMemberName)
                 .Append(", (new(");
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -39,6 +39,7 @@ namespace Godot.SourceGenerators
 
                                 return true;
                             }
+
                             return false;
                         })
                         .Select(x => x.symbol)
@@ -64,9 +65,9 @@ namespace Godot.SourceGenerators
         )
         {
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
-            string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace ?
-                namespaceSymbol.FullQualifiedNameOmitGlobal() :
-                string.Empty;
+            string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace
+                ? namespaceSymbol.FullQualifiedNameOmitGlobal()
+                : string.Empty;
             bool hasNamespace = classNs.Length != 0;
 
             bool isInnerClass = symbol.ContainingType != null;
@@ -129,7 +130,8 @@ namespace Godot.SourceGenerators
             source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
 
             source.Append("    /// <summary>\n")
-                .Append("    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.\n")
+                .Append(
+                    "    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.\n")
                 .Append("    /// </summary>\n");
 
             source.Append(
@@ -175,82 +177,87 @@ namespace Godot.SourceGenerators
 
             if (godotClassProperties.Length > 0 || godotClassFields.Length > 0)
             {
-
-                // Generate SetGodotClassPropertyValue
-
-                bool allPropertiesAreReadOnly = godotClassFields.All(fi => fi.FieldSymbol.IsReadOnly) &&
-                                                godotClassProperties.All(pi => pi.PropertySymbol.IsReadOnly || pi.PropertySymbol.SetMethod!.IsInitOnly);
-
-                if (!allPropertiesAreReadOnly)
+                // Generate GetGodotMethodTrampolines
                 {
-                    source.Append("    /// <inheritdoc/>\n");
-                    source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                    source.Append("    protected override bool SetGodotClassPropertyValue(in godot_string_name name, ");
-                    source.Append("in godot_variant value)\n    {\n");
+                    const string DictType =
+                        "global::System.Collections.Generic.Dictionary<global::Godot.StringName, (global::Godot.Bridge.PropertyGetterTrampoline getterTramp, global::Godot.Bridge.PropertySetterTrampoline setterTramp)>";
+
+                    source.Append(
+                        "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+                    source.Append("    internal new static unsafe ")
+                        .Append(DictType)
+                        .Append(" GetGodotPropertyTrampolines()\n    {\n");
+
+                    source.Append("        var trampolines = new ")
+                        .Append(DictType)
+                        .Append("(")
+                        .Append(godotClassProperties.Length + godotClassFields.Length)
+                        .Append(");\n");
+
+                    // Generate trampolines
 
                     foreach (var property in godotClassProperties)
                     {
-                        if (property.PropertySymbol.IsReadOnly || property.PropertySymbol.SetMethod!.IsInitOnly)
-                            continue;
+                        if (!property.PropertySymbol.IsWriteOnly)
+                        {
+                            GeneratePropertyGetterTrampoline(symbol, property.PropertySymbol.Name,
+                                property.PropertySymbol.Type, property.Type, source);
+                        }
 
-                        GeneratePropertySetter(property.PropertySymbol.Name,
-                            property.PropertySymbol.Type, property.Type, source);
+                        if (!property.PropertySymbol.IsReadOnly && !property.PropertySymbol.SetMethod!.IsInitOnly)
+                        {
+                            GeneratePropertySetterTrampoline(symbol, property.PropertySymbol.Name,
+                                property.PropertySymbol.Type, property.Type, source);
+                        }
                     }
 
                     foreach (var field in godotClassFields)
                     {
-                        if (field.FieldSymbol.IsReadOnly)
-                            continue;
-
-                        GeneratePropertySetter(field.FieldSymbol.Name,
+                        GeneratePropertyGetterTrampoline(symbol, field.FieldSymbol.Name,
                             field.FieldSymbol.Type, field.Type, source);
+
+                        if (!field.FieldSymbol.IsReadOnly)
+                        {
+                            GeneratePropertySetterTrampoline(symbol, field.FieldSymbol.Name,
+                                field.FieldSymbol.Type, field.Type, source);
+                        }
                     }
 
-                    source.Append("        return base.SetGodotClassPropertyValue(name, value);\n");
-
-                    source.Append("    }\n");
-                }
-
-                // Generate GetGodotClassPropertyValue
-                bool allPropertiesAreWriteOnly = godotClassFields.Length == 0 && godotClassProperties.All(pi => pi.PropertySymbol.IsWriteOnly);
-
-                if (!allPropertiesAreWriteOnly)
-                {
-                    source.Append("    /// <inheritdoc/>\n");
-                    source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                    source.Append("    protected override bool GetGodotClassPropertyValue(in godot_string_name name, ");
-                    source.Append("out godot_variant value)\n    {\n");
+                    // Append trampolines
 
                     foreach (var property in godotClassProperties)
                     {
-                        if (property.PropertySymbol.IsWriteOnly)
-                            continue;
-
-                        GeneratePropertyGetter(property.PropertySymbol.Name,
-                            property.PropertySymbol.Type, property.Type, source);
+                        AppendPropertyTrampolines(source, property.PropertySymbol.Name,
+                            hasGetter: !property.PropertySymbol.IsWriteOnly,
+                            hasSetter: !property.PropertySymbol.IsReadOnly &&
+                                       !property.PropertySymbol.SetMethod!.IsInitOnly);
                     }
 
                     foreach (var field in godotClassFields)
                     {
-                        GeneratePropertyGetter(field.FieldSymbol.Name,
-                            field.FieldSymbol.Type, field.Type, source);
+                        AppendPropertyTrampolines(source, field.FieldSymbol.Name,
+                            hasGetter: true,
+                            hasSetter: !field.FieldSymbol.IsReadOnly);
                     }
 
-                    source.Append("        return base.GetGodotClassPropertyValue(name, out value);\n");
-
+                    source.Append("        return trampolines;\n");
                     source.Append("    }\n");
                 }
+
                 // Generate GetGodotPropertyList
 
-                const string DictionaryType = "global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>";
+                const string DictionaryType =
+                    "global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>";
 
                 source.Append("    /// <summary>\n")
                     .Append("    /// Get the property information for all the properties declared in this class.\n")
-                    .Append("    /// This method is used by Godot to register the available properties in the editor.\n")
+                    .Append(
+                        "    /// This method is used by Godot to register the available properties in the editor.\n")
                     .Append("    /// Do not call this method.\n")
                     .Append("    /// </summary>\n");
 
-                source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+                source.Append(
+                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
 
                 source.Append("    internal new static ")
                     .Append(DictionaryType)
@@ -320,45 +327,101 @@ namespace Godot.SourceGenerators
             context.AddSource(uniqueHint, SourceText.From(source.ToString(), Encoding.UTF8));
         }
 
-        private static void GeneratePropertySetter(
-            string propertyMemberName,
-            ITypeSymbol propertyTypeSymbol,
-            MarshalType propertyMarshalType,
-            StringBuilder source
-        )
+        private static void AppendPropertyTrampolines(StringBuilder source,
+            string propertyMemberName, bool hasGetter, bool hasSetter)
         {
-            source.Append("        ");
+            source.Append("        trampolines.Add(PropertyName.@")
+                .Append(propertyMemberName)
+                .Append(", (new global::Godot.Bridge.PropertyGetterTrampoline(");
 
-            source.Append("if (name == PropertyName.@")
-                .Append(propertyMemberName)
-                .Append(") {\n")
-                .Append("            this.@")
-                .Append(propertyMemberName)
-                .Append(" = ")
-                .AppendNativeVariantToManagedExpr("value", propertyTypeSymbol, propertyMarshalType)
-                .Append(";\n")
-                .Append("            return true;\n")
-                .Append("        }\n");
+            if (hasGetter)
+                source.Append("&trampoline_get_").Append(propertyMemberName);
+            else
+                source.Append("null");
+
+            source.Append("), new global::Godot.Bridge.PropertySetterTrampoline(");
+
+            if (hasSetter)
+                source.Append("&trampoline_set_").Append(propertyMemberName);
+            else
+                source.Append("null");
+
+            source.Append(")));\n");
         }
 
-        private static void GeneratePropertyGetter(
+        private static void GeneratePropertyGetterTrampoline(
+            INamedTypeSymbol classSymbol,
             string propertyMemberName,
             ITypeSymbol propertyTypeSymbol,
             MarshalType propertyMarshalType,
             StringBuilder source
         )
         {
-            source.Append("        ");
+            source.Append("        [global::System.Runtime.InteropServices.UnmanagedCallersOnly]\n");
+            source.Append("        static godot_bool trampoline_get_").Append(propertyMemberName);
 
-            source.Append("if (name == PropertyName.@")
-                .Append(propertyMemberName)
-                .Append(") {\n")
-                .Append("            value = ")
-                .AppendManagedToNativeVariantExpr("this.@" + propertyMemberName,
+            source.Append("(global::System.IntPtr godotObjectGCHandle, godot_variant* value)\n        {\n");
+
+            source.Append("          try {\n");
+
+            source.Append("            var godotObject = (").Append(classSymbol.FullQualifiedNameIncludeGlobal())
+                .Append(")global::System.Runtime.InteropServices.GCHandle.FromIntPtr(godotObjectGCHandle).Target;\n")
+                .Append("            if (godotObject == null) {\n")
+                .Append("                return godot_bool.False;\n")
+                .Append("            }\n");
+
+            source
+                .Append("            *value = ")
+                .AppendManagedToNativeVariantExpr(("godotObject.@", propertyMemberName),
                     propertyTypeSymbol, propertyMarshalType)
-                .Append(";\n")
-                .Append("            return true;\n")
-                .Append("        }\n");
+                .Append(";\n");
+
+            source.Append("            return godot_bool.True;\n");
+
+            source.Append("          } catch (global::System.Exception e) {\n");
+            source.Append("              global::Godot.NativeInterop.ExceptionUtils.LogException(e);\n");
+            source.Append("              return godot_bool.False;\n");
+            source.Append("          }\n");
+
+            source.Append("        }\n");
+        }
+
+        private static void GeneratePropertySetterTrampoline(
+            INamedTypeSymbol classSymbol,
+            string propertyMemberName,
+            ITypeSymbol propertyTypeSymbol,
+            MarshalType propertyMarshalType,
+            StringBuilder source
+        )
+        {
+            source.Append("        [global::System.Runtime.InteropServices.UnmanagedCallersOnly]\n");
+            source.Append("        static godot_bool trampoline_set_").Append(propertyMemberName);
+
+            source.Append("(global::System.IntPtr godotObjectGCHandle, godot_variant* value)\n        {\n");
+
+            source.Append("          try {\n");
+
+            source.Append("            var godotObject = (").Append(classSymbol.FullQualifiedNameIncludeGlobal())
+                .Append(")global::System.Runtime.InteropServices.GCHandle.FromIntPtr(godotObjectGCHandle).Target;\n")
+                .Append("            if (godotObject == null) {\n")
+                .Append("                return godot_bool.False;\n")
+                .Append("            }\n");
+
+            source
+                .Append("            godotObject.@")
+                .Append(propertyMemberName)
+                .Append(" = ")
+                .AppendNativeVariantToManagedExpr("*value", propertyTypeSymbol, propertyMarshalType)
+                .Append(";\n");
+
+            source.Append("            return godot_bool.True;\n");
+
+            source.Append("          } catch (global::System.Exception e) {\n");
+            source.Append("              global::Godot.NativeInterop.ExceptionUtils.LogException(e);\n");
+            source.Append("              return godot_bool.False;\n");
+            source.Append("          }\n");
+
+            source.Append("        }\n");
         }
 
         private static void AppendGroupingPropertyInfo(StringBuilder source, PropertyInfo propertyInfo)
@@ -448,7 +511,8 @@ namespace Godot.SourceGenerators
 
             if (exportAttr != null && propertySymbol != null)
             {
-                if (propertySymbol.GetMethod == null || propertySymbol.SetMethod == null || propertySymbol.SetMethod.IsInitOnly)
+                if (propertySymbol.GetMethod == null || propertySymbol.SetMethod == null ||
+                    propertySymbol.SetMethod.IsInitOnly)
                 {
                     // Exports can be neither read-only nor write-only but the diagnostic errors for properties are already
                     // reported by ScriptPropertyDefValGenerator.cs so just quit early here.
@@ -478,7 +542,8 @@ namespace Godot.SourceGenerators
                     return null;
                 }
 
-                static bool PropertyIsExpressionBodiedAndReturnsNewCallable(Compilation compilation, IPropertySymbol? propertySymbol)
+                static bool PropertyIsExpressionBodiedAndReturnsNewCallable(Compilation compilation,
+                    IPropertySymbol? propertySymbol)
                 {
                     if (propertySymbol == null)
                     {
@@ -517,7 +582,8 @@ namespace Godot.SourceGenerators
                     return true;
                 }
 
-                static bool ExpressionBodyReturnsNewCallable(Compilation compilation, ArrowExpressionClauseSyntax? expressionSyntax)
+                static bool ExpressionBodyReturnsNewCallable(Compilation compilation,
+                    ArrowExpressionClauseSyntax? expressionSyntax)
                 {
                     if (expressionSyntax == null)
                     {
@@ -539,14 +605,18 @@ namespace Godot.SourceGenerators
                             {
                                 return typeSymbol.FullQualifiedNameOmitGlobal() == GodotClasses.Callable;
                             }
+
                             break;
 
                         case InvocationExpressionSyntax invocationExpression:
-                            var methodSymbol = semanticModel.GetSymbolInfo(invocationExpression).Symbol as IMethodSymbol;
+                            var methodSymbol =
+                                semanticModel.GetSymbolInfo(invocationExpression).Symbol as IMethodSymbol;
                             if (methodSymbol != null && methodSymbol.Name == "From")
                             {
-                                return methodSymbol.ContainingType.FullQualifiedNameOmitGlobal() == GodotClasses.Callable;
+                                return methodSymbol.ContainingType.FullQualifiedNameOmitGlobal() ==
+                                       GodotClasses.Callable;
                             }
+
                             break;
                     }
 
@@ -608,9 +678,9 @@ namespace Godot.SourceGenerators
                         _ => (PropertyHint)(long)hintValue
                     };
 
-                    hintString = constructorArguments.Length > 1 ?
-                        exportAttr.ConstructorArguments[1].Value?.ToString() :
-                        null;
+                    hintString = constructorArguments.Length > 1
+                        ? exportAttr.ConstructorArguments[1].Value?.ToString()
+                        : null;
                 }
                 else
                 {
@@ -699,8 +769,9 @@ namespace Godot.SourceGenerators
                     hintStringBuilder.Append(val);
                 }
 
-                hintString = !usesDefaultValues ?
-                    hintStringBuilder.ToString() :
+                hintString = !usesDefaultValues
+                    ? hintStringBuilder.ToString()
+                    :
                     // If we use the format NAME:VAL, that's what the editor displays.
                     // That's annoying if the user is not using custom values for the enum constants.
                     // This may not be needed in the future if the editor is changed to not display values.
@@ -733,7 +804,8 @@ namespace Godot.SourceGenerators
                 }
             }
 
-            static bool TryGetNodeOrResourceType(AttributeData exportAttr, out PropertyHint hint, out string? hintString)
+            static bool TryGetNodeOrResourceType(AttributeData exportAttr, out PropertyHint hint,
+                out string? hintString)
             {
                 hint = PropertyHint.None;
                 hintString = null;
@@ -793,9 +865,9 @@ namespace Godot.SourceGenerators
 
                     if (presetHint == PropertyHint.Enum)
                     {
-                        string? presetHintString = constructorArguments.Length > 1 ?
-                            exportAttr.ConstructorArguments[1].Value?.ToString() :
-                            null;
+                        string? presetHintString = constructorArguments.Length > 1
+                            ? exportAttr.ConstructorArguments[1].Value?.ToString()
+                            : null;
 
                         hintString = (int)elementVariantType + "/" + (int)PropertyHint.Enum + ":";
 
@@ -881,7 +953,8 @@ namespace Godot.SourceGenerators
                     return false;
                 }
 
-                var keyElementVariantType = MarshalUtils.ConvertMarshalTypeToVariantType(keyElementMarshalType.Value)!.Value;
+                var keyElementVariantType =
+                    MarshalUtils.ConvertMarshalTypeToVariantType(keyElementMarshalType.Value)!.Value;
                 var keyIsPresetHint = false;
                 var keyHintString = (string?)null;
 
@@ -908,12 +981,14 @@ namespace Godot.SourceGenerators
                     }
                 }
 
-                var valueElementVariantType = MarshalUtils.ConvertMarshalTypeToVariantType(valueElementMarshalType.Value)!.Value;
+                var valueElementVariantType =
+                    MarshalUtils.ConvertMarshalTypeToVariantType(valueElementMarshalType.Value)!.Value;
                 var valueIsPresetHint = false;
                 var valueHintString = (string?)null;
 
                 if (valueElementVariantType == VariantType.String || valueElementVariantType == VariantType.StringName)
-                    valueIsPresetHint = GetStringArrayEnumHint(valueElementVariantType, exportAttr, out valueHintString);
+                    valueIsPresetHint =
+                        GetStringArrayEnumHint(valueElementVariantType, exportAttr, out valueHintString);
 
                 if (!valueIsPresetHint)
                 {
@@ -937,7 +1012,9 @@ namespace Godot.SourceGenerators
 
                 hint = PropertyHint.TypeString;
 
-                hintString = keyHintString != null && valueHintString != null ? $"{keyHintString};{valueHintString}" : null;
+                hintString = keyHintString != null && valueHintString != null
+                    ? $"{keyHintString};{valueHintString}"
+                    : null;
                 return hintString != null;
             }
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -173,7 +173,7 @@ namespace Godot.SourceGenerators
                 source.Append("\";\n");
             }
 
-            source.Append("    }\n"); // class GodotInternal
+            source.Append("    }\n"); // end of class PropertyName
 
             if (godotClassProperties.Length > 0 || godotClassFields.Length > 0)
             {
@@ -332,14 +332,14 @@ namespace Godot.SourceGenerators
         {
             source.Append("        trampolines.Add(PropertyName.@")
                 .Append(propertyMemberName)
-                .Append(", (new global::Godot.Bridge.PropertyGetterTrampoline(");
+                .Append(", (new(");
 
             if (hasGetter)
                 source.Append("&trampoline_get_").Append(propertyMemberName);
             else
                 source.Append("null");
 
-            source.Append("), new global::Godot.Bridge.PropertySetterTrampoline(");
+            source.Append("), new(");
 
             if (hasSetter)
                 source.Append("&trampoline_set_").Append(propertyMemberName);
@@ -357,31 +357,18 @@ namespace Godot.SourceGenerators
             StringBuilder source
         )
         {
-            source.Append("        [global::System.Runtime.InteropServices.UnmanagedCallersOnly]\n");
-            source.Append("        static godot_bool trampoline_get_").Append(propertyMemberName);
-
-            source.Append("(global::System.IntPtr godotObjectGCHandle, godot_variant* value)\n        {\n");
-
-            source.Append("          try {\n");
-
-            source.Append("            var godotObject = (").Append(classSymbol.FullQualifiedNameIncludeGlobal())
-                .Append(")global::System.Runtime.InteropServices.GCHandle.FromIntPtr(godotObjectGCHandle).Target;\n")
-                .Append("            if (godotObject == null) {\n")
-                .Append("                return godot_bool.False;\n")
-                .Append("            }\n");
+            source
+                .Append("        static godot_variant trampoline_get_").Append(propertyMemberName)
+                .Append("(object godotObject)\n        {\n");
 
             source
-                .Append("            *value = ")
-                .AppendManagedToNativeVariantExpr(("godotObject.@", propertyMemberName),
-                    propertyTypeSymbol, propertyMarshalType)
+                .Append("            var ret = ((").Append(classSymbol.FullQualifiedNameIncludeGlobal())
+                .Append(")godotObject).@")
+                .Append(propertyMemberName).Append(";\n");
+            source
+                .Append("            return ")
+                .AppendManagedToNativeVariantExpr("ret", propertyTypeSymbol, propertyMarshalType)
                 .Append(";\n");
-
-            source.Append("            return godot_bool.True;\n");
-
-            source.Append("          } catch (global::System.Exception e) {\n");
-            source.Append("              global::Godot.NativeInterop.ExceptionUtils.LogException(e);\n");
-            source.Append("              return godot_bool.False;\n");
-            source.Append("          }\n");
 
             source.Append("        }\n");
         }
@@ -394,32 +381,17 @@ namespace Godot.SourceGenerators
             StringBuilder source
         )
         {
-            source.Append("        [global::System.Runtime.InteropServices.UnmanagedCallersOnly]\n");
-            source.Append("        static godot_bool trampoline_set_").Append(propertyMemberName);
-
-            source.Append("(global::System.IntPtr godotObjectGCHandle, godot_variant* value)\n        {\n");
-
-            source.Append("          try {\n");
-
-            source.Append("            var godotObject = (").Append(classSymbol.FullQualifiedNameIncludeGlobal())
-                .Append(")global::System.Runtime.InteropServices.GCHandle.FromIntPtr(godotObjectGCHandle).Target;\n")
-                .Append("            if (godotObject == null) {\n")
-                .Append("                return godot_bool.False;\n")
-                .Append("            }\n");
+            source
+                .Append("        static void trampoline_set_").Append(propertyMemberName)
+                .Append("(object godotObject, in godot_variant value)\n        {\n");
 
             source
-                .Append("            godotObject.@")
+                .Append("            ((").Append(classSymbol.FullQualifiedNameIncludeGlobal())
+                .Append(")godotObject).@")
                 .Append(propertyMemberName)
                 .Append(" = ")
-                .AppendNativeVariantToManagedExpr("*value", propertyTypeSymbol, propertyMarshalType)
+                .AppendNativeVariantToManagedExpr("value", propertyTypeSymbol, propertyMarshalType)
                 .Append(";\n");
-
-            source.Append("            return godot_bool.True;\n");
-
-            source.Append("          } catch (global::System.Exception e) {\n");
-            source.Append("              global::Godot.NativeInterop.ExceptionUtils.LogException(e);\n");
-            source.Append("              return godot_bool.False;\n");
-            source.Append("          }\n");
 
             source.Append("        }\n");
         }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -179,11 +179,12 @@ namespace Godot.SourceGenerators
 
             source.Append("    }\n"); // end of class PropertyName
 
-            source.Append("    private static partial class GodotInternal\n    {\n");
+            source.Append("    ").Append(symbol.IsSealed ? "" : "protected ")
+                .Append("internal new static partial class GodotInternal\n    {\n");
 
             // Generate GetGodotMethodTrampolines
             {
-                const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.PropertyTrampolineCollector";
+                const string CollectorType = "global::Godot.Bridge.PropertyTrampolineCollector";
 
                 source.Append("        internal new static ")
                     .Append(isUnsafeAllowed ? "unsafe " : "")

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -181,11 +181,12 @@ namespace Godot.SourceGenerators
 
             source.Append("    }\n"); // end of class PropertyName
 
-            source.Append("    private static partial class GodotInternal\n    {\n");
+            source.Append("    ").Append(symbol.IsSealed ? "" : "protected ")
+                .Append("internal new static partial class GodotInternal\n    {\n");
 
             // Generate GetGodotMethodTrampolines
             {
-                const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.PropertyTrampolineCollector";
+                const string CollectorType = "global::Godot.Bridge.PropertyTrampolineCollector";
 
                 source.Append("        internal new static ")
                     .Append(isUnsafeAllowed ? "unsafe " : "")

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -64,6 +64,9 @@ namespace Godot.SourceGenerators
             INamedTypeSymbol symbol
         )
         {
+            var options = context.Compilation.Options as Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions;
+            bool isUnsafeAllowed = options?.AllowUnsafe ?? false;
+
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
             string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace
                 ? namespaceSymbol.FullQualifiedNameOmitGlobal()
@@ -185,7 +188,9 @@ namespace Godot.SourceGenerators
 
                     source.Append(
                         "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                    source.Append("    internal new static unsafe void GetGodotPropertyTrampolines(")
+                    source.Append("    internal new static ")
+                        .Append(isUnsafeAllowed ? "unsafe " : "")
+                        .Append("void GetGodotPropertyTrampolines(")
                         .Append(CollectorType).Append(" collector)\n    {\n");
 
                     // Generate trampolines
@@ -221,14 +226,14 @@ namespace Godot.SourceGenerators
 
                     foreach (var property in godotClassProperties)
                     {
-                        AppendPropertyTrampolines(source, property.PropertySymbol.Name,
+                        AppendPropertyTrampolines(source, property.PropertySymbol.Name, isUnsafeAllowed,
                             hasGetter: !property.IsWriteOnly,
                             hasSetter: !property.IsReadOnly);
                     }
 
                     foreach (var field in godotClassFields)
                     {
-                        AppendPropertyTrampolines(source, field.FieldSymbol.Name,
+                        AppendPropertyTrampolines(source, field.FieldSymbol.Name, isUnsafeAllowed,
                             hasGetter: true,
                             hasSetter: !field.IsReadOnly);
                     }
@@ -320,23 +325,66 @@ namespace Godot.SourceGenerators
         }
 
         private static void AppendPropertyTrampolines(StringBuilder source,
-            string propertyMemberName, bool hasGetter, bool hasSetter)
+            string propertyMemberName, bool isUnsafeAllowed, bool hasGetter, bool hasSetter)
         {
+            if (!isUnsafeAllowed)
+            {
+                if (hasGetter)
+                {
+                    source.Append("        var aux_delegate_get_").Append(propertyMemberName)
+                        .Append(" = ")
+                        .Append("trampoline_get_").Append(propertyMemberName)
+                        .Append(";\n");
+                }
+
+                if (hasSetter)
+                {
+                    source.Append("        var aux_delegate_set_").Append(propertyMemberName)
+                        .Append(" = ")
+                        .Append("trampoline_set_").Append(propertyMemberName)
+                        .Append(";\n");
+                }
+            }
+
             source.Append("        collector.TryAdd(PropertyName.@")
                 .Append(propertyMemberName)
                 .Append(", (new(");
 
             if (hasGetter)
-                source.Append("&trampoline_get_").Append(propertyMemberName);
+            {
+                if (isUnsafeAllowed)
+                {
+                    source.Append("&trampoline_get_").Append(propertyMemberName);
+                }
+                else
+                {
+                    source.Append("aux_delegate_get_").Append(propertyMemberName)
+                        .Append(".Method.MethodHandle.GetFunctionPointer()");
+                }
+            }
             else
-                source.Append("null");
+            {
+                source.Append(isUnsafeAllowed ? "null" : "global::System.IntPtr.Zero");
+            }
 
             source.Append("), new(");
 
             if (hasSetter)
-                source.Append("&trampoline_set_").Append(propertyMemberName);
+            {
+                if (isUnsafeAllowed)
+                {
+                    source.Append("&trampoline_set_").Append(propertyMemberName);
+                }
+                else
+                {
+                    source.Append("aux_delegate_set_").Append(propertyMemberName)
+                        .Append(".Method.MethodHandle.GetFunctionPointer()");
+                }
+            }
             else
-                source.Append("null");
+            {
+                source.Append(isUnsafeAllowed ? "null" : "global::System.IntPtr.Zero");
+            }
 
             source.Append(")));\n");
         }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -181,20 +181,12 @@ namespace Godot.SourceGenerators
             {
                 // Generate GetGodotMethodTrampolines
                 {
-                    const string DictType =
-                        "global::System.Collections.Generic.Dictionary<global::Godot.StringName, (global::Godot.Bridge.PropertyGetterTrampoline getterTramp, global::Godot.Bridge.PropertySetterTrampoline setterTramp)>";
+                    const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.PropertyTrampolineCollector";
 
                     source.Append(
                         "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                    source.Append("    internal new static unsafe ")
-                        .Append(DictType)
-                        .Append(" GetGodotPropertyTrampolines()\n    {\n");
-
-                    source.Append("        var trampolines = new ")
-                        .Append(DictType)
-                        .Append("(")
-                        .Append(godotClassProperties.Length + godotClassFields.Length)
-                        .Append(");\n");
+                    source.Append("    internal new static unsafe void GetGodotPropertyTrampolines(")
+                        .Append(CollectorType).Append(" collector)\n    {\n");
 
                     // Generate trampolines
 
@@ -241,7 +233,6 @@ namespace Godot.SourceGenerators
                             hasSetter: !field.IsReadOnly);
                     }
 
-                    source.Append("        return trampolines;\n");
                     source.Append("    }\n");
                 }
 
@@ -331,7 +322,7 @@ namespace Godot.SourceGenerators
         private static void AppendPropertyTrampolines(StringBuilder source,
             string propertyMemberName, bool hasGetter, bool hasSetter)
         {
-            source.Append("        trampolines.Add(PropertyName.@")
+            source.Append("        collector.TryAdd(PropertyName.@")
                 .Append(propertyMemberName)
                 .Append(", (new(");
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -175,7 +175,7 @@ namespace Godot.SourceGenerators
                 source.Append("\";\n");
             }
 
-            source.Append("    }\n"); // class GodotInternal
+            source.Append("    }\n"); // end of class PropertyName
 
             if (godotClassProperties.Length > 0 || godotClassFields.Length > 0)
             {
@@ -333,14 +333,14 @@ namespace Godot.SourceGenerators
         {
             source.Append("        trampolines.Add(PropertyName.@")
                 .Append(propertyMemberName)
-                .Append(", (new global::Godot.Bridge.PropertyGetterTrampoline(");
+                .Append(", (new(");
 
             if (hasGetter)
                 source.Append("&trampoline_get_").Append(propertyMemberName);
             else
                 source.Append("null");
 
-            source.Append("), new global::Godot.Bridge.PropertySetterTrampoline(");
+            source.Append("), new(");
 
             if (hasSetter)
                 source.Append("&trampoline_set_").Append(propertyMemberName);
@@ -358,31 +358,18 @@ namespace Godot.SourceGenerators
             StringBuilder source
         )
         {
-            source.Append("        [global::System.Runtime.InteropServices.UnmanagedCallersOnly]\n");
-            source.Append("        static godot_bool trampoline_get_").Append(propertyMemberName);
-
-            source.Append("(global::System.IntPtr godotObjectGCHandle, godot_variant* value)\n        {\n");
-
-            source.Append("          try {\n");
-
-            source.Append("            var godotObject = (").Append(classSymbol.FullQualifiedNameIncludeGlobal())
-                .Append(")global::System.Runtime.InteropServices.GCHandle.FromIntPtr(godotObjectGCHandle).Target;\n")
-                .Append("            if (godotObject == null) {\n")
-                .Append("                return godot_bool.False;\n")
-                .Append("            }\n");
+            source
+                .Append("        static godot_variant trampoline_get_").Append(propertyMemberName)
+                .Append("(object godotObject)\n        {\n");
 
             source
-                .Append("            *value = ")
-                .AppendManagedToNativeVariantExpr(("godotObject.@", propertyMemberName),
-                    propertyTypeSymbol, propertyMarshalType)
+                .Append("            var ret = ((").Append(classSymbol.FullQualifiedNameIncludeGlobal())
+                .Append(")godotObject).@")
+                .Append(propertyMemberName).Append(";\n");
+            source
+                .Append("            return ")
+                .AppendManagedToNativeVariantExpr("ret", propertyTypeSymbol, propertyMarshalType)
                 .Append(";\n");
-
-            source.Append("            return godot_bool.True;\n");
-
-            source.Append("          } catch (global::System.Exception e) {\n");
-            source.Append("              global::Godot.NativeInterop.ExceptionUtils.LogException(e);\n");
-            source.Append("              return godot_bool.False;\n");
-            source.Append("          }\n");
 
             source.Append("        }\n");
         }
@@ -395,32 +382,17 @@ namespace Godot.SourceGenerators
             StringBuilder source
         )
         {
-            source.Append("        [global::System.Runtime.InteropServices.UnmanagedCallersOnly]\n");
-            source.Append("        static godot_bool trampoline_set_").Append(propertyMemberName);
-
-            source.Append("(global::System.IntPtr godotObjectGCHandle, godot_variant* value)\n        {\n");
-
-            source.Append("          try {\n");
-
-            source.Append("            var godotObject = (").Append(classSymbol.FullQualifiedNameIncludeGlobal())
-                .Append(")global::System.Runtime.InteropServices.GCHandle.FromIntPtr(godotObjectGCHandle).Target;\n")
-                .Append("            if (godotObject == null) {\n")
-                .Append("                return godot_bool.False;\n")
-                .Append("            }\n");
+            source
+                .Append("        static void trampoline_set_").Append(propertyMemberName)
+                .Append("(object godotObject, in godot_variant value)\n        {\n");
 
             source
-                .Append("            godotObject.@")
+                .Append("            ((").Append(classSymbol.FullQualifiedNameIncludeGlobal())
+                .Append(")godotObject).@")
                 .Append(propertyMemberName)
                 .Append(" = ")
-                .AppendNativeVariantToManagedExpr("*value", propertyTypeSymbol, propertyMarshalType)
+                .AppendNativeVariantToManagedExpr("value", propertyTypeSymbol, propertyMarshalType)
                 .Append(";\n");
-
-            source.Append("            return godot_bool.True;\n");
-
-            source.Append("          } catch (global::System.Exception e) {\n");
-            source.Append("              global::Godot.NativeInterop.ExceptionUtils.LogException(e);\n");
-            source.Append("              return godot_bool.False;\n");
-            source.Append("          }\n");
 
             source.Append("        }\n");
         }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -39,6 +39,7 @@ namespace Godot.SourceGenerators
 
                                 return true;
                             }
+
                             return false;
                         })
                         .Select(x => x.symbol)
@@ -64,9 +65,9 @@ namespace Godot.SourceGenerators
         )
         {
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
-            string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace ?
-                namespaceSymbol.FullQualifiedNameOmitGlobal() :
-                string.Empty;
+            string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace
+                ? namespaceSymbol.FullQualifiedNameOmitGlobal()
+                : string.Empty;
             bool hasNamespace = classNs.Length != 0;
 
             bool isInnerClass = symbol.ContainingType != null;
@@ -131,7 +132,8 @@ namespace Godot.SourceGenerators
             source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
 
             source.Append("    /// <summary>\n")
-                .Append("    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.\n")
+                .Append(
+                    "    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.\n")
                 .Append("    /// </summary>\n");
 
             source.Append(
@@ -177,81 +179,86 @@ namespace Godot.SourceGenerators
 
             if (godotClassProperties.Length > 0 || godotClassFields.Length > 0)
             {
-
-                // Generate SetGodotClassPropertyValue
-
-                bool allPropertiesAreReadOnly = godotClassFields.All(fi => fi.IsReadOnly) && godotClassProperties.All(pi => pi.IsReadOnly);
-
-                if (!allPropertiesAreReadOnly)
+                // Generate GetGodotMethodTrampolines
                 {
-                    source.Append("    /// <inheritdoc/>\n");
-                    source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                    source.Append("    protected override bool SetGodotClassPropertyValue(in godot_string_name name, ");
-                    source.Append("in godot_variant value)\n    {\n");
+                    const string DictType =
+                        "global::System.Collections.Generic.Dictionary<global::Godot.StringName, (global::Godot.Bridge.PropertyGetterTrampoline getterTramp, global::Godot.Bridge.PropertySetterTrampoline setterTramp)>";
+
+                    source.Append(
+                        "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+                    source.Append("    internal new static unsafe ")
+                        .Append(DictType)
+                        .Append(" GetGodotPropertyTrampolines()\n    {\n");
+
+                    source.Append("        var trampolines = new ")
+                        .Append(DictType)
+                        .Append("(")
+                        .Append(godotClassProperties.Length + godotClassFields.Length)
+                        .Append(");\n");
+
+                    // Generate trampolines
 
                     foreach (var property in godotClassProperties)
                     {
-                        if (property.IsReadOnly)
-                            continue;
+                        if (!property.IsWriteOnly)
+                        {
+                            GeneratePropertyGetterTrampoline(symbol, property.PropertySymbol.Name,
+                                property.PropertySymbol.Type, property.Type, source);
+                        }
 
-                        GeneratePropertySetter(property.PropertySymbol.Name,
-                            property.PropertySymbol.Type, property.Type, source);
+                        if (!property.IsReadOnly)
+                        {
+                            GeneratePropertySetterTrampoline(symbol, property.PropertySymbol.Name,
+                                property.PropertySymbol.Type, property.Type, source);
+                        }
                     }
 
                     foreach (var field in godotClassFields)
                     {
-                        if (field.IsReadOnly)
-                            continue;
-
-                        GeneratePropertySetter(field.FieldSymbol.Name,
+                        GeneratePropertyGetterTrampoline(symbol, field.FieldSymbol.Name,
                             field.FieldSymbol.Type, field.Type, source);
+
+                        if (!field.IsReadOnly)
+                        {
+                            GeneratePropertySetterTrampoline(symbol, field.FieldSymbol.Name,
+                                field.FieldSymbol.Type, field.Type, source);
+                        }
                     }
 
-                    source.Append("        return base.SetGodotClassPropertyValue(name, value);\n");
-
-                    source.Append("    }\n");
-                }
-
-                // Generate GetGodotClassPropertyValue
-                bool allPropertiesAreWriteOnly = godotClassFields.Length == 0 && godotClassProperties.All(pi => pi.IsWriteOnly);
-
-                if (!allPropertiesAreWriteOnly)
-                {
-                    source.Append("    /// <inheritdoc/>\n");
-                    source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                    source.Append("    protected override bool GetGodotClassPropertyValue(in godot_string_name name, ");
-                    source.Append("out godot_variant value)\n    {\n");
+                    // Append trampolines
 
                     foreach (var property in godotClassProperties)
                     {
-                        if (property.PropertySymbol.IsWriteOnly)
-                            continue;
-
-                        GeneratePropertyGetter(property.PropertySymbol.Name,
-                            property.PropertySymbol.Type, property.Type, source);
+                        AppendPropertyTrampolines(source, property.PropertySymbol.Name,
+                            hasGetter: !property.IsWriteOnly,
+                            hasSetter: !property.IsReadOnly);
                     }
 
                     foreach (var field in godotClassFields)
                     {
-                        GeneratePropertyGetter(field.FieldSymbol.Name,
-                            field.FieldSymbol.Type, field.Type, source);
+                        AppendPropertyTrampolines(source, field.FieldSymbol.Name,
+                            hasGetter: true,
+                            hasSetter: !field.IsReadOnly);
                     }
 
-                    source.Append("        return base.GetGodotClassPropertyValue(name, out value);\n");
-
+                    source.Append("        return trampolines;\n");
                     source.Append("    }\n");
                 }
+
                 // Generate GetGodotPropertyList
 
-                const string DictionaryType = "global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>";
+                const string DictionaryType =
+                    "global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>";
 
                 source.Append("    /// <summary>\n")
                     .Append("    /// Get the property information for all the properties declared in this class.\n")
-                    .Append("    /// This method is used by Godot to register the available properties in the editor.\n")
+                    .Append(
+                        "    /// This method is used by Godot to register the available properties in the editor.\n")
                     .Append("    /// Do not call this method.\n")
                     .Append("    /// </summary>\n");
 
-                source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+                source.Append(
+                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
 
                 source.Append("    internal new static ")
                     .Append(DictionaryType)
@@ -321,45 +328,101 @@ namespace Godot.SourceGenerators
             context.AddSource(uniqueHint, SourceText.From(source.ToString(), Encoding.UTF8));
         }
 
-        private static void GeneratePropertySetter(
-            string propertyMemberName,
-            ITypeSymbol propertyTypeSymbol,
-            MarshalType propertyMarshalType,
-            StringBuilder source
-        )
+        private static void AppendPropertyTrampolines(StringBuilder source,
+            string propertyMemberName, bool hasGetter, bool hasSetter)
         {
-            source.Append("        ");
+            source.Append("        trampolines.Add(PropertyName.@")
+                .Append(propertyMemberName)
+                .Append(", (new global::Godot.Bridge.PropertyGetterTrampoline(");
 
-            source.Append("if (name == PropertyName.@")
-                .Append(propertyMemberName)
-                .Append(") {\n")
-                .Append("            this.@")
-                .Append(propertyMemberName)
-                .Append(" = ")
-                .AppendNativeVariantToManagedExpr("value", propertyTypeSymbol, propertyMarshalType)
-                .Append(";\n")
-                .Append("            return true;\n")
-                .Append("        }\n");
+            if (hasGetter)
+                source.Append("&trampoline_get_").Append(propertyMemberName);
+            else
+                source.Append("null");
+
+            source.Append("), new global::Godot.Bridge.PropertySetterTrampoline(");
+
+            if (hasSetter)
+                source.Append("&trampoline_set_").Append(propertyMemberName);
+            else
+                source.Append("null");
+
+            source.Append(")));\n");
         }
 
-        private static void GeneratePropertyGetter(
+        private static void GeneratePropertyGetterTrampoline(
+            INamedTypeSymbol classSymbol,
             string propertyMemberName,
             ITypeSymbol propertyTypeSymbol,
             MarshalType propertyMarshalType,
             StringBuilder source
         )
         {
-            source.Append("        ");
+            source.Append("        [global::System.Runtime.InteropServices.UnmanagedCallersOnly]\n");
+            source.Append("        static godot_bool trampoline_get_").Append(propertyMemberName);
 
-            source.Append("if (name == PropertyName.@")
-                .Append(propertyMemberName)
-                .Append(") {\n")
-                .Append("            value = ")
-                .AppendManagedToNativeVariantExpr("this.@" + propertyMemberName,
+            source.Append("(global::System.IntPtr godotObjectGCHandle, godot_variant* value)\n        {\n");
+
+            source.Append("          try {\n");
+
+            source.Append("            var godotObject = (").Append(classSymbol.FullQualifiedNameIncludeGlobal())
+                .Append(")global::System.Runtime.InteropServices.GCHandle.FromIntPtr(godotObjectGCHandle).Target;\n")
+                .Append("            if (godotObject == null) {\n")
+                .Append("                return godot_bool.False;\n")
+                .Append("            }\n");
+
+            source
+                .Append("            *value = ")
+                .AppendManagedToNativeVariantExpr(("godotObject.@", propertyMemberName),
                     propertyTypeSymbol, propertyMarshalType)
-                .Append(";\n")
-                .Append("            return true;\n")
-                .Append("        }\n");
+                .Append(";\n");
+
+            source.Append("            return godot_bool.True;\n");
+
+            source.Append("          } catch (global::System.Exception e) {\n");
+            source.Append("              global::Godot.NativeInterop.ExceptionUtils.LogException(e);\n");
+            source.Append("              return godot_bool.False;\n");
+            source.Append("          }\n");
+
+            source.Append("        }\n");
+        }
+
+        private static void GeneratePropertySetterTrampoline(
+            INamedTypeSymbol classSymbol,
+            string propertyMemberName,
+            ITypeSymbol propertyTypeSymbol,
+            MarshalType propertyMarshalType,
+            StringBuilder source
+        )
+        {
+            source.Append("        [global::System.Runtime.InteropServices.UnmanagedCallersOnly]\n");
+            source.Append("        static godot_bool trampoline_set_").Append(propertyMemberName);
+
+            source.Append("(global::System.IntPtr godotObjectGCHandle, godot_variant* value)\n        {\n");
+
+            source.Append("          try {\n");
+
+            source.Append("            var godotObject = (").Append(classSymbol.FullQualifiedNameIncludeGlobal())
+                .Append(")global::System.Runtime.InteropServices.GCHandle.FromIntPtr(godotObjectGCHandle).Target;\n")
+                .Append("            if (godotObject == null) {\n")
+                .Append("                return godot_bool.False;\n")
+                .Append("            }\n");
+
+            source
+                .Append("            godotObject.@")
+                .Append(propertyMemberName)
+                .Append(" = ")
+                .AppendNativeVariantToManagedExpr("*value", propertyTypeSymbol, propertyMarshalType)
+                .Append(";\n");
+
+            source.Append("            return godot_bool.True;\n");
+
+            source.Append("          } catch (global::System.Exception e) {\n");
+            source.Append("              global::Godot.NativeInterop.ExceptionUtils.LogException(e);\n");
+            source.Append("              return godot_bool.False;\n");
+            source.Append("          }\n");
+
+            source.Append("        }\n");
         }
 
         private static void AppendGroupingPropertyInfo(StringBuilder source, PropertyInfo propertyInfo)
@@ -479,7 +542,8 @@ namespace Godot.SourceGenerators
                     return null;
                 }
 
-                static bool PropertyIsExpressionBodiedAndReturnsNewCallable(Compilation compilation, IPropertySymbol? propertySymbol)
+                static bool PropertyIsExpressionBodiedAndReturnsNewCallable(Compilation compilation,
+                    IPropertySymbol? propertySymbol)
                 {
                     if (propertySymbol == null)
                     {
@@ -518,7 +582,8 @@ namespace Godot.SourceGenerators
                     return true;
                 }
 
-                static bool ExpressionBodyReturnsNewCallable(Compilation compilation, ArrowExpressionClauseSyntax? expressionSyntax)
+                static bool ExpressionBodyReturnsNewCallable(Compilation compilation,
+                    ArrowExpressionClauseSyntax? expressionSyntax)
                 {
                     if (expressionSyntax == null)
                     {
@@ -540,14 +605,18 @@ namespace Godot.SourceGenerators
                             {
                                 return typeSymbol.FullQualifiedNameOmitGlobal() == GodotClasses.Callable;
                             }
+
                             break;
 
                         case InvocationExpressionSyntax invocationExpression:
-                            var methodSymbol = semanticModel.GetSymbolInfo(invocationExpression).Symbol as IMethodSymbol;
+                            var methodSymbol =
+                                semanticModel.GetSymbolInfo(invocationExpression).Symbol as IMethodSymbol;
                             if (methodSymbol != null && methodSymbol.Name == "From")
                             {
-                                return methodSymbol.ContainingType.FullQualifiedNameOmitGlobal() == GodotClasses.Callable;
+                                return methodSymbol.ContainingType.FullQualifiedNameOmitGlobal() ==
+                                       GodotClasses.Callable;
                             }
+
                             break;
                     }
 
@@ -609,9 +678,9 @@ namespace Godot.SourceGenerators
                         _ => (PropertyHint)(long)hintValue
                     };
 
-                    hintString = constructorArguments.Length > 1 ?
-                        exportAttr.ConstructorArguments[1].Value?.ToString() :
-                        null;
+                    hintString = constructorArguments.Length > 1
+                        ? exportAttr.ConstructorArguments[1].Value?.ToString()
+                        : null;
                 }
                 else
                 {
@@ -700,8 +769,9 @@ namespace Godot.SourceGenerators
                     hintStringBuilder.Append(val);
                 }
 
-                hintString = !usesDefaultValues ?
-                    hintStringBuilder.ToString() :
+                hintString = !usesDefaultValues
+                    ? hintStringBuilder.ToString()
+                    :
                     // If we use the format NAME:VAL, that's what the editor displays.
                     // That's annoying if the user is not using custom values for the enum constants.
                     // This may not be needed in the future if the editor is changed to not display values.
@@ -734,7 +804,8 @@ namespace Godot.SourceGenerators
                 }
             }
 
-            static bool TryGetNodeOrResourceType(AttributeData exportAttr, out PropertyHint hint, out string? hintString)
+            static bool TryGetNodeOrResourceType(AttributeData exportAttr, out PropertyHint hint,
+                out string? hintString)
             {
                 hint = PropertyHint.None;
                 hintString = null;
@@ -794,9 +865,9 @@ namespace Godot.SourceGenerators
 
                     if (presetHint == PropertyHint.Enum)
                     {
-                        string? presetHintString = constructorArguments.Length > 1 ?
-                            exportAttr.ConstructorArguments[1].Value?.ToString() :
-                            null;
+                        string? presetHintString = constructorArguments.Length > 1
+                            ? exportAttr.ConstructorArguments[1].Value?.ToString()
+                            : null;
 
                         hintString = (int)elementVariantType + "/" + (int)PropertyHint.Enum + ":";
 
@@ -882,7 +953,8 @@ namespace Godot.SourceGenerators
                     return false;
                 }
 
-                var keyElementVariantType = MarshalUtils.ConvertMarshalTypeToVariantType(keyElementMarshalType.Value)!.Value;
+                var keyElementVariantType =
+                    MarshalUtils.ConvertMarshalTypeToVariantType(keyElementMarshalType.Value)!.Value;
                 var keyIsPresetHint = false;
                 var keyHintString = (string?)null;
 
@@ -909,12 +981,14 @@ namespace Godot.SourceGenerators
                     }
                 }
 
-                var valueElementVariantType = MarshalUtils.ConvertMarshalTypeToVariantType(valueElementMarshalType.Value)!.Value;
+                var valueElementVariantType =
+                    MarshalUtils.ConvertMarshalTypeToVariantType(valueElementMarshalType.Value)!.Value;
                 var valueIsPresetHint = false;
                 var valueHintString = (string?)null;
 
                 if (valueElementVariantType == VariantType.String || valueElementVariantType == VariantType.StringName)
-                    valueIsPresetHint = GetStringArrayEnumHint(valueElementVariantType, exportAttr, out valueHintString);
+                    valueIsPresetHint =
+                        GetStringArrayEnumHint(valueElementVariantType, exportAttr, out valueHintString);
 
                 if (!valueIsPresetHint)
                 {
@@ -938,7 +1012,9 @@ namespace Godot.SourceGenerators
 
                 hint = PropertyHint.TypeString;
 
-                hintString = keyHintString != null && valueHintString != null ? $"{keyHintString};{valueHintString}" : null;
+                hintString = keyHintString != null && valueHintString != null
+                    ? $"{keyHintString};{valueHintString}"
+                    : null;
                 return hintString != null;
             }
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -139,8 +139,9 @@ namespace Godot.SourceGenerators
                     "    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.\n")
                 .Append("    /// </summary>\n");
 
-            source.Append(
-                $"    public new class PropertyName : {symbol.BaseType!.FullQualifiedNameIncludeGlobal()}.PropertyName {{\n");
+            source.Append("    public new class PropertyName : ")
+                .Append(symbol.BaseType!.FullQualifiedNameIncludeGlobal())
+                .Append(".PropertyName {\n");
 
             // Generate cached StringNames for methods and properties, for fast lookup
 
@@ -180,67 +181,69 @@ namespace Godot.SourceGenerators
 
             source.Append("    }\n"); // end of class PropertyName
 
-            if (godotClassProperties.Length > 0 || godotClassFields.Length > 0)
+            source.Append("    private static partial class GodotInternal\n    {\n");
+
+            // Generate GetGodotMethodTrampolines
             {
-                // Generate GetGodotMethodTrampolines
+                const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.PropertyTrampolineCollector";
+
+                source.Append("        internal new static ")
+                    .Append(isUnsafeAllowed ? "unsafe " : "")
+                    .Append("void GetGodotPropertyTrampolines(")
+                    .Append(CollectorType).Append(" collector)\n        {\n");
+
+                // Generate trampolines
+
+                foreach (var property in godotClassProperties)
                 {
-                    const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.PropertyTrampolineCollector";
-
-                    source.Append(
-                        "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                    source.Append("    internal new static ")
-                        .Append(isUnsafeAllowed ? "unsafe " : "")
-                        .Append("void GetGodotPropertyTrampolines(")
-                        .Append(CollectorType).Append(" collector)\n    {\n");
-
-                    // Generate trampolines
-
-                    foreach (var property in godotClassProperties)
+                    if (!property.IsWriteOnly)
                     {
-                        if (!property.IsWriteOnly)
-                        {
-                            GeneratePropertyGetterTrampoline(symbol, property.PropertySymbol.Name,
-                                property.PropertySymbol.Type, property.Type, source);
-                        }
-
-                        if (!property.IsReadOnly)
-                        {
-                            GeneratePropertySetterTrampoline(symbol, property.PropertySymbol.Name,
-                                property.PropertySymbol.Type, property.Type, source);
-                        }
+                        GeneratePropertyGetterTrampoline(symbol, property.PropertySymbol.Name,
+                            property.PropertySymbol.Type, property.Type, source);
                     }
 
-                    foreach (var field in godotClassFields)
+                    if (!property.IsReadOnly)
                     {
-                        GeneratePropertyGetterTrampoline(symbol, field.FieldSymbol.Name,
-                            field.FieldSymbol.Type, field.Type, source);
-
-                        if (!field.IsReadOnly)
-                        {
-                            GeneratePropertySetterTrampoline(symbol, field.FieldSymbol.Name,
-                                field.FieldSymbol.Type, field.Type, source);
-                        }
+                        GeneratePropertySetterTrampoline(symbol, property.PropertySymbol.Name,
+                            property.PropertySymbol.Type, property.Type, source);
                     }
-
-                    // Append trampolines
-
-                    foreach (var property in godotClassProperties)
-                    {
-                        AppendPropertyTrampolines(source, property.PropertySymbol.Name, isUnsafeAllowed,
-                            hasGetter: !property.IsWriteOnly,
-                            hasSetter: !property.IsReadOnly);
-                    }
-
-                    foreach (var field in godotClassFields)
-                    {
-                        AppendPropertyTrampolines(source, field.FieldSymbol.Name, isUnsafeAllowed,
-                            hasGetter: true,
-                            hasSetter: !field.IsReadOnly);
-                    }
-
-                    source.Append("    }\n");
                 }
 
+                foreach (var field in godotClassFields)
+                {
+                    GeneratePropertyGetterTrampoline(symbol, field.FieldSymbol.Name,
+                        field.FieldSymbol.Type, field.Type, source);
+
+                    if (!field.IsReadOnly)
+                    {
+                        GeneratePropertySetterTrampoline(symbol, field.FieldSymbol.Name,
+                            field.FieldSymbol.Type, field.Type, source);
+                    }
+                }
+
+                // Append trampolines
+
+                foreach (var property in godotClassProperties)
+                {
+                    AppendPropertyTrampolines(source, property.PropertySymbol.Name, isUnsafeAllowed,
+                        hasGetter: !property.IsWriteOnly,
+                        hasSetter: !property.IsReadOnly);
+                }
+
+                foreach (var field in godotClassFields)
+                {
+                    AppendPropertyTrampolines(source, field.FieldSymbol.Name, isUnsafeAllowed,
+                        hasGetter: true,
+                        hasSetter: !field.IsReadOnly);
+                }
+
+                source.Append("        }\n");
+            }
+
+            source.Append("    }\n"); // partial class GodotInternal
+
+            if (godotClassProperties.Length > 0 || godotClassFields.Length > 0)
+            {
                 // Generate GetGodotPropertyList
 
                 const string DictionaryType =
@@ -298,9 +301,9 @@ namespace Godot.SourceGenerators
 
                 source.Append("        return properties;\n");
                 source.Append("    }\n");
-
-                source.Append("#pragma warning restore CS0109\n");
             }
+
+            source.Append("#pragma warning restore CS0109\n");
 
             source.Append("}\n"); // partial class
 
@@ -331,7 +334,7 @@ namespace Godot.SourceGenerators
             {
                 if (hasGetter)
                 {
-                    source.Append("        var aux_delegate_get_").Append(propertyMemberName)
+                    source.Append("            var aux_delegate_get_").Append(propertyMemberName)
                         .Append(" = ")
                         .Append("trampoline_get_").Append(propertyMemberName)
                         .Append(";\n");
@@ -339,14 +342,14 @@ namespace Godot.SourceGenerators
 
                 if (hasSetter)
                 {
-                    source.Append("        var aux_delegate_set_").Append(propertyMemberName)
+                    source.Append("            var aux_delegate_set_").Append(propertyMemberName)
                         .Append(" = ")
                         .Append("trampoline_set_").Append(propertyMemberName)
                         .Append(";\n");
                 }
             }
 
-            source.Append("        collector.TryAdd(PropertyName.@")
+            source.Append("            collector.TryAdd(PropertyName.@")
                 .Append(propertyMemberName)
                 .Append(", (new(");
 
@@ -398,19 +401,19 @@ namespace Godot.SourceGenerators
         )
         {
             source
-                .Append("        static godot_variant trampoline_get_").Append(propertyMemberName)
-                .Append("(object godotObject)\n        {\n");
+                .Append("            static godot_variant trampoline_get_").Append(propertyMemberName)
+                .Append("(object godotObject)\n            {\n");
 
             source
-                .Append("            var ret = ((").Append(classSymbol.FullQualifiedNameIncludeGlobal())
+                .Append("                var ret = ((").Append(classSymbol.FullQualifiedNameIncludeGlobal())
                 .Append(")godotObject).@")
                 .Append(propertyMemberName).Append(";\n");
             source
-                .Append("            return ")
+                .Append("                return ")
                 .AppendManagedToNativeVariantExpr("ret", propertyTypeSymbol, propertyMarshalType)
                 .Append(";\n");
 
-            source.Append("        }\n");
+            source.Append("            }\n");
         }
 
         private static void GeneratePropertySetterTrampoline(
@@ -422,18 +425,18 @@ namespace Godot.SourceGenerators
         )
         {
             source
-                .Append("        static void trampoline_set_").Append(propertyMemberName)
-                .Append("(object godotObject, in godot_variant value)\n        {\n");
+                .Append("            static void trampoline_set_").Append(propertyMemberName)
+                .Append("(object godotObject, in godot_variant value)\n            {\n");
 
             source
-                .Append("            ((").Append(classSymbol.FullQualifiedNameIncludeGlobal())
+                .Append("                ((").Append(classSymbol.FullQualifiedNameIncludeGlobal())
                 .Append(")godotObject).@")
                 .Append(propertyMemberName)
                 .Append(" = ")
                 .AppendNativeVariantToManagedExpr("value", propertyTypeSymbol, propertyMarshalType)
                 .Append(";\n");
 
-            source.Append("        }\n");
+            source.Append("            }\n");
         }
 
         private static void AppendGroupingPropertyInfo(StringBuilder source, PropertyInfo propertyInfo)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -253,20 +253,12 @@ namespace Godot.SourceGenerators
 
             if (godotSignalDelegates.Count > 0)
             {
-                const string DictType =
-                    "global::System.Collections.Generic.Dictionary<global::Godot.Bridge.SignalKey, global::Godot.Bridge.RaiseSignalTrampoline>";
+                const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.RaiseSignalTrampolineCollector";
 
                 source.Append(
                     "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static unsafe ")
-                    .Append(DictType)
-                    .Append(" GetGodotRaiseSignalTrampolines()\n    {\n");
-
-                source.Append("        var trampolines = new ")
-                    .Append(DictType)
-                    .Append("(")
-                    .Append(godotSignalDelegates.Count)
-                    .Append(");\n");
+                source.Append("    internal new static unsafe void GetGodotRaiseSignalTrampolines(")
+                    .Append(CollectorType).Append(" collector)\n    {\n");
 
                 foreach (var signal in godotSignalDelegates)
                 {
@@ -274,7 +266,6 @@ namespace Godot.SourceGenerators
                     AppendRaiseSignalTrampoline(source, signal);
                 }
 
-                source.Append("        return trampolines;\n");
                 source.Append("    }\n");
             }
 
@@ -502,7 +493,7 @@ namespace Godot.SourceGenerators
             string methodName = signal.Name;
             int parameterCount = signal.InvokeMethodData.ParamTypes.Length;
 
-            source.Append("        trampolines.Add(new(SignalName.@")
+            source.Append("        collector.TryAdd(new(SignalName.@")
                 .Append(methodName).Append(", ").Append(parameterCount)
                 .Append("), new(&trampoline_")
                 .Append(parameterCount).Append("_").Append(methodName)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -65,9 +65,9 @@ namespace Godot.SourceGenerators
         )
         {
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
-            string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace ?
-                namespaceSymbol.FullQualifiedNameOmitGlobal() :
-                string.Empty;
+            string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace
+                ? namespaceSymbol.FullQualifiedNameOmitGlobal()
+                : string.Empty;
             bool hasNamespace = classNs.Length != 0;
 
             bool isInnerClass = symbol.ContainingType != null;
@@ -226,7 +226,8 @@ namespace Godot.SourceGenerators
                     .Append("    /// Do not call this method.\n")
                     .Append("    /// </summary>\n");
 
-                source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+                source.Append(
+                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
 
                 source.Append("    internal new static ")
                     .Append(ListType)
@@ -245,6 +246,35 @@ namespace Godot.SourceGenerators
                 }
 
                 source.Append("        return signals;\n");
+                source.Append("    }\n");
+            }
+
+            // Generate GetGodotMethodTrampolines
+
+            if (godotSignalDelegates.Count > 0)
+            {
+                const string DictType =
+                    "global::System.Collections.Generic.Dictionary<global::Godot.Bridge.SignalKey, global::Godot.Bridge.RaiseSignalTrampoline>";
+
+                source.Append(
+                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+                source.Append("    internal new static unsafe ")
+                    .Append(DictType)
+                    .Append(" GetGodotRaiseSignalTrampolines()\n    {\n");
+
+                source.Append("        var trampolines = new ")
+                    .Append(DictType)
+                    .Append("(")
+                    .Append(godotSignalDelegates.Count)
+                    .Append(");\n");
+
+                foreach (var signal in godotSignalDelegates)
+                {
+                    GenerateRaiseSignalTrampoline(symbol, signal, source);
+                    AppendRaiseSignalTrampoline(source, signal);
+                }
+
+                source.Append("        return trampolines;\n");
                 source.Append("    }\n");
             }
 
@@ -287,9 +317,8 @@ namespace Godot.SourceGenerators
                 var invokeMethodSymbol = signalDelegate.InvokeMethodData.Method;
                 int paramCount = invokeMethodSymbol.Parameters.Length;
 
-                string raiseMethodModifiers = signalDelegate.DelegateSymbol.ContainingType.IsSealed ?
-                    "private" :
-                    "protected";
+                string raiseMethodModifiers =
+                    signalDelegate.DelegateSymbol.ContainingType.IsSealed ? "private" : "protected";
 
                 source.Append($"    {raiseMethodModifiers} void EmitSignal{signalName}(");
                 for (int i = 0; i < paramCount; i++)
@@ -301,6 +330,7 @@ namespace Godot.SourceGenerators
                         source.Append(", ");
                     }
                 }
+
                 source.Append(")\n");
                 source.Append("    {\n");
                 source.Append($"        EmitSignal(SignalName.{signalName}, [");
@@ -321,46 +351,8 @@ namespace Godot.SourceGenerators
 
                     source.Append($"@{paramSymbol.Name}");
                 }
+
                 source.Append("]);\n");
-                source.Append("    }\n");
-            }
-
-            // Generate RaiseGodotClassSignalCallbacks
-
-            if (godotSignalDelegates.Count > 0)
-            {
-                source.Append("    /// <inheritdoc/>\n");
-                source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append(
-                    "    protected override void RaiseGodotClassSignalCallbacks(in godot_string_name signal, ");
-                source.Append("NativeVariantPtrArgs args)\n    {\n");
-
-                foreach (var signal in godotSignalDelegates)
-                {
-                    GenerateSignalEventInvoker(signal, source);
-                }
-
-                source.Append("        base.RaiseGodotClassSignalCallbacks(signal, args);\n");
-
-                source.Append("    }\n");
-            }
-
-            // Generate HasGodotClassSignal
-
-            if (godotSignalDelegates.Count > 0)
-            {
-                source.Append("    /// <inheritdoc/>\n");
-                source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append(
-                    "    protected override bool HasGodotClassSignal(in godot_string_name signal)\n    {\n");
-
-                foreach (var signal in godotSignalDelegates)
-                {
-                    GenerateHasSignalEntry(signal.Name, source);
-                }
-
-                source.Append("        return base.HasGodotClassSignal(signal);\n");
-
                 source.Append("    }\n");
             }
 
@@ -440,6 +432,7 @@ namespace Godot.SourceGenerators
                     .Append(propertyInfo.ClassName)
                     .Append("\")");
             }
+
             source.Append(")");
         }
 
@@ -504,31 +497,52 @@ namespace Godot.SourceGenerators
                 PropertyHint.None, string.Empty, propUsage, className, exported: false);
         }
 
-        private static void GenerateHasSignalEntry(
-            string signalName,
-            StringBuilder source
-        )
+        private static void AppendRaiseSignalTrampoline(StringBuilder source, GodotSignalDelegateData signal)
         {
-            source.Append("        ");
-            source.Append("if (signal == SignalName.@");
-            source.Append(signalName);
-            source.Append(") {\n           return true;\n        }\n");
+            string methodName = signal.Name;
+            int parameterCount = signal.InvokeMethodData.ParamTypes.Length;
+
+            source.Append("        trampolines.Add(new(SignalName.@")
+                .Append(methodName).Append(", ").Append(parameterCount)
+                .Append("), new global::Godot.Bridge.RaiseSignalTrampoline(&trampoline_")
+                .Append(parameterCount).Append("_").Append(methodName)
+                .Append("));\n");
         }
 
-        private static void GenerateSignalEventInvoker(
+        private static void GenerateRaiseSignalTrampoline(
+            INamedTypeSymbol classSymbol,
             GodotSignalDelegateData signal,
             StringBuilder source
         )
         {
             string signalName = signal.Name;
             var invokeMethodData = signal.InvokeMethodData;
+            int parameterCount = invokeMethodData.ParamTypes.Length;
 
-            source.Append("        if (signal == SignalName.@");
-            source.Append(signalName);
-            source.Append(" && args.Count == ");
-            source.Append(invokeMethodData.ParamTypes.Length);
+            source.Append("        [global::System.Runtime.InteropServices.UnmanagedCallersOnly]\n");
+            source.Append("        static void trampoline_")
+                .Append(parameterCount).Append("_").Append(signalName);
+
+            source.Append("(global::System.IntPtr godotObjectGCHandle, godot_variant** args, int argCount, ");
+            source.Append("godot_bool* outOwnerIsNull)\n        {\n");
+
+            source.Append("          try {\n");
+
+            source.Append("            if (argCount != ");
+            source.Append(parameterCount);
             source.Append(") {\n");
-            source.Append("            backing_");
+            source.Append("                return;\n");
+            source.Append("            }\n");
+
+            source
+                .Append("            var godotObject = (").Append(classSymbol.FullQualifiedNameIncludeGlobal())
+                .Append(")global::System.Runtime.InteropServices.GCHandle.FromIntPtr(godotObjectGCHandle).Target;\n")
+                .Append("            if (godotObject == null) {\n")
+                .Append("                *outOwnerIsNull = godot_bool.True;\n")
+                .Append("                return;\n")
+                .Append("            }\n");
+
+            source.Append("            godotObject.backing_");
             source.Append(signalName);
             source.Append("?.Invoke(");
 
@@ -537,13 +551,15 @@ namespace Godot.SourceGenerators
                 if (i != 0)
                     source.Append(", ");
 
-                source.AppendNativeVariantToManagedExpr(string.Concat("args[", i.ToString(), "]"),
+                source.AppendNativeVariantToManagedExpr(string.Concat("*(args[", i.ToString(), "])"),
                     invokeMethodData.ParamTypeSymbols[i], invokeMethodData.ParamTypes[i]);
             }
 
             source.Append(");\n");
 
-            source.Append("            return;\n");
+            source.Append("          } catch (global::System.Exception e) {\n");
+            source.Append("              global::Godot.NativeInterop.ExceptionUtils.LogException(e);\n");
+            source.Append("          }\n");
 
             source.Append("        }\n");
         }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -64,6 +64,9 @@ namespace Godot.SourceGenerators
             INamedTypeSymbol symbol
         )
         {
+            var options = context.Compilation.Options as Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions;
+            bool isUnsafeAllowed = options?.AllowUnsafe ?? false;
+
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
             string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace
                 ? namespaceSymbol.FullQualifiedNameOmitGlobal()
@@ -257,13 +260,15 @@ namespace Godot.SourceGenerators
 
                 source.Append(
                     "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static unsafe void GetGodotRaiseSignalTrampolines(")
+                source.Append("    internal new static ")
+                    .Append(isUnsafeAllowed ? "unsafe " : "")
+                    .Append("void GetGodotRaiseSignalTrampolines(")
                     .Append(CollectorType).Append(" collector)\n    {\n");
 
                 foreach (var signal in godotSignalDelegates)
                 {
                     GenerateRaiseSignalTrampoline(symbol, signal, source);
-                    AppendRaiseSignalTrampoline(source, signal);
+                    AppendRaiseSignalTrampoline(source, signal, isUnsafeAllowed);
                 }
 
                 source.Append("    }\n");
@@ -488,16 +493,41 @@ namespace Godot.SourceGenerators
                 PropertyHint.None, string.Empty, propUsage, className, exported: false);
         }
 
-        private static void AppendRaiseSignalTrampoline(StringBuilder source, GodotSignalDelegateData signal)
+        private static void AppendRaiseSignalTrampoline(StringBuilder source, GodotSignalDelegateData signal,
+            bool isUnsafeAllowed)
         {
-            string methodName = signal.Name;
+            string signalName = signal.Name;
             int parameterCount = signal.InvokeMethodData.ParamTypes.Length;
 
+            if (!isUnsafeAllowed)
+            {
+                source.Append("        var aux_delegate_")
+                    .Append(parameterCount).Append("_").Append(signalName)
+                    .Append(" = ")
+                    .Append("trampoline_")
+                    .Append(parameterCount).Append("_").Append(signalName)
+                    .Append(";\n");
+            }
+
             source.Append("        collector.TryAdd(new(SignalName.@")
-                .Append(methodName).Append(", ").Append(parameterCount)
-                .Append("), new(&trampoline_")
-                .Append(parameterCount).Append("_").Append(methodName)
-                .Append("));\n");
+                .Append(signalName).Append(", ").Append(parameterCount)
+                .Append("), new(");
+
+            if (isUnsafeAllowed)
+            {
+                source
+                    .Append("&trampoline_")
+                    .Append(parameterCount).Append("_").Append(signalName);
+            }
+            else
+            {
+                source
+                    .Append("aux_delegate_")
+                    .Append(parameterCount).Append("_").Append(signalName)
+                    .Append(".Method.MethodHandle.GetFunctionPointer()");
+            }
+
+            source.Append("));\n");
         }
 
         private static void GenerateRaiseSignalTrampoline(

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -193,8 +193,9 @@ namespace Godot.SourceGenerators
                 .Append("    /// Cached StringNames for the signals contained in this class, for fast lookup.\n")
                 .Append("    /// </summary>\n");
 
-            source.Append(
-                $"    public new class SignalName : {symbol.BaseType!.FullQualifiedNameIncludeGlobal()}.SignalName {{\n");
+            source.Append("    public new class SignalName : ")
+                .Append(symbol.BaseType!.FullQualifiedNameIncludeGlobal())
+                .Append(".SignalName {\n");
 
             // Generate cached StringNames for methods and properties, for fast lookup
 
@@ -254,16 +255,15 @@ namespace Godot.SourceGenerators
 
             // Generate GetGodotMethodTrampolines
 
-            if (godotSignalDelegates.Count > 0)
             {
+                source.Append("    private static partial class GodotInternal\n    {\n");
+
                 const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.RaiseSignalTrampolineCollector";
 
-                source.Append(
-                    "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    internal new static ")
+                source.Append("        internal new static ")
                     .Append(isUnsafeAllowed ? "unsafe " : "")
                     .Append("void GetGodotRaiseSignalTrampolines(")
-                    .Append(CollectorType).Append(" collector)\n    {\n");
+                    .Append(CollectorType).Append(" collector)\n        {\n");
 
                 foreach (var signal in godotSignalDelegates)
                 {
@@ -271,7 +271,9 @@ namespace Godot.SourceGenerators
                     AppendRaiseSignalTrampoline(source, signal, isUnsafeAllowed);
                 }
 
-                source.Append("    }\n");
+                source.Append("        }\n");
+
+                source.Append("    }\n"); // partial class GodotInternal
             }
 
             source.Append("#pragma warning restore CS0109\n");
@@ -306,7 +308,7 @@ namespace Godot.SourceGenerators
                     .Append("        remove => backing_")
                     .Append(signalName)
                     .Append(" -= value;\n")
-                    .Append("}\n");
+                    .Append("    }\n");
 
                 // Generate EmitSignal{EventName} method to raise the event
 
@@ -501,7 +503,7 @@ namespace Godot.SourceGenerators
 
             if (!isUnsafeAllowed)
             {
-                source.Append("        var aux_delegate_")
+                source.Append("            var aux_delegate_")
                     .Append(parameterCount).Append("_").Append(signalName)
                     .Append(" = ")
                     .Append("trampoline_")
@@ -509,7 +511,7 @@ namespace Godot.SourceGenerators
                     .Append(";\n");
             }
 
-            source.Append("        collector.TryAdd(new(SignalName.@")
+            source.Append("            collector.TryAdd(new(SignalName.@")
                 .Append(signalName).Append(", ").Append(parameterCount)
                 .Append("), new(");
 
@@ -541,18 +543,18 @@ namespace Godot.SourceGenerators
             int parameterCount = invokeMethodData.ParamTypes.Length;
 
             source
-                .Append("        static void trampoline_")
+                .Append("            static void trampoline_")
                 .Append(parameterCount).Append("_").Append(signalName)
-                .Append("(object godotObject, NativeVariantPtrArgs args)\n        {\n");
+                .Append("(object godotObject, NativeVariantPtrArgs args)\n            {\n");
 
-            source.Append("            if (args.Count != ");
+            source.Append("                if (args.Count != ");
             source.Append(parameterCount);
             source.Append(") {\n");
-            source.Append("                return;\n");
-            source.Append("            }\n");
+            source.Append("                    return;\n");
+            source.Append("                }\n");
 
             source
-                .Append("            ((").Append(classSymbol.FullQualifiedNameIncludeGlobal())
+                .Append("                ((").Append(classSymbol.FullQualifiedNameIncludeGlobal())
                 .Append(")godotObject).backing_")
                 .Append(signalName)
                 .Append("?.Invoke(");
@@ -568,7 +570,7 @@ namespace Godot.SourceGenerators
 
             source.Append(");\n");
 
-            source.Append("        }\n");
+            source.Append("            }\n");
         }
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -256,9 +256,10 @@ namespace Godot.SourceGenerators
             // Generate GetGodotMethodTrampolines
 
             {
-                source.Append("    private static partial class GodotInternal\n    {\n");
+                source.Append("    ").Append(symbol.IsSealed ? "" : "protected ")
+                    .Append("internal new static partial class GodotInternal\n    {\n");
 
-                const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.RaiseSignalTrampolineCollector";
+                const string CollectorType = "global::Godot.Bridge.RaiseSignalTrampolineCollector";
 
                 source.Append("        internal new static ")
                     .Append(isUnsafeAllowed ? "unsafe " : "")

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -143,7 +143,7 @@ namespace Godot.SourceGenerators
 
                 if (invokeMethodData == null)
                 {
-                    if (signalDelegateSymbol.DelegateInvokeMethod is IMethodSymbol methodSymbol)
+                    if (signalDelegateSymbol.DelegateInvokeMethod is { } methodSymbol)
                     {
                         foreach (var parameter in methodSymbol.Parameters)
                         {
@@ -212,7 +212,7 @@ namespace Godot.SourceGenerators
                 source.Append("\";\n");
             }
 
-            source.Append("    }\n"); // class GodotInternal
+            source.Append("    }\n"); // end of class SignalName
 
             // Generate GetGodotSignalList
 
@@ -504,7 +504,7 @@ namespace Godot.SourceGenerators
 
             source.Append("        trampolines.Add(new(SignalName.@")
                 .Append(methodName).Append(", ").Append(parameterCount)
-                .Append("), new global::Godot.Bridge.RaiseSignalTrampoline(&trampoline_")
+                .Append("), new(&trampoline_")
                 .Append(parameterCount).Append("_").Append(methodName)
                 .Append("));\n");
         }
@@ -519,47 +519,33 @@ namespace Godot.SourceGenerators
             var invokeMethodData = signal.InvokeMethodData;
             int parameterCount = invokeMethodData.ParamTypes.Length;
 
-            source.Append("        [global::System.Runtime.InteropServices.UnmanagedCallersOnly]\n");
-            source.Append("        static void trampoline_")
-                .Append(parameterCount).Append("_").Append(signalName);
+            source
+                .Append("        static void trampoline_")
+                .Append(parameterCount).Append("_").Append(signalName)
+                .Append("(object godotObject, NativeVariantPtrArgs args)\n        {\n");
 
-            source.Append("(global::System.IntPtr godotObjectGCHandle, godot_variant** args, int argCount, ");
-            source.Append("godot_bool* outOwnerIsNull)\n        {\n");
-
-            source.Append("          try {\n");
-
-            source.Append("            if (argCount != ");
+            source.Append("            if (args.Count != ");
             source.Append(parameterCount);
             source.Append(") {\n");
             source.Append("                return;\n");
             source.Append("            }\n");
 
             source
-                .Append("            var godotObject = (").Append(classSymbol.FullQualifiedNameIncludeGlobal())
-                .Append(")global::System.Runtime.InteropServices.GCHandle.FromIntPtr(godotObjectGCHandle).Target;\n")
-                .Append("            if (godotObject == null) {\n")
-                .Append("                *outOwnerIsNull = godot_bool.True;\n")
-                .Append("                return;\n")
-                .Append("            }\n");
-
-            source.Append("            godotObject.backing_");
-            source.Append(signalName);
-            source.Append("?.Invoke(");
+                .Append("            ((").Append(classSymbol.FullQualifiedNameIncludeGlobal())
+                .Append(")godotObject).backing_")
+                .Append(signalName)
+                .Append("?.Invoke(");
 
             for (int i = 0; i < invokeMethodData.ParamTypes.Length; i++)
             {
                 if (i != 0)
                     source.Append(", ");
 
-                source.AppendNativeVariantToManagedExpr(string.Concat("*(args[", i.ToString(), "])"),
+                source.AppendNativeVariantToManagedExpr(string.Concat("args[", i.ToString(), "]"),
                     invokeMethodData.ParamTypeSymbols[i], invokeMethodData.ParamTypes[i]);
             }
 
             source.Append(");\n");
-
-            source.Append("          } catch (global::System.Exception e) {\n");
-            source.Append("              global::Godot.NativeInterop.ExceptionUtils.LogException(e);\n");
-            source.Append("          }\n");
 
             source.Append("        }\n");
         }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/TrampolineCollectorDispatchGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/TrampolineCollectorDispatchGenerator.cs
@@ -126,8 +126,6 @@ public class TrampolineCollectorDispatchGenerator : ISourceGenerator
 
         source
             .Append("        ").Append(symbol.FullQualifiedNameIncludeGlobal()).Append(".GodotInternal")
-            .Append(".GetGodotMethodNameToProxyNameMap(collectors.NameToProxyNameMapCollector);\n")
-            .Append("        ").Append(symbol.FullQualifiedNameIncludeGlobal()).Append(".GodotInternal")
             .Append(".GetGodotMethodTrampolines(collectors.MethodTrampolineCollector);\n")
             .Append("        ").Append(symbol.FullQualifiedNameIncludeGlobal()).Append(".GodotInternal")
             .Append(".GetGodotPropertyTrampolines(collectors.PropertyTrampolineCollector);\n")

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/TrampolineCollectorDispatchGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/TrampolineCollectorDispatchGenerator.cs
@@ -1,0 +1,171 @@
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Godot.SourceGenerators;
+
+[Generator]
+public class TrampolineCollectorDispatchGenerator : ISourceGenerator
+{
+    public void Initialize(GeneratorInitializationContext context)
+    {
+    }
+
+    public void Execute(GeneratorExecutionContext context)
+    {
+        if (context.IsGodotSourceGeneratorDisabled("ScriptMethods"))
+            return;
+
+        INamedTypeSymbol[] godotClasses = context
+            .Compilation.SyntaxTrees
+            .SelectMany(tree =>
+                tree.GetRoot().DescendantNodes()
+                    .OfType<ClassDeclarationSyntax>()
+                    .SelectGodotScriptClasses(context.Compilation)
+                    // Report and skip non-partial classes
+                    .Where(x =>
+                    {
+                        if (x.cds.IsPartial())
+                        {
+                            if (x.cds.IsNested() && !x.cds.AreAllOuterTypesPartial(out _))
+                            {
+                                return false;
+                            }
+
+                            return true;
+                        }
+
+                        return false;
+                    })
+                    .Select(x => x.symbol)
+            )
+            .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default)
+            .ToArray();
+
+        if (godotClasses.Length > 0)
+        {
+            foreach (var godotClass in godotClasses)
+            {
+                VisitGodotScriptClass(context, godotClass);
+            }
+        }
+    }
+
+    private static void VisitGodotScriptClass(
+        GeneratorExecutionContext context,
+        INamedTypeSymbol symbol
+    )
+    {
+        INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
+        string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace
+            ? namespaceSymbol.FullQualifiedNameOmitGlobal()
+            : string.Empty;
+        bool hasNamespace = classNs.Length != 0;
+
+        bool isInnerClass = symbol.ContainingType != null;
+
+        string uniqueHint = symbol.FullQualifiedNameOmitGlobal().SanitizeQualifiedNameForUniqueHint()
+                            + "_TrampolineCollectorDispatch.generated";
+
+        var source = new StringBuilder();
+
+        source.Append("using Godot;\n");
+        source.Append("using Godot.NativeInterop;\n");
+        source.Append("\n");
+
+        if (hasNamespace)
+        {
+            source.Append("namespace ");
+            source.Append(classNs);
+            source.Append(";\n\n");
+        }
+
+        if (isInnerClass)
+        {
+            AppendPartialContainingTypeDeclarations(symbol.ContainingType);
+
+            void AppendPartialContainingTypeDeclarations(INamedTypeSymbol? containingType)
+            {
+                if (containingType == null)
+                    return;
+
+                AppendPartialContainingTypeDeclarations(containingType.ContainingType);
+
+                source.Append("partial ");
+                source.Append(containingType.GetDeclarationKeyword());
+                source.Append(" ");
+                source.Append(containingType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+                source.Append("\n{\n");
+            }
+        }
+
+        source.Append("partial class ");
+        source.Append(symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+        source.Append("\n{\n");
+
+        source.Append("#pragma warning disable CS0628 // Disable warning about redundant 'new' keyword\n");
+        source.Append("#pragma warning disable CS0109")
+            .Append(" // Disable warning about new protected member declared in sealed type\n");
+
+        const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.TrampolineCollectors";
+        const string OptionsType = "global::Godot.Bridge.ScriptManagerBridge.TrampolineCollectionOptions";
+
+        source.Append("    /// <summary>\n")
+            .Append("    /// Collects the trampolines for all the members visible to Godot.\n")
+            .Append(
+                "    /// This method is used by Godot to collect the trampolines to call this class's members from the native side.\n")
+            .Append("    /// Do not call this method.\n")
+            .Append("    /// </summary>\n");
+
+        source.Append(
+                "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n")
+            .Append("    protected internal new static void GetGodotClassTrampolines(")
+            .Append(CollectorType).Append(" collectors, ").Append(OptionsType).Append(" options)\n    {\n");
+
+        source
+            .Append("        ").Append(symbol.FullQualifiedNameIncludeGlobal()).Append(".GodotInternal")
+            .Append(".GetGodotMethodNameToProxyNameMap(collectors.NameToProxyNameMapCollector);\n")
+            .Append("        ").Append(symbol.FullQualifiedNameIncludeGlobal()).Append(".GodotInternal")
+            .Append(".GetGodotMethodTrampolines(collectors.MethodTrampolineCollector);\n")
+            .Append("        ").Append(symbol.FullQualifiedNameIncludeGlobal()).Append(".GodotInternal")
+            .Append(".GetGodotPropertyTrampolines(collectors.PropertyTrampolineCollector);\n")
+            .Append("        ").Append(symbol.FullQualifiedNameIncludeGlobal()).Append(".GodotInternal")
+            .Append(".GetGodotRaiseSignalTrampolines(collectors.RaiseSignalTrampolineCollector);\n");
+
+        var usableBaseType = symbol.GetClosestBaseTypeDeclaringGodotInternalMethod("GetGodotClassTrampolines");
+
+        if (usableBaseType != null)
+        {
+            source
+                .Append("            if (options.IncludeAncestors) {\n")
+                .Append("                ").Append(usableBaseType.FullQualifiedNameIncludeGlobal())
+                .Append(".GodotInternal.GetGodotClassTrampolines(collectors, options);\n")
+                .Append("            }\n");
+        }
+
+
+        source
+            .Append("    }\n");
+
+        source.Append("#pragma warning restore CS0109\n");
+        source.Append("#pragma warning restore CS0628\n");
+
+        source.Append("}\n"); // partial class
+
+        if (isInnerClass)
+        {
+            var containingType = symbol.ContainingType;
+
+            while (containingType != null)
+            {
+                source.Append("}\n"); // outer class
+
+                containingType = containingType.ContainingType;
+            }
+        }
+
+        context.AddSource(uniqueHint, SourceText.From(source.ToString(), Encoding.UTF8));
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/TrampolineCollectorDispatchGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/TrampolineCollectorDispatchGenerator.cs
@@ -109,27 +109,29 @@ public class TrampolineCollectorDispatchGenerator : ISourceGenerator
         source.Append("#pragma warning disable CS0109")
             .Append(" // Disable warning about new protected member declared in sealed type\n");
 
-        const string CollectorType = "global::Godot.Bridge.ScriptManagerBridge.TrampolineCollectors";
-        const string OptionsType = "global::Godot.Bridge.ScriptManagerBridge.TrampolineCollectionOptions";
+        source.Append("    ").Append(symbol.IsSealed ? "" : "protected ")
+            .Append("internal new static partial class GodotInternal\n    {\n");
 
-        source.Append("    /// <summary>\n")
-            .Append("    /// Collects the trampolines for all the members visible to Godot.\n")
+        const string CollectorType = "global::Godot.Bridge.TrampolineCollectors";
+        const string OptionsType = "global::Godot.Bridge.TrampolineCollectionOptions";
+
+        source.Append("        /// <summary>\n")
+            .Append("        /// Collects the trampolines for all the members visible to Godot.\n")
             .Append(
-                "    /// This method is used by Godot to collect the trampolines to call this class's members from the native side.\n")
-            .Append("    /// Do not call this method.\n")
-            .Append("    /// </summary>\n");
-
-        source.Append(
-                "    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n")
-            .Append("    protected internal new static void GetGodotClassTrampolines(")
-            .Append(CollectorType).Append(" collectors, ").Append(OptionsType).Append(" options)\n    {\n");
+                "        /// This method is used by Godot to collect the trampolines to call this class's members from the native side.\n")
+            .Append("        /// Do not call this method.\n")
+            .Append("        /// </summary>\n");
 
         source
-            .Append("        ").Append(symbol.FullQualifiedNameIncludeGlobal()).Append(".GodotInternal")
+            .Append("        public static void GetGodotClassTrampolines(")
+            .Append(CollectorType).Append(" collectors, ").Append(OptionsType).Append(" options)\n        {\n");
+
+        source
+            .Append("            ").Append(symbol.FullQualifiedNameIncludeGlobal()).Append(".GodotInternal")
             .Append(".GetGodotMethodTrampolines(collectors.MethodTrampolineCollector);\n")
-            .Append("        ").Append(symbol.FullQualifiedNameIncludeGlobal()).Append(".GodotInternal")
+            .Append("            ").Append(symbol.FullQualifiedNameIncludeGlobal()).Append(".GodotInternal")
             .Append(".GetGodotPropertyTrampolines(collectors.PropertyTrampolineCollector);\n")
-            .Append("        ").Append(symbol.FullQualifiedNameIncludeGlobal()).Append(".GodotInternal")
+            .Append("            ").Append(symbol.FullQualifiedNameIncludeGlobal()).Append(".GodotInternal")
             .Append(".GetGodotRaiseSignalTrampolines(collectors.RaiseSignalTrampolineCollector);\n");
 
         var usableBaseType = symbol.GetClosestBaseTypeDeclaringGodotInternalMethod("GetGodotClassTrampolines");
@@ -145,7 +147,9 @@ public class TrampolineCollectorDispatchGenerator : ISourceGenerator
 
 
         source
-            .Append("    }\n");
+            .Append("        }\n");
+
+        source.Append("    }\n"); // partial class GodotInternal
 
         source.Append("#pragma warning restore CS0109\n");
         source.Append("#pragma warning restore CS0628\n");

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs
@@ -99,7 +99,8 @@ namespace Godot.Bridge
                 // Signals
                 if (godotObject.HasGodotClassSignal(CustomUnsafe.AsRef(name)))
                 {
-                    godot_signal signal = new godot_signal(NativeFuncs.godotsharp_string_name_new_copy(*name), godotObject.GetInstanceId());
+                    godot_signal signal = new godot_signal(NativeFuncs.godotsharp_string_name_new_copy(*name),
+                        godotObject.GetInstanceId());
                     *outRet = VariantUtils.CreateFromSignalTakingOwnershipOfDisposableValue(signal);
                     return godot_bool.True;
                 }
@@ -107,7 +108,8 @@ namespace Godot.Bridge
                 // Methods
                 if (godotObject.HasGodotClassMethod(CustomUnsafe.AsRef(name)))
                 {
-                    godot_callable method = new godot_callable(NativeFuncs.godotsharp_string_name_new_copy(*name), godotObject.GetInstanceId());
+                    godot_callable method = new godot_callable(NativeFuncs.godotsharp_string_name_new_copy(*name),
+                        godotObject.GetInstanceId());
                     *outRet = VariantUtils.CreateFromCallableTakingOwnershipOfDisposableValue(method);
                     return godot_bool.True;
                 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs
@@ -8,7 +8,7 @@ namespace Godot.Bridge
     {
         [UnmanagedCallersOnly]
         internal static unsafe godot_bool Call(IntPtr godotObjectGCHandle, godot_string_name* method,
-            godot_variant** args, int argCount, godot_variant_call_error* refCallError, godot_variant* ret)
+            godot_variant** args, int argCount, godot_variant_call_error* refCallError, godot_variant* outRet)
         {
             try
             {
@@ -16,7 +16,7 @@ namespace Godot.Bridge
 
                 if (godotObject == null)
                 {
-                    *ret = default;
+                    *outRet = default;
                     (*refCallError).Error = godot_variant_call_error_error.GODOT_CALL_ERROR_CALL_ERROR_INSTANCE_IS_NULL;
                     return godot_bool.False;
                 }
@@ -26,20 +26,20 @@ namespace Godot.Bridge
 
                 if (!methodInvoked)
                 {
-                    *ret = default;
+                    *outRet = default;
                     // This is important, as it tells Object::call that no method was called.
                     // Otherwise, it would prevent Object::call from calling native methods.
                     (*refCallError).Error = godot_variant_call_error_error.GODOT_CALL_ERROR_CALL_ERROR_INVALID_METHOD;
                     return godot_bool.False;
                 }
 
-                *ret = retValue;
+                *outRet = retValue;
                 return godot_bool.True;
             }
             catch (Exception e)
             {
                 ExceptionUtils.LogException(e);
-                *ret = default;
+                *outRet = default;
                 return godot_bool.False;
             }
         }
@@ -52,7 +52,7 @@ namespace Godot.Bridge
                 var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
 
                 if (godotObject == null)
-                    throw new InvalidOperationException();
+                    throw new InvalidOperationException("Godot Object instance is null.");
 
                 if (godotObject.SetGodotClassPropertyValue(CustomUnsafe.AsRef(name), CustomUnsafe.AsRef(value)))
                 {
@@ -87,7 +87,7 @@ namespace Godot.Bridge
                 var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
 
                 if (godotObject == null)
-                    throw new InvalidOperationException();
+                    throw new InvalidOperationException("Godot Object instance is null.");
 
                 // Properties
                 if (godotObject.GetGodotClassPropertyValue(CustomUnsafe.AsRef(name), out godot_variant outRetValue))
@@ -131,6 +131,79 @@ namespace Godot.Bridge
                 }
 
                 *outRet = ret.CopyNativeVariant();
+                return godot_bool.True;
+            }
+            catch (Exception e)
+            {
+                ExceptionUtils.LogException(e);
+                *outRet = default;
+                return godot_bool.False;
+            }
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe godot_bool CallViaTrampoline(
+            MethodTrampolineDelegate methodTrampoline,
+            IntPtr godotObjectGCHandle, godot_variant** args, int argCount,
+            godot_variant_call_error* refCallError, godot_variant* outRet)
+        {
+            try
+            {
+                object godotObject = GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+
+                if (godotObject == null)
+                {
+                    *outRet = default;
+                    (*refCallError).Error = godot_variant_call_error_error.GODOT_CALL_ERROR_CALL_ERROR_INSTANCE_IS_NULL;
+                    return godot_bool.False;
+                }
+
+                *outRet = methodTrampoline(godotObject, new NativeVariantPtrArgs(args, argCount), ref *refCallError);
+                return godot_bool.True;
+            }
+            catch (Exception e)
+            {
+                ExceptionUtils.LogException(e);
+                *outRet = default;
+                return godot_bool.False;
+            }
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe godot_bool SetViaTrampoline(
+            PropertySetterTrampolineDelegate setterTrampoline,
+            IntPtr godotObjectGCHandle, godot_variant* value)
+        {
+            try
+            {
+                object godotObject = GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+
+                if (godotObject == null)
+                    throw new InvalidOperationException("Godot Object instance is null.");
+
+                setterTrampoline(godotObject, *value);
+                return godot_bool.True;
+            }
+            catch (Exception e)
+            {
+                ExceptionUtils.LogException(e);
+                return godot_bool.False;
+            }
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe godot_bool GetViaTrampoline(
+            PropertyGetterTrampolineDelegate getterTrampoline,
+            IntPtr godotObjectGCHandle, godot_variant* outRet)
+        {
+            try
+            {
+                object godotObject = GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+
+                if (godotObject == null)
+                    throw new InvalidOperationException("Godot Object instance is null.");
+
+                *outRet = getterTrampoline(godotObject);
                 return godot_bool.True;
             }
             catch (Exception e)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/Collectors.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/Collectors.cs
@@ -1,0 +1,172 @@
+using System;
+using Godot.NativeInterop;
+
+namespace Godot.Bridge;
+
+using PropertyTrampolines = (PropertyGetterTrampoline getterTramp, PropertySetterTrampoline setterTramp);
+
+/// <summary>
+/// This is used to collect the method trampolines for a script.
+/// </summary>
+/// <remarks>
+/// The user script can implement a static method "GetGodotClassTrampolines"
+/// that receives an instance of <see cref="TrampolineCollectors"/> which
+/// contains an instance of this class. The user script can then call the
+/// <see cref="TryAdd"/> method of this class to add methodsto the script.<br/>
+/// <br/>
+/// "GetGodotClassTrampolines" must be called on the most derived class first,
+/// and after collecting the members for that class, its implementation must call the base
+/// implementation to also collect members from the base classes in inheritance order.<br/>
+/// As a result, <see cref="TryAdd"/> will not add a method from a base class if the derived class
+/// has already added a method with the same MethodKey.
+/// </remarks>
+public class MethodTrampolineCollector
+{
+    private IntPtr _scriptPtr;
+    private unsafe TryAddMethodTrampolineDelegate _tryAddDelegate;
+
+    internal unsafe MethodTrampolineCollector(IntPtr scriptPtr, TryAddMethodTrampolineDelegate tryAddDelegate)
+    {
+        _scriptPtr = scriptPtr;
+        _tryAddDelegate = tryAddDelegate;
+    }
+
+    internal unsafe void Update(IntPtr scriptPtr, TryAddMethodTrampolineDelegate tryAddDelegate)
+    {
+        _scriptPtr = scriptPtr;
+        _tryAddDelegate = tryAddDelegate;
+    }
+
+    /// <summary>
+    /// Adds a method trampoline to the script if a trampoline for the given method key doesn't already exist.
+    /// </summary>
+    public unsafe void TryAdd(MethodKey methodKey, MethodTrampoline trampoline)
+    {
+        var nameSelf = (godot_string_name)methodKey.Name.NativeValue;
+        _tryAddDelegate(_scriptPtr, &nameSelf, methodKey.ArgumentCount,
+            trampoline.TrampolineDelegate, trampoline.IsStatic.ToGodotBool());
+    }
+}
+
+/// <summary>
+/// This is used to collect the property trampolines for a script.
+/// </summary>
+/// <remarks>
+/// The user script can implement a static method "GetGodotClassTrampolines"
+/// that receives an instance of <see cref="TrampolineCollectors"/> which
+/// contains an instance of this class. The user script can then call the
+/// <see cref="TryAdd"/> method of this class to add properties to the script.<br/>
+/// <br/>
+/// "GetGodotClassTrampolines" must be called on the most derived class first,
+/// and after collecting the members for that class, its implementation must call the base
+/// implementation to also collect members from the base classes in inheritance order.<br/>
+/// As a result, <see cref="TryAdd"/> will not add a property from a base class if the derived class
+/// has already added a property with the same name.
+/// </remarks>
+public class PropertyTrampolineCollector
+{
+    private IntPtr _scriptPtr;
+    private unsafe TryAddPropertyTrampolineDelegate _tryAddDelegate;
+
+    internal unsafe PropertyTrampolineCollector(IntPtr scriptPtr,
+        TryAddPropertyTrampolineDelegate tryAddDelegate)
+    {
+        _scriptPtr = scriptPtr;
+        _tryAddDelegate = tryAddDelegate;
+    }
+
+    internal unsafe void Update(IntPtr scriptPtr, TryAddPropertyTrampolineDelegate tryAddDelegate)
+    {
+        _scriptPtr = scriptPtr;
+        _tryAddDelegate = tryAddDelegate;
+    }
+
+    /// <summary>
+    /// Adds property trampolines to the script if trampolines for the given property name don't already exist.
+    /// If trampolines for the property already exist, but one of the getter or setter trampolines is missing,
+    /// the missing trampoline will be added if provided. This allows a derived class to introduce a readonly
+    /// or writeonly property with the same name as a property in the base class, overriding that specific
+    /// accessor while inheriting the other one. This is done only to match the behavior of the old
+    /// trampoline system (SetGodotClassPropertyTrampoline and GetGodotClassPropertyTrampoline).
+    /// </summary>
+    public unsafe void TryAdd(StringName propertyName, PropertyTrampolines trampolines)
+    {
+        var propertyNameSelf = (godot_string_name)propertyName.NativeValue;
+        _tryAddDelegate(_scriptPtr, &propertyNameSelf,
+            trampolines.getterTramp.TrampolineDelegate,
+            trampolines.setterTramp.TrampolineDelegate);
+    }
+}
+
+/// <summary>
+/// This is used to collect the raise signal trampolines for a script.
+/// </summary>
+/// <remarks>
+/// The user script can implement a static method "GetGodotClassTrampolines"
+/// that receives an instance of <see cref="TrampolineCollectors"/> which
+/// contains an instance of this class. The user script can then call the
+/// <see cref="TryAdd"/> method of this class to add signals to the script.<br/>
+/// <br/>
+/// "GetGodotClassTrampolines" must be called on the most derived class first,
+/// and after collecting the members for that class, its implementation must call the base
+/// implementation to also collect members from the base classes in inheritance order.<br/>
+/// As a result, <see cref="TryAdd"/> will not add a signal from a base class if the derived class
+/// has already added a signal with the same SignalKey.
+/// </remarks>
+public class RaiseSignalTrampolineCollector
+{
+    private IntPtr _scriptPtr;
+    private unsafe TryAddRaiseSignalTrampolineDelegate _tryAddDelegate;
+
+    internal unsafe RaiseSignalTrampolineCollector(IntPtr scriptPtr,
+        TryAddRaiseSignalTrampolineDelegate tryAddDelegate)
+    {
+        _scriptPtr = scriptPtr;
+        _tryAddDelegate = tryAddDelegate;
+    }
+
+    internal unsafe void Update(IntPtr scriptPtr, TryAddRaiseSignalTrampolineDelegate tryAddDelegate)
+    {
+        _scriptPtr = scriptPtr;
+        _tryAddDelegate = tryAddDelegate;
+    }
+
+    /// <summary>
+    /// Adds a raise signal trampoline to the script if a trampoline for the given signal key doesn't already exist.
+    /// </summary>
+    public unsafe void TryAdd(SignalKey signalKey, RaiseSignalTrampoline trampoline)
+    {
+        var nameSelf = (godot_string_name)signalKey.Name.NativeValue;
+        _tryAddDelegate(_scriptPtr, &nameSelf, signalKey.ArgumentCount, trampoline.TrampolineDelegate);
+    }
+}
+
+/// <summary>
+/// Group of collectors passed to the user script to collect trampolines
+/// and method name to proxy name mappings for a script.
+/// </summary>
+public record TrampolineCollectors(
+    MethodTrampolineCollector MethodTrampolineCollector,
+    PropertyTrampolineCollector PropertyTrampolineCollector,
+    RaiseSignalTrampolineCollector RaiseSignalTrampolineCollector)
+{
+    internal unsafe void UpdateCollectors(IntPtr scriptPtr,
+        TryAddMethodTrampolineDelegate tryAddMethodTrampoline,
+        TryAddPropertyTrampolineDelegate tryAddPropertyTrampoline,
+        TryAddRaiseSignalTrampolineDelegate tryAddRaiseSignalTrampoline)
+    {
+        MethodTrampolineCollector.Update(scriptPtr, tryAddMethodTrampoline);
+        PropertyTrampolineCollector.Update(scriptPtr, tryAddPropertyTrampoline);
+        RaiseSignalTrampolineCollector.Update(scriptPtr, tryAddRaiseSignalTrampoline);
+    }
+}
+
+/// <summary>
+/// Options for collecting trampolines for a script.
+/// </summary>
+/// <param name="IncludeAncestors">
+/// Whether trampolines from ancestor classes should also be collected.
+/// If true, the trampoline collection method of each ancestor class must be called
+/// after the trampoline collection method of the current class.
+/// </param>
+public record TrampolineCollectionOptions(bool IncludeAncestors);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GodotClassTrampolines.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GodotClassTrampolines.cs
@@ -16,6 +16,9 @@ public readonly struct MethodTrampoline
     public unsafe MethodTrampoline(MethodTrampolineDelegate trampolineDelegate)
         => TrampolineDelegate = trampolineDelegate;
 
+    public unsafe MethodTrampoline(IntPtr trampolineDelegate)
+        => TrampolineDelegate = (MethodTrampolineDelegate)trampolineDelegate;
+
     public unsafe MethodTrampolineDelegate TrampolineDelegate { get; }
 }
 
@@ -30,6 +33,9 @@ public readonly struct PropertyGetterTrampoline
 {
     public unsafe PropertyGetterTrampoline(PropertyGetterTrampolineDelegate trampolineDelegate)
         => TrampolineDelegate = trampolineDelegate;
+
+    public unsafe PropertyGetterTrampoline(IntPtr trampolineDelegate)
+        => TrampolineDelegate = (PropertyGetterTrampolineDelegate)trampolineDelegate;
 
     public unsafe PropertyGetterTrampolineDelegate TrampolineDelegate { get; }
 }
@@ -46,6 +52,9 @@ public readonly struct PropertySetterTrampoline
     public unsafe PropertySetterTrampoline(PropertySetterTrampolineDelegate trampolineDelegate)
         => TrampolineDelegate = trampolineDelegate;
 
+    public unsafe PropertySetterTrampoline(IntPtr trampolineDelegate)
+        => TrampolineDelegate = (PropertySetterTrampolineDelegate)trampolineDelegate;
+
     public unsafe PropertySetterTrampolineDelegate TrampolineDelegate { get; }
 }
 
@@ -60,6 +69,9 @@ public readonly struct RaiseSignalTrampoline
 {
     public unsafe RaiseSignalTrampoline(RaiseSignalTrampolineDelegate trampolineDelegate)
         => TrampolineDelegate = trampolineDelegate;
+
+    public unsafe RaiseSignalTrampoline(IntPtr trampolineDelegate)
+        => TrampolineDelegate = (RaiseSignalTrampolineDelegate)trampolineDelegate;
 
     public unsafe RaiseSignalTrampolineDelegate TrampolineDelegate { get; }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GodotClassTrampolines.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GodotClassTrampolines.cs
@@ -1,45 +1,8 @@
 using System;
-using Godot.NativeInterop;
 
 namespace Godot.Bridge;
 
 #nullable enable
-using unsafe MethodTrampolineDelegate = delegate* unmanaged<
-    /* godotObjectGCHandle: */
-    IntPtr,
-    /* args: */
-    godot_variant**,
-    /* argCount: */
-    int,
-    /* outRefCallError: */
-    godot_variant_call_error*,
-    /* outRet: */
-    godot_variant*,
-    void>;
-using unsafe PropertyGetterTrampolineDelegate = delegate* unmanaged<
-    /* godotObjectGCHandle: */
-    IntPtr,
-    /* outValue: */
-    godot_variant*,
-    /* return (success): */
-    godot_bool>;
-using unsafe PropertySetterTrampolineDelegate = delegate* unmanaged<
-    /* godotObjectGCHandle: */
-    IntPtr,
-    /* value: */
-    godot_variant*,
-    /* return (success): */
-    godot_bool>;
-using unsafe RaiseSignalTrampolineDelegate = delegate* unmanaged<
-    /* godotObjectGCHandle: */
-    IntPtr,
-    /* args: */
-    godot_variant**,
-    /* argCount: */
-    int,
-    /* outOwnerIsNull: */
-    godot_bool*,
-    void>;
 
 public readonly struct MethodTrampoline
 {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GodotClassTrampolines.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GodotClassTrampolines.cs
@@ -13,13 +13,21 @@ namespace Godot.Bridge;
 /// </summary>
 public readonly struct MethodTrampoline
 {
-    public unsafe MethodTrampoline(MethodTrampolineDelegate trampolineDelegate)
-        => TrampolineDelegate = trampolineDelegate;
+    public unsafe MethodTrampoline(MethodTrampolineDelegate trampolineDelegate, bool isStatic)
+    {
+        TrampolineDelegate = trampolineDelegate;
+        IsStatic = isStatic;
+    }
 
-    public unsafe MethodTrampoline(IntPtr trampolineDelegate)
-        => TrampolineDelegate = (MethodTrampolineDelegate)trampolineDelegate;
+    public unsafe MethodTrampoline(IntPtr trampolineDelegate, bool isStatic)
+    {
+        TrampolineDelegate = (MethodTrampolineDelegate)trampolineDelegate;
+        IsStatic = isStatic;
+    }
 
     public unsafe MethodTrampolineDelegate TrampolineDelegate { get; }
+
+    public bool IsStatic { get; }
 }
 
 /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GodotClassTrampolines.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GodotClassTrampolines.cs
@@ -4,6 +4,13 @@ namespace Godot.Bridge;
 
 #nullable enable
 
+/// <summary>
+/// Struct representing a method trampoline, containing a delegate to the trampoline function.
+/// The trampoline is a <c>delegate* managed</c> with a signature equivalent to the following C# delegate:
+/// <code>
+/// delegate godot_variant MethodTrampoline(object godotObject, NativeVariantPtrArgs args, ref godot_variant_call_error callError);
+/// </code>
+/// </summary>
 public readonly struct MethodTrampoline
 {
     public unsafe MethodTrampoline(MethodTrampolineDelegate trampolineDelegate)
@@ -12,6 +19,13 @@ public readonly struct MethodTrampoline
     public unsafe MethodTrampolineDelegate TrampolineDelegate { get; }
 }
 
+/// <summary>
+/// Struct representing a property getter trampoline, containing a delegate to the trampoline function.
+/// The trampoline is a <c>delegate* managed</c> with a signature equivalent to the following C# delegate:
+/// <code>
+/// delegate godot_variant PropertyGetterTrampoline(object godotObject);
+/// </code>
+/// </summary>
 public readonly struct PropertyGetterTrampoline
 {
     public unsafe PropertyGetterTrampoline(PropertyGetterTrampolineDelegate trampolineDelegate)
@@ -20,6 +34,13 @@ public readonly struct PropertyGetterTrampoline
     public unsafe PropertyGetterTrampolineDelegate TrampolineDelegate { get; }
 }
 
+/// <summary>
+/// Struct representing a property setter trampoline, containing a delegate to the trampoline function.
+/// The trampoline is a <c>delegate* managed</c> with a signature equivalent to the following C# delegate:
+/// <code>
+/// delegate void PropertySetterTrampoline(object godotObject, in godot_variant value);
+/// </code>
+/// </summary>
 public readonly struct PropertySetterTrampoline
 {
     public unsafe PropertySetterTrampoline(PropertySetterTrampolineDelegate trampolineDelegate)
@@ -28,6 +49,13 @@ public readonly struct PropertySetterTrampoline
     public unsafe PropertySetterTrampolineDelegate TrampolineDelegate { get; }
 }
 
+/// <summary>
+/// Struct representing a raise signal trampoline, containing a delegate to the trampoline function.
+/// The trampoline is a <c>delegate* managed</c> with a signature equivalent to the following C# delegate:
+/// <code>
+/// delegate void RaiseSignalTrampoline(object godotObject, NativeVariantPtrArgs args);
+/// </code>
+/// </summary>
 public readonly struct RaiseSignalTrampoline
 {
     public unsafe RaiseSignalTrampoline(RaiseSignalTrampolineDelegate trampolineDelegate)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GodotClassTrampolines.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GodotClassTrampolines.cs
@@ -1,0 +1,74 @@
+using System;
+using Godot.NativeInterop;
+
+namespace Godot.Bridge;
+
+#nullable enable
+using unsafe MethodTrampolineDelegate = delegate* unmanaged<
+    /* godotObjectGCHandle: */
+    IntPtr,
+    /* args: */
+    godot_variant**,
+    /* argCount: */
+    int,
+    /* outRefCallError: */
+    godot_variant_call_error*,
+    /* outRet: */
+    godot_variant*,
+    void>;
+using unsafe PropertyGetterTrampolineDelegate = delegate* unmanaged<
+    /* godotObjectGCHandle: */
+    IntPtr,
+    /* outValue: */
+    godot_variant*,
+    /* return (success): */
+    godot_bool>;
+using unsafe PropertySetterTrampolineDelegate = delegate* unmanaged<
+    /* godotObjectGCHandle: */
+    IntPtr,
+    /* value: */
+    godot_variant*,
+    /* return (success): */
+    godot_bool>;
+using unsafe RaiseSignalTrampolineDelegate = delegate* unmanaged<
+    /* godotObjectGCHandle: */
+    IntPtr,
+    /* args: */
+    godot_variant**,
+    /* argCount: */
+    int,
+    /* outOwnerIsNull: */
+    godot_bool*,
+    void>;
+
+public readonly struct MethodTrampoline
+{
+    public unsafe MethodTrampoline(MethodTrampolineDelegate trampolineDelegate)
+        => TrampolineDelegate = trampolineDelegate;
+
+    public unsafe MethodTrampolineDelegate TrampolineDelegate { get; }
+}
+
+public readonly struct PropertyGetterTrampoline
+{
+    public unsafe PropertyGetterTrampoline(PropertyGetterTrampolineDelegate trampolineDelegate)
+        => TrampolineDelegate = trampolineDelegate;
+
+    public unsafe PropertyGetterTrampolineDelegate TrampolineDelegate { get; }
+}
+
+public readonly struct PropertySetterTrampoline
+{
+    public unsafe PropertySetterTrampoline(PropertySetterTrampolineDelegate trampolineDelegate)
+        => TrampolineDelegate = trampolineDelegate;
+
+    public unsafe PropertySetterTrampolineDelegate TrampolineDelegate { get; }
+}
+
+public readonly struct RaiseSignalTrampoline
+{
+    public unsafe RaiseSignalTrampoline(RaiseSignalTrampolineDelegate trampolineDelegate)
+        => TrampolineDelegate = trampolineDelegate;
+
+    public unsafe RaiseSignalTrampolineDelegate TrampolineDelegate { get; }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -22,6 +22,7 @@ namespace Godot.Bridge
         public delegate* unmanaged<godot_string*, godot_string*, godot_string*, godot_bool*, godot_bool*, godot_string*, void> ScriptManagerBridge_GetGlobalClassName;
         public delegate* unmanaged<IntPtr, IntPtr, void> ScriptManagerBridge_SetGodotObjectPtr;
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant**, int, godot_bool*, void> ScriptManagerBridge_RaiseEventSignal;
+        public delegate* unmanaged<RaiseSignalTrampolineDelegate, IntPtr, godot_variant**, int, godot_bool*, void> ScriptManagerBridge_RaiseEventSignalViaTrampoline;
         public delegate* unmanaged<IntPtr, IntPtr, godot_bool> ScriptManagerBridge_ScriptIsOrInherits;
         public delegate* unmanaged<IntPtr, godot_string*, godot_bool> ScriptManagerBridge_AddScriptBridge;
         public delegate* unmanaged<godot_string*, godot_ref*, void> ScriptManagerBridge_GetOrCreateScriptBridgeForPath;
@@ -41,6 +42,9 @@ namespace Godot.Bridge
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant**, int, godot_variant_call_error*, godot_variant*, godot_bool> CSharpInstanceBridge_Call;
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant*, godot_bool> CSharpInstanceBridge_Set;
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant*, godot_bool> CSharpInstanceBridge_Get;
+        public delegate* unmanaged<MethodTrampolineDelegate, IntPtr, godot_variant**, int, godot_variant_call_error*, godot_variant*, godot_bool> CSharpInstanceBridge_CallViaTrampoline;
+        public delegate* unmanaged<PropertySetterTrampolineDelegate, IntPtr, godot_variant*, godot_bool> CSharpInstanceBridge_SetViaTrampoline;
+        public delegate* unmanaged<PropertyGetterTrampolineDelegate, IntPtr, godot_variant*, godot_bool> CSharpInstanceBridge_GetViaTrampoline;
         public delegate* unmanaged<IntPtr, godot_bool, void> CSharpInstanceBridge_CallDispose;
         public delegate* unmanaged<IntPtr, godot_string*, godot_bool*, void> CSharpInstanceBridge_CallToString;
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_bool> CSharpInstanceBridge_HasMethodUnknownParams;
@@ -72,6 +76,7 @@ namespace Godot.Bridge
                 ScriptManagerBridge_GetGlobalClassName = &ScriptManagerBridge.GetGlobalClassName,
                 ScriptManagerBridge_SetGodotObjectPtr = &ScriptManagerBridge.SetGodotObjectPtr,
                 ScriptManagerBridge_RaiseEventSignal = &ScriptManagerBridge.RaiseEventSignal,
+                ScriptManagerBridge_RaiseEventSignalViaTrampoline = &ScriptManagerBridge.RaiseEventSignalViaTrampoline,
                 ScriptManagerBridge_ScriptIsOrInherits = &ScriptManagerBridge.ScriptIsOrInherits,
                 ScriptManagerBridge_AddScriptBridge = &ScriptManagerBridge.AddScriptBridge,
                 ScriptManagerBridge_GetOrCreateScriptBridgeForPath = &ScriptManagerBridge.GetOrCreateScriptBridgeForPath,
@@ -86,6 +91,9 @@ namespace Godot.Bridge
                 CSharpInstanceBridge_Call = &CSharpInstanceBridge.Call,
                 CSharpInstanceBridge_Set = &CSharpInstanceBridge.Set,
                 CSharpInstanceBridge_Get = &CSharpInstanceBridge.Get,
+                CSharpInstanceBridge_CallViaTrampoline = &CSharpInstanceBridge.CallViaTrampoline,
+                CSharpInstanceBridge_SetViaTrampoline = &CSharpInstanceBridge.SetViaTrampoline,
+                CSharpInstanceBridge_GetViaTrampoline = &CSharpInstanceBridge.GetViaTrampoline,
                 CSharpInstanceBridge_CallDispose = &CSharpInstanceBridge.CallDispose,
                 CSharpInstanceBridge_CallToString = &CSharpInstanceBridge.CallToString,
                 CSharpInstanceBridge_HasMethodUnknownParams = &CSharpInstanceBridge.HasMethodUnknownParams,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -27,6 +27,12 @@ namespace Godot.Bridge
         public delegate* unmanaged<godot_string*, godot_ref*, void> ScriptManagerBridge_GetOrCreateScriptBridgeForPath;
         public delegate* unmanaged<IntPtr, void> ScriptManagerBridge_RemoveScriptBridge;
         public delegate* unmanaged<IntPtr, godot_bool> ScriptManagerBridge_TryReloadRegisteredScriptWithClass;
+        public delegate* unmanaged<IntPtr, godot_bool*,
+            delegate* unmanaged<IntPtr, godot_string_name*, int, godot_string_name*, void>,
+            delegate* unmanaged<IntPtr, godot_string_name*, int, void*, void>,
+            delegate* unmanaged<IntPtr, godot_string_name*, void*, void*, void>,
+            delegate* unmanaged<IntPtr, godot_string_name*, int, void*, void>,
+            void> ScriptManagerBridge_UpdateScriptTrampolines;
         public delegate* unmanaged<IntPtr, godot_csharp_type_info*, godot_array*, godot_dictionary*, godot_dictionary*, godot_ref*, void> ScriptManagerBridge_UpdateScriptClassInfo;
         public delegate* unmanaged<IntPtr, IntPtr*, godot_bool, godot_bool> ScriptManagerBridge_SwapGCHandleForType;
         public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, godot_string*, void*, int, void>, void> ScriptManagerBridge_GetPropertyInfoList;
@@ -71,6 +77,7 @@ namespace Godot.Bridge
                 ScriptManagerBridge_GetOrCreateScriptBridgeForPath = &ScriptManagerBridge.GetOrCreateScriptBridgeForPath,
                 ScriptManagerBridge_RemoveScriptBridge = &ScriptManagerBridge.RemoveScriptBridge,
                 ScriptManagerBridge_TryReloadRegisteredScriptWithClass = &ScriptManagerBridge.TryReloadRegisteredScriptWithClass,
+                ScriptManagerBridge_UpdateScriptTrampolines = &ScriptManagerBridge.UpdateScriptTrampolines,
                 ScriptManagerBridge_UpdateScriptClassInfo = &ScriptManagerBridge.UpdateScriptClassInfo,
                 ScriptManagerBridge_SwapGCHandleForType = &ScriptManagerBridge.SwapGCHandleForType,
                 ScriptManagerBridge_GetPropertyInfoList = &ScriptManagerBridge.GetPropertyInfoList,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -29,7 +29,6 @@ namespace Godot.Bridge
         public delegate* unmanaged<IntPtr, void> ScriptManagerBridge_RemoveScriptBridge;
         public delegate* unmanaged<IntPtr, godot_bool> ScriptManagerBridge_TryReloadRegisteredScriptWithClass;
         public delegate* unmanaged<IntPtr, godot_bool*,
-            delegate* unmanaged<IntPtr, godot_string_name*, int, godot_string_name*, void>,
             delegate* unmanaged<IntPtr, godot_string_name*, int, void*, godot_bool, void>,
             delegate* unmanaged<IntPtr, godot_string_name*, void*, void*, void>,
             delegate* unmanaged<IntPtr, godot_string_name*, int, void*, void>,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -30,7 +30,7 @@ namespace Godot.Bridge
         public delegate* unmanaged<IntPtr, godot_bool> ScriptManagerBridge_TryReloadRegisteredScriptWithClass;
         public delegate* unmanaged<IntPtr, godot_bool*,
             delegate* unmanaged<IntPtr, godot_string_name*, int, godot_string_name*, void>,
-            delegate* unmanaged<IntPtr, godot_string_name*, int, void*, void>,
+            delegate* unmanaged<IntPtr, godot_string_name*, int, void*, godot_bool, void>,
             delegate* unmanaged<IntPtr, godot_string_name*, void*, void*, void>,
             delegate* unmanaged<IntPtr, godot_string_name*, int, void*, void>,
             void> ScriptManagerBridge_UpdateScriptTrampolines;
@@ -39,6 +39,7 @@ namespace Godot.Bridge
         public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, godot_string*, void*, int, void>, void> ScriptManagerBridge_GetPropertyInfoList;
         public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, void*, int, void>, void> ScriptManagerBridge_GetPropertyDefaultValues;
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant**, int, godot_variant_call_error*, godot_variant*, godot_bool> ScriptManagerBridge_CallStatic;
+        public delegate* unmanaged<MethodTrampolineDelegate, godot_variant**, int, godot_variant_call_error*, godot_variant*, godot_bool> ScriptManagerBridge_CallStaticWithTrampoline;
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant**, int, godot_variant_call_error*, godot_variant*, godot_bool> CSharpInstanceBridge_Call;
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant*, godot_bool> CSharpInstanceBridge_Set;
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant*, godot_bool> CSharpInstanceBridge_Get;
@@ -88,6 +89,7 @@ namespace Godot.Bridge
                 ScriptManagerBridge_GetPropertyInfoList = &ScriptManagerBridge.GetPropertyInfoList,
                 ScriptManagerBridge_GetPropertyDefaultValues = &ScriptManagerBridge.GetPropertyDefaultValues,
                 ScriptManagerBridge_CallStatic = &ScriptManagerBridge.CallStatic,
+                ScriptManagerBridge_CallStaticWithTrampoline = &ScriptManagerBridge.CallStaticWithTrampoline,
                 CSharpInstanceBridge_Call = &CSharpInstanceBridge.Call,
                 CSharpInstanceBridge_Set = &CSharpInstanceBridge.Set,
                 CSharpInstanceBridge_Get = &CSharpInstanceBridge.Get,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/MethodKey.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/MethodKey.cs
@@ -1,0 +1,15 @@
+namespace Godot.Bridge;
+
+#nullable enable
+
+public readonly struct MethodKey
+{
+    public StringName Name { get; init; }
+    public int ArgumentCount { get; init; } = 0;
+
+    public MethodKey(StringName name, int argumentCount)
+    {
+        Name = name;
+        ArgumentCount = argumentCount;
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -15,8 +15,6 @@ using Godot.NativeInterop;
 namespace Godot.Bridge
 {
     using PropertyTrampolines = (PropertyGetterTrampoline getterTramp, PropertySetterTrampoline setterTramp);
-    using unsafe TryAddNameToProxyNameMapDelegate = delegate* unmanaged<
-        IntPtr, godot_string_name*, int, godot_string_name*, void>;
     using unsafe TryAddMethodTrampolineDelegate = delegate* unmanaged<
         IntPtr, godot_string_name*, int, void*, godot_bool, void>;
     using unsafe TryAddPropertyTrampolineDelegate = delegate* unmanaged<
@@ -803,7 +801,6 @@ namespace Godot.Bridge
         [UnmanagedCallersOnly]
         internal static unsafe void UpdateScriptTrampolines(
             IntPtr scriptPtr, godot_bool* outShouldFallbackToLegacyTrampolines,
-            TryAddNameToProxyNameMapDelegate tryAddNameToProxyNameMap,
             TryAddMethodTrampolineDelegate tryAddMethodTrampoline,
             TryAddPropertyTrampolineDelegate tryAddPropertyTrampoline,
             TryAddRaiseSignalTrampolineDelegate tryAddRaiseSignalTrampoline)
@@ -821,7 +818,6 @@ namespace Godot.Bridge
                     _cachedTrampolineCollectorPool = new(
                         TwoArgumentArray: new object[2],
                         Collectors: new(
-                            new(scriptPtr, tryAddNameToProxyNameMap),
                             new(scriptPtr, tryAddMethodTrampoline),
                             new(scriptPtr, tryAddPropertyTrampoline),
                             new(scriptPtr, tryAddRaiseSignalTrampoline)),
@@ -832,8 +828,8 @@ namespace Godot.Bridge
                 else
                 {
                     collectorPool = _cachedTrampolineCollectorPool.Value;
-                    collectorPool.Collectors.UpdateCollectors(scriptPtr, tryAddNameToProxyNameMap,
-                        tryAddMethodTrampoline, tryAddPropertyTrampoline, tryAddRaiseSignalTrampoline);
+                    collectorPool.Collectors.UpdateCollectors(scriptPtr, tryAddMethodTrampoline,
+                        tryAddPropertyTrampoline, tryAddRaiseSignalTrampoline);
                 }
 
                 GetGodotClassTrampolinesForType(scriptType, collectorPool);
@@ -1088,50 +1084,6 @@ namespace Godot.Bridge
         }
 
         /// <summary>
-        /// This is used to collect the method name to proxy name map for a script.
-        /// </summary>
-        /// <remarks>
-        /// The user script can implement a static method "GetGodotClassTrampolines"
-        /// that receives an instance of <see cref="TrampolineCollectors"/> which
-        /// contains an instance of this class. The user script can then call the
-        /// <see cref="TryAdd"/> method of this class to add proxy name mappings to the script.<br/>
-        /// <br/>
-        /// "GetGodotClassTrampolines" must be called on the most derived class first,
-        /// and after collecting the members for that class, its implementation must call the base
-        /// implementation to also collect members from the base classes in inheritance order.<br/>
-        /// As a result, <see cref="TryAdd"/> will not add a method from a base class if the derived class
-        /// has already added a method with the same MethodKey.
-        /// </remarks>
-        public class NameToProxyNameMapCollector
-        {
-            private IntPtr _scriptPtr;
-            private unsafe TryAddNameToProxyNameMapDelegate _tryAddDelegate;
-
-            internal unsafe NameToProxyNameMapCollector(IntPtr scriptPtr,
-                TryAddNameToProxyNameMapDelegate tryAddDelegate)
-            {
-                _scriptPtr = scriptPtr;
-                _tryAddDelegate = tryAddDelegate;
-            }
-
-            internal unsafe void Update(IntPtr scriptPtr, TryAddNameToProxyNameMapDelegate tryAddDelegate)
-            {
-                _scriptPtr = scriptPtr;
-                _tryAddDelegate = tryAddDelegate;
-            }
-
-            /// <summary>
-            /// Adds a method name to proxy name mapping to the script if a mapping for the given method key doesn't already exist.
-            /// </summary>
-            public unsafe void TryAdd(MethodKey methodKey, StringName proxyName)
-            {
-                var nameSelf = (godot_string_name)methodKey.Name.NativeValue;
-                var proxyNameSelf = (godot_string_name)proxyName.NativeValue;
-                _tryAddDelegate(_scriptPtr, &nameSelf, methodKey.ArgumentCount, &proxyNameSelf);
-            }
-        }
-
-        /// <summary>
         /// This is used to collect the method trampolines for a script.
         /// </summary>
         /// <remarks>
@@ -1272,18 +1224,15 @@ namespace Godot.Bridge
         /// and method name to proxy name mappings for a script.
         /// </summary>
         public record TrampolineCollectors(
-            NameToProxyNameMapCollector NameToProxyNameMapCollector,
             MethodTrampolineCollector MethodTrampolineCollector,
             PropertyTrampolineCollector PropertyTrampolineCollector,
             RaiseSignalTrampolineCollector RaiseSignalTrampolineCollector)
         {
             internal unsafe void UpdateCollectors(IntPtr scriptPtr,
-                TryAddNameToProxyNameMapDelegate tryAddNameToProxyNameMap,
                 TryAddMethodTrampolineDelegate tryAddMethodTrampoline,
                 TryAddPropertyTrampolineDelegate tryAddPropertyTrampoline,
                 TryAddRaiseSignalTrampolineDelegate tryAddRaiseSignalTrampoline)
             {
-                NameToProxyNameMapCollector.Update(scriptPtr, tryAddNameToProxyNameMap);
                 MethodTrampolineCollector.Update(scriptPtr, tryAddMethodTrampoline);
                 PropertyTrampolineCollector.Update(scriptPtr, tryAddPropertyTrampoline);
                 RaiseSignalTrampolineCollector.Update(scriptPtr, tryAddRaiseSignalTrampoline);
@@ -1311,17 +1260,17 @@ namespace Godot.Bridge
 
         private static void GetGodotClassTrampolinesForType(Type type, TrampolineCollectorPool collectorPool)
         {
-            var getGodotMethodNameToProxyNameMap = type.GetMethod(
+            var getGodotClassTrampolines = type.GetMethod(
                 "GetGodotClassTrampolines",
                 BindingFlags.DeclaredOnly | BindingFlags.Static |
                 BindingFlags.NonPublic | BindingFlags.Public);
 
-            if (getGodotMethodNameToProxyNameMap == null)
+            if (getGodotClassTrampolines == null)
                 return;
 
             collectorPool.TwoArgumentArray[0] = collectorPool.Collectors;
             collectorPool.TwoArgumentArray[1] = collectorPool.CollectionOptions;
-            getGodotMethodNameToProxyNameMap.Invoke(null, collectorPool.TwoArgumentArray);
+            getGodotClassTrampolines.Invoke(null, collectorPool.TwoArgumentArray);
         }
 
 #pragma warning disable IDE1006 // Naming rule violation

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -15,6 +15,14 @@ using Godot.NativeInterop;
 namespace Godot.Bridge
 {
     using PropertyTrampolines = (PropertyGetterTrampoline getterTramp, PropertySetterTrampoline setterTramp);
+    using unsafe TryAddNameToProxyNameMapDelegate = delegate* unmanaged<
+        IntPtr, godot_string_name*, int, godot_string_name*, void>;
+    using unsafe TryAddMethodTrampolineDelegate = delegate* unmanaged<
+        IntPtr, godot_string_name*, int, void*, void>;
+    using unsafe TryAddPropertyTrampolineDelegate = delegate* unmanaged<
+        IntPtr, godot_string_name*, void*, void*, void>;
+    using unsafe TryAddRaiseSignalTrampolineDelegate = delegate* unmanaged<
+        IntPtr, godot_string_name*, int, void*, void>;
 
     // TODO: Make class internal once we replace LookupScriptsInAssembly (the only public member) with source generators
     public static partial class ScriptManagerBridge
@@ -790,13 +798,15 @@ namespace Godot.Bridge
             outTypeInfo->IsConstructedGenericType = scriptType.IsConstructedGenericType.ToGodotBool();
         }
 
+        [ThreadStatic] private static TrampolineCollectorPool? _cachedTrampolineCollectorPool;
+
         [UnmanagedCallersOnly]
         internal static unsafe void UpdateScriptTrampolines(
             IntPtr scriptPtr, godot_bool* outShouldFallbackToLegacyTrampolines,
-            delegate* unmanaged<IntPtr, godot_string_name*, int, godot_string_name*, void> tryAddNameToProxyNameMap,
-            delegate* unmanaged<IntPtr, godot_string_name*, int, void*, void> tryAddMethodTrampoline,
-            delegate* unmanaged<IntPtr, godot_string_name*, void*, void*, void> tryAddPropertyTrampoline,
-            delegate* unmanaged<IntPtr, godot_string_name*, int, void*, void> tryAddRaiseSignalTrampoline)
+            TryAddNameToProxyNameMapDelegate tryAddNameToProxyNameMap,
+            TryAddMethodTrampolineDelegate tryAddMethodTrampoline,
+            TryAddPropertyTrampolineDelegate tryAddPropertyTrampoline,
+            TryAddRaiseSignalTrampolineDelegate tryAddRaiseSignalTrampoline)
         {
             try
             {
@@ -806,57 +816,34 @@ namespace Godot.Bridge
 
                 Type native = GodotObject.InternalGetClassNativeBase(scriptType);
 
+                TrampolineCollectorPool collectorPool;
+
+                if (_cachedTrampolineCollectorPool == null)
+                {
+                    _cachedTrampolineCollectorPool = new(
+                        OneArgumentArray: new object[1],
+                        new(scriptPtr, tryAddNameToProxyNameMap),
+                        new(scriptPtr, tryAddMethodTrampoline),
+                        new(scriptPtr, tryAddPropertyTrampoline),
+                        new(scriptPtr, tryAddRaiseSignalTrampoline));
+
+                    collectorPool = _cachedTrampolineCollectorPool.Value;
+                }
+                else
+                {
+                    collectorPool = _cachedTrampolineCollectorPool.Value;
+                    collectorPool.NameToProxyNameMapCollector.Change(scriptPtr, tryAddNameToProxyNameMap);
+                    collectorPool.MethodTrampolineCollector.Change(scriptPtr, tryAddMethodTrampoline);
+                    collectorPool.PropertyTrampolineCollector.Change(scriptPtr, tryAddPropertyTrampoline);
+                    collectorPool.RaiseSignalTrampolineCollector.Change(scriptPtr, tryAddRaiseSignalTrampoline);
+                }
+
                 for (Type? top = scriptType; top != null && top != native; top = top.BaseType)
                 {
-                    var methodNameToProxyNameMap = GetMethodNameToProxyNameMapForType(top);
-
-                    if (methodNameToProxyNameMap != null)
-                    {
-                        foreach (var (methodKey, proxyName) in methodNameToProxyNameMap)
-                        {
-                            var nameSelf = (godot_string_name)methodKey.Name.NativeValue;
-                            int argc = methodKey.ArgumentCount;
-                            var proxyNameSelf = (godot_string_name)proxyName.NativeValue;
-                            tryAddNameToProxyNameMap(scriptPtr, &nameSelf, argc, &proxyNameSelf);
-                        }
-                    }
-
-                    var methodTrampolines = GetMethodTrampolinesForType(top);
-
-                    if (methodTrampolines != null)
-                    {
-                        foreach (var (methodKey, trampoline) in methodTrampolines)
-                        {
-                            var nameSelf = (godot_string_name)methodKey.Name.NativeValue;
-                            int argc = methodKey.ArgumentCount;
-                            tryAddMethodTrampoline(scriptPtr, &nameSelf, argc, trampoline.TrampolineDelegate);
-                        }
-                    }
-
-                    var propertyTrampolines = GetPropertyTrampolinesForType(top);
-
-                    if (propertyTrampolines != null)
-                    {
-                        foreach (var (name, trampolines) in propertyTrampolines)
-                        {
-                            var nameSelf = (godot_string_name)name.NativeValue;
-                            tryAddPropertyTrampoline(scriptPtr, &nameSelf,
-                                trampolines.getterTramp.TrampolineDelegate,
-                                trampolines.setterTramp.TrampolineDelegate);
-                        }
-                    }
-
-                    var raiseSignalTrampolines = GetRaiseSignalTrampolinesForType(top);
-
-                    if (raiseSignalTrampolines != null)
-                    {
-                        foreach (var (signalKey, trampoline) in raiseSignalTrampolines)
-                        {
-                            var nameSelf = (godot_string_name)signalKey.Name.NativeValue;
-                            int argc = signalKey.ArgumentCount;
-                            tryAddRaiseSignalTrampoline(scriptPtr, &nameSelf, argc, trampoline.TrampolineDelegate);
-                        }
-                    }
+                    GetMethodNameToProxyNameMapForType(top, collectorPool);
+                    GetMethodTrampolinesForType(top, collectorPool);
+                    GetPropertyTrampolinesForType(top, collectorPool);
+                    GetRaiseSignalTrampolinesForType(top, collectorPool);
                 }
 
                 bool DoesUserScriptContainMethod(string methodName)
@@ -1106,7 +1093,185 @@ namespace Godot.Bridge
             return (List<MethodInfo>?)getGodotMethodListMethod.Invoke(null, null);
         }
 
-        private static Dictionary<MethodKey, StringName>? GetMethodNameToProxyNameMapForType(Type type)
+        /// <summary>
+        /// This is used to collect the method name to proxy name map for a script.
+        /// </summary>
+        /// <remarks>
+        /// The user script can implement a static method "GetGodotMethodNameToProxyNameMap"
+        /// that receives an instance of this class and calls its <see cref="TryAdd"/> method.<br/>
+        /// <br/>
+        /// "GetGodotMethodNameToProxyNameMap" is called on the most derived class first,
+        /// then through the base classes one by one in inheritance order.
+        /// As a result, <see cref="TryAdd"/> will not add a method from a base class if the derived class
+        /// has already added a method with the same MethodKey.
+        /// </remarks>
+        public class NameToProxyNameMapCollector
+        {
+            private IntPtr _scriptPtr;
+            private unsafe TryAddNameToProxyNameMapDelegate _tryAddDelegate;
+
+            internal unsafe NameToProxyNameMapCollector(IntPtr scriptPtr,
+                TryAddNameToProxyNameMapDelegate tryAddDelegate)
+            {
+                _scriptPtr = scriptPtr;
+                _tryAddDelegate = tryAddDelegate;
+            }
+
+            internal unsafe void Change(IntPtr scriptPtr, TryAddNameToProxyNameMapDelegate tryAddDelegate)
+            {
+                _scriptPtr = scriptPtr;
+                _tryAddDelegate = tryAddDelegate;
+            }
+
+            /// <summary>
+            /// Adds a method name to proxy name mapping to the script if a mapping for the given method key doesn't already exist.
+            /// </summary>
+            public unsafe void TryAdd(MethodKey methodKey, StringName proxyName)
+            {
+                var nameSelf = (godot_string_name)methodKey.Name.NativeValue;
+                var proxyNameSelf = (godot_string_name)proxyName.NativeValue;
+                _tryAddDelegate(_scriptPtr, &nameSelf, methodKey.ArgumentCount, &proxyNameSelf);
+            }
+        }
+
+        /// <summary>
+        /// This is used to collect the method trampolines for a script.
+        /// </summary>
+        /// <remarks>
+        /// The user script can implement a static method "GetGodotMethodTrampolines"
+        /// that receives an instance of this class and calls its <see cref="TryAdd"/> method.<br/>
+        /// <br/>
+        /// "GetGodotMethodTrampolines" is called on the most derived class first,
+        /// then through the base classes one by one in inheritance order.
+        /// As a result, <see cref="TryAdd"/> will not add a method from a base class if the derived class
+        /// has already added a method with the same MethodKey.
+        /// </remarks>
+        public class MethodTrampolineCollector
+        {
+            private IntPtr _scriptPtr;
+            private unsafe TryAddMethodTrampolineDelegate _tryAddDelegate;
+
+            internal unsafe MethodTrampolineCollector(IntPtr scriptPtr, TryAddMethodTrampolineDelegate tryAddDelegate)
+            {
+                _scriptPtr = scriptPtr;
+                _tryAddDelegate = tryAddDelegate;
+            }
+
+            internal unsafe void Change(IntPtr scriptPtr, TryAddMethodTrampolineDelegate tryAddDelegate)
+            {
+                _scriptPtr = scriptPtr;
+                _tryAddDelegate = tryAddDelegate;
+            }
+
+            /// <summary>
+            /// Adds a method trampoline to the script if a trampoline for the given method key doesn't already exist.
+            /// </summary>
+            public unsafe void TryAdd(MethodKey methodKey, MethodTrampoline trampoline)
+            {
+                var nameSelf = (godot_string_name)methodKey.Name.NativeValue;
+                _tryAddDelegate(_scriptPtr, &nameSelf, methodKey.ArgumentCount, trampoline.TrampolineDelegate);
+            }
+        }
+
+        /// <summary>
+        /// This is used to collect the property trampolines for a script.
+        /// </summary>
+        /// <remarks>
+        /// The user script can implement a static method "GetGodotPropertyTrampolines"
+        /// that receives an instance of this class and calls its <see cref="TryAdd"/> method.<br/>
+        /// <br/>
+        /// "GetGodotPropertyTrampolines" is called on the most derived class first,
+        /// then through the base classes one by one in inheritance order.
+        /// As a result, <see cref="TryAdd"/> will not add a property from a base class if the derived class
+        /// has already added a property with the same name.
+        /// </remarks>
+        public class PropertyTrampolineCollector
+        {
+            private IntPtr _scriptPtr;
+            private unsafe TryAddPropertyTrampolineDelegate _tryAddDelegate;
+
+            internal unsafe PropertyTrampolineCollector(IntPtr scriptPtr,
+                TryAddPropertyTrampolineDelegate tryAddDelegate)
+            {
+                _scriptPtr = scriptPtr;
+                _tryAddDelegate = tryAddDelegate;
+            }
+
+            internal unsafe void Change(IntPtr scriptPtr, TryAddPropertyTrampolineDelegate tryAddDelegate)
+            {
+                _scriptPtr = scriptPtr;
+                _tryAddDelegate = tryAddDelegate;
+            }
+
+            /// <summary>
+            /// Adds property trampolines to the script if trampolines for the given property name don't already exist.
+            /// If trampolines for the property already exist, but one of the getter or setter trampolines is missing,
+            /// the missing trampoline will be added if provided. This allows a derived class to introduce a readonly
+            /// or writeonly property with the same name as a property in the base class, overriding that specific
+            /// accessor while inheriting the other one. This is done only to match the behavior of the old
+            /// trampoline system (SetGodotClassPropertyTrampoline and GetGodotClassPropertyTrampoline).
+            /// </summary>
+            public unsafe void TryAdd(StringName propertyName, PropertyTrampolines trampolines)
+            {
+                var propertyNameSelf = (godot_string_name)propertyName.NativeValue;
+                _tryAddDelegate(_scriptPtr, &propertyNameSelf,
+                    trampolines.getterTramp.TrampolineDelegate,
+                    trampolines.setterTramp.TrampolineDelegate);
+            }
+        }
+
+        /// <summary>
+        /// This is used to collect the raise signal trampolines for a script.
+        /// </summary>
+        /// <remarks>
+        /// The user script can implement a static method "GetGodotRaiseSignalTrampolines"
+        /// that receives an instance of this class and calls its <see cref="TryAdd"/> method.<br/>
+        /// <br/>
+        /// "GetGodotRaiseSignalTrampolines" is called on the most derived class first,
+        /// then through the base classes one by one in inheritance order.
+        /// As a result, <see cref="TryAdd"/> will not add a signal from a base class if the derived class
+        /// has already added a signal with the same SignalKey.
+        /// </remarks>
+        public class RaiseSignalTrampolineCollector
+        {
+            private IntPtr _scriptPtr;
+            private unsafe TryAddRaiseSignalTrampolineDelegate _tryAddDelegate;
+
+            internal unsafe RaiseSignalTrampolineCollector(IntPtr scriptPtr,
+                TryAddRaiseSignalTrampolineDelegate tryAddDelegate)
+            {
+                _scriptPtr = scriptPtr;
+                _tryAddDelegate = tryAddDelegate;
+            }
+
+            internal unsafe void Change(IntPtr scriptPtr, TryAddRaiseSignalTrampolineDelegate tryAddDelegate)
+            {
+                _scriptPtr = scriptPtr;
+                _tryAddDelegate = tryAddDelegate;
+            }
+
+            /// <summary>
+            /// Adds a raise signal trampoline to the script if a trampoline for the given signal key doesn't already exist.
+            /// </summary>
+            public unsafe void TryAdd(SignalKey signalKey, RaiseSignalTrampoline trampoline)
+            {
+                var nameSelf = (godot_string_name)signalKey.Name.NativeValue;
+                _tryAddDelegate(_scriptPtr, &nameSelf, signalKey.ArgumentCount, trampoline.TrampolineDelegate);
+            }
+        }
+
+        /// <summary>
+        /// This is used as a pool to avoid having to allocate multiple instances of the
+        /// collectors and argument arrays when updating trampolines for a script.
+        /// </summary>
+        private record struct TrampolineCollectorPool(
+            object[] OneArgumentArray,
+            NameToProxyNameMapCollector NameToProxyNameMapCollector,
+            MethodTrampolineCollector MethodTrampolineCollector,
+            PropertyTrampolineCollector PropertyTrampolineCollector,
+            RaiseSignalTrampolineCollector RaiseSignalTrampolineCollector);
+
+        private static void GetMethodNameToProxyNameMapForType(Type type, TrampolineCollectorPool collectorPool)
         {
             var getGodotMethodNameToProxyNameMap = type.GetMethod(
                 "GetGodotMethodNameToProxyNameMap",
@@ -1114,12 +1279,13 @@ namespace Godot.Bridge
                 BindingFlags.NonPublic | BindingFlags.Public);
 
             if (getGodotMethodNameToProxyNameMap == null)
-                return null;
+                return;
 
-            return (Dictionary<MethodKey, StringName>?)getGodotMethodNameToProxyNameMap.Invoke(null, null);
+            collectorPool.OneArgumentArray[0] = collectorPool.NameToProxyNameMapCollector;
+            getGodotMethodNameToProxyNameMap.Invoke(null, collectorPool.OneArgumentArray);
         }
 
-        private static Dictionary<MethodKey, MethodTrampoline>? GetMethodTrampolinesForType(Type type)
+        private static void GetMethodTrampolinesForType(Type type, TrampolineCollectorPool collectorPool)
         {
             var getGodotMethodTrampolines = type.GetMethod(
                 "GetGodotMethodTrampolines",
@@ -1127,12 +1293,13 @@ namespace Godot.Bridge
                 BindingFlags.NonPublic | BindingFlags.Public);
 
             if (getGodotMethodTrampolines == null)
-                return null;
+                return;
 
-            return (Dictionary<MethodKey, MethodTrampoline>?)getGodotMethodTrampolines.Invoke(null, null);
+            collectorPool.OneArgumentArray[0] = collectorPool.MethodTrampolineCollector;
+            getGodotMethodTrampolines.Invoke(null, collectorPool.OneArgumentArray);
         }
 
-        private static Dictionary<StringName, PropertyTrampolines>? GetPropertyTrampolinesForType(Type type)
+        private static void GetPropertyTrampolinesForType(Type type, TrampolineCollectorPool collectorPool)
         {
             var getGodotPropertyTrampolines = type.GetMethod(
                 "GetGodotPropertyTrampolines",
@@ -1140,12 +1307,13 @@ namespace Godot.Bridge
                 BindingFlags.NonPublic | BindingFlags.Public);
 
             if (getGodotPropertyTrampolines == null)
-                return null;
+                return;
 
-            return (Dictionary<StringName, PropertyTrampolines>?)getGodotPropertyTrampolines.Invoke(null, null);
+            collectorPool.OneArgumentArray[0] = collectorPool.PropertyTrampolineCollector;
+            getGodotPropertyTrampolines.Invoke(null, collectorPool.OneArgumentArray);
         }
 
-        private static Dictionary<SignalKey, RaiseSignalTrampoline>? GetRaiseSignalTrampolinesForType(Type type)
+        private static void GetRaiseSignalTrampolinesForType(Type type, TrampolineCollectorPool collectorPool)
         {
             var getGodotRaiseSignalTrampolines = type.GetMethod(
                 "GetGodotRaiseSignalTrampolines",
@@ -1153,9 +1321,10 @@ namespace Godot.Bridge
                 BindingFlags.NonPublic | BindingFlags.Public);
 
             if (getGodotRaiseSignalTrampolines == null)
-                return null;
+                return;
 
-            return (Dictionary<SignalKey, RaiseSignalTrampoline>?)getGodotRaiseSignalTrampolines.Invoke(null, null);
+            collectorPool.OneArgumentArray[0] = collectorPool.RaiseSignalTrampolineCollector;
+            getGodotRaiseSignalTrampolines.Invoke(null, collectorPool.OneArgumentArray);
         }
 
 #pragma warning disable IDE1006 // Naming rule violation

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -14,14 +14,6 @@ using Godot.NativeInterop;
 
 namespace Godot.Bridge
 {
-    using PropertyTrampolines = (PropertyGetterTrampoline getterTramp, PropertySetterTrampoline setterTramp);
-    using unsafe TryAddMethodTrampolineDelegate = delegate* unmanaged<
-        IntPtr, godot_string_name*, int, void*, godot_bool, void>;
-    using unsafe TryAddPropertyTrampolineDelegate = delegate* unmanaged<
-        IntPtr, godot_string_name*, void*, void*, void>;
-    using unsafe TryAddRaiseSignalTrampolineDelegate = delegate* unmanaged<
-        IntPtr, godot_string_name*, int, void*, void>;
-
     // TODO: Make class internal once we replace LookupScriptsInAssembly (the only public member) with source generators
     public static partial class ScriptManagerBridge
     {
@@ -1084,172 +1076,6 @@ namespace Godot.Bridge
         }
 
         /// <summary>
-        /// This is used to collect the method trampolines for a script.
-        /// </summary>
-        /// <remarks>
-        /// The user script can implement a static method "GetGodotClassTrampolines"
-        /// that receives an instance of <see cref="TrampolineCollectors"/> which
-        /// contains an instance of this class. The user script can then call the
-        /// <see cref="TryAdd"/> method of this class to add methodsto the script.<br/>
-        /// <br/>
-        /// "GetGodotClassTrampolines" must be called on the most derived class first,
-        /// and after collecting the members for that class, its implementation must call the base
-        /// implementation to also collect members from the base classes in inheritance order.<br/>
-        /// As a result, <see cref="TryAdd"/> will not add a method from a base class if the derived class
-        /// has already added a method with the same MethodKey.
-        /// </remarks>
-        public class MethodTrampolineCollector
-        {
-            private IntPtr _scriptPtr;
-            private unsafe TryAddMethodTrampolineDelegate _tryAddDelegate;
-
-            internal unsafe MethodTrampolineCollector(IntPtr scriptPtr, TryAddMethodTrampolineDelegate tryAddDelegate)
-            {
-                _scriptPtr = scriptPtr;
-                _tryAddDelegate = tryAddDelegate;
-            }
-
-            internal unsafe void Update(IntPtr scriptPtr, TryAddMethodTrampolineDelegate tryAddDelegate)
-            {
-                _scriptPtr = scriptPtr;
-                _tryAddDelegate = tryAddDelegate;
-            }
-
-            /// <summary>
-            /// Adds a method trampoline to the script if a trampoline for the given method key doesn't already exist.
-            /// </summary>
-            public unsafe void TryAdd(MethodKey methodKey, MethodTrampoline trampoline)
-            {
-                var nameSelf = (godot_string_name)methodKey.Name.NativeValue;
-                _tryAddDelegate(_scriptPtr, &nameSelf, methodKey.ArgumentCount,
-                    trampoline.TrampolineDelegate, trampoline.IsStatic.ToGodotBool());
-            }
-        }
-
-        /// <summary>
-        /// This is used to collect the property trampolines for a script.
-        /// </summary>
-        /// <remarks>
-        /// The user script can implement a static method "GetGodotClassTrampolines"
-        /// that receives an instance of <see cref="TrampolineCollectors"/> which
-        /// contains an instance of this class. The user script can then call the
-        /// <see cref="TryAdd"/> method of this class to add properties to the script.<br/>
-        /// <br/>
-        /// "GetGodotClassTrampolines" must be called on the most derived class first,
-        /// and after collecting the members for that class, its implementation must call the base
-        /// implementation to also collect members from the base classes in inheritance order.<br/>
-        /// As a result, <see cref="TryAdd"/> will not add a property from a base class if the derived class
-        /// has already added a property with the same name.
-        /// </remarks>
-        public class PropertyTrampolineCollector
-        {
-            private IntPtr _scriptPtr;
-            private unsafe TryAddPropertyTrampolineDelegate _tryAddDelegate;
-
-            internal unsafe PropertyTrampolineCollector(IntPtr scriptPtr,
-                TryAddPropertyTrampolineDelegate tryAddDelegate)
-            {
-                _scriptPtr = scriptPtr;
-                _tryAddDelegate = tryAddDelegate;
-            }
-
-            internal unsafe void Update(IntPtr scriptPtr, TryAddPropertyTrampolineDelegate tryAddDelegate)
-            {
-                _scriptPtr = scriptPtr;
-                _tryAddDelegate = tryAddDelegate;
-            }
-
-            /// <summary>
-            /// Adds property trampolines to the script if trampolines for the given property name don't already exist.
-            /// If trampolines for the property already exist, but one of the getter or setter trampolines is missing,
-            /// the missing trampoline will be added if provided. This allows a derived class to introduce a readonly
-            /// or writeonly property with the same name as a property in the base class, overriding that specific
-            /// accessor while inheriting the other one. This is done only to match the behavior of the old
-            /// trampoline system (SetGodotClassPropertyTrampoline and GetGodotClassPropertyTrampoline).
-            /// </summary>
-            public unsafe void TryAdd(StringName propertyName, PropertyTrampolines trampolines)
-            {
-                var propertyNameSelf = (godot_string_name)propertyName.NativeValue;
-                _tryAddDelegate(_scriptPtr, &propertyNameSelf,
-                    trampolines.getterTramp.TrampolineDelegate,
-                    trampolines.setterTramp.TrampolineDelegate);
-            }
-        }
-
-        /// <summary>
-        /// This is used to collect the raise signal trampolines for a script.
-        /// </summary>
-        /// <remarks>
-        /// The user script can implement a static method "GetGodotClassTrampolines"
-        /// that receives an instance of <see cref="TrampolineCollectors"/> which
-        /// contains an instance of this class. The user script can then call the
-        /// <see cref="TryAdd"/> method of this class to add signals to the script.<br/>
-        /// <br/>
-        /// "GetGodotClassTrampolines" must be called on the most derived class first,
-        /// and after collecting the members for that class, its implementation must call the base
-        /// implementation to also collect members from the base classes in inheritance order.<br/>
-        /// As a result, <see cref="TryAdd"/> will not add a signal from a base class if the derived class
-        /// has already added a signal with the same SignalKey.
-        /// </remarks>
-        public class RaiseSignalTrampolineCollector
-        {
-            private IntPtr _scriptPtr;
-            private unsafe TryAddRaiseSignalTrampolineDelegate _tryAddDelegate;
-
-            internal unsafe RaiseSignalTrampolineCollector(IntPtr scriptPtr,
-                TryAddRaiseSignalTrampolineDelegate tryAddDelegate)
-            {
-                _scriptPtr = scriptPtr;
-                _tryAddDelegate = tryAddDelegate;
-            }
-
-            internal unsafe void Update(IntPtr scriptPtr, TryAddRaiseSignalTrampolineDelegate tryAddDelegate)
-            {
-                _scriptPtr = scriptPtr;
-                _tryAddDelegate = tryAddDelegate;
-            }
-
-            /// <summary>
-            /// Adds a raise signal trampoline to the script if a trampoline for the given signal key doesn't already exist.
-            /// </summary>
-            public unsafe void TryAdd(SignalKey signalKey, RaiseSignalTrampoline trampoline)
-            {
-                var nameSelf = (godot_string_name)signalKey.Name.NativeValue;
-                _tryAddDelegate(_scriptPtr, &nameSelf, signalKey.ArgumentCount, trampoline.TrampolineDelegate);
-            }
-        }
-
-        /// <summary>
-        /// Group of collectors passed to the user script to collect trampolines
-        /// and method name to proxy name mappings for a script.
-        /// </summary>
-        public record TrampolineCollectors(
-            MethodTrampolineCollector MethodTrampolineCollector,
-            PropertyTrampolineCollector PropertyTrampolineCollector,
-            RaiseSignalTrampolineCollector RaiseSignalTrampolineCollector)
-        {
-            internal unsafe void UpdateCollectors(IntPtr scriptPtr,
-                TryAddMethodTrampolineDelegate tryAddMethodTrampoline,
-                TryAddPropertyTrampolineDelegate tryAddPropertyTrampoline,
-                TryAddRaiseSignalTrampolineDelegate tryAddRaiseSignalTrampoline)
-            {
-                MethodTrampolineCollector.Update(scriptPtr, tryAddMethodTrampoline);
-                PropertyTrampolineCollector.Update(scriptPtr, tryAddPropertyTrampoline);
-                RaiseSignalTrampolineCollector.Update(scriptPtr, tryAddRaiseSignalTrampoline);
-            }
-        }
-
-        /// <summary>
-        /// Options for collecting trampolines for a script.
-        /// </summary>
-        /// <param name="IncludeAncestors">
-        /// Whether trampolines from ancestor classes should also be collected.
-        /// If true, the trampoline collection method of each ancestor class must be called
-        /// after the trampoline collection method of the current class.
-        /// </param>
-        public record TrampolineCollectionOptions(bool IncludeAncestors);
-
-        /// <summary>
         /// This is used as a pool to avoid having to allocate multiple instances of the
         /// collectors and argument arrays when updating trampolines for a script.
         /// </summary>
@@ -1260,10 +1086,13 @@ namespace Godot.Bridge
 
         private static void GetGodotClassTrampolinesForType(Type type, TrampolineCollectorPool collectorPool)
         {
-            var getGodotClassTrampolines = type.GetMethod(
-                "GetGodotClassTrampolines",
-                BindingFlags.DeclaredOnly | BindingFlags.Static |
-                BindingFlags.NonPublic | BindingFlags.Public);
+            var getGodotClassTrampolines = type.GetNestedType("GodotInternal",
+                    BindingFlags.DeclaredOnly | BindingFlags.Static |
+                    BindingFlags.NonPublic | BindingFlags.Public)
+                ?.GetMethod(
+                    "GetGodotClassTrampolines",
+                    BindingFlags.DeclaredOnly | BindingFlags.Static |
+                    BindingFlags.NonPublic | BindingFlags.Public);
 
             if (getGodotClassTrampolines == null)
                 return;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -10,12 +10,12 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
-using System.Runtime.Serialization;
-using System.Text;
 using Godot.NativeInterop;
 
 namespace Godot.Bridge
 {
+    using PropertyTrampolines = (PropertyGetterTrampoline getterTramp, PropertySetterTrampoline setterTramp);
+
     // TODO: Make class internal once we replace LookupScriptsInAssembly (the only public member) with source generators
     public static partial class ScriptManagerBridge
     {
@@ -90,7 +90,8 @@ namespace Godot.Bridge
         }
 
         [UnmanagedCallersOnly]
-        internal static unsafe IntPtr CreateManagedForGodotObjectBinding(godot_string_name* nativeTypeName, IntPtr godotObject)
+        internal static unsafe IntPtr CreateManagedForGodotObjectBinding(godot_string_name* nativeTypeName,
+            IntPtr godotObject)
         {
             try
             {
@@ -121,7 +122,8 @@ namespace Godot.Bridge
                 // Performance is not critical here as this will be replaced with source generators.
                 Type scriptType = _scriptTypeBiMap.GetScriptType(scriptPtr);
 
-                Debug.Assert(!scriptType.IsAbstract, $"Cannot create script instance. The class '{scriptType.FullName}' is abstract.");
+                Debug.Assert(!scriptType.IsAbstract,
+                    $"Cannot create script instance. The class '{scriptType.FullName}' is abstract.");
 
                 var ctor = scriptType
                     .GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
@@ -199,7 +201,8 @@ namespace Godot.Bridge
         }
 
         [UnmanagedCallersOnly]
-        internal static unsafe void GetGlobalClassName(godot_string* scriptPath, godot_string* outBaseType, godot_string* outIconPath, godot_bool* outIsAbstract, godot_bool* outIsTool, godot_string* outClassName)
+        internal static unsafe void GetGlobalClassName(godot_string* scriptPath, godot_string* outBaseType,
+            godot_string* outIconPath, godot_bool* outIsAbstract, godot_bool* outIsTool, godot_string* outClassName)
         {
             // This method must always return the outBaseType for every script, even if the script is
             // not a global class. But if the script is not a global class it must return an empty
@@ -248,6 +251,7 @@ namespace Godot.Bridge
 
                     top = top.BaseType;
                 }
+
                 if (!foundGlobalBaseScript)
                 {
                     string nativeName = native.GetCustomAttribute<GodotClassNameAttribute>(false)?.Name ?? native.Name;
@@ -433,7 +437,7 @@ namespace Godot.Bridge
             }
         }
 
-        private static unsafe bool AddScriptBridgeCore(IntPtr scriptPtr, string scriptPath)
+        private static bool AddScriptBridgeCore(IntPtr scriptPtr, string scriptPath)
         {
             _scriptTypeBiMap.ReadWriteLock.EnterUpgradeableReadLock();
             try
@@ -473,7 +477,8 @@ namespace Godot.Bridge
                 return;
             }
 
-            Debug.Assert(!scriptType.IsGenericTypeDefinition, $"Cannot get or create script for a generic type definition '{scriptType.FullName}'. Path: '{scriptPathStr}'.");
+            Debug.Assert(!scriptType.IsGenericTypeDefinition,
+                $"Cannot get or create script for a generic type definition '{scriptType.FullName}'. Path: '{scriptPathStr}'.");
 
             GetOrCreateScriptBridgeForType(scriptType, outScript);
         }
@@ -562,7 +567,8 @@ namespace Godot.Bridge
             {
                 // This path is slower, but it's only executed for the first instantiation of the type
 
-                if (scriptType.IsConstructedGenericType && !scriptPath.StartsWith("csharp://", StringComparison.Ordinal))
+                if (scriptType.IsConstructedGenericType &&
+                    !scriptPath.StartsWith("csharp://", StringComparison.Ordinal))
                 {
                     // If the script type is generic it can't be loaded using the real script path.
                     // Construct a virtual path unique to this constructed generic type and add it
@@ -610,7 +616,8 @@ namespace Godot.Bridge
         /// </summary>
         private static unsafe void CreateScriptBridgeForType(Type scriptType, godot_ref* outScript)
         {
-            Debug.Assert(!scriptType.IsGenericTypeDefinition, $"Script type must be a constructed generic type or not generic at all. Type: {scriptType}.");
+            Debug.Assert(!scriptType.IsGenericTypeDefinition,
+                $"Script type must be a constructed generic type or not generic at all. Type: {scriptType}.");
 
             _scriptTypeBiMap.ReadWriteLock.EnterWriteLock();
             try
@@ -755,18 +762,119 @@ namespace Godot.Bridge
             outTypeInfo->IsAbstract = scriptType.IsAbstract.ToGodotBool();
             outTypeInfo->IsGenericTypeDefinition = scriptType.IsGenericTypeDefinition.ToGodotBool();
             outTypeInfo->IsConstructedGenericType = scriptType.IsConstructedGenericType.ToGodotBool();
+        }
 
+        [UnmanagedCallersOnly]
+        internal static unsafe void UpdateScriptTrampolines(
+            IntPtr scriptPtr, godot_bool* outShouldFallbackToLegacyTrampolines,
+            delegate* unmanaged<IntPtr, godot_string_name*, int, godot_string_name*, void> tryAddNameToProxyNameMap,
+            delegate* unmanaged<IntPtr, godot_string_name*, int, void*, void> tryAddMethodTrampoline,
+            delegate* unmanaged<IntPtr, godot_string_name*, void*, void*, void> tryAddPropertyTrampoline,
+            delegate* unmanaged<IntPtr, godot_string_name*, int, void*, void> tryAddRaiseSignalTrampoline)
+        {
+            try
+            {
+                var scriptType = _scriptTypeBiMap.GetScriptType(scriptPtr);
+                Debug.Assert(!scriptType.IsGenericTypeDefinition,
+                    $"Script type must be a constructed generic type or not generic at all. Type: {scriptType}.");
+
+                Type native = GodotObject.InternalGetClassNativeBase(scriptType);
+
+                for (Type? top = scriptType; top != null && top != native; top = top.BaseType)
+                {
+                    var methodNameToProxyNameMap = GetMethodNameToProxyNameMapForType(top);
+
+                    if (methodNameToProxyNameMap != null)
+                    {
+                        foreach (var (methodKey, proxyName) in methodNameToProxyNameMap)
+                        {
+                            var nameSelf = (godot_string_name)methodKey.Name.NativeValue;
+                            int argc = methodKey.ArgumentCount;
+                            var proxyNameSelf = (godot_string_name)proxyName.NativeValue;
+                            tryAddNameToProxyNameMap(scriptPtr, &nameSelf, argc, &proxyNameSelf);
+                        }
+                    }
+
+                    var methodTrampolines = GetMethodTrampolinesForType(top);
+
+                    if (methodTrampolines != null)
+                    {
+                        foreach (var (methodKey, trampoline) in methodTrampolines)
+                        {
+                            var nameSelf = (godot_string_name)methodKey.Name.NativeValue;
+                            int argc = methodKey.ArgumentCount;
+                            tryAddMethodTrampoline(scriptPtr, &nameSelf, argc, trampoline.TrampolineDelegate);
+                        }
+                    }
+
+                    var propertyTrampolines = GetPropertyTrampolinesForType(top);
+
+                    if (propertyTrampolines != null)
+                    {
+                        foreach (var (name, trampolines) in propertyTrampolines)
+                        {
+                            var nameSelf = (godot_string_name)name.NativeValue;
+                            tryAddPropertyTrampoline(scriptPtr, &nameSelf,
+                                trampolines.getterTramp.TrampolineDelegate,
+                                trampolines.setterTramp.TrampolineDelegate);
+                        }
+                    }
+
+                    var raiseSignalTrampolines = GetRaiseSignalTrampolinesForType(top);
+
+                    if (raiseSignalTrampolines != null)
+                    {
+                        foreach (var (signalKey, trampoline) in raiseSignalTrampolines)
+                        {
+                            var nameSelf = (godot_string_name)signalKey.Name.NativeValue;
+                            int argc = signalKey.ArgumentCount;
+                            tryAddRaiseSignalTrampoline(scriptPtr, &nameSelf, argc, trampoline.TrampolineDelegate);
+                        }
+                    }
+                }
+
+                bool DoesUserScriptContainMethod(string methodName)
+                {
+                    var methodInfo = scriptType.GetMethod(methodName,
+                        BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+
+                    if (methodInfo == null)
+                        return false;
+
+                    for (Type? top = scriptType; top != null && top != native; top = top.BaseType)
+                    {
+                        if (methodInfo.DeclaringType == top)
+                            return true;
+                    }
+
+                    return false;
+                }
+
+                // No need to check for "HasGodotClassMethod" nor "HasGodotClassSignal",
+                // as these always accompany "InvokeGodotClassMethod" and "RaiseGodotClassSignalCallbacks".
+                *outShouldFallbackToLegacyTrampolines =
+                    (DoesUserScriptContainMethod("InvokeGodotClassMethod")
+                     || DoesUserScriptContainMethod("SetGodotClassPropertyValue")
+                     || DoesUserScriptContainMethod("GetGodotClassPropertyValue")
+                     || DoesUserScriptContainMethod("RaiseGodotClassSignalCallbacks")).ToGodotBool();
+            }
+            catch (Exception e)
+            {
+                ExceptionUtils.LogException(e);
+            }
         }
 
         [UnmanagedCallersOnly]
         internal static unsafe void UpdateScriptClassInfo(IntPtr scriptPtr, godot_csharp_type_info* outTypeInfo,
-            godot_array* outMethodsDest, godot_dictionary* outRpcFunctionsDest, godot_dictionary* outEventSignalsDest, godot_ref* outBaseScript)
+            godot_array* outMethodsDest, godot_dictionary* outRpcFunctionsDest, godot_dictionary* outEventSignalsDest,
+            godot_ref* outBaseScript)
         {
             try
             {
                 // Performance is not critical here as this will be replaced with source generators.
                 var scriptType = _scriptTypeBiMap.GetScriptType(scriptPtr);
-                Debug.Assert(!scriptType.IsGenericTypeDefinition, $"Script type must be a constructed generic type or not generic at all. Type: {scriptType}.");
+                Debug.Assert(!scriptType.IsGenericTypeDefinition,
+                    $"Script type must be a constructed generic type or not generic at all. Type: {scriptType}.");
 
                 GetScriptTypeInfo(scriptType, outTypeInfo);
 
@@ -777,7 +885,6 @@ namespace Godot.Bridge
                 // Performance is not critical here as this will be replaced with source generators.
                 using var methods = new Collections.Array();
 
-                Type? top = scriptType;
                 if (scriptType != native)
                 {
                     var methodList = GetMethodListForType(scriptType);
@@ -840,7 +947,7 @@ namespace Godot.Bridge
 
                 Collections.Dictionary rpcFunctions = new();
 
-                top = scriptType;
+                Type? top = scriptType;
 
                 while (top != null && top != native)
                 {
@@ -973,6 +1080,58 @@ namespace Godot.Bridge
             return (List<MethodInfo>?)getGodotMethodListMethod.Invoke(null, null);
         }
 
+        private static Dictionary<MethodKey, StringName>? GetMethodNameToProxyNameMapForType(Type type)
+        {
+            var getGodotMethodNameToProxyNameMap = type.GetMethod(
+                "GetGodotMethodNameToProxyNameMap",
+                BindingFlags.DeclaredOnly | BindingFlags.Static |
+                BindingFlags.NonPublic | BindingFlags.Public);
+
+            if (getGodotMethodNameToProxyNameMap == null)
+                return null;
+
+            return (Dictionary<MethodKey, StringName>?)getGodotMethodNameToProxyNameMap.Invoke(null, null);
+        }
+
+        private static Dictionary<MethodKey, MethodTrampoline>? GetMethodTrampolinesForType(Type type)
+        {
+            var getGodotMethodTrampolines = type.GetMethod(
+                "GetGodotMethodTrampolines",
+                BindingFlags.DeclaredOnly | BindingFlags.Static |
+                BindingFlags.NonPublic | BindingFlags.Public);
+
+            if (getGodotMethodTrampolines == null)
+                return null;
+
+            return (Dictionary<MethodKey, MethodTrampoline>?)getGodotMethodTrampolines.Invoke(null, null);
+        }
+
+        private static Dictionary<StringName, PropertyTrampolines>? GetPropertyTrampolinesForType(Type type)
+        {
+            var getGodotPropertyTrampolines = type.GetMethod(
+                "GetGodotPropertyTrampolines",
+                BindingFlags.DeclaredOnly | BindingFlags.Static |
+                BindingFlags.NonPublic | BindingFlags.Public);
+
+            if (getGodotPropertyTrampolines == null)
+                return null;
+
+            return (Dictionary<StringName, PropertyTrampolines>?)getGodotPropertyTrampolines.Invoke(null, null);
+        }
+
+        private static Dictionary<SignalKey, RaiseSignalTrampoline>? GetRaiseSignalTrampolinesForType(Type type)
+        {
+            var getGodotRaiseSignalTrampolines = type.GetMethod(
+                "GetGodotRaiseSignalTrampolines",
+                BindingFlags.DeclaredOnly | BindingFlags.Static |
+                BindingFlags.NonPublic | BindingFlags.Public);
+
+            if (getGodotRaiseSignalTrampolines == null)
+                return null;
+
+            return (Dictionary<SignalKey, RaiseSignalTrampoline>?)getGodotRaiseSignalTrampolines.Invoke(null, null);
+        }
+
 #pragma warning disable IDE1006 // Naming rule violation
         // ReSharper disable once InconsistentNaming
         // ReSharper disable once NotAccessedField.Local
@@ -1069,7 +1228,8 @@ namespace Godot.Bridge
                         interopProperties[i] = interopProperty;
                     }
 
-                    using godot_string currentClassName = Marshaling.ConvertStringToNative(ReflectionUtils.ConstructTypeName(type));
+                    using godot_string currentClassName =
+                        Marshaling.ConvertStringToNative(ReflectionUtils.ConstructTypeName(type));
 
                     addPropInfoFunc(scriptPtr, &currentClassName, interopProperties, length);
 
@@ -1104,7 +1264,8 @@ namespace Godot.Bridge
         }
 #pragma warning restore IDE1006
 
-        private delegate bool InvokeGodotClassStaticMethodDelegate(in godot_string_name method, NativeVariantPtrArgs args, out godot_variant ret);
+        private delegate bool InvokeGodotClassStaticMethodDelegate(in godot_string_name method,
+            NativeVariantPtrArgs args, out godot_variant ret);
 
         [UnmanagedCallersOnly]
         internal static unsafe godot_bool CallStatic(IntPtr scriptPtr, godot_string_name* method,
@@ -1128,8 +1289,10 @@ namespace Godot.Bridge
 
                     if (invokeGodotClassStaticMethod != null)
                     {
-                        var invoked = invokeGodotClassStaticMethod.CreateDelegate<InvokeGodotClassStaticMethodDelegate>()(
-                            CustomUnsafe.AsRef(method), new NativeVariantPtrArgs(args, argCount), out godot_variant retValue);
+                        var invoked =
+                            invokeGodotClassStaticMethod.CreateDelegate<InvokeGodotClassStaticMethodDelegate>()(
+                                CustomUnsafe.AsRef(method), new NativeVariantPtrArgs(args, argCount),
+                                out godot_variant retValue);
                         if (invoked)
                         {
                             *ret = retValue;
@@ -1293,9 +1456,9 @@ namespace Godot.Bridge
                 }
 
                 // Release the current weak handle and replace it with a strong handle.
-                var newGCHandle = createWeak.ToBool() ?
-                    CustomGCHandle.AllocWeak(target) :
-                    CustomGCHandle.AllocStrong(target);
+                var newGCHandle = createWeak.ToBool()
+                    ? CustomGCHandle.AllocWeak(target)
+                    : CustomGCHandle.AllocStrong(target);
 
                 CustomGCHandle.Free(oldGCHandle);
                 *outNewGCHandlePtr = GCHandle.ToIntPtr(newGCHandle);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -378,7 +378,7 @@ namespace Godot.Bridge
 
         [UnmanagedCallersOnly]
         internal static unsafe void RaiseEventSignal(IntPtr ownerGCHandlePtr,
-            godot_string_name* eventSignalName, godot_variant** args, int argCount, godot_bool* outOwnerIsNull)
+            godot_string_name* eventSignalName, godot_variant** args, int argCount, godot_bool* refOwnerIsNull)
         {
             try
             {
@@ -386,11 +386,11 @@ namespace Godot.Bridge
 
                 if (owner == null)
                 {
-                    *outOwnerIsNull = godot_bool.True;
+                    *refOwnerIsNull = godot_bool.True;
                     return;
                 }
 
-                *outOwnerIsNull = godot_bool.False;
+                *refOwnerIsNull = godot_bool.False;
 
                 owner.RaiseGodotClassSignalCallbacks(CustomUnsafe.AsRef(eventSignalName),
                     new NativeVariantPtrArgs(args, argCount));
@@ -398,7 +398,33 @@ namespace Godot.Bridge
             catch (Exception e)
             {
                 ExceptionUtils.LogException(e);
-                *outOwnerIsNull = godot_bool.False;
+                *refOwnerIsNull = godot_bool.False;
+            }
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe void RaiseEventSignalViaTrampoline(
+            RaiseSignalTrampolineDelegate raiseSignalTrampoline,
+            IntPtr ownerGCHandlePtr, godot_variant** args, int argCount, godot_bool* refOwnerIsNull)
+        {
+            try
+            {
+                object? owner = GCHandle.FromIntPtr(ownerGCHandlePtr).Target;
+
+                if (owner == null)
+                {
+                    *refOwnerIsNull = godot_bool.True;
+                    return;
+                }
+
+                *refOwnerIsNull = godot_bool.False;
+
+                raiseSignalTrampoline(owner, new NativeVariantPtrArgs(args, argCount));
+            }
+            catch (Exception e)
+            {
+                ExceptionUtils.LogException(e);
+                *refOwnerIsNull = godot_bool.False;
             }
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -814,37 +814,31 @@ namespace Godot.Bridge
                 Debug.Assert(!scriptType.IsGenericTypeDefinition,
                     $"Script type must be a constructed generic type or not generic at all. Type: {scriptType}.");
 
-                Type native = GodotObject.InternalGetClassNativeBase(scriptType);
-
                 TrampolineCollectorPool collectorPool;
 
                 if (_cachedTrampolineCollectorPool == null)
                 {
                     _cachedTrampolineCollectorPool = new(
-                        OneArgumentArray: new object[1],
-                        new(scriptPtr, tryAddNameToProxyNameMap),
-                        new(scriptPtr, tryAddMethodTrampoline),
-                        new(scriptPtr, tryAddPropertyTrampoline),
-                        new(scriptPtr, tryAddRaiseSignalTrampoline));
+                        TwoArgumentArray: new object[2],
+                        Collectors: new(
+                            new(scriptPtr, tryAddNameToProxyNameMap),
+                            new(scriptPtr, tryAddMethodTrampoline),
+                            new(scriptPtr, tryAddPropertyTrampoline),
+                            new(scriptPtr, tryAddRaiseSignalTrampoline)),
+                        CollectionOptions: new(IncludeAncestors: true));
 
                     collectorPool = _cachedTrampolineCollectorPool.Value;
                 }
                 else
                 {
                     collectorPool = _cachedTrampolineCollectorPool.Value;
-                    collectorPool.NameToProxyNameMapCollector.Change(scriptPtr, tryAddNameToProxyNameMap);
-                    collectorPool.MethodTrampolineCollector.Change(scriptPtr, tryAddMethodTrampoline);
-                    collectorPool.PropertyTrampolineCollector.Change(scriptPtr, tryAddPropertyTrampoline);
-                    collectorPool.RaiseSignalTrampolineCollector.Change(scriptPtr, tryAddRaiseSignalTrampoline);
+                    collectorPool.Collectors.UpdateCollectors(scriptPtr, tryAddNameToProxyNameMap,
+                        tryAddMethodTrampoline, tryAddPropertyTrampoline, tryAddRaiseSignalTrampoline);
                 }
 
-                for (Type? top = scriptType; top != null && top != native; top = top.BaseType)
-                {
-                    GetMethodNameToProxyNameMapForType(top, collectorPool);
-                    GetMethodTrampolinesForType(top, collectorPool);
-                    GetPropertyTrampolinesForType(top, collectorPool);
-                    GetRaiseSignalTrampolinesForType(top, collectorPool);
-                }
+                GetGodotClassTrampolinesForType(scriptType, collectorPool);
+
+                Type native = GodotObject.InternalGetClassNativeBase(scriptType);
 
                 bool DoesUserScriptContainMethod(string methodName)
                 {
@@ -1097,11 +1091,14 @@ namespace Godot.Bridge
         /// This is used to collect the method name to proxy name map for a script.
         /// </summary>
         /// <remarks>
-        /// The user script can implement a static method "GetGodotMethodNameToProxyNameMap"
-        /// that receives an instance of this class and calls its <see cref="TryAdd"/> method.<br/>
+        /// The user script can implement a static method "GetGodotClassTrampolines"
+        /// that receives an instance of <see cref="TrampolineCollectors"/> which
+        /// contains an instance of this class. The user script can then call the
+        /// <see cref="TryAdd"/> method of this class to add proxy name mappings to the script.<br/>
         /// <br/>
-        /// "GetGodotMethodNameToProxyNameMap" is called on the most derived class first,
-        /// then through the base classes one by one in inheritance order.
+        /// "GetGodotClassTrampolines" must be called on the most derived class first,
+        /// and after collecting the members for that class, its implementation must call the base
+        /// implementation to also collect members from the base classes in inheritance order.<br/>
         /// As a result, <see cref="TryAdd"/> will not add a method from a base class if the derived class
         /// has already added a method with the same MethodKey.
         /// </remarks>
@@ -1117,7 +1114,7 @@ namespace Godot.Bridge
                 _tryAddDelegate = tryAddDelegate;
             }
 
-            internal unsafe void Change(IntPtr scriptPtr, TryAddNameToProxyNameMapDelegate tryAddDelegate)
+            internal unsafe void Update(IntPtr scriptPtr, TryAddNameToProxyNameMapDelegate tryAddDelegate)
             {
                 _scriptPtr = scriptPtr;
                 _tryAddDelegate = tryAddDelegate;
@@ -1138,11 +1135,14 @@ namespace Godot.Bridge
         /// This is used to collect the method trampolines for a script.
         /// </summary>
         /// <remarks>
-        /// The user script can implement a static method "GetGodotMethodTrampolines"
-        /// that receives an instance of this class and calls its <see cref="TryAdd"/> method.<br/>
+        /// The user script can implement a static method "GetGodotClassTrampolines"
+        /// that receives an instance of <see cref="TrampolineCollectors"/> which
+        /// contains an instance of this class. The user script can then call the
+        /// <see cref="TryAdd"/> method of this class to add methodsto the script.<br/>
         /// <br/>
-        /// "GetGodotMethodTrampolines" is called on the most derived class first,
-        /// then through the base classes one by one in inheritance order.
+        /// "GetGodotClassTrampolines" must be called on the most derived class first,
+        /// and after collecting the members for that class, its implementation must call the base
+        /// implementation to also collect members from the base classes in inheritance order.<br/>
         /// As a result, <see cref="TryAdd"/> will not add a method from a base class if the derived class
         /// has already added a method with the same MethodKey.
         /// </remarks>
@@ -1157,7 +1157,7 @@ namespace Godot.Bridge
                 _tryAddDelegate = tryAddDelegate;
             }
 
-            internal unsafe void Change(IntPtr scriptPtr, TryAddMethodTrampolineDelegate tryAddDelegate)
+            internal unsafe void Update(IntPtr scriptPtr, TryAddMethodTrampolineDelegate tryAddDelegate)
             {
                 _scriptPtr = scriptPtr;
                 _tryAddDelegate = tryAddDelegate;
@@ -1178,11 +1178,14 @@ namespace Godot.Bridge
         /// This is used to collect the property trampolines for a script.
         /// </summary>
         /// <remarks>
-        /// The user script can implement a static method "GetGodotPropertyTrampolines"
-        /// that receives an instance of this class and calls its <see cref="TryAdd"/> method.<br/>
+        /// The user script can implement a static method "GetGodotClassTrampolines"
+        /// that receives an instance of <see cref="TrampolineCollectors"/> which
+        /// contains an instance of this class. The user script can then call the
+        /// <see cref="TryAdd"/> method of this class to add properties to the script.<br/>
         /// <br/>
-        /// "GetGodotPropertyTrampolines" is called on the most derived class first,
-        /// then through the base classes one by one in inheritance order.
+        /// "GetGodotClassTrampolines" must be called on the most derived class first,
+        /// and after collecting the members for that class, its implementation must call the base
+        /// implementation to also collect members from the base classes in inheritance order.<br/>
         /// As a result, <see cref="TryAdd"/> will not add a property from a base class if the derived class
         /// has already added a property with the same name.
         /// </remarks>
@@ -1198,7 +1201,7 @@ namespace Godot.Bridge
                 _tryAddDelegate = tryAddDelegate;
             }
 
-            internal unsafe void Change(IntPtr scriptPtr, TryAddPropertyTrampolineDelegate tryAddDelegate)
+            internal unsafe void Update(IntPtr scriptPtr, TryAddPropertyTrampolineDelegate tryAddDelegate)
             {
                 _scriptPtr = scriptPtr;
                 _tryAddDelegate = tryAddDelegate;
@@ -1225,11 +1228,14 @@ namespace Godot.Bridge
         /// This is used to collect the raise signal trampolines for a script.
         /// </summary>
         /// <remarks>
-        /// The user script can implement a static method "GetGodotRaiseSignalTrampolines"
-        /// that receives an instance of this class and calls its <see cref="TryAdd"/> method.<br/>
+        /// The user script can implement a static method "GetGodotClassTrampolines"
+        /// that receives an instance of <see cref="TrampolineCollectors"/> which
+        /// contains an instance of this class. The user script can then call the
+        /// <see cref="TryAdd"/> method of this class to add signals to the script.<br/>
         /// <br/>
-        /// "GetGodotRaiseSignalTrampolines" is called on the most derived class first,
-        /// then through the base classes one by one in inheritance order.
+        /// "GetGodotClassTrampolines" must be called on the most derived class first,
+        /// and after collecting the members for that class, its implementation must call the base
+        /// implementation to also collect members from the base classes in inheritance order.<br/>
         /// As a result, <see cref="TryAdd"/> will not add a signal from a base class if the derived class
         /// has already added a signal with the same SignalKey.
         /// </remarks>
@@ -1245,7 +1251,7 @@ namespace Godot.Bridge
                 _tryAddDelegate = tryAddDelegate;
             }
 
-            internal unsafe void Change(IntPtr scriptPtr, TryAddRaiseSignalTrampolineDelegate tryAddDelegate)
+            internal unsafe void Update(IntPtr scriptPtr, TryAddRaiseSignalTrampolineDelegate tryAddDelegate)
             {
                 _scriptPtr = scriptPtr;
                 _tryAddDelegate = tryAddDelegate;
@@ -1262,70 +1268,60 @@ namespace Godot.Bridge
         }
 
         /// <summary>
+        /// Group of collectors passed to the user script to collect trampolines
+        /// and method name to proxy name mappings for a script.
+        /// </summary>
+        public record TrampolineCollectors(
+            NameToProxyNameMapCollector NameToProxyNameMapCollector,
+            MethodTrampolineCollector MethodTrampolineCollector,
+            PropertyTrampolineCollector PropertyTrampolineCollector,
+            RaiseSignalTrampolineCollector RaiseSignalTrampolineCollector)
+        {
+            internal unsafe void UpdateCollectors(IntPtr scriptPtr,
+                TryAddNameToProxyNameMapDelegate tryAddNameToProxyNameMap,
+                TryAddMethodTrampolineDelegate tryAddMethodTrampoline,
+                TryAddPropertyTrampolineDelegate tryAddPropertyTrampoline,
+                TryAddRaiseSignalTrampolineDelegate tryAddRaiseSignalTrampoline)
+            {
+                NameToProxyNameMapCollector.Update(scriptPtr, tryAddNameToProxyNameMap);
+                MethodTrampolineCollector.Update(scriptPtr, tryAddMethodTrampoline);
+                PropertyTrampolineCollector.Update(scriptPtr, tryAddPropertyTrampoline);
+                RaiseSignalTrampolineCollector.Update(scriptPtr, tryAddRaiseSignalTrampoline);
+            }
+        }
+
+        /// <summary>
+        /// Options for collecting trampolines for a script.
+        /// </summary>
+        /// <param name="IncludeAncestors">
+        /// Whether trampolines from ancestor classes should also be collected.
+        /// If true, the trampoline collection method of each ancestor class must be called
+        /// after the trampoline collection method of the current class.
+        /// </param>
+        public record TrampolineCollectionOptions(bool IncludeAncestors);
+
+        /// <summary>
         /// This is used as a pool to avoid having to allocate multiple instances of the
         /// collectors and argument arrays when updating trampolines for a script.
         /// </summary>
         private record struct TrampolineCollectorPool(
-            object[] OneArgumentArray,
-            NameToProxyNameMapCollector NameToProxyNameMapCollector,
-            MethodTrampolineCollector MethodTrampolineCollector,
-            PropertyTrampolineCollector PropertyTrampolineCollector,
-            RaiseSignalTrampolineCollector RaiseSignalTrampolineCollector);
+            object[] TwoArgumentArray,
+            TrampolineCollectors Collectors,
+            TrampolineCollectionOptions CollectionOptions);
 
-        private static void GetMethodNameToProxyNameMapForType(Type type, TrampolineCollectorPool collectorPool)
+        private static void GetGodotClassTrampolinesForType(Type type, TrampolineCollectorPool collectorPool)
         {
             var getGodotMethodNameToProxyNameMap = type.GetMethod(
-                "GetGodotMethodNameToProxyNameMap",
+                "GetGodotClassTrampolines",
                 BindingFlags.DeclaredOnly | BindingFlags.Static |
                 BindingFlags.NonPublic | BindingFlags.Public);
 
             if (getGodotMethodNameToProxyNameMap == null)
                 return;
 
-            collectorPool.OneArgumentArray[0] = collectorPool.NameToProxyNameMapCollector;
-            getGodotMethodNameToProxyNameMap.Invoke(null, collectorPool.OneArgumentArray);
-        }
-
-        private static void GetMethodTrampolinesForType(Type type, TrampolineCollectorPool collectorPool)
-        {
-            var getGodotMethodTrampolines = type.GetMethod(
-                "GetGodotMethodTrampolines",
-                BindingFlags.DeclaredOnly | BindingFlags.Static |
-                BindingFlags.NonPublic | BindingFlags.Public);
-
-            if (getGodotMethodTrampolines == null)
-                return;
-
-            collectorPool.OneArgumentArray[0] = collectorPool.MethodTrampolineCollector;
-            getGodotMethodTrampolines.Invoke(null, collectorPool.OneArgumentArray);
-        }
-
-        private static void GetPropertyTrampolinesForType(Type type, TrampolineCollectorPool collectorPool)
-        {
-            var getGodotPropertyTrampolines = type.GetMethod(
-                "GetGodotPropertyTrampolines",
-                BindingFlags.DeclaredOnly | BindingFlags.Static |
-                BindingFlags.NonPublic | BindingFlags.Public);
-
-            if (getGodotPropertyTrampolines == null)
-                return;
-
-            collectorPool.OneArgumentArray[0] = collectorPool.PropertyTrampolineCollector;
-            getGodotPropertyTrampolines.Invoke(null, collectorPool.OneArgumentArray);
-        }
-
-        private static void GetRaiseSignalTrampolinesForType(Type type, TrampolineCollectorPool collectorPool)
-        {
-            var getGodotRaiseSignalTrampolines = type.GetMethod(
-                "GetGodotRaiseSignalTrampolines",
-                BindingFlags.DeclaredOnly | BindingFlags.Static |
-                BindingFlags.NonPublic | BindingFlags.Public);
-
-            if (getGodotRaiseSignalTrampolines == null)
-                return;
-
-            collectorPool.OneArgumentArray[0] = collectorPool.RaiseSignalTrampolineCollector;
-            getGodotRaiseSignalTrampolines.Invoke(null, collectorPool.OneArgumentArray);
+            collectorPool.TwoArgumentArray[0] = collectorPool.Collectors;
+            collectorPool.TwoArgumentArray[1] = collectorPool.CollectionOptions;
+            getGodotMethodNameToProxyNameMap.Invoke(null, collectorPool.TwoArgumentArray);
         }
 
 #pragma warning disable IDE1006 // Naming rule violation

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -18,7 +18,7 @@ namespace Godot.Bridge
     using unsafe TryAddNameToProxyNameMapDelegate = delegate* unmanaged<
         IntPtr, godot_string_name*, int, godot_string_name*, void>;
     using unsafe TryAddMethodTrampolineDelegate = delegate* unmanaged<
-        IntPtr, godot_string_name*, int, void*, void>;
+        IntPtr, godot_string_name*, int, void*, godot_bool, void>;
     using unsafe TryAddPropertyTrampolineDelegate = delegate* unmanaged<
         IntPtr, godot_string_name*, void*, void*, void>;
     using unsafe TryAddRaiseSignalTrampolineDelegate = delegate* unmanaged<
@@ -1169,7 +1169,8 @@ namespace Godot.Bridge
             public unsafe void TryAdd(MethodKey methodKey, MethodTrampoline trampoline)
             {
                 var nameSelf = (godot_string_name)methodKey.Name.NativeValue;
-                _tryAddDelegate(_scriptPtr, &nameSelf, methodKey.ArgumentCount, trampoline.TrampolineDelegate);
+                _tryAddDelegate(_scriptPtr, &nameSelf, methodKey.ArgumentCount,
+                    trampoline.TrampolineDelegate, trampoline.IsStatic.ToGodotBool());
             }
         }
 
@@ -1464,10 +1465,8 @@ namespace Godot.Bridge
 
         [UnmanagedCallersOnly]
         internal static unsafe godot_bool CallStatic(IntPtr scriptPtr, godot_string_name* method,
-            godot_variant** args, int argCount, godot_variant_call_error* refCallError, godot_variant* ret)
+            godot_variant** args, int argCount, godot_variant_call_error* refCallError, godot_variant* outRet)
         {
-            // TODO: Optimize with source generators and delegate pointers.
-
             try
             {
                 Type scriptType = _scriptTypeBiMap.GetScriptType(scriptPtr);
@@ -1490,7 +1489,7 @@ namespace Godot.Bridge
                                 out godot_variant retValue);
                         if (invoked)
                         {
-                            *ret = retValue;
+                            *outRet = retValue;
                             return godot_bool.True;
                         }
                     }
@@ -1501,13 +1500,30 @@ namespace Godot.Bridge
             catch (Exception e)
             {
                 ExceptionUtils.LogException(e);
-                *ret = default;
+                *outRet = default;
                 return godot_bool.False;
             }
 
-            *ret = default;
+            *outRet = default;
             (*refCallError).Error = godot_variant_call_error_error.GODOT_CALL_ERROR_CALL_ERROR_INVALID_METHOD;
             return godot_bool.False;
+        }
+
+        [UnmanagedCallersOnly]
+        internal static unsafe godot_bool CallStaticWithTrampoline(MethodTrampolineDelegate methodTrampoline,
+            godot_variant** args, int argCount, godot_variant_call_error* refCallError, godot_variant* outRet)
+        {
+            try
+            {
+                *outRet = methodTrampoline(null, new NativeVariantPtrArgs(args, argCount), ref *refCallError);
+                return godot_bool.True;
+            }
+            catch (Exception e)
+            {
+                ExceptionUtils.LogException(e);
+                *outRet = default;
+                return godot_bool.False;
+            }
         }
 
         [UnmanagedCallersOnly]

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/SignalKey.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/SignalKey.cs
@@ -1,0 +1,15 @@
+namespace Godot.Bridge;
+
+#nullable enable
+
+public readonly struct SignalKey
+{
+    public StringName Name { get; init; }
+    public int ArgumentCount { get; init; } = 0;
+
+    public SignalKey(StringName name, int argumentCount)
+    {
+        Name = name;
+        ArgumentCount = argumentCount;
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace Godot.NativeInterop
 {
-    public static class ExceptionUtils
+    internal static class ExceptionUtils
     {
         public static void PushError(string message)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace Godot.NativeInterop
 {
-    internal static class ExceptionUtils
+    public static class ExceptionUtils
     {
         public static void PushError(string message)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
@@ -103,6 +103,16 @@ namespace Godot.NativeInterop
             readonly get => (Godot.Variant.Type)expected;
             set => expected = (int)value;
         }
+
+        public static godot_variant_call_error CreateInvalidArgumentCountError(int expected, int provided)
+        {
+            return new godot_variant_call_error
+            {
+                error = provided < expected
+                    ? godot_variant_call_error_error.GODOT_CALL_ERROR_CALL_ERROR_TOO_FEW_ARGUMENTS
+                    : godot_variant_call_error_error.GODOT_CALL_ERROR_CALL_ERROR_TOO_MANY_ARGUMENTS
+            };
+        }
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/modules/mono/glue/GodotSharp/GodotSharp/GlobalUsings.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GlobalUsings.cs
@@ -3,3 +3,20 @@ global using real_t = System.Double;
 #else
 global using real_t = System.Single;
 #endif
+
+global using unsafe MethodTrampolineDelegate = delegate* managed<
+    /* godotObject: */ object,
+    /* args: */ Godot.NativeInterop.NativeVariantPtrArgs,
+    /* callError: */ ref Godot.NativeInterop.godot_variant_call_error,
+    /* return (value): */ Godot.NativeInterop.godot_variant>;
+global using unsafe PropertyGetterTrampolineDelegate = delegate* managed<
+    /* godotObject: */ object,
+    /* return (value): */ Godot.NativeInterop.godot_variant>;
+global using unsafe PropertySetterTrampolineDelegate = delegate* managed<
+    /* godotObject: */ object,
+    /* value: */ in Godot.NativeInterop.godot_variant,
+    /* return: */ void>;
+global using unsafe RaiseSignalTrampolineDelegate = delegate* managed<
+    /* godotObject: */ object,
+    /* args: */ Godot.NativeInterop.NativeVariantPtrArgs,
+    /* return */ void>;

--- a/modules/mono/glue/GodotSharp/GodotSharp/GlobalUsings.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GlobalUsings.cs
@@ -20,3 +20,23 @@ global using unsafe RaiseSignalTrampolineDelegate = delegate* managed<
     /* godotObject: */ object,
     /* args: */ Godot.NativeInterop.NativeVariantPtrArgs,
     /* return */ void>;
+
+global using unsafe TryAddMethodTrampolineDelegate = delegate* unmanaged<
+    /* scriptPtr: */ System.IntPtr,
+    /* name: */ Godot.NativeInterop.godot_string_name*,
+    /* argCount: */ int,
+    /* trampolineDelegate: */ void*,
+    /* isStatic: */ Godot.NativeInterop.godot_bool,
+    /* return */ void>;
+global using unsafe TryAddPropertyTrampolineDelegate = delegate* unmanaged<
+    /* scriptPtr: */ System.IntPtr,
+    /* name: */ Godot.NativeInterop.godot_string_name*,
+    /* getterTrampolineDelegate: */ void*,
+    /* setterTrampolineDelegate: */ void*,
+    /* return */ void>;
+global using unsafe TryAddRaiseSignalTrampolineDelegate = delegate* unmanaged<
+    /* scriptPtr: */ System.IntPtr,
+    /* name: */ Godot.NativeInterop.godot_string_name*,
+    /* argCount: */ int,
+    /* trampolineDelegate: */ void*,
+    /* return */ void>;

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -58,6 +58,9 @@
     <Compile Include="Core\Attributes\ExportToolButtonAttribute.cs" />
     <Compile Include="Core\Bridge\GodotSerializationInfo.cs" />
     <Compile Include="Core\Bridge\MethodInfo.cs" />
+    <Compile Include="Core\Bridge\GodotClassTrampolines.cs" />
+    <Compile Include="Core\Bridge\MethodKey.cs" />
+    <Compile Include="Core\Bridge\SignalKey.cs" />
     <Compile Include="Core\Callable.generics.cs" />
     <Compile Include="Core\CustomGCHandle.cs" />
     <Compile Include="Core\Array.cs" />

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -56,6 +56,7 @@
   <ItemGroup>
     <Compile Include="Core\Aabb.cs" />
     <Compile Include="Core\Attributes\ExportToolButtonAttribute.cs" />
+    <Compile Include="Core\Bridge\Collectors.cs" />
     <Compile Include="Core\Bridge\GodotSerializationInfo.cs" />
     <Compile Include="Core\Bridge\MethodInfo.cs" />
     <Compile Include="Core\Bridge\GodotClassTrampolines.cs" />

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -68,6 +68,7 @@ void update_godot_api_cache(const ManagedCallbacks &p_managed_callbacks) {
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, GetOrCreateScriptBridgeForPath);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, RemoveScriptBridge);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, TryReloadRegisteredScriptWithClass);
+	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, UpdateScriptTrampolines);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, UpdateScriptClassInfo);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, SwapGCHandleForType);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, GetPropertyInfoList);

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -75,6 +75,7 @@ void update_godot_api_cache(const ManagedCallbacks &p_managed_callbacks) {
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, GetPropertyInfoList);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, GetPropertyDefaultValues);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, CallStatic);
+	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, CallStaticWithTrampoline);
 	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, Call);
 	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, Set);
 	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, Get);

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -63,6 +63,7 @@ void update_godot_api_cache(const ManagedCallbacks &p_managed_callbacks) {
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, GetGlobalClassName);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, SetGodotObjectPtr);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, RaiseEventSignal);
+	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, RaiseEventSignalViaTrampoline);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, ScriptIsOrInherits);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, AddScriptBridge);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, GetOrCreateScriptBridgeForPath);
@@ -77,6 +78,9 @@ void update_godot_api_cache(const ManagedCallbacks &p_managed_callbacks) {
 	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, Call);
 	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, Set);
 	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, Get);
+	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, CallViaTrampoline);
+	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, SetViaTrampoline);
+	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, GetViaTrampoline);
 	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, CallDispose);
 	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, CallToString);
 	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, HasMethodUnknownParams);

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -68,7 +68,6 @@ struct godotsharp_property_def_val_pair {
 };
 
 struct ManagedCallbacks {
-	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddNameToProxyNameMap = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name, int32_t p_argc, const StringName *p_proxy_name);
 	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddMethod = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name, int32_t p_argc, godotsharp::MethodTrampoline p_trampoline, bool p_is_static);
 	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddProperty = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name,
 			godotsharp::PropertyGetterTrampoline p_getter_trampoline, godotsharp::PropertySetterTrampoline p_setter_trampoline);
@@ -97,7 +96,6 @@ struct ManagedCallbacks {
 	using FuncScriptManagerBridge_RemoveScriptBridge = void(GD_CLR_STDCALL *)(const CSharpScript *);
 	using FuncScriptManagerBridge_TryReloadRegisteredScriptWithClass = bool(GD_CLR_STDCALL *)(const CSharpScript *);
 	using FuncScriptManagerBridge_UpdateScriptTrampolines = void(GD_CLR_STDCALL *)(const CSharpScript *, bool *,
-			Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddNameToProxyNameMap,
 			Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddMethod,
 			Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddProperty,
 			Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddRaiseSignal);

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -69,7 +69,7 @@ struct godotsharp_property_def_val_pair {
 
 struct ManagedCallbacks {
 	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddNameToProxyNameMap = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name, int32_t p_argc, const StringName *p_proxy_name);
-	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddMethod = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name, int32_t p_argc, godotsharp::MethodTrampoline p_trampoline);
+	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddMethod = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name, int32_t p_argc, godotsharp::MethodTrampoline p_trampoline, bool p_is_static);
 	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddProperty = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name,
 			godotsharp::PropertyGetterTrampoline p_getter_trampoline, godotsharp::PropertySetterTrampoline p_setter_trampoline);
 	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddRaiseSignal = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name, int32_t p_argc, godotsharp::RaiseSignalTrampoline p_trampoline);
@@ -106,6 +106,7 @@ struct ManagedCallbacks {
 	using FuncScriptManagerBridge_GetPropertyInfoList = void(GD_CLR_STDCALL *)(CSharpScript *, Callback_ScriptManagerBridge_GetPropertyInfoList_Add);
 	using FuncScriptManagerBridge_GetPropertyDefaultValues = void(GD_CLR_STDCALL *)(CSharpScript *, Callback_ScriptManagerBridge_GetPropertyDefaultValues_Add);
 	using FuncScriptManagerBridge_CallStatic = bool(GD_CLR_STDCALL *)(const CSharpScript *, const StringName *, const Variant **, int32_t, Callable::CallError *, Variant *);
+	using FuncScriptManagerBridge_CallStaticWithTrampoline = bool(GD_CLR_STDCALL *)(godotsharp::MethodTrampoline p_trampoline, const Variant **, int32_t, Callable::CallError *, Variant *);
 	using FuncCSharpInstanceBridge_Call = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, const StringName *, const Variant **, int32_t, Callable::CallError *, Variant *);
 	using FuncCSharpInstanceBridge_Set = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, const StringName *, const Variant *);
 	using FuncCSharpInstanceBridge_Get = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, const StringName *, Variant *);
@@ -149,6 +150,7 @@ struct ManagedCallbacks {
 	FuncScriptManagerBridge_GetPropertyInfoList ScriptManagerBridge_GetPropertyInfoList;
 	FuncScriptManagerBridge_GetPropertyDefaultValues ScriptManagerBridge_GetPropertyDefaultValues;
 	FuncScriptManagerBridge_CallStatic ScriptManagerBridge_CallStatic;
+	FuncScriptManagerBridge_CallStaticWithTrampoline ScriptManagerBridge_CallStaticWithTrampoline;
 	FuncCSharpInstanceBridge_Call CSharpInstanceBridge_Call;
 	FuncCSharpInstanceBridge_Set CSharpInstanceBridge_Set;
 	FuncCSharpInstanceBridge_Get CSharpInstanceBridge_Get;

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -68,6 +68,11 @@ struct godotsharp_property_def_val_pair {
 };
 
 struct ManagedCallbacks {
+	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddNameToProxyNameMap = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name, int32_t p_argc, const StringName *p_proxy_name);
+	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddMethod = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name, int32_t p_argc, MethodTrampoline p_trampoline);
+	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddProperty = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name,
+			PropertyGetterTrampoline p_getter_trampoline, PropertySetterTrampoline p_setter_trampoline);
+	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddRaiseSignal = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name, int32_t p_argc, RaiseSignalTrampoline p_trampoline);
 	using Callback_ScriptManagerBridge_GetPropertyInfoList_Add = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const String *, void *p_props, int32_t p_count);
 	using Callback_ScriptManagerBridge_GetPropertyDefaultValues_Add = void(GD_CLR_STDCALL *)(CSharpScript *p_script, void *p_def_vals, int32_t p_count);
 
@@ -90,6 +95,11 @@ struct ManagedCallbacks {
 	using FuncScriptManagerBridge_GetOrCreateScriptBridgeForPath = void(GD_CLR_STDCALL *)(const String *, Ref<CSharpScript> *);
 	using FuncScriptManagerBridge_RemoveScriptBridge = void(GD_CLR_STDCALL *)(const CSharpScript *);
 	using FuncScriptManagerBridge_TryReloadRegisteredScriptWithClass = bool(GD_CLR_STDCALL *)(const CSharpScript *);
+	using FuncScriptManagerBridge_UpdateScriptTrampolines = void(GD_CLR_STDCALL *)(const CSharpScript *, bool *,
+			Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddNameToProxyNameMap,
+			Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddMethod,
+			Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddProperty,
+			Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddRaiseSignal);
 	using FuncScriptManagerBridge_UpdateScriptClassInfo = void(GD_CLR_STDCALL *)(const CSharpScript *, CSharpScript::TypeInfo *, Array *, Dictionary *, Dictionary *, Ref<CSharpScript> *);
 	using FuncScriptManagerBridge_SwapGCHandleForType = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, GCHandleIntPtr *, bool);
 	using FuncScriptManagerBridge_GetPropertyInfoList = void(GD_CLR_STDCALL *)(CSharpScript *, Callback_ScriptManagerBridge_GetPropertyInfoList_Add);
@@ -128,6 +138,7 @@ struct ManagedCallbacks {
 	FuncScriptManagerBridge_GetOrCreateScriptBridgeForPath ScriptManagerBridge_GetOrCreateScriptBridgeForPath;
 	FuncScriptManagerBridge_RemoveScriptBridge ScriptManagerBridge_RemoveScriptBridge;
 	FuncScriptManagerBridge_TryReloadRegisteredScriptWithClass ScriptManagerBridge_TryReloadRegisteredScriptWithClass;
+	FuncScriptManagerBridge_UpdateScriptTrampolines ScriptManagerBridge_UpdateScriptTrampolines;
 	FuncScriptManagerBridge_UpdateScriptClassInfo ScriptManagerBridge_UpdateScriptClassInfo;
 	FuncScriptManagerBridge_SwapGCHandleForType ScriptManagerBridge_SwapGCHandleForType;
 	FuncScriptManagerBridge_GetPropertyInfoList ScriptManagerBridge_GetPropertyInfoList;

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -69,10 +69,10 @@ struct godotsharp_property_def_val_pair {
 
 struct ManagedCallbacks {
 	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddNameToProxyNameMap = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name, int32_t p_argc, const StringName *p_proxy_name);
-	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddMethod = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name, int32_t p_argc, MethodTrampoline p_trampoline);
+	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddMethod = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name, int32_t p_argc, godotsharp::MethodTrampoline p_trampoline);
 	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddProperty = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name,
-			PropertyGetterTrampoline p_getter_trampoline, PropertySetterTrampoline p_setter_trampoline);
-	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddRaiseSignal = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name, int32_t p_argc, RaiseSignalTrampoline p_trampoline);
+			godotsharp::PropertyGetterTrampoline p_getter_trampoline, godotsharp::PropertySetterTrampoline p_setter_trampoline);
+	using Callback_ScriptManagerBridge_UpdateScriptTrampolines_TryAddRaiseSignal = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const StringName *p_name, int32_t p_argc, godotsharp::RaiseSignalTrampoline p_trampoline);
 	using Callback_ScriptManagerBridge_GetPropertyInfoList_Add = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const String *, void *p_props, int32_t p_count);
 	using Callback_ScriptManagerBridge_GetPropertyDefaultValues_Add = void(GD_CLR_STDCALL *)(CSharpScript *p_script, void *p_def_vals, int32_t p_count);
 
@@ -90,6 +90,7 @@ struct ManagedCallbacks {
 	using FuncScriptManagerBridge_GetGlobalClassName = void(GD_CLR_STDCALL *)(const String *, String *, String *, bool *, bool *, String *);
 	using FuncScriptManagerBridge_SetGodotObjectPtr = void(GD_CLR_STDCALL *)(GCHandleIntPtr, Object *);
 	using FuncScriptManagerBridge_RaiseEventSignal = void(GD_CLR_STDCALL *)(GCHandleIntPtr, const StringName *, const Variant **, int32_t, bool *);
+	using FuncScriptManagerBridge_RaiseEventSignalViaTrampoline = void(GD_CLR_STDCALL *)(godotsharp::RaiseSignalTrampoline p_trampoline, GCHandleIntPtr p_obj_gchandle, const Variant **p_args, int32_t p_argc, bool *r_owner_is_null);
 	using FuncScriptManagerBridge_ScriptIsOrInherits = bool(GD_CLR_STDCALL *)(const CSharpScript *, const CSharpScript *);
 	using FuncScriptManagerBridge_AddScriptBridge = bool(GD_CLR_STDCALL *)(const CSharpScript *, const String *);
 	using FuncScriptManagerBridge_GetOrCreateScriptBridgeForPath = void(GD_CLR_STDCALL *)(const String *, Ref<CSharpScript> *);
@@ -108,6 +109,9 @@ struct ManagedCallbacks {
 	using FuncCSharpInstanceBridge_Call = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, const StringName *, const Variant **, int32_t, Callable::CallError *, Variant *);
 	using FuncCSharpInstanceBridge_Set = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, const StringName *, const Variant *);
 	using FuncCSharpInstanceBridge_Get = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, const StringName *, Variant *);
+	using FuncCSharpInstanceBridge_CallViaTrampoline = bool(GD_CLR_STDCALL *)(godotsharp::MethodTrampoline p_trampoline, GCHandleIntPtr p_obj_gchandle, const Variant **p_args, int32_t p_argc, Callable::CallError *r_ref_call_error, Variant *r_ret);
+	using FuncCSharpInstanceBridge_SetViaTrampoline = bool(GD_CLR_STDCALL *)(godotsharp::PropertySetterTrampoline p_trampoline, GCHandleIntPtr p_obj_gchandle, const Variant *p_args);
+	using FuncCSharpInstanceBridge_GetViaTrampoline = bool(GD_CLR_STDCALL *)(godotsharp::PropertyGetterTrampoline p_trampoline, GCHandleIntPtr p_obj_gchandle, Variant *r_args);
 	using FuncCSharpInstanceBridge_CallDispose = void(GD_CLR_STDCALL *)(GCHandleIntPtr, bool);
 	using FuncCSharpInstanceBridge_CallToString = void(GD_CLR_STDCALL *)(GCHandleIntPtr, String *, bool *);
 	using FuncCSharpInstanceBridge_HasMethodUnknownParams = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, const StringName *);
@@ -133,6 +137,7 @@ struct ManagedCallbacks {
 	FuncScriptManagerBridge_GetGlobalClassName ScriptManagerBridge_GetGlobalClassName;
 	FuncScriptManagerBridge_SetGodotObjectPtr ScriptManagerBridge_SetGodotObjectPtr;
 	FuncScriptManagerBridge_RaiseEventSignal ScriptManagerBridge_RaiseEventSignal;
+	FuncScriptManagerBridge_RaiseEventSignalViaTrampoline ScriptManagerBridge_RaiseEventSignalViaTrampoline;
 	FuncScriptManagerBridge_ScriptIsOrInherits ScriptManagerBridge_ScriptIsOrInherits;
 	FuncScriptManagerBridge_AddScriptBridge ScriptManagerBridge_AddScriptBridge;
 	FuncScriptManagerBridge_GetOrCreateScriptBridgeForPath ScriptManagerBridge_GetOrCreateScriptBridgeForPath;
@@ -147,6 +152,9 @@ struct ManagedCallbacks {
 	FuncCSharpInstanceBridge_Call CSharpInstanceBridge_Call;
 	FuncCSharpInstanceBridge_Set CSharpInstanceBridge_Set;
 	FuncCSharpInstanceBridge_Get CSharpInstanceBridge_Get;
+	FuncCSharpInstanceBridge_CallViaTrampoline CSharpInstanceBridge_CallViaTrampoline;
+	FuncCSharpInstanceBridge_SetViaTrampoline CSharpInstanceBridge_SetViaTrampoline;
+	FuncCSharpInstanceBridge_GetViaTrampoline CSharpInstanceBridge_GetViaTrampoline;
 	FuncCSharpInstanceBridge_CallDispose CSharpInstanceBridge_CallDispose;
 	FuncCSharpInstanceBridge_CallToString CSharpInstanceBridge_CallToString;
 	FuncCSharpInstanceBridge_HasMethodUnknownParams CSharpInstanceBridge_HasMethodUnknownParams;

--- a/modules/mono/signal_awaiter_utils.cpp
+++ b/modules/mono/signal_awaiter_utils.cpp
@@ -183,19 +183,7 @@ void EventSignalCallable::call(const Variant **p_arguments, int p_argcount, Vari
 	CSharpInstance *csharp_instance = CAST_CSHARP_INSTANCE(owner->get_script_instance());
 	ERR_FAIL_NULL(csharp_instance);
 
-	GCHandleIntPtr owner_gchandle_intptr = csharp_instance->get_gchandle_intptr();
-
-	bool awaiter_is_null = false;
-	GDMonoCache::managed_callbacks.ScriptManagerBridge_RaiseEventSignal(
-			owner_gchandle_intptr, &event_signal_name,
-			p_arguments, p_argcount, &awaiter_is_null);
-
-	if (awaiter_is_null) {
-		r_call_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
-		return;
-	}
-
-	r_call_error.error = Callable::CallError::CALL_OK;
+	csharp_instance->raise_event_signal(event_signal_name, p_arguments, p_argcount, r_call_error);
 }
 
 EventSignalCallable::EventSignalCallable(Object *p_owner, const StringName &p_event_signal_name) :


### PR DESCRIPTION
Closes #89217 and closes #120331 (there may be more issues like this one)

This should bring the call speed in line with Godot 3.x, if not better.

I was very cautious to not accidentally introduce a change in behavior that could cause regressions, but there's still a chance I might have missed something.

We still fallback to the old, slower call logic if we detect that a script class overrides the related method. This is for backwards compatibility.

I included a first commit (will squash later) that was using `delegate* unmanaged` instead of `delegate* managed`, in case anyone is interested in comparing them. But that one doesn't support generic classes. The speed difference is minimal. If you're going to try both, you must delete the `res://.godot/mono/` folder in between, or it will crash.

It may be worth comparing against #89826 (it uses delegates so it should be slower) and https://github.com/godotengine/godot/issues/89217#issuecomment-3871150214 (it may depend on which is faster between .NET's Dictionary and Godot's AHashMap).

### Results for #89217 (test_mono_method_cache)

Results are in [this comment](https://github.com/godotengine/godot/pull/116300#issuecomment-5690451443).

### Results for #115960 (PerformanceTestMRP_Godot4.5)

I'm confused about this MRP. It mentions the FPS drop when going from 100 buttons to 300, but this doesn't seem to be C# related.
I edited the MRP to add a shortcut for 300 buttons without script, and I notice no difference.

<details>
<summary>100 buttons</summary>
<img width="1150" height="648" alt="no script 100" src="https://github.com/user-attachments/assets/c9941fdf-c4ba-4a2f-b5cd-68af4637bfc7" />
<img width="1150" height="648" alt="script 100" src="https://github.com/user-attachments/assets/164c30d8-9509-4ae6-9a5c-e80ba4b8b901" />
</details>

<details>
<summary>300 buttons</summary>
<img width="1097" height="617" alt="no script 300" src="https://github.com/user-attachments/assets/a0045158-7b26-4932-b78f-a7d8128525bc" />
<img width="1097" height="617" alt="script 300" src="https://github.com/user-attachments/assets/7ed574ab-7bb6-4a34-9402-162b64f0374f" />
</details>
