### PR TITLE
Fix trails not updating for mesh property changes

### DIFF
--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -284,14 +284,20 @@ int GPUParticles3D::get_draw_passes() const {
 void GPUParticles3D::set_draw_pass_mesh(int p_pass, const Ref<Mesh> &p_mesh) {
 	ERR_FAIL_INDEX(p_pass, draw_passes.size());
 
-	if (Engine::get_singleton()->is_editor_hint() && draw_passes.write[p_pass].is_valid()) {
-		draw_passes.write[p_pass]->disconnect_changed(callable_mp((Node *)this, &Node::update_configuration_warnings));
+	if (draw_passes.write[p_pass].is_valid()) {
+		if (Engine::get_singleton()->is_editor_hint()) {
+			draw_passes.write[p_pass]->disconnect_changed(callable_mp((Node *)this, &Node::update_configuration_warnings));
+		}
+		draw_passes.write[p_pass]->disconnect_changed(callable_mp(this, &GPUParticles3D::_skinning_changed));
 	}
 
 	draw_passes.write[p_pass] = p_mesh;
 
-	if (Engine::get_singleton()->is_editor_hint() && draw_passes.write[p_pass].is_valid()) {
-		draw_passes.write[p_pass]->connect_changed(callable_mp((Node *)this, &Node::update_configuration_warnings), CONNECT_DEFERRED);
+	if (draw_passes.write[p_pass].is_valid()) {
+		if (Engine::get_singleton()->is_editor_hint()) {
+			draw_passes.write[p_pass]->connect_changed(callable_mp((Node *)this, &Node::update_configuration_warnings), CONNECT_DEFERRED);
+		}
+		draw_passes.write[p_pass]->connect_changed(callable_mp(this, &GPUParticles3D::_skinning_changed));
 	}
 
 	RID mesh_rid;


### PR DESCRIPTION
Fixes #81109
Fixes #121306

Was just missing an update to the trail bind poses when mesh properties change, so after an increase in section count, the `RenderingServer` wasn't aware of the new sections.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
