### PR TITLE
Clean and simplify `Inspector` header

### DIFF
--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -738,9 +738,13 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	HBoxContainer *general_options_hb = memnew(HBoxContainer);
 	main_vb->add_child(general_options_hb);
 
+	HBoxContainer *button_hb = memnew(HBoxContainer);
+	button_hb->add_theme_constant_override("separation", 0);
+	general_options_hb->add_child(button_hb);
+
 	backward_button = memnew(Button);
 	backward_button->set_theme_type_variation(SceneStringName(FlatButton));
-	general_options_hb->add_child(backward_button);
+	button_hb->add_child(backward_button);
 	backward_button->set_tooltip_text(TTR("Go to previous edited object in history.") + "\n" + TTR("Right-click to show history of edited objects."));
 	backward_button->set_disabled(true);
 	backward_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_edit_back_pressed));
@@ -754,7 +758,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 
 	forward_button = memnew(Button);
 	forward_button->set_theme_type_variation(SceneStringName(FlatButton));
-	general_options_hb->add_child(forward_button);
+	button_hb->add_child(forward_button);
 	forward_button->set_tooltip_text(TTRC("Go to next edited object in history."));
 	forward_button->set_disabled(true);
 	forward_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_edit_forward));

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -80,6 +80,13 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 			_menu_expand_revertable();
 		} break;
 
+		case RESOURCE_NEW: {
+			_new_resource();
+		} break;
+		case RESOURCE_LOAD: {
+			_load_resource();
+		} break;
+
 		case RESOURCE_SAVE: {
 			_save_resource(false);
 		} break;
@@ -318,7 +325,7 @@ void InspectorDock::_prepare_history() {
 
 	int history_to = MAX(0, editor_history->get_history_len() - 25);
 
-	history_menu->get_popup()->clear();
+	backward_popup->clear();
 
 	HashSet<ObjectID> already;
 	for (int i = editor_history->get_history_len() - 1; i >= history_to; i--) {
@@ -358,7 +365,7 @@ void InspectorDock::_prepare_history() {
 		if (i == editor_history->get_history_pos() && current) {
 			text += " " + TTR("(Current)");
 		}
-		history_menu->get_popup()->add_icon_item(icon, text, i);
+		backward_popup->add_icon_item(icon, text, i);
 	}
 }
 
@@ -420,7 +427,7 @@ void InspectorDock::_edit_forward() {
 	}
 }
 
-void InspectorDock::_edit_back() {
+void InspectorDock::_edit_back_pressed() {
 	EditorSelectionHistory *editor_history = EditorNode::get_singleton()->get_editor_selection_history();
 	if ((current && editor_history->previous()) || editor_history->get_path_size() == 1) {
 		EditorNode::get_singleton()->edit_current();
@@ -428,6 +435,15 @@ void InspectorDock::_edit_back() {
 		if (const EditorDebuggerRemoteObjects *robjs = Object::cast_to<EditorDebuggerRemoteObjects>(current)) {
 			EditorDebuggerNode::get_singleton()->set_remote_selection(robjs->remote_object_ids.duplicate());
 		}
+	}
+}
+
+void InspectorDock::_edit_back_input(const Ref<InputEvent> &p_event) {
+	const Ref<InputEventMouseButton> mb = p_event;
+
+	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
+		backward_popup->set_position(backward_button->get_screen_position() + Vector2(0, backward_button->get_size().y));
+		backward_popup->popup();
 	}
 }
 
@@ -459,16 +475,17 @@ void InspectorDock::_notification(int p_what) {
 		}
 		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
-			resource_new_button->set_button_icon(get_editor_theme_icon(SNAME("New")));
-			resource_load_button->set_button_icon(get_editor_theme_icon(SNAME("Load")));
 			resource_save_button->set_button_icon(get_editor_theme_icon(SNAME("Save")));
 			resource_extra_button->set_button_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
-			open_docs_button->set_button_icon(get_editor_theme_icon(SNAME("HelpSearch")));
 
 			PopupMenu *resource_extra_popup = resource_extra_button->get_popup();
+			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_NEW), get_editor_theme_icon(SNAME("New")));
+			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_LOAD), get_editor_theme_icon(SNAME("Load")));
+			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_SAVE), get_editor_theme_icon(SNAME("Save")));
 			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_EDIT_CLIPBOARD), get_editor_theme_icon(SNAME("ActionPaste")));
 			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_COPY), get_editor_theme_icon(SNAME("ActionCopy")));
 			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_SHOW_IN_FILESYSTEM), get_editor_theme_icon(SNAME("ShowInFileSystem")));
