### PR TITLE
CI: Bump JavaScript actions to Node 24

### DIFF
--- a/.github/actions/godot-cache-restore/action.yml
+++ b/.github/actions/godot-cache-restore/action.yml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Restore default cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       id: cache-ping
       with:
         path: ${{ inputs.scons-cache }}
@@ -27,7 +27,7 @@ runs:
     # This is done after pulling the default cache so that PRs can integrate any potential changes
     # from the default branch without conflicting with whatever local changes were already made.
     - name: Restore local cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       if: github.ref_name != github.event.repository.default_branch
       with:
         path: ${{ inputs.scons-cache }}

--- a/.github/actions/godot-cache-save/action.yml
+++ b/.github/actions/godot-cache-save/action.yml
@@ -16,7 +16,7 @@ runs:
       run: misc/scripts/purge_cache.py ${{ env.CACHE_TIMESTAMP }} "${{ inputs.scons-cache }}"
 
     - name: Save SCons cache directory
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ inputs.scons-cache }}
         key: ${{ inputs.cache-name }}|${{ github.ref_name }}|${{ github.sha }}

--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         # Semantic version range syntax or exact version of a Python version.
         python-version: ${{ inputs.python-version }}

--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Upload Godot Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
Bumps all relevant JavaScript actions to Node 24 that support it. ~~The only one that doesn't, `pre-commit/action`, will instead silently migrate to it by passing `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`.~~ This addresses the warning noise currently clogging our build actions

**EDIT:** The environment variable didn't do anything, apparantly. Guess `static_checks` is stuck with a bogus warning for 3 months 🤷 