### PR TITLE
Fix signal button disable on script edit

### DIFF
--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -1733,7 +1733,8 @@ void ConnectionsDock::update_tree() {
 
 	connect_button->set_text(TTRC("Connect..."));
 	connect_button->set_button_icon(get_editor_theme_icon(SNAME("Instance")));
-	connect_button->set_disabled(true);
+	// Check if connect button can be enabled.
+	_tree_item_selected();
 }
 
 ConnectionsDock::ConnectionsDock() {


### PR DESCRIPTION
Fixes #117623 where editing a script file would cause the "Connect..." button to become disabled. This change checks for selection in connections dock tree to see if connect button can be enabled or disabled.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
