### PR TITLE
Fix `MeshInstance3D` not reattaching skeleton after switching `World3D`

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -341,6 +341,7 @@ void MeshInstance3D::create_multiple_convex_collisions(const Ref<MeshConvexDecom
 
 void MeshInstance3D::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_ENTER_WORLD:
 		case NOTIFICATION_ENTER_TREE: {
 #ifndef DISABLE_DEPRECATED
 			if (upgrading_skeleton_compat) {


### PR DESCRIPTION
`VisualInstance3D` detaches the skeleton after receiving `NOTIFICATION_EXIT_WORLD`:

https://github.com/godotengine/godot/blob/923c751af4e35fe8ef5f24d72333a561030f7382/scene/3d/visual_instance_3d.cpp#L108-L112

But `MeshInstance3D` attaches it only when it enters the tree, not if the world is changed.