### PR TITLE
Make `Window.move_to_center()` use `DisplayServer.screen_get_usable_rect()`

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -390,8 +390,7 @@ void Window::move_to_center() {
 		parent_rect = get_embedder()->get_visible_rect();
 	} else {
 		int parent_screen = DisplayServer::get_singleton()->window_get_current_screen(get_window_id());
-		parent_rect.position = DisplayServer::get_singleton()->screen_get_position(parent_screen);
-		parent_rect.size = DisplayServer::get_singleton()->screen_get_size(parent_screen);
+		parent_rect = DisplayServer::get_singleton()->screen_get_usable_rect(parent_screen);
 	}
 
 	if (parent_rect != Rect2()) {


### PR DESCRIPTION
Fixes #101357

Implementing this function was my first contribution to godot in #81012, but at the time I was not aware of `screen_get_usable_rect()` being preferred in such situations. Using it matches other logic for centering the window too, as shown by the issue.