### PR TITLE
Add `@deprecated` and `@experimental` annotations to GDScript

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3677,6 +3677,25 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			parser->push_warning(p_call, GDScriptWarning::STATIC_CALLED_ON_INSTANCE, p_call->function_name, caller_type);
 		}
 
+		// Check if the called function is deprecated or experimental.
+		if (!is_constructor && base_type.kind == GDScriptParser::DataType::CLASS && base_type.class_type != nullptr) {
+			List<GDScriptParser::ClassNode *> class_list;
+			get_class_node_current_scope_classes(base_type.class_type, &class_list, p_call);
+			for (GDScriptParser::ClassNode *cl : class_list) {
+				if (cl->has_member(p_call->function_name)) {
+					const GDScriptParser::ClassNode::Member &member = cl->get_member(p_call->function_name);
+					if (member.type == GDScriptParser::ClassNode::Member::FUNCTION) {
+						if (member.function->is_deprecated) {
+							parser->push_warning(p_call, GDScriptWarning::DEPRECATED_MEMBER_USED, "function", p_call->function_name, member.function->deprecated_message);
+						} else if (member.function->is_experimental) {
+							parser->push_warning(p_call, GDScriptWarning::EXPERIMENTAL_MEMBER_USED, "function", p_call->function_name, member.function->experimental_message);
+						}
+					}
+					break;
+				}
+			}
+		}
+
 		// Consider `emit_signal()`, `connect()`, and `disconnect()` as implicit uses of the signal.
 		if (is_self && (p_call->function_name == SNAME("emit_signal") || p_call->function_name == SNAME("connect") || p_call->function_name == SNAME("disconnect")) && !p_call->arguments.is_empty()) {
 			const GDScriptParser::ExpressionNode *signal_arg = p_call->arguments[0];
@@ -4163,6 +4182,13 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 			if (script_class->outer != nullptr) {
 				p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CLASS;
 			}
+#ifdef DEBUG_ENABLED
+			if (script_class->is_deprecated) {
+				parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_MEMBER_USED, "class", name, script_class->deprecated_message);
+			} else if (script_class->is_experimental) {
+				parser->push_warning(p_identifier, GDScriptWarning::EXPERIMENTAL_MEMBER_USED, "class", name, script_class->experimental_message);
+			}
+#endif // DEBUG_ENABLED
 			return;
 		}
 
@@ -4181,6 +4207,13 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 					p_identifier->reduced_value = member.constant->initializer->reduced_value;
 					p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CONSTANT;
 					p_identifier->constant_source = member.constant;
+#ifdef DEBUG_ENABLED
+					if (member.constant->is_deprecated) {
+						parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_MEMBER_USED, "constant", name, member.constant->deprecated_message);
+					} else if (member.constant->is_experimental) {
+						parser->push_warning(p_identifier, GDScriptWarning::EXPERIMENTAL_MEMBER_USED, "constant", name, member.constant->experimental_message);
+					}
+#endif // DEBUG_ENABLED
 					return;
 				}
 
@@ -4206,6 +4239,13 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 						p_identifier->source = member.variable->is_static ? GDScriptParser::IdentifierNode::STATIC_VARIABLE : GDScriptParser::IdentifierNode::MEMBER_VARIABLE;
 						p_identifier->variable_source = member.variable;
 						member.variable->usages += 1;
+#ifdef DEBUG_ENABLED
+						if (member.variable->is_deprecated) {
+							parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_MEMBER_USED, "variable", name, member.variable->deprecated_message);
+						} else if (member.variable->is_experimental) {
+							parser->push_warning(p_identifier, GDScriptWarning::EXPERIMENTAL_MEMBER_USED, "variable", name, member.variable->experimental_message);
+						}
+#endif // DEBUG_ENABLED
 						return;
 					}
 				} break;
@@ -4216,6 +4256,13 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 						p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_SIGNAL;
 						p_identifier->signal_source = member.signal;
 						member.signal->usages += 1;
