### PR TITLE
GDScript: Use `TightLocalVector` for `members`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1551,7 +1551,7 @@ bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 				callp(member->setter, &args, 1, err);
 				return err.error == Callable::CallError::CALL_OK;
 			} else {
-				members.write[member->index] = value;
+				members[member->index] = value;
 				return true;
 			}
 		}
@@ -1997,23 +1997,19 @@ const Variant GDScriptInstance::get_rpc_config() const {
 void GDScriptInstance::reload_members() {
 #ifdef DEBUG_ENABLED
 
-	Vector<Variant> new_members;
+	TightLocalVector<Variant> new_members;
 	new_members.resize(script->member_indices.size());
 
-	//pass the values to the new indices
+	// Transfer the old members into their new position.
 	for (KeyValue<StringName, GDScript::MemberInfo> &E : script->member_indices) {
 		if (member_indices_cache.has(E.key)) {
 			Variant value = members[member_indices_cache[E.key]];
-			new_members.write[E.value.index] = value;
+			new_members[E.value.index] = value;
 		}
 	}
+	members = std::move(new_members);
 
-	members.resize(new_members.size()); //resize
-
-	//apply
-	members = new_members;
-
-	//pass the values to the new indices
+	// Cache the new indices.
 	member_indices_cache.clear();
 	for (const KeyValue<StringName, GDScript::MemberInfo> &E : script->member_indices) {
 		member_indices_cache[E.key] = E.value.index;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -362,7 +362,7 @@ class GDScriptInstance : public ScriptInstance {
 #ifdef DEBUG_ENABLED
 	HashMap<StringName, int> member_indices_cache; //used only for hot script reloading
 #endif
-	Vector<Variant> members;
+	TightLocalVector<Variant> members;
 
 	SelfList<GDScriptFunctionState>::List pending_func_states;
 

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -324,7 +324,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 
 		for (KeyValue<StringName, GDScript::MemberInfo> &E : gd_ref->member_indices) {
 			if (d.has(E.key)) {
-				inst->members.write[E.value.index] = d[E.key];
+				inst->members[E.value.index] = d[E.key];
 			}
 		}
 	}

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -744,7 +744,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #endif
 
 	bool awaited = false;
-	Variant *variant_addresses[ADDR_TYPE_MAX] = { stack, _constants_ptr, p_instance ? p_instance->members.ptrw() : nullptr };
+	Variant *variant_addresses[ADDR_TYPE_MAX] = { stack, _constants_ptr, p_instance ? p_instance->members.ptr() : nullptr };
 
 #ifdef DEBUG_ENABLED
 	OPCODE_WHILE(ip < _code_size) {


### PR DESCRIPTION
Supersedes and closes https://github.com/godotengine/godot/pull/105555
Closes https://github.com/godotengine/godot/pull/107002

This is my take on https://github.com/godotengine/godot/pull/105555, however I don't feel confident putting a review over there, since the PR seems to change frequently based on results that look like fluctuations to me. So I want to approach this from a different angle:

`TightLocalVector` is the type that makes sense here. We don't need COW for `GDScript::members`. Also `GDScript::members` is not expected to grow.

---

As for time benchmarking nothing of this will have a measurable impact:
- `CowData` isn't stupid. It does not copy if the refcount is just 1. Since we never pass the members around we will never trigger a copy. So the difference here might at best be a few if statements.
- The growing behaviour uses `capacity * 1.5`. The `1.5` growth will not suffice since we only ever do an initial resize, were the initial capacity is `0`. So we will grow to the requested size all the time. So again the difference are at best some bit shifting and if statements. (Which might be subject to inlining + compiler optimization idk).

For those reasons I don't believe this change can be reliably justified via a runtime benchmark.

<details>
<summary>Runtime benchmarked using this script (To sanity check my logic.)</summary>

Simulates a lot of "action" around members.

```gdscript
extends Node2D

const COUNT: int= 100000000

var a: int = 0
var b: int = 1
var c: int = 2

func _ready():
	var time: int = Time.get_ticks_msec()

	for i: int in COUNT:
		var tmp = c
		c = b
		b = a
		a = tmp

	var total_time: int = Time.get_ticks_msec() - time
	
	print(total_time)

	get_tree().quit()
```

</details>

I see no difference that's beyond the usual fluctuations when I run baseline vs baseline. I also did run this on my call overhead benchmark (which isn't bottlenecked by this in any way afaik). And as expected there also are no significant changes. (Data linked below).

Data sheet runtime validation: [tight.ods](https://github.com/user-attachments/files/26135684/tight.ods)

---

__Why bother then?__ There is one consistent improvement in the memory footprint of `GDScriptInstance`, which makes intuitive sense to me, since `Vector` needs to store a refcount. However the memory layout of CowData is beyond me, so I'll leave the sanity check at my intuition here.

<details><summary>To measure this I use an adapted version of the benchmark presented in the recent struct PR, since the awaiting of rendering server seems to be effective in reducing fluctuations</summary>

```gdscript
extends Node2D

const COUNT: int= 100000
const PRINT_TIME: bool = true

class InnerData extends Object:
	var a: String
	var b: int
	var c

var data: Array[Array] = [] # [ memory, type, time ]

func _ready() -> void:
	await RenderingServer.frame_post_draw
	data.resize(1)
	await RenderingServer.frame_post_draw
	print("\nMemory testing with ", COUNT, " elements ...")
	#test_outer_class()
	await RenderingServer.frame_post_draw
	test_inner_class()
	await RenderingServer.frame_post_draw

	#data.sort_custom(func(a: Array, b: Array) -> bool: return a[0] < b[0])
	for entry: Array in data:
		print("- ", entry[0], " bytes : ", entry[1], "" if !PRINT_TIME else " - %s msec" % entry[2])

func test_inner_class():
	var time: int = Time.get_ticks_msec()
	var start: int = OS.get_static_memory_usage()
	var array: Array = []
	array.resize(COUNT)

	for i: int in COUNT:
		var object: InnerData = InnerData.new()
		object.a = "hello"
		object.b = i
		array[i] = object

	await get_tree().process_frame
	var used: int = OS.get_static_memory_usage() - start
	var total_time: int = Time.get_ticks_msec() - time
	@warning_ignore("integer_division")
	data[0] = [used / COUNT, "Class (inner)", total_time]


func test_outer_class():
	var b: Data
	var time: int = Time.get_ticks_msec()
	var start: int = OS.get_static_memory_usage()
	var array: Array = []
	array.resize(COUNT)

	for i: int in COUNT:
		var object: Data = Data.new()
		object.a = "hello"
		object.b = i
		array[i] = object

	await get_tree().process_frame
	var used: int = OS.get_static_memory_usage() - start
	var total_time: int = Time.get_ticks_msec() - time
	@warning_ignore("integer_division")
	data[1] = [used / COUNT, "Class (outer)", total_time]


func _on_button_pressed() -> void:
	test_inner_class()
	for entry: Array in data:
		print("- ", entry[0], " bytes : ", entry[1], "" if !PRINT_TIME else " - %s msec" % entry[2])

```

</details>

I don't have a data sheet on this, since the fluctuation is around 2bytes and I'm seeing a consistent improvement beyond that.

Caution: memory profiling is only available in debug templates. So if any debug only data is stored in any of those data structures it might be offsetting the results.

---

A last word on binary size.

The other PR seems to choose this as an optimization goal and switches between the container to reduce binary size. I don't believe our usage of core containers should be dictated by the size of template instantiations. That's just an esoteric optimization in a codebase of this size. It will not last when someone else uses the container.

