### PR TITLE
Clarify that Linux supports the Use System Accent Color setting

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1246,7 +1246,7 @@
 		</member>
 		<member name="interface/theme/use_system_accent_color" type="bool" setter="" getter="">
 			If [code]true[/code], set accent color based on system settings.
-			[b]Note:[/b] This setting is only effective on Windows, MacOS, and Android.
+			[b]Note:[/b] This setting is effective on Windows, macOS, Linux, and Android.
 		</member>
 		<member name="interface/touchscreen/enable_long_press_as_right_click" type="bool" setter="" getter="">
 			If [code]true[/code], long press on touchscreen is treated as right click.


### PR DESCRIPTION
A reopening of #104128.

Linux has accent color support now, and should be written along with the other platforms in the docs