### PR TITLE
Add `Documentation` button to `Inspector` categories

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -55,6 +55,7 @@
 #include "editor/settings/editor_feature_profile.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/animation/tween.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/spin_box.h"
@@ -1829,8 +1830,51 @@ void EditorInspectorCategory::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("unfavorite_all"));
 }
 
+void EditorInspectorCategory::_fade_category_buttons(const float p_fade_amount) {
+	const Ref<Tween> tween = create_tween();
+	tween->tween_property(button_hbox, NodePath("modulate"), Color(1, 1, 1, p_fade_amount), 0.25);
+}
+
+void EditorInspectorCategory::_setup_category_buttons() {
+	button_hbox = memnew(HBoxContainer);
+	button_hbox->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+	button_hbox->set_alignment(BoxContainer::ALIGNMENT_END);
+	button_hbox->set_mouse_filter(MOUSE_FILTER_PASS);
+	button_hbox->set_modulate(Color(1, 1, 1, FADE_AMOUNT));
+	button_hbox->add_theme_constant_override("separation", 0);
+	add_child(button_hbox);
+
+	if (!info.hint_string.is_empty()) {
+		open_docs_button = memnew(Button);
+		open_docs_button->set_tooltip_text(TTRC("Open documentation for this object."));
+		open_docs_button->set_flat(true);
+		open_docs_button->set_button_icon(get_editor_theme_icon(SNAME("Help")));
+		open_docs_button->set_mouse_filter(MOUSE_FILTER_PASS);
+		open_docs_button->connect(SceneStringName(pressed), callable_mp(this, &EditorInspectorCategory::_handle_menu_option).bind(MENU_OPEN_DOCS));
+		button_hbox->add_child(open_docs_button);
+	}
+}
+
 void EditorInspectorCategory::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_READY: {
+			_setup_category_buttons();
+		} break;
+
+		case NOTIFICATION_MOUSE_ENTER: {
+			_fade_category_buttons(1);
+		} break;
+
+		case NOTIFICATION_MOUSE_EXIT: {
+			_fade_category_buttons(FADE_AMOUNT);
+		} break;
+
+		case NOTIFICATION_THEME_CHANGED: {
+			if (open_docs_button) {
+				open_docs_button->set_button_icon(get_editor_theme_icon(SNAME("Help")));
+			}
+		} break;
+
 		case NOTIFICATION_POSTINITIALIZE: {
 			connect(SceneStringName(theme_changed), callable_mp(this, &EditorInspectorCategory::_theme_changed));
 		} break;

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -384,6 +384,8 @@ class EditorInspectorCategory : public Control {
 
 	friend class EditorInspector;
 
+	const float FADE_AMOUNT = 0.25;
+
 	// Right-click context menu options.
 	enum ClassMenuOption {
 		MENU_COPY_VALUE,
@@ -423,11 +425,16 @@ class EditorInspectorCategory : public Control {
 	bool menu_icon_dirty = true;
 	int color_level = -1;
 
+	HBoxContainer *button_hbox = nullptr;
+	Button *open_docs_button = nullptr;
+
 	LocalVector<EditorProperty *> category_properties;
 
 	void _handle_menu_option(int p_option);
 	void _popup_context_menu(const Point2i &p_position);
 	void _update_icon();
+	void _setup_category_buttons();
+	void _fade_category_buttons(float p_fade_amount);
 	void _theme_changed();
 
 protected:


### PR DESCRIPTION
> [!NOTE]
> There will most likely be multiple iterations of this PR, as this seems to be a topic that is hard to gain a consensus on. 😉

Closes https://github.com/godotengine/godot-proposals/issues/14447.
Pairs w/ https://github.com/godotengine/godot/pull/117499 (but can be merged separately if wanted).

This adds a documentation button that will appear when a category is hovered in the inspector. I added a _subtle_ fade to the buttons, as it felt a bit jarring to have them suddenly appear/disappear/gain opacity.

--

https://github.com/user-attachments/assets/bb9d528f-4f89-449b-be00-3d1ebbc05835