### PR TITLE
Add toggle button for texture preview metadata overlay

### DIFF
--- a/editor/scene/texture/texture_3d_editor_plugin.cpp
+++ b/editor/scene/texture/texture_3d_editor_plugin.cpp
@@ -34,6 +34,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/scene/texture/color_channel_selector.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/gui/button.h"
 #include "scene/gui/label.h"
 
 // Shader sources.
@@ -92,6 +93,9 @@ void Texture3DEditor::_notification(int p_what) {
 			if (info) {
 				Ref<Font> metadata_label_font = get_theme_font(SNAME("expression"), EditorStringName(EditorFonts));
 				info->add_theme_font_override(SceneStringName(font), metadata_label_font);
+			}
+			if (info_toggle) {
+				info_toggle->set_button_icon(get_editor_theme_icon(SNAME("Info")));
 			}
 			theme_cache.outline_color = get_theme_color(SNAME("extra_border_color_1"), EditorStringName(Editor));
 		} break;
@@ -201,6 +205,11 @@ void Texture3DEditor::on_selected_channels_changed() {
 	_update_material(false);
 }
 
+void Texture3DEditor::_toggle_info() {
+	info->set_visible(!info->is_visible());
+	info_toggle->set_modulate(Color(1, 1, 1, info->is_visible() ? 0.8 : 0.4));
+}
+
 void Texture3DEditor::init_shaders() {
 	texture_shader.instantiate();
 	texture_shader->set_code(texture_3d_shader);
@@ -285,6 +294,20 @@ Texture3DEditor::Texture3DEditor() {
 	info->set_anchor(SIDE_TOP, 1);
 
 	add_child(info);
+
+	info_toggle = memnew(Button);
+	info_toggle->set_flat(true);
+	info_toggle->set_tooltip_text(TTRC("Toggle metadata overlay."));
+	info_toggle->set_theme_type_variation("PreviewLightButton");
+	info_toggle->set_modulate(Color(1, 1, 1, 0.8));
+	info_toggle->set_h_grow_direction(GROW_DIRECTION_END);
+	info_toggle->set_v_grow_direction(GROW_DIRECTION_BEGIN);
+	info_toggle->set_anchor(SIDE_LEFT, 0);
+	info_toggle->set_anchor(SIDE_RIGHT, 0);
+	info_toggle->set_anchor(SIDE_BOTTOM, 1);
+	info_toggle->set_anchor(SIDE_TOP, 1);
+	info_toggle->connect(SceneStringName(pressed), callable_mp(this, &Texture3DEditor::_toggle_info));
+	add_child(info_toggle);
 }
 
 Texture3DEditor::~Texture3DEditor() {

--- a/editor/scene/texture/texture_3d_editor_plugin.h
+++ b/editor/scene/texture/texture_3d_editor_plugin.h
@@ -37,6 +37,7 @@
 #include "scene/resources/shader.h"
 #include "scene/resources/texture.h"
 
+class Button;
 class ColorChannelSelector;
 
 class Texture3DEditor : public Control {
@@ -48,6 +49,7 @@ class Texture3DEditor : public Control {
 
 	SpinBox *layer = nullptr;
 	Label *info = nullptr;
+	Button *info_toggle = nullptr;
 	Ref<Texture3D> texture;
 
 	static inline Ref<Shader> texture_shader;
@@ -74,6 +76,7 @@ class Texture3DEditor : public Control {
 
 	void _update_material(bool p_texture_changed);
 	void _update_gui();
+	void _toggle_info();
 
 	void on_selected_channels_changed();
 

--- a/editor/scene/texture/texture_editor_plugin.cpp
+++ b/editor/scene/texture/texture_editor_plugin.cpp
@@ -35,6 +35,7 @@
 #include "editor/scene/texture/color_channel_selector.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/aspect_ratio_container.h"
+#include "scene/gui/button.h"
 #include "scene/gui/color_rect.h"
 #include "scene/gui/label.h"
 #include "scene/gui/spin_box.h"
@@ -113,6 +114,10 @@ void TexturePreview::_notification(int p_what) {
 			if (metadata_label) {
 				Ref<Font> metadata_label_font = get_theme_font(SNAME("expression"), EditorStringName(EditorFonts));
 				metadata_label->add_theme_font_override(SceneStringName(font), metadata_label_font);
+			}
+
+			if (metadata_toggle) {
+				metadata_toggle->set_button_icon(get_editor_theme_icon(SNAME("Info")));
 			}
 
 			bg_rect->set_color(get_theme_color(SNAME("dark_color_2"), EditorStringName(Editor)));
@@ -236,6 +241,11 @@ void TexturePreview::_update_metadata_label_text() {
 	}
 }
 
+void TexturePreview::_toggle_metadata_label() {
+	metadata_label->set_visible(!metadata_label->is_visible());
+	metadata_toggle->set_modulate(Color(1, 1, 1, metadata_label->is_visible() ? 0.8 : 0.4));
+}
+
 void TexturePreview::on_selected_channels_changed() {
 	texture_display->set_instance_shader_parameter("u_channel_factors", channel_selector->get_selected_channel_factors());
 }
@@ -337,6 +347,16 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 		metadata_label->set_v_size_flags(Control::SIZE_SHRINK_END);
 
 		add_child(metadata_label);
+
+		metadata_toggle = memnew(Button);
+		metadata_toggle->set_flat(true);
+		metadata_toggle->set_tooltip_text(TTRC("Toggle metadata overlay."));
+		metadata_toggle->set_theme_type_variation("PreviewLightButton");
+		metadata_toggle->set_modulate(Color(1, 1, 1, 0.8));
+		metadata_toggle->set_h_size_flags(Control::SIZE_SHRINK_BEGIN);
+		metadata_toggle->set_v_size_flags(Control::SIZE_SHRINK_END);
+		metadata_toggle->connect(SceneStringName(pressed), callable_mp(this, &TexturePreview::_toggle_metadata_label));
+		add_child(metadata_toggle);
 	}
 }
 

--- a/editor/scene/texture/texture_editor_plugin.cpp
+++ b/editor/scene/texture/texture_editor_plugin.cpp
@@ -35,6 +35,7 @@
 #include "editor/scene/texture/color_channel_selector.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/aspect_ratio_container.h"
+#include "scene/gui/button.h"
 #include "scene/gui/color_rect.h"
 #include "scene/gui/label.h"
 #include "scene/gui/spin_box.h"
@@ -112,6 +113,10 @@ void TexturePreview::_notification(int p_what) {
 			if (metadata_label) {
 				Ref<Font> metadata_label_font = get_theme_font(SNAME("expression"), EditorStringName(EditorFonts));
 				metadata_label->add_theme_font_override(SceneStringName(font), metadata_label_font);
+			}
+
+			if (metadata_toggle) {
+				metadata_toggle->set_button_icon(get_editor_theme_icon(SNAME("Info")));
 			}
 
 			bg_rect->set_color(get_theme_color(SNAME("dark_color_2"), EditorStringName(Editor)));
@@ -235,6 +240,11 @@ void TexturePreview::_update_metadata_label_text() {
 	}
 }
 
+void TexturePreview::_toggle_metadata_label() {
+	metadata_label->set_visible(!metadata_label->is_visible());
+	metadata_toggle->set_modulate(Color(1, 1, 1, metadata_label->is_visible() ? 0.8 : 0.4));
+}
+
 void TexturePreview::on_selected_channels_changed() {
 	texture_display->set_instance_shader_parameter("u_channel_factors", channel_selector->get_selected_channel_factors());
 }
@@ -336,6 +346,16 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 		metadata_label->set_v_size_flags(Control::SIZE_SHRINK_END);
 
 		add_child(metadata_label);
+
+		metadata_toggle = memnew(Button);
+		metadata_toggle->set_flat(true);
+		metadata_toggle->set_tooltip_text(TTRC("Toggle metadata overlay."));
+		metadata_toggle->set_theme_type_variation("PreviewLightButton");
+		metadata_toggle->set_modulate(Color(1, 1, 1, 0.8));
+		metadata_toggle->set_h_size_flags(Control::SIZE_SHRINK_BEGIN);
+		metadata_toggle->set_v_size_flags(Control::SIZE_SHRINK_END);
+		metadata_toggle->connect(SceneStringName(pressed), callable_mp(this, &TexturePreview::_toggle_metadata_label));
+		add_child(metadata_toggle);
 	}
 }
 

--- a/editor/scene/texture/texture_editor_plugin.h
+++ b/editor/scene/texture/texture_editor_plugin.h
@@ -39,6 +39,7 @@ class AspectRatioContainer;
 class ColorRect;
 class TextureRect;
 class ShaderMaterial;
+class Button;
 class ColorChannelSelector;
 class SpinBox;
 
@@ -58,6 +59,7 @@ private:
 	ColorRect *bg_rect = nullptr;
 	TextureRect *checkerboard = nullptr;
 	Label *metadata_label = nullptr;
+	Button *metadata_toggle = nullptr;
 
 	static inline Ref<ShaderMaterial> texture_material;
 
@@ -66,6 +68,7 @@ private:
 
 	void _draw_outline();
 	void _update_metadata_label_text();
+	void _toggle_metadata_label();
 
 protected:
 	void _notification(int p_what);

--- a/editor/scene/texture/texture_layered_editor_plugin.cpp
+++ b/editor/scene/texture/texture_layered_editor_plugin.cpp
@@ -35,6 +35,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/scene/texture/color_channel_selector.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/gui/button.h"
 #include "scene/gui/label.h"
 
 // Shader sources.
@@ -268,6 +269,9 @@ void TextureLayeredEditor::_notification(int p_what) {
 				Ref<Font> metadata_label_font = get_theme_font(SNAME("expression"), EditorStringName(EditorFonts));
 				info->add_theme_font_override(SceneStringName(font), metadata_label_font);
 			}
+			if (info_toggle) {
+				info_toggle->set_button_icon(get_editor_theme_icon(SNAME("Info")));
+			}
 			theme_cache.outline_color = get_theme_color(SNAME("extra_border_color_1"), EditorStringName(Editor));
 		} break;
 	}
