### PR TITLE
Fix 3D focus selection for subgizmos

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -4979,17 +4979,18 @@ void Node3DEditorViewport::focus_selection() {
 
 		if (se->gizmo.is_valid()) {
 			for (const KeyValue<int, Transform3D> &GE : se->subgizmos) {
-				const Vector3 pos = se->gizmo->get_subgizmo_transform(GE.key).origin;
+				const Vector3 pos = node_3d->get_global_gizmo_transform().xform(se->gizmo->get_subgizmo_transform(GE.key).origin);
 				if (pos.is_finite()) {
 					center += pos;
 					count++;
 				}
 			}
-		}
-		const Vector3 pos = node_3d->get_global_gizmo_transform().origin;
-		if (pos.is_finite()) {
-			center += pos;
-			count++;
+		} else {
+			const Vector3 pos = node_3d->get_global_gizmo_transform().origin;
+			if (pos.is_finite()) {
+				center += pos;
+				count++;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
-->

Fixes: https://github.com/godotengine/godot/issues/116949

Local space was used instead of world space, and it was factoring in the node's position as well for no reason.

Demo: 

https://github.com/user-attachments/assets/bf21ea99-b6ca-4fed-9dda-04acd9b1a8a2

