### PR TITLE
Add fixed resolution mode to `SubViewportContainer`.

### DIFF
--- a/doc/classes/SubViewportContainer.xml
+++ b/doc/classes/SubViewportContainer.xml
@@ -20,7 +20,13 @@
 		</method>
 	</methods>
 	<members>
+		<member name="fixed_resolution" type="Vector2i" setter="set_fixed_resolution" getter="get_fixed_resolution" default="Vector2i(512, 512)">
+			Determines the method that is used to set the resolution of the [SubViewport].
+		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="1" />
+		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="SubViewportContainer.ResolutionMode" default="0">
+			Determines the method that is used to set the resolution of the [SubViewport].
+		</member>
 		<member name="mouse_target" type="bool" setter="set_mouse_target" getter="is_mouse_target_enabled" default="false">
 			Configure, if either the [SubViewportContainer] or alternatively the [Control] nodes of its [SubViewport] children should be available as targets of mouse-related functionalities, like identifying the drop target in drag-and-drop operations or cursor shape of hovered [Control] node.
 			If [code]false[/code], the [Control] nodes inside its [SubViewport] children are considered as targets.
@@ -31,9 +37,17 @@
 			[b]Note:[/b] If [code]true[/code], this will prohibit changing [member SubViewport.size] of its children manually.
 		</member>
 		<member name="stretch_shrink" type="int" setter="set_stretch_shrink" getter="get_stretch_shrink" default="1">
-			Divides the sub-viewport's effective resolution by this value while preserving its scale. This can be used to speed up rendering.
+			If [member mode] is [constant RESOLUTION_MODE_SHRINK], divides the sub-viewport's effective resolution by this value while preserving its scale. This can be used to speed up rendering.
 			For example, a 1280×720 sub-viewport with [member stretch_shrink] set to [code]2[/code] will be rendered at 640×360 while occupying the same size in the container.
 			[b]Note:[/b] [member stretch] must be [code]true[/code] for this property to work.
 		</member>
 	</members>
+	<constants>
+		<constant name="RESOLUTION_MODE_SHRINK" value="0" enum="ResolutionMode">
+			Use the [member stretch_shrink] value to calculate the effective resolution of the [SubViewport].
+		</constant>
+		<constant name="RESOLUTION_MODE_FIXED" value="1" enum="ResolutionMode">
+			Use the [member fixed_resolution] value to determine the effective resolution of the [SubViewport].
+		</constant>
+	</constants>
 </class>

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -52,6 +52,38 @@ Size2 SubViewportContainer::get_minimum_size() const {
 	return ms;
 }
 
+void SubViewportContainer::set_mode(ResolutionMode p_mode) {
+	if (mode == p_mode) {
+		return;
+	}
+
+	mode = p_mode;
+	notify_property_list_changed();
+	recalc_force_viewport_sizes();
+	update_minimum_size();
+	queue_sort();
+	queue_redraw();
+}
+
+SubViewportContainer::ResolutionMode SubViewportContainer::get_mode() const {
+	return mode;
+}
+void SubViewportContainer::set_fixed_resolution(const Vector2i &p_fixed_resolution) {
+	if (fixed_resolution == p_fixed_resolution) {
+		return;
+	}
+
+	fixed_resolution = p_fixed_resolution.maxi(1);
+	recalc_force_viewport_sizes();
+	update_minimum_size();
+	queue_sort();
+	queue_redraw();
+}
+
+Vector2i SubViewportContainer::get_fixed_resolution() const {
+	return fixed_resolution;
+}
+
 void SubViewportContainer::set_stretch(bool p_enable) {
 	if (stretch == p_enable) {
 		return;
@@ -92,7 +124,14 @@ void SubViewportContainer::recalc_force_viewport_sizes() {
 			continue;
 		}
 
-		c->set_size_force(get_size() / shrink);
+		switch (mode) {
+			case RESOLUTION_MODE_SHRINK: {
+				c->set_size_force(get_size() / shrink);
+			} break;
+			case RESOLUTION_MODE_FIXED: {
+				c->set_size_force(fixed_resolution);
+			} break;
+		}
 	}
 }
 
@@ -106,6 +145,14 @@ Vector<int> SubViewportContainer::get_allowed_size_flags_horizontal() const {
 
 Vector<int> SubViewportContainer::get_allowed_size_flags_vertical() const {
 	return Vector<int>();
+}
+
+void SubViewportContainer::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "stretch_shrink") {
+		p_property.usage = mode == RESOLUTION_MODE_SHRINK ? PROPERTY_USAGE_DEFAULT : PROPERTY_USAGE_NO_EDITOR;
+	} else if (p_property.name == "fixed_resolution") {
+		p_property.usage = mode == RESOLUTION_MODE_FIXED ? PROPERTY_USAGE_DEFAULT : PROPERTY_USAGE_NO_EDITOR;
+	}
 }
 
 void SubViewportContainer::_notification(int p_what) {
@@ -218,10 +265,18 @@ void SubViewportContainer::gui_input(const Ref<InputEvent> &p_event) {
 		}
 	}
 
