### PR TITLE
Add documentation comments to Godot C++ container types

### DIFF
--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -43,9 +43,13 @@ class StringName;
 class Variant;
 
 /**
- * An array-based implementation of a hash map. It is very efficient in terms of performance and
+ * @brief An array-based implementation of a hash map. Use this as the "default"
+ * map type.
+ *
+ * It is very efficient in terms of performance and
  * memory usage. Works like a dynamic array, adding elements to the end of the array, and
  * allows you to access array elements by their index by using `get_by_index` method.
+ *
  * Example:
  * ```
  *  AHashMap<int, Object *> map;
@@ -62,20 +66,22 @@ class Variant;
  * Still, don`t erase the elements because ID can break.
  *
  * When an element erase, its place is taken by the element from the end.
- *
+ * ```
  *        <-------------
  *      |               |
  *  6 8 X 9 32 -1 5 -10 7 X X X
  *  6 8 7 9 32 -1 5 -10 X X X X
+ * ```
  *
+ * Use `RBMap` if you need to iterate over sorted elements.
  *
- * Use RBMap if you need to iterate over sorted elements.
+ * Use `HashMap` if:
  *
- * Use HashMap if:
  *   - You need to keep an iterator or const pointer to Key and you intend to add/remove elements in the meantime.
+ *
  *   - You need to preserve the insertion order when using erase.
  *
- * It is recommended to use `HashMap` if `KeyValue` size is very large.
+ *   - The `KeyValue` size is very large.
  */
 template <typename TKey, typename TValue,
 		typename Hasher = HashMapHasherDefault,

