### PR TITLE
Soften duplicate signal registration error in JNISingleton

### DIFF
--- a/platform/android/api/jni_singleton.cpp
+++ b/platform/android/api/jni_singleton.cpp
@@ -68,6 +68,10 @@ void JNISingleton::add_method(const StringName &p_name, const Vector<Variant::Ty
 }
 
 void JNISingleton::add_signal(const StringName &p_name, const Vector<Variant::Type> &p_args) {
+	if (ClassDB::has_signal(get_class_static(), p_name)) {
+		WARN_PRINT(vformat("JNISingleton already has signal '%s'. Skipping.", p_name));
+		return;
+	}
 	MethodInfo mi;
 	mi.name = p_name;
 	for (int i = 0; i < p_args.size(); i++) {


### PR DESCRIPTION
Fixes #116615.

When two Android plugins both register a signal with the same name, the engine logs an error.

This PR checks `ClassDB::has_signal` before calling `ADD_SIGNAL` and skips the duplicate registration with a warning instead of erroring out. Signals continue to work as expected as they emit and connect at the instance level, so each plugin's signal still works independently. The class-level registration is only for metadata/validation purposes afaik.