### PR TITLE
Add animation start and duration to import dialog

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1374,6 +1374,7 @@ Node *ResourceImporterScene::_post_fix_animations(Node *p_node, Node *p_root, co
 					}
 				}
 
+				anim->set_length((double)anim_settings["settings/length"]);
 				anim->set_loop_mode(static_cast<Animation::LoopMode>((int)anim_settings["settings/loop_mode"]));
 				bool save = anim_settings["save_to_file/enabled"];
 				String path = anim_settings["save_to_file/path"];
@@ -2278,6 +2279,7 @@ void ResourceImporterScene::get_internal_import_options(InternalImportCategory p
 			r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "use_external/fallback_path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), ""));
 		} break;
 		case INTERNAL_IMPORT_CATEGORY_ANIMATION: {
+			r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "settings/length", PROPERTY_HINT_RANGE, ""), 0));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "settings/loop_mode", PROPERTY_HINT_ENUM, "None,Linear,Pingpong"), 0));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "save_to_file/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "save_to_file/path", PROPERTY_HINT_SAVE_FILE, "*.res,*.anim,*.tres"), ""));

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1374,7 +1374,6 @@ Node *ResourceImporterScene::_post_fix_animations(Node *p_node, Node *p_root, co
 					}
 				}
 
-				anim->set_length((double)anim_settings["settings/length"]);
 				anim->set_loop_mode(static_cast<Animation::LoopMode>((int)anim_settings["settings/loop_mode"]));
 				bool save = anim_settings["save_to_file/enabled"];
 				String path = anim_settings["save_to_file/path"];
