### PR TITLE
Fix docking popup with editor scale != 1.0

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -1062,14 +1062,14 @@ void DockSlotGrid::_notification(int p_what) {
 					draw_rect(slot_rect, used_dock_color);
 				}
 
-				real_t tab_width = ((slot_rect.size.x - (max_tabs - 1) * TAB_MARGIN) / max_tabs) * EDSCALE;
-				real_t initial_offset = (slot_rect.size.x - (max_tabs * tab_width + (max_tabs - 1) * TAB_MARGIN)) * 0.5;
+				real_t tab_width = ((slot_rect.size.x - (max_tabs - 1) * TAB_MARGIN * EDSCALE) / max_tabs);
+				real_t initial_offset = (slot_rect.size.x - (max_tabs * tab_width + (max_tabs - 1) * TAB_MARGIN * EDSCALE)) * 0.5;
 
 				for (int j = 0; j < tabs_to_draw; j++) {
 					real_t pos_x = is_layout_rtl()
-							? slot_rect.size.x - (initial_offset + (j + 1) * tab_width + j * TAB_MARGIN)
-							: initial_offset + j * (tab_width + TAB_MARGIN);
-					const Rect2 tab_rect = Rect2(slot_rect.position + Vector2(pos_x, -MARGINS.y + MARGINS.y / 4), Vector2(tab_width, MARGINS.y / 2));
+							? slot_rect.size.x - (initial_offset + (j + 1) * tab_width + j * TAB_MARGIN * EDSCALE)
+							: initial_offset + j * (tab_width + TAB_MARGIN * EDSCALE);
+					const Rect2 tab_rect = Rect2(slot_rect.position + Vector2(pos_x, -MARGINS.y * EDSCALE + MARGINS.y * EDSCALE / 4), Vector2(tab_width, MARGINS.y * EDSCALE / 2));
 					if (is_context_slot && context_tab_index == j) {
 						draw_rect(tab_rect, tab_selected_color);
 					} else if (is_slot_available) {
@@ -1130,5 +1130,5 @@ void DockSlotGrid::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 Size2 DockSlotGrid::get_minimum_size() const {
-	return GRID_SIZE * CELL_SIZE + (GRID_SIZE - Vector2i(1, 0)) * MARGINS;
+	return GRID_SIZE * CELL_SIZE * EDSCALE + (GRID_SIZE - Vector2i(1, 0)) * MARGINS * EDSCALE;
 }

--- a/editor/docks/editor_dock_manager.h
+++ b/editor/docks/editor_dock_manager.h
@@ -156,9 +156,9 @@ public:
 class DockSlotGrid : public Control {
 	GDCLASS(DockSlotGrid, Control);
 
-	static constexpr Vector2i GRID_SIZE = Vector2i(8, 8);
-	static constexpr Vector2i MARGINS = Vector2i(4, 8);
-	static constexpr Vector2i CELL_SIZE = Vector2i(24, 12);
+	static constexpr Vector2 GRID_SIZE = Vector2(8, 8);
+	static constexpr Vector2 MARGINS = Vector2(4, 8);
+	static constexpr Vector2 CELL_SIZE = Vector2(24, 12);
 	static constexpr int TABS_PER_CELL = 3;
 	static constexpr int TAB_MARGIN = 2;
 


### PR DESCRIPTION
Before (wrong min.size, tab indicators misplaced):
<img width="221" height="250" alt="Screenshot 2026-03-19 at 09 52 53" src="https://github.com/user-attachments/assets/5c3f2fdf-4bdb-4484-adc8-93e0d5ce68a4" />

After:
<img width="287" height="328" alt="Screenshot 2026-03-19 at 10 04 21" src="https://github.com/user-attachments/assets/6dd5f568-39e7-4ae6-b2cc-47f8d922539e" />
