### PR TITLE
Fix GPUParticles3D aligning to imperceptible velocities

### DIFF
--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -1152,7 +1152,7 @@ void ParticleProcessMaterial::_update_shader() {
 
 	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 		if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
-			code += "	if (length(final_velocity) > 0.0) {\n";
+			code += "	if (length(final_velocity) > 0.00001) {\n";
 			code += "		TRANSFORM[1].xyz = normalize(final_velocity);\n";
 			code += "	} else {\n";
 			code += "		TRANSFORM[1].xyz = normalize(TRANSFORM[1].xyz);\n";
@@ -1168,7 +1168,7 @@ void ParticleProcessMaterial::_update_shader() {
 		//TODO Fix so 0 scaling on all axes doesn't break during normalization
 		// Orient particle Y towards velocity.
 		if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
-			code += "	if (length(final_velocity) > 0.0) {\n";
+			code += "	if (length(final_velocity) > 0.00001) {\n";
 			code += "		TRANSFORM[1].xyz = normalize_or_else(final_velocity, vec3(0.0, 1.0, 0.0));\n";
 			code += "	} else {\n";
 			code += "		TRANSFORM[1].xyz = normalize_or_else(TRANSFORM[1].xyz, vec3(0.0, 1.0, 0.0));\n";


### PR DESCRIPTION
Fixes #95715, by altering the requirement of `PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY` to not trigger on imperceptible movements.

The rotation is caused by the `PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY` flag. It rotates the particle in the direction of its current velocity. It applies this based on if velocity is larger than 0.0

When the particles appear stationary micro adjustments actually occur to keep their movement in the direction of the collision normal 0. These adjustment are small but not perfectly zero. This then triggers the Align to velocity portion of the particle code.

The other solution would be to clamp velocity back to 0.0 but I believe this would cause the same issue that #87320 tried to solve.

Before:

https://github.com/user-attachments/assets/f4b14819-5fcd-44d4-a883-aa84482f61e2

After:

https://github.com/user-attachments/assets/8dd6a121-0afb-4c1a-b2fe-389b41f8276f


[godot-particle-shimmer-mrp.zip](https://github.com/user-attachments/files/26164123/godot-particle-shimmer-mrp.zip)
