### PR TITLE
[Buildsystem] Remove "-s" flag from Emscripten when building without debug symbols

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -859,7 +859,8 @@ else:
         if methods.is_apple_clang(env):
             # Apple Clang, its linker doesn't like -s.
             env.AppendUnique(LINKFLAGS=["-Wl,-S", "-Wl,-x", "-Wl,-dead_strip"])
-        else:
+        elif not methods.using_emcc(env):
+            # Emscripten uses -s for build options, so it is excluded.
             env.AppendUnique(LINKFLAGS=["-s"])
 
     # Linker needs optimization flags too, at least for Emscripten.


### PR DESCRIPTION
As far as I found "-s" flag only applies to GCC, but if Clang worked fine before I decided to not touch it and only remove it from Emscripten. Emscripten can use "-s" flag with space to read build options, which is not something that we want here. I think release link flags went something like "-s -Os", so I guess if it meets another flag beginning with "-" it parses the next flag instead, but it shouldn't be passed to emscripten without build option in the first place.

<img width="689" height="144" alt="image" src="https://github.com/user-attachments/assets/557c3f33-72bb-40da-9cec-9b313d1d4ec7" />
