### PR TITLE
Windows: Add `windows.h` drop-in wrapper header

### DIFF
--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -127,19 +127,6 @@ static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
 #define _ALLOW_DISCARD_ (void)
 #endif
 
-// Windows badly defines a lot of stuff we'll never use. Undefine it.
-#ifdef _WIN32
-#undef min // override standard definition
-#undef max // override standard definition
-#undef ERROR // override (really stupid) wingdi.h standard definition
-#undef DELETE // override (another really stupid) winnt.h standard definition
-#undef MessageBox // override winuser.h standard definition
-#undef Error
-#undef OK
-#undef CONNECT_DEFERRED // override from Windows SDK, clashes with Object enum
-#undef MONO_FONT
-#endif
-
 // Make room for our constexpr's below by overriding potential system-specific macros.
 #undef SIGN
 #undef MIN

--- a/platform/windows/windows.h
+++ b/platform/windows/windows.h
@@ -1,0 +1,54 @@
+/**************************************************************************/
+/*  windows.h                                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#ifdef _MSC_VER
+// HACK: MSVC lacks an `include_next` equivalent, so we'll instead utilize the relative path of
+//  the system include by going up one directory and immediately returning.
+#include <../um/windows.h>
+#else
+#include_next <windows.h>
+#endif
+
+// windows.h badly defines macros that clash with our own or types/enums.
+#undef ERROR // wingdi.h
+#undef DELETE // winnt.h
+#undef MessageBox // winuser.h
+#undef CONNECT_DEFERRED // winnetwk.h
+#undef MONO_FONT // wingdi.h


### PR DESCRIPTION
- Alternative to #116690

This is an idea I had entirely on a whim and everything seems to be functioning? So I'm just rolling with it and putting up this PR to see what happens

This PR leverages `#include_next` for clang/gcc and relative-path shenanigans for msvc, in order to allow a `windows.h` file added to `platforms/windows/` to function as the "real" `windows.h` for *the entire repository*. This means that those includes, even for thirdparties, will always have the dumb windows macros disabled & guarantees the lean-and-mean implementation

Frankly, I'm shocked this is working at all, let alone so well. It feels like cheating.