### PR TITLE
Fix HSplitContainer and VSplitContainer docs on multiple children

### DIFF
--- a/doc/classes/HSplitContainer.xml
+++ b/doc/classes/HSplitContainer.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="HSplitContainer" inherits="SplitContainer" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A container that splits two child controls horizontally and provides a grabber for adjusting the split ratio.
+		A container that arranges child controls horizontally and provides grabbers for adjusting the split ratios between them.
 	</brief_description>
 	<description>
-		A container that accepts only two child controls, then arranges them horizontally and creates a divisor between them. The divisor can be dragged around to change the size relation between the child controls.
+		A container that arranges child controls horizontally and creates grabbers between them. The grabbers can be dragged around to change the size relations between the child controls.
 	</description>
 	<tutorials>
 		<link title="Using Containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>

--- a/doc/classes/VSplitContainer.xml
+++ b/doc/classes/VSplitContainer.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VSplitContainer" inherits="SplitContainer" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A container that splits two child controls vertically and provides a grabber for adjusting the split ratio.
+		A container that arranges child controls vertically and provides grabbers for adjusting the split ratios between them.
 	</brief_description>
 	<description>
-		A container that accepts only two child controls, then arranges them vertically and creates a divisor between them. The divisor can be dragged around to change the size relation between the child controls.
+		A container that arranges child controls vertically and creates grabbers between them. The grabbers can be dragged around to change the size relations between the child controls.
 	</description>
 	<tutorials>
 		<link title="Using Containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>


### PR DESCRIPTION
Who knew HSplitContainer and VSplitContainer had their own docs?

I copied the descriptions from SplitContainer, since it looks like that is what it was originally doing.

- from https://github.com/godotengine/godot/pull/90411