### PR TITLE
Make Instant Preview work for first selection after being enabled

### DIFF
--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -209,15 +209,14 @@ bool EditorQuickOpenDialog::_is_instant_preview_active() const {
 }
 
 void EditorQuickOpenDialog::selection_changed() {
-	if (!_is_instant_preview_active()) {
-		return;
-	}
-
 	// This prevents the property from being changed the first time the Quick Open
 	// window is opened.
 	if (!initial_selection_performed) {
 		initial_selection_performed = true;
-	} else {
+		return;
+	}
+
+	if (_is_instant_preview_active()) {
 		preview_property();
 	}
 }


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/116650 .

This PR shifts a little logic around for the Quick Load window so that regardless of Instant Preview's enabled status on window open, the initial selection done by the window itself is still counted, and thus the first selection by the user is always detected.

https://github.com/user-attachments/assets/b1a71a20-c355-40d2-8b47-84e4f36cb54e

