### PR TITLE
Profiler: Fix for graph panning with scrollbar (panning does not work on touchpad)

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -344,6 +344,28 @@ void EditorProfiler::_update_plot() {
 	graph->queue_redraw();
 }
 
+void EditorProfiler::_update_scrollbar() {
+	const int max_profiles_shown = frame_metrics.size() / Math::exp(graph_zoom);
+	const int left_border = _get_zoom_left_border();
+
+	updating_scrollbar = true;
+	graph_scrollbar->set_min(0);
+	graph_scrollbar->set_max(frame_metrics.size());
+	graph_scrollbar->set_page(max_profiles_shown);
+	graph_scrollbar->set_value(left_border);
+	graph_scrollbar->set_visible(max_profiles_shown < frame_metrics.size());
+	updating_scrollbar = false;
+}
+
+void EditorProfiler::_scrollbar_changed(double p_value) {
+	if (updating_scrollbar) {
+		return;
+	}
+	const int max_profiles_shown = frame_metrics.size() / Math::exp(graph_zoom);
+	zoom_center = CLAMP((int)p_value + max_profiles_shown / 2, max_profiles_shown / 2, frame_metrics.size() - max_profiles_shown / 2);
+	_update_plot();
+}
+
 void EditorProfiler::_update_frame() {
 	int cursor_metric = cursor_metric_edit->get_value() - _get_frame_metric(0).frame_number;
 
@@ -429,6 +451,7 @@ void EditorProfiler::_clear_pressed() {
 	clear_button->set_disabled(true);
 	clear();
 	_update_plot();
+	_update_scrollbar();
 }
 
 void EditorProfiler::_internal_profiles_pressed() {
@@ -460,7 +483,11 @@ void EditorProfiler::_notification(int p_what) {
 
 			if (total_metrics > 0) {
 				_update_plot();
+				_update_scrollbar();
 			}
+		} break;
+		case NOTIFICATION_RESIZED: {
+			_update_scrollbar();
 		} break;
 	}
 }
@@ -539,22 +566,11 @@ void EditorProfiler::_graph_tex_input(const Ref<InputEvent> &p_ev) {
 		}
 	}
 
-	if (graph_zoom > 0 && mm.is_valid() && (mm->get_button_mask().has_flag(MouseButtonMask::MIDDLE) || mm->get_button_mask().has_flag(MouseButtonMask::RIGHT))) {
-		// Panning.
-		const int max_profiles_shown = frame_metrics.size() / Math::exp(graph_zoom);
-		pan_accumulator += (float)mm->get_relative().x * max_profiles_shown / graph->get_size().width;
-
-		if (Math::abs(pan_accumulator) > 1) {
-			zoom_center = CLAMP(zoom_center - (int)pan_accumulator, max_profiles_shown / 2, frame_metrics.size() - max_profiles_shown / 2);
-			pan_accumulator -= (int)pan_accumulator;
-			_update_plot();
-		}
-	}
-
 	if (button_idx == MouseButton::WHEEL_DOWN) {
 		// Zooming.
 		graph_zoom = MAX(-0.05 + graph_zoom, 0);
 		_update_plot();
+		_update_scrollbar();
 	} else if (button_idx == MouseButton::WHEEL_UP) {
 		if (graph_zoom == 0) {
 			zoom_center = me->get_position().x;
@@ -562,6 +578,7 @@ void EditorProfiler::_graph_tex_input(const Ref<InputEvent> &p_ev) {
 		}
 		graph_zoom = MIN(0.05 + graph_zoom, 2);
 		_update_plot();
+		_update_scrollbar();
 	}
 
 	graph->queue_redraw();
@@ -785,8 +802,18 @@ EditorProfiler::EditorProfiler() {
 	graph->connect(SceneStringName(gui_input), callable_mp(this, &EditorProfiler::_graph_tex_input));
 	graph->connect(SceneStringName(mouse_exited), callable_mp(this, &EditorProfiler::_graph_tex_mouse_exit));
 
-	h_split->add_child(graph);
+	VBoxContainer *graph_container = memnew(VBoxContainer);
+	graph_container->set_h_size_flags(SIZE_EXPAND_FILL);
+	h_split->add_child(graph_container);
+
 	graph->set_h_size_flags(SIZE_EXPAND_FILL);
+	graph->set_v_size_flags(SIZE_EXPAND_FILL);
+	graph_container->add_child(graph);
+
+	graph_scrollbar = memnew(HScrollBar);
+	graph_scrollbar->set_visible(false);
+	graph_container->add_child(graph_scrollbar);
+	graph_scrollbar->connect(SceneStringName(value_changed), callable_mp(this, &EditorProfiler::_scrollbar_changed));
 
 	int metric_size = CLAMP(int(EDITOR_GET("debugger/profiler_frame_history_size")), 60, 10000);
 	frame_metrics.resize(metric_size);

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -101,11 +101,11 @@ private:
 	Button *activate = nullptr;
 	Button *clear_button = nullptr;
 	TextureRect *graph = nullptr;
+	HScrollBar *graph_scrollbar = nullptr;
 	Ref<ImageTexture> graph_texture;
 	Vector<uint8_t> graph_image;
 
 	float graph_zoom = 0.0f;
-	float pan_accumulator = 0.0f;
 	int zoom_center = -1;
 
 	Tree *variables = nullptr;
@@ -125,6 +125,7 @@ private:
 	int last_metric = -1;
 
 	bool updating_frame = false;
+	bool updating_scrollbar = false;
 
 	int hover_metric = -1;
 
@@ -150,6 +151,9 @@ private:
 	void _item_edited();
 
 	void _update_plot();
+
+	void _scrollbar_changed(double p_value);
+	void _update_scrollbar();
 
 	void _graph_tex_mouse_exit();
 


### PR DESCRIPTION
I decided the best way to fix this bug was to remove panning and add a scrollbar instead. No one really knew panning was available in this graph and panning did not give the user any indication where in the graph they had moved to. The scrollbar solves both of these problems because the scrollbar itself let's them know they can move around and it gives the user visual feedback where in the graph they are currently looking.

Fixes #71112 
Partially address #108840 
There are also some bug that indicate the user was confused when they zoomed in on the graph and then cleared the data which causes the graph to remove it's lines. So they are zoomed in on a black area that is empty and they think the profiler is not working but it is. The scrollbar will fix this by making it obvious where in the graph they are.

Some added and some removed lines of code in two files. No messy blocks of code with intermixed changes.

*******************************
Disclosure and License
-As a software engineer I use many systems to ensure code quality, and that includes AI. I use the AI to: do detailed code analysis, be a sounding board for my different ideas, look for bugs, find unexpected behaviors, identify performance hot spots, expensive CPU calls, race conditions, poorly placed variable initializations, possible optimizations, and many more things. I do this during development and before I push code to the repo. It lists items that are potential problems and I decide what I think is important and make those changes.
-For a descriptive example of my AI usage on a particular PR please read this https://github.com/godotengine/godot/pull/117066#issuecomment-4061773098
-Any and all code attached to this PR falls under the coverage of the MIT License.