### PR TITLE
Fix some classes being incorrectly marked as 100% documented in `doc_status.py`

### DIFF
--- a/doc/tools/doc_status.py
+++ b/doc/tools/doc_status.py
@@ -157,7 +157,7 @@ class ClassStatusProgress:
 
     def to_colored_string(self, format: str = "{has}/{total}", pad_format: str = "{pad_described}{s}{pad_total}"):
         ratio = float(self.described) / float(self.total) if self.total != 0 else 1
-        percent = int(round(100 * ratio))
+        percent = int(math.floor(100 * ratio))
         s = format.format(has=str(self.described), total=str(self.total), percent=str(percent))
         if self.described >= self.total:
             s = color("part_good", s)


### PR DESCRIPTION
- This closes https://github.com/godotengine/doc-status/issues/34.

## Preview

<img width="1431" height="34" alt="image" src="https://github.com/user-attachments/assets/8a641c7c-a809-4bea-8b52-058f6e6acb88" />
