### PR TITLE
Fix Polygon2D has empty UVs when no texture assigned.

### DIFF
--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -239,19 +239,29 @@ void Polygon2D::_notification(int p_what) {
 				}
 			} else {
 				// Even without a texture, shaders will still need UVs to be usable.
-				int uv_size = uv.size();
-				if (uv_size != 0) {
-					// Case no texture, but UVs are still provided.
-					uvs.resize(uv_size);
-					const Vector2 *uvp = uv.ptr();
-					for (int i = 0; i < uv_size; i++) {
-						uvs.write[i] = uvp[i];
+				const Vector<Vector2> *uv_source = (uv.size() == len) ? &uv : &points;
+
+				uvs.resize(len);
+				if (len > 0) {
+					const Vector2 *src = uv_source->ptr();
+					Vector2 min_uv = src[0];
+					Vector2 max_uv = src[0];
+
+					for (int i = 1; i < len; i++) {
+						min_uv.x = MIN(min_uv.x, src[i].x);
+						min_uv.y = MIN(min_uv.y, src[i].y);
+						max_uv.x = MAX(max_uv.x, src[i].x);
+						max_uv.y = MAX(max_uv.y, src[i].y);
 					}
-				} else {
-					// Case no texture and no UVs, the points should give usable coords.
-					uvs.resize(len);
+
+					Vector2 size = max_uv - min_uv;
+
 					for (int i = 0; i < len; i++) {
-						uvs.write[i] = points[i];
+						Vector2 v = src[i];
+						Vector2 normalized;
+						normalized.x = Math::is_zero_approx(size.x) ? 0.5 : (v.x - min_uv.x) / size.x;
+						normalized.y = Math::is_zero_approx(size.y) ? 0.5 : (v.y - min_uv.y) / size.y;
+						uvs.write[i] = normalized;
 					}
 				}
 			}

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -244,14 +244,13 @@ void Polygon2D::_notification(int p_what) {
 				uvs.resize(len);
 				if (len > 0) {
 					const Vector2 *src = uv_source->ptr();
+					Vector2 *uvs_ptrw = uvs.ptrw();
 					Vector2 min_uv = src[0];
 					Vector2 max_uv = src[0];
 
 					for (int i = 1; i < len; i++) {
-						min_uv.x = MIN(min_uv.x, src[i].x);
-						min_uv.y = MIN(min_uv.y, src[i].y);
-						max_uv.x = MAX(max_uv.x, src[i].x);
-						max_uv.y = MAX(max_uv.y, src[i].y);
+						min_uv = min_uv.min(src[i]);
+						max_uv = max_uv.max(src[i]);
 					}
 
 					Vector2 size = max_uv - min_uv;
@@ -261,7 +260,7 @@ void Polygon2D::_notification(int p_what) {
 						Vector2 normalized;
 						normalized.x = Math::is_zero_approx(size.x) ? 0.5 : (v.x - min_uv.x) / size.x;
 						normalized.y = Math::is_zero_approx(size.y) ? 0.5 : (v.y - min_uv.y) / size.y;
-						uvs.write[i] = normalized;
+						uvs_ptrw[i] = normalized;
 					}
 				}
 			}

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -237,6 +237,23 @@ void Polygon2D::_notification(int p_what) {
 						uvs.write[i] = texmat.xform(points[i]) / tex_size;
 					}
 				}
+			} else {
+				// Even without a texture, shaders will still need UVs to be usable.
+				int uv_size = uv.size();
+				if (uv_size != 0) {
+					// Case no texture, but UVs are still provided.
+					uvs.resize(uv_size);
+					const Vector2 *uvp = uv.ptr();
+					for (int i = 0; i < uv_size; i++) {
+						uvs.write[i] = uvp[i];
+					}
+				} else {
+					// Case no texture and no UVs, the points should give usable coords.
+					uvs.resize(len);
+					for (int i = 0; i < len; i++) {
+						uvs.write[i] = points[i];
+					}
+				}
 			}
 
 			if (skeleton_node && !invert && bone_weights.size()) {


### PR DESCRIPTION
Fix Polygon2D UVs When No Texture (#81627)
This PR addresses missing/zeroed UVs in Polygon2D when no texture is assigned. The first commit introduces a basic fallback, and the follow-up commit normalizes fallback UVs to 
[0,1] while keeping user-provided UVs intact when they match vertex count. This ensures shaders receive sane UVs even without textures.

Tested both cases - work as expected on Windows
<img width="1428" height="950" alt="image" src="https://github.com/user-attachments/assets/93e66840-2f56-48a0-8b09-2974a76c8cd4" />
