### PR TITLE
Add auto translate mode for `Window` title

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -778,6 +778,10 @@
 		<member name="title" type="String" setter="set_title" getter="get_title" default="&quot;&quot;">
 			The window's title. If the [Window] is native, title styles set in [Theme] will have no effect.
 		</member>
+		<member name="title_auto_translate_mode" type="int" setter="set_title_auto_translate_mode" getter="get_title_auto_translate_mode" enum="Window.TitleAutoTranslateMode" default="0">
+			Defines if the window title should automatically change to its translated version depending on the current locale.
+			[b]Note:[/b] For the root node, the auto translate mode can also be set via [member ProjectSettings.internationalization/rendering/root_node_auto_translate].
+		</member>
 		<member name="transient" type="bool" setter="set_transient" getter="is_transient" default="false">
 			If [code]true[/code], the [Window] is transient, i.e. it's considered a child of another [Window]. The transient window will be destroyed with its transient parent and will return focus to their parent when closed. The transient window is displayed on top of a non-exclusive full-screen parent window. Transient windows can't enter full-screen mode.
 			Note that behavior might be different depending on the platform.
@@ -1059,6 +1063,16 @@
 		</constant>
 		<constant name="WINDOW_INITIAL_POSITION_CENTER_SCREEN_WITH_KEYBOARD_FOCUS" value="5" enum="WindowInitialPosition">
 			Initial window position is the center of the screen containing the window with the keyboard focus.
+		</constant>
+		<constant name="TITLE_AUTO_TRANSLATE_MODE_INHERIT" value="0" enum="TitleAutoTranslateMode">
+			Inherits [member Node.auto_translate_mode] from the node. This is the default for any newly created node.
+		</constant>
+		<constant name="TITLE_AUTO_TRANSLATE_MODE_ALWAYS" value="1" enum="TitleAutoTranslateMode">
+			Always automatically translate. This is the inverse of [constant TITLE_AUTO_TRANSLATE_MODE_DISABLED], and the default for the root node.
+		</constant>
+		<constant name="TITLE_AUTO_TRANSLATE_MODE_DISABLED" value="2" enum="TitleAutoTranslateMode">
+			Never automatically translate. This is the inverse of [constant TITLE_AUTO_TRANSLATE_MODE_ALWAYS].
+			String parsing for translation template generation will be skipped for this node.
 		</constant>
 	</constants>
 	<theme_items>

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -3731,6 +3731,8 @@ Window::Window() {
 		max_size_used = max_size; // Update max_size_used.
 	}
 
+	title_auto_translate_mode = TITLE_AUTO_TRANSLATE_MODE_INHERIT;
+
 	theme_owner = memnew(ThemeOwner(this));
 	RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RSE::VIEWPORT_UPDATE_DISABLED);
 }

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -3222,6 +3222,21 @@ bool Window::is_auto_translating() const {
 }
 #endif
 
+void Window::set_title_auto_translate_mode(TitleAutoTranslateMode p_mode) {
+	ERR_MAIN_THREAD_GUARD;
+	if (title_auto_translate_mode == p_mode) {
+		return;
+	}
+
+	title_auto_translate_mode = p_mode;
+
+	propagate_notification(NOTIFICATION_TRANSLATION_CHANGED);
+}
+
+Window::TitleAutoTranslateMode Window::get_title_auto_translate_mode() const {
+	return title_auto_translate_mode;
+}
+
 Transform2D Window::get_final_transform() const {
 	ERR_READ_THREAD_GUARD_V(Transform2D());
 	return window_transform * stretch_transform * global_canvas_transform;
@@ -3316,7 +3331,13 @@ void Window::_mouse_leave_viewport() {
 }
 
 void Window::_update_displayed_title() {
-	displayed_title = atr(title);
+	if (get_title_auto_translate_mode() == TITLE_AUTO_TRANSLATE_MODE_INHERIT) {
+		displayed_title = atr(title);
+	} else if (get_title_auto_translate_mode() == TITLE_AUTO_TRANSLATE_MODE_ALWAYS) {
+		displayed_title = tr(title);
+	} else {
+		displayed_title = title;
+	}
 
 #ifdef DEBUG_ENABLED
 	if (window_id == DisplayServerEnums::MAIN_WINDOW_ID && !Engine::get_singleton()->is_project_manager_hint()) {
@@ -3529,6 +3550,8 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_font_oversampling", "enable"), &Window::set_use_font_oversampling);
 	ClassDB::bind_method(D_METHOD("is_using_font_oversampling"), &Window::is_using_font_oversampling);
 #endif
+	ClassDB::bind_method(D_METHOD("set_title_auto_translate_mode", "mode"), &Window::set_title_auto_translate_mode);
+	ClassDB::bind_method(D_METHOD("get_title_auto_translate_mode"), &Window::get_title_auto_translate_mode);
 
 	ClassDB::bind_method(D_METHOD("popup", "rect"), &Window::popup, DEFVAL(Rect2i()));
 	ClassDB::bind_method(D_METHOD("popup_on_parent", "parent_rect"), &Window::popup_on_parent);
@@ -3555,6 +3578,8 @@ void Window::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2I, "nonclient_area", PROPERTY_HINT_NONE, ""), "set_nonclient_area", "get_nonclient_area");
 
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "mouse_passthrough_polygon"), "set_mouse_passthrough_polygon", "get_mouse_passthrough_polygon");
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "title_auto_translate_mode", PROPERTY_HINT_ENUM, "Inherit,Always,Disabled"), "set_title_auto_translate_mode", "get_title_auto_translate_mode");
 
 	ADD_GROUP("Flags", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "visible"), "set_visible", "is_visible");
