### PR TITLE
[RTL] Use shared item RIDOwner for all instances.

### DIFF
--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -579,7 +579,7 @@ private:
 
 	void _texture_changed(RID p_item);
 
-	RID_PtrOwner<Item> items;
+	static inline RID_PtrOwner<Item, true> items;
 	List<String> tag_stack;
 	HashSet<RID> hr_list;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/116925