### PR TITLE
Add @bitfield annotation for enums

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -416,14 +416,31 @@ static void _add_type_to_rt(const String &p_type, const String &p_enum, bool p_i
 	}
 
 	bool is_enum_type = !p_enum.is_empty();
-	bool is_bitfield = p_is_bitfield && is_enum_type;
+	bool is_bitfield = (p_is_bitfield || p_enum.begins_with("BitField[")) && is_enum_type;
 	bool can_ref = !p_type.contains_char('*') || is_enum_type;
 
 	String link_t = p_type; // For links in metadata
 	String display_t; // For display purposes.
+
 	if (is_enum_type) {
-		link_t = p_enum; // The link for enums is always the full enum description
-		display_t = _contextualize_class_specifier(p_enum, p_class);
+		// When stringified, it's possible for enums to be BitField[EnumName] if they're a bitfield,
+		// so we need to remove BitField[], for it to show the proper BitField text and tooltip in the UI,
+		// and for the enum name to contextualize properly.
+		String enum_name = String(p_enum);
+		if (is_bitfield) {
+			// As a side effect, this also handles arrays
+			enum_name = enum_name.trim_prefix("BitField[").replace_first("]", "");
+		}
+		display_t = _contextualize_class_specifier(enum_name, p_class);
+
+		// Handle dictionaries of bitfields
+		if (link_t.begins_with("Dictionary[")) {
+			// Dictionaries get bitfield types as BitField[EnumName] to figure out which type should get the BitField text.
+			link_t = link_t.replace("int", vformat("BitField[%s]", enum_name));
+			display_t = link_t;
+		} else {
+			link_t = enum_name; // The link for enums is always the full enum description, without BitField[]
+		}
 	} else {
 		display_t = _contextualize_class_specifier(p_type, p_class);
 	}
