### PR TITLE
Implement multi-layer projection camera

### DIFF
--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -162,6 +162,118 @@ Projection Projection::create_fit_aabb(const AABB &p_aabb) {
 	return proj;
 }
 
+Projection Projection::create_combined_projection(const Transform3D &p_center, const Projection &p_projection_a, const Transform3D &p_offset_a, const Projection &p_projection_b, const Transform3D &p_offset_b) {
+	Vector<Plane> planes[2];
+	Projection proj;
+
+	/////////////////////////////////////////////////////////////////////////////
+	// Get some basic information
+
+	// 1. obtain our planes
+	planes[0] = p_projection_a.get_projection_planes(p_offset_a);
+	planes[1] = p_projection_b.get_projection_planes(p_offset_b);
+
+	// 2. Intersect horizon, left and right to obtain the combined camera origin.
+	Plane horizon(Vector3(0.0, 1.0, 0.0), Vector3());
+	Vector3 origin;
+	ERR_FAIL_COND_V_MSG(
+			!horizon.intersect_3(planes[0][Projection::PLANE_LEFT], planes[1][Projection::PLANE_RIGHT], &origin), proj, "Can't determine camera origin");
+
+	// 3. figure out our near and far plane, this could use some improvement, we may have our far plane too close like this, not sure if this matters
+	Vector3 near_center = (planes[0][Projection::PLANE_NEAR].get_center() + planes[1][Projection::PLANE_NEAR].get_center()) * 0.5;
+	Plane near_plane = Plane(Vector3(0.0, 0.0, -1.0), near_center);
+	Vector3 far_center = (planes[0][Projection::PLANE_FAR].get_center() + planes[1][Projection::PLANE_FAR].get_center()) * 0.5;
+	Plane far_plane = Plane(Vector3(0.0, 0.0, -1.0), far_center);
+
+	/////////////////////////////////////////////////////////////////////////////
+	// Figure out our top/bottom planes
+
+	// 4. Intersect far and left planes with top planes from both eyes, save the point with highest y as top_left.
+	Vector3 top_left, other;
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[0][Projection::PLANE_LEFT], planes[0][Projection::PLANE_TOP], &top_left), proj, "Can't determine left camera far/left/top vector");
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[1][Projection::PLANE_LEFT], planes[1][Projection::PLANE_TOP], &other), proj, "Can't determine right camera far/left/top vector");
+	if (top_left.y < other.y) {
+		top_left = other;
+	}
+
+	// 5. Intersect far and left planes with bottom planes from both eyes, save the point with lowest y as bottom_left.
+	Vector3 bottom_left;
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[0][Projection::PLANE_LEFT], planes[0][Projection::PLANE_BOTTOM], &bottom_left), proj, "Can't determine left camera far/left/bottom vector");
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[1][Projection::PLANE_LEFT], planes[1][Projection::PLANE_BOTTOM], &other), proj, "Can't determine right camera far/left/bottom vector");
+	if (other.y < bottom_left.y) {
+		bottom_left = other;
+	}
+
+	// 6. Intersect far and right planes with top planes from both eyes, save the point with highest y as top_right.
+	Vector3 top_right;
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[0][Projection::PLANE_RIGHT], planes[0][Projection::PLANE_TOP], &top_right), proj, "Can't determine left camera far/right/top vector");
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[1][Projection::PLANE_RIGHT], planes[1][Projection::PLANE_TOP], &other), proj, "Can't determine right camera far/right/top vector");
+	if (top_right.y < other.y) {
+		top_right = other;
+	}
+
+	//  7. Intersect far and right planes with bottom planes from both eyes, save the point with lowest y as bottom_right.
+	Vector3 bottom_right;
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[0][Projection::PLANE_RIGHT], planes[0][Projection::PLANE_BOTTOM], &bottom_right), proj, "Can't determine left camera far/right/bottom vector");
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[1][Projection::PLANE_RIGHT], planes[1][Projection::PLANE_BOTTOM], &other), proj, "Can't determine right camera far/right/bottom vector");
+	if (other.y < bottom_right.y) {
+		bottom_right = other;
+	}
+
+	// 8. Create top plane with these points: camera origin, top_left, top_right
+	Plane top(origin, top_left, top_right);
+
+	// 9. Create bottom plane with these points: camera origin, bottom_left, bottom_right
+	Plane bottom(origin, bottom_left, bottom_right);
+
+	/////////////////////////////////////////////////////////////////////////////
+	// Figure out our near plane points
+
+	// 10. Intersect near plane with bottm/left planes, to obtain min_vec then top/right to obtain max_vec
+	Vector3 min_vec;
+	ERR_FAIL_COND_V_MSG(
+			!near_plane.intersect_3(bottom, planes[0][Projection::PLANE_LEFT], &min_vec), proj, "Can't determine left camera near/left/bottom vector");
+	ERR_FAIL_COND_V_MSG(
+			!near_plane.intersect_3(bottom, planes[1][Projection::PLANE_LEFT], &other), proj, "Can't determine right camera near/left/bottom vector");
+	if (other.x < min_vec.x) {
+		min_vec = other;
+	}
+
+	Vector3 max_vec;
+	ERR_FAIL_COND_V_MSG(
+			!near_plane.intersect_3(top, planes[0][Projection::PLANE_RIGHT], &max_vec), proj, "Can't determine left camera near/right/top vector");
+	ERR_FAIL_COND_V_MSG(
+			!near_plane.intersect_3(top, planes[1][Projection::PLANE_RIGHT], &other), proj, "Can't determine right camera near/right/top vector");
+	if (max_vec.x < other.x) {
+		max_vec = other;
+	}
+
+	// 11. get x and y from these to obtain left, top, right bottom for the frustum. Get the distance from near plane to camera origin to obtain near, and the distance from the far plane to the camera origin to obtain far.
+	float z_near = -near_plane.distance_to(origin);
+	float z_far = -far_plane.distance_to(origin);
+
+	// Safeguard our near and far values
+	z_near = MAX(z_near, origin.z + 0.01);
+	z_far = MAX(z_far, z_near + 1.0);
+
+	// 12. Use this to build the combined camera matrix.
+	proj.set_frustum(min_vec.x, max_vec.x, min_vec.y, max_vec.y, z_near, z_far);
+
+	// 13. Add in offset to origin
+	Transform3D main_offset(Basis(), -origin);
+	proj = proj * Projection(main_offset);
+
+	return proj;
+}
+
 Projection Projection::perspective_znear_adjusted(real_t p_new_znear) const {
 	Projection proj = *this;
 	proj.adjust_perspective_znear(p_new_znear);
@@ -874,6 +986,17 @@ bool Projection::is_orthogonal() const {
 	// NOTE: This assumes that the matrix is a projection across z-axis
 	// i.e. is invertible and columns[0][1], [0][3], [1][0] and [1][3] == 0
 	return columns[2][3] == 0.0;
+}
+
+bool Projection::is_asymmetrical() const {
+	// NOTE: This assumes that the matrix is a projection across z-axis
+	// i.e. is invertible and columns[0][1], [0][3], [1][0] and [1][3] == 0
+	return columns[2][0] != 0.0 || columns[2][1] != 0.0;
+}
+
+bool Projection::is_z_axis_projection() const {
+	// These need to all be zero for this to be a projection along the z-axis.
+	return columns[0][1] == 0.0 && columns[1][0] == 0.0 && columns[0][3] == 0.0 && columns[1][3] == 0.0;
 }
 
 real_t Projection::get_fov() const {

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -162,6 +162,118 @@ Projection Projection::create_fit_aabb(const AABB &p_aabb) {
 	return proj;
 }
 
+Projection Projection::create_combined_projection(const Transform3D &p_center, const Projection &p_projection_a, const Transform3D &p_offset_a, const Projection &p_projection_b, const Transform3D &p_offset_b) {
+	Vector<Plane> planes[2];
+	Projection proj;
+
+	/////////////////////////////////////////////////////////////////////////////
+	// Get some basic information
+
+	// 1. obtain our planes
+	planes[0] = p_projection_a.get_projection_planes(p_offset_a);
+	planes[1] = p_projection_b.get_projection_planes(p_offset_b);
+
+	// 2. Intersect horizon, left and right to obtain the combined camera origin.
+	Plane horizon(Vector3(0.0, 1.0, 0.0), Vector3());
+	Vector3 origin;
+	ERR_FAIL_COND_V_MSG(
+			!horizon.intersect_3(planes[0][Projection::PLANE_LEFT], planes[1][Projection::PLANE_RIGHT], &origin), proj, "Can't determine camera origin");
+
+	// 3. figure out our near and far plane, this could use some improvement, we may have our far plane too close like this, not sure if this matters
+	Vector3 near_center = (planes[0][Projection::PLANE_NEAR].get_center() + planes[1][Projection::PLANE_NEAR].get_center()) * 0.5;
+	Plane near_plane = Plane(Vector3(0.0, 0.0, -1.0), near_center);
+	Vector3 far_center = (planes[0][Projection::PLANE_FAR].get_center() + planes[1][Projection::PLANE_FAR].get_center()) * 0.5;
+	Plane far_plane = Plane(Vector3(0.0, 0.0, -1.0), far_center);
+
+	/////////////////////////////////////////////////////////////////////////////
+	// Figure out our top/bottom planes
+
+	// 4. Intersect far and left planes with top planes from both eyes, save the point with highest y as top_left.
+	Vector3 top_left, other;
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[0][Projection::PLANE_LEFT], planes[0][Projection::PLANE_TOP], &top_left), proj, "Can't determine left camera far/left/top vector");
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[1][Projection::PLANE_LEFT], planes[1][Projection::PLANE_TOP], &other), proj, "Can't determine right camera far/left/top vector");
+	if (top_left.y < other.y) {
+		top_left = other;
+	}
+
+	// 5. Intersect far and left planes with bottom planes from both eyes, save the point with lowest y as bottom_left.
+	Vector3 bottom_left;
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[0][Projection::PLANE_LEFT], planes[0][Projection::PLANE_BOTTOM], &bottom_left), proj, "Can't determine left camera far/left/bottom vector");
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[1][Projection::PLANE_LEFT], planes[1][Projection::PLANE_BOTTOM], &other), proj, "Can't determine right camera far/left/bottom vector");
+	if (other.y < bottom_left.y) {
+		bottom_left = other;
+	}
+
+	// 6. Intersect far and right planes with top planes from both eyes, save the point with highest y as top_right.
+	Vector3 top_right;
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[0][Projection::PLANE_RIGHT], planes[0][Projection::PLANE_TOP], &top_right), proj, "Can't determine left camera far/right/top vector");
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[1][Projection::PLANE_RIGHT], planes[1][Projection::PLANE_TOP], &other), proj, "Can't determine right camera far/right/top vector");
+	if (top_right.y < other.y) {
+		top_right = other;
+	}
+
+	//  7. Intersect far and right planes with bottom planes from both eyes, save the point with lowest y as bottom_right.
+	Vector3 bottom_right;
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[0][Projection::PLANE_RIGHT], planes[0][Projection::PLANE_BOTTOM], &bottom_right), proj, "Can't determine left camera far/right/bottom vector");
+	ERR_FAIL_COND_V_MSG(
+			!far_plane.intersect_3(planes[1][Projection::PLANE_RIGHT], planes[1][Projection::PLANE_BOTTOM], &other), proj, "Can't determine right camera far/right/bottom vector");
+	if (other.y < bottom_right.y) {
+		bottom_right = other;
+	}
+
+	// 8. Create top plane with these points: camera origin, top_left, top_right
+	Plane top(origin, top_left, top_right);
+
+	// 9. Create bottom plane with these points: camera origin, bottom_left, bottom_right
+	Plane bottom(origin, bottom_left, bottom_right);
+
+	/////////////////////////////////////////////////////////////////////////////
+	// Figure out our near plane points
+
+	// 10. Intersect near plane with bottm/left planes, to obtain min_vec then top/right to obtain max_vec
+	Vector3 min_vec;
+	ERR_FAIL_COND_V_MSG(
+			!near_plane.intersect_3(bottom, planes[0][Projection::PLANE_LEFT], &min_vec), proj, "Can't determine left camera near/left/bottom vector");
+	ERR_FAIL_COND_V_MSG(
+			!near_plane.intersect_3(bottom, planes[1][Projection::PLANE_LEFT], &other), proj, "Can't determine right camera near/left/bottom vector");
+	if (other.x < min_vec.x) {
+		min_vec = other;
+	}
+
+	Vector3 max_vec;
+	ERR_FAIL_COND_V_MSG(
+			!near_plane.intersect_3(top, planes[0][Projection::PLANE_RIGHT], &max_vec), proj, "Can't determine left camera near/right/top vector");
+	ERR_FAIL_COND_V_MSG(
+			!near_plane.intersect_3(top, planes[1][Projection::PLANE_RIGHT], &other), proj, "Can't determine right camera near/right/top vector");
+	if (max_vec.x < other.x) {
+		max_vec = other;
+	}
+
+	// 11. get x and y from these to obtain left, top, right bottom for the frustum. Get the distance from near plane to camera origin to obtain near, and the distance from the far plane to the camera origin to obtain far.
+	float z_near = -near_plane.distance_to(origin);
+	float z_far = -far_plane.distance_to(origin);
+
+	// Safeguard our near and far values
+	z_near = MAX(z_near, origin.z + 0.01);
+	z_far = MAX(z_far, z_near + 1.0);
+
+	// 12. Use this to build the combined camera matrix.
+	proj.set_frustum(min_vec.x, max_vec.x, min_vec.y, max_vec.y, z_near, z_far);
+
+	// 13. Add in offset to origin
+	Transform3D main_offset(Basis(), -origin);
+	proj = proj * Projection(main_offset);
+
+	return proj;
+}
+
 Projection Projection::perspective_znear_adjusted(real_t p_new_znear) const {
 	Projection proj = *this;
 	proj.adjust_perspective_znear(p_new_znear);

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -95,6 +95,7 @@ struct [[nodiscard]] Projection {
 	static Projection create_frustum(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_near, real_t p_far);
 	static Projection create_frustum_aspect(real_t p_size, real_t p_aspect, Vector2 p_offset, real_t p_near, real_t p_far, bool p_flip_fov = false);
 	static Projection create_fit_aabb(const AABB &p_aabb);
+	static Projection create_combined_projection(const Transform3D &p_center, const Projection &p_projection_a, const Transform3D &p_offset_a, const Projection &p_projection_b, const Transform3D &p_offset_b);
 	Projection perspective_znear_adjusted(real_t p_new_znear) const;
 	Plane get_projection_plane(Planes p_plane) const;
 	Projection flipped_y() const;
@@ -109,6 +110,8 @@ struct [[nodiscard]] Projection {
 	real_t get_aspect() const;
 	real_t get_fov() const;
 	bool is_orthogonal() const;
+	bool is_asymmetrical() const;
+	bool is_z_axis_projection() const;
 
 	Vector<Plane> get_projection_planes(const Transform3D &p_transform) const;
 

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -95,6 +95,7 @@ struct [[nodiscard]] Projection {
 	static Projection create_frustum(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_near, real_t p_far);
 	static Projection create_frustum_aspect(real_t p_size, real_t p_aspect, Vector2 p_offset, real_t p_near, real_t p_far, bool p_flip_fov = false);
 	static Projection create_fit_aabb(const AABB &p_aabb);
+	static Projection create_combined_projection(const Transform3D &p_center, const Projection &p_projection_a, const Transform3D &p_offset_a, const Projection &p_projection_b, const Transform3D &p_offset_b);
 	Projection perspective_znear_adjusted(real_t p_new_znear) const;
 	Plane get_projection_plane(Planes p_plane) const;
 	Projection flipped_y() const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2580,6 +2580,8 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Projection, get_aspect, sarray(), varray());
 	bind_method(Projection, get_fov, sarray(), varray());
 	bind_method(Projection, is_orthogonal, sarray(), varray());
+	bind_method(Projection, is_asymmetrical, sarray(), varray());
+	bind_method(Projection, is_z_axis_projection, sarray(), varray());
 
 	bind_method(Projection, get_viewport_half_extents, sarray(), varray());
 	bind_method(Projection, get_far_plane_half_extents, sarray(), varray());

--- a/doc/classes/Projection.xml
+++ b/doc/classes/Projection.xml
@@ -243,10 +243,22 @@
 				Returns a [Projection] that performs the inverse of this [Projection]'s projective transformation.
 			</description>
 		</method>
+		<method name="is_asymmetrical" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this [Projection] is an asymmetrical projection.
+			</description>
+		</method>
 		<method name="is_orthogonal" qualifiers="const">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if this [Projection] performs an orthogonal projection.
+			</description>
+		</method>
+		<method name="is_z_axis_projection" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this [Projection] is z-axis aligned.
 			</description>
 		</method>
 		<method name="jitter_offseted" qualifiers="const">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -198,6 +198,15 @@
 				If [code]true[/code], preserves the horizontal aspect ratio which is equivalent to [constant Camera3D.KEEP_WIDTH]. If [code]false[/code], preserves the vertical aspect ratio which is equivalent to [constant Camera3D.KEEP_HEIGHT].
 			</description>
 		</method>
+		<method name="camera_set_xr_projections" experimental="">
+			<return type="void" />
+			<param index="0" name="camera" type="RID" />
+			<param index="1" name="projections" type="Projection[]" />
+			<param index="2" name="offsets" type="Transform3D[]" default="[]" />
+			<description>
+				Sets camera to use any set of [param projections]. You can specify one projection for each view set on the viewport. If the views are offset (e.g. ocular distance) and/or skewed, this data can be provided through [param offsets].
+			</description>
+		</method>
 		<method name="canvas_create">
 			<return type="RID" />
 			<description>

--- a/doc/classes/XRCamera3D.xml
+++ b/doc/classes/XRCamera3D.xml
@@ -6,12 +6,15 @@
 	<description>
 		A camera node which automatically positions itself based on XR tracking data.
 		In contrast to [XRController3D], the render thread has access to more up-to-date tracking data, and the location of the [XRCamera3D] node can lag a few milliseconds behind what is used for rendering.
-		[b]Note:[/b] If [member Viewport.use_xr] is [code]true[/code], most of the camera properties are overridden by the active [XRInterface]. The only properties that can be trusted are the near and far planes.
 	</description>
 	<tutorials>
 		<link title="XR documentation index">$DOCS_URL/tutorials/xr/index.html</link>
 	</tutorials>
 	<members>
 		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="2" />
+		<member name="tracker" type="StringName" setter="set_tracker" getter="get_tracker" default="&amp;&quot;head&quot;">
+			The name of the camera tracker we're bound to. Which trackers are available is not known during design time.
+			The default tracker refers to the HMD position of the main player. Consult the documentation of the [XRInterface] for any additional trackers. There may be additional tracked headsets for multiplayer systems or a tracker may be available for a physical camera in a mixed reality scenario.
+		</member>
 	</members>
 </class>

--- a/doc/classes/XRInterface.xml
+++ b/doc/classes/XRInterface.xml
@@ -17,6 +17,23 @@
 				If this is an AR interface that requires displaying a camera feed as the background, this method returns the feed ID in the [CameraServer] for this interface.
 			</description>
 		</method>
+		<method name="get_camera_offsets">
+			<return type="Transform3D[]" />
+			<param index="0" name="tracker_name" type="StringName" />
+			<description>
+				Gets an array of offset transforms for each view for tracker [param tracker_name]. [param tracker_name] must refer to an [XRPositionalTracker] used as a camera. Returns an empty array if this interface is not responsible for this tracker.
+			</description>
+		</method>
+		<method name="get_camera_projections">
+			<return type="Projection[]" />
+			<param index="0" name="tracker_name" type="StringName" />
+			<param index="1" name="aspect" type="float" />
+			<param index="2" name="near" type="float" />
+			<param index="3" name="far" type="float" />
+			<description>
+				Gets an array of projection matrices for each view for tracker [param tracker_name]. [param tracker_name] must refer to an [XRPositionalTracker] used as a camera. Returns an empty array if this interface is not responsible for this tracker.
+			</description>
+		</method>
 		<method name="get_capabilities" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -35,7 +52,7 @@
 				Returns an array of vectors that represent the physical play area mapped to the virtual space around the [XROrigin3D] point. The points form a convex polygon that can be used to react to or visualize the play area. This returns an empty array if this feature is not supported or if the information is not yet available.
 			</description>
 		</method>
-		<method name="get_projection_for_view">
+		<method name="get_projection_for_view" deprecated="Use get_camera_projections">
 			<return type="Projection" />
 			<param index="0" name="view" type="int" />
 			<param index="1" name="aspect" type="float" />
@@ -70,7 +87,7 @@
 				If supported, returns the status of our tracking. This will allow you to provide feedback to the user whether there are issues with positional tracking.
 			</description>
 		</method>
-		<method name="get_transform_for_view">
+		<method name="get_transform_for_view" deprecated="Use get_camera_offsets">
 			<return type="Transform3D" />
 			<param index="0" name="view" type="int" />
 			<param index="1" name="cam_transform" type="Transform3D" />

--- a/doc/classes/XRInterfaceExtension.xml
+++ b/doc/classes/XRInterfaceExtension.xml
@@ -28,6 +28,23 @@
 				Returns the camera feed ID for the [CameraFeed] registered with the [CameraServer] that should be presented as the background on an AR capable device (if applicable).
 			</description>
 		</method>
+		<method name="_get_camera_offsets" qualifiers="virtual">
+			<return type="Transform3D[]" />
+			<param index="0" name="tracker_name" type="StringName" />
+			<description>
+				Gets an array of offset transforms for each view for tracker [param tracker_name]. [param tracker_name] must refer to an [XRPositionalTracker] used as a camera. Returns an empty array if this interface is not responsible for this tracker.
+			</description>
+		</method>
+		<method name="_get_camera_projections" qualifiers="virtual">
+			<return type="Projection[]" />
+			<param index="0" name="tracker_name" type="StringName" />
+			<param index="1" name="aspect" type="float" />
+			<param index="2" name="z_near" type="float" />
+			<param index="3" name="z_far" type="float" />
+			<description>
+				Gets an array of projection matrices for each view for tracker [param tracker_name]. [param tracker_name] must refer to an [XRPositionalTracker] used as a camera. Returns an empty array if this interface is not responsible for this tracker.
+			</description>
+		</method>
 		<method name="_get_camera_transform" qualifiers="virtual">
 			<return type="Transform3D" />
 			<description>
@@ -70,7 +87,7 @@
 				Returns the play area mode that sets up our play area.
 			</description>
 		</method>
-		<method name="_get_projection_for_view" qualifiers="virtual">
+		<method name="_get_projection_for_view" qualifiers="virtual" deprecated="Implement _get_camera_projections">
 			<return type="PackedFloat64Array" />
 			<param index="0" name="view" type="int" />
 			<param index="1" name="aspect" type="float" />
@@ -111,7 +128,7 @@
 				Returns the current status of our tracking.
 			</description>
 		</method>
-		<method name="_get_transform_for_view" qualifiers="virtual">
+		<method name="_get_transform_for_view" qualifiers="virtual" deprecated="Implement _get_camera_offsets">
 			<return type="Transform3D" />
 			<param index="0" name="view" type="int" />
 			<param index="1" name="cam_transform" type="Transform3D" />

--- a/doc/classes/XRServer.xml
+++ b/doc/classes/XRServer.xml
@@ -50,6 +50,25 @@
 				Finds an interface by its [param name]. For example, if your project uses capabilities of an AR/VR platform, you can find the interface for that platform by name and initialize it.
 			</description>
 		</method>
+		<method name="get_camera_offsets">
+			<return type="Transform3D[]" />
+			<param index="0" name="tracker_name" type="StringName" />
+			<description>
+				Gets an array of offset transforms for each view for tracker [param tracker_name]. [param tracker_name] must refer to an [XRPositionalTracker] used as a camera.
+				Will check our primary interface first, then check each active interface. Returns empty if no interfaces manage this tracker.
+			</description>
+		</method>
+		<method name="get_camera_projections">
+			<return type="Projection[]" />
+			<param index="0" name="tracker_name" type="StringName" />
+			<param index="1" name="aspect" type="float" />
+			<param index="2" name="near" type="float" />
+			<param index="3" name="far" type="float" />
+			<description>
+				Gets an array of projection matrices for each view for tracker [param tracker_name]. [param tracker_name] must refer to an [XRPositionalTracker] used as a camera.
+				Will check our primary interface first, then check each active interface. Returns empty if no interfaces manage this tracker.
+			</description>
+		</method>
 		<method name="get_hmd_transform">
 			<return type="Transform3D" />
 			<description>
@@ -172,8 +191,8 @@
 		</signal>
 	</signals>
 	<constants>
-		<constant name="TRACKER_HEAD" value="1" enum="TrackerType">
-			The tracker tracks the location of the player's head. This is usually a location centered between the player's eyes. Note that for handheld AR devices this can be the current location of the device.
+		<constant name="TRACKER_CAMERA" value="1" enum="TrackerType">
+			The tracker tracks the position of an XR camera (HMD, external camera, phone camera for phone based AR).
 		</constant>
 		<constant name="TRACKER_CONTROLLER" value="2" enum="TrackerType">
 			The tracker tracks the location of a controller.
@@ -201,6 +220,9 @@
 		</constant>
 		<constant name="TRACKER_ANY" value="255" enum="TrackerType">
 			Used internally to select all trackers.
+		</constant>
+		<constant name="TRACKER_HEAD" value="1" enum="TrackerType" deprecated="Use TRACKER_CAMERA">
+			The tracker tracks the location of the player's head. This is usually a location centered between the player's eyes. Note that for handheld AR devices this can be the current location of the device.
 		</constant>
 		<constant name="RESET_FULL_ROTATION" value="0" enum="RotationMode">
 			Fully reset the orientation of the HMD. Regardless of what direction the user is looking to in the real world. The user will look dead ahead in the virtual world.

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2403,6 +2403,9 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	Ref<RenderSceneBuffersGLES3> rb = p_render_buffers;
 	ERR_FAIL_COND(rb.is_null());
 
+	// View count of our render target must match our camera data.
+	ERR_FAIL_COND(rb->get_view_count() != p_camera_data->view_count);
+
 	if (rb->get_scaling_3d_mode() != RSE::VIEWPORT_SCALING_3D_MODE_OFF) {
 		// If we're scaling, we apply tonemapping etc. in post, so disable it during rendering
 		apply_environment_effects_in_post = true;
@@ -2445,6 +2448,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 		render_data.inv_cam_transform = render_data.cam_transform.affine_inverse();
 		render_data.cam_projection = p_camera_data->main_projection;
 		render_data.cam_orthogonal = p_camera_data->is_orthogonal;
+		render_data.cam_asymmetrical = p_camera_data->is_asymmetrical;
 		render_data.camera_visible_layers = p_camera_data->visible_layers;
 		render_data.main_cam_transform = p_camera_data->main_transform;
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2425,6 +2425,9 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	Ref<RenderSceneBuffersGLES3> rb = p_render_buffers;
 	ERR_FAIL_COND(rb.is_null());
 
+	// View count of our render target must match our camera data.
+	ERR_FAIL_COND(rb->get_view_count() != p_camera_data->view_count);
+
 	if (rb->get_scaling_3d_mode() != RSE::VIEWPORT_SCALING_3D_MODE_OFF) {
 		// If we're scaling, we apply tonemapping etc. in post, so disable it during rendering
 		apply_environment_effects_in_post = true;

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -106,6 +106,7 @@ struct RenderDataGLES3 {
 	Transform3D inv_cam_transform;
 	Projection cam_projection;
 	bool cam_orthogonal = false;
+	bool cam_asymmetrical = false;
 	uint32_t camera_visible_layers = 0xFFFFFFFF;
 
 	// For billboards to cast correct shadows.

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -108,6 +108,7 @@ struct RenderDataGLES3 {
 	Transform3D inv_cam_transform;
 	Projection cam_projection;
 	bool cam_orthogonal = false;
+	bool cam_asymmetrical = false;
 	uint32_t camera_visible_layers = 0xFFFFFFFF;
 
 	// For billboards to cast correct shadows.

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -279,7 +279,13 @@ Rect2 MobileVRInterface::get_offset_rect() const {
 }
 
 void MobileVRInterface::set_iod(const double p_iod) {
-	intraocular_dist = p_iod;
+	if (intraocular_dist != p_iod) {
+		intraocular_dist = p_iod;
+
+		// Clear our cached values, we'll need to recalculate.
+		camera_projections.clear();
+		camera_offsets.clear();
+	}
 }
 
 double MobileVRInterface::get_iod() const {
@@ -287,7 +293,12 @@ double MobileVRInterface::get_iod() const {
 }
 
 void MobileVRInterface::set_display_width(const double p_display_width) {
-	display_width = p_display_width;
+	if (display_width != p_display_width) {
+		display_width = p_display_width;
+
+		// Clear our cached view projections, we'll need to recalculate.
+		camera_projections.clear();
+	}
 }
 
 double MobileVRInterface::get_display_width() const {
@@ -295,7 +306,12 @@ double MobileVRInterface::get_display_width() const {
 }
 
 void MobileVRInterface::set_display_to_lens(const double p_display_to_lens) {
-	display_to_lens = p_display_to_lens;
+	if (display_to_lens != p_display_to_lens) {
+		display_to_lens = p_display_to_lens;
+
+		// Clear our cached view projections, we'll need to recalculate.
+		camera_projections.clear();
+	}
 }
 
 double MobileVRInterface::get_display_to_lens() const {
@@ -303,7 +319,12 @@ double MobileVRInterface::get_display_to_lens() const {
 }
 
 void MobileVRInterface::set_oversample(const double p_oversample) {
-	oversample = p_oversample;
+	if (oversample != p_oversample) {
+		oversample = p_oversample;
+
+		// Clear our cached view projections, we'll need to recalculate.
+		camera_projections.clear();
+	}
 }
 
 double MobileVRInterface::get_oversample() const {
@@ -373,8 +394,8 @@ bool MobileVRInterface::initialize() {
 
 		// we must create a tracker for our head
 		head.instantiate();
-		head->set_tracker_type(XRServer::TRACKER_HEAD);
-		head->set_tracker_name("head");
+		head->set_tracker_type(XRServer::TRACKER_CAMERA);
+		head->set_tracker_name(XR_TRACKER_HEAD);
 		head->set_tracker_desc("Players head");
 		xr_server->add_tracker(head);
 
@@ -406,6 +427,11 @@ void MobileVRInterface::uninitialize() {
 			}
 		}
 
+		// Clear our cached data
+		camera_projections.clear();
+		camera_offsets.clear();
+
+		// And we're no longer initialized.
 		initialized = false;
 	};
 }
@@ -465,8 +491,78 @@ Transform3D MobileVRInterface::get_camera_transform() {
 	return transform_for_eye;
 }
 
+TypedArray<Projection> MobileVRInterface::get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) {
+	_THREAD_SAFE_METHOD_
+
+	if (p_tracker_name != XR_TRACKER_HEAD) {
+		return TypedArray<Projection>();
+	}
+
+	if (aspect != p_aspect || z_near != p_z_near || z_far != p_z_far) {
+		camera_projections.clear();
+		aspect = p_aspect;
+		z_near = p_z_near;
+		z_far = p_z_far;
+	}
+
+	if (!camera_projections.is_empty()) {
+		// Return our cached values.
+		return camera_projections;
+	}
+
+	XRServer *xr_server = XRServer::get_singleton();
+	ERR_FAIL_NULL_V(xr_server, camera_projections);
+
+	if (initialized) {
+		for (int v = 1; v < 3; v++) {
+			Projection projection;
+
+			projection.set_for_hmd(v, aspect, intraocular_dist, display_width, display_to_lens, oversample, z_near, z_far);
+
+			camera_projections.push_back(projection);
+		}
+	}
+
+	return camera_projections;
+}
+
+TypedArray<Transform3D> MobileVRInterface::get_camera_offsets(const StringName &p_tracker_name) {
+	_THREAD_SAFE_METHOD_
+
+	if (p_tracker_name != XR_TRACKER_HEAD) {
+		return TypedArray<Transform3D>();
+	}
+
+	if (!camera_offsets.is_empty()) {
+		// Return our cached values.
+		return camera_offsets;
+	}
+
+	XRServer *xr_server = XRServer::get_singleton();
+	ERR_FAIL_NULL_V(xr_server, camera_offsets);
+
+	if (initialized) {
+		float world_scale = xr_server->get_world_scale();
+
+		for (int v = 0; v < 2; v++) {
+			Transform3D offset;
+
+			// We don't need to check for the existence of our HMD, doesn't affect our values...
+			// note * 0.01 to convert cm to m and * 0.5 as we're moving half in each direction...
+			offset.origin.x = intraocular_dist * 0.01 * world_scale * (v == 0 ? -0.5 : 0.5);
+
+			camera_offsets.push_back(offset);
+		}
+	}
+
+	return camera_offsets;
+}
+
+#ifndef DISABLE_DEPRECATED
 Transform3D MobileVRInterface::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
 	_THREAD_SAFE_METHOD_
+
+	WARN_PRINT_ONCE("MobileVRInterface.get_transform_for_view is deprecated, please use MobileVRInterface.get_camera_offsets");
 
 	Transform3D transform_for_eye;
 
@@ -476,21 +572,14 @@ Transform3D MobileVRInterface::get_transform_for_view(uint32_t p_view, const Tra
 	if (initialized) {
 		float world_scale = xr_server->get_world_scale();
 
-		// we don't need to check for the existence of our HMD, doesn't affect our values...
-		// note * 0.01 to convert cm to m and * 0.5 as we're moving half in each direction...
-		if (p_view == 0) {
-			transform_for_eye.origin.x = -(intraocular_dist * 0.01 * 0.5 * world_scale);
-		} else if (p_view == 1) {
-			transform_for_eye.origin.x = intraocular_dist * 0.01 * 0.5 * world_scale;
-		} else {
-			// should not have any other values..
-		};
-
 		// just scale our origin point of our transform
 		Transform3D _head_transform = head_transform;
 		_head_transform.origin *= world_scale;
 
-		transform_for_eye = p_cam_transform * (xr_server->get_reference_frame()) * _head_transform * transform_for_eye;
+		Transform3D offset;
+		offset.origin.x = intraocular_dist * 0.01 * world_scale * (p_view == 0 ? -0.5 : 0.5);
+
+		transform_for_eye = p_cam_transform * (xr_server->get_reference_frame()) * _head_transform * offset;
 	} else {
 		// huh? well just return what we got....
 		transform_for_eye = p_cam_transform;
@@ -502,6 +591,8 @@ Transform3D MobileVRInterface::get_transform_for_view(uint32_t p_view, const Tra
 Projection MobileVRInterface::get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) {
 	_THREAD_SAFE_METHOD_
 
+	WARN_PRINT_ONCE("MobileVRInterface.get_projection_for_view is deprecated, please use MobileVRInterface.get_camera_projections");
+
 	Projection eye;
 
 	aspect = p_aspect;
@@ -509,6 +600,7 @@ Projection MobileVRInterface::get_projection_for_view(uint32_t p_view, double p_
 
 	return eye;
 }
+#endif
 
 Vector<RenderingServerTypes::BlitToScreen> MobileVRInterface::post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) {
 	_THREAD_SAFE_METHOD_

--- a/modules/mobile_vr/mobile_vr_interface.h
+++ b/modules/mobile_vr/mobile_vr_interface.h
@@ -67,10 +67,14 @@ private:
 	double k1 = 0.215;
 	double k2 = 0.215;
 	double aspect = 1.0;
+	double z_near = 0.01;
+	double z_far = 4096.0;
 
-	// at a minimum we need a tracker for our head
+	// At a minimum we need a tracker for our head.
 	Ref<XRPositionalTracker> head;
 	Transform3D head_transform;
+	TypedArray<Projection> camera_projections;
+	TypedArray<Transform3D> camera_offsets;
 
 	XRVRS xr_vrs;
 
@@ -163,8 +167,12 @@ public:
 	virtual Size2 get_render_target_size() override;
 	virtual uint32_t get_view_count() override;
 	virtual Transform3D get_camera_transform() override;
+	virtual TypedArray<Projection> get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) override;
+	virtual TypedArray<Transform3D> get_camera_offsets(const StringName &p_tracker_name) override;
+#ifndef DISABLE_DEPRECATED
 	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) override;
 	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
+#endif
 	virtual Vector<RenderingServerTypes::BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) override;
 
 	virtual void process() override;

--- a/modules/openxr/doc_classes/OpenXRExtensionWrapper.xml
+++ b/modules/openxr/doc_classes/OpenXRExtensionWrapper.xml
@@ -14,6 +14,23 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_get_camera_offsets" qualifiers="virtual">
+			<return type="Transform3D[]" />
+			<param index="0" name="tracker_name" type="StringName" />
+			<description>
+				Returns an array of offsets for each view rendered for the given camera, if this camera is handled by this extension. [param tracker_name] refers to the camera tracker for which we're retrieving this.
+			</description>
+		</method>
+		<method name="_get_camera_projections" qualifiers="virtual">
+			<return type="Projection[]" />
+			<param index="0" name="tracker_name" type="StringName" />
+			<param index="1" name="aspect" type="float" />
+			<param index="2" name="z_near" type="float" />
+			<param index="3" name="z_far" type="float" />
+			<description>
+				Returns an array of projections for each view rendered for the given camera, if this camera is handled by this extension. [param tracker_name] refers to the camera tracker for which we're retrieving this.
+			</description>
+		</method>
 		<method name="_get_composition_layer" qualifiers="virtual">
 			<return type="int" />
 			<param index="0" name="index" type="int" />

--- a/modules/openxr/extensions/openxr_extension_wrapper.cpp
+++ b/modules/openxr/extensions/openxr_extension_wrapper.cpp
@@ -82,6 +82,9 @@ void OpenXRExtensionWrapper::_bind_methods() {
 	GDVIRTUAL_BIND(_on_viewport_composition_layer_destroyed, "layer");
 	GDVIRTUAL_BIND(_set_android_surface_swapchain_create_info_and_get_next_pointer, "property_values", "next_pointer");
 
+	GDVIRTUAL_BIND(_get_camera_projections, "tracker_name", "aspect", "z_near", "z_far");
+	GDVIRTUAL_BIND(_get_camera_offsets, "tracker_name");
+
 #ifndef DISABLE_DEPRECATED
 	GDVIRTUAL_BIND_COMPAT(_get_requested_extensions_bind_compat_109302);
 	GDVIRTUAL_BIND_COMPAT(_set_instance_create_info_and_get_next_pointer_bind_compat_109302, "next_pointer");
@@ -420,6 +423,22 @@ void *OpenXRExtensionWrapper::set_android_surface_swapchain_create_info_and_get_
 	}
 
 	return p_next_pointer;
+}
+
+TypedArray<Projection> OpenXRExtensionWrapper::get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) {
+	TypedArray<Projection> camera_projections;
+
+	GDVIRTUAL_CALL(_get_camera_projections, p_tracker_name, p_aspect, p_z_near, p_z_far, camera_projections);
+
+	return camera_projections;
+}
+
+TypedArray<Transform3D> OpenXRExtensionWrapper::get_camera_offsets(const StringName &p_tracker_name) {
+	TypedArray<Transform3D> camera_offsets;
+
+	GDVIRTUAL_CALL(_get_camera_offsets, p_tracker_name, camera_offsets);
+
+	return camera_offsets;
 }
 
 Ref<OpenXRAPIExtension> OpenXRExtensionWrapper::_gdextension_get_openxr_api() {

--- a/modules/openxr/extensions/openxr_extension_wrapper.cpp
+++ b/modules/openxr/extensions/openxr_extension_wrapper.cpp
@@ -84,6 +84,9 @@ void OpenXRExtensionWrapper::_bind_methods() {
 	GDVIRTUAL_BIND(_on_viewport_composition_layer_destroyed, "layer");
 	GDVIRTUAL_BIND(_set_android_surface_swapchain_create_info_and_get_next_pointer, "property_values", "next_pointer");
 
+	GDVIRTUAL_BIND(_get_camera_projections, "tracker_name", "aspect", "z_near", "z_far");
+	GDVIRTUAL_BIND(_get_camera_offsets, "tracker_name");
+
 #ifndef DISABLE_DEPRECATED
 	GDVIRTUAL_BIND_COMPAT(_get_requested_extensions_bind_compat_109302);
 	GDVIRTUAL_BIND_COMPAT(_set_instance_create_info_and_get_next_pointer_bind_compat_109302, "next_pointer");
@@ -442,6 +445,22 @@ void *OpenXRExtensionWrapper::set_android_surface_swapchain_create_info_and_get_
 	}
 
 	return p_next_pointer;
+}
+
+TypedArray<Projection> OpenXRExtensionWrapper::get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) {
+	TypedArray<Projection> camera_projections;
+
+	GDVIRTUAL_CALL(_get_camera_projections, p_tracker_name, p_aspect, p_z_near, p_z_far, camera_projections);
+
+	return camera_projections;
+}
+
+TypedArray<Transform3D> OpenXRExtensionWrapper::get_camera_offsets(const StringName &p_tracker_name) {
+	TypedArray<Transform3D> camera_offsets;
+
+	GDVIRTUAL_CALL(_get_camera_offsets, p_tracker_name, camera_offsets);
+
+	return camera_offsets;
 }
 
 Ref<OpenXRAPIExtension> OpenXRExtensionWrapper::_gdextension_get_openxr_api() {

--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -96,6 +96,9 @@ public:
 	virtual void *set_view_configuration_and_get_next_pointer(uint32_t p_view, void *p_next_pointer); // Add additional data structures when calling xrEnumerateViewConfiguration
 	virtual void print_view_configuration_info(uint32_t p_view) const;
 
+	virtual TypedArray<Projection> get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far);
+	virtual TypedArray<Transform3D> get_camera_offsets(const StringName &p_tracker_name);
+
 	//TODO workaround as GDExtensionPtr<void> return type results in build error in godot-cpp
 	GDVIRTUAL1R(uint64_t, _set_system_properties_and_get_next_pointer, GDExtensionPtr<void>);
 	GDVIRTUAL2R(uint64_t, _set_instance_create_info_and_get_next_pointer, uint64_t, GDExtensionPtr<void>);
@@ -114,6 +117,9 @@ public:
 	GDVIRTUAL1(_prepare_view_configuration, int);
 	GDVIRTUAL2R(uint64_t, _set_view_configuration_and_get_next_pointer, uint32_t, GDExtensionPtr<void>);
 	GDVIRTUAL1C(_print_view_configuration_info, int);
+
+	GDVIRTUAL4R(TypedArray<Projection>, _get_camera_projections, const StringName &, double, double, double);
+	GDVIRTUAL1R(TypedArray<Transform3D>, _get_camera_offsets, const StringName &);
 
 #ifndef DISABLE_DEPRECATED
 	GDVIRTUAL0R_COMPAT(_get_requested_extensions_bind_compat_109302, Dictionary, _get_requested_extensions);

--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -98,6 +98,9 @@ public:
 	virtual void *set_view_configuration_and_get_next_pointer(uint32_t p_view, void *p_next_pointer); // Add additional data structures when calling xrEnumerateViewConfiguration
 	virtual void print_view_configuration_info(uint32_t p_view) const;
 
+	virtual TypedArray<Projection> get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far);
+	virtual TypedArray<Transform3D> get_camera_offsets(const StringName &p_tracker_name);
+
 	//TODO workaround as GDExtensionPtr<void> return type results in build error in godot-cpp
 	GDVIRTUAL1R(uint64_t, _set_system_properties_and_get_next_pointer, GDExtensionPtr<void>);
 	GDVIRTUAL2R(uint64_t, _set_instance_create_info_and_get_next_pointer, uint64_t, GDExtensionPtr<void>);
@@ -118,6 +121,9 @@ public:
 	GDVIRTUAL1(_prepare_view_configuration, int);
 	GDVIRTUAL2R(uint64_t, _set_view_configuration_and_get_next_pointer, uint32_t, GDExtensionPtr<void>);
 	GDVIRTUAL1C(_print_view_configuration_info, int);
+
+	GDVIRTUAL4R(TypedArray<Projection>, _get_camera_projections, const StringName &, double, double, double);
+	GDVIRTUAL1R(TypedArray<Transform3D>, _get_camera_offsets, const StringName &);
 
 #ifndef DISABLE_DEPRECATED
 	GDVIRTUAL0R_COMPAT(_get_requested_extensions_bind_compat_109302, Dictionary, _get_requested_extensions);

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -77,6 +77,8 @@
 #include "extensions/openxr_extension_wrapper_extension.h"
 #endif // DISABLE_DEPRECATED
 
+#include <thirdparty/openxr/src/common/xr_linear.h>
+
 #ifdef ANDROID_ENABLED
 #define OPENXR_LOADER_NAME "libopenxr_loader.so"
 #endif
@@ -1336,7 +1338,7 @@ bool OpenXRAPI::create_main_swapchains(const Size2i &p_size) {
 		set_object_name(XR_OBJECT_TYPE_SWAPCHAIN, uint64_t(render_state.main_swapchains[OPENXR_SWAPCHAIN_DEPTH].get_swapchain()), "Main depth swapchain");
 	}
 
-	for (uint32_t i = 0; i < render_state.views.size(); i++) {
+	for (uint32_t i = 0; i < render_state.view_count; i++) {
 		render_state.projection_views[i].subImage.swapchain = render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].get_swapchain();
 		render_state.projection_views[i].subImage.imageArrayIndex = i;
 		render_state.projection_views[i].subImage.imageRect.offset.x = 0;
@@ -1382,7 +1384,8 @@ void OpenXRAPI::destroy_session() {
 		render_state.running = false;
 	}
 
-	render_state.views.clear();
+	render_state.view_poses.clear();
+	render_state.view_fovs.clear();
 	render_state.projection_views.clear();
 	render_state.depth_views.clear();
 
@@ -1906,19 +1909,20 @@ Size2 OpenXRAPI::get_recommended_target_size() {
 	return target_size;
 }
 
-XRPose::TrackingConfidence OpenXRAPI::get_head_center(Transform3D &r_transform, Vector3 &r_linear_velocity, Vector3 &r_angular_velocity) {
+void OpenXRAPI::update_head_tracking() {
 	XrResult result;
 
 	if (!running) {
-		return XRPose::XR_TRACKING_CONFIDENCE_NONE;
+		return;
 	}
 
 	// Get display time
 	XrTime display_time = get_predicted_display_time();
 	if (display_time == 0) {
-		return XRPose::XR_TRACKING_CONFIDENCE_NONE;
+		return;
 	}
 
+	// Get head location first by checking the relationship between our view and play space.
 	XrSpaceVelocity velocity = {
 		XR_TYPE_SPACE_VELOCITY, // type
 		nullptr, // next
@@ -1940,11 +1944,22 @@ XRPose::TrackingConfidence OpenXRAPI::get_head_center(Transform3D &r_transform, 
 	result = xrLocateSpace(view_space, play_space, display_time, &location);
 	if (XR_FAILED(result)) {
 		print_line("OpenXR: Failed to locate view space in play space [", get_error_string(result), "]");
-		return XRPose::XR_TRACKING_CONFIDENCE_NONE;
+		return;
 	}
 
-	XRPose::TrackingConfidence confidence = transform_from_location(location, r_transform);
-	parse_velocities(velocity, r_linear_velocity, r_angular_velocity);
+	XRPose::TrackingConfidence confidence = XRPose::XR_TRACKING_CONFIDENCE_NONE;
+	if (location.locationFlags != 0) {
+		// We only update our head pose if we have tracking data, else use what we had.
+		head_pose = location.pose;
+		confidence = transform_from_location(location, head_transform);
+	}
+	if (velocity.velocityFlags != 0) {
+		parse_velocities(velocity, head_linear_velocity, head_angular_velocity);
+	} else {
+		// No velocity data? then reset these.
+		head_linear_velocity = Vector3();
+		head_angular_velocity = Vector3();
+	}
 
 	if (head_pose_confidence != confidence) {
 		// prevent error spam
@@ -1958,9 +1973,167 @@ XRPose::TrackingConfidence OpenXRAPI::get_head_center(Transform3D &r_transform, 
 		}
 	}
 
-	return confidence;
+	// Make sure we can store the data we're keeping for the main thread.
+	uint32_t view_count = view_configuration_views.size();
+	view_offsets.resize(view_count);
+	view_fovs.resize(view_count);
+
+	// Reserve some local buffers to store intermediate data in.
+	thread_local PackedVector4Array orientations;
+	thread_local PackedVector3Array positions;
+	thread_local PackedVector4Array fovs;
+	orientations.resize(view_count);
+	positions.resize(view_count);
+	fovs.resize(view_count);
+
+	// Now get eye poses in view space...
+	thread_local LocalVector<XrView> views;
+	views.resize(view_count);
+
+	for (uint32_t i = 0; i < view_count; i++) {
+		views[i] = {
+			XR_TYPE_VIEW, // type
+			nullptr, // next
+			{}, // pose
+			{}, // fov
+		};
+	}
+
+	void *view_locate_info_next_pointer = nullptr;
+	for (OpenXRExtensionWrapper *extension : frame_info_extensions) {
+		void *np = extension->set_view_locate_info_and_get_next_pointer(view_locate_info_next_pointer);
+		if (np != nullptr) {
+			view_locate_info_next_pointer = np;
+		}
+	}
+
+	XrViewLocateInfo view_locate_info = {
+		XR_TYPE_VIEW_LOCATE_INFO, // type
+		view_locate_info_next_pointer, // next
+		view_configuration, // viewConfigurationType
+		display_time, // displayTime
+		view_space // space
+	};
+
+	XrViewState view_state = {
+		XR_TYPE_VIEW_STATE, // type
+		nullptr, // next
+		0 // viewStateFlags
+	};
+
+	uint32_t view_count_output;
+	result = xrLocateViews(session, &view_locate_info, &view_state, view_count, &view_count_output, views.ptr());
+	if (XR_FAILED(result)) {
+		print_line("OpenXR: Couldn't locate views [", get_error_string(result), "]");
+		return;
+	}
+
+	view_pose_valid = (view_state.viewStateFlags != 0);
+	Vector4 *o = orientations.ptrw();
+	Vector3 *p = positions.ptrw();
+	Vector4 *f = fovs.ptrw();
+	for (uint32_t v = 0; v < view_count; v++) {
+		view_offsets[v] = transform_from_pose(views[v].pose);
+		view_fovs[v] = views[v].fov;
+
+		// For rendering we need to combine head and view pose
+		XrPosef combined_pose;
+		XrPosef_Multiply(&combined_pose, &head_pose, &views[v].pose);
+
+		// We use Vector3 and Vector4 as a go between as we can't use XrPosef and XrFovf directly.
+		o[v].x = combined_pose.orientation.x;
+		o[v].y = combined_pose.orientation.y;
+		o[v].z = combined_pose.orientation.z;
+		o[v].w = combined_pose.orientation.w;
+
+		p[v].x = combined_pose.position.x;
+		p[v].y = combined_pose.position.y;
+		p[v].z = combined_pose.position.z;
+
+		f[v].x = view_fovs[v].angleLeft;
+		f[v].y = view_fovs[v].angleRight;
+		f[v].z = view_fovs[v].angleUp;
+		f[v].w = view_fovs[v].angleDown;
+	}
+
+	set_render_state_view_poses(view_pose_valid, orientations, positions, fovs);
 }
 
+XRPose::TrackingConfidence OpenXRAPI::get_head_center(Transform3D &r_transform, Vector3 &r_linear_velocity, Vector3 &r_angular_velocity) {
+	if (!running) {
+		return XRPose::XR_TRACKING_CONFIDENCE_NONE;
+	}
+
+	r_transform = head_transform;
+	r_linear_velocity = head_linear_velocity;
+	r_angular_velocity = head_angular_velocity;
+
+	return head_pose_confidence;
+}
+
+TypedArray<Projection> OpenXRAPI::get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) {
+	TypedArray<Projection> camera_projections;
+
+	if (p_tracker_name == XR_TRACKER_HEAD) {
+		XRServer *xr_server = XRServer::get_singleton();
+		ERR_FAIL_NULL_V(xr_server, camera_projections);
+
+		for (uint32_t v = 0; v < get_view_count(); v++) {
+			Projection cm;
+			get_view_projection(v, p_z_near, p_z_far, cm);
+			camera_projections.push_back(cm);
+		}
+	} else {
+		for (OpenXRExtensionWrapper *extension : registered_extension_wrappers) {
+			camera_projections = extension->get_camera_projections(p_tracker_name, p_aspect, p_z_near, p_z_far);
+			if (!camera_projections.is_empty()) {
+				return camera_projections;
+			}
+		}
+	}
+
+	return camera_projections;
+}
+
+TypedArray<Transform3D> OpenXRAPI::get_camera_offsets(const StringName &p_tracker_name) {
+	TypedArray<Transform3D> camera_offsets;
+
+	if (p_tracker_name == XR_TRACKER_HEAD) {
+		XRServer *xr_server = XRServer::get_singleton();
+		ERR_FAIL_NULL_V(xr_server, camera_offsets);
+
+		double world_scale = xr_server->get_world_scale();
+
+		for (uint32_t v = 0; v < get_view_count(); v++) {
+			Transform3D t;
+			get_view_offset(v, t);
+
+			// Apply our world scale
+			t.origin *= world_scale;
+
+			camera_offsets.push_back(t);
+		}
+	} else {
+		for (OpenXRExtensionWrapper *extension : registered_extension_wrappers) {
+			camera_offsets = extension->get_camera_offsets(p_tracker_name);
+			if (!camera_offsets.is_empty()) {
+				return camera_offsets;
+			}
+		}
+	}
+
+	return camera_offsets;
+}
+
+bool OpenXRAPI::get_view_offset(uint32_t p_view, Transform3D &r_transform) {
+	ERR_FAIL_UNSIGNED_INDEX_V(p_view, view_offsets.size(), false);
+
+	r_transform = view_offsets[p_view];
+
+	return true;
+}
+
+#ifndef DISABLE_DEPRECATED
 bool OpenXRAPI::get_view_transform(uint32_t p_view, Transform3D &r_transform) {
 	ERR_NOT_ON_RENDER_THREAD_V(false);
 
@@ -1969,64 +2142,55 @@ bool OpenXRAPI::get_view_transform(uint32_t p_view, Transform3D &r_transform) {
 	}
 
 	// we don't have valid view info
-	if (render_state.views.is_empty() || !render_state.view_pose_valid) {
+	if (render_state.view_poses.is_empty() || !render_state.view_pose_valid) {
 		return false;
 	}
 
 	// Note, the timing of this is set right before rendering, which is what we need here.
-	r_transform = transform_from_pose(render_state.views[p_view].pose);
+	r_transform = transform_from_pose(render_state.view_poses[p_view]);
 
 	return true;
 }
+#endif
 
 bool OpenXRAPI::get_view_projection(uint32_t p_view, double p_z_near, double p_z_far, Projection &p_camera_matrix) {
-	ERR_NOT_ON_RENDER_THREAD_V(false);
 	ERR_FAIL_NULL_V(graphics_extension, false);
 
-	if (!render_state.running) {
+	if (!running) {
 		return false;
 	}
 
 	// we don't have valid view info
-	if (render_state.views.is_empty() || !render_state.view_pose_valid) {
+	if (view_fovs.is_empty() || !view_pose_valid) {
 		return false;
 	}
 
-	// if we're using depth views, make sure we update our near and far there...
-	if (!render_state.depth_views.is_empty()) {
-		for (XrCompositionLayerDepthInfoKHR &depth_view : render_state.depth_views) {
-			// As we are using reverse-Z these need to be flipped.
-			depth_view.nearZ = p_z_far;
-			depth_view.farZ = p_z_near;
-		}
-	}
-
-	render_state.z_near = p_z_near;
-	render_state.z_far = p_z_far;
+	// For now we assume these are the same for all views.
+	set_render_state_near_and_far(p_z_near, p_z_far);
 
 	// now update our projection
-	return graphics_extension->create_projection_fov(render_state.views[p_view].fov, p_z_near, p_z_far, p_camera_matrix);
+	return graphics_extension->create_projection_fov(view_fovs[p_view], p_z_near, p_z_far, p_camera_matrix);
 }
 
 Vector2 OpenXRAPI::get_eye_focus(uint32_t p_view, float p_aspect) {
 	ERR_FAIL_NULL_V(graphics_extension, Vector2());
 
-	if (!render_state.running) {
+	if (!running) {
 		return Vector2();
 	}
 
 	// xrWaitFrame not run yet
-	if (render_state.predicted_display_time == 0) {
+	if (get_predicted_display_time() == 0) {
 		return Vector2();
 	}
 
 	// we don't have valid view info
-	if (render_state.views.is_empty() || !render_state.view_pose_valid) {
+	if (view_fovs.is_empty() || !view_pose_valid) {
 		return Vector2();
 	}
 
 	Projection cm;
-	if (!graphics_extension->create_projection_fov(render_state.views[p_view].fov, 0.1, 1000.0, cm)) {
+	if (!graphics_extension->create_projection_fov(view_fovs[p_view], 0.1, 1000.0, cm)) {
 		return Vector2();
 	}
 
@@ -2038,7 +2202,7 @@ Vector2 OpenXRAPI::get_eye_focus(uint32_t p_view, float p_aspect) {
 	if (eye_gaze_interaction && eye_gaze_interaction->supports_eye_gaze_interaction()) {
 		Vector3 eye_gaze_pose;
 		if (eye_gaze_interaction->get_eye_gaze_pose(1.0, eye_gaze_pose)) {
-			Transform3D view_transform = transform_from_pose(render_state.views[p_view].pose);
+			Transform3D view_transform = head_transform * view_offsets[p_view];
 
 			eye_gaze_pose = view_transform.xform_inv(eye_gaze_pose);
 			focus = cm.xform(eye_gaze_pose);
@@ -2167,16 +2331,12 @@ void OpenXRAPI::_allocate_view_buffers_rt(uint32_t p_view_count, bool p_submit_d
 	openxr_api->render_state.submit_depth_buffer = p_submit_depth_buffer;
 
 	// Allocate buffers we'll be populating with view information.
-	openxr_api->render_state.views.resize(p_view_count);
+	openxr_api->render_state.view_count = p_view_count;
+	openxr_api->render_state.view_poses.resize(p_view_count);
+	openxr_api->render_state.view_fovs.resize(p_view_count);
 	openxr_api->render_state.projection_views.resize(p_view_count);
 
 	for (uint32_t i = 0; i < p_view_count; i++) {
-		openxr_api->render_state.views[i] = {
-			XR_TYPE_VIEW, // type
-			nullptr, // next
-			{}, // pose
-			{}, // fov
-		};
 		openxr_api->render_state.projection_views[i] = {
 			XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW, // type
 			nullptr, // next
@@ -2257,6 +2417,60 @@ void OpenXRAPI::_set_render_state_render_region_rt(const Rect2i &p_render_region
 	openxr_api->render_state.render_region = p_render_region;
 }
 
+void OpenXRAPI::_set_render_state_view_poses(bool p_is_valid, const PackedVector4Array &p_orientations, const PackedVector3Array &p_positions, const PackedVector4Array &p_fovs) {
+	ERR_NOT_ON_RENDER_THREAD;
+
+	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
+	ERR_FAIL_NULL(openxr_api);
+
+	if (openxr_api->render_state.view_pose_valid != p_is_valid) {
+		openxr_api->render_state.view_pose_valid = p_is_valid;
+		if (!openxr_api->render_state.view_pose_valid) {
+			print_verbose("OpenXR View pose became invalid");
+		} else {
+			print_verbose("OpenXR View pose became valid");
+		}
+	}
+
+	if (p_is_valid) {
+		const uint32_t view_count = openxr_api->render_state.view_count;
+		ERR_FAIL_COND(p_orientations.size() != view_count);
+		ERR_FAIL_COND(p_positions.size() != view_count);
+		ERR_FAIL_COND(p_fovs.size() != view_count);
+
+		for (uint32_t view = 0; view < view_count; view++) {
+			// We use Vector3 and Vector4 as a go between as we can't use XrPosef and XrFovf directly.
+
+			const Vector4 &o = p_orientations[view];
+			const Vector3 &p = p_positions[view];
+			const Vector4 &f = p_fovs[view];
+
+			openxr_api->render_state.view_poses[view].orientation = { float(o.x), float(o.y), float(o.z), float(o.w) };
+			openxr_api->render_state.view_poses[view].position = { float(p.x), float(p.y), float(p.z) };
+			openxr_api->render_state.view_fovs[view] = { float(f.x), float(f.y), float(f.z), float(f.w) };
+		}
+	}
+}
+
+void OpenXRAPI::_set_render_state_near_and_far(double p_z_near, double p_z_far) {
+	ERR_NOT_ON_RENDER_THREAD;
+
+	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
+	ERR_FAIL_NULL(openxr_api);
+
+	// if we're using depth views, make sure we update our near and far there...
+	if (!openxr_api->render_state.depth_views.is_empty()) {
+		for (XrCompositionLayerDepthInfoKHR &depth_view : openxr_api->render_state.depth_views) {
+			// As we are using reverse-Z these need to be flipped.
+			depth_view.nearZ = p_z_far;
+			depth_view.farZ = p_z_near;
+		}
+	}
+
+	openxr_api->render_state.z_near = p_z_near;
+	openxr_api->render_state.z_far = p_z_far;
+}
+
 void OpenXRAPI::_update_main_swapchain_size_rt() {
 	ERR_NOT_ON_RENDER_THREAD;
 
@@ -2331,6 +2545,20 @@ void OpenXRAPI::set_render_state_render_region(const Rect2i &p_render_region) {
 	ERR_FAIL_NULL(rendering_server);
 
 	rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_state_render_region_rt).bind(p_render_region));
+}
+
+void OpenXRAPI::set_render_state_view_poses(bool p_is_valid, const PackedVector4Array &p_orientations, const PackedVector3Array &p_positions, const PackedVector4Array &p_fovs) {
+	RenderingServer *rendering_server = RenderingServer::get_singleton();
+	ERR_FAIL_NULL(rendering_server);
+
+	rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_state_view_poses).bind(p_is_valid, p_orientations, p_positions, p_fovs));
+}
+
+void OpenXRAPI::set_render_state_near_and_far(double p_z_near, double p_z_far) {
+	RenderingServer *rendering_server = RenderingServer::get_singleton();
+	ERR_FAIL_NULL(rendering_server);
+
+	rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_state_near_and_far).bind(p_z_near, p_z_far));
 }
 
 void OpenXRAPI::update_main_swapchain_size() {
@@ -2410,6 +2638,8 @@ bool OpenXRAPI::process() {
 		play_space_is_dirty = false;
 	}
 
+	update_head_tracking();
+
 	GodotProfileZoneGrouped(_profile_zone, "extension wrappers on_process");
 	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
 		wrapper->on_process();
@@ -2437,60 +2667,6 @@ void OpenXRAPI::pre_render() {
 	// Process any swapchains that were queued to be freed
 	OpenXRSwapChainInfo::free_queued();
 
-	void *view_locate_info_next_pointer = nullptr;
-	for (OpenXRExtensionWrapper *extension : frame_info_extensions) {
-		void *np = extension->set_view_locate_info_and_get_next_pointer(view_locate_info_next_pointer);
-		if (np != nullptr) {
-			view_locate_info_next_pointer = np;
-		}
-	}
-
-	// Get our view info for the frame we're about to render, note from the OpenXR manual:
-	// "Repeatedly calling xrLocateViews with the same time may not necessarily return the same result. Instead the prediction gets increasingly accurate as the function is called closer to the given time for which a prediction is made"
-
-	// We're calling this "relatively" early, the positioning we're obtaining here will be used to do our frustum culling,
-	// occlusion culling, etc. There is however a technique that we can investigate in the future where after our entire
-	// Vulkan command buffer is build, but right before vkSubmitQueue is called, we call xrLocateViews one more time and
-	// update the view and projection matrix once more with a slightly more accurate predication and then submit the
-	// command queues.
-
-	// That is not possible yet but worth investigating in the future.
-
-	XrViewLocateInfo view_locate_info = {
-		XR_TYPE_VIEW_LOCATE_INFO, // type
-		view_locate_info_next_pointer, // next
-		view_configuration, // viewConfigurationType
-		render_state.predicted_display_time, // displayTime
-		render_state.play_space // space
-	};
-	XrViewState view_state = {
-		XR_TYPE_VIEW_STATE, // type
-		nullptr, // next
-		0 // viewStateFlags
-	};
-	uint32_t view_count_output;
-	XrResult result = xrLocateViews(session, &view_locate_info, &view_state, render_state.views.size(), &view_count_output, render_state.views.ptr());
-	if (XR_FAILED(result)) {
-		print_line("OpenXR: Couldn't locate views [", get_error_string(result), "]");
-		return;
-	}
-
-	bool pose_valid = true;
-	for (uint64_t i = 0; i < view_count_output; i++) {
-		if ((view_state.viewStateFlags & XR_VIEW_STATE_ORIENTATION_VALID_BIT) == 0 ||
-				(view_state.viewStateFlags & XR_VIEW_STATE_POSITION_VALID_BIT) == 0) {
-			pose_valid = false;
-		}
-	}
-	if (render_state.view_pose_valid != pose_valid) {
-		render_state.view_pose_valid = pose_valid;
-		if (!render_state.view_pose_valid) {
-			print_verbose("OpenXR View pose became invalid");
-		} else {
-			print_verbose("OpenXR View pose became valid");
-		}
-	}
-
 	// We should get our frame no from the rendering server, but this will do.
 	begin_debug_label_region(String("Session Frame ") + String::num_uint64(++render_state.frame));
 
@@ -2499,7 +2675,7 @@ void OpenXRAPI::pre_render() {
 		XR_TYPE_FRAME_BEGIN_INFO, // type
 		nullptr // next
 	};
-	result = xrBeginFrame(session, &frame_begin_info);
+	XrResult result = xrBeginFrame(session, &frame_begin_info);
 	if (XR_FAILED(result)) {
 		print_line("OpenXR: failed to begin frame [", get_error_string(result), "]");
 		return;
@@ -2720,9 +2896,9 @@ void OpenXRAPI::end_frame() {
 		}
 	}
 
-	for (uint32_t eye = 0; eye < render_state.views.size(); eye++) {
-		render_state.projection_views[eye].fov = render_state.views[eye].fov;
-		render_state.projection_views[eye].pose = render_state.views[eye].pose;
+	for (uint32_t v = 0; v < render_state.view_count; v++) {
+		render_state.projection_views[v].fov = render_state.view_fovs[v];
+		render_state.projection_views[v].pose = render_state.view_poses[v];
 	}
 
 	Vector<OrderedCompositionLayer> ordered_layers_list;

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -78,6 +78,8 @@
 #include "extensions/openxr_extension_wrapper_extension.h"
 #endif // DISABLE_DEPRECATED
 
+#include <thirdparty/openxr/src/common/xr_linear.h>
+
 #ifdef ANDROID_ENABLED
 #define OPENXR_LOADER_NAME "libopenxr_loader.so"
 #endif
@@ -1337,7 +1339,7 @@ bool OpenXRAPI::create_main_swapchains(const Size2i &p_size) {
 		set_object_name(XR_OBJECT_TYPE_SWAPCHAIN, uint64_t(render_state.main_swapchains[OPENXR_SWAPCHAIN_DEPTH].get_swapchain()), "Main depth swapchain");
 	}
 
-	for (uint32_t i = 0; i < render_state.views.size(); i++) {
+	for (uint32_t i = 0; i < render_state.view_count; i++) {
 		render_state.projection_views[i].subImage.swapchain = render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].get_swapchain();
 		render_state.projection_views[i].subImage.imageArrayIndex = i;
 		render_state.projection_views[i].subImage.imageRect.offset.x = 0;
@@ -1385,7 +1387,8 @@ void OpenXRAPI::destroy_session() {
 		render_state.running = false;
 	}
 
-	render_state.views.clear();
+	render_state.view_poses.clear();
+	render_state.view_fovs.clear();
 	render_state.projection_views.clear();
 	render_state.depth_views.clear();
 
@@ -1909,19 +1912,20 @@ Size2 OpenXRAPI::get_recommended_target_size() {
 	return target_size;
 }
 
-XRPose::TrackingConfidence OpenXRAPI::get_head_center(Transform3D &r_transform, Vector3 &r_linear_velocity, Vector3 &r_angular_velocity) {
+void OpenXRAPI::update_head_tracking() {
 	XrResult result;
 
 	if (!running) {
-		return XRPose::XR_TRACKING_CONFIDENCE_NONE;
+		return;
 	}
 
 	// Get display time
 	XrTime display_time = get_predicted_display_time();
 	if (display_time == 0) {
-		return XRPose::XR_TRACKING_CONFIDENCE_NONE;
+		return;
 	}
 
+	// Get head location first by checking the relationship between our view and play space.
 	XrSpaceVelocity velocity = {
 		XR_TYPE_SPACE_VELOCITY, // type
 		nullptr, // next
@@ -1943,11 +1947,22 @@ XRPose::TrackingConfidence OpenXRAPI::get_head_center(Transform3D &r_transform, 
 	result = xrLocateSpace(view_space, play_space, display_time, &location);
 	if (XR_FAILED(result)) {
 		print_line("OpenXR: Failed to locate view space in play space [", get_error_string(result), "]");
-		return XRPose::XR_TRACKING_CONFIDENCE_NONE;
+		return;
 	}
 
-	XRPose::TrackingConfidence confidence = transform_from_location(location, r_transform);
-	parse_velocities(velocity, r_linear_velocity, r_angular_velocity);
+	XRPose::TrackingConfidence confidence = XRPose::XR_TRACKING_CONFIDENCE_NONE;
+	if (location.locationFlags != 0) {
+		// We only update our head pose if we have tracking data, else use what we had.
+		head_pose = location.pose;
+		confidence = transform_from_location(location, head_transform);
+	}
+	if (velocity.velocityFlags != 0) {
+		parse_velocities(velocity, head_linear_velocity, head_angular_velocity);
+	} else {
+		// No velocity data? then reset these.
+		head_linear_velocity = Vector3();
+		head_angular_velocity = Vector3();
+	}
 
 	if (head_pose_confidence != confidence) {
 		// prevent error spam
@@ -1961,9 +1976,179 @@ XRPose::TrackingConfidence OpenXRAPI::get_head_center(Transform3D &r_transform, 
 		}
 	}
 
-	return confidence;
+	// Make sure we can store the data we're keeping for the main thread.
+	uint32_t view_count = view_configuration_views.size();
+	view_offsets.resize(view_count);
+	view_fovs.resize(view_count);
+
+	// Reserve some local buffers to store intermediate data in.
+	thread_local PackedVector4Array orientations;
+	thread_local PackedVector3Array positions;
+	thread_local PackedVector4Array fovs;
+	orientations.resize(view_count);
+	positions.resize(view_count);
+	fovs.resize(view_count);
+
+	// Now get eye poses in view space...
+	thread_local LocalVector<XrView> views;
+	views.resize(view_count);
+
+	for (uint32_t i = 0; i < view_count; i++) {
+		views[i] = {
+			XR_TYPE_VIEW, // type
+			nullptr, // next
+			{}, // pose
+			{}, // fov
+		};
+	}
+
+	bool should_submit_spatial_container_layers = false;
+	if (is_spatial_container_enabled()) {
+		OpenXRSpatialContainerExtension *spatial_container_ext = OpenXRSpatialContainerExtension::get_singleton();
+		ERR_FAIL_NULL(spatial_container_ext);
+		result = spatial_container_ext->locate_spatial_container_views(views.ptr(), view_pose_valid, should_submit_spatial_container_layers);
+		if (XR_FAILED(result)) {
+			print_line("OpenXR: Couldn't locate spatial container views [", get_error_string(result), "]");
+			return;
+		}
+	} else {
+		void *view_locate_info_next_pointer = nullptr;
+		for (OpenXRExtensionWrapper *extension : frame_info_extensions) {
+			void *np = extension->set_view_locate_info_and_get_next_pointer(view_locate_info_next_pointer);
+			if (np != nullptr) {
+				view_locate_info_next_pointer = np;
+			}
+		}
+
+		XrViewLocateInfo view_locate_info = {
+			XR_TYPE_VIEW_LOCATE_INFO, // type
+			view_locate_info_next_pointer, // next
+			view_configuration, // viewConfigurationType
+			display_time, // displayTime
+			view_space // space
+		};
+
+		XrViewState view_state = {
+			XR_TYPE_VIEW_STATE, // type
+			nullptr, // next
+			0 // viewStateFlags
+		};
+
+		uint32_t view_count_output;
+		result = xrLocateViews(session, &view_locate_info, &view_state, view_count, &view_count_output, views.ptr());
+		if (XR_FAILED(result)) {
+			print_line("OpenXR: Couldn't locate views [", get_error_string(result), "]");
+			return;
+		}
+
+		view_pose_valid = (view_state.viewStateFlags != 0);
+	}
+
+	Vector4 *o = orientations.ptrw();
+	Vector3 *p = positions.ptrw();
+	Vector4 *f = fovs.ptrw();
+	for (uint32_t v = 0; v < view_count; v++) {
+		view_offsets[v] = transform_from_pose(views[v].pose);
+		view_fovs[v] = views[v].fov;
+
+		// For submitting our layer, we need to combine head and view pose
+		XrPosef combined_pose;
+		XrPosef_Multiply(&combined_pose, &head_pose, &views[v].pose);
+
+		// We use Vector3 and Vector4 as a go between as we can't use XrPosef and XrFovf directly.
+		o[v].x = combined_pose.orientation.x;
+		o[v].y = combined_pose.orientation.y;
+		o[v].z = combined_pose.orientation.z;
+		o[v].w = combined_pose.orientation.w;
+
+		p[v].x = combined_pose.position.x;
+		p[v].y = combined_pose.position.y;
+		p[v].z = combined_pose.position.z;
+
+		f[v].x = view_fovs[v].angleLeft;
+		f[v].y = view_fovs[v].angleRight;
+		f[v].z = view_fovs[v].angleUp;
+		f[v].w = view_fovs[v].angleDown;
+	}
+
+	set_render_state_view_poses(view_pose_valid, should_submit_spatial_container_layers, orientations, positions, fovs);
 }
 
+XRPose::TrackingConfidence OpenXRAPI::get_head_center(Transform3D &r_transform, Vector3 &r_linear_velocity, Vector3 &r_angular_velocity) {
+	if (!running) {
+		return XRPose::XR_TRACKING_CONFIDENCE_NONE;
+	}
+
+	r_transform = head_transform;
+	r_linear_velocity = head_linear_velocity;
+	r_angular_velocity = head_angular_velocity;
+
+	return head_pose_confidence;
+}
+
+TypedArray<Projection> OpenXRAPI::get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) {
+	TypedArray<Projection> camera_projections;
+
+	if (p_tracker_name == XR_TRACKER_HEAD) {
+		XRServer *xr_server = XRServer::get_singleton();
+		ERR_FAIL_NULL_V(xr_server, camera_projections);
+
+		for (uint32_t v = 0; v < get_view_count(); v++) {
+			Projection cm;
+			get_view_projection(v, p_z_near, p_z_far, cm);
+			camera_projections.push_back(cm);
+		}
+	} else {
+		for (OpenXRExtensionWrapper *extension : registered_extension_wrappers) {
+			camera_projections = extension->get_camera_projections(p_tracker_name, p_aspect, p_z_near, p_z_far);
+			if (!camera_projections.is_empty()) {
+				return camera_projections;
+			}
+		}
+	}
+
+	return camera_projections;
+}
+
+TypedArray<Transform3D> OpenXRAPI::get_camera_offsets(const StringName &p_tracker_name) {
+	TypedArray<Transform3D> camera_offsets;
+
+	if (p_tracker_name == XR_TRACKER_HEAD) {
+		XRServer *xr_server = XRServer::get_singleton();
+		ERR_FAIL_NULL_V(xr_server, camera_offsets);
+
+		double world_scale = xr_server->get_world_scale();
+
+		for (uint32_t v = 0; v < get_view_count(); v++) {
+			Transform3D t;
+			get_view_offset(v, t);
+
+			// Apply our world scale
+			t.origin *= world_scale;
+
+			camera_offsets.push_back(t);
+		}
+	} else {
+		for (OpenXRExtensionWrapper *extension : registered_extension_wrappers) {
+			camera_offsets = extension->get_camera_offsets(p_tracker_name);
+			if (!camera_offsets.is_empty()) {
+				return camera_offsets;
+			}
+		}
+	}
+
+	return camera_offsets;
+}
+
+bool OpenXRAPI::get_view_offset(uint32_t p_view, Transform3D &r_transform) {
+	ERR_FAIL_UNSIGNED_INDEX_V(p_view, view_offsets.size(), false);
+
+	r_transform = view_offsets[p_view];
+
+	return true;
+}
+
+#ifndef DISABLE_DEPRECATED
 bool OpenXRAPI::get_view_transform(uint32_t p_view, Transform3D &r_transform) {
 	ERR_NOT_ON_RENDER_THREAD_V(false);
 
@@ -1972,64 +2157,55 @@ bool OpenXRAPI::get_view_transform(uint32_t p_view, Transform3D &r_transform) {
 	}
 
 	// we don't have valid view info
-	if (render_state.views.is_empty() || !render_state.view_pose_valid) {
+	if (render_state.view_poses.is_empty() || !render_state.view_pose_valid) {
 		return false;
 	}
 
 	// Note, the timing of this is set right before rendering, which is what we need here.
-	r_transform = transform_from_pose(render_state.views[p_view].pose);
+	r_transform = transform_from_pose(render_state.view_poses[p_view]);
 
 	return true;
 }
+#endif
 
 bool OpenXRAPI::get_view_projection(uint32_t p_view, double p_z_near, double p_z_far, Projection &p_camera_matrix) {
-	ERR_NOT_ON_RENDER_THREAD_V(false);
 	ERR_FAIL_NULL_V(graphics_extension, false);
 
-	if (!render_state.running) {
+	if (!running) {
 		return false;
 	}
 
 	// we don't have valid view info
-	if (render_state.views.is_empty() || !render_state.view_pose_valid) {
+	if (view_fovs.is_empty() || !view_pose_valid) {
 		return false;
 	}
 
-	// if we're using depth views, make sure we update our near and far there...
-	if (!render_state.depth_views.is_empty()) {
-		for (XrCompositionLayerDepthInfoKHR &depth_view : render_state.depth_views) {
-			// As we are using reverse-Z these need to be flipped.
-			depth_view.nearZ = p_z_far;
-			depth_view.farZ = p_z_near;
-		}
-	}
-
-	render_state.z_near = p_z_near;
-	render_state.z_far = p_z_far;
+	// For now we assume these are the same for all views.
+	set_render_state_near_and_far(p_z_near, p_z_far);
 
 	// now update our projection
-	return graphics_extension->create_projection_fov(render_state.views[p_view].fov, p_z_near, p_z_far, p_camera_matrix);
+	return graphics_extension->create_projection_fov(view_fovs[p_view], p_z_near, p_z_far, p_camera_matrix);
 }
 
 Vector2 OpenXRAPI::get_eye_focus(uint32_t p_view, float p_aspect) {
 	ERR_FAIL_NULL_V(graphics_extension, Vector2());
 
-	if (!render_state.running) {
+	if (!running) {
 		return Vector2();
 	}
 
 	// xrWaitFrame not run yet
-	if (render_state.predicted_display_time == 0) {
+	if (get_predicted_display_time() == 0) {
 		return Vector2();
 	}
 
 	// we don't have valid view info
-	if (render_state.views.is_empty() || !render_state.view_pose_valid) {
+	if (view_fovs.is_empty() || !view_pose_valid) {
 		return Vector2();
 	}
 
 	Projection cm;
-	if (!graphics_extension->create_projection_fov(render_state.views[p_view].fov, 0.1, 1000.0, cm)) {
+	if (!graphics_extension->create_projection_fov(view_fovs[p_view], 0.1, 1000.0, cm)) {
 		return Vector2();
 	}
 
@@ -2041,7 +2217,7 @@ Vector2 OpenXRAPI::get_eye_focus(uint32_t p_view, float p_aspect) {
 	if (eye_gaze_interaction && eye_gaze_interaction->supports_eye_gaze_interaction()) {
 		Vector3 eye_gaze_pose;
 		if (eye_gaze_interaction->get_eye_gaze_pose(1.0, eye_gaze_pose)) {
-			Transform3D view_transform = transform_from_pose(render_state.views[p_view].pose);
+			Transform3D view_transform = head_transform * view_offsets[p_view];
 
 			eye_gaze_pose = view_transform.xform_inv(eye_gaze_pose);
 			focus = cm.xform(eye_gaze_pose);
@@ -2184,16 +2360,12 @@ void OpenXRAPI::_allocate_view_buffers_rt(uint32_t p_view_count, bool p_submit_d
 	openxr_api->render_state.submit_depth_buffer = p_submit_depth_buffer;
 
 	// Allocate buffers we'll be populating with view information.
-	openxr_api->render_state.views.resize(p_view_count);
+	openxr_api->render_state.view_count = p_view_count;
+	openxr_api->render_state.view_poses.resize(p_view_count);
+	openxr_api->render_state.view_fovs.resize(p_view_count);
 	openxr_api->render_state.projection_views.resize(p_view_count);
 
 	for (uint32_t i = 0; i < p_view_count; i++) {
-		openxr_api->render_state.views[i] = {
-			XR_TYPE_VIEW, // type
-			nullptr, // next
-			{}, // pose
-			{}, // fov
-		};
 		openxr_api->render_state.projection_views[i] = {
 			XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW, // type
 			nullptr, // next
@@ -2274,6 +2446,62 @@ void OpenXRAPI::_set_render_state_render_region_rt(const Rect2i &p_render_region
 	openxr_api->render_state.render_region = p_render_region;
 }
 
+void OpenXRAPI::_set_render_state_view_poses(bool p_is_valid, bool p_should_submit_spatial_container_layers, const PackedVector4Array &p_orientations, const PackedVector3Array &p_positions, const PackedVector4Array &p_fovs) {
+	ERR_NOT_ON_RENDER_THREAD;
+
+	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
+	ERR_FAIL_NULL(openxr_api);
+
+	if (openxr_api->render_state.view_pose_valid != p_is_valid) {
+		openxr_api->render_state.view_pose_valid = p_is_valid;
+		if (!openxr_api->render_state.view_pose_valid) {
+			print_verbose("OpenXR View pose became invalid");
+		} else {
+			print_verbose("OpenXR View pose became valid");
+		}
+	}
+
+	openxr_api->render_state.should_submit_spatial_container_layers = p_should_submit_spatial_container_layers;
+
+	if (p_is_valid) {
+		const uint32_t view_count = openxr_api->render_state.view_count;
+		ERR_FAIL_COND(p_orientations.size() != view_count);
+		ERR_FAIL_COND(p_positions.size() != view_count);
+		ERR_FAIL_COND(p_fovs.size() != view_count);
+
+		for (uint32_t view = 0; view < view_count; view++) {
+			// We use Vector3 and Vector4 as a go between as we can't use XrPosef and XrFovf directly.
+
+			const Vector4 &o = p_orientations[view];
+			const Vector3 &p = p_positions[view];
+			const Vector4 &f = p_fovs[view];
+
+			openxr_api->render_state.view_poses[view].orientation = { float(o.x), float(o.y), float(o.z), float(o.w) };
+			openxr_api->render_state.view_poses[view].position = { float(p.x), float(p.y), float(p.z) };
+			openxr_api->render_state.view_fovs[view] = { float(f.x), float(f.y), float(f.z), float(f.w) };
+		}
+	}
+}
+
+void OpenXRAPI::_set_render_state_near_and_far(double p_z_near, double p_z_far) {
+	ERR_NOT_ON_RENDER_THREAD;
+
+	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
+	ERR_FAIL_NULL(openxr_api);
+
+	// if we're using depth views, make sure we update our near and far there...
+	if (!openxr_api->render_state.depth_views.is_empty()) {
+		for (XrCompositionLayerDepthInfoKHR &depth_view : openxr_api->render_state.depth_views) {
+			// As we are using reverse-Z these need to be flipped.
+			depth_view.nearZ = p_z_far;
+			depth_view.farZ = p_z_near;
+		}
+	}
+
+	openxr_api->render_state.z_near = p_z_near;
+	openxr_api->render_state.z_far = p_z_far;
+}
+
 void OpenXRAPI::_update_main_swapchain_size_rt() {
 	ERR_NOT_ON_RENDER_THREAD;
 
@@ -2348,6 +2576,20 @@ void OpenXRAPI::set_render_state_render_region(const Rect2i &p_render_region) {
 	ERR_FAIL_NULL(rendering_server);
 
 	rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_state_render_region_rt).bind(p_render_region));
+}
+
+void OpenXRAPI::set_render_state_view_poses(bool p_is_valid, bool p_should_submit_spatial_container_layers, const PackedVector4Array &p_orientations, const PackedVector3Array &p_positions, const PackedVector4Array &p_fovs) {
+	RenderingServer *rendering_server = RenderingServer::get_singleton();
+	ERR_FAIL_NULL(rendering_server);
+
+	rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_state_view_poses).bind(p_is_valid, p_should_submit_spatial_container_layers, p_orientations, p_positions, p_fovs));
+}
+
+void OpenXRAPI::set_render_state_near_and_far(double p_z_near, double p_z_far) {
+	RenderingServer *rendering_server = RenderingServer::get_singleton();
+	ERR_FAIL_NULL(rendering_server);
+
+	rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_state_near_and_far).bind(p_z_near, p_z_far));
 }
 
 void OpenXRAPI::update_main_swapchain_size() {
@@ -2427,6 +2669,8 @@ bool OpenXRAPI::process() {
 		play_space_is_dirty = false;
 	}
 
+	update_head_tracking();
+
 	GodotProfileZoneGrouped(_profile_zone, "extension wrappers on_process");
 	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
 		wrapper->on_process();
@@ -2454,71 +2698,6 @@ void OpenXRAPI::pre_render() {
 	// Process any swapchains that were queued to be freed
 	OpenXRSwapChainInfo::free_queued();
 
-	// Get our view info for the frame we're about to render, note from the OpenXR manual:
-	// "Repeatedly calling xrLocateViews with the same time may not necessarily return the same result. Instead the prediction gets increasingly accurate as the function is called closer to the given time for which a prediction is made"
-
-	// We're calling this "relatively" early, the positioning we're obtaining here will be used to do our frustum culling,
-	// occlusion culling, etc. There is however a technique that we can investigate in the future where after our entire
-	// Vulkan command buffer is build, but right before vkSubmitQueue is called, we call xrLocateViews one more time and
-	// update the view and projection matrix once more with a slightly more accurate predication and then submit the
-	// command queues.
-
-	// That is not possible yet but worth investigating in the future.
-
-	XrResult result;
-	bool pose_valid = true;
-	if (is_spatial_container_enabled()) {
-		OpenXRSpatialContainerExtension *spatial_container_ext = OpenXRSpatialContainerExtension::get_singleton();
-		ERR_FAIL_NULL(spatial_container_ext);
-		result = spatial_container_ext->locate_spatial_container_views(render_state.views.ptr(), pose_valid,
-				render_state.should_submit_spatial_container_layers);
-		if (XR_FAILED(result)) {
-			print_line("OpenXR: Couldn't locate spatial container views [", get_error_string(result), "]");
-			return;
-		}
-	} else {
-		void *view_locate_info_next_pointer = nullptr;
-		for (OpenXRExtensionWrapper *extension : frame_info_extensions) {
-			void *np = extension->set_view_locate_info_and_get_next_pointer(view_locate_info_next_pointer);
-			if (np != nullptr) {
-				view_locate_info_next_pointer = np;
-			}
-		}
-
-		XrViewLocateInfo view_locate_info = {
-			XR_TYPE_VIEW_LOCATE_INFO, // type
-			view_locate_info_next_pointer, // next
-			view_configuration, // viewConfigurationType
-			render_state.predicted_display_time, // displayTime
-			render_state.play_space // space
-		};
-		XrViewState view_state = {
-			XR_TYPE_VIEW_STATE, // type
-			nullptr, // next
-			0 // viewStateFlags
-		};
-		uint32_t view_count_output;
-		result = xrLocateViews(session, &view_locate_info, &view_state, render_state.views.size(), &view_count_output, render_state.views.ptr());
-		if (XR_FAILED(result)) {
-			print_line("OpenXR: Couldn't locate views [", get_error_string(result), "]");
-			return;
-		}
-
-		if ((view_state.viewStateFlags & XR_VIEW_STATE_ORIENTATION_VALID_BIT) == 0 ||
-				(view_state.viewStateFlags & XR_VIEW_STATE_POSITION_VALID_BIT) == 0) {
-			pose_valid = false;
-		}
-	}
-
-	if (render_state.view_pose_valid != pose_valid) {
-		render_state.view_pose_valid = pose_valid;
-		if (!render_state.view_pose_valid) {
-			print_verbose("OpenXR View pose became invalid");
-		} else {
-			print_verbose("OpenXR View pose became valid");
-		}
-	}
-
 	// We should get our frame no from the rendering server, but this will do.
 	begin_debug_label_region(String("Session Frame ") + String::num_uint64(++render_state.frame));
 
@@ -2527,7 +2706,7 @@ void OpenXRAPI::pre_render() {
 		XR_TYPE_FRAME_BEGIN_INFO, // type
 		nullptr // next
 	};
-	result = xrBeginFrame(session, &frame_begin_info);
+	XrResult result = xrBeginFrame(session, &frame_begin_info);
 	if (XR_FAILED(result)) {
 		print_line("OpenXR: failed to begin frame [", get_error_string(result), "]");
 		return;
@@ -2748,9 +2927,9 @@ void OpenXRAPI::end_frame() {
 		}
 	}
 
-	for (uint32_t eye = 0; eye < render_state.views.size(); eye++) {
-		render_state.projection_views[eye].fov = render_state.views[eye].fov;
-		render_state.projection_views[eye].pose = render_state.views[eye].pose;
+	for (uint32_t v = 0; v < render_state.view_count; v++) {
+		render_state.projection_views[v].fov = render_state.view_fovs[v];
+		render_state.projection_views[v].pose = render_state.view_poses[v];
 	}
 
 	Vector<OrderedCompositionLayer> ordered_layers_list;

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -167,7 +167,18 @@ private:
 	XrSpace play_space = XR_NULL_HANDLE;
 	XrSpace custom_play_space = XR_NULL_HANDLE;
 	XrSpace view_space = XR_NULL_HANDLE;
+
+	// Head info
 	XRPose::TrackingConfidence head_pose_confidence = XRPose::XR_TRACKING_CONFIDENCE_NONE;
+	XrPosef head_pose = { { 0.0, 0.0, 0.0, 1.0 }, { 0.0, 1.6, 0.0 } }; // While we haven't received tracking data, place the camera 1.6 meters above the origin by default.
+	Transform3D head_transform;
+	Vector3 head_linear_velocity;
+	Vector3 head_angular_velocity;
+
+	// View (eye) info
+	bool view_pose_valid = false;
+	LocalVector<Transform3D> view_offsets;
+	LocalVector<XrFovf> view_fovs;
 
 	RID velocity_texture;
 	RID velocity_depth_texture;
@@ -271,6 +282,7 @@ private:
 	bool is_reference_space_supported(XrReferenceSpaceType p_reference_space);
 	bool setup_play_space();
 	bool setup_view_space();
+	void update_head_tracking();
 	bool load_supported_swapchain_formats();
 	bool is_swapchain_format_supported(int64_t p_swapchain_format);
 	bool obtain_swapchain_formats();
@@ -360,12 +372,15 @@ private:
 		uint64_t frame = 0;
 		Rect2i render_region;
 
-		LocalVector<XrView> views;
 		LocalVector<XrCompositionLayerProjectionView> projection_views;
 		LocalVector<XrCompositionLayerDepthInfoKHR> depth_views; // Only used by Composition Layer Depth Extension if available
 		bool submit_depth_buffer = false; // if set to true we submit depth buffers to OpenXR if a suitable extension is enabled.
 		bool use_subsampled_images = true; // We need to default to true for the warning to be shown if we fallback immediately at startup.
+
+		uint32_t view_count = 0;
 		bool view_pose_valid = false;
+		LocalVector<XrPosef> view_poses;
+		LocalVector<XrFovf> view_fovs;
 
 		double z_near = 0.0;
 		double z_far = 0.0;
@@ -390,6 +405,8 @@ private:
 	static void _set_render_environment_blend_mode_rt(int32_t p_environment_blend_mode);
 	static void _set_render_state_multiplier_rt(double p_render_target_size_multiplier);
 	static void _set_render_state_render_region_rt(const Rect2i &p_render_region);
+	static void _set_render_state_view_poses(bool p_is_valid, const PackedVector4Array &p_orientations, const PackedVector3Array &p_positions, const PackedVector4Array &p_fovs);
+	static void _set_render_state_near_and_far(double p_z_near, double p_z_far);
 	static void _update_main_swapchain_size_rt();
 
 	void allocate_view_buffers(uint32_t p_view_count, bool p_submit_depth_buffer);
@@ -399,6 +416,8 @@ private:
 	void set_render_environment_blend_mode(XrEnvironmentBlendMode p_mode);
 	void set_render_state_multiplier(double p_render_target_size_multiplier);
 	void set_render_state_render_region(const Rect2i &p_render_region);
+	void set_render_state_view_poses(bool p_is_valid, const PackedVector4Array &p_orientations, const PackedVector3Array &p_positions, const PackedVector4Array &p_fovs);
+	void set_render_state_near_and_far(double p_z_near, double p_z_far);
 
 public:
 	void update_main_swapchain_size();
@@ -483,7 +502,12 @@ public:
 
 	Size2 get_recommended_target_size();
 	XRPose::TrackingConfidence get_head_center(Transform3D &r_transform, Vector3 &r_linear_velocity, Vector3 &r_angular_velocity);
+	TypedArray<Projection> get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far);
+	TypedArray<Transform3D> get_camera_offsets(const StringName &p_tracker_name);
+	bool get_view_offset(uint32_t p_view, Transform3D &r_transform);
+#ifndef DISABLE_DEPRECATED
 	bool get_view_transform(uint32_t p_view, Transform3D &r_transform);
+#endif
 	bool get_view_projection(uint32_t p_view, double p_z_near, double p_z_far, Projection &p_camera_matrix);
 	Vector2 get_eye_focus(uint32_t p_view, float p_aspect);
 	bool process();

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -169,7 +169,18 @@ private:
 	XrSpace play_space = XR_NULL_HANDLE;
 	XrSpace custom_play_space = XR_NULL_HANDLE;
 	XrSpace view_space = XR_NULL_HANDLE;
+
+	// Head info
 	XRPose::TrackingConfidence head_pose_confidence = XRPose::XR_TRACKING_CONFIDENCE_NONE;
+	XrPosef head_pose = { { 0.0, 0.0, 0.0, 1.0 }, { 0.0, 1.6, 0.0 } }; // While we haven't received tracking data, place the camera 1.6 meters above the origin by default.
+	Transform3D head_transform;
+	Vector3 head_linear_velocity;
+	Vector3 head_angular_velocity;
+
+	// View (eye) info
+	bool view_pose_valid = false;
+	LocalVector<Transform3D> view_offsets;
+	LocalVector<XrFovf> view_fovs;
 
 	RID velocity_texture;
 	RID velocity_depth_texture;
@@ -273,6 +284,7 @@ private:
 	bool is_reference_space_supported(XrReferenceSpaceType p_reference_space);
 	bool setup_play_space();
 	bool setup_view_space();
+	void update_head_tracking();
 	bool load_supported_swapchain_formats();
 	bool is_swapchain_format_supported(int64_t p_swapchain_format);
 	bool obtain_swapchain_formats();
@@ -366,12 +378,15 @@ private:
 		uint64_t frame = 0;
 		Rect2i render_region;
 
-		LocalVector<XrView> views;
 		LocalVector<XrCompositionLayerProjectionView> projection_views;
 		LocalVector<XrCompositionLayerDepthInfoKHR> depth_views; // Only used by Composition Layer Depth Extension if available
 		bool submit_depth_buffer = false; // if set to true we submit depth buffers to OpenXR if a suitable extension is enabled.
 		bool use_subsampled_images = true; // We need to default to true for the warning to be shown if we fallback immediately at startup.
+
+		uint32_t view_count = 0;
 		bool view_pose_valid = false;
+		LocalVector<XrPosef> view_poses;
+		LocalVector<XrFovf> view_fovs;
 
 		double z_near = 0.0;
 		double z_far = 0.0;
@@ -396,6 +411,8 @@ private:
 	static void _set_render_environment_blend_mode_rt(int32_t p_environment_blend_mode);
 	static void _set_render_state_multiplier_rt(double p_render_target_size_multiplier);
 	static void _set_render_state_render_region_rt(const Rect2i &p_render_region);
+	static void _set_render_state_view_poses(bool p_is_valid, bool p_should_submit_spatial_container_layers, const PackedVector4Array &p_orientations, const PackedVector3Array &p_positions, const PackedVector4Array &p_fovs);
+	static void _set_render_state_near_and_far(double p_z_near, double p_z_far);
 	static void _update_main_swapchain_size_rt();
 
 	void allocate_view_buffers(uint32_t p_view_count, bool p_submit_depth_buffer);
@@ -405,6 +422,8 @@ private:
 	void set_render_environment_blend_mode(XrEnvironmentBlendMode p_mode);
 	void set_render_state_multiplier(double p_render_target_size_multiplier);
 	void set_render_state_render_region(const Rect2i &p_render_region);
+	void set_render_state_view_poses(bool p_is_valid, bool p_should_submit_spatial_container_layers, const PackedVector4Array &p_orientations, const PackedVector3Array &p_positions, const PackedVector4Array &p_fovs);
+	void set_render_state_near_and_far(double p_z_near, double p_z_far);
 
 public:
 	void update_main_swapchain_size();
@@ -489,7 +508,12 @@ public:
 
 	Size2 get_recommended_target_size();
 	XRPose::TrackingConfidence get_head_center(Transform3D &r_transform, Vector3 &r_linear_velocity, Vector3 &r_angular_velocity);
+	TypedArray<Projection> get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far);
+	TypedArray<Transform3D> get_camera_offsets(const StringName &p_tracker_name);
+	bool get_view_offset(uint32_t p_view, Transform3D &r_transform);
+#ifndef DISABLE_DEPRECATED
 	bool get_view_transform(uint32_t p_view, Transform3D &r_transform);
+#endif
 	bool get_view_projection(uint32_t p_view, double p_z_near, double p_z_far, Projection &p_camera_matrix);
 	Vector2 get_eye_focus(uint32_t p_view, float p_aspect);
 	bool process();

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -702,8 +702,8 @@ bool OpenXRInterface::initialize() {
 
 	// we must create a tracker for our head
 	head.instantiate();
-	head->set_tracker_type(XRServer::TRACKER_HEAD);
-	head->set_tracker_name("head");
+	head->set_tracker_type(XRServer::TRACKER_CAMERA);
+	head->set_tracker_name(XR_TRACKER_HEAD);
 	head->set_tracker_desc("Players head");
 	xr_server->add_tracker(head);
 
@@ -1085,28 +1085,33 @@ Transform3D OpenXRInterface::get_camera_transform() {
 	hmd_transform.basis = head_transform.basis;
 	hmd_transform.origin = head_transform.origin * world_scale;
 
-	return hmd_transform;
+	return xr_server->get_reference_frame() * hmd_transform;
 }
 
+TypedArray<Projection> OpenXRInterface::get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) {
+	ERR_FAIL_NULL_V(openxr_api, TypedArray<Projection>());
+
+	return openxr_api->get_camera_projections(p_tracker_name, p_aspect, p_z_near, p_z_far);
+}
+
+TypedArray<Transform3D> OpenXRInterface::get_camera_offsets(const StringName &p_tracker_name) {
+	ERR_FAIL_NULL_V(openxr_api, TypedArray<Transform3D>());
+
+	return openxr_api->get_camera_offsets(p_tracker_name);
+}
+
+#ifndef DISABLE_DEPRECATED
 Transform3D OpenXRInterface::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL_V(xr_server, Transform3D());
+	ERR_FAIL_NULL_V(openxr_api, Transform3D());
 	ERR_FAIL_UNSIGNED_INDEX_V_MSG(p_view, get_view_count(), Transform3D(), "View index outside bounds.");
 
-	Transform3D t;
-	if (openxr_api && openxr_api->get_view_transform(p_view, t)) {
-		// update our cached value if we have a valid transform
-		transform_for_view[p_view] = t;
-	} else {
-		// reuse cached value
-		t = transform_for_view[p_view];
-	}
+	Transform3D view_offset;
+	openxr_api->get_view_offset(p_view, view_offset);
+	view_offset.origin *= xr_server->get_world_scale();
 
-	// Apply our world scale
-	double world_scale = xr_server->get_world_scale();
-	t.origin *= world_scale;
-
-	return p_cam_transform * xr_server->get_reference_frame() * t;
+	return p_cam_transform * xr_server->get_reference_frame() * head_transform * view_offset;
 }
 
 Projection OpenXRInterface::get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) {
@@ -1124,6 +1129,7 @@ Projection OpenXRInterface::get_projection_for_view(uint32_t p_view, double p_as
 
 	return cm;
 }
+#endif
 
 Rect2i OpenXRInterface::get_render_region() {
 	if (openxr_api) {

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -182,8 +182,12 @@ public:
 	virtual Size2 get_render_target_size() override;
 	virtual uint32_t get_view_count() override;
 	virtual Transform3D get_camera_transform() override;
+	virtual TypedArray<Projection> get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) override;
+	virtual TypedArray<Transform3D> get_camera_offsets(const StringName &p_tracker_name) override;
+#ifndef DISABLE_DEPRECATED
 	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) override;
 	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
+#endif
 
 	virtual Rect2i get_render_region() override;
 

--- a/modules/visionos_xr/visionos_definitions.h
+++ b/modules/visionos_xr/visionos_definitions.h
@@ -32,6 +32,7 @@
 
 #ifdef VISIONOS_ENABLED
 
+#include "core/os/mutex.h"
 #include "core/templates/safe_refcount.h"
 #include "drivers/metal/metal_objects_shared.h"
 #include "drivers/metal/rendering_context_driver_metal.h"

--- a/modules/visionos_xr/visionos_xr_interface.h
+++ b/modules/visionos_xr/visionos_xr_interface.h
@@ -79,6 +79,7 @@ public:
 private:
 	bool initialized = false;
 	XRInterface::TrackingStatus tracking_state;
+	float minimum_supported_near_plane = 0.0;
 
 	RenderingServer *rendering_server;
 
@@ -131,14 +132,17 @@ private:
 		bool initialized = false;
 		RenderingDevice *rendering_device = nullptr;
 		PixelFormats *pixel_formats = nullptr;
+		Mutex mutex;
 
-		float minimum_supported_near_plane = 0;
+		float minimum_supported_near_plane = 0.0;
 
 		// RenderThread must query the device anchor again,
 		// because ar_device_anchor_t objects cannot be safely shared between threads
 		ar_device_anchor_t current_device_anchor = nullptr;
 		ar_world_tracking_provider_t world_tracking_provider = nullptr;
 		Transform3D origin_from_head;
+		double scaled_z_near = 0.1;
+		double scaled_z_far = 4096.0;
 
 		cp_frame_t current_frame = nullptr;
 		cp_drawable_t current_drawable = nullptr;
@@ -160,6 +164,12 @@ private:
 		// is included from non-Objective-C++ translation units.
 		static void encode_drawable_no_op_and_present(cp_drawable_t p_drawable, cp_frame_t p_frame, void *p_command_buffer);
 
+		// Set in pre_render on render thread,
+		// retrieved in main thread when obtaining view info.
+		bool has_view_data = false;
+		Projection view_projections[2];
+		Transform3D view_offsets[2];
+
 	public:
 		void initialize();
 		void uninitialize();
@@ -172,6 +182,10 @@ private:
 		// Expects an ar_world_tracking_provider_t
 		void set_world_tracking_provider(uint64_t p_world_tracking_provider);
 
+		void set_near_and_far(double p_scaled_z_near, double p_scaled_z_far);
+		Projection get_view_projection(uint32_t p_view);
+		Transform3D get_view_offset(uint32_t p_view);
+
 		// Safe to be called from the game thread
 		void start_frame_update();
 		void end_frame_update();
@@ -180,8 +194,10 @@ private:
 		// Only safe to be called from the render thread
 		uint32_t get_view_count();
 		Transform3D get_camera_transform();
+#ifndef DISABLE_DEPRECATED
 		Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform);
 		Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far);
+#endif
 		Rect2i get_render_region();
 
 		void pre_render();
@@ -251,6 +267,8 @@ public:
 	// Methods called from the game thread
 	virtual void process() override;
 	virtual Size2 get_render_target_size() override;
+	virtual TypedArray<Projection> get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) override;
+	virtual TypedArray<Transform3D> get_camera_offsets(const StringName &p_tracker_name) override;
 
 	// Methods only called from the render thread
 	virtual uint32_t get_view_count() override {
@@ -259,12 +277,14 @@ public:
 	virtual Transform3D get_camera_transform() override {
 		return rt.get_camera_transform();
 	}
+#ifndef DISABLE_DEPRECATED
 	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) override {
 		return rt.get_transform_for_view(p_view, p_cam_transform);
 	}
 	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override {
 		return rt.get_projection_for_view(p_view, p_aspect, p_z_near, p_z_far);
 	}
+#endif
 	virtual Rect2i get_render_region() override {
 		return rt.get_render_region();
 	}

--- a/modules/visionos_xr/visionos_xr_interface.mm
+++ b/modules/visionos_xr/visionos_xr_interface.mm
@@ -603,6 +603,88 @@ Size2 VisionOSXRInterface::get_render_target_size() {
 	return rt.get_render_target_size();
 }
 
+TypedArray<Projection> VisionOSXRInterface::get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) {
+	TypedArray<Projection> ret;
+
+	if (!initialized) {
+		return ret;
+	}
+
+	if (p_tracker_name == XR_TRACKER_HEAD) {
+		XRServer *xr_server = XRServer::get_singleton();
+		ERR_FAIL_NULL_V(xr_server, ret);
+
+		float world_scale = xr_server->get_world_scale();
+		double scaled_z_near = p_z_near / world_scale;
+		double scaled_z_far = p_z_far / world_scale;
+
+		ERR_FAIL_COND_V_MSG(scaled_z_near < minimum_supported_near_plane, ret, "Your XRCamera3D Near value is lower than the minimum value supported by the visionOS platform. Make sure that Near divided by XROrigin's World Scale is higher than or equal to the value returned by LayerRender.Capabilities.supportedMinimumNearPlaneDistance. This value is 0.1 for Apple Vision Pro.");
+
+		// We can't get/set data around our projection matrix until our render thread
+		// starts processing our frame.
+		// So our first frame will have an incorrect projection matrix
+		// and our subsequent frames use last frames projection matrix.
+		// Unless our IPD changes, or our near/far changes,
+		// our projection matrices should not change.
+
+		rendering_server = RenderingServer::get_singleton();
+		ERR_FAIL_NULL_V(rendering_server, ret);
+		rendering_server->call_on_render_thread(callable_mp(&rt, &RenderThread::set_near_and_far).bind(scaled_z_near, scaled_z_far));
+
+		// Godot renderers work in the normalized [-1, 1] depth space, and they do a final z remap of the projection matrixes to the [0, 1] depth space in RenderSceneDataRD::update_ubo().
+		// Compositor Services projection matrices are already in the [0, 1] depth space, so we need to apply the inverse z remap before passing them to the renderer.
+		Projection normalized_depth_correction;
+		normalized_depth_correction.set_depth_correction(false, false, true);
+		normalized_depth_correction = normalized_depth_correction.inverse();
+
+		// Correct depth by world_scale
+		Projection reverse_z;
+		real_t *m = &reverse_z.columns[0][0];
+		m[10] = -1.0;
+		m[14] = 1.0;
+
+		Projection world_scale_correction;
+		world_scale_correction.make_scale(Vector3(1, 1, world_scale));
+		world_scale_correction = reverse_z.inverse() * world_scale_correction * reverse_z;
+
+		for (uint32_t v = 0; v < 2; v++) {
+			Projection view_projection = rt.get_view_projection(v);
+			ret.push_back(normalized_depth_correction * world_scale_correction * view_projection);
+		}
+	}
+
+	return ret;
+}
+
+TypedArray<Transform3D> VisionOSXRInterface::get_camera_offsets(const StringName &p_tracker_name) {
+	TypedArray<Transform3D> ret;
+
+	if (!initialized) {
+		return ret;
+	}
+
+	if (p_tracker_name == XR_TRACKER_HEAD) {
+		// We can't get/set data around our offsets until our render thread
+		// starts processing our frame.
+		// So our first frame will have an incorrect offsets
+		// and our subsequent frames use last frames offsets.
+		// Unless our IPD changes, our offsets should not change.
+
+		XRServer *xr_server = XRServer::get_singleton();
+		ERR_FAIL_NULL_V(xr_server, ret);
+
+		float world_scale = xr_server->get_world_scale();
+
+		for (uint32_t v = 0; v < 2; v++) {
+			Transform3D offset = rt.get_view_offset(v);
+			offset.origin *= world_scale;
+			ret.push_back(offset);
+		}
+	}
+
+	return ret;
+}
+
 void VisionOSXRInterface::RenderThread::set_minimum_supported_near_plane(float p_minimum_supported_near_plane) {
 	ERR_NOT_ON_RENDER_THREAD;
 	minimum_supported_near_plane = p_minimum_supported_near_plane;
@@ -623,6 +705,45 @@ void VisionOSXRInterface::RenderThread::set_current_frame(uint64_t p_current_fra
 
 	simd_float4x4 origin_from_head_simd = ar_anchor_get_origin_from_anchor_transform(current_device_anchor);
 	origin_from_head = MTL::simd_to_transform3D(origin_from_head_simd);
+}
+
+void VisionOSXRInterface::RenderThread::set_near_and_far(double p_scaled_z_near, double p_scaled_z_far) {
+	ERR_NOT_ON_RENDER_THREAD;
+
+	scaled_z_near = p_scaled_z_near;
+	scaled_z_far = p_scaled_z_far;
+}
+
+Projection VisionOSXRInterface::RenderThread::get_view_projection(uint32_t p_view) {
+	ERR_FAIL_UNSIGNED_INDEX_V(p_view, 2, Projection());
+
+	if (!has_view_data) {
+		// We want to return a valid projection matrix even if it doesn't match our device.
+		// This will prevent error spam at startup.
+		return Projection::create_for_hmd(p_view + 1, 1.0, 6.0, 15.0, 4.0, 1.0, 0.1, 1000.0);
+	}
+
+	mutex.lock();
+	Projection ret = view_projections[p_view];
+	mutex.unlock();
+
+	return ret;
+}
+
+Transform3D VisionOSXRInterface::RenderThread::get_view_offset(uint32_t p_view) {
+	ERR_FAIL_UNSIGNED_INDEX_V(p_view, 2, Transform3D());
+
+	if (!has_view_data) {
+		// We want to return a valid transform even if it doesn't match our device.
+		// This will prevent error spam at startup.
+		return Transform3D(Basis(), Vector3(p_view == 0 ? -0.03 : 0.03, 0.0, 0.0));
+	}
+
+	mutex.lock();
+	Transform3D ret = view_offsets[p_view];
+	mutex.unlock();
+
+	return ret;
 }
 
 uint32_t VisionOSXRInterface::RenderThread::get_view_count() {
@@ -647,6 +768,7 @@ Transform3D VisionOSXRInterface::RenderThread::get_camera_transform() {
 	return camera_transform;
 }
 
+#ifndef DISABLE_DEPRECATED
 Transform3D VisionOSXRInterface::RenderThread::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
 	Transform3D origin_from_eye;
 	ERR_NOT_ON_RENDER_THREAD_V(origin_from_eye);
@@ -715,6 +837,7 @@ Projection VisionOSXRInterface::RenderThread::get_projection_for_view(uint32_t p
 	eye_projection = normalized_depth_correction.inverse() * reverse_z.inverse() * world_scale_correction * reverse_z * eye_projection;
 	return eye_projection;
 }
+#endif
 
 // The render region is the logical texture size. With foveated rendering, it's bigger than the
 // physical texture size. This value is equivalent to rasterizationRateMap.screenSize.
@@ -801,6 +924,23 @@ void VisionOSXRInterface::RenderThread::pre_render() {
 	} else {
 		ERR_PRINT("Current device anchor is nil, will present drawable without a device anchor.");
 	}
+
+	simd_float2 depth_range = simd_make_float2(scaled_z_far, scaled_z_near);
+	cp_drawable_set_depth_range(current_drawable, depth_range);
+
+	mutex.lock();
+
+	for (uint32_t v = 0; v < 2; v++) {
+		simd_float4x4 eye_simd_projection = cp_drawable_compute_projection(current_drawable, cp_axis_direction_convention_right_up_forward, v);
+		view_projections[v] = MTL::simd_to_projection(eye_simd_projection);
+
+		cp_view_t view = cp_drawable_get_view(current_drawable, v);
+		simd_float4x4 view_offset_simd = cp_view_get_transform(view);
+		view_offsets[v] = MTL::simd_to_transform3D(view_offset_simd);
+	}
+	has_view_data = true;
+
+	mutex.unlock();
 }
 
 Vector<RenderingServerTypes::BlitToScreen> VisionOSXRInterface::RenderThread::post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) {

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -311,8 +311,8 @@ bool WebXRInterfaceJS::initialize() {
 		head_transform.basis = Basis();
 		head_transform.origin = Vector3();
 		head_tracker.instantiate();
-		head_tracker->set_tracker_type(XRServer::TRACKER_HEAD);
-		head_tracker->set_tracker_name("head");
+		head_tracker->set_tracker_type(XRServer::TRACKER_CAMERA);
+		head_tracker->set_tracker_name(XR_TRACKER_HEAD);
 		head_tracker->set_tracker_desc("Players head");
 		xr_server->add_tracker(head_tracker);
 
@@ -454,6 +454,87 @@ Transform3D WebXRInterfaceJS::get_camera_transform() {
 	return camera_transform;
 }
 
+TypedArray<Projection> WebXRInterfaceJS::get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) {
+	TypedArray<Projection> camera_projections;
+
+	if (p_tracker_name != XR_TRACKER_HEAD) {
+		return camera_projections;
+	}
+
+	XRServer *xr_server = XRServer::get_singleton();
+	ERR_FAIL_NULL_V(xr_server, camera_projections);
+	ERR_FAIL_COND_V(!initialized, camera_projections);
+
+	for (uint32_t v = 0; v < get_view_count(); v++) {
+		Projection view;
+
+		float js_matrix[16];
+		bool has_projection = godot_webxr_get_projection_for_view(v, js_matrix);
+		if (!has_projection) {
+			return camera_projections;
+		}
+
+		int k = 0;
+		for (int i = 0; i < 4; i++) {
+			for (int j = 0; j < 4; j++) {
+				view.columns[i][j] = js_matrix[k++];
+			}
+		}
+
+		// Copied from godot_oculus_mobile's ovr_mobile_session.cpp
+		view.columns[2][2] = -(p_z_far + p_z_near) / (p_z_far - p_z_near);
+		view.columns[3][2] = -(2.0f * p_z_far * p_z_near) / (p_z_far - p_z_near);
+
+		camera_projections.push_back(view);
+	}
+
+	return camera_projections;
+}
+
+TypedArray<Transform3D> WebXRInterfaceJS::get_camera_offsets(const StringName &p_tracker_name) {
+	TypedArray<Transform3D> camera_offsets;
+
+	if (p_tracker_name != XR_TRACKER_HEAD) {
+		return camera_offsets;
+	}
+
+	XRServer *xr_server = XRServer::get_singleton();
+	ERR_FAIL_NULL_V(xr_server, camera_offsets);
+	ERR_FAIL_COND_V(!initialized, camera_offsets);
+
+	// Get our world scale
+	double world_scale = xr_server->get_world_scale();
+
+	// Get our head transform
+	float js_matrix[16];
+	bool has_transform = godot_webxr_get_transform_for_view(-1, js_matrix);
+	if (!has_transform) {
+		return camera_offsets;
+	}
+
+	Transform3D inv_head_transform = _js_matrix_to_transform(js_matrix).inverse();
+
+	for (uint32_t v = 0; v < get_view_count(); v++) {
+		// Get our view transform
+		has_transform = godot_webxr_get_transform_for_view(v, js_matrix);
+		if (!has_transform) {
+			return camera_offsets;
+		}
+
+		Transform3D transform_for_view = _js_matrix_to_transform(js_matrix);
+
+		// Calculate the offset
+		Transform3D offset = inv_head_transform * transform_for_view;
+
+		offset.origin *= world_scale;
+
+		camera_offsets.push_back(offset);
+	}
+
+	return camera_offsets;
+}
+
+#ifndef DISABLE_DEPRECATED
 Transform3D WebXRInterfaceJS::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL_V(xr_server, p_cam_transform);
@@ -497,6 +578,7 @@ Projection WebXRInterfaceJS::get_projection_for_view(uint32_t p_view, double p_a
 
 	return view;
 }
+#endif
 
 bool WebXRInterfaceJS::pre_draw_viewport(RID p_render_target) {
 	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();

--- a/modules/webxr/webxr_interface_js.h
+++ b/modules/webxr/webxr_interface_js.h
@@ -131,8 +131,12 @@ public:
 	virtual Size2 get_render_target_size() override;
 	virtual uint32_t get_view_count() override;
 	virtual Transform3D get_camera_transform() override;
+	virtual TypedArray<Projection> get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) override;
+	virtual TypedArray<Transform3D> get_camera_offsets(const StringName &p_tracker_name) override;
+#ifndef DISABLE_DEPRECATED
 	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) override;
 	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
+#endif
 	virtual bool pre_draw_viewport(RID p_render_target) override;
 	virtual Vector<RenderingServerTypes::BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) override;
 	virtual RID get_color_texture() override;

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -117,7 +117,7 @@ protected:
 
 	void _update_camera();
 	virtual void _request_camera_update();
-	void _update_camera_mode();
+	virtual void _update_camera_mode();
 
 	virtual void fti_pump_property() override;
 	virtual void fti_update_servers_property() override;

--- a/scene/3d/xr/xr_nodes.cpp
+++ b/scene/3d/xr/xr_nodes.cpp
@@ -36,9 +36,16 @@
 #include "core/object/class_db.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/viewport.h"
+#include "servers/rendering/rendering_server.h"
 #include "servers/xr/xr_interface.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void XRCamera3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_tracker", "tracker_name"), &XRCamera3D::set_tracker);
+	ClassDB::bind_method(D_METHOD("get_tracker"), &XRCamera3D::get_tracker);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "tracker", PROPERTY_HINT_ENUM_SUGGESTION), "set_tracker", "get_tracker");
+}
 
 void XRCamera3D::_validate_property(PropertyInfo &p_property) const {
 	if (!Engine::get_singleton()->is_editor_hint()) {
@@ -47,21 +54,99 @@ void XRCamera3D::_validate_property(PropertyInfo &p_property) const {
 	// Hide properties that are managed by XRInterface or otherwise not applicable for XRCamera3D.
 	if (p_property.name == "fov" || p_property.name == "projection" || p_property.name == "size" || p_property.name == "frustum_offset" || p_property.name == "keep_aspect") {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+	} else if (p_property.name == "tracker") {
+		// Set to our default head tracker.
+		String hint_string = "head";
+		p_property.hint_string = hint_string;
 	}
+}
+
+void XRCamera3D::set_tracker(const StringName &p_tracker_name) {
+	if (tracker.is_valid() && tracker->get_tracker_name() == p_tracker_name) {
+		// didn't change
+		return;
+	}
+
+	// just in case
+	_unbind_tracker();
+
+	// copy the name
+	tracker_name = p_tracker_name;
+	pose_name = SceneStringName(default_);
+
+	// see if it's already available
+	_bind_tracker();
+
+	update_configuration_warnings();
+	notify_property_list_changed();
+}
+
+StringName XRCamera3D::get_tracker() const {
+	return tracker_name;
+}
+
+void XRCamera3D::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			if (is_current()) {
+				_update_projections();
+			}
+		} break;
+	}
+}
+
+void XRCamera3D::_update_camera_mode() {
+	// Ignore this here, we are setting our projection matrices later.
+}
+
+void XRCamera3D::fti_update_servers_property() {
+	// Skip the logic in Camera3D.
+	Node3D::fti_update_servers_property();
+}
+
+void XRCamera3D::_update_projections() {
+	if (tracker.is_null()) {
+		return;
+	}
+
+	RenderingServer *rendering_server = RenderingServer::get_singleton();
+	ERR_FAIL_NULL(rendering_server);
+	XRServer *xr_server = XRServer::get_singleton();
+	ERR_FAIL_NULL(xr_server);
+	Viewport *vp = get_viewport();
+	ERR_FAIL_NULL(vp);
+
+	Size2 viewport_size = vp->get_visible_rect().size;
+
+	rendering_server->camera_set_xr_projections(
+			get_camera(),
+			xr_server->get_camera_projections(tracker_name, viewport_size.aspect(), get_near(), get_far()),
+			xr_server->get_camera_offsets(tracker_name));
+
+	return;
 }
 
 void XRCamera3D::_bind_tracker() {
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL(xr_server);
 
-	tracker = xr_server->get_tracker(tracker_name);
-	if (tracker.is_valid()) {
-		tracker->connect("pose_changed", callable_mp(this, &XRCamera3D::_pose_changed));
+	Ref<XRTracker> new_tracker = xr_server->get_tracker(tracker_name);
+	if (new_tracker.is_null()) {
+		// Fail silently, tracker does not yet exist.
+		return;
+	} else if (tracker == new_tracker) {
+		// Already bound?
+		return;
+	}
 
-		Ref<XRPose> pose = tracker->get_pose(pose_name);
-		if (pose.is_valid()) {
-			set_transform(pose->get_adjusted_transform());
-		}
+	// Assign our new tracker
+	tracker = new_tracker;
+	tracker->connect("pose_changed", callable_mp(this, &XRCamera3D::_pose_changed));
+
+	// Update our initial pose
+	Ref<XRPose> pose = tracker->get_pose(pose_name);
+	if (pose.is_valid()) {
+		set_transform(pose->get_adjusted_transform());
 	}
 }
 
@@ -74,6 +159,8 @@ void XRCamera3D::_unbind_tracker() {
 
 void XRCamera3D::_changed_tracker(const StringName &p_tracker_name, int p_tracker_type) {
 	if (p_tracker_name == tracker_name) {
+		// Rebind it.
+		_unbind_tracker();
 		_bind_tracker();
 	}
 }
@@ -221,6 +308,9 @@ Vector<Plane> XRCamera3D::get_frustum() const {
 XRCamera3D::XRCamera3D() {
 	// XRCamera3D gets its transform updated every render frame and shouldn't be interpolated.
 	set_physics_interpolation_mode(Node::PHYSICS_INTERPOLATION_MODE_OFF);
+
+	// Run internal process at runtime.
+	set_desired_process_modes(!Engine::get_singleton()->is_editor_hint(), false);
 
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL(xr_server);

--- a/scene/3d/xr/xr_nodes.h
+++ b/scene/3d/xr/xr_nodes.h
@@ -41,13 +41,17 @@ class XRCamera3D : public Camera3D {
 	GDCLASS(XRCamera3D, Camera3D);
 
 protected:
-	// The name and pose for our HMD tracker is currently the only hardcoded bit.
-	// If we ever are able to support multiple HMDs we may need to make this settable.
-	StringName tracker_name = "head";
+	StringName tracker_name = XR_TRACKER_HEAD;
 	StringName pose_name = SceneStringName(default_);
 	Ref<XRPositionalTracker> tracker;
 
+	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
+	void _notification(int p_what);
+
+	virtual void _update_camera_mode() override;
+	virtual void fti_update_servers_property() override;
+	void _update_projections();
 
 	void _bind_tracker();
 	void _unbind_tracker();
@@ -63,6 +67,9 @@ public:
 	virtual Point2 unproject_position(const Vector3 &p_pos) const override;
 	virtual Vector3 project_position(const Point2 &p_point, real_t p_z_depth) const override;
 	virtual Vector<Plane> get_frustum() const override;
+
+	void set_tracker(const StringName &p_tracker_name);
+	StringName get_tracker() const;
 
 	XRCamera3D();
 	~XRCamera3D();

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1365,6 +1365,9 @@ void RendererSceneRenderRD::render_scene(const Ref<RenderSceneBuffers> &p_render
 	Ref<RenderSceneBuffersRD> rb = p_render_buffers;
 	ERR_FAIL_COND(rb.is_null());
 
+	// View count of our render target must match our camera data.
+	ERR_FAIL_COND(rb->get_view_count() != p_camera_data->view_count);
+
 	// setup scene data
 	RenderSceneDataRD scene_data;
 	{
@@ -1372,6 +1375,7 @@ void RendererSceneRenderRD::render_scene(const Ref<RenderSceneBuffers> &p_render
 		scene_data.cam_transform = p_camera_data->main_transform;
 		scene_data.cam_projection = p_camera_data->main_projection;
 		scene_data.cam_orthogonal = p_camera_data->is_orthogonal;
+		scene_data.cam_asymmetrical = p_camera_data->is_asymmetrical;
 		scene_data.camera_visible_layers = p_camera_data->visible_layers;
 		scene_data.taa_jitter = p_camera_data->taa_jitter;
 		scene_data.taa_frame_count = p_camera_data->taa_frame_count;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1370,6 +1370,9 @@ void RendererSceneRenderRD::render_scene(const Ref<RenderSceneBuffers> &p_render
 	Ref<RenderSceneBuffersRD> rb = p_render_buffers;
 	ERR_FAIL_COND(rb.is_null());
 
+	// View count of our render target must match our camera data.
+	ERR_FAIL_COND(rb->get_view_count() != p_camera_data->view_count);
+
 	// setup scene data
 	RenderSceneDataRD scene_data;
 	{

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
@@ -48,6 +48,7 @@ public:
 	float taa_frame_count = 0.0f;
 	uint32_t camera_visible_layers;
 	bool cam_orthogonal = false;
+	bool cam_asymmetrical = false;
 	bool flip_y = false;
 
 	// For billboards to cast correct shadows.

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -41,7 +41,6 @@
 
 #ifndef XR_DISABLED
 #include "servers/xr/xr_interface.h"
-#include "servers/xr/xr_server.h"
 #endif
 
 //#define DEBUG_CULL_TIME
@@ -94,6 +93,8 @@ void RendererSceneCull::camera_set_perspective(RID p_camera, float p_fovy_degree
 	camera->fov = p_fovy_degrees;
 	camera->znear = p_z_near;
 	camera->zfar = p_z_far;
+	camera->offsets.clear();
+	camera->projections.clear();
 }
 
 void RendererSceneCull::camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) {
@@ -103,6 +104,8 @@ void RendererSceneCull::camera_set_orthogonal(RID p_camera, float p_size, float 
 	camera->size = p_size;
 	camera->znear = p_z_near;
 	camera->zfar = p_z_far;
+	camera->offsets.clear();
+	camera->projections.clear();
 }
 
 void RendererSceneCull::camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) {
@@ -113,6 +116,32 @@ void RendererSceneCull::camera_set_frustum(RID p_camera, float p_size, Vector2 p
 	camera->offset = p_offset;
 	camera->znear = p_z_near;
 	camera->zfar = p_z_far;
+	camera->offsets.clear();
+	camera->projections.clear();
+}
+
+void RendererSceneCull::camera_set_xr_projections(RID p_camera, TypedArray<Projection> p_projections, TypedArray<Transform3D> p_offsets) {
+	ERR_FAIL_COND(p_projections.is_empty());
+	bool has_offsets = !p_offsets.is_empty();
+	ERR_FAIL_COND(has_offsets && p_offsets.size() != p_projections.size());
+
+	for (const Projection projection : p_projections) {
+		ERR_FAIL_COND_MSG(!projection.is_z_axis_projection(), "Projections must be z-axis aligned. Use [param p_offsets] to apply any transforms.");
+	}
+
+	Camera *camera = camera_owner.get_or_null(p_camera);
+	ERR_FAIL_NULL(camera);
+	camera->type = Camera::MULTIVIEW_PROJECTION;
+	camera->offsets.resize(p_projections.size());
+	camera->projections.resize(p_projections.size());
+	for (int i = 0; i < p_projections.size(); i++) {
+		if (has_offsets) {
+			camera->offsets[i] = p_offsets[i];
+		} else {
+			camera->offsets[i] = Transform3D();
+		}
+		camera->projections[i] = p_projections[i];
+	}
 }
 
 void RendererSceneCull::camera_set_transform(RID p_camera, const Transform3D &p_transform) {
@@ -2671,7 +2700,7 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 	return animated_material_found;
 }
 
-void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_screen_mesh_lod_threshold, RID p_shadow_atlas, Ref<XRInterface> &p_xr_interface, float p_window_output_max_value, RenderingServerTypes::RenderInfo *r_render_info) {
+void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_screen_mesh_lod_threshold, RID p_shadow_atlas, float p_window_output_max_value, RenderingServerTypes::RenderInfo *r_render_info) {
 #ifndef _3D_DISABLED
 
 	Camera *camera = camera_owner.get_or_null(p_camera);
@@ -2698,89 +2727,79 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 	RendererSceneRender::CameraData camera_data;
 
 	// Setup Camera(s)
-	if (p_xr_interface.is_null()) {
-		// Normal camera
-		Transform3D transform = camera->transform;
-		Projection projection;
-		bool vaspect = camera->vaspect;
-		bool is_orthogonal = false;
+	// Normal camera
+	Transform3D transform = camera->transform;
+	bool vaspect = camera->vaspect;
+	bool is_orthogonal = false;
+	bool is_asymmetrical = false;
 
-		switch (camera->type) {
-			case Camera::ORTHOGONAL: {
-				projection.set_orthogonal(
-						camera->size,
-						p_viewport_size.width / (float)p_viewport_size.height,
-						camera->znear,
-						camera->zfar,
-						camera->vaspect);
-				is_orthogonal = true;
-			} break;
-			case Camera::PERSPECTIVE: {
-				projection.set_perspective(
-						camera->fov,
-						p_viewport_size.width / (float)p_viewport_size.height,
-						camera->znear,
-						camera->zfar,
-						camera->vaspect);
+	switch (camera->type) {
+		case Camera::ORTHOGONAL: {
+			Projection projection;
+			projection.set_orthogonal(
+					camera->size,
+					p_viewport_size.width / (float)p_viewport_size.height,
+					camera->znear,
+					camera->zfar,
+					camera->vaspect);
+			is_orthogonal = true;
 
-			} break;
-			case Camera::FRUSTUM: {
-				projection.set_frustum(
-						camera->size,
-						p_viewport_size.width / (float)p_viewport_size.height,
-						camera->offset,
-						camera->znear,
-						camera->zfar,
-						camera->vaspect);
-			} break;
-		}
+			camera->offsets.resize(1);
+			camera->offsets[0] = Transform3D();
+			camera->projections.resize(1);
+			camera->projections[0] = projection;
+		} break;
+		case Camera::PERSPECTIVE: {
+			Projection projection;
+			projection.set_perspective(
+					camera->fov,
+					p_viewport_size.width / (float)p_viewport_size.height,
+					camera->znear,
+					camera->zfar,
+					camera->vaspect);
 
-		camera_data.set_camera(transform, projection, is_orthogonal, vaspect, jitter, taa_frame_count, camera->visible_layers);
-#ifndef XR_DISABLED
+			camera->offsets.resize(1);
+			camera->offsets[0] = Transform3D();
+			camera->projections.resize(1);
+			camera->projections[0] = projection;
+		} break;
+		case Camera::FRUSTUM: {
+			Projection projection;
+			projection.set_frustum(
+					camera->size,
+					p_viewport_size.width / (float)p_viewport_size.height,
+					camera->offset,
+					camera->znear,
+					camera->zfar,
+					camera->vaspect);
+
+			camera->offsets.resize(1);
+			camera->offsets[0] = Transform3D();
+			camera->projections.resize(1);
+			camera->projections[0] = projection;
+		} break;
+		case Camera::MULTIVIEW_PROJECTION:
+			break;
+	}
+
+	for (const Projection &projection : camera->projections) {
+		is_orthogonal |= projection.is_orthogonal();
+		is_asymmetrical |= projection.is_asymmetrical();
+	}
+
+	if (camera->projections.size() == 1) {
+		camera_data.set_camera(transform * camera->offsets[0], camera->projections[0], is_orthogonal, is_asymmetrical, vaspect, jitter, taa_frame_count, camera->visible_layers);
+	} else if (camera->projections.size() == 2) {
+		camera_data.set_multiview_camera(transform, camera->offsets, camera->projections, is_orthogonal, is_asymmetrical, vaspect, camera->visible_layers);
 	} else {
-		XRServer *xr_server = XRServer::get_singleton();
-
-		// Setup our camera for our XR interface.
-		// We can support multiple views here each with their own camera
-		Transform3D transforms[RendererSceneRender::MAX_RENDER_VIEWS];
-		Projection projections[RendererSceneRender::MAX_RENDER_VIEWS];
-
-		uint32_t view_count = p_xr_interface->get_view_count();
-		ERR_FAIL_COND_MSG(view_count == 0 || view_count > RendererSceneRender::MAX_RENDER_VIEWS, "Requested view count is not supported");
-
-		float aspect = p_viewport_size.width / (float)p_viewport_size.height;
-
-		Transform3D world_origin = xr_server->get_world_origin();
-
-		// We ignore our camera position, it will have been positioned with a slightly old tracking position.
-		// Instead we take our origin point and have our XR interface add fresh tracking data! Whoohoo!
-		for (uint32_t v = 0; v < view_count; v++) {
-			transforms[v] = p_xr_interface->get_transform_for_view(v, world_origin);
-			projections[v] = p_xr_interface->get_projection_for_view(v, aspect, camera->znear, camera->zfar);
-		}
-
-		// If requested, we move the views to be rendered as if the HMD is at the XROrigin.
-		if (unlikely(xr_server->is_camera_locked_to_origin())) {
-			Transform3D camera_reset = p_xr_interface->get_camera_transform().affine_inverse() * xr_server->get_reference_frame().affine_inverse();
-			for (uint32_t v = 0; v < view_count; v++) {
-				transforms[v] *= camera_reset;
-			}
-		}
-
-		if (view_count == 1) {
-			camera_data.set_camera(transforms[0], projections[0], false, camera->vaspect, jitter, p_jitter_phase_count, camera->visible_layers);
-		} else if (view_count == 2) {
-			camera_data.set_multiview_camera(view_count, transforms, projections, false, camera->vaspect, camera->visible_layers);
-		} else {
-			// this won't be called (see fail check above) but keeping this comment to indicate we may support more then 2 views in the future...
-		}
-#endif // XR_DISABLED
+		ERR_FAIL_MSG("Unsupported camera setup.");
 	}
 
 	RID environment = _render_get_environment(p_camera, p_scenario);
 	RID compositor = _render_get_compositor(p_camera, p_scenario);
 
 	RENDER_TIMESTAMP("Update Occlusion Buffer")
+
 	// For now just cull on the first camera
 	RendererSceneOcclusionCull::get_singleton()->buffer_update(p_viewport, camera_data.main_transform, camera_data.main_projection, camera_data.is_orthogonal);
 
@@ -3773,7 +3792,7 @@ void RendererSceneCull::render_empty_scene(const Ref<RenderSceneBuffers> &p_rend
 	RENDER_TIMESTAMP("Render Empty 3D Scene");
 
 	RendererSceneRender::CameraData camera_data;
-	camera_data.set_camera(Transform3D(), Projection(), true, false);
+	camera_data.set_camera(Transform3D(), Projection(), true, false, false);
 
 	scene_render->render_scene(p_render_buffers, &camera_data, &camera_data, PagedArray<RenderGeometryInstance *>(), PagedArray<RID>(), PagedArray<RID>(), PagedArray<RID>(), PagedArray<RID>(), PagedArray<RID>(), PagedArray<RID>(), environment, RID(), compositor, p_shadow_atlas, RID(), scenario->reflection_atlas, RID(), 0, 0, nullptr, 0, nullptr, 0, p_window_output_max_value, nullptr);
 #endif
@@ -3839,7 +3858,7 @@ bool RendererSceneCull::_render_reflection_probe_step(Instance *p_instance, int 
 
 			RendererSceneRender::CameraData camera_data;
 			Transform3D xform = p_instance->transform * local_view;
-			camera_data.set_camera(xform, cm, false, false);
+			camera_data.set_camera(xform, cm, false, false, false);
 
 			RENDER_TIMESTAMP("Render ReflectionProbe, Face " + itos(face));
 			_render_scene(&camera_data, render_buffers, environment, RID(), RID(), RSG::light_storage->reflection_probe_get_cull_mask(p_instance->base), p_instance->scenario->self, RID(), shadow_atlas, reflection_probe->instance, face, mesh_lod_threshold, use_shadows);

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -41,7 +41,6 @@
 
 #ifndef XR_DISABLED
 #include "servers/xr/xr_interface.h"
-#include "servers/xr/xr_server.h"
 #endif
 
 //#define DEBUG_CULL_TIME
@@ -94,6 +93,8 @@ void RendererSceneCull::camera_set_perspective(RID p_camera, float p_fovy_degree
 	camera->fov = p_fovy_degrees;
 	camera->znear = p_z_near;
 	camera->zfar = p_z_far;
+	camera->offsets.clear();
+	camera->projections.clear();
 }
 
 void RendererSceneCull::camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) {
@@ -103,6 +104,8 @@ void RendererSceneCull::camera_set_orthogonal(RID p_camera, float p_size, float 
 	camera->size = p_size;
 	camera->znear = p_z_near;
 	camera->zfar = p_z_far;
+	camera->offsets.clear();
+	camera->projections.clear();
 }
 
 void RendererSceneCull::camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) {
@@ -113,6 +116,28 @@ void RendererSceneCull::camera_set_frustum(RID p_camera, float p_size, Vector2 p
 	camera->offset = p_offset;
 	camera->znear = p_z_near;
 	camera->zfar = p_z_far;
+	camera->offsets.clear();
+	camera->projections.clear();
+}
+
+void RendererSceneCull::camera_set_xr_projections(RID p_camera, TypedArray<Projection> p_projections, TypedArray<Transform3D> p_offsets) {
+	ERR_FAIL_COND(p_projections.is_empty());
+	bool has_offsets = !p_offsets.is_empty();
+	ERR_FAIL_COND(has_offsets && p_offsets.size() != p_projections.size());
+
+	Camera *camera = camera_owner.get_or_null(p_camera);
+	ERR_FAIL_NULL(camera);
+	camera->type = Camera::MULTIVIEW_PROJECTION;
+	camera->offsets.resize(p_projections.size());
+	camera->projections.resize(p_projections.size());
+	for (int i = 0; i < p_projections.size(); i++) {
+		if (has_offsets) {
+			camera->offsets[i] = p_offsets[i];
+		} else {
+			camera->offsets[i] = Transform3D();
+		}
+		camera->projections[i] = p_projections[i];
+	}
 }
 
 void RendererSceneCull::camera_set_transform(RID p_camera, const Transform3D &p_transform) {
@@ -2673,7 +2698,7 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 	return animated_material_found;
 }
 
-void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_screen_mesh_lod_threshold, RID p_shadow_atlas, Ref<XRInterface> &p_xr_interface, float p_window_output_max_value, RenderingServerTypes::RenderInfo *r_render_info) {
+void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_screen_mesh_lod_threshold, RID p_shadow_atlas, float p_window_output_max_value, RenderingServerTypes::RenderInfo *r_render_info) {
 #ifndef _3D_DISABLED
 
 	Camera *camera = camera_owner.get_or_null(p_camera);
@@ -2700,89 +2725,77 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 	RendererSceneRender::CameraData camera_data;
 
 	// Setup Camera(s)
-	if (p_xr_interface.is_null()) {
-		// Normal camera
-		Transform3D transform = camera->transform;
-		Projection projection;
-		bool vaspect = camera->vaspect;
-		bool is_orthogonal = false;
+	// Normal camera
+	Transform3D transform = camera->transform;
+	bool vaspect = camera->vaspect;
+	bool is_orthogonal = false;
 
-		switch (camera->type) {
-			case Camera::ORTHOGONAL: {
-				projection.set_orthogonal(
-						camera->size,
-						p_viewport_size.width / (float)p_viewport_size.height,
-						camera->znear,
-						camera->zfar,
-						camera->vaspect);
-				is_orthogonal = true;
-			} break;
-			case Camera::PERSPECTIVE: {
-				projection.set_perspective(
-						camera->fov,
-						p_viewport_size.width / (float)p_viewport_size.height,
-						camera->znear,
-						camera->zfar,
-						camera->vaspect);
+	switch (camera->type) {
+		case Camera::ORTHOGONAL: {
+			Projection projection;
+			projection.set_orthogonal(
+					camera->size,
+					p_viewport_size.width / (float)p_viewport_size.height,
+					camera->znear,
+					camera->zfar,
+					camera->vaspect);
+			is_orthogonal = true;
 
-			} break;
-			case Camera::FRUSTUM: {
-				projection.set_frustum(
-						camera->size,
-						p_viewport_size.width / (float)p_viewport_size.height,
-						camera->offset,
-						camera->znear,
-						camera->zfar,
-						camera->vaspect);
-			} break;
-		}
+			camera->offsets.resize(1);
+			camera->offsets[0] = Transform3D();
+			camera->projections.resize(1);
+			camera->projections[0] = projection;
+		} break;
+		case Camera::PERSPECTIVE: {
+			Projection projection;
+			projection.set_perspective(
+					camera->fov,
+					p_viewport_size.width / (float)p_viewport_size.height,
+					camera->znear,
+					camera->zfar,
+					camera->vaspect);
 
-		camera_data.set_camera(transform, projection, is_orthogonal, vaspect, jitter, taa_frame_count, camera->visible_layers);
-#ifndef XR_DISABLED
+			camera->offsets.resize(1);
+			camera->offsets[0] = Transform3D();
+			camera->projections.resize(1);
+			camera->projections[0] = projection;
+		} break;
+		case Camera::FRUSTUM: {
+			Projection projection;
+			projection.set_frustum(
+					camera->size,
+					p_viewport_size.width / (float)p_viewport_size.height,
+					camera->offset,
+					camera->znear,
+					camera->zfar,
+					camera->vaspect);
+
+			camera->offsets.resize(1);
+			camera->offsets[0] = Transform3D();
+			camera->projections.resize(1);
+			camera->projections[0] = projection;
+		} break;
+		case Camera::MULTIVIEW_PROJECTION:
+			break;
+	}
+
+	for (const Projection &projection : camera->projections) {
+		is_orthogonal |= projection.is_orthogonal();
+	}
+
+	if (camera->projections.size() == 1) {
+		camera_data.set_camera(transform * camera->offsets[0], camera->projections[0], is_orthogonal, vaspect, jitter, taa_frame_count, camera->visible_layers);
+	} else if (camera->projections.size() == 2) {
+		camera_data.set_multiview_camera(transform, camera->offsets, camera->projections, is_orthogonal, vaspect, camera->visible_layers);
 	} else {
-		XRServer *xr_server = XRServer::get_singleton();
-
-		// Setup our camera for our XR interface.
-		// We can support multiple views here each with their own camera
-		Transform3D transforms[RendererSceneRender::MAX_RENDER_VIEWS];
-		Projection projections[RendererSceneRender::MAX_RENDER_VIEWS];
-
-		uint32_t view_count = p_xr_interface->get_view_count();
-		ERR_FAIL_COND_MSG(view_count == 0 || view_count > RendererSceneRender::MAX_RENDER_VIEWS, "Requested view count is not supported");
-
-		float aspect = p_viewport_size.width / (float)p_viewport_size.height;
-
-		Transform3D world_origin = xr_server->get_world_origin();
-
-		// We ignore our camera position, it will have been positioned with a slightly old tracking position.
-		// Instead we take our origin point and have our XR interface add fresh tracking data! Whoohoo!
-		for (uint32_t v = 0; v < view_count; v++) {
-			transforms[v] = p_xr_interface->get_transform_for_view(v, world_origin);
-			projections[v] = p_xr_interface->get_projection_for_view(v, aspect, camera->znear, camera->zfar);
-		}
-
-		// If requested, we move the views to be rendered as if the HMD is at the XROrigin.
-		if (unlikely(xr_server->is_camera_locked_to_origin())) {
-			Transform3D camera_reset = p_xr_interface->get_camera_transform().affine_inverse() * xr_server->get_reference_frame().affine_inverse();
-			for (uint32_t v = 0; v < view_count; v++) {
-				transforms[v] *= camera_reset;
-			}
-		}
-
-		if (view_count == 1) {
-			camera_data.set_camera(transforms[0], projections[0], false, camera->vaspect, jitter, p_jitter_phase_count, camera->visible_layers);
-		} else if (view_count == 2) {
-			camera_data.set_multiview_camera(view_count, transforms, projections, false, camera->vaspect, camera->visible_layers);
-		} else {
-			// this won't be called (see fail check above) but keeping this comment to indicate we may support more then 2 views in the future...
-		}
-#endif // XR_DISABLED
+		ERR_FAIL_MSG("Unsupported camera setup.");
 	}
 
 	RID environment = _render_get_environment(p_camera, p_scenario);
 	RID compositor = _render_get_compositor(p_camera, p_scenario);
 
 	RENDER_TIMESTAMP("Update Occlusion Buffer")
+
 	// For now just cull on the first camera
 	RendererSceneOcclusionCull::get_singleton()->buffer_update(p_viewport, camera_data.main_transform, camera_data.main_projection, camera_data.is_orthogonal);
 

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -75,7 +75,8 @@ public:
 		enum Type {
 			PERSPECTIVE,
 			ORTHOGONAL,
-			FRUSTUM
+			FRUSTUM,
+			MULTIVIEW_PROJECTION,
 		};
 		Type type;
 		float fov;
@@ -88,7 +89,9 @@ public:
 		RID attributes;
 		RID compositor;
 
-		Transform3D transform;
+		Transform3D transform; // Our main camera transform
+		LocalVector<Transform3D> offsets; // camera offsets for each view
+		LocalVector<Projection> projections; // projection matrix for each view
 
 		Camera() {
 			visible_layers = 0xFFFFFFFF;
@@ -110,6 +113,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far);
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far);
+	virtual void camera_set_xr_projections(RID p_camera, TypedArray<Projection> p_projections, TypedArray<Transform3D> p_offsets = TypedArray<Transform3D>());
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform);
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers);
 	virtual void camera_set_environment(RID p_camera, RID p_env);
@@ -1156,7 +1160,7 @@ public:
 	void _render_scene(const RendererSceneRender::CameraData *p_camera_data, const Ref<RenderSceneBuffers> &p_render_buffers, RID p_environment, RID p_force_camera_attributes, RID p_compositor, uint32_t p_visible_layers, RID p_scenario, RID p_viewport, RID p_shadow_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, float p_window_output_max_value, bool p_using_shadows = true, RenderingServerTypes::RenderInfo *r_render_info = nullptr);
 	void render_empty_scene(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_scenario, RID p_shadow_atlas, float p_window_output_max_value);
 
-	void render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_screen_mesh_lod_threshold, RID p_shadow_atlas, Ref<XRInterface> &p_xr_interface, float p_window_output_max_value, RenderingServerTypes::RenderInfo *r_render_info = nullptr);
+	void render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_screen_mesh_lod_threshold, RID p_shadow_atlas, float p_window_output_max_value, RenderingServerTypes::RenderInfo *r_render_info = nullptr);
 	void update_dirty_instances() const;
 
 	void render_particle_colliders();

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -75,7 +75,8 @@ public:
 		enum Type {
 			PERSPECTIVE,
 			ORTHOGONAL,
-			FRUSTUM
+			FRUSTUM,
+			MULTIVIEW_PROJECTION,
 		};
 		Type type;
 		float fov;
@@ -88,7 +89,9 @@ public:
 		RID attributes;
 		RID compositor;
 
-		Transform3D transform;
+		Transform3D transform; // Our main camera transform
+		LocalVector<Transform3D> offsets; // camera offsets for each view
+		LocalVector<Projection> projections; // projection matrix for each view
 
 		Camera() {
 			visible_layers = 0xFFFFFFFF;
@@ -110,6 +113,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far);
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far);
+	virtual void camera_set_xr_projections(RID p_camera, TypedArray<Projection> p_projections, TypedArray<Transform3D> p_offsets = TypedArray<Transform3D>());
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform);
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers);
 	virtual void camera_set_environment(RID p_camera, RID p_env);
@@ -1160,7 +1164,7 @@ public:
 	void _render_scene(const RendererSceneRender::CameraData *p_camera_data, const Ref<RenderSceneBuffers> &p_render_buffers, RID p_environment, RID p_force_camera_attributes, RID p_compositor, uint32_t p_visible_layers, RID p_scenario, RID p_viewport, RID p_shadow_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, float p_window_output_max_value, bool p_using_shadows = true, RenderingServerTypes::RenderInfo *r_render_info = nullptr);
 	void render_empty_scene(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_scenario, RID p_shadow_atlas, float p_window_output_max_value);
 
-	void render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_screen_mesh_lod_threshold, RID p_shadow_atlas, Ref<XRInterface> &p_xr_interface, float p_window_output_max_value, RenderingServerTypes::RenderInfo *r_render_info = nullptr);
+	void render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_screen_mesh_lod_threshold, RID p_shadow_atlas, float p_window_output_max_value, RenderingServerTypes::RenderInfo *r_render_info = nullptr);
 	void update_dirty_instances() const;
 
 	void render_particle_colliders();

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -35,9 +35,10 @@
 /////////////////////////////////////////////////////////////////////////////
 // CameraData
 
-void RendererSceneRender::CameraData::set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter, float p_taa_frame_count, uint32_t p_visible_layers) {
+void RendererSceneRender::CameraData::set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_is_asymmetrical, bool p_vaspect, const Vector2 &p_taa_jitter, float p_taa_frame_count, uint32_t p_visible_layers) {
 	view_count = 1;
 	is_orthogonal = p_is_orthogonal;
+	is_asymmetrical = p_is_asymmetrical;
 	vaspect = p_vaspect;
 
 	main_transform = p_transform;
@@ -50,141 +51,21 @@ void RendererSceneRender::CameraData::set_camera(const Transform3D p_transform, 
 	taa_frame_count = p_taa_frame_count;
 }
 
-void RendererSceneRender::CameraData::set_multiview_camera(uint32_t p_view_count, const Transform3D *p_transforms, const Projection *p_projections, bool p_is_orthogonal, bool p_vaspect, uint32_t p_visible_layers) {
-	ERR_FAIL_COND_MSG(p_view_count != 2, "Incorrect view count for stereoscopic view");
+void RendererSceneRender::CameraData::set_multiview_camera(const Transform3D &p_transform, const LocalVector<Transform3D> &p_offsets, const LocalVector<Projection> &p_projections, bool p_is_orthogonal, bool p_is_asymmetrical, bool p_vaspect, uint32_t p_visible_layers) {
+	ERR_FAIL_COND_MSG(p_projections.size() != 2, "Incorrect view count for stereoscopic view");
+	ERR_FAIL_COND(p_projections.size() != p_offsets.size());
 
 	visible_layers = p_visible_layers;
-	view_count = p_view_count;
+	view_count = p_projections.size();
 	is_orthogonal = p_is_orthogonal;
+	is_asymmetrical = p_is_asymmetrical;
 	vaspect = p_vaspect;
-	Vector<Plane> planes[2];
 
-	/////////////////////////////////////////////////////////////////////////////
-	// Figure out our center transform
+	main_transform = p_transform;
+	main_projection = Projection::create_combined_projection(p_transform, p_projections[0], p_offsets[0], p_projections[1], p_offsets[1]);
 
-	// 1. obtain our planes
 	for (uint32_t v = 0; v < view_count; v++) {
-		planes[v] = p_projections[v].get_projection_planes(p_transforms[v]);
-	}
-
-	// 2. average and normalize plane normals to obtain z vector, cross them to obtain y vector, and from there the x vector for combined camera basis.
-	Vector3 n0 = planes[0][Projection::PLANE_LEFT].normal;
-	Vector3 n1 = planes[1][Projection::PLANE_RIGHT].normal;
-	Vector3 z = (n0 + n1).normalized();
-	Vector3 y = n0.cross(n1).normalized();
-	Vector3 x = y.cross(z).normalized();
-	y = z.cross(x).normalized();
-	main_transform.basis.set_columns(x, y, z);
-
-	// 3. create a horizon plane with one of the eyes and the up vector as normal.
-	Plane horizon(y, p_transforms[0].origin);
-
-	// 4. Intersect horizon, left and right to obtain the combined camera origin.
-	ERR_FAIL_COND_MSG(
-			!horizon.intersect_3(planes[0][Projection::PLANE_LEFT], planes[1][Projection::PLANE_RIGHT], &main_transform.origin), "Can't determine camera origin");
-
-	// handy to have the inverse of the transform we just build
-	Transform3D main_transform_inv = main_transform.inverse();
-
-	// 5. figure out far plane, this could use some improvement, we may have our far plane too close like this, not sure if this matters
-	Vector3 far_center = (planes[0][Projection::PLANE_FAR].get_center() + planes[1][Projection::PLANE_FAR].get_center()) * 0.5;
-	Plane far_plane = Plane(-z, far_center);
-
-	/////////////////////////////////////////////////////////////////////////////
-	// Figure out our top/bottom planes
-
-	// 6. Intersect far and left planes with top planes from both eyes, save the point with highest y as top_left.
-	Vector3 top_left, other;
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[0][Projection::PLANE_LEFT], planes[0][Projection::PLANE_TOP], &top_left), "Can't determine left camera far/left/top vector");
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[1][Projection::PLANE_LEFT], planes[1][Projection::PLANE_TOP], &other), "Can't determine right camera far/left/top vector");
-	if (y.dot(top_left) < y.dot(other)) {
-		top_left = other;
-	}
-
-	// 7. Intersect far and left planes with bottom planes from both eyes, save the point with lowest y as bottom_left.
-	Vector3 bottom_left;
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[0][Projection::PLANE_LEFT], planes[0][Projection::PLANE_BOTTOM], &bottom_left), "Can't determine left camera far/left/bottom vector");
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[1][Projection::PLANE_LEFT], planes[1][Projection::PLANE_BOTTOM], &other), "Can't determine right camera far/left/bottom vector");
-	if (y.dot(other) < y.dot(bottom_left)) {
-		bottom_left = other;
-	}
-
-	// 8. Intersect far and right planes with top planes from both eyes, save the point with highest y as top_right.
-	Vector3 top_right;
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[0][Projection::PLANE_RIGHT], planes[0][Projection::PLANE_TOP], &top_right), "Can't determine left camera far/right/top vector");
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[1][Projection::PLANE_RIGHT], planes[1][Projection::PLANE_TOP], &other), "Can't determine right camera far/right/top vector");
-	if (y.dot(top_right) < y.dot(other)) {
-		top_right = other;
-	}
-
-	//  9. Intersect far and right planes with bottom planes from both eyes, save the point with lowest y as bottom_right.
-	Vector3 bottom_right;
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[0][Projection::PLANE_RIGHT], planes[0][Projection::PLANE_BOTTOM], &bottom_right), "Can't determine left camera far/right/bottom vector");
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[1][Projection::PLANE_RIGHT], planes[1][Projection::PLANE_BOTTOM], &other), "Can't determine right camera far/right/bottom vector");
-	if (y.dot(other) < y.dot(bottom_right)) {
-		bottom_right = other;
-	}
-
-	// 10. Create top plane with these points: camera origin, top_left, top_right
-	Plane top(main_transform.origin, top_left, top_right);
-
-	// 11. Create bottom plane with these points: camera origin, bottom_left, bottom_right
-	Plane bottom(main_transform.origin, bottom_left, bottom_right);
-
-	/////////////////////////////////////////////////////////////////////////////
-	// Figure out our near plane points
-
-	// 12. Create a near plane using -camera z and the eye further along in that axis.
-	Plane near_plane;
-	Vector3 neg_z = -z;
-	if (neg_z.dot(p_transforms[1].origin) < neg_z.dot(p_transforms[0].origin)) {
-		near_plane = Plane(neg_z, p_transforms[0].origin);
-	} else {
-		near_plane = Plane(neg_z, p_transforms[1].origin);
-	}
-
-	// 13. Intersect near plane with bottm/left planes, to obtain min_vec then top/right to obtain max_vec
-	Vector3 min_vec;
-	ERR_FAIL_COND_MSG(
-			!near_plane.intersect_3(bottom, planes[0][Projection::PLANE_LEFT], &min_vec), "Can't determine left camera near/left/bottom vector");
-	ERR_FAIL_COND_MSG(
-			!near_plane.intersect_3(bottom, planes[1][Projection::PLANE_LEFT], &other), "Can't determine right camera near/left/bottom vector");
-	if (x.dot(other) < x.dot(min_vec)) {
-		min_vec = other;
-	}
-
-	Vector3 max_vec;
-	ERR_FAIL_COND_MSG(
-			!near_plane.intersect_3(top, planes[0][Projection::PLANE_RIGHT], &max_vec), "Can't determine left camera near/right/top vector");
-	ERR_FAIL_COND_MSG(
-			!near_plane.intersect_3(top, planes[1][Projection::PLANE_RIGHT], &other), "Can't determine right camera near/right/top vector");
-	if (x.dot(max_vec) < x.dot(other)) {
-		max_vec = other;
-	}
-
-	// 14. transform these points by the inverse camera to obtain local_min_vec and local_max_vec
-	Vector3 local_min_vec = main_transform_inv.xform(min_vec);
-	Vector3 local_max_vec = main_transform_inv.xform(max_vec);
-
-	// 15. get x and y from these to obtain left, top, right bottom for the frustum. Get the distance from near plane to camera origin to obtain near, and the distance from the far plane to the camera origin to obtain far.
-	float z_near = -near_plane.distance_to(main_transform.origin);
-	float z_far = -far_plane.distance_to(main_transform.origin);
-
-	// 16. Use this to build the combined camera matrix.
-	main_projection.set_frustum(local_min_vec.x, local_max_vec.x, local_min_vec.y, local_max_vec.y, z_near, z_far);
-
-	/////////////////////////////////////////////////////////////////////////////
-	// 3. Copy our view data
-	for (uint32_t v = 0; v < view_count; v++) {
-		view_offset[v] = main_transform_inv * p_transforms[v];
+		view_offset[v] = p_offsets[v];
 		view_projection[v] = p_projections[v] * Projection(view_offset[v].inverse());
 	}
 }

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -50,141 +50,20 @@ void RendererSceneRender::CameraData::set_camera(const Transform3D p_transform, 
 	taa_frame_count = p_taa_frame_count;
 }
 
-void RendererSceneRender::CameraData::set_multiview_camera(uint32_t p_view_count, const Transform3D *p_transforms, const Projection *p_projections, bool p_is_orthogonal, bool p_vaspect, uint32_t p_visible_layers) {
-	ERR_FAIL_COND_MSG(p_view_count != 2, "Incorrect view count for stereoscopic view");
+void RendererSceneRender::CameraData::set_multiview_camera(const Transform3D &p_transform, const LocalVector<Transform3D> &p_offsets, const LocalVector<Projection> &p_projections, bool p_is_orthogonal, bool p_vaspect, uint32_t p_visible_layers) {
+	ERR_FAIL_COND_MSG(p_projections.size() != 2, "Incorrect view count for stereoscopic view");
+	ERR_FAIL_COND(p_projections.size() != p_offsets.size());
 
 	visible_layers = p_visible_layers;
-	view_count = p_view_count;
+	view_count = p_projections.size();
 	is_orthogonal = p_is_orthogonal;
 	vaspect = p_vaspect;
-	Vector<Plane> planes[2];
 
-	/////////////////////////////////////////////////////////////////////////////
-	// Figure out our center transform
+	main_transform = p_transform;
+	main_projection = Projection::create_combined_projection(p_transform, p_projections[0], p_offsets[0], p_projections[1], p_offsets[1]);
 
-	// 1. obtain our planes
 	for (uint32_t v = 0; v < view_count; v++) {
-		planes[v] = p_projections[v].get_projection_planes(p_transforms[v]);
-	}
-
-	// 2. average and normalize plane normals to obtain z vector, cross them to obtain y vector, and from there the x vector for combined camera basis.
-	Vector3 n0 = planes[0][Projection::PLANE_LEFT].normal;
-	Vector3 n1 = planes[1][Projection::PLANE_RIGHT].normal;
-	Vector3 z = (n0 + n1).normalized();
-	Vector3 y = n0.cross(n1).normalized();
-	Vector3 x = y.cross(z).normalized();
-	y = z.cross(x).normalized();
-	main_transform.basis.set_columns(x, y, z);
-
-	// 3. create a horizon plane with one of the eyes and the up vector as normal.
-	Plane horizon(y, p_transforms[0].origin);
-
-	// 4. Intersect horizon, left and right to obtain the combined camera origin.
-	ERR_FAIL_COND_MSG(
-			!horizon.intersect_3(planes[0][Projection::PLANE_LEFT], planes[1][Projection::PLANE_RIGHT], &main_transform.origin), "Can't determine camera origin");
-
-	// handy to have the inverse of the transform we just build
-	Transform3D main_transform_inv = main_transform.inverse();
-
-	// 5. figure out far plane, this could use some improvement, we may have our far plane too close like this, not sure if this matters
-	Vector3 far_center = (planes[0][Projection::PLANE_FAR].get_center() + planes[1][Projection::PLANE_FAR].get_center()) * 0.5;
-	Plane far_plane = Plane(-z, far_center);
-
-	/////////////////////////////////////////////////////////////////////////////
-	// Figure out our top/bottom planes
-
-	// 6. Intersect far and left planes with top planes from both eyes, save the point with highest y as top_left.
-	Vector3 top_left, other;
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[0][Projection::PLANE_LEFT], planes[0][Projection::PLANE_TOP], &top_left), "Can't determine left camera far/left/top vector");
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[1][Projection::PLANE_LEFT], planes[1][Projection::PLANE_TOP], &other), "Can't determine right camera far/left/top vector");
-	if (y.dot(top_left) < y.dot(other)) {
-		top_left = other;
-	}
-
-	// 7. Intersect far and left planes with bottom planes from both eyes, save the point with lowest y as bottom_left.
-	Vector3 bottom_left;
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[0][Projection::PLANE_LEFT], planes[0][Projection::PLANE_BOTTOM], &bottom_left), "Can't determine left camera far/left/bottom vector");
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[1][Projection::PLANE_LEFT], planes[1][Projection::PLANE_BOTTOM], &other), "Can't determine right camera far/left/bottom vector");
-	if (y.dot(other) < y.dot(bottom_left)) {
-		bottom_left = other;
-	}
-
-	// 8. Intersect far and right planes with top planes from both eyes, save the point with highest y as top_right.
-	Vector3 top_right;
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[0][Projection::PLANE_RIGHT], planes[0][Projection::PLANE_TOP], &top_right), "Can't determine left camera far/right/top vector");
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[1][Projection::PLANE_RIGHT], planes[1][Projection::PLANE_TOP], &other), "Can't determine right camera far/right/top vector");
-	if (y.dot(top_right) < y.dot(other)) {
-		top_right = other;
-	}
-
-	//  9. Intersect far and right planes with bottom planes from both eyes, save the point with lowest y as bottom_right.
-	Vector3 bottom_right;
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[0][Projection::PLANE_RIGHT], planes[0][Projection::PLANE_BOTTOM], &bottom_right), "Can't determine left camera far/right/bottom vector");
-	ERR_FAIL_COND_MSG(
-			!far_plane.intersect_3(planes[1][Projection::PLANE_RIGHT], planes[1][Projection::PLANE_BOTTOM], &other), "Can't determine right camera far/right/bottom vector");
-	if (y.dot(other) < y.dot(bottom_right)) {
-		bottom_right = other;
-	}
-
-	// 10. Create top plane with these points: camera origin, top_left, top_right
-	Plane top(main_transform.origin, top_left, top_right);
-
-	// 11. Create bottom plane with these points: camera origin, bottom_left, bottom_right
-	Plane bottom(main_transform.origin, bottom_left, bottom_right);
-
-	/////////////////////////////////////////////////////////////////////////////
-	// Figure out our near plane points
-
-	// 12. Create a near plane using -camera z and the eye further along in that axis.
-	Plane near_plane;
-	Vector3 neg_z = -z;
-	if (neg_z.dot(p_transforms[1].origin) < neg_z.dot(p_transforms[0].origin)) {
-		near_plane = Plane(neg_z, p_transforms[0].origin);
-	} else {
-		near_plane = Plane(neg_z, p_transforms[1].origin);
-	}
-
-	// 13. Intersect near plane with bottm/left planes, to obtain min_vec then top/right to obtain max_vec
-	Vector3 min_vec;
-	ERR_FAIL_COND_MSG(
-			!near_plane.intersect_3(bottom, planes[0][Projection::PLANE_LEFT], &min_vec), "Can't determine left camera near/left/bottom vector");
-	ERR_FAIL_COND_MSG(
-			!near_plane.intersect_3(bottom, planes[1][Projection::PLANE_LEFT], &other), "Can't determine right camera near/left/bottom vector");
-	if (x.dot(other) < x.dot(min_vec)) {
-		min_vec = other;
-	}
-
-	Vector3 max_vec;
-	ERR_FAIL_COND_MSG(
-			!near_plane.intersect_3(top, planes[0][Projection::PLANE_RIGHT], &max_vec), "Can't determine left camera near/right/top vector");
-	ERR_FAIL_COND_MSG(
-			!near_plane.intersect_3(top, planes[1][Projection::PLANE_RIGHT], &other), "Can't determine right camera near/right/top vector");
-	if (x.dot(max_vec) < x.dot(other)) {
-		max_vec = other;
-	}
-
-	// 14. transform these points by the inverse camera to obtain local_min_vec and local_max_vec
-	Vector3 local_min_vec = main_transform_inv.xform(min_vec);
-	Vector3 local_max_vec = main_transform_inv.xform(max_vec);
-
-	// 15. get x and y from these to obtain left, top, right bottom for the frustum. Get the distance from near plane to camera origin to obtain near, and the distance from the far plane to the camera origin to obtain far.
-	float z_near = -near_plane.distance_to(main_transform.origin);
-	float z_far = -far_plane.distance_to(main_transform.origin);
-
-	// 16. Use this to build the combined camera matrix.
-	main_projection.set_frustum(local_min_vec.x, local_max_vec.x, local_min_vec.y, local_max_vec.y, z_near, z_far);
-
-	/////////////////////////////////////////////////////////////////////////////
-	// 3. Copy our view data
-	for (uint32_t v = 0; v < view_count; v++) {
-		view_offset[v] = main_transform_inv * p_transforms[v];
+		view_offset[v] = p_offsets[v];
 		view_projection[v] = p_projections[v] * Projection(view_offset[v].inverse());
 	}
 }

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -306,6 +306,7 @@ public:
 		// flags
 		uint32_t view_count;
 		bool is_orthogonal;
