### PR TITLE
Core: Trim unused headers in `variant.h`

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -31,6 +31,7 @@
 #include "project_settings.h"
 
 #include "core/core_bind.h" // For Compression enum.
+#include "core/core_string_names.h"
 #include "core/input/input_map.h"
 #include "core/io/config_file.h"
 #include "core/io/dir_access.h"

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -36,6 +36,7 @@
 #include "core/io/file_access.h"
 #include "core/io/image.h"
 #include "core/io/xml_parser.h"
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language_extension.h"
 #include "core/object/worker_thread_pool.h"

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -35,6 +35,7 @@
 #include "core/io/image_loader.h"
 #include "core/io/resource_loader.h"
 #include "core/math/math_funcs.h"
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "core/templates/hash_map.h"
 #include "core/variant/dictionary.h"

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -31,7 +31,9 @@
 #include "json.h"
 
 #include "core/config/engine.h"
+#include "core/core_string_names.h"
 #include "core/io/file_access.h"
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "core/variant/container_type_validate.h"

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -30,7 +30,9 @@
 
 #include "marshalls.h"
 
+#include "core/core_string_names.h"
 #include "core/io/resource_loader.h"
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "core/object/ref_counted.h"
 #include "core/object/script_language.h"

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -30,6 +30,7 @@
 
 #include "resource.h"
 
+#include "core/core_string_names.h"
 #include "core/io/resource_loader.h"
 #include "core/math/math_funcs.h"
 #include "core/math/random_pcg.h"

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -33,6 +33,7 @@
 #include "core/io/resource_uid.h"
 #include "core/object/gdvirtual.gen.h"
 #include "core/object/ref_counted.h"
+#include "core/templates/rid.h"
 #include "core/templates/safe_refcount.h"
 #include "core/templates/self_list.h"
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -31,9 +31,11 @@
 #include "resource_format_binary.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access_compressed.h"
 #include "core/io/missing_resource.h"
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "core/version.h"

--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/rect2i.h"
 #include "core/object/gdvirtual.gen.h"
 #include "core/object/ref_counted.h"
 #include "core/templates/local_vector.h"

--- a/core/math/math_fieldwise.cpp
+++ b/core/math/math_fieldwise.cpp
@@ -32,6 +32,23 @@
 
 #include "math_fieldwise.h"
 
+#include "core/math/aabb.h"
+#include "core/math/basis.h"
+#include "core/math/color.h"
+#include "core/math/plane.h"
+#include "core/math/projection.h"
+#include "core/math/quaternion.h"
+#include "core/math/rect2.h"
+#include "core/math/rect2i.h"
+#include "core/math/transform_2d.h"
+#include "core/math/transform_3d.h"
+#include "core/math/vector2.h"
+#include "core/math/vector2i.h"
+#include "core/math/vector3.h"
+#include "core/math/vector3i.h"
+#include "core/math/vector4.h"
+#include "core/math/vector4i.h"
+
 #define SETUP_TYPE(m_type) \
 	m_type source = p_source; \
 	m_type target = p_target;

--- a/core/math/static_raycaster.h
+++ b/core/math/static_raycaster.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/vector3.h"
 #include "core/object/ref_counted.h"
 
 class StaticRaycaster : public RefCounted {

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -31,6 +31,7 @@
 #include "class_db.h"
 
 #include "core/config/engine.h"
+#include "core/core_string_names.h"
 #include "core/io/resource_loader.h"
 #include "core/object/script_language.h"
 #include "core/templates/sort_array.h"

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -31,8 +31,7 @@
 #include "message_queue.h"
 
 #include "core/config/project_settings.h"
-#include "core/object/class_db.h"
-#include "core/object/script_language.h"
+#include "core/core_string_names.h"
 
 #include <cstdio>
 

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -30,6 +30,7 @@
 
 #include "object.h"
 
+#include "core/core_string_names.h"
 #include "core/extension/gdextension_manager.h"
 #include "core/io/resource.h"
 #include "core/object/class_db.h"

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/core_bind.h"
+#include "core/core_string_names.h"
 #include "core/crypto/aes_context.h"
 #include "core/crypto/crypto.h"
 #include "core/crypto/hashing_context.h"

--- a/core/string/fuzzy_search.h
+++ b/core/string/fuzzy_search.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/vector2i.h"
 #include "core/variant/variant.h"
 
 class FuzzyTokenMatch;

--- a/core/string/print_string.cpp
+++ b/core/string/print_string.cpp
@@ -31,6 +31,7 @@
 #include "print_string.h"
 
 #include "core/core_globals.h"
+#include "core/math/color.h"
 #include "core/os/os.h"
 
 #include <cstdio>

--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -34,6 +34,7 @@
 #include "core/os/mutex.h"
 #include "core/string/print_string.h"
 #include "core/templates/local_vector.h"
+#include "core/templates/rid.h"
 #include "core/templates/safe_refcount.h"
 #include "core/variant/variant.h"
 

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -30,6 +30,12 @@
 
 #pragma once
 
+#include "core/math/vector2.h"
+#include "core/math/vector2i.h"
+#include "core/math/vector3.h"
+#include "core/math/vector3i.h"
+#include "core/math/vector4.h"
+#include "core/math/vector4i.h"
 #include "core/object/object.h"
 #include "core/templates/simple_type.h"
 #include "core/typedefs.h"

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/face3.h"
 #include "core/object/object.h"
 #include "core/object/object_id.h"
 #include "core/templates/simple_type.h"

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -30,10 +30,47 @@
 
 #include "variant.h"
 
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Vector2);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Vector2i);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Rect2);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Rect2i);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Vector3);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Vector3i);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Vector4);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Vector4i);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Plane);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, AABB);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Quaternion);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Basis);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Transform2D);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Transform3D);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Projection);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Color);
+
+STATIC_ASSERT_INCOMPLETE_TYPE(class, NodePath);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, RID);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Object);
+
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, PropertyInfo);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, MethodInfo);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, Face3);
+STATIC_ASSERT_INCOMPLETE_TYPE(struct, IPAddress);
+
+STATIC_ASSERT_INCOMPLETE_TYPE(class, CoreStringNames);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Mesh);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, DisplayServer);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Shader);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, OS);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Engine);
+
+#include "core/core_string_names.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/io/json.h"
 #include "core/io/resource.h"
