### PR TITLE
Create markers on all debugger monitors rather than just one

### DIFF
--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -190,7 +190,7 @@ void EditorPerformanceProfiler::_monitor_draw() {
 				monitor_draw->draw_line(rect.position + Point2(from, h2), rect.position + Point2(from + spacing, prev), draw_color, Math::round(EDSCALE));
 			}
 
-			if (marker_key == active[i] && count == marker_frame) {
+			if (count == marker_frame) {
 				Color line_color;
 				line_color.set_hsv(draw_color.get_h(), draw_color.get_s() * 0.8f, draw_color.get_v(), 0.5f);
 				monitor_draw->draw_line(rect.position + Point2(from, 0), rect.position + Point2(from, rect.size.y), line_color, Math::round(EDSCALE));


### PR DESCRIPTION
Most multi-monitor views create markers on all graphs at once, rather than only the active monitor. This is already the behaviour in the editor's visual profiler, but not in the debugger's "Monitors" view.

Enabling markers on multiple monitors at once will help users to understand the performance profile of their program.

### Before
<img width="973" height="452" alt="single-marker-example" src="https://github.com/user-attachments/assets/1ace4677-3875-4be6-a85c-dbc29c477316" />

### After
[multi-marker.webm](https://github.com/user-attachments/assets/5afd5480-1d07-4702-a054-223ddaebe60b)

## Final thoughts
I did experiment with changing the trigger to place a marker from mouse click to mouse move but it resulted in high CPU usage due to many redraws.