### PR TITLE
Fix RichTextLabel drag selection not working after double-click

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2988,6 +2988,8 @@ void RichTextLabel::gui_input(const Ref<InputEvent> &p_event) {
 					selection.selection_mode = Selection::DOUBLE_CLICK;
 					last_double_click = OS::get_singleton()->get_ticks_msec();
 					last_double_click_pos = b->get_position();
+					is_selecting_text = true;
+					click_select_held->start();
 				}
 			} else if (!b->is_pressed()) {
 				if (selection.enabled && DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_CLIPBOARD_PRIMARY)) {


### PR DESCRIPTION
Fixes #116860
Start the selection timer after a double-click so that dragging to extend a word selection works correctly.

Regression introduced in #104715 which moved selection updates into a timer callback (click_select_held) but did not start the timer in the double-click handler, only in the single-click handler.
