### PR TITLE
InputMap: improve vague documentation 

### DIFF
--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -23,9 +23,7 @@
 			<param index="0" name="action" type="StringName" />
 			<param index="1" name="event" type="InputEvent" />
 			<description>
-				Removes an [InputEvent] from an action. This [InputEvent] will no longer trigger the action.
-				For removing all [InputEvent]s from an action, see [method action_erase_events].
-				For including actions instead, see [method action_add_event].
+				Removes an [InputEvent] from an action. This [InputEvent] will no longer trigger the action. To remove all [InputEvent]s from an action, use [method action_erase_events]. To include actions instead, use [method action_add_event].
 			</description>
 		</method>
 		<method name="action_erase_events">

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -37,8 +37,7 @@
 			<return type="float" />
 			<param index="0" name="action" type="StringName" />
 			<description>
-				Returns the current, minimum percentage value for the analog threshold of the given [code]action[/code]
-				in which it activates. Analog input strengths below that value will not activate.
+				Returns the current, minimum percentage value for the analog threshold of the given [param action] in which it activates. Analog input strengths below that value will not activate.
 			</description>
 		</method>
 		<method name="action_get_events">

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -37,7 +37,7 @@
 			<return type="float" />
 			<param index="0" name="action" type="StringName" />
 			<description>
-				Returns the current, minimum percentage value for the analog threshold of the given [param action] in which it activates. Analog input strengths below that value will not activate.
+				Returns the current, minimum percentage value (a number between [code]0.0[/code] and [code]1.0[/code] representing between [code]0%[/code] and [code]100%[/code] respectively) for the analog threshold of the given [param action] in which it activates. Analog input strengths below that value will not activate.
 			</description>
 		</method>
 		<method name="action_get_events">

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -97,7 +97,7 @@
 			<description>
 				Returns a list of keys bound to this action, separated by [code]" or "[/code].
 				[b]Example:[/b][br]
-				- [code]&amp;"ui_accept"[/code] turns into [code]"Enter or KP Enter or Space"[/code]
+				- [code]&amp;"ui_accept"[/code] turns into [code]"Enter or KP Enter or Space"[/code].
 				- [code]&amp;"ui_cancel"[/code] turns into [code]"Escape"[/code]
 			</description>
 		</method>

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -37,7 +37,8 @@
 			<return type="float" />
 			<param index="0" name="action" type="StringName" />
 			<description>
-				Returns a deadzone value for the action.
+				Returns the current, minimum percentage value for the analog threshold of the given [code]action[/code]
+				in which it activates. Analog input strengths below that value will not activate.
 			</description>
 		</method>
 		<method name="action_get_events">
@@ -94,7 +95,10 @@
 			<return type="String" />
 			<param index="0" name="action" type="StringName" />
 			<description>
-				Returns the human-readable description of the given action.
+				Returns a list of keys bound to this action, separated by " or ".[br]
+				[b]Example:[/b][br]
+				- [code]&amp;"ui_accept"[/code] turns into [code]"Enter or KP Enter or Space"[/code]
+				- [code]&amp;"ui_cancel"[/code] turns into [code]"Escape"[/code]
 			</description>
 		</method>
 		<method name="get_actions">

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -15,8 +15,7 @@
 			<param index="0" name="action" type="StringName" />
 			<param index="1" name="event" type="InputEvent" />
 			<description>
-				Inserts an [InputEvent] into an action. This [InputEvent] will trigger the action.
-				For removing actions instead, see [method action_erase_event].
+				Inserts an [InputEvent] into an action. This [InputEvent] will trigger the action. To remove an action instead, use [method action_erase_event].
 			</description>
 		</method>
 		<method name="action_erase_event">

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -95,7 +95,7 @@
 			<param index="0" name="action" type="StringName" />
 			<description>
 				Returns a list of keys bound to this action, separated by [code]" or "[/code].
-				[b]Example:[/b][br]
+				[b]Example:[/b]
 				- [code]&amp;"ui_accept"[/code] turns into [code]"Enter or KP Enter or Space"[/code].
 				- [code]&amp;"ui_cancel"[/code] turns into [code]"Escape"[/code]
 			</description>

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -31,7 +31,7 @@
 			<param index="0" name="action" type="StringName" />
 			<description>
 				Removes all events from an action. With no binds to an [InputEvent], this action will no longer be able to be triggered until a new [InputEvent] is added. See [method action_add_event].
