### PR TITLE
Remove unused `edit_hb` variable in `TextEditorBase` which causes warnings

### DIFF
--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -645,8 +645,6 @@ TextEditorBase::TextEditorBase() {
 	context_menu->connect(SceneStringName(id_pressed), callable_mp(this, &TextEditorBase::_edit_option));
 	add_child(context_menu);
 
-	edit_hb = memnew(HBoxContainer);
-
 	goto_line_popup = memnew(GotoLinePopup);
 	add_child(goto_line_popup);
 

--- a/editor/script/script_editor_base.h
+++ b/editor/script/script_editor_base.h
@@ -161,7 +161,6 @@ protected:
 
 	bool editor_enabled = false;
 	CodeTextEditor *code_editor = nullptr;
-	HBoxContainer *edit_hb = nullptr;
 
 	GotoLinePopup *goto_line_popup = nullptr;
 


### PR DESCRIPTION
Removes a variable I missed when adjusting https://github.com/godotengine/godot/pull/114917 with `EditorMenu` classes. It causes leaked RID warnings when closing the editor because it is instantiated but never deleted.