### PR TITLE
Move `ResourceUID::ID` to `ResourceUIDTypes` to decouple `resource_uid.h` from `resource.h`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -132,7 +132,7 @@ bool ResourceLoader::exists(const String &p_path, const String &p_type_hint) {
 	return ::ResourceLoader::exists(p_path, p_type_hint);
 }
 
-ResourceUID::ID ResourceLoader::get_resource_uid(const String &p_path) {
+ResourceUIDTypes::ID ResourceLoader::get_resource_uid(const String &p_path) {
 	return ::ResourceLoader::get_resource_uid(p_path);
 }
 
@@ -175,7 +175,7 @@ Error ResourceSaver::save(RequiredParam<Resource> p_resource, const String &p_pa
 	return ::ResourceSaver::save(p_resource, p_path, p_flags);
 }
 
-Error ResourceSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+Error ResourceSaver::set_uid(const String &p_path, ResourceUIDTypes::ID p_uid) {
 	return ::ResourceSaver::set_uid(p_path, p_uid);
 }
 
@@ -197,7 +197,7 @@ void ResourceSaver::remove_resource_format_saver(Ref<ResourceFormatSaver> p_form
 	::ResourceSaver::remove_resource_format_saver(p_format_saver);
 }
 
-ResourceUID::ID ResourceSaver::get_resource_id_for_path(const String &p_path, bool p_generate) {
+ResourceUIDTypes::ID ResourceSaver::get_resource_id_for_path(const String &p_path, bool p_generate) {
 	return ::ResourceSaver::get_resource_id_for_path(p_path, p_generate);
 }
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -34,6 +34,7 @@
 #include "core/io/logger.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/io/resource_uid_types.h"
 #include "core/object/class_db.h"
 #include "core/object/script_backtrace.h"
 #include "core/os/semaphore.h"
@@ -83,7 +84,7 @@ public:
 	bool has_cached(const String &p_path);
 	Ref<Resource> get_cached_ref(const String &p_path);
 	bool exists(const String &p_path, const String &p_type_hint = "");
-	ResourceUID::ID get_resource_uid(const String &p_path);
+	ResourceUIDTypes::ID get_resource_uid(const String &p_path);
 
 	Vector<String> list_directory(const String &p_directory);
 
@@ -112,12 +113,12 @@ public:
 	static ResourceSaver *get_singleton() { return singleton; }
 
 	Error save(RequiredParam<Resource> p_resource, const String &p_path, BitField<SaverFlags> p_flags);
-	Error set_uid(const String &p_path, ResourceUID::ID p_uid);
+	Error set_uid(const String &p_path, ResourceUIDTypes::ID p_uid);
 	Vector<String> get_recognized_extensions(const Ref<Resource> &p_resource);
 	void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front);
 	void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);
 
-	ResourceUID::ID get_resource_id_for_path(const String &p_path, bool p_generate = false);
+	ResourceUIDTypes::ID get_resource_id_for_path(const String &p_path, bool p_generate = false);
 
 	ResourceSaver() { singleton = this; }
 };

--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -34,6 +34,7 @@
 #include "core/io/resource.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/io/resource_uid_types.h"
 #include "core/object/ref_counted.h"
 
 class CryptoKey : public Resource {
@@ -155,7 +156,7 @@ public:
 	virtual String get_resource_type(const String &p_path) const override;
 
 	// Treat certificates as text files, do not generate a `*.{crt,key,pub}.uid` file.
-	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override { return ResourceUID::INVALID_ID; }
+	virtual ResourceUIDTypes::ID get_resource_uid(const String &p_path) const override { return ResourceUIDTypes::INVALID_ID; }
 	virtual bool has_custom_uid_support() const override { return true; }
 };
 

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -38,6 +38,7 @@
 #include "core/io/file_access_pack.h"
 #include "core/io/marshalls.h"
 #include "core/io/resource_uid.h"
