### PR TITLE
Update `HTTPRequest` example to use static `JSON.stringify()`

### DIFF
--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -25,7 +25,7 @@
 			# Perform a POST request. The URL below returns JSON as of writing.
 			# Note: Don't make simultaneous requests using a single HTTPRequest node.
 			# The snippet below is provided for reference only.
-			var body = JSON.new().stringify({"name": "Godette"})
+			var body = JSON.stringify({"name": "Godette"})
 			error = http_request.request("https://httpbin.org/post", [], HTTPClient.METHOD_POST, body)
 			if error != OK:
 				push_error("An error occurred in the HTTP request.")
@@ -57,7 +57,7 @@
 			// Perform a POST request. The URL below returns JSON as of writing.
 			// Note: Don't make simultaneous requests using a single HTTPRequest node.
 			// The snippet below is provided for reference only.
-			string body = new Json().Stringify(new Godot.Collections.Dictionary
+			string body = Json.Stringify(new Godot.Collections.Dictionary
 			{
 				{ "name", "Godette" }
 			});


### PR DESCRIPTION
Updated the `HTTPRequest` example to use `JSON.stringify()` instead of `JSON.new().stringify()` after the function was made static in https://github.com/godotengine/godot/pull/60515