### PR TITLE
Fix change dock layout caused missing debugger for EditorDebuggerSession

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -435,6 +435,10 @@ void EditorDebuggerNode::_notification(int p_what) {
 				debugger->update_live_edit_root();
 			}
 		} break;
+
+		case NOTIFICATION_POST_ENTER_TREE: {
+			attach_plugin_session_debugger();
+		} break;
 	}
 }
 
@@ -954,4 +958,12 @@ bool EditorDebuggerNode::plugins_capture(ScriptEditorDebugger *p_debugger, const
 		}
 	}
 	return parsed;
+}
+
+void EditorDebuggerNode::attach_plugin_session_debugger() {
+	if (!debugger_plugins.is_empty()) {
+		for (Ref<EditorDebuggerPlugin> plugin : debugger_plugins) {
+			plugin->attach_plugin_session_debugger(get_debugger(0));
+		}
+	}
 }

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -227,4 +227,5 @@ public:
 	bool plugins_capture(ScriptEditorDebugger *p_debugger, const String &p_message, const Array &p_data);
 	void add_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin);
 	void remove_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin);
+	void attach_plugin_session_debugger();
 };

--- a/editor/debugger/editor_debugger_plugin.cpp
+++ b/editor/debugger/editor_debugger_plugin.cpp
@@ -112,10 +112,18 @@ void EditorDebuggerSession::detach_debugger() {
 	if (!debugger) {
 		return;
 	}
-	debugger->disconnect("started", callable_mp(this, &EditorDebuggerSession::_started));
-	debugger->disconnect("stopped", callable_mp(this, &EditorDebuggerSession::_stopped));
-	debugger->disconnect("breaked", callable_mp(this, &EditorDebuggerSession::_breaked));
-	debugger->disconnect(SceneStringName(tree_exited), callable_mp(this, &EditorDebuggerSession::_debugger_gone_away));
+	if (debugger->is_connected("started", callable_mp(this, &EditorDebuggerSession::_started))) {
+		debugger->disconnect("started", callable_mp(this, &EditorDebuggerSession::_started));
+	}
+	if (debugger->is_connected("stopped", callable_mp(this, &EditorDebuggerSession::_stopped))) {
+		debugger->disconnect("stopped", callable_mp(this, &EditorDebuggerSession::_stopped));
+	}
+	if (debugger->is_connected("breaked", callable_mp(this, &EditorDebuggerSession::_breaked))) {
+		debugger->disconnect("breaked", callable_mp(this, &EditorDebuggerSession::_breaked));
+	}
+	if (debugger->is_connected(SceneStringName(tree_exited), callable_mp(this, &EditorDebuggerSession::_debugger_gone_away))) {
+		debugger->disconnect(SceneStringName(tree_exited), callable_mp(this, &EditorDebuggerSession::_debugger_gone_away));
+	}
 	for (Control *tab : tabs) {
 		debugger->remove_debugger_tab(tab);
 	}
@@ -123,18 +131,29 @@ void EditorDebuggerSession::detach_debugger() {
 	debugger = nullptr;
 }
 
+void EditorDebuggerSession::attach_debugger(ScriptEditorDebugger *p_debugger) {
+	ERR_FAIL_NULL(p_debugger);
+	debugger = p_debugger;
+	if (!debugger->is_connected("started", callable_mp(this, &EditorDebuggerSession::_started))) {
+		debugger->connect("started", callable_mp(this, &EditorDebuggerSession::_started));
+	}
+	if (!debugger->is_connected("stopped", callable_mp(this, &EditorDebuggerSession::_stopped))) {
+		debugger->connect("stopped", callable_mp(this, &EditorDebuggerSession::_stopped));
+	}
+	if (!debugger->is_connected("breaked", callable_mp(this, &EditorDebuggerSession::_breaked))) {
+		debugger->connect("breaked", callable_mp(this, &EditorDebuggerSession::_breaked));
+	}
+	if (!debugger->is_connected(SceneStringName(tree_exited), callable_mp(this, &EditorDebuggerSession::_debugger_gone_away))) {
+		debugger->connect(SceneStringName(tree_exited), callable_mp(this, &EditorDebuggerSession::_debugger_gone_away), CONNECT_ONE_SHOT);
+	}
+}
+
 void EditorDebuggerSession::_debugger_gone_away() {
-	debugger = nullptr;
-	tabs.clear();
+	detach_debugger();
 }
 
 EditorDebuggerSession::EditorDebuggerSession(ScriptEditorDebugger *p_debugger) {
-	ERR_FAIL_NULL(p_debugger);
-	debugger = p_debugger;
-	debugger->connect("started", callable_mp(this, &EditorDebuggerSession::_started));
-	debugger->connect("stopped", callable_mp(this, &EditorDebuggerSession::_stopped));
-	debugger->connect("breaked", callable_mp(this, &EditorDebuggerSession::_breaked));
-	debugger->connect(SceneStringName(tree_exited), callable_mp(this, &EditorDebuggerSession::_debugger_gone_away), CONNECT_ONE_SHOT);
+	attach_debugger(p_debugger);
 }
 
 EditorDebuggerSession::~EditorDebuggerSession() {
@@ -157,6 +176,12 @@ void EditorDebuggerPlugin::clear() {
 void EditorDebuggerPlugin::create_session(ScriptEditorDebugger *p_debugger) {
 	sessions.push_back(Ref<EditorDebuggerSession>(memnew(EditorDebuggerSession(p_debugger))));
 	setup_session(sessions.size() - 1);
+}
+
+void EditorDebuggerPlugin::attach_plugin_session_debugger(ScriptEditorDebugger *p_debugger) {
+	for (const Ref<EditorDebuggerSession> &session : sessions) {
+		session->attach_debugger(p_debugger);
+	}
 }
 
 void EditorDebuggerPlugin::setup_session(int p_idx) {

--- a/editor/debugger/editor_debugger_plugin.h
+++ b/editor/debugger/editor_debugger_plugin.h
@@ -53,6 +53,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	void attach_debugger(ScriptEditorDebugger *p_debugger);
 	void detach_debugger();
 
 	void add_session_tab(Control *p_tab);
@@ -81,6 +82,7 @@ protected:
 public:
 	void create_session(ScriptEditorDebugger *p_debugger);
 	void clear();
+	void attach_plugin_session_debugger(ScriptEditorDebugger *p_debugger);
 
 	virtual void setup_session(int p_idx);
 	virtual bool capture(const String &p_message, const Array &p_data, int p_session);


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/117243

## Issue Description

When we changed layout of editor, e.g. move `EditorDebuggerPlugin` from default position to bottom. It will first remove from original position, then add to target position.

The remove child operation will trigger a `tree_exited` signal, which connected to `_debugger_gone_away()`.

https://github.com/godotengine/godot/blob/d103efb6ea076ec52b4deca358e83f1fd177d163/editor/debugger/editor_debugger_plugin.cpp#L118

It will set debugger to nullptr in `_debugger_gone_away()`, then cause `Plugin is not attached to debugger` at the next operation.

## Solution

We can observe `NOTIFICATION_POST_ENTER_TREE` to atttach debugger for relevant `EditorDebuggerSession`  to fix missing debugger issue while changing layout.

[debugger-error.webm](https://github.com/user-attachments/assets/2d18372b-3896-4752-bc16-4c26cde76503)

