### PR TITLE
Add Click Margin Theme Constant for `BaseButton`

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -129,4 +129,9 @@
 			Require a press and a subsequent release before considering the button clicked.
 		</constant>
 	</constants>
+	<theme_items>
+		<theme_item name="click_margin" data_type="constant" type="int" default="0">
+			Defines the margin around the button's area that still counts as a valid click. This is useful to make it easier to click small buttons.
+		</theme_item>
+	</theme_items>
 </class>

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -419,6 +419,14 @@ void ThemeClassic::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edi
 
 		p_theme->set_constant("align_to_largest_stylebox", "Button", 1); // Enabled.
 
+#ifdef ANDROID_ENABLED
+		// Use a larger click margin on the Android editor to improve touchscreen usability.
+		const int click_margin = Math::round(4 * EDSCALE);
+#else
+		const int click_margin = Math::round(2 * EDSCALE);
+#endif
+		p_theme->set_constant("click_margin", "BaseButton", click_margin);
+
 		// MenuBar.
 
 		p_theme->set_stylebox(CoreStringName(normal), "MenuBar", p_config.button_style);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -496,6 +496,14 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		p_theme->set_constant("outline_size", "Button", 0);
 		p_theme->set_constant("align_to_largest_stylebox", "Button", 1); // Enabled.
 
+#ifdef ANDROID_ENABLED
+		// Use a larger click margin on the Android editor to improve touchscreen usability.
+		const int click_margin = Math::round(4 * EDSCALE);
+#else
+		const int click_margin = Math::round(2 * EDSCALE);
+#endif
+		p_theme->set_constant("click_margin", "BaseButton", click_margin);
+
 		// MenuBar.
 
 		p_theme->set_stylebox(CoreStringName(normal), "MenuBar", p_config.button_style);

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -35,6 +35,7 @@
 #include "core/object/class_db.h"
 #include "scene/gui/label.h"
 #include "scene/main/timer.h"
+#include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"
 
 void BaseButton::_unpress_group() {
@@ -394,6 +395,16 @@ BaseButton::DrawMode BaseButton::get_draw_mode() const {
 	}
 }
 
+bool BaseButton::has_point(const Point2 &p_point) const {
+	ERR_READ_THREAD_GUARD_V(false);
+	bool ret;
+	if (GDVIRTUAL_CALL(_has_point, p_point, ret)) {
+		return ret;
+	}
+	Rect2 rect = Rect2(Point2(), get_size()).grow(theme_cache.click_margin);
+	return rect.has_area() && rect.has_point(p_point);
+}
+
 void BaseButton::set_toggle_mode(bool p_on) {
 	// Make sure to set 'pressed' to false if we are not in toggle mode
 	if (!p_on) {
@@ -624,6 +635,8 @@ void BaseButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shortcut", PROPERTY_HINT_RESOURCE_TYPE, Shortcut::get_class_static()), "set_shortcut", "get_shortcut");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shortcut_feedback"), "set_shortcut_feedback", "is_shortcut_feedback");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shortcut_in_tooltip"), "set_shortcut_in_tooltip", "is_shortcut_in_tooltip_enabled");
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, BaseButton, click_margin);
 
 	BIND_ENUM_CONSTANT(DRAW_NORMAL);
 	BIND_ENUM_CONSTANT(DRAW_PRESSED);

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -46,6 +46,10 @@ public:
 	};
 
 private:
+	struct ThemeCache {
+		int click_margin = 0;
+	} theme_cache;
+
 	BitField<MouseButtonMask> button_mask = MouseButtonMask::LEFT;
 	bool toggle_mode = false;
 	bool shortcut_in_tooltip = true;
@@ -102,6 +106,8 @@ public:
 	};
 
 	DrawMode get_draw_mode() const;
+
+	virtual bool has_point(const Point2 &p_point) const override;
 
 	/* Signals */
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4338

This adds a Hit Margin Theme Constant for BaseButton. 
The only way I found to implement this was by overriding the has_point for the BaseButton. This is needed since the BaseButton uses gui_input for detecting input  and gui_input is only be called when has_point is true.


https://github.com/user-attachments/assets/dcf7f715-f0cd-45e9-bf6b-44ad34ae820a


