### PR TITLE
Add `tween_assign()` for non-interpolated property assignment in `Tween` animations

### DIFF
--- a/doc/classes/AssignTweener.xml
+++ b/doc/classes/AssignTweener.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AssignTweener" inherits="Tweener" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Instantly assigns a value to an [Object]'s property.
+	</brief_description>
+	<description>
+		[AssignTweener] is used to assign a value to an [Object]'s property.
+		The tweener will finish automatically if the target object is freed.
+		[b]Note:[/b] [method Tween.tween_assign] is the only correct way to create [AssignTweener]. Any [AssignTweener] created manually will not function correctly.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="set_delay">
+			<return type="AssignTweener" />
+			<param index="0" name="delay" type="float" />
+			<description>
+				Makes the assignment delayed by given time in seconds.
+				[b]Example:[/b] Set the node's position to [code](100, 100)[/code] after 2 seconds:
+				[codeblocks]
+				[gdscript]
+				var tween = get_tree().create_tween()
+				tween.tween_assign(self, "position", Vector2(100, 100)).set_delay(2)
+				[/gdscript]
+				[csharp]
+				Tween tween = GetTree().CreateTween();
+				tween.TweenAssign(this, "position", new Vector2(100.0f, 100.0f)).SetDelay(2.0f);
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -317,6 +317,30 @@
 				[b]Note:[/b] If a Tween is stopped and not bound to any node, it will exist indefinitely until manually started or invalidated. If you lose a reference to such Tween, you can retrieve it using [method SceneTree.get_processed_tweens].
 			</description>
 		</method>
+		<method name="tween_assign">
+			<return type="AssignTweener" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="property" type="NodePath" />
+			<param index="2" name="new_val" type="Variant" />
+			<description>
+				Creates and appends an [AssignTweener]. This method is similar to [method tween_property], but it doesn't interpolate the value over time. Instead, it assigns the desired value to the property when the tweener starts. This can be useful for sequencing actions in a tween without any animation, or for setting up initial values for later tweening.
+				[codeblocks]
+				[gdscript]
+				var tween = create_tween()
+				tween.tween_assign($Sprite, "texture", new_texture)
+				tween.tween_assign($Sprite, "position", Vector2(100, 200))
+				tween.tween_property($Sprite, "position", Vector2(200, 300), 1.0)
+				[/gdscript]
+				[csharp]
+				Tween tween = CreateTween();
+				tween.TweenAssign(GetNode("Sprite"), "texture", newTexture);
+				tween.TweenAssign(GetNode("Sprite"), "position", new Vector2(100.0f, 200.0f));
+				tween.TweenProperty(GetNode("Sprite"), "position", new Vector2(200.0f, 300.0f), 1.0f);
+				[/csharp]
+				[/codeblocks]
+				In the example above, the sprite will be immediately moved to position [code](100, 200)[/code] and then tweened to [code](200, 300)[/code].
+			</description>
+		</method>
 		<method name="tween_await">
 			<return type="AwaitTweener" />
 			<param index="0" name="signal" type="Signal" />

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -177,6 +177,17 @@ RequiredResult<AwaitTweener> Tween::tween_await(const Signal &p_signal) {
 	return tweener;
 }
 
+RequiredResult<AssignTweener> Tween::tween_assign(RequiredParam<const Object> rp_target, const NodePath &p_property, Variant p_new_val) {
+	EXTRACT_PARAM_OR_FAIL_V(p_target, rp_target, nullptr);
+	CHECK_VALID();
+
+	Vector<StringName> property_subnames = p_property.get_as_property_path().get_subnames();
+	Ref<AssignTweener> tweener;
+	tweener.instantiate(p_target, property_subnames, p_new_val);
+	append(tweener);
+	return tweener;
+}
+
 void Tween::append(Ref<Tweener> p_tweener) {
 	p_tweener->set_tween(this);
 
@@ -483,6 +494,7 @@ void Tween::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("tween_method", "method", "from", "to", "duration"), &Tween::tween_method);
 	ClassDB::bind_method(D_METHOD("tween_subtween", "subtween"), &Tween::tween_subtween);
 	ClassDB::bind_method(D_METHOD("tween_await", "signal"), &Tween::tween_await);
