### PR TITLE
Add a project setting to adjust the maximum number of instance uniform indices

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3180,7 +3180,7 @@
 			[b]Note:[/b] This setting is only effective when using the Forward+ rendering method, not Mobile and Compatibility.
 		</member>
 		<member name="rendering/limits/global_shader_variables/buffer_size" type="int" setter="" getter="" default="65536">
-			The maximum number of uniforms that can be used by the global shader uniform buffer. Each item takes up one slot. In other words, a single uniform float and a uniform vec4 will take the same amount of space in the buffer.
+			The maximum number of uniforms that can be used by the global and per-instance shader uniform buffer. Each item takes up one slot. In other words, a single uniform float and a uniform vec4 will take the same amount of space in the buffer. See also [member rendering/limits/shaders/max_instance_uniform_indices].
 			[b]Note:[/b] When using the Compatibility renderer, most mobile devices (and all web exports) will be limited to a maximum size of 1024 due to hardware constraints.
 		</member>
 		<member name="rendering/limits/opengl/max_lights_per_object" type="int" setter="" getter="" default="8">
@@ -3194,6 +3194,9 @@
 		<member name="rendering/limits/opengl/max_renderable_lights" type="int" setter="" getter="" default="32">
 			Max number of positional lights renderable in a frame. If more lights than this number are used, they will be ignored. Setting this low will slightly reduce memory usage and may decrease shader compile times, particularly on web. For most uses, the default value is suitable, but consider lowering as much as possible on web export.
 			[b]Note:[/b] This setting is only effective when using the Compatibility rendering method, not Forward+ and Mobile.
+		</member>
+		<member name="rendering/limits/shaders/max_instance_uniform_indices" type="int" setter="" getter="" default="16">
+			The maximum number of global and per-instance uniforms that may be present per [Shader]. This can be increased to allow more complex shaders to compile without errors. See also [member rendering/limits/global_shader_variables/buffer_size].
 		</member>
 		<member name="rendering/limits/spatial_indexer/threaded_cull_minimum_instances" type="int" setter="" getter="" default="1000">
 			The minimum number of instances that must be present in a scene to enable culling computations on multiple threads. If a scene has fewer instances than this number, culling is done on a single thread.

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2078,10 +2078,10 @@ GLuint MaterialStorage::global_shader_parameters_get_uniform_buffer() const {
 
 int32_t MaterialStorage::global_shader_parameters_instance_allocate(RID p_instance) {
 	ERR_FAIL_COND_V(global_shader_uniforms.instance_buffer_pos.has(p_instance), -1);
-	int32_t pos = _global_shader_uniform_allocate(ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES);
+	int32_t pos = _global_shader_uniform_allocate(ShaderLanguage::get_max_instance_uniform_indices());
 	global_shader_uniforms.instance_buffer_pos[p_instance] = pos; //save anyway
 	ERR_FAIL_COND_V_MSG(pos < 0, -1, vformat("Too many instances using shader instance variables. Consider increasing rendering/limits/global_shader_variables/buffer_size in the Project Settings. Maximum items supported by this hardware is: %d.", Config::get_singleton()->max_uniform_buffer_size / sizeof(GlobalShaderUniforms::Value)));
-	global_shader_uniforms.buffer_usage[pos].elements = ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES;
+	global_shader_uniforms.buffer_usage[pos].elements = ShaderLanguage::get_max_instance_uniform_indices();
 	return pos;
 }
 
@@ -2103,7 +2103,7 @@ void MaterialStorage::global_shader_parameters_instance_update(RID p_instance, i
 	if (pos < 0) {
 		return; //again, not allocated, ignore
 	}
-	ERR_FAIL_INDEX(p_index, ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES);
+	ERR_FAIL_INDEX(p_index, ShaderLanguage::get_max_instance_uniform_indices());
 
 	Variant::Type value_type = p_value.get_type();
 	ERR_FAIL_COND_MSG(p_value.get_type() > Variant::COLOR, "Unsupported variant type for instance parameter: " + Variant::get_type_name(value_type)); //anything greater not supported

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -2018,10 +2018,10 @@ RID MaterialStorage::global_shader_uniforms_get_storage_buffer() const {
 
 int32_t MaterialStorage::global_shader_parameters_instance_allocate(RID p_instance) {
 	ERR_FAIL_COND_V(global_shader_uniforms.instance_buffer_pos.has(p_instance), -1);
-	int32_t pos = _global_shader_uniform_allocate(ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES);
+	int32_t pos = _global_shader_uniform_allocate(ShaderLanguage::get_max_instance_uniform_indices());
 	global_shader_uniforms.instance_buffer_pos[p_instance] = pos; //save anyway
 	ERR_FAIL_COND_V_MSG(pos < 0, -1, "Too many instances using shader instance variables. Increase buffer size in Project Settings.");
-	global_shader_uniforms.buffer_usage[pos].elements = ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES;
+	global_shader_uniforms.buffer_usage[pos].elements = ShaderLanguage::get_max_instance_uniform_indices();
 	return pos;
 }
 
@@ -2043,7 +2043,7 @@ void MaterialStorage::global_shader_parameters_instance_update(RID p_instance, i
 	if (pos < 0) {
 		return; //again, not allocated, ignore
 	}
-	ERR_FAIL_INDEX(p_index, ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES);
+	ERR_FAIL_INDEX(p_index, ShaderLanguage::get_max_instance_uniform_indices());
 
 	Variant::Type value_type = p_value.get_type();
 	ERR_FAIL_COND_MSG(p_value.get_type() > Variant::COLOR, "Unsupported variant type for instance parameter: " + Variant::get_type_name(value_type)); //anything greater not supported

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3767,6 +3767,7 @@ void RenderingServer::init() {
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/environment/subsurface_scattering/subsurface_scattering_depth_scale", PROPERTY_HINT_RANGE, "0.001,1,0.001"), 0.01);
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/limits/global_shader_variables/buffer_size", PROPERTY_HINT_RANGE, "16,1048576,1"), 65536);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/limits/shaders/max_instance_uniform_indices", PROPERTY_HINT_RANGE, "16,512,1"), 16);
 
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/lightmapping/probe_capture/update_speed", PROPERTY_HINT_RANGE, "0.001,256,0.001"), 15);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/lightmapping/primitive_meshes/texel_size", PROPERTY_HINT_RANGE, "0.001,100,0.001"), 0.2);

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -31,6 +31,7 @@
 #include "shader_language.h"
 
 #include "core/config/engine.h"
+#include "core/config/project_settings.h"
 #include "core/os/os.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/rb_set.h"
@@ -5316,6 +5317,10 @@ void ShaderLanguage::get_builtin_funcs(List<String> *r_keywords) {
 	}
 }
 
