### PR TITLE
Add `EditorInterface::open_scene_or_resource_from_path()`

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -314,6 +314,15 @@
 				Opens the scene at the given path. If [param set_inherited] is [code]true[/code], creates a new inherited scene.
 			</description>
 		</method>
+		<method name="open_scene_or_resource_from_path">
+			<return type="int" enum="Error" />
+			<param index="0" name="scene_path" type="String" />
+			<param index="1" name="change_scene_tab_if_already_open" type="bool" default="false" />
+			<description>
+				Opens the scene or resource at the given path. If [param change_scene_tab_if_already_open] is [code]true[/code], the scene will be opened in a new tab if it is already open.
+				Returns [constant OK] if the scene or resource is opened successfully, [constant ERR_BUSY] if the editor is busy, or one of the other [enum Error] constants if the scene or resource cannot be opened.
+			</description>
+		</method>
 		<method name="play_current_scene">
 			<return type="void" />
 			<description>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -684,6 +684,18 @@ void EditorInterface::inspect_object(Object *p_obj, const String &p_for_property
 	EditorNode::get_singleton()->push_item(p_obj, p_for_property, p_inspector_only);
 }
 
+Error EditorInterface::open_scene_or_resource_from_path(const String &p_path, bool p_change_scene_tab_if_already_open) {
+	if (ClassDB::is_parent_class(ResourceLoader::get_resource_type(p_path), "PackedScene")) {
+		if (EditorNode::get_singleton()->is_scene_open(p_path) && (!p_change_scene_tab_if_already_open || (get_edited_scene_root() && get_edited_scene_root()->get_scene_file_path() == p_path))) {
+			return OK;
+		}
+		if (EditorNode::get_singleton()->is_changing_scene()) {
+			return ERR_BUSY;
+		}
+	}
+	return EditorNode::get_singleton()->load_scene_or_resource(p_path, false, p_change_scene_tab_if_already_open);
+}
+
 void EditorInterface::edit_resource(const Ref<Resource> &p_resource) {
 	EditorNode::get_singleton()->edit_resource(p_resource);
 }
@@ -913,6 +925,8 @@ void EditorInterface::_bind_methods() {
 	// Object/Resource/Node editing.
 
 	ClassDB::bind_method(D_METHOD("inspect_object", "object", "for_property", "inspector_only"), &EditorInterface::inspect_object, DEFVAL(String()), DEFVAL(false));
+
+	ClassDB::bind_method(D_METHOD("open_scene_or_resource_from_path", "scene_path", "change_scene_tab_if_already_open"), &EditorInterface::open_scene_or_resource_from_path, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("edit_resource", "resource"), &EditorInterface::edit_resource);
 	ClassDB::bind_method(D_METHOD("edit_node", "node"), &EditorInterface::edit_node);

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -168,6 +168,8 @@ public:
 
 	void inspect_object(Object *p_obj, const String &p_for_property = String(), bool p_inspector_only = false);
 
+	Error open_scene_or_resource_from_path(const String &scene_path, bool p_change_scene_tab_if_already_open = false);
+
 	void edit_resource(const Ref<Resource> &p_resource);
 	void edit_node(Node *p_node);
 	void edit_script(const Ref<Script> &p_script, int p_line = -1, int p_col = 0, bool p_grab_focus = true);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Fixes https://github.com/godotengine/godot-proposals/issues/14497

This adds `EditorInterface::open_scene_or_resource_from_path`. It's a simple bind of `EditorNode::load_scene_or_resource`, with a check if the editor is currently changing scenes. If it's changing scenes, we return `ERR_BUSY`.