+			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(OBJECT_REQUEST_HELP), get_editor_theme_icon(SNAME("Help")));
 
 			if (is_layout_rtl()) {
 				backward_button->set_button_icon(get_editor_theme_icon(SNAME("Forward")));
@@ -479,9 +496,8 @@ void InspectorDock::_notification(int p_what) {
 			}
 
 			const int icon_width = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
-			history_menu->get_popup()->add_theme_constant_override("icon_max_width", icon_width);
+			backward_popup->add_theme_constant_override("icon_max_width", icon_width);
 
-			history_menu->set_button_icon(get_editor_theme_icon(SNAME("History")));
 			object_menu->set_button_icon(get_editor_theme_icon(SNAME("Tools")));
 			search->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 			if (info_is_warning) {
@@ -548,10 +564,6 @@ void InspectorDock::update(Object *p_object) {
 	backward_button->set_disabled(editor_history->is_at_beginning());
 	forward_button->set_disabled(editor_history->is_at_end());
 
-	history_menu->set_disabled(true);
-	if (editor_history->get_history_len() > 0) {
-		history_menu->set_disabled(false);
-	}
 	object_selector->update_path();
 
 	current = p_object;
@@ -564,9 +576,11 @@ void InspectorDock::update(Object *p_object) {
 	object_menu->set_disabled(!is_object || is_text_file);
 	search->set_editable(is_object && !is_text_file);
 	resource_save_button->set_disabled(!is_resource || is_text_file);
-	open_docs_button->set_disabled(is_text_file || (!is_resource && !is_node));
+	resource_save_button->set_visible(is_resource || is_text_file);
 
 	PopupMenu *resource_extra_popup = resource_extra_button->get_popup();
+	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_SAVE), !is_resource || is_text_file);
+	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_SAVE_AS), !is_resource || is_text_file);
 	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_COPY), !is_resource || is_text_file);
 	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_MAKE_BUILT_IN), !is_resource || is_text_file);
 
@@ -626,10 +640,6 @@ void InspectorDock::update(Object *p_object) {
 			I = I->next();
 		}
 	}
-}
-
-void InspectorDock::go_back() {
-	_edit_back();
 }
 
 EditorPropertyNameProcessor::Style InspectorDock::get_property_name_style() const {
@@ -728,28 +738,38 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	HBoxContainer *general_options_hb = memnew(HBoxContainer);
 	main_vb->add_child(general_options_hb);
 
-	resource_new_button = memnew(Button);
-	resource_new_button->set_theme_type_variation("FlatMenuButton");
-	resource_new_button->set_tooltip_text(TTRC("Create a new resource in memory and edit it."));
-	general_options_hb->add_child(resource_new_button);
-	resource_new_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_new_resource));
-	resource_new_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	backward_button = memnew(Button);
+	backward_button->set_theme_type_variation(SceneStringName(FlatButton));
+	general_options_hb->add_child(backward_button);
+	backward_button->set_tooltip_text(TTR("Go to previous edited object in history.") + "\n" + TTR("Right-click to show history of edited objects."));
+	backward_button->set_disabled(true);
+	backward_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_edit_back_pressed));
+	backward_button->connect(SceneStringName(gui_input), callable_mp(this, &InspectorDock::_edit_back_input));
 
-	resource_load_button = memnew(Button);
-	resource_load_button->set_theme_type_variation("FlatMenuButton");
-	resource_load_button->set_tooltip_text(TTRC("Load an existing resource from disk and edit it."));
-	general_options_hb->add_child(resource_load_button);
-	resource_load_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_open_resource_selector));
-	resource_load_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	backward_popup = memnew(PopupMenu);
+	backward_popup->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	backward_button->add_child(backward_popup);
+	backward_popup->connect("about_to_popup", callable_mp(this, &InspectorDock::_prepare_history));
+	backward_popup->connect(SceneStringName(id_pressed), callable_mp(this, &InspectorDock::_select_history));
 
