### PR TITLE
GDScript: Add warning for shadowing global constants

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -6209,6 +6209,10 @@ void GDScriptAnalyzer::is_shadowing(GDScriptParser::IdentifierNode *p_identifier
 		}
 		native_base_class = ClassDB::get_parent_class(native_base_class);
 	}
+	if (GDScriptLanguage::get_singleton()->get_global_map().has(name)) {
+    	parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_VARIABLE, p_context, name, "global constant", "Global Scope");
+    	return;
+	}
 }
 #endif // DEBUG_ENABLED
 


### PR DESCRIPTION
### Description
This PR adds a missing warning in GDScript when a local variable or property shadows a global constant (such as `PI`, `OK`, or `INF`). 

Previously, shadowing these global constants would happen silently, which could lead to confusing logic errors for users who expect to be using the built-in global values.

### Fixes


### Changes
- In `gdscript_analyzer.cpp`, added a check against `GDScriptLanguage::get_singleton()->get_global_map()` within the `is_shadowing` validation logic.
- Trigger a `SHADOWED_VARIABLE` warning if a match is found in the global scope.

### Validation
Tested with the following script:
```gdscript
var PI = 3.14 # Now triggers a warning
var OK = 0    # Now triggers a warning
