### PR TITLE
Implement sandbox check for openKylin Kaiming

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -232,6 +232,11 @@ String OS_LinuxBSD::get_processor_name() const {
 }
 
 bool OS_LinuxBSD::is_sandboxed() const {
+	// Check for openKylin Kaiming
+	if (has_environment("KAIMING_ID")) {
+		return true;
+	}
+	
 	// This function is derived from SDL:
 	// https://github.com/libsdl-org/SDL/blob/main/src/core/linux/SDL_sandbox.c#L28-L45
 


### PR DESCRIPTION
Add openKylin Kaiming version detection to the is_sandboxed function for accurate sandbox status checks.

Refs: https://gitee.com/kaiming-docs/kaiming-design-docs/