### PR TITLE
Remove deleted nodes track in _post_fix_animations

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1160,7 +1160,11 @@ Node *ResourceImporterScene::_post_fix_animations(Node *p_node, Node *p_root, co
 					}
 					AnimationImportTracks track_mode = import_tracks_mode[track_channel_type];
 					NodePath path = anim->track_get_path(track_i);
-					Node *n = p_root->get_node(path);
+					Node *n = p_root->get_node_or_null(path);
+					if (!n) {
+						tracks_to_keep.remove_at(tracks_to_keep.size() - 1);
+						continue;
+					}
 					Node3D *n3d = Object::cast_to<Node3D>(n);
 					Skeleton3D *skel = Object::cast_to<Skeleton3D>(n);
 					bool keep_track = false;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
Fixes : #117150 

Issue :
Nodes with "Skip Import" on are being deleted in _post_fix_node. But animation tracks are being created before _post_fix_node, which means we also create tracks for "Skip Import" nodes. So we end up with tracks that points to nodes that no longer exist. Creating an error in _post_fix_animations when we try to use get_node using the track's path, we also ended up with theses useless tracks in tracks_to_keep.

Fix :
We use get_node_or_null instead and delete the tracks that point to deleted nodes

Note :
I felt that deleting theses tracks in _post_fix_animations made the most sense, but deleting them in _post_fix_node right before deleting the node is also an option