### PR TITLE
Editor: Fix Bone2D creation to form proper bone chains from selected Node2D hierarchies

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -5143,13 +5143,33 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				return;
 			}
 
-			undo_redo->create_action(TTR("Create Custom Bone2D(s) from Node(s)"));
+			// Collect selected Node2Ds and sort by depth so parent is always before child.
+			struct Node2DDepthComparator {
+				_FORCE_INLINE_ bool operator()(const Node2D *a, const Node2D *b) const {
+					int depth_a = 0;
+					for (const Node *p = a; p; p = p->get_parent()) {
+						depth_a++;
+					}
+					int depth_b = 0;
+					for (const Node *p = b; p; p = p->get_parent()) {
+						depth_b++;
+					}
+					return depth_a < depth_b;
+				}
+			};
+			Vector<Node2D *> nodes;
 			for (const KeyValue<ObjectID, Object *> &E : selection) {
 				Node2D *n2d = ObjectDB::get_instance<Node2D>(E.key);
-				if (!n2d) {
-					continue;
+				if (n2d) {
+					nodes.push_back(n2d);
 				}
+			}
+			nodes.sort_custom<Node2DDepthComparator>();
 
+			HashMap<Node *, Bone2D *> node_to_bone;
+
+			undo_redo->create_action(TTR("Create Custom Bone2D(s) from Node(s)"));
+			for (Node2D *n2d : nodes) {
 				Bone2D *new_bone = memnew(Bone2D);
 				String new_bone_name = n2d->get_name();
 				new_bone_name += "Bone2D";
@@ -5158,10 +5178,17 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 				Node *n2d_parent = n2d->get_parent();
 				if (!n2d_parent) {
+					memdelete(new_bone);
 					continue;
 				}
 
-				undo_redo->add_do_method(n2d_parent, "add_child", new_bone);
+				// Parent the new bone under the bone we created for this node's parent (if any), so bones form a chain.
+				Node *parent_for_bone = n2d_parent;
+				if (node_to_bone.has(n2d_parent)) {
+					parent_for_bone = node_to_bone[n2d_parent];
+				}
+
+				undo_redo->add_do_method(parent_for_bone, "add_child", new_bone);
 				undo_redo->add_do_method(n2d_parent, "remove_child", n2d);
 				undo_redo->add_do_method(new_bone, "add_child", n2d);
 				undo_redo->add_do_method(n2d, "set_transform", Transform2D());
@@ -5170,9 +5197,11 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 				undo_redo->add_undo_method(new_bone, "remove_child", n2d);
 				undo_redo->add_undo_method(n2d_parent, "add_child", n2d);
-				undo_redo->add_undo_method(n2d_parent, "remove_child", new_bone);
+				undo_redo->add_undo_method(parent_for_bone, "remove_child", new_bone);
 				undo_redo->add_undo_method(n2d, "set_transform", new_bone->get_transform());
 				undo_redo->add_undo_method(this, "_set_owner_for_node_and_children", n2d, editor_root);
+
+				node_to_bone[n2d] = new_bone;
 			}
 			undo_redo->commit_action();
 

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -5143,20 +5143,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				return;
 			}
 
-			// Collect selected Node2Ds and sort by depth so parent is always before child.
-			struct Node2DDepthComparator {
-				_FORCE_INLINE_ bool operator()(const Node2D *a, const Node2D *b) const {
-					int depth_a = 0;
-					for (const Node *p = a; p; p = p->get_parent()) {
-						depth_a++;
-					}
-					int depth_b = 0;
-					for (const Node *p = b; p; p = p->get_parent()) {
-						depth_b++;
-					}
-					return depth_a < depth_b;
-				}
-			};
+			// Collect selected Node2Ds.
 			Vector<Node2D *> nodes;
 			for (const KeyValue<ObjectID, Object *> &E : selection) {
 				Node2D *n2d = ObjectDB::get_instance<Node2D>(E.key);
@@ -5164,17 +5151,42 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					nodes.push_back(n2d);
 				}
 			}
