### PR TITLE
Fix `Curve` point properties usage flags

### DIFF
--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -233,8 +233,9 @@ void Curve::_remove_point(int p_index, bool p_mark_dirty) {
 }
 
 void Curve::_set_point_position(int p_index, const Vector2 &p_position) {
-	set_point_value(p_index, p_position.x);
-	set_point_offset(p_index, p_position.y);
+	// Set the value first, setting the offset might change the index.
+	set_point_value(p_index, p_position.y);
+	set_point_offset(p_index, p_position.x);
 }
 
 void Curve::remove_point(int p_index) {
@@ -653,11 +654,11 @@ void Curve::_bind_methods() {
 	base_property_helper.set_prefix("point_");
 	base_property_helper.set_array_length_getter(&Curve::get_point_count);
 	base_property_helper.set_property_filter(&Curve::_filter_property);
-	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "position"), defaults.position, &Curve::_set_point_position, &Curve::get_point_position);
-	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, "left_tangent"), defaults.left_tangent, &Curve::set_point_left_tangent, &Curve::get_point_left_tangent);
-	base_property_helper.register_property(PropertyInfo(Variant::INT, "left_mode", PROPERTY_HINT_ENUM, mode_hint), defaults.left_mode, &Curve::set_point_left_mode, &Curve::get_point_left_mode);
-	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, "right_tangent"), defaults.right_tangent, &Curve::set_point_right_tangent, &Curve::get_point_right_tangent);
-	base_property_helper.register_property(PropertyInfo(Variant::INT, "right_mode", PROPERTY_HINT_ENUM, mode_hint), defaults.right_mode, &Curve::set_point_right_mode, &Curve::get_point_right_mode);
+	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.position, &Curve::_set_point_position, &Curve::get_point_position);
+	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, "left_tangent", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.left_tangent, &Curve::set_point_left_tangent, &Curve::get_point_left_tangent);
+	base_property_helper.register_property(PropertyInfo(Variant::INT, "left_mode", PROPERTY_HINT_ENUM, mode_hint, PROPERTY_USAGE_EDITOR), defaults.left_mode, &Curve::set_point_left_mode, &Curve::get_point_left_mode);
+	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, "right_tangent", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.right_tangent, &Curve::set_point_right_tangent, &Curve::get_point_right_tangent);
+	base_property_helper.register_property(PropertyInfo(Variant::INT, "right_mode", PROPERTY_HINT_ENUM, mode_hint, PROPERTY_USAGE_EDITOR), defaults.right_mode, &Curve::set_point_right_mode, &Curve::get_point_right_mode);
 	PropertyListHelper::register_base_helper(&base_property_helper);
 }
 
@@ -1337,9 +1338,9 @@ void Curve2D::_bind_methods() {
 	base_property_helper.set_prefix("point_");
 	base_property_helper.set_array_length_getter(&Curve2D::get_point_count);
 	base_property_helper.set_property_filter(&Curve2D::_filter_property);
-	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "position"), defaults.position, &Curve2D::set_point_position, &Curve2D::get_point_position);
-	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "in"), defaults.in, &Curve2D::set_point_in, &Curve2D::get_point_in);
-	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "out"), defaults.out, &Curve2D::set_point_out, &Curve2D::get_point_out);
+	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.position, &Curve2D::set_point_position, &Curve2D::get_point_position);
+	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "in", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.in, &Curve2D::set_point_in, &Curve2D::get_point_in);
+	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "out", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.out, &Curve2D::set_point_out, &Curve2D::get_point_out);
 	PropertyListHelper::register_base_helper(&base_property_helper);
 }
 
@@ -2380,10 +2381,10 @@ void Curve3D::_bind_methods() {
 	base_property_helper.set_prefix("point_");
 	base_property_helper.set_array_length_getter(&Curve3D::get_point_count);
 	base_property_helper.set_property_filter(&Curve3D::_filter_property);
-	base_property_helper.register_property(PropertyInfo(Variant::VECTOR3, "position"), defaults.position, &Curve3D::set_point_position, &Curve3D::get_point_position);
-	base_property_helper.register_property(PropertyInfo(Variant::VECTOR3, "in"), defaults.in, &Curve3D::set_point_in, &Curve3D::get_point_in);
-	base_property_helper.register_property(PropertyInfo(Variant::VECTOR3, "out"), defaults.out, &Curve3D::set_point_out, &Curve3D::get_point_out);
-	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, "tilt"), defaults.tilt, &Curve3D::set_point_tilt, &Curve3D::get_point_tilt);
+	base_property_helper.register_property(PropertyInfo(Variant::VECTOR3, "position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.position, &Curve3D::set_point_position, &Curve3D::get_point_position);
+	base_property_helper.register_property(PropertyInfo(Variant::VECTOR3, "in", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.in, &Curve3D::set_point_in, &Curve3D::get_point_in);
+	base_property_helper.register_property(PropertyInfo(Variant::VECTOR3, "out", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.out, &Curve3D::set_point_out, &Curve3D::get_point_out);
+	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, "tilt", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.tilt, &Curve3D::set_point_tilt, &Curve3D::get_point_tilt);
 	PropertyListHelper::register_base_helper(&base_property_helper);
 }
 


### PR DESCRIPTION
Fixes #116323.
Fixes #116442

Regression from #92282:

`Curve`/`Curve2D`/`Curve3D` per point properties were incorrectly changed to use default usage flags (including `PROPERTY_USAGE_STORAGE`). These should be editor-only, actual data is stored in a single `_data` property per curve.
Duplicated data in #116323 MRP:
```
[sub_resource type="Curve" id="Curve_tgo4v"]
resource_local_to_scene = true
_limits = [1.0, 8.0, 0.0, 1.0]
_data = [Vector2(0, 1.103612), 0.0, 0.0, 0, 0, Vector2(1, 8), 0.0, 0.0, 0, 0]
point_count = 2
point_0/position = Vector2(0, 1.103612)
point_1/position = Vector2(1, 8)
```

---

`Curve::_set_point_position` got `value`/`offset` values swapped. But in fact, before #92282 there was a bug in the `Curve::_set`, as when setting a point position it was setting the offset before the value for the same point index:
https://github.com/godotengine/godot/blob/f3466332fdca2d30aac244063542dadfa4fd1f2e/scene/resources/curve.cpp#L585-L588
but setting the offset for a point at given index might result in changing the index of the given point (as points are sorted by offsets). Correct is either:
```cpp
set_point_value(point_index, position.y);
set_point_offset(point_index, position.x);
```
or:
```cpp
int new_index = set_point_offset(point_index, position.x);
set_point_value(new_index, position.y);
```
