### PR TITLE
Fix `SplitContainerDragger` dragging with enabled screen reader, allow resizing with keyboard shortcuts.

### DIFF
--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -39,8 +39,21 @@ void SplitContainerDragger::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
 	SplitContainer *sc = Object::cast_to<SplitContainer>(get_parent());
+	ERR_FAIL_NULL(sc);
 
 	if (sc->collapsed || sc->valid_children.size() < 2u || !sc->dragging_enabled) {
+		return;
+	}
+
+	if ((sc->vertical && p_event->is_action_pressed("ui_up", true)) || (!sc->vertical && !is_layout_rtl() && p_event->is_action_pressed("ui_left", true)) || (!sc->vertical && is_layout_rtl() && p_event->is_action_pressed("ui_right", true))) {
+		sc->set_split_offset(sc->get_split_offset(dragger_index) - (sc->vertical ? sc->get_size().height : sc->get_size().width) * 0.1, dragger_index);
+		sc->clamp_split_offset(dragger_index);
+		accept_event();
+		return;
+	} else if ((sc->vertical && p_event->is_action_pressed("ui_down", true)) || (!sc->vertical && !is_layout_rtl() && p_event->is_action_pressed("ui_right", true)) || (!sc->vertical && is_layout_rtl() && p_event->is_action_pressed("ui_left", true))) {
+		sc->set_split_offset(sc->get_split_offset(dragger_index) + (sc->vertical ? sc->get_size().height : sc->get_size().width) * 0.1, dragger_index);
+		sc->clamp_split_offset(dragger_index);
+		accept_event();
 		return;
 	}
 
@@ -64,6 +77,7 @@ void SplitContainerDragger::gui_input(const Ref<InputEvent> &p_event) {
 				queue_redraw();
 				sc->emit_signal(SNAME("drag_ended"));
 			}
+			accept_event();
 		}
 	}
 
@@ -102,7 +116,7 @@ void SplitContainerDragger::_accessibility_action_inc(const Variant &p_data) {
 	if (sc->collapsed || sc->valid_children.size() < 2u || !sc->dragging_enabled) {
 		return;
 	}
-	sc->set_split_offset(sc->get_split_offset(dragger_index) - 10, dragger_index);
+	sc->set_split_offset(sc->get_split_offset(dragger_index) - (sc->vertical ? sc->get_size().height : sc->get_size().width) * 0.1, dragger_index);
 	sc->clamp_split_offset(dragger_index);
 }
 
@@ -112,7 +126,7 @@ void SplitContainerDragger::_accessibility_action_dec(const Variant &p_data) {
 	if (sc->collapsed || sc->valid_children.size() < 2u || !sc->dragging_enabled) {
 		return;
 	}
-	sc->set_split_offset(sc->get_split_offset(dragger_index) + 10, dragger_index);
+	sc->set_split_offset(sc->get_split_offset(dragger_index) + (sc->vertical ? sc->get_size().height : sc->get_size().width) * 0.1, dragger_index);
 	sc->clamp_split_offset(dragger_index);
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/116535