### PR TITLE
Fix timeline cursor following mouse during marker selection

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -9170,6 +9170,7 @@ void AnimationMarkerEdit::gui_input(const Ref<InputEvent> &p_event) {
 			float offset = (pos.x - timeline->get_name_limit()) / timeline->get_zoom_scale();
 			if (!read_only) {
 				bool selected = _try_select_at_ui_pos(pos, mb->is_command_or_control_pressed() || mb->is_shift_pressed(), false);
+				moving_selection_attempt = false;
 
 				menu->clear();
 				menu->add_icon_item(get_editor_theme_icon(SNAME("Key")), TTRC("Insert Marker..."), MENU_KEY_INSERT);


### PR DESCRIPTION
When right-clicking an existing marker and then left-clicking an empty space on the timeline, and click another place on the timeline, the timeline cursor follow mouse without holding mouse.

Reproducible in: 4.6.1.stable
Not reproducible in: 4.5.1.stable

Before fix:

https://github.com/user-attachments/assets/2fe84dc3-50f4-420c-93a4-a0d5289d6aec

After fix:

https://github.com/user-attachments/assets/baaa50f1-8ebf-442e-a86b-8de184f25f29

Similar to #117276, The bug is reproducible in 4.6.1.stable while not reproducible in 4.5.1.stable. The bug was introduced in commit 2a10291. I confirmed that 2a10291~1 doesn't have this problem. The cause of the bug is that `moving_selection_attempt` is set as true in `_try_select_at_ui_pos`, and `AnimationMarkerEdit` accept the mouse releasing event when `moving_selection_attempt` is true, so the timeline doesn't know left-mouse has been released. To solve this problem we can add a `moving_selection_attempt = false`.

MRP
[mrp-timecursor-follow-jump.zip](https://github.com/user-attachments/files/26114886/mrp-timecursor-follow-jump.zip)

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
