### PR TITLE
Fix Warp mouse on Tablet/Trackpad 3D Navigation Scheme

### DIFF
--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -2006,12 +2006,31 @@ static bool _redirect_freelook_input(const Ref<InputEvent> &p_event, Node3DEdito
 // This is only active during instant transforms,
 // to capture and wrap mouse events outside the control.
 void Node3DEditorViewport::input(const Ref<InputEvent> &p_event) {
-	ERR_FAIL_COND(!_edit.instant);
-	Ref<InputEventMouseMotion> m = p_event;
+	if (!_edit.instant && !emulated_nav_mouse_captured) {
+		return;
+	}
 
-	if (m.is_valid()) {
+	Ref<InputEventMouseMotion> m = p_event;
+	if (!m.is_valid()) {
+		return;
+	}
+
+	if (_edit.instant) {
 		_edit.mouse_pos += view_3d_controller->get_warped_mouse_motion(p_event, surface->get_global_rect());
 		update_transform(_get_key_modifier(m) == Key::SHIFT);
+		return;
+	}
+
+	if (surface->get_global_rect().has_point(m->get_global_position())) {
+		// Ignore regular in-viewport motion while emulated navigation is captured.
+		return;
+	}
+
+	_edit.mouse_pos += m->get_relative();
+	view_3d_controller->gui_input(p_event, surface->get_global_rect());
+	if (!view_3d_controller->is_navigating()) {
+		emulated_nav_mouse_captured = false;
+		set_process_input(_edit.instant);
 	}
 }
 
@@ -2196,6 +2215,28 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 	// Several parts of the 3D navigation are handled here.
 	bool was_navigating = view_3d_controller->is_navigating();
 	view_3d_controller->gui_input(p_event, surface->get_global_rect());
+
+	const BitField<MouseButtonMask> mouse_mask = Input::get_singleton()->get_mouse_button_mask();
+	const bool no_mouse_buttons_pressed = !mouse_mask.has_flag(MouseButtonMask::LEFT) &&
+			!mouse_mask.has_flag(MouseButtonMask::MIDDLE) &&
+			!mouse_mask.has_flag(MouseButtonMask::RIGHT) &&
+			!mouse_mask.has_flag(MouseButtonMask::MB_XBUTTON1) &&
+			!mouse_mask.has_flag(MouseButtonMask::MB_XBUTTON2);
+	const bool emulated_nav_active = bool(EDITOR_GET("editors/3d/navigation/emulate_3_button_mouse")) &&
+			!view_3d_controller->is_freelook_enabled() &&
+			Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_VISIBLE &&
+			no_mouse_buttons_pressed &&
+			view_3d_controller->is_navigating();
+
+	if (!emulated_nav_mouse_captured && emulated_nav_active) {
+		emulated_nav_mouse_captured = true;
+		set_process_input(true);
+	}
+
+	if (emulated_nav_mouse_captured && !view_3d_controller->is_navigating()) {
+		emulated_nav_mouse_captured = false;
+		set_process_input(_edit.instant);
+	}
 	if (was_navigating && !view_3d_controller->is_navigating()) {
 		return;
 	}
@@ -2516,6 +2557,15 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 					surface->queue_redraw();
 				} else {
+					if (emulated_nav_mouse_captured) {
+						emulated_nav_mouse_captured = false;
+						set_process_input(_edit.instant);
+						Input::MouseMode mouse_mode = Input::get_singleton()->get_mouse_mode();
+						if (mouse_mode == Input::MouseMode::MOUSE_MODE_CAPTURED || mouse_mode == Input::MouseMode::MOUSE_MODE_CONFINED || mouse_mode == Input::MouseMode::MOUSE_MODE_CONFINED_HIDDEN) {
+							Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
+						}
+					}
+
 					if (ruler->is_inside_tree()) {
 						EditorNode::get_singleton()->get_scene_root()->remove_child(ruler);
 						ruler_start_point->set_visible(false);

--- a/editor/scene/3d/node_3d_editor_viewport.h
+++ b/editor/scene/3d/node_3d_editor_viewport.h
@@ -288,6 +288,7 @@ private:
 	bool vertex_snap_has_target = false;
 	bool vertex_snap_has_source = false;
 	HashMap<ObjectID, Vector3> vertex_snap_original_positions;
+	bool emulated_nav_mouse_captured = false;
 
 	PanelContainer *info_panel = nullptr;
 	Label *info_label = nullptr;

--- a/scene/debugger/view_3d_controller.cpp
+++ b/scene/debugger/view_3d_controller.cpp
@@ -771,7 +771,8 @@ void View3DController::set_auto_orthogonal_allowed(const bool p_enabled) {
 }
 
 Point2 View3DController::get_warped_mouse_motion(const Ref<InputEventMouseMotion> &p_event, const Rect2 &p_surface_rect) const {
-	if (warped_mouse_panning) {
+	const bool captured_mode = Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_CAPTURED;
+	if (warped_mouse_panning && !captured_mode) {
 		return Input::get_singleton()->warp_mouse_motion(p_event, p_surface_rect);
 	}
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/5c8c19a7-3826-4cb4-b2b3-ba1866cf1e0c

**(the lag in the video is not reflective of how the engine is running, it's just the windows snipping tool doing some weird cuts on the video).**

This fixes #116177 where emulated 3-button navigation (e.g. Alt/Shift + trackpad drag) stopped when the pointer left the 3D viewport. Instead of relying on mouse capture (which hides the cursor), this PR adds an emulated-nav continuation path in **Node3DEditorViewport:**
- tracks whether emulated navigation is active,
- computes active emulated nav mode from current modifier shortcuts,
- temporarily enables global input() processing while emulated nav is active,
- applies nav updates from outside-viewport motion there,
- disables that path when modifiers/nav mode are no longer active.

Inside-viewport motion still uses the existing _sinput() flow, so behavior remains consistent and avoids double-processing.

### **Changed files**
- node_3d_editor_plugin.h
- node_3d_editor_plugin.cpp
- view_3d_controller.cpp

### **Testing**
- Emulated 3-button trackpad nav continues when crossing viewport edges.
- Cursor remains visible.
- Standard navigation and freelook behavior remain unchanged.
