### PR TITLE
Animation editors: Reorganize/fix UI to make it fit in editor (at its minimum size in single-window mode) better

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -40,6 +40,7 @@
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/gui/button.h"
 #include "scene/gui/check_box.h"
+#include "scene/gui/flow_container.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
@@ -614,6 +615,7 @@ void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 
 			if (error != error_label->get_text()) {
 				error_label->set_text(error);
+				error_label->set_tooltip_text(error);
 				if (!error.is_empty()) {
 					error_panel->show();
 				} else {
@@ -664,8 +666,11 @@ AnimationNodeBlendSpace1DEditor *AnimationNodeBlendSpace1DEditor::singleton = nu
 AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	singleton = this;
 
-	HBoxContainer *top_hb = memnew(HBoxContainer);
-	add_child(top_hb);
+	FlowContainer *top_fc = memnew(FlowContainer);
+	add_child(top_fc);
+
+	HBoxContainer *left_hb = memnew(HBoxContainer);
+	top_fc->add_child(left_hb);
 
 	Ref<ButtonGroup> bg;
 	bg.instantiate();
@@ -674,7 +679,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	tool_select->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_select->set_toggle_mode(true);
 	tool_select->set_button_group(bg);
-	top_hb->add_child(tool_select);
+	left_hb->add_child(tool_select);
 	tool_select->set_pressed(true);
 	tool_select->set_tooltip_text(TTR("Select and move points.\nRMB: Create point at position clicked.\nShift+LMB+Drag: Set the blending position within the space."));
 	tool_select->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_tool_switch).bind(0));
@@ -683,7 +688,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	tool_create->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_create->set_toggle_mode(true);
 	tool_create->set_button_group(bg);
-	top_hb->add_child(tool_create);
+	left_hb->add_child(tool_create);
 	tool_create->set_tooltip_text(TTR("Create points."));
 	tool_create->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_tool_switch).bind(1));
 
@@ -691,50 +696,56 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	tool_blend->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_blend->set_toggle_mode(true);
 	tool_blend->set_button_group(bg);
-	top_hb->add_child(tool_blend);
+	left_hb->add_child(tool_blend);
 	tool_blend->set_tooltip_text(TTR("Set the blending position within the space."));
 	tool_blend->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_tool_switch).bind(2));
 
 	tool_erase_sep = memnew(VSeparator);
-	top_hb->add_child(tool_erase_sep);
+	left_hb->add_child(tool_erase_sep);
+
 	tool_erase = memnew(Button);
 	tool_erase->set_theme_type_variation(SceneStringName(FlatButton));
-	top_hb->add_child(tool_erase);
+	left_hb->add_child(tool_erase);
 	tool_erase->set_tooltip_text(TTR("Erase points."));
 	tool_erase->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_erase_selected));
 
-	top_hb->add_child(memnew(VSeparator));
+	left_hb->add_child(memnew(VSeparator));
 
 	snap = memnew(Button);
 	snap->set_theme_type_variation(SceneStringName(FlatButton));
 	snap->set_toggle_mode(true);
-	top_hb->add_child(snap);
+	left_hb->add_child(snap);
 	snap->set_pressed(true);
 	snap->set_tooltip_text(TTR("Enable snap and show grid."));
 	snap->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_snap_toggled));
 
 	snap_value = memnew(SpinBox);
-	top_hb->add_child(snap_value);
+	left_hb->add_child(snap_value);
 	snap_value->set_min(0.01);
 	snap_value->set_step(0.01);
 	snap_value->set_max(1000);
+	snap_value->set_tooltip_text(TTRC("Grid Step"));
 	snap_value->set_accessibility_name(TTRC("Grid Step"));
 
-	top_hb->add_child(memnew(VSeparator));
-	top_hb->add_child(memnew(Label(TTR("Sync:"))));
+	left_hb->add_child(memnew(VSeparator));
+
+	HBoxContainer *center_hb = memnew(HBoxContainer);
+	top_fc->add_child(center_hb);
+
 	sync = memnew(CheckBox);
-	top_hb->add_child(sync);
+	sync->set_text(TTRC("Sync"));
+	center_hb->add_child(sync);
 	sync->connect(SceneStringName(toggled), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_config_changed));
 
-	top_hb->add_child(memnew(VSeparator));
+	center_hb->add_child(memnew(VSeparator));
 
-	top_hb->add_child(memnew(Label(TTR("Blend:"))));
+	center_hb->add_child(memnew(Label(TTRC("Blend:"))));
 	interpolation = memnew(OptionButton);
-	top_hb->add_child(interpolation);
 	interpolation->connect(SceneStringName(item_selected), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_config_changed));
+	center_hb->add_child(interpolation);
 
 	edit_hb = memnew(HBoxContainer);
-	top_hb->add_child(edit_hb);
+	top_fc->add_child(edit_hb);
 	edit_hb->add_child(memnew(VSeparator));
 	edit_hb->add_child(memnew(Label(TTR("Point"))));
 
@@ -811,6 +822,10 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 
 	error_label = memnew(Label);
 	error_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+	error_label->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+	error_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
