### PR TITLE
Expose methods to add/remove format queries in `EditorFileSystem`

### DIFF
--- a/doc/classes/EditorFileSystem.xml
+++ b/doc/classes/EditorFileSystem.xml
@@ -10,6 +10,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="add_import_format_support_query">
+			<return type="void" />
+			<param index="0" name="query" type="EditorFileSystemImportFormatSupportQuery" />
+			<description>
+				Adds an import format support query to be used by the filesystem.
+			</description>
+		</method>
 		<method name="get_file_type" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="path" type="String" />
@@ -55,6 +62,13 @@
 				Reimports a set of files. Call this if these files or their [code].import[/code] files were directly edited by script or an external program.
 				If the file type changed or the file was newly created, use [method update_file] or [method scan].
 				[b]Note:[/b] This function blocks until the import is finished. However, the main loop iteration, including timers and [method Node._process], will occur during the import process due to progress bar updates. Avoid calls to [method reimport_files] or [method scan] while an import is in progress.
+			</description>
+		</method>
+		<method name="remove_import_format_support_query">
+			<return type="void" />
+			<param index="0" name="query" type="EditorFileSystemImportFormatSupportQuery" />
+			<description>
+				Removes an import format support query from the filesystem.
 			</description>
 		</method>
 		<method name="scan">

--- a/doc/classes/EditorFileSystemImportFormatSupportQuery.xml
+++ b/doc/classes/EditorFileSystemImportFormatSupportQuery.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This class is used to query and configure a certain import format. It is used in conjunction with asset format import plugins.
+		To use [EditorFileSystemImportFormatSupportQuery], register it using the [method EditorFileSystem.add_import_format_support_query] method first.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -3697,6 +3697,8 @@ void EditorFileSystem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_filesystem_path", "path"), &EditorFileSystem::get_filesystem_path);
 	ClassDB::bind_method(D_METHOD("get_file_type", "path"), &EditorFileSystem::get_file_type);
 	ClassDB::bind_method(D_METHOD("reimport_files", "files"), &EditorFileSystem::reimport_files);
+	ClassDB::bind_method(D_METHOD("add_import_format_support_query", "query"), &EditorFileSystem::add_import_format_support_query);
+	ClassDB::bind_method(D_METHOD("remove_import_format_support_query", "query"), &EditorFileSystem::remove_import_format_support_query);
 
 	ADD_SIGNAL(MethodInfo("filesystem_changed"));
 	ADD_SIGNAL(MethodInfo("script_classes_updated"));


### PR DESCRIPTION
`EditorFileSystemImportFormatSupportQuery` is a class exposed to scripting, however for it to work properly, it needs to be added to `EditorFileSystem` using `EditorFileSystem::add_import_format_support_query`, which is a method that is not exposed. This fixes that by exposing both the methods to add and remove format queries.
