### PR TITLE
Do not block peer_disconnected signal upon calling disconnect_peer

### DIFF
--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -426,11 +426,7 @@ void SceneMultiplayer::_del_peer(int p_id) {
 
 void SceneMultiplayer::disconnect_peer(int p_id) {
 	ERR_FAIL_COND(multiplayer_peer.is_null() || multiplayer_peer->get_connection_status() != MultiplayerPeer::CONNECTION_CONNECTED);
-	// Block signals to avoid emitting peer_disconnected.
-	bool blocking = is_blocking_signals();
-	set_block_signals(true);
 	_del_peer(p_id);
-	set_block_signals(blocking);
 	multiplayer_peer->disconnect_peer(p_id);
 }
 


### PR DESCRIPTION
This logic seems to have been added in order to preserve old behaviour in https://github.com/godotengine/godot/pull/91011 , but it just seems to cause inconsistencies for any systems listening for MultiplayerAPI.peer_disconnected. It's also confusing because it's not documented anywhere. If you wanted to keep this behaviour you could manually call `set_block_signals()` yourself.