### PR TITLE
Add explicit OptionButton fallback state in ScriptCreateDialog

### DIFF
--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -413,6 +413,9 @@ void ScriptCreateDialog::_load_exist() {
 
 void ScriptCreateDialog::_language_changed(int l) {
 	language = ScriptServer::get_language(l);
+	if (language == nullptr) {
+		return;
+	}
 
 	can_inherit_from_file = language->can_inherit_from_file();
 	supports_built_in = language->supports_builtin_mode();
@@ -527,6 +530,9 @@ void ScriptCreateDialog::_path_changed(const String &p_path) {
 }
 
 void ScriptCreateDialog::_update_template_menu() {
+	if (language == nullptr) {
+		return;
+	}
 	bool is_language_using_templates = language->is_using_templates();
 	template_menu->set_disabled(false);
 	template_menu->clear();
@@ -898,8 +904,18 @@ ScriptCreateDialog::ScriptCreateDialog() {
 			default_language = i;
 		}
 	}
-	if (default_language >= 0) {
+	if (ScriptServer::get_language_count() == 0) {
+		// Edge Case 1: No scripting languages exist at all.
+		get_ok_button()->set_disabled(true); // Explicitly disable the confirmation button to prevent downstream crashes.
+		language_menu->set_disabled(true);
+		language_menu->set_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
+		language_menu->add_item(TTR("No Scripting Languages Available"));
+	} else if (default_language >= 0) {
+		// Normal Case: GDScript is available, select it.
 		language_menu->select(default_language);
+	} else {
+		// Edge Case 2: Languages exist (like C#), but GDScript is disabled.
+		language_menu->select(0);
 	}
 
 	language_menu->connect(SceneStringName(item_selected), callable_mp(this, &ScriptCreateDialog::_language_changed));


### PR DESCRIPTION
This PR adds explicit defensive state handling to the `Language` OptionButton in `ScriptCreateDialog`.

**The Context:**
While investigating and fixing a compilation bug related to `module_gdscript_enabled=no` (see PR #117013), I discovered that `ScriptCreateDialog` relies on implicit UI behavior when GDScript is missing. 

**The Current Behavior:**
Currently, if a user builds with `module_gdscript_enabled=no` but keeps another language active (like C# via `module_mono_enabled=yes`), the `default_language` index remains `-1`. The `OptionButton` only avoids a broken blank state because the Godot UI framework implicitly auto-selects index `0` when an item is added to an empty dropdown. 

Furthermore, if zero languages are registered, the dialog has no internal fallback state (relying entirely on an outer-wall check from `SceneTreeDock` to prevent it from opening).

**The Fix:**
This PR makes the dialog's state handling explicit and resilient:
1. If zero languages are registered, the `OptionButton` is explicitly disabled with a fallback warning text.
2. If languages exist but GDScript is disabled, it explicitly calls `select(0)` to default to the first available language, rather than relying on the UI node's implicit auto-selection.

This future-proofs the dialog against potential changes to `OptionButton`'s default behavior and provides a hard internal fail-safe for the zero-language edge case. Fixes #116873.

- Supersedes https://github.com/godotengine/godot/pull/110532 
- Supersedes https://github.com/godotengine/godot/pull/98805