### PR TITLE
Fix `Skeleton3D` editor gizmos when using modifiers

### DIFF
--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -39,7 +39,6 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/inspector/editor_properties.h"
 #include "editor/inspector/editor_properties_vector.h"
-#include "editor/scene/3d/node_3d_editor_gizmos.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"

--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -39,6 +39,7 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/inspector/editor_properties.h"
 #include "editor/inspector/editor_properties_vector.h"
+#include "editor/scene/3d/node_3d_editor_gizmos.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
@@ -1223,6 +1224,7 @@ void Skeleton3DEditor::_notification(int p_what) {
 			joint_tree->connect("button_clicked", callable_mp(this, &Skeleton3DEditor::_joint_tree_button_clicked));
 
 			skeleton->connect(SceneStringName(pose_updated), callable_mp(this, &Skeleton3DEditor::_draw_gizmo));
+			skeleton->connect(SceneStringName(skeleton_updated), callable_mp(this, &Skeleton3DEditor::_draw_gizmo));
 			skeleton->connect(SceneStringName(pose_updated), callable_mp(this, &Skeleton3DEditor::_update_properties));
 			skeleton->connect(SceneStringName(bone_enabled_changed), callable_mp(this, &Skeleton3DEditor::_bone_enabled_changed));
 			skeleton->connect(SceneStringName(show_rest_only_changed), callable_mp(this, &Skeleton3DEditor::_update_gizmo_visible));
@@ -1406,7 +1408,7 @@ void Skeleton3DEditor::_draw_handles() {
 			} else {
 				c = Color(0.1, 0.25, 0.8);
 			}
-			Vector3 point = skeleton->get_bone_global_pose(i).origin;
+			Vector3 point = skeleton->get_bone_global_pose_final(i).origin;
 			handles_mesh->surface_set_color(c);
 			handles_mesh->surface_add_vertex(point);
 		}
