### PR TITLE
Unix: kill process group instead of single process

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -995,7 +995,8 @@ Error OS_Unix::create_process(const String &p_path, const List<String> &p_argume
 }
 
 Error OS_Unix::kill(const ProcessID &p_pid) {
-	int ret = ::kill(p_pid, SIGKILL);
+	// Use negative pid to kill the entire process group instead of only the parent process
+	int ret = ::kill(-p_pid, SIGKILL);
 	if (!ret) {
 		//avoid zombie process
 		int st;


### PR DESCRIPTION
Fixes #97429

I believe this is only an issue with the snap version of Blender. I tested with a standalone version and it's working as expected.

This is because the snapcraft version of Blender creates two processes for some reason. `blender` and `blender-wrapper`. I could not find a reason why they do this.
The pid we get when creating the process is from the `blender-wrapper`. Killing this process does not kill the `blender` processm which is the one actually running the server and communicating with godot. Not killing the server has unintended consequences, such as the blender python script not able to create the server due to the port already being used, or godot communicating with the wrong server and blocking the entire process.

The fix is to kill the entire process group (with negative pid) instead of the single process.

This might not be the proper way to handle this issue. It works in the case of Blender, it might have side effects for other scenarios. I can't see why we would want to kill a process but not its children at first glance

It might be safer to add a boolean when calling OS::kill(), but I didn't feel like changing the API and implementing the change on windows (far more annoying to implement). 
Another way would be to ask the Blender team to only use a single process in snap package, or ask them to handle process signals for child processes. But I assume they do it for a reason.