### PR TITLE
Escape `\r` in multiline strings, and ignore raw `\r` when reading.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4495,6 +4495,7 @@ String String::c_escape_multiline() const {
 	String escaped = *this;
 	escaped = escaped.replace("\\", "\\\\");
 	escaped = escaped.replace("\"", "\\\"");
+	escaped = escaped.replace("\r", "\\r");
 
 	return escaped;
 }

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -284,6 +284,8 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 						r_err_str = "Unterminated string";
 						r_token.type = TK_ERROR;
 						return ERR_PARSE_ERROR;
+					} else if (ch == '\r') {
+						continue;
 					} else if (ch == '"') {
 						break;
 					} else if (ch == '\\') {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/117561

Node: needs testing, it is possible I have not accounted for some special cases.