+		bool is_asymmetrical;
 		uint32_t visible_layers;
 		bool vaspect;
 
@@ -318,8 +319,8 @@ public:
 		Vector2 taa_jitter;
 		float taa_frame_count = 0.0f;
 
-		void set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter = Vector2(), float p_taa_frame_count = 0.0f, uint32_t p_visible_layers = 0xFFFFFFFF);
-		void set_multiview_camera(uint32_t p_view_count, const Transform3D *p_transforms, const Projection *p_projections, bool p_is_orthogonal, bool p_vaspect, uint32_t p_visible_layers = 0xFFFFFFFF);
+		void set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_is_asymmetrical, bool p_vaspect, const Vector2 &p_taa_jitter = Vector2(), float p_taa_frame_count = 0.0f, uint32_t p_visible_layers = 0xFFFFFFFF);
+		void set_multiview_camera(const Transform3D &p_transform, const LocalVector<Transform3D> &p_offsets, const LocalVector<Projection> &p_projection, bool p_is_orthogonal, bool p_is_asymmetrical, bool p_vaspect, uint32_t p_visible_layers = 0xFFFFFFFF);
 	};
 
 	virtual void render_scene(const Ref<RenderSceneBuffers> &p_render_buffers, const CameraData *p_camera_data, const CameraData *p_prev_camera_data, const PagedArray<RenderGeometryInstance *> &p_instances, const PagedArray<RID> &p_lights, const PagedArray<RID> &p_reflection_probes, const PagedArray<RID> &p_voxel_gi_instances, const PagedArray<RID> &p_decals, const PagedArray<RID> &p_lightmaps, const PagedArray<RID> &p_fog_volumes, RID p_environment, RID p_camera_attributes, RID p_compositor, RID p_shadow_atlas, RID p_occluder_debug_tex, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, const RenderShadowData *p_render_shadows, int p_render_shadow_count, const RenderSDFGIData *p_render_sdfgi_regions, int p_render_sdfgi_region_count, float p_window_output_max_value, const RenderSDFGIUpdateData *p_sdfgi_update_data = nullptr, RenderingServerTypes::RenderInfo *r_render_info = nullptr) = 0;

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -319,7 +319,7 @@ public:
 		float taa_frame_count = 0.0f;
 
 		void set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter = Vector2(), float p_taa_frame_count = 0.0f, uint32_t p_visible_layers = 0xFFFFFFFF);
