### PR TITLE
Fix RichTextLabel scrollbar when too small to show it

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3798,7 +3798,7 @@ _FORCE_INLINE_ float RichTextLabel::_update_scroll_exceeds(float p_total_height,
 	updating_scroll = true;
 
 	float total_height = p_total_height;
-	bool exceeds = p_total_height > p_ctrl_height && scroll_active;
+	bool exceeds = scroll_active && p_total_height > p_ctrl_height && p_width > vscroll->get_combined_minimum_size().width;
 	if (exceeds != scroll_visible) {
 		if (exceeds) {
 			scroll_visible = true;


### PR DESCRIPTION
- Related https://github.com/godotengine/godot/pull/116343

When the RTL is too small to show the scrollbar, it isn't handled well, and the scollbar may be visible or not. When changing the size it flickers.

Before:

https://github.com/user-attachments/assets/016014a0-43f6-4cdf-852e-e8d573cebbf4

After:

https://github.com/user-attachments/assets/0a166f1a-18fc-452b-9a2b-18ac4f7b38d6


It also had issues when in a BoxContainer and it was too small to show, such as the script editor's error text at minimum width. It was escaping the BoxContainer rect.

 Before (depending on the speed you do it, this is if you minimize it slowly):
<img width="166" height="92" alt="Screenshot 2026-02-15 221657" src="https://github.com/user-attachments/assets/f79bbd67-522b-4e27-8332-48f695b6ab85" />

After:
<img width="137" height="101" alt="Screenshot 2026-02-16 185730" src="https://github.com/user-attachments/assets/ba0317c5-4e06-4a1c-8ca6-b665139cc61f" />


Now the scrollbar just doesn't show if too small.
This check prevents `p_width - scroll_w` from being 0 or less which caused issues.