### PR TITLE
Fix property grouping in TileSet Paint collision editor

### DIFF
--- a/editor/scene/2d/tiles/tile_data_editors.cpp
+++ b/editor/scene/2d/tiles/tile_data_editors.cpp
@@ -1589,8 +1589,19 @@ void TileDataCollisionEditor::_property_selected(const StringName &p_path, int p
 }
 
 void TileDataCollisionEditor::_polygons_changed() {
+	// Clear old labels first to prevent duplicates.
+	for (int i = get_child_count() - 1; i >= 0; i--) {
+		if (Object::cast_to<Label>(get_child(i))) {
+			get_child(i)->queue_free();
+		}
+	}
 	// Update the dummy object properties and their editors.
 	for (int i = 0; i < polygon_editor->get_polygon_count(); i++) {
+		Label *header = memnew(Label);
+		header->set_text(vformat(TTR("Polygon %d"), i));
+		header->add_theme_font_override("font", get_theme_font(SNAME("bold"), SNAME("EditorFonts")));
+		add_child(header);
+
 		StringName one_way_property = vformat("polygon_%d_one_way", i);
 		StringName one_way_margin_property = vformat("polygon_%d_one_way_margin", i);
 
@@ -1607,25 +1618,29 @@ void TileDataCollisionEditor::_polygons_changed() {
 		if (!property_editors.has(one_way_property)) {
 			EditorProperty *one_way_property_editor = EditorInspectorDefaultPlugin::get_editor_for_property(dummy_object, Variant::BOOL, one_way_property, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT);
 			one_way_property_editor->set_object_and_property(dummy_object, one_way_property);
-			one_way_property_editor->set_label(one_way_property);
+			one_way_property_editor->set_label(TTR("One Way"));
 			one_way_property_editor->connect("property_changed", callable_mp(this, &TileDataCollisionEditor::_property_value_changed).unbind(1));
 			one_way_property_editor->connect("selected", callable_mp(this, &TileDataCollisionEditor::_property_selected));
 			one_way_property_editor->set_tooltip_text(one_way_property_editor->get_edited_property());
 			one_way_property_editor->update_property();
 			add_child(one_way_property_editor);
 			property_editors[one_way_property] = one_way_property_editor;
+		} else {
+			move_child(property_editors[one_way_property], -1);
 		}
 
 		if (!property_editors.has(one_way_margin_property)) {
 			EditorProperty *one_way_margin_property_editor = EditorInspectorDefaultPlugin::get_editor_for_property(dummy_object, Variant::FLOAT, one_way_margin_property, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT);
 			one_way_margin_property_editor->set_object_and_property(dummy_object, one_way_margin_property);
-			one_way_margin_property_editor->set_label(one_way_margin_property);
+			one_way_margin_property_editor->set_label(TTR("One Way Margin"));
 			one_way_margin_property_editor->connect("property_changed", callable_mp(this, &TileDataCollisionEditor::_property_value_changed).unbind(1));
 			one_way_margin_property_editor->connect("selected", callable_mp(this, &TileDataCollisionEditor::_property_selected));
 			one_way_margin_property_editor->set_tooltip_text(one_way_margin_property_editor->get_edited_property());
 			one_way_margin_property_editor->update_property();
 			add_child(one_way_margin_property_editor);
 			property_editors[one_way_margin_property] = one_way_margin_property_editor;
+		} else {
+			move_child(property_editors[one_way_margin_property], -1);
 		}
 	}
 
@@ -1785,7 +1800,7 @@ TileDataCollisionEditor::TileDataCollisionEditor() {
 
 	EditorProperty *linear_velocity_editor = EditorInspectorDefaultPlugin::get_editor_for_property(dummy_object, Variant::VECTOR2, "linear_velocity", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT);
 	linear_velocity_editor->set_object_and_property(dummy_object, "linear_velocity");
-	linear_velocity_editor->set_label("linear_velocity");
+	linear_velocity_editor->set_label(TTR("Linear Velocity"));
 	linear_velocity_editor->connect("property_changed", callable_mp(this, &TileDataCollisionEditor::_property_value_changed).unbind(1));
 	linear_velocity_editor->connect("selected", callable_mp(this, &TileDataCollisionEditor::_property_selected));
 	linear_velocity_editor->set_tooltip_text(linear_velocity_editor->get_edited_property());
@@ -1795,7 +1810,7 @@ TileDataCollisionEditor::TileDataCollisionEditor() {
 
 	EditorProperty *angular_velocity_editor = EditorInspectorDefaultPlugin::get_editor_for_property(dummy_object, Variant::FLOAT, "angular_velocity", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT);
 	angular_velocity_editor->set_object_and_property(dummy_object, "angular_velocity");
-	angular_velocity_editor->set_label("angular_velocity");
+	angular_velocity_editor->set_label(TTR("Angular Velocity"));
 	angular_velocity_editor->connect("property_changed", callable_mp(this, &TileDataCollisionEditor::_property_value_changed).unbind(1));
 	angular_velocity_editor->connect("selected", callable_mp(this, &TileDataCollisionEditor::_property_selected));
 	angular_velocity_editor->set_tooltip_text(angular_velocity_editor->get_edited_property());

--- a/editor/scene/2d/tiles/tile_data_editors.cpp
+++ b/editor/scene/2d/tiles/tile_data_editors.cpp
@@ -1599,7 +1599,7 @@ void TileDataCollisionEditor::_polygons_changed() {
 	for (int i = 0; i < polygon_editor->get_polygon_count(); i++) {
 		Label *header = memnew(Label);
 		header->set_text(vformat(TTR("Polygon %d"), i));
-		header->add_theme_font_override("font", get_theme_font(SNAME("bold"), SNAME("EditorFonts")));
+		header->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("bold"), EditorStringName(EditorFonts)));
 		add_child(header);
 
 		StringName one_way_property = vformat("polygon_%d_one_way", i);


### PR DESCRIPTION
Fixes: #117514

This builds on #117534, as that fix makes it more difficult to differentiate between each polygon's properties.

To fix the problem, I added persistent labels ("Polygon [index]") before each set of properties so the user knows which polygon the property concerns.
- Used `move_child(..., -1)`  so that the existing property editors stay in the correct visual order relative to the headers during UI updates.

Before: (the fix in #117534)
<img width="285" height="623" alt="image" src="https://github.com/user-attachments/assets/55023ef0-360b-497a-93ab-e5751b6e9ccc" />
After:
<img width="309" height="622" alt="image" src="https://github.com/user-attachments/assets/5d8ce01c-845b-43f3-8f55-aad7a05ed251" />