### PR TITLE
Use `TRACY_ON_DEMAND` by default for Tracy integration

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -221,6 +221,13 @@ opts.Add(
         False,
     )
 )
+opts.Add(
+    BoolVariable(
+        "profiler_record_on_demand",
+        "Record only when the profiler is connected, if the profiler supports it. In Tracy, this configures TRACY_ON_DEMAND, which has a performance impact if enabled.",
+        True,
+    )
+)
 
 
 # Advanced options

--- a/core/profiling/SCsub
+++ b/core/profiling/SCsub
@@ -50,6 +50,8 @@ if env["profiler"]:
             print("profiler_sample_callstack ignored. Please configure callstack sampling in Instruments instead.")
         if env["profiler_track_memory"]:
             print("profiler_track_memory ignored. Please configure memory tracking in Instruments instead.")
+        if env["profiler_record_on_demand"]:
+            print("profiler_record_on_demand ignored. Instruments is always recording.")
     elif env["profiler"] == "tracy":
         if not env["profiler_path"]:
             print("profiler_path must be set when using the tracy profiler. Aborting.")
@@ -69,6 +71,8 @@ if env["profiler"]:
             env_tracy.Append(CPPDEFINES=[("TRACY_CALLSTACK", 62)])
         if env["profiler_track_memory"]:
             env_tracy.Append(CPPDEFINES=["GODOT_PROFILER_TRACK_MEMORY"])
+        if env["profiler_record_on_demand"]:
+            env_tracy.Append(CPPDEFINES=["TRACY_ON_DEMAND"])
         env_tracy.disable_warnings()
         env_tracy.add_source_files(env.core_sources, str((profiler_path / "TracyClient.cpp").absolute()))
     elif env["profiler"] == "perfetto":
@@ -85,6 +89,8 @@ if env["profiler"]:
         if env["profiler_track_memory"]:
             print("Perfetto does not support memory tracking. Aborting.")
             Exit(255)
+        if env["profiler_record_on_demand"]:
+            print("profiler_record_on_demand ignored. Perfetto is always recording.")
         env_perfetto.disable_warnings()
         env_perfetto.Prepend(CPPPATH=[str(profiler_path.absolute())])
         env_perfetto.add_source_files(env.core_sources, str((profiler_path / "perfetto.cc").absolute()))
@@ -94,6 +100,11 @@ elif env["profiler_path"]:
 
 env.CommandNoCache(
     "profiling.gen.h",
-    [env.Value(env["profiler"]), env.Value(env["profiler_sample_callstack"]), env.Value(env["profiler_track_memory"])],
+    [
+        env.Value(env["profiler"]),
+        env.Value(env["profiler_sample_callstack"]),
+        env.Value(env["profiler_track_memory"]),
+        env.Value(env["profiler_record_on_demand"]),
+    ],
     env.Run(profiling_builders.profiler_gen_builder),
 )

--- a/core/profiling/profiling_builders.py
+++ b/core/profiling/profiling_builders.py
@@ -11,6 +11,8 @@ def profiler_gen_builder(target, source, env):
                 file.write("#define TRACY_CALLSTACK 62\n")
             if env["profiler_track_memory"]:
                 file.write("#define GODOT_PROFILER_TRACK_MEMORY\n")
+            if env["profiler_record_on_demand"]:
+                file.write("#define TRACY_ON_DEMAND\n")
         if env["profiler"] == "perfetto":
             file.write("#define GODOT_USE_PERFETTO\n")
         if env["profiler"] == "instruments":


### PR DESCRIPTION
Fixes #115798.

As per Tracy's manual ([PDF here](https://github.com/wolfpld/tracy/releases/latest/download/tracy.pdf)) Tracy will accumulate events even before you've connected a client to it. This accumulation can be hundreds of megabytes per second for non-trivial applications, pretty much forcing you to have Tracy running (and have it set to use a memory limit) if you don't want to cause crashes or severe slowdowns of your system due to running out of memory.

However, Tracy offers a `TRACY_ON_DEMAND` compile definition that stops it from accumulating these events when there isn't a client connected:

<details><summary>[Click to expand/collapse]</summary>
<p>
<img width="799" height="341" alt="image" src="https://github.com/user-attachments/assets/9797d1a6-592f-4995-9998-b564e62e45d4" />
</p>
</details>

Therefore, this pull request adds a new build option called `profiler_record_on_demand`, which maps to `TRACY_ON_DEMAND`, allowing you to omit `TRACY_ON_DEMAND` by disabling this new option.

This new option is enabled by default, meaning `TRACY_ON_DEMAND` is now enabled/provided, since the current behavior without it seems very costly, especially since even when the Tracy client is connected its memory allocations seem quite intense, effectively limiting how long you can record samples for in general, with or without this new build option:

<details><summary>[Click to expand/collapse]</summary>
<p>
<img width="801" height="243" alt="image" src="https://github.com/user-attachments/assets/2ec4aace-9829-41a0-9129-d7d9e5419722" />
</p>
</details>