### PR TITLE
Expose bool `<=` and `>=` operators

### DIFF
--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -744,6 +744,7 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorLess<::RID, ::RID>>(Variant::OP_LESS, Variant::RID, Variant::RID);
 	register_op<OperatorEvaluatorLess<Array, Array>>(Variant::OP_LESS, Variant::ARRAY, Variant::ARRAY);
 
+	register_op<OperatorEvaluatorLessEqual<bool, bool>>(Variant::OP_LESS_EQUAL, Variant::BOOL, Variant::BOOL);
 	register_op<OperatorEvaluatorLessEqual<int64_t, int64_t>>(Variant::OP_LESS_EQUAL, Variant::INT, Variant::INT);
 	register_op<OperatorEvaluatorLessEqual<int64_t, double>>(Variant::OP_LESS_EQUAL, Variant::INT, Variant::FLOAT);
 	register_op<OperatorEvaluatorLessEqual<double, int64_t>>(Variant::OP_LESS_EQUAL, Variant::FLOAT, Variant::INT);
@@ -775,6 +776,7 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorGreater<::RID, ::RID>>(Variant::OP_GREATER, Variant::RID, Variant::RID);
 	register_op<OperatorEvaluatorGreater<Array, Array>>(Variant::OP_GREATER, Variant::ARRAY, Variant::ARRAY);
 
+	register_op<OperatorEvaluatorGreaterEqual<bool, bool>>(Variant::OP_GREATER_EQUAL, Variant::BOOL, Variant::BOOL);
 	register_op<OperatorEvaluatorGreaterEqual<int64_t, int64_t>>(Variant::OP_GREATER_EQUAL, Variant::INT, Variant::INT);
 	register_op<OperatorEvaluatorGreaterEqual<int64_t, double>>(Variant::OP_GREATER_EQUAL, Variant::INT, Variant::FLOAT);
 	register_op<OperatorEvaluatorGreaterEqual<double, int64_t>>(Variant::OP_GREATER_EQUAL, Variant::FLOAT, Variant::INT);

--- a/doc/classes/bool.xml
+++ b/doc/classes/bool.xml
@@ -91,6 +91,13 @@
 				Returns [code]true[/code] if the left [bool] is [code]false[/code] and [param right] is [code]true[/code].
 			</description>
 		</operator>
+		<operator name="operator &lt;=">
+			<return type="bool" />
+			<param index="0" name="right" type="bool" />
+			<description>
+				Returns [code]true[/code] if the left [bool] is [code]false[/code], or if both [bool]s are [code]true[/code].
+			</description>
+		</operator>
 		<operator name="operator ==">
 			<return type="bool" />
 			<param index="0" name="right" type="bool" />
@@ -103,6 +110,13 @@
 			<param index="0" name="right" type="bool" />
 			<description>
 				Returns [code]true[/code] if the left [bool] is [code]true[/code] and [param right] is [code]false[/code].
+			</description>
+		</operator>
+		<operator name="operator &gt;=">
+			<return type="bool" />
+			<param index="0" name="right" type="bool" />
+			<description>
+				Returns [code]true[/code] if the left [bool] is [code]true[/code], or if both [bool]s are [code]false[/code].
 			</description>
 		</operator>
 	</operators>


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/issues/14413

Changes:
- Exposes `<=` and `>=` operators in `bool` class.
  - Adds method descriptions.