### PR TITLE
Add window presets to project settings

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -227,6 +227,11 @@ void ProjectSettings::set_initial_value(const String &p_name, const Variant &p_v
 	props[p_name].initial = p_value.duplicate();
 }
 
+Variant ProjectSettings::get_initial_value(const String &p_name) const {
+	ERR_FAIL_COND_V_MSG(!props.has(p_name), Variant(), vformat("Request for nonexistent project setting: '%s'.", p_name));
+	return props[p_name].initial;
+}
+
 void ProjectSettings::set_restart_if_changed(const String &p_name, bool p_restart) {
 	ERR_FAIL_COND_MSG(!props.has(p_name), vformat("Request for nonexistent project setting: '%s'.", p_name));
 	props[p_name].restart_if_changed = p_restart;
@@ -1711,6 +1716,8 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "accessibility/general/accessibility_support", PROPERTY_HINT_ENUM, "Auto (When Screen Reader is Running),Always Active,Disabled"), 0);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "accessibility/general/updates_per_second", PROPERTY_HINT_RANGE, "1,100,1"), 60);
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, "accessibility/general/accessibility_driver", PROPERTY_HINT_ENUM, "accesskit,dummy"), "accesskit");
+
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/preset", PROPERTY_HINT_ENUM, WINDOW_PRESETS), 0);
 
 	// The default window size is tuned to:
 	// - Have a 16:9 aspect ratio,

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -160,6 +160,8 @@ protected:
 public:
 	static const int CONFIG_VERSION = 5;
 
+	const String WINDOW_PRESETS = "Default,Desktop Game Non-pixel art 4K,Desktop Game Non-pixel art HD,Desktop Game Pixel art Large,Desktop Game Pixel art Medium,Desktop Game Pixel art Small,Mobile Game Landscape HD,Mobile Game Landscape,Mobile Game Landscape Tablets,Mobile Game Portrait HD,Mobile Game Portrait,Mobile Game Portrait Tablets";
+
 #ifdef TOOLS_ENABLED
 	HashMap<String, PropertyInfo> editor_settings_info;
 #endif
@@ -176,6 +178,7 @@ public:
 	String globalize_path(const String &p_path) const;
 
 	void set_initial_value(const String &p_name, const Variant &p_value);
+	Variant get_initial_value(const String &p_name) const;
 	void set_as_basic(const String &p_name, bool p_basic);
 	void set_as_internal(const String &p_name, bool p_internal);
 	void set_restart_if_changed(const String &p_name, bool p_restart);
@@ -263,6 +266,7 @@ Variant _GLOBAL_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p
 #define GLOBAL_DEF_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, true)
 #define GLOBAL_DEF_RST_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, true)
 #define GLOBAL_GET(m_var) ProjectSettings::get_singleton()->get_setting_with_override(m_var)
+#define GLOBAL_GET_INIT(m_var) ProjectSettings::get_singleton()->get_initial_value(m_var)
 
 #define GLOBAL_DEF_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, false, true)
 #define GLOBAL_DEF_RST_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, false, true)

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1004,6 +1004,24 @@
 		<member name="display/window/per_pixel_transparency/allowed" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], allows per-pixel transparency for the window background. This affects performance, so leave it on [code]false[/code] unless you need it. See also [member display/window/size/transparent] and [member rendering/viewport/transparent_background].
 		</member>
+		<member name="display/window/preset" type="int" setter="" getter="" default="0">
+			Window preset to use for the project. Provides quick configuration for common game types and platforms.
+			The options are:
+			- [b]Default[/b]: Default Godot window settings (1152×648)
+			- [b]Desktop Game Non-pixel art 4K[/b]: 3840×2160 resolution, canvas_items stretch mode, expand aspect, fractional scaling
+			- [b]Desktop Game Non-pixel art HD[/b]: 1920×1080 resolution, canvas_items stretch mode, expand aspect, fractional scaling
+			- [b]Desktop Game Pixel art Large[/b]: 640×480 resolution, viewport stretch mode, keep aspect, integer scaling
+			- [b]Desktop Game Pixel art Medium[/b]: 640×360 resolution, viewport stretch mode, keep aspect, integer scaling
+			- [b]Desktop Game Pixel art Small[/b]: 256×224 resolution, viewport stretch mode, keep aspect, integer scaling
+			- [b]Mobile Game Landscape HD[/b]: 1920×1080 resolution, canvas_items stretch mode, expand aspect, fractional scaling, 2.0x theme scale
+			- [b]Mobile Game Landscape[/b]: 1280×720 resolution, canvas_items stretch mode, expand aspect, fractional scaling
+			- [b]Mobile Game Landscape Tablets[/b]: 1280×960 resolution, canvas_items stretch mode, expand aspect, fractional scaling
+			- [b]Mobile Game Portrait HD[/b]: 1080×1920 resolution, canvas_items stretch mode, expand aspect, fractional scaling, 2.0x theme scale
+			- [b]Mobile Game Portrait[/b]: 720×1280 resolution, canvas_items stretch mode, expand aspect, fractional scaling
+			- [b]Mobile Game Portrait Tablets[/b]: 960×1280 resolution, canvas_items stretch mode, expand aspect, fractional scaling
+			- [b]Custom[/b]: Custom settings (automatically selected when settings are modified)
+			[b]Note:[/b] When you modify any window-related setting after selecting a preset, the preset will automatically change to "Custom".
+		</member>
 		<member name="display/window/size/always_on_top" type="bool" setter="" getter="" default="false">
 			Forces the main window to be always on top.
 			[b]Note:[/b] This setting is ignored on iOS, Android, and Web.

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -75,6 +75,7 @@ void ProjectSettingsEditor::popup_project_settings(bool p_clear_filter) {
 	}
 
 	_focus_current_search_box();
