### PR TITLE
[.NET] Implement [ExportStorage]

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ExportDiagnosticsTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ExportDiagnosticsTests.cs
@@ -111,4 +111,13 @@ public class ExportDiagnosticsTests
             new string[] { "ExportDiagnostics_GD0111_ScriptProperties.generated.cs" }
         );
     }
+
+    [Fact]
+    public async Task ExportAndExportStorageOnSameMember()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
+            new string[] { "ExportDiagnostics_GD0112.cs" },
+            new string[] { "ExportDiagnostics_GD0112_ScriptProperties.generated.cs" }
+        );
+    }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPropertiesGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/ScriptPropertiesGeneratorTests.cs
@@ -76,4 +76,13 @@ public class ScriptPropertiesGeneratorTests
             "ExportedToolButtons_ScriptProperties.generated.cs"
         );
     }
+
+    [Fact]
+    public async Task ExportedStorage()
+    {
+        await CSharpSourceGeneratorVerifier<ScriptPropertiesGenerator>.Verify(
+            "ExportedStorage.cs",
+            "ExportedStorage_ScriptProperties.generated.cs"
+        );
+    }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,5 @@
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+GD0112  |  Usage   |  Error   | ScriptPropertiesGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0112.html)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
@@ -119,12 +119,12 @@ namespace Godot.SourceGenerators
 
         public static readonly DiagnosticDescriptor ExportToolButtonShouldNotBeUsedWithExportRule =
             new DiagnosticDescriptor(id: "GD0109",
-                title: "The '[ExportToolButton]' attribute cannot be used with another '[Export]' attribute",
-                messageFormat: "The '[ExportToolButton]' attribute cannot be used with another '[Export]' attribute on '{0}'",
+                title: "The '[ExportToolButton]' attribute cannot be used with another '[Export]' or '[ExportStorage]' attribute",
+                messageFormat: "The '[ExportToolButton]' attribute cannot be used with another '[Export]' or '[ExportStorage]' attribute on '{0}'",
                 category: "Usage",
                 DiagnosticSeverity.Error,
                 isEnabledByDefault: true,
-                "The '[ExportToolButton]' attribute cannot be used with the '[Export]' attribute. Remove one of the attributes.",
+                "The '[ExportToolButton]' attribute cannot be used with the '[Export]' or '[ExportStorage]' attribute. Remove one of the attributes.",
                 helpLinkUri: string.Format(_helpLinkFormat, "GD0109"));
 
         public static readonly DiagnosticDescriptor ExportToolButtonIsNotCallableRule =
@@ -146,6 +146,16 @@ namespace Godot.SourceGenerators
                 isEnabledByDefault: true,
                 "The exported tool button must be an expression-bodied property. The '[ExportToolButton]' attribute is only supported on expression-bodied properties with a 'new Callable(...)' or 'Callable.From(...)' expression.",
                 helpLinkUri: string.Format(_helpLinkFormat, "GD0111"));
