### PR TITLE
Fix Dictionary editor losing selection when changing types in Remote inspector

### DIFF
--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -1487,7 +1487,7 @@ void EditorPropertyDictionary::update_property() {
 
 			// We need to grab the focus of the property that is being changed, even if the type didn't actually changed.
 			// Otherwise, focus will stay on the change type button, which is not very user friendly.
-			if (changing_type_index == slot.index) {
+			if (changing_type_index == slot.index && (!change_type || !change_type->is_visible())) {
 				callable_mp(slot.prop, &EditorProperty::grab_focus).call_deferred(0);
 				changing_type_index = EditorPropertyDictionaryObject::NOT_CHANGING_TYPE; // Reset to avoid grabbing focus again.
 			}


### PR DESCRIPTION
Fixes #116748

**Description:**
In the Remote inspector, the `EditorPropertyDictionary` continuously polls and calls `update_property()` to sync with the running game state. 

If a user attempts to change the type of a dictionary key or value using the `EditorVariantTypePopupMenu` (the pencil icon), the asynchronous polling loop evaluates the `changing_type_index == slot.index` condition. Prior to this fix, the poll would prematurely reset `changing_type_index` to `EditorPropertyDictionaryObject::NOT_CHANGING_TYPE` and steal focus while the popup menu was still actively open. 

When the user finally made a selection, the callback would fire against a cleared index, throwing the error: `Tried to change the type of a dict key or value, but nothing was selected.`

**The Fix:**
Added a visibility state guard (`&& (!change_type || !change_type->is_visible())`) to the focus-grabbing and state-reset block at the end of `update_property()`. This prevents the polling loop from resetting the target index while the type-selection popup is actively open, safely preserving the state until the user completes their selection and the menu closes.

**Testing:**
- Verified on `master` that changing dictionary key/value types via the pencil icon in the Remote inspector no longer throws an error and successfully applies the newly selected type.
- Verified that local inspector behavior remains unaffected and correctly grabs focus after a type change.