### PR TITLE
Avoid busy work on various components of the Tile system

### DIFF
--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -3733,6 +3733,7 @@ void TileMapLayerEditor::_notification(int p_what) {
 
 				CanvasItemEditor::get_singleton()->update_viewport();
 				tile_map_layer_changed_needs_update = false;
+				set_process_internal(false);
 			}
 		} break;
 
@@ -4106,6 +4107,7 @@ Vector<Vector2i> TileMapLayerEditor::get_line(const TileMapLayer *p_tile_map_lay
 
 void TileMapLayerEditor::_tile_map_layer_changed() {
 	tile_map_layer_changed_needs_update = true;
+	set_process_internal(true);
 }
 
 void TileMapLayerEditor::_tab_changed(int p_tab_id) {
@@ -4498,7 +4500,7 @@ void TileMapLayerEditor::update_layout(DockLayout p_layout) {
 }
 
 TileMapLayerEditor::TileMapLayerEditor() {
-	set_process_internal(true);
+	set_process_internal(false);
 	set_name(TTRC("TileMap"));
 	set_icon_name("TileMapDock");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_tile_map_bottom_panel", TTRC("Open TileMap Dock")));

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -1089,7 +1089,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 			current_tile_data_editor->forward_painting_atlas_gui_input(tile_atlas_view, tile_set_atlas_source, p_event);
 		}
 		// Update only what's needed.
-		tile_set_changed_needs_update = false;
+		_set_tile_set_changed_needs_update(false);
 
 		tile_atlas_control->queue_redraw();
 		tile_atlas_control_unscaled->queue_redraw();
@@ -1159,7 +1159,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 					drag_current_tile = coords;
 
 					// Update only what's needed.
-					tile_set_changed_needs_update = false;
+					_set_tile_set_changed_needs_update(false);
 					_update_tile_inspector();
 					_update_atlas_view();
 					_update_tile_id_label();
@@ -1201,7 +1201,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 					drag_current_tile = new_rect.position;
 
 					// Update only what's needed.
-					tile_set_changed_needs_update = false;
+					_set_tile_set_changed_needs_update(false);
 					_update_tile_inspector();
 					_update_atlas_view();
 					_update_tile_id_label();
@@ -2113,19 +2113,25 @@ void TileSetAtlasSourceEditor::_tile_alternatives_control_unscaled_draw() {
 	}
 }
 
+void TileSetAtlasSourceEditor::_set_tile_set_changed_needs_update(bool p_needs_update) {
+	tile_set_changed_needs_update = p_needs_update;
+	set_process_internal(p_needs_update);
+}
+
 void TileSetAtlasSourceEditor::_tile_set_changed() {
 	if (tile_set->get_source_count() == 0) {
 		// No sources, so nothing to do here anymore.
+		_set_tile_set_changed_needs_update(false);
 		tile_set->disconnect_changed(callable_mp(this, &TileSetAtlasSourceEditor::_tile_set_changed));
 		tile_set = Ref<TileSet>();
 		return;
 	}
 
-	tile_set_changed_needs_update = true;
+	_set_tile_set_changed_needs_update(true);
 }
 
 void TileSetAtlasSourceEditor::_tile_proxy_object_changed(const String &p_what) {
-	tile_set_changed_needs_update = false; // Avoid updating too many things.
+	_set_tile_set_changed_needs_update(false); // Avoid updating too many things.
 	_update_atlas_view();
 }
 
@@ -2505,7 +2511,7 @@ void TileSetAtlasSourceEditor::_notification(int p_what) {
 				_update_tile_data_editors();
 				_update_current_tile_data_editor();
 
-				tile_set_changed_needs_update = false;
+				_set_tile_set_changed_needs_update(false);
 			}
 		} break;
 
@@ -2530,7 +2536,7 @@ void TileSetAtlasSourceEditor::_bind_methods() {
 TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	set_shortcut_context(this);
 	set_process_shortcut_input(true);
-	set_process_internal(true);
+	set_process_internal(false);
 	TileSetEditor::get_singleton()->register_split(this);
 
 	// Middle panel.

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.h
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.h
@@ -282,6 +282,7 @@ private:
 	void _check_outside_tiles();
 	void _cleanup_outside_tiles();
 
+	void _set_tile_set_changed_needs_update(bool p_needs_update);
 	void _tile_set_changed();
 	void _tile_proxy_object_changed(const String &p_what);
 	void _atlas_source_proxy_object_changed(const String &p_what);

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -363,6 +363,11 @@ void TileSetEditor::_set_source_sort(int p_sort) {
 	}
 }
 
+void TileSetEditor::_set_tile_set_changed_needs_update(bool p_needs_update) {
+	tile_set_changed_needs_update = p_needs_update;
+	set_process_internal(p_needs_update);
+}
+
 void TileSetEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -400,7 +405,7 @@ void TileSetEditor::_notification(int p_what) {
 				sources_advanced_menu_button->set_disabled(read_only);
 				source_sort_button->set_disabled(read_only);
 
-				tile_set_changed_needs_update = false;
+				_set_tile_set_changed_needs_update(false);
 			}
 		} break;
 
@@ -460,7 +465,7 @@ void TileSetEditor::_update_patterns_list() {
 }
 
 void TileSetEditor::_tile_set_changed() {
-	tile_set_changed_needs_update = true;
+	_set_tile_set_changed_needs_update(true);
 }
 
 void TileSetEditor::_tab_changed(int p_tab_changed) {
@@ -823,7 +828,7 @@ TileSetEditor::TileSetEditor() {
 	set_global(false);
 	set_transient(true);
 
-	set_process_internal(true);
+	set_process_internal(false);
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);

--- a/editor/scene/2d/tiles/tile_set_editor.h
+++ b/editor/scene/2d/tiles/tile_set_editor.h
@@ -106,6 +106,7 @@ private:
 	ObjectID expanded_editor_parent;
 	LocalVector<SplitContainer *> disable_on_expand;
 
+	void _set_tile_set_changed_needs_update(bool p_needs_update);
 	void _tile_set_changed();
 	void _tab_changed(int p_tab_changed);
 


### PR DESCRIPTION
Various tile components kept going

continously when it was unnecessary.   Now, whenever we determine that there is
actual work required, we turn on the existing system and then turn it off when
we are done.

This is part of the work to reduce the CPU consumption when idling, on my machine it gives me about 0.6% of the idle time for each of these.

For a discussion see:

https://github.com/godotengine/godot/issues/116845
https://github.com/godotengine/godot/issues/68269