### PR TITLE
Improve visual consistency of BlendSpace editors within AnimationTree

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -80,6 +80,11 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 		}
 	}
 
+	const float pm = POINT_MARGIN * EDSCALE;
+
+	const Vector2 margin_ofs(pm, pm); // Offset all drawing into the inner area.
+	const Size2 inner_size = blend_space_draw->get_size() - margin_ofs * 2; // Inner size, for coordinate math.
+
 	Ref<InputEventMouseButton> mb = p_event;
 
 	if (mb.is_valid() && mb->is_pressed() && ((tool_select->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) || (mb->get_button_index() == MouseButton::LEFT && tool_create->is_pressed()))) {
@@ -122,7 +127,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 			menu->reset_size();
 			menu->popup();
 
-			add_point_pos = (mb->get_position() / blend_space_draw->get_size()).x;
+			add_point_pos = ((mb->get_position() - margin_ofs) / inner_size).x;
 			add_point_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
 			add_point_pos += blend_space->get_min_space();
 
@@ -151,6 +156,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 		}
 
 		// Then check point positions.
+		// points[] are stored in control-local space (margin-offset included).
 		for (int i = 0; i < points.size(); i++) {
 			if (Math::abs(float(points[i] - mb->get_position().x)) < 10 * EDSCALE) {
 				_set_selected_point(i);
@@ -213,7 +219,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 
 	// *set* the blend
 	if (mb.is_valid() && mb->is_pressed() && !dragging_selected_attempt && ((tool_select->is_pressed() && mb->is_shift_pressed()) || tool_blend->is_pressed()) && mb->get_button_index() == MouseButton::LEFT) {
-		float blend_pos = mb->get_position().x / blend_space_draw->get_size().x;
+		float blend_pos = (mb->get_position().x - pm) / inner_size.x;
 		blend_pos *= blend_space->get_max_space() - blend_space->get_min_space();
 		blend_pos += blend_space->get_min_space();
 
@@ -231,13 +237,14 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 
 	if (mm.is_valid() && dragging_selected_attempt) {
 		dragging_selected = true;
-		drag_ofs = ((mm->get_position() - drag_from) / blend_space_draw->get_size()) * ((blend_space->get_max_space() - blend_space->get_min_space()) * Vector2(1, 0));
+		// drag_from and mm->get_position() are both in the same padded coordinate space, so their delta is unaffected by POINT_MARGIN.
+		drag_ofs = ((mm->get_position() - drag_from) / inner_size) * ((blend_space->get_max_space() - blend_space->get_min_space()) * Vector2(1, 0));
 		blend_space_draw->queue_redraw();
 		_update_edited_point_pos();
 	}
 
 	if (mm.is_valid() && dragging_blend_position && !dragging_selected_attempt && ((tool_select->is_pressed() && mm->is_shift_pressed()) || tool_blend->is_pressed()) && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
-		float blend_pos = mm->get_position().x / blend_space_draw->get_size().x;
+		float blend_pos = (mm->get_position().x - pm) / inner_size.x;
 		blend_pos *= blend_space->get_max_space() - blend_space->get_min_space();
 		blend_pos += blend_space->get_min_space();
 
@@ -287,14 +294,10 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 	Ref<Texture2D> icon = get_editor_theme_icon(SNAME("KeyValue"));
 	Ref<Texture2D> icon_selected = get_editor_theme_icon(SNAME("KeySelected"));
 
-	Size2 s = blend_space_draw->get_size();
+	const float pm = POINT_MARGIN * EDSCALE;
 
-	if (blend_space_draw->has_focus()) {
-		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-		blend_space_draw->draw_rect(Rect2(Point2(), s), color, false);
-	}
-
-	blend_space_draw->draw_line(Point2(1, s.height - 1), Point2(s.width - 1, s.height - 1), linecolor, Math::round(EDSCALE));
+	const Vector2 ofs(pm, pm); // Offset all drawing into the inner area.
+	const Size2 s = blend_space_draw->get_size() - ofs * 2; // Inner size, for coordinate math.
 
 	if (blend_space->get_min_space() <= 0 && blend_space->get_max_space() >= 0) {
 		float point = 0.0;
@@ -303,9 +306,9 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 
 		float x = point;
 
-		blend_space_draw->draw_line(Point2(x, s.height - 1), Point2(x, s.height - 5 * EDSCALE), linecolor, Math::round(EDSCALE));
-		blend_space_draw->draw_string(font, Point2(x + 2 * EDSCALE, s.height - 2 * EDSCALE - font->get_height(font_size) + font->get_ascent(font_size)), "0", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, linecolor);
-		blend_space_draw->draw_line(Point2(x, s.height - 5 * EDSCALE), Point2(x, 0), linecolor_soft, Math::round(EDSCALE));
+		blend_space_draw->draw_line(ofs + Point2(x, s.height - 1), ofs + Point2(x, s.height - 5 * EDSCALE), linecolor, Math::round(EDSCALE));
+		blend_space_draw->draw_string(font, ofs + Point2(x + 4 * EDSCALE, s.height - font->get_height(font_size) + font->get_ascent(font_size)), "0", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, linecolor);
+		blend_space_draw->draw_line(ofs + Point2(x, s.height - 5 * EDSCALE), ofs + Point2(x, 0), linecolor_soft, Math::round(EDSCALE));
 	}
 
 	if (snap->is_pressed()) {
@@ -319,7 +322,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 				int idx = int(v / blend_space->get_snap());
 
 				if (i > 0 && prev_idx != idx) {
-					blend_space_draw->draw_line(Point2(i, 0), Point2(i, s.height), linecolor_soft, Math::round(EDSCALE));
+					blend_space_draw->draw_line(ofs + Point2(i, 0), ofs + Point2(i, s.height), linecolor_soft, Math::round(EDSCALE));
 				}
 
 				prev_idx = idx;
@@ -341,15 +344,16 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 
 		point = (point - blend_space->get_min_space()) / (blend_space->get_max_space() - blend_space->get_min_space());
 		point *= s.width;
-		points.push_back(point);
 
-		Vector2 gui_point = (Vector2(point, s.height / 2.0) - icon->get_size() / 2.0).floor();
+		points.push_back(point + ofs.x);
+
+		Vector2 gui_point = (ofs + Vector2(point, s.height / 2.0) - icon->get_size() / 2.0).floor();
 		blend_space_draw->draw_texture(i == selected_point ? icon_selected : icon, gui_point);
 
 		if (point >= 0.0 && point <= s.width && editing_point != i) {
 			String name_text = show_indices ? itos(i) : String(blend_space->get_blend_point_name(i));
 			Vector2 text_size = font->get_string_size(name_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size);
-			Vector2 text_pos = Vector2(CLAMP(point - text_size.x / 2.0, 0, s.width - text_size.x), gui_point.y - 4 * EDSCALE);
+			Vector2 text_pos = ofs + Vector2(CLAMP(point - text_size.x / 2.0, 0, s.width - text_size.x), gui_point.y - ofs.y - 4 * EDSCALE);
 
 			Color name_color = i == selected_point ? get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) : linecolor;
 			blend_space_draw->draw_string(font, text_pos, name_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
@@ -377,7 +381,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 		point = (point - blend_space->get_min_space()) / (blend_space->get_max_space() - blend_space->get_min_space());
 		point *= s.width;
 
-		Vector2 gui_point = Vector2(point, s.height / 2.0);
+		Vector2 gui_point = ofs + Vector2(point, s.height / 2.0);
 
 		float mind = 5 * EDSCALE;
 		float maxd = 15 * EDSCALE;
@@ -417,7 +421,6 @@ void AnimationNodeBlendSpace1DEditor::_config_changed(double) {
 
 	updating = true;
 
-	constexpr double STEP_UNIT = 0.01;
 	min_value->set_max(max_value->get_value() - STEP_UNIT);
 	max_value->set_min(min_value->get_value() + STEP_UNIT);
 
@@ -740,7 +743,7 @@ void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			error_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
 			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
-			panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
+			panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("GraphBlendSpace")));
 			tool_blend->set_button_icon(get_editor_theme_icon(SNAME("EditPivot")));
 			tool_select->set_button_icon(get_editor_theme_icon(SNAME("ToolSelect")));
 			tool_create->set_button_icon(get_editor_theme_icon(SNAME("EditKey")));
@@ -837,10 +840,11 @@ void AnimationNodeBlendSpace1DEditor::_start_inline_edit(int p_point) {
 		float editor_width = text_rect.size.x;
 		inline_editor->set_size(Vector2(editor_width, text_rect.size.y));
 
-		Size2 s = blend_space_draw->get_size();
+		const float pm = POINT_MARGIN * EDSCALE;
+		const Size2 s = blend_space_draw->get_size() - Vector2(pm * 2, pm * 2);
 
 		float editor_x = inline_editor_point_x - editor_width / 2.0;
-		editor_x = CLAMP(editor_x, 0.0f, s.width - editor_width);
+		editor_x = CLAMP(editor_x, pm, pm + s.width - editor_width);
 		inline_editor->set_position(Vector2(editor_x, text_rect.position.y - 1 * EDSCALE));
 	}
 
@@ -889,13 +893,14 @@ void AnimationNodeBlendSpace1DEditor::_inline_editor_text_changed(const String &
 		return;
 	}
 
-	inline_editor->set_size(Vector2(0, inline_editor->get_size().y));
-
 	Vector2 editor_size = inline_editor->get_size();
-	Size2 s = blend_space_draw->get_size();
+	inline_editor->set_size(Vector2(0, editor_size.y));
+
+	const float pm = POINT_MARGIN * EDSCALE;
+	const Size2 s = blend_space_draw->get_size() - Vector2(pm * 2, pm * 2);
 
 	float editor_x = inline_editor_point_x - editor_size.x / 2.0;
-	editor_x = CLAMP(editor_x, 0.0f, s.width - editor_size.x);
+	editor_x = CLAMP(editor_x, pm, pm + s.width - editor_size.x);
 
 	inline_editor->set_position(Vector2(editor_x, inline_editor->get_position().y));
 }
@@ -1031,9 +1036,6 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 
 	edit_hb->add_child(memnew(VSeparator));
 
-	constexpr double STEP_UNIT = 0.01;
-	constexpr double ABS_MAX = 10000;
-
 	edit_hb->add_child(memnew(Label(TTR("Position"))));
 	edit_value = memnew(SpinBox);
 	edit_hb->add_child(edit_value);
@@ -1062,6 +1064,8 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	blend_space_draw->connect(SceneStringName(draw), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_blend_space_draw));
 	blend_space_draw->set_focus_mode(FOCUS_ALL);
 
+	blend_space_draw->set_anchors_preset(PRESET_FULL_RECT);
+
 	panel->add_child(blend_space_draw);
 
 	{
@@ -1073,16 +1077,21 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 		min_value->set_min(-ABS_MAX);
 		min_value->set_max(ABS_MAX - STEP_UNIT);
 		min_value->set_step(STEP_UNIT);
+		min_value->get_line_edit()->set_expand_to_text_length_enabled(true);
+		min_value->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 		min_value->set_accessibility_name(TTRC("Min"));
 
 		max_value = memnew(SpinBox);
 		max_value->set_min(-ABS_MAX + STEP_UNIT);
 		max_value->set_max(ABS_MAX);
 		max_value->set_step(STEP_UNIT);
+		max_value->get_line_edit()->set_expand_to_text_length_enabled(true);
+		max_value->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 		max_value->set_accessibility_name(TTRC("Max"));
 
 		label_value = memnew(LineEdit);
 		label_value->set_expand_to_text_length_enabled(true);
+		label_value->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 		label_value->set_accessibility_name(TTRC("Value"));
 
 		// now add
@@ -1101,7 +1110,6 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 
 	error_panel = memnew(PanelContainer);
 	add_child(error_panel);
-
 	error_label = create_error_label_node();
 	error_panel->add_child(error_label);
 	error_panel->hide();

--- a/editor/animation/animation_blend_space_1d_editor.h
+++ b/editor/animation/animation_blend_space_1d_editor.h
@@ -50,6 +50,10 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	Ref<AnimationNodeBlendSpace1D> blend_space;
 	bool read_only = false;
 
+	static constexpr float POINT_MARGIN = 6.0f;
+	static constexpr double STEP_UNIT = 0.01;
+	static constexpr double ABS_MAX = 10000;
+
 	PanelContainer *panel = nullptr;
 	Button *tool_blend = nullptr;
 	Button *tool_select = nullptr;

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -125,6 +125,11 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 		}
 	}
 
+	const float pm = POINT_MARGIN * EDSCALE;
+
+	const Vector2 margin_ofs(pm, pm); // Offset all drawing into the inner area.
+	const Size2 inner_size = blend_space_draw->get_size() - margin_ofs * 2; // Inner size, for coordinate math.
+
 	Ref<InputEventMouseButton> mb = p_event;
 
 	if (mb.is_valid() && mb->is_pressed() && ((tool_select->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) || (mb->get_button_index() == MouseButton::LEFT && tool_create->is_pressed()))) {
@@ -165,7 +170,8 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 			menu->set_position(blend_space_draw->get_screen_position() + mb->get_position());
 			menu->reset_size();
 			menu->popup();
-			add_point_pos = (mb->get_position() / blend_space_draw->get_size());
+
+			add_point_pos = ((mb->get_position() - margin_ofs) / inner_size);
 			add_point_pos.y = 1.0 - add_point_pos.y;
 			add_point_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
 			add_point_pos += blend_space->get_min_space();
@@ -195,6 +201,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 		}
 
 		// Then check point positions.
+		// points[] are stored in control-local space (margin-offset included).
 		for (int i = 0; i < points.size(); i++) {
 			if (points[i].distance_to(mb->get_position()) < 10 * EDSCALE) {
 				_set_selected_point(i);
@@ -309,7 +316,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 	}
 
 	if (mb.is_valid() && mb->is_pressed() && !dragging_selected_attempt && ((tool_select->is_pressed() && mb->is_shift_pressed()) || tool_blend->is_pressed()) && mb->get_button_index() == MouseButton::LEFT) {
-		Vector2 blend_pos = (mb->get_position() / blend_space_draw->get_size());
+		Vector2 blend_pos = ((mb->get_position() - margin_ofs) / inner_size);
 		blend_pos.y = 1.0 - blend_pos.y;
 		blend_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
 		blend_pos += blend_space->get_min_space();
@@ -329,7 +336,8 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 	if (mm.is_valid() && dragging_selected_attempt) {
 		dragging_selected = true;
 		if (!read_only) {
-			drag_ofs = ((mm->get_position() - drag_from) / blend_space_draw->get_size()) * (blend_space->get_max_space() - blend_space->get_min_space()) * Vector2(1, -1);
+			// drag_from and mm->get_position() are both in the same padded coordinate space, so their delta is unaffected by POINT_MARGIN.
+			drag_ofs = ((mm->get_position() - drag_from) / inner_size) * (blend_space->get_max_space() - blend_space->get_min_space()) * Vector2(1, -1);
 		}
 		blend_space_draw->queue_redraw();
 		_update_edited_point_pos();
@@ -345,7 +353,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 	}
 
 	if (mm.is_valid() && dragging_blend_position && !dragging_selected_attempt && ((tool_select->is_pressed() && mm->is_shift_pressed()) || tool_blend->is_pressed()) && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
-		Vector2 blend_pos = (mm->get_position() / blend_space_draw->get_size());
+		Vector2 blend_pos = ((mm->get_position() - margin_ofs) / inner_size);
 		blend_pos.y = 1.0 - blend_pos.y;
 		blend_pos *= (blend_space->get_max_space() - blend_space->get_min_space());
 		blend_pos += blend_space->get_min_space();
@@ -531,28 +539,23 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 	Ref<Texture2D> icon = get_editor_theme_icon(SNAME("KeyValue"));
 	Ref<Texture2D> icon_selected = get_editor_theme_icon(SNAME("KeySelected"));
 
-	Size2 s = blend_space_draw->get_size();
+	const float pm = POINT_MARGIN * EDSCALE;
 
-	if (blend_space_draw->has_focus(true)) {
-		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-		blend_space_draw->draw_rect(Rect2(Point2(), s), color, false);
-	}
-	blend_space_draw->draw_line(Point2(1, 0), Point2(1, s.height - 1), linecolor, Math::round(EDSCALE));
-	blend_space_draw->draw_line(Point2(1, s.height - 1), Point2(s.width - 1, s.height - 1), linecolor, Math::round(EDSCALE));
+	const Vector2 ofs(pm, pm); // Offset all drawing into the inner area.
+	const Size2 s = blend_space_draw->get_size() - ofs * 2; // Inner size, for coordinate math.
 
-	blend_space_draw->draw_line(Point2(0, 0), Point2(5 * EDSCALE, 0), linecolor, Math::round(EDSCALE));
 	if (blend_space->get_min_space().y <= 0 && blend_space->get_max_space().y >= 0) {
 		int y = (blend_space->get_max_space().y / (blend_space->get_max_space().y - blend_space->get_min_space().y)) * s.height;
-		blend_space_draw->draw_line(Point2(0, y), Point2(5 * EDSCALE, y), linecolor, Math::round(EDSCALE));
-		blend_space_draw->draw_string(font, Point2(2 * EDSCALE, y - font->get_height(font_size) + font->get_ascent(font_size)), "0", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, linecolor);
-		blend_space_draw->draw_line(Point2(5 * EDSCALE, y), Point2(s.width, y), linecolor_soft, Math::round(EDSCALE));
+		blend_space_draw->draw_line(ofs + Point2(0, y), ofs + Point2(5 * EDSCALE, y), linecolor, Math::round(EDSCALE));
+		blend_space_draw->draw_string(font, ofs + Point2(4 * EDSCALE, y - font->get_height(font_size) + font->get_ascent(font_size)), "0", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, linecolor);
+		blend_space_draw->draw_line(ofs + Point2(5 * EDSCALE, y), ofs + Point2(s.width, y), linecolor_soft, Math::round(EDSCALE));
 	}
 
 	if (blend_space->get_min_space().x <= 0 && blend_space->get_max_space().x >= 0) {
 		int x = (-blend_space->get_min_space().x / (blend_space->get_max_space().x - blend_space->get_min_space().x)) * s.width;
-		blend_space_draw->draw_line(Point2(x, s.height - 1), Point2(x, s.height - 5 * EDSCALE), linecolor, Math::round(EDSCALE));
-		blend_space_draw->draw_string(font, Point2(x + 2 * EDSCALE, s.height - 2 * EDSCALE - font->get_height(font_size) + font->get_ascent(font_size)), "0", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, linecolor);
-		blend_space_draw->draw_line(Point2(x, s.height - 5 * EDSCALE), Point2(x, 0), linecolor_soft, Math::round(EDSCALE));
+		blend_space_draw->draw_line(ofs + Point2(x, s.height - 1), ofs + Point2(x, s.height - 5 * EDSCALE), linecolor, Math::round(EDSCALE));
+		blend_space_draw->draw_string(font, ofs + Point2(x + 4 * EDSCALE, s.height - font->get_height(font_size) + font->get_ascent(font_size)), "0", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, linecolor);
+		blend_space_draw->draw_line(ofs + Point2(x, s.height - 5 * EDSCALE), ofs + Point2(x, 0), linecolor_soft, Math::round(EDSCALE));
 	}
 
 	if (snap->is_pressed()) {
@@ -565,7 +568,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 				int idx = int(v / blend_space->get_snap().x);
 
 				if (i > 0 && prev_idx != idx) {
-					blend_space_draw->draw_line(Point2(i, 0), Point2(i, s.height), linecolor_soft, Math::round(EDSCALE));
+					blend_space_draw->draw_line(ofs + Point2(i, 0), ofs + Point2(i, s.height), linecolor_soft, Math::round(EDSCALE));
 				}
 
 				prev_idx = idx;
@@ -579,7 +582,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 				int idx = int(v / blend_space->get_snap().y);
 
 				if (i > 0 && prev_idx != idx) {
-					blend_space_draw->draw_line(Point2(0, i), Point2(s.width, i), linecolor_soft, Math::round(EDSCALE));
+					blend_space_draw->draw_line(ofs + Point2(0, i), ofs + Point2(s.width, i), linecolor_soft, Math::round(EDSCALE));
 				}
 
 				prev_idx = idx;
@@ -605,7 +608,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 			point = (point - blend_space->get_min_space()) / (blend_space->get_max_space() - blend_space->get_min_space());
 			point *= s;
 			point.y = s.height - point.y;
-			bl_points.write[j] = point;
+			bl_points.write[j] = ofs + point;
 		}
 
 		for (int j = 0; j < 3; j++) {
@@ -643,9 +646,10 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 		point = (point - blend_space->get_min_space()) / (blend_space->get_max_space() - blend_space->get_min_space());
 		point *= s;
 		point.y = s.height - point.y;
-		points.push_back(point);
 
-		Vector2 gui_point = (point - icon->get_size() / 2).floor();
+		points.push_back(ofs + point);
+
+		Vector2 gui_point = (ofs + point - icon->get_size() / 2).floor();
 		blend_space_draw->draw_texture(i == selected_point ? icon_selected : icon, gui_point);
 
 		if (point.x >= 0.0 && point.x <= s.width && point.y >= 0.0 && point.y <= s.height && editing_point != i) {
@@ -653,9 +657,9 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 			Vector2 text_size = font->get_string_size(name_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size);
 
 			float half_icon_h = icon->get_size().y / 2.0;
-			float above_pos_y = point.y - half_icon_h - 4 * EDSCALE;
-			float text_x = CLAMP(point.x - text_size.x / 2.0, 0, s.width - text_size.x);
-			float text_y = above_pos_y >= text_size.y ? above_pos_y : point.y + half_icon_h + font->get_ascent(font_size);
+			float above_pos_y = (ofs.y + point.y) - half_icon_h - 4 * EDSCALE;
+			float text_x = CLAMP((ofs.x + point.x) - text_size.x / 2.0, ofs.x, ofs.x + s.width - text_size.x);
+			float text_y = above_pos_y >= (ofs.y + text_size.y) ? above_pos_y : (ofs.y + point.y) + half_icon_h + font->get_ascent(font_size);
 			Vector2 text_pos = Vector2(text_x, text_y);
 
 			Color name_color = i == selected_point ? get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) : linecolor;
@@ -676,7 +680,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 			point = (point - blend_space->get_min_space()) / (blend_space->get_max_space() - blend_space->get_min_space());
 			point *= s;
 			point.y = s.height - point.y;
-			bl_points.push_back(point);
+			bl_points.push_back(ofs + point);
 		}
 
 		for (int i = 0; i < bl_points.size() - 1; i++) {
@@ -702,12 +706,14 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 		point = (point - blend_space->get_min_space()) / (blend_space->get_max_space() - blend_space->get_min_space());
 		point *= s;
 		point.y = s.height - point.y;
+		point += ofs;
 
 		if (blend_space->get_triangle_count()) {
 			Vector2 closest = blend_space->get_closest_point(blend_pos);
 			closest = (closest - blend_space->get_min_space()) / (blend_space->get_max_space() - blend_space->get_min_space());
 			closest *= s;
 			closest.y = s.height - closest.y;
+			closest += ofs;
 
 			Color lcol = color;
 			lcol.a *= 0.4;
@@ -769,7 +775,6 @@ void AnimationNodeBlendSpace2DEditor::_config_changed(double) {
 
 	updating = true;
 
-	constexpr double STEP_UNIT = 0.01;
 	min_x_value->set_max(max_x_value->get_value() - STEP_UNIT);
 	max_x_value->set_min(min_x_value->get_value() + STEP_UNIT);
 	min_y_value->set_max(max_y_value->get_value() - STEP_UNIT);
@@ -983,7 +988,7 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			error_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
 			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
-			panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
+			panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("GraphBlendSpace")));
 			tool_blend->set_button_icon(get_editor_theme_icon(SNAME("EditPivot")));
 			tool_select->set_button_icon(get_editor_theme_icon(SNAME("ToolSelect")));
 			tool_create->set_button_icon(get_editor_theme_icon(SNAME("EditKey")));
@@ -1105,10 +1110,12 @@ void AnimationNodeBlendSpace2DEditor::_start_inline_edit(int p_point) {
 		float editor_width = text_rect.size.x;
 		inline_editor->set_size(Vector2(editor_width, text_rect.size.y));
 
-		Size2 s = blend_space_draw->get_size();
+		const float pm = POINT_MARGIN * EDSCALE;
+		const Size2 s = blend_space_draw->get_size() - Vector2(pm * 2, pm * 2);
 
 		float editor_x = inline_editor_point_x - editor_width / 2.0;
-		editor_x = CLAMP(editor_x, 0.0f, s.width - editor_width);
+		editor_x = CLAMP(editor_x, pm, pm + s.width - editor_width);
+
 		inline_editor->set_position(Vector2(editor_x, text_rect.position.y - 1 * EDSCALE));
 	}
 
@@ -1157,13 +1164,14 @@ void AnimationNodeBlendSpace2DEditor::_inline_editor_text_changed(const String &
 		return;
 	}
 
-	inline_editor->set_size(Vector2(0, inline_editor->get_size().y));
-
 	Vector2 editor_size = inline_editor->get_size();
-	Size2 s = blend_space_draw->get_size();
+	inline_editor->set_size(Vector2(0, editor_size.y));
+
+	const float pm = POINT_MARGIN * EDSCALE;
+	const Size2 s = blend_space_draw->get_size() - Vector2(pm * 2, pm * 2);
 
 	float editor_x = inline_editor_point_x - editor_size.x / 2.0;
-	editor_x = CLAMP(editor_x, 0.0f, s.width - editor_size.x);
+	editor_x = CLAMP(editor_x, pm, pm + s.width - editor_size.x);
 
 	inline_editor->set_position(Vector2(editor_x, inline_editor->get_position().y));
 }
@@ -1298,9 +1306,6 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 
 	edit_hb->add_child(memnew(VSeparator));
 
-	constexpr double STEP_UNIT = 0.01;
-	constexpr double ABS_MAX = 10000;
-
 	edit_hb->add_child(memnew(Label(TTR("Position"))));
 	edit_x = memnew(SpinBox);
 	edit_hb->add_child(edit_x);
@@ -1335,15 +1340,20 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 		left_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
 		max_y_value = memnew(SpinBox);
 		max_y_value->set_accessibility_name(TTRC("Max Y"));
+		max_y_value->get_line_edit()->set_expand_to_text_length_enabled(true);
+		max_y_value->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 		left_vbox->add_child(max_y_value);
 		left_vbox->add_spacer();
 		label_y = memnew(LineEdit);
 		label_y->set_accessibility_name(TTRC("Y Value"));
-		left_vbox->add_child(label_y);
 		label_y->set_expand_to_text_length_enabled(true);
+		label_y->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+		left_vbox->add_child(label_y);
 		left_vbox->add_spacer();
 		min_y_value = memnew(SpinBox);
 		min_y_value->set_accessibility_name(TTRC("Min Y"));
+		min_y_value->get_line_edit()->set_expand_to_text_length_enabled(true);
+		min_y_value->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 		left_vbox->add_child(min_y_value);
 
 		max_y_value->set_max(ABS_MAX);
@@ -1365,6 +1375,8 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	blend_space_draw->connect(SceneStringName(draw), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_blend_space_draw));
 	blend_space_draw->set_focus_mode(FOCUS_ALL);
 
+	blend_space_draw->set_anchors_preset(PRESET_FULL_RECT);
+
 	panel->add_child(blend_space_draw);
 	main_grid->add_child(memnew(Control)); //empty bottom left
 
@@ -1374,15 +1386,20 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 		bottom_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
 		min_x_value = memnew(SpinBox);
 		min_x_value->set_accessibility_name(TTRC("Min X"));
+		min_x_value->get_line_edit()->set_expand_to_text_length_enabled(true);
+		min_x_value->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 		bottom_vbox->add_child(min_x_value);
 		bottom_vbox->add_spacer();
 		label_x = memnew(LineEdit);
 		label_x->set_accessibility_name(TTRC("X Value"));
-		bottom_vbox->add_child(label_x);
 		label_x->set_expand_to_text_length_enabled(true);
+		label_x->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+		bottom_vbox->add_child(label_x);
 		bottom_vbox->add_spacer();
 		max_x_value = memnew(SpinBox);
 		max_x_value->set_accessibility_name(TTRC("Max X"));
+		max_x_value->get_line_edit()->set_expand_to_text_length_enabled(true);
+		max_x_value->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 		bottom_vbox->add_child(max_x_value);
 
 		max_x_value->set_max(ABS_MAX);

--- a/editor/animation/animation_blend_space_2d_editor.h
+++ b/editor/animation/animation_blend_space_2d_editor.h
@@ -50,6 +50,10 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	Ref<AnimationNodeBlendSpace2D> blend_space;
 	bool read_only = false;
 
+	static constexpr float POINT_MARGIN = 6.0f;
+	static constexpr double STEP_UNIT = 0.01;
+	static constexpr double ABS_MAX = 10000;
+
 	PanelContainer *panel = nullptr;
 	Button *tool_blend = nullptr;
 	Button *tool_select = nullptr;

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -2108,7 +2108,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	top_hb->add_child(transition_tools_hb);
 	transition_tools_hb->add_child(memnew(VSeparator));
 
-	transition_tools_hb->add_child(memnew(Label(TTR("Transition:"))));
+	transition_tools_hb->add_child(memnew(Label(TTR("Transition"))));
 	switch_mode = memnew(OptionButton);
 	transition_tools_hb->add_child(switch_mode);
 
@@ -2119,11 +2119,9 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	auto_advance->set_pressed(true);
 	transition_tools_hb->add_child(auto_advance);
 
-	//
-
 	top_hb->add_spacer();
 
-	top_hb->add_child(memnew(Label(TTR("Play Mode:"))));
+	top_hb->add_child(memnew(Label(TTR("Play Mode"))));
 	play_mode = memnew(OptionButton);
 	top_hb->add_child(play_mode);
 

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -2505,6 +2505,13 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			p_theme->set_color("playback_color", "GraphStateMachine", p_config.font_color);
 			p_theme->set_color("playback_background_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.3));
 		}
+
+		// BlendSpace graph.
+		{
+			Ref<StyleBox> bs_panel_style = p_config.tree_panel_style->duplicate();
+			bs_panel_style->set_content_margin_all(0);
+			p_theme->set_stylebox(SceneStringName(panel), "GraphBlendSpace", bs_panel_style);
+		}
 	}
 
 	// TileSet editor.

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -2836,6 +2836,13 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_color("playback_color", "GraphStateMachine", p_config.font_color);
 			p_theme->set_color("playback_background_color", "GraphStateMachine", p_config.font_color * Color(1, 1, 1, 0.3));
 		}
+
+		// BlendSpace graph.
+		{
+			Ref<StyleBox> bs_panel_style = p_config.tree_panel_style->duplicate();
+			bs_panel_style->set_content_margin_all(0);
+			p_theme->set_stylebox(SceneStringName(panel), "GraphBlendSpace", bs_panel_style);
+		}
 	}
 
 	// TileSet editor.

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -523,9 +523,3 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(ProcessState &p_
 String AnimationNodeBlendSpace1D::get_caption() const {
 	return "BlendSpace1D";
 }
-
-AnimationNodeBlendSpace1D::AnimationNodeBlendSpace1D() {
-}
-
-AnimationNodeBlendSpace1D::~AnimationNodeBlendSpace1D() {
-}

--- a/scene/animation/animation_blend_space_1d.h
+++ b/scene/animation/animation_blend_space_1d.h
@@ -129,9 +129,6 @@ public:
 	String get_caption() const override;
 
 	Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
-
-	AnimationNodeBlendSpace1D();
-	~AnimationNodeBlendSpace1D();
 };
 
 VARIANT_ENUM_CAST(AnimationNodeBlendSpace1D::BlendMode)

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -840,9 +840,3 @@ void AnimationNodeBlendSpace2D::_bind_methods() {
 	BIND_ENUM_CONSTANT(BLEND_MODE_DISCRETE);
 	BIND_ENUM_CONSTANT(BLEND_MODE_DISCRETE_CARRY);
 }
-
-AnimationNodeBlendSpace2D::AnimationNodeBlendSpace2D() {
-}
-
-AnimationNodeBlendSpace2D::~AnimationNodeBlendSpace2D() {
-}

--- a/scene/animation/animation_blend_space_2d.h
+++ b/scene/animation/animation_blend_space_2d.h
@@ -157,9 +157,6 @@ public:
 	bool is_using_sync() const;
 
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
-
-	AnimationNodeBlendSpace2D();
-	~AnimationNodeBlendSpace2D();
 };
 
 VARIANT_ENUM_CAST(AnimationNodeBlendSpace2D::BlendMode)