-		void set_multiview_camera(uint32_t p_view_count, const Transform3D *p_transforms, const Projection *p_projections, bool p_is_orthogonal, bool p_vaspect, uint32_t p_visible_layers = 0xFFFFFFFF);
+		void set_multiview_camera(const Transform3D &p_transform, const LocalVector<Transform3D> &p_offsets, const LocalVector<Projection> &p_projection, bool p_is_orthogonal, bool p_vaspect, uint32_t p_visible_layers = 0xFFFFFFFF);
 	};
 
 	virtual void render_scene(const Ref<RenderSceneBuffers> &p_render_buffers, const CameraData *p_camera_data, const CameraData *p_prev_camera_data, const PagedArray<RenderGeometryInstance *> &p_instances, const PagedArray<RID> &p_lights, const PagedArray<RID> &p_reflection_probes, const PagedArray<RID> &p_voxel_gi_instances, const PagedArray<RID> &p_decals, const PagedArray<RID> &p_lightmaps, const PagedArray<RID> &p_fog_volumes, RID p_environment, RID p_camera_attributes, RID p_compositor, RID p_shadow_atlas, RID p_occluder_debug_tex, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, const RenderShadowData *p_render_shadows, int p_render_shadow_count, const RenderSDFGIData *p_render_sdfgi_regions, int p_render_sdfgi_region_count, float p_window_output_max_value, const RenderSDFGIUpdateData *p_sdfgi_update_data = nullptr, RenderingServerTypes::RenderInfo *r_render_info = nullptr) = 0;

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -306,13 +306,6 @@ void RendererViewport::_draw_3d(Viewport *p_viewport) {
 #ifndef _3D_DISABLED
 	RENDER_TIMESTAMP("> Render 3D Scene");
 
-	Ref<XRInterface> xr_interface;
-#ifndef XR_DISABLED
-	if (p_viewport->use_xr && XRServer::get_singleton() != nullptr) {
-		xr_interface = XRServer::get_singleton()->get_primary_interface();
-	}
-#endif // XR_DISABLED
-
 	if (p_viewport->use_occlusion_culling) {
 		if (p_viewport->occlusion_buffer_dirty) {
 			float aspect = p_viewport->size.aspect();
@@ -329,7 +322,7 @@ void RendererViewport::_draw_3d(Viewport *p_viewport) {
 	}
 
 	float screen_mesh_lod_threshold = p_viewport->mesh_lod_threshold / float(p_viewport->size.width);
-	RSG::scene->render_camera(p_viewport->render_buffers, p_viewport->camera, p_viewport->scenario, p_viewport->self, p_viewport->internal_size, p_viewport->jitter_phase_count, screen_mesh_lod_threshold, p_viewport->shadow_atlas, xr_interface, p_viewport->window_output_max_value, &p_viewport->render_info);
+	RSG::scene->render_camera(p_viewport->render_buffers, p_viewport->camera, p_viewport->scenario, p_viewport->self, p_viewport->internal_size, p_viewport->jitter_phase_count, screen_mesh_lod_threshold, p_viewport->shadow_atlas, p_viewport->window_output_max_value, &p_viewport->render_info);
 
 	RENDER_TIMESTAMP("< Render 3D Scene");
 #endif // _3D_DISABLED

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -316,13 +316,6 @@ void RendererViewport::_draw_3d(Viewport *p_viewport) {
 #ifndef _3D_DISABLED
 	RENDER_TIMESTAMP("> Render 3D Scene");
 
-	Ref<XRInterface> xr_interface;
-#ifndef XR_DISABLED
-	if (p_viewport->use_xr && XRServer::get_singleton() != nullptr) {
-		xr_interface = XRServer::get_singleton()->get_primary_interface();
-	}
-#endif // XR_DISABLED
-
 	if (p_viewport->use_occlusion_culling) {
 		if (p_viewport->occlusion_buffer_dirty) {
 			float aspect = p_viewport->size.aspect();
@@ -339,7 +332,7 @@ void RendererViewport::_draw_3d(Viewport *p_viewport) {
 	}
 
 	float screen_mesh_lod_threshold = p_viewport->mesh_lod_threshold / float(p_viewport->size.width);
-	RSG::scene->render_camera(p_viewport->render_buffers, p_viewport->camera, p_viewport->scenario, p_viewport->self, p_viewport->internal_size, p_viewport->jitter_phase_count, screen_mesh_lod_threshold, p_viewport->shadow_atlas, xr_interface, p_viewport->window_output_max_value, &p_viewport->render_info);
+	RSG::scene->render_camera(p_viewport->render_buffers, p_viewport->camera, p_viewport->scenario, p_viewport->self, p_viewport->internal_size, p_viewport->jitter_phase_count, screen_mesh_lod_threshold, p_viewport->shadow_atlas, p_viewport->window_output_max_value, &p_viewport->render_info);
 
 	RENDER_TIMESTAMP("< Render 3D Scene");
 #endif // _3D_DISABLED

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/variant/typed_array.h"
 #include "core/variant/variant.h"
 #include "servers/rendering/rendering_server_enums.h"
 #include "servers/rendering/rendering_server_types.h"
@@ -53,6 +54,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_xr_projections(RID p_camera, TypedArray<Projection> p_projections, TypedArray<Transform3D> p_offsets = TypedArray<Transform3D>()) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;
@@ -350,7 +352,7 @@ public:
 
 	virtual void render_empty_scene(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_scenario, RID p_shadow_atlas, float p_window_output_max_value) = 0;
 
-	virtual void render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_mesh_lod_threshold, RID p_shadow_atlas, Ref<XRInterface> &p_xr_interface, float p_window_output_max_value, RenderingServerTypes::RenderInfo *r_render_info = nullptr) = 0;
+	virtual void render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_mesh_lod_threshold, RID p_shadow_atlas, float p_window_output_max_value, RenderingServerTypes::RenderInfo *r_render_info = nullptr) = 0;
 
 	virtual void update() = 0;
 	virtual void render_probes() = 0;

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2846,6 +2846,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("camera_set_perspective", "camera", "fovy_degrees", "z_near", "z_far"), &RenderingServer::camera_set_perspective);
 	ClassDB::bind_method(D_METHOD("camera_set_orthogonal", "camera", "size", "z_near", "z_far"), &RenderingServer::camera_set_orthogonal);
 	ClassDB::bind_method(D_METHOD("camera_set_frustum", "camera", "size", "offset", "z_near", "z_far"), &RenderingServer::camera_set_frustum);
+	ClassDB::bind_method(D_METHOD("camera_set_xr_projections", "camera", "projections", "offsets"), &RenderingServer::camera_set_xr_projections, DEFVAL(TypedArray<Transform3D>()));
 	ClassDB::bind_method(D_METHOD("camera_set_transform", "camera", "transform"), &RenderingServer::camera_set_transform);
 	ClassDB::bind_method(D_METHOD("camera_set_cull_mask", "camera", "layers"), &RenderingServer::camera_set_cull_mask);
 	ClassDB::bind_method(D_METHOD("camera_set_environment", "camera", "env"), &RenderingServer::camera_set_environment);

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2850,6 +2850,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("camera_set_perspective", "camera", "fovy_degrees", "z_near", "z_far"), &RenderingServer::camera_set_perspective);
 	ClassDB::bind_method(D_METHOD("camera_set_orthogonal", "camera", "size", "z_near", "z_far"), &RenderingServer::camera_set_orthogonal);
 	ClassDB::bind_method(D_METHOD("camera_set_frustum", "camera", "size", "offset", "z_near", "z_far"), &RenderingServer::camera_set_frustum);
+	ClassDB::bind_method(D_METHOD("camera_set_xr_projections", "camera", "projections", "offsets"), &RenderingServer::camera_set_xr_projections, DEFVAL(TypedArray<Transform3D>()));
 	ClassDB::bind_method(D_METHOD("camera_set_transform", "camera", "transform"), &RenderingServer::camera_set_transform);
 	ClassDB::bind_method(D_METHOD("camera_set_cull_mask", "camera", "layers"), &RenderingServer::camera_set_cull_mask);
 	ClassDB::bind_method(D_METHOD("camera_set_environment", "camera", "env"), &RenderingServer::camera_set_environment);

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -529,6 +529,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_xr_projections(RID p_camera, TypedArray<Projection> p_projections, TypedArray<Transform3D> p_offsets = TypedArray<Transform3D>()) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -537,6 +537,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_xr_projections(RID p_camera, TypedArray<Projection> p_projections, TypedArray<Transform3D> p_offsets = TypedArray<Transform3D>()) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -716,6 +716,7 @@ public:
 	FUNC4(camera_set_perspective, RID, float, float, float)
 	FUNC4(camera_set_orthogonal, RID, float, float, float)
 	FUNC5(camera_set_frustum, RID, float, Vector2, float, float)
+	FUNC3(camera_set_xr_projections, RID, TypedArray<Projection>, TypedArray<Transform3D>)
 	FUNC2(camera_set_transform, RID, const Transform3D &)
 	FUNC2(camera_set_cull_mask, RID, uint32_t)
 	FUNC2(camera_set_environment, RID, RID)

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -721,6 +721,7 @@ public:
 	FUNC4(camera_set_perspective, RID, float, float, float)
 	FUNC4(camera_set_orthogonal, RID, float, float, float)
 	FUNC5(camera_set_frustum, RID, float, Vector2, float, float)
+	FUNC3(camera_set_xr_projections, RID, TypedArray<Projection>, TypedArray<Transform3D>)
 	FUNC2(camera_set_transform, RID, const Transform3D &)
 	FUNC2(camera_set_cull_mask, RID, uint32_t)
 	FUNC2(camera_set_environment, RID, RID)

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -75,8 +75,14 @@ void XRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_passthrough_enabled"), &XRInterface::is_passthrough_enabled);
 	ClassDB::bind_method(D_METHOD("start_passthrough"), &XRInterface::start_passthrough);
 	ClassDB::bind_method(D_METHOD("stop_passthrough"), &XRInterface::stop_passthrough);
+
+	ClassDB::bind_method(D_METHOD("get_camera_projections", "tracker_name", "aspect", "near", "far"), &XRInterface::get_camera_projections);
+	ClassDB::bind_method(D_METHOD("get_camera_offsets", "tracker_name"), &XRInterface::get_camera_offsets);
+
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("get_transform_for_view", "view", "cam_transform"), &XRInterface::get_transform_for_view);
 	ClassDB::bind_method(D_METHOD("get_projection_for_view", "view", "aspect", "near", "far"), &XRInterface::get_projection_for_view);
+#endif
 
 	/** environment blend mode. */
 	ClassDB::bind_method(D_METHOD("get_supported_environment_blend_modes"), &XRInterface::get_supported_environment_blend_modes);

--- a/servers/xr/xr_interface.h
+++ b/servers/xr/xr_interface.h
@@ -33,6 +33,8 @@
 #include "core/object/ref_counted.h"
 #include "core/os/thread_safe.h"
 #include "core/variant/type_info.h"
+#include "core/variant/typed_array.h"
+#include "core/variant/variant.h"
 
 /**
 	The XR interface is a template class on top of which we build interface to different AR, VR and tracking SDKs.
@@ -132,16 +134,22 @@ public:
 	/** rendering and internal **/
 
 	// These methods are called from the main thread.
-	virtual Transform3D get_camera_transform() = 0; /* returns the position of our camera, only used for updating reference frame. For monoscopic this is equal to the views transform, for stereoscopic this should be an average */
 	virtual void process() = 0;
+
+	// Camera information
+	virtual Transform3D get_camera_transform() = 0; /* returns the position of our main camera, only used for updating reference frame. For monoscopic this is equal to the views transform, for stereoscopic this should be an average */
+	virtual TypedArray<Projection> get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) = 0; /* Get projections for each eye of the given camera */
+	virtual TypedArray<Transform3D> get_camera_offsets(const StringName &p_tracker_name) = 0; /* Get offsets for each eye of the given camera */
 
 	// These methods can be called from both main and render thread.
 	virtual Size2 get_render_target_size() = 0; /* returns the recommended render target size per eye for this device */
