### PR TITLE
 Fix resource previews could not be automatically regenerated

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -1075,11 +1075,10 @@ bool EditorFileSystem::_update_scan_actions() {
 
 	if (reloads.size()) {
 		emit_signal(SNAME("resources_reload"), reloads);
-	}
-
-	for (const String &file : reloads) {
-		// Update preview.
-		EditorResourcePreview::get_singleton()->check_for_invalidation(file);
+		for (const String &file : reloads) {
+			// Update preview.
+			EditorResourcePreview::get_singleton()->check_for_invalidation(file);
+		}
 	}
 
 	scan_actions.clear();
@@ -2521,15 +2520,6 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 				}
 			}
 
-			if (!is_scanning()) {
-				Ref<Resource> res = ResourceCache::get_ref(file);
-				if (res.is_valid()) {
-					res->reload_from_file();
-				}
-				// Update preview
-				EditorResourcePreview::get_singleton()->check_for_invalidation(file);
-			}
-
 			if (ClassDB::is_parent_class(fi->type, SNAME("Script"))) {
 				_queue_update_script_class(file, ScriptClassInfoUpdate::from_file_info(fi));
 			}
@@ -2569,6 +2559,14 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 		if (!filesystem_changed_queued) {
 			filesystem_changed_queued = true;
 			callable_mp(this, &EditorFileSystem::_notify_filesystem_changed).call_deferred();
+		}
+	}
+
+	if (!is_scanning()) {
+		// `update_file()` may be called by a tool script.
+		emit_signal(SNAME("resources_reload"), p_script_paths);
+		for (const String &file : p_script_paths) {
+			EditorResourcePreview::get_singleton()->check_for_invalidation(file); // Update preview.
 		}
 	}
 }

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -1076,6 +1076,12 @@ bool EditorFileSystem::_update_scan_actions() {
 	if (reloads.size()) {
 		emit_signal(SNAME("resources_reload"), reloads);
 	}
+
+	for (const String &file : reloads) {
+		// Update preview.
+		EditorResourcePreview::get_singleton()->check_for_invalidation(file);
+	}
+
 	scan_actions.clear();
 
 	return fs_changed;
@@ -2515,8 +2521,14 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 				}
 			}
 
-			// Update preview
-			EditorResourcePreview::get_singleton()->check_for_invalidation(file);
+			if (!is_scanning()) {
+				Ref<Resource> res = ResourceCache::get_ref(file);
+				if (res.is_valid()) {
+					res->reload_from_file();
+				}
+				// Update preview
+				EditorResourcePreview::get_singleton()->check_for_invalidation(file);
+			}
 
 			if (ClassDB::is_parent_class(fi->type, SNAME("Script"))) {
 				_queue_update_script_class(file, ScriptClassInfoUpdate::from_file_info(fi));
@@ -2793,8 +2805,6 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 				r->set_import_last_modified_time(0);
 			}
 		}
-
-		EditorResourcePreview::get_singleton()->check_for_invalidation(file);
 	}
 
 	return err;
@@ -2875,7 +2885,6 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 			fs->files[cpos]->deps.clear();
 			fs->files[cpos]->type = "";
 			fs->files[cpos]->import_valid = false;
-			EditorResourcePreview::get_singleton()->check_for_invalidation(p_file);
 		}
 		return OK;
 	}
@@ -3075,8 +3084,6 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		}
 	}
 
-	EditorResourcePreview::get_singleton()->check_for_invalidation(p_file);
-
 	print_verbose(vformat("EditorFileSystem: \"%s\" import took %d ms.", p_file, OS::get_singleton()->get_ticks_msec() - start_time));
 
 	ERR_FAIL_COND_V_MSG(err != OK, ERR_FILE_UNRECOGNIZED, "Error importing '" + p_file + "'.");
