### PR TITLE
Hide property groups from the "Members" section in Debugger

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -417,6 +417,10 @@ void EditorDebuggerInspector::add_stack_variable(const Array &p_array, int p_off
 			type = "Locals/";
 			break;
 		case 1:
+			if (n.begins_with("@")) {
+				return; // Skip groups.
+			}
+
 			type = "Members/";
 			break;
 		case 2:


### PR DESCRIPTION
Like https://github.com/godotengine/godot/pull/108213 but for the `Debugger`.

| Before | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/981bb216-95ad-46e4-92de-960a3d78ff37) | ![image](https://github.com/user-attachments/assets/d6d95ff5-3b8d-4f29-8496-bd643b943f66) |

