### PR TITLE
Android: Fix FileAccess crash when using `treeUri` in Gradle-built apps

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 
     implementation "androidx.fragment:fragment:$versions.fragmentVersion"
     implementation "androidx.core:core-splashscreen:$versions.splashscreenVersion"
+    implementation "androidx.documentfile:documentfile:$versions.documentfileVersion"
 
     if (rootProject.findProject(":lib")) {
         implementation project(":lib")

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -23,6 +23,7 @@ ext.versions = [
     kotlinTestVersion  : '1.3.11',
     testRunnerVersion  : '1.7.0',
     testOrchestratorVersion: '1.6.1',
+    documentfileVersion: '1.1.0',
 ]
 
 ext.getExportPackageName = { ->

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -13,7 +13,7 @@ apply from: "../scripts/publish-module.gradle"
 
 dependencies {
     implementation "androidx.fragment:fragment:$versions.fragmentVersion"
-    implementation 'androidx.documentfile:documentfile:1.1.0'
+    implementation "androidx.documentfile:documentfile:$versions.documentfileVersion"
 
     testImplementation "junit:junit:4.13.2"
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/117111

`androidx.documentfile:documentfile` dependency was missing in `app` module.

<img width="1525" height="489" src="https://github.com/user-attachments/assets/85a4d036-e664-407d-a9e0-7ac25214f23f" />

