### PR TITLE
Fix Reinhard and AgX tonemapper in Mobile renderer when using subpass.

### DIFF
--- a/servers/rendering/renderer_rd/effects/tone_mapper.cpp
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.cpp
@@ -331,6 +331,7 @@ void ToneMapper::tonemapper_subpass(RD::DrawListID p_subpass_draw_list, RID p_so
 	tonemap_mobile.push_constant.exposure = p_settings.exposure;
 	tonemap_mobile.push_constant.white = p_settings.white;
 	tonemap_mobile.push_constant.luminance_multiplier = p_settings.luminance_multiplier;
+	tonemap_mobile.push_constant.output_max_value = MAX(p_settings.max_value, 1.0f);
 
 	tonemap_mobile.push_constant.tonemapper_params[0] = p_settings.tonemapper_params[0];
 	tonemap_mobile.push_constant.tonemapper_params[1] = p_settings.tonemapper_params[1];


### PR DESCRIPTION
- Fixes #116643

When #110077 was merged, #94496 needed to be rebased. During that rebase, one function where the `output_max_value` needed to be set was missed. This caused Reinhard and AgX tonemappers to break with the mobile renderer when using that subpass function.