### PR TITLE
`AudioStreamWAV`: Check for `eof_reached` when reading LIST INFO tags

### DIFF
--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -881,6 +881,7 @@ Ref<AudioStreamWAV> AudioStreamWAV::load_from_buffer(const Vector<uint8_t> &p_st
 				// 'INFO' list type.
 				// The size of an entry can be arbitrary.
 				while (file->get_position() < end_of_chunk) {
+					ERR_BREAK_MSG(file->eof_reached(), "EOF reached while reading INFO chunk.");
 					char info_id[4];
 					file->get_buffer((uint8_t *)&info_id, 4);
 


### PR DESCRIPTION
Fixes #116099. Supersedes #116112 which touches code beyond the issue.

By analyzing the file, it seems to have a `LIST` chunk that not only is placed after `data` (which is usually the last), but also informs a size of 3,225,026,560 bytes, which is far beyond the end of the file.

This is an unusual case, but it can be solved by simply adding an `eof_reached` check that breaks the `INFO` loop (which honestly, should have been there long ago).

It will print an error in the editor, but it's reasonable for a file with invalid chunks.