### PR TITLE
Fix: Fixed the renaming in tree as popup editor floating after window move/resize

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5274,10 +5274,18 @@ void Tree::_notification(int p_what) {
 		case NOTIFICATION_RESIZED:
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (popup_edited_item != nullptr) {
+				Size2 scale = popup_editor->get_parent_viewport()->get_popup_base_transform().get_scale()
+                            * get_global_transform_with_canvas().get_scale();
+				real_t popup_scale = MIN(scale.x, scale.y);
 				Rect2 rect = _get_item_focus_rect(popup_edited_item);
+				rect.position *= popup_scale;
 
-				popup_editor->set_position(get_global_position() + rect.position);
-				popup_editor->set_size(rect.size);
+
+				popup_editor->set_position(get_screen_position() + rect.position);
+				popup_editor->set_size(rect.size * popup_scale);
+				if (!popup_editor->is_embedded()) {
+                    popup_editor->set_content_scale_factor(popup_scale);
+                }
 				popup_editor->child_controls_changed();
 			}
 		} break;


### PR DESCRIPTION
## Bugfix: Fix Tree popup editor floating/misplacing after window move or resize

Fixes the inline cell editor popup (used for node renaming and editable `Tree` cells) appearing at a wrong screen position or drifting after the editor window is moved or resized. on tiling window managers (Awesome, i3, Sway) the popup appears as an
untitled OS window at a random screen corner instead of over the target cell. On all platforms, the popup freezes at its original screen coordinates when the editor window is dragged or resized, and only disappears when Escape or Enter is pressed.

The problem was never in how the editor initiates the rename — it was in how `Tree` itself repositions the popup on transform change.

Fixes #116875

## Changes
| File | Change |
|---|---|
| `scene/gui/tree.cpp` | Fix `NOTIFICATION_TRANSFORM_CHANGED` to use `get_screen_position()` and apply `popup_scale`, matching `edit_selected()` |


