### PR TITLE
Use `open_search` shortcut instead of hard-coded events

### DIFF
--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -788,7 +788,7 @@ void EditorAssetLibrary::shortcut_input(const Ref<InputEvent> &p_event) {
 	const Ref<InputEventKey> key = p_event;
 
 	if (key.is_valid() && key->is_pressed()) {
-		if (key->is_match(InputEventKey::create_reference(KeyModifierMask::CMD_OR_CTRL | Key::F)) && is_visible_in_tree()) {
+		if (ED_IS_SHORTCUT("editor/open_search", p_event) && is_visible_in_tree()) {
 			filter->grab_focus();
 			filter->select_all();
 			accept_event();

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -322,7 +322,7 @@ void EditorSettingsDialog::shortcut_input(const Ref<InputEvent> &p_event) {
 			}
 		}
 
-		if (k->is_match(InputEventKey::create_reference(KeyModifierMask::CMD_OR_CTRL | Key::F))) {
+		if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
 			_focus_current_search_box();
 			handled = true;
 		}


### PR DESCRIPTION
`editor/open_search` shortcut is used most commonly for focusing the search bars. For whatever reason in 2 places it was instead hardcoded as Ctrl+F, and what's worse, hard-coded using `InputEventKey::create_reference()` (which was creating a key reference every time an event was received).