-	virtual uint32_t get_view_count() = 0; /* returns the view count we need (1 is monoscopic, 2 is stereoscopic but can be more) */
+	virtual uint32_t get_view_count() = 0; /* returns the primary view count we need (1 is monoscopic, 2 is stereoscopic but can be more) */
 
 	// These methods are called from the rendering thread.
-	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) = 0; /* get each views transform */
-	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) = 0; /* get each view projection matrix */
+#ifndef DISABLE_DEPRECATED
+	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) { return Transform3D(); } /* Deprecated, get each views transform */
+	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) { return Projection(); } /* Deprecated, get each view projection matrix */
+#endif
 	virtual RID get_color_texture(); /* obtain color output texture (if applicable) */
 	virtual RID get_depth_texture(); /* obtain depth output texture (if applicable, used for reprojection) */
 	virtual RID get_velocity_texture(); /* obtain velocity output texture (if applicable, used for spacewarp) */

--- a/servers/xr/xr_interface.h
+++ b/servers/xr/xr_interface.h
@@ -33,6 +33,8 @@
 #include "core/object/ref_counted.h"
 #include "core/os/thread_safe.h"
 #include "core/variant/type_info.h"
+#include "core/variant/typed_array.h"
+#include "core/variant/variant.h"
 #include "servers/rendering/rendering_server_types.h"
 
 /**
@@ -130,16 +132,22 @@ public:
 	/** rendering and internal **/
 
 	// These methods are called from the main thread.
