### PR TITLE
Add soft Gaussian-blurred shadows to StyleBoxFlat

### DIFF
--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -159,6 +159,15 @@
 			Expands the stylebox outside of the control rect on the top edge. Useful in combination with [member border_width_top] to draw a border outside the control rect.
 			[b]Note:[/b] Unlike [member StyleBox.content_margin_top], [member expand_margin_top] does [i]not[/i] affect the size of the clickable area for [Control]s. This can negatively impact usability if used wrong, as the user may try to click an area of the StyleBox that cannot actually receive clicks.
 		</member>
+		<member name="gaussian_approximate_gaussian" type="bool" setter="set_approximate_gaussian" getter="is_using_approximate_gaussian" default="false">
+			Toggle to switch to a shadow that approximates a softer Gaussian falloff by combining multiple linear shadows. Tends to take more processing power.
+		</member>
+		<member name="gaussian_quality" type="int" setter="set_gaussian_rings" getter="get_gaussian_rings" default="6">
+			The amount of concentric shadows used to approximate a Gaussian falloff. More shadows tend to look better but take more processing power.
+		</member>
+		<member name="gaussian_spread" type="float" setter="set_gaussian_spread" getter="get_gaussian_spread" default="0.0">
+			Grows or shrinks the whole shadow (in pixels) while keeping the falloff the same.
+		</member>
 		<member name="shadow_color" type="Color" setter="set_shadow_color" getter="get_shadow_color" default="Color(0, 0, 0, 0.6)">
 			The color of the shadow. This has no effect if [member shadow_size] is lower than 1.
 		</member>

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -138,6 +138,37 @@ int StyleBoxFlat::get_corner_detail() const {
 	return corner_detail;
 }
 
+void StyleBoxFlat::set_approximate_gaussian(bool p_approximate_gaussian) {
+	if (approximate_gaussian == p_approximate_gaussian) {
+		return;
+	}
+	approximate_gaussian = p_approximate_gaussian;
+	emit_changed();
+	notify_property_list_changed();
+}
+
+bool StyleBoxFlat::is_using_approximate_gaussian() const {
+	return approximate_gaussian;
+}
+
+void StyleBoxFlat::set_gaussian_rings(int p_gaussian_rings) {
+	gaussian_rings = CLAMP(p_gaussian_rings, 1, 30);
+	emit_changed();
+}
+
+int StyleBoxFlat::get_gaussian_rings() const {
+	return gaussian_rings;
+}
+
+void StyleBoxFlat::set_gaussian_spread(real_t p_gaussian_spread) {
+	gaussian_spread = p_gaussian_spread;
+	emit_changed();
+}
+
+real_t StyleBoxFlat::get_gaussian_spread() const {
+	return gaussian_spread;
+}
+
 void StyleBoxFlat::set_expand_margin(Side p_side, float p_size) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 	expand_margin[p_side] = p_size;
@@ -456,6 +487,17 @@ Rect2 StyleBoxFlat::get_draw_rect(const Rect2 &p_rect) const {
 	return draw_rect;
 }
 
+real_t shadow_erf_approx(float x, int shadow_size) {
+	x = x / ((shadow_size / 2.6) * 1.41421f);
+	x = 1 + 0.278393 * x + 0.230389 * x * x + 0.000972 * x * x * x + 0.078108 * x * x * x * x;
+	return 1.0 / (x * x * x * x);
+}
+
+real_t shadow_dist_at(int ring_index, int ring_count, int shadow_size) {
+	float t = float(ring_index) / float(ring_count);
+	return shadow_size * Math::pow(t, 0.9f);
+}
+
 void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	bool draw_border = (border_width[0] > 0) || (border_width[1] > 0) || (border_width[2] > 0) || (border_width[3] > 0);
 	bool draw_shadow = (shadow_size > 0);
@@ -493,6 +535,18 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	adapt_values(CORNER_TOP_LEFT, CORNER_TOP_RIGHT, adapted_corner, corner_radius, width, width - adapted_border[SIDE_RIGHT], width - adapted_border[SIDE_LEFT]);
 	adapt_values(CORNER_BOTTOM_LEFT, CORNER_BOTTOM_RIGHT, adapted_corner, corner_radius, width, width - adapted_border[SIDE_RIGHT], width - adapted_border[SIDE_LEFT]);
 
