### PR TITLE
Refactor `blas_create` to accept multiple geometries.

### DIFF
--- a/doc/classes/RDAccelerationStructureGeometry.xml
+++ b/doc/classes/RDAccelerationStructureGeometry.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RDAccelerationStructureGeometry" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Acceleration structure geometry (used by [RenderingDevice]).
+	</brief_description>
+	<description>
+		[RDAccelerationStructureGeometry] describes a set of triangles used as raytracing geometry in the [method RenderingDevice.blas_create] method.
+		The geometry is always in triangle list form, either indexed or non-indexed. Triangle strips are not supported.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="flags" type="int" setter="set_flags" getter="get_flags" enum="RenderingDevice.AccelerationStructureGeometryFlagBits" is_bitfield="true" default="0">
+			Flags for the geometry.
+		</member>
+		<member name="index_buffer" type="RID" setter="set_index_buffer" getter="get_index_buffer" default="RID()">
+			Buffer containing vertex indices. If [code]null[/code], triangles are non-indexed.
+		</member>
+		<member name="index_count" type="int" setter="set_index_count" getter="get_index_count" default="0">
+			Number of indices used by this geometry in [member index_buffer].
+		</member>
+		<member name="index_offset" type="int" setter="set_index_offset" getter="get_index_offset" default="0">
+			Byte offset of the first index in [member index_buffer].
+		</member>
+		<member name="vertex_buffer" type="RID" setter="set_vertex_buffer" getter="get_vertex_buffer" default="RID()">
+			Buffer containing vertices.
+		</member>
+		<member name="vertex_count" type="int" setter="set_vertex_count" getter="get_vertex_count" default="0">
+			Number of vertices used by this geometry in [member vertex_buffer].
+		</member>
+		<member name="vertex_format" type="int" setter="set_vertex_format" getter="get_vertex_format" enum="RenderingDevice.DataFormat" default="232">
+			Format of the vertices in [member vertex_buffer].
+		</member>
+		<member name="vertex_offset" type="int" setter="set_vertex_offset" getter="get_vertex_offset" default="0">
+			Byte offset of the first vertex in [member vertex_buffer].
+		</member>
+		<member name="vertex_stride" type="int" setter="set_vertex_stride" getter="get_vertex_stride" default="0">
+			Number of bytes between each vertex in [member vertex_buffer].
+		</member>
+	</members>
+</class>

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -31,14 +31,10 @@
 		</method>
 		<method name="blas_create">
 			<return type="RID" />
-			<param index="0" name="vertex_array" type="RID" />
-			<param index="1" name="index_array" type="RID" />
-			<param index="2" name="geometry_bits" type="int" enum="RenderingDevice.AccelerationStructureGeometryBits" is_bitfield="true" default="0" />
-			<param index="3" name="position_attribute_location" type="int" default="0" />
+			<param index="0" name="geometries" type="RDAccelerationStructureGeometry[]" />
 			<description>
 				Creates a new Bottom Level Acceleration Structure. It can be accessed with the RID that is returned.
 				Once finished with your RID, you will want to free the RID using the RenderingDevice's [method free_rid] method.
-				[param position_attribute_location] selects which vertex attribute location supplies the position data (default is 0).
 			</description>
 		</method>
 		<method name="buffer_clear">
@@ -763,7 +759,7 @@
 				assert(rd.has_feature(RenderingDevice.SUPPORTS_RAYTRACING_PIPELINE))
 
 				# Create a BLAS for a mesh.
-				blas = rd.blas_create(vertex_array, index_array, RenderingDevice.ACCELERATION_STRUCTURE_GEOMETRY_OPAQUE)
+				blas = rd.blas_create(geometries)
 				# Create TLAS with BLASs.
 				instances_buffer = rd.tlas_instances_buffer_create(1)
 				rd.tlas_instances_buffer_fill(instances_buffer, [blas], [Transform3D()])
@@ -2298,10 +2294,10 @@
 			[/gdscript]
 			[/codeblocks]
 		</constant>
-		<constant name="ACCELERATION_STRUCTURE_GEOMETRY_OPAQUE" value="1" enum="AccelerationStructureGeometryBits" is_bitfield="true">
+		<constant name="ACCELERATION_STRUCTURE_GEOMETRY_OPAQUE_BIT" value="1" enum="AccelerationStructureGeometryFlagBits" is_bitfield="true">
 			An opaque geometry does not invoke the any hit shaders.
 		</constant>
