### PR TITLE
Profiler: Fix for graph not displaying performance spikes at different zoom levels

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -211,6 +211,20 @@ void EditorProfiler::_update_plot() {
 		wr[i + 3] = 255;
 	}
 
+	struct PlotData {
+		Vector<float> frame_values;
+	};
+	Vector<PlotData> flat_plots;
+	flat_plots.resize(plot_sigs.size());
+	for (int i = 0; i < flat_plots.size(); i++) {
+		flat_plots.write[i].frame_values.resize(total_metrics);
+		flat_plots.write[i].frame_values.fill(0.0);
+	}
+
+	const int max_profiles_shown = frame_metrics.size() / Math::exp(graph_zoom);
+	const int left_border = _get_zoom_left_border();
+	const int profiles_drawn = CLAMP(total_metrics - left_border, 0, max_profiles_shown);
+
 	//find highest value
 
 	const bool use_self = display_time->get_selected() == DISPLAY_SELF_TIME;
@@ -219,20 +233,42 @@ void EditorProfiler::_update_plot() {
 	for (int i = 0; i < total_metrics; i++) {
 		const Metric &m = _get_frame_metric(i);
 
+		int plot_sig_index = 0;
+		int compressed_frame_target = 0;
+		if (i >= left_border && i < left_border + profiles_drawn) { // if this data is visible in the graph
+			if (w < max_profiles_shown) { // if more data points than pixels
+				int pixel = (i - left_border) * w / max_profiles_shown; // Figure out which frame the pixel is going to get data from in the draw code
+				compressed_frame_target = (pixel * max_profiles_shown / w) + left_border; // Copy draw code "int current = (i * max_profiles_shown / w) + left_border;"
+			}
+		}
+
 		for (const StringName &E : plot_sigs) {
+			float val = 0;
+
 			HashMap<StringName, Metric::Category *>::ConstIterator F = m.category_ptrs.find(E);
 			if (F) {
-				highest = MAX(F->value->total_time, highest);
+				val = F->value->total_time;
 			}
 
 			HashMap<StringName, Metric::Category::Item *>::ConstIterator G = m.item_ptrs.find(E);
 			if (G) {
 				if (use_self) {
-					highest = MAX(G->value->self, highest);
+					val = G->value->self;
 				} else {
-					highest = MAX(G->value->total, highest);
+					val = G->value->total;
 				}
 			}
+
+			highest = MAX(highest, val);
+			if (i >= left_border && i < left_border + profiles_drawn) { // if this data is visible in the graph
+				if (w < max_profiles_shown) { // if more data points than pixels
+					float max_val = MAX(val, flat_plots[plot_sig_index].frame_values[compressed_frame_target]);
+					flat_plots.write[plot_sig_index].frame_values.write[compressed_frame_target] = max_val;
+				} else { // if same number of data points as pixels, or less data points than pixels
+					flat_plots.write[plot_sig_index].frame_values.write[i] = val;
+				}
+			}
+			plot_sig_index++;
 		}
 	}
 
@@ -248,9 +284,6 @@ void EditorProfiler::_update_plot() {
 
 		HashMap<StringName, int> prev_plots;
 
-		const int max_profiles_shown = frame_metrics.size() / Math::exp(graph_zoom);
-		const int left_border = _get_zoom_left_border();
-		const int profiles_drawn = CLAMP(total_metrics - left_border, 0, max_profiles_shown);
 		const int pixel_cols = (profiles_drawn * w) / max_profiles_shown - 1;
 
 		for (int i = 0; i < pixel_cols; i++) {
@@ -259,25 +292,10 @@ void EditorProfiler::_update_plot() {
 			}
 
 			int current = (i * max_profiles_shown / w) + left_border;
+			int plot_sig_index = 0;
 
 			for (const StringName &E : plot_sigs) {
-				const Metric &m = _get_frame_metric(current);
-
-				float value = 0;
-
-				HashMap<StringName, Metric::Category *>::ConstIterator F = m.category_ptrs.find(E);
-				if (F) {
-					value = F->value->total_time;
-				}
-
-				HashMap<StringName, Metric::Category::Item *>::ConstIterator G = m.item_ptrs.find(E);
-				if (G) {
-					if (use_self) {
-						value = G->value->self;
-					} else {
-						value = G->value->total;
-					}
-				}
+				float value = flat_plots[plot_sig_index].frame_values[current];
 
 				int plot_pos = CLAMP(int(value * h / highest), 0, h - 1);
 
@@ -305,6 +323,8 @@ void EditorProfiler::_update_plot() {
 					column[j * 4 + 2] += Math::fast_ftoi(CLAMP(col.b * 255, 0, 255));
 					column[j * 4 + 3] += 1;
 				}
+
+				plot_sig_index++;
 			}
 
 			for (int j = 0; j < h * 4; j += 4) {


### PR DESCRIPTION
Profiler: graph was not displaying performance spikes at different zoom levels.
NOTE: BRAND NEW CODE AS OF 3/22/2026

While zooming in and out on the profiler graph the performance spikes would vanish. This was because the sampling method was skipping spike data as it picked data to display. The new method captures min and max over the entire sampling window so no high or low points are missed - no matter what the zoom scale is.

Additionally before this fix the graph would flicker and jitter as the sample points were changing. Users have assumed something was broken with the graph and comment things like this in their bugs: "instead the graph starts to flicker or something." This is from #76146 

***********
The old code would not draw the graph correctly.
The new code does draw it correctly and has a touch better performance.

Speed before code fix to display performance spikes correctly:
_update_plot 100 runs total: 168466 usec, average: 1684 usec per call - graph is starting to fill up
_update_plot 100 runs total: 357756 usec, average: 3577 usec per call
_update_plot 100 runs total: 537164 usec, average: 5371 usec per call - graph is full from here on
_update_plot 100 runs total: 566930 usec, average: 5669 usec per call
_update_plot 100 runs total: 584532 usec, average: 5845 usec per call
_update_plot 100 runs total: 586033 usec, average: 5860 usec per call
_update_plot 100 runs total: 592993 usec, average: 5929 usec per call

Speed after code fix to display performance spikes correctly:
_update_plot 100 runs total: 167741 usec, average: 1677 usec per call - graph is starting to fill up
_update_plot 100 runs total: 340753 usec, average: 3407 usec per call
_update_plot 100 runs total: 488717 usec, average: 4887 usec per call - graph is full from here on
_update_plot 100 runs total: 521295 usec, average: 5212 usec per call
_update_plot 100 runs total: 519643 usec, average: 5196 usec per call
_update_plot 100 runs total: 532377 usec, average: 5323 usec per call
_update_plot 100 runs total: 546293 usec, average: 5462 usec per call

***********
NOTE: BRAND NEW MOVIES AS OF 3/22/2026
[before fix simple.webm](https://github.com/user-attachments/assets/cc32746c-eff7-4cfa-9c17-da066fba4922)
[after fix simple.webm](https://github.com/user-attachments/assets/ace71797-6c20-453c-aa8b-326a3aacf240)

Here are a before the fix video and an after the fix video.
Both these video show the profiler just running - no zoom, no panning, no user input. You can see the frame count incrementing in the upper right corner so data is coming in and the graph is moving to the left as that new data comes in.

In the before my code fix video the graph is very jittery and the performance spikes appear and disappear.
In the after my code fix video the graph motion is smooth and the performance spikes do NOT disappear.

I'd rate this as a high importance fix because the point of the profiler graph is to find the performance spikes.
***********

All code changes are in 1 method only.

The graph will now never hide performance issues from the user.

*******************************
Disclosure and License
-As a software engineer I use many systems to ensure code quality, and that includes AI. I use the AI to: do detailed code analysis, be a sounding board for my different ideas, look for bugs, find unexpected behaviors, identify performance hot spots, expensive CPU calls, race conditions, poorly placed variable initializations, possible optimizations, and many more things. I do this during development and before I push code to the repo. It lists items that are potential problems and I decide what I think is important and make those changes.
-For a descriptive example of my AI usage on a particular PR please read this https://github.com/godotengine/godot/pull/117066#issuecomment-4061773098
-Any and all code attached to this PR falls under the coverage of the MIT License.