### PR TITLE
 Allow baking VoxelGI nodes off the main-thread 

### DIFF
--- a/doc/classes/VoxelGI.xml
+++ b/doc/classes/VoxelGI.xml
@@ -47,6 +47,25 @@
 			Number of times to subdivide the grid that the [VoxelGI] operates on. A higher number results in finer detail and thus higher visual quality, while lower numbers result in better performance.
 		</member>
 	</members>
+	<signals>
+		<signal name="bake_begin">
+			<description>
+				Emitted when the node starts baking its [VoxelGIData].
+			</description>
+		</signal>
+		<signal name="bake_end">
+			<description>
+				Emitted when the node fully completed baking its [VoxelGIData].
+			</description>
+		</signal>
+		<signal name="bake_step">
+			<param index="0" name="step" type="int" />
+			<param index="1" name="status" type="String" />
+			<description>
+				Emitted every time the bake process completes a step. The step value starts with [code]0[/code] and ends with [code]999[/code]. The status value is an arbitrary string that describes the current section of the bake process.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 		<constant name="SUBDIV_64" value="0" enum="Subdiv">
 			Use 64 subdivisions. This is the lowest quality setting, but the fastest. Use it if you can, but especially use it on lower-end hardware.

--- a/doc/classes/VoxelGI.xml
+++ b/doc/classes/VoxelGI.xml
@@ -19,10 +19,12 @@
 			<return type="void" />
 			<param index="0" name="from_node" type="Node" default="null" />
 			<param index="1" name="create_visual_debug" type="bool" default="false" />
+			<param index="2" name="threaded" type="bool" default="false" />
 			<description>
 				Bakes the effect from all [GeometryInstance3D]s marked with [constant GeometryInstance3D.GI_MODE_STATIC] and [Light3D]s marked with either [constant Light3D.BAKE_STATIC] or [constant Light3D.BAKE_DYNAMIC]. If [param create_visual_debug] is [code]true[/code], after baking the light, this will generate a [MultiMesh] that has a cube representing each solid cell with each cube colored to the cell's albedo color. This can be used to visualize the [VoxelGI]'s data and debug any issues that may be occurring.
 				[b]Note:[/b] [method bake] works from the editor and in exported projects. This makes it suitable for procedurally generated or user-built levels. Baking a [VoxelGI] node generally takes from 5 to 20 seconds in most scenes. Reducing [member subdiv] can speed up baking.
 				[b]Note:[/b] [GeometryInstance3D]s and [Light3D]s must be fully ready before [method bake] is called. If you are procedurally creating those and some meshes or lights are missing from your baked [VoxelGI], use [code]call_deferred("bake")[/code] instead of calling [method bake] directly.
+				[b]Note:[/b] Setting [param threaded] to [code]true[/code] will bake the node on a sub-thread. This allows baking multiple nodes at the same time.
 			</description>
 		</method>
 		<method name="debug_bake">

