### PR TITLE
OpenXR: Limit Windows includes to COM interface

### DIFF
--- a/modules/openxr/openxr_platform_inc.h
+++ b/modules/openxr/openxr_platform_inc.h
@@ -33,6 +33,8 @@
 // In various places we need to include platform definitions but we can't
 // include these in our normal header files as we'll end up with issues.
 
+// IWYU pragma: begin_keep
+
 #ifdef VULKAN_ENABLED
 #define XR_USE_GRAPHICS_API_VULKAN
 #include "drivers/vulkan/rendering_context_driver_vulkan.h"
@@ -78,9 +80,9 @@
 #endif // X11_ENABLED
 
 #ifdef WINDOWS_ENABLED
-// Including windows.h here is absolutely evil, we shouldn't be doing this outside of platform
-// however due to the way the openxr headers are put together, we have no choice.
-#include <windows.h>
+#define COM_NO_WINDOWS_H
+#include <objbase.h>
+#include <unknwn.h> // codespell:ignore unknwn
 #endif // WINDOWS_ENABLED
 
 #ifdef ANDROID_ENABLED
@@ -90,3 +92,5 @@
 
 // Include platform dependent structs.
 #include <openxr/openxr_platform.h>
+
+// IWYU pragma: end_keep


### PR DESCRIPTION
Fixes the following compilation errors that show up when `d3d12=no`
```
Compiling modules\openxr\openxr_api.cpp ...
D:\a\godot4-nightly\godot4-nightly\thirdparty\openxr\include\openxr/openxr_platform.h(565): error C2061: syntax error: identifier 'IUnknown'
D:\a\godot4-nightly\godot4-nightly\thirdparty\openxr\include\openxr/openxr_platform.h(566): error C2061: syntax error: identifier 'IUnknown'
D:\a\godot4-nightly\godot4-nightly\thirdparty\openxr\include\openxr/openxr_platform.h(594): error C2143: syntax error: missing ';' before '*'
D:\a\godot4-nightly\godot4-nightly\thirdparty\openxr\include\openxr/openxr_platform.h(594): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
scons: *** [bin\obj\modules\openxr\openxr_api.windows.editor.dev.x86_64.obj] Error 2
```