### PR TITLE
Add overwrite confirmation dialog

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2079,6 +2079,48 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 	}
 }
 
+// TODO: Add overwrite check
+void FileSystemDock::_add_dropped_files_recursive(const Vector<String> &p_files, String p_to_path) {
+	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	ERR_FAIL_COND(dir.is_null());
+
+	for (int i = 0; i < p_files.size(); i++) {
+		const String &from = p_files[i];
+		String to = p_to_path.path_join(from.get_file());
+
+		if (dir->dir_exists(from)) {
+			Vector<String> sub_files;
+
+			Ref<DirAccess> sub_dir = DirAccess::open(from);
+			ERR_FAIL_COND(sub_dir.is_null());
+
+			sub_dir->list_dir_begin();
+
+			String next_file = sub_dir->get_next();
+			while (!next_file.is_empty()) {
+				if (next_file == "." || next_file == "..") {
+					next_file = sub_dir->get_next();
+					continue;
+				}
+
+				sub_files.push_back(from.path_join(next_file));
+				next_file = sub_dir->get_next();
+			}
+
+			sub_dir->list_dir_end();
+
+			if (!sub_files.is_empty()) {
+				dir->make_dir(to);
+				_add_dropped_files_recursive(sub_files, to);
+			}
+
+			continue;
+		}
+
+		dir->copy(from, to);
+	}
+}
+
 void FileSystemDock::_before_move(HashSet<String> &r_file_owners) const {
 	HashSet<String> renamed_files;
 	for (int i = 0; i < to_move.size(); i++) {
@@ -2964,6 +3006,10 @@ String FileSystemDock::get_folder_path_at_mouse_position() const {
 	}
 	String fpath = item->get_metadata(0);
 	return fpath.get_base_dir();
+}
+
+void FileSystemDock::handle_external_file_drop(const Vector<String> &p_files, const String &p_to_path) {
+	_add_dropped_files_recursive(p_files, p_to_path);
 }
 
 Control *FileSystemDock::create_tooltip_for_path(const String &p_path) const {

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1731,8 +1731,9 @@ String FileSystemDock::_get_unique_name(const FileOrFolder &p_entry, const Strin
 		new_path = p_at_path.path_join(p_entry.path.get_file());
 		new_path_base = new_path.get_basename() + " (%d)." + new_path.get_extension();
 	} else {
-		PackedStringArray path_split = p_entry.path.split("/");
-		new_path = p_at_path.path_join(path_split[path_split.size() - 2]);
+		String trimmed_path = p_entry.path.trim_suffix("/");
+		PackedStringArray path_split = trimmed_path.split("/");
+		new_path = p_at_path.path_join(path_split[path_split.size() - 1]);
 		new_path_base = new_path + " (%d)";
 	}
 
@@ -2033,11 +2034,25 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 	}
 
 	if (p_copy) {
+		Vector<String> external_files;
+
 		for (int i = 0; i < to_move.size(); i++) {
 			if (to_move[i].path != new_paths[i]) {
-				_try_duplicate_item(to_move[i], new_paths[i]);
+				if (to_move[i].path.begins_with("res://")) {
+					// Copy a project file
+					_try_duplicate_item(to_move[i], new_paths[i]);
+				} else {
+					external_files.push_back(to_move[i].path);
+				}
+
 				select_after_scan = new_paths[i];
 			}
+		}
+
+		if (!external_files.is_empty()) {
+			// Copy external files
+			_add_dropped_files_recursive(external_files, p_to_path, p_overwrite);
+			EditorFileSystem::get_singleton()->scan_changes();
 		}
 	} else {
 		// Check groups.
@@ -2079,8 +2094,7 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 	}
 }
 
