### PR TITLE
Make `MeshLibrary` use `PropertyListHelper`

### DIFF
--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -51,16 +51,6 @@ void MeshLibraryEditor::edit(const Ref<MeshLibrary> &p_mesh_library) {
 	}
 }
 
-void MeshLibraryEditor::_menu_remove_confirm() {
-	switch (option) {
-		case MENU_OPTION_REMOVE_ITEM: {
-			mesh_library->remove_item(to_erase);
-		} break;
-		default: {
-		};
-	}
-}
-
 void MeshLibraryEditor::_menu_update_confirm(bool p_apply_xforms) {
 	cd_update->hide();
 	apply_xforms = p_apply_xforms;
@@ -233,17 +223,6 @@ Error MeshLibraryEditor::update_library_file(Node *p_base_scene, Ref<MeshLibrary
 void MeshLibraryEditor::_menu_cbk(int p_option) {
 	option = p_option;
 	switch (p_option) {
-		case MENU_OPTION_ADD_ITEM: {
-			mesh_library->create_item(mesh_library->get_last_unused_item_id());
-		} break;
-		case MENU_OPTION_REMOVE_ITEM: {
-			String p = InspectorDock::get_inspector_singleton()->get_selected_path();
-			if (p.begins_with("item") && p.get_slice_count("/") >= 2) {
-				to_erase = p.get_slicec('/', 1).to_int();
-				cd_remove->set_text(vformat(TTR("Remove item %d?"), to_erase));
-				cd_remove->popup_centered(Size2(300, 60));
-			}
-		} break;
 		case MENU_OPTION_IMPORT_FROM_SCENE: {
 			apply_xforms = false;
 			file->popup_file_dialog();
@@ -280,9 +259,6 @@ MeshLibraryEditor::MeshLibraryEditor() {
 	menu->set_button_icon(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("MeshLibrary"), EditorStringName(EditorIcons)));
 	menu->set_flat(false);
 	menu->set_theme_type_variation("FlatMenuButtonNoIconTint");
-	menu->get_popup()->add_item(TTR("Add Item"), MENU_OPTION_ADD_ITEM);
-	menu->get_popup()->add_item(TTR("Remove Selected Item"), MENU_OPTION_REMOVE_ITEM);
-	menu->get_popup()->add_separator();
 	menu->get_popup()->add_item(TTR("Import from Scene (Ignore Transforms)"), MENU_OPTION_IMPORT_FROM_SCENE);
 	menu->get_popup()->add_item(TTR("Import from Scene (Apply Transforms)"), MENU_OPTION_IMPORT_FROM_SCENE_APPLY_XFORMS);
 	menu->get_popup()->add_item(TTR("Update from Scene"), MENU_OPTION_UPDATE_FROM_SCENE);
@@ -290,9 +266,6 @@ MeshLibraryEditor::MeshLibraryEditor() {
 	menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &MeshLibraryEditor::_menu_cbk));
 	menu->hide();
 
-	cd_remove = memnew(ConfirmationDialog);
-	add_child(cd_remove);
-	cd_remove->get_ok_button()->connect(SceneStringName(pressed), callable_mp(this, &MeshLibraryEditor::_menu_remove_confirm));
 	cd_update = memnew(ConfirmationDialog);
 	add_child(cd_update);
 	cd_update->set_ok_button_text(TTR("Apply without Transforms"));

--- a/editor/scene/3d/mesh_library_editor_plugin.h
+++ b/editor/scene/3d/mesh_library_editor_plugin.h
@@ -44,15 +44,12 @@ class MeshLibraryEditor : public Control {
 	Ref<MeshLibrary> mesh_library;
 
 	MenuButton *menu = nullptr;
-	ConfirmationDialog *cd_remove = nullptr;
 	ConfirmationDialog *cd_update = nullptr;
 	EditorFileDialog *file = nullptr;
 	bool apply_xforms = false;
 	int to_erase = 0;
 
 	enum {
-		MENU_OPTION_ADD_ITEM,
-		MENU_OPTION_REMOVE_ITEM,
 		MENU_OPTION_UPDATE_FROM_SCENE,
 		MENU_OPTION_IMPORT_FROM_SCENE,
 		MENU_OPTION_IMPORT_FROM_SCENE_APPLY_XFORMS
@@ -61,7 +58,6 @@ class MeshLibraryEditor : public Control {
 	int option = 0;
 	void _import_scene_cbk(const String &p_str);
 	void _menu_cbk(int p_option);
-	void _menu_remove_confirm();
 	void _menu_update_confirm(bool p_apply_xforms);
 
 	static void _import_scene(Node *p_scene, Ref<MeshLibrary> p_library, bool p_merge, bool p_apply_xforms);

--- a/scene/resources/3d/mesh_library.cpp
+++ b/scene/resources/3d/mesh_library.cpp
@@ -38,69 +38,40 @@
 
 bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 	String prop_name = p_name;
-	if (prop_name.begins_with("item/")) {
-		int idx = prop_name.get_slicec('/', 1).to_int();
-		String what = prop_name.get_slicec('/', 2);
-		if (!item_map.has(idx)) {
-			create_item(idx);
-		}
-
-		if (what == "name") {
-			set_item_name(idx, p_value);
-		} else if (what == "mesh") {
-			set_item_mesh(idx, p_value);
-		} else if (what == "mesh_transform") {
-			set_item_mesh_transform(idx, p_value);
-		} else if (what == "mesh_cast_shadow") {
-			switch ((int)p_value) {
-				case 0: {
-					set_item_mesh_cast_shadow(idx, RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_OFF);
-				} break;
-				case 1: {
-					set_item_mesh_cast_shadow(idx, RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_ON);
-				} break;
-				case 2: {
-					set_item_mesh_cast_shadow(idx, RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_DOUBLE_SIDED);
-				} break;
-				case 3: {
-					set_item_mesh_cast_shadow(idx, RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_SHADOWS_ONLY);
-				} break;
-				default: {
-					set_item_mesh_cast_shadow(idx, RS::ShadowCastingSetting::SHADOW_CASTING_SETTING_ON);
-				} break;
-			}
-#ifndef PHYSICS_3D_DISABLED
-		} else if (what == "shape") {
-			Vector<ShapeData> shapes;
-			ShapeData sd;
-			sd.shape = p_value;
-			shapes.push_back(sd);
-			set_item_shapes(idx, shapes);
-		} else if (what == "shapes") {
-			_set_item_shapes(idx, p_value);
-#endif // PHYSICS_3D_DISABLED
-		} else if (what == "preview") {
-			set_item_preview(idx, p_value);
-		} else if (what == "navigation_mesh") {
-			set_item_navigation_mesh(idx, p_value);
-		} else if (what == "navigation_mesh_transform") {
-			set_item_navigation_mesh_transform(idx, p_value);
-#ifndef DISABLE_DEPRECATED
-		} else if (what == "navmesh") { // Renamed in 4.0 beta 9.
-			set_item_navigation_mesh(idx, p_value);
-		} else if (what == "navmesh_transform") { // Renamed in 4.0 beta 9.
-			set_item_navigation_mesh_transform(idx, p_value);
-#endif // DISABLE_DEPRECATED
-		} else if (what == "navigation_layers") {
-			set_item_navigation_layers(idx, p_value);
-		} else {
-			return false;
-		}
-
-		return true;
+	if (!prop_name.begins_with("item/")) {
+		return false;
 	}
 
-	return false;
+	int idx = prop_name.get_slicec('/', 1).to_int();
+	String what = prop_name.get_slicec('/', 2);
+	if (!item_map.has(idx)) {
+		_set_item_count(idx + 1);
+	}
+	item_map[idx].hide_from_list = false;
+
+#ifndef PHYSICS_3D_DISABLED
+	if (what == "shape") {
+		Vector<ShapeData> shapes;
+		ShapeData sd;
+		sd.shape = p_value;
+		shapes.push_back(sd);
+		set_item_shapes(idx, shapes);
+		return true;
+	}
+#endif // PHYSICS_3D_DISABLED
+
+#ifndef DISABLE_DEPRECATED
+	if (what == "navmesh") { // Renamed in 4.0 beta 9.
+		set_item_navigation_mesh(idx, p_value);
+		return true;
+	}
+	if (what == "navmesh_transform") { // Renamed in 4.0 beta 9.
+		set_item_navigation_mesh_transform(idx, p_value);
+		return true;
+	}
+#endif // DISABLE_DEPRECATED
+
+	return property_helper.property_set_value(p_name, p_value);
 }
 
 bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
@@ -109,52 +80,18 @@ bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 	ERR_FAIL_COND_V(!item_map.has(idx), false);
 	String what = prop_name.get_slicec('/', 2);
 
-	if (what == "name") {
-		r_ret = get_item_name(idx);
-	} else if (what == "mesh") {
-		r_ret = get_item_mesh(idx);
-	} else if (what == "mesh_transform") {
-		r_ret = get_item_mesh_transform(idx);
-	} else if (what == "mesh_cast_shadow") {
-		r_ret = (int)get_item_mesh_cast_shadow(idx);
-#ifndef PHYSICS_3D_DISABLED
-	} else if (what == "shapes") {
-		r_ret = _get_item_shapes(idx);
-#endif // PHYSICS_3D_DISABLED
-	} else if (what == "navigation_mesh") {
-		r_ret = get_item_navigation_mesh(idx);
-	} else if (what == "navigation_mesh_transform") {
-		r_ret = get_item_navigation_mesh_transform(idx);
 #ifndef DISABLE_DEPRECATED
-	} else if (what == "navmesh") { // Renamed in 4.0 beta 9.
+	if (what == "navmesh") { // Renamed in 4.0 beta 9.
 		r_ret = get_item_navigation_mesh(idx);
-	} else if (what == "navmesh_transform") { // Renamed in 4.0 beta 9.
+		return true;
+	}
+	if (what == "navmesh_transform") { // Renamed in 4.0 beta 9.
 		r_ret = get_item_navigation_mesh_transform(idx);
+		return true;
+	}
 #endif // DISABLE_DEPRECATED
-	} else if (what == "navigation_layers") {
-		r_ret = get_item_navigation_layers(idx);
-	} else if (what == "preview") {
-		r_ret = get_item_preview(idx);
-	} else {
-		return false;
-	}
 
-	return true;
-}
-
-void MeshLibrary::_get_property_list(List<PropertyInfo> *p_list) const {
-	for (const KeyValue<int, Item> &E : item_map) {
-		String prop_name = vformat("%s/%d/", PNAME("item"), E.key);
-		p_list->push_back(PropertyInfo(Variant::STRING, prop_name + PNAME("name")));
-		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("mesh"), PROPERTY_HINT_RESOURCE_TYPE, Mesh::get_class_static()));
-		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prop_name + PNAME("mesh_transform"), PROPERTY_HINT_NONE, "suffix:m"));
-		p_list->push_back(PropertyInfo(Variant::INT, prop_name + PNAME("mesh_cast_shadow"), PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only"));
-		p_list->push_back(PropertyInfo(Variant::ARRAY, prop_name + PNAME("shapes")));
-		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("navigation_mesh"), PROPERTY_HINT_RESOURCE_TYPE, NavigationMesh::get_class_static()));
-		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prop_name + PNAME("navigation_mesh_transform"), PROPERTY_HINT_NONE, "suffix:m"));
-		p_list->push_back(PropertyInfo(Variant::INT, prop_name + PNAME("navigation_layers"), PROPERTY_HINT_LAYERS_3D_NAVIGATION));
-		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("preview"), PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static(), PROPERTY_USAGE_DEFAULT));
-	}
+	return property_helper.property_get_value(prop_name, r_ret);
 }
 
 void MeshLibrary::create_item(int p_item) {
@@ -289,9 +226,16 @@ void MeshLibrary::clear() {
 Vector<int> MeshLibrary::get_item_list() const {
 	Vector<int> ret;
 	ret.resize(item_map.size());
+
 	int idx = 0;
 	for (const KeyValue<int, Item> &E : item_map) {
-		ret.write[idx++] = E.key;
+		if (!E.value.hide_from_list) {
+			ret.write[idx++] = E.key;
+		}
+	}
+
+	if (ret.size() > idx) {
+		ret.resize(idx);
 	}
 
 	return ret;
@@ -366,9 +310,58 @@ Array MeshLibrary::_get_item_shapes(int p_item) const {
 }
 #endif // PHYSICS_3D_DISABLED
 
+void MeshLibrary::_set_item_hide_from_list(int p_item, bool p_hide) {
+	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	item_map[p_item].hide_from_list = p_hide;
+	emit_changed();
+}
+
+bool MeshLibrary::_get_item_hide_from_list(int p_item) const {
+	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), false, "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	return item_map[p_item].hide_from_list;
+}
+
+void MeshLibrary::_set_item_count(int p_count) {
+	ERR_FAIL_COND(p_count < 0);
+	int prev_size = item_map.size();
+	if (prev_size == p_count) {
+		return;
+	}
+
+	if (prev_size < p_count) {
+		// Fill in potential gaps between indexes.
+		for (int i = 0; i < p_count; i++) {
+			if (!item_map.has(i)) {
+				item_map[i] = Item();
+				// We don't want to show fillers in the `GridMap` editor.
+				item_map[i].hide_from_list = true;
+				prev_size++;
+			}
+			if (prev_size == p_count) {
+				// Avoid hiding ones created by the user.
+				item_map[i].hide_from_list = false;
+				break;
+			}
+		}
+	} else {
+		while (prev_size > p_count) {
+			item_map.remove(item_map.back());
+			prev_size--;
+		}
+	}
+
+	emit_changed();
+	notify_property_list_changed();
+}
+
+int MeshLibrary::_get_item_count() const {
+	return item_map.size();
+}
+
 void MeshLibrary::reset_state() {
 	clear();
 }
+
 void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_item", "id"), &MeshLibrary::create_item);
 	ClassDB::bind_method(D_METHOD("set_item_name", "id", "name"), &MeshLibrary::set_item_name);
@@ -382,6 +375,7 @@ void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_item_shapes", "id", "shapes"), &MeshLibrary::_set_item_shapes);
 #endif // PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("set_item_preview", "id", "texture"), &MeshLibrary::set_item_preview);
+	ClassDB::bind_method(D_METHOD("_set_item_count", "count"), &MeshLibrary::_set_item_count);
 	ClassDB::bind_method(D_METHOD("get_item_name", "id"), &MeshLibrary::get_item_name);
 	ClassDB::bind_method(D_METHOD("get_item_mesh", "id"), &MeshLibrary::get_item_mesh);
 	ClassDB::bind_method(D_METHOD("get_item_mesh_transform", "id"), &MeshLibrary::get_item_mesh_transform);
@@ -393,16 +387,37 @@ void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_shapes", "id"), &MeshLibrary::_get_item_shapes);
 #endif // PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_item_preview", "id"), &MeshLibrary::get_item_preview);
+	ClassDB::bind_method(D_METHOD("_get_item_count"), &MeshLibrary::_get_item_count);
 	ClassDB::bind_method(D_METHOD("remove_item", "id"), &MeshLibrary::remove_item);
 	ClassDB::bind_method(D_METHOD("find_item_by_name", "name"), &MeshLibrary::find_item_by_name);
 
 	ClassDB::bind_method(D_METHOD("clear"), &MeshLibrary::clear);
 	ClassDB::bind_method(D_METHOD("get_item_list"), &MeshLibrary::get_item_list);
 	ClassDB::bind_method(D_METHOD("get_last_unused_item_id"), &MeshLibrary::get_last_unused_item_id);
+
+	ADD_ARRAY_COUNT_WITH_USAGE_FLAGS("Items", "item_count", "_set_item_count", "_get_item_count", "item/", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL);
+
+	base_property_helper.set_prefix("item/");
+	base_property_helper.set_array_length_getter(&MeshLibrary::_get_item_count);
+
+	Item defaults;
+
+	base_property_helper.register_property(PropertyInfo(Variant::STRING, "name"), defaults.name, &MeshLibrary::set_item_name, &MeshLibrary::get_item_name);
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, Mesh::get_class_static()), defaults.mesh, &MeshLibrary::set_item_mesh, &MeshLibrary::get_item_mesh);
+	base_property_helper.register_property(PropertyInfo(Variant::TRANSFORM3D, "mesh_transform", PROPERTY_HINT_NONE, "suffix:m"), defaults.mesh_transform, &MeshLibrary::set_item_mesh_transform, &MeshLibrary::get_item_mesh_transform);
+	base_property_helper.register_property(PropertyInfo(Variant::INT, "mesh_cast_shadow", PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only"), defaults.mesh_cast_shadow, &MeshLibrary::set_item_mesh_cast_shadow, &MeshLibrary::get_item_mesh_cast_shadow);
+#ifndef PHYSICS_3D_DISABLED
+	base_property_helper.register_property(PropertyInfo(Variant::ARRAY, "shapes"), Array(), &MeshLibrary::_set_item_shapes, &MeshLibrary::_get_item_shapes);
+#endif // PHYSICS_3D_DISABLED
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "navigation_mesh", PROPERTY_HINT_RESOURCE_TYPE, NavigationMesh::get_class_static()), defaults.navigation_mesh, &MeshLibrary::set_item_navigation_mesh, &MeshLibrary::get_item_navigation_mesh);
+	base_property_helper.register_property(PropertyInfo(Variant::TRANSFORM3D, "navigation_mesh_transform", PROPERTY_HINT_NONE, "suffix:m"), defaults.navigation_mesh_transform, &MeshLibrary::set_item_navigation_mesh_transform, &MeshLibrary::get_item_navigation_mesh_transform);
+	base_property_helper.register_property(PropertyInfo(Variant::INT, "navigation_layers", PROPERTY_HINT_LAYERS_3D_NAVIGATION), defaults.navigation_layers, &MeshLibrary::set_item_navigation_layers, &MeshLibrary::get_item_navigation_layers);
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "preview", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.preview, &MeshLibrary::set_item_preview, &MeshLibrary::get_item_preview);
+	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "hide_from_list", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), defaults.hide_from_list, &MeshLibrary::_set_item_hide_from_list, &MeshLibrary::_get_item_hide_from_list);
+
+	PropertyListHelper::register_base_helper(&base_property_helper);
 }
 
 MeshLibrary::MeshLibrary() {
-}
-
-MeshLibrary::~MeshLibrary() {
+	property_helper.setup_for_instance(base_property_helper, this);
 }