+	error_label->set_mouse_filter(MOUSE_FILTER_PASS);
+	error_label->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 	error_panel->add_child(error_label);
 	error_panel->hide();
 
@@ -828,6 +843,4 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	open_file->set_title(TTR("Open Animation Node"));
 	open_file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	open_file->connect("file_selected", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_file_opened));
-
-	set_custom_minimum_size(Size2(0, 150 * EDSCALE));
 }

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -43,6 +43,7 @@
 #include "scene/animation/animation_player.h"
 #include "scene/gui/button.h"
 #include "scene/gui/check_box.h"
+#include "scene/gui/flow_container.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/menu_button.h"
@@ -845,6 +846,7 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 
 			if (error != error_label->get_text()) {
 				error_label->set_text(error);
+				error_label->set_tooltip_text(error);
 				if (!error.is_empty()) {
 					error_panel->show();
 				} else {
@@ -890,8 +892,11 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	singleton = this;
 	updating = false;
 
-	HBoxContainer *top_hb = memnew(HBoxContainer);
-	add_child(top_hb);
+	FlowContainer *top_fc = memnew(FlowContainer);
+	add_child(top_fc);
+
+	HBoxContainer *left_hb = memnew(HBoxContainer);
+	top_fc->add_child(left_hb);
 
 	Ref<ButtonGroup> bg;
 	bg.instantiate();
@@ -900,7 +905,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	tool_select->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_select->set_toggle_mode(true);
 	tool_select->set_button_group(bg);
-	top_hb->add_child(tool_select);
+	left_hb->add_child(tool_select);
 	tool_select->set_pressed(true);
 	tool_select->set_tooltip_text(TTR("Select and move points.\nRMB: Create point at position clicked.\nShift+LMB+Drag: Set the blending position within the space."));
 	tool_select->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch).bind(0));
@@ -909,7 +914,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	tool_create->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_create->set_toggle_mode(true);
 	tool_create->set_button_group(bg);
-	top_hb->add_child(tool_create);
+	left_hb->add_child(tool_create);
 	tool_create->set_tooltip_text(TTR("Create points."));
 	tool_create->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch).bind(1));
 
@@ -917,7 +922,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	tool_blend->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_blend->set_toggle_mode(true);
 	tool_blend->set_button_group(bg);
-	top_hb->add_child(tool_blend);
+	left_hb->add_child(tool_blend);
 	tool_blend->set_tooltip_text(TTR("Set the blending position within the space."));
 	tool_blend->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch).bind(2));
 
@@ -925,40 +930,40 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	tool_triangle->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_triangle->set_toggle_mode(true);
 	tool_triangle->set_button_group(bg);
-	top_hb->add_child(tool_triangle);
+	left_hb->add_child(tool_triangle);
 	tool_triangle->set_tooltip_text(TTR("Create triangles by connecting points."));
 	tool_triangle->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_tool_switch).bind(3));
 
-	tool_erase_sep = memnew(VSeparator);
-	top_hb->add_child(tool_erase_sep);
+	left_hb->add_child(memnew(VSeparator));
+
 	tool_erase = memnew(Button);
 	tool_erase->set_theme_type_variation(SceneStringName(FlatButton));
-	top_hb->add_child(tool_erase);
+	left_hb->add_child(tool_erase);
 	tool_erase->set_tooltip_text(TTR("Erase points and triangles."));
 	tool_erase->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_erase_selected));
 	tool_erase->set_disabled(true);
 
-	top_hb->add_child(memnew(VSeparator));
+	left_hb->add_child(memnew(VSeparator));
 
 	auto_triangles = memnew(Button);
 	auto_triangles->set_theme_type_variation(SceneStringName(FlatButton));
-	top_hb->add_child(auto_triangles);
+	left_hb->add_child(auto_triangles);
 	auto_triangles->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_auto_triangles_toggled));
 	auto_triangles->set_toggle_mode(true);
 	auto_triangles->set_tooltip_text(TTR("Generate blend triangles automatically (instead of manually)"));
 
-	top_hb->add_child(memnew(VSeparator));
+	left_hb->add_child(memnew(VSeparator));
 
 	snap = memnew(Button);
 	snap->set_theme_type_variation(SceneStringName(FlatButton));
 	snap->set_toggle_mode(true);
-	top_hb->add_child(snap);
+	left_hb->add_child(snap);
 	snap->set_pressed(true);
 	snap->set_tooltip_text(TTR("Enable snap and show grid."));
 	snap->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_snap_toggled));
 
 	snap_x = memnew(SpinBox);
-	top_hb->add_child(snap_x);
+	left_hb->add_child(snap_x);
 	snap_x->set_prefix("x:");
 	snap_x->set_min(0.01);
 	snap_x->set_step(0.01);
@@ -966,29 +971,35 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	snap_x->set_accessibility_name(TTRC("Grid X Step"));
 
 	snap_y = memnew(SpinBox);
