### PR TITLE
Core: Fix `VariantCallable` comparison using identity instead of hash only

### DIFF
--- a/core/variant/variant_callable.cpp
+++ b/core/variant/variant_callable.cpp
@@ -33,11 +33,24 @@
 #include "core/templates/hashfuncs.h"
 
 bool VariantCallable::compare_equal(const CallableCustom *p_a, const CallableCustom *p_b) {
-	return p_a->hash() == p_b->hash();
+	if (p_a->hash() != p_b->hash()) {
+		return false;
+	}
+	const VariantCallable *vca = static_cast<const VariantCallable *>(p_a);
+	const VariantCallable *vcb = static_cast<const VariantCallable *>(p_b);
+	return vca->variant.identity_compare(vcb->variant) && vca->method == vcb->method;
 }
 
 bool VariantCallable::compare_less(const CallableCustom *p_a, const CallableCustom *p_b) {
-	return p_a->hash() < p_b->hash();
+	if (p_a->hash() != p_b->hash()) {
+		return p_a->hash() < p_b->hash();
+	}
+	const VariantCallable *vca = static_cast<const VariantCallable *>(p_a);
+	const VariantCallable *vcb = static_cast<const VariantCallable *>(p_b);
+	if (vca->method != vcb->method) {
+		return vca->method < vcb->method;
+	}
+	return !vca->variant.identity_compare(vcb->variant) && vca->variant.hash() < vcb->variant.hash();
 }
 
 uint32_t VariantCallable::hash() const {

--- a/core/variant/variant_callable.cpp
+++ b/core/variant/variant_callable.cpp
@@ -48,7 +48,7 @@ bool VariantCallable::compare_less(const CallableCustom *p_a, const CallableCust
 	const VariantCallable *vca = static_cast<const VariantCallable *>(p_a);
 	const VariantCallable *vcb = static_cast<const VariantCallable *>(p_b);
 	if (!vca->variant.identity_compare(vcb->variant)) {
-		return vca->variant.hash() < vcb->variant.hash();
+		return vca->variant < vcb->variant;
 	}
 	return vca->method < vcb->method;
 }

--- a/core/variant/variant_callable.cpp
+++ b/core/variant/variant_callable.cpp
@@ -47,10 +47,10 @@ bool VariantCallable::compare_less(const CallableCustom *p_a, const CallableCust
 	}
 	const VariantCallable *vca = static_cast<const VariantCallable *>(p_a);
 	const VariantCallable *vcb = static_cast<const VariantCallable *>(p_b);
-	if (vca->method != vcb->method) {
-		return vca->method < vcb->method;
+	if (!vca->variant.identity_compare(vcb->variant)) {
+		return vca->variant.hash() < vcb->variant.hash();
 	}
-	return !vca->variant.identity_compare(vcb->variant) && vca->variant.hash() < vcb->variant.hash();
+	return vca->method < vcb->method;
 }
 
 uint32_t VariantCallable::hash() const {

--- a/tests/core/variant/test_callable.cpp
+++ b/tests/core/variant/test_callable.cpp
@@ -196,7 +196,7 @@ TEST_CASE("[Callable] Bound and unbound argument count") {
 	memdelete(test_instance);
 }
 
-TEST_CASE("[Callable] VariantCallable equality") {
+TEST_CASE("[Callable] VariantCallable equality and ordering") {
 	// Different arrays with same contents.
 	Array a1 = { 1 };
 	Array a2 = { 1 };
@@ -237,8 +237,9 @@ TEST_CASE("[Callable] VariantCallable equality") {
 	CHECK_FALSE(c_front < c_back);
 
 	// Ordering: different arrays should have a consistent order.
-	CHECK(c1 < c2 || c2 < c1);
-	CHECK_FALSE(c1 < c2 && c2 < c1);
+	bool c1_less = c1 < c2;
+	bool c2_less = c2 < c1;
+	CHECK_NE(c1_less, c2_less);
 }
 
 } // namespace TestCallable

--- a/tests/core/variant/test_callable.cpp
+++ b/tests/core/variant/test_callable.cpp
@@ -236,10 +236,6 @@ TEST_CASE("[Callable] VariantCallable equality and ordering") {
 	CHECK(c_back < c_front); // "back" < "front"
 	CHECK_FALSE(c_front < c_back);
 
-	// Ordering: different arrays should have a consistent order.
-	bool c1_less = c1 < c2;
-	bool c2_less = c2 < c1;
-	CHECK_NE(c1_less, c2_less);
 }
 
 } // namespace TestCallable

--- a/tests/core/variant/test_callable.cpp
+++ b/tests/core/variant/test_callable.cpp
@@ -235,7 +235,6 @@ TEST_CASE("[Callable] VariantCallable equality and ordering") {
 	Callable c_front = Callable(memnew(VariantCallable(a1, "front")));
 	CHECK(c_back < c_front); // "back" < "front"
 	CHECK_FALSE(c_front < c_back);
-
 }
 
 } // namespace TestCallable

--- a/tests/core/variant/test_callable.cpp
+++ b/tests/core/variant/test_callable.cpp
@@ -229,6 +229,16 @@ TEST_CASE("[Callable] VariantCallable equality") {
 	Callable c9 = Callable(memnew(VariantCallable(d1, "clear")));
 	Callable c10 = Callable(memnew(VariantCallable(d2, "clear")));
 	CHECK_NE(c9, c10);
+
+	// Ordering: same array, different methods should be ordered by method name.
+	Callable c_back = Callable(memnew(VariantCallable(a1, "back")));
+	Callable c_front = Callable(memnew(VariantCallable(a1, "front")));
+	CHECK(c_back < c_front); // "back" < "front"
+	CHECK_FALSE(c_front < c_back);
+
+	// Ordering: different arrays should have a consistent order.
+	CHECK(c1 < c2 || c2 < c1);
+	CHECK_FALSE(c1 < c2 && c2 < c1);
 }
 
 } // namespace TestCallable

