### PR TITLE
Fix Verbose mode from being enabled after quitting to the Project Manager

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6755,6 +6755,11 @@ void EditorNode::_restart_editor(bool p_goto_project_manager) {
 			args.push_back("--path");
 			args.push_back(exec_dir);
 		}
+
+		List<String>::Element *vbf = args.find("--verbose");
+		if (vbf) {
+			args.erase(vbf);
+		}
 	} else {
 		args.push_back("--path");
 		args.push_back(ProjectSettings::get_singleton()->get_resource_path());


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/116590

Adds a check just prior to restarting the editor that removes the `--verbose` flag if it was passed to the editor. The flag is only removed when quitting to the project list and not when restarting the editor.