### PR TITLE
[4.6] Fix EditorDock not reopening

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -496,6 +496,7 @@ void EditorDockManager::_move_dock(EditorDock *p_dock, Control *p_target, int p_
 	}
 
 	if (!p_target) {
+		p_dock->is_open = false;
 		return;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/117331#issuecomment-4042158377 in `4.6` branch (already fixed in `master`/`4.7`).

Bisecting pointed to #115482 which seems mostly unrelated, this PR backports a single line change from that PR which fixes mentioned issue in `4.6` branch for me.