### PR TITLE
Fix GPUParticles2D trails not aligning to velocity

### DIFF
--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -180,8 +180,6 @@ void GPUParticles2D::set_trail_enabled(bool p_enabled) {
 	RS::get_singleton()->particles_set_trails(particles, trail_enabled, trail_lifetime);
 	queue_redraw();
 	update_configuration_warnings();
-
-	RS::get_singleton()->particles_set_transform_align(particles, p_enabled ? RS::PARTICLES_TRANSFORM_ALIGN_Y_TO_VELOCITY : RS::PARTICLES_TRANSFORM_ALIGN_DISABLED);
 }
 
 void GPUParticles2D::set_trail_lifetime(double p_seconds) {


### PR DESCRIPTION
Fixes godotengine/godot#89449

Hello! This is my first contribution to Godot, feedback is welcome. 

### Problem 
When GPUParticles2D trails are used with radial/orbit/directional velocities, the trails don't align to the direction of motion.  

This was caused by the engine forcibly applying `PARTICLES_TRANSFORM_ALIGN_Y_TO_VELOCITY` when trails were enabled, which overwrote the process shader's velocity alignment with an incomplete cached velocity.  As a result, the radial/orbit/directional velocity components were ignored when determining alignment.

### Solution
Remove the forced `PARTICLES_TRANSFORM_ALIGN_Y_TO_VELOCITY` in `GPUParticles2D::set_trail_enabled`.
Trails now respect the process shaders `Align Y` particle flag, making the trail behavior consistent with GPUParticles3D.

### Breaks compatibility
Projects relying on automatic y-alignment for GPUParticles2D trails will need to enable the `Align Y` particle flag on their process shader when previously they didn't.

### Testing
- Verified that 2D trails can now align with particles when they have animated velocities, and that toggling the flag turns alignment on/off for trails.
- Here's how the fix behaves in my minimal repro project https://github.com/heyomidk/godot-minrepo-89449:

![fix-89449](https://github.com/user-attachments/assets/a8c3a61e-770c-4aed-9772-3174af4a8b4d)