### PR TITLE
[GDScript Tokenizer] Do not scan outside source string bounds.

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -1378,7 +1378,7 @@ GDScriptTokenizer::Token GDScriptTokenizerText::scan() {
 
 	if (pending_indents != 0) {
 		// Adjust position for indent.
-		_start -= start_column - 1;
+		_start -= MIN(start_column - 1, _start - _source);
 		start_column = 1;
 		if (pending_indents > 0) {
 			// Indents.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/117546

Instead of reading token from the end of the previous string, it was trying to read data before the string if indent is at the start of the source.