+	// Adapt shadow corners (prevent weird overlapping/glitchy drawings).
+	real_t shadow_corner[4] = { 1000000.0, 1000000.0, 1000000.0, 1000000.0 };
+	real_t shadow_corner_radius_arr[4];
+	const real_t center_shadow_radius = MAX(MIN(style_rect.size.height, style_rect.size.width) - shadow_size / 2.0 + gaussian_spread * 2.0, 2.0);
+	for (int i = 0; i < 4; i++) {
+		shadow_corner_radius_arr[i] = MIN(MAX(MAX(1.0, shadow_size / 2.8), adapted_corner[i]), center_shadow_radius / 2.0);
+	}
+	adapt_values(CORNER_TOP_RIGHT, CORNER_BOTTOM_RIGHT, shadow_corner, shadow_corner_radius_arr, height, height - adapted_border[SIDE_BOTTOM], height - adapted_border[SIDE_TOP]);
+	adapt_values(CORNER_TOP_LEFT, CORNER_BOTTOM_LEFT, shadow_corner, shadow_corner_radius_arr, height, height - adapted_border[SIDE_BOTTOM], height - adapted_border[SIDE_TOP]);
+	adapt_values(CORNER_TOP_LEFT, CORNER_TOP_RIGHT, shadow_corner, shadow_corner_radius_arr, width, width - adapted_border[SIDE_RIGHT], width - adapted_border[SIDE_LEFT]);
+	adapt_values(CORNER_BOTTOM_LEFT, CORNER_BOTTOM_RIGHT, shadow_corner, shadow_corner_radius_arr, width, width - adapted_border[SIDE_RIGHT], width - adapted_border[SIDE_LEFT]);
+
 	Rect2 infill_rect = style_rect.grow_individual(-adapted_border[SIDE_LEFT], -adapted_border[SIDE_TOP], -adapted_border[SIDE_RIGHT], -adapted_border[SIDE_BOTTOM]);
 
 	Rect2 border_style_rect = style_rect;
@@ -529,16 +583,46 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 		Rect2 shadow_inner_rect = style_rect;
 		shadow_inner_rect.position += shadow_offset;
 
-		Rect2 shadow_rect = style_rect.grow(shadow_size);
-		shadow_rect.position += shadow_offset;
+		if (approximate_gaussian) {
+			real_t smallest_dim = MIN(style_rect.size.height, style_rect.size.width);
+			// Shrink inner rect so the shadow doesn't start at the edge of the shape.
+			real_t start_shadow_size = -shadow_size / 4.0 + gaussian_spread;
+			if (start_shadow_size * 2.0 + smallest_dim <= 2.0) {
+				start_shadow_size = (-smallest_dim / 2.0) + 1;
+			}
+			shadow_inner_rect = shadow_inner_rect.grow(start_shadow_size);
 
-		Color shadow_color_transparent = Color(shadow_color.r, shadow_color.g, shadow_color.b, 0);
+			// If there are more rings than the size of the shadow in pixels, we get weird artifacts.
+			int real_gaussian_rings = MAX(shadow_size / 2 > gaussian_rings ? gaussian_rings : shadow_size / 2, 1);
 
-		draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, adapted_corner,
-				shadow_rect, shadow_inner_rect, shadow_color, shadow_color_transparent, corner_detail, skew);
+			for (int r = 0; r < real_gaussian_rings; r++) {
+				// Avoid hard shadow edges by making the rings increasingly thin.
+				real_t inner_dist = shadow_dist_at(r, real_gaussian_rings, shadow_size);
+				real_t outer_dist = shadow_dist_at(r + 1, real_gaussian_rings, shadow_size);
+				Color inner_col = shadow_color;
+				Color outer_col = shadow_color;
+				// Error function approximation (by A&S), gives a Gaussian-like transition.
+				inner_col.a *= shadow_erf_approx(inner_dist, shadow_size);
+				outer_col.a *= shadow_erf_approx(outer_dist, shadow_size);
 
-		if (draw_center) {
+				Rect2 inner = style_rect.grow(start_shadow_size + inner_dist);
+				inner.position += shadow_offset;
+				Rect2 outer = style_rect.grow(start_shadow_size + outer_dist);
+				outer.position += shadow_offset;
+				draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, shadow_corner,
+						outer, inner, inner_col, outer_col, corner_detail, skew);
+			}
+		} else {
+			Rect2 shadow_rect = style_rect.grow(shadow_size);
+			shadow_rect.position += shadow_offset;
+
+			Color shadow_color_transparent = Color(shadow_color.r, shadow_color.g, shadow_color.b, 0);
+
 			draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, adapted_corner,
+					shadow_rect, shadow_inner_rect, shadow_color, shadow_color_transparent, corner_detail, skew);
+		}
+		if (draw_center) {
+			draw_rounded_rectangle(verts, indices, colors, shadow_inner_rect, approximate_gaussian ? shadow_corner : adapted_corner,
 					shadow_inner_rect, shadow_inner_rect, shadow_color, shadow_color, corner_detail, skew, true);
 		}
 	}
