### PR TITLE
Make `get_modified_time()` return the maximum value of `ctime` and `mtime` on Unix

### DIFF
--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -137,7 +137,9 @@ uint64_t DirAccessUnix::get_modified_time(String p_file) {
 	bool success = (stat(p_file.utf8().get_data(), &flags) == 0);
 
 	if (success) {
-		return flags.st_mtime;
+		// `mv` may only update the ctime, whereas `cp -p` preserves the mtime as well.
+		// The "copy-paste" operation in OS file managers (such as Nemo and Nautilus) also preserves the mtime.
+		return MAX(flags.st_mtime, flags.st_ctime);
 	} else {
 		ERR_FAIL_V(0);
 	}

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -375,15 +375,13 @@ uint64_t FileAccessUnix::_get_modified_time(const String &p_file) {
 		if ((st.st_mode & S_IFMT) == S_IFLNK || (st.st_mode & S_IFMT) == S_IFREG || (st.st_mode & S_IFDIR) == S_IFDIR) {
 			modified_time = st.st_mtime;
 		}
-#ifdef ANDROID_ENABLED
 		// Workaround for GH-101007
-		//FIXME: After saving, all timestamps (st_mtime, st_ctime, st_atime) are set to the same value.
-		// After exporting or after some time, only 'modified_time' resets to a past timestamp.
+		// `mv` may only update the ctime, whereas `cp -p` preserves the mtime as well.
+		// The "copy-paste" operation in OS file managers (such as Nemo and Nautilus) also preserves the mtime.
 		uint64_t created_time = st.st_ctime;
 		if (modified_time < created_time) {
 			modified_time = created_time;
 		}
-#endif
 		return modified_time;
 	} else {
 		return 0;


### PR DESCRIPTION
Since `mv` and `cp -p` may preserve the `mtime`. And the OS file manager seems to behave in accordance with these behaviors.

Files extracted from the same compressed file may have the same timestamp.

Therefore, when using these files to overwrite, from the perspective of the path, the `mtime` may not change, even though the content may have changed.

See https://github.com/godotengine/godot/issues/117048#issuecomment-4064779512.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
