### PR TITLE
Capture XR to Texture for grabbing full eye seamlessly using compositor

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -520,4 +520,45 @@ void RasterizerGLES3::set_boot_image_with_stretch(const Ref<Image> &p_image, con
 	texture_storage->texture_free(texture);
 }
 
+void RasterizerGLES3::blit_to_texture(RID p_src_texture, RID p_dst_texture, uint32_t p_src_layer, bool p_linear_to_srgb) {
+	GLES3::TextureStorage *ts = GLES3::TextureStorage::get_singleton();
+
+	GLES3::Texture *src = ts->get_texture(p_src_texture);
+	GLES3::Texture *dst = ts->get_texture(p_dst_texture);
+	ERR_FAIL_NULL(src);
+	ERR_FAIL_NULL(dst);
+
+	// Build a transient FBO targeting the destination texture.
+	GLuint fbo = 0;
+	glGenFramebuffers(1, &fbo);
+	glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, dst->tex_id, 0);
+	ERR_FAIL_COND_MSG(glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE,
+			"blit_to_texture: destination framebuffer incomplete.");
+
+	glViewport(0, 0, dst->width, dst->height);
+	glDisable(GL_CULL_FACE);
+	glDisable(GL_BLEND);
+	glDepthMask(GL_FALSE);
+
+	// Bind the source texture and blit via copy_effects.
+	glActiveTexture(GL_TEXTURE0);
+	GLenum target = (src->type == GLES3::Texture::TYPE_LAYERED) ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
+	glBindTexture(target, src->tex_id);
+
+	Rect2 full_rect(0.0f, 0.0f, 1.0f, 1.0f);
+
+	if (src->type == GLES3::Texture::TYPE_LAYERED) {
+		copy_effects->copy_to_rect_3d(full_rect, p_src_layer, src->type, 0.0f, p_linear_to_srgb);
+	} else {
+		copy_effects->copy_to_rect(full_rect, p_linear_to_srgb);
+	}
+
+	glBindTexture(target, 0);
+
+	// Restore default FBO and clean up.
+	glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
+	glDeleteFramebuffers(1, &fbo);
+}
+
 #endif // GLES3_ENABLED

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -100,6 +100,7 @@ public:
 	void begin_frame(double frame_step);
 
 	void blit_render_targets_to_screen(DisplayServerEnums::WindowID p_screen, const RenderingServerTypes::BlitToScreen *p_render_targets, int p_amount);
+	void blit_to_texture(RID p_src_texture, RID p_dst_texture, uint32_t p_src_layer = 0, bool p_linear_to_srgb = false);
 
 	bool is_opengl() { return true; }
 	void gl_end_frame(bool p_swap_buffers);

--- a/modules/openxr/doc_classes/OpenXRInterface.xml
+++ b/modules/openxr/doc_classes/OpenXRInterface.xml
@@ -11,6 +11,48 @@
 		<link title="Setting up XR">$DOCS_URL/tutorials/xr/setting_up_xr.html</link>
 	</tutorials>
 	<methods>
+		<method name="capture_frame">
+			<return type="void" />
+			<param index="0" name="rd_texture" type="RID" />
+			<param index="1" name="convert_to_srgb" type="bool" />
+			<description>
+				Asynchronously requests a single-frame capture of the left eye from the XR swapchain.
+				The provided [param rd_texture] must be a valid [RenderingDevice] texture created by the caller with [constant RenderingDevice.TEXTURE_USAGE_COLOR_ATTACHMENT_BIT] and [constant RenderingDevice.TEXTURE_USAGE_CAN_COPY_FROM_BIT], and must match the dimensions returned by [method XRInterface.get_render_target_size]. The capture is performed via an internal blit during [code]XRInterface post_draw_viewport[/code], before the swapchain image is released back to the OpenXR runtime. Once the blit is complete, [signal frame_captured] is emitted on the next [code]XRInterface::process[/code] tick. Only one capture may be in flight at a time. Calling this again before [signal frame_captured] is emitted will overwrite the pending request.
+				[b]Note:[/b] The caller owns [param rd_texture] and is responsible for freeing it when no longer needed.
+				[codeblock]
+				var xr: OpenXRInterface
+				var capture_tex: RID
+
+				func _ready():
+				    xr = XRServer.find_interface("OpenXR") as OpenXRInterface
+				    xr.frame_captured.connect(_on_frame_captured)
+
+				func take_screenshot():
+				    var rd := RenderingServer.get_rendering_device()
+				    var size := xr.get_render_target_size()
+				    var fmt := RDTextureFormat.new()
+				    fmt.width = int(size.x)
+				    fmt.height = int(size.y)
+				    fmt.format = RenderingDevice.DATA_FORMAT_R8G8B8A8_SRGB
+				    fmt.usage_bits = (
+				            RenderingDevice.TEXTURE_USAGE_COLOR_ATTACHMENT_BIT
+				            | RenderingDevice.TEXTURE_USAGE_CAN_COPY_FROM_BIT
+				        )
+				    capture_tex = rd.texture_create(fmt, RDTextureView.new())
+				    xr.capture_frame(capture_tex)
+
+				func _on_frame_captured(rd_texture: RID):
+				    var rd := RenderingServer.get_rendering_device()
+				    var data := rd.texture_get_data(rd_texture, 0)
+				    var size := xr.get_render_target_size()
+				    var img := Image.create_from_data(
+				            int(size.x), int(size.y), false,
+				            Image.FORMAT_RGBA8, data)
+				    img.save_jpg("user://screenshot.jpg")
+				    rd.free_rid(capture_tex)
+				[/codeblock]
+			</description>
+		</method>
 		<method name="get_action_sets" qualifiers="const">
 			<return type="Array" />
 			<description>
