### PR TITLE
Fix visual shift of animation editor keys during selection

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -3251,6 +3251,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				}
 
 				bool selected = _try_select_at_ui_pos(pos, mb->is_command_or_control_pressed() || mb->is_shift_pressed(), false);
+				moving_selection_attempt = false;
 
 				menu->clear();
 				if (animation->track_get_type(track) == Animation::TYPE_METHOD) {


### PR DESCRIPTION
Fixes #117276

After fix:

https://github.com/user-attachments/assets/d5bf665d-4665-4f65-aabd-e6fc8b3a2b85

