### PR TITLE
Fix `EditorPlugin::remove_control_from_docks` freeing passed control

### DIFF
--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -93,6 +93,7 @@ Button *EditorPlugin::add_control_to_bottom_panel(Control *p_control, const Stri
 void EditorPlugin::add_control_to_dock(DockSlot p_slot, Control *p_control, const Ref<Shortcut> &p_shortcut) {
 	ERR_FAIL_NULL(p_control);
 	ERR_FAIL_COND(legacy_docks.has(p_control));
+	ERR_FAIL_COND(p_control->get_parent() != nullptr);
 
 	EditorDock *dock = memnew(EditorDock);
 	dock->set_title(p_control->get_name());
@@ -107,6 +108,9 @@ void EditorPlugin::add_control_to_dock(DockSlot p_slot, Control *p_control, cons
 void EditorPlugin::remove_control_from_docks(Control *p_control) {
 	ERR_FAIL_NULL(p_control);
 	ERR_FAIL_COND(!legacy_docks.has(p_control));
+
+	// Ensure freeing the legacy dock won't free `p_control` (freeing it is up to the user).
+	legacy_docks[p_control]->remove_child(p_control);
 
 	EditorDockManager::get_singleton()->remove_dock(legacy_docks[p_control]);
 	legacy_docks[p_control]->queue_free();


### PR DESCRIPTION
Fixes #117331.

Fixes a regression from #106503 which made `remove_control_from_docks(docked_control)` result in freeing the passed `docked_control`.

After #106503 when a Control is added to a dock with `add_control_from_dock` it is wrapped into an EditorDock node by adding it as its child. On `remove_control_from_docks` such EditorDock is freed, but the wrapped control was never being removed from it, hence it was freed together with its parent. This is a regresion / compatibilty breakage, as `remove_control_from_docks` is documented to not free the passed control and tells clearly it's the user responsibility.

https://github.com/godotengine/godot/blob/9095a76ff54ff96778c75260ac629cd4d1f1535f/doc/classes/EditorPlugin.xml#L681-L686