### PR TITLE
Bypass physics command queue during physics processing

### DIFF
--- a/servers/physics_2d/physics_server_2d_wrap_mt.h
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.h
@@ -35,7 +35,7 @@
 #include "core/templates/command_queue_mt.h"
 #include "servers/physics_2d/physics_server_2d.h"
 
-#define ASYNC_COND_PUSH (Thread::get_caller_id() != server_thread)
+#define ASYNC_COND_PUSH (Thread::get_caller_id() != server_thread && !(doing_sync.is_set() && Thread::is_main_thread()))
 #define ASYNC_COND_PUSH_AND_RET (Thread::get_caller_id() != server_thread && !(doing_sync.is_set() && Thread::is_main_thread()))
 #define ASYNC_COND_PUSH_AND_SYNC (Thread::get_caller_id() != server_thread && !(doing_sync.is_set() && Thread::is_main_thread()))
 

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -35,7 +35,7 @@
 #include "core/templates/command_queue_mt.h"
 #include "servers/physics_3d/physics_server_3d.h"
 
-#define ASYNC_COND_PUSH (Thread::get_caller_id() != server_thread)
+#define ASYNC_COND_PUSH (Thread::get_caller_id() != server_thread && !(doing_sync.is_set() && Thread::is_main_thread()))
 #define ASYNC_COND_PUSH_AND_RET (Thread::get_caller_id() != server_thread && !(doing_sync.is_set() && Thread::is_main_thread()))
 #define ASYNC_COND_PUSH_AND_SYNC (Thread::get_caller_id() != server_thread && !(doing_sync.is_set() && Thread::is_main_thread()))
 


### PR DESCRIPTION
Relates to #109591.
Fixes #109213.
Fixes #113270.
Supersedes #116897.

> [!NOTE]
> While this is labeled as a regression fix, this is not strictly a regression. #109591 just made much more apparent the race conditions that have been present for years, likely since `physics/*d/run_on_separate_thread` was first introduced.

This makes it so that physics server commands are not queued up at all [during physics processing](https://github.com/godotengine/godot/blob/74de2ec0477690f9b1817c15741117ef929d3249/main/main.cpp#L4937-L4981) when `physics/*d/run_on_separate_thread` is enabled, and will instead be invoked immediately/synchronously. The only things that will be queued up to run asynchronously now is `PhysicsServer*D::step()` (which is still significant) or stuff done during idle processing.

This can potentially have a non-trivial performance impact for projects that rely on `physics/*d/run_on_separate_thread` and are doing many costly physics-related state changes in things like `_physics_process`.

This is unfortunately somewhat necessary because physics queries do not currently force a flush of the command queue, which leads to physics queries potentially operating on stale physics data, leading to issues like the ones seen in #109213 and #113270.

While there could be a reasonable argument for exposing some way to forcefully flush the physics command queue instead, it would need to be called in unintuitive places and would lead to weird/drastic/unintuitive performance pitfalls, so I've opted to go with this simpler (albeit much more aggressive) approach instead.