### PR TITLE
Make constants read-only in remote scene view

### DIFF
--- a/scene/debugger/scene_debugger_object.cpp
+++ b/scene/debugger/scene_debugger_object.cpp
@@ -159,10 +159,12 @@ void SceneDebuggerObject::_parse_script_properties(Script *p_script, ScriptInsta
 			String script_path = sc.key == p_script ? "" : sc.key->get_path().get_file() + "/";
 			if (E.value.get_type() == Variant::OBJECT) {
 				Variant inst_id = ((Object *)E.value)->get_instance_id();
-				PropertyInfo pi(inst_id.get_type(), "Constants/" + E.key, PROPERTY_HINT_OBJECT_ID, "Object");
+				PropertyInfo pi(inst_id.get_type(), "Constants/" + E.key, PROPERTY_HINT_OBJECT_ID, "Object", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY);
 				properties.push_back(SceneDebuggerProperty(pi, inst_id));
 			} else {
 				PropertyInfo pi(E.value.get_type(), "Constants/" + script_path + E.key);
+				pi.usage |= PROPERTY_USAGE_READ_ONLY;
+
 				properties.push_back(SceneDebuggerProperty(pi, E.value));
 			}
 		}


### PR DESCRIPTION
Changes constants to be readonly when viewing in the remote scene view. They don't seem to be editable anyways, so this makes sense (I think?).

<img width="1156" height="478" alt="image" src="https://github.com/user-attachments/assets/54bf2034-2203-4007-b9de-58fa76a01de2" />