### PR TITLE
Fix tangent decoding detection when computing vertex skinning

### DIFF
--- a/servers/rendering/renderer_rd/shaders/skeleton.glsl
+++ b/servers/rendering/renderer_rd/shaders/skeleton.glsl
@@ -110,6 +110,13 @@ uint encode_tang_to_uint_oct(vec4 base) {
 	// Encode binormal sign in y component
 	oct.y = oct.y * 0.5f + 0.5f;
 	oct.y = base.w >= 0.0f ? oct.y : 1 - oct.y;
+
+	if (oct.x == 0.0 && oct.y == 1.0) {
+		// (1, 1) and (0, 1) decode to the same value, but (0, 1) messes with our compression detection.
+		// So we sanitize here.
+		oct.x = 1.0;
+	}
+
 	return vec2_to_uint(oct);
 }
 


### PR DESCRIPTION
Fixes #81446

When decoding veretx tangent in the shader, there is a special case to detect which encoding system to use (Octahedral or axis-angle coordinates). See scene.glsl, line 618.
In the issue mentioned above, some octahedral encoded tangents are exactly (0, 1) which is the value used to detect the encoding. When this special value is detected, we switch to axis-angle decoding, instead of Octahedral, resulting is undefined results. This only happened for skinned objects.

The fix is the same as the c++ code (rendering_server.cpp line ~650) : detect this special case when encoding the tangent in the skeleton compute shader, and apply a different but equivalent encoding instead.

I did not modify the gles3 skeleton shader.  I could be wrong, but the compatibility mode does not seem to suffer from this.

For the fix, we could also check the uint value directly for slightly fewer instructions, but I feel this would make the code harder to maintain in the future.