@@ -3111,6 +3118,10 @@ void EditorFileSystem::reimport_file_with_custom_parameters(const String &p_file
 
 	// Emit the resource_reimported signal for the single file we just reimported.
 	emit_signal(SNAME("resources_reimported"), reloads);
+	for (const String &file : reloads) {
+		// Update preview.
+		EditorResourcePreview::get_singleton()->check_for_invalidation(file);
+	}
 }
 
 Error EditorFileSystem::_copy_file(const String &p_from, const String &p_to) {
@@ -3427,6 +3438,10 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 		emit_signal(SNAME("filesystem_changed"));
 	}
 	emit_signal(SNAME("resources_reimported"), reloads);
+	for (const String &file : reloads) {
+		// Update preview.
+		EditorResourcePreview::get_singleton()->check_for_invalidation(file);
+	}
 	memdelete_notnull(ep);
 }
 
@@ -3441,6 +3456,10 @@ Error EditorFileSystem::reimport_append(const String &p_file, const HashMap<Stri
 
 	// Emit the resource_reimported signal for the single file we just reimported.
 	emit_signal(SNAME("resources_reimported"), reloads);
+	for (const String &file : reloads) {
+		// Update preview.
+		EditorResourcePreview::get_singleton()->check_for_invalidation(file);
+	}
 	return ret;
 }
 

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -166,6 +166,7 @@ void EditorResourcePreview::_preview_ready(const String &p_path, int p_hash, con
 		item.last_hash = p_hash;
 		item.modified_time = modified_time;
 		item.preview_metadata = p_metadata;
+		item.callable = p_callback; // Cached for the regeneration of edited resource previews triggered by file changes.
 
 		cache[p_path] = item;
 	}
