### PR TITLE
Android export: Add error message when ETC2/ASTC compression is not enabled

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -3087,6 +3087,9 @@ bool EditorExportPlatformAndroid::has_valid_project_configuration(const Ref<Edit
 
 	if (!ResourceImporterTextureSettings::should_import_etc2_astc()) {
 		valid = false;
+		if (EditorNode::is_cmdline_mode()) {
+			err += TTR("ETC2/ASTC texture compression is required for Android export. In Project Settings, search for 'ETC2' in the search field, or enable 'Advanced Settings' and go to Rendering > Textures > VRAM Compression to enable 'Import ETC2 ASTC'.") + "\n";
+		}
 	}
 
 	bool gradle_build_enabled = p_preset->get("gradle_build/use_gradle_build");


### PR DESCRIPTION
When `rendering/textures/vram_compression/import_etc2_astc` is disabled in Project Settings, the Android export would silently fail with only a generic "configuration errors" message, giving no indication of what needed to be fixed.

This was especially problematic for headless/CI exports where there is no visual feedback at all.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
