### PR TITLE
Fix Errors and tab swapping when changing docks

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -327,7 +327,7 @@ void EditorDockManager::_move_dock(EditorDock *p_dock, Control *p_target, int p_
 				p_dock->previous_tab_index = parent_tabs->get_tab_idx_from_control(p_dock);
 
 				// Swap to previous tab when closing current tab.
-				if (parent_tabs->get_current_tab() == p_dock->previous_tab_index) {
+				if (parent_tabs->get_current_tab() == p_dock->previous_tab_index && parent_tabs->get_previous_tab() != -1) {
 					parent_tabs->set_current_tab(parent_tabs->get_previous_tab());
 				}
 			}
@@ -529,7 +529,7 @@ void EditorDockManager::load_docks_from_config(Ref<ConfigFile> p_layout, const S
 					_move_dock(dock, closed_dock_parent);
 				} else {
 					dock->is_open = true;
-					_move_dock(dock, dock_slots[i], 0);
+					_move_dock(dock, dock_slots[i], 0, false);
 				}
 			}
 			dock->load_layout_from_config(p_layout, section_name);
@@ -541,7 +541,7 @@ void EditorDockManager::load_docks_from_config(Ref<ConfigFile> p_layout, const S
 
 	// Set the selected tabs.
 	for (int i = 0; i < EditorDock::DOCK_SLOT_MAX; i++) {
-		int selected_tab_idx = p_layout->get_value(p_section, DockTabContainer::get_config_key(i) + "_selected_tab_idx", -1);
+		int selected_tab_idx = p_layout->get_value(p_section, DockTabContainer::get_config_key(i) + "_selected_tab_idx", 0);
 		dock_slots[i]->load_selected_tab(selected_tab_idx);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/pull/115932#discussion_r2855280080 and https://github.com/godotengine/godot/pull/115932#discussion_r2855439891

I added a `-1` check for the first comment, and for the second one, I realized that `load_docks_from_config` was incorrectly setting every dock to current (thus showing them and immediately hiding them), which caused the second comment, so now none of the docks are set to current, and the tab_index is set outside the loop on line 545.