-			nodes.sort_custom<Node2DDepthComparator>();
+
+			if (nodes.is_empty()) {
+				return;
+			}
+
+			// Precompute depths once, then sort shallowest-first so a parent bone is always created before its child's bone.
+			HashMap<const Node2D *, int> depth_cache;
+			for (Node2D *n2d : nodes) {
+				int d = 0;
+				for (const Node *p = n2d; p; p = p->get_parent()) {
+					d++;
+				}
+				depth_cache[n2d] = d;
+			}
+			struct Node2DDepthComparator {
+				const HashMap<const Node2D *, int> *cache;
+				_FORCE_INLINE_ bool operator()(const Node2D *a, const Node2D *b) const {
+					return cache->get(a) < cache->get(b);
+				}
+			};
+			Node2DDepthComparator depth_cmp;
+			depth_cmp.cache = &depth_cache;
+			nodes.sort_custom<Node2DDepthComparator>(depth_cmp);
 
 			HashMap<Node *, Bone2D *> node_to_bone;
 
 			undo_redo->create_action(TTR("Create Custom Bone2D(s) from Node(s)"));
 			for (Node2D *n2d : nodes) {
+				// Capture the original transform explicitly before creating the bone.
+				Transform2D original_transform = n2d->get_transform();
+
 				Bone2D *new_bone = memnew(Bone2D);
 				String new_bone_name = n2d->get_name();
 				new_bone_name += "Bone2D";
 				new_bone->set_name(new_bone_name);
-				new_bone->set_transform(n2d->get_transform());
+				new_bone->set_transform(original_transform);
 
 				Node *n2d_parent = n2d->get_parent();
 				if (!n2d_parent) {
@@ -5198,10 +5210,16 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				undo_redo->add_undo_method(new_bone, "remove_child", n2d);
 				undo_redo->add_undo_method(n2d_parent, "add_child", n2d);
 				undo_redo->add_undo_method(parent_for_bone, "remove_child", new_bone);
-				undo_redo->add_undo_method(n2d, "set_transform", new_bone->get_transform());
-				undo_redo->add_undo_method(this, "_set_owner_for_node_and_children", n2d, editor_root);
+				undo_redo->add_undo_method(n2d, "set_transform", original_transform);
 
 				node_to_bone[n2d] = new_bone;
+			}
+			// Defer all ownership restoration to after all structural undo ops complete, so no node's
+			// children are still attached to intermediate bones when _set_owner_for_node_and_children recurses.
+			for (Node2D *n2d : nodes) {
+				if (node_to_bone.has(n2d)) {
+					undo_redo->add_undo_method(this, "_set_owner_for_node_and_children", n2d, editor_root);
+				}
 			}
 			undo_redo->commit_action();
 

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -5179,14 +5179,14 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			undo_redo->create_action(TTR("Create Custom Bone2D(s) from Node(s)"));
 			for (Node2D *n2d : nodes) {
-				// Capture the original transform explicitly before creating the bone.
-				Transform2D original_transform = n2d->get_transform();
+				// Capture the node's transform explicitly before creating the bone.
+				Transform2D n2d_transform = n2d->get_transform();
 
 				Bone2D *new_bone = memnew(Bone2D);
 				String new_bone_name = n2d->get_name();
 				new_bone_name += "Bone2D";
 				new_bone->set_name(new_bone_name);
-				new_bone->set_transform(original_transform);
+				new_bone->set_transform(n2d_transform);
 
 				Node *n2d_parent = n2d->get_parent();
 				if (!n2d_parent) {
@@ -5210,7 +5210,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				undo_redo->add_undo_method(new_bone, "remove_child", n2d);
 				undo_redo->add_undo_method(n2d_parent, "add_child", n2d);
 				undo_redo->add_undo_method(parent_for_bone, "remove_child", new_bone);
-				undo_redo->add_undo_method(n2d, "set_transform", original_transform);
+				undo_redo->add_undo_method(n2d, "set_transform", n2d_transform);
 
 				node_to_bone[n2d] = new_bone;
 			}


### PR DESCRIPTION
When using "Make Custom Bone2D(s) from Node(s)" with a selection that includes
both a parent and its child Node2D, the resulting Bone2D nodes were previously
inserted at the same level in the scene tree — the parent/child relationship
between the original nodes was not reflected in the bone hierarchy at all.

This commit fixes that by:

- Sorting selected nodes by depth (shallowest first) before processing, so a
  parent's bone is always created before its child's bone.
- Tracking a node→bone mapping so that each new Bone2D is reparented under the
  Bone2D created for its Node2D's parent (when that parent was also selected),
  producing a proper bone chain rather than a flat list.

Several correctness issues in the undo/redo logic are also fixed:

- A `memdelete` was added for the allocated Bone2D when the node has no parent,
  fixing a pre-existing memory leak.
- An early return is added when the selection contains no Node2D instances (e.g.
  only Control nodes), preventing an empty no-op undo action from being pushed
  onto the stack.
- All `_set_owner_for_node_and_children` undo calls are deferred to after the
  structural undo operations (remove/add child) for all nodes have been
  registered. This prevents the recursive ownership walk from descending into
  intermediate Bone2D nodes that are still attached to the tree mid-undo in
  scenes with non-selected nodes between two selected ancestors.
- The original transform is now captured into a local variable before the Bone2D
  is constructed, making the intent of the undo transform restore explicit rather
  than relying on `new_bone->get_transform()` being equal to the captured value.
- Depths are precomputed into a HashMap before sorting, reducing the sort from
  O(n·d·log n) to O(n·d + n·log n) by avoiding repeated ancestor traversals per
  comparison.