+int ShaderLanguage::get_max_instance_uniform_indices() {
+	return GLOBAL_GET_CACHED(int, "rendering/limits/shaders/max_instance_uniform_indices");
+}
+
 ShaderLanguage::DataType ShaderLanguage::get_scalar_type(DataType p_type) {
 	static const DataType scalar_types[] = {
 		TYPE_VOID,
@@ -10041,8 +10046,8 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 									custom_instance_index = tk.constant;
 									current_uniform_instance_index_defined = true;
 
-									if (custom_instance_index >= MAX_INSTANCE_UNIFORM_INDICES) {
-										_set_error(vformat(RTR("Allowed instance uniform indices must be within [0..%d] range."), MAX_INSTANCE_UNIFORM_INDICES - 1));
+									if (custom_instance_index >= get_max_instance_uniform_indices()) {
+										_set_error(vformat(RTR("Allowed instance uniform indices must be within [0..%d] range."), get_max_instance_uniform_indices() - 1));
 										return ERR_PARSE_ERROR;
 									}
 
@@ -10203,8 +10208,8 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 							uniform.instance_index = custom_instance_index;
 						} else {
 							uniform.instance_index = instance_index++;
-							if (instance_index > MAX_INSTANCE_UNIFORM_INDICES) {
-								_set_error(vformat(RTR("Too many '%s' uniforms in shader, maximum supported is %d."), "instance", MAX_INSTANCE_UNIFORM_INDICES));
+							if (instance_index > get_max_instance_uniform_indices()) {
+								_set_error(vformat(RTR("Too many '%s' uniforms in shader, maximum supported is %d."), "instance", get_max_instance_uniform_indices()));
 								return ERR_PARSE_ERROR;
 							}
 						}

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -347,10 +347,6 @@ public:
 		REPEAT_DEFAULT,
 	};
 
-	enum {
-		MAX_INSTANCE_UNIFORM_INDICES = 16
-	};
-
 	struct VaryingFunctionNames {
 		StringName fragment;
 		StringName vertex;
@@ -867,6 +863,8 @@ public:
 	static void get_keyword_list(List<String> *r_keywords);
 	static bool is_control_flow_keyword(String p_keyword);
 	static void get_builtin_funcs(List<String> *r_keywords);
+
+	static int get_max_instance_uniform_indices();
 
 	static SafeNumeric<int> instance_counter;
 


### PR DESCRIPTION
This can be increased for more complex shaders, at the cost of possible compatibility issues with mobile GPUs.

The default limit of `16` remains unchanged.

Please test this on various GPUs (desktop, mobile, web) so we can document some known limits on common platforms.

- This closes https://github.com/godotengine/godot-proposals/issues/4467.

**Testing project:** [test_max_instance_uniform_indices.zip](https://github.com/user-attachments/files/25695844/test_max_instance_uniform_indices.zip)
*Features a shader with 512 `int` per-instance uniforms, working on Linux + NVIDIA (works with `vec4` too).*
