### PR TITLE
OpenXR: Use Android-independent OpenGL ES compile time checks

### DIFF
--- a/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
@@ -59,7 +59,7 @@
 HashMap<String, bool *> OpenXROpenGLExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
-#ifdef ANDROID_ENABLED
+#ifdef XR_USE_GRAPHICS_API_OPENGL_ES
 	request_extensions[XR_KHR_OPENGL_ES_ENABLE_EXTENSION_NAME] = nullptr;
 #else
 	request_extensions[XR_KHR_OPENGL_ENABLE_EXTENSION_NAME] = nullptr;
@@ -75,7 +75,7 @@ void OpenXROpenGLExtension::on_instance_created(const XrInstance p_instance) {
 	// Obtain pointers to functions we're accessing here.
 	ERR_FAIL_NULL(OpenXRAPI::get_singleton());
 
-#ifdef ANDROID_ENABLED
+#ifdef XR_USE_GRAPHICS_API_OPENGL_ES
 	EXT_INIT_XR_FUNC(xrGetOpenGLESGraphicsRequirementsKHR);
 #else
 	EXT_INIT_XR_FUNC(xrGetOpenGLGraphicsRequirementsKHR);
@@ -89,7 +89,7 @@ bool OpenXROpenGLExtension::check_graphics_api_support(XrVersion p_desired_versi
 	XrSystemId system_id = OpenXRAPI::get_singleton()->get_system_id();
 	XrInstance instance = OpenXRAPI::get_singleton()->get_instance();
 
-#ifdef ANDROID_ENABLED
+#ifdef XR_USE_GRAPHICS_API_OPENGL_ES
 	XrGraphicsRequirementsOpenGLESKHR opengl_requirements;
 	opengl_requirements.type = XR_TYPE_GRAPHICS_REQUIREMENTS_OPENGL_ES_KHR;
 	opengl_requirements.next = nullptr;
@@ -232,14 +232,14 @@ bool OpenXROpenGLExtension::get_swapchain_image_data(XrSwapchain p_swapchain, in
 		return false;
 	}
 
-#ifdef ANDROID_ENABLED
+#ifdef XR_USE_GRAPHICS_API_OPENGL_ES
 	LocalVector<XrSwapchainImageOpenGLESKHR> images;
 #else
 	LocalVector<XrSwapchainImageOpenGLKHR> images;
 #endif
 	images.resize(swapchain_length);
 
-#ifdef ANDROID_ENABLED
+#ifdef XR_USE_GRAPHICS_API_OPENGL_ES
 	for (XrSwapchainImageOpenGLESKHR &image : images) {
 		image.type = XR_TYPE_SWAPCHAIN_IMAGE_OPENGL_ES_KHR;
 #else
@@ -334,7 +334,7 @@ void OpenXROpenGLExtension::cleanup_swapchain_graphics_data(void **p_swapchain_g
 String OpenXROpenGLExtension::get_swapchain_format_name(int64_t p_swapchain_format) const {
 	// These are somewhat different per platform, will need to weed some stuff out...
 	switch (p_swapchain_format) {
-#ifdef ANDROID_ENABLED
+#ifdef XR_USE_GRAPHICS_API_OPENGL_ES
 		// using definitions from GLES3/gl3.h
 
 		ENUM_TO_STRING_CASE(GL_RGBA4)

--- a/modules/openxr/extensions/platform/openxr_opengl_extension.h
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.h
@@ -84,7 +84,7 @@ private:
 
 	bool check_graphics_api_support(XrVersion p_desired_version);
 
-#ifdef ANDROID_ENABLED
+#ifdef XR_USE_GRAPHICS_API_OPENGL_ES
 	EXT_PROTO_XRRESULT_FUNC3(xrGetOpenGLESGraphicsRequirementsKHR, (XrInstance), p_instance, (XrSystemId), p_system_id, (XrGraphicsRequirementsOpenGLESKHR *), p_graphics_requirements)
 #else
 	EXT_PROTO_XRRESULT_FUNC3(xrGetOpenGLGraphicsRequirementsKHR, (XrInstance), p_instance, (XrSystemId), p_system_id, (XrGraphicsRequirementsOpenGLKHR *), p_graphics_requirements)


### PR DESCRIPTION
Godot currently guards several OpenGL ES code paths by checking for `ANDROID_ENABLED`. This commit changes them to the more specific `XR_USE_GRAPHICS_API_OPENGL_ES` (which is [always defined when `ANDROID_ENABLED` and `GLES3_ENABLED` are defined](https://github.com/godotengine/godot/blob/ad4c2c3da892029981707d757a80ddef12e59d7a/modules/openxr/openxr_platform_inc.h#L48)), making it possible to create custom non-Android based engine builds using OpenGL ES.