### PR TITLE
LSP: Fix singleton registration

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1572,6 +1572,10 @@
 		<member name="GDExtensionManager" type="GDExtensionManager" setter="" getter="">
 			The [GDExtensionManager] singleton.
 		</member>
+		<member name="GDScriptLanguageProtocol" type="GDScriptLanguageProtocol" setter="" getter="">
+			The [GDScriptLanguageProtocol] singleton.
+			[b]Note:[/b] Only available in editor builds.
+		</member>
 		<member name="Geometry2D" type="Geometry2D" setter="" getter="">
 			The [Geometry2D] singleton.
 		</member>

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -988,7 +988,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 			}
 			pd.name = s.name;
 			pd.type = s.ptr->get_class();
-			while (String(ClassDB::get_parent_class(pd.type)) != "Object") {
+			while (!ClassDB::is_class_exposed(pd.type)) {
 				pd.type = ClassDB::get_parent_class(pd.type);
 			}
 			c.properties.push_back(pd);

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -126,12 +126,6 @@ static void _editor_init() {
 	gdscript_syntax_highlighter.instantiate();
 	ScriptEditor::get_singleton()->register_syntax_highlighter(gdscript_syntax_highlighter);
 #endif
-
-#ifndef GDSCRIPT_NO_LSP
-	Engine::Singleton singleton("GDScriptLanguageProtocol", GDScriptLanguageProtocol::get_singleton());
-	singleton.editor_only = true;
-	Engine::get_singleton()->add_singleton(singleton);
-#endif // !GDSCRIPT_NO_LSP
 }
 
 #endif // TOOLS_ENABLED
@@ -166,6 +160,10 @@ void initialize_gdscript_module(ModuleInitializationLevel p_level) {
 		register_lsp_types();
 		memnew(GDScriptLanguageProtocol);
 		EditorPlugins::add_by_type<GDScriptLanguageServer>();
+
+		Engine::Singleton singleton("GDScriptLanguageProtocol", GDScriptLanguageProtocol::get_singleton());
+		singleton.editor_only = true;
+		Engine::get_singleton()->add_singleton(singleton);
 #endif // !GDSCRIPT_NO_LSP
 	}
 #endif // TOOLS_ENABLED

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -496,9 +496,6 @@ void validate_class(const Context &p_context, const ExposedClass &p_exposed_clas
 				"Object class is registered as a singleton.");
 	}
 
-	TEST_FAIL_COND((p_exposed_class.is_singleton && p_exposed_class.base != p_context.names_cache.object_class),
-			"Singleton base class '", String(p_exposed_class.base), "' is not Object, for class '", p_exposed_class.name, "'.");
-
 	TEST_FAIL_COND((is_derived_type && !p_context.exposed_classes.has(p_exposed_class.base)),
 			"Base type '", p_exposed_class.base.operator String(), "' does not exist, for class '", p_exposed_class.name, "'.");
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/52162
Fixes https://github.com/godotengine/godot/issues/86132

The singleton is now registered on `MODULE_INITIALIZATION_LEVEL_EDITOR` instead of a late callback.

To make this work I removed an old test case that limited singletons to only types that inherit directly from `Object`. This should be fine based on my question on RC.