### PR TITLE
Add MultiRect command

### DIFF
--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -836,6 +836,16 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #endif
 
 #ifdef DEV_ENABLED
+#define DEV_CHECK(m_cond) \
+	if (unlikely(!(m_cond))) { \
+		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "DEV_CHECK failed  \"" _STR(m_cond) "\" is false."); \
+	} else \
+		((void)0)
+#else
+#define DEV_CHECK(m_cond)
+#endif
+
+#ifdef DEV_ENABLED
 #define DEV_CHECK_ONCE(m_cond) \
 	if (true) { \
 		static bool first_print = true; \

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1021,6 +1021,109 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 				_add_to_batch(r_index, r_batch_broken);
 			} break;
 
+			case Item::Command::TYPE_MULTIRECT: {
+				const Item::CommandMultiRect *mr = static_cast<const Item::CommandMultiRect *>(c);
+
+				if (mr->flags & CANVAS_RECT_TILE && state.canvas_instance_batches[state.current_batch_index].repeat != RSE::CanvasItemTextureRepeat::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED) {
+					_new_batch(r_batch_broken);
+					state.canvas_instance_batches[state.current_batch_index].repeat = RSE::CanvasItemTextureRepeat::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED;
+				}
+
+				if (mr->texture != state.canvas_instance_batches[state.current_batch_index].tex || state.canvas_instance_batches[state.current_batch_index].command_type != Item::Command::TYPE_MULTIRECT) {
+					_new_batch(r_batch_broken);
+					state.canvas_instance_batches[state.current_batch_index].tex = mr->texture;
+					state.canvas_instance_batches[state.current_batch_index].command_type = Item::Command::TYPE_MULTIRECT;
+					state.canvas_instance_batches[state.current_batch_index].command = c;
+					state.canvas_instance_batches[state.current_batch_index].specialization &= specialization_command_mask;
+					state.canvas_instance_batches[state.current_batch_index].flags = 0;
+				}
+
+				_prepare_canvas_texture(mr->texture, state.canvas_instance_batches[state.current_batch_index].filter, state.canvas_instance_batches[state.current_batch_index].repeat, r_index, texpixel_size);
+
+				int i = 0;
+				Rect2 src_rect;
+				Rect2 dst_rect;
+				bool valid_tex = mr->texture != RID();
+
+				if (mr->flags & CANVAS_RECT_MSDF) {
+					state.instance_data_array[r_index].flags |= INSTANCE_FLAGS_USE_MSDF;
+					state.instance_data_array[r_index].msdf[0] = mr->px_range; // Pixel range.
+					state.instance_data_array[r_index].msdf[1] = mr->outline; // Outline size.
+					state.instance_data_array[r_index].msdf[2] = 0.f; // Reserved.
+					state.instance_data_array[r_index].msdf[3] = 0.f; // Reserved.
+				} else if (mr->flags & CANVAS_RECT_LCD) {
+					state.instance_data_array[r_index].flags |= INSTANCE_FLAGS_USE_LCD;
+				}
+
+				while (i < mr->rects.size()) {
+					if (valid_tex) {
+						src_rect = (mr->flags & CANVAS_RECT_REGION) ? Rect2(mr->sources[i].position * texpixel_size, mr->sources[i].size * texpixel_size) : Rect2(0, 0, 1, 1);
+						dst_rect = Rect2(mr->rects[i].position, mr->rects[i].size);
+
+						if (dst_rect.size.width < 0) {
+							dst_rect.position.x += dst_rect.size.width;
+							dst_rect.size.width *= -1;
+						}
+						if (dst_rect.size.height < 0) {
+							dst_rect.position.y += dst_rect.size.height;
+							dst_rect.size.height *= -1;
+						}
+
+						if (mr->flags & CANVAS_RECT_FLIP_H) {
+							src_rect.size.x *= -1;
+						}
+
+						if (mr->flags & CANVAS_RECT_FLIP_V) {
+							src_rect.size.y *= -1;
+						}
+
+						if (mr->flags & CANVAS_RECT_TRANSPOSE) {
+							state.instance_data_array[r_index].flags |= INSTANCE_FLAGS_TRANSPOSE_RECT;
+						}
+
+						if (mr->flags & CANVAS_RECT_CLIP_UV) {
+							state.instance_data_array[r_index].flags |= INSTANCE_FLAGS_CLIP_RECT_UV;
+						}
+					} else {
+						dst_rect = Rect2(mr->rects[i].position, mr->rects[i].size);
+
+						if (dst_rect.size.width < 0) {
+							dst_rect.position.x += dst_rect.size.width;
+							dst_rect.size.width *= -1;
+						}
+						if (dst_rect.size.height < 0) {
+							dst_rect.position.y += dst_rect.size.height;
+							dst_rect.size.height *= -1;
+						}
+
+						src_rect = Rect2(0, 0, 1, 1);
+					}
+
+					state.instance_data_array[r_index].modulation[0] = mr->modulate.r * base_color.r;
+					state.instance_data_array[r_index].modulation[1] = mr->modulate.g * base_color.g;
+					state.instance_data_array[r_index].modulation[2] = mr->modulate.b * base_color.b;
+					state.instance_data_array[r_index].modulation[3] = mr->modulate.a * base_color.a;
+
+					state.instance_data_array[r_index].src_rect[0] = src_rect.position.x;
+					state.instance_data_array[r_index].src_rect[1] = src_rect.position.y;
+					state.instance_data_array[r_index].src_rect[2] = src_rect.size.width;
+					state.instance_data_array[r_index].src_rect[3] = src_rect.size.height;
+
+					state.instance_data_array[r_index].dst_rect[0] = dst_rect.position.x;
+					state.instance_data_array[r_index].dst_rect[1] = dst_rect.position.y;
+					state.instance_data_array[r_index].dst_rect[2] = dst_rect.size.width;
+					state.instance_data_array[r_index].dst_rect[3] = dst_rect.size.height;
+
+					_add_to_batch(r_index, r_batch_broken);
+					i += 1;
+
+					if (r_index != 0 && i != mr->rects.size()) {
+						// Copy previous instance
+						memcpy(&state.instance_data_array[r_index], &state.instance_data_array[r_index - 1], sizeof(InstanceData));
+					}
+				}
+			} break;
+
 			case Item::Command::TYPE_NINEPATCH: {
 				const Item::CommandNinePatch *np = static_cast<const Item::CommandNinePatch *>(c);
 
@@ -1306,6 +1409,7 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index, Ren
 
 	switch (state.canvas_instance_batches[p_index].command_type) {
 		case Item::Command::TYPE_RECT:
+		case Item::Command::TYPE_MULTIRECT:
 		case Item::Command::TYPE_NINEPATCH: {
 			glBindVertexArray(data.indexed_quad_array);
 			glBindBuffer(GL_ARRAY_BUFFER, state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers[state.canvas_instance_batches[p_index].instance_buffer_index]);

--- a/platform/macos/display_server_macos_base.h
+++ b/platform/macos/display_server_macos_base.h
@@ -30,10 +30,6 @@
 
 #pragma once
 
-#include "core/os/thread_safe.h"
-#include "core/typedefs.h" // IWYU pragma: keep. Prevent macOS `MAX`/`MIN` from being defined.
-#include "servers/display/display_server.h"
-
 #define FontVariation __FontVariation
 
 #import <AppKit/AppKit.h>
@@ -43,6 +39,10 @@
 
 class RenderingContextDriver;
 class RenderingDevice;
+
+// Must come after AppKit.h so include chain up to TypeDefs.h appropriately undefines MAX/MIN
+#include "core/input/input.h"
+#include "servers/display/display_server.h"
 
 class DisplayServerMacOSBase : public DisplayServer {
 	GDSOFTCLASS(DisplayServerMacOSBase, DisplayServer)

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -42,6 +42,7 @@
 #include "scene/main/scene_tree.h"
 #include "scene/resources/material.h"
 #include "scene/resources/world_2d.h"
+#include "servers/rendering/renderer_canvas_helper.h"
 #include "servers/rendering/rendering_server.h"
 
 #ifndef PHYSICS_2D_DISABLED
@@ -319,6 +320,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 				Ref<Material> prev_material;
 				int prev_z_index = 0;
 				RID prev_ci;
+				RendererCanvasHelper::tilemap_begin();
 
 				for (SelfList<CellData> *cell_data_quadrant_list_element = rendering_quadrant->cells.first(); cell_data_quadrant_list_element; cell_data_quadrant_list_element = cell_data_quadrant_list_element->next()) {
 					CellData &cell_data = *cell_data_quadrant_list_element->self();
@@ -389,6 +391,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 					draw_tile(ci, local_tile_pos - rendering_quadrant->canvas_items_position, tile_set, cell_data.cell.source_id, cell_data.cell.get_atlas_coords(), cell_data.cell.alternative_tile, -1, tile_data, random_animation_offset);
 				}
 
+				RendererCanvasHelper::tilemap_end();
 				// Reset physics interpolation for any recreated canvas items.
 				if (is_physics_interpolated_and_enabled() && is_visible_in_tree()) {
 					for (const RID &ci : rendering_quadrant->canvas_items) {
@@ -2700,10 +2703,18 @@ void TileMapLayer::draw_tile(RID p_canvas_item, const Vector2 &p_position, const
 		// Draw the tile.
 		if (p_frame >= 0) {
 			Rect2i source_rect = atlas_source->get_runtime_tile_texture_region(p_atlas_coords, p_frame);
-			tex->draw_rect_region(p_canvas_item, dest_rect, source_rect, modulate, transpose, p_tile_set->is_uv_clipping());
+			if (RendererCanvasHelper::_active_tilemap) {
+				RendererCanvasHelper::tilemap_add_rect(p_canvas_item, dest_rect, tex->get_rid(), source_rect, modulate, transpose, p_tile_set->is_uv_clipping());
+			} else {
+				tex->draw_rect_region(p_canvas_item, dest_rect, source_rect, modulate, transpose, p_tile_set->is_uv_clipping());
+			}
 		} else if (atlas_source->get_tile_animation_frames_count(p_atlas_coords) == 1) {
 			Rect2i source_rect = atlas_source->get_runtime_tile_texture_region(p_atlas_coords, 0);
-			tex->draw_rect_region(p_canvas_item, dest_rect, source_rect, modulate, transpose, p_tile_set->is_uv_clipping());
+			if (RendererCanvasHelper::_active_tilemap) {
+				RendererCanvasHelper::tilemap_add_rect(p_canvas_item, dest_rect, tex->get_rid(), source_rect, modulate, transpose, p_tile_set->is_uv_clipping());
+			} else {
+				tex->draw_rect_region(p_canvas_item, dest_rect, source_rect, modulate, transpose, p_tile_set->is_uv_clipping());
+			}
 		} else {
 			real_t speed = atlas_source->get_tile_animation_speed(p_atlas_coords);
 			real_t animation_duration = atlas_source->get_tile_animation_total_duration(p_atlas_coords) / speed;

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1705,6 +1705,32 @@ void RendererCanvasCull::canvas_item_add_texture_rect_region(RID p_item, const R
 	}
 }
 
+void RendererCanvasCull::canvas_item_add_texture_multirect_region(RID p_item, const Vector<Rect2> &p_rects, RID p_texture, const Vector<Rect2> &p_src_rects, const Color &p_modulate, uint32_t p_canvas_rect_flags) {
+	ERR_FAIL_COND(p_rects.size() != p_src_rects.size());
+
+	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
+	ERR_FAIL_COND(!canvas_item);
+
+	Item::CommandMultiRect *mrect = canvas_item->alloc_command<Item::CommandMultiRect>();
+	ERR_FAIL_COND(!mrect);
+	mrect->modulate = p_modulate;
+	mrect->texture = p_texture;
+	mrect->flags = p_canvas_rect_flags;
+
+	mrect->rects = p_rects;
+	mrect->sources = p_src_rects;
+
+	int num_rects = mrect->rects.size();
+	Rect2 r;
+	if (num_rects) {
+		r = mrect->rects[0];
+		for (int n = 1; n < num_rects; n++) {
+			r = mrect->rects[n].merge(r);
+		}
+	}
+	mrect->full_rect = r;
+}
+
 void RendererCanvasCull::canvas_item_add_nine_patch(RID p_item, const Rect2 &p_rect, const Rect2 &p_source, RID p_texture, const Vector2 &p_topleft, const Vector2 &p_bottomright, RSE::NinePatchAxisMode p_x_axis_mode, RSE::NinePatchAxisMode p_y_axis_mode, bool p_draw_center, const Color &p_modulate) {
 	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
 	ERR_FAIL_NULL(canvas_item);

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -267,6 +267,7 @@ public:
 	void canvas_item_add_circle(RID p_item, const Point2 &p_pos, float p_radius, const Color &p_color, bool p_antialiased);
 	void canvas_item_add_texture_rect(RID p_item, const Rect2 &p_rect, RID p_texture, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false);
 	void canvas_item_add_texture_rect_region(RID p_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = false);
+	void canvas_item_add_texture_multirect_region(RID p_item, const Vector<Rect2> &p_rects, RID p_texture, const Vector<Rect2> &p_src_rects, const Color &p_modulate = Color(1, 1, 1), uint32_t p_canvas_rect_flags = 0);
 	void canvas_item_add_msdf_texture_rect_region(RID p_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), int p_outline_size = 0, float p_px_range = 1.0, float p_scale = 1.0);
 	void canvas_item_add_lcd_texture_rect_region(RID p_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1));
 	void canvas_item_add_nine_patch(RID p_item, const Rect2 &p_rect, const Rect2 &p_source, RID p_texture, const Vector2 &p_topleft, const Vector2 &p_bottomright, RSE::NinePatchAxisMode p_x_axis_mode = RSE::NINE_PATCH_STRETCH, RSE::NinePatchAxisMode p_y_axis_mode = RSE::NINE_PATCH_STRETCH, bool p_draw_center = true, const Color &p_modulate = Color(1, 1, 1));

--- a/servers/rendering/renderer_canvas_helper.cpp
+++ b/servers/rendering/renderer_canvas_helper.cpp
@@ -1,0 +1,297 @@
+/**************************************************************************/
+/*  renderer_canvas_helper.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "renderer_canvas_helper.h"
+
+#include "servers/rendering/renderer_canvas_render.h"
+#include "servers/rendering/rendering_server.h"
+
+LocalVector<MultiRect> RendererCanvasHelper::_tilemap_multirects;
+Mutex RendererCanvasHelper::_tilemap_mutex;
+
+bool RendererCanvasHelper::_multirect_enabled = true;
+bool RendererCanvasHelper::_active_tilemap = false;
+
+MultiRect::MultiRect() {
+	begin();
+}
+MultiRect::~MultiRect() {
+	end();
+}
+
+void MultiRect::begin() {
+	DEV_CHECK_ONCE(!rects.size());
+	rects.clear();
+	sources.clear();
+
+	state.flags = 0;
+	state_set = false;
+}
+
+void MultiRect::add_rect(RID p_canvas_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, bool p_clip_uv) {
+	bool new_common_data = true;
+
+	Rect2 rect = p_rect;
+	Rect2 source = p_src_rect;
+
+	// To make the rendering code as efficient as possible,
+	// a single MultiRect command should have identical flips and transpose etc.
+	// If these change, it flushes the previous multirect and starts a new one.
+	uint32_t flags = RendererCanvasRender::CANVAS_RECT_REGION;
+
+	if (p_rect.size.x < 0) {
+		flags |= RendererCanvasRender::CANVAS_RECT_FLIP_H;
+		rect.size.x = -rect.size.x;
+	}
+	if (source.size.x < 0) {
+		flags ^= RendererCanvasRender::CANVAS_RECT_FLIP_H;
+		source.size.x = -source.size.x;
+	}
+	if (p_rect.size.y < 0) {
+		flags |= RendererCanvasRender::CANVAS_RECT_FLIP_V;
+		rect.size.y = -rect.size.y;
+	}
+	if (source.size.y < 0) {
+		flags ^= RendererCanvasRender::CANVAS_RECT_FLIP_V;
+		source.size.y = -source.size.y;
+	}
+
+	if (p_transpose) {
+		flags |= RendererCanvasRender::CANVAS_RECT_TRANSPOSE;
+		SWAP(rect.size.x, rect.size.y);
+	}
+
+	if (p_clip_uv) {
+		flags |= RendererCanvasRender::CANVAS_RECT_CLIP_UV;
+	}
+
+	RendererCanvasHelper::State s;
+	s.item = p_canvas_item;
+	s.texture = p_texture;
+	s.modulate = p_modulate;
+	s.flags = flags;
+
+	if (!is_empty()) {
+		if ((state != s) ||
+				(rects.size() >= MAX_RECTS)) {
+			end();
+		} else {
+			new_common_data = false;
+		}
+	}
+
+	if (new_common_data) {
+		state = s;
+	}
+
+	rects.push_back(rect);
+	sources.push_back(source);
+}
+
+void MultiRect::set_msdf(int p_outline_size, float p_px_range, float p_scale) {
+	state.flags |= RendererCanvasRender::CANVAS_RECT_MSDF;
+	state.outline = (float)p_outline_size / p_scale / 4.0;
+	state.px_range = p_px_range;
+}
+
+void MultiRect::flag_lcd() {
+	state.flags |= RendererCanvasRender::CANVAS_RECT_LCD;
+}
+
+void MultiRect::begin(const RendererCanvasHelper::State &p_state) {
+	DEV_CHECK_ONCE(!rects.size());
+	rects.clear();
+	sources.clear();
+
+	state = p_state;
+	state_set = true;
+}
+
+uint32_t MultiRect::flags_from_rects(Rect2 &r_rect, Rect2 &r_source) {
+	uint32_t flags = 0;
+
+	if (r_rect.size.x < 0) {
+		flags |= RendererCanvasRender::CANVAS_RECT_FLIP_H;
+		r_rect.size.x = -r_rect.size.x;
+	}
+	if (r_rect.size.y < 0) {
+		flags |= RendererCanvasRender::CANVAS_RECT_FLIP_V;
+		r_rect.size.y = -r_rect.size.y;
+	}
+
+	if (r_source.size.x < 0) {
+		flags ^= RendererCanvasRender::CANVAS_RECT_FLIP_H;
+		r_source.size.x = -r_source.size.x;
+	}
+	if (r_source.size.y < 0) {
+		flags ^= RendererCanvasRender::CANVAS_RECT_FLIP_V;
+		r_source.size.y = -r_source.size.y;
+	}
+
+	return flags;
+}
+
+bool MultiRect::add_pre_flipped(const Rect2 &p_rect, const Rect2 &p_src_rect) {
+	if (rects.is_full()) {
+		return false;
+	}
+	//rects.append(p_rect);
+	//sources.append(p_src_rect);
+	rects.push_back(p_rect);
+	sources.push_back(p_src_rect);
+	return true;
+}
+
+bool MultiRect::add(const Rect2 &p_rect, const Rect2 &p_src_rect, bool p_commit_on_flip_change) {
+	if (rects.is_full()) {
+		return false;
+	}
+
+	Rect2 rect = p_rect;
+	Rect2 source = p_src_rect;
+
+	uint32_t flags = flags_from_rects(rect, source);
+
+	if (state_set) {
+		// if we are changing these flips, we can no longer continue the same multirect
+		if ((state.flags & (RendererCanvasRender::CANVAS_RECT_FLIP_H | RendererCanvasRender::CANVAS_RECT_FLIP_V)) != flags) {
+			// different state requires a new multirect
+			return false;
+		}
+
+	} else {
+		state.flags |= flags;
+		state_set = true;
+	}
+
+	//rects.append(p_rect);
+	//sources.append(p_src_rect);
+	rects.push_back(rect);
+	sources.push_back(source);
+	return true;
+}
+
+void MultiRect::end() {
+	if (!is_empty()) {
+		if (RendererCanvasHelper::_multirect_enabled) {
+			RenderingServer::get_singleton()->canvas_item_add_texture_multirect_region(state.item, Vector(rects.span()), state.texture, Vector(sources.span()), state.modulate, state.flags);
+
+		} else {
+			// legacy path
+			bool transpose = state.flags & RendererCanvasRender::CANVAS_RECT_TRANSPOSE;
+			bool clip_uv = state.flags & RendererCanvasRender::CANVAS_RECT_CLIP_UV;
+
+			for (uint32_t n = 0; n < rects.size(); n++) {
+				RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(state.item, rects[n], state.texture, sources[n], state.modulate, transpose, clip_uv);
+			}
+		}
+
+		rects.clear();
+		sources.clear();
+	}
+	state_set = false;
+}
+
+void RendererCanvasHelper::tilemap_begin() {
+	if (_multirect_enabled) {
+		_tilemap_mutex.lock();
+		_active_tilemap = true;
+	}
+}
+
+void RendererCanvasHelper::tilemap_add_rect(RID p_canvas_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, bool p_clip_uv) {
+	if (!_multirect_enabled) {
+		RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas_item, p_rect, p_texture, p_src_rect, p_modulate, p_transpose, p_clip_uv);
+		return;
+	}
+
+	Rect2 rect = p_rect;
+	Rect2 source = p_src_rect;
+
+	// To make the rendering code as efficient as possible,
+	// a single MultiRect command should have identical flips and transpose etc.
+	// If these change, it flushes the previous multirect and starts a new one.
+	uint32_t flags = MultiRect::flags_from_rects(rect, source);
+
+	flags |= RendererCanvasRender::CANVAS_RECT_REGION;
+
+	if (p_transpose) {
+		flags |= RendererCanvasRender::CANVAS_RECT_TRANSPOSE;
+		SWAP(rect.size.x, rect.size.y);
+	}
+
+	if (p_clip_uv) {
+		flags |= RendererCanvasRender::CANVAS_RECT_CLIP_UV;
+	}
+
+	State state;
+	state.item = p_canvas_item;
+	state.texture = p_texture;
+	state.modulate = p_modulate;
+	state.flags = flags;
+
+	// attempt to add to existing multirect
+	for (int n = _tilemap_multirects.size() - 1; n >= 0; n--) {
+		MultiRect &mr = _tilemap_multirects[n];
+
+		// matches state?
+		if (mr.state == state) {
+			// add .. this may fail if the multirect is full
+			if (mr.add_pre_flipped(rect, source)) {
+				return;
+			}
+		}
+
+		// disallow if we overlap a multirect
+		if (mr.overlaps(rect)) {
+			break;
+		}
+	}
+
+	// create new multirect
+	_tilemap_multirects.resize(_tilemap_multirects.size() + 1);
+	MultiRect &mr = _tilemap_multirects[_tilemap_multirects.size() - 1];
+	mr.begin(state);
+	mr.add_pre_flipped(rect, source);
+}
+
+void RendererCanvasHelper::tilemap_end() {
+	if (!_multirect_enabled) {
+		return;
+	}
+
+	for (uint32_t n = 0; n < _tilemap_multirects.size(); n++) {
+		_tilemap_multirects[n].end();
+	}
+
+	_active_tilemap = false;
+	_tilemap_multirects.clear();
+	_tilemap_mutex.unlock();
+}

--- a/servers/rendering/renderer_canvas_helper.h
+++ b/servers/rendering/renderer_canvas_helper.h
@@ -1,0 +1,120 @@
+/**************************************************************************/
+/*  renderer_canvas_helper.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/math/color.h"
+#include "core/math/rect2.h"
+#include "core/os/mutex.h"
+#include "core/templates/fixed_vector.h"
+#include "core/templates/local_vector.h"
+#include "core/templates/rid.h"
+#include "core/templates/vector.h"
+
+class MultiRect;
+
+class RendererCanvasHelper {
+public:
+	struct State {
+		RID item;
+		RID texture;
+		Color modulate;
+		uint32_t flags = 0;
+		float outline = 0;
+		float px_range = 1;
+
+		bool operator==(const State &p_state) const {
+			return ((item == p_state.item) &&
+					(texture == p_state.texture) &&
+					(modulate == p_state.modulate) &&
+					(flags == p_state.flags) &&
+					(outline == p_state.outline) &&
+					(px_range == p_state.px_range));
+		}
+		bool operator!=(const State &p_state) const { return !(*this == p_state); }
+	};
+
+private:
+	// There is a single mutex for tilemaps, only one quadrant can be adding
+	// at a time.
+	static LocalVector<MultiRect> _tilemap_multirects;
+	static Mutex _tilemap_mutex;
+
+public:
+	static void tilemap_begin();
+	static void tilemap_add_rect(RID p_canvas_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = false);
+	static void tilemap_end();
+
+	static bool _active_tilemap;
+	static bool _multirect_enabled;
+};
+
+class MultiRect {
+	friend class RendererCanvasHelper;
+
+public:
+	enum { MAX_RECTS = 2048 };
+
+private:
+	RendererCanvasHelper::State state;
+	bool state_set = false;
+	//Vector<Rect2> rects;
+	//Vector<Rect2> sources;
+	FixedVector<Rect2, 2048> rects;
+	FixedVector<Rect2, 2048> sources;
+
+	static uint32_t flags_from_rects(Rect2 &r_rect, Rect2 &r_source);
+	bool overlaps(const Rect2 &p_rect) const {
+		for (uint32_t n = 0; n < rects.size(); n++) {
+			if (rects[n].intersects(p_rect)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	bool add_pre_flipped(const Rect2 &p_rect, const Rect2 &p_src_rect);
+
+public:
+	// Simple API
+	void begin();
+	void add_rect(RID p_canvas_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = false);
+
+	void set_msdf(int p_outline_size, float p_px_range, float p_scale);
+	void flag_lcd();
+
+	// Efficient API
+	void begin(const RendererCanvasHelper::State &p_state);
+	bool add(const Rect2 &p_rect, const Rect2 &p_src_rect, bool p_commit_on_flip_change = true);
+	bool is_empty() const { return rects.is_empty(); }
+	void end();
+
+	MultiRect();
+	~MultiRect();
+};

--- a/servers/rendering/renderer_canvas_render.cpp
+++ b/servers/rendering/renderer_canvas_render.cpp
@@ -62,6 +62,10 @@ const Rect2 &RendererCanvasRender::Item::get_rect() const {
 				r = crect->rect;
 
 			} break;
+			case Item::Command::TYPE_MULTIRECT: {
+				const Item::CommandMultiRect *mrect = static_cast<const Item::CommandMultiRect *>(c);
+				r = mrect->full_rect;
+			} break;
 			case Item::Command::TYPE_NINEPATCH: {
 				const Item::CommandNinePatch *style = static_cast<const Item::CommandNinePatch *>(c);
 				r = style->rect;

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/fixed_vector.h"
 #include "servers/rendering/rendering_server_enums.h"
 #include "servers/rendering/rendering_server_types.h"
 
@@ -181,6 +182,7 @@ public:
 		struct Command {
 			enum Type {
 				TYPE_RECT,
+				TYPE_MULTIRECT,
 				TYPE_NINEPATCH,
 				TYPE_POLYGON,
 				TYPE_PRIMITIVE,
@@ -212,6 +214,25 @@ public:
 				outline = 0;
 				px_range = 1;
 				type = TYPE_RECT;
+			}
+		};
+
+		struct CommandMultiRect : public Command {
+			Color modulate;
+			uint16_t flags;
+			RID texture;
+			float outline;
+			float px_range;
+			Rect2 full_rect;
+
+			Vector<Rect2> rects;
+			Vector<Rect2> sources;
+
+			CommandMultiRect() {
+				flags = 0;
+				outline = 0;
+				px_range = 1;
+				type = TYPE_MULTIRECT;
 			}
 		};
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2532,6 +2532,137 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 				_add_to_batch(r_batch_broken, r_current_batch);
 			} break;
 
+			case Item::Command::TYPE_MULTIRECT: {
+				const Item::CommandMultiRect *mr = static_cast<const Item::CommandMultiRect *>(c);
+
+				if (r_current_batch->command_type != Item::Command::TYPE_MULTIRECT) {
+					r_current_batch = _new_batch(r_batch_broken);
+					r_current_batch->command_type = Item::Command::TYPE_MULTIRECT;
+					r_current_batch->command = c;
+					// default variant
+					r_current_batch->shader_variant = SHADER_VARIANT_QUAD;
+					r_current_batch->render_primitive = RD::RENDER_PRIMITIVE_TRIANGLES;
+					r_current_batch->flags = 0;
+				}
+
+				RSE::CanvasItemTextureRepeat rect_repeat = texture_repeat;
+				if (bool(mr->flags & CANVAS_RECT_TILE)) {
+					rect_repeat = RSE::CanvasItemTextureRepeat::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED;
+				}
+
+				Color modulated = mr->modulate * base_color;
+				if (use_linear_colors) {
+					modulated = modulated.srgb_to_linear();
+				}
+
+				bool has_blend = bool(mr->flags & CANVAS_RECT_LCD);
+				// Start a new batch if the blend mode has changed,
+				// or blend mode is enabled and the modulation has changed.
+				if (has_blend != r_current_batch->has_blend || (has_blend && modulated != r_current_batch->modulate)) {
+					r_current_batch = _new_batch(r_batch_broken);
+					r_current_batch->has_blend = has_blend;
+					r_current_batch->modulate = modulated;
+					r_current_batch->shader_variant = SHADER_VARIANT_QUAD;
+					r_current_batch->render_primitive = RD::RENDER_PRIMITIVE_TRIANGLES;
+				}
+
+				bool has_msdf = bool(mr->flags & CANVAS_RECT_MSDF);
+				TextureState tex_state(mr->texture, texture_filter, rect_repeat, has_msdf, use_linear_colors);
+				TextureInfo *tex_info = texture_info_map.getptr(tex_state);
+				if (!tex_info) {
+					tex_info = &texture_info_map.insert(tex_state, TextureInfo())->value;
+					_prepare_batch_texture_info(mr->texture, tex_state, tex_info);
+				}
+
+				if (has_msdf != r_current_batch->use_msdf) {
+					r_current_batch = _new_batch(r_batch_broken);
+					r_current_batch->use_msdf = has_msdf;
+					r_current_batch->msdf_pix_range = mr->px_range;
+					r_current_batch->msdf_outline = mr->outline;
+				}
+
+				bool has_lcd = bool(mr->flags & CANVAS_RECT_LCD);
+				if (has_lcd != r_current_batch->use_lcd) {
+					r_current_batch = _new_batch(r_batch_broken);
+					r_current_batch->use_lcd = has_lcd;
+				}
+
+				if (r_current_batch->tex_info != tex_info) {
+					r_current_batch = _new_batch(r_batch_broken);
+					r_current_batch->tex_info = tex_info;
+				}
+
+				int i = 0;
+				Rect2 src_rect;
+				Rect2 dst_rect;
+				// Actually stores a reference to a batches 'intermediary_instance_data' (PR #115757)
+				// Which is copied out to the primary data buffer in _add_to_batch
+				// So we can just reuse & overwrite the same reference for the whole loop
+				InstanceData *instance_data = new_instance_data(*r_current_batch, template_instance);
+
+				bool valid_tex = mr->texture.is_valid();
+				while (i < mr->rects.size()) {
+					if (valid_tex) {
+						src_rect = (mr->flags & CANVAS_RECT_REGION) ? Rect2(mr->sources[i].position * tex_info->texpixel_size, mr->sources[i].size * tex_info->texpixel_size) : Rect2(0, 0, 1, 1);
+						dst_rect = Rect2(mr->rects[i].position, mr->rects[i].size);
+
+						if (dst_rect.size.width < 0) {
+							dst_rect.position.x += dst_rect.size.width;
+							dst_rect.size.width *= -1;
+						}
+						if (dst_rect.size.height < 0) {
+							dst_rect.position.y += dst_rect.size.height;
+							dst_rect.size.height *= -1;
+						}
+
+						if (mr->flags & CANVAS_RECT_FLIP_H) {
+							src_rect.size.x *= -1;
+						}
+
+						if (mr->flags & CANVAS_RECT_FLIP_V) {
+							src_rect.size.y *= -1;
+						}
+
+						if (mr->flags & CANVAS_RECT_TRANSPOSE) {
+							instance_data->flags |= INSTANCE_FLAGS_TRANSPOSE_RECT;
+						}
+
+						if (mr->flags & CANVAS_RECT_CLIP_UV) {
+							instance_data->flags |= INSTANCE_FLAGS_CLIP_RECT_UV;
+						}
+					} else {
+						dst_rect = Rect2(mr->rects[i].position, mr->rects[i].size);
+
+						if (dst_rect.size.width < 0) {
+							dst_rect.position.x += dst_rect.size.width;
+							dst_rect.size.width *= -1;
+						}
+						if (dst_rect.size.height < 0) {
+							dst_rect.position.y += dst_rect.size.height;
+							dst_rect.size.height *= -1;
+						}
+
+						src_rect = Rect2(0, 0, 1, 1);
+					}
+					instance_data->modulation[0] = modulated.r;
+					instance_data->modulation[1] = modulated.g;
+					instance_data->modulation[2] = modulated.b;
+					instance_data->modulation[3] = modulated.a;
+
+					instance_data->src_rect[0] = src_rect.position.x;
+					instance_data->src_rect[1] = src_rect.position.y;
+					instance_data->src_rect[2] = src_rect.size.width;
+					instance_data->src_rect[3] = src_rect.size.height;
+
+					instance_data->dst_rect[0] = dst_rect.position.x;
+					instance_data->dst_rect[1] = dst_rect.position.y;
+					instance_data->dst_rect[2] = dst_rect.size.width;
+					instance_data->dst_rect[3] = dst_rect.size.height;
+					_add_to_batch(r_batch_broken, r_current_batch);
+					i += 1;
+				}
+			} break;
+
 			case Item::Command::TYPE_NINEPATCH: {
 				const Item::CommandNinePatch *np = static_cast<const Item::CommandNinePatch *>(c);
 
@@ -3058,6 +3189,7 @@ void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasSha
 
 	switch (p_batch->command_type) {
 		case Item::Command::TYPE_RECT:
+		case Item::Command::TYPE_MULTIRECT:
 		case Item::Command::TYPE_NINEPATCH: {
 			PushConstant push_constant = p_batch->push_constant();
 

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/image.h"
+#include "core/templates/fixed_vector.h"
 #include "core/templates/rid.h"
 #include "core/variant/typed_array.h"
 #include "core/variant/variant.h"
@@ -831,6 +832,7 @@ public:
 	virtual void canvas_item_add_circle(RID p_item, const Point2 &p_pos, float p_radius, const Color &p_color, bool p_antialiased = false) = 0;
 	virtual void canvas_item_add_texture_rect(RID p_item, const Rect2 &p_rect, RID p_texture, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) = 0;
 	virtual void canvas_item_add_texture_rect_region(RID p_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = false) = 0;
+	virtual void canvas_item_add_texture_multirect_region(RID p_item, const Vector<Rect2> &p_rects, RID p_texture, const Vector<Rect2> &p_src_rects, const Color &p_modulate = Color(1, 1, 1), uint32_t p_canvas_rect_flags = 0) = 0;
 	virtual void canvas_item_add_msdf_texture_rect_region(RID p_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), int p_outline_size = 0, float p_px_range = 1.0, float p_scale = 1.0) = 0;
 	virtual void canvas_item_add_lcd_texture_rect_region(RID p_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1)) = 0;
 	virtual void canvas_item_add_nine_patch(RID p_item, const Rect2 &p_rect, const Rect2 &p_source, RID p_texture, const Vector2 &p_topleft, const Vector2 &p_bottomright, RSE::NinePatchAxisMode p_x_axis_mode = RSE::NINE_PATCH_STRETCH, RSE::NinePatchAxisMode p_y_axis_mode = RSE::NINE_PATCH_STRETCH, bool p_draw_center = true, const Color &p_modulate = Color(1, 1, 1)) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -1037,6 +1037,7 @@ public:
 	FUNC5(canvas_item_add_circle, RID, const Point2 &, float, const Color &, bool)
 	FUNC6(canvas_item_add_texture_rect, RID, const Rect2 &, RID, bool, const Color &, bool)
 	FUNC7(canvas_item_add_texture_rect_region, RID, const Rect2 &, RID, const Rect2 &, const Color &, bool, bool)
+	FUNC6(canvas_item_add_texture_multirect_region, RID, const Vector<Rect2> &, RID, const Vector<Rect2> &, const Color &, uint32_t)
 	FUNC8(canvas_item_add_msdf_texture_rect_region, RID, const Rect2 &, RID, const Rect2 &, const Color &, int, float, float)
 	FUNC5(canvas_item_add_lcd_texture_rect_region, RID, const Rect2 &, RID, const Rect2 &, const Color &)
 	FUNC10(canvas_item_add_nine_patch, RID, const Rect2 &, const Rect2 &, RID, const Vector2 &, const Vector2 &, RSE::NinePatchAxisMode, RSE::NinePatchAxisMode, bool, const Color &)


### PR DESCRIPTION
Superseding: https://github.com/godotengine/godot/pull/70415
Porting: https://github.com/godotengine/godot/pull/68960 for Godot ~4.7

This is a port of the Multirect batching command for Godot 4.7. This is largely derived from @lawnjelly's implementation of this feature in both Godot 3.x and the draft he published in PR #70415 - I rebased the Draft onto 4.7 and finished implementing the MultiRect Command in both the Forward+ Renderer and the Compatibility renderer.

Repetitive Rect Drawing Commands (such as rendering large amounts of text) can still be taxing on the CPU as the Command Batcher re-processes some redundant information for every single Rect. Using a Multirect command can indicate to the Batcher that it should skip much of the redundant processing! 

### This implements:
* The Backend for MultiRect commands in both Forward+ and compatibility
* A Helper Class for preparing MultiRects, called RendererCanvasHelper, common to the whole Rendering Server
* Basic usage of MultiRects by Label Nodes.
* Basic usage of MultiRects by TileMapLayer Nodes.

### Basic Performance Measurements
Performing a brief test (on my particular computer) by having a label render 355,200 characters:
* Stable 4.6 -- Compatibility Renderer -- averages 11.3 CPU milliseconds per Frame
* MultiRect 4.7 -- Compatibility Render -- averages 3.6 CPU milliseconds per Frame
* Stable 4.6 -- Forward + Renderer -- averages 4.3 CPU milliseconds per Frame
* MultiRect 4.7 -- Forward+ Renderer --  averages 2.2 CPU milliseconds per Frame

TileMap test, render about 1.8 million Tiles on my computer.
* Stable 4.6 -- Compatibility -- Average 28 CPU milliseconds per frame
* Multirect 4.7 -- Compatibility -- Average 10 CPU milliseconds per frame
* Stable 4.6 -- Forward+ -- Average 10 CPU milliseconds per frame
* Multirect 4.7 -- Forward+ -- Average 5 CPU milliseconds per frame.


Using this project to test the performance (Taken & Modified from LawnJelly's original PR). 
[batch_test_text.zip](https://github.com/user-attachments/files/25699424/batch_test_text.zip)

Control.tscn has a Label with buttons to add 44k Characters of text to the label.
Tiles.tscn has a Tilemap that is roughly 1.2k x 1.2k tiles being rendered at 0.1 Scale (So all ~1.8 million tiles are attempted to render rather than being culled for being off screen).
Using the in-editor profiler for measurements.