-	virtual Transform3D get_camera_transform() = 0; /* returns the position of our camera, only used for updating reference frame. For monoscopic this is equal to the views transform, for stereoscopic this should be an average */
 	virtual void process() = 0;
+
+	// Camera information
+	virtual Transform3D get_camera_transform() = 0; /* returns the position of our main camera, only used for updating reference frame. For monoscopic this is equal to the views transform, for stereoscopic this should be an average */
+	virtual TypedArray<Projection> get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) = 0; /* Get projections for each eye of the given camera */
+	virtual TypedArray<Transform3D> get_camera_offsets(const StringName &p_tracker_name) = 0; /* Get offsets for each eye of the given camera */
 
 	// These methods can be called from both main and render thread.
 	virtual Size2 get_render_target_size() = 0; /* returns the recommended render target size per eye for this device */
-	virtual uint32_t get_view_count() = 0; /* returns the view count we need (1 is monoscopic, 2 is stereoscopic but can be more) */
+	virtual uint32_t get_view_count() = 0; /* returns the primary view count we need (1 is monoscopic, 2 is stereoscopic but can be more) */
 
 	// These methods are called from the rendering thread.
-	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) = 0; /* get each views transform */
-	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) = 0; /* get each view projection matrix */
+#ifndef DISABLE_DEPRECATED
+	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) { return Transform3D(); } /* Deprecated, get each views transform */
+	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) { return Projection(); } /* Deprecated, get each view projection matrix */
+#endif
 	virtual RID get_color_texture(); /* obtain color output texture (if applicable) */
 	virtual RID get_depth_texture(); /* obtain depth output texture (if applicable, used for reprojection) */
 	virtual RID get_velocity_texture(); /* obtain velocity output texture (if applicable, used for spacewarp) */

