### PR TITLE
GDScript: Avoid bounds check in `call` hot-path

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -583,41 +583,42 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		stack = (Variant *)aptr;
 
 		const int non_vararg_arg_count = MIN(p_argcount, _argument_count);
+		const GDScriptDataType *unsafe_argument_types = argument_types.ptr();
 		for (int i = 0; i < non_vararg_arg_count; i++) {
-			if (!argument_types[i].has_type()) {
+			if (!unsafe_argument_types[i].has_type()) {
 				memnew_placement(&stack[i + FIXED_ADDRESSES_MAX], Variant(*p_args[i]));
 				continue;
 			}
 			// If types already match, don't call Variant::construct(). Constructors of some types
 			// (e.g. packed arrays) do copies, whereas they pass by reference when inside a Variant.
-			if (argument_types[i].is_type(*p_args[i], false)) {
+			if (unsafe_argument_types[i].is_type(*p_args[i], false)) {
 				memnew_placement(&stack[i + FIXED_ADDRESSES_MAX], Variant(*p_args[i]));
 				continue;
 			}
-			if (!argument_types[i].is_type(*p_args[i], true)) {
+			if (!unsafe_argument_types[i].is_type(*p_args[i], true)) {
 				r_err.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 				r_err.argument = i;
-				r_err.expected = argument_types[i].builtin_type;
+				r_err.expected = unsafe_argument_types[i].builtin_type;
 				call_depth--;
 				return _get_default_variant_for_data_type(return_type);
 			}
-			if (argument_types[i].kind == GDScriptDataType::BUILTIN) {
-				if (argument_types[i].builtin_type == Variant::DICTIONARY && argument_types[i].has_container_element_types()) {
-					const GDScriptDataType &arg_key_type = argument_types[i].get_container_element_type_or_variant(0);
-					const GDScriptDataType &arg_value_type = argument_types[i].get_container_element_type_or_variant(1);
+			if (unsafe_argument_types[i].kind == GDScriptDataType::BUILTIN) {
+				if (unsafe_argument_types[i].builtin_type == Variant::DICTIONARY && unsafe_argument_types[i].has_container_element_types()) {
+					const GDScriptDataType &arg_key_type = unsafe_argument_types[i].get_container_element_type_or_variant(0);
+					const GDScriptDataType &arg_value_type = unsafe_argument_types[i].get_container_element_type_or_variant(1);
 					Dictionary dict(p_args[i]->operator Dictionary(), arg_key_type.builtin_type, arg_key_type.native_type, arg_key_type.script_type, arg_value_type.builtin_type, arg_value_type.native_type, arg_value_type.script_type);
 					memnew_placement(&stack[i + FIXED_ADDRESSES_MAX], Variant(dict));
-				} else if (argument_types[i].builtin_type == Variant::ARRAY && argument_types[i].has_container_element_type(0)) {
-					const GDScriptDataType &arg_type = argument_types[i].container_element_types[0];
+				} else if (unsafe_argument_types[i].builtin_type == Variant::ARRAY && unsafe_argument_types[i].has_container_element_type(0)) {
+					const GDScriptDataType &arg_type = unsafe_argument_types[i].container_element_types[0];
 					Array array(p_args[i]->operator Array(), arg_type.builtin_type, arg_type.native_type, arg_type.script_type);
 					memnew_placement(&stack[i + FIXED_ADDRESSES_MAX], Variant(array));
 				} else {
 					Variant variant;
-					Variant::construct(argument_types[i].builtin_type, variant, &p_args[i], 1, r_err);
+					Variant::construct(unsafe_argument_types[i].builtin_type, variant, &p_args[i], 1, r_err);
 					if (unlikely(r_err.error)) {
 						r_err.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 						r_err.argument = i;
-						r_err.expected = argument_types[i].builtin_type;
+						r_err.expected = unsafe_argument_types[i].builtin_type;
 						call_depth--;
 						return _get_default_variant_for_data_type(return_type);
 					}


### PR DESCRIPTION
`GDScriptFunction::call` should be considered a hot-path. Without this PR we woud do a bounds check for each passed argument. However, the indices are inherently in-bound (if there is no compiler bug) due to being limited to `_argument_count`.

This PR uses raw pointer access to avoid the unnecessary bounds checks.

<details>
<summary>Benchmarked using this script</summary>

```gdscript
extends Node

var iter : int = 1_000_000
var test_strick : float = 0.0
var time : float = 0.0

func add10(p0: int, p1: int, p2: int, p3: int, p4: int, p5: int, p6: int, p7: int, p8: int, p9: int) -> int:
	return p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9

func add2(p0: int, p2: int) -> int:
	return p0 + p2

func noarg() -> int:
	return v0

var v0 := 0
var v1 := 1
var v2 := 2
var v3 := 3
var v4 := 4
var v5 := 5
var v6 := 6
var v7 := 7
var v8 := 8
var v9 := 9

func _ready() -> void:
	for ii in range(1):
		var sum: int
		var func_10_t: float
		var in_10_t: float
		var func_2_t: float
		var in_2_t: float
		var func_no_t: float
		var in_no_t: float
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += add10(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9)
		func_10_t = Time.get_unix_time_from_system() - time
		
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += v0 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9
		in_10_t = Time.get_unix_time_from_system() - time
		
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += add2(v1, v2)
		func_2_t = Time.get_unix_time_from_system() - time
		
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += v1 + v2
		in_2_t = Time.get_unix_time_from_system() - time
		
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += noarg()
		func_no_t = Time.get_unix_time_from_system() - time
		
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += v0
		in_no_t = Time.get_unix_time_from_system() - time
		
		print("Args, Function, Inline, Overhead")
		print(10, ", ", func_10_t, ", ", in_10_t, ", ", func_10_t - in_10_t)
		print(2, ", ", func_2_t, ", ", in_2_t, ", ", func_2_t - in_2_t)
		print(0, ", ", func_no_t, ", ", in_no_t, ", ", func_no_t - in_no_t)
		
	get_tree().quit()

```

</details>

In a debug build this PR reduces the call overhead by around 8% for a function with 10 arguments. It does not negatively impact the overhead for functions with no/few arguments.

Due to high variance I'm not able to reliably benchmark this against a release build.
