### PR TITLE
Circumvent `Projection`'s getters inconsistencies with GPU transformed matrices

### DIFF
--- a/doc/classes/RenderSceneData.xml
+++ b/doc/classes/RenderSceneData.xml
@@ -10,10 +10,16 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_cam_projection" qualifiers="const">
+		<method name="get_aspect" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the X:Y aspect ratio of camera projection used to render this frame.
+			</description>
+		</method>
+		<method name="get_cam_projection" qualifiers="const" deprecated="Use [method RenderSceneData.get_transformed_projection_data] instead.">
 			<return type="Projection" />
 			<description>
-				Returns the camera projection used to render this frame.
+				Returns the camera projection used to render this frame. This is a transformed projection and is only suitable for copying to the GPU.
 				[b]Note:[/b] If more than one view is rendered, this will return a combined projection.
 			</description>
 		</method>
@@ -22,6 +28,29 @@
 			<description>
 				Returns the camera transform used to render this frame.
 				[b]Note:[/b] If more than one view is rendered, this will return a centered transform.
+			</description>
+		</method>
+		<method name="get_far_plane_half_extents" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the dimensions of the far clipping plane of the projection used to render this frame, divided by two.
+				[b]Note:[/b] If more than one view is rendered, this will return centered dimensions.
+			</description>
+		</method>
+		<method name="get_pixels_per_meter" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="for_pixel_width" type="int" />
+			<description>
+				Returns [param for_pixel_width] divided by the viewport's width measured in meters on the near plane, after this view's projection is applied.
+				[b]Note:[/b] If more than one view is rendered, this will return centered dimensions.
+			</description>
+		</method>
+		<method name="get_transformed_projection_data" qualifiers="const">
+			<return type="PackedFloat32Array" />
+			<description>
+				Returns the camera projection data used to render this frame. This is transformed projection data and is only suitable for copying to the GPU.
+				To access the near and far distances, use [method get_z_near] and [method get_z_far].
+				[b]Note:[/b] If more than one view is rendered, this will return combined projection data.
 			</description>
 		</method>
 		<method name="get_uniform_buffer" qualifiers="const">
@@ -49,6 +78,27 @@
 			<description>
 				Returns the view projection per view used to render this frame.
 				[b]Note:[/b] If a single view is rendered, this returns the camera projection. If more than one view is rendered, this will return a projection for the given view including the eye offset.
+			</description>
+		</method>
+		<method name="get_viewport_half_extents" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the dimensions of the viewport plane used to render this frame, divided by two.
+				[b]Note:[/b] If more than one view is rendered, this will return centered dimensions.
+			</description>
+		</method>
+		<method name="get_z_far" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the distance beyond which positions are clipped, used to render this frame.
+				[b]Note:[/b] If more than one view is rendered, this will return combined distance.
+			</description>
+		</method>
+		<method name="get_z_near" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the distance before which positions are clipped, used to render this frame.
+				[b]Note:[/b] If more than one view is rendered, this will return combined distance.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RenderSceneDataExtension.xml
+++ b/doc/classes/RenderSceneDataExtension.xml
@@ -9,7 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_get_cam_projection" qualifiers="virtual const">
+		<method name="_get_aspect" qualifiers="virtual const">
+			<return type="float" />
+			<description>
+				Implement this in GDExtension to return the X:Y aspect ratio of camera projection used to render this frame.
+			</description>
+		</method>
+		<method name="_get_cam_projection" qualifiers="virtual const" deprecated="Use [method RenderSceneDataExtension._get_transformed_projection_data] instead.">
 			<return type="Projection" />
 			<description>
 				Implement this in GDExtension to return the camera [Projection].
@@ -19,6 +25,25 @@
 			<return type="Transform3D" />
 			<description>
 				Implement this in GDExtension to return the camera [Transform3D].