@@ -449,14 +466,49 @@ static void _add_type_to_rt(const String &p_type, const String &p_enum, bool p_i
 			p_rt->add_text("Dictionary");
 			p_rt->pop(); // meta
 			p_rt->add_text("[");
-			p_rt->push_meta("#" + link_t.get_slice(", ", 0), RichTextLabel::META_UNDERLINE_ON_HOVER); // class
-			p_rt->add_text(_contextualize_class_specifier(display_t.get_slice(", ", 0), p_class));
+
+			// Handle the first type of the dictionary, text for this one gets added immediately
+			is_bitfield = display_t.get_slice(", ", 0).contains("BitField[");
+
+			if (is_bitfield) {
+				String slice = display_t.get_slice(", ", 0).trim_prefix("BitField[").replace_first("]", "");
+
+				p_rt->push_color(Color(type_color, 0.5));
+				p_rt->push_hint(TTR("This value is an integer composed as a bitmask of the following flags."));
+				p_rt->add_text("BitField");
+				p_rt->pop(); // hint
+				p_rt->add_text("[");
+				p_rt->pop(); // color
+
+				p_rt->push_meta("$" + slice, RichTextLabel::META_UNDERLINE_ON_HOVER); // enum
+				p_rt->add_text(_contextualize_class_specifier(slice, p_class));
+
+				p_rt->push_color(Color(type_color, 0.5));
+				p_rt->add_text("]");
+				p_rt->pop(); // color
+			} else {
+				p_rt->push_meta("#" + link_t.get_slice(", ", 0), RichTextLabel::META_UNDERLINE_ON_HOVER); // class
+				p_rt->add_text(_contextualize_class_specifier(display_t.get_slice(", ", 0), p_class));
+			}
+
 			p_rt->pop(); // meta
 			p_rt->add_text(", ");
 
-			link_t = link_t.get_slice(", ", 1);
-			display_t = _contextualize_class_specifier(display_t.get_slice(", ", 1), p_class);
-		} else if (is_bitfield) {
+			is_bitfield = display_t.get_slice(", ", 1).contains("BitField[");
+
+			// Handle second type of the dictionary, text for this one gets added later on
+			if (is_bitfield) {
+				String slice = display_t.get_slice(", ", 1).trim_prefix("BitField[").replace_first("]", "");
+				link_t = slice;
+				display_t = _contextualize_class_specifier(slice, p_class);
+			} else {
+				link_t = link_t.get_slice(", ", 1);
+				display_t = _contextualize_class_specifier(display_t.get_slice(", ", 1), p_class);
+				// If is_bitfield was ever true, then this is also true, and it will mess up the meta to link to the second type of the dict
+				is_enum_type = false;
+			}
+		}
+		if (is_bitfield) {
 			p_rt->push_color(Color(type_color, 0.5));
 			p_rt->push_hint(TTR("This value is an integer composed as a bitmask of the following flags."));
 			p_rt->add_text("BitField");
@@ -474,12 +526,13 @@ static void _add_type_to_rt(const String &p_type, const String &p_enum, bool p_i
 	p_rt->add_text(display_t);
 	if (can_ref) {
 		p_rt->pop(); // meta
-		if (add_typed_container) {
-			p_rt->add_text("]");
-		} else if (is_bitfield) {
+		if (is_bitfield) {
 			p_rt->push_color(Color(type_color, 0.5));
 			p_rt->add_text("]");
 			p_rt->pop(); // color
+		}
+		if (add_typed_container) {
+			p_rt->add_text("]");
 		}
 	}
 	p_rt->pop(); // color

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -317,6 +317,33 @@
 				[/codeblock]
 			</description>
 		</annotation>
+        <annotation name="@bitfield">
+            <return type="void" />
+            <description>
+                Marks an enum as a bitfield.
+                Automatically assigns all values of the enum to [code]2^n[/code], while still respecting manually defined values. Variables with the same type as the bitfield enum will automatically have [constant PROPERTY_HINT_FLAGS] when exported, allowing for easier exporting of bitfields. Those same variables will automatically show their type as being [code]BitField[EnumName][/code] in documentation, similar to bitfields defined in the engine.
+                When returning or exporting the bitfield enum, the warnings [member ProjectSettings.debug/gdscript/warnings/int_as_enum_without_cast], [member ProjectSettings.debug/gdscript/warnings/int_as_enum_without_cast] and [member ProjectSettings.debug/gdscript/warnings/enum_variable_without_default] automatically get ignored for easier use.
+                See also [annotation @export_flags].
+                [codeblock]
+                @bitfield
+                enum Type {
+                    FIRE,  # Value: 1
+                    ICE,   # Value: 2
+                    WATER, # Value: 4
+                    WIND,  # Value: 8
+                    EARTH  # Value: 16
+                }
+
+                @export var type: Type # Ignores the ENUM_VARIABLE_WITHOUT_DEFAULT warning
+
+                # Has the same effect as above, but can be more annoying to use
+                @export_flags("Fire", "Ice", "Water", "Wind", "Earth") var type2 = 0
+
+                func return_bitfield_enum() -> Type:
+                    return Type.FIRE | Type.ICE # Ignores the INT_AS_ENUM_WITHOUT_CAST warning
+                [/codeblock]
+            </description>
+        </annotation>
 		<annotation name="@export">
 			<return type="void" />
 			<description>
@@ -472,7 +499,7 @@
 			<param index="0" name="names" type="String" />
 			<description>
 				Export an integer property as a bit flag field. This allows to store several "checked" or [code]true[/code] values with one property, and comfortably select them from the Inspector dock.
-				See also [constant PROPERTY_HINT_FLAGS].
+				See also [constant PROPERTY_HINT_FLAGS] and [annotation @bitfield].
 				[codeblock]
 				@export_flags("Fire", "Water", "Earth", "Wind") var spell_elements = 0
 				[/codeblock]

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -146,6 +146,9 @@ void GDScriptDocGen::_doctype_from_gdtype(const GDType &p_gdtype, String &r_type
 					r_enum = _get_script_name(r_enum);
 				}
 			}
+			if (p_gdtype.is_enum_bitfield) {
+				r_enum = vformat("BitField[%s]", r_enum);
+			}
 			return;
 		case GDType::VARIANT:
 		case GDType::RESOLVING:
@@ -553,6 +556,7 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 					const_doc.deprecated_message = val.doc_data.deprecated_message;
 					const_doc.is_experimental = val.doc_data.is_experimental;
 					const_doc.experimental_message = val.doc_data.experimental_message;
+					const_doc.is_bitfield = m_enum->is_bitfield;
 
 					doc.constants.push_back(const_doc);
 				}
@@ -576,6 +580,8 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 				const_doc.deprecated_message = m_enum_val.doc_data.deprecated_message;
 				const_doc.is_experimental = m_enum_val.doc_data.is_experimental;
 				const_doc.experimental_message = m_enum_val.doc_data.experimental_message;
+				const_doc.is_bitfield = m_enum_val.parent_enum->is_bitfield;
+
 				doc.constants.push_back(const_doc);
 			} break;
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1153,13 +1153,19 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 				member.m_enum->set_datatype(resolving_datatype);
 				GDScriptParser::DataType enum_type = make_class_enum_type(member.m_enum->identifier->name, p_class, parser->script_path, true);
 
