### PR TITLE
Profiler: Fix for graph disappears when user stops and starts profiler while zoomed in

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -98,6 +98,7 @@ void EditorProfiler::clear() {
 	frame_metrics.resize(metric_size);
 	total_metrics = 0;
 	last_metric = -1;
+	zoom_center = -1;
 	variables->clear();
 	plot_sigs.clear();
 	plot_sigs.insert("physics_frame_time");


### PR DESCRIPTION
This is a bug where the user pauses the profiler and zooms into the graph. They then stop the profiler and restart it. Because the zoom did not get reset the user sees no profiler graph and thinks it's not working. Is it in fact working but the graph is way to the left because of the previous zoom state.

Another way to reproduce this bug. Start profiling, zoom in to a section of the graph way to the right, press the "Clear" button in the profiler. The graph will disappear. This confuses the user who see an empty graph and thinks it's not working. It is working, it's just all the way to the left where they can't see it because of the zoom. This PR fixes the issue by moving (resetting the variable) the graph to where the user can see it.

1 line of code added to 1 file. 
That 1 line sets 1 variable to it's original initialized state when the user clears the data from the profiler graph.

With this fix the user will no longer think the profiler graph is broken when they stop and start (or Clear) it while zoomed in.

*******************************
Disclosure and License
-As a software engineer I use many systems to ensure code quality, and that includes AI. I use the AI to: do detailed code analysis, be a sounding board for my different ideas, look for bugs, find unexpected behaviors, identify performance hot spots, expensive CPU calls, race conditions, poorly placed variable initializations, possible optimizations, and many more things. I do this during development and before I push code to the repo. It lists items that are potential problems and I decide what I think is important and make those changes.
-For a descriptive example of my AI usage on a particular PR please read this https://github.com/godotengine/godot/pull/117066#issuecomment-4061773098
-Any and all code attached to this PR falls under the coverage of the MIT License.