### PR TITLE
Fix virtual joystick visibility mode redraw

### DIFF
--- a/scene/gui/virtual_joystick.cpp
+++ b/scene/gui/virtual_joystick.cpp
@@ -358,7 +358,11 @@ StringName VirtualJoystick::get_action_down() const {
 }
 
 void VirtualJoystick::set_visibility_mode(VisibilityMode p_mode) {
+	if (visibility == p_mode) {
+		return;
+	}
 	visibility = p_mode;
+	queue_redraw();
 }
 
 VirtualJoystick::VisibilityMode VirtualJoystick::get_visibility_mode() const {


### PR DESCRIPTION
**Fixes #117236**

The virtual joystick was not redrawn after changing the visibility mode.  
As a result, the joystick would not update immediately and only appeared after the user interacted with it.

```cpp
void VirtualJoystick::set_visibility_mode(VisibilityMode p_mode) {
	visibility = p_mode;
}
```

### Fix
Call the `queue_redraw()` after changing the visibility mode

```cpp
void VirtualJoystick::set_visibility_mode(VisibilityMode p_mode) {
// No need to update if visibility mode is same.
	if(visibility == p_mode){
		return;
	}
	visibility = p_mode;
	queue_redraw();
}
```
