### PR TITLE
Open the Shader Editor when creating a new Shader in the Inspector

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -2687,6 +2687,8 @@ void SceneTreeDock::_shader_created(Ref<Shader> p_shader) {
 	undo_redo->add_do_method(selected_shader_material.ptr(), "set_shader", p_shader);
 	undo_redo->add_undo_method(selected_shader_material.ptr(), "set_shader", existing);
 	undo_redo->commit_action();
+
+	EditorNode::get_singleton()->edit_item(p_shader.ptr(), this);
 }
 
 void SceneTreeDock::_script_creation_closed() {


### PR DESCRIPTION
This change opens the Shader Editor upon creating a new Shader in the Inspector.

[Screen recording showing a new Shader created in the inspector. The Shader Editor subequently appears.](https://github.com/user-attachments/assets/4a459666-f847-477e-ba06-d8c14cf59b39)

When the user creates a new Shader Resource from the FileSystem Dock, the Shader Editor window will automatically open. As of writing, this doesn't happen when we create a new Shader on a ShaderMaterial in the Inspector. This change helps make the editor more predictable, always opening the Shader Editor when a new Shader is created.

This change should also address https://github.com/godotengine/godot-proposals/issues/14389. 

### Notes
Since this is my [first contribution](https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors), I just wanted to note:
1. `pre-commit` hooks were run locally before committing
2. [No AI was used](https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#doc-ai-assisted-contributions) to research, write, or test the contents of this PR

- *Bugsquad edit:* fixes godotengine/godot-proposals#14389