### PR TITLE
Add finite check for `normalize()` in vector classes

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -54,7 +54,8 @@ void Basis::invert() {
 }
 
 void Basis::orthonormalize() {
-	// Gram-Schmidt Process
+	// Orthonormalizable check is done in Vector3 class below.
+	// Gram-Schmidt Process:
 
 	Vector3 x = get_column(0);
 	Vector3 y = get_column(1);

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -38,9 +38,15 @@ void Plane::set_normal(const Vector3 &p_normal) {
 }
 
 void Plane::normalize() {
+#ifdef MATH_CHECKS
+	if (!is_finite()) {
+		WARN_PRINT("Plane cannot be normalized, the distance and the normal should be finite.");
+	}
+#endif // MATH_CHECKS
+
 	real_t l = normal.length();
 	if (l == 0) {
-		*this = Plane(0, 0, 0, 0);
+		zero();
 		return;
 	}
 	normal /= l;

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -45,6 +45,11 @@ struct [[nodiscard]] Plane {
 	void set_normal(const Vector3 &p_normal);
 	_FORCE_INLINE_ Vector3 get_normal() const { return normal; }
 
+	void zero() {
+		normal.zero();
+		d = 0;
+	}
+
 	void normalize();
 	Plane normalized() const;
 

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -63,6 +63,11 @@ real_t Quaternion::length() const {
 }
 
 void Quaternion::normalize() {
+#ifdef MATH_CHECKS
+	if (!is_finite()) {
+		WARN_PRINT("Quaternion cannot be normalized, the elements should be finite.");
+	}
+#endif // MATH_CHECKS
 	*this /= length();
 }
 

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -145,7 +145,8 @@ void Transform2D::translate_local(const Vector2 &p_translation) {
 }
 
 void Transform2D::orthonormalize() {
-	// Gram-Schmidt Process
+	// Orthonormalizable check is done in Vector2 class below.
+	// Gram-Schmidt Process:
 
 	Vector2 x = columns[0];
 	Vector2 y = columns[1];

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -150,6 +150,7 @@ Transform3D Transform3D::translated_local(const Vector3 &p_translation) const {
 }
 
 void Transform3D::orthonormalize() {
+	// Orthonormalizable check is done in Basis class below.
 	basis.orthonormalize();
 }
 

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -50,8 +50,18 @@ real_t Vector2::length_squared() const {
 }
 
 void Vector2::normalize() {
-	real_t l = x * x + y * y;
-	if (l != 0) {
+	if (!is_finite()) {
+#ifdef MATH_CHECKS
+		WARN_PRINT("Vector2 cannot be normalized, the elements must be finite. Making (0, 0) as a fallback.");
+#endif // MATH_CHECKS
+		zero();
+		return;
+	}
+
+	real_t l = length_squared();
+	if (l == 0) {
+		zero();
+	} else {
 		l = Math::sqrt(l);
 		x /= l;
 		y /= l;

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -91,6 +91,8 @@ struct [[nodiscard]] Vector2 {
 	real_t length_squared() const;
 	Vector2 limit_length(real_t p_len = 1.0) const;
 
+	void zero() { x = y = 0; }
+
 	Vector2 min(const Vector2 &p_vector2) const {
 		return Vector2(MIN(x, p_vector2.x), MIN(y, p_vector2.y));
 	}

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -546,14 +546,22 @@ real_t Vector3::length_squared() const {
 }
 
 void Vector3::normalize() {
-	real_t lengthsq = length_squared();
-	if (lengthsq == 0) {
-		x = y = z = 0;
+	if (!is_finite()) {
+#ifdef MATH_CHECKS
+		WARN_PRINT("Vector3 cannot be normalized, the elements must be finite. Making (0, 0, 0) as a fallback.");
+#endif // MATH_CHECKS
+		zero();
+		return;
+	}
+
+	real_t l = length_squared();
+	if (l == 0) {
+		zero();
 	} else {
-		real_t length = Math::sqrt(lengthsq);
-		x /= length;
-		y /= length;
-		z /= length;
+		l = Math::sqrt(l);
+		x /= l;
+		y /= l;
+		z /= l;
 	}
 }
 

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -79,15 +79,23 @@ real_t Vector4::length() const {
 }
 
 void Vector4::normalize() {
-	real_t lengthsq = length_squared();
-	if (lengthsq == 0) {
-		x = y = z = w = 0;
+	if (!is_finite()) {
+#ifdef MATH_CHECKS
+		WARN_PRINT("Vector4 cannot be normalized, the elements must be finite. Making (0, 0, 0, 0) as a fallback.");
+#endif // MATH_CHECKS
+		zero();
+		return;
+	}
+
+	real_t l = length_squared();
+	if (l == 0) {
+		zero();
 	} else {
-		real_t length = Math::sqrt(lengthsq);
-		x /= length;
-		y /= length;
-		z /= length;
-		w /= length;
+		l = Math::sqrt(l);
+		x /= l;
+		y /= l;
+		z /= l;
+		w /= l;
 	}
 }
 

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -98,6 +98,8 @@ struct [[nodiscard]] Vector4 {
 	Vector4 normalized() const;
 	bool is_normalized() const;
 
+	void zero() { x = y = z = w = 0; }
+
 	real_t distance_to(const Vector4 &p_to) const;
 	real_t distance_squared_to(const Vector4 &p_to) const;
 	Vector4 direction_to(const Vector4 &p_to) const;


### PR DESCRIPTION
- Supersedes/closes https://github.com/godotengine/godot/pull/116422
- Fixes https://github.com/godotengine/godot/issues/73299

Add a finite check to the `normalize()` function.

In practice, cases occur where `normalize()` does not produce a normalized result when the vector length is zero. Currently, it returns the zero vector in such cases. Since many implementations in Godot's core rely on this zero vector being returned, adding a check for the zero vector would cause a large number of errors to be spammed and break compatibility. Therefore, I will limit the change to adding only the finite check.

Also, the addition checks were kept to a minimum since they affect performance. Specifically, in the case of Script https://github.com/godotengine/godot/issues/73299, the warning occurs due to using `Vector3()::normalize()` instead of `Basis::orthonormalize()`.

<img width="1555" height="496" alt="image" src="https://github.com/user-attachments/assets/9c8134cb-f733-4330-8cc1-1b48c6c09896" />

However, since what's argument passed to the function is a Transform3D, I don't think it makes much difference whether it's a Basis warning or a Vector3 warning, although the confusion with the origin and the basis elements possibly occur.. In any case, since now it can warn that something within Transform3D is infinite, this is far preferable to the original warning.

By the way, I remember we briefly discussed in the past the possibility of improving `interpolate_with()` to avoid using `orthonormalized()` altogether in https://github.com/godotengine/godot/pull/72287. While this should be a completely separate PR, if feasible, it could potentially eliminate from `interpolate_with()` entirely (Although the result is expected to be either nan or infinite, so another function will likely throw an error).