### PR TITLE
GDScript: Reduce temporary count for chained operators

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -132,18 +132,18 @@ uint32_t GDScriptByteCodeGenerator::add_temporary(const GDScriptDataType &p_type
 	return slot;
 }
 
-void GDScriptByteCodeGenerator::pop_temporary() {
-	ERR_FAIL_COND(used_temporaries.is_empty());
-	int slot_idx = used_temporaries.back()->get();
-	if (temporaries[slot_idx].can_contain_object) {
+void GDScriptByteCodeGenerator::pop_temporary(int p_slot_idx) {
+	List<int>::Element *iter = used_temporaries.find(p_slot_idx);
+	ERR_FAIL_NULL(iter);
+	if (temporaries[p_slot_idx].can_contain_object) {
 		// Avoid keeping in the stack long-lived references to objects,
 		// which may prevent `RefCounted` objects from being freed.
 		// However, the cleanup will be performed an the end of the
 		// statement, to allow object references to survive chaining.
-		temporaries_pending_clear.insert(slot_idx);
+		temporaries_pending_clear.insert(p_slot_idx);
 	}
-	temporaries_pool[temporaries[slot_idx].type].push_back(slot_idx);
-	used_temporaries.pop_back();
+	temporaries_pool[temporaries[p_slot_idx].type].push_back(p_slot_idx);
+	used_temporaries.erase(iter);
 }
 
 void GDScriptByteCodeGenerator::start_parameters() {

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -59,7 +59,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 		void cleanup() {
 			DEV_ASSERT(!cleaned);
 			if (is_new_temporary) {
-				codegen->pop_temporary();
+				codegen->pop_temporary(target.address);
 			}
 #ifdef DEV_ENABLED
 			cleaned = true;
@@ -455,7 +455,7 @@ public:
 	virtual uint32_t add_or_get_constant(const Variant &p_constant) override;
 	virtual uint32_t add_or_get_name(const StringName &p_name) override;
 	virtual uint32_t add_temporary(const GDScriptDataType &p_type) override;
-	virtual void pop_temporary() override;
+	virtual void pop_temporary(int p_slot_idx) override;
 	virtual void clear_temporaries() override;
 	virtual void clear_address(const Address &p_address) override;
 	virtual bool is_local_dirty(const Address &p_address) const override;

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -70,7 +70,7 @@ public:
 	virtual uint32_t add_or_get_constant(const Variant &p_constant) = 0;
 	virtual uint32_t add_or_get_name(const StringName &p_name) = 0;
 	virtual uint32_t add_temporary(const GDScriptDataType &p_type) = 0;
-	virtual void pop_temporary() = 0;
+	virtual void pop_temporary(int p_slot_idx) = 0;
 	virtual void clear_temporaries() = 0;
 	virtual void clear_address(const Address &p_address) = 0;
 	virtual bool is_local_dirty(const Address &p_address) const = 0;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -522,7 +522,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 			for (int i = 0; i < values.size(); i++) {
 				if (values[i].mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					gen->pop_temporary();
+					gen->pop_temporary(values[i].address);
 				}
 			}
 
@@ -572,7 +572,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 			for (int i = 0; i < elements.size(); i++) {
 				if (elements[i].mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					gen->pop_temporary();
+					gen->pop_temporary(elements[i].address);
 				}
 			}
 
@@ -592,7 +592,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				gen->write_cast(result, src, cast_type);
 
 				if (src.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					gen->pop_temporary();
+					gen->pop_temporary(src.address);
 				}
 			} else {
 				result = _parse_expression(codegen, r_error, cn->operand);
@@ -721,7 +721,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 									gen->write_call(result, base, call->function_name, arguments);
 								}
 								if (base.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-									gen->pop_temporary();
+									gen->pop_temporary(base.address);
 								}
 							}
 						} else {
@@ -739,7 +739,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 			for (int i = 0; i < arguments.size(); i++) {
 				if (arguments[i].mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					gen->pop_temporary();
+					gen->pop_temporary(arguments[i].address);
 				}
 			}
 			return result;
@@ -778,7 +778,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			gen->write_await(result, argument);
 
 			if (argument.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-				gen->pop_temporary();
+				gen->pop_temporary(argument.address);
 			}
 
 			return result;
@@ -812,7 +812,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 					if (MI && MI->value.getter == "") {
 						// Remove result temp as we don't need it.
-						gen->pop_temporary();
+						gen->pop_temporary(result.address);
 						// Faster than indexing self (as if no self. had been used).
 						return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::MEMBER, MI->value.index, _gdtype_from_datatype(subscript->type_constraint, codegen.script));
 					}
@@ -841,10 +841,10 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			}
 
 			if (index.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-				gen->pop_temporary();
+				gen->pop_temporary(index.address);
 			}
 			if (base.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-				gen->pop_temporary();
+				gen->pop_temporary(base.address);
 			}
 
 			return result;
