### PR TITLE
Allow searching editor shortcuts by path

### DIFF
--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -520,7 +520,7 @@ TreeItem *EditorSettingsDialog::_create_shortcut_treeitem(TreeItem *p_parent, co
 	return shortcut_item;
 }
 
-bool EditorSettingsDialog::_should_display_shortcut(const String &p_name, const Array &p_events, bool p_match_localized_name) const {
+bool EditorSettingsDialog::_should_display_shortcut(const String &p_path, const Array &p_events, const String &p_name) const {
 	const Ref<InputEvent> search_ev = shortcut_search_bar->get_event();
 	if (search_ev.is_valid()) {
 		bool event_match = false;
@@ -543,7 +543,10 @@ bool EditorSettingsDialog::_should_display_shortcut(const String &p_name, const 
 	if (search_text.is_subsequence_ofn(p_name)) {
 		return true;
 	}
-	if (p_match_localized_name && search_text.is_subsequence_ofn(TTR(p_name))) {
+	if (search_text.is_subsequence_ofn(TTR(p_name))) {
+		return true;
+	}
+	if (search_text.is_subsequence_ofn(p_path)) {
 		return true;
 	}
 
@@ -615,7 +618,7 @@ void EditorSettingsDialog::_update_shortcuts() {
 
 		const List<Ref<InputEvent>> &all_default_events = InputMap::get_singleton()->get_builtins_with_feature_overrides_applied().find(action_name)->value;
 		Array action_events = _event_list_to_array_helper(action.inputs);
-		if (!_should_display_shortcut(action_name, action_events, false)) {
+		if (!_should_display_shortcut(action_name, action_events)) {
 			continue;
 		}
 
@@ -678,7 +681,7 @@ void EditorSettingsDialog::_update_shortcuts() {
 		String section_name = E.get_slicec('/', 0);
 		TreeItem *section = sections[section_name];
 
-		if (!_should_display_shortcut(sc->get_name(), sc->get_events(), true)) {
+		if (!_should_display_shortcut(E, sc->get_events(), sc->get_name())) {
 			continue;
 		}
 

--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -107,7 +107,7 @@ class EditorSettingsDialog : public AcceptDialog {
 	PropertyInfo _create_mouse_shortcut_property_info(const String &p_property_name, const String &p_shortcut_1_name, const String &p_shortcut_2_name);
 	String _get_shortcut_button_string(const String &p_shortcut_name);
 
-	bool _should_display_shortcut(const String &p_name, const Array &p_events, bool p_match_localized_name) const;
+	bool _should_display_shortcut(const String &p_path, const Array &p_events, const String &p_name = String()) const;
 
 	void _update_shortcuts();
 	void _shortcut_button_pressed(Object *p_item, int p_column, int p_idx, MouseButton p_button = MouseButton::LEFT);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/14500

Makes it so that by default you search by the path name of a shortcut, as well as the "localized" string. By extension, this change makes it so that can filter by the section name as well, since that is part of the path

Before this PR:
<img width="900" height="700" alt="image" src="https://github.com/user-attachments/assets/ac7d44f2-8399-4cee-b163-9e989978839f" />


After this PR (and shows the path that was used as the search key)
<img width="950" height="783" alt="image" src="https://github.com/user-attachments/assets/709a68e8-0413-4184-876b-066bb1a20a8e" />

