### PR TITLE
Clean editor settings when addons are removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -696,6 +696,7 @@ Table of contents:
 - Fix setting remote properties that take objects not working ([GH-107687](https://github.com/godotengine/godot/pull/107687)).
 - Show description for editor setting overrides ([GH-107692](https://github.com/godotengine/godot/pull/107692)).
 - Improve editor settings override display ([GH-107765](https://github.com/godotengine/godot/pull/107765)).
+- Remove leftover editor settings when an addon/plugin is uninstalled or its folder is manually deleted ([GH-116393](https://github.com/godotengine/godot/issues/116393)).
 - Simplify Node Filter's placeholder in Scene dock ([GH-107942](https://github.com/godotengine/godot/pull/107942)).
 - Replace Inspector `pending` stack usage with loop ([GH-107947](https://github.com/godotengine/godot/pull/107947)).
 - Clean up numeric EditorProperty `setup()` methods ([GH-108065](https://github.com/godotengine/godot/pull/108065)).

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1207,6 +1207,15 @@ void EditorNode::_remove_plugin_from_enabled(const String &p_name) {
 		}
 	}
 	ps->set("editor_plugins/enabled", enabled_plugins);
+
+	// When a plugin is removed from the list (usually because its folder no
+	// longer exists or it failed to load) also wipe out any editor settings that
+	// were created by that addon. We derive the group prefix from the directory
+	// name, which matches the common convention used by most plugins.
+	String plugin_folder = p_name.get_base_dir().get_file();
+	if (!plugin_folder.is_empty()) {
+		EditorSettings::get_singleton()->erase_group(plugin_folder);
+	}
 }
 
 void EditorNode::_plugin_over_edit(EditorPlugin *p_plugin, Object *p_object) {
@@ -4337,6 +4346,13 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled,
 	if (!DirAccess::exists(addon_path.get_base_dir())) {
 		_remove_plugin_from_enabled(addon_path);
 		WARN_PRINT("Addon '" + addon_path + "' failed to load. No directory found. Removing from enabled plugins.");
+		// If the addon has been deleted from disk we also need to purge any
+		// editor settings left behind by it so that stray options don't remain
+		// visible when opening Editor Settings (see #116393).
+		String plugin_folder = addon_path.get_base_dir().get_file();
+		if (!plugin_folder.is_empty()) {
+			EditorSettings::get_singleton()->erase_group(plugin_folder);
+		}
 		return;
 	}
 	Error err = cf->load(addon_path);

--- a/editor/plugins/editor_plugin_settings.cpp
+++ b/editor/plugins/editor_plugin_settings.cpp
@@ -75,6 +75,31 @@ void EditorPluginSettings::update_plugins() {
 	Vector<String> plugins = _get_plugins("res://addons");
 	plugins.sort();
 
+	// Clean up any plugins that were enabled but whose config no longer exists
+	// on disk. This can happen if the user deletes the addon folder while the
+	// editor is running. Removing the entry here ensures editor settings
+	// introduced by the plugin are also erased (see #116393).
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	if (ps->has_setting("editor_plugins/enabled")) {
+		PackedStringArray enabled = ps->get("editor_plugins/enabled");
+		bool changed = false;
+		for (int i = enabled.size() - 1; i >= 0; i--) {
+			String path = enabled.get(i);
+			if (!plugins.has(path)) {
+				// plugin no longer present on disk, drop it and wipe its settings
+				enabled.remove_at(i);
+				String prefix = path.get_base_dir().get_file();
+				if (!prefix.is_empty()) {
+					EditorSettings::get_singleton()->erase_group(prefix);
+				}
+				changed = true;
+			}
+		}
+		if (changed) {
+			ps->set("editor_plugins/enabled", enabled);
+		}
+	}
+
 	for (int i = 0; i < plugins.size(); i++) {
 		Ref<ConfigFile> cfg;
 		cfg.instantiate();

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1470,6 +1470,39 @@ void EditorSettings::erase(const String &p_setting) {
 	props.erase(p_setting);
 }
 
+void EditorSettings::erase_group(const String &p_group) {
+	// Remove any settings whose name begins with the given prefix (either exactly
+	// matching the prefix or followed by a '/'). This is used by the editor when an
+	// addon/plugin is uninstalled so that its custom settings and shortcuts don't
+	// linger in the global editor settings.
+	_THREAD_SAFE_METHOD_
+
+	String prefix = p_group;
+	if (!prefix.ends_with("/")) {
+		prefix += "/";
+	}
+
+	Vector<String> to_erase;
+	// Gather keys to erase first to avoid modifying the map while iterating.
+	for (const KeyValue<String, VariantContainer> &kv : props) {
+		const String &name = kv.key;
+		if (name == p_group || name.begins_with(prefix)) {
+			to_erase.push_back(name);
+		}
+	}
+
+	for (const String &name : to_erase) {
+		props.erase(name);
+		hints.erase(name);
+		shortcuts.erase(name);
+		builtin_action_overrides.erase(name);
+	}
+
+	if (!to_erase.empty()) {
+		emit_signal(SNAME("settings_changed"));
+	}
+}
+
 void EditorSettings::raise_order(const String &p_setting) {
 	_THREAD_SAFE_METHOD_
 
@@ -2266,6 +2299,7 @@ void EditorSettings::get_argument_options(const StringName &p_function, int p_id
 void EditorSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_setting", "name"), &EditorSettings::has_setting);
 	ClassDB::bind_method(D_METHOD("set_setting", "name", "value"), &EditorSettings::set_setting);
+	ClassDB::bind_method(D_METHOD("erase_group", "prefix"), &EditorSettings::erase_group);
 	ClassDB::bind_method(D_METHOD("get_setting", "name"), &EditorSettings::get_setting);
 	ClassDB::bind_method(D_METHOD("erase", "property"), &EditorSettings::erase);
 	ClassDB::bind_method(D_METHOD("set_initial_value", "name", "value", "update_current"), &EditorSettings::set_initial_value);

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -154,6 +154,7 @@ public:
 	Variant get_setting(const String &p_setting) const;
 	bool has_setting(const String &p_setting) const;
 	void erase(const String &p_setting);
+	void erase_group(const String &p_group);
 	void raise_order(const String &p_setting);
 	void set_initial_value(const StringName &p_setting, const Variant &p_value, bool p_update_current = false);
 	void set_restart_if_changed(const StringName &p_setting, bool p_restart);

--- a/tests/test_editor_settings.cpp
+++ b/tests/test_editor_settings.cpp
@@ -1,0 +1,67 @@
+#include "core/io/project_settings.h"
+#include "editor/settings/editor_settings.h"
+#include "editor/editor_node.h"
+#include "core/input/shortcut.h"
+#include "core/string/translation.h"
+
+// This file contains a few basic unit tests for the new `erase_group`
+// functionality added in PR-116393.  The tests are tagged with `[Editor]`
+// so that the editor environment (paths/settings) is automatically
+// initialized by the test harness.
+
+TEST_CASE("[Editor][Settings] erase_group removes settings and shortcuts") {
+	EditorSettings *es = EditorSettings::get_singleton();
+	REQUIRE(es != nullptr);
+
+	// Prepare a couple of settings that would normally be created by a
+	// plugin using its folder name as prefix.
+	es->set_setting("myplugin/option", 42);
+	Ref<Shortcut> sc;
+	sc.instantiate();
+	es->add_shortcut("myplugin/action", sc);
+
+	REQUIRE(es->has_setting("myplugin/option"));
+	REQUIRE(!es->get_shortcut("myplugin/action").is_null());
+
+	// Erasing the "myplugin" group should wipe both the normal setting and
+	// the shortcut.
+	es->erase_group("myplugin");
+
+	CHECK(!es->has_setting("myplugin/option"));
+	CHECK(es->get_shortcut("myplugin/action").is_null());
+}
+
+TEST_CASE("[Editor][Settings] _remove_plugin_from_enabled triggers cleanup") {
+	EditorSettings *es = EditorSettings::get_singleton();
+	REQUIRE(es != nullptr);
+
+	// Create a dummy editor node so we can call the private method. The
+	// constructor is heavy but safe in the test environment because
+	// `Engine::set_editor_hint(true)` has already been called by the harness.
+	auto *node = memnew(EditorNode);
+
+	// Simulate some leftover settings from an addon that has been deleted on
+	// disk.  The cleanup code should remove them when the addon is dropped from
+	// the enabled list.
+	es->set_setting("removed/one", 2);
+	REQUIRE(es->has_setting("removed/one"));
+
+	node->_remove_plugin_from_enabled("res://addons/removed/plugin.cfg");
+
+	CHECK(!es->has_setting("removed/one"));
+
+	memdelete(node);
+}
+
+TEST_CASE("[Editor][Settings] update_plugins drops missing enabled addons") {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	PackedStringArray enabled;
+	enabled.push_back("res://addons/nonexistent/plugin.cfg");
+	ps->set("editor_plugins/enabled", enabled);
+
+	EditorPluginSettings eps;
+	eps.update_plugins();
+
+	PackedStringArray new_enabled = ps->get("editor_plugins/enabled");
+	CHECK(!new_enabled.has("res://addons/nonexistent/plugin.cfg"));
+}


### PR DESCRIPTION
\n- Add EditorSettings::erase_group API\n- Automatically purge settings when plugin folder disappears\n- Cleanup stale enabled addons in update_plugins\n- Add unit tests for new behavior\n- Update changelog

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
