### PR TITLE
Fix Error on Embedded windows not redrawn borders after unfocus

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -424,8 +424,10 @@ void Viewport::_sub_window_grab_focus(Window *p_window) {
 		// Release current focus.
 		if (gui.subwindow_focused) {
 			gui.subwindow_focused->_event_callback(DisplayServerEnums::WINDOW_EVENT_FOCUS_OUT);
+			Window *old_focus = gui.subwindow_focused;
 			gui.subwindow_focused = nullptr;
 			gui.subwindow_drag = SUB_WINDOW_DRAG_DISABLED;
+			_sub_window_update(old_focus);
 		}
 
 		Window *this_window = Object::cast_to<Window>(this);


### PR DESCRIPTION
When the user click on the background, the current focused window is nullptr, which cause the previous focused window not to be updated. Thus, we need to call the updating function after setting the the previous focused window to be nullptr.
