### PR TITLE
Reload resources in editor_resource_preview when import settings change

### DIFF
--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -352,11 +352,10 @@ void EditorResourcePreview::_iterate() {
 			f.unref();
 			cache_valid = false;
 		} else if (source_modtime > last_modtime) {
-			String last_md5 = f->get_line();
 			String md5 = FileAccess::get_md5(item.path);
 			f.unref();
 
-			if (last_md5 != md5) {
+			if (hash != md5) {
 				cache_valid = false;
 			} else {
 				// Update modified time.

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -360,7 +360,6 @@ void EditorResourcePreview::_iterate() {
 				cache_valid = false;
 			} else {
 				// Update modified time.
-
 				Ref<FileAccess> f2 = FileAccess::open(file, FileAccess::WRITE);
 				if (f2.is_null()) {
 					// Not returning as this would leave the thread hanging and would require

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -323,10 +323,12 @@ void EditorResourcePreview::_iterate() {
 		// No cache found, generate.
 		_generate_preview(texture, small_texture, item, cache_base, preview_metadata);
 	} else {
-		uint64_t modtime = FileAccess::get_modified_time(item.path);
+		uint64_t source_modtime = FileAccess::get_modified_time(item.path);
 		String import_path = item.path + ".import";
-		if (FileAccess::exists(import_path)) {
-			modtime = MAX(modtime, FileAccess::get_modified_time(import_path));
+		bool has_import_file = FileAccess::exists(import_path);
+		uint64_t import_modtime = 0;
+		if (has_import_file) {
+			import_modtime = FileAccess::get_modified_time(import_path);
 		}
 
 		int tsize;
@@ -344,7 +346,12 @@ void EditorResourcePreview::_iterate() {
 		} else if (outdated) {
 			cache_valid = false;
 			f.unref();
-		} else if (last_modtime != modtime) {
+		} else if (has_import_file && import_modtime > last_modtime) {
+			// Import settings changed; reload cached resource.
+			ResourceLoader::load(item.path, "", ResourceFormatLoader::CACHE_MODE_REPLACE);
+			f.unref();
+			cache_valid = false;
+		} else if (source_modtime > last_modtime) {
 			String last_md5 = f->get_line();
 			String md5 = FileAccess::get_md5(item.path);
 			f.unref();
@@ -360,6 +367,7 @@ void EditorResourcePreview::_iterate() {
 					// some proper cleanup/disabling of resource preview generation.
 					ERR_PRINT("Cannot create file '" + file + "'. Check user write permissions.");
 				} else {
+					uint64_t modtime = MAX(source_modtime, import_modtime);
 					_write_preview_cache(f2, thumbnail_size, has_small_texture, modtime, md5, preview_metadata);
 				}
 			}


### PR DESCRIPTION
## Issue
Fixes https://github.com/godotengine/godot/issues/33745

## Motivation
If you change import settings that impact texture ("Invert Color" in my case) the preview is not updated in the file system. You can work around by clicking "reimport" twice. 

https://github.com/user-attachments/assets/f23f479c-545e-4c35-b934-d8621fd7800f

## Solution
EditorResourcePreview maintains an in-memory cache of resources. When the resource file is updated, we check the last modified time and MD5 hash and perform our cache/load operations as needed.

However, if the **import** file changes, those md5 and last modified values of the **resource** file remain the same. The import change does not get picked up in [iterate()](https://github.com/godotengine/godot/blob/master/editor/inspector/editor_resource_preview.cpp#L288) and is not reflected when generating the preview/thumbnail.

To address this, I added a check in [iterate()](https://github.com/godotengine/godot/blob/master/editor/inspector/editor_resource_preview.cpp#L288) to see if the import file last_modtime is more recent than the cached last_modtime. If so, we know the cached data is stale, which we can fix by reloading from disk. 
 
### Note 1: Why does the following code in the conditional block not fix this issue? 
```
f.unref();
cache_valid = false;
```

When `cache_valid == false`, we go into the [_generate_preview()](https://github.com/godotengine/godot/blob/master/editor/inspector/editor_resource_preview.cpp#L176) function. This function also loads the resource with ResourceLoader. However this load uses the CACHE_MODE_REUSE. Meaning we are just loading the stale data and using that to display our preview. 

This is why I added `ResourceLoader::load(item.path, "", ResourceFormatLoader::CACHE_MODE_REPLACE);` in the new conditional block. CACHE_MODE_REPLACE causes the loader to update the cache entry with the data loaded from disk. Now our resource cache is up-to-date, and [_generate_preview()](https://github.com/godotengine/godot/blob/master/editor/inspector/editor_resource_preview.cpp#L176)'s load will use the correct (not stale) data.

### Note 2: Wait! In the existing code, why does last_md5 != md5 evaluate to true if only the import was updated? Since we are comparing the source md5 with the cached md5, and the source is the same, shouldn't the hashes be equal?
Yes. I believe this is actually another currently existing bug. Earlier during [_read_preview_cache()](https://github.com/godotengine/godot/blob/master/editor/inspector/editor_resource_preview.cpp#L345), we already iterated through the entire cache file. Therefore in the following code, we are reading EOF and `last_md5` gets set to `""`. So this conditional ALWAYS resolves to true.
```
String last_md5 = f->get_line();
String md5 = FileAccess::get_md5(item.path);
f.unref();
if (last_md5 != md5) {
    cache_valid = false;
}
```
If this bug were not present, the workaround I mention above (clicking reimport twice) would no longer apply.

I went ahead and fixed this as well since it's related and in the same code path. I am willing to move this change out into a separate PR (after this one lands) though since it does not really cause or resolve the bug at hand. 

## Testing
Manually tested with following project: [MRP.zip](https://github.com/user-attachments/files/25788806/MRP.zip).
See video:

https://github.com/user-attachments/assets/5f43292c-22a9-48f3-bbbd-22c75e02c34b