### PR TITLE
Fix able to delete metadata on read-only object

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -4894,11 +4894,15 @@ void EditorInspector::update_tree() {
 				}
 
 				if (p.name.begins_with("metadata/")) {
-					Variant _default = Variant();
-					if (node != nullptr) {
-						_default = PropertyUtils::get_property_default_value(node, p.name, nullptr, &sstack, false, nullptr, nullptr);
+					if (property_read_only || all_read_only) {
+						ep->set_deletable(false);
+					} else {
+						Variant _default = Variant();
+						if (node != nullptr) {
+							_default = PropertyUtils::get_property_default_value(node, p.name, nullptr, &sstack, false, nullptr, nullptr);
+						}
+						ep->set_deletable(_default == Variant());
 					}
-					ep->set_deletable(_default == Variant());
 				} else {
 					ep->set_deletable(deletable_properties);
 				}


### PR DESCRIPTION
Closes #116842

This PR prevent deleting metadata when the object is in read only state.

I think about editing the EditorProperty so when it's set to read only it imply that you can't delete it. But since there is 2 flag I guess you can delete a read only property for some reasons. But in that case if it's read only you should now allow editing it.

Before / After side by side
<img width="367" height="676" alt="image" src="https://github.com/user-attachments/assets/26c52c65-a1e9-4cd3-afe5-eb97dc1cc280" /><img width="352" height="652" alt="image" src="https://github.com/user-attachments/assets/91769633-63d1-4019-a754-fceaf36815b4" />
