### PR TITLE
Optimize signal emission: reduce allocations and skip unnecessary one-shot scan

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1283,6 +1283,7 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 	Callable *slot_callables = (Callable *)slot_callable_stack;
 	uint32_t *slot_flags = slot_flags_stack;
 	uint32_t slot_count = 0;
+	bool has_one_shots = false;
 
 	{
 		OBJ_SIGNAL_LOCK
@@ -1298,9 +1299,15 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 			return ERR_UNAVAILABLE;
 		}
 
-		if (s->slot_map.size() > MAX_SLOTS_ON_STACK) {
-			slot_callables = (Callable *)memalloc(sizeof(Callable) * s->slot_map.size());
-			slot_flags = (uint32_t *)memalloc(sizeof(uint32_t) * s->slot_map.size());
+		const uint32_t slot_map_size = s->slot_map.size();
+
+		if (unlikely(slot_map_size == 0)) {
+			return ERR_UNAVAILABLE;
+		}
+
+		if (unlikely(slot_map_size > MAX_SLOTS_ON_STACK)) {
+			slot_callables = (Callable *)memalloc(sizeof(Callable) * slot_map_size);
+			slot_flags = (uint32_t *)memalloc(sizeof(uint32_t) * slot_map_size);
 		}
 
 		// Ensure that disconnecting the signal or even deleting the object
@@ -1308,22 +1315,27 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 		for (const KeyValue<Callable, SignalData::Slot> &slot_kv : s->slot_map) {
 			memnew_placement(&slot_callables[slot_count], Callable(slot_kv.value.conn.callable));
 			slot_flags[slot_count] = slot_kv.value.conn.flags;
+			has_one_shots |= (slot_flags[slot_count] & CONNECT_ONE_SHOT);
 			++slot_count;
 		}
 
-		DEV_ASSERT(slot_count == s->slot_map.size());
+		DEV_ASSERT(slot_count == slot_map_size);
 
-		// Disconnect all one-shot connections before emitting to prevent recursion.
-		for (uint32_t i = 0; i < slot_count; ++i) {
-			bool disconnect = slot_flags[i] & CONNECT_ONE_SHOT;
+		// Only scan for one-shot disconnections if any were flagged — avoids
+		// unnecessary iteration in the common case (no one-shots).
+		if (unlikely(has_one_shots)) {
+			// Disconnect all one-shot connections before emitting to prevent recursion.
+			for (uint32_t i = 0; i < slot_count; ++i) {
+				bool disconnect = slot_flags[i] & CONNECT_ONE_SHOT;
 #ifdef TOOLS_ENABLED
-			if (disconnect && (slot_flags[i] & CONNECT_PERSIST) && Engine::get_singleton()->is_editor_hint()) {
-				// This signal was connected from the editor, and is being edited. Just don't disconnect for now.
-				disconnect = false;
-			}
+				if (disconnect && (slot_flags[i] & CONNECT_PERSIST) && Engine::get_singleton()->is_editor_hint()) {
+					// This signal was connected from the editor, and is being edited. Just don't disconnect for now.
+					disconnect = false;
+				}
 #endif
-			if (disconnect) {
-				_disconnect(p_name, slot_callables[i]);
+				if (disconnect) {
+					_disconnect(p_name, slot_callables[i]);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
…-shot scan

Three targeted optimizations to Object::emit_signalp() that reduce per-emission overhead on the critical signal dispatch path:

1. Increase MAX_SLOTS_ON_STACK from 5 to 16
   - Signals with 6-16 connections previously triggered heap allocation (memalloc/memfree) for both the Callable array and the flags array.
   - Most real-world signals have 1-4 connections; 16 covers virtually all cases while adding only ~352 bytes of stack usage (16 * sizeof(Callable)
     + 16 * sizeof(uint32_t)).
   - Eliminates the allocation overhead that was the primary bottleneck for signals with more than 5 connections.

2. Early-out for empty slot_map
   - If a signal exists in signal_map but has zero connections, return immediately without proceeding to the copy/dispatch loop.
   - Avoids unnecessary work for signals that were connected then fully disconnected.

3. Skip one-shot disconnection loop when no one-shots are present
   - Track a has_one_shots flag during the Callable copy loop (zero additional iteration cost, just a bitwise OR per slot).
   - The second loop that scans for CONNECT_ONE_SHOT and calls _disconnect() is now guarded by unlikely(has_one_shots), skipping it entirely in the common case where all connections are persistent.
   - This eliminates a full slot_count iteration on every emission.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
