### PR TITLE
GDScript: Fix async call without await check

### DIFF
--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -623,6 +623,10 @@ class GDScriptFunctionState : public RefCounted {
 	SelfList<GDScriptFunctionState> scripts_list;
 	SelfList<GDScriptFunctionState> instances_list;
 
+#ifdef DEBUG_ENABLED
+	bool _handled = false;
+#endif
+
 protected:
 	static void _bind_methods();
 

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1951,13 +1951,27 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						Object *obj = ret->get_validated_object_with_check(was_freed);
 
 						if (obj && obj->is_class_ptr(GDScriptFunctionState::get_class_ptr_static())) {
-							err_text = R"(Trying to call an async function without "await".)";
-							OPCODE_BREAK;
+							GDScriptFunctionState *gdfs = Object::cast_to<GDScriptFunctionState>(obj);
+							if (!gdfs->_handled) {
+								err_text = R"(Trying to call an async function without "await".)";
+								OPCODE_BREAK;
+							}
 						}
 					}
 #endif
 				} else {
 					base->callp(*methodname, (const Variant **)argptrs, argc, temp_ret, err);
+#ifdef DEBUG_ENABLED
+					if (temp_ret.get_type() == Variant::OBJECT) {
+						bool was_freed = false;
+						Object *obj = temp_ret.get_validated_object_with_check(was_freed);
+
+						if (obj && obj->is_class_ptr(GDScriptFunctionState::get_class_ptr_static())) {
+							GDScriptFunctionState *gdfs = Object::cast_to<GDScriptFunctionState>(obj);
+							gdfs->_handled = true;
+						}
+					}
+#endif
 				}
 #ifdef DEBUG_ENABLED
 
@@ -2575,6 +2589,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						if (obj) {
 							if (obj->is_class_ptr(GDScriptFunctionState::get_class_ptr_static())) {
 								result = Signal(obj, SNAME("completed"));
+#ifdef DEBUG_ENABLED
+								GDScriptFunctionState *gdfs = Object::cast_to<GDScriptFunctionState>(obj);
+								gdfs->_handled = true;
+#endif
 							}
 						}
 					}

--- a/modules/gdscript/tests/scripts/runtime/errors/coroutine_result_without_await.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/coroutine_result_without_await.gd
@@ -1,0 +1,8 @@
+signal test_signal
+
+func coroutine():
+	await test_signal
+	return 1
+
+func test():
+	var _result = self.call("coroutine")

--- a/modules/gdscript/tests/scripts/runtime/errors/coroutine_result_without_await.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/coroutine_result_without_await.out
@@ -1,0 +1,2 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR at runtime/errors/coroutine_result_without_await.gd:8 on test(): Trying to call an async function without "await".

--- a/modules/gdscript/tests/scripts/runtime/features/access_coroutine_state.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/access_coroutine_state.gd
@@ -1,0 +1,13 @@
+# https://github.com/godotengine/godot/issues/95210
+signal _signal
+
+func foo():
+	await _signal
+
+func test():
+	@warning_ignore("missing_await")
+	foo()
+
+	var awaiting_callable: Callable = _signal.get_connections()[0].callable
+	if awaiting_callable.get_object() != null:
+		print("ok")

--- a/modules/gdscript/tests/scripts/runtime/features/access_coroutine_state.out
+++ b/modules/gdscript/tests/scripts/runtime/features/access_coroutine_state.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok


### PR DESCRIPTION
Fixes #95210

The runtime check for an async function called without `await` was done by assuming all calls that return a `GDScriptFunctionState` instance were invalid (when the return value is actually used and not validated, i. e. `call-ret`). This assumption doesn't always hold, as there are valid ways of accessing such instances, for example a `get_object()` call on a `Callable` from a `Signal` connection that has a function awaiting it.

To fix this, I added a new `bool` field on the `GDScriptFunctionState` class (present only in debug builds), to mark if each instance was properly "handled", and only throwing the runtime error when the returned instance doesn't have this flag set.