### PR TITLE
Move method maps from `ClassDB` to `GDType`.

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -1100,7 +1100,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 						Dictionary d2;
 						d2["name"] = String(method_name);
 
-						MethodBind *method = ClassDB::get_method(class_name, method_name);
+						const MethodBind *method = ClassDB::get_method(class_name, method_name);
 						if (!method) {
 							continue;
 						}

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -561,8 +561,6 @@ void GDExtension::_register_extension_class_internal(GDExtensionClassLibraryPtr 
 	}
 #endif
 
-	extension->gdextension.create_gdtype();
-
 	ClassDB::register_extension_class(&extension->gdextension);
 
 	if (p_extension_funcs->icon_path != nullptr) {
@@ -580,6 +578,8 @@ void GDExtension::_register_extension_class_method(GDExtensionClassLibraryPtr p_
 	StringName method_name = *reinterpret_cast<const StringName *>(p_method_info->name);
 	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), vformat("Attempt to register extension method '%s' for unexisting class '%s'.", String(method_name), class_name));
 
+	bool is_from_old_extension = false;
+
 #ifdef TOOLS_ENABLED
 	Extension *extension = &self->extension_classes[class_name];
 	GDExtensionMethodBind *method = nullptr;
@@ -596,8 +596,6 @@ void GDExtension::_register_extension_class_method(GDExtensionClassLibraryPtr p_
 		// mark as invalid and create a new one.
 		if (!method->is_reloading || !method->try_update(p_method_info)) {
 			method->valid = false;
-			self->invalid_methods.push_back(method);
-
 			method = nullptr;
 		}
 	}
@@ -608,13 +606,14 @@ void GDExtension::_register_extension_class_method(GDExtensionClassLibraryPtr p_
 		extension->methods[method_name] = method;
 	} else {
 		method->is_reloading = false;
+		is_from_old_extension = true;
 	}
 #else
 	GDExtensionMethodBind *method = memnew(GDExtensionMethodBind(p_method_info));
 	method->set_instance_class(class_name);
 #endif
 
