### PR TITLE
Optimize AnimationTree, Improve internals & Editor & `Node::process_thread_group` safety

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -225,6 +225,12 @@
 				Emitted by nodes that inherit from this class and that have an internal tree when one of their animation node names changes. The animation nodes that emit this signal are [AnimationNodeBlendSpace1D], [AnimationNodeBlendSpace2D], [AnimationNodeStateMachine], and [AnimationNodeBlendTree].
 			</description>
 		</signal>
+		<signal name="node_updated" experimental="">
+			<param index="0" name="object_id" type="int" />
+			<description>
+				Emitted by [AnimationNodeAnimation] when its [member AnimationNodeAnimation.animation] resource is changed, or by [AnimationNodeBlendTree] when its connections change.
+			</description>
+		</signal>
 		<signal name="tree_changed">
 			<description>
 				Emitted by nodes that inherit from this class and that have an internal tree when one of their animation nodes changes. The animation nodes that emit this signal are [AnimationNodeBlendSpace1D], [AnimationNodeBlendSpace2D], [AnimationNodeStateMachine], [AnimationNodeBlendTree] and [AnimationNodeTransition].

--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -45,6 +45,7 @@
 #include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
+#include "scene/gui/rich_text_label.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/spin_box.h"
 #include "scene/main/timer.h"
@@ -88,7 +89,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 			animations_to_add.clear();
 
 			LocalVector<StringName> classes;
-			ClassDB::get_inheriters_from_class("AnimationRootNode", classes);
+			ClassDB::get_inheriters_from_class(SNAME("AnimationRootNode"), classes);
 			classes.sort_custom<StringName::AlphCompare>();
 
 			menu->add_submenu_node_item(TTR("Add Animation"), animations_menu);
@@ -730,7 +731,7 @@ void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			error_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
-			error_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 			panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
 			tool_blend->set_button_icon(get_editor_theme_icon(SNAME("EditPivot")));
 			tool_select->set_button_icon(get_editor_theme_icon(SNAME("ToolSelect")));
@@ -750,18 +751,7 @@ void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 				return;
 			}
 
-			String error;
-
-			error = tree->get_editor_error_message();
-
-			if (error != error_label->get_text()) {
-				error_label->set_text(error);
-				if (!error.is_empty()) {
-					error_panel->show();
-				} else {
-					error_panel->hide();
-				}
-			}
+			update_error_message(tree, error_panel, error_label);
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -1101,8 +1091,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	error_panel = memnew(PanelContainer);
 	add_child(error_panel);
 
-	error_label = memnew(Label);
-	error_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+	error_label = create_error_label_node();
 	error_panel->add_child(error_label);
 	error_panel->hide();
 

--- a/editor/animation/animation_blend_space_1d_editor.h
+++ b/editor/animation/animation_blend_space_1d_editor.h
@@ -77,7 +77,7 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	Control *blend_space_draw = nullptr;
 
 	PanelContainer *error_panel = nullptr;
-	Label *error_label = nullptr;
+	RichTextLabel *error_label = nullptr;
 
 	bool updating = false;
 
@@ -94,7 +94,7 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 
 	PopupMenu *menu = nullptr;
 	PopupMenu *animations_menu = nullptr;
-	Vector<String> animations_to_add;
+	Vector<StringName> animations_to_add;
 	float add_point_pos = 0.0f;
 	Vector<real_t> points;
 

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -51,6 +51,7 @@
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel.h"
 #include "scene/gui/panel_container.h"
+#include "scene/gui/rich_text_label.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/spin_box.h"
 #include "scene/main/timer.h"
@@ -970,7 +971,7 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			error_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
-			error_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 			panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
 			tool_blend->set_button_icon(get_editor_theme_icon(SNAME("EditPivot")));
 			tool_select->set_button_icon(get_editor_theme_icon(SNAME("ToolSelect")));
@@ -992,22 +993,7 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 				return;
 			}
 
-			String error;
-
-			error = tree->get_editor_error_message();
-
-			if (error.is_empty() && blend_space->get_triangle_count() == 0) {
-				error = TTR("No triangles exist, so no blending can take place.");
-			}
-
-			if (error != error_label->get_text()) {
-				error_label->set_text(error);
-				if (!error.is_empty()) {
-					error_panel->show();
-				} else {
-					error_panel->hide();
-				}
-			}
+			update_error_message(tree, error_panel, error_label);
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -1405,8 +1391,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 
 	error_panel = memnew(PanelContainer);
 	add_child(error_panel);
-	error_label = memnew(Label);
-	error_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+	error_label = create_error_label_node();
 	error_panel->add_child(error_label);
 	error_panel->hide();
 

--- a/editor/animation/animation_blend_space_2d_editor.h
+++ b/editor/animation/animation_blend_space_2d_editor.h
@@ -85,7 +85,7 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	Control *blend_space_draw = nullptr;
 
 	PanelContainer *error_panel = nullptr;
-	Label *error_label = nullptr;
+	RichTextLabel *error_label = nullptr;
 
 	bool updating;
 
@@ -102,7 +102,7 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 
 	PopupMenu *menu = nullptr;
 	PopupMenu *animations_menu = nullptr;
-	Vector<String> animations_to_add;
+	Vector<StringName> animations_to_add;
 	Vector2 add_point_pos;
 	Vector<Vector2> points;
 

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -50,6 +50,7 @@
 #include "scene/gui/menu_button.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/progress_bar.h"
+#include "scene/gui/rich_text_label.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/view_panner.h"
 #include "scene/main/window.h"
@@ -122,6 +123,18 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 	if (updating || blend_tree.is_null()) {
 		return;
 	}
