### PR TITLE
Use physical key locations for 2D editor zoom shortcuts

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -5658,34 +5658,34 @@ CanvasItemEditor::CanvasItemEditor() {
 	// To ensure that scripts can parse the list of shortcuts correctly, we have to define
 	// those shortcuts one by one. Define shortcut before using it (by EditorZoomWidget).
 	ED_SHORTCUT_ARRAY("canvas_item_editor/zoom_3.125_percent", TTRC("Zoom to 3.125%"),
-			{ int32_t(KeyModifierMask::SHIFT | Key::KEY_5), int32_t(KeyModifierMask::SHIFT | Key::KP_5) });
+			{ int32_t(KeyModifierMask::SHIFT | Key::KEY_5), int32_t(KeyModifierMask::SHIFT | Key::KP_5) }, true);
 
 	ED_SHORTCUT_ARRAY("canvas_item_editor/zoom_6.25_percent", TTRC("Zoom to 6.25%"),
-			{ int32_t(KeyModifierMask::SHIFT | Key::KEY_4), int32_t(KeyModifierMask::SHIFT | Key::KP_4) });
+			{ int32_t(KeyModifierMask::SHIFT | Key::KEY_4), int32_t(KeyModifierMask::SHIFT | Key::KP_4) }, true);
 
 	ED_SHORTCUT_ARRAY("canvas_item_editor/zoom_12.5_percent", TTRC("Zoom to 12.5%"),
-			{ int32_t(KeyModifierMask::SHIFT | Key::KEY_3), int32_t(KeyModifierMask::SHIFT | Key::KP_3) });
+			{ int32_t(KeyModifierMask::SHIFT | Key::KEY_3), int32_t(KeyModifierMask::SHIFT | Key::KP_3) }, true);
 
 	ED_SHORTCUT_ARRAY("canvas_item_editor/zoom_25_percent", TTRC("Zoom to 25%"),
-			{ int32_t(KeyModifierMask::SHIFT | Key::KEY_2), int32_t(KeyModifierMask::SHIFT | Key::KP_2) });
+			{ int32_t(KeyModifierMask::SHIFT | Key::KEY_2), int32_t(KeyModifierMask::SHIFT | Key::KP_2) }, true);
 
 	ED_SHORTCUT_ARRAY("canvas_item_editor/zoom_50_percent", TTRC("Zoom to 50%"),
-			{ int32_t(KeyModifierMask::SHIFT | Key::KEY_1), int32_t(KeyModifierMask::SHIFT | Key::KP_1) });
+			{ int32_t(KeyModifierMask::SHIFT | Key::KEY_1), int32_t(KeyModifierMask::SHIFT | Key::KP_1) }, true);
 
 	ED_SHORTCUT_ARRAY("canvas_item_editor/zoom_100_percent", TTRC("Zoom to 100%"),
-			{ int32_t(Key::KEY_1), int32_t(KeyModifierMask::CMD_OR_CTRL | Key::KEY_0), int32_t(Key::KP_1), int32_t(KeyModifierMask::CMD_OR_CTRL | Key::KP_0) });
+			{ int32_t(Key::KEY_1), int32_t(KeyModifierMask::CMD_OR_CTRL | Key::KEY_0), int32_t(Key::KP_1), int32_t(KeyModifierMask::CMD_OR_CTRL | Key::KP_0) }, true);
 
 	ED_SHORTCUT_ARRAY("canvas_item_editor/zoom_200_percent", TTRC("Zoom to 200%"),
-			{ int32_t(Key::KEY_2), int32_t(Key::KP_2) });
+			{ int32_t(Key::KEY_2), int32_t(Key::KP_2) }, true);
 
 	ED_SHORTCUT_ARRAY("canvas_item_editor/zoom_400_percent", TTRC("Zoom to 400%"),
-			{ int32_t(Key::KEY_3), int32_t(Key::KP_3) });
+			{ int32_t(Key::KEY_3), int32_t(Key::KP_3) }, true);
 
 	ED_SHORTCUT_ARRAY("canvas_item_editor/zoom_800_percent", TTRC("Zoom to 800%"),
-			{ int32_t(Key::KEY_4), int32_t(Key::KP_4) });
+			{ int32_t(Key::KEY_4), int32_t(Key::KP_4) }, true);
 
 	ED_SHORTCUT_ARRAY("canvas_item_editor/zoom_1600_percent", TTRC("Zoom to 1600%"),
-			{ int32_t(Key::KEY_5), int32_t(Key::KP_5) });
+			{ int32_t(Key::KEY_5), int32_t(Key::KP_5) }, true);
 
 	HBoxContainer *controls_hb = memnew(HBoxContainer);
 	controls_vb->add_child(controls_hb);


### PR DESCRIPTION
- Related to https://github.com/godotengine/godot/pull/64392.

This ensures the shortcuts work on any keyboard layout. Tested on Linux/X11 with the `fr-oss` layout.

## Preview

Note that numpad inputs don't show `- Physical` next to them, as none of the keys involved differ according to the keyboard layout.

<img width="696" height="285" alt="image" src="https://github.com/user-attachments/assets/c53acd7c-9a62-4cb2-8ec4-2a84c4827805" />
