### PR TITLE
[GDExtension] Load embedded extension before project settings

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -675,6 +675,10 @@ void ProjectSettings::_convert_to_last_version(int p_from_version) {
  *    If nothing was found, error out.
  */
 Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, bool p_upwards, bool p_ignore_override) {
+	if (CoreGlobals::run_global_project_settings_function()) {
+		return OK;
+	}
+
 	if (!OS::get_singleton()->get_resource_dir().is_empty()) {
 		// OS will call ProjectSettings->get_resource_path which will be empty if not overridden!
 		// If the OS would rather use a specific location, then it will not be empty.

--- a/core/core_globals.h
+++ b/core/core_globals.h
@@ -30,6 +30,11 @@
 
 #pragma once
 
+#include "core/extension/gdextension_interface.gen.h"
+
+typedef GDExtensionBool (*GDInitFunction)();
+typedef void (*GDWorldInitFunction)();
+
 // Home for state needed from global functions
 // that cannot be stored in Engine or OS due to e.g. circular includes
 
@@ -38,4 +43,25 @@ public:
 	static inline bool leak_reporting_enabled = true;
 	static inline bool print_line_enabled = true;
 	static inline bool print_error_enabled = true;
+
+	static inline GDInitFunction global_project_settings_function = nullptr;
+	static inline GDWorldInitFunction global_world_init_function = nullptr;
+
+	static inline bool run_global_project_settings_function() {
+		if (global_project_settings_function == nullptr) {
+			return false;
+		}
+		return global_project_settings_function();
+	}
+
+	static inline bool run_global_world_init_function() {
+		if (global_world_init_function == nullptr) {
+			return false;
+		}
+		global_world_init_function();
+		return true;
+	}
+
+	static inline GDExtensionInitializationFunction global_init_func_libgodot = nullptr;
+	static inline int32_t global_load_status_libgodot = 0;
 };

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -31,6 +31,7 @@
 #include "gdextension_interface.gen.h"
 
 #include "core/config/engine.h"
+#include "core/core_globals.h"
 #include "core/extension/gdextension.h"
 #include "core/extension/gdextension_special_compat_hashes.h"
 #include "core/io/file_access.h"
@@ -1692,6 +1693,11 @@ static void gdextension_editor_help_load_xml_from_utf8_chars(const char *p_data)
 #endif
 }
 
+static void gdextension_register_libgodot_callbacks(GDExtensionClassLibraryPtr p_library, const GDExtensionLibGodotCallbacks *p_callbacks) {
+	CoreGlobals::global_project_settings_function = (GDInitFunction)p_callbacks->project_settings_func;
+	CoreGlobals::global_world_init_function = (GDWorldInitFunction)p_callbacks->world_init_func;
+}
+
 #define REGISTER_INTERFACE_FUNC(m_name) GDExtension::register_interface_function(#m_name, (GDExtensionInterfaceFunctionPtr) & gdextension_##m_name)
 
 void gdextension_setup_interface() {
@@ -1866,6 +1872,7 @@ void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(editor_help_load_xml_from_utf8_chars_and_len);
 	REGISTER_INTERFACE_FUNC(image_ptrw);
 	REGISTER_INTERFACE_FUNC(image_ptr);
+	REGISTER_INTERFACE_FUNC(register_libgodot_callbacks);
 }
 
 #undef REGISTER_INTERFACE_FUNCTION

--- a/core/extension/gdextension_interface.json
+++ b/core/extension/gdextension_interface.json
@@ -3488,6 +3488,47 @@
                     ]
                 }
             ]
