### PR TITLE
Allow toggling AnimationTree error panel

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -377,11 +377,9 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 			text_rects.write[i] = Rect2(Vector2(text_pos.x, text_pos.y - font->get_ascent(font_size)), text_size);
 		}
 	}
-	if (does_include_invalid_key) {
-		invalid_point_warning_hb->show();
-	} else {
-		invalid_point_warning_hb->hide();
-	}
+	AnimationTreeEditor::get_singleton()->current_playback_error = does_include_invalid_key
+			? TTR("Cyclic sync modes require that all blend points in BlendSpace use non-nested Animation nodes with a finite, immutable length.")
+			: String();
 
 	// blend position
 	{
@@ -766,8 +764,6 @@ void AnimationNodeBlendSpace1DEditor::_open_editor() {
 void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			error_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
-			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 			panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("GraphBlendSpace")));
 			tool_blend->set_button_icon(get_editor_theme_icon(SNAME("EditPivot")));
 			tool_select->set_button_icon(get_editor_theme_icon(SNAME("ToolSelect")));
@@ -779,27 +775,13 @@ void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackContinuous")), TTR("Continuous"), 0);
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackDiscrete")), TTR("Discrete"), 1);
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackCapture")), TTR("Capture"), 2);
-			invalid_point_warning->set_button_icon(get_editor_theme_icon(SNAME("NodeWarning")));
 		} break;
-
-		case NOTIFICATION_PROCESS: {
-			AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
-			if (!tree) {
-				return;
-			}
-
-			update_error_message(tree, error_panel, error_label);
-		} break;
-
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			set_process(is_visible_in_tree());
+			if (!is_visible_in_tree()) {
+				AnimationTreeEditor::get_singleton()->current_playback_error = String();
+			}
 		} break;
 	}
-}
-
-void AnimationNodeBlendSpace1DEditor::_show_invalid_point_warning() {
-	EditorNode::get_singleton()->show_warning(
-			TTR("BlendSpace contains points that are not AnimationNodeAnimation.\nCyclic sync modes require that all blend points use AnimationNodeAnimation with a finite, immutable length."));
 }
 
 void AnimationNodeBlendSpace1DEditor::_bind_methods() {
@@ -1154,22 +1136,6 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	min_value->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_config_changed));
 	max_value->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_config_changed));
 	label_value->connect(SceneStringName(text_changed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_labels_changed));
-
-	error_panel = memnew(PanelContainer);
-	add_child(error_panel);
-	error_label = create_error_label_node();
-	error_panel->add_child(error_label);
-	error_panel->hide();
-
-	invalid_point_warning_hb = memnew(HBoxContainer);
-	add_child(invalid_point_warning_hb);
-	invalid_point_warning_hb->hide();
-
-	invalid_point_warning = memnew(Button);
-	invalid_point_warning->set_text(TTRC("Contains Invalid Point"));
-	invalid_point_warning->set_tooltip_text(TTRC("Warning: BlendSpace contains invalid points for cyclic sync"));
-	invalid_point_warning->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_show_invalid_point_warning));
-	invalid_point_warning_hb->add_child(invalid_point_warning);
 
 	menu = memnew(PopupMenu);
 	add_child(menu);

--- a/editor/animation/animation_blend_space_1d_editor.h
+++ b/editor/animation/animation_blend_space_1d_editor.h
@@ -81,13 +81,6 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 
 	Control *blend_space_draw = nullptr;
 
-	PanelContainer *error_panel = nullptr;
-	RichTextLabel *error_label = nullptr;
-
-	HBoxContainer *invalid_point_warning_hb = nullptr;
-	Button *invalid_point_warning = nullptr;
-	void _show_invalid_point_warning();
-
 	bool updating = false;
 
 	static AnimationNodeBlendSpace1DEditor *singleton;

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -682,11 +682,9 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 			text_rects.write[i] = Rect2(Vector2(text_pos.x, text_pos.y - font->get_ascent(font_size)), text_size);
 		}
 	}
