### PR TITLE
Add missing `GDVIRTUAL_BIND(_get_supported_extensions)` on `MovieWriter`

### DIFF
--- a/doc/classes/MovieWriter.xml
+++ b/doc/classes/MovieWriter.xml
@@ -30,6 +30,12 @@
 				Called when the audio speaker mode used for recording the audio is requested by the engine. This can affect the number of output channels in the resulting audio file/stream. Defaults to [constant AudioServer.SPEAKER_MODE_STEREO] if [method _get_audio_speaker_mode] is not overridden.
 			</description>
 		</method>
+		<method name="_get_supported_extensions" qualifiers="virtual required const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns the list of supported filename extensions for movies written with this [MovieWriter].
+			</description>
+		</method>
 		<method name="_handles_file" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="path" type="String" />

--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -142,6 +142,7 @@ void MovieWriter::_bind_methods() {
 	GDVIRTUAL_BIND(_get_audio_speaker_mode)
 
 	GDVIRTUAL_BIND(_handles_file, "path")
+	GDVIRTUAL_BIND(_get_supported_extensions)
 
 	GDVIRTUAL_BIND(_write_begin, "movie_size", "fps", "base_path")
 	GDVIRTUAL_BIND(_write_frame, "frame_image", "audio_frame_block")


### PR DESCRIPTION
It looks like the `GDVIRTUAL_BIND()` for this virtual method was simply forgotten. Otherwise, it's there and appears to be implemented correctly.