### PR TITLE
Robust `safe_normalize` routine (32 bit)

### DIFF
--- a/core/math/math_defs.h
+++ b/core/math/math_defs.h
@@ -45,6 +45,9 @@ inline constexpr double PI = 3.1415926535897932384626433833;
 inline constexpr double E = 2.7182818284590452353602874714;
 inline constexpr double INF = std::numeric_limits<double>::infinity();
 inline constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
+
+inline constexpr float NORMALIZE_32_SAFE_THRESHOLD = 5e-5f;
+inline constexpr float NORMALIZE_32_RESCUE_THRESHOLD = 1e-7f;
 } // namespace Math
 
 #define CMP_EPSILON 0.00001

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -69,6 +69,68 @@ bool Vector2::is_normalized() const {
 	return Math::is_equal_approx(length_squared(), 1, (real_t)UNIT_EPSILON);
 }
 
+real_t Vector2::safe_normalize() {
+	// Don't allow Inf / NaN to propagate.
+	if (!is_finite()) {
+		x = y = 0;
+		return 0;
+	}
+
+	real_t lengthsq = length_squared();
+
+#ifdef REAL_T_IS_DOUBLE
+	// Threshold where standard normalization is safe & accurate in float64
+	// (should be the same as the 32 bit lower threshold, in order to preserve
+	// behavior between the two builds).
+	if (lengthsq >= (real_t)Math::NORMALIZE_32_RESCUE_THRESHOLD) {
+		real_t length = Math::sqrt(lengthsq);
+		*this /= length;
+		return length;
+	}
+#else
+
+	// Threshold where standard normalization is safe & accurate in float32
+	if (lengthsq >= (real_t)Math::NORMALIZE_32_SAFE_THRESHOLD) {
+		real_t length = Math::sqrt(lengthsq);
+		*this /= length;
+		return length;
+	}
+
+	// Rescue branch: try to preserve tiny direction.
+	if (lengthsq >= (real_t)Math::NORMALIZE_32_RESCUE_THRESHOLD) {
+		// Estimate current (tiny) length once.
+		real_t tiny_len = Math::sqrt(lengthsq);
+
+		// Scale up toward unit length — avoid huge multipliers.
+		// We clamp the scale so boosted length stays roughly in [0.1, 10] range
+		// where float32 has best relative precision.
+		real_t target_scale = 1 / MAX(tiny_len, (real_t)1e-5f); // cap extreme scaling.
+
+		*this *= target_scale;
+
+		// Recompute squared length after scaling (necessary because of FP rounding).
+		real_t boosted_sq = length_squared();
+
+		if (boosted_sq > 0) { // should always be true unless catastrophic underflow.
+			real_t boosted_len = Math::sqrt(boosted_sq);
+
+			// Final normalization.
+			*this /= boosted_len;
+
+			// Recover approximate original length.
+			real_t original_len = boosted_len / target_scale;
+
+			return original_len;
+		}
+	}
+#endif
+
+	// Give up, length not enough to give a reasonable result.
+	// Zero vector is cleaner than leaving non-zero result.
+	x = y = 0;
+	return 0;
+}
+
 real_t Vector2::distance_to(const Vector2 &p_vector2) const {
 	return Math::sqrt((x - p_vector2.x) * (x - p_vector2.x) + (y - p_vector2.y) * (y - p_vector2.y));
 }

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -86,6 +86,7 @@ struct [[nodiscard]] Vector2 {
 	void normalize();
 	Vector2 normalized() const;
 	bool is_normalized() const;
+	real_t safe_normalize();
 
 	real_t length() const;
 	real_t length_squared() const;


### PR DESCRIPTION
This function guarantees unit length output in 32 bit and 64 bit real_t builds down to a minimum epsilon, and returns the length of the input vector, or 0 on failure.

Just `Vector2` for now, to make bikeshedding / changes easier, although similar may be applicable in `Vector3` and other classes.

Supersedes #74912
Helps address #74852

## TLDR
This version of `safe_normalize` uses a trick boost to the input vector before normalization in order to guarantee a unit length result. It should be faster than an alternative approach of conversion to `double` for the normalization (which is done in alternative PR #116666).

Which one to go for might possibly be different in Godot 3.x and 4.x ... possibly doubles in 4.x and 32 bit approach in 3.x (partly because of support for 32 bit mobile which may emulate 64 bit math / or be slow at it).

## Explanation
Since I first used Godot I noticed that the normalize functions checked against zero, rather than an epsilon. All previous engines I had encountered and written used an epsilon here. I filed it under something to investigate later in my _memory palace_ :grin: .

| Engine | Epsilon by default | Epsilon | Returns if unsafe |
| ----- | ----- | ----- | ---- |
| Godot | no | 0 | zero |
| Bevy | no | 0 | zero / panic |
| Unity | yes | 1e-5f | zero |
| Unreal | yes (user definable) | 1e-8f (squared) | zero or unchanged |
| CryEngine | yes | unknown |unit vector |
| Gamebryo | yes | unknown | zero |

While having a special case for zero is mathematically correct, in practice we are using floating point, and the behaviour on normalization of small vectors breaks down, resulting in non-unit vector output, and possibly overflow (or other unpredictable behaviour depending on CPU and rounding mode).

In Godot this can exhibit as failing later math checks for `is_normalized()` (which itself is very conservative in non-precise mode). But non-unit length results can also lead to subtle bugs throughout geometry processing. This can be acceptable in some applications (e.g. normalize on GPU) but is probably not a good trade off in others (especially non-bottleneck code).

This led to some investigation as this is an interesting problem.

### How would you choose an epsilon?
* Something that reliably produces a "reasonable" unit vector output (that passes `is_normalized()` in our case)
* The epsilon can (in theory) be lower in 64 bit than in 32 bit (to produce the same accuracy in result)

Most engines just use 32 bit, however we have the choice of builds. However I would personally go with using the same constants in 32 bit and 64 bit, i.e. tuning for the lowest common denominator, as changing these can lead to subtle and hard to track bugs between the builds (this is the approach Godot generally takes afaik).

**Note that the epsilons chosen are designed to pass `is_normalized()` with the more stringent precise math checks, rather than the rather looser defaults. If we only need to pass defaults, the epsilons could likely be relaxed a little.**

## Can we do better?
Inspired by our particular problem (passing math checks) we realize we can **do better** and increase the unit length accuracy of the result at low inputs (at low performance cost).

Instead of giving up and returning zero at the point where the result length would deviate significantly from 1.0, we can extend the range quite a bit by adding a second branch to "rescue" the result and recalibrate it to be closer to length 1.0.

#### We evaluated some rescue approaches:
1) Apply a fixed multiplication "boost" to small vectors before normalization, then remove this boost from returned lengths (see #74912)
2) Essentially apply normalization "twice" (the approach in this PR)
3) Convert to `double` in the rescue branch, then convert back to `float` for the result

