### PR TITLE
Fix SplitContainer accessibility errors

### DIFF
--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -185,6 +185,9 @@ void SplitContainerDragger::update_touch_dragger() {
 void SplitContainerDragger::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ACCESSIBILITY_UPDATE: {
+			if (dragger_index < 0) {
+				return;
+			}
 			RID ae = get_accessibility_element();
 			ERR_FAIL_COND(ae.is_null());
 
@@ -765,6 +768,9 @@ void SplitContainer::_resort() {
 }
 
 void SplitContainer::_update_draggers() {
+	if (!is_visible_in_tree()) {
+		return;
+	}
 	const int valid_child_count = (int)valid_children.size();
 	const int dragger_count = MAX(valid_child_count - 1, 1);
 	const int draggers_size_diff = dragger_count - (int)dragging_area_controls.size();

--- a/tests/scene/test_split_container.cpp
+++ b/tests/scene/test_split_container.cpp
@@ -1788,6 +1788,7 @@ TEST_CASE("[SceneTree][SplitContainer] More children") {
 	SUBCASE("[SplitContainer] Duplicate") {
 		// Make sure dynamically added internal draggers duplicate properly.
 		SplitContainer *duplicate = (SplitContainer *)(Node *)split_container->duplicate();
+		SceneTree::get_singleton()->get_root()->add_child(duplicate);
 		MessageQueue::get_singleton()->flush();
 		CHECK(duplicate->get_child_count(false) == split_container->get_child_count(false));
 		CHECK(duplicate->get_child_count(true) == split_container->get_child_count(true));


### PR DESCRIPTION
There are a bunch of errors when enabling narrator in the editor on 4.6 or later:

<img width="1117" height="583" alt="image" src="https://github.com/user-attachments/assets/4898fc75-ff0e-432e-a823-9d4d78bc292c" />

This is because the NOTIFICATION_ACCESSIBILITY_UPDATE happened before the dragger was setup, or on invisible SplitContainers that had their draggers added but don't have correct split_offsets yet.

`_update_draggers` will get updated when it is made visible (on sort), so it is fine to not add them while not visible.
And `NOTIFICATION_ACCESSIBILITY_UPDATE` will get sent later, they still get updated in my testing.