### PR TITLE
Fix different behavior between debug and release exports for invalid `await` on runtime null

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -814,10 +814,6 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 					Variant ret;
 					Variant::evaluate(op, *a, *b, ret, valid);
-#else
-					Variant::evaluate(op, *a, *b, *dst, valid);
-#endif
-#ifdef DEBUG_ENABLED
 					if (!valid) {
 						if (ret.get_type() == Variant::STRING) {
 							//return a string when invalid with the error
@@ -829,6 +825,11 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						OPCODE_BREAK;
 					}
 					*dst = ret;
+#else
+					Variant::evaluate(op, *a, *b, *dst, valid);
+					if (!valid) {
+						OPCODE_BREAK;
+					}
 #endif
 				}
 				ip += 7 + _pointer_size;
@@ -989,8 +990,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #else
 				dst->set(*index, *value, &valid);
 #endif
-#ifdef DEBUG_ENABLED
 				if (!valid) {
+#ifdef DEBUG_ENABLED
 					if (dst->is_read_only()) {
 						err_text = "Invalid assignment on read-only value (on base: '" + _get_var_type(dst) + "').";
 					} else {
@@ -1014,9 +1015,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 							}
 						}
 					}
+#endif
 					OPCODE_BREAK;
 				}
-#endif
+
 				ip += 4;
 			}
 			DISPATCH_OPCODE;
@@ -1035,8 +1037,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				bool valid;
 				setter(dst, index, value, &valid);
 
-#ifdef DEBUG_ENABLED
 				if (!valid) {
+#ifdef DEBUG_ENABLED
 					if (dst->is_read_only()) {
 						err_text = "Invalid assignment on read-only value (on base: '" + _get_var_type(dst) + "').";
 					} else {
@@ -1048,9 +1050,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						}
 						err_text = "Invalid assignment of property or key " + v + " with value of type '" + _get_var_type(value) + "' on a base object of type '" + _get_var_type(dst) + "'.";
 					}
+#endif
 					OPCODE_BREAK;
 				}
-#endif
+
 				ip += 5;
 			}
 			DISPATCH_OPCODE;
@@ -1071,8 +1074,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				bool oob;
 				setter(dst, int_index, value, &oob);
 
-#ifdef DEBUG_ENABLED
 				if (oob) {
+#ifdef DEBUG_ENABLED
 					if (dst->is_read_only()) {
 						err_text = "Invalid assignment on read-only value (on base: '" + _get_var_type(dst) + "').";
 					} else {
@@ -1084,9 +1087,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						}
 						err_text = "Out of bounds set index " + v + " (on base: '" + _get_var_type(dst) + "')";
 					}
+#endif
 					OPCODE_BREAK;
 				}
-#endif
+
 				ip += 5;
 			}
 			DISPATCH_OPCODE;
@@ -1105,7 +1109,9 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant ret = src->get(*index, &valid, &err_code);
 #else
 				*dst = src->get(*index, &valid);
-
+				if (!valid) {
+					OPCODE_BREAK;
+				}
 #endif
 #ifdef DEBUG_ENABLED
 				if (!valid) {
@@ -1143,10 +1149,6 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				// Allow better error message in cases where src and dst are the same stack position.
 				Variant ret;
 				getter(src, key, &ret, &valid);
-#else
-				getter(src, key, dst, &valid);
-#endif
-#ifdef DEBUG_ENABLED
 				if (!valid) {
 					String v = key->operator String();
 					if (!v.is_empty()) {
@@ -1158,6 +1160,11 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					OPCODE_BREAK;
 				}
 				*dst = ret;
+#else
+				getter(src, key, dst, &valid);
+				if (!valid) {
+					OPCODE_BREAK;
+				}
 #endif
 				ip += 5;
 			}
@@ -1179,8 +1186,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				bool oob;
 				getter(src, int_index, dst, &oob);
 
-#ifdef DEBUG_ENABLED
 				if (oob) {
+#ifdef DEBUG_ENABLED
 					String v = index->operator String();
 					if (!v.is_empty()) {
 						v = "'" + v + "'";
@@ -1188,9 +1195,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						v = "of type '" + _get_var_type(index) + "'";
 					}
 					err_text = "Out of bounds get index " + v + " (on base: '" + _get_var_type(src) + "')";
+#endif
 					OPCODE_BREAK;
 				}
-#endif
+
 				ip += 5;
 			}
 			DISPATCH_OPCODE;
@@ -1209,8 +1217,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				bool valid;
 				dst->set_named(*index, *value, valid);
 
