### PR TITLE
Fix adding carets above and then below

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5442,6 +5442,7 @@ void TextEdit::add_caret_at_carets(bool p_below) {
 			carets.remove_at(new_caret_index);
 			carets.insert(0, new_caret);
 			i++;
+			num_carets += 1;
 		}
 	}
 


### PR DESCRIPTION
Fixes #117549 bug where adding a caret on the line above then the line below and then above again
results in carets no longer being added. There was an off by one error when new caret was going
to be merged with main caret. 

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
