### PR TITLE
`AudioStreamWAV`: Use unsigned offset on decode

### DIFF
--- a/scene/resources/audio/audio_stream_wav.cpp
+++ b/scene/resources/audio/audio_stream_wav.cpp
@@ -99,7 +99,7 @@ void AudioStreamPlaybackWAV::decode_samples(const Depth *p_src, AudioFrame *p_ds
 	int32_t final = 0, final_r = 0;
 	while (p_amount) {
 		p_amount--;
-		int64_t pos = p_offset << (is_stereo && !is_ima_adpcm && !is_qoa ? 1 : 0);
+		uint64_t pos = p_offset << (is_stereo && !is_ima_adpcm && !is_qoa ? 1 : 0);
 
 		if (is_ima_adpcm) {
 			int64_t sample_pos = pos + p_ima_adpcm[0].window_ofs;


### PR DESCRIPTION
If `pos` is unsigned, the compiler will perform *slightly* more aggressive optimizations in case of a QOA stream (which uses constant divisions and modulo to map to the decoded buffer). Other compression formats have a negligible difference.

Profiled using a test project that plays 768 at nearly the same time using `AudioStreamPolyphonic` for 10 seconds, essentially a stress test.

On `dev_build=yes optimize=debug` builds (which already optimizes significantly), `decode_samples` took around 9% less CPU cycles after the change.

On `production=yes target=template_release` builds I only measured CPU usage through system monitor:
| Build | CPU usage |
|-|-|
| `master` | 3.0-3.2% |
| PR | 2.9-3.1% |

The improvement isn't that significant, but I believe lower-end CPUs could probably feel a difference.

`decode_samples`'s `p_offset` virtually can't receive a negative value, so doing this should be safe.