### PR TITLE
Profiler: Fix for graph stopping when excessive zooming consumes the CPU

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -553,15 +553,21 @@ void EditorProfiler::_graph_tex_input(const Ref<InputEvent> &p_ev) {
 
 	if (button_idx == MouseButton::WHEEL_DOWN) {
 		// Zooming.
+		float current_graph_zoom = graph_zoom;
 		graph_zoom = MAX(-0.05 + graph_zoom, 0);
-		_update_plot();
+		if (current_graph_zoom != graph_zoom) {
+			_update_plot();
+		}
 	} else if (button_idx == MouseButton::WHEEL_UP) {
 		if (graph_zoom == 0) {
 			zoom_center = me->get_position().x;
 			zoom_center = zoom_center * frame_metrics.size() / graph->get_size().width;
 		}
+		float current_graph_zoom = graph_zoom;
 		graph_zoom = MIN(0.05 + graph_zoom, 2);
-		_update_plot();
+		if (current_graph_zoom != graph_zoom) {
+			_update_plot();
+		}
 	}
 
 	graph->queue_redraw();


### PR DESCRIPTION
This is a bug where the user can overload the CPU and the profiler by continuous zooming in or out.
The Godot editor app will slow way down and the profiler graph will stop updating.
It looks like everything is stuck to the user.

The issue was that the zoom was causing a re-draw of the profiler graph very quickly even if the graph was already at max zoom or min zoom.

8 line code change in 1 file.

The new code stops the graph re-drawing after you have reached the min or max zoom.

The Godot editor app will no longer temporary lock up.

*******************************
Disclosure and License
-As a software engineer I use many systems to ensure code quality, and that includes AI. I use the AI to: do detailed code analysis, be a sounding board for my different ideas, look for bugs, find unexpected behaviors, identify performance hot spots, expensive CPU calls, race conditions, poorly placed variable initializations, possible optimizations, and many more things. I do this during development and before I push code to the repo. It lists items that are potential problems and I decide what I think is important and make those changes.
-For a descriptive example of my AI usage on a particular PR please read this https://github.com/godotengine/godot/pull/117066#issuecomment-4061773098
-Any and all code attached to this PR falls under the coverage of the MIT License.