### PR TITLE
Minimize include dependencies of `display_server.h`

### DIFF
--- a/drivers/apple_embedded/display_server_apple_embedded.h
+++ b/drivers/apple_embedded/display_server_apple_embedded.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/input/input.h"
 #include "servers/display/display_server.h"
 
 #if defined(RD_ENABLED)
@@ -54,6 +53,9 @@
 
 #import <Foundation/Foundation.h>
 #import <QuartzCore/CAMetalLayer.h>
+
+class InputEvent;
+class NativeMenu;
 
 class DisplayServerAppleEmbedded : public DisplayServer {
 	GDSOFTCLASS(DisplayServerAppleEmbedded, DisplayServer);

--- a/drivers/apple_embedded/display_server_apple_embedded.mm
+++ b/drivers/apple_embedded/display_server_apple_embedded.mm
@@ -40,7 +40,9 @@
 #import "tts_apple_embedded.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 #include "core/io/file_access_pack.h"
+#include "servers/display/native_menu.h"
 
 #import <GameController/GameController.h>
 

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -32,6 +32,7 @@
 
 #include "core/templates/hash_map.h"
 #include "core/templates/paged_allocator.h"
+#include "core/templates/rb_map.h"
 #include "drivers/vulkan/rendering_context_driver_vulkan.h"
 #include "drivers/vulkan/rendering_shader_container_vulkan.h"
 #include "servers/rendering/rendering_device_driver.h"

--- a/editor/animation/animation_bezier_editor.h
+++ b/editor/animation/animation_bezier_editor.h
@@ -30,8 +30,10 @@
 
 #pragma once
 
-#include "animation_track_editor.h"
 #include "core/templates/hashfuncs.h"
+#include "core/templates/rb_map.h"
+#include "core/templates/rb_set.h"
+#include "editor/animation/animation_track_editor.h"
 
 class ViewPanner;
 

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
+#include "core/templates/rb_set.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/rb_map.h"
 #include "editor/editor_data.h"
 #include "editor/inspector/editor_properties.h"
 #include "editor/inspector/property_selector.h"

--- a/editor/doc/editor_help_search.h
+++ b/editor/doc/editor_help_search.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/rb_set.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/option_button.h"

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -33,6 +33,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/json.h"
 #include "core/io/zip_io.h"
+#include "core/templates/rb_set.h"
 #include "core/version.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/rb_set.h"
 #include "editor/export/editor_export_preset.h"
 #include "scene/gui/dialogs.h"
 

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -31,6 +31,7 @@
 #include "editor_import_collada.h"
 
 #include "core/config/project_settings.h"
+#include "core/templates/rb_set.h"
 #include "editor/import/3d/collada.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/importer_mesh_instance_3d.h"

--- a/editor/scene/3d/multimesh_editor_plugin.cpp
+++ b/editor/scene/3d/multimesh_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "multimesh_editor_plugin.h"
 
+#include "core/templates/rb_map.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"

--- a/editor/scene/gui/theme_editor_plugin.h
+++ b/editor/scene/gui/theme_editor_plugin.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/rb_map.h"
 #include "editor/docks/editor_dock.h"
 #include "editor/plugins/editor_plugin.h"
 #include "editor/scene/gui/theme_editor_preview.h"

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -44,6 +44,7 @@
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "core/string/translation_server.h"
+#include "core/templates/rb_set.h"
 #include "core/version.h"
 #include "editor/editor_node.h"
 #include "editor/file_system/editor_paths.h"

--- a/modules/navigation_2d/2d/nav_mesh_queries_2d.cpp
+++ b/modules/navigation_2d/2d/nav_mesh_queries_2d.cpp
@@ -36,6 +36,7 @@
 #include "nav_region_iteration_2d.h"
 
 #include "core/math/geometry_2d.h"
+#include "core/templates/rb_map.h"
 
 using namespace Nav2D;
 

--- a/modules/navigation_3d/3d/nav_mesh_queries_3d.cpp
+++ b/modules/navigation_3d/3d/nav_mesh_queries_3d.cpp
@@ -34,8 +34,8 @@
 #include "../nav_map_3d.h"
 #include "nav_region_iteration_3d.h"
 
-#include "core/math/geometry_2d.h"
 #include "core/math/geometry_3d.h"
+#include "core/templates/rb_map.h"
 
 using namespace Nav3D;
 

--- a/modules/webxr/webxr_interface_js.h
+++ b/modules/webxr/webxr_interface_js.h
@@ -32,9 +32,11 @@
 
 #ifdef WEB_ENABLED
 
+#include "webxr_interface.h"
+
+#include "core/templates/rb_map.h"
 #include "servers/xr/xr_controller_tracker.h"
 #include "servers/xr/xr_hand_tracker.h"
-#include "webxr_interface.h"
 
 /**
 	The WebXR interface is a VR/AR interface that can be used on the web.

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -37,6 +37,8 @@
 
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
+#include "core/input/input_event.h"
+#include "servers/display/native_menu.h"
 
 #if defined(RD_ENABLED)
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -30,8 +30,10 @@
 
 #pragma once
 
-#include "core/input/input_event.h"
 #include "servers/display/display_server.h"
+
+class InputEvent;
+class NativeMenu;
 
 #if defined(RD_ENABLED)
 class RenderingContextDriver;

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -39,17 +39,26 @@
 #define DEBUG_LOG_WAYLAND(...)
 #endif
 
+#include "core/config/project_settings.h"
 #include "core/input/input.h"
+#include "core/input/input_event.h"
 #include "core/os/main_loop.h"
+#include "servers/display/native_menu.h"
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 
+#ifdef RD_ENABLED
 #ifdef VULKAN_ENABLED
+#include "wayland/rendering_context_driver_vulkan_wayland.h"
+#endif
+
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
 #endif
 
 #ifdef GLES3_ENABLED
-#include "core/io/file_access.h"
 #include "detect_prime_egl.h"
+
+#include "core/io/file_access.h"
+#include "drivers/egl/egl_manager.h"
 #include "drivers/gles3/rasterizer_gles3.h"
 #include "wayland/egl_manager_wayland.h"
 #include "wayland/egl_manager_wayland_gles.h"
@@ -60,11 +69,19 @@
 #endif
 
 #ifdef DBUS_ENABLED
+#include "freedesktop_at_spi_monitor.h"
+#include "freedesktop_portal_desktop.h"
+#include "freedesktop_screensaver.h"
+
 #ifdef SOWRAP_ENABLED
 #include "dbus-so_wrap.h"
 #else
 #include <dbus/dbus.h>
 #endif
+#endif
+
+#ifdef SPEECHD_ENABLED
+#include "tts_linux.h"
 #endif
 
 #define WAYLAND_MAX_FRAME_TIME_US (1'000'000)

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -34,38 +34,29 @@
 
 #include "wayland/wayland_thread.h"
 
+#include "servers/display/display_server.h"
+
+class InputEvent;
+class NativeMenu;
+
 #ifdef RD_ENABLED
 class RenderingDevice;
-
-#ifdef VULKAN_ENABLED
-#include "wayland/rendering_context_driver_vulkan_wayland.h"
+class RenderingContextDriver;
 #endif
-
-#endif //RD_ENABLED
 
 #ifdef GLES3_ENABLED
-#include "drivers/egl/egl_manager.h"
-#endif
-
-#if defined(SPEECHD_ENABLED)
-#include "tts_linux.h"
+class EGLManager;
 #endif
 
 #ifdef DBUS_ENABLED
-#include "freedesktop_at_spi_monitor.h"
-#include "freedesktop_portal_desktop.h"
-#include "freedesktop_screensaver.h"
+class FreeDesktopPortalDesktop;
+class FreeDesktopAtSPIMonitor;
+class FreeDesktopScreenSaver;
 #endif
 
-#include "core/config/project_settings.h"
-#include "core/input/input_event.h"
-#include "core/templates/rb_map.h"
-#include "servers/display/display_server.h"
-
-#include <climits>
-#include <cstdio>
-
-#undef CursorShape
+#ifdef SPEECHD_ENABLED
+class TTS_Linux;
+#endif
 
 class DisplayServerWayland : public DisplayServer {
 	GDSOFTCLASS(DisplayServerWayland, DisplayServer);

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -32,7 +32,6 @@
 
 #ifdef X11_ENABLED
 
-#include "x11/detect_prime_x11.h"
 #include "x11/key_mapping_x11.h"
 
 #include "core/config/project_settings.h"
@@ -42,17 +41,42 @@
 #include "core/os/main_loop.h"
 #include "core/string/print_string.h"
 #include "core/string/ustring.h"
-#include "core/version.h"
 #include "drivers/png/png_driver_common.h"
+#include "drivers/unix/os_unix.h"
 #include "main/main.h"
-
+#include "servers/display/native_menu.h"
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 
-#if defined(VULKAN_ENABLED)
+#include <X11/Xatom.h>
+
+#ifdef SOWRAP_ENABLED
+#include "x11/dynwrappers/xext-so_wrap.h"
+#include "x11/dynwrappers/xinerama-so_wrap.h"
+#include "x11/dynwrappers/xrender-so_wrap.h"
+#else // !SOWRAP_ENABLED
+#undef CursorShape
+#include <X11/XKBlib.h>
+#include <X11/Xutil.h>
+
+#include <X11/extensions/Xext.h>
+#include <X11/extensions/Xinerama.h>
+#include <X11/extensions/Xrender.h>
+#include <X11/extensions/shape.h>
+#endif
+
+#ifdef RD_ENABLED
+#ifdef VULKAN_ENABLED
+#include "x11/rendering_context_driver_vulkan_x11.h"
+#endif
+
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
 #endif
 
-#if defined(GLES3_ENABLED)
+#ifdef GLES3_ENABLED
+#include "x11/detect_prime_x11.h"
+#include "x11/gl_manager_x11.h"
+#include "x11/gl_manager_x11_egl.h"
+
 #include "drivers/gles3/rasterizer_gles3.h"
 #endif
 
@@ -61,6 +85,10 @@
 #endif
 
 #ifdef DBUS_ENABLED
+#include "freedesktop_at_spi_monitor.h"
+#include "freedesktop_portal_desktop.h"
+#include "freedesktop_screensaver.h"
+
 #ifdef SOWRAP_ENABLED
 #include "dbus-so_wrap.h"
 #else
@@ -68,16 +96,17 @@
 #endif
 #endif
 
-#include <dlfcn.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <climits>
-#include <cstdio>
-#include <cstdlib>
+#ifdef SPEECHD_ENABLED
+#include "tts_linux.h"
+#endif
 
-#undef CursorShape
-#include <X11/XKBlib.h>
+#include <dlfcn.h> // dlopen
+//#include <sys/stat.h>
+//#include <sys/types.h>
+//#include <unistd.h>
+#include <climits> // LONG_MAX
+#include <cstdio> // stderr
+#include <cstdlib> // getenv
 
 // ICCCM
 #define WM_NormalState 1L // window normal state

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -32,76 +32,59 @@
 
 #ifdef X11_ENABLED
 
-#include "core/input/input_event.h"
+#include "core/input/input_enums.h"
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
 #include "core/templates/local_vector.h"
-#include "core/templates/rb_map.h"
-#include "drivers/alsa/audio_driver_alsa.h"
-#include "drivers/alsamidi/midi_driver_alsamidi.h"
-#include "drivers/pulseaudio/audio_driver_pulseaudio.h"
-#include "drivers/unix/os_unix.h"
-#include "servers/audio/audio_server.h"
 #include "servers/display/display_server.h"
-#include "servers/rendering/renderer_compositor.h"
-#include "servers/rendering/rendering_server.h"
-
-#if defined(SPEECHD_ENABLED)
-#include "tts_linux.h"
-#endif
-
-#if defined(GLES3_ENABLED)
-#include "x11/gl_manager_x11.h"
-#include "x11/gl_manager_x11_egl.h"
-#endif
-
-#if defined(RD_ENABLED)
-
-#if defined(VULKAN_ENABLED)
-#include "x11/rendering_context_driver_vulkan_x11.h"
-#endif
-#endif
-
-#if defined(DBUS_ENABLED)
-#include "freedesktop_at_spi_monitor.h"
-#include "freedesktop_portal_desktop.h"
-#include "freedesktop_screensaver.h"
-#endif
-
-#include <X11/Xatom.h>
-#include <X11/Xlib.h>
-#include <X11/Xutil.h>
-#include <X11/keysym.h>
 
 #ifdef SOWRAP_ENABLED
 #include "x11/dynwrappers/xlib-so_wrap.h"
 
 #include "x11/dynwrappers/xcursor-so_wrap.h"
-#include "x11/dynwrappers/xext-so_wrap.h"
-#include "x11/dynwrappers/xinerama-so_wrap.h"
 #include "x11/dynwrappers/xinput2-so_wrap.h"
 #include "x11/dynwrappers/xrandr-so_wrap.h"
-#include "x11/dynwrappers/xrender-so_wrap.h"
 
+#ifdef XKB_ENABLED
 #include "xkbcommon-so_wrap.h"
-#else
-#include <X11/XKBlib.h>
+#endif
+#else // !SOWRAP_ENABLED
 #include <X11/Xlib.h>
-#include <X11/Xutil.h>
 
 #include <X11/Xcursor/Xcursor.h>
 #include <X11/extensions/XInput2.h>
-#include <X11/extensions/Xext.h>
-#include <X11/extensions/Xinerama.h>
 #include <X11/extensions/Xrandr.h>
-#include <X11/extensions/Xrender.h>
-#include <X11/extensions/shape.h>
 
 #ifdef XKB_ENABLED
 #include <xkbcommon/xkbcommon-compose.h>
-#include <xkbcommon/xkbcommon-keysyms.h>
 #include <xkbcommon/xkbcommon.h>
 #endif
+#endif
+
+#undef CursorShape // Xlib macro conflicting with our type.
+
+class InputEvent;
+class InputEventWithModifiers;
+class NativeMenu;
+
+#ifdef RD_ENABLED
+class RenderingDevice;
+class RenderingContextDriver;
+#endif
+
+#ifdef GLES3_ENABLED
+class GLManager_X11;
+class GLManagerEGL_X11;
+#endif
+
+#ifdef DBUS_ENABLED
+class FreeDesktopPortalDesktop;
+class FreeDesktopAtSPIMonitor;
+class FreeDesktopScreenSaver;
+#endif
+
+#ifdef SPEECHD_ENABLED
+class TTS_Linux;
 #endif
 
 typedef struct _xrr_monitor_info {
@@ -117,8 +100,6 @@ typedef struct _xrr_monitor_info {
 	int mheight = 0;
 	RROutput *outputs = nullptr;
 } xrr_monitor_info;
-
-#undef CursorShape
 
 class DisplayServerX11 : public DisplayServer {
 	GDSOFTCLASS(DisplayServerX11, DisplayServer);

--- a/platform/macos/display_server_embedded.h
+++ b/platform/macos/display_server_embedded.h
@@ -34,7 +34,9 @@
 
 @class CAContext;
 @class CALayer;
+class InputEvent;
 class GLManagerEmbedded;
+class NativeMenu;
 class RenderingContextDriver;
 class RenderingDevice;
 

--- a/platform/macos/display_server_embedded.mm
+++ b/platform/macos/display_server_embedded.mm
@@ -54,8 +54,11 @@
 
 #import "core/config/project_settings.h"
 #import "core/debugger/engine_debugger.h"
+#import "core/input/input.h"
+#import "core/input/input_event.h"
 #import "core/io/marshalls.h"
 #import "core/os/main_loop.h"
+#import "servers/display/native_menu.h"
 
 DisplayServerEmbedded::DisplayServerEmbedded(const String &p_rendering_driver, WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, Error &r_error) {
 	EmbeddedDebugger::initialize(this);

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -37,8 +37,6 @@
 #include "gl_manager_macos_legacy.h"
 #endif // GLES3_ENABLED
 
-#import "native_menu_macos.h"
-
 #if defined(RD_ENABLED)
 #include "servers/rendering/rendering_device.h"
 
@@ -77,6 +75,10 @@
 #ifdef TOOLS_ENABLED
 class EmbeddedProcessMacOS;
 #endif
+
+class InputEvent;
+class InputEventWithModifiers;
+class NativeMenuMacOS;
 
 class DisplayServerMacOS : public DisplayServerMacOSBase {
 	GDSOFTCLASS(DisplayServerMacOS, DisplayServerMacOSBase);

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -43,6 +43,7 @@
 #import "godot_window.h"
 #import "godot_window_delegate.h"
 #import "key_mapping_macos.h"
+#import "native_menu_macos.h"
 #import "os_macos.h"
 
 #ifdef TOOLS_ENABLED
@@ -50,6 +51,7 @@
 #endif
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 #include "core/io/file_access.h"
 #include "core/io/marshalls.h"
 #include "core/math/geometry_2d.h"
@@ -58,15 +60,12 @@
 #include "drivers/png/png_driver_common.h"
 #include "main/main.h"
 #include "scene/resources/image_texture.h"
+#include "servers/rendering/dummy/rasterizer_dummy.h"
 
 #ifdef TOOLS_ENABLED
 #import "display_server_embedded.h"
 #import "editor/embedded_process_macos.h"
 #endif
-
-#include <AppKit/AppKit.h>
-
-#include "servers/rendering/dummy/rasterizer_dummy.h"
 
 #if defined(GLES3_ENABLED)
 #include "drivers/gles3/rasterizer_gles3.h"
@@ -81,6 +80,7 @@
 #include "drivers/accesskit/accessibility_driver_accesskit.h"
 #endif
 
+#include <AppKit/AppKit.h>
 #import <Carbon/Carbon.h>
 #import <Cocoa/Cocoa.h>
 #import <IOKit/IOCFPlugIn.h>

--- a/platform/macos/display_server_macos_base.h
+++ b/platform/macos/display_server_macos_base.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/input/input.h"
 #include "servers/display/display_server.h"
 
 #define FontVariation __FontVariation

--- a/platform/macos/embedded_debugger.mm
+++ b/platform/macos/embedded_debugger.mm
@@ -33,6 +33,8 @@
 #include "display_server_embedded.h"
 
 #include "core/debugger/engine_debugger.h"
+#include "core/input/input.h"
+#include "core/input/input_event.h"
 #include "core/input/input_event_codec.h"
 #include "core/os/main_loop.h"
 

--- a/platform/macos/embedded_gl_manager.h
+++ b/platform/macos/embedded_gl_manager.h
@@ -32,8 +32,7 @@
 
 #if defined(MACOS_ENABLED) && defined(GLES3_ENABLED)
 
-#include "core/os/os.h"
-#include "core/templates/local_vector.h"
+#include "core/templates/rb_map.h"
 #include "servers/display/display_server.h"
 
 #import <AppKit/AppKit.h>

--- a/platform/macos/gl_manager_macos_legacy.h
+++ b/platform/macos/gl_manager_macos_legacy.h
@@ -32,8 +32,7 @@
 
 #if defined(MACOS_ENABLED) && defined(GLES3_ENABLED)
 
-#include "core/os/os.h"
-#include "core/templates/local_vector.h"
+#include "core/templates/rb_map.h"
 #include "servers/display/display_server.h"
 
 #import <AppKit/AppKit.h>

--- a/platform/macos/godot_application_delegate.mm
+++ b/platform/macos/godot_application_delegate.mm
@@ -36,6 +36,8 @@
 #import "native_menu_macos.h"
 #import "os_macos.h"
 
+#import "core/input/input.h"
+#import "core/input/input_event.h"
 #import "core/os/main_loop.h"
 #import "main/main.h"
 

--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -34,6 +34,9 @@
 #import "godot_window.h"
 #import "key_mapping_macos.h"
 
+#include "core/input/input.h"
+#include "core/input/input_event.h"
+#include "core/os/keyboard.h"
 #include "core/profiling/profiling.h"
 #include "main/main.h"
 

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -36,8 +36,10 @@
 
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
+#include "core/input/input_event.h"
 #include "core/object/callable_method_pointer.h"
 #include "core/os/main_loop.h"
+#include "servers/display/native_menu.h"
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 
 #ifdef GLES3_ENABLED

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -30,12 +30,18 @@
 
 #pragma once
 
+#include "core/input/input_enums.h"
+#include "core/os/keyboard.h"
 #include "servers/display/display_server.h"
 
 #include "godot_js.h"
 
 #include <emscripten.h>
 #include <emscripten/html5.h>
+
+class InputEvent;
+class InputEventWithModifiers;
+class NativeMenu;
 
 class DisplayServerWeb : public DisplayServer {
 	GDSOFTCLASS(DisplayServerWeb, DisplayServer);

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -31,8 +31,8 @@
 #include "display_server_windows.h"
 
 #include "drop_target_windows.h"
+#include "native_menu_windows.h"
 #include "os_windows.h"
-#include "scene/main/window.h"
 #include "wgl_detect_version.h"
 
 #include "core/config/project_settings.h"
@@ -44,13 +44,13 @@
 #include "core/version.h"
 #include "drivers/png/png_driver_common.h"
 #include "main/main.h"
+#include "scene/main/window.h"
 #include "scene/resources/texture.h"
+#include "servers/rendering/dummy/rasterizer_dummy.h"
 
 #ifdef SDL_ENABLED
 #include "drivers/sdl/joypad_sdl.h"
 #endif
-
-#include "servers/rendering/dummy/rasterizer_dummy.h"
 
 #if defined(VULKAN_ENABLED)
 #include "rendering_context_driver_vulkan_windows.h"

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -60,8 +60,6 @@
 #include "gl_manager_windows_native.h"
 #endif // GLES3_ENABLED
 
-#include "native_menu_windows.h"
-
 #include <io.h>
 #include <cstdio>
 
@@ -192,6 +190,7 @@ typedef struct {
 } ICONDIR, *LPICONDIR;
 
 class DropTargetWindows;
+class NativeMenuWindows;
 
 #ifndef WDA_EXCLUDEFROMCAPTURE
 #define WDA_EXCLUDEFROMCAPTURE 0x00000011

--- a/platform/windows/gl_manager_windows_native.h
+++ b/platform/windows/gl_manager_windows_native.h
@@ -34,6 +34,7 @@
 
 #include "core/os/os.h"
 #include "core/templates/local_vector.h"
+#include "core/templates/rb_map.h"
 #include "servers/display/display_server.h"
 
 #include <windows.h>

--- a/scene/2d/physics/collision_object_2d.h
+++ b/scene/2d/physics/collision_object_2d.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/rb_map.h"
 #include "scene/2d/node_2d.h"
 #include "scene/main/viewport.h"
 #include "scene/resources/2d/shape_2d.h"

--- a/scene/3d/physics/collision_object_3d.h
+++ b/scene/3d/physics/collision_object_3d.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/rb_map.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/node_3d.h"
 #include "scene/resources/3d/shape_3d.h"

--- a/scene/debugger/runtime_node_select.cpp
+++ b/scene/debugger/runtime_node_select.cpp
@@ -36,6 +36,7 @@
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/input/input.h"
+#include "core/input/input_event.h"
 #include "core/math/geometry_3d.h"
 #include "scene/2d/camera_2d.h"
 #include "scene/debugger/scene_debugger_object.h"

--- a/scene/debugger/runtime_node_select.h
+++ b/scene/debugger/runtime_node_select.h
@@ -37,6 +37,9 @@
 #include "scene/resources/mesh.h"
 #endif // _3D_DISABLED
 
+class InputEvent;
+class InputEventMouseMotion;
+class InputEventWithModifiers;
 class Node;
 class PopupMenu;
 

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -30,6 +30,7 @@
 
 #include "grid_container.h"
 
+#include "core/templates/rb_map.h"
 #include "core/templates/rb_set.h"
 #include "scene/theme/theme_db.h"
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -35,6 +35,7 @@
 #include "scene/gui/scroll_container.h"
 #include "scene/property_list_helper.h"
 #include "scene/resources/text_line.h"
+#include "servers/display/native_menu.h"
 
 class PanelContainer;
 class Timer;

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -33,6 +33,7 @@
 #include "core/io/resource.h"
 #include "core/object/object.h"
 #include "core/templates/local_vector.h"
+#include "core/templates/rb_map.h"
 #include "core/templates/rb_set.h"
 #include "scene/2d/light_occluder_2d.h"
 #include "scene/main/canvas_item.h"

--- a/scene/resources/particle_process_material.h
+++ b/scene/resources/particle_process_material.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/rb_set.h"
 #include "core/templates/rid.h"
 #include "core/templates/self_list.h"
 #include "scene/resources/curve_texture.h"

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/string/string_builder.h"
+#include "core/templates/rb_map.h"
 #include "core/templates/safe_refcount.h"
 #include "scene/gui/control.h"
 #include "scene/resources/shader.h"

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -32,10 +32,15 @@
 #include "display_server.compat.inc"
 
 STATIC_ASSERT_INCOMPLETE_TYPE(class, Input);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, NativeMenu);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Texture2D);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 
 #include "core/input/input.h"
 #include "scene/resources/texture.h"
 #include "servers/display/display_server_headless.h"
+#include "servers/display/native_menu.h"
+#include "servers/rendering/rendering_server.h"
 
 #if defined(RD_ENABLED)
 #include "servers/rendering/rendering_device.h"
@@ -43,7 +48,6 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, Input);
 
 #if defined(VULKAN_ENABLED)
 #include "drivers/vulkan/rendering_context_driver_vulkan.h"
-#undef CursorShape
 #endif
 #if defined(D3D12_ENABLED)
 #include "drivers/d3d12/rendering_context_driver_d3d12.h"

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -30,18 +30,17 @@
 
 #pragma once
 
-#include "core/input/input_event.h"
 #include "core/io/image.h"
 #include "core/io/resource.h"
+#include "core/object/object.h"
+#include "core/os/keyboard.h"
 #include "core/os/os.h"
-#include "core/templates/rb_map.h"
-#include "core/templates/rb_set.h"
 #include "core/variant/callable.h"
 #include "core/variant/typed_array.h"
-#include "servers/display/native_menu.h"
 
-class Texture2D;
 class AccessibilityDriver;
+class NativeMenu;
+class Texture2D;
 
 namespace InputClassEnums {
 enum MouseMode : int;

--- a/servers/display/display_server_headless.h
+++ b/servers/display/display_server_headless.h
@@ -30,10 +30,10 @@
 
 #pragma once
 
-#include "core/input/input.h"
 #include "servers/display/display_server.h"
 
-#include "servers/rendering/dummy/rasterizer_dummy.h"
+class InputEvent;
+class NativeMenu;
 
 class DisplayServerHeadless : public DisplayServer {
 	GDSOFTCLASS(DisplayServerHeadless, DisplayServer);
@@ -47,21 +47,10 @@ private:
 		return drivers;
 	}
 
-	static DisplayServer *create_func(const String &p_rendering_driver, DisplayServer::WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error) {
-		r_error = OK;
-		RasterizerDummy::make_current();
-		return memnew(DisplayServerHeadless());
-	}
+	static DisplayServer *create_func(const String &p_rendering_driver, DisplayServer::WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error);
 
-	static void _dispatch_input_events(const Ref<InputEvent> &p_event) {
-		static_cast<DisplayServerHeadless *>(get_singleton())->_dispatch_input_event(p_event);
-	}
-
-	void _dispatch_input_event(const Ref<InputEvent> &p_event) {
-		if (input_event_callback.is_valid()) {
-			input_event_callback.call(p_event);
-		}
-	}
+	static void _dispatch_input_events(const Ref<InputEvent> &p_event);
+	void _dispatch_input_event(const Ref<InputEvent> &p_event);
 
 	NativeMenu *native_menu = nullptr;
 	Callable input_event_callback;
@@ -156,9 +145,7 @@ public:
 
 	int64_t window_get_native_handle(HandleType p_handle_type, WindowID p_window = MAIN_WINDOW_ID) const override { return 0; }
 
-	void process_events() override {
-		Input::get_singleton()->flush_buffered_events();
-	}
+	void process_events() override;
 
 	void set_native_icon(const String &p_filename) override {}
 	void set_icon(const Ref<Image> &p_icon) override {}
@@ -200,15 +187,6 @@ public:
 	void status_indicator_set_callback(IndicatorID p_id, const Callable &p_callback) override {}
 	void delete_status_indicator(IndicatorID p_id) override {}
 
-	DisplayServerHeadless() {
-		native_menu = memnew(NativeMenu);
-		Input::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
-	}
-
-	~DisplayServerHeadless() {
-		if (native_menu) {
-			memdelete(native_menu);
-			native_menu = nullptr;
-		}
-	}
+	DisplayServerHeadless();
+	~DisplayServerHeadless();
 };

--- a/servers/display/native_menu.cpp
+++ b/servers/display/native_menu.cpp
@@ -30,7 +30,7 @@
 
 #include "native_menu.h"
 
-#include "scene/resources/image_texture.h"
+#include "scene/resources/texture.h"
 
 NativeMenu *NativeMenu::singleton = nullptr;
 

--- a/servers/display/native_menu.h
+++ b/servers/display/native_menu.h
@@ -30,8 +30,9 @@
 
 #pragma once
 
-#include "core/input/input_event.h"
-#include "core/templates/rb_map.h"
+#include "core/object/class_db.h"
+#include "core/object/object.h"
+#include "core/os/keyboard.h"
 #include "core/variant/callable.h"
 
 class Texture2D;

--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -29,9 +29,11 @@
 /**************************************************************************/
 
 #include "movie_writer.h"
+
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/os/time.h"
+#include "core/templates/rb_set.h"
 #include "scene/main/window.h"
 #include "servers/audio/audio_driver_dummy.h"
 #include "servers/display/display_server.h"

--- a/servers/rendering/rendering_device_graph.h
+++ b/servers/rendering/rendering_device_graph.h
@@ -34,6 +34,10 @@
 #include "rendering_device_commons.h"
 #include "rendering_device_driver.h"
 
+#ifdef DEV_ENABLED
+#include "core/templates/rb_map.h"
+#endif
+
 // Buffer barriers have not shown any significant improvement or shown to be
 // even detrimental to performance. However, there are currently some known
 // cases where using them can solve problems that using singular memory

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -32,10 +32,11 @@
 
 #include "core/os/os.h"
 #include "core/templates/local_vector.h"
+#include "core/templates/rb_set.h"
 #include "servers/rendering/renderer_compositor.h"
 #include "servers/rendering/rendering_server.h"
 #include "servers/rendering/rendering_server_globals.h"
-#include "shader_types.h"
+#include "servers/rendering/shader_types.h"
 
 #define HAS_WARNING(flag) (warning_flags & flag)
 

--- a/tests/display_server_mock.h
+++ b/tests/display_server_mock.h
@@ -32,8 +32,6 @@
 
 #include "servers/display/display_server_headless.h"
 
-#include "servers/rendering/dummy/rasterizer_dummy.h"
-
 // Specialized DisplayServer for unittests based on DisplayServerHeadless, that
 // additionally supports things like mouse enter/exit events and clipboard.
 class DisplayServerMock : public DisplayServerHeadless {
@@ -56,11 +54,7 @@ private:
 		return drivers;
 	}
 
-	static DisplayServer *create_func(const String &p_rendering_driver, DisplayServer::WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error) {
-		r_error = OK;
-		RasterizerDummy::make_current();
-		return memnew(DisplayServerMock());
-	}
+	static DisplayServer *create_func(const String &p_rendering_driver, DisplayServer::WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error);
 
 	void _set_mouse_position(const Point2i &p_position) {
 		if (mouse_position == p_position) {
@@ -105,19 +99,7 @@ public:
 	// The events will be delivered to Godot's Input-system.
 	// Mouse-events (Button & Motion) will additionally update the DisplayServer's mouse position.
 	// For Mouse motion events, the `relative`-property is set based on the distance to the previous mouse position.
-	void simulate_event(Ref<InputEvent> p_event) {
-		Ref<InputEvent> event = p_event;
-		Ref<InputEventMouse> me = p_event;
-		if (me.is_valid()) {
-			Ref<InputEventMouseMotion> mm = p_event;
-			if (mm.is_valid()) {
-				mm->set_relative(mm->get_position() - mouse_position);
-				event = mm;
-			}
-			_set_mouse_position(me->get_position());
-		}
-		Input::get_singleton()->parse_input_event(event);
-	}
+	void simulate_event(Ref<InputEvent> p_event);
 
 	// Returns the current cursor shape.
 	CursorShape get_cursor_shape() {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -31,6 +31,7 @@
 #include "test_main.h"
 
 #include "core/error/error_macros.h"
+#include "core/input/input.h"
 #include "core/io/dir_access.h"
 #include "modules/modules_enabled.gen.h"
 


### PR DESCRIPTION
- Helps address #111218. `display_server.h` is one of the biggest contributor to slow build times, so reducing its direct dependencies should help a bit. The real gains will come from reducing its reverse dependencies, i.e. files which include `display_server.h` (oftentimes only for `DisplayServer::WindowID` which is a prime candidate for moving to a separate `display_server_enums.h` file).

Changes:

- Removes `native_menu.h` dependency from `display_server.h`. It's now forward-declared in all DisplayServer implementations and should be included in the .cpp's.
  * I did it for X11/Wayland, together with a thorough cleanup to move as much as possible to the .cpp. Will have to check the other platforms before this is mergeable.
  * *Edit:* Done for other platforms with minimal changes.
- Removes some unused `rb_set.h` and `rb_map.h` dependencies, which leads to having to include them explicitly in half the scene and editor codebase... which shows how much we depend on `display_server.h`.
- Replaces `input_event.h` with a forward-declare, so now we need only `keyboard.h`.