+	_settings_popup();
 }
 
 void ProjectSettingsEditor::popup_for_override(const String &p_override) {
@@ -162,6 +163,73 @@ void ProjectSettingsEditor::_setting_selected(const String &p_path) {
 	property_box->set_text(general_settings_inspector->get_current_section() + "/" + p_path);
 
 	_update_property_box(); // set_text doesn't trigger text_changed
+}
+
+void ProjectSettingsEditor::_settings_popup() {
+	int preset = ps->get_setting("display/window/preset", 0);
+	int custom = window_presets.size();
+	if (preset == custom) {
+		GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/preset", PROPERTY_HINT_ENUM, ps->WINDOW_PRESETS + ",Custom"), 0);
+		general_settings_inspector->update_category_list();
+		Preset::set_custom(true);
+	}
+}
+
+void ProjectSettingsEditor::_settings_changed() {
+	if (Preset::is_updating()) {
+		return;
+	}
+
+	if (ps->check_changed_settings_in_group("display/window/preset")) {
+		Preset::set_updating(true);
+		int preset = ps->get_setting("display/window/preset", 0);
+		int custom = window_presets.size();
+		if (preset < custom) {
+			if (Preset::is_custom()) {
+				GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/preset", PROPERTY_HINT_ENUM, ps->WINDOW_PRESETS), 0);
+				general_settings_inspector->update_category_list();
+				Preset::set_custom(false);
+			}
+			for (const KeyValue<StringName, Variant> &E : window_presets[preset].data) {
+				ps->set_setting(E.key, E.value);
+			}
+		}
+		Preset::set_updating(false);
+	} else if (ps->check_changed_settings_in_group("display/window")) {
+		Preset::set_updating(true);
+		if (Preset::is_custom()) {
+			for (int i = 0; i < window_presets.size(); i++) {
+				uint32_t same = 0;
+				for (const KeyValue<StringName, Variant> &E : window_presets[i].data) {
+					if (ps->get_setting(E.key) == E.value) {
+						same++;
+					}
+				}
+				if (same == window_presets[i].data.size()) {
+					GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/preset", PROPERTY_HINT_ENUM, ps->WINDOW_PRESETS), 0);
+					general_settings_inspector->update_category_list();
+					ps->set_setting("display/window/preset", i);
+					Preset::set_custom(false);
+					break;
+				}
+			}
+		} else {
+			int preset = ps->get_setting("display/window/preset", 0);
+			int custom = window_presets.size();
+			if (preset < custom) {
+				for (const KeyValue<StringName, Variant> &E : window_presets[preset].data) {
+					if (ps->get_setting(E.key) != E.value) {
+						GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/preset", PROPERTY_HINT_ENUM, ps->WINDOW_PRESETS + ",Custom"), 0);
+						general_settings_inspector->update_category_list();
+						ps->set_setting("display/window/preset", custom);
+						Preset::set_custom(true);
+						break;
+					}
+				}
+			}
+		}
+		Preset::set_updating(false);
+	}
 }
 
 void ProjectSettingsEditor::_add_setting() {
@@ -700,7 +768,35 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	set_flag(FLAG_MAXIMIZE_DISABLED, false);
 	set_clamp_to_embedder(true);
 
+	// Window pressets
+	// Default"
+	window_presets.push_back(Preset());
+	// Desktop Game Non-pixel art 4K
+	window_presets.push_back(Preset(3840, 2160, Preset::CANVAS_ITEMS, Preset::EXPAND, Preset::FRACTIONAL, Preset::LANDSCAPE, 3.0f));
+	// Desktop Game Non-pixel art HD
+	window_presets.push_back(Preset(1920, 1080, Preset::CANVAS_ITEMS, Preset::EXPAND, Preset::FRACTIONAL, Preset::LANDSCAPE));
+	// Desktop Game Pixel art Large
+	window_presets.push_back(Preset(640, 480, Preset::VIEWPORT, Preset::KEEP, Preset::INTEGER, Preset::LANDSCAPE));
+	// Desktop Game Pixel art Medium
+	window_presets.push_back(Preset(640, 360, Preset::VIEWPORT, Preset::KEEP, Preset::INTEGER, Preset::LANDSCAPE));
+	// Desktop Game Pixel art Small
+	window_presets.push_back(Preset(256, 224, Preset::VIEWPORT, Preset::KEEP, Preset::INTEGER, Preset::LANDSCAPE));
+	// Mobile Game Landscape HD
+	window_presets.push_back(Preset(1920, 1080, Preset::CANVAS_ITEMS, Preset::EXPAND, Preset::FRACTIONAL, Preset::LANDSCAPE, 2.0f));
+	// Mobile Game Landscape
+	window_presets.push_back(Preset(1280, 720, Preset::CANVAS_ITEMS, Preset::EXPAND, Preset::FRACTIONAL, Preset::LANDSCAPE));
+	// Mobile Game Landscape Tablets
+	window_presets.push_back(Preset(1280, 960, Preset::CANVAS_ITEMS, Preset::EXPAND, Preset::FRACTIONAL, Preset::LANDSCAPE));
+	// Mobile Game Portrait HD
+	window_presets.push_back(Preset(1080, 1920, Preset::CANVAS_ITEMS, Preset::EXPAND, Preset::FRACTIONAL, Preset::LANDSCAPE, 2.0f));
+	// Mobile Game Portrait
+	window_presets.push_back(Preset(720, 1280, Preset::CANVAS_ITEMS, Preset::EXPAND, Preset::FRACTIONAL, Preset::LANDSCAPE));
+	// Mobile Game Portrait Tablets
+	window_presets.push_back(Preset(960, 1280, Preset::CANVAS_ITEMS, Preset::EXPAND, Preset::FRACTIONAL, Preset::LANDSCAPE));
+
 	ps = ProjectSettings::get_singleton();
+	ps->connect("settings_changed", callable_mp(this, &ProjectSettingsEditor::_settings_changed));
+
 	data = p_data;
 
 	tab_container = memnew(TabContainer);

--- a/editor/settings/project_settings_editor.h
+++ b/editor/settings/project_settings_editor.h
@@ -53,11 +53,112 @@ class ProjectSettingsEditor : public AcceptDialog {
 
 	inline static ProjectSettingsEditor *singleton = nullptr;
 
+	struct Preset {
+	private:
+		static inline bool updating = false;
+		static inline bool custom = false;
+
+	public:
+		enum StretchMode {
+			DISABLED,
+			CANVAS_ITEMS,
+			VIEWPORT,
+		};
+
+		enum StretchAspect {
+			IGNORE,
+			KEEP,
+			KEEP_WIDTH,
+			KEEP_HEIGHT,
+			EXPAND,
+		};
+
+		enum StretchScaleMode {
+			FRACTIONAL,
+			INTEGER,
+		};
+
+		enum Orientation {
+			LANDSCAPE,
+			PORTRAIT,
+			REVERSE_LANDSCAPE,
+			REVERSE_PORTRAIT,
+			SENSOR_LANDSCAPE,
+			SENSOR_PORTRAIT,
+			SENSOR,
+		};
+
+		const Vector<String> STRETCH_MODE = {
+			"disabled",
+			"canvas_items",
+			"viewport",
+		};
+		const Vector<String> STRETCH_ASPECT = {
+			"ignore",
+			"keep",
+			"keep_width",
+			"keep_height",
+			"expand",
+		};
+		const Vector<String> STRETCH_SCALE_MODE = {
+			"fractional",
+			"integer",
+		};
+
+		HashMap<StringName, Variant> data;
+
+		Preset(int p_width = 1152, int p_height = 648, StretchMode p_stretch_mode = DISABLED,
+				StretchAspect p_stretch_aspect = KEEP, StretchScaleMode p_scale_mode = FRACTIONAL,
+				Orientation p_orientation = LANDSCAPE, float p_theme_scale = 1.0f) {
+			data["display/window/size/viewport_width"] = p_width;
+			data["display/window/size/viewport_height"] = p_height;
+			data["display/window/size/mode"] = GLOBAL_GET_INIT("display/window/size/mode");
+			data["display/window/size/initial_position_type"] = GLOBAL_GET_INIT("display/window/size/initial_position_type");
+			data["display/window/size/initial_position"] = GLOBAL_GET_INIT("display/window/size/initial_position");
+			data["display/window/size/initial_screen"] = GLOBAL_GET_INIT("display/window/size/initial_screen");
+			data["display/window/size/resizable"] = GLOBAL_GET_INIT("display/window/size/resizable");
+			data["display/window/size/borderless"] = GLOBAL_GET_INIT("display/window/size/borderless");
+			data["display/window/size/always_on_top"] = GLOBAL_GET_INIT("display/window/size/always_on_top");
+			data["display/window/size/transparent"] = GLOBAL_GET_INIT("display/window/size/transparent");
+			data["display/window/size/extend_to_title"] = GLOBAL_GET_INIT("display/window/size/extend_to_title");
+			data["display/window/size/no_focus"] = GLOBAL_GET_INIT("display/window/size/no_focus");
+			data["display/window/size/sharp_corners"] = GLOBAL_GET_INIT("display/window/size/sharp_corners");
+			data["display/window/size/minimize_disabled"] = GLOBAL_GET_INIT("display/window/size/minimize_disabled");
+			data["display/window/size/maximize_disabled"] = GLOBAL_GET_INIT("display/window/size/maximize_disabled");
+			data["display/window/size/window_width_override"] = GLOBAL_GET_INIT("display/window/size/window_width_override");
+			data["display/window/size/window_height_override"] = GLOBAL_GET_INIT("display/window/size/window_height_override");
+			data["display/window/energy_saving/keep_screen_on"] = GLOBAL_GET_INIT("display/window/energy_saving/keep_screen_on");
+			data["display/window/subwindows/embed_subwindows"] = GLOBAL_GET_INIT("display/window/subwindows/embed_subwindows");
+			data["display/window/frame_pacing/android/enable_frame_pacing"] = GLOBAL_GET_INIT("display/window/frame_pacing/android/enable_frame_pacing");
+			data["display/window/frame_pacing/android/swappy_mode"] = GLOBAL_GET_INIT("display/window/frame_pacing/android/swappy_mode");
+			data["display/window/stretch/mode"] = STRETCH_MODE[p_stretch_mode];
+			data["display/window/stretch/aspect"] = STRETCH_ASPECT[p_stretch_aspect];
+			data["display/window/stretch/scale"] = GLOBAL_GET_INIT("display/window/stretch/scale");
+			data["display/window/stretch/scale_mode"] = STRETCH_SCALE_MODE[p_scale_mode];
+			data["display/window/dpi/allow_hidpi"] = GLOBAL_GET_INIT("display/window/dpi/allow_hidpi");
+			data["display/window/per_pixel_transparency/allowed"] = GLOBAL_GET_INIT("display/window/per_pixel_transparency/allowed");
+			data["display/window/handheld/orientation"] = p_orientation;
+			data["display/window/vsync/vsync_mode"] = GLOBAL_GET_INIT("display/window/vsync/vsync_mode");
+			data["display/window/ios/allow_high_refresh_rate"] = GLOBAL_GET_INIT("display/window/ios/allow_high_refresh_rate");
+			data["display/window/ios/hide_home_indicator"] = GLOBAL_GET_INIT("display/window/ios/hide_home_indicator");
+			data["display/window/ios/hide_status_bar"] = GLOBAL_GET_INIT("display/window/ios/hide_status_bar");
+			data["display/window/ios/suppress_ui_gesture"] = GLOBAL_GET_INIT("display/window/ios/suppress_ui_gesture");
+			data["gui/theme/default_theme_scale"] = p_theme_scale;
+		}
+
+		static void set_updating(bool p_updating) { updating = p_updating; }
+		static bool is_updating() { return updating; }
+		static void set_custom(bool p_custom) { custom = p_custom; }
+		static bool is_custom() { return custom; }
+	};
+
 	enum {
 		FEATURE_ALL,
 		FEATURE_CUSTOM,
 		FEATURE_FIRST,
 	};
+
+	Vector<Preset> window_presets;
 
 	ProjectSettings *ps = nullptr;
 	Timer *timer = nullptr;
@@ -109,6 +210,8 @@ class ProjectSettingsEditor : public AcceptDialog {
 	String _get_setting_name() const;
 	void _setting_edited(const String &p_name);
 	void _setting_selected(const String &p_path);
+	void _settings_popup();
+	void _settings_changed();
 	void _add_setting();
 	void _delete_setting();
 


### PR DESCRIPTION
This PR adds the list of presets so developers can quickly set up their own project.
<img width="1505" height="911" alt="image" src="https://github.com/user-attachments/assets/1dedabe1-17dc-49da-8cc2-62b585f5fdf9" />

closes https://github.com/godotengine/godot-proposals/issues/14275

I'm not sure about the implementation, preset names, and functionality.

- Should all window settings be reset to the default value when the preset is changed?
- Should the developer be able to save their own preset?