### PR TITLE
Fix incorrect index usage in path string construction in `PostImportPluginSkeletonRestFixer`

### DIFF
--- a/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
@@ -604,7 +604,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 											Vector<StringName> names = anim->track_get_path(i).get_names();
 											names.remove_at(0);
 											for (int j = 0; j < names.size(); j++) {
-												path_string += "/" + names[i].operator String();
+												path_string += "/" + names[j].operator String();
 											}
 										}
 										if (anim->track_get_path(i).get_subname_count() > 0) {


### PR DESCRIPTION
On my readthrough of the post_import_plugin_skeleton_fixer.cpp I saw this for loop with i in place of j. I cannot think a reason we would need i but I may be wrong.

In case we do need i and not j, then maybe the for loop could be styled more like this:
for (const StringName &name : names) {
    path_string += "/" + name.operator String();
}