### PR TITLE
Add early return in set_antialiased method

### DIFF
--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -265,6 +265,7 @@ int Line2D::get_round_precision() const {
 }
 
 void Line2D::set_antialiased(bool p_antialiased) {
+	if(1<=_points.size()) return;
 	_antialiased = p_antialiased;
 	queue_redraw();
 }


### PR DESCRIPTION
It theoretically solves the weird line under 1 length problem.  May be buggy.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
