### PR TITLE
Fix type deduction while exporting Variant variables

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4725,7 +4725,7 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 	DataType export_type = variable->get_datatype();
 
 	// Use initializer type if specified type is `Variant`.
-	if (export_type.is_variant() && variable->initializer != nullptr && variable->initializer->datatype.is_set()) {
+	if (export_type.is_variant() && !export_type.is_hard_type() && variable->initializer != nullptr && variable->initializer->datatype.is_set()) {
 		export_type = variable->initializer->get_datatype();
 		export_type.type_source = DataType::INFERRED;
 	}

--- a/modules/gdscript/tests/scripts/parser/features/export_enum.gd
+++ b/modules/gdscript/tests/scripts/parser/features/export_enum.gd
@@ -24,11 +24,6 @@ var temp_packed_string_array: PackedStringArray
 @export_enum("Red", "Green", "Blue") var test_hard_array_int: Array[int]
 @export_enum("Red", "Green", "Blue") var test_hard_array_string: Array[String]
 
-@export_enum("Red", "Green", "Blue") var test_variant_array_int: Variant = temp_array_int
-@export_enum("Red", "Green", "Blue") var test_variant_packed_int32_array: Variant = temp_packed_int32_array
-@export_enum("Red", "Green", "Blue") var test_variant_array_string: Variant = temp_array_string
-@export_enum("Red", "Green", "Blue") var test_variant_packed_string_array: Variant = temp_packed_string_array
-
 func test():
 	for property in get_property_list():
 		if str(property.name).begins_with("test_"):

--- a/modules/gdscript/tests/scripts/parser/features/export_enum.out
+++ b/modules/gdscript/tests/scripts/parser/features/export_enum.out
@@ -31,11 +31,3 @@ var test_hard_array_int: Array = Array[int]([])
   hint=TYPE_STRING hint_string="<int>/<ENUM>:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE class_name=&""
 var test_hard_array_string: Array = Array[String]([])
   hint=TYPE_STRING hint_string="<String>/<ENUM>:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE class_name=&""
-var test_variant_array_int: Array = Array[int]([])
-  hint=TYPE_STRING hint_string="<int>/<ENUM>:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE class_name=&""
-var test_variant_packed_int32_array: PackedInt32Array = PackedInt32Array()
-  hint=TYPE_STRING hint_string="<int>/<ENUM>:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE class_name=&""
-var test_variant_array_string: Array = Array[String]([])
-  hint=TYPE_STRING hint_string="<String>/<ENUM>:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE class_name=&""
-var test_variant_packed_string_array: PackedStringArray = PackedStringArray()
-  hint=TYPE_STRING hint_string="<String>/<ENUM>:Red,Green,Blue" usage=DEFAULT|SCRIPT_VARIABLE class_name=&""


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/110205.

Now `@export var test: Variant = 33` will be exported as a Variant type in editor.

Expected behaviour:

```
# exports as Variant type. Allows changing the type in the inspector <- unchanged
@export var m_with_type_without_default: Variant

# exports as Variant type. Allows changing the type in the inspector <-- new change
# previously it was exported as String only even when we explicitly state the type.
@export var m_with_type_with_default: Variant = 'm_with_type_with_default'

# exports as String. <- unchanged
@export var m_without_type_with_default = 'm_without_type_with_default'

# this one could work but raises a parser error
# @export var m_without_type_without_default
```

previously:
<img width="1644" height="230" alt="image" src="https://github.com/user-attachments/assets/56ed3f53-563a-4168-b9c1-0b4a92c2e87f" />


new change:
<img width="1919" height="255" alt="image" src="https://github.com/user-attachments/assets/5c41dc95-506f-453e-b3ab-46389826bd75" />
