### PR TITLE
Build profile: Only allow classes derived from `Resource` and `Node` to be disabled

### DIFF
--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -837,7 +837,9 @@ void EditorBuildProfileManager::_find_files(EditorFileSystemDirectory *p_dir, co
 		HashSet<StringName> classes;
 		ResourceLoader::get_classes_used(p, &classes);
 		for (const StringName &E : classes) {
-			cache.classes.push_back(E);
+			if (E == "Resource" || E == "Node" || ClassDB::is_parent_class(E, "Resource") || ClassDB::is_parent_class(E, "Node")) {
+				cache.classes.push_back(E);
+			}
 		}
 
 		HashSet<String> build_deps;
@@ -935,12 +937,8 @@ void EditorBuildProfileManager::_detect_from_project() {
 	const LocalVector<String> hardcoded_classes = {
 		"Font",
 		"InputEvent",
-		"MainLoop",
-		"Mutex",
 		"ShaderInclude",
-		"ShaderIncludeDB",
 		"StyleBox",
-		"Time",
 		"Window",
 	};
 
@@ -1000,8 +998,16 @@ void EditorBuildProfileManager::_detect_from_project() {
 	ClassDB::get_class_list(all_classes);
 
 	for (const StringName &class_name : all_classes) {
-		if (String(class_name).begins_with("Editor") || ClassDB::get_api_type(class_name) != ClassDB::API_CORE || all_used_classes.has(class_name)) {
-			// This class is valid or editor-only, do nothing.
+		ClassDB::APIType class_api = ClassDB::get_api_type(class_name);
+		if (class_api == ClassDB::API_EDITOR || class_api != ClassDB::API_CORE) {
+			continue; // This class is editor-only or not from Godot itself.
+		}
+
+		if (class_name != "Resource" && class_name != "Node" && (ClassDB::is_parent_class(class_name, "Resource") || ClassDB::is_parent_class(class_name, "Node"))) {
+			continue;
+		}
+
+		if (all_used_classes.has(class_name)) {
 			continue;
 		}
 
@@ -1160,10 +1166,10 @@ void EditorBuildProfileManager::_fill_classes_from(TreeItem *p_parent, const Str
 	child_classes.sort_custom<StringName::AlphCompare>();
 
 	for (const StringName &name : child_classes) {
-		if (String(name).begins_with("Editor") || ClassDB::get_api_type(name) != ClassDB::API_CORE) {
-			continue;
+		ClassDB::APIType class_api = ClassDB::get_api_type(name);
+		if (class_api != ClassDB::API_EDITOR && class_api == ClassDB::API_CORE) {
+			_fill_classes_from(class_item, name, p_selected);
 		}
-		_fill_classes_from(class_item, name, p_selected);
 	}
 }
 


### PR DESCRIPTION
The editor profile builder dialog shows only classes derived from `Resource` and `Node` in the tree to be toggled. However, the option to generate a profile from the project adds classes that don't derive from those. This PR makes so that the behavior from project generation now matches with the dialog options.

This PR also makes that the check to see if a class is editor-only uses the `APIType` instead of just checking if the name starts with "Editor".

Fixes #117414.