### PR TITLE
Fix assymmetrical rendering of reflections in SDFGI

### DIFF
--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -3868,7 +3868,7 @@ void GI::process_gi(Ref<RenderSceneBuffersRD> p_render_buffers, const RID *p_nor
 		}
 
 		Projection correction;
-		correction.set_depth_correction(false);
+		correction.set_depth_correction(true);
 
 		for (uint32_t v = 0; v < p_view_count; v++) {
 			Projection temp = correction * p_projections[v];
@@ -3910,8 +3910,8 @@ void GI::process_gi(Ref<RenderSceneBuffersRD> p_render_buffers, const RID *p_nor
 	// these are only used if we have 1 view, else we use the projections in our scene data
 	push_constant.proj_info[0] = -2.0f / (internal_size.x * p_projections[0].columns[0][0]);
 	push_constant.proj_info[1] = -2.0f / (internal_size.y * p_projections[0].columns[1][1]);
-	push_constant.proj_info[2] = (1.0f - p_projections[0].columns[0][2]) / p_projections[0].columns[0][0];
-	push_constant.proj_info[3] = (1.0f + p_projections[0].columns[1][2]) / p_projections[0].columns[1][1];
+	push_constant.proj_info[2] = (1.0f - p_projections[0].columns[2][0]) / p_projections[0].columns[0][0];
+	push_constant.proj_info[3] = (1.0f + p_projections[0].columns[2][1]) / p_projections[0].columns[1][1];
 
 	bool use_sdfgi = p_render_buffers->has_custom_data(RB_SCOPE_SDFGI);
 	bool use_voxel_gi_instances = push_constant.max_voxel_gi_instances > 0;

--- a/servers/rendering/renderer_rd/shaders/environment/gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/gi.glsl
@@ -162,7 +162,7 @@ vec3 reconstruct_position(ivec2 screen_pos) {
 	if (sc_use_full_projection_matrix) {
 		vec4 pos;
 		pos.xy = (2.0 * vec2(screen_pos) / vec2(scene_data.screen_size)) - 1.0;
-		pos.z = texelFetch(sampler2D(depth_buffer, linear_sampler), screen_pos, 0).r * 2.0 - 1.0;
+		pos.z = texelFetch(sampler2D(depth_buffer, linear_sampler), screen_pos, 0).r;
 		pos.w = 1.0;
 
 		pos = scene_data.inv_projection[params.view_index] * pos;
@@ -184,6 +184,8 @@ vec3 reconstruct_position(ivec2 screen_pos) {
 		if (!params.orthogonal) {
 			pos.xy *= pos.z;
 		}
+
+		pos.y = -pos.y;
 
 		return pos;
 	}
@@ -714,7 +716,6 @@ void main() {
 	vec4 reflection_light = vec4(0.0);
 
 	vec3 vertex = reconstruct_position(pos);
-	vertex.y = -vertex.y;
 
 	process_gi(pos, vertex, ambient_light, reflection_light);
 


### PR DESCRIPTION
This PR extends the changes in #108628

Retrotails PR mostly fixed the issue around using the Frustum camera mode but due to our y-flip logic, stereo projection was still incorrect. This PR fixes both frustum camera and stereo projection logic

Co-authored-by: @retrotails

Fixes #117303