-	if (does_include_invalid_key) {
-		invalid_point_warning_hb->show();
-	} else {
-		invalid_point_warning_hb->hide();
-	}
+	AnimationTreeEditor::get_singleton()->current_playback_error = does_include_invalid_key
+			? TTR("Cyclic sync modes require that all blend points in BlendSpace use non-nested Animation nodes with a finite, immutable length.")
+			: String();
 
 	if (making_triangle.size()) {
 		Vector<Vector2> bl_points;
@@ -1009,8 +1007,6 @@ void AnimationNodeBlendSpace2DEditor::_edit_point_name(const String &p_name) {
 void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			error_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
-			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 			panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("GraphBlendSpace")));
 			tool_blend->set_button_icon(get_editor_theme_icon(SNAME("EditPivot")));
 			tool_select->set_button_icon(get_editor_theme_icon(SNAME("ToolSelect")));
@@ -1024,27 +1020,13 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackContinuous")), TTR("Continuous"), 0);
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackDiscrete")), TTR("Discrete"), 1);
 			interpolation->add_icon_item(get_editor_theme_icon(SNAME("TrackCapture")), TTR("Capture"), 2);
-			invalid_point_warning->set_button_icon(get_editor_theme_icon(SNAME("NodeWarning")));
 		} break;
-
-		case NOTIFICATION_PROCESS: {
-			AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
-			if (!tree) {
-				return;
-			}
-
-			update_error_message(tree, error_panel, error_label);
-		} break;
-
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			set_process(is_visible_in_tree());
+			if (!is_visible_in_tree()) {
+				AnimationTreeEditor::get_singleton()->current_playback_error = String();
+			}
 		} break;
 	}
-}
-
-void AnimationNodeBlendSpace2DEditor::_show_invalid_point_warning() {
-	EditorNode::get_singleton()->show_warning(
-			TTR("BlendSpace contains points that are not AnimationNodeAnimation.\nCyclic sync modes require that all blend points use AnimationNodeAnimation with a finite, immutable length."));
 }
 
 void AnimationNodeBlendSpace2DEditor::_open_editor() {
@@ -1463,22 +1445,6 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	min_y_value->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_config_changed));
 	label_x->connect(SceneStringName(text_changed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_labels_changed));
 	label_y->connect(SceneStringName(text_changed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_labels_changed));
-
-	error_panel = memnew(PanelContainer);
-	add_child(error_panel);
-	error_label = create_error_label_node();
-	error_panel->add_child(error_label);
-	error_panel->hide();
-
-	invalid_point_warning_hb = memnew(HBoxContainer);
-	add_child(invalid_point_warning_hb);
-	invalid_point_warning_hb->hide();
-
-	invalid_point_warning = memnew(Button);
-	invalid_point_warning->set_text(TTRC("Contains Invalid Point"));
-	invalid_point_warning->set_tooltip_text(TTRC("Warning: BlendSpace contains invalid points for cyclic sync"));
-	invalid_point_warning->connect(SceneStringName(pressed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_show_invalid_point_warning));
-	invalid_point_warning_hb->add_child(invalid_point_warning);
 
 	set_custom_minimum_size(Size2(0, 300 * EDSCALE));
 

--- a/editor/animation/animation_blend_space_2d_editor.h
+++ b/editor/animation/animation_blend_space_2d_editor.h
@@ -89,13 +89,6 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 
 	Control *blend_space_draw = nullptr;
 
-	PanelContainer *error_panel = nullptr;
-	RichTextLabel *error_label = nullptr;
-
-	HBoxContainer *invalid_point_warning_hb = nullptr;
-	Button *invalid_point_warning = nullptr;
-	void _show_invalid_point_warning();
-
 	bool updating;
 
 	static AnimationNodeBlendSpace2DEditor *singleton;

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -36,7 +36,6 @@
 #include "core/object/class_db.h"
 #include "core/templates/rb_set.h"
 #include "editor/editor_node.h"
-#include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/inspector/editor_inspector.h"
@@ -1044,9 +1043,6 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			error_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
-			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
-
 			if (is_visible_in_tree()) {
 				update_graph();
 			}
@@ -1061,8 +1057,6 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 			if (graph_update_queued) {
 				return;
 			}
-
-			update_error_message(tree, error_panel, error_label);
 
 			LocalVector<AnimationNodeBlendTree::NodeConnection> conns;
 			blend_tree->get_node_connections(&conns);