@@ -202,6 +244,13 @@
 			<param index="2" name="to_level" type="int" />
 			<description>
 				Informs the device CPU performance level has changed in the specified subdomain.
+			</description>
+		</signal>
+		<signal name="frame_captured">
+			<param index="0" name="rd_texture" type="RID" />
+			<description>
+				Emitted on the main thread during method XRInterface process after a frame capture requested via [method capture_frame] has completed. The [param rd_texture] is the same [RenderingDevice] texture RID that was passed to [method capture_frame], now containing the rendered left eye image.
+				Use [method RenderingDevice.texture_get_data] or [method RenderingDevice.texture_get_data_async] to read the pixel data. The caller remains responsible for freeing [param rd_texture] when done.
 			</description>
 		</signal>
 		<signal name="gpu_level_changed">

--- a/modules/openxr/doc_classes/OpenXRInterface.xml
+++ b/modules/openxr/doc_classes/OpenXRInterface.xml
@@ -24,7 +24,7 @@
 				var capture_tex: RID
 
 				func _ready():
-				    xr = XRServer.find_interface("OpenXR") as OpenXRInterface
+					xr = XRServer.find_interface("OpenXR") as OpenXRInterface
 				    xr.frame_captured.connect(_on_frame_captured)
 
 				func take_screenshot():

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -41,6 +41,7 @@
 #include "core/io/resource_saver.h"
 #include "core/object/class_db.h"
 #include "servers/display/display_server.h"
+#include "servers/rendering/renderer_compositor.h"
 #include "servers/rendering/rendering_server_types.h"
 
 #include <openxr/openxr.h>
@@ -56,6 +57,7 @@ void OpenXRInterface::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("instance_exiting"));
 	ADD_SIGNAL(MethodInfo("pose_recentered"));
 	ADD_SIGNAL(MethodInfo("refresh_rate_changed", PropertyInfo(Variant::FLOAT, "refresh_rate")));
+	ADD_SIGNAL(MethodInfo("frame_captured", PropertyInfo(Variant::RID, "rd_texture")));
 
 	ADD_SIGNAL(MethodInfo("cpu_level_changed", PropertyInfo(Variant::INT, "sub_domain"), PropertyInfo(Variant::INT, "from_level"), PropertyInfo(Variant::INT, "to_level")));
 	ADD_SIGNAL(MethodInfo("gpu_level_changed", PropertyInfo(Variant::INT, "sub_domain"), PropertyInfo(Variant::INT, "from_level"), PropertyInfo(Variant::INT, "to_level")));
@@ -120,6 +122,9 @@ void OpenXRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_hand_tracking_supported"), &OpenXRInterface::is_hand_tracking_supported);
 	ClassDB::bind_method(D_METHOD("is_hand_interaction_supported"), &OpenXRInterface::is_hand_interaction_supported);
 	ClassDB::bind_method(D_METHOD("is_eye_gaze_interaction_supported"), &OpenXRInterface::is_eye_gaze_interaction_supported);
+
+	// Frame Capture
+	ClassDB::bind_method(D_METHOD("capture_frame", "rd_texture", "convert_to_srgb"), &OpenXRInterface::capture_frame);
 
 	// VRS
 	ClassDB::bind_method(D_METHOD("get_vrs_min_radius"), &OpenXRInterface::get_vrs_min_radius);