-	resource_save_button = memnew(MenuButton);
+	forward_button = memnew(Button);
+	forward_button->set_theme_type_variation(SceneStringName(FlatButton));
+	general_options_hb->add_child(forward_button);
+	forward_button->set_tooltip_text(TTRC("Go to next edited object in history."));
+	forward_button->set_disabled(true);
+	forward_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_edit_forward));
+
+	object_selector = memnew(EditorObjectSelector(EditorNode::get_singleton()->get_editor_selection_history()));
+	object_selector->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	object_selector->set_theme_type_variation("FlatMenuButton");
+	general_options_hb->add_child(object_selector);
+
+	resource_save_button = memnew(Button);
 	resource_save_button->set_flat(false);
 	resource_save_button->set_theme_type_variation("FlatMenuButton");
 	resource_save_button->set_tooltip_text(TTRC("Save the currently edited resource."));
+	resource_save_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_save_resource).bind(false));
 	general_options_hb->add_child(resource_save_button);
-	resource_save_button->get_popup()->add_item(TTRC("Save"), RESOURCE_SAVE);
-	resource_save_button->get_popup()->add_item(TTRC("Save As..."), RESOURCE_SAVE_AS);
-	resource_save_button->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &InspectorDock::_menu_option));
 	resource_save_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	resource_save_button->set_disabled(true);
 
@@ -759,53 +779,29 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	resource_extra_button->set_tooltip_text(TTRC("Extra resource options."));
 	general_options_hb->add_child(resource_extra_button);
 	resource_extra_button->connect("about_to_popup", callable_mp(this, &InspectorDock::_prepare_resource_extra_popup));
-	resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/paste_resource", TTRC("Edit Resource from Clipboard")), RESOURCE_EDIT_CLIPBOARD);
-	resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/copy_resource", TTRC("Copy Resource")), RESOURCE_COPY);
-	resource_extra_button->get_popup()->set_item_disabled(1, true);
-	resource_extra_button->get_popup()->add_separator();
-	resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/show_in_filesystem", TTRC("Show in FileSystem")), RESOURCE_SHOW_IN_FILESYSTEM);
-	resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/unref_resource", TTRC("Make Resource Built-In")), RESOURCE_MAKE_BUILT_IN);
-	resource_extra_button->get_popup()->set_item_disabled(3, true);
-	resource_extra_button->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &InspectorDock::_menu_option));
 
