### PR TITLE
macOS: Work around AppKit include defining `MAX`/`MIN` macros

### DIFF
--- a/platform/macos/display_server_macos_base.h
+++ b/platform/macos/display_server_macos_base.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/os/thread_safe.h"
+#include "core/typedefs.h" // IWYU pragma: keep. Prevent macOS `MAX`/`MIN` from being defined.
 #include "servers/display/display_server.h"
 
 #define FontVariation __FontVariation


### PR DESCRIPTION
Compiling Godot on a MacOS could produce a header conflict where MacOS runtime MAX macro was used instead Core/Typedefs MAX macro

Example: Defining a FixedVector in a header file would fail, due to MacOS MAX not being a ConstEXPR
