### PR TITLE
Wayland: Re-enable window restore logic

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6307,11 +6307,21 @@ void EditorNode::_save_window_settings_to_config(Ref<ConfigFile> p_layout, const
 	if (w) {
 		p_layout->set_value(p_section, "screen", w->get_current_screen());
 
+		Size2i win_size = w->get_size();
+
+		if (DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_SELF_FITTING_WINDOWS)) {
+			// Work around logical size issues with HiDPI on Wayland. See GH-110643.
+			float win_scale = DisplayServer::get_singleton()->window_get_scale(w->get_window_id());
+
+			win_size.width /= win_scale;
+			win_size.height /= win_scale;
+		}
+
 		Window::Mode mode = w->get_mode();
 		switch (mode) {
 			case Window::MODE_WINDOWED:
 				p_layout->set_value(p_section, "mode", "windowed");
-				p_layout->set_value(p_section, "size", w->get_size());
+				p_layout->set_value(p_section, "size", win_size);
 				break;
 			case Window::MODE_FULLSCREEN:
 			case Window::MODE_EXCLUSIVE_FULLSCREEN:

--- a/editor/gui/window_wrapper.cpp
+++ b/editor/gui/window_wrapper.cpp
@@ -239,11 +239,6 @@ void WindowWrapper::restore_window_from_saved_position(const Rect2 p_window_rect
 	int screen = p_screen;
 	Rect2 restored_screen_rect = p_screen_rect;
 
-	if (DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_SELF_FITTING_WINDOWS)) {
-		window_rect = Rect2i();
-		restored_screen_rect = Rect2i();
-	}
-
 	if (screen < 0 || screen >= DisplayServer::get_singleton()->get_screen_count()) {
 		// Fallback to the main window screen if the saved screen is not available.
 		screen = get_window()->get_window_id();


### PR DESCRIPTION
Depends on #116236.
Related to #115369.

It was disabled due to issues with HiDPI but it looks like we can work around it by using the window scale.