### PR TITLE
Change gles3 CopyEffects::set_color rect param to be a float rect.

### DIFF
--- a/drivers/gles3/effects/copy_effects.cpp
+++ b/drivers/gles3/effects/copy_effects.cpp
@@ -309,7 +309,7 @@ void CopyEffects::gaussian_blur(GLuint p_source_texture, int p_mipmap_count, con
 	glViewport(0, 0, p_size.x, p_size.y);
 }
 
-void CopyEffects::set_color(const Color &p_color, const Rect2i &p_region) {
+void CopyEffects::set_color(const Color &p_color, const Rect2 &p_region) {
 	bool success = copy.shader.version_bind_shader(copy.shader_version, CopyShaderGLES3::MODE_SIMPLE_COLOR);
 	if (!success) {
 		return;

--- a/drivers/gles3/effects/copy_effects.h
+++ b/drivers/gles3/effects/copy_effects.h
@@ -69,7 +69,7 @@ public:
 	void copy_cube_to_panorama(float p_mip_level);
 	void bilinear_blur(GLuint p_source_texture, int p_mipmap_count, const Rect2i &p_region);
 	void gaussian_blur(GLuint p_source_texture, int p_mipmap_count, const Rect2i &p_region, const Size2i &p_size);
-	void set_color(const Color &p_color, const Rect2i &p_region);
+	void set_color(const Color &p_color, const Rect2 &p_region);
 	void draw_screen_triangle();
 	void draw_screen_quad();
 };

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -3709,7 +3709,9 @@ void TextureStorage::render_target_clear_back_buffer(RID p_render_target, const 
 			return; //nothing to do
 		}
 		glBindFramebuffer(GL_FRAMEBUFFER, rt->backbuffer_fbo);
-		GLES3::CopyEffects::get_singleton()->set_color(p_color, region);
+		// set_color takes normalized rect (0..1)
+		Rect2 norm_rect = Rect2(Vector2(region.position) / Vector2(rt->size), Vector2(region.size) / Vector2(rt->size));
+		GLES3::CopyEffects::get_singleton()->set_color(p_color, norm_rect);
 	}
 }
 


### PR DESCRIPTION
Fixes #116500

Also normalize the rect the one place where it's used.

Currently `render_target_clear_back_buffer` is only ever called with an empty rect, so `else` part which contains the `set_color` is never executed.

To test add a `copy_effects->set_color(Color(1.0, 1.0, 0.0, 0.5), Rect2(Vector2(0.2, 0.2), Vector2(0.6, 0.6)));` to one of the debug drawers in `RasterizerSceneGLES3::_render_buffers_debug_draw` and then enable in the editor.
 
<img width="636" height="442" alt="image" src="https://github.com/user-attachments/assets/db077f00-e967-4288-9b20-83f9407bc6d6" />
