### PR TITLE
CI: Determine if source files were changed before building

### DIFF
--- a/.github/changed_files.yml
+++ b/.github/changed_files.yml
@@ -1,0 +1,16 @@
+# We lack a convenient means of gathering *all* the changes when specializations are passed, so
+#  a catch-all variable is the easiest workaround.
+everything:
+  - "**"
+
+# Determines if build actions should occur after static checks are ran. Broadly speaking, these
+#  files changing would result in SCons rebuilding the engine, or are otherwise pertinent to the
+#  buildsystem itself.
+sources:
+  - .github/{actions,workflows}/*.yml
+  - "**/{SConstruct,SCsub,*.py}"
+  - "**/*.{h,hpp,hh,hxx,c,cpp,cc,cxx,m,mm,inc,glsl}"
+  - modules/mono/**/*.{cs,csproj,sln,props,targets}
+  - platform/android/java/{gradle*,**/*.{jar,java,kt,gradle}}
+  - platform/web/{package{,-lock}.json,js/**/*.js}
+  - tests/**

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -18,16 +18,19 @@ jobs:
   android-build:
     name: 🤖 Android
     needs: static-checks
+    if: needs.static-checks.outputs.sources-changed == 'true' || github.event_name != 'pull_request'
     uses: ./.github/workflows/android_builds.yml
 
   ios-build:
     name: 🍏 iOS
     needs: static-checks
+    if: needs.static-checks.outputs.sources-changed == 'true' || github.event_name != 'pull_request'
     uses: ./.github/workflows/ios_builds.yml
 
   linux-build:
     name: 🐧 Linux
     needs: static-checks
+    if: needs.static-checks.outputs.sources-changed == 'true' || github.event_name != 'pull_request'
     uses: ./.github/workflows/linux_builds.yml
     with:
       changed-files: ${{ needs.static-checks.outputs.changed-files }}
@@ -35,14 +38,17 @@ jobs:
   macos-build:
     name: 🍎 macOS
     needs: static-checks
+    if: needs.static-checks.outputs.sources-changed == 'true' || github.event_name != 'pull_request'
     uses: ./.github/workflows/macos_builds.yml
 
   windows-build:
     name: 🏁 Windows
     needs: static-checks
+    if: needs.static-checks.outputs.sources-changed == 'true' || github.event_name != 'pull_request'
     uses: ./.github/workflows/windows_builds.yml
 
   web-build:
     name: 🌐 Web
     needs: static-checks
+    if: needs.static-checks.outputs.sources-changed == 'true' || github.event_name != 'pull_request'
     uses: ./.github/workflows/web_builds.yml

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -5,6 +5,9 @@ on:
       changed-files:
         description: A list of changed files.
         value: ${{ jobs.static-checks.outputs.changed-files }}
+      sources-changed:
+        description: Determines if any source files were changed.
+        value: ${{ jobs.static-checks.outputs.sources-changed }}
   workflow_dispatch:
 
 jobs:
@@ -13,7 +16,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     outputs:
-      changed-files: '"${{ steps.changed-files.outputs.all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
+      changed-files: '"${{ steps.changed-files.outputs.everything_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
+      sources-changed: ${{ steps.changed-files.outputs.sources_any_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -33,10 +37,11 @@ jobs:
           safe_output: false # Output passed to environment variable to avoid command injection.
           separator: '" "' # To account for paths with spaces, ensure our items are split by quotes internally.
           skip_initial_fetch: true
+          files_yaml_from_source_file: .github/changed_files.yml
 
       - name: Style checks via pre-commit
         uses: pre-commit/action@v3.0.1
         env:
-          CHANGED_FILES: '"${{ steps.changed-files.outputs.all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
+          CHANGED_FILES: '"${{ steps.changed-files.outputs.everything_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
         with:
           extra_args: --files ${{ env.CHANGED_FILES }}


### PR DESCRIPTION
Implements specialization logic on the new `changed-files` action. This is already utilized by the `godot-cpp` repository to determine what source files changed, which is what I drew inspiration from. However, our repo is a fair bit more complex, so the sources needed to be expanded to cover our bases. This will mean that files only changing documentation or files that have negligible buildsystem impact will not result in GitHub Action resources. These restrictions only apply to Pull Requests; all other action events play out as normal