### PR TITLE
Android: Add haptic feedback on long-press right-click in the editor

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1266,6 +1266,10 @@
 			If [code]true[/code], increases the scrollbar touch area, enables a larger dragger for split containers, and increases PopupMenu vertical separation to improve usability on touchscreen devices.
 			[b]Note:[/b] Defaults to [code]true[/code] on touchscreen devices.
 		</member>
+		<member name="interface/touchscreen/haptic_on_long_press" type="bool" setter="" getter="">
+			If [code]true[/code], the device will vibrate when a long-press gesture triggers a right-click context menu in the editor.
+			[b]Note:[/b] Only has an effect on devices with haptic feedback hardware. Defaults to [code]true[/code] on touchscreen devices.
+		</member>
 		<member name="interface/touchscreen/scale_gizmo_handles" type="float" setter="" getter="">
 			Specify the multiplier to apply to the scale for the editor gizmo handles to improve usability on touchscreen devices.
 			[b]Note:[/b] Defaults to [code]1[/code] on non-touchscreen devices.

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -627,6 +627,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/touchscreen/enable_touch_optimizations", is_native_touchscreen, "")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/touchscreen/enable_long_press_as_right_click", is_native_touchscreen, "")
 	set_restart_if_changed("interface/touchscreen/enable_long_press_as_right_click", true);
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/touchscreen/haptic_on_long_press", is_native_touchscreen, "")
 
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/touchscreen/enable_pan_and_scale_gestures", has_touchscreen_ui, "")
 	set_restart_if_changed("interface/touchscreen/enable_pan_and_scale_gestures", true);

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -450,6 +450,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 		val longPressEnabled = enableLongPressGestures()
 		val panScaleEnabled = enablePanAndScaleGestures()
 		val overrideVolumeButtonsEnabled = overrideVolumeButtons()
+		val hapticEnabled = enableHapticOnLongPress()
 
 		runOnUiThread {
 			// Enable long press, panning and scaling gestures
@@ -457,6 +458,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 				enableLongPress(longPressEnabled)
 				enablePanningAndScalingGestures(panScaleEnabled)
 				setOverrideVolumeButtons(overrideVolumeButtonsEnabled)
+				enableHapticFeedback(hapticEnabled)
 			}
 		}
 	}
@@ -720,6 +722,12 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 	 */
 	protected open fun enableLongPressGestures() =
 		java.lang.Boolean.parseBoolean(GodotLib.getEditorSetting("interface/touchscreen/enable_long_press_as_right_click"))
+
+	/**
+	 * Enable haptic feedback on long-press right-click for the Godot Android editor.
+	 */
+	protected open fun enableHapticOnLongPress() =
+		java.lang.Boolean.parseBoolean(GodotLib.getEditorSetting("interface/touchscreen/haptic_on_long_press"))
 
 	/**
 	 * Disable scroll deadzone for the Godot Android editor.

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotGestureHandler.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotGestureHandler.kt
@@ -57,6 +57,11 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 
 	var scrollDeadzoneDisabled = false
 
+	/**
+	 * Enable haptic feedback on long-press right-click
+	 */
+	var hapticFeedbackEnabled = false
+
 	private var nextDownIsDoubleTap = false
 	private var dragInProgress = false
 	private var scaleInProgress = false
@@ -80,6 +85,9 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 	override fun onLongPress(event: MotionEvent) {
 		val toolType = GodotInputHandler.getEventToolType(event)
 		if (toolType != MotionEvent.TOOL_TYPE_MOUSE) {
+			if (hapticFeedbackEnabled) {
+				inputHandler.performHapticFeedback()
+			}
 			contextClickRouter(event)
 		}
 	}

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
@@ -47,6 +47,7 @@ import android.util.Log;
 import android.util.SparseArray;
 import android.util.SparseIntArray;
 import android.view.GestureDetector;
+import android.view.HapticFeedbackConstants;
 import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -131,6 +132,23 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 	 */
 	public void disableScrollDeadzone(boolean disable) {
 		this.godotGestureHandler.setScrollDeadzoneDisabled(disable);
+	}
+
+	/**
+	 * Enable haptic feedback (vibration) when a long-press right-click is triggered.
+	 */
+	public void enableHapticFeedback(boolean enable) {
+		this.godotGestureHandler.setHapticFeedbackEnabled(enable);
+	}
+
+	/**
+	 * Perform haptic feedback on the render view.
+	 */
+	void performHapticFeedback() {
+		GodotRenderView view = godot.getRenderView();
+		if (view != null) {
+			view.getView().performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/12003
Trigger haptic feedback when a long-press gesture fires a right-click (context menu) in the Android editor. Uses Android's native HapticFeedbackConstants.LONG_PRESS on the render view surface.

An editor setting `interface/touchscreen/haptic_on_long_press` is added under the existing touchscreen section to allow users to disable this behavior. The setting defaults to enabled on native touchscreen devices.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
