### PR TITLE
Change the PR template to send new contributors to a short checklist.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,6 @@
 <!--
-Please target the `master` branch in priority.
+Please target the `master` branch. We will take care of backporting relevant fixes to older versions.
 
-Relevant fixes are cherry-picked for stable branches as needed by maintainers.
-
-To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
-https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
+Before submitting, please read our checklist for new contributors:
+https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
 -->


### PR DESCRIPTION
The template currently tells users to install local style checks, which is useful. But there are other concerns (test your pull request, disclose AI, etc.) that are similarly important to read for new contributors.

Since the PR template is presented without formatting, bloating it up would be unpleasant to read. So I hope adding the checklist to the contributing docs is a decent middle ground.

The section in question can be found online: [Checklist for new contributors](https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors)