### PR TITLE
SCons: Fix compiled tests on scu builds

### DIFF
--- a/scu_builders.py
+++ b/scu_builders.py
@@ -391,23 +391,26 @@ def generate_scu_files(max_includes_per_scu):
     process_folder(["servers/xr"])
 
     # NOTE: Tests previously compiled as one large unit. We replicate this behavior in SCU builds.
-    process_folder([
-        "tests",
-        "/core",
-        "/core/config",
-        "/core/input",
-        "/core/io",
-        "/core/math",
-        "/core/object",
-        "/core/os",
-        "/core/string",
-        "/core/templates",
-        "/core/threads",
-        "/core/variant",
-        "/scene",
-        "/servers",
-        "/servers/rendering",
-    ])
+    process_folder(
+        [
+            "tests",
+            "/core",
+            "/core/config",
+            "/core/input",
+            "/core/io",
+            "/core/math",
+            "/core/object",
+            "/core/os",
+            "/core/string",
+            "/core/templates",
+            "/core/threads",
+            "/core/variant",
+            "/scene",
+            "/servers",
+            "/servers/rendering",
+        ],
+        ["test_macros", "test_main"],
+    )
 
     # Finally change back the path to the calling folder
     os.chdir(curr_folder)


### PR DESCRIPTION
- Fixes #116583

While I couldn't replicate the issue firsthand, as the errors always seemed to come from Apple Clang, I *did* manage to reasonably isolate the problem area from the reported error on [this RC thread](https://chat.godotengine.org/channel/devel?msg=2WnrzTgZcYQNHwacg):
```
In file included from tests/.scu/scu_tests.gen.cpp:154:
In file included from ./tests/test_main.cpp:42:
./tests/force_link.gen.h:43:2: error: attribute declaration must precede definition [-Werror,-Wignored-attributes]
   43 |         TEST_DLL_PRIVATE void force_link_test_time();
      |         ^
./tests/force_link.gen.h:36:41: note: expanded from macro 'TEST_DLL_PRIVATE'
   36 | #define TEST_DLL_PRIVATE __attribute__((visibility("hidden")))
      |                                         ^
./tests//core/test_time.cpp:33:1: note: previous definition is here
   33 | TEST_FORCE_LINK(test_time)
      | ^
./tests/test_macros.h:54:7: note: expanded from macro 'TEST_FORCE_LINK'
   54 |         void force_link_##m_name() {} \
      |              ^
<scratch space>:112:1: note: expanded from here
  112 | force_link_test_time
      | ^
```
As this attribute is only assigned in `tests/force_link.gen.h`, which is only included by `tests/test_main.cpp`, I added this file to the exceptions for scu batching. Similarly, I excluded `tests/test_macros.cpp`, as that's the file which implements the `doctest` logic, which documentation explicitly instructs to only define in a single compilation unit[^1]

[^1]: https://github.com/doctest/doctest/blob/master/doc/markdown/configuration.md#doctest_config_implement