### PR TITLE
Reference correct DockSlot definition location in MSBuildPanel.cs

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -204,7 +204,7 @@ namespace GodotTools.Build
         {
             Name = "MSBuild".TTR();
             IconName = "BuildCSharp";
-            DefaultSlot = EditorDock.DockSlot.Bottom;
+            DefaultSlot = EditorPlugin.DockSlot.Bottom;
             AvailableLayouts = DockLayout.Horizontal | DockLayout.Floating;
             Global = false;
             Transient = true;


### PR DESCRIPTION
Replace EditorDock.DockSlot.Bottom with EditorPlugin.DockSlot.Bottom in MSBuildPanel.cs to correct build issue.


