### PR TITLE
Disable reflection probes 1&2 in compatibility renderer when debug draw unshaded enabled.

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3406,6 +3406,9 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 						spec_constants |= SceneShaderGLES3::DISABLE_LIGHT_SPOT;
 						spec_constants |= SceneShaderGLES3::DISABLE_LIGHT_DIRECTIONAL;
 						spec_constants |= SceneShaderGLES3::DISABLE_LIGHTMAP;
+						spec_constants |= SceneShaderGLES3::DISABLE_REFLECTION_PROBE;
+						// SECOND_REFLECTION_PROBE will be turned on during REFPROBE2 shader setup below, if cache.size() > 1
+						inst->reflection_probe_rid_cache.clear();
 					} else {
 						if (inst->omni_light_gl_cache.is_empty()) {
 							spec_constants |= SceneShaderGLES3::DISABLE_LIGHT_OMNI;


### PR DESCRIPTION
Fixes #103032 

Also ran into this while testing compatibility debug drawing with https://github.com/Calinou/godot-reflection
Generates this error continuously:
`.../drivers/gles3/shader_gles3.h:232 - Parameter "spec" is null.`