+        },
+        {
+            "name": "GDExtensionLibGodotProjectSettingsCallback",
+            "kind": "function",
+            "return_value": {
+                "type": "GDExtensionBool"
+            },
+            "arguments": [],
+            "description": [
+                "Called during ProjectSettings setup to allow the embedded extension to configure project settings.",
+                "Return true if project settings were handled (skips loading from project.godot file)."
+            ]
+        },
+        {
+            "name": "GDExtensionLibGodotWorldInitCallback",
+            "kind": "function",
+            "arguments": [],
+            "description": [
+                "Called during scene initialization to allow the embedded extension to set up the initial scene.",
+                "When registered, this replaces the default scene loading from a project file."
+            ]
+        },
+        {
+            "name": "GDExtensionLibGodotCallbacks",
+            "kind": "struct",
+            "members": [
+                {
+                    "name": "project_settings_func",
+                    "type": "GDExtensionLibGodotProjectSettingsCallback",
+                    "description": [
+                        "Will be called during ProjectSettings::_setup() to allow overriding project settings."
+                    ]
+                },
+                {
+                    "name": "world_init_func",
+                    "type": "GDExtensionLibGodotWorldInitCallback",
+                    "description": [
+                        "Will be called during Main::start() to set up the initial scene instead of loading from a project file."
+                    ]
+                }
+            ]
         }
     ],
     "interface": [
@@ -9038,6 +9079,30 @@
                 "Registers callbacks to be called at different phases of the main loop."
             ],
             "since": "4.5"
+        },
+        {
+            "name": "register_libgodot_callbacks",
+            "arguments": [
+                {
+                    "name": "p_library",
+                    "type": "GDExtensionClassLibraryPtr",
+                    "description": [
+                        "A pointer the library received by the GDExtension's entry point function."
+                    ]
+                },
+                {
+                    "name": "p_callbacks",
+                    "type": "const GDExtensionLibGodotCallbacks*",
+                    "description": [
+                        "A pointer to the structure that contains the callbacks."
+                    ]
+                }
+            ],
+            "description": [
+                "Registers callbacks for LibGodot embedded extensions to override project settings and scene initialization.",
+                "This should be called from the extension's entry point function before initialization levels are processed."
+            ],
+            "since": "4.7"
         }
     ]
 }

--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -63,6 +63,15 @@ GDExtensionManager::LoadStatus GDExtensionManager::_load_extension_internal(cons
 	return LOAD_STATUS_OK;
 }
 
