### PR TITLE
Add menu option to create new material from shader

### DIFF
--- a/doc/classes/EditorResourceConversionPlugin.xml
+++ b/doc/classes/EditorResourceConversionPlugin.xml
@@ -47,5 +47,12 @@
 				Called to determine whether a particular [Resource] can be converted to the target resource type by this plugin.
 			</description>
 		</method>
+		<method name="_replaces_source" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the [Resource] returned by [method _convert] should replace the source [Resource]. This is the default.
+				If [code]false[/code], the source [Resource] is kept and the converted [Resource] is saved as a new file instead. Such conversions are only available in the [b]Create New[/b] submenu of the FileSystem dock; for example, creating a [ShaderMaterial] from a [Shader].
+			</description>
+		</method>
 	</methods>
 </class>

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2613,6 +2613,25 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			make_dir_dialog->popup_centered();
 		} break;
 
+		case FILE_MENU_NEW_MATERIAL_FROM_SHADER: {
+			if (p_selected.size() != 1) {
+				return;
+			}
+			const String &fpath = p_selected[0];
+
+			Ref<ShaderMaterial> shader_material = Ref<ShaderMaterial>(memnew(ShaderMaterial));
+			shader_material->set_shader(Ref<Shader>(ResourceLoader::load(fpath)));
+
+			String name = fpath.get_file().get_basename() + "_material.tres";
+			String save_path = fpath.get_base_dir().path_join(name);
+
+			// Set the path so the save dialog uses it as the suggested file name.
+			shader_material->set_path(save_path);
+
+			EditorNode::get_singleton()->push_item(shader_material.ptr());
+			EditorNode::get_singleton()->save_resource_as(shader_material, fpath.get_base_dir());
+		} break;
+
 		case FILE_MENU_REIMPORT: {
 			ImportDock::get_singleton()->reimport_resources(p_selected);
 		} break;
@@ -3443,6 +3462,11 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 		p_popup->add_submenu_node_item(TTRC("Create New"), new_menu, FILE_MENU_NEW);
 		p_popup->set_item_icon(p_popup->get_item_index(FILE_MENU_NEW), get_editor_theme_icon(SNAME("Add")));
 