-	top_hb->add_child(snap_y);
+	left_hb->add_child(snap_y);
 	snap_y->set_prefix("y:");
 	snap_y->set_min(0.01);
 	snap_y->set_step(0.01);
 	snap_y->set_max(1000);
 	snap_y->set_accessibility_name(TTRC("Grid Y Step"));
 
-	top_hb->add_child(memnew(VSeparator));
+	left_hb->add_child(memnew(VSeparator));
 
-	top_hb->add_child(memnew(Label(TTR("Sync:"))));
+	HBoxContainer *sync_hb = memnew(HBoxContainer);
+	top_fc->add_child(sync_hb);
+
 	sync = memnew(CheckBox);
-	top_hb->add_child(sync);
+	sync->set_text(TTRC("Sync"));
+	sync_hb->add_child(sync);
 	sync->connect(SceneStringName(toggled), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_config_changed));
 
-	top_hb->add_child(memnew(VSeparator));
+	sync_hb->add_child(memnew(VSeparator));
 
-	top_hb->add_child(memnew(Label(TTR("Blend:"))));
+	HBoxContainer *blend_hb = memnew(HBoxContainer);
+	top_fc->add_child(blend_hb);
+
+	blend_hb->add_child(memnew(Label(TTR("Blend:"))));
 	interpolation = memnew(OptionButton);
-	top_hb->add_child(interpolation);
+	blend_hb->add_child(interpolation);
 	interpolation->connect(SceneStringName(item_selected), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_config_changed));
 
 	edit_hb = memnew(HBoxContainer);
-	top_hb->add_child(edit_hb);
+	top_fc->add_child(edit_hb);
 	edit_hb->add_child(memnew(VSeparator));
 	edit_hb->add_child(memnew(Label(TTR("Point"))));
 	edit_x = memnew(SpinBox);
@@ -1017,6 +1028,8 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	main_hb->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	GridContainer *main_grid = memnew(GridContainer);
+	main_grid->add_theme_constant_override(SNAME("h_separation"), 0);
+	main_grid->add_theme_constant_override(SNAME("v_separation"), 0);
 	main_grid->set_columns(2);
 	main_hb->add_child(main_grid);
 	main_grid->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -1098,10 +1111,12 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	add_child(error_panel);
 	error_label = memnew(Label);
 	error_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+	error_label->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+	error_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
+	error_label->set_mouse_filter(MOUSE_FILTER_PASS);
+	error_label->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 	error_panel->add_child(error_label);
 	error_panel->hide();
-
-	set_custom_minimum_size(Size2(0, 300 * EDSCALE));
 
 	menu = memnew(PopupMenu);
 	add_child(menu);

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -96,10 +96,6 @@ void AnimationNodeBlendTreeEditor::_update_options_menu(bool p_has_input_ports) 
 	use_position_from_popup_menu = false;
 }
 
