### PR TITLE
Change native MultiMesh buffer manipulation methods accessibility to `public`.

### DIFF
--- a/scene/resources/multimesh.h
+++ b/scene/resources/multimesh.h
@@ -76,12 +76,13 @@ protected:
 	void _set_custom_data_array(const Vector<Color> &p_array);
 	Vector<Color> _get_custom_data_array() const;
 #endif
+
+public:
 	void set_buffer(const Vector<float> &p_buffer);
 	Vector<float> get_buffer() const;
 
 	void set_buffer_interpolated(const Vector<float> &p_buffer_curr, const Vector<float> &p_buffer_prev);
 
-public:
 	void set_mesh(const Ref<Mesh> &p_mesh);
 	Ref<Mesh> get_mesh() const;
 


### PR DESCRIPTION
This changes the native accessibility of some MultiMesh methods to public.

These methods are exposed to GDScript and are supposed to be exposed to the end user. This simple change brings the native interface into alignment with this to allow other classes to access them as they would via script.

I am working on a custom engine module right now that needs to be able to manipulate these buffers.