### PR TITLE
Revert "Core: Use `__fastfail()` in MSVC error macros"

### DIFF
--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -32,10 +32,6 @@
 
 #include "core/typedefs.h"
 
-#ifdef _MSC_VER
-#include <intrin.h> // `__fastfail()`.
-#endif
-
 class String;
 class ObjectID;
 
@@ -95,11 +91,11 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define FUNCTION_STR __FUNCTION__
 #endif
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 /**
  * Don't use GENERATE_TRAP() directly, should only be used be the macros below.
  */
-#define GENERATE_TRAP() __fastfail(7 /* FAST_FAIL_FATAL_APP_EXIT */)
+#define GENERATE_TRAP() __debugbreak()
 #else
 /**
  * Don't use GENERATE_TRAP() directly, should only be used be the macros below.


### PR DESCRIPTION
This reverts commit b23a233b5b0d80d287f2eeca9c7f3ec26f2558a6, PR #105916.

Confirmed that this indeed fixes the issue. Turns out that an explicit abort doesn't necessarily guarantee a breakpoint. Notably, it only fixes the issue for MSVC if not using console-mode, but that was revealed to be an entirely separate bug that already existed prior to this change

- Fixes #115490
