### PR TITLE
Fix inner class navigation in Editor

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1164,33 +1164,35 @@ Ref<Texture2D> EditorData::get_script_icon(const String &p_script_path) {
 		}
 	}
 
-	Ref<Script> base_scr = ResourceLoader::load(p_script_path, "Script");
-	while (base_scr.is_valid()) {
-		// Check for scripted classes.
-		String icon_path;
-		StringName base_class_name = script_class_get_name(base_scr->get_path());
-		if (base_scr->is_built_in() || base_class_name == StringName()) {
-			icon_path = base_scr->get_class_icon_path();
-		} else {
-			icon_path = script_class_get_icon_path(base_class_name);
-		}
+	if (!p_script_path.is_empty()) {
+		Ref<Script> base_scr = ResourceLoader::load(p_script_path, "Script");
+		while (base_scr.is_valid()) {
+			// Check for scripted classes.
+			String icon_path;
+			StringName base_class_name = script_class_get_name(base_scr->get_path());
+			if (base_scr->is_built_in() || base_class_name == StringName()) {
+				icon_path = base_scr->get_class_icon_path();
+			} else {
+				icon_path = script_class_get_icon_path(base_class_name);
+			}
 
-		Ref<Texture2D> icon = _load_script_icon(icon_path);
-		if (icon.is_valid()) {
-			_script_icon_cache[p_script_path] = icon;
-			return icon;
-		}
+			Ref<Texture2D> icon = _load_script_icon(icon_path);
+			if (icon.is_valid()) {
+				_script_icon_cache[p_script_path] = icon;
+				return icon;
+			}
 
-		// Check for legacy custom classes defined by plugins.
-		// TODO: Should probably be deprecated in 4.x
-		const EditorData::CustomType *ctype = get_custom_type_by_path(base_scr->get_path());
-		if (ctype && ctype->icon.is_valid()) {
-			_script_icon_cache[p_script_path] = ctype->icon;
-			return ctype->icon;
-		}
+			// Check for legacy custom classes defined by plugins.
+			// TODO: Should probably be deprecated in 4.x
+			const EditorData::CustomType *ctype = get_custom_type_by_path(base_scr->get_path());
+			if (ctype && ctype->icon.is_valid()) {
+				_script_icon_cache[p_script_path] = ctype->icon;
+				return ctype->icon;
+			}
 
-		// Move to the base class.
-		base_scr = base_scr->get_base_script();
+			// Move to the base class.
+			base_scr = base_scr->get_base_script();
+		}
 	}
 
 	// Check if the base type is an extension-defined type.

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -51,6 +51,12 @@
 #include "scene/resources/gradient_texture.h"
 #include "scene/resources/image_texture.h"
 
+#include "modules/modules_enabled.gen.h" // for gdscript
+
+#ifdef MODULE_GDSCRIPT_ENABLED
+#include "modules/gdscript/gdscript.h"
+#endif
+
 static bool _has_sub_resources(const Ref<Resource> &p_res) {
 	List<PropertyInfo> property_list;
 	p_res->get_property_list(&property_list);
@@ -182,6 +188,15 @@ void EditorResourcePicker::_update_resource_preview(const String &p_path, const 
 	}
 
 	if (preview_rect) {
+		// For inner classes, show the owner's preview instead, as they don't have their own preview.
+#ifdef MODULE_GDSCRIPT_ENABLED
+		Ref<GDScript> gdscript = edited_resource;
+		if (gdscript.is_valid() && gdscript->is_built_in() && gdscript->has_owner()) {
+			Ref<GDScript> owner_script = gdscript->get_owner();
+			assign_button->set_text(owner_script->get_path().get_file());
+			return;
+		}
+#endif
 		Ref<Script> scr = edited_resource;
 		if (scr.is_valid()) {
 			assign_button->set_text(scr->get_path().get_file());
@@ -219,6 +234,16 @@ void EditorResourcePicker::_resource_selected() {
 		_update_menu();
 		return;
 	}
+
+	// For inner classes, select the owner instead, as they can't be edited directly.
+#ifdef MODULE_GDSCRIPT_ENABLED
+	Ref<GDScript> gdscript = edited_resource;
+	if (gdscript.is_valid() && gdscript->is_built_in() && gdscript->has_owner()) {
+		Ref<GDScript> owner_script = gdscript->get_owner();
+		emit_signal(SNAME("resource_selected"), owner_script, false);
+		return;
+	}
+#endif
 
 	emit_signal(SNAME("resource_selected"), edited_resource, false);
 }

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -78,6 +78,12 @@
 #include "scene/main/window.h"
 #include "servers/display/display_server.h"
 
+#include "modules/modules_enabled.gen.h" // for gdscript
+
+#ifdef MODULE_GDSCRIPT_ENABLED
+#include "modules/gdscript/gdscript.h"
+#endif
+
 void ScriptEditorQuickOpen::popup_dialog(const Vector<String> &p_functions, bool p_dontclear) {
 	popup_centered_ratio(0.6);
 	if (p_dontclear) {
@@ -2161,6 +2167,16 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 	if (p_resource.is_null()) {
 		return false;
 	}
+
+	// Ignore inner classes for the purpose of opening in the editor, as they are not separate resources.
+#ifdef MODULE_GDSCRIPT_ENABLED
+	Ref<GDScript> gdscript = p_resource;
+	if (gdscript.is_valid() && gdscript->is_built_in() && gdscript->has_owner()) {
+		Ref<GDScript> owner_script = gdscript->get_owner();
+		int inner_line = owner_script->get_member_line(gdscript->get_local_name());
+		return edit(owner_script, inner_line - 1, p_col, p_grab_focus);
+	}
+#endif
 
 	Ref<Script> scr = p_resource;
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -307,6 +307,9 @@ public:
 	String get_script_path() const;
 	Error load_source_code(const String &p_path);
 
+	bool has_owner() const { return _owner != nullptr && _owner->is_valid(); }
+	GDScript *get_owner() const { return _owner; }
+
 	void set_binary_tokens_source(const Vector<uint8_t> &p_binary_tokens);
 	const Vector<uint8_t> &get_binary_tokens_source() const;
 	Vector<uint8_t> get_as_binary_tokens() const;


### PR DESCRIPTION
This PR fixes the issue where an inner class script is attached to a node. Selecting a script from `SceneTree` or `Inspector` opens an empty script file.
Related use case of an inner class https://github.com/godotengine/godot-proposals/issues/14285
<details>
<summary>Before this PR:</summary>

https://github.com/user-attachments/assets/ae22c837-e289-4cb8-98f1-2b1fa79980b1
</details>
<details>
<summary>After this PR:</summary>

https://github.com/user-attachments/assets/7ac8c68a-6c3b-44b0-be2c-3572ffd240d7
</details>