### PR TITLE
Fix 2D editor redrawing on modifier echo events

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -515,7 +515,7 @@ void CanvasItemEditor::shortcut_input(const Ref<InputEvent> &p_ev) {
 	}
 
 	if (k.is_valid()) {
-		if (k->get_keycode() == Key::CTRL || k->get_keycode() == Key::ALT || k->get_keycode() == Key::SHIFT) {
+		if (!k->is_echo() && (k->get_keycode() == Key::CTRL || k->get_keycode() == Key::ALT || k->get_keycode() == Key::SHIFT)) {
 			viewport->queue_redraw();
 		}
 


### PR DESCRIPTION
2D editor redraws on every modifier key press/release. No idea what's the reason for that exactly, but what's worse is that it was redrawing on echo events too. It's especially relevant in tile editor, where modifiers are used to switch drawing mode. The constant redraws caused scatter flickering (you can see it [here](https://github.com/godotengine/godot-proposals/issues/14292#issuecomment-3941431251)).