### PR TITLE
Make Remove Missing button check project.godot

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -1423,7 +1423,7 @@ void ProjectList::erase_missing_projects() {
 	for (int i = 0; i < _projects.size(); ++i) {
 		const Item &item = _projects[i];
 
-		if (item.missing) {
+		if (item.missing || !FileAccess::exists(item.path.path_join("project.godot"))) {
 			_remove_project(i, true);
 			--i;
 			++deleted_count;

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -858,8 +858,6 @@ void ProjectManager::_update_project_buttons() {
 	duplicate_btn->set_disabled(empty_selection || is_missing_project_selected);
 	manage_tags_btn->set_disabled(empty_selection || is_missing_project_selected || selected_projects.size() > 1);
 	run_btn->set_disabled(empty_selection || is_missing_project_selected);
-
-	erase_missing_btn->set_disabled(!project_list->is_any_project_missing());
 }
 
 void ProjectManager::_open_options_popup() {


### PR DESCRIPTION
Remove projects from list if project.godot is missing, make the "remove missing" button always clickable.

Checks for all project paths if the project.godot file exists. If not, removes the project from the list. Also makes the "Remove Missing" button always clickable.

Discussion: https://github.com/godotengine/godot-proposals/issues/14286

No AI was used in the making.