### PR TITLE
GDScript: Deprecate `type_exists()` global function

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -133,7 +133,7 @@
 				- A constant from the [enum Variant.Type] enumeration, for example [constant TYPE_INT].
 				- An [Object]-derived class which exists in [ClassDB], for example [Node].
 				- A [Script] (you can use any class, including inner one).
-				Unlike the right operand of the [code]is[/code] operator, [param type] can be a non-constant value. The [code]is[/code] operator supports more features (such as typed arrays). Use the operator instead of this method if you do not need to check the type dynamically.
+				Unlike the right operand of the [code]is[/code] operator, [param type] can be a non-constant value. The [code]is[/code] operator supports more features (such as typed arrays and dictionaries). Use the operator instead of this method if you do not need to check the type dynamically.
 				[b]Examples:[/b]
 				[codeblock]
 				print(is_instance_of(a, TYPE_INT))
@@ -142,7 +142,7 @@
 				print(is_instance_of(a, MyClass.InnerClass))
 				[/codeblock]
 				[b]Note:[/b] If [param value] and/or [param type] are freed objects (see [method @GlobalScope.is_instance_valid]), or [param type] is not one of the above options, this method will raise a runtime error.
-				See also [method @GlobalScope.typeof], [method type_exists], [method Array.is_same_typed] (and other [Array] methods).
+				See also [method @GlobalScope.typeof], [method Object.is_class], [method Object.get_script], [method Array.is_same_typed] (and other [Array] methods), [method Dictionary.is_same_typed] (and other [Dictionary] methods).
 			</description>
 		</method>
 		<method name="len">
@@ -266,7 +266,7 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="type_exists">
+		<method name="type_exists" deprecated="Use [method ClassDB.class_exists] instead.">
 			<return type="bool" />
 			<param index="0" name="type" type="StringName" />
 			<description>

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -109,13 +109,13 @@ struct GDScriptUtilityFunctionsDefinitions {
 
 		Variant::construct(Variant::Type(type), *r_ret, p_args, 1, r_error);
 	}
-#endif // DISABLE_DEPRECATED
 
 	static inline void type_exists(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
 		DEBUG_VALIDATE_ARG_COUNT(1, 1);
 		DEBUG_VALIDATE_ARG_TYPE(0, Variant::STRING_NAME);
 		*r_ret = ClassDB::class_exists(*p_args[0]);
 	}
+#endif // DISABLE_DEPRECATED
 
 	static inline void _char(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
 		DEBUG_VALIDATE_ARG_COUNT(1, 1);
@@ -571,8 +571,8 @@ void GDScriptUtilityFunctions::register_functions() {
 	/* clang-format off */
 #ifndef DISABLE_DEPRECATED
 	REGISTER_FUNC( convert,        true,  RETVAR,             ARGS( ARGVAR("what"), ARGTYPE("type") ), false, varray(     ));
-#endif // DISABLE_DEPRECATED
 	REGISTER_FUNC( type_exists,    true,  RET(BOOL),          ARGS( ARG("type", STRING_NAME)        ), false, varray(     ));
+#endif // DISABLE_DEPRECATED
 	REGISTER_FUNC( _char,          true,  RET(STRING),        ARGS( ARG("code", INT)                ), false, varray(     ));
 	REGISTER_FUNC( ord,            true,  RET(INT),           ARGS( ARG("char", STRING)             ), false, varray(     ));
 	REGISTER_FUNC( range,          false, RET(ARRAY),         NOARGS,                                  true,  varray(     ));

--- a/modules/gdscript/tests/scripts/runtime/features/gdscript_utility_implicit_conversion.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/gdscript_utility_implicit_conversion.gd
@@ -6,7 +6,7 @@ func test():
 	print(var_to_str(COLOR))
 	print(var_to_str(color))
 
-	var string := "Node"
-	var string_name := &"Node"
-	print(type_exists(string))
-	print(type_exists(string_name))
+	var string := "A"
+	var string_name := &"A"
+	print(ord(string))
+	print(ord(string_name))

--- a/modules/gdscript/tests/scripts/runtime/features/gdscript_utility_implicit_conversion.out
+++ b/modules/gdscript/tests/scripts/runtime/features/gdscript_utility_implicit_conversion.out
@@ -1,5 +1,5 @@
 GDTEST_OK
 Color(1, 0, 0, 1)
 Color(1, 0, 0, 1)
-true
-true
+65
+65


### PR DESCRIPTION
This function is a full alias for the `ClassDB.class_exists()` method. It does not support `Variant` types or global custom classes.