### PR TITLE
Support folding, groups, and subgroups in `Remote Scene Inspector`

### DIFF
--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -34,6 +34,7 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "editor/debugger/editor_debugger_node.h"
+#include "editor/docks/inspector_dock.h"
 #include "editor/docks/scene_tree_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
@@ -419,6 +420,15 @@ void EditorDebuggerTree::select_nodes(const TypedArray<int64_t> &p_ids) {
 	inspected_object_ids = p_ids;
 	scrolling_to_item = true;
 
+	// If we have not previously selected any of these items, expand the inspector's properties for this item.
+	for (ObjectID id : p_ids) {
+		if (!selection_cache.has(id)) {
+			selection_cache.insert(id);
+
+			InspectorDock::get_inspector_singleton()->expand_all_folding();
+		}
+	}
+
 	if (!updating_scene_tree) {
 		// Request a tree refresh.
 		EditorDebuggerNode::get_singleton()->request_remote_tree();
@@ -472,6 +482,11 @@ Variant EditorDebuggerTree::get_drag_data(const Point2 &p_point) {
 	}
 
 	return vformat("\"%s\"", path);
+}
+
+void EditorDebuggerTree::set_new_session() {
+	new_session = true;
+	selection_cache.clear();
 }
 
 void EditorDebuggerTree::update_icon_max_width() {

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -67,6 +67,7 @@ private:
 	bool selection_surpassed_limit = false;
 	bool selection_uncollapse_all = false;
 	HashSet<ObjectID> unfold_cache;
+	HashSet<ObjectID> selection_cache;
 	PopupMenu *item_menu = nullptr;
 	EditorFileDialog *file_dialog = nullptr;
 	AcceptDialog *accept = nullptr;
@@ -93,7 +94,7 @@ public:
 
 	virtual Variant get_drag_data(const Point2 &p_point) override;
 
-	void set_new_session() { new_session = true; }
+	void set_new_session();
 	void update_icon_max_width();
 	String get_selected_path();
 	ObjectID get_selected_object();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3125,7 +3125,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 	}
 
 	// Update the use folding setting and state.
-	bool disable_folding = bool(EDITOR_GET("interface/inspector/disable_folding")) || current_obj->is_class("EditorDebuggerRemoteObjects");
+	bool disable_folding = EDITOR_GET("interface/inspector/disable_folding");
 	if (InspectorDock::get_inspector_singleton()->is_using_folding() == disable_folding) {
 		InspectorDock::get_inspector_singleton()->set_use_folding(!disable_folding, false);
 	}

--- a/scene/debugger/scene_debugger_object.cpp
+++ b/scene/debugger/scene_debugger_object.cpp
@@ -82,7 +82,7 @@ SceneDebuggerObject::SceneDebuggerObject(Object *p_obj) {
 			E.hint_string = _parse_type_from_remote_object(m);
 		}
 
-		if (E.usage & (PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CATEGORY)) {
+		if (E.usage & (PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_CATEGORY)) {
 			properties.push_back(SceneDebuggerProperty(E, m));
 		}
 	}


### PR DESCRIPTION
* Closes https://github.com/godotengine/godot-proposals/issues/14341.

Shows folding (expanded by default), groups and subgroups in the `Remote Scene Inspector` to bring functionality closer to the regular `Scene Inspector`.

| Before | After |
| ------------- | ------------- |
|  <video src=https://github.com/user-attachments/assets/82d6bd24-5b0b-4869-84af-f97421b14ec4></video> | <video src=https://github.com/user-attachments/assets/4f7b8e3c-8aa1-444c-9b57-6d8c8bfac701></video> |



