### PR TITLE
Fix TabContainer tab icon, disabled, and hidden not saved before ready

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -857,6 +857,9 @@ void TabContainer::set_tab_icon(int p_tab, const Ref<Texture2D> &p_icon) {
 }
 
 Ref<Texture2D> TabContainer::get_tab_icon(int p_tab) const {
+	if (!is_ready() && p_tab < pending_tabs.size()) {
+		return pending_tabs[p_tab].icon;
+	}
 	return tab_bar->get_tab_icon(p_tab);
 }
 
@@ -896,6 +899,9 @@ void TabContainer::set_tab_disabled(int p_tab, bool p_disabled) {
 }
 
 bool TabContainer::is_tab_disabled(int p_tab) const {
+	if (!is_ready() && p_tab < pending_tabs.size()) {
+		return pending_tabs[p_tab].disabled;
+	}
 	return tab_bar->is_tab_disabled(p_tab);
 }
 
@@ -922,6 +928,9 @@ void TabContainer::set_tab_hidden(int p_tab, bool p_hidden) {
 }
 
 bool TabContainer::is_tab_hidden(int p_tab) const {
+	if (!is_ready() && p_tab < pending_tabs.size()) {
+		return pending_tabs[p_tab].hidden;
+	}
 	return tab_bar->is_tab_hidden(p_tab);
 }
 


### PR DESCRIPTION
Fixes #116358

`TabContainer` stores tab properties (icon, disabled, hidden) in a temporary
buffer `pending_tabs` before the node receives `NOTIFICATION_READY`, then
flushes them into the internal `tab_bar`, the setters (`set_tab_icon`,
`set_tab_disabled`, `set_tab_hidden`) correctly wrote to `pending_tabs`, but
the getters (`get_tab_icon`, `is_tab_disabled`, `is_tab_hidden`) always read
from `tab_bar`, which is empty before ready.

since `PropertyListHelper` calls the getter during serialization and skips
saving any property that matches its default value, these properties were
never written to the scene file and lost on reload.

this PR makes the three getters check `!is_ready()` first, if the node
isn't ready and the index is within `pending_tabs` bounds, they return the
buffered value instead of reading from `tab_bar`.