### PR TITLE
Editor Help: Make codeblocks full-width

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -2739,6 +2739,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 			p_rt->push_font(doc_code_font);
 			p_rt->push_font_size(doc_code_font_size);
 			p_rt->push_table(2);
+			p_rt->set_table_column_expand(0, true, 1, false);
 
 			p_rt->push_cell();
 			p_rt->set_cell_row_background_color(code_bg_color, Color(code_bg_color, 0.99));


### PR DESCRIPTION
* Depends on #116277.

<details>
<summary>Before</summary>

<img width="984" height="634" alt="" src="https://github.com/user-attachments/assets/a545bd9b-f9f7-49cf-9f18-cc8c08ba336f" />

</details>

<details>
<summary>After</summary>

<img width="984" height="634" alt="" src="https://github.com/user-attachments/assets/0f3dfd32-d357-443f-9e80-38e803ee1c4d" />

</details>

<details>
<summary>Online docs</summary>

<img width="703" height="722" alt="" src="https://github.com/user-attachments/assets/b7f33fb0-626b-4e70-bb55-61fdd7e3f7bb" />

</details>