### PR TITLE
Wayland: Only report HDR request failed warning if HDR was actually requested

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1527,7 +1527,7 @@ bool DisplayServerWayland::window_is_hdr_output_supported(DisplayServerEnums::Wi
 
 void DisplayServerWayland::window_request_hdr_output(const bool p_enabled, DisplayServerEnums::WindowID p_window_id) {
 #if defined(RD_ENABLED)
-	ERR_FAIL_COND_MSG(!(rendering_device && rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)), "HDR output is not supported by the rendering device.");
+	ERR_FAIL_COND_MSG(p_enabled && !(rendering_device && rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)), "HDR output is not supported by the rendering device.");
 #endif
 
 	ERR_FAIL_COND(!windows.has(p_window_id));


### PR DESCRIPTION
Fixes #117527

Everything capable of setting HDR on/off assumes that setting it to off won't raise any warns/errors, this check was missing from the Wayland implementation and would always warn if the RenderingDriver didn't support HDR (like OpenGL).
