### PR TITLE
Fix Script Editor doesn't focus with keyboard shortcut on script workspace

### DIFF
--- a/editor/editor_main_screen.cpp
+++ b/editor/editor_main_screen.cpp
@@ -186,6 +186,7 @@ void EditorMainScreen::select(int p_index) {
 	ERR_FAIL_NULL(new_editor);
 
 	if (selected_plugin == new_editor) {
+		selected_plugin->selected_notify();
 		return;
 	}
 


### PR DESCRIPTION
Fixes #116989 

Added selection notification to the current selected plugin when it is the one asked to be selected to ensure plugin focus behavior.  

**Note** :  It doesn't help to focus on scene editors, game view, assetlib because it seems that they don't focus by default even when their not already selected (can't use keyboard shortcut without clicking on the window). Therefore i don't know if it's a bug or intended. 