### PR TITLE
Remove redundant `_has_main_screen()` overrides

### DIFF
--- a/editor/animation/animation_player_editor_plugin.h
+++ b/editor/animation/animation_player_editor_plugin.h
@@ -307,7 +307,6 @@ public:
 	virtual void clear() override { anim_editor->clear(); }
 
 	virtual String get_plugin_name() const override { return "Anim"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
@@ -337,7 +336,6 @@ class AnimationTrackKeyEditEditorPlugin : public EditorPlugin {
 	EditorInspectorPluginAnimationTrackKeyEdit *atk_plugin = nullptr;
 
 public:
-	bool has_main_screen() const override { return false; }
 	virtual bool handles(Object *p_object) const override;
 
 	virtual String get_plugin_name() const override { return "AnimationTrackKeyEdit"; }
@@ -363,7 +361,6 @@ class AnimationMarkerKeyEditEditorPlugin : public EditorPlugin {
 	EditorInspectorPluginAnimationMarkerKeyEdit *amk_plugin = nullptr;
 
 public:
-	bool has_main_screen() const override { return false; }
 	virtual bool handles(Object *p_object) const override;
 
 	virtual String get_plugin_name() const override { return "AnimationMarkerKeyEdit"; }

--- a/editor/animation/animation_tree_editor_plugin.h
+++ b/editor/animation/animation_tree_editor_plugin.h
@@ -100,7 +100,6 @@ class AnimationTreeEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "AnimationTree"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/audio/audio_stream_randomizer_editor_plugin.h
+++ b/editor/audio/audio_stream_randomizer_editor_plugin.h
@@ -40,7 +40,6 @@ private:
 
 public:
 	virtual String get_plugin_name() const override { return "AudioStreamRandomizer"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/audio/editor_audio_buses.h
+++ b/editor/audio/editor_audio_buses.h
@@ -278,7 +278,6 @@ class AudioBusesEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "SampleLibrary"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_node) override;
 	virtual bool handles(Object *p_node) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/debugger/debugger_editor_plugin.h
+++ b/editor/debugger/debugger_editor_plugin.h
@@ -67,7 +67,6 @@ private:
 
 public:
 	virtual String get_plugin_name() const override { return "Debugger"; }
-	bool has_main_screen() const override { return false; }
 
 	DebuggerEditorPlugin(PopupMenu *p_menu);
 	~DebuggerEditorPlugin();

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -634,8 +634,6 @@ private:
 	virtual void input(const Ref<InputEvent> &p_event) override;
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
-	bool has_main_screen() const { return true; }
-
 	void _remove_edited_scene(bool p_change_tab = true);
 	void _remove_scene(int index, bool p_change_tab = true);
 	bool _find_and_save_resource(Ref<Resource> p_res, HashMap<Ref<Resource>, bool> &processed, int32_t flags);

--- a/editor/scene/2d/abstract_polygon_2d_editor.h
+++ b/editor/scene/2d/abstract_polygon_2d_editor.h
@@ -167,7 +167,6 @@ public:
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override { return polygon_editor->forward_gui_input(p_event); }
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { polygon_editor->forward_canvas_draw_over_viewport(p_overlay); }
 
-	bool has_main_screen() const override { return false; }
 	virtual String get_plugin_name() const override { return klass; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/scene/2d/parallax_background_editor_plugin.h
+++ b/editor/scene/2d/parallax_background_editor_plugin.h
@@ -55,7 +55,6 @@ protected:
 
 public:
 	virtual String get_plugin_name() const override { return "ParallaxBackground"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/2d/path_2d_editor_plugin.h
+++ b/editor/scene/2d/path_2d_editor_plugin.h
@@ -148,7 +148,6 @@ public:
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { path2d_editor->forward_canvas_draw_over_viewport(p_overlay); }
 
 	virtual String get_plugin_name() const override { return "Path2D"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/2d/physics/cast_2d_editor_plugin.h
+++ b/editor/scene/2d/physics/cast_2d_editor_plugin.h
@@ -65,7 +65,6 @@ public:
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { cast_2d_editor->forward_canvas_draw_over_viewport(p_overlay); }
 
 	virtual String get_plugin_name() const override { return "Cast2D"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool visible) override;

--- a/editor/scene/2d/physics/collision_shape_2d_editor_plugin.h
+++ b/editor/scene/2d/physics/collision_shape_2d_editor_plugin.h
@@ -105,7 +105,6 @@ public:
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { collision_shape_2d_editor->forward_canvas_draw_over_viewport(p_overlay); }
 
 	virtual String get_plugin_name() const override { return "CollisionShape2D"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_obj) override;
 	virtual bool handles(Object *p_obj) const override;
 	virtual void make_visible(bool visible) override;

--- a/editor/scene/2d/skeleton_2d_editor_plugin.h
+++ b/editor/scene/2d/skeleton_2d_editor_plugin.h
@@ -69,7 +69,6 @@ class Skeleton2DEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "Skeleton2D"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/2d/sprite_2d_editor_plugin.h
+++ b/editor/scene/2d/sprite_2d_editor_plugin.h
@@ -131,7 +131,6 @@ class Sprite2DEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "Sprite2D"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/3d/camera_3d_editor_plugin.h
+++ b/editor/scene/3d/camera_3d_editor_plugin.h
@@ -81,7 +81,6 @@ class Camera3DEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "Camera3D"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/3d/gpu_particles_collision_sdf_editor_plugin.h
+++ b/editor/scene/3d/gpu_particles_collision_sdf_editor_plugin.h
@@ -61,7 +61,6 @@ protected:
 
 public:
 	virtual String get_plugin_name() const override { return "GPUParticlesCollisionSDF3D"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/3d/lightmap_gi_editor_plugin.h
+++ b/editor/scene/3d/lightmap_gi_editor_plugin.h
@@ -57,7 +57,6 @@ protected:
 
 public:
 	virtual String get_plugin_name() const override { return "LightmapGI"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/3d/mesh_instance_3d_editor_plugin.h
+++ b/editor/scene/3d/mesh_instance_3d_editor_plugin.h
@@ -130,7 +130,6 @@ class MeshInstance3DEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "MeshInstance3D"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/3d/mesh_library_editor_plugin.h
+++ b/editor/scene/3d/mesh_library_editor_plugin.h
@@ -83,7 +83,6 @@ class MeshLibraryEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "MeshLibrary"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_node) override;
 	virtual bool handles(Object *p_node) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/3d/multimesh_editor_plugin.h
+++ b/editor/scene/3d/multimesh_editor_plugin.h
@@ -91,7 +91,6 @@ class MultiMeshEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "MultiMesh"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/3d/occluder_instance_3d_editor_plugin.h
+++ b/editor/scene/3d/occluder_instance_3d_editor_plugin.h
@@ -53,7 +53,6 @@ protected:
 
 public:
 	virtual String get_plugin_name() const override { return "OccluderInstance3D"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/3d/path_3d_editor_plugin.h
+++ b/editor/scene/3d/path_3d_editor_plugin.h
@@ -175,7 +175,6 @@ public:
 	virtual EditorPlugin::AfterGUIInput forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override;
 
 	virtual String get_plugin_name() const override { return "Path3D"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/3d/polygon_3d_editor_plugin.h
+++ b/editor/scene/3d/polygon_3d_editor_plugin.h
@@ -102,7 +102,6 @@ public:
 	virtual EditorPlugin::AfterGUIInput forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override { return polygon_editor->forward_3d_gui_input(p_camera, p_event); }
 
 	virtual String get_plugin_name() const override { return "Polygon3DEditor"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/3d/skeleton_3d_editor_plugin.h
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.h
@@ -273,7 +273,6 @@ class Skeleton3DEditorPlugin : public EditorPlugin {
 public:
 	virtual EditorPlugin::AfterGUIInput forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override;
 
-	bool has_main_screen() const override { return false; }
 	virtual bool handles(Object *p_object) const override;
 
 	virtual String get_plugin_name() const override { return "Skeleton3D"; }

--- a/editor/scene/3d/skeleton_ik_3d_editor_plugin.h
+++ b/editor/scene/3d/skeleton_ik_3d_editor_plugin.h
@@ -46,7 +46,6 @@ class SkeletonIK3DEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "SkeletonIK3D"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/3d/voxel_gi_editor_plugin.h
+++ b/editor/scene/3d/voxel_gi_editor_plugin.h
@@ -60,7 +60,6 @@ protected:
 
 public:
 	virtual String get_plugin_name() const override { return "VoxelGI"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/gui/theme_editor_plugin.h
+++ b/editor/scene/gui/theme_editor_plugin.h
@@ -500,7 +500,6 @@ class ThemeEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "Theme"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/resource_preloader_editor_plugin.h
+++ b/editor/scene/resource_preloader_editor_plugin.h
@@ -92,7 +92,6 @@ class ResourcePreloaderEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "ResourcePreloader"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/scene/sprite_frames_editor_plugin.h
+++ b/editor/scene/sprite_frames_editor_plugin.h
@@ -319,7 +319,6 @@ class SpriteFramesEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "SpriteFrames"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/shader/shader_file_editor_plugin.h
+++ b/editor/shader/shader_file_editor_plugin.h
@@ -73,7 +73,6 @@ class ShaderFileEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "ShaderFile"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
@@ -46,10 +46,6 @@ String SceneExporterGLTFPlugin::get_plugin_name() const {
 	return "ConvertGLTF2";
 }
 
-bool SceneExporterGLTFPlugin::has_main_screen() const {
-	return false;
-}
-
 SceneExporterGLTFPlugin::SceneExporterGLTFPlugin() {
 	_gltf_document.instantiate();
 	// Set up the file dialog.

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
@@ -56,6 +56,5 @@ class SceneExporterGLTFPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override;
-	bool has_main_screen() const override;
 	SceneExporterGLTFPlugin();
 };

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -292,7 +292,6 @@ public:
 	virtual void forward_3d_draw_over_viewport(Control *p_overlay) override;
 	virtual EditorPlugin::AfterGUIInput forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override { return grid_map_editor->forward_spatial_input_event(p_camera, p_event); }
 	virtual String get_plugin_name() const override { return "GridMap"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/modules/navigation_2d/editor/navigation_link_2d_editor_plugin.h
+++ b/modules/navigation_2d/editor/navigation_link_2d_editor_plugin.h
@@ -67,7 +67,6 @@ public:
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { editor->forward_canvas_draw_over_viewport(p_overlay); }
 
 	virtual String get_plugin_name() const override { return "NavigationLink2D"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/modules/navigation_3d/editor/navigation_link_3d_editor_plugin.h
+++ b/modules/navigation_3d/editor/navigation_link_3d_editor_plugin.h
@@ -41,7 +41,6 @@ class NavigationLink3DEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "NavigationLink3D"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 

--- a/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.h
+++ b/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.h
@@ -124,7 +124,6 @@ public:
 	virtual EditorPlugin::AfterGUIInput forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override;
 
 	virtual String get_plugin_name() const override { return "NavigationObstacle3DEditor"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/modules/navigation_3d/editor/navigation_region_3d_editor_plugin.h
+++ b/modules/navigation_3d/editor/navigation_region_3d_editor_plugin.h
@@ -91,7 +91,6 @@ class NavigationRegion3DEditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "NavigationRegion3D"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/modules/openxr/editor/openxr_editor_plugin.h
+++ b/modules/openxr/editor/openxr_editor_plugin.h
@@ -67,7 +67,6 @@ class OpenXREditorPlugin : public EditorPlugin {
 
 public:
 	virtual String get_plugin_name() const override { return "OpenXRPlugin"; }
-	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_node) override;
 	virtual bool handles(Object *p_node) const override;
 	virtual void make_visible(bool p_visible) override;


### PR DESCRIPTION
I noticed lots of EditorPlugins override `_has_main_screen()`, only to return `false`, which is the default value. There isn't really any use for that, my theory is that one plugin did this and then it was mindlessly copy-pasted 🤷‍♂️

This PR removes these overrides.