### PR TITLE
Add configuration warning for missing Mesh

### DIFF
--- a/scene/2d/mesh_instance_2d.cpp
+++ b/scene/2d/mesh_instance_2d.cpp
@@ -86,6 +86,7 @@ void MeshInstance2D::set_mesh(const Ref<Mesh> &p_mesh) {
 	}
 
 	queue_redraw();
+	update_configuration_warnings();
 }
 
 Ref<Mesh> MeshInstance2D::get_mesh() const {
@@ -217,5 +218,10 @@ void MeshInstance2D::navmesh_parse_source_geometry(const Ref<NavigationPolygon> 
 }
 #endif // NAVIGATION_2D_DISABLED
 
-MeshInstance2D::MeshInstance2D() {
+PackedStringArray MeshInstance2D::get_configuration_warnings() const {
+	PackedStringArray warnings = Node2D::get_configuration_warnings();
+	if (mesh.is_null()) {
+		warnings.push_back(RTR("MeshInstance2D requires a Mesh to render anything. Please add a mesh resource for it!"));
+	}
+	return warnings;
 }

--- a/scene/2d/mesh_instance_2d.h
+++ b/scene/2d/mesh_instance_2d.h
@@ -69,5 +69,5 @@ public:
 	static void navmesh_parse_source_geometry(const Ref<NavigationPolygon> &p_navigation_mesh, Ref<NavigationMeshSourceGeometryData2D> p_source_geometry_data, Node *p_node);
 #endif // NAVIGATION_2D_DISABLED
 
-	MeshInstance2D();
+	virtual PackedStringArray get_configuration_warnings() const override;
 };

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -136,6 +136,7 @@ void MeshInstance3D::set_mesh(const Ref<Mesh> &p_mesh) {
 	}
 
 	notify_property_list_changed();
+	update_configuration_warnings();
 }
 
 Ref<Mesh> MeshInstance3D::get_mesh() const {
@@ -933,6 +934,14 @@ void MeshInstance3D::_bind_methods() {
 	ADD_GROUP("", "");
 }
 
+PackedStringArray MeshInstance3D::get_configuration_warnings() const {
+	PackedStringArray warnings = GeometryInstance3D::get_configuration_warnings();
+	if (mesh.is_null()) {
+		warnings.push_back(RTR("MeshInstance3D requires a Mesh to render anything. Please add a mesh resource for it!"));
+	}
+	return warnings;
+}
+
 MeshInstance3D::MeshInstance3D() {
 	_define_ancestry(AncestralClass::MESH_INSTANCE_3D);
 #ifndef DISABLE_DEPRECATED
@@ -940,7 +949,4 @@ MeshInstance3D::MeshInstance3D() {
 		skeleton_path = NodePath("..");
 	}
 #endif
-}
-
-MeshInstance3D::~MeshInstance3D() {
 }

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -132,6 +132,7 @@ public:
 	static void navmesh_parse_source_geometry(const Ref<NavigationMesh> &p_navigation_mesh, Ref<NavigationMeshSourceGeometryData3D> p_source_geometry_data, Node *p_node);
 #endif // NAVIGATION_3D_DISABLED
 
+	virtual PackedStringArray get_configuration_warnings() const override;
+
 	MeshInstance3D();
-	~MeshInstance3D();
 };


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/14359
<img width="884" height="91" alt="image" src="https://github.com/user-attachments/assets/29c88a3e-2eca-4505-9032-e0f6324d5fd0" />
Also added to MeshInstanace2D for consistency.