### PR TITLE
Add `EditorInterface.mark_scene_as_saved` method

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -300,6 +300,12 @@
 				Returns mesh previews rendered at the given size as an [Array] of [Texture2D]s.
 			</description>
 		</method>
+		<method name="mark_scene_as_saved">
+			<return type="void" />
+			<description>
+				Marks the current scene tab as saved.
+			</description>
+		</method>
 		<method name="mark_scene_as_unsaved">
 			<return type="void" />
 			<description>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -775,6 +775,11 @@ void EditorInterface::mark_scene_as_unsaved() {
 	EditorSceneTabs::get_singleton()->update_scene_tabs();
 }
 
+void EditorInterface::mark_scene_as_saved() {
+	EditorUndoRedoManager::get_singleton()->set_history_as_saved(EditorNode::get_editor_data().get_current_edited_scene_history_id());
+	EditorSceneTabs::get_singleton()->update_scene_tabs();
+}
+
 void EditorInterface::save_all_scenes() {
 	EditorNode::get_singleton()->save_all_scenes();
 }
@@ -930,6 +935,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("close_scene"), &EditorInterface::close_scene);
 
 	ClassDB::bind_method(D_METHOD("mark_scene_as_unsaved"), &EditorInterface::mark_scene_as_unsaved);
+	ClassDB::bind_method(D_METHOD("mark_scene_as_saved"), &EditorInterface::mark_scene_as_saved);
 
 	// Scene playback.
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -189,6 +189,7 @@ public:
 	Error save_scene();
 	void save_scene_as(const String &p_scene, bool p_with_preview = true);
 	void mark_scene_as_unsaved();
+	void mark_scene_as_saved();
 	void save_all_scenes();
 	Error close_scene();
 

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -384,6 +384,7 @@ bool EditorUndoRedoManager::redo_history(int p_id) {
 void EditorUndoRedoManager::set_history_as_saved(int p_id) {
 	History &history = get_or_create_history(p_id);
 	history.saved_version = history.undo_redo->get_version();
+	emit_signal(SNAME("history_changed"));
 }
 
 void EditorUndoRedoManager::set_history_as_unsaved(int p_id) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

The opposite of [mark_scene_as_unsaved()](https://docs.godotengine.org/de/4.x/classes/class_editorinterface.html#class-editorinterface-method-mark-scene-as-unsaved).

Why? 

You have a plugin that creates a default scene when first launched, or no tabs are open and would like the project to show as unmodified. Having this method helps do this. 

Demo:

https://github.com/user-attachments/assets/1ce0bc81-79d4-4f5c-a25b-b91e4f9cceaa

