### PR TITLE
Resume interrupted Vulkan SDK downloads instead of restarting

### DIFF
--- a/misc/scripts/install_vulkan_sdk_macos.sh
+++ b/misc/scripts/install_vulkan_sdk_macos.sh
@@ -2,21 +2,22 @@
 
 set -euo pipefail
 IFS=$'\n\t'
-new_ver_full=''
+latest_vulkan_version=''
+stripped_latest_vulkan_version=''
 
 # Check currently installed and latest available Vulkan SDK versions.
 if command -v jq 2>&1 >/dev/null; then
 	curl -L "https://sdk.lunarg.com/sdk/download/latest/mac/config.json" -o /tmp/vulkan-sdk.json
 
-	new_ver_full=`jq -r '.version' /tmp/vulkan-sdk.json`
-	new_ver=`echo "$new_ver_full" | awk -F. '{ printf("%d%02d%04d%02d\n", $1,$2,$3,$4); }';`
+	latest_vulkan_version=`jq -r '.version' /tmp/vulkan-sdk.json`
+	stripped_latest_vulkan_version=`echo "$latest_vulkan_version" | awk -F. '{ printf("%d%02d%04d%02d\n", $1,$2,$3,$4); }';`
 
 	rm -f /tmp/vulkan-sdk.json
 
 	for f in $HOME/VulkanSDK/*; do
 		if [ -d "$f" ]; then
 			f=`echo "${f##*/}" | awk -F. '{ printf("%d%02d%04d%02d\n", $1,$2,$3,$4); }';`
-			if [ $f -ge $new_ver ]; then
+			if [ $f -ge $stripped_latest_vulkan_version ]; then
 				echo 'Latest or newer Vulkan SDK is already installed. Skipping installation.'
 				exit 0
 			fi
@@ -27,18 +28,50 @@ else
 	exit 1
 fi
 
-# Download and install the Vulkan SDK.
-curl -L "https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.zip" -o /tmp/vulkan-sdk.zip
-unzip /tmp/vulkan-sdk.zip -d /tmp
+# Download the Vulkan SDK
+vulkan_sdk_url="https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.zip"
+tmp_vulkan_archive_file_path="/tmp/vulkan-sdk-$stripped_latest_vulkan_version.zip"
 
-if [ -d "/tmp/vulkansdk-macOS-$new_ver_full.app" ]; then
-	/tmp/vulkansdk-macOS-$new_ver_full.app/Contents/MacOS/vulkansdk-macOS-$new_ver_full --accept-licenses --default-answer --confirm-command install
-	rm -rf /tmp/vulkansdk-macOS-$new_ver_full.app
+# Fetch Content-Length from the final redirect target
+# `tail -n 1` is used because -L (follow redirects) may return multiple
+# Use last Content-Length headers as there is one per redirect hop.
+remote_size=$(curl -sIL "$vulkan_sdk_url" | grep -i "Content-Length" | awk '{print $2}' | tr -d '\r' | tail -n 1)
+
+# Guard against servers that omit Content-Length (e.g. chunked transfer encoding).
+# If the header is absent, remote_size will be empty; force a download in that case.
+if [ -z "$remote_size" ]; then
+	remote_size=-1
+fi
+
+# stat -f%z is the macOS form for reading a file's byte size
+if [ -f "$tmp_vulkan_archive_file_path" ] && [ "$(stat -f%z "$tmp_vulkan_archive_file_path")" -eq "$remote_size" ] 2>/dev/null; then
+	echo "$tmp_vulkan_archive_file_path is already complete ($remote_size bytes). Skipping download."
 else
-	echo "Couldn't install the Vulkan SDK, the unzipped contents may no longer match what this script expects."
+	if [ -f "$tmp_vulkan_archive_file_path" ]; then
+		echo "Continuing to download $vulkan_sdk_url to $tmp_vulkan_archive_file_path"
+	else
+		echo "Downloading $vulkan_sdk_url to $tmp_vulkan_archive_file_path"
+	fi
+
+	# -C -           resume from the last downloaded byte if a partial file exists
+	# --fail         treat HTTP error responses (4xx, 5xx) as failures
+	# --retry 5      retry up to 5 times on transient failures
+	# --retry-delay  wait 5 seconds between retries
+	curl -C - -L --fail --retry 5 --retry-delay 5 "$vulkan_sdk_url" -o "$tmp_vulkan_archive_file_path"
+fi
+
+unzip "$tmp_vulkan_archive_file_path" -d /tmp
+
+# Install the Vulkan SDK
+tmp_vulkan_directory="/tmp/vulkansdk-macOS-$latest_vulkan_version.app"
+if [ -d "$tmp_vulkan_directory" ]; then
+	"$tmp_vulkan_directory/Contents/MacOS/vulkansdk-macOS-$latest_vulkan_version" --accept-licenses --default-answer --confirm-command install
+	rm -rf "$tmp_vulkan_directory"
+else
+	echo "Couldn't install the Vulkan SDK. Unzipped contents not found at $tmp_vulkan_directory."
 	exit 1
 fi
 