+#include "core/io/resource_uid_types.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/os/time.h"
@@ -260,7 +261,7 @@ String FileAccess::fix_path(const String &p_path) const {
 		case ACCESS_RESOURCES: {
 			if (ProjectSettings::get_singleton()) {
 				if (r_path.begins_with("uid://")) {
-					ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(r_path);
+					ResourceUIDTypes::ID uid = ResourceUID::get_singleton()->text_to_id(r_path);
 					if (ResourceUID::get_singleton()->has_id(uid)) {
 						r_path = ResourceUID::get_singleton()->get_id_path(uid);
 					} else {

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -34,6 +34,7 @@
 #include "core/error/error_macros.h"
 #include "core/io/image_loader.h"
 #include "core/io/resource_loader.h"
+#include "core/io/resource_uid.h"
 #include "core/math/math_funcs.h"
 #include "core/object/class_db.h"
 #include "core/templates/hash_map.h"

--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -30,6 +30,7 @@
 
 #include "image_loader.h"
 
+#include "core/io/resource_uid.h"
 #include "core/object/class_db.h"
 
 void ImageFormatLoader::_bind_methods() {

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -33,6 +33,7 @@
 #include "core/io/resource.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/io/resource_uid_types.h"
 #include "core/variant/variant.h"
 
 class JSON : public Resource {
@@ -116,7 +117,7 @@ public:
 	virtual String get_resource_type(const String &p_path) const override;
 
 	// Treat JSON as a text file, do not generate a `*.json.uid` file.
-	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override { return ResourceUID::INVALID_ID; }
+	virtual ResourceUIDTypes::ID get_resource_uid(const String &p_path) const override { return ResourceUIDTypes::INVALID_ID; }
 	virtual bool has_custom_uid_support() const override { return true; }
 };
 

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/io/resource_uid.h" // IWYU pragma: export. Make available to all resources.
 #include "core/object/gdvirtual.gen.h"
 #include "core/object/ref_counted.h"
 #include "core/templates/self_list.h"

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -34,6 +34,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access_compressed.h"
 #include "core/io/missing_resource.h"
+#include "core/io/resource_uid.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "core/version.h"
@@ -959,7 +960,7 @@ void ResourceLoaderBinary::get_dependencies(Ref<FileAccess> p_f, List<String> *p
 		String dep;
 		String fallback_path;
 
-		if (external_resources[i].uid != ResourceUID::INVALID_ID) {
+		if (external_resources[i].uid != ResourceUIDTypes::INVALID_ID) {
 			dep = ResourceUID::get_singleton()->id_to_text(external_resources[i].uid);
 			fallback_path = external_resources[i].path; // Used by Dependency Editor, in case uid path fails.
 		} else {
@@ -1045,10 +1046,10 @@ void ResourceLoaderBinary::open(Ref<FileAccess> p_f, bool p_no_resources, bool p
 	f->real_is_double = (flags & ResourceFormatSaverBinaryInstance::FORMAT_FLAG_REAL_T_IS_DOUBLE) != 0;
 
 	if (using_uids) {
-		uid = ResourceUID::ID(f->get_64());
+		uid = ResourceUIDTypes::ID(f->get_64());
 	} else {
 		f->get_64(); // skip over uid field
-		uid = ResourceUID::INVALID_ID;
+		uid = ResourceUIDTypes::INVALID_ID;
 	}
 
 	if (flags & ResourceFormatSaverBinaryInstance::FORMAT_FLAG_HAS_SCRIPT_CLASS) {
@@ -1078,8 +1079,8 @@ void ResourceLoaderBinary::open(Ref<FileAccess> p_f, bool p_no_resources, bool p
 		er.type = get_unicode_string();
 		er.path = get_unicode_string();
 		if (using_uids) {
-			er.uid = ResourceUID::ID(f->get_64());
-			if (!p_keep_uuid_paths && er.uid != ResourceUID::INVALID_ID) {
+			er.uid = ResourceUIDTypes::ID(f->get_64());
+			if (!p_keep_uuid_paths && er.uid != ResourceUIDTypes::INVALID_ID) {
 				if (ResourceUID::get_singleton()->has_id(er.uid)) {
 					// If a UID is found and the path is valid, it will be used, otherwise, it falls back to the path.
 					er.path = ResourceUID::get_singleton()->get_id_path(er.uid);
@@ -1436,8 +1437,8 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		String path = get_ustring(f);
 
 		if (using_uids) {
-			ResourceUID::ID uid = f->get_64();
-			if (uid != ResourceUID::INVALID_ID) {
+			ResourceUIDTypes::ID uid = f->get_64();
+			if (uid != ResourceUIDTypes::INVALID_ID) {
 				if (ResourceUID::get_singleton()->has_id(uid)) {
 					// If a UID is found and the path is valid, it will be used, otherwise, it falls back to the path.
 					path = ResourceUID::get_singleton()->get_id_path(uid);
@@ -1467,7 +1468,7 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		save_ustring(fw, path);
 
 		if (using_uids) {
-			ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(full_path);
+			ResourceUIDTypes::ID uid = ResourceSaver::get_resource_id_for_path(full_path);
 			fw->store_64(uint64_t(uid));
 		}
 	}
@@ -1584,15 +1585,15 @@ String ResourceFormatLoaderBinary::get_resource_script_class(const String &p_pat
 	return loader.recognize_script_class(f);
 }
 
-ResourceUID::ID ResourceFormatLoaderBinary::get_resource_uid(const String &p_path) const {
+ResourceUIDTypes::ID ResourceFormatLoaderBinary::get_resource_uid(const String &p_path) const {
 	String ext = p_path.get_extension().to_lower();
 	if (!ClassDB::is_resource_extension(ext)) {
-		return ResourceUID::INVALID_ID;
+		return ResourceUIDTypes::INVALID_ID;
 	}
 
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	if (f.is_null()) {
-		return ResourceUID::INVALID_ID; //could not read
+		return ResourceUIDTypes::INVALID_ID; //could not read
 	}
 
 	ResourceLoaderBinary loader;
@@ -1600,7 +1601,7 @@ ResourceUID::ID ResourceFormatLoaderBinary::get_resource_uid(const String &p_pat
 	loader.res_path = loader.local_path;
 	loader.open(f, true);
 	if (loader.error != OK) {
-		return ResourceUID::INVALID_ID; //could not read
+		return ResourceUIDTypes::INVALID_ID; //could not read
 	}
 	return loader.uid;
 }
@@ -2239,7 +2240,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 
 		f->store_32(format_flags);
 	}
-	ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(p_path, true);
+	ResourceUIDTypes::ID uid = ResourceSaver::get_resource_id_for_path(p_path, true);
 	f->store_64(uint64_t(uid));
 	if (!script_class.is_empty()) {
 		save_unicode_string(f, script_class);
@@ -2326,7 +2327,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 		String res_path = save_order[i]->get_path();
 		res_path = relative_paths ? local_path.path_to_file(res_path) : res_path;
 		save_unicode_string(f, res_path);
-		ResourceUID::ID ruid = ResourceSaver::get_resource_id_for_path(save_order[i]->get_path(), false);
+		ResourceUIDTypes::ID ruid = ResourceSaver::get_resource_id_for_path(save_order[i]->get_path(), false);
 		f->store_64(uint64_t(ruid));
 	}
 	// save internal resource table
@@ -2409,7 +2410,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 	return OK;
 }
 
-Error ResourceFormatSaverBinaryInstance::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+Error ResourceFormatSaverBinaryInstance::set_uid(const String &p_path, ResourceUIDTypes::ID p_uid) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, vformat("Cannot open file '%s'.", p_path));
 
@@ -2528,7 +2529,7 @@ Error ResourceFormatSaverBinary::save(const Ref<Resource> &p_resource, const Str
 	return saver.save(local_path, p_resource, p_flags);
 }
 
-Error ResourceFormatSaverBinary::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+Error ResourceFormatSaverBinary::set_uid(const String &p_path, ResourceUIDTypes::ID p_uid) {
 	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	ResourceFormatSaverBinaryInstance saver;
 	return saver.set_uid(local_path, p_uid);

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -33,6 +33,7 @@
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/io/resource_uid_types.h"
 #include "core/templates/rb_map.h"
 
 class ResourceLoaderBinary {
@@ -47,7 +48,7 @@ class ResourceLoaderBinary {
 
 	uint64_t importmd_ofs = 0;
 
-	ResourceUID::ID uid = ResourceUID::INVALID_ID;
+	ResourceUIDTypes::ID uid = ResourceUIDTypes::INVALID_ID;
 
 	Vector<char> str_buf;
 	List<Ref<Resource>> resource_cache;
@@ -59,7 +60,7 @@ class ResourceLoaderBinary {
 	struct ExtResource {
 		String path;
 		String type;
-		ResourceUID::ID uid = ResourceUID::INVALID_ID;
+		ResourceUIDTypes::ID uid = ResourceUIDTypes::INVALID_ID;
 		Ref<ResourceLoader::LoadToken> load_token;
 	};
 
@@ -117,7 +118,7 @@ public:
 	virtual String get_resource_type(const String &p_path) const override;
 	virtual String get_resource_script_class(const String &p_path) const override;
 	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes) override;
-	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override;
+	virtual ResourceUIDTypes::ID get_resource_uid(const String &p_path) const override;
 	virtual bool has_custom_uid_support() const override;
 	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false) override;
 	virtual Error rename_dependencies(const String &p_path, const HashMap<String, String> &p_map) override;
@@ -175,7 +176,7 @@ public:
 		RESERVED_FIELDS = 11
 	};
 	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
-	Error set_uid(const String &p_path, ResourceUID::ID p_uid);
+	Error set_uid(const String &p_path, ResourceUIDTypes::ID p_uid);
 	static void write_variant(Ref<FileAccess> f, const Variant &p_property, HashMap<Ref<Resource>, int> &resource_map, HashMap<Ref<Resource>, int> &external_resources, HashMap<StringName, int> &string_map, const PropertyInfo &p_hint = PropertyInfo());
 };
 
@@ -185,7 +186,7 @@ class ResourceFormatSaverBinary : public ResourceFormatSaver {
 public:
 	static inline ResourceFormatSaverBinary *singleton = nullptr;
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
-	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
+	virtual Error set_uid(const String &p_path, ResourceUIDTypes::ID p_uid) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/config_file.h"
 #include "core/io/image.h"
+#include "core/io/resource_uid.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/variant/variant_parser.h"
@@ -393,12 +394,12 @@ String ResourceFormatImporter::get_resource_type(const String &p_path) const {
 	return pat.type;
 }
 
-ResourceUID::ID ResourceFormatImporter::get_resource_uid(const String &p_path) const {
+ResourceUIDTypes::ID ResourceFormatImporter::get_resource_uid(const String &p_path) const {
 	PathAndType pat;
 	Error err = _get_path_and_type(p_path, pat, false);
 
 	if (err != OK) {
-		return ResourceUID::INVALID_ID;
+		return ResourceUIDTypes::INVALID_ID;
 	}
 
 	return pat.uid;
@@ -408,7 +409,7 @@ bool ResourceFormatImporter::has_custom_uid_support() const {
 	return true;
 }
 
-Error ResourceFormatImporter::get_resource_import_info(const String &p_path, StringName &r_type, ResourceUID::ID &r_uid, String &r_import_group_file) const {
+Error ResourceFormatImporter::get_resource_import_info(const String &p_path, StringName &r_type, ResourceUIDTypes::ID &r_uid, String &r_import_group_file) const {
 	PathAndType pat;
 	Error err = _get_path_and_type(p_path, pat, false);
 
@@ -418,7 +419,7 @@ Error ResourceFormatImporter::get_resource_import_info(const String &p_path, Str
 		r_import_group_file = pat.group_file;
 	} else {
 		r_type = "";
-		r_uid = ResourceUID::INVALID_ID;
+		r_uid = ResourceUIDTypes::INVALID_ID;
 		r_import_group_file = "";
 	}
 
@@ -588,7 +589,7 @@ void ResourceImporter::_bind_methods() {
 
 /////
 
-Error ResourceFormatImporterSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+Error ResourceFormatImporterSaver::set_uid(const String &p_path, ResourceUIDTypes::ID p_uid) {
 	Ref<ConfigFile> cf;
 	cf.instantiate();
 	Error err = cf->load(p_path + ".import");

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -32,6 +32,7 @@
 
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/io/resource_uid_types.h"
 
 class ResourceImporter;
 class ResourceFormatImporter;
@@ -47,7 +48,7 @@ class ResourceFormatImporter : public ResourceFormatLoader {
 		String importer;
 		String group_file;
 		Variant metadata;
-		ResourceUID::ID uid = ResourceUID::INVALID_ID;
+		ResourceUIDTypes::ID uid = ResourceUIDTypes::INVALID_ID;
 	};
 
 	Error _get_path_and_type(const String &p_path, PathAndType &r_path_and_type, bool p_load, bool *r_valid = nullptr) const;
@@ -70,7 +71,7 @@ public:
 	virtual bool recognize_path(const String &p_path, const String &p_for_type = String()) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
-	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override;
+	virtual ResourceUIDTypes::ID get_resource_uid(const String &p_path) const override;
 	virtual bool has_custom_uid_support() const override;
 	virtual Variant get_resource_metadata(const String &p_path) const;
 	virtual bool is_import_valid(const String &p_path) const override;
@@ -101,7 +102,7 @@ public:
 	String get_import_settings_hash() const;
 
 	String get_import_base_path(const String &p_for_file) const;
-	Error get_resource_import_info(const String &p_path, StringName &r_type, ResourceUID::ID &r_uid, String &r_import_group_file) const;
+	Error get_resource_import_info(const String &p_path, StringName &r_type, ResourceUIDTypes::ID &r_uid, String &r_import_group_file) const;
 
 	ResourceFormatImporter();
 };
@@ -153,7 +154,7 @@ public:
 	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const {}
 	virtual String get_option_group_file() const { return String(); }
 
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) = 0;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) = 0;
 	virtual bool can_import_threaded() const { return false; }
 	virtual void import_threaded_begin() {}
 	virtual void import_threaded_end() {}
@@ -171,5 +172,5 @@ class ResourceFormatImporterSaver : public ResourceFormatSaver {
 	GDCLASS(ResourceFormatImporterSaver, ResourceFormatSaver)
 
 public:
-	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
+	virtual Error set_uid(const String &p_path, ResourceUIDTypes::ID p_uid) override;
 };

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -36,6 +36,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/object/message_queue.h"
@@ -115,8 +116,8 @@ String ResourceFormatLoader::get_resource_script_class(const String &p_path) con
 	return ret;
 }
 
-ResourceUID::ID ResourceFormatLoader::get_resource_uid(const String &p_path) const {
-	int64_t uid = ResourceUID::INVALID_ID;
+ResourceUIDTypes::ID ResourceFormatLoader::get_resource_uid(const String &p_path) const {
+	int64_t uid = ResourceUIDTypes::INVALID_ID;
 	if (has_custom_uid_support()) {
 		GDVIRTUAL_CALL(_get_resource_uid, p_path, uid);
 	} else {
@@ -475,8 +476,8 @@ void ResourceLoader::_run_load_task(void *p_userdata) {
 }
 
 String ResourceLoader::_validate_local_path(const String &p_path) {
-	ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(p_path);
-	if (uid != ResourceUID::INVALID_ID) {
+	ResourceUIDTypes::ID uid = ResourceUID::get_singleton()->text_to_id(p_path);
+	if (uid != ResourceUIDTypes::INVALID_ID) {
 		return ResourceUID::get_singleton()->get_id_path(uid);
 	} else if (p_path.is_relative_path()) {
 		return ("res://" + p_path).simplify_path();
@@ -1201,20 +1202,20 @@ String ResourceLoader::get_resource_script_class(const String &p_path) {
 	return "";
 }
 
-ResourceUID::ID ResourceLoader::get_resource_uid(const String &p_path) {
+ResourceUIDTypes::ID ResourceLoader::get_resource_uid(const String &p_path) {
 	const String local_path = _validate_local_path(p_path);
 	if (!Engine::get_singleton()->is_editor_hint()) {
 		return ResourceUID::get_singleton()->get_path_id(local_path);
 	}
 
 	for (int i = 0; i < loader_count; i++) {
-		ResourceUID::ID id = loader[i]->get_resource_uid(local_path);
-		if (id != ResourceUID::INVALID_ID) {
+		ResourceUIDTypes::ID id = loader[i]->get_resource_uid(local_path);
+		if (id != ResourceUIDTypes::INVALID_ID) {
 			return id;
 		}
 	}
 
-	return ResourceUID::INVALID_ID;
+	return ResourceUIDTypes::INVALID_ID;
 }
 
 bool ResourceLoader::should_create_uid_file(const String &p_path) {

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/resource.h"
+#include "core/io/resource_uid_types.h"
 #include "core/object/gdvirtual.gen.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/os/thread.h"
@@ -64,7 +65,7 @@ protected:
 	GDVIRTUAL1RC(bool, _handles_type, StringName)
 	GDVIRTUAL1RC(String, _get_resource_type, String)
 	GDVIRTUAL1RC(String, _get_resource_script_class, String)
-	GDVIRTUAL1RC(ResourceUID::ID, _get_resource_uid, String)
+	GDVIRTUAL1RC(ResourceUIDTypes::ID, _get_resource_uid, String)
 	GDVIRTUAL2RC(Vector<String>, _get_dependencies, String, bool)
 	GDVIRTUAL1RC(Vector<String>, _get_classes_used, String)
 	GDVIRTUAL2RC(Error, _rename_dependencies, String, Dictionary)
@@ -82,7 +83,7 @@ public:
 	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes);
 	virtual String get_resource_type(const String &p_path) const;
 	virtual String get_resource_script_class(const String &p_path) const;
-	virtual ResourceUID::ID get_resource_uid(const String &p_path) const;
+	virtual ResourceUIDTypes::ID get_resource_uid(const String &p_path) const;
 	virtual bool has_custom_uid_support() const;
 	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false);
 	virtual Error rename_dependencies(const String &p_path, const HashMap<String, String> &p_map);
@@ -250,7 +251,7 @@ public:
 	static void get_classes_used(const String &p_path, HashSet<StringName> *r_classes);
 	static String get_resource_type(const String &p_path);
 	static String get_resource_script_class(const String &p_path);
-	static ResourceUID::ID get_resource_uid(const String &p_path);
+	static ResourceUIDTypes::ID get_resource_uid(const String &p_path);
 	static bool should_create_uid_file(const String &p_path);
 	static void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false);
 	static Error rename_dependencies(const String &p_path, const HashMap<String, String> &p_map);

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -49,7 +49,7 @@ Error ResourceFormatSaver::save(const Ref<Resource> &p_resource, const String &p
 	return err;
 }
 
-Error ResourceFormatSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+Error ResourceFormatSaver::set_uid(const String &p_path, ResourceUIDTypes::ID p_uid) {
 	Error err = ERR_FILE_UNRECOGNIZED;
 	GDVIRTUAL_CALL(_set_uid, p_path, p_uid, err);
 	return err;
@@ -154,7 +154,7 @@ Error ResourceSaver::save(RequiredParam<Resource> rp_resource, const String &p_p
 	return err;
 }
 
-Error ResourceSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+Error ResourceSaver::set_uid(const String &p_path, ResourceUIDTypes::ID p_uid) {
 	String path = p_path;
 
 	ERR_FAIL_COND_V_MSG(path.is_empty(), ERR_INVALID_PARAMETER, "Can't update UID to empty path. Provide non-empty path.");
@@ -282,11 +282,11 @@ void ResourceSaver::remove_custom_savers() {
 	}
 }
 
-ResourceUID::ID ResourceSaver::get_resource_id_for_path(const String &p_path, bool p_generate) {
+ResourceUIDTypes::ID ResourceSaver::get_resource_id_for_path(const String &p_path, bool p_generate) {
 	if (save_get_id_for_path) {
 		return save_get_id_for_path(p_path, p_generate);
 	}
-	return ResourceUID::INVALID_ID;
+	return ResourceUIDTypes::INVALID_ID;
 }
 
 void ResourceSaver::set_get_resource_id_for_path(ResourceSaverGetResourceIDForPath p_callback) {

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/resource.h"
+#include "core/io/resource_uid_types.h"
 #include "core/object/gdvirtual.gen.h"
 
 class ResourceFormatSaver : public RefCounted {
@@ -40,14 +41,14 @@ protected:
 	static void _bind_methods();
 
 	GDVIRTUAL3R(Error, _save, Ref<Resource>, String, uint32_t)
-	GDVIRTUAL2R(Error, _set_uid, String, ResourceUID::ID)
+	GDVIRTUAL2R(Error, _set_uid, String, ResourceUIDTypes::ID)
 	GDVIRTUAL1RC(bool, _recognize, Ref<Resource>)
 	GDVIRTUAL1RC(Vector<String>, _get_recognized_extensions, Ref<Resource>)
 	GDVIRTUAL2RC(bool, _recognize_path, Ref<Resource>, String)
 
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
-	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid);
+	virtual Error set_uid(const String &p_path, ResourceUIDTypes::ID p_uid);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 	virtual bool recognize_path(const Ref<Resource> &p_resource, const String &p_path) const;
@@ -56,7 +57,7 @@ public:
 };
 
 typedef void (*ResourceSavedCallback)(Ref<Resource> p_resource, const String &p_path);
-typedef ResourceUID::ID (*ResourceSaverGetResourceIDForPath)(const String &p_path, bool p_generate);
+typedef ResourceUIDTypes::ID (*ResourceSaverGetResourceIDForPath)(const String &p_path, bool p_generate);
 
 class ResourceSaver {
 	enum {
@@ -88,12 +89,12 @@ public:
 	static void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front = false);
 	static void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);
 
-	static Error set_uid(const String &p_path, ResourceUID::ID p_uid);
+	static Error set_uid(const String &p_path, ResourceUIDTypes::ID p_uid);
 
 	static void set_timestamp_on_save(bool p_timestamp) { timestamp_on_save = p_timestamp; }
 	static bool get_timestamp_on_save() { return timestamp_on_save; }
 
-	static ResourceUID::ID get_resource_id_for_path(const String &p_path, bool p_generate = false);
+	static ResourceUIDTypes::ID get_resource_id_for_path(const String &p_path, bool p_generate = false);
 
 	static void set_save_callback(ResourceSavedCallback p_callback);
 	static void set_get_resource_id_for_path(ResourceSaverGetResourceIDForPath p_callback);

--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -52,7 +52,7 @@ static constexpr uint8_t uuid_characters[] = { 'a', 'b', 'c', 'd', 'e', 'f', 'g'
 static constexpr uint32_t uuid_characters_element_count = std_size(uuid_characters);
 static constexpr uint8_t max_uuid_number_length = 13; // Max 0x7FFFFFFFFFFFFFFF (uid://d4n4ub6itg400) size is 13 characters.
 
-String ResourceUID::id_to_text(ID p_id) const {
+String ResourceUID::id_to_text(ResourceUIDTypes::ID p_id) const {
 	if (p_id < 0) {
 		return "uid://<invalid>";
 	}
@@ -89,9 +89,9 @@ String ResourceUID::id_to_text(ID p_id) const {
 	return txt;
 }
 
-ResourceUID::ID ResourceUID::text_to_id(const String &p_text) const {
+ResourceUIDTypes::ID ResourceUID::text_to_id(const String &p_text) const {
 	if (!p_text.begins_with("uid://") || p_text == "uid://<invalid>") {
-		return INVALID_ID;
+		return ResourceUIDTypes::INVALID_ID;
 	}
 
 	uint32_t l = p_text.length();
@@ -104,13 +104,13 @@ ResourceUID::ID ResourceUID::text_to_id(const String &p_text) const {
 		} else if (is_digit(c)) {
 			uid += c - '0' + char_count;
 		} else {
-			return INVALID_ID;
+			return ResourceUIDTypes::INVALID_ID;
 		}
 	}
-	return ID(uid & 0x7FFFFFFFFFFFFFFF);
+	return ResourceUIDTypes::ID(uid & 0x7FFFFFFFFFFFFFFF);
 }
 
-ResourceUID::ID ResourceUID::create_id() {
+ResourceUIDTypes::ID ResourceUID::create_id() {
 	// mbedTLS may not be fully initialized when the ResourceUID is created, so we
 	// need to lazily instantiate the random number generator.
 	if (crypto == nullptr) {
@@ -119,10 +119,10 @@ ResourceUID::ID ResourceUID::create_id() {
 	}
 
 	while (true) {
-		ID id = INVALID_ID;
+		ResourceUIDTypes::ID id = ResourceUIDTypes::INVALID_ID;
 		MutexLock lock(mutex);
 		Error err = ((CryptoCore::RandomGenerator *)crypto)->get_random_bytes((uint8_t *)&id, sizeof(id));
-		ERR_FAIL_COND_V(err != OK, INVALID_ID);
+		ERR_FAIL_COND_V(err != OK, ResourceUIDTypes::INVALID_ID);
 		id &= 0x7FFFFFFFFFFFFFFF;
 		bool exists = unique_ids.has(id);
 		if (!exists) {
@@ -131,8 +131,8 @@ ResourceUID::ID ResourceUID::create_id() {
 	}
 }
 
-ResourceUID::ID ResourceUID::create_id_for_path(const String &p_path) {
-	ID id = INVALID_ID;
+ResourceUIDTypes::ID ResourceUID::create_id_for_path(const String &p_path) {
+	ResourceUIDTypes::ID id = ResourceUIDTypes::INVALID_ID;
 	RandomPCG rng;
 
 	const String project_name = GLOBAL_GET("application/config/name");
@@ -154,12 +154,12 @@ ResourceUID::ID ResourceUID::create_id_for_path(const String &p_path) {
 	return id;
 }
 
-bool ResourceUID::has_id(ID p_id) const {
+bool ResourceUID::has_id(ResourceUIDTypes::ID p_id) const {
 	MutexLock l(mutex);
 	return unique_ids.has(p_id);
 }
 
-void ResourceUID::add_id(ID p_id, const String &p_path) {
+void ResourceUID::add_id(ResourceUIDTypes::ID p_id, const String &p_path) {
 	MutexLock l(mutex);
 	ERR_FAIL_COND(unique_ids.has(p_id));
 	Cache c;
@@ -171,7 +171,7 @@ void ResourceUID::add_id(ID p_id, const String &p_path) {
 	changed = true;
 }
 
-void ResourceUID::set_id(ID p_id, const String &p_path) {
+void ResourceUID::set_id(ResourceUIDTypes::ID p_id, const String &p_path) {
 	MutexLock l(mutex);
 	ERR_FAIL_COND(!unique_ids.has(p_id));
 	CharString cs = p_path.utf8();
@@ -190,8 +190,8 @@ void ResourceUID::set_id(ID p_id, const String &p_path) {
 	}
 }
 
-String ResourceUID::get_id_path(ID p_id) const {
-	ERR_FAIL_COND_V_MSG(p_id == INVALID_ID, String(), "Invalid UID.");
+String ResourceUID::get_id_path(ResourceUIDTypes::ID p_id) const {
+	ERR_FAIL_COND_V_MSG(p_id == ResourceUIDTypes::INVALID_ID, String(), "Invalid UID.");
 	MutexLock l(mutex);
 	const ResourceUID::Cache *cache = unique_ids.getptr(p_id);
 
@@ -212,15 +212,15 @@ String ResourceUID::get_id_path(ID p_id) const {
 	return String::utf8(cs.ptr());
 }
 
-ResourceUID::ID ResourceUID::get_path_id(const String &p_path) const {
-	const ID *id = reverse_cache.getptr(p_path.utf8());
+ResourceUIDTypes::ID ResourceUID::get_path_id(const String &p_path) const {
+	const ResourceUIDTypes::ID *id = reverse_cache.getptr(p_path.utf8());
 	if (id) {
 		return *id;
 	}
-	return INVALID_ID;
+	return ResourceUIDTypes::INVALID_ID;
 }
 
-void ResourceUID::remove_id(ID p_id) {
+void ResourceUID::remove_id(ResourceUIDTypes::ID p_id) {
 	MutexLock l(mutex);
 	ERR_FAIL_COND(!unique_ids.has(p_id));
 	if (use_reverse_cache) {
@@ -234,8 +234,8 @@ String ResourceUID::uid_to_path(const String &p_uid) {
 }
 
 String ResourceUID::path_to_uid(const String &p_path) {
-	const ID id = ResourceLoader::get_resource_uid(p_path);
-	if (id == INVALID_ID) {
+	const ResourceUIDTypes::ID id = ResourceLoader::get_resource_uid(p_path);
+	if (id == ResourceUIDTypes::INVALID_ID) {
 		return p_path;
 	} else {
 		return singleton->id_to_text(id);
@@ -249,12 +249,12 @@ String ResourceUID::ensure_path(const String &p_uid_or_path) {
 	return p_uid_or_path;
 }
 
-Vector<uint8_t> ResourceUID::encode_binary_cache(const Vector<Pair<ID, String>> &p_entries) {
+Vector<uint8_t> ResourceUID::encode_binary_cache(const Vector<Pair<ResourceUIDTypes::ID, String>> &p_entries) {
 	Ref<StreamPeerBuffer> buffer;
 	buffer.instantiate();
 	buffer->put_u32(p_entries.size());
 
-	for (const Pair<ID, String> &entry : p_entries) {
+	for (const Pair<ResourceUIDTypes::ID, String> &entry : p_entries) {
 		buffer->put_u64(uint64_t(entry.first));
 		CharString cs = entry.second.utf8();
 		buffer->put_u32(cs.length());
@@ -278,12 +278,12 @@ Error ResourceUID::save_to_cache() {
 
 	MutexLock l(mutex);
 
-	Vector<Pair<ID, String>> entries;
+	Vector<Pair<ResourceUIDTypes::ID, String>> entries;
 	entries.reserve(unique_ids.size());
 	cache_entries = 0;
 
-	for (KeyValue<ID, Cache> &E : unique_ids) {
-		entries.push_back(Pair<ID, String>(E.key, String::utf8(E.value.cs.ptr(), E.value.cs.length())));
+	for (KeyValue<ResourceUIDTypes::ID, Cache> &E : unique_ids) {
+		entries.push_back(Pair<ResourceUIDTypes::ID, String>(E.key, String::utf8(E.value.cs.ptr(), E.value.cs.length())));
 		E.value.saved_to_cache = true;
 		cache_entries++;
 	}
@@ -343,7 +343,7 @@ Error ResourceUID::update_cache() {
 	MutexLock l(mutex);
 
 	Ref<FileAccess> f;
-	for (KeyValue<ID, Cache> &E : unique_ids) {
+	for (KeyValue<ResourceUIDTypes::ID, Cache> &E : unique_ids) {
 		if (!E.value.saved_to_cache) {
 			if (f.is_null()) {
 				f = FileAccess::open(get_cache_file(), FileAccess::READ_WRITE); // Append.
@@ -373,7 +373,7 @@ Error ResourceUID::update_cache() {
 
 String ResourceUID::get_path_from_cache(Ref<FileAccess> &p_cache_file, const String &p_uid_string) {
 	const int64_t uid_from_string = singleton->text_to_id(p_uid_string);
-	if (uid_from_string != INVALID_ID) {
+	if (uid_from_string != ResourceUIDTypes::INVALID_ID) {
 		const uint32_t entry_count = p_cache_file->get_32();
 		for (uint32_t i = 0; i < entry_count; i++) {
 			int64_t id = p_cache_file->get_64();
@@ -422,7 +422,7 @@ void ResourceUID::_bind_methods() {
 	ClassDB::bind_static_method("ResourceUID", D_METHOD("path_to_uid", "path"), &ResourceUID::path_to_uid);
 	ClassDB::bind_static_method("ResourceUID", D_METHOD("ensure_path", "path_or_uid"), &ResourceUID::ensure_path);
 
-	BIND_CONSTANT(INVALID_ID)
+	BIND_CONSTANT(ResourceUIDTypes::INVALID_ID)
 }
 ResourceUID *ResourceUID::singleton = nullptr;
 ResourceUID::ResourceUID() {

--- a/core/io/resource_uid.h
+++ b/core/io/resource_uid.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/io/resource_uid_types.h"
 #include "core/object/object.h"
 #include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
@@ -41,9 +42,6 @@ typedef void (*ResourceUIDScanForUIDOnStartup)();
 class ResourceUID : public Object {
 	GDCLASS(ResourceUID, Object)
 public:
-	typedef int64_t ID;
-	constexpr const static ID INVALID_ID = -1;
-
 	static String get_cache_file();
 
 private:
@@ -54,9 +52,9 @@ private:
 		bool saved_to_cache = false;
 	};
 
-	HashMap<ID, Cache> unique_ids; // Unique IDs and utf8 paths (less memory used).
+	HashMap<ResourceUIDTypes::ID, Cache> unique_ids; // Unique IDs and utf8 paths (less memory used).
 	bool use_reverse_cache = false;
-	HashMap<CharString, ID> reverse_cache; // Used at runtime.
+	HashMap<CharString, ResourceUIDTypes::ID> reverse_cache; // Used at runtime.
 	static ResourceUID *singleton;
 
 	uint32_t cache_entries = 0;
@@ -68,17 +66,17 @@ protected:
 public:
 	inline static ResourceUIDScanForUIDOnStartup scan_for_uid_on_startup = nullptr;
 
-	String id_to_text(ID p_id) const;
-	ID text_to_id(const String &p_text) const;
+	String id_to_text(ResourceUIDTypes::ID p_id) const;
+	ResourceUIDTypes::ID text_to_id(const String &p_text) const;
 
-	ID create_id();
-	ID create_id_for_path(const String &p_path);
-	bool has_id(ID p_id) const;
-	void add_id(ID p_id, const String &p_path);
-	void set_id(ID p_id, const String &p_path);
-	String get_id_path(ID p_id) const;
-	ID get_path_id(const String &p_path) const;
-	void remove_id(ID p_id);
+	ResourceUIDTypes::ID create_id();
+	ResourceUIDTypes::ID create_id_for_path(const String &p_path);
+	bool has_id(ResourceUIDTypes::ID p_id) const;
+	void add_id(ResourceUIDTypes::ID p_id, const String &p_path);
+	void set_id(ResourceUIDTypes::ID p_id, const String &p_path);
+	String get_id_path(ResourceUIDTypes::ID p_id) const;
+	ResourceUIDTypes::ID get_path_id(const String &p_path) const;
+	void remove_id(ResourceUIDTypes::ID p_id);
 
 	static String uid_to_path(const String &p_uid);
 	static String path_to_uid(const String &p_path);
@@ -88,7 +86,7 @@ public:
 	Error save_to_cache();
 	Error update_cache();
 	static String get_path_from_cache(Ref<FileAccess> &p_cache_file, const String &p_uid_string);
-	static Vector<uint8_t> encode_binary_cache(const Vector<Pair<ID, String>> &p_entries);
+	static Vector<uint8_t> encode_binary_cache(const Vector<Pair<ResourceUIDTypes::ID, String>> &p_entries);
 
 	void enable_reverse_cache() { use_reverse_cache = true; }
 	void clear();

--- a/core/io/resource_uid_types.h
+++ b/core/io/resource_uid_types.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  resource_importer_imagefont.h                                         */
+/*  resource_uid_types.h                                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,23 +30,9 @@
 
 #pragma once
 
-#include "core/io/resource_importer.h"
-#include "core/io/resource_uid_types.h"
+#include <cstdint>
 
-class ResourceImporterImageFont : public ResourceImporter {
-	GDCLASS(ResourceImporterImageFont, ResourceImporter);
-
-public:
-	virtual String get_importer_name() const override;
-	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
-	virtual String get_save_extension() const override;
-	virtual String get_resource_type() const override;
-
-	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
-	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
-
-	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
-
-	virtual bool can_import_threaded() const override { return true; }
-};
+namespace ResourceUIDTypes {
+typedef int64_t ID;
+constexpr const static ID INVALID_ID = -1;
+} //namespace ResourceUIDTypes

--- a/core/io/translation_loader_po.h
+++ b/core/io/translation_loader_po.h
@@ -32,6 +32,7 @@
 
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
+#include "core/io/resource_uid_types.h"
 
 class TranslationLoaderPO : public ResourceFormatLoader {
 	GDSOFTCLASS(TranslationLoaderPO, ResourceFormatLoader);
@@ -44,6 +45,6 @@ public:
 	virtual String get_resource_type(const String &p_path) const override;
 
 	// Treat translations as text/binary files, do not generate a `*.{po,mo}.uid` file.
-	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override { return ResourceUID::INVALID_ID; }
+	virtual ResourceUIDTypes::ID get_resource_uid(const String &p_path) const override { return ResourceUIDTypes::INVALID_ID; }
 	virtual bool has_custom_uid_support() const override { return true; }
 };

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -33,6 +33,7 @@
 #include "core/crypto/crypto_core.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_uid.h"
+#include "core/io/resource_uid_types.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "core/string/string_buffer.h"
@@ -1158,8 +1159,8 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 
 					Ref<Resource> res;
 					if (!uid_string.is_empty()) {
-						ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(uid_string);
-						if (uid != ResourceUID::INVALID_ID && ResourceUID::get_singleton()->has_id(uid)) {
+						ResourceUIDTypes::ID uid = ResourceUID::get_singleton()->text_to_id(uid_string);
+						if (uid != ResourceUIDTypes::INVALID_ID && ResourceUID::get_singleton()->has_id(uid)) {
 							const String id_path = ResourceUID::get_singleton()->get_id_path(uid);
 							if (!id_path.is_empty()) {
 								res = ResourceLoader::load(id_path);
@@ -2000,8 +2001,8 @@ static String rtos_fix(double p_value, bool p_compat) {
 }
 
 static String encode_resource_reference(const String &path) {
-	ResourceUID::ID uid = ResourceLoader::get_resource_uid(path);
-	if (uid != ResourceUID::INVALID_ID) {
+	ResourceUIDTypes::ID uid = ResourceLoader::get_resource_uid(path);
+	if (uid != ResourceUIDTypes::INVALID_ID) {
 		return "Resource(\"" + ResourceUID::get_singleton()->id_to_text(uid) +
 				"\", \"" + path.c_escape_multiline() + "\")";
 	} else {

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/io/resource_saver.h"
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -36,6 +36,7 @@
 #include "core/extension/gdextension.h"
 #include "core/input/input.h"
 #include "core/io/json.h"
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -35,6 +35,8 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
+#include "core/io/resource_uid.h"
+#include "core/io/resource_uid_types.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
@@ -2662,8 +2664,8 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 
 		case FILE_MENU_COPY_UID: {
 			if (!p_selected.is_empty()) {
-				ResourceUID::ID uid = ResourceLoader::get_resource_uid(p_selected[0]);
-				if (uid != ResourceUID::INVALID_ID) {
+				ResourceUIDTypes::ID uid = ResourceLoader::get_resource_uid(p_selected[0]);
+				if (uid != ResourceUIDTypes::INVALID_ID) {
 					String uid_string = ResourceUID::get_singleton()->id_to_text(uid);
 					DisplayServer::get_singleton()->clipboard_set(uid_string);
 				}
@@ -2826,8 +2828,8 @@ void FileSystemDock::_search_changed(const String &p_text, const Control *p_from
 
 	const String searched_string = p_text.to_lower();
 	if (searched_string.begins_with("uid://")) {
-		ResourceUID::ID id = ResourceUID::get_singleton()->text_to_id(searched_string);
-		if (id != ResourceUID::INVALID_ID && ResourceUID::get_singleton()->has_id(id)) {
+		ResourceUIDTypes::ID id = ResourceUID::get_singleton()->text_to_id(searched_string);
+		if (id != ResourceUIDTypes::INVALID_ID && ResourceUID::get_singleton()->has_id(id)) {
 			navigate_to_path(ResourceUID::get_singleton()->get_id_path(id));
 			return;
 		}
@@ -3499,7 +3501,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 	if (p_paths.size() == 1) {
 		p_popup->add_icon_shortcut(get_editor_theme_icon(SNAME("ActionCopy")), ED_GET_SHORTCUT("filesystem_dock/copy_path"), FILE_MENU_COPY_PATH);
 		p_popup->add_shortcut(ED_GET_SHORTCUT("filesystem_dock/copy_absolute_path"), FILE_MENU_COPY_ABSOLUTE_PATH);
-		if (ResourceLoader::get_resource_uid(p_paths[0]) != ResourceUID::INVALID_ID) {
+		if (ResourceLoader::get_resource_uid(p_paths[0]) != ResourceUIDTypes::INVALID_ID) {
 			p_popup->add_icon_shortcut(get_editor_theme_icon(SNAME("Instance")), ED_GET_SHORTCUT("filesystem_dock/copy_uid"), FILE_MENU_COPY_UID);
 		}
 		if (root_path_not_selected) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -39,6 +39,7 @@
 #include "core/io/image.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -41,6 +41,7 @@
 #include "core/io/image.h"
 #include "core/io/image_loader.h"
 #include "core/io/resource_uid.h"
+#include "core/io/resource_uid_types.h"
 #include "core/io/zip_io.h"
 #include "core/math/random_pcg.h"
 #include "core/object/class_db.h"
@@ -1879,7 +1880,7 @@ EditorExportPlatform::FilteredCache EditorExportPlatform::_get_filtered_cache(co
 
 	Vector<String> extension_lines;
 	Array global_class_list;
-	Vector<Pair<ResourceUID::ID, String>> uid_entries;
+	Vector<Pair<ResourceUIDTypes::ID, String>> uid_entries;
 	extension_lines.reserve(extension_list_lines.size());
 	global_class_list.reserve(class_by_path.size());
 	uid_entries.reserve(p_paths.size());
@@ -1891,9 +1892,9 @@ EditorExportPlatform::FilteredCache EditorExportPlatform::_get_filtered_cache(co
 		if (class_by_path.has(path)) {
 			global_class_list.push_back(class_by_path[path]);
 		}
-		ResourceUID::ID uid = EditorFileSystem::get_singleton()->get_file_uid(path);
-		if (uid != ResourceUID::INVALID_ID) {
-			uid_entries.push_back(Pair<ResourceUID::ID, String>(uid, path));
+		ResourceUIDTypes::ID uid = EditorFileSystem::get_singleton()->get_file_uid(path);
+		if (uid != ResourceUIDTypes::INVALID_ID) {
+			uid_entries.push_back(Pair<ResourceUIDTypes::ID, String>(uid, path));
 		}
 	}
 

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -33,6 +33,8 @@
 #include "core/config/project_settings.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
+#include "core/io/resource_uid.h"
+#include "core/io/resource_uid_types.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "core/os/os.h"
@@ -220,10 +222,10 @@ static String _get_resolved_dep_path(const String &p_dep) {
 	}
 
 	const String uid_text = p_dep.get_slice("::", 0);
-	ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(uid_text);
+	ResourceUIDTypes::ID uid = ResourceUID::get_singleton()->text_to_id(uid_text);
 
 	// Dependency is in UID format, obtain proper path.
-	if (uid != ResourceUID::INVALID_ID && ResourceUID::get_singleton()->has_id(uid)) {
+	if (uid != ResourceUIDTypes::INVALID_ID && ResourceUID::get_singleton()->has_id(uid)) {
 		return ResourceUID::get_singleton()->get_id_path(uid);
 	}
 

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -35,6 +35,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_saver.h"
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/object/worker_thread_pool.h"
@@ -133,8 +134,8 @@ String EditorFileSystemDirectory::get_file_path(int p_idx) const {
 	return get_path().path_join(get_file(p_idx));
 }
 
-ResourceUID::ID EditorFileSystemDirectory::get_file_uid(int p_idx) const {
-	ERR_FAIL_INDEX_V(p_idx, files.size(), ResourceUID::INVALID_ID);
+ResourceUIDTypes::ID EditorFileSystemDirectory::get_file_uid(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, files.size(), ResourceUIDTypes::INVALID_ID);
 	return files[p_idx]->uid;
 }
 
@@ -148,8 +149,8 @@ Vector<String> EditorFileSystemDirectory::get_file_deps(int p_idx) const {
 		if (sep_idx != -1) {
 			dep = dep.substr(0, sep_idx);
 		}
-		ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(dep);
-		if (uid != ResourceUID::INVALID_ID) {
+		ResourceUIDTypes::ID uid = ResourceUID::get_singleton()->text_to_id(dep);
+		if (uid != ResourceUIDTypes::INVALID_ID) {
 			//return proper dependency resource from uid
 			if (ResourceUID::get_singleton()->has_id(uid)) {
 				dep = ResourceUID::get_singleton()->get_id_path(uid);
@@ -295,7 +296,7 @@ void EditorFileSystem::_scan_for_uid_directory(const ScannedDirectory *p_scan_di
 		}
 
 		const String path = p_scan_dir->full_path.path_join(scan_file);
-		ResourceUID::ID uid = ResourceUID::INVALID_ID;
+		ResourceUIDTypes::ID uid = ResourceUIDTypes::INVALID_ID;
 		if (p_import_extensions.has(ext)) {
 			if (FileAccess::exists(path + ".import")) {
 				uid = ResourceFormatImporter::get_singleton()->get_resource_uid(path);
@@ -304,7 +305,7 @@ void EditorFileSystem::_scan_for_uid_directory(const ScannedDirectory *p_scan_di
 			uid = ResourceLoader::get_resource_uid(path);
 		}
 
-		if (uid != ResourceUID::INVALID_ID) {
+		if (uid != ResourceUIDTypes::INVALID_ID) {
 			if (!ResourceUID::get_singleton()->has_id(uid)) {
 				ResourceUID::get_singleton()->add_id(uid, path);
 			}
@@ -916,11 +917,11 @@ bool EditorFileSystem::_update_scan_actions() {
 				fs_changed = true;
 
 				const String new_file_path = ia.dir->get_file_path(idx);
-				const ResourceUID::ID existing_id = ResourceLoader::get_resource_uid(new_file_path);
-				if (existing_id != ResourceUID::INVALID_ID) {
+				const ResourceUIDTypes::ID existing_id = ResourceLoader::get_resource_uid(new_file_path);
+				if (existing_id != ResourceUIDTypes::INVALID_ID) {
 					const String old_path = ResourceUID::get_singleton()->get_id_path(existing_id);
 					if (old_path != new_file_path && FileAccess::exists(old_path)) {
-						const ResourceUID::ID new_id = ResourceUID::get_singleton()->create_id_for_path(new_file_path);
+						const ResourceUIDTypes::ID new_id = ResourceUID::get_singleton()->create_id_for_path(new_file_path);
 						ResourceUID::get_singleton()->add_id(new_id, new_file_path);
 						ResourceSaver::set_uid(new_file_path, new_id);
 						WARN_PRINT(vformat("Duplicate UID detected for Resource at \"%s\".\nOld Resource path: \"%s\". The new file UID was changed automatically.", new_file_path, old_path));
@@ -1289,7 +1290,7 @@ void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, 
 					//note: I think this should not happen any longer..
 				}
 
-				if (fc->uid == ResourceUID::INVALID_ID) {
+				if (fc->uid == ResourceUIDTypes::INVALID_ID) {
 					// imported files should always have a UID, so attempt to fetch it.
 					fi->uid = ResourceLoader::get_resource_uid(path);
 				}
@@ -1372,7 +1373,7 @@ void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, 
 				// Create a UID file and new UID, if it's invalid.
 				Ref<FileAccess> f = FileAccess::open(path + ".uid", FileAccess::WRITE);
 				if (f.is_valid()) {
-					if (fi->uid == ResourceUID::INVALID_ID) {
+					if (fi->uid == ResourceUIDTypes::INVALID_ID) {
 						fi->uid = ResourceUID::get_singleton()->create_id_for_path(path);
 					} else {
 						WARN_PRINT(vformat("Missing .uid file for path \"%s\". The file was re-created from cache.", path));
@@ -1382,7 +1383,7 @@ void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, 
 			}
 		}
 
-		if (fi->uid != ResourceUID::INVALID_ID) {
+		if (fi->uid != ResourceUIDTypes::INVALID_ID) {
 			if (ResourceUID::get_singleton()->has_id(fi->uid)) {
 				// Restrict UID dupe warning to first-scan since we know there are no file moves going on yet.
 				if (first_scan) {
@@ -1998,12 +1999,12 @@ EditorFileSystemDirectory *EditorFileSystem::find_file(const String &p_file, int
 	return fs;
 }
 
-ResourceUID::ID EditorFileSystem::get_file_uid(const String &p_path) const {
+ResourceUIDTypes::ID EditorFileSystem::get_file_uid(const String &p_path) const {
 	int file_idx;
 	EditorFileSystemDirectory *directory = find_file(p_path, &file_idx);
 
 	if (!directory) {
-		return ResourceUID::INVALID_ID;
+		return ResourceUIDTypes::INVALID_ID;
 	}
 	return directory->files[file_idx]->uid;
 }
@@ -2405,7 +2406,7 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 			//was removed
 			_delete_internal_files(file);
 			if (cpos != -1) { // Might've never been part of the editor file system (*.* files deleted in Open dialog).
-				if (fs->files[cpos]->uid != ResourceUID::INVALID_ID) {
+				if (fs->files[cpos]->uid != ResourceUIDTypes::INVALID_ID) {
 					if (ResourceUID::get_singleton()->has_id(fs->files[cpos]->uid)) {
 						ResourceUID::get_singleton()->remove_id(fs->files[cpos]->uid);
 					}
@@ -2436,7 +2437,7 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 			}
 			String script_class = ResourceLoader::get_resource_script_class(file);
 
-			ResourceUID::ID uid = ResourceLoader::get_resource_uid(file);
+			ResourceUIDTypes::ID uid = ResourceLoader::get_resource_uid(file);
 
 			if (cpos == -1) {
 				// The file did not exist, it was added.
@@ -2482,7 +2483,7 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 			fi->deps = _get_dependencies(file);
 			fi->import_valid = (type == "TextFile" || type == "OtherFile") ? true : ResourceLoader::is_import_valid(file);
 
-			if (uid != ResourceUID::INVALID_ID) {
+			if (uid != ResourceUIDTypes::INVALID_ID) {
 				if (ResourceUID::get_singleton()->has_id(uid)) {
 					ResourceUID::get_singleton()->set_id(uid, file);
 				} else {
@@ -2494,7 +2495,7 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 				if (ResourceLoader::should_create_uid_file(file)) {
 					Ref<FileAccess> f = FileAccess::open(file + ".uid", FileAccess::WRITE);
 					if (f.is_valid()) {
-						const ResourceUID::ID id = ResourceUID::get_singleton()->create_id_for_path(file);
+						const ResourceUIDTypes::ID id = ResourceUID::get_singleton()->create_id_for_path(file);
 						ResourceUID::get_singleton()->add_id(id, file);
 						f->store_line(ResourceUID::get_singleton()->id_to_text(id));
 						fi->uid = id;
@@ -2595,7 +2596,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 	String importer_name;
 
 	HashMap<String, HashMap<StringName, Variant>> source_file_options;
-	HashMap<String, ResourceUID::ID> uids;
+	HashMap<String, ResourceUIDTypes::ID> uids;
 	HashMap<String, String> base_paths;
 	for (int i = 0; i < p_files.size(); i++) {
 		Ref<ConfigFile> config;
@@ -2611,7 +2612,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 			ERR_FAIL_V(ERR_FILE_CORRUPT);
 		}
 
-		ResourceUID::ID uid = ResourceUID::INVALID_ID;
+		ResourceUIDTypes::ID uid = ResourceUIDTypes::INVALID_ID;
 
 		if (config->has_section_key("remap", "uid")) {
 			String uidt = config->get_value("remap", "uid");
@@ -2663,7 +2664,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		const String &file = E.key;
 		String base_path = ResourceFormatImporter::get_singleton()->get_import_base_path(file);
 		Vector<String> dest_paths;
-		ResourceUID::ID uid = uids[file];
+		ResourceUIDTypes::ID uid = uids[file];
 		{
 			Ref<FileAccess> f = FileAccess::open(file + ".import", FileAccess::WRITE);
 			ERR_FAIL_COND_V_MSG(f.is_null(), ERR_FILE_CANT_OPEN, "Cannot open import file '" + file + ".import'.");
@@ -2680,7 +2681,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 				f->store_line("type=\"" + importer->get_resource_type() + "\"");
 			}
 
-			if (uid == ResourceUID::INVALID_ID) {
+			if (uid == ResourceUIDTypes::INVALID_ID) {
 				uid = ResourceUID::get_singleton()->create_id_for_path(file);
 			}
 
@@ -2807,7 +2808,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		importer_name = p_custom_importer;
 	}
 
-	ResourceUID::ID uid = ResourceUID::INVALID_ID;
+	ResourceUIDTypes::ID uid = ResourceUIDTypes::INVALID_ID;
 	Variant generator_parameters;
 	String group_file;
 	if (p_generator_parameters) {
@@ -2906,7 +2907,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		}
 	}
 
-	if (uid == ResourceUID::INVALID_ID) {
+	if (uid == ResourceUIDTypes::INVALID_ID) {
 		uid = ResourceUID::get_singleton()->create_id_for_path(p_file);
 	}
 
@@ -3120,7 +3121,7 @@ Error EditorFileSystem::_copy_file(const String &p_from, const String &p_to) {
 		}
 
 		// Roll a new uid for this copied .import file to avoid conflict.
-		ResourceUID::ID res_uid = ResourceUID::get_singleton()->create_id_for_path(p_to);
+		ResourceUIDTypes::ID res_uid = ResourceUID::get_singleton()->create_id_for_path(p_to);
 		cfg->set_value("remap", "uid", ResourceUID::get_singleton()->id_to_text(res_uid));
 		err = cfg->save(p_to + ".import");
 		if (err != OK) {
@@ -3129,7 +3130,7 @@ Error EditorFileSystem::_copy_file(const String &p_from, const String &p_to) {
 
 		// Make sure it's immediately added to the map so we can remap dependencies if we want to after this.
 		ResourceUID::get_singleton()->add_id(res_uid, p_to);
-	} else if (ResourceLoader::get_resource_uid(p_from) == ResourceUID::INVALID_ID) {
+	} else if (ResourceLoader::get_resource_uid(p_from) == ResourceUIDTypes::INVALID_ID) {
 		// Files which do not use an uid can just be copied.
 		Error err = da->copy(p_from, p_to);
 		if (err != OK) {
@@ -3258,8 +3259,8 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 
 		String file = p_files[i];
 
-		ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(file);
-		if (uid != ResourceUID::INVALID_ID && ResourceUID::get_singleton()->has_id(uid)) {
+		ResourceUIDTypes::ID uid = ResourceUID::get_singleton()->text_to_id(file);
+		if (uid != ResourceUIDTypes::INVALID_ID && ResourceUID::get_singleton()->has_id(uid)) {
 			file = ResourceUID::get_singleton()->get_id_path(uid);
 		}
 
@@ -3645,10 +3646,10 @@ Error EditorFileSystem::copy_directory(const String &p_from, const String &p_to)
 	return success ? OK : FAILED;
 }
 
-ResourceUID::ID EditorFileSystem::_resource_saver_get_resource_id_for_path(const String &p_path, bool p_generate) {
+ResourceUIDTypes::ID EditorFileSystem::_resource_saver_get_resource_id_for_path(const String &p_path, bool p_generate) {
 	if (!p_path.is_resource_file() || p_path.begins_with(ProjectSettings::get_singleton()->get_project_data_path())) {
 		// Saved externally (configuration file) or internal file, do not assign an ID.
-		return ResourceUID::INVALID_ID;
+		return ResourceUIDTypes::INVALID_ID;
 	}
 
 	EditorFileSystemDirectory *fs = nullptr;
@@ -3656,22 +3657,22 @@ ResourceUID::ID EditorFileSystem::_resource_saver_get_resource_id_for_path(const
 
 	if (!singleton->_find_file(p_path, &fs, cpos)) {
 		// Fallback to ResourceLoader if filesystem cache fails (can happen during scanning etc.).
-		ResourceUID::ID fallback = ResourceLoader::get_resource_uid(p_path);
-		if (fallback != ResourceUID::INVALID_ID) {
+		ResourceUIDTypes::ID fallback = ResourceLoader::get_resource_uid(p_path);
+		if (fallback != ResourceUIDTypes::INVALID_ID) {
 			return fallback;
 		}
 
 		if (p_generate) {
 			return ResourceUID::get_singleton()->create_id_for_path(p_path); // Just create a new one, we will be notified of save anyway and fetch the right UID at that time, to keep things simple.
 		} else {
-			return ResourceUID::INVALID_ID;
+			return ResourceUIDTypes::INVALID_ID;
 		}
-	} else if (fs->files[cpos]->uid != ResourceUID::INVALID_ID) {
+	} else if (fs->files[cpos]->uid != ResourceUIDTypes::INVALID_ID) {
 		return fs->files[cpos]->uid;
 	} else if (p_generate) {
 		return ResourceUID::get_singleton()->create_id_for_path(p_path); // Just create a new one, we will be notified of save anyway and fetch the right UID at that time, to keep things simple.
 	} else {
-		return ResourceUID::INVALID_ID;
+		return ResourceUIDTypes::INVALID_ID;
 	}
 }
 

--- a/editor/file_system/editor_file_system.h
+++ b/editor/file_system/editor_file_system.h
@@ -33,6 +33,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/resource_importer.h"
 #include "core/io/resource_loader.h"
+#include "core/io/resource_uid_types.h"
 #include "core/os/thread.h"
 #include "core/os/thread_safe.h"
 #include "core/templates/hash_set.h"
@@ -56,7 +57,7 @@ class EditorFileSystemDirectory : public Object {
 		String file;
 		StringName type;
 		StringName resource_script_class; // If any resource has script with a global class name, its found here.
-		ResourceUID::ID uid = ResourceUID::INVALID_ID;
+		ResourceUIDTypes::ID uid = ResourceUIDTypes::INVALID_ID;
 		uint64_t modified_time = 0;
 		uint64_t import_modified_time = 0;
 		String import_md5;
@@ -91,7 +92,7 @@ public:
 	int get_file_count() const;
 	String get_file(int p_idx) const;
 	String get_file_path(int p_idx) const;
-	ResourceUID::ID get_file_uid(int p_idx) const;
+	ResourceUIDTypes::ID get_file_uid(int p_idx) const;
 	StringName get_file_type(int p_idx) const;
 	StringName get_file_resource_script_class(int p_idx) const;
 	Vector<String> get_file_deps(int p_idx) const;
@@ -213,7 +214,7 @@ class EditorFileSystem : public Node {
 	struct FileCache {
 		StringName type;
 		String resource_script_class;
-		ResourceUID::ID uid = ResourceUID::INVALID_ID;
+		ResourceUIDTypes::ID uid = ResourceUIDTypes::INVALID_ID;
 		uint64_t modification_time = 0;
 		uint64_t import_modification_time = 0;
 		String import_md5;
@@ -357,7 +358,7 @@ class EditorFileSystem : public Node {
 
 	void _reimport_thread(uint32_t p_index, ImportThreadData *p_import_data);
 
-	static ResourceUID::ID _resource_saver_get_resource_id_for_path(const String &p_path, bool p_generate);
+	static ResourceUIDTypes::ID _resource_saver_get_resource_id_for_path(const String &p_path, bool p_generate);
 
 	bool _scan_extensions();
 	bool _scan_import_support(const Vector<String> &reimports);
@@ -393,7 +394,7 @@ public:
 	EditorFileSystemDirectory *get_filesystem_path(const String &p_path);
 	String get_file_type(const String &p_file) const;
 	EditorFileSystemDirectory *find_file(const String &p_file, int *r_index) const;
-	ResourceUID::ID get_file_uid(const String &p_path) const;
+	ResourceUIDTypes::ID get_file_uid(const String &p_path) const;
 
 	void reimport_files(const Vector<String> &p_files);
 	Error reimport_append(const String &p_file, const HashMap<StringName, Variant> &p_custom_options, const String &p_custom_importer, Variant p_generator_parameters);

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -31,6 +31,7 @@
 #include "editor_quick_open_dialog.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
@@ -232,7 +233,7 @@ void EditorQuickOpenDialog::item_pressed(bool p_double_click) {
 }
 
 void EditorQuickOpenDialog::preview_property() {
-	ERR_FAIL_COND(container->get_selected() == ResourceUID::INVALID_ID);
+	ERR_FAIL_COND(container->get_selected() == ResourceUIDTypes::INVALID_ID);
 	String path = container->get_selected_path();
 
 	Ref<Resource> loaded_resource = ResourceLoader::load(path);
@@ -422,7 +423,7 @@ QuickOpenResultContainer::QuickOpenResultContainer() {
 }
 
 void QuickOpenResultContainer::_menu_option(int p_option) {
-	ERR_FAIL_COND(get_selected() == ResourceUID::INVALID_ID);
+	ERR_FAIL_COND(get_selected() == ResourceUIDTypes::INVALID_ID);
 	String selected_path = get_selected_path();
 
 	switch (p_option) {
@@ -495,27 +496,27 @@ void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
 			PackedStringArray cleaned_text_uids;
 			cleaned_text_uids.resize(history_uids.size());
 
-			Vector<ResourceUID::ID> cleaned_ids;
+			Vector<ResourceUIDTypes::ID> cleaned_ids;
 			cleaned_ids.resize(history_uids.size());
 
 			{
 				String *text_write = cleaned_text_uids.ptrw();
-				ResourceUID::ID *id_write = cleaned_ids.ptrw();
+				ResourceUIDTypes::ID *id_write = cleaned_ids.ptrw();
 				int i = 0;
 				for (String uid : history_uids) {
 #ifndef DISABLE_DEPRECATED
 					if (!uid.begins_with("uid://")) {
 						// uid might be a path here, if config was written by older editor version
-						ResourceUID::ID id = EditorFileSystem::get_singleton()->get_file_uid(uid);
-						if (id == ResourceUID::INVALID_ID) {
+						ResourceUIDTypes::ID id = EditorFileSystem::get_singleton()->get_file_uid(uid);
+						if (id == ResourceUIDTypes::INVALID_ID) {
 							continue;
 						}
 						uid = ResourceUID::get_singleton()->id_to_text(id);
 					}
 #endif
 
-					ResourceUID::ID id = ResourceUID::get_singleton()->text_to_id(uid);
-					if (id == ResourceUID::INVALID_ID || !ResourceUID::get_singleton()->has_id(id)) {
+					ResourceUIDTypes::ID id = ResourceUID::get_singleton()->text_to_id(uid);
+					if (id == ResourceUIDTypes::INVALID_ID || !ResourceUID::get_singleton()->has_id(id)) {
 						continue;
 					}
 
@@ -541,12 +542,12 @@ void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
 		}
 	} else if (!first_open && base_types.size() == 1) {
 		const StringName &type = base_types[0];
-		Vector<ResourceUID::ID> *history = selected_history.getptr(type);
+		Vector<ResourceUIDTypes::ID> *history = selected_history.getptr(type);
 
 		if (history) {
-			Vector<ResourceUID::ID> clean_history;
+			Vector<ResourceUIDTypes::ID> clean_history;
 
-			for (const ResourceUID::ID &uid : *history) {
+			for (const ResourceUIDTypes::ID &uid : *history) {
 				if (ResourceUID::get_singleton()->has_id(uid)) {
 					clean_history.push_back(uid);
 				} else {
@@ -571,7 +572,7 @@ void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
 
 void QuickOpenResultContainer::_sort_uids(int p_max_results) {
 	struct FilepathComparator {
-		bool operator()(const ResourceUID::ID &p_lhs, const ResourceUID::ID &p_rhs) const {
+		bool operator()(const ResourceUIDTypes::ID &p_lhs, const ResourceUIDTypes::ID &p_rhs) const {
 			String lhs_path = ResourceUID::get_singleton()->get_id_path(p_lhs);
 			String rhs_path = ResourceUID::get_singleton()->get_id_path(p_rhs);
 
@@ -580,7 +581,7 @@ void QuickOpenResultContainer::_sort_uids(int p_max_results) {
 		}
 	};
 
-	SortArray<ResourceUID::ID, FilepathComparator> sorter{};
+	SortArray<ResourceUIDTypes::ID, FilepathComparator> sorter{};
 
 	if ((int)uids.size() > p_max_results) {
 		sorter.partial_sort(0, uids.size(), p_max_results, uids.ptr());
@@ -596,9 +597,9 @@ void QuickOpenResultContainer::_create_initial_results() {
 	filetypes.clear();
 	history_set.clear();
 
-	Vector<ResourceUID::ID> *history = _get_history();
+	Vector<ResourceUIDTypes::ID> *history = _get_history();
 	if (history) {
-		for (const ResourceUID::ID &uid : *history) {
+		for (const ResourceUIDTypes::ID &uid : *history) {
 			history_set.insert(uid);
 		}
 	}
@@ -617,8 +618,8 @@ void QuickOpenResultContainer::_find_uids_in_folder(EditorFileSystemDirectory *p
 	}
 
 	for (int i = 0; i < p_directory->get_file_count(); i++) {
-		ResourceUID::ID uid = p_directory->get_file_uid(i);
-		if (uid == ResourceUID::INVALID_ID) {
+		ResourceUIDTypes::ID uid = p_directory->get_file_uid(i);
+		if (uid == ResourceUIDTypes::INVALID_ID) {
 			continue;
 		}
 
@@ -645,15 +646,15 @@ void QuickOpenResultContainer::set_query_and_update(const String &p_query) {
 	update_results();
 }
 
-Vector<ResourceUID::ID> *QuickOpenResultContainer::_get_history() {
+Vector<ResourceUIDTypes::ID> *QuickOpenResultContainer::_get_history() {
 	if (base_types.size() == 1) {
 		return selected_history.getptr(base_types[0]);
 	}
 	return nullptr;
 }
 
-QuickOpenResultCandidate QuickOpenResultCandidate::from_uid(const ResourceUID::ID &p_uid, bool &r_success) {
-	if (p_uid == ResourceUID::INVALID_ID || !ResourceUID::get_singleton()->has_id(p_uid)) {
+QuickOpenResultCandidate QuickOpenResultCandidate::from_uid(const ResourceUIDTypes::ID &p_uid, bool &r_success) {
+	if (p_uid == ResourceUIDTypes::INVALID_ID || !ResourceUID::get_singleton()->has_id(p_uid)) {
 		r_success = false;
 		return QuickOpenResultCandidate();
 	}
@@ -666,7 +667,7 @@ QuickOpenResultCandidate QuickOpenResultCandidate::from_uid(const ResourceUID::I
 }
 
 QuickOpenResultCandidate QuickOpenResultCandidate::from_result(const FuzzySearchResult &p_result, bool &r_success) {
-	ResourceUID::ID uid = EditorFileSystem::get_singleton()->get_file_uid(p_result.target);
+	ResourceUIDTypes::ID uid = EditorFileSystem::get_singleton()->get_file_uid(p_result.target);
 
 	QuickOpenResultCandidate candidate = from_uid(uid, r_success);
 	if (!r_success) {
@@ -721,11 +722,11 @@ void QuickOpenResultContainer::update_results() {
 }
 
 void QuickOpenResultContainer::_use_default_candidates() {
-	HashSet<ResourceUID::ID> existing_uids;
+	HashSet<ResourceUIDTypes::ID> existing_uids;
 
-	Vector<ResourceUID::ID> *history = _get_history();
+	Vector<ResourceUIDTypes::ID> *history = _get_history();
 	if (history) {
-		for (const ResourceUID::ID &uid : *history) {
+		for (const ResourceUIDTypes::ID &uid : *history) {
 			bool success;
 			QuickOpenResultCandidate candidate = QuickOpenResultCandidate::from_uid(uid, success);
 			if (!success) {
@@ -735,7 +736,7 @@ void QuickOpenResultContainer::_use_default_candidates() {
 		}
 	}
 
-	for (const ResourceUID::ID &uid : uids) {
+	for (const ResourceUIDTypes::ID &uid : uids) {
 		if (candidates.size() >= max_total_results) {
 			break;
 		}
@@ -766,7 +767,7 @@ void QuickOpenResultContainer::_update_fuzzy_search_results() {
 	PackedStringArray paths;
 	paths.reserve_exact(uids.size());
 
-	for (const ResourceUID::ID &uid : uids) {
+	for (const ResourceUIDTypes::ID &uid : uids) {
 		paths.push_back(ResourceUID::get_singleton()->get_id_path(uid));
 	}
 
@@ -1017,8 +1018,8 @@ bool QuickOpenResultContainer::has_nothing_selected() const {
 	return selection_index < 0;
 }
 
-ResourceUID::ID QuickOpenResultContainer::get_selected() const {
-	ERR_FAIL_COND_V_MSG(has_nothing_selected(), ResourceUID::INVALID_ID, "Tried to get selected file, but nothing was selected.");
+ResourceUIDTypes::ID QuickOpenResultContainer::get_selected() const {
+	ERR_FAIL_COND_V_MSG(has_nothing_selected(), ResourceUIDTypes::INVALID_ID, "Tried to get selected file, but nothing was selected.");
 	return candidates[selection_index].uid;
 }
 
@@ -1049,8 +1050,8 @@ QuickOpenDisplayMode QuickOpenResultContainer::get_adaptive_display_mode(const V
 }
 
 String _get_uid_string(const String &p_filepath) {
-	ResourceUID::ID id = EditorFileSystem::get_singleton()->get_file_uid(p_filepath);
-	return id == ResourceUID::INVALID_ID ? p_filepath : ResourceUID::get_singleton()->id_to_text(id);
+	ResourceUIDTypes::ID id = EditorFileSystem::get_singleton()->get_file_uid(p_filepath);
+	return id == ResourceUIDTypes::INVALID_ID ? p_filepath : ResourceUID::get_singleton()->id_to_text(id);
 }
 
 bool QuickOpenResultContainer::is_instant_preview_enabled() const {
@@ -1069,11 +1070,11 @@ void QuickOpenResultContainer::save_selected_item() {
 	}
 
 	const StringName &base_type = base_types[0];
-	ResourceUID::ID selected = get_selected();
-	Vector<ResourceUID::ID> *type_history = selected_history.getptr(base_type);
+	ResourceUIDTypes::ID selected = get_selected();
+	Vector<ResourceUIDTypes::ID> *type_history = selected_history.getptr(base_type);
 
 	if (!type_history) {
-		selected_history.insert(base_type, Vector<ResourceUID::ID>());
+		selected_history.insert(base_type, Vector<ResourceUIDTypes::ID>());
 		type_history = selected_history.getptr(base_type);
 	} else {
 		for (int i = 0; i < type_history->size(); i++) {
@@ -1096,7 +1097,7 @@ void QuickOpenResultContainer::save_selected_item() {
 		String *uids_write = history_uids.ptrw();
 
 		int i = 0;
-		for (const ResourceUID::ID &uid : *type_history) {
+		for (const ResourceUIDTypes::ID &uid : *type_history) {
 			uids_write[i] = ResourceUID::get_singleton()->id_to_text(uid);
 			i++;
 		}

--- a/editor/gui/editor_quick_open_dialog.h
+++ b/editor/gui/editor_quick_open_dialog.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/io/resource_uid_types.h"
 #include "core/templates/a_hash_map.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/margin_container.h"
@@ -60,11 +61,11 @@ enum class QuickOpenDisplayMode {
 };
 
 struct QuickOpenResultCandidate {
-	ResourceUID::ID uid;
+	ResourceUIDTypes::ID uid;
 	Ref<Texture2D> thumbnail;
 	const FuzzySearchResult *result = nullptr;
 
-	static QuickOpenResultCandidate from_uid(const ResourceUID::ID &p_uid, bool &r_success);
+	static QuickOpenResultCandidate from_uid(const ResourceUIDTypes::ID &p_uid, bool &r_success);
 	static QuickOpenResultCandidate from_result(const FuzzySearchResult &p_result, bool &r_success);
 };
 
@@ -98,7 +99,7 @@ public:
 	void update_results();
 
 	bool has_nothing_selected() const;
-	ResourceUID::ID get_selected() const;
+	ResourceUIDTypes::ID get_selected() const;
 	String get_selected_path() const;
 
 	bool is_instant_preview_enabled() const;
@@ -117,13 +118,13 @@ private:
 
 	Vector<FuzzySearchResult> search_results;
 	Vector<StringName> base_types;
-	LocalVector<ResourceUID::ID> uids;
-	AHashMap<ResourceUID::ID, StringName> filetypes;
+	LocalVector<ResourceUIDTypes::ID> uids;
+	AHashMap<ResourceUIDTypes::ID, StringName> filetypes;
 	Vector<QuickOpenResultCandidate> candidates;
-	HashSet<ResourceUID::ID> candidates_uids;
+	HashSet<ResourceUIDTypes::ID> candidates_uids;
 
-	AHashMap<StringName, Vector<ResourceUID::ID>> selected_history;
-	HashSet<ResourceUID::ID> history_set;
+	AHashMap<StringName, Vector<ResourceUIDTypes::ID>> selected_history;
+	HashSet<ResourceUIDTypes::ID> history_set;
 
 	String query;
 	int selection_index = -1;
@@ -160,7 +161,7 @@ private:
 	void _create_initial_results();
 	void _find_uids_in_folder(EditorFileSystemDirectory *p_directory, bool p_include_addons);
 
-	Vector<ResourceUID::ID> *_get_history();
+	Vector<ResourceUIDTypes::ID> *_get_history();
 	void _add_candidate(QuickOpenResultCandidate &p_candidate);
 	void _update_fuzzy_search_results();
 	void _use_default_candidates();

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -658,7 +658,7 @@ bool ResourceImporterOBJ::get_option_visibility(const String &p_path, const Stri
 	return true;
 }
 
-Error ResourceImporterOBJ::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterOBJ::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	List<Ref<ImporterMesh>> meshes;
 
 	Vector<uint8_t> src_lightmap_cache;

--- a/editor/import/3d/resource_importer_obj.h
+++ b/editor/import/3d/resource_importer_obj.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/io/resource_uid_types.h"
 #include "resource_importer_scene.h"
 
 class EditorOBJImporter : public EditorSceneFormatImporter {
@@ -57,5 +58,5 @@ public:
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 };

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -33,6 +33,7 @@
 #include "core/error/error_macros.h"
 #include "core/io/dir_access.h"
 #include "core/io/resource_saver.h"
+#include "core/io/resource_uid.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "editor/editor_interface.h"
@@ -1637,8 +1638,8 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 								if (external_mat.is_valid()) {
 									m->set_surface_material(i, external_mat);
 									if (!path.begins_with("uid://")) {
-										const ResourceUID::ID id = ResourceLoader::get_resource_uid(path);
-										if (id != ResourceUID::INVALID_ID) {
+										const ResourceUIDTypes::ID id = ResourceLoader::get_resource_uid(path);
+										if (id != ResourceUIDTypes::INVALID_ID) {
 											matdata["use_external/path"] = ResourceUID::get_singleton()->id_to_text(id);
 										}
 									}
@@ -3012,7 +3013,7 @@ Node *ResourceImporterScene::pre_import(const String &p_source_file, const HashM
 	return scene;
 }
 
-static Error convert_path_to_uid(ResourceUID::ID p_source_id, const String &p_hash_str, Dictionary &p_settings, const String &p_path_key, const String &p_fallback_path_key) {
+static Error convert_path_to_uid(ResourceUIDTypes::ID p_source_id, const String &p_hash_str, Dictionary &p_settings, const String &p_path_key, const String &p_fallback_path_key) {
 	const String &raw_save_path = p_settings[p_path_key];
 	String save_path = ResourceUID::ensure_path(raw_save_path);
 	if (raw_save_path.begins_with("uid://")) {
@@ -3030,11 +3031,11 @@ static Error convert_path_to_uid(ResourceUID::ID p_source_id, const String &p_ha
 	}
 	ERR_FAIL_COND_V(!save_path.is_empty() && !DirAccess::exists(save_path.get_base_dir()), ERR_FILE_BAD_PATH);
 	if (!save_path.is_empty() && !raw_save_path.begins_with("uid://")) {
-		const ResourceUID::ID id = ResourceLoader::get_resource_uid(save_path);
-		if (id != ResourceUID::INVALID_ID) {
+		const ResourceUIDTypes::ID id = ResourceLoader::get_resource_uid(save_path);
+		if (id != ResourceUIDTypes::INVALID_ID) {
 			p_settings[p_path_key] = ResourceUID::get_singleton()->id_to_text(id);
 		} else {
-			ResourceUID::ID save_id = hash64_murmur3_64(p_hash_str.hash64(), p_source_id) & 0x7FFFFFFFFFFFFFFF;
+			ResourceUIDTypes::ID save_id = hash64_murmur3_64(p_hash_str.hash64(), p_source_id) & 0x7FFFFFFFFFFFFFFF;
 			if (ResourceUID::get_singleton()->has_id(save_id)) {
 				if (save_path != ResourceUID::get_singleton()->get_id_path(save_id)) {
 					// The user has specified a path which does not match the default UID.
@@ -3049,7 +3050,7 @@ static Error convert_path_to_uid(ResourceUID::ID p_source_id, const String &p_ha
 	return OK;
 }
 
-Error ResourceImporterScene::_check_resource_save_paths(ResourceUID::ID p_source_id, const String &p_hash_suffix, const Dictionary &p_data) {
+Error ResourceImporterScene::_check_resource_save_paths(ResourceUIDTypes::ID p_source_id, const String &p_hash_suffix, const Dictionary &p_data) {
 	for (const KeyValue<Variant, Variant> &kv : p_data) {
 		Dictionary settings = kv.value;
 
@@ -3077,7 +3078,7 @@ Error ResourceImporterScene::_check_resource_save_paths(ResourceUID::ID p_source
 	return OK;
 }
 
-Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterScene::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	const String &src_path = p_source_file;
 
 	Ref<EditorSceneFormatImporter> importer;

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -32,6 +32,7 @@
 
 #include "core/error/error_macros.h"
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid_types.h"
 #include "core/variant/dictionary.h"
 #include "scene/3d/importer_mesh_instance_3d.h"
 #include "scene/resources/3d/box_shape_3d.h"
@@ -206,7 +207,7 @@ class ResourceImporterScene : public ResourceImporter {
 		SHAPE_TYPE_AUTOMATIC,
 	};
 
-	static Error _check_resource_save_paths(ResourceUID::ID p_source_id, const String &p_hash_suffix, const Dictionary &p_data);
+	static Error _check_resource_save_paths(ResourceUIDTypes::ID p_source_id, const String &p_hash_suffix, const Dictionary &p_data);
 	Array _get_skinned_pose_transforms(ImporterMeshInstance3D *p_src_mesh_node);
 	void _replace_owner(Node *p_node, Node *p_scene, Node *p_new_owner);
 	Node *_generate_meshes(Node *p_node, const Dictionary &p_mesh_data, bool p_generate_lods, bool p_create_shadow_meshes, LightBakeMode p_light_bake_mode, float p_lightmap_texel_size, const Vector<uint8_t> &p_src_lightmap_cache, Vector<Vector<uint8_t>> &r_lightmap_caches);
@@ -290,7 +291,7 @@ public:
 	void _compress_animations(AnimationPlayer *anim, int p_page_size_kb);
 
 	Node *pre_import(const String &p_source_file, const HashMap<StringName, Variant> &p_options);
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool has_advanced_options() const override;
 	virtual void show_advanced_options(const String &p_path) override;

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -31,6 +31,7 @@
 #include "scene_import_settings.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -148,7 +148,7 @@ bool EditorImportPlugin::get_option_visibility(const String &p_path, const Strin
 	return true;
 }
 
-Error EditorImportPlugin::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error EditorImportPlugin::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	Dictionary options;
 	TypedArray<String> platform_variants, gen_files;
 

--- a/editor/import/editor_import_plugin.h
+++ b/editor/import/editor_import_plugin.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid_types.h"
 #include "core/variant/typed_array.h"
 
 class EditorImportPlugin : public ResourceImporter {
@@ -69,7 +70,7 @@ public:
 	virtual int get_format_version() const override;
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata = nullptr) override;
 	virtual bool can_import_threaded() const override;
 	Error append_import_external_resource(const String &p_file, const HashMap<StringName, Variant> &p_custom_options = HashMap<StringName, Variant>(), const String &p_custom_importer = String(), Variant p_generator_parameters = Variant());
 };

--- a/editor/import/resource_importer_bitmask.cpp
+++ b/editor/import/resource_importer_bitmask.cpp
@@ -72,7 +72,7 @@ void ResourceImporterBitMap::get_import_options(const String &p_path, List<Impor
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "threshold", PROPERTY_HINT_RANGE, "0,1,0.01"), 0.5));
 }
 
-Error ResourceImporterBitMap::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterBitMap::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	int create_from = p_options["create_from"];
 	float threshold = p_options["threshold"];
 	Ref<Image> image;

--- a/editor/import/resource_importer_bitmask.h
+++ b/editor/import/resource_importer_bitmask.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid_types.h"
 
 class ResourceImporterBitMap : public ResourceImporter {
 	GDCLASS(ResourceImporterBitMap, ResourceImporter);
@@ -47,7 +48,7 @@ public:
 
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
 };

--- a/editor/import/resource_importer_bmfont.cpp
+++ b/editor/import/resource_importer_bmfont.cpp
@@ -69,7 +69,7 @@ void ResourceImporterBMFont::get_import_options(const String &p_path, List<Impor
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "scaling_mode", PROPERTY_HINT_ENUM, "Disabled,Enabled (Integer),Enabled (Fractional)"), TextServer::FIXED_SIZE_SCALE_ENABLED));
 }
 
-Error ResourceImporterBMFont::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterBMFont::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	print_verbose("Importing BMFont font from: " + p_source_file);
 
 	Array fallbacks = p_options["fallbacks"];

--- a/editor/import/resource_importer_bmfont.h
+++ b/editor/import/resource_importer_bmfont.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid_types.h"
 
 class ResourceImporterBMFont : public ResourceImporter {
 	GDCLASS(ResourceImporterBMFont, ResourceImporter);
@@ -45,7 +46,7 @@ public:
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
 };

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -32,6 +32,7 @@
 
 #include "core/io/file_access.h"
 #include "core/io/resource_saver.h"
+#include "core/io/resource_uid.h"
 #include "core/string/optimized_translation.h"
 #include "core/string/translation_server.h"
 
@@ -74,7 +75,7 @@ void ResourceImporterCSVTranslation::get_import_options(const String &p_path, Li
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "unescape_translations"), true));
 }
 
-Error ResourceImporterCSVTranslation::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterCSVTranslation::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	Ref<FileAccess> f = FileAccess::open(p_source_file, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_INVALID_PARAMETER, "Cannot open file from path '" + p_source_file + "'.");
 
@@ -242,7 +243,7 @@ Error ResourceImporterCSVTranslation::import(ResourceUID::ID p_source_id, const 
 		}
 
 		String save_path = p_source_file.get_basename() + "." + xlt->get_locale() + ".translation";
-		ResourceUID::ID save_id = hash64_murmur3_64(xlt->get_locale().hash64(), p_source_id) & 0x7FFFFFFFFFFFFFFF;
+		ResourceUIDTypes::ID save_id = hash64_murmur3_64(xlt->get_locale().hash64(), p_source_id) & 0x7FFFFFFFFFFFFFFF;
 		bool uid_already_exists = ResourceUID::get_singleton()->has_id(save_id);
 		if (uid_already_exists) {
 			// Avoid creating a new file with a duplicate UID.

--- a/editor/import/resource_importer_csv_translation.h
+++ b/editor/import/resource_importer_csv_translation.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid_types.h"
 
 class ResourceImporterCSVTranslation : public ResourceImporter {
 	GDCLASS(ResourceImporterCSVTranslation, ResourceImporter);
@@ -48,7 +49,7 @@ public:
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
 };

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -149,7 +149,7 @@ void ResourceImporterDynamicFont::show_advanced_options(const String &p_path) {
 	DynamicFontImportSettingsDialog::get_singleton()->open_settings(p_path);
 }
 
-Error ResourceImporterDynamicFont::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterDynamicFont::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	print_verbose("Importing dynamic font from: " + p_source_file);
 
 	int antialiasing = p_options["antialiasing"];

--- a/editor/import/resource_importer_dynamic_font.h
+++ b/editor/import/resource_importer_dynamic_font.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid_types.h"
 
 class ResourceImporterDynamicFont : public ResourceImporter {
 	GDCLASS(ResourceImporterDynamicFont, ResourceImporter);
@@ -58,7 +59,7 @@ public:
 	bool has_advanced_options() const override;
 	void show_advanced_options(const String &p_path) override;
 
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
 };

--- a/editor/import/resource_importer_image.cpp
+++ b/editor/import/resource_importer_image.cpp
@@ -68,7 +68,7 @@ String ResourceImporterImage::get_preset_name(int p_idx) const {
 void ResourceImporterImage::get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const {
 }
 
-Error ResourceImporterImage::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterImage::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	Ref<FileAccess> f = FileAccess::open(p_source_file, FileAccess::READ);
 
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, "Cannot open file from path '" + p_source_file + "'.");

--- a/editor/import/resource_importer_image.h
+++ b/editor/import/resource_importer_image.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid_types.h"
 
 class ResourceImporterImage : public ResourceImporter {
 	GDCLASS(ResourceImporterImage, ResourceImporter);
@@ -48,7 +49,7 @@ public:
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
 };

--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -77,7 +77,7 @@ void ResourceImporterImageFont::get_import_options(const String &p_path, List<Im
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "scaling_mode", PROPERTY_HINT_ENUM, "Disabled,Enabled (Integer),Enabled (Fractional)"), TextServer::FIXED_SIZE_SCALE_ENABLED));
 }
 
-Error ResourceImporterImageFont::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterImageFont::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	print_verbose("Importing image font from: " + p_source_file);
 
 	int columns = p_options["columns"];

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -295,7 +295,7 @@ void ResourceImporterLayeredTexture::_save_tex(Vector<Ref<Image>> p_images, cons
 	}
 }
 
-Error ResourceImporterLayeredTexture::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterLayeredTexture::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	int compress_mode = p_options["compress/mode"];
 	float lossy = p_options["compress/lossy_quality"];
 	bool high_quality = p_options["compress/high_quality"];

--- a/editor/import/resource_importer_layered_texture.h
+++ b/editor/import/resource_importer_layered_texture.h
@@ -32,6 +32,7 @@
 
 #include "core/io/image.h"
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid_types.h"
 #include "core/object/ref_counted.h"
 
 class CompressedTexture2D;
@@ -113,7 +114,7 @@ public:
 
 	void _save_tex(Vector<Ref<Image>> p_images, const String &p_to_path, int p_compress_mode, float p_lossy, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, Image::CompressSource p_csource, Image::UsedChannels used_channels, bool p_mipmaps, bool p_force_po2);
 
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool are_import_settings_valid(const String &p_path, const Dictionary &p_meta) const override;
 	virtual String get_import_settings_string() const override;

--- a/editor/import/resource_importer_shader_file.cpp
+++ b/editor/import/resource_importer_shader_file.cpp
@@ -89,7 +89,7 @@ static String _include_function(const String &p_path, void *userpointer) {
 	return file_inc->get_as_utf8_string();
 }
 
-Error ResourceImporterShaderFile::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterShaderFile::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	Error err;
 	Ref<FileAccess> file = FileAccess::open(p_source_file, FileAccess::READ, &err);
 	ERR_FAIL_COND_V(err != OK, ERR_CANT_OPEN);

--- a/editor/import/resource_importer_shader_file.h
+++ b/editor/import/resource_importer_shader_file.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid_types.h"
 
 class ResourceImporterShaderFile : public ResourceImporter {
 	GDCLASS(ResourceImporterShaderFile, ResourceImporter);
@@ -48,7 +49,7 @@ public:
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
 };

--- a/editor/import/resource_importer_svg.cpp
+++ b/editor/import/resource_importer_svg.cpp
@@ -74,7 +74,7 @@ void ResourceImporterSVG::get_import_options(const String &p_path, List<ImportOp
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "compress"), true));
 }
 
-Error ResourceImporterSVG::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterSVG::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	Ref<DPITexture> dpi_tex;
 	dpi_tex.instantiate();
 

--- a/editor/import/resource_importer_svg.h
+++ b/editor/import/resource_importer_svg.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid_types.h"
 
 class ResourceImporterSVG : public ResourceImporter {
 	GDCLASS(ResourceImporterSVG, ResourceImporter);
@@ -48,7 +49,7 @@ public:
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
 };

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -696,7 +696,7 @@ void ResourceImporterTexture::_clamp_hdr_exposure(Ref<Image> &r_image) {
 	}
 }
 
-Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterTexture::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	// Parse import options.
 	int32_t loader_flags = ImageFormatLoader::FLAG_NONE;
 

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -33,6 +33,7 @@
 #include "core/io/file_access.h"
 #include "core/io/image.h"
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid_types.h"
 #include "servers/rendering/rendering_server_enums.h"
 
 class CompressedTexture2D;
@@ -116,7 +117,7 @@ public:
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
 

--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -91,7 +91,7 @@ String ResourceImporterTextureAtlas::get_option_group_file() const {
 	return "atlas_file";
 }
 
-Error ResourceImporterTextureAtlas::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterTextureAtlas::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	/* If this happens, it's because the atlas_file field was not filled, so just import a broken texture */
 
 	//use an xpm because it's size independent, the editor images are vector and size dependent

--- a/editor/import/resource_importer_texture_atlas.h
+++ b/editor/import/resource_importer_texture_atlas.h
@@ -32,6 +32,7 @@
 
 #include "core/io/image.h"
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid_types.h"
 class ResourceImporterTextureAtlas : public ResourceImporter {
 	GDCLASS(ResourceImporterTextureAtlas, ResourceImporter);
 
@@ -63,7 +64,7 @@ public:
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 	virtual String get_option_group_file() const override;
 
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 	virtual Error import_group_file(const String &p_group_file, const HashMap<String, HashMap<StringName, Variant>> &p_source_file_options, const HashMap<String, String> &p_base_paths) override;
 
 	virtual bool can_import_threaded() const override { return true; }

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -89,7 +89,7 @@ void ResourceImporterWAV::get_import_options(const String &p_path, List<ImportOp
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/mode", PROPERTY_HINT_ENUM, "PCM (Uncompressed),IMA ADPCM,Quite OK Audio"), 2));
 }
 
-Error ResourceImporterWAV::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterWAV::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	Dictionary options;
 	for (const KeyValue<StringName, Variant> &pair : p_options) {
 		options[pair.key] = pair.value;

--- a/editor/import/resource_importer_wav.h
+++ b/editor/import/resource_importer_wav.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid_types.h"
 
 class ResourceImporterWAV : public ResourceImporter {
 	GDCLASS(ResourceImporterWAV, ResourceImporter);
@@ -48,7 +49,7 @@ public:
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
 };

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -33,6 +33,8 @@
 #include "core/config/project_settings.h"
 #include "core/input/input_map.h"
 #include "core/io/marshalls.h"
+#include "core/io/resource_uid.h"
+#include "core/io/resource_uid_types.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/string/translation_server.h"
@@ -692,8 +694,8 @@ void EditorPropertyPath::_path_selected(const String &p_path) {
 	String full_path = p_path;
 
 	if (enable_uid) {
-		const ResourceUID::ID id = ResourceLoader::get_resource_uid(full_path);
-		if (id != ResourceUID::INVALID_ID) {
+		const ResourceUIDTypes::ID id = ResourceLoader::get_resource_uid(full_path);
+		if (id != ResourceUIDTypes::INVALID_ID) {
 			full_path = ResourceUID::get_singleton()->id_to_text(id);
 		}
 	}

--- a/editor/inspector/editor_resource_preview.h
+++ b/editor/inspector/editor_resource_preview.h
@@ -35,6 +35,7 @@
 #include "core/templates/safe_refcount.h"
 #include "scene/main/node.h"
 
+class FileAccess;
 class ImageTexture;
 class Texture2D;
 

--- a/editor/inspector/editor_resource_tooltip_plugins.cpp
+++ b/editor/inspector/editor_resource_tooltip_plugins.cpp
@@ -30,6 +30,8 @@
 
 #include "editor_resource_tooltip_plugins.h"
 
+#include "core/io/resource_uid.h"
+#include "core/io/resource_uid_types.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "editor/editor_node.h"
@@ -63,8 +65,8 @@ VBoxContainer *EditorResourceTooltipPlugin::make_default_tooltip(const String &p
 		vb->add_child(label);
 	}
 
-	ResourceUID::ID id = EditorFileSystem::get_singleton()->get_file_uid(p_resource_path);
-	if (id != ResourceUID::INVALID_ID) {
+	ResourceUIDTypes::ID id = EditorFileSystem::get_singleton()->get_file_uid(p_resource_path);
+	if (id != ResourceUIDTypes::INVALID_ID) {
 		Label *label = memnew(Label(ResourceUID::get_singleton()->id_to_text(id)));
 		vb->add_child(label);
 	}

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/io/dir_access.h"
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "core/os/os.h"

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "editor/debugger/editor_debugger_node.h"

--- a/editor/scene/2d/scene_paint_2d_editor_plugin.cpp
+++ b/editor/scene/2d/scene_paint_2d_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "scene_paint_2d_editor_plugin.h"
 
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "editor/docks/filesystem_dock.h"

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h" // IWYU pragma: keep. `ADD_SIGNAL` macro.
 #include "core/os/os.h"

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -36,6 +36,8 @@
 #include "core/io/file_access.h"
 #include "core/io/json.h"
 #include "core/io/resource_loader.h"
+#include "core/io/resource_uid.h"
+#include "core/io/resource_uid_types.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
@@ -631,7 +633,7 @@ void ScriptEditor::_copy_script_path() {
 void ScriptEditor::_copy_script_uid() {
 	if (ScriptEditorBase *seb = _get_current_editor()) {
 		Ref<Resource> scr = seb->get_edited_resource();
-		ResourceUID::ID uid = ResourceLoader::get_resource_uid(scr->get_path());
+		ResourceUIDTypes::ID uid = ResourceLoader::get_resource_uid(scr->get_path());
 		DisplayServer::get_singleton()->clipboard_set(ResourceUID::get_singleton()->id_to_text(uid));
 	}
 }
@@ -1383,7 +1385,7 @@ void ScriptEditor::_prepare_file_menu() {
 
 	menu->set_item_disabled(menu->get_item_index(FILE_MENU_SOFT_RELOAD_TOOL), res.is_null());
 	menu->set_item_disabled(menu->get_item_index(FILE_MENU_COPY_PATH), res.is_null() || res->get_path().is_empty());
-	menu->set_item_disabled(menu->get_item_index(FILE_MENU_COPY_UID), res.is_null() || ResourceLoader::get_resource_uid(res->get_path()) == ResourceUID::INVALID_ID);
+	menu->set_item_disabled(menu->get_item_index(FILE_MENU_COPY_UID), res.is_null() || ResourceLoader::get_resource_uid(res->get_path()) == ResourceUIDTypes::INVALID_ID);
 	menu->set_item_disabled(menu->get_item_index(FILE_MENU_SHOW_IN_FILE_SYSTEM), res.is_null());
 
 	menu->set_item_disabled(menu->get_item_index(FILE_MENU_HISTORY_PREV), history_pos <= 0);
@@ -3111,7 +3113,7 @@ void ScriptEditor::_make_script_list_context_menu() {
 		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/copy_path"), FILE_MENU_COPY_PATH);
 		context_menu->set_item_disabled(-1, seb->get_edited_resource()->get_path().is_empty());
 		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/copy_uid"), FILE_MENU_COPY_UID);
-		context_menu->set_item_disabled(-1, ResourceLoader::get_resource_uid(seb->get_edited_resource()->get_path()) == ResourceUID::INVALID_ID);
+		context_menu->set_item_disabled(-1, ResourceLoader::get_resource_uid(seb->get_edited_resource()->get_path()) == ResourceUIDTypes::INVALID_ID);
 		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/show_in_file_system"), FILE_MENU_SHOW_IN_FILE_SYSTEM);
 		context_menu->add_separator();
 	}

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -34,6 +34,8 @@
 #include "core/input/input.h"
 #include "core/io/dir_access.h"
 #include "core/io/json.h"
+#include "core/io/resource_uid.h"
+#include "core/io/resource_uid_types.h"
 #include "core/math/expression.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
@@ -2019,8 +2021,8 @@ static String _quote_drop_data(const String &str) {
 static String _get_dropped_resource_as_member(const Ref<Resource> &p_resource, bool p_create_field, bool p_allow_uid) {
 	String path = p_resource->get_path();
 	if (p_allow_uid) {
-		ResourceUID::ID id = ResourceLoader::get_resource_uid(path);
-		if (id != ResourceUID::INVALID_ID) {
+		ResourceUIDTypes::ID id = ResourceLoader::get_resource_uid(path);
+		if (id != ResourceUIDTypes::INVALID_ID) {
 			path = ResourceUID::get_singleton()->id_to_text(id);
 		}
 	}

--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/core_constants.h"
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "editor/docks/filesystem_dock.h"

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -33,6 +33,8 @@
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/io/resource_loader.h"
+#include "core/io/resource_uid.h"
+#include "core/io/resource_uid_types.h"
 #include "core/math/math_defs.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
@@ -2739,8 +2741,8 @@ void VisualShaderEditor::_restore_editor_state() {
 
 String VisualShaderEditor::_get_cache_id_string() const {
 	String id_string = visual_shader->get_path();
-	const ResourceUID::ID uid = EditorFileSystem::get_singleton()->get_file_uid(id_string);
-	if (uid != ResourceUID::INVALID_ID) {
+	const ResourceUIDTypes::ID uid = EditorFileSystem::get_singleton()->get_file_uid(id_string);
+	if (uid != ResourceUIDTypes::INVALID_ID) {
 		id_string = ResourceUID::get_singleton()->id_to_text(uid);
 	}
 	return id_string;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -47,6 +47,8 @@
 #include "core/io/image.h"
 #include "core/io/image_loader.h"
 #include "core/io/resource_loader.h"
+#include "core/io/resource_uid.h"
+#include "core/io/resource_uid_types.h"
 #include "core/object/class_db.h"
 #include "core/object/message_queue.h"
 #include "core/object/script_language.h"
@@ -3884,7 +3886,7 @@ void Main::setup_boot_logo() {
 		// It's too soon to scan the project files since the ResourceFormatImporter is not loaded yet,
 		// so to prevent printing errors, we will just skip the custom boot logo this time.
 		if (boot_logo_path.begins_with("uid://")) {
-			const ResourceUID::ID logo_id = ResourceUID::get_singleton()->text_to_id(boot_logo_path);
+			const ResourceUIDTypes::ID logo_id = ResourceUID::get_singleton()->text_to_id(boot_logo_path);
 			if (ResourceUID::get_singleton()->has_id(logo_id)) {
 				boot_logo_path = ResourceUID::get_singleton()->get_id_path(logo_id).strip_edges();
 			} else {
@@ -4280,7 +4282,7 @@ int Main::start() {
 	if (script.is_empty() && game_path.is_empty()) {
 		const String main_scene = GLOBAL_GET("application/run/main_scene");
 		if (main_scene.begins_with("uid://")) {
-			ResourceUID::ID id = ResourceUID::get_singleton()->text_to_id(main_scene);
+			ResourceUIDTypes::ID id = ResourceUID::get_singleton()->text_to_id(main_scene);
 			if (!editor && !ResourceUID::get_singleton()->has_id(id) && !FileAccess::exists(ResourceUID::get_singleton()->get_cache_file())) {
 				OS::get_singleton()->alert("Main scene's path could not be resolved from UID. Make sure the project is imported first. Aborting.");
 				ERR_FAIL_V_MSG(EXIT_FAILURE, "Main scene's path could not be resolved from UID. Make sure the project is imported first. Aborting.");

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -39,6 +39,7 @@
 #include "core/core_constants.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
+#include "core/io/resource_uid.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "core/templates/hash_map.h"

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -40,6 +40,7 @@
 #include "core/core_globals.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
+#include "core/io/resource_uid.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/string/string_builder.h"

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -39,6 +39,7 @@
 #include "scene/3d/multimesh_instance_3d.h"
 
 class CSGShape3D;
+class FileAccess;
 class GridMap;
 
 class GLTFDocument : public Resource {

--- a/modules/jpg/movie_writer_mjpeg.h
+++ b/modules/jpg/movie_writer_mjpeg.h
@@ -32,6 +32,8 @@
 
 #include "servers/movie_writer/movie_writer.h"
 
+class FileAccess;
+
 class MovieWriterMJPEG : public MovieWriter {
 	GDCLASS(MovieWriterMJPEG, MovieWriter)
 

--- a/modules/mp3/resource_importer_mp3.cpp
+++ b/modules/mp3/resource_importer_mp3.cpp
@@ -95,7 +95,7 @@ void ResourceImporterMP3::show_advanced_options(const String &p_path) {
 }
 #endif
 
-Error ResourceImporterMP3::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterMP3::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	bool loop = p_options["loop"];
 	float loop_offset = p_options["loop_offset"];
 	double bpm = p_options["bpm"];

--- a/modules/mp3/resource_importer_mp3.h
+++ b/modules/mp3/resource_importer_mp3.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid_types.h"
 
 class ResourceImporterMP3 : public ResourceImporter {
 	GDCLASS(ResourceImporterMP3, ResourceImporter);
@@ -53,7 +54,7 @@ public:
 	virtual void show_advanced_options(const String &p_path) override;
 #endif
 
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
 

--- a/modules/multiplayer/multiplayer_spawner.cpp
+++ b/modules/multiplayer/multiplayer_spawner.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/engine.h"
 #include "core/io/resource_loader.h"
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "scene/main/multiplayer_api.h"

--- a/modules/multiplayer/multiplayer_spawner.h
+++ b/modules/multiplayer/multiplayer_spawner.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/io/resource_uid_types.h"
 #include "core/templates/local_vector.h"
 #include "scene/main/node.h"
 #include "scene/resources/packed_scene.h"
@@ -50,7 +51,7 @@ private:
 
 	LocalVector<SpawnableScene> spawnable_scenes;
 
-	HashSet<ResourceUID::ID> spawnable_ids;
+	HashSet<ResourceUIDTypes::ID> spawnable_ids;
 	NodePath spawn_path;
 
 	struct SpawnInfo {

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -34,6 +34,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "editor/editor_node.h"

--- a/modules/theora/editor/movie_writer_ogv.h
+++ b/modules/theora/editor/movie_writer_ogv.h
@@ -37,6 +37,8 @@
 #include <vorbis/codec.h>
 #include <vorbis/vorbisenc.h>
 
+class FileAccess;
+
 class MovieWriterOGV : public MovieWriter {
 	GDCLASS(MovieWriterOGV, MovieWriter)
 

--- a/modules/vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/vorbis/resource_importer_ogg_vorbis.cpp
@@ -93,7 +93,7 @@ void ResourceImporterOggVorbis::show_advanced_options(const String &p_path) {
 }
 #endif
 
-Error ResourceImporterOggVorbis::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+Error ResourceImporterOggVorbis::import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	bool loop = p_options["loop"];
 	double loop_offset = p_options["loop_offset"];
 	double bpm = p_options["bpm"];

--- a/modules/vorbis/resource_importer_ogg_vorbis.h
+++ b/modules/vorbis/resource_importer_ogg_vorbis.h
@@ -33,6 +33,7 @@
 #include "audio_stream_ogg_vorbis.h"
 
 #include "core/io/resource_importer.h"
+#include "core/io/resource_uid_types.h"
 
 class ResourceImporterOggVorbis : public ResourceImporter {
 	GDCLASS(ResourceImporterOggVorbis, ResourceImporter);
@@ -61,7 +62,7 @@ public:
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
-	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+	virtual Error import(ResourceUIDTypes::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
 	virtual bool can_import_threaded() const override { return true; }
 

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -34,9 +34,10 @@
 #include "core/templates/safe_refcount.h"
 #include "scene/main/node.h"
 
+class FileAccess;
+class StreamPeerGZIP;
 class Thread;
 class Timer;
-class StreamPeerGZIP;
 
 class HTTPRequest : public Node {
 	GDCLASS(HTTPRequest, Node);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -37,6 +37,8 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "core/input/input.h"
 #include "core/io/image_loader.h"
 #include "core/io/resource_loader.h"
+#include "core/io/resource_uid.h"
+#include "core/io/resource_uid_types.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/object/worker_thread_pool.h"
@@ -744,7 +746,7 @@ bool SceneTree::process(double p_time) {
 		if (env_path.begins_with("uid://")) {
 			// If an uid path, ensure it is mapped to a resource which could not be
 			// the case if the editor is still scanning the filesystem.
-			ResourceUID::ID id = ResourceUID::get_singleton()->text_to_id(env_path);
+			ResourceUIDTypes::ID id = ResourceUID::get_singleton()->text_to_id(env_path);
 			can_load = ResourceUID::get_singleton()->has_id(id);
 			if (can_load) {
 				env_path = ResourceUID::get_singleton()->get_id_path(id);

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -32,6 +32,8 @@
 
 #include "core/config/engine.h"
 #include "core/io/resource_loader.h"
+#include "core/io/resource_uid.h"
+#include "core/io/resource_uid_types.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "core/templates/local_vector.h"
@@ -292,8 +294,8 @@ void PropertyUtils::assign_custom_type_script(Object *p_object, const Ref<Script
 	const String &path = p_script->get_path();
 	ERR_FAIL_COND(!path.is_resource_file());
 
-	ResourceUID::ID script_uid = ResourceLoader::get_resource_uid(path);
-	if (script_uid != ResourceUID::INVALID_ID) {
+	ResourceUIDTypes::ID script_uid = ResourceLoader::get_resource_uid(path);
+	if (script_uid != ResourceUIDTypes::INVALID_ID) {
 		p_object->set_meta(SceneStringName(_custom_type_script), ResourceUID::get_singleton()->id_to_text(script_uid));
 	}
 }
@@ -308,8 +310,8 @@ Ref<Script> PropertyUtils::get_custom_type_script(const Object *p_object) {
 		return script_object;
 	}
 #endif
-	ResourceUID::ID id = ResourceUID::get_singleton()->text_to_id(custom_script);
-	if (unlikely(id == ResourceUID::INVALID_ID || !ResourceUID::get_singleton()->has_id(id))) {
+	ResourceUIDTypes::ID id = ResourceUID::get_singleton()->text_to_id(custom_script);
+	if (unlikely(id == ResourceUIDTypes::INVALID_ID || !ResourceUID::get_singleton()->has_id(id))) {
 		const_cast<Object *>(p_object)->remove_meta(SceneStringName(_custom_type_script));
 		ERR_FAIL_V_MSG(Ref<Script>(), vformat("Invalid custom type script UID: %s. Removing.", custom_script.operator String()));
 	} else {

--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -35,6 +35,7 @@
 #include "servers/rendering/rendering_server_enums.h"
 
 class BitMap;
+class FileAccess;
 
 class CompressedTexture2D : public Texture2D {
 	GDCLASS(CompressedTexture2D, Texture2D);

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -34,6 +34,7 @@
 #include "core/io/file_access.h"
 #include "core/io/missing_resource.h"
 #include "core/io/resource_loader.h"
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/missing_resource.h"
+#include "core/io/resource_uid.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "scene/property_utils.h"
@@ -490,8 +491,8 @@ Error ResourceLoaderText::load() {
 
 		if (next_tag.fields.has("uid")) {
 			String uidt = next_tag.fields["uid"];
-			ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(uidt);
-			if (uid != ResourceUID::INVALID_ID && ResourceUID::get_singleton()->has_id(uid)) {
+			ResourceUIDTypes::ID uid = ResourceUID::get_singleton()->text_to_id(uidt);
+			if (uid != ResourceUIDTypes::INVALID_ID && ResourceUID::get_singleton()->has_id(uid)) {
 				// If a UID is found and the path is valid, it will be used, otherwise, it falls back to the path.
 				path = ResourceUID::get_singleton()->get_id_path(uid);
 			} else {
@@ -951,8 +952,8 @@ void ResourceLoaderText::get_dependencies(Ref<FileAccess> p_f, List<String> *p_d
 		if (next_tag.fields.has("uid")) {
 			// If uid exists, return uid in text format, not the path.
 			String uidt = next_tag.fields["uid"];
-			ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(uidt);
-			if (uid != ResourceUID::INVALID_ID) {
+			ResourceUIDTypes::ID uid = ResourceUID::get_singleton()->text_to_id(uidt);
+			if (uid != ResourceUIDTypes::INVALID_ID) {
 				fallback_path = path; // Used by Dependency Editor, in case uid path fails.
 				path = ResourceUID::get_singleton()->id_to_text(uid);
 				using_uid = true;
@@ -1020,12 +1021,12 @@ Error ResourceLoaderText::rename_dependencies(Ref<FileAccess> p_f, const String 
 			if (fw.is_null()) {
 				fw = FileAccess::open(p_path + ".depren", FileAccess::WRITE);
 
-				if (res_uid == ResourceUID::INVALID_ID) {
+				if (res_uid == ResourceUIDTypes::INVALID_ID) {
 					res_uid = ResourceSaver::get_resource_id_for_path(p_path);
 				}
 
 				String uid_text = "";
-				if (res_uid != ResourceUID::INVALID_ID) {
+				if (res_uid != ResourceUIDTypes::INVALID_ID) {
 					uid_text = " uid=\"" + ResourceUID::get_singleton()->id_to_text(res_uid) + "\"";
 				}
 
@@ -1051,8 +1052,8 @@ Error ResourceLoaderText::rename_dependencies(Ref<FileAccess> p_f, const String 
 
 			if (next_tag.fields.has("uid")) {
 				String uidt = next_tag.fields["uid"];
-				ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(uidt);
-				if (uid != ResourceUID::INVALID_ID && ResourceUID::get_singleton()->has_id(uid)) {
+				ResourceUIDTypes::ID uid = ResourceUID::get_singleton()->text_to_id(uidt);
+				if (uid != ResourceUIDTypes::INVALID_ID && ResourceUID::get_singleton()->has_id(uid)) {
 					// If a UID is found and the path is valid, it will be used, otherwise, it falls back to the path.
 					path = ResourceUID::get_singleton()->get_id_path(uid);
 				}
@@ -1074,8 +1075,8 @@ Error ResourceLoaderText::rename_dependencies(Ref<FileAccess> p_f, const String 
 
 			String s = "[ext_resource type=\"" + type + "\"";
 
-			ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(path);
-			if (uid != ResourceUID::INVALID_ID) {
+			ResourceUIDTypes::ID uid = ResourceSaver::get_resource_id_for_path(path);
+			if (uid != ResourceUIDTypes::INVALID_ID) {
 				s += " uid=\"" + ResourceUID::get_singleton()->id_to_text(uid) + "\"";
 			}
 			s += " path=\"" + path + "\" id=\"" + id + "\"]";
@@ -1176,7 +1177,7 @@ void ResourceLoaderText::open(Ref<FileAccess> p_f, bool p_skip_first_tag) {
 	if (tag.fields.has("uid")) {
 		res_uid = ResourceUID::get_singleton()->text_to_id(tag.fields["uid"]);
 	} else {
-		res_uid = ResourceUID::INVALID_ID;
+		res_uid = ResourceUIDTypes::INVALID_ID;
 	}
 
 	if (!p_skip_first_tag) {
@@ -1391,7 +1392,7 @@ String ResourceLoaderText::recognize(Ref<FileAccess> p_f) {
 	return tag.fields["type"];
 }
 
-ResourceUID::ID ResourceLoaderText::get_uid(Ref<FileAccess> p_f) {
+ResourceUIDTypes::ID ResourceLoaderText::get_uid(Ref<FileAccess> p_f) {
 	error = OK;
 
 	lines = 1;
@@ -1406,7 +1407,7 @@ ResourceUID::ID ResourceLoaderText::get_uid(Ref<FileAccess> p_f) {
 
 	if (err) {
 		_printerr();
-		return ResourceUID::INVALID_ID;
+		return ResourceUIDTypes::INVALID_ID;
 	}
 
 	if (tag.fields.has("uid")) { //field is optional
@@ -1414,7 +1415,7 @@ ResourceUID::ID ResourceLoaderText::get_uid(Ref<FileAccess> p_f) {
 		return ResourceUID::get_singleton()->text_to_id(uidt);
 	}
 
-	return ResourceUID::INVALID_ID;
+	return ResourceUIDTypes::INVALID_ID;
 }
 
 /////////////////////
@@ -1549,15 +1550,15 @@ String ResourceFormatLoaderText::get_resource_script_class(const String &p_path)
 	return loader.recognize_script_class(f);
 }
 
-ResourceUID::ID ResourceFormatLoaderText::get_resource_uid(const String &p_path) const {
+ResourceUIDTypes::ID ResourceFormatLoaderText::get_resource_uid(const String &p_path) const {
 	const String ext = p_path.get_extension().to_lower();
 	if (ext != "tscn" && ext != "tres") {
-		return ResourceUID::INVALID_ID;
+		return ResourceUIDTypes::INVALID_ID;
 	}
 
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	if (f.is_null()) {
-		return ResourceUID::INVALID_ID; //could not read
+		return ResourceUIDTypes::INVALID_ID; //could not read
 	}
 
 	ResourceLoaderText loader;
@@ -1798,9 +1799,9 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 
 		title += "format=" + itos(use_compat ? ResourceLoaderText::FORMAT_VERSION_COMPAT : ResourceLoaderText::FORMAT_VERSION) + "";
 
-		ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(local_path, true);
+		ResourceUIDTypes::ID uid = ResourceSaver::get_resource_id_for_path(local_path, true);
 
-		if (uid != ResourceUID::INVALID_ID) {
+		if (uid != ResourceUIDTypes::INVALID_ID) {
 			title += " uid=\"" + ResourceUID::get_singleton()->id_to_text(uid) + "\"";
 		}
 
@@ -1870,8 +1871,8 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 
 		String s = "[ext_resource type=\"" + sorted_er[i].resource->get_save_class() + "\"";
 
-		ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(p, false);
-		if (uid != ResourceUID::INVALID_ID) {
+		ResourceUIDTypes::ID uid = ResourceSaver::get_resource_id_for_path(p, false);
+		if (uid != ResourceUIDTypes::INVALID_ID) {
 			s += " uid=\"" + ResourceUID::get_singleton()->id_to_text(uid) + "\"";
 		}
 		s += " path=\"" + p + "\" id=\"" + sorted_er[i].id + "\"]\n";
@@ -2147,7 +2148,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 	return OK;
 }
 
-Error ResourceLoaderText::set_uid(Ref<FileAccess> p_f, ResourceUID::ID p_uid) {
+Error ResourceLoaderText::set_uid(Ref<FileAccess> p_f, ResourceUIDTypes::ID p_uid) {
 	open(p_f, true);
 	ERR_FAIL_COND_V(error != OK, error);
 	ignore_resource_parsing = true;
@@ -2190,7 +2191,7 @@ Error ResourceFormatSaverText::save(const Ref<Resource> &p_resource, const Strin
 	return saver.save(p_path, p_resource, p_flags);
 }
 
-Error ResourceFormatSaverText::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+Error ResourceFormatSaverText::set_uid(const String &p_path, ResourceUIDTypes::ID p_uid) {
 	String lc = p_path.to_lower();
 	if (!lc.ends_with(".tscn") && !lc.ends_with(".tres")) {
 		return ERR_FILE_UNRECOGNIZED;

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -33,6 +33,7 @@
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/io/resource_uid_types.h"
 #include "core/templates/rb_map.h"
 #include "core/variant/variant_parser.h"
 #include "scene/resources/packed_scene.h"
@@ -89,7 +90,7 @@ private:
 
 	mutable int lines = 0;
 
-	ResourceUID::ID res_uid = ResourceUID::INVALID_ID;
+	ResourceUIDTypes::ID res_uid = ResourceUIDTypes::INVALID_ID;
 
 	HashMap<String, String> remaps;
 
@@ -129,7 +130,7 @@ private:
 public:
 	Ref<Resource> get_resource();
 	Error load();
-	Error set_uid(Ref<FileAccess> p_f, ResourceUID::ID p_uid);
+	Error set_uid(Ref<FileAccess> p_f, ResourceUIDTypes::ID p_uid);
 	int get_stage() const;
 	int get_stage_count() const;
 	void set_translation_remapped(bool p_remapped);
@@ -137,7 +138,7 @@ public:
 	void open(Ref<FileAccess> p_f, bool p_skip_first_tag = false);
 	String recognize(Ref<FileAccess> p_f);
 	String recognize_script_class(Ref<FileAccess> p_f);
-	ResourceUID::ID get_uid(Ref<FileAccess> p_f);
+	ResourceUIDTypes::ID get_uid(Ref<FileAccess> p_f);
 	void get_dependencies(Ref<FileAccess> p_f, List<String> *p_dependencies, bool p_add_types);
 	Error rename_dependencies(Ref<FileAccess> p_f, const String &p_path, const HashMap<String, String> &p_map);
 	Error get_classes_used(HashSet<StringName> *r_classes);
@@ -158,7 +159,7 @@ public:
 
 	virtual String get_resource_type(const String &p_path) const override;
 	virtual String get_resource_script_class(const String &p_path) const override;
-	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override;
+	virtual ResourceUIDTypes::ID get_resource_uid(const String &p_path) const override;
 	virtual bool has_custom_uid_support() const override;
 	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false) override;
 	virtual Error rename_dependencies(const String &p_path, const HashMap<String, String> &p_map) override;
@@ -213,7 +214,7 @@ class ResourceFormatSaverText : public ResourceFormatSaver {
 public:
 	static ResourceFormatSaverText *singleton;
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
-	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
+	virtual Error set_uid(const String &p_path, ResourceUIDTypes::ID p_uid) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 

--- a/servers/movie_writer/movie_writer_pngwav.h
+++ b/servers/movie_writer/movie_writer_pngwav.h
@@ -32,6 +32,8 @@
 
 #include "servers/movie_writer/movie_writer.h"
 
+class FileAccess;
+
 class MovieWriterPNGWAV : public MovieWriter {
 	GDCLASS(MovieWriterPNGWAV, MovieWriter)
 


### PR DESCRIPTION
- May help marginally with #111218

`resource_uid.h` isn't a very problematic gateway I suppose, it includes `Object`, `String`, and `HashMap` which may already be available in most locations, but it's still significantly bigger than `resource.h` itself (`GDVIRTUAL`, `RefCounted`, `SelfList`). In practice I've only had to forward-declare `FileAccess` in a few files to compile after this change.

So I'm not sure yet whether this change is worth the hassle. A good use case for running @StarryWorm's analysis tool, which I haven't taken the time to try out yet.