@@ -862,7 +862,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			gen->write_unary_operator(result, unary->variant_op, operand);
 
 			if (operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-				gen->pop_temporary();
+				gen->pop_temporary(operand.address);
 			}
 
 			return result;
@@ -870,11 +870,12 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 		case GDScriptParser::Node::BINARY_OPERATOR: {
 			const GDScriptParser::BinaryOpNode *binary = static_cast<const GDScriptParser::BinaryOpNode *>(p_expression);
 
-			GDScriptCodeGenerator::Address result = codegen.add_temporary(_gdtype_from_datatype(binary->type_constraint, codegen.script));
+			GDScriptCodeGenerator::Address result;
 
 			switch (binary->operation) {
 				case GDScriptParser::BinaryOpNode::OP_LOGIC_AND: {
 					// AND operator with early out on failure.
+					result = codegen.add_temporary(_gdtype_from_datatype(binary->type_constraint, codegen.script));
 					GDScriptCodeGenerator::Address left_operand = _parse_expression(codegen, r_error, binary->left_operand);
 					gen->write_and_left_operand(left_operand);
 					GDScriptCodeGenerator::Address right_operand = _parse_expression(codegen, r_error, binary->right_operand);
@@ -883,14 +884,15 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					gen->write_end_and(result);
 
 					if (right_operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-						gen->pop_temporary();
+						gen->pop_temporary(right_operand.address);
 					}
 					if (left_operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-						gen->pop_temporary();
+						gen->pop_temporary(left_operand.address);
 					}
 				} break;
 				case GDScriptParser::BinaryOpNode::OP_LOGIC_OR: {
 					// OR operator with early out on success.
+					result = codegen.add_temporary(_gdtype_from_datatype(binary->type_constraint, codegen.script));
 					GDScriptCodeGenerator::Address left_operand = _parse_expression(codegen, r_error, binary->left_operand);
 					gen->write_or_left_operand(left_operand);
 					GDScriptCodeGenerator::Address right_operand = _parse_expression(codegen, r_error, binary->right_operand);
@@ -899,23 +901,24 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					gen->write_end_or(result);
 
 					if (right_operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-						gen->pop_temporary();
+						gen->pop_temporary(right_operand.address);
 					}
 					if (left_operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-						gen->pop_temporary();
+						gen->pop_temporary(left_operand.address);
 					}
 				} break;
 				default: {
 					GDScriptCodeGenerator::Address left_operand = _parse_expression(codegen, r_error, binary->left_operand);
 					GDScriptCodeGenerator::Address right_operand = _parse_expression(codegen, r_error, binary->right_operand);
 
+					result = codegen.add_temporary(_gdtype_from_datatype(binary->type_constraint, codegen.script));
 					gen->write_binary_operator(result, binary->variant_op, left_operand, right_operand);
 
 					if (right_operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-						gen->pop_temporary();
+						gen->pop_temporary(right_operand.address);
 					}
 					if (left_operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-						gen->pop_temporary();
+						gen->pop_temporary(left_operand.address);
 					}
 				}
 			}
@@ -935,7 +938,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			gen->write_ternary_condition(condition);
 
 			if (condition.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-				gen->pop_temporary();
+				gen->pop_temporary(condition.address);
 			}
 
 			GDScriptCodeGenerator::Address true_expr = _parse_expression(codegen, r_error, ternary->true_expr);
@@ -944,7 +947,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			}
 			gen->write_ternary_true_expr(true_expr);
 			if (true_expr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-				gen->pop_temporary();
+				gen->pop_temporary(true_expr.address);
 			}
 
 			GDScriptCodeGenerator::Address false_expr = _parse_expression(codegen, r_error, ternary->false_expr);
@@ -953,7 +956,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			}
 			gen->write_ternary_false_expr(false_expr);
 			if (false_expr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-				gen->pop_temporary();
+				gen->pop_temporary(false_expr.address);
 			}
 
 			gen->write_end_ternary();
