### PR TITLE
Performance hoist more slow lookups

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -576,6 +576,13 @@ void Node3DEditorViewport::_update_navigation_controls_visibility() {
 	look_control->set_visible(show_viewport_navigation_gizmo);
 }
 
+void Node3DEditorViewport::_update_editor_settings() {
+	freelook_inertia = EDITOR_GET("editors/3d/freelook/freelook_inertia");
+	orbit_inertia = EDITOR_GET("editors/3d/navigation_feel/orbit_inertia");
+	translation_inertia = EDITOR_GET("editors/3d/navigation_feel/translation_inertia");
+	zoom_inertia = EDITOR_GET("editors/3d/navigation_feel/zoom_inertia");
+}
+
 bool Node3DEditorViewport::_is_rotation_arc_visible() const {
 	return _edit.mode == TRANSFORM_ROTATE && !Math::is_zero_approx(_edit.accumulated_rotation_angle) && _edit.gizmo_initiated;
 }
@@ -593,13 +600,11 @@ void Node3DEditorViewport::_update_camera(real_t p_interp_delta) {
 		if (is_freelook_active()) {
 			// Higher inertia should increase "lag" (lerp with factor between 0 and 1)
 			// Inertia of zero should produce instant movement (lerp with factor of 1) in this case it returns a really high value and gets clamped to 1.
-			const real_t inertia = EDITOR_GET("editors/3d/freelook/freelook_inertia");
-			real_t factor = (1.0 / inertia) * p_interp_delta;
+			real_t factor = (1.0 / freelook_inertia) * p_interp_delta;
 
 			// We interpolate a different point here, because in freelook mode the focus point (cursor.pos) orbits around eye_pos
 			camera_cursor.eye_pos = old_camera_cursor.eye_pos.lerp(cursor.eye_pos, CLAMP(factor, 0, 1));
 
-			const real_t orbit_inertia = EDITOR_GET("editors/3d/navigation_feel/orbit_inertia");
 			camera_cursor.x_rot = Math::lerp(old_camera_cursor.x_rot, cursor.x_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
 			camera_cursor.y_rot = Math::lerp(old_camera_cursor.y_rot, cursor.y_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
 
@@ -615,10 +620,6 @@ void Node3DEditorViewport::_update_camera(real_t p_interp_delta) {
 			camera_cursor.pos = camera_cursor.eye_pos + forward * camera_cursor.distance;
 
 		} else {
-			const real_t orbit_inertia = EDITOR_GET("editors/3d/navigation_feel/orbit_inertia");
-			const real_t translation_inertia = EDITOR_GET("editors/3d/navigation_feel/translation_inertia");
-			const real_t zoom_inertia = EDITOR_GET("editors/3d/navigation_feel/zoom_inertia");
-
 			camera_cursor.x_rot = Math::lerp(old_camera_cursor.x_rot, cursor.x_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
 			camera_cursor.y_rot = Math::lerp(old_camera_cursor.y_rot, cursor.y_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
 
@@ -3330,6 +3331,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 		case NOTIFICATION_READY: {
 			ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Node3DEditorViewport::_project_settings_changed));
+			_update_editor_settings();
 			_update_navigation_controls_visibility();
 		} break;
 
@@ -3719,6 +3721,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/3d")) {
+				_update_editor_settings();
 				_update_navigation_controls_visibility();
 			}
 		} break;
@@ -6564,6 +6567,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 
 	freelook_active = false;
 	freelook_speed = EDITOR_GET("editors/3d/freelook/freelook_base_speed");
+	_update_editor_settings();
 
 	selection_menu = memnew(PopupMenu);
 	add_child(selection_menu);

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -266,6 +266,10 @@ private:
 
 	bool freelook_active;
 	real_t freelook_speed;
+	real_t freelook_inertia = 0.0;
+	real_t orbit_inertia = 0.0;
+	real_t translation_inertia = 0.0;
+	real_t zoom_inertia = 0.0;
 	Vector2 previous_mouse_position;
 
 	PanelContainer *info_panel = nullptr;
@@ -478,6 +482,7 @@ private:
 
 	void _view_settings_confirmed(real_t p_interp_delta);
 	void _update_camera(real_t p_interp_delta);
+	void _update_editor_settings();
 	void _update_navigation_controls_visibility();
 	Transform3D to_camera_transform(const Cursor &p_cursor) const;
 	void _draw();

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1664,8 +1664,6 @@ void LineEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_FOCUS_ENTER: {
-			set_process_internal(caret_blink_enabled);
-
 			// Only allow editing if the LineEdit is not focused with arrow keys.
 			if (!(Input::get_singleton()->is_action_pressed("ui_up") || Input::get_singleton()->is_action_pressed("ui_down") || Input::get_singleton()->is_action_pressed("ui_left") || Input::get_singleton()->is_action_pressed("ui_right"))) {
 				_edit(virtual_keyboard_show_on_focus);
@@ -1674,8 +1672,6 @@ void LineEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_FOCUS_EXIT: {
-			set_process_internal(false);
-
 			if (editing) {
 				unedit();
 				emit_signal(SNAME("editing_toggled"), false);
@@ -2021,7 +2017,7 @@ void LineEdit::set_caret_blink_enabled(const bool p_enabled) {
 	}
 
 	caret_blink_enabled = p_enabled;
-	set_process_internal(p_enabled && has_focus());
+	set_process_internal(p_enabled);
 
 	draw_caret = !caret_blink_enabled;
 	if (caret_blink_enabled) {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1664,6 +1664,8 @@ void LineEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_FOCUS_ENTER: {
+			set_process_internal(caret_blink_enabled);
+
 			// Only allow editing if the LineEdit is not focused with arrow keys.
 			if (!(Input::get_singleton()->is_action_pressed("ui_up") || Input::get_singleton()->is_action_pressed("ui_down") || Input::get_singleton()->is_action_pressed("ui_left") || Input::get_singleton()->is_action_pressed("ui_right"))) {
 				_edit(virtual_keyboard_show_on_focus);
@@ -1672,6 +1674,8 @@ void LineEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_FOCUS_EXIT: {
+			set_process_internal(false);
+
 			if (editing) {
 				unedit();
 				emit_signal(SNAME("editing_toggled"), false);
@@ -2017,7 +2021,7 @@ void LineEdit::set_caret_blink_enabled(const bool p_enabled) {
 	}
 
 	caret_blink_enabled = p_enabled;
-	set_process_internal(p_enabled);
+	set_process_internal(p_enabled && has_focus());
 
 	draw_caret = !caret_blink_enabled;
 	if (caret_blink_enabled) {


### PR DESCRIPTION
Hoists more expensive lookups to a place where they will not burn cycles gratuitously.

Part of the https://github.com/godotengine/godot/issues/116845 process