### PR TITLE
Fix Script Editor loses focus on esc in Find/Replace bar

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -573,10 +573,7 @@ bool FindReplaceBar::search_next() {
 }
 
 void FindReplaceBar::_hide_bar() {
-	if (replace_text->has_focus() || search_text->has_focus()) {
-		text_editor->grab_focus();
-	}
-
+	text_editor->grab_focus();
 	text_editor->set_search_text("");
 	result_line = -1;
 	result_col = -1;


### PR DESCRIPTION
Think this should fix: https://github.com/godotengine/godot/issues/116985


