### PR TITLE
C#: Deal with invalid script in cache

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -499,8 +499,23 @@ namespace Godot.Bridge
                     {
                         // Use existing
                         NativeFuncs.godotsharp_ref_new_from_ref_counted_ptr(out *outScript, scriptPtr);
-                        scriptPath = null;
-                        return false;
+
+                        if (!outScript->IsNull)
+                        {
+                            scriptPath = null;
+                            return false;
+                        }
+
+                        // Treat an invalid ref the same as not found
+                        _scriptTypeBiMap.ReadWriteLock.EnterWriteLock();
+                        try
+                        {
+                            _scriptTypeBiMap.Remove(scriptPtr);
+                        }
+                        finally
+                        {
+                            _scriptTypeBiMap.ReadWriteLock.ExitWriteLock();
+                        }
                     }
 
                     // This path is slower, but it's only executed for the first instantiation of the type


### PR DESCRIPTION
Fixes #109711

This addresses a potential race condition when a `CSharpScript` is simultaneously being released on the .NET Finalizer thread, and accessed on the main thread. If the main thread tries to access the partially-released value first before the `CSharpScript`'s destructor removes itself from the script cache table, it retrieves an invalid reference.

This resolution has the main thread pre-emptively lock and remove the invalid reference when it is found, and proceed as if it was not found in the table.
