### PR TITLE
AudioStreamInteractive: Remove transitions for deleted clips

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -68,12 +68,23 @@ void AudioStreamInteractive::set_clip_count(int p_count) {
 			}
 		}
 
-		for (KeyValue<TransitionKey, Transition> &K : transition_map) {
-			if (K.value.filler_clip >= p_count) {
-				K.value.use_filler_clip = false;
-				K.value.filler_clip = 0;
+		HashMap<TransitionKey, Transition, TransitionKeyHasher>::Iterator E = transition_map.begin();
+		while (E) {
+			HashMap<TransitionKey, Transition, TransitionKeyHasher>::Iterator N = E;
+			++N;
+
+			if (E->value.filler_clip >= p_count) {
+				E->value.use_filler_clip = false;
+				E->value.filler_clip = 0;
 			}
+
+			if (E->key.from_clip >= (uint32_t)p_count || E->key.to_clip >= (uint32_t)p_count) {
+				transition_map.remove(E);
+			}
+
+			E = N;
 		}
+
 		if (initial_clip >= p_count) {
 			initial_clip = 0;
 		}


### PR DESCRIPTION
Previously, if a transition was defined for a clip index that was subsequently removed (by reducing clip_count), an error would be logged when loading the AudioStreamInteractive:

    ERROR: Condition "p_to_clip < CLIP_ANY || p_to_clip >= clip_count" is true.
       at: add_transition (modules/interactive_music/audio_stream_interactive.cpp:258)

This was because the transition table was not fully updated when reducing clip_count. Previously any references to the deleted clips as filler clips were removed, but transitions from or to the deleted clips were not.

Remove any transition table entries that are from or to deleted clips.

Resolves https://github.com/godotengine/godot/issues/95742