### PR TITLE
Fix inconsistent tooltip for `@GlobalScope` constants

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -4317,13 +4317,6 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 		return OK;
 	}
 
-	if (p_symbol == "PI" || p_symbol == "TAU" || p_symbol == "INF" || p_symbol == "NAN") {
-		r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
-		r_result.class_name = "@GDScript";
-		r_result.class_member = p_symbol;
-		return OK;
-	}
-
 	GDScriptParser parser;
 	parser.parse(p_code, p_path, true);
 
@@ -4537,6 +4530,13 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 							return OK;
 						}
 					}
+				}
+
+				if (p_symbol == "PI" || p_symbol == "TAU" || p_symbol == "INF" || p_symbol == "NAN") {
+					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
+					r_result.class_name = "@GDScript";
+					r_result.class_member = p_symbol;
+					return OK;
 				}
 
 				if (CoreConstants::is_global_enum(p_symbol)) {


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot/issues/106944

Note: Split from https://github.com/godotengine/godot/pull/106984. Can be merged separately.

Changes:
- Fixes incorrect tooltip for shadowed `@GlobalScope` constants.
  - Shadowed `@GDScript` constants did not have this issue.
  - Tooltip is consistent with GDScript's execution behaviour.

Test Script:
https://github.com/godotengine/godot/pull/117545#issuecomment-4078726726

Any help is appreciated!