### PR TITLE
Ignore key echo for axis lock cycling during 3D transforms

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2753,7 +2753,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 				_clear_selected();
 				return;
 			}
-		} else {
+		} else if (!k->is_echo()) {
 			// We're actively transforming, handle keys specially
 			TransformPlane new_plane = TRANSFORM_VIEW;
 			if (ED_IS_SHORTCUT("spatial_editor/lock_transform_x", event_mod)) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Fixes this when I hold down the `Y` key to axis lock on the Y axis after starting a transform with the gizmo for example:

https://github.com/user-attachments/assets/4256087c-0240-46ee-a0bf-fb3371ccb74a

