### PR TITLE
SCons: Write CACHEDIR.TAG to bin/ directory

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -372,6 +372,9 @@ opts.Update(env)
 # Setup caching logic early to catch everything.
 methods.prepare_cache(env)
 
+# Write CACHEDIR.TAG file to bin directory
+methods.prepare_bin_dir(env)
+
 # Copy custom environment variables if set.
 if env["import_env_vars"]:
     for env_var in str(env["import_env_vars"]).split(","):

--- a/methods.py
+++ b/methods.py
@@ -8,6 +8,7 @@ import os
 import re
 import subprocess
 import sys
+import textwrap
 import zlib
 from collections import OrderedDict
 from io import StringIO
@@ -952,6 +953,22 @@ def prepare_cache(env) -> None:
         )
 
     atexit.register(clean_cache, cache_path, cache_limit, env["verbose"])
+
+
+def prepare_bin_dir(env) -> None:
+    bin_dir = env.Dir("#bin").abspath
+    tag_path = os.path.join(bin_dir, "CACHEDIR.TAG")
+    if not os.path.exists(tag_path):
+        os.makedirs(bin_dir, exist_ok=True)
+        with open(tag_path, "w", encoding="utf-8", newline="\n") as f:
+            f.write(
+                textwrap.dedent("""
+                    Signature: 8a477f597d28d172789f06886806bc55
+                    # This file is a cache directory tag created by the Godot build system.
+                    # For information about cache directory tags, see:
+                    #\thttps://bford.info/cachedir/
+                    """).strip()
+            )
 
 
 def prepare_purge(env):


### PR DESCRIPTION
https://bford.info/cachedir/ describes a convention for marking directories as containing only cached data that can easily be recreated and should not be backed up.

A number of backup tools, such as borg, support excluding any directories containing this tag from the backup. For those who develop Godot and use such a backup tool, it would be useful to mark the bin/ directory, which (by default) contains all built binary files, as a cache directory, so that its large, often-changing, not-valuable contents are not backed up.

A number of build tools, including ccache, uv, and cargo, create this tag file in cache directories. In fact, SCons is one such tool: its CacheDir component writes CACHEDIR.TAG. If Godot is built with cache_path set, this path will have an appropriate CACHEDIR.TAG file. But this does not apply to the bin/ directory.

Write CACHEDIR.TAG to the bin/ directory early in the build.