### PR TITLE
Add fast path to Polygon2D 

### DIFF
--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -354,7 +354,19 @@ void Polygon2D::_notification(int p_what) {
 				}
 			}
 
-			RS::get_singleton()->mesh_clear(mesh);
+			bool has_uv = uvs.size() == points.size();
+			bool has_color = colors.size() == points.size();
+			bool has_bones = skeleton_node != nullptr;
+
+			bool needs_clear = len != last_len;
+			needs_clear |= index_array.size() != last_index_count;
+			needs_clear |= has_uv != last_has_uv;
+			needs_clear |= has_color != last_has_color;
+			needs_clear |= has_bones || has_bones != last_has_bones;
+
+			if (needs_clear) {
+				RS::get_singleton()->mesh_clear(mesh);
+			}
 
 			if (index_array.size()) {
 				Array arr;
@@ -397,10 +409,24 @@ void Polygon2D::_notification(int p_what) {
 					return;
 				}
 
-				RS::get_singleton()->mesh_add_surface(mesh, sd);
-				RS::get_singleton()->canvas_item_add_mesh(get_canvas_item(), mesh, Transform2D(), Color(1, 1, 1), texture.is_valid() ? texture->get_scaled_rid() : RID());
+				if (needs_clear) {
+					RS::get_singleton()->mesh_add_surface(mesh, sd);
+				} else {
+					RS::get_singleton()->mesh_surface_update_vertex_region(mesh, 0, 0, sd.vertex_data);
+					if (has_uv || has_color) {
+						RS::get_singleton()->mesh_surface_update_attribute_region(mesh, 0, 0, sd.attribute_data);
+					}
+					RS::get_singleton()->mesh_surface_update_index_region(mesh, 0, 0, sd.index_data);
+				}
 			}
 
+			last_len = len;
+			last_index_count = index_array.size();
+			last_has_uv = has_uv;
+			last_has_color = has_color;
+			last_has_bones = has_bones;
+
+			RS::get_singleton()->canvas_item_add_mesh(get_canvas_item(), mesh, Transform2D(), Color(1, 1, 1), texture.is_valid() ? texture->get_scaled_rid() : RID());
 		} break;
 	}
 }

--- a/scene/2d/polygon_2d.h
+++ b/scene/2d/polygon_2d.h
@@ -74,6 +74,11 @@ class Polygon2D : public Node2D {
 	void _skeleton_bone_setup_changed();
 
 	RID mesh;
+	int last_len = 0;
+	int last_index_count = 0;
+	bool last_has_uv = false;
+	bool last_has_color = false;
+	bool last_has_bones = false;
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
This saves a huge amount of time when animating vertices of a Polygon2D manually

Fixes: https://github.com/godotengine/godot/issues/115476
Fixes: https://github.com/godotengine/godot/issues/74540

The fundamental problem is that previously we recreate the internal mesh every frame. With this change we simply update the mesh each frame instead. This new approach is still not optimal, but it gets us most of the potential performance while being very simple and safe. What makes it not optimal is that we are recalculating all the surface data each time, and updating the entire buffer even if only a portion of the buffer needs to be updated. 

An optimal approach would be to go back to the Godot 3.x way of doing things and introduce a new rendering command to render polygons dynamically. The problem with this is it adds a lot of complexity to Polygon2D and would require a new rendering codepath in the renderer. In practice, it probably isn't worth the added complexity when we get most of the benefit with this simple change

So far I have tested this on an M2 MBP. 

MRP from https://github.com/godotengine/godot/issues/115476: 33 FPS -> 101 FPS

MRP from https://github.com/godotengine/godot/issues/74540: 80 objects -> 220 objects