### PR TITLE
Fix empty navigate to script list button in Script Editor

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -2082,12 +2082,20 @@ void ScriptEditor::_update_script_names() {
 		}
 	}
 
+	bool has_active_tab = false;
+
 	for (const _ScriptEditorItemData &sedata_i : sedata) {
 		if (tab_container->get_current_tab() == sedata_i.index) {
 			script_name_button->set_text(sedata_i.name);
+			script_name_button->show();
 			_calculate_script_name_button_size();
+			has_active_tab = true;
 			break;
 		}
+	}
+
+	if (!has_active_tab) {
+		script_name_button->hide();
 	}
 
 	if (!waiting_update_names) {


### PR DESCRIPTION
Think this should fix: https://github.com/godotengine/godot/issues/116637


[Screencast_20260223_125638.webm](https://github.com/user-attachments/assets/0b009132-9dab-4e97-85c7-8719c443c11b)
