### PR TITLE
Re-activate a few clang-tidy options.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,12 +1,13 @@
 Checks:
   - -*
+  - bugprone-use-after-move
   - modernize-deprecated-headers
-#  - modernize-redundant-void-arg # TODO Re-activate
-#  - modernize-use-bool-literals # TODO Re-activate
+  - modernize-redundant-void-arg
+  - modernize-use-bool-literals
 #  - modernize-use-default-member-init # TODO Re-activate
-#  - modernize-use-nullptr # TODO Re-activate
-#  - readability-braces-around-statements # TODO Re-activate
-#  - readability-redundant-member-init # TODO Re-activate
+  - modernize-use-nullptr
+  - readability-braces-around-statements
+  - readability-redundant-member-init
 HeaderFileExtensions: ["", h, hh, hpp, hxx, inc, glsl]
 ImplementationFileExtensions: [c, cc, cpp, cxx, m, mm, java]
 HeaderFilterRegex: (core|doc|drivers|editor|main|modules|platform|scene|servers|tests)/

--- a/core/string/string_buffer.h
+++ b/core/string/string_buffer.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/math_funcs_binary.h"
 #include "core/string/print_string.h"
 #include "core/string/ustring.h"
 


### PR DESCRIPTION
- Follow-up of #112785 

Enforce a few styles via clang-tidy. None of those seem to modify the codebase, so we've apparently been doing a good job of enforcing them by hand so far.
All of these styles make perfect sense to me, and i think we should be enforcing them.

The header fix is needed on my machine to get clang-tidy to run (missing include).