### PR TITLE
Revert "[.NET] Remove EFS update on reloading assemblies" but with deferred call

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -356,6 +356,20 @@ namespace Godot.Bridge
                     }
                 }
             }
+
+            // This method may be called before initialization.
+            if (NativeFuncs.godotsharp_dotnet_module_is_initialized().ToBool() && Engine.IsEditorHint())
+            {
+                if (_pathTypeBiMap.Paths.Count > 0)
+                {
+                    Callable.From(() =>
+                    {
+                        string[] scriptPaths = _pathTypeBiMap.Paths.ToArray();
+                        using godot_packed_string_array scriptPathsNative = Marshaling.ConvertSystemArrayToNativePackedStringArray(scriptPaths);
+                        NativeFuncs.godotsharp_internal_editor_file_system_update_files(scriptPathsNative);
+                    }).CallDeferred();
+                }
+            }
         }
 
         [UnmanagedCallersOnly]


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/116169

It turns out this call was needed after all, it ensures new scripts are included in the global class list by updating EFS for them. In my previous PR (https://github.com/godotengine/godot/pull/108487) I must've only tested scripts that have been opened or loaded by the editor at some point so I didn't encounter the bug.

This reverts the https://github.com/godotengine/godot/pull/108487 but with a deferred call to avoid reintroducing the bug that the PR fixed (https://github.com/godotengine/godot/issues/104052). Updating EFS here is still too early, so we defer the call to ensure the type info is available.
