### PR TITLE
Fix error when no pattern is selected in the TileMap editor

### DIFF
--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -1127,15 +1127,13 @@ HashMap<Vector2i, TileMapCell> TileMapLayerEditorTilesPlugin::_draw_rect(Vector2
 	// Get or create the pattern.
 	Ref<TileMapPattern> pattern = p_erase ? erase_pattern : selection_pattern;
 
-	ERR_FAIL_COND_V(pattern->is_empty(), (HashMap<Vector2i, TileMapCell>()));
-
-	// Compute the offset to align things to the bottom or right.
-	bool aligned_right = p_end_cell.x < p_start_cell.x;
-	bool valigned_bottom = p_end_cell.y < p_start_cell.y;
-	Vector2i offset = Vector2i(aligned_right ? -(pattern->get_size().x - (rect.get_size().x % pattern->get_size().x)) : 0, valigned_bottom ? -(pattern->get_size().y - (rect.get_size().y % pattern->get_size().y)) : 0);
-
 	HashMap<Vector2i, TileMapCell> output;
 	if (!pattern->is_empty()) {
+		// Compute the offset to align things to the bottom or right.
+		bool aligned_right = p_end_cell.x < p_start_cell.x;
+		bool valigned_bottom = p_end_cell.y < p_start_cell.y;
+		Vector2i offset = Vector2i(aligned_right ? -(pattern->get_size().x - (rect.get_size().x % pattern->get_size().x)) : 0, valigned_bottom ? -(pattern->get_size().y - (rect.get_size().y % pattern->get_size().y)) : 0);
+
 		if (!p_erase && random_tile_toggle->is_pressed()) {
 			// Paint a random tile.
 			for (int x = 0; x < rect.size.x; x++) {

--- a/modules/tilemap/editor/tile_map_layer_editor.cpp
+++ b/modules/tilemap/editor/tile_map_layer_editor.cpp
@@ -1131,15 +1131,13 @@ HashMap<Vector2i, TileMapCell> TileMapLayerEditorTilesPlugin::_draw_rect(Vector2
 	// Get or create the pattern.
 	Ref<TileMapPattern> pattern = p_erase ? erase_pattern : selection_pattern;
 
-	ERR_FAIL_COND_V(pattern->is_empty(), (HashMap<Vector2i, TileMapCell>()));
-
-	// Compute the offset to align things to the bottom or right.
-	bool aligned_right = p_end_cell.x < p_start_cell.x;
-	bool valigned_bottom = p_end_cell.y < p_start_cell.y;
-	Vector2i offset = Vector2i(aligned_right ? -(pattern->get_size().x - (rect.get_size().x % pattern->get_size().x)) : 0, valigned_bottom ? -(pattern->get_size().y - (rect.get_size().y % pattern->get_size().y)) : 0);
-
 	HashMap<Vector2i, TileMapCell> output;
 	if (!pattern->is_empty()) {
+		// Compute the offset to align things to the bottom or right.
+		bool aligned_right = p_end_cell.x < p_start_cell.x;
+		bool valigned_bottom = p_end_cell.y < p_start_cell.y;
+		Vector2i offset = Vector2i(aligned_right ? -(pattern->get_size().x - (rect.get_size().x % pattern->get_size().x)) : 0, valigned_bottom ? -(pattern->get_size().y - (rect.get_size().y % pattern->get_size().y)) : 0);
+
 		if (!p_erase && random_tile_toggle->is_pressed()) {
 			pattern_rng.set_state(rng_base_state);
 			// Paint a random tile.


### PR DESCRIPTION
- Fix error when attempting to use the rectangle tool when no pattern was selected.
- ~Fix drawing tools still using a pattern when it has been deleted.~ See below.