### PR TITLE
Fix misleading physics picking doc in `Viewport`

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -394,17 +394,17 @@
 		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="1" />
 		<member name="physics_object_picking" type="bool" setter="set_physics_object_picking" getter="get_physics_object_picking" default="false">
 			If [code]true[/code], the objects rendered by viewport become subjects of mouse picking process.
-			[b]Note:[/b] The number of simultaneously pickable objects is limited to 64 and they are selected in a non-deterministic order, which can be different in each picking process.
+			[b]Note:[/b] The number of [CanvasItem]s pickable by a single input is limited to 64 and they are selected in a non-deterministic order. The number of pickable 3D objects is not limited.
 		</member>
 		<member name="physics_object_picking_first_only" type="bool" setter="set_physics_object_picking_first_only" getter="get_physics_object_picking_first_only" default="false">
 			If [code]true[/code], the input_event signal will only be sent to one physics object in the mouse picking process. If you want to get the top object only, you must also enable [member physics_object_picking_sort].
 			If [code]false[/code], an input_event signal will be sent to all physics objects in the mouse picking process.
-			This applies to 2D CanvasItem object picking only.
+			This applies to [CanvasItem] picking only.
 		</member>
 		<member name="physics_object_picking_sort" type="bool" setter="set_physics_object_picking_sort" getter="get_physics_object_picking_sort" default="false">
-			If [code]true[/code], objects receive mouse picking events sorted primarily by their [member CanvasItem.z_index] and secondarily by their position in the scene tree. If [code]false[/code], the order is undetermined.
+			If [code]true[/code], objects receive mouse picking events sorted primarily by their [member CanvasItem.z_index] and secondarily by their position in the scene tree. If [code]false[/code], the order is non-deterministic.
 			[b]Note:[/b] This setting is disabled by default because of its potential expensive computational cost.
-			[b]Note:[/b] Sorting happens after selecting the pickable objects. Because of the limitation of 64 simultaneously pickable objects, it is not guaranteed that the object with the highest [member CanvasItem.z_index] receives the picking event.
+			[b]Note:[/b] Sorting happens after selecting the pickable objects. If surpassing the maximum of 64 [CanvasItem]s pickable by a single input, it is not guaranteed that the object with the highest [member CanvasItem.z_index] receives the picking event.
 		</member>
 		<member name="positional_shadow_atlas_16_bits" type="bool" setter="set_positional_shadow_atlas_16_bits" getter="get_positional_shadow_atlas_16_bits" default="true">
 			Use 16 bits for the omni/spot shadow depth map. Enabling this results in shadows having less precision and may result in shadow acne, but can lead to performance improvements on some devices.


### PR DESCRIPTION
While investigating the physics picking features for a 3D game, I came across this note in `Viewport`:
> The number of simultaneously pickable objects is limited to 64 and they are selected in a non-deterministic order, which can be different in each picking process.

I took this to mean that having more than 64 pickable `CollisionObject3D`s in a scene will not work. Being very confused by why such a limitation is necessary I started browsing the source and PR history. The note was added in #80875 with this context - https://github.com/godotengine/godot/issues/80769#issuecomment-1684466790.

Turns out the limit of 64 is for `CanvasItem` picking, which I didn't know existed at all, and it also is about number of objects pickable by a single event, so the note is doubly misleading.

Also reworded some other parts of the physics picking docs.