### PR TITLE
Fix DockContextPopup using screen

### DIFF
--- a/editor/docks/dock_tab_container.cpp
+++ b/editor/docks/dock_tab_container.cpp
@@ -159,6 +159,8 @@ void DockTabContainer::_tab_rmb_clicked(int p_tab_idx) {
 	}
 
 	// Right click context menu.
+	int id = DisplayServer::get_singleton()->get_screen_from_rect(Rect2(DisplayServer::get_singleton()->mouse_get_position(), Vector2(1, 1)));
+	dock_context_popup->set_forced_parent_screen(id);
 	dock_context_popup->set_dock(hovered_dock);
 	dock_context_popup->set_position(get_tab_bar()->get_screen_position() + get_tab_bar()->get_local_mouse_position());
 	dock_context_popup->popup();

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2387,6 +2387,8 @@ Rect2i Window::get_usable_parent_rect() const {
 	Rect2i parent_rect;
 	if (is_embedded()) {
 		parent_rect = get_embedder()->get_visible_rect();
+	} else if (forced_parent_screen > -1) {
+		parent_rect = DisplayServer::get_singleton()->screen_get_usable_rect(forced_parent_screen);
 	} else {
 		const Window *w = is_visible() ? this : get_parent_visible_window();
 		//find a parent that can contain us

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -178,6 +178,7 @@ private:
 	Size2i max_size_used;
 
 	Rect2i nonclient_area;
+	int forced_parent_screen = -1;
 
 	Size2i _clamp_limit_size(const Size2i &p_limit_size);
 	Size2i _clamp_window_size(const Size2i &p_size);
@@ -406,6 +407,8 @@ public:
 
 	void set_nonclient_area(const Rect2i &p_rect);
 	Rect2i get_nonclient_area() const;
+
+	void set_forced_parent_screen(int p_screen) { forced_parent_screen = p_screen; }
 
 	void set_mouse_passthrough_polygon(const Vector<Vector2> &p_region);
 	Vector<Vector2> get_mouse_passthrough_polygon() const;


### PR DESCRIPTION
Fixes #116437

Adds an internal Window property that makes it use specific screen instead of one determined from parent window. The dock popup uses the screen from cursor position.

...and now I realized that any popup has this problem 🤦‍♂️
I'm not sure if there is a more automatic way to fix this that would fix all popups.