### PR TITLE
[Android] Follow up fixes to enabling orientation change in the script editor

### DIFF
--- a/platform/android/editor/editor_utils_jni.cpp
+++ b/platform/android/editor/editor_utils_jni.cpp
@@ -98,9 +98,11 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_runSc
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_toggleTitleBar(JNIEnv *p_env, jclass, jboolean p_visible) {
 #ifdef TOOLS_ENABLED
-	EditorTitleBar *title_bar = EditorNode::get_singleton()->get_title_bar();
-	if (title_bar != nullptr) {
-		title_bar->call_deferred("set_visible", p_visible);
+	if (EditorNode::get_singleton() != nullptr) {
+		EditorTitleBar *title_bar = EditorNode::get_singleton()->get_title_bar();
+		if (title_bar != nullptr) {
+			title_bar->call_deferred("set_visible", p_visible);
+		}
 	}
 #endif
 }

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -256,8 +256,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 
 		// Skip permissions request if running in a device farm (e.g. firebase test lab) or if requested via the launch
 		// intent (e.g. instrumentation tests).
-		val skipPermissionsRequest = isRunningInInstrumentation() ||
-			Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && ActivityManager.isRunningInUserTestHarness()
+		val skipPermissionsRequest = isRunningInInstrumentation() || ActivityManager.isRunningInUserTestHarness()
 		if (!skipPermissionsRequest) {
 			// We exclude certain permissions from the set we request at startup, as they'll be
 			// requested on demand based on use cases.
@@ -279,9 +278,9 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 	override fun onConfigurationChanged(newConfig: Configuration) {
 		super.onConfigurationChanged(newConfig)
 
-		// Show EditorTitleBar only in landscape due to width limitations in portrait.
+		// Show EditorTitleBar on small screens only in landscape due to width limitations in portrait.
 		// TODO: Enable for portrait once the title bar width is optimized.
-		EditorUtils.toggleTitleBar(newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE)
+		EditorUtils.toggleTitleBar(isLargeScreen || newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE)
 	}
 
 	override fun onDestroy() {
@@ -805,7 +804,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 			}
 
 			PermissionsUtil.REQUEST_INSTALL_PACKAGES_REQ_CODE -> {
-				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !packageManager.canRequestPackageInstalls()) {
+				if (!packageManager.canRequestPackageInstalls()) {
 					Toast.makeText(
 						this,
 						R.string.denied_install_packages_permission_error_msg,

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/GameMenuFragment.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/GameMenuFragment.kt
@@ -181,10 +181,7 @@ class GameMenuFragment : Fragment(), PopupMenu.OnMenuItemClickListener {
 		PopupMenu(context, optionsButton).apply {
 			setOnMenuItemClickListener(this@GameMenuFragment)
 			inflate(R.menu.options_menu)
-
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-				menu.setGroupDividerEnabled(true)
-			}
+			menu.setGroupDividerEnabled(true)
 		}
 	}
 


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/117109

- Fix project manager crash when rotating the device
- Fix title bar disappearing when rotating large screen devices (tablet and foldables)

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