-	general_options_hb->add_spacer();
-
-	backward_button = memnew(Button);
-	backward_button->set_theme_type_variation(SceneStringName(FlatButton));
-	general_options_hb->add_child(backward_button);
-	backward_button->set_tooltip_text(TTRC("Go to previous edited object in history."));
-	backward_button->set_disabled(true);
-	backward_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_edit_back));
-
-	forward_button = memnew(Button);
-	forward_button->set_theme_type_variation(SceneStringName(FlatButton));
-	general_options_hb->add_child(forward_button);
-	forward_button->set_tooltip_text(TTRC("Go to next edited object in history."));
-	forward_button->set_disabled(true);
-	forward_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_edit_forward));
-
-	history_menu = memnew(MenuButton);
-	history_menu->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	history_menu->set_flat(false);
-	history_menu->set_theme_type_variation("FlatMenuButton");
-	history_menu->set_tooltip_text(TTRC("History of recently edited objects."));
-	general_options_hb->add_child(history_menu);
-	history_menu->connect("about_to_popup", callable_mp(this, &InspectorDock::_prepare_history));
-	history_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &InspectorDock::_select_history));
-
-	HBoxContainer *subresource_hb = memnew(HBoxContainer);
-	main_vb->add_child(subresource_hb);
-	object_selector = memnew(EditorObjectSelector(EditorNode::get_singleton()->get_editor_selection_history()));
-	object_selector->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	subresource_hb->add_child(object_selector);
-
-	open_docs_button = memnew(Button);
-	open_docs_button->set_theme_type_variation("FlatMenuButton");
-	open_docs_button->set_disabled(true);
-	open_docs_button->set_tooltip_text(TTRC("Open documentation for this object."));
-	open_docs_button->set_shortcut(ED_SHORTCUT("property_editor/open_help", TTRC("Open Documentation")));
-	subresource_hb->add_child(open_docs_button);
-	open_docs_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_menu_option).bind(OBJECT_REQUEST_HELP));
+	PopupMenu *resource_extra_popup = resource_extra_button->get_popup();
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/new_resource", TTRC("New Resource")), RESOURCE_NEW);
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/load_resource", TTRC("Load Resource...")), RESOURCE_LOAD);
+	resource_extra_popup->add_separator();
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/save_resource", TTRC("Save Resource")), RESOURCE_SAVE);
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/save_resource_as", TTRC("Save Resource As...")), RESOURCE_SAVE_AS);
+	resource_extra_popup->add_separator();
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/paste_resource", TTRC("Edit Resource from Clipboard")), RESOURCE_EDIT_CLIPBOARD);
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/copy_resource", TTRC("Copy Resource")), RESOURCE_COPY);
+	resource_extra_popup->set_item_tooltip(resource_extra_popup->get_item_index(RESOURCE_NEW), TTRC("Create a new resource in memory and edit it."));
+	resource_extra_popup->set_item_tooltip(resource_extra_popup->get_item_index(RESOURCE_LOAD), TTRC("Load a resource from disk and edit it."));
+	resource_extra_popup->set_item_tooltip(resource_extra_popup->get_item_index(RESOURCE_SAVE), TTRC("Save the currently edited resource."));
+	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_COPY), true);
+	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_SAVE), true);
+	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_SAVE_AS), true);
+	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_MAKE_BUILT_IN), true);
+	resource_extra_popup->add_separator();
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/show_in_filesystem", TTRC("Show in FileSystem")), RESOURCE_SHOW_IN_FILESYSTEM);
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/open_docs", TTRC("Open Documentation")), OBJECT_REQUEST_HELP);
+	resource_extra_popup->add_separator();
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/unref_resource", TTRC("Make Resource Built-In")), RESOURCE_MAKE_BUILT_IN);
+	resource_extra_popup->connect(SceneStringName(id_pressed), callable_mp(this, &InspectorDock::_menu_option));
 
 	new_resource_dialog = memnew(CreateDialog);
 	EditorNode::get_singleton()->get_gui_base()->add_child(new_resource_dialog);

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -80,6 +80,13 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 			_menu_expand_revertable();
 		} break;
 
+		case RESOURCE_NEW: {
+			_new_resource();
+		} break;
+		case RESOURCE_LOAD: {
+			_load_resource();
+		} break;
+
 		case RESOURCE_SAVE: {
 			_save_resource(false);
 		} break;
@@ -318,7 +325,7 @@ void InspectorDock::_prepare_history() {
 
 	int history_to = MAX(0, editor_history->get_history_len() - 25);
 
-	history_menu->get_popup()->clear();
+	backward_popup->clear();
 
 	HashSet<ObjectID> already;
 	for (int i = editor_history->get_history_len() - 1; i >= history_to; i--) {
@@ -358,7 +365,7 @@ void InspectorDock::_prepare_history() {
 		if (i == editor_history->get_history_pos() && current) {
 			text += " " + TTR("(Current)");
 		}
-		history_menu->get_popup()->add_icon_item(icon, text, i);
+		backward_popup->add_icon_item(icon, text, i);
 	}
 }
 
@@ -420,7 +427,7 @@ void InspectorDock::_edit_forward() {
 	}
 }
 