-rm -f /tmp/vulkan-sdk.zip
+rm -f "$tmp_vulkan_archive_file_path"
 
 echo 'Vulkan SDK installed successfully! You can now build Godot by running "scons".'


### PR DESCRIPTION
- Add version-specific temp filename to avoid cross-version conflicts
- Check Content-Length before downloading; skip if already complete
- Use curl -C - to resume partial downloads on re-run
- Add --fail, --retry 5, --retry-delay 5 for transient error resilience
- Guard against missing Content-Length header (chunked responses)
- Improve error message to include expected unzip path

## Closes https://github.com/godotengine/godot-proposals/issues/14337

## Test Results

### 1. Resumption After Interruption

The script correctly resumes from the point of interruption without restarting the entire process:

```sh
cengiz-pz@macOS godot %  HOME=./cengiz ./misc/scripts/install_vulkan_sdk_macos.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 14211  100 14211    0     0   2727      0  0:00:05  0:00:05 --:--:--  2994
Continuing to download https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.zip to /tmp/vulkan-sdk-104034101.zip
** Resuming transfer from byte position 2785280
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  1  316M    1 3431k    0     0  82712      0  1:06:49  0:00:42  1:06:07 68009^C
cengiz-pz@macOS godot %  HOME=./cengiz ./misc/scripts/install_vulkan_sdk_macos.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 14211  100 14211    0     0   9710      0  0:00:01  0:00:01 --:--:--  9713
Continuing to download https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.zip to /tmp/vulkan-sdk-104034101.zip
** Resuming transfer from byte position 6295552
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
 49  312M   49  155M    0     0  73083      0  1:14:49  0:37:14  0:37:35 10327^C
cengiz-pz@macOS godot %  HOME=./cengiz ./misc/scripts/install_vulkan_sdk_macos.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 14211  100 14211    0     0   5641      0  0:00:02  0:00:02 --:--:--  5643
Continuing to download https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.zip to /tmp/vulkan-sdk-104034101.zip
** Resuming transfer from byte position 169562112
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  157M  100  157M    0     0  85000      0  0:32:19  0:32:19 --:--:--  146k
```

### 2. Completed Download Detection

The script correctly detects whether the archive has already been fully downloaded and verifies that it matches the expected version:

```sh
cengiz-pz@macOS godot % ls /tmp
vulkan-sdk-104034101.zip
cengiz-pz@macOS godot %  HOME=/Users/cengiz-pz/fork/godot/cengiz ./misc/scripts/install_vulkan_sdk_macos.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 14211  100 14211    0     0  15631      0 --:--:-- --:--:-- --:--:-- 15633
/tmp/vulkan-sdk-104034101.zip is already complete (334402528 bytes). Skipping download.
```

### 3. Installation and Cleanup

The script successfully installs the verified archive and performs all necessary cleanup steps as expected:

