### PR TITLE
SCons: Bump minimum Python version (3.8 → 3.9)

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -160,7 +160,7 @@ jobs:
         uses: ./.github/actions/godot-deps
         with:
           # Sync with Ensure*Version in SConstruct.
-          python-version: 3.8
+          python-version: 3.9
           scons-version: 4.0
 
       - name: Force remove preinstalled .NET SDKs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
         types_or: [text]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1 # Latest version that supports Python 3.8
+    rev: v1.19.1
     hooks:
       - id: mypy
         files: \.py$

--- a/SConstruct
+++ b/SConstruct
@@ -2,7 +2,7 @@
 from misc.utility.scons_hints import *
 
 EnsureSConsVersion(4, 0)
-EnsurePythonVersion(3, 8)
+EnsurePythonVersion(3, 9)
 
 # System
 import glob

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,12 @@ warn_redundant_casts = true
 warn_return_any = true
 warn_unreachable = true
 exclude = ["thirdparty/"]
-python_version = "3.8"
+python_version = "3.9"
 
 [tool.ruff]
 extend-exclude = ["thirdparty"]
 extend-include = ["*SConstruct", "*SCsub"]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 preview = true
 fix = true


### PR DESCRIPTION
In an [upcoming SCons release](https://github.com/SCons/scons/pull/4826), Python versions 3.7 and 3.8 are slated for deprecation. They'll still function briefly, but outright removal will likely happen soon after. This is with SCons adopting a 1-year-after-EOL minimum (discussed in their [Discord](https://discord.gg/bXVpWAy)). Given our Python 3.8 bump was a little over a year ago, we're arguably already utilizing the same policy, so making this our new minimum isn't breaking precedent

More pertinently, we currently have 3.9 code in our repo. #113743 inadvertantly broke compatibility with `.removeprefix()`[^1], and this was never caught because the job running this script is not the same as the job running the minimum-supported python version. So if we opt to not bump versions yet, we'll have to change this file to use 3.8 syntax instead, which feels like more of a hassle

This has the added bonus of us no longer having to freeze our `mypy` version, as it's minimum-supported version is also 3.9! Consequently, this bumps the pre-commit hook for it to the latest version

[^1]: https://github.com/godotengine/godot/blob/0df713417b6b7f4ba077923fde624691c3f19014/tests/compatibility_test/run_compatibility_test.py#L56