### PR TITLE
Refactor GDType constructor to simplify hierarchy handling

### DIFF
--- a/core/object/gdtype.cpp
+++ b/core/object/gdtype.cpp
@@ -30,13 +30,12 @@
 
 #include "gdtype.h"
 
-GDType::GDType(const GDType *p_super_type, StringName p_name) :
-		super_type(p_super_type), name(std::move(p_name)) {
-	name_hierarchy.push_back(name);
+GDType::GDType(const GDType *p_super_type, const StringName &p_name)
+    : super_type(p_super_type), name(p_name) {
 
-	if (super_type) {
-		for (const StringName &ancestor_name : super_type->name_hierarchy) {
-			name_hierarchy.push_back(ancestor_name);
-		}
-	}
+    if (super_type) {
+        name_hierarchy = super_type->name_hierarchy;
+    }
+
+    name_hierarchy.push_back(name);
 }


### PR DESCRIPTION
In the original code, the own name was added first, followed by the names of the ancestors.

 In the revised version, the ancestor hierarchy is copied first, followed by the addition of the own name.
Now, the sequence goes from the root to the current type, rather than the other way around.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
