### PR TITLE
Clarify that `maximize_disabled` and `minimize_disabled` are supported on Linux X11

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -701,7 +701,7 @@
 		<member name="maximize_disabled" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the [Window]'s maximize button is disabled.
 			[b]Note:[/b] If both minimize and maximize buttons are disabled, buttons are fully hidden, and only close button is visible.
-			[b]Note:[/b] This property is implemented only on macOS and Windows.
+			[b]Note:[/b] This property is implemented on Linux (X11), macOS, and Windows.
 		</member>
 		<member name="min_size" type="Vector2i" setter="set_min_size" getter="get_min_size" default="Vector2i(0, 0)">
 			If non-zero, the [Window] can't be resized to be smaller than this size.
@@ -710,7 +710,7 @@
 		<member name="minimize_disabled" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the [Window]'s minimize button is disabled.
 			[b]Note:[/b] If both minimize and maximize buttons are disabled, buttons are fully hidden, and only close button is visible.
-			[b]Note:[/b] This property is implemented only on macOS and Windows.
+			[b]Note:[/b] This property is implemented on Linux (X11), macOS, and Windows.
 		</member>
 		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="Window.Mode" default="0">
 			Set's the window's current mode.


### PR DESCRIPTION
Since version 4.6, Godot already supports maximize_disabled and minimize_disabled on Linux X11.
see https://github.com/godotengine/godot/pull/112142