### PR TITLE
Check for focus before opening project with enter

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1230,7 +1230,9 @@ void ProjectManager::shortcut_input(const Ref<InputEvent> &p_ev) {
 
 		switch (k->get_keycode()) {
 			case Key::ENTER: {
-				_open_selected_projects_check_recovery_mode();
+				if (project_list->is_focus_owner_in_shortcut_context()) {
+					_open_selected_projects_check_recovery_mode();
+				}
 			} break;
 			case Key::HOME: {
 				if (project_list->get_project_count() > 0) {


### PR DESCRIPTION
Fixes #116627
When enter is pressed, the project manager checks whether the project list has focus so no project is opened if a button is actually supposed to be pressed.

Feedback is appreciated, no AI was used in the making.