### PR TITLE
Fix `CSGPolygon3D` gizmo persisting after duplicating node

### DIFF
--- a/editor/scene/3d/polygon_3d_editor_plugin.cpp
+++ b/editor/scene/3d/polygon_3d_editor_plugin.cpp
@@ -502,10 +502,9 @@ void Polygon3DEditor::edit(Node *p_node) {
 		wip_active = false;
 		edited_point = -1;
 		if (imgeom->get_parent()) {
-			imgeom->reparent(p_node, false);
-		} else {
-			p_node->add_child(imgeom);
+			imgeom->get_parent()->remove_child(imgeom);
 		}
+		p_node->add_child(imgeom, false, Node::INTERNAL_MODE_FRONT);
 		_polygon_draw();
 		set_process(true);
 		prev_depth = -1;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
-->

Fixes: https://github.com/godotengine/godot/issues/116929

The edit overlay needs to be an internal child, so it doesn't get duplicated over, get orphaned, and cause this bug. 

https://github.com/user-attachments/assets/8f7f11e3-e878-46c9-84f3-bd1bc6b35493

