### PR TITLE
Default value of "Ignore asset root" should be false, when addons is the root folder of the addon

### DIFF
--- a/editor/asset_library/editor_asset_installer.cpp
+++ b/editor/asset_library/editor_asset_installer.cpp
@@ -155,8 +155,8 @@ void EditorAssetInstaller::open_asset(const String &p_path, bool p_autoskip_topl
 	asset_title_label->set_text(asset_name);
 
 	_check_has_toplevel();
-	// Default to false, unless forced.
-	skip_toplevel = p_autoskip_toplevel;
+	// Default to false, unless forced. Don't skip "addons" by default
+	skip_toplevel = p_autoskip_toplevel && toplevel_prefix != "addons/";
 	skip_toplevel_check->set_block_signals(true);
 	skip_toplevel_check->set_pressed(!skip_toplevel_check->is_disabled() && skip_toplevel);
 	skip_toplevel_check->set_block_signals(false);


### PR DESCRIPTION
When addon follows the structure specified in https://docs.godotengine.org/en/stable/community/asset_library/submitting_to_assetlib.html#recommendations
specifically
> place your files inside of an **addons/asset_name/** folder.

by default the  "Ignore asset root" is checked, which causes addon dir to land outside the "addons" directory.

This PR adjusts `skip_toplevel` logic to avoid skipping "addons" folder by default. Fixes https://github.com/godotengine/godot-asset-store-tracker/issues/140
Fixes https://youtrack.jetbrains.com/issue/RIDER-136620/Fix-installation-of-the-Rider-plugin-into-Godot-on-Mac
