### PR TITLE
Fix EditorSettings error due to `android_sdk_path` when exporting a project

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -292,6 +292,12 @@ static const int DEFAULT_TARGET_SDK_VERSION = 36; // Should match the value in '
 
 #ifndef ANDROID_ENABLED
 void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
+	if (!EditorSettings::get_singleton()) {
+		// Some methods called here query editor settings, so we need it to be ready first.
+		// If it's not ready yet, just wait for the next iteration.
+		return;
+	}
+
 	EditorExportPlatformAndroid *ea = static_cast<EditorExportPlatformAndroid *>(ud);
 
 	while (!ea->quit_request.is_set()) {


### PR DESCRIPTION
This editor setting is queried once every 3 seconds, as it is used to check whether devices have been (dis)connected for one-click deploy.

This method may be called early on depending on initialization order, which has led to occasional error messages when exporting a project. The method now returns early if EditorSettings isn't ready yet (it will be called again soon after anyway).

This should fix spurious CI failures that have occurred since https://github.com/godotengine/godot/pull/109146 was merged.

PS: It seems we're performing the `adb devices` polling even when the editor isn't currently focused. This wastes CPU, as the user can't interact with the one-click deploy dropdown if they aren't currently focused on the editor. We should probably early return if we are currently not focused, but I figure I'd leave this to a future PR as to avoid any possible regression here.