+void GDExtensionManager::load_embedded_extension() {
+	if (CoreGlobals::global_init_func_libgodot != nullptr) {
+		GDExtensionConstPtr<const GDExtensionInitializationFunction> ptr((const GDExtensionInitializationFunction *)&CoreGlobals::global_init_func_libgodot);
+		CoreGlobals::global_load_status_libgodot = load_extension_from_function("libgodot://main", ptr);
+	} else {
+		CoreGlobals::global_load_status_libgodot = LOAD_STATUS_FAILED;
+	}
+}
+
 void GDExtensionManager::_finish_load_extension(const Ref<GDExtension> &p_extension) {
 #ifdef TOOLS_ENABLED
 	// Signals that a new extension is loaded so GDScript can register new class names.

--- a/core/extension/gdextension_manager.h
+++ b/core/extension/gdextension_manager.h
@@ -90,6 +90,7 @@ public:
 
 	static GDExtensionManager *get_singleton();
 
+	void load_embedded_extension();
 	void load_extensions();
 	void reload_extensions();
 	bool ensure_extensions_loaded(const HashSet<String> &p_extensions);

--- a/core/extension/godot_instance.cpp
+++ b/core/extension/godot_instance.cpp
@@ -53,12 +53,13 @@ GodotInstance::GodotInstance() {
 GodotInstance::~GodotInstance() {
 }
 
-bool GodotInstance::initialize(GDExtensionInitializationFunction p_init_func) {
-	print_verbose("Godot Instance initialization");
-	GDExtensionManager *gdextension_manager = GDExtensionManager::get_singleton();
-	GDExtensionConstPtr<const GDExtensionInitializationFunction> ptr((const GDExtensionInitializationFunction *)&p_init_func);
-	GDExtensionManager::LoadStatus status = gdextension_manager->load_extension_from_function("libgodot://main", ptr);
-	return status == GDExtensionManager::LoadStatus::LOAD_STATUS_OK;
+bool GodotInstance::initialize() {
+	if (CoreGlobals::global_load_status_libgodot == GDExtensionManager::LoadStatus::LOAD_STATUS_OK) {
+		print_verbose("Godot Instance: embedded extension loaded successfully.");
+		return true;
+	}
+	print_verbose("Godot Instance: embedded extension failed to load.");
+	return false;
 }
 
 bool GodotInstance::start() {
@@ -69,7 +70,9 @@ bool GodotInstance::start() {
 	}
 	started = Main::start() == EXIT_SUCCESS;
 	if (started) {
-		OS::get_singleton()->get_main_loop()->initialize();
+		if (OS::get_singleton()->get_main_loop()) {
+			OS::get_singleton()->get_main_loop()->initialize();
+		}
 	}
 	return started;
 }
@@ -86,7 +89,9 @@ bool GodotInstance::iteration() {
 void GodotInstance::stop() {
 	print_verbose("GodotInstance::stop()");
 	if (started) {
-		OS::get_singleton()->get_main_loop()->finalize();
+		if (OS::get_singleton()->get_main_loop()) {
+			OS::get_singleton()->get_main_loop()->finalize();
+		}
 	}
 	started = false;
 }

--- a/core/extension/godot_instance.h
+++ b/core/extension/godot_instance.h
@@ -45,7 +45,7 @@ public:
 	GodotInstance();
 	~GodotInstance();
 
-	bool initialize(GDExtensionInitializationFunction p_init_func);
+	bool initialize();
 
 	bool start();
 	bool is_started();

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -383,12 +383,16 @@ void register_core_singletons() {
 	OS::get_singleton()->benchmark_end_measure("Core", "Register Singletons");
 }
 
+void gd_extension_load_extensions() {
+	gdextension_manager->load_extensions();
+}
+
 void register_core_extensions() {
 	OS::get_singleton()->benchmark_begin_measure("Core", "Register Extensions");
 
 	// Hardcoded for now.
 	GDExtension::initialize_gdextensions();
-	gdextension_manager->load_extensions();
+	gdextension_manager->load_embedded_extension();
 	gdextension_manager->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_CORE);
 	_is_core_extensions_registered = true;
 

--- a/core/register_core_types.h
+++ b/core/register_core_types.h
@@ -32,6 +32,7 @@
 
 void register_core_types();
 void register_core_settings();
+void gd_extension_load_extensions();
 void register_core_extensions();
 void register_early_core_singletons();
 void register_core_singletons();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -782,6 +782,7 @@ Error Main::test_setup() {
 	register_early_core_singletons();
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
 	register_core_extensions();
+	gd_extension_load_extensions(); // Load GDExtensions that are not embedded
 
 	register_core_singletons();
 
@@ -2050,6 +2051,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 #endif // defined(DEBUG_ENABLED) || defined (TOOLS_ENABLED)
 
+	register_early_core_singletons();
+	initialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
+	register_core_extensions(); // core extensions registered really early for embedded extensions to override the project settings
+
 	OS::get_singleton()->_in_editor = editor;
 	if (globals->setup(project_path, main_pack, false, editor) == OK) {
 #ifdef TOOLS_ENABLED
@@ -2224,9 +2229,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		OS::get_singleton()->_verbose_stdout = GLOBAL_GET("debug/settings/stdout/verbose_stdout");
 	}
 
-	register_early_core_singletons();
-	initialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
-	register_core_extensions(); // core extensions must be registered after globals setup and before display
+	gd_extension_load_extensions(); // Load GDExtensions that are not embedded
 
 	if (!editor) {
 		ResourceUID::get_singleton()->enable_reverse_cache();
@@ -4703,7 +4706,9 @@ int Main::start() {
 			// Load SSL Certificates from Project Settings (or builtin).
 			Crypto::load_default_certificates(GLOBAL_GET("network/tls/certificate_bundle_override"));
 
-			if (!game_path.is_empty()) {
+			if (CoreGlobals::run_global_world_init_function()) {
+				// World initialized by LibGodot callback — skip scene loading.
+			} else if (!game_path.is_empty()) {
 				Node *scene = nullptr;
 				Ref<PackedScene> scenedata = ResourceLoader::load(local_game_path);
 				if (scenedata.is_valid()) {

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -63,6 +63,12 @@
 #include <dlfcn.h>
 #include <sys/system_properties.h>
 
+extern "C" {
+LIBGODOT_API void libgodot_register_function(GDExtensionInitializationFunction p_init_func) {
+	CoreGlobals::global_init_func_libgodot = p_init_func;
+}
+}
+
 const char *OS_Android::ANDROID_EXEC_PATH = "apk";
 
 String _remove_symlink(const String &dir) {

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -32,8 +32,13 @@
 
 #include "audio_driver_opensl.h"
 
+#include "core/extension/libgodot.h"
 #include "core/os/main_loop.h"
 #include "drivers/unix/os_unix.h"
+
+extern "C" {
+LIBGODOT_API void libgodot_register_function(GDExtensionInitializationFunction p_init_func);
+}
 
 class GodotJavaWrapper;
 class GodotIOJavaWrapper;

--- a/platform/linuxbsd/libgodot_linuxbsd.cpp
+++ b/platform/linuxbsd/libgodot_linuxbsd.cpp
@@ -30,6 +30,7 @@
 
 #include "os_linuxbsd.h"
 
+#include "core/core_globals.h"
 #include "core/extension/godot_instance.h"
 #include "core/extension/libgodot.h"
 #include "main/main.h"
@@ -41,6 +42,8 @@ static GodotInstance *instance = nullptr;
 GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
 	ERR_FAIL_COND_V_MSG(instance != nullptr, nullptr, "Only one Godot Instance may be created.");
 
+	CoreGlobals::global_init_func_libgodot = p_init_func;
+
 	os = new OS_LinuxBSD();
 
 	Error err = Main::setup(p_argv[0], p_argc - 1, &p_argv[1], false);
@@ -49,7 +52,7 @@ GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], 
 	}
 
 	instance = memnew(GodotInstance);
-	if (!instance->initialize(p_init_func)) {
+	if (!instance->initialize()) {
 		memdelete(instance);
 		// Note: When Godot Engine supports reinitialization, clear the instance pointer here.
 		//instance = nullptr;

--- a/platform/macos/libgodot_macos.mm
+++ b/platform/macos/libgodot_macos.mm
@@ -30,6 +30,7 @@
 
 #include "os_macos.h"
 
+#include "core/core_globals.h"
 #include "core/extension/godot_instance.h"
 #include "core/extension/libgodot.h"
 #include "main/main.h"
@@ -41,6 +42,8 @@ static GodotInstance *instance = nullptr;
 GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
 	ERR_FAIL_COND_V_MSG(instance != nullptr, nullptr, "Only one Godot Instance may be created.");
 
+	CoreGlobals::global_init_func_libgodot = p_init_func;
+
 	uint32_t remaining_args = p_argc - 1;
 	os = new OS_MacOS_NSApp(p_argv[0], remaining_args, remaining_args > 0 ? &p_argv[1] : nullptr);
 
@@ -51,7 +54,7 @@ GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], 
 		}
 
 		instance = memnew(GodotInstance);
-		if (!instance->initialize(p_init_func)) {
+		if (!instance->initialize()) {
 			memdelete(instance);
 			instance = nullptr;
 			return nullptr;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -8195,4 +8195,6 @@ DisplayServerWindows::~DisplayServerWindows() {
 	}
 
 	OleUninitialize();
+
+	UnregisterClassW(wc.lpszClassName, wc.hInstance);
 }

--- a/platform/windows/libgodot_windows.cpp
+++ b/platform/windows/libgodot_windows.cpp
@@ -30,6 +30,7 @@
 
 #include "os_windows.h"
 
+#include "core/core_globals.h"
 #include "core/extension/godot_instance.h"
 #include "core/extension/libgodot.h"
 #include "main/main.h"
@@ -41,6 +42,8 @@ static GodotInstance *instance = nullptr;
 GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
 	ERR_FAIL_COND_V_MSG(instance != nullptr, nullptr, "Only one Godot Instance may be created at a time.");
 
+	CoreGlobals::global_init_func_libgodot = p_init_func;
+
 	os = new OS_Windows(GetModuleHandle(nullptr));
 
 	Error err = Main::setup(p_argv[0], p_argc - 1, &p_argv[1], false);
@@ -49,7 +52,7 @@ GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], 
 	}
 
 	instance = memnew(GodotInstance);
-	if (!instance->initialize(p_init_func)) {
+	if (!instance->initialize()) {
 		memdelete(instance);
 		instance = nullptr;
 		return nullptr;


### PR DESCRIPTION
Move embedded extension loading earlier in Main::setup() so it runs before globals->setup(). Allows overriding project settings without a project.godot file when using LibGodot.

Adds register_libgodot_callbacks interface function for project settings and world init hooks. Split load_extensions into embedded and file-based.
