### PR TITLE
Make selecting node in remote expand tree

### DIFF
--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -282,18 +282,12 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 		if (debugger_id == p_debugger) { // Can use remote id.
 			if (inspected_object_ids.has(uint64_t(node.id))) {
 				ids_present.append(node.id);
-
-				if (selection_uncollapse_all) {
-					selection_uncollapse_all = false;
-
+				select_items.push_back(item);
+				if (should_scroll) {
 					// Temporarily set to `false`, to allow caching the unfolds.
 					updating_scene_tree = false;
 					item->uncollapse_tree();
 					updating_scene_tree = true;
-				}
-
-				select_items.push_back(item);
-				if (should_scroll) {
 					scroll_item = item;
 				}
 			}
@@ -415,7 +409,6 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 
 void EditorDebuggerTree::select_nodes(const TypedArray<int64_t> &p_ids) {
 	// Manually select, as the tree control may be out-of-date for some reason (e.g. not shown yet).
-	selection_uncollapse_all = true;
 	inspected_object_ids = p_ids;
 	scrolling_to_item = true;
 

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -65,7 +65,6 @@ private:
 	bool scrolling_to_item = false;
 	bool notify_selection_queued = false;
 	bool selection_surpassed_limit = false;
-	bool selection_uncollapse_all = false;
 	HashSet<ObjectID> unfold_cache;
 	PopupMenu *item_menu = nullptr;
 	EditorFileDialog *file_dialog = nullptr;


### PR DESCRIPTION

Fixes https://github.com/godotengine/godot/issues/116807

Using the same project as the fixed issue above, this is the new behavior:

1. User searches in the remote tree with or without hide filtered out parents enabled
2. Click one of the nodes
3. Remove the filter
4. (With this PR) the selected node is still revealed in the tree, rather than being hidden

https://github.com/user-attachments/assets/9cc0cd8f-ffe8-4e50-a304-fb4f11d681dd

