### PR TITLE
Fix corner cases related to scroll hints across the editor

### DIFF
--- a/doc/classes/EditorDock.xml
+++ b/doc/classes/EditorDock.xml
@@ -53,10 +53,11 @@
 		<method name="_update_layout" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="layout" type="int" />
+			<param index="1" name="slot" type="int" />
 			<description>
-				Implement this method to handle the layout switching for this dock. [param layout] is one of the [enum DockLayout] constants.
+				Implement this method to handle the layout/slot switching for this dock. [param layout] is one of the [enum DockLayout] constants, and [param slot] is one of the [enum DockSlot] ones.
 				[codeblock]
-				func _update_layout(layout):
+				func _update_layout(layout, slot):
 					box_container.vertical = (layout == DOCK_LAYOUT_VERTICAL)
 				[/codeblock]
 			</description>

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -1525,18 +1525,12 @@ void EditorAudioBuses::_file_dialog_callback(const String &p_string) {
 	open_layout(ResourceUID::path_to_uid(p_string));
 }
 
-void EditorAudioBuses::update_layout(EditorDock::DockLayout p_layout) {
-	bool new_floating = (p_layout == EditorDock::DOCK_LAYOUT_FLOATING);
-	if (floating == new_floating) {
-		return;
-	}
-	floating = new_floating;
-
-	if (floating) {
+void EditorAudioBuses::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+	if (p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
 		bus_mc->set_theme_type_variation("NoBorderHorizontalBottom");
 		bus_scroll->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_TOP_AND_LEFT);
 	} else {
-		bus_mc->set_theme_type_variation("NoBorderBottomPanel");
+		bus_mc->set_theme_type_variation("NoBorderHorizontal");
 		bus_scroll->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_ALL);
 	}
 }
@@ -1581,7 +1575,7 @@ EditorAudioBuses::EditorAudioBuses() {
 	menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &EditorAudioBuses::_menu_option));
 
 	bus_mc = memnew(MarginContainer);
-	bus_mc->set_theme_type_variation("NoBorderBottomPanel");
+	bus_mc->set_theme_type_variation("NoBorderHorizontal");
 	bus_mc->set_v_size_flags(SIZE_EXPAND_FILL);
 	main_vb->add_child(bus_mc);
 

--- a/editor/audio/editor_audio_buses.h
+++ b/editor/audio/editor_audio_buses.h
@@ -204,8 +204,6 @@ class EditorAudioBuses : public EditorDock {
 	Timer *save_timer = nullptr;
 	String edited_path;
 
-	bool floating = false;
-
 	void _update_file_label();
 	void _update_file_label_size();
 
@@ -240,7 +238,7 @@ protected:
 	static void _bind_methods();
 	void _notification(int p_what);
 
-	virtual void update_layout(EditorDock::DockLayout p_layout) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
 
 public:
 	void open_layout(const String &p_path);

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -236,6 +236,12 @@ void EditorDebuggerNode::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("breakpoints_cleared_in_tree", PropertyInfo(Variant::INT, "debugger")));
 }
 
+void EditorDebuggerNode::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
+		dbg->update_layout(p_layout, p_slot);
+	});
+}
+
 void EditorDebuggerNode::register_undo_redo(UndoRedo *p_undo_redo) {
 	p_undo_redo->set_method_notify_callback(_methods_changed, this);
 	p_undo_redo->set_property_notify_callback(_properties_changed, this);

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -164,6 +164,8 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
+
 public:
 	static EditorDebuggerNode *get_singleton() { return singleton; }
 	void register_undo_redo(UndoRedo *p_undo_redo);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -2107,6 +2107,16 @@ void ScriptEditorDebugger::toggle_profiler(const String &p_profiler, bool p_enab
 	_put_msg("profiler:" + p_profiler, msg_data);
 }
 
+void ScriptEditorDebugger::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+	if (p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
+		vmem_mc->set_theme_type_variation("NoBorderHorizontalBottom");
+		vmem_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_DISABLED);
+	} else {
+		vmem_mc->set_theme_type_variation("NoBorderHorizontal");
+		vmem_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTTOM);
+	}
+}
+
 ScriptEditorDebugger::ScriptEditorDebugger() {
 	if (unlikely(parse_message_handlers.is_empty())) {
 		_init_parse_message_handlers();
@@ -2415,10 +2425,10 @@ Instead, use the monitors tab to obtain more precise VRAM usage.
 		vmem_refresh->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::_video_mem_request));
 		vmem_export->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::_video_mem_export));
 