-Size2 AnimationNodeBlendTreeEditor::get_minimum_size() const {
-	return Size2(10, 200);
-}
-
 void AnimationNodeBlendTreeEditor::_property_changed(const StringName &p_property, const Variant &p_value, const String &p_field, bool p_changing) {
 	AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
 	if (!tree) {
@@ -1014,6 +1010,7 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 
 			if (error != error_label->get_text()) {
 				error_label->set_text(error);
+				error_label->set_tooltip_text(error);
 				if (!error.is_empty()) {
 					error_panel->show();
 				} else {
@@ -1272,8 +1269,12 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	add_child(error_panel);
 	error_label = memnew(Label);
 	error_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+	error_label->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+	error_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
+	error_label->set_mouse_filter(MOUSE_FILTER_PASS);
+	error_label->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 	error_panel->add_child(error_label);
-	error_label->set_text("eh");
+	error_panel->hide();
 
 	filter_dialog = memnew(AcceptDialog);
 	add_child(filter_dialog);

--- a/editor/animation/animation_blend_tree_editor_plugin.h
+++ b/editor/animation/animation_blend_tree_editor_plugin.h
@@ -161,8 +161,6 @@ public:
 	void add_custom_type(const String &p_name, const Ref<Script> &p_script);
 	void remove_custom_type(const Ref<Script> &p_script);
 
-	virtual Size2 get_minimum_size() const override;
-
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) override;
 	virtual void edit(const Ref<AnimationNode> &p_node) override;
 

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -48,6 +48,7 @@
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
 #include "scene/animation/animation_tree.h"
+#include "scene/gui/flow_container.h"
 #include "scene/gui/separator.h"
 #include "scene/main/window.h"
 #include "scene/resources/animation.h"
@@ -980,10 +981,6 @@ void AnimationPlayerEditor::_animation_edit() {
 	}
 }
 
-void AnimationPlayerEditor::_scale_changed(const String &p_scale) {
-	player->set_speed_scale(p_scale.to_float());
-}
-
 void AnimationPlayerEditor::_update_animation() {
 	// the purpose of _update_animation is to reflect the current state
 	// of the animation player in the current editor..
@@ -996,7 +993,6 @@ void AnimationPlayerEditor::_update_animation() {
 		stop->set_button_icon(stop_icon);
 	}
 
-	scale->set_text(String::num(player->get_speed_scale(), 2));
 	String current = player->get_assigned_animation();
 
 	for (int i = 0; i < animation->get_item_count(); i++) {
@@ -2064,12 +2060,16 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 
 	VBoxContainer *main_vbox_container = memnew(VBoxContainer);
 	add_child(main_vbox_container);
-	HBoxContainer *hb = memnew(HBoxContainer);
-	main_vbox_container->add_child(hb);
+
+	FlowContainer *main_fc = memnew(FlowContainer);
+	main_vbox_container->add_child(main_fc);
+
+	HBoxContainer *left_hb = memnew(HBoxContainer);
+	main_fc->add_child(left_hb);
 
 	HBoxContainer *playback_container = memnew(HBoxContainer);
 	playback_container->set_layout_direction(LAYOUT_DIRECTION_LTR);
-	hb->add_child(playback_container);
+	left_hb->add_child(playback_container);
 
 	play_bw_from = memnew(Button);
 	play_bw_from->set_theme_type_variation(SceneStringName(FlatButton));
@@ -2092,24 +2092,21 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 	playback_container->add_child(play_from);
 
 	frame = memnew(SpinBox);
-	hb->add_child(frame);
+	left_hb->add_child(frame);
 	frame->set_custom_minimum_size(Size2(80, 0) * EDSCALE);
 	frame->set_stretch_ratio(2);
 	frame->set_step(0.0001);
 	frame->set_tooltip_text(TTRC("Animation position (in seconds)."));
 
-	hb->add_child(memnew(VSeparator));
-
-	scale = memnew(LineEdit);
-	hb->add_child(scale);
-	scale->set_h_size_flags(SIZE_EXPAND_FILL);
-	scale->set_stretch_ratio(1);
-	scale->set_tooltip_text(TTRC("Scale animation playback globally for the node."));
-	scale->hide();
+	left_hb->add_child(memnew(VSeparator));
 
 	delete_dialog = memnew(ConfirmationDialog);
 	add_child(delete_dialog);
 	delete_dialog->connect(SceneStringName(confirmed), callable_mp(this, &AnimationPlayerEditor::_animation_remove_confirmed));
+
+	HBoxContainer *right_hb = memnew(HBoxContainer);
+	right_hb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	main_fc->add_child(right_hb);
 
 	tool_anim = memnew(MenuButton);
 	tool_anim->set_shortcut_context(this);
@@ -2129,34 +2126,35 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 	tool_anim->get_popup()->add_shortcut(ED_SHORTCUT("animation_player_editor/remove_animation", TTRC("Remove")), TOOL_REMOVE_ANIM);
 	tool_anim->set_disabled(true);
 	tool_anim->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &AnimationPlayerEditor::_animation_tool_menu));
-	hb->add_child(tool_anim);
+	right_hb->add_child(tool_anim);
 
 	animation = memnew(OptionButton);
-	hb->add_child(animation);
+	right_hb->add_child(animation);
 	animation->set_accessibility_name(TTRC("Animation"));
 	animation->set_h_size_flags(SIZE_EXPAND_FILL);
+	animation->set_custom_minimum_size(Size2(70 * EDSCALE, 0));
 	animation->set_tooltip_text(TTRC("Display list of animations in player."));
 	animation->set_clip_text(true);
 	animation->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 
 	autoplay = memnew(Button);
 	autoplay->set_theme_type_variation(SceneStringName(FlatButton));
-	hb->add_child(autoplay);
+	right_hb->add_child(autoplay);
 	autoplay->set_tooltip_text(TTRC("Autoplay on Load"));
 
-	hb->add_child(memnew(VSeparator));
+	right_hb->add_child(memnew(VSeparator));
 
 	track_editor = memnew(AnimationTrackEditor);
-	hb->add_child(track_editor->get_edit_menu());
+	right_hb->add_child(track_editor->get_edit_menu());
 
-	hb->add_child(memnew(VSeparator));
+	right_hb->add_child(memnew(VSeparator));
 
 	onion_toggle = memnew(Button);
 	onion_toggle->set_theme_type_variation(SceneStringName(FlatButton));
 	onion_toggle->set_toggle_mode(true);
 	onion_toggle->set_tooltip_text(TTRC("Enable Onion Skinning"));
 	onion_toggle->connect(SceneStringName(pressed), callable_mp(this, &AnimationPlayerEditor::_onion_skinning_menu).bind(ONION_SKINNING_ENABLE));
-	hb->add_child(onion_toggle);
+	right_hb->add_child(onion_toggle);
 
 	onion_skinning = memnew(MenuButton);
 	onion_skinning->set_accessibility_name(TTRC("Onion Skinning Options"));
@@ -2179,15 +2177,15 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 	onion_skinning->get_popup()->add_check_item(TTRC("Force White Modulate"), ONION_SKINNING_FORCE_WHITE_MODULATE);
 	onion_skinning->get_popup()->add_check_item(TTRC("Include Gizmos (3D)"), ONION_SKINNING_INCLUDE_GIZMOS);
 	onion_skinning->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &AnimationPlayerEditor::_onion_skinning_menu));