@@ -1467,7 +1469,7 @@ void Skeleton3DEditor::_subgizmo_selection_change() {
 			if (plugin.is_null()) {
 				continue;
 			}
-			skeleton->set_subgizmo_selection(gizmo, selected, skeleton->get_bone_global_pose(selected));
+			skeleton->set_subgizmo_selection(gizmo, selected, skeleton->get_bone_global_pose_final(selected));
 			break;
 		}
 	} else {
@@ -1655,7 +1657,7 @@ int Skeleton3DGizmoPlugin::skeleton_intersect_ray(const Skeleton3D *p_skeleton, 
 	real_t closest_dist = 1e10;
 	const int bone_count = p_skeleton->get_bone_count();
 	for (int i = 0; i < bone_count; i++) {
-		Vector3 joint_pos_3d = gt.xform(p_skeleton->get_bone_global_pose(i).origin);
+		Vector3 joint_pos_3d = gt.xform(p_skeleton->get_bone_global_pose_final(i).origin);
 		Vector2 joint_pos_2d = p_camera->unproject_position(joint_pos_3d);
 		real_t dist_3d = ray_from.distance_to(joint_pos_3d);
 		real_t dist_2d = p_point.distance_to(joint_pos_2d);
@@ -1670,8 +1672,7 @@ int Skeleton3DGizmoPlugin::skeleton_intersect_ray(const Skeleton3D *p_skeleton, 
 Transform3D Skeleton3DGizmoPlugin::get_subgizmo_transform(const EditorNode3DGizmo *p_gizmo, int p_id) const {
 	Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(p_gizmo->get_node_3d());
 	ERR_FAIL_NULL_V(skeleton, Transform3D());
-
-	return skeleton->get_bone_global_pose(p_id);
+	return skeleton->get_bone_global_pose_final(p_id);
 }
 
 void Skeleton3DGizmoPlugin::set_subgizmo_transform(const EditorNode3DGizmo *p_gizmo, int p_id, Transform3D p_transform) {
@@ -1682,7 +1683,7 @@ void Skeleton3DGizmoPlugin::set_subgizmo_transform(const EditorNode3DGizmo *p_gi
 	Transform3D original_to_local;
 	int parent_idx = skeleton->get_bone_parent(p_id);
 	if (parent_idx >= 0) {
-		original_to_local = skeleton->get_bone_global_pose(parent_idx);
+		original_to_local = skeleton->get_bone_global_pose_final(parent_idx);
 	}
 	Basis to_local = original_to_local.get_basis().inverse();
 
@@ -1693,8 +1694,8 @@ void Skeleton3DGizmoPlugin::set_subgizmo_transform(const EditorNode3DGizmo *p_gi
 	t.basis = to_local * p_transform.get_basis();
 
 	// Origin.
-	Vector3 orig = skeleton->get_bone_pose(p_id).origin;
-	Vector3 sub = p_transform.origin - skeleton->get_bone_global_pose(p_id).origin;
+	Vector3 orig = skeleton->get_bone_pose_final(p_id).origin;
+	Vector3 sub = p_transform.origin - skeleton->get_bone_global_pose_final(p_id).origin;
 	t.origin = orig + to_local.xform(sub);
 
 	// Apply transform.

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -347,6 +347,18 @@ void Skeleton3D::_notification(int p_what) {
 				return;
 			}
 
+			// Copy the final bone transforms
+			global_bone_transforms_final.clear();
+			global_bone_transforms_final.reserve(bones.size());
+			for (uint32_t i = 0; i < bones.size(); i++) {
+				global_bone_transforms_final.push_back(bonesptr[i].global_pose);
+			}
+			bone_transforms_final.clear();
+			bone_transforms_final.reserve(bones.size());
+			for (uint32_t i = 0; i < bones.size(); i++) {
+				bone_transforms_final.push_back(bonesptr[i].pose_cache);
+			}
+
 			emit_signal(SceneStringName(skeleton_updated));
 
 			// Update skins.
@@ -564,6 +576,15 @@ void Skeleton3D::_update_bone_global_pose(int p_bone) const {
 		bone.global_pose = global_pose;
 		bone_global_pose_dirty[bone.nested_set_offset] = false;
 	}
+}
+
+Transform3D Skeleton3D::get_bone_global_pose_final(int p_bone) const {
+	const int bone_size = global_bone_transforms_final.size();
+	if (p_bone > bone_size) {
+		return get_bone_global_pose(p_bone);
+	}
+
+	return global_bone_transforms_final[p_bone];
 }
 
 Transform3D Skeleton3D::get_bone_global_pose(int p_bone) const {
@@ -927,6 +948,14 @@ Transform3D Skeleton3D::get_bone_pose(int p_bone) const {
 	ERR_FAIL_INDEX_V(p_bone, bone_size, Transform3D());
 	bones[p_bone].update_pose_cache();
 	return bones[p_bone].pose_cache;
+}
+
+Transform3D Skeleton3D::get_bone_pose_final(int p_bone) const {
+	const int bone_size = bone_transforms_final.size();
+	if (p_bone > bone_size) {
+		return get_bone_pose(p_bone);
+	}
+	return bone_transforms_final[p_bone];
 }
 
 void Skeleton3D::_make_dirty() {

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -161,6 +161,8 @@ private:
 	void _skin_changed();
 
 	mutable LocalVector<Bone> bones;
+	mutable LocalVector<Transform3D> global_bone_transforms_final;
+	mutable LocalVector<Transform3D> bone_transforms_final;
 	mutable bool process_order_dirty = false;
 
 	mutable Vector<int> parentless_bones;
@@ -263,6 +265,7 @@ public:
 
 	// Posing API
 	Transform3D get_bone_pose(int p_bone) const;
+	Transform3D get_bone_pose_final(int p_bone) const;
 	Vector3 get_bone_pose_position(int p_bone) const;
 	Quaternion get_bone_pose_rotation(int p_bone) const;
 	Vector3 get_bone_pose_scale(int p_bone) const;
@@ -272,6 +275,7 @@ public:
 	void set_bone_pose_scale(int p_bone, const Vector3 &p_scale);
 
 	Transform3D get_bone_global_pose(int p_bone) const;
+	Transform3D get_bone_global_pose_final(int p_bone) const;
 	void set_bone_global_pose(int p_bone, const Transform3D &p_pose);
 
 	void reset_bone_pose(int p_bone);


### PR DESCRIPTION
Fixes #117350

**Summary of changes**
* Keeping track of additional state in Skeleton3D for post-modified bone transforms
* Exposing that state as getter functions `get_bone_global_pose_final()` and `get_bone_pose_final()`
* Updated `skeleton_3d_editor_plugin.cpp` to use new getter functions

**Technical overview**
There is brief window where the post-modified transform are available [here](https://github.com/Y-o-p/godot/blob/e961aadd6b3a135fbbdfc29c61f8440be7d914ae/scene/3d/skeleton_3d.cpp#L362), but then those transforms get reset back to their original pose. That was causing the gizmo to fetch the original pose data. I'm storing the post-modified transforms separately. Another potential fix is to somehow fetch the data from the rendering server?

Before:
<img width="709" height="642" alt="image" src="https://github.com/user-attachments/assets/18b62861-7682-49da-8c0e-85513096cc41" />
After:
<img width="914" height="545" alt="image" src="https://github.com/user-attachments/assets/7fb4e1ee-8f36-4d34-b06d-8166dd0f01ca" />
