### PR TITLE
Fix new resource locked when created via editable children in inspector

### DIFF
--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -741,6 +741,13 @@ String EditorResourcePicker::_get_owner_path() const {
 		Node *p_edited_scene_root = EditorNode::get_singleton()->get_editor_data().get_edited_scene_root();
 		if (node->get_scene_file_path().is_empty()) {
 			node = node->get_owner();
+			// If the owner is not the currently edited scene root, the node is an editable
+			// child from another scene. Use the edited scene's path so the new resource is
+			// not treated as foreign (belonging to the external scene).
+			if (node && p_edited_scene_root != nullptr && node != p_edited_scene_root &&
+					!p_edited_scene_root->get_scene_file_path().is_empty()) {
+				return p_edited_scene_root->get_scene_file_path();
+			}
 		} else if (p_edited_scene_root != nullptr && p_edited_scene_root->get_scene_file_path() != node->get_scene_file_path()) {
 			// PackedScene should use root scene path.
 			return p_edited_scene_root->get_scene_file_path();


### PR DESCRIPTION
Fixes #112211
Fixes #120192

Creating a new Resource via the inspector picker on a node that is an editable child of another scene, _get_owner_path() would return the owner node's scene file path (the external/child scene), causing the newly created resource to get a path like 'child.tscn::...' instead of 'parent.tscn::...'.

The resource would then appear as foreign to the currently edited scene, locking it as read-only in the inspector until the scene was saved and reopened.

The fix: after resolving the owner via get_owner(), check if that owner belongs to a different scene than the currently edited one. If so, use the edited scene root's path instead, consistent with the existing guard for nodes that have their own scene_file_path set.