### PR TITLE
GDScript: Disallow implicit use of packed arrays as constant expressions

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2108,12 +2108,20 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 		}
 
 		if (is_constant && !p_assignable->initializer->is_constant) {
-			bool is_initializer_value_reduced = false;
-			Variant initializer_value = make_expression_reduced_value(p_assignable->initializer, is_initializer_value_reduced);
-			if (is_initializer_value_reduced) {
-				p_assignable->initializer->is_constant = true;
-				p_assignable->initializer->reduced_value = initializer_value;
-			} else {
+			bool valid = specified_type.can_be_constant_expression();
+
+			if (valid) {
+				bool is_initializer_value_reduced = false;
+				Variant initializer_value = make_expression_reduced_value(p_assignable->initializer, is_initializer_value_reduced);
+				if (is_initializer_value_reduced) {
+					p_assignable->initializer->is_constant = true;
+					p_assignable->initializer->reduced_value = initializer_value;
+				} else {
+					valid = false;
+				}
+			}
+
+			if (!valid) {
 				push_error(vformat(R"(Assigned value for %s "%s" isn't a constant expression.)", p_kind, p_assignable->identifier->name), p_assignable->initializer);
 			}
 		}
@@ -5395,6 +5403,23 @@ Variant GDScriptAnalyzer::make_call_reduced_value(GDScriptParser::CallNode *p_ca
 			argptrs[i] = &args[i];
 		}
 
+		if (type == Variant::ARRAY) {
+			if (args.size() > 1) {
+				const Variant::Type elem_type = args[1];
+				if (elem_type >= Variant::PACKED_BYTE_ARRAY) {
+					return Variant();
+				}
+			}
+		} else if (type == Variant::DICTIONARY) {
+			if (args.size() > 4) {
+				const Variant::Type key_type = args[1];
+				const Variant::Type value_type = args[4];
+				if (key_type >= Variant::PACKED_BYTE_ARRAY || value_type >= Variant::PACKED_BYTE_ARRAY) {
+					return Variant();
+				}
+			}
+		}
+
 		Variant result;
 		Callable::CallError ce;
 		Variant::construct(type, result, argptrs, args.size(), ce);
@@ -5485,7 +5510,7 @@ Variant GDScriptAnalyzer::make_cast_reduced_value(GDScriptParser::CastNode *p_ca
 
 	GDScriptParser::DataType cast_type = type_from_metatype(resolve_datatype(p_cast->cast_type));
 
-	if (!cast_type.is_set()) {
+	if (!cast_type.is_set() || !cast_type.can_be_constant_expression()) {
 		return Variant();
 	}
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -5611,6 +5611,19 @@ bool GDScriptParser::DataType::can_reference(const GDScriptParser::DataType &p_o
 	return true;
 }
 
+bool GDScriptParser::DataType::can_be_constant_expression() const {
+	if (is_typed_container_type()) {
+		return false;
+	} else {
+		for (const GDScriptParser::DataType &param_type : container_element_types) {
+			if (param_type.is_typed_container_type()) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
 void GDScriptParser::complete_extents(Node *p_node) {
 	while (!nodes_in_progress.is_empty() && nodes_in_progress.back()->get() != p_node) {
 		ERR_PRINT("Parser bug: Mismatch in extents tracking stack.");

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -193,6 +193,8 @@ public:
 
 		bool can_reference(const DataType &p_other) const;
 
+		bool can_be_constant_expression() const;
+
 		bool operator==(const DataType &p_other) const {
 			if (type_source == UNDETECTED || p_other.type_source == UNDETECTED) {
 				return true; // Can be considered equal for parsing purposes.

--- a/modules/gdscript/tests/scripts/analyzer/errors/packed_arrays_are_not_const_expr.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/packed_arrays_are_not_const_expr.gd
@@ -1,0 +1,43 @@
+const TEST_TYPE: PackedByteArray = []
+const TEST_TYPE_ARRAY: Array[PackedByteArray] = []
+const TEST_TYPE_DICT_KEY: Dictionary[PackedByteArray, int] = {}
+const TEST_TYPE_DICT_VALUE: Dictionary[int, PackedByteArray] = {}
+
+const TEST_INITIALIZER = [] as PackedByteArray
+const TEST_INITIALIZER_INFER := [] as PackedByteArray
+const TEST_INITIALIZER_NESTED = [[] as PackedByteArray]
+const TEST_INITIALIZER_NESTED_INFER := [[] as PackedByteArray]
+
+const TEST_INITIALIZER_ARRAY = [] as Array[PackedByteArray]
+const TEST_INITIALIZER_INFER_ARRAY := [] as Array[PackedByteArray]
+const TEST_INITIALIZER_NESTED_ARRAY = [[] as Array[PackedByteArray]]
+const TEST_INITIALIZER_NESTED_INFER_ARRAY := [[] as Array[PackedByteArray]]
+
+const TEST_INITIALIZER_ADICT_KEY = {} as Dictionary[PackedByteArray, int]
+const TEST_INITIALIZER_INFER_DICT_KEY := {} as Dictionary[PackedByteArray, int]
+const TEST_INITIALIZER_NESTED_DICT_KEY = [{} as Dictionary[PackedByteArray, int]]
+const TEST_INITIALIZER_NESTED_INFER_DICT_KEY := [{} as Dictionary[PackedByteArray, int]]
+
+const TEST_INITIALIZER_ADICT_VALUE = {} as Dictionary[int, PackedByteArray]
+const TEST_INITIALIZER_INFER_DICT_VALUE := {} as Dictionary[int, PackedByteArray]
+const TEST_INITIALIZER_NESTED_DICT_VALUE = [{} as Dictionary[int, PackedByteArray]]
+const TEST_INITIALIZER_NESTED_INFER_DICT_VALUE := [{} as Dictionary[int, PackedByteArray]]
+
+const TEST_EXPLICIT_CONSTRUCTOR = PackedByteArray()
+const TEST_EXPLICIT_CONSTRUCTOR_ARRAY = Array(
+	[],
+	TYPE_PACKED_BYTE_ARRAY, &"", null,
+)
+const TEST_EXPLICIT_CONSTRUCTOR_DICT_KEY = Dictionary(
+	{},
+	TYPE_PACKED_BYTE_ARRAY, &"", null,
+	TYPE_INT, &"", null,
+)
+const TEST_EXPLICIT_CONSTRUCTOR_DICT_VALUE = Dictionary(
+	{},
+	TYPE_INT, &"", null,
+	TYPE_PACKED_BYTE_ARRAY, &"", null,
+)
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/packed_arrays_are_not_const_expr.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/packed_arrays_are_not_const_expr.out
@@ -1,0 +1,25 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 1: Assigned value for constant "TEST_TYPE" isn't a constant expression.
+>> ERROR at line 2: Assigned value for constant "TEST_TYPE_ARRAY" isn't a constant expression.
+>> ERROR at line 3: Assigned value for constant "TEST_TYPE_DICT_KEY" isn't a constant expression.
+>> ERROR at line 4: Assigned value for constant "TEST_TYPE_DICT_VALUE" isn't a constant expression.
+>> ERROR at line 6: Assigned value for constant "TEST_INITIALIZER" isn't a constant expression.
+>> ERROR at line 7: Assigned value for constant "TEST_INITIALIZER_INFER" isn't a constant expression.
+>> ERROR at line 8: Assigned value for constant "TEST_INITIALIZER_NESTED" isn't a constant expression.
+>> ERROR at line 9: Assigned value for constant "TEST_INITIALIZER_NESTED_INFER" isn't a constant expression.
+>> ERROR at line 11: Assigned value for constant "TEST_INITIALIZER_ARRAY" isn't a constant expression.
+>> ERROR at line 12: Assigned value for constant "TEST_INITIALIZER_INFER_ARRAY" isn't a constant expression.
+>> ERROR at line 13: Assigned value for constant "TEST_INITIALIZER_NESTED_ARRAY" isn't a constant expression.
+>> ERROR at line 14: Assigned value for constant "TEST_INITIALIZER_NESTED_INFER_ARRAY" isn't a constant expression.
+>> ERROR at line 16: Assigned value for constant "TEST_INITIALIZER_ADICT_KEY" isn't a constant expression.
+>> ERROR at line 17: Assigned value for constant "TEST_INITIALIZER_INFER_DICT_KEY" isn't a constant expression.
+>> ERROR at line 18: Assigned value for constant "TEST_INITIALIZER_NESTED_DICT_KEY" isn't a constant expression.
+>> ERROR at line 19: Assigned value for constant "TEST_INITIALIZER_NESTED_INFER_DICT_KEY" isn't a constant expression.
+>> ERROR at line 21: Assigned value for constant "TEST_INITIALIZER_ADICT_VALUE" isn't a constant expression.
+>> ERROR at line 22: Assigned value for constant "TEST_INITIALIZER_INFER_DICT_VALUE" isn't a constant expression.
+>> ERROR at line 23: Assigned value for constant "TEST_INITIALIZER_NESTED_DICT_VALUE" isn't a constant expression.
+>> ERROR at line 24: Assigned value for constant "TEST_INITIALIZER_NESTED_INFER_DICT_VALUE" isn't a constant expression.
+>> ERROR at line 26: Assigned value for constant "TEST_EXPLICIT_CONSTRUCTOR" isn't a constant expression.
+>> ERROR at line 27: Assigned value for constant "TEST_EXPLICIT_CONSTRUCTOR_ARRAY" isn't a constant expression.
+>> ERROR at line 31: Assigned value for constant "TEST_EXPLICIT_CONSTRUCTOR_DICT_KEY" isn't a constant expression.
+>> ERROR at line 36: Assigned value for constant "TEST_EXPLICIT_CONSTRUCTOR_DICT_VALUE" isn't a constant expression.

--- a/modules/gdscript/tests/scripts/analyzer/features/const_conversions.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/const_conversions.gd
@@ -2,9 +2,6 @@ const const_float_int: float = 19
 const const_float_plus: float = 12 + 22
 const const_float_cast: float = 76 as float
 
-const const_packed_empty: PackedFloat64Array = []
-const const_packed_ints: PackedFloat64Array = [52]
-
 func test():
 	Utils.check(typeof(const_float_int) == TYPE_FLOAT)
 	Utils.check(str(const_float_int) == '19.0')
@@ -12,12 +9,5 @@ func test():
 	Utils.check(str(const_float_plus) == '34.0')
 	Utils.check(typeof(const_float_cast) == TYPE_FLOAT)
 	Utils.check(str(const_float_cast) == '76.0')
-
-	Utils.check(typeof(const_packed_empty) == TYPE_PACKED_FLOAT64_ARRAY)
-	Utils.check(str(const_packed_empty) == '[]')
-	Utils.check(typeof(const_packed_ints) == TYPE_PACKED_FLOAT64_ARRAY)
-	Utils.check(str(const_packed_ints) == '[52.0]')
-	Utils.check(typeof(const_packed_ints[0]) == TYPE_FLOAT)
-	Utils.check(str(const_packed_ints[0]) == '52.0')
 
 	print('ok')


### PR DESCRIPTION
* Closes #67873.
* Closes #88753.
* Closes #100458.
* See also #116947.
* See also the [discussion](https://chat.godotengine.org/channel/core/thread/M6vdDHhiBA56wqB3G) in the Contributors Chat.

We can't implement the functionality required for immutable packed arrays in the core (the `make_read_only()` method, as is done for `Array` and `Dictionary`) because it introduces unnecessary overhead. Packed arrays (and the `Vector<T>` template, widely used in the engine) are designed for performance, even at the cost of convenience.

Alternatively, we could fix the crash for constant packed arrays but not implement immutability. This would mean that the contents of constant packed arrays would be mutable, like `Array` and `Dictionary` in 3.x. However, this option would be inconsistent with the behavior of `Array` and `Dictionary` in 4.x. Furthermore, there could be issues with constant dictionaries (if you use packed arrays as keys). Also, in some places, the compiler might rely on the immutability of constant expressions.