### PR TITLE
Consolidate Clang and GCC variable shadowing warnings

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -969,7 +969,7 @@ else:  # GCC, Clang
         if cc_version_major >= 11:
             common_warnings += ["-Wenum-conversion"]
     elif methods.using_clang(env) or methods.using_emcc(env):
-        common_warnings += ["-Wshadow-field-in-constructor", "-Wshadow-uncaptured-local"]
+        common_warnings += ["-Wshadow"]
         # We often implement `operator<` for structs of pointers as a requirement
         # for putting them in `Set` or `Map`. We don't mind about unreliable ordering.
         common_warnings += ["-Wno-ordered-compare-function-pointers"]


### PR DESCRIPTION
This PR aims to consolidate Clang and GCC variable shadowing warnings to prevent wasting CI time (and your own).
For GCC we set `-Wshadow` while Clang just receives `-Wshadow-field-in-constructor` and `-Wshadow-uncaptured-local`.

At least locally, Godot compiled fine with Clang 21.1.8 and `-Wshadow`, let's see what CI does :) 
Loosening variable shadowing warnings is not really an option since GCC only provides very limited control (just `Wshadow=global`, `Wshadow=local` and `Wshadow=compatible-local`).
I'm not sure if this is the best way, hence marked as draft.
Just to be safe, we could check for a specific minimum clang version. Maybe clang behaved differently in the past, so we refrained from using `-Wshadow`.

Opinions? :)