### PR TITLE
Fix compile errors when 3D Navigation or 3D Physics are disabled.

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -413,7 +413,6 @@ void GridMap::set_cell_item(const Vector3i &p_position, int p_item, int p_rot) {
 			PhysicsServer3D::get_singleton()->body_set_param(g->static_body, PhysicsServer3D::BODY_PARAM_FRICTION, physics_material->computed_friction());
 			PhysicsServer3D::get_singleton()->body_set_param(g->static_body, PhysicsServer3D::BODY_PARAM_BOUNCE, physics_material->computed_bounce());
 		}
-#endif // PHYSICS_3D_DISABLED
 		bool debug_collisions = false;
 		switch (collision_visibility_mode) {
 			case DEBUG_VISIBILITY_MODE_DEFAULT: {
@@ -432,6 +431,7 @@ void GridMap::set_cell_item(const Vector3i &p_position, int p_item, int p_rot) {
 			g->collision_debug_instance = RS::get_singleton()->instance_create();
 			RS::get_singleton()->instance_set_base(g->collision_debug_instance, g->collision_debug);
 		}
+#endif // PHYSICS_3D_DISABLED
 
 		octant_map[octantkey] = g;
 

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -34,6 +34,7 @@
 #include "core/object/class_db.h"
 #include "scene/3d/skeleton_3d.h"
 #include "scene/main/scene_tree.h"
+#include "servers/rendering/rendering_server.h"
 
 #ifndef PHYSICS_3D_DISABLED
 #include "scene/3d/physics/collision_shape_3d.h"
@@ -46,7 +47,6 @@
 #include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h"
 #include "scene/resources/navigation_mesh.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
-#include "servers/rendering/rendering_server.h"
 
 Callable MeshInstance3D::_navmesh_source_geometry_parsing_callback;
 RID MeshInstance3D::_navmesh_source_geometry_parser;


### PR DESCRIPTION
This is the third time in a row this has happened in a dev release, so it might be worth considering adding a builder that has 2D/3D navigation/physics disabled.