### PR TITLE
CI: Implement `clangd-tidy` as GitHub Action

### DIFF
--- a/.github/actions/clangd-tidy/action.yml
+++ b/.github/actions/clangd-tidy/action.yml
@@ -1,0 +1,30 @@
+name: clangd-tidy
+description: Setup and run clangd-tidy on relevant files
+
+inputs:
+  changed-files:
+    description: A pre-filtered list of changed files.
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Setup clangd-tidy
+      shell: sh
+      run: |
+        echo "::group::Prerequisite checks"
+        if [ ! -f "compile_commands.json" ]; then
+          echo "::error::clangd-tidy checker requires a compilation database to function"
+          exit 1
+        fi
+        echo "::endgroup::"
+
+        echo "::group::Installing clangd-tidy"
+        # Don't know which python we're using, so just access the global scope.
+        python -m pip install clangd clangd-tidy clang-tidy==22.1.0
+        echo "::endgroup::"
+
+        echo "::group::Running clangd-tidy"
+        clangd-tidy ${{ inputs.changed-files }}
+        echo "::endgroup::"

--- a/.github/changed_files.yml
+++ b/.github/changed_files.yml
@@ -7,10 +7,23 @@ everything:
 #  files changing would result in SCons rebuilding the engine, or are otherwise pertinent to the
 #  buildsystem itself.
 sources:
-  - .github/{actions,workflows}/*.yml
+  - .github/{actions/*,workflows}/*.yml
   - "**/{SConstruct,SCsub,*.py}"
   - "**/*.{h,hpp,hh,hxx,c,cpp,cc,cxx,m,mm,inc,glsl}"
   - modules/mono/**/*.{cs,csproj,sln,props,targets}
   - platform/android/java/{gradle*,**/*.{jar,java,kt,gradle}}
   - platform/web/{package{,-lock}.json,js/**/*.js}
   - tests/**
+
+# Determines which files are appropriate for running clangd-tidy checks on. This is a subset out
+#  of necessity, as we're only evaluating a Linux runner.
+clangd:
+  - "**/*.{h,hpp,hxx,hh,c,cpp,cxx,cc}"
+  - "!**/thirdparty/**"
+  - "!**/*-so_wrap.{h,c}"
+  - "!drivers/{apple*,core*,d3d12,metal,wasapi,windows,winmidi,xaudio2}/**"
+  - "!editor/shader/shader_baker/shader_baker_export_plugin_platform_{d3d12,metal}.{h,cpp}"
+  - "!modules/camera/camera_{android,macos,win}.{h,cpp}"
+  - "!modules/openxr/extensions/platform/openxr_{android,metal}_extension.{h,cpp}"
+  - "!platform/{android,ios,macos,visionos,web,windows}/**"
+  - "platform/{android,ios,macos,visionos,web,windows}/{api,export}/*.{h,hpp,hxx,hh,c,cpp,cxx,cc}"

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       changed-files:
-        description: A list of changed files.
+        description: A list of changed files, pre-filtered for parsing by clangd-tidy.
         required: true
         type: string
   workflow_dispatch:
@@ -44,7 +44,7 @@ jobs:
             artifact: true
             # Validate godot-cpp compatibility on one arbitrary editor build.
             godot-cpp: true
-            clang-tidy: true
+            clangd-tidy: true
 
           - name: Editor with doubles and GCC sanitizers (target=editor, dev_build=yes, scu_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=mold)
             cache-name: linux-editor-double-sanitizers
@@ -186,11 +186,11 @@ jobs:
           platform: linuxbsd
           target: ${{ matrix.target }}
 
-      - name: Style checks via pre-commit
-        if: matrix.clang-tidy
-        uses: pre-commit/action@v3.0.1
+      - name: Style checks via clangd-tidy
+        if: matrix.clangd-tidy
+        uses: ./.github/actions/clangd-tidy
         with:
-          extra_args: --files ${{ inputs.changed-files }} --hook-stage manual clang-tidy
+          changed-files: ${{ inputs.changed-files }}
 
       - name: Compilation (godot-cpp)
         uses: ./.github/actions/godot-cpp-build

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     outputs:
       changed-files:
-        description: A list of changed files.
+        description: A list of changed files, pre-filtered for parsing by clangd-tidy.
         value: ${{ jobs.static-checks.outputs.changed-files }}
       sources-changed:
         description: Determines if any source files were changed.
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     outputs:
-      changed-files: '"${{ steps.changed-files.outputs.everything_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
+      changed-files: '"${{ steps.changed-files.outputs.clangd_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
       sources-changed: ${{ steps.changed-files.outputs.sources_any_changed }}
     steps:
       - name: Checkout

--- a/core/core_constants.cpp
+++ b/core/core_constants.cpp
@@ -32,7 +32,6 @@
 
 #include "core/input/input_enums.h"
 #include "core/object/method_bind_common.h" // IWYU pragma: keep. For `VARIANT_BITFIELD_CAST(MethodFlags)`.
-#include "core/object/object.h"
 #include "core/os/keyboard.h"
 #include "core/variant/type_info.h"
 #include "core/variant/variant.h"

--- a/core/doc_data.cpp
+++ b/core/doc_data.cpp
@@ -30,7 +30,8 @@
 
 #include "doc_data.h"
 
