### PR TITLE
Add anti-aliasing to 3D transform gizmo rotation line

### DIFF
--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -4208,7 +4208,8 @@ void Node3DEditorViewport::_draw() {
 					_edit.mouse_pos,
 					center,
 					handle_color,
-					Math::round(2 * EDSCALE));
+					Math::round(1.5 * EDSCALE),
+					true);
 		}
 	}
 	if (previewing) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
-->

Before:


<img width="865" height="338" alt="image" src="https://github.com/user-attachments/assets/6a9c7dff-e2a9-4a98-ad56-57f387c33595" />



After:


<img width="830" height="337" alt="image" src="https://github.com/user-attachments/assets/5c9e3e0a-b80c-4146-8e25-bddef30e0611" />
