### PR TITLE
Fix find/replace bar hiding current line at bottom of script editor

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -591,6 +591,11 @@ void FindReplaceBar::_update_toggle_replace_button(bool p_replace_visible) {
 
 void FindReplaceBar::_show_search(bool p_with_replace, bool p_show_only) {
 	show();
+
+	if (base_text_editor) {
+		base_text_editor->adjust_viewport_to_caret();
+	}
+
 	if (p_show_only) {
 		return;
 	}


### PR DESCRIPTION
Fixes #117106

Calls adjust_viewport_to_caret when showing the bar to correctly update the layout