### PR TITLE
Add resize font to fit option to `Label` and `RichTextLabel`

### DIFF
--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -33,6 +33,12 @@
 				If there are no lines, returns font size in pixels.
 			</description>
 		</method>
+		<method name="get_rendered_font_size" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the font size that is currently used for rendering. When [member resize_font_to_fit] is enabled, this returns the automatically calculated font size. Otherwise, it returns the theme font size.
+			</description>
+		</method>
 		<method name="get_total_character_count" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -78,9 +84,18 @@
 		<member name="max_lines_visible" type="int" setter="set_max_lines_visible" getter="get_max_lines_visible" default="-1">
 			Limits the lines of text the node shows on screen.
 		</member>
+		<member name="maximum_font_size" type="int" setter="set_maximum_font_size" getter="get_maximum_font_size" default="60">
+			The maximum font size used when [member resize_font_to_fit] is enabled. If [member minimum_font_size] is greater than [member maximum_font_size], the minimum font size takes precedence.
+		</member>
+		<member name="minimum_font_size" type="int" setter="set_minimum_font_size" getter="get_minimum_font_size" default="10">
+			The minimum font size used when [member resize_font_to_fit] is enabled. Also determines the minimum vertical size of this [Label], potentially used by a parent [Container]. If [member minimum_font_size] is greater than [member maximum_font_size], the minimum font size takes precedence.
+		</member>
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" overrides="Control" enum="Control.MouseFilter" default="2" />
 		<member name="paragraph_separator" type="String" setter="set_paragraph_separator" getter="get_paragraph_separator" default="&quot;\\n&quot;">
 			String used as a paragraph separator. Each paragraph is processed independently, in its own BiDi context.
+		</member>
+		<member name="resize_font_to_fit" type="bool" setter="set_resize_font_to_fit" getter="is_resize_font_to_fit_enabled" default="false">
+			If [code]true[/code], the text size will automatically shrink or grow to fit within the node's bounding rectangle. It will pick the largest font size between [member minimum_font_size] and [member maximum_font_size] that doesn't cause the text to be truncated.
 		</member>
 		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" enum="Control.SizeFlags" is_bitfield="true" default="4" />
 		<member name="structured_text_bidi_override" type="int" setter="set_structured_text_bidi_override" getter="get_structured_text_bidi_override" enum="TextServer.StructuredTextParser" default="0">

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -221,6 +221,12 @@
 				Returns the text without BBCode mark-up.
 			</description>
 		</method>
+		<method name="get_rendered_font_size" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the font size that is currently used for rendering. When [member resize_font_to_fit] is enabled, this returns the automatically calculated font size. Otherwise, it returns the theme font size.
+			</description>
+		</method>
 		<method name="get_selected_text" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -754,12 +760,22 @@
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms. If left empty, the current locale is used instead.
 		</member>
+		<member name="maximum_font_size" type="int" setter="set_maximum_font_size" getter="get_maximum_font_size" default="60">
+			The maximum font size used when [member resize_font_to_fit] is enabled. If [member minimum_font_size] is greater than [member maximum_font_size], the minimum font size takes precedence.
+		</member>
 		<member name="meta_underlined" type="bool" setter="set_meta_underline" getter="is_meta_underlined" default="true" keywords="url_underlined">
 			If [code]true[/code], the label underlines meta tags such as [code skip-lint][url]{text}[/url][/code]. These tags can call a function when clicked if [signal meta_clicked] is connected to a function.
+		</member>
+		<member name="minimum_font_size" type="int" setter="set_minimum_font_size" getter="get_minimum_font_size" default="10">
+			The minimum font size used when [member resize_font_to_fit] is enabled. Also determines the minimum vertical size of this [RichTextLabel], potentially used by a parent [Container]. If [member minimum_font_size] is greater than [member maximum_font_size], the minimum font size takes precedence.
 		</member>
 		<member name="progress_bar_delay" type="int" setter="set_progress_bar_delay" getter="get_progress_bar_delay" default="1000">
 			The delay after which the loading progress bar is displayed, in milliseconds. Set to [code]-1[/code] to disable progress bar entirely.
 			[b]Note:[/b] Progress bar is displayed only if [member threaded] is enabled.
