### PR TITLE
Fix `reload_scene_from_path` may crash

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1330,16 +1330,20 @@ void EditorSelection::_update_node_list() {
 	node_list_changed = false;
 }
 
-void EditorSelection::update() {
+void EditorSelection::update(bool p_deferred) {
 	_update_node_list();
 
 	if (!changed) {
 		return;
 	}
 	changed = false;
-	if (!emitted) {
-		emitted = true;
-		callable_mp(this, &EditorSelection::_emit_change).call_deferred();
+	if (p_deferred) {
+		if (!emitted) {
+			emitted = true;
+			callable_mp(this, &EditorSelection::_emit_change).call_deferred();
+		}
+	} else {
+		_emit_change();
 	}
 }
 

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -318,7 +318,7 @@ public:
 	// Adds an editor plugin which can provide metadata for selected nodes.
 	void add_editor_plugin(Object *p_object);
 
-	void update();
+	void update(bool p_deferred = true);
 	void clear();
 
 	// Returns only the top level selected nodes.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4476,7 +4476,8 @@ bool EditorNode::is_addon_plugin_enabled(const String &p_addon) const {
 void EditorNode::_remove_edited_scene(bool p_change_tab) {
 	// When scene gets closed no node is edited anymore, so make sure the editors are notified before nodes are freed.
 	hide_unused_editors(SceneTreeDock::get_singleton());
-	SceneTreeDock::get_singleton()->clear_previous_node_selection();
+	editor_selection->clear();
+	editor_selection->update(false);
 
 	int new_index = editor_data.get_edited_scene();
 	int old_index = new_index;

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -1465,11 +1465,10 @@ void SceneTreeEditor::set_selected(Node *p_node, bool p_emit_selected) {
 	if (selected == p_node) {
 		return;
 	}
+	selected = p_node;
 
 	TreeItem *item = p_node ? _find(tree->get_root(), p_node->get_path()) : nullptr;
-
 	if (item) {
-		selected = p_node;
 		if (auto_expand_selected) {
 			// Make visible when it's collapsed.
 			TreeItem *node = item->get_parent();
@@ -1498,11 +1497,6 @@ void SceneTreeEditor::set_selected(Node *p_node, bool p_emit_selected) {
 				tree->ensure_cursor_is_visible();
 			}
 		}
-	} else {
-		if (!p_node) {
-			selected = nullptr;
-		}
-		selected = p_node;
 	}
 
 	if (p_emit_selected) {


### PR DESCRIPTION
Fixes #116788, also removes a bit of redundant code.

- The crash is caused by accessing a dangling pointer (`selected_node`)
https://github.com/godotengine/godot/blob/15a4311583fbaad2eee5d2ecda5437eb9fd68c63/editor/editor_node.cpp#L4560-L4564
- It is dangling, because `reload_scene_from_path()` removes and frees the old scene without directly calling the `set_selected` counterpart. `set_selected` is called in a lot of places, so I'm not sure exactly when it's properly updated, but `EditorSelection::_emit_change()` seems like the main driver. Anyway, it's not called at the proper time.
https://github.com/godotengine/godot/blob/15a4311583fbaad2eee5d2ecda5437eb9fd68c63/editor/editor_node.cpp#L7019-L7021
- It also has a chance of not crashing, because immediately afterwards the same scene is loaded back, sometimes reusing the same memory. As a result `selected_node` may points to some valid instance, just not the intended one.


<details>
<summary>Backtrace</summary>

The top few frames may vary because invalid memory address is involved
```
================================================================
CrashHandlerException: Program crashed
Engine version: Godot Engine v4.6.1.stable.custom_build (282daf9dca4c1d6d39a9a9681a9fb29bf38e902c)
Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
[0] Object::derives_from<TextFile,Object> (C:\dev\godot\core\object\object.h:1067)
[1] Object::derives_from<TextFile,Object> (C:\dev\godot\core\object\object.h:1067)
[2] Object::cast_to<TextFile> (C:\dev\godot\core\object\object.h:846)
[3] ScriptEditorPlugin::handles (C:\dev\godot\editor\script\script_editor_plugin.cpp:4673)
[4] EditorData::get_handling_main_editor (C:\dev\godot\editor\editor_data.cpp:260)
[5] EditorNode::_set_main_scene_state (C:\dev\godot\editor\editor_node.cpp:4524)
[6] call_with_variant_args_helper<EditorNode,Dictionary,Node *,0,1> (C:\dev\godot\core\variant\binder_common.h:223)
[7] call_with_variant_args<EditorNode,Dictionary,Node *> (C:\dev\godot\core\variant\binder_common.h:337)
[8] CallableCustomMethodPointer<EditorNode,void,Dictionary,Node *>::call (C:\dev\godot\core\object\callable_method_pointer.h:103)
[9] Callable::callp (C:\dev\godot\core\variant\callable.cpp:57)
[10] CallQueue::_call_function (C:\dev\godot\core\object\message_queue.cpp:220)
[11] CallQueue::flush (C:\dev\godot\core\object\message_queue.cpp:268)
[12] SceneTree::process (C:\dev\godot\scene\main\scene_tree.cpp:712)
[13] Main::iteration (C:\dev\godot\main\main.cpp:4930)
[14] OS_Windows::run (C:\dev\godot\platform\windows\os_windows.cpp:2354)
[15] widechar_main (C:\dev\godot\platform\windows\godot_windows.cpp:99)
[16] _main (C:\dev\godot\platform\windows\godot_windows.cpp:126)
[17] main (C:\dev\godot\platform\windows\godot_windows.cpp:140)
[18] WinMain (C:\dev\godot\platform\windows\godot_windows.cpp:154)
[19] __scrt_common_main_seh (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
[20] ShimMainCRTStartup (C:\dev\godot\platform\windows\cpu_feature_validation.c:74)
[21] <couldn't map PC to fn name>
-- END OF C++ BACKTRACE --
================================================================
```

</details>


<details>
<summary> Call stack when memory is reused</summary>

This is captured by breakpoint on write to `SceneTreeDock::get_singleton()->get_tree_editor()->get_selected()->_instance_id`
```
>	Object::_construct_object(bool p_reference=false) Line 2383
 	Object::Object() Line 2396
 	Node::Node() Line 4089
 	CanvasItem::CanvasItem() Line 1773
 	Node2D::Node2D() Line 514
 	ClassDB::creator<Node2D>(bool p_notify_postinitialize=true) Line 173
 	ClassDB::_instantiate_internal(const StringName & p_class={...}, bool p_require_real_class=false, bool p_notify_postinitialize=true, bool p_exposed_only=true) Line 625
 	ClassDB::instantiate(const StringName & p_class={...}) Line 665
 	SceneState::instantiate(SceneState::GenEditState p_edit_state=GEN_EDIT_STATE_INSTANCE) Line 316
 	PackedScene::instantiate(PackedScene::GenEditState p_edit_state=GEN_EDIT_STATE_INSTANCE) Line 2510
 	SceneState::instantiate(SceneState::GenEditState p_edit_state=GEN_EDIT_STATE_INSTANCE) Line 264
 	PackedScene::instantiate(PackedScene::GenEditState p_edit_state=GEN_EDIT_STATE_INSTANCE) Line 2510
 	SceneState::instantiate(SceneState::GenEditState p_edit_state=GEN_EDIT_STATE_INSTANCE) Line 264
 	PackedScene::instantiate(PackedScene::GenEditState p_edit_state=GEN_EDIT_STATE_INSTANCE) Line 2510
 	SceneState::instantiate(SceneState::GenEditState p_edit_state=GEN_EDIT_STATE_MAIN) Line 264
 	PackedScene::instantiate(PackedScene::GenEditState p_edit_state=GEN_EDIT_STATE_MAIN) Line 2510
 	EditorNode::load_scene(const String & p_scene={...}, bool p_ignore_broken_deps=true, bool p_set_inherited=false, bool p_force_open_imported=true, bool p_silent_change_tab=false) Line 4786
 	EditorNode::reload_scene(const String & p_path={...}) Line 6983
 	EditorInterface::reload_scene_from_path(const String & scene_path={...}) Line 705
 	call_with_validated_variant_args_helper<EditorInterface,String const &,0>(EditorInterface * p_instance=0x0000022c44a31f70, void(EditorInterface::*)(const String &) p_method=0x00007ff6a3555400, const Variant * * p_args=0x0000006c061f9a00, IndexSequence<0> __formal={...}) Line 284
 	call_with_validated_object_instance_args<EditorInterface,String const &>(EditorInterface * base=0x0000022c44a31f70, void(EditorInterface::*)(const String &) p_method=0x00007ff6a3555400, const Variant * * p_args=0x0000006c061f9a00) Line 571
 	MethodBindT<EditorInterface,String const &>::validated_call(Object * p_object=0x0000022c44a31f70, const Variant * * p_args=0x0000006c061f9a00, Variant * r_ret=0x0000000000000000) Line 347
 	GDScriptFunction::call(GDScriptInstance * p_instance=0x0000022c6ff25b90, const Variant * * p_args=0x0000006c061fe738, int p_argcount=1, Callable::CallError & r_err={...}, GDScriptFunction::CallState * p_state=0x0000000000000000) Line 2355
 	GDScriptInstance::callp(const StringName & p_method={...}, const Variant * * p_args=0x0000006c061fe738, int p_argcount=1, Callable::CallError & r_error={...}) Line 1907
 	Node::_gdvirtual__process_call(double arg1=0.12317388888888736) Line 427
 	Node::_notification(int p_notification=17) Line 92
 	Node::_notification_forwardv(int p_notification=17) Line 51
 	EditorPlugin::_notification_forwardv(int p_notification=17) Line 60
 	Object::_notification_forward(int p_notification=17) Line 1013
 	Object::notification(int p_notification=17, bool p_reversed=false) Line 929
 	SceneTree::_process_group(SceneTree::ProcessGroup * p_group=0x0000022c4633f338, bool p_physics=false) Line 1204
 	SceneTree::_process(bool p_physics=false) Line 1281
 	SceneTree::process(double p_time=0.12317388888888736) Line 710
 	Main::iteration() Line 4930
 	OS_Windows::run() Line 2354
```

</details>
