### PR TITLE
Add 'layer_mask' property to 'Material'

### DIFF
--- a/doc/classes/Material.xml
+++ b/doc/classes/Material.xml
@@ -18,6 +18,12 @@
 				Only exposed for the purpose of overriding. You cannot call this function directly. Used internally to determine if [member next_pass] should be shown in the editor or not.
 			</description>
 		</method>
+		<method name="_can_use_layer_mask" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Only exposed for the purpose of overriding. You cannot call this function directly. Used internally to determine if [member layer_mask] should be shown in the editor or not.
+			</description>
+		</method>
 		<method name="_can_use_render_priority" qualifiers="virtual const">
 			<return type="bool" />
 			<description>
@@ -42,14 +48,32 @@
 				Creates a placeholder version of this resource ([PlaceholderMaterial]).
 			</description>
 		</method>
+		<method name="get_layer_mask_value" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="layer_number" type="int" />
+			<description>
+				Returns whether or not the specified layer of the [member layer_mask] is enabled, given a [param layer_number] between 1 and 20.
+			</description>
+		</method>
 		<method name="inspect_native_shader_code">
 			<return type="void" />
 			<description>
 				Only available when running in the editor. Opens a popup that visualizes the generated shader code, including all variants and internal shader code. See also [method Shader.inspect_native_shader_code].
 			</description>
 		</method>
+		<method name="set_layer_mask_value">
+			<return type="void" />
+			<param index="0" name="layer_number" type="int" />
+			<param index="1" name="value" type="bool" />
+			<description>
+				Based on [param value], enables or disables the specified layer in the [member layer_mask], given a [param layer_number] between 1 and 20.
+			</description>
+		</method>
 	</methods>
 	<members>
+		<member name="layer_mask" type="int" setter="set_layer_mask" getter="get_layer_mask">
+			The render layer(s) this [Material] will render to. This material will only be visible for [Camera3D]s whose cull mask includes any of the render layers included in this layer mask.
+		</member>
 		<member name="next_pass" type="Material" setter="set_next_pass" getter="get_next_pass">
 			Sets the [Material] to be used for the next pass. This renders the object again using a different material.
 			[b]Note:[/b] [member next_pass] materials are not necessarily drawn immediately after the source [Material]. Draw order is determined by material properties, [member render_priority], and distance to camera.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2354,6 +2354,14 @@
 				Returns the value of a certain material's parameter.
 			</description>
 		</method>
+		<method name="material_set_layer_mask">
+			<return type="void" />
+			<param index="0" name="material" type="RID" />
+			<param index="1" name="layer_mask" type="int" />
+			<description>
+				Sets a material's layer mask.
+			</description>
+		</method>
 		<method name="material_set_next_pass">
 			<return type="void" />
 			<param index="0" name="material" type="RID" />

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1411,6 +1411,11 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 		}
 
 		while (surf) {
+			if ((p_pass_mode == PASS_MODE_COLOR || p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) && !(surf->material->layer_mask & p_render_data->camera_visible_layers)) {
+				surf = surf->next;
+				continue;
+			}
+
 			// LOD
 
 			if (p_render_data->screen_mesh_lod_threshold > 0.0 && mesh_storage->mesh_surface_has_lod(surf->surface)) {

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2310,6 +2310,7 @@ void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
 				material->data->self = material->self;
 				material->data->set_next_pass(material->next_pass);
 				material->data->set_render_priority(material->priority);
+				material->data->set_layer_mask(material->layer_mask);
 			}
 			material->shader_mode = new_mode;
 		}
@@ -2508,6 +2509,7 @@ void MaterialStorage::material_set_shader(RID p_material, RID p_shader) {
 	material->data->self = p_material;
 	material->data->set_next_pass(material->next_pass);
 	material->data->set_render_priority(material->priority);
+	material->data->set_layer_mask(material->layer_mask);
 	//updating happens later
 	material->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MATERIAL);
 	_material_queue_update(material, true, true);