+		const String type = EditorFileSystem::get_singleton()->get_file_type(p_paths[0]);
+		if (type == "Shader" || type == "VisualShader") {
+			new_menu->add_icon_item(get_editor_theme_icon(SNAME("ShaderMaterial")), TTRC("Material From Shader..."), FILE_MENU_NEW_MATERIAL_FROM_SHADER);
+			new_menu->add_separator();
+		}
 		new_menu->add_icon_item(get_editor_theme_icon(SNAME("Folder")), TTRC("Folder..."), FILE_MENU_NEW_FOLDER);
 		new_menu->set_item_shortcut(-1, ED_GET_SHORTCUT("filesystem_dock/new_folder"));
 		new_menu->add_icon_item(get_editor_theme_icon(SNAME("PackedScene")), TTRC("Scene..."), FILE_MENU_NEW_SCENE);

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1292,16 +1292,20 @@ HashSet<String> FileSystemDock::_get_valid_conversions_for_file_paths(const Vect
 
 		Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin_for_type_name(EditorFileSystem::get_singleton()->get_file_type(fpath));
 
-		if (conversions.is_empty()) {
-			// This resource can't convert to anything, so return an empty list.
-			return HashSet<String>();
-		}
-
 		// Get a list of all potential conversion-to targets.
 		HashSet<String> current_valid_conversion_to_targets;
 		for (const Ref<EditorResourceConversionPlugin> &E : conversions) {
+			if (!E->replaces_source()) {
+				// Conversions that create a new resource are offered in the "Create New" submenu instead.
+				continue;
+			}
 			const String what = E->converts_to();
 			current_valid_conversion_to_targets.insert(what);
+		}
+
+		if (current_valid_conversion_to_targets.is_empty()) {
+			// This resource can't convert to anything, so return an empty list.
+			return HashSet<String>();
 		}
 
 		if (all_valid_conversion_to_targets.is_empty()) {
@@ -1322,6 +1326,17 @@ HashSet<String> FileSystemDock::_get_valid_conversions_for_file_paths(const Vect
 	}
 
 	return all_valid_conversion_to_targets;
+}
+
+Vector<Ref<EditorResourceConversionPlugin>> FileSystemDock::_get_new_resource_conversions_for_file_path(const String &p_path) {
+	Vector<Ref<EditorResourceConversionPlugin>> new_resource_conversions;
+	Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin_for_type_name(EditorFileSystem::get_singleton()->get_file_type(p_path));
+	for (const Ref<EditorResourceConversionPlugin> &E : conversions) {
+		if (!E->replaces_source()) {
+			new_resource_conversions.push_back(E);
+		}
+	}
+	return new_resource_conversions;
 }
 
 void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorites, bool p_navigate) {
@@ -2756,6 +2771,20 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				if (!EditorContextMenuPluginManager::get_singleton()->activate_custom_option(EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM, p_option)) {
 					EditorContextMenuPluginManager::get_singleton()->activate_custom_option(EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM_CREATE, p_option);
 				}
+			} else if (p_option >= CONVERT_NEW_BASE_ID) {
+				ERR_FAIL_COND(p_selected.size() != 1);
+				const String &fpath = p_selected[0];
+				Vector<Ref<EditorResourceConversionPlugin>> conversions = _get_new_resource_conversions_for_file_path(fpath);
+				const int conversion_id = p_option - CONVERT_NEW_BASE_ID;
+				ERR_FAIL_INDEX(conversion_id, conversions.size());
+
+				Ref<Resource> res = ResourceLoader::load(fpath);
+				ERR_FAIL_COND(res.is_null());
+				Ref<Resource> converted_res = conversions[conversion_id]->convert(res);
+				ERR_FAIL_COND(converted_res.is_null());
+
+				EditorNode::get_singleton()->push_item(converted_res.ptr());
+				EditorNode::get_singleton()->save_resource_as(converted_res, fpath.get_base_dir());
 			} else if (p_option >= CONVERT_BASE_ID) {
 				selected_conversion_id = p_option - CONVERT_BASE_ID;
 				ERR_FAIL_INDEX(selected_conversion_id, (int)cached_valid_conversion_targets.size());
@@ -3497,6 +3526,23 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 		_add_create_options(p_popup, String());
 	} else if (single_path && p_display_path_dependent_options) {
 		PopupMenu *new_menu = memnew(PopupMenu);
+
+		Vector<Ref<EditorResourceConversionPlugin>> new_resource_conversions = _get_new_resource_conversions_for_file_path(p_paths[0]);
+		if (!new_resource_conversions.is_empty()) {
+			const String type = EditorFileSystem::get_singleton()->get_file_type(p_paths[0]);
+			for (int i = 0; i < new_resource_conversions.size(); i++) {
+				const String what = new_resource_conversions[i]->converts_to();
+				Ref<Texture2D> icon;
+				if (has_theme_icon(what, SNAME("EditorIcons"))) {
+					icon = get_editor_theme_icon(what);
+				} else {
+					icon = get_editor_theme_icon(SNAME("Object"));
+				}
+				new_menu->add_icon_item(icon, vformat(TTR("%s from %s..."), what, type), CONVERT_NEW_BASE_ID + i);
+			}
+			new_menu->add_separator();
+		}
+
 		_add_create_options(new_menu, p_paths[0].get_base_dir());
 		new_menu->connect(SceneStringName(id_pressed), callable_mp(this, &FileSystemDock::_generic_rmb_option_selected));
 

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -137,6 +137,7 @@ private:
 		FILE_MENU_NEW_SCRIPT,
 		FILE_MENU_NEW_SCENE,
 		FILE_MENU_RUN_SCRIPT,
+		FILE_MENU_NEW_MATERIAL_FROM_SHADER,
 		FILE_MENU_MAX,
 		// Extra shortcuts that don't exist in the menu.
 		EXTRA_FOCUS_PATH,

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -50,6 +50,7 @@ class DependencyEditor;
 class DependencyEditorOwners;
 class DependencyRemoveDialog;
 class EditorDirDialog;
+class EditorResourceConversionPlugin;
 class HBoxContainer;
 class LineEdit;
 class ProgressBar;
@@ -145,6 +146,7 @@ private:
 		EXTRA_FOCUS_FILTER,
 
 		CONVERT_BASE_ID = 1000,
+		CONVERT_NEW_BASE_ID = 1500,
 	};
 
 	HashMap<String, TreeItem *> folder_map;