-				For removing a single [InputEvent] from an action, see [method action_erase_event].
+				To remove a single [InputEvent] from an action, use [method action_erase_event].
 			</description>
 		</method>
 		<method name="action_get_deadzone">

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -97,7 +97,7 @@
 				Returns a list of keys bound to this action, separated by [code]" or "[/code].
 				[b]Example:[/b]
 				- [code]&amp;"ui_accept"[/code] turns into [code]"Enter or KP Enter or Space"[/code].
-				- [code]&amp;"ui_cancel"[/code] turns into [code]"Escape"[/code]
+				- [code]&amp;"ui_cancel"[/code] turns into [code]"Escape"[/code].
 			</description>
 		</method>
 		<method name="get_actions">

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -95,7 +95,7 @@
 			<return type="String" />
 			<param index="0" name="action" type="StringName" />
 			<description>
-				Returns a list of keys bound to this action, separated by " or ".[br]
+				Returns a list of keys bound to this action, separated by [code]" or "[/code].
 				[b]Example:[/b][br]
 				- [code]&amp;"ui_accept"[/code] turns into [code]"Enter or KP Enter or Space"[/code]
 				- [code]&amp;"ui_cancel"[/code] turns into [code]"Escape"[/code]

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -15,7 +15,8 @@
 			<param index="0" name="action" type="StringName" />
 			<param index="1" name="event" type="InputEvent" />
 			<description>
-				Adds an [InputEvent] to an action. This [InputEvent] will trigger the action.
+				Inserts an [InputEvent] into an action. This [InputEvent] will trigger the action.
+				For removing actions instead, see [method action_erase_event].
 			</description>
 		</method>
 		<method name="action_erase_event">
@@ -23,14 +24,17 @@
 			<param index="0" name="action" type="StringName" />
 			<param index="1" name="event" type="InputEvent" />
 			<description>
-				Removes an [InputEvent] from an action.
+				Removes an [InputEvent] from an action. This [InputEvent] will no longer trigger the action.
+				For removing all [InputEvent]s from an action, see [method action_erase_events].
+				For including actions instead, see [method action_add_event].
 			</description>
 		</method>
 		<method name="action_erase_events">
 			<return type="void" />
 			<param index="0" name="action" type="StringName" />
 			<description>
-				Removes all events from an action.
+				Removes all events from an action. With no binds to an [InputEvent], this action will no longer be able to be triggered until a new [InputEvent] is added. See [method action_add_event].
+				For removing a single [InputEvent] from an action, see [method action_erase_event].
 			</description>
 		</method>
 		<method name="action_get_deadzone">
@@ -61,7 +65,7 @@
 			<param index="0" name="action" type="StringName" />
 			<param index="1" name="deadzone" type="float" />
 			<description>
-				Sets a deadzone value for the action.
+				Defines the current, minimum percentage value (a number between [code]0.0[/code] and [code]1.0[/code] representing between [code]0%[/code] and [code]100%[/code] respectively) for the analog threshold of the given [param action] in which it activates. Analog input strengths below that value will not activate.
 			</description>
 		</method>
 		<method name="add_action">
@@ -77,7 +81,7 @@
 			<return type="void" />
 			<param index="0" name="action" type="StringName" />
 			<description>
-				Removes an action from the [InputMap].
+				Removes an action from the [InputMap]. Checks for this action will no longer respond.
 			</description>
 		</method>
 		<method name="event_is_action" qualifiers="const">
@@ -103,7 +107,7 @@
 		<method name="get_actions">
 			<return type="StringName[]" />
 			<description>
-				Returns an array of all actions in the [InputMap].
+				Returns an array of the names of all actions in the [InputMap].
 			</description>
 		</method>
 		<method name="has_action" qualifiers="const">


### PR DESCRIPTION
at `InputMap.xml`
the vague descriptions annoyed me so i changed it.

i'm also afraid of breaking things at the moment, so all i changed was description text in that one xml file should be about 4 to 6 lines at most.
may be relevant to mention this is being made right after proposal 14440 at godotengine/godot-docs#11855
