### PR TITLE
Explicitly include `os.h` and `engine.h` where used

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -48,6 +48,7 @@
 #include "core/version.h"
 
 #ifdef TOOLS_ENABLED
+#include "core/config/engine.h"
 #include "modules/modules_enabled.gen.h" // For mono.
 #endif // TOOLS_ENABLED
 

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -41,6 +41,7 @@
 #include "core/object/class_db.h"
 #include "core/object/message_queue.h"
 #include "core/object/script_language.h"
+#include "core/os/os.h"
 #include "core/templates/rb_set.h"
 #include "core/variant/typed_array.h"
 #include "core/variant/variant_parser.h"

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -42,6 +42,7 @@
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #include "core/os/thread_safe.h"
 #include "core/variant/typed_array.h"
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -31,6 +31,7 @@
 #include "core_bind.h"
 #include "core_bind.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
 #include "core/debugger/engine_debugger.h"

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -30,6 +30,7 @@
 
 #include "remote_debugger.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/engine_debugger.h"

--- a/core/extension/gdextension_library_loader.cpp
+++ b/core/extension/gdextension_library_loader.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/os/os.h"
 #include "core/version.h"
 #include "gdextension.h"
 

--- a/core/extension/gdextension_library_loader.cpp
+++ b/core/extension/gdextension_library_loader.cpp
@@ -30,6 +30,7 @@
 
 #include "gdextension_library_loader.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/os/os.h"

--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -30,6 +30,7 @@
 
 #include "gdextension_manager.h"
 
+#include "core/config/engine.h"
 #include "core/extension/gdextension_function_loader.h"
 #include "core/extension/gdextension_library_loader.h"
 #include "core/extension/gdextension_special_compat_hashes.h"

--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -37,6 +37,7 @@
 #include "core/io/file_access.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
