### PR TITLE
Allow all tab containers to optionally enable ctrl + number hotkeys

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -429,6 +429,15 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
 	{ "ui_filedialog_show_hidden",                     TTRC("Show Hidden") },
 	{ "ui_filedialog_find",                            TTRC("Find") },
 	{ "ui_filedialog_focus_path",                      TTRC("Focus Path") },
+	{ "ui_focus_tab1", 			                       TTRC("Focus Tab 1") },
+	{ "ui_focus_tab2", 			                       TTRC("Focus Tab 2") },
+	{ "ui_focus_tab3", 			                       TTRC("Focus Tab 3") },
+	{ "ui_focus_tab4", 			                       TTRC("Focus Tab 4") },
+	{ "ui_focus_tab5", 			                       TTRC("Focus Tab 5") },
+	{ "ui_focus_tab6", 			                       TTRC("Focus Tab 6") },
+	{ "ui_focus_tab7", 			                       TTRC("Focus Tab 7") },
+	{ "ui_focus_tab8", 			                       TTRC("Focus Tab 8") },
+	{ "ui_focus_last_tab", 		                       TTRC("Focus Last Tab") },
 	{ "ui_swap_input_direction",                       TTRC("Swap Input Direction") },
 	{ "ui_unicode_start",                              TTRC("Start Unicode Character Input") },
 	{ "ui_colorpicker_delete_preset",                  TTRC("ColorPicker: Delete Preset") },
@@ -486,6 +495,16 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::TAB | KeyModifierMask::SHIFT));
 	default_builtin_cache.insert("ui_focus_prev", inputs);
+
+	for (int i = 1; i <= 8; i++) {
+		inputs = List<Ref<InputEvent>>();
+		inputs.push_back(InputEventKey::create_reference((Key::KEY_0 + i) | KeyModifierMask::CMD_OR_CTRL));
+		default_builtin_cache.insert("ui_focus_tab" + itos(i), inputs);
+	}
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::KEY_9 | KeyModifierMask::CMD_OR_CTRL));
+	default_builtin_cache.insert("ui_focus_last_tab", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::LEFT));

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -429,6 +429,15 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
 	{ "ui_filedialog_show_hidden",                     TTRC("Show Hidden") },
 	{ "ui_filedialog_find",                            TTRC("Find") },
 	{ "ui_filedialog_focus_path",                      TTRC("Focus Path") },
+	{ "ui_focus_tab1", 			                       TTRC("Focus Tab 1") },
+	{ "ui_focus_tab2", 			                       TTRC("Focus Tab 2") },
+	{ "ui_focus_tab3", 			                       TTRC("Focus Tab 3") },
+	{ "ui_focus_tab4", 			                       TTRC("Focus Tab 4") },
+	{ "ui_focus_tab5", 			                       TTRC("Focus Tab 5") },
+	{ "ui_focus_tab6", 			                       TTRC("Focus Tab 6") },
+	{ "ui_focus_tab7", 			                       TTRC("Focus Tab 7") },
+	{ "ui_focus_tab8", 			                       TTRC("Focus Tab 8") },
+	{ "ui_focus_last_tab", 		                       TTRC("Focus Last Tab") },
 	{ "ui_swap_input_direction",                       TTRC("Swap Input Direction") },
 	{ "ui_unicode_start",                              TTRC("Start Unicode Character Input") },
 	{ "ui_colorpicker_delete_preset",                  TTRC("ColorPicker: Delete Preset") },
@@ -487,6 +496,16 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::TAB | KeyModifierMask::SHIFT));
 	default_builtin_cache.insert("ui_focus_prev", inputs);
+
+	for (int i = 1; i <= 8; i++) {
+		inputs = List<Ref<InputEvent>>();
+		inputs.push_back(InputEventKey::create_reference((Key::KEY_0 + i) | KeyModifierMask::CMD_OR_CTRL));
+		default_builtin_cache.insert("ui_focus_tab" + itos(i), inputs);
+	}
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::KEY_9 | KeyModifierMask::CMD_OR_CTRL));
+	default_builtin_cache.insert("ui_focus_last_tab", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::LEFT));

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1372,6 +1372,10 @@
 			Default [InputEventAction] to go up one directory in a [FileDialog].
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
+		<member name="input/ui_focus_last_tab" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the last tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
 		<member name="input/ui_focus_mode" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to switch [TextEdit] [member input/ui_text_indent] between moving keyboard focus to the next [Control] in the scene and inputting a [code]Tab[/code] character.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