-void InspectorDock::_edit_back() {
+void InspectorDock::_edit_back_pressed() {
 	EditorSelectionHistory *editor_history = EditorNode::get_singleton()->get_editor_selection_history();
 	if ((current && editor_history->previous()) || editor_history->get_path_size() == 1) {
 		EditorNode::get_singleton()->edit_current();
@@ -428,6 +435,15 @@ void InspectorDock::_edit_back() {
 		if (const EditorDebuggerRemoteObjects *robjs = Object::cast_to<EditorDebuggerRemoteObjects>(current)) {
 			EditorDebuggerNode::get_singleton()->set_remote_selection(robjs->remote_object_ids, robjs->debugger_id);
 		}
+	}
+}
+
+void InspectorDock::_edit_back_input(const Ref<InputEvent> &p_event) {
+	const Ref<InputEventMouseButton> mb = p_event;
+
+	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
+		backward_popup->set_position(backward_button->get_screen_position() + Vector2(0, backward_button->get_size().y));
+		backward_popup->popup();
 	}
 }
 
@@ -459,16 +475,17 @@ void InspectorDock::_notification(int p_what) {
 		}
 		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
-			resource_new_button->set_button_icon(get_editor_theme_icon(SNAME("New")));
-			resource_load_button->set_button_icon(get_editor_theme_icon(SNAME("Load")));
 			resource_save_button->set_button_icon(get_editor_theme_icon(SNAME("Save")));
 			resource_extra_button->set_button_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
-			open_docs_button->set_button_icon(get_editor_theme_icon(SNAME("HelpSearch")));
 
 			PopupMenu *resource_extra_popup = resource_extra_button->get_popup();
+			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_NEW), get_editor_theme_icon(SNAME("New")));
+			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_LOAD), get_editor_theme_icon(SNAME("Load")));
+			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_SAVE), get_editor_theme_icon(SNAME("Save")));
 			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_EDIT_CLIPBOARD), get_editor_theme_icon(SNAME("ActionPaste")));
 			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_COPY), get_editor_theme_icon(SNAME("ActionCopy")));
 			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_SHOW_IN_FILESYSTEM), get_editor_theme_icon(SNAME("ShowInFileSystem")));
+			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(OBJECT_REQUEST_HELP), get_editor_theme_icon(SNAME("Help")));
 
 			if (is_layout_rtl()) {
 				backward_button->set_button_icon(get_editor_theme_icon(SNAME("Forward")));
@@ -479,9 +496,8 @@ void InspectorDock::_notification(int p_what) {
 			}
 
 			const int icon_width = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
-			history_menu->get_popup()->add_theme_constant_override("icon_max_width", icon_width);
+			backward_popup->add_theme_constant_override("icon_max_width", icon_width);
 
-			history_menu->set_button_icon(get_editor_theme_icon(SNAME("History")));
 			object_menu->set_button_icon(get_editor_theme_icon(SNAME("Tools")));
 			search->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 			if (info_is_warning) {
@@ -548,10 +564,6 @@ void InspectorDock::update(Object *p_object) {
 	backward_button->set_disabled(editor_history->is_at_beginning());
 	forward_button->set_disabled(editor_history->is_at_end());
 
-	history_menu->set_disabled(true);
-	if (editor_history->get_history_len() > 0) {
-		history_menu->set_disabled(false);
-	}
 	object_selector->update_path();
 
 	current = p_object;
@@ -564,9 +576,11 @@ void InspectorDock::update(Object *p_object) {
 	object_menu->set_disabled(!is_object || is_text_file);
 	search->set_editable(is_object && !is_text_file);
 	resource_save_button->set_disabled(!is_resource || is_text_file);
-	open_docs_button->set_disabled(is_text_file || (!is_resource && !is_node));
+	resource_save_button->set_visible(is_resource || is_text_file);
 
 	PopupMenu *resource_extra_popup = resource_extra_button->get_popup();
+	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_SAVE), !is_resource || is_text_file);
+	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_SAVE_AS), !is_resource || is_text_file);
 	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_COPY), !is_resource || is_text_file);
 	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_MAKE_BUILT_IN), !is_resource || is_text_file);
 
@@ -626,10 +640,6 @@ void InspectorDock::update(Object *p_object) {
 			I = I->next();
 		}
 	}
-}
-
-void InspectorDock::go_back() {
-	_edit_back();
 }
 
 EditorPropertyNameProcessor::Style InspectorDock::get_property_name_style() const {
@@ -728,28 +738,42 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	HBoxContainer *general_options_hb = memnew(HBoxContainer);
 	main_vb->add_child(general_options_hb);
 
-	resource_new_button = memnew(Button);
-	resource_new_button->set_theme_type_variation("FlatMenuButton");
-	resource_new_button->set_tooltip_text(TTRC("Create a new resource in memory and edit it."));
-	general_options_hb->add_child(resource_new_button);
-	resource_new_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_new_resource));
-	resource_new_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	HBoxContainer *button_hb = memnew(HBoxContainer);
+	button_hb->add_theme_constant_override("separation", 0);
+	general_options_hb->add_child(button_hb);
 
