### PR TITLE
Dynamically check for 3D editor snapping state

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -1766,7 +1766,7 @@ void Node3DEditorViewport::_transform_gizmo_apply(Node3D *p_node, const Transfor
 Transform3D Node3DEditorViewport::_compute_transform(TransformMode p_mode, const Transform3D &p_original, const Transform3D &p_original_local, Vector3 p_motion, double p_extra, bool p_local, bool p_orthogonal, bool p_view_axis) {
 	switch (p_mode) {
 		case TRANSFORM_SCALE: {
-			if (_edit.snap || spatial_editor->is_snap_enabled()) {
+			if (spatial_editor->is_snap_enabled()) {
 				p_motion.snapf(p_extra);
 			}
 			Transform3D s;
@@ -1787,7 +1787,7 @@ Transform3D Node3DEditorViewport::_compute_transform(TransformMode p_mode, const
 			return s;
 		}
 		case TRANSFORM_TRANSLATE: {
-			if (_edit.snap || spatial_editor->is_snap_enabled()) {
+			if (spatial_editor->is_snap_enabled()) {
 				p_motion.snapf(p_extra);
 			}
 
@@ -2290,7 +2290,6 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 					_edit.mouse_pos = b->get_position();
 					_edit.original_mouse_pos = b->get_position();
-					_edit.snap = spatial_editor->is_snap_enabled();
 					_edit.mode = TRANSFORM_NONE;
 					_edit.original = spatial_editor->get_gizmo_transform(); // To prevent to break when flipping with scale.
 
@@ -2792,11 +2791,6 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 				}
 				accept_event();
 				return;
-			}
-		}
-		if (ED_IS_SHORTCUT("spatial_editor/snap", event_mod)) {
-			if (_edit.mode != TRANSFORM_NONE) {
-				_edit.snap = !_edit.snap;
 			}
 		}
 		if (ED_IS_SHORTCUT("spatial_editor/bottom_view", event_mod)) {
@@ -5754,7 +5748,6 @@ void Node3DEditorViewport::begin_transform(TransformMode p_mode, bool instant) {
 		_edit.mode = p_mode;
 		_compute_edit(_edit.mouse_pos);
 		_edit.instant = instant;
-		_edit.snap = spatial_editor->is_snap_enabled();
 		_edit.initial_click_vector = Vector3();
 		_edit.previous_rotation_vector = Vector3();
 		_edit.accumulated_rotation_angle = 0.0;
@@ -5958,7 +5951,7 @@ void Node3DEditorViewport::update_transform(bool p_shift) {
 
 			motion /= click.distance_to(_edit.center);
 
-			if (_edit.snap || spatial_editor->is_snap_enabled()) {
+			if (spatial_editor->is_snap_enabled()) {
 				snap = spatial_editor->get_scale_snap() / 100;
 			}
 			Vector3 motion_snapped = motion;
@@ -6026,7 +6019,7 @@ void Node3DEditorViewport::update_transform(bool p_shift) {
 				}
 			}
 
-			if (_edit.snap || spatial_editor->is_snap_enabled()) {
+			if (spatial_editor->is_snap_enabled()) {
 				snap = spatial_editor->get_translate_snap();
 			}
 			Vector3 motion_snapped = motion;
@@ -6067,8 +6060,7 @@ void Node3DEditorViewport::update_transform(bool p_shift) {
 				if (rotation_angle > 0.0f) {
 					rotation_axis /= rotation_angle;
 
-					bool snapping = _edit.snap || spatial_editor->is_snap_enabled();
-					if (snapping) {
+					if (spatial_editor->is_snap_enabled()) {
 						double snap_step = spatial_editor->get_rotate_snap();
 						double angle_deg = Math::rad_to_deg(rotation_angle);
 						angle_deg = Math::snapped(angle_deg, snap_step);
@@ -6143,8 +6135,7 @@ void Node3DEditorViewport::update_transform(bool p_shift) {
 			}
 			_edit.previous_rotation_vector = current_rotation_vector;
 
-			bool snapping = _edit.snap || spatial_editor->is_snap_enabled();
-			if (snapping) {
+			if (spatial_editor->is_snap_enabled()) {
 				snap = spatial_editor->get_rotate_snap();
 				snap_step_decimals = Math::range_step_decimals(snap);
 			}
@@ -6155,12 +6146,12 @@ void Node3DEditorViewport::update_transform(bool p_shift) {
 				Vector3 delta = intersection - click;
 				float projection = delta.dot(projection_axis);
 				double orth_angle = (projection * (Math::PI / 2.0f)) / (gizmo_scale * GIZMO_CIRCLE_SIZE);
-				_edit.rotation_angle = snapping
+				_edit.rotation_angle = spatial_editor->is_snap_enabled()
 						? Math::deg_to_rad(Math::snapped(Math::rad_to_deg(orth_angle), snap))
 						: orth_angle;
 			} else {
 				_edit.show_rotation_line = true;
-				_edit.rotation_angle = snapping
+				_edit.rotation_angle = spatial_editor->is_snap_enabled()
 						? Math::deg_to_rad(Math::snapped(Math::rad_to_deg(_edit.accumulated_rotation_angle), snap))
 						: _edit.accumulated_rotation_angle;
 			}
@@ -6328,7 +6319,6 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 
 	_edit.mode = TRANSFORM_NONE;
 	_edit.plane = TRANSFORM_VIEW;
-	_edit.snap = true;
 	_edit.show_rotation_line = true;
 	_edit.instant = false;
 	_edit.gizmo_handle = -1;

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -353,7 +353,6 @@ private:
 		Vector3 center;
 		Point2 mouse_pos;
 		Point2 original_mouse_pos;
-		bool snap = false;
 		bool show_rotation_line = false;
 		bool is_trackball = false;
 		Ref<EditorNode3DGizmo> gizmo;


### PR DESCRIPTION
This change simplifies the check for snapping when we're editing the transform of a `Node3D`. It should address godotengine/godot#117497.

*Bugsquad edit:* Fixes #117497.

As of writing, we only update `Node3DEditorViewport::EditData::snap` in `Node3DEditorViewport::begin_transform`. This works well when the user toggles snapping before modifying a `Node3D`'s transform.

That said, if the user is pressing and releasing the Ctrl/Cmd key while adjusting a transform, snapping won't necessarily enable/disable.

~~To address this, we update the state of `snap` in `Node3DEditorViewport::update_transform`. This allows the user to toggle snapping while adjusting a `Node3D`'s transform.~~

We now check the snapping state dynamically. See [below](https://github.com/godotengine/godot/pull/117606#issuecomment-4094744134).

## Notes
No generative AI was used in the research, development, or testing of this PR's changes.