### PR TITLE
Select first section matching filter in settings

### DIFF
--- a/editor/inspector/editor_sectioned_inspector.cpp
+++ b/editor/inspector/editor_sectioned_inspector.cpp
@@ -244,7 +244,7 @@ void SectionedInspector::update_category_list() {
 
 	const EditorPropertyNameProcessor::Style name_style = EditorPropertyNameProcessor::get_settings_style();
 	const EditorPropertyNameProcessor::Style tooltip_style = EditorPropertyNameProcessor::get_tooltip_style(name_style);
-
+	String first_element = "";
 	for (PropertyInfo &pi : pinfo) {
 		if (pi.usage & PROPERTY_USAGE_CATEGORY) {
 			continue;
@@ -298,8 +298,15 @@ void SectionedInspector::update_category_list() {
 			if (i == sc - 1) {
 				//if it has children, make selectable
 				section_map[metasection]->set_selectable(0, true);
+				if (first_element.is_empty()) {
+					first_element = metasection;
+				}
 			}
 		}
+	}
+
+	if (!section_map.has(selected_category)) {
+		selected_category = first_element;
 	}
 
 	if (section_map.has(selected_category)) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/14476

If typing a filter causes none of the vertical "tabs" along the left to be selected, the first one is selected.

Fixed version: 

https://github.com/user-attachments/assets/4c895b7a-1a4e-4c2e-a64b-d62e3c338512

