### PR TITLE
Expose `Basis.is_orthonormal()`

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2549,6 +2549,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Basis, is_conformal, sarray(), varray());
 	bind_method(Basis, is_equal_approx, sarray("b"), varray());
 	bind_method(Basis, is_finite, sarray(), varray());
+	bind_method(Basis, is_orthonormal, sarray(), varray());
 	bind_method(Basis, get_rotation_quaternion, sarray(), varray());
 	bind_static_method(Basis, looking_at, sarray("target", "up", "use_model_front"), varray(Vector3::UP, false));
 	bind_static_method(Basis, from_scale, sarray("scale"), varray());

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -207,6 +207,12 @@
 				Returns [code]true[/code] if this basis is finite, by calling [method @GlobalScope.is_finite] on all vector components.
 			</description>
 		</method>
+		<method name="is_orthonormal" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this basis is orthonormal. An orthonormal basis is both [i]orthogonal[/i] (the axes are perpendicular to each other) and [i]normalized[/i] (the length of every axis is [code]1.0[/code]). This method can be especially useful during physics calculations.
+			</description>
+		</method>
 		<method name="looking_at" qualifiers="static">
 			<return type="Basis" />
 			<param index="0" name="target" type="Vector3" />


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/12608

Changes:
- Exposes `Basis.is_orthonormal()`.
  - Adds method descriptions.
