### PR TITLE
Fix project save crash

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1016,7 +1016,17 @@ void EditorNode::_notification(int p_what) {
 						ProjectSettings::get_singleton()->set_setting(initial_setting.key, initial_setting.value);
 					}
 				}
-				ProjectSettings::get_singleton()->save();
+				Error save_err = ProjectSettings::get_singleton()->save();
+				if (save_err != OK) {
+					// Trigger a native OS popup to warn the user
+					OS::get_singleton()->alert(
+						vformat(TTR("Error: Could not save the project at '%s'.\n\nPlease check your folder permissions. If you are on Windows, ensure Windows Defender 'Controlled Folder Access' is not blocking Godot.\n\nThe editor will now exit."), project_settings_path), 
+						TTR("Project Initialization Error")
+					);
+					
+					get_tree()->quit();
+					return; // Stop executing the rest of NOTIFICATION_READY
+		}
 			}
 
 			_titlebar_resized();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1020,13 +1020,11 @@ void EditorNode::_notification(int p_what) {
 				if (save_err != OK) {
 					// Trigger a native OS popup to warn the user
 					OS::get_singleton()->alert(
-						vformat(TTR("Error: Could not save the project at '%s'.\n\nPlease check your folder permissions. If you are on Windows, ensure Windows Defender 'Controlled Folder Access' is not blocking Godot.\n\nThe editor will now exit."), project_settings_path), 
-						TTR("Project Initialization Error")
-					);
-					
+							vformat(TTR("Error: Could not save the project at '%s'.\n\nPlease check your folder permissions. If you are on Windows, ensure Windows Defender 'Controlled Folder Access' is not blocking Godot.\n\nThe editor will now exit."), project_settings_path),
+							TTR("Project Initialization Error"));
 					get_tree()->quit();
 					return; // Stop executing the rest of NOTIFICATION_READY
-		}
+				}
 			}
 
 			_titlebar_resized();


### PR DESCRIPTION
Fixes #116431

**Description:**
When creating or opening a project in a directory protected by OS-level security (such as Windows Defender Controlled Folder Access), `ProjectSettings::get_singleton()->save()` returns an `ERR_UNAUTHORIZED` (or similar file I/O error). 

Previously, during `NOTIFICATION_READY` in `editor_node.cpp`, this return value was ignored. The engine would swallow the error and continue the boot sequence without a valid `project.godot` file or accessible `.godot/` cache directory. This resulted in a static editor state, leading to a massive cascade of file-access errors and eventual segfaults when trying to write filesystem caches or script documentation upon exit.

**The Fix:**
Added a check to capture the `Error` returned by the initial `ProjectSettings::get_singleton()->save()`. If the save fails (`!= OK`), the engine now intercepts the failure, triggers a native `OS::get_singleton()->alert()` to explicitly warn the user about folder permissions/antivirus blocking, and immediately calls `get_tree()->quit()` to cleanly abort the initialization before the editor can enter a corrupted state.

**Testing:**
- Enabled Windows Defender Controlled Folder Access.
- Attempted to open a project in a protected directory.
- Verified that the editor correctly halts, displays the native OS error dialog, and exits cleanly with code 0 upon acknowledgment, preventing any cascading cache errors.