### PR TITLE
Fix error on opening script after documentation

### DIFF
--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -133,8 +133,6 @@ void TextEditorBase::EditMenus::_change_syntax_highlighter(int p_idx) {
 }
 
 void TextEditorBase::EditMenus::_update_bookmark_list() {
-	TextEditorBase *script_text_editor = _get_active_editor();
-	ERR_FAIL_NULL(script_text_editor);
 	bookmarks_menu->clear();
 	bookmarks_menu->reset_size();
 
@@ -142,6 +140,11 @@ void TextEditorBase::EditMenus::_update_bookmark_list() {
 	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/remove_all_bookmarks"), BOOKMARK_REMOVE_ALL);
 	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_bookmark"), BOOKMARK_GOTO_NEXT);
 	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_bookmark"), BOOKMARK_GOTO_PREV);
+
+	TextEditorBase *script_text_editor = _get_active_editor();
+	if (script_text_editor == nullptr) {
+		return;
+	}
 
 	PackedInt32Array bookmark_list = script_text_editor->code_editor->get_text_editor()->get_bookmarked_lines();
 	if (bookmark_list.is_empty()) {

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -135,8 +135,6 @@ ConnectionInfoDialog::ConnectionInfoDialog() {
 ////////////////////////////////////////////////////////////////////////////////
 
 void ScriptTextEditor::EditMenusSTE::_update_breakpoint_list() {
-	TextEditorBase *script_text_editor = _get_active_editor();
-	ERR_FAIL_NULL(script_text_editor);
 	breakpoints_menu->clear();
 	breakpoints_menu->reset_size();
 
@@ -144,6 +142,11 @@ void ScriptTextEditor::EditMenusSTE::_update_breakpoint_list() {
 	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/remove_all_breakpoints"), DEBUG_REMOVE_ALL_BREAKPOINTS);
 	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_breakpoint"), DEBUG_GOTO_NEXT_BREAKPOINT);
 	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_breakpoint"), DEBUG_GOTO_PREV_BREAKPOINT);
+
+	TextEditorBase *script_text_editor = _get_active_editor();
+	if (script_text_editor == nullptr) {
+		return;
+	}
 
 	PackedInt32Array breakpoint_list = script_text_editor->get_code_editor()->get_text_editor()->get_breakpointed_lines();
 	if (breakpoint_list.is_empty()) {


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/117356

Removed the error print for these.
The shortcuts need to be set up and they don't need to be the active editor for that. When this is called it may not be the active editor in some cases.