+
+        public static readonly DiagnosticDescriptor ExportStorageShouldNotBeUsedWithExportRule =
+            new DiagnosticDescriptor(id: "GD0112",
+                title: "The '[ExportStorage]' attribute cannot be used with another '[Export]' attribute",
+                messageFormat: "The '[ExportStorage]' attribute cannot be used with another '[Export]' attribute on '{0}'",
+                category: "Usage",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                "The '[ExportStorage]' attribute cannot be used with the '[Export]' attribute. Remove one of the attributes.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GD0112"));
 
         public static readonly DiagnosticDescriptor SignalDelegateMissingSuffixRule =
             new DiagnosticDescriptor(id: "GD0201",

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -290,6 +290,9 @@ namespace Godot.SourceGenerators
         public static bool IsGodotGlobalClassAttribute(this INamedTypeSymbol symbol)
             => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.GlobalClassAttr;
 
+        public static bool IsGodotExportStorageAttribute(this INamedTypeSymbol symbol)
+            => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.ExportStorageAttr;
+
         public static bool IsGodotExportToolButtonAttribute(this INamedTypeSymbol symbol)
             => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.ExportToolButtonAttr;
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
@@ -7,6 +7,7 @@ namespace Godot.SourceGenerators
         public const string Callable = "Godot.Callable";
         public const string AssemblyHasScriptsAttr = "Godot.AssemblyHasScriptsAttribute";
         public const string ExportAttr = "Godot.ExportAttribute";
+        public const string ExportStorageAttr = "Godot.ExportStorageAttribute";
         public const string ExportCategoryAttr = "Godot.ExportCategoryAttribute";
         public const string ExportGroupAttr = "Godot.ExportGroupAttribute";
         public const string ExportSubgroupAttr = "Godot.ExportSubgroupAttribute";

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -430,13 +430,26 @@ namespace Godot.SourceGenerators
             var exportAttr = memberSymbol.GetAttributes()
                 .FirstOrDefault(a => a.AttributeClass?.IsGodotExportAttribute() ?? false);
 
+            var exportStorageAttr = memberSymbol.GetAttributes()
+                .FirstOrDefault(a => a.AttributeClass?.IsGodotExportStorageAttribute() ?? false);
+
             var exportToolButtonAttr = memberSymbol.GetAttributes()
                 .FirstOrDefault(a => a.AttributeClass?.IsGodotExportToolButtonAttribute() ?? false);
 
-            if (exportAttr != null && exportToolButtonAttr != null)
+            if ((exportAttr != null || exportStorageAttr != null) && exportToolButtonAttr != null)
             {
                 context.ReportDiagnostic(Diagnostic.Create(
                     Common.ExportToolButtonShouldNotBeUsedWithExportRule,
+                    memberSymbol.Locations.FirstLocationWithSourceTreeOrDefault(),
+                    memberSymbol.ToDisplayString()
+                ));
+                return null;
+            }
+
+            if (exportAttr != null && exportStorageAttr != null)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Common.ExportStorageShouldNotBeUsedWithExportRule,
                     memberSymbol.Locations.FirstLocationWithSourceTreeOrDefault(),
                     memberSymbol.ToDisplayString()
                 ));
@@ -586,11 +599,15 @@ namespace Godot.SourceGenerators
                     hintString: hintString, PropertyUsageFlags.Editor, exported: true);
             }
 
-            if (exportAttr == null)
+            if (exportAttr == null && exportStorageAttr == null)
             {
                 return new PropertyInfo(memberVariantType, memberName, PropertyHint.None,
                     hintString: hintString, PropertyUsageFlags.ScriptVariable, exported: false);
             }
+
+            //Treat [ExportStorage] like an [Export] since the only difference is the PropertyUsageFlags having
+            // PropertyUsageFlags.Storage instead of PropertyUsageFlags.Default
+            exportAttr = exportAttr ?? exportStorageAttr!;
 
             if (!TryGetMemberExportHint(typeCache, memberType, exportAttr, memberVariantType,
                     isTypeArgument: false, out var hint, out hintString))
@@ -619,6 +636,11 @@ namespace Godot.SourceGenerators
             }
 
             var propUsage = PropertyUsageFlags.Default | PropertyUsageFlags.ScriptVariable;
+
+            if (exportStorageAttr != null)
+            {
+                propUsage = PropertyUsageFlags.Storage | PropertyUsageFlags.ScriptVariable;
+            }
 
             if (memberVariantType == VariantType.Nil)
                 propUsage |= PropertyUsageFlags.NilIsVariant;

