### PR TITLE
Bind `ResourceLoader::get_resource_script_class()`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -94,6 +94,10 @@ Vector<String> ResourceLoader::get_recognized_extensions_for_type(const String &
 	return ret;
 }
 
+String ResourceLoader::get_resource_script_class(const String &p_path) {
+	return ::ResourceLoader::get_resource_script_class(p_path);
+}
+
 void ResourceLoader::add_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader, bool p_at_front) {
 	::ResourceLoader::add_resource_format_loader(p_format_loader, p_at_front);
 }
@@ -147,6 +151,7 @@ void ResourceLoader::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("load", "path", "type_hint", "cache_mode"), &ResourceLoader::load, DEFVAL(""), DEFVAL(CACHE_MODE_REUSE));
 	ClassDB::bind_method(D_METHOD("get_recognized_extensions_for_type", "type"), &ResourceLoader::get_recognized_extensions_for_type);
+	ClassDB::bind_method(D_METHOD("get_resource_script_class", "path"), &ResourceLoader::get_resource_script_class);
 	ClassDB::bind_method(D_METHOD("add_resource_format_loader", "format_loader", "at_front"), &ResourceLoader::add_resource_format_loader, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_resource_format_loader", "format_loader"), &ResourceLoader::remove_resource_format_loader);
 	ClassDB::bind_method(D_METHOD("set_abort_on_missing_resources", "abort"), &ResourceLoader::set_abort_on_missing_resources);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -76,6 +76,7 @@ public:
 
 	Ref<Resource> load(const String &p_path, const String &p_type_hint = "", CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	Vector<String> get_recognized_extensions_for_type(const String &p_type);
+	String get_resource_script_class(const String &p_path);
 	void add_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader, bool p_at_front);
 	void remove_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader);
 	void set_abort_on_missing_resources(bool p_abort);

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -64,6 +64,13 @@
 				Returns the list of recognized extensions for a resource type.
 			</description>
 		</method>
+		<method name="get_resource_script_class">
+			<return type="String" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Returns the script class for the resource at the given [param path].
+			</description>
+		</method>
 		<method name="get_resource_uid">
 			<return type="int" />
 			<param index="0" name="path" type="String" />


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/14496

This adds `ResourceLoader::get_resource_script_class` to the core binds.