### PR TITLE
Fix closed docks still being present in the dock menu after being disabled

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7723,6 +7723,8 @@ void EditorNode::_feature_profile_changed() {
 			editor_main_screen->set_button_enabled(EditorMainScreen::EDITOR_ASSETLIB, true);
 		}
 	}
+
+	editor_dock_manager->update_docks_menu();
 }
 
 void EditorNode::_bind_methods() {


### PR DESCRIPTION
If you close a dock, and then disable it in the features dialog, it would still be listed in the "Editor > Editor Docks" menu until you selected another dock. This PR makes so that the list is updated on feature changes.