### PR TITLE
Fix previous keyframe needing to be pressed twice

### DIFF
--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -265,7 +265,7 @@ void AnimationPlayerEditor::go_to_nearest_keyframe(bool p_backward) {
 
 	double current_time = player->get_current_animation_position();
 	// Offset the time to avoid finding the same keyframe with Animation::track_find_key().
-	double time_offset = MAX(CMP_EPSILON * 2, current_time * CMP_EPSILON * 2);
+	double time_offset = MAX(frame->get_step(), current_time * frame->get_step());
 	double current_time_offset = current_time + (p_backward ? -time_offset : time_offset);
 
 	float nearest_key_time = p_backward ? 0 : anim->get_length();


### PR DESCRIPTION
Fixes #117543 bug where the previous or next keyframe shortcuts had to be pressed twice to work. The function go_to_nearest_keyframe was using a small offset that was smaller than frame step, which made track_find_key find the same key twice. Changing the offset to the same size as frame step means it will search past the snapping amount.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
