### PR TITLE
Fix "Custom" anchor preset being ignored if the parent isn't a `Control`

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1001,17 +1001,17 @@ Control::LayoutMode Control::_get_default_layout_mode() const {
 }
 
 void Control::_set_anchors_layout_preset(int p_preset) {
-	if (data.stored_layout_mode != LayoutMode::LAYOUT_MODE_UNCONTROLLED && data.stored_layout_mode != LayoutMode::LAYOUT_MODE_ANCHORS) {
-		// In other modes the anchor preset is non-operational and shouldn't be set to anything.
-		return;
-	}
-
 	if (p_preset == -1) {
 		if (!data.stored_use_custom_anchors) {
 			data.stored_use_custom_anchors = true;
 			notify_property_list_changed();
 		}
 		return; // Keep settings as is.
+	}
+
+	if (data.stored_layout_mode != LayoutMode::LAYOUT_MODE_UNCONTROLLED && data.stored_layout_mode != LayoutMode::LAYOUT_MODE_ANCHORS) {
+		// In other modes the anchor preset is non-operational and shouldn't be set to anything.
+		return;
 	}
 
 	bool list_changed = false;


### PR DESCRIPTION
A check was introduced in #70882 to fix `layout_mode` being inconsistently saved in scene files. Down the line, it caused the "Custom" anchor preset to be ignored if the child's parent is not a `Control` too, since `layout_mode` is not saved in those cases.

This PR lowers the check's position to allow the custom mode for anchors to still be set regardless. Hopefully without bring back the original bug.

Should fix #112472.