### PR TITLE
Add vertex snapping to the 3D editor

### DIFF
--- a/core/math/triangle_mesh.h
+++ b/core/math/triangle_mesh.h
@@ -43,21 +43,20 @@ public:
 		int32_t surface_index = 0;
 	};
 
+	struct BVH {
+		AABB aabb;
+		Vector3 center; //used for sorting
+		int left = -1;
+		int right = -1;
+		int32_t face_index = -1;
+	};
+
 protected:
 	static void _bind_methods();
 
 private:
 	Vector<Triangle> triangles;
 	Vector<Vector3> vertices;
-
-	struct BVH {
-		AABB aabb;
-		Vector3 center; //used for sorting
-		int left = -1;
-		int right = -1;
-
-		int32_t face_index = -1;
-	};
 
 	struct BVHCmpX {
 		bool operator()(const BVH *p_left, const BVH *p_right) const {
@@ -91,6 +90,7 @@ public:
 
 	const Vector<Triangle> &get_triangles() const { return triangles; }
 	const Vector<Vector3> &get_vertices() const { return vertices; }
+	const Vector<BVH> &get_bvh() const { return bvh; }
 	void get_indices(Vector<int> *r_triangles_indices) const;
 
 	void create(const Vector<Vector3> &p_faces, const Vector<int32_t> &p_surface_indices = Vector<int32_t>());

--- a/editor/scene/3d/node_3d_editor_gizmos.h
+++ b/editor/scene/3d/node_3d_editor_gizmos.h
@@ -102,6 +102,7 @@ public:
 	void add_mesh(const Ref<Mesh> &p_mesh, const Ref<Material> &p_material = Ref<Material>(), const Transform3D &p_xform = Transform3D(), const Ref<SkinReference> &p_skin_reference = Ref<SkinReference>());
 	void add_collision_segments(const Vector<Vector3> &p_lines);
 	void add_collision_triangles(const Ref<TriangleMesh> &p_tmesh);
+	const LocalVector<Ref<TriangleMesh>> &get_collision_meshes() const { return collision_meshes; }
 	void add_unscaled_billboard(const Ref<Material> &p_material, real_t p_scale = 1, const Color &p_modulate = Color(1, 1, 1));
 	void add_handles(const Vector<Vector3> &p_handles, const Ref<Material> &p_material, const Vector<int> &p_ids = Vector<int>(), bool p_billboard = false, bool p_secondary = false);
 	void add_solid_box(const Ref<Material> &p_material, Vector3 p_size, Vector3 p_position = Vector3(), const Transform3D &p_xform = Transform3D());

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -127,6 +127,8 @@ constexpr int TRACKBALL_SPHERE_RINGS = 16;
 constexpr int TRACKBALL_SPHERE_SECTORS = 32;
 constexpr real_t TRACKBALL_HIGHLIGHT_ALPHA = 0.01;
 constexpr int GIZMO_HIGHLIGHT_AXIS_VIEW_ROTATION = 15;
+
+constexpr float VERTEX_SNAP_THRESHOLD = 30.0f;
 constexpr int GIZMO_HIGHLIGHT_AXIS_TRACKBALL = 16;
 
 constexpr real_t ZOOM_FREELOOK_INDICATOR_DELAY_S = 1.5;
@@ -822,6 +824,263 @@ ObjectID Node3DEditorViewport::_select_ray(const Point2 &p_pos) const {
 	return closest;
 }
 
+float Node3DEditorViewport::_min_screen_dist_to_aabb(const AABB &p_aabb, const Transform3D &p_transform, const Point2 &p_cursor) const {
+	Vector3 first_corner = p_transform.xform(p_aabb.get_endpoint(0));
+	if (camera->is_position_behind(first_corner)) {
+		return 0.0f;
+	}
+	Point2 screen_min = camera->unproject_position(first_corner);
+	Point2 screen_max = screen_min;
+
+	for (int i = 1; i < 8; i++) {
+		Vector3 world_corner = p_transform.xform(p_aabb.get_endpoint(i));
+		if (camera->is_position_behind(world_corner)) {
+			return 0.0f;
+		}
+		Point2 s = camera->unproject_position(world_corner);
+		screen_min = screen_min.min(s);
+		screen_max = screen_max.max(s);
+	}
+
+	float dx = MAX(screen_min.x - p_cursor.x, MAX(0.0f, p_cursor.x - screen_max.x));
+	float dy = MAX(screen_min.y - p_cursor.y, MAX(0.0f, p_cursor.y - screen_max.y));
+	return Math::sqrt(dx * dx + dy * dy);
+}
+
+bool Node3DEditorViewport::_find_closest_vertex_on_node(const Point2 &p_screen_pos, Node3D *p_node, float &r_closest_screen_dist, Vector3 &r_vertex_world) const {
+	bool found = false;
+
+	Transform3D gt = p_node->get_global_transform();
+	Vector<Ref<Node3DGizmo>> gizmos = p_node->get_gizmos();
+
+	for (int i = 0; i < gizmos.size(); i++) {
+		Ref<EditorNode3DGizmo> seg = gizmos[i];
+		if (seg.is_null()) {
+			continue;
+		}
+
+		const LocalVector<Ref<TriangleMesh>> &meshes = seg->get_collision_meshes();
+		for (const Ref<TriangleMesh> &tm : meshes) {
+			if (tm.is_null() || !tm->is_valid()) {
+				continue;
+			}
+
+			const Vector<TriangleMesh::BVH> &bvh = tm->get_bvh();
+			const Vector<TriangleMesh::Triangle> &triangles = tm->get_triangles();
+			const Vector<Vector3> &vertices = tm->get_vertices();
+
+			if (bvh.is_empty()) {
+				continue;
+			}
+
+			// Traverse the TriangleMesh BVH, pruning branches whose screen-space
+			// AABB is farther than the current best.
+			LocalVector<int> stack;
+			stack.push_back(bvh.size() - 1);
+
+			while (!stack.is_empty()) {
+				int node_idx = stack[stack.size() - 1];
+				stack.resize(stack.size() - 1);
+
+				const TriangleMesh::BVH &b = bvh[node_idx];
+
+				if (_min_screen_dist_to_aabb(b.aabb, gt, p_screen_pos) >= r_closest_screen_dist) {
+					continue;
+				}
+
+				if (b.face_index >= 0) {
+					const TriangleMesh::Triangle &tri = triangles[b.face_index];
+					for (int vi = 0; vi < 3; vi++) {
+						Vector3 world_v = gt.xform(vertices[tri.indices[vi]]);
+						if (camera->is_position_behind(world_v)) {
+							continue;
+						}
+						Vector2 screen_v = camera->unproject_position(world_v);
+						float dist = screen_v.distance_to(p_screen_pos);
+						if (dist < r_closest_screen_dist) {
+							r_closest_screen_dist = dist;
+							r_vertex_world = world_v;
+							found = true;
+						}
+					}
+				} else {
+					stack.push_back(b.left);
+					stack.push_back(b.right);
+				}
+			}
+		}
+	}
+
+	return found;
+}
+
+bool Node3DEditorViewport::_find_closest_vertex_in_scene(const Point2 &p_screen_pos, float p_threshold, Vector3 &r_vertex_world, const HashMap<ObjectID, Vector3> *p_exclude) {
+	float closest_screen_dist = p_threshold;
+	bool found = false;
+
+	Point2 min_pos(p_screen_pos.x - p_threshold, p_screen_pos.y - p_threshold);
+	Point2 max_pos(p_screen_pos.x + p_threshold, p_screen_pos.y + p_threshold);
+	Vector<Node3D *> nodes_with_gizmos = Node3DEditor::get_singleton()->gizmo_bvh_frustum_query(_build_screen_frustum(min_pos, max_pos));
+
+	for (Node3D *spat : nodes_with_gizmos) {
+		if (!spat) {
+			continue;
+		}
+
+		if (!Object::cast_to<GeometryInstance3D>(spat)) {
+			continue;
+		}
+
+		if (p_exclude) {
+			bool should_skip = false;
+			Node *current = spat;
+			while (current) {
+				if (p_exclude->has(current->get_instance_id())) {
+					should_skip = true;
+					break;
+				}
+				current = current->get_parent();
+			}
+			if (should_skip) {
+				continue;
+			}
+		}
+
+		if (_find_closest_vertex_on_node(p_screen_pos, spat, closest_screen_dist, r_vertex_world)) {
+			found = true;
+		}
+	}
+
+	return found;
+}
+
+void Node3DEditorViewport::_vertex_snap_commit() {
+	for (const KeyValue<ObjectID, Vector3> &E : vertex_snap_original_positions) {
+		Node3D *node = ObjectDB::get_instance<Node3D>(E.key);
+		if (node) {
+			vertex_snap_source += node->get_global_position() - E.value;
+			break;
+		}
+	}
+
+	HashMap<ObjectID, Vector3> original_positions;
+	for (const KeyValue<ObjectID, Vector3> &E : vertex_snap_original_positions) {
+		original_positions[E.key] = E.value;
+	}
+	vertex_snap_dragging = false;
+	vertex_snap_has_target = false;
+	vertex_snap_original_positions.clear();
+	if (!vertex_snap_mode) {
+		vertex_snap_has_source = false;
+		set_message("");
+	}
+	surface->queue_redraw();
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Vertex Snap"));
+	for (const KeyValue<ObjectID, Vector3> &E : original_positions) {
+		Node3D *node = ObjectDB::get_instance<Node3D>(E.key);
+		if (node) {
+			undo_redo->add_do_method(node, "set_global_position", node->get_global_position());
+			undo_redo->add_undo_method(node, "set_global_position", E.value);
+		}
+	}
+	undo_redo->commit_action(false);
+	_reset_follow_mode_count();
+}
+
+void Node3DEditorViewport::_vertex_snap_cancel() {
+	vertex_snap_mode = false;
+	vertex_snap_keycode = Key::NONE;
+	vertex_snap_dragging = false;
+	vertex_snap_has_source = false;
+	vertex_snap_has_target = false;
+
+	for (const KeyValue<ObjectID, Vector3> &E : vertex_snap_original_positions) {
+		Node3D *node = ObjectDB::get_instance<Node3D>(E.key);
+		if (node) {
+			node->set_global_position(E.value);
+		}
+	}
+	vertex_snap_original_positions.clear();
+	set_message(TTR("Vertex Snap Canceled."), 3);
+	surface->queue_redraw();
+}
+
+bool Node3DEditorViewport::_is_vertex_occluded(const Vector3 &p_world_pos, const Vector2 &p_screen_pos) const {
+	Vector3 ray_pos = get_ray_pos(p_screen_pos);
+	float vertex_dist = ray_pos.distance_to(p_world_pos);
+	Vector<Node3D *> hits = Node3DEditor::get_singleton()->gizmo_bvh_ray_query(ray_pos, ray_pos + get_ray(p_screen_pos) * camera->get_far());
+	for (Node3D *spat : hits) {
+		if (!spat) {
+			continue;
+		}
+		Vector<Ref<Node3DGizmo>> gizmos = spat->get_gizmos();
+		for (int i = 0; i < gizmos.size(); i++) {
+			Ref<EditorNode3DGizmo> seg = gizmos[i];
+			if (seg.is_null()) {
+				continue;
+			}
+			Vector3 point, normal;
+			if (seg->intersect_ray(camera, p_screen_pos, point, normal)) {
+				if (ray_pos.distance_to(point) < vertex_dist - 0.01f) {
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
+void Node3DEditorViewport::_vertex_snap_update_source(const Point2 &p_screen_pos) {
+	const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+	if (selection.is_empty()) {
+		vertex_snap_has_source = false;
+		return;
+	}
+
+	float threshold = VERTEX_SNAP_THRESHOLD * EDSCALE;
+	Vector3 vw;
+	bool found = false;
+	bool selection_has_geometry = false;
+
+	for (Node *E : selection) {
+		Node3D *sp = Object::cast_to<Node3D>(E);
+		if (!sp) {
+			continue;
+		}
+		if (Object::cast_to<GeometryInstance3D>(sp)) {
+			selection_has_geometry = true;
+		}
+		if (_find_closest_vertex_on_node(p_screen_pos, sp, threshold, vw)) {
+			found = true;
+		}
+		for (int i = 0; i < sp->get_child_count(); i++) {
+			Node3D *child = Object::cast_to<Node3D>(sp->get_child(i));
+			if (!child) {
+				continue;
+			}
+			if (Object::cast_to<GeometryInstance3D>(child)) {
+				selection_has_geometry = true;
+			}
+			if (_find_closest_vertex_on_node(p_screen_pos, child, threshold, vw)) {
+				found = true;
+			}
+		}
+	}
+
+	if (!found && !selection_has_geometry) {
+		found = _find_closest_vertex_in_scene(p_screen_pos, threshold, vw);
+	}
+
+	if (found) {
+		vertex_snap_source = vw;
+		vertex_snap_has_source = true;
+	} else {
+		vertex_snap_has_source = false;
+	}
+}
+
 void Node3DEditorViewport::_find_items_at_pos(const Point2 &p_pos, Vector<_RayResult> &r_results, bool p_include_locked_nodes) {
 	Vector3 ray = get_ray(p_pos);
 	Vector3 pos = get_ray_pos(p_pos);
@@ -897,41 +1156,17 @@ Vector3 Node3DEditorViewport::_get_screen_to_space(const Vector3 &p_vector3) {
 	return camera_transform.xform(Vector3(((p_vector3.x / get_size().width) * 2.0 - 1.0) * screen_he.x, ((1.0 - (p_vector3.y / get_size().height)) * 2.0 - 1.0) * screen_he.y, -(get_znear() + p_vector3.z)));
 }
 
-void Node3DEditorViewport::_select_region() {
-	View3DController::Cursor cursor = view_3d_controller->cursor;
-
-	if (cursor.region_begin == cursor.region_end) {
-		if (!clicked_wants_append) {
-			_clear_selected();
-		}
-		return; //nothing really
-	}
-
+Vector<Plane> Node3DEditorViewport::_build_screen_frustum(const Point2 &p_min, const Point2 &p_max) {
 	const real_t z_offset = MAX(0.0, 5.0 - get_znear());
-
 	Vector3 box[4] = {
-		Vector3(
-				MIN(cursor.region_begin.x, cursor.region_end.x),
-				MIN(cursor.region_begin.y, cursor.region_end.y),
-				z_offset),
-		Vector3(
-				MAX(cursor.region_begin.x, cursor.region_end.x),
-				MIN(cursor.region_begin.y, cursor.region_end.y),
-				z_offset),
-		Vector3(
-				MAX(cursor.region_begin.x, cursor.region_end.x),
-				MAX(cursor.region_begin.y, cursor.region_end.y),
-				z_offset),
-		Vector3(
-				MIN(cursor.region_begin.x, cursor.region_end.x),
-				MAX(cursor.region_begin.y, cursor.region_end.y),
-				z_offset)
+		Vector3(p_min.x, p_min.y, z_offset),
+		Vector3(p_max.x, p_min.y, z_offset),
+		Vector3(p_max.x, p_max.y, z_offset),
+		Vector3(p_min.x, p_max.y, z_offset),
 	};
 
 	Vector<Plane> frustum;
-
 	Vector3 cam_pos = _get_camera_position();
-
 	for (int i = 0; i < 4; i++) {
 		Vector3 a = _get_screen_to_space(box[i]);
 		Vector3 b = _get_screen_to_space(box[(i + 1) % 4]);
@@ -941,14 +1176,28 @@ void Node3DEditorViewport::_select_region() {
 			frustum.push_back(Plane(a, b, cam_pos));
 		}
 	}
-
 	Plane near_plane = Plane(-_get_camera_normal(), cam_pos);
 	near_plane.d -= get_znear();
 	frustum.push_back(near_plane);
-
 	Plane far_plane = -near_plane;
 	far_plane.d += get_zfar();
 	frustum.push_back(far_plane);
+	return frustum;
+}
+
+void Node3DEditorViewport::_select_region() {
+	View3DController::Cursor cursor = view_3d_controller->cursor;
+
+	if (cursor.region_begin == cursor.region_end) {
+		if (!clicked_wants_append) {
+			_clear_selected();
+		}
+		return;
+	}
+
+	Point2 region_min = cursor.region_begin.min(cursor.region_end);
+	Point2 region_max = cursor.region_begin.max(cursor.region_end);
+	Vector<Plane> frustum = _build_screen_frustum(region_min, region_max);
 
 	if (spatial_editor->get_single_selected_node()) {
 		Node3D *single_selected = spatial_editor->get_single_selected_node();
@@ -1741,6 +1990,37 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		}
 	}
 
+	if (k.is_valid()) {
+		if (!vertex_snap_mode && !vertex_snap_dragging && k->is_pressed() && _edit.mode == TRANSFORM_NONE && ED_IS_SHORTCUT("spatial_editor/vertex_snap", p_event)) {
+			vertex_snap_mode = true;
+			vertex_snap_keycode = k->get_physical_keycode() != Key::NONE ? k->get_physical_keycode() : k->get_keycode();
+			_disable_follow_mode();
+			set_message(TTR("Vertex Snap"));
+			_vertex_snap_update_source(_edit.mouse_pos);
+			surface->queue_redraw();
+		} else if (vertex_snap_mode && !k->is_pressed() && k->get_physical_keycode() == vertex_snap_keycode) {
+			vertex_snap_mode = false;
+			vertex_snap_keycode = Key::NONE;
+			if (!vertex_snap_dragging) {
+				vertex_snap_has_source = false;
+				vertex_snap_has_target = false;
+				set_message("");
+				surface->queue_redraw();
+			}
+		} else if ((vertex_snap_mode || vertex_snap_dragging) && k->is_pressed() && k->get_keycode() == Key::ESCAPE) {
+			if (vertex_snap_dragging) {
+				_vertex_snap_cancel();
+			} else {
+				vertex_snap_has_source = false;
+				surface->queue_redraw();
+			}
+			vertex_snap_mode = false;
+			vertex_snap_keycode = Key::NONE;
+			set_message("");
+			return;
+		}
+	}
+
 	if (previewing || get_viewport()->gui_get_drag_data()) {
 		// Disable all input actions when previewing a camera or during drag-and-drop.
 		return;
@@ -1748,6 +2028,69 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 	if (_redirect_freelook_input(p_event, this)) {
 		return;
+	}
+
+	{
+		Ref<InputEventMouseButton> vb = p_event;
+		if ((vertex_snap_mode || vertex_snap_dragging) && vb.is_valid()) {
+			if (vb->get_button_index() == MouseButton::RIGHT && vb->is_pressed() && vertex_snap_dragging) {
+				_vertex_snap_cancel();
+				return;
+			}
+			if (vb->get_button_index() == MouseButton::LEFT) {
+				if (vb->is_pressed()) {
+					const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+					bool has_geometry = false;
+					for (Node *E : selection) {
+						if (Object::cast_to<GeometryInstance3D>(E)) {
+							has_geometry = true;
+							break;
+						}
+					}
+
+					if (!has_geometry || !vertex_snap_has_source) {
+						_vertex_snap_update_source(vb->get_position());
+					}
+
+					if (vertex_snap_has_source && !selection.is_empty()) {
+						vertex_snap_original_positions.clear();
+						for (Node *E : selection) {
+							Node3D *sp = Object::cast_to<Node3D>(E);
+							if (sp) {
+								vertex_snap_original_positions[sp->get_instance_id()] = sp->get_global_position();
+							}
+						}
+
+						if (has_geometry) {
+							vertex_snap_dragging = true;
+							Vector3 cam_normal = camera->get_global_transform().basis.get_column(2);
+							vertex_snap_drag_plane = Plane(cam_normal, vertex_snap_source);
+						} else {
+							EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+							undo_redo->create_action(TTR("Vertex Snap"));
+							for (const KeyValue<ObjectID, Vector3> &E2 : vertex_snap_original_positions) {
+								Node3D *node = ObjectDB::get_instance<Node3D>(E2.key);
+								if (node) {
+									node->set_global_position(vertex_snap_source);
+									undo_redo->add_do_method(node, "set_global_position", vertex_snap_source);
+									undo_redo->add_undo_method(node, "set_global_position", E2.value);
+								}
+							}
+							undo_redo->commit_action(false);
+							vertex_snap_original_positions.clear();
+							spatial_editor->update_transform_gizmo();
+							_reset_follow_mode_count();
+						}
+						surface->queue_redraw();
+					}
+				} else {
+					if (vertex_snap_dragging) {
+						_vertex_snap_commit();
+					}
+				}
+				return;
+			}
+		}
 	}
 
 	EditorPlugin::AfterGUIInput after = EditorPlugin::AFTER_GUI_INPUT_PASS;
@@ -2177,6 +2520,50 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 	// Instant transforms process mouse motion in input() to handle wrapping.
 	if (m.is_valid() && !_edit.instant) {
 		_edit.mouse_pos = m->get_position();
+
+		if (vertex_snap_mode || vertex_snap_dragging) {
+			if (!vertex_snap_dragging) {
+				_vertex_snap_update_source(m->get_position());
+			} else {
+				const float vertex_snap_threshold = VERTEX_SNAP_THRESHOLD * EDSCALE;
+				bool has_displacement = false;
+				Vector3 displacement;
+
+				Vector3 target;
+				if (_find_closest_vertex_in_scene(m->get_position(), vertex_snap_threshold, target, &vertex_snap_original_positions)) {
+					vertex_snap_target = target;
+					vertex_snap_has_target = true;
+					displacement = target - vertex_snap_source;
+					has_displacement = true;
+					set_message(TTR("Vertex Snap (Snapped)"));
+				} else {
+					vertex_snap_has_target = false;
+					Vector3 ray_pos = get_ray_pos(m->get_position());
+					Vector3 ray_dir = get_ray(m->get_position());
+					Vector3 intersection;
+					if (vertex_snap_drag_plane.intersects_ray(ray_pos, ray_dir, &intersection)) {
+						displacement = intersection - vertex_snap_source;
+						has_displacement = true;
+					}
+					set_message(TTR("Vertex Snap"));
+				}
+
+				if (has_displacement) {
+					for (const KeyValue<ObjectID, Vector3> &E : vertex_snap_original_positions) {
+						Node3D *node = ObjectDB::get_instance<Node3D>(E.key);
+						if (node) {
+							if (vertex_snap_has_target && !Object::cast_to<GeometryInstance3D>(node)) {
+								node->set_global_position(vertex_snap_target);
+							} else {
+								node->set_global_position(E.value + displacement);
+							}
+						}
+					}
+				}
+			}
+			surface->queue_redraw();
+			return;
+		}
 
 		if (!view_3d_controller->is_freelook_enabled() && spatial_editor->get_single_selected_node()) {
 			Vector<Ref<Node3DGizmo>> gizmos = spatial_editor->get_single_selected_node()->get_gizmos();
@@ -3270,6 +3657,39 @@ void Node3DEditorViewport::_draw() {
 		font->draw_string(ci, msgpos + Point2(1, 1), message, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, Color(0, 0, 0, 0.8));
 		font->draw_string(ci, msgpos + Point2(-1, -1), message, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, Color(0, 0, 0, 0.8));
 		font->draw_string(ci, msgpos, message, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, Color(1, 1, 1, 1));
+	}
+
+	if ((vertex_snap_mode || vertex_snap_dragging) && vertex_snap_has_source) {
+		const float circle_radius = 6.0f * EDSCALE;
+		const float outline_width = 2.0f * EDSCALE;
+		const float occluded_alpha = 0.30f;
+
+		Vector3 source_display = vertex_snap_source;
+		if (vertex_snap_dragging) {
+			for (const KeyValue<ObjectID, Vector3> &E : vertex_snap_original_positions) {
+				Node3D *node = ObjectDB::get_instance<Node3D>(E.key);
+				if (node && Object::cast_to<GeometryInstance3D>(node)) {
+					source_display = vertex_snap_source + (node->get_global_position() - E.value);
+					break;
+				}
+			}
+		}
+
+		if (!camera->is_position_behind(source_display)) {
+			Vector2 screen_pos = camera->unproject_position(source_display);
+			bool occluded = _is_vertex_occluded(source_display, screen_pos);
+			float alpha = occluded ? occluded_alpha : 1.0f;
+			surface->draw_circle(screen_pos, circle_radius + outline_width, Color(0, 0, 0, 0.6 * alpha), true, -1.0, true);
+			surface->draw_circle(screen_pos, circle_radius, Color(1, 1, 0, alpha), true, -1.0, true);
+		}
+
+		if (vertex_snap_dragging && vertex_snap_has_target && !camera->is_position_behind(vertex_snap_target)) {
+			Vector2 screen_pos = camera->unproject_position(vertex_snap_target);
+			bool occluded = _is_vertex_occluded(vertex_snap_target, screen_pos);
+			float alpha = occluded ? occluded_alpha : 1.0f;
+			surface->draw_circle(screen_pos, circle_radius + outline_width, Color(0, 0, 0, 0.6 * alpha), true, -1.0, true);
+			surface->draw_circle(screen_pos, circle_radius, Color(0, 1, 0, alpha), true, -1.0, true);
+		}
 	}
 
 	if (_edit.mode == TRANSFORM_ROTATE) {
@@ -5977,6 +6397,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	ED_SHORTCUT("spatial_editor/reset_transform_position", TTRC("Reset Position"), KeyModifierMask::ALT + Key::W);
 	ED_SHORTCUT("spatial_editor/reset_transform_rotation", TTRC("Reset Rotation"), KeyModifierMask::ALT + Key::E);
 	ED_SHORTCUT("spatial_editor/reset_transform_scale", TTRC("Reset Scale"), KeyModifierMask::ALT + Key::R);
+	ED_SHORTCUT("spatial_editor/vertex_snap", TTRC("Vertex Snap"), Key::B);
 
 	translation_preview_button = memnew(EditorTranslationPreviewButton);
 	hbox->add_child(translation_preview_button);

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -235,6 +235,16 @@ private:
 	bool collision_reposition = false;
 	real_t gizmo_scale;
 
+	bool vertex_snap_mode = false;
+	Key vertex_snap_keycode = Key::NONE;
+	bool vertex_snap_dragging = false;
+	Vector3 vertex_snap_source;
+	Plane vertex_snap_drag_plane;
+	Vector3 vertex_snap_target;
+	bool vertex_snap_has_target = false;
+	bool vertex_snap_has_source = false;
+	HashMap<ObjectID, Vector3> vertex_snap_original_positions;
+
 	PanelContainer *info_panel = nullptr;
 	Label *info_label = nullptr;
 	Label *cinema_label = nullptr;
@@ -271,6 +281,14 @@ private:
 	ObjectID _select_ray(const Point2 &p_pos) const;
 	void _find_items_at_pos(const Point2 &p_pos, Vector<_RayResult> &r_results, bool p_include_locked);
 
+	float _min_screen_dist_to_aabb(const AABB &p_aabb, const Transform3D &p_transform, const Point2 &p_cursor) const;
+	bool _find_closest_vertex_on_node(const Point2 &p_screen_pos, Node3D *p_node, float &r_closest_screen_dist, Vector3 &r_vertex_world) const;
+	bool _find_closest_vertex_in_scene(const Point2 &p_screen_pos, float p_threshold, Vector3 &r_vertex_world, const HashMap<ObjectID, Vector3> *p_exclude = nullptr);
+	void _vertex_snap_update_source(const Point2 &p_screen_pos);
+	void _vertex_snap_commit();
+	void _vertex_snap_cancel();
+	bool _is_vertex_occluded(const Vector3 &p_world_pos, const Vector2 &p_screen_pos) const;
+
 	Transform3D _get_camera_transform() const;
 	int get_selected_count() const;
 	void cancel_transform();
@@ -279,6 +297,7 @@ private:
 	Vector3 _get_camera_position() const;
 	Vector3 _get_camera_normal() const;
 	Vector3 _get_screen_to_space(const Vector3 &p_vector3);
+	Vector<Plane> _build_screen_frustum(const Point2 &p_min, const Point2 &p_max);
 
 	void _select_region();
 	bool _transform_gizmo_select(const Vector2 &p_screenpos, bool p_highlight_only = false);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
 

* Closes: https://github.com/godotengine/godot-proposals/issues/755

Hold the `Vertex Snap` shortcut (default: `B`) to highlight the nearest vertex on the selected node's geometry. Click and drag to snap that vertex to vertices on other meshes. For nodes without geometry (`Camera3D`, `Marker3D`, etc.), the node's origin snaps directly to the target vertex.

https://github.com/user-attachments/assets/efa0c33d-d6dc-4b50-9114-0b184c18586d

