### PR TITLE
LSP: Document editor settings

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1292,6 +1292,33 @@
 			The port number to use to contact the HTTP and HTTPS proxy in the editor (for the asset library and export template downloads). See also [member network/http_proxy/host].
 			[b]Note:[/b] Godot currently doesn't automatically use system proxy settings, so you have to enter them manually here if needed.
 		</member>
+		<member name="network/language_server/enable_smart_resolve" type="bool" setter="" getter="">
+			If [code]true[/code] the language server will try to provide additional results when resolving symbols at the cost of showing wrong results. All symbols in the project are checked and resolved just based on their name, without taking context into account.
+			[codeblock]
+			func untyped(param):
+				param.print() # Will resolve to the global print method for e.g. hover hints.
+			[/codeblock]
+			When using static typing it is recommended to disable this setting, since it will mostly add false positives for typed code.
+			[b]Note:[/b] This setting also influences how symbols are resolved when using renaming capabilities.
+			[b]Note:[/b] The default value of this setting might change in future versions.
+		</member>
+		<member name="network/language_server/poll_limit_usec" type="int" setter="" getter="">
+			The upper limit of time, that the language server spends for IO each poll.
+		</member>
+		<member name="network/language_server/remote_host" type="String" setter="" getter="">
+			The host used to listen for language server clients.
+		</member>
+		<member name="network/language_server/remote_port" type="int" setter="" getter="">
+			The port used to listen for language server clients.
+			[b]Note:[/b] A port configured with command-line options will take priority over this setting: [code]--lsp-port &lt;port&gt;[/code].
+		</member>
+		<member name="network/language_server/show_native_symbols_in_editor" type="bool" setter="" getter="">
+			The declaration of native symbols can't be resolved to a position in the file system. If [code]true[/code] the language server will instead open the documentation for native symbols in the editor.
+			[b]Note:[/b] The VSCode plugin adds additional functionality which allows viewing Godot documentation directly in VSCode, so this option is usually not needed in VSCode.
+		</member>
+		<member name="network/language_server/use_thread" type="bool" setter="" getter="">
+			If [code]true[/code] the language server will run in a separate thread, if [code]false[/code] it will run on the main thread.
+		</member>
 		<member name="network/tls/editor_tls_certificates" type="String" setter="" getter="">
 			The TLS certificate bundle to use for HTTP requests made within the editor (e.g. from the AssetLib tab). If left empty, the [url=https://github.com/godotengine/godot/blob/master/thirdparty/certs/ca-bundle.crt]included Mozilla certificate bundle[/url] will be used.
 		</member>

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1101,6 +1101,14 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("network/debug/remote_host", "127.0.0.1"); // Hints provided in setup_network
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "network/debug/remote_port", 6007, "1,65535,1")
 
+	/* GDScript Language Server */
+	_initial_set("network/language_server/remote_host", "127.0.0.1"); // Hints provided in setup_network
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "network/language_server/remote_port", 6005, "1,65535,1");
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "network/language_server/enable_smart_resolve", true, String());
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "network/language_server/show_native_symbols_in_editor", false, String());
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "network/language_server/use_thread", false, String());
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_NONE, "network/language_server/poll_limit_usec", 100000, "");
+
 	/* Debugger/profiler */
 
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "debugger/auto_switch_to_remote_scene_tree", false, "")
@@ -1387,8 +1395,10 @@ void EditorSettings::setup_network() {
 
 	// Add hints with valid IP addresses to remote_host property.
 	add_property_hint(PropertyInfo(Variant::STRING, "network/debug/remote_host", PROPERTY_HINT_ENUM, hint));
+	add_property_hint(PropertyInfo(Variant::STRING, "network/language_server/remote_host", PROPERTY_HINT_ENUM, hint));
 	// Fix potentially invalid remote_host due to network change.
 	set("network/debug/remote_host", selected);
+	set("network/language_server/remote_host", selected);
 }
 
 void EditorSettings::save() {

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -38,14 +38,6 @@
 int GDScriptLanguageServer::port_override = -1;
 
 GDScriptLanguageServer::GDScriptLanguageServer() {
-	// TODO: Move to editor_settings.cpp
-	_EDITOR_DEF("network/language_server/remote_host", host);
-	_EDITOR_DEF("network/language_server/remote_port", port);
-	_EDITOR_DEF("network/language_server/enable_smart_resolve", true);
-	_EDITOR_DEF("network/language_server/show_native_symbols_in_editor", false);
-	_EDITOR_DEF("network/language_server/use_thread", use_thread);
-	_EDITOR_DEF("network/language_server/poll_limit_usec", poll_limit_usec);
-
 	set_process_internal(true);
 }
 

--- a/modules/gdscript/language_server/gdscript_language_server.h
+++ b/modules/gdscript/language_server/gdscript_language_server.h
@@ -42,10 +42,13 @@ class GDScriptLanguageServer : public EditorPlugin {
 	// There is no notification when the editor is initialized. We need to poll till we attempted to start the server.
 	bool start_attempted = false;
 	bool started = false;
+
+	// Defaults located in editor_settings.cpp
 	bool use_thread = false;
-	String host = "127.0.0.1";
-	int port = 6005;
-	int poll_limit_usec = 100000;
+	String host;
+	int port = 0;
+	int poll_limit_usec = 0;
+
 	static void thread_main(void *p_userdata);
 
 private:


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/110792

Moves setting registration for LSP into `editor_settings.cpp` so that doctool picks them up and adds some basic documentation for the settings.
