### PR TITLE
[CODEOWNERS] Add codeowners for `drivers/sdl/`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,9 @@
 /drivers/winmidi/                             @godotengine/audio
 /drivers/xaudio2/                             @godotengine/audio
 
+## Input
+/drivers/sdl/                                 @godotengine/input
+
 ## Rendering
 /drivers/d3d12/                               @godotengine/rendering
 /drivers/dummy/                               @godotengine/rendering


### PR DESCRIPTION
This PR makes the Input team a codeowner for `drivers/sdl/` folder, since at the moment SDL is only used for joypad input. If in the future we add more subsystems from SDL, we can probably change the codeowners too.