### PR TITLE
Class reference: add description to `omnilight3d/omni_shadow_mode`

### DIFF
--- a/doc/classes/OmniLight3D.xml
+++ b/doc/classes/OmniLight3D.xml
@@ -25,6 +25,7 @@
 			[b]Note:[/b] [member omni_range] is not affected by [member Node3D.scale] (the light's scale or its parent's scale).
 		</member>
 		<member name="omni_shadow_mode" type="int" setter="set_shadow_mode" getter="get_shadow_mode" enum="OmniLight3D.ShadowMode" default="1">
+			The light's shadow rendering algorithm.
 		</member>
 		<member name="shadow_normal_bias" type="float" setter="set_param" getter="get_param" overrides="Light3D" default="1.0" />
 	</members>


### PR DESCRIPTION
Uses the same wording as in [`DirectionalLight3D/directional_shadow_mode`](https://docs.godotengine.org/en/stable/classes/class_directionallight3d.html#class-directionallight3d-property-directional-shadow-mode)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
-->