-	resource_load_button = memnew(Button);
-	resource_load_button->set_theme_type_variation("FlatMenuButton");
-	resource_load_button->set_tooltip_text(TTRC("Load an existing resource from disk and edit it."));
-	general_options_hb->add_child(resource_load_button);
-	resource_load_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_open_resource_selector));
-	resource_load_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	backward_button = memnew(Button);
+	backward_button->set_theme_type_variation(SceneStringName(FlatButton));
+	button_hb->add_child(backward_button);
+	backward_button->set_tooltip_text(TTR("Go to previous edited object in history.") + "\n" + TTR("Right-click to show history of edited objects."));
+	backward_button->set_disabled(true);
+	backward_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_edit_back_pressed));
+	backward_button->connect(SceneStringName(gui_input), callable_mp(this, &InspectorDock::_edit_back_input));
 
-	resource_save_button = memnew(MenuButton);
+	backward_popup = memnew(PopupMenu);
+	backward_popup->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	backward_button->add_child(backward_popup);
+	backward_popup->connect("about_to_popup", callable_mp(this, &InspectorDock::_prepare_history));
+	backward_popup->connect(SceneStringName(id_pressed), callable_mp(this, &InspectorDock::_select_history));
+
+	forward_button = memnew(Button);
+	forward_button->set_theme_type_variation(SceneStringName(FlatButton));
+	button_hb->add_child(forward_button);
+	forward_button->set_tooltip_text(TTRC("Go to next edited object in history."));
+	forward_button->set_disabled(true);
+	forward_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_edit_forward));
+
+	object_selector = memnew(EditorObjectSelector(EditorNode::get_singleton()->get_editor_selection_history()));
+	object_selector->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	object_selector->set_theme_type_variation("FlatMenuButton");
+	general_options_hb->add_child(object_selector);
+
+	resource_save_button = memnew(Button);
 	resource_save_button->set_flat(false);
 	resource_save_button->set_theme_type_variation("FlatMenuButton");
 	resource_save_button->set_tooltip_text(TTRC("Save the currently edited resource."));
+	resource_save_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_save_resource).bind(false));
 	general_options_hb->add_child(resource_save_button);
-	resource_save_button->get_popup()->add_item(TTRC("Save"), RESOURCE_SAVE);
-	resource_save_button->get_popup()->add_item(TTRC("Save As..."), RESOURCE_SAVE_AS);
-	resource_save_button->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &InspectorDock::_menu_option));
 	resource_save_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	resource_save_button->set_disabled(true);
 
@@ -759,53 +783,29 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	resource_extra_button->set_tooltip_text(TTRC("Extra resource options."));
 	general_options_hb->add_child(resource_extra_button);
 	resource_extra_button->connect("about_to_popup", callable_mp(this, &InspectorDock::_prepare_resource_extra_popup));
-	resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/paste_resource", TTRC("Edit Resource from Clipboard")), RESOURCE_EDIT_CLIPBOARD);
-	resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/copy_resource", TTRC("Copy Resource")), RESOURCE_COPY);
-	resource_extra_button->get_popup()->set_item_disabled(1, true);
-	resource_extra_button->get_popup()->add_separator();
-	resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/show_in_filesystem", TTRC("Show in FileSystem")), RESOURCE_SHOW_IN_FILESYSTEM);
-	resource_extra_button->get_popup()->add_shortcut(ED_SHORTCUT("property_editor/unref_resource", TTRC("Make Resource Built-In")), RESOURCE_MAKE_BUILT_IN);
-	resource_extra_button->get_popup()->set_item_disabled(3, true);
-	resource_extra_button->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &InspectorDock::_menu_option));
 
