### PR TITLE
Add Array Variables to Project Settings

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -241,6 +241,21 @@ void ProjectSettings::set_as_internal(const String &p_name, bool p_internal) {
 	props[p_name].internal = p_internal;
 }
 
+void ProjectSettings::set_array_format(const String &p_prefix, const Vector<ArrayElementFormat> &p_format) {
+	ArrayFormat format = ArrayFormat(p_prefix, p_format, array_formats.size());
+
+	if (array_format_map.has(p_prefix)) {
+		format.array_index = array_format_map.get(p_prefix).array_index;
+		array_formats.write[format.array_index] = format;
+
+		array_format_map[p_prefix] = format;
+		return;
+	}
+
+	array_format_map.insert(p_prefix, format);
+	array_formats.push_back(format);
+}
+
 void ProjectSettings::set_ignore_value_in_docs(const String &p_name, bool p_ignore) {
 	ERR_FAIL_COND_MSG(!props.has(p_name), vformat("Request for nonexistent project setting: '%s'.", p_name));
 #ifdef DEBUG_ENABLED
@@ -255,6 +270,10 @@ bool ProjectSettings::get_ignore_value_in_docs(const String &p_name) const {
 #else
 	return false;
 #endif // DEBUG_ENABLED
+}
+
+bool ProjectSettings::get_is_array_internal(const String &p_name) const {
+	return _get_array_count_variable(p_name, nullptr) || _get_array_variable(p_name, nullptr, nullptr, nullptr);
 }
 
 void ProjectSettings::add_hidden_prefix(const String &p_prefix) {
@@ -338,6 +357,27 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 			}
 		}
 
