### PR TITLE
Fix deadlock during shutdown when threaded RenderingServer is still compiling shaders

### DIFF
--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -68,17 +68,6 @@ void WorkerThreadPool::_process_task(Task *p_task) {
 		set_current_thread_safe_for_nodes(false);
 		MessageQueue::set_thread_singleton_override(nullptr);
 
-		// Since the WorkerThreadPool is started before the script server,
-		// its pre-created threads can't have ScriptServer::thread_enter() called on them early.
-		// Therefore, we do it late at the first opportunity, so in case the task
-		// about to be run uses scripting, guarantees are held.
-		// Vice versa, the WorkerThreadPool is destroyed after the script server.
-		// Therefore, we must also protect the thread against calling enter again
-		// after ScriptServer::thread_exit() has been called.
-		if (!curr_thread.exited_languages) {
-			ScriptServer::thread_enter();
-		}
-
 		task_mutex.lock();
 		p_task->pool_thread_index = pool_thread_index;
 		prev_task = curr_thread.current_task;
@@ -87,7 +76,19 @@ void WorkerThreadPool::_process_task(Task *p_task) {
 		if (p_task->pending_notify_yield_over) {
 			curr_thread.yield_is_over = true;
 		}
+		bool enter_script_server = runlevel < RUNLEVEL_EXIT_LANGUAGES;
 		task_mutex.unlock();
+
+		// Since the WorkerThreadPool is started before the script server,
+		// its pre-created threads can't have ScriptServer::thread_enter() called on them early.
+		// Therefore, we do it late at the first opportunity, so in case the task
+		// about to be run uses scripting, guarantees are held.
+		// Vice versa, the WorkerThreadPool is destroyed after the script server.
+		// Therefore, we must not enter the thread again when the language server
+		// is shutting down.
+		if (enter_script_server) {
+			ScriptServer::thread_enter();
+		}
 	}
 #endif
 

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -222,12 +222,20 @@ void WorkerThreadPool::_thread_function(void *p_user) {
 }
 
 void WorkerThreadPool::_post_tasks(Task **p_tasks, uint32_t p_count, bool p_high_priority, MutexLock<BinaryMutex> &p_lock, bool p_pump_task) {
-	// Fall back to processing on the calling thread if there are no worker threads.
+	// Fall back to processing on the calling thread if there are no worker threads,
+	// or if we're shutting down the languages and a worker thread posts a new task.
+	// During language shutdown we block new tasks, however a worker thread posting
+	// a new task would deadlock with the language exit mechanism.
+
+	ThreadData *caller_pool_thread = thread_ids.has(Thread::get_caller_id()) ? &threads[thread_ids[Thread::get_caller_id()]] : nullptr;
+
 	// Separated into its own variable to make it easier to extend this logic
 	// in custom builds.
+	bool no_threads = threads.is_empty();
+	bool worker_thread_during_language_exit = runlevel == RUNLEVEL_EXIT_LANGUAGES && caller_pool_thread;
 
-	// Avoid calling pump tasks or low priority tasks from the calling thread.
-	bool process_on_calling_thread = threads.is_empty() && !p_pump_task;
+	// Avoid calling pump tasks from the calling thread.
+	bool process_on_calling_thread = (no_threads || worker_thread_during_language_exit) && !p_pump_task;
 	if (process_on_calling_thread) {
 		p_lock.temp_unlock();
 		for (uint32_t i = 0; i < p_count; i++) {
@@ -237,14 +245,18 @@ void WorkerThreadPool::_post_tasks(Task **p_tasks, uint32_t p_count, bool p_high
 		return;
 	}
 
+	// If a worker thread during language exit reaches this loop, it will deadlock.
+	// The main thread is waiting in WorkerThreadPool::exit_languages_threads() for
+	// all worker threads to report their language exit at RUNLEVEL_EXIT_LANGUAGES.
+	// The worker thread will indefinitely wait here and is blocked from reporting
+	// its language exit.
+	DEV_ASSERT(!worker_thread_during_language_exit);
 	while (runlevel == RUNLEVEL_EXIT_LANGUAGES) {
 		control_cond_var.wait(p_lock);
 	}
 
 	uint32_t to_process = 0;
 	uint32_t to_promote = 0;
-
-	ThreadData *caller_pool_thread = thread_ids.has(Thread::get_caller_id()) ? &threads[thread_ids[Thread::get_caller_id()]] : nullptr;
 
 	for (uint32_t i = 0; i < p_count; i++) {
 		p_tasks[i]->low_priority = !p_high_priority;

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -72,7 +72,12 @@ void WorkerThreadPool::_process_task(Task *p_task) {
 		// its pre-created threads can't have ScriptServer::thread_enter() called on them early.
 		// Therefore, we do it late at the first opportunity, so in case the task
 		// about to be run uses scripting, guarantees are held.
-		ScriptServer::thread_enter();
+		// Vice versa, the WorkerThreadPool is destroyed after the script server.
+		// Therefore, we must also protect the thread against calling enter again
+		// after ScriptServer::thread_exit() has been called.
+		if (!curr_thread.exited_languages) {
+			ScriptServer::thread_enter();
+		}
 
 		task_mutex.lock();
 		p_task->pool_thread_index = pool_thread_index;


### PR DESCRIPTION
Fix for #117064.

The deadlock is happening because the threaded RenderServer (Worker Thread 0) is trying to post new tasks (shader compilation), while the WorkerThreadPool runlevel is already at `RUNLEVEL_EXIT_LANGUAGES`.

The proposed fix is to change worker threads posting new tasks after language shutdown to run the task directly. External threads are still blocked, only worker threads themselves are unblocked.
As this is happening after `RUNLEVEL_PRE_EXIT_LANGUAGES`, the only active worker threads should be long running pump tasks.