### PR TITLE
Deselect bezier keyframes when switching animations

### DIFF
--- a/editor/animation/animation_bezier_editor.cpp
+++ b/editor/animation/animation_bezier_editor.cpp
@@ -910,6 +910,9 @@ Ref<Animation> AnimationBezierTrackEdit::get_animation() const {
 }
 
 void AnimationBezierTrackEdit::set_animation_and_track(const Ref<Animation> &p_animation, int p_track, bool p_read_only) {
+	if (p_animation != animation) {
+		selection.clear();
+	}
 	animation = p_animation;
 	read_only = p_read_only;
 	selected_track = p_track;


### PR DESCRIPTION
Fix [#116320](https://github.com/godotengine/godot/issues/116320)