### PR TITLE
Limit dragging BlendSpace points to bounds

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -189,6 +189,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 				if (snap->is_pressed()) {
 					point = Math::snapped(point, blend_space->get_snap());
 				}
+				point = CLAMP(point, blend_space->get_min_space(), blend_space->get_max_space());
 
 				updating = true;
 				EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
@@ -334,6 +335,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 			if (snap->is_pressed()) {
 				point = Math::snapped(point, blend_space->get_snap());
 			}
+			point = CLAMP(point, blend_space->get_min_space(), blend_space->get_max_space());
 		}
 
 		point = (point - blend_space->get_min_space()) / (blend_space->get_max_space() - blend_space->get_min_space());
@@ -566,6 +568,7 @@ void AnimationNodeBlendSpace1DEditor::_update_edited_point_pos() {
 			if (snap->is_pressed()) {
 				pos = Math::snapped(pos, blend_space->get_snap());
 			}
+			pos = CLAMP(pos, blend_space->get_min_space(), blend_space->get_max_space());
 		}
 
 		updating = true;

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -286,6 +286,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 			if (snap->is_pressed()) {
 				point = point.snapped(blend_space->get_snap());
 			}
+			point = point.clamp(blend_space->get_min_space(), blend_space->get_max_space());
 
 			if (!read_only) {
 				updating = true;
@@ -598,6 +599,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 				if (snap->is_pressed()) {
 					point = point.snapped(blend_space->get_snap());
 				}
+				point = point.clamp(blend_space->get_min_space(), blend_space->get_max_space());
 			}
 			point = (point - blend_space->get_min_space()) / (blend_space->get_max_space() - blend_space->get_min_space());
 			point *= s;
@@ -634,6 +636,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 			if (snap->is_pressed()) {
 				point = point.snapped(blend_space->get_snap());
 			}
+			point = point.clamp(blend_space->get_min_space(), blend_space->get_max_space());
 		}
 
 		point = (point - blend_space->get_min_space()) / (blend_space->get_max_space() - blend_space->get_min_space());
@@ -865,6 +868,7 @@ void AnimationNodeBlendSpace2DEditor::_update_edited_point_pos() {
 			if (snap->is_pressed()) {
 				pos = pos.snapped(blend_space->get_snap());
 			}
+			pos = pos.clamp(blend_space->get_min_space(), blend_space->get_max_space());
 		}
 		updating = true;
 		edit_x->set_value(pos.x);


### PR DESCRIPTION
Closes #79058.

There's a further improvement to be made here: which would involve expanding the invisible margins of the BlendSpace control, and therefore could allow blend points on the edge to be easier to select, without the cursor needing to be on the "correct" side. But that is a lot more code and is better saved for a follow-up proposal/PR.