### PR TITLE
[RTL] Fix `%` handling in `[img=WxH]` tags.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -6141,9 +6141,18 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 				if (!bbcode_value.is_empty()) {
 					int sep = bbcode_value.find_char('x');
 					if (sep == -1) {
+						if (bbcode_value.ends_with("%")) {
+							width_in_percent = true;
+						}
 						width = bbcode_value.to_int();
 					} else {
+						if (bbcode_value.substr(0, sep).ends_with("%")) {
+							width_in_percent = true;
+						}
 						width = bbcode_value.substr(0, sep).to_int();
+						if (bbcode_value.substr(sep + 1).ends_with("%")) {
+							height_in_percent = true;
+						}
 						height = bbcode_value.substr(sep + 1).to_int();
 					}
 				} else {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/116927