+		{
+			// Because of how EditorInspectorArray is implemented, this needs to pretend that
+			// each element of each array (and their counts) exist as separate variables that
+			// can be modified by calling get() and set().
+
+			String array_prefix;
+			if (_get_array_count_variable(p_name, &array_prefix)) {
+				_set_array_length(array_prefix, p_value);
+				_queue_changed(p_name);
+				return true;
+			}
+
+			String array_key;
+			int array_index;
+			if (_get_array_variable(p_name, &array_prefix, &array_key, &array_index)) {
+				_set_array_value(array_prefix, array_index, array_key, p_value);
+				_queue_changed(p_name);
+				return true;
+			}
+		}
+
 		if (props.has(p_name)) {
 			props[p_name].variant = p_value;
 		} else {
@@ -382,10 +422,112 @@ bool ProjectSettings::_get(const StringName &p_name, Variant &r_ret) const {
 	_THREAD_SAFE_METHOD_
 
 	if (!props.has(p_name)) {
+		String array_prefix;
+		if (_get_array_count_variable(p_name, &array_prefix)) {
+			r_ret = _get_array_length(array_prefix);
+			return true;
+		}
+
+		String array_key;
+		int array_index;
+		if (_get_array_variable(p_name, &array_prefix, &array_key, &array_index)) {
+			r_ret = _get_array_value(array_prefix, array_index, array_key);
+			return true;
+		}
+
 		return false;
 	}
 	r_ret = props[p_name].variant;
 	return true;
+}
+
+int ProjectSettings::_get_array_length(const String &p_prefix) const {
+	Array array = get(p_prefix);
+	return array.size();
+}
+
+void ProjectSettings::_set_array_length(const String &p_prefix, const int p_length) {
+	if (!props.has(p_prefix)) {
+		set(p_prefix, Array());
+	}
+
+	Array array = get_setting(p_prefix);
+	int old_size = array.size();
+	array.resize(p_length);
+
+	const ArrayFormat &format = array_format_map[p_prefix];
+	for (int i = old_size; i < p_length; i++) {
+		Dictionary dict;
+		for (const ArrayElementFormat &elem_format : format.format) {
+			dict.set(elem_format.info.name, elem_format.v_default);
+		}
+
+		array[i] = dict;
+	}
+
+	// Need to notify property list changed here, as EditorInspectorArray will not update the GUI
+	// otherwise.
+	notify_property_list_changed();
+}
+
+void ProjectSettings::_set_array_value(const String &p_prefix, const int p_index, const String &p_key, const Variant &p_value) {
+	Array array = get(p_prefix);
+	Dictionary value = array[p_index];
+	value.set(p_key, p_value);
+}
+
+Variant ProjectSettings::_get_array_value(const String &p_prefix, const int p_index, const String &p_key) const {
+	Array array = get(p_prefix);
+	Dictionary value = array[p_index];
+	return value.get(p_key, Variant());
+}
+
+bool ProjectSettings::_get_array_count_variable(const StringName &p_name, String *r_prefix) const {
+	if (p_name.operator String().ends_with("_count")) {
+		String prefix = p_name.operator String().trim_suffix("_count");
+		if (array_format_map.has(prefix)) {
+			if (r_prefix != nullptr) {
+				*r_prefix = prefix;
+			}
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool ProjectSettings::_get_array_variable(const StringName &p_name, String *r_prefix, String *r_variable, int *r_index) const {
+	const Vector<String> components = p_name.operator String().rsplit("/", true, 1);
+	if (components.size() >= 2) {
+		String prefix = components[0];
+		String stripped_prefix;
+		for (int i = prefix.length() - 1; i >= 0; i--) {
+			// Strip numbers from the end to get the actual prefix for a fast lookup.
+			if (!is_digit(prefix[i])) {
+				stripped_prefix = prefix.substr(0, i + 1);
+				break;
+			}
+		}
+		if (!stripped_prefix.is_empty() && array_format_map.has(stripped_prefix)) {
+			String index_string = prefix.trim_prefix(stripped_prefix);
+			if (r_index != nullptr) {
+				if (index_string.is_valid_int()) {
+					*r_index = index_string.to_int();
+				} else {
+					*r_index = -1;
+				}
+			}
+			if (r_prefix != nullptr) {
+				*r_prefix = stripped_prefix;
+			}
+			if (r_variable != nullptr) {
+				*r_variable = components[1];
+			}
+			return true;
+		}
+	}
+
+	return false;
 }
 
 Variant ProjectSettings::get_setting_with_override_and_custom_features(const StringName &p_name, const Vector<String> &p_features) const {
@@ -510,8 +652,8 @@ void ProjectSettings::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (const _VCSort &base : vclist) {
 		if (custom_prop_info.has(base.name)) {
 			PropertyInfo pi = custom_prop_info[base.name];
-			pi.name = base.name;
-			pi.usage = base.flags;
+			pi.name = pi.usage & PROPERTY_USAGE_ARRAY ? pi.name : base.name;
+			pi.usage = base.flags | (pi.usage & PROPERTY_USAGE_ARRAY);
 			p_list->push_back(pi);
 #ifdef TOOLS_ENABLED
 		} else if (base.name.begins_with(EDITOR_SETTING_OVERRIDE_PREFIX)) {
@@ -545,6 +687,32 @@ void ProjectSettings::_get_property_list(List<PropertyInfo> *p_list) const {
 				} else {
 					p_list->push_back(PropertyInfo(over.type, over.name, PROPERTY_HINT_NONE, "", over.flags));
 				}
+			}
+		}
+	}
+
+	for (const ArrayFormat &format : array_formats) {
+		const VariantContainer *v = &props[format.prefix];
+		int flags = 0;
+
+		// Not handling internal flags here because the whole point of PROPERTY_USAGE_ARRAY is
+		// for the GUI.
+		if (v->basic) {
+			flags |= PROPERTY_USAGE_EDITOR_BASIC_SETTING;
+		}
+
+		if (v->restart_if_changed) {
+			flags |= PROPERTY_USAGE_RESTART_IF_CHANGED;
+		}
+
+		for (const ArrayElementFormat &element_format : format.format) {
+			int count = _get_array_length(format.prefix);
+			PropertyInfo pi = element_format.info;
+			pi.usage |= flags;
+
+			for (int j = 0; j < count; j++) {
+				pi.name = vformat("%s%d/%s", format.prefix, j, element_format.info.name);
+				p_list->push_back(pi);
 			}
 		}
 	}
@@ -1345,6 +1513,23 @@ Variant _GLOBAL_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p
 	return ret;
 }
 
+Variant _GLOBAL_DEF_ARRAY(const String &p_var, const Vector<ProjectSettings::ArrayElementFormat> &p_format, bool p_restart_if_changed, bool p_ignore_value_in_docs, bool p_basic, bool p_internal) {
+	return _GLOBAL_DEF_ARRAY(PropertyInfo(Variant::INT, p_var), p_format, p_restart_if_changed, p_ignore_value_in_docs, p_basic, p_internal);
+}
+
+Variant _GLOBAL_DEF_ARRAY(const PropertyInfo &p_info, const Vector<ProjectSettings::ArrayElementFormat> &p_format, bool p_restart_if_changed, bool p_ignore_value_in_docs, bool p_basic, bool p_internal) {
+	PropertyInfo info = p_info;
+	info.type = Variant::INT;
+	info.usage |= PROPERTY_USAGE_ARRAY;
+	int name_index = p_info.name.rfind_char('/');
+	String label_name = name_index == -1 ? p_info.name : p_info.name.substr(name_index + 1);
+	info.class_name = vformat("%s,%s", label_name.capitalize(), label_name);
+
+	Variant ret = _GLOBAL_DEF(info, Array(), p_restart_if_changed, p_ignore_value_in_docs, p_basic, p_internal);
+	ProjectSettings::get_singleton()->set_array_format(p_info.name, p_format);
+	return ret;
+}
+
 void ProjectSettings::_add_property_info_bind(const Dictionary &p_info) {
 	ERR_FAIL_COND_MSG(!p_info.has("name"), "Property info is missing \"name\" field.");
 	ERR_FAIL_COND_MSG(!p_info.has("type"), "Property info is missing \"type\" field.");
@@ -1372,7 +1557,11 @@ void ProjectSettings::_add_property_info_bind(const Dictionary &p_info) {
 void ProjectSettings::set_custom_property_info(const PropertyInfo &p_info) {
 	const String &prop_name = p_info.name;
 	ERR_FAIL_COND(!props.has(prop_name));
-	custom_prop_info[prop_name] = p_info;
+	PropertyInfo info = p_info;
+	if (p_info.usage & PROPERTY_USAGE_ARRAY) {
+		info.name += "_count";
+	}
+	custom_prop_info[prop_name] = info;
 }
 
 const HashMap<StringName, PropertyInfo> &ProjectSettings::get_custom_property_info() const {

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -70,6 +70,31 @@ public:
 		bool is_singleton = false;
 	};
 
+	struct ArrayElementFormat {
+		PropertyInfo info;
+		Variant v_default;
+
+		ArrayElementFormat(const PropertyInfo &p_info, const Variant &p_default) :
+				info(p_info),
+				v_default(p_default) {
+		}
+	};
+
+	struct ArrayFormat {
+		String prefix;
+		Vector<ArrayElementFormat> format;
+		int array_index = 0;
+
+		ArrayFormat() {
+		}
+
+		ArrayFormat(const String &p_prefix, const Vector<ArrayElementFormat> &p_format, int p_array_index) :
+				prefix(p_prefix),
+				format(p_format),
+				array_index(p_array_index) {
+		}
+	};
+
 protected:
 	struct VariantContainer {
 		int order = 0;
@@ -104,6 +129,10 @@ protected:
 	bool project_loaded = false;
 	List<String> input_presets;
 
+	// Hash map of array formats, with the array's prefix as the key.
+	HashMap<String, ArrayFormat> array_format_map;
+	Vector<ArrayFormat> array_formats;
+
 	HashSet<String> custom_features;
 	HashMap<StringName, LocalVector<Pair<StringName, StringName>>> feature_overrides;
 
@@ -122,6 +151,13 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	bool _property_can_revert(const StringName &p_name) const;
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
+
+	int _get_array_length(const String &p_prefix) const;
+	void _set_array_length(const String &p_prefix, const int p_length);
+	void _set_array_value(const String &p_prefix, const int p_index, const String &p_key, const Variant &p_value);
+	Variant _get_array_value(const String &p_prefix, const int p_index, const String &p_key) const;
+	bool _get_array_count_variable(const StringName &p_name, String *r_prefix) const;
+	bool _get_array_variable(const StringName &p_name, String *r_prefix, String *r_variable, int *r_index) const;
 
 	void _queue_changed(const StringName &p_name);
 	void _emit_changed();
@@ -177,9 +213,11 @@ public:
 	void set_initial_value(const String &p_name, const Variant &p_value);
 	void set_as_basic(const String &p_name, bool p_basic);
 	void set_as_internal(const String &p_name, bool p_internal);
+	void set_array_format(const String &p_prefix, const Vector<ArrayElementFormat> &p_format);
 	void set_restart_if_changed(const String &p_name, bool p_restart);
 	void set_ignore_value_in_docs(const String &p_name, bool p_ignore);
 	bool get_ignore_value_in_docs(const String &p_name) const;
+	bool get_is_array_internal(const String &p_name) const;
 	void add_hidden_prefix(const String &p_prefix);
 
 	String get_project_data_dir_name() const;
@@ -256,6 +294,8 @@ public:
 // Not a macro any longer.
 Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);
 Variant _GLOBAL_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);
+Variant _GLOBAL_DEF_ARRAY(const String &p_var, const Vector<ProjectSettings::ArrayElementFormat> &p_format, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);
+Variant _GLOBAL_DEF_ARRAY(const PropertyInfo &p_info, const Vector<ProjectSettings::ArrayElementFormat> &p_format, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);
 
 #define GLOBAL_DEF(m_var, m_value) _GLOBAL_DEF(m_var, m_value)
 #define GLOBAL_DEF_RST(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true)
@@ -267,6 +307,20 @@ Variant _GLOBAL_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p
 #define GLOBAL_DEF_RST_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, false, true)
 #define GLOBAL_DEF_NOVAL_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, true, true)
 #define GLOBAL_DEF_RST_NOVAL_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, true, true)
+
+// These macros allow for an array of dictionaries to be exposed as a neat list in project settings.
+// The underlying variable will exist at the m_var path.
+// Variable args must be formatted like so: {ProjectSettings::ArrayElementFormat(), [...]}, where each
+// ArrayElementFormat describes an element that will exist in each dictionary.
+#define GLOBAL_DEF_ARRAY(m_var, ...) _GLOBAL_DEF_ARRAY(m_var, Vector<ProjectSettings::ArrayElementFormat>(__VA_ARGS__))
+#define GLOBAL_DEF_ARRAY_RST(m_var, ...) _GLOBAL_DEF_ARRAY(m_var, Vector<ProjectSettings::ArrayElementFormat>(__VA_ARGS__), true)
+#define GLOBAL_DEF_ARRAY_NOVAL(m_var, ...) _GLOBAL_DEF_ARRAY(m_var, Vector<ProjectSettings::ArrayElementFormat>(__VA_ARGS__), false, true)
+#define GLOBAL_DEF_ARRAY_RST_NOVAL(m_var, ...) _GLOBAL_DEF_ARRAY(m_var, Vector<ProjectSettings::ArrayElementFormat>(__VA_ARGS__), true, true)
+
+#define GLOBAL_DEF_ARRAY_BASIC(m_var, ...) _GLOBAL_DEF_ARRAY(m_var, Vector<ProjectSettings::ArrayElementFormat>(__VA_ARGS__), false, false, true)
+#define GLOBAL_DEF_ARRAY_RST_BASIC(m_var, ...) _GLOBAL_DEF_ARRAY(m_var, Vector<ProjectSettings::ArrayElementFormat>(__VA_ARGS__), true, false, true)
+#define GLOBAL_DEF_ARRAY_NOVAL_BASIC(m_var, ...) _GLOBAL_DEF_ARRAY(m_var, Vector<ProjectSettings::ArrayElementFormat>(__VA_ARGS__), false, true, true)
+#define GLOBAL_DEF_ARRAY_RST_NOVAL_BASIC(m_var, ...) _GLOBAL_DEF_ARRAY(m_var, Vector<ProjectSettings::ArrayElementFormat>(__VA_ARGS__), true, true, true)
 
 #define GLOBAL_DEF_INTERNAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, false, false, true)
 

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -515,7 +515,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 					}
 				}
 
-				if (E.usage & PROPERTY_USAGE_GROUP || E.usage & PROPERTY_USAGE_SUBGROUP || E.usage & PROPERTY_USAGE_CATEGORY || E.usage & PROPERTY_USAGE_INTERNAL || (E.type == Variant::NIL && E.usage & PROPERTY_USAGE_ARRAY)) {
+				if (E.usage & PROPERTY_USAGE_GROUP || E.usage & PROPERTY_USAGE_SUBGROUP || E.usage & PROPERTY_USAGE_CATEGORY || E.usage & PROPERTY_USAGE_INTERNAL || ((E.type == Variant::NIL) && E.usage & PROPERTY_USAGE_ARRAY)) {
 					continue;
 				}
 
@@ -535,8 +535,8 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 				Variant default_value;
 
 				if (name == "ProjectSettings") {
-					// Special case for project settings, so that settings are not taken from the current project's settings
-					if (!ProjectSettings::get_singleton()->is_builtin_setting(E.name)) {
+					// Special case for project settings, so that settings are not taken from the current project's settings.
+					if (((E.type == Variant::INT) && E.usage & PROPERTY_USAGE_ARRAY) || ProjectSettings::get_singleton()->get_is_array_internal(E.name) || !ProjectSettings::get_singleton()->is_builtin_setting(E.name)) {
 						continue;
 					}
 					if (E.usage & PROPERTY_USAGE_EDITOR) {

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -3267,7 +3267,7 @@ Array EditorInspectorArray::_extract_properties_as_array(const List<PropertyInfo
 	Array output;
 
 	for (const PropertyInfo &pi : p_list) {
-		if (!(pi.usage & PROPERTY_USAGE_EDITOR)) {
+		if (!(pi.usage & PROPERTY_USAGE_EDITOR) && !(pi.usage & PROPERTY_USAGE_STORAGE)) {
 			continue;
 		}
 

--- a/editor/inspector/editor_sectioned_inspector.cpp
+++ b/editor/inspector/editor_sectioned_inspector.cpp
@@ -158,6 +158,10 @@ void SectionedInspector::_section_selected() {
 	emit_signal(SNAME("category_changed"), selected_category);
 }
 
+void SectionedInspector::_edited_property_list_changed() {
+	filter->notify_property_list_changed();
+}
+
 void SectionedInspector::set_current_section(const String &p_section) {
 	if (section_map.has(p_section)) {
 		TreeItem *item = section_map[p_section];
@@ -185,6 +189,10 @@ String SectionedInspector::get_full_item_path(const String &p_item) {
 }
 
 void SectionedInspector::edit(Object *p_object) {
+	if (obj.is_valid()) {
+		ObjectDB::get_instance(obj)->disconnect(CoreStringName(property_list_changed), callable_mp(this, &SectionedInspector::_edited_property_list_changed));
+	}
+
 	if (!p_object) {
 		obj = ObjectID();
 		sections->clear();
@@ -195,6 +203,7 @@ void SectionedInspector::edit(Object *p_object) {
 		return;
 	}
 
+	p_object->connect(CoreStringName(property_list_changed), callable_mp(this, &SectionedInspector::_edited_property_list_changed));
 	ObjectID id = p_object->get_instance_id();
 
 	inspector->set_object_class(p_object->get_class());

--- a/editor/inspector/editor_sectioned_inspector.h
+++ b/editor/inspector/editor_sectioned_inspector.h
@@ -60,6 +60,7 @@ class SectionedInspector : public HSplitContainer {
 	void _section_selected();
 
 	void _search_changed(const String &p_what);
+	void _edited_property_list_changed();
 	void _advanced_toggled(bool p_toggled_on);
 
 protected:


### PR DESCRIPTION
Adds support for displaying and editing arrays of dictionaries in project settings with neat GUI via integration with EditorInspectorArray's capabilities.

I need this feature so I can properly implement godotengine/godot-proposals#14322, as otherwise editing collision presets would be somewhat annoying / poorly integrated with the editor's systems. Because it's a standalone feature I've decided to split this off into it's own PR.

This does not add array editing features to `EditorSettings`, only `ProjectSettings` as that is what I need for my use-case. I suspect a future PR to implement the same features in `EditorSettings` would be relatively straightforward anyways.

Everything this PR adds can be utilized with eight new macros that I've added:
- GLOBAL_DEF_ARRAY
- GLOBAL_DEF_ARRAY_RST
- GLOBAL_DEF_ARRAY_NOVAL
- GLOBAL_DEF_ARRAY_RST_NOVAL
- GLOBAL_DEF_ARRAY_BASIC
- GLOBAL_DEF_ARRAY_RST_BASIC
- GLOBAL_DEF_ARRAY_NOVAL_BASIC
- GLOBAL_DEF_ARRAY_RST_NOVAL_BASIC

These reflect the already existing GLOBAL_DEF family of macros. I'm not 100% sure about what all of these options are for, really, so I'd be happy to get rid of some of them if they won't see any use.

This change doesn't do anything on it's own, so if you want to test it checkout this branch that adds collision preset settings in physics/2d: https://github.com/Ardot66/godot/tree/add_project_setting_arrays_demo