### PR TITLE
Add title alignment property to Window

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -779,7 +779,7 @@
 			The window's title. If the [Window] is native, title styles set in [Theme] will have no effect.
 		</member>
 		<member name="title_alignment" type="int" setter="set_title_alignment" getter="get_title_alignment" enum="HorizontalAlignment" default="1">
-			The horizontal alignment of the window's title text. Only effective on embedded windows (see [member Viewport.gui_embed_subwindows]).
+			The horizontal alignment of the window's title text. Only effective on embedded windows (see [member Viewport.gui_embed_subwindows]). Non-embedded windows always use the title bar alignment defined by the operating system (left-aligned on Windows, center-aligned on macOS and most Linux desktop environments).
 		</member>
 		<member name="transient" type="bool" setter="set_transient" getter="is_transient" default="false">
 			If [code]true[/code], the [Window] is transient, i.e. it's considered a child of another [Window]. The transient window will be destroyed with its transient parent and will return focus to their parent when closed. The transient window is displayed on top of a non-exclusive full-screen parent window. Transient windows can't enter full-screen mode.

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -778,6 +778,9 @@
 		<member name="title" type="String" setter="set_title" getter="get_title" default="&quot;&quot;">
 			The window's title. If the [Window] is native, title styles set in [Theme] will have no effect.
 		</member>
+		<member name="title_alignment" type="int" setter="set_title_alignment" getter="get_title_alignment" enum="HorizontalAlignment" default="1">
+			The horizontal alignment of the window's title text. Only effective on embedded windows (see [member Viewport.gui_embed_subwindows]).
+		</member>
 		<member name="transient" type="bool" setter="set_transient" getter="is_transient" default="false">
 			If [code]true[/code], the [Window] is transient, i.e. it's considered a child of another [Window]. The transient window will be destroyed with its transient parent and will return focus to their parent when closed. The transient window is displayed on top of a non-exclusive full-screen parent window. Transient windows can't enter full-screen mode.
 			Note that behavior might be different depending on the platform.

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -392,7 +392,9 @@ void Viewport::_sub_window_update(Window *p_window) {
 			TextLine title_text = TextLine(p_window->get_displayed_title(), title_font, font_size);
 			title_text.set_width(title_space);
 			title_text.set_direction(p_window->is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
-			int x = (r.size.width - title_text.get_size().x) / 2;
+			title_text.set_horizontal_alignment(p_window->get_title_alignment());
+
+			int x = panel->get_margin(SIDE_LEFT);
 			int y = (-title_height - title_text.get_size().y) / 2;
 
 			Color font_outline_color = p_window->theme_cache.title_outline_modulate;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1847,6 +1847,20 @@ bool Window::get_keep_title_visible() const {
 	return keep_title_visible;
 }
 
+void Window::set_title_alignment(HorizontalAlignment p_alignment) {
+	if (title_alignment == p_alignment) {
+		return;
+	}
+	title_alignment = p_alignment;
+	if (embedder) {
+		embedder->_sub_window_update(this);
+	}
+}
+
+HorizontalAlignment Window::get_title_alignment() const {
+	return title_alignment;
+}
+
 void Window::set_content_scale_factor(real_t p_factor) {
 	ERR_MAIN_THREAD_GUARD;
 	ERR_FAIL_COND(p_factor <= 0);
@@ -3421,6 +3435,9 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_keep_title_visible", "title_visible"), &Window::set_keep_title_visible);
 	ClassDB::bind_method(D_METHOD("get_keep_title_visible"), &Window::get_keep_title_visible);
 
+	ClassDB::bind_method(D_METHOD("set_title_alignment", "alignment"), &Window::set_title_alignment);
+	ClassDB::bind_method(D_METHOD("get_title_alignment"), &Window::get_title_alignment);
+
 	ClassDB::bind_method(D_METHOD("set_content_scale_factor", "factor"), &Window::set_content_scale_factor);
 	ClassDB::bind_method(D_METHOD("get_content_scale_factor"), &Window::get_content_scale_factor);
 
@@ -3516,6 +3533,7 @@ void Window::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Windowed,Minimized,Maximized,Fullscreen,Exclusive Fullscreen"), "set_mode", "get_mode");
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "title"), "set_title", "get_title");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "title_alignment", PROPERTY_HINT_ENUM, "Left,Center,Right,Fill"), "set_title_alignment", "get_title_alignment");
 
 	// Keep the enum values in sync with the `WindowInitialPosition` enum.
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "initial_position", PROPERTY_HINT_ENUM, "Absolute,Center of Primary Screen,Center of Main Window Screen,Center of Other Screen,Center of Screen With Mouse Pointer,Center of Screen With Keyboard Focus"), "set_initial_position", "get_initial_position");

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -146,6 +146,7 @@ private:
 	bool clamp_to_embedder = false;
 	bool unparent_when_invisible = false;
 	bool keep_title_visible = false;
+	HorizontalAlignment title_alignment = HORIZONTAL_ALIGNMENT_CENTER;
 
 	LayoutDirection layout_dir = LAYOUT_DIRECTION_INHERITED;
 
@@ -400,6 +401,9 @@ public:
 
 	void set_keep_title_visible(bool p_title_visible);
 	bool get_keep_title_visible() const;
+
+	void set_title_alignment(HorizontalAlignment p_alignment);
+	HorizontalAlignment get_title_alignment() const;
 
 	void set_content_scale_factor(real_t p_factor);
 	real_t get_content_scale_factor() const;


### PR DESCRIPTION
This merge request implements the enhancement described in [#13801](https://github.com/godotengine/godot-proposals/issues/13801) by adding a title alignment property to the Window class.

Alternatively, this could be implemented as a theme option, but because themes don't seem to contain enums I have decided to keep this property as part of Window.

I have also tested this to work on my own Godot project. 
<img width="1060" height="424" alt="image" src="https://github.com/user-attachments/assets/487285c1-ca83-43b1-8129-72dfa6ece390" />

- *Bugsquad edit:* closes https://github.com/godotengine/godot-proposals/issues/13801