### PR TITLE
Clean up includes in `drivers/d3d12`

### DIFF
--- a/drivers/d3d12/godot_d3d12ma.h
+++ b/drivers/d3d12/godot_d3d12ma.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  d3d12_hooks.h                                                         */
+/*  godot_d3d12ma.h                                                       */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,19 +30,13 @@
 
 #pragma once
 
-#include <drivers/d3d12/godot_d3dx12.h>
+#include "core/typedefs.h"
 
-class D3D12Hooks {
-private:
-	static D3D12Hooks *singleton;
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wnon-virtual-dtor")
+GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wnon-virtual-dtor")
 
-public:
-	D3D12Hooks();
-	virtual ~D3D12Hooks();
-	virtual D3D_FEATURE_LEVEL get_feature_level() const = 0;
-	virtual LUID get_adapter_luid() const = 0;
-	virtual void set_device(ID3D12Device *p_device) = 0;
-	virtual void set_command_queue(ID3D12CommandQueue *p_queue) = 0;
-	virtual void cleanup_device() = 0;
-	static D3D12Hooks *get_singleton() { return singleton; }
-};
+#define D3D12MA_D3D12_HEADERS_ALREADY_INCLUDED
+#include <thirdparty/d3d12ma/D3D12MemAlloc.h> // IWYU pragma: export.
+
+GODOT_GCC_WARNING_POP
+GODOT_CLANG_WARNING_POP

--- a/drivers/d3d12/godot_d3dx12.h
+++ b/drivers/d3d12/godot_d3dx12.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  d3d12_hooks.h                                                         */
+/*  godot_d3dx12.h                                                        */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,19 +30,17 @@
 
 #pragma once
 
-#include <drivers/d3d12/godot_d3dx12.h>
+#include "core/typedefs.h"
 
-class D3D12Hooks {
-private:
-	static D3D12Hooks *singleton;
+#if !defined(_MSC_VER) && !defined(__REQUIRED_RPCNDR_H_VERSION__)
+// Match current version used by MinGW, MSVC and Direct3D 12 headers use 500.
+#define __REQUIRED_RPCNDR_H_VERSION__ 475
+#endif // !defined(_MSC_VER) && !defined(__REQUIRED_RPCNDR_H_VERSION__)
 
-public:
-	D3D12Hooks();
-	virtual ~D3D12Hooks();
-	virtual D3D_FEATURE_LEVEL get_feature_level() const = 0;
-	virtual LUID get_adapter_luid() const = 0;
-	virtual void set_device(ID3D12Device *p_device) = 0;
-	virtual void set_command_queue(ID3D12CommandQueue *p_queue) = 0;
-	virtual void cleanup_device() = 0;
-	static D3D12Hooks *get_singleton() { return singleton; }
-};
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wnon-virtual-dtor")
+GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wnon-virtual-dtor")
+
+#include <thirdparty/directx_headers/include/directx/d3dx12.h> // IWYU pragma: export.
+
+GODOT_GCC_WARNING_POP
+GODOT_CLANG_WARNING_POP

--- a/drivers/d3d12/godot_nir.h
+++ b/drivers/d3d12/godot_nir.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  d3d12_hooks.h                                                         */
+/*  godot_nir.h                                                           */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,19 +30,21 @@
 
 #pragma once
 
-#include <drivers/d3d12/godot_d3dx12.h>
+#include "core/typedefs.h"
 
-class D3D12Hooks {
-private:
-	static D3D12Hooks *singleton;
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wmissing-field-initializers")
+GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wmissing-field-initializers")
+GODOT_MSVC_WARNING_PUSH
+GODOT_MSVC_WARNING_IGNORE(4200) // "nonstandard extension used: zero-sized array in struct/union".
+GODOT_MSVC_WARNING_IGNORE(4806) // "'&': unsafe operation: no value of type 'bool' promoted to type 'uint32_t' can equal the given constant".
 
-public:
-	D3D12Hooks();
-	virtual ~D3D12Hooks();
-	virtual D3D_FEATURE_LEVEL get_feature_level() const = 0;
-	virtual LUID get_adapter_luid() const = 0;
-	virtual void set_device(ID3D12Device *p_device) = 0;
-	virtual void set_command_queue(ID3D12CommandQueue *p_queue) = 0;
-	virtual void cleanup_device() = 0;
-	static D3D12Hooks *get_singleton() { return singleton; }
-};
+#include <nir_spirv.h>
+#include <nir_to_dxil.h>
+#include <spirv_to_dxil.h>
+extern "C" {
+#include <dxil_spirv_nir.h>
+}
+
+GODOT_GCC_WARNING_POP
+GODOT_CLANG_WARNING_POP
+GODOT_MSVC_WARNING_POP

