### PR TITLE
Fix AudioSpectrumAnalyzer's Hann Window

### DIFF
--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -47,7 +47,8 @@ static void smbFft(float *fftBuffer, long fftFrameSize, long sign)
 {
 	float wr, wi, arg, *p1, *p2, temp;
 	float tr, ti, ur, ui, *p1r, *p1i, *p2r, *p2i;
-	long i, bitm, j, le, le2, k;
+	long i, bitm, j, le, le2, k, logN;
+	logN = (long)(Math::log((double)fftFrameSize) / Math::log(2.) + .5);
 
 	for (i = 2; i < 2 * fftFrameSize - 2; i += 2) {
 		for (bitm = 2, j = 0; bitm < 2 * fftFrameSize; bitm <<= 1) {
@@ -67,7 +68,7 @@ static void smbFft(float *fftBuffer, long fftFrameSize, long sign)
 			*p2 = temp;
 		}
 	}
-	for (k = 0, le = 2; k < (long)(std::log((double)fftFrameSize) / std::log(2.) + .5); k++) {
+	for (k = 0, le = 2; k < logN; k++) {
 		le <<= 1;
 		le2 = le >> 1;
 		ur = 1.0;
@@ -109,7 +110,7 @@ void AudioEffectSpectrumAnalyzerInstance::process(const AudioFrame *p_src_frames
 	while (p_frame_count) {
 		int to_fill = fft_size * 2 - temporal_fft_pos;
 		to_fill = MIN(to_fill, p_frame_count);
-		const double to_fill_step = Math::TAU / (double)fft_size;
+		const double to_fill_step = Math::TAU / (double)(fft_size * 2);
 
 		float *fftw = temporal_fft.ptrw();
 		for (int i = 0; i < to_fill; i++) { //left and right buffers


### PR DESCRIPTION
fixes #116829

Using my [Spectrum Analyzer previewer](https://github.com/goatchurchprime/godot-demo-projects/tree/gtch/spectrum_analyser/audio/spectrum_analyzer) (also in the MRP in the issue)

Before (with triple peak in Fourier Transform of a pure sine wave input): 
[Screencast From 2026-02-26 22-03-37.webm](https://github.com/user-attachments/assets/1423b2c3-e816-4a37-8d33-f84d38db20f2)

After (now with clean single peak in Fourier Transform domain):
[Screencast From 2026-02-26 22-21-46.webm](https://github.com/user-attachments/assets/73318061-e2ee-4e95-84c1-284f4197e8ed)

The logN variable to avoid repeated calculation of the log function in the for-loop, as was done in the [original implementation](https://blogs.zynaptiq.com/bernsee/dft-a-pied/)
