### PR TITLE
Add add_property_category method to ClassDB

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1462,6 +1462,15 @@ bool ClassDB::get_signal(const StringName &p_class, const StringName &p_signal, 
 	return false;
 }
 
+void ClassDB::add_property_category(const StringName &p_class, const String &p_name, const String &p_prefix) {
+	Locker::Lock lock(Locker::STATE_WRITE);
+	ClassInfo *type = classes.getptr(p_class);
+	ERR_FAIL_NULL(type);
+
+	String prefix = p_prefix;
+	type->property_list.push_back(PropertyInfo(Variant::NIL, p_name, PROPERTY_HINT_NONE, prefix, PROPERTY_USAGE_CATEGORY));
+}
+
 void ClassDB::add_property_group(const StringName &p_class, const String &p_name, const String &p_prefix, int p_indent_depth) {
 	Locker::Lock lock(Locker::STATE_WRITE);
 	ClassInfo *type = classes.getptr(p_class);

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -470,6 +470,7 @@ public:
 	static bool get_signal(const StringName &p_class, const StringName &p_signal, MethodInfo *r_signal);
 	static void get_signal_list(const StringName &p_class, List<MethodInfo> *p_signals, bool p_no_inheritance = false);
 
+	static void add_property_category(const StringName &p_class, const String &p_name, const String &p_prefix = "");
 	static void add_property_group(const StringName &p_class, const String &p_name, const String &p_prefix = "", int p_indent_depth = 0);
 	static void add_property_subgroup(const StringName &p_class, const String &p_name, const String &p_prefix = "", int p_indent_depth = 0);
 	static void add_property_array_count(const StringName &p_class, const String &p_label, const StringName &p_count_property, const StringName &p_count_setter, const StringName &p_count_getter, const String &p_array_element_prefix, uint32_t p_count_usage = PROPERTY_USAGE_DEFAULT);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -136,6 +136,7 @@ enum PropertyUsageFlags {
 #define ADD_PROPERTY(m_property, m_setter, m_getter) ::ClassDB::add_property(get_class_static(), m_property, StringName(m_setter), StringName(m_getter))
 #define ADD_PROPERTYI(m_property, m_setter, m_getter, m_index) ::ClassDB::add_property(get_class_static(), m_property, StringName(m_setter), StringName(m_getter), m_index)
 #define ADD_PROPERTY_DEFAULT(m_property, m_default) ::ClassDB::set_property_default_value(get_class_static(), m_property, m_default)
+#define ADD_CATEGORY(m_name, m_prefix) ::ClassDB::add_property_category(get_class_static(), m_name, m_prefix)
 #define ADD_GROUP(m_name, m_prefix) ::ClassDB::add_property_group(get_class_static(), m_name, m_prefix)
 #define ADD_GROUP_INDENT(m_name, m_prefix, m_depth) ::ClassDB::add_property_group(get_class_static(), m_name, m_prefix, m_depth)
 #define ADD_SUBGROUP(m_name, m_prefix) ::ClassDB::add_property_subgroup(get_class_static(), m_name, m_prefix)


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

This PR closes [Proposal 14274](https://github.com/godotengine/godot-proposals/issues/14274).

Adding property categories in C++ and GDExtensions is currently too verbose, requiring a _get_property_list implementation.

With this PR, the workflow is brought up to speed with the ADD_GROUP and ADD_SUBGROUP macros, providing a new ADD_CATEGORY macro.