### PR TITLE
Use `print_rich()` to improve shader error formatting

### DIFF
--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -1580,22 +1580,22 @@ Error ShaderCompiler::compile(RSE::ShaderMode p_mode, const String &p_code, Iden
 
 			if (E.key.is_empty()) {
 				if (p_path == "") {
-					print_line("--Main Shader--");
+					print_line_rich("[u]Main shader");
 				} else {
-					print_line("--" + p_path + "--");
+					print_line_rich("[u]" + p_path);
 				}
 			} else {
-				print_line("--" + E.key + "--");
+				print_line_rich("[u]" + E.key);
 			}
 			const Vector<String> &V = E.value;
 			for (int i = 0; i < V.size(); i++) {
 				if (i == err_line - 1) {
 					// Mark the error line to be visible without having to look at
 					// the trace at the end.
-					print_line(vformat("E%4d-> %s", i + 1, V[i]));
+					print_line_rich(vformat("[color=red][b]E[/b]%4d-> %s", i + 1, V[i]));
 				} else if ((i == err_line - 3) || (i == err_line - 2) || (i == err_line) || (i == err_line + 1)) {
 					// Print 4 lines around the error line.
-					print_line(vformat("%5d | %s", i + 1, V[i]));
+					print_line_rich(vformat("[color=gray]%5d | %s", i + 1, V[i]));
 				}
 			}
 		}


### PR DESCRIPTION
- Related to https://github.com/godotengine/godot/pull/95495 (can be merged independently).

This improves visual grepping when shader errors are printed to the Output panel and terminal.

This only affects errors in user-made shaders, not errors in core shaders which are handled differently.

## Preview

### Editor output panel

*Note that the color appears different from other editor errors, as the editor does not convert `print_rich()` colors according to the current editor theme. That said, `color=red` is readable on both dark and light themes already. See https://github.com/godotengine/godot/pull/77114 which implements better colors that match the editor theme.*

Before | After
-|-
<img width="712" height="114" alt="Screenshot_20260306_185015" src="https://github.com/user-attachments/assets/ce1d0236-991c-4363-b6f9-a84f8601bc58" /> | <img width="711" height="115" alt="Screenshot_20260306_184854" src="https://github.com/user-attachments/assets/f2cf0852-5183-4779-9fc5-16708f44e3cb" />

### Terminal (VS Code)

Before | After
-|-
<img width="876" height="226" alt="Screenshot_20260306_184920" src="https://github.com/user-attachments/assets/5606cd2b-a241-4b8e-b6a4-9f27c3ff52e6" /> | <img width="867" height="225" alt="Screenshot_20260306_184910" src="https://github.com/user-attachments/assets/d22e57b1-994e-43cb-80be-53b842dd349a" />