@@ -977,7 +980,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			}
 
 			if (operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-				gen->pop_temporary();
+				gen->pop_temporary(operand.address);
 			}
 
 			return result;
@@ -1150,9 +1153,9 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 						gen->write_get(value, key, prev_base);
 					}
 					gen->write_binary_operator(op_result, assignment->variant_op, value, assigned);
-					gen->pop_temporary();
+					gen->pop_temporary(value.address);
 					if (assigned.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-						gen->pop_temporary();
+						gen->pop_temporary(assigned.address);
 					}
 					assigned = op_result;
 				}
@@ -1164,10 +1167,10 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					gen->write_set(prev_base, key, assigned);
 				}
 				if (key.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					gen->pop_temporary();
+					gen->pop_temporary(key.address);
 				}
 				if (assigned.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					gen->pop_temporary();
+					gen->pop_temporary(assigned.address);
 				}
 
 				assigned = prev_base;
@@ -1192,10 +1195,10 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 						}
 					}
 					if (!info.is_named && info.key.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-						gen->pop_temporary();
+						gen->pop_temporary(info.key.address);
 					}
 					if (assigned.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-						gen->pop_temporary();
+						gen->pop_temporary(assigned.address);
 					}
 					assigned = info.base;
 				}
@@ -1228,7 +1231,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 							GDScriptCodeGenerator::Address temp = codegen.add_temporary(static_var_data_type);
 							gen->write_assign(temp, assigned);
 							gen->write_set_static_variable(temp, static_var_class, static_var_index);
-							gen->pop_temporary();
+							gen->pop_temporary(temp.address);
 						} else {
 							gen->write_assign(target_member_property, assigned);
 						}
@@ -1248,7 +1251,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				}
 
 				if (assigned.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					gen->pop_temporary();
+					gen->pop_temporary(assigned.address);
 				}
 			} else if (assignment->assignee->type == GDScriptParser::Node::IDENTIFIER && _is_class_member_property(codegen, static_cast<GDScriptParser::IdentifierNode *>(assignment->assignee)->name)) {
 				// Assignment to member property.
@@ -1267,17 +1270,17 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					GDScriptCodeGenerator::Address member = codegen.add_temporary(_gdtype_from_datatype(assignment->assignee->type_constraint, codegen.script));
 					gen->write_get_member(member, name);
 					gen->write_binary_operator(op_result, assignment->variant_op, member, assigned_value);
-					gen->pop_temporary(); // Pop member temp.
+					gen->pop_temporary(member.address); // Pop member temp.
 					to_assign = op_result;
 				}
 
 				gen->write_set_member(to_assign, name);
 
 				if (to_assign.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					gen->pop_temporary(); // Pop the assigned expression or the temp result if it has operation.
+					gen->pop_temporary(to_assign.address); // Pop the assigned expression or the temp result if it has operation.
 				}
 				if (has_operation && assigned_value.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					gen->pop_temporary(); // Pop the assigned expression if not done before.
+					gen->pop_temporary(assigned_value.address); // Pop the assigned expression if not done before.
 				}
 			} else {
 				// Regular assignment.
@@ -1354,7 +1357,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					to_assign = op_result;
 
 					if (og_value.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-						gen->pop_temporary();
+						gen->pop_temporary(og_value.address);
 					}
 				} else {
 					to_assign = assigned_value;
@@ -1374,7 +1377,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 						gen->write_assign(temp, to_assign);
 					}
 					gen->write_set_static_variable(temp, static_var_class, static_var_index);
-					gen->pop_temporary();
+					gen->pop_temporary(temp.address);
 				} else {
 					// Just assign.
 					if (assignment->use_conversion_assign) {
@@ -1385,13 +1388,13 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				}
 
 				if (to_assign.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					gen->pop_temporary(); // Pop assigned value or temp operation result.
+					gen->pop_temporary(to_assign.address); // Pop assigned value or temp operation result.
 				}
 				if (has_operation && assigned_value.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					gen->pop_temporary(); // Pop assigned value if not done before.
+					gen->pop_temporary(assigned_value.address); // Pop assigned value if not done before.
 				}
 				if (target.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					gen->pop_temporary(); // Pop the target to assignment.
+					gen->pop_temporary(target.address); // Pop the target to assignment.
 				}
 			}
 			return GDScriptCodeGenerator::Address(); // Assignment does not return a value.
