### PR TITLE
Improve stability of billboards on double precision builds

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1258,6 +1258,15 @@ void vertex() {)";
 )";
 	}
 
+#ifdef REAL_T_IS_DOUBLE
+	if (billboard_mode != BILLBOARD_DISABLED) {
+		code += R"(
+	// Save the node position for later to improve stability on double precision builds.
+	vec3 node_pos_view = MODELVIEW_MATRIX[3].xyz;
+)";
+	}
+#endif
+
 	switch (billboard_mode) {
 		case BILLBOARD_DISABLED: {
 		} break;
@@ -1272,17 +1281,6 @@ void vertex() {)";
 			MAIN_CAM_INV_VIEW_MATRIX[2],
 			MODEL_MATRIX[3]);
 )";
-			if (flags[FLAG_BILLBOARD_KEEP_SCALE]) {
-				code += R"(
-	// Billboard Keep Scale: Enabled
-	MODELVIEW_MATRIX = MODELVIEW_MATRIX * mat4(
-			vec4(length(MODEL_MATRIX[0].xyz), 0.0, 0.0, 0.0),
-			vec4(0.0, length(MODEL_MATRIX[1].xyz), 0.0, 0.0),
-			vec4(0.0, 0.0, length(MODEL_MATRIX[2].xyz), 0.0),
-			vec4(0.0, 0.0, 0.0, 1.0));
-)";
-			}
-			code += "	MODELVIEW_NORMAL_MATRIX = mat3(MODELVIEW_MATRIX);\n";
 		} break;
 		case BILLBOARD_FIXED_Y: {
 			// `MAIN_CAM_INV_VIEW_MATRIX` is inverse of the camera, even on shadow passes.
@@ -1295,17 +1293,6 @@ void vertex() {)";
 			vec4(normalize(cross(MAIN_CAM_INV_VIEW_MATRIX[0].xyz, vec3(0.0, 1.0, 0.0))), 0.0),
 			MODEL_MATRIX[3]);
 )";
-			if (flags[FLAG_BILLBOARD_KEEP_SCALE]) {
-				code += R"(
-	// Billboard Keep Scale: Enabled
-	MODELVIEW_MATRIX = MODELVIEW_MATRIX * mat4(
-			vec4(length(MODEL_MATRIX[0].xyz), 0.0, 0.0, 0.0),
-			vec4(0.0, length(MODEL_MATRIX[1].xyz), 0.0, 0.0),
-			vec4(0.0, 0.0, length(MODEL_MATRIX[2].xyz), 0.0),
-			vec4(0.0, 0.0, 0.0, 1.0));
-)";
-			}
-			code += "	MODELVIEW_NORMAL_MATRIX = mat3(MODELVIEW_MATRIX);\n";
 		} break;
 		case BILLBOARD_PARTICLES: {
 			// Make billboard and rotated by rotation.
@@ -1324,8 +1311,14 @@ void vertex() {)";
 )";
 			// Set modelview.
 			code += "	MODELVIEW_MATRIX = VIEW_MATRIX * mat_world;\n";
-			if (flags[FLAG_BILLBOARD_KEEP_SCALE]) {
-				code += R"(
+		} break;
+		case BILLBOARD_MAX:
+			break; // Internal value, skip.
+	}
+
+	if (billboard_mode != BILLBOARD_DISABLED) {
+		if (flags[FLAG_BILLBOARD_KEEP_SCALE]) {
+			code += R"(
 	// Billboard Keep Scale: Enabled
 	MODELVIEW_MATRIX = MODELVIEW_MATRIX * mat4(
 			vec4(length(MODEL_MATRIX[0].xyz), 0.0, 0.0, 0.0),
@@ -1333,11 +1326,21 @@ void vertex() {)";
 			vec4(0.0, 0.0, length(MODEL_MATRIX[2].xyz), 0.0),
 			vec4(0.0, 0.0, 0.0, 1.0));
 )";
-			}
-			// Set modelview normal and handle animation.
-			code += R"(
-	MODELVIEW_NORMAL_MATRIX = mat3(MODELVIEW_MATRIX);
+		}
 
+#ifdef REAL_T_IS_DOUBLE
+		code += R"(
+	// Reapply the node position.
+	MODELVIEW_MATRIX[3].xyz = node_pos_view;
+)";
+#endif
+
+		// Set modelview normal.
+		code += "	MODELVIEW_NORMAL_MATRIX = mat3(MODELVIEW_MATRIX);\n";
+
+		if (billboard_mode == BILLBOARD_PARTICLES) {
+			// Handle animation.
+			code += R"(
 	float h_frames = float(particles_anim_h_frames);
 	float v_frames = float(particles_anim_v_frames);
 	float particle_total_frames = float(particles_anim_h_frames * particles_anim_v_frames);
@@ -1350,9 +1353,7 @@ void vertex() {)";
 	UV /= vec2(h_frames, v_frames);
 	UV += vec2(mod(particle_frame, h_frames) / h_frames, floor((particle_frame + 0.5) / h_frames) / v_frames);
 )";
-		} break;
-		case BILLBOARD_MAX:
-			break; // Internal value, skip.
+		}
 	}
 
 	if (flags[FLAG_FIXED_SIZE]) {


### PR DESCRIPTION
Fixes #114704 and fixes #111521

Billboarding is erroneously relying on the translation component of matrices to be precise far from the origin. I fixed this by sourcing the translation from the modelview matrix, which is known to be more precise thanks to #106951.