-	ClassDB::bind_method_custom(class_name, method);
+	ClassDB::bind_method_custom(class_name, method, !is_from_old_extension);
 }
 
 void GDExtension::_register_extension_class_virtual_method(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, const GDExtensionClassVirtualMethodInfo *p_method_info) {
@@ -743,11 +742,7 @@ void GDExtension::_unregister_extension_class(GDExtensionClassLibraryPtr p_libra
 #endif
 	ERR_FAIL_COND_MSG(ext->gdextension.children.size(), vformat("Attempt to unregister class '%s' while other extension classes inherit from it.", class_name));
 
-#ifdef TOOLS_ENABLED
-	ClassDB::unregister_extension_class(class_name, !ext->is_reloading);
-#else
 	ClassDB::unregister_extension_class(class_name);
-#endif
 
 	if (ext->gdextension.parent != nullptr) {
 		ext->gdextension.parent->children.erase(&ext->gdextension);
@@ -878,12 +873,6 @@ GDExtension::~GDExtension() {
 	if (is_library_open()) {
 		close_library();
 	}
-#ifdef TOOLS_ENABLED
-	// If we have any invalid method binds still laying around, we can finally free them!
-	for (GDExtensionMethodBind *E : invalid_methods) {
-		memdelete(E);
-	}
-#endif
 }
 
 void GDExtension::initialize_gdextensions() {
@@ -982,8 +971,6 @@ void GDExtension::_clear_extension(Extension *p_extension) {
 
 		obj->clear_internal_extension();
 	}
-
-	p_extension->gdextension.destroy_gdtype();
 }
 
 void GDExtension::track_instance_binding(Object *p_object) {
@@ -1021,7 +1008,6 @@ void GDExtension::finish_reload() {
 		for (KeyValue<StringName, GDExtensionMethodBind *> &M : E.value.methods) {
 			if (M.value->is_reloading) {
 				M.value->valid = false;
-				invalid_methods.push_back(M.value);
 
 				M.value->is_reloading = false;
 				methods_to_remove.push_back(M.key);

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -561,8 +561,6 @@ void GDExtension::_register_extension_class_internal(GDExtensionClassLibraryPtr 
 	}
 #endif
 
-	extension->gdextension.create_gdtype();
-
 	ClassDB::register_extension_class(&extension->gdextension);
 
 	if (p_extension_funcs->icon_path != nullptr) {
@@ -580,6 +578,8 @@ void GDExtension::_register_extension_class_method(GDExtensionClassLibraryPtr p_
 	StringName method_name = *reinterpret_cast<const StringName *>(p_method_info->name);
 	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), vformat("Attempt to register extension method '%s' for unexisting class '%s'.", String(method_name), class_name));
 
+	bool is_from_old_extension = false;
+
 #ifdef TOOLS_ENABLED
 	Extension *extension = &self->extension_classes[class_name];
 	GDExtensionMethodBind *method = nullptr;
@@ -596,8 +596,6 @@ void GDExtension::_register_extension_class_method(GDExtensionClassLibraryPtr p_
 		// mark as invalid and create a new one.
 		if (!method->is_reloading || !method->try_update(p_method_info)) {
 			method->valid = false;
-			self->invalid_methods.push_back(method);
-
 			method = nullptr;
 		}
 	}
@@ -608,13 +606,14 @@ void GDExtension::_register_extension_class_method(GDExtensionClassLibraryPtr p_
 		extension->methods[method_name] = method;
 	} else {
 		method->is_reloading = false;
+		is_from_old_extension = true;
 	}
 #else
 	GDExtensionMethodBind *method = memnew(GDExtensionMethodBind(p_method_info));
 	method->set_instance_class(class_name);
 #endif
 
-	ClassDB::bind_method_custom(class_name, method);
+	ClassDB::bind_method_custom(class_name, method, !is_from_old_extension);
 }
 
 void GDExtension::_register_extension_class_virtual_method(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, const GDExtensionClassVirtualMethodInfo *p_method_info) {
@@ -743,11 +742,7 @@ void GDExtension::_unregister_extension_class(GDExtensionClassLibraryPtr p_libra
 #endif
 	ERR_FAIL_COND_MSG(ext->gdextension.children.size(), vformat("Attempt to unregister class '%s' while other extension classes inherit from it.", class_name));
 
-#ifdef TOOLS_ENABLED
-	ClassDB::unregister_extension_class(class_name, !ext->is_reloading);
-#else
 	ClassDB::unregister_extension_class(class_name);
-#endif
 
 	if (ext->gdextension.parent != nullptr) {
 		ext->gdextension.parent->children.erase(&ext->gdextension);
@@ -881,12 +876,6 @@ GDExtension::~GDExtension() {
 	if (is_library_open()) {
 		close_library();
 	}
-#ifdef TOOLS_ENABLED
-	// If we have any invalid method binds still laying around, we can finally free them!
-	for (GDExtensionMethodBind *E : invalid_methods) {
-		memdelete(E);
-	}
-#endif
 }
 
 void GDExtension::initialize_gdextensions() {
@@ -985,8 +974,6 @@ void GDExtension::_clear_extension(Extension *p_extension) {
 
 		obj->clear_internal_extension();
 	}
-
-	p_extension->gdextension.destroy_gdtype();
 }
 
 void GDExtension::track_instance_binding(Object *p_object) {
@@ -1024,7 +1011,6 @@ void GDExtension::finish_reload() {
 		for (KeyValue<StringName, GDExtensionMethodBind *> &M : E.value.methods) {
 			if (M.value->is_reloading) {
 				M.value->valid = false;
-				invalid_methods.push_back(M.value);
 
 				M.value->is_reloading = false;
 				methods_to_remove.push_back(M.key);

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -103,7 +103,6 @@ class GDExtension : public Resource {
 
 #ifdef TOOLS_ENABLED
 	bool is_reloading = false;
-	Vector<GDExtensionMethodBind *> invalid_methods;
 	Vector<ObjectID> instance_bindings;
 	GDExtensionEditorGetClassesUsedCallback get_classes_used_callback = nullptr;
 

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1634,7 +1634,7 @@ static GDExtensionMethodBindPtr gdextension_classdb_get_method_bind(GDExtensionC
 	const StringName classname = *reinterpret_cast<const StringName *>(p_classname);
 	const StringName methodname = *reinterpret_cast<const StringName *>(p_methodname);
 	bool exists = false;
-	MethodBind *mb = ClassDB::get_method_with_compatibility(classname, methodname, p_hash, &exists);
+	const MethodBind *mb = ClassDB::get_method_with_compatibility(classname, methodname, p_hash, &exists);
 
 #ifndef DISABLE_DEPRECATED
 	// If lookup failed, see if this is one of the broken hashes from issue #81386.

--- a/core/extension/gdextension_special_compat_hashes.cpp
+++ b/core/extension/gdextension_special_compat_hashes.cpp
@@ -61,7 +61,7 @@ bool GDExtensionSpecialCompatHashes::get_legacy_hashes(const StringName &p_class
 	for (const Mapping &mapping : *methods) {
 		if (mapping.method == p_method) {
 			if (p_check_valid) {
-				MethodBind *mb = ClassDB::get_method_with_compatibility(p_class, p_method, mapping.current_hash);
+				const MethodBind *mb = ClassDB::get_method_with_compatibility(p_class, p_method, mapping.current_hash);
 				if (!mb) {
 					WARN_PRINT(vformat("Compatibility hash %d for %s::%s() mapped to non-existent hash %d in gdextension_special_compat_hashes.cpp.", mapping.legacy_hash, p_class, p_method, mapping.current_hash));
 					continue;

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -403,7 +403,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 
 			List<StringName> snames;
 
-			for (const KeyValue<StringName, MethodBind *> &F : t->method_map) {
+			for (const KeyValue<StringName, const MethodBind *> &F : t->gdtype->get_method_map(true)) {
 				String name = F.key.string();
 
 				ERR_CONTINUE(name.is_empty());
@@ -418,7 +418,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 			snames.sort_custom<StringName::AlphCompare>();
 
 			for (const StringName &F : snames) {
-				MethodBind *mb = t->method_map[F];
+				const MethodBind *mb = t->gdtype->get_method_map(true)[F];
 				hash = hash_murmur3_one_64(mb->get_name().hash(), hash);
 				hash = hash_murmur3_one_64(mb->get_argument_count(), hash);
 				hash = hash_murmur3_one_64(mb->get_argument_type(-1), hash); //return
@@ -952,7 +952,7 @@ void ClassDB::_add_class(GDType &p_class, const GDType *p_inherits) {
 	}
 }
 
-static MethodInfo info_from_bind(MethodBind *p_method) {
+static MethodInfo info_from_bind(const MethodBind *p_method) {
 	MethodInfo minfo;
 	minfo.name = p_method->get_name();
 	minfo.id = p_method->get_method_id();
@@ -977,52 +977,40 @@ void ClassDB::get_method_list(const StringName &p_class, List<MethodInfo> *p_met
 	Locker::Lock lock(Locker::STATE_READ);
 
 	ClassInfo *type = classes.getptr(p_class);
-
-	while (type) {
+	for (const KeyValue<StringName, const MethodBind *> &kv : type->gdtype->get_method_map(p_no_inheritance)) {
 		if (type->disabled) {
-			if (p_no_inheritance) {
-				break;
-			}
-
-			type = type->inherits_ptr;
 			continue;
 		}
+#ifdef DEBUG_ENABLED
+		if (p_exclude_from_properties && type->methods_in_properties.has(kv.key)) {
+			continue;
+		}
+#endif
+
+		p_methods->push_back(info_from_bind(kv.value));
+	}
 
 #ifdef DEBUG_ENABLED
-		for (const MethodInfo &E : type->virtual_methods) {
-			p_methods->push_back(E);
-		}
-
-		for (const StringName &E : type->method_order) {
-			if (p_exclude_from_properties && type->methods_in_properties.has(E)) {
-				continue;
-			}
-
-			MethodBind *method = type->method_map.get(E);
-			MethodInfo minfo = info_from_bind(method);
-
-			p_methods->push_back(minfo);
-		}
-#else
-		for (KeyValue<StringName, MethodBind *> &E : type->method_map) {
-			MethodBind *m = E.value;
-			MethodInfo minfo = info_from_bind(m);
-			p_methods->push_back(minfo);
-		}
-#endif // DEBUG_ENABLED
-
-		if (p_no_inheritance) {
-			break;
-		}
-
-		type = type->inherits_ptr;
-	}
+	ClassDB::get_virtual_methods(p_class, p_methods, p_no_inheritance);
+#endif
 }
 
 void ClassDB::get_method_list_with_compatibility(const StringName &p_class, List<Pair<MethodInfo, uint32_t>> *p_methods, bool p_no_inheritance, bool p_exclude_from_properties) {
 	Locker::Lock lock(Locker::STATE_READ);
 
 	ClassInfo *type = classes.getptr(p_class);
+	for (const KeyValue<StringName, const MethodBind *> &kv : type->gdtype->get_method_map(p_no_inheritance)) {
+		if (type->disabled) {
+			continue;
+		}
+#ifdef DEBUG_ENABLED
+		if (p_exclude_from_properties && type->methods_in_properties.has(kv.key)) {
+			continue;
+		}
+#endif
+
+		p_methods->push_back(Pair(info_from_bind(kv.value), kv.value->get_hash()));
+	}
 
 	while (type) {
 		if (type->disabled) {
@@ -1033,41 +1021,18 @@ void ClassDB::get_method_list_with_compatibility(const StringName &p_class, List
 			type = type->inherits_ptr;
 			continue;
 		}
-
 #ifdef DEBUG_ENABLED
 		for (const MethodInfo &E : type->virtual_methods) {
 			Pair<MethodInfo, uint32_t> pair(E, E.get_compatibility_hash());
 			p_methods->push_back(pair);
 		}
-
-		for (const StringName &E : type->method_order) {
-			if (p_exclude_from_properties && type->methods_in_properties.has(E)) {
-				continue;
-			}
-
-			MethodBind *method = type->method_map.get(E);
-			MethodInfo minfo = info_from_bind(method);
-
-			Pair<MethodInfo, uint32_t> pair(minfo, method->get_hash());
-			p_methods->push_back(pair);
-		}
-#else
-		for (KeyValue<StringName, MethodBind *> &E : type->method_map) {
-			MethodBind *method = E.value;
-			MethodInfo minfo = info_from_bind(method);
-
-			Pair<MethodInfo, uint32_t> pair(minfo, method->get_hash());
-			p_methods->push_back(pair);
-		}
-#endif // DEBUG_ENABLED
-
+#endif
 		for (const KeyValue<StringName, LocalVector<MethodBind *, unsigned int, false, false>> &E : type->method_map_compatibility) {
 			LocalVector<MethodBind *> compat(E.value);
 			for (MethodBind *method : compat) {
 				MethodInfo minfo = info_from_bind(method);
 
-				Pair<MethodInfo, uint32_t> pair(minfo, method->get_hash());
-				p_methods->push_back(pair);
+				p_methods->push_back(Pair<MethodInfo, uint32_t>(minfo, method->get_hash()));
 			}
 		}
 
@@ -1095,8 +1060,8 @@ bool ClassDB::get_method_info(const StringName &p_class, const StringName &p_met
 		}
 
 #ifdef DEBUG_ENABLED
-		MethodBind **method = type->method_map.getptr(p_method);
-		if (method && *method) {
+		const MethodBind *const *method = type->gdtype->get_method_map(true).getptr(p_method);
+		if (method) {
 			if (r_info != nullptr) {
 				MethodInfo minfo = info_from_bind(*method);
 				*r_info = minfo;
@@ -1109,9 +1074,9 @@ bool ClassDB::get_method_info(const StringName &p_class, const StringName &p_met
 			return true;
 		}
 #else
-		if (type->method_map.has(p_method)) {
+		if (type->gdtype->get_method_map(true).has(p_method)) {
 			if (r_info) {
-				MethodBind *m = type->method_map[p_method];
+				const MethodBind *m = type->gdtype->get_method_map(true)[p_method];
 				MethodInfo minfo = info_from_bind(m);
 				*r_info = minfo;
 			}
@@ -1129,19 +1094,16 @@ bool ClassDB::get_method_info(const StringName &p_class, const StringName &p_met
 	return false;
 }
 
-MethodBind *ClassDB::get_method(const StringName &p_class, const StringName &p_name) {
+const MethodBind *ClassDB::get_method(const StringName &p_class, const StringName &p_name) {
 	Locker::Lock lock(Locker::STATE_READ);
 
 	ClassInfo *type = classes.getptr(p_class);
-
-	while (type) {
-		MethodBind **method = type->method_map.getptr(p_name);
-		if (method && *method) {
-			return *method;
-		}
-		type = type->inherits_ptr;
+	if (!type) {
+		return nullptr;
 	}
-	return nullptr;
+
+	const MethodBind *const *method = type->gdtype->get_method_map(false).getptr(p_name);
+	return method ? *method : nullptr;
 }
 
 Vector<uint32_t> ClassDB::get_method_compatibility_hashes(const StringName &p_class, const StringName &p_name) {
@@ -1163,14 +1125,14 @@ Vector<uint32_t> ClassDB::get_method_compatibility_hashes(const StringName &p_cl
 	return Vector<uint32_t>();
 }
 
-MethodBind *ClassDB::get_method_with_compatibility(const StringName &p_class, const StringName &p_name, uint64_t p_hash, bool *r_method_exists, bool *r_is_deprecated) {
+const MethodBind *ClassDB::get_method_with_compatibility(const StringName &p_class, const StringName &p_name, uint64_t p_hash, bool *r_method_exists, bool *r_is_deprecated) {
 	Locker::Lock lock(Locker::STATE_READ);
 
 	ClassInfo *type = classes.getptr(p_class);
 
 	while (type) {
-		MethodBind **method = type->method_map.getptr(p_name);
-		if (method && *method) {
+		const MethodBind *const *method = type->gdtype->get_method_map(true).getptr(p_name);
+		if (method) {
 			if (r_method_exists) {
 				*r_method_exists = true;
 			}
@@ -1427,7 +1389,7 @@ void ClassDB::add_property(const StringName &p_class, const PropertyInfo &p_pinf
 
 	ERR_FAIL_NO_CLASS(type, p_class);
 
-	MethodBind *mb_set = nullptr;
+	const MethodBind *mb_set = nullptr;
 	if (p_setter) {
 		mb_set = get_method(p_class, p_setter);
 #ifdef DEBUG_ENABLED
@@ -1439,7 +1401,7 @@ void ClassDB::add_property(const StringName &p_class, const PropertyInfo &p_pinf
 #endif // DEBUG_ENABLED
 	}
 
-	MethodBind *mb_get = nullptr;
+	const MethodBind *mb_get = nullptr;
 	if (p_getter) {
 		mb_get = get_method(p_class, p_getter);
 #ifdef DEBUG_ENABLED
@@ -1652,7 +1614,7 @@ bool ClassDB::get_property(Object *p_object, const StringName &p_property, Varia
 			return true;
 		}
 
-		if (check->method_map.has(p_property)) { //methods count
+		if (check->gdtype->get_method_map(true).has(p_property)) { //methods count
 			r_value = Callable(p_object, p_property);
 			return true;
 		}
@@ -1768,55 +1730,41 @@ bool ClassDB::has_property(const StringName &p_class, const StringName &p_proper
 void ClassDB::set_method_flags(const StringName &p_class, const StringName &p_method, int p_flags) {
 	Locker::Lock lock(Locker::STATE_WRITE);
 	ClassInfo *type = classes.getptr(p_class);
-	ClassInfo *check = type;
-	ERR_FAIL_NULL(check);
-	ERR_FAIL_COND(!check->method_map.has(p_method));
-	check->method_map[p_method]->set_hint_flags(p_flags);
+	ERR_FAIL_NULL(type);
+	type->gdtype->set_method_flags(p_method, p_flags);
 }
 
 bool ClassDB::has_method(const StringName &p_class, const StringName &p_method, bool p_no_inheritance) {
 	ClassInfo *type = classes.getptr(p_class);
-	ClassInfo *check = type;
-	while (check) {
-		if (check->method_map.has(p_method)) {
-			return true;
-		}
-		if (p_no_inheritance) {
-			return false;
-		}
-		check = check->inherits_ptr;
+	if (!type) {
+		return false;
 	}
-
-	return false;
+	return type->gdtype->get_method_map(p_no_inheritance).has(p_method);
 }
 
 int ClassDB::get_method_argument_count(const StringName &p_class, const StringName &p_method, bool *r_is_valid, bool p_no_inheritance) {
 	Locker::Lock lock(Locker::STATE_READ);
 
 	ClassInfo *type = classes.getptr(p_class);
-
-	while (type) {
-		MethodBind **method = type->method_map.getptr(p_method);
-		if (method && *method) {
+	if (type) {
+		const MethodBind *const *method = type->gdtype->get_method_map(p_no_inheritance).getptr(p_method);
+		if (method) {
 			if (r_is_valid) {
 				*r_is_valid = true;
 			}
 			return (*method)->get_argument_count();
 		}
-		if (p_no_inheritance) {
-			break;
-		}
-		type = type->inherits_ptr;
 	}
 
 	if (r_is_valid) {
 		*r_is_valid = false;
 	}
+
 	return 0;
 }
 
-void ClassDB::bind_method_custom(const StringName &p_class, MethodBind *p_method) {
-	_bind_method_custom(p_class, p_method, false);
+void ClassDB::bind_method_custom(const StringName &p_class, MethodBind *p_method, bool p_take_ownership) {
+	_bind_method_custom(p_class, p_method, false, p_take_ownership);
 }
 void ClassDB::bind_compatibility_method_custom(const StringName &p_class, MethodBind *p_method) {
 	_bind_method_custom(p_class, p_method, true);
@@ -1829,7 +1777,7 @@ void ClassDB::_bind_compatibility(ClassInfo *r_type, MethodBind *p_method) {
 	r_type->method_map_compatibility[p_method->get_name()].push_back(p_method);
 }
 
-void ClassDB::_bind_method_custom(const StringName &p_class, MethodBind *p_method, bool p_compatibility) {
+void ClassDB::_bind_method_custom(const StringName &p_class, MethodBind *p_method, bool p_compatibility, bool p_take_ownership) {
 	Locker::Lock lock(Locker::STATE_WRITE);
 
 	StringName method_name = p_method->get_name();
@@ -1845,17 +1793,7 @@ void ClassDB::_bind_method_custom(const StringName &p_class, MethodBind *p_metho
 		return;
 	}
 
-	if (type->method_map.has(method_name)) {
-		// overloading not supported
-		memdelete(p_method);
-		ERR_FAIL_MSG(vformat("Method already bound '%s::%s'.", p_class, method_name));
-	}
-
-#ifdef DEBUG_ENABLED
-	type->method_order.push_back(method_name);
-#endif // DEBUG_ENABLED
-
-	type->method_map[method_name] = p_method;
+	type->gdtype->bind_method(p_method, p_take_ownership);
 }
 
 MethodBind *ClassDB::_bind_vararg_method(MethodBind *p_bind, const StringName &p_name, const Vector<Variant> &p_default_args, bool p_compatibility) {
@@ -1876,19 +1814,7 @@ MethodBind *ClassDB::_bind_vararg_method(MethodBind *p_bind, const StringName &p
 		return bind;
 	}
 
-	if (type->method_map.has(p_name)) {
-		memdelete(bind);
-		// Overloading not supported
-		ERR_FAIL_V_MSG(nullptr, vformat("Method already bound: '%s::%s'.", instance_type, p_name));
-	}
-	type->method_map[p_name] = bind;
-#ifdef DEBUG_ENABLED
-	// FIXME: <reduz> set_return_type is no longer in MethodBind, so I guess it should be moved to vararg method bind
-	//bind->set_return_type("Variant");
-	type->method_order.push_back(p_name);
-#endif // DEBUG_ENABLED
-
-	return bind;
+	return type->gdtype->bind_method(bind) ? bind : nullptr;
 }
 
 #ifdef DEBUG_ENABLED
@@ -1916,12 +1842,6 @@ MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, bool p_
 		ERR_FAIL_V_MSG(nullptr, vformat("Couldn't bind method '%s' for instance '%s'.", mdname, instance_type));
 	}
 
-	if (!p_compatibility && type->method_map.has(mdname)) {
-		memdelete(p_bind);
-		// overloading not supported
-		ERR_FAIL_V_MSG(nullptr, vformat("Method already bound '%s::%s'.", instance_type, mdname));
-	}
-
 #ifdef DEBUG_ENABLED
 
 	if (p_method_name.args.size() > p_bind->get_argument_count()) {
@@ -1935,16 +1855,14 @@ MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, bool p_
 	}
 
 	p_bind->set_argument_names(p_method_name.args);
-
-	if (!p_compatibility) {
-		type->method_order.push_back(mdname);
-	}
 #endif // DEBUG_ENABLED
 
 	if (p_compatibility) {
 		_bind_compatibility(type, p_bind);
 	} else {
-		type->method_map[mdname] = p_bind;
+		if (!type->gdtype->bind_method(p_bind)) {
+			return nullptr;
+		}
 	}
 
 	Vector<Variant> defvals;
@@ -2286,19 +2204,20 @@ void ClassDB::register_extension_class(ObjectGDExtension *p_extension) {
 	c.is_runtime = p_extension->is_runtime;
 #endif
 
-	c.gdtype = p_extension->gdtype;
+	c.gdtype = memnew(GDType(c.inherits_ptr->gdtype, p_extension->class_name));
+	c.gdtype->initialize();
+	p_extension->gdtype = c.gdtype;
 
 	classes[p_extension->class_name] = c;
 }
 
-void ClassDB::unregister_extension_class(const StringName &p_class, bool p_free_method_binds) {
+static LocalVector<GDType *> gdtype_leaked_autorelease_pool;
+
+void ClassDB::unregister_extension_class(const StringName &p_class) {
 	ClassInfo *c = classes.getptr(p_class);
 	ERR_FAIL_NULL_MSG(c, vformat("Class '%s' does not exist.", String(p_class)));
-	if (p_free_method_binds) {
-		for (KeyValue<StringName, MethodBind *> &F : c->method_map) {
-			memdelete(F.value);
-		}
-	}
+	// Leak the GDType until exit so potential consumers don't have dangling pointers.
+	gdtype_leaked_autorelease_pool.push_back(c->gdtype);
 	classes.erase(p_class);
 	default_values_cached.erase(p_class);
 	default_values.erase(p_class);
@@ -2347,13 +2266,15 @@ void ClassDB::cleanup() {
 	for (KeyValue<StringName, ClassInfo> &E : classes) {
 		ClassInfo &ti = E.value;
 
-		for (KeyValue<StringName, MethodBind *> &F : ti.method_map) {
-			memdelete(F.value);
-		}
 		for (KeyValue<StringName, LocalVector<MethodBind *>> &F : ti.method_map_compatibility) {
 			for (uint32_t i = 0; i < F.value.size(); i++) {
 				memdelete(F.value[i]);
 			}
+		}
+
+		if (E.value.gdextension) {
+			WARN_PRINT(vformat("Extension class '%s' is still registered at exit; its GDExtension did not unregister it.", E.key));
+			gdtype_leaked_autorelease_pool.push_back(E.value.gdtype); // We created it; we need to clear it.
 		}
 	}
 
@@ -2371,6 +2292,11 @@ void ClassDB::cleanup() {
 		*type = nullptr;
 	}
 	gdtype_autorelease_pool.clear();
+
+	for (GDType *type : gdtype_leaked_autorelease_pool) {
+		memdelete(type);
+	}
+	gdtype_leaked_autorelease_pool.clear();
 }
 
 // Array to use in optional parameters on methods and the DEFVAL_ARRAY macro.

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -112,8 +112,8 @@ public:
 		int index;
 		StringName setter;
 		StringName getter;
-		MethodBind *_setptr = nullptr;
-		MethodBind *_getptr = nullptr;
+		const MethodBind *_setptr = nullptr;
+		const MethodBind *_getptr = nullptr;
 		Variant::Type type;
 	};
 
@@ -125,14 +125,12 @@ public:
 
 		ObjectGDExtension *gdextension = nullptr;
 
-		HashMap<StringName, MethodBind *> method_map;
 		HashMap<StringName, LocalVector<MethodBind *>> method_map_compatibility;
 
 		List<PropertyInfo> property_list;
 		HashMap<StringName, PropertyInfo> property_map;
 
 #ifdef DEBUG_ENABLED
-		List<StringName> method_order;
 		HashSet<StringName> methods_in_properties;
 		List<MethodInfo> virtual_methods;
 		HashMap<StringName, MethodInfo> virtual_methods_map;
@@ -233,7 +231,7 @@ private:
 	static bool _is_parent_class(const StringName &p_class, const StringName &p_inherits);
 	static void _bind_compatibility(ClassInfo *r_type, MethodBind *p_method);
 	static MethodBind *_bind_vararg_method(MethodBind *p_bind, const StringName &p_name, const Vector<Variant> &p_default_args, bool p_compatibility);
-	static void _bind_method_custom(const StringName &p_class, MethodBind *p_method, bool p_compatibility);
+	static void _bind_method_custom(const StringName &p_class, MethodBind *p_method, bool p_compatibility, bool p_take_ownership = true);
 
 	static Object *_instantiate_from_gdextension(ObjectGDExtension *p_object_gd_extension, bool p_notify_postinitialize, bool p_with_refcount);
 	static Object *_instantiate_internal(const StringName &p_class, bool p_require_real_class = false, bool p_notify_postinitialize = true, bool p_exposed_only = true, bool p_with_refcount = false);
@@ -302,7 +300,7 @@ public:
 	}
 
 	static void register_extension_class(ObjectGDExtension *p_extension);
-	static void unregister_extension_class(const StringName &p_class, bool p_free_method_binds = true);
+	static void unregister_extension_class(const StringName &p_class);
 
 	template <typename T>
 	static Object *_create_ptr_func(bool p_notify_postinitialize) {
@@ -454,7 +452,7 @@ public:
 		return _bind_vararg_method(bind, p_name, p_default_args, true);
 	}
 
-	static void bind_method_custom(const StringName &p_class, MethodBind *p_method);
+	static void bind_method_custom(const StringName &p_class, MethodBind *p_method, bool p_take_ownership = true);
 	static void bind_compatibility_method_custom(const StringName &p_class, MethodBind *p_method);
 
 	static void add_signal(const StringName &p_class, const MethodInfo &p_signal);
@@ -487,8 +485,8 @@ public:
 	static void get_method_list_with_compatibility(const StringName &p_class, List<Pair<MethodInfo, uint32_t>> *p_methods_with_hash, bool p_no_inheritance = false, bool p_exclude_from_properties = false);
 	static bool get_method_info(const StringName &p_class, const StringName &p_method, MethodInfo *r_info, bool p_no_inheritance = false, bool p_exclude_from_properties = false);
 	static int get_method_argument_count(const StringName &p_class, const StringName &p_method, bool *r_is_valid = nullptr, bool p_no_inheritance = false);
-	static MethodBind *get_method(const StringName &p_class, const StringName &p_name);
-	static MethodBind *get_method_with_compatibility(const StringName &p_class, const StringName &p_name, uint64_t p_hash, bool *r_method_exists = nullptr, bool *r_is_deprecated = nullptr);
+	static const MethodBind *get_method(const StringName &p_class, const StringName &p_name);
+	static const MethodBind *get_method_with_compatibility(const StringName &p_class, const StringName &p_name, uint64_t p_hash, bool *r_method_exists = nullptr, bool *r_is_deprecated = nullptr);
 	static Vector<uint32_t> get_method_compatibility_hashes(const StringName &p_class, const StringName &p_name);
 
 	static void add_virtual_method(const StringName &p_class, const MethodInfo &p_method, bool p_virtual = true, const Vector<String> &p_arg_names = Vector<String>(), bool p_object_core = false);

--- a/core/object/gdtype.cpp
+++ b/core/object/gdtype.cpp
@@ -30,6 +30,7 @@
 
 #include "gdtype.h"
 
+#include "core/object/method_bind.h"
 #include "core/os/memory.h"
 #include "core/os/thread.h"
 
@@ -51,6 +52,9 @@ GDType::~GDType() {
 	for (const KeyValue<StringName, const MethodInfo *> &kv : self_signal_map) {
 		memdelete(const_cast<MethodInfo *>(kv.value));
 	}
+	for (MethodBind *bind : owned_method_map) {
+		memdelete(bind);
+	}
 }
 
 void GDType::initialize() {
@@ -66,6 +70,7 @@ void GDType::initialize() {
 		constant_map = super_type->constant_map;
 		enum_map = super_type->enum_map;
 		signal_map = super_type->signal_map;
+		method_map = super_type->method_map;
 	}
 
 	init_state = InitState::MUTABLE;
@@ -123,4 +128,33 @@ void GDType::add_signal(MethodInfo p_signal) {
 
 	signal_map[signal_name] = ptr;
 	self_signal_map[signal_name] = ptr;
+}
+
+bool GDType::bind_method(MethodBind *p_method, bool p_take_ownership) {
+	ERR_FAIL_COND_V(!Thread::is_main_thread(), false);
+	ERR_FAIL_COND_V(init_state != InitState::MUTABLE, false);
+
+	if (self_method_map.has(p_method->get_name())) {
+		if (p_take_ownership) {
+			memdelete(p_method);
+		}
+		ERR_FAIL_V_MSG(false, vformat("Method already bound '%s::%s'.", name, p_method->get_name()));
+	}
+
+	method_map[p_method->get_name()] = p_method;
+	self_method_map[p_method->get_name()] = p_method;
+	if (p_take_ownership) {
+		owned_method_map.push_back(p_method);
+	}
+	return true;
+}
+
+void GDType::set_method_flags(const StringName &p_method, int p_flags) {
+	ERR_FAIL_COND(!Thread::is_main_thread());
+	ERR_FAIL_COND(init_state != InitState::MUTABLE);
+
+	const MethodBind **method = self_method_map.getptr(p_method);
+	ERR_FAIL_NULL(method);
+
+	const_cast<MethodBind *>(*method)->set_hint_flags(p_flags);
 }

--- a/core/object/gdtype.h
+++ b/core/object/gdtype.h
@@ -35,6 +35,8 @@
 #include "core/templates/a_hash_map.h"
 #include "core/templates/vector.h"
 
+class MethodBind;
+
 class GDType {
 public:
 	enum class InitState {
@@ -67,6 +69,12 @@ protected:
 	AHashMap<StringName, const MethodInfo *> signal_map;
 	AHashMap<StringName, const MethodInfo *> self_signal_map;
 
+	AHashMap<StringName, const MethodBind *> method_map;
+	AHashMap<StringName, const MethodBind *> self_method_map;
+	// This is deliberately not the same as self_method_map because
+	// bind_method supports binding non-owned methods.
+	LocalVector<MethodBind *> owned_method_map;
+
 public:
 	GDType(const GDType *p_super_type, StringName p_name);
 	~GDType();
@@ -89,4 +97,8 @@ public:
 
 	void add_signal(MethodInfo p_signal);
 	const AHashMap<StringName, const MethodInfo *> &get_signal_map(bool p_no_inheritance = false) const { return p_no_inheritance ? self_signal_map : signal_map; }
+
+	bool bind_method(MethodBind *p_method, bool p_take_ownership = true);
+	void set_method_flags(const StringName &p_method, int p_flags);
+	const AHashMap<StringName, const MethodBind *> &get_method_map(bool p_no_inheritance = false) const { return p_no_inheritance ? self_method_map : method_map; }
 };

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -114,39 +114,6 @@ Object::Connection::operator Variant() const {
 	return d;
 }
 
-void ObjectGDExtension::create_gdtype() {
-	ERR_FAIL_COND(gdtype);
-
-	gdtype = memnew(GDType(ClassDB::get_gdtype(parent_class_name), class_name));
-	gdtype->initialize();
-}
-
-void ObjectGDExtension::destroy_gdtype() {
-	ERR_FAIL_COND(!gdtype);
-
-#ifdef TOOLS_ENABLED
-	if (!is_placeholder) {
-#endif
-		memdelete(const_cast<GDType *>(gdtype));
-#ifdef TOOLS_ENABLED
-	}
-#endif
-
-	gdtype = nullptr;
-}
-
-ObjectGDExtension::~ObjectGDExtension() {
-	if (gdtype) {
-#ifdef TOOLS_ENABLED
-		if (!is_placeholder) {
-#endif
-			memdelete(const_cast<GDType *>(gdtype));
-#ifdef TOOLS_ENABLED
-		}
-#endif
-	}
-}
-
 bool Object::Connection::operator<(const Connection &p_conn) const {
 	if (signal == p_conn.signal) {
 		return callable < p_conn.callable;
@@ -659,8 +626,7 @@ bool Object::has_method(const StringName &p_method) const {
 		return true;
 	}
 
-	MethodBind *method = ClassDB::get_method(get_class_name(), p_method);
-	if (method != nullptr) {
+	if (get_gdtype().get_method_map(false).has(p_method)) {
 		return true;
 	}
 
@@ -815,10 +781,10 @@ Variant Object::callp(const StringName &p_method, const Variant **p_args, int p_
 
 	//extension does not need this, because all methods are registered in MethodBind
 
-	MethodBind *method = ClassDB::get_method(get_class_name(), p_method);
+	const MethodBind *const *method = get_gdtype().get_method_map(false).getptr(p_method);
 
 	if (method) {
-		ret = method->call(this, p_args, p_argcount, r_error);
+		ret = (*method)->call(this, p_args, p_argcount, r_error);
 	} else {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
 	}
@@ -859,14 +825,14 @@ Variant Object::call_const(const StringName &p_method, const Variant **p_args, i
 
 	//extension does not need this, because all methods are registered in MethodBind
 
-	MethodBind *method = ClassDB::get_method(get_class_name(), p_method);
+	const MethodBind *const *method = get_gdtype().get_method_map(false).getptr(p_method);
 
 	if (method) {
-		if (!method->is_const()) {
+		if (!(*method)->is_const()) {
 			r_error.error = Callable::CallError::CALL_ERROR_METHOD_NOT_CONST;
 			return ret;
 		}
-		ret = method->call(this, p_args, p_argcount, r_error);
+		ret = (*method)->call(this, p_args, p_argcount, r_error);
 	} else {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
 	}
@@ -2532,8 +2498,8 @@ void ObjectDB::cleanup() {
 			// Ensure calling the native classes because if a leaked instance has a script
 			// that overrides any of those methods, it'd not be OK to call them at this point,
 			// now the scripting languages have already been terminated.
-			MethodBind *node_get_path = ClassDB::get_method("Node", "get_path");
-			MethodBind *resource_get_path = ClassDB::get_method("Resource", "get_path");
+			const MethodBind *node_get_path = ClassDB::get_method("Node", "get_path");
+			const MethodBind *resource_get_path = ClassDB::get_method("Resource", "get_path");
 			Callable::CallError call_error;
 
 			for (uint32_t i = 0, count = slot_count; i < slot_max && count != 0; i++) {

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -114,39 +114,6 @@ Object::Connection::operator Variant() const {
 	return d;
 }
 
-void ObjectGDExtension::create_gdtype() {
-	ERR_FAIL_COND(gdtype);
-
-	gdtype = memnew(GDType(ClassDB::get_gdtype(parent_class_name), class_name));
-	gdtype->initialize();
-}
-
-void ObjectGDExtension::destroy_gdtype() {
-	ERR_FAIL_COND(!gdtype);
-
-#ifdef TOOLS_ENABLED
-	if (!is_placeholder) {
-#endif
-		memdelete(const_cast<GDType *>(gdtype));
-#ifdef TOOLS_ENABLED
-	}
-#endif
-
-	gdtype = nullptr;
-}
-
-ObjectGDExtension::~ObjectGDExtension() {
-	if (gdtype) {
-#ifdef TOOLS_ENABLED
-		if (!is_placeholder) {
-#endif
-			memdelete(const_cast<GDType *>(gdtype));
-#ifdef TOOLS_ENABLED
-		}
-#endif
-	}
-}
-
 bool Object::Connection::operator<(const Connection &p_conn) const {
 	if (signal == p_conn.signal) {
 		return callable < p_conn.callable;
@@ -658,8 +625,7 @@ bool Object::has_method(const StringName &p_method) const {
 		return true;
 	}
 
-	MethodBind *method = ClassDB::get_method(get_class_name(), p_method);
-	if (method != nullptr) {
+	if (get_gdtype().get_method_map(false).has(p_method)) {
 		return true;
 	}
 
@@ -814,10 +780,10 @@ Variant Object::callp(const StringName &p_method, const Variant **p_args, int p_
 
 	//extension does not need this, because all methods are registered in MethodBind
 
-	MethodBind *method = ClassDB::get_method(get_class_name(), p_method);
+	const MethodBind *const *method = get_gdtype().get_method_map(false).getptr(p_method);
 
 	if (method) {
-		ret = method->call(this, p_args, p_argcount, r_error);
+		ret = (*method)->call(this, p_args, p_argcount, r_error);
 	} else {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
 	}
@@ -858,14 +824,14 @@ Variant Object::call_const(const StringName &p_method, const Variant **p_args, i
 
 	//extension does not need this, because all methods are registered in MethodBind
 
-	MethodBind *method = ClassDB::get_method(get_class_name(), p_method);
+	const MethodBind *const *method = get_gdtype().get_method_map(false).getptr(p_method);
 
 	if (method) {
-		if (!method->is_const()) {
+		if (!(*method)->is_const()) {
 			r_error.error = Callable::CallError::CALL_ERROR_METHOD_NOT_CONST;
 			return ret;
 		}
-		ret = method->call(this, p_args, p_argcount, r_error);
+		ret = (*method)->call(this, p_args, p_argcount, r_error);
 	} else {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
 	}
@@ -2529,8 +2495,8 @@ void ObjectDB::cleanup() {
 			// Ensure calling the native classes because if a leaked instance has a script
 			// that overrides any of those methods, it'd not be OK to call them at this point,
 			// now the scripting languages have already been terminated.
-			MethodBind *node_get_path = ClassDB::get_method("Node", "get_path");
-			MethodBind *resource_get_path = ClassDB::get_method("Resource", "get_path");
+			const MethodBind *node_get_path = ClassDB::get_method("Node", "get_path");
+			const MethodBind *resource_get_path = ClassDB::get_method("Resource", "get_path");
 			Callable::CallError call_error;
 
 			for (uint32_t i = 0, count = slot_count; i < slot_max && count != 0; i++) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -131,11 +131,8 @@ struct ObjectGDExtension {
 
 	/// A type for this Object extension.
 	/// This is not exposed through the GDExtension API (yet) so it is inferred from above parameters.
-	GDType *gdtype;
-	void create_gdtype();
-	void destroy_gdtype();
-
-	~ObjectGDExtension();
+	/// The GDType's lifetime is (usually) owned by ClassDB.
+	const GDType *gdtype = nullptr;
 };
 
 #define GDVIRTUAL_CALL(m_name, ...) _gdvirtual_##m_name##_call(__VA_ARGS__)

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -623,7 +623,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 
 				bool found_type = false;
 				if (getter != StringName()) {
-					MethodBind *mb = ClassDB::get_method(name, getter);
+					const MethodBind *mb = ClassDB::get_method(name, getter);
 					if (mb) {
 						PropertyInfo retinfo = mb->get_return_info();
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -78,7 +78,7 @@ bool GDScriptNativeClass::_get(const StringName &p_name, Variant &r_ret) const {
 		return true;
 	}
 
-	MethodBind *method = ClassDB::get_method(name, p_name);
+	const MethodBind *method = ClassDB::get_method(name, p_name);
 	if (method && method->is_static()) {
 		// Native static method.
 		r_ret = Callable(this, p_name);
@@ -114,7 +114,7 @@ Variant GDScriptNativeClass::callp(const StringName &p_method, const Variant **p
 		return Object::callp(p_method, p_args, p_argcount, r_error);
 	}
 
-	MethodBind *method = ClassDB::get_method(name, p_method);
+	const MethodBind *method = ClassDB::get_method(name, p_method);
 	if (method && method->is_static()) {
 		// Native static method.
 		return method->call(nullptr, p_args, p_argcount, r_error);

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4408,7 +4408,7 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 		MethodInfo method_info;
 		if (ClassDB::has_property(native, name)) {
 			StringName getter_name = ClassDB::get_property_getter(native, name);
-			MethodBind *getter = ClassDB::get_method(native, getter_name);
+			const MethodBind *getter = ClassDB::get_method(native, getter_name);
 			if (getter != nullptr) {
 				bool has_setter = ClassDB::get_property_setter(native, name) != StringName();
 				p_identifier->type_constraint = type_from_property(getter->get_return_info(), false, !has_setter);
@@ -6107,7 +6107,7 @@ bool GDScriptAnalyzer::get_function_signature(GDScriptParser::Node *p_source, bo
 			r_method_flags.set_flag(METHOD_FLAG_STATIC);
 		}
 #ifdef DEBUG_ENABLED
-		MethodBind *native_method = ClassDB::get_method(base_native, function_name);
+		const MethodBind *native_method = ClassDB::get_method(base_native, function_name);
 		if (native_method && r_native_class) {
 			*r_native_class = native_method->get_instance_class();
 		}

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4418,7 +4418,7 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 		MethodInfo method_info;
 		if (ClassDB::has_property(native, name)) {
 			StringName getter_name = ClassDB::get_property_getter(native, name);
-			MethodBind *getter = ClassDB::get_method(native, getter_name);
+			const MethodBind *getter = ClassDB::get_method(native, getter_name);
 			if (getter != nullptr) {
 				bool has_setter = ClassDB::get_property_setter(native, name) != StringName();
 				GDScriptParser::DataType ptype = type_from_property(getter->get_return_info(), false, p_identifier);
@@ -6118,7 +6118,7 @@ bool GDScriptAnalyzer::get_function_signature(GDScriptParser::Node *p_source, bo
 			r_method_flags.set_flag(METHOD_FLAG_STATIC);
 		}
 #ifdef DEBUG_ENABLED
-		MethodBind *native_method = ClassDB::get_method(base_native, function_name);
+		const MethodBind *native_method = ClassDB::get_method(base_native, function_name);
 		if (native_method && r_native_class) {
 			*r_native_class = native_method->get_instance_class();
 		}

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -375,7 +375,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->methods.resize(method_bind_map.size());
 		function->_methods_ptr = function->methods.ptrw();
 		function->_methods_count = method_bind_map.size();
-		for (const KeyValue<MethodBind *, int> &E : method_bind_map) {
+		for (const KeyValue<const MethodBind *, int> &E : method_bind_map) {
 			function->methods.write[E.value] = E.key;
 		}
 	} else {
@@ -1264,7 +1264,7 @@ void GDScriptByteCodeGenerator::write_call_builtin_type_static(const Address &p_
 }
 
 void GDScriptByteCodeGenerator::write_call_native_static(const Address &p_target, const StringName &p_class, const StringName &p_method, const Vector<Address> &p_arguments) {
-	MethodBind *method = ClassDB::get_method(p_class, p_method);
+	const MethodBind *method = ClassDB::get_method(p_class, p_method);
 
 	// Perform regular call.
 	append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL_NATIVE_STATIC, p_arguments.size() + 1);
@@ -1279,7 +1279,7 @@ void GDScriptByteCodeGenerator::write_call_native_static(const Address &p_target
 	return;
 }
 
-void GDScriptByteCodeGenerator::write_call_native_static_validated(const GDScriptCodeGenerator::Address &p_target, MethodBind *p_method, const Vector<GDScriptCodeGenerator::Address> &p_arguments) {
+void GDScriptByteCodeGenerator::write_call_native_static_validated(const GDScriptCodeGenerator::Address &p_target, const MethodBind *p_method, const Vector<GDScriptCodeGenerator::Address> &p_arguments) {
 	Variant::Type return_type = Variant::NIL;
 	bool has_return = p_method->has_return();
 
@@ -1309,7 +1309,7 @@ void GDScriptByteCodeGenerator::write_call_native_static_validated(const GDScrip
 	ct.cleanup();
 }
 
-void GDScriptByteCodeGenerator::write_call_method_bind(const Address &p_target, const Address &p_base, MethodBind *p_method, const Vector<Address> &p_arguments) {
+void GDScriptByteCodeGenerator::write_call_method_bind(const Address &p_target, const Address &p_base, const MethodBind *p_method, const Vector<Address> &p_arguments) {
 	append_opcode_and_argcount(p_target.mode == Address::NIL ? GDScriptFunction::OPCODE_CALL_METHOD_BIND : GDScriptFunction::OPCODE_CALL_METHOD_BIND_RET, 2 + p_arguments.size());
 	for (int i = 0; i < p_arguments.size(); i++) {
 		append(p_arguments[i]);
@@ -1322,7 +1322,7 @@ void GDScriptByteCodeGenerator::write_call_method_bind(const Address &p_target, 
 	ct.cleanup();
 }
 
-void GDScriptByteCodeGenerator::write_call_method_bind_validated(const Address &p_target, const Address &p_base, MethodBind *p_method, const Vector<Address> &p_arguments) {
+void GDScriptByteCodeGenerator::write_call_method_bind_validated(const Address &p_target, const Address &p_base, const MethodBind *p_method, const Vector<Address> &p_arguments) {
 	Variant::Type return_type = Variant::NIL;
 	bool has_return = p_method->has_return();
 

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -113,7 +113,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	RBMap<Variant::ValidatedConstructor, int> constructors_map;
 	RBMap<Variant::ValidatedUtilityFunction, int> utilities_map;
 	RBMap<GDScriptUtilityFunctions::FunctionPtr, int> gds_utilities_map;
-	RBMap<MethodBind *, int> method_bind_map;
+	RBMap<const MethodBind *, int> method_bind_map;
 	RBMap<GDScriptFunction *, int> lambdas_map;
 
 #ifdef DEBUG_ENABLED
@@ -328,7 +328,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 		return pos;
 	}
 
-	int get_method_bind_pos(MethodBind *p_method) {
+	int get_method_bind_pos(const MethodBind *p_method) {
 		if (method_bind_map.has(p_method)) {
 			return method_bind_map[p_method];
 		}
@@ -436,7 +436,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 		opcodes.push_back(get_gds_utility_pos(p_gds_utility));
 	}
 
-	void append(MethodBind *p_method) {
+	void append(const MethodBind *p_method) {
 		opcodes.push_back(get_method_bind_pos(p_method));
 	}
 
@@ -515,9 +515,9 @@ public:
 	virtual void write_call_builtin_type(const Address &p_target, const Address &p_base, Variant::Type p_type, const StringName &p_method, const Vector<Address> &p_arguments) override;
 	virtual void write_call_builtin_type_static(const Address &p_target, Variant::Type p_type, const StringName &p_method, const Vector<Address> &p_arguments) override;
 	virtual void write_call_native_static(const Address &p_target, const StringName &p_class, const StringName &p_method, const Vector<Address> &p_arguments) override;
-	virtual void write_call_native_static_validated(const Address &p_target, MethodBind *p_method, const Vector<Address> &p_arguments) override;
-	virtual void write_call_method_bind(const Address &p_target, const Address &p_base, MethodBind *p_method, const Vector<Address> &p_arguments) override;
-	virtual void write_call_method_bind_validated(const Address &p_target, const Address &p_base, MethodBind *p_method, const Vector<Address> &p_arguments) override;
+	virtual void write_call_native_static_validated(const Address &p_target, const MethodBind *p_method, const Vector<Address> &p_arguments) override;
+	virtual void write_call_method_bind(const Address &p_target, const Address &p_base, const MethodBind *p_method, const Vector<Address> &p_arguments) override;
+	virtual void write_call_method_bind_validated(const Address &p_target, const Address &p_base, const MethodBind *p_method, const Vector<Address> &p_arguments) override;
 	virtual void write_call_self(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) override;
 	virtual void write_call_self_async(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) override;
 	virtual void write_lambda(const Address &p_target, GDScriptFunction *p_function, const Vector<Address> &p_captures, bool p_use_self) override;

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -129,9 +129,9 @@ public:
 	virtual void write_call_builtin_type(const Address &p_target, const Address &p_base, Variant::Type p_type, const StringName &p_method, const Vector<Address> &p_arguments) = 0;
 	virtual void write_call_builtin_type_static(const Address &p_target, Variant::Type p_type, const StringName &p_method, const Vector<Address> &p_arguments) = 0;
 	virtual void write_call_native_static(const Address &p_target, const StringName &p_class, const StringName &p_method, const Vector<Address> &p_arguments) = 0;
-	virtual void write_call_native_static_validated(const Address &p_target, MethodBind *p_method, const Vector<Address> &p_arguments) = 0;
-	virtual void write_call_method_bind(const Address &p_target, const Address &p_base, MethodBind *p_method, const Vector<Address> &p_arguments) = 0;
-	virtual void write_call_method_bind_validated(const Address &p_target, const Address &p_base, MethodBind *p_method, const Vector<Address> &p_arguments) = 0;
+	virtual void write_call_native_static_validated(const Address &p_target, const MethodBind *p_method, const Vector<Address> &p_arguments) = 0;
+	virtual void write_call_method_bind(const Address &p_target, const Address &p_base, const MethodBind *p_method, const Vector<Address> &p_arguments) = 0;
+	virtual void write_call_method_bind_validated(const Address &p_target, const Address &p_base, const MethodBind *p_method, const Vector<Address> &p_arguments) = 0;
 	virtual void write_call_self(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) = 0;
 	virtual void write_call_self_async(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) = 0;
 	virtual void write_lambda(const Address &p_target, GDScriptFunction *p_function, const Vector<Address> &p_captures, bool p_use_self) = 0;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -645,7 +645,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 							// Native method, use faster path.
 							GDScriptCodeGenerator::Address self;
 							self.mode = GDScriptCodeGenerator::Address::SELF;
-							MethodBind *method = ClassDB::get_method(codegen.script->native->get_name(), call->function_name);
+							const MethodBind *method = ClassDB::get_method(codegen.script->native->get_name(), call->function_name);
 
 							if (_can_use_validate_call(method, arguments)) {
 								// Exact arguments, use validated call.
@@ -680,7 +680,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 									static_cast<GDScriptParser::IdentifierNode *>(subscript->base)->source == GDScriptParser::IdentifierNode::NATIVE_CLASS && !Engine::get_singleton()->has_singleton(static_cast<GDScriptParser::IdentifierNode *>(subscript->base)->name)) {
 								// It's a static native method call.
 								StringName class_name = static_cast<GDScriptParser::IdentifierNode *>(subscript->base)->name;
-								MethodBind *method = ClassDB::get_method(class_name, subscript->attribute->name);
+								const MethodBind *method = ClassDB::get_method(class_name, subscript->attribute->name);
 								if (_can_use_validate_call(method, arguments)) {
 									// Exact arguments, use validated call.
 									gen->write_call_native_static_validated(result, method, arguments);
@@ -704,7 +704,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 										class_name = base.type.native_type == StringName() ? base.type.script_type->get_instance_base_type() : base.type.native_type;
 									}
 									if (GDScriptAnalyzer::class_exists(class_name) && ClassDB::has_method(class_name, call->function_name)) {
-										MethodBind *method = ClassDB::get_method(class_name, call->function_name);
+										const MethodBind *method = ClassDB::get_method(class_name, call->function_name);
 										if (_can_use_validate_call(method, arguments)) {
 											// Exact arguments, use validated call.
 											gen->write_call_method_bind_validated(result, base, method, arguments);
@@ -752,7 +752,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 			GDScriptCodeGenerator::Address result = codegen.add_temporary(_gdtype_from_datatype(get_node->type_constraint, codegen.script));
 
-			MethodBind *get_node_method = ClassDB::get_method("Node", "get_node");
+			const MethodBind *get_node_method = ClassDB::get_method("Node", "get_node");
 			gen->write_call_method_bind_validated(result, GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::SELF), get_node_method, args);
 
 			return result;

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -722,7 +722,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 					text += "call-method_bind ";
 				}
 
-				MethodBind *method = _methods_ptr[_code_ptr[ip + 2 + instr_var_args]];
+				const MethodBind *method = _methods_ptr[_code_ptr[ip + 2 + instr_var_args]];
 
 				int argc = _code_ptr[ip + 1 + instr_var_args];
 				if (ret) {
@@ -768,7 +768,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 			} break;
 			case OPCODE_CALL_NATIVE_STATIC: {
 				int instr_var_args = _code_ptr[++ip];
-				MethodBind *method = _methods_ptr[_code_ptr[ip + 1 + instr_var_args]];
+				const MethodBind *method = _methods_ptr[_code_ptr[ip + 1 + instr_var_args]];
 				int argc = _code_ptr[ip + 2 + instr_var_args];
 
 				text += "call native method static ";
@@ -793,7 +793,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 			case OPCODE_CALL_NATIVE_STATIC_VALIDATED_RETURN: {
 				int instr_var_args = _code_ptr[++ip];
 				text += "call native static method validated (return) ";
-				MethodBind *method = _methods_ptr[_code_ptr[ip + 2 + instr_var_args]];
+				const MethodBind *method = _methods_ptr[_code_ptr[ip + 2 + instr_var_args]];
 				int argc = _code_ptr[ip + 1 + instr_var_args];
 				text += DADDR(1 + argc) + " = ";
 				text += method->get_instance_class();
@@ -815,7 +815,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				text += "call native static method validated (no return) ";
 
-				MethodBind *method = _methods_ptr[_code_ptr[ip + 2 + instr_var_args]];
+				const MethodBind *method = _methods_ptr[_code_ptr[ip + 2 + instr_var_args]];
 
 				int argc = _code_ptr[ip + 1 + instr_var_args];
 
@@ -838,7 +838,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 			case OPCODE_CALL_METHOD_BIND_VALIDATED_RETURN: {
 				int instr_var_args = _code_ptr[++ip];
 				text += "call method-bind validated (return) ";
-				MethodBind *method = _methods_ptr[_code_ptr[ip + 2 + instr_var_args]];
+				const MethodBind *method = _methods_ptr[_code_ptr[ip + 2 + instr_var_args]];
 				int argc = _code_ptr[ip + 1 + instr_var_args];
 				text += DADDR(2 + argc) + " = ";
 				text += DADDR(1 + argc) + ".";
@@ -859,7 +859,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				text += "call method-bind validated (no return) ";
 
-				MethodBind *method = _methods_ptr[_code_ptr[ip + 2 + instr_var_args]];
+				const MethodBind *method = _methods_ptr[_code_ptr[ip + 2 + instr_var_args]];
 
 				int argc = _code_ptr[ip + 1 + instr_var_args];
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2732,7 +2732,7 @@ static bool _guess_identifier_type_from_base(GDScriptParser::CompletionContext &
 				if (ClassDB::get_property_info(class_name, p_identifier, &prop)) {
 					StringName getter = ClassDB::get_property_getter(class_name, p_identifier);
 					if (getter != StringName()) {
-						MethodBind *g = ClassDB::get_method(class_name, getter);
+						const MethodBind *g = ClassDB::get_method(class_name, getter);
 						if (g) {
 							r_type = _type_from_property(g->get_return_info());
 							return true;
@@ -2916,7 +2916,7 @@ static bool _guess_method_return_type_from_base(GDScriptParser::CompletionContex
 				if (!GDScriptAnalyzer::class_exists(base_type.native_type)) {
 					return false;
 				}
-				MethodBind *mb = ClassDB::get_method(base_type.native_type, p_method);
+				const MethodBind *mb = ClassDB::get_method(base_type.native_type, p_method);
 				if (mb) {
 					r_type = _type_from_property(mb->get_return_info());
 					return true;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2748,7 +2748,7 @@ static bool _guess_identifier_type_from_base(GDScriptParser::CompletionContext &
 				if (ClassDB::get_property_info(class_name, p_identifier, &prop)) {
 					StringName getter = ClassDB::get_property_getter(class_name, p_identifier);
 					if (getter != StringName()) {
-						MethodBind *g = ClassDB::get_method(class_name, getter);
+						const MethodBind *g = ClassDB::get_method(class_name, getter);
 						if (g) {
 							r_type = _type_from_property(g->get_return_info());
 							return true;
@@ -2932,7 +2932,7 @@ static bool _guess_method_return_type_from_base(GDScriptParser::CompletionContex
 				if (!GDScriptAnalyzer::class_exists(base_type.native_type)) {
 					return false;
 				}
-				MethodBind *mb = ClassDB::get_method(base_type.native_type, p_method);
+				const MethodBind *mb = ClassDB::get_method(base_type.native_type, p_method);
 				if (mb) {
 					r_type = _type_from_property(mb->get_return_info());
 					return true;

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -379,7 +379,7 @@ private:
 	Vector<Variant::ValidatedConstructor> constructors;
 	Vector<Variant::ValidatedUtilityFunction> utilities;
 	Vector<GDScriptUtilityFunctions::FunctionPtr> gds_utilities;
-	Vector<MethodBind *> methods;
+	Vector<const MethodBind *> methods;
 	Vector<GDScriptFunction *> lambdas;
 
 	int _code_size = 0;
@@ -415,7 +415,7 @@ private:
 	const Variant::ValidatedConstructor *_constructors_ptr = nullptr;
 	const Variant::ValidatedUtilityFunction *_utilities_ptr = nullptr;
 	const GDScriptUtilityFunctions::FunctionPtr *_gds_utilities_ptr = nullptr;
-	MethodBind **_methods_ptr = nullptr;
+	const MethodBind *const *_methods_ptr = nullptr;
 	GDScriptFunction **_lambdas_ptr = nullptr;
 
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1948,7 +1948,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 							}
 							base_obj = base->get_validated_object();
 							if (base_obj) {
-								MethodBind *method = ClassDB::get_method(base_obj->get_class_name(), *methodname);
+								const MethodBind *method = ClassDB::get_method(base_obj->get_class_name(), *methodname);
 								if (method && !method->has_return()) {
 									err_text = R"(Trying to get a return value of a method that returns "void")";
 									OPCODE_BREAK;
@@ -2043,7 +2043,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				int argc = _code_ptr[ip + 1];
 				GD_ERR_BREAK(argc < 0);
 				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _methods_count);
-				MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
+				const MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
 
 				GodotProfileZoneScriptSystemCall(method, source, name, method->get_name(), line);
 
@@ -2162,7 +2162,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				ip += instr_arg_count;
 
 				GD_ERR_BREAK(_code_ptr[ip + 1] < 0 || _code_ptr[ip + 1] >= _methods_count);
-				MethodBind *method = _methods_ptr[_code_ptr[ip + 1]];
+				const MethodBind *method = _methods_ptr[_code_ptr[ip + 1]];
 
 				GodotProfileZoneScriptSystemCall(method, source, name, method->get_name(), line);
 
@@ -2212,7 +2212,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(argc < 0);
 
 				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _methods_count);
-				MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
+				const MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
 
 				GodotProfileZoneScriptSystemCall(method, source, name, method->get_name(), line);
 
@@ -2250,7 +2250,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(argc < 0);
 
 				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _methods_count);
-				MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
+				const MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
 
 				GodotProfileZoneScriptSystemCall(method, source, name, method->get_name(), line);
 
@@ -2288,7 +2288,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(argc < 0);
 
 				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _methods_count);
-				MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
+				const MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
 
 				GodotProfileZoneScriptSystemCall(method, source, name, method->get_name(), line);
 
@@ -2342,7 +2342,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(argc < 0);
 
 				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _methods_count);
-				MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
+				const MethodBind *method = _methods_ptr[_code_ptr[ip + 2]];
 
 				GodotProfileZoneScriptSystemCall(method, source, name, method->get_name(), line);
 
@@ -2540,7 +2540,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					*dst = E->value->call(p_instance, (const Variant **)argptrs, argc, err);
 				} else if (gds->native.ptr()) {
 					if (*methodname != GDScriptLanguage::get_singleton()->strings._init) {
-						MethodBind *mb = ClassDB::get_method(gds->native->get_name(), *methodname);
+						const MethodBind *mb = ClassDB::get_method(gds->native->get_name(), *methodname);
 						if (!mb) {
 							err.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
 						} else {

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -58,7 +58,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 			List<StringName> snames;
 
-			for (const KeyValue<StringName, MethodBind *> &F : t->method_map) {
+			for (const KeyValue<StringName, const MethodBind *> &F : t->gdtype->get_method_map(true)) {
 				String name = F.key.string();
 
 				ERR_CONTINUE(name.is_empty());
@@ -78,7 +78,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 				Dictionary method_dict;
 				methods.push_back(method_dict);
 
-				MethodBind *mb = t->method_map[F];
+				const MethodBind *mb = t->gdtype->get_method_map(true)[F];
 				method_dict["name"] = mb->get_name();
 				method_dict["argument_count"] = mb->get_argument_count();
 				method_dict["return_type"] = mb->get_argument_type(-1);

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -4065,7 +4065,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 
 			PropertyInfo return_info = method_info.return_val;
 
-			MethodBind *m = nullptr;
+			const MethodBind *m = nullptr;
 
 			if (!imethod.is_virtual) {
 				bool method_exists = false;

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -4033,7 +4033,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 
 			PropertyInfo return_info = method_info.return_val;
 
-			MethodBind *m = nullptr;
+			const MethodBind *m = nullptr;
 
 			if (!imethod.is_virtual) {
 				bool method_exists = false;

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -66,11 +66,11 @@ bool godotsharp_dotnet_module_is_initialized() {
 	return GDMono::get_singleton()->is_initialized();
 }
 
-MethodBind *godotsharp_method_bind_get_method(const StringName *p_classname, const StringName *p_methodname) {
+const MethodBind *godotsharp_method_bind_get_method(const StringName *p_classname, const StringName *p_methodname) {
 	return ClassDB::get_method(*p_classname, *p_methodname);
 }
 
-MethodBind *godotsharp_method_bind_get_method_with_compatibility(const StringName *p_classname, const StringName *p_methodname, uint64_t p_hash) {
+const MethodBind *godotsharp_method_bind_get_method_with_compatibility(const StringName *p_classname, const StringName *p_methodname, uint64_t p_hash) {
 	return ClassDB::get_method_with_compatibility(*p_classname, *p_methodname, p_hash);
 }
 

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -67,11 +67,11 @@ bool godotsharp_dotnet_module_is_initialized() {
 	return GDMono::get_singleton()->is_initialized();
 }
 
-MethodBind *godotsharp_method_bind_get_method(const StringName *p_classname, const StringName *p_methodname) {
+const MethodBind *godotsharp_method_bind_get_method(const StringName *p_classname, const StringName *p_methodname) {
 	return ClassDB::get_method(*p_classname, *p_methodname);
 }
 
-MethodBind *godotsharp_method_bind_get_method_with_compatibility(const StringName *p_classname, const StringName *p_methodname, uint64_t p_hash) {
+const MethodBind *godotsharp_method_bind_get_method_with_compatibility(const StringName *p_classname, const StringName *p_methodname, uint64_t p_hash) {
 	return ClassDB::get_method_with_compatibility(*p_classname, *p_methodname, p_hash);
 }
 

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -52,6 +52,14 @@ RID Occluder3D::get_rid() const {
 	return occluder;
 }
 
+void Occluder3D::_bind_methods() {
+	// TODO Note: These used to be bound in ArrayOccluder3D::_bind_methods, indicating they
+	//            were originally meant to be exposed to ArrayOccluder3D instead of Occluder3D.
+	//            This should be investigated, to either move the binding or remove this comment.
+	ClassDB::bind_method(D_METHOD("get_vertices"), &Occluder3D::get_vertices);
+	ClassDB::bind_method(D_METHOD("get_indices"), &Occluder3D::get_indices);
+}
+
 void Occluder3D::_update() {
 	_update_arrays(vertices, indices);
 
@@ -172,10 +180,7 @@ void ArrayOccluder3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_arrays", "vertices", "indices"), &ArrayOccluder3D::set_arrays);
 
 	ClassDB::bind_method(D_METHOD("set_vertices", "vertices"), &ArrayOccluder3D::set_vertices);
-	ClassDB::bind_method(D_METHOD("get_vertices"), &ArrayOccluder3D::get_vertices);
-
 	ClassDB::bind_method(D_METHOD("set_indices", "indices"), &ArrayOccluder3D::set_indices);
-	ClassDB::bind_method(D_METHOD("get_indices"), &ArrayOccluder3D::get_indices);
 
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR3_ARRAY, "vertices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_vertices", "get_vertices");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "indices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_indices", "get_indices");

--- a/scene/3d/occluder_instance_3d.h
+++ b/scene/3d/occluder_instance_3d.h
@@ -47,6 +47,8 @@ class Occluder3D : public Resource {
 	mutable Vector<Vector3> debug_lines;
 
 protected:
+	static void _bind_methods();
+
 	void _update();
 	virtual void _update_arrays(PackedVector3Array &r_vertices, PackedInt32Array &r_indices) = 0;
 

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -185,6 +185,11 @@ void VisualInstance3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_sorting_use_aabb_center", "enabled"), &VisualInstance3D::set_sorting_use_aabb_center);
 	ClassDB::bind_method(D_METHOD("is_sorting_use_aabb_center"), &VisualInstance3D::is_sorting_use_aabb_center);
 
+	// TODO Note: This used to be bound in GeometryInstance3D::_bind_methods, indicating it
+	//            was originally meant to be exposed to GeometryInstance3D instead of VisualInstance3D.
+	//            This should be investigated, to either move the binding or remove this comment.
+	ClassDB::bind_method(D_METHOD("get_aabb"), &VisualInstance3D::get_aabb);
+
 	GDVIRTUAL_BIND(_get_aabb);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "layers", PROPERTY_HINT_LAYERS_3D_RENDER), "set_layer_mask", "get_layer_mask");
 
@@ -598,8 +603,6 @@ void GeometryInstance3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_custom_aabb", "aabb"), &GeometryInstance3D::set_custom_aabb);
 	ClassDB::bind_method(D_METHOD("get_custom_aabb"), &GeometryInstance3D::get_custom_aabb);
-
-	ClassDB::bind_method(D_METHOD("get_aabb"), &GeometryInstance3D::get_aabb);
 
 	ADD_GROUP("Geometry", "");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material_override", PROPERTY_HINT_RESOURCE_TYPE, "BaseMaterial3D,ShaderMaterial", PROPERTY_USAGE_DEFAULT), "set_material_override", "get_material_override");

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -2552,6 +2552,12 @@ void AnimationMixer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_reset"), &AnimationMixer::reset);
 	ClassDB::bind_method(D_METHOD("_restore", "backup"), &AnimationMixer::restore);
+
+	// TODO Note: These used to be bound in AnimationPlayer::_bind_methods, indicating it
+	//            was originally meant to be exposed to AnimationPlayer instead of AnimationMixer.
+	//            This should be investigated, to either move the binding or remove this comment.
+	ClassDB::bind_method(D_METHOD("find_animation", "animation"), &AnimationMixer::find_animation);
+	ClassDB::bind_method(D_METHOD("find_animation_library", "animation"), &AnimationMixer::find_animation_library);
 }
 
 AnimationMixer::AnimationMixer() {

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1040,9 +1040,6 @@ void AnimationPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_autoplay", "name"), &AnimationPlayer::set_autoplay);
 	ClassDB::bind_method(D_METHOD("get_autoplay"), &AnimationPlayer::get_autoplay);
 
-	ClassDB::bind_method(D_METHOD("find_animation", "animation"), &AnimationPlayer::find_animation);
-	ClassDB::bind_method(D_METHOD("find_animation_library", "animation"), &AnimationPlayer::find_animation_library);
-
 	ClassDB::bind_method(D_METHOD("set_movie_quit_on_finish_enabled", "enabled"), &AnimationPlayer::set_movie_quit_on_finish_enabled);
 	ClassDB::bind_method(D_METHOD("is_movie_quit_on_finish_enabled"), &AnimationPlayer::is_movie_quit_on_finish_enabled);
 

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -828,6 +828,16 @@ void Mesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("surface_get_material", "surf_idx"), &Mesh::surface_get_material);
 	ClassDB::bind_method(D_METHOD("create_placeholder"), &Mesh::create_placeholder);
 
+	// TODO Note: These used to be bound in ArrayMesh::_bind_methods, indicating they
+	//            were originally meant to be exposed to ArrayMesh instead of Mesh.
+	//            This should be investigated, to either move the bindings or remove this comment.
+	ClassDB::bind_method(D_METHOD("create_outline", "margin"), &Mesh::create_outline);
+	ClassDB::bind_method(D_METHOD("generate_triangle_mesh"), &Mesh::generate_triangle_mesh);
+#ifndef PHYSICS_3D_DISABLED
+	ClassDB::bind_method(D_METHOD("create_trimesh_shape"), &Mesh::create_trimesh_shape);
+	ClassDB::bind_method(D_METHOD("create_convex_shape", "clean", "simplify"), &Mesh::create_convex_shape, DEFVAL(true), DEFVAL(false));
+#endif
+
 	BIND_ENUM_CONSTANT(PRIMITIVE_POINTS);
 	BIND_ENUM_CONSTANT(PRIMITIVE_LINES);
 	BIND_ENUM_CONSTANT(PRIMITIVE_LINE_STRIP);
@@ -2310,16 +2320,10 @@ void ArrayMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("surface_find_by_name", "name"), &ArrayMesh::surface_find_by_name);
 	ClassDB::bind_method(D_METHOD("surface_set_name", "surf_idx", "name"), &ArrayMesh::surface_set_name);
 	ClassDB::bind_method(D_METHOD("surface_get_name", "surf_idx"), &ArrayMesh::surface_get_name);
-#ifndef PHYSICS_3D_DISABLED
-	ClassDB::bind_method(D_METHOD("create_trimesh_shape"), &ArrayMesh::create_trimesh_shape);
-	ClassDB::bind_method(D_METHOD("create_convex_shape", "clean", "simplify"), &ArrayMesh::create_convex_shape, DEFVAL(true), DEFVAL(false));
-#endif // PHYSICS_3D_DISABLED
-	ClassDB::bind_method(D_METHOD("create_outline", "margin"), &ArrayMesh::create_outline);
 	ClassDB::bind_method(D_METHOD("regen_normal_maps"), &ArrayMesh::regen_normal_maps);
 	ClassDB::set_method_flags(get_class_static(), StringName("regen_normal_maps"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 	ClassDB::bind_method(D_METHOD("lightmap_unwrap", "transform", "texel_size"), &ArrayMesh::lightmap_unwrap);
 	ClassDB::set_method_flags(get_class_static(), StringName("lightmap_unwrap"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
-	ClassDB::bind_method(D_METHOD("generate_triangle_mesh"), &ArrayMesh::generate_triangle_mesh);
 
 	ClassDB::bind_method(D_METHOD("set_custom_aabb", "aabb"), &ArrayMesh::set_custom_aabb);
 	ClassDB::bind_method(D_METHOD("get_custom_aabb"), &ArrayMesh::get_custom_aabb);

--- a/tests/core/object/test_class_db.cpp
+++ b/tests/core/object/test_class_db.cpp
@@ -603,7 +603,7 @@ void add_exposed_classes(Context &r_context) {
 
 			PropertyInfo return_info = method_info.return_val;
 
-			MethodBind *m = method.is_virtual ? nullptr : ClassDB::get_method(class_name, method_info.name);
+			const MethodBind *m = method.is_virtual ? nullptr : ClassDB::get_method(class_name, method_info.name);
 
 			method.is_vararg = m && m->is_vararg();
 


### PR DESCRIPTION
- Follow-up of #113586 
- Follow-up of https://github.com/godotengine/godot/pull/117474
- Works towards https://github.com/godotengine/godot-proposals/issues/12323

Moves `MethodBind` maps from `ClassDB` to `GDType`, to make access more efficient and to consolidate typing.

This one is not as trivial as https://github.com/godotengine/godot/pull/117474 (some decisions which I'm commenting below), but also not nearly as complicated as #113586. Overall, it should be relatively painless with targeted reviews :)

### Notes

One thing of note is that a few classes currently accidentally bind the methods of supertypes (to the supertypes). For example:

https://github.com/godotengine/godot/blob/456bdea954ee24e48cb562bfbf531de1cd96e371/scene/resources/mesh.cpp#L2318

Can be seen in the docs under `Mesh` instead of `ArrayMesh`:

[docs.godotengine.org/en/stable/classes/class_mesh.html#class-mesh-method-create-trimesh-shape](https://docs.godotengine.org/en/stable/classes/class_mesh.html#class-mesh-method-create-trimesh-shape)

This doesn't work anymore with the new approach, because `GDType` is finalized after `_bind_methods`.
To fix the specific issues, I decided to do the agnostic thing and move the bindings to where they're bound anyway (a practical no-op), with a comment for follow-ups to decide how to address it properly.