### PR TITLE
OpenXR: Fix OpenGL ES driver checks

### DIFF
--- a/modules/openxr/extensions/openxr_fb_update_swapchain_extension.cpp
+++ b/modules/openxr/extensions/openxr_fb_update_swapchain_extension.cpp
@@ -70,7 +70,7 @@ HashMap<String, bool *> OpenXRFBUpdateSwapchainExtension::get_requested_extensio
 #ifdef XR_USE_GRAPHICS_API_VULKAN
 		request_extensions[XR_FB_SWAPCHAIN_UPDATE_STATE_VULKAN_EXTENSION_NAME] = &fb_swapchain_update_state_vulkan_ext;
 #endif
-	} else if (rendering_driver == "opengl3") {
+	} else if (rendering_driver == "opengl3" || rendering_driver == "opengl3_es") {
 #ifdef XR_USE_GRAPHICS_API_OPENGL_ES
 		request_extensions[XR_FB_SWAPCHAIN_UPDATE_STATE_OPENGL_ES_EXTENSION_NAME] = &fb_swapchain_update_state_opengles_ext;
 #endif
@@ -146,7 +146,7 @@ void OpenXRFBUpdateSwapchainExtension::update_swapchain_state(XrSwapchain p_swap
 			return;
 		}
 #endif
-	} else if (rendering_driver == "opengl3") {
+	} else if (rendering_driver == "opengl3" || rendering_driver == "opengl3_es") {
 #ifdef XR_USE_GRAPHICS_API_OPENGL_ES
 		if (!fb_swapchain_update_state_ext || !fb_swapchain_update_state_opengles_ext) {
 			return;

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1718,7 +1718,7 @@ bool OpenXRAPI::initialize(const String &p_rendering_driver) {
 		// shouldn't be possible...
 		ERR_FAIL_V(false);
 #endif
-	} else if (p_rendering_driver == "opengl3") {
+	} else if (p_rendering_driver == "opengl3" || p_rendering_driver == "opengl3_es") {
 #if defined(GLES3_ENABLED) && !defined(MACOS_ENABLED)
 		graphics_extension = memnew(OpenXROpenGLExtension);
 		register_extension_wrapper(graphics_extension);


### PR DESCRIPTION
The `OpenXROpenGLExtension` class handles both OpenGL and OpenGL ES but currently there is no code path to activate the extension when the "opengl3_es" rendering driver is requested explicitly. A similar issue exists in `OpenXRFBUpdateSwapchainExtension`. With this commit both strings are checked.