### PR TITLE
Fix missing name refresh on bindings when changing the OpenXR action map.

### DIFF
--- a/modules/openxr/editor/openxr_action_editor.cpp
+++ b/modules/openxr/editor/openxr_action_editor.cpp
@@ -41,6 +41,7 @@ void OpenXRActionEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_do_set_action_type", "type"), &OpenXRActionEditor::_do_set_action_type);
 
 	ADD_SIGNAL(MethodInfo("remove", PropertyInfo(Variant::OBJECT, "action_editor")));
+	ADD_SIGNAL(MethodInfo("action_renamed", PropertyInfo(Variant::OBJECT, "action_editor")));
 }
 
 void OpenXRActionEditor::_theme_changed() {
@@ -72,8 +73,10 @@ void OpenXRActionEditor::_on_action_name_changed(const String &p_new_text) {
 			action->set_localized_name(p_new_text);
 			action_localized_name->set_text(p_new_text);
 		}
+
 		action->set_name(p_new_text);
 		action->set_edited(true);
+		action_name_dirty = true;
 	}
 }
 
@@ -127,6 +130,13 @@ void OpenXRActionEditor::_on_remove_action() {
 	emit_signal("remove", this);
 }
 
+void OpenXRActionEditor::_on_focus_exit() {
+	if (action_name_dirty) {
+		emit_signal("action_renamed", this);
+		action_name_dirty = false;
+	}
+}
+
 OpenXRActionEditor::OpenXRActionEditor(const Ref<OpenXRAction> &p_action) {
 	undo_redo = EditorUndoRedoManager::get_singleton();
 	action = p_action;
@@ -138,6 +148,7 @@ OpenXRActionEditor::OpenXRActionEditor(const Ref<OpenXRAction> &p_action) {
 	action_name->set_tooltip_text(TTR("Internal name of the action. Some XR runtimes don't allow spaces or special characters."));
 	action_name->set_custom_minimum_size(Size2(150.0 * EDSCALE, 0.0));
 	action_name->connect(SceneStringName(text_changed), callable_mp(this, &OpenXRActionEditor::_on_action_name_changed));
+	action_name->connect(SceneStringName(focus_exited), callable_mp(this, &OpenXRActionEditor::_on_focus_exit));
 	action_name->set_accessibility_name(TTRC("Action Name"));
 	add_child(action_name);
 

--- a/modules/openxr/editor/openxr_action_editor.h
+++ b/modules/openxr/editor/openxr_action_editor.h
@@ -44,6 +44,7 @@ class OpenXRActionEditor : public HBoxContainer {
 private:
 	EditorUndoRedoManager *undo_redo;
 	Ref<OpenXRAction> action;
+	bool action_name_dirty = false;
 
 	LineEdit *action_name = nullptr;
 	LineEdit *action_localized_name = nullptr;
@@ -55,6 +56,7 @@ private:
 	void _on_action_localized_name_changed(const String &p_new_text);
 	void _on_item_selected(int p_idx);
 	void _on_remove_action();
+	void _on_focus_exit();
 
 protected:
 	static void _bind_methods();

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -88,6 +88,7 @@ OpenXRActionSetEditor *OpenXRActionMapEditor::_add_action_set_editor(const Ref<O
 	OpenXRActionSetEditor *action_set_editor = memnew(OpenXRActionSetEditor(action_map, p_action_set));
 	action_set_editor->connect("remove", callable_mp(this, &OpenXRActionMapEditor::_on_remove_action_set));
 	action_set_editor->connect("action_removed", callable_mp(this, &OpenXRActionMapEditor::_on_action_removed));
+	action_set_editor->connect("action_renamed", callable_mp(this, &OpenXRActionMapEditor::_on_action_renamed));
 
 	actionsets_vb->add_child(action_set_editor);
 
@@ -250,6 +251,15 @@ void OpenXRActionMapEditor::_on_action_removed(const Ref<OpenXRAction> &p_action
 	}
 }
 
+void OpenXRActionMapEditor::_on_action_renamed(const Ref<OpenXRAction> &p_action) {
+	for (int i = 0; i < tabs->get_tab_count(); i++) {
+		OpenXRInteractionProfileEditorBase *interaction_profile_editor = Object::cast_to<OpenXRInteractionProfileEditorBase>(tabs->get_tab_control(i));
+		if (interaction_profile_editor) {
+			interaction_profile_editor->_set_dirty();
+		}
+	}
+}
+
 void OpenXRActionMapEditor::_on_add_interaction_profile() {
 	ERR_FAIL_COND(action_map.is_null());
 
@@ -342,6 +352,13 @@ void OpenXRActionMapEditor::_on_reset_to_default_layout() {
 }
 
 void OpenXRActionMapEditor::_on_tabs_tab_changed(int p_tab) {
+	OpenXRInteractionProfileEditorBase *interaction_profile_editor = Object::cast_to<OpenXRInteractionProfileEditorBase>(tabs->get_tab_control(p_tab));
+
+	if (!interaction_profile_editor) {
+		return;
+	}
+
+	interaction_profile_editor->_update_interaction_profile();
 }
 
 void OpenXRActionMapEditor::_on_tab_button_pressed(int p_tab) {

--- a/modules/openxr/editor/openxr_action_map_editor.h
+++ b/modules/openxr/editor/openxr_action_map_editor.h
@@ -80,6 +80,7 @@ private:
 	void _set_focus_on_action_set(OpenXRActionSetEditor *p_action_set_editor);
 	void _on_remove_action_set(Object *p_action_set_editor);
 	void _on_action_removed(const Ref<OpenXRAction> &p_action);
+	void _on_action_renamed(const Ref<OpenXRAction> &p_action);
 
 	void _on_add_interaction_profile();
 	void _on_interaction_profile_selected(const String &p_path);

--- a/modules/openxr/editor/openxr_action_set_editor.cpp
+++ b/modules/openxr/editor/openxr_action_set_editor.cpp
@@ -51,6 +51,7 @@ void OpenXRActionSetEditor::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("remove", PropertyInfo(Variant::OBJECT, "action_set_editor")));
 	ADD_SIGNAL(MethodInfo("action_removed", PropertyInfo(Variant::OBJECT, "action")));
+	ADD_SIGNAL(MethodInfo("action_renamed", PropertyInfo(Variant::OBJECT, "action")));
 }
 
 void OpenXRActionSetEditor::_set_fold_icon() {
@@ -79,6 +80,7 @@ void OpenXRActionSetEditor::_notification(int p_what) {
 OpenXRActionEditor *OpenXRActionSetEditor::_add_action_editor(const Ref<OpenXRAction> &p_action) {
 	OpenXRActionEditor *action_editor = memnew(OpenXRActionEditor(p_action));
 	action_editor->connect("remove", callable_mp(this, &OpenXRActionSetEditor::_on_remove_action));
+	action_editor->connect("action_renamed", callable_mp(this, &OpenXRActionSetEditor::_on_rename_action));
 	actions_vb->add_child(action_editor);
 
 	return action_editor;
@@ -107,6 +109,8 @@ void OpenXRActionSetEditor::_on_action_set_name_changed(const String &p_new_text
 			action_set->set_localized_name(p_new_text);
 			action_set_localized_name->set_text(p_new_text);
 		}
+
+		emit_signal("action_renamed", this);
 		action_set->set_name(p_new_text);
 		action_set->set_edited(true);
 	}
@@ -115,6 +119,7 @@ void OpenXRActionSetEditor::_on_action_set_name_changed(const String &p_new_text
 void OpenXRActionSetEditor::_do_set_name(const String &p_new_text) {
 	action_set->set_name(p_new_text);
 	action_set_name->set_text(p_new_text);
+	emit_signal("action_renamed", this);
 }
 
 void OpenXRActionSetEditor::_on_action_set_localized_name_changed(const String &p_new_text) {
@@ -191,6 +196,16 @@ void OpenXRActionSetEditor::_on_remove_action(Object *p_action_editor) {
 	undo_redo->commit_action(true);
 
 	action_set->set_edited(true);
+}
+
+void OpenXRActionSetEditor::_on_rename_action(Object *p_action_editor) {
+	OpenXRActionEditor *action_editor = Object::cast_to<OpenXRActionEditor>(p_action_editor);
+	ERR_FAIL_NULL(action_editor);
+	ERR_FAIL_COND(action_editor->get_parent() != actions_vb);
+	Ref<OpenXRAction> action = action_editor->get_action();
+	ERR_FAIL_COND(action.is_null());
+
+	emit_signal("action_renamed", action);
 }
 
 void OpenXRActionSetEditor::_do_add_action_editor(OpenXRActionEditor *p_action_editor) {

--- a/modules/openxr/editor/openxr_action_set_editor.h
+++ b/modules/openxr/editor/openxr_action_set_editor.h
@@ -74,6 +74,7 @@ private:
 	void _on_remove_action_set();
 
 	void _on_remove_action(Object *p_action_editor);
+	void _on_rename_action(Object *p_action_editor);
 
 protected:
 	static void _bind_methods();

--- a/modules/openxr/editor/openxr_interaction_profile_editor.cpp
+++ b/modules/openxr/editor/openxr_interaction_profile_editor.cpp
@@ -65,6 +65,10 @@ void OpenXRInteractionProfileEditorBase::_do_update_interaction_profile() {
 	}
 }
 
+void OpenXRInteractionProfileEditorBase::_set_dirty() {
+	is_dirty = true;
+}
+
 void OpenXRInteractionProfileEditorBase::_add_binding(const String &p_action, const String &p_path) {
 	ERR_FAIL_COND(action_map.is_null());
 	ERR_FAIL_COND(interaction_profile.is_null());

--- a/modules/openxr/editor/openxr_interaction_profile_editor.h
+++ b/modules/openxr/editor/openxr_interaction_profile_editor.h
@@ -73,6 +73,7 @@ public:
 	virtual void _theme_changed();
 
 	void _do_update_interaction_profile();
+	void _set_dirty();
 	void _add_binding(const String &p_action, const String &p_path);
 	void _remove_binding(const String &p_action, const String &p_path);
 


### PR DESCRIPTION
Fixes #116477.

Basically, whenever an action was renamed in the action set, the profile wasn't aware of the change, I had to connect a few signals but it should work properly now.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
