### PR TITLE
Wayland: Skip resize request when the size is the same

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1205,6 +1205,10 @@ void DisplayServerWayland::window_set_size(const Size2i p_size, DisplayServer::W
 	ERR_FAIL_COND(!windows.has(p_window_id));
 	WindowData &wd = windows[p_window_id];
 
+	if (wd.rect.size == p_size) {
+		return;
+	}
+
 	Size2i new_size = p_size;
 	if (wd.visible) {
 		new_size = wayland_thread.window_set_size(p_window_id, p_size);


### PR DESCRIPTION
Fixes #116304.
Follow up to #114082.

`DisplayServer::window_set_size` is called lots of times in the code, with the assumption (I suppose) that it's going to be idempotent.

We had checks in `_update_window_rect` but we still called `WaylandThread::window_set_size`, which did a lot of stuff. In particular, this caused issues with HiDPI as it "overrode" the window size before it had a time to figure out its scale.

---

Tested on:
 - Fedora 43 VM with COSMIC 1.0.1, GNOME 49.2, KDE 6.5.4
 - KISS Linux with labwc 0.9.3-49-g654da8c8 (built from git), sway 1.11.

Both with and without #116308.