### PR TITLE
Fix duplicate signal error for `Path3D` when switching tabs

### DIFF
--- a/editor/scene/3d/path_3d_editor_plugin.cpp
+++ b/editor/scene/3d/path_3d_editor_plugin.cpp
@@ -579,7 +579,6 @@ Path3DGizmo::Path3DGizmo(Path3D *p_path) {
 
 	// Connecting to a signal once, rather than plaguing the implementation with calls to `Node3DEditor::update_transform_gizmo`.
 	path->connect("curve_changed", callable_mp(this, &Path3DGizmo::_update_transform_gizmo));
-	path->connect("curve_changed", callable_mp(Path3DEditorPlugin::singleton, &Path3DEditorPlugin::_update_toolbar));
 	path->connect("debug_color_changed", callable_mp(this, &Path3DGizmo::redraw));
 
 	Path3DEditorPlugin::singleton->curve_edit->connect(SceneStringName(pressed), callable_mp(this, &Path3DGizmo::redraw));
@@ -780,7 +779,16 @@ void Path3DEditorPlugin::update_handles() {
 }
 
 void Path3DEditorPlugin::edit(Object *p_object) {
+	if (path) {
+		path->disconnect("curve_changed", callable_mp(this, &Path3DEditorPlugin::_update_toolbar));
+	}
+
 	path = Object::cast_to<Path3D>(p_object);
+
+	if (path) {
+		path->connect("curve_changed", callable_mp(this, &Path3DEditorPlugin::_update_toolbar));
+	}
+
 	_update_toolbar();
 	update_overlays();
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
-->

Fixes: https://github.com/godotengine/godot/issues/117186

Prevents this: `ERROR: Signal 'curve_changed' is already connected to given callable 'Path3DEditorPlugin::_update_toolbar' in that object`