-		MarginContainer *mc = memnew(MarginContainer);
-		mc->set_theme_type_variation("NoBorderBottomPanel");
-		mc->set_v_size_flags(SIZE_EXPAND_FILL);
-		vmem_vb->add_child(mc);
+		vmem_mc = memnew(MarginContainer);
+		vmem_mc->set_theme_type_variation("NoBorderHorizontal");
+		vmem_mc->set_v_size_flags(SIZE_EXPAND_FILL);
+		vmem_vb->add_child(vmem_mc);
 
 		vmem_tree = memnew(Tree);
 		vmem_vb->set_name(TTRC("Video RAM"));
@@ -2437,7 +2447,7 @@ Instead, use the monitors tab to obtain more precise VRAM usage.
 		vmem_tree->set_column_custom_minimum_width(3, 80 * EDSCALE);
 		vmem_tree->set_hide_root(true);
 		vmem_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTTOM);
-		mc->add_child(vmem_tree);
+		vmem_mc->add_child(vmem_tree);
 		vmem_tree->set_allow_rmb_select(true);
 		vmem_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_vmem_item_activated));
 		vmem_tree->connect("item_mouse_selected", callable_mp(this, &ScriptEditorDebugger::_vmem_tree_rmb_selected));
@@ -2505,9 +2515,6 @@ Instead, use the monitors tab to obtain more precise VRAM usage.
 	msgdialog = memnew(AcceptDialog);
 	add_child(msgdialog);
 
-	camera_override = CameraOverride::OVERRIDE_NONE;
-	error_count = 0;
-	warning_count = 0;
 	_update_buttons_state();
 }
 

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -115,8 +115,8 @@ private:
 	};
 	FileDialogPurpose file_dialog_purpose = SAVE_MONITORS_CSV;
 
-	int error_count;
-	int warning_count;
+	int error_count = 0;
+	int warning_count = 0;
 
 	bool skip_breakpoints_value = false;
 	bool ignore_error_breaks_value = false;
@@ -140,6 +140,7 @@ private:
 
 	HashMap<int, String> profiler_signature;
 
+	MarginContainer *vmem_mc = nullptr;
 	Tree *vmem_tree = nullptr;
 	Button *vmem_refresh = nullptr;
 	Button *vmem_export = nullptr;
@@ -197,7 +198,7 @@ private:
 	void _mute_audio_on_break(bool p_mute);
 	void _send_debug_mute_audio_msg(bool p_mute);
 
-	EditorDebuggerNode::CameraOverride camera_override;
+	EditorDebuggerNode::CameraOverride camera_override = EditorDebuggerNode::OVERRIDE_NONE;
 
 	void _stack_dump_frame_selected();
 
@@ -393,6 +394,8 @@ public:
 
 	void send_message(const String &p_message, const Array &p_args);
 	void toggle_profiler(const String &p_profiler, bool p_enable, const Array &p_data);
+
+	void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot);
 
 	ScriptEditorDebugger();
 	~ScriptEditorDebugger();

