### PR TITLE
Add SPM support for Apple Embedded plugins (.gdip)

### DIFF
--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -416,6 +416,12 @@ String EditorExportPlatformAppleEmbedded::_process_config_file_line(const Ref<Ed
 		strnew += p_line.replace("$modules_buildphase", p_config.modules_buildphase) + "\n";
 	} else if (p_line.contains("$modules_buildgrp")) {
 		strnew += p_line.replace("$modules_buildgrp", p_config.modules_buildgrp) + "\n";
+	} else if (p_line.contains("$spm_packages")) {
+		strnew += p_line.replace("$spm_packages", p_config.spm_packages) + "\n";
+	} else if (p_line.contains("$spm_package_refs")) {
+		strnew += p_line.replace("$spm_package_refs", p_config.spm_package_refs) + "\n";
+	} else if (p_line.contains("$spm_package_products")) {
+		strnew += p_line.replace("$spm_package_products", p_config.spm_package_products) + "\n";
 	} else if (p_line.contains("$name")) {
 		strnew += p_line.replace("$name", p_config.pkg_name) + "\n";
 	} else if (p_line.contains("$bundle_identifier")) {
@@ -1645,6 +1651,67 @@ Error EditorExportPlatformAppleEmbedded::_export_apple_embedded_plugins(const Re
 		p_config_data.linker_flags += result_linker_flags;
 	}
 
+	// SPM Packages
+	{
+		PbxId pbx_id;
+		pbx_id.high_bits = 0xDEB00000;
+		pbx_id.mid_bits = 0;
+		pbx_id.low_bits = 0;
+
+		HashMap<String, PluginConfigAppleEmbedded::SPMPackage> unique_packages;
+		for (int i = 0; i < enabled_plugins.size(); i++) {
+			for (const PluginConfigAppleEmbedded::SPMPackage &package : enabled_plugins[i].spm_packages) {
+				if (!unique_packages.has(package.url)) {
+					unique_packages[package.url] = package;
+				} else {
+					for (const String &product : package.products) {
+						if (unique_packages[package.url].products.find(product) == -1) {
+							unique_packages[package.url].products.push_back(product);
+						}
+					}
+				}
+			}
+		}
+
+		Vector<String> sorted_package_urls;
+		for (const KeyValue<String, PluginConfigAppleEmbedded::SPMPackage> &E : unique_packages) {
+			sorted_package_urls.push_back(E.key);
+		}
+		sorted_package_urls.sort();
+
+		for (const String &url : sorted_package_urls) {
+			const PluginConfigAppleEmbedded::SPMPackage &package = unique_packages[url];
+			String package_id = (++pbx_id).str();
+			String package_name = package.url.get_file().get_basename();
+
+			p_config_data.spm_packages += vformat("\t\t\t\t%s /* %s */,\n", package_id, package_name);
+
+			p_config_data.spm_package_refs += vformat("\t\t%s /* %s */ = {\n", package_id, package_name);
+			p_config_data.spm_package_refs += "\t\t\tisa = XCRemoteSwiftPackageReference;\n";
+			p_config_data.spm_package_refs += vformat("\t\t\trepositoryURL = \"%s\";\n", package.url);
+			p_config_data.spm_package_refs += "\t\t\trequirement = {\n";
+			p_config_data.spm_package_refs += "\t\t\t\tkind = exactVersion;\n";
+			p_config_data.spm_package_refs += vformat("\t\t\t\tversion = %s;\n", package.version);
+			p_config_data.spm_package_refs += "\t\t\t};\n";
+			p_config_data.spm_package_refs += "\t\t};\n";
+
+			for (const String &product : package.products) {
+				String product_id = (++pbx_id).str();
+				String build_file_id = (++pbx_id).str();
+
+				p_config_data.spm_package_products += vformat("\t\t%s /* %s */ = {\n", product_id, product);
+				p_config_data.spm_package_products += "\t\t\tisa = XCSwiftPackageProductDependency;\n";
+				p_config_data.spm_package_products += vformat("\t\t\tpackage = %s /* %s */;\n", package_id, package_name);
+				p_config_data.spm_package_products += vformat("\t\t\tproductName = \"%s\";\n", product);
+				p_config_data.spm_package_products += "\t\t};\n";
+
+				p_config_data.modules_buildfile += vformat("\t\t%s /* %s in Frameworks */ = {isa = PBXBuildFile; productRef = %s /* %s */; };\n", build_file_id, product, product_id, product);
+
+				p_config_data.modules_buildphase += vformat("\t\t\t\t%s /* %s in Frameworks */,\n", build_file_id, product);
+			}
+		}
+	}
+
 	return OK;
 }
 
