### PR TITLE
Add a project setting that force exactly match locale when fallback locale is same as current locale

### DIFF
--- a/core/string/translation_domain.cpp
+++ b/core/string/translation_domain.cpp
@@ -198,44 +198,56 @@ bool TranslationDomain::_is_placeholder(const String &p_message, int p_index) co
 					p_message[p_index + 1] == 'o' || p_message[p_index + 1] == 'x' || p_message[p_index + 1] == 'X' || p_message[p_index + 1] == 'f');
 }
 
-StringName TranslationDomain::get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_context) const {
+StringName TranslationDomain::get_message_from_translations(const String &p_locale, const StringName &p_message, bool p_exact, const StringName &p_context) const {
 	StringName res;
 	int best_score = 0;
 
 	for (const Ref<Translation> &E : translations) {
 		int score = TranslationServer::get_singleton()->compare_locales(p_locale, E->get_locale());
-		if (score > 0 && score >= best_score) {
+		if (score == 10) {
 			const StringName r = E->get_message(p_message, p_context);
 			if (!r) {
 				continue;
 			}
 			res = r;
 			best_score = score;
-			if (score == 10) {
-				break; // Exact match, skip the rest.
+			break;
+		}
+		if (!p_exact && score > 0 && score >= best_score) {
+			const StringName r = E->get_message(p_message, p_context);
+			if (!r) {
+				continue;
 			}
+			res = r;
+			best_score = score;
 		}
 	}
 
 	return res;
 }
 
-StringName TranslationDomain::get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
+StringName TranslationDomain::get_message_from_translations(const String &p_locale, const StringName &p_message, bool p_exact, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
 	StringName res;
 	int best_score = 0;
 
 	for (const Ref<Translation> &E : translations) {
 		int score = TranslationServer::get_singleton()->compare_locales(p_locale, E->get_locale());
-		if (score > 0 && score >= best_score) {
+		if (score == 10) {
 			const StringName r = E->get_plural_message(p_message, p_message_plural, p_n, p_context);
 			if (!r) {
 				continue;
 			}
 			res = r;
 			best_score = score;
-			if (score == 10) {
-				break; // Exact match, skip the rest.
+			break;
+		}
+		if (!p_exact && score > 0 && score >= best_score) {
+			const StringName r = E->get_plural_message(p_message, p_message_plural, p_n, p_context);
+			if (!r) {
+				continue;
 			}
+			res = r;
+			best_score = score;
 		}
 	}
 
@@ -354,11 +366,12 @@ StringName TranslationDomain::translate(const StringName &p_message, const Strin
 	}
 
 	const String &locale = locale_override.is_empty() ? TranslationServer::get_singleton()->get_locale() : locale_override;
-	StringName res = get_message_from_translations(locale, p_message, p_context);
-
 	const String &fallback = TranslationServer::get_singleton()->get_fallback_locale();
+	const bool &fallback_exact = (TranslationServer::get_singleton()->get_fallback_exact() ? (locale == fallback) : false);
+
+	StringName res = get_message_from_translations(locale, p_message, fallback_exact, p_context);
 	if (!res && fallback.length() >= 2) {
-		res = get_message_from_translations(fallback, p_message, p_context);
+		res = get_message_from_translations(fallback, p_message, fallback_exact, p_context);
 	}
 
 	if (!res) {
@@ -373,11 +386,12 @@ StringName TranslationDomain::translate_plural(const StringName &p_message, cons
 	}
 
 	const String &locale = locale_override.is_empty() ? TranslationServer::get_singleton()->get_locale() : locale_override;
-	StringName res = get_message_from_translations(locale, p_message, p_message_plural, p_n, p_context);
-
 	const String &fallback = TranslationServer::get_singleton()->get_fallback_locale();
+	const bool &fallback_exact = (TranslationServer::get_singleton()->get_fallback_exact() ? (locale == fallback) : false);
+
+	StringName res = get_message_from_translations(locale, p_message, fallback_exact, p_message_plural, p_n, p_context);
 	if (!res && fallback.length() >= 2) {
-		res = get_message_from_translations(fallback, p_message, p_message_plural, p_n, p_context);
+		res = get_message_from_translations(fallback, p_message, fallback_exact, p_message_plural, p_n, p_context);
 	}
 
 	if (!res) {

--- a/core/string/translation_domain.h
+++ b/core/string/translation_domain.h
@@ -68,8 +68,8 @@ protected:
 
 public:
 	// Methods in this section are not intended for scripting.
-	StringName get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_context) const;
-	StringName get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const;
+	StringName get_message_from_translations(const String &p_locale, const StringName &p_message, bool p_exact, const StringName &p_context) const;
+	StringName get_message_from_translations(const String &p_locale, const StringName &p_message, bool p_exact, const StringName &p_message_plural, int p_n, const StringName &p_context) const;
 	PackedStringArray get_loaded_locales() const;
 
 public:

--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -504,6 +504,14 @@ String TranslationServer::get_fallback_locale() const {
 	return fallback;
 }
 
+void TranslationServer::set_fallback_exact(bool p_exact) {
+	fallback_exact = p_exact;
+}
+
+bool TranslationServer::get_fallback_exact() {
+	return fallback_exact;
+}
+
 bool TranslationServer::is_script_suppored_by_locale(const String &p_locale, const String &p_script) const {
 	Locale l = Locale(*this, p_locale, true);
 	if (l.script == p_script) {
@@ -599,6 +607,7 @@ void TranslationServer::setup() {
 	}
 
 	fallback = GLOBAL_DEF("internationalization/locale/fallback", "en");
+	fallback_exact = GLOBAL_DEF("internationalization/locale/fallback_needs_exactly_match_when_same_as_locale", false);
 	main_domain->set_pseudolocalization_enabled(GLOBAL_DEF("internationalization/pseudolocalization/use_pseudolocalization", false));
 	main_domain->set_pseudolocalization_accents_enabled(GLOBAL_DEF("internationalization/pseudolocalization/replace_with_accents", true));
 	main_domain->set_pseudolocalization_double_vowels_enabled(GLOBAL_DEF("internationalization/pseudolocalization/double_vowels", false));

--- a/core/string/translation_server.h
+++ b/core/string/translation_server.h
@@ -38,6 +38,7 @@ class TranslationServer : public Object {
 
 	String locale = "en";
 	String fallback;
+	bool fallback_exact;
 
 	Ref<TranslationDomain> main_domain;
 #ifdef TOOLS_ENABLED
@@ -111,6 +112,8 @@ public:
 	String get_locale() const;
 	void set_fallback_locale(const String &p_locale);
 	String get_fallback_locale() const;
+	void set_fallback_exact(bool p_exact);
+	bool get_fallback_exact();
 
 #ifndef DISABLE_DEPRECATED
 	Ref<Translation> get_translation_object(const String &p_locale);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1706,6 +1706,10 @@
 			The locale to fall back to if a translation isn't available in a given language. If left empty, [code]en[/code] (English) will be used.
 			[b]Note:[/b] Not to be confused with [TextServerFallback].
 		</member>
+		<member name="internationalization/locale/fallback_needs_exactly_match_when_same_as_locale" type="bool" setter="" getter="" default="false">
+			When current locale is same as [member internationalization/locale/fallback], only translations that exactly match the current locale will be returned.
+			If no such translation exists, it will directly return the original text.
+		</member>
 		<member name="internationalization/locale/include_text_server_data" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], text server break iteration rule sets, dictionaries and other optional data are included in the exported project.
 			[b]Note:[/b] "ICU / HarfBuzz / Graphite" text server data includes dictionaries for Burmese, Chinese, Japanese, Khmer, Lao and Thai as well as Unicode Standard Annex #29 and Unicode Standard Annex #14 word and line breaking rules. Data is about 4 MB large.


### PR DESCRIPTION
Fixes #116051
Related: #117822

Add a project setting `internationalization/locale/fallback_needs_exactly_match_when_same_as_locale`, which is `false` by default to keep compatibility

If it was enabled, when `internationalization/locale/fallback` is same as current locale, `get_message_from_translations()` will only return the translation that locale is exactly match
Which affects `TranslationDomain.translate()` or auto-translate, they will also only return the translation that locale is exactly match, otherwise return original string

This feature is useful for those use a language's original texts as keys (loc with `gettext`), they can set the `internationalization/locale/fallback` to their language, to allow "no translation was loaded by Godot"