### PR TITLE
Explicitly include `scene_tree.h` where used

### DIFF
--- a/editor/docks/groups_editor.cpp
+++ b/editor/docks/groups_editor.cpp
@@ -44,6 +44,7 @@
 #include "scene/gui/check_button.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/label.h"
+#include "scene/main/scene_tree.h"
 #include "scene/resources/packed_scene.h"
 #include "servers/display/display_server.h"
 

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -42,6 +42,7 @@
 #include "editor/inspector/editor_context_menu_plugin.h"
 #include "editor/inspector/multi_node_edit.h"
 #include "editor/plugins/editor_plugin.h"
+#include "scene/main/scene_tree.h"
 #include "scene/property_utils.h"
 #include "scene/resources/packed_scene.h"
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -162,6 +162,7 @@
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/split_container.h"
 #include "scene/gui/tab_container.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/timer.h"
 #include "scene/main/window.h"
 #include "scene/property_utils.h"

--- a/editor/gui/editor_title_bar.cpp
+++ b/editor/gui/editor_title_bar.cpp
@@ -31,6 +31,7 @@
 #include "editor_title_bar.h"
 
 #include "core/object/callable_mp.h"
+#include "scene/main/scene_tree.h"
 #include "servers/display/display_server.h"
 
 void EditorTitleBar::gui_input(const Ref<InputEvent> &p_event) {

--- a/editor/gui/progress_dialog.cpp
+++ b/editor/gui/progress_dialog.cpp
@@ -36,6 +36,7 @@
 #include "editor/themes/editor_scale.h"
 #include "main/main.h"
 #include "scene/gui/panel_container.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "servers/display/display_server.h"
 

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -66,6 +66,7 @@
 #include "scene/gui/panel_container.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/separator.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/theme/theme_db.h"
 #include "servers/display/display_server.h"

--- a/editor/scene/3d/gizmos/physics/collision_object_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/collision_object_3d_gizmo_plugin.cpp
@@ -33,6 +33,7 @@
 #include "scene/3d/physics/collision_object_3d.h"
 #include "scene/3d/physics/collision_polygon_3d.h"
 #include "scene/3d/physics/collision_shape_3d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/resources/surface_tool.h"
 
 CollisionObject3DGizmoPlugin::CollisionObject3DGizmoPlugin() {

--- a/editor/scene/3d/gizmos/physics/ray_cast_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/ray_cast_3d_gizmo_plugin.cpp
@@ -31,6 +31,7 @@
 #include "ray_cast_3d_gizmo_plugin.h"
 
 #include "scene/3d/physics/ray_cast_3d.h"
+#include "scene/main/scene_tree.h"
 
 RayCast3DGizmoPlugin::RayCast3DGizmoPlugin() {
 	const Color gizmo_color = SceneTree::get_singleton()->get_debug_collisions_color();

--- a/editor/scene/3d/gizmos/physics/shape_cast_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/shape_cast_3d_gizmo_plugin.cpp
@@ -31,6 +31,7 @@
 #include "shape_cast_3d_gizmo_plugin.h"
 
 #include "scene/3d/physics/shape_cast_3d.h"
+#include "scene/main/scene_tree.h"
 
 ShapeCast3DGizmoPlugin::ShapeCast3DGizmoPlugin() {
 	const Color gizmo_color = SceneTree::get_singleton()->get_debug_collisions_color();

--- a/editor/scene/3d/gizmos/physics/soft_body_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/soft_body_3d_gizmo_plugin.cpp
@@ -32,6 +32,7 @@
 
 #include "editor/editor_undo_redo_manager.h"
 #include "scene/3d/physics/soft_body_3d.h"
+#include "scene/main/scene_tree.h"
 
 SoftBody3DGizmoPlugin::SoftBody3DGizmoPlugin() {
 	Color gizmo_color = SceneTree::get_singleton()->get_debug_collisions_color();

--- a/editor/scene/3d/gizmos/physics/spring_arm_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/spring_arm_3d_gizmo_plugin.cpp
@@ -31,6 +31,7 @@
 #include "spring_arm_3d_gizmo_plugin.h"
 
 #include "scene/3d/physics/spring_arm_3d.h"
+#include "scene/main/scene_tree.h"
 
 void SpringArm3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	SpringArm3D *spring_arm = Object::cast_to<SpringArm3D>(p_gizmo->get_node_3d());

--- a/editor/scene/3d/gizmos/physics/vehicle_body_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/vehicle_body_3d_gizmo_plugin.cpp
@@ -31,6 +31,7 @@
 #include "vehicle_body_3d_gizmo_plugin.h"
 
 #include "scene/3d/physics/vehicle_body_3d.h"
+#include "scene/main/scene_tree.h"
 
 VehicleWheel3DGizmoPlugin::VehicleWheel3DGizmoPlugin() {
 	Color gizmo_color = SceneTree::get_singleton()->get_debug_collisions_color();

--- a/editor/scene/3d/path_3d_editor_plugin.cpp
+++ b/editor/scene/3d/path_3d_editor_plugin.cpp
@@ -42,6 +42,7 @@
 #include "editor/settings/editor_settings.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/menu_button.h"
+#include "scene/main/scene_tree.h"
 #include "scene/resources/curve.h"
 
 String Path3DGizmo::get_handle_name(int p_id, bool p_secondary) const {

--- a/editor/scene/rename_dialog.cpp
+++ b/editor/scene/rename_dialog.cpp
@@ -45,6 +45,7 @@
 #include "scene/gui/separator.h"
 #include "scene/gui/spin_box.h"
 #include "scene/gui/tab_container.h"
+#include "scene/main/scene_tree.h"
 
 #include "modules/regex/regex.h"
 

--- a/modules/csg/tests/test_csg.h
+++ b/modules/csg/tests/test_csg.h
@@ -32,6 +32,7 @@
 
 #include "../csg.h"
 #include "../csg_shape.h"
+#include "scene/main/scene_tree.h"
 
 #include "tests/test_macros.h"
 

--- a/modules/gltf/tests/test_gltf_extras.h
+++ b/modules/gltf/tests/test_gltf_extras.h
@@ -38,6 +38,7 @@
 #include "editor/import/3d/resource_importer_scene.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/skeleton_3d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/resources/3d/primitive_meshes.h"
 #include "scene/resources/material.h"

--- a/modules/gltf/tests/test_gltf_images.h
+++ b/modules/gltf/tests/test_gltf_images.h
@@ -36,6 +36,7 @@
 
 #include "editor/file_system/editor_file_system.h"
 #include "editor/file_system/editor_paths.h"
+#include "scene/main/scene_tree.h"
 #include "scene/resources/image_texture.h"
 
 namespace TestGltf {

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -35,6 +35,7 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/templates/a_hash_map.h"
+#include "scene/main/scene_tree.h"
 #include "scene/resources/3d/mesh_library.h"
 #include "scene/resources/3d/primitive_meshes.h"
 #include "scene/resources/surface_tool.h"

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -37,6 +37,7 @@
 #include "editor/settings/editor_settings.h"
 #include "scene/gui/control.h"
 #include "scene/main/node.h"
+#include "scene/main/scene_tree.h"
 #include "scene/theme/theme_db.h"
 
 namespace gdmono {

--- a/modules/multiplayer/scene_cache_interface.cpp
+++ b/modules/multiplayer/scene_cache_interface.cpp
@@ -35,6 +35,7 @@
 #include "core/io/marshalls.h"
 #include "core/object/callable_mp.h"
 #include "scene/main/node.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 
 SceneCacheInterface::NodeCache &SceneCacheInterface::_track(Node *p_node) {

--- a/modules/multiplayer/scene_rpc_interface.cpp
+++ b/modules/multiplayer/scene_rpc_interface.cpp
@@ -37,6 +37,7 @@
 #include "core/object/callable_mp.h"
 #include "scene/main/multiplayer_api.h"
 #include "scene/main/node.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 
 // The RPC meta is composed by a single byte that contains (starting from the least significant bit):

--- a/modules/multiplayer/tests/test_multiplayer_spawner.h
+++ b/modules/multiplayer/tests/test_multiplayer_spawner.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/class_db.h"
+#include "scene/main/scene_tree.h"
 #include "tests/test_macros.h"
 #include "tests/test_utils.h"
 

--- a/modules/multiplayer/tests/test_scene_multiplayer.h
+++ b/modules/multiplayer/tests/test_scene_multiplayer.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/callable_mp.h"
+#include "scene/main/scene_tree.h"
 #include "tests/test_macros.h"
 #include "tests/test_utils.h"
 

--- a/modules/objectdb_profiler/snapshot_collector.cpp
+++ b/modules/objectdb_profiler/snapshot_collector.cpp
@@ -36,6 +36,7 @@
 #include "core/os/time.h"
 #include "core/version.h"
 #include "scene/main/node.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 
 void SnapshotCollector::initialize() {

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -34,6 +34,7 @@
 #include "core/math/geometry_2d.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/timer.h"
 #include "scene/resources/mesh.h"
 #include "servers/rendering/rendering_server.h"

--- a/scene/2d/physics/collision_shape_2d.cpp
+++ b/scene/2d/physics/collision_shape_2d.cpp
@@ -35,6 +35,7 @@
 #include "core/object/class_db.h"
 #include "scene/2d/physics/area_2d.h"
 #include "scene/2d/physics/collision_object_2d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/resources/2d/concave_polygon_shape_2d.h"
 #include "scene/resources/2d/convex_polygon_shape_2d.h"
 

--- a/scene/2d/physics/physics_body_2d.cpp
+++ b/scene/2d/physics/physics_body_2d.cpp
@@ -31,6 +31,7 @@
 #include "physics_body_2d.h"
 
 #include "core/object/class_db.h"
+#include "scene/main/scene_tree.h"
 
 void PhysicsBody2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("move_and_collide", "motion", "test_only", "safe_margin", "recovery_as_collision"), &PhysicsBody2D::_move, DEFVAL(false), DEFVAL(0.08), DEFVAL(false));

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -39,6 +39,7 @@
 #include "core/templates/a_hash_map.h"
 #include "scene/2d/tile_map.h"
 #include "scene/gui/control.h"
+#include "scene/main/scene_tree.h"
 #include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h"
 #include "scene/resources/material.h"
 #include "scene/resources/world_2d.h"

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -35,6 +35,7 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "scene/3d/visual_instance_3d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/viewport.h"
 #include "scene/property_utils.h"
 #include "servers/display/accessibility_server.h"

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/main/node.h"
+#include "scene/main/scene_tree.h"
 #include "scene/resources/3d/world_3d.h"
 
 class Node3DGizmo : public RefCounted {

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "scene/main/scene_tree.h"
 #include "scene/resources/mesh.h"
 #include "servers/rendering/rendering_server.h"
 

--- a/scene/3d/physics/collision_polygon_3d.cpp
+++ b/scene/3d/physics/collision_polygon_3d.cpp
@@ -33,6 +33,7 @@
 #include "core/math/geometry_2d.h"
 #include "core/object/class_db.h"
 #include "scene/3d/physics/collision_object_3d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/resources/3d/convex_polygon_shape_3d.h"
 
 void CollisionPolygon3D::_build_polygon() {

--- a/scene/3d/physics/collision_shape_3d.cpp
+++ b/scene/3d/physics/collision_shape_3d.cpp
@@ -35,6 +35,7 @@
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/physics/character_body_3d.h"
 #include "scene/3d/physics/vehicle_body_3d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/resources/3d/concave_polygon_shape_3d.h"
 #include "scene/resources/3d/convex_polygon_shape_3d.h"
 #include "scene/resources/3d/world_boundary_shape_3d.h"

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -31,6 +31,7 @@
 #include "physics_body_3d.h"
 
 #include "core/object/class_db.h"
+#include "scene/main/scene_tree.h"
 
 void PhysicsBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("move_and_collide", "motion", "test_only", "safe_margin", "recovery_as_collision", "max_collisions"), &PhysicsBody3D::_move, DEFVAL(false), DEFVAL(0.001), DEFVAL(false), DEFVAL(1));

--- a/scene/3d/world_environment.cpp
+++ b/scene/3d/world_environment.cpp
@@ -32,6 +32,7 @@
 
 #include "core/object/class_db.h"
 #include "scene/3d/node_3d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/viewport.h"
 
 void WorldEnvironment::_notification(int p_what) {

--- a/scene/3d/xr/xr_nodes.cpp
+++ b/scene/3d/xr/xr_nodes.cpp
@@ -34,6 +34,7 @@
 #include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/viewport.h"
 #include "servers/xr/xr_interface.h"
 

--- a/scene/debugger/runtime_node_select.cpp
+++ b/scene/debugger/runtime_node_select.cpp
@@ -44,6 +44,7 @@
 #include "scene/debugger/scene_debugger_object.h"
 #include "scene/gui/popup_menu.h"
 #include "scene/main/canvas_layer.h"
+#include "scene/main/scene_tree.h"
 #include "scene/resources/mesh.h"
 #include "scene/theme/theme_db.h"
 #include "servers/rendering/rendering_server.h"

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -37,6 +37,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "core/object/class_db.h"
 #include "scene/2d/canvas_group.h"
 #include "scene/main/canvas_layer.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/font.h"

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/main/node.h"
+#include "scene/main/scene_tree.h"
 #include "scene/resources/texture.h"
 #include "servers/rendering/rendering_server_enums.h"
 #include "servers/text/text_server.h"

--- a/scene/main/shader_globals_override.cpp
+++ b/scene/main/shader_globals_override.cpp
@@ -31,6 +31,7 @@
 #include "shader_globals_override.h"
 
 #include "core/object/class_db.h"
+#include "scene/main/scene_tree.h"
 #include "servers/rendering/rendering_server.h"
 
 StringName *ShaderGlobalsOverride::_remap(const StringName &p_name) const {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -47,6 +47,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "scene/gui/popup_menu.h"
 #include "scene/gui/subviewport_container.h"
 #include "scene/main/canvas_layer.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/resources/dpi_texture.h"
 #include "scene/resources/mesh.h"

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -40,6 +40,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "scene/gui/control.h"
+#include "scene/main/scene_tree.h"
 #include "scene/theme/theme_db.h"
 #include "scene/theme/theme_owner.h"
 #include "servers/display/accessibility_server.h"

--- a/tests/scene/test_button.cpp
+++ b/tests/scene/test_button.cpp
@@ -33,6 +33,7 @@
 TEST_FORCE_LINK(test_button)
 
 #include "scene/gui/button.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "tests/display_server_mock.h"
 

--- a/tests/scene/test_camera_2d.cpp
+++ b/tests/scene/test_camera_2d.cpp
@@ -33,6 +33,7 @@
 TEST_FORCE_LINK(test_camera_2d)
 
 #include "scene/2d/camera_2d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/viewport.h"
 #include "scene/main/window.h"
 

--- a/tests/scene/test_camera_3d.cpp
+++ b/tests/scene/test_camera_3d.cpp
@@ -35,6 +35,7 @@ TEST_FORCE_LINK(test_camera_3d)
 #ifndef _3D_DISABLED
 
 #include "scene/3d/camera_3d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/viewport.h"
 #include "scene/main/window.h"
 

--- a/tests/scene/test_code_edit.cpp
+++ b/tests/scene/test_code_edit.cpp
@@ -36,6 +36,7 @@ TEST_FORCE_LINK(test_code_edit)
 
 #include "core/input/input_map.h"
 #include "scene/gui/code_edit.h"
+#include "scene/main/scene_tree.h"
 #include "tests/display_server_mock.h"
 #include "tests/signal_watcher.h"
 

--- a/tests/scene/test_color_picker.cpp
+++ b/tests/scene/test_color_picker.cpp
@@ -35,6 +35,7 @@ TEST_FORCE_LINK(test_color_picker)
 #ifndef ADVANCED_GUI_DISABLED
 
 #include "scene/gui/color_picker.h"
+#include "scene/main/scene_tree.h"
 #include "tests/display_server_mock.h"
 
 namespace TestColorPicker {

--- a/tests/scene/test_control.cpp
+++ b/tests/scene/test_control.cpp
@@ -35,6 +35,7 @@ TEST_FORCE_LINK(test_control)
 #include "core/input/input_map.h" // IWYU pragma: keep // Used by `SEND_GUI_ACTION` macro.
 #include "scene/2d/node_2d.h"
 #include "scene/gui/control.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "tests/display_server_mock.h"
 #include "tests/signal_watcher.h"

--- a/tests/scene/test_convert_transform_modifier_3d.cpp
+++ b/tests/scene/test_convert_transform_modifier_3d.cpp
@@ -37,6 +37,7 @@ TEST_FORCE_LINK(test_convert_transform_modifier_3d)
 #include "core/math/random_number_generator.h"
 #include "scene/3d/bone_attachment_3d.h"
 #include "scene/3d/convert_transform_modifier_3d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 
 namespace TestConvertTransformModifier3D {

--- a/tests/scene/test_copy_transform_modifier_3d.cpp
+++ b/tests/scene/test_copy_transform_modifier_3d.cpp
@@ -37,6 +37,7 @@ TEST_FORCE_LINK(test_copy_transform_modifier_3d)
 #include "core/math/random_number_generator.h"
 #include "scene/3d/bone_attachment_3d.h"
 #include "scene/3d/copy_transform_modifier_3d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 
 namespace TestCopyTransformModifier3D {

--- a/tests/scene/test_instance_placeholder.cpp
+++ b/tests/scene/test_instance_placeholder.cpp
@@ -37,6 +37,7 @@ TEST_FORCE_LINK(test_instance_placeholder)
 #include "core/io/resource_saver.h"
 #include "core/object/class_db.h"
 #include "scene/main/instance_placeholder.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/resources/packed_scene.h"
 #include "tests/test_utils.h"

--- a/tests/scene/test_navigation_agent_2d.cpp
+++ b/tests/scene/test_navigation_agent_2d.cpp
@@ -38,6 +38,7 @@ TEST_FORCE_LINK(test_navigation_agent_2d)
 
 #include "scene/2d/navigation/navigation_agent_2d.h"
 #include "scene/2d/node_2d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/resources/world_2d.h"
 

--- a/tests/scene/test_navigation_agent_3d.cpp
+++ b/tests/scene/test_navigation_agent_3d.cpp
@@ -38,6 +38,7 @@ TEST_FORCE_LINK(test_navigation_agent_3d)
 
 #include "scene/3d/navigation/navigation_agent_3d.h"
 #include "scene/3d/node_3d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 
 namespace TestNavigationAgent3D {

--- a/tests/scene/test_navigation_obstacle_2d.cpp
+++ b/tests/scene/test_navigation_obstacle_2d.cpp
@@ -37,6 +37,7 @@ TEST_FORCE_LINK(test_navigation_obstacle_2d)
 #ifdef MODULE_NAVIGATION_2D_ENABLED
 
 #include "scene/2d/navigation/navigation_obstacle_2d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/resources/world_2d.h"
 

--- a/tests/scene/test_navigation_obstacle_3d.cpp
+++ b/tests/scene/test_navigation_obstacle_3d.cpp
@@ -37,6 +37,7 @@ TEST_FORCE_LINK(test_navigation_obstacle_3d)
 #ifdef MODULE_NAVIGATION_3D_ENABLED
 
 #include "scene/3d/navigation/navigation_obstacle_3d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 
 namespace TestNavigationObstacle3D {

--- a/tests/scene/test_navigation_region_3d.cpp
+++ b/tests/scene/test_navigation_region_3d.cpp
@@ -38,6 +38,7 @@ TEST_FORCE_LINK(test_navigation_region_3d)
 
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/navigation/navigation_region_3d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/resources/3d/primitive_meshes.h"
 

--- a/tests/scene/test_node.cpp
+++ b/tests/scene/test_node.cpp
@@ -36,6 +36,7 @@ TEST_FORCE_LINK(test_node)
 #include "core/io/resource_saver.h"
 #include "core/object/class_db.h"
 #include "scene/main/node.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/resources/packed_scene.h"
 #include "tests/test_utils.h"

--- a/tests/scene/test_node_2d.cpp
+++ b/tests/scene/test_node_2d.cpp
@@ -33,6 +33,7 @@
 TEST_FORCE_LINK(test_node_2d)
 
 #include "scene/2d/node_2d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 
 namespace TestNode2D {

--- a/tests/scene/test_path_follow_2d.cpp
+++ b/tests/scene/test_path_follow_2d.cpp
@@ -33,6 +33,7 @@
 TEST_FORCE_LINK(test_path_follow_2d)
 
 #include "scene/2d/path_2d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 
 namespace TestPathFollow2D {

--- a/tests/scene/test_path_follow_3d.cpp
+++ b/tests/scene/test_path_follow_3d.cpp
@@ -35,6 +35,7 @@ TEST_FORCE_LINK(test_path_follow_3d)
 #ifndef _3D_DISABLED
 
 #include "scene/3d/path_3d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 
 namespace TestPathFollow3D {

--- a/tests/scene/test_split_container.cpp
+++ b/tests/scene/test_split_container.cpp
@@ -35,6 +35,7 @@ TEST_FORCE_LINK(test_split_container)
 #ifndef ADVANCED_GUI_DISABLED
 
 #include "scene/gui/split_container.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "tests/display_server_mock.h"
 #include "tests/signal_watcher.h"

--- a/tests/scene/test_tab_bar.cpp
+++ b/tests/scene/test_tab_bar.cpp
@@ -35,6 +35,7 @@ TEST_FORCE_LINK(test_tab_bar)
 #ifndef ADVANCED_GUI_DISABLED
 
 #include "scene/gui/tab_bar.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "tests/display_server_mock.h"
 #include "tests/signal_watcher.h"

--- a/tests/scene/test_tab_container.cpp
+++ b/tests/scene/test_tab_container.cpp
@@ -36,6 +36,7 @@ TEST_FORCE_LINK(test_tab_container)
 
 #include "scene/gui/box_container.h"
 #include "scene/gui/tab_container.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "tests/display_server_mock.h"
 #include "tests/signal_watcher.h"

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -36,6 +36,7 @@ TEST_FORCE_LINK(test_text_edit)
 
 #include "core/input/input_map.h"
 #include "scene/gui/text_edit.h"
+#include "scene/main/scene_tree.h"
 #include "tests/display_server_mock.h"
 #include "tests/signal_watcher.h"
 

--- a/tests/scene/test_timer.cpp
+++ b/tests/scene/test_timer.cpp
@@ -32,6 +32,7 @@
 
 TEST_FORCE_LINK(test_timer)
 
+#include "scene/main/scene_tree.h"
 #include "scene/main/timer.h"
 #include "scene/main/window.h"
 #include "tests/signal_watcher.h"

--- a/tests/scene/test_viewport.cpp
+++ b/tests/scene/test_viewport.cpp
@@ -37,6 +37,7 @@ TEST_FORCE_LINK(test_viewport)
 #include "scene/gui/control.h"
 #include "scene/gui/subviewport_container.h"
 #include "scene/main/canvas_layer.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "tests/display_server_mock.h"
 #include "tests/signal_watcher.h"

--- a/tests/scene/test_window.cpp
+++ b/tests/scene/test_window.cpp
@@ -34,6 +34,7 @@ TEST_FORCE_LINK(test_window)
 
 #include "core/input/input_map.h" // IWYU pragma: keep // Used by `SEND_GUI_MOUSE_MOTION_EVENT` macro.
 #include "scene/gui/control.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "tests/display_server_mock.h"
 

--- a/tests/servers/test_navigation_server_2d.cpp
+++ b/tests/servers/test_navigation_server_2d.cpp
@@ -38,6 +38,7 @@ TEST_FORCE_LINK(test_navigation_server_2d)
 
 #include "core/object/callable_mp.h"
 #include "scene/2d/polygon_2d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
 #include "tests/signal_watcher.h"

--- a/tests/servers/test_navigation_server_3d.cpp
+++ b/tests/servers/test_navigation_server_3d.cpp
@@ -39,6 +39,7 @@ TEST_FORCE_LINK(test_navigation_server_3d)
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "scene/3d/mesh_instance_3d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/resources/3d/primitive_meshes.h"
 #include "servers/navigation_3d/navigation_server_3d.h"

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -36,6 +36,7 @@
 #include "core/io/dir_access.h"
 #include "core/os/os.h"
 #include "core/string/translation_server.h"
+#include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/theme/theme_db.h"
 #include "servers/audio/audio_server.h"


### PR DESCRIPTION
- Helps address #111218.

Pre-requisite before removing `scene_tree.h` from `node.h` which has cascading consequences on most of the codebase.