--- a/servers/xr/xr_interface_extension.cpp
+++ b/servers/xr/xr_interface_extension.cpp
@@ -50,8 +50,12 @@ void XRInterfaceExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_render_target_size);
 	GDVIRTUAL_BIND(_get_view_count);
 	GDVIRTUAL_BIND(_get_camera_transform);
+	GDVIRTUAL_BIND(_get_camera_projections, "tracker_name", "aspect", "z_near", "z_far");
+	GDVIRTUAL_BIND(_get_camera_offsets, "tracker_name");
+#ifndef DISABLE_DEPRECATED
 	GDVIRTUAL_BIND(_get_transform_for_view, "view", "cam_transform");
 	GDVIRTUAL_BIND(_get_projection_for_view, "view", "aspect", "z_near", "z_far");
+#endif
 	GDVIRTUAL_BIND(_get_vrs_texture);
 	GDVIRTUAL_BIND(_get_vrs_texture_format);
 
@@ -212,6 +216,26 @@ Transform3D XRInterfaceExtension::get_camera_transform() {
 	Transform3D transform;
 	GDVIRTUAL_CALL(_get_camera_transform, transform);
 	return transform;
+}
+
+TypedArray<Projection> XRInterfaceExtension::get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) {
+	TypedArray<Projection> camera_projections;
+
+	if (GDVIRTUAL_CALL(_get_camera_projections, p_tracker_name, p_aspect, p_z_near, p_z_far, camera_projections)) {
+		return camera_projections;
+	}
+
+	return camera_projections;
+}
+
+TypedArray<Transform3D> XRInterfaceExtension::get_camera_offsets(const StringName &p_tracker_name) {
+	TypedArray<Transform3D> camera_offsets;
+
+	if (GDVIRTUAL_CALL(_get_camera_offsets, p_tracker_name, camera_offsets)) {
+		return camera_offsets;
+	}
+
+	return camera_offsets;
 }
 
 Transform3D XRInterfaceExtension::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {

--- a/servers/xr/xr_interface_extension.cpp
+++ b/servers/xr/xr_interface_extension.cpp
@@ -52,8 +52,12 @@ void XRInterfaceExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_render_target_size);
 	GDVIRTUAL_BIND(_get_view_count);
 	GDVIRTUAL_BIND(_get_camera_transform);
