### PR TITLE
Volumetric soft body

### DIFF
--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1299,7 +1299,7 @@
 		<method name="soft_body_set_form">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
-			<param index="1" name="mode" type="int" enum="PhysicsServer3D.SoftBodyForm" />
+			<param index="1" name="form" type="int" enum="PhysicsServer3D.SoftBodyForm" />
 			<description>
 				Sets the geometric form of the soft body.  Choose between either cloth or volumetric.
 				[b]Note:[/b] This value is currently unused by Godot's default physics implementation.
@@ -1454,6 +1454,12 @@
 		</method>
 	</methods>
 	<constants>
+		<constant name="SOFT_BODY_FORM_CLOTH" value="0" enum="SoftBodyForm">
+			Soft body simulates cloth.
+		</constant>
+		<constant name="SOFT_BODY_FORM_VOLUME" value="1" enum="SoftBodyForm">
+			Soft body simulates a volumetric form.
+		</constant>
 		<constant name="JOINT_TYPE_PIN" value="0" enum="JointType">
 			The [Joint3D] is a [PinJoint3D].
 		</constant>
@@ -1839,12 +1845,6 @@
 		</constant>
 		<constant name="BODY_STATE_CAN_SLEEP" value="4" enum="BodyState">
 			Constant to set/get whether the body can sleep.
-		</constant>
-		<constant name="SOFT_BODY_FORM_CLOTH" value="0" enum="SoftBodyForm">
-			Soft body simulates cloth.
-		</constant>
-		<constant name="SOFT_BODY_FORM_VOLUME" value="1" enum="SoftBodyForm">
-			Soft body simulates a volumetric form.
 		</constant>
 		<constant name="AREA_BODY_ADDED" value="0" enum="AreaBodyStatus">
 			The value of the first parameter and area callback function receives, when an object enters one of its shapes.

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1301,7 +1301,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mode" type="int" enum="PhysicsServer3D.SoftBodyForm" />
 			<description>
-				Sets the gometric form of the soft body.  Choose between either cloth or volumetric.
+				Sets the geometric form of the soft body.  Choose between either cloth or volumetric.
 				[b]Note:[/b] This value is currently unused by Godot's default physics implementation.
 			</description>
 		</method>

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1155,6 +1155,13 @@
 				Returns the drag coefficient of the given soft body.
 			</description>
 		</method>
+		<method name="soft_body_get_form" qualifiers="const">
+			<return type="int" enum="PhysicsServer3D.SoftBodyForm" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns the volumetric form of the body.
+			</description>
+		</method>
 		<method name="soft_body_get_linear_stiffness" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
@@ -1286,6 +1293,15 @@
 			<param index="1" name="drag_coefficient" type="float" />
 			<description>
 				Sets the drag coefficient of the given soft body. Higher values increase this body's air resistance.
+				[b]Note:[/b] This value is currently unused by Godot's default physics implementation.
+			</description>
+		</method>
+		<method name="soft_body_set_form">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="mode" type="int" enum="PhysicsServer3D.SoftBodyForm" />
+			<description>
+				Sets the gometric form of the soft body.  Choose between either cloth or volumetric.
 				[b]Note:[/b] This value is currently unused by Godot's default physics implementation.
 			</description>
 		</method>
@@ -1823,6 +1839,12 @@
 		</constant>
 		<constant name="BODY_STATE_CAN_SLEEP" value="4" enum="BodyState">
 			Constant to set/get whether the body can sleep.
+		</constant>
+		<constant name="SOFT_BODY_FORM_CLOTH" value="0" enum="SoftBodyForm">
+			Soft body simulates cloth.
+		</constant>
+		<constant name="SOFT_BODY_FORM_VOLUME" value="1" enum="SoftBodyForm">
+			Soft body simulates a volumetric form.
 		</constant>
 		<constant name="AREA_BODY_ADDED" value="0" enum="AreaBodyStatus">
 			The value of the first parameter and area callback function receives, when an object enters one of its shapes.

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -1183,7 +1183,7 @@
 		<method name="_soft_body_set_form" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
-			<param index="1" name="mode" type="int" enum="PhysicsServer3D.SoftBodyForm" />
+			<param index="1" name="form" type="int" enum="PhysicsServer3D.SoftBodyForm" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -1060,6 +1060,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_soft_body_get_form" qualifiers="virtual required const">
+			<return type="int" enum="PhysicsServer3D.SoftBodyForm" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_soft_body_get_linear_stiffness" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
@@ -1174,6 +1180,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="_soft_body_set_form" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="drag_coefficient" type="float" />
+			<description>
+			</description>
+		</method>
 		<method name="_soft_body_set_linear_stiffness" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
@@ -1184,7 +1197,7 @@
 		<method name="_soft_body_set_mesh" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
-			<param index="1" name="mesh" type="RID" />
+			<param index="1" name="mode" type="int" enum="PhysicsServer3D.SoftBodyForm" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -1183,7 +1183,7 @@
 		<method name="_soft_body_set_form" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
-			<param index="1" name="drag_coefficient" type="float" />
+			<param index="1" name="mode" type="int" enum="PhysicsServer3D.SoftBodyForm" />
 			<description>
 			</description>
 		</method>
@@ -1197,7 +1197,7 @@
 		<method name="_soft_body_set_mesh" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
-			<param index="1" name="mode" type="int" enum="PhysicsServer3D.SoftBodyForm" />
+			<param index="1" name="mesh" type="RID" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -164,6 +164,7 @@
 			Increasing this value will improve the resulting simulation, but can affect performance. Use with care.
 		</member>
 		<member name="soft_body_form" type="int" setter="set_soft_body_form" getter="get_soft_body_form" enum="PhysicsServer3D.SoftBodyForm" default="0">
+			Changes how the mesh structure is interpreted - as either cloth or a volumetric form.
 		</member>
 		<member name="total_mass" type="float" setter="set_total_mass" getter="get_total_mass" default="1.0">
 			The SoftBody3D's mass.

--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -144,6 +144,9 @@
 			The body's drag coefficient. Higher values increase this body's air resistance.
 			[b]Note:[/b] This value is currently unused by Godot's default physics implementation.
 		</member>
+		<member name="form" type="int" setter="set_form" getter="get_form" enum="PhysicsServer3D.SoftBodyForm" default="0">
+			Changes how the mesh structure is interpreted - either as cloth or a volumetric form.
+		</member>
 		<member name="linear_stiffness" type="float" setter="set_linear_stiffness" getter="get_linear_stiffness" default="0.5">
 			Higher values will result in a stiffer body, while lower values will increase the body's ability to bend. The value can be between [code]0.0[/code] and [code]1.0[/code] (inclusive).
 		</member>
@@ -162,9 +165,6 @@
 		</member>
 		<member name="simulation_precision" type="int" setter="set_simulation_precision" getter="get_simulation_precision" default="5">
 			Increasing this value will improve the resulting simulation, but can affect performance. Use with care.
-		</member>
-		<member name="soft_body_form" type="int" setter="set_soft_body_form" getter="get_soft_body_form" enum="PhysicsServer3D.SoftBodyForm" default="0">
-			Changes how the mesh structure is interpreted - as either cloth or a volumetric form.
 		</member>
 		<member name="total_mass" type="float" setter="set_total_mass" getter="get_total_mass" default="1.0">
 			The SoftBody3D's mass.

--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -163,6 +163,8 @@
 		<member name="simulation_precision" type="int" setter="set_simulation_precision" getter="get_simulation_precision" default="5">
 			Increasing this value will improve the resulting simulation, but can affect performance. Use with care.
 		</member>
+		<member name="soft_body_form" type="int" setter="set_soft_body_form" getter="get_soft_body_form" enum="PhysicsServer3D.SoftBodyForm" default="0">
+		</member>
 		<member name="total_mass" type="float" setter="set_total_mass" getter="get_total_mass" default="1.0">
 			The SoftBody3D's mass.
 		</member>

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1203,6 +1203,21 @@ AABB GodotPhysicsServer3D::soft_body_get_bounds(RID p_body) const {
 	return soft_body->get_bounds();
 }
 
