### PR TITLE
Change `Camera3D` Vertical FOV to allow decimal values 0-180 exclusive

### DIFF
--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -729,7 +729,7 @@ Camera3D::ProjectionType Camera3D::get_projection() const {
 }
 
 void Camera3D::set_fov(real_t p_fov) {
-	ERR_FAIL_COND(p_fov < 1 || p_fov > 179);
+	ERR_FAIL_COND(p_fov <= CMP_EPSILON || p_fov >= 180.0 - CMP_EPSILON);
 	fov = p_fov;
 	_update_camera_mode();
 }


### PR DESCRIPTION
Alter vertical field-of-view bounds error conditions from between 1 and 179 inclusive to between 0 and 180 exclusive.

This is to allow for vertical viewing angles of less than one, for virtual broadcast productions and real world lens matching. Most 40x sports broadcast lenses have a sub one degree vertical viewing angle, as do most zoom lenses with extenders. At present, Godot cannot be used for many sports virtual productions that Unity or Unreal are used for due to the unnecessarily restrictive FOV lower bound.

Tested on 4.6, no attempt made to alter the editor property hint as it remains sensible for the majority of use cases.

![fov-adjustment](https://github.com/user-attachments/assets/9fecf5e4-f40e-42f8-a1c7-438f1dd4f648)

