### PR TITLE
Fix truncation of the animation position display in AnimationPlayer

### DIFF
--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -2097,6 +2097,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 	frame->set_stretch_ratio(2);
 	frame->set_step(0.0001);
 	frame->set_tooltip_text(TTRC("Animation position (in seconds)."));
+	frame->get_line_edit()->add_theme_constant_override("minimum_character_width", 5);
 
 	hb->add_child(memnew(VSeparator));
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/116549


Before/After:

<img width="537" height="215" alt="Screenshot_20260221_121430" src="https://github.com/user-attachments/assets/54e773f9-83a8-45fe-af6b-e47d1e3bfb35" />


<img width="537" height="215" alt="Screenshot_20260221_120638" src="https://github.com/user-attachments/assets/9ed0d0b0-61b3-4d8c-b791-cf34a5dccf89" />
