### PR TITLE
Fix keyboard nav in translation preview submenu

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -401,6 +401,7 @@ void PopupMenu::_activate_submenu(int p_over, bool p_by_keyboard) {
 	submenu_popup->set_position(submenu_pos);
 	submenu_popup->activated_by_keyboard = p_by_keyboard;
 	// If not triggered by the mouse, start the popup with its first enabled item focused.
+	submenu_popup->popup();
 	if (p_by_keyboard) {
 		for (int i = 0; i < submenu_popup->get_item_count(); i++) {
 			if (!submenu_popup->is_item_disabled(i)) {
@@ -409,7 +410,6 @@ void PopupMenu::_activate_submenu(int p_over, bool p_by_keyboard) {
 			}
 		}
 	}
-	submenu_popup->popup();
 	// The autohide areas are set on the submenu, but are aligned over the parent menu,
 	// so we spoof `this_rect` position as the negative relative offset of the parent from the submenu.
 	this_rect.position = -(submenu_popup->get_position() - this_pos);


### PR DESCRIPTION
Fixes a minor bug I noticed that no one would bother to report.

<img width="544" height="421" alt="image" src="https://github.com/user-attachments/assets/8d6a3098-fbda-4ffb-b494-dff35005fe5a" />

In these kinds of menus, keyboard navigation means that when you do ui_right, you open the submenu and focus its first element. Focusing the first element shouldn't happen for mouse hover.

<img width="639" height="377" alt="image" src="https://github.com/user-attachments/assets/15d313af-caff-40b2-88f1-c6e254b25637" />

I noticed that this doesn't happen for the translation preview submenu, because it's generated on the about_to_popup signal. So I either had to either:
a)  Change EditorTranslationPreviewMenu to be generated earlier, or
b) Change PopupMenu itself.

I decided to do the latter, as I don't see why the keyboard focus for submenus wouldn't happen only after it's been popped up. This might fix other similar bugs I don't know about and I can't think of any way it would cause regressions.