### PR TITLE
Expand inspector sections while searching

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -4296,6 +4296,11 @@ void EditorInspector::update_tree() {
 	}
 
 	String filter = search_box ? search_box->get_text() : "";
+	// If the inspector filter is active, make everything unfold.
+	bool old_use_folding_state = use_folding;
+	if (!filter.is_empty()) {
+		use_folding = false;
+	}
 	String group;
 	String group_base;
 	EditorInspectorSection *group_togglable_property = nullptr;
@@ -5248,6 +5253,7 @@ void EditorInspector::update_tree() {
 	if (root_inspector_was_following_focus) {
 		get_root_inspector()->set_follow_focus(true);
 	}
+	use_folding = old_use_folding_state;
 }
 
 void EditorInspector::update_property(const String &p_prop) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/14422

If the filter is active, `use_folding` is disabled for that call to `update_tree` (this basically makes everything show as expanded). Once the filter is gone, sections are shown as whatever their state was without the filter.


https://github.com/user-attachments/assets/140da4ec-cb16-4b62-9117-e84c53acefe4