--- a/scene/resources/3d/mesh_library.h
+++ b/scene/resources/3d/mesh_library.h
@@ -32,6 +32,7 @@
 
 #include "core/io/resource.h"
 #include "core/templates/rb_map.h"
+#include "scene/property_list_helper.h"
 #include "scene/resources/mesh.h"
 #include "scene/resources/navigation_mesh.h"
 #include "servers/rendering/rendering_server.h"
@@ -59,23 +60,36 @@ public:
 #ifndef PHYSICS_3D_DISABLED
 		Vector<ShapeData> shapes;
 #endif // PHYSICS_3D_DISABLED
-		Ref<Texture2D> preview;
 		Ref<NavigationMesh> navigation_mesh;
 		Transform3D navigation_mesh_transform;
 		uint32_t navigation_layers = 1;
+		Ref<Texture2D> preview;
+		bool hide_from_list = false; // Needs to be last.
 	};
 
+private:
 	RBMap<int, Item> item_map;
+
+	static inline PropertyListHelper base_property_helper;
+	PropertyListHelper property_helper;
 
 #ifndef PHYSICS_3D_DISABLED
 	void _set_item_shapes(int p_item, const Array &p_shapes);
 	Array _get_item_shapes(int p_item) const;
 #endif // PHYSICS_3D_DISABLED
 
