### PR TITLE
Fix Marker3D editor gizmo being darker than intended for negative axis lines

### DIFF
--- a/editor/scene/3d/gizmos/marker_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/marker_3d_gizmo_plugin.cpp
@@ -63,22 +63,20 @@ Marker3DGizmoPlugin::Marker3DGizmoPlugin() {
 	const Color color_x = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("axis_x_color"), EditorStringName(Editor));
 	cursor_colors.push_back(color_x);
 	cursor_colors.push_back(color_x);
-	// FIXME: Use less strong darkening factor once GH-48573 is fixed.
-	// The current darkening factor compensates for lines being too bright in the 3D editor.
-	cursor_colors.push_back(color_x.lerp(Color(0, 0, 0), 0.75));
-	cursor_colors.push_back(color_x.lerp(Color(0, 0, 0), 0.75));
+	cursor_colors.push_back(color_x.darkened(0.5));
+	cursor_colors.push_back(color_x.darkened(0.5));
 
 	const Color color_y = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("axis_y_color"), EditorStringName(Editor));
 	cursor_colors.push_back(color_y);
 	cursor_colors.push_back(color_y);
-	cursor_colors.push_back(color_y.lerp(Color(0, 0, 0), 0.75));
-	cursor_colors.push_back(color_y.lerp(Color(0, 0, 0), 0.75));
+	cursor_colors.push_back(color_y.darkened(0.5));
+	cursor_colors.push_back(color_y.darkened(0.5));
 
 	const Color color_z = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("axis_z_color"), EditorStringName(Editor));
 	cursor_colors.push_back(color_z);
 	cursor_colors.push_back(color_z);
-	cursor_colors.push_back(color_z.lerp(Color(0, 0, 0), 0.75));
-	cursor_colors.push_back(color_z.lerp(Color(0, 0, 0), 0.75));
+	cursor_colors.push_back(color_z.darkened(0.5));
+	cursor_colors.push_back(color_z.darkened(0.5));
 
 	Ref<StandardMaterial3D> mat = memnew(StandardMaterial3D);
 	mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);


### PR DESCRIPTION
The brightness of those lines was intentionally lowered to [work around a bug](https://github.com/godotengine/godot/issues/48573), but this bug was fixed a long time ago.

The brightness now matches Marker2D.

## Preview

Before | After
-|-
<img width="600" height="438" alt="Screenshot_20260303_012905" src="https://github.com/user-attachments/assets/00be8c39-1fdc-4009-a12b-7c3abc8a81f2" /> | <img width="600" height="438" alt="Screenshot_20260303_013051" src="https://github.com/user-attachments/assets/53355803-f72a-4c11-a65e-c9a1c163ed83" />

Marker2D for comparison:

<img width="218" height="173" alt="image" src="https://github.com/user-attachments/assets/6fb4b723-b545-4112-9e4f-6442970d97f3" />
