### PR TITLE
[.Net] Add `EnsureCapacity` for Godot Native Arrays

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -342,6 +342,26 @@ namespace Godot.Collections
         }
 
         /// <summary>
+        /// Ensures that the capacity of this <see cref="Array"/> is at least the specified
+        /// <paramref name="capacity"/>. You can use this method before repeated insertions to
+        /// improve performance. If the current capacity is less than <paramref name="capacity"/>,
+        /// the capacity grows in 1.5x increments when possible, and uses
+        /// <paramref name="capacity"/> exactly otherwise.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The array is read-only.
+        /// </exception>
+        /// <param name="capacity">The minimum capacity to ensure.</param>
+        /// <returns><see cref="Error.Ok"/> if successful, or an error code.</returns>
+        public Error EnsureCapacity(int capacity)
+        {
+            ThrowIfReadOnly();
+
+            var self = (godot_array)NativeValue;
+            return NativeFuncs.godotsharp_array_reserve(ref self, capacity);
+        }
+
+        /// <summary>
         /// Reverses the order of the elements in the array.
         /// </summary>
         /// <exception cref="InvalidOperationException">
@@ -1284,6 +1304,23 @@ namespace Godot.Collections
         public Error Resize(int newSize)
         {
             return _underlyingArray.Resize(newSize);
+        }
+
+        /// <summary>
+        /// Ensures that the capacity of this <see cref="Array{T}"/> is at least the specified
+        /// <paramref name="capacity"/>. You can use this method before repeated insertions to
+        /// improve performance. If the current capacity is less than <paramref name="capacity"/>,
+        /// the capacity grows in 1.5x increments when possible, and uses
+        /// <paramref name="capacity"/> exactly otherwise.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The array is read-only.
+        /// </exception>
+        /// <param name="capacity">The minimum capacity to ensure.</param>
+        /// <returns><see cref="Error.Ok"/> if successful, or an error code.</returns>
+        public Error EnsureCapacity(int capacity)
+        {
+            return _underlyingArray.EnsureCapacity(capacity);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -422,6 +422,8 @@ namespace Godot.NativeInterop
 
         public static partial Error godotsharp_array_resize(ref godot_array p_self, int p_new_size);
 
+        public static partial Error godotsharp_array_reserve(ref godot_array p_self, int p_new_size);
+
         public static partial void godotsharp_array_reverse(ref godot_array p_self);
 
         public static partial void godotsharp_array_shuffle(ref godot_array p_self);

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1154,6 +1154,10 @@ int32_t godotsharp_array_resize(Array *p_self, int32_t p_new_size) {
 	return (int32_t)p_self->resize(p_new_size);
 }
 
+int32_t godotsharp_array_reserve(Array *p_self, int32_t p_new_size) {
+	return (int32_t)p_self->reserve(p_new_size);
+}
+
 void godotsharp_array_reverse(Array *p_self) {
 	p_self->reverse();
 }
@@ -1773,6 +1777,7 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_array_recursive_equal,
 	(void *)godotsharp_array_remove_at,
 	(void *)godotsharp_array_resize,
+	(void *)godotsharp_array_reserve,
 	(void *)godotsharp_array_reverse,
 	(void *)godotsharp_array_shuffle,
 	(void *)godotsharp_array_slice,


### PR DESCRIPTION
```csharp
public class Godot.Collections.Array
{
+ /// <summary>
+ /// Ensures that the capacity of this <see cref="Array"/> is at least the specified
+ /// <paramref name="capacity"/>. You can use this method before repeated insertions to
+ /// improve performance. If the current capacity is less than <paramref name="capacity"/>,
+ /// the capacity grows in 1.5x increments when possible, and uses
+ /// <paramref name="capacity"/> exactly otherwise.
+ /// </summary>
+ /// <exception cref="InvalidOperationException">
+ /// The array is read-only.
+ /// </exception>
+ /// <param name="capacity">The minimum capacity to ensure.</param>
+ /// <returns><see cref="Error.Ok"/> if successful, or an error code.</returns>
+ public Error EnsureCapacity(int capacity);
}

public class Godot.Collections.Array<[MustBeVariant] T>
{
+ // inheritdoc
+ public Error EnsureCapacity(int capacity);
}
```

This is the C# side's exposure of the `reserve` function, which is crucial for the perf improvements on #106765 and is required for #96319 to have meaningful performance benefits.

Here is a benchmark for a typical batch-add elements with and without using `EnsureCapacity`, results are obtained with a release build of the application:

Code:

<details>

```csharp
public partial class Main : Node
{
    public override void _Ready()
    {
        IConfig config = new ManualConfig()
#if TOOLS
            .WithOptions(ConfigOptions.DisableOptimizationsValidator)
#endif
            .AddLogger(ConsoleLogger.Default)
            .AddJob(JobMode<Job>.Default.WithToolchain(new InProcessEmitToolchain(true)))
            .AddColumnProvider(DefaultColumnProviders.Instance);

        BenchmarkRunner.Run<Benchmarks>(config);

        AddChild(new Label { Text = "Benchmark completed. Check the console or cwd output for results." });
    }
}

public class Benchmarks
{
    private Array<int> _array;

    [IterationCleanup]
    public void Cleanup()
    {
        _array = null;
        GC.Collect();
    }
    
    [IterationSetup]
    public void Setup()
    {
        _array = [];
        GC.Collect();
    }

    [Params([
        10, 1000,
        1_0000, 10_0000,
        100_0000, 1000_0000,
    ])]
    public int Count;

    [Benchmark(Description = "Normal Add", Baseline = true)]
    public int NormalAdd()
    {
        for (var i = 0; i < Count; i++)
        {
            _array.Add(i);
        }

        return _array.Count;
    }

    [Benchmark(Description = "Add With EnsureCapacity")]
    public int AddWithEnsureCapacity()
    {
        _array.EnsureCapacity(Count);
        for (var i = 0; i < Count; i++)
        {
            _array.Add(i);
        }

        return _array.Count;
    }
}
```

</details>

Results:

```markdown
// * Summary *

BenchmarkDotNet v0.15.8, Windows 10 (10.0.19044.7058/21H2/November2021Update)
AMD Ryzen 9 7950X 4.50GHz, 1 CPU, 32 logical and 16 physical cores
.NET SDK 10.0.101
  [Host] : .NET 10.0.1 (10.0.1, 10.0.125.57005), X64 RyuJIT x86-64-v4

Toolchain=InProcessEmitToolchain  InvocationCount=1  UnrollFactor=1

| Method                    | Count    | Mean           | Error         | StdDev        | Median         | Ratio | RatioSD |
|-------------------------- |--------- |---------------:|--------------:|--------------:|---------------:|------:|--------:|
| 'Normal Add'              | 10       |       3.104 us |     0.0602 us |     0.0824 us |       3.100 us |  1.00 |    0.04 |
| 'Add With EnsureCapacity' | 10       |       2.130 us |     0.0443 us |     0.0414 us |       2.150 us |  0.69 |    0.02 |
|                           |          |                |               |               |                |       |         |
| 'Normal Add'              | 1000     |      44.831 us |     0.8873 us |     0.7409 us |      44.900 us |  1.00 |    0.02 |
| 'Add With EnsureCapacity' | 1000     |      40.430 us |     0.7947 us |     1.4126 us |      40.000 us |  0.90 |    0.03 |
|                           |          |                |               |               |                |       |         |
| 'Normal Add'              | 10000    |     157.106 us |     3.1073 us |     5.0177 us |     155.200 us |  1.00 |    0.04 |
| 'Add With EnsureCapacity' | 10000    |     166.898 us |     3.3158 us |     7.4844 us |     165.850 us |  1.06 |    0.06 |
|                           |          |                |               |               |                |       |         |
| 'Normal Add'              | 100000   |   2,102.389 us |    41.3691 us |    70.2479 us |   2,104.400 us |  1.00 |    0.05 |
| 'Add With EnsureCapacity' | 100000   |   1,612.936 us |    26.7175 us |    23.6843 us |   1,612.600 us |  0.77 |    0.03 |
|                           |          |                |               |               |                |       |         |
| 'Normal Add'              | 1000000  |  19,176.900 us |   372.3090 us |   330.0422 us |  19,115.750 us |  1.00 |    0.02 |
| 'Add With EnsureCapacity' | 1000000  |  12,968.549 us |   385.0767 us | 1,123.2868 us |  12,389.350 us |  0.68 |    0.06 |
|                           |          |                |               |               |                |       |         |
| 'Normal Add'              | 10000000 | 203,274.675 us | 3,905.7523 us | 7,335.9501 us | 201,086.500 us |  1.00 |    0.05 |
| 'Add With EnsureCapacity' | 10000000 | 122,456.843 us | 1,797.1436 us | 1,593.1210 us | 122,416.550 us |  0.60 |    0.02 |

// * Legends *
  Count   : Value of the 'Count' parameter
  Mean    : Arithmetic mean of all measurements
  Error   : Half of 99.9% confidence interval
  StdDev  : Standard deviation of all measurements
  Median  : Value separating the higher half of all measurements (50th percentile)
  Ratio   : Mean of the ratio distribution ([Current]/[Baseline])
  RatioSD : Standard deviation of the ratio distribution ([Current]/[Baseline])
  1 us    : 1 Microsecond (0.000001 sec)

// ***** BenchmarkRunner: End *****
Run time: 00:00:20 (20.57 sec), executed benchmarks: 12

Global total time: 00:00:21 (21.1 sec), executed benchmarks: 12
```

The test project (Requires a custom built godot editor + template):
[testensurecapacity_2026-03-19_17-00-06.zip](https://github.com/user-attachments/files/26110988/testensurecapacity_2026-03-19_17-00-06.zip)

Build Args:
```
scons module_mono_enabled=yes compile_db=yes accesskit=no
.\bin\godot.windows.editor.x86_64.mono.console.exe --headless --generate-mono-glue modules\mono\glue
python .\modules\mono\build_scripts\build_assemblies.py --godot-output-dir=.\bin
scons module_mono_enabled=yes accesskit=no target=template_release
```

How to use the test project:

Treat the test project as if it is a console application. Open the application through a terminal, and the tests will run automatically, producing the results. The main Godot application window will remain frozen while the tests are running, which is expected behavior. A test log will be generated alongside the main executable.