### PR TITLE
Fix empty polygon shape assigned to ShapeCast2D crashing editor on osx

### DIFF
--- a/scene/2d/physics/shape_cast_2d.cpp
+++ b/scene/2d/physics/shape_cast_2d.cpp
@@ -151,9 +151,11 @@ bool ShapeCast2D::is_enabled() const {
 	return enabled;
 }
 
+#ifdef TOOLS_ENABLED
 int ShapeCast2D::_get_draw_steps(real_t p_target_length, real_t p_shape_size) {
 	return p_shape_size > 0.0 ? MAX(2, p_target_length / p_shape_size * 4) : 2;
 }
+#endif
 
 void ShapeCast2D::set_shape(const Ref<Shape2D> &p_shape) {
 	if (p_shape == shape) {

--- a/scene/2d/physics/shape_cast_2d.cpp
+++ b/scene/2d/physics/shape_cast_2d.cpp
@@ -151,6 +151,10 @@ bool ShapeCast2D::is_enabled() const {
 	return enabled;
 }
 
+int ShapeCast2D::_get_draw_steps(real_t p_target_length, real_t p_shape_size) {
+	return p_shape_size > 0.0 ? MAX(2, p_target_length / p_shape_size * 4) : 2;
+}
+
 void ShapeCast2D::set_shape(const Ref<Shape2D> &p_shape) {
 	if (p_shape == shape) {
 		return;
@@ -238,7 +242,7 @@ void ShapeCast2D::_notification(int p_what) {
 				draw_col.b = g;
 			}
 			// Draw continuous chain of shapes along the cast.
-			const int steps = MAX(2, target_position.length() / shape->get_rect().get_size().length() * 4);
+			const int steps = _get_draw_steps(target_position.length(), shape->get_rect().get_size().length());
 			for (int i = 0; i <= steps; ++i) {
 				Vector2 t = (real_t(i) / steps) * target_position;
 				draw_set_transform(t, 0.0, Size2(1, 1));

--- a/scene/2d/physics/shape_cast_2d.h
+++ b/scene/2d/physics/shape_cast_2d.h
@@ -119,7 +119,9 @@ public:
 
 	PackedStringArray get_configuration_warnings() const override;
 
+#ifdef TOOLS_ENABLED
 	static int _get_draw_steps(real_t p_target_length, real_t p_shape_size);
+#endif
 
 	ShapeCast2D();
 };

--- a/scene/2d/physics/shape_cast_2d.h
+++ b/scene/2d/physics/shape_cast_2d.h
@@ -119,5 +119,7 @@ public:
 
 	PackedStringArray get_configuration_warnings() const override;
 
+	static int _get_draw_steps(real_t p_target_length, real_t p_shape_size);
+
 	ShapeCast2D();
 };

--- a/tests/scene/test_shape_cast_2d.cpp
+++ b/tests/scene/test_shape_cast_2d.cpp
@@ -38,6 +38,7 @@ TEST_FORCE_LINK(test_shape_cast_2d)
 
 namespace TestShapeCast2D {
 
+#ifdef TOOLS_ENABLED
 TEST_CASE("[SceneTree][ShapeCast2D] _get_draw_steps returns 2 for zero-size shape") {
 	// Regression: empty ConvexPolygonShape2D and ConcavePolygonShape2D have a zero-size bounding rect.
 	// The step count must fall back to 2 rather than dividing by zero.
@@ -58,6 +59,7 @@ TEST_CASE("[SceneTree][ShapeCast2D] _get_draw_steps scales with target length") 
 	int long_cast = ShapeCast2D::_get_draw_steps(500.0, 10.0);
 	CHECK_LT(short_cast, long_cast);
 }
+#endif // TOOLS_ENABLED
 
 TEST_CASE("[SceneTree][ShapeCast2D] Default shape is null") {
 	ShapeCast2D *cast = memnew(ShapeCast2D);

--- a/tests/scene/test_shape_cast_2d.cpp
+++ b/tests/scene/test_shape_cast_2d.cpp
@@ -1,0 +1,143 @@
+/**************************************************************************/
+/*  test_shape_cast_2d.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_shape_cast_2d)
+
+#include "scene/2d/physics/shape_cast_2d.h"
+#include "scene/resources/2d/convex_polygon_shape_2d.h"
+#include "scene/resources/2d/rectangle_shape_2d.h"
+
+namespace TestShapeCast2D {
+
+TEST_CASE("[SceneTree][ShapeCast2D] _get_draw_steps returns 2 for zero-size shape") {
+	// Regression: empty ConvexPolygonShape2D and ConcavePolygonShape2D have a zero-size bounding rect.
+	// The step count must fall back to 2 rather than dividing by zero.
+	CHECK_EQ(ShapeCast2D::_get_draw_steps(50.0, 0.0), 2);
+}
+
+TEST_CASE("[SceneTree][ShapeCast2D] _get_draw_steps returns 2 for zero target length") {
+	CHECK_EQ(ShapeCast2D::_get_draw_steps(0.0, 10.0), 2);
+}
+
+TEST_CASE("[SceneTree][ShapeCast2D] _get_draw_steps returns at least 2 for normal inputs") {
+	CHECK_GE(ShapeCast2D::_get_draw_steps(50.0, 10.0), 2);
+	CHECK_GE(ShapeCast2D::_get_draw_steps(1.0, 100.0), 2);
+}
+
+TEST_CASE("[SceneTree][ShapeCast2D] _get_draw_steps scales with target length") {
+	int short_cast = ShapeCast2D::_get_draw_steps(50.0, 10.0);
+	int long_cast = ShapeCast2D::_get_draw_steps(500.0, 10.0);
+	CHECK_LT(short_cast, long_cast);
+}
+
+TEST_CASE("[SceneTree][ShapeCast2D] Default shape is null") {
+	ShapeCast2D *cast = memnew(ShapeCast2D);
+
+	CHECK(cast->get_shape().is_null());
+
+	memdelete(cast);
+}
+
+TEST_CASE("[SceneTree][ShapeCast2D] Default target position is non-zero") {
+	ShapeCast2D *cast = memnew(ShapeCast2D);
+
+	// Default target_position is (0, 50); its length must be > 0 for the
+	// division in the draw path to matter at all.
+	CHECK_GT(cast->get_target_position().length(), 0.0f);
+
+	memdelete(cast);
+}
+
+TEST_CASE("[SceneTree][ShapeCast2D] Assigning a null shape clears the shape") {
+	ShapeCast2D *cast = memnew(ShapeCast2D);
+	Ref<RectangleShape2D> rect_shape;
+	rect_shape.instantiate();
+
+	cast->set_shape(rect_shape);
+	CHECK(cast->get_shape() == rect_shape);
+
+	cast->set_shape(Ref<Shape2D>());
+	CHECK(cast->get_shape().is_null());
+
+	memdelete(cast);
+}
+
+TEST_CASE("[SceneTree][ShapeCast2D] Assigning an empty ConvexPolygonShape2D does not crash") {
+	ShapeCast2D *cast = memnew(ShapeCast2D);
+	Ref<ConvexPolygonShape2D> shape;
+	shape.instantiate();
+
+	cast->set_shape(shape);
+	CHECK(cast->get_shape() == shape);
+
+	memdelete(cast);
+}
+
+TEST_CASE("[SceneTree][ShapeCast2D] Assigning a ConvexPolygonShape2D with points does not crash") {
+	ShapeCast2D *cast = memnew(ShapeCast2D);
+	Ref<ConvexPolygonShape2D> shape;
+	shape.instantiate();
+
+	Vector<Vector2> pts;
+	pts.push_back(Vector2(-10, -10));
+	pts.push_back(Vector2(10, -10));
+	pts.push_back(Vector2(0, 10));
+	shape->set_points(pts);
+
+	cast->set_shape(shape);
+	CHECK(cast->get_shape() == shape);
+
+	memdelete(cast);
+}
+
+TEST_CASE("[SceneTree][ShapeCast2D] Configuration warning is emitted when shape is null") {
+	ShapeCast2D *cast = memnew(ShapeCast2D);
+
+	PackedStringArray warnings = cast->get_configuration_warnings();
+	CHECK_GT(warnings.size(), 0);
+
+	memdelete(cast);
+}
+
+TEST_CASE("[SceneTree][ShapeCast2D] No configuration warning when shape is assigned") {
+	ShapeCast2D *cast = memnew(ShapeCast2D);
+	Ref<RectangleShape2D> rect_shape;
+	rect_shape.instantiate();
+	cast->set_shape(rect_shape);
+
+	PackedStringArray warnings = cast->get_configuration_warnings();
+	CHECK_EQ(warnings.size(), 0);
+
+	memdelete(cast);
+}
+
+} // namespace TestShapeCast2D

--- a/tests/scene/test_shape_cast_2d.cpp
+++ b/tests/scene/test_shape_cast_2d.cpp
@@ -61,6 +61,7 @@ TEST_CASE("[SceneTree][ShapeCast2D] _get_draw_steps scales with target length") 
 }
 #endif // TOOLS_ENABLED
 
+#ifndef PHYSICS_2D_DISABLED
 TEST_CASE("[SceneTree][ShapeCast2D] Default shape is null") {
 	ShapeCast2D *cast = memnew(ShapeCast2D);
 
@@ -93,34 +94,6 @@ TEST_CASE("[SceneTree][ShapeCast2D] Assigning a null shape clears the shape") {
 	memdelete(cast);
 }
 
-TEST_CASE("[SceneTree][ShapeCast2D] Assigning an empty ConvexPolygonShape2D does not crash") {
-	ShapeCast2D *cast = memnew(ShapeCast2D);
-	Ref<ConvexPolygonShape2D> shape;
-	shape.instantiate();
-
-	cast->set_shape(shape);
-	CHECK(cast->get_shape() == shape);
-
-	memdelete(cast);
-}
-
-TEST_CASE("[SceneTree][ShapeCast2D] Assigning a ConvexPolygonShape2D with points does not crash") {
-	ShapeCast2D *cast = memnew(ShapeCast2D);
-	Ref<ConvexPolygonShape2D> shape;
-	shape.instantiate();
-
-	Vector<Vector2> pts;
-	pts.push_back(Vector2(-10, -10));
-	pts.push_back(Vector2(10, -10));
-	pts.push_back(Vector2(0, 10));
-	shape->set_points(pts);
-
-	cast->set_shape(shape);
-	CHECK(cast->get_shape() == shape);
-
-	memdelete(cast);
-}
-
 TEST_CASE("[SceneTree][ShapeCast2D] Configuration warning is emitted when shape is null") {
 	ShapeCast2D *cast = memnew(ShapeCast2D);
 
@@ -141,5 +114,6 @@ TEST_CASE("[SceneTree][ShapeCast2D] No configuration warning when shape is assig
 
 	memdelete(cast);
 }
+#endif // PHYSICS_2D_DISABLED
 
 } // namespace TestShapeCast2D


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/97308 and https://github.com/godotengine/godot/issues/117310 (duplicate)

On osx, adding an empty convex/concave polygon shape to a ShapeCast2D crashes the editor, since it attempts to draw `inf` steps (due to a division by zero) in the display and runs out of memory.

This is my first contribution to Godot, so I wasn't sure of best practices around a fix for a bug that relates to the editor draw logic. Since this can't be replicated in the unit tests directly, I extracted the steps count logic into its own function so its result can be tested directly. Also added a few general tests for `shape_cast_2d.cpp` since I couldn't see any existing coverage for this scene.