+#ifdef DEBUG_ENABLED
+						if (member.signal->is_deprecated) {
+							parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_MEMBER_USED, "signal", name, member.signal->deprecated_message);
+						} else if (member.signal->is_experimental) {
+							parser->push_warning(p_identifier, GDScriptWarning::EXPERIMENTAL_MEMBER_USED, "signal", name, member.signal->experimental_message);
+						}
+#endif // DEBUG_ENABLED
 						return;
 					}
 				} break;
@@ -4226,6 +4273,13 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 						p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_FUNCTION;
 						p_identifier->function_source = member.function;
 						p_identifier->function_source_is_static = member.function->is_static;
+#ifdef DEBUG_ENABLED
+						if (member.function->is_deprecated) {
+							parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_MEMBER_USED, "function", name, member.function->deprecated_message);
+						} else if (member.function->is_experimental) {
+							parser->push_warning(p_identifier, GDScriptWarning::EXPERIMENTAL_MEMBER_USED, "function", name, member.function->experimental_message);
+						}
+#endif // DEBUG_ENABLED
 						return;
 					}
 				} break;
@@ -4233,6 +4287,13 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 				case GDScriptParser::ClassNode::Member::CLASS: {
 					reduce_identifier_from_base_set_class(p_identifier, member.get_datatype());
 					p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CLASS;
+#ifdef DEBUG_ENABLED
+					if (member.m_class->is_deprecated) {
+						parser->push_warning(p_identifier, GDScriptWarning::DEPRECATED_MEMBER_USED, "class", name, member.m_class->deprecated_message);
+					} else if (member.m_class->is_experimental) {
+						parser->push_warning(p_identifier, GDScriptWarning::EXPERIMENTAL_MEMBER_USED, "class", name, member.m_class->experimental_message);
+					}
+#endif // DEBUG_ENABLED
 					return;
 				}
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -150,6 +150,9 @@ GDScriptParser::GDScriptParser() {
 		register_annotation(MethodInfo("@icon", PropertyInfo(Variant::STRING, "icon_path")), AnnotationInfo::SCRIPT, &GDScriptParser::icon_annotation);
 		register_annotation(MethodInfo("@static_unload"), AnnotationInfo::SCRIPT, &GDScriptParser::static_unload_annotation);
 		register_annotation(MethodInfo("@abstract"), AnnotationInfo::SCRIPT | AnnotationInfo::CLASS | AnnotationInfo::FUNCTION, &GDScriptParser::abstract_annotation);
+		// Deprecation and experimental annotations.
+		register_annotation(MethodInfo("@deprecated", PropertyInfo(Variant::STRING, "message")), AnnotationInfo::SCRIPT | AnnotationInfo::CLASS_LEVEL, &GDScriptParser::deprecated_annotation, varray(""));
+		register_annotation(MethodInfo("@experimental", PropertyInfo(Variant::STRING, "message")), AnnotationInfo::SCRIPT | AnnotationInfo::CLASS_LEVEL, &GDScriptParser::experimental_annotation, varray(""));
 		// Onready annotation.
 		register_annotation(MethodInfo("@onready"), AnnotationInfo::VARIABLE, &GDScriptParser::onready_annotation);
 		// Export annotations.
@@ -1824,11 +1827,7 @@ GDScriptParser::AnnotationNode *GDScriptParser::parse_annotation(uint32_t p_vali
 	bool valid = true;
 
 	if (!valid_annotations.has(annotation->name)) {
-		if (annotation->name == "@deprecated") {
-			push_error(R"("@deprecated" annotation does not exist. Use "## @deprecated: Reason here." instead.)");
-		} else if (annotation->name == "@experimental") {
-			push_error(R"("@experimental" annotation does not exist. Use "## @experimental: Reason here." instead.)");
-		} else if (annotation->name == "@tutorial") {
+		if (annotation->name == "@tutorial") {
 			push_error(R"("@tutorial" annotation does not exist. Use "## @tutorial(Title): https://example.com" instead.)");
 		} else {
 			push_error(vformat(R"(Unrecognized annotation: "%s".)", annotation->name));
@@ -4505,6 +4504,170 @@ bool GDScriptParser::abstract_annotation(AnnotationNode *p_annotation, Node *p_t
 		return true;
 	}
 	ERR_FAIL_V_MSG(false, R"("@abstract" annotation can only be applied to classes and functions.)");
+}
+
+bool GDScriptParser::deprecated_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	// NOTE: Use `p_target`, **not** `p_class`, because when `p_target` is a class then `p_class` refers to the outer class.
+	String message;
+	if (p_annotation->resolved_arguments.size() > 0) {
+		message = String(p_annotation->resolved_arguments[0]);
+	}
+	switch (p_target->type) {
+		case Node::CLASS: {
+			ClassNode *n = static_cast<ClassNode *>(p_target);
+			if (n->is_deprecated) {
+				push_error(R"("@deprecated" annotation can only be used once per class.)", p_annotation);
+				return false;
+			}
+			n->is_deprecated = true;
+			n->deprecated_message = message;
+#ifdef TOOLS_ENABLED
+			n->doc_data.is_deprecated = true;
+			n->doc_data.deprecated_message = message;
+#endif
+			return true;
+		}
+		case Node::FUNCTION: {
+			FunctionNode *n = static_cast<FunctionNode *>(p_target);
+			if (n->is_deprecated) {
+				push_error(R"("@deprecated" annotation can only be used once per function.)", p_annotation);
+				return false;
+			}
+			n->is_deprecated = true;
+			n->deprecated_message = message;
+#ifdef TOOLS_ENABLED
+			n->doc_data.is_deprecated = true;
+			n->doc_data.deprecated_message = message;
+#endif
+			return true;
+		}
+		case Node::VARIABLE: {
+			VariableNode *n = static_cast<VariableNode *>(p_target);
+			if (n->is_deprecated) {
+				push_error(R"("@deprecated" annotation can only be used once per variable.)", p_annotation);
+				return false;
+			}
+			n->is_deprecated = true;
+			n->deprecated_message = message;
+#ifdef TOOLS_ENABLED
+			n->doc_data.is_deprecated = true;
+			n->doc_data.deprecated_message = message;
+#endif
+			return true;
+		}
+		case Node::CONSTANT: {
+			ConstantNode *n = static_cast<ConstantNode *>(p_target);
+			if (n->is_deprecated) {
+				push_error(R"("@deprecated" annotation can only be used once per constant.)", p_annotation);
+				return false;
+			}
+			n->is_deprecated = true;
+			n->deprecated_message = message;
+#ifdef TOOLS_ENABLED
+			n->doc_data.is_deprecated = true;
+			n->doc_data.deprecated_message = message;
+#endif
+			return true;
+		}
+		case Node::SIGNAL: {
+			SignalNode *n = static_cast<SignalNode *>(p_target);
+			if (n->is_deprecated) {
+				push_error(R"("@deprecated" annotation can only be used once per signal.)", p_annotation);
+				return false;
+			}
+			n->is_deprecated = true;
+			n->deprecated_message = message;
+#ifdef TOOLS_ENABLED
+			n->doc_data.is_deprecated = true;
+			n->doc_data.deprecated_message = message;
+#endif
+			return true;
+		}
+		default:
+			ERR_FAIL_V_MSG(false, R"("@deprecated" annotation can only be applied to classes, functions, variables, constants, and signals.)");
+	}
+}
+
+bool GDScriptParser::experimental_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	// NOTE: Use `p_target`, **not** `p_class`, because when `p_target` is a class then `p_class` refers to the outer class.
+	String message;
+	if (p_annotation->resolved_arguments.size() > 0) {
+		message = String(p_annotation->resolved_arguments[0]);
+	}
+	switch (p_target->type) {
+		case Node::CLASS: {
+			ClassNode *n = static_cast<ClassNode *>(p_target);
+			if (n->is_experimental) {
+				push_error(R"("@experimental" annotation can only be used once per class.)", p_annotation);
+				return false;
+			}
+			n->is_experimental = true;
+			n->experimental_message = message;
+#ifdef TOOLS_ENABLED
+			n->doc_data.is_experimental = true;
+			n->doc_data.experimental_message = message;
+#endif
+			return true;
+		}
+		case Node::FUNCTION: {
+			FunctionNode *n = static_cast<FunctionNode *>(p_target);
+			if (n->is_experimental) {
+				push_error(R"("@experimental" annotation can only be used once per function.)", p_annotation);
+				return false;
+			}
+			n->is_experimental = true;
+			n->experimental_message = message;
+#ifdef TOOLS_ENABLED
+			n->doc_data.is_experimental = true;
+			n->doc_data.experimental_message = message;
+#endif
+			return true;
+		}
+		case Node::VARIABLE: {
+			VariableNode *n = static_cast<VariableNode *>(p_target);
+			if (n->is_experimental) {
+				push_error(R"("@experimental" annotation can only be used once per variable.)", p_annotation);
+				return false;
+			}
+			n->is_experimental = true;
+			n->experimental_message = message;
+#ifdef TOOLS_ENABLED
+			n->doc_data.is_experimental = true;
+			n->doc_data.experimental_message = message;
+#endif
+			return true;
+		}
+		case Node::CONSTANT: {
+			ConstantNode *n = static_cast<ConstantNode *>(p_target);
+			if (n->is_experimental) {
+				push_error(R"("@experimental" annotation can only be used once per constant.)", p_annotation);
+				return false;
+			}
+			n->is_experimental = true;
+			n->experimental_message = message;
+#ifdef TOOLS_ENABLED
+			n->doc_data.is_experimental = true;
+			n->doc_data.experimental_message = message;
+#endif
+			return true;
+		}
+		case Node::SIGNAL: {
+			SignalNode *n = static_cast<SignalNode *>(p_target);
+			if (n->is_experimental) {
+				push_error(R"("@experimental" annotation can only be used once per signal.)", p_annotation);
+				return false;
+			}
+			n->is_experimental = true;
+			n->experimental_message = message;
+#ifdef TOOLS_ENABLED
+			n->doc_data.is_experimental = true;
+			n->doc_data.experimental_message = message;
+#endif
+			return true;
+		}
+		default:
+			ERR_FAIL_V_MSG(false, R"("@experimental" annotation can only be applied to classes, functions, variables, constants, and signals.)");
+	}
 }
 
 bool GDScriptParser::onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4514,72 +4514,72 @@ bool GDScriptParser::deprecated_annotation(AnnotationNode *p_annotation, Node *p
 	}
 	switch (p_target->type) {
 		case Node::CLASS: {
-			ClassNode *n = static_cast<ClassNode *>(p_target);
-			if (n->is_deprecated) {
+			ClassNode *class_node = static_cast<ClassNode *>(p_target);
+			if (class_node->is_deprecated) {
 				push_error(R"("@deprecated" annotation can only be used once per class.)", p_annotation);
 				return false;
 			}
-			n->is_deprecated = true;
-			n->deprecated_message = message;
+			class_node->is_deprecated = true;
+			class_node->deprecated_message = message;
 #ifdef TOOLS_ENABLED
-			n->doc_data.is_deprecated = true;
-			n->doc_data.deprecated_message = message;
+			class_node->doc_data.is_deprecated = true;
+			class_node->doc_data.deprecated_message = message;
 #endif
 			return true;
 		}
 		case Node::FUNCTION: {
-			FunctionNode *n = static_cast<FunctionNode *>(p_target);
-			if (n->is_deprecated) {
+			FunctionNode *function_node = static_cast<FunctionNode *>(p_target);
+			if (function_node->is_deprecated) {
 				push_error(R"("@deprecated" annotation can only be used once per function.)", p_annotation);
 				return false;
 			}
-			n->is_deprecated = true;
-			n->deprecated_message = message;
+			function_node->is_deprecated = true;
+			function_node->deprecated_message = message;
 #ifdef TOOLS_ENABLED
-			n->doc_data.is_deprecated = true;
-			n->doc_data.deprecated_message = message;
+			function_node->doc_data.is_deprecated = true;
+			function_node->doc_data.deprecated_message = message;
 #endif
 			return true;
 		}
 		case Node::VARIABLE: {
-			VariableNode *n = static_cast<VariableNode *>(p_target);
-			if (n->is_deprecated) {
+			VariableNode *variable_node = static_cast<VariableNode *>(p_target);
+			if (variable_node->is_deprecated) {
 				push_error(R"("@deprecated" annotation can only be used once per variable.)", p_annotation);
 				return false;
 			}
-			n->is_deprecated = true;
-			n->deprecated_message = message;
+			variable_node->is_deprecated = true;
+			variable_node->deprecated_message = message;
 #ifdef TOOLS_ENABLED
-			n->doc_data.is_deprecated = true;
-			n->doc_data.deprecated_message = message;
+			variable_node->doc_data.is_deprecated = true;
+			variable_node->doc_data.deprecated_message = message;
 #endif
 			return true;
 		}
 		case Node::CONSTANT: {
-			ConstantNode *n = static_cast<ConstantNode *>(p_target);
-			if (n->is_deprecated) {
+			ConstantNode *constant_node = static_cast<ConstantNode *>(p_target);
+			if (constant_node->is_deprecated) {
 				push_error(R"("@deprecated" annotation can only be used once per constant.)", p_annotation);
 				return false;
 			}
-			n->is_deprecated = true;
-			n->deprecated_message = message;
+			constant_node->is_deprecated = true;
+			constant_node->deprecated_message = message;
 #ifdef TOOLS_ENABLED
-			n->doc_data.is_deprecated = true;
-			n->doc_data.deprecated_message = message;
+			constant_node->doc_data.is_deprecated = true;
+			constant_node->doc_data.deprecated_message = message;
 #endif
 			return true;
 		}
 		case Node::SIGNAL: {
-			SignalNode *n = static_cast<SignalNode *>(p_target);
-			if (n->is_deprecated) {
+			SignalNode *signal_node = static_cast<SignalNode *>(p_target);
+			if (signal_node->is_deprecated) {
 				push_error(R"("@deprecated" annotation can only be used once per signal.)", p_annotation);
 				return false;
 			}
-			n->is_deprecated = true;
-			n->deprecated_message = message;
+			signal_node->is_deprecated = true;
+			signal_node->deprecated_message = message;
 #ifdef TOOLS_ENABLED
-			n->doc_data.is_deprecated = true;
-			n->doc_data.deprecated_message = message;
+			signal_node->doc_data.is_deprecated = true;
+			signal_node->doc_data.deprecated_message = message;
 #endif
 			return true;
 		}
@@ -4596,72 +4596,72 @@ bool GDScriptParser::experimental_annotation(AnnotationNode *p_annotation, Node 
 	}
 	switch (p_target->type) {
 		case Node::CLASS: {
-			ClassNode *n = static_cast<ClassNode *>(p_target);
-			if (n->is_experimental) {
+			ClassNode *class_node = static_cast<ClassNode *>(p_target);
+			if (class_node->is_experimental) {
 				push_error(R"("@experimental" annotation can only be used once per class.)", p_annotation);
 				return false;
 			}
-			n->is_experimental = true;
-			n->experimental_message = message;
+			class_node->is_experimental = true;
+			class_node->experimental_message = message;
 #ifdef TOOLS_ENABLED
-			n->doc_data.is_experimental = true;
-			n->doc_data.experimental_message = message;
+			class_node->doc_data.is_experimental = true;
+			class_node->doc_data.experimental_message = message;
 #endif
 			return true;
 		}
 		case Node::FUNCTION: {
-			FunctionNode *n = static_cast<FunctionNode *>(p_target);
-			if (n->is_experimental) {
+			FunctionNode *function_node = static_cast<FunctionNode *>(p_target);
+			if (function_node->is_experimental) {
 				push_error(R"("@experimental" annotation can only be used once per function.)", p_annotation);
 				return false;
 			}
-			n->is_experimental = true;
-			n->experimental_message = message;
+			function_node->is_experimental = true;
+			function_node->experimental_message = message;
 #ifdef TOOLS_ENABLED
-			n->doc_data.is_experimental = true;
-			n->doc_data.experimental_message = message;
+			function_node->doc_data.is_experimental = true;
+			function_node->doc_data.experimental_message = message;
 #endif
 			return true;
 		}
 		case Node::VARIABLE: {
-			VariableNode *n = static_cast<VariableNode *>(p_target);
-			if (n->is_experimental) {
+			VariableNode *variable_node = static_cast<VariableNode *>(p_target);
+			if (variable_node->is_experimental) {
 				push_error(R"("@experimental" annotation can only be used once per variable.)", p_annotation);
 				return false;
 			}
-			n->is_experimental = true;
-			n->experimental_message = message;
+			variable_node->is_experimental = true;
+			variable_node->experimental_message = message;
 #ifdef TOOLS_ENABLED
-			n->doc_data.is_experimental = true;
-			n->doc_data.experimental_message = message;
+			variable_node->doc_data.is_experimental = true;
+			variable_node->doc_data.experimental_message = message;
 #endif
 			return true;
 		}
 		case Node::CONSTANT: {
-			ConstantNode *n = static_cast<ConstantNode *>(p_target);
-			if (n->is_experimental) {
+			ConstantNode *constant_node = static_cast<ConstantNode *>(p_target);
+			if (constant_node->is_experimental) {
 				push_error(R"("@experimental" annotation can only be used once per constant.)", p_annotation);
 				return false;
 			}
-			n->is_experimental = true;
-			n->experimental_message = message;
+			constant_node->is_experimental = true;
+			constant_node->experimental_message = message;
 #ifdef TOOLS_ENABLED
-			n->doc_data.is_experimental = true;
-			n->doc_data.experimental_message = message;
+			constant_node->doc_data.is_experimental = true;
+			constant_node->doc_data.experimental_message = message;
 #endif
 			return true;
 		}
 		case Node::SIGNAL: {
-			SignalNode *n = static_cast<SignalNode *>(p_target);
-			if (n->is_experimental) {
+			SignalNode *signal_node = static_cast<SignalNode *>(p_target);
+			if (signal_node->is_experimental) {
 				push_error(R"("@experimental" annotation can only be used once per signal.)", p_annotation);
 				return false;
 			}
-			n->is_experimental = true;
-			n->experimental_message = message;
+			signal_node->is_experimental = true;
+			signal_node->experimental_message = message;
 #ifdef TOOLS_ENABLED
-			n->doc_data.is_experimental = true;
-			n->doc_data.experimental_message = message;
+			signal_node->doc_data.is_experimental = true;
+			signal_node->doc_data.experimental_message = message;
 #endif
 			return true;
 		}

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -753,6 +753,10 @@ public:
 		bool extends_used = false;
 		bool onready_used = false;
 		bool is_abstract = false;
+		bool is_deprecated = false;
+		String deprecated_message;
+		bool is_experimental = false;
+		String experimental_message;
 		bool has_static_data = false;
 		bool annotated_static_unload = false;
 		String extends_path;
@@ -807,6 +811,10 @@ public:
 	};
 
 	struct ConstantNode : public AssignableNode {
+		bool is_deprecated = false;
+		String deprecated_message;
+		bool is_experimental = false;
+		String experimental_message;
 #ifdef TOOLS_ENABLED
 		MemberDocData doc_data;
 #endif // TOOLS_ENABLED
@@ -860,6 +868,10 @@ public:
 		TypeNode *return_type = nullptr;
 		SuiteNode *body = nullptr;
 		bool is_abstract = false;
+		bool is_deprecated = false;
+		String deprecated_message;
+		bool is_experimental = false;
+		String experimental_message;
 		bool is_static = false; // For lambdas it's determined in the analyzer.
 		bool is_coroutine = false;
 		Variant rpc_config;
@@ -1066,6 +1078,10 @@ public:
 		Vector<ParameterNode *> parameters;
 		HashMap<StringName, int> parameters_indices;
 		MethodInfo method_info;
+		bool is_deprecated = false;
+		String deprecated_message;
+		bool is_experimental = false;
+		String experimental_message;
 #ifdef TOOLS_ENABLED
 		MemberDocData doc_data;
 #endif // TOOLS_ENABLED
@@ -1270,6 +1286,10 @@ public:
 		PropertyInfo export_info;
 		int assignments = 0;
 		bool is_static = false;
+		bool is_deprecated = false;
+		String deprecated_message;
+		bool is_experimental = false;
+		String experimental_message;
 #ifdef TOOLS_ENABLED
 		MemberDocData doc_data;
 #endif // TOOLS_ENABLED
@@ -1556,6 +1576,8 @@ private:
 	bool icon_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool abstract_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool deprecated_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool experimental_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -141,6 +141,18 @@ String GDScriptWarning::get_message() const {
 		case DEPRECATED_KEYWORD:
 			CHECK_SYMBOLS(2);
 			return vformat(R"(The "%s" keyword is deprecated and will be removed in a future release. Please replace it with "%s".)", symbols[0], symbols[1]);
+		case DEPRECATED_MEMBER_USED:
+			CHECK_SYMBOLS(3);
+			if (!symbols[2].is_empty()) {
+				return vformat(R"(The %s "%s" is deprecated: %s)", symbols[0], symbols[1], symbols[2]);
+			}
+			return vformat(R"(The %s "%s" is deprecated and may be removed in a future version.)", symbols[0], symbols[1]);
+		case EXPERIMENTAL_MEMBER_USED:
+			CHECK_SYMBOLS(3);
+			if (!symbols[2].is_empty()) {
+				return vformat(R"(The %s "%s" is experimental: %s)", symbols[0], symbols[1], symbols[2]);
+			}
+			return vformat(R"(The %s "%s" is experimental and may be changed or removed in a future version.)", symbols[0], symbols[1]);
 		case CONFUSABLE_IDENTIFIER:
 			CHECK_SYMBOLS(1);
 			return vformat(R"(The identifier "%s" has misleading characters and might be confused with something else.)", symbols[0]);
@@ -233,6 +245,8 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		PNAME("ENUM_VARIABLE_WITHOUT_DEFAULT"),
 		PNAME("EMPTY_FILE"),
 		PNAME("DEPRECATED_KEYWORD"),
+		PNAME("DEPRECATED_MEMBER_USED"),
+		PNAME("EXPERIMENTAL_MEMBER_USED"),
 		PNAME("CONFUSABLE_IDENTIFIER"),
 		PNAME("CONFUSABLE_LOCAL_DECLARATION"),
 		PNAME("CONFUSABLE_LOCAL_USAGE"),

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -82,6 +82,8 @@ public:
 		ENUM_VARIABLE_WITHOUT_DEFAULT, // A variable with an enum type does not have a default value. The default will be set to `0` instead of the first enum value.
 		EMPTY_FILE, // A script file is empty.
 		DEPRECATED_KEYWORD, // The keyword is deprecated and should be replaced.
+		DEPRECATED_MEMBER_USED, // A GDScript member annotated @deprecated was accessed.
+		EXPERIMENTAL_MEMBER_USED, // A GDScript member annotated @experimental was accessed.
 		CONFUSABLE_IDENTIFIER, // The identifier contains misleading characters that can be confused. E.g. "usеr" (has Cyrillic "е" instead of Latin "e").
 		CONFUSABLE_LOCAL_DECLARATION, // The parent block declares an identifier with the same name below.
 		CONFUSABLE_LOCAL_USAGE, // The identifier will be shadowed below in the block.
@@ -140,6 +142,8 @@ public:
 		WARN, // ENUM_VARIABLE_WITHOUT_DEFAULT
 		WARN, // EMPTY_FILE
 		WARN, // DEPRECATED_KEYWORD
+		WARN, // DEPRECATED_MEMBER_USED
+		WARN, // EXPERIMENTAL_MEMBER_USED
 		WARN, // CONFUSABLE_IDENTIFIER
 		WARN, // CONFUSABLE_LOCAL_DECLARATION
 		WARN, // CONFUSABLE_LOCAL_USAGE


### PR DESCRIPTION
Closes godotengine/godot-proposals#6559.
Related to godotengine/godot-proposals#12105 and #104955.

GDScript currently supports `## @deprecated:` and `## @experimental:` as doc comment tags. They show up in autocomplete and the class reference. 
But setting a property or function as "deprecated" or "experimental" does nothing at the language level, no warnings are triggered, and no feedback reaches the dev.

My PR adds `@deprecated` and `@experimental` as GDScript annotations and makes the editor show warnings when properties or function members are called (also show on in-godot documentation).

### New features added
- Adds 2 new annotations: `@deprecated` and `@experimental`, both accepting an **optional** message string.
- The annotations work on classes, functions, variables, etc.
- `@warning_ignore("deprecated_member_used")` and `@warning_ignore("experimental_member_used")` work with the existing warning system.

### Usage
<img width="917" height="913" alt="image" src="https://github.com/user-attachments/assets/3086968e-3c0d-47f6-8035-72cd1295d30b" />

Warnings shown when hovering over code:
<img width="805" height="149" alt="image" src="https://github.com/user-attachments/assets/925d85c9-c41c-447f-88f1-cf315077b99e" />

<img width="774" height="111" alt="image" src="https://github.com/user-attachments/assets/c9e83ee9-3a5d-411c-9472-fcc8f8667f57" />

Warnings shown when running the game:
<img width="1316" height="110" alt="image" src="https://github.com/user-attachments/assets/2c711eb5-3f5c-406c-ab78-db998b428902" />

How it looks on in-godot documentation:
<img width="1161" height="838" alt="image" src="https://github.com/user-attachments/assets/80997cfa-dd75-46cb-8cba-da427f97b137" />
<img width="998" height="426" alt="image" src="https://github.com/user-attachments/assets/9098d8ac-2dd0-46ae-8b8a-f71d5aceb349" />

### Addressing prior work
PR #100174 decided, at the time, not to register `@deprecated` and `@experimental` as real annotations because 

> declaring a class member deprecated/experimental does nothing at the language level.

And this worked for the scope of that PR, though akien-mga said in that same thread that proper language-level support was always the intended from the beginning. So I decided to create this PR to take this step for GDScript-defined members.

PR #104955 (currently open) adds a `DEPRECATED_IDENTIFIER` warning that fires when doc-comment-tagged members are accessed. This PR is different: the annotations will directly mark the member as deprecated or experimental at the language level), instead of reading that status from doc comment data
In my honest opinion, both approaches are complementary: #104955 focus on using of already-deprecated doc-comment-tagged members, while my PR give the devs a proper annotation syntax with compile-time feedback from the start.

godotengine/godot-proposals#6559. proposed adding `@deprecated` as a real annotation. godotengine/godot-proposals#12105 proposed adding a warning when deprecated identifiers are used. This PR addresses both.