### PR TITLE
GDScript: Infer typed array results for `Array.map` and `Array.filter`

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -646,6 +646,82 @@ Array Array::map(const Callable &p_callable) const {
 		}
 	}
 
+	// Keep typed array metadata if all mapped values can share one typed container.
+	const int mapped_size = new_arr._p->array.size();
+	Variant::Type inferred_type = Variant::NIL;
+	StringName inferred_class_name;
+	Ref<Script> inferred_script;
+	const Variant *read = new_arr._p->array.ptr();
+
+	for (int i = 0; i < mapped_size; i++) {
+		const Variant &value = read[i];
+		const Variant::Type value_type = value.get_type();
+		if (value_type == Variant::NIL) {
+			continue;
+		}
+
+		if (inferred_type == Variant::NIL) {
+			inferred_type = value_type;
+			if (inferred_type == Variant::OBJECT) {
+				Object *object = value;
+				if (object) {
+					inferred_class_name = object->get_class_name();
+					inferred_script = object->get_script();
+				}
+			}
+			continue;
+		}
+
+		if (value_type != inferred_type) {
+			return new_arr;
+		}
+
+		if (inferred_type == Variant::OBJECT) {
+			Object *object = value;
+			if (!object) {
+				continue;
+			}
+
+			const StringName &object_class_name = object->get_class_name();
+			// Reduce to a common native base class for all mapped objects.
+			while (inferred_class_name != StringName() && !ClassDB::is_parent_class(object_class_name, inferred_class_name)) {
+				inferred_class_name = ClassDB::get_parent_class(inferred_class_name);
+			}
+
+			Ref<Script> object_script = object->get_script();
+			if (inferred_script.is_valid()) {
+				if (object_script.is_null()) {
+					inferred_script.unref();
+				} else if (inferred_script != object_script) {
+					// Keep whichever script is a common base. Drop script typing if unrelated.
+					if (object_script->inherits_script(inferred_script)) {
+						// Keep current base script.
+					} else if (inferred_script->inherits_script(object_script)) {
+						inferred_script = object_script;
+					} else {
+						inferred_script.unref();
+					}
+				}
+			}
+		}
+	}
+
+	if (inferred_type == Variant::NIL) {
+		return new_arr;
+	}
+	if (inferred_type != Variant::OBJECT) {
+		inferred_class_name = StringName();
+		inferred_script.unref();
+	}
+	if (inferred_class_name == StringName()) {
+		inferred_script.unref();
+	}
+
+	new_arr._p->typed.type = inferred_type;
+	new_arr._p->typed.class_name = inferred_class_name;
+	new_arr._p->typed.script = inferred_script;
+	new_arr._p->typed.where = "TypedArray";
+
 	return new_arr;
 }
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -646,81 +646,15 @@ Array Array::map(const Callable &p_callable) const {
 		}
 	}
 
