### PR TITLE
Core: Remove `class_db.h` include from `ref_counted.h`

### DIFF
--- a/core/crypto/aes_context.cpp
+++ b/core/crypto/aes_context.cpp
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "core/crypto/aes_context.h"
+#include "aes_context.h"
 
 #include "core/object/class_db.h"
 

--- a/core/crypto/aes_context.h
+++ b/core/crypto/aes_context.h
@@ -32,6 +32,7 @@
 
 #include "core/crypto/crypto_core.h"
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 
 class AESContext : public RefCounted {
 	GDCLASS(AESContext, RefCounted);

--- a/core/crypto/hashing_context.h
+++ b/core/crypto/hashing_context.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 
 class HashingContext : public RefCounted {
 	GDCLASS(HashingContext, RefCounted);

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -36,6 +36,7 @@
 #include "core/os/memory.h"
 #include "core/string/ustring.h"
 #include "core/typedefs.h"
+#include "core/variant/binder_common.h"
 
 /**
  * Multi-Platform abstraction for accessing to files.

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -30,6 +30,8 @@
 
 #include "file_access_compressed.h"
 
+#include "core/math/math_funcs_binary.h"
+
 void FileAccessCompressed::configure(const String &p_magic, Compression::Mode p_mode, uint32_t p_block_size) {
 	magic = p_magic.ascii().get_data();
 	magic = (magic + "    ").substr(0, 4);

--- a/core/io/ip.h
+++ b/core/io/ip.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/io/ip_address.h"
-#include "core/os/os.h"
+#include "core/variant/binder_common.h"
 
 template <typename T>
 class TypedArray;

--- a/core/io/remote_filesystem_client.cpp
+++ b/core/io/remote_filesystem_client.cpp
@@ -33,6 +33,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/stream_peer_tcp.h"
+#include "core/os/os.h"
 #include "core/string/string_builder.h"
 
 #define FILESYSTEM_CACHE_VERSION 1

--- a/core/io/stream_peer_socket.cpp
+++ b/core/io/stream_peer_socket.cpp
@@ -32,6 +32,7 @@
 #include "stream_peer_socket.compat.inc"
 
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 
 Error StreamPeerSocket::poll() {
 	if (status == STATUS_CONNECTED) {

--- a/core/io/stream_peer_tcp.cpp
+++ b/core/io/stream_peer_tcp.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 
 void StreamPeerTCP::accept_socket(Ref<NetSocket> p_sock, const NetSocket::Address &p_addr) {
 	_sock = p_sock;

--- a/core/io/stream_peer_uds.cpp
+++ b/core/io/stream_peer_uds.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 
 void StreamPeerUDS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("bind", "path"), &StreamPeerUDS::bind);

--- a/core/io/xml_parser.h
+++ b/core/io/xml_parser.h
@@ -33,6 +33,7 @@
 #include "core/object/ref_counted.h"
 #include "core/string/ustring.h"
 #include "core/templates/vector.h"
+#include "core/variant/binder_common.h"
 
 /*
   Based on irrXML (see their zlib license). Added mainly for compatibility with their Collada loader.

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
 #include "core/object/object.h"
 #include "core/templates/safe_refcount.h"
 
@@ -237,40 +236,6 @@ public:
 	Variant get_ref() const;
 	void set_obj(Object *p_object);
 	void set_ref(const Ref<RefCounted> &p_ref);
-};
-
-template <typename T>
-struct PtrToArg<Ref<T>> {
-	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
-		if (p_ptr == nullptr) {
-			return Ref<T>();
-		}
-		// p_ptr points to a RefCounted object
-		return Ref<T>(*reinterpret_cast<T *const *>(p_ptr));
-	}
-
-	typedef Ref<T> EncodeT;
-
-	_FORCE_INLINE_ static void encode(Ref<T> p_val, const void *p_ptr) {
-		// p_ptr points to an EncodeT object which is a Ref<T> object.
-		*(const_cast<Ref<RefCounted> *>(reinterpret_cast<const Ref<RefCounted> *>(p_ptr))) = p_val;
-	}
-};
-
-template <typename T>
-struct GetTypeInfo<Ref<T>> {
-	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
-
-	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::OBJECT, String(), PROPERTY_HINT_RESOURCE_TYPE, T::get_class_static());
-	}
-};
-
-template <typename T>
-struct VariantInternalAccessor<Ref<T>> {
-	static _FORCE_INLINE_ Ref<T> get(const Variant *v) { return Ref<T>(*VariantInternal::get_object(v)); }
-	static _FORCE_INLINE_ void set(Variant *v, const Ref<T> &p_ref) { VariantInternal::object_assign(v, p_ref); }
 };
 
 // Zero-constructing Ref initializes reference to nullptr (and thus empty).

--- a/core/string/print_string.cpp
+++ b/core/string/print_string.cpp
@@ -33,6 +33,8 @@
 #include "core/core_globals.h"
 #include "core/os/os.h"
 
+#include <cstdio>
+
 static PrintHandlerList *print_handler_list = nullptr;
 static thread_local bool is_printing = false;
 

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -270,9 +270,32 @@ struct PtrToArg<const T *> {
 	}
 };
 
+// This is for Ref.
+
+template <typename T>
+struct PtrToArg<Ref<T>> {
+	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
+		if (p_ptr == nullptr) {
+			return Ref<T>();
+		}
+		// p_ptr points to a RefCounted object
+		return Ref<T>(*reinterpret_cast<T *const *>(p_ptr));
+	}
+
+	typedef Ref<T> EncodeT;
+
+	_FORCE_INLINE_ static void encode(Ref<T> p_val, const void *p_ptr) {
+		// p_ptr points to an EncodeT object which is a Ref<T> object.
+		*(const_cast<Ref<T> *>(reinterpret_cast<const Ref<T> *>(p_ptr))) = p_val;
+	}
+};
+
 // This is for RequiredParam.
 
-template <class T>
+template <typename T>
+class RequiredParam;
+
+template <typename T>
 struct PtrToArg<RequiredParam<T>> {
 	typedef typename RequiredParam<T>::persistent_type EncodeT;
 
@@ -290,7 +313,10 @@ struct PtrToArg<RequiredParam<T>> {
 
 // This is for RequiredResult.
 
-template <class T>
+template <typename T>
+class RequiredResult;
+
+template <typename T>
 struct PtrToArg<RequiredResult<T>> {
 	typedef typename RequiredResult<T>::ptr_type EncodeT;
 

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -183,10 +183,20 @@ struct GetTypeInfo<T *, std::enable_if_t<std::is_base_of_v<Object, T>>> {
 	}
 };
 
-template <class T>
+template <typename T>
+struct GetTypeInfo<Ref<T>> {
+	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+
+	static inline PropertyInfo get_class_info() {
+		return PropertyInfo(Variant::OBJECT, String(), PROPERTY_HINT_RESOURCE_TYPE, T::get_class_static());
+	}
+};
+
+template <typename T>
 class RequiredParam;
 
-template <class T>
+template <typename T>
 class RequiredResult;
 
 template <typename T>

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -637,6 +637,12 @@ struct VariantInternalAccessor<Object *> {
 	static _FORCE_INLINE_ void set(Variant *v, const Object *p_value) { VariantInternal::object_assign(v, p_value); }
 };
 
+template <typename T>
+struct VariantInternalAccessor<Ref<T>> {
+	static _FORCE_INLINE_ Ref<T> get(const Variant *v) { return Ref<T>(const_cast<Object *>(*VariantInternal::get_object(v))); }
+	static _FORCE_INLINE_ void set(Variant *v, const Ref<T> &p_ref) { VariantInternal::object_assign(v, p_ref); }
+};
+
 template <class T>
 struct VariantInternalAccessor<RequiredParam<T>> {
 	static _FORCE_INLINE_ RequiredParam<T> get(const Variant *v) { return RequiredParam<T>(Object::cast_to<T>(const_cast<Object *>(*VariantInternal::get_object(v)))); }

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -33,6 +33,7 @@
 class EditorExportPlatform;
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 
 class EditorExportPreset : public RefCounted {
 	GDCLASS(EditorExportPreset, RefCounted);

--- a/modules/navigation_2d/2d/nav_map_iteration_2d.h
+++ b/modules/navigation_2d/2d/nav_map_iteration_2d.h
@@ -35,6 +35,7 @@
 #include "nav_mesh_queries_2d.h"
 
 #include "core/math/math_defs.h"
+#include "core/os/rw_lock.h"
 #include "core/os/semaphore.h"
 
 class NavLinkIteration2D;

--- a/modules/navigation_2d/nav_link_2d.h
+++ b/modules/navigation_2d/nav_link_2d.h
@@ -31,6 +31,8 @@
 #pragma once
 
 #include "2d/nav_base_iteration_2d.h"
+#include "core/os/rw_lock.h"
+#include "core/variant/binder_common.h"
 #include "nav_base_2d.h"
 #include "nav_utils_2d.h"
 

--- a/modules/navigation_2d/nav_map_2d.h
+++ b/modules/navigation_2d/nav_map_2d.h
@@ -37,6 +37,7 @@
 
 #include "core/math/math_defs.h"
 #include "core/object/worker_thread_pool.h"
+#include "core/os/rw_lock.h"
 #include "servers/navigation_2d/navigation_constants_2d.h"
 
 #include <KdTree2d.h>

--- a/modules/navigation_3d/3d/nav_map_iteration_3d.h
+++ b/modules/navigation_3d/3d/nav_map_iteration_3d.h
@@ -35,6 +35,7 @@
 #include "nav_mesh_queries_3d.h"
 
 #include "core/math/math_defs.h"
+#include "core/os/rw_lock.h"
 #include "core/os/semaphore.h"
 
 class NavLinkIteration3D;

--- a/modules/navigation_3d/nav_link_3d.h
+++ b/modules/navigation_3d/nav_link_3d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "3d/nav_base_iteration_3d.h"
+#include "core/os/rw_lock.h"
 #include "nav_base_3d.h"
 #include "nav_utils_3d.h"
 

--- a/modules/navigation_3d/nav_map_3d.h
+++ b/modules/navigation_3d/nav_map_3d.h
@@ -37,6 +37,7 @@
 
 #include "core/math/math_defs.h"
 #include "core/object/worker_thread_pool.h"
+#include "core/os/rw_lock.h"
 #include "servers/navigation_3d/navigation_constants_3d.h"
 
 #include <KdTree2d.h>

--- a/modules/upnp/register_types.cpp
+++ b/modules/upnp/register_types.cpp
@@ -38,6 +38,8 @@
 #include "upnp_miniupnp.h"
 #endif
 
+#include "core/object/class_db.h"
+
 void initialize_upnp_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;

--- a/modules/upnp/upnp.h
+++ b/modules/upnp/upnp.h
@@ -33,6 +33,7 @@
 #include "upnp_device.h"
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 
 class UPNP : public RefCounted {
 	GDCLASS(UPNP, RefCounted);

--- a/modules/upnp/upnp_device.h
+++ b/modules/upnp/upnp_device.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 
 class UPNPDevice : public RefCounted {
 	GDCLASS(UPNPDevice, RefCounted);

--- a/modules/upnp/upnp_device_miniupnp.cpp
+++ b/modules/upnp/upnp_device_miniupnp.cpp
@@ -34,7 +34,13 @@
 
 #include "upnp_miniupnp.h"
 
+#include "core/object/class_db.h"
+
 #include <miniupnpc/upnpcommands.h>
+
+UPNPDevice *UPNPDeviceMiniUPNP::_create(bool p_notify_postinitialize) {
+	return static_cast<UPNPDevice *>(ClassDB::creator<UPNPDeviceMiniUPNP>(p_notify_postinitialize));
+}
 
 void UPNPDeviceMiniUPNP::make_default() {
 	UPNPDevice::_create = UPNPDeviceMiniUPNP::_create;

--- a/modules/upnp/upnp_device_miniupnp.h
+++ b/modules/upnp/upnp_device_miniupnp.h
@@ -38,7 +38,7 @@ class UPNPDeviceMiniUPNP : public UPNPDevice {
 	GDCLASS(UPNPDeviceMiniUPNP, UPNPDevice);
 
 private:
-	static UPNPDevice *_create(bool p_notify_postinitialize) { return static_cast<UPNPDevice *>(ClassDB::creator<UPNPDeviceMiniUPNP>(p_notify_postinitialize)); }
+	static UPNPDevice *_create(bool p_notify_postinitialize);
 
 	String description_url;
 	String service_type;

--- a/modules/upnp/upnp_miniupnp.cpp
+++ b/modules/upnp/upnp_miniupnp.cpp
@@ -34,10 +34,16 @@
 
 #include "upnp_device_miniupnp.h"
 
+#include "core/object/class_db.h"
+
 #include <miniupnpc/miniwget.h>
 #include <miniupnpc/upnpcommands.h>
 
 #include <cstdlib>
+
+UPNP *UPNPMiniUPNP::_create(bool p_notify_postinitialize) {
+	return static_cast<UPNP *>(ClassDB::creator<UPNPMiniUPNP>(p_notify_postinitialize));
+}
 
 void UPNPMiniUPNP::make_default() {
 	UPNP::_create = UPNPMiniUPNP::_create;

--- a/modules/upnp/upnp_miniupnp.h
+++ b/modules/upnp/upnp_miniupnp.h
@@ -40,7 +40,7 @@ class UPNPMiniUPNP : public UPNP {
 	GDCLASS(UPNPMiniUPNP, UPNP);
 
 private:
-	static UPNP *_create(bool p_notify_postinitialize) { return static_cast<UPNP *>(ClassDB::creator<UPNPMiniUPNP>(p_notify_postinitialize)); }
+	static UPNP *_create(bool p_notify_postinitialize);
 
 	String discover_multicast_if = "";
 	int discover_local_port = 0;

--- a/modules/webxr/register_types.cpp
+++ b/modules/webxr/register_types.cpp
@@ -33,6 +33,8 @@
 #include "webxr_interface.h"
 #include "webxr_interface_js.h"
 
+#include "core/object/class_db.h"
+
 #ifdef WEB_ENABLED
 Ref<WebXRInterfaceJS> webxr;
 #endif

--- a/platform/android/api/api.cpp
+++ b/platform/android/api/api.cpp
@@ -35,6 +35,7 @@
 #include "jni_singleton.h"
 
 #include "core/config/engine.h"
+#include "core/object/class_db.h"
 
 #if !defined(ANDROID_ENABLED)
 static JavaClassWrapper *java_class_wrapper = nullptr;

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 
 class Tween;
 class Node;

--- a/servers/camera/camera_server.h
+++ b/servers/camera/camera_server.h
@@ -34,6 +34,7 @@
 #include "core/object/ref_counted.h"
 #include "core/os/thread_safe.h"
 #include "core/templates/rid.h"
+#include "core/variant/binder_common.h"
 
 /**
 	The camera server is a singleton object that gives access to the various

--- a/servers/navigation_2d/navigation_path_query_parameters_2d.h
+++ b/servers/navigation_2d/navigation_path_query_parameters_2d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 #include "servers/navigation_2d/navigation_constants_2d.h"
 
 class NavigationPathQueryParameters2D : public RefCounted {

--- a/servers/navigation_2d/navigation_path_query_result_2d.h
+++ b/servers/navigation_2d/navigation_path_query_result_2d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 #include "core/variant/typed_array.h"
 #include "servers/navigation_2d/navigation_constants_2d.h"
 

--- a/servers/navigation_3d/navigation_path_query_parameters_3d.h
+++ b/servers/navigation_3d/navigation_path_query_parameters_3d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 #include "servers/navigation_3d/navigation_constants_3d.h"
 
 class NavigationPathQueryParameters3D : public RefCounted {

--- a/servers/navigation_3d/navigation_path_query_result_3d.h
+++ b/servers/navigation_3d/navigation_path_query_result_3d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 #include "core/variant/typed_array.h"
 #include "servers/navigation_3d/navigation_constants_3d.h"
 

--- a/servers/xr/xr_interface.h
+++ b/servers/xr/xr_interface.h
@@ -32,6 +32,7 @@
 
 #include "core/object/ref_counted.h"
 #include "core/os/thread_safe.h"
+#include "core/variant/binder_common.h"
 
 /**
 	The XR interface is a template class on top of which we build interface to different AR, VR and tracking SDKs.

--- a/servers/xr/xr_pose.h
+++ b/servers/xr/xr_pose.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 
 class XRPose : public RefCounted {
 	GDCLASS(XRPose, RefCounted);

--- a/servers/xr/xr_server.h
+++ b/servers/xr/xr_server.h
@@ -32,6 +32,7 @@
 
 #include "core/object/ref_counted.h"
 #include "core/os/thread_safe.h"
+#include "core/variant/binder_common.h"
 #include "core/variant/variant.h"
 
 class XRInterface;

--- a/tests/core/io/test_tcp_server.cpp
+++ b/tests/core/io/test_tcp_server.cpp
@@ -35,6 +35,7 @@ TEST_FORCE_LINK(test_tcp_server)
 #include "core/config/project_settings.h"
 #include "core/io/stream_peer_tcp.h"
 #include "core/io/tcp_server.h"
+#include "core/os/os.h"
 
 #include <functional>
 

--- a/tests/core/io/test_udp_server.cpp
+++ b/tests/core/io/test_udp_server.cpp
@@ -34,6 +34,7 @@ TEST_FORCE_LINK(test_udp_server)
 
 #include "core/io/packet_peer_udp.h"
 #include "core/io/udp_server.h"
+#include "core/os/os.h"
 
 #include <functional>
 

--- a/tests/core/io/test_uds_server.cpp
+++ b/tests/core/io/test_uds_server.cpp
@@ -38,6 +38,7 @@ TEST_FORCE_LINK(test_uds_server)
 #include "core/io/file_access.h"
 #include "core/io/stream_peer_uds.h"
 #include "core/io/uds_server.h"
+#include "core/os/os.h"
 
 #include <functional>
 

--- a/tests/core/threads/test_worker_thread_pool.cpp
+++ b/tests/core/threads/test_worker_thread_pool.cpp
@@ -32,6 +32,7 @@
 
 TEST_FORCE_LINK(test_worker_thread_pool)
 
+#include "core/object/callable_method_pointer.h"
 #include "core/object/worker_thread_pool.h"
 
 namespace TestWorkerThreadPool {


### PR DESCRIPTION
- Helps address #111218

Changes:
- `Ref` templates for `PtrToArg`, `GetTypeInfo`, and `VariantInternalAccessor` were migrated to the original headers, as there's no longer a risk of circular includes.
- Headers with functions operating on `ClassDB` directly had their logic migrated to implementation files.

I know there's been hesitation in the past about tackling the removal of `class_db.h` includes[^1], but I think the changes here demonstrate that this warrants revisiting. Even after migrating `ClassDB` logic to implementation files, many headers & implementation files alike *still* needed additional includes. This is because several of the affected files weren't for `Object` subclasses at all; plenty of utilities were including `class_db.h` indirectly!

This isn't even mentioning the current cost of these includes. `class_db.h` and `ref_counted.h` both rank in the top 5 of fresh compile **and** recompile times. While `Object` and `Variant` are likely the two "real" compile-time culprits, `Ref` wasn't helping matters with a direct include of `ClassDB`. So while it'll likely still rank fairly high, it's feasible that this change alone could dethrone `ref_counted.h` as the single most expensive file from a fresh compilation.

[^1]: https://github.com/godotengine/godot/pull/111573#pullrequestreview-3330940683