### PR TITLE
[Linux] Improve crash trace symbols

### DIFF
--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -141,39 +141,46 @@ static void handle_crash(int sig) {
 		}
 		args.push_back("-e");
 		args.push_back(_execpath);
+		args.push_back("-f");
+		args.push_back("-p");
+		args.push_back("-C");
 
 		// Try to get the file/line number using addr2line
 		String output;
 		Error err = OS::get_singleton()->execute(exe_name, args, &output, &ret);
-		Vector<String> addr2line_results;
 		if (err == OK) {
-			addr2line_results = output.substr(0, output.length() - 1).split("\n", false);
-		}
+			Vector<String> addr2line_results = output.substr(0, output.length() - 1).split("\n", false);
 
-		for (size_t i = 1; i < size; i++) {
-			char fname[1024];
-			Dl_info info;
+			for (size_t i = 1; i < size; i++) {
+				// Simplify printed file paths to remove redundant `/./` sections (e.g. `/opt/godot/./core` -> `/opt/godot/core`).
+				print_error(vformat("[%d] %x - %s", (int64_t)i, (uint64_t)bt_buffer[i], addr2line_results[i].replace("/./", "/")));
+			}
+		} else {
+			// Otherwise fall back to trace symbols.
+			for (size_t i = 1; i < size; i++) {
+				char fname[1024];
+				Dl_info info;
 
-			snprintf(fname, 1024, "%s", strings[i]);
+				snprintf(fname, 1024, "%s", strings[i]);
 
-			// Try to demangle the function name to provide a more readable one
-			if (dladdr(bt_buffer[i], &info) && info.dli_sname) {
-				if (info.dli_sname[0] == '_') {
-					int status = 0;
-					char *demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &status);
+				// Try to demangle the function name to provide a more readable one.
+				if (dladdr(bt_buffer[i], &info) && info.dli_sname) {
+					if (info.dli_sname[0] == '_') {
+						int status = 0;
+						char *demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &status);
 
-					if (status == 0 && demangled) {
-						snprintf(fname, 1024, "%s", demangled);
-					}
+						if (status == 0 && demangled) {
+							snprintf(fname, 1024, "%s", demangled);
+						}
 
-					if (demangled) {
-						free(demangled);
+						if (demangled) {
+							free(demangled);
+						}
 					}
 				}
-			}
 
-			// Simplify printed file paths to remove redundant `/./` sections (e.g. `/opt/godot/./core` -> `/opt/godot/core`).
-			print_error(vformat("[%d] %x - %s (%s)", (int64_t)i, (uint64_t)bt_buffer[i], fname, err == OK ? addr2line_results[i].replace("/./", "/") : ""));
+				print_error(vformat("[%d] %x - %s", (int64_t)i, (uint64_t)bt_buffer[i], fname));
+			}
 		}
 
 		free(strings);

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -100,11 +100,6 @@ def configure(env: "SConsEnvironment"):
 
     ## Build type
 
-    if env.dev_build:
-        # This is needed for our crash handler to work properly.
-        # gdb works fine without it though, so maybe our crash handler could too.
-        env.Append(LINKFLAGS=["-rdynamic"])
-
     # Cross-compilation
     # TODO: Support cross-compilation on architectures other than x86.
     host_is_64_bit = sys.maxsize > 2**32


### PR DESCRIPTION
This changes things from:
```
================================================================
handle_crash: Program crashed with signal 4
Engine version: Godot Engine v4.7.dev.custom_build
Dumping the backtrace. Please include this when reporting the bug to the project developer.
[1] /lib64/libc.so.6(+0x1a290) [0x7f4a27895290] (/root/godot/core/os/os.cpp:56)
[2] New_Game_Project.x86_64() [0x22c0d4a] (??:0)
[3] New_Game_Project.x86_64() [0x72c247] (/root/godot/core/core_bind.cpp:343)
[4] New_Game_Project.x86_64() [0x5e73ae] (/root/godot/modules/gdscript/gdscript.h:581)
[5] New_Game_Project.x86_64() [0x103d809] (/root/godot/modules/gdscript/gdscript.cpp:1916)
[6] New_Game_Project.x86_64() [0x147fbbd] (/root/godot/core/variant/variant.h:874)
[7] New_Game_Project.x86_64() [0x27a0ca1] (/root/godot/scene/main/canvas_item.h:47)
[8] New_Game_Project.x86_64() [0x1005396] (/root/godot/core/object/object.cpp:1015)
[9] New_Game_Project.x86_64() [0x1005344] (/root/godot/scene/main/node.cpp:338)
[10] New_Game_Project.x86_64() [0x10517cf] (/root/godot/core/templates/hash_map.h:472)
[11] New_Game_Project.x86_64() [0x425f00] (/root/godot/scene/main/node.cpp:3358)
[12] /lib64/libc.so.6(+0x35b5) [0x7f4a2787e5b5] (/root/godot/servers/display/display_server.h:68)
[13] /lib64/libc.so.6(__libc_start_main+0x88) [0x7f4a2787e668] (??:0)
[14] New_Game_Project.x86_64() [0x43b21a] (??:0)
-- END OF C++ BACKTRACE --
================================================================
GDScript backtrace (most recent call first):
    [0] _ready (res://node_2d.tscn::GDScript_y32ns:6)
-- END OF GDSCRIPT BACKTRACE --
================================================================
```

