### PR TITLE
Fix GLSL shader include

### DIFF
--- a/doc/classes/ResourceImporterShaderFile.xml
+++ b/doc/classes/ResourceImporterShaderFile.xml
@@ -8,4 +8,8 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<members>
+		<member name="include_directories" type="Array" setter="" getter="" default="PackedStringArray()">
+		</member>
+	</members>
 </class>

--- a/editor/import/resource_importer_shader_file.cpp
+++ b/editor/import/resource_importer_shader_file.cpp
@@ -66,27 +66,11 @@ String ResourceImporterShaderFile::get_preset_name(int p_idx) const {
 }
 
 void ResourceImporterShaderFile::get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const {
+	r_options->push_back(ImportOption(PropertyInfo(Variant::ARRAY, "include_directories", PropertyHint::PROPERTY_HINT_TYPE_STRING, vformat("%d/%d:", Variant::STRING, PropertyHint::PROPERTY_HINT_DIR)), PackedStringArray()));
 }
 
 bool ResourceImporterShaderFile::get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const {
 	return true;
-}
-
-static String _include_function(const String &p_path, void *userpointer) {
-	Error err;
-
-	String *base_path = (String *)userpointer;
-
-	String include = p_path;
-	if (include.is_relative_path()) {
-		include = base_path->path_join(include);
-	}
-
-	Ref<FileAccess> file_inc = FileAccess::open(include, FileAccess::READ, &err);
-	if (err != OK) {
-		return String();
-	}
-	return file_inc->get_as_utf8_string();
 }
 
 Error ResourceImporterShaderFile::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