-		<constant name="ACCELERATION_STRUCTURE_GEOMETRY_NO_DUPLICATE_ANY_HIT_INVOCATION" value="2" enum="AccelerationStructureGeometryBits" is_bitfield="true">
+		<constant name="ACCELERATION_STRUCTURE_GEOMETRY_NO_DUPLICATE_ANY_HIT_INVOCATION_BIT" value="2" enum="AccelerationStructureGeometryFlagBits" is_bitfield="true">
 			This geometry only calls the any hit shader a single time for each primitive.
 		</constant>
 		<constant name="UNIFORM_TYPE_SAMPLER" value="0" enum="UniformType">

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -5536,7 +5536,7 @@ RDD::PipelineID RenderingDeviceDriverD3D12::compute_pipeline_create(ShaderID p_s
 
 // ---- ACCELERATION STRUCTURES ----
 
-RDD::AccelerationStructureID RenderingDeviceDriverD3D12::blas_create(BufferID p_vertex_buffer, uint64_t p_vertex_offset, VertexFormatID p_vertex_format, uint32_t p_vertex_count, uint32_t p_position_attribute_location, BufferID p_index_buffer, IndexBufferFormat p_index_format, uint64_t p_index_offset, uint32_t p_index_count, BitField<AccelerationStructureGeometryBits> p_geometry_bits) {
+RDD::AccelerationStructureID RenderingDeviceDriverD3D12::blas_create(VectorView<AccelerationStructureGeometry> p_geometries) {
 	ERR_FAIL_V_MSG(AccelerationStructureID(), "Ray tracing is not currently supported by the D3D12 driver.");
 }
 

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -857,7 +857,7 @@ public:
 
 	// ---- ACCELERATION STRUCTURES ----
 
-	virtual AccelerationStructureID blas_create(BufferID p_vertex_buffer, uint64_t p_vertex_offset, VertexFormatID p_vertex_format, uint32_t p_vertex_count, uint32_t p_position_attribute_location, BufferID p_index_buffer, IndexBufferFormat p_index_format, uint64_t p_index_offset, uint32_t p_index_count, BitField<AccelerationStructureGeometryBits> p_geometry_bits) override final;
+	virtual AccelerationStructureID blas_create(VectorView<AccelerationStructureGeometry> p_geometries) override final;
 	virtual uint32_t tlas_instances_buffer_get_size_bytes(uint32_t p_instance_count) override final;
 	virtual void tlas_instances_buffer_fill(BufferID p_instances_buffer, VectorView<AccelerationStructureID> p_blases, VectorView<Transform3D> p_transforms) override final;
 	virtual AccelerationStructureID tlas_create(BufferID p_instances_buffer) override final;

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -2262,7 +2262,7 @@ RDD::PipelineID RenderingDeviceDriverMetal::compute_pipeline_create(ShaderID p_s
 
 // ----- ACCELERATION STRUCTURE -----
 
-RDD::AccelerationStructureID RenderingDeviceDriverMetal::blas_create(BufferID p_vertex_buffer, uint64_t p_vertex_offset, VertexFormatID p_vertex_format, uint32_t p_vertex_count, uint32_t p_position_attribute_location, BufferID p_index_buffer, IndexBufferFormat p_index_format, uint64_t p_index_offset_bytes, uint32_t p_index_coun, BitField<AccelerationStructureGeometryBits> p_geometry_bits) {
+RDD::AccelerationStructureID RenderingDeviceDriverMetal::blas_create(VectorView<AccelerationStructureGeometry> p_geometries) {
 	ERR_FAIL_V_MSG(AccelerationStructureID(), "Ray tracing is not currently supported by the Metal driver.");
 }
 

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -461,7 +461,7 @@ public:
 
 	// ----- ACCELERATION STRUCTURE -----
 
-	virtual AccelerationStructureID blas_create(BufferID p_vertex_buffer, uint64_t p_vertex_offset, VertexFormatID p_vertex_format, uint32_t p_vertex_count, uint32_t p_position_attribute_location, BufferID p_index_buffer, IndexBufferFormat p_index_format, uint64_t p_index_offset_bytes, uint32_t p_index_count, BitField<AccelerationStructureGeometryBits> p_geometry_bits) override final;
+	virtual AccelerationStructureID blas_create(VectorView<AccelerationStructureGeometry> p_geometries) override final;
 	virtual uint32_t tlas_instances_buffer_get_size_bytes(uint32_t p_instance_count) override final;
 	virtual void tlas_instances_buffer_fill(BufferID p_instances_buffer, VectorView<AccelerationStructureID> p_blases, VectorView<Transform3D> p_transforms) override final;
 	virtual AccelerationStructureID tlas_create(BufferID p_instances_buffer) override final;

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -6164,85 +6164,65 @@ RDD::PipelineID RenderingDeviceDriverVulkan::render_pipeline_create(
 /********************/
 
 // RDD::AccelerationStructureGeometryBits == VkGeometryFlagsKHR.
-static_assert(ENUM_MEMBERS_EQUAL(RDD::ACCELERATION_STRUCTURE_GEOMETRY_OPAQUE, VK_GEOMETRY_OPAQUE_BIT_KHR));
-static_assert(ENUM_MEMBERS_EQUAL(RDD::ACCELERATION_STRUCTURE_GEOMETRY_NO_DUPLICATE_ANY_HIT_INVOCATION, VK_GEOMETRY_NO_DUPLICATE_ANY_HIT_INVOCATION_BIT_KHR));
+static_assert(ENUM_MEMBERS_EQUAL(RDD::ACCELERATION_STRUCTURE_GEOMETRY_OPAQUE_BIT, VK_GEOMETRY_OPAQUE_BIT_KHR));
+static_assert(ENUM_MEMBERS_EQUAL(RDD::ACCELERATION_STRUCTURE_GEOMETRY_NO_DUPLICATE_ANY_HIT_INVOCATION_BIT, VK_GEOMETRY_NO_DUPLICATE_ANY_HIT_INVOCATION_BIT_KHR));
 
-RDD::AccelerationStructureID RenderingDeviceDriverVulkan::blas_create(BufferID p_vertex_buffer, uint64_t p_vertex_offset, VertexFormatID p_vertex_format, uint32_t p_vertex_count, uint32_t p_position_attribute_location, BufferID p_index_buffer, IndexBufferFormat p_index_format, uint64_t p_index_offset_bytes, uint32_t p_index_count, BitField<AccelerationStructureGeometryBits> p_geometry_bits) {
+RDD::AccelerationStructureID RenderingDeviceDriverVulkan::blas_create(VectorView<AccelerationStructureGeometry> p_geometries) {
 #if VULKAN_RAYTRACING_ENABLED
-	const VertexFormatInfo *vf_info = (const VertexFormatInfo *)p_vertex_format.id;
-
-	const VkVertexInputAttributeDescription *position_attribute = nullptr;
-	for (const VkVertexInputAttributeDescription &attribute : vf_info->vk_attributes) {
-		if (attribute.location == p_position_attribute_location) {
-			position_attribute = &attribute;
-			break;
-		}
-	}
-	ERR_FAIL_NULL_V_MSG(position_attribute, AccelerationStructureID(), "BLAS position attribute location is missing from the vertex format.");
-
-	uint32_t position_binding_index = position_attribute->binding;
-	if (position_binding_index == UINT32_MAX) {
-		position_binding_index = p_position_attribute_location;
-	}
-
-	const VkVertexInputBindingDescription *position_binding = nullptr;
-	for (const VkVertexInputBindingDescription &binding : vf_info->vk_bindings) {
-		if (binding.binding == position_binding_index) {
-			position_binding = &binding;
-			break;
-		}
-	}
-	ERR_FAIL_NULL_V_MSG(position_binding, AccelerationStructureID(), "BLAS position attribute binding is missing from the vertex format.");
-
-	VkDeviceSize buffer_offset = position_attribute->offset;
-
-	VkDeviceAddress vertex_address = buffer_get_device_address(p_vertex_buffer) + buffer_offset;
-	VkDeviceAddress index_address = buffer_get_device_address(p_index_buffer) + p_index_offset_bytes;
-
-	VkDeviceSize vertex_stride = position_binding->stride;
-	VkFormat vertex_format = position_attribute->format;
-	uint32_t max_vertex = p_vertex_count ? p_vertex_count - 1 : 0;
-
 	AccelerationStructureInfo *accel_info = VersatileResource::allocate<AccelerationStructureInfo>(resources_allocator);
 
-	accel_info->geometry.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
-	accel_info->geometry.geometryType = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
-	accel_info->geometry.flags = p_geometry_bits;
+	accel_info->geometries.resize(p_geometries.size());
+	accel_info->range_infos.resize(p_geometries.size());
 
-	accel_info->geometry.geometry.triangles.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR;
-	accel_info->geometry.geometry.triangles.vertexFormat = vertex_format;
-	accel_info->geometry.geometry.triangles.vertexData.deviceAddress = vertex_address;
-	accel_info->geometry.geometry.triangles.vertexStride = vertex_stride;
-	accel_info->geometry.geometry.triangles.indexType = p_index_format == INDEX_BUFFER_FORMAT_UINT16 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32;
-	accel_info->geometry.geometry.triangles.indexData.deviceAddress = index_address;
-	accel_info->geometry.geometry.triangles.transformData.deviceAddress = 0;
-	// Number of vertices in vertexData minus one, aka max vertex index.
-	accel_info->geometry.geometry.triangles.maxVertex = max_vertex;
+	thread_local LocalVector<uint32_t> max_primitive_counts;
+	max_primitive_counts.resize(p_geometries.size());
 
-	// Info for building BLAS.
-	uint32_t primitive_count = p_vertex_count / 3;
-	if (p_index_buffer) {
-		primitive_count = p_index_count / 3;
+	for (uint32_t i = 0; i < p_geometries.size(); i++) {
+		const AccelerationStructureGeometry &geometry = p_geometries[i];
+
+		VkAccelerationStructureGeometryKHR &vk_geometry = accel_info->geometries[i];
+		vk_geometry = {};
+		vk_geometry.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+		vk_geometry.geometryType = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
+		vk_geometry.flags = geometry.flags;
+
+		vk_geometry.geometry.triangles.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR;
+		vk_geometry.geometry.triangles.vertexFormat = RD_TO_VK_FORMAT[geometry.vertex_format];
+		vk_geometry.geometry.triangles.vertexData.deviceAddress = buffer_get_device_address(geometry.vertex_buffer) + geometry.vertex_offset;
+		vk_geometry.geometry.triangles.vertexStride = geometry.vertex_stride;
+		// Number of vertices in vertexData minus one, aka max vertex index.
+		vk_geometry.geometry.triangles.maxVertex = (geometry.vertex_count ? (geometry.vertex_count - 1) : 0);
+
+		// Info for building BLAS.
+		uint32_t primitive_count;
+		if (geometry.index_buffer != BufferID()) {
+			vk_geometry.geometry.triangles.indexType = (geometry.index_format == INDEX_BUFFER_FORMAT_UINT16 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32);
+			vk_geometry.geometry.triangles.indexData.deviceAddress = buffer_get_device_address(geometry.index_buffer) + geometry.index_offset;
+			primitive_count = geometry.index_count / 3;
+		} else {
+			vk_geometry.geometry.triangles.indexType = VK_INDEX_TYPE_NONE_KHR;
+			primitive_count = geometry.vertex_count / 3;
+		}
+
+		VkAccelerationStructureBuildRangeInfoKHR &vk_range_info = accel_info->range_infos[i];
+		vk_range_info = {};
+		vk_range_info.primitiveCount = primitive_count;
+
+		max_primitive_counts[i] = primitive_count;
 	}
-	// The vertex offset is expressed in bytes.
-	uint32_t first_vertex = p_vertex_offset / vertex_stride;
-	accel_info->range_info.firstVertex = first_vertex;
-	accel_info->range_info.primitiveCount = primitive_count;
-	accel_info->range_info.primitiveOffset = 0;
-	accel_info->range_info.transformOffset = 0;
-	uint32_t max_primitive_count = accel_info->range_info.primitiveCount;
 
+	accel_info->build_info = {};
 	accel_info->build_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
 	accel_info->build_info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
 	accel_info->build_info.mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
-	accel_info->build_info.pGeometries = &accel_info->geometry;
-	accel_info->build_info.geometryCount = 1;
+	accel_info->build_info.pGeometries = accel_info->geometries.ptr();
+	accel_info->build_info.geometryCount = p_geometries.size();
 	accel_info->build_info.flags = VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR;
 
 	VkAccelerationStructureBuildSizesInfoKHR size_info = {};
 	size_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;
 
-	vkGetAccelerationStructureBuildSizesKHR(vk_device, VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR, &accel_info->build_info, &max_primitive_count, &size_info);
+	vkGetAccelerationStructureBuildSizesKHR(vk_device, VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR, &accel_info->build_info, max_primitive_counts.ptr(), &size_info);
 	_acceleration_structure_create(VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR, size_info, accel_info);
 
 	return AccelerationStructureID(accel_info);
@@ -6312,15 +6292,17 @@ RDD::AccelerationStructureID RenderingDeviceDriverVulkan::tlas_create(BufferID p
 
 	AccelerationStructureInfo *accel_info = VersatileResource::allocate<AccelerationStructureInfo>(resources_allocator);
 
-	accel_info->geometry.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
-	accel_info->geometry.geometryType = VK_GEOMETRY_TYPE_INSTANCES_KHR;
-	accel_info->geometry.geometry.instances.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR;
-	accel_info->geometry.geometry.instances.data.deviceAddress = buffer_get_device_address(p_instances_buffer);
+	accel_info->geometries.resize_initialized(1);
+	accel_info->geometries[0].sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+	accel_info->geometries[0].geometryType = VK_GEOMETRY_TYPE_INSTANCES_KHR;
+	accel_info->geometries[0].geometry.instances.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR;
+	accel_info->geometries[0].geometry.instances.data.deviceAddress = buffer_get_device_address(p_instances_buffer);
 
+	accel_info->build_info = {};
 	accel_info->build_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
 	accel_info->build_info.flags = VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR;
 	accel_info->build_info.geometryCount = 1;
-	accel_info->build_info.pGeometries = &accel_info->geometry;
+	accel_info->build_info.pGeometries = &accel_info->geometries[0];
 	accel_info->build_info.mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
 	accel_info->build_info.type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
 
@@ -6328,7 +6310,9 @@ RDD::AccelerationStructureID RenderingDeviceDriverVulkan::tlas_create(BufferID p
 	VkAccelerationStructureBuildSizesInfoKHR size_info = {};
 	size_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;
 	vkGetAccelerationStructureBuildSizesKHR(vk_device, VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR, &accel_info->build_info, &instance_count, &size_info);
-	accel_info->range_info.primitiveCount = instance_count;
+
+	accel_info->range_infos.resize_initialized(1);
+	accel_info->range_infos[0].primitiveCount = instance_count;
 
 	_acceleration_structure_create(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR, size_info, accel_info);
 	return AccelerationStructureID(accel_info);
@@ -6397,9 +6381,9 @@ void RenderingDeviceDriverVulkan::command_build_acceleration_structure(CommandBu
 	VkDeviceAddress scratch_address = buffer_get_device_address(p_scratch_buffer);
 	build_info->scratchData.deviceAddress = _align_up_address(scratch_address, accel_info->scratch_alignment);
 
-	const VkAccelerationStructureBuildRangeInfoKHR *range_info_ptr = &accel_info->range_info;
+	const VkAccelerationStructureBuildRangeInfoKHR *range_infos = accel_info->range_infos.ptr();
 
-	vkCmdBuildAccelerationStructuresKHR(command_buffer->vk_command_buffer, 1, build_info, &range_info_ptr);
+	vkCmdBuildAccelerationStructuresKHR(command_buffer->vk_command_buffer, 1, build_info, &range_infos);
 #endif
 }
 

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -716,13 +716,13 @@ public:
 		RDD::BufferID instances_buffer;
 
 		// Required for building
-		VkAccelerationStructureGeometryKHR geometry;
+		TightLocalVector<VkAccelerationStructureGeometryKHR> geometries;
 		LocalVector<VkAccelerationStructureInstanceKHR> instances;
 		VkAccelerationStructureBuildGeometryInfoKHR build_info;
-		VkAccelerationStructureBuildRangeInfoKHR range_info;
+		TightLocalVector<VkAccelerationStructureBuildRangeInfoKHR> range_infos;
 	};
 
-	virtual AccelerationStructureID blas_create(BufferID p_vertex_buffer, uint64_t p_vertex_offset, VertexFormatID p_vertex_format, uint32_t p_vertex_count, uint32_t p_position_attribute_location, BufferID p_index_buffer, IndexBufferFormat p_index_format, uint64_t p_index_offset_bytes, uint32_t p_index_count, BitField<AccelerationStructureGeometryBits> p_geometry_bits) override final;
+	virtual AccelerationStructureID blas_create(VectorView<AccelerationStructureGeometry> p_geometries) override final;
 	virtual uint32_t tlas_instances_buffer_get_size_bytes(uint32_t p_instance_count) override final;
 	virtual void tlas_instances_buffer_fill(BufferID p_instances_buffer, VectorView<AccelerationStructureID> p_blases, VectorView<Transform3D> p_transforms) override final;
 	virtual AccelerationStructureID tlas_create(BufferID p_instances_buffer) override final;

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -245,6 +245,7 @@ void register_server_types() {
 	GDREGISTER_CLASS(RDShaderSPIRV);
 	GDREGISTER_CLASS(RDShaderFile);
 	GDREGISTER_CLASS(RDPipelineSpecializationConstant);
+	GDREGISTER_CLASS(RDAccelerationStructureGeometry);
 
 	GDREGISTER_ABSTRACT_CLASS(RenderData);
 	GDREGISTER_CLASS(RenderDataExtension);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -223,88 +223,97 @@ RID RenderingDevice::shader_create_from_spirv(const Vector<ShaderStageSPIRVData>
 /**** ACCELERATION STRUCTURE ****/
 /********************************/
 
-RID RenderingDevice::blas_create(RID p_vertex_array, RID p_index_array, BitField<AccelerationStructureGeometryBits> p_geometry_bits, uint32_t p_position_attribute_location) {
+RID RenderingDevice::blas_create(Span<AccelerationStructureGeometry> p_geometries) {
 	ERR_FAIL_COND_V_MSG(!has_feature(SUPPORTS_RAYTRACING_PIPELINE) && !has_feature(SUPPORTS_RAY_QUERY), RID(), "The current rendering device has neither raytracing pipeline nor ray query support.");
 
-	VertexArray *vertex_array = vertex_array_owner.get_or_null(p_vertex_array);
-	ERR_FAIL_NULL_V(vertex_array, RID());
+	thread_local LocalVector<RDD::AccelerationStructureGeometry> rdd_geometries;
+	rdd_geometries.resize(p_geometries.size());
 
-	uint32_t position_binding = p_position_attribute_location;
-	RDD::VertexFormatID vertex_format;
+	Vector<RDG::ResourceTracker *> draw_trackers;
+	HashSet<RID> untracked_buffers;
 
-	if (vertex_array->description != INVALID_ID) {
-		ERR_FAIL_COND_V(!vertex_formats.has(vertex_array->description), RID());
-		const VertexDescriptionCache &vd_cache = vertex_formats[vertex_array->description];
-		vertex_format = vd_cache.driver_id;
+	for (uint64_t i = 0; i < p_geometries.size(); i++) {
+		const AccelerationStructureGeometry &rd_geometry = p_geometries[i];
+		if (rd_geometry.index_buffer.is_valid()) {
+			ERR_FAIL_COND_V_MSG((rd_geometry.index_count % 3) != 0, RID(), "An indexed geometry must have an index count that is a multiple of 3.");
+		} else {
+			ERR_FAIL_COND_V_MSG((rd_geometry.vertex_count % 3) != 0, RID(), "A non-indexed geometry must have a vertex count that is a multiple of 3.");
+		}
 
-		const VertexAttribute *position_attribute = nullptr;
-		for (int i = 0; i < vd_cache.vertex_formats.size(); i++) {
-			const VertexAttribute &attr = vd_cache.vertex_formats[i];
-			if (attr.location == p_position_attribute_location) {
-				position_attribute = &attr;
-				break;
+		RDD::AccelerationStructureGeometry &rdd_geometry = rdd_geometries[i];
+		rdd_geometry = {};
+		rdd_geometry.flags = rd_geometry.flags;
+
+		Buffer *vertex_buffer = vertex_buffer_owner.get_or_null(rd_geometry.vertex_buffer);
+		ERR_FAIL_NULL_V(vertex_buffer, RID());
+
+		ERR_FAIL_COND_V_MSG((rd_geometry.vertex_offset + rd_geometry.vertex_count * rd_geometry.vertex_stride) > vertex_buffer->size, RID(), "The specified vertex offset and count are outside the range of the vertex buffer.");
+		ERR_FAIL_COND_V_MSG(rd_geometry.vertex_format >= DataFormat::DATA_FORMAT_MAX, RID(), "An invalid vertex format was specified.");
+
+		rdd_geometry.vertex_buffer = vertex_buffer->driver_id;
+		rdd_geometry.vertex_offset = rd_geometry.vertex_offset;
+		rdd_geometry.vertex_stride = rd_geometry.vertex_stride;
+		rdd_geometry.vertex_count = rd_geometry.vertex_count;
+		rdd_geometry.vertex_format = rd_geometry.vertex_format;
+
+		if (vertex_buffer->draw_tracker != nullptr) {
+			draw_trackers.push_back(vertex_buffer->draw_tracker);
+		} else {
+			untracked_buffers.insert(rd_geometry.vertex_buffer);
+		}
+
+		_check_transfer_worker_buffer(vertex_buffer);
+
+		if (rd_geometry.index_buffer.is_valid()) {
+			IndexBuffer *index_buffer = index_buffer_owner.get_or_null(rd_geometry.index_buffer);
+			ERR_FAIL_NULL_V(index_buffer, RID());
+
+			uint32_t index_stride = (index_buffer->format == INDEX_BUFFER_FORMAT_UINT32 ? sizeof(uint32_t) : sizeof(uint16_t));
+			ERR_FAIL_COND_V_MSG((rd_geometry.index_offset + rd_geometry.index_count * index_stride) > index_buffer->size, RID(), "The specified index offset and count are outside the range of the index buffer.");
+			ERR_FAIL_COND_V_MSG(index_buffer->max_index >= rd_geometry.vertex_count, RID(), "The index buffer contains an index that is outside the specified vertex range.");
+
+			rdd_geometry.index_buffer = index_buffer->driver_id;
+			rdd_geometry.index_offset = rd_geometry.index_offset;
+			rdd_geometry.index_count = rd_geometry.index_count;
+			rdd_geometry.index_format = index_buffer->format;
+
+			if (index_buffer->draw_tracker != nullptr) {
+				draw_trackers.push_back(index_buffer->draw_tracker);
+			} else {
+				untracked_buffers.insert(rd_geometry.index_buffer);
 			}
+
+			_check_transfer_worker_buffer(index_buffer);
 		}
-		ERR_FAIL_NULL_V_MSG(position_attribute, RID(), vformat("Vertex array is missing a position attribute at location %u.", p_position_attribute_location));
-		ERR_FAIL_COND_V_MSG(position_attribute->frequency != VERTEX_FREQUENCY_VERTEX, RID(), vformat("Position attribute at location %u must use vertex frequency.", p_position_attribute_location));
-
-		if (position_attribute->binding != UINT32_MAX) {
-			position_binding = position_attribute->binding;
-		}
-	}
-
-	ERR_FAIL_COND_V_MSG(position_binding >= (uint32_t)vertex_array->buffers.size(), RID(), vformat("Vertex array is missing a buffer for binding %u.", position_binding));
-	RDD::BufferID vertex_buffer = vertex_array->buffers[position_binding];
-	uint64_t vertex_offset = vertex_array->offsets[position_binding];
-
-	// Indices are optional.
-	IndexArray *index_array = index_array_owner.get_or_null(p_index_array);
-	RDD::BufferID index_buffer = RDD::BufferID();
-	IndexBufferFormat index_format = IndexBufferFormat::INDEX_BUFFER_FORMAT_UINT32;
-	uint32_t index_offset_bytes = 0;
-	uint32_t index_count = 0;
-	if (index_array) {
-		index_buffer = index_array->driver_id;
-		index_format = index_array->format;
-		index_offset_bytes = index_array->offset * (index_array->format == INDEX_BUFFER_FORMAT_UINT16 ? sizeof(uint16_t) : sizeof(uint32_t));
-		index_count = index_array->indices;
 	}
 
 	AccelerationStructure acceleration_structure;
 	acceleration_structure.type = RDD::ACCELERATION_STRUCTURE_TYPE_BLAS;
-
-	BitField<RDD::AccelerationStructureGeometryBits> geometry_bits = 0;
-	if (p_geometry_bits.has_flag(ACCELERATION_STRUCTURE_GEOMETRY_OPAQUE)) {
-		geometry_bits.set_flag(RDD::ACCELERATION_STRUCTURE_GEOMETRY_OPAQUE);
-	}
-	if (p_geometry_bits.has_flag(ACCELERATION_STRUCTURE_GEOMETRY_NO_DUPLICATE_ANY_HIT_INVOCATION)) {
-		geometry_bits.set_flag(RDD::ACCELERATION_STRUCTURE_GEOMETRY_NO_DUPLICATE_ANY_HIT_INVOCATION);
-	}
-
-	acceleration_structure.driver_id = driver->blas_create(vertex_buffer, vertex_offset, vertex_format, vertex_array->vertex_count, p_position_attribute_location, index_buffer, index_format, index_offset_bytes, index_count, geometry_bits);
+	acceleration_structure.driver_id = driver->blas_create(rdd_geometries);
 	ERR_FAIL_COND_V_MSG(!acceleration_structure.driver_id, RID(), "Failed to create BLAS.");
-	acceleration_structure.vertex_array = p_vertex_array;
-	acceleration_structure.index_array = p_index_array;
 
 	acceleration_structure.draw_tracker = RDG::resource_tracker_create();
 	acceleration_structure.draw_tracker->acceleration_structure_driver_id = acceleration_structure.driver_id;
 	// Assume we are going to build this acceleration structure
 	acceleration_structure.draw_tracker->usage = RDG::RESOURCE_USAGE_ACCELERATION_STRUCTURE_READ_WRITE;
 
-	for (int i = 0; i < vertex_array->draw_trackers.size(); i++) {
-		acceleration_structure.draw_trackers.push_back(vertex_array->draw_trackers[i]);
-	}
-	_check_transfer_worker_vertex_array(vertex_array);
-
-	if (index_array && index_array->draw_tracker) {
-		acceleration_structure.draw_trackers.push_back(index_array->draw_tracker);
-	}
-	_check_transfer_worker_index_array(index_array);
+	acceleration_structure.draw_trackers = std::move(draw_trackers);
+	acceleration_structure.untracked_buffers = std::move(untracked_buffers);
 
 	RID id = acceleration_structure_owner.make_rid(acceleration_structure);
 #ifdef DEV_ENABLED
 	set_resource_name(id, "RID:" + itos(id.get_id()));
 #endif
+
+	for (uint32_t i = 0; i < p_geometries.size(); i++) {
+		const AccelerationStructureGeometry &geometry = p_geometries[i];
+		_add_dependency(id, geometry.vertex_buffer);
+
+		if (geometry.index_buffer.is_valid()) {
+			_add_dependency(id, geometry.index_buffer);
+		}
+	}
+
 	return id;
 }
 
@@ -393,7 +402,6 @@ RID RenderingDevice::tlas_create(RID p_instances_buffer) {
 	acceleration_structure.type = RDD::ACCELERATION_STRUCTURE_TYPE_TLAS;
 	acceleration_structure.driver_id = driver->tlas_create(instances_buffer->buffer.driver_id);
 	ERR_FAIL_COND_V_MSG(!acceleration_structure.driver_id, RID(), "Failed to create TLAS.");
-	acceleration_structure.instances_buffer = p_instances_buffer;
 
 	acceleration_structure.draw_tracker = RDG::resource_tracker_create();
 	acceleration_structure.draw_tracker->acceleration_structure_driver_id = acceleration_structure.driver_id;
@@ -6857,6 +6865,18 @@ bool RenderingDevice::_uniform_set_make_mutable(UniformSet *p_uniform_set, RID p
 	}
 }
 
+bool RenderingDevice::_acceleration_structure_make_mutable(AccelerationStructure *p_acceleration_structure, RID p_resource_id, RDG::ResourceTracker *p_resource_tracker) {
+	if (!p_acceleration_structure->untracked_buffers.has(p_resource_id)) {
+		// Acceleration structure thinks the buffer is already tracked or does not use it.
+		return false;
+	} else {
+		// Acceleration structure is aware of the buffer but it isn't being tracked.
+		p_acceleration_structure->draw_trackers.push_back(p_resource_tracker);
+		p_acceleration_structure->untracked_buffers.erase(p_resource_id);
+		return true;
+	}
+}
+
 bool RenderingDevice::_dependency_make_mutable(RID p_id, RID p_resource_id, RDG::ResourceTracker *p_resource_tracker) {
 	if (texture_owner.owns(p_id)) {
 		Texture *texture = texture_owner.get_or_null(p_id);
@@ -6870,6 +6890,9 @@ bool RenderingDevice::_dependency_make_mutable(RID p_id, RID p_resource_id, RDG:
 	} else if (uniform_set_owner.owns(p_id)) {
 		UniformSet *uniform_set = uniform_set_owner.get_or_null(p_id);
 		return _uniform_set_make_mutable(uniform_set, p_resource_id, p_resource_tracker);
+	} else if (acceleration_structure_owner.owns(p_id)) {
+		AccelerationStructure *acceleration_structure = acceleration_structure_owner.get_or_null(p_id);
+		return _acceleration_structure_make_mutable(acceleration_structure, p_resource_id, p_resource_tracker);
 	} else {
 		DEV_ASSERT(false && "Unknown resource type to make mutable.");
 		return false;
@@ -7024,6 +7047,7 @@ void RenderingDevice::_free_internal(RID p_id) {
 		compute_pipeline_owner.free(p_id);
 	} else if (acceleration_structure_owner.owns(p_id)) {
 		AccelerationStructure *acceleration_structure = acceleration_structure_owner.get_or_null(p_id);
+		RDG::resource_tracker_free(acceleration_structure->draw_tracker);
 		frames[frame].acceleration_structures_to_dispose_of.push_back(*acceleration_structure);
 		acceleration_structure_owner.free(p_id);
 	} else if (raytracing_pipeline_owner.owns(p_id)) {
@@ -8395,7 +8419,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("raytracing_pipeline_create", "shader", "specialization_constants"), &RenderingDevice::_raytracing_pipeline_create, DEFVAL(TypedArray<RDPipelineSpecializationConstant>()));
 	ClassDB::bind_method(D_METHOD("raytracing_pipeline_is_valid", "raytracing_pipeline"), &RenderingDevice::raytracing_pipeline_is_valid);
 
-	ClassDB::bind_method(D_METHOD("blas_create", "vertex_array", "index_array", "geometry_bits", "position_attribute_location"), &RenderingDevice::blas_create, DEFVAL(0), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("blas_create", "geometries"), &RenderingDevice::_blas_create);
 	ClassDB::bind_method(D_METHOD("tlas_instances_buffer_create", "instance_count", "creation_bits"), &RenderingDevice::tlas_instances_buffer_create, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("tlas_instances_buffer_fill", "instances_buffer", "blases", "transforms"), &RenderingDevice::_tlas_instances_buffer_fill);
 	ClassDB::bind_method(D_METHOD("tlas_create", "instances_buffer"), &RenderingDevice::tlas_create);
@@ -8855,8 +8879,8 @@ void RenderingDevice::_bind_methods() {
 	//BIND_BITFIELD_FLAG(BUFFER_CREATION_DYNAMIC_PERSISTENT_BIT);
 	BIND_BITFIELD_FLAG(BUFFER_CREATION_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT);
 
-	BIND_BITFIELD_FLAG(ACCELERATION_STRUCTURE_GEOMETRY_OPAQUE);
-	BIND_BITFIELD_FLAG(ACCELERATION_STRUCTURE_GEOMETRY_NO_DUPLICATE_ANY_HIT_INVOCATION);
+	BIND_BITFIELD_FLAG(ACCELERATION_STRUCTURE_GEOMETRY_OPAQUE_BIT);
+	BIND_BITFIELD_FLAG(ACCELERATION_STRUCTURE_GEOMETRY_NO_DUPLICATE_ANY_HIT_INVOCATION_BIT);
 
 	BIND_ENUM_CONSTANT(UNIFORM_TYPE_SAMPLER); //for sampling only (sampler GLSL type)
 	BIND_ENUM_CONSTANT(UNIFORM_TYPE_SAMPLER_WITH_TEXTURE); // for sampling only); but includes a texture); (samplerXX GLSL type)); first a sampler then a texture
@@ -9330,6 +9354,19 @@ RID RenderingDevice::_uniform_set_create(const TypedArray<RDUniform> &p_uniforms
 
 Error RenderingDevice::_buffer_update_bind(RID p_buffer, uint32_t p_offset, uint32_t p_size, const Vector<uint8_t> &p_data) {
 	return buffer_update(p_buffer, p_offset, p_size, p_data.ptr());
+}
+
+RID RenderingDevice::_blas_create(const TypedArray<RDAccelerationStructureGeometry> &p_geometries) {
+	thread_local LocalVector<AccelerationStructureGeometry> geometries;
+	geometries.resize(p_geometries.size());
+
+	for (int i = 0; i < p_geometries.size(); i++) {
+		Ref<RDAccelerationStructureGeometry> geometry = p_geometries[i];
+		ERR_FAIL_COND_V(geometry.is_null(), RID());
+		geometries[i] = geometry->base;
+	}
+
+	return blas_create(geometries);
 }
 
 void RenderingDevice::_tlas_instances_buffer_fill(RID p_instances_buffer, const TypedArray<RID> &p_blases, const TypedArray<Transform3D> &p_transforms) {

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -58,6 +58,7 @@ class RDPipelineDepthStencilState;
 class RDPipelineColorBlendState;
 class RDFramebufferPass;
 class RDPipelineSpecializationConstant;
+class RDAccelerationStructureGeometry;
 
 class RenderingDevice : public RenderingDeviceCommons {
 	GDCLASS(RenderingDevice, Object)
@@ -1300,25 +1301,29 @@ private:
 		RDD::AccelerationStructureType type = RDD::ACCELERATION_STRUCTURE_TYPE_BLAS;
 		RDG::ResourceTracker *draw_tracker = nullptr;
 		Vector<RDG::ResourceTracker *> draw_trackers;
+		HashSet<RID> untracked_buffers;
 
 		// Scratch buffer used during build, owned by the AS.
 		RDD::BufferID scratch_buffer;
-		RID vertex_array;
-		RID index_array;
-		RID transform_buffer;
-		RID instances_buffer;
 	};
 
 	RID_Owner<InstancesBuffer, true> instances_buffer_owner;
-	RID_Owner<AccelerationStructure> acceleration_structure_owner;
+	RID_Owner<AccelerationStructure, true> acceleration_structure_owner;
 
 public:
-	enum AccelerationStructureGeometryBits {
-		ACCELERATION_STRUCTURE_GEOMETRY_OPAQUE = (1 << 0),
-		ACCELERATION_STRUCTURE_GEOMETRY_NO_DUPLICATE_ANY_HIT_INVOCATION = (1 << 1),
+	struct AccelerationStructureGeometry {
+		BitField<AccelerationStructureGeometryFlagBits> flags = {};
+		RID vertex_buffer;
+		uint32_t vertex_offset = 0;
+		uint32_t vertex_stride = 0;
+		uint32_t vertex_count = 0;
+		DataFormat vertex_format = DATA_FORMAT_MAX;
+		RID index_buffer;
+		uint32_t index_offset = 0;
+		uint32_t index_count = 0;
 	};
 
-	RID blas_create(RID p_vertex_array, RID p_index_array, BitField<AccelerationStructureGeometryBits> p_geometry_bits = 0, uint32_t p_position_attribute_location = 0);
+	RID blas_create(Span<AccelerationStructureGeometry> p_geometries);
 	RID tlas_instances_buffer_create(uint32_t p_instance_count, BitField<BufferCreationBits> p_creation_bits = 0);
 	void tlas_instances_buffer_fill(RID p_buffer, const Vector<RID> &p_blases, VectorView<Transform3D> p_transforms);
 	RID tlas_create(RID p_instances_buffer);
@@ -1638,6 +1643,7 @@ private:
 	bool _vertex_array_make_mutable(VertexArray *p_vertex_array, RID p_resource_id, RDG::ResourceTracker *p_resource_tracker);
 	bool _index_array_make_mutable(IndexArray *p_index_array, RDG::ResourceTracker *p_resource_tracker);
 	bool _uniform_set_make_mutable(UniformSet *p_uniform_set, RID p_resource_id, RDG::ResourceTracker *p_resource_tracker);
+	bool _acceleration_structure_make_mutable(AccelerationStructure *p_acceleration_structure, RID p_resource_id, RDG::ResourceTracker *p_resource_tracker);
 	bool _dependency_make_mutable(RID p_id, RID p_resource_id, RDG::ResourceTracker *p_resource_tracker);
 	bool _dependencies_make_mutable_recursive(RID p_id, RDG::ResourceTracker *p_resource_tracker);
 	bool _dependencies_make_mutable(RID p_id, RDG::ResourceTracker *p_resource_tracker);
@@ -1901,6 +1907,7 @@ private:
 
 	Error _buffer_update_bind(RID p_buffer, uint32_t p_offset, uint32_t p_size, const Vector<uint8_t> &p_data);
 
+	RID _blas_create(const TypedArray<RDAccelerationStructureGeometry> &p_geometries);
 	void _tlas_instances_buffer_fill(RID p_buffer, const TypedArray<RID> &p_blases, const TypedArray<Transform3D> &p_transforms);
 
 	RID _render_pipeline_create(RID p_shader, FramebufferFormatID p_framebuffer_format, VertexFormatID p_vertex_format, RenderPrimitive p_render_primitive, const Ref<RDPipelineRasterizationState> &p_rasterization_state, const Ref<RDPipelineMultisampleState> &p_multisample_state, const Ref<RDPipelineDepthStencilState> &p_depth_stencil_state, const Ref<RDPipelineColorBlendState> &p_blend_state, BitField<PipelineDynamicStateFlags> p_dynamic_state_flags, uint32_t p_for_render_pass, const TypedArray<RDPipelineSpecializationConstant> &p_specialization_constants);
@@ -1930,7 +1937,7 @@ VARIANT_ENUM_CAST(RenderingDevice::VertexFrequency)
 VARIANT_ENUM_CAST(RenderingDevice::IndexBufferFormat)
 VARIANT_BITFIELD_CAST(RenderingDevice::StorageBufferUsage)
 VARIANT_BITFIELD_CAST(RenderingDevice::BufferCreationBits)
-VARIANT_BITFIELD_CAST(RenderingDevice::AccelerationStructureGeometryBits)
+VARIANT_BITFIELD_CAST(RenderingDevice::AccelerationStructureGeometryFlagBits)
 VARIANT_ENUM_CAST(RenderingDevice::UniformType)
 VARIANT_ENUM_CAST(RenderingDevice::RenderPrimitive)
 VARIANT_ENUM_CAST(RenderingDevice::PolygonCullMode)

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -745,3 +745,33 @@ protected:
 		ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "attachments", PROPERTY_HINT_ARRAY_TYPE, "RDPipelineColorBlendStateAttachment"), "set_attachments", "get_attachments");
 	}
 };
+
+class RDAccelerationStructureGeometry : public RefCounted {
+	GDCLASS(RDAccelerationStructureGeometry, RefCounted)
+	friend class RenderingDevice;
+	RD::AccelerationStructureGeometry base;
+
+public:
+	RD_SETGET(BitField<RD::AccelerationStructureGeometryFlagBits>, flags)
+	RD_SETGET(RID, vertex_buffer)
+	RD_SETGET(uint32_t, vertex_offset)
+	RD_SETGET(uint32_t, vertex_stride)
+	RD_SETGET(uint32_t, vertex_count)
+	RD_SETGET(RD::DataFormat, vertex_format)
+	RD_SETGET(RID, index_buffer)
+	RD_SETGET(uint32_t, index_offset)
+	RD_SETGET(uint32_t, index_count)
+
+protected:
+	static void _bind_methods() {
+		RD_BIND(Variant::INT, RDAccelerationStructureGeometry, flags);
+		RD_BIND(Variant::RID, RDAccelerationStructureGeometry, vertex_buffer);
+		RD_BIND(Variant::INT, RDAccelerationStructureGeometry, vertex_offset);
+		RD_BIND(Variant::INT, RDAccelerationStructureGeometry, vertex_stride);
+		RD_BIND(Variant::INT, RDAccelerationStructureGeometry, vertex_count);
+		RD_BIND(Variant::INT, RDAccelerationStructureGeometry, vertex_format);
+		RD_BIND(Variant::RID, RDAccelerationStructureGeometry, index_buffer);
+		RD_BIND(Variant::INT, RDAccelerationStructureGeometry, index_offset);
+		RD_BIND(Variant::INT, RDAccelerationStructureGeometry, index_count);
+	}
+};

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -888,6 +888,15 @@ public:
 		DYNAMIC_STATE_STENCIL_REFERENCE = (1 << 6),
 	};
 
+	/********************/
+	/**** RAYTRACING ****/
+	/********************/
+
+	enum AccelerationStructureGeometryFlagBits {
+		ACCELERATION_STRUCTURE_GEOMETRY_OPAQUE_BIT = (1 << 0),
+		ACCELERATION_STRUCTURE_GEOMETRY_NO_DUPLICATE_ANY_HIT_INVOCATION_BIT = (1 << 1),
+	};
+
 	/**************/
 	/**** MISC ****/
 	/**************/

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -747,12 +747,20 @@ public:
 		ACCELERATION_STRUCTURE_TYPE_TLAS,
 	};
 
-	enum AccelerationStructureGeometryBits {
-		ACCELERATION_STRUCTURE_GEOMETRY_OPAQUE = 1 << 0,
-		ACCELERATION_STRUCTURE_GEOMETRY_NO_DUPLICATE_ANY_HIT_INVOCATION = 1 << 1,
+	struct AccelerationStructureGeometry {
+		BitField<AccelerationStructureGeometryFlagBits> flags = {};
+		BufferID vertex_buffer;
+		uint32_t vertex_offset = 0;
+		uint32_t vertex_stride = 0;
+		uint32_t vertex_count = 0;
+		DataFormat vertex_format = DATA_FORMAT_MAX;
+		BufferID index_buffer;
+		uint32_t index_offset = 0;
+		uint32_t index_count = 0;
+		IndexBufferFormat index_format = {};
 	};
 
-	virtual AccelerationStructureID blas_create(BufferID p_vertex_buffer, uint64_t p_vertex_offset, VertexFormatID p_vertex_format, uint32_t p_vertex_count, uint32_t p_position_attribute_location, BufferID p_index_buffer, IndexBufferFormat p_index_format, uint64_t p_index_offset, uint32_t p_index_count, BitField<AccelerationStructureGeometryBits> p_geometry_bits) = 0;
+	virtual AccelerationStructureID blas_create(VectorView<AccelerationStructureGeometry> p_geometries) = 0;
 	virtual uint32_t tlas_instances_buffer_get_size_bytes(uint32_t p_instance_count) = 0;
 	virtual void tlas_instances_buffer_fill(BufferID p_instances_buffer, VectorView<AccelerationStructureID> p_blases, VectorView<Transform3D> p_transforms) = 0;
 	virtual AccelerationStructureID tlas_create(BufferID p_instances_buffer) = 0;


### PR DESCRIPTION
Refactors `blas_create` to accept multiple geometries. What I have in mind with this is having each `AccelerationStructureGeometry` represent a `Mesh::Surface`, and create a BLAS from `Mesh`/`MeshInstance` objects. 

With the previous approach, each `Mesh::Surface` would have to be its own BLAS. That would not be very efficient due to AABB overlaps and increased TLAS instance count.

Further changes to note:
- Taking the vertex/index buffers instead of the vertex/index arrays. I felt the old approach was a little strange since the BLAS does not care about the other components in the vertex array at all. I think it is cleaner to expect the buffers directly.
- Making the BLAS dependent on the buffers and properly bookkeeping their draw trackers. 

To do:
- [x] Documentation for the new class.

Example: https://github.com/blueskythlikesclouds/godot-raytracing-gdscript-demo/commit/2d575518edd4596c9724a1e72e11ee6115673cde