### PR TITLE
GDScript: Reduce memory overhead from hot reloading

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -160,12 +160,6 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 	instance->script = Ref<GDScript>(this);
 	instance->owner = p_owner;
 	instance->owner_id = p_owner->get_instance_id();
-#ifdef DEBUG_ENABLED
-	//needed for hot reloading
-	for (const KeyValue<StringName, MemberInfo> &E : member_indices) {
-		instance->member_indices_cache[E.key] = E.value.index;
-	}
-#endif
 	instance->owner->set_script_instance(instance);
 
 	/* STEP 2, INITIALIZE AND CONSTRUCT */
@@ -2049,18 +2043,13 @@ void GDScriptInstance::reload_members() {
 
 	// Transfer the old members into their new position.
 	for (KeyValue<StringName, GDScript::MemberInfo> &E : script->member_indices) {
-		if (member_indices_cache.has(E.key)) {
-			Variant value = members[member_indices_cache[E.key]];
+		const GDScript::MemberInfo *old = script->old_member_indices.getptr(E.key);
+		if (old != nullptr) {
+			Variant value = members[old->index];
 			new_members[E.value.index] = value;
 		}
 	}
 	members = std::move(new_members);
-
-	// Cache the new indices.
-	member_indices_cache.clear();
-	for (const KeyValue<StringName, GDScript::MemberInfo> &E : script->member_indices) {
-		member_indices_cache[E.key] = E.value.index;
-	}
 
 #endif
 }

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -86,6 +86,9 @@ class GDScript : public Script {
 	// Members are just indices to the instantiated script.
 	HashMap<StringName, MemberInfo> member_indices; // Includes member info of all base GDScript classes.
 	HashSet<StringName> members; // Only members of the current class.
+#ifdef DEBUG_ENABLED
+	HashMap<StringName, MemberInfo> old_member_indices; // Used for hot reloading. Empty while not compiling.
+#endif // DEBUG_ENABLED
 
 	// Only static variables of the current class.
 	HashMap<StringName, MemberInfo> static_variables_indices;
@@ -346,9 +349,6 @@ class GDScriptInstance : public ScriptInstance {
 	ObjectID owner_id;
 	Object *owner = nullptr;
 	Ref<GDScript> script;
-#ifdef DEBUG_ENABLED
-	HashMap<StringName, int> member_indices_cache; //used only for hot script reloading
-#endif
 	TightLocalVector<Variant> members;
 
 	SelfList<GDScriptFunctionState>::List pending_func_states;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2698,6 +2698,10 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 
 	parsing_classes.insert(p_script);
 
+#ifdef DEBUG_ENABLED
+	p_script->old_member_indices = p_script->member_indices;
+#endif // DEBUG_ENABLED
+
 	p_script->clearing = true;
 
 	p_script->cancel_pending_functions(true);
@@ -3096,6 +3100,10 @@ Error GDScriptCompiler::_compile_class(GDScript *p_script, const GDScriptParser:
 	}
 
 	p_script->_static_default_init();
+
+#ifdef DEBUG_ENABLED
+	p_script->old_member_indices.clear();
+#endif // DEBUG_ENABLED
 
 	p_script->valid = true;
 	return OK;


### PR DESCRIPTION
As noticed in https://github.com/godotengine/godot/pull/117410#issuecomment-4062907305 `GDScriptInstance::member_indices_cache` adds quite a bit of memory overhead to GDScript instances in debug builds.

It is needed to find old property values when hot reloading a script. However since member indices are identical for all instances of the same script, there is no need to keep this cached per instance. This PR moves the storage of old member indices into `GDScript` and also cleans the cache up when no reload is taking place.

This removes around 400byte from the `Object` entry of the memory benchmark presented in https://github.com/godotengine/godot/pull/117410. Those savings only apply to debug builds and not to release builds. However since memory profiling is often done through the editor this helps to get a more realistic picture during development.