--- a/editor/scene/3d/voxel_gi_editor_plugin.cpp
+++ b/editor/scene/3d/voxel_gi_editor_plugin.cpp
@@ -169,6 +169,14 @@ void VoxelGIEditorPlugin::bake_func_end() {
 void VoxelGIEditorPlugin::_voxel_gi_save_path_and_bake(const String &p_path) {
 	probe_file->hide();
 	if (voxel_gi) {
+		Callable bake_func_begin = callable_mp_static(VoxelGIEditorPlugin::bake_func_begin);
+		Callable bake_func_step = callable_mp_static(VoxelGIEditorPlugin::bake_func_step);
+		Callable bake_func_end = callable_mp_static(VoxelGIEditorPlugin::bake_func_end);
+
+		voxel_gi->connect("bake_begin", bake_func_begin);
+		voxel_gi->connect("bake_step", bake_func_step);
+		voxel_gi->connect("bake_end", bake_func_end);
+
 		voxel_gi->bake();
 		// Ensure the VoxelGIData is always saved to an external resource.
 		// This avoids bloating the scene file with large binary data,
@@ -177,6 +185,10 @@ void VoxelGIEditorPlugin::_voxel_gi_save_path_and_bake(const String &p_path) {
 		ERR_FAIL_COND(voxel_gi_data.is_null());
 		voxel_gi_data->set_path(p_path);
 		ResourceSaver::save(voxel_gi_data, p_path, ResourceSaver::FLAG_CHANGE_PATH);
+
+		voxel_gi->disconnect("bake_begin", bake_func_begin);
+		voxel_gi->disconnect("bake_step", bake_func_step);
+		voxel_gi->disconnect("bake_end", bake_func_end);
 	}
 }
 
@@ -201,8 +213,4 @@ VoxelGIEditorPlugin::VoxelGIEditorPlugin() {
 	probe_file->connect("file_selected", callable_mp(this, &VoxelGIEditorPlugin::_voxel_gi_save_path_and_bake));
 	EditorInterface::get_singleton()->get_base_control()->add_child(probe_file);
 	probe_file->set_title(TTR("Select path for VoxelGI Data File"));
-
-	VoxelGI::bake_begin_function = bake_func_begin;
-	VoxelGI::bake_step_function = bake_func_step;
-	VoxelGI::bake_end_function = bake_func_end;
 }

--- a/misc/extension_api_validation/4.7-stable/GH-116833.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-116833.txt
@@ -1,0 +1,6 @@
+GH-116833
+---------
+Validate extension JSON: Error: Field 'classes/VoxelGI/methods/bake/arguments': size changed value in new API, from 2 to 3.
+
+Added optional "threaded" argument to bake method in VoxelGI class.
+Compatibility method registered.

--- a/scene/3d/voxel_gi.compat.inc
+++ b/scene/3d/voxel_gi.compat.inc
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  voxel_gi.compat.inc                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "voxel_gi.h"
+
+#include "core/object/class_db.h"
+
+void VoxelGI::_bake_bind_compat_116833(Node *p_from_node, bool p_create_visual_debug) {
+	return bake(p_from_node, p_create_visual_debug, false);
+}
+
+void VoxelGI::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("bake", "from_node", "create_visual_debug"), &VoxelGI::_bake_bind_compat_116833, DEFVAL(Variant()), DEFVAL(false));
+}
+
+#endif // DISABLE_DEPRECATED

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -31,6 +31,7 @@
 #include "voxel_gi.h"
 
 #include "core/config/project_settings.h"
+#include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "scene/3d/mesh_instance_3d.h"
@@ -390,19 +391,27 @@ void VoxelGI::_find_meshes(Node *p_at_node, List<PlotMesh> &plot_meshes) {
 	}
 }
 
-VoxelGI::BakeBeginFunc VoxelGI::bake_begin_function = nullptr;
-VoxelGI::BakeStepFunc VoxelGI::bake_step_function = nullptr;
-VoxelGI::BakeEndFunc VoxelGI::bake_end_function = nullptr;
+void VoxelGI::bake_begin() {
+	emit_signal(VoxelGI::bake_begin_name);
+}
+
+bool VoxelGI::bake_step(int p_step, const String &p_status) {
+	return emit_signal(VoxelGI::bake_step_name, p_step, p_status);
+}
+
+void VoxelGI::bake_end() {
+	emit_signal(VoxelGI::bake_end_name);
+}
 
 static int voxelizer_plot_bake_base = 0;
 static int voxelizer_plot_bake_total = 0;
 
