### PR TITLE
Add UTF-8 encoding to svg file open in `platform_builders.py`

### DIFF
--- a/platform/platform_builders.py
+++ b/platform/platform_builders.py
@@ -10,7 +10,7 @@ def export_icon_builder(target, source, env):
     src_name = src_path.stem
     platform = src_path.parent.parent.stem
 
-    with open(str(source[0]), "r") as file:
+    with open(str(source[0]), "r", encoding="utf-8") as file:
         svg = file.read()
 
     with methods.generated_wrapper(str(target[0])) as file:


### PR DESCRIPTION
This PR fixes the build failure on Windows by explicitly specifying UTF-8 encoding when reading SVG files in platform/platform_builders.py, preventing the UnicodeDecodeError caused by the system default GBK encoding.

When building Godot on Windows, the build process fails with a UnicodeDecodeError during the generation of SVG icon headers for platform exporters. This happens because platform/platform_builders.py reads SVG files without explicitly specifying UTF-8 encoding, causing Python to fall back to the system default encoding — which is GBK on Chinese Windows installations.

Windows systems configured for Chinese locales use GBK as the system default encoding, while SVG files are universally stored in UTF-8 and often contain multi-byte special characters that cannot be decoded correctly by GBK. This encoding mismatch results in an immediate decoding failure and halts the build.

The specific error message is as follows:
```
UnicodeDecodeError : 'gbk' codec can't decode byte 0xaa in position 174: illegal multibyte sequence 
Traceback (most recent call last):
  File "C:\Users\...\SCons\Action.py", line 1434, in execute 
    result = self.execfunction(target=target, source=rsources, env=env) 
  File "...\platform\platform_builders.py", line 14, in export_icon_builder 
    svg = file.read() 
UnicodeDecodeError: 'gbk' codec can't decode byte 0xaa in position 174: illegal multibyte sequence
```

