### PR TITLE
[3.x] Mark MutexLock as `NO_DISCARD` to prevent misuse.

### DIFF
--- a/core/os/mutex.h
+++ b/core/os/mutex.h
@@ -59,7 +59,7 @@ public:
 
 // This is written this way instead of being a template to overcome a limitation of C++ pre-17
 // that would require MutexLock to be used like this: MutexLock<Mutex> lock;
-class MutexLock {
+class _NO_DISCARD_CLASS_ MutexLock {
 	union {
 		std::recursive_mutex *recursive_mutex;
 		std::mutex *mutex;
@@ -107,7 +107,7 @@ public:
 	_ALWAYS_INLINE_ Error try_lock() const { return OK; }
 };
 
-class MutexLock {
+class _NO_DISCARD_CLASS_ MutexLock {
 public:
 	explicit MutexLock(const MutexImpl<FakeMutex> &p_mutex) {}
 };


### PR DESCRIPTION
Backport of #116280 .

## Notes
* The original bug caused by the typo (#116192) wasn't present in 3.x as there was no thread protection currently needed, but it makes sense to add `NO_DISCARD` as free protection from the same problem cropping up again in 3.x.
* We use a macro in 3.x rather than `[[nodiscard]]` directly, because we support some older compilers that need some tweaks (see the macro definitions).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