-	hb->add_child(onion_skinning);
+	right_hb->add_child(onion_skinning);
 
-	hb->add_child(memnew(VSeparator));
+	right_hb->add_child(memnew(VSeparator));
 
 	pin = memnew(Button);
 	pin->set_theme_type_variation(SceneStringName(FlatButton));
 	pin->set_toggle_mode(true);
 	pin->set_tooltip_text(TTRC("Pin AnimationPlayer"));
-	hb->add_child(pin);
+	right_hb->add_child(pin);
 	pin->connect(SceneStringName(pressed), callable_mp(this, &AnimationPlayerEditor::_pin_pressed));
 
 	file = memnew(EditorFileDialog);
@@ -2256,7 +2254,6 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 	animation->connect(SceneStringName(item_selected), callable_mp(this, &AnimationPlayerEditor::_animation_selected));
 
 	frame->connect(SceneStringName(value_changed), callable_mp(this, &AnimationPlayerEditor::_seek_value_changed).bind(false));
-	scale->connect(SceneStringName(text_submitted), callable_mp(this, &AnimationPlayerEditor::_scale_changed));
 
 	main_vbox_container->add_child(track_editor);
 	track_editor->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/animation/animation_player_editor_plugin.h
+++ b/editor/animation/animation_player_editor_plugin.h
@@ -103,7 +103,6 @@ class AnimationPlayerEditor : public EditorDock {
 	MenuButton *onion_skinning = nullptr;
 	Button *pin = nullptr;
 	SpinBox *frame = nullptr;
-	LineEdit *scale = nullptr;
 	LineEdit *name = nullptr;
 	OptionButton *library = nullptr;
 	Label *name_title = nullptr;
@@ -198,7 +197,6 @@ class AnimationPlayerEditor : public EditorDock {
 	void _animation_duplicate();
 	Ref<Animation> _animation_clone(const Ref<Animation> p_anim);
 	void _animation_resource_edit();
-	void _scale_changed(const String &p_scale);
 	void _seek_value_changed(float p_value, bool p_timeline_only = false);
 	void _blend_editor_next_changed(const int p_idx);
 

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -39,6 +39,7 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/animation/animation_blend_tree.h"
+#include "scene/gui/flow_container.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
@@ -1703,6 +1704,7 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 
 			if (error != error_label->get_text()) {
 				error_label->set_text(error);
+				error_label->set_tooltip_text(error);
 				if (!error.is_empty()) {
 					error_panel->show();
 				} else {
@@ -2064,15 +2066,18 @@ AnimationNodeStateMachineEditor *AnimationNodeStateMachineEditor::singleton = nu
 AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	singleton = this;
 
-	HBoxContainer *top_hb = memnew(HBoxContainer);
-	add_child(top_hb);
+	FlowContainer *top_fc = memnew(FlowContainer);
+	add_child(top_fc);
 
 	Ref<ButtonGroup> bg;
 	bg.instantiate();
 
+	HBoxContainer *tools_hb = memnew(HBoxContainer);
+	top_fc->add_child(tools_hb);
+
 	tool_select = memnew(Button);
 	tool_select->set_theme_type_variation(SceneStringName(FlatButton));
-	top_hb->add_child(tool_select);
+	tools_hb->add_child(tool_select);
 	tool_select->set_toggle_mode(true);
 	tool_select->set_button_group(bg);
 	tool_select->set_pressed(true);
@@ -2082,7 +2087,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 
 	tool_create = memnew(Button);
 	tool_create->set_theme_type_variation(SceneStringName(FlatButton));
-	top_hb->add_child(tool_create);
+	tools_hb->add_child(tool_create);
 	tool_create->set_toggle_mode(true);
 	tool_create->set_button_group(bg);
 	tool_create->set_tooltip_text(TTR("Create new nodes."));
@@ -2090,7 +2095,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 
 	tool_connect = memnew(Button);
 	tool_connect->set_theme_type_variation(SceneStringName(FlatButton));
-	top_hb->add_child(tool_connect);
+	tools_hb->add_child(tool_connect);
 	tool_connect->set_toggle_mode(true);
 	tool_connect->set_button_group(bg);
 	tool_connect->set_tooltip_text(TTR("Connect nodes."));
@@ -2098,7 +2103,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 
 	// Context-sensitive selection tools:
 	selection_tools_hb = memnew(HBoxContainer);
-	top_hb->add_child(selection_tools_hb);
+	top_fc->add_child(selection_tools_hb);
 	selection_tools_hb->add_child(memnew(VSeparator));
 
 	tool_erase = memnew(Button);
@@ -2109,7 +2114,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	selection_tools_hb->add_child(tool_erase);
 
 	transition_tools_hb = memnew(HBoxContainer);
-	top_hb->add_child(transition_tools_hb);
+	top_fc->add_child(transition_tools_hb);
 	transition_tools_hb->add_child(memnew(VSeparator));
 
 	transition_tools_hb->add_child(memnew(Label(TTR("Transition:"))));
@@ -2125,11 +2130,14 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 
 	//
 
-	top_hb->add_spacer();
+	HBoxContainer *play_mode_hb = memnew(HBoxContainer);
+	play_mode_hb->set_h_size_flags(SIZE_EXPAND_FILL);
+	play_mode_hb->set_alignment(BoxContainer::ALIGNMENT_END);
+	top_fc->add_child(play_mode_hb);
 
-	top_hb->add_child(memnew(Label(TTR("Play Mode:"))));
+	play_mode_hb->add_child(memnew(Label(TTR("Play Mode:"))));
 	play_mode = memnew(OptionButton);
-	top_hb->add_child(play_mode);
+	play_mode_hb->add_child(play_mode);
 
 	panel = memnew(PanelContainer);
 	panel->set_clip_contents(true);
@@ -2165,10 +2173,12 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	add_child(error_panel);
 	error_label = memnew(Label);
 	error_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+	error_label->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+	error_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
+	error_label->set_mouse_filter(MOUSE_FILTER_PASS);
+	error_label->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 	error_panel->add_child(error_label);
 	error_panel->hide();
-
-	set_custom_minimum_size(Size2(0, 300 * EDSCALE));
 
 	menu = memnew(PopupMenu);
 	add_child(menu);

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -2095,7 +2095,7 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	length->set_max(36000);
 	length->set_step(SECOND_DECIMAL);
 	length->set_allow_greater(true);
-	length->set_custom_minimum_size(Vector2(70 * EDSCALE, 0));
+	length->set_custom_minimum_size(Vector2(60 * EDSCALE, 0));
 	length->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 	length->set_tooltip_text(TTRC("Animation length (seconds)"));
 	length->set_accessibility_name(TTRC("Animation length (seconds)"));
@@ -5450,7 +5450,7 @@ void AnimationTrackEditor::_update_nearest_fps_label() {
 		nearest_fps_label->hide();
 	} else {
 		nearest_fps_label->show();
-		nearest_fps_label->set_text(vformat(TTR("Nearest FPS: %d"), nearest_fps));
+		nearest_fps_label->set_text(vformat(TTR("FPS ~ %d"), nearest_fps));
 	}
 }
 
@@ -8126,7 +8126,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	scroll->get_v_scroll_bar()->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_v_scroll_changed));
 	scroll->get_h_scroll_bar()->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_h_scroll_changed));
 
