### PR TITLE
Profiler: Fix for graph using excessive CPU

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -51,7 +51,7 @@ void EditorProfiler::_make_metric_ptrs(Metric &m) {
 	}
 }
 
-EditorProfiler::Metric EditorProfiler::_get_frame_metric(int index) {
+const EditorProfiler::Metric &EditorProfiler::_get_frame_metric(int index) const {
 	return frame_metrics[(frame_metrics.size() + last_metric - (total_metrics - 1) + index) % frame_metrics.size()];
 }
 

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -163,7 +163,7 @@ private:
 
 	void _combo_changed(int);
 
-	Metric _get_frame_metric(int index);
+	const Metric &_get_frame_metric(int index) const;
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
There's a bug in the profiler graph code that is causing excessive CPU usage.
This bug effects the _update_plot() method (and other places) which is what draws the graph.
This will be very helpful with #117066 

*** This fix results in a 4X improvement in draw speed for the profiler graph! ***

Here are some numbers for the _update_plot() code:
Before the fix
_update_plot 100 runs total:   551381 usec, average:   5513 usec per call - graph is starting to fill up
_update_plot 100 runs total: 1323278 usec, average: 13232 usec per call
_update_plot 100 runs total: 1809684 usec, average: 18096 usec per call - graph is full from here on
_update_plot 100 runs total: 1869551 usec, average: 18695 usec per call
_update_plot 100 runs total: 1873438 usec, average: 18734 usec per call
_update_plot 100 runs total: 2002019 usec, average: 20020 usec per call
_update_plot 100 runs total: 2016659 usec, average: 20166 usec per call

After the fix
_update_plot 100 runs total: 165619 usec, average: 1656 usec per call - graph is starting to fill up
_update_plot 100 runs total: 343914 usec, average: 3439 usec per call
_update_plot 100 runs total: 527919 usec, average: 5279 usec per call - graph is full from here on
_update_plot 100 runs total: 577738 usec, average: 5777 usec per call
_update_plot 100 runs total: 584657 usec, average: 5846 usec per call
_update_plot 100 runs total: 578274 usec, average: 5782 usec per call
_update_plot 100 runs total: 503249 usec, average: 5032 usec per call

1 line code change in 2 files. So simple.

Technical information. Changed from passing by value to passing by reference. When you pass by value the system implicitly makes a temporary copy of the data structure. This particular data structure is fairly complicated so a deep copy is expensive from a CPU perspective. Additionally the system must allocate memory for each temporary copy. Also this code is called many, many times in the graph drawing code so it really adds up from a CPU and memory usage viewpoint. 

AI special thanks. I would never have found this issue without the AI. I asked it to look for optimization possibilities in the drawing code specifically and it pointed out the pass by reference vs value issue. Using that information I put in timing code to get before times, fixed the 2 lines, and ran it again to get the after fix times. The previous developers had tried to capture this using the & for their variables but without the change to the method signature those attempts were not effective. Because everyone else missed it this demonstrates how AI can be an amazingly effective check on your code.

*******************************
Disclosure and License
-As a software engineer I use many systems to ensure code quality, and that includes AI. I use the AI to: do detailed code analysis, be a sounding board for my different ideas, look for bugs, find unexpected behaviors, identify performance hot spots, expensive CPU calls, race conditions, poorly placed variable initializations, possible optimizations, and many more things. I do this during development and before I push code to the repo. It lists items that are potential problems and I decide what I think is important and make those changes.
-For a descriptive example of my AI usage on a particular PR please read this https://github.com/godotengine/godot/pull/117066#issuecomment-4061773098
-Any and all code attached to this PR falls under the coverage of the MIT License.