### PR TITLE
Fix stale texture preview in inspector

### DIFF
--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -278,8 +278,7 @@ void EditorResourcePicker::_on_preview_invalidated(const String &p_path) {
 		return;
 	}
 
-	// The in-memory resource may still hold stale image data.
-	// Explicitly reload it here so that the preview is generated from fresh data.
+	// The in-memory resource may still hold stale data. Explicitly reload it here
 	if (edited_resource->editor_can_reload_from_file()) {
 		edited_resource->reload_from_file();
 	}

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -273,6 +273,19 @@ void EditorResourcePicker::_resource_saved(Object *p_resource) {
 	}
 }
 
+void EditorResourcePicker::_on_preview_invalidated(const String &p_path) {
+	if (!preview_rect || edited_resource.is_null() || edited_resource->get_path() != p_path) {
+		return;
+	}
+
+	// The in-memory resource may still hold stale image data.
+	// Explicitly reload it here so that the preview is generated from fresh data.
+	if (edited_resource->editor_can_reload_from_file()) {
+		edited_resource->reload_from_file();
+	}
+	_update_resource();
+}
+
 void EditorResourcePicker::_update_menu() {
 	if (edit_menu && edit_menu->is_visible()) {
 		edit_button->set_pressed(false);
@@ -1048,6 +1061,7 @@ void EditorResourcePicker::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			EditorNode::get_singleton()->connect("resource_counter_changed", callable_mp(this, &EditorResourcePicker::_update_resource));
+			EditorResourcePreview::get_singleton()->connect("preview_invalidated", callable_mp(this, &EditorResourcePicker::_on_preview_invalidated));
 			_update_resource();
 			[[fallthrough]];
 		}
@@ -1088,11 +1102,15 @@ void EditorResourcePicker::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			Callable resource_saved = callable_mp(this, &EditorResourcePicker::_resource_saved);
 			Callable resource_counter_changed = callable_mp(this, &EditorResourcePicker::_update_resource);
+			Callable preview_invalidated = callable_mp(this, &EditorResourcePicker::_on_preview_invalidated);
 			if (EditorNode::get_singleton()->is_connected("resource_saved", resource_saved)) {
 				EditorNode::get_singleton()->disconnect("resource_saved", resource_saved);
 			}
 			if (EditorNode::get_singleton()->is_connected("resource_counter_changed", resource_counter_changed)) {
 				EditorNode::get_singleton()->disconnect("resource_counter_changed", resource_counter_changed);
+			}
+			if (EditorResourcePreview::get_singleton()->is_connected("preview_invalidated", preview_invalidated)) {
+				EditorResourcePreview::get_singleton()->disconnect("preview_invalidated", preview_invalidated);
 			}
 		} break;
 	}

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -273,7 +273,7 @@ void EditorResourcePicker::_resource_saved(Object *p_resource) {
 	}
 }
 
