### PR TITLE
Fix `AnimationPlayer` not updating animation length when animation resource changes

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -799,6 +799,13 @@ bool AnimationPlayer::is_movie_quit_on_finish_enabled() const {
 	return movie_quit_on_finish;
 }
 
+void AnimationPlayer::_animation_changed(const StringName &p_name) {
+	AnimationMixer::_animation_changed(p_name);
+	if (playback.current.is_enabled && playback.current.animation_name == p_name && animation_set.has(p_name)) {
+		playback.current.animation_length = animation_set[p_name].animation->get_length();
+	}
+}
+
 void AnimationPlayer::_stop_internal(bool p_reset, bool p_keep_state) {
 	_clear_caches();
 	Playback &c = playback;

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -153,6 +153,7 @@ protected:
 	virtual void _blend_capture(double p_delta) override;
 	virtual void _blend_post_process() override;
 
+	virtual void _animation_changed(const StringName &p_name) override;
 	virtual void _animation_removed(const StringName &p_name, const StringName &p_library) override;
 	virtual void _rename_animation(const StringName &p_from_name, const StringName &p_to_name) override;
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Addresses: https://github.com/godotengine/godot/pull/109945#issuecomment-4009300336 w/ confirmation from @passivestar that the issue was fixed.

When an animation's length is changed after being selected, the AnimationPlayer still uses the old length to clamp seek positions. This prevents scrubbing past the original length until the animation is played through once. Fixes this by updating the cached length whenever the animation is modified.

Video of issue:


https://github.com/user-attachments/assets/53691b3f-3e42-4d40-b209-65bae20090d5

