### PR TITLE
Fix RichTextLabel `[ol type=a]` not generating the right prefix

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -261,11 +261,11 @@ String RichTextLabel::_roman(int p_num, bool p_capitalize) const {
 }
 
 String RichTextLabel::_letters(int p_num, bool p_capitalize) const {
-	int64_t n = p_num;
+	uint64_t n = p_num;
 
 	int chars = 0;
 	do {
-		n /= 24;
+		n = (n - 1) / 26;
 		chars++;
 	} while (n);
 
@@ -275,11 +275,10 @@ String RichTextLabel::_letters(int p_num, bool p_capitalize) const {
 	c[chars] = 0;
 	n = p_num;
 	do {
-		int mod = Math::abs(n % 24);
-		char a = (p_capitalize ? 'A' : 'a');
-		c[--chars] = a + mod - 1;
-
-		n /= 24;
+		const char a = (p_capitalize ? 'A' : 'a');
+		n = n - 1;
+		c[--chars] = a + n % 26;
+		n /= 26;
 	} while (n);
 
 	return s;


### PR DESCRIPTION
Previously BBCode with long ordered lists using letters picked a wrong prefix.

Starting with the 24th item, it should pick prefix `x` and continue with `y`, `z` , `aa`, but it picked `` a` ``, `aa`, `ab`, `ac`.

Example BBCode:
```
[ol type=a]
a
b
c
d
e
f
g
h
i
j
k
l
m
n
o
p
q
r
s
t
u
v
w
x
y
z
aa
ab
ac
ad
ae
af
ag
ah
ai
aj
ak
al
am
an
ao
ap
aq
ar
as
at
au
av
aw
ax
ay
az
[/ol]
```