### PR TITLE
TileSet: Add support for user defined hexagonal tile overlap.

### DIFF
--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -631,6 +631,14 @@
 		</method>
 	</methods>
 	<members>
+		<member name="hexagon_tile_overlap" type="float" setter="set_hexagon_tile_overlap" getter="get_hexagon_tile_overlap" default="0.25">
+			Determines how much the rectangular bounding boxes of hexagonal tiles overlap along the [member tile_offset_axis].
+			A value of [code]0.0[/code] creates no overlap, resulting in a shape visually identical to Half-Offset Square tiles.
+			A value of [code]0.25[/code] creates a 25% overlap, resulting in a regular hexagon. This effectively shifts tiles toward each other by 25% of their size along the [member tile_offset_axis].
+			A value of [code]0.5[/code] creates a 50% overlap, shifting the tiles by half of their size, resulting in a shape visually identical to Isometric tiles.
+
+			Using values outside the [code]0.0[/code] to [code]0.5[/code] range is not recommended and may lead to unexpected behavior.
+		</member>
 		<member name="tile_layout" type="int" setter="set_tile_layout" getter="get_tile_layout" enum="TileSet.TileLayout" default="0">
 			For all half-offset shapes (Isometric, Hexagonal and Half-Offset square), changes the way tiles are indexed in the [TileMapLayer] grid.
 		</member>

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -386,6 +386,9 @@ void TileSet::set_tile_offset_axis(TileSet::TileOffsetAxis p_alignment) {
 
 	terrain_bits_meshes_dirty = true;
 	tile_meshes_dirty = true;
+	if (tile_shape == TILE_SHAPE_HEXAGON) {
+		notify_property_list_changed();
+	}
 	emit_changed();
 }
 TileSet::TileOffsetAxis TileSet::get_tile_offset_axis() const {
@@ -397,10 +400,45 @@ void TileSet::set_tile_size(Size2i p_size) {
 	tile_size = p_size;
 	terrain_bits_meshes_dirty = true;
 	tile_meshes_dirty = true;
+	if (tile_shape == TILE_SHAPE_HEXAGON) {
+		notify_property_list_changed();
+	}
 	emit_changed();
 }
 Size2i TileSet::get_tile_size() const {
 	return tile_size;
+}
+
+void TileSet::set_hexagon_tile_overlap(float p_tile_overlap) {
+	hexagon_tile_overlap = p_tile_overlap;
+
+	terrain_bits_meshes_dirty = true;
+	tile_meshes_dirty = true;
+	emit_changed();
+}
+float TileSet::get_hexagon_tile_overlap() const {
+	return hexagon_tile_overlap;
+}
+
+void TileSet::_set_hexagon_flat_side_length(float p_flat_side_length) {
+	int side_size;
+	if (tile_offset_axis == TILE_OFFSET_AXIS_HORIZONTAL) {
+		side_size = tile_size.y;
+	} else { // TILE_OFFSET_AXIS_VERTICAL
+		side_size = tile_size.x;
+	}
+
+	float overlap = (1.0f - p_flat_side_length / side_size) / 2.0f;
+	set_hexagon_tile_overlap(overlap);
+}
+float TileSet::_get_hexagon_flat_side_length() const {
+	int side_size;
+	if (tile_offset_axis == TILE_OFFSET_AXIS_HORIZONTAL) {
+		side_size = tile_size.y;
+	} else { // TILE_OFFSET_AXIS_VERTICAL
+		side_size = tile_size.x;
+	}
+	return (1.0f - hexagon_tile_overlap * 2.0f) * side_size;
 }
 
 int TileSet::get_next_source_id() const {
@@ -1469,17 +1507,7 @@ Vector<Vector2> TileSet::get_tile_shape_polygon() const {
 		points.push_back(Vector2(0.0, 0.5));
 		points.push_back(Vector2(0.5, 0.0));
 	} else {
-		float overlap = 0.0;
-		switch (tile_shape) {
-			case TileSet::TILE_SHAPE_HEXAGON:
-				overlap = 0.25;
-				break;
-			case TileSet::TILE_SHAPE_HALF_OFFSET_SQUARE:
-				overlap = 0.0;
-				break;
-			default:
-				break;
-		}
+		float overlap = _get_tile_overlap();
 
 		points.push_back(Vector2(0.0, -0.5));
 		points.push_back(Vector2(-0.5, overlap - 0.5));
@@ -1546,8 +1574,8 @@ Vector2 TileSet::map_to_local(const Vector2i &p_pos) const {
 	Vector2 ret = p_pos;
 
 	if (tile_shape == TileSet::TILE_SHAPE_HALF_OFFSET_SQUARE || tile_shape == TileSet::TILE_SHAPE_HEXAGON || tile_shape == TileSet::TILE_SHAPE_ISOMETRIC) {
-		// Technically, those 3 shapes are equivalent, as they are basically half-offset, but with different levels or overlap.
-		// square = no overlap, hexagon = 0.25 overlap, isometric = 0.5 overlap.
+		// Technically, those 3 shapes are equivalent, as they are basically half-offset, but with different levels of overlap.
+		// square = no overlap, hexagon = hexagon_tile_overlap, isometric = 0.5 overlap.
 		if (tile_offset_axis == TileSet::TILE_OFFSET_AXIS_HORIZONTAL) {
 			switch (tile_layout) {
 				case TileSet::TILE_LAYOUT_STACKED:
@@ -1594,20 +1622,10 @@ Vector2 TileSet::map_to_local(const Vector2i &p_pos) const {
 	}
 
 	// Multiply by the overlapping ratio.
-	double overlapping_ratio = 1.0;
+	double overlapping_ratio = 1.0 - _get_tile_overlap();
 	if (tile_offset_axis == TileSet::TILE_OFFSET_AXIS_HORIZONTAL) {
-		if (tile_shape == TileSet::TILE_SHAPE_ISOMETRIC) {
-			overlapping_ratio = 0.5;
-		} else if (tile_shape == TileSet::TILE_SHAPE_HEXAGON) {
-			overlapping_ratio = 0.75;
-		}
 		ret.y *= overlapping_ratio;
 	} else { // TILE_OFFSET_AXIS_VERTICAL.
-		if (tile_shape == TileSet::TILE_SHAPE_ISOMETRIC) {
-			overlapping_ratio = 0.5;
-		} else if (tile_shape == TileSet::TILE_SHAPE_HEXAGON) {
-			overlapping_ratio = 0.75;
-		}
 		ret.x *= overlapping_ratio;
 	}
 
@@ -1619,27 +1637,17 @@ Vector2i TileSet::local_to_map(const Vector2 &p_local_position) const {
 	ret /= tile_size;
 
 	// Divide by the overlapping ratio.
-	double overlapping_ratio = 1.0;
+	double overlapping_ratio = 1.0 - _get_tile_overlap();
 	if (tile_offset_axis == TileSet::TILE_OFFSET_AXIS_HORIZONTAL) {
-		if (tile_shape == TileSet::TILE_SHAPE_ISOMETRIC) {
-			overlapping_ratio = 0.5;
-		} else if (tile_shape == TileSet::TILE_SHAPE_HEXAGON) {
-			overlapping_ratio = 0.75;
-		}
 		ret.y /= overlapping_ratio;
 	} else { // TILE_OFFSET_AXIS_VERTICAL.
-		if (tile_shape == TileSet::TILE_SHAPE_ISOMETRIC) {
-			overlapping_ratio = 0.5;
-		} else if (tile_shape == TileSet::TILE_SHAPE_HEXAGON) {
-			overlapping_ratio = 0.75;
-		}
 		ret.x /= overlapping_ratio;
 	}
 
 	// For each half-offset shape, we check if we are in the corner of the tile, and thus should correct the local position accordingly.
 	if (tile_shape == TileSet::TILE_SHAPE_HALF_OFFSET_SQUARE || tile_shape == TileSet::TILE_SHAPE_HEXAGON || tile_shape == TileSet::TILE_SHAPE_ISOMETRIC) {
-		// Technically, those 3 shapes are equivalent, as they are basically half-offset, but with different levels or overlap.
-		// square = no overlap, hexagon = 0.25 overlap, isometric = 0.5 overlap.
+		// Technically, those 3 shapes are equivalent, as they are basically half-offset, but with different levels of overlap.
+		// square = no overlap, hexagon = hexagon_tile_overlap, isometric = 0.5 overlap.
 		if (tile_offset_axis == TileSet::TILE_OFFSET_AXIS_HORIZONTAL) {
 			// Smart floor of the position
 			Vector2 raw_pos = ret;
@@ -2249,17 +2257,7 @@ Vector<Point2> TileSet::get_terrain_polygon(int p_terrain_set) {
 	} else if (tile_shape == TileSet::TILE_SHAPE_ISOMETRIC) {
 		return _get_isometric_terrain_polygon(tile_size);
 	} else {
-		float overlap = 0.0;
-		switch (tile_shape) {
-			case TileSet::TILE_SHAPE_HEXAGON:
-				overlap = 0.25;
-				break;
-			case TileSet::TILE_SHAPE_HALF_OFFSET_SQUARE:
-				overlap = 0.0;
-				break;
-			default:
-				break;
-		}
+		float overlap = _get_tile_overlap();
 		return _get_half_offset_terrain_polygon(tile_size, overlap, tile_offset_axis);
 	}
 }
@@ -2286,17 +2284,7 @@ Vector<Point2> TileSet::get_terrain_peering_bit_polygon(int p_terrain_set, TileS
 			return _get_isometric_side_terrain_peering_bit_polygon(tile_size, p_bit);
 		}
 	} else {
-		float overlap = 0.0;
-		switch (tile_shape) {
-			case TileSet::TILE_SHAPE_HEXAGON:
-				overlap = 0.25;
-				break;
-			case TileSet::TILE_SHAPE_HALF_OFFSET_SQUARE:
-				overlap = 0.0;
-				break;
-			default:
-				break;
-		}
+		float overlap = _get_tile_overlap();
 		if (terrain_mode == TileSet::TERRAIN_MODE_MATCH_CORNERS_AND_SIDES) {
 			return _get_half_offset_corner_or_side_terrain_peering_bit_polygon(tile_size, overlap, tile_offset_axis, p_bit);
 		} else if (terrain_mode == TileSet::TERRAIN_MODE_MATCH_CORNERS) {
@@ -2326,17 +2314,7 @@ void TileSet::draw_terrains(CanvasItem *p_canvas_item, Transform2D p_transform, 
 			} else if (tile_shape == TileSet::TILE_SHAPE_ISOMETRIC) {
 				polygon = _get_isometric_terrain_polygon(tile_size);
 			} else {
-				float overlap = 0.0;
-				switch (tile_shape) {
-					case TileSet::TILE_SHAPE_HEXAGON:
-						overlap = 0.25;
-						break;
-					case TileSet::TILE_SHAPE_HALF_OFFSET_SQUARE:
-						overlap = 0.0;
-						break;
-					default:
-						break;
-				}
+				float overlap = _get_tile_overlap();
 				polygon = _get_half_offset_terrain_polygon(tile_size, overlap, tile_offset_axis);
 			}
 			{
@@ -2378,17 +2356,7 @@ void TileSet::draw_terrains(CanvasItem *p_canvas_item, Transform2D p_transform, 
 							polygon = _get_isometric_side_terrain_peering_bit_polygon(tile_size, bit);
 						}
 					} else {
-						float overlap = 0.0;
-						switch (tile_shape) {
-							case TileSet::TILE_SHAPE_HEXAGON:
-								overlap = 0.25;
-								break;
-							case TileSet::TILE_SHAPE_HALF_OFFSET_SQUARE:
-								overlap = 0.0;
-								break;
-							default:
-								break;
-						}
+						float overlap = _get_tile_overlap();
 						if (terrain_mode == TileSet::TERRAIN_MODE_MATCH_CORNERS_AND_SIDES) {
 							polygon = _get_half_offset_corner_or_side_terrain_peering_bit_polygon(tile_size, overlap, tile_offset_axis, bit);
 						} else if (terrain_mode == TileSet::TERRAIN_MODE_MATCH_CORNERS) {
@@ -2549,6 +2517,26 @@ Vector<Vector<Ref<Texture2D>>> TileSet::generate_terrains_icons(Size2i p_size) {
 void TileSet::_source_changed() {
 	terrains_cache_dirty = true;
 	emit_changed();
+}
+
+// Returns the fraction to which tiles wedge into each other.
+// 0.0 - tiles do not interlock (half-offset square). 0.5 - tiles interlock by half of total width/height (isometric).
+float TileSet::_get_tile_overlap() const {
+	float overlap = 0.0;
+	switch (tile_shape) {
+		case TileSet::TILE_SHAPE_HALF_OFFSET_SQUARE:
+			overlap = 0.0;
+			break;
+		case TileSet::TILE_SHAPE_HEXAGON:
+			overlap = hexagon_tile_overlap;
+			break;
+		case TileSet::TILE_SHAPE_ISOMETRIC:
+			overlap = 0.5;
+			break;
+		default:
+			break;
+	}
+	return overlap;
 }
 
 Vector<Point2> TileSet::_get_square_terrain_polygon(Vector2i p_size) {
@@ -3667,6 +3655,11 @@ Array TileSet::compatibility_tilemap_map(int p_tile_id, Vector2i p_coords, bool 
 #endif // DISABLE_DEPRECATED
 
 bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "flat_side_length") {
+		_set_hexagon_flat_side_length(p_value);
+		return true;
+	}
+
 	Vector<String> components = String(p_name).split("/", true, 2);
 
 #ifndef DISABLE_DEPRECATED
@@ -4012,6 +4005,11 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 }
 
 bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
+	if (p_name == "flat_side_length") {
+		r_ret = _get_hexagon_flat_side_length();
+		return true;
+	}
+
 	Vector<String> components = String(p_name).split("/", true, 2);
 
 	if (components.size() == 2 && components[0].begins_with("occlusion_layer_") && components[0].trim_prefix("occlusion_layer_").is_valid_int()) {
@@ -4146,6 +4144,26 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 
 void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 	PropertyInfo property_info;
+
+	// Flat side length.
+	if (tile_shape == TILE_SHAPE_HEXAGON) {
+		int side_size;
+		if (tile_offset_axis == TILE_OFFSET_AXIS_HORIZONTAL) {
+			side_size = tile_size.y;
+		} else { // TILE_OFFSET_AXIS_VERTICAL
+			side_size = tile_size.x;
+		}
+		property_info = PropertyInfo(Variant::FLOAT, "flat_side_length", PROPERTY_HINT_RANGE, vformat("0.1,%f,0.1,suffix:px", side_size - 0.1), PROPERTY_USAGE_EDITOR);
+
+		// Push after tile_size
+		for (List<PropertyInfo>::Element *E = p_list->front(); E; E = E->next()) {
+			if (E->get().name == "tile_size") {
+				p_list->insert_after(E, property_info);
+				break;
+			}
+		}
+	}
+
 	// Rendering.
 	p_list->push_back(PropertyInfo(Variant::NIL, GNAME("Rendering", ""), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
 	for (int i = 0; i < occlusion_layers.size(); i++) {
@@ -4250,6 +4268,27 @@ void TileSet::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
+bool TileSet::_property_can_revert(const StringName &p_name) const {
+	if (p_name == "flat_side_length") {
+		return true;
+	}
+	return false;
+}
+
+bool TileSet::_property_get_revert(const StringName &p_name, Variant &r_property) const {
+	if (p_name == "flat_side_length") {
+		int side_size;
+		if (tile_offset_axis == TILE_OFFSET_AXIS_HORIZONTAL) {
+			side_size = tile_size.y;
+		} else { // TILE_OFFSET_AXIS_VERTICAL
+			side_size = tile_size.x;
+		}
+		r_property = side_size / 2.0f;
+		return true;
+	}
+	return false;
+}
+
 void TileSet::_bind_methods() {
 	// Sources management.
 	ClassDB::bind_method(D_METHOD("get_next_source_id"), &TileSet::get_next_source_id);
@@ -4270,11 +4309,14 @@ void TileSet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tile_offset_axis"), &TileSet::get_tile_offset_axis);
 	ClassDB::bind_method(D_METHOD("set_tile_size", "size"), &TileSet::set_tile_size);
 	ClassDB::bind_method(D_METHOD("get_tile_size"), &TileSet::get_tile_size);
+	ClassDB::bind_method(D_METHOD("set_hexagon_tile_overlap", "modifier"), &TileSet::set_hexagon_tile_overlap);
+	ClassDB::bind_method(D_METHOD("get_hexagon_tile_overlap"), &TileSet::get_hexagon_tile_overlap);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tile_shape", PROPERTY_HINT_ENUM, "Square,Isometric,Half-Offset Square,Hexagon"), "set_tile_shape", "get_tile_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tile_layout", PROPERTY_HINT_ENUM, "Stacked,Stacked Offset,Stairs Right,Stairs Down,Diamond Right,Diamond Down"), "set_tile_layout", "get_tile_layout");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tile_offset_axis", PROPERTY_HINT_ENUM, "Horizontal Offset,Vertical Offset"), "set_tile_offset_axis", "get_tile_offset_axis");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "tile_size", PROPERTY_HINT_NONE, "suffix:px"), "set_tile_size", "get_tile_size");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "hexagon_tile_overlap", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_hexagon_tile_overlap", "get_hexagon_tile_overlap");
 
 	// Rendering.
 	ClassDB::bind_method(D_METHOD("set_uv_clipping", "uv_clipping"), &TileSet::set_uv_clipping);

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -306,6 +306,9 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _validate_property(PropertyInfo &p_property) const;
 
+	bool _property_can_revert(const StringName &p_name) const;
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
+
 #ifdef TOOLS_ENABLED
 	virtual uint32_t hash_edited_version_for_preview() const override { return 0; } // Not using preview, so disable it for performance.
 #endif
@@ -317,6 +320,7 @@ private:
 	TileLayout tile_layout = TILE_LAYOUT_STACKED;
 	TileOffsetAxis tile_offset_axis = TILE_OFFSET_AXIS_HORIZONTAL;
 	Size2i tile_size = Size2i(16, 16); //Size2(64, 64);
+	float hexagon_tile_overlap = 0.25;
 
 	// Rendering.
 	bool uv_clipping = false;
@@ -390,7 +394,13 @@ private:
 	RBMap<Array, Array> coords_level_proxies;
 	RBMap<Array, Array> alternative_level_proxies;
 
+	// Internal Accessors
+
 	// Helpers
+	void _set_hexagon_flat_side_length(float p_flat_side_length);
+	float _get_hexagon_flat_side_length() const;
+	float _get_tile_overlap() const;
+
 	Vector<Point2> _get_square_terrain_polygon(Vector2i p_size);
 	Vector<Point2> _get_square_corner_or_side_terrain_peering_bit_polygon(Vector2i p_size, TileSet::CellNeighbor p_bit);
 	Vector<Point2> _get_square_corner_terrain_peering_bit_polygon(Vector2i p_size, TileSet::CellNeighbor p_bit);
@@ -421,6 +431,8 @@ public:
 	TileOffsetAxis get_tile_offset_axis() const;
 	void set_tile_size(Size2i p_size);
 	Size2i get_tile_size() const;
+	void set_hexagon_tile_overlap(float p_tile_overlap);
+	float get_hexagon_tile_overlap() const;
 
 	// -- Sources management --
 	int get_next_source_id() const;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
Changed TileSet to use a variable for the hexagonal tile overlap instead of assuming 0.25.

Only changed tile_set.h and tile_set.cpp, don't think it should break anything as interaction with TileSet should happen via map_to_local/local_to_map and get_tile_shape_polygon methods in my understanding.

Motivation:
closes https://github.com/godotengine/godot-proposals/issues/14419

Testing:
Tested on the testing scene i will attach here. Also tested for horizontally offset hexagons not present in the scene. General testing in the editor(trying to find edge cases, double checking selection worked properly). Tested polygon generation for physics and navigation layers, worked as expected.
[hexagons-example.zip](https://github.com/user-attachments/files/25878685/hexagons-example.zip) 
(initially set to godot defaults, the variable needs to be changed in the inspector window)

Use of AI:
No AI was used to write any code. AI was used to help write xml description.
Unsure if xml description is the best since it kind of exposes unseen implementation details, but describing it in other terms will require introducing another unit of measurment and converting it in the getter setter which would also be non ideal for those who think in terms of how its implemented. (IE its easier for me to think of the variable as "flat side length" where 1.0 is 100% of width taken up by flat side. However, I think its more correct to keep it as 0.0-0.5 for neighboring tile overlap as that's what it actually is)