### PR TITLE
Autocompletion: Don't hide certain setters and getters

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1539,11 +1539,14 @@ void ClassDB::add_property(const StringName &p_class, const PropertyInfo &p_pinf
 	type->property_list.push_back(p_pinfo);
 	type->property_map[p_pinfo.name] = p_pinfo;
 #ifdef DEBUG_ENABLED
-	if (mb_get) {
-		type->methods_in_properties.insert(p_getter);
-	}
-	if (mb_set) {
-		type->methods_in_properties.insert(p_setter);
+	// Used to filter out setters and getters in the editor (e.g. autocomplete) to not clutter menus. We only want to filter methods from properties that are easily available to users.
+	if (p_index == -1 && !(p_pinfo.usage & PropertyUsageFlags::PROPERTY_USAGE_INTERNAL)) {
+		if (mb_get) {
+			type->methods_in_properties.insert(p_getter);
+		}
+		if (mb_set) {
+			type->methods_in_properties.insert(p_setter);
+		}
 	}
 #endif // DEBUG_ENABLED
 	PropertySetGet psg;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/116717
Fixes https://github.com/godotengine/godot/issues/114832

Autocompletion filters out getters and setters to not clutter the list. However the filtering applied hides some important methods: indexed props are not easily accessible in other ways and so their getters and setter should be suggest. Also if a property is internal, we really should not hide its public setters and getters.

Sanity check: Is this the right place for fixing this, it's `core/` after all?

`p_methods` is only used together with `p_exclude_from_properties`. `p_exclude_from_properties` is not exposed and only used in two places: autocompletion and listing methods for some picker dialog in the editor. So yeah this is a good place to fix this.

Due to the very limited audience of the parameter there really is no need for any more finegrained control as suggested in https://github.com/godotengine/godot/issues/116717#issuecomment-3958407007

<sub>@wjt I added you as co-author, since half of this PR is basically your suggested patch</sub>