-	timeline_vbox->set_custom_minimum_size(Size2(0, 150) * EDSCALE);
+	timeline_vbox->set_custom_minimum_size(Size2(0, 80) * EDSCALE);
 
 	hscroll = memnew(HScrollBar);
 	hscroll->share(timeline);
@@ -8147,31 +8147,29 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	HFlowContainer *bottom_hf = memnew(HFlowContainer);
 	add_child(bottom_hf);
 
+	HBoxContainer *left_hb = memnew(HBoxContainer);
+	bottom_hf->add_child(left_hb);
+
 	imported_anim_warning = memnew(Button);
 	imported_anim_warning->hide();
 	imported_anim_warning->set_text(TTRC("Imported Animation"));
 	imported_anim_warning->set_tooltip_text(TTRC("Warning: Editing imported animation"));
 	imported_anim_warning->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_show_imported_anim_warning));
-	bottom_hf->add_child(imported_anim_warning);
+	left_hb->add_child(imported_anim_warning);
 
 	dummy_player_warning = memnew(Button);
 	dummy_player_warning->hide();
 	dummy_player_warning->set_text(TTRC("Dummy Player"));
 	dummy_player_warning->set_tooltip_text(TTRC("Warning: Editing dummy AnimationPlayer"));
 	dummy_player_warning->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_show_dummy_player_warning));
-	bottom_hf->add_child(dummy_player_warning);
+	left_hb->add_child(dummy_player_warning);
 
 	inactive_player_warning = memnew(Button);
 	inactive_player_warning->hide();
 	inactive_player_warning->set_text(TTRC("Inactive Player"));
 	inactive_player_warning->set_tooltip_text(TTRC("Warning: AnimationPlayer is inactive"));
 	inactive_player_warning->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_show_inactive_player_warning));
-	bottom_hf->add_child(inactive_player_warning);
-
-	Control *spacer = memnew(Control);
-	spacer->set_mouse_filter(MOUSE_FILTER_PASS);
-	spacer->set_h_size_flags(SIZE_EXPAND_FILL);
-	bottom_hf->add_child(spacer);
+	left_hb->add_child(inactive_player_warning);
 
 	bezier_key_mode = memnew(OptionButton);
 	bezier_key_mode->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
@@ -8182,8 +8180,11 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	bezier_key_mode->select(Animation::HANDLE_MODE_BALANCED);
 	bezier_key_mode->set_accessibility_name(TTRC("Bezier Default Mode"));
 
-	bottom_hf->add_child(bezier_key_mode);
-	bottom_hf->add_child(memnew(VSeparator));
+	left_hb->add_child(bezier_key_mode);
+	left_hb->add_child(memnew(VSeparator));
+
+	HBoxContainer *center_hb = memnew(HBoxContainer);
+	bottom_hf->add_child(center_hb);
 
 	bezier_edit_icon = memnew(Button);
 	bezier_edit_icon->set_flat(true);
