### PR TITLE
Fix an error when specifying the last pined point of a SoftBody3D

### DIFF
--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -207,7 +207,8 @@ bool SoftBody3D::_set_property_pinned_points_indices(const Array &p_indices) {
 			bool insert = false;
 			if (w[i].point_index != -1 && p_indices.find(w[i].point_index) == -1) {
 				pin_point(w[i].point_index, false);
-				insert = true;
+				// If it's the last one, we need to push back to the end
+				insert = i < p_indices_size - 1;
 			}
 			w[i].point_index = point_index;
 			if (insert) {


### PR DESCRIPTION
Fixes #116856

The issue happens when the modification occurs on the last point. In that case, `_set_property_pinned_points_indices` method removes it and the insertion index becomes invalid. So if the last point is being updated, we need to push back instead of insert.