### PR TITLE
Fix quick load for resources imported by editor import plugins

### DIFF
--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -393,6 +393,17 @@ String ResourceFormatImporter::get_resource_type(const String &p_path) const {
 	return pat.type;
 }
 
+String ResourceFormatImporter::get_resource_script_class(const String &p_path) const {
+	PathAndType pat;
+	Error err = _get_path_and_type(p_path, pat, false);
+
+	if (err != OK) {
+		return String();
+	}
+
+	return ResourceLoader::get_resource_script_class(pat.path);
+}
+
 ResourceUID::ID ResourceFormatImporter::get_resource_uid(const String &p_path) const {
 	PathAndType pat;
 	Error err = _get_path_and_type(p_path, pat, false);

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -70,6 +70,7 @@ public:
 	virtual bool recognize_path(const String &p_path, const String &p_for_type = String()) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
+	virtual String get_resource_script_class(const String &p_path) const override;
 	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override;
 	virtual bool has_custom_uid_support() const override;
 	virtual Variant get_resource_metadata(const String &p_path) const;

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -3031,6 +3031,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		fs->files[cpos]->import_dest_paths = dest_paths;
 		fs->files[cpos]->deps = _get_dependencies(p_file);
 		fs->files[cpos]->type = importer->get_resource_type();
+		fs->files[cpos]->resource_script_class = ResourceLoader::get_resource_script_class(p_file);
 		fs->files[cpos]->uid = uid;
 		fs->files[cpos]->import_valid = fs->files[cpos]->type == "TextFile" ? true : ResourceLoader::is_import_valid(p_file);
 	}


### PR DESCRIPTION
Fixes #72639 

This PR fixes script classes not being recognised in imported resources (such as from custom EditorImportPlugin scripts) which is the root cause of them not showing up in the editor's quick load resource picker.


Previously the script class was never registered in the editor file system on first import (in `EditorFileSystem::_reimport_file`).
It also wouldn't get set correctly when refreshed (e.g. from `EditorFileSystem::update_file`) without the `ResourceFormatImporter::get_resource_script_class` method override to remap the original file path to its saved imported resource path.