+#include "core/os/os.h"
 
 GDExtensionManager::LoadStatus GDExtensionManager::_load_extension_internal(const Ref<GDExtension> &p_extension, bool p_first_load) {
 	if (level >= 0) { // Already initialized up to some level.

--- a/core/extension/godot_instance.cpp
+++ b/core/extension/godot_instance.cpp
@@ -33,6 +33,7 @@
 #include "core/extension/gdextension_manager.h"
 #include "core/object/class_db.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #include "main/main.h"
 #include "servers/display/display_server.h"
 

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -31,6 +31,7 @@
 #include "input.h"
 #include "input.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/input/default_controller_mappings.h"
 #include "core/input/input_map.h"

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -34,6 +34,7 @@
 
 #include "core/io/stream_peer_tls.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/version.h"
 
 HTTPClient *HTTPClientTCP::_create_func(bool p_notify_postinitialize) {

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -30,6 +30,7 @@
 
 #include "resource_loader.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/core_bind.h"
 #include "core/io/dir_access.h"

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -30,6 +30,7 @@
 
 #include "object.h"
 
+#include "core/config/engine.h"
 #include "core/extension/gdextension_manager.h"
 #include "core/io/resource.h"
 #include "core/object/class_db.h"

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -30,6 +30,7 @@
 
 #include "script_language.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/core_bind.h"
 #include "core/debugger/engine_debugger.h"

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -36,6 +36,7 @@
 #include "core/debugger/script_debugger.h"
 #include "core/io/resource_loader.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/templates/sort_array.h"
 
 ScriptLanguage *ScriptServer::_languages[MAX_LANGUAGES];

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -35,6 +35,7 @@
 #include "core/io/file_access.h"
 #include "core/io/json.h"
 #include "core/os/midi_driver.h"
+#include "core/os/os.h"
 #include "core/version_generated.gen.h"
 
 #include <cstdarg>

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -77,6 +77,7 @@
 #include "core/object/undo_redo.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #include "core/os/time.h"
 #include "core/string/optimized_translation.h"
 #include "core/string/translation.h"

--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -31,6 +31,7 @@
 #include "translation_server.h"
 #include "translation_server.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
 #include "core/object/class_db.h"

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -32,6 +32,7 @@
 
 #ifdef ALSA_ENABLED
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -32,6 +32,7 @@
 
 #ifdef GLES3_ENABLED
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/math/geometry_2d.h"
 #include "core/math/transform_interpolator.h"

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -32,6 +32,7 @@
 
 #ifdef GLES3_ENABLED
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/image.h"

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -32,6 +32,7 @@
 
 #ifdef GLES3_ENABLED
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
 #include "drivers/gles3/rasterizer_canvas_gles3.h"

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -54,6 +54,7 @@
 #include "rendering_context_driver_metal.h"
 #include "rendering_shader_container_metal.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/marshalls.h"
 #include "core/os/os.h"

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -32,6 +32,7 @@
 
 #ifdef PULSEAUDIO_ENABLED
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 #include "core/version.h"

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -32,6 +32,7 @@
 
 #include "audio_driver_wasapi.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -30,6 +30,7 @@
 
 #include "audio_driver_xaudio2.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -34,6 +34,7 @@
 #include "core/input/input.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
+#include "core/os/os.h"
 #include "editor/animation/animation_tree_editor_plugin.h"
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/docks/inspector_dock.h"

--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "asset_library_editor_plugin.h"
 
+#include "core/config/engine.h"
 #include "core/io/dir_access.h"
 #include "core/io/json.h"
 #include "core/io/stream_peer_tls.h"

--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -35,6 +35,7 @@
 #include "core/io/stream_peer_tls.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
+#include "core/os/os.h"
 #include "core/version.h"
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"

--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -31,6 +31,7 @@
 #include "debug_adapter_parser.h"
 
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "editor/debugger/debug_adapter/debug_adapter_protocol.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -34,6 +34,7 @@
 #include "core/debugger/debugger_marshalls.h"
 #include "core/io/json.h"
 #include "core/io/marshalls.h"
+#include "core/os/os.h"
 #include "editor/debugger/debug_adapter/debug_adapter_parser.h"
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/editor_log.h"

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_debugger_node.h"
 
+#include "core/config/engine.h"
 #include "core/io/resource_loader.h"
 #include "core/object/class_db.h"
 #include "core/object/undo_redo.h"

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -38,6 +38,7 @@
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "core/os/keyboard.h"
+#include "core/os/os.h"
 #include "core/string/string_builder.h"
 #include "core/version.h"
 #include "editor/doc/doc_data_compressed.gen.h"

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_help.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/core_constants.h"
 #include "core/extension/gdextension.h"

--- a/editor/doc/editor_help_search.cpp
+++ b/editor/doc/editor_help_search.cpp
@@ -31,6 +31,7 @@
 #include "editor_help_search.h"
 
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -31,6 +31,7 @@
 #include "editor_interface.h"
 #include "editor_interface.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
 #include "core/object/class_db.h"

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -33,6 +33,7 @@
 #include "core/io/resource_loader.h"
 #include "core/object/undo_redo.h"
 #include "core/os/keyboard.h"
+#include "core/os/os.h"
 #include "core/version.h"
 #include "editor/docks/editor_dock.h"
 #include "editor/docks/inspector_dock.h"

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_node.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/extension/gdextension_manager.h"
 #include "core/input/input.h"

--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/os/os.h"
 #include "core/os/shared_object.h"
 #include "scene/resources/image_texture.h"
 

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -34,6 +34,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "editor/export/editor_export.h"
 #include "editor/settings/editor_settings.h"
 

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -33,6 +33,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/json.h"
 #include "core/io/zip_io.h"
+#include "core/os/os.h"
 #include "core/templates/rb_set.h"
 #include "core/version.h"
 #include "editor/editor_node.h"

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/version.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/export/shader_baker_export_plugin.cpp
+++ b/editor/export/shader_baker_export_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "shader_baker_export_plugin.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/string/string_builder.h"

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -34,6 +34,7 @@
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/file_system/editor_file_system.h"

--- a/editor/gui/editor_about.cpp
+++ b/editor/gui/editor_about.cpp
@@ -33,6 +33,7 @@
 #include "core/authors.gen.h"
 #include "core/donors.gen.h"
 #include "core/license.gen.h"
+#include "core/os/os.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/credits_roll.h"

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/editor_string_names.h"
 #include "editor/file_system/dependency_editor.h"

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/string/fuzzy_search.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/editor_node.h"

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -33,6 +33,7 @@
 #include "unicode_ranges.inc"
 
 #include "core/config/project_settings.h"
+#include "core/os/os.h"
 #include "core/string/translation.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/import/fbx_importer_manager.cpp
+++ b/editor/import/fbx_importer_manager.cpp
@@ -31,6 +31,7 @@
 #include "fbx_importer_manager.h"
 
 #include "core/config/project_settings.h"
+#include "core/os/os.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/settings/editor_settings.h"

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -32,6 +32,7 @@
 
 #include "core/input/input.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "editor/audio/audio_stream_preview.h"
 #include "editor/doc/editor_help.h"
 #include "editor/docks/filesystem_dock.h"

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -35,6 +35,7 @@
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/variant/variant_utility.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/plugins/editor_plugin_settings.cpp
+++ b/editor/plugins/editor_plugin_settings.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_plugin_settings.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/config_file.h"
 #include "core/io/dir_access.h"

--- a/editor/project_manager/engine_update_label.cpp
+++ b/editor/project_manager/engine_update_label.cpp
@@ -32,6 +32,7 @@
 
 #include "core/io/json.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/version.h"
 #include "editor/editor_string_names.h"
 #include "editor/settings/editor_settings.h"

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -34,6 +34,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/zip_io.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/version.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -30,6 +30,7 @@
 
 #include "project_manager.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/io/config_file.h"

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -31,6 +31,7 @@
 #include "register_editor_types.h"
 
 #include "core/object/script_language.h"
+#include "core/os/os.h"
 #include "editor/animation/animation_tree_editor_plugin.h"
 #include "editor/audio/audio_stream_editor_plugin.h"
 #include "editor/audio/audio_stream_randomizer_editor_plugin.h"

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -30,6 +30,7 @@
 
 #include "register_editor_types.h"
 
+#include "core/config/engine.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"
 #include "editor/animation/animation_tree_editor_plugin.h"

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_run_bar.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
 #include "editor/debugger/editor_debugger_node.h"

--- a/editor/scene/2d/particles_2d_editor_plugin.cpp
+++ b/editor/scene/2d/particles_2d_editor_plugin.cpp
@@ -31,6 +31,7 @@
 #include "particles_2d_editor_plugin.h"
 
 #include "core/io/image_loader.h"
+#include "core/os/os.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"

--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -33,6 +33,7 @@
 #include "core/input/input_event.h"
 #include "core/math/geometry_2d.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "editor/docks/editor_dock.h"
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_node.h"

--- a/editor/scene/2d/tiles/tiles_editor_plugin.cpp
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.cpp
@@ -33,7 +33,7 @@
 #include "tile_set_editor.h"
 
 #include "core/os/mutex.h"
-
+#include "core/os/os.h"
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_interface.h"
 #include "editor/editor_node.h"

--- a/editor/scene/3d/lightmap_gi_editor_plugin.cpp
+++ b/editor/scene/3d/lightmap_gi_editor_plugin.cpp
@@ -31,6 +31,7 @@
 #include "lightmap_gi_editor_plugin.h"
 
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_file_dialog.h"

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -38,6 +38,7 @@
 #include "core/math/projection.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
+#include "core/os/os.h"
 #include "core/string/translation_server.h"
 #include "editor/animation/animation_player_editor_plugin.h"
 #include "editor/debugger/editor_debugger_node.h"

--- a/editor/scene/3d/particles_3d_editor_plugin.cpp
+++ b/editor/scene/3d/particles_3d_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "particles_3d_editor_plugin.h"
 
+#include "core/os/os.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/scene/scene_tree_editor.h"

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "canvas_item_editor_plugin.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/object/class_db.h"

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"

--- a/editor/scene/gui/font_config_plugin.cpp
+++ b/editor/scene/gui/font_config_plugin.cpp
@@ -31,6 +31,7 @@
 #include "font_config_plugin.h"
 
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/string/translation_server.h"
 #include "editor/import/dynamic_font_import_settings.h"
 #include "editor/settings/editor_settings.h"

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -30,6 +30,7 @@
 
 #include "scene_tree_editor.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"

--- a/editor/settings/editor_command_palette.cpp
+++ b/editor/settings/editor_command_palette.cpp
@@ -32,6 +32,7 @@
 
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
+#include "core/os/os.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_toaster.h"

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_settings.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/input/input_event.h"
 #include "core/input/input_map.h"

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_settings_dialog.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/input/input_map.h"
 #include "core/object/class_db.h"

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/version_generated.gen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -36,6 +36,7 @@
 #include "core/math/math_defs.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
+#include "core/os/os.h"
 #include "core/version_generated.gen.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/docks/inspector_dock.h"

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -32,6 +32,7 @@
 
 #include "core/error/error_macros.h"
 #include "core/io/resource_loader.h"
+#include "core/os/os.h"
 #include "editor/editor_string_names.h"
 #include "editor/file_system/editor_paths.h"
 #include "editor/settings/editor_settings.h"

--- a/editor/version_control/version_control_editor_plugin.cpp
+++ b/editor/version_control/version_control_editor_plugin.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
+#include "core/os/os.h"
 #include "core/os/time.h"
 #include "editor/docks/editor_dock.h"
 #include "editor/docks/editor_dock_manager.h"

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -30,6 +30,7 @@
 
 #include "main.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/core_globals.h"
 #include "core/crypto/crypto.h"

--- a/main/performance.cpp
+++ b/main/performance.cpp
@@ -31,6 +31,7 @@
 #include "performance.h"
 #include "performance.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/variant/typed_array.h"

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -39,6 +39,7 @@
 #include "rgb_to_rgba.glsl.gen.h"
 
 #include "core/config/project_settings.h"
+#include "core/os/os.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_context_driver.h"
 #include "servers/rendering/rendering_device.h"

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -30,6 +30,7 @@
 
 #include "csg_shape.h"
 
+#include "core/config/engine.h"
 #include "core/math/geometry_2d.h"
 #include "core/object/class_db.h"
 #include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h"

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
@@ -31,6 +31,7 @@
 #include "editor_scene_importer_fbx2gltf.h"
 
 #include "core/config/project_settings.h"
+#include "core/os/os.h"
 #include "editor/settings/editor_settings.h"
 #include "editor_scene_importer_ufbx.h"
 

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -30,6 +30,7 @@
 
 #include "fbx_document.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
 #include "core/io/config_file.h"

--- a/modules/fbx/register_types.cpp
+++ b/modules/fbx/register_types.cpp
@@ -33,6 +33,8 @@
 #include "../gltf/extensions/gltf_document_extension_convert_importer_mesh.h"
 #include "fbx_document.h"
 
+#include "core/config/engine.h"
+
 #ifdef TOOLS_ENABLED
 #include "editor/editor_scene_importer_fbx2gltf.h"
 #include "editor/editor_scene_importer_ufbx.h"

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "editor/doc/doc_tools.h"
 #include "editor/doc/editor_help.h"
 #include "editor/editor_log.h"

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -35,6 +35,7 @@
 #include "editor_import_blend_runner.h"
 
 #include "core/config/project_settings.h"
+#include "core/os/os.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_file_dialog.h"

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -30,13 +30,13 @@
 
 #include "gltf_document.h"
 
-#include "core/object/class_db.h"
 #include "extensions/gltf_document_extension_convert_importer_mesh.h"
 #include "extensions/gltf_spec_gloss.h"
 #include "gltf_state.h"
 #include "gltf_template_convert.h"
 #include "skin_tool.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
 #include "core/io/config_file.h"
@@ -45,6 +45,7 @@
 #include "core/io/file_access_memory.h"
 #include "core/io/json.h"
 #include "core/io/stream_peer.h"
+#include "core/object/class_db.h"
 #include "core/object/object_id.h"
 #include "core/version.h"
 #include "scene/2d/node_2d.h"

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -38,6 +38,8 @@
 #include "gltf_state.h"
 #include "structures/gltf_object_model_property.h"
 
+#include "core/config/engine.h"
+
 #ifndef PHYSICS_3D_DISABLED
 #include "extensions/physics/gltf_document_extension_physics.h"
 #endif // PHYSICS_3D_DISABLED

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -30,6 +30,7 @@
 
 #include "grid_map.h"
 
+#include "core/config/engine.h"
 #include "core/io/marshalls.h"
 #include "core/object/class_db.h"
 #include "core/templates/a_hash_map.h"

--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -30,6 +30,7 @@
 
 #include "audio_stream_interactive.h"
 
+#include "core/config/engine.h"
 #include "core/math/math_funcs.h"
 #include "core/object/class_db.h"
 

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -30,7 +30,6 @@
 
 #include "lightmapper_rd.h"
 
-#include "core/string/print_string.h"
 #include "lm_blendseams.glsl.gen.h"
 #include "lm_compute.glsl.gen.h"
 #include "lm_raster.glsl.gen.h"
@@ -39,6 +38,8 @@
 #include "core/io/dir_access.h"
 #include "core/math/geometry_2d.h"
 #include "core/math/geometry_3d.h"
+#include "core/os/os.h"
+#include "core/string/print_string.h"
 #include "editor/file_system/editor_paths.h"
 #include "editor/settings/editor_settings.h"
 #include "servers/rendering/rendering_device.h"

--- a/modules/mbedtls/register_types.cpp
+++ b/modules/mbedtls/register_types.cpp
@@ -36,6 +36,7 @@
 #include "stream_peer_mbedtls.h"
 
 #include "core/config/project_settings.h"
+#include "core/os/os.h"
 
 #if MBEDTLS_VERSION_MAJOR >= 3
 #include <psa/crypto.h>

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -30,7 +30,6 @@
 
 #include "csharp_script.h"
 
-#include "core/object/class_db.h"
 #include "godotsharp_dirs.h"
 #include "managed_callable.h"
 #include "mono_gd/gd_mono_cache.h"
@@ -49,10 +48,12 @@
 #include "editor/script_templates/templates.gen.h"
 #endif
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
 #include "core/io/file_access.h"
+#include "core/object/class_db.h"
 #include "core/os/mutex.h"
 #include "core/os/os.h"
 #include "core/os/thread.h"

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -33,6 +33,7 @@
 #include "mono_gd/gd_mono.h"
 #include "utils/path_utils.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/os/os.h"

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -47,6 +47,7 @@
 #include "../editor/semver.h"
 #endif
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/io/dir_access.h"

--- a/modules/multiplayer/multiplayer_spawner.cpp
+++ b/modules/multiplayer/multiplayer_spawner.cpp
@@ -30,6 +30,7 @@
 
 #include "multiplayer_spawner.h"
 
+#include "core/config/engine.h"
 #include "core/io/resource_loader.h"
 #include "core/object/class_db.h"
 #include "scene/main/multiplayer_api.h"

--- a/modules/navigation_2d/nav_map_2d.cpp
+++ b/modules/navigation_2d/nav_map_2d.cpp
@@ -40,6 +40,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/worker_thread_pool.h"
+#include "core/os/os.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
 
 #include <Obstacle2d.h>

--- a/modules/navigation_3d/nav_map_3d.cpp
+++ b/modules/navigation_3d/nav_map_3d.cpp
@@ -40,6 +40,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/worker_thread_pool.h"
+#include "core/os/os.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
 
 #include <Obstacle2d.h>

--- a/modules/objectdb_profiler/editor/objectdb_profiler_panel.cpp
+++ b/modules/objectdb_profiler/editor/objectdb_profiler_panel.cpp
@@ -38,6 +38,7 @@
 #include "data_viewers/summary_view.h"
 
 #include "core/config/project_settings.h"
+#include "core/os/os.h"
 #include "core/os/time.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"

--- a/modules/openxr/extensions/platform/openxr_android_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_android_extension.cpp
@@ -36,6 +36,8 @@
 #include "os_android.h"
 #include "thread_jandroid.h"
 
+#include "core/os/os.h"
+
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>
 

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -35,6 +35,7 @@
 #include "extensions/openxr_performance_settings_extension.h"
 #include "extensions/openxr_user_presence_extension.h"
 
+#include "core/config/engine.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/object/class_db.h"

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -100,6 +100,7 @@
 #endif
 
 #include "core/config/project_settings.h"
+#include "core/os/os.h"
 #include "main/main.h"
 
 #ifdef TOOLS_ENABLED

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -99,6 +99,7 @@
 #include "extensions/platform/openxr_android_extension.h"
 #endif
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 #include "main/main.h"

--- a/modules/openxr/scene/openxr_composition_layer.cpp
+++ b/modules/openxr/scene/openxr_composition_layer.cpp
@@ -34,6 +34,7 @@
 #include "../openxr_api.h"
 #include "../openxr_interface.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/xr/xr_nodes.h"

--- a/modules/openxr/scene/openxr_render_model_manager.cpp
+++ b/modules/openxr/scene/openxr_render_model_manager.cpp
@@ -34,6 +34,7 @@
 #include "../extensions/openxr_render_model_extension.h"
 #include "../openxr_api.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
 #include "scene/3d/xr/xr_nodes.h"

--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/math/projection.h"
 #include "core/object/worker_thread_pool.h"
+#include "core/os/os.h"
 
 #ifdef __SSE2__
 #include <pmmintrin.h>

--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -30,6 +30,7 @@
 
 #include "raycast_occlusion_cull.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/math/projection.h"
 #include "core/object/worker_thread_pool.h"

--- a/modules/svg/register_types.cpp
+++ b/modules/svg/register_types.cpp
@@ -32,6 +32,8 @@
 
 #include "image_loader_svg.h"
 
+#include "core/config/engine.h"
+
 #include <thorvg.h>
 
 #ifdef THREADS_ENABLED

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -30,8 +30,6 @@
 
 #include "text_server_adv.h"
 
-#include "core/object/callable_method_pointer.h"
-
 #ifdef GDEXTENSION
 // Headers for building as GDExtension plug-in.
 
@@ -40,6 +38,7 @@
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/translation_server.hpp>
 #include <godot_cpp/core/error_macros.hpp>
+#include <godot_cpp/variant/callable_method_pointer.hpp>
 
 using namespace godot;
 
@@ -51,7 +50,9 @@ using namespace godot;
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
 #include "core/io/file_access.h"
+#include "core/object/callable_method_pointer.h"
 #include "core/object/worker_thread_pool.h"
+#include "core/os/os.h"
 #include "core/string/translation_server.h"
 #include "scene/resources/image_texture.h"
 

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -30,8 +30,6 @@
 
 #include "text_server_fb.h"
 
-#include "core/object/callable_method_pointer.h"
-
 #ifdef GDEXTENSION
 // Headers for building as GDExtension plug-in.
 
@@ -40,6 +38,7 @@
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/translation_server.hpp>
 #include <godot_cpp/core/error_macros.hpp>
+#include <godot_cpp/variant/callable_method_pointer.hpp>
 
 #define OT_TAG(m_c1, m_c2, m_c3, m_c4) ((int32_t)((((uint32_t)(m_c1) & 0xff) << 24) | (((uint32_t)(m_c2) & 0xff) << 16) | (((uint32_t)(m_c3) & 0xff) << 8) | ((uint32_t)(m_c4) & 0xff)))
 
@@ -53,6 +52,8 @@ using namespace godot;
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
 #include "core/io/file_access.h"
+#include "core/object/callable_method_pointer.h"
+#include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/string/translation_server.h"
 

--- a/modules/websocket/editor/editor_debugger_server_websocket.cpp
+++ b/modules/websocket/editor/editor_debugger_server_websocket.cpp
@@ -32,6 +32,7 @@
 
 #include "../remote_debugger_peer_websocket.h"
 
+#include "core/os/os.h"
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/settings/editor_settings.h"

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -33,6 +33,7 @@
 #ifndef WEB_ENABLED
 
 #include "core/io/stream_peer_tls.h"
+#include "core/os/os.h"
 
 CryptoCore::RandomGenerator *WSLPeer::_static_rng = nullptr;
 

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -30,6 +30,8 @@
 
 #include "audio_driver_opensl.h"
 
+#include "core/os/os.h"
+
 #define MAX_NUMBER_INTERFACES 3
 #define MAX_NUMBER_OUTPUT_DEVICES 6
 

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -38,6 +38,7 @@
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/input/input_event.h"
+#include "core/os/os.h"
 #include "servers/display/native_menu.h"
 
 #if defined(RD_ENABLED)

--- a/platform/android/editor/editor_utils_jni.cpp
+++ b/platform/android/editor/editor_utils_jni.cpp
@@ -33,6 +33,7 @@
 #include "jni_utils.h"
 
 #ifdef TOOLS_ENABLED
+#include "core/os/os.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/run/editor_run_bar.h"

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -49,6 +49,7 @@
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #include "core/profiling/profiling.h"
 #include "main/main.h"
 #include "servers/rendering/rendering_server.h"

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -43,6 +43,7 @@
 #include "core/input/input.h"
 #include "core/io/xml_parser.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #include "core/profiling/profiling.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -38,6 +38,7 @@
 #include "java_godot_wrapper.h"
 #include "net_socket_android.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/extension/gdextension_manager.h"
 #include "core/input/input.h"

--- a/platform/android/tts_android.cpp
+++ b/platform/android/tts_android.cpp
@@ -34,6 +34,7 @@
 #include "os_android.h"
 #include "thread_jandroid.h"
 
+#include "core/os/os.h"
 #include "servers/display/display_server.h"
 
 bool TTS_Android::initialized = false;

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -35,6 +35,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/os/os.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/export/editor_export.h"

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -34,13 +34,15 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/os/main_loop.h"
-#ifdef SDL_ENABLED
-#include "drivers/sdl/joypad_sdl.h"
-#endif
+#include "core/os/os.h"
 #include "core/profiling/profiling.h"
 #include "main/main.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
+
+#ifdef SDL_ENABLED
+#include "drivers/sdl/joypad_sdl.h"
+#endif
 
 #ifdef X11_ENABLED
 #include "x11/detect_prime_x11.h"

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -43,6 +43,7 @@
 #include "core/input/input.h"
 #include "core/input/input_event.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #include "servers/display/accessibility_server.h"
 #include "servers/display/native_menu.h"
 #include "servers/rendering/dummy/rasterizer_dummy.h"

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -40,6 +40,7 @@
 #include "core/math/math_funcs.h"
 #include "core/object/callable_method_pointer.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/string/ustring.h"
 #include "drivers/png/png_driver_common.h"

--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -32,6 +32,7 @@
 
 #include "godot_audio.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/object/object.h"
 #include "scene/main/node.h"

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -39,6 +39,7 @@
 #include "core/input/input_event.h"
 #include "core/object/callable_method_pointer.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #include "servers/display/native_menu.h"
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 

--- a/platform/web/export/editor_http_server.cpp
+++ b/platform/web/export/editor_http_server.cpp
@@ -30,6 +30,8 @@
 
 #include "editor_http_server.h"
 
+#include "core/os/os.h"
+
 void EditorHTTPServer::_server_thread_poll(void *data) {
 	EditorHTTPServer *web_server = static_cast<EditorHTTPServer *>(data);
 	while (!web_server->server_quit.is_set()) {

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -35,6 +35,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/os/os.h"
 #include "editor/editor_string_names.h"
 #include "editor/export/editor_export.h"
 #include "editor/import/resource_importer_texture_settings.h"

--- a/platform/web/http_client_web.cpp
+++ b/platform/web/http_client_web.cpp
@@ -30,6 +30,7 @@
 
 #include "http_client_web.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 
 void HTTPClientWeb::_parse_headers(int p_len, const char **p_headers, void *p_ref) {

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -40,6 +40,7 @@
 #include "core/debugger/engine_debugger.h"
 #include "core/io/file_access.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #include "core/profiling/profiling.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"

--- a/platform/web/web_main.cpp
+++ b/platform/web/web_main.cpp
@@ -35,6 +35,7 @@
 #include "core/config/engine.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
+#include "core/os/os.h"
 #include "core/profiling/profiling.h"
 #include "main/main.h"
 #include "scene/main/scene_tree.h"

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -35,6 +35,7 @@
 #include "os_windows.h"
 #include "wgl_detect_version.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/io/file_access.h"

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -35,6 +35,7 @@
 #include "windows_terminal_logger.h"
 #include "windows_utils.h"
 
+#include "core/config/engine.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
 #include "core/io/marshalls.h"

--- a/platform/windows/wgl_detect_version.cpp
+++ b/platform/windows/wgl_detect_version.cpp
@@ -31,8 +31,10 @@
 #if defined(WINDOWS_ENABLED) && defined(GLES3_ENABLED)
 
 #include "wgl_detect_version.h"
+
 #include "os_windows.h"
 
+#include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/string/ustring.h"
 #include "core/variant/dictionary.h"

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -31,6 +31,7 @@
 #include "cpu_particles_2d.h"
 #include "cpu_particles_2d.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/math/random_number_generator.h"
 #include "core/math/transform_interpolator.h"
 #include "core/object/class_db.h"

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -31,6 +31,7 @@
 #include "gpu_particles_2d.h"
 #include "gpu_particles_2d.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "scene/2d/cpu_particles_2d.h"

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -32,6 +32,7 @@
 #include "gpu_particles_2d.compat.inc"
 
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "scene/2d/cpu_particles_2d.h"
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/canvas_item_material.h"

--- a/scene/2d/navigation/navigation_link_2d.cpp
+++ b/scene/2d/navigation/navigation_link_2d.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_link_2d.h"
 
+#include "core/config/engine.h"
 #include "core/math/geometry_2d.h"
 #include "core/object/class_db.h"
 #include "scene/resources/world_2d.h"

--- a/scene/2d/navigation/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation/navigation_obstacle_2d.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_obstacle_2d.h"
 
+#include "core/config/engine.h"
 #include "core/math/geometry_2d.h"
 #include "core/object/class_db.h"
 #include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h"

--- a/scene/2d/navigation/navigation_region_2d.cpp
+++ b/scene/2d/navigation/navigation_region_2d.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_region_2d.h"
 
+#include "core/config/engine.h"
 #include "core/math/random_pcg.h"
 #include "core/object/class_db.h"
 #include "scene/resources/world_2d.h"

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -30,6 +30,7 @@
 
 #include "path_2d.h"
 
+#include "core/config/engine.h"
 #include "core/math/geometry_2d.h"
 #include "core/object/class_db.h"
 #include "scene/main/timer.h"

--- a/scene/2d/physics/area_2d.cpp
+++ b/scene/2d/physics/area_2d.cpp
@@ -30,6 +30,7 @@
 
 #include "area_2d.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "servers/audio/audio_server.h"
 

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -30,6 +30,7 @@
 
 #include "polygon_2d.h"
 
+#include "core/config/engine.h"
 #include "core/math/geometry_2d.h"
 #include "core/object/class_db.h"
 #include "scene/2d/skeleton_2d.h"

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -31,6 +31,7 @@
 #include "tile_map.h"
 #include "tile_map.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/io/marshalls.h"
 #include "core/object/class_db.h"
 

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -30,6 +30,7 @@
 
 #include "tile_map_layer.h"
 
+#include "core/config/engine.h"
 #include "core/io/marshalls.h"
 #include "core/math/geometry_2d.h"
 #include "core/math/random_pcg.h"

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -31,6 +31,7 @@
 #include "cpu_particles_3d.h"
 #include "cpu_particles_3d.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/math/random_number_generator.h"
 #include "core/object/class_db.h"
 #include "scene/3d/camera_3d.h"

--- a/scene/3d/fog_volume.cpp
+++ b/scene/3d/fog_volume.cpp
@@ -31,6 +31,7 @@
 #include "fog_volume.h"
 
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "scene/main/viewport.h"
 #include "scene/resources/environment.h"
 #include "servers/rendering/rendering_server.h"

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -32,6 +32,7 @@
 #include "gpu_particles_3d.compat.inc"
 
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "scene/3d/cpu_particles_3d.h"
 #include "scene/resources/curve_texture.h"
 #include "scene/resources/gradient_texture.h"

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -31,6 +31,7 @@
 #include "gpu_particles_3d.h"
 #include "gpu_particles_3d.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "scene/3d/cpu_particles_3d.h"

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -33,6 +33,7 @@
 #include "core/math/geometry_3d.h"
 #include "core/object/class_db.h"
 #include "core/object/worker_thread_pool.h"
+#include "core/os/os.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/main/viewport.h"

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "label_3d.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "scene/main/window.h"
 #include "scene/resources/mesh.h"

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -30,6 +30,7 @@
 
 #include "lightmap_gi.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/config_file.h"
 #include "core/math/delaunay_3d.h"

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -36,6 +36,7 @@
 #include "core/math/geometry_3d.h"
 #include "core/object/class_db.h"
 #include "core/object/object.h"
+#include "core/os/os.h"
 #include "scene/3d/light_3d.h"
 #include "scene/3d/lightmap_probe.h"
 #include "scene/3d/mesh_instance_3d.h"

--- a/scene/3d/navigation/navigation_link_3d.cpp
+++ b/scene/3d/navigation/navigation_link_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_link_3d.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
 #include "servers/rendering/rendering_server.h"

--- a/scene/3d/navigation/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation/navigation_obstacle_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_obstacle_3d.h"
 
+#include "core/config/engine.h"
 #include "core/math/geometry_2d.h"
 #include "core/object/class_db.h"
 #include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h"

--- a/scene/3d/navigation/navigation_region_3d.cpp
+++ b/scene/3d/navigation/navigation_region_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_region_3d.h"
 
+#include "core/config/engine.h"
 #include "core/math/random_pcg.h"
 #include "core/object/class_db.h"
 #include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h"

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "occluder_instance_3d.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/marshalls.h"
 #include "core/math/geometry_2d.h"

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "path_3d.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "scene/resources/mesh.h"
 #include "servers/rendering/rendering_server.h"

--- a/scene/3d/physics/area_3d.cpp
+++ b/scene/3d/physics/area_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "area_3d.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "servers/audio/audio_server.h"
 

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "collision_object_3d.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "scene/resources/3d/shape_3d.h"
 #include "scene/resources/mesh.h"

--- a/scene/3d/physics/ray_cast_3d.cpp
+++ b/scene/3d/physics/ray_cast_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "ray_cast_3d.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "scene/3d/physics/collision_object_3d.h"
 #include "scene/resources/mesh.h"

--- a/scene/3d/physics/shape_cast_3d.cpp
+++ b/scene/3d/physics/shape_cast_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "shape_cast_3d.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "scene/3d/physics/collision_object_3d.h"
 #include "scene/resources/3d/concave_polygon_shape_3d.h"

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -31,6 +31,7 @@
 #include "soft_body_3d.h"
 #include "soft_body_3d.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "scene/3d/physics/physics_body_3d.h"
 #include "servers/rendering/rendering_server.h"

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "sprite_3d.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/mesh.h"

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -34,6 +34,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "scene/resources/material.h"
 #include "servers/rendering/rendering_server.h"
 

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/multimesh_instance_3d.h"
 #include "scene/3d/voxelizer.h"

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -30,6 +30,7 @@
 
 #include "animation_blend_tree.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "scene/resources/animation.h"
 

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -30,6 +30,7 @@
 
 #include "animation_node_state_machine.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 
 /////////////////////////////////////////////////

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -33,6 +33,7 @@
 
 #include "core/config/engine.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 
 bool AnimationPlayer::_set(const StringName &p_name, const Variant &p_value) {
 	String name = p_name;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -31,8 +31,9 @@
 #include "animation_tree.h"
 #include "animation_tree.compat.inc"
 
-#include "animation_blend_tree.h"
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
+#include "scene/animation/animation_blend_tree.h"
 #include "scene/animation/animation_player.h"
 
 void AnimationNode::get_parameter_list(List<PropertyInfo> *r_list) const {

--- a/scene/animation/root_motion_view.cpp
+++ b/scene/animation/root_motion_view.cpp
@@ -32,6 +32,7 @@
 
 #include "root_motion_view.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "scene/animation/animation_mixer.h"
 #include "scene/resources/material.h"

--- a/scene/audio/audio_stream_player_internal.cpp
+++ b/scene/audio/audio_stream_player_internal.cpp
@@ -30,6 +30,7 @@
 
 #include "audio_stream_player_internal.h"
 
+#include "core/config/engine.h"
 #include "scene/main/node.h"
 #include "servers/audio/audio_stream.h"
 

--- a/scene/debugger/runtime_node_select.cpp
+++ b/scene/debugger/runtime_node_select.cpp
@@ -32,6 +32,7 @@
 
 #include "runtime_node_select.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/engine_debugger.h"

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -37,6 +37,7 @@
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/math/math_fieldwise.h"
+#include "core/os/os.h"
 #include "core/os/time.h"
 #include "core/templates/local_vector.h"
 #include "core/variant/array.h"

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -30,6 +30,7 @@
 
 #include "scene_debugger.h"
 
+#include "core/config/engine.h"
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/input/shortcut.h"

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -30,6 +30,7 @@
 
 #include "color_picker.h"
 
+#include "core/config/engine.h"
 #include "core/input/input.h"
 #include "core/io/image.h"
 #include "core/math/expression.h"

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -34,6 +34,7 @@
 #include "core/io/image.h"
 #include "core/math/expression.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "scene/gui/color_mode.h"
 #include "scene/gui/color_picker_shape.h"
 #include "scene/gui/file_dialog.h"

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -33,12 +33,13 @@
 
 STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 
-#include "container.h"
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/input/input_map.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/string/string_builder.h"
+#include "scene/gui/container.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/main/canvas_layer.h"
 #include "scene/main/window.h"

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -36,6 +36,7 @@
 #include "core/io/file_access.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
+#include "core/os/os.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/flow_container.h"

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -31,6 +31,7 @@
 #include "graph_edit.h"
 #include "graph_edit.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/input/input.h"
 #include "core/math/geometry_2d.h"
 #include "core/math/math_funcs.h"

--- a/scene/gui/graph_element.cpp
+++ b/scene/gui/graph_element.cpp
@@ -30,6 +30,7 @@
 
 #include "graph_element.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "scene/gui/graph_edit.h"
 #include "scene/theme/theme_db.h"

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -31,6 +31,7 @@
 #include "line_edit.h"
 #include "line_edit.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/input/input_map.h"

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -31,6 +31,7 @@
 #include "text_edit.h"
 #include "text_edit.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/input/input_map.h"

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -30,6 +30,7 @@
 
 #include "video_stream_player.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "servers/audio/audio_server.h"

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -33,6 +33,7 @@
 #include "core/io/file_access.h"
 #include "core/io/stream_peer_gzip.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/os/thread.h"
 #include "scene/main/timer.h"
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -31,8 +31,6 @@
 #include "node.h"
 #include "node.compat.inc"
 
-#include "core/object/class_db.h"
-
 STATIC_ASSERT_INCOMPLETE_TYPE(class, Mesh);
 STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 STATIC_ASSERT_INCOMPLETE_TYPE(class, DisplayServer);
@@ -40,9 +38,11 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, Shader);
 STATIC_ASSERT_INCOMPLETE_TYPE(class, OS);
 STATIC_ASSERT_INCOMPLETE_TYPE(class, Engine);
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/resource.h"
 #include "core/io/resource_loader.h"
+#include "core/object/class_db.h"
 #include "core/object/message_queue.h"
 #include "core/object/script_language.h"
 #include "core/string/print_string.h"

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -32,6 +32,7 @@
 
 STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/io/image_loader.h"

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -33,6 +33,7 @@
 
 STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/input/input.h"

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -32,6 +32,7 @@
 
 STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/input/input.h"

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -36,6 +36,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "core/debugger/engine_debugger.h"
 #include "core/input/input.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "scene/gui/control.h"
 #include "scene/theme/theme_db.h"
 #include "scene/theme/theme_owner.h"

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -30,6 +30,7 @@
 
 #include "register_scene_types.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -31,6 +31,7 @@
 #include "tile_set.h"
 #include "tile_set.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/io/marshalls.h"
 #include "core/math/geometry_2d.h"
 #include "core/object/class_db.h"

--- a/scene/resources/3d/navigation_mesh_source_geometry_data_3d.cpp
+++ b/scene/resources/3d/navigation_mesh_source_geometry_data_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_mesh_source_geometry_data_3d.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 
 void NavigationMeshSourceGeometryData3D::set_vertices(const Vector<float> &p_vertices) {

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -30,6 +30,7 @@
 
 #include "primitive_meshes.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/math/math_funcs.h"
 #include "core/object/class_db.h"

--- a/scene/resources/3d/sky_material.cpp
+++ b/scene/resources/3d/sky_material.cpp
@@ -30,6 +30,7 @@
 
 #include "sky_material.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
 #include "core/version.h"

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -30,6 +30,7 @@
 
 #include "environment.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "scene/resources/gradient_texture.h"
 #include "scene/resources/sky.h"
 #include "servers/rendering/rendering_server.h"

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -31,6 +31,7 @@
 #include "font.h"
 #include "font.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/io/image_loader.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -33,6 +33,7 @@
 
 #include "core/io/image_loader.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/hashfuncs.h"
 #include "scene/resources/image_texture.h"

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -34,6 +34,7 @@
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/version.h"
 #include "scene/main/scene_tree.h"
 #include "scene/resources/texture.h"

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -30,6 +30,7 @@
 
 #include "particle_process_material.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "core/version.h"
 #include "servers/rendering/rendering_server.h"

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -31,6 +31,7 @@
 #include "shader.h"
 #include "shader.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/io/file_access.h"
 #include "core/object/class_db.h"
 #include "scene/main/scene_tree.h"

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -30,6 +30,7 @@
 
 #include "visual_shader.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "core/templates/rb_map.h"
 #include "core/variant/variant_utility.h"

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -32,6 +32,7 @@
 #include "visual_shader_nodes.compat.inc"
 
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "servers/rendering/rendering_server.h"
 
 ////////////// Vector Base

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -30,6 +30,7 @@
 
 #include "theme_db.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
 #include "core/object/class_db.h"

--- a/servers/audio/effects/audio_effect_compressor.cpp
+++ b/servers/audio/effects/audio_effect_compressor.cpp
@@ -30,6 +30,7 @@
 
 #include "audio_effect_compressor.h"
 
+#include "core/config/engine.h"
 #include "core/object/class_db.h"
 #include "servers/audio/audio_server.h"
 

--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -32,6 +32,7 @@
 
 #include "core/io/marshalls.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 
 void AudioEffectRecordInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
 	if (!is_recording) {

--- a/servers/debugger/servers_debugger.cpp
+++ b/servers/debugger/servers_debugger.cpp
@@ -35,6 +35,7 @@
 #include "core/debugger/engine_profiler.h"
 #include "core/io/resource_loader.h"
 #include "core/object/script_language.h"
+#include "core/os/os.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
 

--- a/servers/debugger/servers_debugger.cpp
+++ b/servers/debugger/servers_debugger.cpp
@@ -30,6 +30,7 @@
 
 #include "servers_debugger.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/engine_profiler.h"

--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -30,6 +30,7 @@
 
 #include "movie_writer.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/object/class_db.h"

--- a/servers/navigation_2d/navigation_server_2d.cpp
+++ b/servers/navigation_2d/navigation_server_2d.cpp
@@ -31,6 +31,7 @@
 #include "navigation_server_2d.h"
 #include "navigation_server_2d.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
 #include "scene/main/node.h"

--- a/servers/navigation_3d/navigation_server_3d.cpp
+++ b/servers/navigation_3d/navigation_server_3d.cpp
@@ -31,6 +31,7 @@
 #include "navigation_server_3d.h"
 #include "navigation_server_3d.compat.inc"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/object/class_db.h"
 #include "scene/main/node.h"

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
+#include "core/os/os.h"
 
 #include "audio/audio_effect.h"
 #include "audio/audio_server.h"

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -30,6 +30,7 @@
 
 #include "renderer_canvas_cull.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/math/geometry_2d.h"
 #include "core/math/transform_interpolator.h"

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -30,6 +30,7 @@
 
 #include "renderer_canvas_render_rd.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/math/geometry_2d.h"
 #include "core/math/math_defs.h"

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/os/os.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h"
 #include "servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h"

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -30,6 +30,7 @@
 
 #include "renderer_compositor_rd.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/os/os.h"

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -33,6 +33,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/object/worker_thread_pool.h"
+#include "core/os/os.h"
 #include "core/string/string_builder.h"
 #include "core/version.h"
 #include "servers/rendering/shader_include_db.h"

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -30,6 +30,7 @@
 
 #include "shader_rd.h"
 
+#include "core/config/engine.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/object/worker_thread_pool.h"

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/math/geometry_3d.h"
+#include "core/os/os.h"
 #include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
 #include "servers/rendering/renderer_rd/storage_rd/texture_storage.h"
 #include "servers/rendering/rendering_server_globals.h"

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -34,6 +34,7 @@
 #include "../framebuffer_cache_rd.h"
 #include "../uniform_set_cache_rd.h"
 
+#include "core/config/engine.h"
 #include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
 #include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
 #include "servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h"

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -34,6 +34,7 @@
 #include "core/math/geometry_3d.h"
 #include "core/object/callable_method_pointer.h"
 #include "core/object/worker_thread_pool.h"
+#include "core/os/os.h"
 #include "servers/rendering/rendering_light_culler.h"
 #include "servers/rendering/rendering_server.h"
 #include "servers/rendering/rendering_server_default.h"

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -30,6 +30,7 @@
 
 #include "renderer_scene_cull.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/math/geometry_3d.h"
 #include "core/object/callable_method_pointer.h"

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -30,6 +30,7 @@
 
 #include "renderer_viewport.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/math/transform_interpolator.h"
 #include "core/object/worker_thread_pool.h"

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/math/transform_interpolator.h"
 #include "core/object/worker_thread_pool.h"
+#include "core/os/os.h"
 #include "core/profiling/profiling.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/renderer_canvas_cull.h"

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -38,6 +38,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/profiling/profiling.h"
 #include "core/templates/fixed_vector.h"
 #include "modules/modules_enabled.gen.h"

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -34,6 +34,7 @@
 #include "rendering_device_binds.h"
 #include "shader_include_db.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"

--- a/servers/rendering/rendering_light_culler.cpp
+++ b/servers/rendering/rendering_light_culler.cpp
@@ -30,6 +30,7 @@
 
 #include "rendering_light_culler.h"
 
+#include "core/config/engine.h"
 #include "core/math/plane.h"
 #include "core/math/projection.h"
 #include "rendering_server_globals.h"

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -34,6 +34,7 @@
 #include "core/config/project_settings.h"
 #include "core/math/geometry_3d.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/variant/typed_array.h"
 #include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server_types.h"

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -30,6 +30,7 @@
 
 #include "shader_language.h"
 
+#include "core/config/engine.h"
 #include "core/os/os.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/rb_set.h"

--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -30,6 +30,7 @@
 
 #include "shader_preprocessor.h"
 #include "core/math/expression.h"
+#include "core/os/os.h"
 
 const char32_t CURSOR = 0xFFFF;
 

--- a/tests/core/threads/test_worker_thread_pool.cpp
+++ b/tests/core/threads/test_worker_thread_pool.cpp
@@ -34,6 +34,7 @@ TEST_FORCE_LINK(test_worker_thread_pool)
 
 #include "core/object/callable_method_pointer.h"
 #include "core/object/worker_thread_pool.h"
+#include "core/os/os.h"
 
 namespace TestWorkerThreadPool {
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -33,6 +33,7 @@
 #include "core/input/input.h"
 #include "core/input/input_map.h"
 #include "core/io/dir_access.h"
+#include "core/os/os.h"
 #include "core/string/translation_server.h"
 #include "scene/main/window.h"
 #include "scene/theme/theme_db.h"

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -30,6 +30,7 @@
 
 #include "test_main.h"
 
+#include "core/config/engine.h"
 #include "core/input/input.h"
 #include "core/input/input_map.h"
 #include "core/io/dir_access.h"


### PR DESCRIPTION
- Helps address #111218
- Related to #116826

I have a follow-up PR moving `OS::ProcessID` out of `os.h`, and removing `os.h` as dependency in as many headers as possible. This leads to having to include `os.h` and `engine.h` explicitly in a lot of files. I had similar problems with previous PRs decoupling RenderingServer and DisplayServer. So I'm doing a thorough pass as a pre-requisite to further decoupling.