### PR TITLE
Add enter and escape shortcuts in input map editor

### DIFF
--- a/editor/settings/event_listener_line_edit.cpp
+++ b/editor/settings/event_listener_line_edit.cpp
@@ -190,7 +190,7 @@ void EventListenerLineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	accept_event();
-	if (!event_to_check->is_pressed() || event_to_check->is_echo() || event_to_check->is_match(event) || !_is_event_allowed(event_to_check)) {
+	if (event_to_check.is_null() || !event_to_check->is_pressed() || event_to_check->is_echo() || event_to_check->is_match(event) || !_is_event_allowed(event_to_check)) {
 		return;
 	}
 

--- a/editor/settings/input_event_configuration_dialog.cpp
+++ b/editor/settings/input_event_configuration_dialog.cpp
@@ -44,8 +44,22 @@
 
 void InputEventConfigurationDialog::_set_event(const Ref<InputEvent> &p_event, const Ref<InputEvent> &p_original_event, bool p_update_input_list_selection) {
 	if (p_event.is_valid()) {
-		event = p_event;
-		original_event = p_original_event;
+		// If there is already a binding set, let enter or escape confirm/cancel the popup.
+		if (event.is_valid()) {
+			Ref<InputEventKey> current_key = p_event;
+			// Without this is_visible() check, the gui would not open if the already bound
+			// keybind was escape.
+			if (is_visible()) {
+				if (current_key->get_physical_keycode() == Key::ENTER) {
+					_ok_pressed();
+					return;
+				}
+				if (current_key->get_physical_keycode() == Key::ESCAPE) {
+					_cancel_pressed();
+					return;
+				}
+			}
+		}
 
 		// If the event is changed to something which is not the same as the listener,
 		// clear out the event from the listener text box to avoid confusion.
@@ -53,7 +67,8 @@ void InputEventConfigurationDialog::_set_event(const Ref<InputEvent> &p_event, c
 		if (listener_event.is_valid() && !listener_event->is_match(p_event)) {
 			event_listener->clear_event();
 		}
-
+		event = p_event;
+		original_event = p_original_event;
 		// Update Label
 		event_as_text->set_text(EventListenerLineEdit::get_event_text(event, true));
 


### PR DESCRIPTION
Without this PR, it is not possible to set keybinds in the input map editor without using the mouse.

https://github.com/user-attachments/assets/dc868287-0954-48fc-8895-717e3f0754f3

Current features (shown in video):
- If a key has already been set for this listening event (either, the "pencil" icon was pressed, or the dialogue was opened and a key like "a" has been pressed), then:
    -  If the user presses enter, the equivalent of pressing the "ok" button is done (confirming the key)
    -  If the user presses escape, the equivalent of pressing the "cancel" button is done (canceling the change of the key)
- When pressing the "+" icon to add a keybind, if nothing has been pressed yet, and enter is pressed, the current bind is set to Enter. Same for escape

Incorporates the fix from this PR https://github.com/godotengine/godot/pull/116200, which addresses this bug https://github.com/godotengine/godot/issues/116181

This PR addresses this proposal (by me) https://github.com/godotengine/godot-proposals/issues/14299