### PR TITLE
Update documentation for `Curve` `set_point_offset`

### DIFF
--- a/doc/classes/Curve.xml
+++ b/doc/classes/Curve.xml
@@ -128,7 +128,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="offset" type="float" />
 			<description>
-				Sets the offset from [code]0.5[/code].
+				Assigns the horizontal position [param offset] to the point at [param index].
 			</description>
 		</method>
 		<method name="set_point_right_mode">


### PR DESCRIPTION
In #67857,  the docs should have been updated to reflect the fact that offsets are no longer in reference to `0.5`. I copied the description from `set_point_value`.
