### PR TITLE
Tweak ObjectDB instance leak warning message to mention object count

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2641,7 +2641,7 @@ void ObjectDB::cleanup() {
 	spin_lock.lock();
 
 	if (slot_count > 0) {
-		WARN_PRINT("ObjectDB instances leaked at exit (run with --verbose for details).");
+		WARN_PRINT(vformat("%d ObjectDB %s leaked at exit (run with `--verbose` for details).", slot_count, slot_count == 1 ? "instance was" : "instances were"));
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			// Ensure calling the native classes because if a leaked instance has a script
 			// that overrides any of those methods, it'd not be OK to call them at this point,

--- a/misc/scripts/check_ci_log.py
+++ b/misc/scripts/check_ci_log.py
@@ -46,7 +46,10 @@ if file_contents.find("ERROR: LeakSanitizer:") != -1:
 # this possibility should also be handled as a potential error, even if
 # LeakSanitizer doesn't report anything
 
-if file_contents.find("ObjectDB instances leaked at exit") != -1:
+if (
+    file_contents.find("ObjectDB instance was leaked at exit") != -1
+    or file_contents.find("ObjectDB instances were leaked at exit") != -1
+):
     print("ERROR: Memory leak was found")
     sys.exit(54)
 


### PR DESCRIPTION
This helps assess how important the situation is to resolve for project developers, without having to run the project with `--verbose` again.

I had the idea for this while testing https://github.com/godotengine/godot/issues/84860.

## Preview

```
WARNING: 1 ObjectDB instance was leaked at exit (run with `--verbose` for details).
     at: cleanup (./core/object/object.cpp:2644)
```

```
WARNING: 2830 ObjectDB instances were leaked at exit (run with `--verbose` for details).
     at: cleanup (./core/object/object.cpp:2644)
```