### PR TITLE
ScrollBar: Fix compilation with `precision=double`

### DIFF
--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -58,14 +58,14 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 		if (orientation == HORIZONTAL) {
 			if (pg->get_delta().x != 0) {
 				if (pg->get_delta().x < 0) {
-					scroll(-MAX(fabsf(pg->get_delta().x), get_step()));
+					scroll(-MAX(Math::abs(pg->get_delta().x), get_step()));
 				}
 				if (pg->get_delta().x > 0) {
 					scroll(MAX(pg->get_delta().x, get_step()));
 				}
 			} else if (pg->get_delta().y != 0) {
 				if (pg->get_delta().y < 0) {
-					scroll(-MAX(fabsf(pg->get_delta().y), get_step()));
+					scroll(-MAX(Math::abs(pg->get_delta().y), get_step()));
 				}
 				if (pg->get_delta().y > 0) {
 					scroll(MAX(pg->get_delta().y, get_step()));
@@ -73,7 +73,7 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 			}
 		} else {
 			if (pg->get_delta().y < 0) {
-				scroll(-MAX(fabsf(pg->get_delta().y), get_step()));
+				scroll(-MAX(Math::abs(pg->get_delta().y), get_step()));
 			}
 			if (pg->get_delta().y > 0) {
 				scroll(MAX(pg->get_delta().y, get_step()));
@@ -373,7 +373,7 @@ void ScrollBar::_notification(int p_what) {
 			if (scrolling) {
 				if (get_value() != target_scroll) {
 					double target = target_scroll - get_value();
-					double dist = std::abs(target);
+					double dist = Math::abs(target);
 					double vel = ((target / dist) * 500) * get_process_delta_time();
 
 					if (Math::abs(vel) >= dist) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/117222