### PR TITLE
Reset follow mode focus count on selection change

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -3965,6 +3965,13 @@ void Node3DEditorViewport::_disable_follow_mode() {
 	times_focused_consecutively = 0;
 }
 
+void Node3DEditorViewport::_reset_follow_mode_count() {
+	bool is_in_follow_mode = times_focused_consecutively >= 2 && times_focused_consecutively % 2 == 0;
+	if (!is_in_follow_mode) {
+		times_focused_consecutively = 0;
+	}
+}
+
 void Node3DEditorViewport::_toggle_camera_preview(bool p_activate) {
 	ERR_FAIL_COND(p_activate && !preview);
 	ERR_FAIL_COND(!p_activate && !previewing);
@@ -5731,6 +5738,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 
 	index = p_index;
 	editor_selection = EditorNode::get_singleton()->get_editor_selection();
+	editor_selection->connect("selection_changed", callable_mp(this, &Node3DEditorViewport::_reset_follow_mode_count));
 
 	message_time = 0;
 	zoom_indicator_delay = 0.0;

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -409,6 +409,7 @@ private:
 	void _preview_camera_property_changed();
 	void _update_centered_labels();
 	void _disable_follow_mode();
+	void _reset_follow_mode_count();
 	void _toggle_camera_preview(bool);
 	void _toggle_cinema_preview(bool);
 	void _init_gizmo_instance(int p_idx);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

This PR https://github.com/godotengine/godot/pull/99499 added the ability to follow a selection in the editor by pressing the focus shortcut twice. The problem now though is that the count of how many times it was pressed does not reset when selecting a different node which can be very annoying when trying to focus different nodes subsequently. 

Continuing to follow various nodes when already in follow mode is fine, however.

The fix is to reset the focus on count on selection change. CC: @Calinou 

