### PR TITLE
Silently stop all script debuggers if no debugging server is active

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -313,6 +313,17 @@ void EditorDebuggerNode::stop(bool p_force) {
 	inspect_edited_object_wait = false;
 
 	current_uri.clear();
+	// Also close all debugging sessions.
+	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
+		// If the server is also still active, let the debugger notify that it stopped.
+		// Otherwise, just stop it silently.
+		if (server.is_valid() || dbg->is_session_active()) {
+			dbg->_stop_and_notify();
+		} else {
+			dbg->stop();
+		}
+	});
+
 	if (server.is_valid()) {
 		server->stop();
 		EditorNode::get_log()->add_message("--- Debugging process stopped ---", EditorLog::MSG_TYPE_EDITOR);
@@ -325,12 +336,6 @@ void EditorDebuggerNode::stop(bool p_force) {
 		server.unref();
 	}
 
-	// Also close all debugging sessions.
-	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
-		if (dbg->is_session_active()) {
-			dbg->_stop_and_notify();
-		}
-	});
 	_break_state_changed();
 	breakpoints.clear();
 	EditorUndoRedoManager::get_singleton()->clear_history(EditorUndoRedoManager::REMOTE_HISTORY, false);


### PR DESCRIPTION
Different approach from #114457 (cc @kbieganski)

Closes #111175 (cannot reproduce myself, but has received feedback from @tmilker & @rsa17826
 it works)

Instead of the original solution of always propagating the `stopped` signal even when no debugger session was active (breaks DAP since it expects the signal to be emitted once and when a session is active), this approach does so only if the debug server is valid or the debugger session is active. If neither of those happen, then we still stop the debugging session but "internally", without propagating the `stopped` signal.

(cc @m4gr3d due to f713a20c94478bef3a8bc0e9300c24d37987b984 / #108518, just to double check this doesn't reintroduce an issue you fixed)