### PR TITLE
i18n: Extract Control accessibility name/description in POT generator

### DIFF
--- a/editor/translations/packed_scene_translation_parser_plugin.cpp
+++ b/editor/translations/packed_scene_translation_parser_plugin.cpp
@@ -230,6 +230,8 @@ PackedSceneEditorTranslationParserPlugin::PackedSceneEditorTranslationParserPlug
 	lookup_properties.insert("filters");
 	lookup_properties.insert("script");
 	lookup_properties.insert("item_*/text");
+	lookup_properties.insert("accessibility_name");
+	lookup_properties.insert("accessibility_description");
 
 	// Exception list (to prevent false positives).
 	exception_list.insert("LineEdit", { "text" });


### PR DESCRIPTION
## Summary

Fixes #115366.

Control nodes gained `accessibility_name` and `accessibility_description` properties in Godot 4.5 (shown in the **Accessibility** tab of the Inspector). These strings are passed through `tr()` at runtime, making them translatable — but `PackedSceneEditorTranslationParserPlugin` was never updated to extract them, so they were silently omitted from generated `.pot` files.

**Fix:** add both property names to the `lookup_properties` set in `PackedSceneEditorTranslationParserPlugin`'s constructor, alongside the existing translatable properties (`text`, `title`, etc.).

## Validation

Verified with a headless GDScript test that `SceneState` exposes these properties as plain strings — the same API the C++ parser uses internally:

```
[PASS] accessibility_name readable via SceneState
[PASS] accessibility_description readable via SceneState
```

No new logic is introduced; the change is equivalent to the existing entries in `lookup_properties`.

Note: `accessibility_name` and `accessibility_description` do **not** need to be added to `exception_list` — unlike `LineEdit::text` or `TextEdit::text`, these fields are author-defined labels (not user-entered content), so extracting them for translation is always correct.