### PR TITLE
Set accessibility name on Tree inline cell editor when editing

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4528,6 +4528,9 @@ bool Tree::edit_selected(bool p_force_edit) {
 		line_editor->select_all();
 		line_editor->show();
 
+		const String &col_title = columns[col].title;
+		line_editor->set_accessibility_name(col_title.is_empty() ? c.text : col_title);
+
 		text_editor->hide();
 
 		popup_editor->set_position(popup_rect.position);
@@ -4551,6 +4554,9 @@ bool Tree::edit_selected(bool p_force_edit) {
 		text_editor->set_text(c.text);
 		text_editor->select_all();
 		text_editor->show();
+
+		const String &col_title_ml = columns[col].title;
+		text_editor->set_accessibility_name(col_title_ml.is_empty() ? c.text : col_title_ml);
 
 		popup_editor->set_position(get_screen_position() + rect.position);
 		popup_editor->set_size(rect.size * popup_scale);


### PR DESCRIPTION
## Summary

Fixes #110417.

When editing a `Tree` item inline — e.g. renaming a node in the Scene dock via **F2** — a `LineEdit` (or `TextEdit` for multiline cells) appears inside a `Popup`. This editor had no `accessibility_name` set, so screen readers had nothing to announce when it received focus.

For comparison, the search box in the **Add Node** dialog works correctly because it has a `placeholder_text` which `LineEdit` uses as its accessible name (see `NOTIFICATION_ACCESSIBILITY_UPDATE` in `line_edit.cpp`).

**Fix:** in `Tree::edit_selected()`, set the accessibility name on `line_editor` / `text_editor` before `grab_focus()`:
- Use the column's translated title (`xl_title`) if one is set.
- Fall back to the item's current text (e.g. the node name) so the screen reader announces context like *"Node2D, edit text"*.

Both the single-line (`CELL_MODE_STRING`) and multiline cases are fixed.

## Notes

- The column title fallback to item text is intentional: the Scene dock tree has no column title, so using the node name gives the user clear context about what they are editing.
- Tested that the fix compiles cleanly. Runtime verification with a screen reader (NVDA/Narrator) is needed to confirm the announcement behavior.