+		</member>
+		<member name="resize_font_to_fit" type="bool" setter="set_resize_font_to_fit" getter="is_resize_font_to_fit_enabled" default="false">
+			If [code]true[/code], the text size will automatically shrink or grow to fit within the node's bounding rectangle. It will pick the largest font size between [member minimum_font_size] and [member maximum_font_size] that doesn't cause the text to be truncated.
+			Font sizes that are overridden with the [code skip-lint][font_size][/code] tag are scaled relative to the theme font size. For example, if the theme font size is [code]16[/code] and [code skip-lint][font_size=24][/code] is used with an automatic font size determined to be [code]32[/code], text in the overridden block will be in size [code]48[/code].
 		</member>
 		<member name="scroll_active" type="bool" setter="set_scroll_active" getter="is_scroll_active" default="true">
 			If [code]true[/code], the scrollbar is visible. Setting this to [code]false[/code] does not block scrolling completely. See [method scroll_to_line].

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -114,7 +114,7 @@ bool Label::is_uppercase() const {
 
 int Label::get_line_height(int p_line) const {
 	Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	int font_size = get_rendered_font_size();
 	int font_h = font->get_height(font_size);
 	if (p_line >= 0 && p_line < total_line_count) {
 		RID rid = get_line_rid(p_line);
@@ -144,6 +144,7 @@ void Label::_shape() const {
 
 	Ref<StyleBox> style = theme_cache.normal_style;
 	int width = (get_size().width - style->get_minimum_size().width);
+	int height = (get_size().height - style->get_minimum_size().height);
 	float combined_maximum_width = get_combined_maximum_size().x;
 	bool wrap_with_max_width = autowrap_mode != TextServer::AUTOWRAP_OFF && combined_maximum_width > 0;
 	int maximum_width = -1;
@@ -187,6 +188,54 @@ void Label::_shape() const {
 		text_dirty = false;
 	}
 
+	int base_font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	if (resize_font_to_fit && width > 0 && height > 0) {
+		int low = minimum_font_size;
+		int high = maximum_font_size;
+		int best = low;
+
+		while (low <= high) {
+			int mid = low + (high - low) / 2;
+			if (_shape_lines(mid, width, height)) {
+				best = mid;
+				low = mid + 1;
+			} else {
+				high = mid - 1;
+			}
+		}
+		current_fitted_font_size = best;
+
+		font_dirty = true;
+		for (Paragraph &para : paragraphs) {
+			para.lines_dirty = true;
+		}
+		_shape_internal();
+	} else {
+		current_fitted_font_size = base_font_size;
+		_shape_internal();
+	}
+}
+
+void Label::_shape_internal() const {
+	const String &lang = language.is_empty() ? _get_locale() : language;
+
+	Ref<StyleBox> style = theme_cache.normal_style;
+	int width = (get_size().width - style->get_minimum_size().width);
+	float combined_maximum_width = get_combined_maximum_size().x;
+	bool wrap_with_max_width = autowrap_mode != TextServer::AUTOWRAP_OFF && combined_maximum_width > 0;
+	int maximum_width = -1;
+	if (wrap_with_max_width) {
+		maximum_width = int(combined_maximum_width - style->get_minimum_size().width);
+		if (maximum_width <= 0) {
+			maximum_width = 1;
+		}
+		if (width > 0) {
+			width = MIN(width, maximum_width);
+		} else {
+			width = maximum_width;
+		}
+	}
+
 	total_line_count = 0;
 	for (Paragraph &para : paragraphs) {
 		if (para.dirty || font_dirty) {
@@ -199,7 +248,7 @@ void Label::_shape() const {
 				TS->shaped_text_set_direction(para.text_rid, (TextServer::Direction)text_direction);
 			}
 			const Ref<Font> &font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-			int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+			int font_size = get_rendered_font_size();
 			ERR_FAIL_COND(font.is_null());
 
 			if (para.dirty) {
@@ -365,12 +414,26 @@ void Label::_shape() const {
 	}
 }
 
+bool Label::_shape_lines(int p_font_size, int p_width, int p_height) const {
+	font_dirty = true;
+	for (Paragraph &para : paragraphs) {
+		para.lines_dirty = true;
+	}
+	current_fitted_font_size = p_font_size;
+	_shape_internal();
+
+	if (autowrap_mode == TextServer::AUTOWRAP_OFF && minsize.width > p_width) {
+		return false;
+	}
+	return minsize.height <= p_height;
+}
+
 void Label::_update_visible() const {
 	int line_spacing = settings.is_valid() ? settings->get_line_spacing() : theme_cache.line_spacing;
 	int paragraph_spacing = settings.is_valid() ? settings->get_paragraph_spacing() : theme_cache.paragraph_spacing;
 	Ref<StyleBox> style = theme_cache.normal_style;
 	Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	int font_size = get_rendered_font_size();
 	int font_h = font->get_height(font_size);
 	int lines_visible = total_line_count;
 
@@ -494,7 +557,7 @@ Rect2 Label::_get_line_rect(int p_para, int p_line) const {
 	bool rtl_layout = is_layout_rtl();
 	Ref<StyleBox> style = theme_cache.normal_style;
 	Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	int font_size = get_rendered_font_size();
 	int font_h = font->get_height(font_size);
 	Size2 size = get_size();
 	RID rid = paragraphs[p_para].lines_rid[p_line];
@@ -544,7 +607,7 @@ int Label::get_layout_data(Vector2 &r_offset, int &r_last_line, int &r_line_spac
 	Size2 size = get_size();
 	Ref<StyleBox> style = theme_cache.normal_style;
 	Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	int font_size = get_rendered_font_size();
 	int font_h = font->get_height(font_size);
 	int line_spacing = settings.is_valid() ? settings->get_line_spacing() : theme_cache.line_spacing;
 	int paragraph_spacing = settings.is_valid() ? settings->get_paragraph_spacing() : theme_cache.paragraph_spacing;
@@ -681,7 +744,7 @@ PackedStringArray Label::get_configuration_warnings() const {
 	Ref<FontFile> ff = font;
 	if (ff.is_valid() && ff->is_multichannel_signed_distance_field()) {
 		bool has_settings = settings.is_valid();
-		int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+		int font_size = get_rendered_font_size();
 		int outline_size = has_settings ? settings->get_outline_size() : theme_cache.font_outline_size;
 		Vector<LabelSettings::StackedOutlineData> stacked_outline_datas = has_settings ? settings->get_stacked_outline_data() : Vector<LabelSettings::StackedOutlineData>();
 		Vector<LabelSettings::StackedShadowData> stacked_shadow_datas = has_settings ? settings->get_stacked_shadow_data() : Vector<LabelSettings::StackedShadowData>();
@@ -775,7 +838,7 @@ void Label::_notification(int p_what) {
 
 			Ref<StyleBox> style = theme_cache.normal_style;
 			Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-			int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+			int font_size = get_rendered_font_size();
 			int font_h = font->get_height(font_size);
 			Color font_color = has_settings ? settings->get_font_color() : theme_cache.font_color;
 			Color font_shadow_color = has_settings ? settings->get_shadow_color() : theme_cache.font_shadow_color;
@@ -930,7 +993,7 @@ Rect2 Label::get_character_bounds(int p_pos) const {
 
 	int paragraph_spacing = settings.is_valid() ? settings->get_paragraph_spacing() : theme_cache.paragraph_spacing;
 	Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	int font_size = get_rendered_font_size();
 	int font_h = font->get_height(font_size);
 
 	Vector2 ofs;
@@ -996,9 +1059,12 @@ Size2 Label::get_minimum_size() const {
 	Size2 combined_maximum_size = get_combined_maximum_size();
 	bool wrap_with_max_width = autowrap_mode != TextServer::AUTOWRAP_OFF && combined_maximum_size.x > 0;
 	bool overrun_with_max_width = autowrap_mode == TextServer::AUTOWRAP_OFF && combined_maximum_size.x > 0 && (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING);
+	if (resize_font_to_fit) {
+		min_size = Size2(1, 1);
+	}
 
 	const Ref<Font> &font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	int font_size = resize_font_to_fit ? minimum_font_size : (settings.is_valid() ? settings->get_font_size() : theme_cache.font_size);
 
 	min_size.height = MAX(min_size.height, font->get_height(font_size));
 
@@ -1017,7 +1083,7 @@ Size2 Label::get_minimum_size() const {
 			return Size2(1, min_size.height) + min_style;
 		}
 	} else {
-		if (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
+		if (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING || resize_font_to_fit) {
 			if (overrun_with_max_width) {
 				min_size.width = MAX(1, min_size.width);
 			} else {
@@ -1057,7 +1123,7 @@ int Label::get_line_count() const {
 int Label::get_visible_line_count() const {
 	Ref<StyleBox> style = theme_cache.normal_style;
 	Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	int font_size = get_rendered_font_size();
 	int font_h = font->get_height(font_size);
 	int line_spacing = settings.is_valid() ? settings->get_line_spacing() : theme_cache.line_spacing;
 	int paragraph_spacing = settings.is_valid() ? settings->get_paragraph_spacing() : theme_cache.paragraph_spacing;
@@ -1254,6 +1320,70 @@ void Label::set_paragraph_separator(const String &p_paragraph_separator) {
 
 String Label::get_paragraph_separator() const {
 	return paragraph_separator;
+}
+
+void Label::set_resize_font_to_fit(bool p_enabled) {
+	if (resize_font_to_fit == p_enabled) {
+		return;
+	}
+
+	resize_font_to_fit = p_enabled;
+	if (!p_enabled) {
+		current_fitted_font_size = 0;
+	}
+	font_dirty = true;
+	for (Paragraph &para : paragraphs) {
+		para.lines_dirty = true;
+	}
+	queue_redraw();
+	update_minimum_size();
+	update_configuration_warnings();
+}
+
+bool Label::is_resize_font_to_fit_enabled() const {
+	return resize_font_to_fit;
+}
+
+void Label::set_minimum_font_size(int p_size) {
+	if (minimum_font_size == p_size) {
+		return;
+	}
+
+	minimum_font_size = p_size;
+	if (resize_font_to_fit) {
+		for (Paragraph &para : paragraphs) {
+			para.lines_dirty = true;
+		}
+		queue_redraw();
+		update_minimum_size();
+	}
+}
+
+int Label::get_minimum_font_size() const {
+	return minimum_font_size;
+}
+
+void Label::set_maximum_font_size(int p_size) {
+	if (maximum_font_size == p_size) {
+		return;
+	}
+
+	maximum_font_size = p_size;
+	if (resize_font_to_fit) {
+		for (Paragraph &para : paragraphs) {
+			para.lines_dirty = true;
+		}
+		queue_redraw();
+		update_minimum_size();
+	}
+}
+
+int Label::get_maximum_font_size() const {
+	return maximum_font_size;
+}
+
+int Label::get_rendered_font_size() const {
+	return current_fitted_font_size > 0 ? current_fitted_font_size : (settings.is_valid() ? settings->get_font_size() : theme_cache.font_size);
 }
 
 void Label::set_clip_text(bool p_clip) {
@@ -1474,6 +1604,14 @@ void Label::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_structured_text_bidi_override_options", "args"), &Label::set_structured_text_bidi_override_options);
 	ClassDB::bind_method(D_METHOD("get_structured_text_bidi_override_options"), &Label::get_structured_text_bidi_override_options);
 
+	ClassDB::bind_method(D_METHOD("set_resize_font_to_fit", "enabled"), &Label::set_resize_font_to_fit);
+	ClassDB::bind_method(D_METHOD("is_resize_font_to_fit_enabled"), &Label::is_resize_font_to_fit_enabled);
+	ClassDB::bind_method(D_METHOD("set_minimum_font_size", "size"), &Label::set_minimum_font_size);
+	ClassDB::bind_method(D_METHOD("get_minimum_font_size"), &Label::get_minimum_font_size);
+	ClassDB::bind_method(D_METHOD("set_maximum_font_size", "size"), &Label::set_maximum_font_size);
+	ClassDB::bind_method(D_METHOD("get_maximum_font_size"), &Label::get_maximum_font_size);
+	ClassDB::bind_method(D_METHOD("get_rendered_font_size"), &Label::get_rendered_font_size);
+
 	ClassDB::bind_method(D_METHOD("get_character_bounds", "pos"), &Label::get_character_bounds);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text", PROPERTY_HINT_MULTILINE_TEXT), "set_text", "get_text");
@@ -1490,6 +1628,11 @@ void Label::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "ellipsis_char"), "set_ellipsis_char", "get_ellipsis_char");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "uppercase"), "set_uppercase", "is_uppercase");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT32_ARRAY, "tab_stops"), "set_tab_stops", "get_tab_stops");
+
+	ADD_GROUP("Resize Font to Fit", "");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "resize_font_to_fit", PROPERTY_HINT_GROUP_ENABLE), "set_resize_font_to_fit", "is_resize_font_to_fit_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "minimum_font_size", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), "set_minimum_font_size", "get_minimum_font_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "maximum_font_size", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), "set_maximum_font_size", "get_maximum_font_size");
 
 	ADD_GROUP("Displayed Text", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "lines_skipped", PROPERTY_HINT_RANGE, "0,999,1"), "set_lines_skipped", "get_lines_skipped");

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -116,7 +116,7 @@ bool Label::is_uppercase() const {
 
 int Label::get_line_height(int p_line) const {
 	Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	int font_size = get_rendered_font_size();
 	int font_h = font->get_height(font_size);
 	if (p_line >= 0 && p_line < total_line_count) {
 		RID rid = get_line_rid(p_line);
@@ -146,6 +146,7 @@ void Label::_shape() const {
 
 	Ref<StyleBox> style = theme_cache.normal_style;
 	int width = (get_size().width - style->get_minimum_size().width);
+	int height = (get_size().height - style->get_minimum_size().height);
 	float combined_maximum_width = get_combined_maximum_size().x;
 	bool wrap_with_max_width = autowrap_mode != TextServer::AUTOWRAP_OFF && combined_maximum_width > 0;
 	int maximum_width = -1;
@@ -189,6 +190,54 @@ void Label::_shape() const {
 		text_dirty = false;
 	}
 
+	int base_font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	if (resize_font_to_fit && width > 0 && height > 0) {
+		int low = minimum_font_size;
+		int high = maximum_font_size;
+		int best = low;
+
+		while (low <= high) {
+			int mid = low + (high - low) / 2;
+			if (_shape_lines(mid, width, height)) {
+				best = mid;
+				low = mid + 1;
+			} else {
+				high = mid - 1;
+			}
+		}
+		current_fitted_font_size = best;
+
+		font_dirty = true;
+		for (Paragraph &para : paragraphs) {
+			para.lines_dirty = true;
+		}
+		_shape_internal();
+	} else {
+		current_fitted_font_size = base_font_size;
+		_shape_internal();
+	}
+}
+
+void Label::_shape_internal() const {
+	const String &lang = language.is_empty() ? _get_locale() : language;
+
+	Ref<StyleBox> style = theme_cache.normal_style;
+	int width = (get_size().width - style->get_minimum_size().width);
+	float combined_maximum_width = get_combined_maximum_size().x;
+	bool wrap_with_max_width = autowrap_mode != TextServer::AUTOWRAP_OFF && combined_maximum_width > 0;
+	int maximum_width = -1;
+	if (wrap_with_max_width) {
+		maximum_width = int(combined_maximum_width - style->get_minimum_size().width);
+		if (maximum_width <= 0) {
+			maximum_width = 1;
+		}
+		if (width > 0 && !is_expanded_by_desired_size()) {
+			width = MIN(width, maximum_width);
+		} else {
+			width = maximum_width;
+		}
+	}
+
 	total_line_count = 0;
 	for (Paragraph &para : paragraphs) {
 		if (para.dirty || font_dirty) {
@@ -201,7 +250,7 @@ void Label::_shape() const {
 				TS->shaped_text_set_direction(para.text_rid, (TextServer::Direction)text_direction);
 			}
 			const Ref<Font> &font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-			int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+			int font_size = get_rendered_font_size();
 			ERR_FAIL_COND(font.is_null());
 
 			if (para.dirty) {
@@ -367,12 +416,26 @@ void Label::_shape() const {
 	}
 }
 
+bool Label::_shape_lines(int p_font_size, int p_width, int p_height) const {
+	font_dirty = true;
+	for (Paragraph &para : paragraphs) {
+		para.lines_dirty = true;
+	}
+	current_fitted_font_size = p_font_size;
+	_shape_internal();
+
+	if (autowrap_mode == TextServer::AUTOWRAP_OFF && minsize.width > p_width) {
+		return false;
+	}
+	return minsize.height <= p_height;
+}
+
 void Label::_update_visible() const {
 	int line_spacing = settings.is_valid() ? settings->get_line_spacing() : theme_cache.line_spacing;
 	int paragraph_spacing = settings.is_valid() ? settings->get_paragraph_spacing() : theme_cache.paragraph_spacing;
 	Ref<StyleBox> style = theme_cache.normal_style;
 	Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	int font_size = get_rendered_font_size();
 	int font_h = font->get_height(font_size);
 	int lines_visible = total_line_count;
 
@@ -496,7 +559,7 @@ Rect2 Label::_get_line_rect(int p_para, int p_line) const {
 	bool rtl_layout = is_layout_rtl();
 	Ref<StyleBox> style = theme_cache.normal_style;
 	Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	int font_size = get_rendered_font_size();
 	int font_h = font->get_height(font_size);
 	Size2 size = get_size();
 	RID rid = paragraphs[p_para].lines_rid[p_line];
@@ -546,7 +609,7 @@ int Label::get_layout_data(Vector2 &r_offset, int &r_last_line, int &r_line_spac
 	Size2 size = get_size();
 	Ref<StyleBox> style = theme_cache.normal_style;
 	Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	int font_size = get_rendered_font_size();
 	int font_h = font->get_height(font_size);
 	int line_spacing = settings.is_valid() ? settings->get_line_spacing() : theme_cache.line_spacing;
 	int paragraph_spacing = settings.is_valid() ? settings->get_paragraph_spacing() : theme_cache.paragraph_spacing;
@@ -683,7 +746,7 @@ PackedStringArray Label::get_configuration_warnings() const {
 	Ref<FontFile> ff = font;
 	if (ff.is_valid() && ff->is_multichannel_signed_distance_field()) {
 		bool has_settings = settings.is_valid();
-		int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+		int font_size = get_rendered_font_size();
 		int outline_size = has_settings ? settings->get_outline_size() : theme_cache.font_outline_size;
 		Vector<LabelSettings::StackedOutlineData> stacked_outline_datas = has_settings ? settings->get_stacked_outline_data() : Vector<LabelSettings::StackedOutlineData>();
 		Vector<LabelSettings::StackedShadowData> stacked_shadow_datas = has_settings ? settings->get_stacked_shadow_data() : Vector<LabelSettings::StackedShadowData>();
@@ -777,7 +840,7 @@ void Label::_notification(int p_what) {
 
 			Ref<StyleBox> style = theme_cache.normal_style;
 			Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-			int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+			int font_size = get_rendered_font_size();
 			int font_h = font->get_height(font_size);
 			Color font_color = has_settings ? settings->get_font_color() : theme_cache.font_color;
 			Color font_shadow_color = has_settings ? settings->get_shadow_color() : theme_cache.font_shadow_color;
@@ -933,7 +996,7 @@ Rect2 Label::get_character_bounds(int p_pos) const {
 
 	int paragraph_spacing = settings.is_valid() ? settings->get_paragraph_spacing() : theme_cache.paragraph_spacing;
 	Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	int font_size = get_rendered_font_size();
 	int font_h = font->get_height(font_size);
 
 	Vector2 ofs;
@@ -996,9 +1059,12 @@ Size2 Label::get_minimum_size() const {
 	_ensure_shaped();
 
 	Size2 min_size = minsize;
+	if (resize_font_to_fit) {
+		min_size = Size2(1, 1);
+	}
 
 	const Ref<Font> &font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	int font_size = resize_font_to_fit ? minimum_font_size : (settings.is_valid() ? settings->get_font_size() : theme_cache.font_size);
 
 	min_size.height = MAX(min_size.height, font->get_height(font_size));
 
@@ -1012,7 +1078,7 @@ Size2 Label::get_minimum_size() const {
 		}
 		return Size2(1, min_size.height) + min_style;
 	} else {
-		if (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
+		if (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING || resize_font_to_fit) {
 			min_size.width = 1;
 		}
 		return min_size + min_style;
@@ -1058,7 +1124,7 @@ int Label::get_line_count() const {
 int Label::get_visible_line_count() const {
 	Ref<StyleBox> style = theme_cache.normal_style;
 	Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+	int font_size = get_rendered_font_size();
 	int font_h = font->get_height(font_size);
 	int line_spacing = settings.is_valid() ? settings->get_line_spacing() : theme_cache.line_spacing;
 	int paragraph_spacing = settings.is_valid() ? settings->get_paragraph_spacing() : theme_cache.paragraph_spacing;
@@ -1257,6 +1323,70 @@ void Label::set_paragraph_separator(const String &p_paragraph_separator) {
 
 String Label::get_paragraph_separator() const {
 	return paragraph_separator;
+}
+
+void Label::set_resize_font_to_fit(bool p_enabled) {
+	if (resize_font_to_fit == p_enabled) {
+		return;
+	}
+
+	resize_font_to_fit = p_enabled;
+	if (!p_enabled) {
+		current_fitted_font_size = 0;
+	}
+	font_dirty = true;
+	for (Paragraph &para : paragraphs) {
+		para.lines_dirty = true;
+	}
+	queue_redraw();
+	update_minimum_size();
+	update_configuration_warnings();
+}
+
+bool Label::is_resize_font_to_fit_enabled() const {
+	return resize_font_to_fit;
+}
+
+void Label::set_minimum_font_size(int p_size) {
+	if (minimum_font_size == p_size) {
+		return;
+	}
+
+	minimum_font_size = p_size;
+	if (resize_font_to_fit) {
+		for (Paragraph &para : paragraphs) {
+			para.lines_dirty = true;
+		}
+		queue_redraw();
+		update_minimum_size();
+	}
+}
+
+int Label::get_minimum_font_size() const {
+	return minimum_font_size;
+}
+
+void Label::set_maximum_font_size(int p_size) {
+	if (maximum_font_size == p_size) {
+		return;
+	}
+
+	maximum_font_size = p_size;
+	if (resize_font_to_fit) {
+		for (Paragraph &para : paragraphs) {
+			para.lines_dirty = true;
+		}
+		queue_redraw();
+		update_minimum_size();
+	}
+}
+
+int Label::get_maximum_font_size() const {
+	return maximum_font_size;
+}
+
+int Label::get_rendered_font_size() const {
+	return current_fitted_font_size > 0 ? current_fitted_font_size : (settings.is_valid() ? settings->get_font_size() : theme_cache.font_size);
 }
 
 void Label::set_clip_text(bool p_clip) {
@@ -1480,6 +1610,14 @@ void Label::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_structured_text_bidi_override_options", "args"), &Label::set_structured_text_bidi_override_options);
 	ClassDB::bind_method(D_METHOD("get_structured_text_bidi_override_options"), &Label::get_structured_text_bidi_override_options);
 
+	ClassDB::bind_method(D_METHOD("set_resize_font_to_fit", "enabled"), &Label::set_resize_font_to_fit);
+	ClassDB::bind_method(D_METHOD("is_resize_font_to_fit_enabled"), &Label::is_resize_font_to_fit_enabled);
+	ClassDB::bind_method(D_METHOD("set_minimum_font_size", "size"), &Label::set_minimum_font_size);
+	ClassDB::bind_method(D_METHOD("get_minimum_font_size"), &Label::get_minimum_font_size);
+	ClassDB::bind_method(D_METHOD("set_maximum_font_size", "size"), &Label::set_maximum_font_size);
+	ClassDB::bind_method(D_METHOD("get_maximum_font_size"), &Label::get_maximum_font_size);
+	ClassDB::bind_method(D_METHOD("get_rendered_font_size"), &Label::get_rendered_font_size);
+
 	ClassDB::bind_method(D_METHOD("get_character_bounds", "pos"), &Label::get_character_bounds);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text", PROPERTY_HINT_MULTILINE_TEXT), "set_text", "get_text");
@@ -1496,6 +1634,11 @@ void Label::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "ellipsis_char"), "set_ellipsis_char", "get_ellipsis_char");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "uppercase"), "set_uppercase", "is_uppercase");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT32_ARRAY, "tab_stops"), "set_tab_stops", "get_tab_stops");
+
+	ADD_GROUP("Resize Font to Fit", "");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "resize_font_to_fit", PROPERTY_HINT_GROUP_ENABLE), "set_resize_font_to_fit", "is_resize_font_to_fit_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "minimum_font_size", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), "set_minimum_font_size", "get_minimum_font_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "maximum_font_size", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), "set_maximum_font_size", "get_maximum_font_size");
 
 	ADD_GROUP("Displayed Text", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "lines_skipped", PROPERTY_HINT_RANGE, "0,999,1"), "set_lines_skipped", "get_lines_skipped");

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -78,6 +78,11 @@ private:
 	int max_lines_visible = -1;
 	PackedFloat32Array tab_stops;
 
+	bool resize_font_to_fit = false;
+	int minimum_font_size = 10;
+	int maximum_font_size = 60;
+	mutable int current_fitted_font_size = -1;
+
 	Ref<LabelSettings> settings;
 
 	struct ThemeCache {
@@ -100,6 +105,8 @@ private:
 	void _ensure_shaped() const;
 	void _update_visible() const;
 	void _shape() const;
+	void _shape_internal() const;
+	bool _shape_lines(int p_font_size, int p_width, int p_height) const;
 	void _invalidate();
 	void _maximum_size_changed();
 
@@ -138,6 +145,17 @@ public:
 
 	void set_paragraph_separator(const String &p_paragraph_separator);
 	String get_paragraph_separator() const;
+
+	void set_resize_font_to_fit(bool p_enabled);
+	bool is_resize_font_to_fit_enabled() const;
+
+	void set_minimum_font_size(int p_size);
+	int get_minimum_font_size() const;
+
+	void set_maximum_font_size(int p_size);
+	int get_maximum_font_size() const;
+
+	int get_rendered_font_size() const;
 
 	void set_structured_text_bidi_override(TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override() const;

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -78,6 +78,11 @@ private:
 	int max_lines_visible = -1;
 	PackedFloat32Array tab_stops;
 
+	bool resize_font_to_fit = false;
+	int minimum_font_size = 10;
+	int maximum_font_size = 60;
+	mutable int current_fitted_font_size = -1;
+
 	Ref<LabelSettings> settings;
 
 	struct ThemeCache {
@@ -100,6 +105,8 @@ private:
 	void _ensure_shaped() const;
 	void _update_visible() const;
 	void _shape() const;
+	void _shape_internal() const;
+	bool _shape_lines(int p_font_size, int p_width, int p_height) const;
 	void _invalidate();
 	void _maximum_size_changed();
 
@@ -139,6 +146,17 @@ public:
 
 	void set_paragraph_separator(const String &p_paragraph_separator);
 	String get_paragraph_separator() const;
+
+	void set_resize_font_to_fit(bool p_enabled);
+	bool is_resize_font_to_fit_enabled() const;
+
+	void set_minimum_font_size(int p_size);
+	int get_minimum_font_size() const;
+
+	void set_maximum_font_size(int p_size);
+	int get_maximum_font_size() const;
+
+	int get_rendered_font_size() const;
 
 	void set_structured_text_bidi_override(TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override() const;

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -329,7 +329,7 @@ String RichTextLabel::_get_prefix(Item *p_item, const Vector<int> &p_list_index,
 	return prefix + " ";
 }
 
-void RichTextLabel::_add_list_prefixes(ItemFrame *p_frame, int p_line, Line &r_l) {
+void RichTextLabel::_add_list_prefixes(ItemFrame *p_frame, int p_line, Line &r_l, int p_base_font_size) {
 	Vector<int> list_index;
 	Vector<int> list_count;
 	Vector<ItemList *> list_items;
@@ -420,6 +420,9 @@ void RichTextLabel::_add_list_prefixes(ItemFrame *p_frame, int p_line, Line &r_l
 					}
 					font = found_font_item != nullptr ? found_font_item->font : font;
 					font_size = item_font_size != -1 ? item_font_size : font_size;
+					if (resize_font_to_fit && theme_cache.normal_font_size > 0 && font_size != p_base_font_size) {
+						font_size = MAX(1, font_size * p_base_font_size / theme_cache.normal_font_size);
+					}
 					list_index.write[0] = index;
 					String prefix = _get_prefix(list_row_line.from, list_index, list_items);
 					list_row_line.text_prefix.instantiate();
@@ -441,7 +444,7 @@ void RichTextLabel::_update_line_font(ItemFrame *p_frame, int p_line, const Ref<
 	MutexLock lock(l.text_buf->get_mutex());
 
 	// List.
-	_add_list_prefixes(p_frame, p_line, l);
+	_add_list_prefixes(p_frame, p_line, l, p_base_font_size);
 
 	{
 		RID t = l.text_buf->get_rid();
@@ -458,13 +461,16 @@ void RichTextLabel::_update_line_font(ItemFrame *p_frame, int p_line, const Ref<
 					if (font_it->font.is_valid()) {
 						font = font_it->font;
 					}
-					if (font_it->font_size > 0) {
+					if (font_it->font_size > 0 && !font_it->def_size) {
 						font_size = font_it->font_size;
 					}
 				}
 				ItemFontSize *font_size_it = _find_font_size(it);
 				if (font_size_it && font_size_it->font_size > 0) {
 					font_size = font_size_it->font_size;
+				}
+				if (resize_font_to_fit && theme_cache.normal_font_size > 0 && font_size != p_base_font_size) {
+					font_size = MAX(1, font_size * p_base_font_size / theme_cache.normal_font_size);
 				}
 				TS->shaped_set_span_update_font(t, i, font->get_rids(), font_size, font->get_opentype_features());
 			} else {
@@ -487,13 +493,16 @@ void RichTextLabel::_update_line_font(ItemFrame *p_frame, int p_line, const Ref<
 					if (font_it->font.is_valid()) {
 						font = font_it->font;
 					}
-					if (font_it->font_size > 0) {
+					if (font_it->font_size > 0 && !font_it->def_size) {
 						font_size = font_it->font_size;
 					}
 				}
 				ItemFontSize *font_size_it = _find_font_size(it);
 				if (font_size_it && font_size_it->font_size > 0) {
 					font_size = font_size_it->font_size;
+				}
+				if (resize_font_to_fit && theme_cache.normal_font_size > 0 && font_size != p_base_font_size) {
+					font_size = MAX(1, font_size * p_base_font_size / theme_cache.normal_font_size);
 				}
 				TS->shaped_set_span_update_font(t, i, font->get_rids(), font_size, font->get_opentype_features());
 			} else {
@@ -693,7 +702,7 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 	l.char_count = 0;
 
 	// List.
-	_add_list_prefixes(p_frame, p_line, l);
+	_add_list_prefixes(p_frame, p_line, l, p_base_font_size);
 
 	// Add indent.
 	l.indent = _find_margin(l.from, p_base_font, p_base_font_size) + l.prefix_width;
@@ -721,7 +730,11 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 			case ITEM_DROPCAP: {
 				// Add dropcap.
 				ItemDropcap *dc = static_cast<ItemDropcap *>(it);
-				l.text_buf->set_dropcap(dc->text, dc->font, dc->font_size, dc->dropcap_margins);
+				int dc_font_size = dc->font_size;
+				if (resize_font_to_fit && theme_cache.normal_font_size > 0 && dc_font_size != p_base_font_size) {
+					dc_font_size = MAX(1, dc_font_size * p_base_font_size / theme_cache.normal_font_size);
+				}
+				l.text_buf->set_dropcap(dc->text, dc->font, dc_font_size, dc->dropcap_margins);
 				l.dc_item = dc;
 				l.dc_color = dc->color;
 				l.dc_ol_size = dc->ol_size;
@@ -744,6 +757,9 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 				if (font_size_it && font_size_it->font_size > 0) {
 					font_size = font_size_it->font_size;
 				}
+				if (resize_font_to_fit && theme_cache.normal_font_size > 0 && font_size != p_base_font_size) {
+					font_size = MAX(1, font_size * p_base_font_size / theme_cache.normal_font_size);
+				}
 				l.text_buf->add_string(String::chr(0x200B), font, font_size, String(), it->rid);
 				txt += "\n";
 				l.char_count++;
@@ -759,13 +775,16 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 					if (font_it->font.is_valid()) {
 						font = font_it->font;
 					}
-					if (font_it->font_size > 0) {
+					if (font_it->font_size > 0 && !font_it->def_size) {
 						font_size = font_it->font_size;
 					}
 				}
 				ItemFontSize *font_size_it = _find_font_size(it);
 				if (font_size_it && font_size_it->font_size > 0) {
 					font_size = font_size_it->font_size;
+				}
+				if (resize_font_to_fit && theme_cache.normal_font_size > 0 && font_size != p_base_font_size) {
+					font_size = MAX(1, font_size * p_base_font_size / theme_cache.normal_font_size);
 				}
 				String lang = _find_language(it);
 				String tx = t->text;
@@ -892,16 +911,23 @@ Size2 RichTextLabel::_get_item_image_final_size(ItemImage *p_img, float p_orig_w
 	Size2 new_size(p_img->rq_size);
 	ItemFontSize *font_size_it = _find_font_size(p_img);
 
+	// When resize_font_to_fit is active, scale the font_size from [font_size] tags
+	// the same way text font sizes are scaled, so em-based images scale proportionally.
+	float effective_font_size = font_size_it ? font_size_it->font_size : 0;
+	if (font_size_it && resize_font_to_fit && theme_cache.normal_font_size > 0 && effective_font_size != p_base_font_size) {
+		effective_font_size = MAX(1, effective_font_size * p_base_font_size / theme_cache.normal_font_size);
+	}
+
 	if (p_img->width_unit == IMAGE_UNIT_PERCENT) {
 		new_size.width = p_orig_width * p_img->rq_size.width / 100.f;
 	} else if (p_img->width_unit == IMAGE_UNIT_EM) {
-		new_size.width = (font_size_it ? font_size_it->font_size : p_base_font_size) * p_img->rq_size.width;
+		new_size.width = (font_size_it ? effective_font_size : p_base_font_size) * p_img->rq_size.width;
 	}
 
 	if (p_img->height_unit == IMAGE_UNIT_PERCENT) {
 		new_size.height = p_orig_width * p_img->rq_size.height / 100.f;
 	} else if (p_img->height_unit == IMAGE_UNIT_EM) {
-		new_size.height = (font_size_it ? font_size_it->font_size : p_base_font_size) * p_img->rq_size.height;
+		new_size.height = (font_size_it ? effective_font_size : p_base_font_size) * p_img->rq_size.height;
 	}
 	return new_size;
 }
@@ -2637,7 +2663,10 @@ void RichTextLabel::_notification(int p_what) {
 
 		case NOTIFICATION_RESIZED: {
 			_stop_thread();
-			main->first_resized_line.store(0); // Invalidate all lines.
+			if (resize_font_to_fit) {
+				main->first_invalid_line.store(0);
+			}
+			main->first_resized_line.store(0);
 			_invalidate_accessibility();
 			queue_accessibility_update();
 			queue_redraw();
@@ -2645,7 +2674,13 @@ void RichTextLabel::_notification(int p_what) {
 
 		case NOTIFICATION_THEME_CHANGED: {
 			_stop_thread();
-			main->first_invalid_font_line.store(0); // Invalidate all lines.
+			if (resize_font_to_fit) {
+				main->first_invalid_line.store(0);
+			} else {
+				current_fitted_font_size = 0;
+			}
+			main->first_invalid_font_line.store(0);
+			main->first_resized_line.store(0);
 			for (const RID &E : hr_list) {
 				Item *it = items.get_or_null(E);
 				if (it) {
@@ -4024,7 +4059,7 @@ _FORCE_INLINE_ float RichTextLabel::_update_scroll_exceeds(float p_total_height,
 
 		total_height = 0;
 		for (int j = 0; j <= p_idx; j++) {
-			total_height = _resize_line(main, j, theme_cache.normal_font, theme_cache.normal_font_size, p_width - scroll_w, total_height);
+			total_height = _resize_line(main, j, theme_cache.normal_font, current_fitted_font_size > 0 ? current_fitted_font_size : theme_cache.normal_font_size, p_width - scroll_w, total_height);
 
 			main->first_resized_line.store(j);
 		}
@@ -4057,7 +4092,7 @@ bool RichTextLabel::_validate_line_caches() {
 		float old_scroll = vscroll->get_value();
 		if (main->first_invalid_font_line.load() != (int)main->lines.size()) {
 			for (int i = main->first_invalid_font_line.load(); i < (int)main->lines.size(); i++) {
-				_update_line_font(main, i, theme_cache.normal_font, theme_cache.normal_font_size);
+				_update_line_font(main, i, theme_cache.normal_font, current_fitted_font_size > 0 ? current_fitted_font_size : theme_cache.normal_font_size);
 			}
 			main->first_resized_line.store(main->first_invalid_font_line.load());
 			main->first_invalid_font_line.store(main->lines.size());
@@ -4078,7 +4113,7 @@ bool RichTextLabel::_validate_line_caches() {
 
 		float total_height = (fi == 0) ? 0 : _calculate_line_vertical_offset(main->lines[fi - 1]);
 		for (int i = fi; i < (int)main->lines.size(); i++) {
-			total_height = _resize_line(main, i, theme_cache.normal_font, theme_cache.normal_font_size, wrap_width - scroll_w, total_height);
+			total_height = _resize_line(main, i, theme_cache.normal_font, current_fitted_font_size > 0 ? current_fitted_font_size : theme_cache.normal_font_size, wrap_width - scroll_w, total_height);
 			total_height = _update_scroll_exceeds(total_height, ctrl_height, wrap_width, i, old_scroll, text_rect.size.height);
 			main->first_resized_line.store(i);
 		}
@@ -4134,12 +4169,49 @@ void RichTextLabel::_process_line_caches() {
 	float old_scroll = vscroll->get_value();
 
 	float total_height = 0;
+
+	if (resize_font_to_fit && (main->first_invalid_line.load() == 0 || main->first_invalid_font_line.load() == 0 || main->first_resized_line.load() == 0)) {
+		int low = minimum_font_size;
+		int high = maximum_font_size;
+		int best = minimum_font_size;
+
+		while (low <= high) {
+			int mid = low + (high - low) / 2;
+			current_fitted_font_size = mid;
+
+			float total_h = 0;
+			int max_w = 0;
+			int dummy_chars = 0;
+
+			for (int i = 0; i < (int)main->lines.size(); i++) {
+				total_h = _shape_line(main, i, theme_cache.normal_font, current_fitted_font_size, text_rect.get_size().width - scroll_w, total_h, &dummy_chars);
+				max_w = MAX(max_w, _get_line_max_width(main, i));
+			}
+
+			if (total_h <= text_rect.size.height) {
+				best = mid;
+				low = mid + 1;
+			} else {
+				high = mid - 1;
+			}
+		}
+
+		current_fitted_font_size = best;
+		fi = 0;
+		total_chars = 0;
+		main->first_invalid_line.store(0);
+		main->first_invalid_font_line.store(0);
+		main->first_resized_line.store(0);
+	} else if (!resize_font_to_fit) {
+		current_fitted_font_size = theme_cache.normal_font_size;
+	}
+
 	if (fi != 0) {
 		int sr = MIN(main->first_invalid_font_line.load(), main->first_resized_line.load());
 
 		// Update fonts.
 		for (int i = main->first_invalid_font_line.load(); i < fi; i++) {
-			_update_line_font(main, i, theme_cache.normal_font, theme_cache.normal_font_size);
+			_update_line_font(main, i, theme_cache.normal_font, current_fitted_font_size);
 
 			main->first_invalid_font_line.store(i);
 
@@ -4155,7 +4227,7 @@ void RichTextLabel::_process_line_caches() {
 		}
 
 		for (int i = sr; i < fi; i++) {
-			total_height = _resize_line(main, i, theme_cache.normal_font, theme_cache.normal_font_size, wrap_width - scroll_w, total_height);
+			total_height = _resize_line(main, i, theme_cache.normal_font, current_fitted_font_size, wrap_width - scroll_w, total_height);
 			total_height = _update_scroll_exceeds(total_height, ctrl_height, wrap_width, i, old_scroll, text_rect.size.height);
 
 			main->first_resized_line.store(i);
@@ -4169,7 +4241,7 @@ void RichTextLabel::_process_line_caches() {
 
 	total_height = (fi == 0) ? 0 : _calculate_line_vertical_offset(main->lines[fi - 1]);
 	for (int i = fi; i < (int)main->lines.size(); i++) {
-		total_height = _shape_line(main, i, theme_cache.normal_font, theme_cache.normal_font_size, wrap_width - scroll_w, total_height, &total_chars);
+		total_height = _shape_line(main, i, theme_cache.normal_font, current_fitted_font_size, wrap_width - scroll_w, total_height, &total_chars);
 		total_height = _update_scroll_exceeds(total_height, ctrl_height, wrap_width, i, old_scroll, text_rect.size.height);
 
 		main->first_invalid_line.store(i);
@@ -5298,6 +5370,64 @@ void RichTextLabel::set_fit_content(bool p_enabled) {
 
 	fit_content = p_enabled;
 	update_minimum_size();
+}
+
+void RichTextLabel::set_resize_font_to_fit(bool p_enabled) {
+	if (resize_font_to_fit == p_enabled) {
+		return;
+	}
+	resize_font_to_fit = p_enabled;
+	if (!p_enabled) {
+		current_fitted_font_size = 0;
+	}
+	_stop_thread();
+	main->first_invalid_line.store(0);
+	_validate_line_caches();
+	queue_redraw();
+	update_minimum_size();
+}
+
+bool RichTextLabel::is_resize_font_to_fit_enabled() const {
+	return resize_font_to_fit;
+}
+
+void RichTextLabel::set_minimum_font_size(int p_size) {
+	if (minimum_font_size == p_size) {
+		return;
+	}
+	minimum_font_size = p_size;
+	if (resize_font_to_fit) {
+		main->first_invalid_line.store(0);
+		main->first_resized_line.store(0);
+		main->first_invalid_font_line.store(0);
+		queue_redraw();
+	}
+}
+
+int RichTextLabel::get_minimum_font_size() const {
+	return minimum_font_size;
+}
+
+void RichTextLabel::set_maximum_font_size(int p_size) {
+	if (maximum_font_size == p_size) {
+		return;
+	}
+
+	maximum_font_size = p_size;
+	if (resize_font_to_fit) {
+		main->first_invalid_line.store(0);
+		main->first_resized_line.store(0);
+		main->first_invalid_font_line.store(0);
+		queue_redraw();
+	}
+}
+
+int RichTextLabel::get_maximum_font_size() const {
+	return maximum_font_size;
+}
+
+int RichTextLabel::get_rendered_font_size() const {
+	return current_fitted_font_size;
 }
 
 bool RichTextLabel::is_fit_content_enabled() const {
@@ -7863,6 +7993,17 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_fit_content", "enabled"), &RichTextLabel::set_fit_content);
 	ClassDB::bind_method(D_METHOD("is_fit_content_enabled"), &RichTextLabel::is_fit_content_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_resize_font_to_fit", "enabled"), &RichTextLabel::set_resize_font_to_fit);
+	ClassDB::bind_method(D_METHOD("is_resize_font_to_fit_enabled"), &RichTextLabel::is_resize_font_to_fit_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_minimum_font_size", "size"), &RichTextLabel::set_minimum_font_size);
+	ClassDB::bind_method(D_METHOD("get_minimum_font_size"), &RichTextLabel::get_minimum_font_size);
+
+	ClassDB::bind_method(D_METHOD("set_maximum_font_size", "size"), &RichTextLabel::set_maximum_font_size);
+	ClassDB::bind_method(D_METHOD("get_maximum_font_size"), &RichTextLabel::get_maximum_font_size);
+
+	ClassDB::bind_method(D_METHOD("get_rendered_font_size"), &RichTextLabel::get_rendered_font_size);
+
 	ClassDB::bind_method(D_METHOD("set_selection_enabled", "enabled"), &RichTextLabel::set_selection_enabled);
 	ClassDB::bind_method(D_METHOD("is_selection_enabled"), &RichTextLabel::is_selection_enabled);
 
@@ -7979,6 +8120,11 @@ void RichTextLabel::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "selection_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_selection_enabled", "is_selection_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deselect_on_focus_loss_enabled"), "set_deselect_on_focus_loss_enabled", "is_deselect_on_focus_loss_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_and_drop_selection_enabled"), "set_drag_and_drop_selection_enabled", "is_drag_and_drop_selection_enabled");
+
+	ADD_GROUP("Resize Font to Fit", "");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "resize_font_to_fit", PROPERTY_HINT_GROUP_ENABLE), "set_resize_font_to_fit", "is_resize_font_to_fit_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "minimum_font_size", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), "set_minimum_font_size", "get_minimum_font_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "maximum_font_size", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), "set_maximum_font_size", "get_maximum_font_size");
 
 	ADD_GROUP("Displayed Text", "");
 	// Note: "visible_characters" and "visible_ratio" should be set after "text" to be correctly applied.
@@ -8243,7 +8389,13 @@ Size2 RichTextLabel::get_minimum_size() const {
 		if (!wrap_with_max_width) {
 			min_size.x = get_content_width();
 		}
-		min_size.y = get_content_height();
+		if (!resize_font_to_fit) {
+			min_size.y = get_content_height();
+		}
+	}
+
+	if (resize_font_to_fit) {
+		min_size.height = MAX(min_size.height, theme_cache.normal_font->get_height(minimum_font_size));
 	}
 
 	if (wrap_with_max_width) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -325,7 +325,7 @@ String RichTextLabel::_get_prefix(Item *p_item, const Vector<int> &p_list_index,
 	return prefix + " ";
 }
 
-void RichTextLabel::_add_list_prefixes(ItemFrame *p_frame, int p_line, Line &r_l) {
+void RichTextLabel::_add_list_prefixes(ItemFrame *p_frame, int p_line, Line &r_l, int p_base_font_size) {
 	Vector<int> list_index;
 	Vector<int> list_count;
 	Vector<ItemList *> list_items;
@@ -416,6 +416,9 @@ void RichTextLabel::_add_list_prefixes(ItemFrame *p_frame, int p_line, Line &r_l
 					}
 					font = found_font_item != nullptr ? found_font_item->font : font;
 					font_size = item_font_size != -1 ? item_font_size : font_size;
+					if (resize_font_to_fit && theme_cache.normal_font_size > 0 && font_size != p_base_font_size) {
+						font_size = MAX(1, font_size * p_base_font_size / theme_cache.normal_font_size);
+					}
 					list_index.write[0] = index;
 					String prefix = _get_prefix(list_row_line.from, list_index, list_items);
 					list_row_line.text_prefix.instantiate();
@@ -437,7 +440,7 @@ void RichTextLabel::_update_line_font(ItemFrame *p_frame, int p_line, const Ref<
 	MutexLock lock(l.text_buf->get_mutex());
 
 	// List.
-	_add_list_prefixes(p_frame, p_line, l);
+	_add_list_prefixes(p_frame, p_line, l, p_base_font_size);
 
 	{
 		RID t = l.text_buf->get_rid();
@@ -454,13 +457,16 @@ void RichTextLabel::_update_line_font(ItemFrame *p_frame, int p_line, const Ref<
 					if (font_it->font.is_valid()) {
 						font = font_it->font;
 					}
-					if (font_it->font_size > 0) {
+					if (font_it->font_size > 0 && !font_it->def_size) {
 						font_size = font_it->font_size;
 					}
 				}
 				ItemFontSize *font_size_it = _find_font_size(it);
 				if (font_size_it && font_size_it->font_size > 0) {
 					font_size = font_size_it->font_size;
+				}
+				if (resize_font_to_fit && theme_cache.normal_font_size > 0 && font_size != p_base_font_size) {
+					font_size = MAX(1, font_size * p_base_font_size / theme_cache.normal_font_size);
 				}
 				TS->shaped_set_span_update_font(t, i, font->get_rids(), font_size, font->get_opentype_features());
 			} else {
@@ -483,13 +489,16 @@ void RichTextLabel::_update_line_font(ItemFrame *p_frame, int p_line, const Ref<
 					if (font_it->font.is_valid()) {
 						font = font_it->font;
 					}
-					if (font_it->font_size > 0) {
+					if (font_it->font_size > 0 && !font_it->def_size) {
 						font_size = font_it->font_size;
 					}
 				}
 				ItemFontSize *font_size_it = _find_font_size(it);
 				if (font_size_it && font_size_it->font_size > 0) {
 					font_size = font_size_it->font_size;
+				}
+				if (resize_font_to_fit && theme_cache.normal_font_size > 0 && font_size != p_base_font_size) {
+					font_size = MAX(1, font_size * p_base_font_size / theme_cache.normal_font_size);
 				}
 				TS->shaped_set_span_update_font(t, i, font->get_rids(), font_size, font->get_opentype_features());
 			} else {
@@ -689,7 +698,7 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 	l.char_count = 0;
 
 	// List.
-	_add_list_prefixes(p_frame, p_line, l);
+	_add_list_prefixes(p_frame, p_line, l, p_base_font_size);
 
 	// Add indent.
 	l.indent = _find_margin(l.from, p_base_font, p_base_font_size) + l.prefix_width;
@@ -719,7 +728,11 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 			case ITEM_DROPCAP: {
 				// Add dropcap.
 				ItemDropcap *dc = static_cast<ItemDropcap *>(it);
-				l.text_buf->set_dropcap(dc->text, dc->font, dc->font_size, dc->dropcap_margins);
+				int dc_font_size = dc->font_size;
+				if (resize_font_to_fit && theme_cache.normal_font_size > 0 && dc_font_size != p_base_font_size) {
+					dc_font_size = MAX(1, dc_font_size * p_base_font_size / theme_cache.normal_font_size);
+				}
+				l.text_buf->set_dropcap(dc->text, dc->font, dc_font_size, dc->dropcap_margins);
 				l.dc_item = dc;
 				l.dc_color = dc->color;
 				l.dc_ol_size = dc->ol_size;
@@ -742,6 +755,9 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 				if (font_size_it && font_size_it->font_size > 0) {
 					font_size = font_size_it->font_size;
 				}
+				if (resize_font_to_fit && theme_cache.normal_font_size > 0 && font_size != p_base_font_size) {
+					font_size = MAX(1, font_size * p_base_font_size / theme_cache.normal_font_size);
+				}
 				l.text_buf->add_string(String::chr(0x200B), font, font_size, String(), it->rid);
 				txt += "\n";
 				l.char_count++;
@@ -758,13 +774,16 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 					if (font_it->font.is_valid()) {
 						font = font_it->font;
 					}
-					if (font_it->font_size > 0) {
+					if (font_it->font_size > 0 && !font_it->def_size) {
 						font_size = font_it->font_size;
 					}
 				}
 				ItemFontSize *font_size_it = _find_font_size(it);
 				if (font_size_it && font_size_it->font_size > 0) {
 					font_size = font_size_it->font_size;
+				}
+				if (resize_font_to_fit && theme_cache.normal_font_size > 0 && font_size != p_base_font_size) {
+					font_size = MAX(1, font_size * p_base_font_size / theme_cache.normal_font_size);
 				}
 				String lang = _find_language(it);
 				String tx = t->text;
@@ -913,16 +932,23 @@ Size2 RichTextLabel::_get_item_image_final_size(ItemImage *p_img, float p_orig_w
 	Size2 new_size(p_img->rq_size);
 	ItemFontSize *font_size_it = _find_font_size(p_img);
 
+	// When resize_font_to_fit is active, scale the font_size from [font_size] tags
+	// the same way text font sizes are scaled, so em-based images scale proportionally.
+	float effective_font_size = font_size_it ? font_size_it->font_size : 0;
+	if (font_size_it && resize_font_to_fit && theme_cache.normal_font_size > 0 && effective_font_size != p_base_font_size) {
+		effective_font_size = MAX(1, effective_font_size * p_base_font_size / theme_cache.normal_font_size);
+	}
+
 	if (p_img->width_unit == IMAGE_UNIT_PERCENT) {
 		new_size.width = p_orig_width * p_img->rq_size.width / 100.f;
 	} else if (p_img->width_unit == IMAGE_UNIT_EM) {
-		new_size.width = (font_size_it ? font_size_it->font_size : p_base_font_size) * p_img->rq_size.width;
+		new_size.width = (font_size_it ? effective_font_size : p_base_font_size) * p_img->rq_size.width;
 	}
 
 	if (p_img->height_unit == IMAGE_UNIT_PERCENT) {
 		new_size.height = p_orig_width * p_img->rq_size.height / 100.f;
 	} else if (p_img->height_unit == IMAGE_UNIT_EM) {
-		new_size.height = (font_size_it ? font_size_it->font_size : p_base_font_size) * p_img->rq_size.height;
+		new_size.height = (font_size_it ? effective_font_size : p_base_font_size) * p_img->rq_size.height;
 	}
 	return new_size;
 }
@@ -2670,7 +2696,10 @@ void RichTextLabel::_notification(int p_what) {
 
 		case NOTIFICATION_RESIZED: {
 			_stop_thread();
-			main->first_resized_line.store(0); // Invalidate all lines.
+			if (resize_font_to_fit) {
+				main->first_invalid_line.store(0);
+			}
+			main->first_resized_line.store(0);
 			_invalidate_accessibility();
 			queue_accessibility_update();
 			queue_redraw();
@@ -2678,7 +2707,13 @@ void RichTextLabel::_notification(int p_what) {
 
 		case NOTIFICATION_THEME_CHANGED: {
 			_stop_thread();
-			main->first_invalid_font_line.store(0); // Invalidate all lines.
+			if (resize_font_to_fit) {
+				main->first_invalid_line.store(0);
+			} else {
+				current_fitted_font_size = 0;
+			}
+			main->first_invalid_font_line.store(0);
+			main->first_resized_line.store(0);
 			for (const RID &E : hr_list) {
 				Item *it = items.get_or_null(E);
 				if (it) {
@@ -4078,7 +4113,7 @@ _FORCE_INLINE_ float RichTextLabel::_update_scroll_exceeds(float p_total_height,
 
 		total_height = 0;
 		for (int j = 0; j <= p_idx; j++) {
-			total_height = _resize_line(main, j, theme_cache.normal_font, theme_cache.normal_font_size, p_width - scroll_w, total_height);
+			total_height = _resize_line(main, j, theme_cache.normal_font, current_fitted_font_size > 0 ? current_fitted_font_size : theme_cache.normal_font_size, p_width - scroll_w, total_height);
 
 			main->first_resized_line.store(j);
 		}
@@ -4111,7 +4146,7 @@ bool RichTextLabel::_validate_line_caches() {
 		float old_scroll = vscroll->get_value();
 		if (main->first_invalid_font_line.load() != (int)main->lines.size()) {
 			for (int i = main->first_invalid_font_line.load(); i < (int)main->lines.size(); i++) {
-				_update_line_font(main, i, theme_cache.normal_font, theme_cache.normal_font_size);
+				_update_line_font(main, i, theme_cache.normal_font, current_fitted_font_size > 0 ? current_fitted_font_size : theme_cache.normal_font_size);
 			}
 			main->first_resized_line.store(main->first_invalid_font_line.load());
 			main->first_invalid_font_line.store(main->lines.size());
@@ -4132,7 +4167,7 @@ bool RichTextLabel::_validate_line_caches() {
 
 		float total_height = (fi == 0) ? 0 : _calculate_line_vertical_offset(main->lines[fi - 1]);
 		for (int i = fi; i < (int)main->lines.size(); i++) {
-			total_height = _resize_line(main, i, theme_cache.normal_font, theme_cache.normal_font_size, wrap_width - scroll_w, total_height);
+			total_height = _resize_line(main, i, theme_cache.normal_font, current_fitted_font_size > 0 ? current_fitted_font_size : theme_cache.normal_font_size, wrap_width - scroll_w, total_height);
 			total_height = _update_scroll_exceeds(total_height, ctrl_height, wrap_width, i, old_scroll, text_rect.size.height);
 			main->first_resized_line.store(i);
 		}
@@ -4188,12 +4223,49 @@ void RichTextLabel::_process_line_caches() {
 	float old_scroll = vscroll->get_value();
 
 	float total_height = 0;
+
+	if (resize_font_to_fit && (main->first_invalid_line.load() == 0 || main->first_invalid_font_line.load() == 0 || main->first_resized_line.load() == 0)) {
+		int low = minimum_font_size;
+		int high = maximum_font_size;
+		int best = minimum_font_size;
+
+		while (low <= high) {
+			int mid = low + (high - low) / 2;
+			current_fitted_font_size = mid;
+
+			float total_h = 0;
+			int max_w = 0;
+			int dummy_chars = 0;
+
+			for (int i = 0; i < (int)main->lines.size(); i++) {
+				total_h = _shape_line(main, i, theme_cache.normal_font, current_fitted_font_size, text_rect.get_size().width - scroll_w, total_h, &dummy_chars);
+				max_w = MAX(max_w, _get_line_max_width(main, i));
+			}
+
+			if (total_h <= text_rect.size.height) {
+				best = mid;
+				low = mid + 1;
+			} else {
+				high = mid - 1;
+			}
+		}
+
+		current_fitted_font_size = best;
+		fi = 0;
+		total_chars = 0;
+		main->first_invalid_line.store(0);
+		main->first_invalid_font_line.store(0);
+		main->first_resized_line.store(0);
+	} else if (!resize_font_to_fit) {
+		current_fitted_font_size = theme_cache.normal_font_size;
+	}
+
 	if (fi != 0) {
 		int sr = MIN(main->first_invalid_font_line.load(), main->first_resized_line.load());
 
 		// Update fonts.
 		for (int i = main->first_invalid_font_line.load(); i < fi; i++) {
-			_update_line_font(main, i, theme_cache.normal_font, theme_cache.normal_font_size);
+			_update_line_font(main, i, theme_cache.normal_font, current_fitted_font_size);
 
 			main->first_invalid_font_line.store(i);
 
@@ -4209,7 +4281,7 @@ void RichTextLabel::_process_line_caches() {
 		}
 
 		for (int i = sr; i < fi; i++) {
-			total_height = _resize_line(main, i, theme_cache.normal_font, theme_cache.normal_font_size, wrap_width - scroll_w, total_height);
+			total_height = _resize_line(main, i, theme_cache.normal_font, current_fitted_font_size, wrap_width - scroll_w, total_height);
 			total_height = _update_scroll_exceeds(total_height, ctrl_height, wrap_width, i, old_scroll, text_rect.size.height);
 
 			main->first_resized_line.store(i);
@@ -4223,7 +4295,7 @@ void RichTextLabel::_process_line_caches() {
 
 	total_height = (fi == 0) ? 0 : _calculate_line_vertical_offset(main->lines[fi - 1]);
 	for (int i = fi; i < (int)main->lines.size(); i++) {
-		total_height = _shape_line(main, i, theme_cache.normal_font, theme_cache.normal_font_size, wrap_width - scroll_w, total_height, &total_chars);
+		total_height = _shape_line(main, i, theme_cache.normal_font, current_fitted_font_size, wrap_width - scroll_w, total_height, &total_chars);
 		total_height = _update_scroll_exceeds(total_height, ctrl_height, wrap_width, i, old_scroll, text_rect.size.height);
 
 		main->first_invalid_line.store(i);
@@ -5362,6 +5434,64 @@ void RichTextLabel::set_fit_content(bool p_enabled) {
 
 	fit_content = p_enabled;
 	update_minimum_size();
+}
+
+void RichTextLabel::set_resize_font_to_fit(bool p_enabled) {
+	if (resize_font_to_fit == p_enabled) {
+		return;
+	}
+	resize_font_to_fit = p_enabled;
+	if (!p_enabled) {
+		current_fitted_font_size = 0;
+	}
+	_stop_thread();
+	main->first_invalid_line.store(0);
+	_validate_line_caches();
+	queue_redraw();
+	update_minimum_size();
+}
+
+bool RichTextLabel::is_resize_font_to_fit_enabled() const {
+	return resize_font_to_fit;
+}
+
+void RichTextLabel::set_minimum_font_size(int p_size) {
+	if (minimum_font_size == p_size) {
+		return;
+	}
+	minimum_font_size = p_size;
+	if (resize_font_to_fit) {
+		main->first_invalid_line.store(0);
+		main->first_resized_line.store(0);
+		main->first_invalid_font_line.store(0);
+		queue_redraw();
+	}
+}
+
+int RichTextLabel::get_minimum_font_size() const {
+	return minimum_font_size;
+}
+
+void RichTextLabel::set_maximum_font_size(int p_size) {
+	if (maximum_font_size == p_size) {
+		return;
+	}
+
+	maximum_font_size = p_size;
+	if (resize_font_to_fit) {
+		main->first_invalid_line.store(0);
+		main->first_resized_line.store(0);
+		main->first_invalid_font_line.store(0);
+		queue_redraw();
+	}
+}
+
+int RichTextLabel::get_maximum_font_size() const {
+	return maximum_font_size;
+}
+
+int RichTextLabel::get_rendered_font_size() const {
+	return current_fitted_font_size;
 }
 
 bool RichTextLabel::is_fit_content_enabled() const {
@@ -7917,6 +8047,17 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_fit_content", "enabled"), &RichTextLabel::set_fit_content);
 	ClassDB::bind_method(D_METHOD("is_fit_content_enabled"), &RichTextLabel::is_fit_content_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_resize_font_to_fit", "enabled"), &RichTextLabel::set_resize_font_to_fit);
+	ClassDB::bind_method(D_METHOD("is_resize_font_to_fit_enabled"), &RichTextLabel::is_resize_font_to_fit_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_minimum_font_size", "size"), &RichTextLabel::set_minimum_font_size);
+	ClassDB::bind_method(D_METHOD("get_minimum_font_size"), &RichTextLabel::get_minimum_font_size);
+
+	ClassDB::bind_method(D_METHOD("set_maximum_font_size", "size"), &RichTextLabel::set_maximum_font_size);
+	ClassDB::bind_method(D_METHOD("get_maximum_font_size"), &RichTextLabel::get_maximum_font_size);
+
+	ClassDB::bind_method(D_METHOD("get_rendered_font_size"), &RichTextLabel::get_rendered_font_size);
+
 	ClassDB::bind_method(D_METHOD("set_selection_enabled", "enabled"), &RichTextLabel::set_selection_enabled);
 	ClassDB::bind_method(D_METHOD("is_selection_enabled"), &RichTextLabel::is_selection_enabled);
 
@@ -8033,6 +8174,11 @@ void RichTextLabel::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "selection_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_selection_enabled", "is_selection_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deselect_on_focus_loss_enabled"), "set_deselect_on_focus_loss_enabled", "is_deselect_on_focus_loss_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_and_drop_selection_enabled"), "set_drag_and_drop_selection_enabled", "is_drag_and_drop_selection_enabled");
+
+	ADD_GROUP("Resize Font to Fit", "");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "resize_font_to_fit", PROPERTY_HINT_GROUP_ENABLE), "set_resize_font_to_fit", "is_resize_font_to_fit_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "minimum_font_size", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), "set_minimum_font_size", "get_minimum_font_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "maximum_font_size", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), "set_maximum_font_size", "get_maximum_font_size");
 
 	ADD_GROUP("Displayed Text", "");
 	// Note: "visible_characters" and "visible_ratio" should be set after "text" to be correctly applied.
@@ -8295,7 +8441,13 @@ Size2 RichTextLabel::get_minimum_size() const {
 		if (!wrap_with_max_width) {
 			min_size.x = get_content_width();
 		}
-		min_size.y = get_content_height();
+		if (!resize_font_to_fit) {
+			min_size.y = get_content_height();
+		}
+	}
+
+	if (resize_font_to_fit) {
+		min_size.height = MAX(min_size.height, theme_cache.normal_font->get_height(minimum_font_size));
 	}
 
 	if (wrap_with_max_width) {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -739,7 +739,7 @@ private:
 	Size2 _get_item_image_final_size(ItemImage *p_img, float p_orig_width, float p_base_font_size);
 
 	String _get_prefix(Item *p_item, const Vector<int> &p_list_index, const Vector<ItemList *> &p_list_items);
-	void _add_list_prefixes(ItemFrame *p_frame, int p_line, Line &r_l);
+	void _add_list_prefixes(ItemFrame *p_frame, int p_line, Line &r_l, int p_base_font_size);
 
 	static int _find_unquoted(const String &p_src, char32_t p_chr, int p_from);
 	static Vector<String> _split_unquoted(const String &p_src, char32_t p_splitter);
@@ -766,6 +766,11 @@ private:
 	RID accessibility_scroll_element;
 
 	bool fit_content = false;
+
+	bool resize_font_to_fit = false;
+	int minimum_font_size = 10;
+	int maximum_font_size = 60;
+	mutable int current_fitted_font_size = -1;
 
 	struct ThemeCache {
 		Ref<StyleBox> normal_style;
@@ -902,6 +907,17 @@ public:
 
 	void set_fit_content(bool p_enabled);
 	bool is_fit_content_enabled() const;
+
+	void set_resize_font_to_fit(bool p_enabled);
+	bool is_resize_font_to_fit_enabled() const;
+
+	void set_minimum_font_size(int p_size);
+	int get_minimum_font_size() const;
+
+	void set_maximum_font_size(int p_size);
+	int get_maximum_font_size() const;
+
+	int get_rendered_font_size() const;
 
 	bool search(const String &p_string, bool p_from_selection = false, bool p_search_previous = false);
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -737,7 +737,7 @@ private:
 	Size2 _get_item_image_final_size(ItemImage *p_img, float p_orig_width, float p_base_font_size);
 
 	String _get_prefix(Item *p_item, const Vector<int> &p_list_index, const Vector<ItemList *> &p_list_items);
-	void _add_list_prefixes(ItemFrame *p_frame, int p_line, Line &r_l);
+	void _add_list_prefixes(ItemFrame *p_frame, int p_line, Line &r_l, int p_base_font_size);
 
 	static int _find_unquoted(const String &p_src, char32_t p_chr, int p_from);
 	static Vector<String> _split_unquoted(const String &p_src, char32_t p_splitter);
@@ -764,6 +764,11 @@ private:
 	RID accessibility_scroll_element;
 
 	bool fit_content = false;
+
+	bool resize_font_to_fit = false;
+	int minimum_font_size = 10;
+	int maximum_font_size = 60;
+	mutable int current_fitted_font_size = -1;
 
 	struct ThemeCache {
 		Ref<StyleBox> normal_style;
@@ -900,6 +905,17 @@ public:
 
 	void set_fit_content(bool p_enabled);
 	bool is_fit_content_enabled() const;
+
+	void set_resize_font_to_fit(bool p_enabled);
+	bool is_resize_font_to_fit_enabled() const;
+
+	void set_minimum_font_size(int p_size);
+	int get_minimum_font_size() const;
+
+	void set_maximum_font_size(int p_size);
+	int get_maximum_font_size() const;
+
+	int get_rendered_font_size() const;
 
 	bool search(const String &p_string, bool p_from_selection = false, bool p_search_previous = false);
 


### PR DESCRIPTION
Adds `auto_font_size`, `min_font_size`, and `max_font_size` properties to
Label and RichTextLabel

When enabled, font size is automatically adjusted using binary search to
best fit the text within the control's bounding box. Updates on resize,
theme change, and text change.

Closes godotengine/godot-proposals#7750



https://github.com/user-attachments/assets/b90d4d30-a4ca-4e5c-9302-0afd4741ae2a