@@ -1312,12 +1306,6 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	add_options.push_back(AddOption("BlendSpace2D", "AnimationNodeBlendSpace2D"));
 	add_options.push_back(AddOption("StateMachine", "AnimationNodeStateMachine"));
 	_update_options_menu();
-
-	error_panel = memnew(PanelContainer);
-	add_child(error_panel);
-	error_label = create_error_label_node();
-	error_panel->add_child(error_label);
-
 	filter_dialog = memnew(AcceptDialog);
 	add_child(filter_dialog);
 	filter_dialog->set_title(TTR("Edit Filtered Tracks:"));

--- a/editor/animation/animation_blend_tree_editor_plugin.h
+++ b/editor/animation/animation_blend_tree_editor_plugin.h
@@ -37,7 +37,6 @@
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/graph_edit.h"
-#include "scene/gui/panel_container.h"
 #include "scene/gui/tree.h"
 
 class AcceptDialog;
@@ -61,9 +60,6 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	MenuButton *add_node = nullptr;
 	Vector2 position_from_popup_menu;
 	bool use_position_from_popup_menu;
-
-	PanelContainer *error_panel = nullptr;
-	RichTextLabel *error_label = nullptr;
 
 	AcceptDialog *filter_dialog = nullptr;
 	Tree *filters = nullptr;

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -72,6 +72,8 @@ void AnimationNodeStateMachineEditor::edit(const Ref<AnimationNode> &p_node) {
 		connected_nodes.clear();
 		_update_mode();
 		_update_graph();
+	} else {
+		AnimationTreeEditor::get_singleton()->current_playback_error = String();
 	}
 
 	if (read_only) {
@@ -1665,8 +1667,6 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			panel->add_theme_style_override(SceneStringName(panel), theme_cache.panel_style);
-			error_panel->add_theme_style_override(SceneStringName(panel), theme_cache.error_panel_style);
-			error_label->add_theme_color_override(SNAME("default_color"), theme_cache.error_color);
 
 			tool_select->set_button_icon(theme_cache.tool_icon_select);
 			tool_create->set_button_icon(theme_cache.tool_icon_create);
@@ -1692,19 +1692,9 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 				return;
 			}
 
-			String error;
-
-			Ref<AnimationNodeStateMachinePlayback> playback = tree->get(AnimationTreeEditor::get_singleton()->get_base_path() + "playback");
-
-			if (error_time > 0) {
-				error_time -= get_process_delta_time();
-			}
-
-			if (playback.is_null()) {
-				error = vformat(TTR("No playback resource set at path: %s."), AnimationTreeEditor::get_singleton()->get_base_path() + "playback");
-			}
-
-			update_error_message(tree, error_panel, error_label, &error);
+			const String playback_path = AnimationTreeEditor::get_singleton()->get_base_path() + "playback";
+			Ref<AnimationNodeStateMachinePlayback> playback = tree->get(playback_path);
+			AnimationTreeEditor::get_singleton()->current_playback_error = playback.is_null() ? vformat(TTR("No playback resource set at path: %s."), playback_path) : String();
 
 			for (int i = 0; i < transition_lines.size(); i++) {
 				int tidx = -1;
@@ -1841,6 +1831,8 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 			hovered_node_name = StringName();
 			hovered_node_area = HOVER_NODE_NONE;
 			set_process(is_visible_in_tree());
+
+			AnimationTreeEditor::get_singleton()->current_playback_error = String();
 		} break;
 	}
 }
@@ -2154,12 +2146,6 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	h_scroll->set_anchors_and_offsets_preset(PRESET_BOTTOM_WIDE);
 	h_scroll->set_offset(SIDE_RIGHT, -v_scroll->get_size().x * EDSCALE);
 	h_scroll->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeStateMachineEditor::_scroll_changed));
-
-	error_panel = memnew(PanelContainer);
-	add_child(error_panel);
-	error_label = create_error_label_node();
-	error_panel->add_child(error_label);
-	error_panel->hide();
 
 	set_custom_minimum_size(Size2(0, 300 * EDSCALE));
 

--- a/editor/animation/animation_state_machine_editor.h
+++ b/editor/animation/animation_state_machine_editor.h
@@ -74,9 +74,6 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	Control *state_machine_draw = nullptr;
 	Control *state_machine_play_pos = nullptr;
 
