### PR TITLE
CI: Restore godot-cpp caching

### DIFF
--- a/.github/actions/godot-cpp-build/action.yml
+++ b/.github/actions/godot-cpp-build/action.yml
@@ -35,4 +35,6 @@ runs:
 
     - name: SCons Build
       shell: sh
+      env:
+        SCONS_CACHE: ${{ inputs.scons-cache }}
       run: scons --directory=./godot-cpp/test "gdextension_dir=${{ github.workspace }}" ${{ inputs.scons-flags }}


### PR DESCRIPTION
The logic for caching godot-cpp files was erroneously removed while rebasing #99938, meaning the godot-cpp builder hasn't had caching functionality for ~9 months. This cache speeds up the `godot-cpp-build` action from ~6 minutes to ~30 seconds