### PR TITLE
Fix BlendTree appearing empty

### DIFF
--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -133,11 +133,13 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 
 void AnimationNodeBlendTreeEditor::update_graph_immediately() {
 	if (updating || blend_tree.is_null()) {
+		graph_update_queued = false;
 		return;
 	}
 
 	AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
 	if (!tree) {
+		graph_update_queued = false;
 		return;
 	}
 


### PR DESCRIPTION
An early return in `update_graph_immediately` can lock `graph_update_queued` as `true` forever, rendering `update_graph_immediately` impossible for `update_graph` to call again, due to its own early return when `graph_update_queued` is true, causing all BlendTrees to appear empty until the engine is restarted.

This bug is very difficult to reproduce, but I'm positive I've encountered it twice since the optimisation PR.
Hopefully a glance at the file makes this make sense.