### PR TITLE
CI: Keep targeted macOS artifacts for distribution

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -94,7 +94,6 @@ jobs:
       - name: Prepare artifact
         run: |
           lipo -create ./bin/godot.macos.${{ matrix.target }}.x86_64 ./bin/godot.macos.${{ matrix.target }}.arm64 -output ./bin/godot.macos.${{ matrix.target }}.universal
-          rm ./bin/godot.macos.${{ matrix.target }}.x86_64 ./bin/godot.macos.${{ matrix.target }}.arm64
           rm -rf ./bin/build_deps
           strip bin/godot.*
           chmod +x bin/godot.*


### PR DESCRIPTION
This keeps individual macOS `x86_64`/`ARM64` builds for artifact distribution, in addition to `Universal`

Targeted builds have the benefits of decreased file sizes (halved to ~150 MB in this case!) and faster startup, compared to the Universal. Also minor preparation for the future, where new macOS versions will only support ARM64 builds

Tested and works as expected. Your release distribution seems to be handled manually though, so please communicate this change to include them (unless I am mistaken, and I need to do something more here)

Also I would like to request adding this to the 4.6 branch, as this is minor and would help me! Thanks!