### PR TITLE
Don't use invalid holding event in event listener

### DIFF
--- a/editor/settings/event_listener_line_edit.cpp
+++ b/editor/settings/event_listener_line_edit.cpp
@@ -181,7 +181,7 @@ void EventListenerLineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		accept_event();
 		return;
 	}
-	if (p_event->is_action_released(SNAME("ui_cancel"), true)) {
+	if (p_event->is_action_released(SNAME("ui_cancel"), true) && hold_event.is_valid()) {
 		event_to_check = hold_event;
 		hold_next = 0;
 		hold_event = Ref<InputEvent>();


### PR DESCRIPTION
- Fixes: https://github.com/godotengine/godot/issues/117021

## Issue Description

When we try to add event in input map setting panel, if we released `ui_cancel` using `ESC`, it maybe cause crash.

https://github.com/godotengine/godot/blob/778cf54dabd8a9e25b698a87036ab8604183f303/editor/settings/event_listener_line_edit.cpp#L184-L188

When released `ESC`, it will set back `hold_event` to `event_to_check` without null Pointer checking. When the `hold_event` is invalid, it will cause `event_to_check` crashed later.

https://github.com/godotengine/godot/blob/778cf54dabd8a9e25b698a87036ab8604183f303/editor/settings/event_listener_line_edit.cpp#L191

## Solution

So we should check whether `hold_event` is valid before setting.

After checking validation, I cannot re-produce crash on my local ubuntu environment any more.

[input-esc.webm](https://github.com/user-attachments/assets/4b6f8c7e-4036-4b20-94fa-f6611a3015c8)