--- a/editor/docks/editor_dock.cpp
+++ b/editor/docks/editor_dock.cpp
@@ -143,9 +143,13 @@ void EditorDock::_bind_methods() {
 	BIND_ENUM_CONSTANT(DOCK_SLOT_BOTTOM_R);
 	BIND_ENUM_CONSTANT(DOCK_SLOT_MAX);
 
-	GDVIRTUAL_BIND(_update_layout, "layout");
+	GDVIRTUAL_BIND(_update_layout, "layout", "slot");
 	GDVIRTUAL_BIND(_save_layout_to_config, "config", "section");
 	GDVIRTUAL_BIND(_load_layout_from_config, "config", "section");
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND_COMPAT(_update_layout_, "layout");
+#endif
 }
 
 void EditorDock::open() {

--- a/editor/docks/editor_dock.h
+++ b/editor/docks/editor_dock.h
@@ -103,9 +103,13 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	GDVIRTUAL1(_update_layout, int)
+	GDVIRTUAL2(_update_layout, int, int)
 	GDVIRTUAL2C(_save_layout_to_config, Ref<ConfigFile>, const String &)
 	GDVIRTUAL2(_load_layout_from_config, Ref<ConfigFile>, const String &)
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL1_COMPAT(_update_layout_, _update_layout, int)
+#endif
 
 public:
 	void open();
@@ -157,8 +161,9 @@ public:
 	void update_tab_style();
 	Ref<Texture2D> get_effective_icon(const Callable &p_icon_fetch);
 
-	virtual void update_layout(DockLayout p_layout) { GDVIRTUAL_CALL(_update_layout, p_layout); }
+	virtual void update_layout(DockLayout p_layout, DockSlot p_slot) { GDVIRTUAL_CALL(_update_layout, p_layout, p_slot); }
 	DockLayout get_current_layout() const { return current_layout; }
+	DockSlot get_current_slot() const { return (DockSlot)dock_slot_index; }
 
 	virtual void save_layout_to_config(Ref<ConfigFile> &p_layout, const String &p_section) const { GDVIRTUAL_CALL(_save_layout_to_config, p_layout, p_section); }
 	virtual void load_layout_from_config(const Ref<ConfigFile> &p_layout, const String &p_section) { GDVIRTUAL_CALL(_load_layout_from_config, p_layout, p_section); }

--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -294,7 +294,7 @@ void EditorDockManager::_open_dock_in_window(EditorDock *p_dock, bool p_show_win
 	EditorNode::get_singleton()->get_gui_base()->add_child(wrapper);
 
 	_move_dock(p_dock, nullptr);
-	p_dock->update_layout(EditorDock::DOCK_LAYOUT_FLOATING);
+	p_dock->update_layout(EditorDock::DOCK_LAYOUT_FLOATING, EditorDock::DOCK_SLOT_NONE);
 	p_dock->current_layout = EditorDock::DOCK_LAYOUT_FLOATING;
 	wrapper->set_wrapped_control(p_dock);
 
@@ -374,11 +374,9 @@ void EditorDockManager::_move_dock(EditorDock *p_dock, Control *p_target, int p_
 	p_dock->hide();
 
 	DockTabContainer *dock_tab_container = Object::cast_to<DockTabContainer>(p_target);
-	if (p_target != closed_dock_parent) {
-		if (dock_tab_container->layout != p_dock->current_layout) {
-			p_dock->update_layout(dock_tab_container->layout);
-			p_dock->current_layout = dock_tab_container->layout;
-		}
+	if (p_target != closed_dock_parent && (dock_tab_container->layout != p_dock->current_layout || dock_tab_container->dock_slot != p_dock->dock_slot_index)) {
+		p_dock->update_layout(dock_tab_container->layout, dock_tab_container->dock_slot);
+		p_dock->current_layout = dock_tab_container->layout;
 		p_dock->dock_slot_index = dock_tab_container->dock_slot;
 	}
 

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -507,8 +507,8 @@ void FileSystemDock::_update_display_mode(bool p_force) {
 			if (horizontal) {
 				toolbar2_hbc->hide();
 
-				tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
-				tree_mc->set_theme_type_variation("NoBorderBottomPanel");
+				tree->set_scroll_hint_mode(touches_bottom ? Tree::SCROLL_HINT_MODE_TOP : Tree::SCROLL_HINT_MODE_BOTH);
+				tree_mc->set_theme_type_variation("NoBorderHorizontal");
 			} else {
 				toolbar2_hbc->show();
 
@@ -4167,12 +4167,14 @@ MenuButton *FileSystemDock::_create_file_menu_button() {
 	return button;
 }
 
-void FileSystemDock::update_layout(EditorDock::DockLayout p_layout) {
+void FileSystemDock::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
 	bool new_horizontal = (p_layout == EditorDock::DOCK_LAYOUT_HORIZONTAL);
-	if (horizontal == new_horizontal) {
+	bool new_touches_bottom = (p_slot != EditorDock::DOCK_SLOT_BOTTOM);
+	if (horizontal == new_horizontal && touches_bottom == new_touches_bottom) {
 		return;
 	}
 	horizontal = new_horizontal;
+	touches_bottom = new_touches_bottom;
 
 	if (horizontal) {
 		path_hb->reparent(toolbar_hbc);

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -187,6 +187,7 @@ private:
 	DisplayMode old_display_mode;
 
 	bool horizontal = false;
+	bool touches_bottom = false;
 
 	PopupMenu *file_list_popup = nullptr;
 	PopupMenu *tree_popup = nullptr;
@@ -399,7 +400,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	virtual void update_layout(EditorDock::DockLayout p_layout) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
 	virtual void save_layout_to_config(Ref<ConfigFile> &p_layout, const String &p_section) const override;
 	virtual void load_layout_from_config(const Ref<ConfigFile> &p_layout, const String &p_section) override;
 

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -2158,8 +2158,8 @@ void TileMapLayerEditorTilesPlugin::edit(ObjectID p_tile_map_layer_id) {
 	edited_tile_map_layer_id = p_tile_map_layer_id;
 }
 
-void TileMapLayerEditorTilesPlugin::update_layout(EditorDock::DockLayout p_layout) {
-	bool is_vertical = (p_layout == EditorDock::DockLayout::DOCK_LAYOUT_VERTICAL);
+void TileMapLayerEditorTilesPlugin::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+	bool is_vertical = (p_layout == EditorDock::DOCK_LAYOUT_VERTICAL);
 	atlas_sources_split_container->set_vertical(is_vertical);
 	atlas_sources_split_container->move_child(split_container_left_side, is_vertical ? -1 : 0);
 	split_container_left_side->set_vertical(!is_vertical);
@@ -2174,11 +2174,11 @@ void TileMapLayerEditorTilesPlugin::update_layout(EditorDock::DockLayout p_layou
 	bucket_contiguous_checkbox->reparent(is_vertical ? wide_toolbar : tools_settings);
 	scatter_controls_container->reparent(is_vertical ? wide_toolbar : tools_settings);
 
-	if (p_layout == EditorDock::DockLayout::DOCK_LAYOUT_FLOATING) {
+	if (p_layout == EditorDock::DOCK_LAYOUT_FLOATING || (!is_vertical && p_slot != EditorDock::DOCK_SLOT_BOTTOM)) {
 		patterns_mc->set_theme_type_variation("NoBorderHorizontalBottom");
 		patterns_item_list->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_TOP);
 	} else {
-		patterns_mc->set_theme_type_variation(is_vertical ? "" : "NoBorderBottomPanel");
+		patterns_mc->set_theme_type_variation(is_vertical ? "" : "NoBorderHorizontal");
 		patterns_item_list->set_scroll_hint_mode(is_vertical ? ItemList::SCROLL_HINT_MODE_DISABLED : ItemList::SCROLL_HINT_MODE_BOTH);
 	}
 	patterns_item_list->set_theme_type_variation(is_vertical ? "ItemListSecondary" : "");
@@ -3500,7 +3500,7 @@ void TileMapLayerEditorTerrainsPlugin::edit(ObjectID p_edited_tile_map_layer_id)
 	}
 }
 
-void TileMapLayerEditorTerrainsPlugin::update_layout(EditorDock::DockLayout p_layout) {
+void TileMapLayerEditorTerrainsPlugin::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
 	bool is_vertical = (p_layout == EditorDock::DockLayout::DOCK_LAYOUT_VERTICAL);
 	// Main Panel.
 	main_box_container->set_vertical(is_vertical);
@@ -4480,7 +4480,7 @@ void TileMapLayerEditor::_update_layer_selector_layout(bool p_is_vertical) {
 	}
 }
 
-void TileMapLayerEditor::update_layout(DockLayout p_layout) {
+void TileMapLayerEditor::update_layout(DockLayout p_layout, DockSlot p_slot) {
 	bool is_vertical = (p_layout == EditorDock::DockLayout::DOCK_LAYOUT_VERTICAL);
 	tile_map_toolbar->set_vertical(is_vertical);
 	layer_selector_separator->set_vertical(is_vertical);
@@ -4506,7 +4506,7 @@ void TileMapLayerEditor::update_layout(DockLayout p_layout) {
 
 	// Propagate layout change to sub plugins
 	for (TileMapLayerSubEditorPlugin *tab_plugin : tabs_plugins) {
-		tab_plugin->update_layout(p_layout);
+		tab_plugin->update_layout(p_layout, p_slot);
 	}
 }
 

--- a/editor/scene/2d/tiles/tile_map_layer_editor.h
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.h
@@ -88,7 +88,7 @@ public:
 	virtual void tile_set_changed() {}
 	virtual void edit(ObjectID p_tile_map_layer_id) {}
 	virtual void draw_tile_coords_over_viewport(Control *p_overlay, const TileMapLayer *p_edited_layer, Ref<TileSet> p_tile_set, bool p_show_rectangle_size, const Vector2i &p_rectangle_origin);
-	virtual void update_layout(EditorDock::DockLayout p_layout) {}
+	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {}
 };
 
 class TileMapLayerEditorTilesPlugin : public TileMapLayerSubEditorPlugin {
@@ -264,7 +264,7 @@ public:
 	virtual Vector<TabData> get_tabs() const override;
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override;
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override;
-	virtual void update_layout(EditorDock::DockLayout p_layout) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
 
 	virtual void edit(ObjectID p_tile_map_layer_id) override;
 
@@ -358,7 +358,7 @@ public:
 	virtual Vector<TabData> get_tabs() const override;
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override;
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override;
-	virtual void update_layout(EditorDock::DockLayout p_layout) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
 
 	virtual void edit(ObjectID p_tile_map_layer_id) override;
 
@@ -447,7 +447,7 @@ private:
 protected:
 	void _notification(int p_what);
 	void _draw_shape(Control *p_control, Rect2 p_region, TileSet::TileShape p_shape, TileSet::TileOffsetAxis p_offset_axis, Color p_color);
-	virtual void update_layout(DockLayout p_layout) override;
+	virtual void update_layout(DockLayout p_layout, DockSlot p_slot) override;
 
 public:
 	bool forward_canvas_gui_input(const Ref<InputEvent> &p_event);

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -413,6 +413,16 @@ void TileSetEditor::_notification(int p_what) {
 	}
 }
 
+void TileSetEditor::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+	if (p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
+		patterns_mc->set_theme_type_variation("NoBorderHorizontalBottom");
+		patterns_item_list->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_TOP);
+	} else {
+		patterns_mc->set_theme_type_variation("NoBorderHorizontal");
+		patterns_item_list->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_BOTH);
+	}
+}
+
 void TileSetEditor::_patterns_item_list_gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(tile_set.is_null());
 
@@ -965,7 +975,7 @@ TileSetEditor::TileSetEditor() {
 
 	patterns_mc = memnew(MarginContainer);
 	patterns_mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	patterns_mc->set_theme_type_variation("NoBorderBottomPanel");
+	patterns_mc->set_theme_type_variation("NoBorderHorizontal");
 	main_vb->add_child(patterns_mc);
 	patterns_mc->hide();
 

--- a/editor/scene/2d/tiles/tile_set_editor.h
+++ b/editor/scene/2d/tiles/tile_set_editor.h
@@ -115,6 +115,8 @@ private:
 protected:
 	void _notification(int p_what);
 
+	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
+
 public:
 	_FORCE_INLINE_ static TileSetEditor *get_singleton() { return singleton; }
 

--- a/editor/scene/resource_preloader_editor_plugin.cpp
+++ b/editor/scene/resource_preloader_editor_plugin.cpp
@@ -348,14 +348,8 @@ void ResourcePreloaderEditor::drop_data_fw(const Point2 &p_point, const Variant 
 	}
 }
 
-void ResourcePreloaderEditor::update_layout(EditorDock::DockLayout p_layout) {
-	bool new_horizontal = (p_layout == EditorDock::DOCK_LAYOUT_HORIZONTAL);
-	if (horizontal == new_horizontal) {
-		return;
-	}
-	horizontal = new_horizontal;
-
-	if (horizontal) {
+void ResourcePreloaderEditor::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+	if (p_layout == EditorDock::DOCK_LAYOUT_HORIZONTAL && p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
 		mc->set_theme_type_variation("NoBorderHorizontal");
 		tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
 	} else {

--- a/editor/scene/resource_preloader_editor_plugin.h
+++ b/editor/scene/resource_preloader_editor_plugin.h
@@ -53,7 +53,6 @@ class ResourcePreloaderEditor : public EditorDock {
 	MarginContainer *mc = nullptr;
 	Tree *tree = nullptr;
 
-	bool horizontal = false;
 	bool loading_scene = false;
 
 	EditorFileDialog *file = nullptr;
@@ -78,7 +77,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	virtual void update_layout(EditorDock::DockLayout p_layout) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
 
 public:
 	void edit(ResourcePreloader *p_preloader);

--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -737,19 +737,13 @@ void FindInFilesPanel::stop_search() {
 	cancel_button->hide();
 }
 
-void FindInFilesPanel::update_layout(EditorDock::DockLayout p_layout) {
-	bool new_floating = (p_layout == EditorDock::DOCK_LAYOUT_FLOATING);
-	if (floating == new_floating) {
-		return;
-	}
-	floating = new_floating;
-
-	if (floating) {
-		results_mc->set_theme_type_variation("NoBorderHorizontalBottom");
-		results_display->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
-	} else {
-		results_mc->set_theme_type_variation("NoBorderHorizontal");
+void FindInFilesPanel::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+	if (p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
+		results_display->set_theme_type_variation("NoBorderHorizontal");
 		results_display->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
+	} else {
+		results_display->set_theme_type_variation("NoBorderHorizontalBottom");
+		results_display->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
 	}
 }
 
@@ -1462,11 +1456,11 @@ void FindInFilesContainer::_bar_input(const Ref<InputEvent> &p_input) {
 	}
 }
 
-void FindInFilesContainer::update_layout(EditorDock::DockLayout p_layout) {
+void FindInFilesContainer::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
 	for (Node *node : tabs->iterate_children()) {
 		FindInFilesPanel *panel = Object::cast_to<FindInFilesPanel>(node);
 		if (panel) {
-			panel->update_layout(p_layout);
+			panel->update_layout(p_layout, p_slot);
 		}
 	}
 }

--- a/editor/script/find_in_files.h
+++ b/editor/script/find_in_files.h
@@ -186,7 +186,6 @@ class FindInFilesPanel : public MarginContainer {
 	LineEdit *replace_line_edit = nullptr;
 	Button *replace_all_button = nullptr;
 
-	bool floating = false;
 	MarginContainer *results_mc = nullptr;
 
 	void _on_button_clicked(TreeItem *p_item, int p_column, int p_id, int p_mouse_button_index);
@@ -225,7 +224,7 @@ public:
 	void start_search();
 	void stop_search();
 
-	void update_layout(EditorDock::DockLayout p_layout);
+	void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot);
 
 	FindInFilesPanel();
 };
@@ -270,7 +269,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual void update_layout(EditorDock::DockLayout p_layout) override;
+	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
 
 	FindInFilesPanel *get_panel_for_results(const String &p_label);
 

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1777,6 +1777,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// Bottom panel.
 		Ref<StyleBoxFlat> style_bottom_panel = p_config.content_panel_style->duplicate();
+		style_bottom_panel->set_content_margin_all(p_config.tab_container_style->get_content_margin(SIDE_LEFT));
 		style_bottom_panel->set_border_width(SIDE_BOTTOM, 0);
 		style_bottom_panel->set_corner_radius_all(p_config.corner_radius * EDSCALE);
 		style_bottom_panel->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
@@ -2079,20 +2080,17 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_constant("margin_left", "NoBorderAssetLibProjectManagerHorizontal", margin);
 			p_theme->set_constant("margin_right", "NoBorderAssetLibProjectManagerHorizontal", margin);
 
-			int bottom_margin = p_theme->get_stylebox(SNAME("BottomPanel"), EditorStringName(EditorStyles))->get_content_margin(SIDE_LEFT);
-			margin = -bottom_margin;
-
-			// Used in editors residing in the bottom panel.
-			p_theme->set_type_variation("NoBorderBottomPanel", "MarginContainer");
-			p_theme->set_constant("margin_left", "NoBorderBottomPanel", margin);
-			p_theme->set_constant("margin_right", "NoBorderBottomPanel", margin);
-
-			margin = -panel_margin - bottom_margin;
+			int bottom_panel_margin = p_theme->get_stylebox(SNAME("BottomPanel"), EditorStringName(EditorStyles))->get_content_margin(SIDE_LEFT);
+			margin = -panel_margin - bottom_panel_margin;
 
 			// Used in the animation track editor.
 			p_theme->set_type_variation("NoBorderAnimation", "MarginContainer");
 			p_theme->set_constant("margin_left", "NoBorderAnimation", margin);
 			p_theme->set_constant("margin_right", "NoBorderAnimation", margin);
+
+			// Used in the OpenXR action map editor.
+			p_theme->set_type_variation("NoBorderOpenXR", "NoBorderAnimation");
+			p_theme->set_constant("margin_bottom", "NoBorderOpenXR", -panel_margin);
 
 			margin = -p_theme->get_stylebox(SceneStringName(panel), SNAME("AcceptDialog"))->get_content_margin(SIDE_LEFT);
 

--- a/misc/extension_api_validation/4.7-stable/GH-117080.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-117080.txt
@@ -1,0 +1,5 @@
+GH-117080
+---------
+Validate extension JSON: Error: Field 'classes/EditorDock/methods/_update_layout/arguments': size changed value in new API, from 1 to 2.
+
+Add an extra argument for the slot. Compatibility method registered.

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1074,6 +1074,19 @@ void GridMapEditor::_icon_size_changed(float p_value) {
 	update_palette();
 }
 
+void GridMapEditor::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+	if (categories->is_visible()) {
+		item_palette_mc->set_theme_type_variation("");
+		mesh_library_palette->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_DISABLED);
+		mesh_library_palette->set_theme_type_variation("ItemListSecondary");
+	} else {
+		bool is_bottom = p_slot == EditorDock::DOCK_SLOT_BOTTOM;
+		item_palette_mc->set_theme_type_variation(is_bottom ? "NoBorderHorizontal" : "NoBorderHorizontalBottom");
+		mesh_library_palette->set_scroll_hint_mode(is_bottom ? ItemList::SCROLL_HINT_MODE_BOTH : ItemList::SCROLL_HINT_MODE_TOP);
+		mesh_library_palette->set_theme_type_variation("");
+	}
+}
+
 void GridMapEditor::update_palette() {
 	float min_size = EDITOR_GET("editors/grid_map/preview_size");
 	min_size *= EDSCALE;
@@ -1183,9 +1196,7 @@ void GridMapEditor::_rebuild_categories() {
 
 	if (mesh_library.is_null()) {
 		categories->hide();
-		item_palette_mc->set_theme_type_variation("NoBorderBottomPanel");
-		mesh_library_palette->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_BOTH);
-		mesh_library_palette->set_theme_type_variation("");
+		update_layout(get_current_layout(), get_current_slot());
 
 		return;
 	}
@@ -1254,12 +1265,10 @@ void GridMapEditor::_rebuild_categories() {
 				item_mapping);
 	}
 
-	bool has_categories = !root_categories.is_empty();
-	categories->set_visible(has_categories); // Only show the category tree if there are categories present.
-	item_palette_mc->set_theme_type_variation(has_categories ? "" : "NoBorderBottomPanel");
-	mesh_library_palette->set_scroll_hint_mode(has_categories ? ItemList::SCROLL_HINT_MODE_DISABLED : ItemList::SCROLL_HINT_MODE_BOTH);
-	mesh_library_palette->set_theme_type_variation(has_categories ? "ItemListSecondary" : "");
+	// Only show the category tree if there are categories present.
+	categories->set_visible(!root_categories.is_empty());
 
+	update_layout(get_current_layout(), get_current_slot());
 	update_palette();
 }
 

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -283,6 +283,8 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
+
 public:
 	EditorPlugin::AfterGUIInput forward_spatial_input_event(Camera3D *p_camera, const Ref<InputEvent> &p_event);
 

--- a/modules/multiplayer/editor/replication_editor.cpp
+++ b/modules/multiplayer/editor/replication_editor.cpp
@@ -264,6 +264,11 @@ ReplicationEditor::ReplicationEditor() {
 	pin->set_tooltip_text(TTRC("Pin replication editor"));
 	hb->add_child(pin);
 
+	tree_mc = memnew(MarginContainer);
+	tree_mc->set_theme_type_variation("NoBorderHorizontal");
+	tree_mc->set_v_size_flags(SIZE_EXPAND_FILL);
+	vb->add_child(tree_mc);
+
 	tree = memnew(Tree);
 	tree->set_hide_root(true);
 	tree->set_columns(4);
@@ -280,8 +285,8 @@ ReplicationEditor::ReplicationEditor() {
 	tree->create_item();
 	tree->connect("button_clicked", callable_mp(this, &ReplicationEditor::_tree_button_pressed));
 	tree->connect("item_edited", callable_mp(this, &ReplicationEditor::_tree_item_edited));
-	tree->set_v_size_flags(SIZE_EXPAND_FILL);
-	vb->add_child(tree);
+	tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTTOM);
+	tree_mc->add_child(tree);
 
 	drop_label = memnew(Label(TTRC("Add properties using the options above, or\ndrag them from the inspector and drop them here.")));
 	drop_label->set_focus_mode(FOCUS_ACCESSIBILITY);
@@ -524,6 +529,16 @@ void ReplicationEditor::_update_config() {
 	for (int i = 0; i < props.size(); i++) {
 		const NodePath path = props[i];
 		_add_property(path, config->property_get_spawn(path), config->property_get_replication_mode(path));
+	}
+}
+
+void ReplicationEditor::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+	if (p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
+		tree_mc->set_theme_type_variation("NoBorderHorizontalBottom");
+		tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_DISABLED);
+	} else {
+		tree_mc->set_theme_type_variation("NoBorderHorizontal");
+		tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTTOM);
 	}
 }
 

--- a/modules/multiplayer/editor/replication_editor.h
+++ b/modules/multiplayer/editor/replication_editor.h
@@ -59,6 +59,8 @@ private:
 
 	Ref<SceneReplicationConfig> config;
 	NodePath deleting;
+
+	MarginContainer *tree_mc = nullptr;
 	Tree *tree = nullptr;
 
 	PropertySelector *prop_selector = nullptr;
@@ -91,9 +93,10 @@ private:
 	void _add_sync_property(String p_path);
 
 protected:
+	void _notification(int p_what);
 	static void _bind_methods();
 
-	void _notification(int p_what);
+	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
 
 public:
 	void edit(MultiplayerSynchronizer *p_object);

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -64,21 +64,24 @@ void OpenXRActionMapEditor::_bind_methods() {
 void OpenXRActionMapEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			const String theme_style = EDITOR_GET("interface/theme/style");
-			tabs->set_theme_type_variation(theme_style == "Classic" ? "TabContainerOdd" : "TabContainerInner");
-
-			for (int i = 0; i < tabs->get_child_count(); i++) {
-				Control *tab = Object::cast_to<Control>(tabs->get_child(i));
-				if (tab) {
-					tab->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
-				}
-			}
+			const bool is_theme_classic = EDITOR_GET("interface/theme/style") == "Classic";
+			tabs->set_theme_type_variation(is_theme_classic ? "TabContainerOdd" : "TabContainerInner");
 		} break;
 
 		case NOTIFICATION_READY: {
 			_create_action_sets();
 			_create_interaction_profiles();
 		} break;
+	}
+}
+
+void OpenXRActionMapEditor::update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) {
+	if (p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
+		actionsets_mc->set_theme_type_variation("NoBorderHorizontalBottomWide");
+		actionsets_scroll->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_TOP_AND_LEFT);
+	} else {
+		actionsets_mc->set_theme_type_variation("NoBorderOpenXR");
+		actionsets_scroll->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_ALL);
 	}
 }
 
