### PR TITLE
`RingBuffer`: Fix overreading on methods that take an offset as an argument

### DIFF
--- a/core/templates/ring_buffer.h
+++ b/core/templates/ring_buffer.h
@@ -78,7 +78,7 @@ public:
 	int copy(T *p_buf, int p_offset, int p_size) const {
 		int left = data_left();
 		if ((p_offset + p_size) > left) {
-			p_size -= left - p_offset;
+			p_size = left - p_offset;
 			if (p_size <= 0) {
 				return 0;
 			}
@@ -104,7 +104,7 @@ public:
 	int find(const T &t, int p_offset, int p_max_size) const {
 		int left = data_left();
 		if ((p_offset + p_max_size) > left) {
-			p_max_size -= left - p_offset;
+			p_max_size = left - p_offset;
 			if (p_max_size <= 0) {
 				return 0;
 			}


### PR DESCRIPTION
`RingBuffer` methods that take an offset value as an argument (`copy` and `find`)  are susceptible to reading past the write position in cases where `(p_offset + p_size) > data_left()`.

This PR should fix this issue.