@@ -510,7 +511,7 @@ void EditorResourcePreview::_queue_resource_preview(const String &p_path, Object
 
 void EditorResourcePreview::queue_resource_preview(const String &p_path, const Callable &p_callback) {
 	_update_thumbnail_sizes();
-
+	int count = 0;
 	{
 		MutexLock lock(preview_mutex);
 
@@ -524,8 +525,25 @@ void EditorResourcePreview::queue_resource_preview(const String &p_path, const C
 		item.path = p_path;
 		item.callback = p_callback;
 		queue.push_back(item);
+		count++;
+
+		Ref<Resource> res = ResourceCache::get_ref(p_path);
+		if (res.is_valid()) {
+			String path_id = "ID:" + itos(res->get_instance_id());
+			HashMap<String, EditorResourcePreview::Item>::Iterator I = cache.find(path_id);
+			if (I) {
+				QueueItem cached_res_item;
+				cached_res_item.resource = res;
+				cached_res_item.path = path_id;
+				cached_res_item.callback = I->value.callable;
+				queue.push_back(cached_res_item);
+				count++;
+
+				cache.remove(I); // Erase if exists, since it will be regen.
+			}
+		}
 	}
-	preview_sem.post();
+	preview_sem.post(count);
 }
 
 void EditorResourcePreview::add_preview_generator(const Ref<EditorResourcePreviewGenerator> &p_generator) {

--- a/editor/inspector/editor_resource_preview.h
+++ b/editor/inspector/editor_resource_preview.h
@@ -98,6 +98,7 @@ class EditorResourcePreview : public Node {
 		Dictionary preview_metadata;
 		uint32_t last_hash = 0;
 		uint64_t modified_time = 0;
+		Callable callable;
 	};
 
 	HashMap<String, Item> cache;

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -450,14 +450,18 @@ void TileMapLayerEditorTilesPlugin::_update_scenes_collection_view() {
 
 		Ref<PackedScene> scene = scenes_collection_source->get_scene_tile_scene(scene_id);
 
+		Dictionary custom_metadata;
+		custom_metadata["scene_id"] = scene_id;
+
 		int item_index = 0;
 		if (scene.is_valid()) {
+			custom_metadata["path"] = "ID:" + itos(scene->get_instance_id());
 			item_index = scene_tiles_list->add_item(vformat("%s (Path: %s, ID: %d)", scene->get_path().get_file().get_basename(), scene->get_path(), scene_id));
 			EditorResourcePreview::get_singleton()->queue_edited_resource_preview(scene, callable_mp(this, &TileMapLayerEditorTilesPlugin::_scene_thumbnail_done).bind(i));
 		} else {
 			item_index = scene_tiles_list->add_item(TTR("Tile with Invalid Scene"), tiles_bottom_panel->get_editor_theme_icon(SNAME("PackedScene")));
 		}
-		scene_tiles_list->set_item_metadata(item_index, scene_id);
+		scene_tiles_list->set_item_metadata(item_index, custom_metadata);
 
 		// Check if in selection.
 		if (tile_set_selection.has(TileMapCell(source_id, Vector2i(), scene_id))) {
@@ -475,9 +479,16 @@ void TileMapLayerEditorTilesPlugin::_update_scenes_collection_view() {
 }
 
 void TileMapLayerEditorTilesPlugin::_scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_index) {
-	if (p_index >= 0 && p_index < scene_tiles_list->get_item_count()) {
-		scene_tiles_list->set_item_icon(p_index, p_preview);
+	if (p_index < 0 && p_index >= scene_tiles_list->get_item_count()) {
+		return;
 	}
+
+	Dictionary custom_metadata = scene_tiles_list->get_item_metadata(p_index);
+	if (unlikely(custom_metadata.get("path", String()) != p_path)) {
+		return;
+	}
+
+	scene_tiles_list->set_item_icon(p_index, p_preview);
 }
 
 void TileMapLayerEditorTilesPlugin::_scenes_list_multi_selected(int p_index, bool p_selected) {
@@ -492,7 +503,8 @@ void TileMapLayerEditorTilesPlugin::_scenes_list_multi_selected(int p_index, boo
 	}
 
 	// Add or remove the Tile form the selection.
-	int scene_id = scene_tiles_list->get_item_metadata(p_index);
+	Dictionary custom_metadata = scene_tiles_list->get_item_metadata(p_index);
+	int scene_id = custom_metadata["scene_id"];
 	int source_id = sources_list->get_item_metadata(sources_list->get_current());
 	TileSetSource *source = *tile_set->get_source(source_id);
 	TileSetScenesCollectionSource *scenes_collection_source = Object::cast_to<TileSetScenesCollectionSource>(source);

--- a/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -225,13 +225,21 @@ void TileSetScenesCollectionSourceEditor::_tile_set_scenes_collection_source_cha
 }
 
 void TileSetScenesCollectionSourceEditor::_scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_idx) {
-	if (p_idx >= 0 && p_idx < scene_tiles_list->get_item_count()) {
-		scene_tiles_list->set_item_icon(p_idx, p_preview);
+	if (p_idx < 0 || p_idx >= scene_tiles_list->get_item_count()) {
+		return;
 	}
+
+	Dictionary custom_metadata = scene_tiles_list->get_item_metadata(p_idx);
+	if (unlikely(custom_metadata.get("path", String()) != p_path)) {
+		return;
+	}
+
+	scene_tiles_list->set_item_icon(p_idx, p_preview);
 }
 
 void TileSetScenesCollectionSourceEditor::_scenes_list_item_activated(int p_index) {
-	Ref<PackedScene> packed_scene = tile_set_scenes_collection_source->get_scene_tile_scene(scene_tiles_list->get_item_metadata(p_index));
+	Dictionary custom_metadata = scene_tiles_list->get_item_metadata(p_index);
+	Ref<PackedScene> packed_scene = tile_set_scenes_collection_source->get_scene_tile_scene(custom_metadata["scene_id"]);
 	if (packed_scene.is_valid()) {
 		EditorNode::get_singleton()->load_scene(packed_scene->get_path());
 	}
@@ -267,7 +275,8 @@ void TileSetScenesCollectionSourceEditor::_scene_file_selected(const String &p_p
 void TileSetScenesCollectionSourceEditor::_source_delete_pressed() {
 	Vector<int> selected_indices = scene_tiles_list->get_selected_items();
 	ERR_FAIL_COND(selected_indices.is_empty());
-	int scene_id = scene_tiles_list->get_item_metadata(selected_indices[0]);
+	Dictionary custom_metadata = scene_tiles_list->get_item_metadata(selected_indices[0]);
+	int scene_id = custom_metadata["scene_id"];
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Remove a Scene Tile"));
@@ -295,7 +304,8 @@ void TileSetScenesCollectionSourceEditor::_update_tile_inspector() {
 		tile_proxy_object.instantiate(this);
 		tile_proxy_object->connect(CoreStringName(changed), callable_mp(this, &TileSetScenesCollectionSourceEditor::_update_scenes_list).unbind(1));
 		tile_proxy_object->connect(CoreStringName(changed), callable_mp(this, &TileSetScenesCollectionSourceEditor::_update_action_buttons).unbind(1));
-		int scene_id = scene_tiles_list->get_item_metadata(selected_indices[0]);
+		Dictionary custom_metadata = scene_tiles_list->get_item_metadata(selected_indices[0]);
+		int scene_id = custom_metadata["scene_id"];
 		tile_proxy_object->edit(*tile_set_scenes_collection_source, scene_id);
 		tile_inspector->edit(tile_proxy_object.ptr());
 	}
@@ -323,7 +333,11 @@ void TileSetScenesCollectionSourceEditor::_update_scenes_list() {
 
 	// Get the previously selected id.
 	Vector<int> selected_indices = scene_tiles_list->get_selected_items();
-	int old_selected_scene_id = (selected_indices.size() > 0) ? int(scene_tiles_list->get_item_metadata(selected_indices[0])) : -1;
+	int old_selected_scene_id = -1;
+	if (selected_indices.size() > 0) {
+		Dictionary custom_metadata = scene_tiles_list->get_item_metadata(selected_indices[0]);
+		old_selected_scene_id = custom_metadata["scene_id"];
+	}
 
 	// Clear the list.
 	scene_tiles_list->clear();
@@ -335,14 +349,18 @@ void TileSetScenesCollectionSourceEditor::_update_scenes_list() {
 
 		Ref<PackedScene> scene = tile_set_scenes_collection_source->get_scene_tile_scene(scene_id);
 
+		Dictionary custom_metadata;
+		custom_metadata["scene_id"] = scene_id;
+
 		int item_index = 0;
 		if (scene.is_valid()) {
+			custom_metadata["path"] = "ID:" + itos(scene->get_instance_id());
 			item_index = scene_tiles_list->add_item(vformat("%s (path:%s id:%d)", scene->get_path().get_file().get_basename(), scene->get_path(), scene_id));
 			EditorResourcePreview::get_singleton()->queue_edited_resource_preview(scene, callable_mp(this, &TileSetScenesCollectionSourceEditor::_scene_thumbnail_done).bind(i));
 		} else {
 			item_index = scene_tiles_list->add_item(TTR("Tile with Invalid Scene"), get_editor_theme_icon(SNAME("PackedScene")));
 		}
-		scene_tiles_list->set_item_metadata(item_index, scene_id);
+		scene_tiles_list->set_item_metadata(item_index, custom_metadata);
 
 		if (old_selected_scene_id >= 0 && scene_id == old_selected_scene_id) {
 			to_reselect = i;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Ensure that `EditorResourcePreview::check_for_invalidation()` is called after the cached instance is reloaded:
1. For importable files: after the `resources_reimported` signal is emitted;
2. For other files: after the `resources_reload` signal is emitted;

Cache the `callable` within the `cache` of `EditorResourcePreview` to facilitate regenerating the previews for cached resource instances.

When generating a preview for a file, simultaneously attempt to regenerate the preview for its cached instance (if a preview has previously been generated).


Fix #33745.
Fix part of #117048. A complete fix requires using this in conjunction with #117515.


This PR:

https://github.com/user-attachments/assets/c156164a-1421-47ee-96be-7e1bf4edda32


This PR + #117515:

https://github.com/user-attachments/assets/ec220b1e-2d41-41ca-8c3f-53f6185fd4aa




