### PR TITLE
Implement `Signal::disconnect_all`

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1713,6 +1713,33 @@ bool Object::has_connections(const StringName &p_signal) const {
 	return !s->slot_map.is_empty();
 }
 
+void Object::disconnect_all(const StringName &p_signal) {
+	OBJ_SIGNAL_LOCK
+
+	SignalData *s = signal_map.getptr(p_signal);
+	if (!s) {
+		bool signal_is_valid = ClassDB::has_signal(get_class_name(), p_signal);
+		if (signal_is_valid) {
+			return;
+		}
+
+		if (script_instance && script_instance->get_script()->has_script_signal(p_signal)) {
+			return;
+		}
+
+		ERR_FAIL_MSG(vformat("Nonexistent signal: '%s'.", p_signal));
+	}
+
+	for (const KeyValue<Callable, SignalData::Slot> &slot_kv : s->slot_map) {
+		Object *target = slot_kv.key.get_object();
+		if (target) {
+			target->connections.erase(slot_kv.value.cE);
+		}
+	}
+
+	s->slot_map.clear();
+}
+
 void Object::disconnect(const StringName &p_signal, const Callable &p_callable) {
 	_disconnect(p_signal, p_callable);
 }

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1714,30 +1714,27 @@ bool Object::has_connections(const StringName &p_signal) const {
 }
 
 void Object::disconnect_all(const StringName &p_signal) {
+	_disconnect_all(p_signal);
+}
+
+bool Object::_disconnect_all(const StringName &p_signal, bool p_force) {
+	// use p_force like in _disconnect
 	OBJ_SIGNAL_LOCK
 
 	SignalData *s = signal_map.getptr(p_signal);
 	if (!s) {
-		bool signal_is_valid = ClassDB::has_signal(get_class_name(), p_signal);
-		if (signal_is_valid) {
-			return;
-		}
-
-		if (script_instance && script_instance->get_script()->has_script_signal(p_signal)) {
-			return;
-		}
-
-		ERR_FAIL_MSG(vformat("Nonexistent signal: '%s'.", p_signal));
+		bool signal_is_valid = ClassDB::has_signal(get_class_name(), p_signal) ||
+				(script_instance && script_instance->get_script()->has_script_signal(p_signal));
+		ERR_FAIL_COND_V_MSG(signal_is_valid, false, vformat("Attempt to disconnect all connections from nonexistent signal '%s'. Signal: '%s'.", to_string(), p_signal));
 	}
-
-	for (const KeyValue<Callable, SignalData::Slot> &slot_kv : s->slot_map) {
-		Object *target = slot_kv.key.get_object();
-		if (target) {
-			target->connections.erase(slot_kv.value.cE);
-		}
-	}
-
+	ERR_FAIL_NULL_V_MSG(s, false, vformat("Disconnecting all connections from nonexistent signal '%s' in '%s'.", p_signal, to_string()));
+	ERR_FAIL_COND_V_MSG(s->slot_map.is_empty(), false, vformat("No connections to disconnect from signal '%s' in '%s'.", p_signal, to_string()));
 	s->slot_map.clear();
+	if (ClassDB::has_signal(get_class_name(), p_signal) && s->user.name.is_empty()) {
+		//not user signal, delete
+		signal_map.erase(p_signal);
+	}
+	return true;
 }
 
 void Object::disconnect(const StringName &p_signal, const Callable &p_callable) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -794,6 +794,7 @@ protected:
 	static void _add_class_to_classdb(const GDType &p_class, const GDType *p_inherits);
 	static void _get_property_list_from_classdb(const StringName &p_class, List<PropertyInfo> *p_list, bool p_no_inheritance, const Object *p_validator);
 
+	bool _disconnect_all(const StringName &p_signal, bool p_force = false);
 	bool _disconnect(const StringName &p_signal, const Callable &p_callable, bool p_force = false);
 	void _define_ancestry(AncestralClass p_class) { _ancestry |= (uint32_t)p_class; }
 	// Prefer using derives_from.

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -987,6 +987,7 @@ public:
 	DEBUG_VIRTUAL void get_signals_connected_to_this(List<Connection> *p_connections) const;
 
 	DEBUG_VIRTUAL Error connect(const StringName &p_signal, const Callable &p_callable, uint32_t p_flags = 0);