--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -30,30 +30,19 @@
 
 #include "rendering_context_driver_d3d12.h"
 
-#include "d3d12_hooks.h"
-
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/string/ustring.h"
 #include "core/templates/local_vector.h"
-#include "core/version.h"
+#include "drivers/d3d12/d3d12_hooks.h"
 
-GODOT_GCC_WARNING_PUSH
-GODOT_GCC_WARNING_IGNORE("-Wmissing-field-initializers")
-GODOT_GCC_WARNING_IGNORE("-Wnon-virtual-dtor")
-GODOT_GCC_WARNING_IGNORE("-Wshadow")
-GODOT_GCC_WARNING_IGNORE("-Wswitch")
-GODOT_CLANG_WARNING_PUSH
-GODOT_CLANG_WARNING_IGNORE("-Wmissing-field-initializers")
-GODOT_CLANG_WARNING_IGNORE("-Wnon-virtual-dtor")
-GODOT_CLANG_WARNING_IGNORE("-Wstring-plus-int")
-GODOT_CLANG_WARNING_IGNORE("-Wswitch")
-
+GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wnon-virtual-dtor")
+GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wnon-virtual-dtor")
 #include <dxcapi.h>
-#include <dxgi1_6.h>
-
 GODOT_GCC_WARNING_POP
 GODOT_CLANG_WARNING_POP
+
+#include <dxgi1_6.h>
 
 #if !defined(_MSC_VER)
 #include <guiddef.h>

--- a/drivers/d3d12/rendering_context_driver_d3d12.h
+++ b/drivers/d3d12/rendering_context_driver_d3d12.h
@@ -30,39 +30,11 @@
 
 #pragma once
 
-#include "core/os/mutex.h"
-#include "core/string/ustring.h"
-#include "core/templates/rid_owner.h"
-#include "rendering_device_driver_d3d12.h"
+#include "drivers/d3d12/rendering_device_driver_d3d12.h"
 #include "servers/display/display_server_enums.h"
 #include "servers/rendering/rendering_context_driver.h"
 
-#if !defined(_MSC_VER) && !defined(__REQUIRED_RPCNDR_H_VERSION__)
-// Match current version used by MinGW, MSVC and Direct3D 12 headers use 500.
-#define __REQUIRED_RPCNDR_H_VERSION__ 475
-#endif // !defined(_MSC_VER) && !defined(__REQUIRED_RPCNDR_H_VERSION__)
-
-GODOT_GCC_WARNING_PUSH
-GODOT_GCC_WARNING_IGNORE("-Wimplicit-fallthrough")
-GODOT_GCC_WARNING_IGNORE("-Wmissing-field-initializers")
-GODOT_GCC_WARNING_IGNORE("-Wnon-virtual-dtor")
-GODOT_GCC_WARNING_IGNORE("-Wshadow")
-GODOT_GCC_WARNING_IGNORE("-Wswitch")
-GODOT_CLANG_WARNING_PUSH
-GODOT_CLANG_WARNING_IGNORE("-Wimplicit-fallthrough")
-GODOT_CLANG_WARNING_IGNORE("-Wmissing-field-initializers")
-GODOT_CLANG_WARNING_IGNORE("-Wnon-virtual-dtor")
-GODOT_CLANG_WARNING_IGNORE("-Wstring-plus-int")
-GODOT_CLANG_WARNING_IGNORE("-Wswitch")
-
-#include <thirdparty/directx_headers/include/directx/d3dx12.h>
-
-GODOT_GCC_WARNING_POP
-GODOT_CLANG_WARNING_POP
-
-#if defined(AS)
-#undef AS
-#endif
+#include <drivers/d3d12/godot_d3dx12.h>
 
 #ifdef DCOMP_ENABLED
 #include <dcomp.h>

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -30,50 +30,16 @@
 
 #include "rendering_device_driver_d3d12.h"
 
-#include "d3d12_hooks.h"
-
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
-#include "core/io/marshalls.h"
 #include "core/os/os.h"
