### PR TITLE
Performance: avoid polling in the Debugger and GDScriptLanguage servers.

### DIFF
--- a/core/io/net_socket.h
+++ b/core/io/net_socket.h
@@ -118,5 +118,7 @@ public:
 	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) = 0;
 	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) = 0;
 
+	virtual int get_native_fd() const { return -1; }
+
 	virtual ~NetSocket() {}
 };

--- a/core/io/stream_peer_tcp.cpp
+++ b/core/io/stream_peer_tcp.cpp
@@ -32,6 +32,11 @@
 
 #include "core/config/project_settings.h"
 
+int StreamPeerTCP::get_native_fd() const {
+	ERR_FAIL_COND_V(_sock.is_null(), -1);
+	return _sock->get_native_fd();
+}
+
 void StreamPeerTCP::accept_socket(Ref<NetSocket> p_sock, const NetSocket::Address &p_addr) {
 	_sock = p_sock;
 	_sock->set_blocking_enabled(false);

--- a/core/io/stream_peer_tcp.h
+++ b/core/io/stream_peer_tcp.h
@@ -52,4 +52,6 @@ public:
 	int get_local_port() const;
 
 	void set_no_delay(bool p_enabled);
+
+	int get_native_fd() const;
 };

--- a/core/io/tcp_server.h
+++ b/core/io/tcp_server.h
@@ -44,5 +44,6 @@ public:
 	Error listen(uint16_t p_port, const IPAddress &p_bind_address = IPAddress("*"));
 	int get_local_port() const;
 	Ref<StreamPeerTCP> take_connection();
+	int get_native_fd() const;
 	Ref<StreamPeerSocket> take_socket_connection() override { return take_connection(); }
 };

--- a/drivers/apple/socket_monitor_gcd.h
+++ b/drivers/apple/socket_monitor_gcd.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  tcp_server.cpp                                                        */
+/*  socket_monitor_gcd.h                                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,47 +28,21 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "tcp_server.h"
+#pragma once
 
-void TCPServer::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("listen", "port", "bind_address"), &TCPServer::listen, DEFVAL("*"));
-	ClassDB::bind_method(D_METHOD("get_local_port"), &TCPServer::get_local_port);
-	ClassDB::bind_method(D_METHOD("take_connection"), &TCPServer::take_connection);
-}
+#include <dispatch/dispatch.h>
 
-Error TCPServer::listen(uint16_t p_port, const IPAddress &p_bind_address) {
-	ERR_FAIL_COND_V(_sock.is_null(), ERR_UNAVAILABLE);
-	ERR_FAIL_COND_V(_sock->is_open(), ERR_ALREADY_IN_USE);
-	ERR_FAIL_COND_V(!p_bind_address.is_valid() && !p_bind_address.is_wildcard(), ERR_INVALID_PARAMETER);
+#include "core/variant/callable.h"
 
-	Error err;
-	IP::Type ip_type = IP::TYPE_ANY;
+class SocketMonitorGCD {
+	dispatch_source_t _source = nullptr;
+	bool _active = false;
 
-	// If the bind address is valid use its type as the socket type
-	if (p_bind_address.is_valid()) {
-		ip_type = p_bind_address.is_ipv4() ? IP::TYPE_IPV4 : IP::TYPE_IPV6;
-	}
-
-	err = _sock->open(NetSocket::Family::INET, NetSocket::TYPE_TCP, ip_type);
-
-	ERR_FAIL_COND_V(err != OK, ERR_CANT_CREATE);
-
-	_sock->set_reuse_address_enabled(true);
-
-	return _listen(NetSocket::Address(p_bind_address, p_port));
-}
-
-int TCPServer::get_local_port() const {
-	NetSocket::Address addr;
-	_sock->get_socket_address(&addr);
-	return addr.port();
-}
-
-Ref<StreamPeerTCP> TCPServer::take_connection() {
-	return _take_connection<StreamPeerTCP>();
-}
-
-int TCPServer::get_native_fd() const {
-	ERR_FAIL_COND_V(_sock.is_null(), -1);
-	return _sock->get_native_fd();
-}
+public:
+	// Start monitoring fd for readability. Callback is invoked via
+	// call_deferred() so it runs during Godot's MessageQueue flush.
+	void start(int p_fd, const Callable &p_on_readable);
+	void stop();
+	bool is_active() const { return _active; }
+	~SocketMonitorGCD();
+};

--- a/drivers/apple/socket_monitor_gcd.h
+++ b/drivers/apple/socket_monitor_gcd.h
@@ -34,8 +34,11 @@
 
 #include "core/variant/callable.h"
 
+struct SocketMonitorGCDState;
+
 class SocketMonitorGCD {
 	dispatch_source_t _source = nullptr;
+	SocketMonitorGCDState *_state = nullptr;
 	bool _active = false;
 
 public:

--- a/drivers/apple/socket_monitor_gcd.mm
+++ b/drivers/apple/socket_monitor_gcd.mm
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  tcp_server.cpp                                                        */
+/*  socket_monitor_gcd.mm                                                 */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,47 +28,35 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "tcp_server.h"
+#include "socket_monitor_gcd.h"
 
