### PR TITLE
Fix out-of-bounds error when right-click deleting a `Path3D` curve point

### DIFF
--- a/editor/scene/3d/path_3d_editor_plugin.cpp
+++ b/editor/scene/3d/path_3d_editor_plugin.cpp
@@ -734,6 +734,7 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_3d_gui_input(Camera3D *p
 					ur->create_action(TTR("Remove Path Point"));
 					ur->add_do_method(c.ptr(), "remove_point", i);
 					ur->add_undo_method(c.ptr(), "add_point", c->get_point_position(i), c->get_point_in(i), c->get_point_out(i), i);
+					Node3DEditor::get_singleton()->clear_subgizmo_selection();
 					ur->commit_action();
 					return EditorPlugin::AFTER_GUI_INPUT_STOP;
 				} else if (dist_to_p_out < click_dist) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Prevents the error:

>  ERROR: editor\scene\3d\path_3d_editor_plugin.cpp:1222 - Index p_id = 3 is out of bounds (curve->get_point_count() = 3).