+#include "core/math/face3.h"
 #include "core/math/math_funcs.h"
+#include "core/math/rect2i.h"
 #include "core/variant/variant_parser.h"
 #include "core/variant/variant_pools.h"
 

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -30,39 +30,35 @@
 
 #pragma once
 
-#include "core/core_string_names.h"
-#include "core/error/error_macros.h"
-#include "core/io/ip_address.h"
-#include "core/math/aabb.h"
-#include "core/math/basis.h"
-#include "core/math/color.h"
-#include "core/math/face3.h"
-#include "core/math/plane.h"
-#include "core/math/projection.h"
-#include "core/math/quaternion.h"
-#include "core/math/rect2.h"
-#include "core/math/rect2i.h"
-#include "core/math/transform_2d.h"
-#include "core/math/transform_3d.h"
-#include "core/math/vector2.h"
-#include "core/math/vector2i.h"
-#include "core/math/vector3.h"
-#include "core/math/vector3i.h"
-#include "core/math/vector4.h"
-#include "core/math/vector4i.h"
 #include "core/object/object_id.h"
-#include "core/string/node_path.h"
 #include "core/string/ustring.h"
 #include "core/templates/bit_field.h"
 #include "core/templates/hashfuncs.h"
 #include "core/templates/list.h"
-#include "core/templates/rid.h"
 #include "core/typedefs.h"
 #include "core/variant/array.h"
 #include "core/variant/callable.h"
 #include "core/variant/dictionary.h"
 #include "core/variant/variant_deep_duplicate.h"
 
+struct Vector2;
+struct Vector2i;
+struct Rect2;
+struct Rect2i;
+struct Vector3;
+struct Vector3i;
+struct Vector4;
+struct Vector4i;
+struct Plane;
+struct AABB;
+struct Quaternion;
+struct Basis;
+struct Transform2D;
+struct Transform3D;
+struct Projection;
+struct Color;
+class NodePath;
+class RID;
 class Object;
 class RefCounted;
 
@@ -77,6 +73,8 @@ class TypedDictionary;
 
 struct PropertyInfo;
 struct MethodInfo;
+struct Face3;
+struct IPAddress;
 
 typedef Vector<uint8_t> PackedByteArray;
 typedef Vector<int32_t> PackedInt32Array;
@@ -89,6 +87,11 @@ typedef Vector<Vector2> PackedVector2Array;
 typedef Vector<Vector3> PackedVector3Array;
 typedef Vector<Color> PackedColorArray;
 typedef Vector<Vector4> PackedVector4Array;
