### PR TITLE
Fix freelook mouse events not reaching viewport

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -1967,42 +1967,27 @@ void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 	}
 }
 
-// Helper function to redirect mouse events to the active freelook viewport
-static bool _redirect_freelook_input(const Ref<InputEvent> &p_event, Node3DEditorViewport *p_exclude_viewport = nullptr) {
-	if (Input::get_singleton()->get_mouse_mode() != Input::MouseMode::MOUSE_MODE_CAPTURED) {
-		return false;
-	}
-
-	Node3DEditor *editor = Node3DEditor::get_singleton();
-	if (!editor->get_freelook_viewport()) {
-		return false;
-	}
-
-	Node3DEditorViewport *freelook_vp = editor->get_freelook_viewport();
-	if (freelook_vp == p_exclude_viewport) {
-		return false;
-	}
-
-	Ref<InputEventMouse> mouse_event = p_event;
-	if (!mouse_event.is_valid()) {
-		return false;
-	}
-
-	Control *target_surface = freelook_vp->get_surface();
-
-	target_surface->emit_signal(SceneStringName(gui_input), p_event);
-	return true;
-}
-
-// This is only active during instant transforms,
-// to capture and wrap mouse events outside the control.
+// This is only active during instant transforms or freelook,
+// to capture mouse events that may not reach the viewport through normal GUI routing
+// (e.g., when the mouse position is outside the viewport due to MOUSE_MODE_CAPTURED
+// centering the cursor at the window center).
 void Node3DEditorViewport::input(const Ref<InputEvent> &p_event) {
-	ERR_FAIL_COND(!_edit.instant);
 	Ref<InputEventMouseMotion> m = p_event;
 
-	if (m.is_valid()) {
+	if (_edit.instant && m.is_valid()) {
 		_edit.mouse_pos += view_3d_controller->get_warped_mouse_motion(p_event, surface->get_global_rect());
 		update_transform(_get_key_modifier(m) == Key::SHIFT);
+	}
+
+	if (view_3d_controller->is_freelook_enabled()) {
+		Ref<InputEventMouse> mouse_event = p_event;
+		if (mouse_event.is_valid()) {
+			Ref<InputEventMouseButton> mb = p_event;
+			if (mb.is_null() || mb->get_button_index() != MouseButton::LEFT) {
+				_sinput(p_event);
+			}
+			get_viewport()->set_input_as_handled();
+		}
 	}
 }
 
@@ -2050,10 +2035,6 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 			set_message("");
 			return;
 		}
-	}
-
-	if (_redirect_freelook_input(p_event, this)) {
-		return;
 	}
 
 	{
@@ -2998,7 +2979,7 @@ void Node3DEditorViewport::_cursor_interpolated() {
 }
 
 void Node3DEditorViewport::_freelook_changed() {
-	spatial_editor->set_freelook_viewport(view_3d_controller->is_freelook_enabled() ? this : nullptr);
+	set_process_input(view_3d_controller->is_freelook_enabled());
 }
 
 void Node3DEditorViewport::_freelook_speed_scaled() {

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -799,8 +799,6 @@ private:
 
 	Node3D *selected = nullptr;
 
-	Node3DEditorViewport *freelook_viewport = nullptr;
-
 	void _request_gizmo(Object *p_obj);
 	void _request_gizmo_for_id(ObjectID p_id);
 	void _set_subgizmo_selection(Object *p_obj, Ref<Node3DGizmo> p_gizmo, int p_id, Transform3D p_transform = Transform3D());
@@ -1011,9 +1009,6 @@ public:
 		return viewports[p_idx];
 	}
 	Node3DEditorViewport *get_last_used_viewport();
-
-	void set_freelook_viewport(Node3DEditorViewport *p_viewport) { freelook_viewport = p_viewport; }
-	Node3DEditorViewport *get_freelook_viewport() const { return freelook_viewport; }
 
 	void add_gizmo_plugin(Ref<EditorNode3DGizmoPlugin> p_plugin);
 	void remove_gizmo_plugin(Ref<EditorNode3DGizmoPlugin> p_plugin);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Fixes: https://github.com/godotengine/godot/issues/116332
Fixes: https://github.com/godotengine/godot/issues/116016
Fixes: https://github.com/godotengine/godot/issues/52446

Supersedes: https://github.com/godotengine/godot/pull/116020
Supersedes: https://github.com/godotengine/godot/pull/101820

Would be nice to include: https://github.com/godotengine/godot/pull/116019

Got this idea from playing around with instant transforms to basically reuse the same mechanism to prevent freelook issues with multiple viewports or panels blocking the captured mouse at the center.