-
-#include "thirdparty/zlib/zlib.h"
-
-#include "d3d12_godot_nir_bridge.h"
-#include "rendering_context_driver_d3d12.h"
-
-GODOT_GCC_WARNING_PUSH
-GODOT_GCC_WARNING_IGNORE("-Wimplicit-fallthrough")
-GODOT_GCC_WARNING_IGNORE("-Wlogical-not-parentheses")
-GODOT_GCC_WARNING_IGNORE("-Wmissing-field-initializers")
-GODOT_GCC_WARNING_IGNORE("-Wnon-virtual-dtor")
-GODOT_GCC_WARNING_IGNORE("-Wshadow")
-GODOT_GCC_WARNING_IGNORE("-Wswitch")
-GODOT_CLANG_WARNING_PUSH
-GODOT_CLANG_WARNING_IGNORE("-Wimplicit-fallthrough")
-GODOT_CLANG_WARNING_IGNORE("-Wlogical-not-parentheses")
-GODOT_CLANG_WARNING_IGNORE("-Wmissing-field-initializers")
-GODOT_CLANG_WARNING_IGNORE("-Wnon-virtual-dtor")
-GODOT_CLANG_WARNING_IGNORE("-Wstring-plus-int")
-GODOT_CLANG_WARNING_IGNORE("-Wswitch")
-GODOT_MSVC_WARNING_PUSH
-GODOT_MSVC_WARNING_IGNORE(4200) // "nonstandard extension used: zero-sized array in struct/union".
-GODOT_MSVC_WARNING_IGNORE(4806) // "'&': unsafe operation: no value of type 'bool' promoted to type 'uint32_t' can equal the given constant".
+#include "drivers/d3d12/d3d12_hooks.h"
+#include "drivers/d3d12/rendering_context_driver_d3d12.h"
 
 #include <dxgi1_6.h>
-#define D3D12MA_D3D12_HEADERS_ALREADY_INCLUDED
-#include <thirdparty/d3d12ma/D3D12MemAlloc.h>
-
-#include <nir_spirv.h>
-#include <nir_to_dxil.h>
-#include <spirv_to_dxil.h>
-extern "C" {
-#include <dxil_spirv_nir.h>
-}
-
-GODOT_GCC_WARNING_POP
-GODOT_CLANG_WARNING_POP
-GODOT_MSVC_WARNING_POP
+// Ensure d3dx12 and dxgi are included first.
+#include <drivers/d3d12/godot_d3d12ma.h>
+#include <drivers/d3d12/godot_nir.h>
 
 #if !defined(_MSC_VER)
 #include <guiddef.h>

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -35,31 +35,10 @@
 #include "core/templates/paged_allocator.h"
 #include "core/templates/rb_map.h"
 #include "core/templates/self_list.h"
-#include "rendering_shader_container_d3d12.h"
+#include "drivers/d3d12/rendering_shader_container_d3d12.h"
 #include "servers/rendering/rendering_device_driver.h"
 
-#if !defined(_MSC_VER) && !defined(__REQUIRED_RPCNDR_H_VERSION__)
-// Match current version used by MinGW, MSVC and Direct3D 12 headers use 500.
-#define __REQUIRED_RPCNDR_H_VERSION__ 475
-#endif // !defined(_MSC_VER) && !defined(__REQUIRED_RPCNDR_H_VERSION__)
-
-GODOT_GCC_WARNING_PUSH
-GODOT_GCC_WARNING_IGNORE("-Wimplicit-fallthrough")
-GODOT_GCC_WARNING_IGNORE("-Wmissing-field-initializers")
-GODOT_GCC_WARNING_IGNORE("-Wnon-virtual-dtor")
-GODOT_GCC_WARNING_IGNORE("-Wshadow")
-GODOT_GCC_WARNING_IGNORE("-Wswitch")
-GODOT_CLANG_WARNING_PUSH
-GODOT_CLANG_WARNING_IGNORE("-Wimplicit-fallthrough")
-GODOT_CLANG_WARNING_IGNORE("-Wmissing-field-initializers")
-GODOT_CLANG_WARNING_IGNORE("-Wnon-virtual-dtor")
-GODOT_CLANG_WARNING_IGNORE("-Wstring-plus-int")
-GODOT_CLANG_WARNING_IGNORE("-Wswitch")
-
-#include <thirdparty/directx_headers/include/directx/d3dx12.h>
-
-GODOT_GCC_WARNING_POP
-GODOT_CLANG_WARNING_POP
+#include <drivers/d3d12/godot_d3dx12.h>
 
 #include <wrl/client.h>
 

