### PR TITLE
Use render target's color texture instead of default white texture.

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -2210,8 +2210,7 @@ void RasterizerCanvasGLES3::canvas_begin(RID p_to_render_target, bool p_to_backb
 	if (p_to_backbuffer) {
 		glBindFramebuffer(GL_FRAMEBUFFER, render_target->backbuffer_fbo);
 		glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 4);
-		GLES3::Texture *tex = texture_storage->get_texture(texture_storage->texture_gl_get_default(GLES3::DEFAULT_GL_TEXTURE_WHITE));
-		glBindTexture(GL_TEXTURE_2D, tex->tex_id);
+		glBindTexture(GL_TEXTURE_2D, render_target->color);
 	} else {
 		glBindFramebuffer(GL_FRAMEBUFFER, render_target->fbo);
 		glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 4);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/116729

`p_to_backbuffer` is only true when it's a canvas group, so should not impact anything else.

<img width="370" height="510" alt="compat" src="https://github.com/user-attachments/assets/cf35c654-140d-4728-a58d-78a3f4e560cb" />

Note: I turned on hdr 2d to avoid banding seen in the issue screenshot. Default rt color image format is `GL_RGB10_A2` (`GL_RGBA8` when viewport transparency enabled or `GL_RGBA16F` when hdr 2d enabled)
