### PR TITLE
Highlight help items when following documentation references

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -56,9 +56,9 @@
 #include "editor/script/syntax_highlighters.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/gui/color_rect.h"
 #include "scene/gui/line_edit.h"
 #include "servers/display/display_server.h"
-#include "scene/gui/color_rect.h"
 
 #include "modules/modules_enabled.gen.h" // For gdscript, mono.
 
@@ -2448,7 +2448,7 @@ void EditorHelp::_help_callback(const String &p_topic) {
 		_update_search_highlight();
 	} else {
 		scroll_to = line;
-	}	
+	}
 }
 
 static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const Control *p_owner_node, const String &p_class) {
@@ -3475,11 +3475,11 @@ EditorHelp::EditorHelp() {
 	status_bar->set_custom_minimum_size(Size2(0, 24 * EDSCALE));
 
 	search_highlight = memnew(ColorRect);
-	search_highlight->set_color(Color(0.4, 0.7, 1.0, 0.15)); 
-	search_highlight->set_mouse_filter(MOUSE_FILTER_IGNORE); 
+	search_highlight->set_color(Color(0.4, 0.7, 1.0, 0.15));
+	search_highlight->set_mouse_filter(MOUSE_FILTER_IGNORE);
 	search_highlight->set_size(Vector2(0, 0));
 	search_highlight->set_position(Vector2(0, 0));
-	class_desc->call_deferred("add_child", search_highlight);
+	class_desc->add_child(search_highlight);
 
 	toggle_files_button = memnew(Button);
 	toggle_files_button->set_theme_type_variation(SceneStringName(FlatButton));

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -267,11 +267,11 @@ void EditorHelp::_search(bool p_search_previous) {
 }
 
 void EditorHelp::_update_search_highlight() {
-	float y_offset = class_desc->get_paragraph_offset(line_to_highlight);
-	float y_offset2 = class_desc->get_paragraph_offset(line_to_highlight + 2);
+	float start_y = class_desc->get_paragraph_offset(line_to_highlight + 1);
+	float end_y = class_desc->get_paragraph_offset(line_to_highlight_end);
 	float scroll_y = class_desc->get_v_scroll_bar()->get_value();
-	float highlight_position_y = y_offset - scroll_y;
-	float highlight_size_y = y_offset2 - y_offset;
+	float highlight_position_y = start_y - scroll_y;
+	float highlight_size_y = end_y - start_y;
 
 	search_highlight->set_position(Vector2(0, highlight_position_y));
 	search_highlight->set_size(Vector2(class_desc->get_size().x, highlight_size_y));
@@ -286,6 +286,26 @@ void EditorHelp::_start_search_highlight_tweener() {
 	search_highlight->set_modulate(Color(1.0, 1.0, 1.0, 1.0));
 	search_highlight_tween->tween_interval(0.5);
 	search_highlight_tween->tween_property(search_highlight, NodePath("modulate:a"), 0.0, 2.0);
+}
+
+int EditorHelp::_calculate_search_highlight_end(const HashMap<String, int> *query_table) {
+	if (!query_table || query_table->is_empty()) {
+		return line_to_highlight;
+	}
+
+	for (const KeyValue<String, int> &E : *query_table) {
+		if (E.value > line_to_highlight) {
+			return E.value;
+		}
+	}
+
+	for (const Pair<String, int> &E : section_line) {
+		if (E.second > line_to_highlight) {
+			return E.second;
+		}
+	}
+
+	return class_desc->get_paragraph_count() - 1;
 }
 
 void EditorHelp::_class_desc_finished() {
@@ -367,6 +387,7 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 		if (table->has(link)) {
 			// Found in the current page.
 			line_to_highlight = (*table)[link];
+			line_to_highlight_end = _calculate_search_highlight_end(table);
 			if (class_desc->is_finished()) {
 				emit_signal(SNAME("request_save_history"));
 				class_desc->scroll_to_paragraph((*table)[link]);
@@ -2405,47 +2426,58 @@ void EditorHelp::_help_callback(const String &p_topic) {
 	_request_help(clss); // First go to class.
 
 	int line = 0;
+	const HashMap<String, int> *query_table = nullptr;
 
 	if (what == "class_desc") {
 		line = description_line;
 	} else if (what == "class_signal") {
 		if (signal_line.has(name)) {
 			line = signal_line[name];
+			query_table = &signal_line;
 		}
 	} else if (what == "class_method" || what == "class_method_desc") {
 		if (method_line.has(name)) {
 			line = method_line[name];
+			query_table = &method_line;
 		}
 	} else if (what == "class_property") {
 		if (property_line.has(name)) {
 			line = property_line[name];
+			query_table = &property_line;
 		}
 	} else if (what == "class_enum") {
 		if (enum_line.has(name)) {
 			line = enum_line[name];
+			query_table = &enum_line;
 		}
 	} else if (what == "class_theme_item") {
 		if (theme_property_line.has(name)) {
 			line = theme_property_line[name];
+			query_table = &theme_property_line;
 		}
 	} else if (what == "class_constant") {
 		if (constant_line.has(name)) {
 			line = constant_line[name];
+			query_table = &constant_line;
 		}
 	} else if (what == "class_annotation") {
 		if (annotation_line.has(name)) {
 			line = annotation_line[name];
+			query_table = &annotation_line;
 		}
 	} else if (what == "class_global") { // Deprecated.
 		if (constant_line.has(name)) {
 			line = constant_line[name];
+			query_table = &constant_line;
 		} else if (method_line.has(name)) {
 			line = method_line[name];
+			query_table = &method_line;
 		} else {
 			HashMap<String, HashMap<String, int>>::Iterator iter = enum_values_line.begin();
 			while (true) {
 				if (iter->value.has(name)) {
 					line = iter->value[name];
+					query_table = &(iter->value);
 					break;
 				} else if (iter == enum_values_line.last()) {
 					break;
@@ -2457,6 +2489,7 @@ void EditorHelp::_help_callback(const String &p_topic) {
 	}
 
 	line_to_highlight = line;
+	line_to_highlight_end = _calculate_search_highlight_end(query_table);
 
 	if (class_desc->is_finished()) {
 		class_desc->scroll_to_paragraph(line);

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -56,6 +56,7 @@
 #include "editor/script/syntax_highlighters.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/animation/tween.h"
 #include "scene/gui/color_rect.h"
 #include "scene/gui/line_edit.h"
 #include "servers/display/display_server.h"
@@ -276,10 +277,22 @@ void EditorHelp::_update_search_highlight() {
 	search_highlight->set_size(Vector2(class_desc->get_size().x, highlight_size_y));
 }
 
+void EditorHelp::_start_search_highlight_tweener() {
+	if (search_highlight_tween.is_valid() && search_highlight_tween->is_running()) {
+		search_highlight_tween->kill();
+	}
+
+	search_highlight_tween = class_desc->create_tween();
+	search_highlight->set_modulate(Color(1.0, 1.0, 1.0, 1.0));
+	search_highlight_tween->tween_interval(0.5);
+	search_highlight_tween->tween_property(search_highlight, NodePath("modulate:a"), 0.0, 2.0);
+}
+
 void EditorHelp::_class_desc_finished() {
 	if (scroll_to >= 0) {
 		class_desc->connect(SceneStringName(draw), callable_mp(class_desc, &RichTextLabel::scroll_to_paragraph).bind(scroll_to), CONNECT_ONE_SHOT | CONNECT_DEFERRED);
 		_update_search_highlight();
+		_start_search_highlight_tweener();
 	}
 	scroll_to = -1;
 }
@@ -357,6 +370,8 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 			if (class_desc->is_finished()) {
 				emit_signal(SNAME("request_save_history"));
 				class_desc->scroll_to_paragraph((*table)[link]);
+				_update_search_highlight();
+				_start_search_highlight_tweener();
 			} else {
 				scroll_to = (*table)[link];
 			}
@@ -2446,6 +2461,7 @@ void EditorHelp::_help_callback(const String &p_topic) {
 	if (class_desc->is_finished()) {
 		class_desc->scroll_to_paragraph(line);
 		_update_search_highlight();
+		_start_search_highlight_tweener();
 	} else {
 		scroll_to = line;
 	}
@@ -3475,7 +3491,7 @@ EditorHelp::EditorHelp() {
 	status_bar->set_custom_minimum_size(Size2(0, 24 * EDSCALE));
 
 	search_highlight = memnew(ColorRect);
-	search_highlight->set_color(Color(0.4, 0.7, 1.0, 0.15));
+	search_highlight->set_color(Color(0.4, 0.7, 1.0, 0.25));
 	search_highlight->set_mouse_filter(MOUSE_FILTER_IGNORE);
 	search_highlight->set_size(Vector2(0, 0));
 	search_highlight->set_position(Vector2(0, 0));

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -58,6 +58,7 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/line_edit.h"
 #include "servers/display/display_server.h"
+#include "scene/gui/color_rect.h"
 
 #include "modules/modules_enabled.gen.h" // For gdscript, mono.
 
@@ -264,9 +265,21 @@ void EditorHelp::_search(bool p_search_previous) {
 	}
 }
 
+void EditorHelp::_update_search_highlight() {
+	float y_offset = class_desc->get_paragraph_offset(line_to_highlight);
+	float y_offset2 = class_desc->get_paragraph_offset(line_to_highlight + 2);
+	float scroll_y = class_desc->get_v_scroll_bar()->get_value();
+	float highlight_position_y = y_offset - scroll_y;
+	float highlight_size_y = y_offset2 - y_offset;
+
+	search_highlight->set_position(Vector2(0, highlight_position_y));
+	search_highlight->set_size(Vector2(class_desc->get_size().x, highlight_size_y));
+}
+
 void EditorHelp::_class_desc_finished() {
 	if (scroll_to >= 0) {
 		class_desc->connect(SceneStringName(draw), callable_mp(class_desc, &RichTextLabel::scroll_to_paragraph).bind(scroll_to), CONNECT_ONE_SHOT | CONNECT_DEFERRED);
+		_update_search_highlight();
 	}
 	scroll_to = -1;
 }
@@ -340,6 +353,7 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 		// Case order is important here to correctly handle edge cases like `Variant.Type` in `@GlobalScope`.
 		if (table->has(link)) {
 			// Found in the current page.
+			line_to_highlight = (*table)[link];
 			if (class_desc->is_finished()) {
 				emit_signal(SNAME("request_save_history"));
 				class_desc->scroll_to_paragraph((*table)[link]);
@@ -2427,11 +2441,14 @@ void EditorHelp::_help_callback(const String &p_topic) {
 		}
 	}
 
+	line_to_highlight = line;
+
 	if (class_desc->is_finished()) {
 		class_desc->scroll_to_paragraph(line);
+		_update_search_highlight();
 	} else {
 		scroll_to = line;
-	}
+	}	
 }
 
 static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const Control *p_owner_node, const String &p_class) {
@@ -3444,6 +3461,7 @@ EditorHelp::EditorHelp() {
 	class_desc->connect("meta_clicked", callable_mp(this, &EditorHelp::_class_desc_select));
 	class_desc->connect(SceneStringName(gui_input), callable_mp(this, &EditorHelp::_class_desc_input));
 	class_desc->connect(SceneStringName(resized), callable_mp(this, &EditorHelp::_class_desc_resized).bind(false));
+	class_desc->connect(SceneStringName(draw), callable_mp(this, &EditorHelp::_update_search_highlight));
 
 	// Added second so it opens at the bottom so it won't offset the entire widget.
 	find_bar = memnew(FindBar);
@@ -3455,6 +3473,13 @@ EditorHelp::EditorHelp() {
 	add_child(status_bar);
 	status_bar->set_h_size_flags(SIZE_EXPAND_FILL);
 	status_bar->set_custom_minimum_size(Size2(0, 24 * EDSCALE));
+
+	search_highlight = memnew(ColorRect);
+	search_highlight->set_color(Color(0.4, 0.7, 1.0, 0.15)); 
+	search_highlight->set_mouse_filter(MOUSE_FILTER_IGNORE); 
+	search_highlight->set_size(Vector2(0, 0));
+	search_highlight->set_position(Vector2(0, 0));
+	class_desc->call_deferred("add_child", search_highlight);
 
 	toggle_files_button = memnew(Button);
 	toggle_files_button->set_theme_type_variation(SceneStringName(FlatButton));

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -288,12 +288,12 @@ void EditorHelp::_start_search_highlight_tweener() {
 	search_highlight_tween->tween_property(search_highlight, NodePath("modulate:a"), 0.0, 2.0);
 }
 
-int EditorHelp::_calculate_search_highlight_end(const HashMap<String, int> *query_table) {
-	if (!query_table || query_table->is_empty()) {
+int EditorHelp::_calculate_search_highlight_end(const HashMap<String, int> *p_query_table) {
+	if (!p_query_table || p_query_table->is_empty()) {
 		return line_to_highlight;
 	}
 
-	for (const KeyValue<String, int> &E : *query_table) {
+	for (const KeyValue<String, int> &E : *p_query_table) {
 		if (E.value > line_to_highlight) {
 			return E.value;
 		}

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -81,6 +81,7 @@ public:
 };
 
 class EditorFileSystemDirectory;
+class ColorRect;
 
 class EditorHelp : public VBoxContainer {
 	GDCLASS(EditorHelp, VBoxContainer);
@@ -110,6 +111,7 @@ class EditorHelp : public VBoxContainer {
 	HashMap<String, HashMap<String, int>> enum_values_line;
 	int description_line = 0;
 
+	ColorRect *search_highlight = nullptr;
 	RichTextLabel *class_desc = nullptr;
 	inline static DocTools *doc = nullptr;
 	inline static DocTools *ext_doc = nullptr;
@@ -149,6 +151,8 @@ class EditorHelp : public VBoxContainer {
 
 	int scroll_to = -1;
 
+	int line_to_highlight = -1;
+
 	void _help_callback(const String &p_topic);
 
 	void _add_text(const String &p_bbcode);
@@ -167,6 +171,8 @@ class EditorHelp : public VBoxContainer {
 	void _pop_title_font();
 	void _push_code_font();
 	void _pop_code_font();
+
+	void _update_search_highlight();
 
 	void _class_desc_finished();
 	void _class_list_select(const String &p_select);

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -176,7 +176,7 @@ class EditorHelp : public VBoxContainer {
 
 	void _update_search_highlight();
 	void _start_search_highlight_tweener();
-	int _calculate_search_highlight_end(const HashMap<String, int> *query_table);
+	int _calculate_search_highlight_end(const HashMap<String, int> *p_query_table);
 
 	void _class_desc_finished();
 	void _class_list_select(const String &p_select);

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -111,6 +111,7 @@ class EditorHelp : public VBoxContainer {
 	HashMap<String, HashMap<String, int>> enum_values_line;
 	int description_line = 0;
 
+	Ref<Tween> search_highlight_tween;
 	ColorRect *search_highlight = nullptr;
 	RichTextLabel *class_desc = nullptr;
 	inline static DocTools *doc = nullptr;
@@ -173,6 +174,7 @@ class EditorHelp : public VBoxContainer {
 	void _pop_code_font();
 
 	void _update_search_highlight();
+	void _start_search_highlight_tweener();
 
 	void _class_desc_finished();
 	void _class_list_select(const String &p_select);

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -153,6 +153,7 @@ class EditorHelp : public VBoxContainer {
 	int scroll_to = -1;
 
 	int line_to_highlight = -1;
+	int line_to_highlight_end = -1;
 
 	void _help_callback(const String &p_topic);
 
@@ -175,6 +176,7 @@ class EditorHelp : public VBoxContainer {
 
 	void _update_search_highlight();
 	void _start_search_highlight_tweener();
+	int _calculate_search_highlight_end(const HashMap<String, int> *query_table);
 
 	void _class_desc_finished();
 	void _class_list_select(const String &p_select);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
## Summary
Highlights the relevant help item when following documentation references to methods/properties/etc.

## Motivation
Closes godotengine/godot-proposals#2248.

When navigating cross-references inside the documentation, especially in classes with many members or long pages, it can be hard to visually locate the referenced method/property after the jump. Highlighting the destination makes navigation clearer and faster.

## Example screenshot
<img width="2739" height="1567" alt="image" src="https://github.com/user-attachments/assets/4ac40983-05e3-4f6a-8e04-2d81620d7a52" />


## Technical details
- Added highlighting for the destination help item when a documentation reference is followed.
- Updated the relevant documentation/help UI code to make the referenced section easier to identify after navigation.
- The change is minimal and kept local to the editor_help code.

## Testing
- Built the editor locally.
- Opened the class reference/help viewer.
- Clicked method/property references in a script file or directly from the documentation pages.
- Verified that the referenced help item is visibly highlighted after navigation.
- Confirmed normal navigation still works as expected and the highlighted item remains visible after switching to other windows or scrolling.

## Related proposal
- godotengine/godot-proposals#2248