### PR TITLE
Reduce contention when reading from Tracy intern table

### DIFF
--- a/core/profiling/profiling.cpp
+++ b/core/profiling/profiling.cpp
@@ -34,7 +34,9 @@
 // Use the tracy profiler.
 
 #include "core/os/mutex.h"
+#include "core/os/thread.h"
 #include "core/templates/paged_allocator.h"
+#include "core/templates/safe_refcount.h"
 
 namespace tracy {
 static bool configured = false;
@@ -47,51 +49,121 @@ struct StringInternData {
 	StringName name;
 	CharString name_utf8;
 
-	uint32_t hash = 0;
-	StringInternData *prev = nullptr;
 	StringInternData *next = nullptr;
-
-	StringInternData() {}
 };
 
 struct SourceLocationInternData {
-	const StringInternData *file;
-	const StringInternData *function;
-	const StringInternData *name;
+	const StringInternData *file = nullptr;
+	const StringInternData *function = nullptr;
+	const StringInternData *name = nullptr;
 
-	tracy::SourceLocationData source_location_data;
+	tracy::SourceLocationData source_location_data = {};
 
 	uint32_t function_ptr_hash = 0;
-	SourceLocationInternData *prev = nullptr;
 	SourceLocationInternData *next = nullptr;
-
-	SourceLocationInternData() {}
 };
 
 struct TracyInternTable {
 	constexpr static uint32_t TABLE_BITS = 16;
 	constexpr static uint32_t TABLE_LEN = 1 << TABLE_BITS;
 	constexpr static uint32_t TABLE_MASK = TABLE_LEN - 1;
+	constexpr static uint32_t READER_SLOT_COUNT = 128;
 
-	static inline BinaryMutex mutex;
+	// We can't use a `RWLock` here, since it writes to an atomic within the lock whenever a reader locks or unlocks it,
+	// and since the critical section here is small and heavily read from, the cache line bouncing caused by the atomic
+	// writes would be almost as bad as a mutex. So instead we use a custom R/W lock with multiple reader counters that
+	// all sit on their own cache lines, significantly reducing the likelihood of any contention.
 
-	static inline SourceLocationInternData *source_location_table[TABLE_LEN];
+	struct alignas(Thread::CACHE_LINE_BYTES) ReaderSlot {
+		constexpr static uint32_t WRITER_BIT = 1u << 31;
+		constexpr static uint32_t READER_MASK = ~WRITER_BIT;
+
+		SafeNumeric<uint32_t> state;
+
+		bool has_writer() const { return state.get() & WRITER_BIT; }
+		bool has_readers() const { return state.get() & READER_MASK; }
+		bool add_reader() { return !(state.postincrement() & WRITER_BIT); }
+		void remove_reader() { state.decrement(); }
+		void set_writing() { state.bit_or(WRITER_BIT); }
+		void clear_writing() { state.bit_and(READER_MASK); }
+	};
+
+	static inline BinaryMutex write_mutex;
+	static inline ReaderSlot reader_slots[READER_SLOT_COUNT];
+
+	static inline SourceLocationInternData *source_location_table[TABLE_LEN] = {};
 	static inline PagedAllocator<SourceLocationInternData> source_location_allocator;
 
-	static inline StringInternData *string_table[TABLE_LEN];
+	static inline StringInternData *string_table[TABLE_LEN] = {};
 	static inline PagedAllocator<StringInternData> string_allocator;
+
+	static void read_lock() {
+		uint32_t slot_idx = Thread::get_caller_id() % READER_SLOT_COUNT;
+		ReaderSlot &slot = reader_slots[slot_idx];
+
+		while (true) {
+			while (slot.has_writer()) {
+				Thread::yield();
+			}
+
+			if (slot.add_reader()) {
+				return;
+			}
+
+			slot.remove_reader();
+		}
+	}
+
+	static void read_unlock() {
+		uint32_t slot_idx = Thread::get_caller_id() % READER_SLOT_COUNT;
+		reader_slots[slot_idx].remove_reader();
+	}
+
+	static void write_lock() {
+		write_mutex.lock();
+
+		for (uint32_t i = 0; i < READER_SLOT_COUNT; i++) {
+			reader_slots[i].set_writing();
+		}
+
+		for (uint32_t i = 0; i < READER_SLOT_COUNT; i++) {
+			while (reader_slots[i].has_readers()) {
+				Thread::yield();
+			}
+		}
+	}
+
+	static void write_unlock() {
+		for (uint32_t i = 0; i < READER_SLOT_COUNT; i++) {
+			reader_slots[i].clear_writing();
+		}
+
+		write_mutex.unlock();
+	}
+
+	struct [[nodiscard]] ReadLock {
+		ReadLock() { read_lock(); }
+		~ReadLock() { read_unlock(); }
+		ReadLock(const ReadLock &) = delete;
+		ReadLock &operator=(const ReadLock &) = delete;
+	};
+
+	struct [[nodiscard]] WriteLock {
+		WriteLock() { write_lock(); }
+		~WriteLock() { write_unlock(); }
+		WriteLock(const WriteLock &) = delete;
+		WriteLock &operator=(const WriteLock &) = delete;
+	};
 };
 
-const StringInternData *_intern_name(const StringName &p_name) {
-	CRASH_COND(!configured);
-
+static const StringInternData *_intern_name(const StringName &p_name) {
 	const uint32_t hash = p_name.hash();
 	const uint32_t idx = hash & TracyInternTable::TABLE_MASK;
 
 	StringInternData *_data = TracyInternTable::string_table[idx];
 
 	while (_data) {
-		if (_data->hash == hash) {
+		if (_data->name == p_name) {
 			return _data;
 		}
 		_data = _data->next;
@@ -102,30 +174,39 @@ const StringInternData *_intern_name(const StringName &p_name) {
 	_data->name_utf8 = p_name.operator String().utf8();
 
 	_data->next = TracyInternTable::string_table[idx];
-	_data->prev = nullptr;
-
-	if (TracyInternTable::string_table[idx]) {
-		TracyInternTable::string_table[idx]->prev = _data;
-	}
 	TracyInternTable::string_table[idx] = _data;
 
 	return _data;
+}
+
+static SourceLocationInternData *_find_source_location(uint32_t p_hash, const StringName &p_file, const StringName &p_function, const StringName &p_name, uint32_t p_line) {
+	const uint32_t idx = p_hash & TracyInternTable::TABLE_MASK;
+	for (SourceLocationInternData *_data = TracyInternTable::source_location_table[idx]; _data; _data = _data->next) {
+		if (_data->function_ptr_hash == p_hash && _data->source_location_data.line == p_line && _data->file->name == p_file && _data->function->name == p_function && _data->name->name == p_name) {
+			return _data;
+		}
+	}
+
+	return nullptr;
 }
 
 const tracy::SourceLocationData *intern_source_location(const void *p_function_ptr, const StringName &p_file, const StringName &p_function, const StringName &p_name, uint32_t p_line, bool p_is_script) {
 	ERR_FAIL_COND_V(!configured, &dummy_source_location);
 
 	const uint32_t hash = HashMapHasherDefault::hash(p_function_ptr);
-	const uint32_t idx = hash & TracyInternTable::TABLE_MASK;
 
-	MutexLock lock(TracyInternTable::mutex);
-	SourceLocationInternData *_data = TracyInternTable::source_location_table[idx];
-
-	while (_data) {
-		if (_data->function_ptr_hash == hash && _data->source_location_data.line == p_line && _data->file->name == p_file && _data->function->name == p_function && _data->name->name == p_name) {
+	{
+		TracyInternTable::ReadLock lock;
+		SourceLocationInternData *_data = _find_source_location(hash, p_file, p_function, p_name, p_line);
+		if (_data != nullptr) {
 			return &_data->source_location_data;
 		}
-		_data = _data->next;
+	}
+
+	TracyInternTable::WriteLock lock;
+	SourceLocationInternData *_data = _find_source_location(hash, p_file, p_function, p_name, p_line);
+	if (_data != nullptr) {
+		return &_data->source_location_data;
 	}
 
 	_data = TracyInternTable::source_location_allocator.alloc();
@@ -142,12 +223,8 @@ const tracy::SourceLocationData *intern_source_location(const void *p_function_p
 	_data->source_location_data.line = p_line;
 	_data->source_location_data.color = p_is_script ? 0x478cbf : 0; // godot_logo_blue
 
+	const uint32_t idx = hash & TracyInternTable::TABLE_MASK;
 	_data->next = TracyInternTable::source_location_table[idx];
-	_data->prev = nullptr;
-
-	if (TracyInternTable::source_location_table[idx]) {
-		TracyInternTable::source_location_table[idx]->prev = _data;
-	}
 	TracyInternTable::source_location_table[idx] = _data;
 
 	return &_data->source_location_data;
@@ -155,15 +232,7 @@ const tracy::SourceLocationData *intern_source_location(const void *p_function_p
 } // namespace tracy
 
 void godot_init_profiler() {
-	MutexLock lock(tracy::TracyInternTable::mutex);
 	ERR_FAIL_COND(tracy::configured);
-
-	for (uint32_t i = 0; i < tracy::TracyInternTable::TABLE_LEN; i++) {
-		tracy::TracyInternTable::source_location_table[i] = nullptr;
-	}
-	for (uint32_t i = 0; i < tracy::TracyInternTable::TABLE_LEN; i++) {
-		tracy::TracyInternTable::string_table[i] = nullptr;
-	}
 
 	tracy::configured = true;
 
@@ -173,20 +242,21 @@ void godot_init_profiler() {
 }
 
 void godot_cleanup_profiler() {
-	MutexLock lock(tracy::TracyInternTable::mutex);
 	ERR_FAIL_COND(!tracy::configured);
+
+	tracy::TracyInternTable::WriteLock lock;
 
 	for (uint32_t i = 0; i < tracy::TracyInternTable::TABLE_LEN; i++) {
 		while (tracy::TracyInternTable::source_location_table[i]) {
 			tracy::SourceLocationInternData *d = tracy::TracyInternTable::source_location_table[i];
-			tracy::TracyInternTable::source_location_table[i] = tracy::TracyInternTable::source_location_table[i]->next;
+			tracy::TracyInternTable::source_location_table[i] = d->next;
 			tracy::TracyInternTable::source_location_allocator.free(d);
 		}
 	}
 	for (uint32_t i = 0; i < tracy::TracyInternTable::TABLE_LEN; i++) {
 		while (tracy::TracyInternTable::string_table[i]) {
 			tracy::StringInternData *d = tracy::TracyInternTable::string_table[i];
-			tracy::TracyInternTable::string_table[i] = tracy::TracyInternTable::string_table[i]->next;
+			tracy::TracyInternTable::string_table[i] = d->next;
 			tracy::TracyInternTable::string_allocator.free(d);
 		}
 	}


### PR DESCRIPTION
Fixes #117640.

_(This PR originally took a thread-local approach to this problem, but ended up being rewritten. See below for the original description.)_

This changes the locking mechanism of `TracyInternTable` to not use a single global `BinaryMutex` but instead use a custom R/W lock that uses multiple (128) reader counters, specifically to avoid the cache contention that something like Godot's actual `RWLock` would suffer from in a small critical section like this.

Here are the results from the MRP after this change, showing nearly linear scaling:

```
1 thread: 4914 ms
32 threads: 324 ms
Ideal scaling (assuming hyper-threading) would be 16x, but actual scaling is 15.2x
```

<details><summary><i>[Click to see original description]</i></summary>
<p>

> This simply makes the members of `TracyInternTable` non-static, and instead makes `TracyInternTable` itself a `static thread_local`, which allows us to remove the `TracyInternTable::mutex` that's causing so much contention with multi-threaded GDScript workloads. Having `TracyInternTable` itself be a static thread-local means we can also guarantee that proper cleanup happens before the program exits.
> 
> This will of course multiply the memory normally used by this interning by the number of threads, but given how memory-heavy Tracy seems to be in its profiling anyway, this is likely a drop in the ocean.
> 
> Here are the numbers I'm now seeing in the MRP from #117640, again with `target=template_release` and `production=yes`:
> 
> ```
> 1 thread: 7039 ms
> 32 threads: 615 ms
> Ideal scaling (assuming hyper-threading) would be 16x, but actual scaling is 11.4x
> ```

</p>
</details>

---

*Disclaimer: AI tooling was used in the making of this change. Any code not physically typed out by myself has been carefully reviewed to the best of my ability.*