### PR TITLE
GUI: Fix table whitespace when getting line text

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -7020,7 +7020,11 @@ String RichTextLabel::_get_line_text(ItemFrame *p_frame, int p_line) const {
 				ERR_CONTINUE(E->type != ITEM_FRAME); // Children should all be frames.
 				ItemFrame *frame = static_cast<ItemFrame *>(E);
 				for (int i = 0; !selection.to_line_found && i < (int)frame->lines.size(); i++) {
-					txt += _get_line_text(frame, i);
+					String cell_text = _get_line_text(frame, i);
+					if (!txt.is_empty() && !cell_text.is_empty()) {
+						txt += " ";
+					}
+					txt += cell_text;
 				}
 				if (selection.to_line_found) {
 					break;
@@ -7037,7 +7041,7 @@ String RichTextLabel::_get_line_text(ItemFrame *p_frame, int p_line) const {
 		} else if (it->type == ITEM_TEXT) {
 			const ItemText *t = static_cast<ItemText *>(it);
 			txt += t->text;
-		} else if (it->type == ITEM_NEWLINE) {
+		} else if (it->type == ITEM_NEWLINE || it->type == ITEM_PARAGRAPH) {
 			txt += "\n";
 		} else if (it->type == ITEM_IMAGE) {
 			txt += " ";


### PR DESCRIPTION
Fixes #116859

Newlines are now added between table rows, and spaces between table columns.

Using the issue's example, the copied text is now:
```
Properties

NodePath animation_path [default: NodePath("")] 
float cell_size [default: 1.0] 
Color color [default: Color(0.5, 0.5, 1, 1)] 
float radius [default: 10.0] 
bool zero_y [default: true]
```