### PR TITLE
`RingBuffer`: Fix `T read()` method reading empty buffer

### DIFF
--- a/core/templates/ring_buffer.h
+++ b/core/templates/ring_buffer.h
@@ -48,7 +48,7 @@ class RingBuffer {
 
 public:
 	T read() {
-		ERR_FAIL_COND_V(space_left() < 1, T());
+		ERR_FAIL_COND_V(data_left() < 1, T());
 		return data.ptr()[inc(read_pos, 1)];
 	}
 


### PR DESCRIPTION
`T read()` method of the `RingBuffer` checks the `space_left()` instead of `data_left()`, causing it to read empty buffers and not reading full ones.

I couldn't find any instances where this method is used in the engine, but I commonly use it for my tests and benchmarks.