### PR TITLE
[macOS/Windows] Remove dynamically linked ANGLE support, add flag to enable/disable ANGLE.

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -49,6 +49,17 @@ jobs:
       - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
 
+      - name: Download pre-built ANGLE
+        shell: sh
+        id: angle-sdk
+        run: |
+          if python ./misc/scripts/install_angle.py; then
+            echo "ANGLE_ENABLED=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::ANGLE SDK installation failed, building without ANGLE support."
+            echo "ANGLE_ENABLED=no" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download pre-built AccessKit
         shell: sh
         id: accesskit-sdk
@@ -74,14 +85,14 @@ jobs:
       - name: Compilation (x86_64)
         uses: ./.github/actions/godot-build
         with:
-          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }} arch=x86_64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }} accesskit=${{ steps.accesskit-sdk.outputs.ACCESSKIT_ENABLED }}
+          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }} arch=x86_64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }} accesskit=${{ steps.accesskit-sdk.outputs.ACCESSKIT_ENABLED }} angle=${{ steps.angle-sdk.outputs.ANGLE_ENABLED }}
           platform: macos
           target: ${{ matrix.target }}
 
       - name: Compilation (arm64)
         uses: ./.github/actions/godot-build
         with:
-          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }} arch=arm64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }} accesskit=${{ steps.accesskit-sdk.outputs.ACCESSKIT_ENABLED }}
+          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }} arch=arm64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }} accesskit=${{ steps.accesskit-sdk.outputs.ACCESSKIT_ENABLED }} angle=${{ steps.angle-sdk.outputs.ANGLE_ENABLED }}
           platform: macos
           target: ${{ matrix.target }}
 

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -9,7 +9,6 @@ env:
     dev_mode=yes
     module_text_server_fb_enabled=yes
     debug_symbols=no
-    "angle_libs=${{ github.workspace }}/"
   SCONS_CACHE_MSVC_CONFIG: true
   PYTHONIOENCODING: utf8
 
@@ -83,16 +82,16 @@ jobs:
           fi
         continue-on-error: true
 
-      - name: Download pre-built ANGLE static libraries
-        uses: dsaltares/fetch-gh-release-asset@1.1.2
-        with:
-          repo: godotengine/godot-angle-static
-          version: tags/chromium/6601.2
-          file: godot-angle-static-x86_64-${{ matrix.compiler == 'gcc' && 'gcc' || 'msvc' }}-release.zip
-          target: angle/angle.zip
-
-      - name: Extract pre-built ANGLE static libraries
-        run: Expand-Archive -Force angle/angle.zip ${{ github.workspace }}/
+      - name: Download pre-built ANGLE
+        shell: sh
+        id: angle-sdk
+        run: |
+          if python ./misc/scripts/install_angle.py; then
+            echo "ANGLE_ENABLED=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::ANGLE SDK installation failed, building without ANGLE support."
+            echo "ANGLE_ENABLED=no" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Download pre-built AccessKit
         shell: sh
@@ -108,7 +107,7 @@ jobs:
       - name: Compilation
         uses: ./.github/actions/godot-build
         with:
-          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }} d3d12=${{ steps.d3d12-sdk.outputs.D3D12_ENABLED }} accesskit=${{ steps.accesskit-sdk.outputs.ACCESSKIT_ENABLED }}
+          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }} d3d12=${{ steps.d3d12-sdk.outputs.D3D12_ENABLED }} accesskit=${{ steps.accesskit-sdk.outputs.ACCESSKIT_ENABLED }} angle=${{ steps.angle-sdk.outputs.ANGLE_ENABLED }}
           platform: windows
           target: ${{ matrix.target }}
 

