### PR TITLE
Fix FoldableContainers emit folding_changed correctly when FoldableGroup is attached

### DIFF
--- a/scene/gui/foldable_container.cpp
+++ b/scene/gui/foldable_container.cpp
@@ -56,12 +56,10 @@ Size2 FoldableContainer::get_minimum_size() const {
 
 void FoldableContainer::fold() {
 	set_folded(true);
-	emit_signal(SNAME("folding_changed"), folded);
 }
 
 void FoldableContainer::expand() {
 	set_folded(false);
-	emit_signal(SNAME("folding_changed"), folded);
 }
 
 void FoldableContainer::set_folded(bool p_folded) {
@@ -79,6 +77,8 @@ void FoldableContainer::set_folded(bool p_folded) {
 		update_minimum_size();
 		queue_sort();
 		queue_redraw();
+		
+		emit_signal(SNAME("folding_changed"), folded);
 	}
 }
 
@@ -234,7 +234,6 @@ void FoldableContainer::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (p_event->is_action_pressed(SNAME("ui_accept"), false, true)) {
 		set_folded(!folded);
-		emit_signal(SNAME("folding_changed"), folded);
 		accept_event();
 		return;
 	}
@@ -243,7 +242,6 @@ void FoldableContainer::gui_input(const Ref<InputEvent> &p_event) {
 	if (b.is_valid()) {
 		if (b->get_button_index() == MouseButton::LEFT && b->is_pressed() && _get_title_rect().has_point(b->get_position())) {
 			set_folded(!folded);
-			emit_signal(SNAME("folding_changed"), folded);
 			accept_event();
 		}
 	}

--- a/scene/gui/foldable_container.cpp
+++ b/scene/gui/foldable_container.cpp
@@ -77,7 +77,7 @@ void FoldableContainer::set_folded(bool p_folded) {
 		update_minimum_size();
 		queue_sort();
 		queue_redraw();
-		
+
 		emit_signal(SNAME("folding_changed"), folded);
 	}
 }


### PR DESCRIPTION
Fixes #117199
Correctly emits `folding_changed` signal any time the `folded` property changes.

The current behaviour has many cases where the `folding_changed` signal is not emitted, despite the documentation describing it as "Emitted when the container is folded/expanded."
- Any folding state change from `FoldableGroup` does not emit the signal, as described in the linked issue.
- Any modification to the `folded` property does not emit the signal either.

Clicks to the title bar always emits the signal, regardless if `folded` has changed. As well as calls to `fold()` and `expand()`. 


If this is intentional behaviour I'd like clarification on the reasoning, as it causes a lot of unexpected behaviour when using this container.