### PR TITLE
Add Back/Forward shortcuts to FileDialog using extra mouse buttons

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -895,6 +895,15 @@ String InputEventMouseButton::_to_string() {
 	return vformat("InputEventMouseButton: %s, pressed=%s, canceled=%s, position=(%s), button_mask=%d, double_click=%s", index_and_mods, p, canceled_state, String(get_position()), get_button_mask(), d);
 }
 
+Ref<InputEventMouseButton> InputEventMouseButton::create_reference(MouseButton p_button) {
+	Ref<InputEventMouseButton> ie;
+	ie.instantiate();
+	ie->set_button_index(p_button);
+	ie->set_device(DEVICE_ID_MOUSE);
+
+	return ie;
+}
+
 void InputEventMouseButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_factor", "factor"), &InputEventMouseButton::set_factor);
 	ClassDB::bind_method(D_METHOD("get_factor"), &InputEventMouseButton::get_factor);

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -261,6 +261,8 @@ public:
 	virtual String as_text() const override;
 	virtual String _to_string() override;
 
+	static Ref<InputEventMouseButton> create_reference(MouseButton p_button);
+
 	InputEventType get_type() const final override { return InputEventType::MOUSE_BUTTON; }
 };
 

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -424,6 +424,8 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
 	{ "ui_graph_follow_left",                          TTRC("Follow Input Port Connection") },
 	{ "ui_graph_follow_right",                         TTRC("Follow Output Port Connection") },
 	{ "ui_filedialog_delete",                          TTRC("Delete") },
+	{ "ui_filedialog_previous",                        TTRC("Go to Previous") },
+	{ "ui_filedialog_next",                            TTRC("Go to Next") },
 	{ "ui_filedialog_up_one_level",                    TTRC("Go Up One Level") },
 	{ "ui_filedialog_refresh",                         TTRC("Refresh") },
 	{ "ui_filedialog_show_hidden",                     TTRC("Show Hidden") },
@@ -842,6 +844,17 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::BACKSPACE));
+	inputs.push_back(InputEventKey::create_reference(Key::LEFT | KeyModifierMask::ALT));
+	inputs.push_back(InputEventMouseButton::create_reference(MouseButton::MB_XBUTTON1));
+	default_builtin_cache.insert("ui_filedialog_previous", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::RIGHT | KeyModifierMask::ALT));
+	inputs.push_back(InputEventMouseButton::create_reference(MouseButton::MB_XBUTTON2));
+	default_builtin_cache.insert("ui_filedialog_next", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::UP | KeyModifierMask::ALT));
 	default_builtin_cache.insert("ui_filedialog_up_one_level", inputs);
 
 	inputs = List<Ref<InputEvent>>();

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -336,6 +336,19 @@ void FileDialog::_notification(int p_what) {
 	}
 }
 
+void FileDialog::_input_from_window(const Ref<InputEvent> &p_event) {
+	if (p_event.is_valid() && p_event->is_pressed() && !p_event->is_echo()) {
+		// Previous/next shortcuts need to be implemented here instead of using Button's shortcut property.
+		if (action_shortcuts[ITEM_MENU_PREVIOUS]->matches_event(p_event)) {
+			_go_back();
+			set_input_as_handled();
+		} else if (action_shortcuts[ITEM_MENU_NEXT]->matches_event(p_event)) {
+			_go_forward();
+			set_input_as_handled();
+		}
+	}
+}
+
 void FileDialog::shortcut_input(const Ref<InputEvent> &p_event) {
 	if (p_event.is_null() || p_event->is_released() || p_event->is_echo()) {
 		return;
@@ -2318,6 +2331,8 @@ FileDialog::FileDialog() {
 	}
 
 	action_shortcuts[ITEM_MENU_DELETE] = Shortcut::make_from_action("ui_filedialog_delete");
+	action_shortcuts[ITEM_MENU_PREVIOUS] = Shortcut::make_from_action("ui_filedialog_previous");
+	action_shortcuts[ITEM_MENU_NEXT] = Shortcut::make_from_action("ui_filedialog_next");
 	action_shortcuts[ITEM_MENU_GO_UP] = Shortcut::make_from_action("ui_filedialog_up_one_level");
 	action_shortcuts[ITEM_MENU_REFRESH] = Shortcut::make_from_action("ui_filedialog_refresh");
 	action_shortcuts[ITEM_MENU_TOGGLE_HIDDEN] = Shortcut::make_from_action("ui_filedialog_show_hidden");
@@ -2337,12 +2352,14 @@ FileDialog::FileDialog() {
 	dir_prev = memnew(Button);
 	dir_prev->set_theme_type_variation(SceneStringName(FlatButton));
 	dir_prev->set_tooltip_text(ETR("Go to previous folder."));
+	dir_prev->set_shortcut(action_shortcuts[ITEM_MENU_PREVIOUS]);
 	top_toolbar->add_child(dir_prev);
 	dir_prev->connect(SceneStringName(pressed), callable_mp(this, &FileDialog::_go_back));
 
 	dir_next = memnew(Button);
 	dir_next->set_theme_type_variation(SceneStringName(FlatButton));
 	dir_next->set_tooltip_text(ETR("Go to next folder."));
+	dir_next->set_shortcut(action_shortcuts[ITEM_MENU_NEXT]);
 	top_toolbar->add_child(dir_next);
 	dir_next->connect(SceneStringName(pressed), callable_mp(this, &FileDialog::_go_forward));
 

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -138,6 +138,8 @@ public:
 		ITEM_MENU_SHOW_IN_EXPLORER,
 		ITEM_MENU_SHOW_BUNDLE_CONTENT,
 		// Not in the menu, only for shortcuts.
+		ITEM_MENU_PREVIOUS,
+		ITEM_MENU_NEXT,
 		ITEM_MENU_GO_UP,
 		ITEM_MENU_TOGGLE_HIDDEN,
 		ITEM_MENU_FIND,
@@ -355,6 +357,7 @@ private:
 	void _setup_button(Button *p_button, const Ref<Texture2D> &p_icon);
 	void _update_make_dir_visible();
 
+	virtual void _input_from_window(const Ref<InputEvent> &p_event) override;
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 	void _native_popup();


### PR DESCRIPTION
- Also add <kbd>Alt + Left/Right arrow</kbd> for Back/Forward, and <kbd>Backspace</kbd> as an alternative for Back to match OS standards.
- Change Go Up One Level shortcut to match OS standards (<kbd>Backspace</kbd> -> <kbd>Alt + Up arrow</kbd>).
- Add `InputEventMouseButton::create_reference()` to simplify C++ code where mouse buttons are used in shortcuts.

Works in the editor and in projects, since FileDialog is now used in both. Tested with and without window embedding enabled, in both the editor and projects.

- This closes https://github.com/godotengine/godot-proposals/issues/15358.
- This partially addresses https://github.com/godotengine/godot-proposals/issues/954.

## Preview

*Press the auxiliary side buttons on a mouse to navigate history, or use the keyboard shortcuts listed above.*

https://github.com/user-attachments/assets/1616a546-b325-47a9-aaf8-04768f95cc64