-	if (stretch && shrink > 1) {
-		Transform2D xform;
-		xform.scale(Vector2(1, 1) / shrink);
-		_send_event_to_viewports(p_event->xformed_by(xform));
+	Vector2 s;
+	switch (mode) {
+		case RESOLUTION_MODE_SHRINK: {
+			s = Vector2(1, 1) / shrink;
+		} break;
+		case RESOLUTION_MODE_FIXED: {
+			s = Vector2(fixed_resolution) / get_size();
+		} break;
+	}
+
+	if (stretch) {
+		_send_event_to_viewports(p_event->xformed_by(Transform2D().scaled(s)));
 	} else {
 		_send_event_to_viewports(p_event);
 	}
@@ -289,6 +344,12 @@ PackedStringArray SubViewportContainer::get_configuration_warnings() const {
 }
 
 void SubViewportContainer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_mode", "mode"), &SubViewportContainer::set_mode);
+	ClassDB::bind_method(D_METHOD("get_mode"), &SubViewportContainer::get_mode);
+
+	ClassDB::bind_method(D_METHOD("set_fixed_resolution", "fixed_resolution"), &SubViewportContainer::set_fixed_resolution);
+	ClassDB::bind_method(D_METHOD("get_fixed_resolution"), &SubViewportContainer::get_fixed_resolution);
+
 	ClassDB::bind_method(D_METHOD("set_stretch", "enable"), &SubViewportContainer::set_stretch);
 	ClassDB::bind_method(D_METHOD("is_stretch_enabled"), &SubViewportContainer::is_stretch_enabled);
 
@@ -298,9 +359,14 @@ void SubViewportContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mouse_target", "amount"), &SubViewportContainer::set_mouse_target);
 	ClassDB::bind_method(D_METHOD("is_mouse_target_enabled"), &SubViewportContainer::is_mouse_target_enabled);
 
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Shrink,Fixed"), "set_mode", "get_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "fixed_resolution"), "set_fixed_resolution", "get_fixed_resolution");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stretch"), "set_stretch", "is_stretch_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "stretch_shrink", PROPERTY_HINT_RANGE, "1,32,1,or_greater"), "set_stretch_shrink", "get_stretch_shrink");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mouse_target"), "set_mouse_target", "is_mouse_target_enabled");
+
+	BIND_ENUM_CONSTANT(RESOLUTION_MODE_SHRINK);
+	BIND_ENUM_CONSTANT(RESOLUTION_MODE_FIXED);
 
 	GDVIRTUAL_BIND(_propagate_input_event, "event");
 }

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -35,8 +35,16 @@
 class SubViewportContainer : public Container {
 	GDCLASS(SubViewportContainer, Container);
 
+public:
+	enum ResolutionMode {
+		RESOLUTION_MODE_SHRINK,
+		RESOLUTION_MODE_FIXED,
+	};
+
+	ResolutionMode mode = RESOLUTION_MODE_SHRINK;
 	bool stretch = false;
 	int shrink = 1;
+	Vector2i fixed_resolution = Vector2i(512, 512);
 	bool mouse_target = false;
 
 	void _notify_viewports(int p_notification);
@@ -54,6 +62,12 @@ protected:
 	GDVIRTUAL1RC(bool, _propagate_input_event, RequiredParam<InputEvent>);
 
 public:
+	void set_mode(ResolutionMode p_mode);
+	ResolutionMode get_mode() const;
+
+	void set_fixed_resolution(const Vector2i &p_fixed_resolution);
+	Vector2i get_fixed_resolution() const;
+
 	void set_stretch(bool p_enable);
 	bool is_stretch_enabled() const;
 
@@ -72,7 +86,10 @@ public:
 	virtual Vector<int> get_allowed_size_flags_horizontal() const override;
 	virtual Vector<int> get_allowed_size_flags_vertical() const override;
 
+	void _validate_property(PropertyInfo &p_property) const;
 	PackedStringArray get_configuration_warnings() const override;
 
 	SubViewportContainer();
 };
+
+VARIANT_ENUM_CAST(SubViewportContainer::ResolutionMode);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3415,7 +3415,14 @@ void Viewport::_update_mouse_over(Vector2 p_pos) {
 		}
 		Vector2 pos = c->get_global_transform_with_canvas().affine_inverse().xform(p_pos);
 		if (c->is_stretch_enabled()) {
-			pos /= c->get_stretch_shrink();
+			switch (c->get_mode()) {
+				case SubViewportContainer::RESOLUTION_MODE_SHRINK: {
+					pos /= c->get_stretch_shrink();
+				} break;
+				case SubViewportContainer::RESOLUTION_MODE_FIXED: {
+					pos /= c->get_size() / c->get_fixed_resolution();
+				} break;
+			}
 		}
 
 		for (int i = 0; i < c->get_child_count(); i++) {


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/issues/14387

This adds a new mode to `SubViewportContainer` that allows the end user to specify a specific resolution rather than the existing behaviour of scaling based on native resolution.

<img width="521" height="364" alt="image" src="https://github.com/user-attachments/assets/4eb28740-77fd-429e-9e71-615b3167e24d" />

This is incredibly useful for developers working on retro games that are designed to emulate specific resolutions and looks.

<img width="1165" height="544" alt="image" src="https://github.com/user-attachments/assets/7fed1c2d-91e8-4d09-9466-8ec6c6a3ac57" />

For example if I was making a PSX game I could set the fixed resolution of the `SubViewportContainer` to 320x240.

---

This needs to be implemented on the engine level as you can somewhat emulate this via implementing your own SVC via script however there is integration within the Viewport class that scales mouse position information and mouse picking (selecting nodes via the mouse) relies on the `SubViewportContainer` class.

You can't achieve the same effect by messing with the shrink property since it is an integer, even if it was changed to a float, it feels hacky.