### PR TITLE
Add support for `--ignore-error-breaks` to `LocalDebugger`

### DIFF
--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -115,6 +115,10 @@ struct LocalDebugger::ScriptsProfiler {
 };
 
 void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
+	if (script_debugger->is_ignoring_error_breaks() && p_is_error_breakpoint) {
+		return;
+	}
+
 	ScriptLanguage *script_lang = script_debugger->get_break_language();
 
 	if (!target_function.is_empty()) {


### PR DESCRIPTION
Fixes #116822.

As mentioned in #116822, the `--ignore-error-breaks` argument that was added in #77015 only did so for `RemoteDebugger` and not `LocalDebugger`, so doesn't work in the context of `--debug`.

This adds it for `LocalDebugger` as well, by basically just copying this from `RemoteDebugger::debug`:

https://github.com/godotengine/godot/blob/5cba18ff3bbe5adc9b4a8d7e970084979014b5f4/core/debugger/remote_debugger.cpp#L404-L406