### PR TITLE
Allow providing Android APK/AAB as base packs for patch PCKs

### DIFF
--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -144,7 +144,7 @@ unzFile ZipArchive::get_file_handle(const String &p_file) const {
 	return pkg;
 }
 
-bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset = 0) {
+bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key) {
 	// load with offset feature only supported for PCK files
 	ERR_FAIL_COND_V_MSG(p_offset != 0, false, "Invalid PCK data. Note that loading files with a non-zero offset isn't supported with ZIP archives.");
 
@@ -209,7 +209,7 @@ bool ZipArchive::file_exists(const String &p_name) const {
 	return files.has(p_name);
 }
 
-Ref<FileAccess> ZipArchive::get_file(const String &p_path, PackedData::PackedFile *p_file) {
+Ref<FileAccess> ZipArchive::get_file(const String &p_path, PackedData::PackedFile *p_file, const Vector<uint8_t> &p_decryption_key) {
 	return memnew(FileAccessZip(p_path, *p_file));
 }
 

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -61,8 +61,8 @@ public:
 
 	bool file_exists(const String &p_name) const;
 
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) override;
-	Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file) override;
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>()) override;
+	Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>()) override;
 
 	static ZipArchive *get_singleton();
 

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -105,7 +105,8 @@ public:
 	static bool _store_header(Ref<FileAccess> p_fd, bool p_enc, bool p_sparse, uint64_t &r_file_base_ofs, uint64_t &r_dir_base_ofs, const String &p_salt);
 	static bool _encrypt_and_store_directory(Ref<FileAccess> p_fd, PackData &p_pack_data, const Vector<uint8_t> &p_key, uint64_t p_seed, uint64_t p_file_base);
 	static Error _encrypt_and_store_data(Ref<FileAccess> p_fd, const String &p_path, const Vector<uint8_t> &p_data, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key, uint64_t p_seed, bool &r_encrypt);
-	String _get_script_encryption_key(const Ref<EditorExportPreset> &p_preset) const;
+	static String _get_script_encryption_key(const Ref<EditorExportPreset> &p_preset);
+	static Vector<uint8_t> _get_script_encryption_key_bytes(const Ref<EditorExportPreset> &p_preset);
 
 private:
 	struct ZipData {
@@ -116,6 +117,7 @@ private:
 	};
 
 	Vector<ExportMessage> messages;
+	Vector<String> patch_temp_dirs;
 
 	void _export_find_resources(EditorFileSystemDirectory *p_dir, HashSet<String> &p_paths);
 	void _export_find_customized_resources(const Ref<EditorExportPreset> &p_preset, EditorFileSystemDirectory *p_dir, EditorExportPreset::FileExportMode p_mode, HashSet<String> &p_paths);
@@ -205,7 +207,8 @@ protected:
 	Error ssh_run_on_remote_no_wait(const String &p_host, const String &p_port, const Vector<String> &p_ssh_args, const String &p_cmd_args, OS::ProcessID *r_pid = nullptr, int p_port_fwd = -1) const;
 	Error ssh_push_to_remote(const String &p_host, const String &p_port, const Vector<String> &p_scp_args, const String &p_src_file, const String &p_dst_file) const;
 
-	Error _load_patches(const Vector<String> &p_patches);
+	Error _extract_android_assets(const String &p_bundle_path, String &r_pck_path, String &r_temp_dir);
+	Error _load_patches(const Ref<EditorExportPreset> &p_preset, const Vector<String> &p_patches);
 	void _unload_patches();
 
 	Ref<Image> _load_icon_or_splash_image(const String &p_path, Error *r_error) const;

--- a/editor/export/editor_export_platform_extension.cpp
+++ b/editor/export/editor_export_platform_extension.cpp
@@ -310,7 +310,7 @@ Error EditorExportPlatformExtension::export_zip(const Ref<EditorExportPreset> &p
 Error EditorExportPlatformExtension::export_pack_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, const Vector<String> &p_patches, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
-	Error err = _load_patches(p_patches.is_empty() ? p_preset->get_patches() : p_patches);
+	Error err = _load_patches(p_preset, p_patches.is_empty() ? p_preset->get_patches() : p_patches);
 	if (err != OK) {
 		return err;
 	}
@@ -329,7 +329,7 @@ Error EditorExportPlatformExtension::export_pack_patch(const Ref<EditorExportPre
 Error EditorExportPlatformExtension::export_zip_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, const Vector<String> &p_patches, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
-	Error err = _load_patches(p_patches.is_empty() ? p_preset->get_patches() : p_patches);
+	Error err = _load_patches(p_preset, p_patches.is_empty() ? p_preset->get_patches() : p_patches);
 	if (err != OK) {
 		return err;
 	}

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1795,6 +1795,8 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	patch_dialog = memnew(EditorFileDialog);
 	patch_dialog->add_filter("*.pck", TTR("Godot Project Pack"));
+	patch_dialog->add_filter("*.aab", TTR("Android App Bundle"));
+	patch_dialog->add_filter("*.apk", TTR("Android Package"));
 	patch_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	patch_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	patch_dialog->connect("file_selected", callable_mp(this, &ProjectExportDialog::_patch_file_selected));


### PR DESCRIPTION
Resolves godotengine/godot-proposals#14293.

This adds support for passing `*.apk` and `*.aab` files as part of the "Base Packs" in the "Patching" export settings, or as part of the `--patches` command-line argument. This will cause the export step to extract the `assets` folder in the APK/AAB to a temporary folder and load the `*.sparsepck` from there. Once the exporting is done the temporary folder is deleted.

If the assets in the APK/AAB is encrypted in any way, it will decrypt them using whatever encryption key is already provided through the "Encryption" export tab, or using the `GODOT_SCRIPT_ENCRYPTION_KEY` environment variable. This also means we're adding support for patching encrypted PCKs in general, which was not possible before.