### PR TITLE
Add `EditorInterface::import_and_save_resource`

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -248,6 +248,17 @@
 				Returns an array of file paths of currently unsaved scenes.
 			</description>
 		</method>
+		<method name="import_and_save_resource">
+			<return type="PackedStringArray" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="importer_name" type="String" />
+			<param index="2" name="params" type="Dictionary" />
+			<param index="3" name="save_base_path" type="String" />
+			<description>
+				Imports the resource at the given path and saves it to the given base path.
+				Returns an array of file paths of the imported resources and generated files.
+			</description>
+		</method>
 		<method name="inspect_object">
 			<return type="void" />
 			<param index="0" name="object" type="Object" />

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -785,6 +785,54 @@ Error EditorInterface::close_scene() {
 	return EditorNode::get_singleton()->close_scene() ? OK : ERR_DOES_NOT_EXIST;
 }
 
+Vector<String> EditorInterface::import_and_save_resource(const String &p_path, const String &p_importer_name, const Dictionary &p_params, const String &p_import_base_path) {
+	Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(p_importer_name);
+	ERR_FAIL_COND_V_MSG(importer.is_null(), {}, "Importer not found");
+
+	String base_dir = p_import_base_path.get_base_dir();
+	// make dir recursive
+	DirAccess::make_dir_recursive_absolute(base_dir);
+
+	HashMap<StringName, Variant> params;
+	for (const KeyValue<Variant, Variant> &E : p_params) {
+		params[E.key] = E.value;
+	}
+
+	// set the default values for the import options in case they are not present
+	// in the import file
+	List<ResourceImporter::ImportOption> opts;
+	importer->get_import_options(p_path, &opts);
+
+	for (const ResourceImporter::ImportOption &E : opts) {
+		if (!params.has(E.option.name)) { // this one is not present
+			params[E.option.name] = E.default_value;
+		}
+	}
+	List<String> import_variants;
+	List<String> gen_files;
+
+	Variant md;
+	ERR_FAIL_COND_V_MSG(importer->import(ResourceUID::INVALID_ID, p_path, p_import_base_path,
+								params, &import_variants, &gen_files, &md) != OK,
+			{}, "Failed to import resource");
+
+	Vector<String> ret;
+	if (import_variants.size()) {
+		//import with variants
+		for (const String &E : import_variants) {
+			String path = p_import_base_path + "." + E + "." + importer->get_save_extension();
+			ret.push_back(path);
+		}
+	} else {
+		ret.push_back(p_import_base_path + "." + importer->get_save_extension());
+	}
+	for (const String &E : gen_files) {
+		ret.push_back(base_dir.path_join(E));
+	}
+
+	return ret;
+}
+
 // Scene playback.
 
 void EditorInterface::play_main_scene() {
@@ -930,6 +978,8 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("save_scene_as", "path", "with_preview"), &EditorInterface::save_scene_as, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("save_all_scenes"), &EditorInterface::save_all_scenes);
 	ClassDB::bind_method(D_METHOD("close_scene"), &EditorInterface::close_scene);
+
+	ClassDB::bind_method(D_METHOD("import_and_save_resource", "path", "importer_name", "params", "save_base_path"), &EditorInterface::import_and_save_resource);
 
 	ClassDB::bind_method(D_METHOD("mark_scene_as_unsaved"), &EditorInterface::mark_scene_as_unsaved);
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -192,6 +192,8 @@ public:
 	void save_all_scenes();
 	Error close_scene();
 
+	Vector<String> import_and_save_resource(const String &p_path, const String &p_importer_name, const Dictionary &p_params, const String &p_save_base_path);
+
 	// Scene playback.
 
 	void play_main_scene();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
-->

This PR adds `EditorInterface::import_and_save_resource()`. 

We are currently working on a version control system plugin for Godot, and we would like to be able to display a preview of imported resources as they were at previous points in the history in our visual diffs of commits.

However, there is currently no way to perform a "test import" of a resource for the purposes of displaying an import preview, or any other discrete "import" function. 

This is a basic implementation of such a function that allows for importing and saving to a temporary path so that we can import and then load imported resources.