### PR TITLE
Add smooth to the changing of properties values in visual shader

### DIFF
--- a/doc/classes/EditorSpinSlider.xml
+++ b/doc/classes/EditorSpinSlider.xml
@@ -13,6 +13,9 @@
 		<member name="control_state" type="int" setter="set_control_state" getter="get_control_state" enum="EditorSpinSlider.ControlState" default="0">
 			The state in which the control used to manipulate the value will be.
 		</member>
+		<member name="deferred_drag_mode" type="bool" setter="set_deferred_drag_mode_enabled" getter="is_deferred_drag_mode_enabled" default="false">
+			If [code]true[/code], changing via dragging is applied only at the end of the input (for example, when the user releases a mouse button).
+		</member>
 		<member name="editing_integer" type="bool" setter="set_editing_integer" getter="is_editing_integer" default="false">
 			If [code]true[/code], the [EditorSpinSlider] is considered to be editing an integer value. If [code]false[/code], the [EditorSpinSlider] is considered to be editing a floating-point value. This is used to determine whether a slider should be drawn by default. The slider is only drawn for floats; integers use up-down arrows similar to [SpinBox] instead, unless [member control_state] is set to [constant CONTROL_STATE_PREFER_SLIDER]. It will also use [member EditorSettings.interface/inspector/integer_drag_speed] instead of [member EditorSettings.interface/inspector/float_drag_speed] if the slider is available.
 		</member>

