### PR TITLE
[POC] GDScript: Reduce call overhead for functions that don't use `self` or class

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -1347,7 +1347,8 @@ void GDScriptByteCodeGenerator::write_call_self(const Address &p_target, const S
 	for (int i = 0; i < p_arguments.size(); i++) {
 		append(p_arguments[i]);
 	}
-	append(GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
+	append(GDScriptFunction::ADDR_SELF);
+	function->_self_used = true;
 	CallTarget ct = get_call_target(p_target);
 	append(ct.target);
 	append(p_arguments.size());
@@ -1361,6 +1362,7 @@ void GDScriptByteCodeGenerator::write_call_self_async(const Address &p_target, c
 		append(p_arguments[i]);
 	}
 	append(GDScriptFunction::ADDR_SELF);
+	function->_self_used = true;
 	CallTarget ct = get_call_target(p_target);
 	append(ct.target);
 	append(p_arguments.size());

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -392,6 +392,12 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	}
 
 	void append(const Address &p_address) {
+		if (p_address.mode == GDScriptCodeGenerator::Address::SELF) {
+			function->_self_used = true;
+		}
+		if (p_address.mode == GDScriptCodeGenerator::Address::CLASS) {
+			function->_class_used = true;
+		}
 		opcodes.push_back(address_of(p_address));
 	}
 

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -346,6 +346,8 @@ private:
 	StringName name;
 	StringName source;
 	bool _static = false;
+	bool _self_used = false;
+	bool _class_used = false;
 	Vector<GDScriptDataType> argument_types;
 	GDScriptDataType return_type;
 	MethodInfo method_info;

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -346,8 +346,12 @@ private:
 	StringName name;
 	StringName source;
 	bool _static = false;
+
+public:
 	bool _self_used = false;
 	bool _class_used = false;
+
+private:
 	Vector<GDScriptDataType> argument_types;
 	GDScriptDataType return_type;
 	MethodInfo method_info;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -654,13 +654,19 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 	}
 
 	if (p_instance) {
-		memnew_placement(&stack[ADDR_STACK_SELF], Variant(p_instance->owner));
+		if (_self_used) {
+			memnew_placement(&stack[ADDR_STACK_SELF], Variant(p_instance->owner));
+		}
 		script = p_instance->script.ptr();
 	} else {
-		memnew_placement(&stack[ADDR_STACK_SELF], Variant);
+		if (_self_used) {
+			memnew_placement(&stack[ADDR_STACK_SELF], Variant);
+		}
 		script = _script;
 	}
-	memnew_placement(&stack[ADDR_STACK_CLASS], Variant(script));
+	if (_class_used) {
+		memnew_placement(&stack[ADDR_STACK_CLASS], Variant(script));
+	}
 	memnew_placement(&stack[ADDR_STACK_NIL], Variant);
 
 	String err_text;
@@ -4007,7 +4013,14 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		GDScriptLanguage::get_singleton()->exit_function();
 	}
 
