### PR TITLE
Clarify the orientation of Decal `upper_fade`/`lower_fade` in the class reference

### DIFF
--- a/doc/classes/Decal.xml
+++ b/doc/classes/Decal.xml
@@ -78,7 +78,7 @@
 			Energy multiplier for the emission texture. This will make the decal emit light at a higher or lower intensity, independently of the albedo color. See also [member modulate].
 		</member>
 		<member name="lower_fade" type="float" setter="set_lower_fade" getter="get_lower_fade" default="0.3">
-			Sets the curve over which the decal will fade as the surface gets further from the center of the [AABB]. Only positive values are valid (negative values will be clamped to [code]0.0[/code]). See also [member upper_fade].
+			Sets the curve over which the decal will fade as the surface gets further from the center of the [AABB] (away from the decal's projection angle). Only positive values are valid (negative values will be clamped to [code]0.0[/code]). See also [member upper_fade].
 		</member>
 		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" default="Color(1, 1, 1, 1)" keywords="color, colour">
 			Changes the [Color] of the Decal by multiplying the albedo and emission colors with this value. The alpha component is only taken into account when multiplying the albedo color, not the emission color. See also [member emission_energy] and [member albedo_mix] to change the emission and albedo intensity independently of each other.
@@ -111,7 +111,7 @@
 			[b]Note:[/b] Due to technical limitations, modifying the underlying surface's roughness using [member texture_orm] does [i]not[/i] affect screen-space reflections ([member Environment.ssr_enabled]), reflections from [VoxelGI], and reflections from SDFGI ([member Environment.sdfgi_enabled]). Only reflections from [ReflectionProbe]s are affected.
 		</member>
 		<member name="upper_fade" type="float" setter="set_upper_fade" getter="get_upper_fade" default="0.3">
-			Sets the curve over which the decal will fade as the surface gets further from the center of the [AABB]. Only positive values are valid (negative values will be clamped to [code]0.0[/code]). See also [member lower_fade].
+			Sets the curve over which the decal will fade as the surface gets further from the center of the [AABB] (towards the decal's projection angle). Only positive values are valid (negative values will be clamped to [code]0.0[/code]). See also [member lower_fade].
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
This information is present on the [Using decals](https://docs.godotengine.org/en/stable/tutorials/3d/using_decals.html) manual page, but was missing from the class reference.

- See https://github.com/godotengine/godot/issues/51299#issuecomment-4020171020.
