### PR TITLE
Move the definition of `open_search` shortcut earlier

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -592,8 +592,6 @@ EditorLog::EditorLog() {
 	eh.errfunc = _error_handler;
 	eh.userdata = this;
 	add_error_handler(&eh);
-
-	ED_SHORTCUT("editor/open_search", TTRC("Focus Search/Filter Bar"), KeyModifierMask::CMD_OR_CTRL | Key::F);
 }
 
 void EditorLog::deinit() {

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1397,6 +1397,7 @@ void EditorSettings::create() {
 
 		print_verbose("EditorSettings: Load OK!");
 
+		singleton->init_shortcuts();
 		singleton->setup_language(true);
 		singleton->setup_network();
 		singleton->load_favorites_and_recent_dirs();
@@ -1424,9 +1425,14 @@ fail:
 	singleton->set_path(config_file_path, true);
 	singleton->save_changed_setting = true;
 	singleton->_load_defaults(extra_config);
+	singleton->init_shortcuts();
 	singleton->setup_language(true);
 	singleton->setup_network();
 	singleton->update_text_editor_themes_list();
+}
+
+void EditorSettings::init_shortcuts() {
+	ED_SHORTCUT("editor/open_search", TTRC("Focus Search/Filter Bar"), KeyModifierMask::CMD_OR_CTRL | Key::F);
 }
 
 void EditorSettings::setup_language(bool p_initial_setup) {

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -146,6 +146,7 @@ public:
 	static String get_newest_settings_path();
 
 	static void create();
+	void init_shortcuts();
 	void setup_language(bool p_initial_setup);
 	void setup_network();
 	static void save();


### PR DESCRIPTION
Fixes #117386

The problem was that the `open_search` shortcut was used in AssetLib, but only defined in EditorLog, which does not exist in Project Manager. I didn't find a good place to put the shortcut, so I added a new initialization method to EditorSettings 🤷‍♂️ 