+	GDVIRTUAL_BIND(_get_camera_projections, "tracker_name", "aspect", "z_near", "z_far");
+	GDVIRTUAL_BIND(_get_camera_offsets, "tracker_name");
+#ifndef DISABLE_DEPRECATED
 	GDVIRTUAL_BIND(_get_transform_for_view, "view", "cam_transform");
 	GDVIRTUAL_BIND(_get_projection_for_view, "view", "aspect", "z_near", "z_far");
+#endif
 	GDVIRTUAL_BIND(_get_vrs_texture);
 	GDVIRTUAL_BIND(_get_vrs_texture_format);
 
@@ -214,6 +218,26 @@ Transform3D XRInterfaceExtension::get_camera_transform() {
 	Transform3D transform;
 	GDVIRTUAL_CALL(_get_camera_transform, transform);
 	return transform;
+}
+
+TypedArray<Projection> XRInterfaceExtension::get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) {
+	TypedArray<Projection> camera_projections;
+
+	if (GDVIRTUAL_CALL(_get_camera_projections, p_tracker_name, p_aspect, p_z_near, p_z_far, camera_projections)) {
+		return camera_projections;
+	}
+
+	return camera_projections;
+}
+
+TypedArray<Transform3D> XRInterfaceExtension::get_camera_offsets(const StringName &p_tracker_name) {
+	TypedArray<Transform3D> camera_offsets;
+
+	if (GDVIRTUAL_CALL(_get_camera_offsets, p_tracker_name, camera_offsets)) {
+		return camera_offsets;
+	}
+
+	return camera_offsets;
 }
 
 Transform3D XRInterfaceExtension::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {

--- a/servers/xr/xr_interface_extension.h
+++ b/servers/xr/xr_interface_extension.h
@@ -101,8 +101,12 @@ public:
 	virtual Size2 get_render_target_size() override;
 	virtual uint32_t get_view_count() override;
 	virtual Transform3D get_camera_transform() override;
+	virtual TypedArray<Projection> get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) override;
+	virtual TypedArray<Transform3D> get_camera_offsets(const StringName &p_tracker_name) override;
+#ifndef DISABLE_DEPRECATED
 	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) override;
 	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