-#ifdef DEBUG_ENABLED
 				if (!valid) {
+#ifdef DEBUG_ENABLED
 					if (dst->is_read_only()) {
 						err_text = "Invalid assignment on read-only value (on base: '" + _get_var_type(dst) + "').";
 					} else {
@@ -1225,9 +1233,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 							err_text = "Invalid assignment of property or key '" + String(*index) + "' with value of type '" + _get_var_type(value) + "' on a base object of type '" + _get_var_type(dst) + "'.";
 						}
 					}
+#endif
 					OPCODE_BREAK;
 				}
-#endif
+
 				ip += 4;
 			}
 			DISPATCH_OPCODE;
@@ -1262,16 +1271,16 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 				//allow better error message in cases where src and dst are the same stack position
 				Variant ret = src->get_named(*index, valid);
-
-#else
-				*dst = src->get_named(*index, valid);
-#endif
-#ifdef DEBUG_ENABLED
 				if (!valid) {
 					err_text = "Invalid access to property or key '" + index->operator String() + "' on a base object of type '" + _get_var_type(src) + "'.";
 					OPCODE_BREAK;
 				}
 				*dst = ret;
+#else
+				*dst = src->get_named(*index, valid);
+				if (!valid) {
+					OPCODE_BREAK;
+				}
 #endif
 				ip += 4;
 			}
@@ -1301,7 +1310,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				bool valid;
 #ifndef DEBUG_ENABLED
-				ClassDB::set_property(p_instance->owner, *index, *src, &valid);
+				bool ok = ClassDB::set_property(p_instance->owner, *index, *src, &valid);
+				if (!ok || !valid) {
+					OPCODE_BREAK;
+				}
 #else
 				bool ok = ClassDB::set_property(p_instance->owner, *index, *src, &valid);
 				if (!ok) {
@@ -1322,15 +1334,14 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				int indexname = _code_ptr[ip + 2];
 				GD_ERR_BREAK(indexname < 0 || indexname >= _global_names_count);
 				const StringName *index = &_global_names_ptr[indexname];
-#ifndef DEBUG_ENABLED
-				ClassDB::get_property(p_instance->owner, *index, *dst);
-#else
 				bool ok = ClassDB::get_property(p_instance->owner, *index, *dst);
 				if (!ok) {
+#ifndef DEBUG_ENABLED
 					err_text = "Internal error getting property: " + String(*index);
+#endif
 					OPCODE_BREAK;
 				}
-#endif
+
 				ip += 3;
 			}
 			DISPATCH_OPCODE;
@@ -1740,12 +1751,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Callable::CallError err;
 				Variant::construct(t, *dst, (const Variant **)argptrs, argc, err);
 
-#ifdef DEBUG_ENABLED
 				if (err.error != Callable::CallError::CALL_OK) {
+#ifdef DEBUG_ENABLED
 					err_text = _get_call_error("'" + Variant::get_type_name(t) + "' constructor", (const Variant **)argptrs, argc, *dst, err);
+#endif
 					OPCODE_BREAK;
 				}
-#endif
 
 				ip += 3;
 			}
@@ -1968,8 +1979,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					}
 					function_call_time += t_taken;
 				}
+#endif // DEBUG_ENABLED
 
 				if (err.error != Callable::CallError::CALL_OK) {
+#ifdef DEBUG_ENABLED
 					String methodstr = *methodname;
 					String basestr = _get_var_type(base);
 					bool is_callable = false;
@@ -2008,9 +2021,9 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					} else {
 						err_text = _get_call_error(vformat("function '%s' in base '%s'", methodstr, basestr), (const Variant **)argptrs, argc, temp_ret, err);
 					}
+#endif // DEBUG_ENABLED
 					OPCODE_BREAK;
 				}
-#endif // DEBUG_ENABLED
 
 				ip += 3;
 			}
@@ -2072,8 +2085,9 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					_profile_native_call(t_taken, method->get_name(), method->get_instance_class());
 					function_call_time += t_taken;
 				}
-
+#endif
 				if (err.error != Callable::CallError::CALL_OK) {
+#ifdef DEBUG_ENABLED
 					String methodstr = method->get_name();
 					String basestr = _get_var_type(base);
 
@@ -2096,9 +2110,9 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						}
 					}
 					err_text = _get_call_error("function '" + methodstr + "' in base '" + basestr + "'", (const Variant **)argptrs, argc, temp_ret, err);
+#endif
 					OPCODE_BREAK;
 				}
-#endif
 				ip += 3;
 			}
 			DISPATCH_OPCODE;
@@ -2128,12 +2142,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Callable::CallError err;
 				Variant::call_static(builtin_type, *methodname, argptrs, argc, *ret, err);
 
-#ifdef DEBUG_ENABLED
 				if (err.error != Callable::CallError::CALL_OK) {
+#ifdef DEBUG_ENABLED
 					err_text = _get_call_error("static function '" + methodname->operator String() + "' in type '" + Variant::get_type_name(builtin_type) + "'", argptrs, argc, *ret, err);
+#endif
 					OPCODE_BREAK;
 				}
