### PR TITLE
Fix startup errors/warnings on X11 when the Prefer Wayland editor setting is enabled

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3051,7 +3051,12 @@ Error Main::setup2(bool p_show_boot_logo) {
 								init_custom_scale = value;
 								init_custom_scale_found = true;
 							} else if (!prefer_wayland_found && assign == "run/platforms/linuxbsd/prefer_wayland") {
-								prefer_wayland = value;
+								if (!OS::get_singleton()->get_environment("WAYLAND_DISPLAY").is_empty()) {
+									// Do not prefer Wayland if not currently on a Wayland session.
+									// This avoids error messages on startup when currently on X11
+									// and the Prefer Wayland setting is enabled.
+									prefer_wayland = value;
+								}
 								prefer_wayland_found = true;
 							} else if (!tablet_found && assign == "interface/editor/tablet_driver") {
 								tablet_driver_editor = value;


### PR DESCRIPTION
This makes the editor setting act as if it's ignored when not currently on a Wayland session.

Previously, this was printed on every editor launch when the setting is enabled:

```
ERROR: Parameter "display" is null.
   at: init (platform/linuxbsd/wayland/wayland_embedder.cpp:2819)
ERROR: Can't initialize Wayland embedder.
   at: init (platform/linuxbsd/wayland/wayland_thread.cpp:4799)
ERROR: Could not initialize the Wayland thread.
   at: DisplayServerWayland (platform/linuxbsd/wayland/display_server_wayland.cpp:2032)
ERROR: Can't create the Wayland display server.
   at: create_func (platform/linuxbsd/wayland/display_server_wayland.cpp:2002)
WARNING: Display driver wayland failed, falling back to x11.
     at: setup2 (main/main.cpp:3251)
```

Tested on KDE with X11 and Wayland sessions (Wayland is still used correctly on the Wayland session).
