### PR TITLE
Core: Get rid of all unnecessary `class_db.h` includers

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -39,6 +39,7 @@
 #include "core/input/input.h"
 #include "core/io/resource_loader.h"
 #include "core/math/expression.h"
+#include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"
 #include "servers/display/display_server.h"

--- a/core/debugger/remote_debugger.h
+++ b/core/debugger/remote_debugger.h
@@ -33,7 +33,6 @@
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/remote_debugger_peer.h"
-#include "core/object/class_db.h"
 #include "core/string/string_name.h"
 #include "core/string/ustring.h"
 #include "core/variant/array.h"

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -35,6 +35,7 @@
 #include "core/extension/gdextension_special_compat_hashes.h"
 #include "core/io/file_access.h"
 #include "core/io/json.h"
+#include "core/object/class_db.h"
 #include "core/templates/pair.h"
 #include "core/version.h"
 

--- a/core/extension/godot_instance.h
+++ b/core/extension/godot_instance.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "core/extension/gdextension_interface.gen.h"
-#include "core/object/class_db.h"
+#include "core/object/object.h"
 
 class GodotInstance : public Object {
 	GDCLASS(GodotInstance, Object);

--- a/core/io/packet_peer.h
+++ b/core/io/packet_peer.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "core/io/stream_peer.h"
-#include "core/object/class_db.h"
 #include "core/templates/ring_buffer.h"
 
 #include "core/extension/ext_wrappers.gen.h"

--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -30,8 +30,8 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
 #include "core/object/ref_counted.h"
+#include "core/variant/binder_common.h"
 
 class UndoRedo : public Object {
 	GDCLASS(UndoRedo, Object);

--- a/core/os/time.h
+++ b/core/os/time.h
@@ -30,7 +30,8 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
+#include "core/object/object.h"
+#include "core/variant/binder_common.h"
 #include "time_enums.h"
 
 // This Time class conforms with as many of the ISO 8601 standards as possible.

--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -35,9 +35,10 @@
 #include "core/crypto/crypto_core.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/io/compression.h"
-#include "core/object/class_db.h"
 #include "core/templates/a_hash_map.h"
 #include "core/templates/local_vector.h"
+#include "core/variant/native_ptr.h"
+#include "core/variant/variant_internal.h"
 
 template <typename T>
 struct PtrConstruct {};

--- a/core/variant/variant_destruct.h
+++ b/core/variant/variant_destruct.h
@@ -30,9 +30,8 @@
 
 #pragma once
 
+#include "core/variant/type_info.h"
 #include "core/variant/variant.h"
-
-#include "core/object/class_db.h"
 
 template <typename T>
 struct VariantDestruct {};

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -33,7 +33,7 @@
 #include "variant.h"
 
 #include "core/debugger/engine_debugger.h"
-#include "core/object/class_db.h"
+#include "core/variant/native_ptr.h"
 
 template <typename Evaluator>
 class CommonEvaluate {

--- a/core/variant/variant_setget.h
+++ b/core/variant/variant_setget.h
@@ -33,7 +33,7 @@
 #include "variant.h"
 
 #include "core/debugger/engine_debugger.h"
-#include "core/object/class_db.h"
+#include "core/variant/native_ptr.h"
 #include "core/variant/variant_internal.h"
 
 /**** NAMED SETTERS AND GETTERS ****/

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -34,6 +34,7 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
+#include "core/math/math_funcs_binary.h"
 #include "core/os/os.h"
 
 #include <cerrno>

--- a/drivers/apple_embedded/apple_embedded.h
+++ b/drivers/apple_embedded/apple_embedded.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
+#include "core/object/object.h"
 
 #import <CoreHaptics/CoreHaptics.h>
 

--- a/drivers/coreaudio/audio_driver_coreaudio.mm
+++ b/drivers/coreaudio/audio_driver_coreaudio.mm
@@ -34,6 +34,7 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
+#include "core/math/math_funcs_binary.h"
 #include "core/os/os.h"
 
 #define kOutputBus 0

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -34,6 +34,7 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
+#include "core/math/math_funcs_binary.h"
 #include "core/os/os.h"
 #include "core/version.h"
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "core/io/resource.h"
-#include "core/object/class_db.h"
 #include "core/object/object.h"
 #include "core/object/script_language.h"
 

--- a/editor/file_system/editor_paths.h
+++ b/editor/file_system/editor_paths.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
 #include "core/object/object.h"
 #include "core/string/ustring.h"
 

--- a/editor/inspector/editor_preview_plugins.cpp
+++ b/editor/inspector/editor_preview_plugins.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/image.h"
 #include "core/io/resource_loader.h"
+#include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "editor/file_system/editor_paths.h"
 #include "editor/settings/editor_settings.h"

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -33,6 +33,7 @@
 #include "core/input/input.h"
 #include "core/io/marshalls.h"
 #include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/project_upgrade/project_converter_3_to_4.cpp
+++ b/editor/project_upgrade/project_converter_3_to_4.cpp
@@ -35,6 +35,7 @@
 #include "core/error/error_macros.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
+#include "core/object/class_db.h"
 #include "core/object/ref_counted.h"
 #include "core/os/keyboard.h"
 #include "core/os/time.h"

--- a/editor/project_upgrade/project_upgrade_tool.h
+++ b/editor/project_upgrade/project_upgrade_tool.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
+#include "core/object/object.h"
 
 class ConfirmationDialog;
 class EditorFileSystemDirectory;

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -31,6 +31,7 @@
 #include "register_editor_types.h"
 
 #include "core/config/engine.h"
+#include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"
 #include "editor/animation/animation_tree_editor_plugin.h"

--- a/editor/scene/2d/scene_paint_2d_editor_plugin.cpp
+++ b/editor/scene/2d/scene_paint_2d_editor_plugin.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/docks/scene_tree_dock.h"

--- a/editor/scene/2d/tiles/atlas_merging_dialog.cpp
+++ b/editor/scene/2d/tiles/atlas_merging_dialog.cpp
@@ -31,6 +31,7 @@
 #include "atlas_merging_dialog.h"
 
 #include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/themes/editor_scale.h"

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -34,6 +34,7 @@
 #include "tiles_editor_plugin.h"
 
 #include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/file_system/editor_file_system.h"

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -36,6 +36,7 @@
 #include "core/io/json.h"
 #include "core/math/expression.h"
 #include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
 #include "core/os/keyboard.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/doc/editor_help.h"

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -48,6 +48,7 @@
 #include "core/io/image_loader.h"
 #include "core/io/ip.h"
 #include "core/io/resource_loader.h"
+#include "core/object/class_db.h"
 #include "core/object/message_queue.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"

--- a/main/performance.h
+++ b/main/performance.h
@@ -30,8 +30,9 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
+#include "core/object/object.h"
 #include "core/templates/hash_map.h"
+#include "core/variant/binder_common.h"
 
 #define PERF_WARN_OFFLINE_FUNCTION
 #define PERF_WARN_PROCESS_SYNC

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -32,6 +32,7 @@
 
 #include "core/math/geometry_3d.h"
 #include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/scene/3d/gizmos/gizmo_3d_helper.h"

--- a/modules/enet/register_types.cpp
+++ b/modules/enet/register_types.cpp
@@ -35,6 +35,7 @@
 #include "enet_packet_peer.h"
 
 #include "core/error/error_macros.h"
+#include "core/object/class_db.h"
 
 static bool enet_ok = false;
 

--- a/modules/fbx/register_types.cpp
+++ b/modules/fbx/register_types.cpp
@@ -34,6 +34,7 @@
 #include "fbx_document.h"
 
 #include "core/config/engine.h"
+#include "core/object/class_db.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_scene_importer_fbx2gltf.h"

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -35,6 +35,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/core_constants.h"
+#include "core/object/class_db.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_theme_manager.h"
 #include "scene/gui/text_edit.h"

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -36,6 +36,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
 #include "core/math/math_defs.h"
+#include "core/object/class_db.h"
 #include "scene/main/multiplayer_api.h"
 
 #ifdef DEBUG_ENABLED

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -39,6 +39,7 @@
 #include "structures/gltf_object_model_property.h"
 
 #include "core/config/engine.h"
+#include "core/object/class_db.h"
 
 #ifndef PHYSICS_3D_DISABLED
 #include "extensions/physics/gltf_document_extension_physics.h"

--- a/modules/jpg/register_types.cpp
+++ b/modules/jpg/register_types.cpp
@@ -33,6 +33,8 @@
 #include "image_loader_libjpeg_turbo.h"
 #include "movie_writer_mjpeg.h"
 
+#include "core/object/class_db.h"
+
 static Ref<ImageLoaderLibJPEGTurbo> image_loader_libjpeg_turbo;
 static MovieWriterMJPEG *writer_mjpeg = nullptr;
 

--- a/modules/jsonrpc/jsonrpc.h
+++ b/modules/jsonrpc/jsonrpc.h
@@ -30,7 +30,8 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
+#include "core/object/object.h"
+#include "core/variant/binder_common.h"
 #include "core/variant/variant.h"
 
 class JSONRPC : public Object {

--- a/modules/mbedtls/dtls_server_mbedtls.cpp
+++ b/modules/mbedtls/dtls_server_mbedtls.cpp
@@ -32,6 +32,8 @@
 
 #include "packet_peer_mbed_dtls.h"
 
+#include "core/object/class_db.h"
+
 Error DTLSServerMbedTLS::setup(Ref<TLSOptions> p_options) {
 	ERR_FAIL_COND_V(p_options.is_null() || !p_options->is_server(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(cookies->setup() != OK, ERR_ALREADY_IN_USE);

--- a/modules/mbedtls/packet_peer_mbed_dtls.cpp
+++ b/modules/mbedtls/packet_peer_mbed_dtls.cpp
@@ -30,6 +30,8 @@
 
 #include "packet_peer_mbed_dtls.h"
 
+#include "core/object/class_db.h"
+
 int PacketPeerMbedDTLS::bio_send(void *ctx, const unsigned char *buf, size_t len) {
 	if (buf == nullptr || len == 0) {
 		return 0;

--- a/modules/mp3/register_types.cpp
+++ b/modules/mp3/register_types.cpp
@@ -32,6 +32,8 @@
 
 #include "audio_stream_mp3.h"
 
+#include "core/object/class_db.h"
+
 #ifdef TOOLS_ENABLED
 #include "core/config/engine.h"
 #include "editor/editor_node.h"

--- a/modules/multiplayer/register_types.cpp
+++ b/modules/multiplayer/register_types.cpp
@@ -37,6 +37,8 @@
 #include "scene_replication_interface.h"
 #include "scene_rpc_interface.h"
 
+#include "core/object/class_db.h"
+
 #ifdef TOOLS_ENABLED
 #include "editor/multiplayer_editor_plugin.h"
 #endif

--- a/modules/multiplayer/tests/test_multiplayer_spawner.h
+++ b/modules/multiplayer/tests/test_multiplayer_spawner.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/class_db.h"
 #include "tests/test_macros.h"
 #include "tests/test_utils.h"
 

--- a/modules/navigation_2d/2d/nav_mesh_generator_2d.h
+++ b/modules/navigation_2d/2d/nav_mesh_generator_2d.h
@@ -32,7 +32,7 @@
 
 #ifdef CLIPPER2_ENABLED
 
-#include "core/object/class_db.h"
+#include "core/object/object.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/templates/rid_owner.h"
 #include "servers/navigation_2d/navigation_server_2d.h"

--- a/modules/navigation_2d/nav_agent_2d.h
+++ b/modules/navigation_2d/nav_agent_2d.h
@@ -32,8 +32,10 @@
 
 #include "nav_rid_2d.h"
 
-#include "core/object/class_db.h"
+#include "core/math/vector2.h"
 #include "core/templates/self_list.h"
+#include "core/variant/callable.h"
+#include "core/variant/dictionary.h"
 #include "servers/navigation_2d/navigation_constants_2d.h"
 
 #include <Agent2d.h>

--- a/modules/navigation_2d/nav_obstacle_2d.h
+++ b/modules/navigation_2d/nav_obstacle_2d.h
@@ -32,8 +32,9 @@
 
 #include "nav_rid_2d.h"
 
-#include "core/object/class_db.h"
+#include "core/math/vector2.h"
 #include "core/templates/self_list.h"
+#include "core/templates/vector.h"
 
 class NavAgent2D;
 class NavMap2D;

--- a/modules/navigation_3d/3d/nav_mesh_generator_3d.h
+++ b/modules/navigation_3d/3d/nav_mesh_generator_3d.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
+#include "core/object/object.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/templates/rid_owner.h"
 #include "servers/navigation_3d/navigation_server_3d.h"

--- a/modules/navigation_3d/nav_agent_3d.h
+++ b/modules/navigation_3d/nav_agent_3d.h
@@ -32,8 +32,10 @@
 
 #include "nav_rid_3d.h"
 
-#include "core/object/class_db.h"
+#include "core/math/vector3.h"
 #include "core/templates/self_list.h"
+#include "core/variant/callable.h"
+#include "core/variant/dictionary.h"
 #include "servers/navigation_3d/navigation_constants_3d.h"
 
 #include <Agent2d.h>

--- a/modules/navigation_3d/nav_obstacle_3d.h
+++ b/modules/navigation_3d/nav_obstacle_3d.h
@@ -32,7 +32,7 @@
 
 #include "nav_rid_3d.h"
 
-#include "core/object/class_db.h"
+#include "core/math/vector3.h"
 #include "core/templates/self_list.h"
 
 class NavAgent3D;

--- a/modules/navigation_3d/register_types.cpp
+++ b/modules/navigation_3d/register_types.cpp
@@ -44,6 +44,7 @@
 
 #include "core/config/engine.h"
 #include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
 
 #ifndef DISABLE_DEPRECATED

--- a/modules/openxr/editor/openxr_select_runtime.cpp
+++ b/modules/openxr/editor/openxr_select_runtime.cpp
@@ -38,6 +38,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/json.h"
 #include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "editor/settings/editor_settings.h"
 

--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -32,7 +32,6 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/projection.h"
-#include "core/object/class_db.h"
 #include "core/object/gdvirtual.gen.h"
 #include "core/object/ref_counted.h"
 #include "core/templates/hash_map.h"

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -38,6 +38,7 @@
 #include "action_map/openxr_haptic_feedback.h"
 #include "action_map/openxr_interaction_profile.h"
 #include "action_map/openxr_interaction_profile_metadata.h"
+#include "core/object/class_db.h"
 #include "openxr_api_extension.h"
 #include "openxr_interface.h"
 

--- a/modules/vorbis/register_types.cpp
+++ b/modules/vorbis/register_types.cpp
@@ -32,6 +32,8 @@
 
 #include "audio_stream_ogg_vorbis.h"
 
+#include "core/object/class_db.h"
+
 #ifdef TOOLS_ENABLED
 #include "editor/editor_node.h"
 #include "resource_importer_ogg_vorbis.h"

--- a/modules/webrtc/register_types.cpp
+++ b/modules/webrtc/register_types.cpp
@@ -37,6 +37,7 @@
 #include "webrtc_peer_connection_extension.h"
 
 #include "core/config/project_settings.h"
+#include "core/object/class_db.h"
 
 void initialize_webrtc_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {

--- a/modules/websocket/emws_peer.cpp
+++ b/modules/websocket/emws_peer.cpp
@@ -33,6 +33,11 @@
 #ifdef WEB_ENABLED
 
 #include "core/io/ip.h"
+#include "core/object/class_db.h"
+
+WebSocketPeer *EMWSPeer::_create(bool p_notify_postinitialize) {
+	return static_cast<WebSocketPeer *>(ClassDB::creator<EMWSPeer>(p_notify_postinitialize));
+}
 
 void EMWSPeer::_esws_on_connect(void *p_obj, char *p_proto) {
 	EMWSPeer *peer = static_cast<EMWSPeer *>(p_obj);

--- a/modules/websocket/emws_peer.h
+++ b/modules/websocket/emws_peer.h
@@ -66,7 +66,7 @@ private:
 	String selected_protocol;
 	String requested_url;
 
-	static WebSocketPeer *_create(bool p_notify_postinitialize) { return static_cast<WebSocketPeer *>(ClassDB::creator<EMWSPeer>(p_notify_postinitialize)); }
+	static WebSocketPeer *_create(bool p_notify_postinitialize);
 	static void _esws_on_connect(void *obj, char *proto);
 	static void _esws_on_message(void *obj, const uint8_t *p_data, int p_data_size, int p_is_string);
 	static void _esws_on_error(void *obj);

--- a/modules/websocket/register_types.cpp
+++ b/modules/websocket/register_types.cpp
@@ -46,6 +46,7 @@
 
 #include "core/debugger/engine_debugger.h"
 #include "core/error/error_macros.h"
+#include "core/object/class_db.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/debugger/editor_debugger_server.h"

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -33,6 +33,7 @@
 #ifndef WEB_ENABLED
 
 #include "core/io/stream_peer_tls.h"
+#include "core/object/class_db.h"
 #include "core/os/os.h"
 
 CryptoCore::RandomGenerator *WSLPeer::_static_rng = nullptr;
@@ -48,6 +49,10 @@ void WSLPeer::deinitialize() {
 		memdelete(_static_rng);
 		_static_rng = nullptr;
 	}
+}
+
+WebSocketPeer *WSLPeer::_create(bool p_notify_postinitialize) {
+	return static_cast<WebSocketPeer *>(ClassDB::creator<WSLPeer>(p_notify_postinitialize));
 }
 
 ///

--- a/modules/websocket/wsl_peer.h
+++ b/modules/websocket/wsl_peer.h
@@ -45,7 +45,7 @@
 class WSLPeer : public WebSocketPeer {
 private:
 	static CryptoCore::RandomGenerator *_static_rng;
-	static WebSocketPeer *_create(bool p_notify_postinitialize) { return static_cast<WebSocketPeer *>(ClassDB::creator<WSLPeer>(p_notify_postinitialize)); }
+	static WebSocketPeer *_create(bool p_notify_postinitialize);
 
 	// Callbacks.
 	static ssize_t _wsl_recv_callback(wslay_event_context_ptr ctx, uint8_t *data, size_t len, int flags, void *user_data);

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -32,6 +32,7 @@
 
 #include "export_plugin.h"
 
+#include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "editor/export/editor_export.h"
 #include "editor/file_system/editor_paths.h"

--- a/platform/web/api/javascript_bridge_singleton.h
+++ b/platform/web/api/javascript_bridge_singleton.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
 #include "core/object/ref_counted.h"
 
 class JavaScriptObject : public RefCounted {

--- a/platform/web/export/export.cpp
+++ b/platform/web/export/export.cpp
@@ -32,6 +32,7 @@
 
 #include "export_plugin.h"
 
+#include "core/object/class_db.h"
 #include "editor/export/editor_export.h"
 #include "editor/settings/editor_settings.h"
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -38,6 +38,7 @@
 #include "core/input/input_event.h"
 #include "core/io/image.h"
 #include "core/os/process_id.h"
+#include "core/templates/a_hash_map.h"
 #include "core/templates/rb_map.h"
 #include "drivers/wasapi/audio_driver_wasapi.h"
 #include "drivers/winmidi/midi_driver_winmidi.h"

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -40,6 +40,7 @@
 #include "core/io/resource_saver.h"
 #include "core/math/math_fieldwise.h"
 #include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/os/time.h"
 #include "core/templates/local_vector.h"

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "core/math/audio_frame.h"
-#include "core/object/class_db.h"
 #include "core/templates/safe_list.h"
 #include "core/variant/variant.h"
 #include "servers/audio/audio_effect.h"

--- a/servers/display/native_menu.h
+++ b/servers/display/native_menu.h
@@ -30,9 +30,9 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
 #include "core/object/object.h"
 #include "core/os/keyboard.h"
+#include "core/variant/binder_common.h"
 #include "core/variant/callable.h"
 
 class Texture2D;

--- a/servers/navigation_2d/navigation_server_2d.h
+++ b/servers/navigation_2d/navigation_server_2d.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
 #include "core/templates/rid_owner.h"
 
 #include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h"

--- a/servers/navigation_3d/navigation_server_3d.h
+++ b/servers/navigation_3d/navigation_server_3d.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
 #include "core/templates/rid_owner.h"
 
 #include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h"

--- a/servers/physics_2d/physics_server_2d.h
+++ b/servers/physics_2d/physics_server_2d.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "core/io/resource.h"
-#include "core/object/class_db.h"
 #include "core/object/ref_counted.h"
 
 constexpr int MAX_CONTACTS_REPORTED_2D_MAX = 4096;

--- a/servers/rendering/shader_include_db.h
+++ b/servers/rendering/shader_include_db.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
+#include "core/object/object.h"
 
 class ShaderIncludeDB : public Object {
 	GDCLASS(ShaderIncludeDB, Object)

--- a/tests/core/object/test_undo_redo.cpp
+++ b/tests/core/object/test_undo_redo.cpp
@@ -33,6 +33,7 @@
 TEST_FORCE_LINK(test_undo_redo)
 
 #include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
 #include "core/object/undo_redo.h"
 
 namespace TestUndoRedo {

--- a/tests/servers/test_navigation_server_3d.cpp
+++ b/tests/servers/test_navigation_server_3d.cpp
@@ -37,6 +37,7 @@ TEST_FORCE_LINK(test_navigation_server_3d)
 #ifdef MODULE_NAVIGATION_3D_ENABLED
 
 #include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/main/window.h"
 #include "scene/resources/3d/primitive_meshes.h"


### PR DESCRIPTION
• Part of #111218
• Follow up to #111573

This PR removes all unnecessary `class_db.h` inclusions in header files. Some including headers still remain because I am either not confident in migrating them, or they simply can't be removed.
All changes, with the exception of the removals, are downstream changes required for compilation.

This PR allows us to go from 1346 inclusions (782 direct, 564 transitive) to 810 inclusions (789 direct, 21 transitive). This is a 40% reduction and the completion of the `class_db.h` cleanup series. 

From now on, every file that uses `ClassDB` methods will have to explicitly include it, as it is no longer available transitively (with a very minor exception of through 14 headers). 

<details>
<summary> Before PR </summary>

# Include Dependents Report

## Summary
| Metric | Value |
| --- | --- |
| Direct includers | 782 |
| Total includers (direct + transitive) | 1346 |

## Split Totals (.h / .cpp / other)
| Category | .h | .cpp | Other |
| --- | --- | --- | --- |
| Direct includers | 35 | 747 | 0 |
| Total includers | 301 | 1045 | 0 |

## Direct Includer Breakdown
| Direct Includer | Files Through Gateway |
| --- | --- |
| servers\display\native_menu.h | 183 |
| servers\audio\audio_server.h | 148 |
| modules\openxr\extensions\openxr_extension_wrapper.h | 74 |
| servers\physics_2d\physics_server_2d.h | 54 |
| core\object\undo_redo.h | 52 |
| core\io\packet_peer.h | 49 |
| editor\file_system\editor_paths.h | 25 |
| core\os\time.h | 19 |
| servers\navigation_3d\navigation_server_3d.h | 16 |
| modules\gdscript\language_server\godot_lsp.h | 13 |
| modules\jsonrpc\jsonrpc.h | 11 |
| servers\navigation_2d\navigation_server_2d.h | 11 |
| core\debugger\remote_debugger.h | 10 |
| editor\editor_interface.h | 10 |
| modules\navigation_3d\nav_agent_3d.h | 7 |
| modules\navigation_2d\nav_agent_2d.h | 7 |
| servers\rendering\rendering_device_binds.h | 7 |
| modules\navigation_2d\nav_obstacle_2d.h | 6 |
| modules\navigation_3d\nav_obstacle_3d.h | 6 |
| servers\rendering\shader_include_db.h | 5 |
| main\performance.h | 4 |
| modules\navigation_2d\2d\nav_mesh_generator_2d.h | 3 |
| drivers\apple_embedded\apple_embedded.h | 3 |
| core\extension\godot_instance.h | 3 |
| platform\web\api\javascript_bridge_singleton.h | 3 |
| modules\navigation_3d\3d\nav_mesh_generator_3d.h | 3 |
| modules\mono\editor\bindings_generator.h | 3 |
| core\variant\variant_setget.h | 2 |
| modules\mono\class_db_api_json.h | 2 |
| core\core_bind.h | 2 |
| core\variant\variant_op.h | 2 |
| core\variant\variant_construct.h | 2 |
| core\variant\variant_destruct.h | 2 |
| core\variant\container_type_validate.h | 2 |
| editor\project_upgrade\project_upgrade_tool.h | 1 |
</details>

<details>
<summary> After PR </summary>

# Include Dependents Report

## Summary
| Metric | Value |
| --- | --- |
| Direct includers | 789 |
| Total includers (direct + transitive) | 810 |

## Split Totals (.h / .cpp / other)
| Category | .h | .cpp | Other |
| --- | --- | --- | --- |
| Direct includers | 7 | 782 | 0 |
| Total includers | 14 | 796 | 0 |

## Direct Includer Breakdown
| Direct Includer | Files Through Gateway |
| --- | --- |
| modules\gdscript\language_server\godot_lsp.h | 12 |
| servers\rendering\rendering_device_binds.h | 7 |
| modules\multiplayer\tests\test_multiplayer_spawner.h | 3 |
| core\core_bind.h | 2 |
| modules\mono\class_db_api_json.h | 2 |
| core\variant\container_type_validate.h | 2 |
| modules\mono\editor\bindings_generator.h | 2 |
</details>