### PR TITLE
Change loop override text for AudioStreamMP3 and AudioStreamOggVorbis

### DIFF
--- a/modules/mp3/audio_stream_mp3.cpp
+++ b/modules/mp3/audio_stream_mp3.cpp
@@ -167,7 +167,7 @@ void AudioStreamPlaybackMP3::set_sample_playback(const Ref<AudioSamplePlayback> 
 }
 
 void AudioStreamPlaybackMP3::set_parameter(const StringName &p_name, const Variant &p_value) {
-	if (p_name == SNAME("looping")) {
+	if (p_name == SNAME("loop_override")) {
 		if (p_value == Variant()) {
 			looping_override = false;
 			looping = false;
@@ -179,7 +179,7 @@ void AudioStreamPlaybackMP3::set_parameter(const StringName &p_name, const Varia
 }
 
 Variant AudioStreamPlaybackMP3::get_parameter(const StringName &p_name) const {
-	if (looping_override && p_name == SNAME("looping")) {
+	if (looping_override && p_name == SNAME("loop_override")) {
 		return looping;
 	}
 	return Variant();
@@ -269,7 +269,7 @@ bool AudioStreamMP3::is_monophonic() const {
 }
 
 void AudioStreamMP3::get_parameter_list(List<Parameter> *r_parameters) {
-	r_parameters->push_back(Parameter(PropertyInfo(Variant::BOOL, "looping", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CHECKABLE), Variant()));
+	r_parameters->push_back(Parameter(PropertyInfo(Variant::BOOL, "loop_override", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CHECKABLE), Variant()));
 }
 
 void AudioStreamMP3::set_bpm(double p_bpm) {

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -259,7 +259,7 @@ void AudioStreamPlaybackOggVorbis::tag_used_streams() {
 }
 
 void AudioStreamPlaybackOggVorbis::set_parameter(const StringName &p_name, const Variant &p_value) {
-	if (p_name == SNAME("looping")) {
+	if (p_name == SNAME("loop_override")) {
 		if (p_value == Variant()) {
 			looping_override = false;
 			looping = false;
@@ -271,7 +271,7 @@ void AudioStreamPlaybackOggVorbis::set_parameter(const StringName &p_name, const
 }
 
 Variant AudioStreamPlaybackOggVorbis::get_parameter(const StringName &p_name) const {
-	if (looping_override && p_name == SNAME("looping")) {
+	if (looping_override && p_name == SNAME("loop_override")) {
 		return looping;
 	}
 	return Variant();
@@ -563,7 +563,7 @@ bool AudioStreamOggVorbis::is_monophonic() const {
 }
 
 void AudioStreamOggVorbis::get_parameter_list(List<Parameter> *r_parameters) {
-	r_parameters->push_back(Parameter(PropertyInfo(Variant::BOOL, "looping", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CHECKABLE), Variant()));
+	r_parameters->push_back(Parameter(PropertyInfo(Variant::BOOL, "loop_override", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CHECKABLE), Variant()));
 }
 
 Ref<AudioSample> AudioStreamOggVorbis::generate_sample() const {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
-->
Closes: #96194
(maybe)
Related to: #96200

The first checkbox is the `looping_override` bool. If checked, the checkbox next to it in the UI is what decides whether or not the audio will loop or not, instead of the import `loop`. This one is `looping` in code.

This shouldn't break compatibility, since this parameter has no setter/getter.
Removing the first checkbox (`looping_override`) may sound like a reasonable solution, but it breaks compatibility.

See, I'd have changed the "change" in the title to "clarify". The problem is, I cannot find how to change the tooltip text for that paremeter, which could actually help clarify why there are two checkboxes.
This parameter is not documented, which means I can't just change its description. And I'm not sure if I could add it to the docs, since it does not have a setter/getter. Adding those to code could probably significantly increase the scope of this fix.
I could not find any examples in code of Parameters with tooltips. So just calling it "Loop Override" is the best I could do for now. I hope it clarifies at least a little what that checkbox does.

Tested, works on my end.