### PR TITLE
Fix scroll bar unable to use full area with custom stylebox types

### DIFF
--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -492,7 +492,7 @@ double ScrollBar::get_area_size() const {
 	switch (orientation) {
 		case VERTICAL: {
 			double area = get_size().height;
-			area -= theme_cache.scroll_style->get_minimum_size().height;
+			area -= theme_cache.scroll_style->get_margin(Side::SIDE_TOP) + theme_cache.scroll_style->get_margin(Side::SIDE_BOTTOM);
 			area -= theme_cache.increment_icon->get_height();
 			area -= theme_cache.decrement_icon->get_height();
 			area -= get_grabber_min_size();
@@ -500,7 +500,7 @@ double ScrollBar::get_area_size() const {
 		} break;
 		case HORIZONTAL: {
 			double area = get_size().width;
-			area -= theme_cache.scroll_style->get_minimum_size().width;
+			area -= theme_cache.scroll_style->get_margin(Side::SIDE_LEFT) + theme_cache.scroll_style->get_margin(Side::SIDE_RIGHT);
 			area -= theme_cache.increment_icon->get_width();
 			area -= theme_cache.decrement_icon->get_width();
 			area -= get_grabber_min_size();


### PR DESCRIPTION
Fixes #116508 

Simply changes scrollbar's area size along the orientation to be based on the `StyleBox` margins instead of min size. This allows grabber size/positioning to be controlled by the properties in the Content Margins group which is independent from min size for custom `StyleBox` types.

The `StyleBox` types in the engine in will behave the same since their min sizes are the margins.
https://github.com/godotengine/godot/blob/897172fa25699455f0a537f054654068b3dda5d5/scene/resources/style_box.cpp#L35-L48

From what I could tell, the intention was that the scroll bar area was constrained by the margins since these lines had been this way since the first commit and, at that point, min size was always based on margins. However, min size was made independent for custom types as of #71686 , so this change should get it closer to how it worked before.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
