### PR TITLE
Fixes for completion of shader preprocessor defines

### DIFF
--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -440,9 +440,6 @@ void ShaderTextEditor::_code_complete_script(const String &p_code, List<ScriptLa
 		}
 		return;
 	}
-	for (const ScriptLanguage::CodeCompletionOption &E : pp_defines) {
-		r_options->push_back(E);
-	}
 
 	ShaderLanguage sl;
 	String calltip;
@@ -453,6 +450,12 @@ void ShaderTextEditor::_code_complete_script(const String &p_code, List<ScriptLa
 		comp_info.is_include = true;
 
 		sl.complete(code, comp_info, r_options, calltip);
+		if (sl.get_completion_type() == ShaderLanguage::COMPLETION_IDENTIFIER) {
+			for (const ScriptLanguage::CodeCompletionOption &E : pp_defines) {
+				r_options->push_back(E);
+			}
+		}
+
 		get_text_editor()->set_code_hint(calltip);
 		return;
 	}
@@ -463,6 +466,12 @@ void ShaderTextEditor::_code_complete_script(const String &p_code, List<ScriptLa
 	comp_info.shader_types = ShaderTypes::get_singleton()->get_types();
 
 	sl.complete(code, comp_info, r_options, calltip);
+	if (sl.get_completion_type() == ShaderLanguage::COMPLETION_IDENTIFIER) {
+		for (const ScriptLanguage::CodeCompletionOption &E : pp_defines) {
+			r_options->push_back(E);
+		}
+	}
+
 	get_text_editor()->set_code_hint(calltip);
 }
 

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -1275,6 +1275,7 @@ public:
 
 	String get_error_text();
 	Vector<FilePosition> get_include_positions();
+	CompletionType get_completion_type() const { return completion_type; }
 	int get_error_line();
 
 	ShaderNode *get_shader();

--- a/servers/rendering/shader_preprocessor.h
+++ b/servers/rendering/shader_preprocessor.h
@@ -161,6 +161,7 @@ private:
 		bool disabled = false;
 		CompletionType completion_type = COMPLETION_TYPE_NONE;
 		HashSet<Ref<ShaderInclude>> shader_includes;
+		bool completion_show_defines = false;
 	};
 
 private:


### PR DESCRIPTION
This will fix a regular nuisance with completion for vectors, structs and other indexed objects:

Before:

<details>
<summary>Details</summary>

<img width="954" height="811" alt="изображение" src="https://github.com/user-attachments/assets/dc798ff5-ab3c-4f39-a587-07f6959e73b3" />

</details>

After:

<details>
<summary>Details</summary>

<img width="571" height="748" alt="изображение" src="https://github.com/user-attachments/assets/2da363c2-bed1-407d-894f-c06e81858d06" />


</details>

Also supersedes https://github.com/godotengine/godot/pull/99060