### PR TITLE
GDScript: preserve constant initializer value

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -5618,19 +5618,37 @@ Dictionary GDScriptAnalyzer::make_dictionary_from_element_datatype(const GDScrip
 
 Variant GDScriptAnalyzer::make_variable_default_value(GDScriptParser::VariableNode *p_variable) {
 	Variant result = Variant();
+	GDScriptParser::DataType datatype = p_variable->get_datatype();
 
 	if (p_variable->initializer) {
-		if (p_variable->initializer->is_constant) {
-			result = p_variable->initializer->reduced_value;
-		} else {
-			bool is_initializer_value_reduced = false;
-			Variant initializer_value = make_expression_reduced_value(p_variable->initializer, is_initializer_value_reduced);
-			if (is_initializer_value_reduced) {
-				result = initializer_value;
+		bool is_initializer_value_reduced = false;
+		Variant initializer_value = make_expression_reduced_value(p_variable->initializer, is_initializer_value_reduced);
+		if (is_initializer_value_reduced) {
+			result = initializer_value;
+
+			if (datatype.is_hard_type() && datatype.kind == GDScriptParser::DataType::BUILTIN && datatype.builtin_type != Variant::OBJECT) {
+				if (datatype.builtin_type == Variant::ARRAY && datatype.has_container_element_type(0)) {
+					Array array = make_array_from_element_datatype(datatype.get_container_element_type(0));
+					array.assign(result);
+					result = array;
+				} else if (datatype.builtin_type == Variant::DICTIONARY && datatype.has_container_element_types()) {
+					GDScriptParser::DataType key = datatype.get_container_element_type_or_variant(0);
+					GDScriptParser::DataType value = datatype.get_container_element_type_or_variant(1);
+					Dictionary dictionary = make_dictionary_from_element_datatype(key, value);
+					dictionary.assign(result);
+					result = dictionary;
+				} else if (result.get_type() != datatype.builtin_type) {
+					Variant converted_to;
+					const Variant *converted_from = &result;
+					Callable::CallError call_error;
+					Variant::construct(datatype.builtin_type, converted_to, &converted_from, 1, call_error);
+					if (call_error.error == Callable::CallError::CALL_OK) {
+						result = converted_to;
+					}
+				}
 			}
 		}
 	} else {
-		GDScriptParser::DataType datatype = p_variable->get_datatype();
 		if (datatype.is_hard_type()) {
 			if (datatype.kind == GDScriptParser::DataType::BUILTIN && datatype.builtin_type != Variant::OBJECT) {
 				if (datatype.builtin_type == Variant::ARRAY && datatype.has_container_element_type(0)) {

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -5620,10 +5620,14 @@ Variant GDScriptAnalyzer::make_variable_default_value(GDScriptParser::VariableNo
 	Variant result = Variant();
 
 	if (p_variable->initializer) {
-		bool is_initializer_value_reduced = false;
-		Variant initializer_value = make_expression_reduced_value(p_variable->initializer, is_initializer_value_reduced);
-		if (is_initializer_value_reduced) {
-			result = initializer_value;
+		if (p_variable->initializer->is_constant) {
+			result = p_variable->initializer->reduced_value;
+		} else {
+			bool is_initializer_value_reduced = false;
+			Variant initializer_value = make_expression_reduced_value(p_variable->initializer, is_initializer_value_reduced);
+			if (is_initializer_value_reduced) {
+				result = initializer_value;
+			}
 		}
 	} else {
 		GDScriptParser::DataType datatype = p_variable->get_datatype();


### PR DESCRIPTION
Fixes #116909

make_variable_default_value() was re-reducing constant initializers. For exported typed defaults like @export var float32_array: PackedFloat32Array = [], this could cache the default as an untyped Array and break save/load defaults

This change uses `initializer->reduced_value` when the initializer is already constant.
