### PR TITLE
More fault-tolerant DLL copies on Windows

### DIFF
--- a/core/extension/gdextension_library_loader.cpp
+++ b/core/extension/gdextension_library_loader.cpp
@@ -191,7 +191,7 @@ Error GDExtensionLibraryLoader::open_library(const String &p_path) {
 	OS::GDExtensionData data = {
 		true, // also_set_library_path
 		&library_path, // r_resolved_path
-		Engine::get_singleton()->is_editor_hint(), // generate_temp_files
+		Engine::get_singleton()->is_extension_reloading_enabled(), // generate_temp_files
 		&abs_dependencies_paths, // library_dependencies
 	};
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2152,7 +2152,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef TOOLS_ENABLED
 	if (editor) {
 		Engine::get_singleton()->set_editor_hint(true);
-		Engine::get_singleton()->set_extension_reloading_enabled(true);
+		bool script_mode = (main_args.find("--script") != nullptr);
+		Engine::get_singleton()->set_extension_reloading_enabled(!script_mode);
 
 		// Create initialization lock file to detect crashes during startup.
 		OS::get_singleton()->create_lock_file();

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -492,24 +492,31 @@ Error OS_Windows::open_dynamic_library(const String &p_path, void *&p_library_ha
 	if (p_data != nullptr && p_data->generate_temp_files) {
 		// Copy the file to the same directory as the original with a prefix in the name.
 		// This is so relative path to dependencies are satisfied.
-		load_path = path.get_base_dir().path_join("~" + path.get_file());
+		for (int idx = 0; idx < 10; idx++) {
+			String candidate_load_path = path.get_base_dir().path_join(vformat("~%d~%s", idx, path.get_file()));
 
-		// If there's a left-over copy (possibly from a crash) then delete it first.
-		if (FileAccess::exists(load_path)) {
-			DirAccess::remove_absolute(load_path);
-		}
+			// If there's a left-over copy (possibly from a crash) then delete it first.
+			if (FileAccess::exists(candidate_load_path)) {
+				DirAccess::remove_absolute(candidate_load_path);
+			}
 
-		Error copy_err = DirAccess::copy_absolute(path, load_path);
-		if (copy_err) {
-			ERR_PRINT("Error copying library: " + path);
-			return ERR_CANT_CREATE;
-		}
+			// Try to copy the library to a temporary location.
+			Error copy_err = DirAccess::copy_absolute(path, candidate_load_path);
+			if (copy_err == 0) {
+				// Only change the load path if the copy succeeded.
+				load_path = candidate_load_path;
 
-		FileAccess::set_hidden_attribute(load_path, true);
+				FileAccess::set_hidden_attribute(load_path, true);
 
-		Error pdb_err = WindowsUtils::copy_and_rename_pdb(load_path);
-		if (pdb_err != OK && pdb_err != ERR_SKIP) {
-			WARN_PRINT(vformat("Failed to rename the PDB file. The original PDB file for '%s' will be loaded.", path));
+				Error pdb_err = WindowsUtils::copy_and_rename_pdb(load_path);
+				if (pdb_err != OK && pdb_err != ERR_SKIP) {
+					WARN_PRINT(vformat("Failed to rename the PDB file. The original PDB file for '%s' will be loaded.", path));
+				}
+				break;
+			}
+
+			// This can often fail if the file is locked by another process.
+			WARN_PRINT(vformat("Error %d copying library '%s' to temporary location '%s'. Will try the next index.", copy_err, path, candidate_load_path));
 		}
 	}
 


### PR DESCRIPTION
- Failing to copy a DLL in `open_dynamic_library` now results in loading without copying rather than failing the extension load. This will prevent hot-reload, but is better than outright failure.
- Try to copy DLLs to a couple of numbered paths before giving up.
- Use is_extension_reloading_enabled() to control generate_temp_files rather than is_editor_hint()
- don't call set_extension_reloading_enabled(true) when run with --script parameter. Scripts often spawn processes quickly and can trigger the file locking issue. Also they're not normally interactive so enabling hot-reloading support by default is of dubious value.

Fixes #107089