### PR TITLE
Fix mute button after pausing and stopping

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1356,6 +1356,8 @@ void ScriptEditorDebugger::stop() {
 	visual_profiler->set_enabled(false);
 	visual_profiler->set_profiling(false);
 
+	audio_muted_on_break = false;
+
 	inspector->edit(nullptr);
 	_update_buttons_state();
 }


### PR DESCRIPTION
Fixes #116127

The problem was that an internal variable was not being reset correctly when the game was stopped.

* _Bugsquad edit: Supersedes #116382._