### PR TITLE
Add option for CSG nodes to use backface collisions.

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -106,29 +106,24 @@ void CSGShape3D::set_use_collision(bool p_enable) {
 		return;
 	}
 
-	if (use_collision) {
-		root_collision_shape.instantiate();
-		root_collision_body = PhysicsServer3D::get_singleton()->body_create();
-		PhysicsServer3D::get_singleton()->body_set_mode(root_collision_body, PS3DE::BODY_MODE_STATIC);
-		PhysicsServer3D::get_singleton()->body_set_state(root_collision_body, PS3DE::BODY_STATE_TRANSFORM, get_global_transform());
-		PhysicsServer3D::get_singleton()->body_add_shape(root_collision_body, root_collision_shape->get_rid());
-		PhysicsServer3D::get_singleton()->body_set_space(root_collision_body, get_world_3d()->get_space());
-		PhysicsServer3D::get_singleton()->body_attach_object_instance_id(root_collision_body, get_instance_id());
-		set_collision_layer(collision_layer);
-		set_collision_mask(collision_mask);
-		set_collision_priority(collision_priority);
-		_make_dirty(); //force update
-	} else {
-		PhysicsServer3D::get_singleton()->free_rid(root_collision_body);
-		root_collision_body = RID();
-		root_collision_shape.unref();
-	}
+	_build_collision_shape();
 	notify_property_list_changed();
 	update_gizmos();
 }
 
 bool CSGShape3D::is_using_collision() const {
 	return use_collision;
+}
+
+void CSGShape3D::set_use_backface_collision(bool p_enable) {
+	use_backface_collision = p_enable;
+	if (use_collision) {
+		_build_collision_shape(true);
+	}
+}
+
+bool CSGShape3D::is_using_backface_collision() const {
+	return use_backface_collision;
 }
 
 void CSGShape3D::set_collision_layer(uint32_t p_layer) {
@@ -903,6 +898,33 @@ Vector<Vector3> CSGShape3D::_get_brush_collision_faces() {
 	return collision_faces;
 }
 
+void CSGShape3D::_build_collision_shape(bool p_recreate) {
+	if (!is_inside_tree() || !is_root_shape()) {
+		return;
+	}
+
+	if (!use_collision || p_recreate) {
+		PhysicsServer3D::get_singleton()->free_rid(root_collision_body);
+		root_collision_body = RID();
+		root_collision_shape.unref();
+	}
+
+	if (use_collision || p_recreate) {
+		root_collision_shape.instantiate();
+		root_collision_shape->set_backface_collision_enabled(use_backface_collision);
+		root_collision_body = PhysicsServer3D::get_singleton()->body_create();
+		PhysicsServer3D::get_singleton()->body_set_mode(root_collision_body, PS3DE::BODY_MODE_STATIC);
+		PhysicsServer3D::get_singleton()->body_set_state(root_collision_body, PS3DE::BODY_STATE_TRANSFORM, get_global_transform());
+		PhysicsServer3D::get_singleton()->body_add_shape(root_collision_body, root_collision_shape->get_rid());
+		PhysicsServer3D::get_singleton()->body_set_space(root_collision_body, get_world_3d()->get_space());
+		PhysicsServer3D::get_singleton()->body_attach_object_instance_id(root_collision_body, get_instance_id());
+		set_collision_layer(collision_layer);
+		set_collision_mask(collision_mask);
+		set_collision_priority(collision_priority);
+		_make_dirty(); //force update
+	}
+}
+
 void CSGShape3D::_update_collision_faces() {
 	if (use_collision && is_root_shape() && root_collision_shape.is_valid()) {
 		root_collision_shape->set_faces(_get_brush_collision_faces());
@@ -917,9 +939,11 @@ Ref<ConcavePolygonShape3D> CSGShape3D::bake_collision_shape() {
 	Ref<ConcavePolygonShape3D> baked_collision_shape;
 	if (is_root_shape() && root_collision_shape.is_valid()) {
 		baked_collision_shape.instantiate();
+		baked_collision_shape->set_backface_collision_enabled(use_backface_collision);
 		baked_collision_shape->set_faces(root_collision_shape->get_faces());
 	} else if (is_root_shape()) {
 		baked_collision_shape.instantiate();
+		baked_collision_shape->set_backface_collision_enabled(use_backface_collision);
 		baked_collision_shape->set_faces(_get_brush_collision_faces());
 	}
 	return baked_collision_shape;
@@ -1036,6 +1060,7 @@ void CSGShape3D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			if (use_collision && is_root_shape()) {
 				root_collision_shape.instantiate();
+				root_collision_shape->set_backface_collision_enabled(use_backface_collision);
 				root_collision_body = PhysicsServer3D::get_singleton()->body_create();
 				PhysicsServer3D::get_singleton()->body_set_mode(root_collision_body, PS3DE::BODY_MODE_STATIC);
 				PhysicsServer3D::get_singleton()->body_set_state(root_collision_body, PS3DE::BODY_STATE_TRANSFORM, get_global_transform());
@@ -1109,6 +1134,8 @@ void CSGShape3D::_validate_property(PropertyInfo &p_property) const {
 	if ((is_collision_prefixed || p_property.name.begins_with("use_collision")) && is_inside_tree() && !is_root_shape()) {
 		//hide collision if not root
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+	} else if (p_property.name.begins_with("use_backface_collision") && !bool(get("use_collision"))) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	} else if (is_collision_prefixed && !bool(get("use_collision"))) {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
@@ -1161,6 +1188,8 @@ void CSGShape3D::_bind_methods() {
 #ifndef PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("set_use_collision", "operation"), &CSGShape3D::set_use_collision);
 	ClassDB::bind_method(D_METHOD("is_using_collision"), &CSGShape3D::is_using_collision);
+	ClassDB::bind_method(D_METHOD("set_use_backface_collision", "enable"), &CSGShape3D::set_use_backface_collision);
+	ClassDB::bind_method(D_METHOD("is_using_backface_collision"), &CSGShape3D::is_using_backface_collision);
 
 	ClassDB::bind_method(D_METHOD("set_collision_layer", "layer"), &CSGShape3D::set_collision_layer);
 	ClassDB::bind_method(D_METHOD("get_collision_layer"), &CSGShape3D::get_collision_layer);
@@ -1207,6 +1236,7 @@ void CSGShape3D::_bind_methods() {
 #ifndef PHYSICS_3D_DISABLED
 	ADD_GROUP("Collision", "collision_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_collision"), "set_use_collision", "is_using_collision");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_backface_collision"), "set_use_backface_collision", "is_using_backface_collision");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_layer", "get_collision_layer");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_priority"), "set_collision_priority", "get_collision_priority");

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -71,6 +71,7 @@ private:
 
 #ifndef PHYSICS_3D_DISABLED
 	bool use_collision = false;
+	bool use_backface_collision = false;
 	uint32_t collision_layer = 1;
 	uint32_t collision_mask = 1;
 	real_t collision_priority = 1.0;
@@ -99,6 +100,7 @@ private:
 	};
 
 #ifndef PHYSICS_3D_DISABLED
+	void _build_collision_shape(bool p_recreate = false);
 	void _update_collision_faces();
 	bool _is_debug_collision_shape_visible();
 	void _update_debug_collision_shape();
@@ -137,6 +139,8 @@ public:
 #ifndef PHYSICS_3D_DISABLED
 	void set_use_collision(bool p_enable);
 	bool is_using_collision() const;
+	void set_use_backface_collision(bool p_enable);
+	bool is_using_backface_collision() const;
 
 	void set_collision_layer(uint32_t p_layer);
 	uint32_t get_collision_layer() const;

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -102,6 +102,9 @@
 		<member name="snap" type="float" setter="set_snap" getter="get_snap" deprecated="The CSG library no longer uses snapping.">
 			This property does nothing.
 		</member>
+		<member name="use_backface_collision" type="bool" setter="set_use_backface_collision" getter="is_using_backface_collision" default="false">
+			If set to [code]true[/code], collisions occur on both sides of the concave shape faces. Otherwise, they occur only on the front normals. See also [member ConcavePolygonShape3D.backface_collision].
+		</member>
 		<member name="use_collision" type="bool" setter="set_use_collision" getter="is_using_collision" default="false">
 			Adds a collision shape to the physics engine for our CSG shape. This will always act like a static body. Note that the collision shape is still active even if the CSG shape itself is hidden. See also [member collision_mask] and [member collision_priority].
 		</member>


### PR DESCRIPTION
Solves https://github.com/godotengine/godot-proposals/issues/14371

Add the ability for CSG nodes with collision to use backface collisions for improved reliability when it is needed.

This can also be used to fix the shapecast inconsistency bug (https://github.com/godotengine/godot/issues/115640)
Here it is using the backface collisions to fix the shapecast:

https://github.com/user-attachments/assets/c992e6f0-d8b8-48bf-b769-30f33928c641

This also allows the workaround to fix shapecasts to be used with CSG nodes, partially solving https://github.com/godotengine/godot/issues/115640