### PR TITLE
Move `windows.h` includes to wrapper with `WIN32_LEAN_AND_MEAN` and undefs

### DIFF
--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -127,19 +127,6 @@ static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
 #define _ALLOW_DISCARD_ (void)
 #endif
 
-// Windows badly defines a lot of stuff we'll never use. Undefine it.
-#ifdef _WIN32
-#undef min // override standard definition
-#undef max // override standard definition
-#undef ERROR // override (really stupid) wingdi.h standard definition
-#undef DELETE // override (another really stupid) winnt.h standard definition
-#undef MessageBox // override winuser.h standard definition
-#undef Error
-#undef OK
-#undef CONNECT_DEFERRED // override from Windows SDK, clashes with Object enum
-#undef MONO_FONT
-#endif
-
 // Make room for our constexpr's below by overriding potential system-specific macros.
 #undef SIGN
 #undef MIN

--- a/drivers/d3d12/dxil_hash.h
+++ b/drivers/d3d12/dxil_hash.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 
 void compute_dxil_hash(const BYTE *pData, UINT byteCount, BYTE *pOutHash);

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -39,8 +39,8 @@
 
 #include <audioclient.h>
 #include <mmdeviceapi.h>
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+
+#include "drivers/windows/windows_inc.h"
 
 class AudioDriverWASAPI : public AudioDriver {
 	class AudioDeviceWASAPI {

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -40,8 +40,8 @@
 
 #include <cstdio>
 #include <cwchar>
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+
+#include "drivers/windows/windows_inc.h"
 
 typedef struct _NT_IO_STATUS_BLOCK {
 	union {

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -38,8 +38,8 @@
 
 #include <share.h> // _SH_DENYNO
 #include <shlwapi.h>
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+
+#include "drivers/windows/windows_inc.h"
 
 #include <io.h>
 #include <sys/stat.h>

--- a/drivers/windows/file_access_windows_pipe.h
+++ b/drivers/windows/file_access_windows_pipe.h
@@ -35,8 +35,7 @@
 #include "core/io/file_access.h"
 #include "core/os/memory.h"
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 
 class FileAccessWindowsPipe : public FileAccess {
 	GDSOFTCLASS(FileAccessWindowsPipe, FileAccess);

--- a/drivers/windows/ip_windows.cpp
+++ b/drivers/windows/ip_windows.cpp
@@ -32,8 +32,8 @@
 
 #include "ip_windows.h"
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
+
 #include <winsock2.h>
 #include <ws2tcpip.h>
 

--- a/drivers/windows/windows_inc.h
+++ b/drivers/windows/windows_inc.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  thread_windows.cpp                                                    */
+/*  windows_inc.h                                                         */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,31 +28,18 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifdef WINDOWS_ENABLED
+#pragma once
 
-#include "thread_windows.h"
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
 
-#include "core/os/thread.h"
-#include "core/string/ustring.h"
-
-#include "drivers/windows/windows_inc.h"
-
-typedef HRESULT(WINAPI *SetThreadDescriptionPtr)(HANDLE p_thread, PCWSTR p_thread_description);
-SetThreadDescriptionPtr w10_SetThreadDescription = nullptr;
-
-static Error set_name(const String &p_name) {
-	HANDLE hThread = GetCurrentThread();
-	HRESULT res = E_FAIL;
-	if (w10_SetThreadDescription) {
-		res = w10_SetThreadDescription(hThread, (LPCWSTR)p_name.utf16().get_data()); // Windows 10 Redstone (1607) only.
-	}
-	return SUCCEEDED(res) ? OK : ERR_INVALID_PARAMETER;
-}
-
-void init_thread_win() {
-	w10_SetThreadDescription = (SetThreadDescriptionPtr)(void *)GetProcAddress(LoadLibraryW(L"kernel32.dll"), "SetThreadDescription");
-
-	Thread::_set_platform_functions({ set_name });
-}
-
-#endif // WINDOWS_ENABLED
+// windows.h badly defines macros that clash with our own or types/enums.
+#undef min // minwindef.h
+#undef max // minwindef.h
+#undef ERROR // wingdi.h
+#undef DELETE // winnt.h
+#undef MessageBox // winuser.h
+#undef CONNECT_DEFERRED // winnetwk.h
+#undef MONO_FONT // wingdi.h

--- a/drivers/winmidi/midi_driver_winmidi.h
+++ b/drivers/winmidi/midi_driver_winmidi.h
@@ -36,8 +36,8 @@
 #include "core/templates/vector.h"
 
 #include <cstdio>
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+
+#include "drivers/windows/windows_inc.h"
 
 #include <mmsystem.h>
 

--- a/drivers/xaudio2/audio_driver_xaudio2.h
+++ b/drivers/xaudio2/audio_driver_xaudio2.h
@@ -36,8 +36,9 @@
 #include "servers/audio/audio_server.h"
 
 #include <mmsystem.h>
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+
+#include "drivers/windows/windows_inc.h"
+
 #include <wrl/client.h>
 #include <xaudio2.h>
 

--- a/editor/shader/shader_baker/shader_baker_export_plugin_platform_d3d12.cpp
+++ b/editor/shader/shader_baker/shader_baker_export_plugin_platform_d3d12.cpp
@@ -32,7 +32,7 @@
 
 #include "drivers/d3d12/rendering_shader_container_d3d12.h"
 
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 
 RenderingShaderContainerFormat *ShaderBakerExportPluginPlatformD3D12::create_shader_container_format(const Ref<EditorExportPlatform> &p_platform, const Ref<EditorExportPreset> &p_preset) {
 	if (lib_d3d12 == nullptr) {

--- a/modules/mono/editor/hostfxr_resolver.cpp
+++ b/modules/mono/editor/hostfxr_resolver.cpp
@@ -69,8 +69,7 @@ SOFTWARE.
 #include "core/os/os.h"
 
 #ifdef WINDOWS_ENABLED
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 #endif
 
 // We don't use libnethost as it gives us issues with some compilers.

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -38,8 +38,7 @@
 #include <cstdlib>
 
 #ifdef WINDOWS_ENABLED
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 
 #define ENV_PATH_SEP ";"
 #else

--- a/modules/openxr/editor/openxr_select_runtime.cpp
+++ b/modules/openxr/editor/openxr_select_runtime.cpp
@@ -31,8 +31,7 @@
 #include "openxr_select_runtime.h"
 
 #ifdef WINDOWS_ENABLED
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 #endif
 
 #include "core/io/dir_access.h"

--- a/modules/openxr/openxr_platform_inc.h
+++ b/modules/openxr/openxr_platform_inc.h
@@ -80,7 +80,7 @@
 #ifdef WINDOWS_ENABLED
 // Including windows.h here is absolutely evil, we shouldn't be doing this outside of platform
 // however due to the way the openxr headers are put together, we have no choice.
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 #endif // WINDOWS_ENABLED
 
 #ifdef ANDROID_ENABLED

--- a/platform/windows/console_wrapper_windows.cpp
+++ b/platform/windows/console_wrapper_windows.cpp
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 
 #include <shlwapi.h>
 #include <cstdio>

--- a/platform/windows/cpu_feature_validation.c
+++ b/platform/windows/cpu_feature_validation.c
@@ -28,7 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
+
 #ifdef _MSC_VER
 #include <intrin.h> // For builtin __cpuid.
 #else

--- a/platform/windows/crash_handler_windows.h
+++ b/platform/windows/crash_handler_windows.h
@@ -30,8 +30,7 @@
 
 #pragma once
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 
 // Crash handler exception only enabled with MSVC
 #if defined(DEBUG_ENABLED)

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -63,9 +63,9 @@
 #include <io.h>
 #include <cstdio>
 
-#define WIN32_LEAN_AND_MEAN
+#include "drivers/windows/windows_inc.h"
+
 #include <shobjidl.h>
-#include <windows.h>
 #include <windowsx.h>
 
 // WinTab API

--- a/platform/windows/gl_manager_windows_angle.h
+++ b/platform/windows/gl_manager_windows_angle.h
@@ -37,7 +37,7 @@
 #include "drivers/egl/egl_manager.h"
 #include "servers/display/display_server.h"
 
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 
 class GLManagerANGLE_Windows : public EGLManager {
 private:

--- a/platform/windows/gl_manager_windows_native.h
+++ b/platform/windows/gl_manager_windows_native.h
@@ -37,7 +37,7 @@
 #include "core/templates/rb_map.h"
 #include "servers/display/display_server.h"
 
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 
 typedef bool(APIENTRY *PFNWGLSWAPINTERVALEXTPROC)(int interval);
 typedef int(APIENTRY *PFNWGLGETSWAPINTERVALEXTPROC)(void);

--- a/platform/windows/key_mapping_windows.h
+++ b/platform/windows/key_mapping_windows.h
@@ -32,8 +32,8 @@
 
 #include "core/os/keyboard.h"
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
+
 #include <winuser.h>
 
 class KeyMappingWindows {

--- a/platform/windows/native_menu_windows.h
+++ b/platform/windows/native_menu_windows.h
@@ -35,8 +35,7 @@
 #include "core/templates/rid_owner.h"
 #include "servers/display/native_menu.h"
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 
 class NativeMenuWindows : public NativeMenu {
 	GDCLASS(NativeMenuWindows, NativeMenu)

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -49,10 +49,10 @@
 #include <shellapi.h>
 #include <cstdio>
 
-#define WIN32_LEAN_AND_MEAN
+#include "drivers/windows/windows_inc.h"
+
 #include <dwrite.h>
 #include <dwrite_2.h>
-#include <windows.h>
 #include <windowsx.h>
 
 #ifdef DEBUG_ENABLED

--- a/platform/windows/rendering_context_driver_vulkan_windows.h
+++ b/platform/windows/rendering_context_driver_vulkan_windows.h
@@ -34,8 +34,7 @@
 
 #include "drivers/vulkan/rendering_context_driver_vulkan.h"
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 
 class RenderingContextDriverVulkanWindows : public RenderingContextDriverVulkan {
 private:

--- a/platform/windows/tts_windows.h
+++ b/platform/windows/tts_windows.h
@@ -41,8 +41,7 @@
 #include <winnls.h>
 #include <cwchar>
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 
 class TTS_Windows {
 	List<DisplayServer::TTSUtterance> queue;

--- a/platform/windows/wgl_detect_version.cpp
+++ b/platform/windows/wgl_detect_version.cpp
@@ -31,13 +31,14 @@
 #if defined(WINDOWS_ENABLED) && defined(GLES3_ENABLED)
 
 #include "wgl_detect_version.h"
+
 #include "os_windows.h"
 
 #include "core/string/print_string.h"
 #include "core/string/ustring.h"
 #include "core/variant/dictionary.h"
 
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 
 #include <dwmapi.h>
 #include <cstdio>

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -30,15 +30,14 @@
 
 #include "windows_terminal_logger.h"
 
+#ifdef WINDOWS_ENABLED
+
 #include "core/object/script_backtrace.h"
 #include "core/os/os.h"
 
-#ifdef WINDOWS_ENABLED
-
 #include <cstdio>
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 
 void WindowsTerminalLogger::logv(const char *p_format, va_list p_list, bool p_err) {
 	if (!should_log(p_err)) {

--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -36,9 +36,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#undef FAILED // Overrides Error::FAILED
+#include "drivers/windows/windows_inc.h"
 
 // dbghelp is linked only in DEBUG_ENABLED builds.
 #ifdef DEBUG_ENABLED

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -408,6 +408,7 @@ a new version of the web instance.
 Patches:
 
 - `0001-enable-both-gl-and-gles.patch` ([GH-72831](https://github.com/godotengine/godot/pull/72831))
+- `0002-egl-windows-inc.patch` ([GH-116690](https://github.com/godotengine/godot/pull/116690))
 
 
 ## glslang

--- a/thirdparty/glad/EGL/eglplatform.h
+++ b/thirdparty/glad/EGL/eglplatform.h
@@ -55,10 +55,7 @@ typedef void *EGLNativePixmapType;
 typedef void *EGLNativeWindowType;
 
 #elif defined(_WIN32) || defined(__VC32__) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__) /* Win32 and WinCE */
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN 1
-#endif
-#include <windows.h>
+#include "drivers/windows/windows_inc.h"
 
 typedef HDC     EGLNativeDisplayType;
 typedef HBITMAP EGLNativePixmapType;

--- a/thirdparty/glad/patches/0002-egl-windows-inc.patch
+++ b/thirdparty/glad/patches/0002-egl-windows-inc.patch
@@ -1,0 +1,16 @@
+diff --git a/thirdparty/glad/EGL/eglplatform.h b/thirdparty/glad/EGL/eglplatform.h
+index 6786afd90b..912e3927c1 100644
+--- a/thirdparty/glad/EGL/eglplatform.h
++++ b/thirdparty/glad/EGL/eglplatform.h
+@@ -55,10 +55,7 @@ typedef void *EGLNativePixmapType;
+ typedef void *EGLNativeWindowType;
+ 
+ #elif defined(_WIN32) || defined(__VC32__) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__) /* Win32 and WinCE */
+-#ifndef WIN32_LEAN_AND_MEAN
+-#define WIN32_LEAN_AND_MEAN 1
+-#endif
+-#include <windows.h>
++#include "drivers/windows/windows_inc.h"
+ 
+ typedef HDC     EGLNativeDisplayType;
+ typedef HBITMAP EGLNativePixmapType;


### PR DESCRIPTION
Extracted from #116454 and reworked as discussed with @bruvzg.

In the end I also patched glad to remove the unchecked `windows.h` include that pollutes files including EGL.

Note that the same file exists in the ANGLE headers, I didn't patch it here as it didn't seem necessary to build, but I could do it.