+	DEBUG_VIRTUAL void disconnect_all(const StringName &p_signal);
 	DEBUG_VIRTUAL void disconnect(const StringName &p_signal, const Callable &p_callable);
 	DEBUG_VIRTUAL bool is_connected(const StringName &p_signal, const Callable &p_callable) const;
 	DEBUG_VIRTUAL bool has_connections(const StringName &p_signal) const;

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -549,7 +549,7 @@ Error Signal::connect(const Callable &p_callable, uint32_t p_flags) {
 void Signal::disconnect_all() {
 	Object *obj = get_object();
 	ERR_FAIL_NULL(obj);
-	obj->disconnect(name);
+	obj->disconnect_all(name);
 }
 
 void Signal::disconnect(const Callable &p_callable) {

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -546,6 +546,12 @@ Error Signal::connect(const Callable &p_callable, uint32_t p_flags) {
 	return obj->connect(name, p_callable, p_flags);
 }
 
+void Signal::disconnect_all() {
+	Object *obj = get_object();
+	ERR_FAIL_NULL(obj);
+	obj->disconnect(name);
+}
+
 void Signal::disconnect(const Callable &p_callable) {
 	Object *obj = get_object();
 	ERR_FAIL_NULL(obj);

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -195,6 +195,7 @@ public:
 
 	Error emit(const Variant **p_arguments, int p_argcount) const;
 	Error connect(const Callable &p_callable, uint32_t p_flags = 0);
+	void disconnect_all();
 	void disconnect(const Callable &p_callable);
 	bool is_connected(const Callable &p_callable) const;
 	bool has_connections() const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2499,6 +2499,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Signal, get_name, sarray(), varray());
 
 	bind_method(Signal, connect, sarray("callable", "flags"), varray(0));
+	bind_method(Signal, disconnect_all, sarray(), varray());
 	bind_method(Signal, disconnect, sarray("callable"), varray());
 	bind_method(Signal, is_connected, sarray("callable"), varray());
 	bind_method(Signal, get_connections, sarray(), varray());

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -534,6 +534,13 @@
 				[b]Note:[/b] This method, and all other signal-related methods, are thread-safe.
 			</description>
 		</method>
+		<method name="disconnect_all">
+			<return type="void" />
+			<param index="0" name="signal" type="StringName" />
+			<description>
+				Disconnects all emitters from a given [param signal]. If any connection does not exist, generates an error. Use [method is_connected] to make sure that any connection exists.
+			</description>
+		</method>
 		<method name="disconnect">
 			<return type="void" />
 			<param index="0" name="signal" type="StringName" />

--- a/doc/classes/Signal.xml
+++ b/doc/classes/Signal.xml
@@ -193,6 +193,12 @@
 				[b]Note:[/b] If the [param callable]'s object is freed, the connection will be lost.
 			</description>
 		</method>
+		<method name="disconnect_all">
+			<return type="void" />
+			<description>
+				Disconnects all emitters from this signal. If no connection exists, generates an error. Use [method is_connected] to make sure that any connection exists.
+			</description>
+		</method>
 		<method name="disconnect">
 			<return type="void" />
 			<param index="0" name="callable" type="Callable" />

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -4214,7 +4214,7 @@ void Node::disconnect_all(const StringName &p_signal) {
 	List<Connection> _connections;
 	Object::get_signal_connection_list(p_signal, &_connections);
 #endif
-	[[maybe_unused]] bool changed = Object::disconnect_all(p_signal);
+	[[maybe_unused]] bool changed = Object::_disconnect_all(p_signal);
 
 #ifdef TOOLS_ENABLED
 	if (changed) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -4206,6 +4206,23 @@ Error Node::connect(const StringName &p_signal, const Callable &p_callable, uint
 	return retval;
 }
 
+void Node::disconnect_all(const StringName &p_signal) {
+	ERR_THREAD_GUARD;
+
+#ifdef TOOLS_ENABLED
+	// Already under thread guard, don't check again.
+	List<Connection> connections;
+	Object::get_signal_connection_list(p_signal, &connections);
+#endif
+	[[maybe_unused]] bool changed = Object::disconnect_all(p_signal);
+
+#ifdef TOOLS_ENABLED
+	if (changed) {
+		_emit_editor_state_changed();
+	}
+#endif
+}
+
 void Node::disconnect(const StringName &p_signal, const Callable &p_callable) {
 	ERR_THREAD_GUARD;
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -4211,8 +4211,8 @@ void Node::disconnect_all(const StringName &p_signal) {
 
 #ifdef TOOLS_ENABLED
 	// Already under thread guard, don't check again.
-	List<Connection> connections;
-	Object::get_signal_connection_list(p_signal, &connections);
+	List<Connection> _connections;
+	Object::get_signal_connection_list(p_signal, &_connections);
 #endif
 	[[maybe_unused]] bool changed = Object::disconnect_all(p_signal);
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -880,6 +880,7 @@ public:
 	virtual void get_signals_connected_to_this(List<Connection> *p_connections) const override;
 
 	virtual Error connect(const StringName &p_signal, const Callable &p_callable, uint32_t p_flags = 0) override;
+	virtual void disconnect_all(const StringName &p_signal) override;
 	virtual void disconnect(const StringName &p_signal, const Callable &p_callable) override;
 	virtual bool is_connected(const StringName &p_signal, const Callable &p_callable) const override;
 	virtual bool has_connections(const StringName &p_signal) const override;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

This PR was inspired by #87344. Also, I checked the [Engine development](https://docs.godotengine.org/en/latest/engine_details/development/index.html) and [Editor development](https://docs.godotengine.org/en/latest/engine_details/editor/index.html).

Added to `Object` and `Signal`. Just like in #87344, there is no unit testing, but I wrote a sample project in debug build and exported it as ZIP. After adding two callables to `$Button`'s `pressed` signal, GDScript shows the count of connections before and after `disconnect_all`.

[test-project_2026-02-20_00-06-54.zip](https://github.com/user-attachments/files/25427375/test-project_2026-02-20_00-06-54.zip)

Some notes:

a. I, myself, am not a C++ dev. I have a decent Rust experience. So, during your reviews, if you want further changes, I might want you to be a little more verbose.
b. As I said, the PR was inspired by #87344. The same files in that PR were changed.
c. I want to be honest. Considering (a), `Object::_disconnect_all` in `core/object/object.cpp` was generated by AI. Some parts of it, I have a vague idea what it's doing (e.g. I can understand what `ClassDB::has_signal` does) but has no idea about some other parts (e.g. I don't know what `s->slot_map.clear()` does). So, test project I have given works, but I can't guarantee regression (which there must not be, because all I did was addition, not changes to the existing logic, but who knows).

Closes: https://github.com/godotengine/godot-proposals/issues/12831