### PR TITLE
Free RD resources asynchronously.

### DIFF
--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -239,7 +239,7 @@ public:
 		TUD *ud = memnew(TUD);
 		ud->instance = p_instance;
 		ud->method = p_method;
-		ud->userdata = p_userdata;
+		ud->userdata = std::move(p_userdata);
 		return _add_task(Callable(), nullptr, nullptr, ud, p_high_priority, p_description);
 	}
 	TaskID add_native_task(void (*p_func)(void *), void *p_userdata, bool p_high_priority = false, const String &p_description = String());

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -1883,27 +1883,8 @@ static const FLOAT RD_TO_D3D12_SAMPLER_BORDER_COLOR[RDD::SAMPLER_BORDER_COLOR_MA
 };
 
 RDD::SamplerID RenderingDeviceDriverD3D12::sampler_create(const SamplerState &p_state) {
-	uint32_t slot = UINT32_MAX;
-
-	if (samplers.is_empty()) {
-		// Adding a seemigly busy slot 0 makes things easier elsewhere.
-		samplers.push_back({});
-		samplers.push_back({});
-		slot = 1;
-	} else {
-		for (uint32_t i = 1; i < samplers.size(); i++) {
-			if ((int)samplers[i].Filter == INT_MAX) {
-				slot = i;
-				break;
-			}
-		}
-		if (slot == UINT32_MAX) {
-			slot = samplers.size();
-			samplers.push_back({});
-		}
-	}
-
-	D3D12_SAMPLER_DESC &sampler_desc = samplers[slot];
+	D3D12_SAMPLER_DESC *sampler_desc = VersatileResource::allocate<D3D12_SAMPLER_DESC>(resources_allocator);
+	*sampler_desc = {};
 
 	// D3D12 does not support anisotropic nearest filtering.
 	bool use_anisotropy = p_state.use_anisotropy && p_state.min_filter == RDD::SAMPLER_FILTER_LINEAR && p_state.mag_filter == RDD::SAMPLER_FILTER_LINEAR;
@@ -1918,47 +1899,48 @@ RDD::SamplerID RenderingDeviceDriverD3D12::sampler_create(const SamplerState &p_
 	if (use_anisotropy) {
 		if (p_state.mip_filter == RDD::SAMPLER_FILTER_NEAREST) {
 			// This path is never going to be taken if the capability is unsupported.
-			sampler_desc.Filter = D3D12_ENCODE_MIN_MAG_ANISOTROPIC_MIP_POINT_FILTER(reduction_type);
+			sampler_desc->Filter = D3D12_ENCODE_MIN_MAG_ANISOTROPIC_MIP_POINT_FILTER(reduction_type);
 		} else {
-			sampler_desc.Filter = D3D12_ENCODE_ANISOTROPIC_FILTER(reduction_type);
+			sampler_desc->Filter = D3D12_ENCODE_ANISOTROPIC_FILTER(reduction_type);
 		}
-		sampler_desc.MaxAnisotropy = p_state.anisotropy_max;
+		sampler_desc->MaxAnisotropy = p_state.anisotropy_max;
 	} else {
 		static const D3D12_FILTER_TYPE RD_FILTER_TYPE_TO_D3D12[] = {
 			D3D12_FILTER_TYPE_POINT, // SAMPLER_FILTER_NEAREST.
 			D3D12_FILTER_TYPE_LINEAR, // SAMPLER_FILTER_LINEAR.
 		};
-		sampler_desc.Filter = D3D12_ENCODE_BASIC_FILTER(
+		sampler_desc->Filter = D3D12_ENCODE_BASIC_FILTER(
 				RD_FILTER_TYPE_TO_D3D12[p_state.min_filter],
 				RD_FILTER_TYPE_TO_D3D12[p_state.mag_filter],
 				RD_FILTER_TYPE_TO_D3D12[p_state.mip_filter],
 				reduction_type);
 	}
 
-	sampler_desc.AddressU = RD_REPEAT_MODE_TO_D3D12_ADDRESS_MODE[p_state.repeat_u];
-	sampler_desc.AddressV = RD_REPEAT_MODE_TO_D3D12_ADDRESS_MODE[p_state.repeat_v];
-	sampler_desc.AddressW = RD_REPEAT_MODE_TO_D3D12_ADDRESS_MODE[p_state.repeat_w];
+	sampler_desc->AddressU = RD_REPEAT_MODE_TO_D3D12_ADDRESS_MODE[p_state.repeat_u];
+	sampler_desc->AddressV = RD_REPEAT_MODE_TO_D3D12_ADDRESS_MODE[p_state.repeat_v];
+	sampler_desc->AddressW = RD_REPEAT_MODE_TO_D3D12_ADDRESS_MODE[p_state.repeat_w];
 
 	for (int i = 0; i < 4; i++) {
-		sampler_desc.BorderColor[i] = RD_TO_D3D12_SAMPLER_BORDER_COLOR[p_state.border_color][i];
+		sampler_desc->BorderColor[i] = RD_TO_D3D12_SAMPLER_BORDER_COLOR[p_state.border_color][i];
 	}
 
-	sampler_desc.MinLOD = p_state.min_lod;
-	sampler_desc.MaxLOD = p_state.max_lod;
-	sampler_desc.MipLODBias = p_state.lod_bias;
+	sampler_desc->MinLOD = p_state.min_lod;
+	sampler_desc->MaxLOD = p_state.max_lod;
+	sampler_desc->MipLODBias = p_state.lod_bias;
 
-	sampler_desc.ComparisonFunc = p_state.enable_compare ? RD_TO_D3D12_COMPARE_OP[p_state.compare_op] : D3D12_COMPARISON_FUNC_NEVER;
+	sampler_desc->ComparisonFunc = p_state.enable_compare ? RD_TO_D3D12_COMPARE_OP[p_state.compare_op] : D3D12_COMPARISON_FUNC_NEVER;
 
 	// TODO: Emulate somehow?
 	if (p_state.unnormalized_uvw) {
 		WARN_PRINT("Creating a sampler with unnormalized UVW, which is not supported.");
 	}
 
-	return SamplerID(slot);
+	return SamplerID(sampler_desc);
 }
 
 void RenderingDeviceDriverD3D12::sampler_free(SamplerID p_sampler) {
-	samplers[p_sampler.id].Filter = (D3D12_FILTER)INT_MAX;
+	D3D12_SAMPLER_DESC *sampler_desc = (D3D12_SAMPLER_DESC *)p_sampler.id;
+	VersatileResource::free(resources_allocator, sampler_desc);
 }
 
 bool RenderingDeviceDriverD3D12::sampler_is_format_supported_for_filter(DataFormat p_format, SamplerFilter p_filter) {
@@ -3380,6 +3362,8 @@ RDD::UniformSetID RenderingDeviceDriverD3D12::uniform_set_create(VectorView<Boun
 
 	// Allocate range for resource descriptors.
 	if (uniform_set.resource_descriptor_count > 0) {
+		MutexLock lock(resource_descriptor_heap_mutex);
+
 		Error err = resource_descriptor_heap.allocate(uniform_set.resource_descriptor_count, uniform_set_info->resource_descriptor_heap_alloc);
 		if (unlikely(err != OK)) {
 			VersatileResource::free(resources_allocator, uniform_set_info);
@@ -3414,6 +3398,8 @@ RDD::UniformSetID RenderingDeviceDriverD3D12::uniform_set_create(VectorView<Boun
 			}
 		}
 		sampler_key = hash_fmix32(sampler_key);
+
+		MutexLock lock(sampler_descriptor_heap_mutex);
 
 		RBMap<uint32_t, SamplerDescriptorHeapAllocation>::Iterator find_result = sampler_descriptor_heap_allocations.find(sampler_key);
 		if (find_result != sampler_descriptor_heap_allocations.end()) {
@@ -3453,16 +3439,16 @@ RDD::UniformSetID RenderingDeviceDriverD3D12::uniform_set_create(VectorView<Boun
 			case UNIFORM_TYPE_SAMPLER: {
 				if (create_samplers) {
 					for (uint32_t j = 0; j < uniform.ids.size(); j++) {
-						const D3D12_SAMPLER_DESC &sampler_desc = samplers[uniform.ids[j].id];
-						device->CreateSampler(&sampler_desc, get_cpu_handle(uniform_set_info->sampler_descriptor_heap_alloc->cpu_handle, binding.sampler_descriptor_offset + j, sampler_descriptor_heap.increment_size));
+						const D3D12_SAMPLER_DESC *sampler_desc = (const D3D12_SAMPLER_DESC *)uniform.ids[j].id;
+						device->CreateSampler(sampler_desc, get_cpu_handle(uniform_set_info->sampler_descriptor_heap_alloc->cpu_handle, binding.sampler_descriptor_offset + j, sampler_descriptor_heap.increment_size));
 					}
 				}
 			} break;
 			case UNIFORM_TYPE_SAMPLER_WITH_TEXTURE: {
 				for (uint32_t j = 0; j < uniform.ids.size(); j += 2) {
 					if (create_samplers) {
-						const D3D12_SAMPLER_DESC &sampler_desc = samplers[uniform.ids[j].id];
-						device->CreateSampler(&sampler_desc, get_cpu_handle(uniform_set_info->sampler_descriptor_heap_alloc->cpu_handle, binding.sampler_descriptor_offset + (j / 2), sampler_descriptor_heap.increment_size));
+						const D3D12_SAMPLER_DESC *sampler_desc = (const D3D12_SAMPLER_DESC *)uniform.ids[j].id;
+						device->CreateSampler(sampler_desc, get_cpu_handle(uniform_set_info->sampler_descriptor_heap_alloc->cpu_handle, binding.sampler_descriptor_offset + (j / 2), sampler_descriptor_heap.increment_size));
 					}
 
 					TextureInfo *texture_info = (TextureInfo *)uniform.ids[j + 1].id;
@@ -3616,9 +3602,15 @@ RDD::UniformSetID RenderingDeviceDriverD3D12::uniform_set_create(VectorView<Boun
 void RenderingDeviceDriverD3D12::uniform_set_free(UniformSetID p_uniform_set) {
 	UniformSetInfo *uniform_set_info = (UniformSetInfo *)p_uniform_set.id;
 
-	resource_descriptor_heap.free(uniform_set_info->resource_descriptor_heap_alloc);
+	if (uniform_set_info->resource_descriptor_heap_alloc.virtual_alloc_handle != 0) {
+		MutexLock lock(resource_descriptor_heap_mutex);
+
+		resource_descriptor_heap.free(uniform_set_info->resource_descriptor_heap_alloc);
+	}
 
 	if (uniform_set_info->sampler_descriptor_heap_alloc != nullptr) {
+		MutexLock lock(sampler_descriptor_heap_mutex);
+
 		if ((--uniform_set_info->sampler_descriptor_heap_alloc->use_count) == 0) {
 			sampler_descriptor_heap.free(*uniform_set_info->sampler_descriptor_heap_alloc);
 			sampler_descriptor_heap_allocations.erase(uniform_set_info->sampler_descriptor_heap_alloc->key);
@@ -3806,7 +3798,13 @@ RenderingDeviceDriverD3D12::DescriptorHeap::Allocation RenderingDeviceDriverD3D1
 	} else {
 		DescriptorHeap::Allocation descriptor_allocation = {};
 
-		Error err = resource_descriptor_heap.allocate(1, descriptor_allocation);
+		Error err;
+		{
+			MutexLock lock(resource_descriptor_heap_mutex);
+
+			err = resource_descriptor_heap.allocate(1, descriptor_allocation);
+		}
+
 		ERR_FAIL_COND_V_MSG(err == ERR_OUT_OF_MEMORY, DescriptorHeap::Allocation(), "Cannot allocate per frame descriptor because there's not enough room in the RESOURCES descriptor heap.\n"
 																					"Please increase the value of the rendering/rendering_device/d3d12/max_resource_descriptors project setting.");
 

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -2022,27 +2022,8 @@ static const FLOAT RD_TO_D3D12_SAMPLER_BORDER_COLOR[RDD::SAMPLER_BORDER_COLOR_MA
 };
 
 RDD::SamplerID RenderingDeviceDriverD3D12::sampler_create(const SamplerState &p_state) {
-	uint32_t slot = UINT32_MAX;
-
-	if (samplers.is_empty()) {
-		// Adding a seemigly busy slot 0 makes things easier elsewhere.
-		samplers.push_back({});
-		samplers.push_back({});
-		slot = 1;
-	} else {
-		for (uint32_t i = 1; i < samplers.size(); i++) {
-			if ((int)samplers[i].Filter == INT_MAX) {
-				slot = i;
-				break;
-			}
-		}
-		if (slot == UINT32_MAX) {
-			slot = samplers.size();
-			samplers.push_back({});
-		}
-	}
-
-	D3D12_SAMPLER_DESC &sampler_desc = samplers[slot];
+	D3D12_SAMPLER_DESC *sampler_desc = VersatileResource::allocate<D3D12_SAMPLER_DESC>(resources_allocator);
+	*sampler_desc = {};
 
 	// D3D12 does not support anisotropic nearest filtering.
 	bool use_anisotropy = p_state.use_anisotropy && p_state.min_filter == RDD::SAMPLER_FILTER_LINEAR && p_state.mag_filter == RDD::SAMPLER_FILTER_LINEAR;
@@ -2057,47 +2038,48 @@ RDD::SamplerID RenderingDeviceDriverD3D12::sampler_create(const SamplerState &p_
 	if (use_anisotropy) {
 		if (p_state.mip_filter == RDD::SAMPLER_FILTER_NEAREST) {
 			// This path is never going to be taken if the capability is unsupported.
-			sampler_desc.Filter = D3D12_ENCODE_MIN_MAG_ANISOTROPIC_MIP_POINT_FILTER(reduction_type);
+			sampler_desc->Filter = D3D12_ENCODE_MIN_MAG_ANISOTROPIC_MIP_POINT_FILTER(reduction_type);
 		} else {
-			sampler_desc.Filter = D3D12_ENCODE_ANISOTROPIC_FILTER(reduction_type);
+			sampler_desc->Filter = D3D12_ENCODE_ANISOTROPIC_FILTER(reduction_type);
 		}
-		sampler_desc.MaxAnisotropy = p_state.anisotropy_max;
+		sampler_desc->MaxAnisotropy = p_state.anisotropy_max;
 	} else {
 		static const D3D12_FILTER_TYPE RD_FILTER_TYPE_TO_D3D12[] = {
 			D3D12_FILTER_TYPE_POINT, // SAMPLER_FILTER_NEAREST.
 			D3D12_FILTER_TYPE_LINEAR, // SAMPLER_FILTER_LINEAR.
 		};
-		sampler_desc.Filter = D3D12_ENCODE_BASIC_FILTER(
+		sampler_desc->Filter = D3D12_ENCODE_BASIC_FILTER(
 				RD_FILTER_TYPE_TO_D3D12[p_state.min_filter],
 				RD_FILTER_TYPE_TO_D3D12[p_state.mag_filter],
 				RD_FILTER_TYPE_TO_D3D12[p_state.mip_filter],
 				reduction_type);
 	}
 
-	sampler_desc.AddressU = RD_REPEAT_MODE_TO_D3D12_ADDRESS_MODE[p_state.repeat_u];
-	sampler_desc.AddressV = RD_REPEAT_MODE_TO_D3D12_ADDRESS_MODE[p_state.repeat_v];
-	sampler_desc.AddressW = RD_REPEAT_MODE_TO_D3D12_ADDRESS_MODE[p_state.repeat_w];
+	sampler_desc->AddressU = RD_REPEAT_MODE_TO_D3D12_ADDRESS_MODE[p_state.repeat_u];
+	sampler_desc->AddressV = RD_REPEAT_MODE_TO_D3D12_ADDRESS_MODE[p_state.repeat_v];
+	sampler_desc->AddressW = RD_REPEAT_MODE_TO_D3D12_ADDRESS_MODE[p_state.repeat_w];
 
 	for (int i = 0; i < 4; i++) {
-		sampler_desc.BorderColor[i] = RD_TO_D3D12_SAMPLER_BORDER_COLOR[p_state.border_color][i];
+		sampler_desc->BorderColor[i] = RD_TO_D3D12_SAMPLER_BORDER_COLOR[p_state.border_color][i];
 	}
 
-	sampler_desc.MinLOD = p_state.min_lod;
-	sampler_desc.MaxLOD = p_state.max_lod;
-	sampler_desc.MipLODBias = p_state.lod_bias;
+	sampler_desc->MinLOD = p_state.min_lod;
+	sampler_desc->MaxLOD = p_state.max_lod;
+	sampler_desc->MipLODBias = p_state.lod_bias;
 
-	sampler_desc.ComparisonFunc = p_state.enable_compare ? RD_TO_D3D12_COMPARE_OP[p_state.compare_op] : D3D12_COMPARISON_FUNC_NEVER;
+	sampler_desc->ComparisonFunc = p_state.enable_compare ? RD_TO_D3D12_COMPARE_OP[p_state.compare_op] : D3D12_COMPARISON_FUNC_NEVER;
 
 	// TODO: Emulate somehow?
 	if (p_state.unnormalized_uvw) {
 		WARN_PRINT("Creating a sampler with unnormalized UVW, which is not supported.");
 	}
 
-	return SamplerID(slot);
+	return SamplerID(sampler_desc);
 }
 
 void RenderingDeviceDriverD3D12::sampler_free(SamplerID p_sampler) {
-	samplers[p_sampler.id].Filter = (D3D12_FILTER)INT_MAX;
+	D3D12_SAMPLER_DESC *sampler_desc = (D3D12_SAMPLER_DESC *)p_sampler.id;
+	VersatileResource::free(resources_allocator, sampler_desc);
 }
 
 bool RenderingDeviceDriverD3D12::sampler_is_format_supported_for_filter(DataFormat p_format, SamplerFilter p_filter) {
@@ -3618,16 +3600,16 @@ RDD::UniformSetID RenderingDeviceDriverD3D12::uniform_set_create(VectorView<Boun
 			case UNIFORM_TYPE_SAMPLER: {
 				if (create_samplers) {
 					for (uint32_t j = 0; j < uniform.ids.size(); j++) {
-						const D3D12_SAMPLER_DESC &sampler_desc = samplers[uniform.ids[j].id];
-						device->CreateSampler(&sampler_desc, get_cpu_handle(uniform_set_info->sampler_descriptor_heap_alloc->cpu_handle, binding.sampler_descriptor_offset + j, sampler_descriptor_heap.increment_size));
+						const D3D12_SAMPLER_DESC *sampler_desc = (const D3D12_SAMPLER_DESC *)uniform.ids[j].id;
+						device->CreateSampler(sampler_desc, get_cpu_handle(uniform_set_info->sampler_descriptor_heap_alloc->cpu_handle, binding.sampler_descriptor_offset + j, sampler_descriptor_heap.increment_size));
 					}
 				}
 			} break;
 			case UNIFORM_TYPE_SAMPLER_WITH_TEXTURE: {
 				for (uint32_t j = 0; j < uniform.ids.size(); j += 2) {
 					if (create_samplers) {
-						const D3D12_SAMPLER_DESC &sampler_desc = samplers[uniform.ids[j].id];
-						device->CreateSampler(&sampler_desc, get_cpu_handle(uniform_set_info->sampler_descriptor_heap_alloc->cpu_handle, binding.sampler_descriptor_offset + (j / 2), sampler_descriptor_heap.increment_size));
+						const D3D12_SAMPLER_DESC *sampler_desc = (const D3D12_SAMPLER_DESC *)uniform.ids[j].id;
+						device->CreateSampler(sampler_desc, get_cpu_handle(uniform_set_info->sampler_descriptor_heap_alloc->cpu_handle, binding.sampler_descriptor_offset + (j / 2), sampler_descriptor_heap.increment_size));
 					}
 
 					TextureInfo *texture_info = (TextureInfo *)uniform.ids[j + 1].id;

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -168,7 +168,11 @@ class RenderingDeviceDriverD3D12 : public RenderingDeviceDriver {
 	};
 
 	DescriptorHeap resource_descriptor_heap;
+	BinaryMutex resource_descriptor_heap_mutex;
+
 	DescriptorHeap sampler_descriptor_heap;
+	BinaryMutex sampler_descriptor_heap_mutex;
+
 	CPUDescriptorHeapPool resource_descriptor_heap_pool;
 	CPUDescriptorHeapPool rtv_descriptor_heap_pool;
 	CPUDescriptorHeapPool dsv_descriptor_heap_pool;
@@ -336,8 +340,6 @@ public:
 	/**** SAMPLER ****/
 	/*****************/
 private:
-	LocalVector<D3D12_SAMPLER_DESC> samplers;
-
 	struct SamplerDescriptorHeapAllocation : DescriptorHeap::Allocation {
 		uint32_t key = 0;
 		uint32_t use_count = 1;
@@ -945,9 +947,9 @@ private:
 
 	using VersatileResource = VersatileResourceTemplate<
 			BufferInfo,
+			BufferDynamicInfo,
 			TextureInfo,
-			TextureInfo,
-			TextureInfo,
+			D3D12_SAMPLER_DESC,
 			VertexFormatInfo,
 			CommandBufferInfo,
 			FramebufferInfo,

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -356,8 +356,6 @@ public:
 	/**** SAMPLER ****/
 	/*****************/
 private:
-	LocalVector<D3D12_SAMPLER_DESC> samplers;
-
 	struct SamplerDescriptorHeapAllocation : DescriptorHeap::Allocation {
 		uint32_t key = 0;
 		uint32_t use_count = 1;
@@ -966,9 +964,9 @@ private:
 
 	using VersatileResource = VersatileResourceTemplate<
 			BufferInfo,
+			BufferDynamicInfo,
 			TextureInfo,
-			TextureInfo,
-			TextureInfo,
+			D3D12_SAMPLER_DESC,
 			VertexFormatInfo,
 			CommandBufferInfo,
 			FramebufferInfo,

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -4645,22 +4645,6 @@ VkDescriptorPool RenderingDeviceDriverVulkan::_descriptor_set_pool_create(const 
 	return vk_pool;
 }
 
-void RenderingDeviceDriverVulkan::_descriptor_set_pool_unreference(DescriptorSetPools::Iterator p_pool_sets_it, VkDescriptorPool p_vk_descriptor_pool, int p_linear_pool_index) {
-	HashMap<VkDescriptorPool, uint32_t>::Iterator pool_rcs_it = p_pool_sets_it->value.find(p_vk_descriptor_pool);
-	pool_rcs_it->value--;
-	if (pool_rcs_it->value == 0) {
-		vkDestroyDescriptorPool(vk_device, p_vk_descriptor_pool, VKC::get_allocation_callbacks(VK_OBJECT_TYPE_DESCRIPTOR_POOL));
-		p_pool_sets_it->value.erase(p_vk_descriptor_pool);
-		if (p_pool_sets_it->value.is_empty()) {
-			if (linear_descriptor_pools_enabled && p_linear_pool_index >= 0) {
-				linear_descriptor_set_pools[p_linear_pool_index].remove(p_pool_sets_it);
-			} else {
-				descriptor_set_pools.remove(p_pool_sets_it);
-			}
-		}
-	}
-}
-
 RDD::UniformSetID RenderingDeviceDriverVulkan::uniform_set_create(VectorView<BoundUniform> p_uniforms, ShaderID p_shader, uint32_t p_set_index, int p_linear_pool_index) {
 	if (!linear_descriptor_pools_enabled) {
 		p_linear_pool_index = -1;
@@ -4901,14 +4885,8 @@ RDD::UniformSetID RenderingDeviceDriverVulkan::uniform_set_create(VectorView<Bou
 	}
 
 	bool linear_pool = p_linear_pool_index >= 0;
-	DescriptorSetPools::Iterator pool_sets_it = linear_pool ? linear_descriptor_set_pools[p_linear_pool_index].find(pool_key) : descriptor_set_pools.find(pool_key);
-	if (!pool_sets_it) {
-		if (linear_pool) {
-			pool_sets_it = linear_descriptor_set_pools[p_linear_pool_index].insert(pool_key, HashMap<VkDescriptorPool, uint32_t>());
-		} else {
-			pool_sets_it = descriptor_set_pools.insert(pool_key, HashMap<VkDescriptorPool, uint32_t>());
-		}
-	}
+	DescriptorSetPools::Iterator pool_sets_it;
+	VkDescriptorSet vk_descriptor_set = VK_NULL_HANDLE;
 
 	VkDescriptorSetAllocateInfo descriptor_set_allocate_info = {};
 	descriptor_set_allocate_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -4916,38 +4894,64 @@ RDD::UniformSetID RenderingDeviceDriverVulkan::uniform_set_create(VectorView<Bou
 	const ShaderInfo *shader_info = (const ShaderInfo *)p_shader.id;
 	descriptor_set_allocate_info.pSetLayouts = &shader_info->vk_descriptor_set_layouts[p_set_index];
 
-	VkDescriptorSet vk_descriptor_set = VK_NULL_HANDLE;
-	for (KeyValue<VkDescriptorPool, uint32_t> &E : pool_sets_it->value) {
-		if (E.value < max_descriptor_sets_per_pool) {
-			descriptor_set_allocate_info.descriptorPool = E.key;
+	{
+		struct MutexHolder {
+			BinaryMutex *mutex = nullptr;
+
+			~MutexHolder() {
+				if (mutex != nullptr) {
+					mutex->unlock();
+				}
+			}
+		} mutex_holder;
+
+		// Linear pools do not need to hold a mutex.
+		if (!linear_pool) {
+			mutex_holder.mutex = &descriptor_set_pool_mutex;
+			descriptor_set_pool_mutex.lock();
+		}
+
+		pool_sets_it = linear_pool ? linear_descriptor_set_pools[p_linear_pool_index].find(pool_key) : descriptor_set_pools.find(pool_key);
+		if (!pool_sets_it) {
+			if (linear_pool) {
+				pool_sets_it = linear_descriptor_set_pools[p_linear_pool_index].insert(pool_key, HashMap<VkDescriptorPool, uint32_t>());
+			} else {
+				pool_sets_it = descriptor_set_pools.insert(pool_key, HashMap<VkDescriptorPool, uint32_t>());
+			}
+		}
+
+		for (KeyValue<VkDescriptorPool, uint32_t> &E : pool_sets_it->value) {
+			if (E.value < max_descriptor_sets_per_pool) {
+				descriptor_set_allocate_info.descriptorPool = E.key;
+				VkResult res = vkAllocateDescriptorSets(vk_device, &descriptor_set_allocate_info, &vk_descriptor_set);
+
+				// Break early on success.
+				if (res == VK_SUCCESS) {
+					break;
+				}
+
+				// "Fragmented pool" and "out of pool memory" errors are handled by creating more pools. Any other error is unexpected.
+				if (res != VK_ERROR_FRAGMENTED_POOL && res != VK_ERROR_OUT_OF_POOL_MEMORY) {
+					ERR_FAIL_V_MSG(UniformSetID(), vformat("Couldn't allocate Vulkan descriptor sets (VkResult error %d).", res));
+				}
+			}
+		}
+
+		// Create a new pool when no allocations could be made from the existing pools.
+		if (vk_descriptor_set == VK_NULL_HANDLE) {
+			descriptor_set_allocate_info.descriptorPool = _descriptor_set_pool_create(pool_key, linear_pool);
 			VkResult res = vkAllocateDescriptorSets(vk_device, &descriptor_set_allocate_info, &vk_descriptor_set);
 
-			// Break early on success.
-			if (res == VK_SUCCESS) {
-				break;
-			}
-
-			// "Fragmented pool" and "out of memory pool" errors are handled by creating more pools. Any other error is unexpected.
-			if (res != VK_ERROR_FRAGMENTED_POOL && res != VK_ERROR_OUT_OF_POOL_MEMORY) {
+			// All errors are unexpected at this stage.
+			if (res) {
+				vkDestroyDescriptorPool(vk_device, descriptor_set_allocate_info.descriptorPool, VKC::get_allocation_callbacks(VK_OBJECT_TYPE_DESCRIPTOR_POOL));
 				ERR_FAIL_V_MSG(UniformSetID(), vformat("Couldn't allocate Vulkan descriptor sets (VkResult error %d).", res));
 			}
 		}
+
+		DEV_ASSERT(descriptor_set_allocate_info.descriptorPool != VK_NULL_HANDLE && vk_descriptor_set != VK_NULL_HANDLE);
+		pool_sets_it->value[descriptor_set_allocate_info.descriptorPool]++;
 	}
-
-	// Create a new pool when no allocations could be made from the existing pools.
-	if (vk_descriptor_set == VK_NULL_HANDLE) {
-		descriptor_set_allocate_info.descriptorPool = _descriptor_set_pool_create(pool_key, linear_pool);
-		VkResult res = vkAllocateDescriptorSets(vk_device, &descriptor_set_allocate_info, &vk_descriptor_set);
-
-		// All errors are unexpected at this stage.
-		if (res) {
-			vkDestroyDescriptorPool(vk_device, descriptor_set_allocate_info.descriptorPool, VKC::get_allocation_callbacks(VK_OBJECT_TYPE_DESCRIPTOR_POOL));
-			ERR_FAIL_V_MSG(UniformSetID(), vformat("Couldn't allocate Vulkan descriptor sets (VkResult error %d).", res));
-		}
-	}
-
-	DEV_ASSERT(descriptor_set_allocate_info.descriptorPool != VK_NULL_HANDLE && vk_descriptor_set != VK_NULL_HANDLE);
-	pool_sets_it->value[descriptor_set_allocate_info.descriptorPool]++;
 
 	for (uint32_t i = 0; i < writes_amount; i++) {
 		vk_writes[i].dstSet = vk_descriptor_set;
@@ -4958,7 +4962,7 @@ RDD::UniformSetID RenderingDeviceDriverVulkan::uniform_set_create(VectorView<Bou
 
 	UniformSetInfo *usi = VersatileResource::allocate<UniformSetInfo>(resources_allocator);
 	usi->vk_descriptor_set = vk_descriptor_set;
-	if (p_linear_pool_index >= 0) {
+	if (linear_pool) {
 		usi->vk_linear_descriptor_pool = descriptor_set_allocate_info.descriptorPool;
 	} else {
 		usi->vk_descriptor_pool = descriptor_set_allocate_info.descriptorPool;
@@ -4983,8 +4987,26 @@ void RenderingDeviceDriverVulkan::uniform_set_free(UniformSetID p_uniform_set) {
 		// _descriptor_set_pool_find_or_create() need usi->pool_sets_it->value to stay so that we can
 		// tell if the pool has ran out of space and we need to create a new pool.
 	} else {
-		vkFreeDescriptorSets(vk_device, usi->vk_descriptor_pool, 1, &usi->vk_descriptor_set);
-		_descriptor_set_pool_unreference(usi->pool_sets_it, usi->vk_descriptor_pool, -1);
+		bool should_destroy_descriptor_pool = false;
+		{
+			MutexLock lock(descriptor_set_pool_mutex);
+			vkFreeDescriptorSets(vk_device, usi->vk_descriptor_pool, 1, &usi->vk_descriptor_set);
+
+			HashMap<VkDescriptorPool, uint32_t>::Iterator pool_rcs_it = usi->pool_sets_it->value.find(usi->vk_descriptor_pool);
+			pool_rcs_it->value--;
+			if (pool_rcs_it->value == 0) {
+				should_destroy_descriptor_pool = true;
+
+				usi->pool_sets_it->value.erase(usi->vk_descriptor_pool);
+				if (usi->pool_sets_it->value.is_empty()) {
+					descriptor_set_pools.remove(usi->pool_sets_it);
+				}
+			}
+		}
+
+		if (should_destroy_descriptor_pool) {
+			vkDestroyDescriptorPool(vk_device, usi->vk_descriptor_pool, VKC::get_allocation_callbacks(VK_OBJECT_TYPE_DESCRIPTOR_POOL));
+		}
 	}
 
 	VersatileResource::free(resources_allocator, usi);

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -4694,22 +4694,6 @@ VkDescriptorPool RenderingDeviceDriverVulkan::_descriptor_set_pool_create(const 
 	return vk_pool;
 }
 
-void RenderingDeviceDriverVulkan::_descriptor_set_pool_unreference(DescriptorSetPools::Iterator p_pool_sets_it, VkDescriptorPool p_vk_descriptor_pool, int p_linear_pool_index) {
-	HashMap<VkDescriptorPool, uint32_t>::Iterator pool_rcs_it = p_pool_sets_it->value.find(p_vk_descriptor_pool);
-	pool_rcs_it->value--;
-	if (pool_rcs_it->value == 0) {
-		vkDestroyDescriptorPool(vk_device, p_vk_descriptor_pool, VKC::get_allocation_callbacks(VK_OBJECT_TYPE_DESCRIPTOR_POOL));
-		p_pool_sets_it->value.erase(p_vk_descriptor_pool);
-		if (p_pool_sets_it->value.is_empty()) {
-			if (linear_descriptor_pools_enabled && p_linear_pool_index >= 0) {
-				linear_descriptor_set_pools[p_linear_pool_index].remove(p_pool_sets_it);
-			} else {
-				descriptor_set_pools.remove(p_pool_sets_it);
-			}
-		}
-	}
-}
-
 RDD::UniformSetID RenderingDeviceDriverVulkan::uniform_set_create(VectorView<BoundUniform> p_uniforms, ShaderID p_shader, uint32_t p_set_index, int p_linear_pool_index) {
 	if (!linear_descriptor_pools_enabled) {
 		p_linear_pool_index = -1;
@@ -4950,14 +4934,8 @@ RDD::UniformSetID RenderingDeviceDriverVulkan::uniform_set_create(VectorView<Bou
 	}
 
 	bool linear_pool = p_linear_pool_index >= 0;
-	DescriptorSetPools::Iterator pool_sets_it = linear_pool ? linear_descriptor_set_pools[p_linear_pool_index].find(pool_key) : descriptor_set_pools.find(pool_key);
-	if (!pool_sets_it) {
-		if (linear_pool) {
-			pool_sets_it = linear_descriptor_set_pools[p_linear_pool_index].insert(pool_key, HashMap<VkDescriptorPool, uint32_t>());
-		} else {
-			pool_sets_it = descriptor_set_pools.insert(pool_key, HashMap<VkDescriptorPool, uint32_t>());
-		}
-	}
+	DescriptorSetPools::Iterator pool_sets_it;
+	VkDescriptorSet vk_descriptor_set = VK_NULL_HANDLE;
 
 	VkDescriptorSetAllocateInfo descriptor_set_allocate_info = {};
 	descriptor_set_allocate_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -4965,38 +4943,64 @@ RDD::UniformSetID RenderingDeviceDriverVulkan::uniform_set_create(VectorView<Bou
 	const ShaderInfo *shader_info = (const ShaderInfo *)p_shader.id;
 	descriptor_set_allocate_info.pSetLayouts = &shader_info->vk_descriptor_set_layouts[p_set_index];
 
-	VkDescriptorSet vk_descriptor_set = VK_NULL_HANDLE;
-	for (KeyValue<VkDescriptorPool, uint32_t> &E : pool_sets_it->value) {
-		if (E.value < max_descriptor_sets_per_pool) {
-			descriptor_set_allocate_info.descriptorPool = E.key;
+	{
+		struct MutexHolder {
+			BinaryMutex *mutex = nullptr;
+
+			~MutexHolder() {
+				if (mutex != nullptr) {
+					mutex->unlock();
+				}
+			}
+		} mutex_holder;
+
+		// Linear pools do not need to hold a mutex.
+		if (!linear_pool) {
+			mutex_holder.mutex = &descriptor_set_pool_mutex;
+			descriptor_set_pool_mutex.lock();
+		}
+
+		pool_sets_it = linear_pool ? linear_descriptor_set_pools[p_linear_pool_index].find(pool_key) : descriptor_set_pools.find(pool_key);
+		if (!pool_sets_it) {
+			if (linear_pool) {
+				pool_sets_it = linear_descriptor_set_pools[p_linear_pool_index].insert(pool_key, HashMap<VkDescriptorPool, uint32_t>());
+			} else {
+				pool_sets_it = descriptor_set_pools.insert(pool_key, HashMap<VkDescriptorPool, uint32_t>());
+			}
+		}
+
+		for (KeyValue<VkDescriptorPool, uint32_t> &E : pool_sets_it->value) {
+			if (E.value < max_descriptor_sets_per_pool) {
+				descriptor_set_allocate_info.descriptorPool = E.key;
+				VkResult res = vkAllocateDescriptorSets(vk_device, &descriptor_set_allocate_info, &vk_descriptor_set);
+
+				// Break early on success.
+				if (res == VK_SUCCESS) {
+					break;
+				}
+
+				// "Fragmented pool" and "out of pool memory" errors are handled by creating more pools. Any other error is unexpected.
+				if (res != VK_ERROR_FRAGMENTED_POOL && res != VK_ERROR_OUT_OF_POOL_MEMORY) {
+					ERR_FAIL_V_MSG(UniformSetID(), vformat("Couldn't allocate Vulkan descriptor sets (VkResult error %d).", res));
+				}
+			}
+		}
+
+		// Create a new pool when no allocations could be made from the existing pools.
+		if (vk_descriptor_set == VK_NULL_HANDLE) {
+			descriptor_set_allocate_info.descriptorPool = _descriptor_set_pool_create(pool_key, linear_pool);
 			VkResult res = vkAllocateDescriptorSets(vk_device, &descriptor_set_allocate_info, &vk_descriptor_set);
 
-			// Break early on success.
-			if (res == VK_SUCCESS) {
-				break;
-			}
-
-			// "Fragmented pool" and "out of memory pool" errors are handled by creating more pools. Any other error is unexpected.
-			if (res != VK_ERROR_FRAGMENTED_POOL && res != VK_ERROR_OUT_OF_POOL_MEMORY) {
+			// All errors are unexpected at this stage.
+			if (res) {
+				vkDestroyDescriptorPool(vk_device, descriptor_set_allocate_info.descriptorPool, VKC::get_allocation_callbacks(VK_OBJECT_TYPE_DESCRIPTOR_POOL));
 				ERR_FAIL_V_MSG(UniformSetID(), vformat("Couldn't allocate Vulkan descriptor sets (VkResult error %d).", res));
 			}
 		}
+
+		DEV_ASSERT(descriptor_set_allocate_info.descriptorPool != VK_NULL_HANDLE && vk_descriptor_set != VK_NULL_HANDLE);
+		pool_sets_it->value[descriptor_set_allocate_info.descriptorPool]++;
 	}
-
-	// Create a new pool when no allocations could be made from the existing pools.
-	if (vk_descriptor_set == VK_NULL_HANDLE) {
-		descriptor_set_allocate_info.descriptorPool = _descriptor_set_pool_create(pool_key, linear_pool);
-		VkResult res = vkAllocateDescriptorSets(vk_device, &descriptor_set_allocate_info, &vk_descriptor_set);
-
-		// All errors are unexpected at this stage.
-		if (res) {
-			vkDestroyDescriptorPool(vk_device, descriptor_set_allocate_info.descriptorPool, VKC::get_allocation_callbacks(VK_OBJECT_TYPE_DESCRIPTOR_POOL));
-			ERR_FAIL_V_MSG(UniformSetID(), vformat("Couldn't allocate Vulkan descriptor sets (VkResult error %d).", res));
-		}
-	}
-
-	DEV_ASSERT(descriptor_set_allocate_info.descriptorPool != VK_NULL_HANDLE && vk_descriptor_set != VK_NULL_HANDLE);
-	pool_sets_it->value[descriptor_set_allocate_info.descriptorPool]++;
 
 	for (uint32_t i = 0; i < writes_amount; i++) {
 		vk_writes[i].dstSet = vk_descriptor_set;
@@ -5007,7 +5011,7 @@ RDD::UniformSetID RenderingDeviceDriverVulkan::uniform_set_create(VectorView<Bou
 
 	UniformSetInfo *usi = VersatileResource::allocate<UniformSetInfo>(resources_allocator);
 	usi->vk_descriptor_set = vk_descriptor_set;
-	if (p_linear_pool_index >= 0) {
+	if (linear_pool) {
 		usi->vk_linear_descriptor_pool = descriptor_set_allocate_info.descriptorPool;
 	} else {
 		usi->vk_descriptor_pool = descriptor_set_allocate_info.descriptorPool;
@@ -5032,8 +5036,26 @@ void RenderingDeviceDriverVulkan::uniform_set_free(UniformSetID p_uniform_set) {
 		// _descriptor_set_pool_find_or_create() need usi->pool_sets_it->value to stay so that we can
 		// tell if the pool has ran out of space and we need to create a new pool.
 	} else {
-		vkFreeDescriptorSets(vk_device, usi->vk_descriptor_pool, 1, &usi->vk_descriptor_set);
-		_descriptor_set_pool_unreference(usi->pool_sets_it, usi->vk_descriptor_pool, -1);
+		bool should_destroy_descriptor_pool = false;
+		{
+			MutexLock lock(descriptor_set_pool_mutex);
+			vkFreeDescriptorSets(vk_device, usi->vk_descriptor_pool, 1, &usi->vk_descriptor_set);
+
+			HashMap<VkDescriptorPool, uint32_t>::Iterator pool_rcs_it = usi->pool_sets_it->value.find(usi->vk_descriptor_pool);
+			pool_rcs_it->value--;
+			if (pool_rcs_it->value == 0) {
+				should_destroy_descriptor_pool = true;
+
+				usi->pool_sets_it->value.erase(usi->vk_descriptor_pool);
+				if (usi->pool_sets_it->value.is_empty()) {
+					descriptor_set_pools.remove(usi->pool_sets_it);
+				}
+			}
+		}
+
+		if (should_destroy_descriptor_pool) {
+			vkDestroyDescriptorPool(vk_device, usi->vk_descriptor_pool, VKC::get_allocation_callbacks(VK_OBJECT_TYPE_DESCRIPTOR_POOL));
+		}
 	}
 
 	VersatileResource::free(resources_allocator, usi);

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -531,12 +531,12 @@ private:
 
 	using DescriptorSetPools = RBMap<DescriptorSetPoolKey, HashMap<VkDescriptorPool, uint32_t>>;
 	DescriptorSetPools descriptor_set_pools;
+	BinaryMutex descriptor_set_pool_mutex;
 	uint32_t max_descriptor_sets_per_pool = 0;
 
 	HashMap<int, DescriptorSetPools> linear_descriptor_set_pools;
 	bool linear_descriptor_pools_enabled = true;
 	VkDescriptorPool _descriptor_set_pool_create(const DescriptorSetPoolKey &p_key, bool p_linear_pool);
-	void _descriptor_set_pool_unreference(DescriptorSetPools::Iterator p_pool_sets_it, VkDescriptorPool p_vk_descriptor_pool, int p_linear_pool_index);
 
 	// Global flag to toggle usage of immutable sampler when creating pipeline layouts.
 	// It cannot change after creating the PSOs, since we need to skipping samplers when creating uniform sets.

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -530,12 +530,12 @@ private:
 
 	using DescriptorSetPools = RBMap<DescriptorSetPoolKey, HashMap<VkDescriptorPool, uint32_t>>;
 	DescriptorSetPools descriptor_set_pools;
+	BinaryMutex descriptor_set_pool_mutex;
 	uint32_t max_descriptor_sets_per_pool = 0;
 
 	HashMap<int, DescriptorSetPools> linear_descriptor_set_pools;
 	bool linear_descriptor_pools_enabled = true;
 	VkDescriptorPool _descriptor_set_pool_create(const DescriptorSetPoolKey &p_key, bool p_linear_pool);
-	void _descriptor_set_pool_unreference(DescriptorSetPools::Iterator p_pool_sets_it, VkDescriptorPool p_vk_descriptor_pool, int p_linear_pool_index);
 
 	// Global flag to toggle usage of immutable sampler when creating pipeline layouts.
 	// It cannot change after creating the PSOs, since we need to skipping samplers when creating uniform sets.

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -259,7 +259,7 @@ Error RenderingDevice::_acceleration_structure_scratch_buffer_create(Acceleratio
 			to_dispose.driver_id = p_acceleration_structure->scratch_buffer;
 			DEV_ASSERT(scratch_buffer_size <= UINT32_MAX);
 			to_dispose.size = scratch_buffer_size;
-			frames[frame].buffers_to_dispose_of.push_back(to_dispose);
+			frames[frame].resources_to_dispose_of.buffers.push_back(to_dispose);
 			p_acceleration_structure->scratch_buffer = RDD::BufferID();
 		}
 	}
@@ -592,7 +592,7 @@ Error RenderingDevice::_hit_sbt_buffer_update(HitShaderBindingTable *p_hit_sbt, 
 		ERR_FAIL_COND_V(!buffer, ERR_CANT_CREATE);
 
 		RDG::resource_tracker_free(p_hit_sbt->draw_tracker);
-		frames[frame].buffers_to_dispose_of.push_back(*p_hit_sbt);
+		frames[frame].resources_to_dispose_of.buffers.push_back(*p_hit_sbt);
 
 		p_hit_sbt->driver_id = buffer;
 		p_hit_sbt->size = buffer_size;
@@ -7637,27 +7637,26 @@ void RenderingDevice::_free_internal(RID p_id) {
 			}
 		}
 
-		frames[frame].textures_to_dispose_of.push_back(*texture);
+		frames[frame].resources_to_dispose_of.textures.push_back(*texture);
 		texture_owner.free(p_id);
 	} else if (framebuffer_owner.owns(p_id)) {
 		Framebuffer *framebuffer = framebuffer_owner.get_or_null(p_id);
-		frames[frame].framebuffers_to_dispose_of.push_back(*framebuffer);
-
 		if (framebuffer->invalidated_callback != nullptr) {
 			framebuffer->invalidated_callback(framebuffer->invalidated_callback_userdata);
 		}
 
+		frames[frame].resources_to_dispose_of.framebuffers.push_back(*framebuffer);
 		framebuffer_owner.free(p_id);
 	} else if (sampler_owner.owns(p_id)) {
 		RDD::SamplerID sampler_driver_id = *sampler_owner.get_or_null(p_id);
-		frames[frame].samplers_to_dispose_of.push_back(sampler_driver_id);
+		frames[frame].resources_to_dispose_of.samplers.push_back(sampler_driver_id);
 		sampler_owner.free(p_id);
 	} else if (vertex_buffer_owner.owns(p_id)) {
 		Buffer *vertex_buffer = vertex_buffer_owner.get_or_null(p_id);
 		_check_transfer_worker_buffer(vertex_buffer);
 
 		RDG::resource_tracker_free(vertex_buffer->draw_tracker);
-		frames[frame].buffers_to_dispose_of.push_back(*vertex_buffer);
+		frames[frame].resources_to_dispose_of.buffers.push_back(*vertex_buffer);
 		vertex_buffer_owner.free(p_id);
 	} else if (vertex_array_owner.owns(p_id)) {
 		vertex_array_owner.free(p_id);
@@ -7666,14 +7665,14 @@ void RenderingDevice::_free_internal(RID p_id) {
 		_check_transfer_worker_buffer(index_buffer);
 
 		RDG::resource_tracker_free(index_buffer->draw_tracker);
-		frames[frame].buffers_to_dispose_of.push_back(*index_buffer);
+		frames[frame].resources_to_dispose_of.buffers.push_back(*index_buffer);
 		index_buffer_owner.free(p_id);
 	} else if (index_array_owner.owns(p_id)) {
 		index_array_owner.free(p_id);
 	} else if (shader_owner.owns(p_id)) {
 		Shader *shader = shader_owner.get_or_null(p_id);
 		if (shader->driver_id) { // Not placeholder?
-			frames[frame].shaders_to_dispose_of.push_back(*shader);
+			frames[frame].resources_to_dispose_of.shaders.push_back(*shader);
 		}
 		shader_owner.free(p_id);
 	} else if (uniform_buffer_owner.owns(p_id)) {
@@ -7681,37 +7680,37 @@ void RenderingDevice::_free_internal(RID p_id) {
 		_check_transfer_worker_buffer(uniform_buffer);
 
 		RDG::resource_tracker_free(uniform_buffer->draw_tracker);
-		frames[frame].buffers_to_dispose_of.push_back(*uniform_buffer);
+		frames[frame].resources_to_dispose_of.buffers.push_back(*uniform_buffer);
 		uniform_buffer_owner.free(p_id);
 	} else if (texture_buffer_owner.owns(p_id)) {
 		Buffer *texture_buffer = texture_buffer_owner.get_or_null(p_id);
 		_check_transfer_worker_buffer(texture_buffer);
 
 		RDG::resource_tracker_free(texture_buffer->draw_tracker);
-		frames[frame].buffers_to_dispose_of.push_back(*texture_buffer);
+		frames[frame].resources_to_dispose_of.buffers.push_back(*texture_buffer);
 		texture_buffer_owner.free(p_id);
 	} else if (storage_buffer_owner.owns(p_id)) {
 		Buffer *storage_buffer = storage_buffer_owner.get_or_null(p_id);
 		_check_transfer_worker_buffer(storage_buffer);
 
 		RDG::resource_tracker_free(storage_buffer->draw_tracker);
-		frames[frame].buffers_to_dispose_of.push_back(*storage_buffer);
+		frames[frame].resources_to_dispose_of.buffers.push_back(*storage_buffer);
 		storage_buffer_owner.free(p_id);
 	} else if (uniform_set_owner.owns(p_id)) {
 		UniformSet *uniform_set = uniform_set_owner.get_or_null(p_id);
-		frames[frame].uniform_sets_to_dispose_of.push_back(*uniform_set);
-		uniform_set_owner.free(p_id);
-
 		if (uniform_set->invalidated_callback != nullptr) {
 			uniform_set->invalidated_callback(uniform_set->invalidated_callback_userdata);
 		}
+
+		frames[frame].resources_to_dispose_of.uniform_sets.push_back(*uniform_set);
+		uniform_set_owner.free(p_id);
 	} else if (render_pipeline_owner.owns(p_id)) {
 		RenderPipeline *pipeline = render_pipeline_owner.get_or_null(p_id);
-		frames[frame].render_pipelines_to_dispose_of.push_back(*pipeline);
+		frames[frame].resources_to_dispose_of.render_pipelines.push_back(*pipeline);
 		render_pipeline_owner.free(p_id);
 	} else if (compute_pipeline_owner.owns(p_id)) {
 		ComputePipeline *pipeline = compute_pipeline_owner.get_or_null(p_id);
-		frames[frame].compute_pipelines_to_dispose_of.push_back(*pipeline);
+		frames[frame].resources_to_dispose_of.compute_pipelines.push_back(*pipeline);
 		compute_pipeline_owner.free(p_id);
 	} else if (acceleration_structure_owner.owns(p_id)) {
 		AccelerationStructure *acceleration_structure = acceleration_structure_owner.get_or_null(p_id);
@@ -7721,16 +7720,16 @@ void RenderingDevice::_free_internal(RID p_id) {
 			_tlas_remove_blas_dependencies(acceleration_structure, p_id);
 		}
 		RDG::resource_tracker_free(acceleration_structure->draw_tracker);
-		frames[frame].acceleration_structures_to_dispose_of.push_back(*acceleration_structure);
+		frames[frame].resources_to_dispose_of.acceleration_structures.push_back(*acceleration_structure);
 		acceleration_structure_owner.free(p_id);
 	} else if (raytracing_pipeline_owner.owns(p_id)) {
 		RaytracingPipeline *pipeline = raytracing_pipeline_owner.get_or_null(p_id);
-		frames[frame].raytracing_pipelines_to_dispose_of.push_back(*pipeline);
+		frames[frame].resources_to_dispose_of.raytracing_pipelines.push_back(*pipeline);
 		raytracing_pipeline_owner.free(p_id);
 	} else if (hit_sbt_owner.owns(p_id)) {
 		HitShaderBindingTable *hit_sbt = hit_sbt_owner.get_or_null(p_id);
 		RDG::resource_tracker_free(hit_sbt->draw_tracker);
-		frames[frame].buffers_to_dispose_of.push_back(*hit_sbt);
+		frames[frame].resources_to_dispose_of.buffers.push_back(*hit_sbt);
 		hit_sbt_owner.free(p_id);
 	} else {
 #ifdef DEV_ENABLED
@@ -7895,39 +7894,39 @@ void RenderingDevice::sync() {
 	local_device_processing = false;
 }
 
-void RenderingDevice::_free_pending_resources(int p_frame) {
+void RenderingDevice::_free_pending_resources(ResourcesToDisposeOf &p_resources_to_dispose_of) {
 	// Free in dependency usage order, so nothing weird happens.
 	// Pipelines.
-	while (frames[p_frame].render_pipelines_to_dispose_of.front()) {
-		RenderPipeline *pipeline = &frames[p_frame].render_pipelines_to_dispose_of.front()->get();
+	while (p_resources_to_dispose_of.render_pipelines.front()) {
+		RenderPipeline *pipeline = &p_resources_to_dispose_of.render_pipelines.front()->get();
 
 		driver->pipeline_free(pipeline->driver_id);
 
-		frames[p_frame].render_pipelines_to_dispose_of.pop_front();
+		p_resources_to_dispose_of.render_pipelines.pop_front();
 	}
 
-	while (frames[p_frame].compute_pipelines_to_dispose_of.front()) {
-		ComputePipeline *pipeline = &frames[p_frame].compute_pipelines_to_dispose_of.front()->get();
+	while (p_resources_to_dispose_of.compute_pipelines.front()) {
+		ComputePipeline *pipeline = &p_resources_to_dispose_of.compute_pipelines.front()->get();
 
 		driver->pipeline_free(pipeline->driver_id);
 
-		frames[p_frame].compute_pipelines_to_dispose_of.pop_front();
+		p_resources_to_dispose_of.compute_pipelines.pop_front();
 	}
 
-	while (frames[p_frame].raytracing_pipelines_to_dispose_of.front()) {
-		RaytracingPipeline *pipeline = &frames[p_frame].raytracing_pipelines_to_dispose_of.front()->get();
+	while (p_resources_to_dispose_of.raytracing_pipelines.front()) {
+		RaytracingPipeline *pipeline = &p_resources_to_dispose_of.raytracing_pipelines.front()->get();
 
 		driver->buffer_free(pipeline->sbt_buffer.driver_id);
 		buffer_memory.sub(pipeline->sbt_buffer.size);
 
 		driver->raytracing_pipeline_free(pipeline->driver_id);
 
-		frames[p_frame].raytracing_pipelines_to_dispose_of.pop_front();
+		p_resources_to_dispose_of.raytracing_pipelines.pop_front();
 	}
 
 	// Acceleration structures.
-	while (frames[p_frame].acceleration_structures_to_dispose_of.front()) {
-		AccelerationStructure &acceleration_structure = frames[p_frame].acceleration_structures_to_dispose_of.front()->get();
+	while (p_resources_to_dispose_of.acceleration_structures.front()) {
+		AccelerationStructure &acceleration_structure = p_resources_to_dispose_of.acceleration_structures.front()->get();
 
 		driver->acceleration_structure_free(acceleration_structure.driver_id);
 
@@ -7946,46 +7945,46 @@ void RenderingDevice::_free_pending_resources(int p_frame) {
 			buffer_memory.sub(instance_buffer_size * acceleration_structure.instance_buffers.size());
 		}
 
-		frames[p_frame].acceleration_structures_to_dispose_of.pop_front();
+		p_resources_to_dispose_of.acceleration_structures.pop_front();
 	}
 
 	// Uniform sets.
-	while (frames[p_frame].uniform_sets_to_dispose_of.front()) {
-		UniformSet *uniform_set = &frames[p_frame].uniform_sets_to_dispose_of.front()->get();
+	while (p_resources_to_dispose_of.uniform_sets.front()) {
+		UniformSet *uniform_set = &p_resources_to_dispose_of.uniform_sets.front()->get();
 
 		driver->uniform_set_free(uniform_set->driver_id);
 
-		frames[p_frame].uniform_sets_to_dispose_of.pop_front();
+		p_resources_to_dispose_of.uniform_sets.pop_front();
 	}
 
 	// Shaders.
-	while (frames[p_frame].shaders_to_dispose_of.front()) {
-		Shader *shader = &frames[p_frame].shaders_to_dispose_of.front()->get();
+	while (p_resources_to_dispose_of.shaders.front()) {
+		Shader *shader = &p_resources_to_dispose_of.shaders.front()->get();
 
 		driver->shader_free(shader->driver_id);
 
-		frames[p_frame].shaders_to_dispose_of.pop_front();
+		p_resources_to_dispose_of.shaders.pop_front();
 	}
 
 	// Samplers.
-	while (frames[p_frame].samplers_to_dispose_of.front()) {
-		RDD::SamplerID sampler = frames[p_frame].samplers_to_dispose_of.front()->get();
+	while (p_resources_to_dispose_of.samplers.front()) {
+		RDD::SamplerID sampler = p_resources_to_dispose_of.samplers.front()->get();
 
 		driver->sampler_free(sampler);
 
-		frames[p_frame].samplers_to_dispose_of.pop_front();
+		p_resources_to_dispose_of.samplers.pop_front();
 	}
 
 	// Framebuffers.
-	while (frames[p_frame].framebuffers_to_dispose_of.front()) {
-		Framebuffer *framebuffer = &frames[p_frame].framebuffers_to_dispose_of.front()->get();
+	while (p_resources_to_dispose_of.framebuffers.front()) {
+		Framebuffer *framebuffer = &p_resources_to_dispose_of.framebuffers.front()->get();
 		draw_graph.framebuffer_cache_free(driver, framebuffer->framebuffer_cache);
-		frames[p_frame].framebuffers_to_dispose_of.pop_front();
+		p_resources_to_dispose_of.framebuffers.pop_front();
 	}
 
 	// Textures.
-	while (frames[p_frame].textures_to_dispose_of.front()) {
-		Texture *texture = &frames[p_frame].textures_to_dispose_of.front()->get();
+	while (p_resources_to_dispose_of.textures.front()) {
+		Texture *texture = &p_resources_to_dispose_of.textures.front()->get();
 		if (texture->bound) {
 			WARN_PRINT("Deleted a texture while it was bound.");
 		}
@@ -7995,16 +7994,44 @@ void RenderingDevice::_free_pending_resources(int p_frame) {
 		texture_memory.sub(driver->texture_get_allocation_size(texture->driver_id));
 		driver->texture_free(texture->driver_id);
 
-		frames[p_frame].textures_to_dispose_of.pop_front();
+		p_resources_to_dispose_of.textures.pop_front();
 	}
 
 	// Buffers.
-	while (frames[p_frame].buffers_to_dispose_of.front()) {
-		Buffer &buffer = frames[p_frame].buffers_to_dispose_of.front()->get();
+	while (p_resources_to_dispose_of.buffers.front()) {
+		Buffer &buffer = p_resources_to_dispose_of.buffers.front()->get();
 		driver->buffer_free(buffer.driver_id);
 		buffer_memory.sub(buffer.size);
 
-		frames[p_frame].buffers_to_dispose_of.pop_front();
+		p_resources_to_dispose_of.buffers.pop_front();
+	}
+}
+
+void RenderingDevice::_free_pending_resources(int p_frame, bool p_async) {
+	Frame &f = frames[p_frame];
+
+	for (uint32_t i = 0; i < f.resource_dispose_tasks.size();) {
+		WorkerThreadPool::TaskID task_id = f.resource_dispose_tasks[i];
+
+		if (!p_async || WorkerThreadPool::get_singleton()->is_task_completed(task_id)) {
+			WorkerThreadPool::get_singleton()->wait_for_task_completion(task_id);
+			f.resource_dispose_tasks.remove_at_unordered(i);
+		} else {
+			++i;
+		}
+	}
+
+	if (p_async) {
+		if (!f.resources_to_dispose_of.is_empty()) {
+			WorkerThreadPool::TaskID task_id = WorkerThreadPool::get_singleton()->add_template_task(
+					this,
+					(void (RenderingDevice::*)(ResourcesToDisposeOf &))&RenderingDevice::_free_pending_resources,
+					std::move(f.resources_to_dispose_of));
+
+			f.resource_dispose_tasks.push_back(task_id);
+		}
+	} else {
+		_free_pending_resources(f.resources_to_dispose_of);
 	}
 
 	if (frames_pending_resources_for_processing > 0u) {
@@ -8063,7 +8090,7 @@ void RenderingDevice::_begin_frame(bool p_presented) {
 
 	// Erase pending resources.
 	GodotProfileZoneGrouped(_profile_zone, "_free_pending_resources");
-	_free_pending_resources(frame);
+	_free_pending_resources(frame, /* p_async = */ p_presented);
 
 	// Advance staging buffers if used.
 	if (upload_staging_buffers.used) {
@@ -8920,7 +8947,7 @@ void RenderingDevice::finalize() {
 	// Free everything pending.
 	for (uint32_t i = 0; i < frames.size(); i++) {
 		int f = (frame + i) % frames.size();
-		_free_pending_resources(f);
+		_free_pending_resources(f, /* p_async = */ false);
 		driver->command_pool_free(frames[i].command_pool);
 		driver->timestamp_query_pool_free(frames[i].timestamp_pool);
 		driver->semaphore_free(frames[i].semaphore);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -305,11 +305,7 @@ Error RenderingDevice::_acceleration_structure_scratch_buffer_create(Acceleratio
 	if (p_acceleration_structure->scratch_buffer) {
 		uint64_t scratch_buffer_size = driver->buffer_get_allocation_size(p_acceleration_structure->scratch_buffer);
 		if (scratch_buffer_size < scratch_size) {
-			Buffer to_dispose = Buffer();
-			to_dispose.driver_id = p_acceleration_structure->scratch_buffer;
-			DEV_ASSERT(scratch_buffer_size <= UINT32_MAX);
-			to_dispose.size = scratch_buffer_size;
-			frames[frame].buffers_to_dispose_of.push_back(to_dispose);
+			frames[frame].resources_to_dispose_of.buffers.push_back(p_acceleration_structure->scratch_buffer);
 			p_acceleration_structure->scratch_buffer = RDD::BufferID();
 		}
 	}
@@ -318,7 +314,7 @@ Error RenderingDevice::_acceleration_structure_scratch_buffer_create(Acceleratio
 		p_acceleration_structure->scratch_buffer = driver->buffer_create(scratch_size, RDD::BUFFER_USAGE_STORAGE_BIT | RDD::BUFFER_USAGE_DEVICE_ADDRESS_BIT, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
 		ERR_FAIL_COND_V(!p_acceleration_structure->scratch_buffer, ERR_CANT_CREATE);
 
-		buffer_memory.add(scratch_size);
+		buffer_memory.add(driver->buffer_get_allocation_size(p_acceleration_structure->scratch_buffer));
 	}
 
 	return OK;
@@ -560,7 +556,7 @@ Error RenderingDevice::tlas_build(RID p_tlas, Span<AccelerationStructureInstance
 			ERR_FAIL_V(ERR_CANT_CREATE);
 		}
 
-		buffer_memory.add(instance_buffer_size);
+		buffer_memory.add(driver->buffer_get_allocation_size(instance_buffer_driver_id));
 
 		AccelerationStructure::InstanceBuffer instance_buffer;
 		instance_buffer.driver_id = instance_buffer_driver_id;
@@ -625,7 +621,7 @@ Error RenderingDevice::tlas_build(RID p_tlas, Span<AccelerationStructureInstance
 RDD::BufferID RenderingDevice::_hit_sbt_buffer_create(uint32_t p_buffer_size) {
 	RDD::BufferID buffer = driver->buffer_create(p_buffer_size, RDD::BUFFER_USAGE_TRANSFER_TO_BIT | RDD::BUFFER_USAGE_DEVICE_ADDRESS_BIT | RDD::BUFFER_USAGE_SHADER_BINDING_TABLE_BIT, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
 	if (buffer) {
-		buffer_memory.add(p_buffer_size);
+		buffer_memory.add(driver->buffer_get_allocation_size(buffer));
 	}
 
 	return buffer;
@@ -643,7 +639,7 @@ Error RenderingDevice::_hit_sbt_buffer_update(HitShaderBindingTable *p_hit_sbt, 
 		ERR_FAIL_COND_V(!buffer, ERR_CANT_CREATE);
 
 		RDG::resource_tracker_free(p_hit_sbt->draw_tracker);
-		frames[frame].buffers_to_dispose_of.push_back(*p_hit_sbt);
+		frames[frame].resources_to_dispose_of.buffers.push_back(p_hit_sbt->driver_id);
 
 		p_hit_sbt->driver_id = buffer;
 		p_hit_sbt->size = buffer_size;
@@ -1557,7 +1553,7 @@ RID RenderingDevice::storage_buffer_create(uint32_t p_size_bytes, Span<uint8_t> 
 		_buffer_initialize(&buffer, p_data);
 	}
 
-	buffer_memory.add(buffer.size);
+	buffer_memory.add(driver->buffer_get_allocation_size(buffer.driver_id));
 
 	RID id = storage_buffer_owner.make_rid(buffer);
 #ifdef DEV_ENABLED
@@ -1595,7 +1591,7 @@ RID RenderingDevice::texture_buffer_create(uint32_t p_size_elements, DataFormat 
 		_buffer_initialize(&texture_buffer, p_data);
 	}
 
-	buffer_memory.add(size_bytes);
+	buffer_memory.add(driver->buffer_get_allocation_size(texture_buffer.driver_id));
 
 	RID id = texture_buffer_owner.make_rid(texture_buffer);
 #ifdef DEV_ENABLED
@@ -2489,14 +2485,14 @@ void RenderingDevice::_texture_free_shared_fallback(Texture *p_texture) {
 			RDG::resource_tracker_free(p_texture->shared_fallback->buffer_tracker);
 		}
 
+		ResourcesToDisposeOf &resources_to_dispose_of = frames[frame].resources_to_dispose_of;
+
 		if (p_texture->shared_fallback->texture.id != 0) {
-			texture_memory.sub(driver->texture_get_allocation_size(p_texture->shared_fallback->texture));
-			driver->texture_free(p_texture->shared_fallback->texture);
+			resources_to_dispose_of.textures.push_back(p_texture->shared_fallback->texture);
 		}
 
 		if (p_texture->shared_fallback->buffer.id != 0) {
-			buffer_memory.sub(driver->buffer_get_allocation_size(p_texture->shared_fallback->buffer));
-			driver->buffer_free(p_texture->shared_fallback->buffer);
+			resources_to_dispose_of.buffers.push_back(p_texture->shared_fallback->buffer);
 		}
 
 		memdelete(p_texture->shared_fallback);
@@ -3952,7 +3948,7 @@ RID RenderingDevice::vertex_buffer_create(uint32_t p_size_bytes, Span<uint8_t> p
 		_buffer_initialize(&buffer, p_data);
 	}
 
-	buffer_memory.add(buffer.size);
+	buffer_memory.add(driver->buffer_get_allocation_size(buffer.driver_id));
 
 	RID id = vertex_buffer_owner.make_rid(buffer);
 #ifdef DEV_ENABLED
@@ -4170,7 +4166,7 @@ RID RenderingDevice::index_buffer_create(uint32_t p_index_count, IndexBufferForm
 		_buffer_initialize(&index_buffer, p_data);
 	}
 
-	buffer_memory.add(index_buffer.size);
+	buffer_memory.add(driver->buffer_get_allocation_size(index_buffer.driver_id));
 
 	RID id = index_buffer_owner.make_rid(index_buffer);
 #ifdef DEV_ENABLED
@@ -4436,7 +4432,7 @@ RID RenderingDevice::uniform_buffer_create(uint32_t p_size_bytes, Span<uint8_t> 
 		_buffer_initialize(&buffer, p_data);
 	}
 
-	buffer_memory.add(buffer.size);
+	buffer_memory.add(driver->buffer_get_allocation_size(buffer.driver_id));
 
 	RID id = uniform_buffer_owner.make_rid(buffer);
 #ifdef DEV_ENABLED
@@ -5263,7 +5259,7 @@ Error RenderingDevice::_raytracing_pipeline_create_sbt_buffer(RDD::RaytracingPip
 		ERR_FAIL_V(err);
 	}
 
-	buffer_memory.add(r_sbt_buffer.size);
+	buffer_memory.add(driver->buffer_get_allocation_size(r_sbt_buffer.driver_id));
 
 	return OK;
 }
@@ -7745,10 +7741,16 @@ void RenderingDevice::_free_internal(RID p_id) {
 	}
 #endif
 
+	ResourcesToDisposeOf &resources_to_dispose_of = frames[frame].resources_to_dispose_of;
+
 	// Push everything so it's disposed of next time this frame index is processed (means, it's safe to do it).
 	if (texture_owner.owns(p_id)) {
 		Texture *texture = texture_owner.get_or_null(p_id);
 		_check_transfer_worker_texture(texture);
+
+		if (texture->bound) {
+			WARN_PRINT("Deleted a texture while it was bound.");
+		}
 
 		RDG::ResourceTracker *draw_tracker = texture->draw_tracker;
 		if (draw_tracker != nullptr) {
@@ -7771,27 +7773,27 @@ void RenderingDevice::_free_internal(RID p_id) {
 			}
 		}
 
-		frames[frame].textures_to_dispose_of.push_back(*texture);
+		_texture_free_shared_fallback(texture);
+
+		resources_to_dispose_of.textures.push_back(texture->driver_id);
 		texture_owner.free(p_id);
 	} else if (framebuffer_owner.owns(p_id)) {
 		Framebuffer *framebuffer = framebuffer_owner.get_or_null(p_id);
-		frames[frame].framebuffers_to_dispose_of.push_back(*framebuffer);
-
 		if (framebuffer->invalidated_callback != nullptr) {
 			framebuffer->invalidated_callback(framebuffer->invalidated_callback_userdata);
 		}
-
+		resources_to_dispose_of.framebuffer_caches.push_back(framebuffer->framebuffer_cache);
 		framebuffer_owner.free(p_id);
 	} else if (sampler_owner.owns(p_id)) {
 		RDD::SamplerID sampler_driver_id = *sampler_owner.get_or_null(p_id);
-		frames[frame].samplers_to_dispose_of.push_back(sampler_driver_id);
+		resources_to_dispose_of.samplers.push_back(sampler_driver_id);
 		sampler_owner.free(p_id);
 	} else if (vertex_buffer_owner.owns(p_id)) {
 		Buffer *vertex_buffer = vertex_buffer_owner.get_or_null(p_id);
 		_check_transfer_worker_buffer(vertex_buffer);
 
 		RDG::resource_tracker_free(vertex_buffer->draw_tracker);
-		frames[frame].buffers_to_dispose_of.push_back(*vertex_buffer);
+		resources_to_dispose_of.buffers.push_back(vertex_buffer->driver_id);
 		vertex_buffer_owner.free(p_id);
 	} else if (vertex_array_owner.owns(p_id)) {
 		vertex_array_owner.free(p_id);
@@ -7800,14 +7802,14 @@ void RenderingDevice::_free_internal(RID p_id) {
 		_check_transfer_worker_buffer(index_buffer);
 
 		RDG::resource_tracker_free(index_buffer->draw_tracker);
-		frames[frame].buffers_to_dispose_of.push_back(*index_buffer);
+		resources_to_dispose_of.buffers.push_back(index_buffer->driver_id);
 		index_buffer_owner.free(p_id);
 	} else if (index_array_owner.owns(p_id)) {
 		index_array_owner.free(p_id);
 	} else if (shader_owner.owns(p_id)) {
 		Shader *shader = shader_owner.get_or_null(p_id);
 		if (shader->driver_id) { // Not placeholder?
-			frames[frame].shaders_to_dispose_of.push_back(*shader);
+			resources_to_dispose_of.shaders.push_back(shader->driver_id);
 		}
 		shader_owner.free(p_id);
 	} else if (uniform_buffer_owner.owns(p_id)) {
@@ -7815,37 +7817,36 @@ void RenderingDevice::_free_internal(RID p_id) {
 		_check_transfer_worker_buffer(uniform_buffer);
 
 		RDG::resource_tracker_free(uniform_buffer->draw_tracker);
-		frames[frame].buffers_to_dispose_of.push_back(*uniform_buffer);
+		resources_to_dispose_of.buffers.push_back(uniform_buffer->driver_id);
 		uniform_buffer_owner.free(p_id);
 	} else if (texture_buffer_owner.owns(p_id)) {
 		Buffer *texture_buffer = texture_buffer_owner.get_or_null(p_id);
 		_check_transfer_worker_buffer(texture_buffer);
 
 		RDG::resource_tracker_free(texture_buffer->draw_tracker);
-		frames[frame].buffers_to_dispose_of.push_back(*texture_buffer);
+		resources_to_dispose_of.buffers.push_back(texture_buffer->driver_id);
 		texture_buffer_owner.free(p_id);
 	} else if (storage_buffer_owner.owns(p_id)) {
 		Buffer *storage_buffer = storage_buffer_owner.get_or_null(p_id);
 		_check_transfer_worker_buffer(storage_buffer);
 
 		RDG::resource_tracker_free(storage_buffer->draw_tracker);
-		frames[frame].buffers_to_dispose_of.push_back(*storage_buffer);
+		resources_to_dispose_of.buffers.push_back(storage_buffer->driver_id);
 		storage_buffer_owner.free(p_id);
 	} else if (uniform_set_owner.owns(p_id)) {
 		UniformSet *uniform_set = uniform_set_owner.get_or_null(p_id);
-		frames[frame].uniform_sets_to_dispose_of.push_back(*uniform_set);
-		uniform_set_owner.free(p_id);
-
 		if (uniform_set->invalidated_callback != nullptr) {
 			uniform_set->invalidated_callback(uniform_set->invalidated_callback_userdata);
 		}
+		resources_to_dispose_of.uniform_sets.push_back(uniform_set->driver_id);
+		uniform_set_owner.free(p_id);
 	} else if (render_pipeline_owner.owns(p_id)) {
 		RenderPipeline *pipeline = render_pipeline_owner.get_or_null(p_id);
-		frames[frame].render_pipelines_to_dispose_of.push_back(*pipeline);
+		resources_to_dispose_of.pipelines.push_back(pipeline->driver_id);
 		render_pipeline_owner.free(p_id);
 	} else if (compute_pipeline_owner.owns(p_id)) {
 		ComputePipeline *pipeline = compute_pipeline_owner.get_or_null(p_id);
-		frames[frame].compute_pipelines_to_dispose_of.push_back(*pipeline);
+		resources_to_dispose_of.pipelines.push_back(pipeline->driver_id);
 		compute_pipeline_owner.free(p_id);
 	} else if (acceleration_structure_owner.owns(p_id)) {
 		AccelerationStructure *acceleration_structure = acceleration_structure_owner.get_or_null(p_id);
@@ -7854,17 +7855,27 @@ void RenderingDevice::_free_internal(RID p_id) {
 		} else if (acceleration_structure->type == ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL) {
 			_tlas_remove_blas_dependencies(acceleration_structure, p_id);
 		}
+		for (AccelerationStructure::InstanceBuffer &instance_buffer : acceleration_structure->instance_buffers) {
+			driver->buffer_unmap(instance_buffer.driver_id);
+			resources_to_dispose_of.buffers.push_back(instance_buffer.driver_id);
+		}
+		if (acceleration_structure->scratch_buffer) {
+			resources_to_dispose_of.buffers.push_back(acceleration_structure->scratch_buffer);
+		}
 		RDG::resource_tracker_free(acceleration_structure->draw_tracker);
-		frames[frame].acceleration_structures_to_dispose_of.push_back(*acceleration_structure);
+		resources_to_dispose_of.acceleration_structures.push_back(acceleration_structure->driver_id);
 		acceleration_structure_owner.free(p_id);
 	} else if (raytracing_pipeline_owner.owns(p_id)) {
 		RaytracingPipeline *pipeline = raytracing_pipeline_owner.get_or_null(p_id);
-		frames[frame].raytracing_pipelines_to_dispose_of.push_back(*pipeline);
+		_check_transfer_worker_buffer(&pipeline->sbt_buffer);
+
+		resources_to_dispose_of.buffers.push_back(pipeline->sbt_buffer.driver_id);
+		resources_to_dispose_of.raytracing_pipelines.push_back(pipeline->driver_id);
 		raytracing_pipeline_owner.free(p_id);
 	} else if (hit_sbt_owner.owns(p_id)) {
 		HitShaderBindingTable *hit_sbt = hit_sbt_owner.get_or_null(p_id);
 		RDG::resource_tracker_free(hit_sbt->draw_tracker);
-		frames[frame].buffers_to_dispose_of.push_back(*hit_sbt);
+		resources_to_dispose_of.buffers.push_back(hit_sbt->driver_id);
 		hit_sbt_owner.free(p_id);
 	} else {
 #ifdef DEV_ENABLED
@@ -7878,6 +7889,8 @@ void RenderingDevice::_free_internal(RID p_id) {
 }
 
 void RenderingDevice::texture_replace_rid(RID p_old_texture, RID p_new_texture) {
+	ERR_RENDER_THREAD_GUARD();
+
 	_THREAD_SAFE_METHOD_
 	ERR_FAIL_COND(p_old_texture == p_new_texture);
 
@@ -7947,10 +7960,8 @@ void RenderingDevice::texture_replace_rid(RID p_old_texture, RID p_new_texture) 
 		UniformSet *new_us = uniform_set_owner.get_or_null(new_us_rid);
 		ERR_CONTINUE(!new_us);
 
-		// Create a temporary UniformSet with only the driver_id so it gets freed.
-		UniformSet old_us_for_disposal;
-		old_us_for_disposal.driver_id = us->driver_id;
-		frames[frame].uniform_sets_to_dispose_of.push_back(old_us_for_disposal);
+		// Free the old uniform set.
+		frames[frame].resources_to_dispose_of.uniform_sets.push_back(us->driver_id);
 
 		// Copy new data in.
 		us->driver_id = new_us->driver_id;
@@ -8151,116 +8162,96 @@ void RenderingDevice::sync() {
 	local_device_processing = false;
 }
 
-void RenderingDevice::_free_pending_resources(int p_frame) {
+void RenderingDevice::_free_pending_resources(ResourcesToDisposeOf &p_resources_to_dispose_of) {
 	// Free in dependency usage order, so nothing weird happens.
-	// Pipelines.
-	while (frames[p_frame].render_pipelines_to_dispose_of.front()) {
-		RenderPipeline *pipeline = &frames[p_frame].render_pipelines_to_dispose_of.front()->get();
 
-		driver->pipeline_free(pipeline->driver_id);
-
-		frames[p_frame].render_pipelines_to_dispose_of.pop_front();
+	for (RDD::RaytracingPipelineID raytracing_pipeline : p_resources_to_dispose_of.raytracing_pipelines) {
+		driver->raytracing_pipeline_free(raytracing_pipeline);
 	}
+	p_resources_to_dispose_of.raytracing_pipelines.clear();
 
-	while (frames[p_frame].compute_pipelines_to_dispose_of.front()) {
-		ComputePipeline *pipeline = &frames[p_frame].compute_pipelines_to_dispose_of.front()->get();
-
-		driver->pipeline_free(pipeline->driver_id);
-
-		frames[p_frame].compute_pipelines_to_dispose_of.pop_front();
+	for (RDD::PipelineID pipeline : p_resources_to_dispose_of.pipelines) {
+		driver->pipeline_free(pipeline);
 	}
+	p_resources_to_dispose_of.pipelines.clear();
 
-	while (frames[p_frame].raytracing_pipelines_to_dispose_of.front()) {
-		RaytracingPipeline *pipeline = &frames[p_frame].raytracing_pipelines_to_dispose_of.front()->get();
-
-		driver->buffer_free(pipeline->sbt_buffer.driver_id);
-		buffer_memory.sub(pipeline->sbt_buffer.size);
-
-		driver->raytracing_pipeline_free(pipeline->driver_id);
-
-		frames[p_frame].raytracing_pipelines_to_dispose_of.pop_front();
+	for (RDD::UniformSetID uniform_set : p_resources_to_dispose_of.uniform_sets) {
+		driver->uniform_set_free(uniform_set);
 	}
+	p_resources_to_dispose_of.uniform_sets.clear();
 
-	// Acceleration structures.
-	while (frames[p_frame].acceleration_structures_to_dispose_of.front()) {
-		AccelerationStructure &acceleration_structure = frames[p_frame].acceleration_structures_to_dispose_of.front()->get();
-
-		driver->acceleration_structure_free(acceleration_structure.driver_id);
-
-		if (acceleration_structure.scratch_buffer) {
-			buffer_memory.sub(driver->buffer_get_allocation_size(acceleration_structure.scratch_buffer));
-			driver->buffer_free(acceleration_structure.scratch_buffer);
-		}
-
-		if (!acceleration_structure.instance_buffers.is_empty()) {
-			uint32_t instance_buffer_size = driver->api_trait_get(RDD::API_TRAIT_ACCELERATION_STRUCTURE_INSTANCE_SIZE) * acceleration_structure.max_instance_count;
-			for (AccelerationStructure::InstanceBuffer &instance_buffer : acceleration_structure.instance_buffers) {
-				driver->buffer_unmap(instance_buffer.driver_id);
-				driver->buffer_free(instance_buffer.driver_id);
-			}
-
-			buffer_memory.sub(instance_buffer_size * acceleration_structure.instance_buffers.size());
-		}
-
-		frames[p_frame].acceleration_structures_to_dispose_of.pop_front();
+	for (RDD::ShaderID shader : p_resources_to_dispose_of.shaders) {
+		driver->shader_free(shader);
 	}
+	p_resources_to_dispose_of.shaders.clear();
 
-	// Uniform sets.
-	while (frames[p_frame].uniform_sets_to_dispose_of.front()) {
-		UniformSet *uniform_set = &frames[p_frame].uniform_sets_to_dispose_of.front()->get();
-
-		driver->uniform_set_free(uniform_set->driver_id);
-
-		frames[p_frame].uniform_sets_to_dispose_of.pop_front();
+	for (RDD::AccelerationStructureID acceleration_structure : p_resources_to_dispose_of.acceleration_structures) {
+		driver->acceleration_structure_free(acceleration_structure);
 	}
+	p_resources_to_dispose_of.acceleration_structures.clear();
 
-	// Shaders.
-	while (frames[p_frame].shaders_to_dispose_of.front()) {
-		Shader *shader = &frames[p_frame].shaders_to_dispose_of.front()->get();
-
-		driver->shader_free(shader->driver_id);
-
-		frames[p_frame].shaders_to_dispose_of.pop_front();
-	}
-
-	// Samplers.
-	while (frames[p_frame].samplers_to_dispose_of.front()) {
-		RDD::SamplerID sampler = frames[p_frame].samplers_to_dispose_of.front()->get();
-
+	for (RDD::SamplerID sampler : p_resources_to_dispose_of.samplers) {
 		driver->sampler_free(sampler);
-
-		frames[p_frame].samplers_to_dispose_of.pop_front();
 	}
+	p_resources_to_dispose_of.samplers.clear();
 
-	// Framebuffers.
-	while (frames[p_frame].framebuffers_to_dispose_of.front()) {
-		Framebuffer *framebuffer = &frames[p_frame].framebuffers_to_dispose_of.front()->get();
-		draw_graph.framebuffer_cache_free(driver, framebuffer->framebuffer_cache);
-		frames[p_frame].framebuffers_to_dispose_of.pop_front();
+	for (RDG::FramebufferCache *framebuffer_cache : p_resources_to_dispose_of.framebuffer_caches) {
+		RDG::framebuffer_cache_free(driver, framebuffer_cache);
 	}
+	p_resources_to_dispose_of.framebuffer_caches.clear();
 
-	// Textures.
-	while (frames[p_frame].textures_to_dispose_of.front()) {
-		Texture *texture = &frames[p_frame].textures_to_dispose_of.front()->get();
-		if (texture->bound) {
-			WARN_PRINT("Deleted a texture while it was bound.");
+	for (RDD::TextureID texture : p_resources_to_dispose_of.textures) {
+		uint64_t texture_allocation_size = driver->texture_get_allocation_size(texture);
+		driver->texture_free(texture);
+		texture_memory.sub(texture_allocation_size);
+	}
+	p_resources_to_dispose_of.textures.clear();
+
+	for (RDD::BufferID buffer : p_resources_to_dispose_of.buffers) {
+		uint64_t buffer_allocation_size = driver->buffer_get_allocation_size(buffer);
+		driver->buffer_free(buffer);
+		buffer_memory.sub(buffer_allocation_size);
+	}
+	p_resources_to_dispose_of.buffers.clear();
+}
+
+void RenderingDevice::_free_pending_resources(void *p_userdata) {
+	ResourceDisposeTask *resource_dispose_task = (ResourceDisposeTask *)p_userdata;
+	resource_dispose_task->rendering_device->_free_pending_resources(resource_dispose_task->resources_to_dispose_of);
+}
+
+void RenderingDevice::_free_pending_resources(int p_frame, bool p_async) {
+	Frame &f = frames[p_frame];
+	ResourceDisposeTask &task = resource_dispose_tasks[p_frame];
+
+#if 0
+	thread_local String env_var;
+	if (env_var.is_empty()) {
+		env_var = OS::get_singleton()->get_environment("ASYNC_RD_FREE");
+		if (env_var.is_empty()) {
+			env_var = "0";
 		}
+	}
+	p_async &= (env_var[0] == '1');
+#endif
 
-		_texture_free_shared_fallback(texture);
-
-		texture_memory.sub(driver->texture_get_allocation_size(texture->driver_id));
-		driver->texture_free(texture->driver_id);
-
-		frames[p_frame].textures_to_dispose_of.pop_front();
+	if (task.id != WorkerThreadPool::INVALID_TASK_ID) {
+		WorkerThreadPool::get_singleton()->wait_for_task_completion(task.id);
+		task.id = WorkerThreadPool::INVALID_TASK_ID;
 	}
 
-	// Buffers.
-	while (frames[p_frame].buffers_to_dispose_of.front()) {
-		Buffer &buffer = frames[p_frame].buffers_to_dispose_of.front()->get();
-		driver->buffer_free(buffer.driver_id);
-		buffer_memory.sub(buffer.size);
+	if (p_async) {
+		if (!f.resources_to_dispose_of.is_empty()) {
+			// Swap to preserve the capacity of the local vectors.
+			SWAP(task.resources_to_dispose_of, f.resources_to_dispose_of);
 
-		frames[p_frame].buffers_to_dispose_of.pop_front();
+			task.id = WorkerThreadPool::get_singleton()->add_native_task(
+					&RenderingDevice::_free_pending_resources,
+					&task,
+					true);
+		}
+	} else {
+		_free_pending_resources(f.resources_to_dispose_of);
 	}
 
 	if (frames_pending_resources_for_processing > 0u) {
@@ -8319,7 +8310,7 @@ void RenderingDevice::_begin_frame(bool p_presented) {
 
 	// Erase pending resources.
 	GodotProfileZoneGrouped(_profile_zone, "_free_pending_resources");
-	_free_pending_resources(frame);
+	_free_pending_resources(frame, /* p_async = */ p_presented);
 
 	// Advance staging buffers if used.
 	if (upload_staging_buffers.used) {
@@ -8771,6 +8762,12 @@ Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServ
 		ERR_FAIL_V_MSG(FAILED, "Failed to create frame data.");
 	}
 
+	// Create resource dispose task data.
+	resource_dispose_tasks.resize(frame_count);
+	for (ResourceDisposeTask &task : resource_dispose_tasks) {
+		task.rendering_device = this;
+	}
+
 	// Start from frame count, so everything else is immediately old.
 	frames_drawn = frames.size();
 
@@ -9189,7 +9186,7 @@ void RenderingDevice::finalize() {
 	// Free everything pending.
 	for (uint32_t i = 0; i < frames.size(); i++) {
 		int f = (frame + i) % frames.size();
-		_free_pending_resources(f);
+		_free_pending_resources(f, /* p_async = */ false);
 		driver->command_pool_free(frames[i].command_pool);
 		driver->timestamp_query_pool_free(frames[i].timestamp_pool);
 		driver->semaphore_free(frames[i].semaphore);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1777,18 +1777,36 @@ private:
 	// nature of the GPU. They will get deleted
 	// when the frame is cycled.
 
-	struct Frame {
+	struct ResourcesToDisposeOf {
 		// List in usage order, from last to free to first to free.
-		List<Buffer> buffers_to_dispose_of;
-		List<Texture> textures_to_dispose_of;
-		List<Framebuffer> framebuffers_to_dispose_of;
-		List<RDD::SamplerID> samplers_to_dispose_of;
-		List<Shader> shaders_to_dispose_of;
-		List<UniformSet> uniform_sets_to_dispose_of;
-		List<RenderPipeline> render_pipelines_to_dispose_of;
-		List<ComputePipeline> compute_pipelines_to_dispose_of;
-		List<AccelerationStructure> acceleration_structures_to_dispose_of;
-		List<RaytracingPipeline> raytracing_pipelines_to_dispose_of;
+		List<Buffer> buffers;
+		List<Texture> textures;
+		List<Framebuffer> framebuffers;
+		List<RDD::SamplerID> samplers;
+		List<Shader> shaders;
+		List<UniformSet> uniform_sets;
+		List<RenderPipeline> render_pipelines;
+		List<ComputePipeline> compute_pipelines;
+		List<AccelerationStructure> acceleration_structures;
+		List<RaytracingPipeline> raytracing_pipelines;
+
+		_FORCE_INLINE_ bool is_empty() const {
+			return buffers.is_empty() &&
+					textures.is_empty() &&
+					framebuffers.is_empty() &&
+					samplers.is_empty() &&
+					shaders.is_empty() &&
+					uniform_sets.is_empty() &&
+					render_pipelines.is_empty() &&
+					compute_pipelines.is_empty() &&
+					acceleration_structures.is_empty() &&
+					raytracing_pipelines.is_empty();
+		}
+	};
+
+	struct Frame {
+		ResourcesToDisposeOf resources_to_dispose_of;
+		LocalVector<WorkerThreadPool::TaskID> resource_dispose_tasks;
 
 		// Pending asynchronous data transfer for buffers.
 		LocalVector<RDD::BufferID> download_buffer_staging_buffers;
@@ -1862,7 +1880,8 @@ public:
 	bool has_pending_resources_for_processing() const { return frames_pending_resources_for_processing != 0u; }
 
 private:
-	void _free_pending_resources(int p_frame);
+	void _free_pending_resources(ResourcesToDisposeOf &p_resources_to_dispose_of);
+	void _free_pending_resources(int p_frame, bool p_async);
 
 	SafeNumeric<uint64_t> texture_memory;
 	SafeNumeric<uint64_t> buffer_memory;

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1795,18 +1795,35 @@ private:
 	// nature of the GPU. They will get deleted
 	// when the frame is cycled.
 
-	struct Frame {
+	struct ResourcesToDisposeOf {
 		// List in usage order, from last to free to first to free.
-		List<Buffer> buffers_to_dispose_of;
-		List<Texture> textures_to_dispose_of;
-		List<Framebuffer> framebuffers_to_dispose_of;
-		List<RDD::SamplerID> samplers_to_dispose_of;
-		List<Shader> shaders_to_dispose_of;
-		List<UniformSet> uniform_sets_to_dispose_of;
-		List<RenderPipeline> render_pipelines_to_dispose_of;
-		List<ComputePipeline> compute_pipelines_to_dispose_of;
-		List<AccelerationStructure> acceleration_structures_to_dispose_of;
-		List<RaytracingPipeline> raytracing_pipelines_to_dispose_of;
+		LocalVector<RDD::BufferID> buffers;
+		LocalVector<RDD::TextureID> textures;
+		LocalVector<RDG::FramebufferCache *> framebuffer_caches;
+		LocalVector<RDD::SamplerID> samplers;
+		LocalVector<RDD::AccelerationStructureID> acceleration_structures;
+		LocalVector<RDD::ShaderID> shaders;
+		LocalVector<RDD::UniformSetID> uniform_sets;
+		LocalVector<RDD::PipelineID> pipelines;
+		LocalVector<RDD::RaytracingPipelineID> raytracing_pipelines;
+
+		_FORCE_INLINE_ bool is_empty() const {
+			return buffers.is_empty() &&
+					textures.is_empty() &&
+					framebuffer_caches.is_empty() &&
+					samplers.is_empty() &&
+					acceleration_structures.is_empty() &&
+					shaders.is_empty() &&
+					uniform_sets.is_empty() &&
+					pipelines.is_empty() &&
+					raytracing_pipelines.is_empty();
+		}
+	};
+
+	void _free_pending_resources(ResourcesToDisposeOf &p_resources_to_dispose_of);
+
+	struct Frame {
+		ResourcesToDisposeOf resources_to_dispose_of;
 
 		// Pending asynchronous data transfer for buffers.
 		LocalVector<RDD::BufferID> download_buffer_staging_buffers;
@@ -1869,6 +1886,15 @@ private:
 	TightLocalVector<Frame> frames;
 	uint64_t frames_drawn = 0;
 
+	struct ResourceDisposeTask {
+		RenderingDevice *rendering_device = nullptr;
+		WorkerThreadPool::TaskID id = WorkerThreadPool::INVALID_TASK_ID;
+		ResourcesToDisposeOf resources_to_dispose_of;
+	};
+	TightLocalVector<ResourceDisposeTask> resource_dispose_tasks; // Per frame.
+
+	static void _free_pending_resources(void *p_userdata);
+
 	// Whenever logic/physics request a graphics operation (not just deleting a resource) that requires
 	// us to flush all graphics commands, we must set frames_pending_resources_for_processing = frames.size().
 	// This is important for when the user requested for the logic loop to still be updated while
@@ -1880,7 +1906,7 @@ public:
 	bool has_pending_resources_for_processing() const { return frames_pending_resources_for_processing != 0u; }
 
 private:
-	void _free_pending_resources(int p_frame);
+	void _free_pending_resources(int p_frame, bool p_async);
 
 	SafeNumeric<uint64_t> texture_memory;
 	SafeNumeric<uint64_t> buffer_memory;


### PR DESCRIPTION
Freeing RD resources can be really expensive, taking up to several milliseconds. The cost can be avoided by delegating it to a separate task, allowing it to overlap with the next frame.

# Results

MRP that creates 100 meshes and frees them every frame. Comparing `RenderingServerDefault::_draw`:

D3D12:
- Before: 12.03 ms
- After: 7.53 ms

Vulkan:
- Before: 7.77 ms
- After: 6.97 ms


# TODO

Some of the rendering driver free functions are not thread safe. These need to be fixed:

- [x] D3D12 thread safety (uniform set, sampler)
- [x] Vulkan thread safety (uniform set)
- [ ] Metal (yet to check)