### PR TITLE
Editor: Fix inconsistent shader uniform name capitalization

### DIFF
--- a/editor/inspector/editor_property_name_processor.cpp
+++ b/editor/inspector/editor_property_name_processor.cpp
@@ -328,7 +328,10 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["xray"] = "X-Ray";
 	capitalize_string_remaps["xy"] = "XY";
 	capitalize_string_remaps["xz"] = "XZ";
+	capitalize_string_remaps["yx"] = "YX";
 	capitalize_string_remaps["yz"] = "YZ";
+	capitalize_string_remaps["zx"] = "ZX";
+	capitalize_string_remaps["zy"] = "ZY";
 
 	// Articles, conjunctions, prepositions.
 	// The following initialization is parsed in https://github.com/godotengine/godot-editor-l10n/blob/main/scripts/common.py

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -34,6 +34,7 @@
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
 #include "core/version.h"
+#include "editor/inspector/editor_property_name_processor.h"
 #include "scene/main/scene_tree.h"
 #include "scene/resources/texture.h"
 
@@ -274,7 +275,7 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 					if (!groups.has(last_group)) {
 						PropertyInfo info;
 						info.usage = PROPERTY_USAGE_GROUP;
-						info.name = last_group.capitalize();
+						info.name = EditorPropertyNameProcessor::get_singleton()->process_name(last_group, EditorPropertyNameProcessor::STYLE_CAPITALIZED);
 						info.hint_string = "shader_parameter/";
 
 						List<PropertyInfo> none_subgroup;
@@ -290,7 +291,7 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 					if (!groups[last_group].has(last_subgroup)) {
 						PropertyInfo info;
 						info.usage = PROPERTY_USAGE_SUBGROUP;
-						info.name = last_subgroup.capitalize();
+						info.name = EditorPropertyNameProcessor::get_singleton()->process_name(last_group, EditorPropertyNameProcessor::STYLE_CAPITALIZED);
 						info.hint_string = "shader_parameter/";
 
 						List<PropertyInfo> subgroup;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -34,7 +34,6 @@
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
 #include "core/version.h"
-#include "editor/inspector/editor_property_name_processor.h"
 #include "scene/main/scene_tree.h"
 #include "scene/resources/texture.h"
 
@@ -275,7 +274,7 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 					if (!groups.has(last_group)) {
 						PropertyInfo info;
 						info.usage = PROPERTY_USAGE_GROUP;
-						info.name = EditorPropertyNameProcessor::get_singleton()->process_name(last_group, EditorPropertyNameProcessor::STYLE_CAPITALIZED);
+						info.name = last_group;
 						info.hint_string = "shader_parameter/";
 
 						List<PropertyInfo> none_subgroup;
@@ -291,7 +290,7 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 					if (!groups[last_group].has(last_subgroup)) {
 						PropertyInfo info;
 						info.usage = PROPERTY_USAGE_SUBGROUP;
-						info.name = EditorPropertyNameProcessor::get_singleton()->process_name(last_subgroup, EditorPropertyNameProcessor::STYLE_CAPITALIZED);
+						info.name = last_subgroup;
 						info.hint_string = "shader_parameter/";
 
 						List<PropertyInfo> subgroup;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -291,7 +291,7 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 					if (!groups[last_group].has(last_subgroup)) {
 						PropertyInfo info;
 						info.usage = PROPERTY_USAGE_SUBGROUP;
-						info.name = EditorPropertyNameProcessor::get_singleton()->process_name(last_group, EditorPropertyNameProcessor::STYLE_CAPITALIZED);
+						info.name = EditorPropertyNameProcessor::get_singleton()->process_name(last_subgroup, EditorPropertyNameProcessor::STYLE_CAPITALIZED);
 						info.hint_string = "shader_parameter/";
 
 						List<PropertyInfo> subgroup;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/116251

**Aditional Remaps**

Added more remaping options for axis combinations on the EditorPropertyNameProcessor:

New remaps:
```
capitalize_string_remaps["yx"] = "YX";
capitalize_string_remaps["zx"] = "ZX";
capitalize_string_remaps["zy"] = "ZY";
```

Solved the following:
```
uniform bool project_xy = true;
uniform bool project_xz = true;
uniform bool project_zy = true;
```

**Updated Material's Group and Sub-Group Naming Convention**

On the original issue it was mentioned that the Group and Sub-Group's names for the shader on the Editor's Inspector didn't follow the rest of the Editor's capitalization convention. I pin-pointed the issue to be on material.cpp's _get_property_list(), where the info.name was getting capitalized for both the group and sub-group. This capitalized did not follow the rest of the UI capitalization, as it didn't check the remaping values to capitalize known strings, like in this case the UV.

```
if (!groups.has(last_group)) {
  PropertyInfo info;
  info.usage = PROPERTY_USAGE_GROUP;
  info.name = last_group.capitalize();

if (!groups[last_group].has(last_subgroup)) {
  PropertyInfo info;
  info.usage = PROPERTY_USAGE_GROUP;
  info.name = last_subgroup.capitalize();
```

I decided to add to material.cpp `#include "editor/inspector/editor_property_name_processor.h"` so I could use:

```
info.name = EditorPropertyNameProcessor::get_singleton()->process_name(last_group, EditorPropertyNameProcessor::STYLE_CAPITALIZED);
info.name = EditorPropertyNameProcessor::get_singleton()->process_name(last_subgroup, EditorPropertyNameProcessor::STYLE_CAPITALIZED);
```

This way I could follow the capitalization of the rest of the UI and send the info.name to the editor_inspector.cpp update_tree() correctly capitalized before it was built into the UI.

The result:
<img width="278" height="238" alt="image" src="https://github.com/user-attachments/assets/aac2e985-a96d-4ebb-9ee3-342659661202" />