@@ -1419,7 +1422,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 			for (int i = 0; i < captures.size(); i++) {
 				if (captures[i].mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					gen->pop_temporary();
+					gen->pop_temporary(captures[i].address);
 				}
 			}
 
@@ -1464,7 +1467,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 				codegen.generator->write_binary_operator(tmp_comp_addr, Variant::OP_EQUAL, p_type_addr, type_stringname_addr);
 				codegen.generator->write_binary_operator(type_equality_addr, Variant::OP_OR, type_equality_addr, tmp_comp_addr);
 
-				codegen.generator->pop_temporary(); // Remove tmp_comp_addr from stack.
+				codegen.generator->pop_temporary(tmp_comp_addr.address); // Remove tmp_comp_addr from stack.
 			} else if (literal_type == Variant::STRING_NAME) {
 				GDScriptCodeGenerator::Address type_string_addr = codegen.add_constant(Variant::STRING);
 
@@ -1474,7 +1477,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 				codegen.generator->write_binary_operator(tmp_comp_addr, Variant::OP_EQUAL, p_type_addr, type_string_addr);
 				codegen.generator->write_binary_operator(type_equality_addr, Variant::OP_OR, type_equality_addr, tmp_comp_addr);
 
-				codegen.generator->pop_temporary(); // Remove tmp_comp_addr from stack.
+				codegen.generator->pop_temporary(tmp_comp_addr.address); // Remove tmp_comp_addr from stack.
 			}
 
 			codegen.generator->write_and_left_operand(type_equality_addr);
@@ -1493,10 +1496,10 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 			// AND both together (reuse temporary location).
 			codegen.generator->write_end_and(type_equality_addr);
 
-			codegen.generator->pop_temporary(); // Remove equality_addr from stack.
+			codegen.generator->pop_temporary(equality_addr.address); // Remove equality_addr from stack.
 
 			if (literal_addr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-				codegen.generator->pop_temporary();
+				codegen.generator->pop_temporary(literal_addr.address);
 			}
 
 			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
@@ -1512,7 +1515,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 				// Just assign this value to the accumulator temporary.
 				codegen.generator->write_assign(p_previous_test, type_equality_addr);
 			}
-			codegen.generator->pop_temporary(); // Remove type_equality_addr.
+			codegen.generator->pop_temporary(type_equality_addr.address); // Remove type_equality_addr.
 
 			return p_previous_test;
 		} break;
@@ -1565,9 +1568,9 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 			codegen.generator->write_binary_operator(stringy_comp_addr, Variant::OP_AND, stringy_comp_addr, stringy_comp_addr_2);
 			codegen.generator->write_binary_operator(result_addr, Variant::OP_OR, result_addr, stringy_comp_addr);
 
-			codegen.generator->pop_temporary(); // Remove expr_type_addr from stack.
-			codegen.generator->pop_temporary(); // Remove stringy_comp_addr_2 from stack.
-			codegen.generator->pop_temporary(); // Remove stringy_comp_addr from stack.
+			codegen.generator->pop_temporary(expr_type_addr.address); // Remove expr_type_addr from stack.
+			codegen.generator->pop_temporary(stringy_comp_addr_2.address); // Remove stringy_comp_addr_2 from stack.
+			codegen.generator->pop_temporary(stringy_comp_addr.address); // Remove stringy_comp_addr from stack.
 
 			codegen.generator->write_and_left_operand(result_addr);
 
@@ -1580,9 +1583,9 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 
 			// We don't need the expression temporary anymore.
 			if (expr_addr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-				codegen.generator->pop_temporary();
+				codegen.generator->pop_temporary(expr_addr.address);
 			}
-			codegen.generator->pop_temporary(); // Remove equality_test_addr from stack.
+			codegen.generator->pop_temporary(equality_test_addr.address); // Remove equality_test_addr from stack.
 
 			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
 			if (p_is_nested) {
@@ -1597,7 +1600,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 				// Just assign this value to the accumulator temporary.
 				codegen.generator->write_assign(p_previous_test, result_addr);
 			}
-			codegen.generator->pop_temporary(); // Remove temp result addr.
+			codegen.generator->pop_temporary(result_addr.address); // Remove temp result addr.
 
 			return p_previous_test;
 		} break;
@@ -1640,8 +1643,8 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 			codegen.generator->write_end_and(result_addr);
 
 			// Remove length temporaries.
