### PR TITLE
`ShaderEditor`: Change custom minimum size to prevent overflow in editor at its minimum size

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -9086,6 +9086,7 @@ EditorNode::EditorNode() {
 	{
 		Dictionary offsets;
 		offsets["Audio"] = -450;
+		offsets["Shader Editor"] = -300;
 		default_layout->set_value(EDITOR_NODE_CONFIG_SECTION, "bottom_panel_offsets", offsets);
 	}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -9349,6 +9349,7 @@ EditorNode::EditorNode() {
 		Dictionary offsets;
 		offsets["Audio"] = -450;
 		offsets["Output"] = -270;
+		offsets["Shader Editor"] = -348;
 		default_layout->set_value(EDITOR_NODE_CONFIG_SECTION, "bottom_panel_offsets", offsets);
 	}
 

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -635,7 +635,7 @@ DocumentList::DocumentList(ScriptEditor *p_script_editor) {
 
 	item_list = memnew(ItemList);
 	item_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	item_list->set_custom_minimum_size(Size2(100, 60) * EDSCALE);
+	item_list->set_custom_minimum_size(Size2(60, 40) * EDSCALE);
 	item_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	item_list->set_theme_type_variation("ItemListSecondary");
 	item_list->set_allow_rmb_select(true);
@@ -853,7 +853,7 @@ DocumentOutline::DocumentOutline(ScriptEditor *p_script_editor) {
 	tree->set_allow_rmb_select(true);
 	tree->set_hide_root(true);
 	tree->set_hide_folding(true);
-	tree->set_custom_minimum_size(Size2(0, 60) * EDSCALE);
+	tree->set_custom_minimum_size(Size2(0, 40 * EDSCALE));
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 	tree->connect(SceneStringName(item_selected), callable_mp(this, &DocumentOutline::_tree_selected));
 	add_child(tree);

--- a/editor/shader/shader_editor_plugin.cpp
+++ b/editor/shader/shader_editor_plugin.cpp
@@ -868,7 +868,7 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	shader_dock->set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_shader_editor_bottom_panel", TTRC("Toggle Shader Editor Dock"), KeyModifierMask::ALT | Key::S));
 	shader_dock->set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	shader_dock->set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
-	shader_dock->set_custom_minimum_size(Size2(460, 300) * EDSCALE);
+	shader_dock->set_custom_minimum_size(Size2(150, 220) * EDSCALE);
 	EditorDockManager::get_singleton()->add_dock(shader_dock);
 
 	set_process_shortcut_input(true);
@@ -888,7 +888,7 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	shader_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	shader_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	shader_list->set_theme_type_variation("ItemListSecondary");
-	shader_list->set_custom_minimum_size(Size2(100, 60) * EDSCALE);
+	shader_list->set_custom_minimum_size(Size2(60 * EDSCALE, 0));
 	shader_list->connect(SceneStringName(item_selected), callable_mp(this, &ShaderEditorPlugin::_shader_selected).bind(true));
 	shader_list->connect("item_clicked", callable_mp(this, &ShaderEditorPlugin::_shader_list_clicked));
 	shader_list->set_allow_rmb_select(true);

--- a/editor/shader/shader_editor_plugin.cpp
+++ b/editor/shader/shader_editor_plugin.cpp
@@ -156,7 +156,6 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	shader_dock->set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_shader_editor_bottom_panel", TTRC("Toggle Shader Editor Dock"), KeyModifierMask::ALT | Key::S));
 	shader_dock->set_default_slot(EditorDock::DOCK_SLOT_BOTTOM);
 	shader_dock->set_available_layouts(EditorDock::DOCK_LAYOUT_HORIZONTAL | EditorDock::DOCK_LAYOUT_FLOATING);
-	shader_dock->set_custom_minimum_size(Size2(460, 300) * EDSCALE);
 	EditorDockManager::get_singleton()->add_dock(shader_dock);
 
 	set_process_shortcut_input(true);

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
@@ -6613,7 +6613,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	graph = memnew(GraphEdit);
 	graph->set_v_size_flags(SIZE_EXPAND_FILL);
 	graph->set_h_size_flags(SIZE_EXPAND_FILL);
-	graph->set_custom_minimum_size(Size2(200 * EDSCALE, 0));
+	graph->set_custom_minimum_size(Size2(260, 180) * EDSCALE);
 	graph->set_grid_pattern(GraphEdit::GridPattern::GRID_PATTERN_DOTS);
 	int grid_pattern = EDITOR_GET("editors/visual_editors/grid_pattern");
 	graph->set_grid_pattern((GraphEdit::GridPattern)grid_pattern);


### PR DESCRIPTION
- Addresses https://github.com/godotengine/godot/issues/26835, but only for `ShaderEditor`.
- Extracted from https://github.com/godotengine/godot/pull/102301
- Needs https://github.com/godotengine/godot/pull/116412 to be fully functional, but works ok as-is.

---

| Before | After |
| --- | --- |
| <img width="1077" height="631" alt="image" src="https://github.com/user-attachments/assets/d37a21a5-9a94-4197-8928-bd580622b2bf" /> | <img width="1077" height="631" alt="image" src="https://github.com/user-attachments/assets/5774f893-9919-40ac-8c8d-0b62e5c1024d" /> |