-void EditorResourcePicker::_on_preview_invalidated(const String &p_path) {
+void EditorResourcePicker::_preview_invalidated(const String &p_path) {
 	if (!preview_rect || edited_resource.is_null() || edited_resource->get_path() != p_path) {
 		return;
 	}
@@ -1060,7 +1060,7 @@ void EditorResourcePicker::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			EditorNode::get_singleton()->connect("resource_counter_changed", callable_mp(this, &EditorResourcePicker::_update_resource));
-			EditorResourcePreview::get_singleton()->connect("preview_invalidated", callable_mp(this, &EditorResourcePicker::_on_preview_invalidated));
+			EditorResourcePreview::get_singleton()->connect("preview_invalidated", callable_mp(this, &EditorResourcePicker::_preview_invalidated));
 			_update_resource();
 			[[fallthrough]];
 		}
@@ -1101,7 +1101,7 @@ void EditorResourcePicker::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			Callable resource_saved = callable_mp(this, &EditorResourcePicker::_resource_saved);
 			Callable resource_counter_changed = callable_mp(this, &EditorResourcePicker::_update_resource);
-			Callable preview_invalidated = callable_mp(this, &EditorResourcePicker::_on_preview_invalidated);
+			Callable preview_invalidated = callable_mp(this, &EditorResourcePicker::_preview_invalidated);
 			if (EditorNode::get_singleton()->is_connected("resource_saved", resource_saved)) {
 				EditorNode::get_singleton()->disconnect("resource_saved", resource_saved);
 			}

--- a/editor/inspector/editor_resource_picker.h
+++ b/editor/inspector/editor_resource_picker.h
@@ -97,6 +97,7 @@ class EditorResourcePicker : public HBoxContainer {
 	void _file_selected(const String &p_path);
 
 	void _resource_saved(Object *p_resource);
+	void _on_preview_invalidated(const String &p_path);
 
 	void _update_menu();
 	void _update_menu_items();

--- a/editor/inspector/editor_resource_picker.h
+++ b/editor/inspector/editor_resource_picker.h
@@ -97,7 +97,7 @@ class EditorResourcePicker : public HBoxContainer {
 	void _file_selected(const String &p_path);
 
 	void _resource_saved(Object *p_resource);
-	void _on_preview_invalidated(const String &p_path);
+	void _preview_invalidated(const String &p_path);
 
 	void _update_menu();
 	void _update_menu_items();

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -566,13 +566,12 @@ void EditorResourcePreview::check_for_invalidation(const String &p_path) {
 			if (modified_time != cache[p_path].modified_time) {
 				cache.erase(p_path);
 				call_invalidated = true;
+				// Evict the ID-based cache entry for the in-memory resource at p_path, if one exists.
+				Ref<Resource> cached_res = ResourceCache::get_ref(p_path);
+				if (cached_res.is_valid()) {
+					cache.erase("ID:" + itos(cached_res->get_instance_id()));
+				}
 			}
-		}
-
-		// Evict the ID-based cache entry for the in-memory resource at p_path, if one exists.
-		Ref<Resource> cached_res = ResourceCache::get_ref(p_path);
-		if (cached_res.is_valid()) {
-			cache.erase("ID:" + itos(cached_res->get_instance_id()));
 		}
 	}
 

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -568,6 +568,12 @@ void EditorResourcePreview::check_for_invalidation(const String &p_path) {
 				call_invalidated = true;
 			}
 		}
+
+		// Evict the ID-based cache entry for the in-memory resource at p_path, if one exists.
+		Ref<Resource> cached_res = ResourceCache::get_ref(p_path);
+		if (cached_res.is_valid()) {
+			cache.erase("ID:" + itos(cached_res->get_instance_id()));
+		}
 	}
 
 	if (call_invalidated) { //do outside mutex


### PR DESCRIPTION
## Motivation
Fixes: https://github.com/godotengine/godot/issues/117048

In a project I'm working on, I have a custom resource which contains a Texture2D. When replacing one of the textures on disk and allowing Godot to reimport it, the preview thumbnail shown in the EditorResourcePicker continued displaying the old image. The only way to have the preview reflect the new image was to close the scene and reopen.

https://github.com/user-attachments/assets/a167bd6c-5baf-4c0b-bcb4-20023c013ed0

## Background:
EditorResourcePreview maintains an in-memory cache of generated preview thumbnails. It uses two kinds of keys: path-based (ex: `res://rock.png`) and instance-ID-based (ex: `ID:123`).

Path entries are requested via [queue_resource_preview](https://github.com/godotengine/godot/blob/master/editor/inspector/editor_resource_preview.cpp#L502) and are used by things like the filesystem dock. ID-based entries are requested via [queue_edited_resource_preview](https://github.com/godotengine/godot/blob/master/editor/inspector/editor_resource_preview.cpp#L469) and are used by EditorResourcePicker in the inspector. For ID-based lookups, the cache is considered valid as long as [hash_edited_version_for_preview()](https://github.com/godotengine/godot/blob/master/core/io/resource.cpp#L632) matches the stored hash. 

Entries are invalidated via check_for_invalidation, which compares the file's current modification time against the cached value and erases the entry if they differ.

## Changes
### editor/inspector/editor_resource_preview.cpp
- check_for_invalidation now evicts the ID-based preview cache entry for the affected resource in addition to the path-based one.

### editor/inspector/editor_resource_picker.cpp
- EditorResourcePicker now listens to the preview_invalidated signal, reloads the in-memory resource via reload_from_file(), and re-requests the preview 

## Testing
Manually tested, see video:

https://github.com/user-attachments/assets/7baf450e-4410-4e6a-970c-aeb5c0b1c2b0


