### PR TITLE
Core: Add non-finite checks to Transform3D::interpolate_with() and Basis::get_quaternion()

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -713,6 +713,7 @@ Basis::operator String() const {
 
 Quaternion Basis::get_quaternion() const {
 #ifdef MATH_CHECKS
+	ERR_FAIL_COND_V_MSG(!is_finite(), Quaternion(), "The Basis is not finite, contains NaN or INF.");
 	ERR_FAIL_COND_V_MSG(!is_rotation(), Quaternion(), "Basis " + operator String() + " must be normalized in order to be casted to a Quaternion. Use get_rotation_quaternion() or call orthonormalized() if the Basis contains linearly independent vectors.");
 #endif
 	/* Allow getting a quaternion from an unnormalized transform */

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -713,7 +713,7 @@ Basis::operator String() const {
 
 Quaternion Basis::get_quaternion() const {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_V_MSG(!is_finite(), Quaternion(), "The Basis is not finite, contains NaN or INF.");
+	ERR_FAIL_COND_V_MSG(!is_finite(), Quaternion(), "Basis " + operator String() + " is not finite, contains NaN or INF.");
 	ERR_FAIL_COND_V_MSG(!is_rotation(), Quaternion(), "Basis " + operator String() + " must be normalized in order to be casted to a Quaternion. Use get_rotation_quaternion() or call orthonormalized() if the Basis contains linearly independent vectors.");
 #endif
 	/* Allow getting a quaternion from an unnormalized transform */

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -97,7 +97,6 @@ Transform3D Transform3D::interpolate_with(const Transform3D &p_transform, real_t
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!is_finite(), Transform3D(), "The starting transform is not finite, contains NaN or INF.");
 	ERR_FAIL_COND_V_MSG(!p_transform.is_finite(), Transform3D(), "The destination transform is not finite, contains NaN or INF.");
-	ERR_FAIL_COND_V_MSG(!Math::is_finite(p_c), Transform3D(), "The interpolation weight is not finite, contains NaN or INF.");
 #endif
 	Transform3D interp;
 

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -94,6 +94,11 @@ void Transform3D::set_look_at(const Vector3 &p_eye, const Vector3 &p_target, con
 }
 
 Transform3D Transform3D::interpolate_with(const Transform3D &p_transform, real_t p_c) const {
+#ifdef MATH_CHECKS
+	ERR_FAIL_COND_V_MSG(!is_finite(), Transform3D(), "The starting transform is not finite, contains NaN or INF.");
+	ERR_FAIL_COND_V_MSG(!p_transform.is_finite(), Transform3D(), "The destination transform is not finite, contains NaN or INF.");
+	ERR_FAIL_COND_V_MSG(!Math::is_finite(p_c), Transform3D(), "The interpolation weight is not finite, contains NaN or INF.");
+#endif
 	Transform3D interp;
 
 	Vector3 src_scale = basis.get_scale();


### PR DESCRIPTION
### Summary of changes
Added `is_finite()` checks to `Transform3D::interpolate_with()` and `Basis::get_quaternion()` to provide clearer error reporting for non-finite values (NaN/INF).

### Motivation
Fixes #73299. The current error message "Basis must be normalized in order to be casted to a Quaternion" confused developers on what the actual cause is for the error in cases where the transforms or weight were not finite. This change helps developers identify the root cause faster.

### Technical overview
* **Transform3D**: Added checks for the starting transform, destination transform, and interpolation weight. This ensures the function fails early with a specific message before performing math with NaN or INF values.
* **Basis**: Added a check to `get_quaternion()` to catch non-finite bases. This prevents the code from reaching the `is_rotation()` check, which was the source of the confusing "not normalized" error reported in the issue.

### Testing
Tested using the reproduction script provided in issue #73299.

**Result:** The console now provides a stack trace specific to the non-finite values, rather than a generic normalization error.

```text
E 0:00:00:886   character_body_3d.gd:27 @ _ready(): The starting transform is not finite, contains NaN or INF.
  <C++ Error>   Condition "!is_finite()" is true. Returning: Transform3D()
  <C++ Source>  core\math\transform_3d.cpp:98 @ Transform3D::interpolate_with()
  <Stack Trace> character_body_3d.gd:27 @ _ready()

E 0:00:00:893   Basis::get_quaternion: The Basis is not finite, contains NaN or INF.
  <C++ Error>   Condition "!is_finite()" is true. Returning: Quaternion()
  <C++ Source>  core\math\basis.cpp:716 @ Basis::get_quaternion()