### PR TITLE
Reset follow mode focus count after committing a transform

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -5233,6 +5233,7 @@ void Node3DEditorViewport::commit_transform() {
 
 	collision_reposition = false;
 	finish_transform();
+	_reset_follow_mode_count();
 	set_message("");
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

* Fixes: https://github.com/godotengine/godot/issues/117284

Another situation similar to: 
* https://github.com/godotengine/godot/pull/117214 

We should reset the count here too. CC: @Calinou 
