### PR TITLE
Clarify `normalize()` & make consistent with document for vector classes

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -54,7 +54,8 @@ void Basis::invert() {
 }
 
 void Basis::orthonormalize() {
-	// Gram-Schmidt Process
+	// Orthonormalizable check is done in Vector3 class below.
+	// Gram-Schmidt Process:
 
 	Vector3 x = get_column(0);
 	Vector3 y = get_column(1);

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -38,9 +38,15 @@ void Plane::set_normal(const Vector3 &p_normal) {
 }
 
 void Plane::normalize() {
+#ifdef MATH_CHECKS
+	if (!is_finite()) {
+		WARN_PRINT("Plane cannot be normalized, the distance and the normal should be finite.");
+	}
+#endif // MATH_CHECKS
+
 	real_t l = normal.length();
 	if (l == 0) {
-		*this = Plane(0, 0, 0, 0);
+		zero();
 		return;
 	}
 	normal /= l;

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -44,11 +44,11 @@ void Plane::normalize() {
 	}
 #endif // MATH_CHECKS
 
-	real_t l = normal.length();
-	if (l == 0) {
+	if (normal.is_zero_approx()) {
 		zero();
 		return;
 	}
+	real_t l = normal.length();
 	normal /= l;
 	d /= l;
 }

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -45,6 +45,11 @@ struct [[nodiscard]] Plane {
 	void set_normal(const Vector3 &p_normal);
 	_FORCE_INLINE_ Vector3 get_normal() const { return normal; }
 
+	void zero() {
+		normal.zero();
+		d = 0;
+	}
+
 	void normalize();
 	Plane normalized() const;
 

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -63,6 +63,11 @@ real_t Quaternion::length() const {
 }
 
 void Quaternion::normalize() {
+#ifdef MATH_CHECKS
+	if (!is_finite()) {
+		WARN_PRINT("Quaternion cannot be normalized, the elements should be finite.");
+	}
+#endif // MATH_CHECKS
 	*this /= length();
 }
 

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -145,7 +145,8 @@ void Transform2D::translate_local(const Vector2 &p_translation) {
 }
 
 void Transform2D::orthonormalize() {
-	// Gram-Schmidt Process
+	// Orthonormalizable check is done in Vector2 class below.
+	// Gram-Schmidt Process:
 
 	Vector2 x = columns[0];
 	Vector2 y = columns[1];

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -150,6 +150,7 @@ Transform3D Transform3D::translated_local(const Vector3 &p_translation) const {
 }
 
 void Transform3D::orthonormalize() {
+	// Orthonormalizable check is done in Basis class below.
 	basis.orthonormalize();
 }
 

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -50,8 +50,18 @@ real_t Vector2::length_squared() const {
 }
 
 void Vector2::normalize() {
-	real_t l = x * x + y * y;
-	if (l != 0) {
+	if (!is_finite()) {
+#ifdef MATH_CHECKS
+		WARN_PRINT("Vector2 cannot be normalized, the elements must be finite. Making (0, 0) as a fallback.");
+#endif // MATH_CHECKS
+		zero();
+		return;
+	}
+
+	real_t l = length_squared();
+	if (l == 0) {
+		zero();
+	} else {
 		l = Math::sqrt(l);
 		x /= l;
 		y /= l;

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -58,11 +58,10 @@ void Vector2::normalize() {
 		return;
 	}
 
-	real_t l = length_squared();
-	if (l == 0) {
+	if (is_zero_approx()) {
 		zero();
 	} else {
-		l = Math::sqrt(l);
+		real_t l = length();
 		x /= l;
 		y /= l;
 	}

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -91,6 +91,8 @@ struct [[nodiscard]] Vector2 {
 	real_t length_squared() const;
 	Vector2 limit_length(real_t p_len = 1.0) const;
 
+	void zero() { x = y = 0; }
+
 	Vector2 min(const Vector2 &p_vector2) const {
 		return Vector2(MIN(x, p_vector2.x), MIN(y, p_vector2.y));
 	}

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -546,14 +546,22 @@ real_t Vector3::length_squared() const {
 }
 
 void Vector3::normalize() {
-	real_t lengthsq = length_squared();
-	if (lengthsq == 0) {
-		x = y = z = 0;
+	if (!is_finite()) {
+#ifdef MATH_CHECKS
+		WARN_PRINT("Vector3 cannot be normalized, the elements must be finite. Making (0, 0, 0) as a fallback.");
+#endif // MATH_CHECKS
+		zero();
+		return;
+	}
+
+	real_t l = length_squared();
+	if (l == 0) {
+		zero();
 	} else {
-		real_t length = Math::sqrt(lengthsq);
-		x /= length;
-		y /= length;
-		z /= length;
+		l = Math::sqrt(l);
+		x /= l;
+		y /= l;
+		z /= l;
 	}
 }
 

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -554,11 +554,10 @@ void Vector3::normalize() {
 		return;
 	}
 
-	real_t l = length_squared();
-	if (l == 0) {
+	if (is_zero_approx()) {
 		zero();
 	} else {
-		l = Math::sqrt(l);
+		real_t l = length();
 		x /= l;
 		y /= l;
 		z /= l;

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -79,15 +79,23 @@ real_t Vector4::length() const {
 }
 
 void Vector4::normalize() {
-	real_t lengthsq = length_squared();
-	if (lengthsq == 0) {
-		x = y = z = w = 0;
+	if (!is_finite()) {
+#ifdef MATH_CHECKS
+		WARN_PRINT("Vector4 cannot be normalized, the elements must be finite. Making (0, 0, 0, 0) as a fallback.");
+#endif // MATH_CHECKS
+		zero();
+		return;
+	}
+
+	real_t l = length_squared();
+	if (l == 0) {
+		zero();
 	} else {
-		real_t length = Math::sqrt(lengthsq);
-		x /= length;
-		y /= length;
-		z /= length;
-		w /= length;
+		l = Math::sqrt(l);
+		x /= l;
+		y /= l;
+		z /= l;
+		w /= l;
 	}
 }
 

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -87,11 +87,10 @@ void Vector4::normalize() {
 		return;
 	}
 
-	real_t l = length_squared();
-	if (l == 0) {
+	if (is_zero_approx()) {
 		zero();
 	} else {
-		l = Math::sqrt(l);
+		real_t l = length();
 		x /= l;
 		y /= l;
 		z /= l;

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -98,6 +98,8 @@ struct [[nodiscard]] Vector4 {
 	Vector4 normalized() const;
 	bool is_normalized() const;
 
+	void zero() { x = y = z = w = 0; }
+
 	real_t distance_to(const Vector4 &p_to) const;
 	real_t distance_squared_to(const Vector4 &p_to) const;
 	Vector4 direction_to(const Vector4 &p_to) const;

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -139,7 +139,7 @@
 		<method name="normalized" qualifiers="const">
 			<return type="Plane" />
 			<description>
-				Returns a copy of the plane, with normalized [member normal] (so it's a unit vector). Returns [code]Plane(0, 0, 0, 0)[/code] if [member normal] can't be normalized (it has zero length).
+				Returns a copy of the plane, with normalized [member normal] (so it's a unit vector). Returns [code]Plane(0, 0, 0, 0)[/code] if [member normal] can't be normalized (it has almost zero length). See also [method Vector3.is_zero_approx].
 			</description>
 		</method>
 		<method name="project" qualifiers="const">

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -327,7 +327,7 @@
 			<return type="Vector2" />
 			<description>
 				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code]. Returns [code](0, 0)[/code] if [code]v.length() == 0[/code]. See also [method is_normalized].
-				[b]Note:[/b] This function may return incorrect values if the input vector length is near zero.
+				[b]Note:[/b] This function may return incorrect values if the input vector length is near zero. See also [method is_zero_approx].
 			</description>
 		</method>
 		<method name="orthogonal" qualifiers="const">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -294,7 +294,7 @@
 			<return type="Vector3" />
 			<description>
 				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code]. Returns [code](0, 0, 0)[/code] if [code]v.length() == 0[/code]. See also [method is_normalized].
-				[b]Note:[/b] This function may return incorrect values if the input vector length is near zero.
+				[b]Note:[/b] This function may return incorrect values if the input vector length is near zero. See also [method is_zero_approx].
 			</description>
 		</method>
 		<method name="octahedron_decode" qualifiers="static">

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -228,7 +228,7 @@
 			<return type="Vector4" />
 			<description>
 				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code]. Returns [code](0, 0, 0, 0)[/code] if [code]v.length() == 0[/code]. See also [method is_normalized].
-				[b]Note:[/b] This function may return incorrect values if the input vector length is near zero.
+				[b]Note:[/b] This function may return incorrect values if the input vector length is near zero. See also [method is_zero_approx].
 			</description>
 		</method>
 		<method name="posmod" qualifiers="const">


### PR DESCRIPTION
- Prerequisite: https://github.com/godotengine/godot/pull/116427
- Another approach with https://github.com/godotengine/godot/pull/116580


The PR #116580 defines `RESCUE_THRESHOLD` as a threshold smaller than the epsilon value, and attempts to perform normalization when each element is smaller than the epsilon value but larger than `RESCUE_THRESHOLD`. At this time, users need to pay attention to two threshold: `RESCUE_THRESHOLD` and the epsilon. It is unclear whether `RESCUE_THRESHOLD` should be exposed, but values that are excessively small compared to the epsilon value may be displayed as `0` during debugging, which could cause user anxiety and confusion.

This PR sets the normalized result to 0 when each element is smaller than the epsilon value. Determining whether normalization is possible is straightforward, as it relies on the `is_zero_approx()` check for each vector. Additionally, explicitly documenting the connection to `is_zero_approx()` will enhance clarity.

However, as described in #116580, we should first discuss whether to eliminate the handling of values smaller than epsilon within the `normalize()` function.

Test result based on https://github.com/godotengine/godot/pull/116580#discussion_r2836397850:

Code:

```gdscript
func _ready() -> void:
	check_normalization(Vector3(0.1, 0.3, 0.5))
	check_normalization(Vector3(0.00001, 0.00003, 0.00005))
	check_normalization(Vector3(0.000001, 0.000003, 0.000005))
	check_normalization(Vector3(0.00000000000000001 * 0.000001, 0.00000000000000003 * 0.000001, 0.00000000000000005 * 0.000001))

func check_normalization(v: Vector3) -> void:
	print(" ")
	print("== Check normalization ==")
	print("--- Before normalization ---")
	print("current value: " + str(v))
	print("length() result: " + str(v.length()))
	print("length_squared() result: " + str(v.length_squared()))
	print("is zero approx?: " + str(v.is_zero_approx()))
	print("is_normalized() result: " + str(v.is_normalized()))
	v = (v).normalized()
	print("--- After normalization ---")
	print("current value: " + str(v))
	print("length() result: " + str(v.length()))
	print("length_squared() result: " + str(v.length_squared()))
	print("is_normalized() result: " + str(v.is_normalized()))
	print(" ")
```

Before:

```
== Check normalization ==
--- Before normalization ---
current value: (0.1, 0.3, 0.5)
length() result: 0.59160798788071
length_squared() result: 0.34999999403954
is zero approx?: false
is_normalized() result: false
--- After normalization ---
current value: (0.169031, 0.507093, 0.845154)
length() result: 0.99999994039536
length_squared() result: 0.99999994039536
is_normalized() result: true
 
 
== Check normalization ==
--- Before normalization ---
current value: (0.00001, 0.00003, 0.00005)
length() result: 0.00005916079681
length_squared() result: 0.0000000035
is zero approx?: false
is_normalized() result: false
--- After normalization ---
current value: (0.169031, 0.507093, 0.845154)
length() result: 0.99999994039536
length_squared() result: 0.99999994039536
is_normalized() result: true
 
 
== Check normalization ==
--- Before normalization ---
current value: (0.000001, 0.000003, 0.000005)
length() result: 0.00000591607977
length_squared() result: 0.000000000035
is zero approx?: true
is_normalized() result: false
--- After normalization ---
current value: (0.169031, 0.507093, 0.845154)
length() result: 1.0
length_squared() result: 1.0
is_normalized() result: true
 
 
== Check normalization ==
--- Before normalization ---
current value: (0.0, 0.0, 0.0)
length() result: 0.0
length_squared() result: 0.0
is zero approx?: true
is_normalized() result: false
--- After normalization ---
current value: (0.154232, 0.462696, 0.771159)
length() result: 0.91244792938232
length_squared() result: 0.8325611948967
is_normalized() result: false
```

After:

```
== Check normalization ==
--- Before normalization ---
current value: (0.1, 0.3, 0.5)
length() result: 0.59160798788071
length_squared() result: 0.34999999403954
is zero approx?: false
is_normalized() result: false
--- After normalization ---
current value: (0.169031, 0.507093, 0.845154)
length() result: 0.99999994039536
length_squared() result: 0.99999994039536
is_normalized() result: true
 
 
== Check normalization ==
--- Before normalization ---
current value: (0.00001, 0.00003, 0.00005)
length() result: 0.00005916079681
length_squared() result: 0.0000000035
is zero approx?: false
is_normalized() result: false
--- After normalization ---
current value: (0.169031, 0.507093, 0.845154)
length() result: 0.99999994039536
length_squared() result: 0.99999994039536
is_normalized() result: true
 
 
== Check normalization ==
--- Before normalization ---
current value: (0.000001, 0.000003, 0.000005)
length() result: 0.00000591607977
length_squared() result: 0.000000000035
is zero approx?: true
is_normalized() result: false
--- After normalization ---
current value: (0.0, 0.0, 0.0)
length() result: 0.0
length_squared() result: 0.0
is_normalized() result: false
 
 
== Check normalization ==
--- Before normalization ---
current value: (0.0, 0.0, 0.0)
length() result: 0.0
length_squared() result: 0.0
is zero approx?: true
is_normalized() result: false
--- After normalization ---
current value: (0.0, 0.0, 0.0)
length() result: 0.0
length_squared() result: 0.0
is_normalized() result: false
```