### PR TITLE
Fix `are_spans_equal` for `p_size = 0` when pointers may be invalid

### DIFF
--- a/core/templates/span.h
+++ b/core/templates/span.h
@@ -38,7 +38,9 @@ bool are_spans_equal(const LHS *p_lhs, const RHS *p_rhs, size_t p_size) {
 	if constexpr (std::is_same_v<LHS, RHS> && std::is_fundamental_v<LHS>) {
 		// Optimize trivial type comparison.
 		// is_trivially_equality_comparable would help, but it doesn't exist.
-		return memcmp(p_lhs, p_rhs, p_size * sizeof(LHS)) == 0;
+		// memcmp requires pointer argument to be valid even on size = 0 (C11 §7.24.1(2)).
+		// Span allows ptr arguments to be invalid as long as size = 0, so only call when p_size > 0.
+		return p_size == 0 || memcmp(p_lhs, p_rhs, p_size * sizeof(LHS)) == 0;
 	} else {
 		// Normal case: Need to iterate the array manually.
 		for (size_t j = 0; j < p_size; j++) {


### PR DESCRIPTION
- Should fix https://github.com/godotengine/godot/issues/117103

Should fix crashes in some configurations when comparing strings.

## Explanation 

`memcmp` (and other string comparison methods) apparently require non-nullptr arguments, even when size = 0. This requirement is specified in the C11 reference §7.24.1(2): https://port70.net/~nsz/c/c11/n1570.pdf

It makes no sense for implementations to dereference the pointer on size = 0, so this does not usually cause problems.
However, there is a specific gcc optimization `-fdelete-null-pointer-checks` that deletes nullptr checks if it is confident that they are not required.
It may see the `memcmp` call, and according to §7.24.1(2) assume that the call means the pointers are non-nullptr. So it may delete non-nullptr checks, leading to a dereference of invalid data. By introducing a `size > 0` check before `memcmp`, we disallow it to propagate the invariant.

Future C versions may hopefully relax the `memcmp` requirement.

> [!NOTE]
> AI disclaimer: I used AI to track down the exact specs of `memcmp` (yielding §7.24.1(2)) and the `-fdelete-null-pointer-checks` optimization. I checked the specs and implemented the fix myself.