-			codegen.generator->pop_temporary();
-			codegen.generator->pop_temporary();
+			codegen.generator->pop_temporary(length_compat_addr.address);
+			codegen.generator->pop_temporary(value_length_addr.address);
 
 			// Create temporaries outside the loop so they can be reused.
 			GDScriptCodeGenerator::Address element_addr = codegen.add_temporary();
@@ -1678,8 +1681,8 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 				codegen.generator->write_end_and(result_addr);
 			}
 			// Remove element temporaries.
-			codegen.generator->pop_temporary();
-			codegen.generator->pop_temporary();
+			codegen.generator->pop_temporary(element_type_addr.address);
+			codegen.generator->pop_temporary(element_addr.address);
 
 			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
 			if (p_is_nested) {
@@ -1694,7 +1697,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 				// Just assign this value to the accumulator temporary.
 				codegen.generator->write_assign(p_previous_test, result_addr);
 			}
-			codegen.generator->pop_temporary(); // Remove temp result addr.
+			codegen.generator->pop_temporary(result_addr.address); // Remove temp result addr.
 
 			return p_previous_test;
 		} break;
@@ -1737,8 +1740,8 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 			codegen.generator->write_end_and(result_addr);
 
 			// Remove length temporaries.
-			codegen.generator->pop_temporary();
-			codegen.generator->pop_temporary();
+			codegen.generator->pop_temporary(length_compat_addr.address);
+			codegen.generator->pop_temporary(value_length_addr.address);
 
 			// Create temporaries outside the loop so they can be reused.
 			GDScriptCodeGenerator::Address element_addr = codegen.add_temporary();
@@ -1792,13 +1795,13 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 
 				// Remove pattern key temporary.
 				if (pattern_key_addr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					codegen.generator->pop_temporary();
+					codegen.generator->pop_temporary(pattern_key_addr.address);
 				}
 			}
 
 			// Remove element temporaries.
-			codegen.generator->pop_temporary();
-			codegen.generator->pop_temporary();
+			codegen.generator->pop_temporary(element_type_addr.address);
+			codegen.generator->pop_temporary(element_addr.address);
 
 			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
 			if (p_is_nested) {
@@ -1813,7 +1816,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &c
 				// Just assign this value to the accumulator temporary.
 				codegen.generator->write_assign(p_previous_test, result_addr);
 			}
-			codegen.generator->pop_temporary(); // Remove temp result addr.
+			codegen.generator->pop_temporary(result_addr.address); // Remove temp result addr.
 
 			return p_previous_test;
 		} break;
@@ -1923,7 +1926,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 				gen->write_assign(value, value_expr);
 
 				if (value_expr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					codegen.generator->pop_temporary();
+					codegen.generator->pop_temporary(value_expr.address);
 				}
 
 				// Then, let's save the type of the value in the stack too, so we can reuse for later comparisons.
@@ -1978,7 +1981,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 						gen->write_end_and(pattern_result);
 
 						if (guard_result.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-							codegen.generator->pop_temporary();
+							codegen.generator->pop_temporary(guard_result.address);
 						}
 					}
 
@@ -1986,7 +1989,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 					gen->write_if(pattern_result);
 
 					// Remove the result from stack.
-					gen->pop_temporary();
+					gen->pop_temporary(pattern_result.address);
 
 					// Parse the branch block.
 					err = _parse_block(codegen, branch->block, false); // Don't add locals again.
@@ -2016,7 +2019,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 				gen->write_if(condition);
 
 				if (condition.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					codegen.generator->pop_temporary();
+					codegen.generator->pop_temporary(condition.address);
 				}
 
 				err = _parse_block(codegen, if_n->true_block);
@@ -2085,7 +2088,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 
 					for (int j = 0; j < args.size(); j++) {
 						if (args[j].mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-							codegen.generator->pop_temporary();
+							codegen.generator->pop_temporary(args[j].address);
 						}
 					}
 				} else {
@@ -2097,7 +2100,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 					gen->write_for_list_assignment(list);
 
 					if (list.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-						codegen.generator->pop_temporary();
+						codegen.generator->pop_temporary(list.address);
 					}
 				}
 
@@ -2134,7 +2137,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 				gen->write_while(condition);
 
 				if (condition.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					codegen.generator->pop_temporary();
+					codegen.generator->pop_temporary(condition.address);
 				}
 
 				// Loop variables must be cleared even when `break`/`continue` is used.
