### PR TITLE
Fix `tile_set.h` not including `ArrayMesh`

### DIFF
--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -53,6 +53,7 @@
 #include "scene/resources/shader.h"
 #endif
 
+class ArrayMesh;
 class TileMap;
 class TileSetSource;
 class TileSetAtlasSource;


### PR DESCRIPTION
`tile_set.h` uses `ArrayMesh`, but when `NAVIGATION_2D_DISABLED` is `true`, the declaration of `ArrayMesh` is not introduced into `tile_set.h` through `mesh.h` -> `navigation_mesh.h` -> `navigation_polygon.h` -> `tile_set.h`, the compilation error under the corresponding condition has been fixed.