-void TCPServer::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("listen", "port", "bind_address"), &TCPServer::listen, DEFVAL("*"));
-	ClassDB::bind_method(D_METHOD("get_local_port"), &TCPServer::get_local_port);
-	ClassDB::bind_method(D_METHOD("take_connection"), &TCPServer::take_connection);
-}
+#include "core/variant/variant.h"
 
-Error TCPServer::listen(uint16_t p_port, const IPAddress &p_bind_address) {
-	ERR_FAIL_COND_V(_sock.is_null(), ERR_UNAVAILABLE);
-	ERR_FAIL_COND_V(_sock->is_open(), ERR_ALREADY_IN_USE);
-	ERR_FAIL_COND_V(!p_bind_address.is_valid() && !p_bind_address.is_wildcard(), ERR_INVALID_PARAMETER);
+void SocketMonitorGCD::start(int p_fd, const Callable &p_on_readable) {
+	stop();
 
-	Error err;
-	IP::Type ip_type = IP::TYPE_ANY;
-
-	// If the bind address is valid use its type as the socket type
-	if (p_bind_address.is_valid()) {
-		ip_type = p_bind_address.is_ipv4() ? IP::TYPE_IPV4 : IP::TYPE_IPV6;
+	_source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, p_fd, 0, dispatch_get_main_queue());
+	if (!_source) {
+		return;
 	}
 
-	err = _sock->open(NetSocket::Family::INET, NetSocket::TYPE_TCP, ip_type);
+	Callable cb = p_on_readable;
+	dispatch_source_set_event_handler(_source, ^{
+		cb.call_deferred();
+	});
 
-	ERR_FAIL_COND_V(err != OK, ERR_CANT_CREATE);
-
-	_sock->set_reuse_address_enabled(true);
-
-	return _listen(NetSocket::Address(p_bind_address, p_port));
+	dispatch_resume(_source);
+	_active = true;
 }
 
-int TCPServer::get_local_port() const {
-	NetSocket::Address addr;
-	_sock->get_socket_address(&addr);
-	return addr.port();
+void SocketMonitorGCD::stop() {
+	if (_source) {
+		dispatch_source_cancel(_source);
+		_source = nullptr;
+	}
+	_active = false;
 }
 
-Ref<StreamPeerTCP> TCPServer::take_connection() {
-	return _take_connection<StreamPeerTCP>();
-}
-
-int TCPServer::get_native_fd() const {
-	ERR_FAIL_COND_V(_sock.is_null(), -1);
-	return _sock->get_native_fd();
+SocketMonitorGCD::~SocketMonitorGCD() {
+	stop();
 }

--- a/drivers/apple/socket_monitor_gcd.mm
+++ b/drivers/apple/socket_monitor_gcd.mm
@@ -40,9 +40,12 @@ void SocketMonitorGCD::start(int p_fd, const Callable &p_on_readable) {
 		return;
 	}
 
-	Callable cb = p_on_readable;
+	Callable *cb = memnew(Callable(p_on_readable));
 	dispatch_source_set_event_handler(_source, ^{
-		cb.call_deferred();
+		cb->call_deferred();
+	});
+	dispatch_source_set_cancel_handler(_source, ^{
+		memdelete(cb);
 	});
 
 	dispatch_resume(_source);

--- a/drivers/apple/socket_monitor_gcd.mm
+++ b/drivers/apple/socket_monitor_gcd.mm
@@ -32,6 +32,17 @@
 
 #include "core/variant/variant.h"
 
+#include <atomic>
+
+// State we capture, to prevent use after free
+struct SocketMonitorGCDState {
+	Callable callable;
+	std::atomic<bool> cancelled = false;
+
+	explicit SocketMonitorGCDState(const Callable &p_callable) :
+			callable(p_callable) {}
+};
+
 void SocketMonitorGCD::start(int p_fd, const Callable &p_on_readable) {
 	stop();
 
@@ -40,12 +51,19 @@ void SocketMonitorGCD::start(int p_fd, const Callable &p_on_readable) {
 		return;
 	}
 
-	Callable *cb = memnew(Callable(p_on_readable));
+	SocketMonitorGCDState *state = memnew(SocketMonitorGCDState(p_on_readable));
+	_state = state;
+
 	dispatch_source_set_event_handler(_source, ^{
-		cb->call_deferred();
+		// Once cancellation has been requested, stop delivering: the callable's
+		// target may already be tearing down. 
+		if (!state->cancelled.load()) {
+			state->callable.call_deferred();
+		}
 	});
 	dispatch_source_set_cancel_handler(_source, ^{
-		memdelete(cb);
+		// Runs after the last event handler completes; sole owner that frees state.
+		memdelete(state);
 	});
 
 	dispatch_resume(_source);
@@ -54,6 +72,12 @@ void SocketMonitorGCD::start(int p_fd, const Callable &p_on_readable) {
 
 void SocketMonitorGCD::stop() {
 	if (_source) {
+		if (_state) {
+			// Signal in-flight/queued event handlers before triggering the
+			// asynchronous cancellation that will eventually free the state.
+			_state->cancelled.store(true);
+			_state = nullptr;
+		}
 		dispatch_source_cancel(_source);
 		_source = nullptr;
 	}

--- a/drivers/unix/net_socket_unix.h
+++ b/drivers/unix/net_socket_unix.h
@@ -112,6 +112,8 @@ public:
 	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
 	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
 
+	int get_native_fd() const override { return _sock; }
+
 	NetSocketUnix();
 	~NetSocketUnix() override;
 };

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -151,12 +151,30 @@ Error DebugAdapterProtocol::on_client_connected() {
 	peer->connection = tcp_peer;
 	clients.push_back(peer);
 
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+	int peer_fd = tcp_peer->get_native_fd();
+	if (peer_fd >= 0) {
+		SocketMonitorGCD *monitor = memnew(SocketMonitorGCD);
+		monitor->start(peer_fd, callable_mp(this, &DebugAdapterProtocol::_on_peer_readable).bind(peer_fd));
+		_peer_monitors.insert(peer_fd, monitor);
+	}
+#endif
+
 	EditorDebuggerNode::get_singleton()->get_default_debugger()->set_move_to_foreground(false);
 	EditorNode::get_log()->add_message("[DAP] Connection Taken", EditorLog::MSG_TYPE_EDITOR);
 	return OK;
 }
 
 void DebugAdapterProtocol::on_client_disconnected(const Ref<DAPeer> &p_peer) {
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+	int peer_fd = p_peer->connection->get_native_fd();
+	if (_peer_monitors.has(peer_fd)) {
+		SocketMonitorGCD *monitor = _peer_monitors[peer_fd];
+		monitor->stop();
+		memdelete(monitor);
+		_peer_monitors.erase(peer_fd);
+	}
+#endif
 	clients.erase(p_peer);
 	if (!clients.size()) {
 		reset_ids();
@@ -888,6 +906,7 @@ bool DebugAdapterProtocol::process_message(const String &p_text) {
 void DebugAdapterProtocol::notify_initialized() {
 	Dictionary event = parser->ev_initialized();
 	_current_peer->res_queue.push_back(event);
+	_flush_peer(_current_peer);
 }
 
 void DebugAdapterProtocol::notify_process() {
@@ -897,6 +916,7 @@ void DebugAdapterProtocol::notify_process() {
 	for (const Ref<DAPeer> &peer : clients) {
 		peer->res_queue.push_back(event);
 	}
+	_flush_all_peers();
 }
 
 void DebugAdapterProtocol::notify_terminated() {
@@ -907,6 +927,7 @@ void DebugAdapterProtocol::notify_terminated() {
 		}
 		peer->res_queue.push_back(event);
 	}
+	_flush_all_peers();
 }
 
 void DebugAdapterProtocol::notify_exited(const int &p_exitcode) {
@@ -917,6 +938,7 @@ void DebugAdapterProtocol::notify_exited(const int &p_exitcode) {
 		}
 		peer->res_queue.push_back(event);
 	}
+	_flush_all_peers();
 }
 
 void DebugAdapterProtocol::notify_stopped_paused() {
@@ -924,6 +946,7 @@ void DebugAdapterProtocol::notify_stopped_paused() {
 	for (const Ref<DAPeer> &peer : clients) {
 		peer->res_queue.push_back(event);
 	}
+	_flush_all_peers();
 }
 
 void DebugAdapterProtocol::notify_stopped_exception(const String &p_error) {
@@ -931,6 +954,7 @@ void DebugAdapterProtocol::notify_stopped_exception(const String &p_error) {
 	for (const Ref<DAPeer> &peer : clients) {
 		peer->res_queue.push_back(event);
 	}
+	_flush_all_peers();
 }
 
 void DebugAdapterProtocol::notify_stopped_breakpoint(const int &p_id) {
@@ -938,6 +962,7 @@ void DebugAdapterProtocol::notify_stopped_breakpoint(const int &p_id) {
 	for (const Ref<DAPeer> &peer : clients) {
 		peer->res_queue.push_back(event);
 	}
+	_flush_all_peers();
 }
 
 void DebugAdapterProtocol::notify_stopped_step() {
@@ -945,6 +970,7 @@ void DebugAdapterProtocol::notify_stopped_step() {
 	for (const Ref<DAPeer> &peer : clients) {
 		peer->res_queue.push_back(event);
 	}
+	_flush_all_peers();
 }
 
 void DebugAdapterProtocol::notify_continued() {
@@ -955,6 +981,7 @@ void DebugAdapterProtocol::notify_continued() {
 		}
 		peer->res_queue.push_back(event);
 	}
+	_flush_all_peers();
 
 	reset_stack_info();
 }
@@ -964,6 +991,7 @@ void DebugAdapterProtocol::notify_output(const String &p_message, RemoteDebugger
 	for (const Ref<DAPeer> &peer : clients) {
 		peer->res_queue.push_back(event);
 	}
+	_flush_all_peers();
 }
 
 void DebugAdapterProtocol::notify_custom_data(const String &p_msg, const Array &p_data) {
@@ -973,6 +1001,7 @@ void DebugAdapterProtocol::notify_custom_data(const String &p_msg, const Array &
 			peer->res_queue.push_back(event);
 		}
 	}
+	_flush_all_peers();
 }
 
 void DebugAdapterProtocol::notify_breakpoint(const DAP::Breakpoint &p_breakpoint, const bool &p_enabled) {
@@ -983,6 +1012,7 @@ void DebugAdapterProtocol::notify_breakpoint(const DAP::Breakpoint &p_breakpoint
 		}
 		peer->res_queue.push_back(event);
 	}
+	_flush_all_peers();
 }
 
 Array DebugAdapterProtocol::update_breakpoints(const String &p_path, const Array &p_lines) {
@@ -1199,6 +1229,75 @@ void DebugAdapterProtocol::on_debug_data(const String &p_msg, const Array &p_dat
 	notify_custom_data(p_msg, p_data);
 }
 
+void DebugAdapterProtocol::_flush_peer(const Ref<DAPeer> &p_peer) {
+	p_peer->send_data();
+}
+
+void DebugAdapterProtocol::_flush_all_peers() {
+	for (const Ref<DAPeer> &peer : clients) {
+		_flush_peer(peer);
+	}
+}
+
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+void DebugAdapterProtocol::_on_server_readable() {
+	if (_handling) {
+		return;
+	}
+	_handling = true;
+
+	if (server->is_connection_available()) {
+		on_client_connected();
+	}
+
+	_handling = false;
+}
+
+Ref<DAPeer> DebugAdapterProtocol::_find_peer_by_fd(int p_fd) const {
+	for (const Ref<DAPeer> &peer : clients) {
+		if (peer->connection->get_native_fd() == p_fd) {
+			return peer;
+		}
+	}
+	return Ref<DAPeer>();
+}
+
+void DebugAdapterProtocol::_on_peer_readable(int p_fd) {
+	if (_handling) {
+		return;
+	}
+	_handling = true;
+
+	Ref<DAPeer> p_peer = _find_peer_by_fd(p_fd);
+	if (p_peer.is_null()) {
+		_handling = false;
+		return;
+	}
+
+	p_peer->connection->poll();
+	StreamPeerTCP::Status status = p_peer->connection->get_status();
+	if (status == StreamPeerTCP::STATUS_NONE || status == StreamPeerTCP::STATUS_ERROR) {
+		on_client_disconnected(p_peer);
+	} else {
+		_current_peer = p_peer;
+		Error err = p_peer->handle_data();
+		if (err != OK && err != ERR_BUSY) {
+			on_client_disconnected(p_peer);
+			_handling = false;
+			return;
+		}
+		err = p_peer->send_data();
+		if (err != OK && err != ERR_BUSY) {
+			on_client_disconnected(p_peer);
+			_handling = false;
+			return;
+		}
+	}
+
+	_handling = false;
+}
+#endif
+
 void DebugAdapterProtocol::poll() {
 	if (server->is_connection_available()) {
 		on_client_connected();
@@ -1232,10 +1331,37 @@ Error DebugAdapterProtocol::start(int p_port, const IPAddress &p_bind_ip) {
 	_request_timeout = (uint64_t)_EDITOR_GET("network/debug_adapter/request_timeout");
 	_sync_breakpoints = (bool)_EDITOR_GET("network/debug_adapter/sync_breakpoints");
 	_initialized = true;
-	return server->listen(p_port, p_bind_ip);
+	Error err = server->listen(p_port, p_bind_ip);
+	if (err != OK) {
+		return err;
+	}
+
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+	int server_fd = server->get_native_fd();
+	if (server_fd >= 0) {
+		_server_monitor = memnew(SocketMonitorGCD);
+		_server_monitor->start(server_fd, callable_mp(this, &DebugAdapterProtocol::_on_server_readable));
+	}
+#endif
+
+	return OK;
 }
 
 void DebugAdapterProtocol::stop() {
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+	for (KeyValue<int, SocketMonitorGCD *> &E : _peer_monitors) {
+		E.value->stop();
+		memdelete(E.value);
+	}
+	_peer_monitors.clear();
+
+	if (_server_monitor) {
+		_server_monitor->stop();
+		memdelete(_server_monitor);
+		_server_monitor = nullptr;
+	}
+#endif
+
 	for (const Ref<DAPeer> &peer : clients) {
 		peer->connection->disconnect_from_host();
 	}

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.h
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.h
@@ -37,6 +37,10 @@
 #include "editor/debugger/debug_adapter/debug_adapter_types.h"
 #include "scene/debugger/scene_debugger_object.h"
 
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+#include "drivers/apple/socket_monitor_gcd.h"
+#endif
+
 #define DAP_MAX_BUFFER_SIZE 4194304 // 4MB
 #define DAP_MAX_CLIENTS 8
 
@@ -83,6 +87,16 @@ private:
 
 	List<Ref<DAPeer>> clients;
 	Ref<TCPServer> server;
+
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+	SocketMonitorGCD *_server_monitor = nullptr;
+	HashMap<int, SocketMonitorGCD *> _peer_monitors; // keyed by native fd
+	bool _handling = false;
+
+	void _on_server_readable();
+	void _on_peer_readable(int p_fd);
+	Ref<DAPeer> _find_peer_by_fd(int p_fd) const;
+#endif
 
 	Error on_client_connected();
 	void on_client_disconnected(const Ref<DAPeer> &p_peer);
@@ -164,6 +178,9 @@ public:
 	void notify_breakpoint(const DAP::Breakpoint &p_breakpoint, const bool &p_enabled);
 
 	Array update_breakpoints(const String &p_path, const Array &p_lines);
+
+	void _flush_peer(const Ref<DAPeer> &p_peer);
+	void _flush_all_peers();
 
 	void poll();
 	Error start(int p_port, const IPAddress &p_bind_ip);

--- a/editor/debugger/debug_adapter/debug_adapter_server.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_server.cpp
@@ -54,6 +54,7 @@ void DebugAdapterServer::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
+#if !defined(MACOS_ENABLED) && !defined(APPLE_EMBEDDED_ENABLED)
 			// The main loop can be run again during request processing, which modifies internal state of the protocol.
 			// Thus, "polling" is needed to prevent it from parsing other requests while the current one isn't finished.
 			if (started && !polling) {
@@ -61,6 +62,7 @@ void DebugAdapterServer::_notification(int p_what) {
 				protocol.poll();
 				polling = false;
 			}
+#endif
 		} break;
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
@@ -82,7 +84,9 @@ void DebugAdapterServer::start() {
 	remote_port = (DebugAdapterServer::port_override > -1) ? DebugAdapterServer::port_override : (int)_EDITOR_GET("network/debug_adapter/remote_port");
 	if (protocol.start(remote_port, IPAddress("127.0.0.1")) == OK) {
 		EditorNode::get_log()->add_message("--- Debug adapter server started on port " + itos(remote_port) + " ---", EditorLog::MSG_TYPE_EDITOR);
+#if !defined(MACOS_ENABLED) && !defined(APPLE_EMBEDDED_ENABLED)
 		set_process_internal(true);
+#endif
 		started = true;
 	}
 }

--- a/editor/debugger/debug_adapter/debug_adapter_server.h
+++ b/editor/debugger/debug_adapter/debug_adapter_server.h
@@ -40,7 +40,9 @@ class DebugAdapterServer : public EditorPlugin {
 
 	int remote_port = 6006;
 	bool started = false;
+#if !defined(MACOS_ENABLED) && !defined(APPLE_EMBEDDED_ENABLED)
 	bool polling = false;
+#endif
 	static void thread_func(void *p_userdata);
 
 private:

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -140,13 +140,32 @@ Error GDScriptLanguageProtocol::on_client_connected() {
 	ERR_FAIL_COND_V_MSG(clients.size() >= LSP_MAX_CLIENTS, FAILED, "Max client limits reached");
 	Ref<LSPeer> peer = memnew(LSPeer);
 	peer->connection = tcp_peer;
-	clients.insert(next_client_id, peer);
+	int client_id = next_client_id;
+	clients.insert(client_id, peer);
 	next_client_id++;
+
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+	int peer_fd = tcp_peer->get_native_fd();
+	if (peer_fd >= 0) {
+		SocketMonitorGCD *monitor = memnew(SocketMonitorGCD);
+		monitor->start(peer_fd, callable_mp(this, &GDScriptLanguageProtocol::_on_peer_readable).bind(client_id));
+		_peer_monitors.insert(client_id, monitor);
+	}
+#endif
+
 	EditorNode::get_log()->add_message("[LSP] Connection Taken", EditorLog::MSG_TYPE_EDITOR);
 	return OK;
 }
 
 void GDScriptLanguageProtocol::on_client_disconnected(const int &p_client_id) {
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+	if (_peer_monitors.has(p_client_id)) {
+		SocketMonitorGCD *monitor = _peer_monitors[p_client_id];
+		monitor->stop();
+		memdelete(monitor);
+		_peer_monitors.erase(p_client_id);
+	}
+#endif
 	clients.erase(p_client_id);
 	if (clients.is_empty()) {
 		scene_cache.clear();
@@ -268,6 +287,74 @@ void GDScriptLanguageProtocol::initialized(const Variant &p_params) {
 	notify_client("gdscript/capabilities", capabilities.to_json());
 }
 
+void GDScriptLanguageProtocol::_flush_peer(const Ref<LSPeer> &p_peer) {
+	p_peer->send_data();
+}
+
+void GDScriptLanguageProtocol::_flush_all_peers() {
+	for (const KeyValue<int, Ref<LSPeer>> &E : clients) {
+		_flush_peer(E.value);
+	}
+}
+
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+void GDScriptLanguageProtocol::_on_server_readable() {
+	if (_handling) {
+		return;
+	}
+	_handling = true;
+
+	if (server->is_connection_available()) {
+		on_client_connected();
+	}
+
+	_handling = false;
+}
+
+void GDScriptLanguageProtocol::_on_peer_readable(int p_client_id) {
+	if (_handling) {
+		return;
+	}
+	_handling = true;
+
+	if (!clients.has(p_client_id)) {
+		_handling = false;
+		return;
+	}
+
+	Ref<LSPeer> peer = clients[p_client_id];
+	peer->connection->poll();
+	StreamPeerTCP::Status status = peer->connection->get_status();
+	if (status == StreamPeerTCP::STATUS_NONE || status == StreamPeerTCP::STATUS_ERROR) {
+		on_client_disconnected(p_client_id);
+	} else {
+		Error err = OK;
+		while (peer->connection->get_available_bytes() > 0) {
+			latest_client_id = p_client_id;
+			err = peer->handle_data();
+			if (err != OK) {
+				break;
+			}
+		}
+
+		if (err != OK && err != ERR_BUSY) {
+			on_client_disconnected(p_client_id);
+			_handling = false;
+			return;
+		}
+
+		err = peer->send_data();
+		if (err != OK && err != ERR_BUSY) {
+			on_client_disconnected(p_client_id);
+			_handling = false;
+			return;
+		}
+	}
+
+	_handling = false;
+}
+#endif
+
 void GDScriptLanguageProtocol::poll(int p_limit_usec) {
 	uint64_t target_ticks = OS::get_singleton()->get_ticks_usec() + p_limit_usec;
 
@@ -314,10 +401,37 @@ void GDScriptLanguageProtocol::poll(int p_limit_usec) {
 }
 
 Error GDScriptLanguageProtocol::start(int p_port, const IPAddress &p_bind_ip) {
-	return server->listen(p_port, p_bind_ip);
+	Error err = server->listen(p_port, p_bind_ip);
+	if (err != OK) {
+		return err;
+	}
+
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+	int server_fd = server->get_native_fd();
+	if (server_fd >= 0) {
+		_server_monitor = memnew(SocketMonitorGCD);
+		_server_monitor->start(server_fd, callable_mp(this, &GDScriptLanguageProtocol::_on_server_readable));
+	}
+#endif
+
+	return OK;
 }
 
 void GDScriptLanguageProtocol::stop() {
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+	for (KeyValue<int, SocketMonitorGCD *> &E : _peer_monitors) {
+		E.value->stop();
+		memdelete(E.value);
+	}
+	_peer_monitors.clear();
+
+	if (_server_monitor) {
+		_server_monitor->stop();
+		memdelete(_server_monitor);
+		_server_monitor = nullptr;
+	}
+#endif
+
 	for (const KeyValue<int, Ref<LSPeer>> &E : clients) {
 		Ref<LSPeer> peer = clients.get(E.key);
 		peer->connection->disconnect_from_host();
@@ -345,6 +459,7 @@ void GDScriptLanguageProtocol::notify_client(const String &p_method, const Varia
 	String msg = Variant(message).to_json_string();
 	msg = format_output(msg);
 	peer->res_queue.push_back(msg.utf8());
+	_flush_peer(peer);
 }
 
 void GDScriptLanguageProtocol::request_client(const String &p_method, const Variant &p_params, int p_client_id) {
@@ -366,6 +481,7 @@ void GDScriptLanguageProtocol::request_client(const String &p_method, const Vari
 	String msg = Variant(message).to_json_string();
 	msg = format_output(msg);
 	peer->res_queue.push_back(msg.utf8());
+	_flush_peer(peer);
 }
 
 bool GDScriptLanguageProtocol::is_smart_resolve_enabled() const {

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -39,6 +39,10 @@
 
 #include "modules/jsonrpc/jsonrpc.h"
 
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+#include "drivers/apple/socket_monitor_gcd.h"
+#endif
+
 #define LSP_MAX_BUFFER_SIZE 4194304
 #define LSP_MAX_CLIENTS 8
 
@@ -96,6 +100,15 @@ private:
 	int latest_client_id = LSP_NO_CLIENT;
 	int next_client_id = 0;
 
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+	SocketMonitorGCD *_server_monitor = nullptr;
+	HashMap<int, SocketMonitorGCD *> _peer_monitors;
+	bool _handling = false;
+
+	void _on_server_readable();
+	void _on_peer_readable(int p_client_id);
+#endif
+
 	int next_server_id = 0;
 
 	Ref<GDScriptTextDocument> text_document;
@@ -122,6 +135,9 @@ public:
 	_FORCE_INLINE_ SceneCache *get_scene_cache() { return &scene_cache; }
 
 	_FORCE_INLINE_ bool is_initialized() const { return _initialized; }
+
+	void _flush_peer(const Ref<LSPeer> &p_peer);
+	void _flush_all_peers();
 
 	void poll(int p_limit_usec);
 	Error start(int p_port, const IPAddress &p_bind_ip);

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -53,9 +53,11 @@ void GDScriptLanguageServer::_notification(int p_what) {
 				start();
 			}
 
+#if !defined(MACOS_ENABLED) && !defined(APPLE_EMBEDDED_ENABLED)
 			if (started && !use_thread) {
 				GDScriptLanguageProtocol::get_singleton()->poll(poll_limit_usec);
 			}
+#endif
 		} break;
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
@@ -95,8 +97,15 @@ void GDScriptLanguageServer::start() {
 		if (use_thread) {
 			thread_running = true;
 			thread.start(GDScriptLanguageServer::thread_main, this);
+			set_process_internal(false);
+		} else {
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+			// GCD dispatch_source monitors handle socket events.
+			set_process_internal(false);
+#else
+			set_process_internal(true);
+#endif
 		}
-		set_process_internal(!use_thread);
 		started = true;
 	}
 }


### PR DESCRIPTION
Avoid polling on gdscript/language_server and editor/debugger/debug_adapter for network connections, instead let the operating system notify us.

Reduces the polling time that was killing my editor frame rate.   

See https://github.com/godotengine/godot/issues/116845 for the whole saga.