+
+typedef Vector2 Size2;
+typedef Vector2 Point2;
+typedef Vector2i Size2i;
+typedef Vector2i Point2i;
 
 class Variant {
 public:

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -34,10 +34,12 @@
 #include "core/debugger/engine_debugger.h"
 #include "core/io/compression.h"
 #include "core/io/marshalls.h"
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/templates/a_hash_map.h"
 #include "core/templates/local_vector.h"
+#include "core/templates/rid.h"
 
 typedef void (*VariantFunc)(Variant &r_ret, Variant &p_self, const Variant **p_args);
 typedef void (*VariantConstructFunc)(Variant &r_ret, const Variant **p_args);

--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -35,10 +35,12 @@
 #include "core/crypto/crypto_core.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/io/compression.h"
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/templates/a_hash_map.h"
 #include "core/templates/local_vector.h"
+#include "core/templates/rid.h"
 
 template <typename T>
 struct PtrConstruct {};

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -30,6 +30,15 @@
 
 #pragma once
 
+#include "core/io/ip_address.h"
+#include "core/math/aabb.h"
+#include "core/math/basis.h"
+#include "core/math/color.h"
+#include "core/math/projection.h"
+#include "core/math/quaternion.h"
+#include "core/math/transform_2d.h"
+#include "core/math/transform_3d.h"
+#include "core/string/node_path.h"
 #include "core/templates/simple_type.h"
 #include "core/variant/type_info.h"
 #include "core/variant/variant.h"

--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -30,6 +30,9 @@
 
 #include "variant_op.h"
 
+#include "core/math/rect2i.h"
+#include "core/templates/rid.h"
+
 typedef void (*VariantEvaluatorFunction)(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid);
 
 static Variant::Type operator_return_type_table[Variant::OP_MAX][Variant::VARIANT_MAX][Variant::VARIANT_MAX];

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -33,6 +33,7 @@
 #include "core/crypto/crypto_core.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_uid.h"
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "core/string/string_buffer.h"

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -29,9 +29,10 @@
 /**************************************************************************/
 
 #include "variant_setget.h"
-#include "variant_callable.h"
 
+#include "core/core_string_names.h"
 #include "core/io/resource.h"
+#include "core/variant/variant_callable.h"
 
 struct VariantSetterGetterInfo {
 	void (*setter)(Variant *base, const Variant *value, bool &valid);

--- a/core/variant/variant_setget.h
+++ b/core/variant/variant_setget.h
@@ -33,6 +33,7 @@
 #include "variant.h"
 
 #include "core/debugger/engine_debugger.h"
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "core/variant/variant_internal.h"
 

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -31,6 +31,7 @@
 #include "variant_utility.h"
 
 #include "core/io/marshalls.h"
+#include "core/math/rect2i.h"
 #include "core/object/ref_counted.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -35,6 +35,7 @@
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/marshalls.h"
+#include "core/math/rect2i.h"
 #include "core/os/os.h"
 
 #include "thirdparty/zlib/zlib.h"

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -33,6 +33,8 @@
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/marshalls.h"
+#include "core/math/rect2i.h"
+#include "core/math/transform_3d.h"
 #include "core/os/os.h"
 #include "core/templates/fixed_vector.h"
 #include "vulkan_hooks.h"

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -30,6 +30,7 @@
 
 #include "animation_state_machine_editor.h"
 
+#include "core/core_string_names.h"
 #include "core/io/resource_loader.h"
 #include "core/math/geometry_2d.h"
 #include "core/object/class_db.h"

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -32,6 +32,7 @@
 
 #include "animation_track_editor_plugins.h"
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/error/error_macros.h"
 #include "core/input/input.h"
 #include "core/object/class_db.h"

--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "asset_library_editor_plugin.h"
 
+#include "core/core_string_names.h"
 #include "core/io/dir_access.h"
 #include "core/io/json.h"
 #include "core/io/stream_peer_tls.h"

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -31,6 +31,7 @@
 #include "editor_audio_buses.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/io/resource_saver.h"
 #include "core/object/class_db.h"

--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_performance_profiler.h"
 
+#include "core/core_string_names.h"
 #include "core/string/translation_server.h"
 #include "editor/editor_string_names.h"
 #include "editor/inspector/editor_property_name_processor.h"

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -31,6 +31,7 @@
 #include "script_editor_debugger.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/remote_debugger.h"
 #include "core/object/class_db.h"

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/core_constants.h"
+#include "core/core_string_names.h"
 #include "core/extension/gdextension.h"
 #include "core/input/input.h"
 #include "core/io/json.h"

--- a/editor/docks/dock_tab_container.h
+++ b/editor/docks/dock_tab_container.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/rect2i.h"
 #include "editor/docks/editor_dock.h"
 #include "scene/gui/tab_container.h"
 

--- a/editor/docks/import_dock.cpp
+++ b/editor/docks/import_dock.cpp
@@ -31,6 +31,7 @@
 #include "import_dock.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -31,6 +31,7 @@
 #include "scene_tree_dock.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/io/resource_saver.h"
 #include "core/object/class_db.h"

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/resource.h"
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "core/object/object.h"
 #include "core/object/script_language.h"

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -31,6 +31,7 @@
 #include "editor_node.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/extension/gdextension_manager.h"
 #include "core/input/input.h"
 #include "core/io/config_file.h"

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -30,6 +30,7 @@
 
 #include "code_editor.h"
 
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"

--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -31,6 +31,7 @@
 #include "editor_spin_slider.h"
 
 #include "core/config/engine.h"
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/math/expression.h"
 #include "core/object/class_db.h"

--- a/editor/gui/editor_zoom_widget.cpp
+++ b/editor/gui/editor_zoom_widget.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_zoom_widget.h"
 
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"

--- a/editor/import/editor_atlas_packer.cpp
+++ b/editor/import/editor_atlas_packer.cpp
@@ -32,6 +32,7 @@
 
 #include "core/math/geometry_2d.h"
 #include "core/math/math_funcs_binary.h"
+#include "core/math/rect2i.h"
 #include "core/math/vector2.h"
 #include "core/math/vector2i.h"
 #include "scene/resources/bit_map.h"

--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -32,6 +32,7 @@
 
 #include "core/io/image_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/math/rect2i.h"
 
 String ResourceImporterImageFont::get_importer_name() const {
 	return "font_data_image";

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
 #include "core/io/image_loader.h"
+#include "core/math/rect2i.h"
 #include "core/object/ref_counted.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/import/resource_importer_texture.h"

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -31,6 +31,7 @@
 #include "editor_inspector.h"
 #include "editor_inspector.compat.inc"
 
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -31,6 +31,7 @@
 #include "editor_properties.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/input/input_map.h"
 #include "core/io/marshalls.h"
 #include "core/object/class_db.h"

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_resource_picker.h"
 
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/object/class_db.h"
 #include "editor/audio/audio_stream_preview.h"

--- a/editor/inspector/multi_node_edit.cpp
+++ b/editor/inspector/multi_node_edit.cpp
@@ -30,6 +30,7 @@
 
 #include "multi_node_edit.h"
 
+#include "core/core_string_names.h"
 #include "core/math/math_fieldwise.h"
 #include "core/object/class_db.h"
 #include "editor/editor_node.h"

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -31,6 +31,7 @@
 #include "project_manager.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/io/config_file.h"
 #include "core/io/dir_access.h"

--- a/editor/run/editor_run.h
+++ b/editor/run/editor_run.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/vector2i.h"
 #include "core/os/os.h"
 
 typedef void (*EditorRunInstanceStarting)(int p_index, List<String> &r_arguments);

--- a/editor/run/embedded_process.h
+++ b/editor/run/embedded_process.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/rect2i.h"
 #include "core/os/os.h"
 #include "scene/gui/control.h"
 

--- a/editor/run/game_view_plugin.h
+++ b/editor/run/game_view_plugin.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/rect2i.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/editor_debugger_plugin.h"
 #include "editor/editor_main_screen.h"

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -33,6 +33,7 @@
 #include "core/object/class_db.h"
 #include "tiles_editor_plugin.h"
 
+#include "core/core_string_names.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/inspector/editor_resource_preview.h"

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -32,6 +32,7 @@
 
 #include "tiles_editor_plugin.h"
 
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -30,6 +30,7 @@
 
 #include "tile_set_scenes_collection_source_editor.h"
 
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"

--- a/editor/scene/2d/tiles/tiles_editor_plugin.cpp
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.cpp
@@ -34,6 +34,7 @@
 
 #include "core/os/mutex.h"
 
+#include "core/core_string_names.h"
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_interface.h"
 #include "editor/editor_node.h"

--- a/editor/scene/3d/gizmos/gizmo_3d_helper.h
+++ b/editor/scene/3d/gizmos/gizmo_3d_helper.h
@@ -30,6 +30,9 @@
 
 #pragma once
 
+#include "core/math/transform_3d.h"
+#include "core/math/vector2.h"
+#include "core/math/vector3.h"
 #include "core/object/ref_counted.h"
 
 class Camera3D;

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -31,6 +31,7 @@
 #include "node_3d_editor_plugin.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/input/input_map.h"
 #include "core/math/geometry_3d.h"

--- a/editor/scene/gradient_editor_plugin.cpp
+++ b/editor/scene/gradient_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "gradient_editor_plugin.h"
 
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"

--- a/editor/scene/group_settings_editor.cpp
+++ b/editor/scene/group_settings_editor.cpp
@@ -31,6 +31,7 @@
 #include "group_settings_editor.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/docks/scene_tree_dock.h"

--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "theme_editor_plugin.h"
 
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 #include "editor/doc/editor_help.h"
 #include "editor/docks/editor_dock_manager.h"

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -31,6 +31,7 @@
 #include "scene_tree_editor.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "editor/animation/animation_player_editor_plugin.h"

--- a/editor/scene/texture/bit_map_editor_plugin.cpp
+++ b/editor/scene/texture/bit_map_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "bit_map_editor_plugin.h"
 
+#include "core/core_string_names.h"
 #include "core/object/callable_method_pointer.h"
 #include "editor/editor_string_names.h"
 #include "editor/themes/editor_scale.h"

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -31,6 +31,7 @@
 #include "script_editor_plugin.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/io/config_file.h"
 #include "core/io/file_access.h"

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -31,6 +31,7 @@
 #include "script_text_editor.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/io/dir_access.h"
 #include "core/io/json.h"

--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/core_constants.h"
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/editor_node.h"

--- a/editor/settings/editor_feature_profile.cpp
+++ b/editor/settings/editor_feature_profile.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_feature_profile.h"
 
+#include "core/core_string_names.h"
 #include "core/io/dir_access.h"
 #include "core/io/json.h"
 #include "core/object/class_db.h"

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -31,6 +31,7 @@
 #include "text_shader_editor.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 #include "core/version_generated.gen.h"
 #include "editor/editor_node.h"

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -31,6 +31,7 @@
 #include "visual_shader_editor_plugin.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/io/resource_loader.h"
 #include "core/math/math_defs.h"

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_theme_manager.h"
 
+#include "core/core_string_names.h"
 #include "core/error/error_macros.h"
 #include "core/io/resource_loader.h"
 #include "editor/editor_string_names.h"

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -30,6 +30,7 @@
 
 #include "theme_classic.h"
 
+#include "core/core_string_names.h"
 #include "editor/editor_string_names.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -30,6 +30,7 @@
 
 #include "theme_modern.h"
 
+#include "core/core_string_names.h"
 #include "core/math/math_defs.h"
 #include "editor/editor_string_names.h"
 #include "editor/settings/editor_settings.h"

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -30,6 +30,7 @@
 
 #include "gdscript.h"
 
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 #include "gdscript_analyzer.h"
 #include "gdscript_cache.h"

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -37,6 +37,7 @@
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/core_constants.h"
+#include "core/core_string_names.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
 #include "core/object/class_db.h"

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -38,9 +38,8 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
-
-#include "scene/scene_string_names.h"
 
 bool GDScriptCompiler::_is_class_member_property(CodeGen &codegen, const StringName &p_name) {
 	if (codegen.function_node && codegen.function_node->is_static) {

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -32,6 +32,7 @@
 
 #include "core/error/error_macros.h"
 #include "core/string/char_utils.h"
+#include "core/string/node_path.h"
 
 #ifdef DEBUG_ENABLED
 #include "servers/text/text_server.h"

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -32,6 +32,8 @@
 #include "gdscript_function.h"
 #include "gdscript_lambda_callable.h"
 
+#include "core/core_string_names.h"
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/profiling/profiling.h"

--- a/modules/gltf/editor/editor_scene_exporter_gltf_settings.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_settings.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_scene_exporter_gltf_settings.h"
 
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 
 const uint32_t PROP_EDITOR_SCRIPT_VAR = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_SCRIPT_VARIABLE;

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "grid_map_editor_plugin.h"
 
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/math/geometry_2d.h"
 #include "core/object/class_db.h"

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -30,6 +30,7 @@
 
 #include "grid_map.h"
 
+#include "core/core_string_names.h"
 #include "core/io/marshalls.h"
 #include "core/object/class_db.h"
 #include "core/templates/a_hash_map.h"

--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
@@ -30,12 +30,12 @@
 
 #pragma once
 
+#include "core/math/vector3.h"
 #include "core/os/mutex.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/hash_set.h"
 #include "core/templates/hashfuncs.h"
 #include "core/templates/local_vector.h"
-#include "core/templates/safe_refcount.h"
 #include "core/variant/variant.h"
 
 #include "Jolt/Jolt.h"

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -42,6 +42,7 @@
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
 #include "core/io/marshalls.h"
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "core/object/method_bind.h"
 #include "core/os/os.h"

--- a/modules/multiplayer/scene_cache_interface.h
+++ b/modules/multiplayer/scene_cache_interface.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/string/node_path.h"
 
 class Node;
 class SceneMultiplayer;

--- a/modules/navigation_2d/nav_utils_2d.h
+++ b/modules/navigation_2d/nav_utils_2d.h
@@ -30,11 +30,12 @@
 
 #pragma once
 
-#include "core/math/vector3.h"
+#include "core/math/vector2.h"
 #include "core/object/ref_counted.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/hashfuncs.h"
 #include "core/templates/local_vector.h"
+#include "core/templates/rid.h"
 #include "servers/navigation_2d/navigation_constants_2d.h"
 
 class NavBaseIteration2D;

--- a/modules/navigation_3d/3d/nav_base_iteration_3d.h
+++ b/modules/navigation_3d/3d/nav_base_iteration_3d.h
@@ -33,6 +33,7 @@
 #include "../nav_utils_3d.h"
 
 #include "core/object/ref_counted.h"
+#include "core/templates/rid.h"
 #include "servers/navigation_3d/navigation_constants_3d.h"
 
 class NavBaseIteration3D : public RefCounted {

--- a/modules/navigation_3d/nav_utils_3d.h
+++ b/modules/navigation_3d/nav_utils_3d.h
@@ -35,6 +35,7 @@
 #include "core/templates/hash_map.h"
 #include "core/templates/hashfuncs.h"
 #include "core/templates/local_vector.h"
+#include "core/templates/rid.h"
 #include "servers/navigation_3d/navigation_constants_3d.h"
 
 class NavBaseIteration3D;

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -36,6 +36,7 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/projection.h"
+#include "core/math/rect2i.h"
 #include "core/math/transform_3d.h"
 #include "core/math/vector2.h"
 #include "core/string/ustring.h"

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -32,6 +32,7 @@
 
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
+#include "core/math/rect2i.h"
 #include "core/os/thread.h"
 #include "scene/resources/video_stream.h"
 

--- a/platform/linuxbsd/wayland/wayland_embedder.h
+++ b/platform/linuxbsd/wayland/wayland_embedder.h
@@ -34,6 +34,8 @@
 
 #ifdef TOOLS_ENABLED
 
+#include "core/math/rect2i.h"
+#include "core/math/vector2i.h"
 #include "core/templates/a_hash_map.h"
 #include "core/templates/pooled_list.h"
 

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -31,6 +31,7 @@
 #include "animated_sprite_2d.h"
 
 #include "core/config/engine.h"
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 #include "scene/main/viewport.h"
 #include "servers/display/accessibility_server.h"

--- a/scene/2d/navigation/navigation_agent_2d.cpp
+++ b/scene/2d/navigation/navigation_agent_2d.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_agent_2d.h"
 
+#include "core/core_string_names.h"
 #include "core/math/geometry_2d.h"
 #include "core/object/class_db.h"
 #include "scene/2d/navigation/navigation_link_2d.h"

--- a/scene/2d/physics/touch_screen_button.cpp
+++ b/scene/2d/physics/touch_screen_button.cpp
@@ -31,6 +31,7 @@
 #include "touch_screen_button.h"
 
 #include "core/config/engine.h"
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/object/class_db.h"
 #include "scene/main/viewport.h"

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -31,6 +31,7 @@
 #include "tile_map.h"
 #include "tile_map.compat.inc"
 
+#include "core/core_string_names.h"
 #include "core/io/marshalls.h"
 #include "core/object/class_db.h"
 

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -30,6 +30,7 @@
 
 #include "tile_map_layer.h"
 
+#include "core/core_string_names.h"
 #include "core/io/marshalls.h"
 #include "core/math/geometry_2d.h"
 #include "core/math/random_pcg.h"

--- a/scene/3d/lightmapper.h
+++ b/scene/3d/lightmapper.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/vector3.h"
 #include "core/object/ref_counted.h"
 
 class Image;

--- a/scene/3d/navigation/navigation_agent_3d.cpp
+++ b/scene/3d/navigation/navigation_agent_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_agent_3d.h"
 
+#include "core/core_string_names.h"
 #include "core/math/geometry_3d.h"
 #include "core/object/class_db.h"
 #include "scene/3d/navigation/navigation_link_3d.h"

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "sprite_3d.h"
 
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/mesh.h"

--- a/scene/3d/velocity_tracker_3d.h
+++ b/scene/3d/velocity_tracker_3d.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/vector3.h"
 #include "core/object/ref_counted.h"
 
 class VelocityTracker3D : public RefCounted {

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -33,6 +33,7 @@
 STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 #include "scene/resources/material.h"
 #include "servers/rendering/rendering_server.h"

--- a/scene/debugger/runtime_node_select.h
+++ b/scene/debugger/runtime_node_select.h
@@ -32,7 +32,13 @@
 
 #ifdef DEBUG_ENABLED
 
+#include "core/math/aabb.h"
+#include "core/math/color.h"
+#include "core/math/transform_2d.h"
+#include "core/math/transform_3d.h"
+#include "core/math/vector3.h"
 #include "core/object/object.h"
+#include "core/templates/rid.h"
 #include "scene/gui/view_panner.h"
 
 class InputEvent;

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -33,6 +33,10 @@
 #include "core/object/ref_counted.h"
 #include "core/string/ustring.h"
 
+#ifdef DEBUG_ENABLED
+#include "core/string/node_path.h"
+#endif
+
 class Array;
 class InputEvent;
 class Node;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -30,6 +30,7 @@
 
 #include "color_picker.h"
 
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/io/image.h"
 #include "core/math/expression.h"

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -30,6 +30,7 @@
 
 #include "graph_node.h"
 
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/graph_edit.h"

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/rect2i.h"
 #include "scene/gui/control.h"
 #include "scene/gui/scroll_bar.h"
 #include "scene/property_list_helper.h"

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -30,6 +30,7 @@
 
 #include "range.h"
 
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 #include "servers/display/accessibility_server.h"
 #include "thirdparty/misc/r128.h"

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/engine.h"
 #include "core/input/input.h"
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -30,6 +30,7 @@
 
 #include "spin_box.h"
 
+#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/math/expression.h"
 #include "core/object/class_db.h"

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/rect2i.h"
 #include "scene/gui/control.h"
 #include "scene/resources/text_paragraph.h"
 #include "servers/display/accessibility_server.h"

--- a/scene/gui/view_panner.h
+++ b/scene/gui/view_panner.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "core/math/rect2.h"
+#include "core/math/vector2.h"
 #include "core/object/ref_counted.h"
 
 class InputEvent;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -41,6 +41,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, OS);
 STATIC_ASSERT_INCOMPLETE_TYPE(class, Engine);
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/io/resource.h"
 #include "core/io/resource_loader.h"
 #include "core/object/message_queue.h"

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/rect2i.h"
 #include "scene/main/node.h"
 #include "scene/resources/texture.h"
 #include "servers/display/display_server_enums.h"

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/rect2i.h"
 #include "scene/main/viewport.h"
 #include "scene/resources/theme.h"
 #include "servers/display/display_server_enums.h"

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -31,6 +31,7 @@
 #include "property_utils.h"
 
 #include "core/config/engine.h"
+#include "core/core_string_names.h"
 #include "core/io/resource_loader.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -31,6 +31,7 @@
 #include "tile_set.h"
 #include "tile_set.compat.inc"
 
+#include "core/core_string_names.h"
 #include "core/io/marshalls.h"
 #include "core/math/geometry_2d.h"
 #include "core/object/class_db.h"

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -32,6 +32,7 @@
 #include "animation.compat.inc"
 
 #include "core/io/marshalls.h"
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 
 bool Animation::_set(const StringName &p_name, const Variant &p_value) {

--- a/scene/resources/atlas_texture.cpp
+++ b/scene/resources/atlas_texture.cpp
@@ -30,6 +30,7 @@
 
 #include "atlas_texture.h"
 
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 
 int AtlasTexture::get_width() const {

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -30,6 +30,7 @@
 
 #include "bit_map.h"
 
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "core/variant/typed_array.h"
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -31,6 +31,7 @@
 #include "packed_scene.h"
 
 #include "core/config/engine.h"
+#include "core/core_string_names.h"
 #include "core/io/file_access.h"
 #include "core/io/missing_resource.h"
 #include "core/io/resource_loader.h"

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -31,6 +31,7 @@
 #include "resource_format_text.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/io/dir_access.h"
 #include "core/io/missing_resource.h"
 #include "core/object/class_db.h"

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -30,6 +30,7 @@
 
 #include "visual_shader.h"
 
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 #include "core/templates/rb_map.h"
 #include "core/variant/variant_utility.h"

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -30,6 +30,7 @@
 
 #include "default_theme.h"
 
+#include "core/core_string_names.h"
 #include "core/io/image.h"
 #include "scene/resources/dpi_texture.h"
 #include "scene/resources/font.h"

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -31,6 +31,7 @@
 #include "theme_db.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/io/resource_loader.h"
 #include "core/object/class_db.h"
 #include "scene/gui/control.h"

--- a/scene/theme/theme_owner.cpp
+++ b/scene/theme/theme_owner.cpp
@@ -30,6 +30,7 @@
 
 #include "theme_owner.h"
 
+#include "core/core_string_names.h"
 #include "core/object/callable_method_pointer.h"
 #include "scene/gui/control.h"
 #include "scene/main/window.h"

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -31,6 +31,7 @@
 #include "audio_stream.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 
 void AudioStreamPlayback::start(double p_from_pos) {

--- a/servers/display/accessibility_server_dummy.h
+++ b/servers/display/accessibility_server_dummy.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/rid.h"
 #include "servers/display/accessibility_server.h"
 
 class AccessibilityServerDummy : public AccessibilityServer {

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -32,6 +32,7 @@
 
 #include "core/io/image.h"
 #include "core/io/resource.h"
+#include "core/math/rect2i.h"
 #include "core/object/object.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"

--- a/servers/navigation_2d/navigation_path_query_parameters_2d.cpp
+++ b/servers/navigation_2d/navigation_path_query_parameters_2d.cpp
@@ -31,6 +31,7 @@
 #include "navigation_path_query_parameters_2d.h"
 
 #include "core/object/class_db.h"
+#include "core/templates/rid.h"
 #include "core/variant/typed_array.h"
 
 void NavigationPathQueryParameters2D::set_pathfinding_algorithm(const NavigationPathQueryParameters2D::PathfindingAlgorithm p_pathfinding_algorithm) {

--- a/servers/navigation_2d/navigation_path_query_parameters_2d.h
+++ b/servers/navigation_2d/navigation_path_query_parameters_2d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/templates/rid.h"
 #include "core/variant/binder_common.h"
 #include "servers/navigation_2d/navigation_constants_2d.h"
 

--- a/servers/navigation_2d/navigation_path_query_result_2d.cpp
+++ b/servers/navigation_2d/navigation_path_query_result_2d.cpp
@@ -31,6 +31,7 @@
 #include "navigation_path_query_result_2d.h"
 
 #include "core/object/class_db.h"
+#include "core/templates/rid.h"
 
 void NavigationPathQueryResult2D::set_path(const Vector<Vector2> &p_path) {
 	path = p_path;

--- a/servers/navigation_3d/navigation_path_query_parameters_3d.cpp
+++ b/servers/navigation_3d/navigation_path_query_parameters_3d.cpp
@@ -30,7 +30,9 @@
 
 #include "navigation_path_query_parameters_3d.h"
 
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
+#include "core/templates/rid.h"
 #include "core/variant/typed_array.h"
 
 void NavigationPathQueryParameters3D::set_pathfinding_algorithm(const NavigationPathQueryParameters3D::PathfindingAlgorithm p_pathfinding_algorithm) {

--- a/servers/navigation_3d/navigation_path_query_parameters_3d.h
+++ b/servers/navigation_3d/navigation_path_query_parameters_3d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/templates/rid.h"
 #include "core/variant/binder_common.h"
 #include "servers/navigation_3d/navigation_constants_3d.h"
 

--- a/servers/navigation_3d/navigation_path_query_result_3d.cpp
+++ b/servers/navigation_3d/navigation_path_query_result_3d.cpp
@@ -31,6 +31,7 @@
 #include "navigation_path_query_result_3d.h"
 
 #include "core/object/class_db.h"
+#include "core/templates/rid.h"
 
 void NavigationPathQueryResult3D::set_path(const Vector<Vector3> &p_path) {
 	path = p_path;

--- a/servers/rendering/dummy/storage/light_storage.h
+++ b/servers/rendering/dummy/storage/light_storage.h
@@ -32,6 +32,11 @@
 
 #include "core/templates/rid_owner.h"
 
+#include "core/math/aabb.h"
+#include "core/math/color.h"
+#include "core/math/projection.h"
+#include "core/math/transform_3d.h"
+#include "core/templates/rid.h"
 #include "servers/rendering/storage/light_storage.h"
 
 namespace RendererDummy {

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -30,8 +30,8 @@
 
 #pragma once
 
+#include "core/math/color.h"
 #include "core/object/object.h"
-#include "core/variant/type_info.h"
 
 #define STEPIFY(m_number, m_alignment) ((((m_number) + ((m_alignment) - 1)) / (m_alignment)) * (m_alignment))
 

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -45,6 +45,8 @@
 //   There's no backwards communication from the driver to query data from RenderingDevice.
 // ***********************************************************************************
 
+#include "core/math/vector2i.h"
+#include "core/math/vector3i.h"
 #include "core/object/object.h"
 #include "core/templates/paged_allocator.h"
 #include "core/variant/type_info.h"

--- a/servers/rendering/rendering_device_graph.h
+++ b/servers/rendering/rendering_device_graph.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/rect2i.h"
 #include "core/object/worker_thread_pool.h"
 #include "rendering_device_commons.h"
 #include "rendering_device_driver.h"

--- a/servers/rendering/storage/environment_storage.h
+++ b/servers/rendering/storage/environment_storage.h
@@ -30,6 +30,9 @@
 
 #pragma once
 
+#include "core/math/basis.h"
+#include "core/math/color.h"
+#include "core/templates/rid.h"
 #include "core/templates/rid_owner.h"
 #include "servers/rendering/rendering_server_enums.h"
 

--- a/servers/rendering/storage/light_storage.h
+++ b/servers/rendering/storage/light_storage.h
@@ -30,6 +30,11 @@
 
 #pragma once
 
+#include "core/math/aabb.h"
+#include "core/math/projection.h"
+#include "core/math/transform_3d.h"
+#include "core/math/vector2.h"
+#include "core/templates/rid.h"
 #include "servers/rendering/rendering_server_enums.h"
 #include "servers/rendering/storage/render_scene_buffers.h"
 

--- a/servers/rendering/storage/render_scene_buffers.h
+++ b/servers/rendering/storage/render_scene_buffers.h
@@ -30,7 +30,9 @@
 
 #pragma once
 
+#include "core/math/vector2i.h"
 #include "core/object/ref_counted.h"
+#include "core/templates/rid.h"
 #include "servers/rendering/rendering_server_enums.h"
 
 class RenderSceneBuffersConfiguration : public RefCounted {

--- a/servers/rendering/storage/render_scene_data.cpp
+++ b/servers/rendering/storage/render_scene_data.cpp
@@ -31,6 +31,7 @@
 #include "render_scene_data.h"
 
 #include "core/object/class_db.h"
+#include "core/templates/rid.h" // IWYU pragma: keep // `get_uniform_buffer` return type.
 
 void RenderSceneData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_cam_transform"), &RenderSceneData::get_cam_transform);

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -30,6 +30,7 @@
 
 #include "xr_interface.h"
 
+#include "core/math/rect2i.h"
 #include "core/object/class_db.h"
 #include "servers/xr/xr_server.h"
 

--- a/servers/xr/xr_interface.h
+++ b/servers/xr/xr_interface.h
@@ -32,6 +32,7 @@
 
 #include "core/object/ref_counted.h"
 #include "core/os/thread_safe.h"
+#include "core/templates/rid.h"
 #include "core/variant/binder_common.h"
 
 /**

--- a/servers/xr/xr_vrs.h
+++ b/servers/xr/xr_vrs.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "core/math/rect2i.h"
+#include "core/math/vector2.h"
 #include "core/math/vector2i.h"
 #include "core/object/object.h"
 #include "core/templates/rid.h"

--- a/tests/core/input/test_input_event.cpp
+++ b/tests/core/input/test_input_event.cpp
@@ -32,6 +32,7 @@
 
 TEST_FORCE_LINK(test_input_event)
 
+#include "core/core_string_names.h"
 #include "core/input/input_event.h"
 #include "core/input/input_map.h"
 #include "core/math/rect2.h"

--- a/tests/core/io/test_image.cpp
+++ b/tests/core/io/test_image.cpp
@@ -34,6 +34,7 @@ TEST_FORCE_LINK(test_image)
 
 #include "core/io/file_access.h"
 #include "core/io/image.h"
+#include "core/math/rect2i.h"
 #include "tests/test_utils.h"
 
 #include "modules/modules_enabled.gen.h" // For bmp, jpg, svg, webp, tga.

--- a/tests/core/io/test_json_native.cpp
+++ b/tests/core/io/test_json_native.cpp
@@ -33,6 +33,7 @@
 TEST_FORCE_LINK(test_json_native)
 
 #include "core/io/json.h"
+#include "core/math/rect2i.h"
 #include "core/variant/typed_array.h"
 #include "core/variant/typed_dictionary.h"
 

--- a/tests/core/math/test_quaternion.cpp
+++ b/tests/core/math/test_quaternion.cpp
@@ -32,6 +32,7 @@
 
 TEST_FORCE_LINK(test_quaternion)
 
+#include "core/math/basis.h"
 #include "core/math/math_defs.h"
 #include "core/math/math_funcs.h"
 #include "core/math/quaternion.h"

--- a/tests/core/math/test_vector3.cpp
+++ b/tests/core/math/test_vector3.cpp
@@ -33,6 +33,7 @@
 TEST_FORCE_LINK(test_vector3)
 
 #include "core/math/vector3.h"
+#include "core/math/vector3i.h"
 
 namespace TestVector3 {
 

--- a/tests/core/math/test_vector3i.cpp
+++ b/tests/core/math/test_vector3i.cpp
@@ -32,6 +32,7 @@
 
 TEST_FORCE_LINK(test_vector3i)
 
+#include "core/math/vector3.h"
 #include "core/math/vector3i.h"
 
 namespace TestVector3i {

--- a/tests/core/math/test_vector4i.cpp
+++ b/tests/core/math/test_vector4i.cpp
@@ -32,6 +32,7 @@
 
 TEST_FORCE_LINK(test_vector4i)
 
+#include "core/math/vector4.h"
 #include "core/math/vector4i.h"
 
 namespace TestVector4i {

--- a/tests/core/object/test_object.cpp
+++ b/tests/core/object/test_object.cpp
@@ -32,6 +32,7 @@
 
 TEST_FORCE_LINK(test_object)
 
+#include "core/core_string_names.h"
 #include "core/object/class_db.h"
 #include "core/object/object.h"
 #include "core/object/script_language.h"

--- a/tests/core/string/test_string.cpp
+++ b/tests/core/string/test_string.cpp
@@ -32,6 +32,11 @@
 
 TEST_FORCE_LINK(test_string)
 
+#include "core/io/ip_address.h"
+#include "core/math/vector2.h"
+#include "core/math/vector3.h"
+#include "core/math/vector3i.h"
+#include "core/math/vector4.h"
 #include "core/string/ustring.h"
 
 namespace TestString {

--- a/tests/core/templates/test_command_queue.cpp
+++ b/tests/core/templates/test_command_queue.cpp
@@ -33,6 +33,7 @@
 TEST_FORCE_LINK(test_command_queue)
 
 #include "core/config/project_settings.h"
+#include "core/math/transform_3d.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/os/os.h"
 #include "core/os/thread.h"

--- a/tests/core/templates/test_list.cpp
+++ b/tests/core/templates/test_list.cpp
@@ -32,6 +32,7 @@
 
 TEST_FORCE_LINK(test_list)
 
+#include "core/math/color.h"
 #include "core/templates/list.h"
 
 namespace TestList {

--- a/tests/core/templates/test_vector.cpp
+++ b/tests/core/templates/test_vector.cpp
@@ -32,6 +32,10 @@
 
 TEST_FORCE_LINK(test_vector)
 
+#include "core/math/color.h"
+#include "core/math/vector2.h"
+#include "core/math/vector3.h"
+#include "core/math/vector4.h"
 #include "core/templates/vector.h"
 
 namespace TestVector {

--- a/tests/core/test_validate_testing.cpp
+++ b/tests/core/test_validate_testing.cpp
@@ -33,7 +33,25 @@
 TEST_FORCE_LINK(test_validate_testing)
 
 #include "core/core_globals.h"
+#include "core/math/aabb.h"
+#include "core/math/basis.h"
+#include "core/math/color.h"
+#include "core/math/plane.h"
+#include "core/math/projection.h"
+#include "core/math/quaternion.h"
+#include "core/math/rect2.h"
+#include "core/math/rect2i.h"
+#include "core/math/transform_2d.h"
+#include "core/math/transform_3d.h"
+#include "core/math/vector2.h"
+#include "core/math/vector2i.h"
+#include "core/math/vector3.h"
+#include "core/math/vector3i.h"
+#include "core/math/vector4.h"
+#include "core/math/vector4i.h"
 #include "core/object/object.h"
+#include "core/string/node_path.h"
+#include "core/templates/rid.h"
 #include "tests/test_tools.h"
 
 namespace TestValidateTesting {
@@ -81,6 +99,12 @@ TEST_SUITE("Validate tests") {
 		Vector3i vec3i(1, 2, 3);
 		INFO(vec3i);
 
+		Vector4 vec4(0.5, 1.0, 2.0, 3.333);
+		INFO(vec4);
+
+		Vector4i vec4i(1, 2, 3, 4);
+		INFO(vec4i);
+
 		Transform2D trans2d(0.5, Vector2(100, 100));
 		INFO(trans2d);
 
@@ -98,6 +122,9 @@ TEST_SUITE("Validate tests") {
 
 		Transform3D trans(basis);
 		INFO(trans);
+
+		Projection proj(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+		INFO(proj);
 
 		Color color(1, 0.5, 0.2, 0.3);
 		INFO(color);

--- a/tests/core/variant/test_dictionary.cpp
+++ b/tests/core/variant/test_dictionary.cpp
@@ -32,6 +32,7 @@
 
 TEST_FORCE_LINK(test_dictionary)
 
+#include "core/math/vector2.h"
 #include "core/object/ref_counted.h"
 #include "core/variant/typed_dictionary.h"
 

--- a/tests/core/variant/test_variant.cpp
+++ b/tests/core/variant/test_variant.cpp
@@ -32,6 +32,7 @@
 
 TEST_FORCE_LINK(test_variant)
 
+#include "core/math/rect2i.h"
 #include "core/variant/variant.h"
 #include "core/variant/variant_parser.h"
 

--- a/tests/core/variant/test_variant_utility.cpp
+++ b/tests/core/variant/test_variant_utility.cpp
@@ -32,6 +32,12 @@
 
 TEST_FORCE_LINK(test_variant_utility)
 
+#include "core/math/basis.h"
+#include "core/math/transform_3d.h"
+#include "core/math/vector2.h"
+#include "core/math/vector3.h"
+#include "core/math/vector3i.h"
+#include "core/math/vector4.h"
 #include "core/variant/variant_utility.h"
 
 namespace TestVariantUtility {

--- a/tests/scene/test_bit_map.cpp
+++ b/tests/scene/test_bit_map.cpp
@@ -32,6 +32,7 @@
 
 TEST_FORCE_LINK(test_bit_map)
 
+#include "core/math/rect2i.h"
 #include "scene/resources/bit_map.h"
 
 namespace TestBitMap {


### PR DESCRIPTION
- Helps address #111218

With the recent change separating variant pools to their own files, it's now more feasible than ever to start trimming away at the headers in `variant.h`. This PR tries to do exactly that, under the stipulation that `Variant` itself remain entirely unchanged. Even with that restriction, it still resulted in MANY headers being removed; most notably: every single `core/math` header. As most math headers ended up included in other headers beforehand (generally out of necessity), it turned out that `core/core_string_names.h` was the most-needed explicit include!

*However*, I'm marking this as a draft, because I'm not certain if this is the best way to go about it. At least, not yet. After digging more into what files are actually required in the binding process, it feels like much of `variant_internal.h`, `type_info.h`, `common_bindings.h`, and `class_db.h` are utilizing templates and bindings inefficently. That is: we shouldn't *need* to include headers for most of these files! I believe that most of them (all of them?) could be reworked such that the relevant logic can be assigned via forward-declares exclusively

So while I'm 100% onboard with *eventually* trimming `variant.h` headers, ideally sooner than later, it might be best to do so in a way that could be done in a single "burst". It's just how to go about that is up-in-the-air, and likely warrants a dedicated proposal. In any case, this PR serves as a good reference point for just making changes directly and as-is, so I'm bringing it up here first to serve as a clear example