### PR TITLE
Implement sandbox check for openKylin Kaiming

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -248,6 +248,10 @@ bool OS_LinuxBSD::is_sandboxed() const {
 	if (access("/run/host/container-manager", F_OK) == 0) {
 		return true;
 	}
+	
+	if (has_environment("KAIMING_ID")) {
+		return true;
+	}
 
 	return false;
 }


### PR DESCRIPTION
Add openKylin Kaiming version detection to the is_sandboxed function for accurate sandbox status checks.

Refs: https://gitee.com/kaiming-docs/kaiming-design-docs/