### PR TITLE
Fix editor infinite loop and crash in sub-inspector auto-open

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3389,8 +3389,18 @@ void EditorPropertyResource::_resource_selected(const Ref<Resource> &p_resource,
 
 	if (!p_inspect && use_sub_inspector) {
 		bool unfold = !get_edited_object()->editor_is_section_unfolded(get_edited_property());
+		bool open_editor = unfold && _has_external_editor(p_resource);
+		if (open_editor) {
+			// Mark before update_property() so the sub-inspector update path doesn't queue the same open twice.
+			opened_editor = true;
+		}
 		get_edited_object()->editor_set_section_unfold(get_edited_property(), unfold);
 		update_property();
+
+		if (open_editor) {
+			callable_mp(this, &EditorPropertyResource::_open_resource_editor).call_deferred(p_resource);
+		}
+
 	} else if (!is_checkable() || is_checked()) {
 		emit_signal(SNAME("resource_selected"), get_edited_property(), p_resource);
 	}
@@ -3499,10 +3509,31 @@ void EditorPropertyResource::_sub_inspector_object_id_selected(int p_id) {
 	emit_signal(SNAME("object_id_selected"), get_edited_property(), p_id);
 }
 
+bool EditorPropertyResource::_has_external_editor(const Ref<Resource> &p_resource) const {
+	if (p_resource.is_null()) {
+		return false;
+	}
+
+	for (int i = 0; i < EditorNode::get_editor_data().get_editor_plugin_count(); i++) {
+		EditorPlugin *ep = EditorNode::get_editor_data().get_editor_plugin(i);
+		if (ep->handles(p_resource.ptr())) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void EditorPropertyResource::_open_editor_pressed() {
 	Ref<Resource> res = get_edited_property_value();
 	if (res.is_valid()) {
 		EditorNode::get_singleton()->edit_item(res.ptr(), this);
+	}
+}
+
+void EditorPropertyResource::_open_resource_editor(const Ref<Resource> &p_resource) {
+	if (p_resource.is_valid()) {
+		EditorNode::get_singleton()->edit_item(p_resource.ptr(), this);
 	}
 }
 
@@ -3668,25 +3699,15 @@ void EditorPropertyResource::update_property() {
 				set_bottom_editor(sub_inspector);
 
 				resource_picker->set_toggle_pressed(true);
-
-				Array editor_list;
-				for (int i = 0; i < EditorNode::get_editor_data().get_editor_plugin_count(); i++) {
-					EditorPlugin *ep = EditorNode::get_editor_data().get_editor_plugin(i);
-					if (ep->handles(res.ptr())) {
-						editor_list.push_back(ep);
-					}
-				}
-
-				if (!editor_list.is_empty()) {
-					// Open editor directly.
-					_open_editor_pressed();
-					opened_editor = true;
-				}
 			}
 
 			sub_inspector->set_read_only(is_checkable() && !is_checked());
 
 			if (res.ptr() != sub_inspector->get_edited_object()) {
+				if (_has_external_editor(res) && (!opened_editor || sub_inspector->get_edited_object() != nullptr)) {
+					callable_mp(this, &EditorPropertyResource::_open_resource_editor).call_deferred(res);
+					opened_editor = true;
+				}
 				sub_inspector->edit(res.ptr());
 				_update_property_bg();
 			}

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -758,6 +758,8 @@ class EditorPropertyResource : public EditorProperty {
 	void _sub_inspector_resource_selected(const Ref<Resource> &p_resource, const String &p_property);
 	void _sub_inspector_object_id_selected(int p_id);
 
+	bool _has_external_editor(const Ref<Resource> &p_resource) const;
+	void _open_resource_editor(const Ref<Resource> &p_resource);
 	void _open_editor_pressed();
 	void _update_preferred_shader();
 	bool _should_stop_editing() const;


### PR DESCRIPTION
Fixes
Fixes #116523

Description
Unfolding a resource that automatically opens a bottom panel plugin triggered a synchronous inspector rebuild. If a custom EditorPlugin unconditionally returns true for _handles(), this resulted in a Use-After-Free crash or an infinite loop that locked the UI, as the inspector was being destroyed while iterating over its own properties.

This PR fixes the issue by decoupling the bottom panel open logic from the manual fold toggle and tying it directly to the sub-inspector's state lifecycle in update_property(). When the edited object changes or is initialized from a previous state, it checks a new _has_external_editor() helper. If a plugin handles the resource, the _open_resource_editor call is deferred to the end of the frame.

Steps to test

    Download and extract the official MRP provided in issue #116523: editorplugin_issue_mrp.zip (also attached below).

    Open the project in the compiled Godot Editor with this PR applied.

    Verify that the included custom EditorPlugin (which globally intercepts resources) is enabled.

    In the Scene tree, select the MeshInstance3D node.

    In the Inspector dock, locate either the shadow_mesh or material property.

    Click on the resource slot for shadow_mesh or material to unfold it in the inspector.

Expected: The resource sub-inspector unfolds successfully. The Editor UI completes its layout update and remains completely stable.
Regression: The Editor immediately crashes (Use-After-Free) or locks up in an infinite UI rebuild loop.

Attachments
[editorplugin_issue_mrp(1).zip](https://github.com/user-attachments/files/25804672/editorplugin_issue_mrp.1.zip)
