### PR TITLE
Rendering shader compiler: remove unused variables

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3400,16 +3400,8 @@
 		<member name="rendering/scaling_3d/scale" type="float" setter="" getter="" default="1.0">
 			Scales the 3D render buffer based on the viewport size uses an image filter specified in [member rendering/scaling_3d/mode] to scale the output image to the full viewport size. Values lower than [code]1.0[/code] can be used to speed up 3D rendering at the cost of quality (undersampling). Values greater than [code]1.0[/code] are only valid for bilinear mode and can be used to improve 3D rendering quality at a high performance cost (supersampling). See also [member rendering/anti_aliasing/quality/msaa_3d] for multi-sample antialiasing, which is significantly cheaper but only smooths the edges of polygons.
 		</member>
-		<member name="rendering/shader_compiler/shader_cache/compress" type="bool" setter="" getter="" default="true">
-		</member>
 		<member name="rendering/shader_compiler/shader_cache/enabled" type="bool" setter="" getter="" default="true">
 			Enable the shader cache, which stores compiled shaders to disk to prevent stuttering from shader compilation the next time the shader is needed.
-		</member>
-		<member name="rendering/shader_compiler/shader_cache/strip_debug" type="bool" setter="" getter="" default="false">
-		</member>
-		<member name="rendering/shader_compiler/shader_cache/strip_debug.release" type="bool" setter="" getter="" default="true">
-		</member>
-		<member name="rendering/shader_compiler/shader_cache/use_zstd_compression" type="bool" setter="" getter="" default="true">
 		</member>
 		<member name="rendering/shading/overrides/force_lambert_over_burley" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], uses faster but lower-quality Lambert material lighting model instead of Burley.

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -812,22 +812,7 @@ void ShaderGLES3::set_shader_cache_dir(const String &p_dir) {
 	shader_cache_dir = p_dir;
 }
 
-void ShaderGLES3::set_shader_cache_save_compressed(bool p_enable) {
-	shader_cache_save_compressed = p_enable;
-}
-
-void ShaderGLES3::set_shader_cache_save_compressed_zstd(bool p_enable) {
-	shader_cache_save_compressed_zstd = p_enable;
-}
-
-void ShaderGLES3::set_shader_cache_save_debug(bool p_enable) {
-	shader_cache_save_debug = p_enable;
-}
-
 String ShaderGLES3::shader_cache_dir;
