### PR TITLE
Improve DockContextPopup spacing

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -918,6 +918,10 @@ DockContextPopup::DockContextPopup() {
 	dock_select_popup_vb->add_child(dock_select);
 	dock_select->connect("slot_clicked", callable_mp(this, &DockContextPopup::_slot_clicked));
 
+	Control *separator = memnew(Control);
+	separator->set_custom_minimum_size(Vector2(0, 8 * EDSCALE));
+	dock_select_popup_vb->add_child(separator);
+
 	make_float_button = memnew(Button);
 	make_float_button->set_text(TTRC("Make Floating"));
 	if (!EditorNode::get_singleton()->is_multi_window_enabled()) {
@@ -972,7 +976,7 @@ void DockSlotGrid::_update_rect_cache() {
 
 	// Temporarily hard-coded, until main screen is registered as a slot.
 	{
-		Rect2 rect = Rect2i(2, 0, 2, 4);
+		Rect2 rect = Rect2i(2, 0, 4, 4);
 		if (is_layout_rtl()) {
 			rect.position.x = GRID_SIZE.x - rect.position.x - rect.size.x;
 		}

--- a/editor/docks/editor_dock_manager.h
+++ b/editor/docks/editor_dock_manager.h
@@ -155,7 +155,7 @@ public:
 class DockSlotGrid : public Control {
 	GDCLASS(DockSlotGrid, Control);
 
-	static constexpr Vector2i GRID_SIZE = Vector2i(6, 8);
+	static constexpr Vector2i GRID_SIZE = Vector2i(8, 8);
 	static constexpr Vector2i MARGINS = Vector2i(4, 8);
 	static constexpr Vector2i CELL_SIZE = Vector2i(24, 12);
 	static constexpr int TABS_PER_CELL = 3;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8619,13 +8619,13 @@ EditorNode::EditorNode() {
 	right_l_vsplit->set_vertical(true);
 	main_hsplit->add_child(right_l_vsplit);
 	{
-		DockTabContainer *dock_container = memnew(SideDockTabContainer(EditorDock::DOCK_SLOT_RIGHT_UL, Rect2i(4, 0, 1, 3)));
+		DockTabContainer *dock_container = memnew(SideDockTabContainer(EditorDock::DOCK_SLOT_RIGHT_UL, Rect2i(6, 0, 1, 3)));
 		dock_container->set_name("DockSlotRightUL");
 		right_l_vsplit->add_child(dock_container);
 		dock_slots.push_back(dock_container);
 	}
 	{
-		DockTabContainer *dock_container = memnew(SideDockTabContainer(EditorDock::DOCK_SLOT_RIGHT_BL, Rect2i(4, 3, 1, 3)));
+		DockTabContainer *dock_container = memnew(SideDockTabContainer(EditorDock::DOCK_SLOT_RIGHT_BL, Rect2i(6, 3, 1, 3)));
 		dock_container->set_name("DockSlotRightBL");
 		right_l_vsplit->add_child(dock_container);
 		dock_slots.push_back(dock_container);
@@ -8636,13 +8636,13 @@ EditorNode::EditorNode() {
 	right_r_vsplit->set_vertical(true);
 	main_hsplit->add_child(right_r_vsplit);
 	{
-		DockTabContainer *dock_container = memnew(SideDockTabContainer(EditorDock::DOCK_SLOT_RIGHT_UR, Rect2i(5, 0, 1, 3)));
+		DockTabContainer *dock_container = memnew(SideDockTabContainer(EditorDock::DOCK_SLOT_RIGHT_UR, Rect2i(7, 0, 1, 3)));
 		dock_container->set_name("DockSlotRightUR");
 		right_r_vsplit->add_child(dock_container);
 		dock_slots.push_back(dock_container);
 	}
 	{
-		DockTabContainer *dock_container = memnew(SideDockTabContainer(EditorDock::DOCK_SLOT_RIGHT_BR, Rect2i(5, 3, 1, 3)));
+		DockTabContainer *dock_container = memnew(SideDockTabContainer(EditorDock::DOCK_SLOT_RIGHT_BR, Rect2i(7, 3, 1, 3)));
 		dock_container->set_name("DockSlotRightBR");
 		right_r_vsplit->add_child(dock_container);
 		dock_slots.push_back(dock_container);
@@ -8652,13 +8652,13 @@ EditorNode::EditorNode() {
 	bottom_hsplit->set_name("DockHSplitBottom");
 	main_vsplit->add_child(bottom_hsplit);
 	{
-		DockTabContainer *dock_container = memnew(BottomSideDockTabContainer(EditorDock::DOCK_SLOT_BOTTOM_L, Rect2i(0, 6, 3, 2)));
+		DockTabContainer *dock_container = memnew(BottomSideDockTabContainer(EditorDock::DOCK_SLOT_BOTTOM_L, Rect2i(0, 6, 4, 2)));
 		dock_container->set_name("DockSlotBottomL");
 		bottom_hsplit->add_child(dock_container);
 		dock_slots.push_back(dock_container);
 	}
 	{
-		DockTabContainer *dock_container = memnew(BottomSideDockTabContainer(EditorDock::DOCK_SLOT_BOTTOM_R, Rect2i(3, 6, 3, 2)));
+		DockTabContainer *dock_container = memnew(BottomSideDockTabContainer(EditorDock::DOCK_SLOT_BOTTOM_R, Rect2i(4, 6, 4, 2)));
 		dock_container->set_name("DockSlotBottomR");
 		bottom_hsplit->add_child(dock_container);
 		dock_slots.push_back(dock_container);

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -270,7 +270,7 @@ void EditorBottomPanel::_on_button_visibility_changed(Button *p_button, EditorDo
 EditorBottomPanel::EditorBottomPanel() :
 		DockTabContainer(EditorDock::DOCK_SLOT_BOTTOM) {
 	layout = EditorDock::DOCK_LAYOUT_HORIZONTAL;
-	grid_rect = Rect2i(2, 4, 2, 2);
+	grid_rect = Rect2i(2, 4, 4, 2);
 
 	get_tab_bar()->connect("tab_changed", callable_mp(this, &EditorBottomPanel::_on_tab_changed));
 	set_tabs_position(TabPosition::POSITION_BOTTOM);


### PR DESCRIPTION
I noticed that after adding the new bottom dock slots, the new slots have confusing margin at the top due to not having any tabs by default. So this PR adds a separator, which makes them look more like slots. Also addresses https://github.com/godotengine/godot/pull/114360#issuecomment-3917406461

|Before|After|
|-|-|
|<img width="215" height="306" alt="image" src="https://github.com/user-attachments/assets/8052a645-359b-4907-ae2d-bd380d001f46" />|<img width="259" height="317" alt="image" src="https://github.com/user-attachments/assets/470495e9-23dd-4fe3-81bf-68222b9f291d" />|

HOWEVER 💀
There is a problem with the new size. Ideally the bottom panel should take 3 cells in the grid, but in this PR it takes 4, making the main screen part awkwardly square, which again does not really represent how it looks normally (or maybe it's like that on bigger screens?). This is because the new bottom slots kinda enforce the width to be even (unless we allow them to be asymmetrical :/). You can check the linked comment for comparison.