To:
```
================================================================
handle_crash: Program crashed with signal 4
Engine version: Godot Engine v4.7.dev.custom_build (f40628fe4e5cc03b4dee95ed091cd358d4421212)
Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
[1] ?? ??:0
[2] CoreBind::OS::crash(String const&) at ./core/core_bind.cpp:344 (discriminator 2)
[3] void call_with_validated_variant_args_helper<__UnexistingClass, String const&, 0ul>(__UnexistingClass*, void (__UnexistingClass::*)(String const&), Variant const**, IndexSequence<0ul>) at ./core/variant/binder_common.h:300
[4] void call_with_validated_object_instance_args<__UnexistingClass, String const&>(__UnexistingClass*, void (__UnexistingClass::*)(String const&), Variant const**) at ./core/variant/binder_common.h:587
[5] MethodBindT<String const&>::validated_call(Object*, Variant const**, Variant*) const at ./core/object/method_bind.h:351
[6] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) at ./modules/gdscript/gdscript_vm.cpp:2359
[7] GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) at ./modules/gdscript/gdscript.cpp:1917 (discriminator 1)
[8] Node::_gdvirtual__ready_call() at ./scene/main/node.h:430 (discriminator 11)
[9] Node::_notification(int) at ./scene/main/node.cpp:281
[10] Node::_notification_forwardv(int) at ./scene/main/node.h:52
[11] CanvasItem::_notification_forwardv(int) at ./scene/main/canvas_item.h:47 (discriminator 1)
[12] Node2D::_notification_forwardv(int) at ./scene/2d/node_2d.h:36 (discriminator 1)
[13] Object::_notification_forward(int) at ./core/object/object.cpp:1015
[14] Object::notification(int, bool) at ./core/object/object.h:931
[15] Node::_propagate_ready() at ./scene/main/node.cpp:338
[16] Node::_propagate_ready() at ./scene/main/node.cpp:327 (discriminator 8)
[17] Node::_set_tree(SceneTree*) at ./scene/main/node.cpp:3358
[18] SceneTree::initialize() at ./scene/main/scene_tree.cpp:588
[19] OS_LinuxBSD::run() at ./platform/linuxbsd/os_linuxbsd.cpp:991
[20] main at ./platform/linuxbsd/godot_linuxbsd.cpp:121
[21] ?? ??:0
[22] ?? ??:0
[23] _start at ??:?
-- END OF C++ BACKTRACE --
================================================================
GDScript backtrace (most recent call first):
    [0] _ready (res://node_2d.tscn::GDScript_y32ns:6)
-- END OF GDSCRIPT BACKTRACE --
================================================================
```

The exact format depends on the specific `addr2line` implementation, above is with the standard `addr2line`, below is with llvm and gimli respectively

