### PR TITLE
Add a comment to run clang-format and clang-tidy on all files on changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,6 @@
+# If you change this file, please format all files of the codebase as part of your PR:
+# pre-commit run clang-format --all
+
 # Commented out parameters are those with the same value as base LLVM style.
 # We can uncomment them if we want to change their value, or enforce the
 # chosen value in case the base style changes (last sync: Clang 18.1.8).

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,6 @@
+# If you change this file, please format all files of the codebase as part of your PR:
+# pre-commit run --hook-stage manual clang-tidy --all
+
 Checks:
   - -*
   - bugprone-use-after-move


### PR DESCRIPTION
I realized that we don't have a convenient note for this yet. Adding this comment should help avoid PRs merged without a style check.