### PR TITLE
Fix collision cache being out of date after adding a new setting

### DIFF
--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -857,6 +857,7 @@ void SpringBoneSimulator3D::set_setting_count(int p_count) {
 		}
 	}
 	notify_property_list_changed();
+	_make_collisions_dirty();
 }
 
 int SpringBoneSimulator3D::get_setting_count() const {


### PR DESCRIPTION
Closes #110274

The underlying problem was that the Spring Bone Simulator 3D was never initializing the `cached_collisions` of the newly created setting.

Simplified minimal reproduction:

1. Open the attached zip
2. Select the `SpringBoneSimulator3D` node in the `main` scene
3. Add new element to the `Settings` property
4. Set `Root Bone Name` to `Root`
5. Set `End Bone Name` to `Child`

Before the fix: the `Child` bone doesn't move out of the way of the child sphere
After the fix: the `Child` bone moves out of the way of the child sphere

[case_110274_mrp.zip](https://github.com/user-attachments/files/25621060/case_110274_mrp.zip)
