### PR TITLE
Fix keying state not being updated for sub-inspectors

### DIFF
--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -278,7 +278,7 @@ public:
 	void set_draw_warning(bool p_draw_warning);
 	bool is_draw_warning() const;
 
-	void set_keying(bool p_keying);
+	virtual void set_keying(bool p_keying);
 	bool is_keying() const;
 
 	virtual bool is_colored(ColorationMode p_mode) { return false; }

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3747,6 +3747,13 @@ void EditorPropertyResource::fold_resource() {
 	}
 }
 
+void EditorPropertyResource::set_keying(bool p_keying) {
+	EditorProperty::set_keying(p_keying);
+	if (sub_inspector) {
+		sub_inspector->set_keying(p_keying);
+	}
+}
+
 bool EditorPropertyResource::is_colored(ColorationMode p_mode) {
 	switch (p_mode) {
 		case COLORATION_CONTAINER_RESOURCE:

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -780,6 +780,8 @@ public:
 	void set_use_filter(bool p_use);
 	void fold_resource();
 
+	virtual void set_keying(bool p_keying) override;
+
 	virtual bool is_colored(ColorationMode p_mode) override;
 
 	EditorPropertyResource();


### PR DESCRIPTION
Before, if the animation editor was opened or closed, sub-inspectors wouldn't be updated to change the visibility of the key buttons in their properties.