### PR TITLE
Add goto next error keybind

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -931,6 +931,11 @@ void CodeTextEditor::input(const Ref<InputEvent> &event) {
 		accept_event();
 		return;
 	}
+	if (ED_IS_SHORTCUT("script_text_editor/next_error", key_event)) {
+		goto_error();
+		accept_event();
+		return;
+	}
 }
 
 void CodeTextEditor::_text_editor_gui_input(const Ref<InputEvent> &p_event) {

--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -204,6 +204,7 @@ TextEditorBase::EditMenus::EditMenus() {
 		edit_menu_line->add_shortcut(ED_GET_SHORTCUT("script_text_editor/unindent"), EDIT_UNINDENT);
 		edit_menu_line->add_shortcut(ED_GET_SHORTCUT("script_text_editor/delete_line"), EDIT_DELETE_LINE);
 		edit_menu_line->add_shortcut(ED_GET_SHORTCUT("script_text_editor/join_lines"), EDIT_JOIN_LINES);
+		edit_menu_line->add_shortcut(ED_GET_SHORTCUT("script_text_editor/next_error"), ERROR_GOTO_NEXT);
 		edit_menu_line->connect(SceneStringName(id_pressed), callable_mp(this, &EditMenus::_edit_option));
 		edit_menu->get_popup()->add_submenu_node_item(TTRC("Line"), edit_menu_line);
 	}
@@ -421,6 +422,9 @@ bool TextEditorBase::_edit_option(int p_op) {
 		} break;
 		case EDIT_JOIN_LINES: {
 			tx->join_lines();
+		} break;
+		case ERROR_GOTO_NEXT: {
+			code_editor->goto_error();
 		} break;
 		case EDIT_DUPLICATE_SELECTION: {
 			tx->duplicate_selection();

--- a/editor/script/script_editor_base.h
+++ b/editor/script/script_editor_base.h
@@ -123,6 +123,7 @@ protected:
 		EDIT_JOIN_LINES,
 
 		BASE_ENUM_COUNT,
+		ERROR_GOTO_NEXT,
 	};
 
 	class EditMenus : public HBoxContainer {

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -2667,6 +2667,7 @@ void ScriptTextEditor::register_editor() {
 	ED_SHORTCUT("script_text_editor/remove_all_breakpoints", TTRC("Remove All Breakpoints"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::F9);
 	// Using Control for these shortcuts even on macOS because Command+Comma is taken for opening Editor Settings.
 	ED_SHORTCUT("script_text_editor/goto_next_breakpoint", TTRC("Go to Next Breakpoint"), KeyModifierMask::CTRL | Key::PERIOD);
+	ED_SHORTCUT("script_text_editor/next_error", TTRC("Go to Next Error"), KeyModifierMask::ALT | Key::N);
 	ED_SHORTCUT("script_text_editor/goto_previous_breakpoint", TTRC("Go to Previous Breakpoint"), KeyModifierMask::CTRL | Key::COMMA);
 
 	ScriptEditor::register_create_script_editor_function(create_editor);

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -796,6 +796,9 @@ void TextShaderEditor::_menu_option(int p_option) {
 		case EDIT_JOIN_LINES: {
 			code_editor->get_text_editor()->join_lines();
 		} break;
+		case SEARCH_GOTO_NEXT_ERROR: {
+			code_editor->goto_error();
+		} break;
 	}
 	if (p_option != SEARCH_FIND && p_option != SEARCH_REPLACE && p_option != SEARCH_GOTO_LINE) {
 		callable_mp((Control *)code_editor->get_text_editor(), &Control::grab_focus).call_deferred(false);
@@ -1246,6 +1249,7 @@ TextShaderEditor::TextShaderEditor() {
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/unindent"), EDIT_UNINDENT);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/delete_line"), EDIT_DELETE_LINE);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/join_lines"), EDIT_JOIN_LINES);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/next_error"), SEARCH_GOTO_NEXT_ERROR);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_comment"), EDIT_TOGGLE_COMMENT);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/duplicate_selection"), EDIT_DUPLICATE_SELECTION);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/duplicate_lines"), EDIT_DUPLICATE_LINES);

--- a/editor/shader/text_shader_editor.h
+++ b/editor/shader/text_shader_editor.h
@@ -135,6 +135,7 @@ class TextShaderEditor : public ShaderEditor {
 		HELP_DOCS,
 		EDIT_EMOJI_AND_SYMBOL,
 		EDIT_JOIN_LINES,
+		SEARCH_GOTO_NEXT_ERROR,
 	};
 
 	HBoxContainer *menu_bar_hbox = nullptr;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/9038

I made the default Alt + N (this is what I use in VSCode)

https://github.com/user-attachments/assets/06a90150-9aa5-4ab2-9b07-fd471237ca84

