### PR TITLE
Stop drag actions in the `TileMapLayer` and `GridMap` editors when focus is lost

### DIFF
--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -3742,6 +3742,14 @@ void TileMapLayerEditor::_notification(int p_what) {
 				toggle_highlight_selected_layer_button->set_pressed_no_signal(EDITOR_GET("editors/tiles_editor/highlight_selected_layer"));
 			}
 		} break;
+
+		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
+			// Simulate mouse released event to stop drawing when editor focus exits.
+			Ref<InputEventMouseButton> release;
+			release.instantiate();
+			release->set_button_index(MouseButton::LEFT);
+			forward_canvas_gui_input(release);
+		} break;
 	}
 }
 

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1334,8 +1334,8 @@ void GridMapEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
-			if (input_action == INPUT_PAINT) {
-				// Simulate mouse released event to stop drawing when editor focus exists.
+			if (input_action == INPUT_PAINT || input_action == INPUT_ERASE || input_action == INPUT_SELECT) {
+				// Simulate mouse released event to stop drawing when editor focus exits.
 				Ref<InputEventMouseButton> release;
 				release.instantiate();
 				release->set_button_index(MouseButton::LEFT);


### PR DESCRIPTION
Similar to how it's done in other editors, when the focus is lost, stop any dragging operations.