+			</description>
+		</method>
+		<method name="_get_far_plane_half_extents" qualifiers="virtual const">
+			<return type="Vector2" />
+			<description>
+				Implement this in GDExtension to return the dimensions of the far clipping plane of the projection used to render this frame, divided by two.
+			</description>
+		</method>
+		<method name="_get_pixels_per_meter" qualifiers="virtual const">
+			<return type="int" />
+			<param index="0" name="for_pixel_width" type="int" />
+			<description>
+				Implement this in GDExtension to return [param for_pixel_width] divided by the viewport's width measured in meters on the near plane, after this view's projection is applied.
+			</description>
+		</method>
+		<method name="_get_transformed_projection_data" qualifiers="virtual const">
+			<return type="PackedFloat32Array" />
+			<description>
+				Implement this in GDExtension to return the camera transformed projection data.
 			</description>
 		</method>
 		<method name="_get_uniform_buffer" qualifiers="virtual const">
@@ -45,6 +70,24 @@
 			<param index="0" name="view" type="int" />
 			<description>
 				Implement this in GDExtension to return the view [Projection] for the given [param view].
+			</description>
+		</method>
+		<method name="_get_viewport_half_extents" qualifiers="virtual const">
+			<return type="Vector2" />
+			<description>
+				Implement this in GDExtension to return the dimensions of the viewport plane used to render this frame, divided by two.
+			</description>
+		</method>
+		<method name="_get_z_far" qualifiers="virtual const">
+			<return type="float" />
+			<description>
+				Implement this in GDExtension to return the distance beyond which positions are clipped, used to render this frame.
+			</description>
+		</method>
+		<method name="_get_z_near" qualifiers="virtual const">
+			<return type="float" />
+			<description>
+				Implement this in GDExtension to return the distance before which positions are clipped, used to render this frame.
 			</description>
 		</method>
 	</methods>

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "render_scene_data_rd.h"
+#include "core/error/error_macros.h"
 #include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
 #include "servers/rendering/renderer_rd/storage_rd/light_storage.h"
 #include "servers/rendering/renderer_rd/storage_rd/texture_storage.h"
