### PR TITLE
Move disconnect_peer from SceneMultiplayer to MultiplayerAPI

### DIFF
--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -18,6 +18,13 @@
 				Returns a new instance of the default MultiplayerAPI.
 			</description>
 		</method>
+		<method name="disconnect_peer">
+			<return type="void" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Disconnects the peer identified by [param id], closing the underlying connection with it.
+			</description>
+		</method>
 		<method name="get_default_interface" qualifiers="static">
 			<return type="StringName" />
 			<description>

--- a/doc/classes/MultiplayerAPIExtension.xml
+++ b/doc/classes/MultiplayerAPIExtension.xml
@@ -82,6 +82,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_disconnect_peer" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Callback for [method MultiplayerAPI.disconnect_peer].
+			</description>
+		</method>
 		<method name="_get_multiplayer_peer" qualifiers="virtual">
 			<return type="MultiplayerPeer" />
 			<description>

--- a/misc/extension_api_validation/4.6-stable/GH-116914.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-116914.txt
@@ -1,0 +1,5 @@
+GH-116914
+---------
+Validate extension JSON: API was removed: classes/SceneMultiplayer/methods/disconnect_peer
+
+Method has been moved to parent class, error is a false-positive.

--- a/modules/multiplayer/doc_classes/SceneMultiplayer.xml
+++ b/modules/multiplayer/doc_classes/SceneMultiplayer.xml
@@ -24,14 +24,7 @@
 			<param index="0" name="id" type="int" />
 			<description>
 				Mark the authentication step as completed for the remote peer identified by [param id]. The [signal MultiplayerAPI.peer_connected] signal will be emitted for this peer once the remote side also completes the authentication. No further authentication messages are expected to be received from this peer.
-				If a peer disconnects before completing authentication, either due to a network issue, the [member auth_timeout] expiring, or manually calling [method disconnect_peer], the [signal peer_authentication_failed] signal will be emitted instead of [signal MultiplayerAPI.peer_disconnected].
-			</description>
-		</method>
-		<method name="disconnect_peer">
-			<return type="void" />
-			<param index="0" name="id" type="int" />
-			<description>
-				Disconnects the peer identified by [param id], removing it from the list of connected peers, and closing the underlying connection with it.
+				If a peer disconnects before completing authentication, either due to a network issue, the [member auth_timeout] expiring, or manually calling [method MultiplayerAPI.disconnect_peer], the [signal peer_authentication_failed] signal will be emitted instead of [signal MultiplayerAPI.peer_disconnected].
 			</description>
 		</method>
 		<method name="get_authenticating_peers">

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -638,8 +638,6 @@ void SceneMultiplayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_root_path"), &SceneMultiplayer::get_root_path);
 	ClassDB::bind_method(D_METHOD("clear"), &SceneMultiplayer::clear);
 
-	ClassDB::bind_method(D_METHOD("disconnect_peer", "id"), &SceneMultiplayer::disconnect_peer);
-
 	ClassDB::bind_method(D_METHOD("get_authenticating_peers"), &SceneMultiplayer::get_authenticating_peer_ids);
 	ClassDB::bind_method(D_METHOD("send_auth", "id", "data"), &SceneMultiplayer::send_auth);
 	ClassDB::bind_method(D_METHOD("complete_auth", "id"), &SceneMultiplayer::complete_auth);

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -162,13 +162,13 @@ public:
 	virtual Error object_configuration_add(Object *p_obj, Variant p_config) override;
 	virtual Error object_configuration_remove(Object *p_obj, Variant p_config) override;
 
+	void disconnect_peer(int p_id) override;
+
 	void clear();
 
 	// Usually from object_configuration_add/remove
 	void set_root_path(const NodePath &p_path);
 	NodePath get_root_path() const;
-
-	void disconnect_peer(int p_id);
 
 	Error send_auth(int p_to, Vector<uint8_t> p_bytes);
 	Error complete_auth(int p_peer);

--- a/scene/main/multiplayer_api.cpp
+++ b/scene/main/multiplayer_api.cpp
@@ -295,6 +295,7 @@ void MultiplayerAPI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("rpc", "peer", "object", "method", "arguments"), &MultiplayerAPI::_rpc_bind, DEFVAL(Array()));
 	ClassDB::bind_method(D_METHOD("object_configuration_add", "object", "configuration"), &MultiplayerAPI::object_configuration_add);
 	ClassDB::bind_method(D_METHOD("object_configuration_remove", "object", "configuration"), &MultiplayerAPI::object_configuration_remove);
+	ClassDB::bind_method(D_METHOD("disconnect_peer", "id"), &MultiplayerAPI::disconnect_peer);
 
 	ClassDB::bind_method(D_METHOD("get_peers"), &MultiplayerAPI::get_peer_ids);
 
@@ -376,6 +377,10 @@ Error MultiplayerAPIExtension::object_configuration_remove(Object *p_object, Var
 	return err;
 }
 
+void MultiplayerAPIExtension::disconnect_peer(int p_id) {
+	GDVIRTUAL_CALL(_disconnect_peer, p_id);
+}
+
 void MultiplayerAPIExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_poll);
 	GDVIRTUAL_BIND(_set_multiplayer_peer, "multiplayer_peer");
@@ -386,4 +391,5 @@ void MultiplayerAPIExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_remote_sender_id);
 	GDVIRTUAL_BIND(_object_configuration_add, "object", "configuration");
 	GDVIRTUAL_BIND(_object_configuration_remove, "object", "configuration");
+	GDVIRTUAL_BIND(_disconnect_peer, "id");
 }

--- a/scene/main/multiplayer_api.h
+++ b/scene/main/multiplayer_api.h
@@ -71,6 +71,8 @@ public:
 	virtual Error object_configuration_add(Object *p_object, Variant p_config) = 0;
 	virtual Error object_configuration_remove(Object *p_object, Variant p_config) = 0;
 
+	virtual void disconnect_peer(int p_id) = 0;
+
 	bool has_multiplayer_peer() { return get_multiplayer_peer().is_valid(); }
 	bool is_server() { return get_unique_id() == MultiplayerPeer::TARGET_PEER_SERVER; }
 
@@ -98,6 +100,8 @@ public:
 	virtual Error object_configuration_add(Object *p_object, Variant p_config) override;
 	virtual Error object_configuration_remove(Object *p_object, Variant p_config) override;
 
+	virtual void disconnect_peer(int p_id) override;
+
 	// Extensions
 	GDVIRTUAL0R(Error, _poll);
 	GDVIRTUAL1(_set_multiplayer_peer, Ref<MultiplayerPeer>);
@@ -108,4 +112,5 @@ public:
 	GDVIRTUAL0RC(int, _get_remote_sender_id);
 	GDVIRTUAL2R(Error, _object_configuration_add, Object *, Variant);
 	GDVIRTUAL2R(Error, _object_configuration_remove, Object *, Variant);
+	GDVIRTUAL1(_disconnect_peer, int);
 };


### PR DESCRIPTION
This is another method which feels like it should be a standard feature of MultiplayerAPI instead of just SceneMultiplayer because it basically just calls `MultiplayerPeer.disconnect_peer()` and MultiplayerAPI is dependent on MultiplayerPeer already.