### PR TITLE
Evaluate empty EditorSpinSliders to 0

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -581,6 +581,10 @@ String EditorSpinSlider::get_suffix() const {
 }
 
 void EditorSpinSlider::_evaluate_input_text() {
+	if (value_input->get_text().is_empty()) {
+		set_value(0);
+		return;
+	}
 	const String &lang = _get_locale();
 
 	Ref<Expression> expr;


### PR DESCRIPTION
When user clears any numeric input field (that uses `EditorSpinSlider`) and then confirms or changes focus, the empty string would fail to parse as an Expression, causing the function to return early without updating the value. 

This PR adds an early return at the beginning of `_evaluate_input_text()` that checks if the input text is empty. If so, it sets the value to 0 (a reasonable default for cleared input) and returns early, avoiding the Expression parsing failure. 

Similar behavior is used in Blender and Unity for example, which makes the process of clearing fields much easier using Ctrl+X. instead of explicitly setting them to 0. It's especially useful for `Vector`, `AABB` etc., where you often want to clear individual components. 