### PR TITLE
Add `queue_free_children` and `free_children`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -321,6 +321,13 @@
 				[b]Note:[/b] As this method walks upwards in the scene tree, it can be slow in large, deeply nested nodes. Consider storing a reference to the found node in a variable. Alternatively, use [method get_node] with unique names (see [member unique_name_in_owner]).
 			</description>
 		</method>
+		<method name="free_children">
+			<return type="void" />
+			<description>
+				Immediately deletes all children of this node. Unlike [method queue_free_children], this happens instantly and can only be called from the main thread. The node itself is not deleted. See also [method queue_free_children].
+				[b]Note:[/b] This is equivalent to calling [method Object.free] on each child.
+			</description>
+		</method>
 		<method name="get_accessibility_element" qualifiers="const">
 			<return type="RID" />
 			<description>
@@ -826,13 +833,6 @@
 				Queues this node to be deleted at the end of the current frame. When deleted, all of its children are deleted as well, and all references to the node and its children become invalid.
 				Unlike with [method Object.free], the node is not deleted instantly, and it can still be accessed before deletion. It is also safe to call [method queue_free] multiple times. Use [method Object.is_queued_for_deletion] to check if the node will be deleted at the end of the frame.
 				[b]Note:[/b] The node will only be freed after all other deferred calls are finished. Using this method is not always the same as calling [method Object.free] through [method Object.call_deferred].
-			</description>
-		</method>
-		<method name="free_children">
-			<return type="void" />
-			<description>
-				Immediately deletes all children of this node. Unlike [method queue_free_children], this happens instantly and can only be called from the main thread. The node itself is not deleted. See also [method queue_free_children].
-				[b]Note:[/b] This is equivalent to calling [method Object.free] on each child.
 			</description>
 		</method>
 		<method name="queue_free_children">

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -828,6 +828,20 @@
 				[b]Note:[/b] The node will only be freed after all other deferred calls are finished. Using this method is not always the same as calling [method Object.free] through [method Object.call_deferred].
 			</description>
 		</method>
+		<method name="free_children">
+			<return type="void" />
+			<description>
+				Immediately deletes all children of this node. Unlike [method queue_free_children], this happens instantly and can only be called from the main thread. The node itself is not deleted. See also [method queue_free_children].
+				[b]Note:[/b] This is equivalent to calling [method Object.free] on each child.
+			</description>
+		</method>
+		<method name="queue_free_children">
+			<return type="void" />
+			<description>
+				Queues all children of this node to be deleted at the end of the current frame. The node itself is not deleted. See also [method free_children].
+				[b]Note:[/b] This is equivalent to calling [method queue_free] on each child.
+			</description>
+		</method>
 		<method name="remove_child">
 			<return type="void" />
 			<param index="0" name="node" type="Node" />

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -409,6 +409,38 @@ void Node::_propagate_after_exit_tree() {
 	emit_signal(SceneStringName(tree_exited));
 }
 
