### PR TITLE
Fix 3D editor overlay not redrawing on camera navigation

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2522,6 +2522,7 @@ void Node3DEditorViewport::_cursor_interpolated() {
 	rotation_control->queue_redraw();
 	position_control->queue_redraw();
 	look_control->queue_redraw();
+	surface->queue_redraw();
 	spatial_editor->update_grid();
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
-->

Fixes: https://github.com/godotengine/godot/issues/116887

We need to redraw the overlay when the camera is navigating. 

https://github.com/user-attachments/assets/2dbdb497-7306-428c-941f-69ecb99d3f20

