### PR TITLE
Add sampler functions to `HeightMapShape3D`

### DIFF
--- a/doc/classes/HeightMapShape3D.xml
+++ b/doc/classes/HeightMapShape3D.xml
@@ -26,6 +26,23 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_height" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<description>
+				Returns the exact height at [code](x, y)[/code].
+				This is the same as [method get_heightv], but with two integer arguments instead of a [Vector2i] argument.
+			</description>
+		</method>
+		<method name="get_heightv" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="point" type="Vector2i" />
+			<description>
+				Returns the exact height at [param point].
+				This is the same as [method get_height], but with a [Vector2i] argument instead of two integer arguments.
+			</description>
+		</method>
 		<method name="get_max_height" qualifiers="const">
 			<return type="float" />
 			<description>
@@ -36,6 +53,23 @@
 			<return type="float" />
 			<description>
 				Returns the smallest height value found in [member map_data]. Recalculates only when [member map_data] changes.
+			</description>
+		</method>
+		<method name="sample_height" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="x" type="float" />
+			<param index="1" name="y" type="float" />
+			<description>
+				Returns the height at [code](x, y)[/code] as computed from the four nearest heights on the heightmap using triangle-based interpolation. This function may return NaN if any of the four nearest points are NaN.
+				This is the same as [method sample_heightv], but with two integer arguments instead of a [Vector2] argument.
+			</description>
+		</method>
+		<method name="sample_heightv" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="point" type="Vector2" />
+			<description>
+				Returns the height at [param point] as computed from the four nearest heights on the heightmap using triangle-based interpolation. This function may return NaN if any of the four nearest points are NaN.
+				This is the same as [method sample_height], but with a [Vector2] argument instead of two integer arguments.
 			</description>
 		</method>
 		<method name="update_map_data_from_image">

--- a/scene/resources/3d/height_map_shape_3d.cpp
+++ b/scene/resources/3d/height_map_shape_3d.cpp
@@ -244,6 +244,46 @@ real_t HeightMapShape3D::get_max_height() const {
 	return max_height;
 }
 
+real_t HeightMapShape3D::get_height(int x, int y) const {
+	ERR_FAIL_COND_V(x < 0 || y < 0 || x >= map_width || y >= map_depth, NAN);
+
+	return map_data[y * map_width + x];
+}
+
+real_t HeightMapShape3D::get_heightv(const Point2i &p_point) const {
+	return get_height(p_point.x, p_point.y);
+}
+
+real_t HeightMapShape3D::sample_height(float x, float y) const {
+	return sample_heightv(Point2(x, y));
+}
+
+real_t HeightMapShape3D::sample_heightv(const Point2 &p_point) const {
+	ERR_FAIL_COND_V(p_point.x < 0.0 || p_point.y < 0.0 || p_point.x >= map_width || p_point.y >= map_depth, NAN);
+
+	const Point2i p0 = p_point;
+	const Point2i p1 = p0 + Point2i(1, 1);
+
+	// If any of these 4 height values are NaN, then NaN propagation rules ensure that the final output will always be NaN
+	const real_t h0 = get_height(p0.x, p0.y); // bl
+	const real_t h1 = get_height(p1.x, p0.y); // br
+	const real_t h2 = get_height(p0.x, p1.y); // tl
+	const real_t h3 = get_height(p1.x, p1.y); // tr
+
+	const Point2 frac = p_point - p_point.floor();
+
+	// Sample the height using triangle-based interpolation. This exactly matches the method used by both the Godot and Jolt physics engines.
+	if (frac.x + frac.y < 1.0) {
+		const real_t hx = (h1 - h0) * frac.x;
+		const real_t hy = (h2 - h0) * frac.y;
+		return h0 + hx + hy;
+	} else {
+		const real_t hx = (h2 - h3) * (1.0 - frac.x);
+		const real_t hy = (h1 - h3) * (1.0 - frac.y);
+		return h3 + hx + hy;
+	}
+}
+
 void HeightMapShape3D::update_map_data_from_image(const Ref<Image> &p_image, real_t p_height_min, real_t p_height_max) {
 	ERR_FAIL_COND_MSG(p_image.is_null(), "Heightmap update image requires a valid Image reference.");
 	ERR_FAIL_COND_MSG(p_image->get_format() != Image::FORMAT_RF && p_image->get_format() != Image::FORMAT_RH && p_image->get_format() != Image::FORMAT_R8, "Heightmap update image requires Image in format FORMAT_RF (32 bit), FORMAT_RH (16 bit), or FORMAT_R8 (8 bit).");
@@ -353,6 +393,12 @@ void HeightMapShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_max_height"), &HeightMapShape3D::get_max_height);
 
 	ClassDB::bind_method(D_METHOD("update_map_data_from_image", "image", "height_min", "height_max"), &HeightMapShape3D::update_map_data_from_image);
+
+	ClassDB::bind_method(D_METHOD("get_height", "x", "y"), &HeightMapShape3D::get_height);
+	ClassDB::bind_method(D_METHOD("get_heightv", "point"), &HeightMapShape3D::get_heightv);
+
+	ClassDB::bind_method(D_METHOD("sample_height", "x", "y"), &HeightMapShape3D::sample_height);
+	ClassDB::bind_method(D_METHOD("sample_heightv", "point"), &HeightMapShape3D::sample_heightv);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "map_width", PROPERTY_HINT_RANGE, "1,100,1,or_greater"), "set_map_width", "get_map_width");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "map_depth", PROPERTY_HINT_RANGE, "1,100,1,or_greater"), "set_map_depth", "get_map_depth");

--- a/scene/resources/3d/height_map_shape_3d.h
+++ b/scene/resources/3d/height_map_shape_3d.h
@@ -61,6 +61,12 @@ public:
 
 	void update_map_data_from_image(const Ref<Image> &p_image, real_t p_height_min, real_t p_height_max);
 
+	real_t get_height(int x, int y) const;
+	real_t get_heightv(const Point2i &p_point) const;
+
+	real_t sample_height(float x, float y) const;
+	real_t sample_heightv(const Point2 &p_point) const;
+
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
 	virtual real_t get_enclosing_radius() const override;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/14363 by implementing sampler functions for `HeightMapShape3D` that return the height at a given position without invoking `PhysicsServer3D`. This has been tested extensively and accurately mirrors how the physics engine (both Jolt and GodotPhysics3D) compute heightmap collisions, including NaN holes.

This project [heightmap-test.zip](https://github.com/user-attachments/files/25659546/heightmap-test.zip) provides a basic test environment to validate my changes. Ensure that you open it using this PR's build and that `Debug > Visible Collision Shapes` is enabled. A random heightmap of size 25x25 with a NaN hole in the middle will be generated each time the project is run. The camera can be moved with WASD and rotated by holding right click while dragging the mouse. A green sphere is drawn based on a raycast emitted from the center of the camera. While a blue sphere is drawn based on the sampled heightmap height at the same position. The margin between Y position of the two spheres is displayed in the top left (closer to zero is better).