+void Node::_propagate_exit_tree_and_cleanup() {
+#ifdef DEBUG_ENABLED
+	if (!data.scene_file_path.is_empty()) {
+		SceneDebugger::remove_from_cache(data.scene_file_path, this);
+	}
+#endif
+	data.blocked++;
+
+	for (HashMap<StringName, Node *>::Iterator I = data.children.last(); I; --I) {
+		I->value->_propagate_exit_tree_and_cleanup();
+	}
+
+	data.blocked--;
+
+	notification(NOTIFICATION_EXIT_TREE, true);
+
+	for (KeyValue<StringName, GroupData> &E : data.grouped) {
+		data.tree->remove_from_group(E.key, this);
+		E.value.group = nullptr;
+	}
+
+	data.viewport = nullptr;
+
+	data.ready_notified = false;
+	data.tree = nullptr;
+	data.depth = -1;
+
+	if (data.owner) {
+		_clean_up_owner();
+	}
+}
+
 void Node::_propagate_exit_tree() {
 	//block while removing children
 
@@ -3448,8 +3480,6 @@ TypedArray<int> Node::get_orphan_node_ids() {
 }
 
 void Node::queue_free() {
-	// There are users which instantiate multiple scene trees for their games.
-	// Use the node's own tree to handle its deletion when relevant.
 	if (data.tree) {
 		data.tree->queue_delete(this);
 	} else {
@@ -3457,6 +3487,83 @@ void Node::queue_free() {
 		ERR_FAIL_NULL_MSG(tree, "Can't queue free a node when no SceneTree is available.");
 		tree->queue_delete(this);
 	}
+}
+
+void Node::free_children() {
+	ERR_FAIL_COND_MSG(data.tree && !Thread::is_main_thread(), "Freeing children from a node inside the SceneTree is only allowed from the main thread.");
+	ERR_THREAD_GUARD
+
+	if (data.children.is_empty()) {
+		return;
+	}
+
+	uint32_t count = data.children.size();
+	LocalVector<Node *> children_copy;
+	children_copy.reserve(count);
+	for (KeyValue<StringName, Node *> &K : data.children) {
+		children_copy.push_back(K.value);
+	}
+
+	data.children.clear();
+	data.children_cache.clear();
+	data.children_cache_dirty = false;
+	data.internal_children_front_count_cache = 0;
+	data.internal_children_back_count_cache = 0;
+	data.external_children_count_cache = 0;
+
+	if (data.tree) {
+		data.blocked++;
+		for (uint32_t i = count; i > 0; i--) {
+			Node *child = children_copy[i - 1];
+			child->_propagate_exit_tree_and_cleanup();
+			child->data.parent = nullptr;
+			memdelete(child);
+		}
+		data.blocked--;
+		data.tree->tree_changed();
+	} else {
+		for (uint32_t i = count; i > 0; i--) {
+			Node *child = children_copy[i - 1];
+			child->data.parent = nullptr;
+			memdelete(child);
+		}
+	}
+
+	notification(NOTIFICATION_CHILD_ORDER_CHANGED);
+	emit_signal(SNAME("child_order_changed"));
+}
+
+void Node::queue_free_children() {
+	ERR_THREAD_GUARD
+
+	if (data.children.is_empty()) {
+		return;
+	}
+
+	SceneTree *tree = data.tree ? data.tree : SceneTree::get_singleton();
+	ERR_FAIL_NULL_MSG(tree, "Can't queue free children when no SceneTree is available.");
+
+	uint32_t count = data.children.size();
+	{
+		MutexLock tree_lock(tree->_thread_safe_);
+		tree->delete_queue.reserve(tree->delete_queue.size() + count);
+		for (KeyValue<StringName, Node *> &K : data.children) {
+			Node *child = K.value;
+			child->data.parent = nullptr;
+			child->_is_queued_for_deletion = true;
+			tree->delete_queue.push_back(child->get_instance_id());
+		}
+	}
+
+	data.children.clear();
+	data.children_cache.clear();
+	data.children_cache_dirty = false;
+	data.internal_children_front_count_cache = 0;
+	data.internal_children_back_count_cache = 0;
+	data.external_children_count_cache = 0;
+
+	notification(NOTIFICATION_CHILD_ORDER_CHANGED);
+	emit_signal(SNAME("child_order_changed"));
 }
 
 #ifdef TOOLS_ENABLED
@@ -3851,6 +3958,9 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_viewport"), &Node::get_viewport);
 
 	ClassDB::bind_method(D_METHOD("queue_free"), &Node::queue_free);
+
+	ClassDB::bind_method(D_METHOD("free_children"), &Node::free_children);
+	ClassDB::bind_method(D_METHOD("queue_free_children"), &Node::queue_free_children);
 
 	ClassDB::bind_method(D_METHOD("request_ready"), &Node::request_ready);
 	ClassDB::bind_method(D_METHOD("is_node_ready"), &Node::is_ready);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -311,6 +311,7 @@ private:
 	void _propagate_ready();
 	void _propagate_exit_tree();
 	void _propagate_after_exit_tree();
+	void _propagate_exit_tree_and_cleanup();
 	void _propagate_physics_interpolated(bool p_interpolated);
 	void _propagate_physics_interpolation_reset_requested(bool p_requested);
 	void _propagate_process_owner(Node *p_owner, int p_pause_notification, int p_enabled_notification);
@@ -777,7 +778,8 @@ public:
 
 	void queue_free();
 
-	//hacks for speed
+	void free_children();
+	void queue_free_children();
 	static void init_node_hrcr();
 
 	bool is_owned_by_parent() const;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1617,14 +1617,22 @@ Vector<Node *> SceneTree::get_nodes_in_group(const StringName &p_group) {
 }
 
 void SceneTree::_flush_delete_queue() {
-	_THREAD_SAFE_METHOD_
+	LocalVector<ObjectID> delete_queue_copy;
+	{
+		_THREAD_SAFE_METHOD_
 
-	while (delete_queue.size()) {
-		Object *obj = ObjectDB::get_instance(delete_queue.front()->get());
+		if (delete_queue.is_empty()) {
+			return;
+		}
+
+		SWAP(delete_queue, delete_queue_copy);
+	}
+
+	for (uint32_t i = 0; i < delete_queue_copy.size(); i++) {
+		Object *obj = ObjectDB::get_instance(delete_queue_copy[i]);
 		if (obj) {
 			memdelete(obj);
 		}
-		delete_queue.pop_front();
 	}
 }
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -185,7 +185,7 @@ private:
 	int nodes_removed_on_group_call_lock = 0;
 	HashSet<Node *> nodes_removed_on_group_call; // Skip erased nodes.
 
-	List<ObjectID> delete_queue;
+	LocalVector<ObjectID> delete_queue;
 
 	uint64_t accessibility_upd_per_sec = 0;
 	bool accessibility_force_update = true;


### PR DESCRIPTION
Closes godotengine/godot-proposals#764.
Related to godotengine/godot#94163.
Co-authored-by: @radiantgurl

### I added:
- Add `free_children()` to Node class
- Add `queue_free_children()` to Node class

### Optimization test
Testing of speed using 1000 children iterating for 500 times.
```
free_children() (in tree)
  Manual loop:     386.574 ms
  Native loop:       148.931 ms
  Speedup:         2.60x

queue_free_children() (in tree)
  Manual loop:     92.189 ms
  Native loop:       32.323 ms
  Speedup:         2.85x

free_children() (not in tree)
  Manual loop:     238.888 ms
  Native loop:       137.957 ms
  Speedup:         1.73x

queue_free_children() (not in tree)
  Manual loop:     92.856 ms
  Native loop:       36.007 ms
  Speedup:         2.58x
```

As you can see, the `free_children()` on the "not in tree" gain is slower, and it is because the standalone path skips most SceneTree overhead already, runtime then leans on per-child memdelete cost, and relative gain ends lower than in-tree path.

### PC build for testing:
Windows 11
AMD Ryzen 5 5600
AMD RX 6750XT 12GB
48GB RAM 3200MHz
SSD M.2 512GB