@@ -1382,6 +1386,38 @@
 		</member>
 		<member name="input/ui_focus_prev" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to focus the previous [Control] in the scene. The focus behavior can be configured via [member Control.focus_previous].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab1" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the first tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab2" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the second tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab3" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the third tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab4" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the fourth tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab5" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the fifth tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab6" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the sixth tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab7" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the seventh tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab8" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the eighth tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
 		<member name="input/ui_graph_delete" type="Dictionary" setter="" getter="">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1375,6 +1375,10 @@
 			Default [InputEventAction] to go up one directory in a [FileDialog].
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
+		<member name="input/ui_focus_last_tab" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the last tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
 		<member name="input/ui_focus_mode" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to switch [TextEdit] [member input/ui_text_indent] between moving keyboard focus to the next [Control] in the scene and inputting a [code]Tab[/code] character.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
@@ -1385,6 +1389,38 @@
 		</member>
 		<member name="input/ui_focus_prev" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to focus the previous [Control] in the scene. The focus behavior can be configured via [member Control.focus_previous].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab1" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the first tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab2" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the second tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab3" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the third tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab4" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the fourth tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab5" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the fifth tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab6" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the sixth tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab7" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the seventh tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_focus_tab8" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to focus the eighth tab in a [TabContainer]. Only works if the [TabContainer] has [member TabContainer.allow_tab_hotkeys] set to [code]true[/code].
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
 		<member name="input/ui_graph_delete" type="Dictionary" setter="" getter="">

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -209,6 +209,9 @@
 		<member name="all_tabs_in_front" type="bool" setter="set_all_tabs_in_front" getter="is_all_tabs_in_front" default="false">
 			If [code]true[/code], all tabs are drawn in front of the panel. If [code]false[/code], inactive tabs are drawn behind the panel.
 		</member>
+		<member name="allow_tab_hotkeys" type="bool" setter="set_allows_tab_hotkeys" getter="does_allow_tab_hotkeys" default="false">
+			If [code]true[/code], the shortcuts [code]ui_focus_tab[1-8][/code] and [code]ui_focus_last_tab[/code] will switch the active tab on this [TabContainer]. Otherwise, these shortcuts will be ignored.
+		</member>
 		<member name="clip_tabs" type="bool" setter="set_clip_tabs" getter="get_clip_tabs" default="true">
 			If [code]true[/code], tabs overflowing this node's width will be hidden, displaying two navigation buttons instead. Otherwise, this node's minimum size is updated so that all tabs are visible.
 		</member>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -209,6 +209,9 @@
 		<member name="all_tabs_in_front" type="bool" setter="set_all_tabs_in_front" getter="is_all_tabs_in_front" deprecated="Due to internal changes this doesn&apos;t do anything anymore, as they&apos;re always in front.">
 			This doesn't do anything.
 		</member>
+		<member name="allow_tab_hotkeys" type="bool" setter="set_allows_tab_hotkeys" getter="does_allow_tab_hotkeys" default="false">
+			If [code]true[/code], the shortcuts [code]ui_focus_tab[1-8][/code] and [code]ui_focus_last_tab[/code] will switch the active tab on this [TabContainer]. Otherwise, these shortcuts will be ignored.
+		</member>
 		<member name="clip_tabs" type="bool" setter="set_clip_tabs" getter="get_clip_tabs" default="true">
 			If [code]true[/code], tabs overflowing this node's width will be hidden, displaying two navigation buttons instead. Otherwise, this node's minimum size is updated so that all tabs are visible.
 		</member>

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -1039,6 +1039,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 
 	tabs->add_child(tab_shortcuts);
 	tab_shortcuts->set_name(TTRC("Shortcuts"));
+	tabs->set_allows_tab_hotkeys(true);
 
 	shortcut_search_bar = memnew(EditorEventSearchBar);
 	shortcut_search_bar->connect(SceneStringName(value_changed), callable_mp(this, &EditorSettingsDialog::_update_shortcuts));

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -1081,6 +1081,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 
 	tabs->add_child(tab_shortcuts);
 	tab_shortcuts->set_name(TTRC("Shortcuts"));
+	tabs->set_allows_tab_hotkeys(true);
 
 	shortcut_search_bar = memnew(EditorEventSearchBar);
 	shortcut_search_bar->connect(SceneStringName(value_changed), callable_mp(this, &EditorSettingsDialog::_update_shortcuts));

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -867,6 +867,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	import_defaults_editor = memnew(ImportDefaultsEditor);
 	import_defaults_editor->set_name(TTRC("Import Defaults"));
 	tab_container->add_child(import_defaults_editor);
+	tab_container->set_allows_tab_hotkeys(true);
 
 	MovieWriter::set_extensions_hint(); // ensure extensions are properly displayed.
 }

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -887,6 +887,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	import_defaults_editor = memnew(ImportDefaultsEditor);
 	import_defaults_editor->set_name(TTRC("Import Defaults"));
 	tab_container->add_child(import_defaults_editor);