-	for (int i = 0; i < _stack_size; i++) {
+	if (_self_used) {
+		stack[ADDR_STACK_SELF].~Variant();
+	}
+	if (_class_used) {
+		stack[ADDR_STACK_CLASS].~Variant();
+	}
+	stack[ADDR_STACK_NIL].~Variant();
+	for (int i = FIXED_ADDRESSES_MAX; i < _stack_size; i++) {
 		stack[i].~Variant();
 	}
 

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -32,10 +32,15 @@
 
 #include "gdscript_language_protocol.h"
 
+#include "core/config/project_settings.h"
+#include "core/io/dir_access.h"
+#include "core/object/callable_mp.h"
 #include "core/os/os.h"
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
+#include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
+#include "scene/main/node.h"
 
 int GDScriptLanguageServer::port_override = -1;
 
@@ -43,8 +48,62 @@ GDScriptLanguageServer::GDScriptLanguageServer() {
 	set_process_internal(true);
 }
 
+void survey_folder(const String &p_dir, int &r_total, int &r_self, int &r_class) {
+	Error err = OK;
+	Ref<DirAccess> dir = DirAccess::open(p_dir, &err);
+
+	if (err != OK) {
+		return;
+	}
+
+	String path = dir->get_current_dir();
+
+	dir->list_dir_begin();
+	String next = dir->get_next();
+
+	while (!next.is_empty()) {
+		if (dir->current_is_dir()) {
+			if (next == "." || next == "..") {
+				next = dir->get_next();
+				continue;
+			}
+			survey_folder(path.path_join(next), r_total, r_self, r_class);
+		} else if (next.ends_with(".gd")) {
+			Ref<GDScript> script = ResourceLoader::load(ProjectSettings::get_singleton()->localize_path(path.path_join(next)));
+
+			HashMap<StringName, GDScriptFunction *> m_funcs = HashMap<StringName, GDScriptFunction *>(script->get_member_functions());
+			m_funcs["@implicit_new"] = const_cast<GDScriptFunction *>(script->get_implicit_initializer());
+			m_funcs["@implicit_ready"] = const_cast<GDScriptFunction *>(script->get_implicit_ready());
+			m_funcs["@static_initializer"] = const_cast<GDScriptFunction *>(script->get_static_initializer());
+
+			for (auto fn : script->get_member_functions()) {
+				r_total += 1;
+				if (fn.value->_self_used) {
+					r_self += 1;
+				}
+				if (fn.value->_class_used) {
+					r_class += 1;
+				}
+			}
+		}
+		next = dir->get_next();
+	}
+}
+
+static void survey() {
+	int total_fn = 0;
+	int self_used = 0;
+	int class_used = 0;
+	survey_folder("res://", total_fn, self_used, class_used);
+	print_line("total: ", total_fn, " self: ", self_used, " class: ", class_used);
+}
+
 void GDScriptLanguageServer::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			EditorCommandPalette::get_singleton()->add_command("GDScript Survey: Stack Use", "gdscript/survey/stack_use", callable_mp_static(&survey));
+		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			stop();
 		} break;

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -38,9 +38,15 @@
 #include "gdscript_test_runner.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/dir_access.h"
 #include "core/io/file_access.h"
+#include "core/io/resource_loader.h"
 #include "core/os/os.h"
+#include "core/string/print_string.h"
 #include "core/string/string_builder.h"
+#include "core/string/string_name.h"
+#include "modules/gdscript/gdscript.h"
+#include "modules/gdscript/gdscript_function.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/settings/editor_settings.h"


### PR DESCRIPTION
Note:
- Better solution for `CLASS`: https://github.com/godotengine/godot/pull/117850

When a GDScript function gets called there is an overhead from setting up and cleaning up the stack. Some of that time is spent referencing and unreferencing the script and the instance, because we always make those available on the stack and storing them in a variant triggers ref counting.

For functions that don't actually use those stack entries this work isn't really necessary. This PR saves whether a function uses self or its class. And if not leaves those stack spaces uninitialized, in an attempt to reduce the call overhead in some situations.


<details>
<summary>For a very specific benchmark that tests a pure function that just does math I see around a 10% improvement.</summary>

```gdscript
extends Node

var iter : int = 1_000_000
var test_strick : float = 0.0
var time : float = 0.0

func sqrt_v1(num:int) -> float:
	return num**0.5
	
func _ready() -> void:
	for ii in range(5):
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			test_strick += sqrt_v1(i)
		print(Time.get_unix_time_from_system() - time)
	get_tree().quit()
```
</details>

However this is unlikely to translate to real projects, since a most functions will need those stack entries. I don't have any realistic projects to test against so I'll just put it as draft for now.

Actual benchmark data (benchmark script slightly altered): [stack_uninit.ods](https://github.com/user-attachments/files/26064276/stack_uninit.ods)