### PR TITLE
Wayland: Use release method when available

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -750,7 +750,12 @@ void WaylandThread::_wl_registry_on_global_remove(void *data, struct wl_registry
 
 	if (name == registry->wl_shm_name) {
 		if (registry->wl_shm) {
-			wl_shm_destroy(registry->wl_shm);
+			if (wl_shm_get_version(registry->wl_shm) >= WL_SHM_RELEASE_SINCE_VERSION) {
+				wl_shm_release(registry->wl_shm);
+			} else {
+				wl_shm_destroy(registry->wl_shm);
+			}
+
 			registry->wl_shm = nullptr;
 		}
 
@@ -807,7 +812,12 @@ void WaylandThread::_wl_registry_on_global_remove(void *data, struct wl_registry
 			ERR_FAIL_NULL(ss);
 
 			if (ss->wl_data_device) {
-				wl_data_device_destroy(ss->wl_data_device);
+				if (wl_data_device_get_version(ss->wl_data_device) >= WL_DATA_DEVICE_RELEASE_SINCE_VERSION) {
+					wl_data_device_release(ss->wl_data_device);
+				} else {
+					wl_data_device_destroy(ss->wl_data_device);
+				}
+
 				ss->wl_data_device = nullptr;
 			}
 
@@ -1125,12 +1135,23 @@ void WaylandThread::_wl_registry_on_global_remove(void *data, struct wl_registry
 			ERR_FAIL_NULL(ss);
 
 			if (ss->wl_seat_name == name) {
+				// Destroy all capabilities (pointer, keyboard, touch).
+				_wl_seat_on_capabilities(wl_seat_get_user_data(wl_seat), wl_seat, 0);
+
 				if (wl_seat) {
-					wl_seat_destroy(wl_seat);
+					if (wl_seat_get_version(wl_seat) >= WL_SEAT_RELEASE_SINCE_VERSION) {
+						wl_seat_release(wl_seat);
+					} else {
+						wl_seat_destroy(wl_seat);
+					}
 				}
 
 				if (ss->wl_data_device) {
-					wl_data_device_destroy(ss->wl_data_device);
+					if (wl_data_device_get_version(ss->wl_data_device) >= WL_DATA_DEVICE_RELEASE_SINCE_VERSION) {
+						wl_data_device_release(ss->wl_data_device);
+					} else {
+						wl_data_device_destroy(ss->wl_data_device);
+					}
 				}
 
 				if (ss->wp_tablet_seat) {
@@ -1171,7 +1192,12 @@ void WaylandThread::_wl_registry_on_global_remove(void *data, struct wl_registry
 				registry->wl_outputs.erase(it);
 
 				memdelete(ss);
-				wl_output_destroy(wl_output);
+
+				if (wl_output_get_version(wl_output) >= WL_OUTPUT_RELEASE_SINCE_VERSION) {
+					wl_output_release(wl_output);
+				} else {
+					wl_output_destroy(wl_output);
+				}
 
 				return;
 			}
@@ -1707,7 +1733,12 @@ void WaylandThread::_wl_seat_on_capabilities(void *data, struct wl_seat *wl_seat
 		}
 
 		if (ss->wl_pointer) {
-			wl_pointer_destroy(ss->wl_pointer);
+			if (wl_pointer_get_version(ss->wl_pointer) >= WL_POINTER_RELEASE_SINCE_VERSION) {
+				wl_pointer_release(ss->wl_pointer);
+			} else {
+				wl_pointer_destroy(ss->wl_pointer);
+			}
+
 			ss->wl_pointer = nullptr;
 		}
 
@@ -1768,7 +1799,12 @@ void WaylandThread::_wl_seat_on_capabilities(void *data, struct wl_seat *wl_seat
 		}
 
 		if (ss->wl_keyboard) {
-			wl_keyboard_destroy(ss->wl_keyboard);
+			if (wl_keyboard_get_version(ss->wl_keyboard) >= WL_KEYBOARD_RELEASE_SINCE_VERSION) {
+				wl_keyboard_release(ss->wl_keyboard);
+			} else {
+				wl_keyboard_destroy(ss->wl_keyboard);
+			}
+
 			ss->wl_keyboard = nullptr;
 		}
 	}


### PR DESCRIPTION
Historically the core protocol didn't have a way to truly destroy certain objects. Calling `destroy` on `wl_shm`, `wl_output`, `wl_seat` and its input objects, would just destroy the local proxy.

New versions include a `release` method that actually cleans the object from the compositor. This patch prefers it over `destroy`, if available.

It also properly destroys a seat's child objects (`wl_keyboard`, `wl_pointer`) when it gets removed.