### PR TITLE
Add disk size display to texture preview metadata

### DIFF
--- a/editor/scene/texture/texture_3d_editor_plugin.cpp
+++ b/editor/scene/texture/texture_3d_editor_plugin.cpp
@@ -30,6 +30,8 @@
 
 #include "texture_3d_editor_plugin.h"
 
+#include "core/io/file_access.h"
+#include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "editor/editor_string_names.h"
 #include "editor/scene/texture/color_channel_selector.h"
@@ -164,27 +166,40 @@ void Texture3DEditor::_update_gui() {
 	const Image::Format format = texture->get_format();
 	const String format_name = Image::get_format_name(format);
 
+	// Determine export file size. Uses the imported resource path (e.g., .ctex) rather than the source file, as this reflects the size that ends up in the exported PCK.
+	String export_size_text;
+	const String res_path = texture->get_path();
+	if (!res_path.is_empty() && !texture->is_built_in()) {
+		const String imported_path = ResourceLoader::import_remap(res_path);
+		if (!imported_path.is_empty() && FileAccess::exists(imported_path)) {
+			const uint64_t export_size = FileAccess::get_size(imported_path);
+			export_size_text = "\n" + vformat(TTR("Export Size: %s"), String::humanize_size(export_size));
+		}
+	}
+
 	if (texture->has_mipmaps()) {
 		const int mip_count = Image::get_image_required_mipmaps(texture->get_width(), texture->get_height(), format);
 		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), format, true) * texture->get_depth();
 
 		info->set_text(vformat(String::utf8("%d×%d×%d %s\n") + TTR("%s Mipmaps") + "\n" + TTR("Memory: %s"),
-				texture->get_width(),
-				texture->get_height(),
-				texture->get_depth(),
-				format_name,
-				mip_count,
-				String::humanize_size(memory)));
+							   texture->get_width(),
+							   texture->get_height(),
+							   texture->get_depth(),
+							   format_name,
+							   mip_count,
+							   String::humanize_size(memory)) +
+				export_size_text);
 
 	} else {
 		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), format, false) * texture->get_depth();
 
 		info->set_text(vformat(String::utf8("%d×%d×%d %s\n") + TTR("No Mipmaps") + "\n" + TTR("Memory: %s"),
-				texture->get_width(),
-				texture->get_height(),
-				texture->get_depth(),
-				format_name,
-				String::humanize_size(memory)));
+							   texture->get_width(),
+							   texture->get_height(),
+							   texture->get_depth(),
+							   format_name,
+							   String::humanize_size(memory)) +
+				export_size_text);
 	}
 
 	const uint32_t components_mask = Image::get_format_component_mask(format);

--- a/editor/scene/texture/texture_editor_plugin.cpp
+++ b/editor/scene/texture/texture_editor_plugin.cpp
@@ -51,6 +51,9 @@
 #include "scene/resources/texture_rd.h"
 #include "servers/rendering/rendering_device.h"
 
+#include "core/io/file_access.h"
+#include "core/io/resource_loader.h"
+
 constexpr const char *texture_2d_shader_code = R"(
 shader_type canvas_item;
 render_mode blend_mix;
@@ -193,6 +196,17 @@ void TexturePreview::_update_metadata_label_text() {
 
 	const Vector2i resolution = texture->get_size();
 
+	// Determine imported file size on disk. Uses the imported resource path (e.g., .ctex) rather than the source file, as this reflects the size that ends up in the exported PCK.
+	String disk_size_text;
+	const String res_path = texture->get_path();
+	if (!res_path.is_empty() && !texture->is_built_in()) {
+		const String imported_path = ResourceLoader::import_remap(res_path);
+		if (!imported_path.is_empty() && FileAccess::exists(imported_path)) {
+			const uint64_t disk_size = FileAccess::get_size(imported_path);
+			disk_size_text = "\n" + vformat(TTR("Disk Size: %s"), String::humanize_size(disk_size));
+		}
+	}
+
 	if (format != Image::FORMAT_MAX) {
 		// Avoid signed integer overflow that could occur with huge texture sizes by casting everything to uint64_t.
 		uint64_t memory = uint64_t(resolution.x) * uint64_t(resolution.y) * uint64_t(Image::get_format_pixel_size(format));
@@ -216,7 +230,8 @@ void TexturePreview::_update_metadata_label_text() {
 							texture->get_height(),
 							format_name,
 							mipmaps,
-							String::humanize_size(memory)));
+							String::humanize_size(memory)) +
+					disk_size_text);
 		} else {
 			// "No Mipmaps" is easier to distinguish than "0 Mipmaps",
 			// especially since 0, 6, and 8 look quite close with the default code font.
@@ -225,14 +240,16 @@ void TexturePreview::_update_metadata_label_text() {
 							texture->get_width(),
 							texture->get_height(),
 							format_name,
-							String::humanize_size(memory)));
+							String::humanize_size(memory)) +
+					disk_size_text);
 		}
 	} else {
 		metadata_label->set_text(
 				vformat(String::utf8("%d×%d %s"),
 						texture->get_width(),
 						texture->get_height(),
-						format_name));
+						format_name) +
+				disk_size_text);
 	}
 }
 