@@ -98,8 +82,18 @@ Error ResourceImporterShaderFile::import(ResourceUID::ID p_source_id, const Stri
 	String file_txt = file->get_as_utf8_string();
 	Ref<RDShaderFile> shader_file;
 	shader_file.instantiate();
-	String base_path = p_source_file.get_base_dir();
-	err = shader_file->parse_versions_from_text(file_txt, "", _include_function, &base_path);
+
+	TypedArray<String> option_include_directories = p_options["include_directories"];
+
+	Vector<String> include_directories;
+	include_directories.resize(option_include_directories.size());
+
+	for (int i = 0; i < option_include_directories.size(); ++i) {
+		String dir = option_include_directories[i];
+		include_directories.set(i, dir);
+	}
+
+	err = shader_file->parse_versions_from_text(file_txt, "", p_source_file, include_directories);
 
 	if (err != OK) {
 		if (!ShaderFileEditor::singleton->is_visible_in_tree()) {

--- a/modules/glslang/register_types.cpp
+++ b/modules/glslang/register_types.cpp
@@ -33,6 +33,7 @@
 #include "shader_compile.h"
 
 #include "core/config/engine.h"
+#include "core/io/file_access.h"
 
 #ifdef D3D12_ENABLED
 #include "core/os/os.h"
@@ -46,7 +47,78 @@ GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wshadow")
 
 GODOT_GCC_WARNING_POP
 
-Vector<uint8_t> compile_glslang_shader(RenderingDeviceCommons::ShaderStage p_stage, const String &p_source_code, RenderingDeviceCommons::ShaderLanguageVersion p_language_version, RenderingDeviceCommons::ShaderSpirvVersion p_spirv_version, String *r_error) {
+class GlslIncluder : public glslang::TShader::Includer {
+	static const int max_depth = 1000;
+
+	int num_base_include_dirs = 0;
+	Vector<String> dirs;
+
+	IncludeResult *new_error(const String &p_error_message) const {
+		CharString cs_error_message = p_error_message.utf8();
+		char *cs_error_message_ptr = (char *)memalloc(cs_error_message.length() + 1);
+		memcpy(cs_error_message_ptr, cs_error_message.get_data(), cs_error_message.length() + 1);
+
+		return memnew(IncludeResult("", cs_error_message_ptr, cs_error_message.length(), cs_error_message_ptr));
+	}
+
+public:
+	void add_include_dirs(const Vector<String> &p_include_dirs) {
+		dirs.append_array(p_include_dirs);
+		num_base_include_dirs += p_include_dirs.size();
+	}
+
+	virtual IncludeResult *includeSystem(const char *p_header_name, const char *p_includer_name, size_t p_inclusion_depth) override {
+		if (p_inclusion_depth > max_depth) {
+			return new_error(vformat("Inclusion depth (%d) exceeded maximum (%d)", p_inclusion_depth, max_depth));
+		}
+
+		dirs.resize(num_base_include_dirs + p_inclusion_depth - 1);
+
+		String include_path = p_header_name;
+		if (include_path.is_relative_path()) {
+			for (int i = dirs.size() - 1; i >= 0; --i) {
+				String tmp_include = dirs[i].path_join(include_path);
+				if (FileAccess::exists(tmp_include)) {
+					include_path = tmp_include;
+					break;
+				}
+			}
+		}
+
+		Error err;
+		Ref<FileAccess> file_inc = FileAccess::open(include_path, FileAccess::READ, &err);
+		if (err == OK) {
+			dirs.append(include_path.get_base_dir());
+			CharString cs_include_path = include_path.utf8();
+
+			CharString cs_include_content = file_inc->get_as_utf8_string().utf8();
+			char *cs_include_content_ptr = (char *)memalloc(cs_include_content.length() + 1);
+			memcpy(cs_include_content_ptr, cs_include_content.get_data(), cs_include_content.length() + 1);
+
+			return memnew(IncludeResult(cs_include_path.get_data(), cs_include_content_ptr, cs_include_content.length(), cs_include_content_ptr));
+		}
+
+		return nullptr;
+	}
+
+	virtual IncludeResult *includeLocal(const char *p_header_name, const char *p_includer_name, size_t p_inclusion_depth) override {
+		// This will fall-through to includeSystem. See thirdparty/glslang/glslang/MachineIndependent/preprocessor/Pp.cpp#L717
+		return nullptr;
+	}
+
+	virtual void releaseInclude(IncludeResult *p_include_result) override {
+		if (p_include_result) {
+			if (p_include_result->userData) {
+				memfree(p_include_result->userData);
+			}
+			memdelete(p_include_result);
+		}
+	}
+
+	virtual ~GlslIncluder() override {}
+};
+
+Vector<uint8_t> compile_glslang_shader(RenderingDeviceCommons::ShaderStage p_stage, const String &p_source_code, RenderingDeviceCommons::ShaderLanguageVersion p_language_version, RenderingDeviceCommons::ShaderSpirvVersion p_spirv_version, String *r_error, const String &p_source_file_path, const Vector<String> &p_include_dirs) {
 	Vector<uint8_t> ret;
 	EShLanguage stages[RenderingDeviceCommons::SHADER_STAGE_MAX] = {
 		EShLangVertex,
@@ -70,9 +142,12 @@ Vector<uint8_t> compile_glslang_shader(RenderingDeviceCommons::ShaderStage p_sta
 	glslang::TShader shader(stages[p_stage]);
 	CharString cs = p_source_code.utf8();
 	const char *cs_strings = cs.get_data();
+	int source_code_length = cs.length();
 	std::string preamble = "";
 
-	shader.setStrings(&cs_strings, 1);
+	CharString cs_source_file_path = p_source_file_path.utf8();
+	const char *cs_names = cs_source_file_path.get_data();
+	shader.setStringsWithLengthsAndNames(&cs_strings, &source_code_length, &cs_names, 1);
 	shader.setEnvInput(glslang::EShSourceGlsl, stages[p_stage], glslang::EShClientVulkan, ClientInputSemanticsVersion);
 	shader.setEnvClient(glslang::EShClientVulkan, ClientVersion);
 	shader.setEnvTarget(glslang::EShTargetSpv, TargetVersion);
@@ -95,8 +170,15 @@ Vector<uint8_t> compile_glslang_shader(RenderingDeviceCommons::ShaderStage p_sta
 	}
 	const int DefaultVersion = 100;
 
+	GlslIncluder includer = {};
+
+	includer.add_include_dirs(p_include_dirs);
+	if (!p_source_file_path.is_empty()) {
+		includer.add_include_dirs({ p_source_file_path.get_base_dir() });
+	}
+
 	//parse
-	if (!shader.parse(GetDefaultResources(), DefaultVersion, false, messages)) {
+	if (!shader.parse(GetDefaultResources(), DefaultVersion, false, messages, includer)) {
 		if (r_error) {
 			(*r_error) = "Failed parse:\n";
 			(*r_error) += shader.getInfoLog();

--- a/modules/glslang/shader_compile.h
+++ b/modules/glslang/shader_compile.h
@@ -32,4 +32,4 @@
 
 #include "servers/rendering/rendering_device_commons.h"
 
-Vector<uint8_t> compile_glslang_shader(RenderingDeviceCommons::ShaderStage p_stage, const String &p_source_code, RenderingDeviceCommons::ShaderLanguageVersion p_language_version, RenderingDeviceCommons::ShaderSpirvVersion p_spirv_version, String *r_error);
+Vector<uint8_t> compile_glslang_shader(RenderingDeviceCommons::ShaderStage p_stage, const String &p_source_code, RenderingDeviceCommons::ShaderLanguageVersion p_language_version, RenderingDeviceCommons::ShaderSpirvVersion p_spirv_version, String *r_error, const String &p_source_file_path = "", const Vector<String> &p_additional_include_dirs = {});

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -37,7 +37,7 @@
 
 #include "servers/rendering/shader_include_db.h"
 
-Error RDShaderFile::parse_versions_from_text(const String &p_text, const String p_defines, OpenIncludeFunction p_include_func, void *p_include_func_userdata) {
+Error RDShaderFile::parse_versions_from_text(const String &p_text, const String p_defines, const String &p_source_file_path, const Vector<String> &p_include_dirs) {
 	Vector<String> lines = p_text.split("\n");
 
 	bool reading_versions = false;
@@ -142,33 +142,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 			}
 
 			if (stage != RD::SHADER_STAGE_MAX) {
-				if (line.strip_edges().begins_with("#include")) {
-					if (p_include_func) {
-						//process include
-						String include = line.replace("#include", "").strip_edges();
-						if (!include.begins_with("\"") || !include.ends_with("\"")) {
-							base_error = "Malformed #include syntax, expected #include \"<path>\", found instead: " + include;
-							break;
-						}
-						include = include.substr(1, include.length() - 2).strip_edges();
-
-						String include_code = ShaderIncludeDB::get_built_in_include_file(include);
-						if (!include_code.is_empty()) {
-							stage_code[stage] += "\n" + include_code + "\n";
-						} else {
-							String include_text = p_include_func(include, p_include_func_userdata);
-							if (!include_text.is_empty()) {
-								stage_code[stage] += "\n" + include_text + "\n";
-							} else {
-								base_error = "#include failed for file '" + include + "'.";
-							}
-						}
-					} else {
-						base_error = "#include used, but no include function provided.";
-					}
-				} else {
-					stage_code[stage] += line + "\n";
-				}
+				stage_code[stage] += line + "\n";
 			}
 		}
 	}
@@ -198,7 +172,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 				code = code.replace("VERSION_DEFINES", E.value);
 				String error;
 #ifdef MODULE_GLSLANG_ENABLED
-				Vector<uint8_t> spirv = compile_glslang_shader(RD::ShaderStage(i), ShaderIncludeDB::parse_include_files(code), RD::SHADER_LANGUAGE_VULKAN_VERSION_1_1, RD::SHADER_SPIRV_VERSION_1_4, &error);
+				Vector<uint8_t> spirv = compile_glslang_shader(RD::ShaderStage(i), ShaderIncludeDB::parse_include_files(code), RD::SHADER_LANGUAGE_VULKAN_VERSION_1_1, RD::SHADER_SPIRV_VERSION_1_4, &error, p_source_file_path, p_include_dirs);
 				bytecode->set_stage_bytecode(RD::ShaderStage(i), spirv);
 #else
 				error = "Shader compilation is not supported because glslang was not enabled.";

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -431,7 +431,7 @@ public:
 	}
 
 	typedef String (*OpenIncludeFunction)(const String &, void *userdata);
-	Error parse_versions_from_text(const String &p_text, const String p_defines = String(), OpenIncludeFunction p_include_func = nullptr, void *p_include_func_userdata = nullptr);
+	Error parse_versions_from_text(const String &p_text, const String p_defines = String(), const String &p_source_file_path = "", const Vector<String> &p_include_dirs = {});
 
 protected:
 	Dictionary _get_versions() const {


### PR DESCRIPTION
Fixes #80532 by implementing the `Includer` interface from glslang. Note that includes via `ShaderIncludeDB` should not be affected by this PR.
Local-style (`"path"`) and system-style (`<path>`) includes are treated the same.
An inclusion extension (`GL_ARB_shading_language_include` or `GL_GOOGLE_include_directive`) needs to be enabled to be able to include files. This matches standard GLSL behaviour, but is a breaking change.¹ The Godot editor displays a helpful glslang error however.
I've set an arbitrary depth limit of 1000 to prevent cyclic includes from freezing the engine indefinitely. Should this be something like a project setting instead?

[Here](https://github.com/sblana/Godot-GLSL-include-tests) is a repo with some test cases.

¹ The breaking change is this:
Currently
```glsl
#[compute]
#version 460
#include "include_a.glsl"
...
```
After this PR
```glsl
#[compute]
#version 460
#extension GL_ARB_shading_language_include : enable // or require,
// which in this case does the same thing.
// GL_GOOGLE_include_directive can also be used instead.
#include "include_a.glsl"
...
```
Note that this _is_ expected and correct behaviour according to GLSL spec ([see §3.3 of GLSL 4.6 spec](<https://registry.khronos.org/OpenGL/specs/gl/GLSLangSpec.4.60.pdf#preprocessor>)). It may be unintuitive to people using GLSL for the first time, so perhaps this should be mentioned in the docs?