### PR TITLE
Fix undoing terrain set move duplicates terrain in second set

### DIFF
--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -92,6 +92,13 @@
 				Clears tile proxies pointing to invalid tiles.
 			</description>
 		</method>
+		<method name="clear_terrains">
+			<return type="void" />
+			<param index="0" name="terrain_set" type="int" />
+			<description>
+				Clears all terrain properties for the given terrain set.
+			</description>
+		</method>
 		<method name="clear_tile_proxies">
 			<return type="void" />
 			<description>

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -544,6 +544,14 @@ void TileSetEditor::_move_tile_set_array_element(Object *p_undo_redo, Object *p_
 		}
 	}
 
+	// Terrain sets have a variable number of properties.
+	// Clearing terrain properties is needed to ensure UNDO works correctly.
+	if (p_array_prefix == "terrain_set_" && p_from_index >= 0 && p_to_pos >= 0) {
+		for (int i = begin; i < end; i++) {
+			undo_redo_man->add_undo_method(ed_tile_set, "clear_terrains", i);
+		}
+	}
+
 	// Save layers' properties.
 	List<PropertyInfo> properties;
 	ed_tile_set->get_property_list(&properties);

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -847,6 +847,22 @@ void TileSet::remove_terrain(int p_terrain_set, int p_index) {
 	emit_changed();
 }
 
+void TileSet::clear_terrains(int p_terrain_set) {
+	ERR_FAIL_INDEX(p_terrain_set, terrain_sets.size());
+	Vector<Terrain> &terrains = terrain_sets.write[p_terrain_set].terrains;
+
+	int terrain_count = terrains.size();
+	for (KeyValue<int, Ref<TileSetSource>> source : sources) {
+		for (int i = terrain_count - 1; i >= 0; i--) {
+			source.value->remove_terrain(p_terrain_set, i);
+		}
+	}
+	terrains.clear();
+	notify_property_list_changed();
+	terrains_cache_dirty = true;
+	emit_changed();
+}
+
 void TileSet::set_terrain_name(int p_terrain_set, int p_terrain_index, String p_name) {
 	ERR_FAIL_INDEX(p_terrain_set, terrain_sets.size());
 	ERR_FAIL_INDEX(p_terrain_index, terrain_sets[p_terrain_set].terrains.size());
@@ -4314,6 +4330,7 @@ void TileSet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_terrain", "terrain_set", "to_position"), &TileSet::add_terrain, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("move_terrain", "terrain_set", "terrain_index", "to_position"), &TileSet::move_terrain);
 	ClassDB::bind_method(D_METHOD("remove_terrain", "terrain_set", "terrain_index"), &TileSet::remove_terrain);
+	ClassDB::bind_method(D_METHOD("clear_terrains", "terrain_set"), &TileSet::clear_terrains);
 	ClassDB::bind_method(D_METHOD("set_terrain_name", "terrain_set", "terrain_index", "name"), &TileSet::set_terrain_name);
 	ClassDB::bind_method(D_METHOD("get_terrain_name", "terrain_set", "terrain_index"), &TileSet::get_terrain_name);
 	ClassDB::bind_method(D_METHOD("set_terrain_color", "terrain_set", "terrain_index", "color"), &TileSet::set_terrain_color);

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -475,6 +475,7 @@ public:
 	void add_terrain(int p_terrain_set, int p_index = -1);
 	void move_terrain(int p_terrain_set, int p_from_index, int p_to_pos);
 	void remove_terrain(int p_terrain_set, int p_index);
+	void clear_terrains(int p_terrain_set);
 	void set_terrain_name(int p_terrain_set, int p_terrain_index, String p_name);
 	String get_terrain_name(int p_terrain_set, int p_terrain_index) const;
 	void set_terrain_color(int p_terrain_set, int p_terrain_index, Color p_color);


### PR DESCRIPTION
Fixes: #116636 

## Bug Preview

https://github.com/user-attachments/assets/4b831ab7-a54d-4aeb-95d6-5b948c5990c2

## Cause

The issue was caused by the undo system restoring terrain properties without clearing the existing terrain container first. Because of this, the previous terrain state was effectively applied on top of the current one, leading to duplicated or mismatched terrain data.

## Fix

This PR fixes the problem by clearing the terrains in the affected terrain sets before restoring their properties during undo. This ensures the terrain containers are rebuilt from the saved undo state instead of being merged with the current state.

https://github.com/user-attachments/assets/b3c86048-a57b-47e3-be3d-8d36ebdea7c4