### PR TITLE
Fix `TabContainer` accessibility sub-element cleanup.

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -84,6 +84,7 @@ bool TabContainer::_property_get_revert(const StringName &p_name, Variant &r_pro
 
 void TabContainer::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_EXIT_TREE:
 		case NOTIFICATION_ACCESSIBILITY_INVALIDATE: {
 			tab_panels.clear();
 		} break;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/116534 (crash)
Fixes https://github.com/godotengine/godot/issues/115500

Note: `SplitContaner` errors also mentioned in the issue are fixed by https://github.com/godotengine/godot/pull/116601