### PR TITLE
Fix WAV import failure reporting for corrupt files

### DIFF
--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -96,6 +96,7 @@ Error ResourceImporterWAV::import(ResourceUID::ID p_source_id, const String &p_s
 	}
 
 	Ref<AudioStreamWAV> sample = AudioStreamWAV::load_from_file(p_source_file, options);
-	ResourceSaver::save(sample, p_save_path + ".sample");
-	return OK;
+	ERR_FAIL_COND_V_MSG(sample.is_null(), ERR_FILE_CORRUPT, "Failed to import WAV (corrupt or invalid).");
+	Error save_err = ResourceSaver::save(sample, p_save_path + ".sample");
+	return save_err;
 }

--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -773,8 +773,7 @@ Ref<AudioStreamWAV> AudioStreamWAV::load_from_buffer(const Vector<uint8_t> &p_st
 			uint64_t remaining_bytes = file_size - file_pos;
 			frames = chunksize;
 			if (remaining_bytes < chunksize) {
-				WARN_PRINT("Data chunk size is smaller than expected. Proceeding with actual data size.");
-				frames = remaining_bytes;
+				ERR_FAIL_V_MSG(Ref<AudioStreamWAV>(), "Data chunk size is smaller than expected.");
 			}
 
 			ERR_FAIL_COND_V(format_channels == 0, Ref<AudioStreamWAV>());


### PR DESCRIPTION
# Partial Fix for: #117528 

- Abort WAV import when the loader returns a null stream (corrupt/invalid files).

- Emit a clear error so the import fails visibly instead of looping.

maybe it should be applied for every file corrupted, not only wav

for now it should patch wav files