### PR TITLE
iOS: Propagate VC UI preferences to SwiftUI hosting controller

### DIFF
--- a/drivers/apple_embedded/godot_view_controller.mm
+++ b/drivers/apple_embedded/godot_view_controller.mm
@@ -42,6 +42,7 @@
 
 #import <AVFoundation/AVFoundation.h>
 #import <GameController/GameController.h>
+#import <objc/runtime.h>
 
 @interface GDTViewController () <GDTViewDelegate>
 
@@ -172,6 +173,9 @@
 - (void)viewDidAppear:(BOOL)animated {
 	[super viewDidAppear:animated];
 	[self.godotView startRendering];
+#ifdef IOS_ENABLED
+	[self propagateUIPreferencesToRootViewController];
+#endif
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
@@ -236,6 +240,35 @@
 
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 }
+
+// Propagate UI preferences to the root VC (the SwiftUI hosting controller doesn't delegate these).
+#ifdef IOS_ENABLED
+- (void)propagateUIPreferencesToRootViewController {
+	UIViewController *rootVC = self.view.window.rootViewController;
+	if (!rootVC || rootVC == self) {
+		return;
+	}
+
+	Class rootClass = [rootVC class];
+
+	SEL selectors[] = {
+		@selector(preferredScreenEdgesDeferringSystemGestures),
+		@selector(prefersHomeIndicatorAutoHidden),
+		@selector(prefersStatusBarHidden),
+	};
+
+	for (SEL sel : selectors) {
+		Method method = class_getInstanceMethod([GDTViewController class], sel);
+		if (!class_addMethod(rootClass, sel, method_getImplementation(method), method_getTypeEncoding(method))) {
+			method_setImplementation(class_getInstanceMethod(rootClass, sel), method_getImplementation(method));
+		}
+	}
+
+	[rootVC setNeedsUpdateOfScreenEdgesDeferringSystemGestures];
+	[rootVC setNeedsUpdateOfHomeIndicatorAutoHidden];
+	[rootVC setNeedsStatusBarAppearanceUpdate];
+}
+#endif
 
 // MARK: Orientation
 


### PR DESCRIPTION
Fixes #116632
Fixes https://github.com/godotengine/godot/issues/115552

The SwiftUI lifecycle migration (#109974) wraps `GDTViewController` inside a `UIViewControllerRepresentable`. The hosting controller becomes the window's root view controller, but it doesn't delegate `preferredScreenEdgesDeferringSystemGestures`, `prefersHomeIndicatorAutoHidden`, or `prefersStatusBarHidden` to child VCs. Since iOS queries the root VC for these, the corresponding Godot project settings (`suppress_ui_gesture`, `hide_home_indicator`, `hide_status_bar`) are silently ignored.

This adds `propagateUIPreferencesToRootViewController` which copies `GDTViewController`'s existing method implementations onto the hosting controller's class using `class_addMethod` / `method_setImplementation`, called from `viewDidAppear:` when the window hierarchy is established.

Guarded with `#ifdef IOS_ENABLED` since visionOS doesn't use these APIs.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
