### PR TITLE
Fix direct physics states observing outdated data when using separate physics thread

### DIFF
--- a/servers/physics_2d/physics_server_2d_wrap_mt.h
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.h
@@ -99,6 +99,7 @@ public:
 	//these work well, but should be used from the main thread only
 	bool shape_collide(RID p_shape_A, const Transform2D &p_xform_A, const Vector2 &p_motion_A, RID p_shape_B, const Transform2D &p_xform_B, const Vector2 &p_motion_B, Vector2 *r_results, int p_result_max, int &r_result_count) override {
 		ERR_FAIL_COND_V(!Thread::is_main_thread(), false);
+		command_queue.flush_if_pending();
 		return physics_server_2d->shape_collide(p_shape_A, p_xform_A, p_motion_A, p_shape_B, p_xform_B, p_motion_B, r_results, p_result_max, r_result_count);
 	}
 
@@ -114,6 +115,7 @@ public:
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectSpaceState2D *space_get_direct_state(RID p_space) override {
 		ERR_FAIL_COND_V(!Thread::is_main_thread(), nullptr);
+		command_queue.flush_if_pending();
 		return physics_server_2d->space_get_direct_state(p_space);
 	}
 
@@ -259,6 +261,8 @@ public:
 	FUNC3(body_set_force_integration_callback, RID, const Callable &, const Variant &);
 
 	bool body_collide_shape(RID p_body, int p_body_shape, RID p_shape, const Transform2D &p_shape_xform, const Vector2 &p_motion, Vector2 *r_results, int p_result_max, int &r_result_count) override {
+		ERR_FAIL_COND_V(!Thread::is_main_thread(), false);
+		command_queue.flush_if_pending();
 		return physics_server_2d->body_collide_shape(p_body, p_body_shape, p_shape, p_shape_xform, p_motion, r_results, p_result_max, r_result_count);
 	}
 
@@ -266,12 +270,14 @@ public:
 
 	bool body_test_motion(RID p_body, const MotionParameters &p_parameters, MotionResult *r_result = nullptr) override {
 		ERR_FAIL_COND_V(!Thread::is_main_thread(), false);
+		command_queue.flush_if_pending();
 		return physics_server_2d->body_test_motion(p_body, p_parameters, r_result);
 	}
 
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectBodyState2D *body_get_direct_state(RID p_body) override {
 		ERR_FAIL_COND_V(!Thread::is_main_thread(), nullptr);
+		command_queue.flush_if_pending();
 		return physics_server_2d->body_get_direct_state(p_body);
 	}
 

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -121,6 +121,7 @@ public:
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectSpaceState3D *space_get_direct_state(RID p_space) override {
 		ERR_FAIL_COND_V(!Thread::is_main_thread(), nullptr);
+		command_queue.flush_if_pending();
 		return physics_server_3d->space_get_direct_state(p_space);
 	}
 
@@ -273,12 +274,14 @@ public:
 
 	bool body_test_motion(RID p_body, const MotionParameters &p_parameters, MotionResult *r_result = nullptr) override {
 		ERR_FAIL_COND_V(!Thread::is_main_thread(), false);
+		command_queue.flush_if_pending();
 		return physics_server_3d->body_test_motion(p_body, p_parameters, r_result);
 	}
 
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectBodyState3D *body_get_direct_state(RID p_body) override {
 		ERR_FAIL_COND_V(!Thread::is_main_thread(), nullptr);
+		command_queue.flush_if_pending();
 		return physics_server_3d->body_get_direct_state(p_body);
 	}
 


### PR DESCRIPTION
Fixes #113270

I tried the reported issue on 4.4, and there I was getting raycast hits ~90% of the frames. On the latest versions, raycast misses 100% of the frames (except for the first frame).

I then tried bisecting it and arrived at pull request [109591](https://github.com/godotengine/godot/pull/109591).

After a bit more digging, the bug unfolds like this:
- Physics iteration begins
- Physics server is sync'ed and transforms are read back into nodes via `flush_queries`
- During readback, the `Area3D` gets a notification that its global transform has changed, and it sets the new transform to the server.
    - The transform changes because the `Area3D` is parented to a `RigidBody3D`
- One of the following then happens:
    1. Without threading, the new transform immediately propagates and updates the physics engine's query tree
    2. With threading, on latest versions, the command to update is queued up, but nothing happens as the server is paused
    3. With threading, on older versions, the command to update is queued up and starts executing at some point
- The `physics_process` callback is invoked and a raycast is performed
    1. Without threading, the raycast succeeds as the query tree is up to date
    2. With threading, on latest versions, the raycast misses as the query tree is out of date
    3. With threading, on older versions, the raycast sometimes misses and sometimes hits, based on how fast the physics thread is

The proposed change flushes any pending commands when retrieving direct state access. This is the same behavior as calling any other server function that returns a value. With the change, spatial queries and other direct state functions are able to operate on latest data.

It's still possible to perform a spatial query on an outdated tree by:
1. Getting a direct space state
2. Setting some transform to the server
3. Performing the spatial query

But this change at least covers the bug that occurs without using any low-level access.