### PR TITLE
Don't tint the preview camera icon

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -6427,6 +6427,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	preview_camera->set_shortcut(ED_SHORTCUT("spatial_editor/toggle_camera_preview", TTRC("Toggle Camera Preview"), KeyModifierMask::CTRL | Key::P));
 	vbox->add_child(preview_camera);
 	preview_camera->set_h_size_flags(0);
+	preview_camera->set_theme_type_variation("CheckBoxNoIconTint");
 	preview_camera->hide();
 	preview_camera->connect(SceneStringName(toggled), callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
 	previewing = nullptr;


### PR DESCRIPTION
Removes accent color tint, same as https://github.com/godotengine/godot/pull/114874

| Master | PR |
|--------|--------|
| ![1](https://github.com/user-attachments/assets/79d2fb0a-4d02-4de4-816b-bbf6a5f9c100) | ![2](https://github.com/user-attachments/assets/c1a39d30-e7cb-481b-a3a2-2cb31b023c03) |