### PR TITLE
Fix doc formatting issue in `@GlobalScope.log()`, `OS.shell_open()`, `JavaScriptBridge.is_js_buffer()`, and `Signal`

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -678,7 +678,7 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns the [url=https://en.wikipedia.org/wiki/Natural_logarithm]natural logarithm[/url] of [param x] (base [url=https://en.wikipedia.org/wiki/E_(mathematical_constant)][i]e[/i][/url], with [i]e[/i] being approximately 2.71828). This is the amount of time needed to reach a certain level of continuous growth.
+				Returns the [url=https://en.wikipedia.org/wiki/Natural_logarithm]natural logarithm[/url] of [param x] (base [url=https://en.wikipedia.org/wiki/E_(mathematical_constant)]e[/url], with [i]e[/i] being approximately 2.71828). This is the amount of time needed to reach a certain level of continuous growth.
 				[b]Note:[/b] This is not the same as the "log" function on most calculators, which uses a base 10 logarithm. To use base 10 logarithm, use [code]log(x) / log(10)[/code].
 				[codeblock]
 				log(10) # Returns 2.302585

--- a/doc/classes/JavaScriptBridge.xml
+++ b/doc/classes/JavaScriptBridge.xml
@@ -65,7 +65,7 @@
 			<return type="bool" />
 			<param index="0" name="javascript_object" type="JavaScriptObject" />
 			<description>
-				Returns [code]true[/code] if the given [param javascript_object] is of type [url=https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer][code]ArrayBuffer[/code][/url], [url=https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView][code]DataView[/code][/url], or one of the many [url=https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray]typed array objects[/url].
+				Returns [code]true[/code] if the given [param javascript_object] is of type [url=https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer]ArrayBuffer[/url], [url=https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView]DataView[/url], or one of the many [url=https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray]typed array objects[/url].
 			</description>
 		</method>
 		<method name="js_buffer_to_packed_byte_array">

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -868,7 +868,7 @@
 				- [code]OS.shell_open("C:\\Users\\name\\Downloads")[/code] on Windows opens the file explorer at the user's Downloads folder.
 				- [code]OS.shell_open("C:/Users/name/Downloads")[/code] also works on Windows and opens the file explorer at the user's Downloads folder.
 				- [code]OS.shell_open("https://godotengine.org")[/code] opens the default web browser on the official Godot website.
-				- [code]OS.shell_open("mailto:example@example.com")[/code] opens the default email client with the "To" field set to [code]example@example.com[/code]. See [url=https://datatracker.ietf.org/doc/html/rfc2368]RFC 2368 - The [code]mailto[/code] URL scheme[/url] for a list of fields that can be added.
+				- [code]OS.shell_open("mailto:example@example.com")[/code] opens the default email client with the "To" field set to [code]example@example.com[/code]. See [url=https://datatracker.ietf.org/doc/html/rfc2368]RFC 2368 - The mailto URL scheme[/url] for a list of fields that can be added.
 				Use [method ProjectSettings.globalize_path] to convert a [code]res://[/code] or [code]user://[/code] project path into a system path for use with this method.
 				[b]Note:[/b] Use [method String.uri_encode] to encode characters within URLs in a URL-safe, portable way. This is especially required for line breaks. Otherwise, [method shell_open] may not work correctly in a project exported to the Web platform.
 				[b]Note:[/b] This method is implemented on Android, iOS, Web, Linux, macOS and Windows.

--- a/doc/classes/Signal.xml
+++ b/doc/classes/Signal.xml
@@ -69,7 +69,7 @@
 		}
 		[/csharp]
 		[/codeblocks]
-		[b][code skip-lint]Object.connect()[/code] or [code skip-lint]Signal.connect()[/code]?[/b]
+		[code skip-lint]Object.connect()[/code] [b]or[/b] [code skip-lint]Signal.connect()[/code][b]?[/b]
 		As seen above, the recommended method to connect signals is not [method Object.connect]. The code block below shows the four options for connecting signals, using either this legacy method or the recommended [method Signal.connect], and using either an implicit [Callable] or a manually defined one.
 		[codeblocks]
 		[gdscript]

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -1869,7 +1869,20 @@ def format_text_block(
 
     pos = 0
     tag_depth = 0
+    debug_tag_stack: list[str] = []
     while True:
+        if tag_depth > 2 or (
+            tag_depth == 2
+            and not (
+                debug_tag_stack[0] == "codeblocks"
+                and (debug_tag_stack[1] == "gdscript" or debug_tag_stack[1] == "csharp")
+            )
+        ):
+            print_warning(
+                f"{state.current_class}.xml: Found nested tags [{']['.join(debug_tag_stack)}] in {context_name} (online doc will contain invalid RST markup).",
+                state,
+            )
+
         pos = text.find("[", pos)
         if pos == -1:
             break
@@ -1908,6 +1921,7 @@ def format_text_block(
                     if is_in_tagset(tag_state.name, RESERVED_CODEBLOCK_TAGS):
                         tag_text = ""
                         tag_depth -= 1
+                        debug_tag_stack.pop()
                         inside_code = False
                         ignore_code_warnings = False
                         # Strip newline if the tag was alone on one
@@ -1917,6 +1931,7 @@ def format_text_block(
                     elif is_in_tagset(tag_state.name, ["code"]):
                         tag_text = "``"
                         tag_depth -= 1
+                        debug_tag_stack.pop()
                         inside_code = False
                         ignore_code_warnings = False
                         escape_post = True
@@ -1946,15 +1961,18 @@ def format_text_block(
                     has_codeblocks_csharp = False
 
                     tag_depth -= 1
+                    debug_tag_stack.pop()
                     tag_text = ""
                     inside_code_tabs = False
                 else:
                     tag_depth += 1
+                    debug_tag_stack.append(tag_state.name)
                     tag_text = "\n.. tabs::"
                     inside_code_tabs = True
 
             elif is_in_tagset(tag_state.name, RESERVED_CODEBLOCK_TAGS):
                 tag_depth += 1
+                debug_tag_stack.append(tag_state.name)
 
                 if tag_state.name == "gdscript":
                     if not inside_code_tabs:
@@ -1994,6 +2012,7 @@ def format_text_block(
             elif is_in_tagset(tag_state.name, ["code"]):
                 tag_text = "``"
                 tag_depth += 1
+                debug_tag_stack.append(tag_state.name)
 
                 inside_code = True
                 inside_code_tag = "code"
@@ -2280,6 +2299,12 @@ def format_text_block(
                         )
                         break
                     link_title = text[endq_pos + 1 : endurl_pos]
+                    for rft in RESERVED_FORMATTING_TAGS:
+                        if link_title.find(f"[{rft}]") != -1:
+                            print_warning(
+                                f"{state.current_class}.xml: Found nested tags [url][{rft}] in {context_name} (online doc will contain invalid RST markup).",
+                                state,
+                            )
                     tag_text = make_link(url_target, link_title)
 
                     pre_text = text[:pos]
@@ -2304,34 +2329,42 @@ def format_text_block(
             elif tag_state.name == "center":
                 if tag_state.closing:
                     tag_depth -= 1
+                    debug_tag_stack.pop()
                 else:
                     tag_depth += 1
+                    debug_tag_stack.append(tag_state.name)
                 tag_text = ""
 
             elif tag_state.name == "i":
                 if tag_state.closing:
                     tag_depth -= 1
+                    debug_tag_stack.pop()
                     escape_post = True
                 else:
                     tag_depth += 1
+                    debug_tag_stack.append(tag_state.name)
                     escape_pre = True
                 tag_text = "*"
 
             elif tag_state.name == "b":
                 if tag_state.closing:
                     tag_depth -= 1
+                    debug_tag_stack.pop()
                     escape_post = True
                 else:
                     tag_depth += 1
+                    debug_tag_stack.append(tag_state.name)
                     escape_pre = True
                 tag_text = "**"
 
             elif tag_state.name == "u":
                 if tag_state.closing:
                     tag_depth -= 1
+                    debug_tag_stack.pop()
                     escape_post = True
                 else:
                     tag_depth += 1
+                    debug_tag_stack.append(tag_state.name)
                     escape_pre = True
                 tag_text = ""
 
@@ -2345,10 +2378,12 @@ def format_text_block(
                 tag_text = "`"
                 if tag_state.closing:
                     tag_depth -= 1
+                    debug_tag_stack.pop()
                     escape_post = True
                 else:
                     tag_text = ":kbd:" + tag_text
                     tag_depth += 1
+                    debug_tag_stack.append(tag_state.name)
                     escape_pre = True
 
             # Invalid syntax.


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-docs/issues/11834

Changes:
- Removes nested tags in `@GlobalScope.log()`, `OS.shell_open()`, `JavaScriptBridge.is_js_buffer()`, and `Signal`.
- Adds new warnings for nested tags in `make_rst.py`.
- ~Fixes RST generator to correctly render nested tags.~