### PR TITLE
CI: Pass `generate_bundle=yes` to apple builders

### DIFF
--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -9,6 +9,7 @@ env:
     dev_mode=yes
     module_text_server_fb_enabled=yes
     debug_symbols=no
+    generate_bundle=yes
 
 jobs:
   ios-template:

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -23,13 +23,13 @@ jobs:
           - name: Editor (target=editor)
             cache-name: macos-editor
             target: editor
-            bin: ./bin/godot.macos.editor.universal
+            bin: ./godot.macos.editor.universal
 
           - name: Template (target=template_release)
             cache-name: macos-template
             target: template_release
             scons-flags: debug_symbols=no
-            bin: ./bin/godot.macos.template_release.universal
+            bin: ./godot.macos.template_release.universal
 
     steps:
       - name: Checkout
@@ -82,7 +82,7 @@ jobs:
       - name: Compilation (arm64)
         uses: ./.github/actions/godot-build
         with:
-          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }} arch=arm64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }}
+          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }} arch=arm64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }} generate_bundle=yes
           platform: macos
           target: ${{ matrix.target }}
 
@@ -94,10 +94,10 @@ jobs:
 
       - name: Prepare artifact
         run: |
-          lipo -create ./bin/godot.macos.${{ matrix.target }}.x86_64 ./bin/godot.macos.${{ matrix.target }}.arm64 -output ./bin/godot.macos.${{ matrix.target }}.universal
-          rm ./bin/godot.macos.${{ matrix.target }}.x86_64 ./bin/godot.macos.${{ matrix.target }}.arm64
-          strip bin/godot.*
-          chmod +x bin/godot.*
+          lipo -create ./bin/godot.macos.${{ matrix.target }}.x86_64 ./bin/godot.macos.${{ matrix.target }}.arm64 -output ${{ matrix.bin }}
+          rm ./bin/godot.*
+          strip ${{ matrix.bin }}
+          chmod +x ${{ matrix.bin }}
 
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact


### PR DESCRIPTION
- [RC thread for context](https://chat.godotengine.org/channel/apple?msg=CdMnHNCnYRpvxXD9p)

Amends the `iOS` and `macOS` builders with `generate_bundle=yes`, which should make the templates produced "feature-complete". I've never built for apple platforms before so I'm flying a bit blind, but `iOS` should be fully accounted for at least. For `macOS` I'm currently passing the value for both editor and template on both architectures; will likely need further adjustment based on build output