### PR TITLE
Expose `Control.call_gui_input()` (reverted)

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -774,6 +774,16 @@
 				Returns [code]true[/code] if the layout is right-to-left. See also [member layout_direction].
 			</description>
 		</method>
+		<method name="call_gui_input">
+			<return type="void" />
+			<param index="0" name="event" type="InputEvent" />
+			<description>
+				Push a GUI-specific [InputEvent] to this specific [Control] node without affecting focus.
+				This is a low-level method, so it is your responsibility to manage focus using [method grab_focus] and deliver [constant NOTIFICATION_MOUSE_ENTER] and [constant NOTIFICATION_MOUSE_EXIT] noftifications as needed.
+				Make sure to convert [member InputEventMouse.position] to local coordinates using [code]event.global_position * control.get_global_transform_with_canvas()[/code]
+				See [method Viewport.push_input] for the preferred high level way to deliver events to a [Viewport].
+			</description>
+		</method>
 		<method name="release_focus">
 			<return type="void" />
 			<description>

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2166,7 +2166,7 @@ Transform2D Control::get_offset_transform() const {
 
 // Input events.
 
-void Control::_call_gui_input(const Ref<InputEvent> &p_event) {
+void Control::call_gui_input(const Ref<InputEvent> &p_event) {
 	if (p_event->get_device() != InputEvent::DEVICE_ID_INTERNAL) {
 		emit_signal(SceneStringName(gui_input), p_event); // Signal should be first, so it's possible to override an event (and then accept it).
 	}
@@ -4365,6 +4365,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("find_prev_valid_focus"), &Control::find_prev_valid_focus);
 	ClassDB::bind_method(D_METHOD("find_next_valid_focus"), &Control::find_next_valid_focus);
 	ClassDB::bind_method(D_METHOD("find_valid_focus_neighbor", "side"), &Control::find_valid_focus_neighbor);
+	ClassDB::bind_method(D_METHOD("call_gui_input", "event"), &Control::call_gui_input);
 
 	ClassDB::bind_method(D_METHOD("set_h_size_flags", "flags"), &Control::set_h_size_flags);
 	ClassDB::bind_method(D_METHOD("get_h_size_flags"), &Control::get_h_size_flags);

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -364,7 +364,7 @@ private:
 
 	// Input events.
 
-	void _call_gui_input(const Ref<InputEvent> &p_event);
+	void call_gui_input(const Ref<InputEvent> &p_event);
 
 	// Mouse Filter.
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1764,7 +1764,7 @@ void Viewport::_gui_call_input(Control *p_control, const Ref<InputEvent> &p_inpu
 		Control *control = Object::cast_to<Control>(ci);
 		if (control) {
 			if (control->get_mouse_filter_with_override() != Control::MOUSE_FILTER_IGNORE) {
-				control->_call_gui_input(ev);
+				control->call_gui_input(ev);
 			}
 
 			if (!control->is_inside_tree() || control->is_set_as_top_level()) {
@@ -2321,7 +2321,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 		if (gui.key_focus) {
 			if (gui.key_focus->can_process()) {
-				gui.key_focus->_call_gui_input(p_event);
+				gui.key_focus->call_gui_input(p_event);
 			}
 
 			if (is_input_handled()) {
@@ -2777,7 +2777,7 @@ void Viewport::_drop_mouse_focus() {
 			mb->set_button_index(MouseButton(i + 1));
 			mb->set_pressed(false);
 			mb->set_device(InputEvent::DEVICE_ID_INTERNAL);
-			c->_call_gui_input(mb);
+			c->call_gui_input(mb);
 		}
 	}
 }
@@ -2836,7 +2836,7 @@ void Viewport::_post_gui_grab_click_focus() {
 				mb->set_button_index(MouseButton(i + 1));
 				mb->set_pressed(false);
 				mb->set_device(InputEvent::DEVICE_ID_INTERNAL);
-				gui.mouse_focus->_call_gui_input(mb);
+				gui.mouse_focus->call_gui_input(mb);
 			}
 		}
 
@@ -2854,7 +2854,7 @@ void Viewport::_post_gui_grab_click_focus() {
 				mb->set_button_index(MouseButton(i + 1));
 				mb->set_pressed(true);
 				mb->set_device(InputEvent::DEVICE_ID_INTERNAL);
-				callable_mp(gui.mouse_focus, &Control::_call_gui_input).call_deferred(mb);
+				callable_mp(gui.mouse_focus, &Control::call_gui_input).call_deferred(mb);
 			}
 		}
 	}


### PR DESCRIPTION
This allows simulated events to be sent directly to individual controls.

Implementation of godotengine/godot-proposals#14256