### PR TITLE
Optimize Projection::determinant()

### DIFF
--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -38,18 +38,31 @@
 #include "core/string/ustring.h"
 
 real_t Projection::determinant() const {
-	return columns[0][3] * columns[1][2] * columns[2][1] * columns[3][0] - columns[0][2] * columns[1][3] * columns[2][1] * columns[3][0] -
-			columns[0][3] * columns[1][1] * columns[2][2] * columns[3][0] + columns[0][1] * columns[1][3] * columns[2][2] * columns[3][0] +
-			columns[0][2] * columns[1][1] * columns[2][3] * columns[3][0] - columns[0][1] * columns[1][2] * columns[2][3] * columns[3][0] -
-			columns[0][3] * columns[1][2] * columns[2][0] * columns[3][1] + columns[0][2] * columns[1][3] * columns[2][0] * columns[3][1] +
-			columns[0][3] * columns[1][0] * columns[2][2] * columns[3][1] - columns[0][0] * columns[1][3] * columns[2][2] * columns[3][1] -
-			columns[0][2] * columns[1][0] * columns[2][3] * columns[3][1] + columns[0][0] * columns[1][2] * columns[2][3] * columns[3][1] +
-			columns[0][3] * columns[1][1] * columns[2][0] * columns[3][2] - columns[0][1] * columns[1][3] * columns[2][0] * columns[3][2] -
-			columns[0][3] * columns[1][0] * columns[2][1] * columns[3][2] + columns[0][0] * columns[1][3] * columns[2][1] * columns[3][2] +
-			columns[0][1] * columns[1][0] * columns[2][3] * columns[3][2] - columns[0][0] * columns[1][1] * columns[2][3] * columns[3][2] -
-			columns[0][2] * columns[1][1] * columns[2][0] * columns[3][3] + columns[0][1] * columns[1][2] * columns[2][0] * columns[3][3] +
-			columns[0][2] * columns[1][0] * columns[2][1] * columns[3][3] - columns[0][0] * columns[1][2] * columns[2][1] * columns[3][3] -
-			columns[0][1] * columns[1][0] * columns[2][2] * columns[3][3] + columns[0][0] * columns[1][1] * columns[2][2] * columns[3][3];
+	// Cofactor expansion approach that breaks the problem into smaller subproblems recursively
+	// to compute determinants in a structured and parallelized way. Saves on CPU cycles.
+	// https://en.wikipedia.org/wiki/Laplace_expansion
+
+	real_t m0 = columns[0][0];
+	real_t m4 = columns[1][0];
+	real_t m8 = columns[2][0];
+	real_t m12 = columns[3][0];
+	real_t m1 = columns[0][1];
+	real_t m5 = columns[1][1];
+	real_t m9 = columns[2][1];
+	real_t m13 = columns[3][1];
+	real_t m2 = columns[0][2];
+	real_t m6 = columns[1][2];
+	real_t m10 = columns[2][2];
+	real_t m14 = columns[3][2];
+	real_t m3 = columns[0][3];
+	real_t m7 = columns[1][3];
+	real_t m11 = columns[2][3];
+	real_t m15 = columns[3][3];
+
+	return (m0 * ((m5 * (m10 * m15 - m11 * m14) - m9 * (m6 * m15 - m7 * m14) + m13 * (m6 * m11 - m7 * m10))) -
+			m4 * ((m1 * (m10 * m15 - m11 * m14) - m9 * (m2 * m15 - m3 * m14) + m13 * (m2 * m11 - m3 * m10))) +
+			m8 * ((m1 * (m6 * m15 - m7 * m14) - m5 * (m2 * m15 - m3 * m14) + m13 * (m2 * m7 - m3 * m6))) -
+			m12 * ((m1 * (m6 * m11 - m7 * m10) - m5 * (m2 * m11 - m3 * m10) + m9 * (m2 * m7 - m3 * m6))));
 }
 
 void Projection::set_identity() {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
@@ -473,18 +473,27 @@ namespace Godot
         /// <returns>The determinant calculated from this projection.</returns>
         public readonly real_t Determinant()
         {
-            return X.W * Y.Z * Z.Y * W.X - X.Z * Y.W * Z.Y * W.X -
-                   X.W * Y.Y * Z.Z * W.X + X.Y * Y.W * Z.Z * W.X +
-                   X.Z * Y.Y * Z.W * W.X - X.Y * Y.Z * Z.W * W.X -
-                   X.W * Y.Z * Z.X * W.Y + X.Z * Y.W * Z.X * W.Y +
-                   X.W * Y.X * Z.Z * W.Y - X.X * Y.W * Z.Z * W.Y -
-                   X.Z * Y.X * Z.W * W.Y + X.X * Y.Z * Z.W * W.Y +
-                   X.W * Y.Y * Z.X * W.Z - X.Y * Y.W * Z.X * W.Z -
-                   X.W * Y.X * Z.Y * W.Z + X.X * Y.W * Z.Y * W.Z +
-                   X.Y * Y.X * Z.W * W.Z - X.X * Y.Y * Z.W * W.Z -
-                   X.Z * Y.Y * Z.X * W.W + X.Y * Y.Z * Z.X * W.W +
-                   X.Z * Y.X * Z.Y * W.W - X.X * Y.Z * Z.Y * W.W -
-                   X.Y * Y.X * Z.Z * W.W + X.X * Y.Y * Z.Z * W.W;
+            real_t m0 = X.X;
+            real_t m4 = Y.X;
+            real_t m8 = Z.X;
+            real_t m12 = W.X;
+            real_t m1 = X.Y;
+            real_t m5 = Y.Y;
+            real_t m9 = Z.Y;
+            real_t m13 = W.Y;
+            real_t m2 = X.Z;
+            real_t m6 = Y.Z;
+            real_t m10 = Z.Z;
+            real_t m14 = W.Z;
+            real_t m3 = X.W;
+            real_t m7 = Y.W;
+            real_t m11 = Z.W;
+            real_t m15 = W.W;
+
+            return (m0 * ((m5 * (m10 * m15 - m11 * m14) - m9 * (m6 * m15 - m7 * m14) + m13 * (m6 * m11 - m7 * m10))) -
+                    m4 * ((m1 * (m10 * m15 - m11 * m14) - m9 * (m2 * m15 - m3 * m14) + m13 * (m2 * m11 - m3 * m10))) +
+                    m8 * ((m1 * (m6 * m15 - m7 * m14) - m5 * (m2 * m15 - m3 * m14) + m13 * (m2 * m7 - m3 * m6))) -
+                    m12 * ((m1 * (m6 * m11 - m7 * m10) - m5 * (m2 * m11 - m3 * m10) + m9 * (m2 * m7 - m3 * m6))));
         }
 
         /// <summary>


### PR DESCRIPTION
Revives https://github.com/godotengine/godot/pull/103671

I just followed Ivorforce's feedback from that PR. It's been years since I did very little C++ so I figured a small PR like this is a good way to start, even if there's little I personally did apart from the revival.

~~I don't have any setup for C# installed which is why I didn't include the changes beicause asked for.~~ The C# are now included as well, but untested so far.

GDScript Performance Test (I chose the matrix from [here](https://github.com/godotengine/godot/blob/897172fa25699455f0a537f054654068b3dda5d5/tests/core/math/test_projection.cpp#L99)). n = 30 is often used in statistics as a minimum for normal distribution but I could test with higher n if that's wanted. Note that I didn't actually test for normality, I just calculated average and standard deviation from the results.
```
extends Node

var proj := Projection(
	Vector4(1, 5, 9, 13),
	Vector4(2, 6, 11, 15),
	Vector4(4, 7, 11, 15),
	Vector4(4, 8, 12, 16)
)
	
func _ready():
	for i in 30:
		var start := Time.get_ticks_usec()
		
		for j in 10000000:
			var det : float = proj.determinant()
			#print("Projection determinant: ", det)
		
		var end := Time.get_ticks_usec()
		
		var elapsed := end - start
		print("Elapsed time [micro s] = ", elapsed)

```
Built with `scons platform=macos production=yes debug_symbols=yes tests=yes`

This PR: 170324 ± 1872 μs
Master: 197082 ± 1557 μs

Improvement roughly 13.6 %. This doesn't come close to https://github.com/godotengine/godot-proposals/issues/11821 but I figure that's due to GDScript overhead.

- *Bugsquad edit:* closes https://github.com/godotengine/godot-proposals/issues/11821