### PR TITLE
Fix LCD batching flag for StyleBoxTexture

### DIFF
--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2542,6 +2542,7 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 					r_current_batch->render_primitive = RD::RENDER_PRIMITIVE_TRIANGLES;
 					r_current_batch->flags = 0;
 					r_current_batch->use_msdf = false;
+					r_current_batch->use_lcd = false;
 				}
 
 				TextureState tex_state(np->texture, texture_filter, texture_repeat, false, use_linear_colors);
@@ -2618,6 +2619,7 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 				r_current_batch->command = c;
 				r_current_batch->flags = 0;
 				r_current_batch->use_msdf = false;
+				r_current_batch->use_lcd = false;
 
 				TextureState tex_state(polygon->texture, texture_filter, texture_repeat, false, use_linear_colors);
 				TextureInfo *tex_info = texture_info_map.getptr(tex_state);
@@ -2745,6 +2747,7 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 				r_current_batch->has_blend = false;
 				r_current_batch->flags = 0;
 				r_current_batch->use_msdf = false;
+				r_current_batch->use_lcd = false;
 
 				InstanceData *instance_data = nullptr;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/115483

Similar to this solution: https://github.com/godotengine/godot/pull/113924
except it's `use_lcd` and not `use_msdf`.
