### PR TITLE
Editor: Default to base folder if saved editor layout folder does not exist

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -4255,9 +4255,64 @@ void FileSystemDock::load_layout_from_config(const Ref<ConfigFile> &p_layout, co
 
 	if (p_layout->has_section_key(p_section, "selected_paths")) {
 		PackedStringArray dock_filesystem_selected_paths = p_layout->get_value(p_section, "selected_paths");
-		for (int i = 0; i < dock_filesystem_selected_paths.size(); i++) {
-			select_file(dock_filesystem_selected_paths[i]);
+
+		if (dock_filesystem_selected_paths.size() > 1) {
+			get_tree_control()->deselect_all();
+
+			Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+			HashSet<String> paths_to_select;
+			for (const String &path : dock_filesystem_selected_paths) {
+				if (da->file_exists(path) || da->dir_exists(path)) {
+					paths_to_select.insert(path);
+				}
+			}
+
+			if (paths_to_select.is_empty()) {
+				select_file("res://"); // No valid file to select, default to base folder.
+			} else {
+				// Simple BFS from "res://" node to prevent default selection in "Favorite".
+				TreeItem *res_ti = get_tree_control()->get_item_with_metadata("res://", 0);
+				LocalVector<TreeItem *> ti_visit;
+				ti_visit.push_back(res_ti);
+				while (!ti_visit.is_empty()) {
+					TreeItem *curr_ti = ti_visit[0];
+
+					const String &path = curr_ti->get_metadata(0);
+					if (paths_to_select.has(path)) {
+						curr_ti->select(0);
+						current_path = path;
+
+						paths_to_select.erase(path);
+
+						if (paths_to_select.is_empty()) {
+							break;
+						}
+					}
+
+					TreeItem *child_ti = curr_ti->get_first_child();
+					while (child_ti) {
+						ti_visit.push_back(child_ti);
+						child_ti = child_ti->get_next();
+					}
+
+					ti_visit.remove_at(0);
+				}
+			}
+		} else if (dock_filesystem_selected_paths.size() == 1) {
+			Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+			const String &path = dock_filesystem_selected_paths[0];
+
+			if (da->file_exists(path) || da->dir_exists(path)) {
+				select_file(path);
+			} else {
+				select_file("res://"); // For single-selection, default to base folder.
+			}
+		} else {
+			get_tree_control()->deselect_all();
+			current_path = "";
 		}
+
+		current_path_line_edit->set_text(current_path);
 	}
 
 	// Restore collapsed state.


### PR DESCRIPTION
Fixes #117625, small QOL fix to default to res:// if a saved editor layout folder dne

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
