### PR TITLE
Add audio preview controls to MP3 and OGG AudioStream subclassess

### DIFF
--- a/editor/audio/audio_stream_editor_plugin.cpp
+++ b/editor/audio/audio_stream_editor_plugin.cpp
@@ -29,12 +29,13 @@
 /**************************************************************************/
 
 #include "audio_stream_editor_plugin.h"
-#include "scene/resources/audio_stream_wav.h"
+
 #include "core/object/callable_mp.h"
 #include "editor/audio/audio_stream_preview.h"
 #include "editor/editor_string_names.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/resources/audio_stream_wav.h"
 #include "servers/rendering/rendering_server.h"
 
 // AudioStreamEditor

--- a/editor/audio/audio_stream_editor_plugin.cpp
+++ b/editor/audio/audio_stream_editor_plugin.cpp
@@ -298,8 +298,8 @@ bool EditorInspectorPluginAudioStream::can_handle(Object *p_object) {
 	}
 	String cls = p_object->get_class();
 	return cls == "AudioStreamWAV" ||
-		   cls == "AudioStreamMP3" ||
-		   cls == "AudioStreamOggVorbis";
+			cls == "AudioStreamMP3" ||
+			cls == "AudioStreamOggVorbis";
 }
 
 void EditorInspectorPluginAudioStream::parse_begin(Object *p_object) {

--- a/editor/audio/audio_stream_editor_plugin.cpp
+++ b/editor/audio/audio_stream_editor_plugin.cpp
@@ -35,7 +35,6 @@
 #include "editor/editor_string_names.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
-#include "scene/resources/audio_stream_wav.h"
 #include "servers/rendering/rendering_server.h"
 
 // AudioStreamEditor
@@ -75,16 +74,30 @@ void AudioStreamEditor::_notification(int p_what) {
 }
 
 void AudioStreamEditor::_draw_preview() {
+	if (stream.is_null()) {
+		return;
+	}
 	Size2 size = get_size();
 	int width = size.width;
 	if (width <= 0) {
-		return; // No points to draw.
+		return;
 	}
-
-	Rect2 rect = _preview->get_rect();
-
+	if (stream->get_length() <= 0.0f) {
+		const Color col = get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor));
+		Ref<Font> font = get_theme_font(SNAME("status_source"), EditorStringName(EditorFonts));
+		int font_size = get_theme_font_size(SNAME("status_source_size"), EditorStringName(EditorFonts));
+		_preview->draw_string(font,
+				Point2(8 * EDSCALE, size.height * 0.5f + font_size * 0.25f),
+				TTR("Waveform preview not available"),
+				HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, col);
+		return;
+	}
 	Ref<AudioStreamPreview> preview = AudioStreamPreviewGenerator::get_singleton()->generate_preview(stream);
 	float preview_len = preview->get_length();
+
+	if (preview_len <= 0.0f) {
+		return;
+	}
 
 	Vector<Vector2> points;
 	points.resize(width * 2);
@@ -96,8 +109,8 @@ void AudioStreamEditor::_draw_preview() {
 		float min = preview->get_min(ofs, ofs_n) * 0.5 + 0.5;
 
 		int idx = i;
-		points.write[idx * 2 + 0] = Vector2(i + 1, rect.position.y + min * rect.size.y);
-		points.write[idx * 2 + 1] = Vector2(i + 1, rect.position.y + max * rect.size.y);
+		points.write[idx * 2 + 0] = Vector2(i + 1, min * size.height);
+		points.write[idx * 2 + 1] = Vector2(i + 1, max * size.height);
 	}
 
 	Vector<Color> colors = { get_theme_color(SNAME("contrast_color_2"), EditorStringName(Editor)) };
