### PR TITLE
Add pivot position to Control

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1194,6 +1194,9 @@
 			Has no effect unless [member offset_transform_enabled] is [code]true[/code].
 		</member>
 		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="2" />
+		<member name="pivot_global_position" type="Vector2" setter="set_pivot_global_position" getter="get_pivot_global_position">
+			The position of the control's pivot point in global coordinates. This is equivalent to [member global_position] + [method get_combined_pivot_offset]. Setting this property changes the [member global_position] so that the pivot point ends up at the specified location.
+		</member>
 		<member name="pivot_offset" type="Vector2" setter="set_pivot_offset" getter="get_pivot_offset" default="Vector2(0, 0)">
 			By default, the node's pivot is its top-left corner. When you change its [member rotation] or [member scale], it will rotate or scale around this pivot.
 			The actual offset is the combined value of this property and [member pivot_offset_ratio].
@@ -1201,6 +1204,9 @@
 		<member name="pivot_offset_ratio" type="Vector2" setter="set_pivot_offset_ratio" getter="get_pivot_offset_ratio" default="Vector2(0, 0)">
 			Same as [member pivot_offset], but expressed as uniform vector, where [code]Vector2(0, 0)[/code] is the top-left corner of this control, and [code]Vector2(1, 1)[/code] is its bottom-right corner. Set this property to [code]Vector2(0.5, 0.5)[/code] to pivot around this control's center.
 			The actual offset is the combined value of this property and [member pivot_offset].
+		</member>
+		<member name="pivot_position" type="Vector2" setter="set_pivot_position" getter="get_pivot_position">
+			The position of the control's pivot point in its local coordinate system. This is equivalent to [member position] + [method get_combined_pivot_offset]. Setting this property changes the [member position] so that the pivot point ends up at the specified location.
 		</member>
 		<member name="position" type="Vector2" setter="_set_position" getter="get_position" default="Vector2(0, 0)">
 			The node's position, relative to its containing node. It corresponds to the rectangle's top-left corner. The property is not affected by [member pivot_offset].

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1695,6 +1695,22 @@ Vector2 Control::get_combined_pivot_offset() const {
 	return data.pivot_offset + data.pivot_offset_ratio * get_size();
 }
 
+void Control::set_pivot_position(const Point2 &p_point) {
+	set_position(p_point - get_combined_pivot_offset());
+}
+
+Vector2 Control::get_pivot_position() const {
+	return get_combined_pivot_offset() + get_position();
+}
+
+void Control::set_pivot_global_position(const Point2 &p_point) {
+	set_global_position(p_point - get_combined_pivot_offset());
+}
+
+Vector2 Control::get_pivot_global_position() const {
+	return get_combined_pivot_offset() + get_global_position();
+}
+
 /// Sizes.
 
 void Control::set_propagate_maximum_size(bool p_propagate) {
@@ -4593,6 +4609,8 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_scale", "scale"), &Control::set_scale);
 	ClassDB::bind_method(D_METHOD("set_pivot_offset", "pivot_offset"), &Control::set_pivot_offset);
 	ClassDB::bind_method(D_METHOD("set_pivot_offset_ratio", "ratio"), &Control::set_pivot_offset_ratio);
+	ClassDB::bind_method(D_METHOD("set_pivot_position", "position"), &Control::set_pivot_position);
+	ClassDB::bind_method(D_METHOD("set_pivot_global_position", "position"), &Control::set_pivot_global_position);
 	ClassDB::bind_method(D_METHOD("get_begin"), &Control::get_begin);
 	ClassDB::bind_method(D_METHOD("get_end"), &Control::get_end);
 	ClassDB::bind_method(D_METHOD("get_position"), &Control::get_position);
@@ -4604,6 +4622,8 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_pivot_offset_ratio"), &Control::get_pivot_offset_ratio);
 	ClassDB::bind_method(D_METHOD("get_combined_pivot_offset"), &Control::get_combined_pivot_offset);
 	ClassDB::bind_method(D_METHOD("get_custom_maximum_size"), &Control::get_custom_maximum_size);
+	ClassDB::bind_method(D_METHOD("get_pivot_position"), &Control::get_pivot_position);
+	ClassDB::bind_method(D_METHOD("get_pivot_global_position"), &Control::get_pivot_global_position);
 	ClassDB::bind_method(D_METHOD("get_custom_minimum_size"), &Control::get_custom_minimum_size);
 	ClassDB::bind_method(D_METHOD("get_parent_area_size"), &Control::get_parent_area_size);
 	ClassDB::bind_method(D_METHOD("get_global_position"), &Control::get_global_position);
@@ -4855,6 +4875,8 @@ void Control::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "scale"), "set_scale", "get_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "pivot_offset", PROPERTY_HINT_NONE, "suffix:px"), "set_pivot_offset", "get_pivot_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "pivot_offset_ratio"), "set_pivot_offset_ratio", "get_pivot_offset_ratio");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "pivot_position", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_NONE), "set_pivot_position", "get_pivot_position");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "pivot_global_position", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_NONE), "set_pivot_global_position", "get_pivot_global_position");
 
 	ADD_SUBGROUP("Container Sizing", "size_flags_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "size_flags_horizontal", PROPERTY_HINT_FLAGS, "Fill:1,Expand:2,Shrink Center:4,Shrink End:8"), "set_h_size_flags", "get_h_size_flags");

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -597,6 +597,10 @@ public:
 	void set_pivot_offset(const Vector2 &p_pivot);
 	Vector2 get_pivot_offset() const;
 	Vector2 get_combined_pivot_offset() const;
+	void set_pivot_position(const Point2 &p_point);
+	Vector2 get_pivot_position() const;
+	void set_pivot_global_position(const Point2 &p_point);
+	Vector2 get_pivot_global_position() const;
 
 	void set_propagate_maximum_size(bool p_propagate);
 	bool is_propagating_maximum_size();


### PR DESCRIPTION
This PR adds 2 new properties to the `Control` nodes and resolves [14099](https://github.com/godotengine/godot-proposals/issues/14099) by allowing the pivot position to be set and retrieved directly rather than calculated manually.
```GDScript
Vector2 pivot_position
Vector2 pivot_global_position
```