### PR TITLE
Allow for an easy way to pass JVM and activity references to GDExtensions

### DIFF
--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -261,6 +261,19 @@ Error OS_Android::open_dynamic_library(const String &p_path, void *&p_library_ha
 		*p_data->r_resolved_path = path;
 	}
 
+	// If a library requests for JVM and main activity, provide it those data
+	typedef void (*RequestFunc)(JavaVM *, jobject);
+	RequestFunc request_func = (RequestFunc)dlsym(p_library_handle, "request_java_ref");
+	if (request_func) {
+		JNIEnv *env = get_jni_env();
+		JavaVM *jvm = nullptr;
+		if (godot_java && env) {
+			env->GetJavaVM(&jvm);
+			jobject activity = godot_java->get_activity();
+			request_func(jvm, activity);
+		}
+	}
+
 	return OK;
 }
 


### PR DESCRIPTION
The idea behind this PR is to add an easy way to access the main activity and Java VM that are inited by Godot in gdextensions. As of now, one is forced to create a whole plugin to achieve this goal, which most of the time is quite overengineered of a solution. This PR adds a function that can be exposed by gdextensions (`request_java_ref`, although i'm not sure if the naming here must follow some speicifc standard and thus another name is more appropriate) that, when found in the symtable of a loaded so, gets automatically called with references to the JVM and the godot activity. This way a gdextension can get references to those with a code as simple as this (showcasing an example with FMOD initialization that requires such references on Android to correctly init):

```
extern "C" {
#include <jni.h>
#include <fmod_android.h>
}

static JavaVM* _jvm = nullptr;
static jobject _activity = nullptr;

extern "C" JNIEXPORT void request_java_ref(JavaVM *jvm, jobject activity) {
    _jvm = jvm;
    _activity = activity;
}

void init_fmod() {
   FMOD_Android_JNI_Init(_jvm, _activity);
}
```