### PR TITLE
Fix Viewport path update error when dock is reparented during tree

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -563,7 +563,7 @@ void Viewport::_update_viewport_path() {
 
 	for (ViewportTexture *E : viewport_textures) {
 		Node *loc_scene = E->get_local_scene();
-		if (loc_scene) {
+		if (loc_scene && loc_scene->is_inside_tree()) {
 			E->path = loc_scene->get_path_to(this);
 		}
 	}


### PR DESCRIPTION
Fixes #115512.

Guard _update_viewport_path() against calling get_path_to() when the ViewportTexture's local scene is not yet inside the scene tree.

When an EditorDock is moved to closed_dock_parent (e.g. when switching scene tabs with a MultiplayerSynchronizer selected), the dock is reparented mid-tree-propagation. This triggers NOTIFICATION_ENTER_TREE on any Viewport inside the dock, which calls _update_viewport_path(). At that moment the ViewportTexture's local scene may not be inside the tree yet, causing get_path_to() to fail with:

    ERROR: Parameter "common_parent" is null.

The path will be correctly updated on the next ENTER_TREE once the node is fully propagated into the tree.
