### PR TITLE
Remove unused includes in `scene` with clangd-tidy

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -56,6 +56,7 @@
 #include "scene/resources/animation.h"
 #include "scene/resources/bone_map.h"
 #include "scene/resources/packed_scene.h"
+#include "scene/resources/physics_material.h"
 #include "scene/resources/resource_format_text.h"
 
 void EditorSceneFormatImporter::get_extensions(List<String> *r_extensions) const {

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -59,6 +59,7 @@
 #include "scene/gui/color_picker.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/text_edit.h"
+#include "scene/gui/texture_button.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/resources/font.h"

--- a/editor/scene/2d/sprite_2d_editor_plugin.cpp
+++ b/editor/scene/2d/sprite_2d_editor_plugin.cpp
@@ -49,6 +49,7 @@
 #include "scene/gui/panel.h"
 #include "scene/gui/view_panner.h"
 #include "scene/main/scene_tree.h"
+#include "scene/resources/bit_map.h"
 #include "scene/resources/mesh.h"
 #include "thirdparty/clipper2/include/clipper2/clipper.h"
 

--- a/editor/scene/3d/bone_map_editor_plugin.h
+++ b/editor/scene/3d/bone_map_editor_plugin.h
@@ -33,11 +33,11 @@
 #include "editor/editor_node.h"
 #include "editor/inspector/editor_properties.h"
 #include "editor/plugins/editor_plugin.h"
-
 #include "scene/3d/skeleton_3d.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/color_rect.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/texture_button.h"
 #include "scene/resources/bone_map.h"
 #include "scene/resources/texture.h"
 

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -67,6 +67,7 @@
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/split_container.h"
+#include "scene/gui/texture_button.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/gui/tree.h"
 #include "scene/gui/view_panner.h"

--- a/modules/multiplayer/tests/test_scene_multiplayer.h
+++ b/modules/multiplayer/tests/test_scene_multiplayer.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/callable_mp.h"
+#include "scene/2d/node_2d.h"
 #include "scene/main/scene_tree.h"
 #include "tests/test_macros.h"
 #include "tests/test_utils.h"

--- a/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
@@ -33,6 +33,8 @@
 #include "nav_mesh_generator_2d.h"
 
 #include "core/config/project_settings.h"
+#include "scene/2d/node_2d.h"
+#include "scene/main/node.h"
 #include "scene/main/scene_tree.h"
 #include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h"
 #include "scene/resources/2d/navigation_polygon.h"

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -32,7 +32,6 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
-#include "core/input/input.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "scene/main/scene_tree.h"

--- a/scene/2d/mesh_instance_2d.cpp
+++ b/scene/2d/mesh_instance_2d.cpp
@@ -39,7 +39,6 @@
 #include "servers/navigation_2d/navigation_server_2d.h"
 
 #include "thirdparty/clipper2/include/clipper2/clipper.h"
-#include "thirdparty/misc/polypartition.h"
 #endif // NAVIGATION_2D_DISABLED
 
 Callable MeshInstance2D::_navmesh_source_geometry_parsing_callback;

--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -39,7 +39,6 @@
 #include "servers/navigation_2d/navigation_server_2d.h"
 
 #include "thirdparty/clipper2/include/clipper2/clipper.h"
-#include "thirdparty/misc/polypartition.h"
 #endif // NAVIGATION_2D_DISABLED
 
 Callable MultiMeshInstance2D::_navmesh_source_geometry_parsing_callback;

--- a/scene/2d/navigation/navigation_region_2d.h
+++ b/scene/2d/navigation/navigation_region_2d.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "scene/2d/node_2d.h"
 #include "scene/resources/2d/navigation_polygon.h"
 
 class NavigationRegion2D : public Node2D {

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -39,10 +39,6 @@
 #include "scene/resources/mesh.h"
 #include "servers/rendering/rendering_server.h"
 
-#ifdef TOOLS_ENABLED
-#include "editor/themes/editor_scale.h"
-#endif
-
 #ifdef DEBUG_ENABLED
 Rect2 Path2D::_edit_get_rect() const {
 	if (curve.is_null() || curve->get_point_count() == 0) {

--- a/scene/2d/physics/physics_body_2d.h
+++ b/scene/2d/physics/physics_body_2d.h
@@ -32,7 +32,6 @@
 
 #include "scene/2d/physics/collision_object_2d.h"
 #include "scene/2d/physics/kinematic_collision_2d.h"
-#include "scene/resources/physics_material.h"
 #include "servers/physics_2d/physics_server_2d.h"
 
 class PhysicsBody2D : public CollisionObject2D {

--- a/scene/2d/physics/rigid_body_2d.cpp
+++ b/scene/2d/physics/rigid_body_2d.cpp
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "scene/resources/physics_material.h"
 
 void RigidBody2D::_body_enter_tree(ObjectID p_id) {
 	Object *obj = ObjectDB::get_instance(p_id);

--- a/scene/2d/physics/rigid_body_2d.h
+++ b/scene/2d/physics/rigid_body_2d.h
@@ -33,6 +33,8 @@
 #include "core/templates/vset.h"
 #include "scene/2d/physics/physics_body_2d.h"
 
+class PhysicsMaterial;
+
 class RigidBody2D : public PhysicsBody2D {
 	GDCLASS(RigidBody2D, PhysicsBody2D);
 

--- a/scene/2d/physics/static_body_2d.cpp
+++ b/scene/2d/physics/static_body_2d.cpp
@@ -32,6 +32,7 @@
 
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "scene/resources/physics_material.h"
 
 #ifndef NAVIGATION_2D_DISABLED
 #include "scene/resources/2d/capsule_shape_2d.h"

--- a/scene/2d/physics/static_body_2d.h
+++ b/scene/2d/physics/static_body_2d.h
@@ -32,8 +32,12 @@
 
 #include "scene/2d/physics/physics_body_2d.h"
 
+class PhysicsMaterial;
+
+#ifndef NAVIGATION_2D_DISABLED
 class NavigationPolygon;
 class NavigationMeshSourceGeometryData2D;
+#endif
 
 class StaticBody2D : public PhysicsBody2D {
 	GDCLASS(StaticBody2D, PhysicsBody2D);

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -31,7 +31,6 @@
 #include "sprite_2d.h"
 
 #include "core/config/engine.h"
-#include "core/input/input.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "scene/main/viewport.h"

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -31,10 +31,10 @@
 #include "label_3d.h"
 
 #include "core/config/engine.h"
+#include "core/math/triangle_mesh.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "scene/main/window.h"
-#include "scene/resources/mesh.h"
 #include "scene/resources/theme.h"
 #include "scene/theme/theme_db.h"
 #include "servers/rendering/rendering_server.h"

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -37,7 +37,6 @@
 #include "core/math/geometry_3d.h"
 #include "core/object/class_db.h"
 #include "core/object/object.h"
-#include "core/os/os.h"
 #include "scene/3d/light_3d.h"
 #include "scene/3d/lightmap_probe.h"
 #include "scene/3d/mesh_instance_3d.h"
@@ -49,6 +48,10 @@
 #include "servers/rendering/rendering_server.h"
 
 #include "modules/modules_enabled.gen.h" // For lightmapper_rd.
+
+#if defined(ANDROID_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+#include "core/os/os.h"
+#endif
 
 void LightmapGIData::add_user(const NodePath &p_path, const Rect2 &p_uv_scale, int p_slice_index, int32_t p_sub_instance) {
 	User user;

--- a/scene/3d/physics/physics_body_3d.h
+++ b/scene/3d/physics/physics_body_3d.h
@@ -32,7 +32,6 @@
 
 #include "scene/3d/physics/collision_object_3d.h"
 #include "scene/3d/physics/kinematic_collision_3d.h"
-#include "scene/resources/physics_material.h"
 #include "servers/physics_3d/physics_server_3d.h"
 
 class PhysicsBody3D : public CollisionObject3D {

--- a/scene/3d/physics/rigid_body_3d.cpp
+++ b/scene/3d/physics/rigid_body_3d.cpp
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "scene/resources/physics_material.h"
 
 void RigidBody3D::_body_enter_tree(ObjectID p_id) {
 	Object *obj = ObjectDB::get_instance(p_id);

--- a/scene/3d/physics/rigid_body_3d.h
+++ b/scene/3d/physics/rigid_body_3d.h
@@ -33,6 +33,8 @@
 #include "core/templates/vset.h"
 #include "scene/3d/physics/physics_body_3d.h"
 
+class PhysicsMaterial;
+
 class RigidBody3D : public PhysicsBody3D {
 	GDCLASS(RigidBody3D, PhysicsBody3D);
 

--- a/scene/3d/physics/static_body_3d.cpp
+++ b/scene/3d/physics/static_body_3d.cpp
@@ -45,8 +45,8 @@
 #include "scene/resources/3d/primitive_meshes.h"
 #include "scene/resources/3d/shape_3d.h"
 #include "scene/resources/3d/sphere_shape_3d.h"
-#include "scene/resources/3d/world_boundary_shape_3d.h"
 #include "scene/resources/navigation_mesh.h"
+#include "scene/resources/physics_material.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
 
 Callable StaticBody3D::_navmesh_source_geometry_parsing_callback;

--- a/scene/3d/physics/static_body_3d.h
+++ b/scene/3d/physics/static_body_3d.h
@@ -32,6 +32,8 @@
 
 #include "scene/3d/physics/physics_body_3d.h"
 
+class PhysicsMaterial;
+
 #ifndef NAVIGATION_3D_DISABLED
 class NavigationMesh;
 class NavigationMeshSourceGeometryData3D;

--- a/scene/3d/spline_ik_3d.cpp
+++ b/scene/3d/spline_ik_3d.cpp
@@ -31,6 +31,7 @@
 #include "spline_ik_3d.h"
 
 #include "core/object/class_db.h"
+#include "scene/3d/path_3d.h"
 
 bool SplineIK3D::_set(const StringName &p_path, const Variant &p_value) {
 	String path = p_path;

--- a/scene/3d/spline_ik_3d.h
+++ b/scene/3d/spline_ik_3d.h
@@ -31,7 +31,8 @@
 #pragma once
 
 #include "scene/3d/chain_ik_3d.h"
-#include "scene/3d/path_3d.h"
+
+class Curve3D;
 
 class SplineIK3D : public ChainIK3D {
 	GDCLASS(SplineIK3D, ChainIK3D);

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -31,10 +31,10 @@
 #include "sprite_3d.h"
 
 #include "core/config/engine.h"
+#include "core/math/triangle_mesh.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "scene/resources/atlas_texture.h"
-#include "scene/resources/mesh.h"
 #include "servers/rendering/rendering_server.h"
 
 Color SpriteBase3D::_get_color_accum() {

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -32,7 +32,6 @@
 
 STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 
-#include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -33,7 +33,6 @@
 #include "core/config/project_settings.h"
 #include "core/io/image.h"
 #include "core/math/geometry_3d.h"
-#include "scene/resources/curve.h"
 #include "scene/resources/texture.h"
 
 static _FORCE_INLINE_ void get_uv_and_normal(const Vector3 &p_pos, const Vector3 *p_vtx, const Vector2 *p_uv, const Vector3 *p_normal, Vector2 &r_uv, Vector3 &r_normal) {

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -35,7 +35,6 @@
 #include "core/math/geometry_2d.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
-#include "scene/resources/material.h"
 
 void AnimationNodeBlendSpace2D::get_parameter_list(List<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);

--- a/scene/animation/easing_equations.h
+++ b/scene/animation/easing_equations.h
@@ -64,15 +64,15 @@ inline real_t in(real_t t, real_t b, real_t c, real_t d) {
 
 namespace Sine {
 inline real_t in(real_t t, real_t b, real_t c, real_t d) {
-	return -c * std::cos(t / d * (Math::PI / 2)) + c + b;
+	return -c * Math::cos(t / d * (Math::PI / 2)) + c + b;
 }
 
 inline real_t out(real_t t, real_t b, real_t c, real_t d) {
-	return c * std::sin(t / d * (Math::PI / 2)) + b;
+	return c * Math::sin(t / d * (Math::PI / 2)) + b;
 }
 
 inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
-	return -c / 2 * (std::cos(Math::PI * t / d) - 1) + b;
+	return -c / 2 * (Math::cos(Math::PI * t / d) - 1) + b;
 }
 
 inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
@@ -86,20 +86,20 @@ inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 
 namespace Quint {
 inline real_t in(real_t t, real_t b, real_t c, real_t d) {
-	return c * std::pow(t / d, 5) + b;
+	return c * Math::pow(t / d, 5) + b;
 }
 
 inline real_t out(real_t t, real_t b, real_t c, real_t d) {
-	return c * (std::pow(t / d - 1, 5) + 1) + b;
+	return c * (Math::pow(t / d - 1, 5) + 1) + b;
 }
 
 inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
 	t = t / d * 2;
 
 	if (t < 1) {
-		return c / 2 * std::pow(t, 5) + b;
+		return c / 2 * Math::pow(t, 5) + b;
 	}
-	return c / 2 * (std::pow(t - 2, 5) + 2) + b;
+	return c / 2 * (Math::pow(t - 2, 5) + 2) + b;
 }
 
 inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
@@ -113,20 +113,20 @@ inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 
 namespace Quart {
 inline real_t in(real_t t, real_t b, real_t c, real_t d) {
-	return c * std::pow(t / d, 4) + b;
+	return c * Math::pow(t / d, 4) + b;
 }
 
 inline real_t out(real_t t, real_t b, real_t c, real_t d) {
-	return -c * (std::pow(t / d - 1, 4) - 1) + b;
+	return -c * (Math::pow(t / d - 1, 4) - 1) + b;
 }
 
 inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
 	t = t / d * 2;
 
 	if (t < 1) {
-		return c / 2 * std::pow(t, 4) + b;
+		return c / 2 * Math::pow(t, 4) + b;
 	}
-	return -c / 2 * (std::pow(t - 2, 4) - 2) + b;
+	return -c / 2 * (Math::pow(t - 2, 4) - 2) + b;
 }
 
 inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
@@ -140,7 +140,7 @@ inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 
 namespace Quad {
 inline real_t in(real_t t, real_t b, real_t c, real_t d) {
-	return c * std::pow(t / d, 2) + b;
+	return c * Math::pow(t / d, 2) + b;
 }
 
 inline real_t out(real_t t, real_t b, real_t c, real_t d) {
@@ -152,7 +152,7 @@ inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
 	t = t / d * 2;
 
 	if (t < 1) {
-		return c / 2 * std::pow(t, 2) + b;
+		return c / 2 * Math::pow(t, 2) + b;
 	}
 	return -c / 2 * ((t - 1) * (t - 3) - 1) + b;
 }
@@ -171,14 +171,14 @@ inline real_t in(real_t t, real_t b, real_t c, real_t d) {
 	if (t == 0) {
 		return b;
 	}
-	return c * std::pow(2, 10 * (t / d - 1)) + b - c * 0.001;
+	return c * Math::pow(2, 10 * (t / d - 1)) + b - c * 0.001;
 }
 
 inline real_t out(real_t t, real_t b, real_t c, real_t d) {
 	if (t == d) {
 		return b + c;
 	}
-	return c * 1.001 * (-std::pow(2, -10 * t / d) + 1) + b;
+	return c * 1.001 * (-Math::pow(2, -10 * t / d) + 1) + b;
 }
 
 inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
@@ -193,9 +193,9 @@ inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
 	t = t / d * 2;
 
 	if (t < 1) {
-		return c / 2 * std::pow(2, 10 * (t - 1)) + b - c * 0.0005;
+		return c / 2 * Math::pow(2, 10 * (t - 1)) + b - c * 0.0005;
 	}
-	return c / 2 * 1.0005 * (-std::pow(2, -10 * (t - 1)) + 2) + b;
+	return c / 2 * 1.0005 * (-Math::pow(2, -10 * (t - 1)) + 2) + b;
 }
 
 inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
@@ -220,10 +220,10 @@ inline real_t in(real_t t, real_t b, real_t c, real_t d) {
 
 	t -= 1;
 	float p = d * 0.3f;
-	float a = c * std::pow(2, 10 * t);
+	float a = c * Math::pow(2, 10 * t);
 	float s = p / 4;
 
-	return -(a * std::sin((t * d - s) * (2 * Math::PI) / p)) + b;
+	return -(a * Math::sin((t * d - s) * (2 * Math::PI) / p)) + b;
 }
 
 inline real_t out(real_t t, real_t b, real_t c, real_t d) {
@@ -239,7 +239,7 @@ inline real_t out(real_t t, real_t b, real_t c, real_t d) {
 	float p = d * 0.3f;
 	float s = p / 4;
 
-	return (c * std::pow(2, -10 * t) * std::sin((t * d - s) * (2 * Math::PI) / p) + c + b);
+	return (c * Math::pow(2, -10 * t) * Math::sin((t * d - s) * (2 * Math::PI) / p) + c + b);
 }
 
 inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
@@ -257,13 +257,13 @@ inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
 
 	if (t < 1) {
 		t -= 1;
-		a *= std::pow(2, 10 * t);
-		return -0.5f * (a * std::sin((t * d - s) * (2 * Math::PI) / p)) + b;
+		a *= Math::pow(2, 10 * t);
+		return -0.5f * (a * Math::sin((t * d - s) * (2 * Math::PI) / p)) + b;
 	}
 
 	t -= 1;
-	a *= std::pow(2, -10 * t);
-	return a * std::sin((t * d - s) * (2 * Math::PI) / p) * 0.5f + c + b;
+	a *= Math::pow(2, -10 * t);
+	return a * Math::sin((t * d - s) * (2 * Math::PI) / p) * 0.5f + c + b;
 }
 
 inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
@@ -308,22 +308,22 @@ inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 namespace Circ {
 inline real_t in(real_t t, real_t b, real_t c, real_t d) {
 	t /= d;
-	return -c * (std::sqrt(1 - t * t) - 1) + b;
+	return -c * (Math::sqrt(1 - t * t) - 1) + b;
 }
 
 inline real_t out(real_t t, real_t b, real_t c, real_t d) {
 	t = t / d - 1;
-	return c * std::sqrt(1 - t * t) + b;
+	return c * Math::sqrt(1 - t * t) + b;
 }
 
 inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
 	t /= d / 2;
 	if (t < 1) {
-		return -c / 2 * (std::sqrt(1 - t * t) - 1) + b;
+		return -c / 2 * (Math::sqrt(1 - t * t) - 1) + b;
 	}
 
 	t -= 2;
-	return c / 2 * (std::sqrt(1 - t * t) + 1) + b;
+	return c / 2 * (Math::sqrt(1 - t * t) + 1) + b;
 }
 
 inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
@@ -418,7 +418,7 @@ namespace Spring {
 inline real_t out(real_t t, real_t b, real_t c, real_t d) {
 	t /= d;
 	real_t s = 1.0 - t;
-	t = (std::sin(t * Math::PI * (0.2 + 2.5 * t * t * t)) * std::pow(s, 2.2) + t) * (1.0 + (1.2 * s));
+	t = (Math::sin(t * Math::PI * (0.2 + 2.5 * t * t * t)) * Math::pow(s, (real_t)2.2) + t) * (1.0 + (1.2 * s));
 	return c * t + b;
 }
 

--- a/scene/debugger/view_3d_controller.cpp
+++ b/scene/debugger/view_3d_controller.cpp
@@ -35,7 +35,7 @@
 #include "core/config/engine.h"
 #include "core/input/input.h"
 #include "core/input/shortcut.h"
-#include "core/object/class_db.h"
+#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -30,7 +30,6 @@
 
 #include "check_box.h"
 
-#include "core/object/class_db.h"
 #include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"
 

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -30,7 +30,6 @@
 
 #include "check_button.h"
 
-#include "core/object/class_db.h"
 #include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -36,7 +36,6 @@
 #include "core/math/expression.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
-#include "core/os/os.h"
 #include "scene/gui/color_mode.h"
 #include "scene/gui/color_picker_shape.h"
 #include "scene/gui/file_dialog.h"
@@ -60,6 +59,10 @@
 #include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"
 #include "servers/display/display_server.h"
+
+#ifdef MACOS_ENABLED
+#include "core/os/os.h"
+#endif
 
 static inline bool is_color_overbright(const Color &color) {
 	return (color.r > 1.0) || (color.g > 1.0) || (color.b > 1.0);

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -35,7 +35,6 @@
 #include "scene/gui/label.h"
 #include "scene/gui/panel.h"
 #include "scene/gui/popup.h"
-#include "scene/gui/texture_button.h"
 #include "scene/main/window.h"
 
 class LineEdit;

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -41,7 +41,6 @@
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
 #include "core/string/alt_codes.h"
-#include "core/string/translation_server.h"
 #include "scene/gui/label.h"
 #include "scene/main/window.h"
 #include "scene/theme/theme_db.h"

--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -30,7 +30,6 @@
 
 #include "margin_container.h"
 
-#include "core/object/class_db.h"
 #include "scene/theme/theme_db.h"
 
 Size2 MarginContainer::get_minimum_size() const {

--- a/scene/gui/panel.cpp
+++ b/scene/gui/panel.cpp
@@ -30,7 +30,6 @@
 
 #include "panel.h"
 
-#include "core/object/class_db.h"
 #include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"
 

--- a/scene/gui/panel_container.cpp
+++ b/scene/gui/panel_container.cpp
@@ -30,7 +30,6 @@
 
 #include "panel_container.h"
 
-#include "core/object/class_db.h"
 #include "scene/theme/theme_db.h"
 
 Size2 PanelContainer::get_minimum_size() const {

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -32,7 +32,7 @@
 
 #include "core/config/engine.h"
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h"
+#include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "scene/gui/panel.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/theme/theme_db.h"

--- a/scene/gui/separator.cpp
+++ b/scene/gui/separator.cpp
@@ -30,7 +30,6 @@
 
 #include "separator.h"
 
-#include "core/object/class_db.h"
 #include "scene/theme/theme_db.h"
 
 Size2 Separator::get_minimum_size() const {

--- a/scene/gui/virtual_joystick.cpp
+++ b/scene/gui/virtual_joystick.cpp
@@ -32,7 +32,6 @@
 
 #include "core/config/engine.h"
 #include "core/input/input.h"
-#include "core/input/input_map.h"
 #include "core/object/class_db.h"
 #include "scene/theme/theme_db.h"
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -35,7 +35,7 @@
 #include "core/object/object.h"
 #include "core/object/ref_counted.h"
 #include "core/templates/iterable.h"
-#include "scene/scene_string_names.h"
+#include "scene/scene_string_names.h" // IWYU pragma: export. Make available to all Nodes.
 
 class MultiplayerAPI;
 class NodePath;

--- a/scene/resources/2d/navigation_polygon.h
+++ b/scene/resources/2d/navigation_polygon.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "scene/2d/node_2d.h"
 #include "scene/resources/navigation_mesh.h"
 #include "servers/navigation_2d/navigation_constants_2d.h"
 

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -43,10 +43,6 @@
 #include "scene/resources/mesh.h"
 #include "servers/rendering/rendering_server.h"
 
-#ifndef NAVIGATION_2D_DISABLED
-#include "servers/navigation_2d/navigation_server_2d.h"
-#endif // NAVIGATION_2D_DISABLED
-
 /////////////////////////////// TileMapPattern //////////////////////////////////////
 
 void TileMapPattern::_set_tile_data(const Vector<int> &p_data) {

--- a/scene/resources/3d/joint_limitation_3d.cpp
+++ b/scene/resources/3d/joint_limitation_3d.cpp
@@ -30,8 +30,6 @@
 
 #include "joint_limitation_3d.h"
 
-#include "scene/3d/skeleton_modifier_3d.h"
-
 Quaternion JointLimitation3D::make_space(const Vector3 &p_local_forward_vector, const Vector3 &p_local_right_vector, const Quaternion &p_rotation_offset) const {
 	const double ALMOST_ONE = 1.0 - CMP_EPSILON;
 	// The default is to interpret the forward vector as the +Y axis.

--- a/scene/resources/dpi_texture.cpp
+++ b/scene/resources/dpi_texture.cpp
@@ -30,13 +30,10 @@
 
 #include "dpi_texture.h"
 
-#include "core/io/image_loader.h"
 #include "core/object/class_db.h"
-#include "scene/main/canvas_item.h"
-#include "scene/main/viewport.h"
 #include "scene/resources/bit_map.h"
-#include "scene/resources/placeholder_textures.h"
 #include "servers/rendering/rendering_server.h"
+#include "servers/text/text_server.h"
 
 #include "modules/modules_enabled.gen.h" // For svg.
 #ifdef MODULE_SVG_ENABLED

--- a/scene/resources/dpi_texture.h
+++ b/scene/resources/dpi_texture.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/templates/lru.h"
 #include "scene/resources/texture.h"
 
 class BitMap;

--- a/scene/resources/drawable_texture_2d.cpp
+++ b/scene/resources/drawable_texture_2d.cpp
@@ -31,6 +31,8 @@
 #include "drawable_texture_2d.h"
 
 #include "core/object/class_db.h"
+#include "scene/resources/atlas_texture.h"
+#include "scene/resources/material.h"
 #include "servers/rendering/rendering_server.h"
 
 DrawableTexture2D::DrawableTexture2D() {

--- a/scene/resources/drawable_texture_2d.h
+++ b/scene/resources/drawable_texture_2d.h
@@ -30,9 +30,9 @@
 
 #pragma once
 
-#include "scene/resources/atlas_texture.h"
-#include "scene/resources/image_texture.h"
-#include "scene/resources/material.h"
+#include "scene/resources/texture.h"
+
+class Material;
 
 class DrawableTexture2D : public Texture2D {
 	GDCLASS(DrawableTexture2D, Texture2D);

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -37,7 +37,6 @@
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/templates/hash_map.h"
-#include "core/templates/hashfuncs.h"
 #include "scene/resources/image_texture.h"
 #include "scene/resources/text_line.h"
 #include "scene/resources/text_paragraph.h"

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -32,7 +32,7 @@
 
 #include "core/io/resource.h"
 #include "core/templates/lru.h"
-#include "scene/resources/texture.h"
+#include "core/variant/typed_array.h"
 #include "servers/text/text_server.h"
 
 class TextLine;

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -32,9 +32,8 @@
 
 #include "core/config/engine.h"
 #include "core/object/class_db.h"
-#include "scene/main/canvas_item.h"
-#include "scene/main/viewport.h"
 #include "servers/rendering/rendering_server.h"
+#include "servers/text/text_server.h"
 
 float StyleBoxFlat::get_style_margin(Side p_side) const {
 	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);

--- a/scene/theme/icons/default_theme_icons_builders.py
+++ b/scene/theme/icons/default_theme_icons_builders.py
@@ -22,8 +22,6 @@ def make_default_theme_icons_action(target, source, env):
 
     with methods.generated_wrapper(str(target[0])) as file:
         file.write(f"""\
-#include "modules/modules_enabled.gen.h"
-
 inline constexpr int default_theme_icons_count = {len(icons_names)};
 inline constexpr const char *default_theme_icons_sources[] = {{
 	{icons_raw_str}


### PR DESCRIPTION
- Helps address https://github.com/godotengine/godot/issues/111218.

I found that `clangd` seems able to detect unused includes on a per file basis: https://clangd.llvm.org/guides/include-cleaner
The clangd extension in VS Code for example can detect this in open files.

To analyze the whole codebase at once, I tried using [`clangd-tidy`](https://github.com/lljbash/clangd-tidy) (not to confuse with `clang-tidy`).

I ran:
```
cd scene
clangd-tidy $(find -name "*.cpp" -o -name "*.h" -o -name "*.inc") &> ../clangd-tidy.log
```
and then did relevant changes manually.

Results seem pretty good!

Local clangd/clang-tidy config tweaks to remove diagnostics I'm not interested in here:
```diff
diff --git a/.clang-tidy b/.clang-tidy
index 47ef444cc6..45a0096b42 100644
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,15 +3,6 @@
 
 Checks:
   - -*
-  - bugprone-use-after-move
-  - modernize-deprecated-headers
-  - modernize-redundant-void-arg
-  - modernize-use-bool-literals
-#  - modernize-use-default-member-init # TODO Re-activate
-  - modernize-use-nullptr
-  - readability-braces-around-statements
-  - readability-redundant-member-init
-  - readability-operators-representation
 HeaderFileExtensions: ["", h, hh, hpp, hxx, inc, glsl]
 ImplementationFileExtensions: [c, cc, cpp, cxx, m, mm, java]
 HeaderFilterRegex: (core|doc|drivers|editor|main|modules|platform|scene|servers|tests)/
diff --git a/.clangd b/.clangd
index 3c9792eafb..02c0d6fef8 100644
--- a/.clangd
+++ b/.clangd
@@ -3,6 +3,7 @@
 # Default conditions, apply everywhere.
 
 Diagnostics:
+  UnusedIncludes: Strict
   Includes:
     IgnoreHeader:
       - \.compat\.inc
```