-	// Keep typed array metadata if all mapped values can share one typed container.
-	const int mapped_size = new_arr._p->array.size();
-	Variant::Type inferred_type = Variant::NIL;
-	StringName inferred_class_name;
-	Ref<Script> inferred_script;
-	const Variant *read = new_arr._p->array.ptr();
-
-	for (int i = 0; i < mapped_size; i++) {
-		const Variant &value = read[i];
-		const Variant::Type value_type = value.get_type();
-		if (value_type == Variant::NIL) {
-			continue;
-		}
-
-		if (inferred_type == Variant::NIL) {
-			inferred_type = value_type;
-			if (inferred_type == Variant::OBJECT) {
-				Object *object = value;
-				if (object) {
-					inferred_class_name = object->get_class_name();
-					inferred_script = object->get_script();
-				}
-			}
-			continue;
-		}
-
-		if (value_type != inferred_type) {
-			return new_arr;
-		}
-
-		if (inferred_type == Variant::OBJECT) {
-			Object *object = value;
-			if (!object) {
-				continue;
-			}
-
-			const StringName &object_class_name = object->get_class_name();
-			// Reduce to a common native base class for all mapped objects.
-			while (inferred_class_name != StringName() && !ClassDB::is_parent_class(object_class_name, inferred_class_name)) {
-				inferred_class_name = ClassDB::get_parent_class(inferred_class_name);
-			}
-
-			Ref<Script> object_script = object->get_script();
-			if (inferred_script.is_valid()) {
-				if (object_script.is_null()) {
-					inferred_script.unref();
-				} else if (inferred_script != object_script) {
-					// Keep whichever script is a common base. Drop script typing if unrelated.
-					if (object_script->inherits_script(inferred_script)) {
-						// Keep current base script.
-					} else if (inferred_script->inherits_script(object_script)) {
-						inferred_script = object_script;
-					} else {
-						inferred_script.unref();
-					}
-				}
-			}
-		}
+	// Preserve typed array metadata from the callable's return type when available.
+	MethodInfo mi;
+	Variant return_script;
+	if (p_callable.get_method_info(&mi, &return_script) && mi.return_val.type != Variant::NIL) {
+		new_arr._p->typed.type = mi.return_val.type;
+		new_arr._p->typed.class_name = mi.return_val.class_name;
+		new_arr._p->typed.script = return_script;
+		new_arr._p->typed.where = "TypedArray";
 	}
-
-	if (inferred_type == Variant::NIL) {
-		return new_arr;
-	}
-	if (inferred_type != Variant::OBJECT) {
-		inferred_class_name = StringName();
-		inferred_script.unref();
-	}
-	if (inferred_class_name == StringName()) {
-		inferred_script.unref();
-	}
-
-	new_arr._p->typed.type = inferred_type;
-	new_arr._p->typed.class_name = inferred_class_name;
-	new_arr._p->typed.script = inferred_script;
-	new_arr._p->typed.where = "TypedArray";
 
 	return new_arr;
 }

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -30,12 +30,15 @@
 
 #include "callable.h"
 
+#include "core/object/class_db.h"
 #include "core/object/message_queue.h"
 #include "core/object/object.h"
 #include "core/object/ref_counted.h"
 #include "core/object/script_language.h"
 #include "core/variant/callable_bind.h"
 #include "core/variant/variant_callable.h"
+
+#include <functional>
 
 void Callable::call_deferredp(const Variant **p_arguments, int p_argcount) const {
 	MessageQueue::get_singleton()->push_callablep(*this, p_arguments, p_argcount, true);
@@ -199,6 +202,29 @@ int Callable::get_argument_count(bool *r_is_valid) const {
 	}
 }
 
