### PR TITLE
Robust `safe_normalize` routine

### DIFF
--- a/core/math/math_defs.h
+++ b/core/math/math_defs.h
@@ -45,6 +45,9 @@ inline constexpr double PI = 3.1415926535897932384626433833;
 inline constexpr double E = 2.7182818284590452353602874714;
 inline constexpr double INF = std::numeric_limits<double>::infinity();
 inline constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
+
+inline constexpr float NORMALIZE_32_SAFE_THRESHOLD = 1e-4f;
+inline constexpr float NORMALIZE_32_RESCUE_THRESHOLD = 1e-16f;
 } // namespace Math
 
 #define CMP_EPSILON 0.00001
@@ -158,3 +161,15 @@ namespace Math {
 using int_alt_t = std::conditional_t<std::is_same_v<int64_t, long>, long long, long>;
 using uint_alt_t = std::conditional_t<std::is_same_v<uint64_t, unsigned long>, unsigned long long, unsigned long>;
 } //namespace Math
+
+// NORMALIZATION epsilons.
+// We want rescue to cover tiny-but-representable vectors, but still avoid
+// catastrophic cancellation or excessive denormal behavior.
+static_assert(Math::NORMALIZE_32_SAFE_THRESHOLD >= 1e-5f && Math::NORMALIZE_32_SAFE_THRESHOLD <= 1e-3f,
+		"NORMALIZE_32_SAFE_THRESHOLD should be in a practical range (~1e-5 … 1e-3)");
+
+static_assert(Math::NORMALIZE_32_RESCUE_THRESHOLD >= 1e-20f && Math::NORMALIZE_32_RESCUE_THRESHOLD <= 1e-10f,
+		"NORMALIZE_32_RESCUE_THRESHOLD should cover tiny vectors but avoid denormals/underflow issues");
+
+static_assert(Math::NORMALIZE_32_RESCUE_THRESHOLD < Math::NORMALIZE_32_SAFE_THRESHOLD,
+		"Rescue threshold must be strictly below safe threshold");

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -49,6 +49,66 @@ real_t Vector2::length_squared() const {
 	return x * x + y * y;
 }
 
+real_t Vector2::safe_normalize() {
+	// Don't allow Inf / NaN to propagate.
+	if (!is_finite()) {
+		x = y = 0;
+		return 0;
+	}
+
+	real_t lengthsq = length_squared();
+
+	// Extra paranoid checks for NaN.
+	if (!Math::is_finite(lengthsq)) {
+		x = y = 0;
+		return 0;
+	}
+
+#ifdef REAL_T_IS_DOUBLE
+	// Threshold where standard normalization is safe & accurate in float64
+	// (should be the same as the 32 bit lower threshold, in order to preserve
+	// behavior between the two builds).
+	if (lengthsq >= (real_t)Math::NORMALIZE_32_RESCUE_THRESHOLD) {
+		real_t length = Math::sqrt(lengthsq);
+		*this /= length;
+		return length;
+	}
+#else
+	// Threshold where standard normalization is safe & accurate in float32
+	if (lengthsq >= (real_t)Math::NORMALIZE_32_SAFE_THRESHOLD) {
+		real_t length = Math::sqrt(lengthsq);
+		*this /= length;
+		return length;
+	}
+
+	// Rescue branch: try to preserve tiny direction.
+	if (lengthsq >= (real_t)Math::NORMALIZE_32_RESCUE_THRESHOLD) {
+		double x_d = (double)x;
+		double y_d = (double)y;
+
+		double len_sq_d = x_d * x_d + y_d * y_d;
+		double len_d = Math::sqrt(len_sq_d);
+		x = (real_t)(x_d / len_d);
+		y = (real_t)(y_d / len_d);
+
+		// Grok warns that if NORMALIZE_32_RESCUE_THRESHOLD is low enough,
+		// we may need to perform another 32 bit normalization step to ensure we
+		// pass is_normalized() checks in all cases with precise math checks.
+
+		// Note: If pushing NORMALIZE_32_RESCUE_THRESHOLD to very low values,
+		// for super robustness you could add another is_finite() check to the 32 bit length.
+		*this /= length(); // Forces length exactly to 1 (in single precision)
+
+		return (real_t)len_d;
+	}
+#endif
+
+	// Give up, length not enough to give a reasonable result.
+	// Zero vector is cleaner than leaving non-zero result.
+	x = y = 0;
+	return 0;
+}
+
 void Vector2::normalize() {
 	real_t l = x * x + y * y;
 	if (l != 0) {

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -84,6 +84,7 @@ struct [[nodiscard]] Vector2 {
 	}
 
 	void normalize();
+	real_t safe_normalize();
 	Vector2 normalized() const;
 	bool is_normalized() const;
 


### PR DESCRIPTION
This function guarantees unit length output in 32 bit and 64 bit `real_t` builds down to a minimum epsilon.

Implements https://github.com/godotengine/godot-proposals/issues/14315
_(Please add non PR specific discussion to the proposal rather than the PR)_

Alternative to #116580 (see that PR for full description of the problem)
Helps address #74852

It also only covers `Vector2` (for clarity), but the same approach can be used on other classes.

## AI Disclosure
used AI to:
* suggest epsilons to work with 32 bit CPUs
* performance testing
* empirical testing that it passed math checks
* suggest the use of a final normalization for robustness to ensure passing math checks

## Notes
* Not bound yet, or unit tests etc, as this is proof of concept prior to decisions on how to proceed.
* Minimalistic, non-invasive, and does not alter any existing code.
* Follow up PR would be needed to apply this where beneficial in the engine code, if we decide not to wrap the existing normalization functions with the new version.
* Did extensive empirical testing with Grok to ensure this passes `is_normalized()` in all extreme cases (except where the input is below the threshold, or non-finite, in which case it returns 0 for failure), with both precise and non-precise MATH_CHECKS.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
