### PR TITLE
Add move semantics to `RBMap` and `RBSet`. Make their copy constructors explicit.

### DIFF
--- a/core/templates/rb_map.h
+++ b/core/templates/rb_map.h
@@ -757,11 +757,32 @@ public:
 	}
 
 	void operator=(const RBMap &p_map) {
+		if (this == &p_map) {
+			return;
+		}
+
 		_copy_from(p_map);
 	}
 
-	RBMap(const RBMap &p_map) {
+	void operator=(RBMap &&p_map) {
+		if (this == &p_map) {
+			return;
+		}
+
+		SWAP(_data._root, p_map._data._root);
+		SWAP(_data.size_cache, p_map._data.size_cache);
+	}
+
+	explicit RBMap(const RBMap &p_map) {
 		_copy_from(p_map);
+	}
+
+	RBMap(RBMap &&p_map) {
+		_data._root = p_map._data._root;
+		_data.size_cache = p_map._data.size_cache;
+
+		p_map._data._root = nullptr;
+		p_map._data.size_cache = 0;
 	}
 
 	RBMap(std::initializer_list<KeyValue<K, V>> p_init) {

--- a/core/templates/rb_set.h
+++ b/core/templates/rb_set.h
@@ -694,11 +694,32 @@ public:
 	}
 
 	void operator=(const RBSet &p_set) {
+		if (this == &p_set) {
+			return;
+		}
+
 		_copy_from(p_set);
 	}
 
-	RBSet(const RBSet &p_set) {
+	void operator=(RBSet &&p_set) {
+		if (this == &p_set) {
+			return;
+		}
+
+		SWAP(_data._root, p_set._data._root);
+		SWAP(_data.size_cache, p_set._data.size_cache);
+	}
+
+	explicit RBSet(const RBSet &p_set) {
 		_copy_from(p_set);
+	}
+
+	RBSet(RBSet &&p_set) {
+		_data._root = p_set._data._root;
+		_data.size_cache = p_set._data.size_cache;
+
+		p_set._data._root = nullptr;
+		p_set._data.size_cache = 0;
 	}
 
 	RBSet(std::initializer_list<T> p_init) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -256,7 +256,7 @@ void EditorNode::disambiguate_filenames(const Vector<String> p_full_paths, Vecto
 
 	// For each index set with a size > 1, we need to disambiguate.
 	for (int i = 0; i < index_sets.size(); i++) {
-		RBSet<int> iset = index_sets[i];
+		RBSet<int> iset(index_sets[i]);
 		while (iset.size() > 1) {
 			// Append the parent folder to each scene name.
 			for (const int &E : iset) {

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.h
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.h
@@ -101,7 +101,7 @@ public:
 
 	public:
 		Ref<TileSetAtlasSource> get_edited_tile_set_atlas_source() const { return tile_set_atlas_source; }
-		RBSet<TileSelection> get_edited_tiles() const { return tiles; }
+		RBSet<TileSelection> get_edited_tiles() const { return RBSet<TileSelection>(tiles); }
 
 		// Update the proxied object.
 		void edit(Ref<TileSetAtlasSource> p_tile_set_atlas_source, const RBSet<TileSelection> &p_tiles = RBSet<TileSelection>());

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -2382,7 +2382,7 @@ HashMap<Vector2i, TileSet::TerrainsPattern> TileMapLayer::terrain_fill_constrain
 	}
 
 	// Copy the constraints set.
-	RBSet<TerrainConstraint> constraints = p_constraints;
+	RBSet<TerrainConstraint> constraints(p_constraints);
 
 	// Output map.
 	HashMap<Vector2i, TileSet::TerrainsPattern> output;

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -1399,7 +1399,7 @@ RBSet<TileSet::TerrainsPattern> TileSet::get_terrains_pattern_set(int p_terrain_
 RBSet<TileMapCell> TileSet::get_tiles_for_terrains_pattern(int p_terrain_set, TerrainsPattern p_terrain_tile_pattern) {
 	ERR_FAIL_INDEX_V(p_terrain_set, terrain_sets.size(), RBSet<TileMapCell>());
 	_update_terrains_cache();
-	return per_terrain_pattern_tiles[p_terrain_set][p_terrain_tile_pattern];
+	return RBSet<TileMapCell>(per_terrain_pattern_tiles[p_terrain_set][p_terrain_tile_pattern]);
 }
 
 TileMapCell TileSet::get_random_tile_from_terrains_pattern(int p_terrain_set, TileSet::TerrainsPattern p_terrain_tile_pattern) {
@@ -1408,7 +1408,7 @@ TileMapCell TileSet::get_random_tile_from_terrains_pattern(int p_terrain_set, Ti
 
 	// Count the sum of probabilities.
 	double sum = 0.0;
-	RBSet<TileMapCell> set = per_terrain_pattern_tiles[p_terrain_set][p_terrain_tile_pattern];
+	RBSet<TileMapCell> set(per_terrain_pattern_tiles[p_terrain_set][p_terrain_tile_pattern]);
 	for (const TileMapCell &E : set) {
 		if (E.source_id >= 0) {
 			Ref<TileSetSource> source = sources[E.source_id];


### PR DESCRIPTION
- Similar to #115093 
- Similar to #115309 
- Similar to #115646
- Similar to #115646
- Similar to #116381
- Supersedes part of https://github.com/godotengine/godot/pull/111372

This change makes it harder to accidentally copy `RBMap` and `RBSet` instances. This decreases the chance of performance problems and regressions.

Programmers will be forced to take a reference, move, otherwise avoid the copy, or explicitly make the copy:

```c++
RBSet<int> rbset;

RBSet<int> other = rbset; // implicit copy, now impossible 

RBSet<int> other(rbset); // explicit copy
RBSet<int> other = RBSet<int>(rbset); // explicit copy
RBSet<int> &other = rbset; // reference
RBSet<int> other = std::move(rbset); // move
```

This PR is performance agnostic; that is, if a copy was happening beforehand, there will be a copy afterwards (just explicit instead of implicit).

The PR also adds move constructors and assignment to `RBMap` and `RBSet`. These can be very useful for performance purposes, and are needed in basically any container.