### PR TITLE
GDScript: Fix `find_function` failing when script has overindented blocks

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -232,6 +232,9 @@ int GDScriptLanguage::find_function(const String &p_function, const String &p_co
 			indent++;
 		} else if (current.type == GDScriptTokenizer::Token::DEDENT) {
 			indent--;
+			if (indent < 0) {
+				indent = 0;
+			}
 		}
 		if (indent == 0 && current.type == GDScriptTokenizer::Token::FUNC) {
 			current = tokenizer.scan();


### PR DESCRIPTION
Fixes (invalid) #117416

When a GDScript source contains an overindented dictionary like:

```gdscript
var dictionary = {
		"foo": "bar"
	}

func button_pressed():
	print("pressed!")
```

the tokenizer produces more DEDENT tokens than INDENT tokens at the top level. The `find_function` method tracks indentation with a simple counter that increments on INDENT and decrements on DEDENT, looking for `func` tokens at indent level 0. Because of the extra DEDENTs from the overindented block, the counter goes negative and never returns to 0, so no function declarations past that point are found.

This causes the signal connection dialog to think the target function doesn't exist and attempt to add a duplicate, which breaks the script.

The fix clamps the indent counter to never go below 0, so that top-level `func` declarations are always found regardless of indentation anomalies earlier in the source. This is safe because `find_function` only cares about finding top-level functions — a negative indent level is never meaningful in that context.

**Steps to test:**
1. Create a scene with a script containing an overindented dictionary body as shown above, followed by a function definition.
2. Use the Signals dock to connect any signal to the existing function.
3. Verify that the editor correctly recognizes the existing function instead of creating a duplicate.