### PR TITLE
Move `_pre_popup` before `set_size`

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2164,11 +2164,12 @@ void Window::popup(const Rect2i &p_screen_rect) {
 	ERR_MAIN_THREAD_GUARD;
 	emit_signal(SNAME("about_to_popup"));
 
+	_pre_popup();
+
 	Rect2i screen_rect = p_screen_rect;
 	if (screen_rect != Rect2i()) {
 		set_size(screen_rect.size);
 	}
-	_pre_popup();
 	if (screen_rect != Rect2i()) {
 		screen_rect.size = get_size();
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
Fixes : #116835 

Issue :
`popup_menu::_pre_popup` does compute the content scale factor correctly, but it was called after `set_size` in `Window::popup`. When opening the popup for the first time after changing the zoom, `set_size` would set the old size instead of the correct new one

Fix :
Move `_pre_popup` call before `set_size` in `Window::popup`