### PR TITLE
Blender attempts should be incremented to avoid endless loop

### DIFF
--- a/modules/gltf/editor/editor_import_blend_runner.cpp
+++ b/modules/gltf/editor/editor_import_blend_runner.cpp
@@ -210,6 +210,7 @@ HTTPClient::Status EditorImportBlendRunner::connect_blender_rpc(const Ref<HTTPCl
 	bool done = false;
 	while (!done) {
 		OS::get_singleton()->delay_usec(wait_usecs);
+		attempts++;
 		status = p_client->get_status();
 		switch (status) {
 			case HTTPClient::STATUS_RESOLVING:


### PR DESCRIPTION
The number of attempts is used to guard against endless loops but it is not properly incremented.