### PR TITLE
Wayland: Scale pan delta

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -2064,7 +2064,7 @@ void WaylandThread::_wl_pointer_on_frame(void *data, struct wl_pointer *wl_point
 
 			pg->set_window_id(ws->id);
 
-			pg->set_delta(pd.scroll_vector);
+			pg->set_delta(pd.scroll_vector * scale);
 
 			Ref<InputEventMessage> msg;
 			msg.instantiate();


### PR DESCRIPTION
The documentation says that `wl_pointer::axis` uses surface-local units, i.e. unscaled units, so we need to scale them.

---

NOTE: This is under the assumption that the expected unit for gestures is the pixel. See: https://github.com/godotengine/godot/pull/116499#issuecomment-3930881219