### PR TITLE
[Accessibility] Add viewport flag to ensure keyboard focus can't be trapped by non Control tree.

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -341,6 +341,9 @@
 		<member name="debug_draw" type="int" setter="set_debug_draw" getter="get_debug_draw" enum="Viewport.DebugDraw" default="0">
 			The overlay mode for test rendered geometry in debug purposes.
 		</member>
+		<member name="deep_focus_lookup" type="bool" setter="set_deep_focus_lookup" getter="is_deep_focus_lookup" default="false">
+			If [code]true[/code], the viewport will check all descendants when looking for a control to focus with the [code]ui_focus_next[/code] and [code]ui_focus_prev[/code] actions. Otherwise, only direct children of the [Viewport] are checked.
+		</member>
 		<member name="disable_3d" type="bool" setter="set_disable_3d" getter="is_3d_disabled" default="false">
 			Disable 3D rendering (but keep 2D rendering).
 		</member>

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -5247,6 +5247,13 @@ void EditorInspector::edit(Object *p_object) {
 	// Keep it available until the end so it works with both main and sub inspectors.
 	next_object = nullptr;
 
+	// Grab keyboard focus if nothing is foucsed.
+	if (is_inside_tree() && p_object) {
+		if (get_viewport()->gui_get_focus_owner() == nullptr) {
+			grab_focus(true);
+		}
+	}
+
 	emit_signal(SNAME("edited_object_changed"));
 }
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4557,6 +4557,7 @@ int Main::start() {
 
 			editor_node = memnew(EditorNode);
 			sml->get_root()->add_child(editor_node);
+			sml->get_root()->set_deep_focus_lookup(true);
 
 			if (!_export_preset.is_empty()) {
 				editor_node->export_preset(_export_preset, positional_arg, export_debug, export_pack_only, install_android_build_template, export_patch, patches);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1850,6 +1850,30 @@ Control *Viewport::gui_find_control(const Point2 &p_global) {
 	return nullptr;
 }
 
+Control *Viewport::_find_control_to_focus(Node *p_control, bool p_deep) const {
+	for (int i = 0; i < p_control->get_child_count(true); i++) {
+		Control *c = Object::cast_to<Control>(p_control->get_child(i, true));
+		if (!c || !c->is_visible_in_tree() || c->is_set_as_top_level()) {
+			continue;
+		}
+
+		return c;
+	}
+	if (p_deep) {
+		for (int i = 0; i < p_control->get_child_count(true); i++) {
+			Node *n = p_control->get_child(i, true);
+			if (!n) {
+				continue;
+			}
+			Control *from = _find_control_to_focus(n, p_deep);
+			if (from) {
+				return from;
+			}
+		}
+	}
+	return nullptr;
+}
+
 Control *Viewport::_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_global, const Transform2D &p_xform) {
 	if (!p_node->is_visible()) {
 		return nullptr; // Canvas item hidden, discard.
@@ -2331,15 +2355,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 		Control *from = gui.key_focus ? gui.key_focus : nullptr;
 		if (!from) {
-			for (int i = 0; i < get_child_count(true); i++) {
-				Control *c = Object::cast_to<Control>(get_child(i, true));
-				if (!c || !c->is_visible_in_tree() || c->is_set_as_top_level()) {
-					continue;
-				}
-
-				from = c;
-				break;
-			}
+			from = _find_control_to_focus(this, gui.deep_focus_lookup);
 		}
 
 		if (from && p_event->is_pressed()) {
@@ -3894,6 +3910,16 @@ int Viewport::get_render_info(RenderInfoType p_type, RenderInfo p_info) {
 	return RS::get_singleton()->viewport_get_render_info(viewport, RSE::ViewportRenderInfoType(p_type), RSE::ViewportRenderInfo(p_info));
 }
 
+void Viewport::set_deep_focus_lookup(bool p_enabled) {
+	ERR_MAIN_THREAD_GUARD;
+	gui.deep_focus_lookup = p_enabled;
+}
+
+bool Viewport::is_deep_focus_lookup() const {
+	ERR_READ_THREAD_GUARD_V(false);
+	return gui.deep_focus_lookup;
+}
+
 void Viewport::set_snap_controls_to_pixels(bool p_enable) {
 	ERR_MAIN_THREAD_GUARD;
 	snap_controls_to_pixels = p_enable;
@@ -5202,6 +5228,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_positional_shadow_atlas_16_bits", "enable"), &Viewport::set_positional_shadow_atlas_16_bits);
 	ClassDB::bind_method(D_METHOD("get_positional_shadow_atlas_16_bits"), &Viewport::get_positional_shadow_atlas_16_bits);
 
+	ClassDB::bind_method(D_METHOD("set_deep_focus_lookup", "enabled"), &Viewport::set_deep_focus_lookup);
+	ClassDB::bind_method(D_METHOD("is_deep_focus_lookup"), &Viewport::is_deep_focus_lookup);
+
 	ClassDB::bind_method(D_METHOD("set_snap_controls_to_pixels", "enabled"), &Viewport::set_snap_controls_to_pixels);
 	ClassDB::bind_method(D_METHOD("is_snap_controls_to_pixels_enabled"), &Viewport::is_snap_controls_to_pixels_enabled);
 
@@ -5356,6 +5385,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_snap_controls_to_pixels"), "set_snap_controls_to_pixels", "is_snap_controls_to_pixels_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_embed_subwindows"), "set_embedding_subwindows", "is_embedding_subwindows");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "gui_drag_threshold"), "set_drag_threshold", "get_drag_threshold");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deep_focus_lookup"), "set_deep_focus_lookup", "is_deep_focus_lookup");
 	ADD_GROUP("SDF", "sdf_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sdf_oversize", PROPERTY_HINT_ENUM, "100%,120%,150%,200%"), "set_sdf_oversize", "get_sdf_oversize");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sdf_scale", PROPERTY_HINT_ENUM, "100%,50%,25%"), "set_sdf_scale", "get_sdf_scale");

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -405,6 +405,7 @@ private:
 		bool drag_successful = false;
 		Control *target_control = nullptr; // Control that the mouse is over in the innermost nested Viewport. Only used in root-Viewport and SubViewports, that are not children of a SubViewportContainer.
 		bool embed_subwindows_hint = false;
+		bool deep_focus_lookup = false;
 		int drag_threshold = 10;
 
 		Window *subwindow_focused = nullptr;
@@ -436,6 +437,8 @@ private:
 
 	void _gui_sort_roots();
 	Control *_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_global, const Transform2D &p_xform);
+
+	Control *_find_control_to_focus(Node *p_control, bool p_deep) const;
 
 	void _gui_input_event(Ref<InputEvent> p_event);
 	void _perform_drop(Control *p_control = nullptr);
@@ -668,6 +671,9 @@ public:
 	DebugDraw get_debug_draw() const;
 
 	int get_render_info(RenderInfoType p_type, RenderInfo p_info);
+
+	void set_deep_focus_lookup(bool p_enabled);
+	bool is_deep_focus_lookup() const;
 
 	void set_snap_controls_to_pixels(bool p_enable);
 	bool is_snap_controls_to_pixels_enabled() const;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/117245

- Grab inspector focus when `edit(object)` is called and nothing else is selected.
- Adds `deep_focus_lookup` flag to ensure Tab/Shift+Tab can always find some focusable control after focus is released, and set it to `true` for the editor root viewport. Mostly a workaround, since the issue is a result of releasing keyboard focus completely, which is not a normal state for GUI apps.
