### PR TITLE
Remove some unused Node methods

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2562,37 +2562,6 @@ String Node::get_tree_string() {
 	return _get_tree_string(this);
 }
 
-void Node::_propagate_reverse_notification(int p_notification) {
-	data.blocked++;
-
-	for (HashMap<StringName, Node *>::Iterator I = data.children.last(); I; --I) {
-		I->value->_propagate_reverse_notification(p_notification);
-	}
-
-	notification(p_notification, true);
-	data.blocked--;
-}
-
-void Node::_propagate_deferred_notification(int p_notification, bool p_reverse) {
-	ERR_FAIL_COND(!is_inside_tree());
-
-	data.blocked++;
-
-	if (!p_reverse) {
-		MessageQueue::get_singleton()->push_notification(this, p_notification);
-	}
-
-	for (KeyValue<StringName, Node *> &K : data.children) {
-		K.value->_propagate_deferred_notification(p_notification, p_reverse);
-	}
-
-	if (p_reverse) {
-		MessageQueue::get_singleton()->push_notification(this, p_notification);
-	}
-
-	data.blocked--;
-}
-
 void Node::propagate_notification(int p_notification) {
 	ERR_THREAD_GUARD
 	data.blocked++;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -304,8 +304,6 @@ private:
 	void _validate_child_name(Node *p_child, bool p_force_human_readable = false);
 	void _generate_serial_child_name(const Node *p_child, StringName &name) const;
 
-	void _propagate_reverse_notification(int p_notification);
-	void _propagate_deferred_notification(int p_notification, bool p_reverse);
 	void _propagate_enter_tree();
 	void _propagate_ready();
 	void _propagate_exit_tree();


### PR DESCRIPTION
Removes `_propagate_reverse_notification()` and `_propagate_deferred_notification()`. They aren't called anywhere.