+	tab_container->set_allows_tab_hotkeys(true);
 
 	MovieWriter::set_extensions_hint(); // ensure extensions are properly displayed.
 }

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -825,6 +825,18 @@ bool TabContainer::are_tabs_visible() const {
 	return tabs_visible;
 }
 
+void TabContainer::set_allows_tab_hotkeys(bool p_allow_hotkeys) {
+	if (p_allow_hotkeys == allows_tab_hotkeys) {
+		return;
+	}
+
+	allows_tab_hotkeys = p_allow_hotkeys;
+}
+
+bool TabContainer::does_allow_tab_hotkeys() const {
+	return allows_tab_hotkeys;
+}
+
 void TabContainer::set_all_tabs_in_front(bool p_in_front) {
 	if (p_in_front == all_tabs_in_front) {
 		return;
@@ -1140,6 +1152,8 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("are_tabs_visible"), &TabContainer::are_tabs_visible);
 	ClassDB::bind_method(D_METHOD("set_all_tabs_in_front", "is_front"), &TabContainer::set_all_tabs_in_front);
 	ClassDB::bind_method(D_METHOD("is_all_tabs_in_front"), &TabContainer::is_all_tabs_in_front);
+	ClassDB::bind_method(D_METHOD("set_allows_tab_hotkeys", "allow_tab_hotkeys"), &TabContainer::set_allows_tab_hotkeys);
+	ClassDB::bind_method(D_METHOD("does_allow_tab_hotkeys"), &TabContainer::does_allow_tab_hotkeys);
 
 	ClassDB::bind_method(D_METHOD("set_tab_title", "tab_idx", "title"), &TabContainer::set_tab_title);
 	ClassDB::bind_method(D_METHOD("get_tab_title", "tab_idx"), &TabContainer::get_tab_title);
@@ -1195,6 +1209,7 @@ void TabContainer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_hidden_tabs_for_min_size"), "set_use_hidden_tabs_for_min_size", "get_use_hidden_tabs_for_min_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tab_focus_mode", PROPERTY_HINT_ENUM, "None,Click,All"), "set_tab_focus_mode", "get_tab_focus_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deselect_enabled"), "set_deselect_enabled", "get_deselect_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_tab_hotkeys"), "set_allows_tab_hotkeys", "does_allow_tab_hotkeys");
 
 	ADD_CLASS_DEPENDENCY("TabBar");
 	ADD_CLASS_DEPENDENCY("Button");
@@ -1255,6 +1270,37 @@ void TabContainer::_bind_methods() {
 	PropertyListHelper::register_base_helper(&base_property_helper);
 }
 
+void TabContainer::shortcut_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	Ref<InputEventKey> key = p_event;
+
+	if (key.is_null() || !key->is_pressed()) {
+		return;
+	}
+
+	if (!allows_tab_hotkeys) {
+		return;
+	}
+	bool handled = false;
+	for (int i = 1; i <= 8; i++) {
+		if (p_event->is_action("ui_focus_tab" + itos(i), true)) {
+			set_current_tab(i - 1);
+			handled = true;
+			break;
+		}
+	}
+
+	if (p_event->is_action("ui_focus_last_tab", true)) {
+		set_current_tab(get_tab_count() - 1);
+		handled = true;
+	}
+
+	if (handled) {
+		get_viewport()->set_input_as_handled();
+	}
+}
+
 TabContainer::TabContainer() {
 	internal_container = memnew(HBoxContainer);
 	internal_container->add_theme_constant_override(SNAME("separation"), 0);
@@ -1277,4 +1323,5 @@ TabContainer::TabContainer() {
 
 	property_helper.setup_for_instance(base_property_helper, this);
 	property_helper.enable_out_of_bounds_assign();
+	set_process_shortcut_input(true);
 }

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -848,6 +848,18 @@ bool TabContainer::are_tabs_visible() const {
 	return tabs_visible;
 }
 
+void TabContainer::set_allows_tab_hotkeys(bool p_allow_hotkeys) {
+	if (p_allow_hotkeys == allows_tab_hotkeys) {
+		return;
+	}
+
+	allows_tab_hotkeys = p_allow_hotkeys;
+}
+
+bool TabContainer::does_allow_tab_hotkeys() const {
+	return allows_tab_hotkeys;
+}
+
 #ifndef DISABLE_DEPRECATED
 void TabContainer::set_all_tabs_in_front(bool p_in_front) {
 	if (p_in_front) {
@@ -1229,6 +1241,8 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_all_tabs_in_front", "is_front"), &TabContainer::set_all_tabs_in_front);
 	ClassDB::bind_method(D_METHOD("is_all_tabs_in_front"), &TabContainer::is_all_tabs_in_front);
 #endif
+	ClassDB::bind_method(D_METHOD("set_allows_tab_hotkeys", "allow_tab_hotkeys"), &TabContainer::set_allows_tab_hotkeys);
+	ClassDB::bind_method(D_METHOD("does_allow_tab_hotkeys"), &TabContainer::does_allow_tab_hotkeys);
 
 	ClassDB::bind_method(D_METHOD("set_tab_title", "tab_idx", "title"), &TabContainer::set_tab_title);
 	ClassDB::bind_method(D_METHOD("get_tab_title", "tab_idx"), &TabContainer::get_tab_title);
@@ -1287,6 +1301,7 @@ void TabContainer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_hidden_tabs_for_min_size"), "set_use_hidden_tabs_for_min_size", "get_use_hidden_tabs_for_min_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tab_focus_mode", PROPERTY_HINT_ENUM, "None,Click,All"), "set_tab_focus_mode", "get_tab_focus_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deselect_enabled"), "set_deselect_enabled", "get_deselect_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_tab_hotkeys"), "set_allows_tab_hotkeys", "does_allow_tab_hotkeys");
 
 	ADD_CLASS_DEPENDENCY("TabBar");
 	ADD_CLASS_DEPENDENCY("Button");
@@ -1347,6 +1362,37 @@ void TabContainer::_bind_methods() {
 	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 
+void TabContainer::shortcut_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	Ref<InputEventKey> key = p_event;
+
+	if (key.is_null() || !key->is_pressed()) {
+		return;
+	}
+
+	if (!allows_tab_hotkeys) {
+		return;
+	}
+	bool handled = false;
+	for (int i = 1; i <= 8; i++) {
+		if (p_event->is_action("ui_focus_tab" + itos(i), true)) {
+			set_current_tab(i - 1);
+			handled = true;
+			break;
+		}
+	}
+
+	if (p_event->is_action("ui_focus_last_tab", true)) {
+		set_current_tab(get_tab_count() - 1);
+		handled = true;
+	}
+
+	if (handled) {
+		get_viewport()->set_input_as_handled();
+	}
+}
+
 TabContainer::TabContainer() {
 	connect(SceneStringName(maximum_size_changed), callable_mp(this, &TabContainer::_maximum_size_changed));
 
@@ -1371,4 +1417,5 @@ TabContainer::TabContainer() {
 
 	property_helper.setup_for_instance(base_property_helper, this);
 	property_helper.enable_out_of_bounds_assign();
+	set_process_shortcut_input(true);
 }

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -54,6 +54,7 @@ private:
 	Button *popup_button = nullptr;
 
 	bool tabs_visible = true;
+	bool allows_tab_hotkeys = false;
 	bool all_tabs_in_front = false;
 	TabPosition tabs_position = POSITION_TOP;
 	mutable ObjectID popup_obj_id;
@@ -165,7 +166,7 @@ protected:
 
 public:
 	virtual bool accessibility_override_tree_hierarchy() const override { return true; }
-
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	HBoxContainer *get_internal_container() { return internal_container; }
 	TabBar *get_tab_bar() const;
 
@@ -186,6 +187,9 @@ public:
 
 	void set_tabs_visible(bool p_visible);
 	bool are_tabs_visible() const;
+
+	void set_allows_tab_hotkeys(bool p_allow_hotkeys);
+	bool does_allow_tab_hotkeys() const;
 
 	void set_all_tabs_in_front(bool p_is_front);
 	bool is_all_tabs_in_front() const;

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -54,6 +54,7 @@ private:
 	Button *popup_button = nullptr;
 
 	bool tabs_visible = true;
+	bool allows_tab_hotkeys = false;
 	TabPosition tabs_position = POSITION_TOP;
 	mutable ObjectID popup_obj_id;
 	bool use_hidden_tabs_for_min_size = false;
@@ -168,7 +169,7 @@ protected:
 
 public:
 	virtual bool accessibility_override_tree_hierarchy() const override { return true; }
-
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	HBoxContainer *get_internal_container() { return internal_container; }
 	TabBar *get_tab_bar() const;
 
@@ -192,6 +193,9 @@ public:
 
 	void set_tabs_visible(bool p_visible);
 	bool are_tabs_visible() const;
+
+	void set_allows_tab_hotkeys(bool p_allow_hotkeys);
+	bool does_allow_tab_hotkeys() const;
 
 #ifndef DISABLE_DEPRECATED
 	void set_all_tabs_in_front(bool p_is_front);


### PR DESCRIPTION
Partially addresses https://github.com/godotengine/godot-proposals/issues/14410

~I think project settings is used the most of all TabContainers, so I figured having this setting somewhere was better than nothing.~

~I also didn't know a great way to make this work across the different GUIs. My understanding is for the tab container to act on an input, it would have to have focus.~

EDIT: Changed so that all tab containers can optionally enable the hotkeys. Currently the project settings and editor settings allow it by default.

https://github.com/user-attachments/assets/99b3cfd3-8bab-4de5-b667-a00b43d3a174