@@ -119,6 +132,9 @@ void AudioStreamEditor::_stream_changed() {
 }
 
 void AudioStreamEditor::_play() {
+	if (stream.is_null() || stream->get_length() <= 0.0f) {
+		return;
+	}
 	if (_player->is_playing()) {
 		_pausing = true;
 		_player->stop();
@@ -152,13 +168,16 @@ void AudioStreamEditor::_on_finished() {
 }
 
 void AudioStreamEditor::_draw_indicator() {
-	if (stream.is_null()) {
-		return;
-	}
-
-	Rect2 rect = _preview->get_rect();
-	float len = stream->get_length();
-	float ofs_x = _current / len * rect.size.width;
+    if (stream.is_null()) {
+        return;
+    }
+    float len = stream->get_length();
+    if (len <= 0.0f) {
+        _current_label->set_text(String::num(_current, 2).pad_decimals(2) + " /");
+        return;
+    }
+    Rect2 rect = _preview->get_rect();
+    float ofs_x = _current / len * rect.size.width;
 	const Color col = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 	Ref<Texture2D> icon = get_editor_theme_icon(SNAME("TimelineIndicator"));
 	_indicator->draw_line(Point2(ofs_x, 0), Point2(ofs_x, rect.size.height), col, Math::round(2 * EDSCALE));
@@ -209,8 +228,12 @@ void AudioStreamEditor::set_stream(const Ref<AudioStream> &p_stream) {
 	_player->set_stream(stream);
 	_current = 0;
 
-	String text = String::num(stream->get_length(), 2).pad_decimals(2) + "s";
-	_duration_label->set_text(text);
+	float len = stream->get_length();
+	if (len > 0.0f) {
+		_duration_label->set_text(String::num(len, 2).pad_decimals(2) + "s");
+	} else {
+		_duration_label->set_text(TTR("dynamic"));
+	}
 
 	queue_redraw();
 }
@@ -269,7 +292,7 @@ AudioStreamEditor::AudioStreamEditor() {
 // EditorInspectorPluginAudioStream
 
 bool EditorInspectorPluginAudioStream::can_handle(Object *p_object) {
-	return Object::cast_to<AudioStreamWAV>(p_object) != nullptr;
+	return Object::cast_to<AudioStream>(p_object) != nullptr;
 }
 
 void EditorInspectorPluginAudioStream::parse_begin(Object *p_object) {

--- a/editor/audio/audio_stream_editor_plugin.cpp
+++ b/editor/audio/audio_stream_editor_plugin.cpp
@@ -29,7 +29,7 @@
 /**************************************************************************/
 
 #include "audio_stream_editor_plugin.h"
-
+#include "scene/resources/audio_stream_wav.h"
 #include "core/object/callable_mp.h"
 #include "editor/audio/audio_stream_preview.h"
 #include "editor/editor_string_names.h"
@@ -293,7 +293,13 @@ AudioStreamEditor::AudioStreamEditor() {
 // EditorInspectorPluginAudioStream
 
 bool EditorInspectorPluginAudioStream::can_handle(Object *p_object) {
-	return Object::cast_to<AudioStream>(p_object) != nullptr;
+	if (Object::cast_to<AudioStream>(p_object) == nullptr) {
+		return false;
+	}
+	String cls = p_object->get_class();
+	return cls == "AudioStreamWAV" ||
+		   cls == "AudioStreamMP3" ||
+		   cls == "AudioStreamOggVorbis";
 }
 
 void EditorInspectorPluginAudioStream::parse_begin(Object *p_object) {

--- a/editor/audio/audio_stream_editor_plugin.cpp
+++ b/editor/audio/audio_stream_editor_plugin.cpp
@@ -99,6 +99,7 @@ void AudioStreamEditor::_draw_preview() {
 		return;
 	}
 
+	Rect2 rect = _preview->get_rect();
 	Vector<Vector2> points;
 	points.resize(width * 2);
 
@@ -109,8 +110,8 @@ void AudioStreamEditor::_draw_preview() {
 		float min = preview->get_min(ofs, ofs_n) * 0.5 + 0.5;
 
 		int idx = i;
-		points.write[idx * 2 + 0] = Vector2(i + 1, min * size.height);
-		points.write[idx * 2 + 1] = Vector2(i + 1, max * size.height);
+		points.write[idx * 2 + 0] = Vector2(i + 1, rect.position.y + min * rect.size.y);
+		points.write[idx * 2 + 1] = Vector2(i + 1, rect.position.y + max * rect.size.y);
 	}
 
 	Vector<Color> colors = { get_theme_color(SNAME("contrast_color_2"), EditorStringName(Editor)) };
@@ -168,16 +169,16 @@ void AudioStreamEditor::_on_finished() {
 }
 
 void AudioStreamEditor::_draw_indicator() {
-    if (stream.is_null()) {
-        return;
-    }
-    float len = stream->get_length();
-    if (len <= 0.0f) {
-        _current_label->set_text(String::num(_current, 2).pad_decimals(2) + " /");
-        return;
-    }
-    Rect2 rect = _preview->get_rect();
-    float ofs_x = _current / len * rect.size.width;
+	if (stream.is_null()) {
+		return;
+	}
+	float len = stream->get_length();
+	if (len <= 0.0f) {
+		_current_label->set_text(String::num(_current, 2).pad_decimals(2) + " /");
+		return;
+	}
+	Rect2 rect = _preview->get_rect();
+	float ofs_x = _current / len * rect.size.width;
 	const Color col = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 	Ref<Texture2D> icon = get_editor_theme_icon(SNAME("TimelineIndicator"));
 	_indicator->draw_line(Point2(ofs_x, 0), Point2(ofs_x, rect.size.height), col, Math::round(2 * EDSCALE));

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -516,7 +516,9 @@ double AudioStreamOggVorbis::get_loop_offset() const {
 }
 
 double AudioStreamOggVorbis::get_length() const {
-	ERR_FAIL_COND_V(packet_sequence.is_null(), 0);
+	if (packet_sequence.is_null()) {
+		return 0;
+	}
 	return packet_sequence->get_length();
 }
 


### PR DESCRIPTION
Resolves: [Issue #14356](https://github.com/godotengine/godot-proposals/issues/14356)

Previously, the audio preview panel (play/stop controls and waveform) in the inspector was only shown for AudioStreamWAV. This change extends it to all AudioStream subclasses.

---

Update after: https://github.com/godotengine/godot/pull/117394#issuecomment-4055443880

- We now display preview on WAV, MP3 and OGG - not all stream types. Displaying on all stream types was bad idead because of Audio Randomizer, Audio Playlist and similar subclasses.

---

Changes:
- (that change was removed in final ver.) **include audio_stream_wav.h** was removed as it seems to be not needed anymore
- (that change was removed in final ver.)  **can_handle** now accepts any AudioStream instead of only AudioStreamWAV
- Streams without a fixed length (e.g. AudioStreamRandomizer) show "dynamic" instead of "0.00s" - (This change can be discussed)
- **_draw_indicator** guards against division by zero when stream length is 0
- **_draw_preview** shows "Waveform preview not available" for streams without a fixed length instead of attempting to generate an empty waveform  - (This change can be discussed)
- **AudioStreamOggVorbis get_length** no longer prints an error when packet_sequence is null - After my changes it was printing errors, so I have to modify get_length. MP3 and WAV was fine because it always return 0.

Examples:
MP3 Before:
<img width="446" height="243" alt="image" src="https://github.com/user-attachments/assets/07eb718b-f4b4-4ff7-b789-258c468242ba" />



MP3 (and OGG etc.) After:
<img width="402" height="349" alt="image" src="https://github.com/user-attachments/assets/7bc08615-e654-4dde-98f0-365ff76195e3" />


Empty WAV Before:
<img width="436" height="354" alt="image" src="https://github.com/user-attachments/assets/e1e47ba1-2b39-430d-9df9-5da852f84814" />

Empty WAV (and any other audio resource) After:
<img width="411" height="328" alt="image" src="https://github.com/user-attachments/assets/06e5616a-b2a7-46ae-8eb1-00172215269b" />

Audio Randomizer before:
<img width="407" height="713" alt="image" src="https://github.com/user-attachments/assets/d69db86e-5d7f-499a-8ac5-58b6e8b68dc7" />

After:
<img width="500" height="1072" alt="image" src="https://github.com/user-attachments/assets/494b30bd-01eb-4d29-9028-97045edc5df0" />


AI disclaimer: Ai was used to help me with implementing those changes. Sorry if that generate additional work for maintainers to check if everything is correct. I was trying to find simple issues to solve as a beginner. Most of the things were already implemented all I had to change was to add preview controls to more subclasses and make sure that this change does not brake anything. I am pretty sure it works great. Checked every stream resource and I hope this PR helps in some way :)