### PR TITLE
Share one `JoltTempAllocator` instance across all `JoltSpace3D`

### DIFF
--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -52,6 +52,7 @@
 #include "spaces/jolt_job_system.h"
 #include "spaces/jolt_physics_direct_space_state_3d.h"
 #include "spaces/jolt_space_3d.h"
+#include "spaces/jolt_temp_allocator.h"
 
 JoltPhysicsServer3D::JoltPhysicsServer3D(bool p_on_separate_thread) :
 		on_separate_thread(p_on_separate_thread) {
@@ -181,7 +182,7 @@ real_t JoltPhysicsServer3D::shape_get_custom_solver_bias(RID p_shape) const {
 }
 
 RID JoltPhysicsServer3D::space_create() {
-	JoltSpace3D *space = memnew(JoltSpace3D(job_system));
+	JoltSpace3D *space = memnew(JoltSpace3D(job_system, temp_allocator));
 	RID rid = space_owner.make_rid(space);
 	space->set_rid(rid);
 
@@ -1605,9 +1606,15 @@ void JoltPhysicsServer3D::set_active(bool p_active) {
 
 void JoltPhysicsServer3D::init() {
 	job_system = new JoltJobSystem();
+	temp_allocator = new JoltTempAllocator();
 }
 
 void JoltPhysicsServer3D::finish() {
+	if (temp_allocator != nullptr) {
+		delete temp_allocator;
+		temp_allocator = nullptr;
+	}
+
 	if (job_system != nullptr) {
 		delete job_system;
 		job_system = nullptr;

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -40,6 +40,7 @@ class JoltJoint3D;
 class JoltShape3D;
 class JoltSoftBody3D;
 class JoltSpace3D;
+class JoltTempAllocator;
 
 class JoltPhysicsServer3D final : public PhysicsServer3D {
 	GDCLASS(JoltPhysicsServer3D, PhysicsServer3D)
@@ -56,6 +57,7 @@ class JoltPhysicsServer3D final : public PhysicsServer3D {
 	HashSet<JoltSpace3D *> active_spaces;
 
 	JoltJobSystem *job_system = nullptr;
+	JoltTempAllocator *temp_allocator = nullptr;
 
 	bool on_separate_thread = false;
 	bool active = true;

--- a/modules/jolt_physics/spaces/jolt_space_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_space_3d.cpp
@@ -42,7 +42,6 @@
 #include "jolt_contact_listener_3d.h"
 #include "jolt_layers.h"
 #include "jolt_physics_direct_space_state_3d.h"
-#include "jolt_temp_allocator.h"
 
 #include "core/io/file_access.h"
 #include "core/os/time.h"
@@ -106,9 +105,9 @@ void JoltSpace3D::_post_step(float p_step) {
 	}
 }
 
-JoltSpace3D::JoltSpace3D(JPH::JobSystem *p_job_system) :
+JoltSpace3D::JoltSpace3D(JPH::JobSystem *p_job_system, JPH::TempAllocator *p_temp_allocator) :
 		job_system(p_job_system),
-		temp_allocator(new JoltTempAllocator()),
+		temp_allocator(p_temp_allocator),
 		layers(new JoltLayers()),
 		contact_listener(new JoltContactListener3D(this)),
 		body_activation_listener(new JoltBodyActivationListener3D()),
@@ -181,11 +180,6 @@ JoltSpace3D::~JoltSpace3D() {
 	if (layers != nullptr) {
 		delete layers;
 		layers = nullptr;
-	}
-
-	if (temp_allocator != nullptr) {
-		delete temp_allocator;
-		temp_allocator = nullptr;
 	}
 }
 

--- a/modules/jolt_physics/spaces/jolt_space_3d.h
+++ b/modules/jolt_physics/spaces/jolt_space_3d.h
@@ -85,7 +85,7 @@ class JoltSpace3D {
 	void _post_step(float p_step);
 
 public:
-	explicit JoltSpace3D(JPH::JobSystem *p_job_system);
+	explicit JoltSpace3D(JPH::JobSystem *p_job_system, JPH::TempAllocator *p_temp_allocator);
 	~JoltSpace3D();
 
 	void step(float p_step);


### PR DESCRIPTION
This makes it so all instances of `JoltSpace3D` share the same instance of `JoltTempAllocator`, which is a LIFO allocator that's used by Jolt internally.

This could potentially be problematic if we ever stepped multiple physics spaces in parallel, but that's not something that we do at the moment, nor have any plans to, and sharing a single `JoltTempAllocator` across all spaces means we don't have to allocate a buffer the size of `physics/jolt_physics_3d/limits/temporary_memory_buffer_size` (which is 32 MiB by default) for every single physics space, like for example when using multiple viewports that have [`own_world_3d`](https://docs.godotengine.org/en/4.6/classes/class_viewport.html#class-viewport-property-own-world-3d) enabled.