### PR TITLE
GDScript: Add warning when exporting inner class resources

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -567,6 +567,9 @@
 		<member name="debug/gdscript/warnings/enum_variable_without_default" type="int" setter="" getter="" default="1">
 			When set to [b]Warn[/b] or [b]Error[/b], produces a warning or an error respectively when a variable has an enum type but no explicit default value, but only if the enum does not contain [code]0[/code] as a valid value.
 		</member>
+		<member name="debug/gdscript/warnings/export_of_unnamed_type" type="int" setter="" getter="" default="1">
+			When set to [b]Warn[/b] or [b]Error[/b], produces a warning or an error respectively when the type of an [code]@export[/code]ed variable has no [code]class_name[/code] or is an inner class.
+		</member>
 		<member name="debug/gdscript/warnings/get_node_default_without_onready" type="int" setter="" getter="" default="2">
 			When set to [b]Warn[/b] or [b]Error[/b], produces a warning or an error respectively when [method Node.get_node] (or the shorthand [code]$[/code]) is used as default value of a class variable without the [code]@onready[/code] annotation.
 		</member>

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1064,8 +1064,15 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 				static_context = previous_static_context;
 
 #ifdef DEBUG_ENABLED
-				if (member.variable->exported && member.variable->onready) {
-					parser->push_warning(member.variable, GDScriptWarning::ONREADY_WITH_EXPORT);
+				if (member.variable->exported) {
+					if (member.variable->onready) {
+						parser->push_warning(member.variable, GDScriptWarning::ONREADY_WITH_EXPORT);
+					}
+					bool is_unnamed_script = member.variable->get_datatype().kind == GDScriptParser::DataType::SCRIPT && member.variable->get_datatype().script_type->get_global_name().is_empty();
+					bool is_unnamed_gdscript = member.variable->get_datatype().kind == GDScriptParser::DataType::CLASS && member.variable->get_datatype().class_type->get_global_name().is_empty();
+					if (is_unnamed_script || is_unnamed_gdscript) {
+						parser->push_warning(member.variable, GDScriptWarning::EXPORT_OF_UNNAMED_TYPE);
+					}
 				}
 				if (member.variable->initializer) {
 					// Check if it is call to get_node() on self (using shorthand $ or not), so we can check if @onready is needed.

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -164,6 +164,8 @@ String GDScriptWarning::get_message() const {
 			return vformat(R"*(The default value uses "%s" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.)*", symbols[0]);
 		case ONREADY_WITH_EXPORT:
 			return R"("@onready" will set the default value after "@export" takes effect and will override it.)";
+		case EXPORT_OF_UNNAMED_TYPE:
+			return R"("@export" does not properly support types without global name, e.g. inner classes.)";
 #ifndef DISABLE_DEPRECATED
 		// Never produced. These warnings migrated from 3.x by mistake.
 		case PROPERTY_USED_AS_FUNCTION: // There is already an error.
@@ -241,6 +243,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		PNAME("NATIVE_METHOD_OVERRIDE"),
 		PNAME("GET_NODE_DEFAULT_WITHOUT_ONREADY"),
 		PNAME("ONREADY_WITH_EXPORT"),
+		PNAME("EXPORT_OF_UNNAMED_TYPE"),
 #ifndef DISABLE_DEPRECATED
 		"PROPERTY_USED_AS_FUNCTION",
 		"CONSTANT_USED_AS_FUNCTION",

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -90,6 +90,7 @@ public:
 		NATIVE_METHOD_OVERRIDE, // The script method overrides a native one, this may not work as intended.
 		GET_NODE_DEFAULT_WITHOUT_ONREADY, // A class variable uses `get_node()` (or the `$` notation) as its default value, but does not use the @onready annotation.
 		ONREADY_WITH_EXPORT, // The `@onready` annotation will set the value after `@export` which is likely not intended.
+		EXPORT_OF_UNNAMED_TYPE, // The `@export` annotation is not able to represent unnamed types (e.g. inner classes).
 #ifndef DISABLE_DEPRECATED
 		PROPERTY_USED_AS_FUNCTION, // Function not found, but there's a property with the same name.
 		CONSTANT_USED_AS_FUNCTION, // Function not found, but there's a constant with the same name.
@@ -148,6 +149,7 @@ public:
 		ERROR, // NATIVE_METHOD_OVERRIDE // May not work as expected.
 		ERROR, // GET_NODE_DEFAULT_WITHOUT_ONREADY // May not work as expected.
 		ERROR, // ONREADY_WITH_EXPORT // May not work as expected.
+		WARN, // EXPORT_OF_UNNAMED_TYPE // Can work correctly if the variable is not used from the editor.
 #ifndef DISABLE_DEPRECATED
 		WARN, // PROPERTY_USED_AS_FUNCTION
 		WARN, // CONSTANT_USED_AS_FUNCTION

--- a/modules/gdscript/tests/scripts/analyzer/warnings/export_of_unnamed_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/export_of_unnamed_type.gd
@@ -1,0 +1,18 @@
+extends Node
+
+class InnerResource extends Resource:
+	pass
+
+class InnerNode extends Node:
+	pass
+
+const UnnamedResource = preload("./export_of_unnamed_type_resource.notest.gd")
+const UnnamedNode = preload("./export_of_unnamed_type_node.notest.gd")
+
+@export var inner_resource: InnerResource
+@export var inner_node: InnerNode
+@export var unnamed_resource: UnnamedResource
+@export var unnamed_node: UnnamedNode
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/export_of_unnamed_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/export_of_unnamed_type.out
@@ -1,0 +1,5 @@
+GDTEST_OK
+~~ WARNING at line 12: (EXPORT_OF_UNNAMED_TYPE) "@export" does not properly support types without global name, e.g. inner classes.
+~~ WARNING at line 13: (EXPORT_OF_UNNAMED_TYPE) "@export" does not properly support types without global name, e.g. inner classes.
+~~ WARNING at line 14: (EXPORT_OF_UNNAMED_TYPE) "@export" does not properly support types without global name, e.g. inner classes.
+~~ WARNING at line 15: (EXPORT_OF_UNNAMED_TYPE) "@export" does not properly support types without global name, e.g. inner classes.

--- a/modules/gdscript/tests/scripts/analyzer/warnings/export_of_unnamed_type_node.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/export_of_unnamed_type_node.notest.gd
@@ -1,0 +1,1 @@
+extends Node

--- a/modules/gdscript/tests/scripts/analyzer/warnings/export_of_unnamed_type_resource.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/export_of_unnamed_type_resource.notest.gd
@@ -1,0 +1,1 @@
+extends Resource

--- a/modules/gdscript/tests/scripts/parser/features/export_variable.gd
+++ b/modules/gdscript/tests/scripts/parser/features/export_variable.gd
@@ -41,6 +41,7 @@ var test_custom_enum_hard_no_export: CustomEnum
 # Global custom classes.
 @export var test_global_class: ExportVariableTest
 @export var test_preloaded_global_class: PreloadedGlobalClass
+@warning_ignore("EXPORT_OF_UNNAMED_TYPE")
 @export var test_preloaded_unnamed_class: PreloadedUnnamedClass # GH-93168
 
 # Arrays.


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/issues/116302

It's pretty common knowledge for more experienced users, that custom resources shouldn't be mixed with inner classes. While this is documented, there are too many ways for new users to try this out without encountering the necessary documentation.

Extending `Resource` in inner classes is not always an issue if you know what you are doing and understand the limitations, so instead I opted to add a warning when exporting props that are typed with something that does not have a global type name. Doing this is always not a good idea and users should be made aware of it:

<img width="1001" height="179" alt="image" src="https://github.com/user-attachments/assets/747760b6-924e-4943-bff0-457b84ccd288" />

In addition to inner class resources the warning also triggers for preloaded types without `class_name`:

```gdscript
const Type = preload("./resource.gd")
@export var res: Type
``` 

Those are not as critical as inner classes, but don't work correctly with the inspector (GDScript falls back to exporting them as `Resource` so the inspector can assign invalid values).

The warning also applies to `Nodes` since the same inspector issues apply.