### PR TITLE
Fix game view freelook not using separate invert Y axis setting

### DIFF
--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -82,6 +82,7 @@ void GameViewDebugger::_session_started(Ref<EditorDebuggerSession> p_session) {
 	settings["editors/3d/navigation/warped_mouse_panning"] = EDITOR_GET("editors/3d/navigation/warped_mouse_panning");
 	settings["editors/3d/freelook/freelook_base_speed"] = EDITOR_GET("editors/3d/freelook/freelook_base_speed");
 	settings["editors/3d/freelook/freelook_sensitivity"] = EDITOR_GET("editors/3d/freelook/freelook_sensitivity");
+	settings["editors/3d/freelook/freelook_invert_y_axis"] = EDITOR_GET("editors/3d/freelook/freelook_invert_y_axis");
 	settings["editors/3d/navigation_feel/orbit_sensitivity"] = EDITOR_GET("editors/3d/navigation_feel/orbit_sensitivity");
 	settings["editors/3d/navigation_feel/translation_sensitivity"] = EDITOR_GET("editors/3d/navigation_feel/translation_sensitivity");
 	settings["editors/3d/selection_box_color"] = EDITOR_GET("editors/3d/selection_box_color");

--- a/scene/debugger/runtime_node_select.cpp
+++ b/scene/debugger/runtime_node_select.cpp
@@ -129,6 +129,7 @@ void RuntimeNodeSelect::_setup(const Dictionary &p_settings) {
 	invert_y_axis = p_settings.get("editors/3d/navigation/invert_y_axis", false);
 	warped_mouse_panning_3d = p_settings.get("editors/3d/navigation/warped_mouse_panning", true);
 
+	freelook_invert_y_axis = p_settings.get("editors/3d/freelook/freelook_invert_y_axis", false);
 	freelook_base_speed = p_settings.get("editors/3d/freelook/freelook_base_speed", 5);
 	freelook_sensitivity = Math::deg_to_rad((real_t)p_settings.get("editors/3d/freelook/freelook_sensitivity", 0.25));
 	orbit_sensitivity = Math::deg_to_rad((real_t)p_settings.get("editors/3d/navigation_feel/orbit_sensitivity", 0.004));
@@ -1526,7 +1527,7 @@ void RuntimeNodeSelect::_cursor_look(Ref<InputEventWithModifiers> p_event) {
 	const Vector2 relative = _get_warped_mouse_motion(p_event, Rect2(Vector2(), root->get_size()));
 	const Transform3D prev_camera_transform = _get_cursor_transform();
 
-	if (invert_y_axis) {
+	if (freelook_invert_y_axis) {
 		cursor.x_rot -= relative.y * freelook_sensitivity;
 	} else {
 		cursor.x_rot += relative.y * freelook_sensitivity;

--- a/scene/debugger/runtime_node_select.h
+++ b/scene/debugger/runtime_node_select.h
@@ -155,6 +155,7 @@ private:
 	bool invert_y_axis = false;
 	bool warped_mouse_panning_3d = false;
 
+	bool freelook_invert_y_axis = false;
 	real_t freelook_base_speed = 0;
 	real_t freelook_sensitivity = 0;
 	real_t orbit_sensitivity = 0;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Fixes: https://github.com/godotengine/godot/pull/116991#issuecomment-4005697616