### PR TITLE
Docs: Add units of time to AudioServer's documentation

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -186,13 +186,13 @@
 		<method name="get_time_since_last_mix" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the relative time since the last mix occurred.
+				Returns the relative time since the last mix occurred, in seconds.
 			</description>
 		</method>
 		<method name="get_time_to_next_mix" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the relative time until the next mix occurs.
+				Returns the relative time until the next mix occurs, in seconds.
 			</description>
 		</method>
 		<method name="is_bus_bypassing_effects" qualifiers="const">


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot-docs/issues/7009

Added the unit of time, seconds, to the functions get_time_since_last_mix() and get_time_to_next_mix() on the class AudioServer's documentation.