### PR TITLE
Add +- scalar operators to Vector*(i)

### DIFF
--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -145,6 +145,12 @@ struct [[nodiscard]] Vector2 {
 	constexpr void operator-=(const Vector2 &p_v);
 	constexpr Vector2 operator*(const Vector2 &p_v1) const;
 
+	constexpr Vector2 operator+(real_t p_rvalue) const;
+	constexpr void operator+=(real_t p_rvalue);
+
+	constexpr Vector2 operator-(real_t p_rvalue) const;
+	constexpr void operator-=(real_t p_rvalue);
+
 	constexpr Vector2 operator*(real_t p_rvalue) const;
 	constexpr void operator*=(real_t p_rvalue);
 	constexpr void operator*=(const Vector2 &p_rvalue) { *this = *this * p_rvalue; }
@@ -234,6 +240,24 @@ constexpr void Vector2::operator-=(const Vector2 &p_v) {
 
 constexpr Vector2 Vector2::operator*(const Vector2 &p_v1) const {
 	return Vector2(x * p_v1.x, y * p_v1.y);
+}
+
+constexpr Vector2 Vector2::operator+(real_t p_rvalue) const {
+	return Vector2(x + p_rvalue, y + p_rvalue);
+}
+
+constexpr void Vector2::operator+=(real_t p_rvalue) {
+	x += p_rvalue;
+	y += p_rvalue;
+}
+
+constexpr Vector2 Vector2::operator-(real_t p_rvalue) const {
+	return Vector2(x - p_rvalue, y - p_rvalue);
+}
+
+constexpr void Vector2::operator-=(real_t p_rvalue) {
+	x -= p_rvalue;
+	y -= p_rvalue;
 }
 
 constexpr Vector2 Vector2::operator*(real_t p_rvalue) const {

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -108,11 +108,15 @@ struct [[nodiscard]] Vector2i {
 	}
 
 	constexpr Vector2i operator+(const Vector2i &p_v) const;
+	constexpr Vector2i operator+(int32_t p_s) const;
 	constexpr void operator+=(const Vector2i &p_v);
+	constexpr void operator+=(int32_t p_s);
 	constexpr Vector2i operator-(const Vector2i &p_v) const;
+	constexpr Vector2i operator-(int32_t p_s) const;
 	constexpr void operator-=(const Vector2i &p_v);
-	constexpr Vector2i operator*(const Vector2i &p_v1) const;
+	constexpr void operator-=(int32_t p_s);
 
+	constexpr Vector2i operator*(const Vector2i &p_v1) const;
 	constexpr Vector2i operator*(int32_t p_rvalue) const;
 	constexpr void operator*=(int32_t p_rvalue);
 
@@ -171,18 +175,36 @@ constexpr Vector2i Vector2i::operator+(const Vector2i &p_v) const {
 	return Vector2i(x + p_v.x, y + p_v.y);
 }
 
+constexpr Vector2i Vector2i::operator+(int32_t p_s) const {
+	return Vector2i(x + p_s, y + p_s);
+}
+
 constexpr void Vector2i::operator+=(const Vector2i &p_v) {
 	x += p_v.x;
 	y += p_v.y;
+}
+
+constexpr void Vector2i::operator+=(int32_t p_s) {
+	x += p_s;
+	y += p_s;
 }
 
 constexpr Vector2i Vector2i::operator-(const Vector2i &p_v) const {
 	return Vector2i(x - p_v.x, y - p_v.y);
 }
 
+constexpr Vector2i Vector2i::operator-(int32_t p_s) const {
+	return Vector2i(x - p_s, y - p_s);
+}
+
 constexpr void Vector2i::operator-=(const Vector2i &p_v) {
 	x -= p_v.x;
 	y -= p_v.y;
+}
+
+constexpr void Vector2i::operator-=(int32_t p_s) {
+	x -= p_s;
+	y -= p_s;
 }
 
 constexpr Vector2i Vector2i::operator*(const Vector2i &p_v1) const {

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -197,6 +197,12 @@ struct [[nodiscard]] Vector3 {
 	constexpr Vector3 &operator/=(const Vector3 &p_v);
 	constexpr Vector3 operator/(const Vector3 &p_v) const;
 
+	constexpr Vector3 &operator+=(real_t p_scalar);
+	constexpr Vector3 operator+(real_t p_scalar) const;
+
+	constexpr Vector3 &operator-=(real_t p_scalar);
+	constexpr Vector3 operator-(real_t p_scalar) const;
+
 	constexpr Vector3 &operator*=(real_t p_scalar);
 	constexpr Vector3 operator*(real_t p_scalar) const;
 	constexpr Vector3 &operator/=(real_t p_scalar);
@@ -426,6 +432,28 @@ constexpr Vector3 &Vector3::operator/=(const Vector3 &p_v) {
 
 constexpr Vector3 Vector3::operator/(const Vector3 &p_v) const {
 	return Vector3(x / p_v.x, y / p_v.y, z / p_v.z);
+}
+
+constexpr Vector3 &Vector3::operator+=(real_t p_scalar) {
+	x += p_scalar;
+	y += p_scalar;
+	z += p_scalar;
+	return *this;
+}
+
+constexpr Vector3 Vector3::operator+(real_t p_scalar) const {
+	return Vector3(x + p_scalar, y + p_scalar, z + p_scalar);
+}
+
+constexpr Vector3 &Vector3::operator-=(real_t p_scalar) {
+	x -= p_scalar;
+	y -= p_scalar;
+	z -= p_scalar;
+	return *this;
+}
+
+constexpr Vector3 Vector3::operator-(real_t p_scalar) const {
+	return Vector3(x - p_scalar, y - p_scalar, z - p_scalar);
 }
 
 constexpr Vector3 &Vector3::operator*=(real_t p_scalar) {

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -122,6 +122,10 @@ struct [[nodiscard]] Vector3i {
 	constexpr Vector3i &operator%=(const Vector3i &p_v);
 	constexpr Vector3i operator%(const Vector3i &p_v) const;
 
+	constexpr Vector3i &operator+=(int32_t p_scalar);
+	constexpr Vector3i operator+(int32_t p_scalar) const;
+	constexpr Vector3i &operator-=(int32_t p_scalar);
+	constexpr Vector3i operator-(int32_t p_scalar) const;
 	constexpr Vector3i &operator*=(int32_t p_scalar);
 	constexpr Vector3i operator*(int32_t p_scalar) const;
 	constexpr Vector3i &operator/=(int32_t p_scalar);
@@ -240,6 +244,28 @@ constexpr Vector3i &Vector3i::operator%=(const Vector3i &p_v) {
 
 constexpr Vector3i Vector3i::operator%(const Vector3i &p_v) const {
 	return Vector3i(x % p_v.x, y % p_v.y, z % p_v.z);
+}
+
+constexpr Vector3i &Vector3i::operator+=(int32_t p_scalar) {
+	x += p_scalar;
+	y += p_scalar;
+	z += p_scalar;
+	return *this;
+}
+
+constexpr Vector3i Vector3i::operator+(int32_t p_scalar) const {
+	return Vector3i(x + p_scalar, y + p_scalar, z + p_scalar);
+}
+
+constexpr Vector3i &Vector3i::operator-=(int32_t p_scalar) {
+	x -= p_scalar;
+	y -= p_scalar;
+	z -= p_scalar;
+	return *this;
+}
+
+constexpr Vector3i Vector3i::operator-(int32_t p_scalar) const {
+	return Vector3i(x - p_scalar, y - p_scalar, z - p_scalar);
 }
 
 constexpr Vector3i &Vector3i::operator*=(int32_t p_scalar) {

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -137,6 +137,12 @@ struct [[nodiscard]] Vector4 {
 	constexpr Vector4 operator*(real_t p_s) const;
 	constexpr Vector4 operator/(real_t p_s) const;
 
+	constexpr Vector4 operator+(real_t p_s) const;
+	constexpr void operator+=(real_t p_s);
+
+	constexpr Vector4 operator-(real_t p_s) const;
+	constexpr void operator-=(real_t p_s);
+
 	constexpr bool operator==(const Vector4 &p_vec4) const;
 	constexpr bool operator!=(const Vector4 &p_vec4) const;
 	constexpr bool operator>(const Vector4 &p_vec4) const;
@@ -228,6 +234,28 @@ constexpr Vector4 Vector4::operator/(const Vector4 &p_vec4) const {
 
 constexpr Vector4 Vector4::operator-() const {
 	return Vector4(-x, -y, -z, -w);
+}
+
+constexpr Vector4 Vector4::operator+(real_t p_s) const {
+	return Vector4(x + p_s, y + p_s, z + p_s, w + p_s);
+}
+
+constexpr void Vector4::operator+=(real_t p_s) {
+	x += p_s;
+	y += p_s;
+	z += p_s;
+	w += p_s;
+}
+
+constexpr Vector4 Vector4::operator-(real_t p_s) const {
+	return Vector4(x - p_s, y - p_s, z - p_s, w - p_s);
+}
+
+constexpr void Vector4::operator-=(real_t p_s) {
+	x -= p_s;
+	y -= p_s;
+	z -= p_s;
+	w -= p_s;
 }
 
 constexpr Vector4 Vector4::operator*(real_t p_s) const {

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -117,6 +117,10 @@ struct [[nodiscard]] Vector4i {
 	constexpr Vector4i &operator%=(const Vector4i &p_v);
 	constexpr Vector4i operator%(const Vector4i &p_v) const;
 
+	constexpr Vector4i &operator+=(int32_t p_scalar);
+	constexpr Vector4i operator+(int32_t p_scalar) const;
+	constexpr Vector4i &operator-=(int32_t p_scalar);
+	constexpr Vector4i operator-(int32_t p_scalar) const;
 	constexpr Vector4i &operator*=(int32_t p_scalar);
 	constexpr Vector4i operator*(int32_t p_scalar) const;
 	constexpr Vector4i &operator/=(int32_t p_scalar);
@@ -265,6 +269,30 @@ constexpr Vector4i operator*(float p_scalar, const Vector4i &p_vector) {
 
 constexpr Vector4i operator*(double p_scalar, const Vector4i &p_vector) {
 	return p_vector * p_scalar;
+}
+
+constexpr Vector4i &Vector4i::operator+=(int32_t p_scalar) {
+	x += p_scalar;
+	y += p_scalar;
+	z += p_scalar;
+	w += p_scalar;
+	return *this;
+}
+
+constexpr Vector4i Vector4i::operator+(int32_t p_scalar) const {
+	return Vector4i(x + p_scalar, y + p_scalar, z + p_scalar, w + p_scalar);
+}
+
+constexpr Vector4i &Vector4i::operator-=(int32_t p_scalar) {
+	x -= p_scalar;
+	y -= p_scalar;
+	z -= p_scalar;
+	w -= p_scalar;
+	return *this;
+}
+
+constexpr Vector4i Vector4i::operator-(int32_t p_scalar) const {
+	return Vector4i(x - p_scalar, y - p_scalar, z - p_scalar, w - p_scalar);
 }
 
 constexpr Vector4i &Vector4i::operator/=(int32_t p_scalar) {

--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -221,11 +221,17 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorAdd<double, double, double>>(Variant::OP_ADD, Variant::FLOAT, Variant::FLOAT);
 	register_string_op(OperatorEvaluatorStringConcat, Variant::OP_ADD);
 	register_op<OperatorEvaluatorAdd<Vector2, Vector2, Vector2>>(Variant::OP_ADD, Variant::VECTOR2, Variant::VECTOR2);
+	register_op<OperatorEvaluatorAdd<Vector2, Vector2, double>>(Variant::OP_ADD, Variant::VECTOR2, Variant::FLOAT);
 	register_op<OperatorEvaluatorAdd<Vector2i, Vector2i, Vector2i>>(Variant::OP_ADD, Variant::VECTOR2I, Variant::VECTOR2I);
+	register_op<OperatorEvaluatorAdd<Vector2i, Vector2i, int64_t>>(Variant::OP_ADD, Variant::VECTOR2I, Variant::INT);
 	register_op<OperatorEvaluatorAdd<Vector3, Vector3, Vector3>>(Variant::OP_ADD, Variant::VECTOR3, Variant::VECTOR3);
+	register_op<OperatorEvaluatorAdd<Vector3, Vector3, double>>(Variant::OP_ADD, Variant::VECTOR3, Variant::FLOAT);
 	register_op<OperatorEvaluatorAdd<Vector3i, Vector3i, Vector3i>>(Variant::OP_ADD, Variant::VECTOR3I, Variant::VECTOR3I);
+	register_op<OperatorEvaluatorAdd<Vector3i, Vector3i, int64_t>>(Variant::OP_ADD, Variant::VECTOR3I, Variant::INT);
 	register_op<OperatorEvaluatorAdd<Vector4, Vector4, Vector4>>(Variant::OP_ADD, Variant::VECTOR4, Variant::VECTOR4);
+	register_op<OperatorEvaluatorAdd<Vector4, Vector4, double>>(Variant::OP_ADD, Variant::VECTOR4, Variant::FLOAT);
 	register_op<OperatorEvaluatorAdd<Vector4i, Vector4i, Vector4i>>(Variant::OP_ADD, Variant::VECTOR4I, Variant::VECTOR4I);
+	register_op<OperatorEvaluatorAdd<Vector4i, Vector4i, int64_t>>(Variant::OP_ADD, Variant::VECTOR4I, Variant::INT);
 	register_op<OperatorEvaluatorAdd<Quaternion, Quaternion, Quaternion>>(Variant::OP_ADD, Variant::QUATERNION, Variant::QUATERNION);
 	register_op<OperatorEvaluatorAdd<Color, Color, Color>>(Variant::OP_ADD, Variant::COLOR, Variant::COLOR);
 	register_op<OperatorEvaluatorAddArray>(Variant::OP_ADD, Variant::ARRAY, Variant::ARRAY);
@@ -245,11 +251,17 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorSub<double, double, int64_t>>(Variant::OP_SUBTRACT, Variant::FLOAT, Variant::INT);
 	register_op<OperatorEvaluatorSub<double, double, double>>(Variant::OP_SUBTRACT, Variant::FLOAT, Variant::FLOAT);
 	register_op<OperatorEvaluatorSub<Vector2, Vector2, Vector2>>(Variant::OP_SUBTRACT, Variant::VECTOR2, Variant::VECTOR2);
+	register_op<OperatorEvaluatorSub<Vector2, Vector2, double>>(Variant::OP_SUBTRACT, Variant::VECTOR2, Variant::FLOAT);
 	register_op<OperatorEvaluatorSub<Vector2i, Vector2i, Vector2i>>(Variant::OP_SUBTRACT, Variant::VECTOR2I, Variant::VECTOR2I);
+	register_op<OperatorEvaluatorSub<Vector2i, Vector2i, int64_t>>(Variant::OP_SUBTRACT, Variant::VECTOR2I, Variant::INT);
 	register_op<OperatorEvaluatorSub<Vector3, Vector3, Vector3>>(Variant::OP_SUBTRACT, Variant::VECTOR3, Variant::VECTOR3);
+	register_op<OperatorEvaluatorSub<Vector3, Vector3, double>>(Variant::OP_SUBTRACT, Variant::VECTOR3, Variant::FLOAT);
 	register_op<OperatorEvaluatorSub<Vector3i, Vector3i, Vector3i>>(Variant::OP_SUBTRACT, Variant::VECTOR3I, Variant::VECTOR3I);
+	register_op<OperatorEvaluatorSub<Vector3i, Vector3i, int64_t>>(Variant::OP_SUBTRACT, Variant::VECTOR3I, Variant::INT);
 	register_op<OperatorEvaluatorSub<Vector4, Vector4, Vector4>>(Variant::OP_SUBTRACT, Variant::VECTOR4, Variant::VECTOR4);
+	register_op<OperatorEvaluatorSub<Vector4, Vector4, double>>(Variant::OP_SUBTRACT, Variant::VECTOR4, Variant::FLOAT);
 	register_op<OperatorEvaluatorSub<Vector4i, Vector4i, Vector4i>>(Variant::OP_SUBTRACT, Variant::VECTOR4I, Variant::VECTOR4I);
+	register_op<OperatorEvaluatorSub<Vector4i, Vector4i, int64_t>>(Variant::OP_SUBTRACT, Variant::VECTOR4I, Variant::INT);
 	register_op<OperatorEvaluatorSub<Quaternion, Quaternion, Quaternion>>(Variant::OP_SUBTRACT, Variant::QUATERNION, Variant::QUATERNION);
 	register_op<OperatorEvaluatorSub<Color, Color, Color>>(Variant::OP_SUBTRACT, Variant::COLOR, Variant::COLOR);
 

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -507,6 +507,12 @@
 				[/codeblock]
 			</description>
 		</operator>
+		<operator name="operator +">
+			<return type="Vector2" />
+			<param index="0" name="right" type="float" />
+			<description>
+			</description>
+		</operator>
 		<operator name="operator -">
 			<return type="Vector2" />
 			<param index="0" name="right" type="Vector2" />
@@ -515,6 +521,12 @@
 				[codeblock]
 				print(Vector2(10, 20) - Vector2(3, 4)) # Prints (7.0, 16.0)
 				[/codeblock]
+			</description>
+		</operator>
+		<operator name="operator -">
+			<return type="Vector2" />
+			<param index="0" name="right" type="float" />
+			<description>
 			</description>
 		</operator>
 		<operator name="operator /">

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -266,6 +266,12 @@
 				[/codeblock]
 			</description>
 		</operator>
+		<operator name="operator +">
+			<return type="Vector2i" />
+			<param index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
 		<operator name="operator -">
 			<return type="Vector2i" />
 			<param index="0" name="right" type="Vector2i" />
@@ -274,6 +280,12 @@
 				[codeblock]
 				print(Vector2i(10, 20) - Vector2i(3, 4)) # Prints (7, 16)
 				[/codeblock]
+			</description>
+		</operator>
+		<operator name="operator -">
+			<return type="Vector2i" />
+			<param index="0" name="right" type="int" />
+			<description>
 			</description>
 		</operator>
 		<operator name="operator /">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -546,6 +546,12 @@
 				[/codeblock]
 			</description>
 		</operator>
+		<operator name="operator +">
+			<return type="Vector3" />
+			<param index="0" name="right" type="float" />
+			<description>
+			</description>
+		</operator>
 		<operator name="operator -">
 			<return type="Vector3" />
 			<param index="0" name="right" type="Vector3" />
@@ -554,6 +560,12 @@
 				[codeblock]
 				print(Vector3(10, 20, 30) - Vector3(3, 4, 5)) # Prints (7.0, 16.0, 25.0)
 				[/codeblock]
+			</description>
+		</operator>
+		<operator name="operator -">
+			<return type="Vector3" />
+			<param index="0" name="right" type="float" />
+			<description>
 			</description>
 		</operator>
 		<operator name="operator /">

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -273,6 +273,12 @@
 				[/codeblock]
 			</description>
 		</operator>
+		<operator name="operator +">
+			<return type="Vector3i" />
+			<param index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
 		<operator name="operator -">
 			<return type="Vector3i" />
 			<param index="0" name="right" type="Vector3i" />
@@ -281,6 +287,12 @@
 				[codeblock]
 				print(Vector3i(10, 20, 30) - Vector3i(3, 4, 5)) # Prints (7, 16, 25)
 				[/codeblock]
+			</description>
+		</operator>
+		<operator name="operator -">
+			<return type="Vector3i" />
+			<param index="0" name="right" type="int" />
+			<description>
 			</description>
 		</operator>
 		<operator name="operator /">

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -364,6 +364,12 @@
 				[/codeblock]
 			</description>
 		</operator>
+		<operator name="operator +">
+			<return type="Vector4" />
+			<param index="0" name="right" type="float" />
+			<description>
+			</description>
+		</operator>
 		<operator name="operator -">
 			<return type="Vector4" />
 			<param index="0" name="right" type="Vector4" />
@@ -372,6 +378,12 @@
 				[codeblock]
 				print(Vector4(10, 20, 30, 40) - Vector4(3, 4, 5, 6)) # Prints (7.0, 16.0, 25.0, 34.0)
 				[/codeblock]
+			</description>
+		</operator>
+		<operator name="operator -">
+			<return type="Vector4" />
+			<param index="0" name="right" type="float" />
+			<description>
 			</description>
 		</operator>
 		<operator name="operator /">

--- a/doc/classes/Vector4i.xml
+++ b/doc/classes/Vector4i.xml
@@ -260,6 +260,12 @@
 				[/codeblock]
 			</description>
 		</operator>
+		<operator name="operator +">
+			<return type="Vector4i" />
+			<param index="0" name="right" type="int" />
+			<description>
+			</description>
+		</operator>
 		<operator name="operator -">
 			<return type="Vector4i" />
 			<param index="0" name="right" type="Vector4i" />
@@ -268,6 +274,12 @@
 				[codeblock]
 				print(Vector4i(10, 20, 30, 40) - Vector4i(3, 4, 5, 6)) # Prints (7, 16, 25, 34)
 				[/codeblock]
+			</description>
+		</operator>
+		<operator name="operator -">
+			<return type="Vector4i" />
+			<param index="0" name="right" type="int" />
+			<description>
 			</description>
 		</operator>
 		<operator name="operator /">

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -1148,7 +1148,7 @@ HashMap<Vector2i, TileMapCell> TileMapLayerEditorTilesPlugin::_draw_rect(Vector2
 				for (int y = 0; y <= rect.size.y / pattern->get_size().y; y++) {
 					Vector2i pattern_coords = rect.position + Vector2i(x, y) * pattern->get_size() + offset;
 					for (int j = 0; j < used_cells.size(); j++) {
-						Vector2i coords = pattern_coords + used_cells[j];
+						Vector2i coords = pattern_coords + static_cast<Vector2i>(used_cells[j]);
 						if (rect.has_point(coords)) {
 							_add_to_output_if_tile_changed(output, edited_layer, coords, TileMapCell(pattern->get_cell_source_id(used_cells[j]), pattern->get_cell_atlas_coords(used_cells[j]), pattern->get_cell_alternative_tile(used_cells[j])));
 						}

--- a/tests/core/math/test_vector2.cpp
+++ b/tests/core/math/test_vector2.cpp
@@ -262,6 +262,27 @@ TEST_CASE("[Vector2] Operators") {
 			"Vector2 division with integers should give exact results.");
 
 	CHECK_MESSAGE(
+			(Vector2(1.5f, 2.25f) + 1.5f) == Vector2(3.0f, 3.75f),
+			"Vector2 + float should give expected results.");
+	CHECK_MESSAGE(
+			(Vector2(1.5f, 2.25f) - 1.5f) == Vector2(0.0f, 0.75f),
+			"Vector2 - float should give expected results.");
+	{
+		Vector2 v(1.5f, 2.25f);
+		v += -5.0f;
+		CHECK_MESSAGE(
+				v == Vector2(-3.5f, -2.75f),
+				"Vector2 += float should give expected results.");
+	}
+	{
+		Vector2 v(1.5f, 2.25f);
+		v -= -1.75f;
+		CHECK_MESSAGE(
+				v == Vector2(3.25f, 4.0f),
+				"Vector2 -= float should give expected results.");
+	}
+
+	CHECK_MESSAGE(
 			((Vector2i)decimal1) == Vector2i(2, 4),
 			"Vector2 cast to Vector2i should work as expected.");
 	CHECK_MESSAGE(

--- a/tests/core/math/test_vector2i.cpp
+++ b/tests/core/math/test_vector2i.cpp
@@ -128,6 +128,27 @@ TEST_CASE("[Vector2i] Operators") {
 	CHECK_MESSAGE(
 			Vector2i(Vector2(1.1, 2.9)) == Vector2i(1, 2),
 			"Vector2i constructed from Vector2 should work as expected.");
+
+	CHECK_MESSAGE(
+			(Vector2i(1, 2) + 1) == Vector2i(2, 3),
+			"Vector2i + int should give expected results.");
+	CHECK_MESSAGE(
+			(Vector2i(1, 2) - 3) == Vector2i(-2, -1),
+			"Vector2i - int should give expected results.");
+	{
+		Vector2i v(1, 2);
+		v += -5;
+		CHECK_MESSAGE(
+				v == Vector2i(-4, -3),
+				"Vector2i += int should give expected results.");
+	}
+	{
+		Vector2i v(1, 2);
+		v -= -5;
+		CHECK_MESSAGE(
+				v == Vector2i(6, 7),
+				"Vector2i -= int should give expected results.");
+	}
 }
 
 TEST_CASE("[Vector2i] Other methods") {

--- a/tests/core/math/test_vector3.cpp
+++ b/tests/core/math/test_vector3.cpp
@@ -279,6 +279,27 @@ TEST_CASE("[Vector3] Operators") {
 			"Vector3 division with integers should give exact results.");
 
 	CHECK_MESSAGE(
+			(Vector3(1.5f, 2.25f, -1.0f) + 1.5f) == Vector3(3.0f, 3.75f, 0.5f),
+			"Vector3 + float should give expected results.");
+	CHECK_MESSAGE(
+			(Vector3(1.5f, 2.25f, -1.0f) - 1.5f) == Vector3(-0.0f, 0.75f, -2.5f),
+			"Vector3 - float should give expected results.");
+	{
+		Vector3 v(1.5f, 2.25f, -1.0f);
+		v += -5.0f;
+		CHECK_MESSAGE(
+				v == Vector3(-3.5f, -2.75f, -6.0f),
+				"Vector3 += float should give expected results.");
+	}
+	{
+		Vector3 v(1.5f, 2.25f, -1.0f);
+		v -= -1.75f;
+		CHECK_MESSAGE(
+				v == Vector3(3.25f, 4.0f, 0.75f),
+				"Vector3 -= float should give expected results.");
+	}
+
+	CHECK_MESSAGE(
 			((Vector3i)decimal1) == Vector3i(2, 4, 7),
 			"Vector3 cast to Vector3i should work as expected.");
 	CHECK_MESSAGE(

--- a/tests/core/math/test_vector3i.cpp
+++ b/tests/core/math/test_vector3i.cpp
@@ -131,6 +131,27 @@ TEST_CASE("[Vector3i] Operators") {
 	CHECK_MESSAGE(
 			Vector3i(Vector3(1.1, 2.9, 3.9)) == Vector3i(1, 2, 3),
 			"Vector3i constructed from Vector3 should work as expected.");
+
+	CHECK_MESSAGE(
+			(Vector3i(1, 2, 3) + 1) == Vector3i(2, 3, 4),
+			"Vector3i + int should give expected results.");
+	CHECK_MESSAGE(
+			(Vector3i(1, 2, 3) - 3) == Vector3i(-2, -1, 0),
+			"Vector3i - int should give expected results.");
+	{
+		Vector3i v(1, 2, 3);
+		v += -5;
+		CHECK_MESSAGE(
+				v == Vector3i(-4, -3, -2),
+				"Vector3i += int should give expected results.");
+	}
+	{
+		Vector3i v(1, 2, 3);
+		v -= -5;
+		CHECK_MESSAGE(
+				v == Vector3i(6, 7, 8),
+				"Vector3i -= int should give expected results.");
+	}
 }
 
 TEST_CASE("[Vector3i] Other methods") {

--- a/tests/core/math/test_vector4.cpp
+++ b/tests/core/math/test_vector4.cpp
@@ -205,6 +205,26 @@ TEST_CASE("[Vector4] Operators") {
 			"Vector4 division with integers should give exact results.");
 
 	CHECK_MESSAGE(
+			(Vector4(1.5f, 2.25f, -1.0f, 0.5f) + 1.5f) == Vector4(3.0f, 3.75f, 0.5f, 2.0f),
+			"Vector4 + float should give expected results.");
+	CHECK_MESSAGE(
+			(Vector4(1.5f, 2.25f, -1.0f, 0.5f) - 1.5f) == Vector4(0.0f, 0.75f, -2.5f, -1.0f),
+			"Vector4 - float should give expected results.");
+	{
+		Vector4 v(1.5f, 2.25f, -1.0f, 0.5f);
+		v += -5.0f;
+		CHECK_MESSAGE(
+				v == Vector4(-3.5f, -2.75f, -6.0f, -4.5f),
+				"Vector4 += float should give expected results.");
+	}
+	{
+		Vector4 v(1.5f, 2.25f, -1.0f, 0.5f);
+		v -= -1.75f;
+		CHECK_MESSAGE(
+				v == Vector4(3.25f, 4.0f, 0.75f, 2.25f),
+				"Vector4 -= float should give expected results.");
+	}
+	CHECK_MESSAGE(
 			((String)decimal1) == "(2.3, 4.9, 7.8, 3.2)",
 			"Vector4 cast to String should work as expected.");
 	CHECK_MESSAGE(

--- a/tests/core/math/test_vector4i.cpp
+++ b/tests/core/math/test_vector4i.cpp
@@ -134,6 +134,27 @@ TEST_CASE("[Vector4i] Operators") {
 	CHECK_MESSAGE(
 			Vector4i(Vector4(1.1, 2.9, 3.9, 100.5)) == Vector4i(1, 2, 3, 100),
 			"Vector4i constructed from Vector4 should work as expected.");
+
+	CHECK_MESSAGE(
+			(Vector4i(1, 2, 3, 4) + 1) == Vector4i(2, 3, 4, 5),
+			"Vector4i + int should give expected results.");
+	CHECK_MESSAGE(
+			(Vector4i(1, 2, 3, 4) - 3) == Vector4i(-2, -1, 0, 1),
+			"Vector4i - int should give expected results.");
+	{
+		Vector4i v(1, 2, 3, 4);
+		v += -5;
+		CHECK_MESSAGE(
+				v == Vector4i(-4, -3, -2, -1),
+				"Vector4i += int should give expected results.");
+	}
+	{
+		Vector4i v(1, 2, 3, 4);
+		v -= -5;
+		CHECK_MESSAGE(
+				v == Vector4i(6, 7, 8, 9),
+				"Vector4i -= int should give expected results.");
+	}
 }
 
 TEST_CASE("[Vector3i] Other methods") {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5476

What this PR implements:
* `Vector* + float`
* `Vector*i + int`
* `Vector* += float`
* `Vector*i += int`
* Same for `-`

What it does not include:
* `Vector* + int`
* `Vector*i + float`
* `int + Vector*i`
* `float + Vector*i`

Test project for GDScript
[vec_add.zip](https://github.com/user-attachments/files/25573673/vec_add.zip)


