### PR TITLE
Tidy some things up in `modules/jolt_physics`

### DIFF
--- a/modules/jolt_physics/objects/jolt_object_3d.h
+++ b/modules/jolt_physics/objects/jolt_object_3d.h
@@ -61,8 +61,6 @@ public:
 	};
 
 protected:
-	LocalVector<JoltShapeInstance3D> shapes;
-
 	RID rid;
 	ObjectID instance_id;
 	JoltSpace3D *space = nullptr;

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
@@ -286,7 +286,7 @@ JPH::ShapeRefC JoltShapedObject3D::build_shapes(bool p_optimize_compound) {
 
 	if (new_shape == nullptr) {
 		if (has_custom_center_of_mass()) {
-			new_shape = JPH::EmptyShapeSettings(to_jolt(get_center_of_mass_custom())).Create().Get();
+			new_shape = new JPH::EmptyShape(to_jolt(get_center_of_mass_custom()));
 		} else {
 			new_shape = new JPH::EmptyShape();
 		}

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.h
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.h
@@ -46,6 +46,8 @@ protected:
 	SelfList<JoltShapedObject3D> shapes_changed_element;
 	SelfList<JoltShapedObject3D> needs_optimization_element;
 
+	LocalVector<JoltShapeInstance3D> shapes;
+
 	Vector3 scale = Vector3(1, 1, 1);
 
 	JPH::ShapeRefC jolt_shape;

--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
@@ -447,7 +447,7 @@ void JoltContactListener3D::_evaluate_area_overlap(const JoltArea3D &p_area, con
 	const MutexLock write_lock(write_mutex);
 
 	if (p_area.can_monitor(p_body)) {
-		area_soft_body_overlaps.insert(p_shape_pair);
+		area_soft_body_overlaps.push_back(p_shape_pair);
 		if (!area_exits.erase(p_shape_pair)) {
 			area_enters.insert(p_shape_pair);
 		}

--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
@@ -88,9 +88,9 @@ class JoltContactListener3D final
 
 	HashMap<JPH::SubShapeIDPair, Manifold, ShapePairHasher> manifolds_by_shape_pair;
 	HashSet<JPH::SubShapeIDPair, ShapePairHasher> area_overlaps;
-	HashSet<JPH::SubShapeIDPair, ShapePairHasher> area_soft_body_overlaps;
 	HashSet<JPH::SubShapeIDPair, ShapePairHasher> area_enters;
 	HashSet<JPH::SubShapeIDPair, ShapePairHasher> area_exits;
+	LocalVector<JPH::SubShapeIDPair> area_soft_body_overlaps;
 	Mutex write_mutex;
 	JoltSpace3D *space = nullptr;
 

--- a/modules/jolt_physics/spaces/jolt_space_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_space_3d.cpp
@@ -94,9 +94,14 @@ void JoltSpace3D::_pre_step(float p_step) {
 		JoltObject3D *object = reinterpret_cast<JoltObject3D *>(jolt_body->GetUserData());
 		object->pre_step(p_step, *jolt_body);
 	}
+
+	physics_system->SetBodyActivationListener(body_activation_listener);
 }
 
 void JoltSpace3D::_post_step(float p_step) {
+	// We only want a listener during the step, as it will otherwise be called when pending bodies are flushed, which causes issues (e.g. GH-115322).
+	physics_system->SetBodyActivationListener(nullptr);
+
 	contact_listener->post_step();
 
 	while (shapes_changed_list.first()) {
@@ -195,8 +200,6 @@ void JoltSpace3D::step(float p_step) {
 
 	_pre_step(p_step);
 
-	physics_system->SetBodyActivationListener(body_activation_listener);
-
 	const JPH::EPhysicsUpdateError update_error = physics_system->Update(p_step, 1, temp_allocator, job_system);
 
 	if ((update_error & JPH::EPhysicsUpdateError::ManifoldCacheFull) != JPH::EPhysicsUpdateError::None) {
@@ -219,9 +222,6 @@ void JoltSpace3D::step(float p_step) {
 								"Maximum number of contact constraints is currently set to %d.",
 				JoltProjectSettings::max_contact_constraints));
 	}
-
-	// We only want a listener during the step, as it will otherwise be called when pending bodies are flushed, which causes issues (e.g. GH-115322).
-	physics_system->SetBodyActivationListener(nullptr);
 
 	_post_step(p_step);
 


### PR DESCRIPTION
I'm sure I could find many more things to change, but I've had some of these lying around in a branch for months now, waiting for more of these minor changes to pile up, and now seems like a good time to push them.

The changes are as follows:

1. Moved `JoltObject3D::shapes` into `JoltShapedObject3D` instead, since it had no business being there, so just added 16 bytes to every `JoltSoftBody3D` for no reason.
2. Have the creation of `JPH::EmptyShape` just use the constructor rather than going the roundabout way of `JPH::EmptyShapeSettings(...).Create().Get()`.
3. Moved the recently moved `SetBodyActivationListener` calls from `JoltSpace3D::step` into `JoltSpace3D::_pre_step` and `JoltSpace3D::_post_step`, where they arguably belong.
4. Changed `JoltContactListener3D::area_soft_body_overlaps` to be a `LocalVector` instead of a `HashSet`, since we have no need for the deduplication, sorting or lookup that `HashSet` would offer.