### PR TITLE
Export: update information on apple bundle ID's

### DIFF
--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -22,7 +22,7 @@
 		</member>
 		<member name="application/bundle_identifier" type="String" setter="" getter="">
 			Unique application identifier. Case-insensitive. Can only contain alphanumeric characters ([code]A-Z[/code], [code]a-z[/code], and [code]0-9[/code]), hyphens ([code]-[/code]), and periods ([code].[/code]).
-			Apple recommends using reverse-DNS format (e.g. com.example) of a domain you own, so that your bundle ID is guaranteed to be unique. See [url=https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier]CFBundleIdentifier[/url].
+			Apple recommends using reverse-DNS format (e.g. [code]com.example.your-game[/code]) of a domain you own, so that your bundle ID is guaranteed to be unique. See [url=https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier]CFBundleIdentifier[/url].
 		</member>
 		<member name="application/code_sign_identity_debug" type="String" setter="" getter="">
 			The "Full Name", "Common Name", or SHA-1 hash of the signing identity used for debug export.

--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -21,7 +21,8 @@
 			Apple Team ID, unique 10-character string. To locate your Team ID check "Membership details" section in your Apple developer account dashboard, or "Organizational Unit" of your code signing certificate. See [url=https://developer.apple.com/help/account/manage-your-team/locate-your-team-id]Locate your Team ID[/url].
 		</member>
 		<member name="application/bundle_identifier" type="String" setter="" getter="">
-			Unique application identifier in a reverse-DNS format, can only contain alphanumeric characters ([code]A-Z[/code], [code]a-z[/code], and [code]0-9[/code]), hyphens ([code]-[/code]), and periods ([code].[/code]).
+			Unique application identifier. Case-insensitive. Can only contain alphanumeric characters ([code]A-Z[/code], [code]a-z[/code], and [code]0-9[/code]), hyphens ([code]-[/code]), and periods ([code].[/code]).
+			Apple recommends using reverse-DNS format (e.g. com.example) of a domain you own, so that your bundle ID is guaranteed to be unique. See [url=https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier]CFBundleIdentifier[/url].
 		</member>
 		<member name="application/code_sign_identity_debug" type="String" setter="" getter="">
 			The "Full Name", "Common Name", or SHA-1 hash of the signing identity used for debug export.

--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -22,7 +22,7 @@
 		</member>
 		<member name="application/bundle_identifier" type="String" setter="" getter="">
 			Unique application identifier. Case-insensitive. Can only contain alphanumeric characters ([code]A-Z[/code], [code]a-z[/code], and [code]0-9[/code]), hyphens ([code]-[/code]), and periods ([code].[/code]).
-			Apple recommends using reverse-DNS format (e.g. com.example) of a domain you own, so that your bundle ID is guaranteed to be unique. See [url=https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier]CFBundleIdentifier[/url].
+			Apple recommends using reverse-DNS format (e.g. [code]com.example.your-game[/code]) of a domain you own, so that your bundle ID is guaranteed to be unique. See [url=https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier]CFBundleIdentifier[/url].
 		</member>
 		<member name="application/copyright" type="String" setter="" getter="">
 			Copyright notice for the bundle visible to the user (in English).

--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -21,7 +21,8 @@
 			Application category for the App Store.
 		</member>
 		<member name="application/bundle_identifier" type="String" setter="" getter="">
-			Unique application identifier in a reverse-DNS format, can only contain alphanumeric characters ([code]A-Z[/code], [code]a-z[/code], and [code]0-9[/code]), hyphens ([code]-[/code]), and periods ([code].[/code]).
+			Unique application identifier. Case-insensitive. Can only contain alphanumeric characters ([code]A-Z[/code], [code]a-z[/code], and [code]0-9[/code]), hyphens ([code]-[/code]), and periods ([code].[/code]).
+			Apple recommends using reverse-DNS format (e.g. com.example) of a domain you own, so that your bundle ID is guaranteed to be unique. See [url=https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier]CFBundleIdentifier[/url].
 		</member>
 		<member name="application/copyright" type="String" setter="" getter="">
 			Copyright notice for the bundle visible to the user (in English).

--- a/platform/visionos/doc_classes/EditorExportPlatformVisionOS.xml
+++ b/platform/visionos/doc_classes/EditorExportPlatformVisionOS.xml
@@ -21,7 +21,8 @@
 			Apple Team ID, unique 10-character string. To locate your Team ID check "Membership details" section in your Apple developer account dashboard, or "Organizational Unit" of your code signing certificate. See [url=https://developer.apple.com/help/account/manage-your-team/locate-your-team-id]Locate your Team ID[/url].
 		</member>
 		<member name="application/bundle_identifier" type="String" setter="" getter="">
-			Unique application identifier in a reverse-DNS format, can only contain alphanumeric characters ([code]A-Z[/code], [code]a-z[/code], and [code]0-9[/code]), hyphens ([code]-[/code]), and periods ([code].[/code]).
+			Unique application identifier. Case-insensitive. Can only contain alphanumeric characters ([code]A-Z[/code], [code]a-z[/code], and [code]0-9[/code]), hyphens ([code]-[/code]), and periods ([code].[/code]).
+			Apple recommends using reverse-DNS format (e.g. com.example) of a domain you own, so that your bundle ID is guaranteed to be unique. See [url=https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier]CFBundleIdentifier[/url].
 		</member>
 		<member name="application/code_sign_identity_debug" type="String" setter="" getter="">
 			The "Full Name", "Common Name" or SHA-1 hash of the signing identity used for debug export.

--- a/platform/visionos/doc_classes/EditorExportPlatformVisionOS.xml
+++ b/platform/visionos/doc_classes/EditorExportPlatformVisionOS.xml
@@ -22,7 +22,7 @@
 		</member>
 		<member name="application/bundle_identifier" type="String" setter="" getter="">
 			Unique application identifier. Case-insensitive. Can only contain alphanumeric characters ([code]A-Z[/code], [code]a-z[/code], and [code]0-9[/code]), hyphens ([code]-[/code]), and periods ([code].[/code]).
-			Apple recommends using reverse-DNS format (e.g. com.example) of a domain you own, so that your bundle ID is guaranteed to be unique. See [url=https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier]CFBundleIdentifier[/url].
+			Apple recommends using reverse-DNS format (e.g. [code]com.example.your-game[/code]) of a domain you own, so that your bundle ID is guaranteed to be unique. See [url=https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier]CFBundleIdentifier[/url].
 		</member>
 		<member name="application/code_sign_identity_debug" type="String" setter="" getter="">
 			The "Full Name", "Common Name" or SHA-1 hash of the signing identity used for debug export.


### PR DESCRIPTION
I believe that the bundle ID doesn't strictly have to be in reverse-DNS format, its just a recommendation. This PR updates the class reference to reflect this, and also links to apple's wording [here](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier).

See also the corresponding issue & PR from godot-docs:
- https://github.com/godotengine/godot-docs/issues/11734
- https://github.com/godotengine/godot-docs/pull/11809

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
-->