-#endif
 
 				ip += 4;
 			}
@@ -2176,7 +2190,9 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #endif
 
 				if (err.error != Callable::CallError::CALL_OK) {
+#ifdef DEBUG_ENABLED
 					err_text = _get_call_error("static function '" + method->get_name().operator String() + "' in type '" + method->get_instance_class().operator String() + "'", argptrs, argc, *ret, err);
+#endif
 					OPCODE_BREAK;
 				}
 
@@ -2408,8 +2424,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Callable::CallError err;
 				Variant::call_utility_function(function, dst, (const Variant **)argptrs, argc, err);
 
-#ifdef DEBUG_ENABLED
 				if (err.error != Callable::CallError::CALL_OK) {
+#ifdef DEBUG_ENABLED
 					String methodstr = function;
 					if (dst->get_type() == Variant::STRING && !dst->operator String().is_empty()) {
 						// Call provided error string.
@@ -2417,9 +2433,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					} else {
 						err_text = _get_call_error(vformat(R"*(utility function "%s()")*", methodstr), (const Variant **)argptrs, argc, *dst, err);
 					}
+#endif
 					OPCODE_BREAK;
 				}
-#endif
+
 				ip += 3;
 			}
 			DISPATCH_OPCODE;
@@ -2465,8 +2482,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Callable::CallError err;
 				function(dst, (const Variant **)argptrs, argc, err);
 
-#ifdef DEBUG_ENABLED
 				if (err.error != Callable::CallError::CALL_OK) {
+#ifdef DEBUG_ENABLED
 					String methodstr = gds_utilities_names[_code_ptr[ip + 2]];
 					if (dst->get_type() == Variant::STRING && !dst->operator String().is_empty()) {
 						// Call provided error string.
@@ -2474,9 +2491,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					} else {
 						err_text = _get_call_error(vformat(R"*(GDScript utility function "%s()")*", methodstr), (const Variant **)argptrs, argc, *dst, err);
 					}
+#endif
 					OPCODE_BREAK;
 				}
-#endif
+
 				ip += 3;
 			}
 			DISPATCH_OPCODE;
@@ -2540,9 +2558,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				}
 
 				if (err.error != Callable::CallError::CALL_OK) {
+#ifdef DEBUG_ENABLED
 					String methodstr = *methodname;
 					err_text = _get_call_error("function '" + methodstr + "'", (const Variant **)argptrs, argc, *dst, err);
-
+#endif
 					OPCODE_BREAK;
 				}
 
@@ -2920,8 +2939,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(!nc);
 
 				if (r->get_type() != Variant::OBJECT && r->get_type() != Variant::NIL) {
+#ifdef DEBUG_ENABLED
 					err_text = vformat(R"(Trying to return value of type "%s" from a function whose return type is "%s".)",
 							Variant::get_type_name(r->get_type()), nc->get_name());
+#endif // DEBUG_ENABLED
 					OPCODE_BREAK;
 				}
 
@@ -3026,12 +3047,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				bool valid;
 				if (!container->iter_init(*counter, valid)) {
-#ifdef DEBUG_ENABLED
 					if (!valid) {
+#ifdef DEBUG_ENABLED
 						err_text = "Unable to iterate on object of type '" + Variant::get_type_name(container->get_type()) + "'.";
+#endif
 						OPCODE_BREAK;
 					}
-#endif
+
 					int jumpto = _code_ptr[ip + 4];
 					GD_ERR_BREAK(jumpto < 0 || jumpto > _code_size);
 					ip = jumpto;
@@ -3039,12 +3061,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					GET_VARIANT_PTR(iterator, 2);
 
 					*iterator = container->iter_get(*counter, valid);
-#ifdef DEBUG_ENABLED
 					if (!valid) {
+#ifdef DEBUG_ENABLED
 						err_text = "Unable to obtain iterator object of type '" + Variant::get_type_name(container->get_type()) + "'.";
+#endif
 						OPCODE_BREAK;
 					}
-#endif
 					ip += 5; // Skip regular iterate which is always next.
 				}
 			}
@@ -3364,12 +3386,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Callable::CallError ce;
 				Variant has_next = obj->callp(CoreStringName(_iter_init), args, 1, ce);
 
-#ifdef DEBUG_ENABLED
 				if (ref.size() != 1 || ce.error != Callable::CallError::CALL_OK) {
+#ifdef DEBUG_ENABLED
 					err_text = vformat(R"(There was an error calling "_iter_next" on iterator object of type %s.)", *container);
+#endif
 					OPCODE_BREAK;
 				}