@@ -695,6 +779,15 @@ void StyleBoxFlat::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_corner_detail", "detail"), &StyleBoxFlat::set_corner_detail);
 	ClassDB::bind_method(D_METHOD("get_corner_detail"), &StyleBoxFlat::get_corner_detail);
 
+	ClassDB::bind_method(D_METHOD("set_gaussian_rings", "rings"), &StyleBoxFlat::set_gaussian_rings);
+	ClassDB::bind_method(D_METHOD("get_gaussian_rings"), &StyleBoxFlat::get_gaussian_rings);
+
+	ClassDB::bind_method(D_METHOD("set_approximate_gaussian", "approximate_gaussian"), &StyleBoxFlat::set_approximate_gaussian);
+	ClassDB::bind_method(D_METHOD("is_using_approximate_gaussian"), &StyleBoxFlat::is_using_approximate_gaussian);
+
+	ClassDB::bind_method(D_METHOD("set_gaussian_spread", "spread"), &StyleBoxFlat::set_gaussian_spread);
+	ClassDB::bind_method(D_METHOD("get_gaussian_spread"), &StyleBoxFlat::get_gaussian_spread);
+
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "bg_color"), "set_bg_color", "get_bg_color");
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_center"), "set_draw_center", "is_draw_center_enabled");
@@ -729,6 +822,10 @@ void StyleBoxFlat::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "shadow_color"), "set_shadow_color", "get_shadow_color");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "shadow_size", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_shadow_size", "get_shadow_size");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "shadow_offset", PROPERTY_HINT_NONE, "suffix:px"), "set_shadow_offset", "get_shadow_offset");
+	ADD_SUBGROUP("Gaussian", "gaussian_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gaussian_approximate_gaussian", PROPERTY_HINT_GROUP_ENABLE), "set_approximate_gaussian", "is_using_approximate_gaussian");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "gaussian_quality", PROPERTY_HINT_RANGE, "1,16,1"), "set_gaussian_rings", "get_gaussian_rings");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "gaussian_spread", PROPERTY_HINT_RANGE, "-100,100,0.1,or_greater,suffix:px"), "set_gaussian_spread", "get_gaussian_spread");
 
 	ADD_GROUP("Anti Aliasing", "anti_aliasing_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "anti_aliasing"), "set_anti_aliased", "is_anti_aliased");

--- a/scene/resources/style_box_flat.h
+++ b/scene/resources/style_box_flat.h
@@ -50,6 +50,9 @@ class StyleBoxFlat : public StyleBox {
 
 	int corner_detail = 8;
 	int shadow_size = 0;
+	bool approximate_gaussian = false;
+	int gaussian_rings = 6;
+	real_t gaussian_spread = 0;
 	Point2 shadow_offset;
 	real_t aa_size = 1;
 
@@ -81,6 +84,15 @@ public:
 
 	void set_corner_detail(const int &p_corner_detail);
 	int get_corner_detail() const;
+
+	void set_approximate_gaussian(bool p_approximate_gaussian);
+	bool is_using_approximate_gaussian() const;
+
+	void set_gaussian_rings(int p_gaussian_rings);
+	int get_gaussian_rings() const;
+
+	void set_gaussian_spread(real_t p_gaussian_spread);
+	real_t get_gaussian_spread() const;
 
 	void set_expand_margin(Side p_expand_side, float p_size);
 	void set_expand_margin_all(float p_expand_margin_size);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13755

<img width="1554" height="869" alt="Screenshot 2026-02-19 201106" src="https://github.com/user-attachments/assets/91b366d7-83bf-49b9-ad0e-6b1b483cbc5c" />

This emulates a "real" Gaussian falloff by combining multiple "rings" of shadow with linear falloff (the image below shows the rings, in the final implementation the rings actually get thinner towards the shadow edge, to get a softer falloff).
<img width="374" height="334" alt="image" src="https://github.com/user-attachments/assets/a6e4f57f-ce43-4a3d-a91b-37a094f4b3b7" />

This adds a new toggle menu under "Shadow" where the user can pick the amount of shadow rings (it usually needs around 6 to look good) and the shadow spread.
<img width="433" height="206" alt="image" src="https://github.com/user-attachments/assets/129a25e6-d438-4293-b779-b47f9ebde994" />

I've done some really basic benchmarking: in a scene with hundreds of constantly rescaling Panels, if I want to stay at 60fps I can either have ~400 regular shadow styleboxes, or ~200 gaussian shadow styleboxes (each with 8 rings). The performance-hit seems to almost entirely be caused by the additional draw commands, so I'm not sure if there's an easy way to make this much faster.

Thx to @sockeye-d for feedback, fine-tuning of the shadow shape, and implementation of the error-function!