@@ -317,6 +321,11 @@ void TextureLayeredEditor::_update_material(bool p_texture_changed) {
 
 void TextureLayeredEditor::on_selected_channels_changed() {
 	_update_material(false);
+}
+
+void TextureLayeredEditor::_toggle_info() {
+	info->set_visible(!info->is_visible());
+	info_toggle->set_modulate(Color(1, 1, 1, info->is_visible() ? 0.8 : 0.4));
 }
 
 void TextureLayeredEditor::_draw_outline() {
@@ -451,6 +460,20 @@ TextureLayeredEditor::TextureLayeredEditor() {
 	info->set_anchor(SIDE_TOP, 1);
 
 	add_child(info);
+
+	info_toggle = memnew(Button);
+	info_toggle->set_flat(true);
+	info_toggle->set_tooltip_text(TTRC("Toggle metadata overlay."));
+	info_toggle->set_theme_type_variation("PreviewLightButton");
+	info_toggle->set_modulate(Color(1, 1, 1, 0.8));
+	info_toggle->set_h_grow_direction(GROW_DIRECTION_END);
+	info_toggle->set_v_grow_direction(GROW_DIRECTION_BEGIN);
+	info_toggle->set_anchor(SIDE_LEFT, 0);
+	info_toggle->set_anchor(SIDE_RIGHT, 0);
+	info_toggle->set_anchor(SIDE_BOTTOM, 1);
+	info_toggle->set_anchor(SIDE_TOP, 1);
+	info_toggle->connect(SceneStringName(pressed), callable_mp(this, &TextureLayeredEditor::_toggle_info));
+	add_child(info_toggle);
 }
 
 bool EditorInspectorPluginLayeredTexture::can_handle(Object *p_object) {

--- a/editor/scene/texture/texture_layered_editor_plugin.h
+++ b/editor/scene/texture/texture_layered_editor_plugin.h
@@ -37,6 +37,7 @@
 #include "scene/resources/shader.h"
 #include "scene/resources/texture.h"
 
+class Button;
 class ColorChannelSelector;
 
 class TextureLayeredEditor : public Control {
@@ -48,6 +49,7 @@ class TextureLayeredEditor : public Control {
 
 	SpinBox *layer = nullptr;
 	Label *info = nullptr;
+	Button *info_toggle = nullptr;
 	Ref<TextureLayered> texture;
 
 	static inline Ref<Shader> shaders[3];
@@ -64,6 +66,7 @@ class TextureLayeredEditor : public Control {
 	ColorChannelSelector *channel_selector = nullptr;
 
 	void _draw_outline();
+	void _toggle_info();
 
 	void _make_materials();
 	void _update_material(bool p_texture_changed);


### PR DESCRIPTION
This PR adds an info toggle button to the texture preview panel in the Godot editor. The metadata overlay can now be shown or hidden by clicking a small "Info" icon button in the bottom-left corner.

![godot windows editor dev x86_64_3yWv6arNif](https://github.com/user-attachments/assets/aad54129-2b51-4dc3-9ae1-3247ef7ef524)

This change was prompted by this PR comment: https://github.com/godotengine/godot/pull/117071#pullrequestreview-3909980017