-	PanelContainer *error_panel = nullptr;
-	RichTextLabel *error_label = nullptr;
-
 	struct ThemeCache {
 		Ref<StyleBox> panel_style;
 		Ref<StyleBox> error_panel_style;
@@ -278,8 +275,6 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	float last_fading_pos = 0.0f;
 	float fading_time = 0.0f;
 	float fading_pos = 0.0f;
-
-	float error_time = 0.0f;
 
 	EditorFileDialog *open_file = nullptr;
 	Ref<AnimationNode> file_loaded;

--- a/editor/animation/animation_tree_editor_plugin.cpp
+++ b/editor/animation/animation_tree_editor_plugin.cpp
@@ -38,30 +38,20 @@
 #include "editor/animation/animation_state_machine_editor.h"
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_node.h"
+#include "editor/editor_string_names.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/gui/button.h"
 #include "scene/gui/margin_container.h"
-#include "scene/gui/panel_container.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/main/scene_tree.h"
 
-RichTextLabel *AnimationTreeNodeEditorPlugin::create_error_label_node() {
-	RichTextLabel *error_label = memnew(RichTextLabel);
-	error_label->set_focus_mode(FOCUS_ACCESSIBILITY);
-	error_label->set_fit_content(true);
-	error_label->set_h_size_flags(SIZE_EXPAND_FILL);
-	error_label->set_meta_underline(true);
-	error_label->connect("meta_clicked", callable_mp(this, &AnimationTreeNodeEditorPlugin::_meta_clicked));
-	return error_label;
-}
-
-void AnimationTreeNodeEditorPlugin::_meta_clicked(Variant p_meta) {
+void AnimationTreeEditor::_meta_clicked(Variant p_meta) {
 	if (p_meta.get_type() != Variant::STRING) {
 		return;
 	}
@@ -76,19 +66,30 @@ void AnimationTreeNodeEditorPlugin::_meta_clicked(Variant p_meta) {
 		input_index = input_index_str.to_int();
 	}
 
-	AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
-	ERR_FAIL_NULL(tree);
+	AnimationTree *anim_tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
+	ERR_FAIL_NULL(anim_tree);
 
-	// e.g. "parameters/blend_tree/node_name/" -> "parameters/blend_tree/"
-	String parent_path = full_path_str.rstrip("/").substr(0, full_path_str.rstrip("/").rfind_char('/') + 1);
+	// Check if the node at the full path can be entered directly.
+	Ref<AnimationNode> target_node = anim_tree->get_animation_node_by_path(full_path_str);
+	if (target_node.is_valid() && can_edit(target_node)) {
+		const String to_edit_path = full_path_str.replace_first(Animation::PARAMETERS_BASE_PATH, "").trim_suffix("/");
+		Vector<String> navigate_to;
+		if (!to_edit_path.is_empty()) {
+			navigate_to = to_edit_path.split("/");
+		}
+		if (AnimationTreeEditor::get_singleton()->get_edited_path() != navigate_to) {
+			AnimationTreeEditor::get_singleton()->edit_path(navigate_to);
+		}
+		return;
+	}
 
-	Ref<AnimationRootNode> root_node = tree->get_animation_node_by_path(parent_path);
+	// Otherwise, navigate to parent and pan to node.
+	String parent_path = full_path_str.rstrip("/").substr(0, full_path_str.rstrip("/").rfind_char('/') + 1); // e.g. "parameters/blend_tree/node_name/" -> "parameters/blend_tree/"
+
+	Ref<AnimationRootNode> root_node = anim_tree->get_animation_node_by_path(parent_path);
 	ERR_FAIL_COND(root_node.is_null());
 
-	String to_edit_root_path = String(parent_path);
-	to_edit_root_path = to_edit_root_path.replace_first(Animation::PARAMETERS_BASE_PATH, "");
-	to_edit_root_path = to_edit_root_path.trim_suffix("/");
-
+	const String to_edit_root_path = String(parent_path).replace_first(Animation::PARAMETERS_BASE_PATH, "").trim_suffix("/");
 	Vector<String> navigate_to;
 	if (!to_edit_root_path.is_empty()) {
 		// empty string still has 1 element when split.
@@ -107,13 +108,16 @@ void AnimationTreeNodeEditorPlugin::_meta_clicked(Variant p_meta) {
 	}
 }
 
-void AnimationTreeNodeEditorPlugin::update_error_message(const AnimationTree *p_tree, PanelContainer *p_error_panel, RichTextLabel *p_error_label, const String *p_other_errors) {
-	const String editor_error_message = p_tree->get_editor_error_message();
-	const AHashMap<StringName, AnimationNode::InvalidInstance> &invalid_instances = p_tree->get_invalid_instances();
+void AnimationTreeEditor::_update_error_message(const String *p_other_errors) {
+	const String editor_error_message = tree->get_editor_error_message();
+	const AHashMap<StringName, AnimationNode::InvalidInstance> &invalid_instances = tree->get_invalid_instances();
 
+	static String last_error_key;
 	if (editor_error_message.is_empty() && invalid_instances.is_empty() && (!p_other_errors || p_other_errors->is_empty())) {
 		last_error_key = String();
-		p_error_panel->hide();
+		error_button->hide();
+		error_scroll->hide();
+		current_scope_error_label->clear();
 		return;
 	}
 
@@ -121,6 +125,7 @@ void AnimationTreeNodeEditorPlugin::update_error_message(const AnimationTree *p_
 	// Though it would be better, to only call this when the tree changes.
 	{
 		StringBuffer k;
+		k += get_base_path();
 		k += editor_error_message;
 		if (p_other_errors) {
 			k += *p_other_errors;
@@ -143,56 +148,132 @@ void AnimationTreeNodeEditorPlugin::update_error_message(const AnimationTree *p_
 		last_error_key = error_key;
 	}
 
-	const String point = String::utf8("•  ");
-
-	p_error_label->clear();
-	p_error_label->append_text(editor_error_message);
-	if (p_other_errors) {
-		p_error_label->append_text(*p_other_errors);
+	// Get the currently open node by traversing edited_path.
+	Ref<AnimationNode> current_node = tree->get_root_animation_node();
+	for (const String &p : edited_path) {
+		if (current_node.is_null()) {
+			break;
+		}
+		current_node = current_node->get_child_by_name(p);
 	}
 
-	bool first = true;
+	// Get direct children of current node for scope checking.
+	LocalVector<AnimationNode::ChildNode> current_children;
+	if (current_node.is_valid()) {
+		current_node->get_child_nodes(&current_children);
+	}
+
+	error_label->clear();
+	int count = 0;
+	bool scope_error_found = false;
+	StringName fallback_key;
+	StringName downstream_key;
+
+	if (!editor_error_message.is_empty()) {
+		error_label->append_text(editor_error_message);
+		error_label->add_newline();
+		count++;
+	}
+
+	if (p_other_errors) {
+		error_label->append_text(*p_other_errors);
+		error_label->add_newline();
+		count++;
+
+		scope_error_found = true;
+	}
+
+	error_label->push_table(2);
 	for (const KeyValue<StringName, AnimationNode::InvalidInstance> &kv : invalid_instances) {
-		if (!first) {
-			p_error_label->add_newline();
-		}
-		first = false;
-
-		Ref<AnimationNode> node = p_tree->get_animation_node_by_path(kv.key);
+		Ref<AnimationNode> node = tree->get_animation_node_by_path(kv.key);
 		ERR_CONTINUE(node.is_null());
-
-		p_error_label->append_text(vformat(RTR("%s at "), node->get_class()));
-		p_error_label->push_meta(String(kv.key));
-		{
-			p_error_label->append_text(vformat(RTR("'%s'"), kv.key));
+		count++;
+		if (!scope_error_found && current_node.is_valid()) {
+			if (fallback_key.is_empty()) {
+				fallback_key = kv.key;
+			}
+			bool is_self = (node == current_node);
+			bool is_leaf_child = false;
+			bool is_editable_child = false;
+			if (!is_self) {
+				for (const AnimationNode::ChildNode &child : current_children) {
+					if (child.node == node) {
+						if (!can_edit(child.node)) {
+							is_leaf_child = true;
+						} else {
+							is_editable_child = true;
+						}
+						break;
+					}
+				}
+			}
+			if (is_self || is_leaf_child) {
+				scope_error_found = true;
+				fallback_key = kv.key;
+			} else if ((is_editable_child || String(kv.key).begins_with(get_base_path())) && downstream_key.is_empty()) {
+				downstream_key = kv.key;
+			}
 		}
-		p_error_label->pop();
-		p_error_label->append_text(RTR(" has errors.\n"));
 
-		StringBuffer instance_error_builder;
+		error_label->push_cell();
+		error_label->push_color(error_label->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		error_label->append_text(vformat(RTR("%s at "), node->get_class()));
+		error_label->push_meta(String(kv.key));
+		error_label->append_text(vformat(RTR("'%s':"), kv.key));
+		error_label->pop(); // Meta.
+		error_label->pop(); // Color.
+		error_label->pop(); // Cell.
+
+		error_label->push_cell();
+		error_label->push_color(error_label->get_theme_color(SceneStringName(font_color), EditorStringName(Editor)));
 		for (const String &reason : kv.value.errors) {
-			instance_error_builder += point;
-			instance_error_builder += reason;
-			instance_error_builder += "\n";
+			error_label->append_text(reason);
+			error_label->add_newline();
 		}
-		p_error_label->append_text(instance_error_builder.as_string());
 
-		// Input errors.
-		String input_error_base = String(kv.key) + "::";
+		const String input_error_base = String(kv.key) + "::";
 		for (const AnimationNode::InvalidInstance::InputError &input_error : kv.value.input_errors) {
 			const String input_name = node->get_input_name(input_error.index);
+			error_label->append_text(input_error.error + " ");
+			error_label->push_meta(input_error_base + itos(input_error.index));
+			error_label->append_text(vformat(RTR("input %d '%s'."), input_error.index, input_name));
+			error_label->pop(); // Meta.
+			error_label->append_text(" ");
+		}
+		error_label->pop(); // Color.
+		error_label->pop(); // Cell.
+	}
+	error_label->pop(); // Table.
 
-			p_error_label->append_text(point + input_error.error + " ");
-			p_error_label->push_meta(input_error_base + itos(input_error.index));
-			{
-				p_error_label->append_text(vformat(RTR("input %d '%s'."), input_error.index, input_name));
+	current_scope_error_label->clear();
+	if (p_other_errors) {
+		current_scope_error_label->push_color(current_scope_error_label->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		current_scope_error_label->append_text(TTR("Error: ") + *p_other_errors);
+		current_scope_error_label->pop(); // Color.
+	} else {
+		const StringName display_key = scope_error_found ? fallback_key : (!downstream_key.is_empty() ? downstream_key : fallback_key);
+		if (!display_key.is_empty()) {
+			const AnimationNode::InvalidInstance &inst = invalid_instances.get(display_key);
+			Ref<AnimationNode> node = tree->get_animation_node_by_path(display_key);
+			const String input_error_base = String(display_key) + "::";
+			current_scope_error_label->push_color(current_scope_error_label->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			current_scope_error_label->append_text(TTR("Error: "));
+			if (!inst.errors.is_empty()) {
+				current_scope_error_label->push_meta(String(display_key));
+				current_scope_error_label->append_text(inst.errors[0]);
+				current_scope_error_label->pop(); // Meta.
+			} else if (!inst.input_errors.is_empty() && node.is_valid()) {
+				current_scope_error_label->push_meta(input_error_base + itos(inst.input_errors[0].index));
+				current_scope_error_label->append_text(inst.input_errors[0].error + " ");
+				current_scope_error_label->append_text(vformat(RTR("input %d '%s'."), inst.input_errors[0].index, node->get_input_name(inst.input_errors[0].index)));
+				current_scope_error_label->pop(); // Meta.
 			}
-			p_error_label->pop();
-			p_error_label->add_newline();
+			current_scope_error_label->pop(); // Color.
 		}
 	}
 
-	p_error_panel->show();
+	error_button->set_text(itos(count));
+	error_button->show();
 }
 
 void AnimationTreeEditor::edit(AnimationTree *p_tree) {
@@ -310,6 +391,7 @@ void AnimationTreeEditor::edit_path(const Vector<String> &p_path) {
 	}
 
 	_update_path();
+	_update_error_message(current_playback_error.is_empty() ? nullptr : &current_playback_error);
 }
 
 void AnimationTreeEditor::_clear_editors() {
@@ -335,6 +417,19 @@ void AnimationTreeEditor::enter_editor(const String &p_path) {
 
 void AnimationTreeEditor::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			Ref<StyleBoxEmpty> empty_style;
+			empty_style.instantiate();
+			error_scroll->add_theme_style_override(SceneStringName(panel), empty_style);
+			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			error_button->set_button_icon(get_editor_theme_icon(SNAME("StatusError")));
+			error_button->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			current_scope_error_label->add_theme_font_override(SNAME("normal_font"), get_theme_font(SNAME("main"), EditorStringName(EditorFonts)));
+			current_scope_error_label->add_theme_font_size_override(SNAME("normal_font_size"), get_theme_font_size(SNAME("main_size"), EditorStringName(EditorFonts)));
+			current_scope_error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			current_scope_error_label->add_theme_style_override(SNAME("normal"), get_theme_stylebox(SNAME("normal"), SNAME("Label")));
+		} break;
+
 		case NOTIFICATION_PROCESS: {
 			ObjectID root;
 			if (tree && tree->get_root_animation_node().is_valid()) {
@@ -347,6 +442,10 @@ void AnimationTreeEditor::_notification(int p_what) {
 
 			if (button_path.size() != edited_path.size()) {
 				edit_path(edited_path);
+			}
+
+			if (tree) {
+				_update_error_message(current_playback_error.is_empty() ? nullptr : &current_playback_error);
 			}
 		} break;
 
@@ -409,6 +508,10 @@ LocalVector<StringName> AnimationTreeEditor::get_animation_list() {
 	return tree->get_sorted_animation_list();
 }
 
+void AnimationTreeEditor::_toggle_error_panel() {
+	error_scroll->set_visible(!error_scroll->is_visible());
+}
+
 AnimationTreeEditor::AnimationTreeEditor() {
 	singleton = this;
 	AnimationNodeAnimation::get_editable_animation_list = get_animation_list;
@@ -434,14 +537,60 @@ AnimationTreeEditor::AnimationTreeEditor() {
 
 	main_vbox_container->add_child(memnew(HSeparator));
 
+	VSplitContainer *split = memnew(VSplitContainer);
+	split->set_v_size_flags(SIZE_EXPAND_FILL);
+	main_vbox_container->add_child(split);
+
+	VBoxContainer *editor_vbox = memnew(VBoxContainer);
+	editor_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
+	split->add_child(editor_vbox);
+
 	editor_base = memnew(MarginContainer);
 	editor_base->set_v_size_flags(SIZE_EXPAND_FILL);
-	main_vbox_container->add_child(editor_base);
+	editor_vbox->add_child(editor_base);
+
+	HBoxContainer *status_bar = memnew(HBoxContainer);
+	editor_vbox->add_child(status_bar);
+
+	current_scope_error_label = memnew(RichTextLabel);
+	current_scope_error_label->set_fit_content(true);
+	current_scope_error_label->set_h_size_flags(SIZE_EXPAND_FILL);
+	current_scope_error_label->set_v_size_flags(SIZE_SHRINK_CENTER);
+	current_scope_error_label->set_meta_underline(false);
+	current_scope_error_label->connect("meta_clicked", callable_mp(this, &AnimationTreeEditor::_meta_clicked));
+	status_bar->add_child(current_scope_error_label);
+
+	error_button = memnew(Button);
+	error_button->set_flat(true);
+	error_button->set_h_size_flags(SIZE_SHRINK_END);
+	error_button->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
+	error_button->set_default_cursor_shape(CURSOR_POINTING_HAND);
+	error_button->hide();
+	error_button->connect(SceneStringName(pressed), callable_mp(this, &AnimationTreeEditor::_toggle_error_panel));
+	error_button->set_tooltip_text(TTRC("Errors"));
+	status_bar->add_child(error_button);
 
 	add_plugin(memnew(AnimationNodeBlendTreeEditor));
 	add_plugin(memnew(AnimationNodeBlendSpace1DEditor));
 	add_plugin(memnew(AnimationNodeBlendSpace2DEditor));
 	add_plugin(memnew(AnimationNodeStateMachineEditor));
+
+	error_scroll = memnew(ScrollContainer);
+	error_scroll->set_h_size_flags(SIZE_EXPAND_FILL);
+	error_scroll->set_v_size_flags(SIZE_EXPAND_FILL);
+	error_scroll->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
+	error_scroll->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_AUTO);
+	split->add_child(error_scroll);
+
+	error_label = memnew(RichTextLabel);
+	error_label->set_selection_enabled(true);
+	error_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+	error_label->set_h_size_flags(SIZE_EXPAND_FILL);
+	error_label->set_v_size_flags(SIZE_EXPAND_FILL);
+	error_label->set_meta_underline(true);
+	error_label->connect("meta_clicked", callable_mp(this, &AnimationTreeEditor::_meta_clicked));
+	error_scroll->add_child(error_label);
+	error_scroll->hide();
 }
 
 void AnimationTreeEditorPlugin::edit(Object *p_object) {

--- a/editor/animation/animation_tree_editor_plugin.h
+++ b/editor/animation/animation_tree_editor_plugin.h
@@ -48,13 +48,6 @@ public:
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) = 0;
 	virtual void edit(const Ref<AnimationNode> &p_node) = 0;
 
-protected:
-	RichTextLabel *create_error_label_node();
-
-	void _meta_clicked(Variant p_meta);
-
-	void update_error_message(const AnimationTree *p_tree, PanelContainer *p_error_panel, RichTextLabel *p_error_label, const String *p_other_errors = nullptr);
-
 private:
 	String last_error_key;
 };
@@ -64,6 +57,10 @@ class AnimationTreeEditor : public EditorDock {
 
 	ScrollContainer *path_edit = nullptr;
 	HBoxContainer *path_hb = nullptr;
+	RichTextLabel *current_scope_error_label = nullptr;
+	Button *error_button = nullptr;
+	ScrollContainer *error_scroll = nullptr;
+	RichTextLabel *error_label = nullptr;
 
 	AnimationTree *tree = nullptr;
 	MarginContainer *editor_base = nullptr;
@@ -79,15 +76,21 @@ class AnimationTreeEditor : public EditorDock {
 	void _path_button_pressed(int p_path);
 	void _animation_list_changed();
 
+	void _toggle_error_panel();
+	void _update_error_message(const String *p_other_errors = nullptr);
+
 	static LocalVector<StringName> get_animation_list();
 
 protected:
+	void _meta_clicked(Variant p_meta);
 	void _notification(int p_what);
 	void _node_removed(Node *p_node);
 
 	static AnimationTreeEditor *singleton;
 
 public:
+	String current_playback_error;
+
 	AnimationTree *get_animation_tree() { return tree; }
 	void add_plugin(AnimationTreeNodeEditorPlugin *p_editor);
 	void remove_plugin(AnimationTreeNodeEditorPlugin *p_editor);

--- a/editor/icons/KeyInvalid.svg
+++ b/editor/icons/KeyInvalid.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><path fill="none" stroke="#ff5f5f" stroke-width="2" d="m1 1 6 6M1 7 7 1"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><path fill="none" stroke="#ff5f5f" stroke-width="2" d="m1.5 1.5 7 7M1.5 8.5 8.5 1.5"/></svg>


### PR DESCRIPTION
Closes #117427.

This PR moves the duplicated error panel code from `BlendSpace1D`, `BlendSpace2D`, `StateMachine`, and `BlendTree`'s editor plugins, and instead places it as part of a panel + split container beneath each editor plugin's areas, in the `AnimationTree` dock itself. This is done to unify the state of the error panel which would previously flicker during navigation between node types, and also was styled differently for different plugins, and allow the user to resize or hide it entirely, when active.

https://github.com/user-attachments/assets/af111bb4-1385-49e5-9cf5-483b0dc42f26

Additionally, there is a persistent error always visible, chosen from the list with this priority:
1. Error reported by current node's editor plugin (sync in BlendSpace & playback in StateMachine)
2. Direct scope (current node or non-editable child).
3. Downstream (editable child or deeper).
4. First error in log.

It also changes the click behaviour for non-BlendTree errors to navigate to inside the invalid node, rather than to their parent.