### PR TITLE
GDScript: Use `VariantInitializer` to initialize temporaries

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -628,7 +628,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			}
 		}
 		for (int i = non_vararg_arg_count + FIXED_ADDRESSES_MAX; i < _stack_size; i++) {
-			memnew_placement(&stack[i], Variant);
+			VariantInitializer<Variant>::init(&stack[i]);
 		}
 
 		if (is_vararg()) {


### PR DESCRIPTION
<details>
<summary>Benchmarked using this script</summary>

```gdscript
extends Node

var iter : int = 1_000_000
var test_strick : float = 0.0
var time : float = 0.0

func add10(p0: int, p1: int, p2: int, p3: int, p4: int, p5: int, p6: int, p7: int, p8: int, p9: int) -> int:
	return p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9

func add2(p0: int, p2: int) -> int:
	return p0 + p2

func noarg() -> int:
	return v0

var v0 := 0
var v1 := 1
var v2 := 2
var v3 := 3
var v4 := 4
var v5 := 5
var v6 := 6
var v7 := 7
var v8 := 8
var v9 := 9

func _ready() -> void:
	for ii in range(1):
		var sum: int
		var func_10_t: float
		var in_10_t: float
		var func_2_t: float
		var in_2_t: float
		var func_no_t: float
		var in_no_t: float
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += add10(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9)
		func_10_t = Time.get_unix_time_from_system() - time
		
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += v0 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9
		in_10_t = Time.get_unix_time_from_system() - time
		
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += add2(v1, v2)
		func_2_t = Time.get_unix_time_from_system() - time
		
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += v1 + v2
		in_2_t = Time.get_unix_time_from_system() - time
		
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += noarg()
		func_no_t = Time.get_unix_time_from_system() - time
		
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += v0
		in_no_t = Time.get_unix_time_from_system() - time
		
		print("Args, Function, Inline, Overhead")
		print(10, ", ", func_10_t, ", ", in_10_t, ", ", func_10_t - in_10_t)
		print(2, ", ", func_2_t, ", ", in_2_t, ", ", func_2_t - in_2_t)
		print(0, ", ", func_no_t, ", ", in_no_t, ", ", func_no_t - in_no_t)
		
	get_tree().quit()

```

</details>

In a debug build for a function with 10 temporaries I'm seeing around a 5% decrease in call overhead. Due to high variance I can not reliably benchmark this against a production build.

Also this is kinda a black box optimization for me, since I have no understanding of how `memnew_placement` works, I can not really say why it is slower.