### PR TITLE
Tighten `GDType` registration restrictions by auto-finalizing it after `Object` registration events

### DIFF
--- a/core/object/gdtype.cpp
+++ b/core/object/gdtype.cpp
@@ -57,15 +57,19 @@ void GDType::initialize() {
 	if (super_type) {
 		// Now that a subtype is registered, the supertype cannot change anymore.
 		// Otherwise, our caches would become invalid.
-		// This shouldn't be a problem, since classes should register all their
-		// parts in _bind_methods, which is called on registration.
-		super_type->init_state = InitState::FINALIZED;
+		// For internal classes, finalize() will already have been called by this point.
+		// This is not the case for GDExtensions, which currently do not trigger finalize().
+		finalize();
 
 		constant_map = super_type->constant_map;
 		enum_map = super_type->enum_map;
 	}
 
 	init_state = InitState::MUTABLE;
+}
+
+void GDType::finalize() {
+	init_state = InitState::FINALIZED;
 }
 
 void GDType::bind_integer_constant(const StringName &p_enum, const StringName &p_name, int64_t p_constant, bool p_is_bitfield) {

--- a/core/object/gdtype.h
+++ b/core/object/gdtype.h
@@ -69,7 +69,10 @@ public:
 	~GDType();
 
 	InitState get_init_state() const { return init_state; }
+	// Prepare for registration events. Automatically called externally during the GDType lifecycle.
 	void initialize();
+	// Disallow future changes to the type. Automatically called externally during the GDType lifecycle.
+	void finalize();
 
 	const GDType *get_super_type() const { return super_type; }
 	const StringName &get_name() const { return name; }

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1812,6 +1812,7 @@ void Object::initialize_class() {
 	get_gdtype_static_mutable().initialize();
 	_bind_methods();
 	_bind_compatibility_methods();
+	get_gdtype_static_mutable().finalize();
 	initialized = true;
 }
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -550,6 +550,7 @@ public: \
 		if (m_class::_get_bind_compatibility_methods() != m_inherits::_get_bind_compatibility_methods()) { \
 			_bind_compatibility_methods(); \
 		} \
+		get_gdtype_static_mutable().finalize(); \
 		initialized = true; \
 	} \
 \


### PR DESCRIPTION
Historically, `ClassDB` may allow registration calls to take place after the type has been registered, practically even after subtypes have been registered or instances been created.
This creates undefined behavior, and should be caught at the call site.

#113586 already tightened restrictions to only allow registrations until a subtype is registered.
This PR further tightens the restriction by finalizing as early as possible (right after construction). This triggers for internal types, although for GDExtension types we do not know when they are done registering, so the restrictions stay a bit looser there for now.