### PR TITLE
Fix error "Convex decomposing failed" when adding a new CollisionPolygon2D

### DIFF
--- a/editor/scene/2d/abstract_polygon_2d_editor.cpp
+++ b/editor/scene/2d/abstract_polygon_2d_editor.cpp
@@ -138,7 +138,10 @@ Vector2 AbstractPolygon2DEditor::_get_geometric_center() const {
 	int n_subs = 0;
 	for (int i = 0; i < n_polygons; i++) {
 		const Vector<Vector2> &vertices = _get_polygon(i);
-		Vector<Vector<Point2>> decomp = ::Geometry2D::decompose_polygon_in_convex(vertices);
+		Vector<Vector<Point2>> decomp;
+		if (vertices.size() >= 3) {
+			decomp = ::Geometry2D::decompose_polygon_in_convex(vertices);
+		}
 		if (decomp.is_empty()) {
 			continue;
 		}


### PR DESCRIPTION
fix #117658 
This error occurs because editor attempts to decompose polygon in convex when the number of vertexes is less than three,so I add a conditional to avoid the situation.