### PR TITLE
Input: Fix action matching for projects saved before device ID change

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -205,6 +205,22 @@ void InputMap::action_add_event(const StringName &p_action, RequiredParam<InputE
 		return; // Already added.
 	}
 
+	// Normalize legacy device IDs: before the device ID change,
+	// keyboard and mouse events defaulted to device=0.
+	if (p_event->get_device() == 0) {
+		switch (p_event->get_type()) {
+			case InputEventType::KEY:
+				p_event->set_device(InputEvent::DEVICE_ID_KEYBOARD);
+				break;
+			case InputEventType::MOUSE_BUTTON:
+			case InputEventType::MOUSE_MOTION:
+				p_event->set_device(InputEvent::DEVICE_ID_MOUSE);
+				break;
+			default:
+				break;
+		}
+	}
+
 	input_map[p_action].inputs.push_back(p_event);
 }
 


### PR DESCRIPTION
# Summary

Some existing projects are broken with #116274 due to them serialising events with device_id = 0. An example would be the Global Illumination project.

# Solution

Normalize legacy device=0 on keyboard/mouse events when loading input actions from project settings. Before #116274, these events defaulted to device=0; now they use DEVICE_ID_KEYBOARD (16) and DEVICE_ID_MOUSE (32), causing _find_event() mismatches.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