@@ -294,6 +296,7 @@ private:
 	bool _handle_custom_context_callback(Ref<InputEvent> p_event, const PackedStringArray &p_selected);
 
 	HashSet<String> _get_valid_conversions_for_file_paths(const Vector<String> &p_paths);
+	Vector<Ref<EditorResourceConversionPlugin>> _get_new_resource_conversions_for_file_path(const String &p_path);
 
 	void _update_file_list(bool p_keep_selection, const Vector<String> &p_override_selection = Vector<String>());
 	void _toggle_file_display();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -9575,6 +9575,10 @@ EditorNode::EditorNode() {
 		Ref<FogMaterialConversionPlugin> fog_mat_convert;
 		fog_mat_convert.instantiate();
 		resource_conversion_plugins.push_back(fog_mat_convert);
+
+		Ref<ShaderConversionPlugin> shader_convert;
+		shader_convert.instantiate();
+		resource_conversion_plugins.push_back(shader_convert);
 	}
 
 	update_spinner_step_msec = OS::get_singleton()->get_ticks_msec();

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -414,12 +414,18 @@ void EditorResourcePicker::_update_menu_items() {
 	// Add options to convert existing resource to another type of resource.
 	if (is_editable() && edited_resource.is_valid()) {
 		Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin_for_resource(edited_resource);
-		if (!conversions.is_empty()) {
-			edit_menu->add_separator();
-		}
-		int relative_id = 0;
-		for (const Ref<EditorResourceConversionPlugin> &conversion : conversions) {
-			String what = conversion->converts_to();
+		bool separator_added = false;
+		for (int i = 0; i < conversions.size(); i++) {
+			if (!conversions[i]->replaces_source()) {
+				// Conversions that create a new resource can't replace the edited one.
+				continue;
+			}
+			if (!separator_added) {
+				edit_menu->add_separator();
+				separator_added = true;
+			}
+
+			String what = conversions[i]->converts_to();
 			Ref<Texture2D> icon;
 			if (has_theme_icon(what, EditorStringName(EditorIcons))) {
 				icon = get_editor_theme_icon(what);
@@ -427,8 +433,7 @@ void EditorResourcePicker::_update_menu_items() {
 				icon = get_editor_theme_icon(SNAME("Object"));
 			}
 
-			edit_menu->add_icon_item(icon, vformat(TTR("Convert to %s"), what), CONVERT_BASE_ID + relative_id);
-			relative_id++;
+			edit_menu->add_icon_item(icon, vformat(TTR("Convert to %s"), what), CONVERT_BASE_ID + i);
 		}
 	}
 }

--- a/editor/plugins/editor_resource_conversion_plugin.cpp
+++ b/editor/plugins/editor_resource_conversion_plugin.cpp
@@ -36,6 +36,7 @@ void EditorResourceConversionPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_converts_to);
 	GDVIRTUAL_BIND(_handles, "resource");
 	GDVIRTUAL_BIND(_convert, "resource");
+	GDVIRTUAL_BIND(_replaces_source);
 }
 
 String EditorResourceConversionPlugin::converts_to() const {
@@ -53,5 +54,11 @@ bool EditorResourceConversionPlugin::handles(const Ref<Resource> &p_resource) co
 Ref<Resource> EditorResourceConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<Resource> ret;
 	GDVIRTUAL_CALL(_convert, p_resource, ret);
+	return ret;
+}
+
+bool EditorResourceConversionPlugin::replaces_source() const {
+	bool ret = true;
+	GDVIRTUAL_CALL(_replaces_source, ret);
 	return ret;
 }

