### PR TITLE
Autoclip script editor search docs buttons text

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1422,6 +1422,12 @@ void ScriptEditor::_file_menu_closed() {
 	menu->set_item_disabled(menu->get_item_index(FILE_MENU_RUN), false);
 }
 
+void ScriptEditor::_update_search_docs_buttons() {
+	bool should_clip = search_buttons_ph->get_size().x <= (int)search_buttons_ph->get_meta("collapse_size");
+	help_search->set_clip_text(should_clip);
+	site_search->set_clip_text(should_clip);
+}
+
 void ScriptEditor::_tab_changed(int p_which) {
 	ensure_select_current();
 }
@@ -1444,6 +1450,23 @@ void ScriptEditor::_notification(int p_what) {
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
 			tab_container->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("ScriptEditor"), EditorStringName(EditorStyles)));
+
+			const Ref<Texture> icon_help_search = get_editor_theme_icon(SNAME("HelpSearch"));
+			const Ref<Texture> icon_site_search = get_editor_theme_icon(SNAME("ExternalLink"));
+
+			help_search->set_button_icon(icon_help_search);
+			site_search->set_button_icon(icon_site_search);
+
+			int search_width = help_search->get_minimum_size_for_text_and_icon("", icon_help_search, true).x;
+			search_width += search_buttons_hb->get_theme_constant(SNAME("separation"), SNAME("HBoxContainer"));
+			search_width += site_search->get_minimum_size_for_text_and_icon("", icon_site_search, true).x;
+			search_buttons_ph->set_custom_minimum_size(Vector2(search_width, 0));
+
+			int collapse_size = help_search->get_minimum_size_for_text_and_icon("", help_search->get_button_icon()).x;
+			collapse_size += search_buttons_hb->get_theme_constant(SNAME("separation"), SNAME("HBoxContainer"));
+			collapse_size += site_search->get_minimum_size_for_text_and_icon("", site_search->get_button_icon()).x;
+			search_buttons_ph->set_meta("collapse_size", collapse_size);
+			_update_search_docs_buttons();
 
 			_calculate_script_name_button_size();
 
@@ -1857,6 +1880,13 @@ void ScriptEditor::_update_online_doc() {
 		site_search->set_text(TTRC("Online Docs"));
 		site_search->set_tooltip_text(TTRC("Open Godot online documentation."));
 	}
+
+	int collapse_size = help_search->get_minimum_size_for_text_and_icon("", help_search->get_button_icon()).x;
+	collapse_size += search_buttons_hb->get_theme_constant(SNAME("separation"), SNAME("HBoxContainer"));
+	collapse_size += site_search->get_minimum_size_for_text_and_icon("", site_search->get_button_icon()).x;
+	search_buttons_ph->set_meta("collapse_size", collapse_size);
+
+	_update_search_docs_buttons();
 }
 
 void ScriptEditor::_update_script_colors() {
@@ -4025,17 +4055,28 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	script_name_button_right_spacer->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	script_name_button_hbox->add_child(script_name_button_right_spacer);
 
+	search_buttons_ph = memnew(Control);
+	search_buttons_ph->set_h_size_flags(SIZE_EXPAND_FILL);
+	search_buttons_ph->connect(SceneStringName(resized), callable_mp(this, &ScriptEditor::_update_search_docs_buttons));
+	menu_hb->add_child(search_buttons_ph);
+
+	search_buttons_hb = memnew(HBoxContainer);
+	search_buttons_ph->add_child(search_buttons_hb);
+	search_buttons_hb->set_alignment(BoxContainer::ALIGNMENT_END);
+	search_buttons_hb->set_anchors_preset(PRESET_RIGHT_WIDE);
+	search_buttons_hb->set_grow_direction_preset(PRESET_RIGHT_WIDE);
+
 	site_search = memnew(Button);
 	site_search->set_theme_type_variation(SceneStringName(FlatButton));
 	site_search->set_accessibility_name(TTRC("Site Search"));
 	site_search->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditor::_menu_option).bind(SEARCH_WEBSITE));
-	menu_hb->add_child(site_search);
+	search_buttons_hb->add_child(site_search);
 
 	help_search = memnew(Button);
 	help_search->set_theme_type_variation(SceneStringName(FlatButton));
 	help_search->set_text(TTRC("Search Help"));
 	help_search->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditor::_menu_option).bind(SEARCH_HELP));
