### PR TITLE
Add warning toasts for improper vertex snap usage

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -50,6 +50,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_spin_slider.h"
+#include "editor/gui/editor_toaster.h"
 #include "editor/plugins/editor_plugin_list.h"
 #include "editor/run/editor_run_bar.h"
 #include "editor/scene/3d/gizmos/audio_listener_3d_gizmo_plugin.h"
@@ -2092,6 +2093,16 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 					if (use_origin_snap || !vertex_snap_has_source) {
 						_vertex_snap_update_source(vb->get_position());
+					}
+
+					if (selection.is_empty()) {
+						EditorToaster::get_singleton()->popup_str(TTR("Select a node to vertex snap."), EditorToaster::SEVERITY_WARNING);
+					} else if (!vertex_snap_has_source) {
+						if (use_origin_snap) {
+							EditorToaster::get_singleton()->popup_str(TTR("No vertex found near cursor."), EditorToaster::SEVERITY_WARNING);
+						} else {
+							EditorToaster::get_singleton()->popup_str(TTR("No vertex found on selected node near cursor."), EditorToaster::SEVERITY_WARNING);
+						}
 					}
 
 					if (vertex_snap_has_source && !selection.is_empty()) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Follow up to:
* https://github.com/godotengine/godot/pull/117235
* https://github.com/godotengine/godot/pull/117380

Shows toasts when vertex snap is enabled, left click and:

- No node is selected
- No vertex is selected w/ message depending on snap base. 

These toast notifications should not show up under normal usage, so they should generally not be too intrusive, and should help users find out what to do. 

https://github.com/user-attachments/assets/33a58b79-a6b1-45ac-9499-00490b013745

