### PR TITLE
Fix compilation error with `module_gdscript_enabled=no` by adding explicit `EditorSyntaxHighlighter` include

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -50,6 +50,7 @@
 #include "editor/gui/editor_toaster.h"
 #include "editor/inspector/editor_property_name_processor.h"
 #include "editor/script/script_editor_plugin.h"
+#include "editor/script/syntax_highlighters.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/line_edit.h"


### PR DESCRIPTION
Fixes a module dependency logic error in `editor/doc/editor_help.cpp` by explicitly including the header file `editor/script/syntax_highlighters.h`.

Currently, `EditorSyntaxHighlighter` is being transitively accessed via GDScript dependencies. When compiling the engine with GDScript disabled (`scons module_gdscript_enabled=no`), the build fails with an "invalid use of incomplete type" error because the class blueprint is missing.

This PR makes the inclusion explicit, allowing the engine to compile successfully when `module_gdscript_enabled=no` (such as when building a C#-only engine with `module_mono_enabled=yes`).