-	general_options_hb->add_spacer();
-
-	backward_button = memnew(Button);
-	backward_button->set_theme_type_variation(SceneStringName(FlatButton));
-	general_options_hb->add_child(backward_button);
-	backward_button->set_tooltip_text(TTRC("Go to previous edited object in history."));
-	backward_button->set_disabled(true);
-	backward_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_edit_back));
-
-	forward_button = memnew(Button);
-	forward_button->set_theme_type_variation(SceneStringName(FlatButton));
-	general_options_hb->add_child(forward_button);
-	forward_button->set_tooltip_text(TTRC("Go to next edited object in history."));
-	forward_button->set_disabled(true);
-	forward_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_edit_forward));
-
-	history_menu = memnew(MenuButton);
-	history_menu->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	history_menu->set_flat(false);
-	history_menu->set_theme_type_variation("FlatMenuButton");
-	history_menu->set_tooltip_text(TTRC("History of recently edited objects."));
-	general_options_hb->add_child(history_menu);
-	history_menu->connect("about_to_popup", callable_mp(this, &InspectorDock::_prepare_history));
-	history_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &InspectorDock::_select_history));
-
-	HBoxContainer *subresource_hb = memnew(HBoxContainer);
-	main_vb->add_child(subresource_hb);
-	object_selector = memnew(EditorObjectSelector(EditorNode::get_singleton()->get_editor_selection_history()));
-	object_selector->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	subresource_hb->add_child(object_selector);
-
-	open_docs_button = memnew(Button);
-	open_docs_button->set_theme_type_variation("FlatMenuButton");
-	open_docs_button->set_disabled(true);
-	open_docs_button->set_tooltip_text(TTRC("Open documentation for this object."));
-	open_docs_button->set_shortcut(ED_SHORTCUT("property_editor/open_help", TTRC("Open Documentation")));
-	subresource_hb->add_child(open_docs_button);
-	open_docs_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_menu_option).bind(OBJECT_REQUEST_HELP));
+	PopupMenu *resource_extra_popup = resource_extra_button->get_popup();
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/new_resource", TTRC("New Resource")), RESOURCE_NEW);
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/load_resource", TTRC("Load Resource...")), RESOURCE_LOAD);
+	resource_extra_popup->add_separator();
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/save_resource", TTRC("Save Resource")), RESOURCE_SAVE);
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/save_resource_as", TTRC("Save Resource As...")), RESOURCE_SAVE_AS);
+	resource_extra_popup->add_separator();
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/paste_resource", TTRC("Edit Resource from Clipboard")), RESOURCE_EDIT_CLIPBOARD);
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/copy_resource", TTRC("Copy Resource")), RESOURCE_COPY);
+	resource_extra_popup->set_item_tooltip(resource_extra_popup->get_item_index(RESOURCE_NEW), TTRC("Create a new resource in memory and edit it."));
+	resource_extra_popup->set_item_tooltip(resource_extra_popup->get_item_index(RESOURCE_LOAD), TTRC("Load a resource from disk and edit it."));
+	resource_extra_popup->set_item_tooltip(resource_extra_popup->get_item_index(RESOURCE_SAVE), TTRC("Save the currently edited resource."));
+	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_COPY), true);
+	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_SAVE), true);
+	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_SAVE_AS), true);
+	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_MAKE_BUILT_IN), true);
+	resource_extra_popup->add_separator();
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/show_in_filesystem", TTRC("Show in FileSystem")), RESOURCE_SHOW_IN_FILESYSTEM);
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/open_docs", TTRC("Open Documentation")), OBJECT_REQUEST_HELP);
+	resource_extra_popup->add_separator();
+	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/unref_resource", TTRC("Make Resource Built-In")), RESOURCE_MAKE_BUILT_IN);
+	resource_extra_popup->connect(SceneStringName(id_pressed), callable_mp(this, &InspectorDock::_menu_option));
 
 	new_resource_dialog = memnew(CreateDialog);
 	EditorNode::get_singleton()->get_gui_base()->add_child(new_resource_dialog);

