### PR TITLE
Fix `ShaderEditor`'s UI overflowing when shrunk

### DIFF
--- a/editor/shader/shader_editor.h
+++ b/editor/shader/shader_editor.h
@@ -30,14 +30,14 @@
 
 #pragma once
 
-#include "scene/gui/control.h"
+#include "scene/gui/margin_container.h"
 #include "scene/resources/shader.h"
 
 class Button;
 class MenuButton;
 
-class ShaderEditor : public Control {
-	GDCLASS(ShaderEditor, Control);
+class ShaderEditor : public MarginContainer {
+	GDCLASS(ShaderEditor, MarginContainer);
 
 public:
 	virtual void edit_shader(const Ref<Shader> &p_shader) = 0;

--- a/editor/shader/text_shader_editor.h
+++ b/editor/shader/text_shader_editor.h
@@ -208,7 +208,5 @@ public:
 	void tag_saved_version();
 	ShaderTextEditor *get_code_editor() { return code_editor; }
 
-	virtual Size2 get_minimum_size() const override { return Size2(0, 200); }
-
 	TextShaderEditor();
 };

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -2564,10 +2564,6 @@ void VisualShaderEditor::_set_mode(int p_which) {
 	set_current_shader_type((VisualShader::Type)saved_type);
 }
 
-Size2 VisualShaderEditor::get_minimum_size() const {
-	return Size2(10, 200);
-}
-
 void VisualShaderEditor::update_toggle_files_button() {
 	ERR_FAIL_NULL(toggle_files_list);
 	bool forward = toggle_files_list->is_visible() == is_layout_rtl();

--- a/editor/shader/visual_shader_editor_plugin.h
+++ b/editor/shader/visual_shader_editor_plugin.h
@@ -684,7 +684,6 @@ public:
 	Dictionary get_custom_node_data(Ref<VisualShaderNodeCustom> &p_custom_node);
 	void update_custom_type(const Ref<Resource> &p_resource);
 
-	virtual Size2 get_minimum_size() const override;
 	virtual void update_toggle_files_button() override;
 
 	Ref<VisualShader> get_visual_shader() const { return visual_shader; }


### PR DESCRIPTION
Fully fixes #116278.