### PR TITLE
Improve `OS.is_process_running` error messages.

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -857,8 +857,8 @@ bool OS_Unix::_check_pid_is_running(const pid_t p_pid, int *r_status) const {
 		// Thread is still running.
 		return true;
 	}
-
-	ERR_FAIL_COND_V_MSG(result != 0, false, vformat("Thread %d exited with errno: %d", (int)p_pid, errno));
+	ERR_FAIL_COND_V_MSG(result != 0 && errno == ECHILD, false, vformat("The process %d does not exist or is not a child of the calling process.", (int)p_pid));
+	ERR_FAIL_COND_V_MSG(result != 0, false, vformat("waitpid for process %d failed with errno: %d", (int)p_pid, errno));
 
 	// Thread exited normally.
 	status = WIFEXITED(status) ? WEXITSTATUS(status) : status;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/117315