### PR TITLE
`Camera2D.position_smoothing_speed`: correct description and fix overshoot bug

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -174,7 +174,7 @@
 			If [code]true[/code], the camera's view smoothly moves towards its target position at [member position_smoothing_speed].
 		</member>
 		<member name="position_smoothing_speed" type="float" setter="set_position_smoothing_speed" getter="get_position_smoothing_speed" default="5.0">
-			Speed in pixels per second of the camera's smoothing effect when [member position_smoothing_enabled] is [code]true[/code].
+			Interpolation amount per frame, divided by delta. For example a value of 30 with a framerate of 60 means each frame the camera will move half way from the last smoothed position to the target position. Requires [member position_smoothing_enabled] to be [code]true[/code].
 		</member>
 		<member name="process_callback" type="int" setter="set_process_callback" getter="get_process_callback" enum="Camera2D.Camera2DProcessCallback" default="1">
 			The camera's process callback.
@@ -184,7 +184,7 @@
 			[b]Note:[/b] This property has no effect if [member ignore_rotation] is [code]true[/code].
 		</member>
 		<member name="rotation_smoothing_speed" type="float" setter="set_rotation_smoothing_speed" getter="get_rotation_smoothing_speed" default="5.0">
-			The angular, asymptotic speed of the camera's rotation smoothing effect when [member rotation_smoothing_enabled] is [code]true[/code].
+			Interpolation amount per frame, divided by delta. For example a value of 30 with a framerate of 60 means each frame the camera will rotate half way from the last smoothed angle to the target angle. Requires [member rotation_smoothing_enabled] to be [code]true[/code].
 		</member>
 		<member name="zoom" type="Vector2" setter="set_zoom" getter="get_zoom" default="Vector2(1, 1)">
 			The camera's zoom. Higher values are more zoomed in. For example, a zoom of [code]Vector2(2.0, 2.0)[/code] will be twice as zoomed in on each axis (the view covers an area four times smaller). In contrast, a zoom of [code]Vector2(0.5, 0.5)[/code] will be twice as zoomed out on each axis (the view covers an area four times larger). The X and Y components should generally always be set to the same value, unless you wish to stretch the camera view.

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -199,7 +199,7 @@ Transform2D Camera2D::get_camera_transform() {
 		if (position_smoothing_enabled && !is_part_of_edited_scene()) {
 			bool physics_process = (process_callback == CAMERA2D_PROCESS_PHYSICS) || is_physics_interpolated_and_enabled();
 			real_t delta = physics_process ? get_physics_process_delta_time() : get_process_delta_time();
-			real_t c = position_smoothing_speed * delta;
+			real_t c = MIN(1.0, position_smoothing_speed * delta);
 			smoothed_camera_pos = ((camera_pos - smoothed_camera_pos) * c) + smoothed_camera_pos;
 			ret_camera_pos = smoothed_camera_pos;
 			//camera_pos=camera_pos*(1.0-position_smoothing_speed)+new_camera_pos*position_smoothing_speed;
@@ -216,7 +216,7 @@ Transform2D Camera2D::get_camera_transform() {
 
 	if (!ignore_rotation) {
 		if (rotation_smoothing_enabled && !is_part_of_edited_scene()) {
-			real_t step = rotation_smoothing_speed * (process_callback == CAMERA2D_PROCESS_PHYSICS ? get_physics_process_delta_time() : get_process_delta_time());
+			real_t step = MIN(1.0, rotation_smoothing_speed * (process_callback == CAMERA2D_PROCESS_PHYSICS ? get_physics_process_delta_time() : get_process_delta_time()));
 			camera_angle = Math::lerp_angle(camera_angle, get_global_rotation(), step);
 		} else {
 			camera_angle = get_global_rotation();
@@ -978,7 +978,7 @@ void Camera2D::_bind_methods() {
 
 	ADD_GROUP("Position Smoothing", "position_smoothing_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "position_smoothing_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_position_smoothing_enabled", "is_position_smoothing_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "position_smoothing_speed", PROPERTY_HINT_NONE, "suffix:px/s"), "set_position_smoothing_speed", "get_position_smoothing_speed");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "position_smoothing_speed", PROPERTY_HINT_NONE), "set_position_smoothing_speed", "get_position_smoothing_speed");
 
 	ADD_GROUP("Rotation Smoothing", "rotation_smoothing_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rotation_smoothing_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_rotation_smoothing_enabled", "is_rotation_smoothing_enabled");


### PR DESCRIPTION
In `Camera2D`, the property `position_smoothing_speed` has the following description: 

> Speed in pixels per second of the camera's smoothing effect when [member position_smoothing_enabled] is [code]true[/code].

This doesn't really make sense if we look at the observed behavior and looking at the code we can confirm it's indeed not a velocity at all.

From Camera2D::get_camera_transform():

```
// Get the time delta from process or physics_process depending on how the camera is set up
bool physics_process = (process_callback == CAMERA2D_PROCESS_PHYSICS) || is_physics_interpolated_and_enabled();
real_t delta = physics_process ? get_physics_process_delta_time() : get_process_delta_time();
// Calculate the offset vector from smoothed_position to the target position and scale it by position_smoothing_speed * delta. Then add it to smoothed position.
real_t c = position_smoothing_speed * delta;
smoothed_camera_pos = ((camera_pos - smoothed_camera_pos) * c) + smoothed_camera_pos;
```

As you can see what we're doing is a simple lerp: `smoothed_pos = lerp(smoothed_pos, target_pos, position_smoothing_speed * delta)` 

So `position_smoothing_speed` is not in px/s but 1/s and does not determine speed or acceleration, it's just part of a ratio calculation. It determines what proportion (not pixels) of the distance between the smoothed_position and the target_position the camera will cover every tick (process or physics depending on configuration). 

Besides the incorrect description, the approach can cause different behavior, even big glitches depending on framerate:

Any time `position_smoothing_speed * delta` ends up being higher than 1.0 we are extrapolating rather than interpolating. This is easy to trigger by `position_smoothing_speed` to a value higher than the max fps but it can also happen with reasonable values if time delta becomes high enough. 

For example, if the camera is set to update on process, and `position_smoothing_speed` is set to 60 then when delta is 1/120 the lerping factor is 0.5 so the camera moves half way to the target position each frame. If delta increases to 1/60 then the camera moves all the way to the target position, as if with no smoothing. So far so good. If the framerate drops to 30 a delta of 1/30 will result in a lerping factor of 2. That means the camera actually overshoots across the target position and ends at the same distance it was before, causing a constant oscillation. Any consistent drops in framerate that result in a lerping factor above 2 will completely break smoothing since the camera will overshoot more and more each frame as can be observed here: 

https://github.com/user-attachments/assets/c3112b61-c1b6-412a-88e0-fd3b5ee3e67c

**What this PR does**

This PR corrects the description of `position_smoothing_speed` to give users a more accurate intuition on what different values do and fixes the overshoot by clamping the calculated lerp factor to 1. 

This fixes the overshoot bug in a compatible manner. A more correct solution would be to use frame-independent interpolation such as exponential decay, as explained here: https://docs.godotengine.org/en/stable/tutorials/math/interpolation.html#smoothing-motion (see Note)


