### PR TITLE
[3.x] Fix sync issue in separate-thread physics

### DIFF
--- a/core/command_queue_mt.cpp
+++ b/core/command_queue_mt.cpp
@@ -94,7 +94,7 @@ tryagain:
 	return true;
 }
 
-CommandQueueMT::CommandQueueMT(bool p_sync) {
+CommandQueueMT::CommandQueueMT(bool p_sync, bool (*p_is_bypass_enabled_for_thread)()) {
 	read_ptr_and_epoch = 0;
 	write_ptr_and_epoch = 0;
 	dealloc_ptr = 0;
@@ -108,8 +108,10 @@ CommandQueueMT::CommandQueueMT(bool p_sync) {
 		sync_sems[i].in_use = false;
 	}
 	if (p_sync) {
+		is_bypass_enabled_for_thread = p_is_bypass_enabled_for_thread;
 		sync = memnew(Semaphore);
 	} else {
+		DEV_ASSERT(!p_is_bypass_enabled_for_thread);
 		sync = nullptr;
 	}
 }

--- a/core/command_queue_mt.h
+++ b/core/command_queue_mt.h
@@ -225,16 +225,20 @@
 #define CMD_TYPE(N) Command##N<T, M COMMA(N) COMMA_SEP_LIST(TYPE_ARG, N)>
 #define CMD_ASSIGN_PARAM(N) cmd->p##N = p##N
 
-#define DECL_PUSH(N)                                                         \
-	template <class T, class M COMMA(N) COMMA_SEP_LIST(TYPE_PARAM, N)>       \
-	void push(T *p_instance, M p_method COMMA(N) COMMA_SEP_LIST(PARAM, N)) { \
-		CMD_TYPE(N) *cmd = allocate_and_lock<CMD_TYPE(N)>();                 \
-		cmd->instance = p_instance;                                          \
-		cmd->method = p_method;                                              \
-		SEMIC_SEP_LIST(CMD_ASSIGN_PARAM, N);                                 \
-		unlock();                                                            \
-		if (sync)                                                            \
-			sync->post();                                                    \
+#define DECL_PUSH(N)                                                                    \
+	template <class T, class M COMMA(N) COMMA_SEP_LIST(TYPE_PARAM, N)>                  \
+	void push(T *p_instance, M p_method COMMA(N) COMMA_SEP_LIST(PARAM, N)) {            \
+		if (unlikely(is_bypass_enabled_for_thread && is_bypass_enabled_for_thread())) { \
+			(p_instance->*p_method)(COMMA_SEP_LIST(ARG, N));                            \
+			return;                                                                     \
+		}                                                                               \
+		CMD_TYPE(N) *cmd = allocate_and_lock<CMD_TYPE(N)>();                            \
+		cmd->instance = p_instance;                                                     \
+		cmd->method = p_method;                                                         \
+		SEMIC_SEP_LIST(CMD_ASSIGN_PARAM, N);                                            \
+		unlock();                                                                       \
+		if (sync)                                                                       \
+			sync->post();                                                               \
 	}
 
 #define CMD_RET_TYPE(N) CommandRet##N<T, M, COMMA_SEP_LIST(TYPE_ARG, N) COMMA(N) R>
@@ -242,6 +246,10 @@
 #define DECL_PUSH_AND_RET(N)                                                                   \
 	template <class T, class M, COMMA_SEP_LIST(TYPE_PARAM, N) COMMA(N) class R>                \
 	void push_and_ret(T *p_instance, M p_method, COMMA_SEP_LIST(PARAM, N) COMMA(N) R *r_ret) { \
+		if (unlikely(is_bypass_enabled_for_thread && is_bypass_enabled_for_thread())) {        \
+			*r_ret = (p_instance->*p_method)(COMMA_SEP_LIST(ARG, N));                          \
+			return;                                                                            \
+		}                                                                                      \
 		SyncSemaphore *ss = _alloc_sync_sem();                                                 \
 		CMD_RET_TYPE(N) *cmd = allocate_and_lock<CMD_RET_TYPE(N)>();                           \
 		cmd->instance = p_instance;                                                            \
@@ -258,20 +266,24 @@
 
 #define CMD_SYNC_TYPE(N) CommandSync##N<T, M COMMA(N) COMMA_SEP_LIST(TYPE_ARG, N)>
 
-#define DECL_PUSH_AND_SYNC(N)                                                         \
-	template <class T, class M COMMA(N) COMMA_SEP_LIST(TYPE_PARAM, N)>                \
-	void push_and_sync(T *p_instance, M p_method COMMA(N) COMMA_SEP_LIST(PARAM, N)) { \
-		SyncSemaphore *ss = _alloc_sync_sem();                                        \
-		CMD_SYNC_TYPE(N) *cmd = allocate_and_lock<CMD_SYNC_TYPE(N)>();                \
-		cmd->instance = p_instance;                                                   \
-		cmd->method = p_method;                                                       \
-		SEMIC_SEP_LIST(CMD_ASSIGN_PARAM, N);                                          \
-		cmd->sync_sem = ss;                                                           \
-		unlock();                                                                     \
-		if (sync)                                                                     \
-			sync->post();                                                             \
-		ss->sem.wait();                                                               \
-		ss->in_use = false;                                                           \
+#define DECL_PUSH_AND_SYNC(N)                                                           \
+	template <class T, class M COMMA(N) COMMA_SEP_LIST(TYPE_PARAM, N)>                  \
+	void push_and_sync(T *p_instance, M p_method COMMA(N) COMMA_SEP_LIST(PARAM, N)) {   \
+		if (unlikely(is_bypass_enabled_for_thread && is_bypass_enabled_for_thread())) { \
+			(p_instance->*p_method)(COMMA_SEP_LIST(ARG, N));                            \
+			return;                                                                     \
+		}                                                                               \
+		SyncSemaphore *ss = _alloc_sync_sem();                                          \
+		CMD_SYNC_TYPE(N) *cmd = allocate_and_lock<CMD_SYNC_TYPE(N)>();                  \
+		cmd->instance = p_instance;                                                     \
+		cmd->method = p_method;                                                         \
+		SEMIC_SEP_LIST(CMD_ASSIGN_PARAM, N);                                            \
+		cmd->sync_sem = ss;                                                             \
+		unlock();                                                                       \
+		if (sync)                                                                       \
+			sync->post();                                                               \
+		ss->sem.wait();                                                                 \
+		ss->in_use = false;                                                             \
 	}
 
 #define MAX_CMD_PARAMS 13
@@ -322,6 +334,7 @@ class CommandQueueMT {
 	SyncSemaphore sync_sems[SYNC_SEMAPHORES];
 	Mutex mutex;
 	Semaphore *sync;
+	bool (*is_bypass_enabled_for_thread)();
 
 	template <class T>
 	T *allocate() {
@@ -487,7 +500,7 @@ public:
 		unlock();
 	}
 
-	CommandQueueMT(bool p_sync);
+	CommandQueueMT(bool p_sync, bool (*is_bypass_enabled_for_thread)() = nullptr);
 	~CommandQueueMT();
 };
 

--- a/servers/physics_2d/physics_2d_server_wrap_mt.cpp
+++ b/servers/physics_2d/physics_2d_server_wrap_mt.cpp
@@ -32,6 +32,12 @@
 
 #include "core/os/os.h"
 
+static thread_local bool cmd_queue_bypass_enabled = false;
+
+static bool is_cmd_queue_bypass_enabled() {
+	return cmd_queue_bypass_enabled;
+}
+
 void Physics2DServerWrapMT::thread_exit() {
 	exit.set();
 }
@@ -39,6 +45,10 @@ void Physics2DServerWrapMT::thread_exit() {
 void Physics2DServerWrapMT::thread_step(real_t p_delta) {
 	physics_2d_server->step(p_delta);
 	step_sem.post();
+}
+
+void Physics2DServerWrapMT::thread_flush_and_halt() {
+	thread_halted_semaphore.post();
 }
 
 void Physics2DServerWrapMT::_thread_callback(void *_instance) {
@@ -77,6 +87,8 @@ void Physics2DServerWrapMT::step(real_t p_step) {
 
 void Physics2DServerWrapMT::sync() {
 	if (create_thread) {
+		command_queue.push(this, &Physics2DServerWrapMT::thread_flush_and_halt);
+		thread_halted_semaphore.wait();
 		if (first_frame) {
 			first_frame = false;
 		} else {
@@ -93,6 +105,7 @@ void Physics2DServerWrapMT::flush_queries() {
 
 void Physics2DServerWrapMT::end_sync() {
 	physics_2d_server->end_sync();
+	cmd_queue_bypass_enabled = false;
 }
 
 void Physics2DServerWrapMT::init() {
@@ -130,7 +143,7 @@ void Physics2DServerWrapMT::finish() {
 }
 
 Physics2DServerWrapMT::Physics2DServerWrapMT(Physics2DServer *p_contained, bool p_create_thread) :
-		command_queue(p_create_thread) {
+		command_queue(p_create_thread, p_create_thread ? is_cmd_queue_bypass_enabled : (bool (*)()) nullptr) {
 	physics_2d_server = p_contained;
 	create_thread = p_create_thread;
 

--- a/servers/physics_2d/physics_2d_server_wrap_mt.h
+++ b/servers/physics_2d/physics_2d_server_wrap_mt.h
@@ -61,6 +61,9 @@ class Physics2DServerWrapMT : public Physics2DServer {
 	Semaphore step_sem;
 	void thread_step(real_t p_delta);
 
+	Semaphore thread_halted_semaphore;
+	void thread_flush_and_halt();
+
 	void thread_exit();
 
 	bool first_frame;


### PR DESCRIPTION
**EDIT (adding description):**
This PR prevents the situation where the main thread is within the physics sync stage in an interation with the separate physics thread still pumping and running commands. "Ownership" of the physics server should be unique, which means the main and the physics thread dealing with the server should be exclusive, never overlapping.

---
This PR is proudly donated by [Pedrocorp](http://pedrocorp.net).