### PR TITLE
Add warning for renaming animation name

### DIFF
--- a/editor/animation/animation_library_editor.cpp
+++ b/editor/animation/animation_library_editor.cpp
@@ -484,6 +484,8 @@ void AnimationLibraryEditor::_item_renamed() {
 			// Renamed library
 
 			if (mixer->has_animation_library(text)) {
+				error_dialog->set_text(vformat(TTR("Animation '%s' already exists!"), text));
+				error_dialog->popup_centered();
 				restore_text = true;
 			} else {
 				undo_redo->create_action(vformat(TTR("Rename Animation Library: %s"), text));
@@ -508,6 +510,8 @@ void AnimationLibraryEditor::_item_renamed() {
 
 			if (al.is_valid()) {
 				if (al->has_animation(text)) {
+					error_dialog->set_text(vformat(TTR("Animation '%s' already exists!"), text));
+					error_dialog->popup_centered();
 					restore_text = true;
 				} else {
 					undo_redo->create_action(vformat(TTR("Rename Animation: %s"), text));


### PR DESCRIPTION
- Fixes: https://github.com/godotengine/godot/issues/116732

## Issue Description

Just add warning for renaming animation name in animation manager.

MRP:  [test-116732.zip](https://github.com/user-attachments/files/25535470/test-116732.zip)

[anim-manage-alert.webm](https://github.com/user-attachments/assets/2f133677-ab20-4d58-a02a-1e7ccfd12563)