--- a/editor/docks/inspector_dock.h
+++ b/editor/docks/inspector_dock.h
@@ -47,6 +47,7 @@ class InspectorDock : public EditorDock {
 	GDCLASS(InspectorDock, EditorDock);
 
 	enum MenuOptions {
+		RESOURCE_NEW,
 		RESOURCE_LOAD,
 		RESOURCE_SAVE,
 		RESOURCE_SAVE_AS,
@@ -78,18 +79,15 @@ class InspectorDock : public EditorDock {
 	Object *current = nullptr;
 
 	Button *backward_button = nullptr;
+	PopupMenu *backward_popup = nullptr;
 	Button *forward_button = nullptr;
 
 	EditorFileDialog *load_resource_dialog = nullptr;
 	CreateDialog *new_resource_dialog = nullptr;
-	Button *resource_new_button = nullptr;
-	Button *resource_load_button = nullptr;
-	MenuButton *resource_save_button = nullptr;
+	Button *resource_save_button = nullptr;
 	MenuButton *resource_extra_button = nullptr;
-	MenuButton *history_menu = nullptr;
 	LineEdit *search = nullptr;
 
-	Button *open_docs_button = nullptr;
 	MenuButton *object_menu = nullptr;
 	EditorObjectSelector *object_selector = nullptr;
 
@@ -112,7 +110,6 @@ class InspectorDock : public EditorDock {
 
 	void _new_resource();
 	void _load_resource(const String &p_type = "");
-	void _open_resource_selector() { _load_resource(); } // just used to call from arg-less signal
 	void _resource_file_selected(const String &p_file);
 	void _save_resource(bool save_as);
 	void _unref_resource();
@@ -126,7 +123,8 @@ class InspectorDock : public EditorDock {
 	void _resource_selected(const Ref<Resource> &p_res, const String &p_property);
 	void _files_moved(const String &p_old_file, const String &p_new_file);
 	void _edit_forward();
-	void _edit_back();
+	void _edit_back_pressed();
+	void _edit_back_input(const Ref<InputEvent> &p_event);
 	void _menu_collapseall();
 	void _menu_expandall();
 	void _menu_expand_revertable();
@@ -147,7 +145,6 @@ protected:
 	void _notification(int p_what);
 
 public:
-	void go_back();
 	void edit_resource(const Ref<Resource> &p_resource);
 	void open_resource(const String &p_type);
 	void clear();

--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -195,7 +195,7 @@ void EditorObjectSelector::_notification(int p_what) {
 			int icon_size = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
 
 			current_object_icon->set_custom_minimum_size(Size2(icon_size, icon_size));
-			current_object_label->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("main"), EditorStringName(EditorFonts)));
+			current_object_label->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("bold"), EditorStringName(EditorFonts)));
 			sub_objects_icon->set_texture(get_theme_icon(SNAME("arrow"), SNAME("OptionButton")));
 			sub_objects_menu->add_theme_constant_override("icon_max_width", icon_size);
 		} break;

--- a/editor/icons/Back.svg
+++ b/editor/icons/Back.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="8" height="16"><path fill="none" stroke="#e0e0e0" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 2 2 8l4 6"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="16" viewBox="0 0 12 16"><path fill="none" stroke="#e0e0e0" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 2 L3 8 L9 14"/></svg>

--- a/editor/icons/BackStart.svg
+++ b/editor/icons/BackStart.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="none" stroke="#e0e0e0" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.99998 2 9.9999798 8 13.99998 14M5.9999798 2l-4 6 4 6"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="none" stroke="#e0e0e0" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 2 L8 8 L14 14 M8 2 L2 8 L8 14"/></svg>

--- a/editor/icons/Forward.svg
+++ b/editor/icons/Forward.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="8" height="16"><path fill="none" stroke="#e0e0e0" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m2 2 4 6-4 6"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="16" viewBox="0 0 12 16"><path fill="none" stroke="#e0e0e0" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 2 L9 8 L3 14"/></svg>

--- a/editor/icons/ForwardEnd.svg
+++ b/editor/icons/ForwardEnd.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="none" stroke="#e0e0e0" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2 2 6 8 2 14M10 2l4 6-4 6"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="none" stroke="#e0e0e0" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2 2 L8 8 L2 14 M8 2 L14 8 L8 14"/></svg>


### PR DESCRIPTION
> [!NOTE]
> There will most likely be multiple iterations of this PR, as this seems to be a topic that is hard to gain a consensus on. 😉

Closes https://github.com/godotengine/godot-proposals/issues/14446 and closes https://github.com/godotengine/godot-proposals/issues/9836.

This is a "mix" between these two proposals to cleanup and simplify the `Inspector` header.

**Changes done here:**
- Remove top Resource buttons (new, load, save) and place them into _three-dotted menu._
- Consolidate the `Go back` and `Go forward` to the left and same row as the Node header.
- Remove history button, but replaces functionality by having the popup appearing when you `Right-Click`  the `Go back` button.
- Remove `Documentation` button (see https://github.com/godotengine/godot/pull/117503).


| Before | After |
| ------------- | ------------- |
|  <video src=https://github.com/user-attachments/assets/c0b860a9-7e30-4cb8-b040-32a9e6b1201b></video> | <video src=https://github.com/user-attachments/assets/14c2b453-3d9f-446a-b501-7bae9b6ee17b></video> |

- *Bugsquad edit:* closes godotengine/godot-proposals#14012