### PR TITLE
Fix `Tree` hover highlighting on scroll

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3791,7 +3791,7 @@ bool Tree::_scroll(bool p_horizontal, float p_pages) {
 
 	bool scroll_happened = scroll->get_value() != prev_value;
 	if (scroll_happened) {
-		_determine_hovered_item();
+		_queue_update_hovered_item();
 	}
 	return scroll_happened;
 }
@@ -5796,7 +5796,6 @@ int Tree::get_columns() const {
 }
 
 void Tree::_scroll_moved(float) {
-	_determine_hovered_item();
 	queue_redraw();
 	popup_editor->hide();
 }


### PR DESCRIPTION
- Resolves https://github.com/godotengine/godot/issues/116931

Fixes the issue by delaying the update until after the tree is actually updated with the new scroll position. Also removes a redundant call to `_determine_hovered_item`.