### PR TITLE
Add `add_submenu_node_item` to POT generation

### DIFF
--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -450,6 +450,7 @@ GDScriptEditorTranslationParserPlugin::GDScriptEditorTranslationParserPlugin() {
 	first_arg_patterns.insert("add_radio_check_item");
 	first_arg_patterns.insert("add_separator");
 	first_arg_patterns.insert("add_submenu_item");
+	first_arg_patterns.insert("add_submenu_node_item");
 
 	second_arg_patterns.insert("set_tab_title");
 	second_arg_patterns.insert("add_icon_check_item");


### PR DESCRIPTION
This will add `PopupMenu.add_submenu_node_item`, introduced in #85477, to the POT generation. The labels are auto translated.