### PR TITLE
CI: Bump macOS runners

### DIFF
--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   ios-template:
     # From https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#choosing-github-hosted-runners
-    runs-on: macos-latest
+    runs-on: macos-26
     name: Template (target=template_release)
     timeout-minutes: 60
 
@@ -22,10 +22,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-
-      # From https://github.com/actions/runner-images/blob/main/images/macos
-      - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.0.1.app
 
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build-macos:
     # From https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#choosing-github-hosted-runners
-    runs-on: macos-latest
+    runs-on: macos-26
     name: ${{ matrix.name }}
     timeout-minutes: 120
     strategy:
@@ -35,10 +35,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-
-      # From https://github.com/actions/runner-images/blob/main/images/macos
-      - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.0.1.app
 
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore


### PR DESCRIPTION
Changes from the generic `macos-latest` to `macos-26` explicitly, which will soon be the latest version. This uses a later version of XCode by default (26.2), which should fix the issue of our macOS arm64 template failing