### PR TITLE
Disable tooltip and symbol lookup for class names in non-docstring comments

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1184,7 +1184,33 @@ void ScriptTextEditor::_on_caret_moved() {
 	previous_line = current_line;
 }
 
+bool ScriptTextEditor::_should_skip_symbol(const String &p_symbol, int p_row, int p_column) const {
+	CodeEdit *te = code_editor->get_text_editor();
+	if (p_row < 0 || p_row >= te->get_line_count()) {
+		return false;
+	}
+
+	int comment_idx = te->is_in_comment(p_row, p_column);
+	if (comment_idx == -1) {
+		return false;
+	}
+
+	// Allow bracket references like in doc comments (##) e.g. [Color]
+	if (te->get_delimiter_start_key(comment_idx) == "##") {
+		const String &line = te->get_line(p_row);
+		if (line.rfind("[" + p_symbol + "]", p_column) != -1) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_column) {
+	if (_should_skip_symbol(p_symbol, p_row, p_column)) {
+		return;
+	}
+
 	Ref<Script> script = edited_res;
 	Node *base = get_tree()->get_edited_scene_root();
 	if (base) {
@@ -1304,6 +1330,12 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 void ScriptTextEditor::_validate_symbol(const String &p_symbol) {
 	CodeEdit *text_edit = code_editor->get_text_editor();
 
+	Point2i pos = text_edit->get_line_column_at_pos(text_edit->get_local_mouse_pos(), false, false);
+	if (_should_skip_symbol(p_symbol, pos.y, pos.x)) {
+		text_edit->set_symbol_lookup_word_as_valid(false);
+		return;
+	}
+
 	Ref<Script> script = edited_res;
 	Node *base = get_tree()->get_edited_scene_root();
 	if (base) {
@@ -1330,6 +1362,10 @@ void ScriptTextEditor::_validate_symbol(const String &p_symbol) {
 
 void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, int p_column, bool p_shortcut) {
 	if (!EDITOR_GET("text_editor/behavior/documentation/enable_tooltips").booleanize()) {
+		return;
+	}
+
+	if (_should_skip_symbol(p_symbol, p_row, p_column)) {
 		return;
 	}
 

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -193,6 +193,7 @@ protected:
 
 	void _lookup_symbol(const String &p_symbol, int p_row, int p_column);
 	void _validate_symbol(const String &p_symbol);
+	bool _should_skip_symbol(const String &p_symbol, int p_row, int p_column) const;
 
 	void _show_symbol_tooltip(const String &p_symbol, int p_row, int p_column, bool p_shortcut = false);
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/117306

`lookup_code()` resolves class names before parsing, so it has no awareness of whether the symbol is inside a comment. this causes hover tooltips and Ctrl/Cmd+Click navigation to trigger on class names in comments (e.g. `# Color is too saturated`).

This change adds `_should_skip_symbol()` to `ScriptTextEditor`, which is called before `lookup_code()` in three places:
- `_show_symbol_tooltip` - hover tooltips
- `_validate_symbol` - underline on Ctrl/Cmd+hover
- `_lookup_symbol` - navigation on Ctrl/Cmd+Click

These are independent signal handlers for `symbol_hovered`, `symbol_validate`, and `symbol_lookup` respectively, so each needs their own check

The check skips symbols inside comments, with an exception for bracket references in doc comments (e.g. `## [Color]`)

## Test plan
- `# Color is too saturated` - no tooltip on hover, no navigation on Ctrl/Cmd+Click
- `## Color is a class` - no tooltip, no navigation
- `## [Color] is a class` - tooltip works, navigation works
- `var c: Color` - tooltip works, navigation works

https://github.com/user-attachments/assets/42b45365-0cc0-4e69-b829-398265dfe851