### PR TITLE
Fix find next (f3) match line behind find bar

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -217,7 +217,7 @@ bool FindReplaceBar::_search(uint32_t p_flags, int p_from_line, int p_from_col) 
 		if (!preserve_cursor && !is_selection_only()) {
 			text_editor->unfold_line(pos.y);
 			text_editor->select(pos.y, pos.x, pos.y, pos.x + text.length());
-			text_editor->center_viewport_to_caret(0);
+			base_text_editor->center_viewport_to_caret();
 			text_editor->set_code_hint("");
 			text_editor->cancel_code_completion();
 


### PR DESCRIPTION
changed line 220 in code_editor.cpp from 
text_editor->center_viewport_to_caret(0); to 
base_text_editor->center_viewport_to_caret(); 

This centers the caret in the viewport after layout recalculations have been done. This means that editor will wait until the find bar has appeared fully before it scrolls to find the match, making the match appear above the find line instead of behind it. 

* *Bugsquad edit, closes: #117105*

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
