### PR TITLE
Automatically remove incomplete file downloads

### DIFF
--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -30,6 +30,7 @@
 
 #include "http_request.h"
 
+#include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/stream_peer_gzip.h"
 #include "core/object/callable_mp.h"
@@ -204,13 +205,20 @@ void HTTPRequest::cancel_request() {
 		}
 	}
 
-	file.unref();
+	if (file.is_valid()) {
+		file.unref();
+		if (!download_complete) {
+			DirAccess::remove_absolute(download_to_file);
+		}
+	}
+
 	decompressor.unref();
 	client->close();
 	body.clear();
 	got_response = false;
 	response_code = -1;
 	request_sent = false;
+	download_complete = false;
 	requesting = false;
 }
 
@@ -501,6 +509,7 @@ bool HTTPRequest::_update_connection() {
 
 			if (body_len >= 0) {
 				if (downloaded.get() == body_len) {
+					download_complete = true;
 					_defer_done(RESULT_SUCCESS, response_code, response_headers, body);
 					return true;
 				}

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -62,6 +62,7 @@ public:
 
 private:
 	bool requesting = false;
+	bool download_complete = false;
 
 	String request_string;
 	String url;


### PR DESCRIPTION
When HTTPRequest fails to download a file (either by download error or manual cancel), the file is saved anyway and is incomplete (corrupted). There is no way to resume the download AFAIK, so there is no reason to keep the file.

This PR makes incomplete files automatically deleted. I don't know much about HTTPRequest, so not sure if there isn't another code path for successful downloads, but I tested that it works correctly with simple requests.

This change is needed for #117072. I tried manually removing the file after failed/canceled request, but it does not work for whatever reason 🤷‍♂️