### PR TITLE
[TextEdit] Fix clipping of last character due to right margin rounding

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -948,7 +948,7 @@ void TextEdit::_notification(int p_what) {
 			int left_margin = Math::ceil(style->get_margin(SIDE_LEFT));
 			int xmargin_beg = left_margin + gutters_width + gutter_padding;
 
-			int xmargin_end = size.width - Math::ceil(style->get_margin(SIDE_RIGHT));
+			int xmargin_end = size.width - Math::floor(style->get_margin(SIDE_RIGHT));
 			if (draw_minimap) {
 				xmargin_end -= minimap_width;
 			}
@@ -3616,7 +3616,7 @@ Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
 		return CURSOR_ARROW;
 	}
 
-	int xmargin_end = get_size().width - Math::ceil(style->get_margin(SIDE_RIGHT));
+	int xmargin_end = get_size().width - Math::floor(style->get_margin(SIDE_RIGHT));
 	if (draw_minimap && p_pos.x > xmargin_end - minimap_width && p_pos.x <= xmargin_end) {
 		return CURSOR_ARROW;
 	}
@@ -8930,7 +8930,7 @@ void TextEdit::_adjust_viewport_to_caret_horizontally(int p_caret, bool p_maximi
 
 void TextEdit::_update_minimap_hover() {
 	const Point2 mp = get_local_mouse_pos();
-	const int xmargin_end = get_size().width - Math::ceil(_get_current_stylebox()->get_margin(SIDE_RIGHT));
+	const int xmargin_end = get_size().width - Math::floor(_get_current_stylebox()->get_margin(SIDE_RIGHT));
 
 	bool hovering_sidebar = mp.x > xmargin_end - minimap_width && mp.x < xmargin_end;
 	if (!hovering_sidebar) {
@@ -8957,7 +8957,7 @@ void TextEdit::_update_minimap_hover() {
 void TextEdit::_update_minimap_click() {
 	Point2 mp = get_local_mouse_pos();
 
-	int xmargin_end = get_size().width - Math::ceil(_get_current_stylebox()->get_margin(SIDE_RIGHT));
+	int xmargin_end = get_size().width - Math::floor(_get_current_stylebox()->get_margin(SIDE_RIGHT));
 	if (!dragging_minimap && (mp.x < xmargin_end - minimap_width || mp.x > xmargin_end)) {
 		minimap_clicked = false;
 		return;


### PR DESCRIPTION
This fixes an off-by-one clipping issue introduced in commit 1794098.
Using ceil() on the right margin reduces the visible text area by up to 1 px,
causing the last character of long lines to be clipped.

This restores the previous behavior by using floor() for SIDE_RIGHT while
keeping ceil() for SIDE_LEFT.

- Fixes #110577.

See also:
-  #114221
- https://github.com/godotengine/godot/pull/110791

This pull request resolves the issue without affecting other behavior: it only adjusts the one extra pixel needed at the end of `TextEdit` on custom scales so the last character is visible again. Probably using floats is a proper solution (#114221), but if that is not planned in the near future, this is a simple, low-risk improvement to the currently severely impacted usability.