```
================================================================
handle_crash: Program crashed with signal 4
Engine version: Godot Engine v4.7.dev.custom_build (f40628fe4e5cc03b4dee95ed091cd358d4421212)
Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
[1] _end at ??:0
[2] CoreBind::OS::crash(String const&) at ./core/core_bind.cpp:344 (discriminator 2)
[3] void call_with_validated_variant_args_helper<__UnexistingClass, String const&, 0ul>(__UnexistingClass*, void (__UnexistingClass::*)(String const&), Variant const**, IndexSequence<0ul>) at ./core/variant/binder_common.h:300
[4] void call_with_validated_object_instance_args<__UnexistingClass, String const&>(__UnexistingClass*, void (__UnexistingClass::*)(String const&), Variant const**) at ./core/variant/binder_common.h:587
[5] MethodBindT<String const&>::validated_call(Object*, Variant const**, Variant*) const at ./core/object/method_bind.h:351
[6] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) at ./modules/gdscript/gdscript_vm.cpp:2359
[7] GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) at ./modules/gdscript/gdscript.cpp:1917 (discriminator 1)
[8] Node::_gdvirtual__ready_call() at ./scene/main/node.h:430 (discriminator 11)
[9] Node::_notification(int) at ./scene/main/node.cpp:281
[10] Node::_notification_forwardv(int) at ./scene/main/node.h:52
[11] CanvasItem::_notification_forwardv(int) at ./scene/main/canvas_item.h:47 (discriminator 1)
[12] Node2D::_notification_forwardv(int) at ./scene/2d/node_2d.h:36 (discriminator 1)
[13] Object::_notification_forward(int) at ./core/object/object.cpp:1015
[14] Object::notification(int, bool) at ./core/object/object.h:931
[15] Node::_propagate_ready() at ./scene/main/node.cpp:338
[16] Node::_propagate_ready() at ./scene/main/node.cpp:327 (discriminator 8)
[17] Node::_set_tree(SceneTree*) at ./scene/main/node.cpp:3358
[18] SceneTree::initialize() at ./scene/main/scene_tree.cpp:588
[19] OS_LinuxBSD::run() at ./platform/linuxbsd/os_linuxbsd.cpp:991
[20] main at ./platform/linuxbsd/godot_linuxbsd.cpp:121
[21] _end at ??:0
[22] _end at ??:0
[23] _start at ??:0
-- END OF C++ BACKTRACE --
================================================================
GDScript backtrace (most recent call first):
    [0] _ready (res://node_2d.tscn::GDScript_y32ns:6)
-- END OF GDSCRIPT BACKTRACE --
================================================================
```

```
================================================================
handle_crash: Program crashed with signal 4
Engine version: Godot Engine v4.7.dev.custom_build (f40628fe4e5cc03b4dee95ed091cd358d4421212)
Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
[1] version_lock_mutex at ??:0
[2] CoreBind::OS::crash(String const&) at ./core/core_bind.cpp:344
[3] void call_with_validated_variant_args_helper<__UnexistingClass, String const&, (unsigned long)0>(__UnexistingClass*, void (__UnexistingClass::*)(String const&), Variant const**, IndexSequence<((unsigned long)0)...>) at ./core/variant/binder_common.h:300
[4] void call_with_validated_object_instance_args<__UnexistingClass, String const&>(__UnexistingClass*, void (__UnexistingClass::*)(String const&), Variant const**) at ./core/variant/binder_common.h:587
[5] MethodBindT<String const&>::validated_call(Object*, Variant const**, Variant*) const at ./core/object/method_bind.h:351
[6] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) at ./modules/gdscript/gdscript_vm.cpp:2359
[7] GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) at ./modules/gdscript/gdscript.cpp:1917
[8] Node::_gdvirtual__ready_call() at ./scene/main/node.h:430
[9] Node::_notification(int) at ./scene/main/node.cpp:281
[10] Node::_notification_forwardv(int) at ./scene/main/node.h:52
[11] CanvasItem::_notification_forwardv(int) at ./scene/main/canvas_item.h:47
[12] Node2D::_notification_forwardv(int) at ./scene/2d/node_2d.h:36
[13] Object::_notification_forward(int) at ./core/object/object.cpp:1015
[14] Object::notification(int, bool) at ./core/object/object.h:931
[15] Node::_propagate_ready() at ./scene/main/node.cpp:338
[16] Node::_propagate_ready() at ./scene/main/node.cpp:327
[17] Node::_set_tree(SceneTree*) at ./scene/main/node.cpp:3358
[18] SceneTree::initialize() at ./scene/main/scene_tree.cpp:588
[19] OS_LinuxBSD::run() at ./platform/linuxbsd/os_linuxbsd.cpp:991
[20] main at ./platform/linuxbsd/godot_linuxbsd.cpp:121
[21] version_lock_mutex at ??:0
[22] version_lock_mutex at ??:0
[23] _start at ??:0
-- END OF C++ BACKTRACE --
================================================================
GDScript backtrace (most recent call first):
    [0] _ready (res://node_2d.tscn::GDScript_y32ns:6)
-- END OF GDSCRIPT BACKTRACE --
================================================================
```

Includes:
* https://github.com/godotengine/godot/pull/117067

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
-->