@@ -3674,6 +3699,10 @@ void Window::_bind_methods() {
 	BIND_ENUM_CONSTANT(WINDOW_INITIAL_POSITION_CENTER_OTHER_SCREEN);
 	BIND_ENUM_CONSTANT(WINDOW_INITIAL_POSITION_CENTER_SCREEN_WITH_MOUSE_FOCUS);
 	BIND_ENUM_CONSTANT(WINDOW_INITIAL_POSITION_CENTER_SCREEN_WITH_KEYBOARD_FOCUS);
+
+	BIND_ENUM_CONSTANT(TITLE_AUTO_TRANSLATE_MODE_INHERIT);
+	BIND_ENUM_CONSTANT(TITLE_AUTO_TRANSLATE_MODE_ALWAYS);
+	BIND_ENUM_CONSTANT(TITLE_AUTO_TRANSLATE_MODE_DISABLED);
 
 	GDVIRTUAL_BIND(_get_contents_minimum_size);
 

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -114,6 +114,12 @@ public:
 		WINDOW_INITIAL_POSITION_CENTER_SCREEN_WITH_KEYBOARD_FOCUS,
 	};
 
+	enum TitleAutoTranslateMode : unsigned int {
+		TITLE_AUTO_TRANSLATE_MODE_INHERIT,
+		TITLE_AUTO_TRANSLATE_MODE_ALWAYS,
+		TITLE_AUTO_TRANSLATE_MODE_DISABLED,
+	};
+
 private:
 	DisplayServerEnums::WindowID window_id = DisplayServerEnums::INVALID_WINDOW_ID;
 	bool initialized = false;
@@ -263,6 +269,8 @@ private:
 	void _update_displayed_title();
 
 	static int root_layout_direction;
+
+	TitleAutoTranslateMode title_auto_translate_mode : 2;
 
 protected:
 	virtual void _popup_base(const Rect2i &p_screen_rect = Rect2i());
@@ -471,6 +479,9 @@ public:
 	bool is_auto_translating() const;
 #endif
 
+	void set_title_auto_translate_mode(TitleAutoTranslateMode p_mode);
+	TitleAutoTranslateMode get_title_auto_translate_mode() const;
+
 	// Theming.
 
 	void set_theme_owner_node(Node *p_node);
@@ -555,3 +566,4 @@ VARIANT_ENUM_CAST(Window::ContentScaleAspect);
 VARIANT_ENUM_CAST(Window::ContentScaleStretch);
 VARIANT_ENUM_CAST(Window::LayoutDirection);
 VARIANT_ENUM_CAST(Window::WindowInitialPosition);
+VARIANT_ENUM_CAST(Window::TitleAutoTranslateMode);


### PR DESCRIPTION
Fixes godotengine/godot-proposals#13726

Implement `Window.TitleAutoTranslateMode` enum
Implement `Window.title_auto_translate_mode` member
When it's `Inherit`, it will be determined by `auto_translate_mode`
And when in other modes, it will act as their names

<img width="971" height="349" alt="image" src="https://github.com/user-attachments/assets/d6bedd63-08fa-4139-b54e-27fe1aaa78d0" />

Project for test: [windowtitleautotranslatetest.zip](https://github.com/user-attachments/files/25460095/windowtitleautotranslatetest.zip)