### PR TITLE
Fix Control minimum size check too aggressive

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1663,11 +1663,10 @@ void Control::_update_minimum_size() {
 		return;
 	}
 
-	bool was_invalid = !data.minimum_size_valid;
 	Size2 minsize = get_combined_minimum_size();
 	data.updating_last_minimum_size = false;
 
-	if (was_invalid || minsize != data.last_minimum_size) {
+	if (minsize != data.last_minimum_size) {
 		data.last_minimum_size = minsize;
 		_size_changed();
 		emit_signal(SceneStringName(minimum_size_changed));
@@ -1698,6 +1697,8 @@ void Control::update_minimum_size() {
 	}
 
 	if (!is_visible_in_tree()) {
+		// Invalidate the last minimum size so it will update when made visible.
+		data.last_minimum_size = Size2(-1, -1);
 		return;
 	}
 


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/116289

CodeTextEditor changes the RichTextLabel's minimum size based on its content height when it resizes. This causes it to resize again with a different content height and it continues going back and forth between 2 values.
RichTextLabel can have a different content height even if only the minimum size height changes, because the scrollbar may show or not depending on if it fits. There is also no reserve scrollbar mode like ScrollContainer has.

The error RichTextLabel changes size and causes its minimum height to be set which calls `Control::update_minimum_size()` then `Control::_update_minimum_size()`, which causes the size to change again. But this time the HBoxContainer it is in gets resorted before `Control::_update_minimum_size()` is called since it is deferred. The HBoxContainer resort updates the size which sets the minimum height again back to the original value. Previously (before #115596) it would then just be ignored since it has the same value as before, even though it changed and its effects got overridden. So in some ways it would be correct to update the size again in this case, but it also allows infinite loops to happen.

In the future, RichTextLabel should probably be able to reserve the scrollbar space or do something for when it is at minimum size, since it isn't great at either of the values it is trying to use.
At the lower height (26) without a scrollbar, you can see the `E r r` text go outside of its rect (4.6, this PR):
<img width="166" height="92" alt="image" src="https://github.com/user-attachments/assets/a443dded-2eb3-4aca-8886-d25ceae7ae36" />

And at the higher height (62) with a scrollbar, the scrollbar cannot move and the text is on one line (master, increasing size causes the freeze):
<img width="178" height="121" alt="image" src="https://github.com/user-attachments/assets/15ff758b-cbf8-4a31-88e7-39356b66afa9" />

It looks like there are also cases where the change in https://github.com/godotengine/godot/pull/115596 updates the size where it isn't necessary, its too aggressive in updating sizes. So I am reverting that change and implementing a different fix for https://github.com/godotengine/godot/issues/109497 that only affects Controls that are made invisible but also doesn't resize them when invisible.