### PR TITLE
GDScript: Fix interrupted coroutines not clearing

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -277,5 +277,6 @@ GDScriptFunctionState::~GDScriptFunctionState() {
 		MutexLock lock(GDScriptLanguage::singleton->mutex);
 		scripts_list.remove_from_list();
 		instances_list.remove_from_list();
+		_clear_stack();
 	}
 }

--- a/modules/gdscript/tests/scripts/runtime/features/coroutine_clearing.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/coroutine_clearing.gd
@@ -1,0 +1,33 @@
+# GH-116706
+
+class Instance:
+	func _init() -> void:
+		print("Instance _init")
+
+	func _notification(what: int) -> void:
+		if what == NOTIFICATION_PREDELETE:
+			print("Instance predelete")
+
+class LocalOwner:
+	signal never_emitted()
+
+	func _init() -> void:
+		print("LocalOwner _init")
+
+	func _notification(what: int) -> void:
+		if what == NOTIFICATION_PREDELETE:
+			print("LocalOwner predelete")
+
+	func interrupted_coroutine() -> void:
+		print("interrupted_coroutine begin")
+		var _instance := Instance.new()
+		await never_emitted
+		print("interrupted_coroutine end")
+
+func test():
+	print("test begin")
+	var local_owner := LocalOwner.new()
+	@warning_ignore("missing_await")
+	local_owner.interrupted_coroutine()
+	local_owner = null
+	print("test end")

--- a/modules/gdscript/tests/scripts/runtime/features/coroutine_clearing.out
+++ b/modules/gdscript/tests/scripts/runtime/features/coroutine_clearing.out
@@ -1,0 +1,8 @@
+GDTEST_OK
+test begin
+LocalOwner _init
+interrupted_coroutine begin
+Instance _init
+LocalOwner predelete
+Instance predelete
+test end


### PR DESCRIPTION
* Fixes #79669.
* Fixes #84860.
* Fixes #116706.
* Supersedes #96441.
* See also #61003.
* Need to make sure this doesn't reintroduce #57126.