--- a/SConstruct
+++ b/SConstruct
@@ -200,6 +200,7 @@ opts.Add(BoolVariable("d3d12", "Enable the Direct3D 12 rendering driver on suppo
 opts.Add(BoolVariable("metal", "Enable the Metal rendering driver on supported platforms (Apple arm64 only)", False))
 opts.Add(BoolVariable("use_volk", "Use the volk library to load the Vulkan loader dynamically", True))
 opts.Add(BoolVariable("accesskit", "Enable the AccessKit driver for screen reader support", True))
+opts.Add(BoolVariable("angle", "Enable the ANGLE rendering driver for OpenGL ES 3.0 on supported platforms", True))
 opts.Add(BoolVariable("sdl", "Enable the SDL3 input driver", True))
 opts.Add(
     EnumVariable(

--- a/drivers/gl_context/SCsub
+++ b/drivers/gl_context/SCsub
@@ -8,15 +8,17 @@ if env["platform"] in ["macos", "windows", "linuxbsd"]:
     thirdparty_dir = "#thirdparty/glad/"
     thirdparty_sources = ["gl.c"]
 
-    if not env.get("angle_libs"):
-        thirdparty_sources += ["egl.c"]
-
-    thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
-
     env.Prepend(CPPPATH=[thirdparty_dir])
 
     env.Append(CPPDEFINES=["GLAD_ENABLED"])
-    env.Append(CPPDEFINES=["EGL_ENABLED"])
+    if env["platform"] == "linuxbsd":
+        thirdparty_sources += ["egl.c"]
+        env.Append(CPPDEFINES=["EGL_ENABLED", "GLAD_GLES2"])
+    else:
+        if env["angle"]:
+            env.Append(CPPDEFINES=["EGL_ENABLED", "GLAD_GLES2"])
+
+    thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
     env_thirdparty = env.Clone()
     env_thirdparty.disable_warnings()

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -261,10 +261,12 @@ RasterizerGLES3::RasterizerGLES3() {
 		if (!glad_loaded && gladLoaderLoadGL()) {
 			glad_loaded = true;
 		}
+#ifdef GLES_API_ENABLED
 	} else {
 		if (!glad_loaded && gladLoaderLoadGLES2()) {
 			glad_loaded = true;
 		}
+#endif
 	}
 
 	// FIXME this is an early return from a constructor.  Any other code using this instance will crash or the finalizer will crash, because none of

--- a/misc/scripts/install_angle.py
+++ b/misc/scripts/install_angle.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import os
+import platform
+import shutil
+import sys
+import urllib.request
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../"))
+
+from misc.utility.color import Ansi, color_print
+
+# Base Godot dependencies path
+# If cross-compiling (no LOCALAPPDATA), we install in `bin`
+deps_folder = os.getenv("LOCALAPPDATA")
+if deps_folder:
+    deps_folder = os.path.join(deps_folder, "Godot", "build_deps")
+else:
+    deps_folder = os.path.join("bin", "build_deps")
+
+# ANGLE
+# Check for latest version: https://github.com/godotengine/godot-angle-static/releases/latest
+angle_version = "chromium/7219"
+angle_folder = os.path.join(deps_folder, "angle")
+
+# Create dependencies folder
+if not os.path.exists(deps_folder):
+    os.makedirs(deps_folder)
+
+# Mesa NIR
+print(f"Downloading ANGLE {angle_version} ...")
+archs = [
+    "arm64-llvm",
+    "x86_32-gcc",
+    "x86_32-llvm",
+    "x86_64-gcc",
+    "x86_64-llvm",
+]
+if platform.system() == "Windows":
+    # Only download MSVC libraries if we can build using it.
+    archs.append("arm64-msvc")
+    archs.append("x86_32-msvc")
+    archs.append("x86_64-msvc")
+elif platform.system() == "Darwin":
+    # Only download macOS/iOS libraries if we can build for these platforms.
+    archs.append("arm64-ios")
+    archs.append("arm64-ios-sim")
+    archs.append("arm64-macos")
+    archs.append("x86_64-macos")
+
+for arch in archs:
+    angle_filename = f"godot-angle-static-{arch}-release.zip"
+    angle_archive = os.path.join(deps_folder, angle_filename)
+    angle_folder = os.path.join(deps_folder, f"angle-{arch}")
+
+    if os.path.isfile(angle_archive):
+        os.remove(angle_archive)
+    print(f"Downloading ANGLE {angle_filename} ...")
+    urllib.request.urlretrieve(
+        f"https://github.com/godotengine/godot-angle-static/releases/download/{angle_version}/{angle_filename}",
+        angle_archive,
+    )
+    if os.path.exists(angle_folder):
+        print(f"Removing existing local ANGLE installation in {angle_folder} ...")
+        shutil.rmtree(angle_folder)
+    print(f"Extracting ANGLE {angle_filename} to {angle_folder} ...")
+    shutil.unpack_archive(angle_archive, angle_folder)
+    os.remove(angle_archive)
+print("ANGLE installed successfully.\n")
+
+# Complete message
+color_print(f'{Ansi.GREEN}All ANGLE components were installed to "{deps_folder}" successfully!')
+color_print(f'{Ansi.GREEN}You can now build Godot with statically linked ANGLE by running "scons angle=yes".')

--- a/platform/linuxbsd/platform_gl.h
+++ b/platform/linuxbsd/platform_gl.h
@@ -38,6 +38,10 @@
 #define GLES_API_ENABLED // Allow using GLES.
 #endif
 
+#ifndef GLAD_GLES2
+#define GLAD_GLES2
+#endif
+
 // IWYU pragma: begin_exports.
 #include <thirdparty/glad/glad/egl.h>
 #include <thirdparty/glad/glad/gl.h>

--- a/platform/linuxbsd/wayland/detect_prime_egl.h
+++ b/platform/linuxbsd/wayland/detect_prime_egl.h
@@ -34,8 +34,7 @@
 #ifdef EGL_ENABLED
 
 #ifdef GLAD_ENABLED
-#include <thirdparty/glad/glad/egl.h>
-#include <thirdparty/glad/glad/gl.h>
+#include <platform_gl.h>
 #else
 #include <EGL/egl.h>
 #include <EGL/eglext.h>

--- a/platform/linuxbsd/x11/detect_prime_x11.cpp
+++ b/platform/linuxbsd/x11/detect_prime_x11.cpp
@@ -36,8 +36,9 @@
 #include "core/string/print_string.h"
 #include "core/variant/variant.h"
 
-#include <thirdparty/glad/glad/gl.h>
 #include <thirdparty/glad/glad/glx.h>
+
+#include <platform_gl.h>
 
 #ifdef SOWRAP_ENABLED
 #include "x11/dynwrappers/xlib-so_wrap.h"

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -26,10 +26,12 @@ files = [
     "dir_access_macos.mm",
     "tts_macos.mm",
     "rendering_context_driver_vulkan_macos.mm",
-    "gl_manager_macos_angle.mm",
     "gl_manager_macos_legacy.mm",
     "godot_progress_view.mm",
 ]
+
+if env["angle"]:
+    files += ["gl_manager_macos_angle.mm"]
 
 if env.editor_build:
     files += [

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -59,7 +59,11 @@ def get_opts():
             "Path to the AccessKit C SDK",
             os.path.join(deps_folder, "accesskit"),
         ),
-        ("angle_libs", "Path to the ANGLE static libraries", ""),
+        (
+            "angle_libs",
+            "Path to the ANGLE static libraries",
+            os.path.join(deps_folder, "angle"),
+        ),
         (
             "bundle_sign_identity",
             "The 'Full Name', 'Common Name' or SHA-1 hash of the signing identity used to sign editor .app bundle.",
@@ -279,13 +283,25 @@ def configure(env: "SConsEnvironment"):
 
     if env["opengl3"]:
         env.Append(CPPDEFINES=["GLES3_ENABLED"])
-        if env["angle_libs"] != "":
-            env.AppendUnique(CPPDEFINES=["EGL_STATIC"])
-            env.Append(LINKFLAGS=["-L" + env["angle_libs"]])
-            env.Append(LINKFLAGS=["-lANGLE.macos." + env["arch"]])
-            env.Append(LINKFLAGS=["-lEGL.macos." + env["arch"]])
-            env.Append(LINKFLAGS=["-lGLES.macos." + env["arch"]])
-        env.Prepend(CPPPATH=["#thirdparty/angle/include"])
+        if env["angle"]:
+            angle_path = env["angle_libs"] + "-" + env["arch"] + "-macos"
+            print(angle_path)
+            if os.path.exists(angle_path):
+                env.Prepend(CPPPATH=["#thirdparty/angle/include"])
+                env.AppendUnique(CPPDEFINES=["ANGLE_ENABLED", "EGL_STATIC"])
+                env.Append(LINKFLAGS=["-L" + angle_path])
+                env.Append(LINKFLAGS=["-lANGLE.macos." + env["arch"]])
+                env.Append(LINKFLAGS=["-lEGL.macos." + env["arch"]])
+                env.Append(LINKFLAGS=["-lGLES.macos." + env["arch"]])
+            else:
+                print_warning(
+                    "The ANGLE rendering driver requires dependencies to be installed.\n"
+                    f"You can install them by running `python {os.path.join('misc', 'scripts', 'install_angle.py')}`.\n"
+                    "See the documentation for more information:\n"
+                    "\thttps://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_windows.html\n"
+                    "Alternatively, disable this driver by compiling with `angle=no` explicitly."
+                )
+                env["angle"] = False
 
     env.Append(LINKFLAGS=["-rpath", "@executable_path/../Frameworks", "-rpath", "@executable_path"])
 

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -33,7 +33,9 @@
 #include "display_server_macos_base.h"
 
 #if defined(GLES3_ENABLED)
+#if defined(ANGLE_ENABLED)
 #include "gl_manager_macos_angle.h"
+#endif
 #include "gl_manager_macos_legacy.h"
 #endif // GLES3_ENABLED
 
@@ -167,7 +169,9 @@ private:
 
 #if defined(GLES3_ENABLED)
 	GLManagerLegacy_MacOS *gl_manager_legacy = nullptr;
+#if defined(ANGLE_ENABLED)
 	GLManagerANGLE_MacOS *gl_manager_angle = nullptr;
+#endif
 #endif
 	String rendering_driver;
 

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -207,12 +207,14 @@ DisplayServerEnums::WindowID DisplayServerMacOS::_create_window(DisplayServerEnu
 				gl_failed = true;
 			}
 		}
+#if defined(ANGLE_ENABLED)
 		if (gl_manager_angle) {
 			Error err = gl_manager_angle->window_create(window_id_counter, nullptr, (__bridge void *)layer, p_rect.size.width, p_rect.size.height);
 			if (err != OK) {
 				gl_failed = true;
 			}
 		}
+#endif
 		if (gl_failed) {
 			AccessibilityServer::get_singleton()->window_destroy(id);
 
@@ -250,9 +252,11 @@ DisplayServerEnums::WindowID DisplayServerMacOS::_create_window(DisplayServerEnu
 	if (gl_manager_legacy) {
 		gl_manager_legacy->window_resize(id, wd.size.width, wd.size.height);
 	}
+#if defined(ANGLE_ENABLED)
 	if (gl_manager_angle) {
 		gl_manager_angle->window_resize(id, wd.size.width, wd.size.height);
 	}
+#endif
 #endif
 
 	return id;
@@ -784,9 +788,11 @@ void DisplayServerMacOS::window_resize(DisplayServerEnums::WindowID p_window, in
 	if (gl_manager_legacy) {
 		gl_manager_legacy->window_resize(p_window, p_width, p_height);
 	}
+#if defined(ANGLE_ENABLED)
 	if (gl_manager_angle) {
 		gl_manager_angle->window_resize(p_window, p_width, p_height);
 	}
+#endif
 #endif
 }
 
@@ -2747,21 +2753,27 @@ int64_t DisplayServerMacOS::window_get_native_handle(DisplayServerEnums::HandleT
 			if (gl_manager_legacy) {
 				return (int64_t)gl_manager_legacy->get_context(p_window);
 			}
+#if defined(ANGLE_ENABLED)
 			if (gl_manager_angle) {
 				return (int64_t)gl_manager_angle->get_context(p_window);
 			}
+#endif
 			return 0;
 		}
 		case DisplayServerEnums::EGL_DISPLAY: {
+#if defined(ANGLE_ENABLED)
 			if (gl_manager_angle) {
 				return (int64_t)gl_manager_angle->get_display(p_window);
 			}
+#endif
 			return 0;
 		}
 		case DisplayServerEnums::EGL_CONFIG: {
+#if defined(ANGLE_ENABLED)
 			if (gl_manager_angle) {
 				return (int64_t)gl_manager_angle->get_config(p_window);
 			}
+#endif
 			return 0;
 		}
 #endif
@@ -2790,18 +2802,22 @@ void DisplayServerMacOS::gl_window_make_current(DisplayServerEnums::WindowID p_w
 	if (gl_manager_legacy) {
 		gl_manager_legacy->window_make_current(p_window_id);
 	}
+#if defined(ANGLE_ENABLED)
 	if (gl_manager_angle) {
 		gl_manager_angle->window_make_current(p_window_id);
 	}
+#endif
 #endif
 }
 
 void DisplayServerMacOS::window_set_vsync_mode(DisplayServerEnums::VSyncMode p_vsync_mode, DisplayServerEnums::WindowID p_window) {
 	_THREAD_SAFE_METHOD_
 #if defined(GLES3_ENABLED)
+#if defined(ANGLE_ENABLED)
 	if (gl_manager_angle) {
 		gl_manager_angle->set_use_vsync(p_vsync_mode != DisplayServerEnums::VSYNC_DISABLED);
 	}
+#endif
 	if (gl_manager_legacy) {
 		gl_manager_legacy->set_use_vsync(p_vsync_mode != DisplayServerEnums::VSYNC_DISABLED);
 	}
@@ -2816,9 +2832,11 @@ void DisplayServerMacOS::window_set_vsync_mode(DisplayServerEnums::VSyncMode p_v
 DisplayServerEnums::VSyncMode DisplayServerMacOS::window_get_vsync_mode(DisplayServerEnums::WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 #if defined(GLES3_ENABLED)
+#if defined(ANGLE_ENABLED)
 	if (gl_manager_angle) {
 		return (gl_manager_angle->is_using_vsync() ? DisplayServerEnums::VSyncMode::VSYNC_ENABLED : DisplayServerEnums::VSyncMode::VSYNC_DISABLED);
 	}
+#endif
 	if (gl_manager_legacy) {
 		return (gl_manager_legacy->is_using_vsync() ? DisplayServerEnums::VSyncMode::VSYNC_ENABLED : DisplayServerEnums::VSyncMode::VSYNC_DISABLED);
 	}
@@ -3224,9 +3242,11 @@ void DisplayServerMacOS::force_process_and_drop_events() {
 
 void DisplayServerMacOS::release_rendering_thread() {
 #if defined(GLES3_ENABLED)
+#if defined(ANGLE_ENABLED)
 	if (gl_manager_angle) {
 		gl_manager_angle->release_current();
 	}
+#endif
 	if (gl_manager_legacy) {
 		gl_manager_legacy->release_current();
 	}
@@ -3235,9 +3255,11 @@ void DisplayServerMacOS::release_rendering_thread() {
 
 void DisplayServerMacOS::swap_buffers() {
 #if defined(GLES3_ENABLED)
+#if defined(ANGLE_ENABLED)
 	if (gl_manager_angle) {
 		gl_manager_angle->swap_buffers();
 	}
+#endif
 	if (gl_manager_legacy) {
 		gl_manager_legacy->swap_buffers();
 	}
@@ -3467,7 +3489,9 @@ Vector<String> DisplayServerMacOS::get_rendering_drivers_func() {
 #endif
 #if defined(GLES3_ENABLED)
 	drivers.push_back("opengl3");
+#if defined(ANGLE_ENABLED)
 	drivers.push_back("opengl3_angle");
+#endif
 #endif
 	drivers.push_back("dummy");
 
@@ -3786,6 +3810,7 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, Display
 #endif
 
 #if defined(GLES3_ENABLED)
+#if defined(ANGLE_ENABLED)
 	if (rendering_driver == "opengl3" && OS::get_singleton()->get_processor_name().contains("Virtual")) {
 		WARN_PRINT("Virtual Machine detected, switching to ANGLE.");
 		rendering_driver = "opengl3_angle";
@@ -3801,11 +3826,7 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, Display
 			}
 			bool fallback = GLOBAL_GET("rendering/gl_compatibility/fallback_to_native");
 			if (fallback) {
-#ifdef EGL_STATIC
 				WARN_PRINT("Your video card drivers seem not to support GLES3 / ANGLE, switching to native OpenGL.");
-#else
-				WARN_PRINT("Your video card drivers seem not to support GLES3 / ANGLE or ANGLE dynamic libraries (libEGL.dylib and libGLESv2.dylib) are missing, switching to native OpenGL.");
-#endif
 				rendering_driver = "opengl3";
 				OS::get_singleton()->set_current_rendering_driver_name(rendering_driver, OS::RENDERING_SOURCE_FALLBACK);
 			} else {
@@ -3814,7 +3835,12 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, Display
 			}
 		}
 	}
-
+#else
+	if (rendering_driver == "opengl3" && OS::get_singleton()->get_processor_name().contains("Virtual")) {
+		r_error = ERR_UNAVAILABLE;
+		ERR_FAIL_MSG("Virtual Machine detected, could not initialize OpenGL.");
+	}
+#endif
 	if (rendering_driver == "opengl3") {
 		gl_manager_legacy = memnew(GLManagerLegacy_MacOS);
 		if (gl_manager_legacy->initialize() != OK) {
@@ -3863,9 +3889,11 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, Display
 	if (rendering_driver == "opengl3") {
 		RasterizerGLES3::make_current(true);
 	}
+#if defined(ANGLE_ENABLED)
 	if (rendering_driver == "opengl3_angle") {
 		RasterizerGLES3::make_current(false);
 	}
+#endif
 #endif
 #if defined(RD_ENABLED)
 	if (rendering_context) {
@@ -3904,10 +3932,12 @@ DisplayServerMacOS::~DisplayServerMacOS() {
 		memdelete(gl_manager_legacy);
 		gl_manager_legacy = nullptr;
 	}
+#if defined(ANGLE_ENABLED)
 	if (gl_manager_angle) {
 		memdelete(gl_manager_angle);
 		gl_manager_angle = nullptr;
 	}
+#endif
 #endif
 #if defined(RD_ENABLED)
 	if (rendering_device) {

--- a/platform/macos/gl_manager_macos_legacy.h
+++ b/platform/macos/gl_manager_macos_legacy.h
@@ -32,6 +32,8 @@
 
 #if defined(MACOS_ENABLED) && defined(GLES3_ENABLED)
 
+#include "platform_gl.h"
+
 #include "core/error/error_list.h"
 #include "core/templates/rb_map.h"
 #include "servers/display/display_server_enums.h"

--- a/platform/macos/platform_gl.h
+++ b/platform/macos/platform_gl.h
@@ -34,8 +34,13 @@
 #define GL_API_ENABLED // Allow using desktop GL.
 #endif
 
+#ifdef ANGLE_ENABLED
 #ifndef GLES_API_ENABLED
 #define GLES_API_ENABLED // Allow using GLES (ANGLE).
+#endif
+
+#ifndef GLAD_GLES2
+#define GLAD_GLES2
 #endif
 
 // IWYU pragma: begin_exports.
@@ -44,8 +49,8 @@
 #include <thirdparty/angle/include/EGL/egl.h>
 #include <thirdparty/angle/include/EGL/eglext.h>
 #undef KHRONOS_STATIC
-#else
-#include <thirdparty/glad/glad/egl.h>
 #endif
+#endif
+
 #include <thirdparty/glad/glad/gl.h>
 // IWYU pragma: end_exports.

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -21,11 +21,13 @@ common_win = [
     "windows_utils.cpp",
     "native_menu_windows.cpp",
     "gl_manager_windows_native.cpp",
-    "gl_manager_windows_angle.cpp",
     "wgl_detect_version.cpp",
     "rendering_context_driver_vulkan_windows.cpp",
     "drop_target_windows.cpp",
 ]
+
+if env["angle"]:
+    common_win += ["gl_manager_windows_angle.cpp"]
 
 if env["library_type"] == "executable":
     common_win += ["godot_windows.cpp"]

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -200,7 +200,11 @@ def get_opts():
             "Path to the AccessKit C SDK",
             os.path.join(deps_folder, "accesskit"),
         ),
-        ("angle_libs", "Path to the ANGLE static libraries", ""),
+        (
+            "angle_libs",
+            "Path to the ANGLE static libraries",
+            os.path.join(deps_folder, "angle"),
+        ),
         # Direct3D 12 support.
         (
             "mesa_libs",
@@ -482,16 +486,26 @@ def configure_msvc(env: "SConsEnvironment"):
 
     if env["opengl3"]:
         env.AppendUnique(CPPDEFINES=["GLES3_ENABLED"])
-        if env["angle_libs"] != "":
-            env.AppendUnique(CPPDEFINES=["EGL_STATIC"])
-            env.Append(LIBPATH=[env["angle_libs"]])
+        angle_path = env["angle_libs"] + "-" + env["arch"] + "-msvc"
+        if os.path.exists(angle_path):
+            env.Prepend(CPPPATH=["#thirdparty/angle/include"])
+            env.AppendUnique(CPPDEFINES=["ANGLE_ENABLED", "EGL_STATIC"])
+            env.Append(LIBPATH=[angle_path])
             LIBS += [
                 "libANGLE.windows." + env["arch"] + prebuilt_lib_extra_suffix,
                 "libEGL.windows." + env["arch"] + prebuilt_lib_extra_suffix,
                 "libGLES.windows." + env["arch"] + prebuilt_lib_extra_suffix,
             ]
             LIBS += ["dxgi", "d3d9", "d3d11"]
-        env.Prepend(CPPPATH=["#thirdparty/angle/include"])
+        else:
+            print_warning(
+                "The ANGLE rendering driver requires dependencies to be installed.\n"
+                f"You can install them by running `python {os.path.join('misc', 'scripts', 'install_angle.py')}`.\n"
+                "See the documentation for more information:\n"
+                "\thttps://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_windows.html\n"
+                "Alternatively, disable this driver by compiling with `angle=no` explicitly."
+            )
+            env["angle"] = False
 
     if env["target"] in ["editor", "template_debug"]:
         LIBS += ["psapi", "dbghelp"]
@@ -881,18 +895,29 @@ def configure_mingw(env: "SConsEnvironment"):
 
     if env["opengl3"]:
         env.Append(CPPDEFINES=["GLES3_ENABLED"])
-        if env["angle_libs"] != "":
-            env.AppendUnique(CPPDEFINES=["EGL_STATIC"])
-            env.Append(LIBPATH=[env["angle_libs"]])
-            env.Append(
-                LIBS=[
-                    "EGL.windows." + env["arch"],
-                    "GLES.windows." + env["arch"],
-                    "ANGLE.windows." + env["arch"],
-                ]
-            )
-            env.Append(LIBS=["dxgi", "d3d9", "d3d11"])
-        env.Prepend(CPPPATH=["#thirdparty/angle/include"])
+        if env["angle"]:
+            angle_path = env["angle_libs"] + "-" + env["arch"] + ("-llvm" if env["use_llvm"] else "-gcc")
+            if os.path.exists(angle_path):
+                env.Prepend(CPPPATH=["#thirdparty/angle/include"])
+                env.AppendUnique(CPPDEFINES=["ANGLE_ENABLED", "EGL_STATIC"])
+                env.Append(LIBPATH=[angle_path])
+                env.Append(
+                    LIBS=[
+                        "EGL.windows." + env["arch"],
+                        "GLES.windows." + env["arch"],
+                        "ANGLE.windows." + env["arch"],
+                    ]
+                )
+                env.Append(LIBS=["dxgi", "d3d9", "d3d11"])
+            else:
+                print_warning(
+                    "The ANGLE rendering driver requires dependencies to be installed.\n"
+                    f"You can install them by running `python {os.path.join('misc', 'scripts', 'install_angle.py')}`.\n"
+                    "See the documentation for more information:\n"
+                    "\thttps://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_windows.html\n"
+                    "Alternatively, disable this driver by compiling with `angle=no` explicitly."
+                )
+                env["angle"] = False
 
     env.Append(CPPDEFINES=["MINGW_ENABLED", ("MINGW_HAS_SECURE_API", 1)])
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1938,9 +1938,11 @@ void DisplayServerWindows::delete_sub_window(DisplayServerEnums::WindowID p_wind
 	}
 #endif
 #ifdef GLES3_ENABLED
+#ifdef ANGLE_ENABLED
 	if (gl_manager_angle) {
 		gl_manager_angle->window_destroy(p_window);
 	}
+#endif
 	if (gl_manager_native) {
 		gl_manager_native->window_destroy(p_window);
 	}
@@ -1955,9 +1957,11 @@ void DisplayServerWindows::delete_sub_window(DisplayServerEnums::WindowID p_wind
 
 void DisplayServerWindows::gl_window_make_current(DisplayServerEnums::WindowID p_window_id) {
 #if defined(GLES3_ENABLED)
+#if defined(ANGLE_ENABLED)
 	if (gl_manager_angle) {
 		gl_manager_angle->window_make_current(p_window_id);
 	}
+#endif
 	if (gl_manager_native) {
 		gl_manager_native->window_make_current(p_window_id);
 	}
@@ -1985,21 +1989,27 @@ int64_t DisplayServerWindows::window_get_native_handle(DisplayServerEnums::Handl
 			if (gl_manager_native) {
 				return (int64_t)gl_manager_native->get_hglrc(p_window);
 			}
+#if defined(ANGLE_ENABLED)
 			if (gl_manager_angle) {
 				return (int64_t)gl_manager_angle->get_context(p_window);
 			}
+#endif
 			return 0;
 		}
 		case DisplayServerEnums::EGL_DISPLAY: {
+#if defined(ANGLE_ENABLED)
 			if (gl_manager_angle) {
 				return (int64_t)gl_manager_angle->get_display(p_window);
 			}
+#endif
 			return 0;
 		}
 		case DisplayServerEnums::EGL_CONFIG: {
+#if defined(ANGLE_ENABLED)
 			if (gl_manager_angle) {
 				return (int64_t)gl_manager_angle->get_config(p_window);
 			}
+#endif
 			return 0;
 		}
 #endif
@@ -4182,9 +4192,11 @@ void DisplayServerWindows::force_process_and_drop_events() {
 
 void DisplayServerWindows::release_rendering_thread() {
 #if defined(GLES3_ENABLED)
+#if defined(ANGLE_ENABLED)
 	if (gl_manager_angle) {
 		gl_manager_angle->release_current();
 	}
+#endif
 	if (gl_manager_native) {
 		gl_manager_native->release_current();
 	}
@@ -4193,9 +4205,11 @@ void DisplayServerWindows::release_rendering_thread() {
 
 void DisplayServerWindows::swap_buffers() {
 #if defined(GLES3_ENABLED)
+#if defined(ANGLE_ENABLED)
 	if (gl_manager_angle) {
 		gl_manager_angle->swap_buffers();
 	}
+#endif
 	if (gl_manager_native) {
 		gl_manager_native->swap_buffers();
 	}
@@ -4589,9 +4603,11 @@ void DisplayServerWindows::window_set_vsync_mode(DisplayServerEnums::VSyncMode p
 	if (gl_manager_native) {
 		gl_manager_native->set_use_vsync(p_window, p_vsync_mode != DisplayServerEnums::VSYNC_DISABLED);
 	}
+#if defined(ANGLE_ENABLED)
 	if (gl_manager_angle) {
 		gl_manager_angle->set_use_vsync(p_vsync_mode != DisplayServerEnums::VSYNC_DISABLED);
 	}
+#endif
 #endif
 }
 
@@ -4607,9 +4623,11 @@ DisplayServerEnums::VSyncMode DisplayServerWindows::window_get_vsync_mode(Displa
 	if (gl_manager_native) {
 		return gl_manager_native->is_using_vsync(p_window) ? DisplayServerEnums::VSYNC_ENABLED : DisplayServerEnums::VSYNC_DISABLED;
 	}
+#ifdef ANGLE_ENABLED
 	if (gl_manager_angle) {
 		return gl_manager_angle->is_using_vsync() ? DisplayServerEnums::VSYNC_ENABLED : DisplayServerEnums::VSYNC_DISABLED;
 	}
+#endif
 #endif
 	return DisplayServerEnums::VSYNC_ENABLED;
 }
@@ -6323,9 +6341,11 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				if (window.create_completed && gl_manager_native && window.gl_native_window_created) {
 					gl_manager_native->window_resize(window_id, window.width + off.x, window.height + off.y);
 				}
+#if defined(ANGLE_ENABLED)
 				if (window.create_completed && gl_manager_angle && window.gl_angle_window_created) {
 					gl_manager_angle->window_resize(window_id, window.width + off.x, window.height + off.y);
 				}
+#endif
 #endif
 			}
 
@@ -7154,7 +7174,7 @@ Error DisplayServerWindows::_create_gl_window(DisplayServerEnums::WindowID p_win
 
 		wd.gl_native_window_created = true;
 	}
-
+#ifdef ANGLE_ENABLED
 	if (gl_manager_angle) {
 		WindowData &wd = windows[p_window_id];
 
@@ -7163,6 +7183,7 @@ Error DisplayServerWindows::_create_gl_window(DisplayServerEnums::WindowID p_win
 
 		wd.gl_angle_window_created = true;
 	}
+#endif
 
 	return OK;
 }
@@ -7436,6 +7457,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Dis
 	ZeroMemory(&os_ver, sizeof(OSVERSIONINFOW));
 	os_ver.dwOSVersionInfoSize = sizeof(OSVERSIONINFOW);
 
+#if defined(ANGLE_ENABLED)
 	HMODULE nt_lib = LoadLibraryW(L"ntdll.dll");
 	bool is_wine = false;
 	if (nt_lib) {
@@ -7450,6 +7472,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Dis
 		}
 		FreeLibrary(nt_lib);
 	}
+#endif
 
 	// Load UXTheme.
 	if (os_ver.dwBuildNumber >= 10240) { // Not available on Wine, use only if real Windows 10/11 detected.
@@ -7763,15 +7786,21 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Dis
 #endif
 
 #if defined(GLES3_ENABLED)
-
+#if defined(ANGLE_ENABLED)
 	bool fallback = GLOBAL_GET("rendering/gl_compatibility/fallback_to_angle");
 	bool show_warning = true;
+#endif
 
 	if (rendering_driver == "opengl3") {
 		// There's no native OpenGL drivers on Windows for ARM, always enable fallback.
 #if defined(__arm__) || defined(__aarch64__) || defined(_M_ARM) || defined(_M_ARM64)
+#if defined(ANGLE_ENABLED)
 		fallback = true;
 		show_warning = false;
+#else
+		r_error = ERR_UNAVAILABLE;
+		ERR_FAIL_MSG("Could not initialize OpenGL.");
+#endif
 #else
 		typedef BOOL(WINAPI * IsWow64Process2Ptr)(HANDLE, USHORT *, USHORT *);
 
@@ -7783,13 +7812,19 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Dis
 				machine_arch = 0;
 			}
 			if (machine_arch == 0xAA64) {
+#if defined(ANGLE_ENABLED)
 				fallback = true;
 				show_warning = false;
+#else
+				r_error = ERR_UNAVAILABLE;
+				ERR_FAIL_MSG("Could not initialize OpenGL.");
+#endif
 			}
 		}
 #endif
 	}
 
+#if defined(ANGLE_ENABLED)
 	bool gl_supported = true;
 	if (fallback && !is_wine && (rendering_driver == "opengl3")) {
 		Dictionary gl_info = detect_wgl();
@@ -7840,40 +7875,20 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Dis
 		gl_manager_angle = memnew(GLManagerANGLE_Windows);
 		tested_drivers.set_flag(DRIVER_ID_COMPAT_ANGLE_D3D11);
 
-#ifndef EGL_STATIC
-		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-		if (!da->file_exists(OS::get_singleton()->get_executable_path().get_base_dir().path_join("libEGL.dll")) || !da->file_exists(OS::get_singleton()->get_executable_path().get_base_dir().path_join("libGLESv2.dll"))) {
+		if (gl_manager_angle->initialize() != OK) {
+			memdelete(gl_manager_angle);
+			gl_manager_angle = nullptr;
 			bool fallback_to_native = GLOBAL_GET("rendering/gl_compatibility/fallback_to_native");
 			if (fallback_to_native && gl_supported) {
-				WARN_PRINT("Your video card drivers seem not to support GLES3 / ANGLE or ANGLE dynamic libraries (libEGL.dll and libGLESv2.dll) are missing, switching to native OpenGL.");
+				WARN_PRINT("Your video card drivers seem not to support GLES3 / ANGLE, switching to native OpenGL.");
 				rendering_driver = "opengl3";
-				OS::get_singleton()->set_current_rendering_driver_name(rendering_driver, OS::RENDERING_SOURCE_FALLBACK);
 			} else {
 				r_error = ERR_UNAVAILABLE;
 				ERR_FAIL_MSG("Could not initialize ANGLE OpenGL.");
 			}
-		} else {
-#else
-		{
-#endif
-			if (gl_manager_angle->initialize() != OK) {
-				memdelete(gl_manager_angle);
-				gl_manager_angle = nullptr;
-				bool fallback_to_native = GLOBAL_GET("rendering/gl_compatibility/fallback_to_native");
-				if (fallback_to_native && gl_supported) {
-#ifdef EGL_STATIC
-					WARN_PRINT("Your video card drivers seem not to support GLES3 / ANGLE, switching to native OpenGL.");
-#else
-					WARN_PRINT("Your video card drivers seem not to support GLES3 / ANGLE or ANGLE dynamic libraries (libEGL.dll and libGLESv2.dll) are missing, switching to native OpenGL.");
-#endif
-					rendering_driver = "opengl3";
-				} else {
-					r_error = ERR_UNAVAILABLE;
-					ERR_FAIL_MSG("Could not initialize ANGLE OpenGL.");
-				}
-			}
 		}
 	}
+#endif // ANGLE_ENABLED
 	if (rendering_driver == "opengl3") {
 		gl_manager_native = memnew(GLManagerNative_Windows);
 		tested_drivers.set_flag(DRIVER_ID_COMPAT_OPENGL3);
@@ -7925,6 +7940,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Dis
 		}
 		RasterizerGLES3::make_current(true);
 	}
+#ifdef ANGLE_ENABLED
 	if (rendering_driver == "opengl3_angle") {
 		if (_create_gl_window(DisplayServerEnums::MAIN_WINDOW_ID) != OK) {
 			memdelete(gl_manager_angle);
@@ -7935,6 +7951,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Dis
 		}
 		RasterizerGLES3::make_current(false);
 	}
+#endif
 #endif
 
 	window_set_vsync_mode(p_vsync_mode, DisplayServerEnums::MAIN_WINDOW_ID);
@@ -8024,7 +8041,9 @@ Vector<String> DisplayServerWindows::get_rendering_drivers_func() {
 #endif
 #ifdef GLES3_ENABLED
 	drivers.push_back("opengl3");
+#ifdef ANGLE_ENABLED
 	drivers.push_back("opengl3_angle");
+#endif
 #endif
 	drivers.push_back("dummy");
 
@@ -8181,10 +8200,12 @@ DisplayServerWindows::~DisplayServerWindows() {
 		SystemParametersInfoA(SPI_SETMOUSETRAILS, restore_mouse_trails, nullptr, 0);
 	}
 #ifdef GLES3_ENABLED
+#ifdef ANGLE_ENABLED
 	if (gl_manager_angle) {
 		memdelete(gl_manager_angle);
 		gl_manager_angle = nullptr;
 	}
+#endif
 	if (gl_manager_native) {
 		memdelete(gl_manager_native);
 		gl_manager_native = nullptr;

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -48,7 +48,9 @@
 #endif
 
 #if defined(GLES3_ENABLED)
+#if defined(ANGLE_ENABLED)
 #include "gl_manager_windows_angle.h"
+#endif // ANGLE_ENABLED
 #include "gl_manager_windows_native.h"
 #endif // GLES3_ENABLED
 
@@ -255,7 +257,9 @@ class DisplayServerWindows : public DisplayServer {
 	Point2i center;
 
 #if defined(GLES3_ENABLED)
+#if defined(ANGLE_ENABLED)
 	GLManagerANGLE_Windows *gl_manager_angle = nullptr;
+#endif
 	GLManagerNative_Windows *gl_manager_native = nullptr;
 #endif
 
@@ -314,7 +318,9 @@ class DisplayServerWindows : public DisplayServer {
 		bool exclusive = false;
 		bool rendering_context_window_created = false;
 		bool gl_native_window_created = false;
+#ifdef ANGLE_ENABLED
 		bool gl_angle_window_created = false;
+#endif
 		bool mpass = false;
 		bool sharp_corners = false;
 		bool hide_from_capture = false;

--- a/platform/windows/platform_gl.h
+++ b/platform/windows/platform_gl.h
@@ -34,8 +34,13 @@
 #define GL_API_ENABLED // Allow using desktop GL.
 #endif
 
+#ifdef ANGLE_ENABLED
 #ifndef GLES_API_ENABLED
 #define GLES_API_ENABLED // Allow using GLES (ANGLE).
+#endif
+
+#ifndef GLAD_GLES2
+#define GLAD_GLES2
 #endif
 
 // IWYU pragma: begin_exports.
@@ -44,8 +49,7 @@
 #include <thirdparty/angle/include/EGL/egl.h>
 #include <thirdparty/angle/include/EGL/eglext.h>
 #undef KHRONOS_STATIC
-#else
-#include <thirdparty/glad/glad/egl.h>
+#endif
 #endif
 
 #include <thirdparty/glad/glad/gl.h>

--- a/thirdparty/glad/glad/gl.h
+++ b/thirdparty/glad/glad/gl.h
@@ -67,7 +67,6 @@
 #endif
 
 #define GLAD_GL
-#define GLAD_GLES2
 #define GLAD_OPTION_GL_LOADER
 
 #ifdef __cplusplus

--- a/thirdparty/glad/patches/0001-enable-both-gl-and-gles.patch
+++ b/thirdparty/glad/patches/0001-enable-both-gl-and-gles.patch
@@ -47,16 +47,3 @@ index e8cc5ff1d9..ee0cc188fc 100644
 +        _glad_gles_loader_handle = NULL;
      }
  }
- 
-diff --git a/thirdparty/glad/glad/gl.h b/thirdparty/glad/glad/gl.h
-index 7f77d6a13f..307ea4dbb8 100644
---- a/thirdparty/glad/glad/gl.h
-+++ b/thirdparty/glad/glad/gl.h
-@@ -67,6 +67,7 @@
- #endif
- 
- #define GLAD_GL
-+#define GLAD_GLES2
- #define GLAD_OPTION_GL_LOADER
- 
- #ifdef __cplusplus


### PR DESCRIPTION
Supersede https://github.com/godotengine/godot/pull/109889
Same as https://github.com/godotengine/godot/pull/117313 for ANGLE.

- Adds `angle` build flag to fully enable/disable ANGLE (defaults to `true`.
- If libs are missing, warning is printed and `angle` is set to false.

~Note: since there's https://github.com/godotengine/godot/pull/109889, I have not added an installation script or lookup in the deps folder.~ *Added the script from #109889 instead.*