### PR TITLE
Animation: Fix timeline length control clipping

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -1458,6 +1458,11 @@ int AnimationTimelineEdit::get_name_limit() const {
 void AnimationTimelineEdit::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
+			const Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
+			const int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
+			const int min_length_field_width = int(Math::ceil(font->get_string_size("0000.0000", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x + 28 * EDSCALE));
+			length->set_custom_minimum_size(Size2(MAX(int(70 * EDSCALE), min_length_field_width), 0));
+
 			add_track->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 			loop->set_button_icon(get_editor_theme_icon(SNAME("Loop")));
 			time_icon->set_texture(get_editor_theme_icon(SNAME("Time")));
@@ -1747,7 +1752,9 @@ Size2 AnimationTimelineEdit::get_minimum_size() const {
 	Size2 ms = filter_track->get_minimum_size();
 	const Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	const int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	ms.height = MAX(ms.height, font->get_height(font_size));
+	const int timeline_handle_height = get_editor_theme_icon(SNAME("TimelineHandle"))->get_height();
+	const int right_controls_height = len_hb ? int(Math::ceil(len_hb->get_combined_minimum_size().y)) : 0;
+	ms.height = MAX(ms.height, MAX(font->get_height(font_size), MAX(timeline_handle_height, right_controls_height)));
 	ms.width = get_buttons_width() + add_track->get_minimum_size().width + get_editor_theme_icon(SNAME("Hsize"))->get_width() + 2 + 8 * EDSCALE;
 	return ms;
 }

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -1367,17 +1367,19 @@ void AnimationTimelineEdit::_update_length_field_width() {
 	const int sep = int(4 * EDSCALE) + stylebox->get_offset().x;
 	const float text_width = font->get_string_size(length->get_text_value(), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x;
 	const int min_length_field_width = int(Math::ceil(stylebox->get_minimum_size().width + sep + text_width + 2 * EDSCALE));
+	const int desired_length_field_width = MAX(int(70 * EDSCALE), min_length_field_width);
 
-	length->set_custom_minimum_size(Size2(MAX(int(70 * EDSCALE), min_length_field_width), 0));
+	length->set_custom_minimum_size(Size2(desired_length_field_width, 0));
+
+	const int right_controls_width = get_buttons_width();
+	len_hb->set_position(Vector2(get_size().width - right_controls_width, 0));
+	len_hb->set_size(Size2(right_controls_width, get_size().height));
 }
 
 void AnimationTimelineEdit::_anim_length_changed(double p_new_len) {
 	if (editing) {
 		return;
 	}
-
-	_update_length_field_width();
-	update_minimum_size();
 
 	p_new_len = MAX(SECOND_DECIMAL, p_new_len);
 	if (use_fps && animation->get_step() > 0) {
@@ -1489,6 +1491,7 @@ void AnimationTimelineEdit::_notification(int p_what) {
 			add_track->get_popup()->add_icon_item(get_editor_theme_icon(SNAME("KeyAnimation")), TTR("Animation Playback Track..."));
 
 			timeline_resize_rect.size = get_editor_theme_icon(SNAME("TimelineHandle"))->get_size();
+
 			_update_length_field_width();
 			update_minimum_size();
 		} break;
@@ -1505,10 +1508,13 @@ void AnimationTimelineEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_RESIZED: {
-			len_hb->set_position(Vector2(get_size().width - get_buttons_width(), 0));
-			len_hb->set_size(Size2(get_buttons_width(), get_size().height));
+			const int right_controls_width = get_buttons_width();
+			len_hb->set_position(Vector2(get_size().width - right_controls_width, 0));
+			len_hb->set_size(Size2(right_controls_width, get_size().height));
 			int hsize_icon_width = get_editor_theme_icon(SNAME("Hsize"))->get_width();
 			add_track_hb->set_size(Size2(name_limit - ((hsize_icon_width + 16) * EDSCALE), 0));
+			_update_length_field_width();
+			update_minimum_size();
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -1750,6 +1756,7 @@ void AnimationTimelineEdit::set_animation(const Ref<Animation> &p_animation, boo
 			add_track->show();
 		}
 		play_position->show();
+		update_values();
 	} else {
 		len_hb->hide();
 		filter_track->hide();

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -1360,10 +1360,24 @@ float AnimationTimelineEdit::_get_zoom_scale(double p_zoom_value) const {
 	}
 }
 
+void AnimationTimelineEdit::_update_length_field_width() {
+	const Ref<StyleBox> stylebox = length->get_theme_stylebox(CoreStringName(normal), SNAME("LineEdit"));
+	const Ref<Font> font = length->get_theme_font(SceneStringName(font), SNAME("LineEdit"));
+	const int font_size = length->get_theme_font_size(SceneStringName(font_size), SNAME("LineEdit"));
+	const int sep = int(4 * EDSCALE) + stylebox->get_offset().x;
+	const float text_width = font->get_string_size(length->get_text_value(), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x;
+	const int min_length_field_width = int(Math::ceil(stylebox->get_minimum_size().width + sep + text_width + 2 * EDSCALE));
+
+	length->set_custom_minimum_size(Size2(MAX(int(70 * EDSCALE), min_length_field_width), 0));
+}
+
 void AnimationTimelineEdit::_anim_length_changed(double p_new_len) {
 	if (editing) {
 		return;
 	}
+
+	_update_length_field_width();
+	update_minimum_size();
 
 	p_new_len = MAX(SECOND_DECIMAL, p_new_len);
 	if (use_fps && animation->get_step() > 0) {
@@ -1458,11 +1472,6 @@ int AnimationTimelineEdit::get_name_limit() const {
 void AnimationTimelineEdit::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			const Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-			const int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-			const int min_length_field_width = int(Math::ceil(font->get_string_size("0000.0000", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x + 28 * EDSCALE));
-			length->set_custom_minimum_size(Size2(MAX(int(70 * EDSCALE), min_length_field_width), 0));
-
 			add_track->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 			loop->set_button_icon(get_editor_theme_icon(SNAME("Loop")));
 			time_icon->set_texture(get_editor_theme_icon(SNAME("Time")));
@@ -1480,6 +1489,8 @@ void AnimationTimelineEdit::_notification(int p_what) {
 			add_track->get_popup()->add_icon_item(get_editor_theme_icon(SNAME("KeyAnimation")), TTR("Animation Playback Track..."));
 
 			timeline_resize_rect.size = get_editor_theme_icon(SNAME("TimelineHandle"))->get_size();
+			_update_length_field_width();
+			update_minimum_size();
 		} break;
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
@@ -1752,9 +1763,7 @@ Size2 AnimationTimelineEdit::get_minimum_size() const {
 	Size2 ms = filter_track->get_minimum_size();
 	const Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	const int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	const int timeline_handle_height = get_editor_theme_icon(SNAME("TimelineHandle"))->get_height();
-	const int right_controls_height = len_hb ? int(Math::ceil(len_hb->get_combined_minimum_size().y)) : 0;
-	ms.height = MAX(ms.height, MAX(font->get_height(font_size), MAX(timeline_handle_height, right_controls_height)));
+	ms.height = MAX(ms.height, font->get_height(font_size));
 	ms.width = get_buttons_width() + add_track->get_minimum_size().width + get_editor_theme_icon(SNAME("Hsize"))->get_width() + 2 + 8 * EDSCALE;
 	return ms;
 }
@@ -1868,6 +1877,8 @@ void AnimationTimelineEdit::update_values() {
 		length->set_tooltip_text(TTR("Animation length (seconds)"));
 		time_icon->set_tooltip_text(TTR("Animation length (seconds)"));
 	}
+	_update_length_field_width();
+	update_minimum_size();
 
 	switch (animation->get_loop_mode()) {
 		case Animation::LOOP_NONE: {

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -217,7 +217,6 @@ class AnimationTimelineEdit : public Range {
 	void _anim_length_changed(double p_new_len);
 	void _anim_loop_pressed();
 	void _update_length_field_width();
-	void _update_right_controls_layout();
 
 	void _play_position_draw();
 	Rect2 hsize_rect;

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -216,6 +216,8 @@ class AnimationTimelineEdit : public Range {
 	void _zoom_changed(double);
 	void _anim_length_changed(double p_new_len);
 	void _anim_loop_pressed();
+	void _update_length_field_width();
+	void _update_right_controls_layout();
 
 	void _play_position_draw();
 	Rect2 hsize_rect;


### PR DESCRIPTION
### Summary
Fixes clipping of the Animation Timeline right-side length controls under large editor fonts/scales.

### Problem
When editor font/scale is increased, the timeline length controls can be partially clipped, making them hard to read/edit.
The issue is reproducible when main_font_size is around 20+ (see issue details).

### Root cause
Timeline minimum sizing did not fully account for:

actual width needed by the length text field in current theme font, and
full vertical size requirements of timeline handle and right-side controls.

### Solution
Updated [animation_track_editor.cpp](vscode-file://vscode-app/c:/Users/guanxin/AppData/Local/Programs/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to:

apply a font-aware minimum width for the length field on theme changes, and
include label/timeline-handle/right-controls heights in timeline minimum size calculation.

### Testing

Built editor locally on Windows with incremental SCons build.
Opened AnimationPlayer timeline and verified no clipping with larger font sizes/scales (including main_font_size around 20+).
Confirmed no obvious regressions at normal scale/font settings.

### Notes

Minimal, targeted UI sizing fix.
No API changes.

Fixes #115838 

<img width="2568" height="1400" alt="50f21604455c1eafe48125452c23f329" src="https://github.com/user-attachments/assets/3ddc6f42-5190-4cea-8be4-19d86b2825db" />
