### PR TITLE
Clamp uv coordinates of omni light projector

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -665,6 +665,10 @@ void light_process_omni(uint idx, vec3 vertex, hvec3 eye_vec, hvec3 normal, vec3
 		local_v.xy = local_v.xy * 0.5 + 0.5;
 		vec2 proj_uv = local_v.xy * atlas_rect.zw;
 
+		// Clamp the uv coordinates to prevent bleeding from neighboring decals.
+		vec2 texel_size = 1.0 / vec2(textureSize(sampler2D(decal_atlas_srgb, light_projector_sampler), 0));
+		proj_uv = clamp(proj_uv, texel_size * 0.5, atlas_rect.zw - texel_size * 0.5);
+
 		if (sc_projector_use_mipmaps()) {
 			vec2 proj_uv_ddx;
 			vec2 proj_uv_ddy;


### PR DESCRIPTION
Fixes #89440

Removes bleeding due to bilinear interpolation. Essentially it limits the uv coordinates to only valid texels. 

Mipmap texels however are not accounted for, so when the decal atlas is minified on screen the problem may still occur, though would be less noticeable.

If I chose to slightly scale the uv instead, it would sacrifice accuracy in the projection especially as the texture size decreases. This way the projection remains accurate.

Before and after (256x256 texture size):

<img width="574" height="323" alt="image" src="https://github.com/user-attachments/assets/ffd4f37f-fcb9-4b89-a5fd-3892ad50c5a8" />

<img width="574" height="323" alt="image" src="https://github.com/user-attachments/assets/a3c02e40-c893-4f20-83f6-5dd3121cfd1a" />

Before and after (16x16 texture size):

<img width="574" height="323" alt="image" src="https://github.com/user-attachments/assets/8aad2521-fb64-464e-817d-dd25dc47afe3" />

<img width="574" height="323" alt="image" src="https://github.com/user-attachments/assets/f37bcc0e-7cd8-47fd-9641-920a82eddcdd" />
