### PR TITLE
Fix macOS Steam time tracking lost when opening a project

### DIFF
--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -820,6 +820,7 @@ Error OS_MacOS::create_process(const String &p_path, const List<String> &p_argum
 			NSWorkspaceOpenConfiguration *configuration = [[NSWorkspaceOpenConfiguration alloc] init];
 			[configuration setArguments:arguments];
 			[configuration setCreatesNewApplicationInstance:YES];
+			[configuration setEnvironment:[[NSProcessInfo processInfo] environment]];
 			__block dispatch_semaphore_t lock = dispatch_semaphore_create(0);
 			__block Error err = ERR_TIMEOUT;
 			__block pid_t pid = 0;
@@ -849,7 +850,11 @@ Error OS_MacOS::create_process(const String &p_path, const List<String> &p_argum
 		} else {
 			Error err = ERR_TIMEOUT;
 			NSError *error = nullptr;
-			NSRunningApplication *app = [[NSWorkspace sharedWorkspace] launchApplicationAtURL:url options:NSWorkspaceLaunchNewInstance configuration:[NSDictionary dictionaryWithObject:arguments forKey:NSWorkspaceLaunchConfigurationArguments] error:&error];
+			NSDictionary *config = @{
+				NSWorkspaceLaunchConfigurationArguments : arguments,
+				NSWorkspaceLaunchConfigurationEnvironment : [[NSProcessInfo processInfo] environment]
+			};
+			NSRunningApplication *app = [[NSWorkspace sharedWorkspace] launchApplicationAtURL:url options:NSWorkspaceLaunchNewInstance configuration:config error:&error];
 			if (error) {
 				err = ERR_CANT_FORK;
 				NSLog(@"Failed to execute: %@", error.localizedDescription);


### PR DESCRIPTION
Fixes #112281.

On macOS, when the Project Manager opens a project, it spawns the Editor via `NSWorkspace`. The `NSWorkspaceOpenConfiguration` object doesn't carry over the parent's environment by default — it gets a clean one from `launchd`. This causes `SteamAppId` (set by the Steam client) to be missing in the Editor process, so `SteamAPI_Init()` silently fails and Steam shows "no longer running."

This passes the parent process environment through to the spawned app instance, matching the behavior on Windows (`CreateProcessW` inherits by default) and Linux (`fork`/`execvp` inherits by default). Both the modern `NSWorkspaceOpenConfiguration` path and the legacy `launchApplicationAtURL:` path (x86_64 pre-10.15) are fixed.