### PR TITLE
Add new signals to the AudioServer to know when the buses' effect stacks are modified

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -404,6 +404,32 @@
 				Emitted when the audio bus at [param bus_index] is renamed from [param old_name] to [param new_name].
 			</description>
 		</signal>
+		<signal name="effect_created">
+			<param index="0" name="bus_index" type="int" />
+			<param index="1" name="effect_index" type="int" />
+			<description>
+				Emitted after an audio effect has been created on the bus at [param bus_index], at index [param effect_index].
+				[b]Note:[/b] If an effect is moved to another index and/or bus, this signal is also emitted for its new position.
+			</description>
+		</signal>
+		<signal name="effect_moved">
+			<param index="0" name="old_bus_index" type="int" />
+			<param index="1" name="old_effect_index" type="int" />
+			<param index="2" name="new_bus_index" type="int" />
+			<param index="3" name="new_effect_index" type="int" />
+			<description>
+				Emitted when an audio effect is moved from the bus at [param old_bus_index], at index [param old_effect_index] to the bus at [param new_bus_index], at index [param new_effect_index].
+				[b]Note:[/b] Moving an effect also causes [signal effect_created] to be emitted on its source position and [signal effect_removed] to be emitted on its destination position.
+			</description>
+		</signal>
+		<signal name="effect_removed">
+			<param index="0" name="old_bus_index" type="int" />
+			<param index="1" name="old_effect_index" type="int" />
+			<description>
+				Emitted when the audio effect on the bus at [param old_bus_index], at index [param old_effect_index] is removed.
+				[b]Note:[/b] If an effect is moved to another index and/or bus, this signal is also emitted for its previous position.
+			</description>
+		</signal>
 	</signals>
 	<constants>
 		<constant name="SPEAKER_MODE_STEREO" value="0" enum="SpeakerMode">

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -746,12 +746,15 @@ void EditorAudioBus::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 			paste_at--;
 		}
 	}
+	ur->add_do_method(AudioServer::get_singleton(), "emit_signal", SNAME("effect_moved"), bus, effect, get_index(), paste_at);
+
 	if (!enabled) {
 		ur->add_do_method(AudioServer::get_singleton(), "set_bus_effect_enabled", get_index(), paste_at, false);
 	}
 
 	ur->add_undo_method(AudioServer::get_singleton(), "remove_bus_effect", get_index(), paste_at);
 	ur->add_undo_method(AudioServer::get_singleton(), "add_bus_effect", bus, AudioServer::get_singleton()->get_bus_effect(bus, effect), effect);
+	ur->add_undo_method(AudioServer::get_singleton(), "emit_signal", SNAME("effect_moved"), get_index(), paste_at, bus, effect);
 	if (!enabled) {
 		ur->add_undo_method(AudioServer::get_singleton(), "set_bus_effect_enabled", bus, effect, false);
 	}

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -1133,12 +1133,15 @@ void AudioServer::add_bus_effect(int p_bus, const Ref<AudioEffect> &p_effect, in
 #endif
 
 	if (p_at_pos >= buses[p_bus]->effects.size() || p_at_pos < 0) {
+		p_at_pos = buses[p_bus]->effects.size();
 		buses[p_bus]->effects.push_back(fx);
 	} else {
 		buses[p_bus]->effects.insert(p_at_pos, fx);
 	}
 
 	_update_bus_effects(p_bus);
+
+	emit_signal(SNAME("effect_created"), p_bus, p_at_pos);
 
 	unlock();
 }
@@ -1152,6 +1155,7 @@ void AudioServer::remove_bus_effect(int p_bus, int p_effect) {
 
 	buses[p_bus]->effects.remove_at(p_effect);
 	_update_bus_effects(p_bus);
+	emit_signal(SNAME("effect_removed"), p_bus, p_effect);
 
 	unlock();
 }
@@ -1187,6 +1191,15 @@ void AudioServer::swap_bus_effects(int p_bus, int p_effect, int p_by_effect) {
 	lock();
 	SWAP(buses.write[p_bus]->effects.write[p_effect], buses.write[p_bus]->effects.write[p_by_effect]);
 	_update_bus_effects(p_bus);
+
+	emit_signal(SNAME("effect_removed"), p_bus, p_effect);
+	emit_signal(SNAME("effect_created"), p_bus, p_by_effect);
+	emit_signal(SNAME("effect_moved"), p_bus, p_effect, p_bus, p_by_effect);
+
+	emit_signal(SNAME("effect_removed"), p_bus, p_by_effect);
+	emit_signal(SNAME("effect_created"), p_bus, p_effect);
+	emit_signal(SNAME("effect_moved"), p_bus, p_by_effect, p_bus, p_effect);
+
 	unlock();
 }
 
@@ -2123,6 +2136,10 @@ void AudioServer::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("bus_layout_changed"));
 	ADD_SIGNAL(MethodInfo("bus_renamed", PropertyInfo(Variant::INT, "bus_index"), PropertyInfo(Variant::STRING_NAME, "old_name"), PropertyInfo(Variant::STRING_NAME, "new_name")));
+
+	ADD_SIGNAL(MethodInfo("effect_created", PropertyInfo(Variant::INT, "bus_index"), PropertyInfo(Variant::INT, "effect_index")));
+	ADD_SIGNAL(MethodInfo("effect_moved", PropertyInfo(Variant::INT, "old_bus_index"), PropertyInfo(Variant::INT, "old_effect_index"), PropertyInfo(Variant::INT, "new_bus_index"), PropertyInfo(Variant::INT, "new_effect_index")));
+	ADD_SIGNAL(MethodInfo("effect_removed", PropertyInfo(Variant::INT, "old_bus_index"), PropertyInfo(Variant::INT, "old_effect_index")));
 
 	BIND_ENUM_CONSTANT(SPEAKER_MODE_STEREO);
 	BIND_ENUM_CONSTANT(SPEAKER_SURROUND_31);


### PR DESCRIPTION
Hello !

This is a small PR to adress [this proposal I created last week](https://github.com/godotengine/godot-proposals/issues/14414).
I added more details in the proposal but in short, I needed a way to know when audio effects are moved around or removed. I created three new signals and added them in the class reference:

- `effect_moved(old_bus_index: int, old_effect_index: int, new_bus_index: int, new_effect_index: int)`
- `effect_created(bus_index: int, effect_index: int)`
- `effect_removed(old_bus_index: int, old_effect_index: int)`

It's my first time contributing, hope I didn't make mistakes :)

This resolves godotengine/godot-proposals#14414 .

Have a nice day !