### PR TITLE
Add missing code snippet copy notification to `EditorHelpBit`

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -4343,6 +4343,7 @@ void EditorHelpBit::_meta_clicked(const String &p_select) {
 		OS::get_singleton()->shell_open(p_select);
 	} else if (p_select.begins_with("^")) { // Copy button.
 		DisplayServer::get_singleton()->clipboard_set(p_select.substr(1));
+		EditorToaster::get_singleton()->popup_str(TTR("Code snippet copied to clipboard."), EditorToaster::SEVERITY_INFO);
 	}
 }
 


### PR DESCRIPTION
* See #99451.

https://github.com/godotengine/godot/blob/fe6f78a4c788e6a9fddb333d1cb467ee572262e8/editor/doc/editor_help.cpp#L381-L384

This notification appears when copying code into `EditorHelp`, but does not appear in `EditorHelpBit`.