### PR TITLE
[Apple Embedded] Fix static .a/.xcframework library loading in `open_dynamic_library`

### DIFF
--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -319,7 +319,14 @@ Error OS_AppleEmbedded::open_dynamic_library(const String &p_path, void *&p_libr
 	}
 
 	if (!FileAccess::exists(path) && (p_path.ends_with(".a") || p_path.ends_with(".xcframework"))) {
-		path = String(); // Try loading static library.
+		// Static library already linked into the binary — use RTLD_SELF.
+		p_library_handle = RTLD_SELF;
+
+		if (p_data != nullptr && p_data->r_resolved_path != nullptr) {
+			*p_data->r_resolved_path = p_path;
+		}
+
+		return OK;
 	} else {
 		ERR_FAIL_COND_V(!FileAccess::exists(path), ERR_FILE_NOT_FOUND);
 	}


### PR DESCRIPTION
## Problem
When building iOS with vulkan=no, GDExtension loading fails with ERR_CANT_OPEN.

The static library fallback in open_dynamic_library sets path = String() and calls dlopen(""), which doesn't search the statically linked symbol table. The fix returns RTLD_SELF early instead, consistent with the existing empty-path case already handled in the function.

Tested on iOS with vulkan=no.
