### PR TITLE
GDScript: Add the ability to patch methods at runtime to support modding

### DIFF
--- a/modules/gdscript/doc_classes/GDScript.xml
+++ b/modules/gdscript/doc_classes/GDScript.xml
@@ -23,5 +23,26 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="patch_method" experimental="">
+			<return type="bool" />
+			<param index="0" name="method" type="StringName" />
+			<param index="1" name="wrapper" type="Callable" />
+			<description>
+				Replaces a script method at runtime with a wrapper. The wrapper must accept the following parameters:
+				- [code]instance[/code]: [Object] - The instance on which the method is called. [code]null[/code] if the method is static.
+				- [code]args[/code]: [Array] - The list of passed arguments.
+				- [code]previous[/code]: [Callable] - The previous function (last applied patch or original implementation).
+				Each wrapper must return a value that matches the expected type of the original function.
+				Returns [code]true[/code] if the replacement was successful. Returns [code]false[/code] on error. You cannot replace non-existent or abstract methods.
+				[codeblock]
+				func my_wrapper(instance, args, previous):
+					prints("my_wrapper", instance, args)
+					return previous.callv(args)
+
+				func load_mod():
+					game_script.patch_method("some_method", my_wrapper)
+				[/codeblock]
+			</description>
+		</method>
 	</methods>
 </class>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1078,6 +1078,7 @@ void GDScript::_get_property_list(List<PropertyInfo> *p_properties) const {
 
 void GDScript::_bind_methods() {
 	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "new", &GDScript::_new, MethodInfo("new"));
+	ClassDB::bind_method(D_METHOD("patch_method", "method", "wrapper"), &GDScript::patch_method);
 }
 
 void GDScript::set_path_cache(const String &p_path) {
@@ -1307,6 +1308,20 @@ void GDScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
 	_get_script_signal_list(r_signals, true);
 }
 