@@ -38,11 +39,53 @@ Transform3D RenderSceneDataRD::get_cam_transform() const {
 }
 
 Projection RenderSceneDataRD::get_cam_projection() const {
+	WARN_DEPRECATED_MSG(R"*(RenderSceneDataRD::get_cam_projection() is deprecated. Use RenderSceneDataRD::get_transformed_projection_data() instead.)*");
+	WARN_PRINT_ONCE(R"*(RenderSceneDataRD.get_cam_projection() returns a transformed projection and is only suitable for copying to the GPU.)*");
 	Projection correction;
 	correction.set_depth_correction(flip_y);
 	correction.add_jitter_offset(taa_jitter);
 
 	return correction * cam_projection;
+}
+
+PackedFloat32Array RenderSceneDataRD::get_transformed_projection_data() const {
+	Projection correction;
+	correction.set_depth_correction(flip_y);
+	correction.add_jitter_offset(taa_jitter);
+	Projection corrected = correction * cam_projection;
+
+	PackedFloat32Array ret;
+	ret.reserve_exact(16);
+	for (int col = 0; col < 4; col++) {
+		for (int row = 0; row < 4; row++) {
+			ret.append(static_cast<float>(corrected[col][row]));
+		}
+	}
+	return ret;
+}
+
+float RenderSceneDataRD::get_z_far() const {
+	return z_far;
+}
+
+float RenderSceneDataRD::get_z_near() const {
+	return z_near;
+}
+
+float RenderSceneDataRD::get_aspect() const {
+	return cam_projection.get_aspect();
+}
+
+Vector2 RenderSceneDataRD::get_viewport_half_extents() const {
+	return cam_projection.get_viewport_half_extents();
+}
+
+Vector2 RenderSceneDataRD::get_far_plane_half_extents() const {
+	return cam_projection.get_far_plane_half_extents();
+}
+
+int RenderSceneDataRD::get_pixels_per_meter(int p_for_pixel_width) const {
+	return cam_projection.get_pixels_per_meter(p_for_pixel_width);
 }
 
 uint32_t RenderSceneDataRD::get_view_count() const {

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
@@ -40,11 +40,53 @@ Transform3D RenderSceneDataRD::get_cam_transform() const {
 }
 
 Projection RenderSceneDataRD::get_cam_projection() const {
+	WARN_DEPRECATED_MSG(R"*(RenderSceneDataRD::get_cam_projection() is deprecated. Use RenderSceneDataRD::get_transformed_projection_data() instead.)*");
+	WARN_PRINT_ONCE(R"*(RenderSceneDataRD.get_cam_projection() returns a transformed projection and is only suitable for copying to the GPU.)*");
 	Projection correction;
 	correction.set_depth_correction(flip_y);
 	correction.add_jitter_offset(taa_jitter);
 
 	return correction * cam_projection;
+}
+
+PackedFloat32Array RenderSceneDataRD::get_transformed_projection_data() const {
+	Projection correction;
+	correction.set_depth_correction(flip_y);
+	correction.add_jitter_offset(taa_jitter);
+	Projection corrected = correction * cam_projection;
+
+	PackedFloat32Array ret;
+	ret.reserve_exact(16);
+	for (int col = 0; col < 4; col++) {
+		for (int row = 0; row < 4; row++) {
+			ret.append(static_cast<float>(corrected[col][row]));
+		}
+	}
+	return ret;
+}
+
+float RenderSceneDataRD::get_z_far() const {
+	return z_far;
+}
+
+float RenderSceneDataRD::get_z_near() const {
+	return z_near;
+}
+
+float RenderSceneDataRD::get_aspect() const {
+	return cam_projection.get_aspect();
+}
+
+Vector2 RenderSceneDataRD::get_viewport_half_extents() const {
+	return cam_projection.get_viewport_half_extents();
+}
+
+Vector2 RenderSceneDataRD::get_far_plane_half_extents() const {
+	return cam_projection.get_far_plane_half_extents();
+}
+
+int RenderSceneDataRD::get_pixels_per_meter(int p_for_pixel_width) const {
+	return cam_projection.get_pixels_per_meter(p_for_pixel_width);
 }
 
 uint32_t RenderSceneDataRD::get_view_count() const {

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
@@ -90,6 +90,15 @@ public:
 	virtual Transform3D get_cam_transform() const override;
 	virtual Projection get_cam_projection() const override;
 
+	virtual PackedFloat32Array get_transformed_projection_data() const override;
+
+	virtual float get_z_far() const override;
+	virtual float get_z_near() const override;
+	virtual float get_aspect() const override;
+	virtual Vector2 get_viewport_half_extents() const override;
+	virtual Vector2 get_far_plane_half_extents() const override;
+	virtual int get_pixels_per_meter(int p_for_pixel_width) const override;
+
 	virtual uint32_t get_view_count() const override;
 	virtual Vector3 get_view_eye_offset(uint32_t p_view) const override;
 	virtual Projection get_view_projection(uint32_t p_view) const override;

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
@@ -89,6 +89,15 @@ public:
 	virtual Transform3D get_cam_transform() const override;
 	virtual Projection get_cam_projection() const override;
 
+	virtual PackedFloat32Array get_transformed_projection_data() const override;
+
+	virtual float get_z_far() const override;
+	virtual float get_z_near() const override;
+	virtual float get_aspect() const override;
+	virtual Vector2 get_viewport_half_extents() const override;
+	virtual Vector2 get_far_plane_half_extents() const override;
+	virtual int get_pixels_per_meter(int p_for_pixel_width) const override;
+
 	virtual uint32_t get_view_count() const override;
 	virtual Vector3 get_view_eye_offset(uint32_t p_view) const override;
 	virtual Projection get_view_projection(uint32_t p_view) const override;

--- a/servers/rendering/storage/render_data_extension.cpp
+++ b/servers/rendering/storage/render_data_extension.cpp
@@ -68,6 +68,13 @@ void RenderSceneBuffersExtension::set_use_debanding(bool p_use_debanding) {
 void RenderSceneDataExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_cam_transform);
 	GDVIRTUAL_BIND(_get_cam_projection);
+	GDVIRTUAL_BIND(_get_transformed_projection_data);
+	GDVIRTUAL_BIND(_get_z_far);
+	GDVIRTUAL_BIND(_get_z_near);
+	GDVIRTUAL_BIND(_get_aspect);
+	GDVIRTUAL_BIND(_get_viewport_half_extents);
+	GDVIRTUAL_BIND(_get_far_plane_half_extents);
+	GDVIRTUAL_BIND(_get_pixels_per_meter, "for_pixel_width");
 	GDVIRTUAL_BIND(_get_view_count);
 	GDVIRTUAL_BIND(_get_view_eye_offset, "view");
 	GDVIRTUAL_BIND(_get_view_projection, "view");
@@ -82,8 +89,51 @@ Transform3D RenderSceneDataExtension::get_cam_transform() const {
 }
 
 Projection RenderSceneDataExtension::get_cam_projection() const {
+	WARN_DEPRECATED_MSG(R"*(RenderSceneDataExtension::get_cam_projection() is deprecated. Use RenderSceneDataExtension::get_transformed_projection_data() instead.)*");
 	Projection ret;
 	GDVIRTUAL_CALL(_get_cam_projection, ret);
+	return ret;
+}
+
+PackedFloat32Array RenderSceneDataExtension::get_transformed_projection_data() const {
+	PackedFloat32Array ret;
+	GDVIRTUAL_CALL(_get_transformed_projection_data, ret);
+	return ret;
+}
+
+float RenderSceneDataExtension::get_z_far() const {
+	float ret = 0;
+	GDVIRTUAL_CALL(_get_z_far, ret);
+	return ret;
+}
+
+float RenderSceneDataExtension::get_z_near() const {
+	float ret = 0;
+	GDVIRTUAL_CALL(_get_z_near, ret);
+	return ret;
+}
+
+float RenderSceneDataExtension::get_aspect() const {
+	float ret = 0;
+	GDVIRTUAL_CALL(_get_aspect, ret);
+	return ret;
+}
+
+Vector2 RenderSceneDataExtension::get_viewport_half_extents() const {
+	Vector2 ret;
+	GDVIRTUAL_CALL(_get_viewport_half_extents, ret);
+	return ret;
+}
+
+Vector2 RenderSceneDataExtension::get_far_plane_half_extents() const {
+	Vector2 ret;
+	GDVIRTUAL_CALL(_get_far_plane_half_extents, ret);
+	return ret;
+}
+
+int RenderSceneDataExtension::get_pixels_per_meter(int p_for_pixel_width) const {
+	int ret = 0;
+	GDVIRTUAL_CALL(_get_pixels_per_meter, p_for_pixel_width, ret);
 	return ret;
 }
 

--- a/servers/rendering/storage/render_data_extension.h
+++ b/servers/rendering/storage/render_data_extension.h
@@ -68,6 +68,15 @@ public:
 	virtual Transform3D get_cam_transform() const override;
 	virtual Projection get_cam_projection() const override;
 
+	virtual PackedFloat32Array get_transformed_projection_data() const override;
+
+	virtual float get_z_far() const override;
+	virtual float get_z_near() const override;
+	virtual float get_aspect() const override;
+	virtual Vector2 get_viewport_half_extents() const override;
+	virtual Vector2 get_far_plane_half_extents() const override;
+	virtual int get_pixels_per_meter(int p_for_pixel_width) const override;
+
 	virtual uint32_t get_view_count() const override;
 	virtual Vector3 get_view_eye_offset(uint32_t p_view) const override;
 	virtual Projection get_view_projection(uint32_t p_view) const override;
@@ -76,6 +85,15 @@ public:
 
 	GDVIRTUAL0RC(Transform3D, _get_cam_transform)
 	GDVIRTUAL0RC(Projection, _get_cam_projection)
+
+	GDVIRTUAL0RC(PackedFloat32Array, _get_transformed_projection_data)
+
+	GDVIRTUAL0RC(float, _get_z_far)
+	GDVIRTUAL0RC(float, _get_z_near)
+	GDVIRTUAL0RC(float, _get_aspect)
+	GDVIRTUAL0RC(Vector2, _get_viewport_half_extents)
+	GDVIRTUAL0RC(Vector2, _get_far_plane_half_extents)
+	GDVIRTUAL1RC(int, _get_pixels_per_meter, int)
 
 	GDVIRTUAL0RC(uint32_t, _get_view_count)
 	GDVIRTUAL1RC(Vector3, _get_view_eye_offset, uint32_t)

--- a/servers/rendering/storage/render_scene_data.cpp
+++ b/servers/rendering/storage/render_scene_data.cpp
@@ -34,6 +34,15 @@ void RenderSceneData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_cam_transform"), &RenderSceneData::get_cam_transform);
 	ClassDB::bind_method(D_METHOD("get_cam_projection"), &RenderSceneData::get_cam_projection);
 
+	ClassDB::bind_method(D_METHOD("get_transformed_projection_data"), &RenderSceneData::get_transformed_projection_data);
+
+	ClassDB::bind_method(D_METHOD("get_z_far"), &RenderSceneData::get_z_far);
+	ClassDB::bind_method(D_METHOD("get_z_near"), &RenderSceneData::get_z_near);
+	ClassDB::bind_method(D_METHOD("get_aspect"), &RenderSceneData::get_aspect);
+	ClassDB::bind_method(D_METHOD("get_viewport_half_extents"), &RenderSceneData::get_viewport_half_extents);
+	ClassDB::bind_method(D_METHOD("get_far_plane_half_extents"), &RenderSceneData::get_far_plane_half_extents);
+	ClassDB::bind_method(D_METHOD("get_pixels_per_meter", "for_pixel_width"), &RenderSceneData::get_pixels_per_meter);
+
 	ClassDB::bind_method(D_METHOD("get_view_count"), &RenderSceneData::get_view_count);
 	ClassDB::bind_method(D_METHOD("get_view_eye_offset", "view"), &RenderSceneData::get_view_eye_offset);
 	ClassDB::bind_method(D_METHOD("get_view_projection", "view"), &RenderSceneData::get_view_projection);
@@ -44,6 +53,13 @@ void RenderSceneData::_bind_methods() {
 void RenderSceneDataExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_cam_transform);
 	GDVIRTUAL_BIND(_get_cam_projection);
+	GDVIRTUAL_BIND(_get_transformed_projection_data);
+	GDVIRTUAL_BIND(_get_z_far);
+	GDVIRTUAL_BIND(_get_z_near);
+	GDVIRTUAL_BIND(_get_aspect);
+	GDVIRTUAL_BIND(_get_viewport_half_extents);
+	GDVIRTUAL_BIND(_get_far_plane_half_extents);
+	GDVIRTUAL_BIND(_get_pixels_per_meter, "for_pixel_width");
 	GDVIRTUAL_BIND(_get_view_count);
 	GDVIRTUAL_BIND(_get_view_eye_offset, "view");
 	GDVIRTUAL_BIND(_get_view_projection, "view");
@@ -58,8 +74,51 @@ Transform3D RenderSceneDataExtension::get_cam_transform() const {
 }
 
 Projection RenderSceneDataExtension::get_cam_projection() const {
+	WARN_DEPRECATED_MSG(R"*(RenderSceneDataExtension::get_cam_projection() is deprecated. Use RenderSceneDataExtension::get_transformed_projection_data() instead.)*");
 	Projection ret;
 	GDVIRTUAL_CALL(_get_cam_projection, ret);
+	return ret;
+}
+
+PackedFloat32Array RenderSceneDataExtension::get_transformed_projection_data() const {
+	PackedFloat32Array ret;
+	GDVIRTUAL_CALL(_get_transformed_projection_data, ret);
+	return ret;
+}
+
+float RenderSceneDataExtension::get_z_far() const {
+	float ret = 0;
+	GDVIRTUAL_CALL(_get_z_far, ret);
+	return ret;
+}
+
+float RenderSceneDataExtension::get_z_near() const {
+	float ret = 0;
+	GDVIRTUAL_CALL(_get_z_near, ret);
+	return ret;
+}
+
+float RenderSceneDataExtension::get_aspect() const {
+	float ret = 0;
+	GDVIRTUAL_CALL(_get_aspect, ret);
+	return ret;
+}
+
+Vector2 RenderSceneDataExtension::get_viewport_half_extents() const {
+	Vector2 ret;
+	GDVIRTUAL_CALL(_get_viewport_half_extents, ret);
+	return ret;
+}
+
+Vector2 RenderSceneDataExtension::get_far_plane_half_extents() const {
+	Vector2 ret;
+	GDVIRTUAL_CALL(_get_far_plane_half_extents, ret);
+	return ret;
+}
+
+int RenderSceneDataExtension::get_pixels_per_meter(int p_for_pixel_width) const {
+	int ret = 0;
+	GDVIRTUAL_CALL(_get_pixels_per_meter, p_for_pixel_width, ret);
 	return ret;
 }
 

--- a/servers/rendering/storage/render_scene_data.cpp
+++ b/servers/rendering/storage/render_scene_data.cpp
@@ -36,6 +36,15 @@ void RenderSceneData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_cam_transform"), &RenderSceneData::get_cam_transform);
 	ClassDB::bind_method(D_METHOD("get_cam_projection"), &RenderSceneData::get_cam_projection);
 
+	ClassDB::bind_method(D_METHOD("get_transformed_projection_data"), &RenderSceneData::get_transformed_projection_data);
+
+	ClassDB::bind_method(D_METHOD("get_z_far"), &RenderSceneData::get_z_far);
+	ClassDB::bind_method(D_METHOD("get_z_near"), &RenderSceneData::get_z_near);
+	ClassDB::bind_method(D_METHOD("get_aspect"), &RenderSceneData::get_aspect);
+	ClassDB::bind_method(D_METHOD("get_viewport_half_extents"), &RenderSceneData::get_viewport_half_extents);
+	ClassDB::bind_method(D_METHOD("get_far_plane_half_extents"), &RenderSceneData::get_far_plane_half_extents);
+	ClassDB::bind_method(D_METHOD("get_pixels_per_meter", "for_pixel_width"), &RenderSceneData::get_pixels_per_meter);
+
 	ClassDB::bind_method(D_METHOD("get_view_count"), &RenderSceneData::get_view_count);
 	ClassDB::bind_method(D_METHOD("get_view_eye_offset", "view"), &RenderSceneData::get_view_eye_offset);
 	ClassDB::bind_method(D_METHOD("get_view_projection", "view"), &RenderSceneData::get_view_projection);

--- a/servers/rendering/storage/render_scene_data.h
+++ b/servers/rendering/storage/render_scene_data.h
@@ -34,6 +34,7 @@
 #include "core/object/gdvirtual.gen.h"
 #include "core/object/object.h"
 #include "core/object/script_language.h"
+#include "core/variant/variant.h"
 
 class RenderSceneData : public Object {
 	GDCLASS(RenderSceneData, Object);
@@ -44,6 +45,15 @@ protected:
 public:
 	virtual Transform3D get_cam_transform() const = 0;
 	virtual Projection get_cam_projection() const = 0;
+
+	virtual PackedFloat32Array get_transformed_projection_data() const = 0;
+
+	virtual float get_z_far() const = 0;
+	virtual float get_z_near() const = 0;
+	virtual float get_aspect() const = 0;
+	virtual Vector2 get_viewport_half_extents() const = 0;
+	virtual Vector2 get_far_plane_half_extents() const = 0;
+	virtual int get_pixels_per_meter(int p_for_pixel_width) const = 0;
 
 	virtual uint32_t get_view_count() const = 0;
 	virtual Vector3 get_view_eye_offset(uint32_t p_view) const = 0;
@@ -62,6 +72,15 @@ public:
 	virtual Transform3D get_cam_transform() const override;
 	virtual Projection get_cam_projection() const override;
 
+	virtual PackedFloat32Array get_transformed_projection_data() const override;
+
+	virtual float get_z_far() const override;
+	virtual float get_z_near() const override;
+	virtual float get_aspect() const override;
+	virtual Vector2 get_viewport_half_extents() const override;
+	virtual Vector2 get_far_plane_half_extents() const override;
+	virtual int get_pixels_per_meter(int p_for_pixel_width) const override;
+
 	virtual uint32_t get_view_count() const override;
 	virtual Vector3 get_view_eye_offset(uint32_t p_view) const override;
 	virtual Projection get_view_projection(uint32_t p_view) const override;
@@ -70,6 +89,15 @@ public:
 
 	GDVIRTUAL0RC(Transform3D, _get_cam_transform)
 	GDVIRTUAL0RC(Projection, _get_cam_projection)
+
+	GDVIRTUAL0RC(PackedFloat32Array, _get_transformed_projection_data)
+
+	GDVIRTUAL0RC(float, _get_z_far)
+	GDVIRTUAL0RC(float, _get_z_near)
+	GDVIRTUAL0RC(float, _get_aspect)
+	GDVIRTUAL0RC(Vector2, _get_viewport_half_extents)
+	GDVIRTUAL0RC(Vector2, _get_far_plane_half_extents)
+	GDVIRTUAL1RC(int, _get_pixels_per_meter, int)
 
 	GDVIRTUAL0RC(uint32_t, _get_view_count)
 	GDVIRTUAL1RC(Vector3, _get_view_eye_offset, uint32_t)

--- a/servers/rendering/storage/render_scene_data.h
+++ b/servers/rendering/storage/render_scene_data.h
@@ -42,6 +42,15 @@ public:
 	virtual Transform3D get_cam_transform() const = 0;
 	virtual Projection get_cam_projection() const = 0;
 
+	virtual PackedFloat32Array get_transformed_projection_data() const = 0;
+
+	virtual float get_z_far() const = 0;
+	virtual float get_z_near() const = 0;
+	virtual float get_aspect() const = 0;
+	virtual Vector2 get_viewport_half_extents() const = 0;
+	virtual Vector2 get_far_plane_half_extents() const = 0;
+	virtual int get_pixels_per_meter(int p_for_pixel_width) const = 0;
+
 	virtual uint32_t get_view_count() const = 0;
 	virtual Vector3 get_view_eye_offset(uint32_t p_view) const = 0;
 	virtual Projection get_view_projection(uint32_t p_view) const = 0;


### PR DESCRIPTION
Circumvents inconsistent behavior of the `Projection`'s getters for z-near, z-far, aspect ratio, half-extents and pixel-per-meters, when called on GPU projection matrices, as per @clayjohn's suggestion in https://github.com/godotengine/godot/pull/108250#issuecomment-3037134957 :
> I am unhappy that we have exposed the transformed projection directly, we should have exposed it as an array of floats or something to make it clear that it is just for passing to the GPU.

- Add `RenderSceneData::get_transformed_projection_data()` that returns the transformed projection matrix as a `PackedFloat32Array` to avoid `Projection`'s getters be called directly.
- Add `RenderSceneData::get_z_near()`, `get_z_far()`, `get_aspect()`, `get_viewport_half_extents()`, `get_far_plane_half_extents()` and `get_pixels_per_meter()`. These getters either return member variables of `RenderSceneData` when available or wrap calls to the non-transformed `Projection` object.
- Deprecate `RenderSceneData::get_cam_projection()`. It could also be left as is and just issue a `WARN_PRINT_ONCE`. I'm leaving this open for discussion below.
- Update class documentation accordingly.

Closes #106312
Supersedes #108250
Supersedes #106314