### PR TITLE
[4.6] Add editor option to toggle idle parsing

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1519,6 +1519,9 @@
 		<member name="text_editor/completion/idle_parse_delay_with_errors_found" type="float" setter="" getter="">
 			The delay used instead of [member text_editor/completion/idle_parse_delay], when the parser has found errors. A lower value should feel more responsive while fixing code, but may cause notable stuttering and increase CPU usage.
 		</member>
+		<member name="text_editor/completion/idle_parse_enabled" type="bool" setter="" getter="">
+			Whether or not scripts should periodically be parsed when the user stops typing. If enabled, the idle parsing delay is determined by [member text_editor/completion/idle_parse_delay] and [member text_editor/completion/idle_parse_delay_with_errors_found]. Parsing is always performed when the script is saved.
+		</member>
 		<member name="text_editor/completion/put_callhint_tooltip_below_current_line" type="bool" setter="" getter="">
 			If [code]true[/code], the code completion tooltip will appear below the current line unless there is no space on screen below the current line. If [code]false[/code], the code completion tooltip will appear above the current line.
 		</member>

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1010,7 +1010,9 @@ void CodeTextEditor::_text_changed() {
 		code_complete_timer->start();
 	}
 
-	idle->start();
+	if (idle_parse_enabled) {
+		idle->start();
+	}
 
 	if (find_replace_bar) {
 		find_replace_bar->needs_to_count_results = true;
@@ -1160,6 +1162,7 @@ void CodeTextEditor::update_editor_settings() {
 	code_complete_timer->set_wait_time(EDITOR_GET("text_editor/completion/code_complete_delay"));
 	idle_time = EDITOR_GET("text_editor/completion/idle_parse_delay");
 	idle_time_with_errors = EDITOR_GET("text_editor/completion/idle_parse_delay_with_errors_found");
+	idle_parse_enabled = EDITOR_GET("text_editor/completion/idle_parse_enabled");
 
 	// Appearance: Guidelines
 	if (EDITOR_GET("text_editor/appearance/guidelines/show_line_length_guidelines")) {
@@ -1637,12 +1640,16 @@ void CodeTextEditor::_update_font_ligatures() {
 }
 
 void CodeTextEditor::_text_changed_idle_timeout() {
-	_validate_script();
-	emit_signal(SNAME("validate_script"));
+	if (idle_parse_enabled) {
+		_validate_script();
+		emit_signal(SNAME("validate_script"));
+	}
 }
 
 void CodeTextEditor::validate_script() {
-	idle->start();
+	if (idle_parse_enabled) {
+		idle->start();
+	}
 }
 
 void CodeTextEditor::_error_button_pressed() {

--- a/editor/gui/code_editor.h
+++ b/editor/gui/code_editor.h
@@ -178,6 +178,7 @@ class CodeTextEditor : public VBoxContainer {
 	bool code_complete_enabled = true;
 	Timer *code_complete_timer = nullptr;
 	int code_complete_timer_line = 0;
+	bool idle_parse_enabled = true;
 
 	float zoom_factor = 1.0f;
 

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -144,6 +144,24 @@ Vector<String> ScriptTextEditor::get_functions() {
 }
 
 void ScriptTextEditor::apply_code() {
+/*
+	CRE8OR: There is an infinite recursion when ctrl-clicking on a custom class inside a GDScript,
+	caused by:
+		-> ScriptTextEditor::apply_code()
+		-> ScriptTextEditor::_validate_script()
+		-> ... (?)
+		-> ScriptEditor::_update_script_names()
+		-> ScriptEditor::_go_to_tab()
+		-> ScriptTextEditor::apply_code()
+	The following bool prevents apply_code() from being executed twice within the same callstack.
+	TODO: Find a cleaner way to implement this!
+*/
+	if (apply_code_locked) {
+		WARN_PRINT("apply_code() called twice within the same callstack!");
+		return;
+	}
+	apply_code_locked = true;
+
 	if (script.is_null()) {
 		return;
 	}
@@ -154,6 +172,9 @@ void ScriptTextEditor::apply_code() {
 	}
 
 	code_editor->get_text_editor()->get_syntax_highlighter()->update_cache();
+
+	_validate_script();
+	apply_code_locked = false;
 }
 
 Ref<Resource> ScriptTextEditor::get_edited_resource() const {

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -65,6 +65,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 	Variant pending_state;
 	bool script_is_valid = false;
 	bool editor_enabled = false;
+	bool apply_code_locked = false;
 
 	Vector<String> functions;
 	List<ScriptLanguage::Warning> warnings;

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -837,11 +837,12 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_PLACEHOLDER_TEXT, "text_editor/external/exec_flags", "{file}", "Call flags with placeholders: {project}, {file}, {col}, {line}.");
 
 	// Completion
-	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay", 1.5, "0.1,10,0.01")
-	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay_with_errors_found", 0.5, "0.1,5,0.01")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay", 1.5, "0.1,10,0.01");
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay_with_errors_found", 0.5, "0.1,5,0.01");
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/completion/idle_parse_enabled", true, "");
 	_initial_set("text_editor/completion/auto_brace_complete", true, true);
 	_initial_set("text_editor/completion/code_complete_enabled", true, true);
-	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/code_complete_delay", 0.3, "0.01,5,0.01,or_greater")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/code_complete_delay", 0.3, "0.01,5,0.01,or_greater");
 	_initial_set("text_editor/completion/put_callhint_tooltip_below_current_line", true);
 	_initial_set("text_editor/completion/complete_file_paths", true);
 	_initial_set("text_editor/completion/add_type_hints", true, true);


### PR DESCRIPTION
This is a port of my PR #105590 for Godot 4.6. I am making a new PR because it has nearly been a full year since I submitted the previous PR for Godot 4.4, and I figured merging my changes directly into the 4.6 branch would be a better idea.

---

## Quick recap:

This PR adds an editor option to enable (or disable) idle parsing. When disabled, the script editor will no longer perform any idle parsing. It will, however, continue to parse scripts:
- when they are saved, or
- when another script is opened (e.g. by switching through scripts in the script editor).

That first point is worth elaborating on. In upstream 4.6, scripts are not parsed in the script editor upon saving. Instead, you have to wait for the idle parsing timer to complete in order to have your scripts validated/checked for errors. While I didn't aim to address this directly, my idle parse toggling implementation _required_ me to enable parsing on file save, as parsing would otherwise not occur at all. This is good because it has the side effect of making the script editor more intuitive to use, which is a welcome bonus as far as I'm concerned. :stuck_out_tongue: 