### PR DESCRIPTION
Closes [#14453](https://github.com/godotengine/godot-proposals/issues/14453). In theme with #117432.

Follows #117377 in reclaiming margins:
- Expands the margins of the BlendSpace to the full rect of its panel, then manually insetting them to allow blend points some input headroom for being selected from the overflow side when at the edge, while still visually looking the same.

| Previously | Now |
| ------------- | ------------- |
| <img width="170" height="102" alt="space-previously" src="https://github.com/user-attachments/assets/133f1ced-98e9-47c1-a72a-1561902e02cc" /> | <img width="170" height="102" alt="space-now" src="https://github.com/user-attachments/assets/b262c9cf-5438-4940-a240-5c251070698a" /> | 
| Initiating a drag in the red region, outside the blend space grid but inside the panel, even when on the blendpoint, was not possible. So 3/4ths of the blendpoint could be unselectable. | With the margins expanded to fill the panel and the blend space grid inset, initiating a drag is now possible from either side. |

Follows #110369 in polishing BlendSpace:
1. Give the BlendSpace editor panel the same StyleBox as StateMachine, to make each AnimationTree editor have a consistent tone.
2. Allow overflowing triangles to clip gracefully at the edge of this now-distinct panel.
3. Remove the white 1px lines that represented axes in both BlendSpace editors, and allow the layout to reinforce the axes instead.
4. Remove the blue focus rectangle from BlendSpace1D's, and the nonfunctional one from BlendSpace2D's editor.
5. Change each LineEdit's horizontal orientation to better hug grid position. In BlendSpace1D and BlendSpace2D's x axis, left-center-right for min-label-max. In BlendSpace2D's y axis, right-right-right for min-label-max.
6. Colons were previously removed from labels to reduce clutter in the very busy BlendSpace editor toolbar, and StateMachine's are made to follow suit, for `Transition` and `Play Mode`.
7. The now-unused constructors/destructors in both BlendSpace resources are removed.
8. Finally, an extra commit on top duplicates #117470 to support number 5, in getting out of the way of the numbers as they hug their axes' extremes. If that PR isn't desired, this can be undone.

| Before | After |
| ------------- | ------------- |
| <img width="1083" height="656" alt="before" src="https://github.com/user-attachments/assets/244a49bc-67a1-4e7a-ae52-7a7f143ed7bb" /> | <img width="1083" height="656" alt="after" src="https://github.com/user-attachments/assets/e07a43a5-c3f0-485b-a465-ae7982e9760e" /> | 
| <img width="1583" height="651" alt="Image" src="https://github.com/user-attachments/assets/3f151ce3-405e-4258-a2b3-0ee92a0dc1e0" /> | <img width="1583" height="651" alt="Image" src="https://github.com/user-attachments/assets/7128e987-31fc-42c8-9824-053b1330157f" /> |

Anything else that is deemed extraneous can also be removed. If one of these would be better suited on it's own, let me know.