### PR TITLE
Fix time property drag range in FPS mode for AnimationKey and Marker

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -8804,6 +8804,7 @@ AnimationTrackKeyEditEditor::AnimationTrackKeyEditEditor(Ref<Animation> p_animat
 			fps = 1.0 / fps;
 		}
 		spinner->set_value(key_ofs * fps);
+		spinner->set_max(animation->get_length() * fps);
 		spinner->connect("updown_pressed", callable_mp(this, &AnimationTrackKeyEditEditor::_time_edit_spun), CONNECT_DEFERRED);
 	} else {
 		spinner->set_step(SECOND_DECIMAL);
@@ -9979,6 +9980,7 @@ AnimationMarkerKeyEditEditor::AnimationMarkerKeyEditEditor(Ref<Animation> p_anim
 			fps = 1.0 / fps;
 		}
 		spinner->set_value(time * fps);
+		spinner->set_max(animation->get_length() * fps);
 		spinner->connect("updown_pressed", callable_mp(this, &AnimationMarkerKeyEditEditor::_time_edit_exited), CONNECT_DEFERRED);
 	} else {
 		spinner->set_step(SECOND_DECIMAL);


### PR DESCRIPTION
In FPS mode, the time in the inspector uses a fixed 0–100 drag range,
instead of the actual animation length.

This PR sets the max value based on the animation length in FPS units.

https://github.com/user-attachments/assets/9dc966ff-af69-4257-844e-116b3472a87d




Fixes #117635