### PR TITLE
Fix NavigationLink connection building with multiple NavigationRegions

### DIFF
--- a/modules/navigation_2d/2d/nav_map_builder_2d.cpp
+++ b/modules/navigation_2d/2d/nav_map_builder_2d.cpp
@@ -280,34 +280,45 @@ void NavMapBuilder2D::_build_step_navlink_connections(NavMapIterationBuild2D &r_
 
 	HashMap<const NavBaseIteration2D *, LocalVector<LocalVector<Nav2D::Connection>>> &navbases_polygons_external_connections = map_iteration->navbases_polygons_external_connections;
 	LocalVector<Nav2D::Polygon> &navlink_polygons = map_iteration->navlink_polygons;
-	navlink_polygons.clear();
-	navlink_polygons.resize(links.size());
+	navlink_polygons.clear(); // navlink_polygons must not be resized after use because we are storing pointers to its elements.
 	uint32_t navlink_index = 0;
 
-	// Search for polygons within range of a nav link.
-	for (const Ref<NavLinkIteration2D> &link : links) {
-		polygon_count++;
-		Polygon &new_polygon = navlink_polygons[navlink_index++];
+	// We don't know how many navlink polygons we will need, so hold all the data in these vectors until we do
+	LocalVector<LocalVector<Nav2D::Polygon *>> link_start_polygons = LocalVector<LocalVector<Nav2D::Polygon *>>();
+	link_start_polygons.resize(links.size());
+	LocalVector<LocalVector<Vector2>> link_start_points = LocalVector<LocalVector<Vector2>>();
+	link_start_points.resize(links.size());
+	LocalVector<LocalVector<Nav2D::Polygon *>> link_end_polygons = LocalVector<LocalVector<Nav2D::Polygon *>>();
+	link_end_polygons.resize(links.size());
+	LocalVector<LocalVector<Vector2>> link_end_points = LocalVector<LocalVector<Vector2>>();
+	link_end_points.resize(links.size());
 
-		new_polygon.id = 0;
-		new_polygon.owner = link.ptr();
+	// Search for polygons within range of a nav link.
+	uint32_t link_index = 0;
+	for (const Ref<NavLinkIteration2D> &link : links) {
+		LocalVector<Nav2D::Polygon *> &start_polygons = link_start_polygons[link_index];
+		LocalVector<Vector2> &closest_start_points = link_start_points[link_index];
+		LocalVector<Nav2D::Polygon *> &end_polygons = link_end_polygons[link_index];
+		LocalVector<Vector2> &closest_end_points = link_end_points[link_index];
+		link_index++;
 
 		const Vector2 link_start_pos = link->get_start_position();
 		const Vector2 link_end_pos = link->get_end_position();
 
-		Polygon *closest_start_polygon = nullptr;
-		real_t closest_start_sqr_dist = link_connection_radius_sqr;
-		Vector2 closest_start_point;
-
-		Polygon *closest_end_polygon = nullptr;
-		real_t closest_end_sqr_dist = link_connection_radius_sqr;
-		Vector2 closest_end_point;
-
 		for (const Ref<NavRegionIteration2D> &region : map_iteration->region_iterations) {
 			Rect2 region_bounds = region->get_bounds().grow(link_connection_radius);
-			if (!region_bounds.has_point(link_start_pos) && !region_bounds.has_point(link_end_pos)) {
+			if ((!region_bounds.has_point(link_start_pos) && !region_bounds.has_point(link_end_pos)) ||
+					((region->navigation_layers & link->navigation_layers) == 0)) {
 				continue;
 			}
+
+			Polygon *closest_start_polygon = nullptr;
+			real_t closest_start_sqr_dist = link_connection_radius_sqr;
+			Vector2 closest_start_point;
+
+			Polygon *closest_end_polygon = nullptr;
+			real_t closest_end_sqr_dist = link_connection_radius_sqr;
+			Vector2 closest_end_point;
 
 			for (Polygon &polyon : region->navmesh_polygons) {
 				for (uint32_t point_id = 2; point_id < polyon.vertices.size(); point_id += 1) {
@@ -338,52 +349,89 @@ void NavMapBuilder2D::_build_step_navlink_connections(NavMapIterationBuild2D &r_
 					}
 				}
 			}
-		}
 
-		// If we have both a start and end point, then create a synthetic polygon to route through.
-		if (closest_start_polygon && closest_end_polygon) {
-			new_polygon.vertices.resize(4);
-
-			// Build a set of vertices that create a thin polygon going from the start to the end point.
-			new_polygon.vertices[0] = closest_start_point;
-			new_polygon.vertices[1] = closest_start_point;
-			new_polygon.vertices[2] = closest_end_point;
-			new_polygon.vertices[3] = closest_end_point;
-
-			// Setup connections to go forward in the link.
-			{
-				Connection entry_connection;
-				entry_connection.polygon = &new_polygon;
-				entry_connection.edge = -1;
-				entry_connection.pathway_start = new_polygon.vertices[0];
-				entry_connection.pathway_end = new_polygon.vertices[1];
-				navbases_polygons_external_connections[closest_start_polygon->owner][closest_start_polygon->id].push_back(entry_connection);
-
-				Connection exit_connection;
-				exit_connection.polygon = closest_end_polygon;
-				exit_connection.edge = -1;
-				exit_connection.pathway_start = new_polygon.vertices[2];
-				exit_connection.pathway_end = new_polygon.vertices[3];
-				navbases_polygons_external_connections[link.ptr()].push_back(LocalVector<Nav2D::Connection>());
-				navbases_polygons_external_connections[link.ptr()][new_polygon.id].push_back(exit_connection);
+			if (closest_start_polygon) {
+				start_polygons.push_back(closest_start_polygon);
+				closest_start_points.push_back(closest_start_point);
 			}
+			if (closest_end_polygon) {
+				end_polygons.push_back(closest_end_polygon);
+				closest_end_points.push_back(closest_end_point);
+			}
+		}
+	}
 
-			// If the link is bi-directional, create connections from the end to the start.
-			if (link->is_bidirectional()) {
-				Connection entry_connection;
-				entry_connection.polygon = &new_polygon;
-				entry_connection.edge = -1;
-				entry_connection.pathway_start = new_polygon.vertices[2];
-				entry_connection.pathway_end = new_polygon.vertices[3];
-				navbases_polygons_external_connections[closest_end_polygon->owner][closest_end_polygon->id].push_back(entry_connection);
+	// Calculate how many navlink polygons we need and resize the vector once before using it.
+	uint32_t navlink_polygon_count = 0;
+	for (uint32_t i = 0; i < link_start_polygons.size(); i++) {
+		navlink_polygon_count += link_start_polygons[i].size() * link_end_polygons[i].size();
+	}
+	navlink_polygons.resize(navlink_polygon_count);
+	polygon_count += navlink_polygon_count;
 
-				Connection exit_connection;
-				exit_connection.polygon = closest_start_polygon;
-				exit_connection.edge = -1;
-				exit_connection.pathway_start = new_polygon.vertices[0];
-				exit_connection.pathway_end = new_polygon.vertices[1];
-				navbases_polygons_external_connections[link.ptr()].push_back(LocalVector<Nav2D::Connection>());
-				navbases_polygons_external_connections[link.ptr()][new_polygon.id].push_back(exit_connection);
+	link_index = 0;
+	for (const Ref<NavLinkIteration2D> &link : links) {
+		LocalVector<Nav2D::Polygon *> &start_polygons = link_start_polygons[link_index];
+		LocalVector<Vector2> &closest_start_points = link_start_points[link_index];
+		LocalVector<Nav2D::Polygon *> &end_polygons = link_end_polygons[link_index];
+		LocalVector<Vector2> &closest_end_points = link_end_points[link_index];
+		link_index++;
+
+		uint32_t new_polygon_id = 0;
+
+		for (uint32_t i = 0; i < start_polygons.size(); i++) {
+			for (uint32_t j = 0; j < end_polygons.size(); j++) {
+				Polygon *closest_start_polygon = start_polygons[i];
+				Vector2 closest_start_point = closest_start_points[i];
+				Polygon *closest_end_polygon = end_polygons[j];
+				Vector2 closest_end_point = closest_end_points[j];
+
+				// If we have both a start and end point, then create a synthetic polygon to route through.
+				Polygon &new_polygon = navlink_polygons[navlink_index++];
+				new_polygon.id = new_polygon_id++;
+				new_polygon.owner = link.ptr();
+				new_polygon.vertices.resize(4);
+
+				// Build a set of vertices that create a thin polygon going from the start to the end point.
+				new_polygon.vertices[0] = closest_start_point;
+				new_polygon.vertices[1] = closest_start_point;
+				new_polygon.vertices[2] = closest_end_point;
+				new_polygon.vertices[3] = closest_end_point;
+
+				// Setup connections to go forward in the link.
+				{
+					Connection entry_connection;
+					entry_connection.polygon = &new_polygon;
+					entry_connection.edge = -1;
+					entry_connection.pathway_start = new_polygon.vertices[0];
+					entry_connection.pathway_end = new_polygon.vertices[1];
+					navbases_polygons_external_connections[closest_start_polygon->owner][closest_start_polygon->id].push_back(entry_connection);
+
+					Connection exit_connection;
+					exit_connection.polygon = closest_end_polygon;
+					exit_connection.edge = -1;
+					exit_connection.pathway_start = new_polygon.vertices[2];
+					exit_connection.pathway_end = new_polygon.vertices[3];
+					navbases_polygons_external_connections[link.ptr()].push_back(LocalVector<Nav2D::Connection>());
+					navbases_polygons_external_connections[link.ptr()][new_polygon.id].push_back(exit_connection);
+				}
+
+				// If the link is bi-directional, create connections from the end to the start.
+				if (link->is_bidirectional()) {
+					Connection entry_connection;
+					entry_connection.polygon = &new_polygon;
+					entry_connection.edge = -1;
+					entry_connection.pathway_start = new_polygon.vertices[2];
+					entry_connection.pathway_end = new_polygon.vertices[3];
+					navbases_polygons_external_connections[closest_end_polygon->owner][closest_end_polygon->id].push_back(entry_connection);
+
+					Connection exit_connection;
+					exit_connection.polygon = closest_start_polygon;
+					exit_connection.edge = -1;
+					exit_connection.pathway_start = new_polygon.vertices[0];
+					exit_connection.pathway_end = new_polygon.vertices[1];
+					navbases_polygons_external_connections[link.ptr()][new_polygon.id].push_back(exit_connection);
+				}
 			}
 		}
 	}

--- a/modules/navigation_3d/3d/nav_map_builder_3d.cpp
+++ b/modules/navigation_3d/3d/nav_map_builder_3d.cpp
@@ -281,34 +281,45 @@ void NavMapBuilder3D::_build_step_navlink_connections(NavMapIterationBuild3D &r_
 
 	HashMap<const NavBaseIteration3D *, LocalVector<LocalVector<Nav3D::Connection>>> &navbases_polygons_external_connections = map_iteration->navbases_polygons_external_connections;
 	LocalVector<Nav3D::Polygon> &navlink_polygons = map_iteration->navlink_polygons;
-	navlink_polygons.clear();
-	navlink_polygons.resize(links.size());
+	navlink_polygons.clear(); // navlink_polygons must not be resized after use because we are storing pointers to its elements.
 	uint32_t navlink_index = 0;
 
-	// Search for polygons within range of a nav link.
-	for (const Ref<NavLinkIteration3D> &link : links) {
-		polygon_count++;
-		Polygon &new_polygon = navlink_polygons[navlink_index++];
+	// We don't know how many navlink polygons we will need, so hold all the data in these vectors until we do
+	LocalVector<LocalVector<Nav3D::Polygon *>> link_start_polygons = LocalVector<LocalVector<Nav3D::Polygon *>>();
+	link_start_polygons.resize(links.size());
+	LocalVector<LocalVector<Vector3>> link_start_points = LocalVector<LocalVector<Vector3>>();
+	link_start_points.resize(links.size());
+	LocalVector<LocalVector<Nav3D::Polygon *>> link_end_polygons = LocalVector<LocalVector<Nav3D::Polygon *>>();
+	link_end_polygons.resize(links.size());
+	LocalVector<LocalVector<Vector3>> link_end_points = LocalVector<LocalVector<Vector3>>();
+	link_end_points.resize(links.size());
 
-		new_polygon.id = 0;
-		new_polygon.owner = link.ptr();
+	// Search for polygons within range of a nav link.
+	uint32_t link_index = 0;
+	for (const Ref<NavLinkIteration3D> &link : links) {
+		LocalVector<Nav3D::Polygon *> &start_polygons = link_start_polygons[link_index];
+		LocalVector<Vector3> &closest_start_points = link_start_points[link_index];
+		LocalVector<Nav3D::Polygon *> &end_polygons = link_end_polygons[link_index];
+		LocalVector<Vector3> &closest_end_points = link_end_points[link_index];
+		link_index++;
 
 		const Vector3 link_start_pos = link->get_start_position();
 		const Vector3 link_end_pos = link->get_end_position();
 
-		Polygon *closest_start_polygon = nullptr;
-		real_t closest_start_sqr_dist = link_connection_radius_sqr;
-		Vector3 closest_start_point;
-
-		Polygon *closest_end_polygon = nullptr;
-		real_t closest_end_sqr_dist = link_connection_radius_sqr;
-		Vector3 closest_end_point;
-
 		for (const Ref<NavRegionIteration3D> &region : map_iteration->region_iterations) {
 			AABB region_bounds = region->get_bounds().grow(link_connection_radius);
-			if (!region_bounds.has_point(link_start_pos) && !region_bounds.has_point(link_end_pos)) {
+			if ((!region_bounds.has_point(link_start_pos) && !region_bounds.has_point(link_end_pos)) ||
+					((region->navigation_layers & link->navigation_layers) == 0)) {
 				continue;
 			}
+
+			Polygon *closest_start_polygon = nullptr;
+			real_t closest_start_sqr_dist = link_connection_radius_sqr;
+			Vector3 closest_start_point;
+
+			Polygon *closest_end_polygon = nullptr;
+			real_t closest_end_sqr_dist = link_connection_radius_sqr;
+			Vector3 closest_end_point;
 
 			for (Polygon &polyon : region->navmesh_polygons) {
 				for (uint32_t point_id = 2; point_id < polyon.vertices.size(); point_id += 1) {
@@ -339,52 +350,89 @@ void NavMapBuilder3D::_build_step_navlink_connections(NavMapIterationBuild3D &r_
 					}
 				}
 			}
-		}
 
-		// If we have both a start and end point, then create a synthetic polygon to route through.
-		if (closest_start_polygon && closest_end_polygon) {
-			new_polygon.vertices.resize(4);
-
-			// Build a set of vertices that create a thin polygon going from the start to the end point.
-			new_polygon.vertices[0] = closest_start_point;
-			new_polygon.vertices[1] = closest_start_point;
-			new_polygon.vertices[2] = closest_end_point;
-			new_polygon.vertices[3] = closest_end_point;
-
-			// Setup connections to go forward in the link.
-			{
-				Connection entry_connection;
-				entry_connection.polygon = &new_polygon;
-				entry_connection.edge = -1;
-				entry_connection.pathway_start = new_polygon.vertices[0];
-				entry_connection.pathway_end = new_polygon.vertices[1];
-				navbases_polygons_external_connections[closest_start_polygon->owner][closest_start_polygon->id].push_back(entry_connection);
-
-				Connection exit_connection;
-				exit_connection.polygon = closest_end_polygon;
-				exit_connection.edge = -1;
-				exit_connection.pathway_start = new_polygon.vertices[2];
-				exit_connection.pathway_end = new_polygon.vertices[3];
-				navbases_polygons_external_connections[link.ptr()].push_back(LocalVector<Nav3D::Connection>());
-				navbases_polygons_external_connections[link.ptr()][new_polygon.id].push_back(exit_connection);
+			if (closest_start_polygon) {
+				start_polygons.push_back(closest_start_polygon);
+				closest_start_points.push_back(closest_start_point);
 			}
+			if (closest_end_polygon) {
+				end_polygons.push_back(closest_end_polygon);
+				closest_end_points.push_back(closest_end_point);
+			}
+		}
+	}
 
-			// If the link is bi-directional, create connections from the end to the start.
-			if (link->is_bidirectional()) {
-				Connection entry_connection;
-				entry_connection.polygon = &new_polygon;
-				entry_connection.edge = -1;
-				entry_connection.pathway_start = new_polygon.vertices[2];
-				entry_connection.pathway_end = new_polygon.vertices[3];
-				navbases_polygons_external_connections[closest_end_polygon->owner][closest_end_polygon->id].push_back(entry_connection);
+	// Calculate how many navlink polygons we need and resize the vector once before using it.
+	uint32_t navlink_polygon_count = 0;
+	for (uint32_t i = 0; i < link_start_polygons.size(); i++) {
+		navlink_polygon_count += link_start_polygons[i].size() * link_end_polygons[i].size();
+	}
+	navlink_polygons.resize(navlink_polygon_count);
+	polygon_count += navlink_polygon_count;
 
-				Connection exit_connection;
-				exit_connection.polygon = closest_start_polygon;
-				exit_connection.edge = -1;
-				exit_connection.pathway_start = new_polygon.vertices[0];
-				exit_connection.pathway_end = new_polygon.vertices[1];
-				navbases_polygons_external_connections[link.ptr()].push_back(LocalVector<Nav3D::Connection>());
-				navbases_polygons_external_connections[link.ptr()][new_polygon.id].push_back(exit_connection);
+	link_index = 0;
+	for (const Ref<NavLinkIteration3D> &link : links) {
+		LocalVector<Nav3D::Polygon *> &start_polygons = link_start_polygons[link_index];
+		LocalVector<Vector3> &closest_start_points = link_start_points[link_index];
+		LocalVector<Nav3D::Polygon *> &end_polygons = link_end_polygons[link_index];
+		LocalVector<Vector3> &closest_end_points = link_end_points[link_index];
+		link_index++;
+
+		uint32_t new_polygon_id = 0;
+
+		for (uint32_t i = 0; i < start_polygons.size(); i++) {
+			for (uint32_t j = 0; j < end_polygons.size(); j++) {
+				Polygon *closest_start_polygon = start_polygons[i];
+				Vector3 closest_start_point = closest_start_points[i];
+				Polygon *closest_end_polygon = end_polygons[j];
+				Vector3 closest_end_point = closest_end_points[j];
+
+				// If we have both a start and end point, then create a synthetic polygon to route through.
+				Polygon &new_polygon = navlink_polygons[navlink_index++];
+				new_polygon.id = new_polygon_id++;
+				new_polygon.owner = link.ptr();
+				new_polygon.vertices.resize(4);
+
+				// Build a set of vertices that create a thin polygon going from the start to the end point.
+				new_polygon.vertices[0] = closest_start_point;
+				new_polygon.vertices[1] = closest_start_point;
+				new_polygon.vertices[2] = closest_end_point;
+				new_polygon.vertices[3] = closest_end_point;
+
+				// Setup connections to go forward in the link.
+				{
+					Connection entry_connection;
+					entry_connection.polygon = &new_polygon;
+					entry_connection.edge = -1;
+					entry_connection.pathway_start = new_polygon.vertices[0];
+					entry_connection.pathway_end = new_polygon.vertices[1];
+					navbases_polygons_external_connections[closest_start_polygon->owner][closest_start_polygon->id].push_back(entry_connection);
+
+					Connection exit_connection;
+					exit_connection.polygon = closest_end_polygon;
+					exit_connection.edge = -1;
+					exit_connection.pathway_start = new_polygon.vertices[2];
+					exit_connection.pathway_end = new_polygon.vertices[3];
+					navbases_polygons_external_connections[link.ptr()].push_back(LocalVector<Nav3D::Connection>());
+					navbases_polygons_external_connections[link.ptr()][new_polygon.id].push_back(exit_connection);
+				}
+
+				// If the link is bi-directional, create connections from the end to the start.
+				if (link->is_bidirectional()) {
+					Connection entry_connection;
+					entry_connection.polygon = &new_polygon;
+					entry_connection.edge = -1;
+					entry_connection.pathway_start = new_polygon.vertices[2];
+					entry_connection.pathway_end = new_polygon.vertices[3];
+					navbases_polygons_external_connections[closest_end_polygon->owner][closest_end_polygon->id].push_back(entry_connection);
+
+					Connection exit_connection;
+					exit_connection.polygon = closest_start_polygon;
+					exit_connection.edge = -1;
+					exit_connection.pathway_start = new_polygon.vertices[0];
+					exit_connection.pathway_end = new_polygon.vertices[1];
+					navbases_polygons_external_connections[link.ptr()][new_polygon.id].push_back(exit_connection);
+				}
 			}
 		}
 	}

--- a/tests/servers/test_navigation_server_2d.cpp
+++ b/tests/servers/test_navigation_server_2d.cpp
@@ -747,6 +747,129 @@ TEST_SUITE("[Navigation2D]") {
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 
+	// This test case does not check precise values on purpose - to not be too sensitive.
+	TEST_CASE("[NavigationServer2D] Links should function properly when multiple overlapping regions are present") {
+		NavigationServer2D *navigation_server = NavigationServer2D::get_singleton();
+		Ref<NavigationPolygon> navigation_polygon;
+		navigation_polygon.instantiate();
+		Ref<NavigationMeshSourceGeometryData2D> source_geometry;
+		source_geometry.instantiate();
+
+		navigation_polygon->add_outline(PackedVector2Array({ Vector2(-1250.0, -250.0), Vector2(-750.0, -250.0), Vector2(-750.0, 250.0), Vector2(-1250.0, 250.0) }));
+		navigation_polygon->add_outline(PackedVector2Array({ Vector2(-250.0, -250.0), Vector2(250.0, -250.0), Vector2(250.0, 250.0), Vector2(-250.0, 250.0) }));
+		navigation_polygon->add_outline(PackedVector2Array({ Vector2(750.0, -250.0), Vector2(1250.0, -250.0), Vector2(1250.0, 250.0), Vector2(750.0, 250.0) }));
+		navigation_server->bake_from_source_geometry_data(navigation_polygon, source_geometry, Callable());
+
+		// Spews warnings about edge errors if I use 3 of the same navmesh, so I'm making a bigger one.
+		Ref<NavigationPolygon> navigation_polygon_bigger;
+		navigation_polygon_bigger.instantiate();
+		navigation_polygon_bigger->add_outline(PackedVector2Array({ Vector2(-1300.0, -300.0), Vector2(-700.0, -300.0), Vector2(-700.0, 300.0), Vector2(-1300.0, 300.0) }));
+		navigation_polygon_bigger->add_outline(PackedVector2Array({ Vector2(-300.0, -300.0), Vector2(300.0, -300.0), Vector2(300.0, 300.0), Vector2(-300.0, 300.0) }));
+		navigation_polygon_bigger->add_outline(PackedVector2Array({ Vector2(700.0, -300.0), Vector2(1300.0, -300.0), Vector2(1300.0, 300.0), Vector2(700.0, 300.0) }));
+		navigation_server->bake_from_source_geometry_data(navigation_polygon_bigger, source_geometry, Callable());
+
+		RID map = navigation_server->map_create();
+		navigation_server->map_set_use_edge_connections(map, false);
+		RID region1 = navigation_server->region_create();
+		RID region2 = navigation_server->region_create();
+		RID region3 = navigation_server->region_create();
+		navigation_server->map_set_active(map, true);
+		navigation_server->map_set_use_async_iterations(map, false);
+		navigation_server->region_set_use_async_iterations(region1, false);
+		navigation_server->region_set_use_async_iterations(region2, false);
+		navigation_server->region_set_use_async_iterations(region3, false);
+		navigation_server->region_set_navigation_layers(region1, 1);
+		navigation_server->region_set_navigation_layers(region2, 2);
+		navigation_server->region_set_navigation_layers(region3, 4);
+		navigation_server->region_set_map(region1, map);
+		navigation_server->region_set_map(region2, map);
+		navigation_server->region_set_map(region3, map);
+		navigation_server->region_set_navigation_polygon(region1, navigation_polygon_bigger);
+		navigation_server->region_set_navigation_polygon(region2, navigation_polygon);
+		navigation_server->region_set_navigation_polygon(region3, navigation_polygon);
+
+		RID link1 = navigation_server->link_create();
+		navigation_server->link_set_navigation_layers(link1, 6);
+		navigation_server->link_set_bidirectional(link1, true);
+		navigation_server->link_set_start_position(link1, Vector2(-800, 0));
+		navigation_server->link_set_end_position(link1, Vector2(-200, 0));
+		navigation_server->link_set_map(link1, map);
+		RID link2 = navigation_server->link_create();
+		navigation_server->link_set_navigation_layers(link2, 6);
+		navigation_server->link_set_bidirectional(link2, false);
+		navigation_server->link_set_start_position(link2, Vector2(200, 0));
+		navigation_server->link_set_end_position(link2, Vector2(800, 0));
+		navigation_server->link_set_map(link2, map);
+
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
+
+		SUBCASE("Should not find path from left platform to right platform as there are no links on first layer") {
+			Ref<NavigationPathQueryParameters2D> query_parameters;
+			query_parameters.instantiate();
+			query_parameters->set_map(map);
+			query_parameters->set_path_postprocessing(NavigationPathQueryParameters2D::PATH_POSTPROCESSING_CORRIDORFUNNEL);
+			query_parameters->set_navigation_layers(1);
+			query_parameters->set_start_position(Vector2(-1000, 0));
+			query_parameters->set_target_position(Vector2(1000, 0));
+			Ref<NavigationPathQueryResult2D> query_result;
+			query_result.instantiate();
+			navigation_server->query_path(query_parameters, query_result);
+			uint32_t path_size = query_result->get_path().size();
+			CHECK_GT(path_size, 0);
+			if (path_size > 0) {
+				CHECK_LT(query_result->get_path()[path_size - 1].x, -500);
+			}
+		}
+
+		SUBCASE("Should find path from left platform to right platform on second and third layers") {
+			Ref<NavigationPathQueryParameters2D> query_parameters;
+			query_parameters.instantiate();
+			query_parameters->set_map(map);
+			query_parameters->set_path_postprocessing(NavigationPathQueryParameters2D::PATH_POSTPROCESSING_CORRIDORFUNNEL);
+			for (uint32_t layer = 2; layer <= 4; layer *= 2) {
+				query_parameters->set_navigation_layers(layer);
+				query_parameters->set_start_position(Vector2(-1000, 0));
+				query_parameters->set_target_position(Vector2(1000, 0));
+				Ref<NavigationPathQueryResult2D> query_result;
+				query_result.instantiate();
+				navigation_server->query_path(query_parameters, query_result);
+				uint32_t path_size = query_result->get_path().size();
+				CHECK_GT(path_size, 0);
+				if (path_size > 0) {
+					CHECK_GT(query_result->get_path()[path_size - 1].x, 500);
+				}
+			}
+		}
+
+		SUBCASE("Should not find path from right platform to left platform because of unidirectional link") {
+			Ref<NavigationPathQueryParameters2D> query_parameters;
+			query_parameters.instantiate();
+			query_parameters->set_map(map);
+			query_parameters->set_path_postprocessing(NavigationPathQueryParameters2D::PATH_POSTPROCESSING_CORRIDORFUNNEL);
+			for (uint32_t layer = 1; layer <= 4; layer *= 2) {
+				query_parameters->set_navigation_layers(layer);
+				query_parameters->set_start_position(Vector2(1000, 0));
+				query_parameters->set_target_position(Vector2(-1000, 0));
+				Ref<NavigationPathQueryResult2D> query_result;
+				query_result.instantiate();
+				navigation_server->query_path(query_parameters, query_result);
+				uint32_t path_size = query_result->get_path().size();
+				CHECK_GT(path_size, 0);
+				if (path_size > 0) {
+					CHECK_GT(query_result->get_path()[path_size - 1].x, 500);
+				}
+			}
+		}
+
+		navigation_server->free_rid(region1);
+		navigation_server->free_rid(region2);
+		navigation_server->free_rid(region3);
+		navigation_server->free_rid(link1);
+		navigation_server->free_rid(link2);
+		navigation_server->free_rid(map);
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
+	}
+
 	TEST_CASE("[NavigationServer2D] Server should simplify path properly") {
 		real_t simplify_epsilon = 0.2;
 		Vector<Vector2> source_path;

--- a/tests/servers/test_navigation_server_3d.cpp
+++ b/tests/servers/test_navigation_server_3d.cpp
@@ -813,6 +813,124 @@ TEST_SUITE("[Navigation3D]") {
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 
+	// This test case does not check precise values on purpose - to not be too sensitive.
+	TEST_CASE("[NavigationServer3D] Links should function properly when multiple overlapping regions are present") {
+		NavigationServer3D *navigation_server = NavigationServer3D::get_singleton();
+		Ref<NavigationMesh> navigation_mesh = memnew(NavigationMesh);
+		Ref<NavigationMesh> navigation_mesh_bigger = memnew(NavigationMesh);
+		Ref<NavigationMeshSourceGeometryData3D> source_geometry = memnew(NavigationMeshSourceGeometryData3D);
+
+		Array arr;
+		arr.resize(RSE::ARRAY_MAX);
+		BoxMesh::create_mesh_array(arr, Vector3(5.0, 0.1, 5.0));
+		source_geometry->add_mesh_array(arr, Transform3D(Basis(), Vector3(-10, 0, 0)));
+		source_geometry->add_mesh_array(arr, Transform3D());
+		source_geometry->add_mesh_array(arr, Transform3D(Basis(), Vector3(10, 0, 0)));
+		navigation_server->bake_from_source_geometry_data(navigation_mesh, source_geometry, Callable());
+
+		// Spews warnings about edge errors if I use 3 of the same navmesh, so I'm making a bigger one.
+		BoxMesh::create_mesh_array(arr, Vector3(6.0, 0.1, 6.0));
+		source_geometry->add_mesh_array(arr, Transform3D(Basis(), Vector3(-10, 0, 0)));
+		source_geometry->add_mesh_array(arr, Transform3D());
+		source_geometry->add_mesh_array(arr, Transform3D(Basis(), Vector3(10, 0, 0)));
+		navigation_server->bake_from_source_geometry_data(navigation_mesh_bigger, source_geometry, Callable());
+
+		RID map = navigation_server->map_create();
+		navigation_server->map_set_use_edge_connections(map, false);
+		RID region1 = navigation_server->region_create();
+		RID region2 = navigation_server->region_create();
+		RID region3 = navigation_server->region_create();
+		navigation_server->map_set_active(map, true);
+		navigation_server->map_set_use_async_iterations(map, false);
+		navigation_server->region_set_use_async_iterations(region1, false);
+		navigation_server->region_set_use_async_iterations(region2, false);
+		navigation_server->region_set_use_async_iterations(region3, false);
+		navigation_server->region_set_navigation_layers(region1, 1);
+		navigation_server->region_set_navigation_layers(region2, 2);
+		navigation_server->region_set_navigation_layers(region3, 4);
+		navigation_server->region_set_map(region1, map);
+		navigation_server->region_set_map(region2, map);
+		navigation_server->region_set_map(region3, map);
+		navigation_server->region_set_navigation_mesh(region1, navigation_mesh_bigger);
+		navigation_server->region_set_navigation_mesh(region2, navigation_mesh);
+		navigation_server->region_set_navigation_mesh(region3, navigation_mesh);
+
+		RID link1 = navigation_server->link_create();
+		navigation_server->link_set_navigation_layers(link1, 6);
+		navigation_server->link_set_bidirectional(link1, true);
+		navigation_server->link_set_start_position(link1, Vector3(-8, 0, 0));
+		navigation_server->link_set_end_position(link1, Vector3(-2, 0, 0));
+		navigation_server->link_set_map(link1, map);
+		RID link2 = navigation_server->link_create();
+		navigation_server->link_set_navigation_layers(link2, 6);
+		navigation_server->link_set_bidirectional(link2, false);
+		navigation_server->link_set_start_position(link2, Vector3(2, 0, 0));
+		navigation_server->link_set_end_position(link2, Vector3(8, 0, 0));
+		navigation_server->link_set_map(link2, map);
+
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
+
+		SUBCASE("Should not find path from left platform to right platform as there are no links on first layer") {
+			Ref<NavigationPathQueryParameters3D> query_parameters = memnew(NavigationPathQueryParameters3D);
+			query_parameters->set_map(map);
+			query_parameters->set_path_postprocessing(NavigationPathQueryParameters3D::PATH_POSTPROCESSING_CORRIDORFUNNEL);
+			query_parameters->set_navigation_layers(1);
+			query_parameters->set_start_position(Vector3(-10, 0, 0));
+			query_parameters->set_target_position(Vector3(10, 0, 0));
+			Ref<NavigationPathQueryResult3D> query_result = memnew(NavigationPathQueryResult3D);
+			navigation_server->query_path(query_parameters, query_result);
+			uint32_t path_size = query_result->get_path().size();
+			CHECK_GT(path_size, 0);
+			if (path_size > 0) {
+				CHECK_LT(query_result->get_path()[path_size - 1].x, -5);
+			}
+		}
+
+		SUBCASE("Should find path from left platform to right platform on second and third layers") {
+			Ref<NavigationPathQueryParameters3D> query_parameters = memnew(NavigationPathQueryParameters3D);
+			query_parameters->set_map(map);
+			query_parameters->set_path_postprocessing(NavigationPathQueryParameters3D::PATH_POSTPROCESSING_CORRIDORFUNNEL);
+			for (uint32_t layer = 2; layer <= 4; layer *= 2) {
+				query_parameters->set_navigation_layers(layer);
+				query_parameters->set_start_position(Vector3(-10, 0, 0));
+				query_parameters->set_target_position(Vector3(10, 0, 0));
+				Ref<NavigationPathQueryResult3D> query_result = memnew(NavigationPathQueryResult3D);
+				navigation_server->query_path(query_parameters, query_result);
+				uint32_t path_size = query_result->get_path().size();
+				CHECK_GT(path_size, 0);
+				if (path_size > 0) {
+					CHECK_GT(query_result->get_path()[path_size - 1].x, 5);
+				}
+			}
+		}
+
+		SUBCASE("Should not find path from right platform to left platform because of unidirectional link") {
+			Ref<NavigationPathQueryParameters3D> query_parameters = memnew(NavigationPathQueryParameters3D);
+			query_parameters->set_map(map);
+			query_parameters->set_path_postprocessing(NavigationPathQueryParameters3D::PATH_POSTPROCESSING_CORRIDORFUNNEL);
+			for (uint32_t layer = 1; layer <= 4; layer *= 2) {
+				query_parameters->set_navigation_layers(layer);
+				query_parameters->set_start_position(Vector3(10, 0, 0));
+				query_parameters->set_target_position(Vector3(-10, 0, 0));
+				Ref<NavigationPathQueryResult3D> query_result = memnew(NavigationPathQueryResult3D);
+				navigation_server->query_path(query_parameters, query_result);
+				uint32_t path_size = query_result->get_path().size();
+				CHECK_GT(path_size, 0);
+				if (path_size > 0) {
+					CHECK_GT(query_result->get_path()[path_size - 1].x, 5);
+				}
+			}
+		}
+
+		navigation_server->free_rid(region1);
+		navigation_server->free_rid(region2);
+		navigation_server->free_rid(region3);
+		navigation_server->free_rid(link1);
+		navigation_server->free_rid(link2);
+		navigation_server->free_rid(map);
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
+	}
+
 	// FIXME: The race condition mentioned below is actually a problem and fails on CI (GH-90613).
 	/*
 	TEST_CASE("[NavigationServer3D] Server should be able to bake asynchronously") {


### PR DESCRIPTION
Fixes #117138

The connection building function previously would only allocate one connection per nav link, and it would search for the closest connecting polygons among all regions in the map, even regions that did not match the link's navigation layers. This resulted in wrong connections being built in any case where the start or end point of a link was in range of multiple region's navigation meshes.

This commit skips regions that don't match the link's navigation layer. The closest polygons are now found per region, and for each pair of start and end polygons, a connection is built. This allows links to work properly with multiple regions and multiple navigation layers.

The test cases test a scenario with 3 regions on different layers and nav links with layers 2 and 3 set. Pathfinding across floating platforms should fail on layer 1 and succeed on layers 2 and 3.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
