### PR TITLE
Remove previous animation libraries before adding them to dummy player

### DIFF
--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -2464,6 +2464,12 @@ void AnimationPlayerEditorPlugin::_update_dummy_player(AnimationMixer *p_mixer) 
 	memdelete(default_node);
 
 	// Library list is dynamically added to property list, should be copied explicitly.
+	List<StringName> existing_libs;
+	dummy_player->get_animation_library_list(&existing_libs);
+	for (const StringName &K : existing_libs) {
+		dummy_player->remove_animation_library(K);
+	}
+
 	List<StringName> libraries;
 	p_mixer->get_animation_library_list(&libraries);
 	for (const StringName &K : libraries) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
Fixes : #116944 

Issue appeard here : #114482 
The fix added library copying to fix an issue where no library properties would appear in the AnimationTree. However, it does not take into account the case where _update_dummy_player is being called multiple times with the same dummy_player instance

Fix : We clear dummy_player's animation library before adding AnimationMixer's libraries

Why not just change the add_animation_library loop to only add libraries that are not already in dummy_player?
This would break on library rename and does not handle library removal