--- a/editor/scene/texture/texture_editor_plugin.cpp
+++ b/editor/scene/texture/texture_editor_plugin.cpp
@@ -30,6 +30,8 @@
 
 #include "texture_editor_plugin.h"
 
+#include "core/io/file_access.h"
+#include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "editor/editor_string_names.h"
 #include "editor/scene/texture/color_channel_selector.h"
@@ -50,9 +52,6 @@
 #include "scene/resources/style_box_flat.h"
 #include "scene/resources/texture_rd.h"
 #include "servers/rendering/rendering_device.h"
-
-#include "core/io/file_access.h"
-#include "core/io/resource_loader.h"
 
 constexpr const char *texture_2d_shader_code = R"(
 shader_type canvas_item;

--- a/editor/scene/texture/texture_editor_plugin.cpp
+++ b/editor/scene/texture/texture_editor_plugin.cpp
@@ -196,14 +196,14 @@ void TexturePreview::_update_metadata_label_text() {
 
 	const Vector2i resolution = texture->get_size();
 
-	// Determine imported file size on disk. Uses the imported resource path (e.g., .ctex) rather than the source file, as this reflects the size that ends up in the exported PCK.
-	String disk_size_text;
+	// Determine export file size. Uses the imported resource path (e.g., .ctex) rather than the source file, as this reflects the size that ends up in the exported PCK.
+	String export_size_text;
 	const String res_path = texture->get_path();
 	if (!res_path.is_empty() && !texture->is_built_in()) {
 		const String imported_path = ResourceLoader::import_remap(res_path);
 		if (!imported_path.is_empty() && FileAccess::exists(imported_path)) {
-			const uint64_t disk_size = FileAccess::get_size(imported_path);
-			disk_size_text = "\n" + vformat(TTR("Disk Size: %s"), String::humanize_size(disk_size));
+			const uint64_t export_size = FileAccess::get_size(imported_path);
+			export_size_text = "\n" + vformat(TTR("Export Size: %s"), String::humanize_size(export_size));
 		}
 	}
 
@@ -231,7 +231,7 @@ void TexturePreview::_update_metadata_label_text() {
 							format_name,
 							mipmaps,
 							String::humanize_size(memory)) +
-					disk_size_text);
+					export_size_text);
 		} else {
 			// "No Mipmaps" is easier to distinguish than "0 Mipmaps",
 			// especially since 0, 6, and 8 look quite close with the default code font.
@@ -241,7 +241,7 @@ void TexturePreview::_update_metadata_label_text() {
 							texture->get_height(),
 							format_name,
 							String::humanize_size(memory)) +
-					disk_size_text);
+					export_size_text);
 		}
 	} else {
 		metadata_label->set_text(
@@ -249,7 +249,7 @@ void TexturePreview::_update_metadata_label_text() {
 						texture->get_width(),
 						texture->get_height(),
 						format_name) +
-				disk_size_text);
+				export_size_text);
 	}
 }
 

--- a/editor/scene/texture/texture_layered_editor_plugin.cpp
+++ b/editor/scene/texture/texture_layered_editor_plugin.cpp
@@ -31,6 +31,8 @@
 #include "texture_layered_editor_plugin.h"
 
 #include "core/input/input.h"
+#include "core/io/file_access.h"
+#include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "editor/editor_string_names.h"
 #include "editor/scene/texture/color_channel_selector.h"
@@ -224,6 +226,17 @@ void TextureLayeredEditor::_update_gui() {
 		}
 	}
 
+	// Determine export file size. Uses the imported resource path (e.g., .ctex) rather than the source file, as this reflects the size that ends up in the exported PCK.
+	String export_size_text;
+	const String res_path = texture->get_path();
+	if (!res_path.is_empty() && !texture->is_built_in()) {
+		const String imported_path = ResourceLoader::import_remap(res_path);
+		if (!imported_path.is_empty() && FileAccess::exists(imported_path)) {
+			const uint64_t export_size = FileAccess::get_size(imported_path);
+			export_size_text = "\n" + vformat(TTR("Export Size: %s"), String::humanize_size(export_size));
+		}
+	}
+
 	if (texture->has_mipmaps()) {
 		const int mip_count = Image::get_image_required_mipmaps(texture->get_width(), texture->get_height(), format);
 		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), format, true) * texture->get_layers();
@@ -239,6 +252,7 @@ void TextureLayeredEditor::_update_gui() {
 				String::humanize_size(memory));
 	}
 
+	texture_info += export_size_text;
 	info->set_text(texture_info);
 
 	const uint32_t components_mask = Image::get_format_component_mask(format);


### PR DESCRIPTION
Shows the imported file's size on disk in the texture preview overlay, alongside the existing resolution, format, and VRAM info. Uses the imported resource path (e.g., .ctex) to reflect the size that ends up in the exported PCK.

Resolves https://github.com/godotengine/godot-proposals/issues/14378

<img width="274" height="442" alt="image" src="https://github.com/user-attachments/assets/ce06c833-0994-4537-ba06-79eaa9b5114a" />

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/introduction.html#setting-up-a-dev-environment
-->