+	void _set_item_hide_from_list(int p_item, bool p_hide);
+	bool _get_item_hide_from_list(int p_item) const;
+
+	void _set_item_count(int p_count);
+	int _get_item_count() const;
+
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
-	void _get_property_list(List<PropertyInfo> *p_list) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const { property_helper.get_property_list(p_list); }
+	bool _property_can_revert(const StringName &p_name) const { return property_helper.property_can_revert(p_name); }
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return property_helper.property_get_revert(p_name, r_property); }
 
 	virtual void reset_state() override;
 	static void _bind_methods();
@@ -93,6 +107,7 @@ public:
 	void set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes);
 #endif // PHYSICS_3D_DISABLED
 	void set_item_preview(int p_item, const Ref<Texture2D> &p_preview);
+
 	String get_item_name(int p_item) const;
 	Ref<Mesh> get_item_mesh(int p_item) const;
 	Transform3D get_item_mesh_transform(int p_item) const;
@@ -116,5 +131,4 @@ public:
 	int get_last_unused_item_id() const;
 
 	MeshLibrary();
-	~MeshLibrary();
 };


### PR DESCRIPTION
This PR ports from the old way `MeshLibrary` uses to show (common properties in the inspector) and manipulate (options inside a dropdown in the toolbar) its data, to instead using `PropertyListHelper` (already used in stuff like `PopupMenu`, `TileMap`, etc). Allowing to easily create, delete, and move items.

<img width="316" height="691" alt="Screenshot_20260224_173242" src="https://github.com/user-attachments/assets/70c9bbe5-06b6-4c36-b5e0-505658b45f1f" />