### PR TITLE
Android: Remove version check for `FEATURE_NATIVE_DIALOG_FILE` support

### DIFF
--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -71,11 +71,6 @@ bool DisplayServerAndroid::has_feature(Feature p_feature) const {
 			return (native_menu && native_menu->has_feature(NativeMenu::FEATURE_GLOBAL_MENU));
 		} break;
 #endif
-		case FEATURE_NATIVE_DIALOG_FILE: {
-			String sdk_version = OS::get_singleton()->get_version().get_slicec('.', 0);
-			return sdk_version.to_int() >= 29;
-		} break;
-
 		case FEATURE_CURSOR_SHAPE:
 		//case FEATURE_CUSTOM_CURSOR_SHAPE:
 		//case FEATURE_HIDPI:
@@ -85,6 +80,7 @@ bool DisplayServerAndroid::has_feature(Feature p_feature) const {
 		//case FEATURE_MOUSE_WARP:
 		case FEATURE_NATIVE_DIALOG:
 		case FEATURE_NATIVE_DIALOG_INPUT:
+		case FEATURE_NATIVE_DIALOG_FILE:
 		//case FEATURE_NATIVE_DIALOG_FILE_EXTRA:
 		case FEATURE_NATIVE_DIALOG_FILE_MIME:
 		//case FEATURE_NATIVE_ICON:


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
This will enable FEATURE_NATIVE_DIALOG_FILE for all Android versions, including Android ROMs.
For Lineage `get_version()` reported the ROM version, not the SDK.

[Godots minimum requirement](https://docs.godotengine.org/en/stable/about/system_requirements.html) is Android 6.0, which is SDK 23.
SAF should be [supported from SDK 19](https://developer.android.com/guide/topics/providers/document-provider) onward.
As suggested by @syntaxerror247 in #116335, the SDK check is removed completely.

Tested the project from the referenced bug report on my lineage 21 and on emulated android-24;default;x86_64 (SDK 24), native window opens with the patch applied on both.

---
_Bugsquad Edit:_
- Closes #116335
- Follow-up to https://github.com/godotengine/godot/pull/115257