-bool ShaderGLES3::shader_cache_save_compressed = true;
-bool ShaderGLES3::shader_cache_save_compressed_zstd = true;
-bool ShaderGLES3::shader_cache_save_debug = true;
 
 ShaderGLES3::~ShaderGLES3() {
 	LocalVector<RID> remaining = version_owner.get_owned_list();

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -136,9 +136,6 @@ private:
 
 	static String shader_cache_dir;
 	static bool shader_cache_cleanup_on_start;
-	static bool shader_cache_save_compressed;
-	static bool shader_cache_save_compressed_zstd;
-	static bool shader_cache_save_debug;
 	bool shader_cache_dir_valid = false;
 
 	GLint max_image_units = 0;
@@ -244,9 +241,6 @@ public:
 	bool version_free(RID p_version);
 
 	static void set_shader_cache_dir(const String &p_dir);
-	static void set_shader_cache_save_compressed(bool p_enable);
-	static void set_shader_cache_save_compressed_zstd(bool p_enable);
-	static void set_shader_cache_save_debug(bool p_enable);
 
 	RenderingServerTypes::ShaderNativeSourceCode version_get_native_source_code(RID p_version);
 

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -317,12 +317,6 @@ RendererCompositorRD::RendererCompositorRD() {
 	framebuffer_cache = memnew(FramebufferCacheRD);
 
 	bool shader_cache_enabled = GLOBAL_GET("rendering/shader_compiler/shader_cache/enabled");
-	bool compress = GLOBAL_GET("rendering/shader_compiler/shader_cache/compress");
-	bool use_zstd = GLOBAL_GET("rendering/shader_compiler/shader_cache/use_zstd_compression");
-	bool strip_debug = GLOBAL_GET("rendering/shader_compiler/shader_cache/strip_debug");
-	ShaderRD::set_shader_cache_save_compressed(compress);
-	ShaderRD::set_shader_cache_save_compressed_zstd(use_zstd);
-	ShaderRD::set_shader_cache_save_debug(!strip_debug);
 
 	// Shader cache is forcefully enabled when running the editor.
 	if (shader_cache_enabled || Engine::get_singleton()->is_editor_hint()) {

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -1140,18 +1140,6 @@ const String &ShaderRD::get_shader_cache_res_dir() {
 	return shader_cache_res_dir;
 }
 
-void ShaderRD::set_shader_cache_save_compressed(bool p_enable) {
-	shader_cache_save_compressed = p_enable;
-}
-
-void ShaderRD::set_shader_cache_save_compressed_zstd(bool p_enable) {
-	shader_cache_save_compressed_zstd = p_enable;
-}
-
-void ShaderRD::set_shader_cache_save_debug(bool p_enable) {
-	shader_cache_save_debug = p_enable;
-}
-
 Vector<RD::ShaderStageSPIRVData> ShaderRD::compile_stages(const Vector<String> &p_stage_sources, const Vector<uint64_t> &p_dynamic_buffers) {
 	RD::ShaderStageSPIRVData stage;
 	Vector<RD::ShaderStageSPIRVData> stages;
@@ -1225,9 +1213,6 @@ PackedByteArray ShaderRD::save_shader_cache_bytes(const LocalVector<int> &p_vari
 
 String ShaderRD::shader_cache_user_dir;
 String ShaderRD::shader_cache_res_dir;
-bool ShaderRD::shader_cache_save_compressed = true;
-bool ShaderRD::shader_cache_save_compressed_zstd = true;
-bool ShaderRD::shader_cache_save_debug = true;
 
 ShaderRD::~ShaderRD() {
 	LocalVector<RID> remaining = version_owner.get_owned_list();

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -150,9 +150,6 @@ private:
 	static String shader_cache_user_dir;
 	static String shader_cache_res_dir;
 	static bool shader_cache_cleanup_on_start;
-	static bool shader_cache_save_compressed;
-	static bool shader_cache_save_compressed_zstd;
-	static bool shader_cache_save_debug;
 	bool shader_cache_user_dir_valid = false;
 	bool shader_cache_res_dir_valid = false;
 
@@ -255,9 +252,6 @@ public:
 	static const String &get_shader_cache_user_dir();
 	static void set_shader_cache_res_dir(const String &p_dir);
 	static const String &get_shader_cache_res_dir();
-	static void set_shader_cache_save_compressed(bool p_enable);
-	static void set_shader_cache_save_compressed_zstd(bool p_enable);
-	static void set_shader_cache_save_debug(bool p_enable);
 
 	static Vector<RD::ShaderStageSPIRVData> compile_stages(const Vector<String> &p_stage_sources, const Vector<uint64_t> &p_dynamic_buffers);
 	static PackedByteArray save_shader_cache_bytes(const LocalVector<int> &p_variants, const Vector<Vector<uint8_t>> &p_variant_data);

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3670,10 +3670,6 @@ void RenderingServer::init() {
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/gl_compatibility/item_buffer_size", PROPERTY_HINT_RANGE, "128,1048576,1"), 16384);
 
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/enabled", true);
-	GLOBAL_DEF("rendering/shader_compiler/shader_cache/compress", true);
-	GLOBAL_DEF("rendering/shader_compiler/shader_cache/use_zstd_compression", true);
-	GLOBAL_DEF("rendering/shader_compiler/shader_cache/strip_debug", false);
-	GLOBAL_DEF("rendering/shader_compiler/shader_cache/strip_debug.release", true);
 
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/reflections/sky_reflections/roughness_layers", PROPERTY_HINT_RANGE, "1,32,1"), 8);
 	GLOBAL_DEF_RST("rendering/reflections/sky_reflections/texture_array_reflections", true);


### PR DESCRIPTION
### Summary

- remove 3 unused variables from the rendering shader compiler
- update `ProjectSettings.xml` appropriately

### Details

The following 4 project settings:

- rendering/shader_compiler/shader_cache/compress
- rendering/shader_compiler/shader_cache/strip_debug
- rendering/shader_compiler/shader_cache/strip_debug.release
- rendering/shader_compiler/shader_cache/use_zstd_compression

all refer to variables whose logic was removed by https://github.com/godotengine/godot/pull/50847. As far as I can tell the variables created from these settings are unaccessed (`strip_debug.release` is never accessed, the others are accessed but then placed into unused variables).

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
