### PR TITLE
Fix `RenderingDevice::texture_clear()` behaving unexpectedly when using the D3D12 driver

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -4039,18 +4039,11 @@ void RenderingDeviceDriverD3D12::command_clear_color_texture(CommandBufferID p_c
 					cmd_buf_info->uav_alloc.cpu_handle,
 					D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
-			UINT values[4] = {
-				(UINT)p_color.get_r8(),
-				(UINT)p_color.get_g8(),
-				(UINT)p_color.get_b8(),
-				(UINT)p_color.get_a8(),
-			};
-
-			cmd_buf_info->cmd_list->ClearUnorderedAccessViewUint(
+			cmd_buf_info->cmd_list->ClearUnorderedAccessViewFloat(
 					shader_visible_descriptor_allocation.gpu_handle,
 					cmd_buf_info->uav_alloc.cpu_handle,
 					tex_info->resource,
-					values,
+					p_color.components,
 					0,
 					nullptr);
 		}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/117210

Using `RenderingDevice::texture_clear()` led to different results between the Vulkan and D3D12 driver, depending on the `DataFormat` of the texture.
This PR changes the D3D12 driver to use `ID3D12GraphicsCommandList::ClearUnorderedAccessViewFloat()` for clearing color textures instead of `ID3D12GraphicsCommandList::ClearUnorderedAccessViewUint()`.
As far as my testing goes, this should make the result of `RenderingDevice::texture_clear()` be on par between the D3D12 and Vulkan driver.

The following example clears textures with different data formats to `Color.HOT_PINK` (left to right: `R8G8B8A8_UNORM`, `R32G32B32A32_SFLOAT`, `R8_UNORM`, `R32_SFLOAT`).

**Before:**
<img width="1940" height="339" alt="Before" src="https://github.com/user-attachments/assets/425237d0-b727-41c3-9773-fa515b25facf" />

**This PR:**
<img width="1940" height="340" alt="PR" src="https://github.com/user-attachments/assets/65302aa9-ef02-4dc1-a241-0ae73d437489" />

Example project: [texture-clear-example.zip](https://github.com/user-attachments/files/25876690/texture-clear-example.zip)

From what I've read about the behavior of those two clearing functions, I think that `ClearUnorderedAccessViewFloat()` would be more appropriate for clearing color textures.
However, I am not sure whether I am missing something here that might cause issues, as I don't know whether there was a reason for using `ClearUnorderedAccessViewUint()` in the first place.
