### PR TITLE
Implement extra mouse button history navigation in the Inspector dock

### DIFF
--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -696,6 +696,26 @@ void InspectorDock::apply_script_properties(Object *p_object) {
 	stored_properties.clear();
 }
 
+void InspectorDock::gui_input(const Ref<InputEvent> &p_event) {
+	// Allow navigation shortcuts only when the mouse is currently over the inspector dock.
+	// This avoids conflicts with the script editor, which uses the same mouse buttons to navigate history,
+	// but does not require clicking over the inspector to get focus first.
+	const Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->is_pressed() && get_rect().has_point(get_local_mouse_position())) {
+		if (mb->get_button_index() == MouseButton::MB_XBUTTON1) {
+			if (EDITOR_GET("interface/editor/input/mouse_extra_buttons_navigate_history")) {
+				_edit_back();
+				get_viewport()->set_input_as_handled();
+			}
+		} else if (mb->get_button_index() == MouseButton::MB_XBUTTON2) {
+			if (EDITOR_GET("interface/editor/input/mouse_extra_buttons_navigate_history")) {
+				_edit_forward();
+				get_viewport()->set_input_as_handled();
+			}
+		}
+	}
+}
+
 void InspectorDock::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 

--- a/editor/docks/inspector_dock.h
+++ b/editor/docks/inspector_dock.h
@@ -134,6 +134,7 @@ class InspectorDock : public EditorDock {
 	void _select_history(int p_idx);
 	void _prepare_history();
 
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 private:


### PR DESCRIPTION
- Follow-up to #117129 
(can be merged independently).

Note that for the FileSystem dock, there is another PR open:

- https://github.com/godotengine/godot/pull/111628

Shortcut priority is determined based on the mouse position at the point the button is pressed. This allows distinguishing between the navigation button being used on different docks, or the script editor.

In the long run, we could also decide to implement this on the main 2D/3D views to switch between open scenes, like it's implemented on the script editor already. This would probably be its own PR, since it would involve adding a notion of scene switching history.

- This partially addresses https://github.com/godotengine/godot-proposals/issues/954.

## Preview

*Press the auxiliary side buttons on a mouse to navigate history.*

https://github.com/user-attachments/assets/329729b5-9bae-4d8a-84e3-7d4fbb5bd4ac

## TODO

- [ ] Fix the input being ignored if the mouse extra button is pressed while over an enum property dropdown, physics/visual layers or any other complex inspector control.
- [ ] Fix the input being ignored when the mouse is at the top of the inspector dock (e.g. on, or near the previous/next history buttons).
- [ ] Fix the input not actually being accepted despite calling `get_viewport()->set_input_as_handled()` (I've also tried `accept_input()`). This causes the script editor to also navigate history even if the mouse was pressed while over the inspector dock.
