### PR TITLE
Fix materials with inverted depth always being invisible with proximity fade

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1851,14 +1851,16 @@ void fragment() {)";
 	}
 
 	if (proximity_fade_enabled) {
-		code += R"(
+		// Invert proximity fade direction if using inverted depth. Otherwise, the material is never visible with proximity fade enabled.
+		code += vformat(R"(
 	// Proximity Fade: Enabled
 	float proximity_depth_tex = textureLod(depth_texture, SCREEN_UV, 0.0).r;
 	vec4 ndc = OUTPUT_IS_SRGB ? vec4(vec3(SCREEN_UV, proximity_depth_tex) * 2.0 - 1.0, 1.0) : vec4(SCREEN_UV * 2.0 - 1.0, proximity_depth_tex, 1.0);
 	vec4 proximity_view_pos = INV_PROJECTION_MATRIX * ndc;
 	proximity_view_pos.xyz /= proximity_view_pos.w;
-	ALPHA *= clamp(1.0 - smoothstep(proximity_view_pos.z + proximity_fade_distance, proximity_view_pos.z, VERTEX.z), 0.0, 1.0);
-)";
+	ALPHA *= clamp(1.0 - smoothstep(proximity_view_pos.z %s proximity_fade_distance, proximity_view_pos.z, VERTEX.z), 0.0, 1.0);
+)",
+				depth_test == DEPTH_TEST_INVERTED ? "-" : "+");
 	}
 
 	if (distance_fade != DISTANCE_FADE_DISABLED) {


### PR DESCRIPTION
This inverts the proximity fade distance calculation when inverted depth is used, so that the material can be visible according to the difference between its depth and the surrounding materials.

- This closes https://github.com/godotengine/godot/issues/117269.

**Testing project:** [test_proximity_fade_inverted_depth.zip](https://github.com/user-attachments/files/25855385/test_proximity_fade_inverted_depth.zip)

## Preview

*Materials in the back have proximity fade disabled. Materials in the front have proximity fade enabled.*

Before | After
-|-
<img width="722" height="475" alt="Screenshot_20260310_002524" src="https://github.com/user-attachments/assets/6e479564-6e00-494b-a038-b93822270435" /> | <img width="722" height="475" alt="Screenshot_20260310_002506" src="https://github.com/user-attachments/assets/de3eba3c-5ebb-4921-b449-cf6b1e2f6bf6" />