@@ -2567,6 +2569,17 @@ void MaterialStorage::material_set_render_priority(RID p_material, int priority)
 	material->priority = priority;
 	if (material->data) {
 		material->data->set_render_priority(priority);
+	}
+	material->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MATERIAL);
+}
+
+void MaterialStorage::material_set_layer_mask(RID p_material, uint32_t p_layer_mask) {
+	GLES3::Material *material = material_owner.get_or_null(p_material);
+	ERR_FAIL_NULL(material);
+
+	material->layer_mask = p_layer_mask;
+	if (material->data) {
+		material->data->set_layer_mask(p_layer_mask);
 	}
 	material->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MATERIAL);
 }
@@ -3246,6 +3259,10 @@ void SceneMaterialData::set_render_priority(int p_priority) {
 
 void SceneMaterialData::set_next_pass(RID p_pass) {
 	next_pass = p_pass;
+}
+
+void SceneMaterialData::set_layer_mask(uint32_t p_layer_mask) {
+	layer_mask = p_layer_mask;
 }
 
 void SceneMaterialData::update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty) {

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -91,6 +91,7 @@ struct MaterialData {
 
 	virtual void set_render_priority(int p_priority) = 0;
 	virtual void set_next_pass(RID p_pass) = 0;
+	virtual void set_layer_mask(uint32_t p_layer_mask) = 0;
 	virtual void update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty) = 0;
 	virtual void bind_uniforms() = 0;
 	virtual ~MaterialData();
@@ -126,6 +127,7 @@ struct Material {
 	HashMap<StringName, Variant> params;
 	int32_t priority = 0;
 	RID next_pass;
+	uint32_t layer_mask = 0xFFFFFFFF;
 	SelfList<Material> update_element;
 
 	Dependency dependency;
@@ -187,6 +189,7 @@ struct CanvasMaterialData : public MaterialData {
 
 	virtual void set_render_priority(int p_priority) {}
 	virtual void set_next_pass(RID p_pass) {}
+	virtual void set_layer_mask(uint32_t p_layer_mask) {}
 	virtual void update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty);
 	virtual void bind_uniforms();
 	virtual ~CanvasMaterialData();
@@ -232,6 +235,7 @@ struct SkyMaterialData : public MaterialData {
 
 	virtual void set_render_priority(int p_priority) {}
 	virtual void set_next_pass(RID p_pass) {}
+	virtual void set_layer_mask(uint32_t p_layer_mask) {}
 	virtual void update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty);
 	virtual void bind_uniforms();
 	virtual ~SkyMaterialData();
@@ -366,8 +370,10 @@ struct SceneMaterialData : public MaterialData {
 	uint32_t index = 0;
 	RID next_pass;
 	uint8_t priority = 0;
+	uint32_t layer_mask = 0xFFFFFFFF;
 	virtual void set_render_priority(int p_priority);
 	virtual void set_next_pass(RID p_pass);
+	virtual void set_layer_mask(uint32_t p_layer_mask);
 	virtual void update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty);
 	virtual void bind_uniforms();
 	virtual ~SceneMaterialData();
@@ -418,6 +424,7 @@ struct ParticleProcessMaterialData : public MaterialData {
 
 	virtual void set_render_priority(int p_priority) {}
 	virtual void set_next_pass(RID p_pass) {}
+	virtual void set_layer_mask(uint32_t p_layer_mask) {}
 	virtual void update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty);
 	virtual void bind_uniforms();
 	virtual ~ParticleProcessMaterialData();
@@ -464,6 +471,7 @@ struct TexBlitMaterialData : public MaterialData {
 
 	virtual void set_render_priority(int p_priority) {}
 	virtual void set_next_pass(RID p_pass) {}
+	virtual void set_layer_mask(uint32_t p_layer_mask) {}
 	virtual void update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty);
 	virtual void bind_uniforms();
 	virtual ~TexBlitMaterialData();
@@ -684,6 +692,7 @@ public:
 
 	virtual void material_set_next_pass(RID p_material, RID p_next_material) override;
 	virtual void material_set_render_priority(RID p_material, int priority) override;
+	virtual void material_set_layer_mask(RID p_material, uint32_t p_layer_mask) override;
 
 	virtual bool material_is_animated(RID p_material) override;
 	virtual bool material_casts_shadows(RID p_material) override;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -81,6 +81,36 @@ int Material::get_render_priority() const {
 	return render_priority;
 }
 
+void Material::set_layer_mask(uint32_t p_layer_mask) {
+	layer_mask = p_layer_mask;
+
+	if (material.is_valid()) {
+		RS::get_singleton()->material_set_layer_mask(material, p_layer_mask);
+	}
+}
+
+uint32_t Material::get_layer_mask() const {
+	return layer_mask;
+}
+
+void Material::set_layer_mask_value(int p_layer_number, bool p_value) {
+	ERR_FAIL_COND_MSG(p_layer_number < 1, "Render layer number must be between 1 and 20 inclusive.");
+	ERR_FAIL_COND_MSG(p_layer_number > 20, "Render layer number must be between 1 and 20 inclusive.");
+	uint32_t mask = get_layer_mask();
+	if (p_value) {
+		mask |= 1 << (p_layer_number - 1);
+	} else {
+		mask &= ~(1 << (p_layer_number - 1));
+	}
+	set_layer_mask(mask);
+}
+
+bool Material::get_layer_mask_value(int p_layer_number) const {
+	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Render layer number must be between 1 and 20 inclusive.");
+	ERR_FAIL_COND_V_MSG(p_layer_number > 20, false, "Render layer number must be between 1 and 20 inclusive.");
+	return layer_mask & (1 << (p_layer_number - 1));
+}
+
 RID Material::get_rid() const {
 	return material;
 }
@@ -89,6 +119,8 @@ void Material::_validate_property(PropertyInfo &p_property) const {
 	if (!_can_do_next_pass() && p_property.name == "next_pass") {
 		p_property.usage = PROPERTY_USAGE_NONE;
 	} else if (!_can_use_render_priority() && p_property.name == "render_priority") {
+		p_property.usage = PROPERTY_USAGE_NONE;
+	} else if (!_can_use_layer_mask() && p_property.name == "layer_mask") {
 		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 }
@@ -150,6 +182,12 @@ bool Material::_can_use_render_priority() const {
 	return ret;
 }
 
+bool Material::_can_use_layer_mask() const {
+	bool ret = false;
+	GDVIRTUAL_CALL(_can_use_layer_mask, ret);
+	return ret;
+}
+
 Ref<Resource> Material::create_placeholder() const {
 	Ref<PlaceholderMaterial> placeholder;
 	placeholder.instantiate();
@@ -163,12 +201,18 @@ void Material::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_render_priority", "priority"), &Material::set_render_priority);
 	ClassDB::bind_method(D_METHOD("get_render_priority"), &Material::get_render_priority);
 
+	ClassDB::bind_method(D_METHOD("set_layer_mask", "mask"), &Material::set_layer_mask);
+	ClassDB::bind_method(D_METHOD("get_layer_mask"), &Material::get_layer_mask);
+	ClassDB::bind_method(D_METHOD("set_layer_mask_value", "layer_number", "value"), &Material::set_layer_mask_value);
+	ClassDB::bind_method(D_METHOD("get_layer_mask_value", "layer_number"), &Material::get_layer_mask_value);
+
 	ClassDB::bind_method(D_METHOD("inspect_native_shader_code"), &Material::inspect_native_shader_code);
 	ClassDB::set_method_flags(get_class_static(), StringName("inspect_native_shader_code"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 
 	ClassDB::bind_method(D_METHOD("create_placeholder"), &Material::create_placeholder);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_priority", PROPERTY_HINT_RANGE, itos(RENDER_PRIORITY_MIN) + "," + itos(RENDER_PRIORITY_MAX) + ",1"), "set_render_priority", "get_render_priority");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "layer_mask", PROPERTY_HINT_LAYERS_3D_RENDER), "set_layer_mask", "get_layer_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "next_pass", PROPERTY_HINT_RESOURCE_TYPE, Material::get_class_static()), "set_next_pass", "get_next_pass");
 
 	BIND_CONSTANT(RENDER_PRIORITY_MAX);
@@ -178,10 +222,12 @@ void Material::_bind_methods() {
 	GDVIRTUAL_BIND(_get_shader_mode)
 	GDVIRTUAL_BIND(_can_do_next_pass)
 	GDVIRTUAL_BIND(_can_use_render_priority)
+	GDVIRTUAL_BIND(_can_use_layer_mask)
 }
 
 Material::Material() {
 	render_priority = 0;
+	layer_mask = 0xFFFFFFFF;
 }
 
 Material::~Material() {
@@ -505,6 +551,7 @@ void ShaderMaterial::_check_material_rid() const {
 		}
 
 		_set_material(RS::get_singleton()->material_create_from_shader(next_pass_rid, get_render_priority(), shader_rid));
+		RS::get_singleton()->material_set_layer_mask(_get_material(), get_layer_mask());
 
 		for (KeyValue<StringName, Variant> param : param_cache) {
 			if (param.value.get_type() == Variant::OBJECT) {
@@ -551,6 +598,10 @@ bool ShaderMaterial::_can_do_next_pass() const {
 }
 
 bool ShaderMaterial::_can_use_render_priority() const {
+	return shader.is_valid() && shader->get_mode() == Shader::MODE_SPATIAL;
+}
+
+bool ShaderMaterial::_can_use_layer_mask() const {
 	return shader.is_valid() && shader->get_mode() == Shader::MODE_SPATIAL;
 }
 
@@ -2107,6 +2158,7 @@ void BaseMaterial3D::_check_material_rid() {
 		}
 
 		_set_material(RS::get_singleton()->material_create_from_shader(next_pass_rid, get_render_priority(), shader_rid));
+		RS::get_singleton()->material_set_layer_mask(_get_material(), get_layer_mask());
 
 		for (KeyValue<StringName, Variant> param : pending_params) {
 			RS::get_singleton()->material_set_param(_get_material(), param.key, param.value);

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -43,6 +43,7 @@ class Material : public Resource {
 	mutable RID material;
 	Ref<Material> next_pass;
 	int render_priority;
+	uint32_t layer_mask;
 
 	enum {
 		INIT_STATE_UNINITIALIZED,
@@ -58,6 +59,7 @@ protected:
 	static void _bind_methods();
 	virtual bool _can_do_next_pass() const;
 	virtual bool _can_use_render_priority() const;
+	virtual bool _can_use_layer_mask() const;
 
 	void _validate_property(PropertyInfo &p_property) const;
 
@@ -68,6 +70,7 @@ protected:
 	GDVIRTUAL0RC_REQUIRED(Shader::Mode, _get_shader_mode)
 	GDVIRTUAL0RC(bool, _can_do_next_pass)
 	GDVIRTUAL0RC(bool, _can_use_render_priority)
+	GDVIRTUAL0RC(bool, _can_use_layer_mask)
 public:
 	enum {
 		RENDER_PRIORITY_MAX = RSE::MATERIAL_RENDER_PRIORITY_MAX,
@@ -81,6 +84,11 @@ public:
 
 	void set_render_priority(int p_priority);
 	int get_render_priority() const;
+
+	void set_layer_mask(uint32_t p_layer_mask);
+	uint32_t get_layer_mask() const;
+	void set_layer_mask_value(int p_layer_number, bool p_value);
+	bool get_layer_mask_value(int p_layer_number) const;
 
 	virtual RID get_rid() const override;
 	virtual RID get_shader_rid() const;
@@ -115,6 +123,7 @@ protected:
 
 	virtual bool _can_do_next_pass() const override;
 	virtual bool _can_use_render_priority() const override;
+	virtual bool _can_use_layer_mask() const override;
 
 	void _shader_changed();
 	void _check_material_rid() const;
@@ -640,6 +649,7 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	virtual bool _can_do_next_pass() const override { return true; }
 	virtual bool _can_use_render_priority() const override { return true; }
+	virtual bool _can_use_layer_mask() const override { return true; }
 
 public:
 	void set_albedo(const Color &p_albedo);

--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -118,6 +118,7 @@ public:
 	virtual void material_free(RID p_rid) override;
 
 	virtual void material_set_render_priority(RID p_material, int priority) override {}
+	virtual void material_set_layer_mask(RID p_material, uint32_t p_layer_mask) override {}
 	virtual void material_set_shader(RID p_shader_material, RID p_shader) override;
 
 	virtual void material_set_param(RID p_material, const StringName &p_param, const Variant &p_value) override {}

--- a/servers/rendering/renderer_rd/environment/fog.h
+++ b/servers/rendering/renderer_rd/environment/fog.h
@@ -230,6 +230,7 @@ private:
 
 		virtual void set_render_priority(int p_priority) {}
 		virtual void set_next_pass(RID p_pass) {}
+		virtual void set_layer_mask(uint32_t p_layer_mask) {}
 		virtual bool update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty);
 		virtual ~FogMaterialData();
 	};

--- a/servers/rendering/renderer_rd/environment/sky.h
+++ b/servers/rendering/renderer_rd/environment/sky.h
@@ -240,6 +240,7 @@ public:
 
 		virtual void set_render_priority(int p_priority) {}
 		virtual void set_next_pass(RID p_pass) {}
+		virtual void set_layer_mask(uint32_t p_layer_mask) {}
 		virtual bool update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty);
 		virtual ~SkyMaterialData();
 	};

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1093,6 +1093,11 @@ void RenderForwardClustered::_fill_render_list(RenderListType p_render_list, con
 		}
 
 		while (surf) {
+			if (p_pass_mode == PASS_MODE_COLOR && !(surf->material->layer_mask & p_render_data->scene_data->camera_visible_layers)) {
+				surf = surf->next;
+				continue;
+			}
+
 			surf->sort.uses_forward_gi = 0;
 			surf->sort.uses_lightmap = 0;
 

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -588,6 +588,10 @@ void SceneShaderForwardClustered::MaterialData::set_next_pass(RID p_pass) {
 	next_pass = p_pass;
 }
 
+void SceneShaderForwardClustered::MaterialData::set_layer_mask(uint32_t p_layer_mask) {
+	layer_mask = p_layer_mask;
+}
+
 bool SceneShaderForwardClustered::MaterialData::update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty) {
 	if (shader_data->version.is_valid()) {
 		RID shader_rid = SceneShaderForwardClustered::singleton->shader.version_get_shader(shader_data->version, 0);

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -330,8 +330,10 @@ public:
 		uint32_t index = 0;
 		RID next_pass;
 		uint8_t priority;
+		uint32_t layer_mask = 0xFFFFFFFF;
 		virtual void set_render_priority(int p_priority);
 		virtual void set_next_pass(RID p_pass);
+		virtual void set_layer_mask(uint32_t p_layer_mask);
 		virtual bool update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty);
 		virtual ~MaterialData();
 	};

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -2172,6 +2172,11 @@ void RenderForwardMobile::_fill_render_list(RenderListType p_render_list, const 
 		}
 
 		while (surf) {
+			if ((p_pass_mode == PASS_MODE_COLOR || p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) && !(surf->material->layer_mask & p_render_data->scene_data->camera_visible_layers)) {
+				surf = surf->next;
+				continue;
+			}
+
 			surf->sort.uses_lightmap = 0;
 
 			// LOD

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -536,6 +536,10 @@ void SceneShaderForwardMobile::MaterialData::set_next_pass(RID p_pass) {
 	next_pass = p_pass;
 }
 
+void SceneShaderForwardMobile::MaterialData::set_layer_mask(uint32_t p_layer_mask) {
+	layer_mask = p_layer_mask;
+}
+
 bool SceneShaderForwardMobile::MaterialData::update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty) {
 	if (shader_data->version.is_valid()) {
 		MutexLock lock(SceneShaderForwardMobile::singleton_mutex);

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -330,8 +330,10 @@ public:
 		uint32_t index = 0;
 		RID next_pass;
 		uint8_t priority;
+		uint32_t layer_mask = 0xFFFFFFFF;
 		virtual void set_render_priority(int p_priority);
 		virtual void set_next_pass(RID p_pass);
+		virtual void set_layer_mask(uint32_t p_layer_mask);
 		virtual bool update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty);
 		virtual ~MaterialData();
 	};

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -206,6 +206,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 
 		virtual void set_render_priority(int p_priority) {}
 		virtual void set_next_pass(RID p_pass) {}
+		virtual void set_layer_mask(uint32_t p_layer_mask) {}
 		virtual bool update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty);
 		virtual ~CanvasMaterialData();
 	};

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -2255,6 +2255,7 @@ void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
 				material->data->self = material->self;
 				material->data->set_next_pass(material->next_pass);
 				material->data->set_render_priority(material->priority);
+				material->data->set_layer_mask(material->layer_mask);
 			}
 			material->shader_type = new_type;
 		}
@@ -2505,6 +2506,7 @@ void MaterialStorage::material_set_shader(RID p_material, RID p_shader) {
 	material->data->self = p_material;
 	material->data->set_next_pass(material->next_pass);
 	material->data->set_render_priority(material->priority);
+	material->data->set_layer_mask(material->layer_mask);
 	//updating happens later
 	material->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MATERIAL);
 	_material_queue_update(material, true, true);
@@ -2571,6 +2573,18 @@ void MaterialStorage::material_set_render_priority(RID p_material, int priority)
 	if (material->data) {
 		material->data->set_render_priority(priority);
 	}
+	material->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MATERIAL);
+}
+
+void MaterialStorage::material_set_layer_mask(RID p_material, uint32_t p_layer_mask) {
+	Material *material = material_owner.get_or_null(p_material);
+	ERR_FAIL_NULL(material);
+
+	material->layer_mask = p_layer_mask;
+	if (material->data) {
+		material->data->set_layer_mask(p_layer_mask);
+	}
+
 	material->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MATERIAL);
 }
 

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.h
@@ -100,6 +100,7 @@ public:
 
 		virtual void set_render_priority(int p_priority) = 0;
 		virtual void set_next_pass(RID p_pass) = 0;
