### PR TITLE
Revert changes made in #114082

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1205,12 +1205,9 @@ void DisplayServerWayland::window_set_size(const Size2i p_size, DisplayServer::W
 	ERR_FAIL_COND(!windows.has(p_window_id));
 	WindowData &wd = windows[p_window_id];
 
-	Size2i new_size = p_size;
-	if (wd.visible) {
-		new_size = wayland_thread.window_set_size(p_window_id, p_size);
+	if (wd.rect_changed_callback.is_valid()) {
+		wd.rect_changed_callback.call(wd.rect);
 	}
-
-	_update_window_rect(Rect2i(wd.rect.position, new_size), p_window_id);
 }
 
 Size2i DisplayServerWayland::window_get_size(DisplayServer::WindowID p_window_id) const {


### PR DESCRIPTION
The changes made in #114082 in `display_server_wayland.cpp` caused dialog windows to shrink when closing and reopening them repeatedly (see #116304).
I reverted them, which fixed the issue.

Perhaps @deralmas could help with finding the actual error that caused this?

Feedback is appreciated.