### PR TITLE
Remove restart requirement for `interface/touchscreen/enable_touch_optimizations` setting

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -50,6 +50,17 @@
 ////////////////////////////////////////////////
 ////////////////////////////////////////////////
 
+void DockSplitContainer::_notification(int p_what) {
+	switch (p_what) {
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			if (!EditorSettings::get_singleton()->check_changed_settings_in_group("interface/touchscreen")) {
+				return;
+			}
+			set_touch_dragger_enabled(EDITOR_GET("interface/touchscreen/enable_touch_optimizations"));
+		} break;
+	}
+}
+
 void DockSplitContainer::_update_visibility() {
 	if (is_updating) {
 		return;

--- a/editor/docks/editor_dock_manager.h
+++ b/editor/docks/editor_dock_manager.h
@@ -52,6 +52,7 @@ private:
 	bool is_updating = false;
 
 protected:
+	void _notification(int p_what);
 	void _update_visibility();
 
 	virtual void add_child_notify(Node *p_child) override;

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -111,6 +111,12 @@ void ProjectExportDialog::_notification(int p_what) {
 			}
 		} break;
 
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/touchscreen")) {
+				main_split->set_touch_dragger_enabled(EDITOR_GET("interface/touchscreen/enable_touch_optimizations"));
+			}
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			_script_encryption_key_visibility_changed(show_script_key->is_pressed());
 			duplicate_preset->set_button_icon(presets->get_editor_theme_icon(SNAME("Duplicate")));
@@ -1534,19 +1540,17 @@ ProjectExportDialog::ProjectExportDialog() {
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);
 
-	HSplitContainer *hbox = memnew(HSplitContainer);
-	main_vb->add_child(hbox);
-	hbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	if (EDITOR_GET("interface/touchscreen/enable_touch_optimizations")) {
-		hbox->set_touch_dragger_enabled(true);
-	}
+	main_split = memnew(HSplitContainer);
+	main_vb->add_child(main_split);
+	main_split->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	main_split->set_touch_dragger_enabled(EDITOR_GET("interface/touchscreen/enable_touch_optimizations"));
 
 	// Presets list.
 
 	VBoxContainer *preset_vb = memnew(VBoxContainer);
 	preset_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	preset_vb->set_stretch_ratio(0.35);
-	hbox->add_child(preset_vb);
+	main_split->add_child(preset_vb);
 
 	Label *l = memnew(Label(TTR("Presets")));
 	l->set_theme_type_variation("HeaderSmall");
@@ -1586,7 +1590,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	settings_vb = memnew(VBoxContainer);
 	settings_vb->hide();
 	settings_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	hbox->add_child(settings_vb);
+	main_split->add_child(settings_vb);
 
 	PanelContainer *panel = memnew(PanelContainer);
 	panel->set_theme_type_variation(SNAME("PanelForeground"));
@@ -1935,7 +1939,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	empty_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	empty_label->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	empty_label->hide();
-	hbox->add_child(empty_label);
+	main_split->add_child(empty_label);
 
 	// Deletion dialog.
 

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -36,6 +36,7 @@
 
 class CheckBox;
 class CheckButton;
+class HSplitContainer;
 class EditorFileDialog;
 class EditorFileSystemDirectory;
 class EditorInspector;
@@ -73,6 +74,7 @@ public:
 class ProjectExportDialog : public ConfirmationDialog {
 	GDCLASS(ProjectExportDialog, ConfirmationDialog);
 
+	HSplitContainer *main_split = nullptr;
 	TabContainer *sections = nullptr;
 
 	MenuButton *add_preset = nullptr;

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -625,7 +625,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	bool is_native_touchscreen = has_touchscreen_ui && !OS::get_singleton()->has_feature("xr_editor"); // Disable some touchscreen settings by default for the XR Editor.
 
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/touchscreen/enable_touch_optimizations", is_native_touchscreen, "")
-	set_restart_if_changed("interface/touchscreen/enable_touch_optimizations", true);
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/touchscreen/enable_long_press_as_right_click", is_native_touchscreen, "")
 	set_restart_if_changed("interface/touchscreen/enable_long_press_as_right_click", true);
 

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -304,6 +304,10 @@ void EditorSettingsDialog::_notification(int p_what) {
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/localization/localize_settings")) {
 				inspector->update_category_list();
 			}
+
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/touchscreen")) {
+				inspector->set_touch_dragger_enabled(EDITOR_GET("interface/touchscreen/enable_touch_optimizations"));
+			}
 		} break;
 	}
 }

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -678,6 +678,12 @@ void ProjectSettingsEditor::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			_update_theme();
 		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/touchscreen")) {
+				general_settings_inspector->set_touch_dragger_enabled(EDITOR_GET("interface/touchscreen/enable_touch_optimizations"));
+			}
+		} break;
 	}
 }
 

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -718,6 +718,7 @@ bool EditorThemeManager::is_generated_theme_outdated() {
 		// TODO: We can use this information more intelligently to do partial theme updates and speed things up.
 		outdated_cache = EditorSettings::get_singleton()->check_changed_settings_in_group("interface/theme") ||
 				EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/fonts") ||
+				EditorSettings::get_singleton()->check_changed_settings_in_group("interface/touchscreen/enable_touch_optimizations") ||
 				EditorSettings::get_singleton()->check_changed_settings_in_group("editors/visual_editors") ||
 				EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/theme") ||
 				EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/help/help") ||


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Tested with: https://github.com/godotengine/godot/pull/117203

https://github.com/user-attachments/assets/dab77c16-e637-4d96-a518-a4daec83cbf3