+		virtual void set_layer_mask(uint32_t p_layer_mask) = 0;
 		virtual bool update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty) = 0;
 		virtual ~MaterialData();
 
@@ -176,6 +177,7 @@ public:
 
 		virtual void set_render_priority(int p_priority) {}
 		virtual void set_next_pass(RID p_pass) {}
+		virtual void set_layer_mask(uint32_t p_layer_mask) {}
 		virtual bool update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty);
 		virtual ~TexBlitMaterialData();
 	};
@@ -299,6 +301,7 @@ private:
 		HashMap<StringName, Variant> params;
 		int32_t priority = 0;
 		RID next_pass;
+		uint32_t layer_mask = 0xFFFFFFFF;
 		SelfList<Material> update_element;
 
 		Dependency dependency;
@@ -499,6 +502,7 @@ public:
 
 	virtual void material_set_next_pass(RID p_material, RID p_next_material) override;
 	virtual void material_set_render_priority(RID p_material, int priority) override;
+	virtual void material_set_layer_mask(RID p_material, uint32_t p_layer_mask) override;
 
 	virtual bool material_is_animated(RID p_material) override;
 	virtual bool material_casts_shadows(RID p_material) override;

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -384,6 +384,7 @@ private:
 
 		virtual void set_render_priority(int p_priority) {}
 		virtual void set_next_pass(RID p_pass) {}
