### PR TITLE
[Editor] Fix performance regression caused by FileSystemDock filtering

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -865,16 +865,12 @@ void FileSystemDock::navigate_to_path(const String &p_path) {
 void FileSystemDock::_file_list_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_index, const String &p_filename) {
 	if (p_preview.is_valid()) {
 		if (p_index < files->get_item_count() && files->get_item_text(p_index) == p_filename && files->get_item_metadata(p_index) == p_path) {
-			Ref<Texture2D> thumbnail;
-
 			if (file_list_display_mode == FILE_LIST_DISPLAY_LIST) {
-				thumbnail = p_small_preview;
+				if (p_small_preview.is_valid()) {
+					files->set_item_icon(p_index, p_small_preview);
+				}
 			} else {
-				thumbnail = p_preview;
-			}
-
-			if (thumbnail.is_valid()) {
-				files->set_item_icon(p_index, _apply_thumbnail_filter(thumbnail, p_path));
+				files->set_item_icon(p_index, p_preview);
 			}
 		}
 	}
@@ -883,35 +879,8 @@ void FileSystemDock::_file_list_thumbnail_done(const String &p_path, const Ref<T
 void FileSystemDock::_tree_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_update_id, ObjectID p_item) {
 	TreeItem *item = ObjectDB::get_instance<TreeItem>(p_item);
 	if (item && tree_update_id == p_update_id && p_small_preview.is_valid()) {
-		item->set_icon(0, _apply_thumbnail_filter(p_small_preview, p_path));
+		item->set_icon(0, p_small_preview);
 	}
-}
-
-Ref<Texture2D> FileSystemDock::_apply_thumbnail_filter(const Ref<Texture2D> &p_thumbnail, const String &p_file_path) const {
-	if (!p_file_path.is_empty()) {
-		int index;
-		EditorFileSystemDirectory *dir = EditorFileSystem::get_singleton()->find_file(p_file_path, &index);
-
-		if (dir) {
-			if (dir->get_file_import_is_valid(index)) {
-				const StringName &file_type = dir->get_file_type(index);
-
-				if (file_type == SNAME("CompressedTexture2D") || file_type == SNAME("Image")) {
-					const String extension = p_file_path.get_extension();
-
-					if (extension != "svg" && extension != "svgz") {
-						Ref<CanvasTexture> thumbnail_wrapped;
-						thumbnail_wrapped.instantiate();
-						thumbnail_wrapped->set_diffuse_texture(p_thumbnail);
-						thumbnail_wrapped->set_texture_filter(CanvasItem::TextureFilter::TEXTURE_FILTER_NEAREST_WITH_MIPMAPS);
-						return thumbnail_wrapped;
-					}
-				}
-			}
-		}
-	}
-
-	return p_thumbnail;
 }
 
 void FileSystemDock::_toggle_file_display() {

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -370,7 +370,6 @@ private:
 	void _preview_invalidated(const String &p_path);
 	void _file_list_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_index, const String &p_filename);
 	void _tree_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_update_id, ObjectID p_item);
-	Ref<Texture2D> _apply_thumbnail_filter(const Ref<Texture2D> &p_thumbnail, const String &p_file_path) const;
 
 	void _update_display_mode(bool p_force = false);
 

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -44,6 +44,19 @@
 #include "scene/resources/image_texture.h"
 #include "servers/rendering/rendering_server_globals.h"
 