@@ -2178,7 +2181,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 					gen->write_return(return_value, return_n->use_conversion);
 				}
 				if (return_value.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					codegen.generator->pop_temporary();
+					codegen.generator->pop_temporary(return_value.address);
 				}
 			} break;
 			case GDScriptParser::Node::ASSERT: {
@@ -2201,10 +2204,10 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 				gen->write_assert(condition, message);
 
 				if (condition.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					codegen.generator->pop_temporary();
+					codegen.generator->pop_temporary(condition.address);
 				}
 				if (message.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					codegen.generator->pop_temporary();
+					codegen.generator->pop_temporary(message.address);
 				}
 #endif
 			} break;
@@ -2231,7 +2234,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 						gen->write_assign(local, src_address);
 					}
 					if (src_address.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-						codegen.generator->pop_temporary();
+						codegen.generator->pop_temporary(src_address.address);
 					}
 					initialized = true;
 				} else if (local_type.kind == GDScriptDataType::BUILTIN || codegen.generator->is_local_dirty(local)) {
@@ -2267,7 +2270,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 						return err;
 					}
 					if (expr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-						codegen.generator->pop_temporary();
+						codegen.generator->pop_temporary(expr.address);
 					}
 				} else {
 					_set_error("Compiler bug (please report): unexpected node in parse tree while parsing statement.", s); // Unreachable code.
@@ -2432,7 +2435,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 					codegen.generator->write_assign(dst_address, src_address);
 				}
 				if (src_address.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					codegen.generator->pop_temporary();
+					codegen.generator->pop_temporary(src_address.address);
 				}
 			}
 		}
@@ -2452,7 +2455,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 				GDScriptCodeGenerator::Address dst_addr = codegen.parameters[parameter->identifier->name];
 				codegen.generator->write_assign_default_parameter(dst_addr, src_addr, parameter->use_conversion_assign);
 				if (src_addr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					codegen.generator->pop_temporary();
+					codegen.generator->pop_temporary(src_addr.address);
 				}
 			}
 			codegen.generator->end_parameters();
@@ -2576,18 +2579,18 @@ GDScriptFunction *GDScriptCompiler::_make_static_initializer(Error &r_error, GDS
 				GDScriptCodeGenerator::Address temp = codegen.add_temporary(field_type);
 				codegen.generator->write_construct_typed_array(temp, field_type.get_container_element_type(0), Vector<GDScriptCodeGenerator::Address>());
 				codegen.generator->write_set_static_variable(temp, class_addr, p_script->static_variables_indices[field->identifier->name].index);
-				codegen.generator->pop_temporary();
+				codegen.generator->pop_temporary(temp.address);
 			} else if (field_type.builtin_type == Variant::DICTIONARY && field_type.has_container_element_types()) {
 				GDScriptCodeGenerator::Address temp = codegen.add_temporary(field_type);
 				codegen.generator->write_construct_typed_dictionary(temp, field_type.get_container_element_type_or_variant(0),
 						field_type.get_container_element_type_or_variant(1), Vector<GDScriptCodeGenerator::Address>());
 				codegen.generator->write_set_static_variable(temp, class_addr, p_script->static_variables_indices[field->identifier->name].index);
-				codegen.generator->pop_temporary();
+				codegen.generator->pop_temporary(temp.address);
 			} else if (field_type.kind == GDScriptDataType::BUILTIN) {
 				GDScriptCodeGenerator::Address temp = codegen.add_temporary(field_type);
 				codegen.generator->write_construct(temp, field_type.builtin_type, Vector<GDScriptCodeGenerator::Address>());
 				codegen.generator->write_set_static_variable(temp, class_addr, p_script->static_variables_indices[field->identifier->name].index);
-				codegen.generator->pop_temporary();
+				codegen.generator->pop_temporary(temp.address);
 			}
 			// The `else` branch is for objects, in such case we leave it as `null`.
 		}
@@ -2621,11 +2624,11 @@ GDScriptFunction *GDScriptCompiler::_make_static_initializer(Error &r_error, GDS
 				codegen.generator->write_assign(temp, src_address);
 			}
 			if (src_address.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-				codegen.generator->pop_temporary();
+				codegen.generator->pop_temporary(src_address.address);
 			}
 
 			codegen.generator->write_set_static_variable(temp, class_addr, p_script->static_variables_indices[field->identifier->name].index);