@@ -1819,11 +1886,14 @@ Error EditorExportPlatformAppleEmbedded::_export_project_helper(const Ref<Editor
 		String(" ").join(_get_preset_architectures(p_preset)),
 		_get_linker_flags(),
 		_get_cpp_code(),
-		"",
-		"",
-		"",
-		"",
-		Vector<String>(),
+		"", // modules_buildfile
+		"", // modules_fileref
+		"", // modules_buildphase
+		"", // modules_buildgrp
+		"", // spm_packages
+		"", // spm_package_refs
+		"", // spm_package_products
+		Vector<String>(), // capabilities
 	};
 
 	config_data.plist_content += p_preset->get("application/additional_plist_content").operator String() + "\n";

--- a/editor/export/editor_export_platform_apple_embedded.h
+++ b/editor/export/editor_export_platform_apple_embedded.h
@@ -143,6 +143,9 @@ protected:
 		String modules_fileref;
 		String modules_buildphase;
 		String modules_buildgrp;
+		String spm_packages;
+		String spm_package_refs;
+		String spm_package_products;
 		Vector<String> capabilities;
 	};
 

--- a/editor/export/plugin_config_apple_embedded.cpp
+++ b/editor/export/plugin_config_apple_embedded.cpp
@@ -205,6 +205,20 @@ PluginConfigAppleEmbedded PluginConfigAppleEmbedded::load_plugin_config(Ref<Conf
 		plugin_config.capabilities = config_file->get_value(PluginConfigAppleEmbedded::DEPENDENCIES_SECTION, PluginConfigAppleEmbedded::DEPENDENCIES_CAPABILITIES_KEY, Vector<String>());
 
 		plugin_config.linker_flags = config_file->get_value(PluginConfigAppleEmbedded::DEPENDENCIES_SECTION, PluginConfigAppleEmbedded::DEPENDENCIES_LINKER_FLAGS, Vector<String>());
+
+		Array spm_packages = config_file->get_value(PluginConfigAppleEmbedded::DEPENDENCIES_SECTION, PluginConfigAppleEmbedded::DEPENDENCIES_SPM_PACKAGES_KEY, Array());
+		for (int i = 0; i < spm_packages.size(); i++) {
+			Dictionary package_config = spm_packages[i];
+			PluginConfigAppleEmbedded::SPMPackage package;
+			package.url = package_config.get("url", String());
+			package.version = package_config.get("version", String());
+
+			Array products = package_config.get("products", Array());
+			for (int j = 0; j < products.size(); j++) {
+				package.products.push_back(products[j]);
+			}
+			plugin_config.spm_packages.push_back(package);
+		}
 	}
 
 	if (config_file->has_section(PluginConfigAppleEmbedded::PLIST_SECTION)) {

--- a/editor/export/plugin_config_apple_embedded.h
+++ b/editor/export/plugin_config_apple_embedded.h
@@ -44,6 +44,7 @@ The `dependencies` and fields are optional.
 - **system**: system dependencies that should be linked.
 - **capabilities**: capabilities that would be used for `UIRequiredDeviceCapabilities` options in Info.plist file.
 - **files**: files that would be copied into application
+- **spm_packages**: array of Swift Package Manager dependencies (url, version, products).
 
 The `plist` section are optional.
 - **key**: key and value that would be added in Info.plist file.
@@ -65,6 +66,7 @@ struct PluginConfigAppleEmbedded {
 	inline static const char *DEPENDENCIES_CAPABILITIES_KEY = "capabilities";
 	inline static const char *DEPENDENCIES_FILES_KEY = "files";
 	inline static const char *DEPENDENCIES_LINKER_FLAGS = "linker_flags";
+	inline static const char *DEPENDENCIES_SPM_PACKAGES_KEY = "spm_packages";
 
 	inline static const char *PLIST_SECTION = "plist";
 
@@ -80,6 +82,12 @@ struct PluginConfigAppleEmbedded {
 	struct PlistItem {
 		PlistItemType type;
 		String value;
+	};
+
+	struct SPMPackage {
+		String url;
+		String version;
+		Vector<String> products;
 	};
 
 	// Set to true when the config file is properly loaded.
@@ -103,6 +111,9 @@ struct PluginConfigAppleEmbedded {
 	Vector<String> capabilities;
 
 	Vector<String> linker_flags;
+
+	// Optional spm_dependencies section.
+	Vector<SPMPackage> spm_packages;
 
 	// Optional plist section
 	// String value is default value.

--- a/misc/dist/apple_embedded_xcode/godot_apple_embedded.xcodeproj/project.pbxproj
+++ b/misc/dist/apple_embedded_xcode/godot_apple_embedded.xcodeproj/project.pbxproj
@@ -176,6 +176,9 @@
 			productRefGroup = D0BCFE3518AEBDA2004A7AAE /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
+			packageReferences = (
+				$spm_packages
+			);
 			targets = (
 				D0BCFE3318AEBDA2004A7AAE /* $binary */,
 			);
@@ -407,6 +410,9 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+		$spm_package_refs
+		$spm_package_products
 	};
 	rootObject = D0BCFE2C18AEBDA2004A7AAE /* Project object */;
 }


### PR DESCRIPTION
Add `spm_packages` key to the `[dependencies]` section of `.gdip` files, allowing plugins to declare Swift Package Manager dependencies with exact version pinning. The export pipeline generates the corresponding PBX entries in the Xcode project.

---

Satisfies https://github.com/godotengine/godot-proposals/issues/4758. Thanks to @MileyHollenberg for initial integration with Cocoapods and telling us about SPM!

Docs PR: https://github.com/godotengine/godot-docs/pull/11805

This PR prevents external plugins from having to rely on hacky workarounds (like post-export scripts) to add Swift Package Manager (SPM) dependencies.

SPM is an excellent addition that will massively simplify the distribution and usage of iOS plugins because:

- **No more post-export hacks**: Plugins no longer need complex export scripts to manipulate the generated Xcode project.
- **One-Click Deploy**: SPM dependencies are natively resolved, guaranteeing that One-Click Deploy works out of the box.
- **CI/CD Ready**: Natively supports automated build pipelines.
- **Lighter, Cleaner Plugins**: Plugins become significantly smaller and simpler since heavy frameworks no longer need to be downloaded or embedded in the repository.

---

This implementation was designed with developer experience in mind. The new `.gdip` format places the SPM packages directly inside the existing `[dependencies]` section:

```ini
[dependencies]
linked=[]
embedded=[]
system=["AppTrackingTransparency.framework"]
capabilities=[]
files=[]
linker_flags=["-ObjC"]
spm_packages=[
  {
    "url": "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
    "version": "12.14.0",
    "products": ["GoogleMobileAds"]
  }
]
```

This approach is highly beneficial because:

1. **Self-Documenting**: The JSON-like `Array[Dictionary]` format exposes `url`, `version`, and `products` explicitly.
1. **Extensible**: More keys (like `platforms` or `checksums`) can be easily added in the future without breaking the parser.
1. **Familiarity**: It respects and closely follows how SPM natively structures its package dependencies.
1. **Deterministic Builds**: The export pipeline forces the Xcode requirement kind to be `exactVersion`. This guarantees reproducible builds and prevents bugs caused by dependencies silently updating to different versions.
1. **100% Backwards Compatible**: Older Godot versions parsing this `.gdip` file will simply ignore the `spm_packages` key safely.

Data Flow Diagram:
```mermaid
flowchart TD
    A["📄 .gdip file<br/><b>[dependencies]</b><br/>spm_packages=[...]"] -->|ConfigFile::load| B["load_plugin_config()<br/><i>plugin_config_apple_embedded.cpp</i>"]
    B -->|"Vector&lt;SPMPackage&gt;"| C["_export_apple_embedded_plugins()<br/><i>editor_export_platform_apple_embedded.cpp</i>"]
    C -->|Deduplicate by URL| D["PBX Generation"]
    D --> E["spm_packages<br/><i>packageReferences list</i>"]
    D --> F["spm_package_refs<br/><i>XCRemoteSwiftPackageReference</i>"]
    D --> G["spm_package_products<br/><i>XCSwiftPackageProductDependency</i>"]
    D --> H["modules_buildfile<br/><i>PBXBuildFile</i>"]
    D --> I["modules_buildphase<br/><i>Frameworks build phase</i>"]
    E --> J["_fix_config_file()<br/>Template Substitution"]
    F --> J
    G --> J
    H --> J
    I --> J
    J -->|"$spm_packages<br/>$spm_package_refs<br/>$spm_package_products"| K["📦 project.pbxproj<br/><i>Xcode resolves SPM at build time</i>"]
```

---

Binaries: [poing-godot-admob-ios.zip](https://github.com/user-attachments/files/25670208/poing-godot-admob-ios.zip)

Follow plugin tutorial if needed (just don't follow the Cocoapods step, this should be automatically now with SPM): https://www.youtube.com/watch?v=TB7WhP8mieo

Or:
- Clone repository: https://github.com/poingstudios/godot-admob-plugin
- Checkout to branch [205-prepare-for-spm-godot-47](https://github.com/poingstudios/godot-admob-plugin/tree/205-prepare-for-spm-godot-47)
- Download the [poing-godot-admob-ios.zip](https://github.com/user-attachments/files/25670208/poing-godot-admob-ios.zip)
- Paste into `res://ios/plugins`
- Export the project 