### PR TITLE
Fix lights with disabled bake mode affecting Voxel GI

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3807,7 +3807,8 @@ void RendererSceneCull::render_probes() {
 			for (Instance *E : probe->lights) {
 				Instance *instance = E;
 				InstanceLightData *instance_light = (InstanceLightData *)instance->base_data;
-				if (!instance->visible) {
+				RSE::LightBakeMode bake_mode = RSG::light_storage->light_get_bake_mode(instance->base);
+				if (!instance->visible || bake_mode == RSE::LIGHT_BAKE_DISABLED) {
 					continue;
 				}
 				if (cache_dirty) {
@@ -3839,7 +3840,8 @@ void RendererSceneCull::render_probes() {
 
 			for (const Instance *instance : probe->owner->scenario->directional_lights) {
 				InstanceLightData *instance_light = (InstanceLightData *)instance->base_data;
-				if (!instance->visible) {
+				RSE::LightBakeMode bake_mode = RSG::light_storage->light_get_bake_mode(instance->base);
+				if (!instance->visible || bake_mode == RSE::LIGHT_BAKE_DISABLED) {
 					continue;
 				}
 				if (cache_dirty) {
@@ -3891,7 +3893,8 @@ void RendererSceneCull::render_probes() {
 				for (Instance *E : probe->lights) {
 					Instance *instance = E;
 					InstanceLightData *instance_light = (InstanceLightData *)instance->base_data;
-					if (!instance->visible) {
+					RSE::LightBakeMode bake_mode = RSG::light_storage->light_get_bake_mode(instance->base);
+					if (!instance->visible || bake_mode == RSE::LIGHT_BAKE_DISABLED) {
 						continue;
 					}
 
@@ -3914,7 +3917,8 @@ void RendererSceneCull::render_probes() {
 				}
 				for (const Instance *instance : probe->owner->scenario->directional_lights) {
 					InstanceLightData *instance_light = (InstanceLightData *)instance->base_data;
-					if (!instance->visible) {
+					RSE::LightBakeMode bake_mode = RSG::light_storage->light_get_bake_mode(instance->base);
+					if (!instance->visible || bake_mode == RSE::LIGHT_BAKE_DISABLED) {
 						continue;
 					}
 


### PR DESCRIPTION
this was originally https://github.com/godotengine/godot/pull/109083, github kind of screwed the history and I don't feel like trying to fix it so here's another PR.

this fixes an issue where lights with `light_bake_mode` set to `Disabled` would sometimes get added to voxel gi. @mrTag in the previous PR was correct that I should have also added the same for the other light types, which I did here, as well as updating it for the recent renderingserver changes.

I have a test file now. there's 64 lights and the max is 32. the green lights have dynamic bake mode, the red ones should not be visible in the voxel gi lighting debug view.
[vgi-light-culling.zip](https://github.com/user-attachments/files/25576136/vgi-light-culling.zip)
the incorrect behavior has missing lights from both groups because lights with disabled bake mode get incorrectly added and it goes over the limit of 32 (if you don't see it, hide the vgi node and re-show it, and the lights sort of randomly change)
<img width="512" height="510" alt="incorrect" src="https://github.com/user-attachments/assets/90dacd85-0cc2-4d3a-abec-5ce8f960629c" />
the correct behavior with the patch shows all 32 green lights and none of the red ones.
<img width="512" height="514" alt="correct" src="https://github.com/user-attachments/assets/63a0bfa8-3a42-4882-b4f5-0fad668f35cc" />
