### PR TITLE
Move ProcessID typedef out of OS, remove `os.h` include where we can

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -34,6 +34,7 @@
 #include "core/config/project_settings.h"
 #include "core/donors.gen.h"
 #include "core/license.gen.h"
+#include "core/object/ref_counted.h"
 #include "core/variant/typed_array.h"
 #include "core/version.h"
 #include "servers/rendering/rendering_device.h"

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -44,6 +44,7 @@
 #include "core/os/keyboard.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
+#include "core/os/process_id.h"
 #include "core/os/thread_safe.h"
 #include "core/variant/typed_array.h"
 
@@ -428,7 +429,7 @@ int OS::create_instance(const Vector<String> &p_arguments) {
 	for (const String &arg : p_arguments) {
 		args.push_back(arg);
 	}
-	::OS::ProcessID pid = 0;
+	ProcessID pid = 0;
 	Error err = ::OS::get_singleton()->create_instance(args, &pid);
 	if (err != OK) {
 		return -1;
@@ -449,7 +450,7 @@ int OS::create_process(const String &p_path, const Vector<String> &p_arguments, 
 	for (const String &arg : p_arguments) {
 		args.push_back(arg);
 	}
-	::OS::ProcessID pid = 0;
+	ProcessID pid = 0;
 	Error err = ::OS::get_singleton()->create_process(p_path, args, &pid, p_open_console);
 	if (err != OK) {
 		return -1;

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/debugger/engine_profiler.h"
+#include "core/io/logger.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/object/class_db.h"

--- a/core/input/input_event_codec.cpp
+++ b/core/input/input_event_codec.cpp
@@ -32,7 +32,6 @@
 
 #include "core/input/input.h"
 #include "core/io/marshalls.h"
-#include "core/os/os.h"
 
 enum class BoolShift : uint8_t {
 	SHIFT = 0,

--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -30,9 +30,9 @@
 
 #pragma once
 
+#include "core/object/object.h"
 #include "core/os/condition_variable.h"
 #include "core/os/memory.h"
-#include "core/os/os.h"
 #include "core/os/semaphore.h"
 #include "core/os/thread.h"
 #include "core/templates/local_vector.h"
@@ -40,6 +40,7 @@
 #include "core/templates/rid.h"
 #include "core/templates/safe_refcount.h"
 #include "core/templates/self_list.h"
+#include "core/variant/callable.h"
 
 class WorkerThreadPool : public Object {
 	GDCLASS(WorkerThreadPool, Object)

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/io/logger.h"
 #include "core/io/remote_filesystem_client.h"
+#include "core/os/process_id.h"
 #include "core/os/time_enums.h"
 #include "core/string/ustring.h"
 #include "core/templates/list.h"
@@ -137,8 +138,6 @@ protected:
 	virtual bool _check_internal_feature_support(const String &p_feature) = 0;
 
 public:
-	typedef int64_t ProcessID;
-
 	static OS *get_singleton();
 
 	static bool prefer_meta_over_ctrl();

--- a/core/os/process_id.h
+++ b/core/os/process_id.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  godot_view_renderer.mm                                                */
+/*  process_id.h                                                          */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,93 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#import "godot_view_renderer.h"
+#pragma once
 
-#import "display_server_apple_embedded.h"
-#import "os_apple_embedded.h"
+#include <cstdint>
 
-#include "core/config/project_settings.h"
-#include "core/os/keyboard.h"
-#include "core/os/os.h"
-#include "main/main.h"
-#include "servers/audio/audio_server.h"
-
-#import <AudioToolbox/AudioServices.h>
-#import <CoreMotion/CoreMotion.h>
-#import <GameController/GameController.h>
-#import <QuartzCore/QuartzCore.h>
-#import <UIKit/UIKit.h>
-
-@interface GDTViewRenderer ()
-
-@property(assign, nonatomic) BOOL hasFinishedProjectDataSetup;
-@property(assign, nonatomic) BOOL hasStartedMain;
-@property(assign, nonatomic) BOOL hasFinishedSetup;
-
-@end
-
-@implementation GDTViewRenderer
-
-- (BOOL)setupView:(UIView *)view {
-	if (self.hasFinishedSetup) {
-		return NO;
-	}
-
-	if (!OS::get_singleton()) {
-		exit(0);
-	}
-
-	if (!self.hasFinishedProjectDataSetup) {
-		[self setupProjectData];
-		return YES;
-	}
-
-	if (!self.hasStartedMain) {
-		self.hasStartedMain = YES;
-		OS_AppleEmbedded::get_singleton()->start();
-		return YES;
-	}
-
-	self.hasFinishedSetup = YES;
-
-	return NO;
-}
-
-- (void)setupProjectData {
-	self.hasFinishedProjectDataSetup = YES;
-
-	Main::setup2();
-
-	// this might be necessary before here
-	NSDictionary *dict = [[NSBundle mainBundle] infoDictionary];
-	for (NSString *key in dict) {
-		NSObject *value = [dict objectForKey:key];
-		String ukey = String::utf8([key UTF8String]);
-
-		// we need a NSObject to Variant conversor
-
-		if ([value isKindOfClass:[NSString class]]) {
-			NSString *str = (NSString *)value;
-			String uval = String::utf8([str UTF8String]);
-
-			ProjectSettings::get_singleton()->set("Info.plist/" + ukey, uval);
-
-		} else if ([value isKindOfClass:[NSNumber class]]) {
-			NSNumber *n = (NSNumber *)value;
-			double dval = [n doubleValue];
-
-			ProjectSettings::get_singleton()->set("Info.plist/" + ukey, dval);
-		}
-		// do stuff
-	}
-}
-
-- (void)renderOnView:(UIView *)view {
-	if (!OS_AppleEmbedded::get_singleton()) {
-		return;
-	}
-
-	OS_AppleEmbedded::get_singleton()->iterate();
-}
-
-@end
+typedef int64_t ProcessID;

--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -36,7 +36,6 @@
 #include "core/debugger/engine_debugger.h"
 #include "core/io/compression.h"
 #include "core/object/class_db.h"
-#include "core/os/os.h"
 #include "core/templates/a_hash_map.h"
 #include "core/templates/local_vector.h"
 

--- a/drivers/apple_embedded/app_delegate_service.mm
+++ b/drivers/apple_embedded/app_delegate_service.mm
@@ -36,6 +36,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #import "drivers/coreaudio/audio_driver_coreaudio.h"
 #include "main/main.h"
 

--- a/drivers/apple_embedded/display_server_apple_embedded.mm
+++ b/drivers/apple_embedded/display_server_apple_embedded.mm
@@ -42,6 +42,7 @@
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/io/file_access_pack.h"
+#include "core/os/os.h"
 #include "servers/display/native_menu.h"
 
 #import <GameController/GameController.h>

--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -37,10 +37,12 @@
 #import "godot_view_apple_embedded.h"
 #import "godot_view_controller.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #include "core/profiling/profiling.h"
 #import "drivers/apple/os_log_logger.h"
 #ifdef SDL_ENABLED

--- a/drivers/coreaudio/audio_driver_coreaudio.mm
+++ b/drivers/coreaudio/audio_driver_coreaudio.mm
@@ -32,6 +32,7 @@
 
 #ifdef COREAUDIO_ENABLED
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -37,6 +37,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/image.h"
 #include "core/os/os.h"
+#include "drivers/gles3/rasterizer_util_gles3.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
 #include "servers/rendering/rendering_server_types.h"
@@ -211,6 +212,13 @@ void RasterizerGLES3::finalize() {
 	memdelete(texture_storage);
 	memdelete(utilities);
 	memdelete(config);
+}
+
+void RasterizerGLES3::make_current(bool p_gles_over_gl) {
+	RasterizerUtilGLES3::set_gles_over_gl(p_gles_over_gl);
+	OS::get_singleton()->set_gles_over_gl(p_gles_over_gl);
+	_create_func = _create_current;
+	low_end = true;
 }
 
 RasterizerGLES3 *RasterizerGLES3::singleton = nullptr;

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -32,7 +32,6 @@
 
 #ifdef GLES3_ENABLED
 
-#include "core/os/os.h"
 #include "drivers/gles3/effects/copy_effects.h"
 #include "drivers/gles3/effects/cubemap_filter.h"
 #include "drivers/gles3/effects/feed_effects.h"
@@ -42,7 +41,6 @@
 #include "drivers/gles3/environment/gi.h"
 #include "drivers/gles3/rasterizer_canvas_gles3.h"
 #include "drivers/gles3/rasterizer_scene_gles3.h"
-#include "drivers/gles3/rasterizer_util_gles3.h"
 #include "drivers/gles3/storage/config.h"
 #include "drivers/gles3/storage/light_storage.h"
 #include "drivers/gles3/storage/material_storage.h"
@@ -113,12 +111,7 @@ public:
 		return memnew(RasterizerGLES3);
 	}
 
-	static void make_current(bool p_gles_over_gl) {
-		RasterizerUtilGLES3::set_gles_over_gl(p_gles_over_gl);
-		OS::get_singleton()->set_gles_over_gl(p_gles_over_gl);
-		_create_func = _create_current;
-		low_end = true;
-	}
+	static void make_current(bool p_gles_over_gl);
 
 #ifdef WINDOWS_ENABLED
 	static void set_screen_flipped_y(bool p_flipped) {

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -32,8 +32,7 @@
 
 #if defined(UNIX_ENABLED)
 
-#include "core/os/os.h"
-#include "core/string/print_string.h"
+#include "core/string/ustring.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>

--- a/drivers/unix/file_access_unix_pipe.cpp
+++ b/drivers/unix/file_access_unix_pipe.cpp
@@ -32,8 +32,7 @@
 
 #if defined(UNIX_ENABLED)
 
-#include "core/os/os.h"
-#include "core/string/print_string.h"
+#include "core/string/ustring.h"
 
 #include <fcntl.h>
 #include <sys/ioctl.h>

--- a/drivers/windows/file_access_windows_pipe.cpp
+++ b/drivers/windows/file_access_windows_pipe.cpp
@@ -32,8 +32,7 @@
 
 #include "file_access_windows_pipe.h"
 
-#include "core/os/os.h"
-#include "core/string/print_string.h"
+#include "core/string/ustring.h"
 
 Error FileAccessWindowsPipe::open_existing(HANDLE p_rfd, HANDLE p_wfd, bool p_blocking) {
 	// Open pipe using handles created by CreatePipe(rfd, wfd, NULL, 4096) call in the OS.execute_with_pipe.

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -31,8 +31,7 @@
 #include "audio_driver_xaudio2.h"
 
 #include "core/config/engine.h"
-#include "core/config/project_settings.h"
-#include "core/os/os.h"
+#include "core/math/math_funcs_binary.h"
 
 Error AudioDriverXAudio2::init() {
 	active.clear();

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -34,6 +34,7 @@
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/remote_debugger.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/string/ustring.h"
 #include "core/variant/typed_dictionary.h"
 #include "core/version.h"

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/object/script_language.h"
-#include "core/os/os.h"
+#include "core/os/process_id.h"
 #include "editor/debugger/editor_debugger_inspector.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "scene/gui/margin_container.h"
@@ -164,7 +164,7 @@ private:
 	EditorPerformanceProfiler *performance_profiler = nullptr;
 	EditorExpressionEvaluator *expression_evaluator = nullptr;
 
-	OS::ProcessID remote_pid = 0;
+	ProcessID remote_pid = 0;
 	bool move_to_foreground = true;
 	bool can_request_idle_draw = false;
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5582,11 +5582,11 @@ bool EditorNode::is_scene_in_use(const String &p_path) {
 	return false;
 }
 
-OS::ProcessID EditorNode::has_child_process(OS::ProcessID p_pid) const {
+ProcessID EditorNode::has_child_process(ProcessID p_pid) const {
 	return project_run_bar->has_child_process(p_pid);
 }
 
-void EditorNode::stop_child_process(OS::ProcessID p_pid) {
+void EditorNode::stop_child_process(ProcessID p_pid) {
 	project_run_bar->stop_child_process(p_pid);
 }
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/object/script_language.h"
-#include "core/os/os.h"
+#include "core/os/process_id.h"
 #include "core/templates/safe_refcount.h"
 #include "editor/editor_data.h"
 #include "editor/plugins/editor_plugin.h"
@@ -952,8 +952,8 @@ public:
 
 	void notify_all_debug_sessions_exited();
 
-	OS::ProcessID has_child_process(OS::ProcessID p_pid) const;
-	void stop_child_process(OS::ProcessID p_pid);
+	ProcessID has_child_process(ProcessID p_pid) const;
+	void stop_child_process(ProcessID p_pid);
 
 	Ref<Theme> get_editor_theme() const { return theme; }
 	void update_preview_themes(int p_mode);

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -43,6 +43,7 @@
 #include "core/io/resource_uid.h"
 #include "core/math/random_pcg.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/os/shared_object.h"
 #include "core/string/translation_server.h"
 #include "core/version.h"
@@ -2570,7 +2571,7 @@ Error EditorExportPlatform::ssh_run_on_remote(const String &p_host, const String
 	return OK;
 }
 
-Error EditorExportPlatform::ssh_run_on_remote_no_wait(const String &p_host, const String &p_port, const Vector<String> &p_ssh_args, const String &p_cmd_args, OS::ProcessID *r_pid, int p_port_fwd) const {
+Error EditorExportPlatform::ssh_run_on_remote_no_wait(const String &p_host, const String &p_port, const Vector<String> &p_ssh_args, const String &p_cmd_args, ProcessID *r_pid, int p_port_fwd) const {
 	String ssh_path = EDITOR_GET("export/ssh/ssh");
 	if (ssh_path.is_empty()) {
 		ssh_path = "ssh";

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/io/zip_io.h"
-#include "core/os/os.h"
+#include "core/os/process_id.h"
 #include "editor/export/editor_export_preset.h"
 
 class DirAccess;
@@ -193,8 +193,8 @@ protected:
 		r_output.push_back(pipe);
 		return err;
 	}
-	OS::ProcessID _ssh_run_on_remote_no_wait(const String &p_host, const String &p_port, const Vector<String> &p_ssh_args, const String &p_cmd_args, int p_port_fwd = -1) const {
-		OS::ProcessID pid = 0;
+	ProcessID _ssh_run_on_remote_no_wait(const String &p_host, const String &p_port, const Vector<String> &p_ssh_args, const String &p_cmd_args, int p_port_fwd = -1) const {
+		ProcessID pid = 0;
 		Error err = ssh_run_on_remote_no_wait(p_host, p_port, p_ssh_args, p_cmd_args, &pid, p_port_fwd);
 		if (err != OK) {
 			return -1;
@@ -204,7 +204,7 @@ protected:
 	}
 
 	Error ssh_run_on_remote(const String &p_host, const String &p_port, const Vector<String> &p_ssh_args, const String &p_cmd_args, String *r_out = nullptr, int p_port_fwd = -1) const;
-	Error ssh_run_on_remote_no_wait(const String &p_host, const String &p_port, const Vector<String> &p_ssh_args, const String &p_cmd_args, OS::ProcessID *r_pid = nullptr, int p_port_fwd = -1) const;
+	Error ssh_run_on_remote_no_wait(const String &p_host, const String &p_port, const Vector<String> &p_ssh_args, const String &p_cmd_args, ProcessID *r_pid = nullptr, int p_port_fwd = -1) const;
 	Error ssh_push_to_remote(const String &p_host, const String &p_port, const Vector<String> &p_scp_args, const String &p_src_file, const String &p_dst_file) const;
 
 	Error _extract_android_assets(const String &p_bundle_path, String &r_pck_path, String &r_temp_dir);

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -32,6 +32,8 @@
 
 #include "core/io/json.h"
 #include "core/io/plist.h"
+#include "core/os/os.h"
+#include "core/os/process_id.h"
 #include "core/string/translation_server.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
@@ -2566,7 +2568,7 @@ int EditorExportPlatformAppleEmbedded::_execute(const String &p_path, const List
 
 	Ref<FileAccess> fa_stdout = pipe_info["stdio"];
 	Ref<FileAccess> fa_stderr = pipe_info["stderr"];
-	OS::ProcessID pid = pipe_info["pid"];
+	ProcessID pid = pipe_info["pid"];
 
 	FileReader stdout_r(fa_stdout);
 	FileReader stderr_r(fa_stderr);

--- a/editor/export/editor_export_platform_apple_embedded.h
+++ b/editor/export/editor_export_platform_apple_embedded.h
@@ -39,7 +39,6 @@
 #include "core/io/marshalls.h"
 #include "core/io/resource_saver.h"
 #include "core/io/zip_io.h"
-#include "core/os/os.h"
 #include "core/templates/safe_refcount.h"
 #include "editor/export/editor_export_platform.h"
 #include "editor/settings/editor_settings.h"

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -492,6 +492,15 @@ struct ProjectListComparator {
 	}
 };
 
+String ProjectList::Item::get_last_edited_string() const {
+	if (missing) {
+		return TTR("Missing Date");
+	}
+
+	OS::TimeZoneInfo tz = OS::get_singleton()->get_time_zone_info();
+	return Time::get_singleton()->get_datetime_string_from_unix_time(last_edited + tz.bias * 60, true);
+}
+
 // Helpers.
 
 bool ProjectList::project_feature_looks_like_version(const String &p_feature) {

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -31,8 +31,6 @@
 #pragma once
 
 #include "core/io/config_file.h"
-#include "core/os/os.h"
-#include "core/os/time.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/scroll_container.h"
 
@@ -193,14 +191,7 @@ public:
 			return path == l.path;
 		}
 
-		String get_last_edited_string() const {
-			if (missing) {
-				return TTR("Missing Date");
-			}
-
-			OS::TimeZoneInfo tz = OS::get_singleton()->get_time_zone_info();
-			return Time::get_singleton()->get_datetime_string_from_unix_time(last_edited + tz.bias * 60, true);
-		}
+		String get_last_edited_string() const;
 	};
 
 private:

--- a/editor/run/editor_run.cpp
+++ b/editor/run/editor_run.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/config_file.h"
+#include "core/os/os.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/editor_node.h"
 #include "editor/run/run_instances_dialog.h"
@@ -177,7 +178,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 			print_line(String(" ").join(output));
 		}
 
-		OS::ProcessID pid = 0;
+		ProcessID pid = 0;
 		Error err = OS::get_singleton()->create_instance(instance_args, &pid);
 		ERR_FAIL_COND_V(err, err);
 		if (pid != 0) {
@@ -202,8 +203,8 @@ bool EditorRun::request_screenshot(const Callable &p_callback) {
 	}
 }
 
-bool EditorRun::has_child_process(OS::ProcessID p_pid) const {
-	for (const OS::ProcessID &E : pids) {
+bool EditorRun::has_child_process(ProcessID p_pid) const {
+	for (const ProcessID &E : pids) {
 		if (E == p_pid) {
 			return true;
 		}
@@ -211,7 +212,7 @@ bool EditorRun::has_child_process(OS::ProcessID p_pid) const {
 	return false;
 }
 
-void EditorRun::stop_child_process(OS::ProcessID p_pid) {
+void EditorRun::stop_child_process(ProcessID p_pid) {
 	if (has_child_process(p_pid)) {
 		OS::get_singleton()->kill(p_pid);
 		pids.erase(p_pid);
@@ -220,7 +221,7 @@ void EditorRun::stop_child_process(OS::ProcessID p_pid) {
 
 void EditorRun::stop() {
 	if (status != STATUS_STOP && pids.size() > 0) {
-		for (const OS::ProcessID &E : pids) {
+		for (const ProcessID &E : pids) {
 			OS::get_singleton()->kill(E);
 		}
 		pids.clear();
@@ -230,7 +231,7 @@ void EditorRun::stop() {
 	running_scene = "";
 }
 
-OS::ProcessID EditorRun::get_current_process() const {
+ProcessID EditorRun::get_current_process() const {
 	if (pids.front() == nullptr) {
 		return 0;
 	}

--- a/editor/run/editor_run.h
+++ b/editor/run/editor_run.h
@@ -30,7 +30,13 @@
 
 #pragma once
 
-#include "core/os/os.h"
+#include "core/math/vector2i.h"
+#include "core/os/process_id.h"
+#include "core/string/ustring.h"
+#include "core/templates/list.h"
+#include "core/variant/callable.h"
+
+#include <climits> // INT_MAX
 
 typedef void (*EditorRunInstanceStarting)(int p_index, List<String> &r_arguments);
 typedef bool (*EditorRunInstanceRequestScreenshot)(const Callable &p_callback);
@@ -43,7 +49,7 @@ public:
 		STATUS_STOP
 	};
 
-	List<OS::ProcessID> pids;
+	List<ProcessID> pids;
 
 	struct WindowPlacement {
 		int screen = 0;
@@ -68,10 +74,10 @@ public:
 	void run_native_notify() { status = STATUS_PLAY; }
 	void stop();
 
-	void stop_child_process(OS::ProcessID p_pid);
-	bool has_child_process(OS::ProcessID p_pid) const;
+	void stop_child_process(ProcessID p_pid);
+	bool has_child_process(ProcessID p_pid) const;
 	int get_child_process_count() const { return pids.size(); }
-	OS::ProcessID get_current_process() const;
+	ProcessID get_current_process() const;
 
 	static bool request_screenshot(const Callable &p_callback);
 

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -480,11 +480,11 @@ Error EditorRunBar::start_native_device(int p_device_id) const {
 	return run_native->start_run_native(p_device_id);
 }
 
-OS::ProcessID EditorRunBar::has_child_process(OS::ProcessID p_pid) const {
+ProcessID EditorRunBar::has_child_process(ProcessID p_pid) const {
 	return editor_run.has_child_process(p_pid);
 }
 
-void EditorRunBar::stop_child_process(OS::ProcessID p_pid) {
+void EditorRunBar::stop_child_process(ProcessID p_pid) {
 	if (!has_child_process(p_pid)) {
 		return;
 	}
@@ -495,7 +495,7 @@ void EditorRunBar::stop_child_process(OS::ProcessID p_pid) {
 	}
 }
 
-OS::ProcessID EditorRunBar::get_current_process() const {
+ProcessID EditorRunBar::get_current_process() const {
 	return editor_run.get_current_process();
 }
 

--- a/editor/run/editor_run_bar.h
+++ b/editor/run/editor_run_bar.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/os/process_id.h"
 #include "editor/export/editor_export.h"
 #include "editor/run/editor_run.h"
 #include "scene/gui/margin_container.h"
@@ -129,9 +130,9 @@ public:
 
 	Error start_native_device(int p_device_id) const;
 
-	OS::ProcessID has_child_process(OS::ProcessID p_pid) const;
-	void stop_child_process(OS::ProcessID p_pid);
-	OS::ProcessID get_current_process() const;
+	ProcessID has_child_process(ProcessID p_pid) const;
+	void stop_child_process(ProcessID p_pid);
+	ProcessID get_current_process() const;
 
 	void set_movie_maker_enabled(bool p_enabled);
 	bool is_movie_maker_enabled() const;

--- a/editor/run/embedded_process.cpp
+++ b/editor/run/embedded_process.cpp
@@ -190,7 +190,7 @@ int EmbeddedProcess::get_embedded_pid() const {
 	return current_process_id;
 }
 
-void EmbeddedProcess::embed_process(OS::ProcessID p_pid) {
+void EmbeddedProcess::embed_process(ProcessID p_pid) {
 	if (!window) {
 		return;
 	}
@@ -395,7 +395,7 @@ void EmbeddedProcess::_check_mouse_over() {
 }
 
 void EmbeddedProcess::_check_focused_process_id() {
-	OS::ProcessID process_id = DisplayServer::get_singleton()->get_focused_process_id();
+	ProcessID process_id = DisplayServer::get_singleton()->get_focused_process_id();
 	if (process_id != focused_process_id) {
 		focused_process_id = process_id;
 		if (focused_process_id == current_process_id) {

--- a/editor/run/embedded_process.h
+++ b/editor/run/embedded_process.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/os/os.h"
+#include "core/os/process_id.h"
 #include "scene/gui/control.h"
 
 class ScriptEditorDebugger;
@@ -64,7 +64,7 @@ public:
 	virtual bool is_embedding_completed() const = 0;
 	virtual bool is_embedding_in_progress() const = 0;
 	virtual bool is_process_focused() const = 0;
-	virtual void embed_process(OS::ProcessID p_pid) = 0;
+	virtual void embed_process(ProcessID p_pid) = 0;
 	virtual int get_embedded_pid() const = 0;
 	virtual void reset() = 0;
 	virtual void reset_timers() = 0;
@@ -87,8 +87,8 @@ class EmbeddedProcess : public EmbeddedProcessBase {
 
 	bool application_has_focus = true;
 	uint64_t last_application_focus_time = 0;
-	OS::ProcessID focused_process_id = 0;
-	OS::ProcessID current_process_id = 0;
+	ProcessID focused_process_id = 0;
+	ProcessID current_process_id = 0;
 	bool embedding_grab_focus = false;
 	bool embedding_completed = false;
 	uint64_t start_embedding_time = 0;
@@ -118,7 +118,7 @@ public:
 	bool is_embedding_in_progress() const override;
 	bool is_embedding_completed() const override;
 	bool is_process_focused() const override;
-	void embed_process(OS::ProcessID p_pid) override;
+	void embed_process(ProcessID p_pid) override;
 	int get_embedded_pid() const override;
 	void reset() override;
 	void reset_timers() override;

--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/debugger/debugger_marshalls.h"
 #include "core/object/class_db.h"
+#include "core/os/process_id.h"
 #include "core/string/translation_server.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"
@@ -461,7 +462,7 @@ void GameView::_play_pressed() {
 		return;
 	}
 
-	OS::ProcessID current_process_id = EditorRunBar::get_singleton()->get_current_process();
+	ProcessID current_process_id = EditorRunBar::get_singleton()->get_current_process();
 	if (current_process_id == 0) {
 		return;
 	}

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -30,9 +30,14 @@
 
 #include "tile_map_layer_editor.h"
 
-#include "core/object/class_db.h"
 #include "tiles_editor_plugin.h"
 
+#include "core/input/input.h"
+#include "core/math/geometry_2d.h"
+#include "core/math/random_pcg.h"
+#include "core/object/class_db.h"
+#include "core/os/keyboard.h"
+#include "core/os/os.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/inspector/editor_resource_preview.h"
@@ -45,11 +50,6 @@
 #include "scene/2d/tile_map_layer.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/split_container.h"
-
-#include "core/input/input.h"
-#include "core/math/geometry_2d.h"
-#include "core/math/random_pcg.h"
-#include "core/os/keyboard.h"
 
 void SwitchSeparator::set_vertical(bool p_vertical) {
 	h_separator->set_visible(p_vertical);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -51,6 +51,7 @@
 #include "core/object/message_queue.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"
+#include "core/os/process_id.h"
 #include "core/os/time.h"
 #include "core/profiling/profiling.h"
 #include "core/register_core_types.h"
@@ -217,7 +218,7 @@ static String locale;
 static String log_file;
 static bool show_help = false;
 static uint64_t quit_after = 0;
-static OS::ProcessID editor_pid = 0;
+static ProcessID editor_pid = 0;
 #ifdef TOOLS_ENABLED
 static bool found_project = false;
 static bool recovery_mode = false;

--- a/main/steam_tracker.cpp
+++ b/main/steam_tracker.cpp
@@ -33,6 +33,7 @@
 #include "steam_tracker.h"
 
 #include "core/io/file_access.h"
+#include "core/os/os.h"
 
 // https://partner.steamgames.com/doc/sdk/api#initialization_and_shutdown
 

--- a/main/steam_tracker.h
+++ b/main/steam_tracker.h
@@ -32,8 +32,6 @@
 
 #if defined(STEAMAPI_ENABLED)
 
-#include "core/os/os.h"
-
 // SteamTracker is used to load SteamAPI dynamic library and initialize
 // the interface, this notifies Steam that Godot editor is running and
 // allow tracking of the usage time of child instances of the engine

--- a/modules/fbx/register_types.cpp
+++ b/modules/fbx/register_types.cpp
@@ -39,6 +39,7 @@
 #include "editor/editor_scene_importer_fbx2gltf.h"
 #include "editor/editor_scene_importer_ufbx.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "editor/editor_node.h"
 

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -32,9 +32,15 @@
 
 #include "gdscript_test_runner.h"
 
-#include "modules/gdscript/gdscript_cache.h"
+#include "../gdscript_cache.h"
+
+#include "core/io/file_access.h"
 #include "tests/test_macros.h"
 #include "tests/test_utils.h"
+
+#ifdef TOOLS_ENABLED
+#include "core/os/os.h"
+#endif
 
 namespace GDScriptTests {
 

--- a/modules/gltf/editor/editor_import_blend_runner.cpp
+++ b/modules/gltf/editor/editor_import_blend_runner.cpp
@@ -32,6 +32,7 @@
 
 #include "core/io/http_client.h"
 #include "core/object/callable_method_pointer.h"
+#include "core/os/os.h"
 #include "editor/editor_node.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/settings/editor_settings.h"
@@ -178,6 +179,10 @@ Error EditorImportBlendRunner::start_blender(const String &p_python_script, bool
 		err = OS::get_singleton()->create_process(blender_path, args, &blender_pid);
 	}
 	return err;
+}
+
+bool EditorImportBlendRunner::is_running() {
+	return blender_pid != 0 && OS::get_singleton()->is_process_running(blender_pid);
 }
 
 Error EditorImportBlendRunner::do_import(const Dictionary &p_options) {

--- a/modules/gltf/editor/editor_import_blend_runner.h
+++ b/modules/gltf/editor/editor_import_blend_runner.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/io/http_client.h"
-#include "core/os/os.h"
+#include "core/os/process_id.h"
 #include "scene/main/node.h"
 #include "scene/main/timer.h"
 
@@ -48,7 +48,7 @@ class EditorImportBlendRunner : public Node {
 
 protected:
 	int rpc_port = 0;
-	OS::ProcessID blender_pid = 0;
+	ProcessID blender_pid = 0;
 	Error start_blender(const String &p_python_script, bool p_blocking);
 	Error do_import_direct(const Dictionary &p_options);
 	Error do_import_rpc(const Dictionary &p_options);
@@ -56,7 +56,7 @@ protected:
 public:
 	static EditorImportBlendRunner *get_singleton() { return singleton; }
 
-	bool is_running() { return blender_pid != 0 && OS::get_singleton()->is_process_running(blender_pid); }
+	bool is_running();
 	bool is_using_rpc() { return rpc_port != 0; }
 	Error do_import(const Dictionary &p_options);
 	HTTPClient::Status connect_blender_rpc(const Ref<HTTPClient> &p_client, int p_timeout_usecs);

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -50,6 +50,7 @@
 #include "editor/editor_scene_importer_blend.h"
 #include "editor/editor_scene_importer_gltf.h"
 
+#include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "editor/editor_node.h"
 #include "editor/settings/editor_settings.h"

--- a/modules/gltf/tests/test_gltf.h
+++ b/modules/gltf/tests/test_gltf.h
@@ -36,7 +36,6 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
-#include "core/os/os.h"
 #include "drivers/png/image_loader_png.h"
 #include "editor/import/3d/resource_importer_scene.h"
 #include "editor/import/resource_importer_texture.h"

--- a/modules/gltf/tests/test_gltf_extras.h
+++ b/modules/gltf/tests/test_gltf_extras.h
@@ -35,7 +35,6 @@
 
 #ifdef TOOLS_ENABLED
 
-#include "core/os/os.h"
 #include "editor/import/3d/resource_importer_scene.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/skeleton_3d.h"

--- a/modules/godot_physics_3d/register_types.cpp
+++ b/modules/godot_physics_3d/register_types.cpp
@@ -32,6 +32,7 @@
 
 #include "godot_physics_server_3d.h"
 
+#include "core/config/project_settings.h"
 #include "core/object/callable_method_pointer.h"
 #include "servers/physics_3d/physics_server_3d.h"
 #include "servers/physics_3d/physics_server_3d_wrap_mt.h"

--- a/modules/jolt_physics/register_types.cpp
+++ b/modules/jolt_physics/register_types.cpp
@@ -34,6 +34,7 @@
 #include "jolt_physics_server_3d.h"
 #include "jolt_project_settings.h"
 
+#include "core/config/project_settings.h"
 #include "core/object/callable_method_pointer.h"
 #include "servers/physics_3d/physics_server_3d_wrap_mt.h"
 

--- a/modules/text_server_fb/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_fb/thorvg_svg_in_ot.cpp
@@ -46,7 +46,6 @@ using namespace godot;
 #include "core/error/error_macros.h"
 #include "core/io/xml_parser.h"
 #include "core/os/memory.h"
-#include "core/os/os.h"
 #include "core/string/ustring.h"
 #include "core/typedefs.h"
 #include "core/variant/variant.h"

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -40,6 +40,7 @@
 #include "core/io/json.h"
 #include "core/io/marshalls.h"
 #include "core/math/random_pcg.h"
+#include "core/os/os.h"
 #include "core/string/translation_server.h"
 #include "core/version.h"
 #include "editor/editor_log.h"

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -38,7 +38,6 @@
 
 #include "core/io/image.h"
 #include "core/io/zip_io.h"
-#include "core/os/os.h"
 #include "editor/export/editor_export_platform.h"
 
 class ImageTexture;

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -30,6 +30,7 @@
 
 #include "gradle_export_util.h"
 
+#include "core/os/os.h"
 #include "core/string/translation_server.h"
 #include "modules/regex/regex.h"
 

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -34,7 +34,6 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/zip_io.h"
-#include "core/os/os.h"
 #include "editor/export/editor_export.h"
 #include "editor/export/editor_export_platform.h"
 #include "servers/display/display_server_enums.h"

--- a/platform/android/file_access_filesystem_jandroid.cpp
+++ b/platform/android/file_access_filesystem_jandroid.cpp
@@ -32,7 +32,6 @@
 
 #include "thread_jandroid.h"
 
-#include "core/os/os.h"
 #include "core/templates/local_vector.h"
 
 #include <unistd.h>

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -106,8 +106,6 @@ public:
 
 	virtual void finalize() override;
 
-	typedef int64_t ProcessID;
-
 	static OS_Android *get_singleton();
 	GodotJavaWrapper *get_godot_java();
 	GodotIOJavaWrapper *get_godot_io_java();

--- a/platform/linuxbsd/export/export_plugin.h
+++ b/platform/linuxbsd/export/export_plugin.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/file_access.h"
+#include "core/os/process_id.h"
 #include "editor/export/editor_export_platform_pc.h"
 #include "editor/settings/editor_settings.h"
 #include "scene/resources/image_texture.h"
@@ -61,7 +62,7 @@ class EditorExportPlatformLinuxBSD : public EditorExportPlatformPC {
 	Ref<ImageTexture> stop_icon;
 
 	Vector<SSHCleanupCommand> cleanup_commands;
-	OS::ProcessID ssh_pid = 0;
+	ProcessID ssh_pid = 0;
 	int menu_options = 0;
 
 	bool is_elf(const String &p_path) const;

--- a/platform/linuxbsd/freedesktop_at_spi_monitor.cpp
+++ b/platform/linuxbsd/freedesktop_at_spi_monitor.cpp
@@ -32,8 +32,6 @@
 
 #ifdef DBUS_ENABLED
 
-#include "core/os/os.h"
-
 #ifdef SOWRAP_ENABLED
 #include "dbus-so_wrap.h"
 #else

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1533,7 +1533,7 @@ bool DisplayServerWayland::get_swap_cancel_ok() {
 	return swap_cancel_ok;
 }
 
-Error DisplayServerWayland::embed_process(DisplayServerEnums::WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
+Error DisplayServerWayland::embed_process(DisplayServerEnums::WindowID p_window, ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
 	MutexLock mutex_lock(wayland_thread.mutex);
 
 	struct godot_embedding_compositor *ec = wayland_thread.get_embedding_compositor();
@@ -1585,7 +1585,7 @@ Error DisplayServerWayland::embed_process(DisplayServerEnums::WindowID p_window,
 	return OK;
 }
 
-Error DisplayServerWayland::request_close_embedded_process(OS::ProcessID p_pid) {
+Error DisplayServerWayland::request_close_embedded_process(ProcessID p_pid) {
 	MutexLock mutex_lock(wayland_thread.mutex);
 
 	struct godot_embedding_compositor *ec = wayland_thread.get_embedding_compositor();
@@ -1606,14 +1606,14 @@ Error DisplayServerWayland::request_close_embedded_process(OS::ProcessID p_pid) 
 	return OK;
 }
 
-Error DisplayServerWayland::remove_embedded_process(OS::ProcessID p_pid) {
+Error DisplayServerWayland::remove_embedded_process(ProcessID p_pid) {
 	return request_close_embedded_process(p_pid);
 }
 
-OS::ProcessID DisplayServerWayland::get_focused_process_id() {
+ProcessID DisplayServerWayland::get_focused_process_id() {
 	MutexLock mutex_lock(wayland_thread.mutex);
 
-	OS::ProcessID embedded_pid = wayland_thread.embedded_compositor_get_focused_pid();
+	ProcessID embedded_pid = wayland_thread.embedded_compositor_get_focused_pid();
 
 	if (embedded_pid < 0) {
 		return OS::get_singleton()->get_process_id();

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -34,6 +34,7 @@
 
 #include "wayland/wayland_thread.h"
 
+#include "core/os/process_id.h"
 #include "servers/display/display_server.h"
 
 class InputEvent;
@@ -322,10 +323,10 @@ public:
 
 	virtual bool get_swap_cancel_ok() override;
 
-	virtual Error embed_process(DisplayServerEnums::WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) override;
-	virtual Error request_close_embedded_process(OS::ProcessID p_pid) override;
-	virtual Error remove_embedded_process(OS::ProcessID p_pid) override;
-	virtual OS::ProcessID get_focused_process_id() override;
+	virtual Error embed_process(DisplayServerEnums::WindowID p_window, ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) override;
+	virtual Error request_close_embedded_process(ProcessID p_pid) override;
+	virtual Error remove_embedded_process(ProcessID p_pid) override;
+	virtual ProcessID get_focused_process_id() override;
 
 	virtual int keyboard_get_layout_count() const override;
 	virtual int keyboard_get_current_layout() const override;

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/engine.h"
 #include "core/io/image.h"
+#include "core/os/os.h"
 
 #ifdef WAYLAND_ENABLED
 
@@ -5497,7 +5498,7 @@ struct godot_embedding_compositor *WaylandThread::get_embedding_compositor() {
 	return registry.godot_embedding_compositor;
 }
 
-OS::ProcessID WaylandThread::embedded_compositor_get_focused_pid() {
+ProcessID WaylandThread::embedded_compositor_get_focused_pid() {
 	EmbeddingCompositorState *ecomp_state = godot_embedding_compositor_get_state(registry.godot_embedding_compositor);
 	ERR_FAIL_NULL_V(ecomp_state, -1);
 

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -88,7 +88,7 @@
 #endif // LIBDECOR_ENABLED
 
 #include "core/input/input_event.h"
-#include "core/os/os.h"
+#include "core/os/process_id.h"
 #include "core/os/thread.h"
 #include "servers/display/display_server_enums.h"
 
@@ -573,7 +573,7 @@ public:
 		// Only a client per PID can create a window.
 		HashMap<int, struct godot_embedded_client *> mapped_clients;
 
-		OS::ProcessID focused_pid = -1;
+		ProcessID focused_pid = -1;
 	};
 
 	struct EmbeddedClientState {
@@ -1204,7 +1204,7 @@ public:
 
 	struct godot_embedding_compositor *get_embedding_compositor();
 
-	OS::ProcessID embedded_compositor_get_focused_pid();
+	ProcessID embedded_compositor_get_focused_pid();
 
 	Error init();
 	void destroy();

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -6072,7 +6072,7 @@ void DisplayServerX11::_set_window_taskbar_pager_enabled(Window p_window, bool p
 	XSendEvent(x11_display, DefaultRootWindow(x11_display), False, SubstructureRedirectMask | SubstructureNotifyMask, (XEvent *)&xev);
 }
 
-Error DisplayServerX11::embed_process(DisplayServerEnums::WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
+Error DisplayServerX11::embed_process(DisplayServerEnums::WindowID p_window, ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_COND_V(!windows.has(p_window), FAILED);
@@ -6208,7 +6208,7 @@ Error DisplayServerX11::embed_process(DisplayServerEnums::WindowID p_window, OS:
 	return OK;
 }
 
-Error DisplayServerX11::request_close_embedded_process(OS::ProcessID p_pid) {
+Error DisplayServerX11::request_close_embedded_process(ProcessID p_pid) {
 	_THREAD_SAFE_METHOD_
 
 	if (!embedded_processes.has(p_pid)) {
@@ -6241,7 +6241,7 @@ Error DisplayServerX11::request_close_embedded_process(OS::ProcessID p_pid) {
 	return OK;
 }
 
-Error DisplayServerX11::remove_embedded_process(OS::ProcessID p_pid) {
+Error DisplayServerX11::remove_embedded_process(ProcessID p_pid) {
 	_THREAD_SAFE_METHOD_
 
 	if (!embedded_processes.has(p_pid)) {
@@ -6258,7 +6258,7 @@ Error DisplayServerX11::remove_embedded_process(OS::ProcessID p_pid) {
 	return OK;
 }
 
-OS::ProcessID DisplayServerX11::get_focused_process_id() {
+ProcessID DisplayServerX11::get_focused_process_id() {
 	Window focused_window = 0;
 	int revert_to = 0;
 

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -34,6 +34,7 @@
 
 #include "core/input/input_enums.h"
 #include "core/os/mutex.h"
+#include "core/os/process_id.h"
 #include "core/os/thread.h"
 #include "core/templates/local_vector.h"
 #include "servers/display/display_server.h"
@@ -373,7 +374,7 @@ class DisplayServerX11 : public DisplayServer {
 		Window process_window = 0;
 		bool visible = true;
 	};
-	HashMap<OS::ProcessID, EmbeddedProcessData *> embedded_processes;
+	HashMap<ProcessID, EmbeddedProcessData *> embedded_processes;
 
 	Point2i _get_window_position(Window p_window) const;
 	Rect2i _get_window_rect(Window p_window) const;
@@ -531,10 +532,10 @@ public:
 	virtual void window_start_drag(DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) override;
 	virtual void window_start_resize(DisplayServerEnums::WindowResizeEdge p_edge, DisplayServerEnums::WindowID p_window) override;
 
-	virtual Error embed_process(DisplayServerEnums::WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) override;
-	virtual Error request_close_embedded_process(OS::ProcessID p_pid) override;
-	virtual Error remove_embedded_process(OS::ProcessID p_pid) override;
-	virtual OS::ProcessID get_focused_process_id() override;
+	virtual Error embed_process(DisplayServerEnums::WindowID p_window, ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) override;
+	virtual Error request_close_embedded_process(ProcessID p_pid) override;
+	virtual Error remove_embedded_process(ProcessID p_pid) override;
+	virtual ProcessID get_focused_process_id() override;
 
 	virtual void cursor_set_shape(DisplayServerEnums::CursorShape p_shape) override;
 	virtual DisplayServerEnums::CursorShape cursor_get_shape() const override;

--- a/platform/linuxbsd/x11/gl_manager_x11.cpp
+++ b/platform/linuxbsd/x11/gl_manager_x11.cpp
@@ -32,6 +32,7 @@
 
 #if defined(X11_ENABLED) && defined(GLES3_ENABLED)
 
+#include "core/os/os.h"
 #include "servers/display/display_server.h"
 
 #include "thirdparty/glad/glad/glx.h"

--- a/platform/linuxbsd/x11/gl_manager_x11.h
+++ b/platform/linuxbsd/x11/gl_manager_x11.h
@@ -32,7 +32,7 @@
 
 #if defined(X11_ENABLED) && defined(GLES3_ENABLED)
 
-#include "core/os/os.h"
+#include "core/math/vector2i.h"
 #include "core/templates/local_vector.h"
 #include "servers/display/display_server_enums.h"
 

--- a/platform/linuxbsd/x11/gl_manager_x11_egl.h
+++ b/platform/linuxbsd/x11/gl_manager_x11_egl.h
@@ -32,7 +32,6 @@
 
 #if defined(X11_ENABLED) && defined(GLES3_ENABLED)
 
-#include "core/os/os.h"
 #include "core/templates/local_vector.h"
 #include "drivers/egl/egl_manager.h"
 #include "servers/display/display_server_enums.h"

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -37,6 +37,8 @@
 #include "gl_manager_macos_legacy.h"
 #endif // GLES3_ENABLED
 
+#include "core/os/process_id.h"
+
 #if defined(RD_ENABLED)
 #include "servers/rendering/rendering_device.h"
 
@@ -244,7 +246,7 @@ private:
 		WindowData *wd = nullptr;
 		CALayer *layer_host = nil;
 	};
-	HashMap<OS::ProcessID, EmbeddedProcessData> embedded_processes;
+	HashMap<ProcessID, EmbeddedProcessData> embedded_processes;
 #endif
 	void _window_update_display_id(WindowData *p_wd);
 
@@ -411,11 +413,11 @@ public:
 
 	virtual bool get_swap_cancel_ok() override;
 
-	virtual void enable_for_stealing_focus(OS::ProcessID pid) override;
+	virtual void enable_for_stealing_focus(ProcessID pid) override;
 #ifdef TOOLS_ENABLED
 	Error embed_process_update(DisplayServerEnums::WindowID p_window, EmbeddedProcessMacOS *p_process);
-	virtual Error request_close_embedded_process(OS::ProcessID p_pid) override;
-	virtual Error remove_embedded_process(OS::ProcessID p_pid) override;
+	virtual Error request_close_embedded_process(ProcessID p_pid) override;
+	virtual Error remove_embedded_process(ProcessID p_pid) override;
 #endif
 
 	void _process_events(bool p_pump);

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -58,6 +58,7 @@
 #include "core/object/callable_method_pointer.h"
 #include "core/os/keyboard.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #include "drivers/png/png_driver_common.h"
 #include "main/main.h"
 #include "scene/resources/image_texture.h"
@@ -2868,7 +2869,7 @@ void DisplayServerMacOS::update_screen_parameters() {
 	}
 
 #ifdef TOOLS_ENABLED
-	for (KeyValue<OS::ProcessID, EmbeddedProcessData> &E : embedded_processes) {
+	for (KeyValue<ProcessID, EmbeddedProcessData> &E : embedded_processes) {
 		E.value.process->display_state_changed();
 	}
 #endif
@@ -3039,7 +3040,7 @@ bool DisplayServerMacOS::get_swap_cancel_ok() {
 	return false;
 }
 
-void DisplayServerMacOS::enable_for_stealing_focus(OS::ProcessID pid) {
+void DisplayServerMacOS::enable_for_stealing_focus(ProcessID pid) {
 }
 
 #define GET_OR_FAIL_V(m_val, m_map, m_key, m_retval) \
@@ -3065,7 +3066,7 @@ void DisplayServerMacOS::_window_update_display_id(WindowData *p_wd) {
 
 #ifdef TOOLS_ENABLED
 	// Notify any embedded processes of the new display ID, so that they can potentially update their vsync.
-	for (KeyValue<OS::ProcessID, EmbeddedProcessData> &E : embedded_processes) {
+	for (KeyValue<ProcessID, EmbeddedProcessData> &E : embedded_processes) {
 		if (E.value.wd == p_wd) {
 			E.value.process->display_state_changed();
 		}
@@ -3081,7 +3082,7 @@ Error DisplayServerMacOS::embed_process_update(DisplayServerEnums::WindowID p_wi
 	WindowData *wd;
 	GET_OR_FAIL_V(wd, windows, p_window, FAILED);
 
-	OS::ProcessID p_pid = p_process->get_embedded_pid();
+	ProcessID p_pid = p_process->get_embedded_pid();
 
 	[CATransaction begin];
 	[CATransaction setDisableActions:YES];
@@ -3118,11 +3119,11 @@ Error DisplayServerMacOS::embed_process_update(DisplayServerEnums::WindowID p_wi
 	return OK;
 }
 
-Error DisplayServerMacOS::request_close_embedded_process(OS::ProcessID p_pid) {
+Error DisplayServerMacOS::request_close_embedded_process(ProcessID p_pid) {
 	return OK;
 }
 
-Error DisplayServerMacOS::remove_embedded_process(OS::ProcessID p_pid) {
+Error DisplayServerMacOS::remove_embedded_process(ProcessID p_pid) {
 	_THREAD_SAFE_METHOD_
 
 	EmbeddedProcessData *ed;

--- a/platform/macos/display_server_macos_base.mm
+++ b/platform/macos/display_server_macos_base.mm
@@ -35,6 +35,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #include "drivers/png/png_driver_common.h"
 
 #if defined(RD_ENABLED)

--- a/platform/macos/display_server_macos_embedded.mm
+++ b/platform/macos/display_server_macos_embedded.mm
@@ -58,6 +58,7 @@
 #import "core/input/input_event.h"
 #import "core/io/marshalls.h"
 #import "core/os/main_loop.h"
+#import "core/os/os.h"
 #import "servers/display/native_menu.h"
 
 DisplayServerMacOSEmbedded::DisplayServerMacOSEmbedded(const String &p_rendering_driver, DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, DisplayServerEnums::Context p_context, Error &r_error) {

--- a/platform/macos/editor/embedded_game_view_plugin.mm
+++ b/platform/macos/editor/embedded_game_view_plugin.mm
@@ -32,6 +32,7 @@
 
 #include "embedded_process_macos.h"
 
+#include "core/config/engine.h"
 #include "core/input/input.h"
 #include "editor/editor_node.h"
 #include "editor/gui/window_wrapper.h"

--- a/platform/macos/editor/embedded_process_macos.h
+++ b/platform/macos/editor/embedded_process_macos.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/class_db.h"
+#include "core/os/process_id.h"
 #include "editor/run/embedded_process.h"
 #include "scene/gui/control.h"
 #include "servers/display/display_server_enums.h"
@@ -85,7 +86,7 @@ class EmbeddedProcessMacOS final : public EmbeddedProcessBase {
 	uint32_t context_id = 0;
 	ScriptEditorDebugger *script_debugger = nullptr;
 	LayerHost *layer_host = nullptr;
-	OS::ProcessID current_process_id = 0;
+	ProcessID current_process_id = 0;
 
 	// Embedded process state.
 
@@ -118,7 +119,7 @@ public:
 	}
 
 	bool is_process_focused() const override { return layer_host->has_focus(); }
-	void embed_process(OS::ProcessID p_pid) override;
+	void embed_process(ProcessID p_pid) override;
 	int get_embedded_pid() const override { return current_process_id; }
 	void reset() override;
 	void reset_timers() override {}

--- a/platform/macos/editor/embedded_process_macos.mm
+++ b/platform/macos/editor/embedded_process_macos.mm
@@ -35,6 +35,7 @@
 
 #include "core/input/input_event_codec.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
@@ -79,7 +80,7 @@ void EmbeddedProcessMacOS::set_script_debugger(ScriptEditorDebugger *p_debugger)
 	_try_embed_process();
 }
 
-void EmbeddedProcessMacOS::embed_process(OS::ProcessID p_pid) {
+void EmbeddedProcessMacOS::embed_process(ProcessID p_pid) {
 	if (!window) {
 		return;
 	}

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -36,6 +36,7 @@
 #include "core/io/image_loader.h"
 #include "core/io/plist.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "core/string/translation_server.h"
 #include "drivers/png/png_driver_common.h"
 #include "editor/editor_node.h"

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -36,7 +36,7 @@
 #include "core/io/image.h"
 #include "core/io/marshalls.h"
 #include "core/io/resource_saver.h"
-#include "core/os/os.h"
+#include "core/os/process_id.h"
 #include "editor/export/editor_export.h"
 #include "editor/settings/editor_settings.h"
 #include "scene/resources/image_texture.h"
@@ -82,7 +82,7 @@ class EditorExportPlatformMacOS : public EditorExportPlatform {
 	Ref<ImageTexture> stop_icon;
 
 	Vector<SSHCleanupCommand> cleanup_commands;
-	OS::ProcessID ssh_pid = 0;
+	ProcessID ssh_pid = 0;
 	int menu_options = 0;
 
 	void _fix_privacy_manifest(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &plist);

--- a/platform/macos/godot_application.h
+++ b/platform/macos/godot_application.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#include "core/os/os.h"
-
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
 #import <IOKit/hidsystem/ev_keymap.h>

--- a/platform/macos/godot_application_delegate.h
+++ b/platform/macos/godot_application_delegate.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#include "core/os/os.h"
-
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
 

--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -37,6 +37,7 @@
 #include "core/input/input.h"
 #include "core/input/input_event.h"
 #include "core/os/keyboard.h"
+#include "core/os/os.h"
 #include "core/profiling/profiling.h"
 #include "main/main.h"
 

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -31,17 +31,20 @@
 #import "os_macos.h"
 
 #import "dir_access_macos.h"
-#ifdef TOOLS_ENABLED
-#import "display_server_macos_embedded.h"
-#endif
 #import "display_server_macos.h"
 #import "godot_application.h"
 #import "godot_application_delegate.h"
 
+#ifdef TOOLS_ENABLED
+#import "display_server_macos_embedded.h"
+#endif
+
+#include "core/config/engine.h"
 #include "core/crypto/crypto_core.h"
 #include "core/input/input.h"
 #include "core/io/file_access.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #include "core/profiling/profiling.h"
 #include "core/version_generated.gen.h"
 #include "drivers/apple/os_log_logger.h"

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -43,6 +43,7 @@
 #include "core/io/xml_parser.h"
 #include "core/object/callable_method_pointer.h"
 #include "core/os/main_loop.h"
+#include "core/os/os.h"
 #include "core/version.h"
 #include "drivers/png/png_driver_common.h"
 #include "main/main.h"
@@ -3321,7 +3322,7 @@ bool DisplayServerWindows::get_swap_cancel_ok() {
 	return true;
 }
 
-void DisplayServerWindows::enable_for_stealing_focus(OS::ProcessID pid) {
+void DisplayServerWindows::enable_for_stealing_focus(ProcessID pid) {
 	_THREAD_SAFE_METHOD_
 
 	AllowSetForegroundWindow(pid);
@@ -3352,7 +3353,7 @@ static BOOL CALLBACK _enum_proc_find_window_from_process_id_callback(HWND hWnd, 
 	return TRUE;
 }
 
-HWND DisplayServerWindows::_find_window_from_process_id(OS::ProcessID p_pid, HWND p_current_hwnd) {
+HWND DisplayServerWindows::_find_window_from_process_id(ProcessID p_pid, HWND p_current_hwnd) {
 	DWORD pid = p_pid;
 	WindowEnumData ed = { pid, p_current_hwnd, NULL };
 
@@ -3461,7 +3462,7 @@ void DisplayServerWindows::_update_hdr_output_for_tracked_windows() {
 	}
 }
 
-Error DisplayServerWindows::embed_process(DisplayServerEnums::WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
+Error DisplayServerWindows::embed_process(DisplayServerEnums::WindowID p_window, ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_COND_V(!windows.has(p_window), FAILED);
@@ -3517,7 +3518,7 @@ Error DisplayServerWindows::embed_process(DisplayServerEnums::WindowID p_window,
 	return OK;
 }
 
-Error DisplayServerWindows::request_close_embedded_process(OS::ProcessID p_pid) {
+Error DisplayServerWindows::request_close_embedded_process(ProcessID p_pid) {
 	_THREAD_SAFE_METHOD_
 
 	if (!embedded_processes.has(p_pid)) {
@@ -3532,7 +3533,7 @@ Error DisplayServerWindows::request_close_embedded_process(OS::ProcessID p_pid) 
 	return OK;
 }
 
-Error DisplayServerWindows::remove_embedded_process(OS::ProcessID p_pid) {
+Error DisplayServerWindows::remove_embedded_process(ProcessID p_pid) {
 	_THREAD_SAFE_METHOD_
 
 	if (!embedded_processes.has(p_pid)) {
@@ -3582,7 +3583,7 @@ Error DisplayServerWindows::remove_embedded_process(OS::ProcessID p_pid) {
 	return OK;
 }
 
-OS::ProcessID DisplayServerWindows::get_focused_process_id() {
+ProcessID DisplayServerWindows::get_focused_process_id() {
 	HWND hwnd = GetForegroundWindow();
 	if (!hwnd) {
 		return 0;

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -37,7 +37,7 @@
 #include "core/config/project_settings.h"
 #include "core/input/input_event.h"
 #include "core/io/image.h"
-#include "core/os/os.h"
+#include "core/os/process_id.h"
 #include "core/templates/rb_map.h"
 #include "drivers/wasapi/audio_driver_wasapi.h"
 #include "drivers/winmidi/midi_driver_winmidi.h"
@@ -541,9 +541,9 @@ class DisplayServerWindows : public DisplayServer {
 		HWND parent_window_handle = 0;
 		bool is_visible = false;
 	};
-	HashMap<OS::ProcessID, EmbeddedProcessData *> embedded_processes;
+	HashMap<ProcessID, EmbeddedProcessData *> embedded_processes;
 
-	HWND _find_window_from_process_id(OS::ProcessID p_pid, HWND p_current_hwnd);
+	HWND _find_window_from_process_id(ProcessID p_pid, HWND p_current_hwnd);
 
 	void initialize_tts() const;
 
@@ -732,11 +732,11 @@ public:
 
 	virtual bool get_swap_cancel_ok() override;
 
-	virtual void enable_for_stealing_focus(OS::ProcessID pid) override;
-	virtual Error embed_process(DisplayServerEnums::WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) override;
-	virtual Error request_close_embedded_process(OS::ProcessID p_pid) override;
-	virtual Error remove_embedded_process(OS::ProcessID p_pid) override;
-	virtual OS::ProcessID get_focused_process_id() override;
+	virtual void enable_for_stealing_focus(ProcessID pid) override;
+	virtual Error embed_process(DisplayServerEnums::WindowID p_window, ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) override;
+	virtual Error request_close_embedded_process(ProcessID p_pid) override;
+	virtual Error remove_embedded_process(ProcessID p_pid) override;
+	virtual ProcessID get_focused_process_id() override;
 
 	virtual Error dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback) override;
 	virtual Error dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback) override;

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -37,6 +37,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/image_loader.h"
+#include "core/os/os.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/export/editor_export.h"

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/io/file_access.h"
-#include "core/os/os.h"
+#include "core/os/process_id.h"
 #include "editor/export/editor_export_platform_pc.h"
 #include "editor/settings/editor_settings.h"
 
@@ -65,7 +65,7 @@ class EditorExportPlatformWindows : public EditorExportPlatformPC {
 	Ref<ImageTexture> stop_icon;
 
 	Vector<SSHCleanupCommand> cleanup_commands;
-	OS::ProcessID ssh_pid = 0;
+	ProcessID ssh_pid = 0;
 	int menu_options = 0;
 
 	Error _process_icon(const Ref<EditorExportPreset> &p_preset, const String &p_src_path, const String &p_dst_path);

--- a/platform/windows/gl_manager_windows_angle.h
+++ b/platform/windows/gl_manager_windows_angle.h
@@ -32,7 +32,6 @@
 
 #if defined(WINDOWS_ENABLED) && defined(GLES3_ENABLED)
 
-#include "core/os/os.h"
 #include "core/templates/local_vector.h"
 #include "drivers/egl/egl_manager.h"
 #include "servers/display/display_server_enums.h"

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -33,6 +33,7 @@
 #if defined(WINDOWS_ENABLED) && defined(GLES3_ENABLED)
 
 #include "core/config/project_settings.h"
+#include "core/os/os.h"
 #include "core/version.h"
 
 #include "thirdparty/misc/nvapi_minimal.h"

--- a/platform/windows/gl_manager_windows_native.h
+++ b/platform/windows/gl_manager_windows_native.h
@@ -32,7 +32,6 @@
 
 #if defined(WINDOWS_ENABLED) && defined(GLES3_ENABLED)
 
-#include "core/os/os.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/rb_map.h"
 #include "servers/display/display_server_enums.h"

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -32,7 +32,6 @@
 
 #include "core/config/engine.h"
 #include "core/object/class_db.h"
-#include "core/os/os.h"
 #include "servers/audio/audio_server.h"
 #include "servers/display/accessibility_server.h"
 

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -59,6 +59,16 @@ void AudioDriver::set_singleton() {
 	singleton = this;
 }
 
+#ifdef DEBUG_ENABLED
+void AudioDriver::start_counting_ticks() {
+	prof_ticks.set(OS::get_singleton()->get_ticks_usec());
+}
+
+void AudioDriver::stop_counting_ticks() {
+	prof_time.add(OS::get_singleton()->get_ticks_usec() - prof_ticks.get());
+}
+#endif // DEBUG_ENABLED
+
 void AudioDriver::audio_server_process(int p_frames, int32_t *p_buffer, bool p_update_mix_time) {
 	if (p_update_mix_time) {
 		update_mix_time(p_frames);

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -32,7 +32,6 @@
 
 #include "core/math/audio_frame.h"
 #include "core/object/class_db.h"
-#include "core/os/os.h"
 #include "core/templates/safe_list.h"
 #include "core/variant/variant.h"
 #include "servers/audio/audio_effect.h"
@@ -70,8 +69,8 @@ protected:
 	int _get_configured_mix_rate();
 
 #ifdef DEBUG_ENABLED
-	_FORCE_INLINE_ void start_counting_ticks() { prof_ticks.set(OS::get_singleton()->get_ticks_usec()); }
-	_FORCE_INLINE_ void stop_counting_ticks() { prof_time.add(OS::get_singleton()->get_ticks_usec() - prof_ticks.get()); }
+	void start_counting_ticks();
+	void stop_counting_ticks();
 #else
 	_FORCE_INLINE_ void start_counting_ticks() {}
 	_FORCE_INLINE_ void stop_counting_ticks() {}

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -38,6 +38,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 
 #include "core/input/input.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "scene/resources/texture.h"
 #include "servers/display/accessibility_server.h"
 #include "servers/display/display_server_headless.h"
@@ -1154,25 +1155,25 @@ bool DisplayServer::get_swap_cancel_ok() {
 	return false;
 }
 
-void DisplayServer::enable_for_stealing_focus(OS::ProcessID pid) {
+void DisplayServer::enable_for_stealing_focus(ProcessID pid) {
 }
 
-Error DisplayServer::embed_process(DisplayServerEnums::WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
+Error DisplayServer::embed_process(DisplayServerEnums::WindowID p_window, ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
 	WARN_PRINT("Embedded process not supported by this display server.");
 	return ERR_UNAVAILABLE;
 }
 
-Error DisplayServer::request_close_embedded_process(OS::ProcessID p_pid) {
+Error DisplayServer::request_close_embedded_process(ProcessID p_pid) {
 	WARN_PRINT("Embedded process not supported by this display server.");
 	return ERR_UNAVAILABLE;
 }
 
-Error DisplayServer::remove_embedded_process(OS::ProcessID p_pid) {
+Error DisplayServer::remove_embedded_process(ProcessID p_pid) {
 	WARN_PRINT("Embedded process not supported by this display server.");
 	return ERR_UNAVAILABLE;
 }
 
-OS::ProcessID DisplayServer::get_focused_process_id() {
+ProcessID DisplayServer::get_focused_process_id() {
 	WARN_PRINT("Embedded process not supported by this display server.");
 	return 0;
 }

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -34,7 +34,7 @@
 #include "core/io/resource.h"
 #include "core/object/object.h"
 #include "core/os/keyboard.h"
-#include "core/os/os.h"
+#include "core/os/process_id.h"
 #include "core/variant/callable.h"
 #include "core/variant/typed_array.h"
 #include "servers/display/display_server_enums.h"
@@ -486,12 +486,12 @@ public:
 
 	/* PROCESS */
 
-	virtual void enable_for_stealing_focus(OS::ProcessID pid);
+	virtual void enable_for_stealing_focus(ProcessID pid);
 
-	virtual Error embed_process(DisplayServerEnums::WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus);
-	virtual Error request_close_embedded_process(OS::ProcessID p_pid);
-	virtual Error remove_embedded_process(OS::ProcessID p_pid);
-	virtual OS::ProcessID get_focused_process_id();
+	virtual Error embed_process(DisplayServerEnums::WindowID p_window, ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus);
+	virtual Error request_close_embedded_process(ProcessID p_pid);
+	virtual Error remove_embedded_process(ProcessID p_pid);
+	virtual ProcessID get_focused_process_id();
 
 	/* DIALOGS */
 

--- a/servers/physics_2d/physics_server_2d_wrap_mt.h
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.h
@@ -53,6 +53,13 @@
 #endif
 #endif
 
+#define ServerName PhysicsServer2D
+#define ServerNameWrapMT PhysicsServer2DWrapMT
+#define server_name physics_server_2d
+#define WRITE_ACTION
+
+#include "servers/server_wrap_mt_common.h"
+
 class PhysicsServer2DWrapMT : public PhysicsServer2D {
 	GDSOFTCLASS(PhysicsServer2DWrapMT, PhysicsServer2D);
 
@@ -72,13 +79,6 @@ class PhysicsServer2DWrapMT : public PhysicsServer2D {
 	void _thread_sync();
 
 public:
-#define ServerName PhysicsServer2D
-#define ServerNameWrapMT PhysicsServer2DWrapMT
-#define server_name physics_server_2d
-#define WRITE_ACTION
-
-#include "servers/server_wrap_mt_common.h"
-
 	//FUNC1RID(shape,ShapeType); todo fix
 	FUNCRID(world_boundary_shape)
 	FUNCRID(separation_ray_shape)

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/config/project_settings.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/os/thread.h"
 #include "core/templates/command_queue_mt.h"
@@ -54,6 +53,13 @@
 #endif
 #endif
 
+#define ServerName PhysicsServer3D
+#define ServerNameWrapMT PhysicsServer3DWrapMT
+#define server_name physics_server_3d
+#define WRITE_ACTION
+
+#include "servers/server_wrap_mt_common.h"
+
 class PhysicsServer3DWrapMT : public PhysicsServer3D {
 	GDSOFTCLASS(PhysicsServer3DWrapMT, PhysicsServer3D);
 
@@ -74,13 +80,6 @@ class PhysicsServer3DWrapMT : public PhysicsServer3D {
 	void _thread_sync();
 
 public:
-#define ServerName PhysicsServer3D
-#define ServerNameWrapMT PhysicsServer3DWrapMT
-#define server_name physics_server_3d
-#define WRITE_ACTION
-
-#include "servers/server_wrap_mt_common.h"
-
 	//FUNC1RID(shape,ShapeType); todo fix
 	FUNCRID(world_boundary_shape)
 	FUNCRID(separation_ray_shape)
@@ -414,12 +413,12 @@ public:
 
 	PhysicsServer3DWrapMT(PhysicsServer3D *p_contained, bool p_create_thread);
 	~PhysicsServer3DWrapMT();
+};
 
 #undef ServerNameWrapMT
 #undef ServerName
 #undef server_name
 #undef WRITE_ACTION
-};
 
 #ifdef DEBUG_SYNC
 #undef DEBUG_SYNC

--- a/servers/server_wrap_mt_common.h
+++ b/servers/server_wrap_mt_common.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "core/config/engine.h"
+
 #ifdef DEBUG_ENABLED
 #define MAIN_THREAD_SYNC_CHECK \
 	if (unlikely(Thread::is_main_thread() && Engine::get_singleton()->notify_frame_server_synced())) { \


### PR DESCRIPTION
- Helps address #111218
- Builds upon #117054 which helps minimize the diff

With this change, an incremental rebuild after editing `os.h` on my machine changes like this:

- Before: 00:02:56.60
- After: 00:01:14.27

I reviewed all headers that still include `os.h` after this PR, they can't be reduced further:
```
$ rg -g'*.h' "core/os/os.h" -l
drivers/unix/os_unix.h
platform/windows/os_windows.h
modules/gdscript/tests/gdscript_test_runner_suite.h
```
(Actually `gdscript_test_runner_suite.h` doesn't seem included anywhere, so it seems to be dead code? CC @dalexeev - *Edit:* It's included in `modules_tests.gen.h`, which `ripgrep` ignores so I didn't find it initially.)

As for .cpp files, I reviewed them all manually to ensure they all use `OS::` explicitly, and removed the include otherwise.