### PR TITLE
Add support for more Variant types in `@GlobalScope.min()` and `.max()`

### DIFF
--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -641,39 +641,32 @@ double VariantUtilityFunctions::pingpong(double value, double length) {
 }
 
 Variant VariantUtilityFunctions::max(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+	// NOTE: This should be consistent with Array::max() .
+
 	if (p_argcount < 2) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
 		r_error.expected = 2;
 		return Variant();
 	}
-	Variant base = *p_args[0];
-	Variant ret;
 
-	for (int i = 0; i < p_argcount; i++) {
-		Variant::Type arg_type = p_args[i]->get_type();
-		if (arg_type != Variant::INT && arg_type != Variant::FLOAT && arg_type != Variant::BOOL) {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.argument = i;
-			r_error.expected = Variant::FLOAT; // TODO maybe this should be p_args[0]->get_type() instead.
-			return Variant();
-		}
-		if (i == 0) {
-			continue;
-		}
+	int max_index = 0;
+	Variant is_greater;
+	for (int i = 1; i < p_argcount; i++) {
 		bool valid;
-		Variant::evaluate(Variant::OP_LESS, base, *p_args[i], ret, valid);
+		Variant::evaluate(Variant::OP_GREATER, *p_args[i], *p_args[max_index], is_greater, valid);
 		if (!valid) {
 			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 			r_error.argument = i;
-			r_error.expected = base.get_type();
+			r_error.expected = p_args[max_index]->get_type();
 			return Variant();
 		}
-		if (ret.booleanize()) {
-			base = *p_args[i];
+		if (is_greater.booleanize()) {
+			max_index = i;
 		}
 	}
+
 	r_error.error = Callable::CallError::CALL_OK;
-	return base;
+	return *p_args[max_index];
 }
 
 double VariantUtilityFunctions::maxf(double x, double y) {
@@ -685,39 +678,32 @@ int64_t VariantUtilityFunctions::maxi(int64_t x, int64_t y) {
 }
 
 Variant VariantUtilityFunctions::min(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+	// NOTE: This should be consistent with Array::min() .
+
 	if (p_argcount < 2) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
 		r_error.expected = 2;
 		return Variant();
 	}
-	Variant base = *p_args[0];
-	Variant ret;
 
-	for (int i = 0; i < p_argcount; i++) {
-		Variant::Type arg_type = p_args[i]->get_type();
-		if (arg_type != Variant::INT && arg_type != Variant::FLOAT && arg_type != Variant::BOOL) {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.argument = i;
-			r_error.expected = Variant::FLOAT; // TODO maybe this should be p_args[0]->get_type() instead.
-			return Variant();
-		}
-		if (i == 0) {
-			continue;
-		}
+	int min_index = 0;
+	Variant is_less;
+	for (int i = 1; i < p_argcount; i++) {
 		bool valid;
-		Variant::evaluate(Variant::OP_GREATER, base, *p_args[i], ret, valid);
+		Variant::evaluate(Variant::OP_LESS, *p_args[i], *p_args[min_index], is_less, valid);
 		if (!valid) {
 			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 			r_error.argument = i;
-			r_error.expected = base.get_type();
+			r_error.expected = p_args[min_index]->get_type();
 			return Variant();
 		}
-		if (ret.booleanize()) {
-			base = *p_args[i];
+		if (is_less.booleanize()) {
+			min_index = i;
 		}
 	}
+
 	r_error.error = Callable::CallError::CALL_OK;
-	return base;
+	return *p_args[min_index];
 }
 
 double VariantUtilityFunctions::minf(double x, double y) {

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -651,10 +651,10 @@ Variant VariantUtilityFunctions::max(const Variant **p_args, int p_argcount, Cal
 
 	for (int i = 0; i < p_argcount; i++) {
 		Variant::Type arg_type = p_args[i]->get_type();
-		if (arg_type != Variant::INT && arg_type != Variant::FLOAT) {
+		if (arg_type != Variant::INT && arg_type != Variant::FLOAT && arg_type != Variant::BOOL) {
 			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 			r_error.argument = i;
-			r_error.expected = Variant::FLOAT;
+			r_error.expected = Variant::FLOAT; // TODO maybe this should be p_args[0]->get_type() instead.
 			return Variant();
 		}
 		if (i == 0) {
@@ -695,10 +695,10 @@ Variant VariantUtilityFunctions::min(const Variant **p_args, int p_argcount, Cal
 
 	for (int i = 0; i < p_argcount; i++) {
 		Variant::Type arg_type = p_args[i]->get_type();
-		if (arg_type != Variant::INT && arg_type != Variant::FLOAT) {
+		if (arg_type != Variant::INT && arg_type != Variant::FLOAT && arg_type != Variant::BOOL) {
 			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 			r_error.argument = i;
-			r_error.expected = Variant::FLOAT;
+			r_error.expected = Variant::FLOAT; // TODO maybe this should be p_args[0]->get_type() instead.
 			return Variant();
 		}
 		if (i == 0) {

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -689,11 +689,13 @@
 		<method name="max" qualifiers="vararg">
 			<return type="Variant" />
 			<description>
-				Returns the maximum of the given numeric values. This function can take any number of arguments.
+				Returns the maximum of the given values. This function can take two or more arguments. Supported types: [int], [float], [bool], [Vector2], [Vector2i], [Vector3], [Vector3i], [Vector4], [Vector4i].
 				[codeblock]
 				max(1, 7, 3, -6, 5) # Returns 7
+				max(true, false)    # Returns true
 				[/codeblock]
-				[b]Note:[/b] When using this on vectors it will [i]not[/i] perform component-wise maximum, and will pick the largest value when compared using [code]x &lt; y[/code]. To perform component-wise maximum, use [method Vector2.max], [method Vector2i.max], [method Vector3.max], [method Vector3i.max], [method Vector4.max], and [method Vector4i.max].
+				See also [method min].
+				[b]Note:[/b] When using this on vectors it will [i]not[/i] perform component-wise maximum, and will pick the largest value when compared using [code]x &lt; y[/code]. To perform component-wise maximum, use [method Vector2.max], [method Vector2i.max], [method Vector3.max], [method Vector3i.max], [method Vector4.max], and [method Vector4i.max]. For better type safety, use [method maxf] or [method maxi].
 			</description>
 		</method>
 		<method name="maxf">
@@ -723,11 +725,13 @@
 		<method name="min" qualifiers="vararg">
 			<return type="Variant" />
 			<description>
-				Returns the minimum of the given numeric values. This function can take any number of arguments.
+				Returns the minimum of the given values. This function can take two or more arguments. Supported types: [int], [float], [bool], [Vector2], [Vector2i], [Vector3], [Vector3i], [Vector4], [Vector4i].
 				[codeblock]
 				min(1, 7, 3, -6, 5) # Returns -6
+				min(true, false)    # Returns false
 				[/codeblock]
-				[b]Note:[/b] When using this on vectors it will [i]not[/i] perform component-wise minimum, and will pick the smallest value when compared using [code]x &lt; y[/code]. To perform component-wise minimum, use [method Vector2.min], [method Vector2i.min], [method Vector3.min], [method Vector3i.min], [method Vector4.min], and [method Vector4i.min].
+				See also [method max].
+				[b]Note:[/b] When using this on vectors it will [i]not[/i] perform component-wise minimum, and will pick the smallest value when compared using [code]x &lt; y[/code]. To perform component-wise minimum, use [method Vector2.min], [method Vector2i.min], [method Vector3.min], [method Vector3i.min], [method Vector4.min], and [method Vector4i.min]. For better type safety, use [method minf] or [method mini].
 			</description>
 		</method>
 		<method name="minf">


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/issues/14402

Changes: (Plan A)
- `@GlobalScope.min()` and `.max()` now accept `bool` type.
  - Cannot mix `int/float` with `bool`.

Changes: (Plan B)
- `@GlobalScope.min()` and `.max()` now accept any `Variant` type with `<` and `>` operators.
  - Cannot mix `int/float` with `bool`, `VectorN`.