### PR TITLE
Fix preprocessor directives for X11 and GLES3

### DIFF
--- a/platform/linuxbsd/x11/gl_manager_x11_egl.cpp
+++ b/platform/linuxbsd/x11/gl_manager_x11_egl.cpp
@@ -57,4 +57,4 @@ Vector<EGLint> GLManagerEGL_X11::_get_platform_context_attribs() const {
 	return ret;
 }
 
-#endif // WINDOWS_ENABLED && GLES3_ENABLED
+#endif // X11_ENABLED && GLES3_ENABLED


### PR DESCRIPTION
Fix preprocessor directive for X11 and GLES3

```
#endif // X11_ENABLED && GLES3_ENABLED
```