### PR TITLE
Improve `get_tab_control()` in TabContainer

### DIFF
--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -124,6 +124,7 @@ private:
 	HashMap<Node *, RID> tab_panels;
 
 	int _get_tab_height() const;
+	Control *_as_tab_control(Node *p_child) const;
 	Vector<Control *> _get_tab_controls() const;
 	void _on_theme_changed();
 	void _repaint();


### PR DESCRIPTION
The TabContainer used `_get_tab_controls()` internally to get a tab control at index. The problem is that this method creates and returns a Vector of all tab controls, which is not needed if you want to find just one tab. This PR improves the method by repeating what `_get_tab_controls()` does, but simply returning the desired Control instead of making a Vector 🙃

`get_tab_idx_from_control()` had the same problem, so I changed it the same way. I also added a helper method to "convert" a child Node to a tab Control (similar to `as_sortable_control()`).