-			codegen.generator->pop_temporary();
+			codegen.generator->pop_temporary(temp.address);
 		}
 	}
 


### PR DESCRIPTION
GDScript uses temporary locations on the stack, e.g. as intermediate targets for operations.

At the moment those temporaries are managed in a stack like fashion. Meaning a temporary `B` which was reserved before a temporary `A`, also must be freed up before `A`.

This approach is not great for chained binary operators `a + (b + c)`. Since the result of an operation needs to be handed out it needs to be reserved before the operands are calculated (since the operands have a shorter lifetime than the result). This keeps the result temporary reserved while the operands are calculated and forces chained binary operators to create new temporaries.

This PR changes temporary management to be able to free up any temporary at any time. This allows to only reserve the result of an operator after operands were calculated. So temporaries from those calculations can be reused.

E.g. for a chain `p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9`

Bytecode before:
```
 2: operator stack(21) = stack(3) + stack(4)
 11: operator stack(20) = stack(21) + stack(5)
 20: operator stack(19) = stack(20) + stack(6)
 29: operator stack(18) = stack(19) + stack(7)
 38: operator stack(17) = stack(18) + stack(8)
 47: operator stack(16) = stack(17) + stack(9)
 56: operator stack(15) = stack(16) + stack(10)
 65: operator stack(14) = stack(15) + stack(11)
```
Bytecode after:
```
 2: operator stack(13) = stack(3) + stack(4)
 11: operator stack(14) = stack(13) + stack(5)
 20: operator stack(13) = stack(14) + stack(6)
 29: operator stack(14) = stack(13) + stack(7)
 38: operator stack(13) = stack(14) + stack(8)
 47: operator stack(14) = stack(13) + stack(9)
 56: operator stack(13) = stack(14) + stack(10)
 65: operator stack(14) = stack(13) + stack(11)
```

(GDScript operates under the assumption, that the result of variant operators can not overlap with the operands. I don't know if that is actually the case due to lack of documentation.)

This reduces the stack size of some functions. A reduced stack size reduces call overhead from setting up/tearing down the stack.

---

<details>
<summary>Benchmarked using this script</summary>

```gdscript
extends Node

var iter : int = 1_000_000
var test_strick : float = 0.0
var time : float = 0.0

func add10(p0: int, p1: int, p2: int, p3: int, p4: int, p5: int, p6: int, p7: int, p8: int, p9: int) -> int:
	return p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9

func add2(p0: int, p2: int) -> int:
	return p0 + p2

func noarg() -> int:
	return v0

var v0 := 0
var v1 := 1
var v2 := 2
var v3 := 3
var v4 := 4
var v5 := 5
var v6 := 6
var v7 := 7
var v8 := 8
var v9 := 9

func _ready() -> void:
	for ii in range(1):
		var sum: int
		var func_10_t: float
		var in_10_t: float
		var func_2_t: float
		var in_2_t: float
		var func_no_t: float
		var in_no_t: float
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += add10(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9)
		func_10_t = Time.get_unix_time_from_system() - time
		
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += v0 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9
		in_10_t = Time.get_unix_time_from_system() - time
		
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += add2(v1, v2)
		func_2_t = Time.get_unix_time_from_system() - time
		
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += v1 + v2
		in_2_t = Time.get_unix_time_from_system() - time
		
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += noarg()
		func_no_t = Time.get_unix_time_from_system() - time
		
		time = Time.get_unix_time_from_system()
		for i:int in range(iter):
			sum += v0
		in_no_t = Time.get_unix_time_from_system() - time
		
		print("Args, Function, Inline, Overhead")
		print(10, ", ", func_10_t, ", ", in_10_t, ", ", func_10_t - in_10_t)
		print(2, ", ", func_2_t, ", ", in_2_t, ", ", func_2_t - in_2_t)
		print(0, ", ", func_no_t, ", ", in_no_t, ", ", func_no_t - in_no_t)
		
	get_tree().quit()

```

</details>

For the function with a long chain of operators I see a reduction in call overhead of around 6%.

I see a slight performance decrease only for the function with 2 arguments. However since this PR does not touch the VM and the bytecode of the function is not changed by this PR, I'm assuming this is some sort of cache shenanigans or code locality stuff.

~Also I benchmarked using a debug build. Variance is too high for release. Might be worth a try to increase the iteration count and see whether the results become meaningful in release builds.~

