### PR TITLE
CI: Bump ruff hook (0.15.0 → 0.15.8)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
         stages: [manual]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.0
+    rev: v0.15.8
     hooks:
       - id: ruff-check
         args: [--color=always]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,20 +21,25 @@ preview = true
 fix = true
 
 [tool.ruff.lint]
+# NOTE: Starting with `0.15.2`, ruff uses a SIGNIFICANTLY expanded set of default rules for
+#  preview builds. While expanding into these new rulesets is something we're interested in,
+#  we'll adopt them gradually, depending on our needs. As such, our base `select` utilizes the
+#  legacy defaults.
+select = ["E4", "E7", "E9", "F"]
 extend-select = [
-	"I",     # isort
-	"UP006", # Use {to} instead of {from} for type annotation
-	"UP007", # Use `X | Y` for type annotations
-	"UP037", # Remove quotes from type annotation
-	"FA",    # Future annotations
+	"FA",    # flake8-future-annotations.
+	"I",     # isort.
+	"UP006", # Use {to} instead of {from} for type annotation.
+	"UP007", # Use `X | Y` for type annotations.
+	"UP037", # Remove quotes from type annotation.
 ]
-extend-safe-fixes = ["UP006", "UP007", "FA"]
+extend-safe-fixes = ["FA", "UP006", "UP007"]
 
 [tool.ruff.lint.per-file-ignores]
 "{SConstruct,SCsub}" = [
-	"E402", # Module level import not at top of file
-	"F403", # Undefined local with import star
-	"F405", # Undefined local with import star usage
+	"E402", # Module level import not at top of file.
+	"F403", # Undefined local with import star.
+	"F405", # Undefined local with import star usage.
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
So originally I was gonna bump ruff as part of the PR bumping our minimum Python version, but it turns out that Ruff made a *significant* change starting with 0.15.2: preview builds have a new set of defaults[^1]! Speaking as the guy who's normally all-in for cutting-edge goodies: **this is way too much all at once**. Granted, I *have* wanted to expand our ruleset for a while now, and these tentative new rules seem like a great end-goal; however, that should be achieved as a gradual roll-out from a familiar baseline. As such, this bump also freezes the "legacy" ruff ruleset alongside our current rules, which is a bit more verbose but is functionally identical to preview rulesets prior to 0.15.2

[^1]: https://github.com/astral-sh/ruff/discussions/23203