+#endif
 	virtual RID get_vrs_texture() override;
 	virtual VRSTextureFormat get_vrs_texture_format() override;
 	virtual RID get_color_texture() override;
@@ -112,8 +116,12 @@ public:
 	GDVIRTUAL0R(Size2, _get_render_target_size);
 	GDVIRTUAL0R(uint32_t, _get_view_count);
 	GDVIRTUAL0R(Transform3D, _get_camera_transform);
+	GDVIRTUAL4R(TypedArray<Projection>, _get_camera_projections, const StringName &, double, double, double);
+	GDVIRTUAL1R(TypedArray<Transform3D>, _get_camera_offsets, const StringName &);
+#ifndef DISABLE_DEPRECATED
 	GDVIRTUAL2R(Transform3D, _get_transform_for_view, uint32_t, const Transform3D &);
 	GDVIRTUAL4R(PackedFloat64Array, _get_projection_for_view, uint32_t, double, double, double);
+#endif
 	GDVIRTUAL0R(RID, _get_vrs_texture);
 	GDVIRTUAL0R(VRSTextureFormat, _get_vrs_texture_format);
 	GDVIRTUAL0R(RID, _get_color_texture);

--- a/servers/xr/xr_positional_tracker.h
+++ b/servers/xr/xr_positional_tracker.h
@@ -41,6 +41,8 @@
 	This is where potentially additional AR/VR interfaces may be active as there are AR/VR SDKs that solely deal with positional tracking.
 */
 
+#define XR_TRACKER_HEAD SNAME("head")
+
 class XRPositionalTracker : public XRTracker {
 	GDCLASS(XRPositionalTracker, XRTracker);
 	_THREAD_SAFE_CLASS_

--- a/servers/xr/xr_server.cpp
+++ b/servers/xr/xr_server.cpp
@@ -82,12 +82,15 @@ void XRServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_trackers", "tracker_types"), &XRServer::get_trackers);
 	ClassDB::bind_method(D_METHOD("get_tracker", "tracker_name"), &XRServer::get_tracker);
 
+	ClassDB::bind_method(D_METHOD("get_camera_projections", "tracker_name", "aspect", "near", "far"), &XRServer::get_camera_projections);
+	ClassDB::bind_method(D_METHOD("get_camera_offsets", "tracker_name"), &XRServer::get_camera_offsets);
+
 	ClassDB::bind_method(D_METHOD("get_primary_interface"), &XRServer::get_primary_interface);
 	ClassDB::bind_method(D_METHOD("set_primary_interface", "interface"), &XRServer::set_primary_interface);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "primary_interface"), "set_primary_interface", "get_primary_interface");
 
-	BIND_ENUM_CONSTANT(TRACKER_HEAD);
+	BIND_ENUM_CONSTANT(TRACKER_CAMERA);
 	BIND_ENUM_CONSTANT(TRACKER_CONTROLLER);
 	BIND_ENUM_CONSTANT(TRACKER_BASESTATION);
 	BIND_ENUM_CONSTANT(TRACKER_ANCHOR);
@@ -97,6 +100,10 @@ void XRServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(TRACKER_ANY_KNOWN);
 	BIND_ENUM_CONSTANT(TRACKER_UNKNOWN);
 	BIND_ENUM_CONSTANT(TRACKER_ANY);
+
+#ifndef DISABLE_DEPRECATED
+	BIND_ENUM_CONSTANT(TRACKER_HEAD);
+#endif
 
 	BIND_ENUM_CONSTANT(RESET_FULL_ROTATION);
 	BIND_ENUM_CONSTANT(RESET_BUT_KEEP_TILT);
@@ -396,6 +403,75 @@ Ref<XRTracker> XRServer::get_tracker(const StringName &p_name) const {
 		// tracker hasn't been registered yet, which is fine, no need to spam the error log...
 		return Ref<XRTracker>();
 	}
+}
+
+TypedArray<Projection> XRServer::get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far) {
+	TypedArray<Projection> projections;
+
+	// Try primary interface first.
+	if (primary_interface.is_valid()) {
+		projections = primary_interface->get_camera_projections(p_tracker_name, p_aspect, p_z_near, p_z_far);
+		if (!projections.is_empty()) {
+			return projections;
+		}
+	}
+
+	// Try any other active interfaces.
+	for (Ref<XRInterface> interface : interfaces) {
+		if (interface != primary_interface && interface->is_initialized()) {
+			projections = interface->get_camera_projections(p_tracker_name, p_aspect, p_z_near, p_z_far);
+			if (!projections.is_empty()) {
+				return projections;
+			}
+		}
+	}
+
+#ifndef DISABLE_DEPRECATED
+	// Fallback on old implementation.
+	if (primary_interface.is_valid() && p_tracker_name == XR_TRACKER_HEAD) {
+		for (uint32_t v = 0; v < primary_interface->get_view_count(); v++) {
+			projections.push_back(primary_interface->get_projection_for_view(v, p_aspect, p_z_near, p_z_far));
+		}
+	}
+#endif
+
+	return projections;
+}
+
+TypedArray<Transform3D> XRServer::get_camera_offsets(const StringName &p_tracker_name) {
+	TypedArray<Transform3D> offsets;
+
+	// Try primary interface first.
+	if (primary_interface.is_valid()) {
+		offsets = primary_interface->get_camera_offsets(p_tracker_name);
+		if (!offsets.is_empty()) {
+			return offsets;
+		}
+	}
+
+	// Try any other active interfaces.
+	for (Ref<XRInterface> interface : interfaces) {
+		if (interface != primary_interface && interface->is_initialized()) {
+			offsets = interface->get_camera_offsets(p_tracker_name);
+			if (!offsets.is_empty()) {
+				return offsets;
+			}
+		}
+	}
+
+#ifndef DISABLE_DEPRECATED
+	// Fallback on old implementation.
+	if (primary_interface.is_valid() && p_tracker_name == XR_TRACKER_HEAD) {
+		Transform3D inv_camera_transform = primary_interface->get_camera_transform().inverse();
+
+		for (uint32_t v = 0; v < primary_interface->get_view_count(); v++) {
+			Transform3D offset = primary_interface->get_transform_for_view(v, Transform3D());
+			offsets.push_back(inv_camera_transform * offset);
+		}
+	}
+#endif
+
+	return offsets;
 }
 
 PackedStringArray XRServer::get_suggested_tracker_names() const {

--- a/servers/xr/xr_server.h
+++ b/servers/xr/xr_server.h
@@ -63,7 +63,7 @@ public:
 	};
 
 	enum TrackerType {
-		TRACKER_HEAD = 0x01, /* tracks the position of the players head (or in case of handheld AR, location of the phone) */
+		TRACKER_CAMERA = 0x01, /* tracks the position of an XR camera (HMD, external camera, phone camera for phone based AR) */
 		TRACKER_CONTROLLER = 0x02, /* tracks a controller */
 		TRACKER_BASESTATION = 0x04, /* tracks location of a base station */
 		TRACKER_ANCHOR = 0x08, /* tracks an anchor point, used in AR to track a real live location */
@@ -73,7 +73,11 @@ public:
 		TRACKER_UNKNOWN = 0x80, /* unknown tracker */
 
 		TRACKER_ANY_KNOWN = 0x7f, /* all except unknown */
-		TRACKER_ANY = 0xff /* used by get_connected_trackers to return all types */
+		TRACKER_ANY = 0xff, /* used by get_connected_trackers to return all types */
+
+#ifndef DISABLE_DEPRECATED
+		TRACKER_HEAD = TRACKER_CAMERA /* Just for backwards compatibility */
+#endif
 	};
 
 	enum RotationMode {
@@ -204,6 +208,10 @@ public:
 	void remove_tracker(const Ref<XRTracker> &p_tracker);
 	Dictionary get_trackers(int p_tracker_types);
 	Ref<XRTracker> get_tracker(const StringName &p_name) const;
+
+	// For camera trackers only, we need access to additional information that can't be stored on the tracker itself.
+	TypedArray<Projection> get_camera_projections(const StringName &p_tracker_name, double p_aspect, double p_z_near, double p_z_far);
+	TypedArray<Transform3D> get_camera_offsets(const StringName &p_tracker_name);
 
 	/*
 		We don't know which trackers and actions will existing during runtime but we can request suggested names from our interfaces to help our IDE UI.


### PR DESCRIPTION
This PR implements a new projection camera mode that allows setting projections per eye/view/layer and removes the override code deep within the renderer targeted at XR use cases.
The change is meant to be transparent for the end user who configures cameras as before.
This also creates a method for developers to set any projection matrix by overriding the projection set by the built-in logic (a long outstanding wish for which many PRs have been risen before).

For XR specifically this attempts to unlock use cases such as:
- Mirrored/portal cameras that still support stereo input.
- Overriding input.
- Submitting multiple stereo layers to the compositor to enable features such as drawing hands over other composition layers.
- Likely required for foveated inset support.

Enhancements for future PRs:
- This makes storing our world origin in the `XRServer` obsolete as normal transform progression is now used. We should remove this in due time.
- We should deprecate `RenderingServer.camera_set_perspective`, `RenderingServer.camera_set_orthogonal`, and `RenderingServer.camera_set_frustum` in favour of calling `RenderingServer.camera_set_projections` directly from `Camera3D`. This does require `Camera3D` from receiving a signal when it's parent viewport changes size as this will change the aspect ratio. The added advantage of doing so is that we don't calculate our projection matrix every frame, and we can thus improve logic within the rendering engine to only recalculate things if the projection matrix actually changes.
- We should investigate if on the XR camera we can call `RenderingServer.camera_set_projections` less frequently as it's likely our projection matrices remain unchanged. Only when eye tracking is used it's possible (though still unlikely) there are adjustments that need to be made to the projection matrices per frame.
- I've had a go at this already but this change is really really big, but it would make sense to introduce a virtual `BaseCamera3D` class that `Camera3D` and `XRCamera3D` subclass and allows for additional custom cameras to be implemented (via GDExtension). 

> [!IMPORTANT]
> With the removal of the camera override logic from the rendering engine, we are now determining
> XR camera positioning slightly earlier in the frame render loop.
> With all XR runtimes always performing a slight reprojection to correct for any tiny tracking differences
> we feel that the pro's far out weigh the con's here. 

> [!IMPORTANT]
> Deprecating `get_transform_for_view` and `get_projection_for_view` in favour of `get_camera_offsets` and  `get_camera_projections` is a breaking change for `XRInterface`s implemented in extensions.
> These will need to be updated. While I'm thinking about adding a fallback, we still have a problem for especially TiltFive where we use a rather dirty workaround that won't work, while our changes here allow our TiltFive external to do things properly.

Implemented on top of https://github.com/godotengine/godot/pull/115799 (merged) ,https://github.com/godotengine/godot/pull/116752 (merged) and https://github.com/godotengine/godot/pull/117619 (merged)
Implements part of https://github.com/godotengine/godot-proposals/issues/4932
