### PR TITLE
Add swizzling for vectors in GDScript

### DIFF
--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -692,8 +692,13 @@ public:
 
 	/* Properties */
 
+	static bool check_swizzling(bool p_is_setter, Variant::Type p_type, const StringName &p_member, int &r_component_count, Variant::Type &r_component_type, bool &r_valid_type, String &r_error);
+
 	void set_named(const StringName &p_member, const Variant &p_value, bool &r_valid);
 	Variant get_named(const StringName &p_member, bool &r_valid) const;
+
+	bool set_swizzled(const StringName &p_member, const Variant &p_value, bool &r_valid_type, String &r_error);
+	Variant get_swizzled(const StringName &p_member, bool &r_valid, bool &r_valid_type, String &r_error) const;
 
 	typedef void (*ValidatedSetter)(Variant *base, const Variant *value);
 	typedef void (*ValidatedGetter)(const Variant *base, Variant *value);

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -263,6 +263,244 @@ void Variant::set_named(const StringName &p_member, const Variant &p_value, bool
 	}
 }
 
+static char32_t vec_members[] = { 'x', 'y', 'z', 'w' };
+
+bool Variant::check_swizzling(bool p_is_setter, Variant::Type p_type, const StringName &p_member, int &r_component_count, Variant::Type &r_component_type, bool &r_valid_type, String &r_error) {
+	r_valid_type = true;
+
+	int max_components = 0;
+	Variant::Type component_type;
+
+	switch (p_type) {
+		case Variant::VECTOR2: {
+			max_components = 2;
+			component_type = Variant::FLOAT;
+		} break;
+		case Variant::VECTOR2I: {
+			max_components = 2;
+			component_type = Variant::INT;
+		} break;
+		case Variant::VECTOR3: {
+			max_components = 3;
+			component_type = Variant::FLOAT;
+		} break;
+		case Variant::VECTOR3I: {
+			max_components = 3;
+			component_type = Variant::INT;
+		} break;
+		case Variant::VECTOR4: {
+			max_components = 4;
+			component_type = Variant::FLOAT;
+		} break;
+		case Variant::VECTOR4I: {
+			max_components = 4;
+			component_type = Variant::INT;
+		} break;
+		default: {
+			r_valid_type = false;
+			return false;
+		} break;
+	}
+
+	if (p_member.length() > max_components) {
+		r_error = vformat("Swizzling failed. Length is exceeded.");
+		return false;
+	}
+
+	LocalVector<char32_t> buffer;
+	const char32_t *ptr = ((String)p_member).ptr();
+
+	for (int i = 0; i < p_member.length(); i++) {
+		const char32_t symbol = ptr[i];
+
+		bool found = false;
+		for (int j = 0; j < max_components; j++) {
+			if (vec_members[j] == symbol) {
+				found = true;
+				break;
+			}
+		}
+
+		if (found) {
+			if (p_is_setter) {
+				for (uint32_t j = 0; j < buffer.size(); j++) {
+					if (buffer[j] == symbol) {
+						r_error = vformat("Swizzling failed. Duplicated symbol found: '%c'.", symbol);
+						return false;
+					}
+				}
+			}
+			buffer.push_back(symbol);
+		} else {
+			r_error = vformat("Swizzling failed. Invalid symbol found: '%c'.", symbol);
+			return false;
+		}
+	}
+
+	r_component_count = buffer.size();
+	r_component_type = component_type;
+
+	return true;
+}
+
+bool Variant::set_swizzled(const StringName &p_member, const Variant &p_value, bool &r_valid_type, String &r_error) {
+	int component_count;
+	Variant::Type component_type;
+
+	if (!Variant::check_swizzling(true, type, p_member, component_count, component_type, r_valid_type, r_error)) {
+		return false;
+	}
+
+	Variant::Type val_component_type = Variant::NIL;
+	int val_component_count = 0;
+
+	switch (p_value.type) {
+		case Variant::VECTOR2: {
+			val_component_count = 2;
+			val_component_type = Variant::FLOAT;
+		} break;
+		case Variant::VECTOR2I: {
+			val_component_count = 2;
+			val_component_type = Variant::INT;
+		} break;
+		case Variant::VECTOR3: {
+			val_component_count = 3;
+			val_component_type = Variant::FLOAT;
+		} break;
+		case Variant::VECTOR3I: {
+			val_component_count = 3;
+			val_component_type = Variant::INT;
+		} break;
+		case Variant::VECTOR4: {
+			val_component_count = 4;
+			val_component_type = Variant::FLOAT;
+		} break;
+		case Variant::VECTOR4I: {
+			val_component_count = 4;
+			val_component_type = Variant::INT;
+		} break;
+		default: {
+		} break;
+	}
+
+	if (val_component_type != component_type || val_component_count != component_count) {
+		r_error = vformat("Swizzling failed. Invalid assigned type: '%s'.", Variant::get_type_name(p_value.get_type()));
+		return false;
+	}
+
+	uint32_t s = variant_setters_getters[type].size();
+	if (!s) {
+		return false;
+	}
+
+	LocalVector<Variant> values;
+	for (uint64_t i = 0; i < p_value.get_indexed_size(); i++) {
+		bool valid;
+		bool oob;
+
+		values.push_back(p_value.get_indexed(i, valid, oob));
+		if (!valid || oob) {
+			return false;
+		}
+	}
+
+	for (int i = 0, k = 0; i < p_member.length(); i++) {
+		for (uint32_t j = 0; j < s; j++) {
+			if (variant_setters_getters_names[type][j] == String::chr(p_member[i])) {
+				const Variant val = values[k++];
+				bool valid;
+
+				variant_setters_getters[type][j].setter(this, &val, valid);
+				if (!valid) {
+					return false;
+				}
+			}
+		}
+	}
+	return true;
+}
+
+Variant Variant::get_swizzled(const StringName &p_member, bool &r_valid, bool &r_valid_type, String &r_error) const {
+	int component_count;
+	Variant::Type component_type;
+
+	if (!Variant::check_swizzling(false, type, p_member, component_count, component_type, r_valid_type, r_error)) {
+		r_valid = false;
+		return Variant();
+	}
+
+	uint32_t s = variant_setters_getters[type].size();
+	if (!s) {
+		return Variant();
+	}
+
+	LocalVector<Variant> values;
+	for (int i = 0; i < p_member.length(); i++) {
+		for (uint32_t j = 0; j < s; j++) {
+			if (variant_setters_getters_names[type][j] == String::chr(p_member[i])) {
+				Variant ret;
+				variant_setters_getters[type][j].getter(this, &ret);
+				values.push_back(ret);
+			}
+		}
+	}
+
+	Variant::Type new_var_type;
+	switch (values.size()) {
+		case 2:
+			switch (component_type) {
+				case Variant::FLOAT:
+					new_var_type = Variant::VECTOR2;
+					break;
+				case Variant::INT:
+					new_var_type = Variant::VECTOR2I;
+					break;
+				default:
+					return Variant();
+			}
+			break;
+		case 3:
+			switch (component_type) {
+				case Variant::FLOAT:
+					new_var_type = Variant::VECTOR3;
+					break;
+				case Variant::INT:
+					new_var_type = Variant::VECTOR3I;
+					break;
+				default:
+					return Variant();
+			}
+			break;
+		case 4:
+			switch (component_type) {
+				case Variant::FLOAT:
+					new_var_type = Variant::VECTOR4;
+					break;
+				case Variant::INT:
+					new_var_type = Variant::VECTOR4I;
+					break;
+				default:
+					return Variant();
+			}
+			break;
+		default:
+			return Variant();
+	}
+
+	LocalVector<const Variant *> value_pointers;
+	for (uint32_t i = 0; i < values.size(); i++) {
+		value_pointers.push_back(&(values.ptr()[i]));
+	}
+
+	Variant new_var;
+	Callable::CallError err;
+
+	Variant::construct(new_var_type, new_var, (const Variant **)value_pointers.ptr(), value_pointers.size(), err);
+	r_valid = true;
+
+	return new_var;
+}
+
 Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 	uint32_t s = variant_setters_getters[type].size();
 	if (s) {

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4007,6 +4007,58 @@ Ref<GDScript> GDScriptAnalyzer::get_depended_shallow_script(const String &p_path
 	return scr;
 }
 
+void GDScriptAnalyzer::reduce_swizzling(GDScriptParser::IdentifierNode *p_identifier, int p_component_count, Variant::Type p_component_type) {
+	const String name = (String)p_identifier->name;
+	Variant::Type type;
+
+	switch (p_component_count) {
+		case 2:
+			switch (p_component_type) {
+				case Variant::FLOAT:
+					type = Variant::VECTOR2;
+					break;
+				case Variant::INT:
+					type = Variant::VECTOR2I;
+					break;
+				default:
+					return;
+			}
+			break;
+		case 3:
+			switch (p_component_type) {
+				case Variant::FLOAT:
+					type = Variant::VECTOR3;
+					break;
+				case Variant::INT:
+					type = Variant::VECTOR3I;
+					break;
+				default:
+					return;
+			}
+			break;
+		case 4:
+			switch (p_component_type) {
+				case Variant::FLOAT:
+					type = Variant::VECTOR4;
+					break;
+				case Variant::INT:
+					type = Variant::VECTOR4I;
+					break;
+				default:
+					return;
+			}
+			break;
+		default:
+			return;
+	}
+
+	Callable::CallError err;
+	Variant value;
+
+	Variant::construct(type, value, nullptr, 0, err);
+	p_identifier->set_datatype(type_from_variant(value, nullptr, false));
+}
+
 void GDScriptAnalyzer::reduce_identifier_from_base_set_class(GDScriptParser::IdentifierNode *p_identifier, GDScriptParser::DataType p_identifier_datatype) {
 	ERR_FAIL_NULL(p_identifier);
 
@@ -4126,6 +4178,18 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 					if (Variant::has_builtin_method(base.builtin_type, name)) {
 						p_identifier->set_datatype(make_callable_type(Variant::get_builtin_method_info(base.builtin_type, name)));
 						return;
+					}
+
+					int component_count;
+					Variant::Type component_type;
+					bool valid_type;
+					String swizzle_error;
+
+					if (Variant::check_swizzling(false, base.builtin_type, name, component_count, component_type, valid_type, swizzle_error)) {
+						reduce_swizzling(p_identifier, component_count, component_type);
+						return;
+					} else if (valid_type) {
+						push_error(swizzle_error);
 					}
 					if (base.is_hard_type()) {
 #ifdef SUGGEST_GODOT4_RENAMES
@@ -5698,9 +5762,9 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_script(const Ref<Script> &p
 	return result;
 }
 
-GDScriptParser::DataType GDScriptAnalyzer::type_from_variant(const Variant &p_value, const GDScriptParser::Node *p_source) {
+GDScriptParser::DataType GDScriptAnalyzer::type_from_variant(const Variant &p_value, const GDScriptParser::Node *p_source, bool p_is_constant) {
 	GDScriptParser::DataType result;
-	result.is_constant = true;
+	result.is_constant = p_is_constant;
 	result.kind = GDScriptParser::DataType::BUILTIN;
 	result.builtin_type = p_value.get_type();
 	result.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT; // Constant has explicit type.

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -107,6 +107,7 @@ class GDScriptAnalyzer {
 	void reduce_get_node(GDScriptParser::GetNodeNode *p_get_node);
 	void reduce_identifier(GDScriptParser::IdentifierNode *p_identifier, bool can_be_builtin = false);
 	void reduce_identifier_from_base(GDScriptParser::IdentifierNode *p_identifier, GDScriptParser::DataType *p_base = nullptr);
+	void reduce_swizzling(GDScriptParser::IdentifierNode *p_identifier, int p_component_count, Variant::Type p_component_type);
 	void reduce_lambda(GDScriptParser::LambdaNode *p_lambda);
 	void reduce_literal(GDScriptParser::LiteralNode *p_literal);
 	void reduce_preload(GDScriptParser::PreloadNode *p_preload);
@@ -134,7 +135,7 @@ class GDScriptAnalyzer {
 	Array make_array_from_element_datatype(const GDScriptParser::DataType &p_element_datatype, const GDScriptParser::Node *p_source_node = nullptr);
 	Dictionary make_dictionary_from_element_datatype(const GDScriptParser::DataType &p_key_element_datatype, const GDScriptParser::DataType &p_value_element_datatype, const GDScriptParser::Node *p_source_node = nullptr);
 	GDScriptParser::DataType type_from_script(const Ref<Script> &p_script, const GDScriptParser::Node *p_source, bool p_is_meta_type);
-	GDScriptParser::DataType type_from_variant(const Variant &p_value, const GDScriptParser::Node *p_source);
+	GDScriptParser::DataType type_from_variant(const Variant &p_value, const GDScriptParser::Node *p_source, bool is_constant = true);
 	GDScriptParser::DataType type_from_property(const PropertyInfo &p_property, bool p_is_arg = false, bool p_is_readonly = false) const;
 	GDScriptParser::DataType make_global_class_meta_type(const StringName &p_class_name, const GDScriptParser::Node *p_source);
 	bool get_function_signature(GDScriptParser::Node *p_source, bool p_is_constructor, GDScriptParser::DataType base_type, const StringName &p_function, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, BitField<MethodFlags> &r_method_flags, StringName *r_native_class = nullptr);

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1209,20 +1209,30 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				bool valid;
 				dst->set_named(*index, *value, valid);
 
+				String swizzle_error;
+				bool valid_swizzle_type = false;
+
+				if (!valid) {
+					valid = dst->set_swizzled(*index, *value, valid_swizzle_type, swizzle_error);
+				}
 #ifdef DEBUG_ENABLED
 				if (!valid) {
 					if (dst->is_read_only()) {
 						err_text = "Invalid assignment on read-only value (on base: '" + _get_var_type(dst) + "').";
 					} else {
-						Object *obj = dst->get_validated_object();
-						bool read_only_property = false;
-						if (obj) {
-							read_only_property = ClassDB::has_property(obj->get_class_name(), *index) && (ClassDB::get_property_setter(obj->get_class_name(), *index) == StringName());
-						}
-						if (read_only_property) {
-							err_text = vformat(R"(Cannot set value into property "%s" (on base "%s") because it is read-only.)", String(*index), _get_var_type(dst));
+						if (valid_swizzle_type) {
+							err_text = swizzle_error;
 						} else {
-							err_text = "Invalid assignment of property or key '" + String(*index) + "' with value of type '" + _get_var_type(value) + "' on a base object of type '" + _get_var_type(dst) + "'.";
+							Object *obj = dst->get_validated_object();
+							bool read_only_property = false;
+							if (obj) {
+								read_only_property = ClassDB::has_property(obj->get_class_name(), *index) && (ClassDB::get_property_setter(obj->get_class_name(), *index) == StringName());
+							}
+							if (read_only_property) {
+								err_text = vformat(R"(Cannot set value into property "%s" (on base "%s") because it is read-only.)", String(*index), _get_var_type(dst));
+							} else {
+								err_text = "Invalid assignment of property or key '" + String(*index) + "' with value of type '" + _get_var_type(value) + "' on a base object of type '" + _get_var_type(dst) + "'.";
+							}
 						}
 					}
 					OPCODE_BREAK;
@@ -1259,16 +1269,31 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				const StringName *index = &_global_names_ptr[indexname];
 
 				bool valid;
+
+				String swizzle_error;
+				bool valid_swizzle_type = false;
+
 #ifdef DEBUG_ENABLED
 				//allow better error message in cases where src and dst are the same stack position
 				Variant ret = src->get_named(*index, valid);
 
+				if (!valid) {
+					ret = src->get_swizzled(*index, valid, valid_swizzle_type, swizzle_error);
+				}
 #else
 				*dst = src->get_named(*index, valid);
+
+				if (!valid) {
+					*dst = src->get_swizzled(*index, valid, valid_swizzle_type, swizzle_error);
+				}
 #endif
 #ifdef DEBUG_ENABLED
 				if (!valid) {
-					err_text = "Invalid access to property or key '" + index->operator String() + "' on a base object of type '" + _get_var_type(src) + "'.";
+					if (valid_swizzle_type) {
+						err_text = swizzle_error;
+					} else {
+						err_text = "Invalid access to property or key '" + index->operator String() + "' on a base object of type '" + _get_var_type(src) + "'.";
+					}
 					OPCODE_BREAK;
 				}
 				*dst = ret;

--- a/modules/gdscript/tests/scripts/analyzer/features/swizzling.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/swizzling.gd
@@ -1,0 +1,38 @@
+extends Node
+
+func test():
+    var v2 = Vector2(1, 2)
+
+    Utils.check(v2.xy == Vector2(1, 2))
+    Utils.check(v2.xx == Vector2(1, 1))
+    Utils.check(v2.yy == Vector2(2, 2))
+    Utils.check(v2.yx == Vector2(2, 1))
+
+    var v3 = Vector3(1, 2, 3)
+
+    Utils.check(v3.xyz == Vector3(1, 2, 3))
+    Utils.check(v3.xxx == Vector3(1, 1, 1))
+    Utils.check(v3.yyy == Vector3(2, 2, 2))
+    Utils.check(v3.zzz == Vector3(3, 3, 3))
+
+    Utils.check(v3.xyy == Vector3(1, 2, 2))
+    Utils.check(v3.yxy == Vector3(2, 1, 2))
+    Utils.check(v3.xxy == Vector3(1, 1, 2))
+    Utils.check(v3.xyx == Vector3(1, 2, 1))
+
+    Utils.check(v3.zyy == Vector3(3, 2, 2))
+    Utils.check(v3.yzy == Vector3(2, 3, 2))
+    Utils.check(v3.zzy == Vector3(3, 3, 2))
+    Utils.check(v3.zyz == Vector3(3, 2, 3))
+
+    Utils.check(v3.zxx == Vector3(3, 1, 1))
+    Utils.check(v3.xzx == Vector3(1, 3, 1))
+    Utils.check(v3.zzx == Vector3(3, 3, 1))
+    Utils.check(v3.zxz == Vector3(3, 1, 3))
+
+    Utils.check(v3.zyx == Vector3(3, 2, 1))
+    Utils.check(v3.xzy == Vector3(1, 3, 2))
+    Utils.check(v3.yzx == Vector3(2, 3, 1))
+    Utils.check(v3.yxz == Vector3(2, 1, 3))
+
+    print('ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/swizzling.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/swizzling.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok


### PR DESCRIPTION
My attempt to implement vector's swizzling. Compared to (https://github.com/godotengine/godot/pull/93012 or https://github.com/godotengine/godot/pull/51165) it does not spawn additional properties and processed through internal Variant API. It works as it is with all vectors.

<img width="1884" height="899" alt="изображение" src="https://github.com/user-attachments/assets/112c8d52-676b-4afc-95fb-af19fe5368a3" />

Things like v.xxxx also possible (only for getters):

<img width="1895" height="915" alt="изображение" src="https://github.com/user-attachments/assets/e204dc93-7501-409f-b7bb-1c67e249ed59" />

It does not support autocompletion - this must be created in a separate PR.
Closes https://github.com/godotengine/godot-proposals/issues/727