### PR TITLE
Windows: Auto-enable single-window mode in virtualized GPU environments

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4370,7 +4370,7 @@ int Main::start() {
 
 		bool embed_subwindows = GLOBAL_GET("display/window/subwindows/embed_subwindows");
 
-		if (single_window || (!project_manager && !editor && embed_subwindows) || !DisplayServer::get_singleton()->has_feature(DisplayServer::Feature::FEATURE_SUBWINDOWS)) {
+		if (single_window || (!project_manager && !editor && embed_subwindows) || !DisplayServer::get_singleton()->has_feature(DisplayServer::Feature::FEATURE_SUBWINDOWS) || DisplayServer::get_singleton()->is_embedding_subwindows_recommended()) {
 			sml->get_root()->set_embedding_subwindows(true);
 		}
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -5309,7 +5309,10 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 		case WM_ERASEBKGND: {
 			Color early_color;
 			if (!_get_window_early_clear_override(early_color)) {
-				break;
+				// Even without an early clear color, suppress default erase to
+				// prevent black flashes when windows are first shown or resized,
+				// especially in virtualized GPU environments.
+				return 1;
 			}
 			bool must_recreate_brush = !window_bkg_brush || window_bkg_brush_color != early_color.to_argb32();
 			if (must_recreate_brush) {
@@ -7942,6 +7945,18 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 			return;
 		}
 		RasterizerGLES3::make_current(false);
+	}
+#endif
+
+#ifdef GLES3_ENABLED
+	// In virtualized environments (e.g., Hyper-V GPU-PV), OpenGL multi-window rendering
+	// causes flickering due to GPU driver limitations with wglMakeCurrent context switching.
+	// Auto-enable single-window mode to avoid these rendering artifacts.
+	if ((rendering_driver == "opengl3" || rendering_driver == "opengl3_angle") &&
+			rendering_context == nullptr &&
+			IsProcessorFeaturePresent(PF_VIRT_FIRMWARE_ENABLED)) {
+		WARN_PRINT("Virtualized GPU detected without Vulkan support. Recommending single-window mode to avoid rendering artifacts.");
+		embedding_subwindows_recommended = true;
 	}
 #endif
 

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -126,6 +126,8 @@ private:
 protected:
 	static void _bind_methods();
 
+	bool embedding_subwindows_recommended = false;
+
 #ifndef DISABLE_DEPRECATED
 	static void _bind_compatibility_methods();
 #endif
@@ -901,6 +903,8 @@ public:
 
 	virtual void release_rendering_thread();
 	virtual void swap_buffers();
+
+	bool is_embedding_subwindows_recommended() const { return embedding_subwindows_recommended; }
 
 	virtual void set_native_icon(const String &p_filename);
 	virtual void set_icon(const Ref<Image> &p_icon);


### PR DESCRIPTION
## Summary

Automatically enable single-window (embedded sub-windows) mode on Windows when running in a virtualized GPU environment where Vulkan device creation has failed.

### Changes

- **VM detection** (`display_server_windows.cpp`): When the rendering driver is OpenGL and no Vulkan rendering context exists, check `IsProcessorFeaturePresent(PF_VIRT_FIRMWARE_ENABLED)` to detect hypervisor environments. If all conditions are met, set `embedding_subwindows_recommended = true`.
- **DisplayServer API** (`display_server.h`): Added `embedding_subwindows_recommended` protected bool and `is_embedding_subwindows_recommended()` public getter to the base `DisplayServer` class.
- **Startup check** (`main.cpp`): Check `is_embedding_subwindows_recommended()` alongside the existing single-window conditions to auto-enable embedded sub-windows.
- **WM_ERASEBKGND** (`display_server_windows.cpp`): Always return 1 (suppress default erase) to reduce flicker during window resize/repaint.

### Motivation

In Hyper-V GPU paravirtualization (GPU-PV) environments with NVIDIA GPUs, Vulkan device creation fails entirely (`VK_ERROR_INITIALIZATION_FAILED`), forcing the engine to use OpenGL. With OpenGL, all windows share a single rendering context via `wglMakeCurrent`. When multiple windows exist (dialogs, popups, sub-windows), the constant context switching causes severe UI flickering due to limitations in the paravirtualized GPU driver.

Single-window mode embeds all sub-windows within the main window, eliminating the need for `wglMakeCurrent` context switching and completely resolving the flickering.

### Detection Logic

The detection is intentionally narrow to avoid false positives:
1. **OpenGL is active** (`rendering_driver == "opengl3"`).
2. **No Vulkan context exists** (`rendering_context == nullptr`), indicating Vulkan failed.
3. **Running in a hypervisor** (`IsProcessorFeaturePresent(PF_VIRT_FIRMWARE_ENABLED)`).

This combination targets specifically GPU-PV environments with broken Vulkan support. Bare-metal users, VMs with working Vulkan, and VMs using software rendering are unaffected.

### Testing

Tested on Hyper-V VM with paravirtualized NVIDIA RTX 4090:
- Before: Severe UI flickering when any dialog or sub-window opens
- After: No flickering; all sub-windows embedded in main window
- Bare-metal: No behavior change (Vulkan works, detection does not trigger)

### Related

PR #116957 improves the Vulkan error logging that helps diagnose these environments.

### Other approaches tried

Before arriving at the single-window auto-detection fix, several other approaches were investigated and tested on the same Hyper-V GPU-PV environment. None resolved the flickering:

- **`DwmFlush()` after swap** — Called `DwmFlush()` per-window in `swap_buffers` and also as a single end-of-frame flush. Had no measurable effect on the flickering because the issue is in `wglMakeCurrent` context switching, not in swap timing or DWM composition.
- **Suppressing `WM_ERASEBKGND`** — Returning 1 from `WM_ERASEBKGND` (kept in this PR) reduces repaint flicker slightly but does not address the core multi-window GL context switching issue on its own.
- **Deferred `SwapBuffers`** — Rendered all viewports first, then called `SwapBuffers` for all windows at the end of the frame. Did not help because the flickering occurs during `wglMakeCurrent` calls between windows, not during the swap itself.
- **Disabling vsync** — No effect on the flickering.
- **Vulkan extension reduction/retry** — Attempted stripping non-essential Vulkan extensions and retrying `vkCreateDevice` (now in PR #116957). The GPU-PV driver fails with `VK_ERROR_INITIALIZATION_FAILED` regardless of which extensions are requested, even with swapchain only. Vulkan is fundamentally unsupported in this environment.
- **ANGLE (OpenGL-over-DirectX)** — Could theoretically bypass the `wglMakeCurrent` issue by using DirectX under the hood, but requires pre-built static libraries not included in the Godot repository and was not feasible to test.
- **`--single-window` command-line flag** — Manually passing `--single-window` confirmed that single-window mode eliminates the flickering entirely, which led to implementing automatic detection in this PR.