### PR TITLE
Fix Apple OsLogLogger build on visionOS

### DIFF
--- a/drivers/apple/os_log_logger.cpp
+++ b/drivers/apple/os_log_logger.cpp
@@ -33,7 +33,8 @@
 #include "core/object/script_backtrace.h"
 #include "core/string/print_string.h"
 
-#include <cstdlib> // For malloc/free
+#include <cstdio> // For vsnprintf.
+#include <cstdlib> // For malloc/free.
 
 OsLogLogger::OsLogLogger(const char *p_subsystem) {
 	const char *subsystem = p_subsystem;


### PR DESCRIPTION
Recent includes refactoring led to missing one here. Apparently this affected visionOS specifically and not iOS.

Reported by @bruvzg in https://github.com/godotengine/godot/pull/116976#pullrequestreview-3882449448.