-// TODO: Add overwrite check
-void FileSystemDock::_add_dropped_files_recursive(const Vector<String> &p_files, String p_to_path) {
+void FileSystemDock::_add_dropped_files_recursive(const Vector<String> &p_files, String p_to_path, Overwrite p_overwrite) {
 	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	ERR_FAIL_COND(dir.is_null());
 
@@ -2089,6 +2103,10 @@ void FileSystemDock::_add_dropped_files_recursive(const Vector<String> &p_files,
 		String to = p_to_path.path_join(from.get_file());
 
 		if (dir->dir_exists(from)) {
+			if (p_overwrite == OVERWRITE_RENAME) {
+				to = _get_unique_name(FileOrFolder(from, false), p_to_path);
+			}
+
 			Vector<String> sub_files;
 
 			Ref<DirAccess> sub_dir = DirAccess::open(from);
@@ -2109,14 +2127,21 @@ void FileSystemDock::_add_dropped_files_recursive(const Vector<String> &p_files,
 
 			sub_dir->list_dir_end();
 
+			if (!dir->dir_exists(to)) {
+				String to_path_global = ProjectSettings::get_singleton()->globalize_path(to);
+				dir->make_dir(to_path_global);
+			}
+
 			if (!sub_files.is_empty()) {
-				dir->make_dir(to);
-				_add_dropped_files_recursive(sub_files, to);
+				_add_dropped_files_recursive(sub_files, to, p_overwrite);
 			}
 
 			continue;
 		}
 
+		if (p_overwrite == OVERWRITE_RENAME) {
+			to = _get_unique_name(FileOrFolder(from, true), to.get_base_dir());
+		}
 		dir->copy(from, to);
 	}
 }
@@ -3009,7 +3034,30 @@ String FileSystemDock::get_folder_path_at_mouse_position() const {
 }
 
 void FileSystemDock::handle_external_file_drop(const Vector<String> &p_files, const String &p_to_path) {
-	_add_dropped_files_recursive(p_files, p_to_path);
+	to_move.clear();
+
+	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+
+	for (int i = 0; i < p_files.size(); i++) {
+		const String &from = p_files[i];
+		bool is_file = false;
+		if (dir->file_exists(from)) {
+			is_file = true;
+		} else if (!dir->dir_exists(from)) {
+			ERR_PRINT(vformat("Unidentified entry: %s", from));
+			continue;
+		}
+
+		// Fix Windows-style file path
+		String normalized_path = from.replace("\\", "/");
+		to_move.push_back(FileOrFolder(normalized_path, is_file));
+	}
+
+	if (to_move.is_empty()) {
+		return;
+	}
+
+	_move_operation_confirm(p_to_path, true, OVERWRITE_UNDECIDED);
 }
 
 Control *FileSystemDock::create_tooltip_for_path(const String &p_path) const {

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -304,7 +304,7 @@ private:
 	void _find_file_owners(EditorFileSystemDirectory *p_efsd, const HashSet<String> &p_renames, HashSet<String> &r_file_owners) const;
 	void _try_move_item(const FileOrFolder &p_item, const String &p_new_path, HashMap<String, String> &p_file_renames, HashMap<String, String> &p_folder_renames);
 	void _try_duplicate_item(const FileOrFolder &p_item, const String &p_new_path) const;
-	void _add_dropped_files_recursive(const Vector<String> &p_files, String p_to_path);
+	void _add_dropped_files_recursive(const Vector<String> &p_files, String p_to_path, Overwrite p_overwrite);
 	void _before_move(HashSet<String> &r_file_owners) const;
 	void _update_dependencies_after_move(const HashMap<String, String> &p_renames, const HashSet<String> &p_file_owners) const;
 	void _update_resource_paths_after_move(const HashMap<String, String> &p_renames) const;

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/vector.h"
 #include "editor/docks/editor_dock.h"
 #include "editor/file_system/dependency_editor.h"
 #include "editor/file_system/editor_file_system.h"
@@ -303,6 +304,7 @@ private:
 	void _find_file_owners(EditorFileSystemDirectory *p_efsd, const HashSet<String> &p_renames, HashSet<String> &r_file_owners) const;
 	void _try_move_item(const FileOrFolder &p_item, const String &p_new_path, HashMap<String, String> &p_file_renames, HashMap<String, String> &p_folder_renames);
 	void _try_duplicate_item(const FileOrFolder &p_item, const String &p_new_path) const;
+	void _add_dropped_files_recursive(const Vector<String> &p_files, String p_to_path);
 	void _before_move(HashSet<String> &r_file_owners) const;
 	void _update_dependencies_after_move(const HashMap<String, String> &p_renames, const HashSet<String> &p_file_owners) const;
 	void _update_resource_paths_after_move(const HashMap<String, String> &p_renames) const;
@@ -417,6 +419,7 @@ public:
 	String get_current_path() const;
 	String get_current_directory() const;
 	String get_folder_path_at_mouse_position() const;
+	void handle_external_file_drop(const Vector<String> &p_files, const String &p_to_path);
 
 	void navigate_to_path(const String &p_path);
 	void focus_on_path();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6940,11 +6940,8 @@ void EditorNode::_dropped_files(const Vector<String> &p_files) {
 	if (to_path.is_empty()) {
 		to_path = FileSystemDock::get_singleton()->get_current_directory();
 	}
-	to_path = ProjectSettings::get_singleton()->globalize_path(to_path);
 
 	FileSystemDock::get_singleton()->handle_external_file_drop(p_files, to_path);
-
-	EditorFileSystem::get_singleton()->scan_changes();
 }
 
 void EditorNode::_file_access_close_error_notify(const String &p_str) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6942,48 +6942,9 @@ void EditorNode::_dropped_files(const Vector<String> &p_files) {
 	}
 	to_path = ProjectSettings::get_singleton()->globalize_path(to_path);
 
-	_add_dropped_files_recursive(p_files, to_path);
+	FileSystemDock::get_singleton()->handle_external_file_drop(p_files, to_path);
 
 	EditorFileSystem::get_singleton()->scan_changes();
-}
-
-void EditorNode::_add_dropped_files_recursive(const Vector<String> &p_files, String to_path) {
-	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	ERR_FAIL_COND(dir.is_null());
-
-	for (int i = 0; i < p_files.size(); i++) {
-		const String &from = p_files[i];
-		String to = to_path.path_join(from.get_file());
-
-		if (dir->dir_exists(from)) {
-			Vector<String> sub_files;
-
-			Ref<DirAccess> sub_dir = DirAccess::open(from);
-			ERR_FAIL_COND(sub_dir.is_null());
-
-			sub_dir->list_dir_begin();
-
-			String next_file = sub_dir->get_next();
-			while (!next_file.is_empty()) {
-				if (next_file == "." || next_file == "..") {
-					next_file = sub_dir->get_next();
-					continue;
-				}
-
-				sub_files.push_back(from.path_join(next_file));
-				next_file = sub_dir->get_next();
-			}
-
-			if (!sub_files.is_empty()) {
-				dir->make_dir(to);
-				_add_dropped_files_recursive(sub_files, to);
-			}
-
-			continue;
-		}
-
-		dir->copy(from, to);
-	}
 }
 
 void EditorNode::_file_access_close_error_notify(const String &p_str) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -614,7 +614,6 @@ private:
 	void _open_recent_scene(int p_idx);
 
 	void _dropped_files(const Vector<String> &p_files);
-	void _add_dropped_files_recursive(const Vector<String> &p_files, String to_path);
 
 	void _update_vsync_mode();
 	void _update_from_settings();


### PR DESCRIPTION
This commit will close https://github.com/godotengine/godot-proposals/issues/14308
- Fix `_get_unique_name` logic; the previous implementation didn't work for folder path without trailing "/"
- Move `_add_dropped_files_recursive` to filesystem_dock.cpp
- Show overwrite confirmation dialog when file name conflict is detected
- If "Keep Both" is selected, Godot will rename the new files to keep the existing ones

AI assists:
- code research
- `handle_external_file_drop` implementation
- bug fix

<img width="531" height="750" alt="screenshot 2026-03-12 162615" src="https://github.com/user-attachments/assets/71bd6d58-3cdc-41f7-9e82-b65f6277c2d9" />