### PR TITLE
Move unsaved script indicator (*) before the script name in the script editor list

### DIFF
--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -78,7 +78,7 @@ String ScriptEditorBase::get_name() {
 	}
 
 	if (is_unsaved()) {
-		name += "(*)";
+		name = "(*)" + name;
 	}
 
 	return name;


### PR DESCRIPTION
I often find myself expanding the script ItemList just to check whether the unsaved indicator is visible.

While having (*) at the end of the name makes sense for tab bars (the scene tabs, script tabs in VSCode, etc.), it would feels more natural at the beginning for the script list, where names tend to get truncated.

This is the tiniest UX change possible, so I felt like I could get away with skipping a proposal in [godotengine/godot-proposals](https://github.com/godotengine/godot-proposals).