-	menu_hb->add_child(help_search);
+	search_buttons_hb->add_child(help_search);
 	help_search->set_tooltip_text(TTRC("Search the reference documentation."));
 
 	menu_hb->add_child(memnew(VSeparator));

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -161,6 +161,8 @@ class ScriptEditor : public PanelContainer {
 
 	Button *help_search = nullptr;
 	Button *site_search = nullptr;
+	HBoxContainer *search_buttons_hb = nullptr;
+	Control *search_buttons_ph = nullptr;
 	Button *make_floating = nullptr;
 	bool is_floating = false;
 	EditorHelpSearch *help_search_dialog = nullptr;
@@ -236,6 +238,8 @@ class ScriptEditor : public PanelContainer {
 	bool _has_script_tab() const;
 	void _prepare_file_menu();
 	void _file_menu_closed();
+
+	void _update_search_docs_buttons();
 
 	Tree *disk_changed_list = nullptr;
 	ConfirmationDialog *disk_changed = nullptr;

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -480,20 +480,23 @@ Size2 Button::_fit_icon_size(const Size2 &p_size) const {
 	return icon_size;
 }
 
-Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Texture2D> p_icon) const {
+Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Texture2D> p_icon, bool p_ignore_text) const {
 	// Do not include `_internal_margin`, it's already added in the `get_minimum_size` overrides.
 
-	Ref<TextParagraph> paragraph;
-	if (p_text.is_empty()) {
-		paragraph = text_buf;
-	} else {
-		paragraph.instantiate();
-		_shape(paragraph, p_text);
-	}
+	Size2 minsize = Size2(0, 0);
+	if (!p_ignore_text) {
+		Ref<TextParagraph> paragraph;
+		if (p_text.is_empty()) {
+			paragraph = text_buf;
+		} else {
+			paragraph.instantiate();
+			_shape(paragraph, p_text);
+		}
+		minsize = paragraph->get_size();
 
-	Size2 minsize = paragraph->get_size();
-	if (clip_text || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING || autowrap_mode != TextServer::AUTOWRAP_OFF) {
-		minsize.width = 0;
+		if (clip_text || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING || autowrap_mode != TextServer::AUTOWRAP_OFF) {
+			minsize.width = 0;
+		}
 	}
 
 	if (!expand_icon && p_icon.is_valid()) {
@@ -506,7 +509,7 @@ Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Textu
 
 		if (horizontal_icon_alignment != HORIZONTAL_ALIGNMENT_CENTER) {
 			minsize.width += icon_size.width;
-			if (!xl_text.is_empty() || !p_text.is_empty()) {
+			if (!p_ignore_text && (!xl_text.is_empty() || !p_text.is_empty())) {
 				minsize.width += MAX(0, theme_cache.h_separation);
 			}
 		} else {
@@ -514,7 +517,7 @@ Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Textu
 		}
 	}
 
-	if (!xl_text.is_empty() || !p_text.is_empty()) {
+	if (!p_ignore_text && (!xl_text.is_empty() || !p_text.is_empty())) {
 		Ref<Font> font = theme_cache.font;
 		float font_height = font->get_height(theme_cache.font_size);
 		if (vertical_icon_alignment == VERTICAL_ALIGNMENT_CENTER) {

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -123,7 +123,7 @@ protected:
 public:
 	virtual Size2 get_minimum_size() const override;
 
-	Size2 get_minimum_size_for_text_and_icon(const String &p_text, Ref<Texture2D> p_icon) const;
+	Size2 get_minimum_size_for_text_and_icon(const String &p_text, Ref<Texture2D> p_icon, bool p_ignore_text = false) const;
 
 	void set_text(const String &p_text);
 	String get_text() const;


### PR DESCRIPTION
I'm opening this as draft, I need to finalize it (but not sure how) to make it look good. Right now it just works, but it doesn't look very good visually and in terms of code.

This is how it looks right now:

https://github.com/user-attachments/assets/75ca8c28-d507-447c-a478-62b195571117

General issue is that `Open '%s' in Godot online documentation.` and `Open in Online Docs` take huge amount of space (especially in some languages) and makes Script editor unnecessarily too wide.

This PR allows to solve several issues:

- Will help with https://github.com/godotengine/godot/pull/117109#issuecomment-4007027887.
- When the editor window has the minimum size, it will be possible to open more docks in different slots (also increases possibility to reduce editor window minimum width):

| Before | After |
| --- | --- |
| <img width="1077" height="631" alt="Godot_v4 6 1-stable_win64_d62wcKkPMl" src="https://github.com/user-attachments/assets/25776f44-d189-4308-855f-07b33ec23bdf" /> | <img width="1077" height="631" alt="godot windows editor dev x86_64_68uTXQLICN" src="https://github.com/user-attachments/assets/801888a8-78da-487b-a552-c9a171261efe" /> |


Alternative solution - just remove text from these buttons completely and leave only tooltips.

сс @syntaxerror247 you may be interested as we discussed this earlier in the PR referenced above.