### PR TITLE
[Web] Remove passed from emscripten to clangd build options

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -6,6 +6,10 @@ Diagnostics:
   Includes:
     IgnoreHeader:
       - \.compat\.inc
+
+CompileFlags:
+  # Remove used emscripten build options and only them
+  Remove: [-sA*, -sI*, -sS*, -sM*, -sO*, -sG*, -sU*, -sD*, -sP*, -sW*, -sT*, -sE*]
 ---
 # Header-specific conditions.
 


### PR DESCRIPTION
Removed passed from emscripten build options. I specifically only targeted build options that are present in `web/detect.py` as this will be used everywhere else. Also I checked both gcc and clang and they didn't have compile flags that began with `-s` followed by a capital letter. The alternative would be to use `-s*` which is shorter, but I guess more precise is better here.