+		virtual void set_layer_mask(uint32_t p_layer_mask) {}
 		virtual bool update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty);
 		virtual ~ParticleProcessMaterialData();
 	};

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2346,6 +2346,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("material_set_param", "material", "parameter", "value"), &RenderingServer::material_set_param);
 	ClassDB::bind_method(D_METHOD("material_get_param", "material", "parameter"), &RenderingServer::material_get_param);
 	ClassDB::bind_method(D_METHOD("material_set_render_priority", "material", "priority"), &RenderingServer::material_set_render_priority);
+	ClassDB::bind_method(D_METHOD("material_set_layer_mask", "material", "layer_mask"), &RenderingServer::material_set_layer_mask);
 
 	ClassDB::bind_method(D_METHOD("material_set_next_pass", "material", "next_material"), &RenderingServer::material_set_next_pass);
 

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -183,6 +183,8 @@ public:
 
 	virtual void material_set_render_priority(RID p_material, int priority) = 0;
 
+	virtual void material_set_layer_mask(RID p_material, uint32_t p_layer_mask) = 0;
+
 	virtual void material_set_next_pass(RID p_material, RID p_next_material) = 0;
 
 	virtual void material_set_use_debanding(bool p_enable) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -349,6 +349,7 @@ public:
 	FUNC2RC(Variant, material_get_param, RID, const StringName &)
 
 	FUNC2(material_set_render_priority, RID, int)
