### PR TITLE
Fix drop preview not working when dragging tabs between windows

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -503,7 +503,19 @@ void TabBar::_notification(int p_what) {
 			[[fallthrough]];
 		}
 
+		case NOTIFICATION_DRAG_BEGIN:
+		case NOTIFICATION_MOUSE_ENTER: {
+			if (get_viewport()->gui_is_dragging() && can_drop_data(get_local_mouse_position(), get_viewport()->gui_get_drag_data())) {
+				dragging_valid_tab = true;
+				queue_redraw();
+			}
+		} break;
+
 		case NOTIFICATION_MOUSE_EXIT: {
+			if (dragging_valid_tab) {
+				dragging_valid_tab = false;
+				queue_redraw();
+			}
 			if (!hover_switch_delay->is_stopped()) {
 				hover_switch_delay->stop();
 			}


### PR DESCRIPTION
Show tab drop preview across native windows during tab drag

Fixes #116577 

When dragging a TabContainer/TabBar tab between non-embedded windows, the
target TabBar could fail to show the drop marker because preview activation
depended on local mouse motion input only.

By updating TabBar drag preview state on drag and hover lifecycle
notifications (NOTIFICATION_DRAG_BEGIN, NOTIFICATION_MOUSE_ENTER,
NOTIFICATION_MOUSE_EXIT), this change ensures the drop indicator appears
reliably for cross-window tab drags.