### PR TITLE
Fix hint string parsing for nested dictionaries

### DIFF
--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -1174,7 +1174,7 @@ void EditorPropertyDictionary::_change_type_menu(int p_index) {
 }
 
 void EditorPropertyDictionary::setup(PropertyHint p_hint, const String &p_hint_string) {
-	PackedStringArray types = p_hint_string.split(";");
+	PackedStringArray types = p_hint_string.split(";", true, 1);
 	if (types.size() > 0 && !types[0].is_empty()) {
 		String key = types[0];
 		int hint_key_subtype_separator = key.find_char(':');


### PR DESCRIPTION
Fixes #104259
Helps #107556

Changes the inspector's hint string parsing to only split on the first `;` instead of all instances which caused the nested hint strings to get decimated and not passed down correctly. This allows typed dictionaries to be nested as the value via property list manipulation. For easier to define nested collection support, see #107556 .

This would also be fixed with the hint string parsing used in #112632, but I went with the minimal change while the other PR is in review.

**Note**: This does not help defining a nested dictionary as a key, only a value. Supporting that kind of hint string would need some kind of grouping syntax to know which `;` belongs to which level of the nesting. This PR is only trying to improve the more common use case.

Working nested collections in editor:
<img width="596" height="561" alt="image" src="https://github.com/user-attachments/assets/36b69262-0e09-427a-bd8e-b3ea14c8ba09" />
<img width="599" height="575" alt="image" src="https://github.com/user-attachments/assets/83b1359c-2b13-46cc-990f-d8db067c10b9" />


<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