+void GodotPhysicsServer3D::soft_body_set_form(RID p_body, PhysicsServer3D::SoftBodyForm p_form) {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(soft_body);
+
+	ERR_FAIL_COND_MSG(p_form != PhysicsServer3D::SOFT_BODY_FORM_CLOTH, "GodotPhysicsServer3D only handles cloth deformation");
+}
+
+PhysicsServer3D::SoftBodyForm GodotPhysicsServer3D::soft_body_get_form(RID p_body) const {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(soft_body, PhysicsServer3D::SOFT_BODY_FORM_CLOTH);
+
+	//For now, GodotPhysicsServer3D only handles cloth deformation
+	return PhysicsServer3D::SOFT_BODY_FORM_CLOTH;
+}
+
 void GodotPhysicsServer3D::soft_body_move_point(RID p_body, int p_point_index, const Vector3 &p_global_position) {
 	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(soft_body);

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1214,7 +1214,7 @@ PhysicsServer3D::SoftBodyForm GodotPhysicsServer3D::soft_body_get_form(RID p_bod
 	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_V(soft_body, PhysicsServer3D::SOFT_BODY_FORM_CLOTH);
 
-	//For now, GodotPhysicsServer3D only handles cloth deformation
+	// GodotPhysicsServer3D only handles cloth deformation
 	return PhysicsServer3D::SOFT_BODY_FORM_CLOTH;
 }
 

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -310,6 +310,9 @@ public:
 
 	virtual AABB soft_body_get_bounds(RID p_body) const override;
 
+	virtual void soft_body_set_form(RID p_body, SoftBodyForm p_form) override;
+	virtual SoftBodyForm soft_body_get_form(RID p_body) const override;
+
 	virtual void soft_body_move_point(RID p_body, int p_point_index, const Vector3 &p_global_position) override;
 	virtual Vector3 soft_body_get_point_global_position(RID p_body, int p_point_index) const override;
 

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -1034,6 +1034,20 @@ AABB JoltPhysicsServer3D::soft_body_get_bounds(RID p_body) const {
 	return body->get_bounds();
 }
 
+void JoltPhysicsServer3D::soft_body_set_form(RID p_body, SoftBodyForm p_form) {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->set_soft_body_form(p_form);
+}
+
+JoltPhysicsServer3D::SoftBodyForm JoltPhysicsServer3D::soft_body_get_form(RID p_body) const {
+	const JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, SOFT_BODY_FORM_CLOTH);
+
+	return body->get_soft_body_form();
+}
+
 void JoltPhysicsServer3D::soft_body_set_collision_layer(RID p_body, uint32_t p_layer) {
 	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -1038,14 +1038,14 @@ void JoltPhysicsServer3D::soft_body_set_form(RID p_body, SoftBodyForm p_form) {
 	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
-	body->set_soft_body_form(p_form);
+	body->set_form(p_form);
 }
 
 JoltPhysicsServer3D::SoftBodyForm JoltPhysicsServer3D::soft_body_get_form(RID p_body) const {
 	const JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_V(body, SOFT_BODY_FORM_CLOTH);
 
-	return body->get_soft_body_form();
+	return body->get_form();
 }
 
 void JoltPhysicsServer3D::soft_body_set_collision_layer(RID p_body, uint32_t p_layer) {

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -352,8 +352,10 @@ public:
 
 	virtual AABB soft_body_get_bounds(RID p_body) const override;
 
-	virtual void soft_body_move_point(RID p_body, int p_point_index, const Vector3 &p_global_position) override;
+	virtual void soft_body_set_form(RID p_body, SoftBodyForm p_form) override;
+	virtual SoftBodyForm soft_body_get_form(RID p_body) const override;
 
+	virtual void soft_body_move_point(RID p_body, int p_point_index, const Vector3 &p_global_position) override;
 	virtual Vector3 soft_body_get_point_global_position(RID p_body, int p_point_index) const override;
 
 	virtual void soft_body_remove_all_pinned_points(RID p_body) override;

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -127,7 +127,7 @@ void JoltSoftBody3D::_add_to_space() {
 }
 
 JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
-	switch (soft_body_form) {
+	switch (form) {
 		default:
 		case PhysicsServer3D::SOFT_BODY_FORM_CLOTH:
 			return _create_shared_settings_cloth();
@@ -988,12 +988,12 @@ void JoltSoftBody3D::set_state(PhysicsServer3D::BodyState p_state, const Variant
 	}
 }
 
-PhysicsServer3D::SoftBodyForm JoltSoftBody3D::get_soft_body_form() const {
-	return soft_body_form;
+PhysicsServer3D::SoftBodyForm JoltSoftBody3D::get_form() const {
+	return form;
 }
 
-void JoltSoftBody3D::set_soft_body_form(PhysicsServer3D::SoftBodyForm p_soft_body_form) {
-	soft_body_form = p_soft_body_form;
+void JoltSoftBody3D::set_form(PhysicsServer3D::SoftBodyForm p_form) {
+	form = p_form;
 	_try_rebuild();
 }
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -43,7 +43,11 @@
 
 #include "Jolt/Physics/SoftBody/SoftBodyMotionProperties.h"
 
+#include <array>
 #include <set>
+#include <map>
+#include <vector>
+#include "../../core/math/triangle_mesh.h"
 
 namespace {
 
@@ -336,14 +340,231 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	const PackedVector3Array mesh_vertices = mesh_data[RenderingServer::ARRAY_VERTEX];
 	ERR_FAIL_COND_V(mesh_vertices.is_empty(), nullptr);
 
-//	std::cout << "entering JoltSoftBody3D::_create_shared_settings_volume()" << std::endl;
-	//WARN_PRINT("entering JoltSoftBody3D::_create_shared_settings_volume()");
+	const Vector3 body_position = Vector3(jolt_settings->mPosition.GetX(), jolt_settings->mPosition.GetY(), jolt_settings->mPosition.GetZ());
 
-	Vector<int32_t> tetrahedra_indices = Geometry3D::tetrahedralize_delaunay(mesh_vertices);
+	//Merge any duplicate vertices in input mesh
+	PackedInt32Array mesh_indices_clean;
+	PackedVector3Array mesh_vertices_clean;
+	std::map<Vector3, int> mesh_vert_to_clean_idx_map;
 
+	for (int i = 0; i < mesh_indices.size(); ++i) {
+		const Vector3 &v = mesh_vertices[mesh_indices[i]] - body_position;
+
+		auto it = mesh_vert_to_clean_idx_map.find(v);
+		if (it == mesh_vert_to_clean_idx_map.end()) {
+			int index = mesh_vertices_clean.size();
+			mesh_vertices_clean.push_back(v);
+			mesh_indices_clean.push_back(index);
+			mesh_vert_to_clean_idx_map[v] = index;
+		} else {
+			int index = it->second;
+			mesh_indices_clean.push_back(index);
+		}
+	}
+
+
+	//Do delaunay tesselation
+	Vector<int32_t> tetrahedra_indices = Geometry3D::tetrahedralize_delaunay(mesh_vertices_clean);
+
+
+	//Find tetrahedra links
+	struct TetrahedraInfo {
+		int index;
+		bool valid;
+		Vector3i face_keys[4];
+		int neighbors[4];
+		int vert_indices[4];
+	};
+	std::vector<TetrahedraInfo> tet_info_list;
+	tet_info_list.reserve(tetrahedra_indices.size() / 4);
+
+	HashMap<Vector3i, int> face_key_to_tet_idx;
+	std::set<Vector3i> face_exterior;
+	std::set<Vector2i> edge_set;
+
+	auto edge_hash_key = [&](int a, int b) {
+		if (b < a) {
+			return Vector2i(b, a);
+		}
+		return Vector2i(a, b);
+	};
+
+	auto face_hash_key = [&](int a, int b, int c) {
+		if (c < a && c < b) {
+			return Vector3i(c, a, b);
+		}
+		if (b < a) {
+			return Vector3i(b, c, a);
+		}
+		return Vector3i(a, b, c);
+	};
+
+	auto face_flipped = [&](Vector3i a) {
+		return Vector3i(a.x, a.z, a.y);
+	};
+
+	
+
+	//Track tetrahedra
+	for (int i = 0; i < tetrahedra_indices.size(); i += 4) {
+		int tet_idx = i / 4;
+
+		int vi0 = tetrahedra_indices[i];
+		int vi1 = tetrahedra_indices[i + 1];
+		int vi2 = tetrahedra_indices[i + 2];
+		int vi3 = tetrahedra_indices[i + 3];
+
+		Vector3 v0 = mesh_vertices_clean[vi0];
+		Vector3 v1 = mesh_vertices_clean[vi1];
+		Vector3 v2 = mesh_vertices_clean[vi2];
+		Vector3 v3 = mesh_vertices_clean[vi3];
+
+		//If volume has incorrect sign, flip order of vertices
+		Basis b(v1 - v0, v2 - v0, v3 - v0);
+		if (b.determinant() < 0) {
+			std::swap(vi2, vi3);
+		}
+
+		//Add edges
+		edge_set.insert(edge_hash_key(vi0, vi1));
+		edge_set.insert(edge_hash_key(vi0, vi2));
+		edge_set.insert(edge_hash_key(vi0, vi3));
+		edge_set.insert(edge_hash_key(vi1, vi2));
+		edge_set.insert(edge_hash_key(vi1, vi3));
+		edge_set.insert(edge_hash_key(vi2, vi3));
+
+		//Add to face-to-tetrahedron map
+		Vector3i f0 = face_hash_key(vi0, vi1, vi2);
+		Vector3i f1 = face_hash_key(vi1, vi0, vi3);
+		Vector3i f2 = face_hash_key(vi2, vi3, vi0);
+		Vector3i f3 = face_hash_key(vi3, vi2, vi1);
+		face_key_to_tet_idx[f0] = tet_idx;
+		face_key_to_tet_idx[f1] = tet_idx;
+		face_key_to_tet_idx[f2] = tet_idx;
+		face_key_to_tet_idx[f3] = tet_idx;
+
+		//Create tetrahedra tracker
+		TetrahedraInfo info;
+		info.index = tet_idx;
+		info.valid = true;
+
+		info.vert_indices[0] = vi0;
+		info.vert_indices[1] = vi1;
+		info.vert_indices[2] = vi2;
+		info.vert_indices[3] = vi3;
+
+		info.face_keys[0] = f0;
+		info.face_keys[1] = f1;
+		info.face_keys[2] = f2;
+		info.face_keys[3] = f3;
+
+		info.neighbors[0] = -1;
+		info.neighbors[1] = -1;
+		info.neighbors[2] = -1;
+		info.neighbors[3] = -1;
+
+		tet_info_list.push_back(info);
+	}
+
+	//Connect tet neighbors
+	for (TetrahedraInfo &t_info : tet_info_list) {
+		for (int i = 0; i < 4; ++i) {
+			Vector3i k0 = t_info.face_keys[i];
+			Vector3i k1 = face_flipped(k0);
+
+			HashMap<Vector3i, int>::ConstIterator it = face_key_to_tet_idx.find(k1);
+			if (it != face_key_to_tet_idx.end()) {
+				t_info.neighbors[i] = it->value;
+			}
+		}
+	}
+
+
+	//Mark exterior tetrahedra
+	bool convex_hull = false;
+	if (!convex_hull) {
+		//Create mesh for inside/outside tests
+		PackedVector3Array surface_tris;
+		surface_tris.reserve(mesh_indices_clean.size());
+
+		PackedVector3Array surface_norms;
+		surface_norms.reserve(mesh_indices_clean.size() / 3);
+
+		for (int i = 0; i < mesh_indices_clean.size(); ++i) {
+			surface_tris.append(mesh_vertices_clean[mesh_indices_clean[i]]);
+		}
+		for (int i = 0; i < surface_tris.size(); i += 3) {
+			Vector3 v0 = surface_tris[i];
+			Vector3 v1 = surface_tris[i + 1];
+			Vector3 v2 = surface_tris[i + 2];
+			surface_norms.append((v1 - v0).cross(v2 - v0).normalized());
+		}
+
+		TriangleMesh surface_mesh;
+		surface_mesh.create_from_faces(surface_tris);
+
+		//Find valid tetrahedra
+		const Vector3 cast_dirs[] = {
+			Vector3(1, 0, 0),
+			Vector3(-1, 0, 0),
+			Vector3(0, 1, 0),
+			Vector3(0, -1, 0),
+			Vector3(0, 0, 1),
+			Vector3(0, 0, -1),
+		};
+
+		for (TetrahedraInfo &t_info : tet_info_list) {
+			Vector3 v0 = mesh_vertices_clean[t_info.vert_indices[0]];
+			Vector3 v1 = mesh_vertices_clean[t_info.vert_indices[1]];
+			Vector3 v2 = mesh_vertices_clean[t_info.vert_indices[2]];
+			Vector3 v3 = mesh_vertices_clean[t_info.vert_indices[3]];
+			Vector3 center = (v0 + v1 + v2 + v3) / 4.0;
+
+			Vector3 point;
+			Vector3 normal;
+			int32_t surf_idx;
+			int32_t face_idx;
+
+//			Vector3 ray_dir = Vector3(1, 0, 0);
+			for (int i = 0; i < 6; ++i) {
+				const Vector3 ray_dir = cast_dirs[i];
+				bool hit = surface_mesh.intersect_ray(center, ray_dir, point, normal, &surf_idx, &face_idx);
+				if (!hit || surface_norms[face_idx].dot(ray_dir) > 0) {
+					//Missed mesh or hit exterior
+					t_info.valid = false;
+					break;
+				}
+			}
+		}
+
+
+	}
+
+	//Find exterior faces
+	for (TetrahedraInfo &t_info : tet_info_list) {
+		if (!t_info.valid) {
+			continue;
+		}
+
+		for (int i = 0; i < 4; ++i) {
+			Vector3i f = t_info.face_keys[i];
+			if (t_info.neighbors[i] == -1 || !tet_info_list[t_info.neighbors[i]].valid) {
+				face_exterior.emplace(f);
+			}
+		}
+	}
 
 	JPH::SoftBodySharedSettings *settings = new JPH::SoftBodySharedSettings();
+	////physics_vertices.emplace_back(JPH::Float3((float)(vertex.x - body_position.GetX())
+	//for (Vector3 v : mesh_vertices_clean) {
+	//	settings->emplace_back(JPH::Float3(v.x, v.y, v.z));
+	//}
 
+
+	return _create_shared_settings_cloth();
+
+	/////////////////
+	/*
 	HashMap<Vector3, int> point_to_physics_index;
 
 	const int mesh_vertex_count = mesh_vertices.size();
@@ -356,10 +577,24 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	settings->mVertices.reserve(mesh_vertex_count);
 	point_to_physics_index.reserve(mesh_vertex_count);
 
+	// 
+	//int next_phys_vert_idx = 0;
+	//for (int i = 0; i < tetrahedra_indices.size(); ++i) {
+	//	int vi_mesh = tetrahedra_indices[i];
+	//	Vector3 v = mesh_vertices[vi_mesh];
+
+	//	if (point_to_physics_index.find(v) != point_to_physics_index.end()) {
+	//		point_to_physics_index[v] = next_phys_vert_idx++;
+	//	}
+	//}
+
+	JPH::SoftBodySharedSettings *settings = new JPH::SoftBodySharedSettings();
+
 	const JPH::RVec3 body_position = jolt_settings->mPosition;
 
 	std::set<std::tuple<int, int>> scanned_edges;
-//	std::set<std::tuple<int, int, int>> scanned_faces;
+	//	std::set<std::tuple<int, int, int>> scanned_faces;
+	HashMap<std::tuple<int, int, int>, int> scanned_face_count;
 
 	auto append_edge_if_absent = [&](int a, int b) {
 		if (a > b) {
@@ -442,14 +677,17 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		//append_face_if_absent(physics_tet[3], physics_tet[2], physics_tet[1]);
 
 		//Add tetrahedron
+		//det([v1 - v0, v2 - v0, v3 - v0]) should be positive to match tetrahedra in SoftBodySharedSettings::sCreateCube
 		JPH::SoftBodySharedSettings::Volume v;
 		v.mVertex[0] = (JPH::uint32)physics_tet[0];
 		v.mVertex[1] = (JPH::uint32)physics_tet[1];
 		v.mVertex[2] = (JPH::uint32)physics_tet[2];
 		v.mVertex[3] = (JPH::uint32)physics_tet[3];
-		settings->mVolumeConstraints.emplace_back(v);
+		settings->mVolumeConstraints.push_back(v);
 	}
-	/*	
+	settings->CalculateEdgeLengths();
+	settings->CalculateVolumeConstraintVolumes();
+
 	//Add surface faces only
 	for (int i = 0; i < mesh_index_count; i += 3) {
 		int vi0 = mesh_to_physics[i];
@@ -467,8 +705,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		settings->AddFace(f);
 		//settings->mFaces.emplace_back((JPH::uint32)vi2, (JPH::uint32)vi1, (JPH::uint32)vi0);
 	}
-	*/
-
+*/
 	/*
 	// Pin whatever pinned vertices we have currently. This is used during the `Optimize` call below to order the
 	// constraints. Note that it's fine if the pinned vertices change later, but that will reduce the effectiveness
@@ -489,9 +726,9 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		e.mRestLength *= multiplier;
 	}
 	*/
-	settings->Optimize();
+	//settings->Optimize();
 
-	return settings;
+	//return settings;
 }
 
 void JoltSoftBody3D::_update_mass() {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -529,7 +529,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 			int32_t face_idx;
 
 			for (int i = 0; i < 6; ++i) {
-				const Vector3 ray_dir = cast_dirs[i];
+				const Vector3 &ray_dir = cast_dirs[i];
 				bool hit = surface_mesh.intersect_ray(center, ray_dir, point, normal, &surf_idx, &face_idx);
 				if (!hit || surface_norms[face_idx].dot(ray_dir) > 0) {
 					//Missed mesh or hit exterior

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -158,8 +158,8 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_cloth() {
 	const int mesh_vertex_count = mesh_vertices.size();
 	const int mesh_index_count = mesh_indices.size();
 
-	mesh_to_physics_vertex_index.resize(mesh_vertex_count);
-	for (int &index : mesh_to_physics_vertex_index) {
+	mesh_to_physics.resize(mesh_vertex_count);
+	for (int &index : mesh_to_physics) {
 		index = -1;
 	}
 	physics_vertices.reserve(mesh_vertex_count);
@@ -184,7 +184,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_cloth() {
 			}
 
 			physics_face[j] = iter_physics_index->value;
-			mesh_to_physics_vertex_index[mesh_index] = iter_physics_index->value;
+			mesh_to_physics[mesh_index] = iter_physics_index->value;
 		}
 
 		if (physics_face[0] == physics_face[1] || physics_face[0] == physics_face[2] || physics_face[1] == physics_face[2]) {
@@ -198,7 +198,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_cloth() {
 	// Pin whatever pinned vertices we have currently. This is used during the `Optimize` call below to order the
 	// constraints. Note that it's fine if the pinned vertices change later, but that will reduce the effectiveness
 	// of the constraints a bit.
-	pin_vertices(*this, pinned_vertices, mesh_to_physics_vertex_index, physics_vertices);
+	pin_vertices(*this, pinned_vertices, mesh_to_physics, physics_vertices);
 
 	// Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt uses actual stiffness for its
 	// edge constraints, we must map one to the other.
@@ -346,8 +346,8 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	const int mesh_vertex_count = mesh_vertices.size();
 	const int mesh_index_count = mesh_indices.size();
 
-	mesh_to_physics_vertex_index.resize(mesh_vertex_count);
-	for (int &index : mesh_to_physics_vertex_index) {
+	mesh_to_physics.resize(mesh_vertex_count);
+	for (int &index : mesh_to_physics) {
 		index = -1;
 	}
 	settings->mVertices.reserve(mesh_vertex_count);
@@ -416,7 +416,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 			}
 
 			physics_tet[j] = iter_physics_index->value;
-			mesh_to_physics_vertex_index[mesh_vertex_index] = iter_physics_index->value;
+			mesh_to_physics[mesh_vertex_index] = iter_physics_index->value;
 		}
 
 		if (physics_tet[0] == physics_tet[1] || physics_tet[0] == physics_tet[2]
@@ -446,6 +446,25 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		v.mVertex[3] = (JPH::uint32)physics_tet[3];
 		settings->mVolumeConstraints.emplace_back(v);
 	}
+	
+	// Pin whatever pinned vertices we have currently. This is used during the `Optimize` call below to order the
+	// constraints. Note that it's fine if the pinned vertices change later, but that will reduce the effectiveness
+	// of the constraints a bit.
+	pin_vertices(*this, pinned_vertices, mesh_to_physics, settings->mVertices);
+
+	// Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt uses actual stiffness for its
+	// edge constraints, we crudely map one to the other with an arbitrary constant.
+	const float stiffness = MAX(Math::pow(stiffness_coefficient, 3.0f) * 100000.0f, 0.000001f);
+	const float inverse_stiffness = 1.0f / stiffness;
+
+	JPH::SoftBodySharedSettings::VertexAttributes vertex_attrib;
+	vertex_attrib.mCompliance = vertex_attrib.mShearCompliance = inverse_stiffness;
+
+	settings->CreateConstraints(&vertex_attrib, 1, JPH::SoftBodySharedSettings::EBendType::None);
+	float multiplier = 1.0f - shrinking_factor;
+	for (JPH::SoftBodySharedSettings::Edge &e : settings->mEdgeConstraints) {
+		e.mRestLength *= multiplier;
+	}
 
 	settings->Optimize();
 
@@ -466,7 +485,7 @@ void JoltSoftBody3D::_update_mass() {
 		vertex.mInvMass = inverse_vertex_mass;
 	}
 
-	pin_vertices(*this, pinned_vertices, mesh_to_physics_vertex_index, physics_vertices);
+	pin_vertices(*this, pinned_vertices, mesh_to_physics, physics_vertices);
 }
 
 void JoltSoftBody3D::_update_pressure() {
@@ -653,8 +672,8 @@ bool JoltSoftBody3D::is_sleeping() const {
 void JoltSoftBody3D::apply_vertex_impulse(int p_index, const Vector3 &p_impulse) {
 	ERR_FAIL_COND_MSG(!in_space(), vformat("Failed to apply impulse to '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
 
-	ERR_FAIL_INDEX(p_index, (int)mesh_to_physics_vertex_index.size());
-	const int physics_index = mesh_to_physics_vertex_index[p_index];
+	ERR_FAIL_INDEX(p_index, (int)mesh_to_physics.size());
+	const int physics_index = mesh_to_physics[p_index];
 	ERR_FAIL_COND_MSG(physics_index < 0, vformat("Soft body vertex %d was not used by a face and has been omitted for '%s'. No impulse can be applied.", p_index, to_string()));
 	ERR_FAIL_COND_MSG(pinned_vertices.has(physics_index), vformat("Failed to apply impulse to point at index %d for '%s'. Point was found to be pinned.", static_cast<int>(physics_index), to_string()));
 
@@ -931,11 +950,11 @@ void JoltSoftBody3D::update_rendering_server(PhysicsServer3DRenderingServerHandl
 		}
 	}
 
-	const int mesh_vertex_count = mesh_to_physics_vertex_index.size();
+	const int mesh_vertex_count = mesh_to_physics.size();
 	const JPH::RVec3 body_position = jolt_body->GetCenterOfMassPosition();
 
 	for (int i = 0; i < mesh_vertex_count; ++i) {
-		const int physics_index = mesh_to_physics_vertex_index[i];
+		const int physics_index = mesh_to_physics[i];
 		if (physics_index >= 0) {
 			const Vector3 vertex = to_godot(body_position + physics_vertices[(size_t)physics_index].mPosition);
 			const Vector3 normal = normals[(uint32_t)physics_index];
@@ -951,8 +970,8 @@ void JoltSoftBody3D::update_rendering_server(PhysicsServer3DRenderingServerHandl
 Vector3 JoltSoftBody3D::get_vertex_position(int p_index) {
 	ERR_FAIL_COND_V_MSG(!in_space(), Vector3(), vformat("Failed to retrieve point position for '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
 
-	ERR_FAIL_INDEX_V(p_index, (int)mesh_to_physics_vertex_index.size(), Vector3());
-	const int physics_index = mesh_to_physics_vertex_index[p_index];
+	ERR_FAIL_INDEX_V(p_index, (int)mesh_to_physics.size(), Vector3());
+	const int physics_index = mesh_to_physics[p_index];
 	ERR_FAIL_COND_V_MSG(physics_index < 0, Vector3(), vformat("Soft body vertex %d was not used by a face and has been omitted for '%s'. Position cannot be returned.", p_index, to_string()));
 
 	const JPH::SoftBodyMotionProperties &motion_properties = static_cast<const JPH::SoftBodyMotionProperties &>(*jolt_body->GetMotionPropertiesUnchecked());
@@ -965,8 +984,8 @@ Vector3 JoltSoftBody3D::get_vertex_position(int p_index) {
 void JoltSoftBody3D::set_vertex_position(int p_index, const Vector3 &p_position) {
 	ERR_FAIL_COND_MSG(!in_space(), vformat("Failed to set point position for '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
 
-	ERR_FAIL_INDEX(p_index, (int)mesh_to_physics_vertex_index.size());
-	const int physics_index = mesh_to_physics_vertex_index[p_index];
+	ERR_FAIL_INDEX(p_index, (int)mesh_to_physics.size());
+	const int physics_index = mesh_to_physics[p_index];
 	ERR_FAIL_COND_MSG(physics_index < 0, vformat("Soft body vertex %d was not used by a face and has been omitted for '%s'. Position cannot be set.", p_index, to_string()));
 
 	JPH::SoftBodyMotionProperties &motion_properties = static_cast<JPH::SoftBodyMotionProperties &>(*jolt_body->GetMotionPropertiesUnchecked());
@@ -1000,8 +1019,8 @@ void JoltSoftBody3D::unpin_all_vertices() {
 bool JoltSoftBody3D::is_vertex_pinned(int p_index) const {
 	ERR_FAIL_COND_V_MSG(!in_space(), false, vformat("Failed retrieve pin status of point for '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
 
-	ERR_FAIL_INDEX_V(p_index, (int)mesh_to_physics_vertex_index.size(), false);
-	const int physics_index = mesh_to_physics_vertex_index[p_index];
+	ERR_FAIL_INDEX_V(p_index, (int)mesh_to_physics.size(), false);
+	const int physics_index = mesh_to_physics[p_index];
 
 	return pinned_vertices.has(physics_index);
 }

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -458,15 +458,15 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		settings->AddFace(f);
 	}
 
-	settings->CalculateEdgeLengths();
-	settings->CalculateVolumeConstraintVolumes();
-
 	// Pin whatever pinned vertices we have currently. This is used during the `Optimize` call below to order the
 	// constraints. Note that it's fine if the pinned vertices change later, but that will reduce the effectiveness
 	// of the constraints a bit.
 	pin_vertices(*this, pinned_vertices, mesh_to_physics, settings->mVertices);
 
 	_apply_physics_values(settings);
+
+	settings->CalculateEdgeLengths();
+	settings->CalculateVolumeConstraintVolumes();
 
 	settings->Optimize();
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -37,10 +37,13 @@
 #include "jolt_area_3d.h"
 #include "jolt_body_3d.h"
 #include "jolt_group_filter.h"
+#include "../../core/math/geometry_3d.h"
 
 #include "servers/rendering/rendering_server.h"
 
 #include "Jolt/Physics/SoftBody/SoftBodyMotionProperties.h"
+
+#include <set>
 
 namespace {
 
@@ -155,8 +158,8 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_cloth() {
 	const int mesh_vertex_count = mesh_vertices.size();
 	const int mesh_index_count = mesh_indices.size();
 
-	mesh_to_physics.resize(mesh_vertex_count);
-	for (int &index : mesh_to_physics) {
+	mesh_to_physics_vertex_index.resize(mesh_vertex_count);
+	for (int &index : mesh_to_physics_vertex_index) {
 		index = -1;
 	}
 	physics_vertices.reserve(mesh_vertex_count);
@@ -181,7 +184,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_cloth() {
 			}
 
 			physics_face[j] = iter_physics_index->value;
-			mesh_to_physics[mesh_index] = iter_physics_index->value;
+			mesh_to_physics_vertex_index[mesh_index] = iter_physics_index->value;
 		}
 
 		if (physics_face[0] == physics_face[1] || physics_face[0] == physics_face[2] || physics_face[1] == physics_face[2]) {
@@ -195,7 +198,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_cloth() {
 	// Pin whatever pinned vertices we have currently. This is used during the `Optimize` call below to order the
 	// constraints. Note that it's fine if the pinned vertices change later, but that will reduce the effectiveness
 	// of the constraints a bit.
-	pin_vertices(*this, pinned_vertices, mesh_to_physics, physics_vertices);
+	pin_vertices(*this, pinned_vertices, mesh_to_physics_vertex_index, physics_vertices);
 
 	// Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt uses actual stiffness for its
 	// edge constraints, we must map one to the other.
@@ -320,26 +323,133 @@ void JoltSoftBody3D::_apply_environmental_forces(float p_step, JPH::Body &p_jolt
 }
 
 JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
-	return _create_shared_settings_cloth();
+//	return _create_shared_settings_cloth();
 
-	//RenderingServer *rendering = RenderingServer::get_singleton();
+	RenderingServer *rendering = RenderingServer::get_singleton();
 
-	//const Array mesh_data = rendering->mesh_surface_get_arrays(mesh, 0);
-	//ERR_FAIL_COND_V(mesh_data.is_empty(), nullptr);
+	const Array mesh_data = rendering->mesh_surface_get_arrays(mesh, 0);
+	ERR_FAIL_COND_V(mesh_data.is_empty(), nullptr);
 
-	//const PackedInt32Array mesh_indices = mesh_data[RenderingServer::ARRAY_INDEX];
-	//ERR_FAIL_COND_V(mesh_indices.is_empty(), nullptr);
+	const PackedInt32Array mesh_indices = mesh_data[RenderingServer::ARRAY_INDEX];
+	ERR_FAIL_COND_V(mesh_indices.is_empty(), nullptr);
 
-	//const PackedVector3Array mesh_vertices = mesh_data[RenderingServer::ARRAY_VERTEX];
-	//ERR_FAIL_COND_V(mesh_vertices.is_empty(), nullptr);
+	const PackedVector3Array mesh_vertices = mesh_data[RenderingServer::ARRAY_VERTEX];
+	ERR_FAIL_COND_V(mesh_vertices.is_empty(), nullptr);
 
-	//JPH::SoftBodySharedSettings *settings = new JPH::SoftBodySharedSettings();
-	//JPH::Array<JPH::SoftBodySharedSettings::Vertex> &physics_vertices = settings->mVertices;
-	//JPH::Array<JPH::SoftBodySharedSettings::Face> &physics_faces = settings->mFaces;
+	Vector<int32_t> tetrahedra_indices = Geometry3D::tetrahedralize_delaunay(mesh_vertices);
 
-	//settings->Optimize();
 
-	//return settings;
+	JPH::SoftBodySharedSettings *settings = new JPH::SoftBodySharedSettings();
+
+	HashMap<Vector3, int> point_to_physics_index;
+
+	const int mesh_vertex_count = mesh_vertices.size();
+	const int mesh_index_count = mesh_indices.size();
+
+	mesh_to_physics_vertex_index.resize(mesh_vertex_count);
+	for (int &index : mesh_to_physics_vertex_index) {
+		index = -1;
+	}
+	settings->mVertices.reserve(mesh_vertex_count);
+	point_to_physics_index.reserve(mesh_vertex_count);
+
+	const JPH::RVec3 body_position = jolt_settings->mPosition;
+
+	std::set<std::tuple<int, int>> scanned_edges;
+	std::set<std::tuple<int, int, int>> scanned_faces;
+
+	auto append_edge_if_absent = [&](int a, int b) {
+		if (a > b) {
+			std::swap(a, b);
+		}
+		std::tuple<int, int> edge_tup(a, b);
+
+		if (scanned_edges.find(edge_tup) == scanned_edges.end()) {
+			scanned_edges.emplace(edge_tup);
+
+			JPH::SoftBodySharedSettings::Edge e;
+			e.mVertex[0] = (JPH::uint32)a;
+			e.mVertex[1] = (JPH::uint32)b;
+			settings->mEdgeConstraints.push_back(e);
+		}
+	};
+
+	auto append_face_if_absent = [&](int a, int b, int c) {
+		if (a > b) {
+			std::swap(a, b);
+		}
+		if (b > c) {
+			std::swap(b, c);
+		}
+		if (a > b) {
+			std::swap(a, b);
+		}
+		std::tuple<int, int, int> face_tup(a, b, c);
+
+		if (scanned_faces.find(face_tup) == scanned_faces.end()) {
+			scanned_faces.emplace(face_tup);
+
+			JPH::SoftBodySharedSettings::Face f;
+			f.mVertex[0] = (JPH::uint32)a;
+			f.mVertex[1] = (JPH::uint32)b;
+			f.mVertex[2] = (JPH::uint32)c;
+			settings->AddFace(f);
+		}
+	};
+
+	//Validate vertices, merging any that may be coincident
+	int vertex_index_count = 0;
+
+	for (int i = 0; i < mesh_index_count; i += 4) {
+		int physics_tet[4];
+
+		for (int j = 0; j < 4; ++j) {
+			const int mesh_vertex_index = mesh_indices[i + j];
+			const Vector3 vertex = mesh_vertices[mesh_vertex_index];
+
+			HashMap<Vector3, int>::Iterator iter_physics_index = point_to_physics_index.find(vertex);
+
+			if (iter_physics_index == point_to_physics_index.end()) {
+				settings->mVertices.emplace_back(
+					JPH::Float3((float)(vertex.x - body_position.GetX()), (float)(vertex.y - body_position.GetY()), (float)(vertex.z - body_position.GetZ())), JPH::Float3(0.0f, 0.0f, 0.0f), 1.0f);
+				iter_physics_index = point_to_physics_index.insert(vertex, vertex_index_count++);
+			}
+
+			physics_tet[j] = iter_physics_index->value;
+			mesh_to_physics_vertex_index[mesh_vertex_index] = iter_physics_index->value;
+		}
+
+		if (physics_tet[0] == physics_tet[1] || physics_tet[0] == physics_tet[2]
+			|| physics_tet[0] == physics_tet[3] || physics_tet[1] == physics_tet[2]
+			|| physics_tet[1] == physics_tet[3] || physics_tet[2] == physics_tet[3]) {
+			continue; // Skip degenerate tetrahedra
+		}
+
+		//Add edges
+		for (int vi0 = 0; vi0 < 3; ++vi0) {
+			for (int vi1 = vi0 + 1; vi1 < 4; ++vi1) {
+				append_edge_if_absent(physics_tet[vi0], physics_tet[vi1]);
+			}
+		}
+
+		//Add faces
+		append_face_if_absent(physics_tet[0], physics_tet[1], physics_tet[2]);
+		append_face_if_absent(physics_tet[1], physics_tet[0], physics_tet[3]);
+		append_face_if_absent(physics_tet[2], physics_tet[3], physics_tet[0]);
+		append_face_if_absent(physics_tet[3], physics_tet[2], physics_tet[1]);
+
+		//Add tetrahedron
+		JPH::SoftBodySharedSettings::Volume v;
+		v.mVertex[0] = (JPH::uint32)physics_tet[0];
+		v.mVertex[1] = (JPH::uint32)physics_tet[1];
+		v.mVertex[2] = (JPH::uint32)physics_tet[2];
+		v.mVertex[3] = (JPH::uint32)physics_tet[3];
+		settings->mVolumeConstraints.emplace_back(v);
+	}
+
+	settings->Optimize();
+
+	return settings;
 }
 
 void JoltSoftBody3D::_update_mass() {
@@ -356,7 +466,7 @@ void JoltSoftBody3D::_update_mass() {
 		vertex.mInvMass = inverse_vertex_mass;
 	}
 
-	pin_vertices(*this, pinned_vertices, mesh_to_physics, physics_vertices);
+	pin_vertices(*this, pinned_vertices, mesh_to_physics_vertex_index, physics_vertices);
 }
 
 void JoltSoftBody3D::_update_pressure() {
@@ -543,8 +653,8 @@ bool JoltSoftBody3D::is_sleeping() const {
 void JoltSoftBody3D::apply_vertex_impulse(int p_index, const Vector3 &p_impulse) {
 	ERR_FAIL_COND_MSG(!in_space(), vformat("Failed to apply impulse to '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
 
-	ERR_FAIL_INDEX(p_index, (int)mesh_to_physics.size());
-	const int physics_index = mesh_to_physics[p_index];
+	ERR_FAIL_INDEX(p_index, (int)mesh_to_physics_vertex_index.size());
+	const int physics_index = mesh_to_physics_vertex_index[p_index];
 	ERR_FAIL_COND_MSG(physics_index < 0, vformat("Soft body vertex %d was not used by a face and has been omitted for '%s'. No impulse can be applied.", p_index, to_string()));
 	ERR_FAIL_COND_MSG(pinned_vertices.has(physics_index), vformat("Failed to apply impulse to point at index %d for '%s'. Point was found to be pinned.", static_cast<int>(physics_index), to_string()));
 
@@ -821,11 +931,11 @@ void JoltSoftBody3D::update_rendering_server(PhysicsServer3DRenderingServerHandl
 		}
 	}
 
-	const int mesh_vertex_count = mesh_to_physics.size();
+	const int mesh_vertex_count = mesh_to_physics_vertex_index.size();
 	const JPH::RVec3 body_position = jolt_body->GetCenterOfMassPosition();
 
 	for (int i = 0; i < mesh_vertex_count; ++i) {
-		const int physics_index = mesh_to_physics[i];
+		const int physics_index = mesh_to_physics_vertex_index[i];
 		if (physics_index >= 0) {
 			const Vector3 vertex = to_godot(body_position + physics_vertices[(size_t)physics_index].mPosition);
 			const Vector3 normal = normals[(uint32_t)physics_index];
@@ -841,8 +951,8 @@ void JoltSoftBody3D::update_rendering_server(PhysicsServer3DRenderingServerHandl
 Vector3 JoltSoftBody3D::get_vertex_position(int p_index) {
 	ERR_FAIL_COND_V_MSG(!in_space(), Vector3(), vformat("Failed to retrieve point position for '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
 
-	ERR_FAIL_INDEX_V(p_index, (int)mesh_to_physics.size(), Vector3());
-	const int physics_index = mesh_to_physics[p_index];
+	ERR_FAIL_INDEX_V(p_index, (int)mesh_to_physics_vertex_index.size(), Vector3());
+	const int physics_index = mesh_to_physics_vertex_index[p_index];
 	ERR_FAIL_COND_V_MSG(physics_index < 0, Vector3(), vformat("Soft body vertex %d was not used by a face and has been omitted for '%s'. Position cannot be returned.", p_index, to_string()));
 
 	const JPH::SoftBodyMotionProperties &motion_properties = static_cast<const JPH::SoftBodyMotionProperties &>(*jolt_body->GetMotionPropertiesUnchecked());
@@ -855,8 +965,8 @@ Vector3 JoltSoftBody3D::get_vertex_position(int p_index) {
 void JoltSoftBody3D::set_vertex_position(int p_index, const Vector3 &p_position) {
 	ERR_FAIL_COND_MSG(!in_space(), vformat("Failed to set point position for '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
 
-	ERR_FAIL_INDEX(p_index, (int)mesh_to_physics.size());
-	const int physics_index = mesh_to_physics[p_index];
+	ERR_FAIL_INDEX(p_index, (int)mesh_to_physics_vertex_index.size());
+	const int physics_index = mesh_to_physics_vertex_index[p_index];
 	ERR_FAIL_COND_MSG(physics_index < 0, vformat("Soft body vertex %d was not used by a face and has been omitted for '%s'. Position cannot be set.", p_index, to_string()));
 
 	JPH::SoftBodyMotionProperties &motion_properties = static_cast<JPH::SoftBodyMotionProperties &>(*jolt_body->GetMotionPropertiesUnchecked());
@@ -890,8 +1000,8 @@ void JoltSoftBody3D::unpin_all_vertices() {
 bool JoltSoftBody3D::is_vertex_pinned(int p_index) const {
 	ERR_FAIL_COND_V_MSG(!in_space(), false, vformat("Failed retrieve pin status of point for '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
 
-	ERR_FAIL_INDEX_V(p_index, (int)mesh_to_physics.size(), false);
-	const int physics_index = mesh_to_physics[p_index];
+	ERR_FAIL_INDEX_V(p_index, (int)mesh_to_physics_vertex_index.size(), false);
+	const int physics_index = mesh_to_physics_vertex_index[p_index];
 
 	return pinned_vertices.has(physics_index);
 }

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -38,6 +38,7 @@
 #include "jolt_body_3d.h"
 #include "jolt_group_filter.h"
 #include "../../core/math/geometry_3d.h"
+#include "../../core/math/triangle_mesh.h"
 
 #include "servers/rendering/rendering_server.h"
 
@@ -47,7 +48,6 @@
 #include <set>
 #include <map>
 #include <vector>
-#include "../../core/math/triangle_mesh.h"
 
 namespace {
 
@@ -362,10 +362,8 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		}
 	}
 
-
 	//Do delaunay tesselation
 	Vector<int32_t> tetrahedra_indices = Geometry3D::tetrahedralize_delaunay(mesh_vertices_clean);
-
 
 	//Find tetrahedra links
 	struct TetrahedraInfo {
@@ -479,10 +477,9 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		}
 	}
 
-
 	//Mark exterior tetrahedra
-	bool convex_hull = false;
-	if (!convex_hull) {
+	bool use_convex_hull = false;
+	if (!use_convex_hull) {
 		//Create mesh for inside/outside tests
 		PackedVector3Array surface_tris;
 		surface_tris.reserve(mesh_indices_clean.size());
@@ -525,7 +522,6 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 			int32_t surf_idx;
 			int32_t face_idx;
 
-//			Vector3 ray_dir = Vector3(1, 0, 0);
 			for (int i = 0; i < 6; ++i) {
 				const Vector3 ray_dir = cast_dirs[i];
 				bool hit = surface_mesh.intersect_ray(center, ray_dir, point, normal, &surf_idx, &face_idx);
@@ -536,8 +532,6 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 				}
 			}
 		}
-
-
 	}
 
 	//Find exterior faces
@@ -556,7 +550,6 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 
 	//Populate settings
 	JPH::SoftBodySharedSettings *settings = new JPH::SoftBodySharedSettings();
-	////physics_vertices.emplace_back(JPH::Float3((float)(vertex.x - body_position.GetX())
 	for (const Vector3& v : mesh_vertices_clean) {
 		settings->mVertices.emplace_back(JPH::Float3(v.x, v.y, v.z));
 	}
@@ -570,7 +563,6 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		v.mVertex[2] = (JPH::uint32)t_info.vert_indices[2];
 		v.mVertex[3] = (JPH::uint32)t_info.vert_indices[3];
 		settings->mVolumeConstraints.push_back(v);
-		//settings->mEdgeConstraints.emplace_back(JPH::SoftBodySharedSettings::Edge((JPH::uint32)e.x, (JPH::uint32)e.y));
 	}
 	for (const Vector3i &fv : face_exterior) {
 		JPH::SoftBodySharedSettings::Face f;
@@ -582,154 +574,8 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 
 	settings->CalculateEdgeLengths();
 	settings->CalculateVolumeConstraintVolumes();
-	settings->Optimize();
 
-	return _create_shared_settings_cloth();
 
-	/////////////////
-	/*
-	HashMap<Vector3, int> point_to_physics_index;
-
-	const int mesh_vertex_count = mesh_vertices.size();
-	const int mesh_index_count = mesh_indices.size();
-
-	mesh_to_physics.resize(mesh_vertex_count);
-	for (int &index : mesh_to_physics) {
-		index = -1;
-	}
-	settings->mVertices.reserve(mesh_vertex_count);
-	point_to_physics_index.reserve(mesh_vertex_count);
-
-	// 
-	//int next_phys_vert_idx = 0;
-	//for (int i = 0; i < tetrahedra_indices.size(); ++i) {
-	//	int vi_mesh = tetrahedra_indices[i];
-	//	Vector3 v = mesh_vertices[vi_mesh];
-
-	//	if (point_to_physics_index.find(v) != point_to_physics_index.end()) {
-	//		point_to_physics_index[v] = next_phys_vert_idx++;
-	//	}
-	//}
-
-	JPH::SoftBodySharedSettings *settings = new JPH::SoftBodySharedSettings();
-
-	const JPH::RVec3 body_position = jolt_settings->mPosition;
-
-	std::set<std::tuple<int, int>> scanned_edges;
-	//	std::set<std::tuple<int, int, int>> scanned_faces;
-	HashMap<std::tuple<int, int, int>, int> scanned_face_count;
-
-	auto append_edge_if_absent = [&](int a, int b) {
-		if (a > b) {
-			std::swap(a, b);
-		}
-		std::tuple<int, int> edge_tup(a, b);
-
-		if (scanned_edges.find(edge_tup) == scanned_edges.end()) {
-			scanned_edges.emplace(edge_tup);
-
-			JPH::SoftBodySharedSettings::Edge e;
-			e.mVertex[0] = (JPH::uint32)a;
-			e.mVertex[1] = (JPH::uint32)b;
-			settings->mEdgeConstraints.push_back(e);
-		}
-	};
-
-	//auto append_face_if_absent = [&](int a, int b, int c) {
-	//	if (a > b) {
-	//		std::swap(a, b);
-	//	}
-	//	if (b > c) {
-	//		std::swap(b, c);
-	//	}
-	//	if (a > b) {
-	//		std::swap(a, b);
-	//	}
-	//	std::tuple<int, int, int> face_tup(a, b, c);
-
-	//	if (scanned_faces.find(face_tup) == scanned_faces.end()) {
-	//		scanned_faces.emplace(face_tup);
-
-	//		JPH::SoftBodySharedSettings::Face f;
-	//		f.mVertex[0] = (JPH::uint32)a;
-	//		f.mVertex[1] = (JPH::uint32)b;
-	//		f.mVertex[2] = (JPH::uint32)c;
-	//		settings->AddFace(f);
-	//	}
-	//};
-
-	//Validate vertices, merging any that may be coincident
-	int phys_vert_index_count = 0;
-
-	for (int i = 0; i < tetrahedra_indices.size(); i += 4) {
-		int physics_tet[4];
-
-		for (int j = 0; j < 4; ++j) {
-			const int mesh_vertex_index = tetrahedra_indices[i + j];
-			const Vector3 vertex = mesh_vertices[mesh_vertex_index];
-
-			HashMap<Vector3, int>::Iterator iter_physics_index = point_to_physics_index.find(vertex);
-
-			if (iter_physics_index == point_to_physics_index.end()) {
-				settings->mVertices.emplace_back(
-					JPH::Float3((float)(vertex.x - body_position.GetX()), (float)(vertex.y - body_position.GetY()), (float)(vertex.z - body_position.GetZ())), JPH::Float3(0.0f, 0.0f, 0.0f), 1.0f);
-				iter_physics_index = point_to_physics_index.insert(vertex, phys_vert_index_count++);
-			}
-
-			physics_tet[j] = iter_physics_index->value;
-			mesh_to_physics[mesh_vertex_index] = iter_physics_index->value;
-		}
-
-		if (physics_tet[0] == physics_tet[1] || physics_tet[0] == physics_tet[2]
-			|| physics_tet[0] == physics_tet[3] || physics_tet[1] == physics_tet[2]
-			|| physics_tet[1] == physics_tet[3] || physics_tet[2] == physics_tet[3]) {
-			continue; // Skip degenerate tetrahedra
-		}
-
-		//Add edges
-		for (int vi0 = 0; vi0 < 3; ++vi0) {
-			for (int vi1 = vi0 + 1; vi1 < 4; ++vi1) {
-				append_edge_if_absent(physics_tet[vi0], physics_tet[vi1]);
-			}
-		}
-
-		//Add faces
-		//append_face_if_absent(physics_tet[0], physics_tet[1], physics_tet[2]);
-		//append_face_if_absent(physics_tet[1], physics_tet[0], physics_tet[3]);
-		//append_face_if_absent(physics_tet[2], physics_tet[3], physics_tet[0]);
-		//append_face_if_absent(physics_tet[3], physics_tet[2], physics_tet[1]);
-
-		//Add tetrahedron
-		//det([v1 - v0, v2 - v0, v3 - v0]) should be positive to match tetrahedra in SoftBodySharedSettings::sCreateCube
-		JPH::SoftBodySharedSettings::Volume v;
-		v.mVertex[0] = (JPH::uint32)physics_tet[0];
-		v.mVertex[1] = (JPH::uint32)physics_tet[1];
-		v.mVertex[2] = (JPH::uint32)physics_tet[2];
-		v.mVertex[3] = (JPH::uint32)physics_tet[3];
-		settings->mVolumeConstraints.push_back(v);
-	}
-	settings->CalculateEdgeLengths();
-	settings->CalculateVolumeConstraintVolumes();
-
-	//Add surface faces only
-	for (int i = 0; i < mesh_index_count; i += 3) {
-		int vi0 = mesh_to_physics[i];
-		int vi1 = mesh_to_physics[i + 1];
-		int vi2 = mesh_to_physics[i + 2];
-
-		if (vi0 == vi1 || vi0 == vi2 || vi1 == vi2)
-			continue;
-
-		// Jolt uses a different winding order, so we swap the indices to account for that.
-		JPH::SoftBodySharedSettings::Face f;
-		f.mVertex[0] = (JPH::uint32)vi0;
-		f.mVertex[1] = (JPH::uint32)vi1;
-		f.mVertex[2] = (JPH::uint32)vi2;
-		settings->AddFace(f);
-		//settings->mFaces.emplace_back((JPH::uint32)vi2, (JPH::uint32)vi1, (JPH::uint32)vi0);
-	}
-*/
-	/*
 	// Pin whatever pinned vertices we have currently. This is used during the `Optimize` call below to order the
 	// constraints. Note that it's fine if the pinned vertices change later, but that will reduce the effectiveness
 	// of the constraints a bit.
@@ -748,10 +594,11 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	for (JPH::SoftBodySharedSettings::Edge &e : settings->mEdgeConstraints) {
 		e.mRestLength *= multiplier;
 	}
-	*/
-	//settings->Optimize();
 
-	//return settings;
+	settings->Optimize();
+
+	return settings;
+	//return _create_shared_settings_cloth();
 }
 
 void JoltSoftBody3D::_update_mass() {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -475,7 +475,12 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	settings->CalculateEdgeLengths();
 	settings->CalculateVolumeConstraintVolumes();
 
-	float multiplier_pow_3 = compliance * compliance * compliance;
+	float multiplier = 1.0f - shrinking_factor;
+	for (JPH::SoftBodySharedSettings::Edge &e : settings->mEdgeConstraints) {
+		e.mRestLength *= multiplier;
+	}
+
+	float multiplier_pow_3 = multiplier * multiplier * multiplier;
 	for (JPH::SoftBodySharedSettings::Volume &v : settings->mVolumeConstraints) {
 		v.mSixRestVolume *= multiplier_pow_3;
 	}

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -361,14 +361,13 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 
 	//Build mesh_to_physics
 	mesh_to_physics.resize(mesh_vertices.size());
-	for (int &index : mesh_to_physics) {
-		index = -1;
-	}
 
 	for (int i = 0; i < mesh_vertices.size(); ++i) {
 		auto it = mesh_vert_to_clean_idx_map.find(mesh_vertices[i]);
 		if (it != mesh_vert_to_clean_idx_map.end()) {
 			mesh_to_physics[i] = it->second;
+		} else {
+			mesh_to_physics[i] = -1;
 		}
 	}
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -693,6 +693,14 @@ void JoltSoftBody3D::set_state(PhysicsServer3D::BodyState p_state, const Variant
 	}
 }
 
+PhysicsServer3D::SoftBodyForm JoltSoftBody3D::get_soft_body_form() const {
+	return soft_body_form;
+}
+
+void JoltSoftBody3D::set_soft_body_form(PhysicsServer3D::SoftBodyForm p_soft_body_form) {
+	soft_body_form = p_soft_body_form;
+}
+
 Transform3D JoltSoftBody3D::get_transform() const {
 	// Since any transform gets baked into the vertices anyway we can just return identity here.
 	return Transform3D();

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -200,7 +200,6 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_cloth() {
 	pin_vertices(*this, pinned_vertices, mesh_to_physics, physics_vertices);
 
 	_apply_physics_values(settings);
-	
 	settings->Optimize();
 
 	return settings;

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -546,9 +546,8 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		}
 
 		for (int i = 0; i < 4; ++i) {
-			Vector3i f = t_info.face_keys[i];
 			if (t_info.neighbors[i] == -1 || !tet_info_list[t_info.neighbors[i]].valid) {
-				face_exterior.emplace(f);
+				face_exterior.emplace(t_info.face_keys[i]);
 			}
 		}
 	}

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -199,7 +199,17 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_cloth() {
 	// of the constraints a bit.
 	pin_vertices(*this, pinned_vertices, mesh_to_physics, physics_vertices);
 
-	_apply_physics_values(settings);
+	float compliance = _calculate_compliance(settings);
+
+	JPH::SoftBodySharedSettings::VertexAttributes vertex_attrib;
+	vertex_attrib.mCompliance = vertex_attrib.mShearCompliance = compliance;
+
+	settings->CreateConstraints(&vertex_attrib, 1, JPH::SoftBodySharedSettings::EBendType::None);
+	float multiplier = 1.0f - shrinking_factor;
+	for (JPH::SoftBodySharedSettings::Edge &e : settings->mEdgeConstraints) {
+		e.mRestLength *= multiplier;
+	}
+
 	settings->Optimize();
 
 	return settings;
@@ -433,11 +443,15 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	for (const Vector3 &v : mesh_vertices_clean) {
 		settings->mVertices.emplace_back(JPH::Float3(v.x, v.y, v.z));
 	}
+
+	float compliance = _calculate_compliance(settings);
+
 	for (const Vector2i &e : edge_set) {
-		settings->mEdgeConstraints.emplace_back(JPH::SoftBodySharedSettings::Edge((JPH::uint32)e.x, (JPH::uint32)e.y));
+		settings->mEdgeConstraints.emplace_back(JPH::SoftBodySharedSettings::Edge((JPH::uint32)e.x, (JPH::uint32)e.y, compliance));
 	}
 	for (const TetrahedraInfo &t_info : tet_info_list) {
 		JPH::SoftBodySharedSettings::Volume v;
+		v.mCompliance = compliance;
 		v.mVertex[0] = (JPH::uint32)t_info.vert_indices[0];
 		v.mVertex[1] = (JPH::uint32)t_info.vert_indices[1];
 		v.mVertex[2] = (JPH::uint32)t_info.vert_indices[2];
@@ -459,17 +473,19 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	pin_vertices(*this, pinned_vertices, mesh_to_physics, settings->mVertices);
 
 	settings->CalculateEdgeLengths();
-
-	_apply_physics_values(settings);
-
 	settings->CalculateVolumeConstraintVolumes();
+
+	float multiplier_pow_3 = compliance * compliance * compliance;
+	for (JPH::SoftBodySharedSettings::Volume &v : settings->mVolumeConstraints) {
+		v.mSixRestVolume *= multiplier_pow_3;
+	}
 
 	settings->Optimize();
 
 	return settings;
 }
 
-void JoltSoftBody3D::_apply_physics_values(JPH::SoftBodySharedSettings *settings) {
+float JoltSoftBody3D::_calculate_compliance(JPH::SoftBodySharedSettings *settings) {
 	// Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt uses actual stiffness for its
 	// edge constraints, we must map one to the other.
 	//
@@ -497,15 +513,7 @@ void JoltSoftBody3D::_apply_physics_values(JPH::SoftBodySharedSettings *settings
 
 	// Now calculate the compliance
 	const float inverse_stiffness = dt * dt * (1.0f / stiffness_coefficient - 1.0f) * w1_plus_w2;
-
-	JPH::SoftBodySharedSettings::VertexAttributes vertex_attrib;
-	vertex_attrib.mCompliance = vertex_attrib.mShearCompliance = inverse_stiffness;
-
-	settings->CreateConstraints(&vertex_attrib, 1, JPH::SoftBodySharedSettings::EBendType::None);
-	float multiplier = 1.0f - shrinking_factor;
-	for (JPH::SoftBodySharedSettings::Edge &e : settings->mEdgeConstraints) {
-		e.mRestLength *= multiplier;
-	}
+	return inverse_stiffness;
 }
 
 void JoltSoftBody3D::_apply_environmental_forces(float p_step, JPH::Body &p_jolt_body) {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -244,87 +244,6 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_cloth() {
 	return settings;
 }
 
-void JoltSoftBody3D::_apply_environmental_forces(float p_step, JPH::Body &p_jolt_body) {
-	// Get approximation of the center of the soft body.
-	Vector3 com_position = to_godot(p_jolt_body.GetCenterOfMassPosition());
-
-	// Calculate gravity and which areas affect the soft body through wind.
-	bool gravity_done = false;
-	Vector3 gravity;
-	LocalVector<JoltArea3D *> wind_areas;
-	for (JoltArea3D *area : areas) {
-		if (!gravity_done) {
-			gravity_done = JoltArea3D::apply_override(gravity, area->get_gravity_mode(), [&]() {
-				return area->compute_gravity(com_position);
-			});
-		}
-
-		if (area->get_wind_pressure() > CMP_EPSILON) {
-			wind_areas.push_back(area);
-		}
-	}
-
-	// Add default gravity.
-	if (!gravity_done) {
-		gravity += space->get_default_area()->compute_gravity(com_position);
-	}
-
-	// Apply gravity to soft body. Note that this only works so long as vertices have uniform mass (excluding pinned vertices).
-	p_jolt_body.AddForce(to_jolt(gravity) * mass);
-
-	if (!wind_areas.is_empty()) {
-		JPH::SoftBodyMotionProperties &motion_properties = static_cast<JPH::SoftBodyMotionProperties &>(*p_jolt_body.GetMotionPropertiesUnchecked());
-		JPH::Array<JPH::SoftBodyVertex> &physics_vertices = motion_properties.GetVertices();
-
-		for (const JPH::SoftBodySharedSettings::Face &physics_face : motion_properties.GetFaces()) {
-			JPH::SoftBodyVertex &physics_vertex0 = physics_vertices[physics_face.mVertex[0]];
-			JPH::SoftBodyVertex &physics_vertex1 = physics_vertices[physics_face.mVertex[1]];
-			JPH::SoftBodyVertex &physics_vertex2 = physics_vertices[physics_face.mVertex[2]];
-
-			// Calculate the triangle centroid.
-			Vector3 v0 = to_godot(physics_vertex0.mPosition);
-			Vector3 v1 = to_godot(physics_vertex1.mPosition);
-			Vector3 v2 = to_godot(physics_vertex2.mPosition);
-			Vector3 centroid = com_position + (v0 + v1 + v2) * real_t(1.0 / 3.0);
-
-			// Calculate the triangle normal.
-			Vector3 normal = (v2 - v0).cross(v1 - v0);
-			real_t normal_length = normal.length();
-			if (normal_length > real_t(1.0e-6)) { // If the normal is near zero, the area is near zero so we can skip this triangle.
-				normal /= normal_length;
-
-				// Area is half the length of the cross product of two sides.
-				real_t triangle_area = real_t(0.5) * normal_length;
-
-				// Accumulate wind forces from all wind areas.
-				Vector3 wind_force;
-				for (const JoltArea3D *area : wind_areas) {
-					const Vector3 &wind_direction = area->get_wind_direction();
-					const Vector3 &wind_source = area->get_wind_source();
-
-					// Calculate attenuation factor based on distance from wind source to triangle centroid.
-					// We do not allow a projection below 1 to ensure that we never amplify and to avoid NaNs when the value would be negative.
-					real_t projection_toward_centroid = MAX((centroid - wind_source).dot(wind_direction), real_t(1.0));
-					real_t attenuation_over_distance = Math::pow(projection_toward_centroid, -real_t(area->get_wind_attenuation_factor()));
-
-					// Calculate force magnitude.
-					real_t force_magnitude = area->get_wind_pressure() * triangle_area;
-
-					// Calculate the resulting wind force on the triangle by projecting wind direction onto triangle normal.
-					// Divide by 3 to distribute force equally over each vertex.
-					wind_force += (force_magnitude * attenuation_over_distance * real_t(1.0 / 3.0) * normal.dot(wind_direction)) * normal;
-				}
-
-				// Apply the force as an impulse over the timestep.
-				JPH::Vec3 impulse = to_jolt(wind_force * p_step);
-				physics_vertex0.mVelocity += impulse * physics_vertex0.mInvMass;
-				physics_vertex1.mVelocity += impulse * physics_vertex1.mInvMass;
-				physics_vertex2.mVelocity += impulse * physics_vertex2.mInvMass;
-			}
-		}
-	}
-}
-
 JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	RenderingServer *rendering = RenderingServer::get_singleton();
 
@@ -586,12 +505,6 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	pin_vertices(*this, pinned_vertices, mesh_to_physics, settings->mVertices);
 
 	// Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt uses actual stiffness for its
-	// edge constraints, we crudely map one to the other with an arbitrary constant.
-	//const float stiffness = MAX(Math::pow(stiffness_coefficient, 3.0f) * 100000.0f, 0.000001f);
-	//const float inverse_stiffness = 1.0f / stiffness;
-
-
-	// Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt uses actual stiffness for its
 	// edge constraints, we must map one to the other.
 	//
 	// Godot uses classic PBD edge constraints, which have a stiffness parameter k that is used in the position correction formula as follows:
@@ -631,6 +544,87 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	settings->Optimize();
 
 	return settings;
+}
+
+void JoltSoftBody3D::_apply_environmental_forces(float p_step, JPH::Body &p_jolt_body) {
+	// Get approximation of the center of the soft body.
+	Vector3 com_position = to_godot(p_jolt_body.GetCenterOfMassPosition());
+
+	// Calculate gravity and which areas affect the soft body through wind.
+	bool gravity_done = false;
+	Vector3 gravity;
+	LocalVector<JoltArea3D *> wind_areas;
+	for (JoltArea3D *area : areas) {
+		if (!gravity_done) {
+			gravity_done = JoltArea3D::apply_override(gravity, area->get_gravity_mode(), [&]() {
+				return area->compute_gravity(com_position);
+			});
+		}
+
+		if (area->get_wind_pressure() > CMP_EPSILON) {
+			wind_areas.push_back(area);
+		}
+	}
+
+	// Add default gravity.
+	if (!gravity_done) {
+		gravity += space->get_default_area()->compute_gravity(com_position);
+	}
+
+	// Apply gravity to soft body. Note that this only works so long as vertices have uniform mass (excluding pinned vertices).
+	p_jolt_body.AddForce(to_jolt(gravity) * mass);
+
+	if (!wind_areas.is_empty()) {
+		JPH::SoftBodyMotionProperties &motion_properties = static_cast<JPH::SoftBodyMotionProperties &>(*p_jolt_body.GetMotionPropertiesUnchecked());
+		JPH::Array<JPH::SoftBodyVertex> &physics_vertices = motion_properties.GetVertices();
+
+		for (const JPH::SoftBodySharedSettings::Face &physics_face : motion_properties.GetFaces()) {
+			JPH::SoftBodyVertex &physics_vertex0 = physics_vertices[physics_face.mVertex[0]];
+			JPH::SoftBodyVertex &physics_vertex1 = physics_vertices[physics_face.mVertex[1]];
+			JPH::SoftBodyVertex &physics_vertex2 = physics_vertices[physics_face.mVertex[2]];
+
+			// Calculate the triangle centroid.
+			Vector3 v0 = to_godot(physics_vertex0.mPosition);
+			Vector3 v1 = to_godot(physics_vertex1.mPosition);
+			Vector3 v2 = to_godot(physics_vertex2.mPosition);
+			Vector3 centroid = com_position + (v0 + v1 + v2) * real_t(1.0 / 3.0);
+
+			// Calculate the triangle normal.
+			Vector3 normal = (v2 - v0).cross(v1 - v0);
+			real_t normal_length = normal.length();
+			if (normal_length > real_t(1.0e-6)) { // If the normal is near zero, the area is near zero so we can skip this triangle.
+				normal /= normal_length;
+
+				// Area is half the length of the cross product of two sides.
+				real_t triangle_area = real_t(0.5) * normal_length;
+
+				// Accumulate wind forces from all wind areas.
+				Vector3 wind_force;
+				for (const JoltArea3D *area : wind_areas) {
+					const Vector3 &wind_direction = area->get_wind_direction();
+					const Vector3 &wind_source = area->get_wind_source();
+
+					// Calculate attenuation factor based on distance from wind source to triangle centroid.
+					// We do not allow a projection below 1 to ensure that we never amplify and to avoid NaNs when the value would be negative.
+					real_t projection_toward_centroid = MAX((centroid - wind_source).dot(wind_direction), real_t(1.0));
+					real_t attenuation_over_distance = Math::pow(projection_toward_centroid, -real_t(area->get_wind_attenuation_factor()));
+
+					// Calculate force magnitude.
+					real_t force_magnitude = area->get_wind_pressure() * triangle_area;
+
+					// Calculate the resulting wind force on the triangle by projecting wind direction onto triangle normal.
+					// Divide by 3 to distribute force equally over each vertex.
+					wind_force += (force_magnitude * attenuation_over_distance * real_t(1.0 / 3.0) * normal.dot(wind_direction)) * normal;
+				}
+
+				// Apply the force as an impulse over the timestep.
+				JPH::Vec3 impulse = to_jolt(wind_force * p_step);
+				physics_vertex0.mVelocity += impulse * physics_vertex0.mInvMass;
+				physics_vertex1.mVelocity += impulse * physics_vertex1.mInvMass;
+				physics_vertex2.mVelocity += impulse * physics_vertex2.mInvMass;
+			}
+		}
+	}
 }
 
 void JoltSoftBody3D::_update_mass() {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -587,8 +587,37 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 
 	// Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt uses actual stiffness for its
 	// edge constraints, we crudely map one to the other with an arbitrary constant.
-	const float stiffness = MAX(Math::pow(stiffness_coefficient, 3.0f) * 100000.0f, 0.000001f);
-	const float inverse_stiffness = 1.0f / stiffness;
+	//const float stiffness = MAX(Math::pow(stiffness_coefficient, 3.0f) * 100000.0f, 0.000001f);
+	//const float inverse_stiffness = 1.0f / stiffness;
+
+
+	// Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt uses actual stiffness for its
+	// edge constraints, we must map one to the other.
+	//
+	// Godot uses classic PBD edge constraints, which have a stiffness parameter k that is used in the position correction formula as follows:
+	// delta_x1 = -k * w1 / (w1 + w2) * (l - l0) / l * (x2 - x1)
+	// where k is the stiffness, w1 and w2 are the inverse masses of the two vertices, l is the current length of the edge = |x2 - x1|, l0 is the rest length of the edge, and x1 and x2 are the vertex positions.
+	//
+	// Note that the actual formula used in Godot physics seems to use an approximation of this which avoids calculating the square root:
+	// delta_x1 = -k * w1 / (w1 + w2) * (l^2 - l0^2) / (l^2 + l0^2) * (x2 - x1)
+	//
+	// Jolt uses XPBD which goes as follows:
+	// delta_x1 = -w1 / (w1 + w2 + compliance / dt^2) * (l - l0) / l * (x2 - x1)
+	// where compliance is the inverse of stiffness and dt is the timestep.
+	//
+	// We can derive Jolt's compliance from Godot's stiffness by evaluating:
+	// k * w1 / (w1 + w2) = w1 / (w1 + w2 + compliance / dt^2)
+	// which simplifies to:
+	// compliance = dt^2 * (1 / k - 1) * (w1 + w2)
+
+	// Assuming that the vertices have the same mass:
+	const float w1_plus_w2 = 2.0f * settings->mVertices.size() / mass;
+
+	// Calculate time step of a single XPBD iteration
+	const float dt = 1.0f / Engine::get_singleton()->get_user_physics_ticks_per_second() / simulation_precision;
+
+	// Now calculate the compliance
+	const float inverse_stiffness = dt * dt * (1.0f / stiffness_coefficient - 1.0f) * w1_plus_w2;
 
 	JPH::SoftBodySharedSettings::VertexAttributes vertex_attrib;
 	vertex_attrib.mCompliance = vertex_attrib.mShearCompliance = inverse_stiffness;

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -367,11 +367,10 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 
 	//Find tetrahedra links
 	struct TetrahedraInfo {
-		int index;
 		bool valid;
+		int vert_indices[4];
 		Vector3i face_keys[4];
 		int neighbors[4];
-		int vert_indices[4];
 	};
 	std::vector<TetrahedraInfo> tet_info_list;
 	tet_info_list.reserve(tetrahedra_indices.size() / 4);
@@ -443,7 +442,6 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 
 		//Create tetrahedra tracker
 		TetrahedraInfo info;
-		info.index = tet_idx;
 		info.valid = true;
 
 		info.vert_indices[0] = vi0;

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -327,8 +327,6 @@ void JoltSoftBody3D::_apply_environmental_forces(float p_step, JPH::Body &p_jolt
 }
 
 JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
-//	return _create_shared_settings_cloth();
-
 	RenderingServer *rendering = RenderingServer::get_singleton();
 
 	const Array mesh_data = rendering->mesh_surface_get_arrays(mesh, 0);
@@ -351,14 +349,27 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		const Vector3 &v = mesh_vertices[mesh_indices[i]] - body_position;
 
 		auto it = mesh_vert_to_clean_idx_map.find(v);
+		int index;
 		if (it == mesh_vert_to_clean_idx_map.end()) {
-			int index = mesh_vertices_clean.size();
+			index = mesh_vertices_clean.size();
 			mesh_vertices_clean.push_back(v);
-			mesh_indices_clean.push_back(index);
 			mesh_vert_to_clean_idx_map[v] = index;
 		} else {
-			int index = it->second;
-			mesh_indices_clean.push_back(index);
+			index = it->second;
+		}
+		mesh_indices_clean.push_back(index);
+	}
+
+	//Build mesh_to_physics
+	mesh_to_physics.resize(mesh_vertices.size());
+	for (int &index : mesh_to_physics) {
+		index = -1;
+	}
+
+	for (int i = 0; i < mesh_vertices.size(); ++i) {
+		auto it = mesh_vert_to_clean_idx_map.find(mesh_vertices[i]);
+		if (it != mesh_vert_to_clean_idx_map.end()) {
+			mesh_to_physics[i] = it->second;
 		}
 	}
 
@@ -400,7 +411,6 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		return Vector3i(a.x, a.z, a.y);
 	};
 
-	
 
 	//Track tetrahedra
 	for (int i = 0; i < tetrahedra_indices.size(); i += 4) {
@@ -563,10 +573,11 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		settings->mVolumeConstraints.push_back(v);
 	}
 	for (const Vector3i &fv : face_exterior) {
+		//Reverse face winding
 		JPH::SoftBodySharedSettings::Face f;
 		f.mVertex[0] = (JPH::uint32)fv.x;
-		f.mVertex[1] = (JPH::uint32)fv.y;
-		f.mVertex[2] = (JPH::uint32)fv.z;
+		f.mVertex[1] = (JPH::uint32)fv.z;
+		f.mVertex[2] = (JPH::uint32)fv.y;
 		settings->AddFace(f);
 	}
 
@@ -596,7 +607,6 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	settings->Optimize();
 
 	return settings;
-	//return _create_shared_settings_cloth();
 }
 
 void JoltSoftBody3D::_update_mass() {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -363,59 +363,55 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		}
 	}
 
-	//Mark exterior tetrahedra
-	bool use_convex_hull = false;
-	if (!use_convex_hull) {
-		//Create mesh for inside/outside tests
-		PackedVector3Array surface_tris;
-		surface_tris.reserve(mesh_indices_clean.size());
+	//Create mesh for inside/outside tests
+	PackedVector3Array surface_tris;
+	surface_tris.reserve(mesh_indices_clean.size());
 
-		PackedVector3Array surface_norms;
-		surface_norms.reserve(mesh_indices_clean.size() / 3);
+	PackedVector3Array surface_norms;
+	surface_norms.reserve(mesh_indices_clean.size() / 3);
 
-		for (int i = 0; i < mesh_indices_clean.size(); ++i) {
-			surface_tris.append(mesh_vertices_clean[mesh_indices_clean[i]]);
-		}
-		for (int i = 0; i < surface_tris.size(); i += 3) {
-			Vector3 v0 = surface_tris[i];
-			Vector3 v1 = surface_tris[i + 1];
-			Vector3 v2 = surface_tris[i + 2];
-			surface_norms.append((v1 - v0).cross(v2 - v0).normalized());
-		}
+	for (int i = 0; i < mesh_indices_clean.size(); ++i) {
+		surface_tris.append(mesh_vertices_clean[mesh_indices_clean[i]]);
+	}
+	for (int i = 0; i < surface_tris.size(); i += 3) {
+		Vector3 v0 = surface_tris[i];
+		Vector3 v1 = surface_tris[i + 1];
+		Vector3 v2 = surface_tris[i + 2];
+		surface_norms.append((v1 - v0).cross(v2 - v0).normalized());
+	}
 
-		TriangleMesh surface_mesh;
-		surface_mesh.create_from_faces(surface_tris);
+	TriangleMesh surface_mesh;
+	surface_mesh.create_from_faces(surface_tris);
 
-		//Find valid tetrahedra
-		const Vector3 cast_dirs[] = {
-			Vector3(1, 0, 0),
-			Vector3(-1, 0, 0),
-			Vector3(0, 1, 0),
-			Vector3(0, -1, 0),
-			Vector3(0, 0, 1),
-			Vector3(0, 0, -1),
-		};
+	//Find valid (interior) tetrahedra
+	const Vector3 cast_dirs[] = {
+		Vector3(1, 0, 0),
+		Vector3(-1, 0, 0),
+		Vector3(0, 1, 0),
+		Vector3(0, -1, 0),
+		Vector3(0, 0, 1),
+		Vector3(0, 0, -1),
+	};
 
-		for (TetrahedraInfo &t_info : tet_info_list) {
-			Vector3 v0 = mesh_vertices_clean[t_info.vert_indices[0]];
-			Vector3 v1 = mesh_vertices_clean[t_info.vert_indices[1]];
-			Vector3 v2 = mesh_vertices_clean[t_info.vert_indices[2]];
-			Vector3 v3 = mesh_vertices_clean[t_info.vert_indices[3]];
-			Vector3 center = (v0 + v1 + v2 + v3) / 4.0;
+	for (TetrahedraInfo &t_info : tet_info_list) {
+		Vector3 v0 = mesh_vertices_clean[t_info.vert_indices[0]];
+		Vector3 v1 = mesh_vertices_clean[t_info.vert_indices[1]];
+		Vector3 v2 = mesh_vertices_clean[t_info.vert_indices[2]];
+		Vector3 v3 = mesh_vertices_clean[t_info.vert_indices[3]];
+		Vector3 center = (v0 + v1 + v2 + v3) / 4.0;
 
-			Vector3 point;
-			Vector3 normal;
-			int32_t surf_idx;
-			int32_t face_idx;
+		Vector3 point;
+		Vector3 normal;
+		int32_t surf_idx;
+		int32_t face_idx;
 
-			for (int i = 0; i < 6; ++i) {
-				const Vector3 &ray_dir = cast_dirs[i];
-				bool hit = surface_mesh.intersect_ray(center, ray_dir, point, normal, &surf_idx, &face_idx);
-				if (!hit || surface_norms[face_idx].dot(ray_dir) > 0) {
-					//Missed mesh or hit exterior
-					t_info.valid = false;
-					break;
-				}
+		for (int i = 0; i < 6; ++i) {
+			const Vector3 &ray_dir = cast_dirs[i];
+			bool hit = surface_mesh.intersect_ray(center, ray_dir, point, normal, &surf_idx, &face_idx);
+			if (!hit || surface_norms[face_idx].dot(ray_dir) > 0) {
+				//Missed mesh or hit exterior
+				t_info.valid = false;
+				break;
 			}
 		}
 	}
@@ -463,9 +459,10 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	// of the constraints a bit.
 	pin_vertices(*this, pinned_vertices, mesh_to_physics, settings->mVertices);
 
+	settings->CalculateEdgeLengths();
+
 	_apply_physics_values(settings);
 
-	settings->CalculateEdgeLengths();
 	settings->CalculateVolumeConstraintVolumes();
 
 	settings->Optimize();

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -271,7 +271,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	HashSet<Vector2i> edge_set;
 
 	std::function<Vector2i(int, int)> edge_hash_key = [&](int a, int b) {
-			if (b < a) {
+		if (b < a) {
 			return Vector2i(b, a);
 		}
 		return Vector2i(a, b);

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -121,6 +121,16 @@ void JoltSoftBody3D::_add_to_space() {
 }
 
 JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
+	switch (soft_body_form) {
+		default:
+		case PhysicsServer3D::SOFT_BODY_FORM_CLOTH:
+			return _create_shared_settings_cloth();
+		case PhysicsServer3D::SOFT_BODY_FORM_VOLUME:
+			return _create_shared_settings_volume();
+	}
+}
+
+JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_cloth() {
 	RenderingServer *rendering = RenderingServer::get_singleton();
 
 	// TODO: calling RenderingServer::mesh_surface_get_arrays() from the physics thread
@@ -307,6 +317,29 @@ void JoltSoftBody3D::_apply_environmental_forces(float p_step, JPH::Body &p_jolt
 			}
 		}
 	}
+}
+
+JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
+	return _create_shared_settings_cloth();
+
+	//RenderingServer *rendering = RenderingServer::get_singleton();
+
+	//const Array mesh_data = rendering->mesh_surface_get_arrays(mesh, 0);
+	//ERR_FAIL_COND_V(mesh_data.is_empty(), nullptr);
+
+	//const PackedInt32Array mesh_indices = mesh_data[RenderingServer::ARRAY_INDEX];
+	//ERR_FAIL_COND_V(mesh_indices.is_empty(), nullptr);
+
+	//const PackedVector3Array mesh_vertices = mesh_data[RenderingServer::ARRAY_VERTEX];
+	//ERR_FAIL_COND_V(mesh_vertices.is_empty(), nullptr);
+
+	//JPH::SoftBodySharedSettings *settings = new JPH::SoftBodySharedSettings();
+	//JPH::Array<JPH::SoftBodySharedSettings::Vertex> &physics_vertices = settings->mVertices;
+	//JPH::Array<JPH::SoftBodySharedSettings::Face> &physics_faces = settings->mFaces;
+
+	//settings->Optimize();
+
+	//return settings;
 }
 
 void JoltSoftBody3D::_update_mass() {
@@ -699,6 +732,7 @@ PhysicsServer3D::SoftBodyForm JoltSoftBody3D::get_soft_body_form() const {
 
 void JoltSoftBody3D::set_soft_body_form(PhysicsServer3D::SoftBodyForm p_soft_body_form) {
 	soft_body_form = p_soft_body_form;
+	_try_rebuild();
 }
 
 Transform3D JoltSoftBody3D::get_transform() const {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -44,8 +44,6 @@
 
 #include "Jolt/Physics/SoftBody/SoftBodyMotionProperties.h"
 
-#include <functional>
-
 namespace {
 
 template <typename TJoltVertex>
@@ -270,14 +268,14 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	HashSet<Vector3i> face_exterior;
 	HashSet<Vector2i> edge_set;
 
-	std::function<Vector2i(int, int)> edge_hash_key = [&](int a, int b) {
+	auto edge_hash_key = [](int a, int b) {
 		if (b < a) {
 			return Vector2i(b, a);
 		}
 		return Vector2i(a, b);
 	};
 
-	std::function<Vector3i(int, int, int)> face_hash_key = [&](int a, int b, int c) {
+	auto face_hash_key = [](int a, int b, int c) {
 		if (c < a && c < b) {
 			return Vector3i(c, a, b);
 		}
@@ -287,7 +285,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		return Vector3i(a, b, c);
 	};
 
-	std::function<Vector3i(Vector3i)> face_flipped = [&](Vector3i a) {
+	auto face_flipped = [](Vector3i a) {
 		return Vector3i(a.x, a.z, a.y);
 	};
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -44,10 +44,6 @@
 
 #include "Jolt/Physics/SoftBody/SoftBodyMotionProperties.h"
 
-#include <map>
-#include <set>
-#include <vector>
-
 namespace {
 
 template <typename TJoltVertex>
@@ -261,7 +257,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	//Merge any duplicate vertices in input mesh
 	PackedInt32Array mesh_indices_clean;
 	PackedVector3Array mesh_vertices_clean;
-	std::map<Vector3, int> mesh_vert_to_clean_idx_map;
+	HashMap<Vector3, int> mesh_vert_to_clean_idx_map;
 
 	for (int i = 0; i < mesh_indices.size(); ++i) {
 		const Vector3 &v = mesh_vertices[mesh_indices[i]] - body_position;
@@ -273,7 +269,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 			mesh_vertices_clean.push_back(v);
 			mesh_vert_to_clean_idx_map[v] = index;
 		} else {
-			index = it->second;
+			index = it->value;
 		}
 		mesh_indices_clean.push_back(index);
 	}
@@ -284,7 +280,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	for (int i = 0; i < mesh_vertices.size(); ++i) {
 		auto it = mesh_vert_to_clean_idx_map.find(mesh_vertices[i]);
 		if (it != mesh_vert_to_clean_idx_map.end()) {
-			mesh_to_physics[i] = it->second;
+			mesh_to_physics[i] = it->value;
 		} else {
 			mesh_to_physics[i] = -1;
 		}
@@ -300,12 +296,12 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		Vector3i face_keys[4];
 		int neighbors[4];
 	};
-	std::vector<TetrahedraInfo> tet_info_list;
+	LocalVector<TetrahedraInfo> tet_info_list;
 	tet_info_list.reserve(tetrahedra_indices.size() / 4);
 
 	HashMap<Vector3i, int> face_key_to_tet_idx;
-	std::set<Vector3i> face_exterior;
-	std::set<Vector2i> edge_set;
+	HashSet<Vector3i> face_exterior;
+	HashSet<Vector2i> edge_set;
 
 	auto edge_hash_key = [&](int a, int b) {
 		if (b < a) {
@@ -466,7 +462,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 
 		for (int i = 0; i < 4; ++i) {
 			if (t_info.neighbors[i] == -1 || !tet_info_list[t_info.neighbors[i]].valid) {
-				face_exterior.emplace(t_info.face_keys[i]);
+				face_exterior.insert(t_info.face_keys[i]);
 			}
 		}
 	}

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -30,6 +30,8 @@
 
 #include "jolt_soft_body_3d.h"
 
+#include "../../core/math/geometry_3d.h"
+#include "../../core/math/triangle_mesh.h"
 #include "../jolt_project_settings.h"
 #include "../misc/jolt_type_conversions.h"
 #include "../spaces/jolt_broad_phase_layer.h"
@@ -37,16 +39,13 @@
 #include "jolt_area_3d.h"
 #include "jolt_body_3d.h"
 #include "jolt_group_filter.h"
-#include "../../core/math/geometry_3d.h"
-#include "../../core/math/triangle_mesh.h"
 
 #include "servers/rendering/rendering_server.h"
 
 #include "Jolt/Physics/SoftBody/SoftBodyMotionProperties.h"
 
-#include <array>
-#include <set>
 #include <map>
+#include <set>
 #include <vector>
 
 namespace {
@@ -411,7 +410,6 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		return Vector3i(a.x, a.z, a.y);
 	};
 
-
 	//Track tetrahedra
 	for (int i = 0; i < tetrahedra_indices.size(); i += 4) {
 		int tet_idx = i / 4;
@@ -558,7 +556,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 
 	//Populate settings
 	JPH::SoftBodySharedSettings *settings = new JPH::SoftBodySharedSettings();
-	for (const Vector3& v : mesh_vertices_clean) {
+	for (const Vector3 &v : mesh_vertices_clean) {
 		settings->mVertices.emplace_back(JPH::Float3(v.x, v.y, v.z));
 	}
 	for (const Vector2i &e : edge_set) {
@@ -583,7 +581,6 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 
 	settings->CalculateEdgeLengths();
 	settings->CalculateVolumeConstraintVolumes();
-
 
 	// Pin whatever pinned vertices we have currently. This is used during the `Optimize` call below to order the
 	// constraints. Note that it's fine if the pinned vertices change later, but that will reduce the effectiveness

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -199,42 +199,8 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_cloth() {
 	// of the constraints a bit.
 	pin_vertices(*this, pinned_vertices, mesh_to_physics, physics_vertices);
 
-	// Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt uses actual stiffness for its
-	// edge constraints, we must map one to the other.
-	//
-	// Godot uses classic PBD edge constraints, which have a stiffness parameter k that is used in the position correction formula as follows:
-	// delta_x1 = -k * w1 / (w1 + w2) * (l - l0) / l * (x2 - x1)
-	// where k is the stiffness, w1 and w2 are the inverse masses of the two vertices, l is the current length of the edge = |x2 - x1|, l0 is the rest length of the edge, and x1 and x2 are the vertex positions.
-	//
-	// Note that the actual formula used in Godot physics seems to use an approximation of this which avoids calculating the square root:
-	// delta_x1 = -k * w1 / (w1 + w2) * (l^2 - l0^2) / (l^2 + l0^2) * (x2 - x1)
-	//
-	// Jolt uses XPBD which goes as follows:
-	// delta_x1 = -w1 / (w1 + w2 + compliance / dt^2) * (l - l0) / l * (x2 - x1)
-	// where compliance is the inverse of stiffness and dt is the timestep.
-	//
-	// We can derive Jolt's compliance from Godot's stiffness by evaluating:
-	// k * w1 / (w1 + w2) = w1 / (w1 + w2 + compliance / dt^2)
-	// which simplifies to:
-	// compliance = dt^2 * (1 / k - 1) * (w1 + w2)
-
-	// Assuming that the vertices have the same mass:
-	const float w1_plus_w2 = 2.0f * physics_vertices.size() / mass;
-
-	// Calculate time step of a single XPBD iteration
-	const float dt = 1.0f / Engine::get_singleton()->get_user_physics_ticks_per_second() / simulation_precision;
-
-	// Now calculate the compliance
-	const float inverse_stiffness = dt * dt * (1.0f / stiffness_coefficient - 1.0f) * w1_plus_w2;
-
-	JPH::SoftBodySharedSettings::VertexAttributes vertex_attrib;
-	vertex_attrib.mCompliance = vertex_attrib.mShearCompliance = inverse_stiffness;
-
-	settings->CreateConstraints(&vertex_attrib, 1, JPH::SoftBodySharedSettings::EBendType::None);
-	float multiplier = 1.0f - shrinking_factor;
-	for (JPH::SoftBodySharedSettings::Edge &e : settings->mEdgeConstraints) {
-		e.mRestLength *= multiplier;
-	}
+	_apply_physics_values(settings);
+	
 	settings->Optimize();
 
 	return settings;
@@ -500,6 +466,14 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	// of the constraints a bit.
 	pin_vertices(*this, pinned_vertices, mesh_to_physics, settings->mVertices);
 
+	_apply_physics_values(settings);
+
+	settings->Optimize();
+
+	return settings;
+}
+
+void JoltSoftBody3D::_apply_physics_values(JPH::SoftBodySharedSettings *settings) {
 	// Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt uses actual stiffness for its
 	// edge constraints, we must map one to the other.
 	//
@@ -536,11 +510,8 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	for (JPH::SoftBodySharedSettings::Edge &e : settings->mEdgeConstraints) {
 		e.mRestLength *= multiplier;
 	}
-
-	settings->Optimize();
-
-	return settings;
 }
+
 
 void JoltSoftBody3D::_apply_environmental_forces(float p_step, JPH::Body &p_jolt_body) {
 	// Get approximation of the center of the soft body.

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -554,12 +554,35 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		}
 	}
 
+	//Populate settings
 	JPH::SoftBodySharedSettings *settings = new JPH::SoftBodySharedSettings();
 	////physics_vertices.emplace_back(JPH::Float3((float)(vertex.x - body_position.GetX())
-	//for (Vector3 v : mesh_vertices_clean) {
-	//	settings->emplace_back(JPH::Float3(v.x, v.y, v.z));
-	//}
+	for (const Vector3& v : mesh_vertices_clean) {
+		settings->mVertices.emplace_back(JPH::Float3(v.x, v.y, v.z));
+	}
+	for (const Vector2i &e : edge_set) {
+		settings->mEdgeConstraints.emplace_back(JPH::SoftBodySharedSettings::Edge((JPH::uint32)e.x, (JPH::uint32)e.y));
+	}
+	for (const TetrahedraInfo &t_info : tet_info_list) {
+		JPH::SoftBodySharedSettings::Volume v;
+		v.mVertex[0] = (JPH::uint32)t_info.vert_indices[0];
+		v.mVertex[1] = (JPH::uint32)t_info.vert_indices[1];
+		v.mVertex[2] = (JPH::uint32)t_info.vert_indices[2];
+		v.mVertex[3] = (JPH::uint32)t_info.vert_indices[3];
+		settings->mVolumeConstraints.push_back(v);
+		//settings->mEdgeConstraints.emplace_back(JPH::SoftBodySharedSettings::Edge((JPH::uint32)e.x, (JPH::uint32)e.y));
+	}
+	for (const Vector3i &fv : face_exterior) {
+		JPH::SoftBodySharedSettings::Face f;
+		f.mVertex[0] = (JPH::uint32)fv.x;
+		f.mVertex[1] = (JPH::uint32)fv.y;
+		f.mVertex[2] = (JPH::uint32)fv.z;
+		settings->AddFace(f);
+	}
 
+	settings->CalculateEdgeLengths();
+	settings->CalculateVolumeConstraintVolumes();
+	settings->Optimize();
 
 	return _create_shared_settings_cloth();
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -30,12 +30,12 @@
 
 #include "jolt_soft_body_3d.h"
 
-#include "../../core/math/geometry_3d.h"
-#include "../../core/math/triangle_mesh.h"
 #include "../jolt_project_settings.h"
 #include "../misc/jolt_type_conversions.h"
 #include "../spaces/jolt_broad_phase_layer.h"
 #include "../spaces/jolt_space_3d.h"
+#include "core/math/geometry_3d.h"
+#include "core/math/triangle_mesh.h"
 #include "jolt_area_3d.h"
 #include "jolt_body_3d.h"
 #include "jolt_group_filter.h"

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -44,6 +44,8 @@
 
 #include "Jolt/Physics/SoftBody/SoftBodyMotionProperties.h"
 
+#include <functional>
+
 namespace {
 
 template <typename TJoltVertex>
@@ -227,7 +229,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	for (int i = 0; i < mesh_indices.size(); ++i) {
 		const Vector3 &v = mesh_vertices[mesh_indices[i]] - body_position;
 
-		auto it = mesh_vert_to_clean_idx_map.find(v);
+		HashMap<Vector3, int>::Iterator it = mesh_vert_to_clean_idx_map.find(v);
 		int index;
 		if (it == mesh_vert_to_clean_idx_map.end()) {
 			index = mesh_vertices_clean.size();
@@ -243,7 +245,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	mesh_to_physics.resize(mesh_vertices.size());
 
 	for (int i = 0; i < mesh_vertices.size(); ++i) {
-		auto it = mesh_vert_to_clean_idx_map.find(mesh_vertices[i]);
+		HashMap<Vector3, int>::Iterator it = mesh_vert_to_clean_idx_map.find(mesh_vertices[i]);
 		if (it != mesh_vert_to_clean_idx_map.end()) {
 			mesh_to_physics[i] = it->value;
 		} else {
@@ -268,14 +270,14 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	HashSet<Vector3i> face_exterior;
 	HashSet<Vector2i> edge_set;
 
-	auto edge_hash_key = [&](int a, int b) {
-		if (b < a) {
+	std::function<Vector2i(int, int)> edge_hash_key = [&](int a, int b) {
+			if (b < a) {
 			return Vector2i(b, a);
 		}
 		return Vector2i(a, b);
 	};
 
-	auto face_hash_key = [&](int a, int b, int c) {
+	std::function<Vector3i(int, int, int)> face_hash_key = [&](int a, int b, int c) {
 		if (c < a && c < b) {
 			return Vector3i(c, a, b);
 		}
@@ -285,7 +287,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		return Vector3i(a, b, c);
 	};
 
-	auto face_flipped = [&](Vector3i a) {
+	std::function<Vector3i(Vector3i)> face_flipped = [&](Vector3i a) {
 		return Vector3i(a.x, a.z, a.y);
 	};
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -336,6 +336,9 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	const PackedVector3Array mesh_vertices = mesh_data[RenderingServer::ARRAY_VERTEX];
 	ERR_FAIL_COND_V(mesh_vertices.is_empty(), nullptr);
 
+//	std::cout << "entering JoltSoftBody3D::_create_shared_settings_volume()" << std::endl;
+	//WARN_PRINT("entering JoltSoftBody3D::_create_shared_settings_volume()");
+
 	Vector<int32_t> tetrahedra_indices = Geometry3D::tetrahedralize_delaunay(mesh_vertices);
 
 
@@ -356,7 +359,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	const JPH::RVec3 body_position = jolt_settings->mPosition;
 
 	std::set<std::tuple<int, int>> scanned_edges;
-	std::set<std::tuple<int, int, int>> scanned_faces;
+//	std::set<std::tuple<int, int, int>> scanned_faces;
 
 	auto append_edge_if_absent = [&](int a, int b) {
 		if (a > b) {
@@ -374,37 +377,37 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		}
 	};
 
-	auto append_face_if_absent = [&](int a, int b, int c) {
-		if (a > b) {
-			std::swap(a, b);
-		}
-		if (b > c) {
-			std::swap(b, c);
-		}
-		if (a > b) {
-			std::swap(a, b);
-		}
-		std::tuple<int, int, int> face_tup(a, b, c);
+	//auto append_face_if_absent = [&](int a, int b, int c) {
+	//	if (a > b) {
+	//		std::swap(a, b);
+	//	}
+	//	if (b > c) {
+	//		std::swap(b, c);
+	//	}
+	//	if (a > b) {
+	//		std::swap(a, b);
+	//	}
+	//	std::tuple<int, int, int> face_tup(a, b, c);
 
-		if (scanned_faces.find(face_tup) == scanned_faces.end()) {
-			scanned_faces.emplace(face_tup);
+	//	if (scanned_faces.find(face_tup) == scanned_faces.end()) {
+	//		scanned_faces.emplace(face_tup);
 
-			JPH::SoftBodySharedSettings::Face f;
-			f.mVertex[0] = (JPH::uint32)a;
-			f.mVertex[1] = (JPH::uint32)b;
-			f.mVertex[2] = (JPH::uint32)c;
-			settings->AddFace(f);
-		}
-	};
+	//		JPH::SoftBodySharedSettings::Face f;
+	//		f.mVertex[0] = (JPH::uint32)a;
+	//		f.mVertex[1] = (JPH::uint32)b;
+	//		f.mVertex[2] = (JPH::uint32)c;
+	//		settings->AddFace(f);
+	//	}
+	//};
 
 	//Validate vertices, merging any that may be coincident
-	int vertex_index_count = 0;
+	int phys_vert_index_count = 0;
 
-	for (int i = 0; i < mesh_index_count; i += 4) {
+	for (int i = 0; i < tetrahedra_indices.size(); i += 4) {
 		int physics_tet[4];
 
 		for (int j = 0; j < 4; ++j) {
-			const int mesh_vertex_index = mesh_indices[i + j];
+			const int mesh_vertex_index = tetrahedra_indices[i + j];
 			const Vector3 vertex = mesh_vertices[mesh_vertex_index];
 
 			HashMap<Vector3, int>::Iterator iter_physics_index = point_to_physics_index.find(vertex);
@@ -412,7 +415,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 			if (iter_physics_index == point_to_physics_index.end()) {
 				settings->mVertices.emplace_back(
 					JPH::Float3((float)(vertex.x - body_position.GetX()), (float)(vertex.y - body_position.GetY()), (float)(vertex.z - body_position.GetZ())), JPH::Float3(0.0f, 0.0f, 0.0f), 1.0f);
-				iter_physics_index = point_to_physics_index.insert(vertex, vertex_index_count++);
+				iter_physics_index = point_to_physics_index.insert(vertex, phys_vert_index_count++);
 			}
 
 			physics_tet[j] = iter_physics_index->value;
@@ -433,10 +436,10 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		}
 
 		//Add faces
-		append_face_if_absent(physics_tet[0], physics_tet[1], physics_tet[2]);
-		append_face_if_absent(physics_tet[1], physics_tet[0], physics_tet[3]);
-		append_face_if_absent(physics_tet[2], physics_tet[3], physics_tet[0]);
-		append_face_if_absent(physics_tet[3], physics_tet[2], physics_tet[1]);
+		//append_face_if_absent(physics_tet[0], physics_tet[1], physics_tet[2]);
+		//append_face_if_absent(physics_tet[1], physics_tet[0], physics_tet[3]);
+		//append_face_if_absent(physics_tet[2], physics_tet[3], physics_tet[0]);
+		//append_face_if_absent(physics_tet[3], physics_tet[2], physics_tet[1]);
 
 		//Add tetrahedron
 		JPH::SoftBodySharedSettings::Volume v;
@@ -446,7 +449,27 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		v.mVertex[3] = (JPH::uint32)physics_tet[3];
 		settings->mVolumeConstraints.emplace_back(v);
 	}
-	
+	/*	
+	//Add surface faces only
+	for (int i = 0; i < mesh_index_count; i += 3) {
+		int vi0 = mesh_to_physics[i];
+		int vi1 = mesh_to_physics[i + 1];
+		int vi2 = mesh_to_physics[i + 2];
+
+		if (vi0 == vi1 || vi0 == vi2 || vi1 == vi2)
+			continue;
+
+		// Jolt uses a different winding order, so we swap the indices to account for that.
+		JPH::SoftBodySharedSettings::Face f;
+		f.mVertex[0] = (JPH::uint32)vi0;
+		f.mVertex[1] = (JPH::uint32)vi1;
+		f.mVertex[2] = (JPH::uint32)vi2;
+		settings->AddFace(f);
+		//settings->mFaces.emplace_back((JPH::uint32)vi2, (JPH::uint32)vi1, (JPH::uint32)vi0);
+	}
+	*/
+
+	/*
 	// Pin whatever pinned vertices we have currently. This is used during the `Optimize` call below to order the
 	// constraints. Note that it's fine if the pinned vertices change later, but that will reduce the effectiveness
 	// of the constraints a bit.
@@ -465,7 +488,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 	for (JPH::SoftBodySharedSettings::Edge &e : settings->mEdgeConstraints) {
 		e.mRestLength *= multiplier;
 	}
-
+	*/
 	settings->Optimize();
 
 	return settings;

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -372,7 +372,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings_volume() {
 		}
 	}
 
-	//Do delaunay tesselation
+	//Do delaunay tessellation
 	Vector<int32_t> tetrahedra_indices = Geometry3D::tetrahedralize_delaunay(mesh_vertices_clean);
 
 	//Find tetrahedra links

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -508,7 +508,6 @@ void JoltSoftBody3D::_apply_physics_values(JPH::SoftBodySharedSettings *settings
 	}
 }
 
-
 void JoltSoftBody3D::_apply_environmental_forces(float p_step, JPH::Body &p_jolt_body) {
 	// Get approximation of the center of the soft body.
 	Vector3 com_position = to_godot(p_jolt_body.GetCenterOfMassPosition());

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -73,6 +73,8 @@ class JoltSoftBody3D final : public JoltObject3D {
 	virtual void _add_to_space() override;
 
 	JPH::SoftBodySharedSettings *_create_shared_settings();
+	JPH::SoftBodySharedSettings *_create_shared_settings_cloth();
+	JPH::SoftBodySharedSettings *_create_shared_settings_volume();
 
 	void _apply_environmental_forces(float p_step, JPH::Body &p_jolt_body);
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -75,7 +75,7 @@ class JoltSoftBody3D final : public JoltObject3D {
 	JPH::SoftBodySharedSettings *_create_shared_settings();
 	JPH::SoftBodySharedSettings *_create_shared_settings_cloth();
 	JPH::SoftBodySharedSettings *_create_shared_settings_volume();
-	void _apply_physics_values(JPH::SoftBodySharedSettings *settings);
+	float _calculate_compliance(JPH::SoftBodySharedSettings *settings);
 
 	void _apply_environmental_forces(float p_step, JPH::Body &p_jolt_body);
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -51,7 +51,7 @@ class JoltSoftBody3D final : public JoltObject3D {
 	LocalVector<RID> exceptions;
 
 	RID mesh;
-	LocalVector<int> mesh_to_physics_vertex_index;
+	LocalVector<int> mesh_to_physics;
 
 	JPH::SoftBodyCreationSettings *jolt_settings = new JPH::SoftBodyCreationSettings();
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -62,7 +62,7 @@ class JoltSoftBody3D final : public JoltObject3D {
 
 	int simulation_precision = 5;
 
-	PhysicsServer3D::SoftBodyForm soft_body_form = PhysicsServer3D::SOFT_BODY_FORM_CLOTH;
+	PhysicsServer3D::SoftBodyForm form = PhysicsServer3D::SOFT_BODY_FORM_CLOTH;
 
 	virtual JPH::BroadPhaseLayer _get_broad_phase_layer() const override;
 	virtual JPH::ObjectLayer _get_object_layer() const override;
@@ -159,8 +159,8 @@ public:
 	Variant get_state(PhysicsServer3D::BodyState p_state) const;
 	void set_state(PhysicsServer3D::BodyState p_state, const Variant &p_value);
 
-	PhysicsServer3D::SoftBodyForm get_soft_body_form() const;
-	void set_soft_body_form(PhysicsServer3D::SoftBodyForm p_soft_body_form);
+	PhysicsServer3D::SoftBodyForm get_form() const;
+	void set_form(PhysicsServer3D::SoftBodyForm p_form);
 
 	Transform3D get_transform() const;
 	void set_transform(const Transform3D &p_transform);

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -62,6 +62,8 @@ class JoltSoftBody3D final : public JoltObject3D {
 
 	int simulation_precision = 5;
 
+	PhysicsServer3D::SoftBodyForm soft_body_form = PhysicsServer3D::SOFT_BODY_FORM_CLOTH;
+
 	virtual JPH::BroadPhaseLayer _get_broad_phase_layer() const override;
 	virtual JPH::ObjectLayer _get_object_layer() const override;
 
@@ -154,6 +156,9 @@ public:
 
 	Variant get_state(PhysicsServer3D::BodyState p_state) const;
 	void set_state(PhysicsServer3D::BodyState p_state, const Variant &p_value);
+
+	PhysicsServer3D::SoftBodyForm get_soft_body_form() const;
+	void set_soft_body_form(PhysicsServer3D::SoftBodyForm p_soft_body_form);
 
 	Transform3D get_transform() const;
 	void set_transform(const Transform3D &p_transform);

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -75,6 +75,7 @@ class JoltSoftBody3D final : public JoltObject3D {
 	JPH::SoftBodySharedSettings *_create_shared_settings();
 	JPH::SoftBodySharedSettings *_create_shared_settings_cloth();
 	JPH::SoftBodySharedSettings *_create_shared_settings_volume();
+	void _apply_physics_values(JPH::SoftBodySharedSettings *settings);
 
 	void _apply_environmental_forces(float p_step, JPH::Body &p_jolt_body);
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -51,6 +51,7 @@ class JoltSoftBody3D final : public JoltObject3D {
 	LocalVector<RID> exceptions;
 
 	RID mesh;
+	LocalVector<int> mesh_to_physics_vertex_index;
 
 	JPH::SoftBodyCreationSettings *jolt_settings = new JPH::SoftBodyCreationSettings();
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -51,7 +51,6 @@ class JoltSoftBody3D final : public JoltObject3D {
 	LocalVector<RID> exceptions;
 
 	RID mesh;
-	LocalVector<int> mesh_to_physics;
 
 	JPH::SoftBodyCreationSettings *jolt_settings = new JPH::SoftBodyCreationSettings();
 

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -377,8 +377,8 @@ void SoftBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_ray_pickable", "ray_pickable"), &SoftBody3D::set_ray_pickable);
 	ClassDB::bind_method(D_METHOD("is_ray_pickable"), &SoftBody3D::is_ray_pickable);
 
-	ClassDB::bind_method(D_METHOD("set_body_type", "body_type"), &SoftBody3D::set_body_type);
-	ClassDB::bind_method(D_METHOD("get_body_type"), &SoftBody3D::get_body_type);
+	ClassDB::bind_method(D_METHOD("set_soft_body_form", "soft_body_form"), &SoftBody3D::set_soft_body_form);
+	ClassDB::bind_method(D_METHOD("get_soft_body_form"), &SoftBody3D::get_soft_body_form);
 
 	ADD_GROUP("Collision", "collision_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_layer", "get_collision_layer");
@@ -395,7 +395,7 @@ void SoftBody3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ray_pickable"), "set_ray_pickable", "is_ray_pickable");
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "body_type", PROPERTY_HINT_ENUM, "Cloth,Tetrahedra"), "set_body_type", "get_body_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "soft_body_form", PROPERTY_HINT_ENUM, "Cloth,Volume"), "set_soft_body_form", "get_soft_body_form");
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "disable_mode", PROPERTY_HINT_ENUM, "Remove,KeepActive"), "set_disable_mode", "get_disable_mode");
 
@@ -737,12 +737,14 @@ bool SoftBody3D::is_ray_pickable() const {
 	return ray_pickable;
 }
 
-void SoftBody3D::set_body_type(BodyType p_body_type) {
-	body_type = p_body_type;
+void SoftBody3D::set_soft_body_form(PhysicsServer3D::SoftBodyForm p_soft_body_form) {
+	//soft_body_form = p_soft_body_form;
+
+	return PhysicsServer3D::get_singleton()->soft_body_set_form(physics_rid, p_soft_body_form);
 }
 
-SoftBody3D::BodyType SoftBody3D::get_body_type() const {
-	return body_type;
+PhysicsServer3D::SoftBodyForm SoftBody3D::get_soft_body_form() const {
+	return PhysicsServer3D::get_singleton()->soft_body_get_form(physics_rid);
 }
 
 SoftBody3D::SoftBody3D() :

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -377,6 +377,9 @@ void SoftBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_ray_pickable", "ray_pickable"), &SoftBody3D::set_ray_pickable);
 	ClassDB::bind_method(D_METHOD("is_ray_pickable"), &SoftBody3D::is_ray_pickable);
 
+	ClassDB::bind_method(D_METHOD("set_body_type", "body_type"), &SoftBody3D::set_body_type);
+	ClassDB::bind_method(D_METHOD("get_body_type"), &SoftBody3D::get_body_type);
+
 	ADD_GROUP("Collision", "collision_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_layer", "get_collision_layer");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
@@ -391,6 +394,8 @@ void SoftBody3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "drag_coefficient", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_drag_coefficient", "get_drag_coefficient");
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ray_pickable"), "set_ray_pickable", "is_ray_pickable");
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "body_type", PROPERTY_HINT_ENUM, "Edges,Tetrahedra"), "set_body_type", "get_body_type");
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "disable_mode", PROPERTY_HINT_ENUM, "Remove,KeepActive"), "set_disable_mode", "get_disable_mode");
 
@@ -730,6 +735,14 @@ void SoftBody3D::set_ray_pickable(bool p_ray_pickable) {
 
 bool SoftBody3D::is_ray_pickable() const {
 	return ray_pickable;
+}
+
+void SoftBody3D::set_body_type(BodyType p_body_type) {
+	body_type = p_body_type;
+}
+
+SoftBody3D::BodyType SoftBody3D::get_body_type() const {
+	return body_type;
 }
 
 SoftBody3D::SoftBody3D() :

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -395,7 +395,7 @@ void SoftBody3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ray_pickable"), "set_ray_pickable", "is_ray_pickable");
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "body_type", PROPERTY_HINT_ENUM, "Edges,Tetrahedra"), "set_body_type", "get_body_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "body_type", PROPERTY_HINT_ENUM, "Cloth,Tetrahedra"), "set_body_type", "get_body_type");
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "disable_mode", PROPERTY_HINT_ENUM, "Remove,KeepActive"), "set_disable_mode", "get_disable_mode");
 

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -738,8 +738,6 @@ bool SoftBody3D::is_ray_pickable() const {
 }
 
 void SoftBody3D::set_soft_body_form(PhysicsServer3D::SoftBodyForm p_soft_body_form) {
-	//soft_body_form = p_soft_body_form;
-
 	return PhysicsServer3D::get_singleton()->soft_body_set_form(physics_rid, p_soft_body_form);
 }
 

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -377,8 +377,8 @@ void SoftBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_ray_pickable", "ray_pickable"), &SoftBody3D::set_ray_pickable);
 	ClassDB::bind_method(D_METHOD("is_ray_pickable"), &SoftBody3D::is_ray_pickable);
 
-	ClassDB::bind_method(D_METHOD("set_soft_body_form", "soft_body_form"), &SoftBody3D::set_soft_body_form);
-	ClassDB::bind_method(D_METHOD("get_soft_body_form"), &SoftBody3D::get_soft_body_form);
+	ClassDB::bind_method(D_METHOD("set_form", "form"), &SoftBody3D::set_form);
+	ClassDB::bind_method(D_METHOD("get_form"), &SoftBody3D::get_form);
 
 	ADD_GROUP("Collision", "collision_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_layer", "get_collision_layer");
@@ -395,7 +395,7 @@ void SoftBody3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ray_pickable"), "set_ray_pickable", "is_ray_pickable");
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "soft_body_form", PROPERTY_HINT_ENUM, "Cloth,Volume"), "set_soft_body_form", "get_soft_body_form");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "form", PROPERTY_HINT_ENUM, "Cloth,Volume"), "set_form", "get_form");
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "disable_mode", PROPERTY_HINT_ENUM, "Remove,KeepActive"), "set_disable_mode", "get_disable_mode");
 
@@ -737,11 +737,11 @@ bool SoftBody3D::is_ray_pickable() const {
 	return ray_pickable;
 }
 
-void SoftBody3D::set_soft_body_form(PhysicsServer3D::SoftBodyForm p_soft_body_form) {
-	return PhysicsServer3D::get_singleton()->soft_body_set_form(physics_rid, p_soft_body_form);
+void SoftBody3D::set_form(PhysicsServer3D::SoftBodyForm p_form) {
+	return PhysicsServer3D::get_singleton()->soft_body_set_form(physics_rid, p_form);
 }
 
-PhysicsServer3D::SoftBodyForm SoftBody3D::get_soft_body_form() const {
+PhysicsServer3D::SoftBodyForm SoftBody3D::get_form() const {
 	return PhysicsServer3D::get_singleton()->soft_body_get_form(physics_rid);
 }
 

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -73,8 +73,8 @@ public:
 	};
 
 	enum BodyType {
-		BODY_TYPE_EDGES,
-		BODY_TYPE_TETRAHEDRA,
+		BODY_TYPE_CLOTH,
+		BODY_TYPE_VOLUME,
 	};
 
 	struct PinnedPoint {
@@ -103,7 +103,7 @@ private:
 	bool simulation_started = false;
 	bool pinned_points_cache_dirty = true;
 
-	BodyType body_type = BODY_TYPE_EDGES;
+	BodyType body_type = BODY_TYPE_CLOTH;
 
 	Ref<ArrayMesh> debug_mesh_cache;
 	class MeshInstance3D *debug_mesh = nullptr;

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -72,11 +72,6 @@ public:
 		DISABLE_MODE_KEEP_ACTIVE,
 	};
 
-	enum BodyType {
-		BODY_TYPE_CLOTH,
-		BODY_TYPE_VOLUME,
-	};
-
 	struct PinnedPoint {
 		int point_index = -1;
 		NodePath spatial_attachment_path;
@@ -103,7 +98,7 @@ private:
 	bool simulation_started = false;
 	bool pinned_points_cache_dirty = true;
 
-	BodyType body_type = BODY_TYPE_CLOTH;
+//	PhysicsServer3D::SoftBodyForm soft_body_form = PhysicsServer3D::SOFT_BODY_FORM_CLOTH;
 
 	Ref<ArrayMesh> debug_mesh_cache;
 	class MeshInstance3D *debug_mesh = nullptr;
@@ -197,8 +192,8 @@ public:
 	void set_ray_pickable(bool p_ray_pickable);
 	bool is_ray_pickable() const;
 
-	void set_body_type(BodyType p_body_type);
-	BodyType get_body_type() const;
+	void set_soft_body_form(PhysicsServer3D::SoftBodyForm p_soft_body_form);
+	PhysicsServer3D::SoftBodyForm get_soft_body_form() const;
 
 	void apply_impulse(int p_point_index, const Vector3 &p_impulse);
 	void apply_force(int p_point_index, const Vector3 &p_force);
@@ -222,4 +217,3 @@ private:
 };
 
 VARIANT_ENUM_CAST(SoftBody3D::DisableMode);
-VARIANT_ENUM_CAST(SoftBody3D::BodyType);

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -72,6 +72,11 @@ public:
 		DISABLE_MODE_KEEP_ACTIVE,
 	};
 
+	enum BodyType {
+		BODY_TYPE_EDGES,
+		BODY_TYPE_TETRAHEDRA,
+	};
+
 	struct PinnedPoint {
 		int point_index = -1;
 		NodePath spatial_attachment_path;
@@ -97,6 +102,8 @@ private:
 	Vector<PinnedPoint> pinned_points;
 	bool simulation_started = false;
 	bool pinned_points_cache_dirty = true;
+
+	BodyType body_type = BODY_TYPE_EDGES;
 
 	Ref<ArrayMesh> debug_mesh_cache;
 	class MeshInstance3D *debug_mesh = nullptr;
@@ -190,6 +197,9 @@ public:
 	void set_ray_pickable(bool p_ray_pickable);
 	bool is_ray_pickable() const;
 
+	void set_body_type(BodyType p_body_type);
+	BodyType get_body_type() const;
+
 	void apply_impulse(int p_point_index, const Vector3 &p_impulse);
 	void apply_force(int p_point_index, const Vector3 &p_force);
 	void apply_central_impulse(const Vector3 &p_impulse);
@@ -212,3 +222,4 @@ private:
 };
 
 VARIANT_ENUM_CAST(SoftBody3D::DisableMode);
+VARIANT_ENUM_CAST(SoftBody3D::BodyType);

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -190,8 +190,8 @@ public:
 	void set_ray_pickable(bool p_ray_pickable);
 	bool is_ray_pickable() const;
 
-	void set_soft_body_form(PhysicsServer3D::SoftBodyForm p_soft_body_form);
-	PhysicsServer3D::SoftBodyForm get_soft_body_form() const;
+	void set_form(PhysicsServer3D::SoftBodyForm p_form);
+	PhysicsServer3D::SoftBodyForm get_form() const;
 
 	void apply_impulse(int p_point_index, const Vector3 &p_impulse);
 	void apply_force(int p_point_index, const Vector3 &p_force);

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -98,8 +98,6 @@ private:
 	bool simulation_started = false;
 	bool pinned_points_cache_dirty = true;
 
-//	PhysicsServer3D::SoftBodyForm soft_body_form = PhysicsServer3D::SOFT_BODY_FORM_CLOTH;
-
 	Ref<ArrayMesh> debug_mesh_cache;
 	class MeshInstance3D *debug_mesh = nullptr;
 

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -857,6 +857,12 @@ void PhysicsServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("soft_body_get_bounds", "body"), &PhysicsServer3D::soft_body_get_bounds);
 
+	ClassDB::bind_method(D_METHOD("soft_body_set_form", "body", "form"), &PhysicsServer3D::soft_body_set_form);
+	ClassDB::bind_method(D_METHOD("soft_body_get_form", "body"), &PhysicsServer3D::soft_body_get_form);
+
+	BIND_ENUM_CONSTANT(SOFT_BODY_FORM_CLOTH);
+	BIND_ENUM_CONSTANT(SOFT_BODY_FORM_VOLUME);
+
 	ClassDB::bind_method(D_METHOD("soft_body_set_collision_layer", "body", "layer"), &PhysicsServer3D::soft_body_set_collision_layer);
 	ClassDB::bind_method(D_METHOD("soft_body_get_collision_layer", "body"), &PhysicsServer3D::soft_body_get_collision_layer);
 

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -574,6 +574,11 @@ public:
 
 	/* SOFT BODY */
 
+	enum SoftBodyForm {
+		SOFT_BODY_FORM_CLOTH,
+		SOFT_BODY_FORM_VOLUME,
+	};
+
 	virtual RID soft_body_create() = 0;
 
 	virtual void soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> rp_rendering_server_handler) = 0;
@@ -584,6 +589,9 @@ public:
 	virtual void soft_body_set_mesh(RID p_body, RID p_mesh) = 0;
 
 	virtual AABB soft_body_get_bounds(RID p_body) const = 0;
+
+	virtual void soft_body_set_form(RID p_body, SoftBodyForm form) = 0;
+	virtual SoftBodyForm soft_body_get_form(RID p_body) const = 0;
 
 	virtual void soft_body_set_collision_layer(RID p_body, uint32_t p_layer) = 0;
 	virtual uint32_t soft_body_get_collision_layer(RID p_body) const = 0;
@@ -1062,6 +1070,7 @@ VARIANT_ENUM_CAST(PhysicsServer3D::BodyParameter);
 VARIANT_ENUM_CAST(PhysicsServer3D::BodyDampMode);
 VARIANT_ENUM_CAST(PhysicsServer3D::BodyState);
 VARIANT_ENUM_CAST(PhysicsServer3D::BodyAxis);
+VARIANT_ENUM_CAST(PhysicsServer3D::SoftBodyForm);
 VARIANT_ENUM_CAST(PhysicsServer3D::PinJointParam);
 VARIANT_ENUM_CAST(PhysicsServer3D::JointType);
 VARIANT_ENUM_CAST(PhysicsServer3D::HingeJointParam);

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -590,7 +590,7 @@ public:
 
 	virtual AABB soft_body_get_bounds(RID p_body) const = 0;
 
-	virtual void soft_body_set_form(RID p_body, SoftBodyForm form) = 0;
+	virtual void soft_body_set_form(RID p_body, SoftBodyForm p_form) = 0;
 	virtual SoftBodyForm soft_body_get_form(RID p_body) const = 0;
 
 	virtual void soft_body_set_collision_layer(RID p_body, uint32_t p_layer) = 0;

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -359,6 +359,9 @@ public:
 	virtual void soft_body_set_drag_coefficient(RID p_body, real_t p_drag_coefficient) override {}
 	virtual real_t soft_body_get_drag_coefficient(RID p_body) const override { return 0; }
 
+	virtual void soft_body_set_form(RID p_body, SoftBodyForm p_form) override {}
+	virtual SoftBodyForm soft_body_get_form(RID p_body) const override { return SOFT_BODY_FORM_CLOTH; }
+
 	virtual void soft_body_move_point(RID p_body, int p_point_index, const Vector3 &p_global_position) override {}
 	virtual Vector3 soft_body_get_point_global_position(RID p_body, int p_point_index) const override { return Vector3(); }
 

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -360,6 +360,9 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_soft_body_get_bounds, "body");
 
+	GDVIRTUAL_BIND(_soft_body_set_form, "body", "form");
+	GDVIRTUAL_BIND(_soft_body_get_form, "body");
+
 	GDVIRTUAL_BIND(_soft_body_move_point, "body", "point_index", "global_position");
 	GDVIRTUAL_BIND(_soft_body_get_point_global_position, "body", "point_index");
 

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -467,6 +467,9 @@ public:
 
 	EXBIND1RC(AABB, soft_body_get_bounds, RID)
 
+	EXBIND2(soft_body_set_form, RID, SoftBodyForm)
+	EXBIND1RC(SoftBodyForm, soft_body_get_form, RID)
+
 	EXBIND3(soft_body_move_point, RID, int, const Vector3 &)
 	EXBIND2RC(Vector3, soft_body_get_point_global_position, RID, int)
 

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -333,6 +333,9 @@ public:
 
 	FUNC1RC(AABB, soft_body_get_bounds, RID);
 
+	FUNC2(soft_body_set_form, RID, SoftBodyForm);
+	FUNC1RC(SoftBodyForm, soft_body_get_form, RID);
+
 	FUNC3(soft_body_move_point, RID, int, const Vector3 &);
 	FUNC2RC(Vector3, soft_body_get_point_global_position, RID, int);
 


### PR DESCRIPTION
This modifies SoftBody3D so that the user can switch between cloth and volumetric simulations.  This also implements building the volumetric structure needed to implement volumetric soft bodied collisions.

Related to:
https://github.com/godotengine/godot/issues/112027, https://github.com/godotengine/godot-proposals/issues/13661

![soft_body_sim](https://github.com/user-attachments/assets/77316055-c8aa-42f5-813c-bfebc85b6bb7)
