### PR TITLE
Add AudioEffectPeakFilter

### DIFF
--- a/doc/classes/AudioEffectFilter.xml
+++ b/doc/classes/AudioEffectFilter.xml
@@ -9,6 +9,7 @@
 		Shelf filters: [AudioEffectLowShelfFilter] and [AudioEffectHighShelfFilter]
 		Band-pass and notch filters: [AudioEffectBandPassFilter], [AudioEffectBandLimitFilter], and [AudioEffectNotchFilter]
 		Low/high-pass filters: [AudioEffectLowPassFilter] and [AudioEffectHighPassFilter]
+		Peak filter: [AudioEffectPeakFilter]
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
@@ -28,7 +29,7 @@
 			Gain at or directly next to the [member cutoff_hz] frequency threshold. Value can range from 0 to 1.
 			Its exact behavior depends on the selected filter type:
 			- For shelf filters, it accentuates or masks the order by increasing frequencies right next to the [member cutoff_hz] frequency and decreasing frequencies on the opposite side.
-			- For the band-pass and notch filters, it widens or narrows the filter at the [member cutoff_hz] frequency threshold.
+			- For the band-pass, notch, and peak filters, it widens or narrows the filter at the [member cutoff_hz] frequency threshold.
 			- For low/high-pass filters, it increases or decreases frequencies at the [member cutoff_hz] frequency threshold.
 		</member>
 	</members>

--- a/doc/classes/AudioEffectPeakFilter.xml
+++ b/doc/classes/AudioEffectPeakFilter.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AudioEffectPeakFilter" inherits="AudioEffectFilter" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Adds a peak filter to an audio bus.
+	</brief_description>
+	<description>
+		A "peak" filter controls the gain of frequencies at [member AudioEffectFilter.cutoff_hz].
+		This filter can be used as a corrective filter, similar to an EQ, by increasing or decreasing the gain of frequencies at any point in the spectrum.
+	</description>
+	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+		<link title="Audio effects">$DOCS_URL/tutorials/audio/audio_effects.html</link>
+	</tutorials>
+</class>

--- a/servers/audio/audio_filter_sw.cpp
+++ b/servers/audio/audio_filter_sw.cpp
@@ -123,6 +123,7 @@ void AudioFilterSW::prepare_coefficients(Coeffs *p_coeffs) {
 			p_coeffs->a2 = 1.0 - alpha;
 		} break;
 		case PEAK: {
+			a0 = (1 + alpha / tmpgain);
 			p_coeffs->b0 = (1.0 + alpha * tmpgain);
 			p_coeffs->b1 = (-2.0 * cos_v);
 			p_coeffs->b2 = (1.0 - alpha * tmpgain);

--- a/servers/audio/effects/audio_effect_filter.h
+++ b/servers/audio/effects/audio_effect_filter.h
@@ -142,6 +142,14 @@ public:
 			AudioEffectFilter(AudioFilterSW::NOTCH) {}
 };
 
+class AudioEffectPeakFilter : public AudioEffectFilter {
+	GDCLASS(AudioEffectPeakFilter, AudioEffectFilter);
+
+public:
+	AudioEffectPeakFilter() :
+			AudioEffectFilter(AudioFilterSW::PEAK) {}
+};
+
 class AudioEffectBandLimitFilter : public AudioEffectFilter {
 	GDCLASS(AudioEffectBandLimitFilter, AudioEffectFilter);
 

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -197,6 +197,7 @@ void register_server_types() {
 		GDREGISTER_CLASS(AudioEffectHighPassFilter);
 		GDREGISTER_CLASS(AudioEffectBandPassFilter);
 		GDREGISTER_CLASS(AudioEffectNotchFilter);
+		GDREGISTER_CLASS(AudioEffectPeakFilter);
 		GDREGISTER_CLASS(AudioEffectBandLimitFilter);
 		GDREGISTER_CLASS(AudioEffectLowShelfFilter);
 		GDREGISTER_CLASS(AudioEffectHighShelfFilter);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
-->
Closes: https://github.com/godotengine/godot-proposals/issues/14580
Addresses: https://github.com/godotengine/godot/issues/80391 (in part... read below -- https://github.com/godotengine/godot/pull/30578 does a better job at closing it)
> Biggest frustration comes from the fact that there are all kinds of filters except the most essential ParametricEq (additive and subtractive frequency filtering with changeable frequency and resonance).

^ this filter CAN do that. It's not an EQ, But achieves the same result with a single cutoff control. There are similar issues/proposals, but I think there's no need to link them since they're not that relevant, and have other PRs that addresses them more directly.

----

`audio_filter_sw` has had a peak filter included since the beginning, but it was never exposed. This PR is an attempt to change that. Out of every filter type, this is one of the most known ones, and I really think it should be added. It not being in the engine at the moment is probably an oversight.
`AudioEffectEQ` has a similar effect, but EQ bands don't move in Godot. This is the easiest way to achieve something like it, I believe. Nothing else in Godot achieves the same effect.

My motivation is to help improve audio in Godot. Especially effects.

This filter was tested by controlling the filter parameters, listening, and watching the results on an external spectrum analyzer. It matched how a peak filter should behave as best as it can with the current implementation of filters. Trying to do any better would involve changing things outside the scope of this PR. As far as this single filter is concerned, it works and behaves as expected.

TODOs:

- [x] Fix `gain` for this filter - wrong behavior and breaks audio at low values
- [x] Fix `resonance` for this filter - wrong behavior
- [x] Write docs

For a future PR: if this is finished and merged, I believe it should be the default filter for `AudioEffectFilter`. It's an effect that shouldn't be used directly, and if it has to have a default mode, I believe a peak filter is better than a low-pass filter.

You can read more about this in the linked proposal. But I feel like this video is important enough that it should be linked here too:

https://github.com/user-attachments/assets/03796ec3-d96b-4bb1-a9b1-2d40927f3f5b

