### PR TITLE
Optimize `get_total_memory_used` in D3D12 and Vulkan.

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -5799,9 +5799,11 @@ uint64_t RenderingDeviceDriverD3D12::get_resource_native_handle(DriverResource p
 }
 
 uint64_t RenderingDeviceDriverD3D12::get_total_memory_used() {
-	D3D12MA::TotalStatistics stats;
-	allocator->CalculateStatistics(&stats);
-	return stats.Total.Stats.BlockBytes;
+	D3D12MA::Budget local_budget;
+	D3D12MA::Budget non_local_budget;
+	allocator->GetBudget(&local_budget, &non_local_budget);
+
+	return local_budget.Stats.AllocationBytes + non_local_budget.Stats.AllocationBytes;
 }
 
 uint64_t RenderingDeviceDriverD3D12::get_lazily_memory_used() {


### PR DESCRIPTION
Fixes #102173.

Changes the function implementations to use `GetBudget`/`vmaGetHeapBudgets` instead of the significantly more expensive "calculate" variants. This reduces the cost of the functions to the point I can't even see them in CPU profilers anymore.

Notes:
- D3D12 used to provide the block allocation size, but I changed it to the resource allocation size for consistency with Vulkan.
- Lazy memory size unfortunately cannot be gathered this way because it requires information from the individual memory types, which `vmaGetHeapBudgets` does not provide.