### PR TITLE
Fix ScriptCreateDialog exclusive child error when adding Global Autoload

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -4558,6 +4558,7 @@ FileSystemDock::FileSystemDock() {
 
 	make_script_dialog = memnew(ScriptCreateDialog);
 	make_script_dialog->set_title(TTRC("Create Script"));
+	make_script_dialog->set_transient_to_focused(true);
 	add_child(make_script_dialog);
 	make_script_dialog->connect("script_created", callable_mp(this, &FileSystemDock::_script_or_shader_created));
 


### PR DESCRIPTION
Fixes #117027

Enables transient_to_focused for FileSystemDock's ScriptCreateDialog.

The error was caused by the ProjectSettingsEditor being set to the main window's exclusive transient child upon opening, which is then overwritten when the ScriptCreateDialog is opened from the Globals -> Autoload menu's "Add" button. The ScriptCreateDialog object is being retrieved from the FileSystemDock, where it is usually opened from the main window and does not cause the error.

When transient_to_focused is enabled, the ScriptCreateDialog correctly sets either the main window's or the project settings window's exclusive transient child when opened from each, respectively. 

This change also has the effect of disallowing interaction with the settings menu until the script creation dialog is closed. Before this change, the following interaction would also cause one or more **CanvasItem RID leaks** notified after closing the editor:
- Open script create dialog via Globals->Autoload->"Add"
- Return to project settings dialog press "Add" again (May leak multiple RID's if changing the autoload name each time, or if pressing "Add" multiple times)
- Close the script creation dialog (in any way)
- Close the editor (with or without saving)

I could not find any instances of similar behavior for other dialogs, but it may be worth investigating the above RID leaks if there are dialogs which can be opened from non-main sub-windows which do not enable transient_to_focused and can be reopened multiple times.