### PR TITLE
macOS: Add `nullptr` checks of `script_debugger` in `LayerHost::gui_input`

### DIFF
--- a/platform/macos/editor/embedded_process_macos.mm
+++ b/platform/macos/editor/embedded_process_macos.mm
@@ -331,7 +331,9 @@ void LayerHost::gui_input(const Ref<InputEvent> &p_event) {
 			DisplayServer *ds = DisplayServer::get_singleton();
 			if (ds->mouse_get_mode() != DisplayServer::MOUSE_MODE_VISIBLE) {
 				ds->mouse_set_mode(DisplayServer::MOUSE_MODE_VISIBLE);
-				script_debugger->send_message("embed:mouse_set_mode", { DisplayServer::MOUSE_MODE_VISIBLE });
+				if (script_debugger != nullptr) {
+					script_debugger->send_message("embed:mouse_set_mode", { DisplayServer::MOUSE_MODE_VISIBLE });
+				}
 			}
 			accept_event();
 			return;
@@ -347,7 +349,9 @@ void LayerHost::gui_input(const Ref<InputEvent> &p_event) {
 
 	PackedByteArray data;
 	if (encode_input_event(p_event, data)) {
-		script_debugger->send_message("embed:event", { data });
+		if (script_debugger != nullptr) {
+			script_debugger->send_message("embed:event", { data });
+		}
 		accept_event();
 	}
 }


### PR DESCRIPTION
Maybe fixes #116721.

This is a tentative (and arguably crude) fix.

Note that this crash could possibly have been fixed in `master` in some other way already, but I have not been able to verify that it actually works, in any branch. However, judging by the information in #116721 it seems likely that it would, if it hasn't been fixed already.