### PR TITLE
Clarify the meaning of "network process" in MultiplayerSynchronizer

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -901,6 +901,7 @@
 		</member>
 		<member name="low_processor_usage_mode" type="bool" setter="set_low_processor_usage_mode" getter="is_in_low_processor_usage_mode" default="false">
 			If [code]true[/code], the engine optimizes for low processor usage by only refreshing the screen if needed. Can improve battery consumption on mobile.
+			[b]Note:[/b] Low processor mode is always enabled in [url=$DOCS_URL/tutorials/export/exporting_for_dedicated_servers.html]dedicated server mode[/url] or when using the [code]--headless[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url], regardless of the value of [member low_processor_usage_mode], as dedicated servers don't perform any rendering.
 			[b]Note:[/b] On start-up, this is the same as [member ProjectSettings.application/run/low_processor_mode].
 		</member>
 		<member name="low_processor_usage_mode_sleep_usec" type="int" setter="set_low_processor_usage_mode_sleep_usec" getter="get_low_processor_usage_mode_sleep_usec" default="6900">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -406,10 +406,11 @@
 			[b]Note:[/b] This setting is implemented on macOS for non-sandboxed applications only.
 		</member>
 		<member name="application/run/low_processor_mode" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], enables low-processor usage mode. When enabled, the engine takes longer to redraw, but only redraws the screen if necessary. This may lower power consumption, and is intended for editors or mobile applications. For most games, because the screen needs to be redrawn every frame, it is recommended to keep this setting disabled.
+			If [code]true[/code], enables low-processor usage mode. When enabled, the engine takes longer to redraw, but only redraws the screen if necessary. The framerate is also automatically limited by the [member application/run/low_processor_mode_sleep_usec] setting. This may lower power consumption, and is intended for editors or mobile applications. For most games, because the screen needs to be redrawn every frame, it is recommended to keep this setting disabled.
+			[b]Note:[/b] Low processor mode is always enabled in [url=$DOCS_URL/tutorials/export/exporting_for_dedicated_servers.html]dedicated server mode[/url] or when using the [code]--headless[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url], regardless of the value of [member application/run/low_processor_mode], as dedicated servers don't perform any rendering.
 		</member>
 		<member name="application/run/low_processor_mode_sleep_usec" type="int" setter="" getter="" default="6900">
-			Amount of sleeping between frames when the low-processor usage mode is enabled (in microseconds). Higher values will result in lower CPU usage.
+			Amount of sleeping between frames when the low-processor usage mode is enabled (in microseconds). Higher values will result in lower CPU usage. The default value limits framerate to roughly 145 FPS.
 		</member>
 		<member name="application/run/main_loop_type" type="String" setter="" getter="" default="&quot;SceneTree&quot;">
 			The name of the type implementing the engine's main loop.

--- a/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
+++ b/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
@@ -53,7 +53,8 @@
 	</methods>
 	<members>
 		<member name="delta_interval" type="float" setter="set_delta_interval" getter="get_delta_interval" default="0.0">
-			Time interval between delta synchronizations. Used when the replication is set to [constant SceneReplicationConfig.REPLICATION_MODE_ON_CHANGE]. If set to [code]0.0[/code] (the default), delta synchronizations happen every network process frame.
+			Time interval between delta synchronizations. Used when the replication is set to [constant SceneReplicationConfig.REPLICATION_MODE_ON_CHANGE]. If set to [code]0.0[/code] (the default), delta synchronizations happen every process frame.
+			The rate at which process frames occurs is determined determined by the server's current framerate. In dedicated server mode, the server's framerate is capped to the value determined by [member ProjectSettings.application/run/low_processor_mode_sleep_usec].
 		</member>
 		<member name="public_visibility" type="bool" setter="set_visibility_public" getter="is_visibility_public" default="true">
 			Whether synchronization should be visible to all peers by default. See [method set_visibility_for] and [method add_visibility_filter] for ways of configuring fine-grained visibility options.
@@ -62,7 +63,8 @@
 			Resource containing which properties to synchronize.
 		</member>
 		<member name="replication_interval" type="float" setter="set_replication_interval" getter="get_replication_interval" default="0.0">
-			Time interval between synchronizations. Used when the replication is set to [constant SceneReplicationConfig.REPLICATION_MODE_ALWAYS]. If set to [code]0.0[/code] (the default), synchronizations happen every network process frame.
+			Time interval between synchronizations. Used when the replication is set to [constant SceneReplicationConfig.REPLICATION_MODE_ALWAYS]. If set to [code]0.0[/code] (the default), synchronizations happen every process frame.
+			The rate at which process frames occurs is determined determined by the server's current framerate. In dedicated server mode, the server's framerate is capped to the value determined by [member ProjectSettings.application/run/low_processor_mode_sleep_usec].
 		</member>
 		<member name="root_path" type="NodePath" setter="set_root_path" getter="get_root_path" default="NodePath(&quot;..&quot;)">
 			Node path that replicated properties are relative to.


### PR DESCRIPTION
While Godot does not have a dedicated "network process" timer like idle and physics, dedicated servers [run at a limited maximum FPS by default](https://github.com/godotengine/godot/issues/32404) (regardless of whether low-processor mode is enabled).

I need to do more extensive testing, but I believe adjusting the low processor mode sleep usec project setting to be a multiple of your game's physics tick rate (e.g. `16666` for 60 Hz physics) will reduce jittering in multiplayer synchronization. I didn't mention this in the docs yet since I'm not 100% sure.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/414#discussioncomment-15729700.