### PR TITLE
Add early return in set_antialiased method for Line2D and Polygon2D

### DIFF
--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -265,6 +265,9 @@ int Line2D::get_round_precision() const {
 }
 
 void Line2D::set_antialiased(bool p_antialiased) {
+	if (_antialiased == p_antialiased) {
+		return;
+	}
 	_antialiased = p_antialiased;
 	queue_redraw();
 }

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -509,6 +509,9 @@ bool Polygon2D::get_invert() const {
 }
 
 void Polygon2D::set_antialiased(bool p_antialiased) {
+	if (antialiased == p_antialiased) {
+		return;
+	}
 	antialiased = p_antialiased;
 	queue_redraw();
 }


### PR DESCRIPTION
Fixes #117482

## Problem
set_antialiased() methods always call queue_redraw(), even when value unchanged.

## Solution
Add early return to avoid unnecessary redraw calls.

## Files Changed
- scene/2d/line_2d.cpp (+3 lines)
- scene/2d/polygon_2d.cpp (+3 lines)

## Testing
- Compiled successfully on macOS (8.25s)
- No functional changes, performance optimization only