### PR TITLE
Fix audio bus effects section margin

### DIFF
--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -2058,6 +2058,10 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		p_theme->set_type_variation("TreeSecondary", "Tree");
 		p_theme->set_type_variation("ItemListSecondary", "ItemList");
 
+		// EditorAudioBusEffectsTree
+		p_theme->set_type_variation("EditorAudioBusEffectsTree", "Tree");
+		p_theme->set_constant("h_separation", "EditorAudioBusEffectsTree", 0);
+
 		// ForegroundPanel.
 		p_theme->set_type_variation("PanelForeground", "Panel");
 		p_theme->set_stylebox(SceneStringName(panel), "PanelForeground", p_config.base_empty_style);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -2201,6 +2201,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 				style_audio_bus_effect_tree->set_border_color(p_config.extra_border_color_2);
 			}
 			p_theme->set_stylebox(SceneStringName(panel), "EditorAudioBusEffectsTree", style_audio_bus_effect_tree);
+			p_theme->set_constant("h_separation", "EditorAudioBusEffectsTree", 0);
 		}
 
 		// ForegroundPanel.


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/109661 
More exactly this part https://github.com/godotengine/godot/issues/109661#issuecomment-3193625600

Before/After


<img width="180" height="403" alt="Screenshot_20260316_003904" src="https://github.com/user-attachments/assets/b042e08d-02f8-4397-a8a3-c1bf38d9766e" />

<img width="180" height="403" alt="Screenshot_20260316_003803" src="https://github.com/user-attachments/assets/ceaf3ef7-1482-4fcd-a463-1e726531c4e7" />
