### PR TITLE
Expose VoxelGI bake progress via signals

### DIFF
--- a/doc/classes/VoxelGI.xml
+++ b/doc/classes/VoxelGI.xml
@@ -47,6 +47,25 @@
 			Number of times to subdivide the grid that the [VoxelGI] operates on. A higher number results in finer detail and thus higher visual quality, while lower numbers result in better performance.
 		</member>
 	</members>
+	<signals>
+		<signal name="bake_begin">
+			<description>
+				Emitted when the node starts baking its [VoxelGIData].
+			</description>
+		</signal>
+		<signal name="bake_end">
+			<description>
+				Emitted when the node fully completed baking its [VoxelGIData].
+			</description>
+		</signal>
+		<signal name="bake_step">
+			<param index="0" name="step" type="int" />
+			<param index="1" name="status" type="String" />
+			<description>
+				Emitted every time the bake process completes a step. The step value starts with [code]0[/code] and ends with [code]999[/code]. The status value is an arbitrary string that describes the current section of the bake process.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 		<constant name="SUBDIV_64" value="0" enum="Subdiv">
 			Use 64 subdivisions. This is the lowest quality setting, but the fastest. Use it if you can, but especially use it on lower-end hardware.

--- a/editor/scene/3d/voxel_gi_editor_plugin.cpp
+++ b/editor/scene/3d/voxel_gi_editor_plugin.cpp
@@ -169,6 +169,14 @@ void VoxelGIEditorPlugin::bake_func_end() {
 void VoxelGIEditorPlugin::_voxel_gi_save_path_and_bake(const String &p_path) {
 	probe_file->hide();
 	if (voxel_gi) {
+		Callable bake_func_begin = callable_mp_static(VoxelGIEditorPlugin::bake_func_begin);
+		Callable bake_func_step = callable_mp_static(VoxelGIEditorPlugin::bake_func_step);
+		Callable bake_func_end = callable_mp_static(VoxelGIEditorPlugin::bake_func_end);
+
+		voxel_gi->connect("bake_begin", bake_func_begin);
+		voxel_gi->connect("bake_step", bake_func_step);
+		voxel_gi->connect("bake_end", bake_func_end);
+
 		voxel_gi->bake();
 		// Ensure the VoxelGIData is always saved to an external resource.
 		// This avoids bloating the scene file with large binary data,
@@ -177,6 +185,10 @@ void VoxelGIEditorPlugin::_voxel_gi_save_path_and_bake(const String &p_path) {
 		ERR_FAIL_COND(voxel_gi_data.is_null());
 		voxel_gi_data->set_path(p_path);
 		ResourceSaver::save(voxel_gi_data, p_path, ResourceSaver::FLAG_CHANGE_PATH);
+
+		voxel_gi->disconnect("bake_begin", bake_func_begin);
+		voxel_gi->disconnect("bake_step", bake_func_step);
+		voxel_gi->disconnect("bake_end", bake_func_end);
 	}
 }
 
@@ -201,8 +213,4 @@ VoxelGIEditorPlugin::VoxelGIEditorPlugin() {
 	probe_file->connect("file_selected", callable_mp(this, &VoxelGIEditorPlugin::_voxel_gi_save_path_and_bake));
 	EditorInterface::get_singleton()->get_base_control()->add_child(probe_file);
 	probe_file->set_title(TTR("Select path for VoxelGI Data File"));
-
-	VoxelGI::bake_begin_function = bake_func_begin;
-	VoxelGI::bake_step_function = bake_func_step;
-	VoxelGI::bake_end_function = bake_func_end;
 }

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -31,6 +31,7 @@
 #include "voxel_gi.h"
 
 #include "core/config/project_settings.h"
+#include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "scene/3d/mesh_instance_3d.h"
@@ -390,19 +391,27 @@ void VoxelGI::_find_meshes(Node *p_at_node, List<PlotMesh> &plot_meshes) {
 	}
 }
 
-VoxelGI::BakeBeginFunc VoxelGI::bake_begin_function = nullptr;
-VoxelGI::BakeStepFunc VoxelGI::bake_step_function = nullptr;
-VoxelGI::BakeEndFunc VoxelGI::bake_end_function = nullptr;
+void VoxelGI::bake_begin() {
+	emit_signal(VoxelGI::bake_begin_name);
+}
+
+bool VoxelGI::bake_step(int p_step, const String &p_status) {
+	return emit_signal(VoxelGI::bake_step_name, p_step, p_status);
+}
+
+void VoxelGI::bake_end() {
+	emit_signal(VoxelGI::bake_end_name);
+}
 
 static int voxelizer_plot_bake_base = 0;
 static int voxelizer_plot_bake_total = 0;
 
-static bool voxelizer_plot_bake_step_function(int current, int) {
-	return VoxelGI::bake_step_function((voxelizer_plot_bake_base + current) * 500 / voxelizer_plot_bake_total, RTR("Plotting Meshes"));
+bool VoxelGI::_voxelizer_plot_bake_step_function(int p_current, int p_total) {
+	return bake_step((voxelizer_plot_bake_base + p_current) * 500 / voxelizer_plot_bake_total, RTR("Plotting Meshes"));
 }
 
-static bool voxelizer_sdf_bake_step_function(int current, int total) {
-	return VoxelGI::bake_step_function(500 + current * 500 / total, RTR("Generating Distance Field"));
+bool VoxelGI::_voxelizer_sdf_bake_step_function(int p_current, int p_total) {
+	return bake_step(500 + p_current * 500 / p_total, RTR("Generating Distance Field"));
 }
 
 Vector3i VoxelGI::get_estimated_cell_size() const {
@@ -447,11 +456,9 @@ void VoxelGI::bake(Node *p_from_node, bool p_create_visual_debug) {
 
 	_find_meshes(p_from_node, mesh_list);
 
-	if (bake_begin_function) {
-		bake_begin_function();
-	}
+	bake_begin();
 
-	Voxelizer::BakeStepFunc voxelizer_step_func = bake_step_function != nullptr ? voxelizer_plot_bake_step_function : nullptr;
+	Callable voxelizer_step_func = callable_mp(this, &VoxelGI::_voxelizer_plot_bake_step_function);
 
 	voxelizer_plot_bake_total = voxelizer_plot_bake_base = 0;
 	for (PlotMesh &E : mesh_list) {
@@ -460,16 +467,13 @@ void VoxelGI::bake(Node *p_from_node, bool p_create_visual_debug) {
 	for (PlotMesh &E : mesh_list) {
 		if (baker.plot_mesh(E.local_xform, E.mesh, E.instance_materials, E.override_material, voxelizer_step_func) != Voxelizer::BAKE_RESULT_OK) {
 			baker.end_bake();
-			if (bake_end_function) {
-				bake_end_function();
-			}
+			bake_end();
 			return;
 		}
 		voxelizer_plot_bake_base += baker.get_bake_steps(E.mesh);
 	}
-	if (bake_step_function) {
-		bake_step_function(500, RTR("Finishing Plot"));
-	}
+
+	bake_step(500, RTR("Finishing Plot"));
 
 	baker.end_bake();
 
@@ -496,14 +500,12 @@ void VoxelGI::bake(Node *p_from_node, bool p_create_visual_debug) {
 			probe_data_new.instantiate();
 		}
 
-		if (bake_step_function) {
-			bake_step_function(500, RTR("Generating Distance Field"));
-		}
+		bake_step(500, RTR("Generating Distance Field"));
 
-		voxelizer_step_func = bake_step_function != nullptr ? voxelizer_sdf_bake_step_function : nullptr;
+		Callable voxelizer_sdf_step_func = callable_mp(this, &VoxelGI::_voxelizer_sdf_bake_step_function);
 
 		Vector<uint8_t> df;
-		if (baker.get_sdf_3d_image(df, voxelizer_step_func) == Voxelizer::BAKE_RESULT_OK) {
+		if (baker.get_sdf_3d_image(df, voxelizer_sdf_step_func) == Voxelizer::BAKE_RESULT_OK) {
 			RS::get_singleton()->voxel_gi_set_baked_exposure_normalization(probe_data_new->get_rid(), exposure_normalization);
 
 			probe_data_new->allocate(baker.get_to_cell_space_xform(), AABB(-size / 2, size), baker.get_voxel_gi_octree_size(), baker.get_voxel_gi_octree_cells(), baker.get_voxel_gi_data_cells(), df, baker.get_voxel_gi_level_cell_count());
@@ -515,9 +517,7 @@ void VoxelGI::bake(Node *p_from_node, bool p_create_visual_debug) {
 		}
 	}
 
-	if (bake_end_function) {
-		bake_end_function();
-	}
+	bake_end();
 
 	notify_property_list_changed(); //bake property may have changed
 }
@@ -581,6 +581,10 @@ void VoxelGI::_bind_methods() {
 	BIND_ENUM_CONSTANT(SUBDIV_256);
 	BIND_ENUM_CONSTANT(SUBDIV_512);
 	BIND_ENUM_CONSTANT(SUBDIV_MAX);
+
+	ADD_SIGNAL(MethodInfo("bake_begin"));
+	ADD_SIGNAL(MethodInfo("bake_step", PropertyInfo(Variant::INT, "step"), PropertyInfo(Variant::STRING, "status")));
+	ADD_SIGNAL(MethodInfo("bake_end"));
 }
 
 VoxelGI::VoxelGI() {

--- a/scene/3d/voxel_gi.h
+++ b/scene/3d/voxel_gi.h
@@ -108,10 +108,6 @@ public:
 
 	};
 
-	typedef void (*BakeBeginFunc)();
-	typedef bool (*BakeStepFunc)(int, const String &);
-	typedef void (*BakeEndFunc)();
-
 private:
 	Ref<VoxelGIData> probe_data;
 
@@ -120,6 +116,10 @@ private:
 	Subdiv subdiv = SUBDIV_128;
 	Vector3 size = Vector3(20, 20, 20);
 	Ref<CameraAttributes> camera_attributes;
+
+	StringName bake_begin_name = "bake_begin";
+	StringName bake_step_name = "bake_step";
+	StringName bake_end_name = "bake_end";
 
 	struct PlotMesh {
 		Ref<Material> override_material;
@@ -130,8 +130,14 @@ private:
 
 	void _find_meshes(Node *p_at_node, List<PlotMesh> &plot_meshes);
 	void _debug_bake();
+	bool _voxelizer_plot_bake_step_function(int p_current, int p_total);
+	bool _voxelizer_sdf_bake_step_function(int p_current, int p_total);
 
 	float _get_camera_exposure_normalization();
+
+	void bake_begin();
+	bool bake_step(int p_step, const String &p_status);
+	void bake_end();
 
 protected:
 	static void _bind_methods();
@@ -141,10 +147,6 @@ protected:
 #endif // DISABLE_DEPRECATED
 
 public:
-	static BakeBeginFunc bake_begin_function;
-	static BakeStepFunc bake_step_function;
-	static BakeEndFunc bake_end_function;
-
 	void set_probe_data(const Ref<VoxelGIData> &p_data);
 	Ref<VoxelGIData> get_probe_data() const;
 

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -405,7 +405,7 @@ int Voxelizer::get_bake_steps(Ref<Mesh> &p_mesh) const {
 	return bake_total;
 }
 
-Voxelizer::BakeResult Voxelizer::plot_mesh(const Transform3D &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_override_material, BakeStepFunc p_bake_step_func) {
+Voxelizer::BakeResult Voxelizer::plot_mesh(const Transform3D &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_override_material, Callable p_bake_step_func) {
 	ERR_FAIL_COND_V_MSG(!p_xform.is_finite(), BAKE_RESULT_INVALID_PARAMETER, "Invalid mesh bake transform.");
 
 	// Precalculate for transforming vertex normals
@@ -457,8 +457,8 @@ Voxelizer::BakeResult Voxelizer::plot_mesh(const Transform3D &p_xform, Ref<Mesh>
 				Vector3 normal[3];
 
 				bake_current++;
-				if (p_bake_step_func != nullptr && (bake_current & 2047) == 1) {
-					if (p_bake_step_func(bake_current, bake_total)) {
+				if (p_bake_step_func.is_valid() && (bake_current & 2047) == 1) {
+					if (p_bake_step_func.call(bake_current, bake_total).booleanize()) {
 						return BAKE_RESULT_CANCELLED;
 					}
 				}
@@ -496,8 +496,8 @@ Voxelizer::BakeResult Voxelizer::plot_mesh(const Transform3D &p_xform, Ref<Mesh>
 				Vector3 normal[3];
 
 				bake_current++;
-				if (p_bake_step_func != nullptr && (bake_current & 2047) == 1) {
-					if (p_bake_step_func(bake_current, bake_total)) {
+				if (p_bake_step_func.is_valid() && (bake_current & 2047) == 1) {
+					if (p_bake_step_func.call(bake_current, bake_total).booleanize()) {
 						return BAKE_RESULT_CANCELLED;
 					}
 				}
@@ -865,7 +865,7 @@ static void edt(float *f, int stride, int n) {
 
 #undef square
 
-Voxelizer::BakeResult Voxelizer::get_sdf_3d_image(Vector<uint8_t> &r_image, BakeStepFunc p_bake_step_function) const {
+Voxelizer::BakeResult Voxelizer::get_sdf_3d_image(Vector<uint8_t> &r_image, Callable p_bake_step_function) const {
 	Vector3i octree_size = get_voxel_gi_octree_size();
 
 	uint32_t float_count = octree_size.x * octree_size.y * octree_size.z;
@@ -898,8 +898,8 @@ Voxelizer::BakeResult Voxelizer::get_sdf_3d_image(Vector<uint8_t> &r_image, Bake
 	//xy->z
 
 	for (int i = 0; i < octree_size.x; i++, bake_current++) {
-		if (p_bake_step_function) {
-			if (p_bake_step_function(bake_current, bake_total)) {
+		if (p_bake_step_function.is_valid()) {
+			if (p_bake_step_function.call(bake_current, bake_total).booleanize()) {
 				memdelete_arr(work_memory);
 				return BAKE_RESULT_CANCELLED;
 			}
@@ -912,8 +912,8 @@ Voxelizer::BakeResult Voxelizer::get_sdf_3d_image(Vector<uint8_t> &r_image, Bake
 	//xz->y
 
 	for (int i = 0; i < octree_size.x; i++, bake_current++) {
-		if (p_bake_step_function) {
-			if (p_bake_step_function(bake_current, bake_total)) {
+		if (p_bake_step_function.is_valid()) {
+			if (p_bake_step_function.call(bake_current, bake_total).booleanize()) {
 				memdelete_arr(work_memory);
 				return BAKE_RESULT_CANCELLED;
 			}
@@ -925,8 +925,8 @@ Voxelizer::BakeResult Voxelizer::get_sdf_3d_image(Vector<uint8_t> &r_image, Bake
 
 	//yz->x
 	for (int i = 0; i < octree_size.y; i++, bake_current++) {
-		if (p_bake_step_function) {
-			if (p_bake_step_function(bake_current, bake_total)) {
+		if (p_bake_step_function.is_valid()) {
+			if (p_bake_step_function.call(bake_current, bake_total).booleanize()) {
 				memdelete_arr(work_memory);
 				return BAKE_RESULT_CANCELLED;
 			}

--- a/scene/3d/voxelizer.h
+++ b/scene/3d/voxelizer.h
@@ -122,7 +122,7 @@ private:
 public:
 	void begin_bake(int p_subdiv, const AABB &p_bounds, float p_exposure_normalization);
 	int get_bake_steps(Ref<Mesh> &p_mesh) const;
-	BakeResult plot_mesh(const Transform3D &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_override_material, BakeStepFunc p_bake_step_function);
+	BakeResult plot_mesh(const Transform3D &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_override_material, Callable p_bake_step_function);
 	void end_bake();
 
 	int get_voxel_gi_octree_depth() const;
@@ -131,7 +131,7 @@ public:
 	Vector<uint8_t> get_voxel_gi_octree_cells() const;
 	Vector<uint8_t> get_voxel_gi_data_cells() const;
 	Vector<int> get_voxel_gi_level_cell_count() const;
-	BakeResult get_sdf_3d_image(Vector<uint8_t> &r_image, BakeStepFunc p_bake_step_function) const;
+	BakeResult get_sdf_3d_image(Vector<uint8_t> &r_image, Callable p_bake_step_function) const;
 
 	Ref<MultiMesh> create_debug_multimesh();
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/14242.

Currently the progress of `VoxelGI::bake` is reported via three C++ function pointers:

- `VoxelGI::bake_begin_function`
- `VoxelGI::bake_step_function`
- `VoxelGI::bake_end_function`

These functions can only be set by engine code and are currently only utilized by the editor to display a progress bar.

Anyone calling `VoxelGI::bake` via `GDScript` or `GDExtension` is unable to observe the progress of the bake process. I would like to keep track of the progress that has been made while baking a node. Being able to observe the progress would allow for more responsive UI updates in games that bake VoxelGI at runtime; i.e., progress bars can be updated more granularly (see caveats regarding remaining limitations).

It will also enable editor plugins to display the baking progress when implementing custom processes like batch processing.

[example_project.zip](https://github.com/user-attachments/files/25461030/example_project.zip) that demonstrates the new signals.

## Caveats
The editor currently utilizes a bit of a hack to update the progress bar when receiving the step function callback. It manually runs the main loop for a few iterations as the VoxelGI bake process is completely blocking the main thread. This limitation will not be removed by migrating to signals but can be addressed in later changes like this proposal: https://github.com/godotengine/godot-proposals/issues/14243.