--- a/editor/gui/editor_spin_slider.h
+++ b/editor/gui/editor_spin_slider.h
@@ -66,6 +66,7 @@ class EditorSpinSlider : public Range {
 	uint64_t value_input_closed_frame = 0;
 	bool value_input_dirty = false;
 	bool value_input_focus_visible = false;
+	bool deferred_drag_mode = false;
 
 public:
 	enum ControlState {
@@ -137,6 +138,8 @@ public:
 	bool is_flat() const;
 
 	bool is_grabbing() const;
+	void set_deferred_drag_mode_enabled(bool p_enabled = true);
+	bool is_deferred_drag_mode_enabled() const;
 
 	void setup_and_show() { _focus_entered(); }
 	LineEdit *get_line_edit();

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1251,6 +1251,7 @@ bool EditorProperty::is_cache_valid() const {
 	}
 	return true;
 }
+
 void EditorProperty::update_cache() {
 	cache.clear();
 	if (object && property != StringName()) {
@@ -1261,6 +1262,15 @@ void EditorProperty::update_cache() {
 		}
 	}
 }
+
+void EditorProperty::set_deferred_drag_mode_enabled(bool p_enabled) {
+	deferred_drag_mode = p_enabled;
+}
+
+bool EditorProperty::is_deferred_drag_mode_enabled() const {
+	return deferred_drag_mode;
+}
+
 Variant EditorProperty::get_drag_data(const Point2 &p_point) {
 	if (property == StringName()) {
 		return Variant();

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -195,6 +195,7 @@ private:
 	bool selectable = true;
 	bool selected = false;
 	int selected_focusable;
+	bool deferred_drag_mode = false;
 
 	float split_ratio;
 
@@ -307,6 +308,9 @@ public:
 	virtual Variant get_drag_data(const Point2 &p_point) override;
 	virtual void update_cache();
 	virtual bool is_cache_valid() const;
+
+	virtual void set_deferred_drag_mode_enabled(bool p_enabled = true);
+	bool is_deferred_drag_mode_enabled() const;
 
 	void set_selectable(bool p_selectable);
 	bool is_selectable() const;

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1561,6 +1561,12 @@ void EditorPropertyInteger::_value_changed(int64_t val) {
 	emit_changed(get_edited_property(), val);
 }
 
+void EditorPropertyInteger::set_deferred_drag_mode_enabled(bool p_enabled) {
+	EditorProperty::set_deferred_drag_mode_enabled(p_enabled);
+
+	spin->set_deferred_drag_mode_enabled(p_enabled);
+}
+
 void EditorPropertyInteger::update_property() {
 	int64_t val = get_edited_property_display_value();
 	spin->set_value_no_signal(val);
@@ -1696,6 +1702,12 @@ void EditorPropertyFloat::_value_changed(double val) {
 		val = Math::deg_to_rad(val);
 	}
 	emit_changed(get_edited_property(), val);
+}
+
+void EditorPropertyFloat::set_deferred_drag_mode_enabled(bool p_enabled) {
+	EditorProperty::set_deferred_drag_mode_enabled(p_enabled);
+
+	spin->set_deferred_drag_mode_enabled(p_enabled);
 }
 
 void EditorPropertyFloat::update_property() {

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -404,6 +404,7 @@ protected:
 	virtual void _set_read_only(bool p_read_only) override;
 
 public:
+	virtual void set_deferred_drag_mode_enabled(bool p_enabled = true) override;
 	virtual void update_property() override;
 	void setup(const EditorPropertyRangeHint &p_range_hint);
 	EditorPropertyInteger();
@@ -455,6 +456,7 @@ protected:
 	virtual void _set_read_only(bool p_read_only) override;
 
 public:
+	virtual void set_deferred_drag_mode_enabled(bool p_enabled = true) override;
 	virtual void update_property() override;
 	void setup(const EditorPropertyRangeHint &p_range_hint);
 	EditorPropertyFloat();

--- a/editor/inspector/editor_properties_vector.cpp
+++ b/editor/inspector/editor_properties_vector.cpp
@@ -239,6 +239,14 @@ EditorPropertyVectorN::EditorPropertyVectorN(Variant::Type p_type, bool p_force_
 	}
 }
 
+void EditorPropertyVectorN::set_deferred_drag_mode_enabled(bool p_enabled) {
+	EditorProperty::set_deferred_drag_mode_enabled(p_enabled);
+
+	for (int i = 0; i < component_count; i++) {
+		spin_sliders[i]->set_deferred_drag_mode_enabled(p_enabled);
+	}
+}
+
 EditorPropertyVector2::EditorPropertyVector2(bool p_force_wide) :
 		EditorPropertyVectorN(Variant::VECTOR2, p_force_wide, EDITOR_GET("interface/inspector/horizontal_vector2_editing")) {}
 

--- a/editor/inspector/editor_properties_vector.h
+++ b/editor/inspector/editor_properties_vector.h
@@ -59,6 +59,7 @@ protected:
 	void _notification(int p_what);
 
 public:
+	virtual void set_deferred_drag_mode_enabled(bool p_enabled = true) override;
 	virtual void update_property() override;
 	void setup(const EditorPropertyRangeHint &p_range_hint, bool p_link = false, bool p_is_int = false);
 	EditorPropertyVectorN(Variant::Type p_type, bool p_force_wide, bool p_horizontal);

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -3405,6 +3405,7 @@ void VisualShaderEditor::_edit_port_default_input(Object *p_button, int p_node, 
 	// TODO: Define these properties with actual PropertyInfo and feed it to the property editor widget.
 	property_editor = EditorInspector::instantiate_property_editor(edited_property_holder.ptr(), value.get_type(), "edited_property", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE, true);
 	ERR_FAIL_NULL_MSG(property_editor, "Failed to create property editor for type: " + Variant::get_type_name(value.get_type()));
+	property_editor->set_deferred_drag_mode_enabled();
 
 	// Determine the best size for the popup based on the property type.
 	// This is done here, since the property editors are also used in the inspector where they have different layout requirements, so we can't just change their default minimum size.
@@ -8237,6 +8238,7 @@ Control *VisualShaderNodePluginDefault::create_editor(const Ref<Resource> &p_par
 		if (!prop) {
 			return nullptr;
 		}
+		prop->set_deferred_drag_mode_enabled();
 
 		if (Object::cast_to<EditorPropertyResource>(prop)) {
 			Object::cast_to<EditorPropertyResource>(prop)->set_use_sub_inspector(false);


### PR DESCRIPTION
This is QoL enhancement for visual shaders - I know that changing values in default ports and editor properties via dragging are not smooth and may frustrate users:

![test1](https://github.com/user-attachments/assets/c4a156bf-fbac-4faa-97d0-05d17c0b518f)

This is because every single change to the input immediately forces `property_change` emitting and thus a code generation (which is slow).
After this change it will change it smoothly, and apply to the shader code after user released a mouse.

![test2](https://github.com/user-attachments/assets/b2cff569-1d7a-4036-bf27-41876f1a15bb)

I've changed it for Vectors, Float and Int properties for now.