+	ClassDB::bind_method(D_METHOD("tween_assign", "object", "property", "new_val"), &Tween::tween_assign);
 
 	ClassDB::bind_method(D_METHOD("custom_step", "delta"), &Tween::custom_step);
 	ClassDB::bind_method(D_METHOD("stop"), &Tween::stop);
@@ -996,4 +1008,48 @@ void AwaitTweener::_bind_methods() {
 
 void AwaitTweener::_signal_received(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	received = true;
+}
+
+void AssignTweener::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_delay", "delay"), &AssignTweener::set_delay);
+}
+
+RequiredResult<AssignTweener> AssignTweener::set_delay(double p_delay) {
+	delay = p_delay;
+	return this;
+}
+
+bool AssignTweener::step(double &r_delta) {
+	if (finished) {
+		return false;
+	}
+
+	Object *target_instance = ObjectDB::get_instance(target);
+	if (!target_instance) {
+		_finish();
+		return false;
+	}
+	elapsed_time += r_delta;
+	if (elapsed_time >= delay) {
+		target_instance->set_indexed(property, new_val);
+		r_delta = elapsed_time - delay;
+		_finish();
+		return false;
+	}
+
+	r_delta = 0;
+	return true;
+}
+
+AssignTweener::AssignTweener(const Object *p_target, const Vector<StringName> &p_property, const Variant &p_new_val) {
+	target = p_target->get_instance_id();
+	property = p_property;
+	new_val = p_new_val;
+	if (p_target->is_ref_counted()) {
+		ref_copy = p_target;
+	}
+}
+
+AssignTweener::AssignTweener() {
+	ERR_FAIL_MSG("AssignTweener can't be created directly. Use tween_assign() method in Tween.");
 }

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -62,6 +62,7 @@ class CallbackTweener;
 class MethodTweener;
 class SubtweenTweener;
 class AwaitTweener;
+class AssignTweener;
 
 class Tween : public RefCounted {
 	GDCLASS(Tween, RefCounted);
@@ -150,6 +151,7 @@ public:
 	RequiredResult<MethodTweener> tween_method(const Callable &p_callback, const Variant p_from, Variant p_to, double p_duration);
 	RequiredResult<SubtweenTweener> tween_subtween(RequiredParam<Tween> rp_subtween);
 	RequiredResult<AwaitTweener> tween_await(const Signal &p_signal);
+	RequiredResult<AssignTweener> tween_assign(RequiredParam<const Object> rp_target, const NodePath &p_property, Variant p_new_val);
 	void append(Ref<Tweener> p_tweener);
 
 	bool custom_step(double p_delta);
@@ -354,4 +356,26 @@ private:
 	void _signal_received(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
 	Ref<RefCounted> ref_copy;
+};
+
+class AssignTweener : public Tweener {
+	GDCLASS(AssignTweener, Tweener);
+
+	ObjectID target;
+	Vector<StringName> property;
+	Variant new_val;
+	double delay = 0;
+
+	Ref<RefCounted> ref_copy;
+
+protected:
+	static void _bind_methods();
+
+public:
+	RequiredResult<AssignTweener> set_delay(double p_delay);
+
+	virtual bool step(double &r_delta) override;
+
+	AssignTweener(const Object *p_target, const Vector<StringName> &p_property, const Variant &p_new_val);
+	AssignTweener();
 };

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -583,6 +583,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(MethodTweener);
 	GDREGISTER_CLASS(SubtweenTweener);
 	GDREGISTER_CLASS(AwaitTweener);
+	GDREGISTER_CLASS(AssignTweener);
 
 	GDREGISTER_ABSTRACT_CLASS(AnimationMixer);
 	GDREGISTER_CLASS(AnimationPlayer);


### PR DESCRIPTION
closes https://github.com/godotengine/godot-proposals/issues/14270