+void apply_texture_filter(Ref<Texture2D> &r_texture) {
+	CanvasTexture *canvas = Object::cast_to<CanvasTexture>(r_texture.ptr());
+	if (canvas != nullptr) {
+		canvas->set_texture_filter(CanvasItem::TextureFilter::TEXTURE_FILTER_NEAREST_WITH_MIPMAPS);
+	} else {
+		Ref<CanvasTexture> filter;
+		filter.instantiate();
+		filter->set_diffuse_texture(r_texture);
+		filter->set_texture_filter(CanvasItem::TextureFilter::TEXTURE_FILTER_NEAREST_WITH_MIPMAPS);
+		r_texture = filter;
+	}
+}
+
 bool EditorResourcePreviewGenerator::handles(const String &p_type) const {
 	bool success = false;
 	GDVIRTUAL_CALL(_handles, p_type, success);
@@ -139,7 +152,7 @@ void EditorResourcePreview::_thread_func(void *ud) {
 	erp->_thread();
 }
 
-void EditorResourcePreview::_preview_ready(const String &p_path, int p_hash, const Ref<Texture2D> &p_texture, const Ref<Texture2D> &p_small_texture, const Callable &p_callback, const Dictionary &p_metadata) {
+void EditorResourcePreview::_preview_ready(const String &p_path, int p_hash, Ref<Texture2D> p_texture, Ref<Texture2D> p_small_texture, const Callable &p_callback, const Dictionary &p_metadata) {
 	{
 		MutexLock lock(preview_mutex);
 
@@ -153,6 +166,17 @@ void EditorResourcePreview::_preview_ready(const String &p_path, int p_hash, con
 			}
 		}
 
+		bool should_apply_filter = false;
+
+		if (p_metadata.has("apply_filter")) {
+			should_apply_filter = p_metadata["apply_filter"];
+		}
+
+		if (should_apply_filter) {
+			apply_texture_filter(p_texture);
+			apply_texture_filter(p_small_texture);
+		}
+
 		Item item;
 		item.preview = p_texture;
 		item.small_preview = p_small_texture;
@@ -162,18 +186,28 @@ void EditorResourcePreview::_preview_ready(const String &p_path, int p_hash, con
 
 		cache[p_path] = item;
 	}
+
 	p_callback.call_deferred(p_path, p_texture, p_small_texture);
 }
 
 void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<ImageTexture> &r_small_texture, const QueueItem &p_item, const String &cache_base, Dictionary &p_metadata) {
 	String type;
+	String extension;
 
 	uint64_t started_at = OS::get_singleton()->get_ticks_usec();
 
 	if (p_item.resource.is_valid()) {
 		type = p_item.resource->get_class();
+		extension = p_item.resource->get_path().get_extension();
+
 	} else {
 		type = ResourceLoader::get_resource_type(p_item.path);
+		extension = p_item.path.get_extension();
+	}
+
+	bool is_svg = extension == "svg" || extension == "svgz";
+	if (ClassDB::is_parent_class(type, "Texture") && !is_svg) {
+		p_metadata["apply_filter"] = true;
 	}
 
 	if (type.is_empty()) {

--- a/editor/inspector/editor_resource_preview.h
+++ b/editor/inspector/editor_resource_preview.h
@@ -75,7 +75,7 @@ public:
 class EditorResourcePreview : public Node {
 	GDCLASS(EditorResourcePreview, Node);
 
-	static constexpr int CURRENT_METADATA_VERSION = 1; // Increment this number to invalidate all previews.
+	static constexpr int CURRENT_METADATA_VERSION = 2; // Increment this number to invalidate all previews.
 	inline static EditorResourcePreview *singleton = nullptr;
 
 	struct QueueItem {
@@ -102,7 +102,7 @@ class EditorResourcePreview : public Node {
 
 	HashMap<String, Item> cache;
 
-	void _preview_ready(const String &p_path, int p_hash, const Ref<Texture2D> &p_texture, const Ref<Texture2D> &p_small_texture, const Callable &p_callback, const Dictionary &p_metadata);
+	void _preview_ready(const String &p_path, int p_hash, Ref<Texture2D> p_texture, Ref<Texture2D> p_small_texture, const Callable &p_callback, const Dictionary &p_metadata);
 	void _generate_preview(Ref<ImageTexture> &r_texture, Ref<ImageTexture> &r_small_texture, const QueueItem &p_item, const String &cache_base, Dictionary &p_metadata);
 
 	int small_thumbnail_size = -1;


### PR DESCRIPTION
My last PR https://github.com/godotengine/godot/pull/112426 introduced a performance regression (whoops). Hopefully this PR fixes it and closes https://github.com/godotengine/godot/issues/116027.

This PR moves the filter logic from FileSystemDock to EditorResourcePreview. It adds an `apply_filter` key to the metadata that determines whether the filter gets applied.

I'm not confident in this solution, so please suggest changes, no matter how drastic.

@KoBeWi @Zehir Please test and see if this fixes the performance issue.

