### PR TITLE
Docs: Clarify that get_instance_shader_parameter returns null if not set

### DIFF
--- a/doc/classes/GeometryInstance3D.xml
+++ b/doc/classes/GeometryInstance3D.xml
@@ -15,6 +15,7 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Get the value of a shader parameter as set on this instance.
+				[b]Note:[/b] This method only returns values previously set via [method set_instance_shader_parameter]. If the parameter has not been explicitly set on this instance, it will return [code]null[/code], even if the parameter has a default value defined in the shader code.
 			</description>
 		</method>
 		<method name="set_instance_shader_parameter">


### PR DESCRIPTION
# Docs: Clarify that `get_instance_shader_parameter` returns `null` if not set

## Description
This PR clarifies the behavior of `get_instance_shader_parameter` in the class reference. 

Currently, the documentation does not explicitly state that this method **only** retrieves values that have been manually overridden via `set_instance_shader_parameter`. Users often expect it to return the default value defined in the shader if no override exists, but the function returns `null` in such cases.

## Changes
- **Updated:** `doc/classes/GeometryInstance3D.xml`
    - Added a `[b]Note:[/b]` to clarify that the method returns `null` if `set_instance_shader_parameter` has not been called for the parameter, regardless of whether the shader defines a default value.