### PR TITLE
Add easy conversion facilities between Color and Vector

### DIFF
--- a/core/math/color.h
+++ b/core/math/color.h
@@ -31,6 +31,8 @@
 #pragma once
 
 #include "core/math/math_funcs.h"
+#include "core/math/vector3.h"
+#include "core/math/vector4.h"
 #include "core/templates/hashfuncs.h"
 
 class String;
@@ -64,6 +66,22 @@ struct [[nodiscard]] Color {
 	float get_ok_hsl_l() const;
 	void set_ok_hsl(float p_h, float p_s, float p_l, float p_alpha = 1.0f);
 	void set_ok_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0f);
+
+	constexpr Vector3 get_rgb() const { return Vector3(r, g, b); }
+	constexpr Vector4 get_rgba() const { return Vector4(r, g, b, a); }
+
+	constexpr void set_rgb(const Vector3 &p_rgb) {
+		r = p_rgb.x;
+		g = p_rgb.y;
+		b = p_rgb.z;
+	}
+
+	constexpr void set_rgba(const Vector4 &p_rgba) {
+		r = p_rgba.x;
+		g = p_rgba.y;
+		b = p_rgba.z;
+		a = p_rgba.w;
+	}
 
 	_FORCE_INLINE_ float &operator[](int p_idx) {
 		return components[p_idx];
@@ -269,6 +287,15 @@ struct [[nodiscard]] Color {
 	 */
 	constexpr Color(const Color &p_c, float p_a) :
 			r(p_c.r), g(p_c.g), b(p_c.b), a(p_a) {}
+
+	constexpr Color(const Vector3 &p_rgb) :
+			r(p_rgb.x), g(p_rgb.y), b(p_rgb.z), a(1) {}
+
+	constexpr Color(const Vector3 &p_rgb, float p_a) :
+			r(p_rgb.x), g(p_rgb.y), b(p_rgb.z), a(p_a) {}
+
+	constexpr Color(const Vector4 &p_rgba) :
+			r(p_rgba.x), g(p_rgba.y), b(p_rgba.z), a(p_rgba.w) {}
 
 	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
 	Color(const String &p_code) {

--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -172,6 +172,9 @@ void Variant::_register_variant_constructors() {
 	add_constructor<VariantConstructor<Color, double, double, double, double>>(sarray("r", "g", "b", "a"));
 	add_constructor<VariantConstructor<Color, String>>(sarray("code"));
 	add_constructor<VariantConstructor<Color, String, double>>(sarray("code", "alpha"));
+	add_constructor<VariantConstructor<Color, Vector3>>(sarray("rgb"));
+	add_constructor<VariantConstructor<Color, Vector3, double>>(sarray("rgb", "a"));
+	add_constructor<VariantConstructor<Color, Vector4>>(sarray("rgba"));
 
 	add_constructor<VariantConstructNoArgs<StringName>>(sarray());
 	add_constructor<VariantConstructor<StringName, StringName>>(sarray("from"));

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -134,6 +134,9 @@ void register_named_setters_getters() {
 	REGISTER_MEMBER(Color, b);
 	REGISTER_MEMBER(Color, a);
 
+	REGISTER_MEMBER(Color, rgb);
+	REGISTER_MEMBER(Color, rgba);
+
 	REGISTER_MEMBER(Color, r8);
 	REGISTER_MEMBER(Color, g8);
 	REGISTER_MEMBER(Color, b8);

--- a/core/variant/variant_setget.h
+++ b/core/variant/variant_setget.h
@@ -358,3 +358,6 @@ SETGET_NUMBER_STRUCT_FUNC(Color, double, v, set_v, get_v)
 SETGET_NUMBER_STRUCT_FUNC(Color, double, ok_hsl_h, set_ok_hsl_h, get_ok_hsl_h)
 SETGET_NUMBER_STRUCT_FUNC(Color, double, ok_hsl_s, set_ok_hsl_s, get_ok_hsl_s)
 SETGET_NUMBER_STRUCT_FUNC(Color, double, ok_hsl_l, set_ok_hsl_l, get_ok_hsl_l)
+
+SETGET_STRUCT_FUNC(Color, Vector3, rgb, set_rgb, get_rgb)
+SETGET_STRUCT_FUNC(Color, Vector4, rgba, set_rgba, get_rgba)

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -97,6 +97,25 @@
 				[/codeblocks]
 			</description>
 		</constructor>
+		<constructor name="Color">
+			<return type="Color" />
+			<param index="0" name="rgb" type="Vector3" />
+			<description>
+			</description>
+		</constructor>
+		<constructor name="Color">
+			<return type="Color" />
+			<param index="0" name="rgb" type="Vector3" />
+			<param index="1" name="a" type="float" />
+			<description>
+			</description>
+		</constructor>
+		<constructor name="Color">
+			<return type="Color" />
+			<param index="0" name="rgba" type="Vector4" />
+			<description>
+			</description>
+		</constructor>
 	</constructors>
 	<methods>
 		<method name="blend" qualifiers="const">
@@ -530,6 +549,10 @@
 		</member>
 		<member name="r8" type="int" setter="" getter="" default="0">
 			Wrapper for [member r] that uses the range 0 to 255, instead of 0 to 1.
+		</member>
+		<member name="rgb" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
+		</member>
+		<member name="rgba" type="Vector4" setter="" getter="" default="Vector4(0, 0, 0, 1)">
 		</member>
 		<member name="s" type="float" setter="" getter="" default="0.0">
 			The HSV saturation of this color, on the range 0 to 1.

--- a/tests/core/math/test_color.cpp
+++ b/tests/core/math/test_color.cpp
@@ -33,6 +33,8 @@
 TEST_FORCE_LINK(test_color)
 
 #include "core/math/color.h"
+#include "core/math/vector3.h"
+#include "core/math/vector4.h"
 
 namespace TestColor {
 
@@ -66,6 +68,16 @@ TEST_CASE("[Color] Constructor methods") {
 	CHECK_MESSAGE(
 			green_rgba.is_equal_approx(green_hsva),
 			"Creation with HSV notation should result in components approximately equal to the default constructor.");
+
+	CHECK_MESSAGE(
+			Color(Vector3(0.5f, 0.5f, 1.0f)).get_rgba() == Vector4(0.5f, 0.5f, 1.0f, 1.0f),
+			"Creation with a Vector3 should result in correct RGBA");
+	CHECK_MESSAGE(
+			Color(Vector3(0.5f, 0.5f, 1.0f), 0.75f).get_rgba() == Vector4(0.5f, 0.5f, 1.0f, 0.75f),
+			"Creation with a Vector3 and a float should result in correct RGBA");
+	CHECK_MESSAGE(
+			Color(Vector4(0.5f, 0.5f, 1.0f, 0.5f)).get_rgba() == Vector4(0.5f, 0.5f, 1.0f, 0.5),
+			"Creation with a Vector4 should result in correct RGBA");
 }
 
 TEST_CASE("[Color] Operators") {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/14342

* Add properties `rgb` and `rgba` to `Color`.
* Add constructors to `Color`: from `Vector3`; from `Vector3` and `float`; from `Vector4`.

GDScript test:
```gdscript
assert(Color(Vector3(0.0, 0.25, 0.5)).rgb == Vector3(0.0, 0.25, 0.5))
assert(Color(Vector3(0.0, 0.25, 0.5)).rgba == Vector4(0.0, 0.25, 0.5, 1.0))
assert(Color(Vector3(0.0, 0.25, 0.5), 0.25).rgba == Vector4(0.0, 0.25, 0.5, 0.25))
assert(Color(Vector4(0.0, 0.25, 0.5, 0.75)).rgba == Vector4(0.0, 0.25, 0.5, 0.75))
```