### PR TITLE
Make 'ctrl shift enter' behavior smart

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1294,16 +1294,44 @@ int CodeEdit::_calculate_spaces_till_next_right_indent(int p_column) const {
 	return indent_size - p_column % indent_size;
 }
 
-void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
+void CodeEdit::_new_line(bool p_split_current_line, bool p_above, int p_caret_to_work_from) {
 	if (!is_editable()) {
 		return;
 	}
 
-	begin_complex_operation();
-	begin_multicaret_edit();
+	if (p_above) {
+		begin_complex_operation();
+		begin_multicaret_edit();
+
+		for (int i = get_caret_count() - 1; i >= 0; i--) {
+			const int caret_line = get_caret_line(i);
+			// Special case for the first line
+			if (caret_line == 0) {
+				set_caret_column(0, i == 0, i);
+				_new_line(true, false, i);
+				set_caret_line(caret_line, false, true, -1, i);
+			} else {
+				set_caret_line(caret_line - 1, false, true, -1, i);
+				set_caret_column(get_line(get_caret_line(i)).length(), i == 0, i);
+				_new_line(false, false, i);
+			}
+		}
+		end_multicaret_edit();
+		end_complex_operation();
+		return;
+	}
+
+	// Only make another operation if we did not come from the p_above section above.
+	if (p_caret_to_work_from == -1) {
+		begin_complex_operation();
+		begin_multicaret_edit();
+	}
 
 	for (int i = 0; i < get_caret_count(); i++) {
 		if (multicaret_edit_ignore_caret(i)) {
+			continue;
+		}
+		if (p_caret_to_work_from != -1 && i != p_caret_to_work_from) {
 			continue;
 		}
 		// When not splitting the line, we need to factor in indentation from the end of the current line.
@@ -1312,10 +1340,7 @@ void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
 
 		const String line = get_line(cl);
 
-		String ins = "";
-		if (!p_above) {
-			ins = "\n";
-		}
+		String ins = "\n";
 
 		// Append current indentation.
 		int space_count = 0;
@@ -1338,16 +1363,13 @@ void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
 			}
 			break;
 		}
-		if (p_above) {
-			ins += "\n";
-		}
 
 		if (is_line_folded(cl)) {
 			unfold_line(cl);
 		}
 
 		// Indent once again if the previous line needs it, ie ':'.
-		// Then add an addition new line for any closing pairs aka '()'.
+		// Then add an additional new line for any closing pairs aka '()'.
 		// Skip this in comments or if we are going above.
 		bool brace_indent = false;
 		if (auto_indent && !p_above && cc > 0 && is_in_comment(cl) == -1) {
@@ -1401,8 +1423,10 @@ void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
 		}
 	}
 
-	end_multicaret_edit();
-	end_complex_operation();
+	if (p_caret_to_work_from == -1) {
+		end_multicaret_edit();
+		end_complex_operation();
+	}
 }
 
 /* Auto brace completion */

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -72,7 +72,7 @@ private:
 	int _calculate_spaces_till_next_left_indent(int p_column) const;
 	int _calculate_spaces_till_next_right_indent(int p_column) const;
 
-	void _new_line(bool p_split_current_line = true, bool p_above = false);
+	void _new_line(bool p_split_current_line = true, bool p_above = false, int p_caret_to_work_from = -1);
 
 	/* Auto brace completion */
 	bool auto_brace_completion_enabled = false;

--- a/tests/scene/test_code_edit.cpp
+++ b/tests/scene/test_code_edit.cpp
@@ -2540,13 +2540,23 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			CHECK(code_edit->get_caret_line() == 1);
 			CHECK(code_edit->get_caret_column() == 1);
 
-			// Preserve current indentation above.
+			// No line above.
 			code_edit->set_text("\ttest");
 			code_edit->set_caret_column(3);
 			SEND_GUI_ACTION("ui_text_newline_above");
-			CHECK(code_edit->get_line(0) == "\t");
+			CHECK(code_edit->get_line(0) == "");
 			CHECK(code_edit->get_line(1) == "\ttest");
 			CHECK(code_edit->get_caret_line() == 0);
+			CHECK(code_edit->get_caret_column() == 0);
+
+			// With line above, use the above line indent.
+			code_edit->set_text("\ttest\n");
+			code_edit->set_caret_line(1);
+			SEND_GUI_ACTION("ui_text_newline_above");
+			CHECK(code_edit->get_line(0) == "\ttest");
+			CHECK(code_edit->get_line(1) == "\t");
+			CHECK(code_edit->get_line(2) == "");
+			CHECK(code_edit->get_caret_line() == 1);
 			CHECK(code_edit->get_caret_column() == 1);
 
 			// Increase existing indentation.
@@ -2701,12 +2711,14 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			CHECK(code_edit->get_caret_column() == 4);
 
 			// Preserve current indentation above.
-			code_edit->set_text("    test");
+			code_edit->set_text("    \n    test");
+			code_edit->set_caret_line(1);
 			code_edit->set_caret_column(6);
 			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line(0) == "    ");
-			CHECK(code_edit->get_line(1) == "    test");
-			CHECK(code_edit->get_caret_line() == 0);
+			CHECK(code_edit->get_line(1) == "    ");
+			CHECK(code_edit->get_line(2) == "    test");
+			CHECK(code_edit->get_caret_line() == 1);
 			CHECK(code_edit->get_caret_column() == 4);
 
 			// Increase existing indentation.
@@ -4934,9 +4946,9 @@ TEST_CASE("[SceneTree][CodeEdit] text manipulation") {
 		CHECK(code_edit->get_line(1) == "");
 		CHECK(code_edit->get_line(2) == "test new line");
 		CHECK(code_edit->get_caret_count() == 2);
-		CHECK(code_edit->get_caret_line(0) == 0);
+		CHECK(code_edit->get_caret_line(1) == 0);
 		CHECK(code_edit->get_caret_column(0) == 0);
-		CHECK(code_edit->get_caret_line(1) == 1);
+		CHECK(code_edit->get_caret_line(0) == 1);
 		CHECK(code_edit->get_caret_column(1) == 0);
 
 		// See '[CodeEdit] auto indent' tests for tests about new line with indentation.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/116969

This makes the shortcut "ctrl shift enter" ("ui_text_newline_above") behave like it does in VSCode and colons. So if the current line has no indentation, and the above line ends with a ":", then doing the shortcut will make the newly inserted line indented.

This is done by making the caret go to the end of the above line, then pressing enter normally. So one behavior that changes is if the line above is indented (and no colon), and your current line has no indent, and you do the shortcut, then

* Without this PR, the new line would stay at no indent
* With the PR, the new line will match the above line indent

https://github.com/user-attachments/assets/46ef1ea2-4a88-4524-b48d-cc200b361f9b