@@ -1255,6 +1260,11 @@ void OpenXRInterface::process() {
 		head->set_pose("default", head_transform, head_linear_velocity, head_angular_velocity, head_confidence);
 	}
 
+	if (capture_complete) {
+		capture_complete = false;
+		emit_signal(SNAME("frame_captured"), capture_rd_texture);
+	}
+
 	if (reference_stage_changing) {
 		// Now that we have updated tracking information in our updated reference space, trigger our pose recentered signal.
 		emit_signal(SNAME("pose_recentered"));
@@ -1308,6 +1318,19 @@ Vector<RenderingServerTypes::BlitToScreen> OpenXRInterface::post_draw_viewport(R
 	}
 #endif
 
+	if (capture_next_frame) {
+		capture_next_frame = false;
+
+		RID color = get_color_texture();
+		if (color.is_valid() && capture_rd_texture.is_valid()) {
+			RendererCompositor *compositor = RendererCompositor::get_singleton();
+			if (compositor) {
+				compositor->blit_to_texture(color, capture_rd_texture, /*layer*/ 0, capture_convert_to_srgb);
+				capture_complete = true;
+			}
+		}
+	}
+
 	if (openxr_api) {
 		openxr_api->post_draw_viewport(p_render_target);
 	}
@@ -1319,6 +1342,14 @@ void OpenXRInterface::end_frame() {
 	if (openxr_api) {
 		openxr_api->end_frame();
 	}
+}
+
+void OpenXRInterface::capture_frame(RID p_rd_texture, bool p_convert_to_srgb) {
+	ERR_FAIL_NULL_MSG(openxr_api, "OpenXR not initialized.");
+	ERR_FAIL_COND_MSG(!p_rd_texture.is_valid(), "Invalid RD texture RID supplied.");
+	capture_rd_texture = p_rd_texture;
+	capture_next_frame = true;
+	capture_convert_to_srgb = p_convert_to_srgb;
 }
 
 bool OpenXRInterface::is_passthrough_supported() {

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -80,6 +80,12 @@ private:
 	XRPose::TrackingConfidence head_confidence;
 	Transform3D transform_for_view[2]; // We currently assume 2, but could be 4 for VARJO which we do not support yet
 
+	// Capture next frame
+	bool capture_next_frame = false;
+	bool capture_complete = false;
+	bool capture_convert_to_srgb = false;
+	RID capture_rd_texture; // Caller-owned RD texture that receives the blit
+
 	XRVRS xr_vrs;
 
 	void _load_action_map();
@@ -154,6 +160,8 @@ public:
 	float get_display_refresh_rate() const;
 	void set_display_refresh_rate(float p_refresh_rate);
 	Array get_available_display_refresh_rates() const;
+
+	void capture_frame(RID p_rd_texture, bool p_convert_to_srgb);
 
 	bool is_action_set_active(const String &p_action_set) const;
 	void set_action_set_active(const String &p_action_set, bool p_active);

--- a/servers/rendering/dummy/rasterizer_dummy.h
+++ b/servers/rendering/dummy/rasterizer_dummy.h
@@ -89,6 +89,7 @@ public:
 	}
 
 	void blit_render_targets_to_screen(int p_screen, const RenderingServerTypes::BlitToScreen *p_render_targets, int p_amount) override {}
+	void blit_to_texture(RID p_src_texture, RID p_dst_texture, uint32_t p_src_layer, bool p_linear_to_srgb) override {}
 
 	bool is_opengl() override { return false; }
 	void gl_end_frame(bool p_swap_buffers) override {}

--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -80,6 +80,7 @@ public:
 	virtual void begin_frame(double frame_step) = 0;
 
 	virtual void blit_render_targets_to_screen(DisplayServerEnums::WindowID p_screen, const RenderingServerTypes::BlitToScreen *p_render_targets, int p_amount) = 0;
+	virtual void blit_to_texture(RID p_src_texture, RID p_dst_texture, uint32_t p_src_layer = 0, bool p_linear_to_srgb = false) = 0;
 
 	virtual bool is_opengl() = 0;
 	virtual void gl_end_frame(bool p_swap_buffers) = 0;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -120,6 +120,69 @@ void RendererCompositorRD::blit_render_targets_to_screen(DisplayServerEnums::Win
 	RD::get_singleton()->draw_list_end();
 }
 
+void RendererCompositorRD::blit_to_texture(RID p_src_texture, RID p_dst_texture, uint32_t p_src_layer, bool p_linear_to_srgb) {
+	ERR_FAIL_COND(p_src_texture.is_null());
+	ERR_FAIL_COND(p_dst_texture.is_null());
+
+	RenderingDevice *rd = RD::get_singleton();
+
+	// Build a transient framebuffer around the destination texture.
+	Vector<RID> fb_textures;
+	fb_textures.push_back(p_dst_texture);
+	RID framebuffer = rd->framebuffer_create(fb_textures);
+	ERR_FAIL_COND(framebuffer.is_null());
+
+	// Lazy-create pipeline for this framebuffer format.
+	RD::FramebufferFormatID fb_format = rd->framebuffer_get_format(framebuffer);
+	BlitPipelines blit_pipelines = _get_blit_pipelines_for_format(fb_format);
+
+	// Uniform set — source texture sampled via the blit shader.
+	Vector<RD::Uniform> uniforms;
+	RD::Uniform u;
+	u.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+	u.binding = 0;
+	u.append_id(blit.sampler);
+	u.append_id(p_src_texture);
+	uniforms.push_back(u);
+	RID uniform_set = rd->uniform_set_create(uniforms,
+			blit.shader.version_get_shader(blit.shader_version, BLIT_MODE_USE_LAYER), 0);
+
+	if (uniform_set.is_null()) {
+		rd->free_rid(framebuffer);
+		ERR_FAIL_MSG("Failed to create uniform set for blit_to_texture.");
+	}
+
+	// Draw.
+	RD::DrawListID draw_list = rd->draw_list_begin(framebuffer);
+	if (draw_list == RD::INVALID_ID) {
+		rd->free_rid(uniform_set);
+		rd->free_rid(framebuffer);
+		ERR_FAIL_MSG("Failed to begin draw list for blit_to_texture.");
+	}
+
+	rd->draw_list_bind_render_pipeline(draw_list, blit_pipelines.pipelines[BLIT_MODE_USE_LAYER]);
+	rd->draw_list_bind_index_array(draw_list, blit.array);
+	rd->draw_list_bind_uniform_set(draw_list, uniform_set, 0);
+
+	BlitPushConstant push = {};
+	push.src_rect[2] = 1.0f;
+	push.src_rect[3] = 1.0f;
+	push.dst_rect[2] = 1.0f;
+	push.dst_rect[3] = 1.0f;
+	push.rotation_cos = 1.0f;
+	push.source_is_srgb = p_linear_to_srgb ? 1u : 0u;
+	push.layer = p_src_layer;
+	push.reference_multiplier = 1.0f;
+	push.output_max_value = 1.0f;
+
+	rd->draw_list_set_push_constant(draw_list, &push, sizeof(BlitPushConstant));
+	rd->draw_list_draw(draw_list, true);
+	rd->draw_list_end();
+
+	rd->free_rid(uniform_set);
+	rd->free_rid(framebuffer);
+}
+
 void RendererCompositorRD::begin_frame(double frame_step) {
 	frame++;
 	delta = frame_step;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -137,6 +137,7 @@ public:
 	virtual void initialize() override;
 	virtual void begin_frame(double frame_step) override;
 	virtual void blit_render_targets_to_screen(DisplayServerEnums::WindowID p_screen, const RenderingServerTypes::BlitToScreen *p_render_targets, int p_amount) override;
+	virtual void blit_to_texture(RID p_src_texture, RID p_dst_texture, uint32_t p_src_layer = 0, bool p_linear_to_srgb = false) override;
 
 	virtual bool is_opengl() override { return false; }
 	virtual void gl_end_frame(bool p_swap_buffers) override {}


### PR DESCRIPTION
As discussed in the XR channel, we had issues on our version of the engine capturing the viewport. This was required for a feedback system in Augmental Puzzles.
Our requirements were:

Capture the full eye
Minimal overhead
Avoid any frame hitch on XR

We implemented this purely as a Vulkan capture similar to how the screen blit is done, though in this PR I have expanded it to include GLES so I could move it into the base compositor. I have not tested the GLES side as I'm less familiar with that part of the code, so it could definitely use a review by someone more familiar with that side.
I've sketched out rough docs and a demo.

Demo project using the feature:
[blit-capture-demo.zip](https://github.com/user-attachments/files/25325395/blit-capture-demo.zip)

AI Disclosure: Claude Opus was used to review this code and help me with the GLES conversion (as I'm less familiar with Godot's GLES implementation), though I have reviewed all the code and there is no direct slop in here. I also used it to write a first draft and spell-check my edits on the docs.