### PR TITLE
Add standard macOS/Windows menu key bindings to the default input map. Handle menu action in some editor controls.

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -801,6 +801,16 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	default_builtin_cache.insert("ui_menu", inputs);
 
 	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::MENU));
+	inputs.push_back(InputEventKey::create_reference(KeyModifierMask::CTRL | Key::ENTER));
+	default_builtin_cache.insert("ui_menu.macos", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::MENU));
+	inputs.push_back(InputEventKey::create_reference(KeyModifierMask::SHIFT | Key::F10));
+	default_builtin_cache.insert("ui_menu.windows", inputs);
+
+	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::ENTER));
 	inputs.push_back(InputEventKey::create_reference(Key::KP_ENTER));
 	default_builtin_cache.insert("ui_text_submit", inputs);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1415,8 +1415,14 @@
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
 		<member name="input/ui_menu" type="Dictionary" setter="" getter="">
-			Default [InputEventAction] to open a context menu in a text field.
+			Default [InputEventAction] to open a context menu.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_menu.macos" type="Dictionary" setter="" getter="">
+			macOS specific override for the shortcut to open a context menu.
+		</member>
+		<member name="input/ui_menu.windows" type="Dictionary" setter="" getter="">
+			Windows specific override for the shortcut to open a context menu.
 		</member>
 		<member name="input/ui_page_down" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to go down a page in a [Control] (e.g. in an [ItemList] or a [Tree]), matching the behavior of [constant KEY_PAGEDOWN] on typical desktop UI systems.

--- a/editor/docks/groups_editor.cpp
+++ b/editor/docks/groups_editor.cpp
@@ -859,6 +859,12 @@ void GroupsEditor::_groups_gui_input(Ref<InputEvent> p_event) {
 		}
 
 		accept_event();
+	} else if (key.is_valid() && key->is_pressed() && key->is_action("ui_menu", true)) {
+		TreeItem *item = tree->get_selected();
+		if (!item) {
+			return;
+		}
+		_item_mouse_selected(tree->get_item_rect(item).position, MouseButton::RIGHT);
 	}
 }
 

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1167,6 +1167,16 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 		select();
 		return;
 	}
+	Ref<InputEventKey> key = p_event;
+	if (key.is_valid() && key->is_pressed() && key->is_action("ui_menu", true)) {
+		accept_event();
+		_update_popup();
+		menu->set_position(get_screen_position());
+		menu->reset_size();
+		menu->popup();
+		select();
+		return;
+	}
 }
 
 void EditorProperty::_accessibility_action_click(const Variant &p_data) {
@@ -2076,6 +2086,10 @@ void EditorInspectorCategory::gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
 		_popup_context_menu(get_screen_position() + mb->get_position());
 	}
+	Ref<InputEventKey> key = p_event;
+	if (key.is_valid() && key->is_pressed() && key->is_action("ui_menu", true)) {
+		_popup_context_menu(get_screen_position());
+	}
 }
 
 EditorInspectorCategory::EditorInspectorCategory() {
@@ -2569,6 +2583,15 @@ void EditorInspectorSection::gui_input(const Ref<InputEvent> &p_event) {
 	} else if (mb.is_valid() && !mb->is_pressed()) {
 		queue_redraw();
 	}
+
+	Ref<InputEventKey> key = p_event;
+	if (key.is_valid() && key->is_pressed() && key->is_action("ui_menu", true)) {
+		accept_event();
+		_update_popup();
+		menu->set_position(get_screen_position());
+		menu->reset_size();
+		menu->popup();
+	}
 }
 
 String EditorInspectorSection::get_section() const {
@@ -2982,6 +3005,17 @@ void EditorInspectorArray::_panel_gui_input(Ref<InputEvent> p_event, int p_index
 		if (array_elements[p_index].panel->has_focus() && key.is_pressed() && key.get_keycode() == Key::KEY_DELETE) {
 			_move_element(begin_array_index + p_index, -1);
 			array_elements[p_index].panel->accept_event();
+		}
+	}
+	if (key_ref.is_valid() && key_ref->is_pressed() && key_ref->is_action("ui_menu", true)) {
+		if (movable) {
+			array_elements[p_index].panel->accept_event();
+			popup_array_index_pressed = begin_array_index + p_index;
+			rmb_popup->set_item_disabled(OPTION_MOVE_UP, popup_array_index_pressed == 0);
+			rmb_popup->set_item_disabled(OPTION_MOVE_DOWN, popup_array_index_pressed == count - 1);
+			rmb_popup->set_position(array_elements[p_index].panel->get_screen_position());
+			rmb_popup->reset_size();
+			rmb_popup->popup();
 		}
 	}
 


### PR DESCRIPTION
Adds standard platform specific menu key combinations to the input map:
- `Ctrl + Enter` on macOS.
- `Shift + F10` on Windows.

Adds `ui_menu` handling to editor GUI elements missing it (note, some uses of context menus are position specific, and can't be directly handled by the key event):
- [x] Editor inspector.
- [ ] TODO

Partially fixes https://github.com/godotengine/godot/issues/117593