### PR TITLE
[macOS] Enable wake for events if `Magnet` is running.

### DIFF
--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -61,7 +61,14 @@
 #include <sys/sysctl.h>
 
 void OS_MacOS::add_frame_delay(bool p_can_draw, bool p_wake_for_events) {
-	if (p_wake_for_events) {
+	bool wake_for_events = p_wake_for_events;
+	if (!wake_for_events) {
+		NSArray<NSRunningApplication *> *proc_array = [NSRunningApplication runningApplicationsWithBundleIdentifier:@"com.crowdcafe.windowmagnet"];
+		if (proc_array && proc_array.count > 0) {
+			wake_for_events = true;
+		}
+	}
+	if (wake_for_events) {
 		uint64_t delay = get_frame_delay(p_can_draw);
 		if (delay == 0) {
 			return;
@@ -79,7 +86,7 @@ void OS_MacOS::add_frame_delay(bool p_can_draw, bool p_wake_for_events) {
 		CFRunLoopAddTimer(CFRunLoopGetCurrent(), wait_timer, kCFRunLoopCommonModes);
 		return;
 	}
-	OS_Unix::add_frame_delay(p_can_draw, p_wake_for_events);
+	OS_Unix::add_frame_delay(p_can_draw, wake_for_events);
 }
 
 void OS_MacOS::initialize() {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/104246
Supersede https://github.com/godotengine/godot/pull/116473
Supersede https://github.com/godotengine/godot-proposals/issues/14245

Sometimes there's still a lag on the first mouse event, but it seems to work fine afterward. Normally `wake_for_events` is used with screen reader is detected to allow immediate response to accessibility events without waiting for the frame delay, since `Magnet` is using accessibility permission, it's likely using the same events for something.