### PR TITLE
Remove unused includes in `platform` and `drivers` with clangd-tidy

### DIFF
--- a/drivers/alsa/asound-so_wrap.h
+++ b/drivers/alsa/asound-so_wrap.h
@@ -1278,7 +1278,7 @@
 #define snd_midi_event_encode snd_midi_event_encode_dylibloader_orig_asound
 #define snd_midi_event_encode_byte snd_midi_event_encode_byte_dylibloader_orig_asound
 #define snd_midi_event_decode snd_midi_event_decode_dylibloader_orig_asound
-#include "thirdparty/linuxbsd_headers/alsa/asoundlib.h"
+#include "thirdparty/linuxbsd_headers/alsa/asoundlib.h" // IWYU pragma: export.
 #undef snd_asoundlib_version
 #undef snd_dlopen
 #undef snd_dlsym

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -33,9 +33,14 @@
 #ifdef ALSA_ENABLED
 
 #include "core/config/engine.h"
-#include "core/config/project_settings.h"
 #include "core/math/math_funcs_binary.h"
 #include "core/os/os.h"
+
+#ifdef SOWRAP_ENABLED
+#include "asound-so_wrap.h"
+#else
+#include <alsa/asoundlib.h>
+#endif
 
 #include <cerrno>
 

--- a/drivers/alsa/audio_driver_alsa.h
+++ b/drivers/alsa/audio_driver_alsa.h
@@ -37,11 +37,8 @@
 #include "core/templates/safe_refcount.h"
 #include "servers/audio/audio_server.h"
 