--- a/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportDiagnostics_GD0112_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportDiagnostics_GD0112_ScriptProperties.generated.cs
@@ -1,0 +1,48 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial class ExportDiagnostics_GD0112
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.
+    /// </summary>
+    public new class PropertyName : global::Godot.Node.PropertyName {
+        /// <summary>
+        /// Cached name for the 'MyBool' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName @MyBool = "MyBool";
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    {
+        if (name == PropertyName.@MyBool) {
+            this.@MyBool = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            return true;
+        }
+        return base.SetGodotClassPropertyValue(name, value);
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    {
+        if (name == PropertyName.@MyBool) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.@MyBool);
+            return true;
+        }
+        return base.GetGodotClassPropertyValue(name, out value);
+    }
+    /// <summary>
+    /// Get the property information for all the properties declared in this class.
+    /// This method is used by Godot to register the available properties in the editor.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo> GetGodotPropertyList()
+    {
+        var properties = new global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>();
+        return properties;
+    }
+#pragma warning restore CS0109
+}

--- a/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportStorage_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportStorage_ScriptProperties.generated.cs
@@ -1,0 +1,49 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial class ExportStorage
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.
+    /// </summary>
+    public new class PropertyName : global::Godot.Node.PropertyName {
+        /// <summary>
+        /// Cached name for the 'ExportStorageField' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName @ExportStorageField = "ExportStorageField";
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    {
+        if (name == PropertyName.@ExportStorageField) {
+            this.@ExportStorageField = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            return true;
+        }
+        return base.SetGodotClassPropertyValue(name, value);
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    {
+        if (name == PropertyName.@ExportStorageField) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.@ExportStorageField);
+            return true;
+        }
+        return base.GetGodotClassPropertyValue(name, out value);
+    }
+    /// <summary>
+    /// Get the property information for all the properties declared in this class.
+    /// This method is used by Godot to register the available properties in the editor.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo> GetGodotPropertyList()
+    {
+        var properties = new global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>();
+        properties.Add(new(type: (global::Godot.Variant.Type)1, name: PropertyName.@ExportStorageField, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4098, exported: true));
+        return properties;
+    }
+#pragma warning restore CS0109
+}

--- a/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportDiagnostics_GD0112.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportDiagnostics_GD0112.cs
@@ -1,0 +1,8 @@
+using Godot;
+using System;
+
+public partial class ExportDiagnostics_GD0112 : Node
+{
+    [Export, ExportStorage]
+    private Boolean {|GD0112:MyBool|} = true;
+}

--- a/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportStorage.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportStorage.cs
@@ -1,0 +1,8 @@
+using Godot;
+using System;
+
+public partial class ExportStorage : Node
+{
+    [ExportStorage]
+    private Boolean ExportStorageField = true;
+}

--- a/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportDiagnostics_GD0112_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportDiagnostics_GD0112_ScriptProperties.generated.cs
@@ -1,0 +1,48 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial class ExportDiagnostics_GD0112
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.
+    /// </summary>
+    public new class PropertyName : global::Godot.Node.PropertyName {
+        /// <summary>
+        /// Cached name for the 'MyBool' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName @MyBool = "MyBool";
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    {
+        if (name == PropertyName.@MyBool) {
+            this.@MyBool = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            return true;
+        }
+        return base.SetGodotClassPropertyValue(name, value);
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    {
+        if (name == PropertyName.@MyBool) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.@MyBool);
+            return true;
+        }
+        return base.GetGodotClassPropertyValue(name, out value);
+    }
+    /// <summary>
+    /// Get the property information for all the properties declared in this class.
+    /// This method is used by Godot to register the available properties in the editor.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo> GetGodotPropertyList()
+    {
+        var properties = new global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>();
+        return properties;
+    }
+#pragma warning restore CS0109
+}