--- a/tests/core/variant/test_callable.cpp
+++ b/tests/core/variant/test_callable.cpp
@@ -35,6 +35,7 @@ TEST_FORCE_LINK(test_callable)
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/object/object.h"
+#include "core/variant/variant_callable.h"
 
 namespace TestCallable {
 
@@ -193,6 +194,41 @@ TEST_CASE("[Callable] Bound and unbound argument count") {
 	CHECK(get_output(test_func.bind(1, 2, 3).unbind(1).unbind(1).unbind(1)) == "3 3 [1, 2, 3] [1, 2, 3] [1, 2, 3]");
 
 	memdelete(test_instance);
+}
+
+TEST_CASE("[Callable] VariantCallable equality") {
+	// Different arrays with same contents.
+	Array a1 = { 1 };
+	Array a2 = { 1 };
+	Callable c1 = Callable(memnew(VariantCallable(a1, "front")));
+	Callable c2 = Callable(memnew(VariantCallable(a2, "front")));
+	CHECK_NE(c1, c2);
+
+	// Different empty arrays.
+	Array empty1;
+	Array empty2;
+	Callable c3 = Callable(memnew(VariantCallable(empty1, "front")));
+	Callable c4 = Callable(memnew(VariantCallable(empty2, "front")));
+	CHECK_NE(c3, c4);
+
+	// Same array, same method.
+	Callable c5 = Callable(memnew(VariantCallable(a1, "front")));
+	Callable c6 = Callable(memnew(VariantCallable(a1, "front")));
+	CHECK_EQ(c5, c6);
+
+	// Same array, different methods.
+	Callable c7 = Callable(memnew(VariantCallable(a1, "front")));
+	Callable c8 = Callable(memnew(VariantCallable(a1, "back")));
+	CHECK_NE(c7, c8);
+
+	// Different dictionaries with same contents.
+	Dictionary d1;
+	d1["key"] = "value";
+	Dictionary d2;
+	d2["key"] = "value";
+	Callable c9 = Callable(memnew(VariantCallable(d1, "clear")));
+	Callable c10 = Callable(memnew(VariantCallable(d2, "clear")));
+	CHECK_NE(c9, c10);
 }
 
 } // namespace TestCallable


### PR DESCRIPTION
Fixes #116141.
Also related to #97044, which was closed as not-a-bug but had the same underlying cause.

`VariantCallable::compare_equal` compared only hashes, so two different
Variant objects with the same contents (e.g. two distinct arrays `[]` and `[]`)
would be treated as the same callable. This caused a spurious "already connected"
error when connecting signals to methods on different objects that happened to
have equal values.

The fix uses `Variant::identity_compare` after the hash check, so that only
callables referencing the exact same object in memory are considered equal.
`compare_less` had the same hash-only issue and is also fixed.

Includes a unit test covering arrays, empty arrays, dictionaries, same-object
identity, and different-method cases.