### PR TITLE
Draw aggregate animation keys on top of folded node groups

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -3926,6 +3926,25 @@ void AnimationTrackEditGroup::_notification(int p_what) {
 				const Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 				draw_line(Point2(px, 0), Point2(px, get_size().height), accent, Math::round(2 * EDSCALE));
 			}
+
+			if (is_group_folded) {
+				for (const AnimationTrackEdit *track_edit : track_edits) {
+					const Ref<Texture2D> &key_type_icon = track_edit->get_key_type_icon();
+					int track = track_edit->get_track();
+					for (int i = 0; i < editor->get_current_animation()->track_get_key_count(track); ++i) {
+						float key_time_offset = editor->get_current_animation()->track_get_key_time(track, i) - timeline->get_value();
+						int key_screen_pos = int(key_time_offset * timeline->get_zoom_scale() + limit);
+						int key_limit_left = timeline->get_name_limit();
+						int key_limit_right = get_size().width - timeline->get_buttons_width();
+						if (key_screen_pos >= key_limit_left && key_screen_pos <= key_limit_right) {
+							draw_texture(
+									key_type_icon,
+									Vector2(key_screen_pos - key_type_icon->get_width() / 2, (get_size().height - key_type_icon->get_height()) / 2),
+									Color(1, 1, 1, 0.3));
+						}
+					}
+				}
+			}
 		} break;
 
 		case NOTIFICATION_MOUSE_EXIT: {

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -520,6 +520,7 @@ public:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
+	const Ref<Texture2D> &get_key_type_icon() const { return type_icon; }
 	virtual int get_key_height() const;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec);
 	virtual bool is_key_selectable_by_distance() const;


### PR DESCRIPTION
Relates to godotengine/godot-proposals#1908.
Complements #113479.

This changes the drawing of folded node groups in the animation editor (as introduced by #113479) to show all keys from all tracks, but at a 30% opacity, giving you a summary overview of all the node's tracks.

Note that key links will not be drawn, nor are keys necessarily drawn the way they would be drawn in the actual track, like for example animation playback tracks and audio playback tracks. We felt that this would make things look too noisy, so keys are simply drawn as their respective track type icons.

Also note that the keys cannot be selected nor edited, they are simply drawn on top of the collapsed group.

[Recording_20260311_130903.webm](https://github.com/user-attachments/assets/7658f88b-f57a-468b-a3bb-074d712e30cd)