### PR TITLE
Expose `Control.get_offset_transform` to GDScript

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -469,6 +469,13 @@
 				Returns the offset for the specified [enum Side]. A getter method for [member offset_bottom], [member offset_left], [member offset_right] and [member offset_top].
 			</description>
 		</method>
+		<method name="get_offset_transform" qualifiers="const">
+			<return type="Transform2D" />
+			<description>
+				Returns the applied offset transform.
+				[b]Note:[/b] If [member offset_transform_visual_only] is [code]false[/code], the offset transform is already included in the values returned by getters related to the transform such as [method CanvasItem.get_transform], [method CanvasItem.get_global_transform], [method CanvasItem.get_global_transform_with_canvas], and [method CanvasItem.get_screen_transform].
+			</description>
+		</method>
 		<method name="get_parent_area_size" qualifiers="const">
 			<return type="Vector2" />
 			<description>
@@ -1132,6 +1139,7 @@
 			If [code]true[/code], the offset transforms is only applied visually and does not affect input. In other words, this Control will still receive input events at its original location before the offset transform is applied.
 			If [code]false[/code], the entire transform of this Control is affected and input events will register where the Control is visually.
 			Has no effect unless [member offset_transform_enabled] is [code]true[/code].
+			[b]Note:[/b] If [member offset_transform_visual_only] is [code]false[/code], the offset transform is already included in the values returned by getters related to the transform such as [method CanvasItem.get_transform], [method CanvasItem.get_global_transform], [method CanvasItem.get_global_transform_with_canvas], and [method CanvasItem.get_screen_transform].
 		</member>
 		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="2" />
 		<member name="pivot_offset" type="Vector2" setter="set_pivot_offset" getter="get_pivot_offset" default="Vector2(0, 0)">

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -4378,6 +4378,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_offset_transform_pivot_ratio"), &Control::get_offset_transform_pivot_ratio);
 	ClassDB::bind_method(D_METHOD("set_offset_transform_visual_only", "enabled"), &Control::set_offset_transform_visual_only);
 	ClassDB::bind_method(D_METHOD("is_offset_transform_visual_only"), &Control::is_offset_transform_visual_only);
+	ClassDB::bind_method(D_METHOD("get_offset_transform"), &Control::get_offset_transform);
 
 	ClassDB::bind_method(D_METHOD("set_theme", "theme"), &Control::set_theme);
 	ClassDB::bind_method(D_METHOD("get_theme"), &Control::get_theme);


### PR DESCRIPTION
This is a followup PR to #87081 to expose `Control::get_offset_transform` and clarify the docs.