--- a/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportStorage_ScriptProperties.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/ExportStorage_ScriptProperties.generated.cs
@@ -1,0 +1,49 @@
+using Godot;
+using Godot.NativeInterop;
+
+partial class ExportStorage
+{
+#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    /// <summary>
+    /// Cached StringNames for the properties and fields contained in this class, for fast lookup.
+    /// </summary>
+    public new class PropertyName : global::Godot.Node.PropertyName {
+        /// <summary>
+        /// Cached name for the 'ExportStorageField' field.
+        /// </summary>
+        public new static readonly global::Godot.StringName @ExportStorageField = "ExportStorageField";
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    {
+        if (name == PropertyName.@ExportStorageField) {
+            this.@ExportStorageField = global::Godot.NativeInterop.VariantUtils.ConvertTo<bool>(value);
+            return true;
+        }
+        return base.SetGodotClassPropertyValue(name, value);
+    }
+    /// <inheritdoc/>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    protected override bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    {
+        if (name == PropertyName.@ExportStorageField) {
+            value = global::Godot.NativeInterop.VariantUtils.CreateFrom<bool>(this.@ExportStorageField);
+            return true;
+        }
+        return base.GetGodotClassPropertyValue(name, out value);
+    }
+    /// <summary>
+    /// Get the property information for all the properties declared in this class.
+    /// This method is used by Godot to register the available properties in the editor.
+    /// Do not call this method.
+    /// </summary>
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal new static global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo> GetGodotPropertyList()
+    {
+        var properties = new global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>();
+        properties.Add(new(type: (global::Godot.Variant.Type)1, name: PropertyName.@ExportStorageField, hint: (global::Godot.PropertyHint)0, hintString: "", usage: (global::Godot.PropertyUsageFlags)4098, exported: true));
+        return properties;
+    }
+#pragma warning restore CS0109
+}

--- a/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportDiagnostics_GD0112.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportDiagnostics_GD0112.cs
@@ -1,0 +1,8 @@
+using Godot;
+using System;
+
+public partial class ExportDiagnostics_GD0112 : Node
+{
+    [Export, ExportStorage]
+    private Boolean {|GD0112:MyBool|} = true;
+}

--- a/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportStorage.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/ExportStorage.cs
@@ -1,0 +1,8 @@
+using Godot;
+using System;
+
+public partial class ExportStorage : Node
+{
+    [ExportStorage]
+    private Boolean ExportStorageField = true;
+}

--- a/modules/mono/editor/Godot.NET.Sdk/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportStorageAttribute.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportStorageAttribute.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Godot
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class ExportStorageAttribute : Attribute
+    {
+        public PropertyHint Hint { get; }
+
+        public string HintString { get; }
+
+        public ExportStorageAttribute(PropertyHint hint = PropertyHint.None, string hintString = "")
+        {
+            Hint = hint;
+            HintString = hintString;
+        }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportStorageAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportStorageAttribute.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Godot
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class ExportStorageAttribute : Attribute
+    {
+        public PropertyHint Hint { get; }
+
+        public string HintString { get; }
+
+        public ExportStorageAttribute(PropertyHint hint = PropertyHint.None, string hintString = "")
+        {
+            Hint = hint;
+            HintString = hintString;
+        }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -55,6 +55,7 @@
   <!-- Sources -->
   <ItemGroup>
     <Compile Include="Core\Aabb.cs" />
+    <Compile Include="Core\Attributes\ExportStorageAttribute.cs" />
     <Compile Include="Core\Attributes\ExportToolButtonAttribute.cs" />
     <Compile Include="Core\Bridge\GodotSerializationInfo.cs" />
     <Compile Include="Core\Bridge\MethodInfo.cs" />


### PR DESCRIPTION
I based this PR mostly on #97894 

I am unsure about this Line in `modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs`:
```C#
//Treat [ExportStorage] like an [Export] since the only difference is the PropertyUsageFlags having
// PropertyUsageFlags.Storage instead of PropertyUsageFlags.Default
exportAttr = exportAttr ?? exportStorageAttr!;
```
But the check for [Export] and [ExportStorage] being on the same variable has already been done so this _should_ be fine.

Also since I'm new to making PRs, I tried asking in the Rocket Chat about how I should go on about adding a PR and specifically this to Godot, but got no Answer so I went ahead with my own judgement.