### PR TITLE
Switch `XRServer` to use `LocalVector` for interfaces and do a little clean up

### DIFF
--- a/servers/xr/xr_server.cpp
+++ b/servers/xr/xr_server.cpp
@@ -279,11 +279,9 @@ void XRServer::set_camera_locked_to_origin(bool p_enable) {
 void XRServer::add_interface(const Ref<XRInterface> &p_interface) {
 	ERR_FAIL_COND(p_interface.is_null());
 
-	for (int i = 0; i < interfaces.size(); i++) {
-		if (interfaces[i] == p_interface) {
-			ERR_PRINT("Interface was already added");
-			return;
-		}
+	if (interfaces.has(p_interface)) {
+		ERR_PRINT("Interface was already added");
+		return;
 	}
 
 	interfaces.push_back(p_interface);
@@ -293,14 +291,7 @@ void XRServer::add_interface(const Ref<XRInterface> &p_interface) {
 void XRServer::remove_interface(const Ref<XRInterface> &p_interface) {
 	ERR_FAIL_COND(p_interface.is_null());
 
-	int idx = -1;
-	for (int i = 0; i < interfaces.size(); i++) {
-		if (interfaces[i] == p_interface) {
-			idx = i;
-			break;
-		}
-	}
-
+	int idx = interfaces.find(p_interface);
 	ERR_FAIL_COND_MSG(idx == -1, "Interface not found.");
 	print_verbose("XR: Removed interface \"" + p_interface->get_name() + "\"");
 	emit_signal(SNAME("interface_removed"), p_interface->get_name());
@@ -312,15 +303,15 @@ int XRServer::get_interface_count() const {
 }
 
 Ref<XRInterface> XRServer::get_interface(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, interfaces.size(), nullptr);
+	ERR_FAIL_INDEX_V(p_index, (int)interfaces.size(), nullptr);
 
 	return interfaces[p_index];
 }
 
 Ref<XRInterface> XRServer::find_interface(const String &p_name) const {
-	for (int i = 0; i < interfaces.size(); i++) {
-		if (interfaces[i]->get_name() == p_name) {
-			return interfaces[i];
+	for (const Ref<XRInterface> &interface : interfaces) {
+		if (interface->get_name() == p_name) {
+			return interface;
 		}
 	}
 	return Ref<XRInterface>();
@@ -329,7 +320,7 @@ Ref<XRInterface> XRServer::find_interface(const String &p_name) const {
 TypedArray<Dictionary> XRServer::get_interfaces() const {
 	Array ret;
 
-	for (int i = 0; i < interfaces.size(); i++) {
+	for (uint32_t i = 0; i < interfaces.size(); i++) {
 		Dictionary iface_info;
 
 		iface_info["id"] = i;
@@ -410,12 +401,11 @@ Ref<XRTracker> XRServer::get_tracker(const StringName &p_name) const {
 PackedStringArray XRServer::get_suggested_tracker_names() const {
 	PackedStringArray arr;
 
-	for (int i = 0; i < interfaces.size(); i++) {
-		Ref<XRInterface> interface = interfaces[i];
+	for (const Ref<XRInterface> &interface : interfaces) {
 		PackedStringArray interface_arr = interface->get_suggested_tracker_names();
-		for (int a = 0; a < interface_arr.size(); a++) {
-			if (!arr.has(interface_arr[a])) {
-				arr.push_back(interface_arr[a]);
+		for (int i = 0; i < interface_arr.size(); i++) {
+			if (!arr.has(interface_arr[i])) {
+				arr.push_back(interface_arr[i]);
 			}
 		}
 	}
@@ -433,8 +423,7 @@ PackedStringArray XRServer::get_suggested_tracker_names() const {
 PackedStringArray XRServer::get_suggested_pose_names(const StringName &p_tracker_name) const {
 	PackedStringArray arr;
 
-	for (int i = 0; i < interfaces.size(); i++) {
-		Ref<XRInterface> interface = interfaces[i];
+	for (const Ref<XRInterface> &interface : interfaces) {
 		PackedStringArray interface_arr = interface->get_suggested_pose_names(p_tracker_name);
 		for (int a = 0; a < interface_arr.size(); a++) {
 			if (!arr.has(interface_arr[a])) {
@@ -462,11 +451,11 @@ void XRServer::_process() {
 	// note that we can have multiple interfaces active if we have interfaces that purely handle tracking
 
 	// process all active interfaces
-	for (int i = 0; i < interfaces.size(); i++) {
-		if (interfaces[i].is_null()) {
+	for (const Ref<XRInterface> &interface : interfaces) {
+		if (interface.is_null()) {
 			// ignore, not a valid reference
-		} else if (interfaces[i]->is_initialized()) {
-			interfaces.write[i]->process();
+		} else if (interface->is_initialized()) {
+			interface->process();
 		}
 	}
 }
@@ -476,11 +465,11 @@ void XRServer::pre_render() {
 	// note that we can have multiple interfaces active if we have interfaces that purely handle tracking
 
 	// process all active interfaces
-	for (int i = 0; i < interfaces.size(); i++) {
-		if (interfaces[i].is_null()) {
+	for (const Ref<XRInterface> &interface : interfaces) {
+		if (interface.is_null()) {
 			// ignore, not a valid reference
-		} else if (interfaces[i]->is_initialized()) {
-			interfaces.write[i]->pre_render();
+		} else if (interface->is_initialized()) {
+			interface->pre_render();
 		}
 	}
 }
@@ -489,11 +478,11 @@ void XRServer::end_frame() {
 	// called from RenderingServerDefault after Vulkan queues have been submitted
 
 	// process all active interfaces
-	for (int i = 0; i < interfaces.size(); i++) {
-		if (interfaces[i].is_null()) {
+	for (const Ref<XRInterface> &interface : interfaces) {
+		if (interface.is_null()) {
 			// ignore, not a valid reference
-		} else if (interfaces[i]->is_initialized()) {
-			interfaces.write[i]->end_frame();
+		} else if (interface->is_initialized()) {
+			interface->end_frame();
 		}
 	}
 }

--- a/servers/xr/xr_server.h
+++ b/servers/xr/xr_server.h
@@ -85,7 +85,7 @@ public:
 private:
 	static XRMode xr_mode;
 
-	Vector<Ref<XRInterface>> interfaces;
+	LocalVector<Ref<XRInterface>> interfaces;
 	Dictionary trackers;
 
 	Ref<XRInterface> primary_interface; /* we'll identify one interface as primary, this will be used by our viewports */


### PR DESCRIPTION
At the last XR team meeting, we were looking at the code in `XRServer::_process()` and noticed that it was using `Vector` and the potentially expensive `.write[i]`, which is totally unnecessary in this case.

So, this PR replaces the `Vector` with `LocalVector`, and also does a little bit of clean-up (replacing some custom code with `.has()` and `.find()`, as well as switching from indexed loops to range-based loops where it makes sense).