### PR TITLE
Class reference: add description to `ScriptNameCasing` enum

### DIFF
--- a/doc/classes/ScriptLanguage.xml
+++ b/doc/classes/ScriptLanguage.xml
@@ -8,14 +8,19 @@
 	</tutorials>
 	<constants>
 		<constant name="SCRIPT_NAME_CASING_AUTO" value="0" enum="ScriptNameCasing">
+			Used by [member ProjectSettings.editor/naming/script_name_casing] to set the default script name casing to the script language's preferred casing.
 		</constant>
 		<constant name="SCRIPT_NAME_CASING_PASCAL_CASE" value="1" enum="ScriptNameCasing">
+			Used by [member ProjectSettings.editor/naming/script_name_casing] to set the default script name casing to [code]PascalCase[/code].
 		</constant>
 		<constant name="SCRIPT_NAME_CASING_SNAKE_CASE" value="2" enum="ScriptNameCasing">
+			Used by [member ProjectSettings.editor/naming/script_name_casing] to set the default script name casing to [code]snake_case[/code].
 		</constant>
 		<constant name="SCRIPT_NAME_CASING_KEBAB_CASE" value="3" enum="ScriptNameCasing">
+			Used by [member ProjectSettings.editor/naming/script_name_casing] to set the default script name casing to [code]kebab-case[/code].
 		</constant>
 		<constant name="SCRIPT_NAME_CASING_CAMEL_CASE" value="4" enum="ScriptNameCasing">
+			Used by [member ProjectSettings.editor/naming/script_name_casing] to set the default script name casing to [code]cascalCase[/code].
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/ScriptLanguage.xml
+++ b/doc/classes/ScriptLanguage.xml
@@ -20,7 +20,7 @@
 			Used by [member ProjectSettings.editor/naming/script_name_casing] to set the default script name casing to [code]kebab-case[/code].
 		</constant>
 		<constant name="SCRIPT_NAME_CASING_CAMEL_CASE" value="4" enum="ScriptNameCasing">
-			Used by [member ProjectSettings.editor/naming/script_name_casing] to set the default script name casing to [code]cascalCase[/code].
+			Used by [member ProjectSettings.editor/naming/script_name_casing] to set the default script name casing to [code]camelCase[/code].
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
Looks like the only setting which uses this enum is `editor/naming/script_name_casing`.

https://github.com/godotengine/godot/blob/master/editor/editor_node.cpp#L3894 defines its usage.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
-->