### PR TITLE
CI: Add `#include` validation hook

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -123,7 +123,7 @@ IncludeCategories:
     Priority: 20
   - Regex: ^"(modules|platform)/.*"$
     Priority: 30
-  - Regex: ^"thirdparty/.*"$
+  - Regex: ^<thirdparty/.*>$
     Priority: 40
   - Regex: ^<(windows|Jolt/Jolt|platform_gl)\.h>$
     Priority: 50

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,10 +110,16 @@ repos:
         additional_dependencies: [xmlschema]
 
       - id: validate-codeowners
-        name: validate codeowners
+        name: validate-codeowners
         language: python
         entry: python misc/scripts/validate_codeowners.py
         args: [--unowned]
+
+      - id: validate-includes
+        name: validate-includes
+        language: python
+        entry: python misc/scripts/validate_includes.py
+        files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|m|mm|inc)$
 
       - id: eslint
         name: eslint

--- a/core/extension/gdextension_function_loader.cpp
+++ b/core/extension/gdextension_function_loader.cpp
@@ -30,7 +30,7 @@
 
 #include "gdextension_function_loader.h"
 
-#include "gdextension.h"
+#include "core/extension/gdextension.h"
 
 Error GDExtensionFunctionLoader::open_library(const String &p_path) {
 	ERR_FAIL_COND_V_MSG(!p_path.begins_with("libgodot://"), ERR_FILE_NOT_FOUND, "Function based GDExtensions should have a path starting with libgodot://");

--- a/core/extension/libgodot.h
+++ b/core/extension/libgodot.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "gdextension_interface.gen.h"
+#include "core/extension/gdextension_interface.gen.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -42,7 +42,7 @@
 #include "core/os/thread.h"
 #endif
 
-#include "thirdparty/gamepadmotionhelpers/GamepadMotion.hpp"
+#include <thirdparty/gamepadmotionhelpers/GamepadMotion.hpp>
 
 #define STANDARD_GRAVITY 9.80665f
 

--- a/core/io/compression.cpp
+++ b/core/io/compression.cpp
@@ -33,6 +33,7 @@
 #include "core/io/zip_io.h"
 
 #include <thirdparty/misc/fastlz.h>
+
 #include <zstd.h>
 
 #ifdef BROTLI_ENABLED

--- a/core/io/compression.cpp
+++ b/core/io/compression.cpp
@@ -32,8 +32,7 @@
 
 #include "core/io/zip_io.h"
 
-#include "thirdparty/misc/fastlz.h"
-
+#include <thirdparty/misc/fastlz.h>
 #include <zstd.h>
 
 #ifdef BROTLI_ENABLED

--- a/core/io/file_access_patched.cpp
+++ b/core/io/file_access_patched.cpp
@@ -30,9 +30,8 @@
 
 #include "file_access_patched.h"
 
-#include "file_access_pack.h"
-
 #include "core/io/delta_encoding.h"
+#include "core/io/file_access_pack.h"
 #include "core/os/os.h"
 
 Error FileAccessPatched::_apply_patch() const {

--- a/core/io/file_access_patched.h
+++ b/core/io/file_access_patched.h
@@ -30,8 +30,8 @@
 
 #pragma once
 
-#include "file_access.h"
-#include "file_access_memory.h"
+#include "core/io/file_access.h"
+#include "core/io/file_access_memory.h"
 
 class FileAccessPatched : public FileAccess {
 	GDSOFTCLASS(FileAccessPatched, FileAccess);

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -34,7 +34,7 @@
 
 #include "core/io/file_access_pack.h"
 
-#include "thirdparty/minizip/unzip.h"
+#include <thirdparty/minizip/unzip.h>
 
 class ZipArchive : public PackSource {
 public:

--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -30,9 +30,8 @@
 
 #pragma once
 
-#include "http_client.h"
-
 #include "core/crypto/crypto.h"
+#include "core/io/http_client.h"
 #include "core/io/ip.h"
 
 class StreamPeerTCP;

--- a/core/io/zip_io.h
+++ b/core/io/zip_io.h
@@ -33,8 +33,8 @@
 #include "core/io/file_access.h"
 
 // This file serves as the Godot interface to minizip.
-#include "thirdparty/minizip/unzip.h" // IWYU pragma: export
-#include "thirdparty/minizip/zip.h" // IWYU pragma: export
+#include <thirdparty/minizip/unzip.h> // IWYU pragma: export
+#include <thirdparty/minizip/zip.h> // IWYU pragma: export
 
 // Get the current file info and safely convert the full filepath to a String.
 int godot_unzip_get_current_file_info(unzFile p_zip_file, unz_file_info64 &r_file_info, String &r_filepath);

--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -50,8 +50,7 @@
 // TYPE_BODY
 // and pairable_mask is either 0 if static, or set to all if non static
 
-#include "bvh_tree.h"
-
+#include "core/math/bvh_tree.h"
 #include "core/math/geometry_3d.h"
 #include "core/os/mutex.h"
 

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -169,8 +169,8 @@ template <typename T, int NUM_TREES, int MAX_CHILDREN, int MAX_ITEMS, typename U
 class BVH_Tree {
 	friend class BVH;
 
-#include "bvh_pair.inc"
-#include "bvh_structs.inc"
+#include "core/math/bvh_pair.inc"
+#include "core/math/bvh_structs.inc"
 
 public:
 	BVH_Tree() {
@@ -440,14 +440,14 @@ private:
 		return child_node_id;
 	}
 
-#include "bvh_cull.inc"
-#include "bvh_debug.inc"
-#include "bvh_integrity.inc"
-#include "bvh_logic.inc"
-#include "bvh_misc.inc"
-#include "bvh_public.inc"
-#include "bvh_refit.inc"
-#include "bvh_split.inc"
+#include "core/math/bvh_cull.inc"
+#include "core/math/bvh_debug.inc"
+#include "core/math/bvh_integrity.inc"
+#include "core/math/bvh_logic.inc"
+#include "core/math/bvh_misc.inc"
+#include "core/math/bvh_public.inc"
+#include "core/math/bvh_refit.inc"
+#include "core/math/bvh_split.inc"
 };
 
 #undef VERBOSE_PRINT

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -35,7 +35,7 @@
 #include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
 
-#include "thirdparty/misc/ok_color.h"
+#include <thirdparty/misc/ok_color.h>
 
 uint32_t Color::to_argb32() const {
 	uint32_t c = (uint8_t)Math::round(a * 255.0f);

--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -39,7 +39,7 @@
 #include "core/templates/local_vector.h"
 #include "core/templates/vector.h"
 
-#include "thirdparty/misc/r128.h"
+#include <thirdparty/misc/r128.h>
 
 class Delaunay3D {
 	struct Simplex;

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -33,11 +33,11 @@
 #include "core/math/math_funcs_binary.h"
 
 GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Walloc-zero")
-#include "thirdparty/clipper2/include/clipper2/clipper.h"
+#include <thirdparty/clipper2/include/clipper2/clipper.h>
 GODOT_GCC_WARNING_POP
-#include "thirdparty/misc/polypartition.h"
+#include <thirdparty/misc/polypartition.h>
 #define STB_RECT_PACK_IMPLEMENTATION
-#include "thirdparty/misc/stb_rect_pack.h"
+#include <thirdparty/misc/stb_rect_pack.h>
 
 const int clipper_precision = 5; // Based on CMP_EPSILON.
 

--- a/core/math/random_pcg.h
+++ b/core/math/random_pcg.h
@@ -32,7 +32,7 @@
 
 #include "core/math/math_funcs.h"
 
-#include "thirdparty/misc/pcg.h"
+#include <thirdparty/misc/pcg.h>
 
 #include <cmath> // ldexp
 

--- a/core/os/condition_variable.h
+++ b/core/os/condition_variable.h
@@ -37,7 +37,7 @@
 
 #ifdef MINGW_ENABLED
 #define MINGW_STDTHREAD_REDUNDANCY_WARNING
-#include "thirdparty/mingw-std-threads/mingw.condition_variable.h"
+#include <thirdparty/mingw-std-threads/mingw.condition_variable.h>
 #define THREADING_NAMESPACE mingw_stdthread
 #else
 #include <condition_variable>

--- a/core/os/mutex.h
+++ b/core/os/mutex.h
@@ -34,7 +34,7 @@
 
 #ifdef MINGW_ENABLED
 #define MINGW_STDTHREAD_REDUNDANCY_WARNING
-#include "thirdparty/mingw-std-threads/mingw.mutex.h"
+#include <thirdparty/mingw-std-threads/mingw.mutex.h>
 #define THREADING_NAMESPACE mingw_stdthread
 #else
 #include <mutex>

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -43,7 +43,7 @@
 
 #ifdef MINGW_ENABLED
 #define MINGW_STDTHREAD_REDUNDANCY_WARNING
-#include "thirdparty/mingw-std-threads/mingw.thread.h"
+#include <thirdparty/mingw-std-threads/mingw.thread.h>
 #define THREADING_NAMESPACE mingw_stdthread
 #else
 #include <thread>

--- a/core/os/rw_lock.h
+++ b/core/os/rw_lock.h
@@ -34,7 +34,7 @@
 
 #ifdef MINGW_ENABLED
 #define MINGW_STDTHREAD_REDUNDANCY_WARNING
-#include "thirdparty/mingw-std-threads/mingw.shared_mutex.h"
+#include <thirdparty/mingw-std-threads/mingw.shared_mutex.h>
 #define THREADING_NAMESPACE mingw_stdthread
 #else
 #include <shared_mutex>

--- a/core/os/semaphore.h
+++ b/core/os/semaphore.h
@@ -40,8 +40,8 @@
 
 #ifdef MINGW_ENABLED
 #define MINGW_STDTHREAD_REDUNDANCY_WARNING
-#include "thirdparty/mingw-std-threads/mingw.condition_variable.h"
-#include "thirdparty/mingw-std-threads/mingw.mutex.h"
+#include <thirdparty/mingw-std-threads/mingw.condition_variable.h>
+#include <thirdparty/mingw-std-threads/mingw.mutex.h>
 #define THREADING_NAMESPACE mingw_stdthread
 #else
 #include <condition_variable>

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -52,7 +52,7 @@
 
 #ifdef MINGW_ENABLED
 #define MINGW_STDTHREAD_REDUNDANCY_WARNING
-#include "thirdparty/mingw-std-threads/mingw.thread.h"
+#include <thirdparty/mingw-std-threads/mingw.thread.h>
 #define THREADING_NAMESPACE mingw_stdthread
 #else
 #include <thread>

--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -34,7 +34,7 @@
 #include "core/templates/pair.h"
 
 extern "C" {
-#include "thirdparty/misc/smaz.h"
+#include <thirdparty/misc/smaz.h>
 }
 
 struct CompressedString {

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -47,7 +47,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, Object);
 #include "core/variant/variant.h"
 #include "core/version_generated.gen.h"
 
-#include "thirdparty/grisu2/grisu2.h"
+#include <thirdparty/grisu2/grisu2.h>
 
 #include <cstdio>
 

--- a/core/templates/lru.h
+++ b/core/templates/lru.h
@@ -30,8 +30,8 @@
 
 #pragma once
 
-#include "hash_map.h"
-#include "list.h"
+#include "core/templates/hash_map.h"
+#include "core/templates/list.h"
 
 template <typename TKey, typename TData, typename Hasher = HashMapHasherDefault, typename Comparator = HashMapComparatorDefault<TKey>, void (*BeforeEvict)(TKey &, TData &) = nullptr>
 class LRUCache {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -28,8 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "variant.h"
-
 #include "core/debugger/engine_debugger.h"
 #include "core/io/compression.h"
 #include "core/io/marshalls.h"
@@ -38,6 +36,7 @@
 #include "core/templates/local_vector.h"
 #include "core/variant/binder_common.h"
 #include "core/variant/method_ptrcall.h"
+#include "core/variant/variant.h"
 #include "core/variant/variant_internal.h"
 
 typedef void (*VariantFunc)(Variant &r_ret, Variant &p_self, const Variant **p_args);

--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -30,10 +30,9 @@
 
 #pragma once
 
-#include "variant.h"
-
 #include "core/templates/a_hash_map.h"
 #include "core/variant/binder_common.h"
+#include "core/variant/variant.h"
 #include "core/variant/variant_internal.h"
 
 template <typename T>

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -30,10 +30,9 @@
 
 #pragma once
 
-#include "variant.h"
-
 #include "core/variant/method_ptrcall.h"
 #include "core/variant/type_info.h"
+#include "core/variant/variant.h"
 #include "core/variant/variant_internal.h"
 
 template <typename Evaluator>

--- a/core/variant/variant_setget.h
+++ b/core/variant/variant_setget.h
@@ -30,9 +30,8 @@
 
 #pragma once
 
-#include "variant.h"
-
 #include "core/variant/method_ptrcall.h"
+#include "core/variant/variant.h"
 #include "core/variant/variant_internal.h"
 
 /**** NAMED SETTERS AND GETTERS ****/

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "variant.h"
+#include "core/variant/variant.h"
 
 struct VariantUtilityFunctions {
 	// Math

--- a/drivers/alsa/asound-so_wrap.c
+++ b/drivers/alsa/asound-so_wrap.c
@@ -1276,7 +1276,7 @@
 #define snd_midi_event_encode snd_midi_event_encode_dylibloader_orig_asound
 #define snd_midi_event_encode_byte snd_midi_event_encode_byte_dylibloader_orig_asound
 #define snd_midi_event_decode snd_midi_event_decode_dylibloader_orig_asound
-#include "thirdparty/linuxbsd_headers/alsa/asoundlib.h"
+#include <thirdparty/linuxbsd_headers/alsa/asoundlib.h>
 #undef snd_asoundlib_version
 #undef snd_dlopen
 #undef snd_dlsym

--- a/drivers/alsa/asound-so_wrap.h
+++ b/drivers/alsa/asound-so_wrap.h
@@ -1278,7 +1278,7 @@
 #define snd_midi_event_encode snd_midi_event_encode_dylibloader_orig_asound
 #define snd_midi_event_encode_byte snd_midi_event_encode_byte_dylibloader_orig_asound
 #define snd_midi_event_decode snd_midi_event_decode_dylibloader_orig_asound
-#include "thirdparty/linuxbsd_headers/alsa/asoundlib.h" // IWYU pragma: export.
+#include <thirdparty/linuxbsd_headers/alsa/asoundlib.h> // IWYU pragma: export.
 #undef snd_asoundlib_version
 #undef snd_dlopen
 #undef snd_dlsym

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -37,7 +37,7 @@
 #include "core/os/os.h"
 
 #ifdef SOWRAP_ENABLED
-#include "asound-so_wrap.h"
+#include "drivers/alsa/asound-so_wrap.h"
 #else
 #include <alsa/asoundlib.h>
 #endif

--- a/drivers/apple_embedded/app_delegate_service.mm
+++ b/drivers/apple_embedded/app_delegate_service.mm
@@ -30,13 +30,12 @@
 
 #import "app_delegate_service.h"
 
-#import "godot_view_apple_embedded.h"
-#import "godot_view_controller.h"
-#import "os_apple_embedded.h"
-
 #include "core/config/project_settings.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
+#import "drivers/apple_embedded/godot_view_apple_embedded.h"
+#import "drivers/apple_embedded/godot_view_controller.h"
+#import "drivers/apple_embedded/os_apple_embedded.h"
 #import "drivers/coreaudio/audio_driver_coreaudio.h"
 #include "main/main.h"
 

--- a/drivers/apple_embedded/apple_embedded.mm
+++ b/drivers/apple_embedded/apple_embedded.mm
@@ -30,10 +30,9 @@
 
 #import "apple_embedded.h"
 
-#import "app_delegate_service.h"
-#import "godot_view_controller.h"
-
 #include "core/object/class_db.h"
+#import "drivers/apple_embedded/app_delegate_service.h"
+#import "drivers/apple_embedded/godot_view_controller.h"
 
 #import <CoreHaptics/CoreHaptics.h>
 #import <UIKit/UIKit.h>

--- a/drivers/apple_embedded/bridging_header_apple_embedded.h
+++ b/drivers/apple_embedded/bridging_header_apple_embedded.h
@@ -31,8 +31,8 @@
 #pragma once
 
 // IWYU pragma: begin_exports.
-#import "app_delegate_service.h"
-#import "godot_app_delegate.h"
-#import "godot_view_apple_embedded.h"
-#import "godot_view_controller.h"
+#import "drivers/apple_embedded/app_delegate_service.h"
+#import "drivers/apple_embedded/godot_app_delegate.h"
+#import "drivers/apple_embedded/godot_view_apple_embedded.h"
+#import "drivers/apple_embedded/godot_view_controller.h"
 // IWYU pragma: end_exports.

--- a/drivers/apple_embedded/display_server_apple_embedded.h
+++ b/drivers/apple_embedded/display_server_apple_embedded.h
@@ -37,7 +37,7 @@
 #include "servers/rendering/rendering_device.h"
 
 #if defined(VULKAN_ENABLED)
-#import "rendering_context_driver_vulkan_apple_embedded.h"
+#import "drivers/apple_embedded/rendering_context_driver_vulkan_apple_embedded.h"
 
 #include <drivers/vulkan/godot_vulkan.h>
 #endif // VULKAN_ENABLED

--- a/drivers/apple_embedded/display_server_apple_embedded.mm
+++ b/drivers/apple_embedded/display_server_apple_embedded.mm
@@ -30,19 +30,18 @@
 
 #import "display_server_apple_embedded.h"
 
-#import "app_delegate_service.h"
-#import "apple_embedded.h"
-#import "godot_keyboard_input_view.h"
-#import "godot_view_apple_embedded.h"
-#import "godot_view_controller.h"
-#import "key_mapping_apple_embedded.h"
-#import "os_apple_embedded.h"
-#import "tts_apple_embedded.h"
-
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/io/file_access_pack.h"
 #include "core/os/os.h"
+#import "drivers/apple_embedded/app_delegate_service.h"
+#import "drivers/apple_embedded/apple_embedded.h"
+#import "drivers/apple_embedded/godot_keyboard_input_view.h"
+#import "drivers/apple_embedded/godot_view_apple_embedded.h"
+#import "drivers/apple_embedded/godot_view_controller.h"
+#import "drivers/apple_embedded/key_mapping_apple_embedded.h"
+#import "drivers/apple_embedded/os_apple_embedded.h"
+#import "drivers/apple_embedded/tts_apple_embedded.h"
 #include "servers/display/native_menu.h"
 
 #import <GameController/GameController.h>

--- a/drivers/apple_embedded/godot_app_delegate.mm
+++ b/drivers/apple_embedded/godot_app_delegate.mm
@@ -30,9 +30,8 @@
 
 #import "godot_app_delegate.h"
 
-#import "app_delegate_service.h"
-
 #include "core/typedefs.h"
+#import "drivers/apple_embedded/app_delegate_service.h"
 
 @implementation GDTApplicationDelegate
 

--- a/drivers/apple_embedded/godot_keyboard_input_view.mm
+++ b/drivers/apple_embedded/godot_keyboard_input_view.mm
@@ -30,10 +30,9 @@
 
 #import "godot_keyboard_input_view.h"
 
-#import "display_server_apple_embedded.h"
-#import "os_apple_embedded.h"
-
 #include "core/os/keyboard.h"
+#import "drivers/apple_embedded/display_server_apple_embedded.h"
+#import "drivers/apple_embedded/os_apple_embedded.h"
 
 @interface GDTKeyboardInputView () <UITextViewDelegate>
 

--- a/drivers/apple_embedded/godot_view_apple_embedded.mm
+++ b/drivers/apple_embedded/godot_view_apple_embedded.mm
@@ -30,13 +30,12 @@
 
 #import "godot_view_apple_embedded.h"
 
-#import "display_layer_apple_embedded.h"
-#import "display_server_apple_embedded.h"
-#import "godot_view_renderer.h"
-
 #include "core/config/project_settings.h"
 #include "core/os/keyboard.h"
 #include "core/string/ustring.h"
+#import "drivers/apple_embedded/display_layer_apple_embedded.h"
+#import "drivers/apple_embedded/display_server_apple_embedded.h"
+#import "drivers/apple_embedded/godot_view_renderer.h"
 
 #import <CoreMotion/CoreMotion.h>
 

--- a/drivers/apple_embedded/godot_view_controller.mm
+++ b/drivers/apple_embedded/godot_view_controller.mm
@@ -30,14 +30,13 @@
 
 #import "godot_view_controller.h"
 
-#import "display_server_apple_embedded.h"
-#import "godot_keyboard_input_view.h"
-#import "godot_view_apple_embedded.h"
-#import "godot_view_renderer.h"
-#import "key_mapping_apple_embedded.h"
-#import "os_apple_embedded.h"
-
 #include "core/config/project_settings.h"
+#import "drivers/apple_embedded/display_server_apple_embedded.h"
+#import "drivers/apple_embedded/godot_keyboard_input_view.h"
+#import "drivers/apple_embedded/godot_view_apple_embedded.h"
+#import "drivers/apple_embedded/godot_view_renderer.h"
+#import "drivers/apple_embedded/key_mapping_apple_embedded.h"
+#import "drivers/apple_embedded/os_apple_embedded.h"
 #include "servers/camera/camera_server.h"
 
 #import <AVFoundation/AVFoundation.h>

--- a/drivers/apple_embedded/godot_view_renderer.mm
+++ b/drivers/apple_embedded/godot_view_renderer.mm
@@ -30,12 +30,11 @@
 
 #import "godot_view_renderer.h"
 
-#import "display_server_apple_embedded.h"
-#import "os_apple_embedded.h"
-
 #include "core/config/project_settings.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
+#import "drivers/apple_embedded/display_server_apple_embedded.h"
+#import "drivers/apple_embedded/os_apple_embedded.h"
 #include "main/main.h"
 #include "servers/audio/audio_server.h"
 

--- a/drivers/apple_embedded/os_apple_embedded.h
+++ b/drivers/apple_embedded/os_apple_embedded.h
@@ -32,8 +32,7 @@
 
 #ifdef APPLE_EMBEDDED_ENABLED
 
-#import "apple_embedded.h"
-
+#import "drivers/apple_embedded/apple_embedded.h"
 #import "drivers/coreaudio/audio_driver_coreaudio.h"
 #include "drivers/unix/os_unix.h"
 #include "servers/audio/audio_server.h"
@@ -43,7 +42,7 @@
 #include "servers/rendering/rendering_device.h"
 
 #if defined(VULKAN_ENABLED)
-#import "rendering_context_driver_vulkan_apple_embedded.h"
+#import "drivers/apple_embedded/rendering_context_driver_vulkan_apple_embedded.h"
 #endif
 #endif
 

--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -32,11 +32,6 @@
 
 #ifdef APPLE_EMBEDDED_ENABLED
 
-#import "app_delegate_service.h"
-#import "display_server_apple_embedded.h"
-#import "godot_view_apple_embedded.h"
-#import "godot_view_controller.h"
-
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
@@ -45,6 +40,10 @@
 #include "core/os/os.h"
 #include "core/profiling/profiling.h"
 #import "drivers/apple/os_log_logger.h"
+#import "drivers/apple_embedded/app_delegate_service.h"
+#import "drivers/apple_embedded/display_server_apple_embedded.h"
+#import "drivers/apple_embedded/godot_view_apple_embedded.h"
+#import "drivers/apple_embedded/godot_view_controller.h"
 #ifdef SDL_ENABLED
 #include "drivers/sdl/joypad_sdl.h"
 #endif

--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -44,8 +44,9 @@ GODOT_CLANG_WARNING_POP
 #include <dxgi1_6.h>
 
 #if !defined(_MSC_VER)
-#include <guiddef.h>
 #include <thirdparty/directx_headers/include/dxguids/dxguids.h>
+
+#include <guiddef.h>
 #endif
 
 using Microsoft::WRL::ComPtr;

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -41,8 +41,9 @@
 #include <dxgi1_6.h>
 
 #if !defined(_MSC_VER)
-#include <guiddef.h>
 #include <thirdparty/directx_headers/include/dxguids/dxguids.h>
+
+#include <guiddef.h>
 #endif
 
 using Microsoft::WRL::ComPtr;

--- a/drivers/metal/metal3_objects.cpp
+++ b/drivers/metal/metal3_objects.cpp
@@ -50,10 +50,10 @@
 
 #include "metal3_objects.h"
 
-#include "metal_utils.h"
-#include "pixel_formats.h"
-#include "rendering_device_driver_metal3.h"
-#include "rendering_shader_container_metal.h"
+#include "drivers/metal/metal_utils.h"
+#include "drivers/metal/pixel_formats.h"
+#include "drivers/metal/rendering_device_driver_metal3.h"
+#include "drivers/metal/rendering_shader_container_metal.h"
 
 #include <algorithm>
 

--- a/drivers/metal/metal3_objects.h
+++ b/drivers/metal/metal3_objects.h
@@ -50,8 +50,7 @@
 /* permissions and limitations under the License.                         */
 /**************************************************************************/
 
-#include "metal_objects_shared.h"
-
+#include "drivers/metal/metal_objects_shared.h"
 #include "servers/rendering/rendering_device_driver.h"
 
 #include <Metal/Metal.hpp>

--- a/drivers/metal/metal_device_profile.cpp
+++ b/drivers/metal/metal_device_profile.cpp
@@ -30,7 +30,7 @@
 
 #include "metal_device_profile.h"
 
-#include "metal_utils.h"
+#include "drivers/metal/metal_utils.h"
 
 Mutex MetalDeviceProfile::profiles_lock;
 HashMap<MetalDeviceProfile::ProfileKey, MetalDeviceProfile> MetalDeviceProfile::profiles;

--- a/drivers/metal/metal_device_properties.cpp
+++ b/drivers/metal/metal_device_properties.cpp
@@ -50,9 +50,8 @@
 
 #include "metal_device_properties.h"
 
-#include "metal_utils.h"
-
 #include "core/os/os.h"
+#include "drivers/metal/metal_utils.h"
 #include "servers/rendering/renderer_rd/effects/metal_fx.h"
 
 #include <MetalFX/MetalFX.hpp>

--- a/drivers/metal/metal_objects_shared.cpp
+++ b/drivers/metal/metal_objects_shared.cpp
@@ -30,7 +30,7 @@
 
 #include "metal_objects_shared.h"
 
-#include "rendering_device_driver_metal.h"
+#include "drivers/metal/rendering_device_driver_metal.h"
 
 #include <os/signpost.h>
 #include <simd/simd.h>

--- a/drivers/metal/metal_objects_shared.h
+++ b/drivers/metal/metal_objects_shared.h
@@ -30,10 +30,10 @@
 
 #pragma once
 
-#include "metal_device_properties.h"
-#include "metal_utils.h"
-#include "pixel_formats.h"
-#include "sha256_digest.h"
+#include "drivers/metal/metal_device_properties.h"
+#include "drivers/metal/metal_utils.h"
+#include "drivers/metal/pixel_formats.h"
+#include "drivers/metal/sha256_digest.h"
 
 #include <CoreFoundation/CoreFoundation.h>
 

--- a/drivers/metal/pixel_formats.cpp
+++ b/drivers/metal/pixel_formats.cpp
@@ -50,7 +50,7 @@
 
 #include "pixel_formats.h"
 
-#include "metal_utils.h"
+#include "drivers/metal/metal_utils.h"
 
 #if TARGET_OS_IPHONE || TARGET_OS_TV
 #if !(__IPHONE_OS_VERSION_MAX_ALLOWED >= 160400) // iOS/tvOS 16.4

--- a/drivers/metal/pixel_formats.h
+++ b/drivers/metal/pixel_formats.h
@@ -54,9 +54,8 @@
 
 GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations")
 
-#include "inflection_map.h"
-#include "metal_device_properties.h"
-
+#include "drivers/metal/inflection_map.h"
+#include "drivers/metal/metal_device_properties.h"
 #include "servers/rendering/rendering_device_commons.h"
 
 #ifdef __OBJC__

--- a/drivers/metal/rendering_context_driver_metal.cpp
+++ b/drivers/metal/rendering_context_driver_metal.cpp
@@ -30,12 +30,11 @@
 
 #include "rendering_context_driver_metal.h"
 
-#include "metal3_objects.h"
-#include "metal_objects_shared.h"
-#include "rendering_device_driver_metal3.h"
-
 #include "core/os/os.h"
 #include "core/templates/sort_array.h"
+#include "drivers/metal/metal3_objects.h"
+#include "drivers/metal/metal_objects_shared.h"
+#include "drivers/metal/rendering_device_driver_metal3.h"
 
 #include <objc/message.h>
 #include <os/log.h>

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -50,10 +50,6 @@
 
 #include "rendering_device_driver_metal.h"
 
-#include "pixel_formats.h"
-#include "rendering_context_driver_metal.h"
-#include "rendering_shader_container_metal.h"
-
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/io/marshalls.h"
@@ -61,6 +57,9 @@
 #include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
 #include "drivers/apple/foundation_helpers.h"
+#include "drivers/metal/pixel_formats.h"
+#include "drivers/metal/rendering_context_driver_metal.h"
+#include "drivers/metal/rendering_shader_container_metal.h"
 
 #include <Metal/Metal.hpp>
 #include <os/log.h>

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -30,9 +30,8 @@
 
 #pragma once
 
-#include "metal_device_profile.h"
-#include "metal_objects_shared.h"
-
+#include "drivers/metal/metal_device_profile.h"
+#include "drivers/metal/metal_objects_shared.h"
 #include "servers/rendering/rendering_device_driver.h"
 
 #include <Metal/Metal.hpp>

--- a/drivers/metal/rendering_device_driver_metal3.cpp
+++ b/drivers/metal/rendering_device_driver_metal3.cpp
@@ -30,12 +30,11 @@
 
 #include "rendering_device_driver_metal3.h"
 
-#include "pixel_formats.h"
-#include "rendering_context_driver_metal.h"
-
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 #include "core/string/ustring.h"
+#include "drivers/metal/pixel_formats.h"
+#include "drivers/metal/rendering_context_driver_metal.h"
 
 namespace MTL3 {
 

--- a/drivers/metal/rendering_device_driver_metal3.h
+++ b/drivers/metal/rendering_device_driver_metal3.h
@@ -30,8 +30,8 @@
 
 #pragma once
 
-#include "metal3_objects.h"
-#include "rendering_device_driver_metal.h"
+#include "drivers/metal/metal3_objects.h"
+#include "drivers/metal/rendering_device_driver_metal.h"
 
 #include <Metal/Metal.hpp>
 

--- a/drivers/metal/rendering_shader_container_metal.cpp
+++ b/drivers/metal/rendering_shader_container_metal.cpp
@@ -36,11 +36,12 @@
 #include "core/templates/fixed_vector.h"
 #include "drivers/metal/metal_utils.h"
 
+#include <thirdparty/spirv-reflect/spirv_reflect.h>
+
 #include <Metal/Metal.hpp>
 #include <spirv.hpp>
 #include <spirv_msl.hpp>
 #include <spirv_parser.hpp>
-#include <thirdparty/spirv-reflect/spirv_reflect.h>
 
 void RenderingShaderContainerMetal::_initialize_toolchain_properties() {
 	if (compiler_props.is_valid()) {

--- a/drivers/metal/rendering_shader_container_metal.cpp
+++ b/drivers/metal/rendering_shader_container_metal.cpp
@@ -30,19 +30,17 @@
 
 #include "rendering_shader_container_metal.h"
 
-#include "metal_utils.h"
-
 #include "core/io/file_access.h"
 #include "core/io/marshalls.h"
 #include "core/os/os.h"
 #include "core/templates/fixed_vector.h"
-
-#include "thirdparty/spirv-reflect/spirv_reflect.h"
+#include "drivers/metal/metal_utils.h"
 
 #include <Metal/Metal.hpp>
 #include <spirv.hpp>
 #include <spirv_msl.hpp>
 #include <spirv_parser.hpp>
+#include <thirdparty/spirv-reflect/spirv_reflect.h>
 
 void RenderingShaderContainerMetal::_initialize_toolchain_properties() {
 	if (compiler_props.is_valid()) {

--- a/drivers/metal/rendering_shader_container_metal.h
+++ b/drivers/metal/rendering_shader_container_metal.h
@@ -30,9 +30,8 @@
 
 #pragma once
 
-#include "metal_device_profile.h"
-#include "sha256_digest.h"
-
+#include "drivers/metal/metal_device_profile.h"
+#include "drivers/metal/sha256_digest.h"
 #include "servers/rendering/rendering_device_driver.h"
 #include "servers/rendering/rendering_shader_container.h"
 

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -38,7 +38,7 @@
 #include "servers/audio/audio_server.h"
 
 #ifdef SOWRAP_ENABLED
-#include "pulse-so_wrap.h" // IWYU pragma: keep. Relies on pulseaudio.h transitive includes.
+#include "drivers/pulseaudio/pulse-so_wrap.h" // IWYU pragma: keep. Relies on pulseaudio.h transitive includes.
 #else
 #include <pulse/pulseaudio.h>
 #endif

--- a/drivers/pulseaudio/pulse-so_wrap.c
+++ b/drivers/pulseaudio/pulse-so_wrap.c
@@ -356,7 +356,7 @@
 #define pa_timeval_store pa_timeval_store_dylibloader_orig_pulse
 #define pa_timeval_load pa_timeval_load_dylibloader_orig_pulse
 #define pa_rtclock_now pa_rtclock_now_dylibloader_orig_pulse
-#include "thirdparty/linuxbsd_headers/pulse/pulseaudio.h"
+#include <thirdparty/linuxbsd_headers/pulse/pulseaudio.h>
 #undef pa_get_library_version
 #undef pa_bytes_per_second
 #undef pa_frame_size

--- a/drivers/pulseaudio/pulse-so_wrap.h
+++ b/drivers/pulseaudio/pulse-so_wrap.h
@@ -358,7 +358,7 @@
 #define pa_timeval_store pa_timeval_store_dylibloader_orig_pulse
 #define pa_timeval_load pa_timeval_load_dylibloader_orig_pulse
 #define pa_rtclock_now pa_rtclock_now_dylibloader_orig_pulse
-#include "thirdparty/linuxbsd_headers/pulse/pulseaudio.h" // IWYU pragma: export.
+#include <thirdparty/linuxbsd_headers/pulse/pulseaudio.h> // IWYU pragma: export.
 #undef pa_get_library_version
 #undef pa_bytes_per_second
 #undef pa_frame_size

--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -37,7 +37,7 @@
 #ifdef ANDROID_ENABLED
 // We could drop this file once we up our API level to 24,
 // where the NDK's ifaddrs.h supports to needed getifaddrs.
-#include "thirdparty/misc/ifaddrs-android.h"
+#include <thirdparty/misc/ifaddrs-android.h>
 #else
 #ifdef __FreeBSD__
 #include <sys/types.h>

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -36,14 +36,14 @@
 #include "core/templates/fixed_vector.h"
 #include "drivers/vulkan/vulkan_hooks.h"
 
-#include "thirdparty/misc/smolv.h"
+#include <thirdparty/misc/smolv.h>
 
 #if defined(SWAPPY_FRAME_PACING_ENABLED)
 #include "platform/android/java_godot_wrapper.h"
 #include "platform/android/os_android.h"
 #include "platform/android/thread_jandroid.h"
 
-#include "thirdparty/swappy-frame-pacing/swappyVk.h"
+#include <thirdparty/swappy-frame-pacing/swappyVk.h>
 #endif
 
 #define ARRAY_SIZE(a) std_size(a)

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -42,10 +42,9 @@
 #define _DEBUG
 #endif
 #endif
-#include "thirdparty/re-spirv/re-spirv.h"
-#include "thirdparty/vulkan/vk_mem_alloc.h"
-
 #include <drivers/vulkan/godot_vulkan.h>
+#include <thirdparty/re-spirv/re-spirv.h>
+#include <thirdparty/vulkan/vk_mem_alloc.h>
 
 class FileAccess;
 

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -42,9 +42,10 @@
 #define _DEBUG
 #endif
 #endif
-#include <drivers/vulkan/godot_vulkan.h>
 #include <thirdparty/re-spirv/re-spirv.h>
 #include <thirdparty/vulkan/vk_mem_alloc.h>
+
+#include <drivers/vulkan/godot_vulkan.h>
 
 class FileAccess;
 

--- a/drivers/vulkan/rendering_shader_container_vulkan.cpp
+++ b/drivers/vulkan/rendering_shader_container_vulkan.cpp
@@ -30,7 +30,7 @@
 
 #include "rendering_shader_container_vulkan.h"
 
-#include "thirdparty/misc/smolv.h"
+#include <thirdparty/misc/smolv.h>
 
 // RenderingShaderContainerVulkan
 

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -32,11 +32,10 @@
 
 #include "dir_access_windows.h"
 
-#include "file_access_windows.h"
-
 #include "core/os/memory.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"
+#include "drivers/windows/file_access_windows.h"
 
 #include <windows.h>
 

--- a/editor/export/editor_export.h
+++ b/editor/export/editor_export.h
@@ -30,8 +30,8 @@
 
 #pragma once
 
-#include "editor_export_platform.h"
-#include "editor_export_plugin.h"
+#include "editor/export/editor_export_platform.h"
+#include "editor/export/editor_export_plugin.h"
 
 class Timer;
 

--- a/editor/export/editor_export_platform_apple_embedded.h
+++ b/editor/export/editor_export_platform_apple_embedded.h
@@ -30,12 +30,11 @@
 
 #pragma once
 
-#include "plugin_config_apple_embedded.h"
-
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/templates/safe_refcount.h"
 #include "editor/export/editor_export_platform.h"
+#include "editor/export/plugin_config_apple_embedded.h"
 #include "scene/resources/image_texture.h"
 
 #include <sys/stat.h>

--- a/editor/export/editor_export_platform_pc.h
+++ b/editor/export/editor_export_platform_pc.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "editor_export_platform.h"
+#include "editor/export/editor_export_platform.h"
 
 class ImageTexture;
 

--- a/editor/export/lipo.cpp
+++ b/editor/export/lipo.cpp
@@ -30,7 +30,7 @@
 
 #include "lipo.h"
 
-#include "macho.h"
+#include "editor/export/macho.h"
 
 bool LipO::is_lipo(const String &p_path) {
 	Ref<FileAccess> fb = FileAccess::open(p_path, FileAccess::READ);

--- a/editor/import/3d/post_import_plugin_skeleton_renamer.h
+++ b/editor/import/3d/post_import_plugin_skeleton_renamer.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "resource_importer_scene.h"
+#include "editor/import/3d/resource_importer_scene.h"
 
 class PostImportPluginSkeletonRenamer : public EditorScenePostImportPlugin {
 	GDCLASS(PostImportPluginSkeletonRenamer, EditorScenePostImportPlugin);

--- a/editor/import/3d/post_import_plugin_skeleton_rest_fixer.h
+++ b/editor/import/3d/post_import_plugin_skeleton_rest_fixer.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "resource_importer_scene.h"
+#include "editor/import/3d/resource_importer_scene.h"
 
 class PostImportPluginSkeletonRestFixer : public EditorScenePostImportPlugin {
 	GDCLASS(PostImportPluginSkeletonRestFixer, EditorScenePostImportPlugin);

--- a/editor/import/3d/post_import_plugin_skeleton_track_organizer.h
+++ b/editor/import/3d/post_import_plugin_skeleton_track_organizer.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "resource_importer_scene.h"
+#include "editor/import/3d/resource_importer_scene.h"
 
 class PostImportPluginSkeletonTrackOrganizer : public EditorScenePostImportPlugin {
 	GDCLASS(PostImportPluginSkeletonTrackOrganizer, EditorScenePostImportPlugin);

--- a/editor/import/3d/resource_importer_obj.h
+++ b/editor/import/3d/resource_importer_obj.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "resource_importer_scene.h"
+#include "editor/import/3d/resource_importer_scene.h"
 
 class EditorOBJImporter : public EditorSceneFormatImporter {
 	GDCLASS(EditorOBJImporter, EditorSceneFormatImporter);

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -30,8 +30,6 @@
 
 #include "dynamic_font_import_settings.h"
 
-#include "unicode_ranges.inc"
-
 #include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
 #include "core/os/os.h"
@@ -39,6 +37,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/file_system/editor_file_system.h"
+#include "editor/import/unicode_ranges.inc"
 #include "editor/inspector/editor_inspector.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"

--- a/editor/scene/2d/sprite_2d_editor_plugin.cpp
+++ b/editor/scene/2d/sprite_2d_editor_plugin.cpp
@@ -52,7 +52,7 @@
 #include "scene/resources/bit_map.h"
 #include "scene/resources/mesh.h"
 
-#include "thirdparty/clipper2/include/clipper2/clipper.h"
+#include <thirdparty/clipper2/include/clipper2/clipper.h>
 
 #define PRECISION 1
 

--- a/editor/scene/2d/tiles/tile_data_editors.cpp
+++ b/editor/scene/2d/tiles/tile_data_editors.cpp
@@ -30,8 +30,6 @@
 
 #include "tile_data_editors.h"
 
-#include "tile_set_editor.h"
-
 #include "core/math/geometry_2d.h"
 #include "core/math/random_pcg.h"
 #include "core/object/callable_mp.h"
@@ -41,6 +39,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/inspector/editor_properties.h"
+#include "editor/scene/2d/tiles/tile_set_editor.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/control.h"

--- a/editor/scene/2d/tiles/tile_data_editors.h
+++ b/editor/scene/2d/tiles/tile_data_editors.h
@@ -30,9 +30,8 @@
 
 #pragma once
 
-#include "tile_atlas_view.h"
-
 #include "editor/inspector/editor_properties.h"
+#include "editor/scene/2d/tiles/tile_atlas_view.h"
 #include "scene/gui/box_container.h"
 
 class Label;

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -30,8 +30,6 @@
 
 #include "tile_map_layer_editor.h"
 
-#include "tiles_editor_plugin.h"
-
 #include "core/input/input.h"
 #include "core/math/geometry_2d.h"
 #include "core/math/random_pcg.h"
@@ -43,6 +41,7 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/inspector/editor_resource_preview.h"
 #include "editor/inspector/multi_node_edit.h"
+#include "editor/scene/2d/tiles/tiles_editor_plugin.h"
 #include "editor/scene/canvas_item_editor_plugin.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.h
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.h
@@ -30,9 +30,8 @@
 
 #pragma once
 
-#include "tile_atlas_view.h"
-#include "tile_data_editors.h"
-
+#include "editor/scene/2d/tiles/tile_atlas_view.h"
+#include "editor/scene/2d/tiles/tile_data_editors.h"
 #include "scene/gui/split_container.h"
 #include "scene/resources/2d/tile_set.h"
 

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -30,9 +30,6 @@
 
 #include "tile_set_editor.h"
 
-#include "tile_data_editors.h"
-#include "tiles_editor_plugin.h"
-
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "editor/editor_node.h"
@@ -40,6 +37,8 @@
 #include "editor/file_system/editor_file_system.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/inspector/editor_inspector.h"
+#include "editor/scene/2d/tiles/tile_data_editors.h"
+#include "editor/scene/2d/tiles/tiles_editor_plugin.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"

--- a/editor/scene/2d/tiles/tiles_editor_plugin.cpp
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.cpp
@@ -30,8 +30,6 @@
 
 #include "tiles_editor_plugin.h"
 
-#include "tile_set_editor.h"
-
 #include "core/object/callable_mp.h"
 #include "core/os/mutex.h"
 #include "core/os/os.h"
@@ -40,6 +38,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/inspector/multi_node_edit.h"
+#include "editor/scene/2d/tiles/tile_set_editor.h"
 #include "editor/scene/canvas_item_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"

--- a/editor/shader/editor_shader_language_plugin.h
+++ b/editor/shader/editor_shader_language_plugin.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "shader_editor.h"
+#include "editor/shader/shader_editor.h"
 
 class EditorShaderLanguagePlugin : public RefCounted {
 	GDCLASS(EditorShaderLanguagePlugin, RefCounted);

--- a/editor/shader/text_shader_language_plugin.cpp
+++ b/editor/shader/text_shader_language_plugin.cpp
@@ -30,9 +30,8 @@
 
 #include "text_shader_language_plugin.h"
 
-#include "text_shader_editor.h"
-
 #include "core/string/string_builder.h"
+#include "editor/shader/text_shader_editor.h"
 #include "servers/rendering/shader_types.h"
 
 bool TextShaderLanguagePlugin::handles_shader(const Ref<Shader> &p_shader) const {

--- a/editor/shader/visual_shader_language_plugin.cpp
+++ b/editor/shader/visual_shader_language_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "visual_shader_language_plugin.h"
 
-#include "visual_shader_editor_plugin.h"
+#include "editor/shader/visual_shader_editor_plugin.h"
 
 bool VisualShaderLanguagePlugin::handles_shader(const Ref<Shader> &p_shader) const {
 	return Object::cast_to<VisualShader>(p_shader.ptr()) != nullptr;

--- a/misc/scripts/validate_includes.py
+++ b/misc/scripts/validate_includes.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+if __name__ != "__main__":
+    raise ImportError(f'Utility script "{__file__}" should not be used as a module!')
+
+import os
+from pathlib import Path
+
+if Path(os.getcwd()).as_posix() != (ROOT := Path(__file__).parent.parent.parent).as_posix():
+    raise RuntimeError(f'Utility script "{__file__}" must be run from the repository root!')
+
+import argparse
+import re
+from dataclasses import dataclass
+
+BASE_FOLDER = Path(__file__).resolve().parent.parent.parent
+RE_INCLUDES = re.compile(
+    r"^#(?P<keyword>include|import) "  # Both `include` and `import` keywords valid.
+    r'(?P<sequence>[<"])'  # Handle both styles of char wrappers. Does NOT handle macro expansion.
+    r'(?P<path>.+?)[>"]',  # Resolve path of include itself. Can safely assume the sequence matches.
+    re.RegexFlag.MULTILINE,
+)
+
+
+@dataclass
+class IncludeData:
+    path: str
+    is_angle: bool
+    is_import: bool
+
+    @staticmethod
+    def from_match(match: re.Match[str]):
+        items = match.groupdict()
+        return IncludeData(
+            items["path"],
+            items["sequence"] == "<",
+            items["keyword"] == "import",
+        )
+
+    def copy(self):
+        return IncludeData(self.path, self.is_angle, self.is_import)
+
+    def __str__(self):
+        return "#{keyword} {rbracket}{path}{lbracket}".format(
+            keyword="import" if self.is_import else "include",
+            rbracket="<" if self.is_angle else '"',
+            path=self.path,
+            lbracket=">" if self.is_angle else '"',
+        )
+
+
+def validate_includes(path: Path) -> int:
+    ret = 0
+    content = path.read_text(encoding="utf-8")
+
+    for data in map(IncludeData.from_match, RE_INCLUDES.finditer(content)):
+        original_data = data.copy()
+
+        if "\\" in data.path:
+            data.path = data.path.replace("\\", "/")
+
+        if data.path.startswith("thirdparty/"):
+            data.is_angle = True
+
+        if (relative_path := path.parent / data.path).exists():
+            # Relative includes are only permitted under certain circumstances.
+
+            if relative_path.name.split(".")[0] == path.name.split(".")[0]:
+                # Identical leading names permitted
+                pass
+
+            elif ("modules" in relative_path.parts and "modules" in path.parts) or (
+                "platform" in relative_path.parts and "platform" in path.parts
+            ):
+                # Modules and platforms can use relative includes if constrained to the module/platform itself.
+                pass
+
+            else:
+                data.path = relative_path.resolve().relative_to(BASE_FOLDER).as_posix()
+
+        if original_data != data:
+            content = content.replace(f"{original_data}", f"{data}")
+            ret += 1
+
+    if ret:
+        with open(path, "w", encoding="utf-8", newline="\n") as file:
+            file.write(content)
+
+    return ret
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate C/C++ includes, correcting if necessary")
+    parser.add_argument("files", nargs="+", help="A list of files to validate")
+    args = parser.parse_args()
+
+    ret = 0
+
+    for file in map(Path, args.files):
+        ret += validate_includes(file)
+
+    return ret
+
+
+try:
+    raise SystemExit(main())
+except KeyboardInterrupt:
+    import signal
+
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    os.kill(os.getpid(), signal.SIGINT)

--- a/modules/bcdec/image_decompress_bcdec.cpp
+++ b/modules/bcdec/image_decompress_bcdec.cpp
@@ -34,7 +34,7 @@
 #include "core/string/print_string.h"
 
 #define BCDEC_IMPLEMENTATION
-#include "thirdparty/misc/bcdec.h"
+#include <thirdparty/misc/bcdec.h>
 
 inline void bcdec_bc6h_half_s(const void *compressedBlock, void *decompressedBlock, int destinationPitch) {
 	bcdec_bc6h_half(compressedBlock, decompressedBlock, destinationPitch, true);

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -39,7 +39,7 @@
 #include "scene/resources/3d/concave_polygon_shape_3d.h"
 #endif // PHYSICS_3D_DISABLED
 
-#include "thirdparty/misc/mikktspace.h"
+#include <thirdparty/misc/mikktspace.h>
 
 class Mesh;
 class NavigationMesh;

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -47,7 +47,7 @@
 
 #include "modules/regex/regex.h"
 
-#include "thirdparty/doctest/doctest.h"
+#include <thirdparty/doctest/doctest.h>
 
 class TestGDScriptLanguageProtocolInitializer {
 public:

--- a/modules/meshoptimizer/register_types.cpp
+++ b/modules/meshoptimizer/register_types.cpp
@@ -32,7 +32,7 @@
 
 #include "scene/resources/surface_tool.h"
 
-#include "thirdparty/meshoptimizer/meshoptimizer.h"
+#include <thirdparty/meshoptimizer/meshoptimizer.h>
 
 void initialize_meshoptimizer_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {

--- a/modules/mp3/audio_stream_mp3.cpp
+++ b/modules/mp3/audio_stream_mp3.cpp
@@ -37,7 +37,7 @@
 #include "core/io/file_access.h"
 #include "core/object/class_db.h"
 
-#include "thirdparty/dr_libs/dr_bridge.h"
+#include <thirdparty/dr_libs/dr_bridge.h>
 
 int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 	if (!active) {

--- a/modules/mp3/audio_stream_mp3.h
+++ b/modules/mp3/audio_stream_mp3.h
@@ -32,7 +32,7 @@
 
 #include "servers/audio/audio_stream.h"
 
-#include "thirdparty/dr_libs/dr_mp3.h"
+#include <thirdparty/dr_libs/dr_mp3.h>
 
 class AudioStreamMP3;
 

--- a/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation_2d/2d/nav_mesh_generator_2d.cpp
@@ -39,8 +39,8 @@
 #include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h"
 #include "scene/resources/2d/navigation_polygon.h"
 
-#include "thirdparty/clipper2/include/clipper2/clipper.h"
-#include "thirdparty/misc/polypartition.h"
+#include <thirdparty/clipper2/include/clipper2/clipper.h>
+#include <thirdparty/misc/polypartition.h>
 
 NavMeshGenerator2D *NavMeshGenerator2D::singleton = nullptr;
 Mutex NavMeshGenerator2D::baking_navmesh_mutex;

--- a/modules/noise/fastnoise_lite.h
+++ b/modules/noise/fastnoise_lite.h
@@ -32,7 +32,7 @@
 
 #include "noise.h"
 
-#include "thirdparty/misc/FastNoiseLite.h"
+#include <thirdparty/misc/FastNoiseLite.h>
 
 typedef fastnoiselite::FastNoiseLite _FastNoiseLite;
 

--- a/modules/openxr/openxr_platform_inc.h
+++ b/modules/openxr/openxr_platform_inc.h
@@ -57,7 +57,7 @@
 #endif // ANDROID_ENABLED
 #if defined(LINUXBSD_ENABLED) && defined(EGL_ENABLED)
 #ifdef GLAD_ENABLED
-#include "thirdparty/glad/glad/egl.h"
+#include <thirdparty/glad/glad/egl.h>
 #else
 #include <EGL/egl.h>
 #endif // GLAD_ENABLED
@@ -65,8 +65,8 @@
 #ifdef X11_ENABLED
 #define GL_GLEXT_PROTOTYPES 1
 #define GL3_PROTOTYPES 1
-#include "thirdparty/glad/glad/gl.h"
-#include "thirdparty/glad/glad/glx.h"
+#include <thirdparty/glad/glad/gl.h>
+#include <thirdparty/glad/glad/glx.h>
 #endif // X11_ENABLED
 #endif // defined(GLES3_ENABLED) && !defined(MACOS_ENABLED)
 

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -35,7 +35,7 @@
 #include "core/object/class_db.h"
 #include "scene/resources/image_texture.h"
 
-#include "thirdparty/misc/yuv2rgb.h"
+#include <thirdparty/misc/yuv2rgb.h>
 
 int VideoStreamPlaybackTheora::buffer_data() {
 	char *buffer = ogg_sync_buffer(&oy, 4096);

--- a/modules/vhacd/register_types.cpp
+++ b/modules/vhacd/register_types.cpp
@@ -32,7 +32,7 @@
 
 #include "scene/resources/mesh.h"
 
-#include "thirdparty/vhacd/public/VHACD.h"
+#include <thirdparty/vhacd/public/VHACD.h>
 
 static Vector<Vector<Vector3>> convex_decompose(const real_t *p_vertices, int p_vertex_count, const uint32_t *p_triangles, int p_triangle_count, const Ref<MeshConvexDecompositionSettings> &p_settings, Vector<Vector<uint32_t>> *r_convex_indices) {
 	VHACD::IVHACD::Parameters params;

--- a/modules/zip/zip_packer.h
+++ b/modules/zip/zip_packer.h
@@ -33,7 +33,7 @@
 #include "core/io/file_access.h"
 #include "core/object/ref_counted.h"
 
-#include "thirdparty/minizip/zip.h"
+#include <thirdparty/minizip/zip.h>
 
 class ZIPPacker : public RefCounted {
 	GDCLASS(ZIPPacker, RefCounted);

--- a/modules/zip/zip_reader.h
+++ b/modules/zip/zip_reader.h
@@ -33,7 +33,7 @@
 #include "core/io/file_access.h"
 #include "core/object/ref_counted.h"
 
-#include "thirdparty/minizip/unzip.h"
+#include <thirdparty/minizip/unzip.h>
 
 class ZIPReader : public RefCounted {
 	GDCLASS(ZIPReader, RefCounted)

--- a/platform/linuxbsd/dbus-so_wrap.c
+++ b/platform/linuxbsd/dbus-so_wrap.c
@@ -243,7 +243,7 @@
 #define dbus_validate_utf8 dbus_validate_utf8_dylibloader_orig_dbus
 #define dbus_threads_init dbus_threads_init_dylibloader_orig_dbus
 #define dbus_threads_init_default dbus_threads_init_default_dylibloader_orig_dbus
-#include "thirdparty/linuxbsd_headers/dbus/dbus.h"
+#include <thirdparty/linuxbsd_headers/dbus/dbus.h>
 #undef dbus_error_init
 #undef dbus_error_free
 #undef dbus_set_error

--- a/platform/linuxbsd/dbus-so_wrap.h
+++ b/platform/linuxbsd/dbus-so_wrap.h
@@ -245,7 +245,7 @@
 #define dbus_validate_utf8 dbus_validate_utf8_dylibloader_orig_dbus
 #define dbus_threads_init dbus_threads_init_dylibloader_orig_dbus
 #define dbus_threads_init_default dbus_threads_init_default_dylibloader_orig_dbus
-#include "thirdparty/linuxbsd_headers/dbus/dbus.h" // IWYU pragma: export.
+#include <thirdparty/linuxbsd_headers/dbus/dbus.h> // IWYU pragma: export.
 #undef dbus_error_init
 #undef dbus_error_free
 #undef dbus_set_error

--- a/platform/linuxbsd/fontconfig-so_wrap.c
+++ b/platform/linuxbsd/fontconfig-so_wrap.c
@@ -210,7 +210,7 @@
 #define FcStrListDone FcStrListDone_dylibloader_orig_fontconfig
 #define FcConfigParseAndLoad FcConfigParseAndLoad_dylibloader_orig_fontconfig
 #define FcConfigParseAndLoadFromMemory FcConfigParseAndLoadFromMemory_dylibloader_orig_fontconfig
-#include "thirdparty/linuxbsd_headers/fontconfig/fontconfig.h"
+#include <thirdparty/linuxbsd_headers/fontconfig/fontconfig.h>
 #undef FcBlanksCreate
 #undef FcBlanksDestroy
 #undef FcBlanksAdd

--- a/platform/linuxbsd/fontconfig-so_wrap.h
+++ b/platform/linuxbsd/fontconfig-so_wrap.h
@@ -212,7 +212,7 @@
 #define FcStrListDone FcStrListDone_dylibloader_orig_fontconfig
 #define FcConfigParseAndLoad FcConfigParseAndLoad_dylibloader_orig_fontconfig
 #define FcConfigParseAndLoadFromMemory FcConfigParseAndLoadFromMemory_dylibloader_orig_fontconfig
-#include "thirdparty/linuxbsd_headers/fontconfig/fontconfig.h" // IWYU pragma: export.
+#include <thirdparty/linuxbsd_headers/fontconfig/fontconfig.h> // IWYU pragma: export.
 #undef FcBlanksCreate
 #undef FcBlanksDestroy
 #undef FcBlanksAdd

--- a/platform/linuxbsd/platform_gl.h
+++ b/platform/linuxbsd/platform_gl.h
@@ -39,6 +39,6 @@
 #endif
 
 // IWYU pragma: begin_exports.
-#include "thirdparty/glad/glad/egl.h"
-#include "thirdparty/glad/glad/gl.h"
+#include <thirdparty/glad/glad/egl.h>
+#include <thirdparty/glad/glad/gl.h>
 // IWYU pragma: end_exports.

--- a/platform/linuxbsd/speechd-so_wrap.c
+++ b/platform/linuxbsd/speechd-so_wrap.c
@@ -80,7 +80,7 @@
 #define spd_execute_command_wo_mutex spd_execute_command_wo_mutex_dylibloader_orig_speechd
 #define spd_send_data spd_send_data_dylibloader_orig_speechd
 #define spd_send_data_wo_mutex spd_send_data_wo_mutex_dylibloader_orig_speechd
-#include "thirdparty/linuxbsd_headers/speechd/libspeechd.h"
+#include <thirdparty/linuxbsd_headers/speechd/libspeechd.h>
 #undef SPDConnectionAddress__free
 #undef spd_get_default_address
 #undef spd_open

--- a/platform/linuxbsd/speechd-so_wrap.h
+++ b/platform/linuxbsd/speechd-so_wrap.h
@@ -82,7 +82,7 @@
 #define spd_execute_command_wo_mutex spd_execute_command_wo_mutex_dylibloader_orig_speechd
 #define spd_send_data spd_send_data_dylibloader_orig_speechd
 #define spd_send_data_wo_mutex spd_send_data_wo_mutex_dylibloader_orig_speechd
-#include "thirdparty/linuxbsd_headers/speechd/libspeechd.h" // IWYU pragma: export.
+#include <thirdparty/linuxbsd_headers/speechd/libspeechd.h> // IWYU pragma: export.
 #undef SPDConnectionAddress__free
 #undef spd_get_default_address
 #undef spd_open

--- a/platform/linuxbsd/wayland/detect_prime_egl.h
+++ b/platform/linuxbsd/wayland/detect_prime_egl.h
@@ -34,8 +34,8 @@
 #ifdef EGL_ENABLED
 
 #ifdef GLAD_ENABLED
-#include "thirdparty/glad/glad/egl.h"
-#include "thirdparty/glad/glad/gl.h"
+#include <thirdparty/glad/glad/egl.h>
+#include <thirdparty/glad/glad/gl.h>
 #else
 #include <EGL/egl.h>
 #include <EGL/eglext.h>

--- a/platform/linuxbsd/x11/detect_prime_x11.cpp
+++ b/platform/linuxbsd/x11/detect_prime_x11.cpp
@@ -36,8 +36,8 @@
 #include "core/string/print_string.h"
 #include "core/variant/variant.h"
 
-#include "thirdparty/glad/glad/gl.h"
-#include "thirdparty/glad/glad/glx.h"
+#include <thirdparty/glad/glad/gl.h>
+#include <thirdparty/glad/glad/glx.h>
 
 #ifdef SOWRAP_ENABLED
 #include "x11/dynwrappers/xlib-so_wrap.h"

--- a/platform/linuxbsd/x11/dynwrappers/xcursor-so_wrap.c
+++ b/platform/linuxbsd/x11/dynwrappers/xcursor-so_wrap.c
@@ -64,7 +64,7 @@
 #define XcursorGetTheme XcursorGetTheme_dylibloader_orig_xcursor
 #define XcursorGetThemeCore XcursorGetThemeCore_dylibloader_orig_xcursor
 #define XcursorSetThemeCore XcursorSetThemeCore_dylibloader_orig_xcursor
-#include "thirdparty/linuxbsd_headers/X11/Xcursor/Xcursor.h"
+#include <thirdparty/linuxbsd_headers/X11/Xcursor/Xcursor.h>
 #undef XcursorImageCreate
 #undef XcursorImageDestroy
 #undef XcursorImagesCreate

--- a/platform/linuxbsd/x11/dynwrappers/xcursor-so_wrap.h
+++ b/platform/linuxbsd/x11/dynwrappers/xcursor-so_wrap.h
@@ -66,7 +66,7 @@
 #define XcursorGetTheme XcursorGetTheme_dylibloader_orig_xcursor
 #define XcursorGetThemeCore XcursorGetThemeCore_dylibloader_orig_xcursor
 #define XcursorSetThemeCore XcursorSetThemeCore_dylibloader_orig_xcursor
-#include "thirdparty/linuxbsd_headers/X11/Xcursor/Xcursor.h" // IWYU pragma: export.
+#include <thirdparty/linuxbsd_headers/X11/Xcursor/Xcursor.h> // IWYU pragma: export.
 #undef XcursorImageCreate
 #undef XcursorImageDestroy
 #undef XcursorImagesCreate

--- a/platform/linuxbsd/x11/dynwrappers/xext-so_wrap.c
+++ b/platform/linuxbsd/x11/dynwrappers/xext-so_wrap.c
@@ -5,7 +5,7 @@
 //
 #include <stdint.h>
 
-#include "thirdparty/linuxbsd_headers/X11/Xlib.h"
+#include <thirdparty/linuxbsd_headers/X11/Xlib.h>
 #define XShapeQueryExtension XShapeQueryExtension_dylibloader_orig_xext
 #define XShapeQueryVersion XShapeQueryVersion_dylibloader_orig_xext
 #define XShapeCombineRegion XShapeCombineRegion_dylibloader_orig_xext
@@ -17,8 +17,8 @@
 #define XShapeSelectInput XShapeSelectInput_dylibloader_orig_xext
 #define XShapeInputSelected XShapeInputSelected_dylibloader_orig_xext
 #define XShapeGetRectangles XShapeGetRectangles_dylibloader_orig_xext
-#include "thirdparty/linuxbsd_headers/X11/extensions/Xext.h"
-#include "thirdparty/linuxbsd_headers/X11/extensions/shape.h"
+#include <thirdparty/linuxbsd_headers/X11/extensions/Xext.h>
+#include <thirdparty/linuxbsd_headers/X11/extensions/shape.h>
 #undef XShapeQueryExtension
 #undef XShapeQueryVersion
 #undef XShapeCombineRegion

--- a/platform/linuxbsd/x11/dynwrappers/xext-so_wrap.h
+++ b/platform/linuxbsd/x11/dynwrappers/xext-so_wrap.h
@@ -18,8 +18,8 @@
 #define XShapeSelectInput XShapeSelectInput_dylibloader_orig_xext
 #define XShapeInputSelected XShapeInputSelected_dylibloader_orig_xext
 #define XShapeGetRectangles XShapeGetRectangles_dylibloader_orig_xext
-#include "thirdparty/linuxbsd_headers/X11/extensions/Xext.h" // IWYU pragma: export.
-#include "thirdparty/linuxbsd_headers/X11/extensions/shape.h" // IWYU pragma: export.
+#include <thirdparty/linuxbsd_headers/X11/extensions/Xext.h> // IWYU pragma: export.
+#include <thirdparty/linuxbsd_headers/X11/extensions/shape.h> // IWYU pragma: export.
 #undef XShapeQueryExtension
 #undef XShapeQueryVersion
 #undef XShapeCombineRegion

--- a/platform/linuxbsd/x11/dynwrappers/xinerama-so_wrap.c
+++ b/platform/linuxbsd/x11/dynwrappers/xinerama-so_wrap.c
@@ -9,7 +9,7 @@
 #define XineramaQueryVersion XineramaQueryVersion_dylibloader_orig_xinerama
 #define XineramaIsActive XineramaIsActive_dylibloader_orig_xinerama
 #define XineramaQueryScreens XineramaQueryScreens_dylibloader_orig_xinerama
-#include "thirdparty/linuxbsd_headers/X11/extensions/Xinerama.h"
+#include <thirdparty/linuxbsd_headers/X11/extensions/Xinerama.h>
 #undef XineramaQueryExtension
 #undef XineramaQueryVersion
 #undef XineramaIsActive

--- a/platform/linuxbsd/x11/dynwrappers/xinerama-so_wrap.h
+++ b/platform/linuxbsd/x11/dynwrappers/xinerama-so_wrap.h
@@ -11,7 +11,7 @@
 #define XineramaQueryVersion XineramaQueryVersion_dylibloader_orig_xinerama
 #define XineramaIsActive XineramaIsActive_dylibloader_orig_xinerama
 #define XineramaQueryScreens XineramaQueryScreens_dylibloader_orig_xinerama
-#include "thirdparty/linuxbsd_headers/X11/extensions/Xinerama.h" // IWYU pragma: export.
+#include <thirdparty/linuxbsd_headers/X11/extensions/Xinerama.h> // IWYU pragma: export.
 #undef XineramaQueryExtension
 #undef XineramaQueryVersion
 #undef XineramaIsActive

--- a/platform/linuxbsd/x11/dynwrappers/xinput2-so_wrap.c
+++ b/platform/linuxbsd/x11/dynwrappers/xinput2-so_wrap.c
@@ -39,7 +39,7 @@
 #define XIBarrierReleasePointers XIBarrierReleasePointers_dylibloader_orig_xinput2
 #define XIBarrierReleasePointer XIBarrierReleasePointer_dylibloader_orig_xinput2
 #define XIFreeDeviceInfo XIFreeDeviceInfo_dylibloader_orig_xinput2
-#include "thirdparty/linuxbsd_headers/X11/extensions/XInput2.h"
+#include <thirdparty/linuxbsd_headers/X11/extensions/XInput2.h>
 #undef XIQueryPointer
 #undef XIWarpPointer
 #undef XIDefineCursor

--- a/platform/linuxbsd/x11/dynwrappers/xinput2-so_wrap.h
+++ b/platform/linuxbsd/x11/dynwrappers/xinput2-so_wrap.h
@@ -41,7 +41,7 @@
 #define XIBarrierReleasePointers XIBarrierReleasePointers_dylibloader_orig_xinput2
 #define XIBarrierReleasePointer XIBarrierReleasePointer_dylibloader_orig_xinput2
 #define XIFreeDeviceInfo XIFreeDeviceInfo_dylibloader_orig_xinput2
-#include "thirdparty/linuxbsd_headers/X11/extensions/XInput2.h" // IWYU pragma: export.
+#include <thirdparty/linuxbsd_headers/X11/extensions/XInput2.h> // IWYU pragma: export.
 #undef XIQueryPointer
 #undef XIWarpPointer
 #undef XIDefineCursor

--- a/platform/linuxbsd/x11/dynwrappers/xlib-so_wrap.c
+++ b/platform/linuxbsd/x11/dynwrappers/xlib-so_wrap.c
@@ -609,9 +609,9 @@
 #define XkbApplyVirtualModChanges XkbApplyVirtualModChanges_dylibloader_orig_xlib
 #define XkbUpdateActionVirtualMods XkbUpdateActionVirtualMods_dylibloader_orig_xlib
 #define XkbUpdateKeyTypeVirtualMods XkbUpdateKeyTypeVirtualMods_dylibloader_orig_xlib
-#include "thirdparty/linuxbsd_headers/X11/Xlib.h"
-#include "thirdparty/linuxbsd_headers/X11/Xutil.h"
-#include "thirdparty/linuxbsd_headers/X11/XKBlib.h"
+#include <thirdparty/linuxbsd_headers/X11/Xlib.h>
+#include <thirdparty/linuxbsd_headers/X11/Xutil.h>
+#include <thirdparty/linuxbsd_headers/X11/XKBlib.h>
 #undef _Xmblen
 #undef XLoadQueryFont
 #undef XQueryFont

--- a/platform/linuxbsd/x11/dynwrappers/xlib-so_wrap.h
+++ b/platform/linuxbsd/x11/dynwrappers/xlib-so_wrap.h
@@ -611,9 +611,9 @@
 #define XkbApplyVirtualModChanges XkbApplyVirtualModChanges_dylibloader_orig_xlib
 #define XkbUpdateActionVirtualMods XkbUpdateActionVirtualMods_dylibloader_orig_xlib
 #define XkbUpdateKeyTypeVirtualMods XkbUpdateKeyTypeVirtualMods_dylibloader_orig_xlib
-#include "thirdparty/linuxbsd_headers/X11/Xlib.h" // IWYU pragma: export.
-#include "thirdparty/linuxbsd_headers/X11/Xutil.h" // IWYU pragma: export.
-#include "thirdparty/linuxbsd_headers/X11/XKBlib.h" // IWYU pragma: export.
+#include <thirdparty/linuxbsd_headers/X11/Xlib.h> // IWYU pragma: export.
+#include <thirdparty/linuxbsd_headers/X11/Xutil.h> // IWYU pragma: export.
+#include <thirdparty/linuxbsd_headers/X11/XKBlib.h> // IWYU pragma: export.
 #undef _Xmblen
 #undef XLoadQueryFont
 #undef XQueryFont

--- a/platform/linuxbsd/x11/dynwrappers/xrandr-so_wrap.c
+++ b/platform/linuxbsd/x11/dynwrappers/xrandr-so_wrap.c
@@ -75,7 +75,7 @@
 #define XRRSetMonitor XRRSetMonitor_dylibloader_orig_xrandr
 #define XRRDeleteMonitor XRRDeleteMonitor_dylibloader_orig_xrandr
 #define XRRFreeMonitors XRRFreeMonitors_dylibloader_orig_xrandr
-#include "thirdparty/linuxbsd_headers/X11/extensions/Xrandr.h"
+#include <thirdparty/linuxbsd_headers/X11/extensions/Xrandr.h>
 #undef XRRQueryExtension
 #undef XRRQueryVersion
 #undef XRRGetScreenInfo

--- a/platform/linuxbsd/x11/dynwrappers/xrandr-so_wrap.h
+++ b/platform/linuxbsd/x11/dynwrappers/xrandr-so_wrap.h
@@ -77,7 +77,7 @@
 #define XRRSetMonitor XRRSetMonitor_dylibloader_orig_xrandr
 #define XRRDeleteMonitor XRRDeleteMonitor_dylibloader_orig_xrandr
 #define XRRFreeMonitors XRRFreeMonitors_dylibloader_orig_xrandr
-#include "thirdparty/linuxbsd_headers/X11/extensions/Xrandr.h" // IWYU pragma: export.
+#include <thirdparty/linuxbsd_headers/X11/extensions/Xrandr.h> // IWYU pragma: export.
 #undef XRRQueryExtension
 #undef XRRQueryVersion
 #undef XRRGetScreenInfo

--- a/platform/linuxbsd/x11/dynwrappers/xrender-so_wrap.c
+++ b/platform/linuxbsd/x11/dynwrappers/xrender-so_wrap.c
@@ -49,7 +49,7 @@
 #define XRenderCreateLinearGradient XRenderCreateLinearGradient_dylibloader_orig_xrender
 #define XRenderCreateRadialGradient XRenderCreateRadialGradient_dylibloader_orig_xrender
 #define XRenderCreateConicalGradient XRenderCreateConicalGradient_dylibloader_orig_xrender
-#include "thirdparty/linuxbsd_headers/X11/extensions/Xrender.h"
+#include <thirdparty/linuxbsd_headers/X11/extensions/Xrender.h>
 #undef XRenderQueryExtension
 #undef XRenderQueryVersion
 #undef XRenderQueryFormats

--- a/platform/linuxbsd/x11/dynwrappers/xrender-so_wrap.h
+++ b/platform/linuxbsd/x11/dynwrappers/xrender-so_wrap.h
@@ -51,7 +51,7 @@
 #define XRenderCreateLinearGradient XRenderCreateLinearGradient_dylibloader_orig_xrender
 #define XRenderCreateRadialGradient XRenderCreateRadialGradient_dylibloader_orig_xrender
 #define XRenderCreateConicalGradient XRenderCreateConicalGradient_dylibloader_orig_xrender
-#include "thirdparty/linuxbsd_headers/X11/extensions/Xrender.h" // IWYU pragma: export.
+#include <thirdparty/linuxbsd_headers/X11/extensions/Xrender.h> // IWYU pragma: export.
 #undef XRenderQueryExtension
 #undef XRenderQueryVersion
 #undef XRenderQueryFormats

--- a/platform/linuxbsd/x11/gl_manager_x11.cpp
+++ b/platform/linuxbsd/x11/gl_manager_x11.cpp
@@ -35,7 +35,7 @@
 #include "core/os/os.h"
 #include "servers/display/display_server.h"
 
-#include "thirdparty/glad/glad/glx.h"
+#include <thirdparty/glad/glad/glx.h>
 
 #ifdef SOWRAP_ENABLED
 #include "dynwrappers/xrender-so_wrap.h"

--- a/platform/macos/platform_gl.h
+++ b/platform/macos/platform_gl.h
@@ -41,11 +41,11 @@
 // IWYU pragma: begin_exports.
 #ifdef EGL_STATIC
 #define KHRONOS_STATIC 1
-#include "thirdparty/angle/include/EGL/egl.h"
-#include "thirdparty/angle/include/EGL/eglext.h"
+#include <thirdparty/angle/include/EGL/egl.h>
+#include <thirdparty/angle/include/EGL/eglext.h>
 #undef KHRONOS_STATIC
 #else
-#include "thirdparty/glad/glad/egl.h"
+#include <thirdparty/glad/glad/egl.h>
 #endif
-#include "thirdparty/glad/glad/gl.h"
+#include <thirdparty/glad/glad/gl.h>
 // IWYU pragma: end_exports.

--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -40,9 +40,10 @@
 
 #ifdef CRASH_HANDLER_EXCEPTION
 
+#include <thirdparty/libbacktrace/backtrace.h>
+
 #include <cxxabi.h>
 #include <psapi.h>
-#include <thirdparty/libbacktrace/backtrace.h>
 
 #include <csignal>
 #include <cstdlib>

--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -40,10 +40,9 @@
 
 #ifdef CRASH_HANDLER_EXCEPTION
 
-#include "thirdparty/libbacktrace/backtrace.h"
-
 #include <cxxabi.h>
 #include <psapi.h>
+#include <thirdparty/libbacktrace/backtrace.h>
 
 #include <csignal>
 #include <cstdlib>

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -36,8 +36,9 @@
 #include "core/os/os.h"
 #include "core/version.h"
 
-#include <dwmapi.h>
 #include <thirdparty/misc/nvapi_minimal.h>
+
+#include <dwmapi.h>
 
 #include <cstdio>
 #include <cstdlib>

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -36,9 +36,8 @@
 #include "core/os/os.h"
 #include "core/version.h"
 
-#include "thirdparty/misc/nvapi_minimal.h"
-
 #include <dwmapi.h>
+#include <thirdparty/misc/nvapi_minimal.h>
 
 #include <cstdio>
 #include <cstdlib>

--- a/platform/windows/platform_gl.h
+++ b/platform/windows/platform_gl.h
@@ -41,12 +41,12 @@
 // IWYU pragma: begin_exports.
 #ifdef EGL_STATIC
 #define KHRONOS_STATIC 1
-#include "thirdparty/angle/include/EGL/egl.h"
-#include "thirdparty/angle/include/EGL/eglext.h"
+#include <thirdparty/angle/include/EGL/egl.h>
+#include <thirdparty/angle/include/EGL/eglext.h>
 #undef KHRONOS_STATIC
 #else
-#include "thirdparty/glad/glad/egl.h"
+#include <thirdparty/glad/glad/egl.h>
 #endif
 
-#include "thirdparty/glad/glad/gl.h"
+#include <thirdparty/glad/glad/gl.h>
 // IWYU pragma: end_exports.

--- a/scene/2d/line_builder.h
+++ b/scene/2d/line_builder.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "line_2d.h"
+#include "scene/2d/line_2d.h"
 
 class LineBuilder {
 public:

--- a/scene/2d/mesh_instance_2d.cpp
+++ b/scene/2d/mesh_instance_2d.cpp
@@ -38,7 +38,7 @@
 #include "scene/resources/2d/navigation_polygon.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
 
-#include "thirdparty/clipper2/include/clipper2/clipper.h"
+#include <thirdparty/clipper2/include/clipper2/clipper.h>
 #endif // NAVIGATION_2D_DISABLED
 
 Callable MeshInstance2D::_navmesh_source_geometry_parsing_callback;

--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -38,7 +38,7 @@
 #include "scene/resources/2d/navigation_polygon.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
 
-#include "thirdparty/clipper2/include/clipper2/clipper.h"
+#include <thirdparty/clipper2/include/clipper2/clipper.h>
 #endif // NAVIGATION_2D_DISABLED
 
 Callable MultiMeshInstance2D::_navmesh_source_geometry_parsing_callback;

--- a/scene/2d/parallax_background.cpp
+++ b/scene/2d/parallax_background.cpp
@@ -30,9 +30,8 @@
 
 #include "parallax_background.h"
 
-#include "parallax_layer.h"
-
 #include "core/object/class_db.h"
+#include "scene/2d/parallax_layer.h"
 
 void ParallaxBackground::_notification(int p_what) {
 	switch (p_what) {

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -31,9 +31,8 @@
 #include "animation_blend_space_1d.h"
 #include "animation_blend_space_1d.compat.inc"
 
-#include "animation_blend_tree.h"
-
 #include "core/object/class_db.h"
+#include "scene/animation/animation_blend_tree.h"
 
 void AnimationNodeBlendSpace1D::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -31,11 +31,10 @@
 #include "animation_blend_space_2d.h"
 #include "animation_blend_space_2d.compat.inc"
 
-#include "animation_blend_tree.h"
-
 #include "core/math/geometry_2d.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "scene/animation/animation_blend_tree.h"
 
 void AnimationNodeBlendSpace2D::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -36,7 +36,7 @@
 #include "scene/resources/material.h"
 #include "servers/rendering/rendering_server.h"
 
-#include "thirdparty/misc/ok_color_shader.h"
+#include <thirdparty/misc/ok_color_shader.h>
 
 void ColorPickerShape::init_shaders() {
 	wheel_shader.instantiate();

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -34,7 +34,7 @@
 #include "core/object/class_db.h"
 #include "servers/display/accessibility_server.h"
 
-#include "thirdparty/misc/r128.h"
+#include <thirdparty/misc/r128.h>
 
 double Range::_snapped_r128(double p_value, double p_step) {
 	if (p_step == 0.0) {

--- a/scene/main/scene_tree_fti.cpp
+++ b/scene/main/scene_tree_fti.cpp
@@ -39,7 +39,7 @@
 #include "scene/3d/visual_instance_3d.h"
 
 #ifdef GODOT_SCENE_TREE_FTI_VERIFY
-#include "scene_tree_fti_tests.h"
+#include "scene/main/scene_tree_fti_tests.h"
 #endif
 
 #ifdef DEV_ENABLED

--- a/scene/resources/2d/navigation_polygon.cpp
+++ b/scene/resources/2d/navigation_polygon.cpp
@@ -34,7 +34,7 @@
 #include "core/object/class_db.h"
 #include "core/os/mutex.h"
 
-#include "thirdparty/misc/polypartition.h"
+#include <thirdparty/misc/polypartition.h>
 
 #ifdef DEBUG_ENABLED
 Rect2 NavigationPolygon::_edit_get_rect() const {

--- a/scene/resources/3d/mesh_library.cpp
+++ b/scene/resources/3d/mesh_library.cpp
@@ -35,7 +35,7 @@
 #include "servers/rendering/rendering_server.h" // IWYU pragma: keep // Needed to bind RSE enums.
 
 #ifndef PHYSICS_3D_DISABLED
-#include "box_shape_3d.h"
+#include "scene/resources/3d/box_shape_3d.h"
 #endif // PHYSICS_3D_DISABLED
 
 bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {

--- a/scene/resources/3d/mesh_library.h
+++ b/scene/resources/3d/mesh_library.h
@@ -37,7 +37,7 @@
 #include "servers/rendering/rendering_server_enums.h"
 
 #ifndef PHYSICS_3D_DISABLED
-#include "shape_3d.h"
+#include "scene/resources/3d/shape_3d.h"
 #endif // PHYSICS_3D_DISABLED
 
 class MeshLibrary : public Resource {

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -41,7 +41,7 @@
 #include "servers/rendering/rendering_server.h"
 #include "servers/rendering/rendering_server_enums.h"
 
-#include "thirdparty/misc/polypartition.h"
+#include <thirdparty/misc/polypartition.h>
 
 #define PADDING_REF_SIZE 1024.0
 

--- a/scene/resources/audio_stream_wav.h
+++ b/scene/resources/audio_stream_wav.h
@@ -32,7 +32,7 @@
 
 #include "servers/audio/audio_stream.h"
 
-#include "thirdparty/misc/qoa.h"
+#include <thirdparty/misc/qoa.h>
 
 class AudioStreamWAV;
 

--- a/scene/resources/bone_map.h
+++ b/scene/resources/bone_map.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "skeleton_profile.h"
+#include "scene/resources/skeleton_profile.h"
 
 class BoneMap : public Resource {
 	GDCLASS(BoneMap, Resource);

--- a/scene/resources/gradient.h
+++ b/scene/resources/gradient.h
@@ -32,7 +32,7 @@
 
 #include "core/io/resource.h"
 
-#include "thirdparty/misc/ok_color.h"
+#include <thirdparty/misc/ok_color.h>
 
 class Gradient : public Resource {
 	GDCLASS(Gradient, Resource);

--- a/scene/resources/skeleton_profile.h
+++ b/scene/resources/skeleton_profile.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "texture.h"
+#include "scene/resources/texture.h"
 
 class SkeletonProfile : public Resource {
 	GDCLASS(SkeletonProfile, Resource);

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -34,7 +34,7 @@
 #include "scene/resources/mesh.h"
 #include "servers/rendering/rendering_server_enums.h"
 
-#include "thirdparty/misc/mikktspace.h"
+#include <thirdparty/misc/mikktspace.h>
 
 class SurfaceTool : public RefCounted {
 	GDCLASS(SurfaceTool, RefCounted);

--- a/servers/physics_2d/physics_server_2d_dummy.h
+++ b/servers/physics_2d/physics_server_2d_dummy.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "physics_server_2d.h"
+#include "servers/physics_2d/physics_server_2d.h"
 
 class PhysicsDirectBodyState2DDummy : public PhysicsDirectBodyState2D {
 	GDCLASS(PhysicsDirectBodyState2DDummy, PhysicsDirectBodyState2D);

--- a/servers/rendering/instance_uniforms.cpp
+++ b/servers/rendering/instance_uniforms.cpp
@@ -30,7 +30,7 @@
 
 #include "instance_uniforms.h"
 
-#include "rendering_server_globals.h"
+#include "servers/rendering/rendering_server_globals.h"
 
 void InstanceUniforms::free(RID p_self) {
 	ERR_FAIL_COND(p_self.is_null());

--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -35,7 +35,7 @@
 #include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
 #include "servers/rendering/renderer_rd/uniform_set_cache_rd.h"
 
-#include "thirdparty/misc/cubemap_coeffs.h"
+#include <thirdparty/misc/cubemap_coeffs.h>
 
 using namespace RendererRD;
 

--- a/servers/rendering/renderer_rd/effects/fsr2.h
+++ b/servers/rendering/renderer_rd/effects/fsr2.h
@@ -45,7 +45,7 @@
 #define FFX_GCC
 #endif
 
-#include "thirdparty/amd-fsr2/ffx_fsr2.h"
+#include <thirdparty/amd-fsr2/ffx_fsr2.h>
 
 #define FSR2_MAX_QUEUED_FRAMES (4)
 #define FSR2_MAX_UNIFORM_BUFFERS (4)

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -35,7 +35,7 @@
 #include "modules/glslang/shader_compile.h"
 #endif
 
-#include "shader_include_db.h"
+#include "servers/rendering/shader_include_db.h"
 
 Error RDShaderFile::parse_versions_from_text(const String &p_text, const String p_defines, OpenIncludeFunction p_include_func, void *p_include_func_userdata) {
 	Vector<String> lines = p_text.split("\n");

--- a/servers/rendering/rendering_shader_container.cpp
+++ b/servers/rendering/rendering_shader_container.cpp
@@ -33,7 +33,7 @@
 #include "core/io/compression.h"
 #include "servers/rendering/renderer_rd/shader_rd.h"
 
-#include "thirdparty/spirv-reflect/spirv_reflect.h"
+#include <thirdparty/spirv-reflect/spirv_reflect.h>
 
 static inline uint32_t aligned_to(uint32_t p_size, uint32_t p_alignment) {
 	if (p_size % p_alignment) {

--- a/servers/xr/xr_positional_tracker.cpp
+++ b/servers/xr/xr_positional_tracker.cpp
@@ -30,9 +30,8 @@
 
 #include "xr_positional_tracker.h"
 
-#include "xr_controller_tracker.h"
-
 #include "core/object/class_db.h"
+#include "servers/xr/xr_controller_tracker.h"
 
 void XRPositionalTracker::_bind_methods() {
 	BIND_ENUM_CONSTANT(TRACKER_HAND_UNKNOWN);

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -47,7 +47,7 @@
 
 // See documentation for doctest at:
 // https://github.com/onqtam/doctest/blob/master/doc/markdown/readme.md#reference
-#include "thirdparty/doctest/doctest.h"
+#include <thirdparty/doctest/doctest.h>
 
 // Forces a test file to be linked.
 #define TEST_FORCE_LINK(m_name) \

--- a/thirdparty/sdl/core/linux/SDL_udev.h
+++ b/thirdparty/sdl/core/linux/SDL_udev.h
@@ -31,7 +31,7 @@
 #endif
 
 //#include <libudev.h>
-#include "thirdparty/linuxbsd_headers/udev/libudev.h"
+#include <thirdparty/linuxbsd_headers/udev/libudev.h>
 #include <sys/time.h>
 #include <sys/types.h>
 

--- a/thirdparty/sdl/patches/0005-fix-libudev-dbus.patch
+++ b/thirdparty/sdl/patches/0005-fix-libudev-dbus.patch
@@ -55,7 +55,7 @@ index 738f4bafe3f..50bed36248e 100644
  
 -#include <libudev.h>
 +//#include <libudev.h>
-+#include "thirdparty/linuxbsd_headers/udev/libudev.h"
++#include <thirdparty/linuxbsd_headers/udev/libudev.h>
  #include <sys/time.h>
  #include <sys/types.h>
  


### PR DESCRIPTION
- Related #117491

In the above PR, it was noted that there's no `clang-format`/`clang-tidy` option to forbid relative includes. I remembered one of my earlier PRs playing around with an `#include` validator to ensure encapsulation, and was able to re-implement that idea as stylistic enforcement instead. In doing so, this new hook revealed nearly 300 instances of non-module files using relative includes!

As a stylistic validator, I also threw in two other checks that felt relevant: forbidding Windows-style paths, and ensuring thirdparty includes use angle-brackets. No manual adjustments were made after the validation steps, to give a clearer idea on what *just* the validator (and subsequent `clang-format` run) results in