### PR TITLE
Add warnings in Node3D about losing transformations

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -1357,7 +1357,6 @@ PackedStringArray Node3D::get_configuration_warnings() const {
 	return warnings;
 }
 
-
 void Node3D::_validate_property(PropertyInfo &p_property) const {
 	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_BASIS && p_property.name == "basis") {
 		p_property.usage = PROPERTY_USAGE_NONE;

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -32,11 +32,10 @@
 
 #include "core/math/transform_interpolator.h"
 #include "scene/3d/visual_instance_3d.h"
-#include "scene/main/viewport.h"
 #include "scene/property_utils.h"
 #include "scene/main/window.h"
 
-		/*
+/*
 
  possible algorithms:
 
@@ -1352,10 +1351,10 @@ NodePath Node3D::get_visibility_parent() const {
 PackedStringArray Node3D::get_configuration_warnings() const {
 	PackedStringArray warnings = Node::get_configuration_warnings();
 	Node *parent = get_parent();
-	if (parent && !Object::cast_to<Node3D>(parent) && parent != get_tree()->get_root() && get_owner() != nullptr) {
+	if (parent && !Object::cast_to<Node3D>(parent) && parent != get_tree()->get_root() && get_owner()) {
 		warnings.push_back(
-				RTR("This Node3D is a child of a Node that has no Transform. "
-					"It will not inherit a 3D transform."));
+			RTR("This Node3D is a child of a Node that has no Transform. \nIt will not inherit a 3D transform.")
+		);
 	}
 	return warnings;
 }

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -1352,9 +1352,7 @@ PackedStringArray Node3D::get_configuration_warnings() const {
 	PackedStringArray warnings = Node::get_configuration_warnings();
 	Node *parent = get_parent();
 	if (parent && !Object::cast_to<Node3D>(parent) && parent != get_tree()->get_root() && get_owner()) {
-		warnings.push_back(
-			RTR("This Node3D is a child of a Node that has no Transform. \nIt will not inherit a 3D transform.")
-		);
+		warnings.push_back(RTR("This Node3D is a child of a Node that has no Transform. It will not inherit a 3D transform."));
 	}
 	return warnings;
 }

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -32,8 +32,8 @@
 
 #include "core/math/transform_interpolator.h"
 #include "scene/3d/visual_instance_3d.h"
-#include "scene/property_utils.h"
 #include "scene/main/window.h"
+#include "scene/property_utils.h"
 
 /*
 

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -34,8 +34,9 @@
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/main/viewport.h"
 #include "scene/property_utils.h"
+#include "scene/main/window.h"
 
-/*
+		/*
 
  possible algorithms:
 
@@ -1347,6 +1348,18 @@ NodePath Node3D::get_visibility_parent() const {
 	ERR_READ_THREAD_GUARD_V(NodePath());
 	return visibility_parent_path;
 }
+
+PackedStringArray Node3D::get_configuration_warnings() const {
+	PackedStringArray warnings = Node::get_configuration_warnings();
+	Node *parent = get_parent();
+	if (parent && !Object::cast_to<Node3D>(parent) && parent != get_tree()->get_root() && get_owner() != nullptr) {
+		warnings.push_back(
+				RTR("This Node3D is a child of a Node that has no Transform. "
+					"It will not inherit a 3D transform."));
+	}
+	return warnings;
+}
+
 
 void Node3D::_validate_property(PropertyInfo &p_property) const {
 	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_BASIS && p_property.name == "basis") {

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -353,6 +353,8 @@ public:
 	void set_visibility_parent(const NodePath &p_path);
 	NodePath get_visibility_parent() const;
 
+	PackedStringArray get_configuration_warnings() const override;
+
 	Node3D();
 	~Node3D();
 };


### PR DESCRIPTION
Add warnings in Node3D to warn when a Node3D is parented to a node without a 3D transform (and not the scene root) and has an owner. The warning helps users detect that the node will not inherit a 3D transform.

<details>
  <summary>Example</summary>
  <img width="1096" height="618" alt="image" src="https://github.com/user-attachments/assets/5e7a29b2-9570-48b5-9e30-21e94ffcdfac" />
</details>

Closes: https://github.com/godotengine/godot-proposals/issues/14328 