### PR TITLE
[.Net] Support generating and shipping localized IntelliSense XML

### DIFF
--- a/editor/translations/editor_translation.cpp
+++ b/editor/translations/editor_translation.cpp
@@ -50,6 +50,17 @@ Vector<String> get_editor_locales() {
 	return locales;
 }
 
+Vector<String> get_doc_locales() {
+	Vector<String> locales;
+
+	for (const EditorTranslationList *etl = _doc_translations; etl->data; etl++) {
+		const String &locale = etl->lang;
+		locales.push_back(locale);
+	}
+
+	return locales;
+}
+
 static void _load(const Ref<TranslationDomain> p_domain, const String &p_locale, const EditorTranslationList *p_etl) {
 	for (const EditorTranslationList *etl = p_etl; etl->data; etl++) {
 		if (etl->lang == p_locale) {

--- a/editor/translations/editor_translation.h
+++ b/editor/translations/editor_translation.h
@@ -34,6 +34,7 @@
 #include "core/templates/vector.h"
 
 Vector<String> get_editor_locales();
+Vector<String> get_doc_locales();
 void load_editor_translations(const String &p_locale);
 void load_doc_translations(const String &p_locale);
 Vector<Vector<String>> get_extractable_message_list();

--- a/modules/mono/README.md
+++ b/modules/mono/README.md
@@ -5,10 +5,19 @@
    ```sh
    <godot_binary> --generate-mono-glue ./modules/mono/glue
    ```
+    To also emit localized IntelliSense XML files into the GodotSharp projects for every available doc translation, add:
+    ```sh
+    <godot_binary> --generate-mono-glue ./modules/mono/glue --generate-localized-docs
+    ```
+    To limit localized XML generation to specific locales, pass the locale list directly to the localized docs option:
+    ```sh
+    <godot_binary> --generate-mono-glue ./modules/mono/glue --generate-localized-docs zh-Hans,fr
+    ```
 3. Build the C# solutions:
    ```sh
    ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir ./bin
    ```
+    If localized XML docs were generated, they are mirrored into the copied GodotSharp API output automatically.
 
 The paths specified in these examples assume the command is being run from
 the Godot source root.

--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -188,6 +188,14 @@ def run_msbuild(tools: ToolsLocation, sln: str, chdir_to: str, msbuild_args: lis
     return subprocess.call(args, env=msbuild_env, cwd=chdir_to)
 
 
+def discover_localized_doc_locales(project_dir: str):
+    localized_docs_dir = os.path.join(project_dir, "LocalizedDocs")
+    if not os.path.isdir(localized_docs_dir):
+        return []
+
+    return sorted(entry.name for entry in os.scandir(localized_docs_dir) if entry.is_dir())
+
+
 def build_godot_api(msbuild_tool, module_dir, output_dir, push_nupkgs_local, precision, no_deprecated, werror):
     target_filenames = [
         "GodotSharp.dll",
@@ -207,6 +215,8 @@ def build_godot_api(msbuild_tool, module_dir, output_dir, push_nupkgs_local, pre
         targets = [os.path.join(editor_api_dir, filename) for filename in target_filenames]
 
         args = ["/restore", "/t:Build", "/p:Configuration=" + build_config, "/p:NoWarn=1591"]
+        if build_config != "Release":
+            args += ["/p:GeneratePackageOnBuild=false"]
         if push_nupkgs_local:
             args += ["/p:ClearNuGetLocalCache=true", "/p:PushNuGetToLocalSource=" + push_nupkgs_local]
         if precision == "double":
@@ -247,6 +257,27 @@ def build_godot_api(msbuild_tool, module_dir, output_dir, push_nupkgs_local, pre
 
         for scons_target in targets:
             copy_target(scons_target)
+
+        from shutil import copy
+
+        def copy_localized_doc(project_bin_dir, assembly_name):
+            project_dir = os.path.dirname(os.path.dirname(project_bin_dir))
+            locales_to_copy = discover_localized_doc_locales(project_dir)
+
+            for locale in locales_to_copy:
+                src_path = os.path.join(project_dir, "LocalizedDocs", locale, f"{assembly_name}.xml")
+                if not os.path.isfile(src_path):
+                    print(f"WARNING: Localized XML doc not found for locale '{locale}': {src_path}. Skipping.")
+                    continue
+
+                dst_dir = os.path.join(editor_api_dir, locale)
+                os.makedirs(dst_dir, exist_ok=True)
+                dst_path = os.path.join(dst_dir, f"{assembly_name}.xml")
+                print(f"Copying localized XML doc to {dst_path}...")
+                copy(src_path, dst_path)
+
+        copy_localized_doc(core_src_dir, "GodotSharp")
+        copy_localized_doc(editor_src_dir, "GodotSharpEditor")
 
     return 0
 
@@ -433,7 +464,6 @@ def main():
     output_dir = os.path.abspath(args.godot_output_dir)
 
     push_nupkgs_local = os.path.abspath(args.push_nupkgs_local) if args.push_nupkgs_local else None
-
     msbuild_tool = find_any_msbuild_tool(args.mono_prefix)
 
     if msbuild_tool is None:

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -42,6 +42,8 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/os/os.h"
+#include "core/string/translation_server.h"
+#include "editor/translations/editor_translation.h"
 #include "main/main.h"
 
 StringBuilder &operator<<(StringBuilder &r_sb, const String &p_string) {
@@ -128,6 +130,8 @@ const Vector<String> ignored_types = {};
 // Don't check against all C# reserved words, as many cases are GDScript-specific.
 const Vector<String> langword_check = { "true", "false", "null" };
 
+static constexpr const char *LOCALIZED_DOCS_DIR = "LocalizedDocs";
+
 // The following properties currently need to be defined with `new` to avoid warnings. We treat
 // them as a special case instead of silencing the warnings altogether, to be warned if more
 // shadowing appears.
@@ -174,6 +178,75 @@ static String fix_doc_description(const String &p_bbcode) {
 	return p_bbcode.dedent()
 			.remove_chars("\r")
 			.strip_edges();
+}
+
+static String _get_doc_indent(const String &p_text) {
+	String indent;
+	bool has_text = false;
+	int line_start = 0;
+
+	for (int i = 0; i < p_text.length(); i++) {
+		const char32_t c = p_text[i];
+		if (c == '\n') {
+			line_start = i + 1;
+		} else if (c > 32) {
+			has_text = true;
+			indent = p_text.substr(line_start, i - line_start);
+			break;
+		}
+	}
+
+	if (!has_text) {
+		return p_text;
+	}
+
+	return indent;
+}
+
+static void _append_localized_doc_locale(Vector<String> &r_locales, const String &p_locale) {
+	TranslationServer *translation_server = TranslationServer::get_singleton();
+	ERR_FAIL_NULL(translation_server);
+
+	String locale = p_locale.strip_edges();
+	if (locale.is_empty()) {
+		return;
+	}
+
+	locale = translation_server->standardize_locale(locale, false).replace("_", "-");
+	if (locale.is_empty()) {
+		return;
+	}
+
+	for (const String &existing_locale : r_locales) {
+		if (existing_locale == locale) {
+			return;
+		}
+	}
+
+	r_locales.push_back(locale);
+}
+
+static Vector<String> _parse_localized_doc_locales(const String &p_locales_arg) {
+	Vector<String> locales;
+	if (p_locales_arg.is_empty()) {
+		return locales;
+	}
+
+	for (const String &raw_locale : p_locales_arg.split(",", false)) {
+		_append_localized_doc_locale(locales, raw_locale);
+	}
+
+	return locales;
+}
+
+static Vector<String> _get_localized_doc_locales() {
+	Vector<String> locales;
+
+	for (const String &locale : get_doc_locales()) {
+		_append_localized_doc_locale(locales, locale);
+	}
+
+	return locales;
 }
 
 String BindingsGenerator::bbcode_to_text(const String &p_bbcode, const TypeInterface *p_itype) {
@@ -809,6 +882,358 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 	xml_output.append("</para>");
 
 	return xml_output.as_string();
+}
+
+String BindingsGenerator::_translate_doc_string(const String &p_text) {
+	const String indent = _get_doc_indent(p_text);
+	const String message = p_text.dedent().strip_edges();
+	const String translated = TranslationServer::get_singleton()->get_doc_domain()->translate(message, StringName());
+	return translated.indent(indent);
+}
+
+String BindingsGenerator::_get_localized_doc_summary_xml(const String &p_text, const TypeInterface *p_itype, bool p_is_signal) {
+	if (p_text.is_empty()) {
+		return String();
+	}
+
+	return bbcode_to_xml(fix_doc_description(_translate_doc_string(p_text)), p_itype, p_is_signal);
+}
+
+String BindingsGenerator::_get_xml_doc_type_name(const TypeReference &p_typeref) {
+	const TypeInterface *itype = _get_type_or_singleton_or_null(p_typeref);
+	ERR_FAIL_NULL_V_MSG(itype, String(), "Type '" + String(p_typeref.cname) + "' was not found for XML docs generation.");
+
+	String cs_type = itype->cs_type;
+	if (cs_type.ends_with("[]")) {
+		String elem_type = cs_type.substr(0, cs_type.length() - 2);
+		if (elem_type == "byte") {
+			elem_type = "System.Byte";
+		} else if (elem_type == "int") {
+			elem_type = "System.Int32";
+		} else if (elem_type == "long") {
+			elem_type = "System.Int64";
+		} else if (elem_type == "float") {
+			elem_type = "System.Single";
+		} else if (elem_type == "double") {
+			elem_type = "System.Double";
+		} else if (elem_type == "string") {
+			elem_type = "System.String";
+		} else if (!elem_type.contains(".")) {
+			elem_type = String(BINDINGS_NAMESPACE) + "." + elem_type;
+		}
+		return elem_type + "[]";
+	}
+
+	if (cs_type == "bool") {
+		cs_type = "System.Boolean";
+	} else if (cs_type == "byte") {
+		cs_type = "System.Byte";
+	} else if (cs_type == "sbyte") {
+		cs_type = "System.SByte";
+	} else if (cs_type == "short") {
+		cs_type = "System.Int16";
+	} else if (cs_type == "ushort") {
+		cs_type = "System.UInt16";
+	} else if (cs_type == "int") {
+		cs_type = "System.Int32";
+	} else if (cs_type == "uint") {
+		cs_type = "System.UInt32";
+	} else if (cs_type == "long") {
+		cs_type = "System.Int64";
+	} else if (cs_type == "ulong") {
+		cs_type = "System.UInt64";
+	} else if (cs_type == "float") {
+		cs_type = "System.Single";
+	} else if (cs_type == "double") {
+		cs_type = "System.Double";
+	} else if (cs_type == "string") {
+		cs_type = "System.String";
+	} else if (!cs_type.contains(".")) {
+		cs_type = String(BINDINGS_NAMESPACE) + "." + cs_type;
+	}
+
+	if (!p_typeref.generic_type_parameters.is_empty()) {
+		cs_type += "{";
+		bool first = true;
+		for (const TypeReference &generic_arg : p_typeref.generic_type_parameters) {
+			if (!first) {
+				cs_type += ",";
+			}
+			first = false;
+			cs_type += _get_xml_doc_type_name(generic_arg);
+		}
+		cs_type += "}";
+	}
+
+	return cs_type;
+}
+
+String BindingsGenerator::_get_xml_doc_method_name(const TypeInterface &p_itype, const MethodInterface &p_imethod) {
+	String member_name = "M:" + String(BINDINGS_NAMESPACE) + "." + p_itype.proxy_name + "." + p_imethod.proxy_name;
+	if (p_imethod.arguments.is_empty()) {
+		return member_name;
+	}
+
+	member_name += "(";
+	bool first = true;
+	for (const ArgumentInterface &argument : p_imethod.arguments) {
+		if (!first) {
+			member_name += ",";
+		}
+		first = false;
+		member_name += _get_xml_doc_type_name(argument.type);
+	}
+	member_name += ")";
+
+	return member_name;
+}
+
+void BindingsGenerator::_append_xml_doc_member(StringBuilder &p_output, const String &p_member_name, const String &p_summary) {
+	if (p_summary.is_empty()) {
+		return;
+	}
+
+	const Vector<String> summary_lines = p_summary.split("\n", false);
+	if (summary_lines.is_empty()) {
+		return;
+	}
+
+	p_output.append("    <member name=\"");
+	p_output.append(p_member_name.xml_escape(true));
+	p_output.append("\">\n");
+	p_output.append("      <summary>\n");
+	for (const String &summary_line : summary_lines) {
+		p_output.append("        ");
+		p_output.append(summary_line);
+		p_output.append("\n");
+	}
+	p_output.append("      </summary>\n");
+	p_output.append("    </member>\n");
+}
+
+void BindingsGenerator::_append_xml_doc_global_members(StringBuilder &p_output) {
+	for (const ConstantInterface &iconstant : global_constants) {
+		if (!iconstant.const_doc || iconstant.const_doc->description.is_empty()) {
+			continue;
+		}
+
+		_append_xml_doc_member(
+				p_output,
+				String("F:") + String(BINDINGS_NAMESPACE) + "." + String(BINDINGS_GLOBAL_SCOPE_CLASS) + "." + iconstant.proxy_name,
+				_get_localized_doc_summary_xml(iconstant.const_doc->description, nullptr));
+	}
+
+	for (const EnumInterface &ienum : global_enums) {
+		const TypeInterface *enum_itype = enum_types.getptr(ienum.cname);
+		if (enum_itype && enum_itype->class_doc && !enum_itype->class_doc->description.is_empty()) {
+			_append_xml_doc_member(
+					p_output,
+					String("T:") + String(BINDINGS_NAMESPACE) + "." + ienum.proxy_name,
+					_get_localized_doc_summary_xml(enum_itype->class_doc->description, nullptr));
+		}
+
+		for (const ConstantInterface &iconstant : ienum.constants) {
+			if (!iconstant.const_doc || iconstant.const_doc->description.is_empty()) {
+				continue;
+			}
+
+			_append_xml_doc_member(
+					p_output,
+					String("F:") + String(BINDINGS_NAMESPACE) + "." + ienum.proxy_name + "." + iconstant.proxy_name,
+					_get_localized_doc_summary_xml(iconstant.const_doc->description, nullptr));
+		}
+	}
+}
+
+void BindingsGenerator::_append_xml_doc_type_members(StringBuilder &p_output, const TypeInterface &p_itype) {
+	if (p_itype.class_doc && !p_itype.class_doc->description.is_empty()) {
+		_append_xml_doc_member(
+				p_output,
+				String("T:") + String(BINDINGS_NAMESPACE) + "." + p_itype.proxy_name,
+				_get_localized_doc_summary_xml(p_itype.class_doc->description, &p_itype));
+	}
+
+	for (const ConstantInterface &iconstant : p_itype.constants) {
+		if (!iconstant.const_doc || iconstant.const_doc->description.is_empty()) {
+			continue;
+		}
+
+		_append_xml_doc_member(
+				p_output,
+				String("F:") + String(BINDINGS_NAMESPACE) + "." + p_itype.proxy_name + "." + iconstant.proxy_name,
+				_get_localized_doc_summary_xml(iconstant.const_doc->description, &p_itype));
+	}
+
+	for (const EnumInterface &ienum : p_itype.enums) {
+		const TypeInterface *enum_itype = enum_types.getptr(ienum.cname);
+		if (enum_itype && enum_itype->class_doc && !enum_itype->class_doc->description.is_empty()) {
+			_append_xml_doc_member(
+					p_output,
+					String("T:") + String(BINDINGS_NAMESPACE) + "." + p_itype.proxy_name + "." + ienum.proxy_name,
+					_get_localized_doc_summary_xml(enum_itype->class_doc->description, &p_itype));
+		}
+
+		for (const ConstantInterface &iconstant : ienum.constants) {
+			if (!iconstant.const_doc || iconstant.const_doc->description.is_empty()) {
+				continue;
+			}
+
+			_append_xml_doc_member(
+					p_output,
+					String("F:") + String(BINDINGS_NAMESPACE) + "." + p_itype.proxy_name + "." + ienum.proxy_name + "." + iconstant.proxy_name,
+					_get_localized_doc_summary_xml(iconstant.const_doc->description, &p_itype));
+		}
+	}
+
+	for (const PropertyInterface &iprop : p_itype.properties) {
+		if (!iprop.prop_doc || iprop.prop_doc->description.is_empty()) {
+			continue;
+		}
+
+		_append_xml_doc_member(
+				p_output,
+				String("P:") + String(BINDINGS_NAMESPACE) + "." + p_itype.proxy_name + "." + iprop.proxy_name,
+				_get_localized_doc_summary_xml(iprop.prop_doc->description, &p_itype));
+	}
+
+	for (const MethodInterface &imethod : p_itype.methods) {
+		if (!imethod.method_doc || imethod.method_doc->description.is_empty()) {
+			continue;
+		}
+
+		_append_xml_doc_member(
+				p_output,
+				_get_xml_doc_method_name(p_itype, imethod),
+				_get_localized_doc_summary_xml(imethod.method_doc->description, &p_itype));
+	}
+
+	for (const SignalInterface &isignal : p_itype.signals_) {
+		if (!isignal.method_doc || isignal.method_doc->description.is_empty()) {
+			continue;
+		}
+
+		_append_xml_doc_member(
+				p_output,
+				String("E:") + String(BINDINGS_NAMESPACE) + "." + p_itype.proxy_name + "." + isignal.proxy_name,
+				_get_localized_doc_summary_xml(isignal.method_doc->description, &p_itype, true));
+	}
+}
+
+Error BindingsGenerator::_generate_localized_xml_doc(ClassDB::APIType p_api_type, const String &p_assembly_name, const String &p_output_file) {
+	StringBuilder output;
+	output.append("<?xml version=\"1.0\"?>\n");
+	output.append("<doc>\n");
+	output.append("  <assembly>\n");
+	output.append("    <name>");
+	output.append(p_assembly_name.xml_escape());
+	output.append("</name>\n");
+	output.append("  </assembly>\n");
+	output.append("  <members>\n");
+
+	if (p_api_type == ClassDB::API_CORE) {
+		_append_xml_doc_global_members(output);
+	}
+
+	for (const KeyValue<StringName, TypeInterface> &entry : obj_types) {
+		const TypeInterface &itype = entry.value;
+		if (itype.api_type != p_api_type) {
+			continue;
+		}
+		_append_xml_doc_type_members(output, itype);
+	}
+
+	output.append("  </members>\n");
+	output.append("</doc>\n");
+
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	ERR_FAIL_COND_V(da.is_null(), ERR_CANT_CREATE);
+
+	const String base_dir = p_output_file.get_base_dir();
+	if (!DirAccess::exists(base_dir)) {
+		Error err = da->make_dir_recursive(base_dir);
+		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot create directory '" + base_dir + "'.");
+	}
+
+	return _save_file(p_output_file, output);
+}
+
+Error BindingsGenerator::_generate_localized_xml_docs(const String &p_output_dir, const Vector<String> &p_locales) {
+	if (p_locales.is_empty()) {
+		return OK;
+	}
+
+	// Pre-clear existing localized docs directories to avoid stale files
+	// from locales that may no longer be generated or have disappeared.
+	{
+		auto clear_localized_docs_dir = [](const String &p_dir) {
+			if (!DirAccess::exists(p_dir)) {
+				return;
+			}
+			Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+			ERR_FAIL_COND_MSG(da.is_null(), "Cannot create DirAccess for clearing: '" + p_dir + "'.");
+			Error err = da->change_dir(p_dir);
+			if (err != OK) {
+				ERR_PRINT("Cannot change to directory: '" + p_dir + "'.");
+				return;
+			}
+			err = da->erase_contents_recursive();
+			if (err != OK) {
+				ERR_PRINT("Cannot erase contents of directory: '" + p_dir + "'.");
+				return;
+			}
+			err = da->change_dir("..");
+			if (err != OK) {
+				return;
+			}
+			err = da->remove(p_dir);
+			if (err != OK) {
+				WARN_PRINT("Cannot remove empty directory: '" + p_dir + "'.");
+			}
+		};
+
+		clear_localized_docs_dir(p_output_dir.path_join(CORE_API_ASSEMBLY_NAME).path_join(LOCALIZED_DOCS_DIR));
+		clear_localized_docs_dir(p_output_dir.path_join(EDITOR_API_ASSEMBLY_NAME).path_join(LOCALIZED_DOCS_DIR));
+	}
+
+	TranslationServer *translation_server = TranslationServer::get_singleton();
+	ERR_FAIL_NULL_V(translation_server, ERR_UNCONFIGURED);
+
+	const String original_locale = translation_server->get_locale();
+
+	for (const String &requested_locale : p_locales) {
+		const String standardized_locale = translation_server->standardize_locale(requested_locale, false);
+		const String nuget_locale = standardized_locale.replace("_", "-");
+		if (standardized_locale.is_empty() || nuget_locale == "en") {
+			continue;
+		}
+
+		load_doc_translations(standardized_locale);
+		translation_server->set_locale(standardized_locale);
+
+		Error err = _generate_localized_xml_doc(
+				ClassDB::API_CORE,
+				CORE_API_ASSEMBLY_NAME,
+				p_output_dir.path_join(CORE_API_ASSEMBLY_NAME).path_join(LOCALIZED_DOCS_DIR).path_join(nuget_locale).path_join(CORE_API_ASSEMBLY_NAME ".xml"));
+		if (err != OK) {
+			load_doc_translations(original_locale);
+			translation_server->set_locale(original_locale);
+			return err;
+		}
+
+		err = _generate_localized_xml_doc(
+				ClassDB::API_EDITOR,
+				EDITOR_API_ASSEMBLY_NAME,
+				p_output_dir.path_join(EDITOR_API_ASSEMBLY_NAME).path_join(LOCALIZED_DOCS_DIR).path_join(nuget_locale).path_join(EDITOR_API_ASSEMBLY_NAME ".xml"));
+		if (err != OK) {
+			load_doc_translations(original_locale);
+			translation_server->set_locale(original_locale);
+			return err;
+		}
+	}
+
+	load_doc_translations(original_locale);
+	translation_server->set_locale(original_locale);
+	return OK;
 }
 
 void BindingsGenerator::_append_text_method(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
@@ -2093,7 +2518,7 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 	return OK;
 }
 
-Error BindingsGenerator::generate_cs_api(const String &p_output_dir) {
+Error BindingsGenerator::generate_cs_api(const String &p_output_dir, const Vector<String> &p_localized_doc_locales) {
 	ERR_FAIL_COND_V(!initialized, ERR_UNCONFIGURED);
 
 	String output_dir = Path::abspath(Path::realpath(p_output_dir));
@@ -2125,6 +2550,12 @@ Error BindingsGenerator::generate_cs_api(const String &p_output_dir) {
 	proj_err = generate_cs_editor_project(editor_proj_dir);
 	if (proj_err != OK) {
 		ERR_PRINT("Generation of the Editor API C# project failed.");
+		return proj_err;
+	}
+
+	proj_err = _generate_localized_xml_docs(output_dir, p_localized_doc_locales);
+	if (proj_err != OK) {
+		ERR_PRINT("Generation of localized XML docs failed.");
 		return proj_err;
 	}
 
@@ -5250,8 +5681,9 @@ void BindingsGenerator::_initialize() {
 }
 
 static String generate_all_glue_option = "--generate-mono-glue";
+static String generate_localized_docs_option = "--generate-localized-docs";
 
-static void handle_cmdline_options(String glue_dir_path) {
+static void handle_cmdline_options(String glue_dir_path, const Vector<String> &p_localized_doc_locales) {
 	BindingsGenerator bindings_generator;
 	bindings_generator.set_log_print_enabled(true);
 
@@ -5262,7 +5694,7 @@ static void handle_cmdline_options(String glue_dir_path) {
 
 	CRASH_COND(glue_dir_path.is_empty());
 
-	if (bindings_generator.generate_cs_api(glue_dir_path.path_join(API_SOLUTION_NAME)) != OK) {
+	if (bindings_generator.generate_cs_api(glue_dir_path.path_join(API_SOLUTION_NAME), p_localized_doc_locales) != OK) {
 		ERR_PRINT(generate_all_glue_option + ": Failed to generate the C# API.");
 	}
 }
@@ -5273,8 +5705,14 @@ static void cleanup_and_exit_godot() {
 	::exit(0);
 }
 
+static bool _is_cmdline_option(const String &p_arg) {
+	return p_arg.begins_with("-");
+}
+
 void BindingsGenerator::handle_cmdline_args(const List<String> &p_cmdline_args) {
 	String glue_dir_path;
+	String localized_docs_locales_arg;
+	bool generate_localized_docs = false;
 
 	const List<String>::Element *elem = p_cmdline_args.front();
 
@@ -5290,17 +5728,30 @@ void BindingsGenerator::handle_cmdline_args(const List<String> &p_cmdline_args) 
 				// Exit once done with invalid command line arguments.
 				cleanup_and_exit_godot();
 			}
+		}
 
-			break;
+		if (elem->get() == generate_localized_docs_option) {
+			generate_localized_docs = true;
+
+			const List<String>::Element *locales_elem = elem->next();
+			if (locales_elem && !_is_cmdline_option(locales_elem->get())) {
+				localized_docs_locales_arg = locales_elem->get();
+				elem = elem->next();
+			}
 		}
 
 		elem = elem->next();
 	}
 
 	if (glue_dir_path.length()) {
+		Vector<String> localized_doc_locales;
+		if (generate_localized_docs) {
+			localized_doc_locales = localized_docs_locales_arg.is_empty() ? _get_localized_doc_locales() : _parse_localized_doc_locales(localized_docs_locales_arg);
+		}
+
 		if (Engine::get_singleton()->is_editor_hint() ||
 				Engine::get_singleton()->is_project_manager_hint()) {
-			handle_cmdline_options(glue_dir_path);
+			handle_cmdline_options(glue_dir_path, localized_doc_locales);
 		} else {
 			// Running from a project folder, which doesn't make sense and crashes.
 			ERR_PRINT(generate_all_glue_option + ": Cannot generate Mono glue while running a game project. Change current directory or enable --editor.");

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -792,6 +792,15 @@ class BindingsGenerator {
 
 	String bbcode_to_text(const String &p_bbcode, const TypeInterface *p_itype);
 	String bbcode_to_xml(const String &p_bbcode, const TypeInterface *p_itype, bool p_is_signal = false);
+	String _translate_doc_string(const String &p_text);
+	String _get_localized_doc_summary_xml(const String &p_text, const TypeInterface *p_itype, bool p_is_signal = false);
+	String _get_xml_doc_type_name(const TypeReference &p_typeref);
+	String _get_xml_doc_method_name(const TypeInterface &p_itype, const MethodInterface &p_imethod);
+	void _append_xml_doc_member(StringBuilder &p_output, const String &p_member_name, const String &p_summary);
+	void _append_xml_doc_global_members(StringBuilder &p_output);
+	void _append_xml_doc_type_members(StringBuilder &p_output, const TypeInterface &p_itype);
+	Error _generate_localized_xml_doc(ClassDB::APIType p_api_type, const String &p_assembly_name, const String &p_output_file);
+	Error _generate_localized_xml_docs(const String &p_output_dir, const Vector<String> &p_locales);
 
 	void _append_text_method(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
 	void _append_text_member(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
@@ -858,7 +867,7 @@ class BindingsGenerator {
 public:
 	Error generate_cs_core_project(const String &p_proj_dir);
 	Error generate_cs_editor_project(const String &p_proj_dir);
-	Error generate_cs_api(const String &p_output_dir);
+	Error generate_cs_api(const String &p_output_dir, const Vector<String> &p_localized_doc_locales = Vector<String>());
 
 	_FORCE_INLINE_ bool is_log_print_enabled() { return log_print_enabled; }
 	_FORCE_INLINE_ void set_log_print_enabled(bool p_enabled) { log_print_enabled = p_enabled; }

--- a/modules/mono/glue/GodotSharp/.gitignore
+++ b/modules/mono/glue/GodotSharp/.gitignore
@@ -1,3 +1,5 @@
 # Generated Godot API sources directories
 GodotSharp/Generated
+GodotSharp/LocalizedDocs
 GodotSharpEditor/Generated
+GodotSharpEditor/LocalizedDocs

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -29,6 +29,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);CollectLocalizedDocsForPack</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <ItemGroup>
@@ -37,6 +38,14 @@
       <Link>SdkPackageVersions.props</Link>
     </None>
   </ItemGroup>
+
+  <Target Name="CollectLocalizedDocsForPack">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="LocalizedDocs\**\*.xml">
+        <PackagePath>lib\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+  </Target>
 
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);GODOT</DefineConstants>

--- a/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
@@ -25,6 +25,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);CollectLocalizedDocsForPack</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);GODOT</DefineConstants>
@@ -35,6 +36,13 @@
       <Private>false</Private>
     </ProjectReference>
   </ItemGroup>
+  <Target Name="CollectLocalizedDocsForPack">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="LocalizedDocs\**\*.xml">
+        <PackagePath>lib\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+  </Target>
   <!-- Compat Sources -->
   <ItemGroup Condition=" '$(GodotNoDeprecated)' == '' ">
     <Compile Include="Compat.cs" />


### PR DESCRIPTION
## Summary

This PR adds support for generating localized XML documentation for the GodotSharp API and shipping those files with the generated assemblies and NuGet packages.

<details>

## Motivation

Godot already ships translated class reference data for multiple locales, but the C# API currently only exposes the default XML documentation output. This makes IntelliSense and API help less useful for users working in other supported documentation languages.

This change extends the Mono glue workflow so localized documentation can be generated from the existing translated docs data and carried through the rest of the GodotSharp distribution pipeline.

## Technical overview

- Adds a way to query available documentation locales from the editor translation data.
- Extends the bindings generator to emit localized XML docs under `LocalizedDocs` when `--generate-localized-docs` is passed during `--generate-mono-glue`.
- Supports generating all available locales by default, or limiting generation to a comma-separated locale list.
- Updates the Mono build script to detect generated localized docs and copy them into the assembled GodotSharp API output.
- Updates the GodotSharp and GodotSharpEditor project files so localized XML docs are included in the packaged output.
- Documents the new workflow in the Mono README.

## Discussion

This is intended to be opt-in and backward-compatible; the official release should be built with the localized docs enabled for best usability.

Without `--generate-localized-docs`, the existing glue generation flow is unchanged. When localized docs are requested, the generator reuses the existing translated documentation data already available in the editor. The build step also fails loudly if a locale is expected but the corresponding XML file is missing, so incomplete localized outputs are not silently shipped.

</details>

## Testing (Windows)

1. Build the editor with mono module: `scons module_mono_enabled=yes`
2. Generate the glue and the localized documentation: `.\bin\godot.windows.editor.x86_64.mono.console.exe --generate-mono-glue ./modules/mono/glue --generate-localized-docs --headless`
3. Build the GodotSharp packages: `python .\modules\mono\build_scripts\build_assemblies.py --godot-output-dir=.\bin`

One liner:
```powershell
scons module_mono_enabled=yes; .\bin\godot.windows.editor.x86_64.mono.console.exe --generate-mono-glue ./modules/mono/glue --generate-localized-docs --headless; python .\modules\mono\build_scripts\build_assemblies.py --godot-output-dir=.\bin
```

## AI disclosure

`GPT 5.4` was used with caution and close supervision while creating this PR and its associated messages. The author has thoroughly reviewed all modified files and made manual adjustments to ensure that the command-line arguments and features introduced in this PR adhere to good ergonomic practices and do not add unnecessary complexity to the codebase. 

Additionally, the author tested the generated package across all available IDEs at hand to confirm its functionality. 
However, it appears that the C# extension in Visual Studio Code (VSCode) does not support localized IntelliSense. Suggestions from VSCode C# users would be appreciated to determine whether this is an actual limitation or a local configuration issue. If it is confirmed that support is lacking, an issue may need to be raised with the VSCode C# extension repository.

## Preview

|Works|Doesn't Work|
|-|-|
|Visual Studio<br/><img width="1271" height="673" alt="image" src="https://github.com/user-attachments/assets/c5ed2316-8ee8-4211-9667-86faa8044821" />|C# VSCode<br/><img width="914" height="435" alt="image" src="https://github.com/user-attachments/assets/2afd12c1-7eb7-4cba-bb41-d50650d7faa2" />|
|Reshaper VSCode<br/><img width="837" height="377" alt="image" src="https://github.com/user-attachments/assets/1e5cb5b7-c17b-407d-bce1-cc103dad0f0e" />|C# (OmniSharp) VSCode<br/><img width="811" height="371" alt="image" src="https://github.com/user-attachments/assets/8ee0ed64-d1e4-4ff9-bf42-8141ab2c9e0e" />|
|Rider<br/><img width="899" height="580" alt="image" src="https://github.com/user-attachments/assets/c2836bf9-5263-4b58-a252-e1e0ccfafd5c" />||
