### PR TITLE
Add editor setting to disable zooming with ctrl Mouse wheel

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1508,6 +1508,9 @@
 		<member name="text_editor/behavior/navigation/drag_and_drop_selection" type="bool" setter="" getter="">
 			If [code]true[/code], allows drag-and-dropping text in the script editor to move text. Disable this if you find yourself accidentally drag-and-dropping text in the script editor.
 		</member>
+		<member name="text_editor/behavior/navigation/mouse_wheel_zoom" type="bool" setter="" getter="">
+			If [code]true[/code], allows zooming in the script editor by scrolling the mouse wheel while holding [kbd]Ctrl[/kbd] ([kbd]Cmd[/kbd] on macOS). Also allows zooming with the magnify gesture [InputEventMagnifyGesture].
+		</member>
 		<member name="text_editor/behavior/navigation/move_caret_on_right_click" type="bool" setter="" getter="">
 			If [code]true[/code], the caret will be moved when right-clicking somewhere in the script editor (like when left-clicking or middle-clicking). If [code]false[/code], the caret will only be moved when left-clicking or middle-clicking somewhere.
 		</member>

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -936,7 +936,7 @@ void CodeTextEditor::input(const Ref<InputEvent> &event) {
 void CodeTextEditor::_text_editor_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> mb = p_event;
 
-	if (mb.is_valid()) {
+	if (mouse_wheel_zoom && mb.is_valid()) {
 		if (mb->is_pressed() && mb->is_command_or_control_pressed()) {
 			if (mb->get_button_index() == MouseButton::WHEEL_UP) {
 				_zoom_in();
@@ -953,7 +953,7 @@ void CodeTextEditor::_text_editor_gui_input(const Ref<InputEvent> &p_event) {
 
 #ifndef ANDROID_ENABLED
 	Ref<InputEventMagnifyGesture> magnify_gesture = p_event;
-	if (magnify_gesture.is_valid()) {
+	if (mouse_wheel_zoom && magnify_gesture.is_valid()) {
 		_zoom_to(zoom_factor * std::pow(magnify_gesture->get_factor(), 0.25f));
 		accept_event();
 		return;
@@ -1157,6 +1157,7 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_use_default_word_separators(EDITOR_GET("text_editor/behavior/navigation/use_default_word_separators"));
 	text_editor->set_use_custom_word_separators(EDITOR_GET("text_editor/behavior/navigation/use_custom_word_separators"));
 	text_editor->set_custom_word_separators(EDITOR_GET("text_editor/behavior/navigation/custom_word_separators"));
+	mouse_wheel_zoom = EDITOR_GET("text_editor/behavior/navigation/mouse_wheel_zoom");
 
 	// Behavior: Indent
 	set_indent_using_spaces(EDITOR_GET("text_editor/behavior/indent/type"));

--- a/editor/gui/code_editor.h
+++ b/editor/gui/code_editor.h
@@ -181,6 +181,7 @@ class CodeTextEditor : public VBoxContainer {
 	int code_complete_timer_line = 0;
 
 	float zoom_factor = 1.0f;
+	bool mouse_wheel_zoom = false;
 
 	RichTextLabel *error = nullptr;
 	int error_line;

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -821,6 +821,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/behavior/navigation/use_default_word_separators", true); // Includes ´`~$^=+|<> General punctuation and CJK punctuation.
 	_initial_set("text_editor/behavior/navigation/use_custom_word_separators", false);
 	_initial_set("text_editor/behavior/navigation/custom_word_separators", ""); // Custom word separators.
+	_initial_set("text_editor/behavior/navigation/mouse_wheel_zoom", false);
 
 	// Behavior: Indent
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/behavior/indent/type", 0, "Tabs,Spaces")

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2253,7 +2253,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 
 		if (mb->is_pressed()) {
-			if (mb->get_button_index() == MouseButton::WHEEL_UP && !mb->is_command_or_control_pressed()) {
+			if (mb->get_button_index() == MouseButton::WHEEL_UP) {
 				if (mb->is_shift_pressed()) {
 					h_scroll->set_value(h_scroll->get_value() - (100 * mb->get_factor()));
 					queue_accessibility_update();
@@ -2265,7 +2265,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					_scroll_up(3 * mb->get_factor(), true);
 				}
 			}
-			if (mb->get_button_index() == MouseButton::WHEEL_DOWN && !mb->is_command_or_control_pressed()) {
+			if (mb->get_button_index() == MouseButton::WHEEL_DOWN) {
 				if (mb->is_shift_pressed()) {
 					h_scroll->set_value(h_scroll->get_value() + (100 * mb->get_factor()));
 					queue_accessibility_update();


### PR DESCRIPTION
- Salvages #97313
- Closes https://github.com/godotengine/godot-proposals/issues/7997

Moved to navigation category instead of its having its own, there are other shortcuts there about scrolling, and it looked better than having it alone.

When disabled, holding `ctrl` will scroll like normal. The checks in TextEdit aren't necessary either way because the zoom accepts the event and were only needed because it used to not accept them.

I went ahead and set it to false by default. In my experience, this is mostly used accidentally and forces you to reset the zoom level. You typically don't need to change the zoom too often. If your script is long it can be laggy, especially if word wrap is on. It's not a freeze like the issue used to have, but it doesn't look great. There is the zoom button dropdown and the `ctrl`+`=`/`-` shortcuts, so it is still easy enough to adjust the zoom IMO.
But if others disagree, I can change it to true by default.