+	if (graph_update_queued) {
+		return;
+	}
+	graph_update_queued = true;
+	// Defer to idle time, so multiple requests can be merged.
+	callable_mp(this, &AnimationNodeBlendTreeEditor::update_graph_immediately).call_deferred();
+}
+
+void AnimationNodeBlendTreeEditor::update_graph_immediately() {
+	if (updating || blend_tree.is_null()) {
+		return;
+	}
 
 	AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
 	if (!tree) {
@@ -131,7 +144,7 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 	visible_properties.clear();
 
 	// Store selected nodes before clearing the graph.
-	List<StringName> selected_nodes;
+	LocalVector<StringName> selected_nodes;
 	for (int i = 0; i < graph->get_child_count(); i++) {
 		GraphNode *gn = Object::cast_to<GraphNode>(graph->get_child(i));
 		if (gn && gn->is_selected()) {
@@ -167,6 +180,7 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 
 		node->set_title(agnode->get_caption());
 		node->set_name(E);
+		node->set_meta(animation_node_name_meta, E);
 
 		int base = 0;
 		if (E != SceneStringName(output)) {
@@ -177,8 +191,8 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 			name->set_custom_minimum_size(Vector2(100, 0) * EDSCALE);
 			node->add_child(name);
 			node->set_slot(0, false, 0, Color(), true, read_only ? -1 : 0, get_theme_color(SceneStringName(font_color), SNAME("Label")));
-			name->connect(SceneStringName(text_submitted), callable_mp(this, &AnimationNodeBlendTreeEditor::_node_renamed).bind(agnode), CONNECT_DEFERRED);
-			name->connect(SceneStringName(focus_exited), callable_mp(this, &AnimationNodeBlendTreeEditor::_node_renamed_focus_out).bind(agnode), CONNECT_DEFERRED);
+			name->connect(SceneStringName(text_submitted), callable_mp(this, &AnimationNodeBlendTreeEditor::_node_renamed).bind(agnode, E), CONNECT_DEFERRED);
+			name->connect(SceneStringName(focus_exited), callable_mp(this, &AnimationNodeBlendTreeEditor::_node_renamed_focus_out).bind(agnode, E), CONNECT_DEFERRED);
 			name->connect(SceneStringName(text_changed), callable_mp(this, &AnimationNodeBlendTreeEditor::_node_rename_lineedit_changed), CONNECT_DEFERRED);
 			base = 1;
 			agnode->set_deletable(true);
@@ -201,7 +215,7 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 			node->set_slot(base + i, true, read_only ? -1 : 0, get_theme_color(SceneStringName(font_color), SNAME("Label")), false, 0, Color());
 		}
 
-		List<PropertyInfo> pinfo;
+		LocalVector<PropertyInfo> pinfo;
 		agnode->get_parameter_list(&pinfo);
 		for (const PropertyInfo &F : pinfo) {
 			if (!(F.usage & PROPERTY_USAGE_EDITOR)) {
@@ -221,7 +235,7 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 				}
 				prop->set_name_split_ratio(ratio);
 				prop->update_property();
-				prop->connect("property_changed", callable_mp(this, &AnimationNodeBlendTreeEditor::_property_changed));
+				prop->connect(SNAME("property_changed"), callable_mp(this, &AnimationNodeBlendTreeEditor::_property_changed));
 
 				if (F.hint == PROPERTY_HINT_RESOURCE_TYPE) {
 					// Give the resource editor some more space to make the inside readable.
@@ -235,7 +249,7 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 			}
 		}
 
-		node->connect("dragged", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_dragged).bind(E));
+		node->connect(SNAME("dragged"), callable_mp(this, &AnimationNodeBlendTreeEditor::_node_dragged).bind(E));
 
 		if (AnimationTreeEditor::get_singleton()->can_edit(agnode)) {
 			node->add_child(memnew(HSeparator));
@@ -285,25 +299,25 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 			animations[E] = pb;
 			node->add_child(pb);
 
-			mb->get_popup()->connect("index_pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_anim_selected).bind(options, E), CONNECT_DEFERRED);
+			mb->get_popup()->connect(SNAME("index_pressed"), callable_mp(this, &AnimationNodeBlendTreeEditor::_anim_selected).bind(options, E), CONNECT_DEFERRED);
 		}
 
-		Ref<StyleBox> sb_panel = node->get_theme_stylebox(SceneStringName(panel), "GraphNode")->duplicate();
+		Ref<StyleBox> sb_panel = node->get_theme_stylebox(SceneStringName(panel), SNAME("GraphNode"))->duplicate();
 		if (sb_panel.is_valid()) {
 			sb_panel->set_content_margin(SIDE_TOP, 12 * EDSCALE);
 			sb_panel->set_content_margin(SIDE_BOTTOM, 12 * EDSCALE);
 			node->add_theme_style_override(SceneStringName(panel), sb_panel);
 		}
 
-		node->add_theme_constant_override("separation", 4 * EDSCALE);
+		node->add_theme_constant_override(SNAME("separation"), 4 * EDSCALE);
 	}
 
-	List<AnimationNodeBlendTree::NodeConnection> node_connections;
+	LocalVector<AnimationNodeBlendTree::NodeConnection> node_connections;
 	blend_tree->get_node_connections(&node_connections);
 
 	for (const AnimationNodeBlendTree::NodeConnection &E : node_connections) {
-		StringName from = E.output_node;
-		StringName to = E.input_node;
+		const StringName &from = E.output_node;
+		const StringName &to = E.input_node;
 		int to_idx = E.input_index;
 
 		graph->connect_node(from, 0, to, to_idx);
@@ -324,6 +338,48 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 			}
 		}
 	}
+
+	graph_update_queued = false;
+}
+
+void AnimationNodeBlendTreeEditor::pan_to_node(const StringName &p_node_name, int p_input_index) {
+	GraphNode *target_node = nullptr;
+	for (int i = 0; i < graph->get_child_count(); i++) {
+		if (GraphNode *gn = Object::cast_to<GraphNode>(graph->get_child(i)); gn && gn->has_meta(animation_node_name_meta)) {
+			if (gn->get_meta(animation_node_name_meta).operator StringName() == p_node_name) {
+				target_node = gn;
+				break;
+			}
+		}
+	}
+	ERR_FAIL_NULL(target_node);
+
+	Vector2 position = target_node->get_position_offset();
+	if (p_input_index != -1) {
+		const Vector2 slot_pos = target_node->get_input_port_position(p_input_index);
+		position += slot_pos;
+	} else {
+		position += target_node->get_size() * 0.5f; // Center of the node.
+	}
+	const Vector2 target = position * graph->get_zoom() - graph->get_size() * 0.5f;
+
+	if (pan_to_tween.is_valid()) {
+		pan_to_tween->kill();
+	}
+	pan_to_tween = Ref<Tween>(graph->create_tween());
+
+	bool is_close_enough = graph->get_scroll_offset().distance_to(target) < 10.0f;
+	if (!is_close_enough) {
+		pan_to_tween
+				->set_trans(Tween::TRANS_CUBIC)
+				->set_ease(Tween::EASE_OUT)
+				->tween_method(callable_mp(graph, &GraphEdit::set_scroll_offset), graph->get_scroll_offset(), target, 0.25);
+	}
+
+	pan_to_tween->tween_property(target_node, NodePath("modulate"), Color(1, 1, 1, 1) * 10, 0.05);
+	pan_to_tween->set_trans(Tween::TRANS_LINEAR)
+			->set_ease(Tween::EASE_OUT)
+			->tween_property(target_node, NodePath("modulate"), Color(1, 1, 1, 1), 0.3);
 }
 
 void AnimationNodeBlendTreeEditor::_file_opened(const String &p_file) {
@@ -547,7 +603,7 @@ void AnimationNodeBlendTreeEditor::_delete_node_request(const String &p_which) {
 	undo_redo->add_do_method(blend_tree.ptr(), "remove_node", p_which);
 	undo_redo->add_undo_method(blend_tree.ptr(), "add_node", p_which, blend_tree->get_node(p_which), blend_tree.ptr()->get_node_position(p_which));
 
-	List<AnimationNodeBlendTree::NodeConnection> conns;
+	LocalVector<AnimationNodeBlendTree::NodeConnection> conns;
 	blend_tree->get_node_connections(&conns);
 
 	for (const AnimationNodeBlendTree::NodeConnection &E : conns) {
@@ -795,13 +851,13 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 
 	updating = true;
 
-	HashSet<String> paths;
-	HashMap<String, RBSet<String>> types;
+	HashSet<NodePath> paths;
+	HashMap<NodePath, RBSet<String>> types;
 	{
 		for (const StringName &E : tree->get_sorted_animation_list()) {
 			Ref<Animation> anim = tree->get_animation(E);
 			for (int i = 0; i < anim->get_track_count(); i++) {
-				String track_path = String(anim->track_get_path(i));
+				NodePath track_path = anim->track_get_path(i);
 				paths.insert(track_path);
 
 				String track_type_name;
@@ -832,8 +888,7 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 
 	HashMap<String, TreeItem *> parenthood;
 
-	for (const String &E : paths) {
-		NodePath path = E;
+	for (const NodePath &path : paths) {
 		TreeItem *ti = nullptr;
 		String accum;
 		for (int i = 0; i < path.get_name_count(); i++) {
@@ -853,8 +908,8 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 				ti->set_selectable(0, false);
 				ti->set_editable(0, false);
 
-				if (base->has_node(accum)) {
-					Node *node = base->get_node(accum);
+				Node *node = base->get_node_or_null(accum);
+				if (node) {
 					ti->set_icon(0, EditorNode::get_singleton()->get_object_icon(node));
 				}
 
@@ -863,10 +918,7 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 			}
 		}
 
-		Node *node = nullptr;
-		if (base->has_node(accum)) {
-			node = base->get_node(accum);
-		}
+		Node *node = base->get_node_or_null(accum);
 		if (!node) {
 			continue; //no node, can't edit
 		}
@@ -991,7 +1043,7 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 
 		case NOTIFICATION_THEME_CHANGED: {
 			error_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
-			error_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 
 			if (is_visible_in_tree()) {
 				update_graph();
@@ -1004,20 +1056,13 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 				return; // Node has been changed.
 			}
 
-			String error;
-
-			error = tree->get_editor_error_message();
-
-			if (error != error_label->get_text()) {
-				error_label->set_text(error);
-				if (!error.is_empty()) {
-					error_panel->show();
-				} else {
-					error_panel->hide();
-				}
+			if (graph_update_queued) {
+				return;
 			}
 
-			List<AnimationNodeBlendTree::NodeConnection> conns;
+			update_error_message(tree, error_panel, error_label);
+
+			LocalVector<AnimationNodeBlendTree::NodeConnection> conns;
 			blend_tree->get_node_connections(&conns);
 			for (const AnimationNodeBlendTree::NodeConnection &E : conns) {
 				float activity = 0;
@@ -1091,7 +1136,7 @@ void AnimationNodeBlendTreeEditor::_node_changed(const StringName &p_node_name) 
 	update_graph();
 }
 
-void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<AnimationNode> p_node) {
+void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<AnimationNode> p_node, const StringName &p_name) {
 	if (blend_tree.is_null()) {
 		return;
 	}
@@ -1101,13 +1146,14 @@ void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<Anima
 		return;
 	}
 
-	String prev_name = blend_tree->get_node_name(p_node);
+	String prev_name = p_name;
 	ERR_FAIL_COND(prev_name.is_empty());
 	GraphNode *gn = Object::cast_to<GraphNode>(graph->get_node(prev_name));
 	ERR_FAIL_NULL(gn);
 
 	const String &new_name = p_text;
 
+	ERR_FAIL_COND_MSG(String(p_name).validate_node_name() != p_name, "Invalid AnimationNode name, ignoring rename.");
 	ERR_FAIL_COND(new_name.is_empty() || new_name.contains_char('.') || new_name.contains_char('/'));
 
 	if (new_name == prev_name) {
@@ -1134,6 +1180,7 @@ void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<Anima
 	undo_redo->commit_action();
 	updating = false;
 	gn->set_name(new_name);
+	gn->set_meta(animation_node_name_meta, new_name);
 	gn->set_size(gn->get_minimum_size());
 
 	//change editors accordingly
@@ -1148,7 +1195,7 @@ void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<Anima
 	//recreate connections
 	graph->clear_connections();
 
-	List<AnimationNodeBlendTree::NodeConnection> node_connections;
+	LocalVector<AnimationNodeBlendTree::NodeConnection> node_connections;
 	blend_tree->get_node_connections(&node_connections);
 
 	for (const AnimationNodeBlendTree::NodeConnection &E : node_connections) {
@@ -1172,11 +1219,11 @@ void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<Anima
 	current_node_rename_text = String();
 }
 
-void AnimationNodeBlendTreeEditor::_node_renamed_focus_out(Ref<AnimationNode> p_node) {
+void AnimationNodeBlendTreeEditor::_node_renamed_focus_out(Ref<AnimationNode> p_node, const StringName &p_name) {
 	if (current_node_rename_text.is_empty()) {
 		return; // The text_submitted signal triggered the graph update and freed the LineEdit.
 	}
-	_node_renamed(current_node_rename_text, p_node);
+	_node_renamed(current_node_rename_text, p_node, p_name);
 }
 
 void AnimationNodeBlendTreeEditor::_node_rename_lineedit_changed(const String &p_text) {
@@ -1266,10 +1313,8 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 
 	error_panel = memnew(PanelContainer);
 	add_child(error_panel);
-	error_label = memnew(Label);
-	error_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+	error_label = create_error_label_node();
 	error_panel->add_child(error_label);
-	error_label->set_text("eh");
 
 	filter_dialog = memnew(AcceptDialog);
 	add_child(filter_dialog);

--- a/editor/animation/animation_blend_tree_editor_plugin.h
+++ b/editor/animation/animation_blend_tree_editor_plugin.h
@@ -47,6 +47,7 @@ class EditorFileDialog;
 class EditorProperty;
 class MenuButton;
 class PanelContainer;
+class RichTextLabel;
 class EditorInspectorPluginAnimationNodeAnimation;
 
 class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
@@ -62,7 +63,7 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	bool use_position_from_popup_menu;
 
 	PanelContainer *error_panel = nullptr;
-	Label *error_label = nullptr;
+	RichTextLabel *error_label = nullptr;
 
 	AcceptDialog *filter_dialog = nullptr;
 	Tree *filters = nullptr;
@@ -95,15 +96,17 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	void _add_node(int p_idx);
 	void _update_options_menu(bool p_has_input_ports = false);
 
+	StringName animation_node_name_meta = StringName("_animation_node_name");
 	static AnimationNodeBlendTreeEditor *singleton;
 
 	void _node_dragged(const Vector2 &p_from, const Vector2 &p_to, const StringName &p_which);
-	void _node_renamed(const String &p_text, Ref<AnimationNode> p_node);
-	void _node_renamed_focus_out(Ref<AnimationNode> p_node);
+	void _node_renamed(const String &p_text, Ref<AnimationNode> p_node, const StringName &p_name);
+	void _node_renamed_focus_out(Ref<AnimationNode> p_node, const StringName &p_name);
 	void _node_rename_lineedit_changed(const String &p_text);
 	void _node_changed(const StringName &p_node_name);
 
 	String current_node_rename_text;
+	bool graph_update_queued;
 	bool updating;
 
 	void _connection_request(const String &p_from, int p_from_index, const String &p_to, int p_to_index);
@@ -150,6 +153,7 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	};
 
 	Ref<EditorInspectorPluginAnimationNodeAnimation> animation_node_inspector_plugin;
+	Ref<Tween> pan_to_tween;
 
 protected:
 	void _notification(int p_what);
@@ -167,7 +171,9 @@ public:
 	virtual void edit(const Ref<AnimationNode> &p_node) override;
 
 	void update_graph();
+	void update_graph_immediately();
 
+	void pan_to_node(const StringName &p_node_name, int p_input_index = -1);
 	AnimationNodeBlendTreeEditor();
 };
 

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -986,7 +986,7 @@ void AnimationNodeStateMachineEditor::_add_animation_type(int p_index) {
 
 	anim->set_animation(animations_to_add[p_index]);
 
-	String base_name = animations_to_add[p_index].validate_node_name();
+	String base_name = String(animations_to_add[p_index]).validate_node_name();
 	int base = 1;
 	String name = base_name;
 	while (state_machine->has_node(name)) {
@@ -1666,7 +1666,7 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			panel->add_theme_style_override(SceneStringName(panel), theme_cache.panel_style);
 			error_panel->add_theme_style_override(SceneStringName(panel), theme_cache.error_panel_style);
-			error_label->add_theme_color_override(SceneStringName(font_color), theme_cache.error_color);
+			error_label->add_theme_color_override(SNAME("default_color"), theme_cache.error_color);
 
 			tool_select->set_button_icon(theme_cache.tool_icon_select);
 			tool_create->set_button_icon(theme_cache.tool_icon_create);
@@ -1697,24 +1697,14 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 			Ref<AnimationNodeStateMachinePlayback> playback = tree->get(AnimationTreeEditor::get_singleton()->get_base_path() + "playback");
 
 			if (error_time > 0) {
-				error = error_text;
 				error_time -= get_process_delta_time();
-			} else {
-				error = tree->get_editor_error_message();
 			}
 
-			if (error.is_empty() && playback.is_null()) {
+			if (playback.is_null()) {
 				error = vformat(TTR("No playback resource set at path: %s."), AnimationTreeEditor::get_singleton()->get_base_path() + "playback");
 			}
 
-			if (error != error_label->get_text()) {
-				error_label->set_text(error);
-				if (!error.is_empty()) {
-					error_panel->show();
-				} else {
-					error_panel->hide();
-				}
-			}
+			update_error_message(tree, error_panel, error_label, &error);
 
 			for (int i = 0; i < transition_lines.size(); i++) {
 				int tidx = -1;
@@ -2169,8 +2159,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 
 	error_panel = memnew(PanelContainer);
 	add_child(error_panel);
-	error_label = memnew(Label);
-	error_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+	error_label = create_error_label_node();
 	error_panel->add_child(error_label);
 	error_panel->hide();
 

--- a/editor/animation/animation_state_machine_editor.h
+++ b/editor/animation/animation_state_machine_editor.h
@@ -75,7 +75,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	Control *state_machine_play_pos = nullptr;
 
 	PanelContainer *error_panel = nullptr;
-	Label *error_label = nullptr;
+	RichTextLabel *error_label = nullptr;
 
 	struct ThemeCache {
 		Ref<StyleBox> panel_style;
@@ -144,7 +144,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	PopupMenu *state_machine_menu = nullptr;
 	PopupMenu *end_menu = nullptr;
 	PopupMenu *animations_menu = nullptr;
-	Vector<String> animations_to_add;
+	Vector<StringName> animations_to_add;
 	Vector<String> nodes_to_connect;
 
 	Vector2 add_node_pos;
@@ -280,7 +280,6 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	float fading_pos = 0.0f;
 
 	float error_time = 0.0f;
-	String error_text;
 
 	EditorFileDialog *open_file = nullptr;
 	Ref<AnimationNode> file_loaded;

--- a/editor/animation/animation_tree_editor_plugin.cpp
+++ b/editor/animation/animation_tree_editor_plugin.cpp
@@ -35,17 +35,165 @@
 #include "animation_blend_tree_editor_plugin.h"
 #include "animation_state_machine_editor.h"
 #include "core/object/callable_mp.h"
+#include "core/string/string_buffer.h"
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_node.h"
+#include "editor/editor_string_names.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/gui/button.h"
 #include "scene/gui/margin_container.h"
+#include "scene/gui/rich_text_label.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/separator.h"
+#include "scene/gui/texture_rect.h"
 #include "scene/main/scene_tree.h"
+
+RichTextLabel *AnimationTreeNodeEditorPlugin::create_error_label_node() {
+	RichTextLabel *error_label = memnew(RichTextLabel);
+	error_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+	error_label->set_fit_content(true);
+	error_label->set_h_size_flags(SIZE_EXPAND_FILL);
+	error_label->set_meta_underline(true);
+	error_label->connect("meta_clicked", callable_mp(this, &AnimationTreeNodeEditorPlugin::_meta_clicked));
+	return error_label;
+}
+
+void AnimationTreeNodeEditorPlugin::_meta_clicked(Variant p_meta) {
+	if (p_meta.get_type() != Variant::STRING) {
+		return;
+	}
+	const String raw_info_str = p_meta;
+	const String full_path_str = raw_info_str.get_slice("::", 0);
+	ERR_FAIL_COND(!full_path_str.ends_with("/"));
+
+	int input_index = -1;
+	if (raw_info_str.contains("::")) {
+		const String input_index_str = raw_info_str.get_slice("::", 1);
+		ERR_FAIL_COND(!input_index_str.is_valid_int());
+		input_index = input_index_str.to_int();
+	}
+
+	AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
+	ERR_FAIL_NULL(tree);
+
+	// e.g. "parameters/blend_tree/node_name/" -> "parameters/blend_tree/"
+	String parent_path = full_path_str.rstrip("/").substr(0, full_path_str.rstrip("/").rfind_char('/') + 1);
+
+	Ref<AnimationRootNode> root_node = tree->get_animation_node_by_path(parent_path);
+	ERR_FAIL_COND(root_node.is_null());
+
+	String to_edit_root_path = String(parent_path);
+	to_edit_root_path = to_edit_root_path.replace_first(Animation::PARAMETERS_BASE_PATH, "");
+	to_edit_root_path = to_edit_root_path.trim_suffix("/");
+
+	Vector<String> navigate_to;
+	if (!to_edit_root_path.is_empty()) {
+		// empty string still has 1 element when split.
+		navigate_to = to_edit_root_path.split("/");
+	}
+	if (AnimationTreeEditor::get_singleton()->get_edited_path() != navigate_to) {
+		AnimationTreeEditor::get_singleton()->edit_path(navigate_to);
+	}
+
+	// Special case for AnimationNodeBlendTree.
+	if (Ref<AnimationNodeBlendTree> blend_tree = root_node; blend_tree.is_valid()) {
+		String child_name = full_path_str;
+		child_name = child_name.replace_first(parent_path, "");
+		child_name = child_name.trim_suffix("/");
+		callable_mp(AnimationNodeBlendTreeEditor::get_singleton(), &AnimationNodeBlendTreeEditor::pan_to_node).call_deferred(child_name, input_index);
+	}
+}
+
+void AnimationTreeNodeEditorPlugin::update_error_message(const AnimationTree *p_tree, PanelContainer *p_error_panel, RichTextLabel *p_error_label, const String *p_other_errors) {
+	const String editor_error_message = p_tree->get_editor_error_message();
+	const AHashMap<StringName, AnimationNode::InvalidInstance> &invalid_instances = p_tree->get_invalid_instances();
+
+	if (editor_error_message.is_empty() && invalid_instances.is_empty() && (!p_other_errors || p_other_errors->is_empty())) {
+		last_error_key = String();
+		p_error_panel->hide();
+		return;
+	}
+
+	// Cheaper to do this, than rebuild rich text label every frame.
+	// Though it would be better, to only call this when the tree changes.
+	{
+		StringBuffer k;
+		k += editor_error_message;
+		if (p_other_errors) {
+			k += *p_other_errors;
+		}
+		for (const KeyValue<StringName, AnimationNode::InvalidInstance> &kv : invalid_instances) {
+			k += kv.key;
+			for (const String &reason : kv.value.errors) {
+				k += reason;
+			}
+			for (const AnimationNode::InvalidInstance::InputError &E : kv.value.input_errors) {
+				k += itos(E.index);
+				k += E.error;
+			}
+		}
+
+		String error_key = k.as_string();
+		if (error_key == last_error_key) {
+			return;
+		}
+		last_error_key = error_key;
+	}
+
+	const String point = String::utf8("•  ");
+
+	p_error_label->clear();
+	p_error_label->append_text(editor_error_message);
+	if (p_other_errors) {
+		p_error_label->append_text(*p_other_errors);
+	}
+
+	bool first = true;
+	for (const KeyValue<StringName, AnimationNode::InvalidInstance> &kv : invalid_instances) {
+		if (!first) {
+			p_error_label->add_newline();
+		}
+		first = false;
+
+		Ref<AnimationNode> node = p_tree->get_animation_node_by_path(kv.key);
+		ERR_CONTINUE(node.is_null());
+
+		p_error_label->append_text(vformat(RTR("%s at "), node->get_class()));
+		p_error_label->push_meta(String(kv.key));
+		{
+			p_error_label->append_text(vformat(RTR("'%s'"), kv.key));
+		}
+		p_error_label->pop();
+		p_error_label->append_text(RTR(" has errors.\n"));
+
+		StringBuffer instance_error_builder;
+		for (const String &reason : kv.value.errors) {
+			instance_error_builder += point;
+			instance_error_builder += reason;
+			instance_error_builder += "\n";
+		}
+		p_error_label->append_text(instance_error_builder.as_string());
+
+		// Input errors.
+		String input_error_base = String(kv.key) + "::";
+		for (const AnimationNode::InvalidInstance::InputError &input_error : kv.value.input_errors) {
+			const String input_name = node->get_input_name(input_error.index);
+
+			p_error_label->append_text(point + input_error.error + " ");
+			p_error_label->push_meta(input_error_base + itos(input_error.index));
+			{
+				p_error_label->append_text(vformat(RTR("input %d '%s'."), input_error.index, input_name));
+			}
+			p_error_label->pop();
+			p_error_label->add_newline();
+		}
+	}
+
+	p_error_panel->show();
+}
 
 void AnimationTreeEditor::edit(AnimationTree *p_tree) {
 	if (p_tree && !p_tree->is_connected("animation_list_changed", callable_mp(this, &AnimationTreeEditor::_animation_list_changed))) {
@@ -106,6 +254,14 @@ void AnimationTreeEditor::_update_path() {
 	b->connect(SceneStringName(pressed), callable_mp(this, &AnimationTreeEditor::_path_button_pressed).bind(-1));
 	path_hb->add_child(b);
 	for (int i = 0; i < button_path.size(); i++) {
+		// bread crumbs.
+		TextureRect *texture_rect = memnew(TextureRect);
+		texture_rect->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
+		texture_rect->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
+		texture_rect->set_custom_minimum_size(Size2(16, 16) * EDSCALE);
+		texture_rect->set_texture(get_editor_theme_icon(SNAME("GuiTreeArrowRight")));
+		path_hb->add_child(texture_rect);
+
 		b = memnew(Button);
 		b->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 		b->set_text(button_path[i]);
@@ -128,7 +284,7 @@ void AnimationTreeEditor::edit_path(const Vector<String> &p_path) {
 
 		for (int i = 0; i < p_path.size(); i++) {
 			Ref<AnimationNode> child = node->get_child_by_name(p_path[i]);
-			ERR_BREAK(child.is_null());
+			ERR_BREAK_MSG(child.is_null(), vformat("Cannot edit path '%s': node '%s' not found as child of '%s'.", String("/").join(p_path), p_path[i], node->get_class()));
 			node = child;
 			button_path.push_back(p_path[i]);
 		}

--- a/editor/animation/animation_tree_editor_plugin.h
+++ b/editor/animation/animation_tree_editor_plugin.h
@@ -38,6 +38,7 @@
 class Button;
 class EditorFileDialog;
 class ScrollContainer;
+class RichTextLabel;
 
 class AnimationTreeNodeEditorPlugin : public VBoxContainer {
 	GDCLASS(AnimationTreeNodeEditorPlugin, VBoxContainer);
@@ -45,6 +46,16 @@ class AnimationTreeNodeEditorPlugin : public VBoxContainer {
 public:
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) = 0;
 	virtual void edit(const Ref<AnimationNode> &p_node) = 0;
+
+protected:
+	RichTextLabel *create_error_label_node();
+
+	void _meta_clicked(Variant p_meta);
+
+	void update_error_message(const AnimationTree *p_tree, PanelContainer *p_error_panel, RichTextLabel *p_error_label, const String *p_other_errors = nullptr);
+
+private:
+	String last_error_key;
 };
 
 class AnimationTreeEditor : public EditorDock {

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -36,7 +36,7 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 
-void AnimationNodeBlendSpace1D::get_parameter_list(List<PropertyInfo> *r_list) const {
+void AnimationNodeBlendSpace1D::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::FLOAT, blend_position));
 	r_list->push_back(PropertyInfo(Variant::INT, closest, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
@@ -73,6 +73,14 @@ void AnimationNodeBlendSpace1D::_animation_node_renamed(const ObjectID &p_oid, c
 
 void AnimationNodeBlendSpace1D::_animation_node_removed(const ObjectID &p_oid, const StringName &p_node) {
 	AnimationRootNode::_animation_node_removed(p_oid, p_node);
+}
+
+void AnimationNodeBlendSpace1D::validate_node(const AnimationTree *p_tree, const StringName &p_path) const {
+	AnimationRootNode::validate_node(p_tree, p_path);
+
+	if (get_blend_point_count() == 0) {
+		add_validation_error(p_tree, p_path, RTR("No blend points exist, so blending cannot take place."));
+	}
 }
 
 void AnimationNodeBlendSpace1D::_bind_methods() {
@@ -118,7 +126,7 @@ void AnimationNodeBlendSpace1D::_bind_methods() {
 	BIND_ENUM_CONSTANT(BLEND_MODE_DISCRETE_CARRY);
 }
 
-void AnimationNodeBlendSpace1D::get_child_nodes(List<ChildNode> *r_child_nodes) {
+void AnimationNodeBlendSpace1D::get_child_nodes(LocalVector<ChildNode> *r_child_nodes) {
 	for (int i = 0; i < blend_points_used; i++) {
 		ChildNode cn;
 		cn.name = blend_points[i].name;
@@ -152,12 +160,10 @@ void AnimationNodeBlendSpace1D::add_blend_point(const Ref<AnimationRootNode> &p_
 	blend_points[p_at_index].position = p_position;
 	blend_points[p_at_index].name = p_name;
 
-	blend_points[p_at_index].node->connect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace1D::_tree_changed), CONNECT_REFERENCE_COUNTED);
-	blend_points[p_at_index].node->connect("animation_node_renamed", callable_mp(this, &AnimationNodeBlendSpace1D::_animation_node_renamed), CONNECT_REFERENCE_COUNTED);
-	blend_points[p_at_index].node->connect("animation_node_removed", callable_mp(this, &AnimationNodeBlendSpace1D::_animation_node_removed), CONNECT_REFERENCE_COUNTED);
+	_add_node(blend_points[p_at_index].node);
 
 	blend_points_used++;
-	emit_signal(SNAME("tree_changed"));
+	_tree_changed();
 }
 
 void AnimationNodeBlendSpace1D::set_blend_point_position(int p_point, float p_position) {
@@ -171,17 +177,13 @@ void AnimationNodeBlendSpace1D::set_blend_point_node(int p_point, const Ref<Anim
 	ERR_FAIL_COND(p_node.is_null());
 
 	if (blend_points[p_point].node.is_valid()) {
-		blend_points[p_point].node->disconnect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace1D::_tree_changed));
-		blend_points[p_point].node->disconnect("animation_node_renamed", callable_mp(this, &AnimationNodeBlendSpace1D::_animation_node_renamed));
-		blend_points[p_point].node->disconnect("animation_node_removed", callable_mp(this, &AnimationNodeBlendSpace1D::_animation_node_removed));
+		_remove_node(blend_points[p_point].node);
 	}
 
 	blend_points[p_point].node = p_node;
-	blend_points[p_point].node->connect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace1D::_tree_changed), CONNECT_REFERENCE_COUNTED);
-	blend_points[p_point].node->connect("animation_node_renamed", callable_mp(this, &AnimationNodeBlendSpace1D::_animation_node_renamed), CONNECT_REFERENCE_COUNTED);
-	blend_points[p_point].node->connect("animation_node_removed", callable_mp(this, &AnimationNodeBlendSpace1D::_animation_node_removed), CONNECT_REFERENCE_COUNTED);
+	_add_node(blend_points[p_point].node);
 
-	emit_signal(SNAME("tree_changed"));
+	_tree_changed();
 }
 
 float AnimationNodeBlendSpace1D::get_blend_point_position(int p_point) const {
@@ -206,8 +208,9 @@ void AnimationNodeBlendSpace1D::set_blend_point_name(int p_point, const StringNa
 	}
 }
 
-StringName AnimationNodeBlendSpace1D::get_blend_point_name(int p_point) const {
-	ERR_FAIL_INDEX_V(p_point, blend_points_used, StringName());
+const StringName &AnimationNodeBlendSpace1D::get_blend_point_name(int p_point) const {
+	const static StringName empty = StringName();
+	ERR_FAIL_INDEX_V(p_point, blend_points_used, empty);
 	return blend_points[p_point].name;
 }
 
@@ -224,9 +227,7 @@ void AnimationNodeBlendSpace1D::remove_blend_point(int p_point) {
 	ERR_FAIL_INDEX(p_point, blend_points_used);
 
 	ERR_FAIL_COND(blend_points[p_point].node.is_null());
-	blend_points[p_point].node->disconnect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace1D::_tree_changed));
-	blend_points[p_point].node->disconnect("animation_node_renamed", callable_mp(this, &AnimationNodeBlendSpace1D::_animation_node_renamed));
-	blend_points[p_point].node->disconnect("animation_node_removed", callable_mp(this, &AnimationNodeBlendSpace1D::_animation_node_removed));
+	_remove_node(blend_points[p_point].node);
 
 	for (int i = p_point; i < blend_points_used - 1; i++) {
 		blend_points[i] = blend_points[i + 1];
@@ -237,7 +238,7 @@ void AnimationNodeBlendSpace1D::remove_blend_point(int p_point) {
 	blend_points[blend_points_used].name = StringName();
 
 	emit_signal(SNAME("animation_node_removed"), get_instance_id(), itos(p_point));
-	emit_signal(SNAME("tree_changed"));
+	_tree_changed();
 }
 
 int AnimationNodeBlendSpace1D::get_blend_point_count() const {
@@ -375,7 +376,7 @@ void AnimationNodeBlendSpace1D::_get_property_list(List<PropertyInfo> *p_list) c
 	}
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
+AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
 	if (!blend_points_used) {
 		return NodeTimeInfo();
 	}
@@ -385,11 +386,12 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(const AnimationM
 	if (blend_points_used == 1) {
 		// only one point available, just play that animation
 		pi.weight = 1.0;
-		return blend_node(blend_points[0].node, get_blend_point_name(0), pi, FILTER_IGNORE, true, p_test_only);
+		AnimationNodeInstance &other_instance = p_instance.get_child_instance_by_path(get_blend_point_name(0));
+		return blend_node(p_process_state, p_instance, &other_instance, pi, FILTER_IGNORE, true, p_test_only);
 	}
 
-	double blend_pos = get_parameter(blend_position);
-	int cur_closest = get_parameter(closest);
+	double blend_pos = p_instance.get_parameter(blend_position);
+	int cur_closest = p_instance.get_parameter_closest();
 	NodeTimeInfo mind;
 
 	if (blend_mode == BLEND_MODE_INTERPOLATED) {
@@ -448,7 +450,8 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(const AnimationM
 		for (int i = 0; i < blend_points_used; i++) {
 			if (i == point_lower || i == point_higher) {
 				pi.weight = weights[i];
-				NodeTimeInfo t = blend_node(blend_points[i].node, get_blend_point_name(i), pi, FILTER_IGNORE, true, p_test_only);
+				AnimationNodeInstance &other_instance = p_instance.get_child_instance_by_path(get_blend_point_name(i));
+				NodeTimeInfo t = blend_node(p_process_state, p_instance, &other_instance, pi, FILTER_IGNORE, true, p_test_only);
 				if (first || pi.weight > max_weight) {
 					max_weight = pi.weight;
 					mind = t;
@@ -456,7 +459,8 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(const AnimationM
 				}
 			} else if (sync) {
 				pi.weight = 0;
-				blend_node(blend_points[i].node, get_blend_point_name(i), pi, FILTER_IGNORE, true, p_test_only);
+				AnimationNodeInstance &other_instance = p_instance.get_child_instance_by_path(get_blend_point_name(i));
+				blend_node(p_process_state, p_instance, &other_instance, pi, FILTER_IGNORE, true, p_test_only);
 			}
 		}
 	} else {
@@ -471,34 +475,33 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(const AnimationM
 			}
 		}
 
+		AnimationNodeInstance *instance_current_closest = p_instance.get_child_instance_by_path_or_null(get_blend_point_name(cur_closest));
 		if (new_closest != cur_closest && new_closest != -1) {
+			AnimationNodeInstance *instance_new_closest = p_instance.get_child_instance_by_path_or_null(get_blend_point_name(new_closest));
+
 			if (blend_mode == BLEND_MODE_DISCRETE_CARRY && cur_closest != -1) {
 				NodeTimeInfo from;
 				// For ping-pong loop.
 				Ref<AnimationNodeAnimation> na_c = static_cast<Ref<AnimationNodeAnimation>>(blend_points[cur_closest].node);
 				Ref<AnimationNodeAnimation> na_n = static_cast<Ref<AnimationNodeAnimation>>(blend_points[new_closest].node);
-				if (na_c.is_valid() && na_n.is_valid()) {
-					na_n->process_state = process_state;
-					na_c->process_state = process_state;
-
-					na_n->set_backward(na_c->is_backward());
-
+				if (na_c.is_valid() && na_n.is_valid() && instance_current_closest && instance_new_closest) {
+					na_n->set_backward(*instance_new_closest, p_process_state, na_c->is_backward(*instance_current_closest, p_process_state));
 					na_n = nullptr;
 					na_c = nullptr;
 				}
 				// See how much animation remains.
 				pi.seeked = false;
 				pi.weight = 0;
-				from = blend_node(blend_points[cur_closest].node, get_blend_point_name(cur_closest), pi, FILTER_IGNORE, true, true);
+				from = blend_node(p_process_state, p_instance, instance_current_closest, pi, FILTER_IGNORE, true, true);
 				pi.time = from.position;
 			}
 			pi.seeked = true;
 			pi.weight = 1.0;
-			mind = blend_node(blend_points[new_closest].node, get_blend_point_name(new_closest), pi, FILTER_IGNORE, true, p_test_only);
+			mind = blend_node(p_process_state, p_instance, instance_new_closest, pi, FILTER_IGNORE, true, p_test_only);
 			cur_closest = new_closest;
 		} else {
 			pi.weight = 1.0;
-			mind = blend_node(blend_points[cur_closest].node, get_blend_point_name(cur_closest), pi, FILTER_IGNORE, true, p_test_only);
+			mind = blend_node(p_process_state, p_instance, instance_current_closest, pi, FILTER_IGNORE, true, p_test_only);
 		}
 
 		if (sync) {
@@ -506,13 +509,14 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(const AnimationM
 			pi.weight = 0;
 			for (int i = 0; i < blend_points_used; i++) {
 				if (i != cur_closest) {
-					blend_node(blend_points[i].node, get_blend_point_name(i), pi, FILTER_IGNORE, true, p_test_only);
+					AnimationNodeInstance &other_instance = p_instance.get_child_instance_by_path(get_blend_point_name(i));
+					blend_node(p_process_state, p_instance, &other_instance, pi, FILTER_IGNORE, true, p_test_only);
 				}
 			}
 		}
 	}
 
-	set_parameter(closest, cur_closest);
+	p_instance.set_parameter_closest(cur_closest, p_process_state.is_testing);
 	return mind;
 }
 

--- a/scene/animation/animation_blend_space_1d.h
+++ b/scene/animation/animation_blend_space_1d.h
@@ -86,10 +86,12 @@ protected:
 #endif
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void validate_node(const AnimationTree *p_tree, const StringName &p_path) const override;
+
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
-	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
+	virtual void get_child_nodes(LocalVector<ChildNode> *r_child_nodes) override;
 
 	void add_blend_point(const Ref<AnimationRootNode> &p_node, float p_position, int p_at_index = -1, const StringName &p_name = "");
 	void set_blend_point_position(int p_point, float p_position);
@@ -98,7 +100,7 @@ public:
 	float get_blend_point_position(int p_point) const;
 	Ref<AnimationRootNode> get_blend_point_node(int p_point) const;
 	void set_blend_point_name(int p_point, const StringName &p_name);
-	StringName get_blend_point_name(int p_point) const;
+	const StringName &get_blend_point_name(int p_point) const;
 	int find_blend_point_by_name(const StringName &p_name) const;
 	void remove_blend_point(int p_point);
 	int get_blend_point_count() const;
@@ -123,7 +125,7 @@ public:
 	void set_use_sync(bool p_sync);
 	bool is_using_sync() const;
 
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 	String get_caption() const override;
 
 	Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -37,7 +37,7 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 
-void AnimationNodeBlendSpace2D::get_parameter_list(List<PropertyInfo> *r_list) const {
+void AnimationNodeBlendSpace2D::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::VECTOR2, blend_position));
 	r_list->push_back(PropertyInfo(Variant::INT, closest, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
@@ -56,7 +56,7 @@ Variant AnimationNodeBlendSpace2D::get_parameter_default_value(const StringName 
 	}
 }
 
-void AnimationNodeBlendSpace2D::get_child_nodes(List<ChildNode> *r_child_nodes) {
+void AnimationNodeBlendSpace2D::get_child_nodes(LocalVector<ChildNode> *r_child_nodes) {
 	for (int i = 0; i < blend_points_used; i++) {
 		ChildNode cn;
 		cn.name = blend_points[i].name;
@@ -97,14 +97,12 @@ void AnimationNodeBlendSpace2D::add_blend_point(const Ref<AnimationRootNode> &p_
 	blend_points[p_at_index].position = p_position;
 	blend_points[p_at_index].name = p_name;
 
-	blend_points[p_at_index].node->connect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace2D::_tree_changed), CONNECT_REFERENCE_COUNTED);
-	blend_points[p_at_index].node->connect("animation_node_renamed", callable_mp(this, &AnimationNodeBlendSpace2D::_animation_node_renamed), CONNECT_REFERENCE_COUNTED);
-	blend_points[p_at_index].node->connect("animation_node_removed", callable_mp(this, &AnimationNodeBlendSpace2D::_animation_node_removed), CONNECT_REFERENCE_COUNTED);
+	_add_node(blend_points[p_at_index].node);
 	blend_points_used++;
 
 	_queue_auto_triangles();
 
-	emit_signal(SNAME("tree_changed"));
+	_tree_changed();
 }
 
 void AnimationNodeBlendSpace2D::set_blend_point_position(int p_point, const Vector2 &p_position) {
@@ -118,16 +116,12 @@ void AnimationNodeBlendSpace2D::set_blend_point_node(int p_point, const Ref<Anim
 	ERR_FAIL_COND(p_node.is_null());
 
 	if (blend_points[p_point].node.is_valid()) {
-		blend_points[p_point].node->disconnect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace2D::_tree_changed));
-		blend_points[p_point].node->disconnect("animation_node_renamed", callable_mp(this, &AnimationNodeBlendSpace2D::_animation_node_renamed));
-		blend_points[p_point].node->disconnect("animation_node_removed", callable_mp(this, &AnimationNodeBlendSpace2D::_animation_node_removed));
+		_remove_node(blend_points[p_point].node);
 	}
 	blend_points[p_point].node = p_node;
-	blend_points[p_point].node->connect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace2D::_tree_changed), CONNECT_REFERENCE_COUNTED);
-	blend_points[p_point].node->connect("animation_node_renamed", callable_mp(this, &AnimationNodeBlendSpace2D::_animation_node_renamed), CONNECT_REFERENCE_COUNTED);
-	blend_points[p_point].node->connect("animation_node_removed", callable_mp(this, &AnimationNodeBlendSpace2D::_animation_node_removed), CONNECT_REFERENCE_COUNTED);
+	_add_node(blend_points[p_point].node);
 
-	emit_signal(SNAME("tree_changed"));
+	_tree_changed();
 }
 
 Vector2 AnimationNodeBlendSpace2D::get_blend_point_position(int p_point) const {
@@ -152,8 +146,9 @@ void AnimationNodeBlendSpace2D::set_blend_point_name(int p_point, const StringNa
 	}
 }
 
-StringName AnimationNodeBlendSpace2D::get_blend_point_name(int p_point) const {
-	ERR_FAIL_INDEX_V(p_point, blend_points_used, StringName());
+const StringName &AnimationNodeBlendSpace2D::get_blend_point_name(int p_point) const {
+	const static StringName empty = StringName();
+	ERR_FAIL_INDEX_V(p_point, blend_points_used, empty);
 	return blend_points[p_point].name;
 }
 
@@ -170,9 +165,7 @@ void AnimationNodeBlendSpace2D::remove_blend_point(int p_point) {
 	ERR_FAIL_INDEX(p_point, blend_points_used);
 
 	ERR_FAIL_COND(blend_points[p_point].node.is_null());
-	blend_points[p_point].node->disconnect("tree_changed", callable_mp(this, &AnimationNodeBlendSpace2D::_tree_changed));
-	blend_points[p_point].node->disconnect("animation_node_renamed", callable_mp(this, &AnimationNodeBlendSpace2D::_animation_node_renamed));
-	blend_points[p_point].node->disconnect("animation_node_removed", callable_mp(this, &AnimationNodeBlendSpace2D::_animation_node_removed));
+	_remove_node(blend_points[p_point].node);
 
 	for (int i = 0; i < triangles.size(); i++) {
 		bool erase = false;
@@ -199,7 +192,7 @@ void AnimationNodeBlendSpace2D::remove_blend_point(int p_point) {
 	blend_points[blend_points_used].name = StringName();
 
 	emit_signal(SNAME("animation_node_removed"), get_instance_id(), itos(p_point));
-	emit_signal(SNAME("tree_changed"));
+	_tree_changed();
 }
 
 int AnimationNodeBlendSpace2D::get_blend_point_count() const {
@@ -568,15 +561,15 @@ void AnimationNodeBlendSpace2D::_blend_triangle(const Vector2 &p_pos, const Vect
 	r_weights[2] = w;
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
+AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
 	_update_triangles();
 
 	if (!blend_points_used) {
 		return NodeTimeInfo();
 	}
 
-	Vector2 blend_pos = get_parameter(blend_position);
-	int cur_closest = get_parameter(closest);
+	Vector2 blend_pos = p_instance.get_parameter(blend_position);
+	int cur_closest = p_instance.get_parameter_closest();
 	NodeTimeInfo mind; //time of min distance point
 
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
@@ -643,7 +636,8 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(const AnimationM
 				if (i == triangle_points[j]) {
 					//blend with the given weight
 					pi.weight = blend_weights[j];
-					NodeTimeInfo t = blend_node(blend_points[i].node, get_blend_point_name(i), pi, FILTER_IGNORE, true, p_test_only);
+					AnimationNodeInstance *other_instance = p_instance.get_child_instance_by_path_or_null(get_blend_point_name(i));
+					NodeTimeInfo t = blend_node(p_process_state, p_instance, other_instance, pi, FILTER_IGNORE, true, p_test_only);
 					if (first || pi.weight > max_weight) {
 						mind = t;
 						max_weight = pi.weight;
@@ -656,7 +650,8 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(const AnimationM
 
 			if (sync && !found) {
 				pi.weight = 0;
-				blend_node(blend_points[i].node, get_blend_point_name(i), pi, FILTER_IGNORE, true, p_test_only);
+				AnimationNodeInstance *other_instance = p_instance.get_child_instance_by_path_or_null(get_blend_point_name(i));
+				blend_node(p_process_state, p_instance, other_instance, pi, FILTER_IGNORE, true, p_test_only);
 			}
 		}
 	} else {
@@ -671,34 +666,33 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(const AnimationM
 			}
 		}
 
+		AnimationNodeInstance *instance_current_closest = p_instance.get_child_instance_by_path_or_null(get_blend_point_name(cur_closest));
 		if (new_closest != cur_closest && new_closest != -1) {
+			AnimationNodeInstance *instance_new_closest = p_instance.get_child_instance_by_path_or_null(get_blend_point_name(new_closest));
+
 			if (blend_mode == BLEND_MODE_DISCRETE_CARRY && cur_closest != -1) {
 				NodeTimeInfo from;
 				// For ping-pong loop.
 				Ref<AnimationNodeAnimation> na_c = static_cast<Ref<AnimationNodeAnimation>>(blend_points[cur_closest].node);
 				Ref<AnimationNodeAnimation> na_n = static_cast<Ref<AnimationNodeAnimation>>(blend_points[new_closest].node);
-				if (na_c.is_valid() && na_n.is_valid()) {
-					na_n->process_state = process_state;
-					na_c->process_state = process_state;
-
-					na_n->set_backward(na_c->is_backward());
-
+				if (na_c.is_valid() && na_n.is_valid() && instance_current_closest && instance_new_closest) {
+					na_n->set_backward(*instance_new_closest, p_process_state, na_c->is_backward(*instance_current_closest, p_process_state));
 					na_n = nullptr;
 					na_c = nullptr;
 				}
 				// See how much animation remains.
 				pi.seeked = false;
 				pi.weight = 0;
-				from = blend_node(blend_points[cur_closest].node, get_blend_point_name(cur_closest), pi, FILTER_IGNORE, true, true);
+				from = blend_node(p_process_state, p_instance, instance_current_closest, pi, FILTER_IGNORE, true, true);
 				pi.time = from.position;
 			}
 			pi.seeked = true;
 			pi.weight = 1.0;
-			mind = blend_node(blend_points[new_closest].node, get_blend_point_name(new_closest), pi, FILTER_IGNORE, true, p_test_only);
+			mind = blend_node(p_process_state, p_instance, instance_new_closest, pi, FILTER_IGNORE, true, p_test_only);
 			cur_closest = new_closest;
 		} else {
 			pi.weight = 1.0;
-			mind = blend_node(blend_points[cur_closest].node, get_blend_point_name(cur_closest), pi, FILTER_IGNORE, true, p_test_only);
+			mind = blend_node(p_process_state, p_instance, instance_current_closest, pi, FILTER_IGNORE, true, p_test_only);
 		}
 
 		if (sync) {
@@ -706,13 +700,14 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(const AnimationM
 			pi.weight = 0;
 			for (int i = 0; i < blend_points_used; i++) {
 				if (i != cur_closest) {
-					blend_node(blend_points[i].node, get_blend_point_name(i), pi, FILTER_IGNORE, true, p_test_only);
+					AnimationNodeInstance &other_instance = p_instance.get_child_instance_by_path(get_blend_point_name(i));
+					blend_node(p_process_state, p_instance, &other_instance, pi, FILTER_IGNORE, true, p_test_only);
 				}
 			}
 		}
 	}
 
-	set_parameter(closest, cur_closest);
+	p_instance.set_parameter_closest(cur_closest, p_process_state.is_testing);
 	return mind;
 }
 
@@ -773,6 +768,15 @@ void AnimationNodeBlendSpace2D::_animation_node_renamed(const ObjectID &p_oid, c
 
 void AnimationNodeBlendSpace2D::_animation_node_removed(const ObjectID &p_oid, const StringName &p_node) {
 	AnimationRootNode::_animation_node_removed(p_oid, p_node);
+}
+
+void AnimationNodeBlendSpace2D::validate_node(const AnimationTree *p_tree, const StringName &p_path) const {
+	AnimationRootNode::validate_node(p_tree, p_path);
+
+	const_cast<AnimationNodeBlendSpace2D *>(this)->_update_triangles();
+	if (get_triangle_count() == 0) {
+		add_validation_error(p_tree, p_path, RTR("No triangles exist, so blending cannot take place."));
+	}
 }
 
 void AnimationNodeBlendSpace2D::_bind_methods() {

--- a/scene/animation/animation_blend_space_2d.h
+++ b/scene/animation/animation_blend_space_2d.h
@@ -101,16 +101,18 @@ protected:
 #endif
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void validate_node(const AnimationTree *p_tree, const StringName &p_path) const override;
+
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
-	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
+	virtual void get_child_nodes(LocalVector<ChildNode> *r_child_nodes) override;
 
 	void add_blend_point(const Ref<AnimationRootNode> &p_node, const Vector2 &p_position, int p_at_index = -1, const StringName &p_name = StringName());
 	void set_blend_point_position(int p_point, const Vector2 &p_position);
 	void set_blend_point_node(int p_point, const Ref<AnimationRootNode> &p_node);
 	void set_blend_point_name(int p_point, const StringName &p_name);
-	StringName get_blend_point_name(int p_point) const;
+	const StringName &get_blend_point_name(int p_point) const;
 	int find_blend_point_by_name(const StringName &p_name) const;
 	Vector2 get_blend_point_position(int p_point) const;
 	Ref<AnimationRootNode> get_blend_point_node(int p_point) const;
@@ -140,7 +142,7 @@ public:
 	void set_y_label(const String &p_label);
 	String get_y_label() const;
 
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 	virtual String get_caption() const override;
 
 	Vector2 get_closest_point(const Vector2 &p_point);

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -36,7 +36,15 @@
 #include "scene/resources/animation.h"
 
 void AnimationNodeAnimation::set_animation(const StringName &p_name) {
+	if (animation == p_name) {
+		return;
+	}
 	animation = p_name;
+	animation_version++;
+	if (unlikely(animation_version == 0)) {
+		animation_version = 1;
+	}
+	_node_updated(get_instance_id());
 }
 
 StringName AnimationNodeAnimation::get_animation() const {
@@ -45,7 +53,16 @@ StringName AnimationNodeAnimation::get_animation() const {
 
 LocalVector<StringName> (*AnimationNodeAnimation::get_editable_animation_list)() = nullptr;
 
-void AnimationNodeAnimation::get_parameter_list(List<PropertyInfo> *r_list) const {
+void AnimationNodeAnimation::validate_node(const AnimationTree *p_tree, const StringName &p_path) const {
+	AnimationRootNode::validate_node(p_tree, p_path);
+
+	const Ref<Animation> &animation_resource = p_tree->get_animation_or_null(animation);
+	if (animation_resource.is_null()) {
+		add_validation_error(p_tree, p_path, vformat(RTR("Animation '%s' not found."), animation));
+	}
+}
+
+void AnimationNodeAnimation::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::BOOL, backward, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
 }
@@ -59,25 +76,6 @@ Variant AnimationNodeAnimation::get_parameter_default_value(const StringName &p_
 		return false;
 	}
 	return 0.0;
-}
-
-AnimationNode::NodeTimeInfo AnimationNodeAnimation::get_node_time_info() const {
-	NodeTimeInfo nti;
-	if (!process_state->tree->has_animation(animation)) {
-		return nti;
-	}
-
-	if (use_custom_timeline) {
-		nti.length = timeline_length;
-		nti.loop_mode = loop_mode;
-	} else {
-		Ref<Animation> anim = process_state->tree->get_animation(animation);
-		nti.length = (double)anim->get_length();
-		nti.loop_mode = anim->get_loop_mode();
-	}
-	nti.position = get_parameter(current_position);
-
-	return nti;
 }
 
 void AnimationNodeAnimation::_validate_property(PropertyInfo &p_property) const {
@@ -101,52 +99,27 @@ void AnimationNodeAnimation::_validate_property(PropertyInfo &p_property) const 
 	}
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeAnimation::process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	process_state->is_testing = p_test_only;
+AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
+	_update_animation_cache(p_process_state.tree, p_instance);
+	const Ref<Animation> &anim = p_instance.cached_animation;
+	// Should not ever happen due to validation earlier.
+	ERR_FAIL_COND_V(anim.is_null(), NodeTimeInfo());
+	double anim_size = anim->get_length();
 
-	AnimationMixer::PlaybackInfo pi = p_playback_info;
-	if (p_playback_info.seeked) {
-		if (p_playback_info.is_external_seeking) {
-			pi.delta = get_node_time_info().position - p_playback_info.time;
-		}
+	double cur_len;
+	Animation::LoopMode cur_loop_mode;
+	if (use_custom_timeline) {
+		cur_len = timeline_length;
+		cur_loop_mode = loop_mode;
 	} else {
-		pi.time = get_node_time_info().position + (get_parameter(backward) ? -p_playback_info.delta : p_playback_info.delta);
+		cur_len = anim_size;
+		cur_loop_mode = anim->get_loop_mode();
 	}
 
-	NodeTimeInfo nti = _process(pi, p_test_only);
-
-	if (!p_test_only) {
-		set_node_time_info(nti);
-	}
-
-	return nti;
-}
-
-AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	if (!process_state->tree->has_animation(animation)) {
-		AnimationNodeBlendTree *tree = Object::cast_to<AnimationNodeBlendTree>(node_state.parent);
-		if (tree) {
-			String node_name = tree->get_node_name(Ref<AnimationNodeAnimation>(this));
-			make_invalid(vformat(RTR("On BlendTree node '%s', animation not found: '%s'"), node_name, animation));
-
-		} else {
-			make_invalid(vformat(RTR("Animation not found: '%s'"), animation));
-		}
-
-		return NodeTimeInfo();
-	}
-
-	Ref<Animation> anim = process_state->tree->get_animation(animation);
-	double anim_size = (double)anim->get_length();
-
-	NodeTimeInfo cur_nti = get_node_time_info();
-	double cur_len = cur_nti.length;
 	double cur_time = p_playback_info.time;
 	double cur_delta = p_playback_info.delta;
-	bool cur_backward = get_parameter(backward);
-
-	Animation::LoopMode cur_loop_mode = cur_nti.loop_mode;
-	double prev_time = cur_nti.position;
+	bool cur_backward = p_instance.get_parameter_backward();
+	double prev_time = p_instance.get_parameter_current_position();
 
 	Animation::LoopedFlag looped_flag = Animation::LOOPED_FLAG_NONE;
 	bool node_backward = play_mode == PLAY_MODE_BACKWARD;
@@ -253,15 +226,15 @@ AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(const AnimationMixe
 
 		// Emit start & finish signal. Internally, the detections are the same for backward.
 		// We should use call_deferred since the track keys are still being processed.
-		if (process_state->tree && !p_test_only) {
+		if (p_process_state.tree && !p_test_only) {
 			// AnimationTree uses seek to 0 "internally" to process the first key of the animation, which is used as the start detection.
 			if (is_started) {
-				process_state->tree->call_deferred(SNAME("emit_signal"), SceneStringName(animation_started), animation);
+				p_process_state.tree->call_deferred(SNAME("emit_signal"), SceneStringName(animation_started), animation);
 			}
 			// Finished.
 			if (Animation::is_less_approx(prev_playback_time, anim_size) && Animation::is_greater_or_equal_approx(cur_playback_time, anim_size)) {
 				cur_playback_time = anim_size;
-				process_state->tree->call_deferred(SNAME("emit_signal"), SceneStringName(animation_finished), animation);
+				p_process_state.tree->call_deferred(SNAME("emit_signal"), SceneStringName(animation_finished), animation);
 			}
 		}
 	}
@@ -279,7 +252,7 @@ AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(const AnimationMixe
 			}
 			pi.delta = 0;
 			pi.weight = CMP_EPSILON;
-			blend_animation(animation, pi);
+			blend_animation(p_process_state, p_instance, animation, pi);
 		}
 
 		AnimationMixer::PlaybackInfo pi = p_playback_info;
@@ -297,9 +270,9 @@ AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(const AnimationMixe
 		}
 		pi.weight = 1.0;
 		pi.looped_flag = looped_flag;
-		blend_animation(animation, pi);
+		blend_animation(p_process_state, p_instance, animation, pi);
 
-		set_parameter(backward, cur_backward);
+		p_instance.set_parameter_backward(cur_backward, p_process_state.is_testing);
 	}
 
 	return nti;
@@ -317,12 +290,12 @@ AnimationNodeAnimation::PlayMode AnimationNodeAnimation::get_play_mode() const {
 	return play_mode;
 }
 
-void AnimationNodeAnimation::set_backward(bool p_backward) {
-	set_parameter(backward, p_backward);
+void AnimationNodeAnimation::set_backward(AnimationNodeInstance &p_instance, ProcessState &p_process_state, bool p_backward) {
+	p_instance.set_parameter_backward(p_backward, p_process_state.is_testing);
 }
 
-bool AnimationNodeAnimation::is_backward() const {
-	return get_parameter(backward);
+bool AnimationNodeAnimation::is_backward(AnimationNodeInstance &p_instance, ProcessState &p_process_state) const {
+	return p_instance.get_parameter_backward();
 }
 
 void AnimationNodeAnimation::set_advance_on_start(bool p_advance_on_start) {
@@ -413,6 +386,21 @@ void AnimationNodeAnimation::_bind_methods() {
 	BIND_ENUM_CONSTANT(PLAY_MODE_BACKWARD);
 }
 
+void AnimationNodeAnimation::_update_animation_cache(AnimationTree *p_tree, AnimationNodeInstance &p_instance) const {
+	if (p_instance.cached_animation_version == animation_version) {
+		return;
+	}
+
+	const Ref<Animation> &anim = p_tree->get_animation_or_null(animation);
+	if (anim.is_null()) {
+		// I don't think this can even occur with validation now.
+		return;
+	}
+
+	p_instance.cached_animation = anim;
+	p_instance.cached_animation_version = animation_version;
+}
+
 AnimationNodeAnimation::AnimationNodeAnimation() {
 }
 
@@ -437,7 +425,7 @@ AnimationNodeSync::AnimationNodeSync() {
 }
 
 ////////////////////////////////////////////////////////
-void AnimationNodeOneShot::get_parameter_list(List<PropertyInfo> *r_list) const {
+void AnimationNodeOneShot::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::BOOL, active, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_READ_ONLY));
 	r_list->push_back(PropertyInfo(Variant::BOOL, internal_active, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_READ_ONLY));
@@ -563,16 +551,16 @@ bool AnimationNodeOneShot::has_filter() const {
 	return true;
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	OneShotRequest cur_request = static_cast<OneShotRequest>((int)get_parameter(request));
-	bool cur_active = get_parameter(active);
-	bool cur_internal_active = get_parameter(internal_active);
-	NodeTimeInfo cur_nti = get_node_time_info();
-	double cur_time_to_restart = get_parameter(time_to_restart);
-	double cur_fade_in_remaining = get_parameter(fade_in_remaining);
-	double cur_fade_out_remaining = get_parameter(fade_out_remaining);
+AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
+	OneShotRequest cur_request = static_cast<OneShotRequest>(p_instance.get_parameter_request());
+	bool cur_active = p_instance.get_parameter_active();
+	bool cur_internal_active = p_instance.get_parameter_internal_active();
+	double prev_position = p_instance.get_parameter_current_position();
+	double cur_time_to_restart = p_instance.get_parameter_time_to_restart();
+	double cur_fade_in_remaining = p_instance.get_parameter_fade_in_remaining();
+	double cur_fade_out_remaining = p_instance.get_parameter_fade_out_remaining();
 
-	set_parameter(request, ONE_SHOT_REQUEST_NONE);
+	p_instance.set_parameter_request(ONE_SHOT_REQUEST_NONE, p_process_state.is_testing);
 
 	bool is_shooting = true;
 	bool is_fading_out = cur_active == true && cur_internal_active == false;
@@ -596,10 +584,10 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(const AnimationMixer:
 	}
 
 	if (is_abort) {
-		set_parameter(internal_active, false);
-		set_parameter(active, false);
-		set_parameter(time_to_restart, -1);
-		set_parameter(fade_out_remaining, 0);
+		p_instance.set_parameter_internal_active(false, p_process_state.is_testing);
+		p_instance.set_parameter_active(false, p_process_state.is_testing);
+		p_instance.set_parameter_time_to_restart(-1, p_process_state.is_testing);
+		p_instance.set_parameter_fade_out_remaining(0, p_process_state.is_testing);
 		cur_fade_out_remaining = 0;
 		is_fading_out = false;
 		is_shooting = false;
@@ -613,15 +601,15 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(const AnimationMixer:
 			// Shot is ended, do nothing.
 			is_shooting = false;
 		}
-		set_parameter(internal_active, false);
-		set_parameter(time_to_restart, -1);
+		p_instance.set_parameter_internal_active(false, p_process_state.is_testing);
+		p_instance.set_parameter_time_to_restart(-1, p_process_state.is_testing);
 	} else if (!do_start && !cur_active) {
 		if (Animation::is_greater_or_equal_approx(cur_time_to_restart, 0) && !p_seek) {
 			cur_time_to_restart -= abs_delta;
 			if (Animation::is_less_approx(cur_time_to_restart, 0)) {
 				do_start = true; // Restart.
 			}
-			set_parameter(time_to_restart, cur_time_to_restart);
+			p_instance.set_parameter_time_to_restart(cur_time_to_restart, p_process_state.is_testing);
 		}
 		if (!do_start) {
 			is_shooting = false;
@@ -633,7 +621,7 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(const AnimationMixer:
 	if (!is_shooting) {
 		AnimationMixer::PlaybackInfo pi = p_playback_info;
 		pi.weight = 1.0;
-		return blend_input(0, pi, FILTER_IGNORE, sync, p_test_only);
+		return blend_input(p_process_state, p_instance, 0, pi, FILTER_IGNORE, sync, p_test_only);
 	}
 
 	if (do_start) {
@@ -642,9 +630,9 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(const AnimationMixer:
 			cur_fade_in_remaining = fade_in; // If already active, don't fade-in again.
 		}
 		cur_internal_active = true;
-		set_parameter(request, ONE_SHOT_REQUEST_NONE);
-		set_parameter(internal_active, true);
-		set_parameter(active, true);
+		p_instance.set_parameter_request(ONE_SHOT_REQUEST_NONE, p_process_state.is_testing);
+		p_instance.set_parameter_internal_active(true, p_process_state.is_testing);
+		p_instance.set_parameter_active(true, p_process_state.is_testing);
 		// Clear fade-out.
 		is_fading_out = false;
 		cur_fade_out_remaining = 0;
@@ -681,23 +669,23 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(const AnimationMixer:
 	NodeTimeInfo main_nti;
 	if (mix == MIX_MODE_ADD) {
 		pi.weight = 1.0;
-		main_nti = blend_input(0, pi, FILTER_IGNORE, sync, p_test_only);
+		main_nti = blend_input(p_process_state, p_instance, 0, pi, FILTER_IGNORE, sync, p_test_only);
 	} else {
 		pi.seeked &= use_blend;
 		pi.weight = 1.0 - blend;
-		main_nti = blend_input(0, pi, FILTER_BLEND, sync, p_test_only); // Unlike below, processing this edge is a corner case.
+		main_nti = blend_input(p_process_state, p_instance, 0, pi, FILTER_BLEND, sync, p_test_only); // Unlike below, processing this edge is a corner case.
 	}
 
 	pi = p_playback_info;
 	if (do_start) {
 		pi.time = 0;
 	} else if (os_seek) {
-		pi.time = cur_nti.position;
+		pi.time = prev_position;
 	}
 	pi.seeked = os_seek;
 	pi.weight = Math::is_zero_approx(blend) ? CMP_EPSILON : blend;
 
-	NodeTimeInfo os_nti = blend_input(1, pi, FILTER_PASS, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
+	NodeTimeInfo os_nti = blend_input(p_process_state, p_instance, 1, pi, FILTER_PASS, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
 
 	if (Animation::is_less_or_equal_approx(cur_fade_in_remaining, 0) && !do_start && !is_fading_out) {
 		// Predict time scale by difference of delta times to estimate input animation's remain time in self time scale.
@@ -709,17 +697,17 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(const AnimationMixer:
 			is_fading_out = true;
 			cur_fade_out_remaining = os_rem + abs_delta;
 			cur_fade_in_remaining = 0;
-			set_parameter(internal_active, false);
+			p_instance.set_parameter_internal_active(false, p_process_state.is_testing);
 		}
 	}
 
 	if (!p_seek) {
 		if (Animation::is_less_or_equal_approx(os_nti.get_remain(break_loop_at_end), 0) || (is_fading_out && Animation::is_less_or_equal_approx(cur_fade_out_remaining, 0))) {
-			set_parameter(internal_active, false);
-			set_parameter(active, false);
+			p_instance.set_parameter_internal_active(false, p_process_state.is_testing);
+			p_instance.set_parameter_active(false, p_process_state.is_testing);
 			if (auto_restart) {
 				double restart_sec = auto_restart_delay + Math::randd() * auto_restart_random_delay;
-				set_parameter(time_to_restart, restart_sec);
+				p_instance.set_parameter_time_to_restart(restart_sec, p_process_state.is_testing);
 			}
 		}
 		if (!do_start) {
@@ -728,8 +716,8 @@ AnimationNode::NodeTimeInfo AnimationNodeOneShot::_process(const AnimationMixer:
 		cur_fade_out_remaining = MAX(0, cur_fade_out_remaining - abs_delta);
 	}
 
-	set_parameter(fade_in_remaining, cur_fade_in_remaining);
-	set_parameter(fade_out_remaining, cur_fade_out_remaining);
+	p_instance.set_parameter_fade_in_remaining(cur_fade_in_remaining, p_process_state.is_testing);
+	p_instance.set_parameter_fade_in_remaining(cur_fade_out_remaining, p_process_state.is_testing);
 
 	return cur_internal_active ? os_nti : main_nti;
 }
@@ -796,7 +784,7 @@ AnimationNodeOneShot::AnimationNodeOneShot() {
 
 ////////////////////////////////////////////////
 
-void AnimationNodeAdd2::get_parameter_list(List<PropertyInfo> *r_list) const {
+void AnimationNodeAdd2::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::FLOAT, add_amount, PROPERTY_HINT_RANGE, "0,1,0.01,or_less,or_greater"));
 }
@@ -818,14 +806,14 @@ bool AnimationNodeAdd2::has_filter() const {
 	return true;
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeAdd2::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	double amount = get_parameter(add_amount);
+AnimationNode::NodeTimeInfo AnimationNodeAdd2::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
+	double amount = p_instance.get_parameter_add_amount();
 
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 	pi.weight = 1.0;
-	NodeTimeInfo nti = blend_input(0, pi, FILTER_IGNORE, sync, p_test_only);
+	NodeTimeInfo nti = blend_input(p_process_state, p_instance, 0, pi, FILTER_IGNORE, sync, p_test_only);
 	pi.weight = amount;
-	blend_input(1, pi, FILTER_PASS, sync, p_test_only);
+	blend_input(p_process_state, p_instance, 1, pi, FILTER_PASS, sync, p_test_only);
 
 	return nti;
 }
@@ -837,7 +825,7 @@ AnimationNodeAdd2::AnimationNodeAdd2() {
 
 ////////////////////////////////////////////////
 
-void AnimationNodeAdd3::get_parameter_list(List<PropertyInfo> *r_list) const {
+void AnimationNodeAdd3::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::FLOAT, add_amount, PROPERTY_HINT_RANGE, "-1,1,0.01,or_less,or_greater"));
 }
@@ -859,16 +847,16 @@ bool AnimationNodeAdd3::has_filter() const {
 	return true;
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeAdd3::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	double amount = get_parameter(add_amount);
+AnimationNode::NodeTimeInfo AnimationNodeAdd3::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
+	double amount = p_instance.get_parameter_add_amount();
 
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 	pi.weight = MAX(0, -amount);
-	blend_input(0, pi, FILTER_PASS, sync, p_test_only);
+	blend_input(p_process_state, p_instance, 0, pi, FILTER_PASS, sync, p_test_only);
 	pi.weight = 1.0;
-	NodeTimeInfo nti = blend_input(1, pi, FILTER_IGNORE, sync, p_test_only);
+	NodeTimeInfo nti = blend_input(p_process_state, p_instance, 1, pi, FILTER_IGNORE, sync, p_test_only);
 	pi.weight = MAX(0, amount);
-	blend_input(2, pi, FILTER_PASS, sync, p_test_only);
+	blend_input(p_process_state, p_instance, 2, pi, FILTER_PASS, sync, p_test_only);
 
 	return nti;
 }
@@ -881,7 +869,7 @@ AnimationNodeAdd3::AnimationNodeAdd3() {
 
 /////////////////////////////////////////////
 
-void AnimationNodeBlend2::get_parameter_list(List<PropertyInfo> *r_list) const {
+void AnimationNodeBlend2::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::FLOAT, blend_amount, PROPERTY_HINT_RANGE, "0,1,0.01,or_less,or_greater"));
 }
@@ -899,14 +887,14 @@ String AnimationNodeBlend2::get_caption() const {
 	return "Blend2";
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeBlend2::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	double amount = get_parameter(blend_amount);
+AnimationNode::NodeTimeInfo AnimationNodeBlend2::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
+	double amount = p_instance.get_parameter_blend_amount();
 
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 	pi.weight = 1.0 - amount;
-	NodeTimeInfo nti0 = blend_input(0, pi, FILTER_BLEND, sync, p_test_only);
+	NodeTimeInfo nti0 = blend_input(p_process_state, p_instance, 0, pi, FILTER_BLEND, sync, p_test_only);
 	pi.weight = amount;
-	NodeTimeInfo nti1 = blend_input(1, pi, FILTER_PASS, sync, p_test_only);
+	NodeTimeInfo nti1 = blend_input(p_process_state, p_instance, 1, pi, FILTER_PASS, sync, p_test_only);
 
 	return amount > 0.5 ? nti1 : nti0; // Hacky but good enough.
 }
@@ -922,7 +910,7 @@ AnimationNodeBlend2::AnimationNodeBlend2() {
 
 //////////////////////////////////////
 
-void AnimationNodeBlend3::get_parameter_list(List<PropertyInfo> *r_list) const {
+void AnimationNodeBlend3::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::FLOAT, blend_amount, PROPERTY_HINT_RANGE, "-1,1,0.01,or_less,or_greater"));
 }
@@ -940,16 +928,16 @@ String AnimationNodeBlend3::get_caption() const {
 	return "Blend3";
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeBlend3::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	double amount = get_parameter(blend_amount);
+AnimationNode::NodeTimeInfo AnimationNodeBlend3::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
+	double amount = p_instance.get_parameter_blend_amount();
 
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 	pi.weight = MAX(0, -amount);
-	NodeTimeInfo nti0 = blend_input(0, pi, FILTER_IGNORE, sync, p_test_only);
+	NodeTimeInfo nti0 = blend_input(p_process_state, p_instance, 0, pi, FILTER_IGNORE, sync, p_test_only);
 	pi.weight = 1.0 - Math::abs(amount);
-	NodeTimeInfo nti1 = blend_input(1, pi, FILTER_IGNORE, sync, p_test_only);
+	NodeTimeInfo nti1 = blend_input(p_process_state, p_instance, 1, pi, FILTER_IGNORE, sync, p_test_only);
 	pi.weight = MAX(0, amount);
-	NodeTimeInfo nti2 = blend_input(2, pi, FILTER_IGNORE, sync, p_test_only);
+	NodeTimeInfo nti2 = blend_input(p_process_state, p_instance, 2, pi, FILTER_IGNORE, sync, p_test_only);
 
 	return amount > 0.5 ? nti2 : (amount < -0.5 ? nti0 : nti1); // Hacky but good enough.
 }
@@ -962,7 +950,7 @@ AnimationNodeBlend3::AnimationNodeBlend3() {
 
 ////////////////////////////////////////////////
 
-void AnimationNodeSub2::get_parameter_list(List<PropertyInfo> *r_list) const {
+void AnimationNodeSub2::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::FLOAT, sub_amount, PROPERTY_HINT_RANGE, "0,1,0.01,or_less,or_greater"));
 }
@@ -984,16 +972,16 @@ bool AnimationNodeSub2::has_filter() const {
 	return true;
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeSub2::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	double amount = get_parameter(sub_amount);
+AnimationNode::NodeTimeInfo AnimationNodeSub2::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
+	double amount = p_instance.get_parameter_sub_amount();
 
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 	// Out = Sub.Transform3D^(-1) * In.Transform3D
 	pi.weight = -amount;
-	blend_input(1, pi, FILTER_PASS, sync, p_test_only);
+	blend_input(p_process_state, p_instance, 1, pi, FILTER_PASS, sync, p_test_only);
 	pi.weight = 1.0;
 
-	return blend_input(0, pi, FILTER_IGNORE, sync, p_test_only);
+	return blend_input(p_process_state, p_instance, 0, pi, FILTER_IGNORE, sync, p_test_only);
 }
 
 AnimationNodeSub2::AnimationNodeSub2() {
@@ -1003,7 +991,7 @@ AnimationNodeSub2::AnimationNodeSub2() {
 
 /////////////////////////////////
 
-void AnimationNodeTimeScale::get_parameter_list(List<PropertyInfo> *r_list) const {
+void AnimationNodeTimeScale::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::FLOAT, scale, PROPERTY_HINT_RANGE, "-32,32,0.01,or_less,or_greater"));
 }
@@ -1021,8 +1009,8 @@ String AnimationNodeTimeScale::get_caption() const {
 	return "TimeScale";
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeTimeScale::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	double cur_scale = get_parameter(scale);
+AnimationNode::NodeTimeInfo AnimationNodeTimeScale::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
+	double cur_scale = p_instance.get_parameter_scale();
 
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 	pi.weight = 1.0;
@@ -1030,7 +1018,7 @@ AnimationNode::NodeTimeInfo AnimationNodeTimeScale::_process(const AnimationMixe
 		pi.delta *= cur_scale;
 	}
 
-	return blend_input(0, pi, FILTER_IGNORE, true, p_test_only);
+	return blend_input(p_process_state, p_instance, 0, pi, FILTER_IGNORE, true, p_test_only);
 }
 
 AnimationNodeTimeScale::AnimationNodeTimeScale() {
@@ -1039,7 +1027,7 @@ AnimationNodeTimeScale::AnimationNodeTimeScale() {
 
 ////////////////////////////////////
 
-void AnimationNodeTimeSeek::get_parameter_list(List<PropertyInfo> *r_list) const {
+void AnimationNodeTimeSeek::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::FLOAT, seek_pos_request, PROPERTY_HINT_RANGE, "-1,3600,0.01,or_greater")); // It will be reset to -1 after seeking the position immediately.
 }
@@ -1065,8 +1053,8 @@ bool AnimationNodeTimeSeek::is_explicit_elapse() const {
 	return explicit_elapse;
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeTimeSeek::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	double cur_seek_pos = get_parameter(seek_pos_request);
+AnimationNode::NodeTimeInfo AnimationNodeTimeSeek::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
+	double cur_seek_pos = p_instance.get_parameter_seek_pos_request();
 
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 	pi.weight = 1.0;
@@ -1074,10 +1062,10 @@ AnimationNode::NodeTimeInfo AnimationNodeTimeSeek::_process(const AnimationMixer
 		pi.time = cur_seek_pos;
 		pi.seeked = true;
 		pi.is_external_seeking = explicit_elapse;
-		set_parameter(seek_pos_request, -1.0); // Reset.
+		p_instance.set_parameter_seek_pos_request(-1.0, p_process_state.is_testing); // Reset.
 	}
 
-	return blend_input(0, pi, FILTER_IGNORE, true, p_test_only);
+	return blend_input(p_process_state, p_instance, 0, pi, FILTER_IGNORE, true, p_test_only);
 }
 
 AnimationNodeTimeSeek::AnimationNodeTimeSeek() {
@@ -1153,7 +1141,7 @@ bool AnimationNodeTransition::_get(const StringName &p_path, Variant &r_ret) con
 	return true;
 }
 
-void AnimationNodeTransition::get_parameter_list(List<PropertyInfo> *r_list) const {
+void AnimationNodeTransition::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	String anims;
 	for (int i = 0; i < get_input_count(); i++) {
@@ -1290,13 +1278,12 @@ bool AnimationNodeTransition::is_allow_transition_to_self() const {
 	return allow_transition_to_self;
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeTransition::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	String cur_transition_request = get_parameter(transition_request);
-	int cur_current_index = get_parameter(current_index);
-	int cur_prev_index = get_parameter(prev_index);
+AnimationNode::NodeTimeInfo AnimationNodeTransition::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
+	const String &cur_transition_request = p_instance.get_parameter_transition_request();
+	int cur_current_index = p_instance.get_parameter_current_index();
+	int cur_prev_index = p_instance.get_parameter_prev_index();
 
-	NodeTimeInfo cur_nti = get_node_time_info();
-	double cur_prev_xfading = get_parameter(prev_xfading);
+	double cur_prev_xfading = p_instance.get_parameter_prev_xfading();
 
 	bool switched = false;
 	bool restart = false;
@@ -1304,16 +1291,16 @@ AnimationNode::NodeTimeInfo AnimationNodeTransition::_process(const AnimationMix
 
 	if (pending_update) {
 		if (cur_current_index < 0 || cur_current_index >= get_input_count()) {
-			set_parameter(prev_index, -1);
+			p_instance.set_parameter_prev_index(-1, p_process_state.is_testing);
 			if (get_input_count() > 0) {
-				set_parameter(current_index, 0);
-				set_parameter(current_state, get_input_name(0));
+				p_instance.set_parameter_current_index(0, p_process_state.is_testing);
+				p_instance.set_parameter_current_state(get_input_name(0), p_process_state.is_testing);
 			} else {
-				set_parameter(current_index, -1);
-				set_parameter(current_state, StringName());
+				p_instance.set_parameter_current_index(-1, p_process_state.is_testing);
+				p_instance.set_parameter_current_state(StringName(), p_process_state.is_testing);
 			}
 		} else {
-			set_parameter(current_state, get_input_name(cur_current_index));
+			p_instance.set_parameter_current_state(get_input_name(cur_current_index), p_process_state.is_testing);
 		}
 		pending_update = false;
 	}
@@ -1338,23 +1325,22 @@ AnimationNode::NodeTimeInfo AnimationNodeTransition::_process(const AnimationMix
 			} else {
 				switched = true;
 				cur_prev_index = cur_current_index;
-				set_parameter(prev_index, cur_current_index);
+				p_instance.set_parameter_prev_index(cur_current_index, p_process_state.is_testing);
 				cur_current_index = new_idx;
-				set_parameter(current_index, cur_current_index);
-				set_parameter(current_state, cur_transition_request);
+				p_instance.set_parameter_current_index(cur_current_index, p_process_state.is_testing);
+				p_instance.set_parameter_current_state(cur_transition_request, p_process_state.is_testing);
 			}
 		} else {
 			ERR_PRINT("No such input: '" + cur_transition_request + "'");
 		}
-		cur_transition_request = String();
-		set_parameter(transition_request, cur_transition_request);
+		p_instance.set_parameter_transition_request(String(), p_process_state.is_testing);
 	}
 
 	if (clear_remaining_fade) {
 		cur_prev_xfading = 0;
-		set_parameter(prev_xfading, 0);
+		p_instance.set_parameter_prev_xfading(0, p_process_state.is_testing);
 		cur_prev_index = -1;
-		set_parameter(prev_index, -1);
+		p_instance.set_parameter_prev_index(-1, p_process_state.is_testing);
 	}
 
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
@@ -1364,7 +1350,7 @@ AnimationNode::NodeTimeInfo AnimationNodeTransition::_process(const AnimationMix
 		pi.time = 0;
 		pi.seeked = true;
 		pi.weight = 1.0;
-		return blend_input(cur_current_index, pi, FILTER_IGNORE, true, p_test_only);
+		return blend_input(p_process_state, p_instance, cur_current_index, pi, FILTER_IGNORE, true, p_test_only);
 	}
 
 	if (switched) {
@@ -1379,16 +1365,17 @@ AnimationNode::NodeTimeInfo AnimationNodeTransition::_process(const AnimationMix
 		pi.weight = 0;
 		for (int i = 0; i < get_input_count(); i++) {
 			if (i != cur_current_index && i != cur_prev_index) {
-				blend_input(i, pi, FILTER_IGNORE, true, p_test_only);
+				blend_input(p_process_state, p_instance, i, pi, FILTER_IGNORE, true, p_test_only);
 			}
 		}
 	}
 
+	NodeTimeInfo cur_nti;
 	if (cur_prev_index < 0) { // Process current animation, check for transition.
 		pi.weight = 1.0;
-		cur_nti = blend_input(cur_current_index, pi, FILTER_IGNORE, true, p_test_only);
+		cur_nti = blend_input(p_process_state, p_instance, cur_current_index, pi, FILTER_IGNORE, true, p_test_only);
 		if (input_data[cur_current_index].auto_advance && Animation::is_less_or_equal_approx(cur_nti.get_remain(input_data[cur_current_index].break_loop_at_end), xfade_time)) {
-			set_parameter(transition_request, get_input_name((cur_current_index + 1) % get_input_count()));
+			p_instance.set_parameter_transition_request(get_input_name((cur_current_index + 1) % get_input_count()), p_process_state.is_testing);
 		}
 	} else { // Cross-fading from prev to current.
 
@@ -1412,21 +1399,21 @@ AnimationNode::NodeTimeInfo AnimationNodeTransition::_process(const AnimationMix
 			pi.time = 0;
 			pi.seeked = true;
 		}
-		cur_nti = blend_input(cur_current_index, pi, FILTER_IGNORE, true, p_test_only);
+		cur_nti = blend_input(p_process_state, p_instance, cur_current_index, pi, FILTER_IGNORE, true, p_test_only);
 
 		pi = p_playback_info;
 		pi.seeked &= use_blend;
 		pi.weight = blend;
-		blend_input(cur_prev_index, pi, FILTER_IGNORE, true, p_test_only);
+		blend_input(p_process_state, p_instance, cur_prev_index, pi, FILTER_IGNORE, true, p_test_only);
 		if (!p_seek) {
 			if (Animation::is_less_or_equal_approx(cur_prev_xfading, 0)) {
-				set_parameter(prev_index, -1);
+				p_instance.set_parameter_prev_index(-1, p_process_state.is_testing);
 			}
 			cur_prev_xfading -= Math::abs(p_playback_info.delta);
 		}
 	}
 
-	set_parameter(prev_xfading, cur_prev_xfading);
+	p_instance.set_parameter_prev_xfading(cur_prev_xfading, p_process_state.is_testing);
 
 	return cur_nti;
 }
@@ -1476,10 +1463,10 @@ String AnimationNodeOutput::get_caption() const {
 	return "Output";
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeOutput::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
+AnimationNode::NodeTimeInfo AnimationNodeOutput::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 	pi.weight = 1.0;
-	return blend_input(0, pi, FILTER_IGNORE, true, p_test_only);
+	return blend_input(p_process_state, p_instance, 0, pi, FILTER_IGNORE, true, p_test_only);
 }
 
 AnimationNodeOutput::AnimationNodeOutput() {
@@ -1487,7 +1474,7 @@ AnimationNodeOutput::AnimationNodeOutput() {
 }
 
 ///////////////////////////////////////////////////////
-void AnimationNodeBlendTree::add_node(const StringName &p_name, Ref<AnimationNode> p_node, const Vector2 &p_position) {
+void AnimationNodeBlendTree::add_node(const StringName &p_name, const Ref<AnimationNode> &p_node, const Vector2 &p_position) {
 	ERR_FAIL_COND(nodes.has(p_name));
 	ERR_FAIL_COND(p_node.is_null());
 	ERR_FAIL_COND(p_name == SceneStringName(output));
@@ -1502,26 +1489,14 @@ void AnimationNodeBlendTree::add_node(const StringName &p_name, Ref<AnimationNod
 	emit_changed();
 	emit_signal(SNAME("tree_changed"));
 
-	p_node->connect(SNAME("tree_changed"), callable_mp(this, &AnimationNodeBlendTree::_tree_changed), CONNECT_REFERENCE_COUNTED);
-	p_node->connect(SNAME("animation_node_renamed"), callable_mp(this, &AnimationNodeBlendTree::_animation_node_renamed), CONNECT_REFERENCE_COUNTED);
-	p_node->connect(SNAME("animation_node_removed"), callable_mp(this, &AnimationNodeBlendTree::_animation_node_removed), CONNECT_REFERENCE_COUNTED);
-	p_node->connect_changed(callable_mp(this, &AnimationNodeBlendTree::_node_changed).bind(p_name), CONNECT_REFERENCE_COUNTED);
+	_add_node(p_node);
+	p_node->connect_changed(callable_mp(this, &AnimationNodeBlendTree::_child_node_changed).bind(p_name), CONNECT_REFERENCE_COUNTED);
 }
 
 Ref<AnimationNode> AnimationNodeBlendTree::get_node(const StringName &p_name) const {
-	ERR_FAIL_COND_V(!nodes.has(p_name), Ref<AnimationNode>());
-
-	return nodes[p_name].node;
-}
-
-StringName AnimationNodeBlendTree::get_node_name(const Ref<AnimationNode> &p_node) const {
-	for (const KeyValue<StringName, Node> &E : nodes) {
-		if (E.value.node == p_node) {
-			return E.key;
-		}
-	}
-
-	ERR_FAIL_V(StringName());
+	const Node *node = nodes.getptr(p_name);
+	ERR_FAIL_NULL_V(node, Ref<AnimationNode>());
+	return node->node;
 }
 
 void AnimationNodeBlendTree::set_node_position(const StringName &p_node, const Vector2 &p_position) {
@@ -1534,17 +1509,11 @@ Vector2 AnimationNodeBlendTree::get_node_position(const StringName &p_node) cons
 	return nodes[p_node].position;
 }
 
-void AnimationNodeBlendTree::get_child_nodes(List<ChildNode> *r_child_nodes) {
-	Vector<StringName> ns;
-
+void AnimationNodeBlendTree::get_child_nodes(LocalVector<ChildNode> *r_child_nodes) {
 	for (const KeyValue<StringName, Node> &E : nodes) {
-		ns.push_back(E.key);
-	}
-
-	for (int i = 0; i < ns.size(); i++) {
 		ChildNode cn;
-		cn.name = ns[i];
-		cn.node = nodes[cn.name].node;
+		cn.name = E.key;
+		cn.node = E.value.node;
 		r_child_nodes->push_back(cn);
 	}
 }
@@ -1553,9 +1522,10 @@ bool AnimationNodeBlendTree::has_node(const StringName &p_name) const {
 	return nodes.has(p_name);
 }
 
-Vector<StringName> AnimationNodeBlendTree::get_node_connection_array(const StringName &p_name) const {
-	ERR_FAIL_COND_V(!nodes.has(p_name), Vector<StringName>());
-	return nodes[p_name].connections;
+const LocalVector<StringName> *AnimationNodeBlendTree::get_node_connection_array(const StringName &p_name) const {
+	const Node *node = nodes.getptr(p_name);
+	ERR_FAIL_NULL_V(node, nullptr);
+	return &node->connections;
 }
 
 void AnimationNodeBlendTree::remove_node(const StringName &p_name) {
@@ -1564,19 +1534,17 @@ void AnimationNodeBlendTree::remove_node(const StringName &p_name) {
 
 	{
 		Ref<AnimationNode> node = nodes[p_name].node;
-		node->disconnect(SNAME("tree_changed"), callable_mp(this, &AnimationNodeBlendTree::_tree_changed));
-		node->disconnect(SNAME("animation_node_renamed"), callable_mp(this, &AnimationNodeBlendTree::_animation_node_renamed));
-		node->disconnect(SNAME("animation_node_removed"), callable_mp(this, &AnimationNodeBlendTree::_animation_node_removed));
-		node->disconnect_changed(callable_mp(this, &AnimationNodeBlendTree::_node_changed));
+		_remove_node(node);
+		node->disconnect_changed(callable_mp(this, &AnimationNodeBlendTree::_child_node_changed));
 	}
 
 	nodes.erase(p_name);
 
 	// Erase connections to name.
 	for (KeyValue<StringName, Node> &E : nodes) {
-		for (int i = 0; i < E.value.connections.size(); i++) {
+		for (uint32_t i = 0; i < E.value.connections.size(); i++) {
 			if (E.value.connections[i] == p_name) {
-				E.value.connections.write[i] = StringName();
+				E.value.connections[i] = StringName();
 			}
 		}
 	}
@@ -1592,7 +1560,7 @@ void AnimationNodeBlendTree::rename_node(const StringName &p_name, const StringN
 	ERR_FAIL_COND(p_name == SceneStringName(output));
 	ERR_FAIL_COND(p_new_name == SceneStringName(output));
 
-	nodes[p_name].node->disconnect_changed(callable_mp(this, &AnimationNodeBlendTree::_node_changed));
+	nodes[p_name].node->disconnect_changed(callable_mp(this, &AnimationNodeBlendTree::_child_node_changed));
 
 	const Node temp_copy = nodes[p_name];
 	nodes[p_new_name] = temp_copy; // might realloc
@@ -1600,14 +1568,14 @@ void AnimationNodeBlendTree::rename_node(const StringName &p_name, const StringN
 
 	// Rename connections.
 	for (KeyValue<StringName, Node> &E : nodes) {
-		for (int i = 0; i < E.value.connections.size(); i++) {
+		for (uint32_t i = 0; i < E.value.connections.size(); i++) {
 			if (E.value.connections[i] == p_name) {
-				E.value.connections.write[i] = p_new_name;
+				E.value.connections[i] = p_new_name;
 			}
 		}
 	}
 	// Connection must be done with new name.
-	nodes[p_new_name].node->connect_changed(callable_mp(this, &AnimationNodeBlendTree::_node_changed).bind(p_new_name), CONNECT_REFERENCE_COUNTED);
+	nodes[p_new_name].node->connect_changed(callable_mp(this, &AnimationNodeBlendTree::_child_node_changed).bind(p_new_name), CONNECT_REFERENCE_COUNTED);
 
 	emit_signal(SNAME("animation_node_renamed"), get_instance_id(), p_name, p_new_name);
 	emit_signal(SNAME("tree_changed"));
@@ -1620,27 +1588,29 @@ void AnimationNodeBlendTree::connect_node(const StringName &p_input_node, int p_
 	ERR_FAIL_COND(p_input_node == p_output_node);
 
 	Ref<AnimationNode> input = nodes[p_input_node].node;
-	ERR_FAIL_INDEX(p_input_index, nodes[p_input_node].connections.size());
+	ERR_FAIL_INDEX(p_input_index, (int)nodes[p_input_node].connections.size());
 
 	for (KeyValue<StringName, Node> &E : nodes) {
-		for (int i = 0; i < E.value.connections.size(); i++) {
+		for (uint32_t i = 0; i < E.value.connections.size(); i++) {
 			StringName output = E.value.connections[i];
 			ERR_FAIL_COND(output == p_output_node);
 		}
 	}
 
-	nodes[p_input_node].connections.write[p_input_index] = p_output_node;
+	nodes[p_input_node].connections[p_input_index] = p_output_node;
 
 	emit_changed();
+	_node_updated(input->get_instance_id());
 }
 
 void AnimationNodeBlendTree::disconnect_node(const StringName &p_node, int p_input_index) {
 	ERR_FAIL_COND(!nodes.has(p_node));
 
 	Ref<AnimationNode> input = nodes[p_node].node;
-	ERR_FAIL_INDEX(p_input_index, nodes[p_node].connections.size());
+	ERR_FAIL_INDEX(p_input_index, (int)nodes[p_node].connections.size());
 
-	nodes[p_node].connections.write[p_input_index] = StringName();
+	nodes[p_node].connections[p_input_index] = StringName();
+	_node_updated(input->get_instance_id());
 }
 
 AnimationNodeBlendTree::ConnectionError AnimationNodeBlendTree::can_connect_node(const StringName &p_input_node, int p_input_index, const StringName &p_output_node) const {
@@ -1658,7 +1628,7 @@ AnimationNodeBlendTree::ConnectionError AnimationNodeBlendTree::can_connect_node
 
 	Ref<AnimationNode> input = nodes[p_input_node].node;
 
-	if (p_input_index < 0 || p_input_index >= nodes[p_input_node].connections.size()) {
+	if (p_input_index < 0 || p_input_index >= (int)nodes[p_input_node].connections.size()) {
 		return CONNECTION_ERROR_NO_INPUT_INDEX;
 	}
 
@@ -1667,7 +1637,7 @@ AnimationNodeBlendTree::ConnectionError AnimationNodeBlendTree::can_connect_node
 	}
 
 	for (const KeyValue<StringName, Node> &E : nodes) {
-		for (int i = 0; i < E.value.connections.size(); i++) {
+		for (uint32_t i = 0; i < E.value.connections.size(); i++) {
 			const StringName output = E.value.connections[i];
 			if (output == p_output_node) {
 				return CONNECTION_ERROR_CONNECTION_EXISTS;
@@ -1677,9 +1647,9 @@ AnimationNodeBlendTree::ConnectionError AnimationNodeBlendTree::can_connect_node
 	return CONNECTION_OK;
 }
 
-void AnimationNodeBlendTree::get_node_connections(List<NodeConnection> *r_connections) const {
+void AnimationNodeBlendTree::get_node_connections(LocalVector<NodeConnection> *r_connections) const {
 	for (const KeyValue<StringName, Node> &E : nodes) {
-		for (int i = 0; i < E.value.connections.size(); i++) {
+		for (uint32_t i = 0; i < E.value.connections.size(); i++) {
 			const StringName output = E.value.connections[i];
 			if (output != StringName()) {
 				NodeConnection nc;
@@ -1696,15 +1666,15 @@ String AnimationNodeBlendTree::get_caption() const {
 	return "BlendTree";
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeBlendTree::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	Ref<AnimationNodeOutput> output = nodes[SceneStringName(output)].node;
-	node_state.connections = nodes[SceneStringName(output)].connections;
+AnimationNode::NodeTimeInfo AnimationNodeBlendTree::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
+	const Ref<AnimationNodeOutput> output = nodes[SceneStringName(output)].node;
 	ERR_FAIL_COND_V(output.is_null(), NodeTimeInfo());
 
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 	pi.weight = 1.0;
 
-	return _blend_node(output, "output", this, pi, FILTER_IGNORE, true, p_test_only, nullptr);
+	AnimationNodeInstance &output_instance = p_instance.get_child_instance_by_path(SceneStringName(output));
+	return _blend_node(p_process_state, p_instance, output_instance, pi, FILTER_IGNORE, true, p_test_only, nullptr);
 }
 
 LocalVector<StringName> AnimationNodeBlendTree::get_node_list() const {
@@ -1792,7 +1762,7 @@ bool AnimationNodeBlendTree::_get(const StringName &p_name, Variant &r_ret) cons
 			}
 		}
 	} else if (prop_name == "node_connections") {
-		List<NodeConnection> nc;
+		LocalVector<NodeConnection> nc;
 		get_node_connections(&nc);
 		Array conns;
 		conns.resize(nc.size() * 3);
@@ -1849,7 +1819,39 @@ void AnimationNodeBlendTree::reset_state() {
 	emit_signal(SNAME("tree_changed"));
 }
 
-void AnimationNodeBlendTree::_node_changed(const StringName &p_node) {
+void AnimationNodeBlendTree::validate_node(const AnimationTree *p_tree, const StringName &p_path) const {
+	AnimationRootNode::validate_node(p_tree, p_path);
+
+	// Validate output connection.
+	{
+		const LocalVector<StringName> *output_connections = get_node_connection_array(SceneStringName(output));
+		const StringName &node_name = output_connections->operator[](0);
+
+		if (const Node *child_node = nodes.getptr(node_name); !child_node) {
+			add_validation_error(p_tree, String(p_path) + SceneStringName(output) + "/", RTR("Nothing connected to output."));
+		}
+	}
+
+	// Rest of children.
+	for (const KeyValue<StringName, Node> &E : nodes) {
+		const Node &child = E.value;
+
+		// Skip output node, already validated.
+		if (E.key == SceneStringName(output)) {
+			continue;
+		}
+
+		for (uint32_t input = 0; input < child.connections.size(); input++) {
+			const StringName &connected_node_name = child.connections[input];
+			if (const Node *connected_to = nodes.getptr(connected_node_name); !connected_to) {
+				StringName path = String(p_path) + String(E.key) + "/";
+				add_validation_error(p_tree, path, "Nothing connected to", input);
+			}
+		}
+	}
+}
+
+void AnimationNodeBlendTree::_child_node_changed(const StringName &p_node) {
 	ERR_FAIL_COND(!nodes.has(p_node));
 	nodes[p_node].connections.resize(nodes[p_node].node->get_input_count());
 	emit_signal(SNAME("node_changed"), p_node);
@@ -1908,7 +1910,7 @@ void AnimationNodeBlendTree::_initialize_node_tree() {
 	n.node = output;
 	n.position = Vector2(300, 150);
 	n.connections.resize(1);
-	nodes["output"] = n;
+	nodes[SceneStringName(output)] = n;
 }
 
 AnimationNodeBlendTree::AnimationNodeBlendTree() {

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -39,6 +39,7 @@ class AnimationNodeAnimation : public AnimationRootNode {
 	StringName backward = "backward"; // Only used by pingpong animation.
 
 	StringName animation;
+	mutable uint32_t animation_version = 1;
 
 	bool advance_on_start = false;
 
@@ -54,16 +55,18 @@ public:
 		PLAY_MODE_BACKWARD
 	};
 
-	void get_parameter_list(List<PropertyInfo> *r_list) const override;
-	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
+	virtual void validate_node(const AnimationTree *p_tree, const StringName &p_path) const override;
 
-	virtual NodeTimeInfo get_node_time_info() const override; // Wrapper of get_parameter().
+	void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
+	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	static LocalVector<StringName> (*get_editable_animation_list)();
 
 	virtual String get_caption() const override;
-	virtual NodeTimeInfo process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	_FORCE_INLINE_ virtual double get_process_delta(AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info) const override final {
+		return (p_instance.get_parameter_backward() ? -p_playback_info.delta : p_playback_info.delta);
+	}
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	void set_animation(const StringName &p_name);
 	StringName get_animation() const;
@@ -71,8 +74,8 @@ public:
 	void set_play_mode(PlayMode p_play_mode);
 	PlayMode get_play_mode() const;
 
-	void set_backward(bool p_backward);
-	bool is_backward() const;
+	void set_backward(AnimationNodeInstance &p_instance, ProcessState &p_process_state, bool p_backward);
+	bool is_backward(AnimationNodeInstance &p_instance, ProcessState &p_process_state) const;
 
 	void set_advance_on_start(bool p_advance_on_start);
 	bool is_advance_on_start() const;
@@ -100,6 +103,8 @@ protected:
 
 private:
 	PlayMode play_mode = PLAY_MODE_FORWARD;
+
+	void _update_animation_cache(AnimationTree *p_tree, AnimationNodeInstance &p_instance) const;
 };
 
 VARIANT_ENUM_CAST(AnimationNodeAnimation::PlayMode)
@@ -159,7 +164,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 	virtual bool is_parameter_read_only(const StringName &p_parameter) const override;
 
@@ -195,7 +200,7 @@ public:
 	bool is_aborted_on_reset() const;
 
 	virtual bool has_filter() const override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	AnimationNodeOneShot();
 };
@@ -209,13 +214,13 @@ class AnimationNodeAdd2 : public AnimationNodeSync {
 	StringName add_amount = PNAME("add_amount");
 
 public:
-	void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
 
 	virtual bool has_filter() const override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	AnimationNodeAdd2();
 };
@@ -226,13 +231,13 @@ class AnimationNodeAdd3 : public AnimationNodeSync {
 	StringName add_amount = PNAME("add_amount");
 
 public:
-	void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
 
 	virtual bool has_filter() const override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	AnimationNodeAdd3();
 };
@@ -243,11 +248,11 @@ class AnimationNodeBlend2 : public AnimationNodeSync {
 	StringName blend_amount = PNAME("blend_amount");
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	virtual bool has_filter() const override;
 	AnimationNodeBlend2();
@@ -259,12 +264,12 @@ class AnimationNodeBlend3 : public AnimationNodeSync {
 	StringName blend_amount = PNAME("blend_amount");
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
 
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 	AnimationNodeBlend3();
 };
 
@@ -274,13 +279,13 @@ class AnimationNodeSub2 : public AnimationNodeSync {
 	StringName sub_amount = PNAME("sub_amount");
 
 public:
-	void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
 
 	virtual bool has_filter() const override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	AnimationNodeSub2();
 };
@@ -291,12 +296,12 @@ class AnimationNodeTimeScale : public AnimationNode {
 	StringName scale = PNAME("scale");
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
 
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	AnimationNodeTimeScale();
 };
@@ -311,12 +316,12 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
 
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	void set_explicit_elapse(bool p_enable);
 	bool is_explicit_elapse() const;
@@ -353,7 +358,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 	virtual bool is_parameter_read_only(const StringName &p_parameter) const override;
 
@@ -383,7 +388,7 @@ public:
 	void set_allow_transition_to_self(bool p_enable);
 	bool is_allow_transition_to_self() const;
 
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	AnimationNodeTransition();
 };
@@ -393,7 +398,7 @@ class AnimationNodeOutput : public AnimationNode {
 
 public:
 	virtual String get_caption() const override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 	AnimationNodeOutput();
 };
 
@@ -405,14 +410,14 @@ class AnimationNodeBlendTree : public AnimationRootNode {
 	struct Node {
 		Ref<AnimationNode> node;
 		Vector2 position;
-		Vector<StringName> connections;
+		LocalVector<StringName> connections;
 	};
 
 	AHashMap<StringName, Node> nodes;
 
 	Vector2 graph_offset;
 
-	void _node_changed(const StringName &p_node);
+	void _child_node_changed(const StringName &p_node);
 
 	void _initialize_node_tree();
 
@@ -439,18 +444,19 @@ public:
 		//no need to check for cycles due to tree topology
 	};
 
-	void add_node(const StringName &p_name, Ref<AnimationNode> p_node, const Vector2 &p_position = Vector2());
+	virtual void validate_node(const AnimationTree *p_tree, const StringName &p_path) const override;
+
+	void add_node(const StringName &p_name, const Ref<AnimationNode> &p_node, const Vector2 &p_position = Vector2());
 	Ref<AnimationNode> get_node(const StringName &p_name) const;
 	void remove_node(const StringName &p_name);
 	void rename_node(const StringName &p_name, const StringName &p_new_name);
 	bool has_node(const StringName &p_name) const;
-	StringName get_node_name(const Ref<AnimationNode> &p_node) const;
-	Vector<StringName> get_node_connection_array(const StringName &p_name) const;
+	const LocalVector<StringName> *get_node_connection_array(const StringName &p_name) const;
 
 	void set_node_position(const StringName &p_node, const Vector2 &p_position);
 	Vector2 get_node_position(const StringName &p_node) const;
 
-	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
+	virtual void get_child_nodes(LocalVector<ChildNode> *r_child_nodes) override;
 
 	void connect_node(const StringName &p_input_node, int p_input_index, const StringName &p_output_node);
 	void disconnect_node(const StringName &p_node, int p_input_index);
@@ -462,10 +468,10 @@ public:
 	};
 
 	ConnectionError can_connect_node(const StringName &p_input_node, int p_input_index, const StringName &p_output_node) const;
-	void get_node_connections(List<NodeConnection> *r_connections) const;
+	void get_node_connections(LocalVector<NodeConnection> *r_connections) const;
 
 	virtual String get_caption() const override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	LocalVector<StringName> get_node_list() const;
 	TypedArray<StringName> get_node_list_as_typed_array() const;

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -167,7 +167,6 @@ void AnimationMixer::_animation_set_cache_update() {
 				ad = &animation_set.insert(key, AnimationData())->value; // 2) Hash key and lookup again.
 				ad->animation = K.value;
 				ad->animation_library = lib.name;
-				ad->name = key;
 				ad->last_update = animation_set_update_pass;
 				cache_valid = false;
 			} else {
@@ -185,6 +184,7 @@ void AnimationMixer::_animation_set_cache_update() {
 	}
 
 	// Check removed.
+	// TODO: Can we avoid this nonsense by iterating in reverse?
 	LocalVector<StringName> to_erase;
 	for (const KeyValue<StringName, AnimationData> &E : animation_set) {
 		if (E.value.last_update != animation_set_update_pass) {
@@ -988,6 +988,11 @@ bool AnimationMixer::_update_caches() {
 		K.value->blend_idx = track_map[K.value->path];
 	}
 
+	track_map_version++;
+	if (track_map_version == 0) {
+		track_map_version = 1;
+	}
+
 	animation_track_num_to_track_cache.clear();
 	for (const StringName &E : sname_list) {
 		const Ref<Animation> &anim = get_animation(E);
@@ -1142,14 +1147,11 @@ void AnimationMixer::blend_capture(double p_delta) {
 	}
 
 	// Build capture animation instance.
-	AnimationData ad;
-	ad.animation = capture_cache.animation;
-
 	PlaybackInfo pi;
 	pi.weight = weight;
 
 	AnimationInstance ai;
-	ai.animation_data = ad;
+	ai.animation = capture_cache.animation;
 	ai.playback_info = pi;
 
 	animation_instances.push_back(ai);
@@ -1157,12 +1159,12 @@ void AnimationMixer::blend_capture(double p_delta) {
 
 void AnimationMixer::_blend_calc_total_weight() {
 	for (const AnimationInstance &ai : animation_instances) {
-		const Ref<Animation> &a = ai.animation_data.animation;
+		const Ref<Animation> &a = ai.animation;
 		real_t weight = ai.playback_info.weight;
 		if (Math::is_zero_approx(weight)) {
 			continue;
 		}
-		Span<real_t> track_weights = ai.playback_info.track_weights;
+		Span<real_t> track_weights = ai.playback_info.track_weights != nullptr ? *ai.playback_info.track_weights : Span<real_t>();
 
 		LocalVector<TrackCache *> *t_cache = animation_track_num_to_track_cache.getptr(a);
 		ERR_CONTINUE_EDMSG(!t_cache, "No animation in cache.");
@@ -1222,7 +1224,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 	bool can_call = is_inside_tree() && !Engine::get_singleton()->is_editor_hint();
 #endif // TOOLS_ENABLED
 	for (const AnimationInstance &ai : animation_instances) {
-		const Ref<Animation> &a = ai.animation_data.animation;
+		const Ref<Animation> &a = ai.animation;
 		double time = ai.playback_info.time;
 		double delta = ai.playback_info.delta;
 		double start = ai.playback_info.start;
@@ -1256,7 +1258,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 			int blend_idx = track->blend_idx;
 			ERR_CONTINUE(blend_idx < 0 || blend_idx >= track_count);
 			real_t blend;
-			Span<real_t> track_weights = ai.playback_info.track_weights;
+			Span<real_t> track_weights = ai.playback_info.track_weights != nullptr ? *ai.playback_info.track_weights : Span<real_t>();
 			if (!track_weights.is_empty() && blend_idx < static_cast<int>(track_weights.size())) {
 				blend = track_weights[blend_idx] * weight;
 			} else {
@@ -1920,6 +1922,10 @@ void AnimationMixer::_blend_apply() {
 					if (!t_skeleton) {
 						return;
 					}
+
+					// TODO: Once https://github.com/godotengine/godot/pull/113441 makes it in
+					// Use set_bone_pose_components when loc_used, rot_used, and scale_used are all true.
+
 					if (t->loc_used) {
 						t_skeleton->set_bone_pose_position(t->bone_idx, t->loc);
 					}
@@ -1935,14 +1941,19 @@ void AnimationMixer::_blend_apply() {
 					if (!t_node_3d) {
 						return;
 					}
-					if (t->loc_used) {
-						t_node_3d->set_position(t->loc);
-					}
-					if (t->rot_used) {
-						t_node_3d->set_rotation(t->rot.get_euler());
-					}
-					if (t->scale_used) {
-						t_node_3d->set_scale(t->scale);
+					if (t->loc_used && t->rot_used && t->scale_used) {
+						Transform3D transform = Transform3D(Basis(t->rot).scaled(t->scale), t->loc);
+						t_node_3d->set_transform(transform);
+					} else {
+						if (t->loc_used) {
+							t_node_3d->set_position(t->loc);
+						}
+						if (t->rot_used) {
+							t_node_3d->set_rotation(t->rot.get_euler());
+						}
+						if (t->scale_used) {
+							t_node_3d->set_scale(t->scale);
+						}
 					}
 				}
 #endif // _3D_DISABLED
@@ -2084,13 +2095,9 @@ void AnimationMixer::_call_object(ObjectID p_object_id, const StringName &p_meth
 void AnimationMixer::make_animation_instance(const StringName &p_name, const PlaybackInfo &p_playback_info) {
 	const Ref<Animation> &animation = get_animation_or_null(p_name);
 	ERR_FAIL_COND(animation.is_null());
-	AnimationData ad;
-	ad.name = p_name;
-	ad.animation = get_animation(p_name);
-	ad.animation_library = find_animation_library(ad.animation);
 
 	AnimationInstance ai;
-	ai.animation_data = std::move(ad);
+	ai.animation = animation;
 	ai.playback_info = p_playback_info;
 
 	animation_instances.push_back(std::move(ai));

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -76,7 +76,6 @@ public:
 	};
 
 	struct AnimationData {
-		StringName name;
 		Ref<Animation> animation;
 		StringName animation_library;
 		uint64_t last_update = 0;
@@ -91,14 +90,11 @@ public:
 		bool is_external_seeking = false;
 		Animation::LoopedFlag looped_flag = Animation::LOOPED_FLAG_NONE;
 		real_t weight = 0.0;
-		// HACK: For now this will still have to be a copy, since we don't have AnimationNodeInstance yet...
-		Vector<real_t> track_weights;
-		// TODO: When rebasing https://github.com/godotengine/godot/pull/113444, update this to use LocalVector instead.
-		// LocalVector<real_t> *track_weights = nullptr;
+		LocalVector<real_t> *track_weights = nullptr;
 	};
 
 	struct AnimationInstance {
-		AnimationData animation_data;
+		Ref<Animation> animation;
 		PlaybackInfo playback_info;
 	};
 
@@ -328,6 +324,7 @@ protected:
 	LocalVector<AnimationInstance> animation_instances;
 	uint64_t animation_instance_weight_pass_counter = 0;
 	AHashMap<NodePath, int> track_map;
+	uint64_t track_map_version = 1;
 	int track_count = 0;
 	bool deterministic = false;
 

--- a/scene/animation/animation_node_extension.cpp
+++ b/scene/animation/animation_node_extension.cpp
@@ -32,7 +32,7 @@
 
 #include "core/object/class_db.h"
 
-AnimationNode::NodeTimeInfo AnimationNodeExtension::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
+AnimationNode::NodeTimeInfo AnimationNodeExtension::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
 	PackedFloat32Array r_ret;
 
 	GDVIRTUAL_CALL(

--- a/scene/animation/animation_node_extension.h
+++ b/scene/animation/animation_node_extension.h
@@ -36,7 +36,7 @@ class AnimationNodeExtension : public AnimationNode {
 	GDCLASS(AnimationNodeExtension, AnimationNode);
 
 public:
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	static bool is_looping(const PackedFloat32Array &p_node_info);
 	static double get_remaining_time(const PackedFloat32Array &p_node_info, bool p_break_loop = false);

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -196,7 +196,7 @@ AnimationNodeStateMachineTransition::AnimationNodeStateMachineTransition() {
 
 ////////////////////////////////////////////////////////
 
-void AnimationNodeStateMachinePlayback::_set_current(AnimationNodeStateMachine *p_state_machine, const StringName &p_state) {
+void AnimationNodeStateMachinePlayback::_set_current(AnimationNode::ProcessState &p_process_state, AnimationNodeStateMachine *p_state_machine, const StringName &p_state) {
 	current = p_state;
 	if (current == StringName()) {
 		group_start_transition = Ref<AnimationNodeStateMachineTransition>();
@@ -204,7 +204,7 @@ void AnimationNodeStateMachinePlayback::_set_current(AnimationNodeStateMachine *
 		return;
 	}
 
-	AnimationTree *tree = p_state_machine->process_state ? p_state_machine->process_state->tree : nullptr;
+	AnimationTree *tree = p_process_state.tree;
 	Ref<AnimationNodeStateMachine> anodesm = p_state_machine->find_node_by_path(current);
 	if (anodesm.is_null()) {
 		group_start_transition = Ref<AnimationNodeStateMachineTransition>();
@@ -358,9 +358,9 @@ bool _is_grouped_state_machine(const Ref<AnimationNodeStateMachine> p_node) {
 	return p_node.is_valid() && p_node->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED;
 }
 
-void AnimationNodeStateMachinePlayback::_clear_fading(AnimationNodeStateMachine *p_state_machine, const StringName &p_state) {
+void AnimationNodeStateMachinePlayback::_clear_fading(AnimationNode::ProcessState &p_process_state, AnimationNodeStateMachine *p_state_machine, const StringName &p_state) {
 	if (!p_state.is_empty() && !_is_grouped_state_machine(p_state_machine->get_node(p_state))) {
-		_signal_state_change(p_state_machine->get_animation_tree(), p_state, false);
+		_signal_state_change(p_process_state.tree, p_state, false);
 	}
 	fading_from = StringName();
 	fadeing_from_nti = AnimationNode::NodeTimeInfo();
@@ -377,8 +377,8 @@ void AnimationNodeStateMachinePlayback::_signal_state_change(AnimationTree *p_an
 	emit_signal(p_started ? SceneStringName(state_started) : SceneStringName(state_finished), p_state);
 }
 
-void AnimationNodeStateMachinePlayback::_clear_path_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_test_only) {
-	List<AnimationNode::ChildNode> child_nodes;
+void AnimationNodeStateMachinePlayback::_clear_path_children(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_test_only) {
+	LocalVector<AnimationNode::ChildNode> child_nodes;
 	p_state_machine->get_child_nodes(&child_nodes);
 	for (const AnimationNode::ChildNode &child_node : child_nodes) {
 		Ref<AnimationNodeStateMachine> anodesm = child_node.node;
@@ -390,9 +390,9 @@ void AnimationNodeStateMachinePlayback::_clear_path_children(AnimationTree *p_tr
 				playback = playback->duplicate();
 			}
 			playback->path.clear();
-			playback->_clear_path_children(p_tree, anodesm.ptr(), p_test_only);
+			playback->_clear_path_children(p_process_state, p_tree, anodesm.ptr(), p_test_only);
 			if (current != child_node.name) {
-				playback->_start(anodesm.ptr()); // Can restart.
+				playback->_start(p_process_state, anodesm.ptr()); // Can restart.
 			}
 		}
 	}
@@ -425,7 +425,7 @@ void AnimationNodeStateMachinePlayback::_start_children(AnimationTree *p_tree, A
 	}
 }
 
-bool AnimationNodeStateMachinePlayback::_travel_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_is_allow_transition_to_self, bool p_is_parent_same_state, bool p_test_only) {
+bool AnimationNodeStateMachinePlayback::_travel_children(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_is_allow_transition_to_self, bool p_is_parent_same_state, bool p_test_only) {
 	if (p_state_machine->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
 		return false; // This function must be fired only by the top state machine, do nothing in child state machine.
 	}
@@ -452,7 +452,7 @@ bool AnimationNodeStateMachinePlayback::_travel_children(AnimationTree *p_tree, 
 				playback = playback->duplicate();
 			}
 			if (!playback->is_playing()) {
-				playback->_start(anodesm.ptr());
+				playback->_start(p_process_state, anodesm.ptr());
 			}
 			ChildStateMachineInfo child_info;
 			child_info.playback = playback;
@@ -475,18 +475,18 @@ bool AnimationNodeStateMachinePlayback::_travel_children(AnimationTree *p_tree, 
 						child_playback = child_playback->duplicate();
 					}
 					child_playback->_travel_main(SceneStringName(End));
-					child_found_route &= child_playback->_travel(p_tree, child_anodesm.ptr(), false, p_test_only);
+					child_found_route &= child_playback->_travel(p_process_state, p_tree, child_anodesm.ptr(), false, p_test_only);
 					child_path += "/" + child_playback->get_current_node();
 				}
 				// Force restart target state machine.
-				playback->_start(anodesm.ptr());
+				playback->_start(p_process_state, anodesm.ptr());
 			}
 			is_parent_same_state = is_current_same_state;
 
 			bool is_deepest_state = i == temp_path.size() - 1;
 			child_info.is_reset = is_deepest_state ? reset_request_on_teleport : false;
 			playback->_travel_main(temp_path[i], child_info.is_reset);
-			if (playback->_make_travel_path(p_tree, anodesm.ptr(), is_deepest_state ? p_is_allow_transition_to_self : false, child_info.path, p_test_only)) {
+			if (playback->_make_travel_path(p_process_state, p_tree, anodesm.ptr(), is_deepest_state ? p_is_allow_transition_to_self : false, child_info.path, p_test_only)) {
 				found_route &= child_found_route;
 			} else {
 				child_info.path.push_back(temp_path[i]);
@@ -515,16 +515,16 @@ bool AnimationNodeStateMachinePlayback::_travel_children(AnimationTree *p_tree, 
 	return found_route;
 }
 
-void AnimationNodeStateMachinePlayback::_start(AnimationNodeStateMachine *p_state_machine) {
+void AnimationNodeStateMachinePlayback::_start(AnimationNode::ProcessState &p_process_state, AnimationNodeStateMachine *p_state_machine) {
 	playing = true;
-	_set_current(p_state_machine, start_request != StringName() ? start_request : SceneStringName(Start));
+	_set_current(p_process_state, p_state_machine, start_request != StringName() ? start_request : SceneStringName(Start));
 	teleport_request = true;
 	stop_request = false;
 	start_request = StringName();
 }
 
-bool AnimationNodeStateMachinePlayback::_travel(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, bool p_test_only) {
-	return _make_travel_path(p_tree, p_state_machine, p_is_allow_transition_to_self, path, p_test_only);
+bool AnimationNodeStateMachinePlayback::_travel(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, bool p_test_only) {
+	return _make_travel_path(p_process_state, p_tree, p_state_machine, p_is_allow_transition_to_self, path, p_test_only);
 }
 
 String AnimationNodeStateMachinePlayback::_validate_path(AnimationNodeStateMachine *p_state_machine, const String &p_path) {
@@ -545,12 +545,12 @@ String AnimationNodeStateMachinePlayback::_validate_path(AnimationNodeStateMachi
 	return target;
 }
 
-bool AnimationNodeStateMachinePlayback::_make_travel_path(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, Vector<StringName> &r_path, bool p_test_only) {
+bool AnimationNodeStateMachinePlayback::_make_travel_path(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, Vector<StringName> &r_path, bool p_test_only) {
 	StringName travel = travel_request;
 	travel_request = StringName();
 
 	if (!playing) {
-		_start(p_state_machine);
+		_start(p_process_state, p_state_machine);
 	}
 
 	ERR_FAIL_COND_V(!p_state_machine->states.has(travel), false);
@@ -682,13 +682,13 @@ bool AnimationNodeStateMachinePlayback::_make_travel_path(AnimationTree *p_tree,
 					playback = playback->duplicate();
 				}
 				if (i > 0) {
-					playback->_start(anodesm.ptr());
+					playback->_start(p_process_state, anodesm.ptr());
 				}
 				if (i >= new_path.size()) {
 					break; // Tracing has been finished, needs to break.
 				}
 				playback->_travel_main(SceneStringName(End));
-				if (!playback->_travel(p_tree, anodesm.ptr(), false, p_test_only)) {
+				if (!playback->_travel(p_process_state, p_tree, anodesm.ptr(), false, p_test_only)) {
 					found_route = false;
 					break;
 				}
@@ -709,8 +709,8 @@ bool AnimationNodeStateMachinePlayback::_make_travel_path(AnimationTree *p_tree,
 	}
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	AnimationNode::NodeTimeInfo nti = _process(p_state_machine, p_playback_info, p_test_only);
+AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::process(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
+	AnimationNode::NodeTimeInfo nti = _process(p_process_state, p_instance, p_state_machine, p_playback_info, p_test_only);
 	start_request = StringName();
 	next_request = false;
 	stop_request = false;
@@ -718,8 +718,8 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::process(Animation
 	return nti;
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	AnimationTree *tree = p_state_machine->process_state->tree;
+AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
+	AnimationTree *tree = p_process_state.tree;
 
 	double p_time = p_playback_info.time;
 	double p_delta = p_playback_info.delta;
@@ -732,9 +732,9 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 			// Restart state machine.
 			if (p_state_machine->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
 				path.clear();
-				_clear_path_children(tree, p_state_machine, p_test_only);
+				_clear_path_children(p_process_state, tree, p_state_machine, p_test_only);
 			}
-			_start(p_state_machine);
+			_start(p_process_state, p_state_machine);
 			reset_request = true;
 		} else {
 			// Reset current state.
@@ -758,7 +758,7 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 	// Process start/travel request.
 	if (start_request != StringName() || travel_request != StringName()) {
 		if (p_state_machine->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
-			_clear_path_children(tree, p_state_machine, p_test_only);
+			_clear_path_children(p_process_state, tree, p_state_machine, p_test_only);
 		}
 	}
 
@@ -772,7 +772,7 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 		}
 		// Teleport to start.
 		if (p_state_machine->states.has(start_request)) {
-			_start(p_state_machine);
+			_start(p_process_state, p_state_machine);
 		} else {
 			StringName node = start_request;
 			ERR_FAIL_V_MSG(AnimationNode::NodeTimeInfo(), "No such node: '" + node + "'");
@@ -787,10 +787,10 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 		StringName temp_travel_request = travel_request; // For the case that can't travel.
 		// Process children.
 		Vector<StringName> new_path;
-		bool can_travel = _make_travel_path(tree, p_state_machine, travel_path.size() <= 1 ? p_state_machine->is_allow_transition_to_self() : false, new_path, p_test_only);
+		bool can_travel = _make_travel_path(p_process_state, tree, p_state_machine, travel_path.size() <= 1 ? p_state_machine->is_allow_transition_to_self() : false, new_path, p_test_only);
 		if (travel_path.size()) {
 			if (can_travel) {
-				can_travel = _travel_children(tree, p_state_machine, travel_target, p_state_machine->is_allow_transition_to_self(), travel_path[0] == current, p_test_only);
+				can_travel = _travel_children(p_process_state, tree, p_state_machine, travel_target, p_state_machine->is_allow_transition_to_self(), travel_path[0] == current, p_test_only);
 			} else {
 				_start_children(tree, p_state_machine, travel_target, p_test_only);
 			}
@@ -804,7 +804,7 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 			if (p_state_machine->states.has(temp_travel_request)) {
 				path.clear();
 				if (current != temp_travel_request || reset_request_on_teleport) {
-					_set_current(p_state_machine, temp_travel_request);
+					_set_current(p_process_state, p_state_machine, temp_travel_request);
 					reset_request = reset_request_on_teleport;
 					teleport_request = true;
 				}
@@ -827,15 +827,16 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 		pi.seeked = true;
 		pi.is_external_seeking = false;
 		pi.weight = 0;
-		current_nti = p_state_machine->blend_node(p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, true);
+		AnimationNodeInstance *other_instance = p_instance.get_child_instance_by_path_or_null(current);
+		current_nti = p_state_machine->blend_node(p_process_state, p_instance, other_instance, pi, AnimationNode::FILTER_IGNORE, true, true);
 		// Don't process first node if not necessary, instead process next node.
-		_transition_to_next_recursive(tree, p_state_machine, p_delta, p_test_only);
+		_transition_to_next_recursive(p_process_state, p_instance, tree, p_state_machine, p_delta, p_test_only);
 	}
 
 	// Check current node existence.
 	if (!p_state_machine->states.has(current)) {
 		playing = false; // Current does not exist.
-		_set_current(p_state_machine, StringName());
+		_set_current(p_process_state, p_state_machine, StringName());
 		return AnimationNode::NodeTimeInfo();
 	}
 
@@ -877,7 +878,8 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 		pi.time = 0;
 		pi.seeked = true;
 	}
-	current_nti = p_state_machine->blend_node(p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
+	AnimationNodeInstance *other_instance = p_instance.get_child_instance_by_path_or_null(current);
+	current_nti = p_state_machine->blend_node(p_process_state, p_instance, other_instance, pi, AnimationNode::FILTER_IGNORE, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
 
 	// Cross-fade process.
 	if (fading_from != StringName()) {
@@ -896,16 +898,17 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 			pi.time = 0;
 			pi.seeked = true;
 		}
-		fadeing_from_nti = p_state_machine->blend_node(p_state_machine->states[fading_from].node, fading_from, pi, AnimationNode::FILTER_IGNORE, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
+		AnimationNodeInstance *fading_from_instance = p_instance.get_child_instance_by_path_or_null(fading_from);
+		fadeing_from_nti = p_state_machine->blend_node(p_process_state, p_instance, fading_from_instance, pi, AnimationNode::FILTER_IGNORE, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
 
 		if (Animation::is_greater_or_equal_approx(fading_pos, fading_time)) {
 			// Finish fading.
-			_clear_fading(p_state_machine, fading_from);
+			_clear_fading(p_process_state, p_state_machine, fading_from);
 		}
 	}
 
 	// Find next and see when to transition.
-	bool will_end = _transition_to_next_recursive(tree, p_state_machine, p_delta, p_test_only) || current == SceneStringName(End);
+	bool will_end = _transition_to_next_recursive(p_process_state, p_instance, tree, p_state_machine, p_delta, p_test_only) || current == SceneStringName(End);
 
 	// Predict remaining time.
 	if (will_end || ((p_state_machine->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_NESTED) && !p_state_machine->has_transition_from(current))) {
@@ -923,7 +926,7 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 	return current_nti;
 }
 
-bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, double p_delta, bool p_test_only) {
+bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, double p_delta, bool p_test_only) {
 	_reset_request_for_fading_from = false;
 
 	AnimationMixer::PlaybackInfo pi;
@@ -932,9 +935,9 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 	Vector<StringName> transition_path;
 	transition_path.push_back(current);
 	while (true) {
-		next = _find_next(p_tree, p_state_machine);
+		next = _find_next(p_process_state, p_instance, p_tree, p_state_machine);
 
-		if (!_can_transition_to_next(p_tree, p_state_machine, next, p_test_only)) {
+		if (!_can_transition_to_next(p_process_state, p_tree, p_state_machine, next, p_test_only)) {
 			break; // Finish transition.
 		}
 
@@ -958,9 +961,10 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 				pi.seeked = true;
 				pi.is_external_seeking = false;
 				pi.weight = 0;
-				p_state_machine->blend_node(p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, p_test_only);
+				AnimationNodeInstance *other_instance = p_instance.get_child_instance_by_path_or_null(current);
+				p_state_machine->blend_node(p_process_state, p_instance, other_instance, pi, AnimationNode::FILTER_IGNORE, true, p_test_only);
 			}
-			_clear_fading(p_state_machine, current);
+			_clear_fading(p_process_state, p_state_machine, current);
 			fading_time = 0;
 			fading_pos = 0;
 		}
@@ -971,7 +975,7 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 		}
 
 		// Update current status.
-		_set_current(p_state_machine, next.node);
+		_set_current(p_process_state, p_state_machine, next.node);
 		current_curve = next.curve;
 
 		if (current == SceneStringName(End)) {
@@ -983,12 +987,13 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 
 		fadeing_from_nti = current_nti;
 
+		AnimationNodeInstance *other_instance = p_instance.get_child_instance_by_path_or_null(current);
 		if (next.switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_SYNC) {
 			pi.time = current_nti.position;
 			pi.seeked = true;
 			pi.is_external_seeking = false;
 			pi.weight = 0;
-			p_state_machine->blend_node(p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, p_test_only);
+			p_state_machine->blend_node(p_process_state, p_instance, other_instance, pi, AnimationNode::FILTER_IGNORE, true, p_test_only);
 		}
 
 		// Just get length to find next recursive.
@@ -996,7 +1001,7 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 		pi.is_external_seeking = false;
 		pi.weight = 0;
 		pi.seeked = next.is_reset;
-		current_nti = p_state_machine->blend_node(p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, true); // Just retrieve remain length, don't process.
+		current_nti = p_state_machine->blend_node(p_process_state, p_instance, other_instance, pi, AnimationNode::FILTER_IGNORE, true, true); // Just retrieve remain length, don't process.
 
 		// Fading must be processed.
 		if (fading_time) {
@@ -1007,7 +1012,7 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 	return next.node == SceneStringName(End);
 }
 
-bool AnimationNodeStateMachinePlayback::_can_transition_to_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, NextInfo p_next, bool p_test_only) {
+bool AnimationNodeStateMachinePlayback::_can_transition_to_next(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, NextInfo p_next, bool p_test_only) {
 	if (p_next.node == StringName()) {
 		return false;
 	}
@@ -1026,7 +1031,7 @@ bool AnimationNodeStateMachinePlayback::_can_transition_to_next(AnimationTree *p
 			}
 			playback->_next_main();
 			// Then, fading should end.
-			_clear_fading(p_state_machine, fading_from);
+			_clear_fading(p_process_state, p_state_machine, fading_from);
 			fading_pos = 0;
 		} else {
 			return true;
@@ -1067,7 +1072,7 @@ Ref<AnimationNodeStateMachineTransition> AnimationNodeStateMachinePlayback::_che
 	return p_transition.transition;
 }
 
-AnimationNodeStateMachinePlayback::NextInfo AnimationNodeStateMachinePlayback::_find_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine) const {
+AnimationNodeStateMachinePlayback::NextInfo AnimationNodeStateMachinePlayback::_find_next(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine) const {
 	NextInfo next;
 	if (path.size()) {
 		for (int i = 0; i < p_state_machine->transitions.size(); i++) {
@@ -1096,7 +1101,7 @@ AnimationNodeStateMachinePlayback::NextInfo AnimationNodeStateMachinePlayback::_
 			if (ref_transition->get_advance_mode() == AnimationNodeStateMachineTransition::ADVANCE_MODE_DISABLED) {
 				continue;
 			}
-			if (p_state_machine->transitions[i].from == current && (_check_advance_condition(anodesm, ref_transition) || bypass)) {
+			if (p_state_machine->transitions[i].from == current && (_check_advance_condition(p_process_state, p_instance, anodesm, ref_transition) || bypass)) {
 				if (ref_transition->get_priority() <= priority_best) {
 					priority_best = ref_transition->get_priority();
 					auto_advance_to = i;
@@ -1120,19 +1125,21 @@ AnimationNodeStateMachinePlayback::NextInfo AnimationNodeStateMachinePlayback::_
 	return next;
 }
 
-bool AnimationNodeStateMachinePlayback::_check_advance_condition(const Ref<AnimationNodeStateMachine> state_machine, const Ref<AnimationNodeStateMachineTransition> transition) const {
+bool AnimationNodeStateMachinePlayback::_check_advance_condition(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, const Ref<AnimationNodeStateMachine> state_machine, const Ref<AnimationNodeStateMachineTransition> transition) const {
 	if (transition->get_advance_mode() != AnimationNodeStateMachineTransition::ADVANCE_MODE_AUTO) {
 		return false;
 	}
 
 	StringName advance_condition_name = transition->get_advance_condition_name();
 
-	if (advance_condition_name != StringName() && !bool(state_machine->get_parameter(advance_condition_name))) {
+	ERR_FAIL_COND_V(p_instance.resource != state_machine, false);
+
+	if (advance_condition_name != StringName() && !bool(p_instance.get_parameter(advance_condition_name))) {
 		return false;
 	}
 
 	if (transition->expression.is_valid()) {
-		AnimationTree *tree_base = state_machine->get_animation_tree();
+		AnimationTree *tree_base = p_process_state.tree;
 		ERR_FAIL_NULL_V(tree_base, false);
 
 		NodePath advance_expression_base_node_path = tree_base->get_advance_expression_base_node();
@@ -1240,7 +1247,7 @@ AnimationNodeStateMachinePlayback::AnimationNodeStateMachinePlayback() {
 
 ///////////////////////////////////////////////////////
 
-void AnimationNodeStateMachine::get_parameter_list(List<PropertyInfo> *r_list) const {
+void AnimationNodeStateMachine::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::OBJECT, playback, PROPERTY_HINT_RESOURCE_TYPE, AnimationNodeStateMachinePlayback::get_class_static(), PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_ALWAYS_DUPLICATE)); // Don't store this object in .tres, it always needs to be made as unique object.
 	List<StringName> advance_conditions;
@@ -1294,12 +1301,9 @@ void AnimationNodeStateMachine::add_node(const StringName &p_name, Ref<Animation
 
 	states[p_name] = state_new;
 
+	_add_node(p_node);
 	emit_changed();
-	emit_signal(SNAME("tree_changed"));
-
-	p_node->connect("tree_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed), CONNECT_REFERENCE_COUNTED);
-	p_node->connect("animation_node_renamed", callable_mp(this, &AnimationNodeStateMachine::_animation_node_renamed), CONNECT_REFERENCE_COUNTED);
-	p_node->connect("animation_node_removed", callable_mp(this, &AnimationNodeStateMachine::_animation_node_removed), CONNECT_REFERENCE_COUNTED);
+	_tree_changed();
 }
 
 void AnimationNodeStateMachine::replace_node(const StringName &p_name, Ref<AnimationNode> p_node) {
@@ -1310,26 +1314,21 @@ void AnimationNodeStateMachine::replace_node(const StringName &p_name, Ref<Anima
 	{
 		Ref<AnimationNode> node = states[p_name].node;
 		if (node.is_valid()) {
-			node->disconnect("tree_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed));
-			node->disconnect("animation_node_renamed", callable_mp(this, &AnimationNodeStateMachine::_animation_node_renamed));
-			node->disconnect("animation_node_removed", callable_mp(this, &AnimationNodeStateMachine::_animation_node_removed));
+			_remove_node(node);
 		}
 	}
 
 	states[p_name].node = p_node;
 
+	_add_node(p_node);
 	emit_changed();
-	emit_signal(SNAME("tree_changed"));
-
-	p_node->connect("tree_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed), CONNECT_REFERENCE_COUNTED);
-	p_node->connect("animation_node_renamed", callable_mp(this, &AnimationNodeStateMachine::_animation_node_renamed), CONNECT_REFERENCE_COUNTED);
-	p_node->connect("animation_node_removed", callable_mp(this, &AnimationNodeStateMachine::_animation_node_removed), CONNECT_REFERENCE_COUNTED);
+	_tree_changed();
 }
 
 void AnimationNodeStateMachine::set_state_machine_type(StateMachineType p_state_machine_type) {
 	state_machine_type = p_state_machine_type;
 	emit_changed();
-	emit_signal(SNAME("tree_changed"));
+	_tree_changed();
 	notify_property_list_changed();
 }
 
@@ -1378,7 +1377,7 @@ StringName AnimationNodeStateMachine::get_node_name(const Ref<AnimationNode> &p_
 	ERR_FAIL_V(StringName());
 }
 
-void AnimationNodeStateMachine::get_child_nodes(List<ChildNode> *r_child_nodes) {
+void AnimationNodeStateMachine::get_child_nodes(LocalVector<ChildNode> *r_child_nodes) {
 	Vector<StringName> nodes;
 
 	for (const KeyValue<StringName, State> &E : states) {
@@ -1416,9 +1415,7 @@ void AnimationNodeStateMachine::remove_node(const StringName &p_name) {
 	{
 		Ref<AnimationNode> node = states[p_name].node;
 		ERR_FAIL_COND(node.is_null());
-		node->disconnect("tree_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed));
-		node->disconnect("animation_node_renamed", callable_mp(this, &AnimationNodeStateMachine::_animation_node_renamed));
-		node->disconnect("animation_node_removed", callable_mp(this, &AnimationNodeStateMachine::_animation_node_removed));
+		_remove_node(node);
 	}
 
 	states.erase(p_name);
@@ -1639,16 +1636,17 @@ Vector2 AnimationNodeStateMachine::get_graph_offset() const {
 	return graph_offset;
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeStateMachine::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	Ref<AnimationNodeStateMachinePlayback> playback_new = get_parameter(playback);
+AnimationNode::NodeTimeInfo AnimationNodeStateMachine::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
+	Ref<AnimationNodeStateMachinePlayback> playback_new = p_instance.get_parameter(playback);
 	ERR_FAIL_COND_V(playback_new.is_null(), AnimationNode::NodeTimeInfo());
-	playback_new->_set_base_path(node_state.get_base_path());
+
+	playback_new->_set_base_path(p_instance.path);
 	playback_new->_set_grouped(state_machine_type == STATE_MACHINE_TYPE_GROUPED);
 	if (p_test_only) {
 		playback_new = playback_new->duplicate(); // Don't process original when testing.
 	}
 
-	return playback_new->process(this, p_playback_info, p_test_only);
+	return playback_new->process(p_process_state, p_instance, this, p_playback_info, p_test_only);
 }
 
 String AnimationNodeStateMachine::get_caption() const {
@@ -1781,7 +1779,7 @@ void AnimationNodeStateMachine::reset_state() {
 	states[SceneStringName(End)] = end;
 
 	emit_changed();
-	emit_signal(SNAME("tree_changed"));
+	_tree_changed();
 }
 
 void AnimationNodeStateMachine::set_node_position(const StringName &p_name, const Vector2 &p_position) {

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -164,7 +164,7 @@ protected:
 	virtual void reset_state() override;
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 	virtual bool is_parameter_read_only(const StringName &p_parameter) const override;
 
@@ -181,7 +181,7 @@ public:
 	void set_node_position(const StringName &p_name, const Vector2 &p_position);
 	Vector2 get_node_position(const StringName &p_name) const;
 
-	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
+	virtual void get_child_nodes(LocalVector<ChildNode> *r_child_nodes) override;
 
 	bool has_transition(const StringName &p_from, const StringName &p_to) const;
 	bool has_transition_from(const StringName &p_from) const;
@@ -212,7 +212,7 @@ public:
 	void set_graph_offset(const Vector2 &p_offset);
 	Vector2 get_graph_offset() const;
 
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 	virtual String get_caption() const override;
 
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
@@ -289,32 +289,32 @@ class AnimationNodeStateMachinePlayback : public Resource {
 
 	bool is_grouped = false;
 
-	void _clear_fading(AnimationNodeStateMachine *p_state_machine, const StringName &p_state);
+	void _clear_fading(AnimationNode::ProcessState &p_process_state, AnimationNodeStateMachine *p_state_machine, const StringName &p_state);
 	void _signal_state_change(AnimationTree *p_animation_tree, const StringName &p_state, bool p_started);
 	void _travel_main(const StringName &p_state, bool p_reset_on_teleport = true);
 	void _start_main(const StringName &p_state, bool p_reset = true);
 	void _next_main();
 	void _stop_main();
 
-	bool _make_travel_path(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, Vector<StringName> &r_path, bool p_test_only);
+	bool _make_travel_path(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, Vector<StringName> &r_path, bool p_test_only);
 	String _validate_path(AnimationNodeStateMachine *p_state_machine, const String &p_path);
-	bool _travel(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, bool p_test_only);
-	void _start(AnimationNodeStateMachine *p_state_machine);
+	bool _travel(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, bool p_test_only);
+	void _start(AnimationNode::ProcessState &p_process_state, AnimationNodeStateMachine *p_state_machine);
 
-	void _clear_path_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_test_only);
-	bool _travel_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_is_allow_transition_to_self, bool p_is_parent_same_state, bool p_test_only);
+	void _clear_path_children(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_test_only);
+	bool _travel_children(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_is_allow_transition_to_self, bool p_is_parent_same_state, bool p_test_only);
 	void _start_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_test_only);
 
-	AnimationNode::NodeTimeInfo process(AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only);
-	AnimationNode::NodeTimeInfo _process(AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only);
+	AnimationNode::NodeTimeInfo process(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only);
+	AnimationNode::NodeTimeInfo _process(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only);
 
-	bool _check_advance_condition(const Ref<AnimationNodeStateMachine> p_state_machine, const Ref<AnimationNodeStateMachineTransition> p_transition) const;
-	bool _transition_to_next_recursive(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, double p_delta, bool p_test_only);
-	NextInfo _find_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine) const;
+	bool _check_advance_condition(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, const Ref<AnimationNodeStateMachine> p_state_machine, const Ref<AnimationNodeStateMachineTransition> p_transition) const;
+	bool _transition_to_next_recursive(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, double p_delta, bool p_test_only);
+	NextInfo _find_next(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine) const;
 	Ref<AnimationNodeStateMachineTransition> _check_group_transition(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const AnimationNodeStateMachine::Transition &p_transition, Ref<AnimationNodeStateMachine> &r_state_machine, bool &r_bypass) const;
-	bool _can_transition_to_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, NextInfo p_next, bool p_test_only);
+	bool _can_transition_to_next(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, NextInfo p_next, bool p_test_only);
 
-	void _set_current(AnimationNodeStateMachine *p_state_machine, const StringName &p_state);
+	void _set_current(AnimationNode::ProcessState &p_process_state, AnimationNodeStateMachine *p_state_machine, const StringName &p_state);
 	void _set_grouped(bool p_is_grouped);
 	void _set_base_path(const String &p_base_path);
 	Ref<AnimationNodeStateMachinePlayback> _get_parent_playback(AnimationTree *p_tree) const;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -37,7 +37,10 @@
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/animation/animation_player.h"
 
-void AnimationNode::get_parameter_list(List<PropertyInfo> *r_list) const {
+thread_local AnimationNode::ProcessState *AnimationNode::tls_process_state = nullptr;
+thread_local AnimationNodeInstance *AnimationNode::current_instance = nullptr;
+
+void AnimationNode::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	Array parameters;
 
 	if (GDVIRTUAL_CALL(_get_parameter_list, parameters)) {
@@ -75,60 +78,19 @@ bool AnimationNode::is_parameter_read_only(const StringName &p_parameter) const 
 	return false;
 }
 
-void AnimationNode::set_parameter(const StringName &p_name, const Variant &p_value) {
-	ERR_FAIL_NULL(process_state);
-	if (process_state->is_testing) {
-		return;
-	}
-
-	const AHashMap<StringName, int>::Iterator it = property_cache.find(p_name);
-	if (it) {
-		Pair<Variant, bool> &prop = process_state->tree->property_map.get_by_index(it->value).value;
-		Variant value = p_value;
-		if (Animation::validate_type_match(prop.first, value)) {
-			prop.first = value;
-		}
-		return;
-	}
-
-	ERR_FAIL_COND(!process_state->tree->property_parent_map.has(node_state.base_path));
-	ERR_FAIL_COND(!process_state->tree->property_parent_map[node_state.base_path].has(p_name));
-	StringName path = process_state->tree->property_parent_map[node_state.base_path][p_name];
-	int idx = process_state->tree->property_map.get_index(path);
-	property_cache.insert_new(p_name, idx);
-	process_state->tree->property_map.get_by_index(idx).value.first = p_value;
+void AnimationNode::set_parameter_ex(const StringName &p_name, const Variant &p_value) {
+	ERR_FAIL_NULL(tls_process_state);
+	ERR_FAIL_NULL(current_instance);
+	current_instance->set_parameter(p_name, p_value, tls_process_state->is_testing);
 }
 
-Variant AnimationNode::get_parameter(const StringName &p_name) const {
-	ERR_FAIL_NULL_V(process_state, Variant());
-	const AHashMap<StringName, int>::ConstIterator it = property_cache.find(p_name);
-	if (it) {
-		return process_state->tree->property_map.get_by_index(it->value).value.first;
-	}
-	ERR_FAIL_COND_V(!process_state->tree->property_parent_map.has(node_state.base_path), Variant());
-	ERR_FAIL_COND_V(!process_state->tree->property_parent_map[node_state.base_path].has(p_name), Variant());
-
-	StringName path = process_state->tree->property_parent_map[node_state.base_path][p_name];
-	int idx = process_state->tree->property_map.get_index(path);
-	property_cache.insert_new(p_name, idx);
-	return process_state->tree->property_map.get_by_index(idx).value.first;
+Variant AnimationNode::get_parameter_ex(const StringName &p_name) const {
+	ERR_FAIL_NULL_V(tls_process_state, Variant());
+	ERR_FAIL_NULL_V(current_instance, Variant());
+	return current_instance->get_parameter(p_name);
 }
 
-void AnimationNode::set_node_time_info(const NodeTimeInfo &p_node_time_info) {
-	set_parameter(current_length, p_node_time_info.length);
-	set_parameter(current_position, p_node_time_info.position);
-	set_parameter(current_delta, p_node_time_info.delta);
-}
-
-AnimationNode::NodeTimeInfo AnimationNode::get_node_time_info() const {
-	NodeTimeInfo nti;
-	nti.length = get_parameter(current_length);
-	nti.position = get_parameter(current_position);
-	nti.delta = get_parameter(current_delta);
-	return nti;
-}
-
-void AnimationNode::get_child_nodes(List<ChildNode> *r_child_nodes) {
+void AnimationNode::get_child_nodes(LocalVector<ChildNode> *r_child_nodes) {
 	Dictionary cn;
 	if (GDVIRTUAL_CALL(_get_child_nodes, cn)) {
 		for (const KeyValue<Variant, Variant> &kv : cn) {
@@ -140,96 +102,81 @@ void AnimationNode::get_child_nodes(List<ChildNode> *r_child_nodes) {
 	}
 }
 
-void AnimationNode::blend_animation(const StringName &p_animation, AnimationMixer::PlaybackInfo p_playback_info) {
-	ERR_FAIL_NULL(process_state);
-	// HACK: See PlaybackInfo.track_weights for more info
-	p_playback_info.track_weights = Vector<real_t>(node_state.track_weights);
-	process_state->tree->make_animation_instance(p_animation, p_playback_info);
+void AnimationNode::blend_animation(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const StringName &p_animation, AnimationMixer::PlaybackInfo &p_playback_info) {
+	p_playback_info.track_weights = &p_instance.track_weights;
+	p_process_state.tree->make_animation_instance(p_animation, p_playback_info);
 }
 
-AnimationNode::NodeTimeInfo AnimationNode::_pre_process(ProcessState *p_process_state, AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	process_state = p_process_state;
-	NodeTimeInfo nti = process(p_playback_info, p_test_only);
-	process_state = nullptr;
+AnimationNode::NodeTimeInfo AnimationNode::_pre_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
+	ERR_FAIL_NULL_V(tls_process_state, NodeTimeInfo()); // Should not ever happen.
+	ERR_FAIL_COND_V_MSG(tls_process_state != &p_process_state, NodeTimeInfo(), "AnimationNodes can only be processed from within their own AnimationTree.");
+
+	AnimationNodeInstance *prev_instance = current_instance;
+
+	current_instance = &p_instance;
+	NodeTimeInfo nti = process(p_process_state, p_instance, p_playback_info, p_test_only);
+	current_instance = prev_instance;
+
 	return nti;
 }
 
-void AnimationNode::make_invalid(const String &p_reason) {
-	ERR_FAIL_NULL(process_state);
-	process_state->valid = false;
-	if (!process_state->invalid_reasons.is_empty()) {
-		process_state->invalid_reasons += "\n";
-	}
-	process_state->invalid_reasons += String::utf8("•  ") + p_reason;
+void AnimationNode::add_validation_error(const AnimationTree *p_tree, const StringName &p_path, const String &p_error, int p_input_index) const {
+	p_tree->_add_validation_error(p_path, p_error, p_input_index);
 }
 
-AnimationTree *AnimationNode::get_animation_tree() const {
-	ERR_FAIL_NULL_V(process_state, nullptr);
-	return process_state->tree;
+void AnimationNode::make_invalid(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const String &p_reason) {
+	p_process_state.valid = false;
+
+	InvalidInstance &invalid_instance = p_process_state.invalid_instances[p_instance.path];
+	invalid_instance.errors.push_back(p_reason);
 }
 
-AnimationNode::NodeTimeInfo AnimationNode::blend_input(int p_input, AnimationMixer::PlaybackInfo p_playback_info, FilterAction p_filter, bool p_sync, bool p_test_only) {
+AnimationNode::NodeTimeInfo AnimationNode::blend_input(ProcessState &p_process_state, AnimationNodeInstance &p_instance, int p_input, const AnimationMixer::PlaybackInfo &p_playback_info, FilterAction p_filter, bool p_sync, bool p_test_only) {
 	ERR_FAIL_INDEX_V(p_input, (int64_t)inputs.size(), NodeTimeInfo());
 
-	AnimationNodeBlendTree *blend_tree = Object::cast_to<AnimationNodeBlendTree>(node_state.parent);
-	ERR_FAIL_NULL_V(blend_tree, NodeTimeInfo());
-
-	// Update connections.
-	StringName current_name = blend_tree->get_node_name(Ref<AnimationNode>(this));
-	node_state.connections = blend_tree->get_node_connection_array(current_name);
-
-	// Get node which is connected input port.
-	StringName node_name = node_state.connections[p_input];
-	if (!blend_tree->has_node(node_name)) {
-		make_invalid(vformat(RTR("Nothing connected to input '%s' of node '%s'."), get_input_name(p_input), current_name));
-		return NodeTimeInfo();
+	AnimationNodeInstance *node_instance = nullptr;
+	if (likely(p_instance.connection_instances.size() > 0)) {
+		node_instance = p_instance.connection_instances[p_input];
 	}
-
-	Ref<AnimationNode> node = blend_tree->get_node(node_name);
-	ERR_FAIL_COND_V(node.is_null(), NodeTimeInfo());
+	// Should not ever happen due to validation earlier.
+	ERR_FAIL_NULL_V(node_instance, NodeTimeInfo());
 
 	real_t activity = 0.0;
-	LocalVector<AnimationTree::Activity> *activity_ptr = process_state->tree->input_activity_map.getptr(node_state.base_path);
-	NodeTimeInfo nti = _blend_node(node, node_name, nullptr, p_playback_info, p_filter, p_sync, p_test_only, &activity);
 
-	if (activity_ptr && p_input < (int64_t)activity_ptr->size()) {
-		(*activity_ptr)[p_input].last_pass = process_state->last_pass;
-		(*activity_ptr)[p_input].activity = activity;
-	}
+	NodeTimeInfo nti = _blend_node(p_process_state, p_instance, *node_instance, p_playback_info, p_filter, p_sync, p_test_only, &activity);
+
+#ifdef ENABLE_ACTIVITY_TRACKING
+	LocalVector<AnimationNodeInstance::Activity> &input_activity = p_instance.input_activity;
+	input_activity[p_input].last_pass = p_process_state.last_pass;
+	input_activity[p_input].activity = activity;
+#endif
+
 	return nti;
 }
 
-AnimationNode::NodeTimeInfo AnimationNode::blend_node(Ref<AnimationNode> p_node, const StringName &p_subpath, AnimationMixer::PlaybackInfo p_playback_info, FilterAction p_filter, bool p_sync, bool p_test_only) {
-	ERR_FAIL_COND_V(p_node.is_null(), NodeTimeInfo());
-	p_node->node_state.connections.clear();
-	return _blend_node(p_node, p_subpath, this, p_playback_info, p_filter, p_sync, p_test_only, nullptr);
+AnimationNode::NodeTimeInfo AnimationNode::blend_node(ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationNodeInstance *p_other, const AnimationMixer::PlaybackInfo &p_playback_info, FilterAction p_filter, bool p_sync, bool p_test_only) {
+	ERR_FAIL_NULL_V(p_other, NodeTimeInfo());
+	return _blend_node(p_process_state, p_instance, *p_other, p_playback_info, p_filter, p_sync, p_test_only, nullptr);
 }
 
-AnimationNode::NodeTimeInfo AnimationNode::_blend_node(Ref<AnimationNode> p_node, const StringName &p_subpath, AnimationNode *p_new_parent, AnimationMixer::PlaybackInfo p_playback_info, FilterAction p_filter, bool p_sync, bool p_test_only, real_t *r_activity) {
-	ERR_FAIL_NULL_V(process_state, NodeTimeInfo());
+AnimationNode::NodeTimeInfo AnimationNode::_blend_node(ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationNodeInstance &p_other, AnimationMixer::PlaybackInfo p_playback_info, FilterAction p_filter, bool p_sync, bool p_test_only, real_t *r_activity) {
+	int blend_count = p_instance.track_weights.size();
 
-	int blend_count = node_state.track_weights.size();
-
-	if ((int64_t)p_node->node_state.track_weights.size() != blend_count) {
-		p_node->node_state.track_weights.resize(blend_count);
+	if ((int64_t)p_other.track_weights.size() != blend_count) {
+		p_other.track_weights.resize(blend_count);
 	}
 
-	real_t *blendw = p_node->node_state.track_weights.ptr();
-	const real_t *blendr = node_state.track_weights.ptr();
+	real_t *blendw = p_other.track_weights.ptr();
+	const real_t *blendr = p_instance.track_weights.ptr();
 
 	bool any_valid = false;
 
 	if (has_filter() && is_filter_enabled() && p_filter != FILTER_IGNORE) {
-		for (int i = 0; i < blend_count; i++) {
-			blendw[i] = 0.0; // All to zero by default.
-		}
+		_update_filter_cache(p_process_state, p_instance);
+		// All to zero by default.
+		memset(blendw, 0, sizeof(real_t) * blend_count);
 
-		for (const KeyValue<NodePath, bool> &E : filter) {
-			const AHashMap<NodePath, int> &map = *process_state->track_map;
-			if (!map.has(E.key)) {
-				continue;
-			}
-			int idx = map[E.key];
+		for (const int idx : p_instance.filtered_track_indices_cache) {
 			blendw[idx] = 1.0; // Filtered goes to one.
 		}
 
@@ -294,33 +241,19 @@ AnimationNode::NodeTimeInfo AnimationNode::_blend_node(Ref<AnimationNode> p_node
 
 	if (r_activity) {
 		*r_activity = 0;
+#ifdef ENABLE_ACTIVITY_TRACKING
 		for (int i = 0; i < blend_count; i++) {
 			*r_activity = MAX(*r_activity, Math::abs(blendw[i]));
 		}
-	}
-
-	String new_path;
-	AnimationNode *new_parent;
-
-	// This is the slowest part of processing, but as strings process in powers of 2, and the paths always exist, it will not result in that many allocations.
-	if (p_new_parent) {
-		new_parent = p_new_parent;
-		new_path = String(node_state.base_path) + String(p_subpath) + "/";
-	} else {
-		ERR_FAIL_NULL_V(node_state.parent, NodeTimeInfo());
-		new_parent = node_state.parent;
-		new_path = String(new_parent->node_state.base_path) + String(p_subpath) + "/";
+#endif
 	}
 
 	// This process, which depends on p_sync is needed to process sync correctly in the case of
 	// that a synced AnimationNodeSync exists under the un-synced AnimationNodeSync.
-	p_node->set_node_state_base_path(new_path);
-	p_node->node_state.parent = new_parent;
 	if (!p_playback_info.seeked && !p_sync && !any_valid) {
 		p_playback_info.delta = 0.0;
-		return p_node->_pre_process(process_state, p_playback_info, p_test_only);
 	}
-	return p_node->_pre_process(process_state, p_playback_info, p_test_only);
+	return p_other.resource->_pre_process(p_process_state, p_other, p_playback_info, p_test_only);
 }
 
 String AnimationNode::get_caption() const {
@@ -374,28 +307,34 @@ int AnimationNode::find_input(const String &p_name) const {
 	return idx;
 }
 
-AnimationNode::NodeTimeInfo AnimationNode::process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	process_state->is_testing = p_test_only;
+AnimationNode::NodeTimeInfo AnimationNode::process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
+	p_process_state.is_testing = p_test_only;
+
+	double &length = *VariantInternal::get_float(p_instance.parameter_ptrs_by_slot[AnimationNodeInstance::SLOT_CURRENT_LENGTH]);
+	double &position = *VariantInternal::get_float(p_instance.parameter_ptrs_by_slot[AnimationNodeInstance::SLOT_CURRENT_POSITION]);
+	double &delta = *VariantInternal::get_float(p_instance.parameter_ptrs_by_slot[AnimationNodeInstance::SLOT_CURRENT_DELTA]);
 
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 	if (p_playback_info.seeked) {
 		if (p_playback_info.is_external_seeking) {
-			pi.delta = get_node_time_info().position - p_playback_info.time;
+			pi.delta = position - p_playback_info.time;
 		}
 	} else {
-		pi.time = get_node_time_info().position + p_playback_info.delta;
+		pi.time = position + get_process_delta(p_instance, p_playback_info);
 	}
 
-	NodeTimeInfo nti = _process(pi, p_test_only);
+	NodeTimeInfo nti = _process(p_process_state, p_instance, pi, p_test_only);
 
 	if (!p_test_only) {
-		set_node_time_info(nti);
+		length = nti.length;
+		position = nti.position;
+		delta = nti.delta;
 	}
 
 	return nti;
 }
 
-AnimationNode::NodeTimeInfo AnimationNode::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
+AnimationNode::NodeTimeInfo AnimationNode::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
 	double r_ret = 0.0;
 	GDVIRTUAL_CALL(_process, p_playback_info.time, p_playback_info.seeked, p_playback_info.is_external_seeking, p_test_only, r_ret);
 	NodeTimeInfo nti;
@@ -405,14 +344,17 @@ AnimationNode::NodeTimeInfo AnimationNode::_process(const AnimationMixer::Playba
 
 void AnimationNode::set_filter_path(const NodePath &p_path, bool p_enable) {
 	if (p_enable) {
-		filter[p_path] = true;
+		(void)p_path.hash(); // Make sure the cache is valid.
+		filter.insert(p_path);
 	} else {
 		filter.erase(p_path);
 	}
+	filters_dirty = true;
 }
 
 void AnimationNode::set_filter_enabled(bool p_enable) {
 	filter_enabled = p_enable;
+	filters_dirty = true;
 }
 
 bool AnimationNode::is_filter_enabled() const {
@@ -428,13 +370,13 @@ bool AnimationNode::is_deletable() const {
 }
 
 ObjectID AnimationNode::get_processing_animation_tree_instance_id() const {
-	ERR_FAIL_NULL_V(process_state, ObjectID());
-	return process_state->tree->get_instance_id();
+	ERR_FAIL_NULL_V(tls_process_state, ObjectID());
+	return tls_process_state->tree->get_instance_id();
 }
 
 bool AnimationNode::is_process_testing() const {
-	ERR_FAIL_NULL_V(process_state, false);
-	return process_state->is_testing;
+	ERR_FAIL_NULL_V(tls_process_state, false);
+	return tls_process_state->is_testing;
 }
 
 bool AnimationNode::is_path_filtered(const NodePath &p_path) const {
@@ -450,8 +392,8 @@ bool AnimationNode::has_filter() const {
 Array AnimationNode::_get_filters() const {
 	Array paths;
 
-	for (const KeyValue<NodePath, bool> &E : filter) {
-		paths.push_back(String(E.key)); // Use strings, so sorting is possible.
+	for (const NodePath &E : filter) {
+		paths.push_back(String(E)); // Use strings, so sorting is possible.
 	}
 	paths.sort(); // Done so every time the scene is saved, it does not change.
 
@@ -463,6 +405,24 @@ void AnimationNode::_set_filters(const Array &p_filters) {
 	for (int i = 0; i < p_filters.size(); i++) {
 		set_filter_path(p_filters[i], true);
 	}
+}
+
+void AnimationNode::_update_filter_cache(const ProcessState &p_process_state, const AnimationNodeInstance &p_instance) {
+	if (!p_process_state.track_map_updated && !filters_dirty) {
+		return; // Cache is valid.
+	}
+
+	p_instance.filtered_track_indices_cache.clear();
+	if (p_instance.filtered_track_indices_cache.size() < filter.size()) {
+		p_instance.filtered_track_indices_cache.reserve(filter.size());
+	}
+
+	for (const NodePath &path : filter) {
+		if (const int *p = p_process_state.track_map->getptr(path)) {
+			p_instance.filtered_track_indices_cache.push_back(*p);
+		}
+	}
+	filters_dirty = false;
 }
 
 void AnimationNode::_validate_property(PropertyInfo &p_property) const {
@@ -490,6 +450,9 @@ Ref<AnimationNode> AnimationNode::find_node_by_path(const String &p_name) const 
 }
 
 void AnimationNode::blend_animation_ex(const StringName &p_animation, double p_time, double p_delta, bool p_seeked, bool p_is_external_seeking, real_t p_blend, Animation::LoopedFlag p_looped_flag) {
+	ERR_FAIL_NULL(tls_process_state);
+	ERR_FAIL_NULL(current_instance);
+
 	AnimationMixer::PlaybackInfo info;
 	info.time = p_time;
 	info.delta = p_delta;
@@ -497,26 +460,38 @@ void AnimationNode::blend_animation_ex(const StringName &p_animation, double p_t
 	info.is_external_seeking = p_is_external_seeking;
 	info.weight = p_blend;
 	info.looped_flag = p_looped_flag;
-	blend_animation(p_animation, info);
+
+	blend_animation(*tls_process_state, *current_instance, p_animation, info);
 }
 
-double AnimationNode::blend_node_ex(const StringName &p_sub_path, Ref<AnimationNode> p_node, double p_time, bool p_seek, bool p_is_external_seeking, real_t p_blend, FilterAction p_filter, bool p_sync, bool p_test_only) {
+double AnimationNode::blend_node_ex(const StringName &p_sub_path, const Ref<AnimationNode> &p_node, double p_time, bool p_seek, bool p_is_external_seeking, real_t p_blend, FilterAction p_filter, bool p_sync, bool p_test_only) {
+	ERR_FAIL_NULL_V(tls_process_state, 0.0);
+	ERR_FAIL_NULL_V(current_instance, 0.0);
+
+	AnimationNodeInstance *other_instance = current_instance->get_child_instance_by_path_or_null(p_sub_path);
+	ERR_FAIL_NULL_V_MSG(other_instance, 0.0, vformat("The sub-path '%s' does not exist under the current node instance.", String(p_sub_path)));
+
 	AnimationMixer::PlaybackInfo info;
 	info.time = p_time;
 	info.seeked = p_seek;
 	info.is_external_seeking = p_is_external_seeking;
 	info.weight = p_blend;
-	NodeTimeInfo nti = blend_node(p_node, p_sub_path, info, p_filter, p_sync, p_test_only);
+
+	NodeTimeInfo nti = blend_node(*tls_process_state, *current_instance, other_instance, info, p_filter, p_sync, p_test_only);
 	return nti.length - nti.position;
 }
 
 double AnimationNode::blend_input_ex(int p_input, double p_time, bool p_seek, bool p_is_external_seeking, real_t p_blend, FilterAction p_filter, bool p_sync, bool p_test_only) {
+	ERR_FAIL_NULL_V(tls_process_state, 0.0);
+	ERR_FAIL_NULL_V(current_instance, 0.0);
+
 	AnimationMixer::PlaybackInfo info;
 	info.time = p_time;
 	info.seeked = p_seek;
 	info.is_external_seeking = p_is_external_seeking;
 	info.weight = p_blend;
-	NodeTimeInfo nti = blend_input(p_input, info, p_filter, p_sync, p_test_only);
+
+	NodeTimeInfo nti = blend_input(*tls_process_state, *current_instance, p_input, info, p_filter, p_sync, p_test_only);
 	return nti.length - nti.position;
 }
 
@@ -530,7 +505,7 @@ void AnimationNode::get_argument_options(const StringName &p_function, int p_idx
 			}
 		} else if (pf == "get_parameter" || pf == "set_parameter") {
 			bool is_setter = pf == "set_parameter";
-			List<PropertyInfo> parameters;
+			LocalVector<PropertyInfo> parameters;
 			get_parameter_list(&parameters);
 			for (const PropertyInfo &E : parameters) {
 				if (is_setter && is_parameter_read_only(E.name)) {
@@ -539,8 +514,8 @@ void AnimationNode::get_argument_options(const StringName &p_function, int p_idx
 				r_options->push_back(E.name.quote());
 			}
 		} else if (pf == "set_filter_path" || pf == "is_path_filtered") {
-			for (const KeyValue<NodePath, bool> &E : filter) {
-				r_options->push_back(String(E.key).quote());
+			for (const NodePath &E : filter) {
+				r_options->push_back(String(E).quote());
 			}
 		}
 	}
@@ -573,8 +548,8 @@ void AnimationNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("blend_node", "name", "node", "time", "seek", "is_external_seeking", "blend", "filter", "sync", "test_only"), &AnimationNode::blend_node_ex, DEFVAL(FILTER_IGNORE), DEFVAL(true), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("blend_input", "input_index", "time", "seek", "is_external_seeking", "blend", "filter", "sync", "test_only"), &AnimationNode::blend_input_ex, DEFVAL(FILTER_IGNORE), DEFVAL(true), DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("set_parameter", "name", "value"), &AnimationNode::set_parameter);
-	ClassDB::bind_method(D_METHOD("get_parameter", "name"), &AnimationNode::get_parameter);
+	ClassDB::bind_method(D_METHOD("set_parameter", "name", "value"), &AnimationNode::set_parameter_ex);
+	ClassDB::bind_method(D_METHOD("get_parameter", "name"), &AnimationNode::get_parameter_ex);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter_enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_filter_enabled", "is_filter_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "filters", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_filters", "_get_filters");
@@ -588,7 +563,10 @@ void AnimationNode::_bind_methods() {
 	GDVIRTUAL_BIND(_get_caption);
 	GDVIRTUAL_BIND(_has_filter);
 
+	// For "tree_changed", wouldn't it be nice, if we could pass in the source?
+	// That way we would be able to partially rebuild instances.
 	ADD_SIGNAL(MethodInfo("tree_changed"));
+	ADD_SIGNAL(MethodInfo("node_updated", PropertyInfo(Variant::INT, "object_id")));
 	ADD_SIGNAL(MethodInfo("animation_node_renamed", PropertyInfo(Variant::INT, "object_id"), PropertyInfo(Variant::STRING, "old_name"), PropertyInfo(Variant::STRING, "new_name")));
 	ADD_SIGNAL(MethodInfo("animation_node_removed", PropertyInfo(Variant::INT, "object_id"), PropertyInfo(Variant::STRING, "name")));
 
@@ -603,8 +581,26 @@ AnimationNode::AnimationNode() {
 
 ////////////////////
 
+void AnimationRootNode::_add_node(const Ref<AnimationNode> &p_node) {
+	p_node->connect(SNAME("tree_changed"), callable_mp(this, &AnimationRootNode::_tree_changed), CONNECT_REFERENCE_COUNTED);
+	p_node->connect(SNAME("node_updated"), callable_mp(this, &AnimationRootNode::_node_updated), CONNECT_REFERENCE_COUNTED);
+	p_node->connect(SNAME("animation_node_renamed"), callable_mp(this, &AnimationRootNode::_animation_node_renamed), CONNECT_REFERENCE_COUNTED);
+	p_node->connect(SNAME("animation_node_removed"), callable_mp(this, &AnimationRootNode::_animation_node_removed), CONNECT_REFERENCE_COUNTED);
+}
+
+void AnimationRootNode::_remove_node(const Ref<AnimationNode> &p_node) {
+	p_node->disconnect(SNAME("tree_changed"), callable_mp(this, &AnimationRootNode::_tree_changed));
+	p_node->disconnect(SNAME("node_updated"), callable_mp(this, &AnimationRootNode::_node_updated));
+	p_node->disconnect(SNAME("animation_node_renamed"), callable_mp(this, &AnimationRootNode::_animation_node_renamed));
+	p_node->disconnect(SNAME("animation_node_removed"), callable_mp(this, &AnimationRootNode::_animation_node_removed));
+}
+
 void AnimationRootNode::_tree_changed() {
 	emit_signal(SNAME("tree_changed"));
+}
+
+void AnimationRootNode::_node_updated(const ObjectID &p_oid) {
+	emit_signal(SNAME("node_updated"), p_oid);
 }
 
 void AnimationRootNode::_animation_node_renamed(const ObjectID &p_oid, const String &p_old_name, const String &p_new_name) {
@@ -620,6 +616,7 @@ void AnimationRootNode::_animation_node_removed(const ObjectID &p_oid, const Str
 void AnimationTree::set_root_animation_node(const Ref<AnimationRootNode> &p_animation_node) {
 	if (root_animation_node.is_valid()) {
 		root_animation_node->disconnect(SNAME("tree_changed"), callable_mp(this, &AnimationTree::_tree_changed));
+		root_animation_node->disconnect(SNAME("node_updated"), callable_mp(this, &AnimationTree::_node_updated));
 		root_animation_node->disconnect(SNAME("animation_node_renamed"), callable_mp(this, &AnimationTree::_animation_node_renamed));
 		root_animation_node->disconnect(SNAME("animation_node_removed"), callable_mp(this, &AnimationTree::_animation_node_removed));
 	}
@@ -628,6 +625,7 @@ void AnimationTree::set_root_animation_node(const Ref<AnimationRootNode> &p_anim
 
 	if (root_animation_node.is_valid()) {
 		root_animation_node->connect(SNAME("tree_changed"), callable_mp(this, &AnimationTree::_tree_changed));
+		root_animation_node->connect(SNAME("node_updated"), callable_mp(this, &AnimationTree::_node_updated));
 		root_animation_node->connect(SNAME("animation_node_renamed"), callable_mp(this, &AnimationTree::_animation_node_renamed));
 		root_animation_node->connect(SNAME("animation_node_removed"), callable_mp(this, &AnimationTree::_animation_node_removed));
 	}
@@ -644,46 +642,65 @@ Ref<AnimationRootNode> AnimationTree::get_root_animation_node() const {
 bool AnimationTree::_blend_pre_process(double p_delta, int p_track_count, const AHashMap<NodePath, int> &p_track_map) {
 	_update_properties(); // If properties need updating, update them.
 
-	if (root_animation_node.is_null()) {
+	bool was_validation_dirty = validation_dirty;
+	if (validation_dirty) {
+		process_state.invalid_instances.clear();
+		validation_successful = true;
+		_validate_animation_graph(Animation::PARAMETERS_BASE_PATH, root_animation_node);
+		validation_dirty = false;
+	}
+	if (!validation_successful) {
 		return false;
 	}
+	if (was_validation_dirty) {
+		_update_connections();
+	}
+
+	AnimationNodeInstance &instance = get_node_instance_by_path(SNAME(Animation::PARAMETERS_BASE_PATH.ascii().get_data()));
 
 	{ // Setup.
 		process_pass++;
+		if (unlikely(process_pass == 0)) {
+			process_pass = 1;
+		}
 
 		// Init process state.
 		process_state = AnimationNode::ProcessState();
 		process_state.tree = this;
 		process_state.valid = true;
-		process_state.invalid_reasons = "";
+		process_state.invalid_instances.clear();
 		process_state.last_pass = process_pass;
 		process_state.track_map = &p_track_map;
+		process_state.track_map_updated = track_map_version != last_track_map_version;
+		process_state.is_testing = false;
+
+		last_track_map_version = track_map_version;
 
 		// Init node state for root AnimationNode.
-		root_animation_node->node_state.track_weights.resize(p_track_count);
-		real_t *src_blendsw = root_animation_node->node_state.track_weights.ptr();
+		instance.track_weights.resize(p_track_count);
+		real_t *src_blendsw = instance.track_weights.ptr();
 		for (int i = 0; i < p_track_count; i++) {
 			src_blendsw[i] = 1.0; // By default all go to 1 for the root input.
 		}
-		root_animation_node->set_node_state_base_path(SNAME(Animation::PARAMETERS_BASE_PATH.ascii().get_data()));
-		root_animation_node->node_state.parent = nullptr;
+		instance.path = SNAME(Animation::PARAMETERS_BASE_PATH.ascii().get_data());
 	}
 
 	// Process.
 	{
 		PlaybackInfo pi;
+		pi.delta = p_delta;
 
 		if (started) {
+			started = false;
 			// If started, seek.
 			pi.seeked = true;
-			pi.delta = p_delta;
-			root_animation_node->_pre_process(&process_state, pi, false);
-			started = false;
 		} else {
 			pi.seeked = false;
-			pi.delta = p_delta;
-			root_animation_node->_pre_process(&process_state, pi, false);
 		}
+
+		AnimationNode::tls_process_state = &process_state;
+		root_animation_node->_pre_process(process_state, instance, pi, false);
+		AnimationNode::tls_process_state = nullptr;
 	}
 
 	if (!process_state.valid) {
@@ -710,12 +727,8 @@ bool AnimationTree::is_state_invalid() const {
 	return !process_state.valid;
 }
 
-String AnimationTree::get_invalid_state_reason() const {
-	return process_state.invalid_reasons;
-}
-
-uint64_t AnimationTree::get_last_process_pass() const {
-	return process_pass;
+const AHashMap<StringName, AnimationNode::InvalidInstance> &AnimationTree::get_invalid_instances() const {
+	return process_state.invalid_instances;
 }
 
 PackedStringArray AnimationTree::get_configuration_warnings() const {
@@ -735,17 +748,30 @@ void AnimationTree::_tree_changed() {
 	properties_dirty = true;
 }
 
+void AnimationTree::_node_updated(const ObjectID &p_oid) {
+	// This is for when the animation in AnimationNodeAnimation changes.
+	// or a connection in AnimationNodeBlendTree changes.
+
+	// Ideally, we would only validate relevant instances, but for now, revalidate all.
+	validation_dirty = true;
+}
+
 void AnimationTree::_animation_node_renamed(const ObjectID &p_oid, const String &p_old_name, const String &p_new_name) {
-	ERR_FAIL_COND(!property_reference_map.has(p_oid));
-	String base_path = property_reference_map[p_oid];
-	String old_base = base_path + p_old_name;
-	String new_base = base_path + p_new_name;
-	for (const PropertyInfo &E : properties) {
-		if (E.name.begins_with(old_base)) {
-			String new_name = E.name.replace_first(old_base, new_base);
-			const Pair<Variant, bool> temp_copy = property_map[E.name];
-			property_map[new_name] = temp_copy;
-			property_map.erase(E.name);
+	//print_line("Node: " + ObjectDB::get_instance(p_oid)->get_class() + " (" + itos(p_oid) + ") renamed: " + p_old_name + " -> " + p_new_name);
+	for (const StringName &pp : instance_paths[p_oid]) {
+		String parent_path = pp;
+		String old_base = parent_path + p_old_name;
+		String new_base = parent_path + p_new_name;
+		//print_line(" - Updating " + pp + ": " + old_base + " -> " + new_base);
+		for (const PropertyInfo &E : properties) {
+			if (E.name.begins_with(old_base)) {
+				StringName old_name = E.name;
+				StringName new_name = E.name.replace_first(old_base, new_base);
+				const Pair<Variant, bool> temp_copy = property_map[old_name];
+				//print_line("   - Property: " + String(old_name) + " -> " + String(new_name));
+				property_map[new_name] = temp_copy;
+				property_map.erase(old_name);
+			}
 		}
 	}
 
@@ -755,11 +781,13 @@ void AnimationTree::_animation_node_renamed(const ObjectID &p_oid, const String 
 }
 
 void AnimationTree::_animation_node_removed(const ObjectID &p_oid, const StringName &p_node) {
-	ERR_FAIL_COND(!property_reference_map.has(p_oid));
-	String base_path = String(property_reference_map[p_oid]) + String(p_node);
-	for (const PropertyInfo &E : properties) {
-		if (E.name.begins_with(base_path)) {
-			property_map.erase(E.name);
+	for (const StringName &parent_path : instance_paths[p_oid]) {
+		String base_path = String(parent_path) + String(p_node);
+
+		for (const PropertyInfo &E : properties) {
+			if (E.name.begins_with(base_path)) {
+				property_map.erase(E.name);
+			}
 		}
 	}
 
@@ -768,50 +796,57 @@ void AnimationTree::_animation_node_removed(const ObjectID &p_oid, const StringN
 	_update_properties();
 }
 
-void AnimationTree::_update_properties_for_node(const String &p_base_path, Ref<AnimationNode> p_node) const {
+void AnimationTree::_update_properties_for_node(const StringName &p_base_path, const Ref<AnimationNode> &p_node) const {
 	ERR_FAIL_COND(p_node.is_null());
-	if (!property_parent_map.has(p_base_path)) {
-		property_parent_map[p_base_path] = AHashMap<StringName, StringName>();
-	}
-	if (!property_reference_map.has(p_node->get_instance_id())) {
-		property_reference_map[p_node->get_instance_id()] = p_base_path;
-	}
 
-	if (p_node->get_input_count() && !input_activity_map.has(p_base_path)) {
-		LocalVector<Activity> activity;
+	instance_paths[p_node->get_instance_id()].insert(p_base_path);
+
+	const String base_path_str = p_base_path;
+
+	AnimationNodeInstance &instance = instance_map[p_base_path];
+	instance.path = p_base_path;
+	instance.resource = p_node;
+
+#ifdef ENABLE_ACTIVITY_TRACKING
+	if (p_node->get_input_count()) {
 		for (int i = 0; i < p_node->get_input_count(); i++) {
-			Activity a;
+			AnimationNodeInstance::Activity a;
 			a.activity = 0;
 			a.last_pass = 0;
-			activity.push_back(a);
+			instance.input_activity.push_back(a);
 		}
-		input_activity_map[p_base_path] = activity;
-		input_activity_map_get[String(p_base_path).substr(0, String(p_base_path).length() - 1)] = input_activity_map.get_index(p_base_path);
 	}
+#endif
 
-	List<PropertyInfo> plist;
+	LocalVector<PropertyInfo> plist;
 	p_node->get_parameter_list(&plist);
 	for (PropertyInfo &pinfo : plist) {
-		StringName key = pinfo.name;
+		StringName pname = pinfo.name;
+		StringName key = base_path_str + pname;
 
-		if (!property_map.has(p_base_path + key)) {
-			Pair<Variant, bool> param;
-			param.first = p_node->get_parameter_default_value(key);
-			param.second = p_node->is_parameter_read_only(key);
-			property_map[p_base_path + key] = param;
+		Pair<Variant, bool> *param = property_map.getptr(key);
+		if (!param) {
+			param = &property_map.insert(key, Pair<Variant, bool>())->value;
+			param->first = p_node->get_parameter_default_value(pname);
+			param->second = p_node->is_parameter_read_only(pname);
 		}
 
-		property_parent_map[p_base_path][key] = p_base_path + key;
-
-		pinfo.name = p_base_path + key;
+		pinfo.name = key;
 		properties.push_back(pinfo);
 	}
-	p_node->make_cache_dirty();
-	List<AnimationNode::ChildNode> children;
+
+	LocalVector<AnimationNode::ChildNode> children;
 	p_node->get_child_nodes(&children);
 
+	// These have to be done in two passes, because _update_properties_for_node invalidates the instance reference.
 	for (const AnimationNode::ChildNode &E : children) {
-		_update_properties_for_node(p_base_path + E.name + "/", E.node);
+		ERR_CONTINUE(E.name.is_empty());
+		instance.child_instances[E.name] = nullptr; // Will be set in _update_properties
+	}
+
+	for (const AnimationNode::ChildNode &E : children) {
+		const StringName child_path = base_path_str + E.name + "/";
+		_update_properties_for_node(child_path, E.node);
 	}
 }
 
@@ -820,19 +855,114 @@ void AnimationTree::_update_properties() const {
 		return;
 	}
 
+	// if properties are dirty, so is the validation state.
+	validation_dirty = true;
 	properties.clear();
-	property_reference_map.clear();
-	property_parent_map.clear();
-	input_activity_map.clear();
-	input_activity_map_get.clear();
+	instance_map.clear();
+	instance_paths.clear();
 
 	if (root_animation_node.is_valid()) {
 		_update_properties_for_node(Animation::PARAMETERS_BASE_PATH, root_animation_node);
+
+		// Now that the properties and instances are stable, we can update them.
+		for (KeyValue<StringName, AnimationNodeInstance> &E : instance_map) {
+			const String &instance_path = E.key;
+			AnimationNodeInstance &instance = E.value;
+
+			// Update children.
+			for (KeyValue<StringName, AnimationNodeInstance *> &kv : instance.child_instances) {
+				const StringName child_path = instance_path + kv.key + "/";
+				kv.value = instance_map.getptr(child_path);
+				CRASH_COND(!kv.value); // Shouldn't ever happen.
+			}
+
+			// Now properties.
+			const Ref<AnimationNode> &node = instance.resource;
+			ERR_FAIL_COND(node.is_null());
+
+			instance.parameter_ptrs_by_slot.resize_initialized(AnimationNodeInstance::SLOT_MAX);
+			LocalVector<PropertyInfo> plist;
+			node->get_parameter_list(&plist);
+			for (const PropertyInfo &pinfo : plist) {
+				StringName pname = pinfo.name;
+
+				Pair<Variant, bool> *pair = property_map.getptr(instance_path + pname);
+				CRASH_COND(!pair); // Shouldn't ever happen.
+
+				instance.property_ptrs[pname] = &pair->first;
+
+				// Some of these get special treatment.
+				instance.maybe_bind_slot_property(pname, &pair->first);
+			}
+		}
 	}
 
 	properties_dirty = false;
 
 	const_cast<AnimationTree *>(this)->notify_property_list_changed();
+}
+
+void AnimationTree::_validate_animation_graph(const StringName &p_path, const Ref<AnimationNode> &p_node) const {
+	if (p_node.is_null()) {
+		validation_successful = false;
+		return;
+	}
+
+	p_node->validate_node(this, p_path);
+	// We will continue even if the validation is not successful, to gather all errors.
+
+	LocalVector<AnimationNode::ChildNode> children;
+	p_node->get_child_nodes(&children);
+
+	for (const AnimationNode::ChildNode &E : children) {
+		const StringName child_path = String(p_path) + E.name + "/";
+		_validate_animation_graph(child_path, E.node);
+	}
+}
+
+void AnimationTree::_update_connections() {
+	for (KeyValue<StringName, AnimationNodeInstance> &E : instance_map) {
+		AnimationNodeInstance &parent_instance = E.value;
+
+		const AnimationNodeBlendTree *blend_tree = Object::cast_to<AnimationNodeBlendTree>(parent_instance.resource.ptr());
+
+		if (!blend_tree) {
+			continue;
+		}
+
+		{
+			const LocalVector<StringName> *output_connections = blend_tree->get_node_connection_array(SceneStringName(output));
+			parent_instance.connection_instances.resize(1);
+			AnimationNodeInstance *connected_instance = parent_instance.get_child_instance_by_path_or_null(output_connections->operator[](0));
+			parent_instance.connection_instances[0] = connected_instance;
+			CRASH_COND(!connected_instance); // Will never happen.
+		}
+
+		for (const KeyValue<StringName, AnimationNodeInstance *> &kv : parent_instance.child_instances) {
+			AnimationNodeInstance *child_instance = kv.value;
+			const LocalVector<StringName> &child_connections = *blend_tree->get_node_connection_array(kv.key);
+			child_instance->connection_instances.clear();
+			child_instance->connection_instances.resize(child_connections.size());
+			for (uint32_t input = 0; input < child_connections.size(); input++) {
+				const StringName &connected_node_name = child_connections[input];
+				AnimationNodeInstance *connected_instance = parent_instance.get_child_instance_by_path_or_null(connected_node_name);
+				child_instance->connection_instances[input] = connected_instance;
+				CRASH_COND(!connected_instance); // Will never happen.
+			}
+		}
+	}
+}
+
+void AnimationTree::_add_validation_error(const StringName &p_path, const String &p_error, int p_input_index) const {
+	validation_successful = false;
+
+	AnimationNode::InvalidInstance &invalid_instance = process_state.invalid_instances[p_path];
+
+	if (p_input_index == -1) {
+		invalid_instance.errors.push_back(p_error);
+	} else {
+		invalid_instance.input_errors.push_back({ p_input_index, p_error });
+	}
 }
 
 void AnimationTree::_notification(int p_what) {
@@ -932,19 +1062,25 @@ bool AnimationTree::_set(const StringName &p_name, const Variant &p_value) {
 		return true;
 	}
 #endif // DISABLE_DEPRECATED
-	if (properties_dirty) {
-		_update_properties();
-	}
+	_update_properties();
 
-	if (property_map.has(p_name)) {
-		if (is_inside_tree() && property_map[p_name].second) {
+	if (Pair<Variant, bool> *property_ptr = property_map.getptr(p_name)) {
+		Pair<Variant, bool> *&pair = property_ptr;
+		if (is_inside_tree() && pair->second) {
 			return false; // Prevent to set property by user.
 		}
-		Pair<Variant, bool> &prop = property_map[p_name];
-		Variant value = p_value;
-		if (Animation::validate_type_match(prop.first, value)) {
-			prop.first = value;
+
+		Variant &prop = pair->first;
+		// Only copy variant if needed.
+		if (Animation::needs_type_cast(prop, p_value)) {
+			Variant value = p_value;
+			if (Animation::validate_type_match(prop, value)) {
+				prop = value;
+			}
+		} else {
+			prop = p_value;
 		}
+
 		return true;
 	}
 
@@ -958,12 +1094,10 @@ bool AnimationTree::_get(const StringName &p_name, Variant &r_ret) const {
 		return true;
 	}
 #endif // DISABLE_DEPRECATED
-	if (properties_dirty) {
-		_update_properties();
-	}
+	_update_properties();
 
-	if (property_map.has(p_name)) {
-		r_ret = property_map[p_name].first;
+	if (const Pair<Variant, bool> *p = property_map.getptr(p_name)) {
+		r_ret = p->first;
 		return true;
 	}
 
@@ -971,38 +1105,35 @@ bool AnimationTree::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void AnimationTree::_get_property_list(List<PropertyInfo> *p_list) const {
-	if (properties_dirty) {
-		_update_properties();
-	}
+	_update_properties();
 
 	for (const PropertyInfo &E : properties) {
 		p_list->push_back(E);
 	}
 }
 
+#ifdef ENABLE_ACTIVITY_TRACKING
 real_t AnimationTree::get_connection_activity(const StringName &p_path, int p_connection) const {
-	if (!input_activity_map_get.has(p_path)) {
+	const AnimationNodeInstance *a = get_node_instance_by_path_or_null(p_path);
+	if (!a) {
 		return 0;
 	}
 
-	int index = input_activity_map_get[p_path];
-	const LocalVector<Activity> &activity = input_activity_map.get_by_index(index).value;
-
+	const LocalVector<AnimationNodeInstance::Activity> &activity = a->input_activity;
 	if (p_connection < 0 || p_connection >= (int64_t)activity.size() || activity[p_connection].last_pass != process_pass) {
 		return 0;
 	}
 
 	return activity[p_connection].activity;
 }
+#endif
 
 #ifdef TOOLS_ENABLED
 String AnimationTree::get_editor_error_message() const {
 	if (!is_active()) {
 		return TTR("The AnimationTree is inactive.\nActivate it in the inspector to enable playback; check node warnings if activation fails.");
 	} else if (!is_enabled()) {
-		return TTR("The AnimationTree node (or one of its parents) has its process mode set to Disabled.\nChange the process mode in the inspector to allow playback.");
-	} else if (is_state_invalid()) {
-		return get_invalid_state_reason();
+		return TTR("The AnimationTree node (or one of its ancestors) has its process mode set to Disabled.\nChange the process mode in the inspector to allow playback.");
 	}
 
 	return "";

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -35,10 +35,15 @@
 
 #define HUGE_LENGTH 31540000 // 31540000 seconds mean 1 year... is it too long? It must be longer than any Animation length and Transition xfade time to prevent time inversion for AnimationNodeStateMachine.
 
+#ifdef TOOLS_ENABLED
+#define ENABLE_ACTIVITY_TRACKING
+#endif
+
 class AnimationNodeBlendTree;
 class AnimationNodeStartState;
 class AnimationNodeEndState;
 class AnimationTree;
+struct AnimationNodeInstance;
 
 class AnimationNode : public Resource {
 	GDCLASS(AnimationNode, Resource);
@@ -59,8 +64,9 @@ public:
 
 	bool closable = false;
 	LocalVector<Input> inputs;
-	AHashMap<NodePath, bool> filter;
+	HashSet<NodePath> filter;
 	bool filter_enabled = false;
+	bool filters_dirty = true;
 
 	// To propagate information from upstream for use in estimation of playback progress.
 	// These values must be taken from the result of blend_node() or blend_input() and must be essentially read-only.
@@ -94,87 +100,72 @@ public:
 		}
 	};
 
-	// Temporary state for blending process which needs to be stored in each AnimationNodes.
-	struct NodeState {
-		friend AnimationNode;
+	struct InvalidInstance {
+		LocalVector<String> errors;
 
-	private:
-		StringName base_path;
+		struct InputError {
+			int index;
+			String error;
+		};
 
-	public:
-		AnimationNode *parent = nullptr;
-		Vector<StringName> connections;
-		LocalVector<real_t> track_weights;
-
-		const StringName get_base_path() const {
-			return base_path;
-		}
-
-	} node_state;
+		LocalVector<InputError> input_errors;
+	};
 
 	// Temporary state for blending process which needs to be started in the AnimationTree, pass through the AnimationNodes, and then return to the AnimationTree.
 	struct ProcessState {
 		AnimationTree *tree = nullptr;
 		const AHashMap<NodePath, int> *track_map; // TODO: Is there a better way to manage filter/tracks?
+		bool track_map_updated = false;
 		bool is_testing = false;
 		bool valid = false;
-		String invalid_reasons;
+		mutable AHashMap<StringName, InvalidInstance> invalid_instances;
 		uint64_t last_pass = 0;
-	} *process_state = nullptr;
+	};
 
-private:
-	mutable AHashMap<StringName, int> property_cache;
+	// For performance ProcessState needs to be passed down,
+	// but the scripting api was already exposed before this optimization was made.
+	// So to keep compatibility, we need this internal state, so that the scripting api can continue working as before.
+	// It also must be thread_local, because multiple AnimationTrees can be processed in different threads.
+	static thread_local ProcessState *tls_process_state;
+	static thread_local AnimationNodeInstance *current_instance;
 
 public:
-	void set_node_state_base_path(const StringName p_base_path) {
-		if (p_base_path != node_state.base_path) {
-			node_state.base_path = p_base_path;
-			make_cache_dirty();
-		}
-	}
-
-	void set_node_state_base_path(const String p_base_path) {
-		if (p_base_path != node_state.base_path) {
-			node_state.base_path = p_base_path;
-			make_cache_dirty();
-		}
-	}
-
-	const StringName get_node_state_base_path() const {
-		return node_state.get_base_path();
-	}
-
-	void make_cache_dirty() {
-		property_cache.clear();
-	}
 	Array _get_filters() const;
 	void _set_filters(const Array &p_filters);
+
+	void _update_filter_cache(const ProcessState &p_process_state, const AnimationNodeInstance &p_instance);
+
 	friend class AnimationNodeBlendTree;
 
+	virtual void validate_node(const AnimationTree *p_tree, const StringName &p_path) const {}
 	// The time information is passed from upstream to downstream by AnimationMixer::PlaybackInfo::p_playback_info until AnimationNodeAnimation processes it.
 	// Conversely, AnimationNodeAnimation returns the processed result as NodeTimeInfo from downstream to upstream.
-	NodeTimeInfo _blend_node(Ref<AnimationNode> p_node, const StringName &p_subpath, AnimationNode *p_new_parent, AnimationMixer::PlaybackInfo p_playback_info, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false, real_t *r_activity = nullptr);
-	NodeTimeInfo _pre_process(ProcessState *p_process_state, AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false);
+	NodeTimeInfo _blend_node(ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationNodeInstance &p_other, AnimationMixer::PlaybackInfo p_playback_info, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false, real_t *r_activity = nullptr);
+	NodeTimeInfo _pre_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false);
 
 protected:
 	StringName current_length = "current_length";
 	StringName current_position = "current_position";
 	StringName current_delta = "current_delta";
 
-	virtual NodeTimeInfo process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false); // To organize time information. Virtualizing for especially AnimationNodeAnimation needs to take "backward" into account.
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false); // Main process.
+	NodeTimeInfo process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false);
+	// Virtualizing for especially AnimationNodeAnimation needs to take "backward" into account.
+	_FORCE_INLINE_ virtual double get_process_delta(AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info) const {
+		return p_playback_info.delta;
+	}
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false); // Main process.
 
-	void blend_animation(const StringName &p_animation, AnimationMixer::PlaybackInfo p_playback_info);
-	NodeTimeInfo blend_node(Ref<AnimationNode> p_node, const StringName &p_subpath, AnimationMixer::PlaybackInfo p_playback_info, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false);
-	NodeTimeInfo blend_input(int p_input, AnimationMixer::PlaybackInfo p_playback_info, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false);
+	void blend_animation(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const StringName &p_animation, AnimationMixer::PlaybackInfo &p_playback_info);
+	NodeTimeInfo blend_node(ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationNodeInstance *p_other, const AnimationMixer::PlaybackInfo &p_playback_info, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false);
+	NodeTimeInfo blend_input(ProcessState &p_process_state, AnimationNodeInstance &p_instance, int p_input, const AnimationMixer::PlaybackInfo &p_playback_info, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false);
 
 	// Bind-able methods to expose for compatibility, moreover AnimationMixer::PlaybackInfo is not exposed.
 	void blend_animation_ex(const StringName &p_animation, double p_time, double p_delta, bool p_seeked, bool p_is_external_seeking, real_t p_blend, Animation::LoopedFlag p_looped_flag = Animation::LOOPED_FLAG_NONE);
-	double blend_node_ex(const StringName &p_sub_path, Ref<AnimationNode> p_node, double p_time, bool p_seek, bool p_is_external_seeking, real_t p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false);
+	double blend_node_ex(const StringName &p_sub_path, const Ref<AnimationNode> &p_node, double p_time, bool p_seek, bool p_is_external_seeking, real_t p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false);
 	double blend_input_ex(int p_input, double p_time, bool p_seek, bool p_is_external_seeking, real_t p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false);
 
-	void make_invalid(const String &p_reason);
-	AnimationTree *get_animation_tree() const;
+	void add_validation_error(const AnimationTree *p_tree, const StringName &p_path, const String &p_error, int p_input_index = -1) const;
+	void make_invalid(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const String &p_reason);
 
 	static void _bind_methods();
 
@@ -190,22 +181,19 @@ protected:
 	GDVIRTUAL0RC(bool, _has_filter)
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const;
 	virtual bool is_parameter_read_only(const StringName &p_parameter) const;
 
-	void set_parameter(const StringName &p_name, const Variant &p_value);
-	Variant get_parameter(const StringName &p_name) const;
-
-	void set_node_time_info(const NodeTimeInfo &p_node_time_info); // Wrapper of set_parameter().
-	virtual NodeTimeInfo get_node_time_info() const; // Wrapper of get_parameter().
+	void set_parameter_ex(const StringName &p_name, const Variant &p_value);
+	Variant get_parameter_ex(const StringName &p_name) const;
 
 	struct ChildNode {
 		StringName name;
 		Ref<AnimationNode> node;
 	};
 
-	virtual void get_child_nodes(List<ChildNode> *r_child_nodes);
+	virtual void get_child_nodes(LocalVector<ChildNode> *r_child_nodes);
 
 	virtual String get_caption() const;
 
@@ -248,7 +236,10 @@ class AnimationRootNode : public AnimationNode {
 	GDCLASS(AnimationRootNode, AnimationNode);
 
 protected:
+	void _add_node(const Ref<AnimationNode> &p_node);
+	void _remove_node(const Ref<AnimationNode> &p_node);
 	virtual void _tree_changed();
+	void _node_updated(const ObjectID &p_oid);
 	virtual void _animation_node_renamed(const ObjectID &p_oid, const String &p_old_name, const String &p_new_name);
 	virtual void _animation_node_removed(const ObjectID &p_oid, const StringName &p_node);
 };
@@ -259,6 +250,181 @@ class AnimationNodeStartState : public AnimationRootNode {
 
 class AnimationNodeEndState : public AnimationRootNode {
 	GDCLASS(AnimationNodeEndState, AnimationRootNode);
+};
+
+// Per instance data, for a node.
+// These get created/destroyed when the AnimationRootNode is updated, so you cannot use it to store persistent data.
+struct AnimationNodeInstance {
+	// This makes it faster to access the most commonly used parameters, since we just index an array instead of doing a hash lookup.
+	// But unfortunately, these are still Variants, which are quite slow,
+	// They are also pointers, which cause a level of indirection.
+	//
+	// In an ideal world, get_parameter and set_parameter are removed, and everything is made strongly typed (without variant).
+	// But that is a ton of work, and this is a good enough optimization for now.
+	LocalVector<Variant *> parameter_ptrs_by_slot;
+
+	mutable LocalVector<AnimationNodeInstance *> connection_instances; // AnimationNodeInstance* | nullptr
+	mutable LocalVector<real_t> track_weights;
+	mutable LocalVector<int> filtered_track_indices_cache;
+	mutable AHashMap<StringName, AnimationNodeInstance *> child_instances; // Child Name -> AnimationNodeInstance*
+
+	// Multiple AnimationNodeInstances can share the same resource btw.
+	Ref<AnimationNode> resource;
+
+	// TODO: these fields are like only used during initialization, or editor, or already slow paths. Consider moving them out of this struct.
+	//AnimationNodeInstance *parent = nullptr;
+	StringName path; // e.g. "parameters/node_name/sub_node_name/"
+
+	mutable AHashMap<StringName, Variant *> property_ptrs;
+
+#ifdef ENABLE_ACTIVITY_TRACKING
+	struct Activity {
+		uint64_t last_pass = 0;
+		real_t activity = 0.0;
+	};
+
+	LocalVector<Activity> input_activity;
+#endif
+
+	// Cache for AnimationNodeAnimation
+	Ref<Animation> cached_animation;
+	uint32_t cached_animation_version = 0;
+
+	// Macro to define all slots.
+	// slot index, enum name, member name, variant type, native type
+	// you can reuse slot index for different nodes if they don't overlap.
+	// Just make sure you update SLOT_MAX accordingly.
+#define ANIM_SLOT_LIST(X) \
+	/* Core parameters. */ \
+	X(0, CURRENT_LENGTH, current_length, Variant::FLOAT, double) \
+	X(1, CURRENT_POSITION, current_position, Variant::FLOAT, double) \
+	X(2, CURRENT_DELTA, current_delta, Variant::FLOAT, double) \
+	/* AnimationNodeTimeScale. */ \
+	X(3, TIME_SCALE, scale, Variant::FLOAT, double) \
+	/* AnimationNodeTimeSeek. */ \
+	X(3, SEEK_POS_REQUEST, seek_pos_request, Variant::FLOAT, double) \
+	/* AnimationNodeAdd2, AnimationNodeAdd3. */ \
+	X(3, ADD_AMOUNT, add_amount, Variant::FLOAT, double) \
+	/* AnimationNodeBlend2, AnimationNodeBlend3. */ \
+	X(3, BLEND_AMOUNT, blend_amount, Variant::FLOAT, double) \
+	/* AnimationNodeSub2. */ \
+	X(3, SUB_AMOUNT, sub_amount, Variant::FLOAT, double) \
+	/* AnimationNodeOneShot. */ \
+	X(3, ONESHOT_TIME_TO_RESTART, time_to_restart, Variant::FLOAT, double) \
+	X(4, ONESHOT_FADE_IN_REMAINING, fade_in_remaining, Variant::FLOAT, double) \
+	X(5, ONESHOT_FADE_OUT_REMAINING, fade_out_remaining, Variant::FLOAT, double) \
+	X(6, ONESHOT_ACTIVE, active, Variant::BOOL, bool) \
+	X(7, ONESHOT_INTERNAL_ACTIVE, internal_active, Variant::BOOL, bool) \
+	X(8, ONESHOT_REQUEST, request, Variant::INT, int) \
+	/* AnimationNodeAnimation */ \
+	X(3, ANIMATION_BACKWARD, backward, Variant::BOOL, bool) \
+	/* AnimationNodeTransition TODO: Make ref & */ \
+	X(3, TRANSITION_REQUEST, transition_request, Variant::STRING, String) \
+	X(4, CURRENT_INDEX, current_index, Variant::INT, int) \
+	X(5, PREV_INDEX, prev_index, Variant::INT, int) \
+	X(6, PREV_XFADING, prev_xfading, Variant::FLOAT, double) \
+	X(7, CURRENT_STATE, current_state, Variant::STRING, String) \
+	/* AnimationNodeBlendSpace1D and AnimationNodeBlendSpace2D, \
+	We currently cannot do blend_position, due to type same name but different type */ \
+	X(3, CLOSEST, closest, Variant::INT, int)
+
+	enum Slot : uint8_t {
+#define SLOT_ENUM(index, e, _member, _variant_type, _native_type) SLOT_##e = index,
+		ANIM_SLOT_LIST(SLOT_ENUM)
+#undef SLOT_ENUM
+				SLOT_MAX = 9
+	};
+
+	void maybe_bind_slot_property(const StringName &p_name, Variant *p_property) {
+#define HANDLE_MAYBE_BIND_SLOT_PARAMETER(_index, slot, name, _variant_type, _native_type) \
+	if (p_name == SNAME(#name)) { \
+		parameter_ptrs_by_slot[SLOT_##slot] = p_property; \
+		return; \
+	}
+		ANIM_SLOT_LIST(HANDLE_MAYBE_BIND_SLOT_PARAMETER)
+#undef HANDLE_MAYBE_BIND_SLOT_PARAMETER
+	}
+
+#define DEFINE_SET_PARAMETER_METHOD(_index, e, member, _variant_type, native_type) \
+	_FORCE_INLINE_ void set_parameter_##member(const native_type p_value, bool p_test_only) { \
+		if (p_test_only) { \
+			return; \
+		} \
+		Variant &prop = *parameter_ptrs_by_slot[SLOT_##e]; \
+		prop = p_value; \
+	}
+	ANIM_SLOT_LIST(DEFINE_SET_PARAMETER_METHOD)
+#undef DEFINE_SET_PARAMETER_METHOD
+
+#define DEFINE_GET_PARAMETER_METHOD(_index, e, member, _variant_type, native_type) \
+	_FORCE_INLINE_ native_type get_parameter_##member() const { \
+		return *parameter_ptrs_by_slot[SLOT_##e]; \
+	}
+	ANIM_SLOT_LIST(DEFINE_GET_PARAMETER_METHOD)
+#undef DEFINE_GET_PARAMETER_METHOD
+
+	_FORCE_INLINE_ void set_parameter(const StringName &p_name, const Variant &p_value, bool p_test_only) {
+		if (p_test_only) {
+			return;
+		}
+
+#define HANDLE_SET_SLOT_PARAMETER(_index, slot, name, variant_type, _native_type) \
+	if (p_name == SNAME(#name)) { \
+		ERR_FAIL_COND(p_value.get_type() != Variant::variant_type); \
+		Variant &prop = *parameter_ptrs_by_slot[SLOT_##slot]; \
+		prop = p_value; \
+		return; \
+	}
+		ANIM_SLOT_LIST(HANDLE_SET_SLOT_PARAMETER)
+#undef HANDLE_SET_SLOT_PARAMETER
+
+		Variant **p = property_ptrs.getptr(p_name);
+		ERR_FAIL_NULL(p);
+		Variant &prop = **p;
+
+		// Only copy variant if needed.
+		if (Animation::needs_type_cast(prop, p_value)) {
+			Variant value = p_value;
+			if (Animation::validate_type_match(prop, value)) {
+				prop = value;
+			}
+		} else {
+			prop = p_value;
+		}
+	}
+
+	_FORCE_INLINE_ Variant &get_parameter(const StringName &p_name) {
+		static Variant dummy = Variant();
+
+#define HANDLE_GET_SLOT_PARAMETER(_index, slot, name, _variant_type, _native_type) \
+	if (p_name == SNAME(#name)) { \
+		return *parameter_ptrs_by_slot[SLOT_##slot]; \
+	}
+		ANIM_SLOT_LIST(HANDLE_GET_SLOT_PARAMETER)
+#undef HANDLE_GET_SLOT_PARAMETER
+
+		Variant **p = property_ptrs.getptr(p_name);
+		ERR_FAIL_NULL_V(p, dummy);
+		Variant &prop = **p;
+		return prop;
+	}
+
+	_FORCE_INLINE_ AnimationNodeInstance *get_child_instance_by_path_or_null(const StringName &p_path) {
+		AnimationNodeInstance **instance_ptr = child_instances.getptr(p_path);
+		if (!instance_ptr) {
+			return nullptr;
+		}
+		AnimationNodeInstance *instance = *instance_ptr;
+		return instance;
+	}
+
+	_FORCE_INLINE_ AnimationNodeInstance &get_child_instance_by_path(const StringName &p_path) {
+		AnimationNodeInstance **instance_ptr = child_instances.getptr(p_path);
+		CRASH_COND_MSG(!instance_ptr, "No child instance found for path: \"" + String(p_path) + "\".");
+		AnimationNodeInstance *instance = *instance_ptr;
+		CRASH_COND_MSG(!instance, "Child instance pointer is null for path: \"" + String(p_path) + "\".");
+		return *instance;
+	}
 };
 
 class AnimationTree : public AnimationMixer {
@@ -279,31 +445,31 @@ private:
 
 	AnimationNode::ProcessState process_state;
 	uint64_t process_pass = 1;
+	uint64_t last_track_map_version = 0;
 
 	bool started = true;
 
 	friend class AnimationNode;
 
-	mutable List<PropertyInfo> properties;
-	mutable AHashMap<StringName, AHashMap<StringName, StringName>> property_parent_map;
-	mutable AHashMap<ObjectID, StringName> property_reference_map;
+	mutable LocalVector<PropertyInfo> properties;
 	mutable AHashMap<StringName, Pair<Variant, bool>> property_map; // Property value and read-only flag.
+	mutable AHashMap<StringName, AnimationNodeInstance> instance_map;
+	mutable AHashMap<ObjectID, HashSet<StringName>> instance_paths;
 
 	mutable bool properties_dirty = true;
+	mutable bool validation_dirty = true;
+	mutable bool validation_successful = false;
 
 	void _update_properties() const;
-	void _update_properties_for_node(const String &p_base_path, Ref<AnimationNode> p_node) const;
+	void _validate_animation_graph(const StringName &p_path, const Ref<AnimationNode> &p_node) const;
+	void _update_connections();
+	void _add_validation_error(const StringName &p_path, const String &p_error, int p_input_index = -1) const;
+	void _update_properties_for_node(const StringName &p_base_path, const Ref<AnimationNode> &p_node) const;
 
 	void _tree_changed();
+	void _node_updated(const ObjectID &p_oid);
 	void _animation_node_renamed(const ObjectID &p_oid, const String &p_old_name, const String &p_new_name);
 	void _animation_node_removed(const ObjectID &p_oid, const StringName &p_node);
-
-	struct Activity {
-		uint64_t last_pass = 0;
-		real_t activity = 0.0;
-	};
-	mutable AHashMap<StringName, LocalVector<Activity>> input_activity_map;
-	mutable AHashMap<StringName, int> input_activity_map_get;
 
 	NodePath animation_player;
 
@@ -334,6 +500,36 @@ private:
 #endif // DISABLE_DEPRECATED
 
 public:
+	AnimationNodeInstance &get_node_instance_by_path(const StringName &p_path) {
+		AnimationNodeInstance *instance = instance_map.getptr(p_path);
+		CRASH_COND_MSG(instance == nullptr, vformat(R"(No instance found for path "%s".)", String(p_path)));
+		return *instance;
+	}
+
+	AnimationNodeInstance *get_node_instance_by_path_or_null(const StringName &p_path) const {
+		return instance_map.getptr(p_path);
+	}
+
+#if TOOLS_ENABLED
+	// Used in situations where instance_map is not built.
+	// Intended for the editor, because its very slow.
+	Ref<AnimationNode> get_animation_node_by_path(const StringName &p_path) const {
+		Ref<AnimationNode> current = root_animation_node;
+
+		int name_count = String(p_path).substr(0, String(p_path).length() - 1).count("/");
+		for (int i = 0; i < name_count; i++) {
+			if (current.is_null()) {
+				return Ref<AnimationNode>();
+			}
+
+			StringName child_name = StringName(String(p_path).get_slicec('/', i + 1));
+			current = current->get_child_by_name(child_name);
+		}
+
+		return current;
+	}
+#endif
+
 	void set_animation_player(const NodePath &p_path);
 	NodePath get_animation_player() const;
 
@@ -346,11 +542,9 @@ public:
 	PackedStringArray get_configuration_warnings() const override;
 
 	bool is_state_invalid() const;
-	String get_invalid_state_reason() const;
+	const AHashMap<StringName, AnimationNode::InvalidInstance> &get_invalid_instances() const;
 
 	real_t get_connection_activity(const StringName &p_path, int p_connection) const;
-
-	uint64_t get_last_process_pass() const;
 
 #ifdef TOOLS_ENABLED
 	String get_editor_error_message() const;

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1832,7 +1832,7 @@ void GraphEdit::_minimap_draw() {
 		Vector2 node_size = minimap->_convert_from_graph_position(graph_frame->get_size() * zoom);
 		Rect2 node_rect = Rect2(node_position, node_size);
 
-		Ref<StyleBoxFlat> sb_minimap = minimap->theme_cache.node_style->duplicate();
+		Ref<StyleBoxFlat> sb_minimap = minimap->theme_cache.node_style;
 
 		// Override default values with colors provided by the GraphNode's stylebox, if possible.
 		Ref<StyleBoxFlat> sb_frame = graph_frame->get_theme_stylebox(graph_frame->is_selected() ? SNAME("panel_selected") : SceneStringName(panel));
@@ -1841,6 +1841,7 @@ void GraphEdit::_minimap_draw() {
 			if (graph_frame->is_tint_color_enabled()) {
 				node_color = graph_frame->get_tint_color();
 			}
+			sb_minimap = sb_minimap->duplicate();
 			sb_minimap->set_bg_color(node_color);
 		}
 
@@ -1858,12 +1859,13 @@ void GraphEdit::_minimap_draw() {
 		Vector2 node_size = minimap->_convert_from_graph_position(graph_node->get_size() * zoom);
 		Rect2 node_rect = Rect2(node_position, node_size);
 
-		Ref<StyleBoxFlat> sb_minimap = minimap->theme_cache.node_style->duplicate();
+		Ref<StyleBoxFlat> sb_minimap = minimap->theme_cache.node_style;
 
 		// Override default values with colors provided by the GraphNode's stylebox, if possible.
 		Ref<StyleBoxFlat> sb_frame = graph_node->is_selected() ? graph_node->theme_cache.panel_selected : graph_node->theme_cache.panel;
 		if (sb_frame.is_valid()) {
 			Color node_color = sb_frame->get_bg_color();
+			sb_minimap = sb_minimap->duplicate();
 			sb_minimap->set_bg_color(node_color);
 		}
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -3285,6 +3285,7 @@ double Animation::get_marker_time(const StringName &p_name) const {
 	return marker_times.get(p_name);
 }
 
+// TODO: This needs to be a TypedArray<StringName> see this PR for rationale https://github.com/godotengine/godot/pull/110767/
 PackedStringArray Animation::get_marker_names() const {
 	PackedStringArray names;
 	// We iterate on marker_names so the result is sorted by time.
@@ -5703,6 +5704,24 @@ Quaternion Animation::interpolate_via_rest(const Quaternion &p_from, const Quate
 bool Animation::is_variant_interpolatable(const Variant p_value) {
 	Variant::Type type = p_value.get_type();
 	return (type >= Variant::BOOL && type <= Variant::STRING_NAME) || type == Variant::ARRAY || type >= Variant::PACKED_INT32_ARRAY; // PackedByteArray is unsigned, so it would be better to ignore since blending uses float.
+}
+
+bool Animation::needs_type_cast(const Variant &p_from, const Variant &p_to) {
+	Variant::Type from_type = p_from.get_type();
+	Variant::Type to_type = p_to.get_type();
+
+	if (from_type == to_type) {
+		return false;
+	}
+
+	// Cast between double and int to avoid minor annoyances.
+	if (from_type == Variant::FLOAT && to_type == Variant::INT) {
+		return true;
+	} else if (from_type == Variant::INT && to_type == Variant::FLOAT) {
+		return true;
+	}
+
+	return false;
 }
 
 bool Animation::validate_type_match(const Variant &p_from, Variant &r_to) {

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -564,6 +564,7 @@ public:
 
 	// Helper functions for Variant.
 	static bool is_variant_interpolatable(const Variant p_value);
+	static bool needs_type_cast(const Variant &p_from, const Variant &p_to);
 	static bool validate_type_match(const Variant &p_from, Variant &r_to);
 
 	static Variant cast_to_blendwise(const Variant p_value);

--- a/tests/scene/test_animation_blend_tree.cpp
+++ b/tests/scene/test_animation_blend_tree.cpp
@@ -61,9 +61,9 @@ TEST_CASE("[SceneTree][AnimationBlendTree] Create AnimationBlendTree and add Ani
 	CHECK_EQ(blend_tree->can_connect_node("output", 0, "test_node"), AnimationNodeBlendTree::CONNECTION_OK);
 	blend_tree->connect_node("output", 0, "test_node");
 
-	Vector<StringName> connections = blend_tree->get_node_connection_array("output");
-	CHECK_EQ(connections.size(), 1);
-	CHECK_EQ(connections[0], StringName("test_node"));
+	const LocalVector<StringName> *connections = blend_tree->get_node_connection_array("output");
+	CHECK_EQ(connections->size(), 1);
+	CHECK_EQ(connections->operator[](0), StringName("test_node"));
 
 	// Test node rename.
 	blend_tree->rename_node("test_node", "renamed_node");
@@ -71,14 +71,14 @@ TEST_CASE("[SceneTree][AnimationBlendTree] Create AnimationBlendTree and add Ani
 	CHECK(blend_tree->has_node("renamed_node"));
 
 	connections = blend_tree->get_node_connection_array("output");
-	CHECK_EQ(connections[0], StringName("renamed_node"));
+	CHECK_EQ(connections->operator[](0), StringName("renamed_node"));
 
 	// Test node removal.
 	blend_tree->remove_node("renamed_node");
 	CHECK_FALSE(blend_tree->has_node("renamed_node"));
 
 	connections = blend_tree->get_node_connection_array("output");
-	CHECK_EQ(connections[0], StringName());
+	CHECK_EQ(connections->operator[](0), StringName());
 }
 
 } // namespace TestAnimationBlendTree


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot/pull/113444

Related https://github.com/godotengine/godot/pull/116394 https://github.com/godotengine/godot/pull/112308 https://github.com/godotengine/godot/pull/110474


# Benchmark

Compiled with `scons production=yes debug_symbols=yes target=editor` 
Ran with `./engine_binary --headless --print-fps --path /path/to/project res://path_to_world.tscn`
Project: [optimize.zip](https://github.com/user-attachments/files/23435265/optimize.zip)

---

Scene: `res://World.tscn`

Before: (a1eaac8171a53e5a74cd511bc144bd28afc4c7ff)

FPS: high 227, low 223, median 224.5
MSPF: high 4.48, low 4.40, median 4.45

After: (ac1c551294f64f60dda5b2b7fc95335666189e2c)

FPS: high 342, low 333, median 338
MSPF: high 3.00, low 2.92, median 2.95

median FPS change: +113.5 (+50.56%)
median MSPF change: -1.50 (-33.71%)

---


Scene: `res://World_StressTest.tscn`

Before: (a1eaac8171a53e5a74cd511bc144bd28afc4c7ff)

FPS: high 110, low 103, median 105
MSPF: high 9.70, low 9.09, median 9.52

After: (ac1c551294f64f60dda5b2b7fc95335666189e2c)

FPS: high 127, low 118, median 126
MSPF: high 8.47, low 7.87, median 7.93

median FPS change: +21 (+20.00%)
median MSPF change: -1.59 (-16.70%)

_Bugsquad edited:_
- Closes https://github.com/godotengine/godot/issues/112053
- Closes https://github.com/godotengine/godot/pull/112050