+	FUNC2(material_set_layer_mask, RID, uint32_t)
 	FUNC2(material_set_next_pass, RID, RID)
 
 	/* MESH API */

--- a/servers/rendering/storage/material_storage.h
+++ b/servers/rendering/storage/material_storage.h
@@ -82,6 +82,7 @@ public:
 	virtual void material_free(RID p_rid) = 0;
 
 	virtual void material_set_render_priority(RID p_material, int priority) = 0;
+	virtual void material_set_layer_mask(RID p_material, uint32_t p_layer_mask) = 0;
 	virtual void material_set_shader(RID p_shader_material, RID p_shader) = 0;
 
 	virtual void material_set_param(RID p_material, const StringName &p_param, const Variant &p_value) = 0;


### PR DESCRIPTION
This PR adds a `layer_mask` property to `Material`, which can be used to select which visual layers an individual material will render on. Like with `render_priority`, this property is only available for subclasses of `BaseMaterial3D` and for `ShaderMaterial` with a spatial shader.

<img width="430" height="601" alt="image" src="https://github.com/user-attachments/assets/e6f209dc-d66a-475b-b636-3df53b812ba5" />

## Motivation

*Implements and closes <https://github.com/godotengine/godot-proposals/issues/11210>.*

Something similar to this could already be accomplished in Godot shaders through use of `CAMERA_VISIBLE_LAYERS`. However, this PR enables this functionality in `StandardMaterial3D` and `ORMMaterial3D`. Also, even for shader materials, it should provide faster layer-based culling than could be accomplished with `CAMERA_VISIBLE_LAYERS` since the material is culled before the draw call. Combined with the ability to add more materials via `next_pass`, this gives users a greater level of control over how their objects render on different layers.

## Related Work

*Supersedes <https://github.com/godotengine/godot/pull/99565>.*

I originally implemented this same feature by modifying the generated shader code for `BaseMaterial3D` to cull based on `CAMERA_VISIBLE_LAYERS`. However, in that PR, it was suggested that I look into doing this before the draw call by passing the layer mask to the rendering server.

## Technical Overview

The culling currently happens in the `_fill_render_list()` method for each renderer. As far as I could tell, this is the first place where there is a list with elements that correspond to individual materials. Prior to that, such as in `RenderSceneCull`, all lists contain complete geometry instances, and so it is not possible to cull individual materials.

Before culling, the code checks to make sure that it is in the color pass. Without this check, I noticed that shadows were broken on Forward+ and Mobile. I could use some feedback about this part since I don't know what should be expected for each type of pass, whether the material should be culled or not. (Note: Even without this check, shadows were not broken on Compatibility. The distinction seems to be that Compatibility defaults `RenderDataGLES3::camera_visible_layers` to 0xFFFFFFFF, while Forward+ and Mobile do not provide a default value for `RenderSceneDataRD::camera_visible_layers`.)