--- a/core/templates/fixed_vector.h
+++ b/core/templates/fixed_vector.h
@@ -36,12 +36,14 @@
 GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Warray-bounds")
 
 /**
- * A high performance Vector of fixed capacity.
+ * @brief A high performance Vector of fixed capacity, roughly equivalent
+ * to `std::array` or `boost::container::static_vector`.
  * Especially useful if you need to create an array on the stack, to
- *  prevent dynamic allocations (especially in bottleneck code).
+ * prevent dynamic allocations (especially in bottleneck code).
  *
- * Choose CAPACITY such that it is enough for all elements that could be added through all branches.
- *
+ * In most cases, `Vector` may be sufficient.
+ * @tparam CAPACITY The maximum capacity of the vector. Ensure this value is chosen
+ * such that it is enough for all elements that could be added through all branches.
  */
 template <class T, uint32_t CAPACITY>
 class FixedVector {

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -62,6 +62,16 @@ struct HashMapElement {
 			data(p_key, p_value) {}
 };
 
+/**
+ * @brief An implementation of a hash map, roughly equivalent to `std::unordered_map`.
+ *
+ * Defensive (robust but slow) map type. Preserves insertion order.
+ * Pointers to keys and values, as well as iterators, are stable under mutation.
+ * Use this map type when either of these affordances are needed.
+ * Use `AHashMap` otherwise.
+ *
+ * See `core/templates/hash_map.h` for more implementation information.
+ */
 template <typename TKey, typename TValue,
 		typename Hasher = HashMapHasherDefault,
 		typename Comparator = HashMapComparatorDefault<TKey>,

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -35,14 +35,15 @@
 #include "core/templates/hashfuncs.h"
 
 /**
- * Implementation of Set using a bidi indexed hash map.
- * Use RBSet instead of this only if the following conditions are met:
+ * @brief Implementation of a set using a bidi indexed hash map, roughly equivalent to `std::unordered_set`.
+ * Use this as the "default" set type.
  *
- * - You need to keep an iterator or const pointer to Key and you intend to add/remove elements in the meantime.
- * - Iteration order does matter (via operator<)
+ * Use `RBSet` instead only if the following conditions are met:
  *
+ * - You need to keep an iterator or const pointer to a key, and you intend to add/remove elements in the meantime.
+ *
+ * - Iteration order does matter (via `operator<`).
  */
-
 template <typename TKey,
 		typename Hasher = HashMapHasherDefault,
 		typename Comparator = HashMapComparatorDefault<TKey>>

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -37,13 +37,16 @@
 #include <initializer_list>
 
 /**
- * Generic Templatized Linked List Implementation.
+ * @brief A generic linked list implementation.
+ *
+ * Generally slower than other array/vector types. Prefer using other types
+ * in new code, unless using `List` avoids the need for type conversions.
+ *
  * The implementation differs from the STL one because
  * a compatible preallocated linked list can be written
  * using the same API, or features such as erasing an element
  * from the iterator.
  */
-
 template <typename T, typename A = DefaultAllocator>
 class List {
 	struct _Data;

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -39,8 +39,16 @@
 #include <initializer_list>
 #include <type_traits>
 
-// If tight, it grows strictly as much as needed.
-// Otherwise, it grows exponentially (the default and what you want in most cases).
+/**
+ * @brief A one-dimensional list-like datatype. Closer to `std::vector` than `Vector`
+ * in semantics, but does not use copy-on-write (COW) so it is faster than `Vector`.
+ *
+ * In most cases, `Vector` may be sufficient.
+ * Prefer `LocalVector` over `Vector` when copying it cheaply is not needed.
+ * @tparam U (Optional) The data type to use for the vector's size and capacity.
+ * @tparam tight (Optional) If `true`, the vector grows strictly as much as needed.
+ * Otherwise, it grows exponentially (the default, and what you want in most cases).
+ */
 template <typename T, typename U = uint32_t, bool force_trivial = false, bool tight = false>
 class LocalVector {
 	static_assert(!force_trivial, "force_trivial is no longer supported. Use resize_uninitialized instead.");

--- a/core/templates/pair.h
+++ b/core/templates/pair.h
@@ -32,6 +32,11 @@
 
 #include "core/typedefs.h"
 
+/**
+ * @brief A pair of values.
+ *
+ * For a pair where the first item is read-only, use `KeyValue`.
+ */
 template <typename F, typename S>
 struct Pair {
 	F first{};
@@ -60,6 +65,9 @@ struct PairSort {
 template <typename F, typename S>
 struct is_zero_constructible<Pair<F, S>> : std::conjunction<is_zero_constructible<F>, is_zero_constructible<S>> {};
 
+/**
+ * @brief A key-value pair. Unlike `Pair`, the key is read-only.
+ */
 template <typename K, typename V>
 struct KeyValue {
 	const K key{};

--- a/core/templates/rb_map.h
+++ b/core/templates/rb_map.h
@@ -39,6 +39,16 @@
 // based on the very nice implementation of rb-trees by:
 // https://web.archive.org/web/20120507164830/https://web.mit.edu/~emin/www/source_code/red_black_tree/index.html
 
+/**
+ * @brief An implementation of a map that uses a red-black tree to find keys,
+ * roughly equivalent to `std::map`.
+ *
+ * It uses a very nice implementation of red-black trees based on
+ * https://web.archive.org/web/20120507164830/https://web.mit.edu/~emin/www/source_code/red_black_tree/index.html.
+ *
+ * The performance benefits of `RBMap` aren't well-established, so prefer using other
+ * types such as `AHashMap`.
+ */
 template <typename K, typename V, typename C = Comparator<K>, typename A = DefaultAllocator>
 class RBMap {
 	enum Color {

--- a/core/templates/rb_set.h
+++ b/core/templates/rb_set.h
@@ -35,9 +35,20 @@
 
 #include <initializer_list>
 
-// based on the very nice implementation of rb-trees by:
-// https://web.archive.org/web/20120507164830/https://web.mit.edu/~emin/www/source_code/red_black_tree/index.html
-
+/**
+ * @brief An unordered collection of items, roughly equivalent to `std::set`.
+ *
+ * In most cases, `HashSet` is better.
+ * Use `RBSet` instead only if the following conditions are met:
+ *
+ * - You need to keep an iterator or const pointer to a key, and you intend to add/remove elements in the meantime.
+ *
+ * - Iteration order does matter (via `operator<`).
+ *
+ * `RBSet` uses a very nice implementation of red-black trees based on
+ * https://web.archive.org/web/20120507164830/https://web.mit.edu/~emin/www/source_code/red_black_tree/index.html,
+ * which allows accesses to be faster.
+ */
 template <typename T, typename C = Comparator<T>, typename A = DefaultAllocator>
 class RBSet {
 	enum Color {

--- a/core/templates/span.h
+++ b/core/templates/span.h
@@ -53,11 +53,16 @@ bool are_spans_equal(const LHS *p_lhs, const RHS *p_rhs, size_t p_size) {
 	}
 }
 
-// Equivalent of std::span.
-// Represents a view into a contiguous memory space.
-// DISCLAIMER: This data type does not own the underlying buffer. DO NOT STORE IT.
-//  Additionally, for the lifetime of the Span, do not resize the buffer, and do not insert or remove elements from it.
-//  Failure to respect this may lead to crashes or undefined behavior.
+/**
+ * @brief Represents a view into a contiguous memory space, roughly equivalent
+ * to `std::span`.
+ *
+ * @warning This data type does not own the underlying buffer. Do not store it.
+ * Additionally, for the lifetime of the Span, do not resize the buffer, and do
+ * not insert or remove elements from it.
+ * Failure to respect this may lead to crashes or undefined behavior.
+ * @tparam T The data type to view.
+ */
 template <typename T>
 class Span {
 	const T *_ptr = nullptr;

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -57,6 +57,14 @@ public:
 	}
 };
 
+/**
+ * @brief A one-dimensional list-like datatype, roughly equivalent to `std::vector`.
+ * Use this as the "default" vector type.
+ *
+ * Uses copy-on-write (COW) semantics. This means it's generally slower but can
+ * be copied around almost for free. Use `LocalVector` instead where COW isn't
+ * needed and performance matters.
+ */
 template <typename T>
 class Vector {
 	friend class VectorWriteProxy<T>;

--- a/core/templates/vset.h
+++ b/core/templates/vset.h
@@ -33,6 +33,15 @@
 #include "core/templates/vector.h"
 #include "core/typedefs.h"
 
+/**
+ * @brief An unordered collection of items, roughly equivalent to `std::flat_set`.
+ *
+ * Unlike `RBSet`, `VSet` uses copy-on-write (COW) semantics. As a result, it is
+ * generally slower but can be copied around almost for free.
+ *
+ * The performance benefits of `VSet` aren't well-established, so prefer using other
+ * types such as `RBSet`.
+ */
 template <typename T>
 class VSet {
 	Vector<T> _data;


### PR DESCRIPTION
This PR adds documentation comments for the following types:
- `AHashMap`
- `FixedVector`
- `HashMap`
- `HashSet`
- `List`
- `LocalVector`
- `Pair`
- `KeyValue`
- `RBMap`
- `RBSet`
- `Span`
- `Vector`
- `VSet`

With these comments added, engine contributors can quickly see information about these data types by hovering over them in an IDE (or, at least VS Code):

https://github.com/user-attachments/assets/705bc178-6bac-4a39-b238-253ff1ecd2a2

The text of the documentation comments is a mix of comments that already existed in the header files themselves, and the comments provided on the documentation ["Core types"](https://docs.godotengine.org/en/stable/engine_details/architecture/core_types.html#containers) page.

> [!note]
> I'd really appreciate people trying this out with other IDEs to see how they handle these documentation comments. If there's a different format that would result in the documentation working more universally, I'd be happy to switch this PR to using that format!
>
> Additionally, while I did the best I could to stick to the facts given in the documentation and already-existing comments for these types' files, it's possible that some details might have gotten mixed up as I'm not intimately familiar with the low-level inner workings of Godot. It'd be great to have feedback and corrections from people who know how these types are architected better than myself.