### PR TITLE
Refactor `RendererCompositorStorage::compositor_get_compositor_effects`

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -5606,6 +5606,7 @@
 			The callback is called after our transparent rendering pass, but before any built-in post-processing effects and output to our render target.
 		</constant>
 		<constant name="COMPOSITOR_EFFECT_CALLBACK_TYPE_ANY" value="-1" enum="CompositorEffectCallbackType">
+			The callback is called when any other [enum CompositorEffectCallbackType] callback is called.
 		</constant>
 		<constant name="ENV_BG_CLEAR_COLOR" value="0" enum="EnvironmentBG">
 			Use the clear color as background.

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -265,7 +265,7 @@ bool RendererSceneRenderRD::_compositor_effects_has_flag(const RenderDataRD *p_r
 	}
 
 	ERR_FAIL_COND_V(!comp_storage->is_compositor(p_render_data->compositor), false);
-	Vector<RID> re_rids = comp_storage->compositor_get_compositor_effects(p_render_data->compositor, p_callback_type, true);
+	Vector<RID> re_rids = comp_storage->compositor_get_compositor_effects(p_render_data->compositor, p_callback_type);
 
 	for (RID rid : re_rids) {
 		if (comp_storage->compositor_effect_get_flag(rid, p_flag)) {
@@ -289,7 +289,7 @@ bool RendererSceneRenderRD::_has_compositor_effect(RSE::CompositorEffectCallback
 
 	ERR_FAIL_COND_V(!comp_storage->is_compositor(p_render_data->compositor), false);
 
-	Vector<RID> effects = comp_storage->compositor_get_compositor_effects(p_render_data->compositor, p_callback_type, true);
+	Vector<RID> effects = comp_storage->compositor_get_compositor_effects(p_render_data->compositor, p_callback_type);
 
 	return effects.size() > 0;
 }
@@ -307,7 +307,7 @@ void RendererSceneRenderRD::_process_compositor_effects(RSE::CompositorEffectCal
 
 	ERR_FAIL_COND(!comp_storage->is_compositor(p_render_data->compositor));
 
-	Vector<RID> re_rids = comp_storage->compositor_get_compositor_effects(p_render_data->compositor, p_callback_type, true);
+	Vector<RID> re_rids = comp_storage->compositor_get_compositor_effects(p_render_data->compositor, p_callback_type);
 
 	for (RID rid : re_rids) {
 		Callable callback = comp_storage->compositor_effect_get_callback(rid);

--- a/servers/rendering/storage/compositor_storage.cpp
+++ b/servers/rendering/storage/compositor_storage.cpp
@@ -174,21 +174,17 @@ void RendererCompositorStorage::compositor_set_compositor_effects(RID p_composit
 	}
 }
 
-Vector<RID> RendererCompositorStorage::compositor_get_compositor_effects(RID p_compositor, RSE::CompositorEffectCallbackType p_callback_type, bool p_enabled_only) const {
+Vector<RID> RendererCompositorStorage::compositor_get_compositor_effects(RID p_compositor, RSE::CompositorEffectCallbackType p_callback_type) const {
 	Compositor *compositor = compositor_owner.get_or_null(p_compositor);
 	ERR_FAIL_NULL_V(compositor, Vector<RID>());
 
-	if (p_enabled_only || p_callback_type != RSE::COMPOSITOR_EFFECT_CALLBACK_TYPE_ANY) {
-		Vector<RID> effects;
+	Vector<RID> effects;
 
-		for (RID rid : compositor->compositor_effects) {
-			if ((!p_enabled_only || compositor_effect_get_enabled(rid)) && (p_callback_type == RSE::COMPOSITOR_EFFECT_CALLBACK_TYPE_ANY || compositor_effect_get_callback_type(rid) == p_callback_type)) {
-				effects.push_back(rid);
-			}
+	for (RID rid : compositor->compositor_effects) {
+		if (compositor_effect_get_enabled(rid) && (p_callback_type == RSE::COMPOSITOR_EFFECT_CALLBACK_TYPE_ANY || compositor_effect_get_callback_type(rid) == p_callback_type)) {
+			effects.push_back(rid);
 		}
-
-		return effects;
-	} else {
-		return compositor->compositor_effects;
 	}
+
+	return effects;
 }

--- a/servers/rendering/storage/compositor_storage.h
+++ b/servers/rendering/storage/compositor_storage.h
@@ -93,5 +93,5 @@ public:
 	}
 
 	void compositor_set_compositor_effects(RID p_compositor, const Vector<RID> &p_effects);
-	Vector<RID> compositor_get_compositor_effects(RID p_compositor, RSE::CompositorEffectCallbackType p_callback_type = RSE::COMPOSITOR_EFFECT_CALLBACK_TYPE_ANY, bool p_enabled_only = true) const;
+	Vector<RID> compositor_get_compositor_effects(RID p_compositor, RSE::CompositorEffectCallbackType p_callback_type = RSE::COMPOSITOR_EFFECT_CALLBACK_TYPE_ANY) const;
 };


### PR DESCRIPTION
- make `compositor_get_compositor_effects` function significantly more readable
- remove `p_enabled_only` bool (which was always set to true)
- update `RenderingServer.xml` to describe `COMPOSITOR_EFFECT_CALLBACK_TYPE_ANY`

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->