### PR TITLE
Rework TileSet editor proxy objects

### DIFF
--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -563,7 +563,17 @@ void TileSetAtlasSourceEditor::_update_tile_id_label() {
 
 void TileSetAtlasSourceEditor::_update_source_inspector() {
 	// Update the proxy object.
+	Object *edited = atlas_source_inspector->get_edited_object();
+	if (edited) {
+		Ref<TileSetAtlasSourceProxyObject> proxy(edited);
+		if (proxy.is_valid() && proxy->get_edited() == tile_set_atlas_source) {
+			return; // Already inspecting it.
+		}
+	}
+	atlas_source_proxy_object.instantiate();
+	atlas_source_proxy_object->connect(CoreStringName(changed), callable_mp(this, &TileSetAtlasSourceEditor::_atlas_source_proxy_object_changed).bind(atlas_source_proxy_object));
 	atlas_source_proxy_object->edit(tile_set, tile_set_atlas_source, tile_set_atlas_source_id);
+	atlas_source_inspector->edit(atlas_source_proxy_object.ptr());
 }
 
 void TileSetAtlasSourceEditor::_update_fix_selected_and_hovered_tiles() {
@@ -599,7 +609,10 @@ void TileSetAtlasSourceEditor::_update_tile_inspector() {
 	// Update visibility.
 	if (tools_button_group->get_pressed_button() == tool_select_button) {
 		if (!selection.is_empty()) {
+			tile_proxy_object.instantiate(this);
+			tile_proxy_object->connect(CoreStringName(changed), callable_mp(this, &TileSetAtlasSourceEditor::_tile_proxy_object_changed));
 			tile_proxy_object->edit(tile_set_atlas_source, selection);
+			tile_inspector->edit(tile_proxy_object.ptr());
 		}
 		tile_inspector->set_visible(!selection.is_empty());
 		tile_inspector_no_tile_selected_label->set_visible(selection.is_empty());
@@ -1491,9 +1504,6 @@ void TileSetAtlasSourceEditor::_end_dragging() {
 			Rect2i region = Rect2i(start_base_tiles_coords, new_base_tiles_coords - start_base_tiles_coords).abs();
 			region.size += Vector2i(1, 1);
 
-			undo_redo->create_action(TTR("Select tiles"));
-			undo_redo->add_undo_method(this, "_set_selection_from_array", _get_selection_as_array());
-
 			// Determine if we clear, then add or remove to the selection.
 			bool add_to_selection = true;
 			if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
@@ -1524,8 +1534,6 @@ void TileSetAtlasSourceEditor::_end_dragging() {
 			_update_tile_inspector();
 			_update_tile_id_label();
 			_update_current_tile_data_editor();
-			undo_redo->add_do_method(this, "_set_selection_from_array", _get_selection_as_array());
-			undo_redo->commit_action(false);
 		} break;
 		case DRAG_TYPE_MAY_POPUP_MENU: {
 			Vector2 mouse_local_pos = tile_atlas_control->get_local_mouse_position();
@@ -1537,12 +1545,8 @@ void TileSetAtlasSourceEditor::_end_dragging() {
 			// Set the selection if needed.
 			if (selection.size() <= 1) {
 				if (selected.tile != TileSetSource::INVALID_ATLAS_COORDS) {
-					undo_redo->create_action(TTR("Select tiles"));
-					undo_redo->add_undo_method(this, "_set_selection_from_array", _get_selection_as_array());
 					selection.clear();
 					selection.insert(selected);
-					undo_redo->add_do_method(this, "_set_selection_from_array", _get_selection_as_array());
-					undo_redo->commit_action(false);
 					_update_tile_inspector();
 					_update_tile_id_label();
 					_update_current_tile_data_editor();
@@ -2126,13 +2130,13 @@ void TileSetAtlasSourceEditor::_tile_proxy_object_changed(const String &p_what) 
 	_update_atlas_view();
 }
 
-void TileSetAtlasSourceEditor::_atlas_source_proxy_object_changed(const String &p_what) {
-	if (p_what == "texture" && !atlas_source_proxy_object->get("texture").is_null()) {
+void TileSetAtlasSourceEditor::_atlas_source_proxy_object_changed(const String &p_what, const Ref<TileSetAtlasSourceProxyObject> &p_object) {
+	if (p_what == "texture" && !p_object->get("texture").is_null()) {
 		atlases_to_auto_create_tiles.clear();
-		atlases_to_auto_create_tiles.append(tile_set_atlas_source);
+		atlases_to_auto_create_tiles.append(p_object->get_edited());
 		confirm_auto_create_tiles->popup_centered();
 	} else if (p_what == "id") {
-		emit_signal(SNAME("source_id_changed"), atlas_source_proxy_object->get_id());
+		emit_signal(SNAME("source_id_changed"), p_object->get_id());
 	}
 }
 
@@ -2427,7 +2431,6 @@ void TileSetAtlasSourceEditor::_auto_remove_tiles() {
 void TileSetAtlasSourceEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			atlas_source_inspector->edit(atlas_source_proxy_object);
 			atlas_source_inspector->add_custom_property_description("TileSetAtlasSourceProxyObject", "id", TTRC("The tile's unique identifier within this TileSet. Each tile stores its source ID, so changing one may make tiles invalid."));
 			atlas_source_inspector->add_custom_property_description("TileSetAtlasSourceProxyObject", "name", TTRC("The human-readable name for the atlas. Use a descriptive name here for organizational purposes (such as \"terrain\", \"decoration\", etc.)."));
 			atlas_source_inspector->add_custom_property_description("TileSetAtlasSourceProxyObject", "texture", TTRC("The image from which the tiles will be created."));
@@ -2436,7 +2439,6 @@ void TileSetAtlasSourceEditor::_notification(int p_what) {
 			atlas_source_inspector->add_custom_property_description("TileSetAtlasSourceProxyObject", "texture_region_size", TTRC("The size of each tile on the atlas in pixels. In most cases, this should match the tile size defined in the TileMap property (although this is not strictly necessary)."));
 			atlas_source_inspector->add_custom_property_description("TileSetAtlasSourceProxyObject", "use_texture_padding", TTRC("If checked, adds a 1-pixel transparent edge around each tile to prevent texture bleeding when filtering is enabled. It's recommended to leave this enabled unless you're running into rendering issues due to texture padding."));
 
-			tile_inspector->edit(tile_proxy_object);
 			tile_inspector->add_custom_property_description("AtlasTileProxyObject", "atlas_coords", TTRC("The position of the tile's top-left corner in the atlas. The position and size must be within the atlas and can't overlap another tile.\nEach painted tile has associated atlas coords, so changing this property may cause your TileMaps to not display properly."));
 			tile_inspector->add_custom_property_description("AtlasTileProxyObject", "size_in_atlas", TTRC("The unit size of the tile."));
 			tile_inspector->add_custom_property_description("AtlasTileProxyObject", "animation_columns", TTRC("Number of columns for the animation grid. If number of columns is lower than number of frames, the animation will automatically adjust row count."));
@@ -2575,9 +2577,6 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	toolbox->add_child(tool_paint_button);
 
 	// Tile inspector.
-	tile_proxy_object = memnew(AtlasTileProxyObject(this));
-	tile_proxy_object->connect(CoreStringName(changed), callable_mp(this, &TileSetAtlasSourceEditor::_tile_proxy_object_changed));
-
 	tile_inspector = memnew(EditorInspector);
 	tile_inspector->set_v_size_flags(SIZE_EXPAND_FILL);
 	tile_inspector->set_show_categories(false, true);
@@ -2632,9 +2631,6 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	tile_data_editors_vbox->add_child(tile_data_painting_editor_container);
 
 	// Atlas source inspector.
-	atlas_source_proxy_object = memnew(TileSetAtlasSourceProxyObject());
-	atlas_source_proxy_object->connect(CoreStringName(changed), callable_mp(this, &TileSetAtlasSourceEditor::_atlas_source_proxy_object_changed));
-
 	atlas_source_inspector = memnew(EditorInspector);
 	atlas_source_inspector->set_v_size_flags(SIZE_EXPAND_FILL);
 	atlas_source_inspector->set_show_categories(false, true);
@@ -2769,9 +2765,6 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 }
 
 TileSetAtlasSourceEditor::~TileSetAtlasSourceEditor() {
-	memdelete(tile_proxy_object);
-	memdelete(atlas_source_proxy_object);
-
 	// Remove listener for old objects, so the TileSet doesn't
 	// try to call the destroyed TileSetAtlasSourceEditor.
 	if (tile_set.is_valid()) {

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.h
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.h
@@ -59,8 +59,8 @@ public:
 	};
 
 	// -- Proxy object for an atlas source, needed by the inspector --
-	class TileSetAtlasSourceProxyObject : public Object {
-		GDCLASS(TileSetAtlasSourceProxyObject, Object);
+	class TileSetAtlasSourceProxyObject : public RefCounted {
+		GDCLASS(TileSetAtlasSourceProxyObject, RefCounted);
 
 	private:
 		Ref<TileSet> tile_set;
@@ -82,8 +82,8 @@ public:
 	};
 
 	// -- Proxy object for a tile, needed by the inspector --
-	class AtlasTileProxyObject : public Object {
-		GDCLASS(AtlasTileProxyObject, Object);
+	class AtlasTileProxyObject : public RefCounted {
+		GDCLASS(AtlasTileProxyObject, RefCounted);
 
 	private:
 		TileSetAtlasSourceEditor *tiles_set_atlas_source_editor = nullptr;
@@ -146,13 +146,13 @@ private:
 	void _tile_data_editors_tree_selected();
 
 	// -- Inspector --
-	AtlasTileProxyObject *tile_proxy_object = nullptr;
+	Ref<AtlasTileProxyObject> tile_proxy_object;
 	EditorInspector *tile_inspector = nullptr;
 	Label *tile_inspector_no_tile_selected_label = nullptr;
 	String selected_property;
 	void _inspector_property_selected(const String &p_property);
 
-	TileSetAtlasSourceProxyObject *atlas_source_proxy_object = nullptr;
+	Ref<TileSetAtlasSourceProxyObject> atlas_source_proxy_object;
 	EditorInspector *atlas_source_inspector = nullptr;
 
 	// -- Atlas view --
@@ -283,7 +283,7 @@ private:
 
 	void _tile_set_changed();
 	void _tile_proxy_object_changed(const String &p_what);
-	void _atlas_source_proxy_object_changed(const String &p_what);
+	void _atlas_source_proxy_object_changed(const String &p_what, const Ref<TileSetAtlasSourceProxyObject> &p_object);
 
 	void _undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, const String &p_property, const Variant &p_new_value);
 

--- a/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -213,9 +213,9 @@ void TileSetScenesCollectionSourceEditor::SceneTileProxyObject::_bind_methods() 
 	ADD_SIGNAL(MethodInfo("changed", PropertyInfo(Variant::STRING, "what")));
 }
 
-void TileSetScenesCollectionSourceEditor::_scenes_collection_source_proxy_object_changed(const String &p_what) {
+void TileSetScenesCollectionSourceEditor::_scenes_collection_source_proxy_object_changed(const String &p_what, const Ref<TileSetScenesCollectionProxyObject> &p_object) {
 	if (p_what == "id") {
-		emit_signal(SNAME("source_id_changed"), scenes_collection_source_proxy_object->get_id());
+		emit_signal(SNAME("source_id_changed"), p_object->get_id());
 	}
 }
 
@@ -279,7 +279,10 @@ void TileSetScenesCollectionSourceEditor::_source_delete_pressed() {
 
 void TileSetScenesCollectionSourceEditor::_update_source_inspector() {
 	// Update the proxy object.
+	scenes_collection_source_proxy_object.instantiate();
+	scenes_collection_source_proxy_object->connect(CoreStringName(changed), callable_mp(this, &TileSetScenesCollectionSourceEditor::_scenes_collection_source_proxy_object_changed).bind(scenes_collection_source_proxy_object));
 	scenes_collection_source_proxy_object->edit(tile_set, *tile_set_scenes_collection_source, tile_set_source_id);
+	scenes_collection_source_inspector->edit(scenes_collection_source_proxy_object.ptr());
 }
 
 void TileSetScenesCollectionSourceEditor::_update_tile_inspector() {
@@ -288,8 +291,12 @@ void TileSetScenesCollectionSourceEditor::_update_tile_inspector() {
 
 	// Update the proxy object.
 	if (has_atlas_tile_selected) {
+		tile_proxy_object.instantiate(this);
+		tile_proxy_object->connect(CoreStringName(changed), callable_mp(this, &TileSetScenesCollectionSourceEditor::_update_scenes_list).unbind(1));
+		tile_proxy_object->connect(CoreStringName(changed), callable_mp(this, &TileSetScenesCollectionSourceEditor::_update_action_buttons).unbind(1));
 		int scene_id = scene_tiles_list->get_item_metadata(selected_indices[0]);
 		tile_proxy_object->edit(*tile_set_scenes_collection_source, scene_id);
+		tile_inspector->edit(tile_proxy_object.ptr());
 	}
 
 	// Update visibility.
@@ -358,11 +365,9 @@ void TileSetScenesCollectionSourceEditor::_update_scenes_list() {
 void TileSetScenesCollectionSourceEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			scenes_collection_source_inspector->edit(scenes_collection_source_proxy_object);
 			scenes_collection_source_inspector->add_custom_property_description("TileSetScenesCollectionProxyObject", "id", TTRC("The tile's unique identifier within this TileSet. Each tile stores its source ID, so changing one may make tiles invalid."));
 			scenes_collection_source_inspector->add_custom_property_description("TileSetScenesCollectionProxyObject", "name", TTRC("The human-readable name for the scene collection. Use a descriptive name here for organizational purposes (such as \"obstacles\", \"decoration\", etc.)."));
 
-			tile_inspector->edit(tile_proxy_object);
 			tile_inspector->add_custom_property_description("SceneTileProxyObject", "id", TTRC("ID of the scene tile in the collection. Each painted tile has associated ID, so changing this property may cause your TileMaps to not display properly."));
 			tile_inspector->add_custom_property_description("SceneTileProxyObject", "scene", TTRC("Absolute path to the scene associated with this tile."));
 			tile_inspector->add_custom_property_description("SceneTileProxyObject", "display_placeholder", TTRC("If [code]true[/code], a placeholder marker will be displayed on top of the scene's preview. The marker is displayed anyway if the scene has no valid preview."));
@@ -533,9 +538,6 @@ TileSetScenesCollectionSourceEditor::TileSetScenesCollectionSourceEditor() {
 	scenes_collection_source_inspector_label->set_text(TTRC("Scenes collection properties:"));
 	middle_vbox_container->add_child(scenes_collection_source_inspector_label);
 
-	scenes_collection_source_proxy_object = memnew(TileSetScenesCollectionProxyObject());
-	scenes_collection_source_proxy_object->connect(CoreStringName(changed), callable_mp(this, &TileSetScenesCollectionSourceEditor::_scenes_collection_source_proxy_object_changed));
-
 	scenes_collection_source_inspector = memnew(EditorInspector);
 	scenes_collection_source_inspector->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	scenes_collection_source_inspector->set_use_doc_hints(true);
@@ -546,10 +548,6 @@ TileSetScenesCollectionSourceEditor::TileSetScenesCollectionSourceEditor() {
 	tile_inspector_label->set_text(TTRC("Tile properties:"));
 	tile_inspector_label->hide();
 	middle_vbox_container->add_child(tile_inspector_label);
-
-	tile_proxy_object = memnew(SceneTileProxyObject(this));
-	tile_proxy_object->connect(CoreStringName(changed), callable_mp(this, &TileSetScenesCollectionSourceEditor::_update_scenes_list).unbind(1));
-	tile_proxy_object->connect(CoreStringName(changed), callable_mp(this, &TileSetScenesCollectionSourceEditor::_update_action_buttons).unbind(1));
 
 	tile_inspector = memnew(EditorInspector);
 	tile_inspector->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
@@ -590,9 +588,4 @@ TileSetScenesCollectionSourceEditor::TileSetScenesCollectionSourceEditor() {
 	scenes_bottom_actions->add_child(scene_tile_delete_button);
 
 	EditorInspector::add_inspector_plugin(memnew(TileSourceInspectorPlugin));
-}
-
-TileSetScenesCollectionSourceEditor::~TileSetScenesCollectionSourceEditor() {
-	memdelete(scenes_collection_source_proxy_object);
-	memdelete(tile_proxy_object);
 }

--- a/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.h
+++ b/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.h
@@ -44,8 +44,8 @@ class TileSetScenesCollectionSourceEditor : public HBoxContainer {
 
 private:
 	// -- Proxy object for an atlas source, needed by the inspector --
-	class TileSetScenesCollectionProxyObject : public Object {
-		GDCLASS(TileSetScenesCollectionProxyObject, Object);
+	class TileSetScenesCollectionProxyObject : public RefCounted {
+		GDCLASS(TileSetScenesCollectionProxyObject, RefCounted);
 
 	private:
 		Ref<TileSet> tile_set;
@@ -66,8 +66,8 @@ private:
 	};
 
 	// -- Proxy object for a tile, needed by the inspector --
-	class SceneTileProxyObject : public Object {
-		GDCLASS(SceneTileProxyObject, Object);
+	class SceneTileProxyObject : public RefCounted {
+		GDCLASS(SceneTileProxyObject, RefCounted);
 
 	private:
 		TileSetScenesCollectionSourceEditor *tile_set_scenes_collection_source_editor = nullptr;
@@ -102,12 +102,12 @@ private:
 	bool tile_set_scenes_collection_source_changed_needs_update = false;
 
 	// Source inspector.
-	TileSetScenesCollectionProxyObject *scenes_collection_source_proxy_object = nullptr;
+	Ref<TileSetScenesCollectionProxyObject> scenes_collection_source_proxy_object;
 	Label *scenes_collection_source_inspector_label = nullptr;
 	EditorInspector *scenes_collection_source_inspector = nullptr;
 
 	// Tile inspector.
-	SceneTileProxyObject *tile_proxy_object = nullptr;
+	Ref<SceneTileProxyObject> tile_proxy_object;
 	Label *tile_inspector_label = nullptr;
 	EditorInspector *tile_inspector = nullptr;
 
@@ -117,7 +117,7 @@ private:
 	EditorFileDialog *scene_select_dialog = nullptr;
 
 	void _tile_set_scenes_collection_source_changed();
-	void _scenes_collection_source_proxy_object_changed(const String &p_what);
+	void _scenes_collection_source_proxy_object_changed(const String &p_what, const Ref<TileSetScenesCollectionProxyObject> &p_object);
 	void _scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_idx);
 	void _scenes_list_item_activated(int p_index);
 
@@ -142,5 +142,4 @@ protected:
 public:
 	void edit(Ref<TileSet> p_tile_set, TileSetScenesCollectionSource *p_tile_set_scenes_collection_source, int p_source_id);
 	TileSetScenesCollectionSourceEditor();
-	~TileSetScenesCollectionSourceEditor();
 };


### PR DESCRIPTION
Fixes #117406

This changes proxy objects used in TileSet editor from singular Object to RefCounted. Every time something is edited, a new proxy object is created specifically for this item, so undo actions are created properly for this specific item. The lifetime of proxy objects is managed by UndoRedo, so this shouldn't cause memory problems.