@@ -510,12 +513,17 @@ OpenXRActionMapEditor::OpenXRActionMapEditor() {
 	tabs->connect("tab_button_pressed", callable_mp(this, &OpenXRActionMapEditor::_on_tab_button_pressed));
 	main_vb->add_child(tabs);
 
+	actionsets_mc = memnew(MarginContainer);
+	actionsets_mc->set_theme_type_variation("NoBorderOpenXR");
+	tabs->add_child(actionsets_mc);
+	actionsets_mc->set_name(TTRC("Action Sets"));
+
 	actionsets_scroll = memnew(ScrollContainer);
 	actionsets_scroll->set_h_size_flags(SIZE_EXPAND_FILL);
 	actionsets_scroll->set_v_size_flags(SIZE_EXPAND_FILL);
 	actionsets_scroll->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
-	tabs->add_child(actionsets_scroll);
-	actionsets_scroll->set_name(TTR("Action Sets"));
+	actionsets_scroll->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_ALL);
+	actionsets_mc->add_child(actionsets_scroll);
 
 	actionsets_vb = memnew(VBoxContainer);
 	actionsets_vb->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/modules/openxr/editor/openxr_action_map_editor.h
+++ b/modules/openxr/editor/openxr_action_map_editor.h
@@ -64,6 +64,7 @@ private:
 	Button *save_as = nullptr;
 	Button *_default = nullptr;
 	TabContainer *tabs = nullptr;
