### PR TITLE
[Windows] Use OneCore/WinRT emoji picker when available.

### DIFF
--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -82,7 +82,7 @@ env.Depends(res_obj, "#core/version_generated.gen.h")
 env.add_source_files(sources, common_win)
 
 env_winrt = env.Clone()
-tts_sources = ["tts_windows.cpp", "tts_driver_sapi.cpp"]
+tts_sources = ["tts_windows.cpp", "tts_driver_sapi.cpp", "winrt_utils.cpp"]
 if env["winrt"]:
     if not env_winrt.msvc:
         if "-std=gnu++17" in env_winrt["CXXFLAGS"]:

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -36,6 +36,7 @@
 #include "os_windows.h"
 #include "tts_windows.h"
 #include "wgl_detect_version.h"
+#include "winrt_utils.h"
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
@@ -4060,24 +4061,26 @@ Key DisplayServerWindows::keyboard_get_label_from_physical(Key p_keycode) const 
 }
 
 void DisplayServerWindows::show_emoji_and_symbol_picker() const {
-	// Send Win + Period shortcut, there's no non-WinRT public API.
+	if (!WinRTUtils::try_show_onecore_emoji_picker()) {
+		// Send Win + Period shortcut.
 
-	INPUT input[4] = {};
-	input[0].type = INPUT_KEYBOARD; // Win down.
-	input[0].ki.wVk = VK_LWIN;
+		INPUT input[4] = {};
+		input[0].type = INPUT_KEYBOARD; // Win down.
+		input[0].ki.wVk = VK_LWIN;
 
-	input[1].type = INPUT_KEYBOARD; // Period down.
-	input[1].ki.wVk = VK_OEM_PERIOD;
+		input[1].type = INPUT_KEYBOARD; // Period down.
+		input[1].ki.wVk = VK_OEM_PERIOD;
 
-	input[2].type = INPUT_KEYBOARD; // Win up.
-	input[2].ki.wVk = VK_LWIN;
-	input[2].ki.dwFlags = KEYEVENTF_KEYUP;
+		input[2].type = INPUT_KEYBOARD; // Win up.
+		input[2].ki.wVk = VK_LWIN;
+		input[2].ki.dwFlags = KEYEVENTF_KEYUP;
 
-	input[3].type = INPUT_KEYBOARD; // Period up.
-	input[3].ki.wVk = VK_OEM_PERIOD;
-	input[3].ki.dwFlags = KEYEVENTF_KEYUP;
+		input[3].type = INPUT_KEYBOARD; // Period up.
+		input[3].ki.wVk = VK_OEM_PERIOD;
+		input[3].ki.dwFlags = KEYEVENTF_KEYUP;
 
-	SendInput(4, input, sizeof(INPUT));
+		SendInput(4, input, sizeof(INPUT));
+	}
 }
 
 String DisplayServerWindows::_get_keyboard_layout_display_name(const String &p_klid) const {

--- a/platform/windows/winrt_utils.cpp
+++ b/platform/windows/winrt_utils.cpp
@@ -1,0 +1,68 @@
+/**************************************************************************/
+/*  winrt_utils.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "winrt_utils.h"
+
+#include "core/typedefs.h"
+
+#ifdef WINRT_ENABLED
+
+GODOT_GCC_WARNING_PUSH
+GODOT_GCC_WARNING_IGNORE("-Wnon-virtual-dtor")
+GODOT_GCC_WARNING_IGNORE("-Wctor-dtor-privacy")
+GODOT_GCC_WARNING_IGNORE("-Wshadow")
+GODOT_GCC_WARNING_IGNORE("-Wstrict-aliasing")
+GODOT_CLANG_WARNING_PUSH
+GODOT_CLANG_WARNING_IGNORE("-Wnon-virtual-dtor")
+
+#include <winrt/Windows.Foundation.Metadata.h>
+#include <winrt/Windows.UI.Input.h>
+#include <winrt/Windows.UI.ViewManagement.Core.h>
+
+GODOT_GCC_WARNING_POP
+GODOT_CLANG_WARNING_POP
+
+using namespace winrt::Windows::Foundation::Metadata;
+using namespace winrt::Windows::UI::ViewManagement::Core;
+
+bool WinRTUtils::try_show_onecore_emoji_picker() {
+	if (ApiInformation::IsApiContractPresent(L"Windows.Foundation.UniversalApiContract", 7)) { // Windows 10, 1809+
+		return CoreInputView::GetForCurrentView().TryShow(CoreInputViewKind::Emoji);
+	}
+	return false;
+}
+
+#else
+
+bool WinRTUtils::try_show_onecore_emoji_picker() {
+	return false;
+}
+
+#endif

--- a/platform/windows/winrt_utils.h
+++ b/platform/windows/winrt_utils.h
@@ -1,0 +1,36 @@
+/**************************************************************************/
+/*  winrt_utils.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+class WinRTUtils {
+public:
+	static bool try_show_onecore_emoji_picker();
+};


### PR DESCRIPTION
Uses `Windows.UI.ViewManagement` API when available (Windows 10, 1809+) instead of simulated key press hack.

Depends on https://github.com/godotengine/godot/pull/116349 (for WinRT).