-#endif
+
 				if (!has_next.booleanize()) {
 					int jumpto = _code_ptr[ip + 4];
 					GD_ERR_BREAK(jumpto < 0 || jumpto > _code_size);
@@ -3379,12 +3402,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 					GET_VARIANT_PTR(iterator, 2);
 					*iterator = obj->callp(CoreStringName(_iter_get), (const Variant **)&counter, 1, ce);
-#ifdef DEBUG_ENABLED
 					if (ce.error != Callable::CallError::CALL_OK) {
+#ifdef DEBUG_ENABLED
 						err_text = vformat(R"(There was an error calling "_iter_get" on iterator object of type %s.)", *container);
+#endif
 						OPCODE_BREAK;
 					}
-#endif
 
 					ip += 5; // Loop again.
 				}
@@ -3432,12 +3455,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				bool valid;
 				if (!container->iter_next(*counter, valid)) {
-#ifdef DEBUG_ENABLED
 					if (!valid) {
+#ifdef DEBUG_ENABLED
 						err_text = "Unable to iterate on object of type '" + Variant::get_type_name(container->get_type()) + "' (type changed since first iteration?).";
+#endif
 						OPCODE_BREAK;
 					}
-#endif
 					int jumpto = _code_ptr[ip + 4];
 					GD_ERR_BREAK(jumpto < 0 || jumpto > _code_size);
 					ip = jumpto;
@@ -3445,12 +3468,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					GET_VARIANT_PTR(iterator, 2);
 
 					*iterator = container->iter_get(*counter, valid);
-#ifdef DEBUG_ENABLED
 					if (!valid) {
+#ifdef DEBUG_ENABLED
 						err_text = "Unable to obtain iterator object of type '" + Variant::get_type_name(container->get_type()) + "' (but was obtained on first iteration?).";
+#endif
 						OPCODE_BREAK;
 					}
-#endif
+
 					ip += 5; //loop again
 				}
 			}
@@ -3730,12 +3754,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Callable::CallError ce;
 				Variant has_next = obj->callp(CoreStringName(_iter_next), args, 1, ce);
 
-#ifdef DEBUG_ENABLED
 				if (ref.size() != 1 || ce.error != Callable::CallError::CALL_OK) {
+#ifdef DEBUG_ENABLED
 					err_text = vformat(R"(There was an error calling "_iter_next" on iterator object of type %s.)", *container);
+#endif
 					OPCODE_BREAK;
 				}
-#endif
+
 				if (!has_next.booleanize()) {
 					int jumpto = _code_ptr[ip + 4];
 					GD_ERR_BREAK(jumpto < 0 || jumpto > _code_size);
@@ -3745,12 +3770,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 					GET_VARIANT_PTR(iterator, 2);
 					*iterator = obj->callp(CoreStringName(_iter_get), (const Variant **)&counter, 1, ce);
-#ifdef DEBUG_ENABLED
 					if (ce.error != Callable::CallError::CALL_OK) {
+#ifdef DEBUG_ENABLED
 						err_text = vformat(R"(There was an error calling "_iter_get" on iterator object of type %s.)", *container);
+#endif
 						OPCODE_BREAK;
 					}
-#endif
 
 					ip += 5; // Loop again.
 				}


### PR DESCRIPTION
- Fixes: https://github.com/godotengine/godot/issues/105153

## Result

**DEBUG** Build:
```
Start loop
ERROR: Parameter "data.tree" is null.
   at: get_tree (scene/main/node.h:485)
SCRIPT ERROR: Invalid access to property or key 'process_frame' on a base object of type 'null instance'.
          at: _process (res://node.gd:17)
```

**RELEASE** Build:
```
Start loop
ERROR: Parameter "data.tree" is null.
   at: Node::get_tree (.\scene/main/node.h:548)
```

<details>
<summary>GDScript code example</summary>

```gdscript
extends Node

var _run_loop = 5
# Setting this to true triggers the bug in this example.
var _remove_from_tree = true

func do_stuff():
	print("Did stuff")

func _process(delta):
	if _remove_from_tree and get_parent():
		get_parent().remove_child(self)

	print("Start loop")

	while _run_loop > 0:
		await get_tree().process_frame
		do_stuff()
		_run_loop -= 1

	print("End loop")
```

</details>

It's issue not about `await`. GDScript virtual machine behaves differently in `debug` and `release` exports. `Debug` stops code execution after error, but `release` sometimes doesn't check errors (and not stop). Solution is add checks for operations and terminate execution if an error occurs for `release` export too.

However, `release` export don't generate `SCRIPT ERROR`. Although, in my opinion, it would be nice to see `SCRIPT ERROR` in `release` export too. But I decided to maintain previous behavior.