### PR TITLE
`RenderingDevice` docs: fix arguments in code examples

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -272,7 +272,7 @@
 				[codeblock]
 				var rd = RenderingDevice.new()
 				var clear_colors = PackedColorArray([Color(0, 0, 0, 0), Color(0, 0, 0, 0), Color(0, 0, 0, 0)])
-				var draw_list = rd.draw_list_begin(framebuffers[i], RenderingDevice.CLEAR_COLOR_ALL, clear_colors, true, 1.0f, true, 0, Rect2(), RenderingDevice.OPAQUE_PASS)
+				var draw_list = rd.draw_list_begin(framebuffers[i], RenderingDevice.DRAW_CLEAR_COLOR_ALL, clear_colors, 1.0f, 0, Rect2(), RenderingDevice.OPAQUE_PASS)
 
 				# Draw opaque.
 				rd.draw_list_bind_render_pipeline(draw_list, raster_pipeline)
@@ -291,7 +291,7 @@
 				The [param breadcrumb] parameter can be an arbitrary 32-bit integer that is useful to diagnose GPU crashes. If Godot is built in dev or debug mode; when the GPU crashes Godot will dump all shaders that were being executed at the time of the crash and the breadcrumb is useful to diagnose what passes did those shaders belong to.
 				It does not affect rendering behavior and can be set to 0. It is recommended to use [enum BreadcrumbMarker] enumerations for consistency but it's not required. It is also possible to use bitwise operations to add extra data. e.g.
 				[codeblock]
-				rd.draw_list_begin(fb[i], RenderingDevice.CLEAR_COLOR_ALL, clear_colors, true, 1.0f, true, 0, Rect2(), RenderingDevice.OPAQUE_PASS | 5)
+				rd.draw_list_begin(fb[i], RenderingDevice.DRAW_CLEAR_COLOR_ALL, clear_colors, 1.0f, 0, Rect2(), RenderingDevice.OPAQUE_PASS | 5)
 				[/codeblock]
 			</description>
 		</method>
@@ -2279,7 +2279,7 @@
 			rd = RenderingServer.get_rendering_device()
 
 			if rd.has_feature(RenderingDevice.SUPPORTS_BUFFER_DEVICE_ADDRESS):
-				storage_buffer = rd.storage_buffer_create(bytes.size(), bytes, RenderingDevice.STORAGE_BUFFER_USAGE_SHADER_DEVICE_ADDRESS)
+				storage_buffer = rd.storage_buffer_create(bytes.size(), bytes, 0, RenderingDevice.STORAGE_BUFFER_USAGE_SHADER_DEVICE_ADDRESS)
 				storage_buffer_address = rd.buffer_get_device_address(storage_buffer)
 			[/gdscript]
 			[/codeblocks]
@@ -2294,7 +2294,7 @@
 			rd = RenderingServer.get_rendering_device()
 
 			if rd.has_feature(RenderingDevice.SUPPORTS_RAYTRACING_PIPELINE):
-			    storage_buffer = rd.storage_buffer_create(bytes.size(), bytes, RenderingDevice.BUFFER_CREATION_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT)
+			    storage_buffer = rd.storage_buffer_create(bytes.size(), bytes, 0, RenderingDevice.BUFFER_CREATION_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT)
 			[/gdscript]
 			[/codeblocks]
 		</constant>


### PR DESCRIPTION
The number of arguments of the calls in these code examples doesn't match the function signatures.