Currently the (2) and (3) are winning on advice from Grok, as the accuracy gained seems to outweigh any small performance costs that occur when this branch is taken.

(3) seems to offer even greater returned length accuracy (more than required?) but is likely slower due to 32-64 bit conversions, and slower SIMD with 64 bit. The choice between (2) and (3) may also depend on CPU with (2) being likely more friendly on lower mobile hardware (maybe 3.x versus 4.x? not sure). Of course this only matters when the rescue branch is taken. I'm happy to do a version with double for comparison, or swap this PR to doubles if we are confident it will be better.

For reference, double rescue branch for `Vector2` would be something like this:
_(and probably omitting this and just changing the threshold to the lower one for the 64 bit Godot builds)_
```
double x_d = (double) x;
double y_d = (double) y;

double len_sq_d = x_d*x_d + y_d*y_d;
double len_d = Math::sqrt(len_sq_d);
x = (real_t)(x_d / len_d);
y = (real_t)(y_d / len_d);
return (real_t)len_d;
```

Some other more complex approaches Grok suggested include:
* high-precision accumulation (kahan / kilisch style)
* posit numbers / tapered precision formats
* fast approx + Newton refinement (1-2 iterations)

Although these may be straying into overkill for general purpose game engine.

### Should we apply the rescue branch at all?
This is debatable.
The obvious argument against would be that input vectors small enough to not produce reliable unit vector output are not accurate enough to give a decent direction.

This can be shown to be false however. The minimum threshold lengths involved (before squaring) are actually _quite large_, numerically speaking. We are talking lengths of around 0.002. For comparison, `FLT_MIN` (32 bit) is 
1.175494351e-38F, way way smaller.

It's clear that a direction can be encoded quite accurately for quite a way below the threshold chosen for a unit length result, even taking into account multiple operations and numerical degradation.

So I would argue that, especially in our case (where math checks are used), we should apply the second rescue branch. There don't seem to be any obvious downsides, especially given the current situation in the codebase (they will currently work, but produce output that varies significantly from unit length). That is, we are likely to see _more_ regressions if we don't use a rescue branch (although see the later note on the distinction between _regressions_ and _misuse_).

That's the version I've gone with here. It's fairly easy to remove / ifdef out the rescue branch.

## How to apply
If we decide to add a new safe function, the question arises, should we apply this technique for the existing bound normalization functions, or should we have engine / games explicitly call a "safe_normalize"?

Keeping the existing normalization functions the same has both pros and cons:
* pro - no risk of regressions
* cons - bugs (possibly not yet identified) are not automatically fixed

Given that the majority of other engines use an epsilon, I would tend in the long term towards making the change and using the new approach by default.

I suspect that logic will show that any _regressions_ that show up as a result are actually **unidentified bugs**. i.e. any code that is currently relying on near zero length normalization is currently bugged and unsafe.

However in the interests of getting things moving, I'm just going with the safer approach of just adding the new function for now and not changing any existing normalization routines.

## Why does `safe_normalize` return length at all?
Length is calculated for free in normalization (in all cases except one extra divide in the rescue branch). The return value should get optimized out where unused. In fact the divide would likely be optimized out in many cases (especially if we placed this in the header after finalization).

In many cases the length of a vector is useful information as well as needing to normalize, so this avoids an extra step. An example in AI is calculating the direction and distance from a player to a waypoint or another player. Another example is `Plane` normalization.

It's actually just _coincidence_ that I was working on improving the normalize at the same time as adding a version that returns length, it made sense to combine these two problems.

## ToDo

- [x] Grok numerical tests - indicates it should pass `is_normalized()` in all cases except failure
- [ ] independent numerical testing
- [ ] other classes (possibly follow up PR) 

## Changes
This is a result of iterating on #74912 with grok.

As such some testing with numerical precision is needed, in case of hallucinations (in my earlier PRs I did this testing and found 32 bit SSE pretty accurate to pretty small lengths, however Grok seems to err on the side of caution with epsilons).

## Notes
* On suggestion from Grok, I've gone for one of the other options, "double normalization", on the rescue branch rather than the multiplication boost we discussed when brainstorming. It seems like the accuracy increase from this option can be significant, and the cost is relatively low versus multiplication boost.
* I've forgone the bool, as in most cases just returning the length directly can be used to test failure almost as efficiently as bool.
* Epsilons are custom chosen (stored in mathdefs) and tuned for 32 bit. 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
