### PR TITLE
Profiler: Fix for tree view becoming empty when you unpause the game

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -56,6 +56,24 @@ EditorProfiler::Metric EditorProfiler::_get_frame_metric(int index) {
 }
 
 void EditorProfiler::add_frame_metric(const Metric &p_metric, bool p_final) {
+	if (total_metrics > 0) {
+		int last_frame_num = frame_metrics[last_metric].frame_number;
+		if (p_metric.frame_number == last_frame_num + 2) {
+			++last_metric;
+			if (last_metric >= frame_metrics.size()) {
+				last_metric = 0;
+			}
+			total_metrics++;
+			if (total_metrics > frame_metrics.size()) {
+				total_metrics = frame_metrics.size();
+			}
+			Metric empty_metric;
+			empty_metric.frame_number = last_frame_num + 1;
+			frame_metrics.write[last_metric] = empty_metric;
+			_make_metric_ptrs(frame_metrics.write[last_metric]);
+		}
+	}
+
 	++last_metric;
 	if (last_metric >= frame_metrics.size()) {
 		last_metric = 0;


### PR DESCRIPTION
This is a fix for the profiler tree becoming empty when you un-pause the game. This fixes part of #76146 

The issue was that when you pause and then un-pause the game, a single profiler data frame is not sent to the profiler. All the code in the editor_profiler.cpp relies on continuous sequential frames to do the math required to display the graph and tree. Rather than a high impact fix where I changed a ton of the code to compensate for this missing frame, I instead insert one empty frame to fill the gap in the internal data structure that holds the frames.

The math to display the tree view was incorrect when it encountered a gap of 1 frame in the profiler data. Because of that the tree view would cease to display anything.

Also when you first start the profiler the tree view is updated continuously as new data comes in. Once you pause and un-pause, that state where the tree is continuously updated is impossible to return to it.
This PR also fixes that, so when you un-pause the tree returns to it's continuously updated state.

An addition of 1 small block of contiguous code in 1 file.

With this fix the tree view always displays data as you pause and un-pause the game.

*******************************
Disclosure and License
-As a software engineer I use many systems to ensure code quality, and that includes AI. I use the AI to: do detailed code analysis, be a sounding board for my different ideas, look for bugs, find unexpected behaviors, identify performance hot spots, expensive CPU calls, race conditions, poorly placed variable initializations, possible optimizations, and many more things. I do this during development and before I push code to the repo. It lists items that are potential problems and I decide what I think is important and make those changes.
-For a descriptive example of my AI usage on a particular PR please read this https://github.com/godotengine/godot/pull/117066#issuecomment-4061773098
-Any and all code attached to this PR falls under the coverage of the MIT License.