### PR TITLE
Fix search help history not tracking local links

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3356,6 +3356,7 @@ void ScriptEditor::_help_class_goto(const String &p_desc) {
 	_go_to_tab(tab_container->get_tab_count() - 1);
 	eh->go_to_help(p_desc);
 	eh->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
+	eh->connect("request_save_history", callable_mp(this, &ScriptEditor::_save_history));
 	_add_recent_script(eh->get_class());
 	_sort_list_on_update = true;
 	_update_script_names();


### PR DESCRIPTION
Resolves godotengine/godot-proposals#14317

This connects the "request_save_history" signal when a `EditorHelp` node is created. This allows newly created `EditorHelp` nodes to actually remember local history as they should.
