### PR TITLE
Add a "Correct translation" menu item to `EditorHelp`

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -45,6 +45,7 @@
 #include "core/os/os.h"
 #include "core/string/regex.h"
 #include "core/string/string_builder.h"
+#include "core/string/translation_server.h"
 #include "core/version.h"
 #include "editor/doc/doc_data_compressed.gen.h"
 #include "editor/docks/filesystem_dock.h"
@@ -727,6 +728,19 @@ void EditorHelp::_push_code_font() {
 void EditorHelp::_pop_code_font() {
 	class_desc->pop(); // font_size
 	class_desc->pop(); // font
+}
+
+void EditorHelp::_menu_option(int p_option) {
+	if (p_option == MENU_CORRECT_TRANSLATION) {
+		StringBuilder sb;
+		sb.append("https://hosted.weblate.org/translate/godot-engine/godot-class-reference/");
+		sb.append(TranslationServer::get_singleton()->get_locale());
+		sb.append("/?q=+location%3A");
+		sb.append(edited_class);
+		sb.append(".xml++");
+		sb.append(class_desc->get_selected_text());
+		OS::get_singleton()->shell_open(sb.as_string());
+	}
 }
 
 Error EditorHelp::_goto_desc(const String &p_class, bool p_can_trigger_save_history) {
@@ -3490,6 +3504,10 @@ EditorHelp::EditorHelp() {
 	class_desc->set_tab_size(8);
 	class_desc->set_autowrap_trim_flags(TextServer::BREAK_TRIM_END_EDGE_SPACES);
 	add_child(class_desc);
+
+	PopupMenu *menu = class_desc->get_menu();
+	menu->add_item(ETR("Correct Translation"), MENU_CORRECT_TRANSLATION);
+	menu->connect(SceneStringName(id_pressed), callable_mp(this, &EditorHelp::_menu_option));
 
 	class_desc->set_threaded(true);
 	class_desc->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -178,6 +178,11 @@ class EditorHelp : public VBoxContainer {
 	void _class_desc_resized(bool p_force_update_theme);
 	int display_margin = 0;
 
+	enum MenuItems {
+		MENU_CORRECT_TRANSLATION = RichTextLabel::MENU_MAX + 1,
+	};
+	void _menu_option(int p_option);
+
 	Error _goto_desc(const String &p_class, bool p_can_trigger_save_history);
 	//void _update_history_buttons();
 	void _update_method_list(MethodType p_method_type, const Vector<DocData::MethodDoc> &p_methods);


### PR DESCRIPTION
This menu item will search for the selected text on [weblate](https://hosted.weblate.org/projects/godot-engine/godot-class-reference/) to help users easily correct/improve the translation of class references.

https://github.com/user-attachments/assets/428c7da1-495c-439b-958c-65b0f2d1bf00

Note that the selected text does not contain bbcode. It's best to avoid searching for text that has been modified with bbcode.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

------

Translation also requires user participation to improve it. Using it in combination with #116007 might make it easier to contribute translations. 