### PR TITLE
[3.x] `MultiRect` - Precalculate bound

### DIFF
--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -841,6 +841,7 @@ public:
 			RID texture;
 			RID normal_map;
 			Color modulate;
+			Rect2 bound;
 			Vector<Rect2> rects;
 			Vector<Rect2> sources;
 			uint8_t flags;
@@ -1111,13 +1112,7 @@ public:
 					} break;
 					case Item::Command::TYPE_MULTIRECT: {
 						const Item::CommandMultiRect *mrect = static_cast<const Item::CommandMultiRect *>(c);
-						int num_rects = mrect->rects.size();
-						if (num_rects) {
-							r = mrect->rects[0];
-							for (int n = 1; n < num_rects; n++) {
-								r = mrect->rects[n].merge(r);
-							}
-						}
+						r = mrect->bound;
 					} break;
 					case Item::Command::TYPE_NINEPATCH: {
 						const Item::CommandNinePatch *style = static_cast<const Item::CommandNinePatch *>(c);

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -1283,6 +1283,16 @@ void VisualServerCanvas::canvas_item_add_texture_multirect_region(RID p_item, co
 	rect->sources = p_src_rects;
 
 	canvas_item->rect_dirty = true;
+
+	// Precalculate bound as a one off, so it doesn't need to be done every frame.
+	int num_rects = p_rects.size();
+	if (num_rects) {
+		rect->bound = p_rects[0];
+		for (int n = 1; n < num_rects; n++) {
+			rect->bound = p_rects[n].merge(rect->bound);
+		}
+	}
+
 	canvas_item->commands.push_back(rect);
 }
 


### PR DESCRIPTION
Calculate bound as a one off when creating the command, to save re-calculating if the bound is requested on multiple frames.

## Explanation
* I noticed this when reviewing #116613 (see https://github.com/godotengine/godot/pull/116613#discussion_r2871750248 )
* I wasn't sure why I didn't add in the original `MultiRect` PR, as this is kind of obvious
* Turns out `get_rect()` is not getting called for the multirect in the example benchmark (it may be using a custom rect), in which case it wouldn't appear in profiles
* If it isn't getting called _at all_ in the wild, it is cheaper not to calculate (without this PR). If it is being used in other scenarios, then it should be better after this PR. This may differ in 3.x versus 4.x. I need to just do some checking to see whether this PR is needed or not in 3.x, hence draft.

## Labels
It turns out this isn't getting called for labels in 3.x, because `Controls` set a `custom_rect`:
```
		case NOTIFICATION_DRAW: {
			_update_canvas_item_transform();
			VisualServer::get_singleton()->canvas_item_set_custom_rect(get_canvas_item(), !data.disable_visibility_clip, Rect2(Point2(), get_size()));
			VisualServer::get_singleton()->canvas_item_set_clip(get_canvas_item(), data.clip_contents);
			//emit_signal(SceneStringNames::get_singleton()->draw);

		} break;
```
So there is no advantage to this PR in vanilla situations with `Label`.
I will test it with tilemaps next to see whether it can improve.

## Tilemaps
This path is getting called for tilemap `MultiRects`, _however_, due to optimizations in the hierarchical culling, the bound is cached so seems to only be called once.

## Conclusion
For now I'm concluding this PR isn't needed in 3.x. But it still may be beneficial in 4.x, so leaving this as reference for @ColinSORourke .

## Notes
* The bound could be calculated server or client side.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
-->
