### PR TITLE
Use interleaved gradient noise to improve subsurface scattering quality

### DIFF
--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -1746,7 +1746,7 @@ void SSEffects::sss_set_scale(float p_scale, float p_depth_scale) {
 	sss_depth_scale = p_depth_scale;
 }
 
-void SSEffects::sub_surface_scattering(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_diffuse, RID p_depth, const Projection &p_camera, const Size2i &p_screen_size) {
+void SSEffects::sub_surface_scattering(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_diffuse, RID p_depth, const Projection &p_camera, const Size2i &p_screen_size, float taa_frame_count) {
 	UniformSetCacheRD *uniform_set_cache = UniformSetCacheRD::get_singleton();
 	ERR_FAIL_NULL(uniform_set_cache);
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
@@ -1777,6 +1777,7 @@ void SSEffects::sub_surface_scattering(Ref<RenderSceneBuffersRD> p_render_buffer
 		sss.push_constant.vertical = false;
 		sss.push_constant.scale = sss_scale;
 		sss.push_constant.depth_scale = sss_depth_scale;
+		sss.push_constant.taa_frame_count = taa_frame_count;
 
 		RID shader = sss.shader.version_get_shader(sss.shader_version, sss_quality - 1);
 		RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, sss.pipelines[sss_quality - 1].get_rid());

--- a/servers/rendering/renderer_rd/effects/ss_effects.h
+++ b/servers/rendering/renderer_rd/effects/ss_effects.h
@@ -157,7 +157,7 @@ public:
 	RSE::SubSurfaceScatteringQuality sss_get_quality() const;
 	void sss_set_scale(float p_scale, float p_depth_scale);
 
-	void sub_surface_scattering(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_diffuse, RID p_depth, const Projection &p_camera, const Size2i &p_screen_size);
+	void sub_surface_scattering(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_diffuse, RID p_depth, const Projection &p_camera, const Size2i &p_screen_size, float taa_frame_count);
 
 private:
 	/* Settings */
@@ -517,7 +517,8 @@ private:
 		float scale;
 
 		float depth_scale;
-		uint32_t pad[3];
+		float taa_frame_count;
+		uint32_t pad[2];
 	};
 
 	struct SubSurfaceScattering {

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1673,7 +1673,8 @@ void RenderForwardClustered::_process_sss(Ref<RenderSceneBuffersRD> p_render_buf
 	for (uint32_t v = 0; v < p_render_buffers->get_view_count(); v++) {
 		RID internal_texture = p_render_buffers->get_internal_texture(v);
 		RID depth_texture = p_render_buffers->get_depth_texture(v);
-		ss_effects->sub_surface_scattering(p_render_buffers, internal_texture, depth_texture, p_camera, internal_size);
+		taa_frame_count += 1.0f;
+		ss_effects->sub_surface_scattering(p_render_buffers, internal_texture, depth_texture, p_camera, internal_size, taa_frame_count);
 	}
 }
 

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -442,6 +442,8 @@ private:
 
 	static RenderForwardClustered *singleton;
 
+	float taa_frame_count = 0.0f;
+
 	uint32_t _setup_environment(const RenderDataRD *p_render_data, bool p_no_fog, const Size2i &p_screen_size, const Size2 &p_viewport_size, const Color &p_default_bg_color, bool p_opaque_render_buffers = false, bool p_apply_alpha_multiplier = false, bool p_pancake_shadows = false);
 	void _setup_voxelgis(const PagedArray<RID> &p_voxelgis);
 	void _setup_lightmaps(const RenderDataRD *p_render_data, const PagedArray<RID> &p_lightmaps, const Transform3D &p_cam_transform);

--- a/servers/rendering/renderer_rd/shaders/effects/subsurface_scattering.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/subsurface_scattering.glsl
@@ -98,7 +98,8 @@ layout(push_constant, std430) uniform Params {
 	float scale;
 
 	float depth_scale;
-	uint pad[3];
+	float taa_frame_count;
+	uint pad[2];
 }
 params;
 
@@ -106,11 +107,19 @@ layout(set = 0, binding = 0) uniform sampler2D source_image;
 layout(rgba16f, set = 1, binding = 0) uniform restrict writeonly image2D dest_image;
 layout(set = 2, binding = 0) uniform sampler2D source_depth;
 
-void do_filter(inout vec3 color_accum, inout vec3 divisor, vec2 uv, vec2 step, bool p_skin) {
+// Interleaved Gradient Noise
+// https://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare
+float quick_hash(vec2 pos) {
+	const vec3 magic = vec3(0.06711056f, 0.00583715f, 52.9829189f);
+	return fract(magic.z * fract(dot(pos, magic.xy)));
+}
+
+void do_filter(inout vec3 color_accum, inout vec3 divisor, vec2 uv, vec2 step, bool p_skin, float taa_frame_count) {
 	// Accumulate the other samples:
 	for (int i = 1; i < kernel_size; i++) {
 		// Fetch color and depth for current sample:
-		vec2 offset = uv + kernel[i].y * step;
+		float dither = quick_hash(gl_GlobalInvocationID.xy + vec2(taa_frame_count * 5.0, taa_frame_count * 2.0));
+		vec2 offset = uv + kernel[i].y * step + vec2(-0.5 + dither, 0.5 - dither) * 0.005;
 		vec4 color = texture(source_image, offset);
 
 		if (abs(color.a) < 0.001) {
@@ -141,6 +150,7 @@ void main() {
 	vec2 uv = (vec2(ssC) + 0.5) / vec2(params.screen_size);
 
 	// Fetch color of current pixel:
+
 	vec4 base_color = texture(source_image, uv);
 	float strength = abs(base_color.a);
 
@@ -179,8 +189,8 @@ void main() {
 
 		vec3 color = base_color.rgb * divisor;
 
-		do_filter(color, divisor, uv, step, skin);
-		do_filter(color, divisor, uv, -step, skin);
+		do_filter(color, divisor, uv, step, skin, params.taa_frame_count);
+		do_filter(color, divisor, uv, -step, skin, params.taa_frame_count);
 
 		base_color.rgb = color / divisor;
 	}


### PR DESCRIPTION
This makes banding artifacts on materials with SSS enabled much less noticeable. The effect works best when TAA or FSR2 is enabled.

- This closes https://github.com/godotengine/godot/issues/75861.

**Testing project:** [test_sss.zip](https://github.com/user-attachments/files/25800445/test_sss.zip)

## Preview

*Click to view at full size.*

No SSS (for reference)
-|
![Screenshot_20260306_180345](https://github.com/user-attachments/assets/130f6b28-f92b-4382-b178-675b851b4063)

### Before

Low quality | Medium quality | High quality
-|-|-
![Screenshot_20260306_180340](https://github.com/user-attachments/assets/444a285c-0570-4c00-8c79-d23e2924afc9) | ![Screenshot_20260306_180341](https://github.com/user-attachments/assets/b231e195-4e7e-4f56-955f-59349b36de71) | ![Screenshot_20260306_180342](https://github.com/user-attachments/assets/b36942e5-dde0-4f99-bee4-5ba092dcf9d0)

### After

#### No TAA

Low quality | Medium quality | High quality
-|-|-
![Screenshot_20260306_180327](https://github.com/user-attachments/assets/c1a34965-4857-44ce-9d26-be460ec6bbdb) | ![Screenshot_20260306_180328](https://github.com/user-attachments/assets/879e1ec0-052d-4321-87a4-d477720a4409) | ![Screenshot_20260306_180329](https://github.com/user-attachments/assets/f0271d22-9047-4352-a2d8-6a782b59362e)

#### With TAA

Low quality | Medium quality | High quality
-|-|-
![Screenshot_20260306_180332](https://github.com/user-attachments/assets/bfcd792b-ca21-49e5-97b3-f8a63152f987) | ![Screenshot_20260306_180333](https://github.com/user-attachments/assets/21d831df-c818-4b69-8fdd-d6d3d47edc59) | ![Screenshot_20260306_180334](https://github.com/user-attachments/assets/6a30fa5f-99f0-41ca-9271-b5b76ac225a5)

## TODO

- [ ] Improve dithering amount (right now, a magic value of `0.005` is used).
  - Is there a way to determine the "correct" amount of dithering to apply?
- [ ] Jitter the dithering pattern only when TAA or FSR2 is enabled (similar to [shadow map filtering](https://github.com/godotengine/godot/pull/61834)).
  - To do this without code duplication, we need to figure out how to get `taa_frame_count`
    from CameraData in `ss_effects.cpp` in a clean way.
    - @BastiaanOlij Any ideas?
- [ ] Benchmark on various GPUs.