### PR TITLE
Allow using a struct name as a variable name in shaders

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -8022,7 +8022,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			}
 		}
 
-		bool is_struct = shader->structs.has(tk.text);
+		bool is_struct = shader->structs.has(tk.text) && !(p_block && _find_identifier(p_block, false, p_function_info, tk.text));
 		bool is_var_init = false;
 		bool is_condition = false;
 


### PR DESCRIPTION
I've detected and fix a small bug which prevent struct usage in case of its instance name are identical to a struct name:

<img width="1077" height="940" alt="изображение" src="https://github.com/user-attachments/assets/e7f81b66-f87e-4d21-aa2b-18f2f3fff7ac" />

