### PR TITLE
Fix BottomPanel tab dropping

### DIFF
--- a/editor/docks/dock_tab_container.cpp
+++ b/editor/docks/dock_tab_container.cpp
@@ -44,7 +44,7 @@ bool EditorDockDragHint::can_drop_data(const Point2 &p_point, const Variant &p_d
 
 void EditorDockDragHint::drop_data(const Point2 &p_point, const Variant &p_data) {
 	// Drop dock into last spot if not over tabbar.
-	if (drop_tabbar->get_rect().has_point(p_point)) {
+	if (drop_tabbar_parent->get_rect().has_point(p_point)) {
 		drop_tabbar->_handle_drop_data("tab_container_tab", p_point, p_data, callable_mp(this, &EditorDockDragHint::_drag_move_tab), callable_mp(this, &EditorDockDragHint::_drag_move_tab_from));
 	} else {
 		EditorDockManager *dock_manager = EditorDockManager::get_singleton();
@@ -72,13 +72,14 @@ void EditorDockDragHint::gui_input(const Ref<InputEvent> &p_event) {
 		if (mouse_inside_tabbar) {
 			queue_redraw();
 		}
-		mouse_inside_tabbar = drop_tabbar->get_rect().has_point(pos);
+		mouse_inside_tabbar = drop_tabbar_parent->get_rect().has_point(pos);
 	}
 }
 
 void EditorDockDragHint::set_slot(DockTabContainer *p_slot) {
 	dock_container = p_slot;
 	drop_tabbar = p_slot->get_tab_bar();
+	drop_tabbar_parent = (Control *)p_slot->get_internal_container();
 }
 
 void EditorDockDragHint::_notification(int p_what) {
@@ -130,8 +131,8 @@ void EditorDockDragHint::_notification(int p_what) {
 			draw_style_box(dock_drop_highlight, dock_rect);
 
 			// Only display tabbar hint if the mouse is over the tabbar.
-			if (drop_tabbar->get_global_rect().has_point(get_global_mouse_position())) {
-				draw_set_transform(drop_tabbar->get_position()); // The TabBar isn't always on top.
+			if (drop_tabbar_parent->get_global_rect().has_point(get_global_mouse_position())) {
+				draw_set_transform(drop_tabbar_parent->get_position()); // The TabBar isn't always on top.
 				drop_tabbar->_draw_tab_drop(get_canvas_item());
 			}
 		} break;

--- a/editor/docks/dock_tab_container.h
+++ b/editor/docks/dock_tab_container.h
@@ -43,6 +43,7 @@ class EditorDockDragHint : public Control {
 	GDCLASS(EditorDockDragHint, Control);
 
 	DockTabContainer *dock_container = nullptr;
+	Control *drop_tabbar_parent = nullptr;
 	TabBar *drop_tabbar = nullptr;
 
 	Color valid_drop_color;


### PR DESCRIPTION
Fixes regression from #114283 🙃
When tabs are at the bottom, TabBar is still at (0, 0) due to being inside the internal container.