### PR TITLE
Add `ItemList` and `TabBar` to the Theme Editor default preview

### DIFF
--- a/editor/scene/gui/theme_editor_preview.cpp
+++ b/editor/scene/gui/theme_editor_preview.cpp
@@ -39,6 +39,7 @@
 #include "scene/gui/check_button.h"
 #include "scene/gui/color_picker.h"
 #include "scene/gui/color_rect.h"
+#include "scene/gui/item_list.h"
 #include "scene/gui/label.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/menu_button.h"
@@ -436,6 +437,12 @@ DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 	Tree *test_tree = memnew(Tree);
 	third_vb->add_child(test_tree);
 	test_tree->set_custom_minimum_size(Size2(0, 175) * EDSCALE);
+
+	ItemList *test_item_list = memnew(ItemList);
+    test_item_list->set_custom_minimum_size(Size2(0, 120) * EDSCALE);
+    test_item_list->add_item(TTR("Item 1"));
+    test_item_list->add_item(TTR("Item 2"));
+    third_vb->add_child(test_item_list);
 
 	TreeItem *item = test_tree->create_item();
 	item->set_text(0, "Tree");

--- a/editor/scene/gui/theme_editor_preview.cpp
+++ b/editor/scene/gui/theme_editor_preview.cpp
@@ -439,10 +439,10 @@ DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 	test_tree->set_custom_minimum_size(Size2(0, 175) * EDSCALE);
 
 	ItemList *test_item_list = memnew(ItemList);
-    test_item_list->set_custom_minimum_size(Size2(0, 120) * EDSCALE);
-    test_item_list->add_item(TTR("Item 1"));
-    test_item_list->add_item(TTR("Item 2"));
-    third_vb->add_child(test_item_list);
+	test_item_list->set_custom_minimum_size(Size2(0, 120) * EDSCALE);
+	test_item_list->add_item(TTR("Item 1"));
+	test_item_list->add_item(TTR("Item 2"));
+	third_vb->add_child(test_item_list);
 
 	TreeItem *item = test_tree->create_item();
 	item->set_text(0, "Tree");

--- a/editor/scene/gui/theme_editor_preview.cpp
+++ b/editor/scene/gui/theme_editor_preview.cpp
@@ -438,6 +438,14 @@ DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 	third_vb->add_child(test_tree);
 	test_tree->set_custom_minimum_size(Size2(0, 175) * EDSCALE);
 
+	TabBar *tb_bar = memnew(TabBar);
+	tb_bar->set_custom_minimum_size(Size2(0, 25) * EDSCALE);
+	tb_bar->add_tab(TTR("Tab 1"));
+	tb_bar->add_tab(TTR("Tab 2"));
+	tb_bar->add_tab(TTR("Tab 3"));
+	tb_bar->set_tab_disabled(2, true);
+	third_vb->add_child(tb_bar);
+
 	ItemList *test_item_list = memnew(ItemList);
 	test_item_list->set_custom_minimum_size(Size2(0, 120) * EDSCALE);
 	test_item_list->add_item(TTR("Item 1"));


### PR DESCRIPTION
Closes: [116324](https://github.com/godotengine/godot/issues/116324)

It is a enhancement pull request

<img width="1994" height="734" alt="image" src="https://github.com/user-attachments/assets/6c634007-d7f2-4eb1-97e0-86733039b3c4" />
On the bottom right there is an itemList