### PR TITLE
Manual physics iteration extended

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -430,6 +430,17 @@ bool Engine::is_embedded_in_editor() const {
 	return embedded_in_editor;
 }
 
+void Engine::set_physics_iteration_callback(PhysicsIterationCallback p_callback) {
+	physics_iteration_callback = p_callback;
+}
+
+bool Engine::physics_iteration(double p_delta) {
+	if (physics_iteration_callback) {
+		return physics_iteration_callback(p_delta);
+	}
+	return false;
+}
+
 Engine::Engine() {
 	singleton = this;
 }

--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -434,9 +434,9 @@ void Engine::set_physics_iteration_callback(PhysicsIterationCallback p_callback)
 	physics_iteration_callback = p_callback;
 }
 
-bool Engine::physics_iteration(double p_delta, bool p_increment_frames) {
+bool Engine::physics_iteration(double p_delta, bool p_increment_frames, FlushQueriesOrder p_flush_queries_order) {
 	if (physics_iteration_callback) {
-		return physics_iteration_callback(p_delta, p_increment_frames);
+		return physics_iteration_callback(p_delta, p_increment_frames, p_flush_queries_order);
 	}
 	return false;
 }

--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -434,9 +434,9 @@ void Engine::set_physics_iteration_callback(PhysicsIterationCallback p_callback)
 	physics_iteration_callback = p_callback;
 }
 
