### PR TITLE
Emit MultiplayerPeer.peer_disconnected when force == true

### DIFF
--- a/doc/classes/MultiplayerPeer.xml
+++ b/doc/classes/MultiplayerPeer.xml
@@ -23,7 +23,7 @@
 			<param index="0" name="peer" type="int" />
 			<param index="1" name="force" type="bool" default="false" />
 			<description>
-				Disconnects the given [param peer] from this host. If [param force] is [code]true[/code] the [signal peer_disconnected] signal will not be emitted for this peer.
+				Disconnects the given [param peer] from this host.
 			</description>
 		</method>
 		<method name="generate_unique_id" qualifiers="const">

--- a/modules/enet/enet_multiplayer_peer.cpp
+++ b/modules/enet/enet_multiplayer_peer.cpp
@@ -280,6 +280,7 @@ void ENetMultiplayerPeer::disconnect_peer(int p_peer, bool p_force) {
 		if (hosts.has(p_peer)) {
 			hosts.erase(p_peer);
 		}
+		emit_signal(SNAME("peer_disconnected"), p_peer);
 		if (active_mode == MODE_CLIENT) {
 			hosts.clear(); // Avoid flushing again.
 			close();

--- a/modules/webrtc/webrtc_multiplayer_peer.cpp
+++ b/modules/webrtc/webrtc_multiplayer_peer.cpp
@@ -346,6 +346,7 @@ void WebRTCMultiplayerPeer::disconnect_peer(int p_peer_id, bool p_force) {
 	ERR_FAIL_COND(!peer_map.has(p_peer_id));
 	if (p_force) {
 		peer_map.erase(p_peer_id);
+		emit_signal(SNAME("peer_disconnected"), p_peer_id);
 		if (network_mode == MODE_CLIENT && p_peer_id == TARGET_PEER_SERVER) {
 			connection_status = CONNECTION_DISCONNECTED;
 		}

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -484,6 +484,7 @@ void WebSocketMultiplayerPeer::disconnect_peer(int p_peer_id, bool p_force) {
 	peers_map[p_peer_id]->close();
 	if (p_force) {
 		peers_map.erase(p_peer_id);
+		emit_signal(SNAME("peer_disconnected"), p_peer_id);
 		if (!is_server()) {
 			_clear();
 		}


### PR DESCRIPTION
I don't know why the signal was intentionally not being emitted when p_force == true but it causes problems and honestly doesn't make sense to me. If you forcefully disconnect a peer then any callbacks waiting for a player to disconnect will never be called.

Probably fixes https://github.com/godotengine/godot/issues/108716