### PR TITLE
Mention `RenderingServer.instance_set_ignore_culling()` affecting visual layer culling

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2002,7 +2002,7 @@
 			<param index="0" name="instance" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If [code]true[/code], ignores both frustum and occlusion culling on the specified 3D geometry instance. This is not the same as [member GeometryInstance3D.ignore_occlusion_culling], which only ignores occlusion culling and leaves frustum culling intact.
+				If [code]true[/code], ignores frustum culling, occlusion culling, and visual layer culling on the specified 3D geometry instance. This is not the same as [member GeometryInstance3D.ignore_occlusion_culling], which only ignores occlusion culling and leaves other forms of culling intact.
 			</description>
 		</method>
 		<method name="instance_set_layer_mask">


### PR DESCRIPTION
Confirmed on 4.7.dev 74de2ec04 on a MeshInstance3D with no layers active.

```gdscript
extends Node3D

func _ready() -> void:
	RenderingServer.instance_set_ignore_culling($MeshInstance3D.get_instance(), true)
```

- See https://github.com/godotengine/godot-docs-user-notes/discussions/42#discussioncomment-16015168.