-bool Engine::physics_iteration(double p_delta) {
+bool Engine::physics_iteration(double p_delta, bool p_increment_frames) {
 	if (physics_iteration_callback) {
-		return physics_iteration_callback(p_delta);
+		return physics_iteration_callback(p_delta, p_increment_frames);
 	}
 	return false;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -44,6 +44,7 @@ class Engine {
 	// Called by main loop when built-in stepping is disabled. Set from main.cpp.
 	using PhysicsIterationCallback = bool (*)(double);
 	PhysicsIterationCallback physics_iteration_callback = nullptr;
+
 public:
 	struct Singleton {
 		StringName name;

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -41,8 +41,16 @@ template <typename T>
 class TypedArray;
 
 class Engine {
+public:
+	enum FlushQueriesOrder {
+		FLUSH_QUERIES_BEFORE_STEP,
+		FLUSH_QUERIES_AFTER_STEP,
+		FLUSH_QUERIES_NEVER
+	};
+
+private:
 	// Called by main loop when built-in stepping is disabled. Set from main.cpp.
-	using PhysicsIterationCallback = bool (*)(double, bool);
+	using PhysicsIterationCallback = bool (*)(double, bool, FlushQueriesOrder);
 	PhysicsIterationCallback physics_iteration_callback = nullptr;
 
 public:
@@ -231,7 +239,7 @@ public:
 	// Manual physics stepping: call once per physics step when built-in stepping is disabled.
 	// Returns true if the main loop should exit (e.g. scene tree requested quit).
 	void set_physics_iteration_callback(PhysicsIterationCallback p_callback);
-	bool physics_iteration(double p_delta, bool p_increment_frames = true);
+	bool physics_iteration(double p_delta, bool p_increment_frames = true, FlushQueriesOrder p_flush_queries_order = FLUSH_QUERIES_BEFORE_STEP);
 
 	Engine();
 	virtual ~Engine();

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -41,6 +41,9 @@ template <typename T>
 class TypedArray;
 
 class Engine {
+	// Called by main loop when built-in stepping is disabled. Set from main.cpp.
+	using PhysicsIterationCallback = bool (*)(double);
+	PhysicsIterationCallback physics_iteration_callback = nullptr;
 public:
 	struct Singleton {
 		StringName name;
@@ -223,6 +226,11 @@ public:
 	void set_freeze_time_scale(bool p_frozen);
 	void set_embedded_in_editor(bool p_enabled);
 	bool is_embedded_in_editor() const;
+
+	// Manual physics stepping: call once per physics step when built-in stepping is disabled.
+	// Returns true if the main loop should exit (e.g. scene tree requested quit).
+	void set_physics_iteration_callback(PhysicsIterationCallback p_callback);
+	bool physics_iteration(double p_delta);
 
 	Engine();
 	virtual ~Engine();

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -42,7 +42,7 @@ class TypedArray;
 
 class Engine {
 	// Called by main loop when built-in stepping is disabled. Set from main.cpp.
-	using PhysicsIterationCallback = bool (*)(double);
+	using PhysicsIterationCallback = bool (*)(double, bool);
 	PhysicsIterationCallback physics_iteration_callback = nullptr;
 
 public:
@@ -231,7 +231,7 @@ public:
 	// Manual physics stepping: call once per physics step when built-in stepping is disabled.
 	// Returns true if the main loop should exit (e.g. scene tree requested quit).
 	void set_physics_iteration_callback(PhysicsIterationCallback p_callback);
-	bool physics_iteration(double p_delta);
+	bool physics_iteration(double p_delta, bool p_increment_frames = true);
 
 	Engine();
 	virtual ~Engine();

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2050,8 +2050,8 @@ bool Engine::is_embedded_in_editor() const {
 	return ::Engine::get_singleton()->is_embedded_in_editor();
 }
 
-bool Engine::physics_iteration(double p_delta) {
-	return ::Engine::get_singleton()->physics_iteration(p_delta);
+bool Engine::physics_iteration(double p_delta, bool p_increment_frames) {
+	return ::Engine::get_singleton()->physics_iteration(p_delta, p_increment_frames);
 }
 
 String Engine::get_write_movie_path() const {
@@ -2134,7 +2134,7 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_editor_hint"), &Engine::is_editor_hint);
 	ClassDB::bind_method(D_METHOD("is_embedded_in_editor"), &Engine::is_embedded_in_editor);
 
-	ClassDB::bind_method(D_METHOD("physics_iteration", "delta"), &Engine::physics_iteration);
+	ClassDB::bind_method(D_METHOD("physics_iteration", "delta", "increment_frames"), &Engine::physics_iteration, DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("get_write_movie_path"), &Engine::get_write_movie_path);
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2050,6 +2050,10 @@ bool Engine::is_embedded_in_editor() const {
 	return ::Engine::get_singleton()->is_embedded_in_editor();
 }
 
+bool Engine::physics_iteration(double p_delta) {
+	return ::Engine::get_singleton()->physics_iteration(p_delta);
+}
+
 String Engine::get_write_movie_path() const {
 	return ::Engine::get_singleton()->get_write_movie_path();
 }
@@ -2129,6 +2133,8 @@ void Engine::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_editor_hint"), &Engine::is_editor_hint);
 	ClassDB::bind_method(D_METHOD("is_embedded_in_editor"), &Engine::is_embedded_in_editor);
+
+	ClassDB::bind_method(D_METHOD("physics_iteration", "delta"), &Engine::physics_iteration);
 
 	ClassDB::bind_method(D_METHOD("get_write_movie_path"), &Engine::get_write_movie_path);
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2050,8 +2050,8 @@ bool Engine::is_embedded_in_editor() const {
 	return ::Engine::get_singleton()->is_embedded_in_editor();
 }
 
-bool Engine::physics_iteration(double p_delta, bool p_increment_frames) {
-	return ::Engine::get_singleton()->physics_iteration(p_delta, p_increment_frames);
+bool Engine::physics_iteration(double p_delta, bool p_increment_frames, FlushQueriesOrder p_flush_queries_order) {
+	return ::Engine::get_singleton()->physics_iteration(p_delta, p_increment_frames, (::Engine::FlushQueriesOrder)p_flush_queries_order);
 }
 
 String Engine::get_write_movie_path() const {
@@ -2134,7 +2134,11 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_editor_hint"), &Engine::is_editor_hint);
 	ClassDB::bind_method(D_METHOD("is_embedded_in_editor"), &Engine::is_embedded_in_editor);
 
-	ClassDB::bind_method(D_METHOD("physics_iteration", "delta", "increment_frames"), &Engine::physics_iteration, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("physics_iteration", "delta", "increment_frames", "flush_queries_order"), &Engine::physics_iteration, DEFVAL(true), DEFVAL(Engine::FLUSH_QUERIES_BEFORE_STEP));
+
+	BIND_ENUM_CONSTANT(FLUSH_QUERIES_BEFORE_STEP);
+	BIND_ENUM_CONSTANT(FLUSH_QUERIES_AFTER_STEP);
+	BIND_ENUM_CONSTANT(FLUSH_QUERIES_NEVER);
 
 	ClassDB::bind_method(D_METHOD("get_write_movie_path"), &Engine::get_write_movie_path);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -624,6 +624,9 @@ public:
 
 	bool is_embedded_in_editor() const;
 
+	// Run one physics step (sync, physics_process, navigation, step). Use when built-in physics stepping is disabled.
+	bool physics_iteration(double p_delta);
+
 	// `set_write_movie_path()` is not exposed to the scripting API as changing it at run-time has no effect.
 	String get_write_movie_path() const;
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -624,7 +624,6 @@ public:
 
 	bool is_embedded_in_editor() const;
 
-	// Run one physics step (sync, physics_process, navigation, step). Use when built-in physics stepping is disabled.
 	bool physics_iteration(double p_delta);
 
 	// `set_write_movie_path()` is not exposed to the scripting API as changing it at run-time has no effect.

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -624,7 +624,7 @@ public:
 
 	bool is_embedded_in_editor() const;
 
-	bool physics_iteration(double p_delta);
+	bool physics_iteration(double p_delta, bool p_increment_frames = true);
 
 	// `set_write_movie_path()` is not exposed to the scripting API as changing it at run-time has no effect.
 	String get_write_movie_path() const;

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -624,7 +624,13 @@ public:
 
 	bool is_embedded_in_editor() const;
 
-	bool physics_iteration(double p_delta, bool p_increment_frames = true);
+	enum FlushQueriesOrder {
+		FLUSH_QUERIES_BEFORE_STEP,
+		FLUSH_QUERIES_AFTER_STEP,
+		FLUSH_QUERIES_NEVER
+	};
+
+	bool physics_iteration(double p_delta, bool p_increment_frames = true, FlushQueriesOrder p_flush_queries_order = FLUSH_QUERIES_BEFORE_STEP);
 
 	// `set_write_movie_path()` is not exposed to the scripting API as changing it at run-time has no effect.
 	String get_write_movie_path() const;
@@ -709,5 +715,7 @@ VARIANT_ENUM_CAST(CoreBind::Geometry2D::PolyJoinType);
 VARIANT_ENUM_CAST(CoreBind::Geometry2D::PolyEndType);
 
 VARIANT_ENUM_CAST(CoreBind::Thread::Priority);
+
+VARIANT_ENUM_CAST(CoreBind::Engine::FlushQueriesOrder);
 
 VARIANT_ENUM_CAST(CoreBind::Special::ClassDB::APIType);

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -278,10 +278,12 @@
 			<return type="bool" />
 			<param index="0" name="delta" type="float" />
 			<param index="1" name="increment_frames" type="bool" default="true" />
+			<param index="2" name="flush_queries_order" type="int" enum="Engine.FlushQueriesOrder" default="0" />
 			<description>
 				Runs one physics step: synchronizes the physics servers, calls [method Node._physics_process] on the scene tree, runs navigation and physics stepping, then flushes the message queue. Use this when [member ProjectSettings.physics/common/use_builtin_physics_stepping] is [code]false[/code] to drive physics manually (e.g. for rollback netcode or custom tick rates).
 				[param delta] should typically be the fixed physics step in seconds, e.g. [code]1.0 / Engine.physics_ticks_per_second[/code].
 				If [param increment_frames] is [code]true[/code], [method get_physics_frames] is incremented for this step (default). Set to [code]false[/code] when re-running physics for the same logical frame (e.g. rollback re-simulation) so that input and frame-dependent logic stay consistent.
+				[param flush_queries_order] controls when area/body monitor callbacks (e.g. [signal Area2D.body_entered]) are delivered: [constant FLUSH_QUERIES_BEFORE_STEP] (default) flushes after sync and before [method Node._physics_process] and step; [constant FLUSH_QUERIES_AFTER_STEP] flushes after the physics step and before end_sync; [constant FLUSH_QUERIES_NEVER] skips flushing.
 				Returns [code]true[/code] if the main loop should exit (e.g. the scene tree requested quit during [method Node._physics_process]); otherwise returns [code]false[/code].
 				[b]Note:[/b] When built-in physics stepping is disabled, you must call this method yourself each time you want to advance the physics simulation. Calling it from [method Node._process] is a common approach.
 			</description>
@@ -365,4 +367,15 @@
 			[b]Note:[/b] This does not automatically adjust [member physics_ticks_per_second]. With values above [code]1.0[/code] physics simulation may become less precise, as each physics tick will stretch over a larger period of engine time. If you're modifying [member Engine.time_scale] to speed up simulation by a large factor, consider also increasing [member physics_ticks_per_second] to make the simulation more reliable.
 		</member>
 	</members>
+	<constants>
+		<constant name="FLUSH_QUERIES_BEFORE_STEP" value="0" enum="FlushQueriesOrder">
+			Flush area/body monitor queries after sync and before [method Node._physics_process] and the physics step (default).
+		</constant>
+		<constant name="FLUSH_QUERIES_AFTER_STEP" value="1" enum="FlushQueriesOrder">
+			Flush area/body monitor queries after the physics step and before end_sync.
+		</constant>
+		<constant name="FLUSH_QUERIES_NEVER" value="2" enum="FlushQueriesOrder">
+			Do not flush area/body monitor queries during this physics iteration.
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -113,16 +113,6 @@
 				Returns the fraction through the current physics tick we are at the time of rendering the frame. This can be used to implement fixed timestep interpolation.
 			</description>
 		</method>
-		<method name="physics_iteration">
-			<return type="bool" />
-			<param index="0" name="delta" type="float" />
-			<description>
-				Runs one physics step: synchronizes the physics servers, calls [method Node._physics_process] on the scene tree, runs navigation and physics stepping, then flushes the message queue. Use this when [member ProjectSettings.physics/common/use_builtin_physics_stepping] is [code]false[/code] to drive physics manually (e.g. for rollback netcode or custom tick rates).
-				[param delta] should typically be the fixed physics step in seconds, e.g. [code]1.0 / Engine.physics_ticks_per_second[/code].
-				Returns [code]true[/code] if the main loop should exit (e.g. the scene tree requested quit during [method Node._physics_process]); otherwise returns [code]false[/code].
-				[b]Note:[/b] When built-in physics stepping is disabled, you must call this method yourself each time you want to advance the physics simulation. Calling it from [method Node._process] is a common approach.
-			</description>
-		</method>
 		<method name="get_process_frames" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -282,6 +272,16 @@
 				func _physics_process(delta):
 					print(Engine.is_in_physics_frame()) # Prints true
 				[/codeblock]
+			</description>
+		</method>
+		<method name="physics_iteration">
+			<return type="bool" />
+			<param index="0" name="delta" type="float" />
+			<description>
+				Runs one physics step: synchronizes the physics servers, calls [method Node._physics_process] on the scene tree, runs navigation and physics stepping, then flushes the message queue. Use this when [member ProjectSettings.physics/common/use_builtin_physics_stepping] is [code]false[/code] to drive physics manually (e.g. for rollback netcode or custom tick rates).
+				[param delta] should typically be the fixed physics step in seconds, e.g. [code]1.0 / Engine.physics_ticks_per_second[/code].
+				Returns [code]true[/code] if the main loop should exit (e.g. the scene tree requested quit during [method Node._physics_process]); otherwise returns [code]false[/code].
+				[b]Note:[/b] When built-in physics stepping is disabled, you must call this method yourself each time you want to advance the physics simulation. Calling it from [method Node._process] is a common approach.
 			</description>
 		</method>
 		<method name="register_script_language">

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -113,6 +113,16 @@
 				Returns the fraction through the current physics tick we are at the time of rendering the frame. This can be used to implement fixed timestep interpolation.
 			</description>
 		</method>
+		<method name="physics_iteration">
+			<return type="bool" />
+			<param index="0" name="delta" type="float" />
+			<description>
+				Runs one physics step: synchronizes the physics servers, calls [method Node._physics_process] on the scene tree, runs navigation and physics stepping, then flushes the message queue. Use this when [member ProjectSettings.physics/common/use_builtin_physics_stepping] is [code]false[/code] to drive physics manually (e.g. for rollback netcode or custom tick rates).
+				[param delta] should typically be the fixed physics step in seconds, e.g. [code]1.0 / Engine.physics_ticks_per_second[/code].
+				Returns [code]true[/code] if the main loop should exit (e.g. the scene tree requested quit during [method Node._physics_process]); otherwise returns [code]false[/code].
+				[b]Note:[/b] When built-in physics stepping is disabled, you must call this method yourself each time you want to advance the physics simulation. Calling it from [method Node._process] is a common approach.
+			</description>
+		</method>
 		<method name="get_process_frames" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -277,9 +277,11 @@
 		<method name="physics_iteration">
 			<return type="bool" />
 			<param index="0" name="delta" type="float" />
+			<param index="1" name="increment_frames" type="bool" default="true" />
 			<description>
 				Runs one physics step: synchronizes the physics servers, calls [method Node._physics_process] on the scene tree, runs navigation and physics stepping, then flushes the message queue. Use this when [member ProjectSettings.physics/common/use_builtin_physics_stepping] is [code]false[/code] to drive physics manually (e.g. for rollback netcode or custom tick rates).
 				[param delta] should typically be the fixed physics step in seconds, e.g. [code]1.0 / Engine.physics_ticks_per_second[/code].
+				If [param increment_frames] is [code]true[/code], [method get_physics_frames] is incremented for this step (default). Set to [code]false[/code] when re-running physics for the same logical frame (e.g. rollback re-simulation) so that input and frame-dependent logic stay consistent.
 				Returns [code]true[/code] if the main loop should exit (e.g. the scene tree requested quit during [method Node._physics_process]); otherwise returns [code]false[/code].
 				[b]Note:[/b] When built-in physics stepping is disabled, you must call this method yourself each time you want to advance the physics simulation. Calling it from [method Node._process] is a common approach.
 			</description>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2682,6 +2682,11 @@
 			[b]Note:[/b] Only [member physics/common/max_physics_steps_per_frame] physics ticks may be simulated per rendered frame at most. If more physics ticks have to be simulated per rendered frame to keep up with rendering, the project will appear to slow down (even if [code]delta[/code] is used consistently in physics calculations). Therefore, it is recommended to also increase [member physics/common/max_physics_steps_per_frame] if increasing [member physics/common/physics_ticks_per_second] significantly above its default value.
 			[b]Note:[/b] Consider enabling [url=$DOCS_URL/tutorials/physics/interpolation/index.html]physics interpolation[/url] if you change [member physics/common/physics_ticks_per_second] to a value that is not a multiple of [code]60[/code]. Using physics interpolation will avoid jittering when the monitor refresh rate and physics update rate don't exactly match.
 		</member>
+		<member name="physics/common/use_builtin_physics_stepping" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], the main loop runs physics automatically each frame (sync, [method Node._physics_process], navigation, and physics step) according to [member physics/common/physics_ticks_per_second] and [member physics/common/max_physics_steps_per_frame]. This is the default behavior.
+			If [code]false[/code], the main loop does not run physics. You must advance physics manually by calling [method Engine.physics_iteration] (e.g. from [method Node._process]) with the desired [code]delta[/code] (typically [code]1.0 / Engine.physics_ticks_per_second[/code]). Use this for custom physics control such as rollback netcode or deterministic replay.
+			[b]Note:[/b] This property is only read when the project starts. Changing it at runtime has no effect until the next run.
+		</member>
 		<member name="physics/jolt_physics_3d/collisions/active_edge_threshold" type="float" setter="" getter="" default="0.87266463">
 			The maximum angle, in radians, between two adjacent triangles in a [ConcavePolygonShape3D] or [HeightMapShape3D] for which the edge between those triangles is considered inactive.
 			Collisions against an inactive edge will have its normal overridden to instead be the surface normal of the triangle. This can help alleviate ghost collisions.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4801,7 +4801,7 @@ static uint64_t s_physics_iteration_ticks = 0;
 static uint64_t s_navigation_iteration_ticks = 0;
 #endif
 
-bool Main::physics_iteration(double delta, bool increment_frames) {
+bool Main::physics_iteration(double delta, bool increment_frames, Engine::FlushQueriesOrder flush_queries_order) {
 	GodotProfileZone("Physics Step");
 	GodotProfileZoneGroupedFirst(_physics_zone, "setup");
 	if (Input::get_singleton()->is_agile_input_event_flushing()) {
@@ -4824,13 +4824,17 @@ bool Main::physics_iteration(double delta, bool increment_frames) {
 #ifndef PHYSICS_3D_DISABLED
 	GodotProfileZoneGrouped(_physics_zone, "PhysicsServer3D::sync");
 	PhysicsServer3D::get_singleton()->sync();
-	PhysicsServer3D::get_singleton()->flush_queries();
+	if (flush_queries_order == Engine::FLUSH_QUERIES_BEFORE_STEP) {
+		PhysicsServer3D::get_singleton()->flush_queries();
+	}
 #endif // PHYSICS_3D_DISABLED
 
 #ifndef PHYSICS_2D_DISABLED
 	GodotProfileZoneGrouped(_physics_zone, "PhysicsServer2D::sync");
 	PhysicsServer2D::get_singleton()->sync();
-	PhysicsServer2D::get_singleton()->flush_queries();
+	if (flush_queries_order == Engine::FLUSH_QUERIES_BEFORE_STEP) {
+		PhysicsServer2D::get_singleton()->flush_queries();
+	}
 #endif // PHYSICS_2D_DISABLED
 
 	GodotProfileZoneGrouped(_physics_zone, "physics_process");
@@ -4867,12 +4871,18 @@ bool Main::physics_iteration(double delta, bool increment_frames) {
 #ifndef PHYSICS_3D_DISABLED
 	GodotProfileZoneGrouped(_profile_zone, "3D physics");
 	PhysicsServer3D::get_singleton()->step(delta);
+	if (flush_queries_order == Engine::FLUSH_QUERIES_AFTER_STEP) {
+		PhysicsServer3D::get_singleton()->flush_queries();
+	}
 	PhysicsServer3D::get_singleton()->end_sync();
 #endif // PHYSICS_3D_DISABLED
 
 #ifndef PHYSICS_2D_DISABLED
 	GodotProfileZoneGrouped(_profile_zone, "2D physics");
 	PhysicsServer2D::get_singleton()->step(delta);
+	if (flush_queries_order == Engine::FLUSH_QUERIES_AFTER_STEP) {
+		PhysicsServer2D::get_singleton()->flush_queries();
+	}
 	PhysicsServer2D::get_singleton()->end_sync();
 #endif // PHYSICS_2D_DISABLED
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4864,14 +4864,14 @@ bool Main::physics_iteration(double delta) {
 
 #ifndef PHYSICS_3D_DISABLED
 	GodotProfileZoneGrouped(_profile_zone, "3D physics");
-	PhysicsServer3D::get_singleton()->end_sync();
 	PhysicsServer3D::get_singleton()->step(delta);
+	PhysicsServer3D::get_singleton()->end_sync();
 #endif // PHYSICS_3D_DISABLED
 
 #ifndef PHYSICS_2D_DISABLED
 	GodotProfileZoneGrouped(_profile_zone, "2D physics");
-	PhysicsServer2D::get_singleton()->end_sync();
 	PhysicsServer2D::get_singleton()->step(delta);
+	PhysicsServer2D::get_singleton()->end_sync();
 #endif // PHYSICS_2D_DISABLED
 
 	message_queue->flush();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4801,7 +4801,7 @@ static uint64_t s_physics_iteration_ticks = 0;
 static uint64_t s_navigation_iteration_ticks = 0;
 #endif
 
-bool Main::physics_iteration(double delta) {
+bool Main::physics_iteration(double delta, bool increment_frames) {
 	GodotProfileZone("Physics Step");
 	GodotProfileZoneGroupedFirst(_physics_zone, "setup");
 	if (Input::get_singleton()->is_agile_input_event_flushing()) {
@@ -4809,7 +4809,9 @@ bool Main::physics_iteration(double delta) {
 	}
 
 	Engine::get_singleton()->_in_physics = true;
-	Engine::get_singleton()->_physics_frames++;
+	if (increment_frames) {
+		Engine::get_singleton()->_physics_frames++;
+	}
 
 	uint64_t physics_begin = OS::get_singleton()->get_ticks_usec();
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2176,6 +2176,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	Engine::get_singleton()->set_physics_ticks_per_second(GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "physics/common/physics_ticks_per_second", PROPERTY_HINT_RANGE, "1,1000,1"), 60));
 	Engine::get_singleton()->set_max_physics_steps_per_frame(GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "physics/common/max_physics_steps_per_frame", PROPERTY_HINT_RANGE, "1,100,1"), 8));
+	GLOBAL_DEF(PropertyInfo(Variant::BOOL, "physics/common/use_builtin_physics_stepping", PROPERTY_HINT_NONE, ""), true);
 	Engine::get_singleton()->set_physics_jitter_fix(GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/common/physics_jitter_fix", PROPERTY_HINT_RANGE, "0,2,0.001,or_greater"), 0.5));
 	Engine::get_singleton()->set_max_fps(GLOBAL_DEF(PropertyInfo(Variant::INT, "application/run/max_fps", PROPERTY_HINT_RANGE, "0,1000,1"), 0));
 	if (max_fps >= 0) {
@@ -2846,6 +2847,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	Engine::get_singleton()->set_frame_delay(frame_delay);
 
 	message_queue = memnew(MessageQueue);
+
+	Engine::get_singleton()->set_physics_iteration_callback(Main::physics_iteration);
 
 	Thread::release_main_thread(); // If setup2() is called from another thread, that one will become main thread, so preventively release this one.
 	set_current_thread_safe_for_nodes(false);
@@ -4792,6 +4795,97 @@ static uint64_t physics_process_max = 0;
 static uint64_t process_max = 0;
 static uint64_t navigation_process_max = 0;
 
+// Last physics_iteration() tick counts; read by Main::iteration() to update local profiling vars.
+static uint64_t s_physics_iteration_ticks = 0;
+#if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
+static uint64_t s_navigation_iteration_ticks = 0;
+#endif
+
+bool Main::physics_iteration(double delta) {
+	GodotProfileZone("Physics Step");
+	GodotProfileZoneGroupedFirst(_physics_zone, "setup");
+	if (Input::get_singleton()->is_agile_input_event_flushing()) {
+		Input::get_singleton()->flush_buffered_events();
+	}
+
+	Engine::get_singleton()->_in_physics = true;
+	Engine::get_singleton()->_physics_frames++;
+
+	uint64_t physics_begin = OS::get_singleton()->get_ticks_usec();
+
+	// Prepare the fixed timestep interpolated nodes BEFORE they are updated
+	// by the physics server, otherwise the current and previous transforms
+	// may be the same, and no interpolation takes place.
+	GodotProfileZoneGrouped(_physics_zone, "main loop iteration prepare");
+	OS::get_singleton()->get_main_loop()->iteration_prepare();
+
+#ifndef PHYSICS_3D_DISABLED
+	GodotProfileZoneGrouped(_physics_zone, "PhysicsServer3D::sync");
+	PhysicsServer3D::get_singleton()->sync();
+	PhysicsServer3D::get_singleton()->flush_queries();
+#endif // PHYSICS_3D_DISABLED
+
+#ifndef PHYSICS_2D_DISABLED
+	GodotProfileZoneGrouped(_physics_zone, "PhysicsServer2D::sync");
+	PhysicsServer2D::get_singleton()->sync();
+	PhysicsServer2D::get_singleton()->flush_queries();
+#endif // PHYSICS_2D_DISABLED
+
+	GodotProfileZoneGrouped(_physics_zone, "physics_process");
+	if (OS::get_singleton()->get_main_loop()->physics_process(delta)) {
+#ifndef PHYSICS_3D_DISABLED
+		PhysicsServer3D::get_singleton()->end_sync();
+#endif // PHYSICS_3D_DISABLED
+#ifndef PHYSICS_2D_DISABLED
+		PhysicsServer2D::get_singleton()->end_sync();
+#endif // PHYSICS_2D_DISABLED
+
+		Engine::get_singleton()->_in_physics = false;
+		return true;
+	}
+
+#if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
+	uint64_t navigation_begin = OS::get_singleton()->get_ticks_usec();
+
+#ifndef NAVIGATION_2D_DISABLED
+	GodotProfileZoneGrouped(_profile_zone, "NavigationServer2D::physics_process");
+	NavigationServer2D::get_singleton()->physics_process(delta);
+#endif // NAVIGATION_2D_DISABLED
+#ifndef NAVIGATION_3D_DISABLED
+	GodotProfileZoneGrouped(_profile_zone, "NavigationServer3D::physics_process");
+	NavigationServer3D::get_singleton()->physics_process(delta);
+#endif // NAVIGATION_3D_DISABLED
+
+	s_navigation_iteration_ticks = OS::get_singleton()->get_ticks_usec() - navigation_begin;
+	navigation_process_max = MAX(s_navigation_iteration_ticks, navigation_process_max);
+
+	message_queue->flush();
+#endif // !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
+
+#ifndef PHYSICS_3D_DISABLED
+	GodotProfileZoneGrouped(_profile_zone, "3D physics");
+	PhysicsServer3D::get_singleton()->end_sync();
+	PhysicsServer3D::get_singleton()->step(delta);
+#endif // PHYSICS_3D_DISABLED
+
+#ifndef PHYSICS_2D_DISABLED
+	GodotProfileZoneGrouped(_profile_zone, "2D physics");
+	PhysicsServer2D::get_singleton()->end_sync();
+	PhysicsServer2D::get_singleton()->step(delta);
+#endif // PHYSICS_2D_DISABLED
+
+	message_queue->flush();
+
+	GodotProfileZoneGrouped(_profile_zone, "main loop iteration end");
+	OS::get_singleton()->get_main_loop()->iteration_end();
+
+	s_physics_iteration_ticks = OS::get_singleton()->get_ticks_usec() - physics_begin;
+	physics_process_max = MAX(s_physics_iteration_ticks, physics_process_max);
+
+	Engine::get_singleton()->_in_physics = false;
+	return false;
+}
+
 // Return false means iterating further, returning true means `OS::run`
 // will terminate the program. In case of failure, the OS exit code needs
 // to be set explicitly here (defaults to EXIT_SUCCESS).
@@ -4844,89 +4938,17 @@ bool Main::iteration() {
 #endif // XR_DISABLED
 
 	GodotProfileZoneGrouped(_profile_zone, "physics");
-	for (int iters = 0; iters < advance.physics_steps; ++iters) {
-		GodotProfileZone("Physics Step");
-		GodotProfileZoneGroupedFirst(_physics_zone, "setup");
-		if (Input::get_singleton()->is_agile_input_event_flushing()) {
-			Input::get_singleton()->flush_buffered_events();
-		}
-
-		Engine::get_singleton()->_in_physics = true;
-		Engine::get_singleton()->_physics_frames++;
-
-		uint64_t physics_begin = OS::get_singleton()->get_ticks_usec();
-
-		// Prepare the fixed timestep interpolated nodes BEFORE they are updated
-		// by the physics server, otherwise the current and previous transforms
-		// may be the same, and no interpolation takes place.
-		GodotProfileZoneGrouped(_physics_zone, "main loop iteration prepare");
-		OS::get_singleton()->get_main_loop()->iteration_prepare();
-
-#ifndef PHYSICS_3D_DISABLED
-		GodotProfileZoneGrouped(_physics_zone, "PhysicsServer3D::sync");
-		PhysicsServer3D::get_singleton()->sync();
-		PhysicsServer3D::get_singleton()->flush_queries();
-#endif // PHYSICS_3D_DISABLED
-
-#ifndef PHYSICS_2D_DISABLED
-		GodotProfileZoneGrouped(_physics_zone, "PhysicsServer2D::sync");
-		PhysicsServer2D::get_singleton()->sync();
-		PhysicsServer2D::get_singleton()->flush_queries();
-#endif // PHYSICS_2D_DISABLED
-
-		GodotProfileZoneGrouped(_physics_zone, "physics_process");
-		if (OS::get_singleton()->get_main_loop()->physics_process(physics_step * time_scale)) {
-#ifndef PHYSICS_3D_DISABLED
-			PhysicsServer3D::get_singleton()->end_sync();
-#endif // PHYSICS_3D_DISABLED
-#ifndef PHYSICS_2D_DISABLED
-			PhysicsServer2D::get_singleton()->end_sync();
-#endif // PHYSICS_2D_DISABLED
-
-			Engine::get_singleton()->_in_physics = false;
-			exit = true;
-			break;
-		}
-
+	if (GLOBAL_GET_CACHED(bool, "physics/common/use_builtin_physics_stepping")) {
+		for (int iters = 0; iters < advance.physics_steps; ++iters) {
+			if (Main::physics_iteration(physics_step * time_scale)) {
+				exit = true;
+				break;
+			}
+			physics_process_ticks = MAX(physics_process_ticks, s_physics_iteration_ticks);
 #if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
-		uint64_t navigation_begin = OS::get_singleton()->get_ticks_usec();
-
-#ifndef NAVIGATION_2D_DISABLED
-		GodotProfileZoneGrouped(_profile_zone, "NavigationServer2D::physics_process");
-		NavigationServer2D::get_singleton()->physics_process(physics_step * time_scale);
-#endif // NAVIGATION_2D_DISABLED
-#ifndef NAVIGATION_3D_DISABLED
-		GodotProfileZoneGrouped(_profile_zone, "NavigationServer3D::physics_process");
-		NavigationServer3D::get_singleton()->physics_process(physics_step * time_scale);
-#endif // NAVIGATION_3D_DISABLED
-
-		navigation_process_ticks = MAX(navigation_process_ticks, OS::get_singleton()->get_ticks_usec() - navigation_begin); // keep the largest one for reference
-		navigation_process_max = MAX(OS::get_singleton()->get_ticks_usec() - navigation_begin, navigation_process_max);
-
-		message_queue->flush();
-#endif // !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
-
-#ifndef PHYSICS_3D_DISABLED
-		GodotProfileZoneGrouped(_profile_zone, "3D physics");
-		PhysicsServer3D::get_singleton()->end_sync();
-		PhysicsServer3D::get_singleton()->step(physics_step * time_scale);
-#endif // PHYSICS_3D_DISABLED
-
-#ifndef PHYSICS_2D_DISABLED
-		GodotProfileZoneGrouped(_profile_zone, "2D physics");
-		PhysicsServer2D::get_singleton()->end_sync();
-		PhysicsServer2D::get_singleton()->step(physics_step * time_scale);
-#endif // PHYSICS_2D_DISABLED
-
-		message_queue->flush();
-
-		GodotProfileZoneGrouped(_profile_zone, "main loop iteration end");
-		OS::get_singleton()->get_main_loop()->iteration_end();
-
-		physics_process_ticks = MAX(physics_process_ticks, OS::get_singleton()->get_ticks_usec() - physics_begin); // keep the largest one for reference
-		physics_process_max = MAX(OS::get_singleton()->get_ticks_usec() - physics_begin, physics_process_max);
-
-		Engine::get_singleton()->_in_physics = false;
+			navigation_process_ticks = MAX(navigation_process_ticks, s_navigation_iteration_ticks);
+#endif
+		}
 	}
 
 	if (Input::get_singleton()->is_agile_input_event_flushing()) {
@@ -4987,6 +5009,12 @@ bool Main::iteration() {
 
 	GodotProfileZoneGrouped(_profile_zone, "AudioServer::update");
 	AudioServer::get_singleton()->update();
+
+	// Include physics ticks from manual Engine.physics_iteration() calls (when use_builtin_physics_stepping is false).
+	physics_process_ticks = MAX(physics_process_ticks, s_physics_iteration_ticks);
+#if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
+	navigation_process_ticks = MAX(navigation_process_ticks, s_navigation_iteration_ticks);
+#endif
 
 	if (EngineDebugger::is_active()) {
 		EngineDebugger::get_singleton()->iteration(frame_time, process_ticks, physics_process_ticks, physics_step);

--- a/main/main.h
+++ b/main/main.h
@@ -80,7 +80,7 @@ public:
 	static int start();
 
 	static bool iteration();
-	static bool physics_iteration(double delta);
+	static bool physics_iteration(double delta, bool increment_frames = true);
 	static void force_redraw();
 
 	static bool is_iterating();

--- a/main/main.h
+++ b/main/main.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/config/engine.h"
 #include "core/os/thread.h"
 #include "core/typedefs.h"
 
@@ -80,7 +81,7 @@ public:
 	static int start();
 
 	static bool iteration();
-	static bool physics_iteration(double delta, bool increment_frames = true);
+	static bool physics_iteration(double delta, bool increment_frames = true, Engine::FlushQueriesOrder flush_queries_order = Engine::FLUSH_QUERIES_BEFORE_STEP);
 	static void force_redraw();
 
 	static bool is_iterating();

--- a/main/main.h
+++ b/main/main.h
@@ -80,7 +80,6 @@ public:
 	static int start();
 
 	static bool iteration();
-	// One physics step (sync, physics_process, navigation, step). Used when use_builtin_physics_stepping is true or via Engine.physics_iteration().
 	static bool physics_iteration(double delta);
 	static void force_redraw();
 

--- a/main/main.h
+++ b/main/main.h
@@ -80,6 +80,8 @@ public:
 	static int start();
 
 	static bool iteration();
+	// One physics step (sync, physics_process, navigation, step). Used when use_builtin_physics_stepping is true or via Engine.physics_iteration().
+	static bool physics_iteration(double delta);
 	static void force_redraw();
 
 	static bool is_iterating();


### PR DESCRIPTION
See #116230.

After some playing around, I found that further exposure of the underlying main loop physics iteration is required to practically use `Engine.physics_iteration` in a re-simulation context.

This is a heavier-handed approach to manual physics stepping with a few more knobs to tweak. Specifically, this adds the following arguments:
1. `increment_frames: Bool`
    Defaults to `true` to retain current behaviour. When `true`, `Engine::_physics_frames` is incremented during this physics iteration. This value is reflected in `Engine.get_physics_frames()`. Passing `false` does not increment `_physics_frames`. This argument is useful when re-simulating multiple physics frames during a single "game physics iteration" e.g. during rollback and re-simulation. If `_physics_frames` is incremented during each frame, input events will appear old despite being received during the current "game physics iteration", thus resulting in e.g. `Input.is_action_just_pressed` being unexpectedly false.
3. `flush_queries_order: Engine.FlushQueriesOrder`
    Defaults to `Engine.FLUSH_QUERIES_BEFORE_STEP` to maintain current behaviour. The main loop currently calls `PhysicsServer2/3D.flush_queries` before calling `physics_process` and then `PhysicsServer2/3D.step`. Passing `Engine.FLUSH_QUERIES_AFTER_STEP` changes this order to `physics_process` → `PhysicsServer2/3D.step` → `PhysicsServer2/3D.flush_queries`. This is useful when resetting state between physics iterations as it avoids flushing stale queries. Finally, the `PhysicsServer2/3D.flush_queries` call can be skipped entirely by passing `Engine.FLUSH_QUERIES_NEVER`.

Additionally, this slightly tweaks the way in which the main loop invokes `PhysicsServer2/3D.step`. It is now called between `PhysicsServer2/3D.sync` and `PhysicsServer2/3D.end_sync`.

Godot's implementation of PhysicsServer uses the internal `doing_sync` set and unset during `sync` and `end_sync`, respectively, to determine when `space_get_direct_state` and `body_get_direct_state` may be called **only** when multithreaded physics is enabled.

