### PR TITLE
Android: Bump the minimum api version and hardware version for Vulkan support

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -293,6 +293,7 @@ static const char *APK_ASSETS_DIRECTORY = "src/main/assets";
 static const char *AAB_ASSETS_DIRECTORY = "assetPackInstallTime/src/main/assets";
 
 static const int DEFAULT_MIN_SDK_VERSION = 24; // Should match the value in 'platform/android/java/app/config.gradle#minSdk'
+static const int VULKAN_MIN_SDK_VERSION = 29; // Minimum recommended sdk version for Vulkan 1.1 support. See https://developer.android.com/games/develop/vulkan/native-engine-support#recommendations
 static const int DEFAULT_TARGET_SDK_VERSION = 36; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
 
 #ifndef ANDROID_ENABLED
@@ -998,7 +999,7 @@ void EditorExportPlatformAndroid::_get_manifest_info(const Ref<EditorExportPrese
 	}
 
 	if (_uses_vulkan(p_preset)) {
-		// Require vulkan hardware level 1 support
+		// Optionally request vulkan hardware level 1 support.
 		FeatureInfo vulkan_level = {
 			"android.hardware.vulkan.level", // name
 			false, // required
@@ -1006,11 +1007,12 @@ void EditorExportPlatformAndroid::_get_manifest_info(const Ref<EditorExportPrese
 		};
 		r_features.append(vulkan_level);
 
-		// Require vulkan version 1.0
+		// Require vulkan version 1.1 if fallback_to_opengl3 is disabled.
+		bool vulkan_1_1_required = !GLOBAL_GET("rendering/rendering_device/fallback_to_opengl3");
 		FeatureInfo vulkan_version = {
 			"android.hardware.vulkan.version", // name
-			true, // required
-			"0x400003" // version - Encoded value for api version 1.0
+			vulkan_1_1_required, // required
+			"0x401000" // version - Encoded value for api version 1.1
 		};
 		r_features.append(vulkan_version);
 	}
@@ -2080,7 +2082,7 @@ String EditorExportPlatformAndroid::get_export_option_warning(const EditorExport
 			int target_sdk_int = DEFAULT_TARGET_SDK_VERSION;
 
 			String min_sdk_str = p_preset->get("gradle_build/min_sdk");
-			int min_sdk_int = DEFAULT_MIN_SDK_VERSION;
+			int min_sdk_int = VULKAN_MIN_SDK_VERSION;
 			if (min_sdk_str.is_valid_int()) {
 				min_sdk_int = min_sdk_str.to_int();
 			}
@@ -2141,7 +2143,7 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "gradle_build/export_format", PROPERTY_HINT_ENUM, "Export APK,Export AAB"), EXPORT_FORMAT_APK, false, true));
 	// Using String instead of int to default to an empty string (no override) with placeholder for instructions (see GH-62465).
 	// This implies doing validation that the string is a proper int.
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "gradle_build/min_sdk", PROPERTY_HINT_PLACEHOLDER_TEXT, vformat("%d (default)", DEFAULT_MIN_SDK_VERSION)), "", false, true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "gradle_build/min_sdk", PROPERTY_HINT_PLACEHOLDER_TEXT, vformat("%d (default)", VULKAN_MIN_SDK_VERSION)), "", false, true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "gradle_build/target_sdk", PROPERTY_HINT_PLACEHOLDER_TEXT, vformat("%d (default)", DEFAULT_TARGET_SDK_VERSION)), "", false, true));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::DICTIONARY, "gradle_build/custom_theme_attributes", PROPERTY_HINT_DICTIONARY_TYPE, "String;String"), Dictionary()));
@@ -3129,6 +3131,20 @@ bool EditorExportPlatformAndroid::has_valid_project_configuration(const Ref<Edit
 		err += "\n";
 	}
 
+	String min_sdk_str = p_preset->get("gradle_build/min_sdk");
+	int min_sdk_int = VULKAN_MIN_SDK_VERSION;
+	if (!min_sdk_str.is_empty()) { // Empty means no override, nothing to do.
+		if (min_sdk_str.is_valid_int()) {
+			min_sdk_int = min_sdk_str.to_int();
+		}
+	}
+	bool fallback_to_opengl3 = GLOBAL_GET("rendering/rendering_device/fallback_to_opengl3");
+	if (_uses_vulkan(p_preset) && min_sdk_int < VULKAN_MIN_SDK_VERSION && !fallback_to_opengl3) {
+		// Warning only, so don't override `valid`.
+		err += vformat(TTR("\"Min SDK\" should be greater or equal to %d for the \"%s\" renderer."), VULKAN_MIN_SDK_VERSION, current_renderer);
+		err += "\n";
+	}
+
 	String package_name = p_preset->get("package/unique_name");
 	if (package_name.contains("$genname") && !is_project_name_valid(p_preset)) {
 		// Warning only, so don't override `valid`.
@@ -3832,7 +3848,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		String version_name = p_preset->get_version("version/name");
 		String min_sdk_version = p_preset->get("gradle_build/min_sdk");
 		if (!min_sdk_version.is_valid_int()) {
-			min_sdk_version = itos(DEFAULT_MIN_SDK_VERSION);
+			min_sdk_version = itos(VULKAN_MIN_SDK_VERSION);
 		}
 		String target_sdk_version = p_preset->get("gradle_build/target_sdk");
 		if (!target_sdk_version.is_valid_int()) {

--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -81,7 +81,7 @@ android {
         applicationId "org.godotengine.editor.v4"
         versionCode generateVersionCode()
         versionName generateVersionName()
-        minSdkVersion versions.minSdk
+        minSdkVersion 29 // Minimum recommended sdk version for Vulkan 1.1 support. See https://developer.android.com/games/develop/vulkan/native-engine-support#recommendations
         targetSdkVersion versions.targetSdk
 
         missingDimensionStrategy 'products', 'editor'
@@ -187,7 +187,6 @@ android {
             }
             applicationIdSuffix ".pico"
             versionNameSuffix "-pico"
-            minSdkVersion 29
             targetSdkVersion 32
         }
     }

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -17,6 +17,14 @@
         android:glEsVersion="0x00030000"
         android:required="true" />
     <uses-feature
+        android:name="android.hardware.vulkan.version"
+        android:required="true"
+        android:version="0x401000" />
+    <uses-feature
+        android:name="android.hardware.vulkan.level"
+        android:required="true"
+        android:version="1" />
+    <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
@@ -978,8 +978,8 @@ class Godot private constructor(val context: Context) {
 			Log.w(TAG, "The vulkan hardware level does not meet the minimum requirement: 1")
 		}
 
-		// Check for api version 1.0
-		return packageManager.hasSystemFeature(PackageManager.FEATURE_VULKAN_HARDWARE_VERSION, 0x400003)
+		// Check for api version 1.1
+		return packageManager.hasSystemFeature(PackageManager.FEATURE_VULKAN_HARDWARE_VERSION, 0x401000)
 	}
 
 	private fun setKeepScreenOn(enabled: Boolean) {


### PR DESCRIPTION
Follows the recommendations from https://developer.android.com/games/develop/vulkan/native-engine-support#recommendations

This bumps the min supported SDK for the Android editor in order to match the minimum requirements for vulkan support. It also updates the Android editor manifest to require vulkan hardware level 1, and vulkan version 1.1.

For the Android export templates, this also bumps the requirement to vulkan version 1.1 when `fallback_to_opengl3` is disabled. When `fallback_to_opengl3` is enabled, vulkan version 1.1 support is made optional. 

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
