### PR TITLE
Fix no GDScript build fails due to no `class_db.h`

### DIFF
--- a/modules/gltf/tests/test_gltf.h
+++ b/modules/gltf/tests/test_gltf.h
@@ -36,6 +36,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/object/class_db.h"
 #include "drivers/png/image_loader_png.h"
 #include "editor/import/3d/resource_importer_scene.h"
 #include "editor/import/resource_importer_texture.h"


### PR DESCRIPTION
Building with `module_gdscript_enabled=no` and with tests fails due to the `GD_IS_CLASS_ENABLED` in `test_gltf.h`. Including `class_db.h` directly fixes it.

- Probably from https://github.com/godotengine/godot/pull/117059 or a related one, not sure but it was recent.