--- a/drivers/d3d12/rendering_shader_container_d3d12.cpp
+++ b/drivers/d3d12/rendering_shader_container_d3d12.cpp
@@ -31,49 +31,22 @@
 #include "rendering_shader_container_d3d12.h"
 
 #include "core/templates/sort_array.h"
+#include "drivers/d3d12/dxil_hash.h"
 
-#include "dxil_hash.h"
-
-#include <zlib.h>
-
-GODOT_GCC_WARNING_PUSH
-GODOT_GCC_WARNING_IGNORE("-Wimplicit-fallthrough")
-GODOT_GCC_WARNING_IGNORE("-Wlogical-not-parentheses")
-GODOT_GCC_WARNING_IGNORE("-Wmissing-field-initializers")
-GODOT_GCC_WARNING_IGNORE("-Wnon-virtual-dtor")
-GODOT_GCC_WARNING_IGNORE("-Wshadow")
-GODOT_GCC_WARNING_IGNORE("-Wswitch")
-GODOT_CLANG_WARNING_PUSH
-GODOT_CLANG_WARNING_IGNORE("-Wimplicit-fallthrough")
-GODOT_CLANG_WARNING_IGNORE("-Wlogical-not-parentheses")
-GODOT_CLANG_WARNING_IGNORE("-Wmissing-field-initializers")
-GODOT_CLANG_WARNING_IGNORE("-Wnon-virtual-dtor")
-GODOT_CLANG_WARNING_IGNORE("-Wstring-plus-int")
-GODOT_CLANG_WARNING_IGNORE("-Wswitch")
-GODOT_MSVC_WARNING_PUSH
-GODOT_MSVC_WARNING_IGNORE(4200) // "nonstandard extension used: zero-sized array in struct/union".
-GODOT_MSVC_WARNING_IGNORE(4806) // "'&': unsafe operation: no value of type 'bool' promoted to type 'uint32_t' can equal the given constant".
-
+#include <drivers/d3d12/godot_d3dx12.h>
 #include <dxgi1_6.h>
-#include <thirdparty/directx_headers/include/directx/d3dx12.h>
-#define D3D12MA_D3D12_HEADERS_ALREADY_INCLUDED
-#include <thirdparty/d3d12ma/D3D12MemAlloc.h>
+// Include d3dx12 and dxgi before d3d12ma.
+#include <drivers/d3d12/godot_d3d12ma.h>
+#include <drivers/d3d12/godot_nir.h>
 
 #include <wrl/client.h>
 
-#include <nir_spirv.h>
-#include <nir_to_dxil.h>
-#include <spirv_to_dxil.h>
-extern "C" {
-#include <dxil_spirv_nir.h>
+#include <zlib.h>
 
+extern "C" {
 void dxil_reassign_driver_locations(nir_shader *s, nir_variable_mode modes,
 		uint64_t other_stage_mask, const BITSET_WORD *other_stage_frac_mask);
 }
-
-GODOT_GCC_WARNING_POP
-GODOT_CLANG_WARNING_POP
-GODOT_MSVC_WARNING_POP
 
 // SPIR-V to DXIL does way too many allocations, which causes worker threads
 // to bottleneck each other due to sharing the same global process heap.

--- a/drivers/d3d12/rendering_shader_container_d3d12.h
+++ b/drivers/d3d12/rendering_shader_container_d3d12.h
@@ -38,7 +38,7 @@
 #undef NIR_ENABLED
 #endif
 
-#include "d3d12_godot_nir_bridge.h"
+#include "drivers/d3d12/d3d12_godot_nir_bridge.h"
 
 #define D3D12_BITCODE_OFFSETS_NUM_STAGES 3
 

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -561,5 +561,3 @@ protected:
 public:
 	AudioBusLayout();
 };
-
-typedef AudioServer AS;


### PR DESCRIPTION
- Extracted from #117328.

While working on the above PR I took the chance to refactor the `drivers/d3d12` code a bit to wrap some thirdparty headers that require specific pragmas or definitions, which adds `godot_d3dx12.h`, `godot_d3d12ma.h`, and `godot_nir.h`. These new wrapper headers should be included with angled brackets to be properly treated as "system"/thirdparty, which avoids some diagnostics to show up with clangd.

I also cleaned up the pragmas to reduce them to what seems to be the minimal changes to compile (possibly some of these warnings were solved in D3D12/Mesa). Needs testing, especially with MSVC as I only tested mingw-gcc and llvm-mingw from Linux.

I removed the `AS` typedef for AudioServer as we don't use it and it caused a `-Wshadow` warning in one of the thirdparty D3D12 headers.