### PR TITLE
Allow building Mono module on RISC-V

### DIFF
--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -1,7 +1,4 @@
 def can_build(env, platform):
-    if env["arch"].startswith("rv"):
-        return False
-
     if env.editor_build:
         env.module_add_dependencies("mono", ["regex"])
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
was able to build it with .NET 10

see also: https://github.com/AOSC-Dev/aosc-os-abbs/pull/14898