@@ -8192,7 +8193,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	bezier_edit_icon->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_toggle_bezier_edit));
 	bezier_edit_icon->set_tooltip_text(TTRC("Toggle between the bezier curve editor and track editor."));
 
-	bottom_hf->add_child(bezier_edit_icon);
+	center_hb->add_child(bezier_edit_icon);
 
 	function_name_toggler = memnew(Button);
 	function_name_toggler->set_flat(true);
@@ -8202,7 +8203,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	function_name_toggler->set_shortcut_in_tooltip(false);
 	function_name_toggler->set_tooltip_text(TTRC("Toggle function names in the track editor."));
 
-	bottom_hf->add_child(function_name_toggler);
+	center_hb->add_child(function_name_toggler);
 
 	selected_filter = memnew(Button);
 	selected_filter->set_flat(true);
@@ -8210,7 +8211,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	selected_filter->set_toggle_mode(true);
 	selected_filter->set_tooltip_text(TTRC("Only show tracks from nodes selected in tree."));
 
-	bottom_hf->add_child(selected_filter);
+	center_hb->add_child(selected_filter);
 
 	alphabetic_sorting = memnew(Button);
 	alphabetic_sorting->set_flat(true);
@@ -8218,7 +8219,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	alphabetic_sorting->set_toggle_mode(true);
 	alphabetic_sorting->set_tooltip_text(TTRC("Sort tracks/groups alphabetically.\nIf disabled, tracks are shown in the order they are added and can be reordered using drag-and-drop."));
 
-	bottom_hf->add_child(alphabetic_sorting);
+	center_hb->add_child(alphabetic_sorting);
 
 	view_group = memnew(Button);
 	view_group->set_flat(true);
@@ -8226,17 +8227,17 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	view_group->set_toggle_mode(true);
 	view_group->set_tooltip_text(TTRC("Group tracks by node or display them as plain list."));
 
-	bottom_hf->add_child(view_group);
+	center_hb->add_child(view_group);
 
 	insert_at_current_time = memnew(Button);
 	insert_at_current_time->set_flat(true);
-	bottom_hf->add_child(insert_at_current_time);
+	center_hb->add_child(insert_at_current_time);
 	insert_at_current_time->set_disabled(true);
 	insert_at_current_time->set_toggle_mode(true);
 	insert_at_current_time->set_pressed(EDITOR_GET("editors/animation/insert_at_current_time"));
 	insert_at_current_time->set_tooltip_text(TTRC("Insert at current time."));
 
-	bottom_hf->add_child(memnew(VSeparator));
+	center_hb->add_child(memnew(VSeparator));
 
 	snap_timeline = memnew(Button);
 	snap_timeline->set_flat(true);
@@ -8244,7 +8245,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	snap_timeline->set_toggle_mode(true);
 	snap_timeline->set_tooltip_text(TTRC("Apply snapping to timeline cursor."));
 	snap_timeline->set_pressed(EditorSettings::get_singleton()->get_project_metadata("animation_track_editor", "snap_timeline", false));
-	bottom_hf->add_child(snap_timeline);
+	center_hb->add_child(snap_timeline);
 	snap_timeline->connect(SceneStringName(toggled), callable_mp(this, &AnimationTrackEditor::_store_snap_states).unbind(1));
 
 	snap_keys = memnew(Button);
@@ -8253,12 +8254,16 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	snap_keys->set_toggle_mode(true);
 	snap_keys->set_tooltip_text(TTRC("Apply snapping to selected key(s)."));
 	snap_keys->set_pressed(EditorSettings::get_singleton()->get_project_metadata("animation_track_editor", "snap_keys", true));
-	bottom_hf->add_child(snap_keys);
+	center_hb->add_child(snap_keys);
 	snap_keys->connect(SceneStringName(toggled), callable_mp(this, &AnimationTrackEditor::_store_snap_states).unbind(1));
+
+	HBoxContainer *right_hb = memnew(HBoxContainer);
+	right_hb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	bottom_hf->add_child(right_hb);
 
 	fps_compat = memnew(Button);
 	fps_compat->set_flat(true);
-	bottom_hf->add_child(fps_compat);
+	right_hb->add_child(fps_compat);
 	fps_compat->set_disabled(true);
 	fps_compat->set_toggle_mode(true);
 	fps_compat->set_pressed(true);
@@ -8268,17 +8273,20 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	nearest_fps_label = memnew(Label);
 	nearest_fps_label->set_focus_mode(FOCUS_ACCESSIBILITY);
 	nearest_fps_label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	bottom_hf->add_child(nearest_fps_label);
+	nearest_fps_label->set_mouse_filter(MOUSE_FILTER_PASS);
+	nearest_fps_label->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
+	nearest_fps_label->set_tooltip_text(TTRC("Nearest FPS amount to the current step."));
+	right_hb->add_child(nearest_fps_label);
 
 	step = memnew(EditorSpinSlider);
 	step->set_min(0);
 	step->set_max(1000000);
 	step->set_step(SECOND_DECIMAL);
 	step->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
