### PR TITLE
Add `interface/editor/fonts/custom_font_scale`

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1073,6 +1073,9 @@
 		<member name="interface/editor/fonts/code_font_size" type="int" setter="" getter="">
 			The size of the font in the script editor. This setting does not impact the font size of the Output panel (see [member run/output/font_size]).
 		</member>
+		<member name="interface/editor/fonts/custom_font_scale" type="float" setter="" getter="">
+			The scale factor for various editor font sizes. Affects main, code, help, and output font sizes. Does not scale other interface elements.
+		</member>
 		<member name="interface/editor/fonts/font_allow_msdf" type="bool" setter="" getter="">
 			If set to [code]true[/code], MSDF font rendering will be used for the visual shader graph editor. You may need to set this to [code]false[/code] when using a custom main font, as some fonts will look broken due to the use of self-intersecting outlines in their font data. Downloading the font from the font maker's official website as opposed to a service like Google Fonts can help resolve this issue.
 		</member>

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1917,7 +1917,8 @@ void CodeTextEditor::_zoom_to(float p_zoom_factor) {
 
 void CodeTextEditor::set_zoom_factor(float p_zoom_factor) {
 	zoom_factor = CLAMP(p_zoom_factor, 0.25f, 3.0f);
-	int neutral_font_size = int(EDITOR_GET("interface/editor/fonts/code_font_size")) * EDSCALE;
+	const float custom_font_scale = EDITOR_GET("interface/editor/fonts/custom_font_scale");
+	int neutral_font_size = Math::round(int(EDITOR_GET("interface/editor/fonts/code_font_size")) * custom_font_scale) * EDSCALE;
 	int new_font_size = Math::round(zoom_factor * neutral_font_size);
 
 	zoom_button->set_text(itos(Math::round(zoom_factor * 100)) + " %");

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -519,6 +519,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/appearance/expand_to_title", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED | PROPERTY_USAGE_EDITOR_BASIC_SETTING)
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/appearance/max_sticky_tree_items", 6, "0,16")
 
+	EDITOR_SETTING_BASIC(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/editor/fonts/custom_font_scale", 1.0, "0.75,1.25,0.01")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/fonts/main_font_size", 14, "8,48,1")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/fonts/code_font_size", 14, "8,48,1")
 	_initial_set("interface/editor/fonts/main_font_custom_opentype_features", "");

--- a/editor/themes/editor_fonts.cpp
+++ b/editor/themes/editor_fonts.cpp
@@ -152,7 +152,8 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	}
 
 	// Load built-in fonts.
-	const int default_font_size = int(EDITOR_GET("interface/editor/fonts/main_font_size")) * EDSCALE;
+	const float custom_font_scale = EDITOR_GET("interface/editor/fonts/custom_font_scale");
+	const int default_font_size = Math::round(int(EDITOR_GET("interface/editor/fonts/main_font_size")) * custom_font_scale) * EDSCALE;
 	const float embolden_strength = 0.6;
 
 	Ref<Font> default_font = load_internal_font(_font_Inter_Regular, _font_Inter_Regular_size, font_hinting, font_antialiasing, true, font_subpixel_positioning, font_disable_embedded_bitmaps, false);
@@ -529,15 +530,15 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	p_theme->set_font("bold_italics_font", "RichTextLabel", bold_italic_fc);
 
 	// Documentation fonts
-	p_theme->set_font_size("doc_size", EditorStringName(EditorFonts), int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
+	p_theme->set_font_size("doc_size", EditorStringName(EditorFonts), Math::round(int(EDITOR_GET("text_editor/help/help_font_size")) * custom_font_scale) * EDSCALE);
 	p_theme->set_font("doc", EditorStringName(EditorFonts), default_fc);
 	p_theme->set_font("doc_bold", EditorStringName(EditorFonts), bold_fc);
 	p_theme->set_font("doc_italic", EditorStringName(EditorFonts), italic_fc);
-	p_theme->set_font_size("doc_title_size", EditorStringName(EditorFonts), int(EDITOR_GET("text_editor/help/help_title_font_size")) * EDSCALE);
+	p_theme->set_font_size("doc_title_size", EditorStringName(EditorFonts), Math::round(int(EDITOR_GET("text_editor/help/help_title_font_size")) * custom_font_scale) * EDSCALE);
 	p_theme->set_font("doc_title", EditorStringName(EditorFonts), bold_fc);
-	p_theme->set_font_size("doc_source_size", EditorStringName(EditorFonts), int(EDITOR_GET("text_editor/help/help_source_font_size")) * EDSCALE);
+	p_theme->set_font_size("doc_source_size", EditorStringName(EditorFonts), Math::round(int(EDITOR_GET("text_editor/help/help_source_font_size")) * custom_font_scale) * EDSCALE);
 	p_theme->set_font("doc_source", EditorStringName(EditorFonts), mono_fc);
-	p_theme->set_font_size("doc_keyboard_size", EditorStringName(EditorFonts), (int(EDITOR_GET("text_editor/help/help_source_font_size")) - 1) * EDSCALE);
+	p_theme->set_font_size("doc_keyboard_size", EditorStringName(EditorFonts), (Math::round(int(EDITOR_GET("text_editor/help/help_source_font_size")) * custom_font_scale) - 1) * EDSCALE);
 	p_theme->set_font("doc_keyboard", EditorStringName(EditorFonts), mono_fc);
 
 	// Ruler font
@@ -549,13 +550,13 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	p_theme->set_font("rotation_control", EditorStringName(EditorFonts), default_fc);
 
 	// Code font
-	p_theme->set_font_size("source_size", EditorStringName(EditorFonts), int(EDITOR_GET("interface/editor/fonts/code_font_size")) * EDSCALE);
+	p_theme->set_font_size("source_size", EditorStringName(EditorFonts), Math::round(int(EDITOR_GET("interface/editor/fonts/code_font_size")) * custom_font_scale) * EDSCALE);
 	p_theme->set_font("source", EditorStringName(EditorFonts), mono_fc);
 
-	p_theme->set_font_size("expression_size", EditorStringName(EditorFonts), (int(EDITOR_GET("interface/editor/fonts/code_font_size")) - 1) * EDSCALE);
+	p_theme->set_font_size("expression_size", EditorStringName(EditorFonts), (Math::round(int(EDITOR_GET("interface/editor/fonts/code_font_size")) * custom_font_scale) - 1) * EDSCALE);
 	p_theme->set_font("expression", EditorStringName(EditorFonts), mono_other_fc);
 
-	p_theme->set_font_size("output_source_size", EditorStringName(EditorFonts), int(EDITOR_GET("run/output/font_size")) * EDSCALE);
+	p_theme->set_font_size("output_source_size", EditorStringName(EditorFonts), Math::round(int(EDITOR_GET("run/output/font_size")) * custom_font_scale) * EDSCALE);
 	p_theme->set_font("output_source", EditorStringName(EditorFonts), mono_other_fc);
 	p_theme->set_font("output_source_bold", EditorStringName(EditorFonts), mono_other_fc_bold);
 	p_theme->set_font("output_source_italic", EditorStringName(EditorFonts), mono_other_fc_italic);


### PR DESCRIPTION
Adds an option to the editor settings for scaling all configurable font sizes. Applies to `interface/editor/fonts/main_font_size`, `interface/editor/fonts/code_font_size`, `text_editor/help/help_font_size`, `text_editor/help/help_source_font_size`, `text_editor/help/help_title_font_size`, and `run/output/font_size`.

If the user wants to change all interface font sizes at once, they can use this option instead of manually adjusting each font size setting. This may be useful for users with low PPI monitors, for whom text may appear large and take up a lot of space. It may also be useful for users with poor vision who would like to increase the font size.

This setting does not scale font sizes that are not included in the editor settings. For example, text on rulers, on rotation control, in texture preview, etc. Perhaps a font size setting should be added for the latter.

https://github.com/user-attachments/assets/1227513e-d534-469a-98fc-d7311a28c1e8

Closes https://github.com/godotengine/godot-proposals/issues/14411