### PR TITLE
Add MultiplayerPeer.closed signal

### DIFF
--- a/doc/classes/MultiplayerPeer.xml
+++ b/doc/classes/MultiplayerPeer.xml
@@ -96,6 +96,12 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="closed">
+			<description>
+				Emitted when the peer closes.
+				[b]Note:[/b] Calling [method close] will not cause this signal to be emitted.
+			</description>
+		</signal>
 		<signal name="peer_connected">
 			<param index="0" name="id" type="int" />
 			<description>

--- a/modules/enet/enet_multiplayer_peer.cpp
+++ b/modules/enet/enet_multiplayer_peer.cpp
@@ -171,7 +171,7 @@ void ENetMultiplayerPeer::poll() {
 	switch (active_mode) {
 		case MODE_CLIENT: {
 			if (!peers.has(1)) {
-				close();
+				_close();
 				return;
 			}
 			ENetConnection::Event event;
@@ -185,11 +185,11 @@ void ENetMultiplayerPeer::poll() {
 						// Client just disconnected from server.
 						emit_signal(SNAME("peer_disconnected"), 1);
 					}
-					close();
+					_close();
 				} else if (ret == ENetConnection::EVENT_RECEIVE) {
 					_store_packet(1, event);
 				} else if (ret != ENetConnection::EVENT_NONE) {
-					close(); // Error.
+					_close(); // Error.
 				}
 			} while (hosts.has(0) && hosts[0]->check_events(ret, event) > 0);
 		} break;
@@ -223,7 +223,7 @@ void ENetMultiplayerPeer::poll() {
 					int32_t source = event.peer->get_meta(SNAME("_net_id"));
 					_store_packet(source, event);
 				} else if (ret != ENetConnection::EVENT_NONE) {
-					close(); // Error
+					_close(); // Error
 				}
 			} while (hosts.has(0) && hosts[0]->check_events(ret, event) > 0);
 		} break;
@@ -282,12 +282,12 @@ void ENetMultiplayerPeer::disconnect_peer(int p_peer, bool p_force) {
 		}
 		if (active_mode == MODE_CLIENT) {
 			hosts.clear(); // Avoid flushing again.
-			close();
+			_close();
 		}
 	}
 }
 
-void ENetMultiplayerPeer::close() {
+void ENetMultiplayerPeer::_close() {
 	if (!_is_active()) {
 		return;
 	}
@@ -311,6 +311,14 @@ void ENetMultiplayerPeer::close() {
 	unique_id = 0;
 	connection_status = CONNECTION_DISCONNECTED;
 	set_refuse_new_connections(false);
+	emit_signal("closed");
+}
+
+void ENetMultiplayerPeer::close() {
+	bool blocking = is_blocking_signals();
+	set_block_signals(true);
+	_close();
+	set_block_signals(blocking);
 }
 
 int ENetMultiplayerPeer::get_available_packet_count() const {
@@ -485,9 +493,7 @@ ENetMultiplayerPeer::ENetMultiplayerPeer() {
 }
 
 ENetMultiplayerPeer::~ENetMultiplayerPeer() {
-	if (_is_active()) {
-		close();
-	}
+	_close();
 }
 
 // Sets IP for ENet to bind when using create_server or create_client

--- a/modules/enet/enet_multiplayer_peer.h
+++ b/modules/enet/enet_multiplayer_peer.h
@@ -86,6 +86,7 @@ private:
 	void _disconnect_inactive_peers();
 	void _destroy_unused(ENetPacket *p_packet);
 	_FORCE_INLINE_ bool _is_active() const { return active_mode != MODE_NONE; }
+	void _close();
 
 	IPAddress bind_ip;
 

--- a/modules/webrtc/webrtc_multiplayer_peer.cpp
+++ b/modules/webrtc/webrtc_multiplayer_peer.cpp
@@ -437,7 +437,11 @@ int WebRTCMultiplayerPeer::get_max_packet_size() const {
 	return 1200;
 }
 
-void WebRTCMultiplayerPeer::close() {
+void WebRTCMultiplayerPeer::_close() {
+	if (network_mode == MODE_NONE) {
+		return;
+	}
+
 	peer_map.clear();
 	channels_config.clear();
 	unique_id = 0;
@@ -446,8 +450,16 @@ void WebRTCMultiplayerPeer::close() {
 	target_peer = 0;
 	network_mode = MODE_NONE;
 	connection_status = CONNECTION_DISCONNECTED;
+	emit_signal("closed");
+}
+
+void WebRTCMultiplayerPeer::close() {
+	bool blocking = is_blocking_signals();
+	set_block_signals(true);
+	_close();
+	set_block_signals(blocking);
 }
 
 WebRTCMultiplayerPeer::~WebRTCMultiplayerPeer() {
-	close();
+	_close();
 }

--- a/modules/webrtc/webrtc_multiplayer_peer.h
+++ b/modules/webrtc/webrtc_multiplayer_peer.h
@@ -85,6 +85,7 @@ private:
 	void _find_next_peer();
 	Ref<ConnectedPeer> _get_next_peer();
 	Error _initialize(int p_self_id, NetworkMode p_mode, const Array &p_channels_config = Array());
+	void _close();
 
 public:
 	WebRTCMultiplayerPeer() {}

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -52,6 +52,10 @@ Ref<WebSocketPeer> WebSocketMultiplayerPeer::_create_peer() {
 }
 
 void WebSocketMultiplayerPeer::_clear() {
+	if (connection_status == CONNECTION_DISCONNECTED) {
+		return;
+	}
+
 	connection_status = CONNECTION_DISCONNECTED;
 	unique_id = 0;
 	peers_map.clear();
@@ -69,6 +73,8 @@ void WebSocketMultiplayerPeer::_clear() {
 	}
 
 	incoming_packets.clear();
+
+	emit_signal("closed");
 }
 
 void WebSocketMultiplayerPeer::_bind_methods() {
@@ -491,5 +497,8 @@ void WebSocketMultiplayerPeer::disconnect_peer(int p_peer_id, bool p_force) {
 }
 
 void WebSocketMultiplayerPeer::close() {
+	bool blocking = is_blocking_signals();
+	set_block_signals(true);
 	_clear();
+	set_block_signals(blocking);
 }

--- a/scene/main/multiplayer_peer.cpp
+++ b/scene/main/multiplayer_peer.cpp
@@ -121,6 +121,7 @@ void MultiplayerPeer::_bind_methods() {
 	BIND_ENUM_CONSTANT(TRANSFER_MODE_UNRELIABLE_ORDERED);
 	BIND_ENUM_CONSTANT(TRANSFER_MODE_RELIABLE);
 
+	ADD_SIGNAL(MethodInfo("closed"));
 	ADD_SIGNAL(MethodInfo("peer_connected", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("peer_disconnected", PropertyInfo(Variant::INT, "id")));
 }


### PR DESCRIPTION
Pretty self-explanatory. This is useful because I want to advertise games when creating a server, but I need to know when they are closed so I can stop advertising them. In my case I am bonding multiple types of servers together using another `MultiplayerPeerExtension` I wrote, so checking `multiplayer.multiplayer_peer` is not really helpful. Another use for this is that I want to automatically leave a Steam lobby when the associated peer closes.