### PR TITLE
Remove redundant Z rescaling in multiview VoxelGI `reconstruct_position`

### DIFF
--- a/servers/rendering/renderer_rd/shaders/environment/gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/gi.glsl
@@ -162,7 +162,7 @@ vec3 reconstruct_position(ivec2 screen_pos) {
 	if (sc_use_full_projection_matrix) {
 		vec4 pos;
 		pos.xy = (2.0 * vec2(screen_pos) / vec2(scene_data.screen_size)) - 1.0;
-		pos.z = texelFetch(sampler2D(depth_buffer, linear_sampler), screen_pos, 0).r * 2.0 - 1.0;
+		pos.z = texelFetch(sampler2D(depth_buffer, linear_sampler), screen_pos, 0).r;
 		pos.w = 1.0;
 
 		pos = scene_data.inv_projection[params.view_index] * pos;


### PR DESCRIPTION
Fix for #116409 
This is a draft because it works on the MRP, and "almost" works on a real XR headset.

After 4.3-dev6, the `* 2.0 - 1.0` in the shader would seem to be double-correcting: `set_depth_correction` in `gi.cpp` should already be accounting for this. 

### MRP on Linux (MobileVR)
Fully fixes the issue, even if the camera is at arbitrary positions and angles.

### MRP on Windows 11 (Bigscreen Beyond 2)
The scene actually has lighting now, but the lighting projection is distorted. I'm not sure how to describe the distortion, but (as you might expect) it varies with camera position.

### Question
Is this `flip_y` really meant to be hardcoded to false, or should it be parameterized to use `render_data->scene_data->flip_y`, as it is in some other places in the codebase?

https://github.com/godotengine/godot/blob/8db94f7b5eb0e97829d1f4fceac2784b55c112c6/servers/rendering/renderer_rd/environment/gi.cpp#L3871