### PR TITLE
Fix game speed UI not resetting when game is restarted (from editor)

### DIFF
--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -561,7 +561,9 @@ void GameView::_update_debugger_buttons() {
 	suspend_button->set_disabled(empty);
 	camera_override_button->set_disabled(empty);
 	speed_state_button->set_disabled(empty);
-	reset_speed_button->set_disabled(empty);
+	bool disabled = time_scale_index == DEFAULT_TIME_SCALE_INDEX;
+
+	reset_speed_button->set_disabled(empty || disabled);
 
 	PopupMenu *menu = camera_override_menu->get_popup();
 
@@ -676,12 +678,11 @@ void GameView::_embed_options_menu_menu_id_pressed(int p_id) {
 }
 
 void GameView::_reset_time_scales() {
-	if (!is_visible_in_tree()) {
-		return;
-	}
 	time_scale_index = DEFAULT_TIME_SCALE_INDEX;
 	debugger->reset_time_scale();
-	_update_speed_buttons();
+	if (is_inside_tree()) {
+		_update_speed_buttons();
+	}
 }
 
 void GameView::_speed_state_menu_pressed(int p_id) {


### PR DESCRIPTION
`_reset_time_scales()` has a visibility guard that was originally needed to prevent resets on session start. After 4e06e305bf2311abb1818085f0022b1e65eda442 scoped the call to only run when all sessions end, the guard is unnecessary and prevents the speed state from being properly reset.

Fixes #115400.

Previously, if you started a game from the editor, set the speed to 2x or something in the pop-up game window toolbar, then closed out using the normal x in the title, and then restart, the UI would still show 2x, but the game itself would still be running at 1x. A minor annoyance. You could still just click 2x again and get the expected behavior.

Now, with this fix, both the actual speed and the displayed icon match the 1x expectation on launch.

I'm not familiar enough with the codebase to know if this alone is a sufficient test case.

Fixed:
[Screencast from 2026-02-20 19-32-22.webm](https://github.com/user-attachments/assets/de50e9fc-9efb-4595-9101-403ab8de7ac0)

Tested on Ubuntu + Godot 4.6.1 (and tip of master), C# version. I believe it was also happening in 4.6.0.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

---

_Disclaimer: this problem was identified and solution verified by me, but the root cause analysis and implementation was performed by Claude Code w/ Opus 4.6._
