### PR TITLE
Fix TabContainer set current tab not immediately updating visibility

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -505,7 +505,7 @@ void TabContainer::_on_tab_hovered(int p_tab) {
 }
 
 void TabContainer::_on_tab_changed(int p_tab) {
-	_repaint_call_deferred();
+	_repaint();
 	queue_redraw();
 	queue_accessibility_update();
 


### PR DESCRIPTION
Fix TabContainer set current tab not immediately updating visibility
- Fixes https://github.com/godotengine/godot/issues/99065
- Fixes https://github.com/godotengine/godot/issues/115947
- Supersedes https://github.com/godotengine/godot/pull/116119

`_on_tab_changed` repaint was made deferred back in #58687, probably because repaint uses `theme_cache` which will crash if used too early. But now `TabContainer::set_current_tab` doesn't immediately set the current tab, it waits for `NOTIFICATION_ENTER_TREE`, since #83893.
This means it should be safe to repaint immediately when the tab changes.

I tested and didn't find any issues with it.

This also fixes the AnimationTree dock issue, because the TabContainer not being visible immediately caused this check to not work:

https://github.com/godotengine/godot/blob/220b0b2f74d8e089481b140c42a42992a76dd6fc/editor/animation/animation_player_editor_plugin.cpp#L2490-L2491

Previously it was only possible to have the AnimationTree dock open automatically if the AnimationPlayer dock was already open. This was because this check in the dock manger never changed the tab to the AnimationPlayer dock because it detected that it was already visible since it didn't update yet to show the tree:

https://github.com/godotengine/godot/blob/220b0b2f74d8e089481b140c42a42992a76dd6fc/editor/docks/editor_dock_manager.cpp#L663

Before that was a lot of dock manager changes, I haven't checked what made it work in 4.5.

`EditorData::get_handling_sub_editors` should probably be not in reverse order too, that way user plugins (and more specific plugins like AnimationTree) take priority over editor plugins, since they are opened in order and the last opened will override the others.
This was sort of even the goal with the PR that changed it #37022