### PR TITLE
Add support for importing R8 and R8G8 DDS textures

### DIFF
--- a/modules/dds/dds_enums.h
+++ b/modules/dds/dds_enums.h
@@ -164,6 +164,8 @@ enum DDSFormat {
 	DDS_LUMINANCE,
 	DDS_LUMINANCE_ALPHA,
 	DDS_LUMINANCE_ALPHA_4,
+	DDS_RG8,
+	DDS_R8,
 	DDS_MAX
 };
 
@@ -223,4 +225,6 @@ static const DDSFormatInfo dds_format_info[DDS_MAX] = {
 	{ "GRAYSCALE", false, 1, 1, Image::FORMAT_L8 },
 	{ "GRAYSCALE_ALPHA", false, 1, 2, Image::FORMAT_LA8 },
 	{ "GRAYSCALE_ALPHA_4", false, 1, 1, Image::FORMAT_LA8 },
+	{ "RG8", false, 1, 2, Image::FORMAT_RG8 },
+	{ "R8", false, 1, 1, Image::FORMAT_R8 },
 };

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -75,7 +75,9 @@ DDSFormat _dxgi_to_dds_format(uint32_t p_dxgi_format) {
 		case DXGI_R32_FLOAT: {
 			return DDS_R32F;
 		}
-		case DXGI_R8_UNORM:
+		case DXGI_R8_UNORM: {
+			return DDS_R8;
+		}
 		case DXGI_A8_UNORM: {
 			return DDS_LUMINANCE;
 		}
@@ -89,7 +91,7 @@ DDSFormat _dxgi_to_dds_format(uint32_t p_dxgi_format) {
 			return DDS_R16I;
 		}
 		case DXGI_R8G8_UNORM: {
-			return DDS_LUMINANCE_ALPHA;
+			return DDS_RG8;
 		}
 		case DXGI_R9G9B9E5: {
 			return DDS_RGB9E5;
@@ -648,6 +650,10 @@ static Vector<Ref<Image>> _dds_load_images_from_buffer(Ref<FileAccess> p_f, DDSF
 				r_dds_format = DDS_BGRX8;
 			} else if (format_rgb_bits == 32 && format_red_mask == 0xff && format_green_mask == 0xff00 && format_blue_mask == 0xff0000) {
 				r_dds_format = DDS_RGBX8;
+			} else if (format_rgb_bits == 8 && format_red_mask == 0xff && format_green_mask == 0 && format_blue_mask == 0) {
+				r_dds_format = DDS_R8;
+			} else if (format_rgb_bits == 16 && format_red_mask == 0xff && format_green_mask == 0xff00 && format_blue_mask == 0) {
+				r_dds_format = DDS_RG8;
 			}
 		}
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/14231 by adding support for importing R8 and R8G8 DDS textures. I've implemented the conservative approach outlined in the proposal so when a non-FourCC DDS texture is imported it must either be in R8 or R8G8 (G8B8 or B8R8 will not work).

I've tested this by importing both non-FourCC style DDS textures (RGB Bits), and by importing DX10 style DDS headers which use DXGI Enums.

Let me know your thoughts on whether the conservative or greedy approach outline in the proposal should be used here for non-FourCC textures.