### PR TITLE
LineEdit: do not hog the notifications if you do not need to blink anything

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1664,6 +1664,8 @@ void LineEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_FOCUS_ENTER: {
+			set_process_internal(caret_blink_enabled);
+
 			// Only allow editing if the LineEdit is not focused with arrow keys.
 			if (!(Input::get_singleton()->is_action_pressed("ui_up") || Input::get_singleton()->is_action_pressed("ui_down") || Input::get_singleton()->is_action_pressed("ui_left") || Input::get_singleton()->is_action_pressed("ui_right"))) {
 				_edit(virtual_keyboard_show_on_focus);
@@ -1672,6 +1674,8 @@ void LineEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_FOCUS_EXIT: {
+			set_process_internal(false);
+
 			if (editing) {
 				unedit();
 				emit_signal(SNAME("editing_toggled"), false);
@@ -2017,7 +2021,7 @@ void LineEdit::set_caret_blink_enabled(const bool p_enabled) {
 	}
 
 	caret_blink_enabled = p_enabled;
-	set_process_internal(p_enabled);
+	set_process_internal(p_enabled && has_focus());
 
 	draw_caret = !caret_blink_enabled;
 	if (caret_blink_enabled) {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1664,7 +1664,7 @@ void LineEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_FOCUS_ENTER: {
-			set_process_internal(caret_blink_enabled);
+			set_process_internal(caret_blink_enabled && (has_focus() || (caret_force_displayed && !is_part_of_edited_scene())));
 
 			// Only allow editing if the LineEdit is not focused with arrow keys.
 			if (!(Input::get_singleton()->is_action_pressed("ui_up") || Input::get_singleton()->is_action_pressed("ui_down") || Input::get_singleton()->is_action_pressed("ui_left") || Input::get_singleton()->is_action_pressed("ui_right"))) {
@@ -1674,7 +1674,7 @@ void LineEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_FOCUS_EXIT: {
-			set_process_internal(false);
+			set_process_internal(caret_blink_enabled && caret_force_displayed && !is_part_of_edited_scene());
 
 			if (editing) {
 				unedit();
@@ -2021,7 +2021,7 @@ void LineEdit::set_caret_blink_enabled(const bool p_enabled) {
 	}
 
 	caret_blink_enabled = p_enabled;
-	set_process_internal(p_enabled && has_focus());
+	set_process_internal(p_enabled && (has_focus() || (caret_force_displayed && !is_part_of_edited_scene())));
 
 	draw_caret = !caret_blink_enabled;
 	if (caret_blink_enabled) {
@@ -2043,6 +2043,7 @@ void LineEdit::set_caret_force_displayed(const bool p_enabled) {
 
 	caret_force_displayed = p_enabled;
 	_validate_caret_can_draw();
+	set_process_internal(caret_blink_enabled && (has_focus() || (caret_force_displayed && !is_part_of_edited_scene())));
 
 	queue_redraw();
 }


### PR DESCRIPTION
This addresses one of the issues in:

https://github.com/godotengine/godot/issues/116845#issuecomment-3973954492

Update: to add more color, without this change, every LineEdit gets called back to blink their cursor, even if they are not focused.  Someone just reported this problem on RocketChat as well:


![](https://chat.godotengine.org/file-upload/69a211e5ec472fda5d5e1606/Clipboard%20-%20February%2027,%202026%202:51%20PM.png)

