### PR TITLE
Fix blend point setter can't restore the name in deprecated=no

### DIFF
--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -321,21 +321,12 @@ bool AnimationNodeBlendSpace1D::_set(const StringName &p_name, const Variant &p_
 	if (prop.begins_with("blend_point_")) {
 		int idx = prop.get_slicec('_', 2).to_int();
 		String what = prop.get_slicec('/', 1);
+		if (idx == blend_points_used && what == "node") {
+			add_blend_point(p_value, 0, -1, StringName(itos(idx)));
+			return true;
+		}
 		if (what == "node") {
-			Ref<AnimationRootNode> node = p_value;
-#ifndef DISABLE_DEPRECATED
-			if (idx == blend_points_used) {
-				add_blend_point(node, 0, -1, blend_points[idx].name.is_empty() ? StringName(itos(idx)) : blend_points[idx].name);
-			} else {
-				set_blend_point_node(idx, node);
-			}
-#else
-			if (idx == blend_points_used) {
-				add_blend_point(node, 0, -1, blend_points[idx].name);
-			} else {
-				set_blend_point_node(idx, node);
-			}
-#endif // DISABLE_DEPRECATED
+			set_blend_point_node(idx, p_value);
 		} else if (what == "pos") {
 			set_blend_point_position(idx, p_value);
 		} else if (what == "name") {

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -393,21 +393,12 @@ bool AnimationNodeBlendSpace2D::_set(const StringName &p_name, const Variant &p_
 	if (prop.begins_with("blend_point_")) {
 		int idx = prop.get_slicec('_', 2).to_int();
 		String what = prop.get_slicec('/', 1);
+		if (idx == blend_points_used && what == "node") {
+			add_blend_point(p_value, Vector2(), -1, StringName(itos(idx)));
+			return true;
+		}
 		if (what == "node") {
-			Ref<AnimationRootNode> node = p_value;
-#ifndef DISABLE_DEPRECATED
-			if (idx == blend_points_used) {
-				add_blend_point(node, Vector2(), -1, blend_points[idx].name.is_empty() ? StringName(itos(idx)) : blend_points[idx].name);
-			} else {
-				set_blend_point_node(idx, node);
-			}
-#else
-			if (idx == blend_points_used) {
-				add_blend_point(node, Vector2(), -1, blend_points[idx].name);
-			} else {
-				set_blend_point_node(idx, node);
-			}
-#endif // DISABLE_DEPRECATED
+			set_blend_point_node(idx, p_value);
 		} else if (what == "pos") {
 			set_blend_point_position(idx, p_value);
 		} else if (what == "name") {


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/117490

The cause of the issue is that `name` is always empty in the following line:

```cpp
		if (what == "node") {
			Ref<AnimationRootNode> node = p_value;
#ifndef DISABLE_DEPRECATED
			if (idx == blend_points_used) {
				add_blend_point(node, Vector2(), -1, blend_points[idx].name.is_empty() ? StringName(itos(idx)) : blend_points[idx].name);
			} else {
				set_blend_point_node(idx, node);
			}
#else
			if (idx == blend_points_used) {
				add_blend_point(node, Vector2(), -1, blend_points[idx].name); // <- Before set name so it always empty on load scene.
			} else {
				set_blend_point_node(idx, node);
			}
#endif // DISABLE_DEPRECATED
```

Ideally, `name` should be the primary key, but since it is more critical that a point cannot be created if `node` is null, we have no choice but to make `node` the primary key.

For now, we will keep `node` as the primary key and insert the `itos` name key regardless of whether it is deprecated. If `name` is set, it will be immediately reset right after restoration, so the `itos` name will not be displayed.
Conflicts may occur if blend_points without a `name` and blend_points with a `name` coexist within a single BlendSpace, but since such cases never happen normally (unless you edit the .tscn directly), this should not be a problem.
