### PR TITLE
Call stop after setting new sprite frames

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -316,7 +316,6 @@ void AnimatedSprite2D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 	if (frames.is_valid()) {
 		frames->disconnect(CoreStringName(changed), callable_mp(this, &AnimatedSprite2D::_res_changed));
 	}
-	stop();
 	frames = p_frames;
 	if (frames.is_valid()) {
 		frames->connect(CoreStringName(changed), callable_mp(this, &AnimatedSprite2D::_res_changed));
@@ -335,6 +334,7 @@ void AnimatedSprite2D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 			}
 		}
 	}
+	stop();
 
 	notify_property_list_changed();
 	queue_redraw();

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1217,7 +1217,6 @@ void AnimatedSprite3D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 	if (frames.is_valid()) {
 		frames->disconnect(CoreStringName(changed), callable_mp(this, &AnimatedSprite3D::_res_changed));
 	}
-	stop();
 	frames = p_frames;
 	if (frames.is_valid()) {
 		frames->connect(CoreStringName(changed), callable_mp(this, &AnimatedSprite3D::_res_changed));
@@ -1236,6 +1235,7 @@ void AnimatedSprite3D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 			}
 		}
 	}
+	stop();
 
 	notify_property_list_changed();
 	_queue_redraw();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/86058

Calling `stop` after setting new sprite frames fixes the bug by calling indirectly `set_frame_and_progress` after new frame duration data is available.
Order of emitted signals is preserved, at least I couldn't find a way to change it in the test code.
Fixing it like this does not introduce any new code.

There's old stale PR https://github.com/godotengine/godot/pull/86277 which could be closed if this one gets merged.

Test project: [frameduration.zip](https://github.com/user-attachments/files/26126874/frameduration.zip)