+	MarginContainer *actionsets_mc = nullptr;
 	ScrollContainer *actionsets_scroll = nullptr;
 	VBoxContainer *actionsets_vb = nullptr;
 	OpenXRSelectInteractionProfileDialog *select_interaction_profile_dialog = nullptr;
@@ -95,6 +96,8 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+
+	virtual void update_layout(EditorDock::DockLayout p_layout, EditorDock::DockSlot p_slot) override;
 
 	void _clear_action_map();
 

--- a/modules/openxr/editor/openxr_interaction_profile_editor.cpp
+++ b/modules/openxr/editor/openxr_interaction_profile_editor.cpp
@@ -35,6 +35,7 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "editor/editor_string_names.h"
+#include "editor/settings/editor_settings.h"
 
 ///////////////////////////////////////////////////////////////////////////
 // Interaction profile editor base
@@ -175,6 +176,7 @@ OpenXRInteractionProfileEditorBase::OpenXRInteractionProfileEditorBase() {
 	set_v_size_flags(SIZE_EXPAND_FILL);
 
 	interaction_profile_sc = memnew(ScrollContainer);
+	interaction_profile_sc->set_theme_type_variation("ScrollContainerSecondary");
 	interaction_profile_sc->set_h_size_flags(SIZE_EXPAND_FILL);
 	interaction_profile_sc->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(interaction_profile_sc);
@@ -398,7 +400,10 @@ void OpenXRInteractionProfileEditor::_update_interaction_profile() {
 void OpenXRInteractionProfileEditor::_theme_changed() {
 	OpenXRInteractionProfileEditorBase::_theme_changed();
 
-	interaction_profile_sc->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
+	const bool is_theme_classic = EDITOR_GET("interface/theme/style") == "Classic";
+	if (is_theme_classic) {
+		interaction_profile_sc->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
+	}
 
 	for (int i = 0; i < interaction_profile_hb->get_child_count(); i++) {
 		Control *panel = Object::cast_to<Control>(interaction_profile_hb->get_child(i));


### PR DESCRIPTION
- Change the `update_layout()` function to also pass the slot, still compatible with the solo argument one. This is necessary for some of the changes below.
- Make the center bottom dock share the same border size as other docks.
- Adjust scroll hints of some docks when placing them in the lower bottom slots.
- Add scroll hints to the OpenXR Action Map editor.
- Fix wrong theming in the OpenXR Action Map editor.

Sorry if this seems like a mashup of unrelated changes, but most of them do need of one another.