### PR TITLE
Misc includes or modernize fixes found via clangd-tidy

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,12 +1,21 @@
 # https://clangd.llvm.org/config
+
 ---
+
 # Default conditions, apply everywhere.
+
+CompileFlags:
+  Add:
+    # Some thirdparty includes seem to require a high -ferror-limit to pass checks.
+    - -ferror-limit=100
 
 Diagnostics:
   Includes:
     IgnoreHeader:
       - \.compat\.inc
+
 ---
+
 # Header-specific conditions.
 
 If:
@@ -20,11 +29,19 @@ CompileFlags:
     - -Wno-unused-const-variable
     - -Wno-unused-function
     - -Wno-unused-variable
+
 ---
-# Suppress all third-party warnings.
+
+# Suppress warnings for third-party or partial code.
 
 If:
-  PathMatch: thirdparty/.*
+  PathMatch:
+    - bin/build_deps/.*
+    - misc/dist/apple_embedded_xcode/.*
+    - tests/compatibility_test/.*
+    - thirdparty/.*
+    - .*/thirdparty/.*
+    - .*-so_wrap.[ch]
 
 Diagnostics:
   Suppress: "*"

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -77,7 +77,7 @@ class CallableCustomExtension : public CallableCustom {
 		const CallableCustomExtension *b = static_cast<const CallableCustomExtension *>(p_b);
 
 		if (a->call_func != b->call_func) {
-			return a->call_func < b->call_func;
+			return (uintptr_t)a->call_func < (uintptr_t)b->call_func;
 		}
 		return a->userdata < b->userdata;
 	}

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -306,7 +306,7 @@ bool Callable::operator<(const Callable &p_callable) const {
 			if (less_a == less_b) {
 				return less_a(custom, p_callable.custom);
 			} else {
-				return less_a < less_b; //it's something..
+				return (uintptr_t)less_a < (uintptr_t)less_b; //it's something..
 			}
 
 		} else {

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -96,7 +96,7 @@ Error AudioDriverALSA::init_output_device() {
 
 	ERR_FAIL_COND_V(status < 0, ERR_CANT_OPEN);
 
-	snd_pcm_hw_params_alloca(&hwparams);
+	snd_pcm_hw_params_alloca(&hwparams); // NOLINT(modernize-use-bool-literals)
 
 	status = snd_pcm_hw_params_any(pcm_handle, hwparams);
 	CHECK_FAIL(status < 0);
@@ -140,7 +140,7 @@ Error AudioDriverALSA::init_output_device() {
 
 	//snd_pcm_hw_params_free(&hwparams);
 
-	snd_pcm_sw_params_alloca(&swparams);
+	snd_pcm_sw_params_alloca(&swparams); // NOLINT(modernize-use-bool-literals)
 
 	status = snd_pcm_sw_params_current(pcm_handle, swparams);
 	CHECK_FAIL(status < 0);

--- a/drivers/d3d12/godot_d3d12ma.h
+++ b/drivers/d3d12/godot_d3d12ma.h
@@ -35,6 +35,9 @@
 GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wnon-virtual-dtor")
 GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wnon-virtual-dtor")
 
+#include <drivers/d3d12/godot_d3dx12.h>
+#include <dxgi1_6.h>
+
 #define D3D12MA_D3D12_HEADERS_ALREADY_INCLUDED
 #include <thirdparty/d3d12ma/D3D12MemAlloc.h> // IWYU pragma: export.
 

--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -34,7 +34,6 @@
 #include "core/config/project_settings.h"
 #include "core/string/ustring.h"
 #include "core/templates/local_vector.h"
-#include "drivers/d3d12/d3d12_hooks.h"
 
 GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wnon-virtual-dtor")
 GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wnon-virtual-dtor")

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -37,7 +37,7 @@
 #include "drivers/d3d12/rendering_context_driver_d3d12.h"
 
 #include <dxgi1_6.h>
-// Ensure d3dx12 and dxgi are included first.
+
 #include <drivers/d3d12/godot_d3d12ma.h>
 #include <drivers/d3d12/godot_nir.h>
 

--- a/drivers/d3d12/rendering_shader_container_d3d12.cpp
+++ b/drivers/d3d12/rendering_shader_container_d3d12.cpp
@@ -33,10 +33,8 @@
 #include "core/templates/sort_array.h"
 #include "drivers/d3d12/dxil_hash.h"
 
-#include <drivers/d3d12/godot_d3dx12.h>
-#include <dxgi1_6.h>
-// Include d3dx12 and dxgi before d3d12ma.
 #include <drivers/d3d12/godot_d3d12ma.h>
+#include <drivers/d3d12/godot_d3dx12.h>
 #include <drivers/d3d12/godot_nir.h>
 
 #include <wrl/client.h>
@@ -430,8 +428,8 @@ bool RenderingShaderContainerD3D12::_convert_spirv_to_nir(Span<ReflectShaderStag
 				shader->info.inputs_read |= VARYING_BIT_POS;
 
 				if (prev_shader) {
-					dxil_reassign_driver_locations(shader, nir_var_shader_in, prev_shader->info.outputs_written, NULL);
-					dxil_reassign_driver_locations(prev_shader, nir_var_shader_out, shader->info.inputs_read, NULL);
+					dxil_reassign_driver_locations(shader, nir_var_shader_in, prev_shader->info.outputs_written, nullptr);
+					dxil_reassign_driver_locations(prev_shader, nir_var_shader_out, shader->info.inputs_read, nullptr);
 				}
 			}
 		}

--- a/drivers/egl/egl_manager.cpp
+++ b/drivers/egl/egl_manager.cpp
@@ -30,6 +30,8 @@
 
 #include "egl_manager.h"
 
+#ifdef EGL_ENABLED
+
 #include "core/config/engine.h"
 #include "core/crypto/crypto_core.h"
 #include "core/io/dir_access.h"
@@ -39,8 +41,6 @@
 #ifdef WINDOWS_ENABLED
 #include "drivers/gles3/rasterizer_gles3.h"
 #endif
-
-#ifdef EGL_ENABLED
 
 #if defined(EGL_STATIC)
 

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -33,10 +33,13 @@
 #ifdef GLES3_ENABLED
 
 #include "core/io/dir_access.h"
-#include "core/io/file_access.h"
 #include "core/string/string_builder.h"
 #include "drivers/gles3/rasterizer_util_gles3.h"
 #include "drivers/gles3/storage/config.h"
+
+#ifndef WEB_ENABLED
+#include "core/io/file_access.h"
+#endif
 
 static String _mkid(const String &p_id) {
 	String id = "m_" + p_id.replace("__", "_dus_");

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -3346,7 +3346,7 @@ GLuint TextureStorage::render_target_get_depth(RID p_render_target) const {
 
 bool TextureStorage::render_target_get_depth_has_stencil(RID p_render_target) const {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
-	ERR_FAIL_NULL_V(rt, 0);
+	ERR_FAIL_NULL_V(rt, false);
 
 	return rt->depth_has_stencil;
 }

--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -34,13 +34,16 @@
 
 #include "core/config/engine.h"
 #include "core/os/os.h"
-#include "drivers/gles3/rasterizer_util_gles3.h"
 #include "drivers/gles3/storage/config.h"
 #include "drivers/gles3/storage/light_storage.h"
 #include "drivers/gles3/storage/material_storage.h"
 #include "drivers/gles3/storage/mesh_storage.h"
 #include "drivers/gles3/storage/particles_storage.h"
 #include "drivers/gles3/storage/texture_storage.h"
+
+#ifdef GL_API_ENABLED
+#include "drivers/gles3/rasterizer_util_gles3.h"
+#endif
 
 using namespace GLES3;
 

--- a/drivers/metal/metal3_objects.h
+++ b/drivers/metal/metal3_objects.h
@@ -348,7 +348,7 @@ public:
 		MDRenderPipeline *pipeline = nullptr;
 		LocalVector<RDD::RenderPassClearValue> clear_values;
 		uint32_t current_subpass = UINT32_MAX;
-		Rect2i render_area = {};
+		Rect2i render_area;
 		bool is_rendering_entire_area = false;
 		NS::SharedPtr<MTL::RenderPassDescriptor> desc;
 		NS::SharedPtr<MTL::RenderCommandEncoder> encoder;
@@ -405,7 +405,7 @@ public:
 			dirty.set_flag(DirtyFlag::DIRTY_UNIFORMS);
 		}
 
-		_FORCE_INLINE_ void mark_uniforms_dirty(void) {
+		_FORCE_INLINE_ void mark_uniforms_dirty() {
 			if (uniform_sets.is_empty()) {
 				return;
 			}
@@ -478,7 +478,7 @@ public:
 		_FORCE_INLINE_ void reset();
 		void end_encoding();
 
-		_FORCE_INLINE_ void mark_uniforms_dirty(void) {
+		_FORCE_INLINE_ void mark_uniforms_dirty() {
 			if (uniform_sets.is_empty()) {
 				return;
 			}

--- a/drivers/metal/metal_objects_shared.h
+++ b/drivers/metal/metal_objects_shared.h
@@ -762,7 +762,7 @@ struct API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0), visionos(2.0)) UniformI
 	MTL::TextureType textureType = MTL::TextureType2D;
 	uint32_t imageFormat = 0;
 	uint32_t arrayLength = 0;
-	bool isMultisampled = 0;
+	bool isMultisampled = false;
 
 	struct Indexes {
 		uint32_t buffer = UINT32_MAX;

--- a/drivers/metal/metal_utils.h
+++ b/drivers/metal/metal_utils.h
@@ -30,9 +30,13 @@
 
 #pragma once
 
+#include "core/error/error_macros.h"
+
 #include <os/log.h>
 
+#include <cstdint>
 #include <functional>
+#include <type_traits>
 
 /// Godot limits the number of dynamic buffers to 8.
 ///

--- a/drivers/png/png_driver_common.cpp
+++ b/drivers/png/png_driver_common.cpp
@@ -30,7 +30,9 @@
 
 #include "png_driver_common.h"
 
+#ifdef TOOLS_ENABLED
 #include "core/config/engine.h"
+#endif
 
 #include <png.h>
 

--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -71,7 +71,7 @@ Error JoypadSDL::initialize() {
 		String mapping_string = DefaultControllerMappings::mappings[i++];
 		CharString data = mapping_string.utf8();
 		SDL_IOStream *rw = SDL_IOFromMem((void *)data.ptr(), data.size());
-		SDL_AddGamepadMappingsFromIO(rw, 1);
+		SDL_AddGamepadMappingsFromIO(rw, true);
 	}
 
 	// Make sure that we handle already connected joypads when the driver is initialized.

--- a/drivers/unix/net_socket_unix.cpp
+++ b/drivers/unix/net_socket_unix.cpp
@@ -189,7 +189,7 @@ bool NetSocketUnix::_can_use_ip(const IPAddress &p_ip, const bool p_for_bind) co
 
 bool NetSocketUnix::_can_use_path(const CharString &p_path) const {
 	// Path must not exceed maximum path length for Unix domain socket
-	return !p_path.is_empty() && (size_t)p_path.length() < sizeof(((sockaddr_un *)0)->sun_path);
+	return !p_path.is_empty() && (size_t)p_path.length() < sizeof(((sockaddr_un *)nullptr)->sun_path);
 }
 
 _FORCE_INLINE_ Error NetSocketUnix::_change_multicast_group(IPAddress p_ip, String p_if_name, bool p_add) {

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -46,7 +46,7 @@ typedef void *gd_iconv_t;
 typedef gd_iconv_t (*PIConvOpen)(const char *, const char *);
 typedef size_t (*PIConv)(gd_iconv_t, char **, size_t *, char **, size_t *);
 typedef int (*PIConvClose)(gd_iconv_t);
-typedef const char *(*PIConvLocaleCharset)(void);
+typedef const char *(*PIConvLocaleCharset)();
 #endif
 
 class OS_Unix : public OS {

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -38,13 +38,11 @@
 
 #include "thirdparty/misc/smolv.h"
 
-#if defined(ANDROID_ENABLED)
+#if defined(SWAPPY_FRAME_PACING_ENABLED)
 #include "platform/android/java_godot_wrapper.h"
 #include "platform/android/os_android.h"
 #include "platform/android/thread_jandroid.h"
-#endif
 
-#if defined(SWAPPY_FRAME_PACING_ENABLED)
 #include "thirdparty/swappy-frame-pacing/swappyVk.h"
 #endif
 
@@ -4178,7 +4176,7 @@ RDD::ShaderID RenderingDeviceDriverVulkan::shader_create_from_container(const Re
 	Vector<uint8_t> decompressed_code;
 	VkShaderModule vk_module;
 	PackedByteArray decoded_spirv;
-	const bool use_respv = RESPV_ENABLED && !shader_container_format.get_debug_info_enabled();
+	const bool use_respv = (RESPV_ENABLED == 1) && !shader_container_format.get_debug_info_enabled();
 	const bool store_respv = use_respv && !shader_refl.specialization_constants.is_empty();
 	const int64_t stage_count = shader_refl.stages_vector.size();
 	shader_info.vk_stages_create_info.reserve(stage_count);
@@ -4228,7 +4226,7 @@ RDD::ShaderID RenderingDeviceDriverVulkan::shader_create_from_container(const Re
 		shader_info.original_stage_size.push_back(decoded_spirv.size());
 
 		if (use_respv) {
-			const bool inline_data = store_respv || !RESPV_ONLY_INLINE_SHADERS_WITH_SPEC_CONSTANTS;
+			const bool inline_data = store_respv || (RESPV_ONLY_INLINE_SHADERS_WITH_SPEC_CONSTANTS == 0);
 			respv::Shader respv_shader(decoded_spirv.ptr(), decoded_spirv.size(), inline_data);
 			if (respv_shader.empty()) {
 #if RESPV_VERBOSE

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -97,7 +97,7 @@ void AudioDriverXAudio2::thread_func(void *p_udata) {
 			ad->stop_counting_ticks();
 			ad->unlock();
 
-			for (unsigned int i = 0; i < ad->buffer_size * ad->channels; i++) {
+			for (int i = 0; i < ad->buffer_size * ad->channels; i++) {
 				ad->samples_out[ad->current_buffer][i] = ad->samples_in[i] >> 16;
 			}
 
@@ -174,7 +174,7 @@ void AudioDriverXAudio2::finish() {
 
 AudioDriverXAudio2::AudioDriverXAudio2() {
 	for (int i = 0; i < AUDIO_BUFFERS; i++) {
-		xaudio_buffer[i] = { 0 };
-		samples_out[i] = 0;
+		xaudio_buffer[i] = {};
+		samples_out[i] = nullptr;
 	}
 }

--- a/drivers/xaudio2/audio_driver_xaudio2.h
+++ b/drivers/xaudio2/audio_driver_xaudio2.h
@@ -35,7 +35,6 @@
 #include "core/templates/safe_refcount.h"
 #include "servers/audio/audio_server.h"
 
-#include <mmsystem.h>
 #include <windows.h>
 #include <wrl/client.h>
 #include <xaudio2.h>
@@ -47,8 +46,14 @@ class AudioDriverXAudio2 : public AudioDriver {
 
 	struct XAudio2DriverVoiceCallback : public IXAudio2VoiceCallback {
 		HANDLE buffer_end_event;
+
 		XAudio2DriverVoiceCallback() :
 				buffer_end_event(CreateEvent(nullptr, FALSE, FALSE, nullptr)) {}
+
+		virtual ~XAudio2DriverVoiceCallback() {
+			CloseHandle(buffer_end_event);
+		}
+
 		void STDMETHODCALLTYPE OnBufferEnd(void *pBufferContext) {
 			SetEvent(buffer_end_event);
 		}
@@ -80,7 +85,7 @@ class AudioDriverXAudio2 : public AudioDriver {
 	SafeFlag exit_thread;
 	bool pcm_open = false;
 
-	WAVEFORMATEX wave_format = { 0 };
+	WAVEFORMATEX wave_format = {};
 	Microsoft::WRL::ComPtr<IXAudio2> xaudio;
 	int current_buffer = 0;
 	IXAudio2MasteringVoice *mastering_voice = nullptr;

--- a/editor/animation/animation_tree_editor_plugin.cpp
+++ b/editor/animation/animation_tree_editor_plugin.cpp
@@ -38,7 +38,6 @@
 #include "core/string/string_buffer.h"
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_node.h"
-#include "editor/editor_string_names.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/themes/editor_scale.h"

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -41,7 +41,6 @@
 #include "editor/docks/inspector_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
-#include "editor/file_system/editor_paths.h"
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"

--- a/modules/camera/camera_android.cpp
+++ b/modules/camera/camera_android.cpp
@@ -89,8 +89,7 @@ String GetFormatName(const int32_t &format) {
 // CameraFeedAndroid - Subclass for our camera feed on Android
 
 CameraFeedAndroid::CameraFeedAndroid(ACameraManager *manager, ACameraMetadata *metadata, const char *id,
-		CameraFeed::FeedPosition position, int32_t orientation) :
-		CameraFeed() {
+		CameraFeed::FeedPosition position, int32_t orientation) {
 	this->manager = manager;
 	this->metadata = metadata;
 	this->orientation = orientation;

--- a/modules/jpg/image_loader_libjpeg_turbo.cpp
+++ b/modules/jpg/image_loader_libjpeg_turbo.cpp
@@ -34,7 +34,7 @@
 
 Error jpeg_turbo_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p_buffer_len) {
 	tjhandle tj_instance = tj3Init(TJINIT_DECOMPRESS);
-	if (tj_instance == NULL) {
+	if (tj_instance == nullptr) {
 		return FAILED;
 	}
 
@@ -128,7 +128,7 @@ static Vector<uint8_t> _jpeg_turbo_buffer_save_func(const Ref<Image> &p_img, flo
 	}
 
 	tjhandle tj_instance = tj3Init(TJINIT_COMPRESS);
-	ERR_FAIL_COND_V_MSG(tj_instance == NULL, output, "Couldn't create tjhandle");
+	ERR_FAIL_COND_V_MSG(tj_instance == nullptr, output, "Couldn't create tjhandle");
 
 	if (tj3Set(tj_instance, TJPARAM_QUALITY, (int)(p_quality * 100)) < 0) {
 		tj3Destroy(tj_instance);
@@ -148,7 +148,7 @@ static Vector<uint8_t> _jpeg_turbo_buffer_save_func(const Ref<Image> &p_img, flo
 	// If the godot image format is `Image::FORMAT_L8` we could set the appropriate
 	// color space here rather than defaulting to RGB.
 
-	unsigned char *jpeg_buff = NULL;
+	unsigned char *jpeg_buff = nullptr;
 	size_t jpeg_size = 0;
 	int code = tj3Compress8(
 			tj_instance,

--- a/modules/openxr/extensions/platform/openxr_android_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_android_extension.cpp
@@ -30,7 +30,7 @@
 
 #include "openxr_android_extension.h"
 
-#include "../../openxr_api.h"
+#include "../../openxr_api.h" // IWYU pragma: keep. `XR_FAILED` macro.
 #include "java_godot_wrapper.h"
 #include "os_android.h"
 #include "thread_jandroid.h"

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -42,25 +42,25 @@ private:
 	jobject godot_io_instance;
 	jclass cls;
 
-	jmethodID _open_URI = 0;
-	jmethodID _get_cache_dir = 0;
-	jmethodID _get_data_dir = 0;
-	jmethodID _get_temp_dir = 0;
-	jmethodID _get_display_cutouts = 0;
-	jmethodID _get_display_rotation = 0;
-	jmethodID _get_display_safe_area = 0;
-	jmethodID _get_locale = 0;
-	jmethodID _get_model = 0;
-	jmethodID _get_screen_DPI = 0;
-	jmethodID _get_scaled_density = 0;
-	jmethodID _get_screen_refresh_rate = 0;
-	jmethodID _get_unique_id = 0;
-	jmethodID _show_keyboard = 0;
-	jmethodID _hide_keyboard = 0;
-	jmethodID _has_hardware_keyboard = 0;
-	jmethodID _set_screen_orientation = 0;
-	jmethodID _get_screen_orientation = 0;
-	jmethodID _get_system_dir = 0;
+	jmethodID _open_URI = nullptr;
+	jmethodID _get_cache_dir = nullptr;
+	jmethodID _get_data_dir = nullptr;
+	jmethodID _get_temp_dir = nullptr;
+	jmethodID _get_display_cutouts = nullptr;
+	jmethodID _get_display_rotation = nullptr;
+	jmethodID _get_display_safe_area = nullptr;
+	jmethodID _get_locale = nullptr;
+	jmethodID _get_model = nullptr;
+	jmethodID _get_screen_DPI = nullptr;
+	jmethodID _get_scaled_density = nullptr;
+	jmethodID _get_screen_refresh_rate = nullptr;
+	jmethodID _get_unique_id = nullptr;
+	jmethodID _show_keyboard = nullptr;
+	jmethodID _hide_keyboard = nullptr;
+	jmethodID _has_hardware_keyboard = nullptr;
+	jmethodID _set_screen_orientation = nullptr;
+	jmethodID _get_screen_orientation = nullptr;
+	jmethodID _get_system_dir = nullptr;
 
 public:
 	GodotIOJavaWrapper(JNIEnv *p_env, jobject p_godot_io_instance);

--- a/platform/android/java_godot_view_wrapper.h
+++ b/platform/android/java_godot_view_wrapper.h
@@ -42,12 +42,12 @@ private:
 
 	jobject _godot_view;
 
-	jmethodID _can_capture_pointer = 0;
-	jmethodID _request_pointer_capture = 0;
-	jmethodID _release_pointer_capture = 0;
+	jmethodID _can_capture_pointer = nullptr;
+	jmethodID _request_pointer_capture = nullptr;
+	jmethodID _release_pointer_capture = nullptr;
 
-	jmethodID _configure_pointer_icon = 0;
-	jmethodID _set_pointer_icon = 0;
+	jmethodID _configure_pointer_icon = nullptr;
+	jmethodID _set_pointer_icon = nullptr;
 
 public:
 	GodotJavaViewWrapper(jobject godot_view);

--- a/platform/macos/embedded_gl_manager.h
+++ b/platform/macos/embedded_gl_manager.h
@@ -43,7 +43,7 @@
 
 GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations") // OpenGL is deprecated in macOS 10.14.
 
-typedef CGLContextObj (*CGLGetCurrentContextPtr)(void);
+typedef CGLContextObj (*CGLGetCurrentContextPtr)();
 typedef CGLError (*CGLTexImageIOSurface2DPtr)(CGLContextObj ctx, GLenum target, GLenum internal_format,
 		GLsizei width, GLsizei height, GLenum format, GLenum type, IOSurfaceRef ioSurface, GLuint plane);
 typedef const char *(*CGLErrorStringPtr)(CGLError);

--- a/platform/macos/gl_manager_macos_legacy.h
+++ b/platform/macos/gl_manager_macos_legacy.h
@@ -44,7 +44,7 @@ GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations") // OpenGL is de
 
 typedef CGLError (*CGLEnablePtr)(CGLContextObj ctx, CGLContextEnable pname);
 typedef CGLError (*CGLSetParameterPtr)(CGLContextObj ctx, CGLContextParameter pname, const GLint *params);
-typedef CGLContextObj (*CGLGetCurrentContextPtr)(void);
+typedef CGLContextObj (*CGLGetCurrentContextPtr)();
 
 class GLManagerLegacy_MacOS {
 	struct GLWindow {

--- a/platform/macos/macos_quartz_core_spi.h
+++ b/platform/macos/macos_quartz_core_spi.h
@@ -57,7 +57,7 @@
 #import <Foundation/Foundation.h>
 #import <Quartz/Quartz.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 // https://chromium.googlesource.com/chromium/src/+/refs/heads/main/ui/base/cocoa/remote_layer_api.h
 

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -67,7 +67,7 @@ private:
 	HashMap<int64_t, CharString> utterance_ids;
 
 	DisplayServerEnums::WindowMode window_mode = DisplayServerEnums::WINDOW_MODE_WINDOWED;
-	ObjectID window_attached_instance_id = {};
+	ObjectID window_attached_instance_id;
 
 	Callable rect_changed_callback;
 	Callable window_event_callback;

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -45,7 +45,7 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/resources/image_texture.h"
 
-#include "modules/modules_enabled.gen.h" // For mono.
+#include "modules/modules_enabled.gen.h" // IWYU pragma: keep. For mono.
 #include "modules/svg/image_loader_svg.h"
 
 Error EditorExportPlatformWeb::_extract_template(const String &p_template, const String &p_dir, const String &p_name, bool pwa) {

--- a/platform/web/http_client_web.cpp
+++ b/platform/web/http_client_web.cpp
@@ -30,8 +30,11 @@
 
 #include "http_client_web.h"
 
-#include "core/config/engine.h"
 #include "core/object/class_db.h"
+
+#ifdef DEBUG_ENABLED
+#include "core/config/engine.h"
+#endif
 
 void HTTPClientWeb::_parse_headers(int p_len, const char **p_headers, void *p_ref) {
 	HTTPClientWeb *client = static_cast<HTTPClientWeb *>(p_ref);

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1543,11 +1543,11 @@ Ref<Image> DisplayServerWindows::screen_get_image_rect(const Rect2i &p_rect) con
 	POINT p2;
 	p2.x = pos.x + size.x;
 	p2.y = pos.y + size.y;
-	LogicalToPhysicalPointForPerMonitorDPI(0, &p1);
-	LogicalToPhysicalPointForPerMonitorDPI(0, &p2);
+	LogicalToPhysicalPointForPerMonitorDPI(nullptr, &p1);
+	LogicalToPhysicalPointForPerMonitorDPI(nullptr, &p2);
 
 	Ref<Image> img;
-	HDC dc = GetDC(0);
+	HDC dc = GetDC(nullptr);
 	if (dc) {
 		HDC hdc = CreateCompatibleDC(dc);
 		int width = p2.x - p1.x;
@@ -1580,7 +1580,7 @@ Ref<Image> DisplayServerWindows::screen_get_image_rect(const Rect2i &p_rect) con
 			}
 			DeleteDC(hdc);
 		}
-		ReleaseDC(NULL, dc);
+		ReleaseDC(nullptr, dc);
 	}
 
 	return img;
@@ -1778,7 +1778,7 @@ DisplayServerEnums::WindowID DisplayServerWindows::create_sub_window(DisplayServ
 #endif
 
 	DisplayServerEnums::WindowID window_id = window_id_counter;
-	Error err = _create_window(window_id, p_mode, p_flags, p_rect, p_exclusive, p_transient_parent, NULL, no_redirection_bitmap);
+	Error err = _create_window(window_id, p_mode, p_flags, p_rect, p_exclusive, p_transient_parent, nullptr, no_redirection_bitmap);
 	ERR_FAIL_COND_V_MSG(err != OK, DisplayServerEnums::INVALID_WINDOW_ID, "Failed to create sub window.");
 	++window_id_counter;
 
@@ -2946,7 +2946,7 @@ void DisplayServerWindows::window_set_taskbar_progress_value(float p_value, Disp
 		return;
 	}
 	if (taskbar == nullptr) {
-		if (CoCreateInstance(CLSID_TaskbarList, 0, CLSCTX_INPROC_SERVER, IID_ITaskbarList, (void **)&taskbar) != S_OK) {
+		if (CoCreateInstance(CLSID_TaskbarList, nullptr, CLSCTX_INPROC_SERVER, IID_ITaskbarList, (void **)&taskbar) != S_OK) {
 			taskbar = nullptr;
 			return;
 		} else {
@@ -2964,7 +2964,7 @@ void DisplayServerWindows::window_set_taskbar_progress_state(DisplayServerEnums:
 	WindowData &wd = windows[p_window];
 	wd.progress_state = p_state;
 	if (taskbar == nullptr) {
-		if (CoCreateInstance(CLSID_TaskbarList, 0, CLSCTX_INPROC_SERVER, IID_ITaskbarList, (void **)&taskbar) != S_OK) {
+		if (CoCreateInstance(CLSID_TaskbarList, nullptr, CLSCTX_INPROC_SERVER, IID_ITaskbarList, (void **)&taskbar) != S_OK) {
 			taskbar = nullptr;
 			return;
 		} else {
@@ -3358,7 +3358,7 @@ static BOOL CALLBACK _enum_proc_find_window_from_process_id_callback(HWND hWnd, 
 
 HWND DisplayServerWindows::_find_window_from_process_id(ProcessID p_pid, HWND p_current_hwnd) {
 	DWORD pid = p_pid;
-	WindowEnumData ed = { pid, p_current_hwnd, NULL };
+	WindowEnumData ed = { pid, p_current_hwnd, nullptr };
 
 	// First, check our own child, maybe it's already embedded.
 	if (!EnumChildWindows(p_current_hwnd, _enum_proc_find_window_from_process_id_callback, (LPARAM)&ed) && (GetLastError() == ERROR_SUCCESS)) {
@@ -3372,7 +3372,7 @@ HWND DisplayServerWindows::_find_window_from_process_id(ProcessID p_pid, HWND p_
 		return ed.hWnd;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 // Get screen HDR capabilities for internal use only.
@@ -7629,7 +7629,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Dis
 		window_position = scr_rect.position + (scr_rect.size - p_resolution) / 2;
 	}
 
-	HWND parent_hwnd = NULL;
+	HWND parent_hwnd = nullptr;
 	if (p_parent_window) {
 		// Parented window.
 		parent_hwnd = (HWND)p_parent_window;

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -150,7 +150,7 @@ enum PreferredAppMode {
 	APPMODE_MAX = 4
 };
 
-typedef const char *(CDECL *WineGetVersionPtr)(void);
+typedef const char *(CDECL *WineGetVersionPtr)();
 typedef bool(WINAPI *ShouldAppsUseDarkModePtr)();
 typedef DWORD(WINAPI *GetImmersiveColorFromColorSetExPtr)(UINT dwImmersiveColorSet, UINT dwImmersiveColorType, bool bIgnoreHighContrast, UINT dwHighContrastCacheMode);
 typedef int(WINAPI *GetImmersiveColorTypeFromNamePtr)(const WCHAR *name);
@@ -381,7 +381,7 @@ class DisplayServerWindows : public DisplayServer {
 
 		bool initialized = false;
 
-		HWND parent_hwnd = 0;
+		HWND parent_hwnd = nullptr;
 
 		bool no_redirection_bitmap = false;
 	};
@@ -425,7 +425,7 @@ class DisplayServerWindows : public DisplayServer {
 	HashMap<DisplayServerEnums::IndicatorID, IndicatorData> indicators;
 
 	struct FileDialogData {
-		HWND hwnd_owner = 0;
+		HWND hwnd_owner = nullptr;
 		Rect2i wrect;
 		String appid;
 		String title;
@@ -529,8 +529,8 @@ class DisplayServerWindows : public DisplayServer {
 	String _get_klid(HKL p_hkl) const;
 
 	struct EmbeddedProcessData {
-		HWND window_handle = 0;
-		HWND parent_window_handle = 0;
+		HWND window_handle = nullptr;
+		HWND parent_window_handle = nullptr;
 		bool is_visible = false;
 	};
 	HashMap<ProcessID, EmbeddedProcessData *> embedded_processes;

--- a/platform/windows/lang_table.h
+++ b/platform/windows/lang_table.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include <winnt.h>
+#include <windef.h>
 
 struct _WinLocale {
 	const char *locale;
@@ -186,5 +186,5 @@ static const _WinLocale _win_locales[] = {
 	{ "zh_HK", LANG_CHINESE, SUBLANG_CHINESE_HONGKONG },
 	{ "zh_SG", LANG_CHINESE, SUBLANG_CHINESE_SINGAPORE },
 	{ "zh_TW", LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL },
-	{ 0, 0, 0 },
+	{ nullptr, 0, 0 },
 };

--- a/platform/windows/native_menu_windows.h
+++ b/platform/windows/native_menu_windows.h
@@ -54,11 +54,11 @@ class NativeMenuWindows : public NativeMenu {
 		int max_states = 0;
 		int state = 0;
 		Ref<Image> img;
-		HBITMAP bmp = 0;
+		HBITMAP bmp = nullptr;
 	};
 
 	struct MenuData {
-		HMENU menu = 0;
+		HMENU menu = nullptr;
 
 		Callable close_cb;
 		bool is_rtl = false;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -202,7 +202,7 @@ bool OS_Windows::is_using_con_wrapper() const {
 	DWORD count = GetConsoleProcessList(&pids[0], 256);
 	for (DWORD i = 0; i < count; i++) {
 		HANDLE process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pids[i]);
-		if (process != NULL) {
+		if (process != nullptr) {
 			WCHAR proc_name[MAX_PATH];
 			DWORD len = MAX_PATH;
 			if (QueryFullProcessImageNameW(process, 0, &proc_name[0], &len)) {
@@ -2120,7 +2120,7 @@ PackedByteArray OS_Windows::get_stdin_buffer(int64_t p_buffer_size) {
 
 OS_Windows::StdHandleType OS_Windows::get_stdin_type() const {
 	HANDLE h = GetStdHandle(STD_INPUT_HANDLE);
-	if (h == 0 || h == INVALID_HANDLE_VALUE) {
+	if (h == nullptr || h == INVALID_HANDLE_VALUE) {
 		return STD_HANDLE_INVALID;
 	}
 	DWORD ftype = GetFileType(h);
@@ -2151,7 +2151,7 @@ OS_Windows::StdHandleType OS_Windows::get_stdin_type() const {
 
 OS_Windows::StdHandleType OS_Windows::get_stdout_type() const {
 	HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
-	if (h == 0 || h == INVALID_HANDLE_VALUE) {
+	if (h == nullptr || h == INVALID_HANDLE_VALUE) {
 		return STD_HANDLE_INVALID;
 	}
 	DWORD ftype = GetFileType(h);
@@ -2177,7 +2177,7 @@ OS_Windows::StdHandleType OS_Windows::get_stdout_type() const {
 
 OS_Windows::StdHandleType OS_Windows::get_stderr_type() const {
 	HANDLE h = GetStdHandle(STD_ERROR_HANDLE);
-	if (h == 0 || h == INVALID_HANDLE_VALUE) {
+	if (h == nullptr || h == INVALID_HANDLE_VALUE) {
 		return STD_HANDLE_INVALID;
 	}
 	DWORD ftype = GetFileType(h);

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -30,10 +30,10 @@
 
 #include "windows_terminal_logger.h"
 
+#ifdef WINDOWS_ENABLED
+
 #include "core/object/script_backtrace.h"
 #include "core/os/os.h"
-
-#ifdef WINDOWS_ENABLED
 
 #include <cstdio>
 

--- a/scene/3d/aim_modifier_3d.cpp
+++ b/scene/3d/aim_modifier_3d.cpp
@@ -172,7 +172,7 @@ void AimModifier3D::set_relative(int p_index, bool p_enabled) {
 }
 
 bool AimModifier3D::is_relative(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), false);
 	AimModifier3DSetting *setting = static_cast<AimModifier3DSetting *>(settings[p_index]);
 	return setting->relative;
 }

--- a/scene/3d/convert_transform_modifier_3d.cpp
+++ b/scene/3d/convert_transform_modifier_3d.cpp
@@ -287,7 +287,7 @@ void ConvertTransformModifier3D::set_relative(int p_index, bool p_enabled) {
 }
 
 bool ConvertTransformModifier3D::is_relative(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), false);
 	ConvertTransform3DSetting *setting = static_cast<ConvertTransform3DSetting *>(settings[p_index]);
 	return setting->is_relative();
 }
@@ -299,7 +299,7 @@ void ConvertTransformModifier3D::set_additive(int p_index, bool p_enabled) {
 }
 
 bool ConvertTransformModifier3D::is_additive(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), false);
 	ConvertTransform3DSetting *setting = static_cast<ConvertTransform3DSetting *>(settings[p_index]);
 	return setting->additive;
 }

--- a/scene/3d/copy_transform_modifier_3d.cpp
+++ b/scene/3d/copy_transform_modifier_3d.cpp
@@ -306,7 +306,7 @@ void CopyTransformModifier3D::set_relative(int p_index, bool p_enabled) {
 }
 
 bool CopyTransformModifier3D::is_relative(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), false);
 	CopyTransform3DSetting *setting = static_cast<CopyTransform3DSetting *>(settings[p_index]);
 	return setting->is_relative();
 }
@@ -318,7 +318,7 @@ void CopyTransformModifier3D::set_additive(int p_index, bool p_enabled) {
 }
 
 bool CopyTransformModifier3D::is_additive(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0);
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), false);
 	CopyTransform3DSetting *setting = static_cast<CopyTransform3DSetting *>(settings[p_index]);
 	return setting->additive;
 }

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -33,7 +33,6 @@
 
 #include "animation_blend_tree.h"
 
-#include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 
 void AnimationNodeBlendSpace1D::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6655,7 +6655,7 @@ int TextEdit::get_total_visible_line_count() const {
 
 // Auto adjust.
 bool TextEdit::is_line_in_viewport(int p_line) const {
-	ERR_FAIL_INDEX_V(p_line, text.size(), 0);
+	ERR_FAIL_INDEX_V(p_line, text.size(), false);
 
 	int line_wrap = get_line_wrap_index_at_column(p_line, 0);
 

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -7394,7 +7394,7 @@ void RenderingDevice::_end_frame() {
 	_submit_transfer_barriers(command_buffer);
 
 	GodotProfileZoneGrouped(_profile_zone, "draw_graph.end");
-	draw_graph.end(RENDER_GRAPH_REORDER, RENDER_GRAPH_FULL_BARRIERS, command_buffer, frames[frame].command_buffer_pool);
+	draw_graph.end(RENDER_GRAPH_REORDER == 1, RENDER_GRAPH_FULL_BARRIERS == 1, command_buffer, frames[frame].command_buffer_pool);
 	GodotProfileZoneGrouped(_profile_zone, "driver->command_buffer_end");
 	driver->command_buffer_end(command_buffer);
 	GodotProfileZoneGrouped(_profile_zone, "driver->end_segment");

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -146,7 +146,7 @@ extern HashMap<String, TestFunc> *test_commands;
 int register_test_command(String p_command, TestFunc p_function);
 
 #define REGISTER_TEST_COMMAND(m_command, m_function) \
-	DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), \
+	DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(GODOT_DOCTEST_ANON_VAR_), \
 			register_test_command(m_command, m_function))
 
 #define MULTICHECK_STRING_EQ(m_obj, m_func, m_param1, m_eq) \


### PR DESCRIPTION
- Helps address https://github.com/godotengine/godot/issues/111218.
- Follow-up to #117286.
- Follow-up to #117295.
- Follow-up to #117301.
- Follow-up to #117328.
- Follow-up to #117366.
- Follow-up to #117402.

After the series of PRs dealing with each section of the engine (minus some Apple platform code I can't analyze from Linux), I did another pass to see if there were any stragglers I missed or omitted from previous PRs.

This PR handles not only `unused-includes` but also a few `modernize-*` checks that we have configured in `.clang-tidy`, which `clangd-tidy` (note the `d`) also reads.

I ran most checks for the Linux platform with Clang 21 on Fedora 43, but I also checked Android, Windows, and Web specific files with a `compile_commands.json` for these platforms.

See [this thread](https://chat.godotengine.org/channel/yQRJDrPTpn5ijkZFt?msg=32QpvZddMQkEG6gMn) for tips on configuring for Emscripten, and [this thread](https://chat.godotengine.org/channel/yQRJDrPTpn5ijkZFt?msg=fCEbCy9xRuDDoyBNe) for my failed attempt at using clangd with osxcross for macOS.

These changes should pave the way to integrating `clangd-tidy` on CI, at least on a subset of the codebase initially. On my system, the non platform-specific files are now diagnostic free for our current config.

Quick notes on which paths require specific handling as they're platform-specific:
```
drivers/{alsa,alsamidi,apple*,core*,d3d12,metal,pulseaudio,wasapi,windows,winmidi,xaudio2}/
editor/shaders/shader_baker/shader_baker_export_plugin_platform_{d3d12,metal}.*
modules/camera/camera_{android,feed_linux,linux,macos,win}.*
modules/openxr/extensions/platform/openxr_{android,metal}_extension.*
platform/{name}/* minus platform/{name}/{api,export}/*
```