### PR TITLE
[old] Fixed doc formatting issue in `@GlobalScope.log()`

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -678,7 +678,7 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns the [url=https://en.wikipedia.org/wiki/Natural_logarithm]natural logarithm[/url] of [param x] (base [url=https://en.wikipedia.org/wiki/E_(mathematical_constant)][i]e[/i][/url], with [i]e[/i] being approximately 2.71828). This is the amount of time needed to reach a certain level of continuous growth.
+				Returns the [url=https://en.wikipedia.org/wiki/Natural_logarithm]natural logarithm[/url] of [param x] (base [i][url=https://en.wikipedia.org/wiki/E_(mathematical_constant)]e[/url][/i], with [i]e[/i] being approximately 2.71828). This is the amount of time needed to reach a certain level of continuous growth.
 				[b]Note:[/b] This is not the same as the "log" function on most calculators, which uses a base 10 logarithm. To use base 10 logarithm, use [code]log(x) / log(10)[/code].
 				[codeblock]
 				log(10) # Returns 2.302585


### PR DESCRIPTION
Moved to https://github.com/godotengine/godot/pull/117227.

~Closes https://github.com/godotengine/godot-docs/issues/11834~

~Changes:~
- ~Fixes @GlobalScope.log() showing `[i]e[/i]` instead of `e`.~