+				// Annotations for enums get applied after checking for conflict and setting the datatype,
+				// but before creating enum values, as certain annotations may change them.
+				for (GDScriptParser::AnnotationNode *&E : member.m_enum->annotations) {
+					resolve_annotation(E);
+					E->apply(parser, member.m_enum, p_class);
+				}
+
 				const GDScriptParser::EnumNode *prev_enum = current_enum;
 				current_enum = member.m_enum;
 
 				Dictionary dictionary;
 				for (int j = 0; j < member.m_enum->values.size(); j++) {
 					GDScriptParser::EnumNode::Value &element = member.m_enum->values.write[j];
-
 					if (element.custom_value) {
 						reduce_expression(element.custom_value);
 						if (!element.custom_value->is_constant) {
@@ -1170,6 +1176,10 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 							element.value = element.custom_value->reduced_value;
 							element.resolved = true;
 						}
+					} else if (current_enum->is_bitfield) {
+						// Use LL explicitly to prevent compiler warning C4334
+						element.value = 1LL << j;
+						element.resolved = true;
 					} else {
 						if (element.index > 0) {
 							element.value = element.parent_enum->values[element.index - 1].value + 1;
@@ -1190,17 +1200,15 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 #endif // DEBUG_ENABLED
 				}
 
+				if (current_enum->is_bitfield) {
+					enum_type.is_enum_bitfield = true;
+				}
+
 				current_enum = prev_enum;
 
 				dictionary.make_read_only();
 				member.m_enum->set_datatype(enum_type);
 				member.m_enum->dictionary = dictionary;
-
-				// Apply annotations.
-				for (GDScriptParser::AnnotationNode *&E : member.m_enum->annotations) {
-					resolve_annotation(E);
-					E->apply(parser, member.m_enum, p_class);
-				}
 			} break;
 			case GDScriptParser::ClassNode::Member::FUNCTION:
 				for (GDScriptParser::AnnotationNode *&E : member.function->annotations) {
@@ -2190,7 +2198,7 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 		} else {
 			parser->push_warning(p_assignable, GDScriptWarning::UNTYPED_DECLARATION, declaration_type, p_assignable->identifier->name);
 		}
-	} else if (!is_parameter && specified_type.kind == GDScriptParser::DataType::ENUM && p_assignable->initializer == nullptr) {
+	} else if (!is_parameter && specified_type.kind == GDScriptParser::DataType::ENUM && p_assignable->initializer == nullptr && !specified_type.is_enum_bitfield) {
 		// Warn about enum variables without default value. Unless the enum defines the "0" value, then it's fine.
 		bool has_zero_value = false;
 		for (const KeyValue<StringName, int64_t> &kv : specified_type.enum_values) {
@@ -2741,7 +2749,7 @@ void GDScriptAnalyzer::update_const_expression_builtin_type(GDScriptParser::Expr
 	}
 
 #ifdef DEBUG_ENABLED
-	if (p_type.kind == GDScriptParser::DataType::ENUM && value_type.builtin_type == Variant::INT && !enum_has_value(p_type, p_expression->reduced_value)) {
+	if (p_type.kind == GDScriptParser::DataType::ENUM && value_type.builtin_type == Variant::INT && !enum_has_value(p_type, p_expression->reduced_value) && !p_type.is_enum_bitfield) {
 		parser->push_warning(p_expression, GDScriptWarning::INT_AS_ENUM_WITHOUT_MATCH, p_usage, p_expression->reduced_value.stringify(), p_type.to_string());
 	}
 #endif // DEBUG_ENABLED
@@ -5884,7 +5892,7 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_property(const PropertyInfo
 			result.set_container_element_type(1, value_elem_type);
 		} else if (p_property.type == Variant::INT) {
 			// Check if it's enum.
-			if ((p_property.usage & PROPERTY_USAGE_CLASS_IS_ENUM) && p_property.class_name != StringName()) {
+			if (p_property.usage & (PROPERTY_USAGE_CLASS_IS_ENUM | PROPERTY_USAGE_CLASS_IS_BITFIELD) && p_property.class_name != StringName()) {
 				if (CoreConstants::is_global_enum(p_property.class_name)) {
 					result = make_global_enum_type(p_property.class_name, StringName(), false);
 					result.is_constant = false;
@@ -5895,8 +5903,11 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_property(const PropertyInfo
 						result.is_constant = false;
 					}
 				}
+
+				if (p_property.usage & PROPERTY_USAGE_CLASS_IS_BITFIELD) {
+					result.is_enum_bitfield = true;
+				}
 			}
-			// PROPERTY_USAGE_CLASS_IS_BITFIELD: BitField[T] isn't supported (yet?), use plain int.
 		}
 	}
 	return result;
@@ -6282,7 +6293,7 @@ bool GDScriptAnalyzer::is_type_compatible(const GDScriptParser::DataType &p_targ
 #ifdef DEBUG_ENABLED
 	if (p_source_node) {
 		if (p_target.kind == GDScriptParser::DataType::ENUM) {
-			if (p_source.kind == GDScriptParser::DataType::BUILTIN && p_source.builtin_type == Variant::INT) {
+			if (p_source.kind == GDScriptParser::DataType::BUILTIN && p_source.builtin_type == Variant::INT && !p_target.is_enum_bitfield) {
 				parser->push_warning(p_source_node, GDScriptWarning::INT_AS_ENUM_WITHOUT_CAST);
 			}
 		}

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -722,11 +722,13 @@ static String _trim_parent_class(const String &p_class, const String &p_base_cla
 
 static String _get_visual_datatype(const PropertyInfo &p_info, bool p_is_arg, const String &p_base_class = "") {
 	String class_name = p_info.class_name;
-	bool is_enum = p_info.type == Variant::INT && p_info.usage & PROPERTY_USAGE_CLASS_IS_ENUM;
-	// PROPERTY_USAGE_CLASS_IS_BITFIELD: BitField[T] isn't supported (yet?), use plain int.
+	bool is_enum = p_info.type == Variant::INT && p_info.usage & (PROPERTY_USAGE_CLASS_IS_ENUM | PROPERTY_USAGE_CLASS_IS_BITFIELD);
 
 	if ((p_info.type == Variant::OBJECT || is_enum) && !class_name.is_empty()) {
 		if (is_enum && CoreConstants::is_global_enum(p_info.class_name)) {
+			if (p_info.usage & PROPERTY_USAGE_CLASS_IS_BITFIELD) {
+				return vformat("BitField[%s]", class_name);
+			}
 			return class_name;
 		}
 		return _trim_parent_class(class_name, p_base_class);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -189,6 +189,8 @@ GDScriptParser::GDScriptParser() {
 		// Networking.
 		// Keep in sync with `rpc_annotation()` and `SceneRPCInterface::_parse_rpc_config()`.
 		register_annotation(MethodInfo("@rpc", PropertyInfo(Variant::STRING, "mode"), PropertyInfo(Variant::STRING, "sync"), PropertyInfo(Variant::STRING, "transfer_mode"), PropertyInfo(Variant::INT, "transfer_channel")), AnnotationInfo::FUNCTION, &GDScriptParser::rpc_annotation, varray("authority", "call_remote", "reliable", 0));
+		// Enums.
+		register_annotation(MethodInfo("@bitfield"), AnnotationInfo::ENUM, &GDScriptParser::bitfield_annotation);
 	}
 
 #ifdef DEBUG_ENABLED
@@ -1131,7 +1133,7 @@ void GDScriptParser::parse_class_body(bool p_is_multiline) {
 				parse_class_member(&GDScriptParser::parse_class, AnnotationInfo::CLASS, "class");
 				break;
 			case GDScriptTokenizer::Token::ENUM:
-				parse_class_member(&GDScriptParser::parse_enum, AnnotationInfo::NONE, "enum");
+				parse_class_member(&GDScriptParser::parse_enum, AnnotationInfo::ENUM, "enum");
 				break;
 			case GDScriptTokenizer::Token::STATIC: {
 				advance();
@@ -4657,8 +4659,12 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 
 	variable->exported = true;
 
+	bool is_bitfield = variable->export_info.hint == PROPERTY_HINT_FLAGS;
+
 	variable->export_info.type = t_type;
-	variable->export_info.hint = t_hint;
+	if (!is_bitfield) {
+		variable->export_info.hint = t_hint;
+	}
 
 	String hint_string;
 	for (int i = 0; i < p_annotation->resolved_arguments.size(); i++) {
@@ -4786,7 +4792,12 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 		switch (export_type.kind) {
 			case GDScriptParser::DataType::BUILTIN:
 				variable->export_info.type = export_type.builtin_type;
-				variable->export_info.hint = PROPERTY_HINT_NONE;
+				// For variables with nested types
+				if (is_bitfield) {
+					variable->export_info.usage |= PROPERTY_USAGE_CLASS_IS_BITFIELD;
+				} else {
+					variable->export_info.hint = PROPERTY_HINT_NONE;
+				}
 				variable->export_info.hint_string = String();
 				break;
 			case GDScriptParser::DataType::NATIVE:
@@ -4811,7 +4822,12 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 					variable->export_info.type = Variant::DICTIONARY;
 				} else {
 					variable->export_info.type = Variant::INT;
-					variable->export_info.hint = PROPERTY_HINT_ENUM;
+					if (is_bitfield) {
+						variable->export_info.usage |= PROPERTY_USAGE_CLASS_IS_BITFIELD;
+					} else {
+						variable->export_info.hint = PROPERTY_HINT_ENUM;
+						variable->export_info.usage |= PROPERTY_USAGE_CLASS_IS_ENUM;
+					}
 
 					String enum_hint_string;
 					bool first = true;
@@ -4827,7 +4843,6 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 					}
 
 					variable->export_info.hint_string = enum_hint_string;
-					variable->export_info.usage |= PROPERTY_USAGE_CLASS_IS_ENUM;
 					variable->export_info.class_name = String(export_type.native_type).replace("::", ".");
 				}
 			} break;
@@ -4888,7 +4903,13 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 						variable->export_info.type = Variant::DICTIONARY;
 					} else {
 						variable->export_info.type = Variant::INT;
-						variable->export_info.hint = PROPERTY_HINT_ENUM;
+						if (is_bitfield) {
+							variable->export_info.hint = PROPERTY_HINT_FLAGS;
+							variable->export_info.usage |= PROPERTY_USAGE_CLASS_IS_BITFIELD;
+						} else {
+							variable->export_info.hint = PROPERTY_HINT_ENUM;
+							variable->export_info.usage |= PROPERTY_USAGE_CLASS_IS_ENUM;
+						}
 
 						String enum_hint_string;
 						bool first = true;
@@ -4904,7 +4925,6 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 						}
 
 						variable->export_info.hint_string = enum_hint_string;
-						variable->export_info.usage |= PROPERTY_USAGE_CLASS_IS_ENUM;
 						variable->export_info.class_name = String(export_type.native_type).replace("::", ".");
 					}
 				} break;
@@ -5281,6 +5301,65 @@ bool GDScriptParser::rpc_annotation(AnnotationNode *p_annotation, Node *p_target
 	return true;
 }
 
+bool GDScriptParser::bitfield_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	ERR_FAIL_COND_V_MSG(p_target->type != Node::ENUM, false, vformat(R"("%s" annotation can only be applied to enum.)", p_annotation->name));
+	ERR_FAIL_NULL_V(p_class, false);
+
+	EnumNode *enum_node = static_cast<EnumNode *>(p_target);
+	enum_node->is_bitfield = true;
+
+	// We need to give variables of the type of the enum the hint PROPERTY_HINT_FLAGS in the editor, so we look for them
+	for (ClassNode::Member member : p_class->members) {
+		if (member.type == ClassNode::Member::VARIABLE) {
+			VariableNode *variable = member.variable;
+			bool apply_flags = false;
+
+			// If the type is specified explicitly
+			if (variable->datatype_specifier != nullptr) {
+				TypeNode *datatype_specifier = variable->datatype_specifier;
+
+				// Check if the variable type is the enum with the bitfield annotation
+				for (IdentifierNode *identifier : datatype_specifier->type_chain) {
+					if (identifier->name == enum_node->identifier->name) {
+						apply_flags = true;
+						break;
+					}
+				}
+
+				if (!apply_flags) {
+					// Check if first type of the array/dictionary is the enum with the bitfield annotation
+					TypeNode *first_container = datatype_specifier->get_container_type_or_null(0);
+					if (first_container != nullptr) {
+						for (IdentifierNode *identifier : first_container->type_chain) {
+							if (identifier->name == enum_node->identifier->name) {
+								apply_flags = true;
+								break;
+							}
+						}
+					}
+				}
+
+				if (!apply_flags) {
+					// Check if second type of the dictionary is the enum with the bitfield annotation
+					TypeNode *second_container = datatype_specifier->get_container_type_or_null(1);
+					if (second_container != nullptr) {
+						for (IdentifierNode *identifier : second_container->type_chain) {
+							if (identifier->name == enum_node->identifier->name) {
+								apply_flags = true;
+								break;
+							}
+						}
+					}
+				}
+			}
+			if (apply_flags) {
+				variable->export_info.hint = PROPERTY_HINT_FLAGS;
+			}
+		}
+	}
+	return true;
+}
+
 GDScriptParser::DataType GDScriptParser::SuiteNode::Local::get_datatype() const {
 	switch (type) {
 		case CONSTANT:
@@ -5519,7 +5598,11 @@ PropertyInfo GDScriptParser::DataType::to_property_info(const String &p_name) co
 				result.type = Variant::DICTIONARY;
 			} else {
 				result.type = Variant::INT;
-				result.usage |= PROPERTY_USAGE_CLASS_IS_ENUM;
+				if (is_enum_bitfield) {
+					result.usage |= PROPERTY_USAGE_CLASS_IS_BITFIELD;
+				} else {
+					result.usage |= PROPERTY_USAGE_CLASS_IS_ENUM;
+				}
 				result.class_name = String(native_type).replace("::", ".");
 			}
 			break;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -127,6 +127,7 @@ public:
 		bool is_meta_type = false;
 		bool is_pseudo_type = false; // For global names that can't be used standalone.
 		bool is_coroutine = false; // For function calls.
+		bool is_enum_bitfield = false; // For bitfield enums.
 
 		Variant::Type builtin_type = Variant::NIL;
 		StringName native_type;
@@ -247,6 +248,7 @@ public:
 			method_info = p_other.method_info;
 			enum_values = p_other.enum_values;
 			container_element_types = p_other.container_element_types;
+			is_enum_bitfield = p_other.is_enum_bitfield;
 		}
 
 		DataType() = default;
@@ -550,6 +552,7 @@ public:
 		IdentifierNode *identifier = nullptr;
 		Vector<Value> values;
 		Variant dictionary;
+		bool is_bitfield = false;
 #ifdef TOOLS_ENABLED
 		MemberDocData doc_data;
 #endif // TOOLS_ENABLED
@@ -1414,7 +1417,8 @@ private:
 			FUNCTION = 1 << 5,
 			STATEMENT = 1 << 6,
 			STANDALONE = 1 << 7,
-			CLASS_LEVEL = CLASS | VARIABLE | CONSTANT | SIGNAL | FUNCTION,
+			ENUM = 1 << 8,
+			CLASS_LEVEL = CLASS | VARIABLE | CONSTANT | SIGNAL | FUNCTION | ENUM,
 		};
 		uint32_t target_kind = 0; // Flags.
 		AnnotationAction apply = nullptr;
@@ -1567,6 +1571,7 @@ private:
 	bool warning_ignore_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool warning_ignore_region_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool rpc_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool bitfield_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	// Statements.
 	Node *parse_statement();
 	VariableNode *parse_variable(bool p_is_static);


### PR DESCRIPTION
This PR adds a `@bitfield` annotation to mark enums as bitfields.

Bitfields enums have the following implications:
- Enum values are automatically initialized to `2^n`, while still respecting manually assigned values,
- Variables with the same type as the bitfield enum get given `PROPERTY_HINT_FLAGS`,
- Variables with the same type show as `BitField[Enum]` instead of just `Enum` in documentation, similar to https://github.com/godotengine/godot/pull/74641,
- `INT_AS_ENUM_WITHOUT_CAST`, `INT_AS_ENUM_WITHOUT_MATCH` and `ENUM_VARIABLE_WITHOUT_DEFAULT` warnings get ignored when dealing with bitfield enums. They still apply to regular enums.

Project that was used for testing, should cover all use-cases, but feel free to add to it:
[bitfield-annotation-test.zip](https://github.com/user-attachments/files/25953025/bitfield-annotation-test.zip)

Closes https://github.com/godotengine/godot-proposals/issues/923