-static bool voxelizer_plot_bake_step_function(int current, int) {
-	return VoxelGI::bake_step_function((voxelizer_plot_bake_base + current) * 500 / voxelizer_plot_bake_total, RTR("Plotting Meshes"));
+bool VoxelGI::_voxelizer_plot_bake_step_function(int p_current, int p_total) {
+	return bake_step((voxelizer_plot_bake_base + p_current) * 500 / voxelizer_plot_bake_total, RTR("Plotting Meshes"));
 }
 
-static bool voxelizer_sdf_bake_step_function(int current, int total) {
-	return VoxelGI::bake_step_function(500 + current * 500 / total, RTR("Generating Distance Field"));
+bool VoxelGI::_voxelizer_sdf_bake_step_function(int p_current, int p_total) {
+	return bake_step(500 + p_current * 500 / p_total, RTR("Generating Distance Field"));
 }
 
 Vector3i VoxelGI::get_estimated_cell_size() const {
@@ -447,11 +456,9 @@ void VoxelGI::bake(Node *p_from_node, bool p_create_visual_debug) {
 
 	_find_meshes(p_from_node, mesh_list);
 
-	if (bake_begin_function) {
-		bake_begin_function();
-	}
+	bake_begin();
 
-	Voxelizer::BakeStepFunc voxelizer_step_func = bake_step_function != nullptr ? voxelizer_plot_bake_step_function : nullptr;
+	Callable voxelizer_step_func = callable_mp(this, &VoxelGI::_voxelizer_plot_bake_step_function);
 
 	voxelizer_plot_bake_total = voxelizer_plot_bake_base = 0;
 	for (PlotMesh &E : mesh_list) {
@@ -460,16 +467,13 @@ void VoxelGI::bake(Node *p_from_node, bool p_create_visual_debug) {
 	for (PlotMesh &E : mesh_list) {
 		if (baker.plot_mesh(E.local_xform, E.mesh, E.instance_materials, E.override_material, voxelizer_step_func) != Voxelizer::BAKE_RESULT_OK) {
 			baker.end_bake();
-			if (bake_end_function) {
-				bake_end_function();
-			}
+			bake_end();
 			return;
 		}
 		voxelizer_plot_bake_base += baker.get_bake_steps(E.mesh);
 	}
-	if (bake_step_function) {
-		bake_step_function(500, RTR("Finishing Plot"));
-	}
+
+	bake_step(500, RTR("Finishing Plot"));
 
 	baker.end_bake();
 
@@ -496,14 +500,12 @@ void VoxelGI::bake(Node *p_from_node, bool p_create_visual_debug) {
 			probe_data_new.instantiate();
 		}
 
-		if (bake_step_function) {
-			bake_step_function(500, RTR("Generating Distance Field"));
-		}
+		bake_step(500, RTR("Generating Distance Field"));
 
-		voxelizer_step_func = bake_step_function != nullptr ? voxelizer_sdf_bake_step_function : nullptr;
+		Callable voxelizer_sdf_step_func = callable_mp(this, &VoxelGI::_voxelizer_sdf_bake_step_function);
 
 		Vector<uint8_t> df;
-		if (baker.get_sdf_3d_image(df, voxelizer_step_func) == Voxelizer::BAKE_RESULT_OK) {
+		if (baker.get_sdf_3d_image(df, voxelizer_sdf_step_func) == Voxelizer::BAKE_RESULT_OK) {
 			RS::get_singleton()->voxel_gi_set_baked_exposure_normalization(probe_data_new->get_rid(), exposure_normalization);
 
 			probe_data_new->allocate(baker.get_to_cell_space_xform(), AABB(-size / 2, size), baker.get_voxel_gi_octree_size(), baker.get_voxel_gi_octree_cells(), baker.get_voxel_gi_data_cells(), df, baker.get_voxel_gi_level_cell_count());
@@ -515,9 +517,7 @@ void VoxelGI::bake(Node *p_from_node, bool p_create_visual_debug) {
 		}
 	}
 
-	if (bake_end_function) {
-		bake_end_function();
-	}
+	bake_end();
 
 	notify_property_list_changed(); //bake property may have changed
 }
@@ -581,6 +581,10 @@ void VoxelGI::_bind_methods() {
 	BIND_ENUM_CONSTANT(SUBDIV_256);
 	BIND_ENUM_CONSTANT(SUBDIV_512);
 	BIND_ENUM_CONSTANT(SUBDIV_MAX);
+
+	ADD_SIGNAL(MethodInfo("bake_begin"));
+	ADD_SIGNAL(MethodInfo("bake_step", PropertyInfo(Variant::INT, "step"), PropertyInfo(Variant::STRING, "status")));
+	ADD_SIGNAL(MethodInfo("bake_end"));
 }
 
 VoxelGI::VoxelGI() {

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -29,10 +29,12 @@
 /**************************************************************************/
 
 #include "voxel_gi.h"
+#include "voxel_gi.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/object/worker_thread_pool.h"
 #include "core/os/os.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/multimesh_instance_3d.h"
@@ -280,7 +282,11 @@ void VoxelGI::set_probe_data(const Ref<VoxelGIData> &p_data) {
 	}
 
 	probe_data = p_data;
-	update_configuration_warnings();
+	if (Thread::is_main_thread()) {
+		update_configuration_warnings();
+	} else {
+		callable_mp((Node *)this, &Node::update_configuration_warnings).call_deferred();
+	}
 }
 
 Ref<VoxelGIData> VoxelGI::get_probe_data() const {
@@ -396,15 +402,23 @@ void VoxelGI::bake_begin() {
 }
 
 bool VoxelGI::bake_step(int p_step, const String &p_status) {
-	return emit_signal(VoxelGI::bake_step_name, p_step, p_status);
+	if (Thread::is_main_thread()) {
+		return emit_signal(VoxelGI::bake_step_name, p_step, p_status);
+	} else {
+		call_deferred("emit_signal", VoxelGI::bake_step_name, p_step, p_status);
+		return false;
+	}
 }
 
 void VoxelGI::bake_end() {
-	emit_signal(VoxelGI::bake_end_name);
+	if (Thread::is_main_thread()) {
+		emit_signal(VoxelGI::bake_end_name);
+		notify_property_list_changed(); // bake property may have changed
+	} else {
+		call_deferred("emit_signal", VoxelGI::bake_end_name);
+		callable_mp((Object *)this, &Object::notify_property_list_changed).call_deferred(); // Bake property may have changed.
+	}
 }
-
-static int voxelizer_plot_bake_base = 0;
-static int voxelizer_plot_bake_total = 0;
 
 bool VoxelGI::_voxelizer_plot_bake_step_function(int p_current, int p_total) {
 	return bake_step((voxelizer_plot_bake_base + p_current) * 500 / voxelizer_plot_bake_total, RTR("Plotting Meshes"));
@@ -440,7 +454,9 @@ Vector3i VoxelGI::get_estimated_cell_size() const {
 	return Vector3i(axis_cell_size[0], axis_cell_size[1], axis_cell_size[2]);
 }
 
-void VoxelGI::bake(Node *p_from_node, bool p_create_visual_debug) {
+void VoxelGI::bake(Node *p_from_node, bool p_create_visual_debug, bool p_threaded) {
+	bake_mutex.lock();
+
 	static const int subdiv_value[SUBDIV_MAX] = { 6, 7, 8, 9 };
 
 	p_from_node = p_from_node ? p_from_node : get_parent();
@@ -458,68 +474,17 @@ void VoxelGI::bake(Node *p_from_node, bool p_create_visual_debug) {
 
 	bake_begin();
 
-	Callable voxelizer_step_func = callable_mp(this, &VoxelGI::_voxelizer_plot_bake_step_function);
+	bake_data.baker = baker;
+	bake_data.create_visual_debug = p_create_visual_debug;
+	bake_data.exposure_normalization = exposure_normalization;
+	bake_data.mesh_list = mesh_list;
+	bake_data.node = this;
 
-	voxelizer_plot_bake_total = voxelizer_plot_bake_base = 0;
-	for (PlotMesh &E : mesh_list) {
-		voxelizer_plot_bake_total += baker.get_bake_steps(E.mesh);
-	}
-	for (PlotMesh &E : mesh_list) {
-		if (baker.plot_mesh(E.local_xform, E.mesh, E.instance_materials, E.override_material, voxelizer_step_func) != Voxelizer::BAKE_RESULT_OK) {
-			baker.end_bake();
-			bake_end();
-			return;
-		}
-		voxelizer_plot_bake_base += baker.get_bake_steps(E.mesh);
-	}
-
-	bake_step(500, RTR("Finishing Plot"));
-
-	baker.end_bake();
-
-	//create the data for rendering server
-
-	if (p_create_visual_debug) {
-		MultiMeshInstance3D *mmi = memnew(MultiMeshInstance3D);
-		mmi->set_multimesh(baker.create_debug_multimesh());
-		add_child(mmi, true);
-#ifdef TOOLS_ENABLED
-		if (is_inside_tree() && get_tree()->get_edited_scene_root() == this) {
-			mmi->set_owner(this);
-		} else {
-			mmi->set_owner(get_owner());
-		}
-#else
-		mmi->set_owner(get_owner());
-#endif
-
+	if (p_threaded) {
+		WorkerThreadPool::get_singleton()->add_native_task(bake_task, &bake_data);
 	} else {
-		Ref<VoxelGIData> probe_data_new = get_probe_data();
-
-		if (probe_data_new.is_null()) {
-			probe_data_new.instantiate();
-		}
-
-		bake_step(500, RTR("Generating Distance Field"));
-
-		Callable voxelizer_sdf_step_func = callable_mp(this, &VoxelGI::_voxelizer_sdf_bake_step_function);
-
-		Vector<uint8_t> df;
-		if (baker.get_sdf_3d_image(df, voxelizer_sdf_step_func) == Voxelizer::BAKE_RESULT_OK) {
-			RS::get_singleton()->voxel_gi_set_baked_exposure_normalization(probe_data_new->get_rid(), exposure_normalization);
-
-			probe_data_new->allocate(baker.get_to_cell_space_xform(), AABB(-size / 2, size), baker.get_voxel_gi_octree_size(), baker.get_voxel_gi_octree_cells(), baker.get_voxel_gi_data_cells(), df, baker.get_voxel_gi_level_cell_count());
-
-			set_probe_data(probe_data_new);
-#ifdef TOOLS_ENABLED
-			probe_data_new->set_edited(true); //so it gets saved
-#endif
-		}
+		bake_task(&bake_data);
 	}
-
-	bake_end();
-
-	notify_property_list_changed(); //bake property may have changed
 }
 
 void VoxelGI::_debug_bake() {
@@ -567,7 +532,7 @@ void VoxelGI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_camera_attributes", "camera_attributes"), &VoxelGI::set_camera_attributes);
 	ClassDB::bind_method(D_METHOD("get_camera_attributes"), &VoxelGI::get_camera_attributes);
 
-	ClassDB::bind_method(D_METHOD("bake", "from_node", "create_visual_debug"), &VoxelGI::bake, DEFVAL(Variant()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("bake", "from_node", "create_visual_debug", "threaded"), &VoxelGI::bake, DEFVAL(Variant()), DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("debug_bake"), &VoxelGI::_debug_bake);
 	ClassDB::set_method_flags(get_class_static(), StringName("debug_bake"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 
@@ -595,4 +560,72 @@ VoxelGI::VoxelGI() {
 VoxelGI::~VoxelGI() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free_rid(voxel_gi);
+}
+
+void VoxelGI::bake_task(void *p_user_data) {
+	BakeData *bake_data = static_cast<BakeData *>(p_user_data);
+	VoxelGI *node = bake_data->node;
+	Vector3 size = node->size;
+
+	Callable voxelizer_step_func = callable_mp(node, &VoxelGI::_voxelizer_plot_bake_step_function);
+
+	node->voxelizer_plot_bake_total = node->voxelizer_plot_bake_base = 0;
+	for (PlotMesh &E : bake_data->mesh_list) {
+		node->voxelizer_plot_bake_total += bake_data->baker.get_bake_steps(E.mesh);
+	}
+	for (PlotMesh &E : bake_data->mesh_list) {
+		if (bake_data->baker.plot_mesh(E.local_xform, E.mesh, E.instance_materials, E.override_material, voxelizer_step_func) != Voxelizer::BAKE_RESULT_OK) {
+			bake_data->baker.end_bake();
+			node->bake_end();
+			return;
+		}
+		node->voxelizer_plot_bake_base += bake_data->baker.get_bake_steps(E.mesh);
+	}
+
+	node->bake_step(500, RTR("Finishing Plot"));
+
+	bake_data->baker.end_bake();
+
+	// Create the data for rendering server
+
+	if (bake_data->create_visual_debug) {
+		MultiMeshInstance3D *mmi = memnew(MultiMeshInstance3D);
+		mmi->set_multimesh(bake_data->baker.create_debug_multimesh());
+		bake_data->node->add_child(mmi, true);
+#ifdef TOOLS_ENABLED
+		if (bake_data->node->is_inside_tree() && node->get_tree()->get_edited_scene_root() == bake_data->node) {
+			mmi->set_owner(node);
+		} else {
+			mmi->set_owner(node->get_owner());
+		}
+#else
+		mmi->set_owner(node->get_owner());
+#endif
+
+	} else {
+		Ref<VoxelGIData> probe_data_new = bake_data->node->get_probe_data();
+
+		if (probe_data_new.is_null()) {
+			probe_data_new.instantiate();
+		}
+
+		bake_data->node->bake_step(500, RTR("Generating Distance Field"));
+
+		Callable voxelizer_sdf_step_func = callable_mp(node, &VoxelGI::_voxelizer_sdf_bake_step_function);
+
+		Vector<uint8_t> df;
+		if (bake_data->baker.get_sdf_3d_image(df, voxelizer_sdf_step_func) == Voxelizer::BAKE_RESULT_OK) {
+			RS::get_singleton()->voxel_gi_set_baked_exposure_normalization(probe_data_new->get_rid(), bake_data->exposure_normalization);
+
+			probe_data_new->allocate(bake_data->baker.get_to_cell_space_xform(), AABB(-size / 2, size), bake_data->baker.get_voxel_gi_octree_size(), bake_data->baker.get_voxel_gi_octree_cells(), bake_data->baker.get_voxel_gi_data_cells(), df, bake_data->baker.get_voxel_gi_level_cell_count());
+
+			bake_data->node->set_probe_data(probe_data_new);
+#ifdef TOOLS_ENABLED
+			probe_data_new->set_edited(true); //so it gets saved
+#endif
+		}
+	}
+
+	node->bake_end();
+	node->bake_mutex.unlock();
 }

--- a/scene/3d/voxel_gi.h
+++ b/scene/3d/voxel_gi.h
@@ -108,10 +108,6 @@ public:
 
 	};
 
-	typedef void (*BakeBeginFunc)();
-	typedef bool (*BakeStepFunc)(int, const String &);
-	typedef void (*BakeEndFunc)();
-
 private:
 	Ref<VoxelGIData> probe_data;
 
@@ -120,6 +116,10 @@ private:
 	Subdiv subdiv = SUBDIV_128;
 	Vector3 size = Vector3(20, 20, 20);
 	Ref<CameraAttributes> camera_attributes;
+
+	StringName bake_begin_name = "bake_begin";
+	StringName bake_step_name = "bake_step";
+	StringName bake_end_name = "bake_end";
 
 	struct PlotMesh {
 		Ref<Material> override_material;
@@ -130,8 +130,14 @@ private:
 
 	void _find_meshes(Node *p_at_node, List<PlotMesh> &plot_meshes);
 	void _debug_bake();
+	bool _voxelizer_plot_bake_step_function(int p_current, int p_total);
+	bool _voxelizer_sdf_bake_step_function(int p_current, int p_total);
 
 	float _get_camera_exposure_normalization();
+
+	void bake_begin();
+	bool bake_step(int p_step, const String &p_status);
+	void bake_end();
 
 protected:
 	static void _bind_methods();
@@ -141,10 +147,6 @@ protected:
 #endif // DISABLE_DEPRECATED
 
 public:
-	static BakeBeginFunc bake_begin_function;
-	static BakeStepFunc bake_step_function;
-	static BakeEndFunc bake_end_function;
-
 	void set_probe_data(const Ref<VoxelGIData> &p_data);
 	Ref<VoxelGIData> get_probe_data() const;
 

--- a/scene/3d/voxel_gi.h
+++ b/scene/3d/voxel_gi.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/3d/visual_instance_3d.h"
+#include "scene/3d/voxelizer.h"
 
 class CameraAttributes;
 class Mesh;
@@ -116,6 +117,7 @@ private:
 	Subdiv subdiv = SUBDIV_128;
 	Vector3 size = Vector3(20, 20, 20);
 	Ref<CameraAttributes> camera_attributes;
+	Mutex bake_mutex;
 
 	StringName bake_begin_name = "bake_begin";
 	StringName bake_step_name = "bake_step";
@@ -128,6 +130,18 @@ private:
 		Transform3D local_xform;
 	};
 
+	struct BakeData {
+		VoxelGI *node;
+		Voxelizer baker;
+		List<PlotMesh> mesh_list;
+		bool create_visual_debug;
+		float exposure_normalization;
+	};
+
+	BakeData bake_data;
+	int voxelizer_plot_bake_base = 0;
+	int voxelizer_plot_bake_total = 0;
+
 	void _find_meshes(Node *p_at_node, List<PlotMesh> &plot_meshes);
 	void _debug_bake();
 	bool _voxelizer_plot_bake_step_function(int p_current, int p_total);
@@ -139,11 +153,15 @@ private:
 	bool bake_step(int p_step, const String &p_status);
 	void bake_end();
 
+	static void bake_task(void *p_user_data);
+
 protected:
 	static void _bind_methods();
 #ifndef DISABLE_DEPRECATED
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_property) const;
+	void _bake_bind_compat_116833(Node *p_from_node = nullptr, bool p_create_visual_debug = false);
+	static void _bind_compatibility_methods();
 #endif // DISABLE_DEPRECATED
 
 public:
@@ -161,7 +179,7 @@ public:
 
 	Vector3i get_estimated_cell_size() const;
 
-	void bake(Node *p_from_node = nullptr, bool p_create_visual_debug = false);
+	void bake(Node *p_from_node = nullptr, bool p_create_visual_debug = false, bool p_threaded = false);
 
 	virtual AABB get_aabb() const override;
 

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -405,7 +405,7 @@ int Voxelizer::get_bake_steps(Ref<Mesh> &p_mesh) const {
 	return bake_total;
 }
 
-Voxelizer::BakeResult Voxelizer::plot_mesh(const Transform3D &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_override_material, BakeStepFunc p_bake_step_func) {
+Voxelizer::BakeResult Voxelizer::plot_mesh(const Transform3D &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_override_material, Callable p_bake_step_func) {
 	ERR_FAIL_COND_V_MSG(!p_xform.is_finite(), BAKE_RESULT_INVALID_PARAMETER, "Invalid mesh bake transform.");
 
 	// Precalculate for transforming vertex normals
@@ -457,8 +457,8 @@ Voxelizer::BakeResult Voxelizer::plot_mesh(const Transform3D &p_xform, Ref<Mesh>
 				Vector3 normal[3];
 
 				bake_current++;
-				if (p_bake_step_func != nullptr && (bake_current & 2047) == 1) {
-					if (p_bake_step_func(bake_current, bake_total)) {
+				if (p_bake_step_func.is_valid() && (bake_current & 2047) == 1) {
+					if (p_bake_step_func.call(bake_current, bake_total).booleanize()) {
 						return BAKE_RESULT_CANCELLED;
 					}
 				}
@@ -496,8 +496,8 @@ Voxelizer::BakeResult Voxelizer::plot_mesh(const Transform3D &p_xform, Ref<Mesh>
 				Vector3 normal[3];
 
 				bake_current++;
-				if (p_bake_step_func != nullptr && (bake_current & 2047) == 1) {
-					if (p_bake_step_func(bake_current, bake_total)) {
+				if (p_bake_step_func.is_valid() && (bake_current & 2047) == 1) {
+					if (p_bake_step_func.call(bake_current, bake_total).booleanize()) {
 						return BAKE_RESULT_CANCELLED;
 					}
 				}
@@ -865,7 +865,7 @@ static void edt(float *f, int stride, int n) {
 
 #undef square
 
-Voxelizer::BakeResult Voxelizer::get_sdf_3d_image(Vector<uint8_t> &r_image, BakeStepFunc p_bake_step_function) const {
+Voxelizer::BakeResult Voxelizer::get_sdf_3d_image(Vector<uint8_t> &r_image, Callable p_bake_step_function) const {
 	Vector3i octree_size = get_voxel_gi_octree_size();
 
 	uint32_t float_count = octree_size.x * octree_size.y * octree_size.z;
@@ -898,8 +898,8 @@ Voxelizer::BakeResult Voxelizer::get_sdf_3d_image(Vector<uint8_t> &r_image, Bake
 	//xy->z
 
 	for (int i = 0; i < octree_size.x; i++, bake_current++) {
-		if (p_bake_step_function) {
-			if (p_bake_step_function(bake_current, bake_total)) {
+		if (p_bake_step_function.is_valid()) {
+			if (p_bake_step_function.call(bake_current, bake_total).booleanize()) {
 				memdelete_arr(work_memory);
 				return BAKE_RESULT_CANCELLED;
 			}
@@ -912,8 +912,8 @@ Voxelizer::BakeResult Voxelizer::get_sdf_3d_image(Vector<uint8_t> &r_image, Bake
 	//xz->y
 
 	for (int i = 0; i < octree_size.x; i++, bake_current++) {
-		if (p_bake_step_function) {
-			if (p_bake_step_function(bake_current, bake_total)) {
+		if (p_bake_step_function.is_valid()) {
+			if (p_bake_step_function.call(bake_current, bake_total).booleanize()) {
 				memdelete_arr(work_memory);
 				return BAKE_RESULT_CANCELLED;
 			}
@@ -925,8 +925,8 @@ Voxelizer::BakeResult Voxelizer::get_sdf_3d_image(Vector<uint8_t> &r_image, Bake
 
 	//yz->x
 	for (int i = 0; i < octree_size.y; i++, bake_current++) {
-		if (p_bake_step_function) {
-			if (p_bake_step_function(bake_current, bake_total)) {
+		if (p_bake_step_function.is_valid()) {
+			if (p_bake_step_function.call(bake_current, bake_total).booleanize()) {
 				memdelete_arr(work_memory);
 				return BAKE_RESULT_CANCELLED;
 			}

--- a/scene/3d/voxelizer.h
+++ b/scene/3d/voxelizer.h
@@ -122,7 +122,7 @@ private:
 public:
 	void begin_bake(int p_subdiv, const AABB &p_bounds, float p_exposure_normalization);
 	int get_bake_steps(Ref<Mesh> &p_mesh) const;
-	BakeResult plot_mesh(const Transform3D &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_override_material, BakeStepFunc p_bake_step_function);
+	BakeResult plot_mesh(const Transform3D &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_override_material, Callable p_bake_step_function);
 	void end_bake();
 
 	int get_voxel_gi_octree_depth() const;
@@ -131,7 +131,7 @@ public:
 	Vector<uint8_t> get_voxel_gi_octree_cells() const;
 	Vector<uint8_t> get_voxel_gi_data_cells() const;
 	Vector<int> get_voxel_gi_level_cell_count() const;
-	BakeResult get_sdf_3d_image(Vector<uint8_t> &r_image, BakeStepFunc p_bake_step_function) const;
+	BakeResult get_sdf_3d_image(Vector<uint8_t> &r_image, Callable p_bake_step_function) const;
 
 	Ref<MultiMesh> create_debug_multimesh();
 


### PR DESCRIPTION
Implementation of Proposal https://github.com/godotengine/godot-proposals/issues/14243.

`VoxelGI::bake` runs on and blocks the main thread. This makes it impossible to bake nodes without a visible freeze. It is also impossible to bake multiple nodes in parallel. Most modern machines should be capable of baking more than one `VoxelGI` node at the same time, which will considerably reduce bake times when doing so at runtime / in-game.

---

Comparison between sequential baking and parallel baking:

Example project: [Sequential Baking of `VoxelGI` nodes](https://github.com/user-attachments/files/25590176/voxel-gi-test-seq.zip)

> VoxelGI baking took 205532 milliseconds

Example project: [Parallel Baking of `VoxelGI` Nodes](https://github.com/user-attachments/files/25590190/voxel-gi-test-par.zip)
> VoxelGI baking took 3137 milliseconds

When baking more than one VoxelGI node, doing it in parallel is significantly faster. My test with the two example projects was done on an MacBook M1 Pro.

---

**This PR relies on the changes from #116600 and contains the commit from the other PR.**

- *Bugsquad edit:* This PR closes https://github.com/godotengine/godot-proposals/issues/14243