-#ifdef SOWRAP_ENABLED
-#include "asound-so_wrap.h"
-#else
-#include <alsa/asoundlib.h>
-#endif
+typedef struct _snd_pcm snd_pcm_t;
+typedef unsigned long snd_pcm_uframes_t;
 
 class AudioDriverALSA : public AudioDriver {
 	Thread thread;

--- a/drivers/alsamidi/midi_driver_alsamidi.cpp
+++ b/drivers/alsamidi/midi_driver_alsamidi.cpp
@@ -34,6 +34,12 @@
 
 #include "core/os/os.h"
 
+#ifdef SOWRAP_ENABLED
+#include "drivers/alsa/asound-so_wrap.h"
+#else
+#include <alsa/asoundlib.h>
+#endif
+
 #include <cerrno>
 
 MIDIDriverALSAMidi::InputConnection::InputConnection(int p_device_index,

--- a/drivers/alsamidi/midi_driver_alsamidi.h
+++ b/drivers/alsamidi/midi_driver_alsamidi.h
@@ -38,11 +38,7 @@
 #include "core/templates/safe_refcount.h"
 #include "core/templates/vector.h"
 
-#ifdef SOWRAP_ENABLED
-#include "../alsa/asound-so_wrap.h"
-#else
-#include <alsa/asoundlib.h>
-#endif
+typedef struct _snd_rawmidi snd_rawmidi_t;
 
 class MIDIDriverALSAMidi : public MIDIDriver {
 	Thread thread;

--- a/drivers/apple/os_log_logger.cpp
+++ b/drivers/apple/os_log_logger.cpp
@@ -31,10 +31,10 @@
 #include "os_log_logger.h"
 
 #include "core/object/script_backtrace.h"
+#include "core/os/memory.h"
 #include "core/string/print_string.h"
 
 #include <cstdio> // For vsnprintf.
-#include <cstdlib> // For malloc/free.
 
 OsLogLogger::OsLogLogger(const char *p_subsystem) {
 	const char *subsystem = p_subsystem;

--- a/drivers/apple_embedded/bridging_header_apple_embedded.h
+++ b/drivers/apple_embedded/bridging_header_apple_embedded.h
@@ -30,7 +30,9 @@
 
 #pragma once
 
+// IWYU pragma: begin_exports.
 #import "app_delegate_service.h"
 #import "godot_app_delegate.h"
 #import "godot_view_apple_embedded.h"
 #import "godot_view_controller.h"
+// IWYU pragma: end_exports.

--- a/drivers/apple_embedded/display_server_apple_embedded.h
+++ b/drivers/apple_embedded/display_server_apple_embedded.h
@@ -39,7 +39,7 @@
 #if defined(VULKAN_ENABLED)
 #import "rendering_context_driver_vulkan_apple_embedded.h"
 
-#include "drivers/vulkan/godot_vulkan.h"
+#include <drivers/vulkan/godot_vulkan.h>
 #endif // VULKAN_ENABLED
 
 #if defined(METAL_ENABLED)

--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -63,7 +63,7 @@
 #import <QuartzCore/CAMetalLayer.h>
 
 #if defined(VULKAN_ENABLED)
-#include "drivers/vulkan/godot_vulkan.h"
+#include <drivers/vulkan/godot_vulkan.h>
 #endif // VULKAN_ENABLED
 #endif
 

--- a/drivers/d3d12/d3d12_godot_nir_bridge.h
+++ b/drivers/d3d12/d3d12_godot_nir_bridge.h
@@ -30,9 +30,13 @@
 
 #pragma once
 
+#ifndef __cplusplus
+#include <stddef.h>
+#include <stdint.h>
+#else
+#include <cstddef>
 #include <cstdint>
 
-#ifdef __cplusplus
 extern "C" {
 #endif
 

--- a/drivers/d3d12/dxil_hash.h
+++ b/drivers/d3d12/dxil_hash.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 void compute_dxil_hash(const BYTE *pData, UINT byteCount, BYTE *pOutHash);

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -36,7 +36,7 @@
 
 // FIXME: platform_gl.h includes windows.h via egl.h, which defines ConnectFlags.
 // This breaks include project_settings.h in config.cpp, so we include object.h first.
-#include "core/object/object.h"
+#include "core/object/object.h" // IWYU pragma: keep.
 
 #include "platform_gl.h"
 

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -38,7 +38,7 @@
 #include "servers/audio/audio_server.h"
 
 #ifdef SOWRAP_ENABLED
-#include "pulse-so_wrap.h"
+#include "pulse-so_wrap.h" // IWYU pragma: keep. Relies on pulseaudio.h transitive includes.
 #else
 #include <pulse/pulseaudio.h>
 #endif

--- a/drivers/pulseaudio/pulse-so_wrap.h
+++ b/drivers/pulseaudio/pulse-so_wrap.h
@@ -358,7 +358,7 @@
 #define pa_timeval_store pa_timeval_store_dylibloader_orig_pulse
 #define pa_timeval_load pa_timeval_load_dylibloader_orig_pulse
 #define pa_rtclock_now pa_rtclock_now_dylibloader_orig_pulse
-#include "thirdparty/linuxbsd_headers/pulse/pulseaudio.h"
+#include "thirdparty/linuxbsd_headers/pulse/pulseaudio.h" // IWYU pragma: export.
 #undef pa_get_library_version
 #undef pa_bytes_per_second
 #undef pa_frame_size

--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -33,7 +33,6 @@
 #ifdef SDL_ENABLED
 
 #include "core/input/default_controller_mappings.h"
-#include "core/os/time.h"
 #include "core/variant/dictionary.h"
 
 #include <SDL3/SDL.h>

--- a/drivers/sdl/joypad_sdl.h
+++ b/drivers/sdl/joypad_sdl.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "core/input/input.h"
-#include "core/os/thread.h"
 
 typedef uint32_t SDL_JoystickID;
 typedef struct SDL_Joystick SDL_Joystick;

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -32,7 +32,6 @@
 
 #if defined(UNIX_ENABLED)
 
-#include "core/os/memory.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/templates/list.h"

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -44,7 +44,6 @@
 #include <cerrno>
 
 #if defined(TOOLS_ENABLED)
-#include <climits>
 #include <cstdlib>
 #endif
 

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -30,12 +30,11 @@
 
 #pragma once
 
+#if defined(UNIX_ENABLED)
+
 #include "core/io/file_access.h"
-#include "core/os/memory.h"
 
 #include <cstdio>
-
-#if defined(UNIX_ENABLED)
 
 class FileAccessUnix : public FileAccess {
 	GDSOFTCLASS(FileAccessUnix, FileAccess);

--- a/drivers/unix/file_access_unix_pipe.h
+++ b/drivers/unix/file_access_unix_pipe.h
@@ -30,12 +30,9 @@
 
 #pragma once
 
-#include "core/io/file_access.h"
-#include "core/os/memory.h"
-
-#include <cstdio>
-
 #if defined(UNIX_ENABLED)
+
+#include "core/io/file_access.h"
 
 class FileAccessUnixPipe : public FileAccess {
 	GDSOFTCLASS(FileAccessUnixPipe, FileAccess);

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -32,14 +32,17 @@
 
 #ifdef UNIX_ENABLED
 
-#include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
 #include "drivers/unix/file_access_unix_pipe.h"
-#include "drivers/unix/net_socket_unix.h"
 #include "drivers/unix/thread_posix.h"
+
+#ifndef UNIX_SOCKET_UNAVAILABLE
+#include "drivers/unix/ip_unix.h"
+#include "drivers/unix/net_socket_unix.h"
+#endif
 
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>
@@ -77,7 +80,6 @@
 #include <unistd.h>
 #include <cerrno>
 #include <csignal>
-#include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -33,7 +33,6 @@
 #ifdef UNIX_ENABLED
 
 #include "core/os/os.h"
-#include "drivers/unix/ip_unix.h"
 
 #if defined(__GLIBC__) || defined(WEB_ENABLED)
 #include <iconv.h>

--- a/drivers/unix/syslog_logger.cpp
+++ b/drivers/unix/syslog_logger.cpp
@@ -32,8 +32,6 @@
 
 #include "syslog_logger.h"
 
-#include "core/string/print_string.h"
-
 #include <syslog.h>
 
 void SyslogLogger::logv(const char *p_format, va_list p_list, bool p_err) {

--- a/drivers/vulkan/godot_vulkan.h
+++ b/drivers/vulkan/godot_vulkan.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+// IWYU pragma: begin_exports.
 #ifdef USE_VOLK
 #include <volk.h>
 #else
@@ -37,3 +38,4 @@
 #define VK_NO_STDINT_H
 #include <vulkan/vulkan.h>
 #endif
+// IWYU pragma: end_exports.

--- a/drivers/vulkan/rendering_context_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan.cpp
@@ -32,15 +32,17 @@
 
 #include "rendering_context_driver_vulkan.h"
 
-#include "vk_enum_string_helper.h"
-
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
-#include "core/os/os.h"
 #include "core/version.h"
+#include "drivers/vulkan/rendering_device_driver_vulkan.h"
+#include "drivers/vulkan/vulkan_hooks.h"
 
-#include "rendering_device_driver_vulkan.h"
-#include "vulkan_hooks.h"
+#ifndef DEV_ENABLED
+#include "core/os/os.h"
+#endif
+
+#include <vk_enum_string_helper.h>
 
 #if defined(VK_TRACK_DRIVER_MEMORY)
 /*************************************************/

--- a/drivers/vulkan/rendering_context_driver_vulkan.h
+++ b/drivers/vulkan/rendering_context_driver_vulkan.h
@@ -36,12 +36,12 @@
 #include "core/templates/local_vector.h"
 #include "servers/rendering/rendering_context_driver.h"
 
-#if defined(DEBUG_ENABLED) || defined(DEV_ENABLED)
+#if defined(DEBUG_ENABLED)
 #define VK_TRACK_DRIVER_MEMORY
 #define VK_TRACK_DEVICE_MEMORY
 #endif
 
-#include "drivers/vulkan/godot_vulkan.h"
+#include <drivers/vulkan/godot_vulkan.h>
 
 class RenderingContextDriverVulkan : public RenderingContextDriver {
 public:

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -32,10 +32,9 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
-#include "core/io/marshalls.h"
 #include "core/os/os.h"
 #include "core/templates/fixed_vector.h"
-#include "vulkan_hooks.h"
+#include "drivers/vulkan/vulkan_hooks.h"
 
 #include "thirdparty/misc/smolv.h"
 

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -45,7 +45,7 @@
 #include "thirdparty/re-spirv/re-spirv.h"
 #include "thirdparty/vulkan/vk_mem_alloc.h"
 
-#include "drivers/vulkan/godot_vulkan.h"
+#include <drivers/vulkan/godot_vulkan.h>
 
 class FileAccess;
 

--- a/drivers/vulkan/vulkan_hooks.h
+++ b/drivers/vulkan/vulkan_hooks.h
@@ -32,7 +32,8 @@
 
 #include "core/math/vector2i.h"
 #include "core/templates/local_vector.h"
-#include "drivers/vulkan/godot_vulkan.h"
+
+#include <drivers/vulkan/godot_vulkan.h>
 
 class VulkanHooks {
 private:

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -33,7 +33,6 @@
 #include "audio_driver_wasapi.h"
 
 #include "core/config/engine.h"
-#include "core/config/project_settings.h"
 #include "core/os/os.h"
 
 #include <functiondiscoverykeys.h>

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -39,7 +39,6 @@
 
 #include <audioclient.h>
 #include <mmdeviceapi.h>
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 class AudioDriverWASAPI : public AudioDriver {

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -33,7 +33,6 @@
 #include "dir_access_windows.h"
 #include "file_access_windows.h"
 
-#include "core/config/project_settings.h"
 #include "core/os/memory.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -38,10 +38,9 @@
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 
+#include <windows.h>
 #include <cstdio>
 #include <cwchar>
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
 
 typedef struct _NT_IO_STATUS_BLOCK {
 	union {

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -38,7 +38,6 @@
 
 #include <share.h> // _SH_DENYNO
 #include <shlwapi.h>
-#include <windows.h>
 
 #include <io.h>
 #include <sys/stat.h>

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -38,7 +38,6 @@
 
 #include <share.h> // _SH_DENYNO
 #include <shlwapi.h>
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 #include <io.h>

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -33,7 +33,6 @@
 #ifdef WINDOWS_ENABLED
 
 #include "core/io/file_access.h"
-#include "core/os/memory.h"
 
 #include <cstdio>
 

--- a/drivers/windows/file_access_windows_pipe.cpp
+++ b/drivers/windows/file_access_windows_pipe.cpp
@@ -34,6 +34,8 @@
 
 #include "core/string/ustring.h"
 
+#include <winbase.h>
+
 Error FileAccessWindowsPipe::open_existing(HANDLE p_rfd, HANDLE p_wfd, bool p_blocking) {
 	// Open pipe using handles created by CreatePipe(rfd, wfd, NULL, 4096) call in the OS.execute_with_pipe.
 	_close();

--- a/drivers/windows/file_access_windows_pipe.h
+++ b/drivers/windows/file_access_windows_pipe.h
@@ -35,7 +35,6 @@
 #include "core/io/file_access.h"
 #include "core/os/memory.h"
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 class FileAccessWindowsPipe : public FileAccess {

--- a/drivers/windows/file_access_windows_pipe.h
+++ b/drivers/windows/file_access_windows_pipe.h
@@ -33,7 +33,6 @@
 #ifdef WINDOWS_ENABLED
 
 #include "core/io/file_access.h"
-#include "core/os/memory.h"
 
 #include <windows.h>
 

--- a/drivers/windows/ip_windows.cpp
+++ b/drivers/windows/ip_windows.cpp
@@ -32,7 +32,6 @@
 
 #include "ip_windows.h"
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>

--- a/drivers/windows/ip_windows.cpp
+++ b/drivers/windows/ip_windows.cpp
@@ -32,13 +32,10 @@
 
 #include "ip_windows.h"
 
-#include <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
 #include <iphlpapi.h>
-
-#include <cstdio>
 
 static IPAddress _sockaddr2ip(struct sockaddr *p_addr) {
 	IPAddress ip;

--- a/drivers/windows/thread_windows.cpp
+++ b/drivers/windows/thread_windows.cpp
@@ -35,7 +35,6 @@
 #include "core/os/thread.h"
 #include "core/string/ustring.h"
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 typedef HRESULT(WINAPI *SetThreadDescriptionPtr)(HANDLE p_thread, PCWSTR p_thread_description);

--- a/drivers/winmidi/midi_driver_winmidi.h
+++ b/drivers/winmidi/midi_driver_winmidi.h
@@ -36,7 +36,6 @@
 #include "core/templates/vector.h"
 
 #include <windows.h>
-#include <cstdio>
 
 #include <mmsystem.h>
 

--- a/drivers/winmidi/midi_driver_winmidi.h
+++ b/drivers/winmidi/midi_driver_winmidi.h
@@ -35,9 +35,8 @@
 #include "core/os/midi_driver.h"
 #include "core/templates/vector.h"
 
-#include <cstdio>
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <cstdio>
 
 #include <mmsystem.h>
 

--- a/drivers/xaudio2/audio_driver_xaudio2.h
+++ b/drivers/xaudio2/audio_driver_xaudio2.h
@@ -36,7 +36,6 @@
 #include "servers/audio/audio_server.h"
 
 #include <mmsystem.h>
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <wrl/client.h>
 #include <xaudio2.h>

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -203,7 +203,9 @@ public:
 	void set_movie_maker_enabled(bool p_enabled);
 	bool is_movie_maker_enabled() const;
 
+#ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
 	// Base.
 	static void create();

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -214,7 +214,9 @@ public:
 
 	void notify_changes();
 
+#ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
 
 	EditorSettings();
 };

--- a/modules/mono/editor/hostfxr_resolver.cpp
+++ b/modules/mono/editor/hostfxr_resolver.cpp
@@ -69,7 +69,6 @@ SOFTWARE.
 #include "core/os/os.h"
 
 #ifdef WINDOWS_ENABLED
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -38,7 +38,6 @@
 #include <cstdlib>
 
 #ifdef WINDOWS_ENABLED
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 #define ENV_PATH_SEP ";"

--- a/modules/openxr/editor/openxr_select_runtime.cpp
+++ b/modules/openxr/editor/openxr_select_runtime.cpp
@@ -31,7 +31,6 @@
 #include "openxr_select_runtime.h"
 
 #ifdef WINDOWS_ENABLED
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 

--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "core/input/input_event.h"
-#include "core/templates/rb_map.h"
 
 // This class encapsulates all the handling of input events that come from the Android UI thread.
 // Remarks:

--- a/platform/android/dir_access_jandroid.h
+++ b/platform/android/dir_access_jandroid.h
@@ -30,12 +30,9 @@
 
 #pragma once
 
-#include "java_godot_lib_jni.h"
-
-#include "core/io/dir_access.h"
 #include "drivers/unix/dir_access_unix.h"
 
-#include <cstdio>
+#include <jni.h>
 
 /// Android implementation of the DirAccess interface used to provide access to
 /// ACCESS_FILESYSTEM and ACCESS_RESOURCES directory resources.

--- a/platform/android/editor/editor_utils_jni.cpp
+++ b/platform/android/editor/editor_utils_jni.cpp
@@ -30,9 +30,9 @@
 
 #include "editor_utils_jni.h"
 
+#ifdef TOOLS_ENABLED
 #include "jni_utils.h"
 
-#ifdef TOOLS_ENABLED
 #include "core/os/os.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -36,26 +36,24 @@
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
-#include "core/io/image_loader.h"
 #include "core/io/json.h"
 #include "core/io/marshalls.h"
 #include "core/math/random_pcg.h"
-#include "core/object/callable_mp.h"
 #include "core/os/os.h"
+#include "core/os/shared_object.h"
 #include "core/string/translation_server.h"
 #include "core/version.h"
-#include "editor/editor_log.h"
 #include "editor/editor_node.h"
-#include "editor/editor_string_names.h"
+#include "editor/export/editor_export.h"
+#include "editor/export/editor_export_plugin.h"
 #include "editor/export/export_template_manager.h"
 #include "editor/file_system/editor_paths.h"
 #include "editor/import/resource_importer_texture_settings.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
-#include "main/splash.gen.h"
 #include "scene/resources/image_texture.h"
 
-#include "modules/modules_enabled.gen.h" // For mono.
+#include "modules/modules_enabled.gen.h" // IWYU pragma: keep. For mono.
 #include "modules/svg/image_loader_svg.h"
 
 #ifdef MODULE_MONO_ENABLED
@@ -63,12 +61,14 @@
 #endif
 
 #ifdef ANDROID_ENABLED
-#include "../java_godot_wrapper.h"
 #include "../os_android.h"
 #include "android_editor_gradle_runner.h"
 #endif
 
 #ifndef ANDROID_ENABLED
+#include "core/object/callable_mp.h"
+#include "editor/editor_log.h"
+#include "editor/editor_string_names.h"
 #endif
 
 static const char *ANDROID_PERMS[] = {

--- a/platform/android/export/godot_plugin_config.cpp
+++ b/platform/android/export/godot_plugin_config.cpp
@@ -32,6 +32,8 @@
 
 #ifndef DISABLE_DEPRECATED
 
+#include "core/config/project_settings.h"
+
 /*
  * Set of prebuilt plugins.
  * Currently unused, this is just for future reference:

--- a/platform/android/export/godot_plugin_config.h
+++ b/platform/android/export/godot_plugin_config.h
@@ -32,7 +32,6 @@
 
 #ifndef DISABLE_DEPRECATED
 
-#include "core/config/project_settings.h"
 #include "core/io/config_file.h"
 #include "core/string/ustring.h"
 

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -30,8 +30,12 @@
 
 #include "gradle_export_util.h"
 
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
 #include "core/os/os.h"
 #include "core/string/translation_server.h"
+#include "editor/export/editor_export.h"
+#include "editor/export/editor_export_plugin.h"
 #include "modules/regex/regex.h"
 
 int _get_android_orientation_value(DisplayServerEnums::ScreenOrientation screen_orientation) {

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -31,10 +31,6 @@
 #pragma once
 
 #include "core/crypto/crypto_core.h"
-#include "core/io/dir_access.h"
-#include "core/io/file_access.h"
-#include "core/io/zip_io.h"
-#include "editor/export/editor_export.h"
 #include "editor/export/editor_export_platform.h"
 #include "servers/display/display_server_enums.h"
 

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -35,7 +35,6 @@
 #include <android/asset_manager.h>
 #include <android/log.h>
 #include <jni.h>
-#include <cstdio>
 
 class FileAccessAndroid : public FileAccess {
 	GDSOFTCLASS(FileAccessAndroid, FileAccess);

--- a/platform/android/file_access_filesystem_jandroid.h
+++ b/platform/android/file_access_filesystem_jandroid.h
@@ -30,9 +30,9 @@
 
 #pragma once
 
-#include "java_godot_lib_jni.h"
-
 #include "core/io/file_access.h"
+
+#include <jni.h>
 
 class FileAccessFilesystemJAndroid : public FileAccess {
 	GDSOFTCLASS(FileAccessFilesystemJAndroid, FileAccess);

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -30,6 +30,9 @@
 
 #include "java_godot_io_wrapper.h"
 
+#include "jni_utils.h"
+#include "thread_jandroid.h"
+
 #include "core/math/rect2.h"
 #include "core/variant/variant.h"
 

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#include "jni_utils.h"
-
 #include "core/math/rect2i.h"
 #include "core/variant/typed_array.h"
 

--- a/platform/android/java_godot_view_wrapper.cpp
+++ b/platform/android/java_godot_view_wrapper.cpp
@@ -32,6 +32,8 @@
 
 #include "thread_jandroid.h"
 
+#include "core/string/ustring.h"
+
 GodotJavaViewWrapper::GodotJavaViewWrapper(jobject godot_view) {
 	JNIEnv *env = get_jni_env();
 	ERR_FAIL_NULL(env);

--- a/platform/android/java_godot_view_wrapper.h
+++ b/platform/android/java_godot_view_wrapper.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#include "jni_utils.h"
-
 #include "core/math/vector2.h"
 
 #include <android/log.h>

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -34,8 +34,9 @@
 
 #include "core/math/color.h"
 #include "core/templates/list.h"
+#include "core/templates/vector.h"
+#include "core/variant/callable.h"
 
-#include <android/log.h>
 #include <jni.h>
 
 // Class that makes functions in java/src/org/godotengine/godot/Godot.kt callable from C++

--- a/platform/android/jni_utils.h
+++ b/platform/android/jni_utils.h
@@ -32,7 +32,6 @@
 
 #include "thread_jandroid.h"
 
-#include "core/config/engine.h"
 #include "core/string/ustring.h"
 #include "core/variant/variant.h"
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -32,30 +32,33 @@
 
 #include "dir_access_jandroid.h"
 #include "display_server_android.h"
-#include "file_access_android.h"
 #include "file_access_filesystem_jandroid.h"
 #include "java_godot_io_wrapper.h"
 #include "java_godot_wrapper.h"
 #include "net_socket_android.h"
 
+#ifndef TOOLS_ENABLED
+#include "file_access_android.h"
+#endif
+
 #include "core/config/engine.h"
-#include "core/config/project_settings.h"
 #include "core/extension/gdextension_manager.h"
 #include "core/input/input.h"
 #include "core/io/xml_parser.h"
-#include "core/object/callable_mp.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
 #include "core/profiling/profiling.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
-#ifdef TOOLS_ENABLED
-#include "editor/editor_node.h"
-#include "editor/run/game_view_plugin.h"
-#endif
 #include "main/main.h"
 #include "scene/main/scene_tree.h"
 #include "servers/rendering/rendering_server.h"
+
+#ifdef TOOLS_ENABLED
+#include "core/object/callable_mp.h"
+#include "editor/editor_node.h"
+#include "editor/run/game_view_plugin.h"
+#endif
 
 #include <dlfcn.h>
 #include <sys/system_properties.h>

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -34,7 +34,6 @@
 
 #include "core/os/main_loop.h"
 #include "drivers/unix/os_unix.h"
-#include "servers/audio/audio_server.h"
 
 class GodotJavaWrapper;
 class GodotIOJavaWrapper;

--- a/platform/android/platform_gl.h
+++ b/platform/android/platform_gl.h
@@ -34,7 +34,9 @@
 #define GLES_API_ENABLED // Allow using GLES.
 #endif
 
+// IWYU pragma: begin_exports.
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <GLES3/gl3.h>
 #include <GLES3/gl3ext.h>
+// IWYU pragma: end_exports.

--- a/platform/android/rendering_context_driver_vulkan_android.cpp
+++ b/platform/android/rendering_context_driver_vulkan_android.cpp
@@ -32,7 +32,7 @@
 
 #ifdef VULKAN_ENABLED
 
-#include "drivers/vulkan/godot_vulkan.h"
+#include <drivers/vulkan/godot_vulkan.h>
 
 const char *RenderingContextDriverVulkanAndroid::_get_platform_surface_extension() const {
 	return VK_KHR_ANDROID_SURFACE_EXTENSION_NAME;

--- a/platform/android/tts_android.cpp
+++ b/platform/android/tts_android.cpp
@@ -30,10 +30,10 @@
 
 #include "tts_android.h"
 
-#include "java_godot_wrapper.h"
-#include "os_android.h"
+#include "jni_utils.h"
 #include "thread_jandroid.h"
 
+#include "core/config/project_settings.h"
 #include "core/os/os.h"
 #include "servers/display/display_server.h"
 

--- a/platform/android/tts_android.h
+++ b/platform/android/tts_android.h
@@ -30,9 +30,10 @@
 
 #pragma once
 
-#include "core/config/project_settings.h"
+#include "core/os/thread.h"
 #include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
+#include "core/templates/safe_refcount.h"
 #include "core/variant/array.h"
 
 #include <jni.h>

--- a/platform/ios/platform_gl.h
+++ b/platform/ios/platform_gl.h
@@ -35,5 +35,5 @@
 #define GLES_API_ENABLED // Allow using GLES.
 #endif
 
-#include <ES3/gl.h>
+#include <ES3/gl.h> // IWYU pragma: export.
 #endif

--- a/platform/linuxbsd/dbus-so_wrap.h
+++ b/platform/linuxbsd/dbus-so_wrap.h
@@ -245,7 +245,7 @@
 #define dbus_validate_utf8 dbus_validate_utf8_dylibloader_orig_dbus
 #define dbus_threads_init dbus_threads_init_dylibloader_orig_dbus
 #define dbus_threads_init_default dbus_threads_init_default_dylibloader_orig_dbus
-#include "thirdparty/linuxbsd_headers/dbus/dbus.h"
+#include "thirdparty/linuxbsd_headers/dbus/dbus.h" // IWYU pragma: export.
 #undef dbus_error_init
 #undef dbus_error_free
 #undef dbus_set_error

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -33,13 +33,14 @@
 #include "logo_svg.gen.h"
 #include "run_icon_svg.gen.h"
 
-#include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/io/file_access.h"
 #include "core/os/os.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/export/editor_export.h"
 #include "editor/file_system/editor_paths.h"
+#include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 
 #include "modules/svg/image_loader_svg.h"

--- a/platform/linuxbsd/export/export_plugin.h
+++ b/platform/linuxbsd/export/export_plugin.h
@@ -30,10 +30,8 @@
 
 #pragma once
 
-#include "core/io/file_access.h"
 #include "core/os/process_id.h"
 #include "editor/export/editor_export_platform_pc.h"
-#include "editor/settings/editor_settings.h"
 #include "scene/resources/image_texture.h"
 
 class EditorExportPlatformLinuxBSD : public EditorExportPlatformPC {

--- a/platform/linuxbsd/fontconfig-so_wrap.h
+++ b/platform/linuxbsd/fontconfig-so_wrap.h
@@ -212,7 +212,7 @@
 #define FcStrListDone FcStrListDone_dylibloader_orig_fontconfig
 #define FcConfigParseAndLoad FcConfigParseAndLoad_dylibloader_orig_fontconfig
 #define FcConfigParseAndLoadFromMemory FcConfigParseAndLoadFromMemory_dylibloader_orig_fontconfig
-#include "thirdparty/linuxbsd_headers/fontconfig/fontconfig.h"
+#include "thirdparty/linuxbsd_headers/fontconfig/fontconfig.h" // IWYU pragma: export.
 #undef FcBlanksCreate
 #undef FcBlanksDestroy
 #undef FcBlanksAdd

--- a/platform/linuxbsd/freedesktop_at_spi_monitor.h
+++ b/platform/linuxbsd/freedesktop_at_spi_monitor.h
@@ -33,7 +33,7 @@
 #ifdef DBUS_ENABLED
 
 #include "core/os/thread.h"
-#include "core/os/thread_safe.h"
+#include "core/templates/safe_refcount.h"
 
 class FreeDesktopAtSPIMonitor {
 private:

--- a/platform/linuxbsd/freedesktop_portal_desktop.h
+++ b/platform/linuxbsd/freedesktop_portal_desktop.h
@@ -33,8 +33,9 @@
 #ifdef DBUS_ENABLED
 
 #include "core/object/object.h"
+#include "core/os/mutex.h"
 #include "core/os/thread.h"
-#include "core/os/thread_safe.h"
+#include "core/templates/safe_refcount.h"
 #include "servers/display/display_server_enums.h"
 
 struct DBusMessage;

--- a/platform/linuxbsd/godot_linuxbsd.cpp
+++ b/platform/linuxbsd/godot_linuxbsd.cpp
@@ -34,7 +34,6 @@
 #include "main/main.h"
 
 #include <unistd.h>
-#include <climits>
 #include <clocale>
 #include <cstdio>
 #include <cstdlib>

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -91,6 +91,14 @@
 #include <sys/sysctl.h>
 #endif
 
+#ifdef FONTCONFIG_ENABLED
+#ifdef SOWRAP_ENABLED
+#include "fontconfig-so_wrap.h"
+#else
+#include <fontconfig/fontconfig.h>
+#endif
+#endif
+
 void OS_LinuxBSD::alert(const String &p_alert, const String &p_title) {
 	const char *message_programs[] = { "zenity", "kdialog", "Xdialog", "xmessage" };
 

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -33,22 +33,17 @@
 #include "crash_handler_linuxbsd.h"
 
 #include "core/input/input_event.h"
-#include "core/templates/rb_map.h"
 #include "drivers/alsa/audio_driver_alsa.h"
 #include "drivers/alsamidi/midi_driver_alsamidi.h"
 #include "drivers/pulseaudio/audio_driver_pulseaudio.h"
 #include "drivers/unix/os_unix.h"
-#include "servers/audio/audio_server.h"
-
-#ifdef FONTCONFIG_ENABLED
-#ifdef SOWRAP_ENABLED
-#include "fontconfig-so_wrap.h"
-#else
-#include <fontconfig/fontconfig.h>
-#endif
-#endif
 
 class JoypadSDL;
+
+#ifdef FONTCONFIG_ENABLED
+typedef struct _FcConfig FcConfig;
+typedef struct _FcObjectSet FcObjectSet;
+#endif
 
 class OS_LinuxBSD : public OS_Unix {
 	virtual void delete_main_loop() override;

--- a/platform/linuxbsd/platform_gl.h
+++ b/platform/linuxbsd/platform_gl.h
@@ -38,5 +38,7 @@
 #define GLES_API_ENABLED // Allow using GLES.
 #endif
 
+// IWYU pragma: begin_exports.
 #include "thirdparty/glad/glad/egl.h"
 #include "thirdparty/glad/glad/gl.h"
+// IWYU pragma: end_exports.

--- a/platform/linuxbsd/speechd-so_wrap.h
+++ b/platform/linuxbsd/speechd-so_wrap.h
@@ -82,7 +82,7 @@
 #define spd_execute_command_wo_mutex spd_execute_command_wo_mutex_dylibloader_orig_speechd
 #define spd_send_data spd_send_data_dylibloader_orig_speechd
 #define spd_send_data_wo_mutex spd_send_data_wo_mutex_dylibloader_orig_speechd
-#include "thirdparty/linuxbsd_headers/speechd/libspeechd.h"
+#include "thirdparty/linuxbsd_headers/speechd/libspeechd.h" // IWYU pragma: export.
 #undef SPDConnectionAddress__free
 #undef spd_get_default_address
 #undef spd_open

--- a/platform/linuxbsd/wayland/detect_prime_egl.cpp
+++ b/platform/linuxbsd/wayland/detect_prime_egl.cpp
@@ -35,7 +35,8 @@
 
 #include "core/core_globals.h"
 #include "core/string/print_string.h"
-#include "core/variant/variant.h"
+#include "core/string/ustring.h"
+#include "core/variant/variant.h" // IWYU pragma: keep. Needed for print_verbose.
 
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/platform/linuxbsd/wayland/dynwrappers/libdecor-so_wrap.h
+++ b/platform/linuxbsd/wayland/dynwrappers/libdecor-so_wrap.h
@@ -48,7 +48,7 @@
 #define libdecor_state_free libdecor_state_free_dylibloader_orig_libdecor
 #define libdecor_configuration_get_content_size libdecor_configuration_get_content_size_dylibloader_orig_libdecor
 #define libdecor_configuration_get_window_state libdecor_configuration_get_window_state_dylibloader_orig_libdecor
-#include "./thirdparty/linuxbsd_headers/libdecor-0/libdecor.h"
+#include "./thirdparty/linuxbsd_headers/libdecor-0/libdecor.h" // IWYU pragma: export.
 #undef libdecor_unref
 #undef libdecor_new
 #undef libdecor_get_fd

--- a/platform/linuxbsd/wayland/dynwrappers/wayland-client-core-so_wrap.h
+++ b/platform/linuxbsd/wayland/dynwrappers/wayland-client-core-so_wrap.h
@@ -61,7 +61,7 @@
 #define wl_display_cancel_read wl_display_cancel_read_dylibloader_orig_wayland_client
 #define wl_display_read_events wl_display_read_events_dylibloader_orig_wayland_client
 #define wl_log_set_handler_client wl_log_set_handler_client_dylibloader_orig_wayland_client
-#include "./thirdparty/linuxbsd_headers/wayland/wayland-client-core.h"
+#include "./thirdparty/linuxbsd_headers/wayland/wayland-client-core.h" // IWYU pragma: export.
 #undef wl_list_init
 #undef wl_list_insert
 #undef wl_list_remove

--- a/platform/linuxbsd/wayland/dynwrappers/wayland-cursor-so_wrap.h
+++ b/platform/linuxbsd/wayland/dynwrappers/wayland-cursor-so_wrap.h
@@ -13,7 +13,7 @@
 #define wl_cursor_image_get_buffer wl_cursor_image_get_buffer_dylibloader_orig_wayland_cursor
 #define wl_cursor_frame wl_cursor_frame_dylibloader_orig_wayland_cursor
 #define wl_cursor_frame_and_duration wl_cursor_frame_and_duration_dylibloader_orig_wayland_cursor
-#include "./thirdparty/linuxbsd_headers/wayland/wayland-cursor.h"
+#include "./thirdparty/linuxbsd_headers/wayland/wayland-cursor.h" // IWYU pragma: export.
 #undef wl_cursor_theme_load
 #undef wl_cursor_theme_destroy
 #undef wl_cursor_theme_get_cursor

--- a/platform/linuxbsd/wayland/dynwrappers/wayland-egl-core-so_wrap.h
+++ b/platform/linuxbsd/wayland/dynwrappers/wayland-egl-core-so_wrap.h
@@ -11,7 +11,7 @@
 #define wl_egl_window_destroy wl_egl_window_destroy_dylibloader_orig_wayland_egl
 #define wl_egl_window_resize wl_egl_window_resize_dylibloader_orig_wayland_egl
 #define wl_egl_window_get_attached_size wl_egl_window_get_attached_size_dylibloader_orig_wayland_egl
-#include "./thirdparty/linuxbsd_headers/wayland/wayland-egl-core.h"
+#include "./thirdparty/linuxbsd_headers/wayland/wayland-egl-core.h" // IWYU pragma: export.
 #undef wl_egl_window_create
 #undef wl_egl_window_destroy
 #undef wl_egl_window_resize

--- a/platform/linuxbsd/wayland/key_mapping_xkb.cpp
+++ b/platform/linuxbsd/wayland/key_mapping_xkb.cpp
@@ -30,6 +30,12 @@
 
 #include "key_mapping_xkb.h"
 
+#ifdef SOWRAP_ENABLED
+#include "xkbcommon-so_wrap.h"
+#else
+#include <xkbcommon/xkbcommon.h>
+#endif // SOWRAP_ENABLED
+
 void KeyMappingXKB::initialize() {
 	// XKB keycode to Godot Key map.
 

--- a/platform/linuxbsd/wayland/key_mapping_xkb.h
+++ b/platform/linuxbsd/wayland/key_mapping_xkb.h
@@ -33,11 +33,8 @@
 #include "core/os/keyboard.h"
 #include "core/templates/hash_map.h"
 
-#ifdef SOWRAP_ENABLED
-#include "xkbcommon-so_wrap.h"
-#else
-#include <xkbcommon/xkbcommon.h>
-#endif // SOWRAP_ENABLED
+typedef uint32_t xkb_keycode_t;
+typedef uint32_t xkb_keysym_t;
 
 class KeyMappingXKB {
 	struct HashMapHasherKeys {

--- a/platform/linuxbsd/wayland/rendering_context_driver_vulkan_wayland.cpp
+++ b/platform/linuxbsd/wayland/rendering_context_driver_vulkan_wayland.cpp
@@ -32,7 +32,7 @@
 
 #include "rendering_context_driver_vulkan_wayland.h"
 
-#include "drivers/vulkan/godot_vulkan.h"
+#include <drivers/vulkan/godot_vulkan.h>
 
 const char *RenderingContextDriverVulkanWayland::_get_platform_surface_extension() const {
 	return VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME;

--- a/platform/linuxbsd/wayland/wayland_embedder.h
+++ b/platform/linuxbsd/wayland/wayland_embedder.h
@@ -37,12 +37,6 @@
 #include "core/templates/a_hash_map.h"
 #include "core/templates/pooled_list.h"
 
-#ifdef SOWRAP_ENABLED
-#include "wayland/dynwrappers/wayland-client-core-so_wrap.h"
-#else
-#include <wayland-client-core.h>
-#endif
-
 #include "protocol/wayland.gen.h"
 
 #include "protocol/linux_dmabuf_v1.gen.h"
@@ -61,7 +55,7 @@
 #include "protocol/pointer_warp.gen.h"
 #include "protocol/primary_selection.gen.h"
 #include "protocol/relative_pointer.gen.h"
-#include "protocol/tablet.gen.h"
+// #include "protocol/tablet.gen.h" // TODO: Needs some extra work
 #include "protocol/tearing_control_v1.gen.h"
 #include "protocol/text_input.gen.h"
 #include "protocol/viewporter.gen.h"
@@ -74,13 +68,12 @@
 #include "protocol/xdg_system_bell.gen.h"
 #include "protocol/xdg_toplevel_icon.gen.h"
 
-#include <errno.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include <poll.h>
 

--- a/platform/linuxbsd/x11/dynwrappers/xcursor-so_wrap.h
+++ b/platform/linuxbsd/x11/dynwrappers/xcursor-so_wrap.h
@@ -66,7 +66,7 @@
 #define XcursorGetTheme XcursorGetTheme_dylibloader_orig_xcursor
 #define XcursorGetThemeCore XcursorGetThemeCore_dylibloader_orig_xcursor
 #define XcursorSetThemeCore XcursorSetThemeCore_dylibloader_orig_xcursor
-#include "thirdparty/linuxbsd_headers/X11/Xcursor/Xcursor.h"
+#include "thirdparty/linuxbsd_headers/X11/Xcursor/Xcursor.h" // IWYU pragma: export.
 #undef XcursorImageCreate
 #undef XcursorImageDestroy
 #undef XcursorImagesCreate

--- a/platform/linuxbsd/x11/dynwrappers/xext-so_wrap.h
+++ b/platform/linuxbsd/x11/dynwrappers/xext-so_wrap.h
@@ -18,8 +18,8 @@
 #define XShapeSelectInput XShapeSelectInput_dylibloader_orig_xext
 #define XShapeInputSelected XShapeInputSelected_dylibloader_orig_xext
 #define XShapeGetRectangles XShapeGetRectangles_dylibloader_orig_xext
-#include "thirdparty/linuxbsd_headers/X11/extensions/Xext.h"
-#include "thirdparty/linuxbsd_headers/X11/extensions/shape.h"
+#include "thirdparty/linuxbsd_headers/X11/extensions/Xext.h" // IWYU pragma: export.
+#include "thirdparty/linuxbsd_headers/X11/extensions/shape.h" // IWYU pragma: export.
 #undef XShapeQueryExtension
 #undef XShapeQueryVersion
 #undef XShapeCombineRegion

--- a/platform/linuxbsd/x11/dynwrappers/xinerama-so_wrap.h
+++ b/platform/linuxbsd/x11/dynwrappers/xinerama-so_wrap.h
@@ -11,7 +11,7 @@
 #define XineramaQueryVersion XineramaQueryVersion_dylibloader_orig_xinerama
 #define XineramaIsActive XineramaIsActive_dylibloader_orig_xinerama
 #define XineramaQueryScreens XineramaQueryScreens_dylibloader_orig_xinerama
-#include "thirdparty/linuxbsd_headers/X11/extensions/Xinerama.h"
+#include "thirdparty/linuxbsd_headers/X11/extensions/Xinerama.h" // IWYU pragma: export.
 #undef XineramaQueryExtension
 #undef XineramaQueryVersion
 #undef XineramaIsActive

--- a/platform/linuxbsd/x11/dynwrappers/xinput2-so_wrap.h
+++ b/platform/linuxbsd/x11/dynwrappers/xinput2-so_wrap.h
@@ -41,7 +41,7 @@
 #define XIBarrierReleasePointers XIBarrierReleasePointers_dylibloader_orig_xinput2
 #define XIBarrierReleasePointer XIBarrierReleasePointer_dylibloader_orig_xinput2
 #define XIFreeDeviceInfo XIFreeDeviceInfo_dylibloader_orig_xinput2
-#include "thirdparty/linuxbsd_headers/X11/extensions/XInput2.h"
+#include "thirdparty/linuxbsd_headers/X11/extensions/XInput2.h" // IWYU pragma: export.
 #undef XIQueryPointer
 #undef XIWarpPointer
 #undef XIDefineCursor

--- a/platform/linuxbsd/x11/dynwrappers/xlib-so_wrap.h
+++ b/platform/linuxbsd/x11/dynwrappers/xlib-so_wrap.h
@@ -611,9 +611,9 @@
 #define XkbApplyVirtualModChanges XkbApplyVirtualModChanges_dylibloader_orig_xlib
 #define XkbUpdateActionVirtualMods XkbUpdateActionVirtualMods_dylibloader_orig_xlib
 #define XkbUpdateKeyTypeVirtualMods XkbUpdateKeyTypeVirtualMods_dylibloader_orig_xlib
-#include "thirdparty/linuxbsd_headers/X11/Xlib.h"
-#include "thirdparty/linuxbsd_headers/X11/Xutil.h"
-#include "thirdparty/linuxbsd_headers/X11/XKBlib.h"
+#include "thirdparty/linuxbsd_headers/X11/Xlib.h" // IWYU pragma: export.
+#include "thirdparty/linuxbsd_headers/X11/Xutil.h" // IWYU pragma: export.
+#include "thirdparty/linuxbsd_headers/X11/XKBlib.h" // IWYU pragma: export.
 #undef _Xmblen
 #undef XLoadQueryFont
 #undef XQueryFont

--- a/platform/linuxbsd/x11/dynwrappers/xrandr-so_wrap.h
+++ b/platform/linuxbsd/x11/dynwrappers/xrandr-so_wrap.h
@@ -77,7 +77,7 @@
 #define XRRSetMonitor XRRSetMonitor_dylibloader_orig_xrandr
 #define XRRDeleteMonitor XRRDeleteMonitor_dylibloader_orig_xrandr
 #define XRRFreeMonitors XRRFreeMonitors_dylibloader_orig_xrandr
-#include "thirdparty/linuxbsd_headers/X11/extensions/Xrandr.h"
+#include "thirdparty/linuxbsd_headers/X11/extensions/Xrandr.h" // IWYU pragma: export.
 #undef XRRQueryExtension
 #undef XRRQueryVersion
 #undef XRRGetScreenInfo

--- a/platform/linuxbsd/x11/dynwrappers/xrender-so_wrap.h
+++ b/platform/linuxbsd/x11/dynwrappers/xrender-so_wrap.h
@@ -51,7 +51,7 @@
 #define XRenderCreateLinearGradient XRenderCreateLinearGradient_dylibloader_orig_xrender
 #define XRenderCreateRadialGradient XRenderCreateRadialGradient_dylibloader_orig_xrender
 #define XRenderCreateConicalGradient XRenderCreateConicalGradient_dylibloader_orig_xrender
-#include "thirdparty/linuxbsd_headers/X11/extensions/Xrender.h"
+#include "thirdparty/linuxbsd_headers/X11/extensions/Xrender.h" // IWYU pragma: export.
 #undef XRenderQueryExtension
 #undef XRenderQueryVersion
 #undef XRenderQueryFormats

--- a/platform/linuxbsd/x11/gl_manager_x11.cpp
+++ b/platform/linuxbsd/x11/gl_manager_x11.cpp
@@ -37,9 +37,13 @@
 
 #include "thirdparty/glad/glad/glx.h"
 
+#ifdef SOWRAP_ENABLED
+#include "dynwrappers/xrender-so_wrap.h"
+#else
+#include <X11/extensions/Xrender.h>
+#endif
+
 #include <unistd.h>
-#include <cstdio>
-#include <cstdlib>
 
 #define GLX_CONTEXT_MAJOR_VERSION_ARB 0x2091
 #define GLX_CONTEXT_MINOR_VERSION_ARB 0x2092

--- a/platform/linuxbsd/x11/gl_manager_x11.h
+++ b/platform/linuxbsd/x11/gl_manager_x11.h
@@ -38,17 +38,9 @@
 
 #ifdef SOWRAP_ENABLED
 #include "dynwrappers/xlib-so_wrap.h"
-
-#include "dynwrappers/xext-so_wrap.h"
-#include "dynwrappers/xrender-so_wrap.h"
 #else
-#include <X11/XKBlib.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
-
-#include <X11/extensions/Xext.h>
-#include <X11/extensions/Xrender.h>
-#include <X11/extensions/shape.h>
 #endif
 
 struct GLManager_X11_Private;

--- a/platform/linuxbsd/x11/gl_manager_x11_egl.cpp
+++ b/platform/linuxbsd/x11/gl_manager_x11_egl.cpp
@@ -32,9 +32,6 @@
 
 #if defined(X11_ENABLED) && defined(GLES3_ENABLED)
 
-#include <cstdio>
-#include <cstdlib>
-
 const char *GLManagerEGL_X11::_get_platform_extension_name() const {
 	return "EGL_KHR_platform_x11";
 }

--- a/platform/linuxbsd/x11/gl_manager_x11_egl.h
+++ b/platform/linuxbsd/x11/gl_manager_x11_egl.h
@@ -32,11 +32,8 @@
 
 #if defined(X11_ENABLED) && defined(GLES3_ENABLED)
 
-#include "core/templates/local_vector.h"
 #include "drivers/egl/egl_manager.h"
 #include "servers/display/display_server_enums.h"
-
-#include <X11/Xlib.h>
 
 class GLManagerEGL_X11 : public EGLManager {
 private:

--- a/platform/linuxbsd/x11/rendering_context_driver_vulkan_x11.cpp
+++ b/platform/linuxbsd/x11/rendering_context_driver_vulkan_x11.cpp
@@ -32,7 +32,7 @@
 
 #include "rendering_context_driver_vulkan_x11.h"
 
-#include "drivers/vulkan/godot_vulkan.h"
+#include <drivers/vulkan/godot_vulkan.h>
 
 const char *RenderingContextDriverVulkanX11::_get_platform_surface_extension() const {
 	return VK_KHR_XLIB_SURFACE_EXTENSION_NAME;

--- a/platform/linuxbsd/xkbcommon-so_wrap.h
+++ b/platform/linuxbsd/xkbcommon-so_wrap.h
@@ -97,9 +97,9 @@
 #define xkb_compose_state_get_status xkb_compose_state_get_status_dylibloader_orig_xkbcommon
 #define xkb_compose_state_get_utf8 xkb_compose_state_get_utf8_dylibloader_orig_xkbcommon
 #define xkb_compose_state_get_one_sym xkb_compose_state_get_one_sym_dylibloader_orig_xkbcommon
-#include "./thirdparty/linuxbsd_headers/xkbcommon/xkbcommon.h"
-#include "./thirdparty/linuxbsd_headers/xkbcommon/xkbcommon-compose.h"
-#include "./thirdparty/linuxbsd_headers/xkbcommon/xkbcommon-keysyms.h"
+#include "./thirdparty/linuxbsd_headers/xkbcommon/xkbcommon.h" // IWYU pragma: export.
+#include "./thirdparty/linuxbsd_headers/xkbcommon/xkbcommon-compose.h" // IWYU pragma: export.
+#include "./thirdparty/linuxbsd_headers/xkbcommon/xkbcommon-keysyms.h" // IWYU pragma: export.
 #undef xkb_keysym_get_name
 #undef xkb_keysym_from_name
 #undef xkb_keysym_to_utf8

--- a/platform/macos/dir_access_macos.h
+++ b/platform/macos/dir_access_macos.h
@@ -32,7 +32,6 @@
 
 #if defined(UNIX_ENABLED)
 
-#include "core/io/dir_access.h"
 #include "drivers/unix/dir_access_unix.h"
 
 #include <dirent.h>

--- a/platform/macos/platform_gl.h
+++ b/platform/macos/platform_gl.h
@@ -38,6 +38,7 @@
 #define GLES_API_ENABLED // Allow using GLES (ANGLE).
 #endif
 
+// IWYU pragma: begin_exports.
 #ifdef EGL_STATIC
 #define KHRONOS_STATIC 1
 #include "thirdparty/angle/include/EGL/egl.h"
@@ -47,3 +48,4 @@
 #include "thirdparty/glad/glad/egl.h"
 #endif
 #include "thirdparty/glad/glad/gl.h"
+// IWYU pragma: end_exports.

--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -33,10 +33,8 @@
 #include "godot_audio.h"
 
 #include "core/config/engine.h"
-#include "core/config/project_settings.h"
 #include "core/math/math_funcs_binary.h"
 #include "core/object/object.h"
-#include "scene/main/node.h"
 #include "servers/audio/audio_stream.h"
 
 #include <emscripten.h>

--- a/platform/web/audio_driver_web.h
+++ b/platform/web/audio_driver_web.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "godot_audio.h"
 #include "godot_js.h"
 
 #include "core/os/mutex.h"

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -37,13 +37,13 @@
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/input/input_event.h"
-#include "core/object/callable_mp.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
 #include "servers/display/native_menu.h"
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 
 #ifdef PROXY_TO_PTHREAD_ENABLED
+#include "core/object/callable_mp.h"
 #endif
 
 #ifdef GLES3_ENABLED

--- a/platform/web/editor/web_tools_editor_plugin.cpp
+++ b/platform/web/editor/web_tools_editor_plugin.cpp
@@ -31,11 +31,9 @@
 #include "web_tools_editor_plugin.h"
 
 #include "core/config/engine.h"
-#include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/object/callable_mp.h"
-#include "core/os/time.h"
 #include "editor/editor_node.h"
 #include "editor/export/project_zip_packer.h"
 

--- a/platform/web/editor/web_tools_editor_plugin.h
+++ b/platform/web/editor/web_tools_editor_plugin.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/io/zip_io.h"
 #include "editor/plugins/editor_plugin.h"
 
 class WebToolsEditorPlugin : public EditorPlugin {

--- a/platform/web/export/editor_http_server.cpp
+++ b/platform/web/export/editor_http_server.cpp
@@ -30,7 +30,9 @@
 
 #include "editor_http_server.h"
 
+#include "core/io/file_access.h"
 #include "core/os/os.h"
+#include "editor/file_system/editor_paths.h"
 
 void EditorHTTPServer::_server_thread_poll(void *data) {
 	EditorHTTPServer *web_server = static_cast<EditorHTTPServer *>(data);

--- a/platform/web/export/editor_http_server.h
+++ b/platform/web/export/editor_http_server.h
@@ -30,11 +30,8 @@
 
 #pragma once
 
-#include "core/io/image_loader.h"
 #include "core/io/stream_peer_tls.h"
 #include "core/io/tcp_server.h"
-#include "core/io/zip_io.h"
-#include "editor/file_system/editor_paths.h"
 
 class EditorHTTPServer : public RefCounted {
 	GDSOFTCLASS(EditorHTTPServer, RefCounted);

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -35,9 +35,11 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/io/zip_io.h"
 #include "core/os/os.h"
 #include "editor/editor_string_names.h"
 #include "editor/export/editor_export.h"
+#include "editor/file_system/editor_paths.h"
 #include "editor/import/resource_importer_texture_settings.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"

--- a/platform/web/export/export_plugin.h
+++ b/platform/web/export/export_plugin.h
@@ -32,11 +32,6 @@
 
 #include "editor_http_server.h"
 
-#include "core/config/project_settings.h"
-#include "core/io/image_loader.h"
-#include "core/io/stream_peer_tls.h"
-#include "core/io/tcp_server.h"
-#include "core/io/zip_io.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/export/editor_export_platform.h"

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -36,8 +36,6 @@
 #include "ip_web.h"
 #include "net_socket_web.h"
 
-#include "core/config/project_settings.h"
-#include "core/debugger/engine_debugger.h"
 #include "core/io/file_access.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
@@ -46,11 +44,8 @@
 #include "drivers/unix/file_access_unix.h"
 #include "main/main.h"
 
-#include "modules/modules_enabled.gen.h" // For websocket.
-
 #include <dlfcn.h>
 #include <emscripten.h>
-#include <cstdlib>
 
 void OS_Web::alert(const String &p_alert, const String &p_title) {
 	godot_js_display_alert(p_alert.utf8().get_data());

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -36,9 +36,7 @@
 #include "godot_js.h"
 
 #include "core/input/input_event.h"
-#include "core/templates/rb_map.h"
 #include "drivers/unix/os_unix.h"
-#include "servers/audio/audio_server.h"
 
 #include <emscripten/html5.h>
 

--- a/platform/web/platform_gl.h
+++ b/platform/web/platform_gl.h
@@ -38,4 +38,4 @@
 #define glGetProcAddress(n) static_assert(false, "Usage of glGetProcessAddress() on the web is a bug.")
 #define eglGetProcAddress(n) static_assert(false, "Usage of eglGetProcessAddress() on the web is a bug.")
 
-#include "platform/web/godot_webgl2.h"
+#include "platform/web/godot_webgl2.h" // IWYU pragma: export.

--- a/platform/web/web_main.cpp
+++ b/platform/web/web_main.cpp
@@ -33,16 +33,17 @@
 #include "os_web.h"
 
 #include "core/config/engine.h"
-#include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
+#include "core/os/main_loop.h"
 #include "core/os/os.h"
 #include "core/profiling/profiling.h"
 #include "main/main.h"
-#include "scene/main/scene_tree.h"
-#include "scene/main/window.h" // SceneTree only forward declares it.
 
 #ifdef TOOLS_ENABLED
+#include "core/io/file_access.h"
 #include "editor/web_tools_editor_plugin.h"
+#include "scene/main/scene_tree.h"
+#include "scene/main/window.h" // SceneTree only forward declares it.
 #endif
 
 #include <emscripten/emscripten.h>

--- a/platform/web/webmidi_driver.cpp
+++ b/platform/web/webmidi_driver.cpp
@@ -30,6 +30,8 @@
 
 #include "webmidi_driver.h"
 
+#include "godot_midi.h"
+
 #ifdef PROXY_TO_PTHREAD_ENABLED
 #include "core/object/callable_mp.h"
 #endif

--- a/platform/web/webmidi_driver.h
+++ b/platform/web/webmidi_driver.h
@@ -33,7 +33,6 @@
 #include "core/os/midi_driver.h"
 
 #include "godot_js.h"
-#include "godot_midi.h"
 
 class MIDIDriverWebMidi : public MIDIDriver {
 private:

--- a/platform/windows/console_wrapper_windows.cpp
+++ b/platform/windows/console_wrapper_windows.cpp
@@ -31,8 +31,8 @@
 #include <windows.h>
 
 #include <shlwapi.h>
-#include <cstdio>
 #include <cstdlib>
+#include <cwchar>
 
 #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
 #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x4

--- a/platform/windows/crash_handler_windows.h
+++ b/platform/windows/crash_handler_windows.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 // Crash handler exception only enabled with MSVC

--- a/platform/windows/crash_handler_windows_seh.cpp
+++ b/platform/windows/crash_handler_windows_seh.cpp
@@ -36,7 +36,6 @@
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/version.h"
-#include "main/main.h"
 
 #ifdef CRASH_HANDLER_EXCEPTION
 

--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -37,16 +37,12 @@
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/version.h"
-#include "main/main.h"
 
 #ifdef CRASH_HANDLER_EXCEPTION
 
 #include <cxxabi.h>
-#include <algorithm>
 #include <csignal>
 #include <cstdlib>
-#include <string>
-#include <vector>
 
 #include <psapi.h>
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -31,8 +31,10 @@
 #include "display_server_windows.h"
 
 #include "drop_target_windows.h"
+#include "key_mapping_windows.h"
 #include "native_menu_windows.h"
 #include "os_windows.h"
+#include "tts_windows.h"
 #include "wgl_detect_version.h"
 
 #include "core/config/engine.h"
@@ -48,10 +50,10 @@
 #include "core/version.h"
 #include "drivers/png/png_driver_common.h"
 #include "main/main.h"
-#include "scene/main/window.h"
 #include "scene/resources/texture.h"
 #include "servers/display/accessibility_server.h"
 #include "servers/rendering/dummy/rasterizer_dummy.h"
+#include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
 
 #ifdef SDL_ENABLED
 #include "drivers/sdl/joypad_sdl.h"

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -30,22 +30,14 @@
 
 #pragma once
 
-#include "crash_handler_windows.h"
-#include "key_mapping_windows.h"
-#include "tts_windows.h"
-
 #include "core/config/project_settings.h"
 #include "core/input/input_event.h"
 #include "core/io/image.h"
 #include "core/os/process_id.h"
 #include "core/templates/a_hash_map.h"
 #include "core/templates/rb_map.h"
-#include "drivers/wasapi/audio_driver_wasapi.h"
-#include "drivers/winmidi/midi_driver_winmidi.h"
-#include "servers/audio/audio_server.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/renderer_compositor.h"
-#include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
 
 #ifdef XAUDIO2_ENABLED
 #include "drivers/xaudio2/audio_driver_xaudio2.h"
@@ -61,9 +53,7 @@
 #endif // GLES3_ENABLED
 
 #include <io.h>
-#include <cstdio>
 
-#define WIN32_LEAN_AND_MEAN
 #include <shobjidl.h>
 #include <windows.h>
 #include <windowsx.h>
@@ -191,6 +181,7 @@ typedef struct {
 
 class DropTargetWindows;
 class NativeMenuWindows;
+class TTS_Windows;
 
 #ifndef WDA_EXCLUDEFROMCAPTURE
 #define WDA_EXCLUDEFROMCAPTURE 0x00000011

--- a/platform/windows/export/export.cpp
+++ b/platform/windows/export/export.cpp
@@ -34,6 +34,7 @@
 
 #include "core/object/class_db.h"
 #include "editor/export/editor_export.h"
+#include "editor/settings/editor_settings.h"
 
 void register_windows_exporter_types() {
 	GDREGISTER_VIRTUAL_CLASS(EditorExportPlatformWindows);

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -36,12 +36,13 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
-#include "core/io/image_loader.h"
+#include "core/io/file_access.h"
 #include "core/os/os.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/export/editor_export.h"
 #include "editor/file_system/editor_paths.h"
+#include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/resources/image_texture.h"
 

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -30,10 +30,8 @@
 
 #pragma once
 
-#include "core/io/file_access.h"
 #include "core/os/process_id.h"
 #include "editor/export/editor_export_platform_pc.h"
-#include "editor/settings/editor_settings.h"
 
 // Optional environment variables for defining confidential information. If any
 // of these is set, they will override the values set in the credentials file.

--- a/platform/windows/export/template_modifier.cpp
+++ b/platform/windows/export/template_modifier.cpp
@@ -30,9 +30,9 @@
 
 #include "template_modifier.h"
 
-#include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/image.h"
+#include "editor/export/editor_export_preset.h"
 
 void TemplateModifier::ByteStream::save(uint8_t p_value, Vector<uint8_t> &r_bytes) const {
 	save(p_value, r_bytes, 1);

--- a/platform/windows/export/template_modifier.h
+++ b/platform/windows/export/template_modifier.h
@@ -31,7 +31,8 @@
 #pragma once
 
 #include "core/io/file_access.h"
-#include "editor/export/editor_export_platform_pc.h"
+
+class EditorExportPreset;
 
 class TemplateModifier {
 	const uint32_t PE_PAGE_SIZE = 4096;

--- a/platform/windows/gl_manager_windows_angle.cpp
+++ b/platform/windows/gl_manager_windows_angle.cpp
@@ -32,9 +32,6 @@
 
 #if defined(WINDOWS_ENABLED) && defined(GLES3_ENABLED)
 
-#include <cstdio>
-#include <cstdlib>
-
 #include <EGL/eglext_angle.h>
 
 const char *GLManagerANGLE_Windows::_get_platform_extension_name() const {

--- a/platform/windows/gl_manager_windows_angle.h
+++ b/platform/windows/gl_manager_windows_angle.h
@@ -32,7 +32,6 @@
 
 #if defined(WINDOWS_ENABLED) && defined(GLES3_ENABLED)
 
-#include "core/templates/local_vector.h"
 #include "drivers/egl/egl_manager.h"
 #include "servers/display/display_server_enums.h"
 

--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -34,7 +34,6 @@
 #include "main/main.h"
 
 #include <clocale>
-#include <cstdio>
 
 // For export templates, add a section; the exporter will patch it to enclose
 // the data appended to the executable (bundled PCK).

--- a/platform/windows/key_mapping_windows.h
+++ b/platform/windows/key_mapping_windows.h
@@ -32,7 +32,6 @@
 
 #include "core/os/keyboard.h"
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <winuser.h>
 

--- a/platform/windows/native_menu_windows.h
+++ b/platform/windows/native_menu_windows.h
@@ -35,7 +35,6 @@
 #include "core/templates/rid_owner.h"
 #include "servers/display/native_menu.h"
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 class NativeMenuWindows : public NativeMenu {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -38,7 +38,6 @@
 #include "core/config/engine.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
-#include "core/io/marshalls.h"
 #include "core/os/main_loop.h"
 #include "core/profiling/profiling.h"
 #include "core/version_generated.gen.h"
@@ -51,7 +50,6 @@
 #include "main/main.h"
 #include "servers/audio/audio_server.h"
 #include "servers/rendering/rendering_server.h"
-#include "servers/rendering/rendering_server_default.h"
 #include "servers/text/text_server.h"
 
 #include <avrt.h>
@@ -84,7 +82,7 @@ extern "C" {
 #endif
 
 #if defined(VULKAN_ENABLED)
-#include "rendering_context_driver_vulkan_windows.h"
+#include "drivers/vulkan/rendering_context_driver_vulkan.h"
 #endif
 #if defined(D3D12_ENABLED)
 #include "drivers/d3d12/rendering_context_driver_d3d12.h"

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -31,15 +31,11 @@
 #pragma once
 
 #include "crash_handler_windows.h"
-#include "key_mapping_windows.h"
 
-#include "core/config/project_settings.h"
 #include "core/input/input_event.h"
 #include "core/os/os.h"
-#include "core/templates/rb_map.h"
 #include "drivers/wasapi/audio_driver_wasapi.h"
 #include "drivers/winmidi/midi_driver_winmidi.h"
-#include "servers/audio/audio_server.h"
 
 #ifdef XAUDIO2_ENABLED
 #include "drivers/xaudio2/audio_driver_xaudio2.h"
@@ -47,9 +43,7 @@
 
 #include <io.h>
 #include <shellapi.h>
-#include <cstdio>
 
-#define WIN32_LEAN_AND_MEAN
 #include <dwrite.h>
 #include <dwrite_2.h>
 #include <windows.h>

--- a/platform/windows/platform_gl.h
+++ b/platform/windows/platform_gl.h
@@ -38,6 +38,7 @@
 #define GLES_API_ENABLED // Allow using GLES (ANGLE).
 #endif
 
+// IWYU pragma: begin_exports.
 #ifdef EGL_STATIC
 #define KHRONOS_STATIC 1
 #include "thirdparty/angle/include/EGL/egl.h"
@@ -48,3 +49,4 @@
 #endif
 
 #include "thirdparty/glad/glad/gl.h"
+// IWYU pragma: end_exports.

--- a/platform/windows/rendering_context_driver_vulkan_windows.cpp
+++ b/platform/windows/rendering_context_driver_vulkan_windows.cpp
@@ -34,7 +34,7 @@
 
 #include "rendering_context_driver_vulkan_windows.h"
 
-#include "drivers/vulkan/godot_vulkan.h"
+#include <drivers/vulkan/godot_vulkan.h>
 
 const char *RenderingContextDriverVulkanWindows::_get_platform_surface_extension() const {
 	return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;

--- a/platform/windows/rendering_context_driver_vulkan_windows.h
+++ b/platform/windows/rendering_context_driver_vulkan_windows.h
@@ -34,7 +34,6 @@
 
 #include "drivers/vulkan/rendering_context_driver_vulkan.h"
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 class RenderingContextDriverVulkanWindows : public RenderingContextDriverVulkan {

--- a/platform/windows/tts_windows.h
+++ b/platform/windows/tts_windows.h
@@ -37,11 +37,8 @@
 
 #include <objbase.h>
 #include <sapi.h>
-#include <winnls.h>
-#include <cwchar>
-
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <winnls.h>
 
 struct TTSUtterance;
 

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -37,7 +37,6 @@
 
 #include <cstdio>
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 void WindowsTerminalLogger::logv(const char *p_format, va_list p_list, bool p_err) {

--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -36,7 +36,6 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #undef FAILED // Overrides Error::FAILED
 

--- a/tests/core/io/test_config_file.cpp
+++ b/tests/core/io/test_config_file.cpp
@@ -33,7 +33,10 @@
 TEST_FORCE_LINK(test_config_file)
 
 #include "core/io/config_file.h"
+
+#ifdef WINDOWS_ENABLED
 #include "core/os/os.h"
+#endif
 
 namespace TestConfigFile {
 

--- a/tests/scene/test_packed_scene.cpp
+++ b/tests/scene/test_packed_scene.cpp
@@ -33,7 +33,6 @@
 TEST_FORCE_LINK(test_packed_scene)
 
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h"
 #include "scene/resources/packed_scene.h"
 
 namespace TestPackedScene {

--- a/tests/servers/test_navigation_server_3d.cpp
+++ b/tests/servers/test_navigation_server_3d.cpp
@@ -37,7 +37,6 @@ TEST_FORCE_LINK(test_navigation_server_3d)
 #ifdef MODULE_NAVIGATION_3D_ENABLED
 
 #include "core/object/callable_mp.h"
-#include "core/object/class_db.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/core_globals.h" // IWYU pragma: Used in macro.
+#include "core/core_globals.h" // IWYU pragma: keep. Used in macro.
 #include "core/variant/variant.h"
 
 #if defined(_MSC_VER) && !defined(DOCTEST_THREAD_LOCAL)

--- a/thirdparty/vulkan/patches/0001-VKEnumStringHelper-godot-vulkan.patch
+++ b/thirdparty/vulkan/patches/0001-VKEnumStringHelper-godot-vulkan.patch
@@ -7,7 +7,7 @@ index 8026787ad4..7a54b12a38 100644
  #include <string>
  #endif
 -#include <vulkan/vulkan.h>
-+#include "drivers/vulkan/godot_vulkan.h"
++#include <drivers/vulkan/godot_vulkan.h>
  static inline const char* string_VkResult(VkResult input_value) {
      switch (input_value) {
          case VK_SUCCESS:

--- a/thirdparty/vulkan/patches/0002-VMA-godot-vulkan.patch
+++ b/thirdparty/vulkan/patches/0002-VMA-godot-vulkan.patch
@@ -6,7 +6,7 @@ index 8df03649b5..42ba704beb 100644
  See documentation chapter: \ref statistics.
  */
  
-+#include "drivers/vulkan/godot_vulkan.h"
++#include <drivers/vulkan/godot_vulkan.h>
  
  #ifdef __cplusplus
  extern "C" {

--- a/thirdparty/vulkan/vk_enum_string_helper.h
+++ b/thirdparty/vulkan/vk_enum_string_helper.h
@@ -13,7 +13,7 @@
 #ifdef __cplusplus
 #include <string>
 #endif
-#include "drivers/vulkan/godot_vulkan.h"
+#include <drivers/vulkan/godot_vulkan.h>
 static inline const char* string_VkResult(VkResult input_value) {
     switch (input_value) {
         case VK_SUCCESS:

--- a/thirdparty/vulkan/vk_mem_alloc.h
+++ b/thirdparty/vulkan/vk_mem_alloc.h
@@ -123,7 +123,7 @@ for user-defined purpose without allocating any real GPU memory.
 See documentation chapter: \ref statistics.
 */
 
-#include "drivers/vulkan/godot_vulkan.h"
+#include <drivers/vulkan/godot_vulkan.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
- Helps address https://github.com/godotengine/godot/issues/111218.
- Follow-up to #117286.
- Follow-up to #117295.
- Follow-up to #117301.

Handled Linux, Windows, Android, and (partially) Web.

Platform-specific code is trickier to assess with my simple `clangd-tidy $(find -name "*.cpp" -o -name "*.h")` in a given platform folder, as it will attempt to parse files it doesn't know how to compile / lacks system headers for.
So I generated a `compile_commands.json` for each of the above platforms to deal with their platform folder specifically.

Someone on macOS could look into macOS and iOS/visionOS, I can't easily compile for them on Linux locally.

Also includes reports from `tests`.

*Edit:* Added what I could check from `drivers` on Linux and Windows.