-	step->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
+	step->set_custom_minimum_size(Size2(85 * EDSCALE, 0));
 	step->set_tooltip_text(TTRC("Animation step value."));
 	step->set_accessibility_name(TTRC("Animation step value."));
-	bottom_hf->add_child(step);
+	right_hb->add_child(step);
 	step->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_update_step));
 	step->set_read_only(true);
 
@@ -8287,12 +8295,13 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	snap_mode->add_item(TTRC("FPS"));
 	snap_mode->set_accessibility_name(TTRC("Snap Mode"));
 	snap_mode->set_disabled(true);
-	bottom_hf->add_child(snap_mode);
+	right_hb->add_child(snap_mode);
 	snap_mode->connect(SceneStringName(item_selected), callable_mp(this, &AnimationTrackEditor::_snap_mode_changed));
 
-	bottom_hf->add_child(memnew(VSeparator));
+	right_hb->add_child(memnew(VSeparator));
 
 	HBoxContainer *zoom_hb = memnew(HBoxContainer);
+	zoom_hb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	zoom_icon = memnew(TextureRect);
 	zoom_icon->set_v_size_flags(SIZE_SHRINK_CENTER);
 	zoom_hb->add_child(zoom_icon);
@@ -8301,11 +8310,12 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	zoom->set_min(0.0);
 	zoom->set_max(2.0);
 	zoom->set_value(1.0);
-	zoom->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
+	zoom->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
 	zoom->set_v_size_flags(SIZE_SHRINK_CENTER);
+	zoom->set_h_size_flags(SIZE_EXPAND_FILL);
 	zoom->set_accessibility_name(TTRC("Zoom"));
 	zoom_hb->add_child(zoom);
-	bottom_hf->add_child(zoom_hb);
+	right_hb->add_child(zoom_hb);
 	timeline->set_zoom(zoom);
 
 	ED_SHORTCUT("animation_editor/auto_fit", TTRC("Fit to panel"), KeyModifierMask::ALT | Key::F);
@@ -8315,7 +8325,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	auto_fit->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_auto_fit));
 	auto_fit->set_shortcut(ED_GET_SHORTCUT("animation_editor/auto_fit"));
 	auto_fit->set_accessibility_name(TTRC("Auto Fit"));
-	bottom_hf->add_child(auto_fit);
+	right_hb->add_child(auto_fit);
 
 	auto_fit_bezier = memnew(Button);
 	auto_fit_bezier->set_flat(true);
@@ -8323,7 +8333,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	auto_fit_bezier->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_auto_fit_bezier));
 	auto_fit_bezier->set_shortcut(ED_GET_SHORTCUT("animation_editor/auto_fit"));
 	auto_fit_bezier->set_accessibility_name(TTRC("Auto Fit Bezier"));
-	bottom_hf->add_child(auto_fit_bezier);
+	right_hb->add_child(auto_fit_bezier);
 
 	edit = memnew(MenuButton);
 	edit->set_shortcut_context(this);

--- a/editor/animation/animation_tree_editor_plugin.cpp
+++ b/editor/animation/animation_tree_editor_plugin.cpp
@@ -284,6 +284,7 @@ AnimationTreeEditor::AnimationTreeEditor() {
 	main_vbox_container->add_child(memnew(HSeparator));
 
 	editor_base = memnew(MarginContainer);
+	editor_base->set_custom_minimum_size(Size2(220, 165) * EDSCALE);
 	editor_base->set_v_size_flags(SIZE_EXPAND_FILL);
 	main_vbox_container->add_child(editor_base);
 
@@ -313,7 +314,6 @@ void AnimationTreeEditorPlugin::make_visible(bool p_visible) {
 
 AnimationTreeEditorPlugin::AnimationTreeEditorPlugin() {
 	anim_tree_editor = memnew(AnimationTreeEditor);
-	anim_tree_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
 	EditorDockManager::get_singleton()->add_dock(anim_tree_editor);
 	anim_tree_editor->close();
 }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -9086,6 +9086,8 @@ EditorNode::EditorNode() {
 	{
 		Dictionary offsets;
 		offsets["Audio"] = -450;
+		offsets["Animation"] = -325;
+		offsets["AnimationTree"] = -370;
 		default_layout->set_value(EDITOR_NODE_CONFIG_SECTION, "bottom_panel_offsets", offsets);
 	}
 


### PR DESCRIPTION
- Addresses **bug** https://github.com/godotengine/godot/issues/26835, but only for animation-related editors.
- Extracted from https://github.com/godotengine/godot/pull/102301 (looks like this is the last one 🥳 )
- Supersedes https://github.com/godotengine/godot/pull/109361

---

**Before:**

https://github.com/user-attachments/assets/a1dc6c21-39b6-4996-9e3d-2ef835ff300d

**After:**

https://github.com/user-attachments/assets/048b385f-fa92-45db-9fb6-f51262578086