### PR TITLE
Expose LightmapGI.bake to scripting.

### DIFF
--- a/doc/classes/LightmapGI.xml
+++ b/doc/classes/LightmapGI.xml
@@ -15,6 +15,20 @@
 	<tutorials>
 		<link title="Using Lightmap global illumination">$DOCS_URL/tutorials/3d/global_illumination/using_lightmap_gi.html</link>
 	</tutorials>
+	<methods>
+		<method name="bake">
+			<return type="int" enum="LightmapGI.BakeError" />
+			<param index="0" name="from_node" type="Node" />
+			<param index="1" name="image_data_path" type="String" default="&quot;&quot;" />
+			<param index="2" name="progress_cb" type="Callable" default="Callable()" />
+			<description>
+				Bakes this lightmap using all [MeshInstance3D] and [Light3D] nodes inside the provided root [Node] [param from_node].
+				The [param image_data_path] should point to an output filename, typically ending in [code].lmbake[/code]. The parameter may only be omitted in order to overwrite the existing baked light data on disk.
+				[param progress_cb] may optionally point to a function taking ([float] progress, [String] message, [bool] redraw) and returns whether or not to cancel the bake. A [code]true[/code] return value from the progress function will cancel the bake. Otherwise, the lightmap will continue baking.
+				Returns a status code such as [constant BAKE_ERROR_OK] on success, or any of the other status codes in [enum LightmapGI.BakeError] on failure.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="bias" type="float" setter="set_bias" getter="get_bias" default="0.0005">
 			The bias to use when computing shadows. Increasing [member bias] can fix shadow acne on the resulting baked lightmap, but can introduce peter-panning (shadows not connecting to their casters). Real-time [Light3D] shadows are not affected by this [member bias] property.

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1503,6 +1503,28 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 	return BAKE_ERROR_OK;
 }
 
+bool LightmapGI::_callable_bake_func_step(float p_progress, const String &p_description, void *p_callable_ptr, bool p_refresh) {
+	const Callable &callable = *(const Callable *)p_callable_ptr;
+	if (!callable.is_valid()) {
+		return false;
+	}
+	Variant arg0 = p_progress;
+	Variant arg1 = p_description;
+	Variant arg2 = p_refresh;
+	const Variant *argptr[3] = { &arg0, &arg1, &arg2 };
+	Variant result;
+	Callable::CallError ce;
+	callable.callp(argptr, 3, result, ce);
+	if (ce.error == Callable::CallError::CALL_OK && result.get_type() == Variant::BOOL) {
+		return (bool)result;
+	}
+	return false;
+}
+
+LightmapGI::BakeError LightmapGI::bake_(Node *p_from_node, const String &p_image_data_path, const Callable &p_bake_step_callable) {
+	return bake(p_from_node, p_image_data_path, _callable_bake_func_step, const_cast<Callable *>(&p_bake_step_callable));
+}
+
 void LightmapGI::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_POST_ENTER_TREE: {
@@ -1914,7 +1936,7 @@ void LightmapGI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_camera_attributes", "camera_attributes"), &LightmapGI::set_camera_attributes);
 	ClassDB::bind_method(D_METHOD("get_camera_attributes"), &LightmapGI::get_camera_attributes);
 
-	//	ClassDB::bind_method(D_METHOD("bake", "from_node"), &LightmapGI::bake, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("bake", "from_node", "image_data_path", "progress_cb"), &LightmapGI::bake_, DEFVAL(""), DEFVAL(Callable()));
 
 	ADD_GROUP("Tweaks", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "quality", PROPERTY_HINT_ENUM, "Low,Medium,High,Ultra"), "set_bake_quality", "get_bake_quality");

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -251,6 +251,7 @@ private:
 		float to_percent = 0.0;
 	};
 
+	static bool _callable_bake_func_step(float p_progress, const String &p_description, void *, bool p_refresh);
 	static bool _lightmap_bake_step_function(float p_completion, const String &p_text, void *ud, bool p_refresh);
 
 	struct GenProbesOctree {
@@ -344,6 +345,8 @@ public:
 	Ref<CameraAttributes> get_camera_attributes() const;
 
 	AABB get_aabb() const override;
+
+	BakeError bake_(Node *p_from_node, const String &p_image_data_path = "", const Callable &p_bake_step_callable = Callable());
 
 	BakeError bake(Node *p_from_node, String p_image_data_path = "", Lightmapper::BakeStepFunc p_bake_step = nullptr, void *p_bake_userdata = nullptr);
 


### PR DESCRIPTION
Closes godotengine/godot-proposals#8656
I had to expose a wrapper function to convert `Callable` to pair of (static bool(*)(...), void*).

Also provides the feature needed for a custom lightmap manager addon / script to implement godotengine/godot-proposals#10323 (which I think is best done as an addon due to being workflow specific).