@@ -2279,7 +2278,6 @@ void ResourceImporterScene::get_internal_import_options(InternalImportCategory p
 			r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "use_external/fallback_path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), ""));
 		} break;
 		case INTERNAL_IMPORT_CATEGORY_ANIMATION: {
-			r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "settings/length", PROPERTY_HINT_RANGE, ""), 0));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "settings/loop_mode", PROPERTY_HINT_ENUM, "None,Linear,Pingpong"), 0));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "save_to_file/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "save_to_file/path", PROPERTY_HINT_SAVE_FILE, "*.res,*.anim,*.tres"), ""));

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -60,8 +60,7 @@ class SceneImportSettingsData : public Object {
 	HashMap<StringName, Variant> defaults;
 	List<ResourceImporter::ImportOption> options;
 	Vector<String> animation_list;
-
-	float animation_length = 0.0f;
+	Ref<Animation> animation;
 
 	bool hide_options = false;
 	String path;
@@ -100,12 +99,13 @@ class SceneImportSettingsData : public Object {
 	}
 
 	bool _get(const StringName &p_name, Variant &r_ret) const {
-        // Expose a read-only "Properties/Animation Duration" value stored on this data object.
 		if (String(p_name) == "properties/animation_length") {
-			r_ret = animation_length;
-			return true;
+			if (animation.is_valid()) {
+				r_ret = animation->get_length();
+				return true;
+			}
+			return false;
 		}
-
 		if (settings) {
 			if (settings->has(p_name)) {
 				r_ret = (*settings)[p_name];
@@ -933,13 +933,7 @@ void SceneImportSettingsDialog::_select(Tree *p_from, const String &p_type, cons
         scene_import_settings_data->settings = &ad.settings;
 		scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION;
 		scene_import_settings_data->hide_options = hide_anim_and_skel_options;
-
-		// Store animation duration for the inspector read-only property.
-		if (ad.animation.is_valid()) {
-			scene_import_settings_data->animation_length = ad.animation->get_length();
-		} else {
-			scene_import_settings_data->animation_length = 0.0f;
-		}
+		scene_import_settings_data->animation = ad.animation;
 
 		_animation_update_skeleton_visibility();
 	} else if (p_type == "Mesh") {
@@ -1193,11 +1187,7 @@ void SceneImportSettingsDialog::_animation_finished(const StringName &p_name) {
 }
 
 void SceneImportSettingsDialog::_animation_update_skeleton_visibility() {
-	if (animation_toggle_skeleton_visibility->is_pressed()) {
-		bones_mesh_preview->show();
-	} else {
-		bones_mesh_preview->hide();
-	}
+	bones_mesh_preview->set_visible(animation_toggle_skeleton_visibility->is_pressed());
 }
 
 void SceneImportSettingsDialog::_material_tree_selected() {

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -930,7 +930,7 @@ void SceneImportSettingsDialog::_select(Tree *p_from, const String &p_type, cons
 		mesh_tree->deselect_all();
 		AnimationData &ad = animation_map[p_id];
 
-        scene_import_settings_data->settings = &ad.settings;
+		scene_import_settings_data->settings = &ad.settings;
 		scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION;
 		scene_import_settings_data->hide_options = hide_anim_and_skel_options;
 		scene_import_settings_data->animation = ad.animation;

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1091,6 +1091,9 @@ void SceneImportSettingsDialog::_stop_current_animation() {
 }
 
 void SceneImportSettingsDialog::_reset_animation(const String &p_animation_name) {
+	animation_start_label->hide();
+	animation_length_label->hide();
+
 	if (p_animation_name.is_empty()) {
 		animation_preview->hide();
 
@@ -1109,9 +1112,15 @@ void SceneImportSettingsDialog::_reset_animation(const String &p_animation_name)
 		animation_pingpong = false;
 
 		if (animation_map.has(p_animation_name)) {
-			HashMap<StringName, Variant> settings(animation_map[p_animation_name].settings);
+			const AnimationData &animation_data = animation_map[p_animation_name];
+			HashMap<StringName, Variant> settings(animation_data.settings);
 			if (settings.has("settings/loop_mode")) {
 				animation_loop_mode = static_cast<Animation::LoopMode>((int)settings["settings/loop_mode"]);
+			}
+			if (animation_data.animation.is_valid()) {
+				animation_start_label->show();
+				animation_length_label->show();
+				animation_length_label->set_text(vformat("%.2f", animation_data.animation->get_length()));
 			}
 		}
 
@@ -1782,6 +1791,9 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	animation_stop_button->set_tooltip_text(TTR("Selected Animation Stop"));
 	animation_stop_button->connect(SceneStringName(pressed), callable_mp(this, &SceneImportSettingsDialog::_stop_current_animation));
 
+	animation_start_label = memnew(Label("0.00"));
+	animation_hbox->add_child(animation_start_label);
+
 	animation_slider = memnew(HSlider);
 	animation_hbox->add_child(animation_slider);
 	animation_slider->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -1792,6 +1804,12 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	animation_slider->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	animation_slider->set_accessibility_name(TTRC("Animation"));
 	animation_slider->connect(SceneStringName(value_changed), callable_mp(this, &SceneImportSettingsDialog::_animation_slider_value_changed));
+
+	animation_length_label = memnew(Label());
+	animation_length_label->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	animation_length_label->set_mouse_filter(Control::MOUSE_FILTER_STOP);
+	animation_length_label->set_tooltip_text(TTR("Animation length (seconds)"));
+	animation_hbox->add_child(animation_length_label);
 
 	animation_toggle_skeleton_visibility = memnew(Button);
 	animation_hbox->add_child(animation_toggle_skeleton_visibility);

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -61,6 +61,8 @@ class SceneImportSettingsData : public Object {
 	List<ResourceImporter::ImportOption> options;
 	Vector<String> animation_list;
 
+	float animation_length = 0.0f;
+
 	bool hide_options = false;
 	String path;
 
@@ -98,6 +100,12 @@ class SceneImportSettingsData : public Object {
 	}
 
 	bool _get(const StringName &p_name, Variant &r_ret) const {
+        // Expose a read-only "Properties/Animation Duration" value stored on this data object.
+		if (String(p_name) == "properties/animation_length") {
+			r_ret = animation_length;
+			return true;
+		}
+
 		if (settings) {
 			if (settings->has(p_name)) {
 				r_ret = (*settings)[p_name];
@@ -353,12 +361,6 @@ void SceneImportSettingsDialog::_fill_animation(Tree *p_tree, const Ref<Animatio
 		ad.animation = p_anim;
 
 		_load_default_subresource_settings(ad.settings, "animations", p_name, ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION);
-
-		double anim_length = p_anim->get_length();
-		if (!ad.settings.has("settings/length") && anim_length != 0.0) {
-			ad.settings["settings/length"] = anim_length;
-		}
-
 		Animation::LoopMode loop_mode = p_anim->get_loop_mode();
 		if (!ad.settings.has("settings/loop_mode") && loop_mode != Animation::LoopMode::LOOP_NONE) {
 			// Update the loop mode to match detected mode (from import hints).
@@ -932,6 +934,13 @@ void SceneImportSettingsDialog::_select(Tree *p_from, const String &p_type, cons
 		scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION;
 		scene_import_settings_data->hide_options = hide_anim_and_skel_options;
 
+		// Store animation duration for the inspector read-only property.
+		if (ad.animation.is_valid()) {
+			scene_import_settings_data->animation_length = ad.animation->get_length();
+		} else {
+			scene_import_settings_data->animation_length = 0.0f;
+		}
+
 		_animation_update_skeleton_visibility();
 	} else if (p_type == "Mesh") {
 		node_selected->hide();
@@ -1031,17 +1040,6 @@ void SceneImportSettingsDialog::_select(Tree *p_from, const String &p_type, cons
 }
 
 void SceneImportSettingsDialog::_inspector_property_edited(const String &p_name) {
-	if (p_name == "settings/length") {
-		if (!animation_map.has(selected_id)) {
-			return;
-		}
-		HashMap<StringName, Variant> settings(animation_map[selected_id].settings);
-		if (settings.has(p_name)) {
-			animation_length = (double)settings[p_name];
-		} else {
-			animation_length = 0.0;
-		}
-	}
 	if (p_name == "settings/loop_mode") {
 		if (!animation_map.has(selected_id)) {
 			return;
@@ -1132,9 +1130,6 @@ void SceneImportSettingsDialog::_reset_animation(const String &p_animation_name)
 		if (animation_map.has(p_animation_name)) {
 			const AnimationData &animation_data = animation_map[p_animation_name];
 			HashMap<StringName, Variant> settings(animation_data.settings);
-			if (settings.has("settings/length")) {
-				animation_length = (double)settings["settings/length"];
-			}
 			if (settings.has("settings/loop_mode")) {
 				animation_loop_mode = static_cast<Animation::LoopMode>((int)settings["settings/loop_mode"]);
 			}

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -61,6 +61,8 @@ class SceneImportSettingsData : public Object {
 	List<ResourceImporter::ImportOption> options;
 	Vector<String> animation_list;
 
+	float animation_length = 0.0f;
+
 	bool hide_options = false;
 	String path;
 
@@ -98,6 +100,12 @@ class SceneImportSettingsData : public Object {
 	}
 
 	bool _get(const StringName &p_name, Variant &r_ret) const {
+        // Expose a read-only "Properties/Animation Duration" value stored on this data object.
+		if (String(p_name) == "properties/animation_length") {
+			r_ret = animation_length;
+			return true;
+		}
+
 		if (settings) {
 			if (settings->has(p_name)) {
 				r_ret = (*settings)[p_name];
@@ -167,6 +175,10 @@ class SceneImportSettingsData : public Object {
 			return;
 		}
 		Ref<ResourceImporterScene> resource_importer_scene = SceneImportSettingsDialog::get_singleton()->get_resource_importer_scene();
+		if (category == ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION) {
+			PropertyInfo duration_prop(Variant::FLOAT, "properties/animation_length", PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY);
+			r_list->push_back(duration_prop);
+		}
 		for (const ResourceImporter::ImportOption &E : options) {
 			PropertyInfo option = E.option;
 			if (category == ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_MAX) {
@@ -918,9 +930,16 @@ void SceneImportSettingsDialog::_select(Tree *p_from, const String &p_type, cons
 		mesh_tree->deselect_all();
 		AnimationData &ad = animation_map[p_id];
 
-		scene_import_settings_data->settings = &ad.settings;
+        scene_import_settings_data->settings = &ad.settings;
 		scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION;
 		scene_import_settings_data->hide_options = hide_anim_and_skel_options;
+
+		// Store animation duration for the inspector read-only property.
+		if (ad.animation.is_valid()) {
+			scene_import_settings_data->animation_length = ad.animation->get_length();
+		} else {
+			scene_import_settings_data->animation_length = 0.0f;
+		}
 
 		_animation_update_skeleton_visibility();
 	} else if (p_type == "Mesh") {
@@ -1091,9 +1110,6 @@ void SceneImportSettingsDialog::_stop_current_animation() {
 }
 
 void SceneImportSettingsDialog::_reset_animation(const String &p_animation_name) {
-	animation_start_label->hide();
-	animation_length_label->hide();
-
 	if (p_animation_name.is_empty()) {
 		animation_preview->hide();
 
@@ -1116,11 +1132,6 @@ void SceneImportSettingsDialog::_reset_animation(const String &p_animation_name)
 			HashMap<StringName, Variant> settings(animation_data.settings);
 			if (settings.has("settings/loop_mode")) {
 				animation_loop_mode = static_cast<Animation::LoopMode>((int)settings["settings/loop_mode"]);
-			}
-			if (animation_data.animation.is_valid()) {
-				animation_start_label->show();
-				animation_length_label->show();
-				animation_length_label->set_text(vformat("%.2f", animation_data.animation->get_length()));
 			}
 		}
 
@@ -1791,9 +1802,6 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	animation_stop_button->set_tooltip_text(TTR("Selected Animation Stop"));
 	animation_stop_button->connect(SceneStringName(pressed), callable_mp(this, &SceneImportSettingsDialog::_stop_current_animation));
 
-	animation_start_label = memnew(Label("0.00"));
-	animation_hbox->add_child(animation_start_label);
-
 	animation_slider = memnew(HSlider);
 	animation_hbox->add_child(animation_slider);
 	animation_slider->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -1804,12 +1812,6 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	animation_slider->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	animation_slider->set_accessibility_name(TTRC("Animation"));
 	animation_slider->connect(SceneStringName(value_changed), callable_mp(this, &SceneImportSettingsDialog::_animation_slider_value_changed));
-
-	animation_length_label = memnew(Label());
-	animation_length_label->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
-	animation_length_label->set_mouse_filter(Control::MOUSE_FILTER_STOP);
-	animation_length_label->set_tooltip_text(TTR("Animation length (seconds)"));
-	animation_hbox->add_child(animation_length_label);
 
 	animation_toggle_skeleton_visibility = memnew(Button);
 	animation_hbox->add_child(animation_toggle_skeleton_visibility);

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -61,8 +61,6 @@ class SceneImportSettingsData : public Object {
 	List<ResourceImporter::ImportOption> options;
 	Vector<String> animation_list;
 
-	float animation_length = 0.0f;
-
 	bool hide_options = false;
 	String path;
 
@@ -100,12 +98,6 @@ class SceneImportSettingsData : public Object {
 	}
 
 	bool _get(const StringName &p_name, Variant &r_ret) const {
-        // Expose a read-only "Properties/Animation Duration" value stored on this data object.
-		if (String(p_name) == "properties/animation_length") {
-			r_ret = animation_length;
-			return true;
-		}
-
 		if (settings) {
 			if (settings->has(p_name)) {
 				r_ret = (*settings)[p_name];
@@ -361,6 +353,12 @@ void SceneImportSettingsDialog::_fill_animation(Tree *p_tree, const Ref<Animatio
 		ad.animation = p_anim;
 
 		_load_default_subresource_settings(ad.settings, "animations", p_name, ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION);
+
+		double anim_length = p_anim->get_length();
+		if (!ad.settings.has("settings/length") && anim_length != 0.0) {
+			ad.settings["settings/length"] = anim_length;
+		}
+
 		Animation::LoopMode loop_mode = p_anim->get_loop_mode();
 		if (!ad.settings.has("settings/loop_mode") && loop_mode != Animation::LoopMode::LOOP_NONE) {
 			// Update the loop mode to match detected mode (from import hints).
@@ -934,13 +932,6 @@ void SceneImportSettingsDialog::_select(Tree *p_from, const String &p_type, cons
 		scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION;
 		scene_import_settings_data->hide_options = hide_anim_and_skel_options;
 
-		// Store animation duration for the inspector read-only property.
-		if (ad.animation.is_valid()) {
-			scene_import_settings_data->animation_length = ad.animation->get_length();
-		} else {
-			scene_import_settings_data->animation_length = 0.0f;
-		}
-
 		_animation_update_skeleton_visibility();
 	} else if (p_type == "Mesh") {
 		node_selected->hide();
@@ -1040,6 +1031,17 @@ void SceneImportSettingsDialog::_select(Tree *p_from, const String &p_type, cons
 }
 
 void SceneImportSettingsDialog::_inspector_property_edited(const String &p_name) {
+	if (p_name == "settings/length") {
+		if (!animation_map.has(selected_id)) {
+			return;
+		}
+		HashMap<StringName, Variant> settings(animation_map[selected_id].settings);
+		if (settings.has(p_name)) {
+			animation_length = (double)settings[p_name];
+		} else {
+			animation_length = 0.0;
+		}
+	}
 	if (p_name == "settings/loop_mode") {
 		if (!animation_map.has(selected_id)) {
 			return;
@@ -1130,6 +1132,9 @@ void SceneImportSettingsDialog::_reset_animation(const String &p_animation_name)
 		if (animation_map.has(p_animation_name)) {
 			const AnimationData &animation_data = animation_map[p_animation_name];
 			HashMap<StringName, Variant> settings(animation_data.settings);
+			if (settings.has("settings/length")) {
+				animation_length = (double)settings["settings/length"];
+			}
 			if (settings.has("settings/loop_mode")) {
 				animation_loop_mode = static_cast<Animation::LoopMode>((int)settings["settings/loop_mode"]);
 			}

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1174,10 +1174,8 @@ void SceneImportSettingsDialog::_animation_frame_spin_box_value_changed(double p
 		return;
 	}
 
-	const double animation_length = animation_map[selected_id].animation->get_length();
-	int frames = (int)Math::round(animation_length * animation_fps);
-	double position = CLAMP(p_value / frames, 0.0, 1.0);
-	animation_slider->set_value(position);
+	int frames = (int)Math::round(animation_map[selected_id].animation->get_length() * animation_fps);
+	animation_slider->set_value(CLAMP(p_value / frames, 0.0, 1.0));
 }
 
 void SceneImportSettingsDialog::_animation_slider_value_changed(double p_value) {

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -810,6 +810,10 @@ void SceneImportSettingsDialog::open_settings(const String &p_path, const String
 		}
 	}
 
+	if (defaults.has(SNAME("animation/fps"))) {
+		animation_fps = (float)defaults[SNAME("animation/fps")];
+	}
+
 	// Regardless of p_scene_import_type, use PackedScene for pre_import because we want to see the full thing.
 	_resource_importer_scene->set_scene_import_type("PackedScene");
 	scene = _resource_importer_scene->pre_import(p_path, defaults);
@@ -1045,6 +1049,11 @@ void SceneImportSettingsDialog::_inspector_property_edited(const String &p_name)
 			animation_loop_mode = Animation::LoopMode::LOOP_NONE;
 		}
 	}
+	if (p_name == "animation/fps") {
+		if (scene_import_settings_data->current.has("animation/fps")) {
+			animation_fps = (float)scene_import_settings_data->current["animation/fps"];
+		}
+	}
 	if ((p_name == "use_external/enabled") || (p_name == "use_external/path") || (p_name == "use_external/fallback_path")) {
 		MaterialData &material_data = material_map[selected_id];
 		String spath = base_path.get_base_dir();
@@ -1100,6 +1109,7 @@ void SceneImportSettingsDialog::_stop_current_animation() {
 	animation_player->stop();
 	animation_play_button->set_button_icon(get_editor_theme_icon(SNAME("MainPlay")));
 	animation_slider->set_value_no_signal(0.0);
+	animation_frame_spin_box->set_value_no_signal(0);
 	set_process(false);
 }
 
@@ -1137,9 +1147,20 @@ void SceneImportSettingsDialog::_reset_animation(const String &p_animation_name)
 			animation_player->set_assigned_animation(p_animation_name);
 			animation_player->seek(0.0, true);
 			animation_slider->set_value_no_signal(0.0);
+			animation_frame_spin_box->set_value_no_signal(0);
 			set_process(false);
 		}
 	}
+}
+
+void SceneImportSettingsDialog::_animation_frame_spin_box_value_changed(double p_value) {
+	if (animation_player == nullptr || !animation_map.has(selected_id) || animation_map[selected_id].animation.is_null()) {
+		return;
+	}
+
+	const double animation_length = animation_map[selected_id].animation->get_length();
+	double position = p_value / (animation_fps * animation_length);
+	animation_slider->set_value(position);
 }
 
 void SceneImportSettingsDialog::_animation_slider_value_changed(double p_value) {
@@ -1151,7 +1172,12 @@ void SceneImportSettingsDialog::_animation_slider_value_changed(double p_value) 
 		animation_play_button->set_button_icon(get_editor_theme_icon(SNAME("MainPlay")));
 		set_process(false);
 	}
-	animation_player->seek(p_value * animation_map[selected_id].animation->get_length(), true);
+	const double animation_length = animation_map[selected_id].animation->get_length();
+	animation_player->seek(p_value * animation_length, true);
+
+	int frame = CLAMP((int)(animation_length * p_value * animation_fps), 0, (int)(animation_length * animation_fps));	
+	print_line(vformat("Animation length: %f, p_value: %f, frame: %d", animation_length, p_value, frame));
+	animation_frame_spin_box->set_value_no_signal(frame);
 }
 
 void SceneImportSettingsDialog::_skeleton_tree_entered(Skeleton3D *p_skeleton) {
@@ -1168,6 +1194,7 @@ void SceneImportSettingsDialog::_animation_finished(const StringName &p_name) {
 		case Animation::LOOP_NONE: {
 			animation_play_button->set_button_icon(get_editor_theme_icon(SNAME("MainPlay")));
 			animation_slider->set_value_no_signal(1.0);
+			animation_frame_spin_box->set_value_no_signal(animation_map[selected_id].animation->get_length() * 30.0);
 			set_process(false);
 		} break;
 		case Animation::LOOP_LINEAR: {
@@ -1791,6 +1818,11 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	animation_stop_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	animation_stop_button->set_tooltip_text(TTR("Selected Animation Stop"));
 	animation_stop_button->connect(SceneStringName(pressed), callable_mp(this, &SceneImportSettingsDialog::_stop_current_animation));
+
+	animation_frame_spin_box = memnew(SpinBox);
+	animation_hbox->add_child(animation_frame_spin_box);
+	animation_frame_spin_box->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	animation_frame_spin_box->connect(SceneStringName(value_changed), callable_mp(this, &SceneImportSettingsDialog::_animation_frame_spin_box_value_changed));
 
 	animation_slider = memnew(HSlider);
 	animation_hbox->add_child(animation_slider);

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -61,6 +61,7 @@ class SceneImportSettingsData : public Object {
 	List<ResourceImporter::ImportOption> options;
 	Vector<String> animation_list;
 	Ref<Animation> animation;
+	float animation_fps = 30.0;
 
 	bool hide_options = false;
 	String path;
@@ -102,6 +103,13 @@ class SceneImportSettingsData : public Object {
 		if (String(p_name) == "properties/animation_length") {
 			if (animation.is_valid()) {
 				r_ret = animation->get_length();
+				return true;
+			}
+			return false;
+		}
+		if (String(p_name) == "properties/animation_frames") {
+			if (animation.is_valid()) {
+				r_ret = (int)Math::round(animation->get_length() * animation_fps);
 				return true;
 			}
 			return false;
@@ -176,8 +184,10 @@ class SceneImportSettingsData : public Object {
 		}
 		Ref<ResourceImporterScene> resource_importer_scene = SceneImportSettingsDialog::get_singleton()->get_resource_importer_scene();
 		if (category == ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION) {
-			PropertyInfo duration_prop(Variant::FLOAT, "properties/animation_length", PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY);
-			r_list->push_back(duration_prop);
+			PropertyInfo animation_length_prop(Variant::FLOAT, "properties/animation_length", PROPERTY_HINT_NONE, "suffix:s", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY);
+			r_list->push_back(animation_length_prop);
+			PropertyInfo animation_frames_prop(Variant::INT, "properties/animation_frames", PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY);
+			r_list->push_back(animation_frames_prop);
 		}
 		for (const ResourceImporter::ImportOption &E : options) {
 			PropertyInfo option = E.option;
@@ -811,7 +821,7 @@ void SceneImportSettingsDialog::open_settings(const String &p_path, const String
 	}
 
 	if (defaults.has(SNAME("animation/fps"))) {
-		animation_fps = (float)defaults[SNAME("animation/fps")];
+		animation_fps = defaults[SNAME("animation/fps")];
 	}
 
 	// Regardless of p_scene_import_type, use PackedScene for pre_import because we want to see the full thing.
@@ -938,6 +948,7 @@ void SceneImportSettingsDialog::_select(Tree *p_from, const String &p_type, cons
 		scene_import_settings_data->category = ResourceImporterScene::INTERNAL_IMPORT_CATEGORY_ANIMATION;
 		scene_import_settings_data->hide_options = hide_anim_and_skel_options;
 		scene_import_settings_data->animation = ad.animation;
+		scene_import_settings_data->animation_fps = animation_fps;
 
 		_animation_update_skeleton_visibility();
 	} else if (p_type == "Mesh") {
@@ -1051,7 +1062,7 @@ void SceneImportSettingsDialog::_inspector_property_edited(const String &p_name)
 	}
 	if (p_name == "animation/fps") {
 		if (scene_import_settings_data->current.has("animation/fps")) {
-			animation_fps = (float)scene_import_settings_data->current["animation/fps"];
+			animation_fps = scene_import_settings_data->current["animation/fps"];
 		}
 	}
 	if ((p_name == "use_external/enabled") || (p_name == "use_external/path") || (p_name == "use_external/fallback_path")) {
@@ -1164,7 +1175,8 @@ void SceneImportSettingsDialog::_animation_frame_spin_box_value_changed(double p
 	}
 
 	const double animation_length = animation_map[selected_id].animation->get_length();
-	double position = p_value / (animation_fps * animation_length);
+	int frames = (int)Math::round(animation_length * animation_fps);
+	double position = CLAMP(p_value / frames, 0.0, 1.0);
 	animation_slider->set_value(position);
 }
 
@@ -1180,8 +1192,8 @@ void SceneImportSettingsDialog::_animation_slider_value_changed(double p_value) 
 	const double animation_length = animation_map[selected_id].animation->get_length();
 	animation_player->seek(p_value * animation_length, true);
 
-	int frame = CLAMP((int)(animation_length * p_value * animation_fps), 0, (int)(animation_length * animation_fps));	
-	print_line(vformat("Animation length: %f, p_value: %f, frame: %d", animation_length, p_value, frame));
+	int frames = (int)Math::round(animation_length * animation_fps);
+	int frame = CLAMP((int)Math::round(p_value * frames), 0, frames);
 	animation_frame_spin_box->set_value_no_signal(frame);
 }
 

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1137,6 +1137,11 @@ void SceneImportSettingsDialog::_reset_animation(const String &p_animation_name)
 			if (settings.has("settings/loop_mode")) {
 				animation_loop_mode = static_cast<Animation::LoopMode>((int)settings["settings/loop_mode"]);
 			}
+
+			if (animation_data.animation.is_valid()) {
+				int max_frames = (int)Math::round(animation_data.animation->get_length() * animation_fps);
+				animation_frame_spin_box->set_max(max_frames);
+			}
 		}
 
 		if (animation_player->is_playing() && animation_loop_mode != Animation::LoopMode::LOOP_NONE) {
@@ -1432,6 +1437,7 @@ void SceneImportSettingsDialog::_notification(int p_what) {
 		case NOTIFICATION_PROCESS: {
 			if (animation_player != nullptr) {
 				animation_slider->set_value_no_signal(animation_player->get_current_animation_position() / animation_player->get_current_animation_length());
+				animation_frame_spin_box->set_value_no_signal(animation_player->get_current_animation_position() * animation_fps);
 			}
 		} break;
 

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1209,7 +1209,7 @@ void SceneImportSettingsDialog::_animation_finished(const StringName &p_name) {
 		case Animation::LOOP_NONE: {
 			animation_play_button->set_button_icon(get_editor_theme_icon(SNAME("MainPlay")));
 			animation_slider->set_value_no_signal(1.0);
-			animation_frame_spin_box->set_value_no_signal(animation_map[selected_id].animation->get_length() * 30.0);
+			animation_frame_spin_box->set_value_no_signal(animation_map[selected_id].animation->get_length() * animation_fps);
 			set_process(false);
 		} break;
 		case Animation::LOOP_LINEAR: {

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1173,9 +1173,16 @@ void SceneImportSettingsDialog::_animation_frame_spin_box_value_changed(double p
 	if (animation_player == nullptr || !animation_map.has(selected_id) || animation_map[selected_id].animation.is_null()) {
 		return;
 	}
-
-	int frames = (int)Math::round(animation_map[selected_id].animation->get_length() * animation_fps);
-	animation_slider->set_value(CLAMP(p_value / frames, 0.0, 1.0));
+	if (animation_player->is_playing()) {
+		animation_player->stop();
+		animation_play_button->set_button_icon(get_editor_theme_icon(SNAME("MainPlay")));
+		set_process(false);
+	}
+	const double animation_length = animation_map[selected_id].animation->get_length();
+	const int frames = (int)Math::round(animation_length * animation_fps);
+	const float slider_value = CLAMP((float)p_value / (float)frames, 0.0f, 1.0f);
+	animation_player->seek(slider_value * animation_length, true);
+	animation_slider->set_value_no_signal(slider_value);
 }
 
 void SceneImportSettingsDialog::_animation_slider_value_changed(double p_value) {
@@ -1190,8 +1197,8 @@ void SceneImportSettingsDialog::_animation_slider_value_changed(double p_value) 
 	const double animation_length = animation_map[selected_id].animation->get_length();
 	animation_player->seek(p_value * animation_length, true);
 
-	int frames = (int)Math::round(animation_length * animation_fps);
-	int frame = CLAMP((int)Math::round(p_value * frames), 0, frames);
+	const int frames = (int)Math::round(animation_length * animation_fps);
+	const int frame = CLAMP((int)Math::round(p_value * frames), 0, frames);
 	animation_frame_spin_box->set_value_no_signal(frame);
 }
 

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -105,6 +105,8 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 	List<Skeleton3D *> skeletons;
 	PanelContainer *animation_preview = nullptr;
 	HSlider *animation_slider = nullptr;
+	Label *animation_start_label = nullptr;
+	Label *animation_length_label = nullptr;
 	Button *animation_play_button = nullptr;
 	Button *animation_stop_button = nullptr;
 	Button *animation_toggle_skeleton_visibility = nullptr;

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -108,6 +108,7 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 	Button *animation_play_button = nullptr;
 	Button *animation_stop_button = nullptr;
 	Button *animation_toggle_skeleton_visibility = nullptr;
+	double animation_length = 0.0;
 	Animation::LoopMode animation_loop_mode = Animation::LOOP_NONE;
 	bool animation_pingpong = false;
 	bool previous_import_as_skeleton = false;

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -105,8 +105,6 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 	List<Skeleton3D *> skeletons;
 	PanelContainer *animation_preview = nullptr;
 	HSlider *animation_slider = nullptr;
-	Label *animation_start_label = nullptr;
-	Label *animation_length_label = nullptr;
 	Button *animation_play_button = nullptr;
 	Button *animation_stop_button = nullptr;
 	Button *animation_toggle_skeleton_visibility = nullptr;

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -108,7 +108,6 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 	Button *animation_play_button = nullptr;
 	Button *animation_stop_button = nullptr;
 	Button *animation_toggle_skeleton_visibility = nullptr;
-	double animation_length = 0.0;
 	Animation::LoopMode animation_loop_mode = Animation::LOOP_NONE;
 	bool animation_pingpong = false;
 	bool previous_import_as_skeleton = false;

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -40,6 +40,7 @@
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/slider.h"
+#include "scene/gui/spin_box.h"
 #include "scene/gui/split_container.h"
 #include "scene/gui/tab_container.h"
 #include "scene/gui/tree.h"
@@ -107,9 +108,12 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 	HSlider *animation_slider = nullptr;
 	Button *animation_play_button = nullptr;
 	Button *animation_stop_button = nullptr;
+	SpinBox *animation_frame_spin_box = nullptr;
+
 	Button *animation_toggle_skeleton_visibility = nullptr;
 	Animation::LoopMode animation_loop_mode = Animation::LOOP_NONE;
 	bool animation_pingpong = false;
+	float animation_fps = 30.0f;
 	bool previous_import_as_skeleton = false;
 	bool previous_rest_as_reset = false;
 	MeshInstance3D *bones_mesh_preview = nullptr;
@@ -187,6 +191,7 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 	void _play_animation();
 	void _stop_current_animation();
 	void _reset_animation(const String &p_animation_name = "");
+	void _animation_frame_spin_box_value_changed(double p_value);
 	void _animation_slider_value_changed(double p_value);
 	void _animation_finished(const StringName &p_name);
 	void _animation_update_skeleton_visibility();


### PR DESCRIPTION
Added in animation importer:
- read only properties showing:
  - animation length in seconds
  - number of frames with current FPS
- editable (and synced with slider) number of current frame 

<img width="1543" height="1019" alt="image" src="https://github.com/user-attachments/assets/610ed57e-76d8-4c53-a309-8edbabb12d06" />

Authored with help of Copilot to quickly navigate the code base and find solutions for problems that were not obvious.