### PR TITLE
Fix visual shader parameter range sliders get stuck on changing

### DIFF
--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -16,6 +16,13 @@
 				Called when the [Range]'s value is changed (following the same conditions as [signal value_changed]).
 			</description>
 		</method>
+		<method name="set_as_ratio_no_signal">
+			<return type="void" />
+			<param index="0" name="value" type="float" />
+			<description>
+				Sets the [Range]'s value mapped between 0 and 1, without emitting the [signal value_changed] signal.
+			</description>
+		</method>
 		<method name="set_value_no_signal">
 			<return type="void" />
 			<param index="0" name="value" type="float" />

--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -99,7 +99,7 @@ void EditorSpinSlider::gui_input(const Ref<InputEvent> &p_event) {
 				_grab_end();
 
 				if (deferred_drag_mode && grabbing) {
-					_notify_shared_value_changed(); // Need to be emitted at the end, since the signal doesn't emitted in `set_value_no_signal` method.
+					_notify_shared_value_changed(); // Need to be emitted at the end, since the signal doesn't emit in `set_value_no_signal` method.
 				}
 			}
 		} else if (mb->get_button_index() == MouseButton::RIGHT) {
@@ -243,6 +243,9 @@ void EditorSpinSlider::_grabber_gui_input(const Ref<InputEvent> &p_event) {
 				if (!mouse_over_grabber) {
 					queue_redraw();
 				}
+				if (deferred_drag_mode) {
+					_notify_shared_value_changed(); // Need to be emitted at the end, since the signal doesn't emit in `set_as_ratio_no_signal` method.
+				}
 			}
 			mousewheel_over_grabber = false;
 			emit_signal("ungrabbed");
@@ -265,7 +268,12 @@ void EditorSpinSlider::_grabber_gui_input(const Ref<InputEvent> &p_event) {
 		float scale_x = get_global_transform_with_canvas().get_scale().x;
 		ERR_FAIL_COND(Math::is_zero_approx(scale_x));
 		float grabbing_ofs = (grabber->get_transform().xform(mm->get_position()).x - grabbing_from) / float(grabber_range) / scale_x;
-		set_as_ratio(grabbing_ratio + grabbing_ofs);
+		double value = grabbing_ratio + grabbing_ofs;
+		if (deferred_drag_mode) {
+			set_as_ratio_no_signal(value);
+		} else {
+			set_as_ratio(value);
+		}
 		queue_redraw();
 	}
 }

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -2758,6 +2758,15 @@ void EditorPropertyTransform3D::_value_changed(double val, const String &p_name)
 	emit_changed(get_edited_property(), p, p_name);
 }
 
+void EditorPropertyTransform3D::set_deferred_drag_mode_enabled(bool p_enabled) {
+	EditorProperty::set_deferred_drag_mode_enabled(p_enabled);
+	const int count = sizeof(spin) / sizeof(spin[0]);
+
+	for (int i = 0; i < count; i++) {
+		spin[i]->set_deferred_drag_mode_enabled(p_enabled);
+	}
+}
+
 void EditorPropertyTransform3D::update_property() {
 	update_using_transform(get_edited_property_value());
 }
@@ -2851,6 +2860,15 @@ void EditorPropertyProjection::_value_changed(double val, const String &p_name) 
 	p.columns[3][3] = spin[15]->get_value();
 
 	emit_changed(get_edited_property(), p, p_name);
+}
+
+void EditorPropertyProjection::set_deferred_drag_mode_enabled(bool p_enabled) {
+	EditorProperty::set_deferred_drag_mode_enabled(p_enabled);
+	const int count = sizeof(spin) / sizeof(spin[0]);
+
+	for (int i = 0; i < count; i++) {
+		spin[i]->set_deferred_drag_mode_enabled(p_enabled);
+	}
 }
 
 void EditorPropertyProjection::update_property() {

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -638,6 +638,7 @@ protected:
 	void _notification(int p_what);
 
 public:
+	virtual void set_deferred_drag_mode_enabled(bool p_enabled = true) override;
 	virtual void update_property() override;
 	virtual void update_using_transform(Transform3D p_transform);
 	void setup(const EditorPropertyRangeHint &p_range_hint);
@@ -654,6 +655,7 @@ protected:
 	void _notification(int p_what);
 
 public:
+	virtual void set_deferred_drag_mode_enabled(bool p_enabled = true) override;
 	virtual void update_property() override;
 	virtual void update_using_transform(Projection p_transform);
 	void setup(const EditorPropertyRangeHint &p_range_hint);

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
@@ -5256,6 +5256,7 @@ void VisualShaderEditor::_param_selected() {
 	prop->connect("property_changed", callable_mp(this, &VisualShaderEditor::_param_property_changed));
 	prop->set_h_size_flags(SIZE_EXPAND_FILL);
 	prop->set_object_and_property(preview_material.ptr(), "shader_parameter/" + pi.name);
+	prop->set_deferred_drag_mode_enabled();
 
 	prop->set_label(TTR("Value:"));
 	prop->update_property();

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -287,7 +287,7 @@ double Range::get_page() const {
 	return shared->page;
 }
 
-void Range::set_as_ratio(double p_value) {
+void Range::_set_as_ratio(double p_value, bool p_emit_signal) {
 	double v;
 
 	if (shared->exp_ratio && get_min() >= 0) {
@@ -304,7 +304,19 @@ void Range::set_as_ratio(double p_value) {
 		}
 	}
 	v = CLAMP(v, get_min(), get_max());
-	set_value(v);
+	if (p_emit_signal) {
+		set_value(v);
+	} else {
+		set_value_no_signal(v);
+	}
+}
+
+void Range::set_as_ratio(double p_value) {
+	_set_as_ratio(p_value, true);
+}
+
+void Range::set_as_ratio_no_signal(double p_value) {
+	_set_as_ratio(p_value, false);
 }
 
 double Range::get_as_ratio() const {
@@ -389,6 +401,7 @@ void Range::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_step", "step"), &Range::set_step);
 	ClassDB::bind_method(D_METHOD("set_page", "pagesize"), &Range::set_page);
 	ClassDB::bind_method(D_METHOD("set_as_ratio", "value"), &Range::set_as_ratio);
+	ClassDB::bind_method(D_METHOD("set_as_ratio_no_signal", "value"), &Range::set_as_ratio_no_signal);
 	ClassDB::bind_method(D_METHOD("set_use_rounded_values", "enabled"), &Range::set_use_rounded_values);
 	ClassDB::bind_method(D_METHOD("is_using_rounded_values"), &Range::is_using_rounded_values);
 	ClassDB::bind_method(D_METHOD("set_exp_ratio", "enabled"), &Range::set_exp_ratio);

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -60,6 +60,7 @@ class Range : public Control {
 	void _value_changed_notify();
 	void _changed_notify();
 	void _set_value_no_signal(double p_val);
+	void _set_as_ratio(double p_value, bool p_emit_signal);
 
 protected:
 	static double _snapped_r128(double p_value, double p_step);
@@ -86,6 +87,7 @@ public:
 	void set_step(double p_step);
 	void set_page(double p_page);
 	void set_as_ratio(double p_value);
+	void set_as_ratio_no_signal(double p_value);
 
 	double get_value() const;
 	double get_min() const;


### PR DESCRIPTION
- Fix https://github.com/godotengine/godot/issues/116439

<details>
<summary>Details</summary>

![test3](https://github.com/user-attachments/assets/f98a5bf3-24f7-4e13-bbae-c3db7e2dc247)

</details>

~also fixed the type of Transform parameter (it needs to be a `Transform3D` not a `Projection`).~