### PR TITLE
Fix GDScript signal callback shadowing native class members

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -446,7 +446,8 @@ void ScriptTextEditor::add_callback(const String &p_function, const PackedString
 	if (pos == -1) {
 		// Function does not exist, create it at the end of the file.
 		int last_line = code_editor->get_text_editor()->get_line_count() - 1;
-		String func = language->make_function("", p_function, p_args);
+		String class_name = script->get_instance_base_type();
+		String func = language->make_function(class_name, p_function, p_args);
 		code_editor->get_text_editor()->insert_text("\n\n" + func, last_line, code_editor->get_text_editor()->get_line(last_line).length());
 		pos = last_line + 3;
 	}

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -538,7 +538,16 @@ String GDScriptLanguage::make_function(const String &p_class, const String &p_na
 			}
 
 			const String name_unstripped = p_args[i].get_slicec(':', 0);
-			result += name_unstripped.strip_edges();
+			String arg_name = name_unstripped.strip_edges();
+
+			// Avoid shadowing class properties.
+			if (!p_class.is_empty() && ClassDB::class_exists(p_class)) {
+				if (ClassDB::has_property(p_class, arg_name, false)) {
+					arg_name = "p_" + arg_name;
+				}
+			}
+
+			result += arg_name;
 
 			if (type_hints) {
 				const String type_stripped = p_args[i].substr(name_unstripped.length() + 1).strip_edges();

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -542,7 +542,7 @@ String GDScriptLanguage::make_function(const String &p_class, const String &p_na
 
 			// Avoid shadowing class properties.
 			if (!p_class.is_empty() && ClassDB::class_exists(p_class)) {
-				if (ClassDB::has_property(p_class, arg_name, false)) {
+				if (ClassDB::has_property(p_class, arg_name)) {
 					arg_name = "p_" + arg_name;
 				}
 			}


### PR DESCRIPTION
### Summary
Fix a problem where the generation of a signal callback (e.g., `value_changed` in `HSlider`) results in argument names that shadow the node's native properties, triggering immediate GDScript warnings.

### Problem
The signal callback generator uses the signal's argument names as is.
For example, `HSlider` (inheriting `Range`) has a signal `value_changed(value: float)`.
This currently generates:
`func _on_value_changed(value: float):`
However, `HSlider` has a property named `value`, so this triggers a shadowing warning.

### Fix
- Modified `ScriptTextEditor::add_callback` to pass the script's base native type to the function generator (instead of an empty string).
- Modified `GDScriptLanguage::make_function` to check `ClassDB` for property shadowing in the class hierarchy (recursive check).
- If a shadow is detected, the argument name is prefixed with `p_` (e.g., `p_value`).

Fixes #116423
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->