### PR TITLE
Clarify that `map_to_local` returns the position of the center of the cell in GridMap

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -186,7 +186,7 @@
 			<return type="Vector3" />
 			<param index="0" name="map_position" type="Vector3i" />
 			<description>
-				Returns the position of a grid cell in the GridMap's local coordinate space. To convert the returned value into global coordinates, use [method Node3D.to_global]. See also [method local_to_map].
+				Returns the position of a grid cell in the GridMap's local coordinate space. The returned position is centered according to the values of [member cell_center_x], [member cell_center_y], and [member cell_center_z]. To convert the returned value into global coordinates, use [method Node3D.to_global]. See also [method local_to_map].
 			</description>
 		</method>
 		<method name="resource_changed" deprecated="Use [signal Resource.changed] instead.">


### PR DESCRIPTION
TL;DR
- Closes #116449 
- Clarifies that `map_to_local` returns the position of the center of the cell in GridMap

> [!NOTE]
> Contributed by 2LazyDevs.