-#include "core/object/object.h"
+#include "core/object/method_info.h"
+#include "core/object/property_info.h"
 
 String DocData::get_default_value_string(const Variant &p_value) {
 	const Variant::Type type = p_value.get_type();

--- a/core/object/method_info.cpp
+++ b/core/object/method_info.cpp
@@ -32,7 +32,7 @@
 
 #include "core/variant/array.h"
 #include "core/variant/dictionary.h"
-#include "core/variant/typed_array.h"
+#include "core/variant/typed_array.h" // IWYU pragma: keep. `convert_property_list` return type.
 
 MethodInfo::operator Dictionary() const {
 	Dictionary d;

--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -30,9 +30,12 @@
 
 #include "memory.h"
 
-#include "core/math/math_funcs_binary.h"
 #include "core/profiling/profiling.h"
 #include "core/templates/safe_refcount.h"
+
+#ifdef DEV_ENABLED
+#include "core/math/math_funcs_binary.h"
+#endif
 
 #include <cstdlib>
 

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/object/object.h"
 #include "core/templates/simple_type.h"
 #include "core/typedefs.h"
 #include "core/variant/method_ptrcall.h"

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -33,7 +33,6 @@
 #include "gdscript_cache.h"
 #include "gdscript_parser.h"
 
-#include "core/object/object.h"
 #include "core/object/ref_counted.h"
 
 class GDScriptAnalyzer {

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -30,6 +30,7 @@
 
 #include "gdscript_warning.h"
 
+#include "core/object/property_info.h"
 #include "core/variant/variant.h"
 
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -32,9 +32,10 @@
 
 #ifdef DEBUG_ENABLED
 
-#include "core/object/object.h"
-#include "core/string/ustring.h"
 #include "core/templates/vector.h"
+
+class String;
+struct PropertyInfo;
 
 class GDScriptWarning {
 public:

--- a/modules/jolt_physics/jolt_globals.cpp
+++ b/modules/jolt_physics/jolt_globals.cpp
@@ -35,8 +35,11 @@
 #include "shapes/jolt_custom_ray_shape.h"
 #include "shapes/jolt_custom_user_data_shape.h"
 
-#include "core/string/print_string.h"
+#include "core/os/memory.h"
+
+#ifdef JPH_ENABLE_ASSERTS
 #include "core/variant/variant.h"
+#endif
 
 #include <Jolt/Jolt.h>
 

--- a/platform/ios/export/export.cpp
+++ b/platform/ios/export/export.cpp
@@ -34,7 +34,10 @@
 
 #include "core/object/class_db.h"
 #include "editor/export/editor_export.h"
+
+#ifdef MACOS_ENABLED
 #include "editor/settings/editor_settings.h"
+#endif
 
 void register_ios_exporter_types() {
 	GDREGISTER_VIRTUAL_CLASS(EditorExportPlatformIOS);

--- a/platform/macos/export/export.cpp
+++ b/platform/macos/export/export.cpp
@@ -33,6 +33,8 @@
 #include "export_plugin.h"
 
 #include "core/object/class_db.h"
+#include "editor/export/editor_export.h"
+#include "editor/settings/editor_settings.h"
 
 void register_macos_exporter_types() {
 	GDREGISTER_VIRTUAL_CLASS(EditorExportPlatformMacOS);

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -33,7 +33,8 @@
 #include "logo_svg.gen.h"
 #include "run_icon_svg.gen.h"
 
-#include "core/io/image_loader.h"
+#include "core/config/project_settings.h"
+#include "core/io/marshalls.h"
 #include "core/io/plist.h"
 #include "core/io/zip_io.h"
 #include "core/object/class_db.h"
@@ -43,10 +44,12 @@
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/export/codesign.h"
+#include "editor/export/editor_export.h"
 #include "editor/export/lipo.h"
 #include "editor/export/macho.h"
 #include "editor/file_system/editor_paths.h"
 #include "editor/import/resource_importer_texture_settings.h"
+#include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/resources/image_texture.h"
 

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -30,15 +30,10 @@
 
 #pragma once
 
-#include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
-#include "core/io/file_access.h"
 #include "core/io/image.h"
-#include "core/io/marshalls.h"
-#include "core/io/resource_saver.h"
 #include "core/os/process_id.h"
-#include "editor/export/editor_export.h"
-#include "editor/settings/editor_settings.h"
+#include "editor/export/editor_export_platform.h"
 #include "scene/resources/image_texture.h"
 
 #include <sys/stat.h>

--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -30,7 +30,6 @@
 
 #include "shader_preprocessor.h"
 
-#include "core/math/expression.h"
 #include "core/os/os.h"
 #include "servers/rendering/shader_expression.h"
 

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -30,7 +30,9 @@
 
 #include "shader_types.h"
 
+#ifdef DEV_ENABLED
 #include "scene/resources/shader.h"
+#endif
 
 const HashMap<StringName, ShaderLanguage::FunctionInfo> &ShaderTypes::get_functions(RSE::ShaderMode p_mode) const {
 	return shader_modes[p_mode].functions;

--- a/servers/rendering/storage/material_storage.h
+++ b/servers/rendering/storage/material_storage.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/object/object.h"
 #include "servers/rendering/rendering_server_enums.h"
 #include "servers/rendering/rendering_server_types.h"
 #include "servers/rendering/storage/utilities.h"


### PR DESCRIPTION
Replaces our current `clang-tidy` checker in CI with a `clangd-tidy` equivalent. This integrates the more lightweight checker in a way that's directly integrated with our repository & should have a wider coverage than the `clang-tidy` pre-commit hook

Example output on filtered files can be viewed on [this runner from a dummy commit](https://github.com/Repiteo/godot/actions/runs/23309574331/job/67793077539).