### PR TITLE
[Linux] Fix `addr2line` call

### DIFF
--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -104,13 +104,13 @@ static void handle_crash(int sig) {
 #endif //__GLIBC__
 	if (strings) {
 		int ret;
-		String output;
 
 		List<String> args;
 		args.push_back("--version");
 		String exe_name;
 
 		if (exe_name.is_empty()) {
+			String output;
 			// Faster implementation from gimli-rs/addr2line.
 			Error err = OS::get_singleton()->execute(OS::get_singleton()->get_environment("HOME").path_join(String("/.cargo/bin/addr2line")), args, &output, &ret);
 			if (err == OK && ret == 0) {
@@ -118,6 +118,7 @@ static void handle_crash(int sig) {
 			}
 		}
 		if (exe_name.is_empty()) {
+			String output;
 			Error err = OS::get_singleton()->execute(String("llvm-addr2line"), args, &output, &ret);
 			if (err == OK && ret == 0) {
 				exe_name = String("llvm-addr2line");
@@ -137,6 +138,7 @@ static void handle_crash(int sig) {
 		args.push_back(_execpath);
 
 		// Try to get the file/line number using addr2line
+		String output;
 		Error err = OS::get_singleton()->execute(exe_name, args, &output, &ret);
 		Vector<String> addr2line_results;
 		if (err == OK) {


### PR DESCRIPTION
See:
* https://github.com/godotengine/godot/pull/115566#issuecomment-3999054139
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
-->