```sh
cengiz-pz@macOS godot %  HOME=/Users/cengiz-pz/fork/godot/cengiz ./misc/scripts/install_vulkan_sdk_macos.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 14211  100 14211    0     0  15631      0 --:--:-- --:--:-- --:--:-- 15633
/tmp/vulkan-sdk-104034101.zip is already complete (334402528 bytes). Skipping download.
Archive:  /tmp/vulkan-sdk-104034101.zip
   creating: /tmp/vulkansdk-macOS-1.4.341.1.app
   creating: /tmp/vulkansdk-macOS-1.4.341.1.app/Contents
   creating: /tmp/vulkansdk-macOS-1.4.341.1.app/Contents/_CodeSignature
   creating: /tmp/vulkansdk-macOS-1.4.341.1.app/Contents/MacOS
   creating: /tmp/vulkansdk-macOS-1.4.341.1.app/Contents/Resources
  inflating: /tmp/vulkansdk-macOS-1.4.341.1.app/Contents/Info.plist  
  inflating: /tmp/vulkansdk-macOS-1.4.341.1.app/Contents/PkgInfo  
  inflating: /tmp/vulkansdk-macOS-1.4.341.1.app/Contents/Resources/vulkansdk-macOS-1.4.341.1.icns  
  inflating: /tmp/vulkansdk-macOS-1.4.341.1.app/Contents/Resources/installer.dat  
  inflating: /tmp/vulkansdk-macOS-1.4.341.1.app/Contents/MacOS/vulkansdk-macOS-1.4.341.1  
  inflating: /tmp/vulkansdk-macOS-1.4.341.1.app/Contents/_CodeSignature/CodeResources  
[0] Arguments: /tmp/vulkansdk-macOS-1.4.341.1.app/Contents/MacOS/vulkansdk-macOS-1.4.341.1, --accept-licenses, --default-answer, --confirm-command, install
[2] Operations sanity check succeeded.
[3] Using metadata cache from "/Users/cengiz-pz/Library/Caches/qt-installer-framework/7131a7fe-e6ca-3647-b670-745b2413b041"
[3] Found 1 cached items.
[5] Loaded control script ":/metadata/installer-config/installscript_qs.qs"
[5] No target directory specified, using default value: "/Users/cengiz-pz/fork/godot/cengiz/VulkanSDK/1.4.341.1"
[5] Fetching latest update information...
[8] Downloading 1 items to cache.
[8] Retrieving information from remote repositories...
[2126] Loading component scripts...
[2132] License "MIT 2.0 or Apache" accepted by user.
[2132] Loading component scripts...
[2133] Warning: QFont::setPixelSize: Pixel size <= 0 (-1)
[2133] Selected components without dependencies:
com.lunarg.vulkan 
com.lunarg.vulkan.core
[2133] Installation space required: "2.55 GB" Temporary space required: "256.00 MB" Local repository size: "0.00 bytes"
[2137] Cache and install directories are on the same volume. Volume mount point: "/" Free space available: "3.23 GB"
[2137] The volume you selected for installation seems to have sufficient space for installation, but there will be less than 1% of the volume's space available afterwards. Installation will use 2.30 GB of disk space.
[2138] perform  operation: Mkdir
[2138] 	- arguments: /Users/cengiz-pz/fork/godot/cengiz/VulkanSDK
[2138] Done
[2138] backup  operation: Mkdir
[2138] 	- arguments: /Users/cengiz-pz/fork/godot/cengiz/VulkanSDK/1.4.341.1
[2138] Done
[2138] perform  operation: Mkdir
[2138] 	- arguments: /Users/cengiz-pz/fork/godot/cengiz/VulkanSDK/1.4.341.1
[2138] Done
[2138] Preparing the installation...
[2138] Install size: 2 components
[2142] Preparing to unpack components...
[2142] backup com.lunarg.vulkan.core concurrent operation: Extract
[2142] 	- arguments: installer://com.lunarg.vulkan.core/1.4.341.1Helpers.7z, /Users/cengiz-pz/fork/godot/cengiz/VulkanSDK/1.4.341.1
[2142] Started
[2142] backup com.lunarg.vulkan.core concurrent operation: Extract
[2142] 	- arguments: installer://com.lunarg.vulkan.core/1.4.341.1vulkan.7z, /Users/cengiz-pz/fork/godot/cengiz/VulkanSDK/1.4.341.1
[2142] Started
[2146] Unpacking components...
[2146] perform com.lunarg.vulkan.core concurrent operation: Extract
[2146] 	- arguments: installer://com.lunarg.vulkan.core/1.4.341.1vulkan.7z, /Users/cengiz-pz/fork/godot/cengiz/VulkanSDK/1.4.341.1
[2146] Started
[2146] perform com.lunarg.vulkan.core concurrent operation: Extract
[2146] 	- arguments: installer://com.lunarg.vulkan.core/1.4.341.1Helpers.7z, /Users/cengiz-pz/fork/godot/cengiz/VulkanSDK/1.4.341.1
[2146] Started
[19168] Installing component Vulkan SDK
[19168] backup com.lunarg.vulkan operation: License
[19168] 	- arguments:
[19168] Done
[19168] perform com.lunarg.vulkan operation: License
[19168] 	- arguments:
[19168] Done
[19173] Installing component The Vulkan SDK Core (Always Installed)
[19173] backup com.lunarg.vulkan.core operation: License
[19173] 	- arguments:
[19173] Done
[19173] perform com.lunarg.vulkan.core operation: License
[19173] 	- arguments:
[19174] Done
[19181] Got a replacement installer base binary: "/Users/cengiz-pz/fork/godot/cengiz/VulkanSDK/1.4.341.1/tmpMaintenanceToolApp/MaintenanceTool.app"
[19218] Maintenance tool hard restart: false.
[19831] Installation finished!
[19831] Components installed successfully.
Vulkan SDK installed successfully! You can now build Godot by running "scons".
cengiz-pz@macOS godot % ls cengiz/VulkanSDK/1.4.341.1/
Applications		Licenses		README.txt		installerResources	uninstall.sh
Helpers			MaintenanceTool.app	VERSIONS.txt		macOS			vulkan.7z
INSTALL_BOM.json	MaintenanceTool.dat	components.xml		network.xml
InstallationLog.txt	MaintenanceTool.ini	install_vulkan.py	setup-env.sh
cengiz-pz@macOS godot % ls /tmp
cengiz-pz@macOS godot % 
```