+bool GDScript::patch_method(const StringName &p_method, const Callable &p_wrapper) {
+	//MutexLock lock(GDScriptLanguage::singleton->mutex); // TODO: Check multithreading.
+
+	if (!member_functions.has(p_method) || (member_functions[p_method]->method_info.flags & METHOD_FLAG_VIRTUAL_REQUIRED) || p_method.operator String().begins_with("@")) {
+		return false;
+	}
+
+	GDScriptFunction *previous = member_functions[p_method];
+	member_functions[p_method] = GDScriptCompiler::generate_wrapper(this, previous, p_wrapper);
+	patched_member_functions.push_back(previous);
+
+	return true;
+}
+
 GDScript::GDScript() :
 		script_list(this) {
 	{
@@ -1440,6 +1455,11 @@ void GDScript::clear() {
 		functions_to_clear.insert(E.value);
 	}
 	member_functions.clear();
+
+	for (GDScriptFunction *E : patched_member_functions) {
+		memdelete(E);
+	}
+	patched_member_functions.clear();
 
 	for (KeyValue<StringName, MemberInfo> &E : member_indices) {
 		E.value.data_type.script_type_ref = Ref<Script>();

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -105,6 +105,7 @@ class GDScript : public Script {
 
 	HashMap<StringName, Variant> constants;
 	HashMap<StringName, GDScriptFunction *> member_functions;
+	LocalVector<GDScriptFunction *> patched_member_functions;
 	HashMap<StringName, Ref<GDScript>> subclasses;
 	HashMap<StringName, MethodInfo> _signals;
 	Dictionary rpc_config;
@@ -342,6 +343,8 @@ public:
 #ifdef TOOLS_ENABLED
 	virtual bool is_placeholder_fallback_enabled() const override { return placeholder_fallback_enabled; }
 #endif
+
+	bool patch_method(const StringName &p_method, const Callable &p_wrapper);
 
 	GDScript();
 	~GDScript();

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -30,8 +30,6 @@
 
 #include "gdscript_byte_codegen.h"
 
-#include "core/debugger/engine_debugger.h"
-
 uint32_t GDScriptByteCodeGenerator::add_parameter(const StringName &p_name, bool p_is_optional, const GDScriptDataType &p_type) {
 	function->_argument_count++;
 	function->argument_types.push_back(p_type);

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "gdscript_function.h"
-#include "gdscript_utility_functions.h"
 
 #include "core/string/string_name.h"
 #include "core/variant/variant.h"

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -34,12 +34,11 @@
 #include "gdscript_analyzer.h"
 #include "gdscript_byte_codegen.h"
 #include "gdscript_cache.h"
+#include "gdscript_function_wrapper_callable.h"
 #include "gdscript_utility_functions.h"
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
-
-#include "scene/scene_string_names.h"
 
 bool GDScriptCompiler::_is_class_member_property(CodeGen &codegen, const StringName &p_name) {
 	if (codegen.function_node && codegen.function_node->is_static) {
@@ -2169,7 +2168,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 				}
 
 				if (return_n->void_return) {
-					// Always return "null", even if the expression is a call to a void function.
+					// Always return `null`, even if the expression is a call to a `void` function.
 					gen->write_return(codegen.add_constant(Variant()));
 				} else {
 					gen->write_return(return_value);
@@ -2669,6 +2668,142 @@ GDScriptFunction *GDScriptCompiler::_make_static_initializer(Error &r_error, GDS
 	return gd_function;
 }
 
+GDScriptFunction *GDScriptCompiler::generate_wrapper(GDScript *p_script, GDScriptFunction *p_previous, const Callable &p_wrapper) {
+	CodeGen codegen;
+	codegen.generator = memnew(GDScriptByteCodeGenerator);
+
+	//codegen.class_node = p_class; // Not required here.
+	codegen.script = p_script;
+
+	const StringName func_name = p_previous->name;
+	const bool is_static = p_previous->is_static();
+	const Variant rpc_config = p_previous->rpc_config;
+	const GDScriptDataType return_type = p_previous->return_type;
+
+	codegen.function_name = func_name;
+	codegen.is_static = is_static;
+	codegen.generator->write_start(p_script, func_name, is_static, rpc_config, return_type);
+
+	const int total_argc = p_previous->_argument_count;
+	const int mandatory_argc = p_previous->_argument_count - p_previous->_default_arg_count;
+	const int optional_argc = p_previous->_default_arg_count;
+	const bool is_vararg = p_previous->is_vararg();
+	const bool is_void = p_previous->return_type.kind == GDScriptDataType::BUILTIN && p_previous->return_type.builtin_type == Variant::NIL;
+
+	Vector<GDScriptCodeGenerator::Address> normal_arg_addrs;
+	GDScriptCodeGenerator::Address vararg_addr;
+	GDScriptCodeGenerator::Address arg_count_addr;
+
+	for (int i = 0; i < p_previous->argument_types.size(); i++) {
+		String par_name = "@arg" + itos(i);
+		bool is_optional = i >= mandatory_argc;
+		GDScriptDataType par_type = p_previous->argument_types[i];
+		uint32_t par_addr = codegen.generator->add_parameter(par_name, is_optional, par_type);
+		GDScriptCodeGenerator::Address arg_addr(GDScriptCodeGenerator::Address::FUNCTION_PARAMETER, par_addr, par_type);
+		codegen.parameters[par_name] = arg_addr;
+		normal_arg_addrs.append(arg_addr);
+	}
+
+	if (is_vararg) {
+		vararg_addr = codegen.add_local("@vararg", GDScriptDataType());
+	}
+
+	if (optional_argc > 0) {
+		GDScriptDataType int_type;
+		int_type.kind = GDScriptDataType::BUILTIN;
+		int_type.builtin_type = Variant::INT;
+		arg_count_addr = codegen.add_local("@arg_count", int_type);
+		codegen.generator->write_assign(arg_count_addr, codegen.add_constant(total_argc));
+
+		codegen.generator->start_parameters();
+		for (int i = mandatory_argc; i < total_argc; i++) {
+			codegen.generator->write_binary_operator(arg_count_addr, Variant::OP_SUBTRACT, arg_count_addr, codegen.add_constant(1));
+
+			GDScriptCodeGenerator::Address arg_addr = codegen.parameters["@arg" + itos(i)];
+			GDScriptCodeGenerator::Address defval_addr = codegen.add_constant(p_previous->_get_default_variant_for_data_type(arg_addr.type));
+			codegen.generator->write_assign_default_parameter(arg_addr, defval_addr, false);
+		}
+		codegen.generator->end_parameters();
+	}
+
+	GDScriptCodeGenerator::Address result_addr;
+	if (is_void) {
+		result_addr = GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::NIL);
+	} else {
+		result_addr = codegen.add_temporary();
+	}
+
+	GDScriptDataType array_type;
+	array_type.kind = GDScriptDataType::BUILTIN;
+	array_type.builtin_type = Variant::ARRAY;
+	GDScriptCodeGenerator::Address args_arr_addr = codegen.add_temporary(array_type);
+
+	GDScriptCodeGenerator::Address nil_addr(GDScriptCodeGenerator::Address::NIL);
+
+	// Collect arguments.
+	codegen.generator->write_construct_array(args_arr_addr, normal_arg_addrs);
+	if (optional_argc > 0) {
+		codegen.generator->write_call_builtin_type(nil_addr, args_arr_addr, Variant::ARRAY, "resize", { arg_count_addr });
+	}
+	if (is_vararg) {
+		codegen.generator->write_call_builtin_type(nil_addr, args_arr_addr, Variant::ARRAY, "append_array", { vararg_addr });
+	}
+
+	GDScriptCodeGenerator::Address self_addr(GDScriptCodeGenerator::Address::SELF);
+
+	GDScriptDataType callable_type;
+	callable_type.kind = GDScriptDataType::BUILTIN;
+	callable_type.builtin_type = Variant::CALLABLE;
+	GDScriptCodeGenerator::Address previous_addr = codegen.add_temporary(callable_type);
+
+	// Construct the `GDScriptFunctionWrapperCallable(self, p_previous)` callable.
+	GDScriptCodeGenerator::Address make_callable_addr = codegen.add_constant(callable_mp_static(&GDScriptFunctionWrapperCallable::make_callable).bind((int64_t)p_previous));
+	codegen.generator->write_call_builtin_type(previous_addr, make_callable_addr, Variant::CALLABLE, "call", { self_addr });
+
+	// Call the `p_wrapper` callable with `(self, args, previous)` arguments.
+	GDScriptCodeGenerator::Address wrapper_addr = codegen.add_constant(p_wrapper);
+	codegen.generator->write_call_async(result_addr, wrapper_addr, "call", { self_addr, args_arr_addr, previous_addr });
+
+	codegen.generator->pop_temporary(); // Pop `previous_addr`.
+	codegen.generator->pop_temporary(); // Pop `args_arr_addr`.
+
+	if (is_void) {
+		// Always return `null`, even if the expression is a call to a `void` function.
+		codegen.generator->write_return(codegen.add_constant(Variant()));
+	} else if (p_previous->return_type.has_type()) {
+		GDScriptCodeGenerator::Address temp_addr = codegen.add_temporary(p_previous->return_type);
+		codegen.generator->write_assign_with_conversion(temp_addr, result_addr);
+		codegen.generator->write_return(temp_addr);
+		codegen.generator->pop_temporary(); // Pop `temp_addr`.
+		codegen.generator->pop_temporary(); // Pop `result_addr`.
+	} else {
+		codegen.generator->write_return(result_addr);
+		codegen.generator->pop_temporary(); // Pop `result_addr`.
+	}
+
+#ifdef DEBUG_ENABLED
+	if (EngineDebugger::is_active()) {
+		codegen.generator->set_signature(p_previous->profile.signature);
+	}
+#endif // DEBUG_ENABLED
+
+	codegen.generator->set_initial_line(p_previous->_initial_line);
+
+	GDScriptFunction *gd_function = codegen.generator->write_end();
+
+	gd_function->return_type = p_previous->return_type;
+
+	if (is_vararg) {
+		gd_function->_vararg_index = vararg_addr.address;
+	}
+
+	gd_function->method_info = p_previous->method_info;
+
+	memdelete(codegen.generator);
+
+	return gd_function;
+}
+
 Error GDScriptCompiler::_parse_setter_getter(GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::VariableNode *p_variable, bool p_is_setter) {
 	Error err = OK;
 
@@ -2711,12 +2846,14 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 	p_script->members.clear();
 
 	// This makes possible to clear script constants and member_functions without heap-use-after-free errors.
+
 	HashMap<StringName, Variant> constants;
 	for (const KeyValue<StringName, Variant> &E : p_script->constants) {
 		constants.insert(E.key, E.value);
 	}
 	p_script->constants.clear();
 	constants.clear();
+
 	HashMap<StringName, GDScriptFunction *> member_functions;
 	for (const KeyValue<StringName, GDScriptFunction *> &E : p_script->member_functions) {
 		member_functions.insert(E.key, E.value);
@@ -2726,6 +2863,11 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 		memdelete(E.value);
 	}
 	member_functions.clear();
+
+	for (GDScriptFunction *E : p_script->patched_member_functions) {
+		memdelete(E);
+	}
+	p_script->patched_member_functions.clear();
 
 	p_script->static_variables.clear();
 
@@ -2739,7 +2881,6 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 		memdelete(p_script->static_initializer);
 	}
 
-	p_script->member_functions.clear();
 	p_script->member_indices.clear();
 	p_script->static_variables_indices.clear();
 	p_script->static_variables.clear();

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -176,6 +176,7 @@ class GDScriptCompiler {
 public:
 	static void convert_to_initializer_type(Variant &p_variant, const GDScriptParser::VariableNode *p_node);
 	static void make_scripts(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);
+	static GDScriptFunction *generate_wrapper(GDScript *p_script, GDScriptFunction *p_previous, const Callable &p_wrapper);
 	Error compile(const GDScriptParser *p_parser, GDScript *p_script, bool p_keep_state = false);
 
 	String get_error() const;

--- a/modules/gdscript/gdscript_function_wrapper_callable.cpp
+++ b/modules/gdscript/gdscript_function_wrapper_callable.cpp
@@ -1,0 +1,126 @@
+/**************************************************************************/
+/*  gdscript_function_wrapper_callable.cpp                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdscript_function_wrapper_callable.h"
+
+#include "gdscript.h"
+
+#include "core/templates/hashfuncs.h"
+
+bool GDScriptFunctionWrapperCallable::compare_equal(const CallableCustom *p_a, const CallableCustom *p_b) {
+	// Wrapper callables are only compared by reference.
+	return p_a == p_b;
+}
+
+bool GDScriptFunctionWrapperCallable::compare_less(const CallableCustom *p_a, const CallableCustom *p_b) {
+	// Wrapper callables are only compared by reference.
+	return p_a < p_b;
+}
+
+bool GDScriptFunctionWrapperCallable::is_valid() const {
+	return function != nullptr;
+}
+
+uint32_t GDScriptFunctionWrapperCallable::hash() const {
+	return h;
+}
+
+String GDScriptFunctionWrapperCallable::get_as_text() const {
+	if (function != nullptr && function->get_name() != StringName()) {
+		return function->get_name().operator String();
+	}
+	return "<invalid GDScript function wrapper>";
+}
+
+CallableCustom::CompareEqualFunc GDScriptFunctionWrapperCallable::get_compare_equal_func() const {
+	return compare_equal;
+}
+
+CallableCustom::CompareLessFunc GDScriptFunctionWrapperCallable::get_compare_less_func() const {
+	return compare_less;
+}
+
+ObjectID GDScriptFunctionWrapperCallable::get_object() const {
+	return object;
+}
+
+StringName GDScriptFunctionWrapperCallable::get_method() const {
+	return (function == nullptr) ? "<invalid GDScript function wrapper>" : function->get_name();
+}
+
+int GDScriptFunctionWrapperCallable::get_argument_count(bool &r_is_valid) const {
+	if (function == nullptr) {
+		r_is_valid = false;
+		return 0;
+	}
+	r_is_valid = true;
+	return function->get_argument_count();
+}
+
+void GDScriptFunctionWrapperCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
+	Object *obj = ObjectDB::get_instance(object);
+
+#ifdef DEBUG_ENABLED
+	if (object.is_valid()) {
+		if (obj == nullptr) {
+			ERR_PRINT("Trying to call a method on a previously freed instance.");
+			r_call_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
+			return;
+		} else if (obj->get_script_instance() == nullptr || obj->get_script_instance()->get_language() != GDScriptLanguage::get_singleton()) {
+			ERR_PRINT("Trying to call a GDScript function wrapper with an invalid instance.");
+			r_call_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
+			return;
+		}
+	}
+#endif // DEBUG_ENABLED
+
+	if (function == nullptr) {
+		r_return_value = Variant();
+		r_call_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
+		return;
+	}
+
+	GDScriptInstance *instance = (obj == nullptr) ? nullptr : static_cast<GDScriptInstance *>(obj->get_script_instance());
+	r_return_value = function->call(instance, p_arguments, p_argcount, r_call_error);
+}
+
+GDScriptFunctionWrapperCallable::GDScriptFunctionWrapperCallable(ObjectID p_object, GDScriptFunction *p_function) :
+		object(p_object), function(p_function) {
+	ERR_FAIL_NULL(p_function);
+
+	h = (uint32_t)hash_murmur3_one_64((uint64_t)this);
+}
+
+Callable GDScriptFunctionWrapperCallable::make_callable(const Variant &p_self, int64_t p_function_ptr) {
+	ObjectID object = (p_self.get_type() == Variant::OBJECT) ? p_self.operator ObjectID() : ObjectID();
+	GDScriptFunction *function = (GDScriptFunction *)p_function_ptr;
+
+	return Callable(memnew(GDScriptFunctionWrapperCallable(object, function)));
+}

--- a/modules/gdscript/gdscript_function_wrapper_callable.h
+++ b/modules/gdscript/gdscript_function_wrapper_callable.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  gdscript_lambda_callable.h                                            */
+/*  gdscript_function_wrapper_callable.h                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -32,19 +32,15 @@
 
 #include "gdscript.h"
 
-#include "core/object/ref_counted.h"
-#include "core/templates/vector.h"
 #include "core/variant/callable.h"
 #include "core/variant/variant.h"
 
 class GDScriptFunction;
 
-class GDScriptLambdaCallable : public CallableCustom {
+class GDScriptFunctionWrapperCallable : public CallableCustom {
+	ObjectID object;
 	GDScript::UpdatableFuncPtr function;
-	Ref<GDScript> script;
 	uint32_t h;
-
-	Vector<Variant> captures;
 
 	static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);
 	static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
@@ -60,38 +56,10 @@ public:
 	int get_argument_count(bool &r_is_valid) const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
-	GDScriptLambdaCallable(GDScriptLambdaCallable &) = delete;
-	GDScriptLambdaCallable(const GDScriptLambdaCallable &) = delete;
-	GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, const Vector<Variant> &p_captures);
-	virtual ~GDScriptLambdaCallable() = default;
-};
+	GDScriptFunctionWrapperCallable(GDScriptFunctionWrapperCallable &) = delete;
+	GDScriptFunctionWrapperCallable(const GDScriptFunctionWrapperCallable &) = delete;
+	GDScriptFunctionWrapperCallable(ObjectID p_object, GDScriptFunction *p_function);
+	virtual ~GDScriptFunctionWrapperCallable() = default;
 
-// Lambda callable that references a particular object, so it can use `self` in the body.
-class GDScriptLambdaSelfCallable : public CallableCustom {
-	GDScript::UpdatableFuncPtr function;
-	Ref<RefCounted> reference; // For objects that are `RefCounted`, keep a reference.
-	Object *object = nullptr; // For non `RefCounted` objects, use a direct pointer.
-	uint32_t h;
-
-	Vector<Variant> captures;
-
-	static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);
-	static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
-
-public:
-	bool is_valid() const override;
-	uint32_t hash() const override;
-	String get_as_text() const override;
-	CompareEqualFunc get_compare_equal_func() const override;
-	CompareLessFunc get_compare_less_func() const override;
-	ObjectID get_object() const override;
-	StringName get_method() const override;
-	int get_argument_count(bool &r_is_valid) const override;
-	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
-
-	GDScriptLambdaSelfCallable(GDScriptLambdaSelfCallable &) = delete;
-	GDScriptLambdaSelfCallable(const GDScriptLambdaSelfCallable &) = delete;
-	GDScriptLambdaSelfCallable(Ref<RefCounted> p_self, GDScriptFunction *p_function, const Vector<Variant> &p_captures);
-	GDScriptLambdaSelfCallable(Object *p_self, GDScriptFunction *p_function, const Vector<Variant> &p_captures);
-	virtual ~GDScriptLambdaSelfCallable() = default;
+	static Callable make_callable(const Variant &p_self, int64_t p_function_ptr);
 };

--- a/modules/gdscript/tests/scripts/runtime/errors/patching_methods.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/patching_methods.gd
@@ -1,0 +1,17 @@
+@abstract class A:
+	@abstract func my_func() -> String
+
+class B extends A:
+	func my_func() -> String:
+		prints("B.my_func")
+		return "abc"
+
+func return_int(_instance: Object, args: Array, previous: Callable) -> int:
+	prints("return_int", args, var_to_str(previous.callv(args)))
+	return 123
+
+func test():
+	print((A as GDScript).patch_method(&"my_func", return_int))
+	print((B as GDScript).patch_method(&"non_existent", return_int))
+	print((B as GDScript).patch_method(&"my_func", return_int))
+	print(var_to_str(B.new().my_func()))

--- a/modules/gdscript/tests/scripts/runtime/errors/patching_methods.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/patching_methods.out
@@ -1,0 +1,8 @@
+GDTEST_RUNTIME_ERROR
+false
+false
+true
+B.my_func
+return_int [] "abc"
+>> SCRIPT ERROR at runtime/errors/patching_methods.gd:5 on B.my_func(): Trying to assign value of type 'int' to a variable of type 'String'.
+""

--- a/modules/gdscript/tests/scripts/runtime/features/patching_methods.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/patching_methods.gd
@@ -1,0 +1,73 @@
+class TestClass:
+	static var max_id: int
+	var id: int
+
+	func _init() -> void:
+		max_id += 1
+		id = max_id
+
+	func _to_string() -> String:
+		return "<TestClass#%d>" % id
+
+	static func static_test_func(a: int, b: int = 0, ...rest: Array) -> int:
+		prints("static_test_func", null, a, b, rest)
+		return 0
+
+	func test_func(a: int, b: int = 0, ...rest: Array) -> int:
+		prints("test_func", self, a, b, rest)
+		return 0
+
+	signal test_signal()
+
+	func test_await(x: int) -> void:
+		prints("test_await", x, "before await")
+		await test_signal
+		prints("test_await", x, "after await")
+
+func add_one(instance: Object, args: Array, previous: Callable) -> int:
+	var result: int = previous.callv(args)
+	prints("add_one", instance, args, previous, result)
+	return result + 1
+
+func add_ten(instance: Object, args: Array, previous: Callable) -> int:
+	var result: int = previous.callv(args)
+	prints("add_ten", instance, args, previous, result)
+	return result + 10
+
+func modify_async(instance: Object, args: Array, previous: Callable) -> void:
+	await previous.call(2)
+	prints("modify_async", instance, args, previous)
+
+func test():
+	print((TestClass as GDScript).patch_method(&"static_test_func", add_one))
+	print((TestClass as GDScript).patch_method(&"static_test_func", add_ten))
+	print((TestClass as GDScript).patch_method(&"test_func", add_one))
+	print((TestClass as GDScript).patch_method(&"test_func", add_ten))
+
+	print("===")
+	print(TestClass.static_test_func(1))
+	print("---")
+	print(TestClass.static_test_func(1, 2))
+	print("---")
+	print(TestClass.static_test_func(1, 2, 3))
+
+	var t := TestClass.new()
+
+	print("===")
+	print(t.test_func(1))
+	print("---")
+	print(t.test_func(1, 2))
+	print("---")
+	print(t.test_func(1, 2, 3))
+
+	print("===")
+	@warning_ignore("missing_await")
+	t.test_await(1)
+	# The replacement does not affect existing coroutines.
+	print((TestClass as GDScript).patch_method(&"test_await", modify_async))
+	t.test_signal.emit()
+
+	print("---")
+	@warning_ignore("missing_await")
+	t.test_await(1)
+	t.test_signal.emit()

--- a/modules/gdscript/tests/scripts/runtime/features/patching_methods.out
+++ b/modules/gdscript/tests/scripts/runtime/features/patching_methods.out
@@ -1,0 +1,43 @@
+GDTEST_OK
+true
+true
+true
+true
+===
+static_test_func <null> 1 0 []
+add_one <null> [1] static_test_func 0
+add_ten <null> [1] static_test_func 1
+11
+---
+static_test_func <null> 1 2 []
+add_one <null> [1, 2] static_test_func 0
+add_ten <null> [1, 2] static_test_func 1
+11
+---
+static_test_func <null> 1 2 [3]
+add_one <null> [1, 2, 3] static_test_func 0
+add_ten <null> [1, 2, 3] static_test_func 1
+11
+===
+test_func <TestClass#1> 1 0 []
+add_one <TestClass#1> [1] test_func 0
+add_ten <TestClass#1> [1] test_func 1
+11
+---
+test_func <TestClass#1> 1 2 []
+add_one <TestClass#1> [1, 2] test_func 0
+add_ten <TestClass#1> [1, 2] test_func 1
+11
+---
+test_func <TestClass#1> 1 2 [3]
+add_one <TestClass#1> [1, 2, 3] test_func 0
+add_ten <TestClass#1> [1, 2, 3] test_func 1
+11
+===
+test_await 1 before await
+true
+test_await 1 after await
+---
+test_await 2 before await
+test_await 2 after await
+modify_async <TestClass#1> [1] test_await


### PR DESCRIPTION
* See #83542.

GDScript currently doesn't allow for script method overriding at runtime, which causes difficulties with modding support. This PR implements a prototype for dynamic method patching using wrappers. This can be used for modding, logging, testing, etc.

```gdscript
func f(a = 0, b = 0, c = 0, ...rest) -> int:
    prints("original", self, a, b, c, rest)
    return 123

func wrapper1(instance: Object, args: Array, previous: Callable) -> int:
    prints("wrapper1", instance, args)
    return previous.callv(args) + 1

func wrapper2(instance: Object, args: Array, previous: Callable) -> int:
    prints("wrapper2", instance, args)
    return previous.callv(args) + 1

func _run() -> void:
    var script: GDScript = get_script()
    script.patch_method(&"f", wrapper1)
    script.patch_method(&"f", wrapper2)
    print(f(1, 2, 3, 4, 5))
    print(f(1, 2))
    print(f())
```

```
wrapper2 <EditorScript#-9223369911198208247> [1, 2, 3, 4, 5]
wrapper1 <EditorScript#-9223369911198208247> [1, 2, 3, 4, 5]
original <EditorScript#-9223369911198208247> 1 2 3 [4, 5]
125
wrapper2 <EditorScript#-9223369911198208247> [1, 2]
wrapper1 <EditorScript#-9223369911198208247> [1, 2]
original <EditorScript#-9223369911198208247> 1 2 0 []
125
wrapper2 <EditorScript#-9223369911198208247> []
wrapper1 <EditorScript#-9223369911198208247> []
original <EditorScript#-9223369911198208247> 0 0 0 []
125
```