### PR TITLE
Set human-readable names for key editor nodes

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -4360,6 +4360,7 @@ FileSystemDock::FileSystemDock() {
 	toolbar_hbc->add_child(nav_hbc);
 
 	button_hist_prev = memnew(Button);
+	button_hist_prev->set_name("HistoryPrevButton");
 	button_hist_prev->set_theme_type_variation(SceneStringName(FlatButton));
 	button_hist_prev->set_disabled(true);
 	button_hist_prev->set_focus_mode(FOCUS_ACCESSIBILITY);
@@ -4367,6 +4368,7 @@ FileSystemDock::FileSystemDock() {
 	nav_hbc->add_child(button_hist_prev);
 
 	button_hist_next = memnew(Button);
+	button_hist_next->set_name("HistoryNextButton");
 	button_hist_next->set_theme_type_variation(SceneStringName(FlatButton));
 	button_hist_next->set_disabled(true);
 	button_hist_next->set_focus_mode(FOCUS_ACCESSIBILITY);
@@ -4374,6 +4376,7 @@ FileSystemDock::FileSystemDock() {
 	nav_hbc->add_child(button_hist_next);
 
 	current_path_line_edit = memnew(LineEdit);
+	current_path_line_edit->set_name("CurrentPathLineEdit");
 	current_path_line_edit->set_structured_text_bidi_override(TextServer::STRUCTURED_TEXT_FILE);
 	current_path_line_edit->set_accessibility_name(TTRC("Path"));
 	current_path_line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -4381,6 +4384,7 @@ FileSystemDock::FileSystemDock() {
 	toolbar_hbc->add_child(current_path_line_edit);
 
 	button_toggle_display_mode = memnew(Button);
+	button_toggle_display_mode->set_name("ToggleDisplayModeButton");
 	button_toggle_display_mode->connect(SceneStringName(pressed), callable_mp(this, &FileSystemDock::_change_split_mode));
 	button_toggle_display_mode->set_focus_mode(FOCUS_ACCESSIBILITY);
 	button_toggle_display_mode->set_tooltip_text(TTRC("Change Split Mode"));
@@ -4391,6 +4395,7 @@ FileSystemDock::FileSystemDock() {
 	top_vbc->add_child(toolbar2_hbc);
 
 	tree_search_box = memnew(LineEdit);
+	tree_search_box->set_name("TreeSearchBox");
 	tree_search_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	tree_search_box->set_placeholder(TTRC("Filter Files"));
 	tree_search_box->set_clear_button_enabled(true);
@@ -4401,14 +4406,15 @@ FileSystemDock::FileSystemDock() {
 	toolbar2_hbc->add_child(tree_button_sort);
 
 	file_list_popup = memnew(PopupMenu);
-
+	file_list_popup->set_name("FileListPopup");
 	add_child(file_list_popup);
 
 	tree_popup = memnew(PopupMenu);
-
+	tree_popup->set_name("TreePopup");
 	add_child(tree_popup);
 
 	split_box = memnew(SplitContainer);
+	split_box->set_name("SplitBox");
 	split_box->set_v_size_flags(SIZE_EXPAND_FILL);
 	split_box->connect("dragged", callable_mp(this, &FileSystemDock::_split_dragged));
 	split_box_offset_h = 240 * EDSCALE;
@@ -4420,6 +4426,7 @@ FileSystemDock::FileSystemDock() {
 	tree_mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	tree = memnew(FileSystemTree);
+	tree->set_name("FileSystemTree");
 	tree->set_accessibility_name(TTRC("Directories"));
 	tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	tree->set_hide_root(true);
@@ -4449,6 +4456,7 @@ FileSystemDock::FileSystemDock() {
 	file_list_vb->add_child(path_hb);
 
 	file_list_search_box = memnew(LineEdit);
+	file_list_search_box->set_name("FileListSearchBox");
 	file_list_search_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	file_list_search_box->set_placeholder(TTRC("Filter Files"));
 	file_list_search_box->set_accessibility_name(TTRC("Filter Files"));
@@ -4470,6 +4478,7 @@ FileSystemDock::FileSystemDock() {
 	files_mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	files = memnew(FileSystemList);
+	files->set_name("FileList");
 	files->set_accessibility_name(TTRC("Files"));
 	files->set_select_mode(ItemList::SELECT_MULTI);
 	files->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_TOP);

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -734,6 +734,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	main_vb->add_child(general_options_hb);
 
 	resource_new_button = memnew(Button);
+	resource_new_button->set_name("ResourceNewButton");
 	resource_new_button->set_theme_type_variation("FlatMenuButton");
 	resource_new_button->set_tooltip_text(TTRC("Create a new resource in memory and edit it."));
 	general_options_hb->add_child(resource_new_button);
@@ -741,6 +742,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	resource_new_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 
 	resource_load_button = memnew(Button);
+	resource_load_button->set_name("ResourceLoadButton");
 	resource_load_button->set_theme_type_variation("FlatMenuButton");
 	resource_load_button->set_tooltip_text(TTRC("Load an existing resource from disk and edit it."));
 	general_options_hb->add_child(resource_load_button);
@@ -748,6 +750,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	resource_load_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 
 	resource_save_button = memnew(MenuButton);
+	resource_save_button->set_name("ResourceSaveButton");
 	resource_save_button->set_flat(false);
 	resource_save_button->set_theme_type_variation("FlatMenuButton");
 	resource_save_button->set_tooltip_text(TTRC("Save the currently edited resource."));
@@ -759,6 +762,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	resource_save_button->set_disabled(true);
 
 	resource_extra_button = memnew(MenuButton);
+	resource_extra_button->set_name("ResourceExtraButton");
 	resource_extra_button->set_flat(false);
 	resource_extra_button->set_theme_type_variation("FlatMenuButton");
 	resource_extra_button->set_tooltip_text(TTRC("Extra resource options."));
@@ -776,6 +780,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	general_options_hb->add_spacer();
 
 	backward_button = memnew(Button);
+	backward_button->set_name("HistoryBackwardButton");
 	backward_button->set_theme_type_variation(SceneStringName(FlatButton));
 	general_options_hb->add_child(backward_button);
 	backward_button->set_tooltip_text(TTRC("Go to previous edited object in history."));
@@ -783,6 +788,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	backward_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_edit_back));
 
 	forward_button = memnew(Button);
+	forward_button->set_name("HistoryForwardButton");
 	forward_button->set_theme_type_variation(SceneStringName(FlatButton));
 	general_options_hb->add_child(forward_button);
 	forward_button->set_tooltip_text(TTRC("Go to next edited object in history."));
@@ -790,6 +796,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	forward_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_edit_forward));
 
 	history_menu = memnew(MenuButton);
+	history_menu->set_name("HistoryMenu");
 	history_menu->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	history_menu->set_flat(false);
 	history_menu->set_theme_type_variation("FlatMenuButton");
@@ -801,10 +808,12 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	HBoxContainer *subresource_hb = memnew(HBoxContainer);
 	main_vb->add_child(subresource_hb);
 	object_selector = memnew(EditorObjectSelector(EditorNode::get_singleton()->get_editor_selection_history()));
+	object_selector->set_name("ObjectSelector");
 	object_selector->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	subresource_hb->add_child(object_selector);
 
 	open_docs_button = memnew(Button);
+	open_docs_button->set_name("OpenDocsButton");
 	open_docs_button->set_theme_type_variation("FlatMenuButton");
 	open_docs_button->set_disabled(true);
 	open_docs_button->set_tooltip_text(TTRC("Open documentation for this object."));
@@ -821,12 +830,14 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	main_vb->add_child(property_tools_hb);
 
 	search = memnew(LineEdit);
+	search->set_name("SearchLineEdit");
 	search->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	search->set_placeholder(TTRC("Filter Properties"));
 	search->set_clear_button_enabled(true);
 	property_tools_hb->add_child(search);
 
 	object_menu = memnew(MenuButton);
+	object_menu->set_name("ObjectMenu");
 	object_menu->set_flat(false);
 	object_menu->set_theme_type_variation("FlatMenuButton");
 	property_tools_hb->add_child(object_menu);
@@ -879,6 +890,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	inspector = memnew(EditorInspector);
+	inspector->set_name("Inspector");
 	mc->add_child(inspector);
 	inspector->set_autoclear(true);
 	inspector->set_show_categories(true, true);

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1722,6 +1722,7 @@ void SceneTreeDock::_notification(int p_what) {
 			node_shortcuts->set_h_size_flags(SIZE_EXPAND_FILL);
 
 			beginner_node_shortcuts = memnew(VBoxContainer);
+			beginner_node_shortcuts->set_name("BeginnerNodeShortcuts");
 			node_shortcuts->add_child(beginner_node_shortcuts);
 
 			button_2d = memnew(Button);
@@ -4971,6 +4972,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	ED_SHORTCUT("scene_tree/delete", TTRC("Delete"), Key::KEY_DELETE);
 
 	button_add = memnew(Button);
+	button_add->set_name("AddNodeButton");
 	button_add->set_theme_type_variation("FlatMenuButton");
 	button_add->connect(SceneStringName(pressed), callable_mp(this, &SceneTreeDock::_tool_selected).bind(TOOL_NEW, false));
 	button_add->set_tooltip_text(TTRC("Add/Create a New Node."));
@@ -4978,6 +4980,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	filter_hbc->add_child(button_add);
 
 	button_instance = memnew(Button);
+	button_instance->set_name("InstanceSceneButton");
 	button_instance->set_theme_type_variation("FlatMenuButton");
 	button_instance->connect(SceneStringName(pressed), callable_mp(this, &SceneTreeDock::_tool_selected).bind(TOOL_INSTANTIATE, false));
 	button_instance->set_tooltip_text(TTRC("Instantiate a scene file as a Node. Creates an inherited scene if no root node exists."));
@@ -4987,6 +4990,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 
 	// The "Filter Nodes" text input above the Scene Tree Editor.
 	filter = memnew(LineEdit);
+	filter->set_name("FilterLineEdit");
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	filter->set_placeholder(TTRC("Filter Nodes"));
 	filter->set_accessibility_name(TTRC("Filter Nodes"));
@@ -5023,6 +5027,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	button_extend_script->hide();
 
 	button_tree_menu = memnew(MenuButton);
+	button_tree_menu->set_name("TreeMenuButton");
 	button_tree_menu->set_flat(false);
 	button_tree_menu->set_theme_type_variation("FlatMenuButton");
 	button_tree_menu->set_tooltip_text(TTR("Extra scene options."));
@@ -5036,6 +5041,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	main_vbox->add_child(button_hb);
 
 	edit_remote = memnew(Button);
+	edit_remote->set_name("EditRemoteButton");
 	edit_remote->set_theme_type_variation(SceneStringName(FlatButton));
 	edit_remote->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit_remote->set_text(TTR("Remote"));
@@ -5045,6 +5051,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	edit_remote->connect(SceneStringName(pressed), callable_mp(this, &SceneTreeDock::_remote_tree_selected));
 
 	edit_local = memnew(Button);
+	edit_local->set_name("EditLocalButton");
 	edit_local->set_theme_type_variation(SceneStringName(FlatButton));
 	edit_local->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit_local->set_text(TTR("Local"));
@@ -5067,6 +5074,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	create_root_dialog->hide();
 
 	scene_tree = memnew(SceneTreeEditor(false, true, true));
+	scene_tree->set_name("SceneTree");
 	main_mc->add_child(scene_tree);
 	scene_tree->get_scene_tree()->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
 	scene_tree->connect("rmb_pressed", callable_mp(this, &SceneTreeDock::_tree_rmb));
@@ -5096,15 +5104,18 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	add_child(inspect_hovered_node_delay);
 
 	create_dialog = memnew(CreateDialog);
+	create_dialog->set_name("CreateDialog");
 	create_dialog->set_base_type("Node");
 	add_child(create_dialog);
 	create_dialog->connect("create", callable_mp(this, &SceneTreeDock::_create));
 	create_dialog->connect("favorites_updated", callable_mp(this, &SceneTreeDock::_update_create_root_dialog).bind(false));
 
 	rename_dialog = memnew(RenameDialog(scene_tree));
+	rename_dialog->set_name("RenameDialog");
 	add_child(rename_dialog);
 
 	script_create_dialog = memnew(ScriptCreateDialog);
+	script_create_dialog->set_name("ScriptCreateDialog");
 	script_create_dialog->set_inheritance_base_type("Node");
 	add_child(script_create_dialog);
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7683,6 +7683,7 @@ void EditorNode::_renderer_selected(int p_index) {
 
 	if (video_restart_dialog == nullptr) {
 		video_restart_dialog = memnew(ConfirmationDialog);
+		video_restart_dialog->set_name("VideoRestartDialog");
 		video_restart_dialog->set_ok_button_text(TTRC("Save & Restart"));
 		video_restart_dialog->get_label()->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 		gui_base->add_child(video_restart_dialog);
@@ -7910,6 +7911,7 @@ void EditorNode::_build_file_menu() {
 	file_menu->add_shortcut(ED_GET_SHORTCUT("editor/reopen_closed_scene"), SCENE_OPEN_PREV);
 	if (!recent_scenes) {
 		recent_scenes = memnew(PopupMenu);
+		recent_scenes->set_name("RecentScenesMenu");
 		recent_scenes->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 		recent_scenes->connect(SceneStringName(id_pressed), callable_mp(this, &EditorNode::_open_recent_scene));
 	}
@@ -7928,6 +7930,7 @@ void EditorNode::_build_file_menu() {
 
 	if (!export_as_menu) {
 		export_as_menu = memnew(PopupMenu);
+		export_as_menu->set_name("ExportAsMenu");
 		export_as_menu->add_shortcut(ED_GET_SHORTCUT("editor/export_as_mesh_library"), FILE_EXPORT_MESH_LIBRARY);
 		export_as_menu->connect("index_pressed", callable_mp(this, &EditorNode::_export_as_menu_option));
 	}
@@ -7983,6 +7986,7 @@ void EditorNode::_build_project_menu() {
 
 	if (!tool_menu) {
 		tool_menu = memnew(PopupMenu);
+		tool_menu->set_name("ToolMenu");
 		tool_menu->connect("index_pressed", callable_mp(this, &EditorNode::_tool_menu_option));
 		tool_menu->add_shortcut(ED_GET_SHORTCUT("editor/orphan_resource_explorer"), TOOLS_ORPHAN_RESOURCES);
 		tool_menu->add_shortcut(ED_GET_SHORTCUT("editor/engine_compilation_configuration_editor"), TOOLS_BUILD_PROFILE_MANAGER);
@@ -8016,6 +8020,7 @@ void EditorNode::_build_settings_menu() {
 
 	if (!editor_layouts) {
 		editor_layouts = memnew(PopupMenu);
+		editor_layouts->set_name("EditorLayoutsMenu");
 		editor_layouts->connect(SceneStringName(id_pressed), callable_mp(this, &EditorNode::_layout_menu_option));
 	}
 	settings_menu->add_submenu_node_item(TTRC("Editor Layout"), editor_layouts);
@@ -8137,6 +8142,7 @@ void EditorNode::_update_main_menu_type() {
 	// Create new menu.
 	if (new_menu_type == MENU_TYPE_COMPACT) {
 		main_menu_button = memnew(MenuButton);
+		main_menu_button->set_name("MainMenuButton");
 		main_menu_button->set_text(TTRC("Main Menu"));
 		main_menu_button->set_theme_type_variation("MainScreenButton");
 		main_menu_button->set_focus_mode(Control::FOCUS_NONE);
@@ -8166,6 +8172,7 @@ void EditorNode::_update_main_menu_type() {
 		}
 	} else {
 		main_menu_bar = memnew(MenuBar);
+		main_menu_bar->set_name("MainMenuBar");
 		main_menu_bar->set_mouse_filter(Control::MOUSE_FILTER_STOP);
 		main_menu_bar->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 		main_menu_bar->set_theme_type_variation("MainMenuBar");
@@ -8554,10 +8561,12 @@ EditorNode::EditorNode() {
 	resource_preview = memnew(EditorResourcePreview);
 	add_child(resource_preview);
 	progress_dialog = memnew(ProgressDialog);
+	progress_dialog->set_name("ProgressDialog");
 	add_child(progress_dialog);
 	progress_dialog->connect(SceneStringName(visibility_changed), callable_mp(this, &EditorNode::_progress_dialog_visibility_changed));
 
 	gui_base = memnew(Panel);
+	gui_base->set_name("GuiBase");
 	add_child(gui_base);
 
 	// Take up all screen.
@@ -8567,15 +8576,19 @@ EditorNode::EditorNode() {
 	gui_base->set_end(Point2(0, 0));
 
 	main_vbox = memnew(VBoxContainer);
+	main_vbox->set_name("MainVBox");
 
 #ifdef ANDROID_ENABLED
 	base_vbox = memnew(VBoxContainer);
+	base_vbox->set_name("BaseVBox");
 	base_vbox->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT, Control::PRESET_MODE_MINSIZE, theme->get_constant(SNAME("window_border_margin"), EditorStringName(Editor)));
 
 	title_bar = memnew(EditorTitleBar);
+	title_bar->set_name("EditorTitleBar");
 	base_vbox->add_child(title_bar);
 
 	main_hbox = memnew(HBoxContainer);
+	main_hbox->set_name("MainHBox");
 	main_hbox->add_child(main_vbox);
 	main_vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	main_hbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
@@ -8588,6 +8601,7 @@ EditorNode::EditorNode() {
 	gui_base->add_child(main_vbox);
 
 	title_bar = memnew(EditorTitleBar);
+	title_bar->set_name("EditorTitleBar");
 	main_vbox->add_child(title_bar);
 #endif
 
@@ -8639,6 +8653,7 @@ EditorNode::EditorNode() {
 	}
 
 	VBoxContainer *center_vb = memnew(VBoxContainer);
+	center_vb->set_name("CenterVBox");
 	center_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	main_hsplit->add_child(center_vb);
 
@@ -8727,21 +8742,25 @@ EditorNode::EditorNode() {
 	add_child(scan_changes_timer);
 
 	top_split = memnew(VSplitContainer);
+	top_split->set_name("TopSplit");
 	center_split->add_child(top_split);
 	top_split->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	top_split->set_collapsed(true);
 
 	VBoxContainer *srt = memnew(VBoxContainer);
+	srt->set_name("SceneRootVBox");
 	srt->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	srt->add_theme_constant_override("separation", 0);
 	top_split->add_child(srt);
 
 	scene_tabs = memnew(EditorSceneTabs);
+	scene_tabs->set_name("SceneTabs");
 	srt->add_child(scene_tabs);
 	scene_tabs->connect("tab_changed", callable_mp(this, &EditorNode::_set_current_scene));
 	scene_tabs->connect("tab_closed", callable_mp(this, &EditorNode::_scene_tab_closed));
 
 	distraction_free = memnew(Button);
+	distraction_free->set_name("DistractionFreeButton");
 	distraction_free->set_theme_type_variation("FlatMenuButton");
 	ED_SHORTCUT_AND_COMMAND("editor/distraction_free_mode", TTRC("Distraction Free Mode"), KeyModifierMask::CTRL | KeyModifierMask::SHIFT | Key::F11);
 	ED_SHORTCUT_OVERRIDE("editor/distraction_free_mode", "macos", KeyModifierMask::META | KeyModifierMask::SHIFT | Key::D);
@@ -8753,12 +8772,14 @@ EditorNode::EditorNode() {
 	distraction_free->connect(SceneStringName(pressed), callable_mp(this, &EditorNode::_toggle_distraction_free_mode));
 
 	editor_main_screen = memnew(EditorMainScreen);
+	editor_main_screen->set_name("EditorMainScreen");
 	editor_main_screen->set_custom_minimum_size(Size2(0, 80) * EDSCALE);
 	editor_main_screen->set_draw_behind_parent(true);
 	srt->add_child(editor_main_screen);
 	editor_main_screen->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	scene_root = memnew(SubViewport);
+	scene_root->set_name("SceneRoot");
 	scene_root->set_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
 	scene_root->set_translation_domain(StringName());
 	scene_root->set_embedding_subwindows(true);
@@ -8767,55 +8788,70 @@ EditorNode::EditorNode() {
 	scene_root->set_as_audio_listener_2d(true);
 
 	accept = memnew(AcceptDialog);
+	accept->set_name("GenericAcceptDialog");
 	accept->set_autowrap(true);
 	accept->set_min_size(Vector2i(600, 0));
 	accept->set_unparent_when_invisible(true);
 
 	save_accept = memnew(AcceptDialog);
+	save_accept->set_name("SaveAcceptDialog");
 	save_accept->set_unparent_when_invisible(true);
 	save_accept->connect(SceneStringName(confirmed), callable_mp(this, &EditorNode::_menu_option).bind((int)MenuOptions::SCENE_SAVE_AS_SCENE));
 
 	project_export = memnew(ProjectExportDialog);
+	project_export->set_name("ProjectExportDialog");
 	gui_base->add_child(project_export);
 
 	dependency_error = memnew(DependencyErrorDialog);
+	dependency_error->set_name("DependencyErrorDialog");
 	gui_base->add_child(dependency_error);
 
 	editor_settings_dialog = memnew(EditorSettingsDialog);
+	editor_settings_dialog->set_name("EditorSettingsDialog");
 	gui_base->add_child(editor_settings_dialog);
 	editor_settings_dialog->connect("restart_requested", callable_mp(this, &EditorNode::restart_editor).bind(false));
 
 	project_settings_editor = memnew(ProjectSettingsEditor(&editor_data));
+	project_settings_editor->set_name("ProjectSettingsEditor");
 	gui_base->add_child(project_settings_editor);
 
 	scene_import_settings = memnew(SceneImportSettingsDialog);
+	scene_import_settings->set_name("SceneImportSettingsDialog");
 	gui_base->add_child(scene_import_settings);
 
 	audio_stream_import_settings = memnew(AudioStreamImportSettingsDialog);
+	audio_stream_import_settings->set_name("AudioStreamImportSettingsDialog");
 	gui_base->add_child(audio_stream_import_settings);
 
 	fontdata_import_settings = memnew(DynamicFontImportSettingsDialog);
+	fontdata_import_settings->set_name("DynamicFontImportSettingsDialog");
 	gui_base->add_child(fontdata_import_settings);
 
 	export_template_manager = memnew(ExportTemplateManager);
+	export_template_manager->set_name("ExportTemplateManager");
 	gui_base->add_child(export_template_manager);
 
 	feature_profile_manager = memnew(EditorFeatureProfileManager);
+	feature_profile_manager->set_name("FeatureProfileManager");
 	gui_base->add_child(feature_profile_manager);
 
 	build_profile_manager = memnew(EditorBuildProfileManager);
+	build_profile_manager->set_name("BuildProfileManager");
 	gui_base->add_child(build_profile_manager);
 
 	about = memnew(EditorAbout);
+	about->set_name("AboutDialog");
 	gui_base->add_child(about);
 	feature_profile_manager->connect("current_feature_profile_changed", callable_mp(this, &EditorNode::_feature_profile_changed));
 
 #if !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
 	fbx_importer_manager = memnew(FBXImporterManager);
+	fbx_importer_manager->set_name("FBXImporterManager");
 	gui_base->add_child(fbx_importer_manager);
 #endif
 
 	warning = memnew(AcceptDialog);
+	warning->set_name("WarningDialog");
 	warning->set_unparent_when_invisible(true);
 	warning->add_button(TTRC("Copy Text"), true, "copy");
 	warning->connect("custom_action", callable_mp(this, &EditorNode::_copy_warning));
@@ -8957,6 +8993,7 @@ EditorNode::EditorNode() {
 	title_bar->add_child(left_spacer);
 
 	project_title = memnew(Label);
+	project_title->set_name("ProjectTitle");
 	project_title->add_theme_font_override(SceneStringName(font), theme->get_font(SNAME("bold"), EditorStringName(EditorFonts)));
 	project_title->add_theme_font_size_override(SceneStringName(font_size), theme->get_font_size(SNAME("bold_size"), EditorStringName(EditorFonts)));
 	project_title->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
@@ -8980,16 +9017,19 @@ EditorNode::EditorNode() {
 	title_bar->add_child(right_spacer);
 
 	project_run_bar = memnew(EditorRunBar);
+	project_run_bar->set_name("EditorRunBar");
 	project_run_bar->set_mouse_filter(Control::MOUSE_FILTER_STOP);
 	title_bar->add_child(project_run_bar);
 	project_run_bar->connect("play_pressed", callable_mp(this, &EditorNode::_project_run_started));
 	project_run_bar->connect("stop_pressed", callable_mp(this, &EditorNode::_project_run_stopped));
 
 	right_menu_hb = memnew(HBoxContainer);
+	right_menu_hb->set_name("RendererSelection");
 	right_menu_hb->set_mouse_filter(Control::MOUSE_FILTER_STOP);
 	title_bar->add_child(right_menu_hb);
 
 	renderer = memnew(OptionButton);
+	renderer->set_name("RendererSelector");
 	renderer->set_visible(true);
 	renderer->set_flat(true);
 	renderer->set_theme_type_variation("TopBarOptionButton");
@@ -9039,12 +9079,14 @@ EditorNode::EditorNode() {
 	progress_hb = memnew(BackgroundProgress);
 
 	layout_dialog = memnew(EditorLayoutsDialog);
+	layout_dialog->set_name("LayoutDialog");
 	gui_base->add_child(layout_dialog);
 	layout_dialog->set_hide_on_ok(false);
 	layout_dialog->set_size(Size2(225, 270) * EDSCALE);
 	layout_dialog->connect("name_confirmed", callable_mp(this, &EditorNode::_dialog_action));
 
 	update_spinner = memnew(MenuButton);
+	update_spinner->set_name("UpdateSpinner");
 	right_menu_hb->add_child(update_spinner);
 	update_spinner->set_button_icon(theme->get_icon(SNAME("Progress1"), EditorStringName(EditorIcons)));
 	update_spinner->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &EditorNode::_menu_option));
@@ -9141,12 +9183,15 @@ EditorNode::EditorNode() {
 	center_split->connect(SceneStringName(resized), callable_mp(this, &EditorNode::_vp_resized));
 
 	native_shader_source_visualizer = memnew(EditorNativeShaderSourceVisualizer);
+	native_shader_source_visualizer->set_name("NativeShaderSourceVisualizer");
 	gui_base->add_child(native_shader_source_visualizer);
 
 	orphan_resources = memnew(OrphanResourcesDialog);
+	orphan_resources->set_name("OrphanResourcesDialog");
 	gui_base->add_child(orphan_resources);
 
 	confirmation = memnew(ConfirmationDialog);
+	confirmation->set_name("ConfirmationDialog");
 	confirmation_button = confirmation->add_button(TTRC("Don't Save"), DisplayServer::get_singleton()->get_swap_cancel_ok(), "discard");
 	gui_base->add_child(confirmation);
 	confirmation->set_min_size(Vector2(450.0 * EDSCALE, 0));
@@ -9155,6 +9200,7 @@ EditorNode::EditorNode() {
 	confirmation->connect("canceled", callable_mp(this, &EditorNode::_cancel_confirmation));
 
 	save_confirmation = memnew(ConfirmationDialog);
+	save_confirmation->set_name("SaveConfirmationDialog");
 	save_confirmation->add_button(TTRC("Don't Save"), DisplayServer::get_singleton()->get_swap_cancel_ok(), "discard");
 	gui_base->add_child(save_confirmation);
 	save_confirmation->set_min_size(Vector2(450.0 * EDSCALE, 0));
@@ -9164,6 +9210,7 @@ EditorNode::EditorNode() {
 	save_confirmation->connect("about_to_popup", callable_mp(this, &EditorNode::_prepare_save_confirmation_popup));
 
 	gradle_build_manage_templates = memnew(ConfirmationDialog);
+	gradle_build_manage_templates->set_name("GradleBuildManageTemplates");
 	gradle_build_manage_templates->set_text(TTR("Android build template is missing, please install relevant templates."));
 	gradle_build_manage_templates->set_ok_button_text(TTR("Manage Templates"));
 	gradle_build_manage_templates->add_button(TTR("Install from file"))->connect(SceneStringName(pressed), callable_mp(this, &EditorNode::_android_install_build_template));

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -279,15 +279,18 @@ EditorBottomPanel::EditorBottomPanel() :
 	set_theme_type_variation("BottomPanel");
 
 	bottom_hbox = memnew(HBoxContainer);
+	bottom_hbox->set_name("BottomHBox");
 	bottom_hbox->set_mouse_filter(MOUSE_FILTER_IGNORE);
 	get_internal_container()->add_child(bottom_hbox);
 
 	bottom_hbox->add_child(memnew(VSeparator));
 
 	editor_toaster = memnew(EditorToaster);
+	editor_toaster->set_name("EditorToaster");
 	bottom_hbox->add_child(editor_toaster);
 
 	EditorVersionButton *version_btn = memnew(EditorVersionButton(EditorVersionButton::FORMAT_BASIC));
+	version_btn->set_name("VersionButton");
 	// Fade out the version label to be less prominent, but still readable.
 	version_btn->set_self_modulate(Color(1, 1, 1, 0.65));
 	version_btn->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
@@ -298,6 +301,7 @@ EditorBottomPanel::EditorBottomPanel() :
 	bottom_hbox->add_child(h_spacer);
 
 	expand_button = memnew(Button);
+	expand_button->set_name("ExpandButton");
 	bottom_hbox->add_child(expand_button);
 	expand_button->hide();
 	expand_button->set_theme_type_variation("BottomPanelButton");

--- a/editor/gui/editor_toaster.cpp
+++ b/editor/gui/editor_toaster.cpp
@@ -576,6 +576,7 @@ EditorToaster::EditorToaster() {
 
 	// VBox.
 	vbox_container = memnew(VBoxContainer);
+	vbox_container->set_name("ToastVBoxContainer");
 	vbox_container->set_as_top_level(true);
 	vbox_container->connect(SceneStringName(resized), callable_mp(this, &EditorToaster::_update_vbox_position));
 	add_child(vbox_container);
@@ -613,6 +614,7 @@ EditorToaster::EditorToaster() {
 
 	// Main button.
 	main_button = memnew(Button);
+	main_button->set_name("NotificationsButton");
 	main_button->set_accessibility_name(TTRC("Notifications:"));
 	main_button->set_tooltip_text(TTRC("No notifications."));
 	main_button->set_modulate(Color(0.5, 0.5, 0.5));
@@ -625,6 +627,7 @@ EditorToaster::EditorToaster() {
 
 	// Disable notification button.
 	disable_notifications_panel = memnew(PanelContainer);
+	disable_notifications_panel->set_name("DisableNotificationsPanel");
 	disable_notifications_panel->set_as_top_level(true);
 	disable_notifications_panel->add_theme_style_override(SceneStringName(panel), info_panel_style_background);
 	add_child(disable_notifications_panel);

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -6332,11 +6332,13 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 
 	c->add_child(viewport);
 	surface = memnew(Control);
+	surface->set_name("SurfaceControl");
 	SET_DRAG_FORWARDING_CD(surface, Node3DEditorViewport);
 	add_child(surface);
 	surface->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	surface->set_clip_contents(true);
 	camera = memnew(Camera3D);
+	camera->set_name("ViewportCamera");
 	camera->set_disable_gizmos(true);
 	camera->set_cull_mask(((1 << 20) - 1) | (1 << (GIZMO_BASE_LAYER + p_index)) | (1 << GIZMO_EDIT_LAYER) | (1 << GIZMO_GRID_LAYER) | (1 << MISC_TOOL_LAYER));
 	viewport->add_child(camera);
@@ -6352,6 +6354,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	vbox->add_child(hbox);
 
 	view_display_menu = memnew(MenuButton);
+	view_display_menu->set_name("ViewDisplayMenu");
 	view_display_menu->set_flat(false);
 	view_display_menu->set_h_size_flags(0);
 	view_display_menu->set_shortcut_context(this);
@@ -6387,6 +6390,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_DISPLAY_NORMAL), true);
 
 	display_submenu = memnew(PopupMenu);
+	display_submenu->set_name("DisplaySubmenu");
 	display_submenu->set_hide_on_checkable_item_selection(false);
 	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Directional Shadow Splits"), VIEW_DISPLAY_DEBUG_PSSM_SPLITS, SupportedRenderingMethods::FORWARD_PLUS_MOBILE,
 			TTRC("Displays directional shadow splits in different colors to make adjusting split thresholds easier. \nRed: 1st split (closest to the camera), Green: 2nd split, Blue: 3rd split, Yellow: 4th split (furthest from the camera)"));
@@ -6527,6 +6531,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	preview_node = nullptr;
 
 	bottom_center_vbox = memnew(VBoxContainer);
+	bottom_center_vbox->set_name("BottomCenterVBox");
 	bottom_center_vbox->set_anchors_preset(LayoutPreset::PRESET_CENTER);
 	bottom_center_vbox->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -20 * EDSCALE);
 	bottom_center_vbox->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -10 * EDSCALE);
@@ -6535,6 +6540,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	surface->add_child(bottom_center_vbox);
 
 	info_panel = memnew(PanelContainer);
+	info_panel->set_name("InfoPanel");
 	info_panel->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -90 * EDSCALE);
 	info_panel->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -90 * EDSCALE);
 	info_panel->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, -10 * EDSCALE);
@@ -6595,6 +6601,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	frame_time_gradient->add_point(0.5, Color());
 
 	top_right_vbox = memnew(VBoxContainer);
+	top_right_vbox->set_name("TopRightVBox");
 	top_right_vbox->add_theme_constant_override("separation", 10.0 * EDSCALE);
 	top_right_vbox->set_anchors_and_offsets_preset(PRESET_TOP_RIGHT, PRESET_MODE_MINSIZE, 10.0 * EDSCALE);
 	top_right_vbox->set_h_grow_direction(GROW_DIRECTION_BEGIN);
@@ -6602,6 +6609,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	const int navigation_control_size = 150;
 
 	position_control = memnew(ViewportNavigationControl);
+	position_control->set_name("PositionControl");
 	position_control->set_navigation_mode(View3DController::NAV_MODE_MOVE);
 	position_control->set_custom_minimum_size(Size2(navigation_control_size, navigation_control_size) * EDSCALE);
 	position_control->set_h_size_flags(SIZE_SHRINK_END);
@@ -6613,6 +6621,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	surface->add_child(position_control);
 
 	look_control = memnew(ViewportNavigationControl);
+	look_control->set_name("LookControl");
 	look_control->set_navigation_mode(View3DController::NAV_MODE_LOOK);
 	look_control->set_custom_minimum_size(Size2(navigation_control_size, navigation_control_size) * EDSCALE);
 	look_control->set_h_size_flags(SIZE_SHRINK_END);
@@ -6624,6 +6633,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	surface->add_child(look_control);
 
 	rotation_control = memnew(ViewportRotationControl);
+	rotation_control->set_name("RotationControl");
 	rotation_control->set_custom_minimum_size(Size2(80, 80) * EDSCALE);
 	rotation_control->set_h_size_flags(SIZE_SHRINK_END);
 	rotation_control->set_viewport(this);
@@ -6631,6 +6641,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	top_right_vbox->add_child(rotation_control);
 
 	frame_time_panel = memnew(PanelContainer);
+	frame_time_panel->set_name("FrameTimePanel");
 	frame_time_panel->set_mouse_filter(MOUSE_FILTER_IGNORE);
 	top_right_vbox->add_child(frame_time_panel);
 	frame_time_panel->hide();
@@ -6653,6 +6664,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	accept = nullptr;
 
 	selection_menu = memnew(PopupMenu);
+	selection_menu->set_name("SelectionMenu");
 	add_child(selection_menu);
 	selection_menu->set_min_size(Size2(100, 0) * EDSCALE);
 	selection_menu->connect(SceneStringName(id_pressed), callable_mp(this, &Node3DEditorViewport::_selection_result_pressed));
@@ -9916,15 +9928,18 @@ Node3DEditor::Node3DEditor() {
 	editor_selection->add_editor_plugin(this);
 
 	MarginContainer *toolbar_margin = memnew(MarginContainer);
+	toolbar_margin->set_name("ToolbarMargin");
 	toolbar_margin->set_theme_type_variation("MainToolBarMargin");
 	vbc->add_child(toolbar_margin);
 
 	// A fluid container for all toolbars.
 	HFlowContainer *main_flow = memnew(HFlowContainer);
+	main_flow->set_name("MainFlow");
 	toolbar_margin->add_child(main_flow);
 
 	// Main toolbars.
 	HBoxContainer *main_menu_hbox = memnew(HBoxContainer);
+	main_menu_hbox->set_name("MainMenuHBox");
 	main_flow->add_child(main_menu_hbox);
 
 	String sct;
@@ -10142,6 +10157,7 @@ Node3DEditor::Node3DEditor() {
 	PopupMenu *p;
 
 	transform_menu = memnew(MenuButton);
+	transform_menu->set_name("TransformMenu");
 	transform_menu->set_flat(false);
 	transform_menu->set_theme_type_variation("FlatMenuButton");
 	transform_menu->set_text(TTRC("Transform"));
@@ -10159,6 +10175,7 @@ Node3DEditor::Node3DEditor() {
 	p->connect(SceneStringName(id_pressed), callable_mp(this, &Node3DEditor::_menu_item_pressed));
 
 	view_layout_menu = memnew(MenuButton);
+	view_layout_menu->set_name("ViewLayoutMenu");
 	view_layout_menu->set_flat(false);
 	view_layout_menu->set_theme_type_variation("FlatMenuButton");
 	// TRANSLATORS: Noun, name of the 2D/3D View menus.
@@ -10170,7 +10187,9 @@ Node3DEditor::Node3DEditor() {
 	main_menu_hbox->add_child(memnew(VSeparator));
 
 	context_toolbar_panel = memnew(PanelContainer);
+	context_toolbar_panel->set_name("ContextToolbarPanel");
 	context_toolbar_hbox = memnew(HBoxContainer);
+	context_toolbar_hbox->set_name("ContextToolbarHBox");
 	context_toolbar_panel->add_child(context_toolbar_hbox);
 	main_flow->add_child(context_toolbar_panel);
 
@@ -10213,17 +10232,21 @@ Node3DEditor::Node3DEditor() {
 	/* REST OF MENU */
 
 	left_panel_split = memnew(HSplitContainer);
+	left_panel_split->set_name("LeftPanelSplit");
 	left_panel_split->set_v_size_flags(SIZE_EXPAND_FILL);
 	vbc->add_child(left_panel_split);
 
 	right_panel_split = memnew(HSplitContainer);
+	right_panel_split->set_name("RightPanelSplit");
 	right_panel_split->set_v_size_flags(SIZE_EXPAND_FILL);
 	left_panel_split->add_child(right_panel_split);
 
 	shader_split = memnew(VSplitContainer);
+	shader_split->set_name("ShaderSplit");
 	shader_split->set_h_size_flags(SIZE_EXPAND_FILL);
 	right_panel_split->add_child(shader_split);
 	viewport_base = memnew(Node3DEditorViewportContainer);
+	viewport_base->set_name("ViewportBase");
 	shader_split->add_child(viewport_base);
 	viewport_base->set_v_size_flags(SIZE_EXPAND_FILL);
 	for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
@@ -10240,6 +10263,7 @@ Node3DEditor::Node3DEditor() {
 	/* SNAP DIALOG */
 
 	snap_dialog = memnew(ConfirmationDialog);
+	snap_dialog->set_name("SnapDialog");
 	snap_dialog->set_title(TTRC("Snap Settings"));
 	add_child(snap_dialog);
 	snap_dialog->connect(SceneStringName(confirmed), callable_mp(this, &Node3DEditor::_snap_changed));
@@ -10276,6 +10300,7 @@ Node3DEditor::Node3DEditor() {
 	/* SETTINGS DIALOG */
 
 	settings_dialog = memnew(ConfirmationDialog);
+	settings_dialog->set_name("SettingsDialog");
 	settings_dialog->set_title(TTRC("Viewport Settings"));
 	add_child(settings_dialog);
 	settings_vbc = memnew(VBoxContainer);
@@ -10317,6 +10342,7 @@ Node3DEditor::Node3DEditor() {
 	/* XFORM DIALOG */
 
 	xform_dialog = memnew(ConfirmationDialog);
+	xform_dialog->set_name("XformDialog");
 	xform_dialog->set_title(TTRC("Transform Change"));
 	add_child(xform_dialog);
 

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -5614,31 +5614,38 @@ CanvasItemEditor::CanvasItemEditor() {
 	SceneTreeDock::get_singleton()->connect("add_node_used", callable_mp(this, &CanvasItemEditor::_reset_create_position));
 
 	MarginContainer *toolbar_margin = memnew(MarginContainer);
+	toolbar_margin->set_name("ToolbarMargin");
 	toolbar_margin->set_theme_type_variation("MainToolBarMargin");
 	add_child(toolbar_margin);
 
 	// A fluid container for all toolbars.
 	HFlowContainer *main_flow = memnew(HFlowContainer);
+	main_flow->set_name("MainFlow");
 	toolbar_margin->add_child(main_flow);
 
 	// Main toolbars.
 	HBoxContainer *main_menu_hbox = memnew(HBoxContainer);
+	main_menu_hbox->set_name("MainMenuHbox");
 	main_menu_hbox->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	main_flow->add_child(main_menu_hbox);
 
 	bottom_split = memnew(VSplitContainer);
+	bottom_split->set_name("BottomSplit");
 	add_child(bottom_split);
 	bottom_split->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	left_panel_split = memnew(HSplitContainer);
+	left_panel_split->set_name("LeftPanelSplit");
 	bottom_split->add_child(left_panel_split);
 	left_panel_split->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	right_panel_split = memnew(HSplitContainer);
+	right_panel_split->set_name("RightPanelSplit");
 	left_panel_split->add_child(right_panel_split);
 	right_panel_split->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	viewport_scrollable = memnew(Control);
+	viewport_scrollable->set_name("ViewportScrollable");
 	right_panel_split->add_child(viewport_scrollable);
 	viewport_scrollable->set_mouse_filter(MOUSE_FILTER_PASS);
 	viewport_scrollable->set_clip_contents(true);
@@ -5737,6 +5744,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	viewport->add_child(controls_vb);
 
 	select_button = memnew(Button);
+	select_button->set_name("SelectButton");
 	select_button->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	select_button->set_theme_type_variation(SceneStringName(FlatButton));
 	main_menu_hbox->add_child(select_button);
@@ -5759,6 +5767,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	main_menu_hbox->add_child(memnew(VSeparator));
 
 	move_button = memnew(Button);
+	move_button->set_name("MoveButton");
 	move_button->set_theme_type_variation(SceneStringName(FlatButton));
 	main_menu_hbox->add_child(move_button);
 	move_button->set_toggle_mode(true);
@@ -5768,6 +5777,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	move_button->set_accessibility_name(TTRC("Move Mode"));
 
 	rotate_button = memnew(Button);
+	rotate_button->set_name("RotateButton");
 	rotate_button->set_theme_type_variation(SceneStringName(FlatButton));
 	main_menu_hbox->add_child(rotate_button);
 	rotate_button->set_toggle_mode(true);
@@ -5777,6 +5787,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	rotate_button->set_accessibility_name(TTRC("Rotate Mode"));
 
 	scale_button = memnew(Button);
+	scale_button->set_name("ScaleButton");
 	scale_button->set_theme_type_variation(SceneStringName(FlatButton));
 	main_menu_hbox->add_child(scale_button);
 	scale_button->set_toggle_mode(true);
@@ -5849,6 +5860,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	grid_snap_button->set_shortcut_context(this);
 
 	snap_config_menu = memnew(MenuButton);
+	snap_config_menu->set_name("SnapConfigMenu");
 	snap_config_menu->set_flat(false);
 	snap_config_menu->set_theme_type_variation("FlatMenuButton");
 	snap_config_menu->set_shortcut_context(this);
@@ -5921,6 +5933,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	main_menu_hbox->add_child(memnew(VSeparator));
 
 	skeleton_menu = memnew(MenuButton);
+	skeleton_menu->set_name("SkeletonMenu");
 	skeleton_menu->set_flat(false);
 	skeleton_menu->set_theme_type_variation("FlatMenuButton");
 	skeleton_menu->set_shortcut_context(this);
@@ -5938,6 +5951,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	main_menu_hbox->add_child(memnew(VSeparator));
 
 	view_menu = memnew(MenuButton);
+	view_menu->set_name("ViewMenu");
 	view_menu->set_flat(false);
 	view_menu->set_theme_type_variation("FlatMenuButton");
 	// TRANSLATORS: Noun, name of the 2D/3D View menus.
@@ -6008,7 +6022,9 @@ CanvasItemEditor::CanvasItemEditor() {
 
 	// Contextual toolbars.
 	context_toolbar_panel = memnew(PanelContainer);
+	context_toolbar_panel->set_name("ContextToolbarPanel");
 	context_toolbar_hbox = memnew(HBoxContainer);
+	context_toolbar_hbox->set_name("ContextToolbarHbox");
 	context_toolbar_panel->add_child(context_toolbar_hbox);
 	main_flow->add_child(context_toolbar_panel);
 
@@ -6081,12 +6097,14 @@ CanvasItemEditor::CanvasItemEditor() {
 	p->add_shortcut(ED_SHORTCUT("canvas_item_editor/anim_clear_pose", TTRC("Clear Pose"), KeyModifierMask::SHIFT | Key::K), ANIM_CLEAR_POSE);
 
 	snap_dialog = memnew(SnapDialog);
+	snap_dialog->set_name("SnapDialog");
 	snap_dialog->connect(SceneStringName(confirmed), callable_mp(this, &CanvasItemEditor::_snap_changed));
 	add_child(snap_dialog);
 
 	select_sb.instantiate();
 
 	selection_menu = memnew(PopupMenu);
+	selection_menu->set_name("SelectionMenu");
 	add_child(selection_menu);
 	selection_menu->set_min_size(Vector2(100, 0));
 	selection_menu->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
@@ -6094,6 +6112,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	selection_menu->connect("popup_hide", callable_mp(this, &CanvasItemEditor::_selection_menu_hide), CONNECT_DEFERRED);
 
 	add_node_menu = memnew(PopupMenu);
+	add_node_menu->set_name("AddNodeMenu");
 	add_child(add_node_menu);
 	add_node_menu->connect(SceneStringName(id_pressed), callable_mp(this, &CanvasItemEditor::_add_node_pressed));
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Starts to implement: 
* https://github.com/godotengine/godot-proposals/issues/1018

I'll just quote the proposal for why:

> When implementing new features in the editor, it's often useful to refer to the scene tree to see how things are organized. This can be done using print_tree_pretty() or with Zylann's excellent [EditorDebugger](https://github.com/Zylann/godot_editor_debugger_plugin) add-on.
> 
> Unfortunately, most nodes in the editor don't have manually assigned names, which makes this tree much less human-readable than it could be.
> 

The argument against this is that it gives the impression for plugin developers that these nodes are stable, and will use them instead of the provided API, and if one doesn't exist create a proposal. 

Personally, I feel like if a plugin developer needs to use these, they're already in the weeds with some kind of advanced use case and are aware when it's worth suggesting exposing some of these nodes via an API. I often find myself in this position and find it hard to justify creating new methods, and there are comments in the proposal that reinforce this. 

As well if reworking the nodes in the editor does break something for plugins, at least with names it's much easier to look into the source code why. Lastly, having names helps in advanced use cases where node order depends on the operating system, other plugins, or if it's the Mono version.


**Note:** This PR only covers the main parts of the editor including the 2D/3D editor plugins for now.
