### PR TITLE
Include some headers explicitly in some important spots, to estimate include costs better.

### DIFF
--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/class_db.h"
+#include "core/object/object.h"
 #include "core/templates/safe_refcount.h"
 
 class RefCounted : public Object {

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/core_string_names.h"
+#include "core/error/error_macros.h"
 #include "core/io/ip_address.h"
 #include "core/math/aabb.h"
 #include "core/math/basis.h"
@@ -53,9 +54,11 @@
 #include "core/string/node_path.h"
 #include "core/string/ustring.h"
 #include "core/templates/bit_field.h"
+#include "core/templates/hashfuncs.h"
 #include "core/templates/list.h"
 #include "core/templates/paged_allocator.h"
 #include "core/templates/rid.h"
+#include "core/typedefs.h"
 #include "core/variant/array.h"
 #include "core/variant/callable.h"
 #include "core/variant/dictionary.h"

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -34,6 +34,7 @@
 #include "editor/inspector/editor_context_menu_plugin.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/gui/control.h"
+#include "scene/main/node.h"
 
 class Node3D;
 class Button;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/input/input_event.h"
+#include "core/object/object.h"
 #include "core/object/ref_counted.h"
 #include "core/string/node_path.h"
 #include "core/templates/iterable.h"


### PR DESCRIPTION
This is a bit of an odd PR, as it doesn't improve compile time per se.

However, it does help https://github.com/godotengine/godot/issues/111218 track include costs a bit better.

Because we use the "minimal includes pattern", some classes don't even explicitly include their direct ancestor. This diminishes the tracker's "understanding" of the relationship of these files: For example, it attributes the full transitive include cost of `object.h` in `ref_counted.h` through `class_db.h`, because it's included transitively through here. However, `ref_counted.h` will always need to include `object.h` because it is its superclass. Therefore, this attribution is misplaced.

By specifying these superclass includes explicitly, we help the tracker produce more faithful numbers. After this change, the top-costly header is no longer `class_db.h`, but `variant.h`, better representing where we need to make changes to reduce compile time.