+bool Callable::get_method_info(MethodInfo *r_info, Variant *r_return_script) const {
+	if (is_custom()) {
+		return custom->get_method_info(r_info, r_return_script);
+	} else if (is_valid()) {
+		Object *obj = get_object();
+		// Try the script first (covers GDScript/C# methods).
+		ScriptInstance *si = obj->get_script_instance();
+		Ref<Script> script = si ? si->get_script() : nullptr;
+		if (script.is_valid()) {
+			MethodInfo mi = script->get_method_info(method);
+			if (!(mi == MethodInfo())) {
+				if (r_info) {
+					*r_info = mi;
+				}
+				return true;
+			}
+		}
+		// Fall back to native ClassDB methods.
+		return ClassDB::get_method_info(obj->get_class_name(), method, r_info);
+	}
+	return false;
+}
+
 int Callable::get_bound_arguments_count() const {
 	if (!is_null() && is_custom()) {
 		return custom->get_bound_arguments_count();
@@ -306,7 +332,7 @@ bool Callable::operator<(const Callable &p_callable) const {
 			if (less_a == less_b) {
 				return less_a(custom, p_callable.custom);
 			} else {
-				return less_a < less_b; //it's something..
+				return std::less<CallableCustom::CompareLessFunc>()(less_a, less_b);
 			}
 
 		} else {
@@ -469,6 +495,10 @@ const Callable *CallableCustom::get_base_comparator() const {
 int CallableCustom::get_argument_count(bool &r_is_valid) const {
 	r_is_valid = false;
 	return 0;
+}
+
+bool CallableCustom::get_method_info(MethodInfo *r_info, Variant *r_return_script) const {
+	return false;
 }
 
 int CallableCustom::get_bound_arguments_count() const {

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -37,6 +37,7 @@ class Array;
 class Object;
 class Variant;
 class CallableCustom;
+struct MethodInfo;
 
 // This is an abstraction of things that can be called.
 // It is used for signals and other cases where efficient calling of functions
@@ -109,6 +110,7 @@ public:
 	StringName get_method() const;
 	CallableCustom *get_custom() const;
 	int get_argument_count(bool *r_is_valid = nullptr) const;
+	bool get_method_info(MethodInfo *r_info, Variant *r_return_script = nullptr) const;
 	int get_bound_arguments_count() const;
 	void get_bound_arguments_ref(Vector<Variant> &r_arguments) const; // Internal engine use, the exposed one is below.
 	Array get_bound_arguments() const;
@@ -161,6 +163,7 @@ public:
 	virtual Error rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const;
 	virtual const Callable *get_base_comparator() const;
 	virtual int get_argument_count(bool &r_is_valid) const;
+	virtual bool get_method_info(MethodInfo *r_info, Variant *r_return_script = nullptr) const;
 	virtual int get_bound_arguments_count() const;
 	virtual void get_bound_arguments(Vector<Variant> &r_arguments) const;
 	virtual int get_unbound_arguments_count() const;

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3642,10 +3642,30 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			if (p_call->function_name == SNAME("filter") && base_type.has_container_element_type(0)) {
 				return_type.set_container_element_type(0, base_type.get_container_element_type(0));
 			} else if (p_call->function_name == SNAME("map") && !p_call->arguments.is_empty()) {
-				const GDScriptParser::DataType &callable_type = p_call->arguments[0]->get_datatype();
+				const GDScriptParser::ExpressionNode *callable_argument = p_call->arguments[0];
+				const GDScriptParser::DataType &callable_type = callable_argument->get_datatype();
 				if (callable_type.kind == GDScriptParser::DataType::BUILTIN && callable_type.builtin_type == Variant::CALLABLE) {
-					// Callable signatures resolved by the analyzer are stored in `method_info`.
-					GDScriptParser::DataType mapped_type = type_from_property(callable_type.method_info.return_val);
+					GDScriptParser::DataType mapped_type;
+
+					// Prefer direct function information when available, as PropertyInfo loses
+					// some script-local class identity (e.g. local inner classes).
+					if (callable_argument->type == GDScriptParser::Node::LAMBDA) {
+						const GDScriptParser::LambdaNode *lambda = static_cast<const GDScriptParser::LambdaNode *>(callable_argument);
+						if (lambda->function != nullptr) {
+							mapped_type = lambda->function->get_datatype();
+						}
+					} else if (callable_argument->type == GDScriptParser::Node::IDENTIFIER) {
+						const GDScriptParser::IdentifierNode *identifier = static_cast<const GDScriptParser::IdentifierNode *>(callable_argument);
+						if (identifier->source == GDScriptParser::IdentifierNode::MEMBER_FUNCTION && identifier->function_source != nullptr) {
+							mapped_type = identifier->function_source->get_datatype();
+						}
+					}
+
+					if (!mapped_type.is_hard_type() || mapped_type.is_variant()) {
+						// Callable signatures resolved by the analyzer are stored in `method_info`.
+						mapped_type = type_from_property(callable_type.method_info.return_val);
+					}
+
 					if (mapped_type.is_hard_type() && !(mapped_type.kind == GDScriptParser::DataType::BUILTIN && mapped_type.builtin_type == Variant::NIL) && !mapped_type.is_variant()) {
 						return_type.set_container_element_type(0, mapped_type);
 					}

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3636,6 +3636,23 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 		}
 		validate_call_arg(par_types, default_arg_count, method_flags.has_flag(METHOD_FLAG_VARARG), p_call);
 
+		const bool is_array_builtin_call = base_type.kind == GDScriptParser::DataType::BUILTIN && base_type.builtin_type == Variant::ARRAY &&
+				return_type.kind == GDScriptParser::DataType::BUILTIN && return_type.builtin_type == Variant::ARRAY;
+		if (is_array_builtin_call) {
+			if (p_call->function_name == SNAME("filter") && base_type.has_container_element_type(0)) {
+				return_type.set_container_element_type(0, base_type.get_container_element_type(0));
+			} else if (p_call->function_name == SNAME("map") && !p_call->arguments.is_empty()) {
+				const GDScriptParser::DataType &callable_type = p_call->arguments[0]->get_datatype();
+				if (callable_type.kind == GDScriptParser::DataType::BUILTIN && callable_type.builtin_type == Variant::CALLABLE) {
+					// Callable signatures resolved by the analyzer are stored in `method_info`.
+					GDScriptParser::DataType mapped_type = type_from_property(callable_type.method_info.return_val);
+					if (mapped_type.is_hard_type() && !(mapped_type.kind == GDScriptParser::DataType::BUILTIN && mapped_type.builtin_type == Variant::NIL) && !mapped_type.is_variant()) {
+						return_type.set_container_element_type(0, mapped_type);
+					}
+				}
+			}
+		}
+
 		if (base_type.kind == GDScriptParser::DataType::ENUM && base_type.is_meta_type) {
 			// Enum type is treated as a dictionary value for function calls.
 			base_type.is_meta_type = false;
@@ -4679,6 +4696,9 @@ void GDScriptAnalyzer::reduce_lambda(GDScriptParser::LambdaNode *p_lambda) {
 	GDScriptParser::LambdaNode *previous_lambda = current_lambda;
 	current_lambda = p_lambda;
 	resolve_function_signature(p_lambda->function, p_lambda, true);
+	// Expose lambda return information through callable metadata for higher-order inference.
+	lambda_type.method_info = p_lambda->function->info;
+	p_lambda->set_datatype(lambda_type);
 	current_lambda = previous_lambda;
 
 	pending_body_resolution_lambdas.push_back(p_lambda);

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -480,6 +480,7 @@ public:
 	_FORCE_INLINE_ bool is_static() const { return _static; }
 	_FORCE_INLINE_ bool is_vararg() const { return _vararg_index >= 0; }
 	_FORCE_INLINE_ MethodInfo get_method_info() const { return method_info; }
+	_FORCE_INLINE_ const GDScriptDataType &get_return_type() const { return return_type; }
 	_FORCE_INLINE_ int get_argument_count() const { return _argument_count; }
 	_FORCE_INLINE_ Variant get_rpc_config() const { return rpc_config; }
 	_FORCE_INLINE_ int get_max_stack_size() const { return _stack_size; }

--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -89,6 +89,24 @@ int GDScriptLambdaCallable::get_argument_count(bool &r_is_valid) const {
 	return function->get_argument_count() - captures.size();
 }
 
+bool GDScriptLambdaCallable::get_method_info(MethodInfo *r_info, Variant *r_return_script) const {
+	if (function == nullptr) {
+		return false;
+	}
+	if (r_info) {
+		*r_info = function->get_method_info();
+	}
+	if (r_return_script) {
+		const GDScriptDataType &ret_type = function->get_return_type();
+		Ref<Script> ret_script = ret_type.script_type_ref;
+		if (ret_script.is_null() && ret_type.script_type != nullptr) {
+			ret_script.reference_ptr(ret_type.script_type);
+		}
+		*r_return_script = ret_script;
+	}
+	return true;
+}
+
 void GDScriptLambdaCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
 	int captures_amount = captures.size();
 
@@ -211,6 +229,24 @@ int GDScriptLambdaSelfCallable::get_argument_count(bool &r_is_valid) const {
 	}
 	r_is_valid = true;
 	return function->get_argument_count() - captures.size();
+}
+
+bool GDScriptLambdaSelfCallable::get_method_info(MethodInfo *r_info, Variant *r_return_script) const {
+	if (function == nullptr) {
+		return false;
+	}
+	if (r_info) {
+		*r_info = function->get_method_info();
+	}
+	if (r_return_script) {
+		const GDScriptDataType &ret_type = function->get_return_type();
+		Ref<Script> ret_script = ret_type.script_type_ref;
+		if (ret_script.is_null() && ret_type.script_type != nullptr) {
+			ret_script.reference_ptr(ret_type.script_type);
+		}
+		*r_return_script = ret_script;
+	}
+	return true;
 }
 
 void GDScriptLambdaSelfCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {

--- a/modules/gdscript/gdscript_lambda_callable.h
+++ b/modules/gdscript/gdscript_lambda_callable.h
@@ -59,6 +59,7 @@ public:
 	ObjectID get_object() const override;
 	StringName get_method() const override;
 	int get_argument_count(bool &r_is_valid) const override;
+	bool get_method_info(MethodInfo *r_info, Variant *r_return_script = nullptr) const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	GDScriptLambdaCallable(GDScriptLambdaCallable &) = delete;
@@ -88,6 +89,7 @@ public:
 	ObjectID get_object() const override;
 	StringName get_method() const override;
 	int get_argument_count(bool &r_is_valid) const override;
+	bool get_method_info(MethodInfo *r_info, Variant *r_return_script = nullptr) const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	GDScriptLambdaSelfCallable(GDScriptLambdaSelfCallable &) = delete;

--- a/modules/gdscript/tests/scripts/analyzer/errors/typed_array_filter_infers_source_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/typed_array_filter_infers_source_type.gd
@@ -1,0 +1,5 @@
+func test():
+	var source: Array[int] = [1, 2, 3]
+	var filtered := source.filter(func(a): return a > 1)
+	var typed: Array[String] = filtered
+	print('not ok')

--- a/modules/gdscript/tests/scripts/analyzer/errors/typed_array_filter_infers_source_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/typed_array_filter_infers_source_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 4: Cannot assign a value of type Array[int] to variable "typed" with specified type Array[String].

--- a/modules/gdscript/tests/scripts/analyzer/errors/typed_array_map_infers_callable_return.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/typed_array_map_infers_callable_return.gd
@@ -1,0 +1,4 @@
+func test():
+	var mapped := [1, 2, 3].map(func(a: int) -> float: return float(a) / 2.0)
+	var typed: Array[int] = mapped
+	print('not ok')

--- a/modules/gdscript/tests/scripts/analyzer/errors/typed_array_map_infers_callable_return.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/typed_array_map_infers_callable_return.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 3: Cannot assign a value of type Array[float] to variable "typed" with specified type Array[int].

--- a/modules/gdscript/tests/scripts/analyzer/errors/typed_array_map_infers_named_callable_return.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/typed_array_map_infers_named_callable_return.gd
@@ -1,0 +1,8 @@
+func half(a: int) -> float:
+	return float(a) / 2.0
+
+func test():
+	var callable = half
+	var mapped := [1, 2, 3].map(callable)
+	var typed: Array[int] = mapped
+	print('not ok')

--- a/modules/gdscript/tests/scripts/analyzer/errors/typed_array_map_infers_named_callable_return.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/typed_array_map_infers_named_callable_return.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 7: Cannot assign a value of type Array[float] to variable "typed" with specified type Array[int].

--- a/modules/gdscript/tests/scripts/analyzer/features/typed_array_map_filter_infers_types.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/typed_array_map_filter_infers_types.gd
@@ -1,22 +1,38 @@
+class Inner:
+	extends RefCounted
+
 func half(a: int) -> float:
 	return float(a) / 2.0
 
 func test():
 	var source: Array[int] = [1, 2, 3]
 
+	# filter preserves source element type.
 	var filtered := source.filter(func(a): return a > 1)
 	var filtered_value: int = filtered[0]
 	Utils.check(filtered_value == 2)
 
+	# map with lambda infers builtin return type.
 	var mapped_lambda := source.map(func(a: int) -> float: return float(a) / 2.0)
 	var mapped_lambda_value: float = mapped_lambda[0]
 	Utils.check(mapped_lambda.get_typed_builtin() == TYPE_FLOAT)
 	Utils.check(is_equal_approx(mapped_lambda_value, 0.5))
 
+	# map with named callable infers builtin return type.
 	var callable: Callable = half
 	var mapped_named := source.map(callable)
 	var mapped_named_value: float = mapped_named[0]
 	Utils.check(mapped_named.get_typed_builtin() == TYPE_FLOAT)
 	Utils.check(is_equal_approx(mapped_named_value, 0.5))
+
+	# map with lambda infers native class return type.
+	var mapped_native := source.map(func(_a: int) -> RefCounted: return RefCounted.new())
+	Utils.check(mapped_native.get_typed_builtin() == TYPE_OBJECT)
+	Utils.check(mapped_native.get_typed_class_name() == &"RefCounted")
+
+	# map with lambda infers custom script class return type.
+	var mapped_script := source.map(func(_a: int) -> Inner: return Inner.new())
+	Utils.check(mapped_script.get_typed_builtin() == TYPE_OBJECT)
+	Utils.check(mapped_script.get_typed_script() == Inner)
 
 	print('ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/typed_array_map_filter_infers_types.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/typed_array_map_filter_infers_types.gd
@@ -1,0 +1,22 @@
+func half(a: int) -> float:
+	return float(a) / 2.0
+
+func test():
+	var source: Array[int] = [1, 2, 3]
+
+	var filtered := source.filter(func(a): return a > 1)
+	var filtered_value: int = filtered[0]
+	Utils.check(filtered_value == 2)
+
+	var mapped_lambda := source.map(func(a: int) -> float: return float(a) / 2.0)
+	var mapped_lambda_value: float = mapped_lambda[0]
+	Utils.check(mapped_lambda.get_typed_builtin() == TYPE_FLOAT)
+	Utils.check(is_equal_approx(mapped_lambda_value, 0.5))
+
+	var callable: Callable = half
+	var mapped_named := source.map(callable)
+	var mapped_named_value: float = mapped_named[0]
+	Utils.check(mapped_named.get_typed_builtin() == TYPE_FLOAT)
+	Utils.check(is_equal_approx(mapped_named_value, 0.5))
+
+	print('ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/typed_array_map_filter_infers_types.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/typed_array_map_filter_infers_types.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok


### PR DESCRIPTION
Fixes #72566.

Changes typed array inference for higher-order array methods in GDScript and aligns runtime behavior for `map()`.

This enables examples like
```gdscript
var source: Array[int] = [1, 2, 3]
var filtered := source.filter(func(a): return a > 1)  # Array[int]
var mapped := source.map(func(a: int) -> float: return float(a) / 2.0)  # Array[float]
```
which would previously fail with `Trying to assign an array of type "Array" to a variable of type "Array[int]".`

### Commit 1: `GDScript: Infer typed array map/filter results`

- **Analyzer:** `Array[T].filter(...)` → `Array[T]`, `Array.map(-> R)` → `Array[R]` when callable return type is known. Lambda callables expose resolved signature info via `method_info`.
- **Runtime:** `Array.map()` scans result values to infer a common type and stamps the array. Falls back to untyped when types are mixed.

### Commit 2: `Core: Add Callable::get_method_info for runtime type introspection`

Replaces "value-scanning" with Callable metadata to get O(1) instead of O(n).

- **Core:** Adds `Callable::get_method_info()` and `CallableCustom::get_method_info()` virtual. Delegates to `Script` for GDScript/C# methods, `ClassDB` for native methods.
- **GDScript:** `GDScriptLambdaCallable` overrides to expose `GDScriptFunction`'s return type, including script class refs.
- **Runtime:** `Array.map()` reads the callable's declared return type directly instead of scanning values. Deterministic — type comes from the declaration, not the data.
- **Analyzer:** Reads return types directly from lambda/identifier AST nodes when available, falling back to `method_info`. This preserves script-local class identity (e.g. inner classes) that `PropertyInfo` loses.
- **Tests:** Added coverage for native class (`RefCounted`) and custom script class (`Inner`) return types.

---

I split these into two commits to show both approaches. If the `Callable::get_method_info` API addition (commit 2) is too broad in scope, commit 1 works standalone. Feedback welcome on which direction is preferred!
