### PR TITLE
Core: Add missing integral conversions to `Variant`

### DIFF
--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -41,7 +41,7 @@ def version_hash_builder(target, source, env):
 #include "core/version.h"
 
 const char *const GODOT_VERSION_HASH = "{git_hash}";
-const uint64_t GODOT_VERSION_TIMESTAMP = {git_timestamp};
+const unsigned long long GODOT_VERSION_TIMESTAMP = {git_timestamp};
 """.format(**source[0].read())
         )
 

--- a/core/math/math_defs.h
+++ b/core/math/math_defs.h
@@ -145,3 +145,16 @@ typedef double real_t;
 #else
 typedef float real_t;
 #endif
+
+/**
+ * Rarely, there will be a scenario where a function/variable expects one of the builtin integral
+ *  types that do NOT utilize the fixed-width constants. In practice, the only discrepancies are
+ *  with `long` or `long long` (and their unsigned equivalents) not being declared when most/all
+ *  other integral constants are. We'll account for this with `int_alt_t` and `uint_alt_t`,
+ *  which assign to the unused fixed-width slot. As this will only be used rarely, keep the types
+ *  scoped to `Math` instead of the global namespace.
+ */
+namespace Math {
+using int_alt_t = std::conditional_t<std::is_same_v<int64_t, long>, long long, long>;
+using uint_alt_t = std::conditional_t<std::is_same_v<uint64_t, unsigned long>, unsigned long long, unsigned long>;
+} //namespace Math

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1490,6 +1490,10 @@ Variant::operator int8_t() const {
 	return _to_int<int8_t>();
 }
 
+Variant::operator Math::int_alt_t() const {
+	return _to_int<Math::int_alt_t>();
+}
+
 Variant::operator uint64_t() const {
 	return _to_int<uint64_t>();
 }
@@ -1504,6 +1508,10 @@ Variant::operator uint16_t() const {
 
 Variant::operator uint8_t() const {
 	return _to_int<uint8_t>();
+}
+
+Variant::operator Math::uint_alt_t() const {
+	return _to_int<Math::uint_alt_t>();
 }
 
 Variant::operator ObjectID() const {
@@ -2319,6 +2327,11 @@ Variant::Variant(int8_t p_int8) :
 	_data._int = p_int8;
 }
 
+Variant::Variant(Math::int_alt_t p_int_alt) :
+		type(INT) {
+	_data._int = p_int_alt;
+}
+
 Variant::Variant(uint64_t p_uint64) :
 		type(INT) {
 	_data._int = int64_t(p_uint64);
@@ -2337,6 +2350,11 @@ Variant::Variant(uint16_t p_uint16) :
 Variant::Variant(uint8_t p_uint8) :
 		type(INT) {
 	_data._int = int64_t(p_uint8);
+}
+
+Variant::Variant(Math::uint_alt_t p_uint_alt) :
+		type(INT) {
+	_data._int = p_uint_alt;
 }
 
 Variant::Variant(float p_float) :

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -412,10 +412,12 @@ public:
 	operator int32_t() const;
 	operator int16_t() const;
 	operator int8_t() const;
+	operator Math::int_alt_t() const;
 	operator uint64_t() const;
 	operator uint32_t() const;
 	operator uint16_t() const;
 	operator uint8_t() const;
+	operator Math::uint_alt_t() const;
 
 	operator ObjectID() const;
 
@@ -488,10 +490,12 @@ public:
 	Variant(int32_t p_int32);
 	Variant(int16_t p_int16);
 	Variant(int8_t p_int8);
+	Variant(Math::int_alt_t p_int_alt);
 	Variant(uint64_t p_uint64);
 	Variant(uint32_t p_uint32);
 	Variant(uint16_t p_uint16);
 	Variant(uint8_t p_uint8);
+	Variant(Math::uint_alt_t p_uint_alt);
 	Variant(float p_float);
 	Variant(double p_double);
 	Variant(const ObjectID &p_id);

--- a/core/version.h
+++ b/core/version.h
@@ -32,8 +32,6 @@
 
 #include "core/version_generated.gen.h" // IWYU pragma: export
 
-#include <stdint.h> // NOLINT(modernize-deprecated-headers) FIXME: MinGW compilation fails when changing to C++ Header.
-
 // Copied from typedefs.h to stay lean.
 #ifndef _STR
 #define _STR(m_x) #m_x
@@ -85,7 +83,7 @@ extern const char *const GODOT_VERSION_HASH;
 
 // Git commit date UNIX timestamp (in seconds), generated at build time in `core/version_hash.gen.cpp`.
 // Set to 0 if unknown.
-extern const uint64_t GODOT_VERSION_TIMESTAMP;
+extern const unsigned long long GODOT_VERSION_TIMESTAMP;
 
 #ifndef DISABLE_DEPRECATED
 // Compatibility with pre-4.5 modules.


### PR DESCRIPTION
- Required for #102378

Under rare circumstances, there'll be a scenario where one of the C builtin types that aren't bound to a fixed type tries to get cast against `Variant`. That is, one of `long` or `long long` (and their unsigned equivalents) are left out of the implicit conversion operations. While we should be moving away from implicit conversions, this should be an exception so long as the other integral types have implicit conversions. This PR achieves this with `Math::int_alt_t` and `Math::uint_alt_t`—scoped for their relative rarity—which enables `Variant` to handle these types gracefully

While the problem this solves is meant for #102378, there's something it can apply to immediately: `version.h`. Instead of having to use a deprecated C header, or needing to find an appropriate wrapper macro for detecting if it's being parsed with rc (`RC_INVOKED` btw[^1]), we can simply exclude the include entirely! That way, we can use the more generic `unsigned long long` for the hash value, rather than `uint64_t`

[^1]: https://learn.microsoft.com/en-us/windows/win32/menurc/predefined-macros