### PR TITLE
[Tests] Always init message queue and rendering server.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -106,6 +106,7 @@
 #endif // XR_DISABLED
 
 #ifdef TESTS_ENABLED
+#include "servers/rendering/dummy/rasterizer_dummy.h"
 #include "tests/test_main.h"
 #endif
 
@@ -792,6 +793,13 @@ Error Main::test_setup() {
 	translation_server->load_project_translations(translation_server->get_main_domain());
 	ResourceLoader::load_translation_remaps(); //load remaps for resources
 
+	message_queue = memnew(MessageQueue);
+
+	RasterizerDummy::make_current();
+	rendering_server = memnew(RenderingServerDefault());
+	rendering_server->init();
+	rendering_server->set_render_loop_enabled(false);
+
 	// Initialize ThemeDB early so that scene types can register their theme items.
 	// Default theme will be initialized later, after modules and ScriptServer are ready.
 	initialize_theme_db();
@@ -884,6 +892,17 @@ void Main::test_cleanup() {
 	unregister_scene_types();
 
 	finalize_theme_db();
+
+	if (rendering_server) {
+		rendering_server->sync();
+		rendering_server->global_shader_parameters_clear();
+		rendering_server->finish();
+		memdelete(rendering_server);
+	}
+	if (message_queue) {
+		message_queue->flush();
+		memdelete(message_queue);
+	}
 
 #ifndef NAVIGATION_2D_DISABLED
 	NavigationServer2DManager::finalize_server();

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -169,8 +169,6 @@ struct GodotTestCaseListener : public doctest::IReporter {
 		String suite_name = String(p_in.m_test_suite);
 
 		if (name.contains("[SceneTree]") || name.contains("[Editor]")) {
-			memnew(MessageQueue);
-
 			memnew(Input);
 			Input::get_singleton()->set_use_accumulated_input(false);
 
@@ -182,9 +180,6 @@ struct GodotTestCaseListener : public doctest::IReporter {
 					break;
 				}
 			}
-			memnew(RenderingServerDefault());
-			RenderingServerDefault::get_singleton()->init();
-			RenderingServerDefault::get_singleton()->set_render_loop_enabled(false);
 
 			// ThemeDB requires RenderingServer to initialize the default theme.
 			// So we have to do this for each test case. Also make sure there is
@@ -327,14 +322,7 @@ struct GodotTestCaseListener : public doctest::IReporter {
 		}
 
 		if (RenderingServer::get_singleton()) {
-			// ThemeDB requires RenderingServer to finalize the default theme.
-			// So we have to do this for each test case.
 			ThemeDB::get_singleton()->finalize_theme();
-
-			RenderingServer::get_singleton()->sync();
-			RenderingServer::get_singleton()->global_shader_parameters_clear();
-			RenderingServer::get_singleton()->finish();
-			memdelete(RenderingServer::get_singleton());
 		}
 
 		if (DisplayServer::get_singleton()) {
@@ -343,11 +331,6 @@ struct GodotTestCaseListener : public doctest::IReporter {
 
 		if (InputMap::get_singleton()) {
 			memdelete(InputMap::get_singleton());
-		}
-
-		if (MessageQueue::get_singleton()) {
-			MessageQueue::get_singleton()->flush();
-			memdelete(MessageQueue::get_singleton());
 		}
 
 		if (AudioServer::get_singleton()) {


### PR DESCRIPTION
Should allow removing some `RenderingServer::get_singleton() != nullptr` checks and decoupling more parts of the engine from `RenderingServer`.