--- a/editor/plugins/editor_resource_conversion_plugin.h
+++ b/editor/plugins/editor_resource_conversion_plugin.h
@@ -42,9 +42,11 @@ protected:
 	GDVIRTUAL0RC(String, _converts_to)
 	GDVIRTUAL1RC(bool, _handles, Ref<Resource>)
 	GDVIRTUAL1RC(Ref<Resource>, _convert, Ref<Resource>)
+	GDVIRTUAL0RC(bool, _replaces_source)
 
 public:
 	virtual String converts_to() const;
 	virtual bool handles(const Ref<Resource> &p_resource) const;
 	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const;
+	virtual bool replaces_source() const;
 };

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -587,3 +587,27 @@ Ref<Resource> BlitMaterialConversionPlugin::convert(const Ref<Resource> &p_resou
 	smat->set_name(mat->get_name());
 	return smat;
 }
+
+String ShaderConversionPlugin::converts_to() const {
+	return "ShaderMaterial";
+}
+
+bool ShaderConversionPlugin::handles(const Ref<Resource> &p_resource) const {
+	Ref<Shader> shader = p_resource;
+	return shader.is_valid();
+}
+
+Ref<Resource> ShaderConversionPlugin::convert(const Ref<Resource> &p_resource) const {
+	Ref<Shader> shader = p_resource;
+	ERR_FAIL_COND_V(shader.is_null(), Ref<Resource>());
+
+	Ref<ShaderMaterial> smat;
+	smat.instantiate();
+	smat->set_shader(shader);
+	return smat;
+}
+
+bool ShaderConversionPlugin::replaces_source() const {
+	// The shader is still needed by the material, so the material is created as a new resource instead.
+	return false;
+}

--- a/editor/scene/material_editor_plugin.h
+++ b/editor/scene/material_editor_plugin.h
@@ -166,3 +166,13 @@ public:
 	virtual bool handles(const Ref<Resource> &p_resource) const override;
 	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const override;
 };
+
+class ShaderConversionPlugin : public EditorResourceConversionPlugin {
+	GDCLASS(ShaderConversionPlugin, EditorResourceConversionPlugin);
+
+public:
+	virtual String converts_to() const override;
+	virtual bool handles(const Ref<Resource> &p_resource) const override;
+	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const override;
+	virtual bool replaces_source() const override;
+};


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/6028
Supersedes https://github.com/godotengine/godot/pull/70776

This PR adds a right click shortcut to Shader and Visual Shader resources to quickly create Shader Material resources with them attached.

Example name: If the shader name is "some_shader", the suggested file name for the material will be "some_shader_material".

<img width="861" height="633" alt="Screenshot 2026-03-19 at 22 16 06" src="https://github.com/user-attachments/assets/0c61e4ef-4cea-4c83-afc6-7d7715f41a34" />


This is a re-creation of the older PR because that one had 3+ years worth of accumulated conflicts.

<details>
<summary>More Screenshots</summary>

<img width="1272" height="775" alt="Screenshot 2026-03-19 at 09 38 33" src="https://github.com/user-attachments/assets/782b1385-5bf9-43a6-9f90-f0857d8ca5fd" />

<img width="445" height="577" alt="Screenshot 2026-03-19 at 09 38 44" src="https://github.com/user-attachments/assets/94a083ea-533c-47eb-8757-4cfe7eacd4e5" />


</details>

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
