### PR TITLE
Fix plugin signal registration error on Android (Reverted)

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
@@ -647,9 +647,6 @@ class Godot private constructor(val context: Context) {
 			})
 
 			renderView?.queueOnRenderThread {
-				for (plugin in pluginRegistry.allPlugins) {
-					plugin.onRegisterPluginWithGodotNative()
-				}
 				setKeepScreenOn(java.lang.Boolean.parseBoolean(GodotLib.getGlobal("display/window/energy_saving/keep_screen_on")))
 			}
 
@@ -850,6 +847,7 @@ class Godot private constructor(val context: Context) {
 		}
 
 		for (plugin in pluginRegistry.allPlugins) {
+			plugin.onRegisterPluginWithGodotNative()
 			plugin.onGodotSetupCompleted()
 		}
 		primaryHost?.onGodotSetupCompleted()


### PR DESCRIPTION
I see these two errors in the log:

```
ERROR: Condition "!Thread::is_main_thread()" is true.
   at: add_signal (core/object/gdtype.cpp:116)
```

```
ERROR: In Object of type 'JNISingleton': Attempt to connect nonexistent signal 'launch_tests' to callable 'Node2D(main.gd)::_launch_tests'.
    at: connect (core/object/object.cpp:1535)
    GDScript backtrace (most recent call first):
       [0] _ready (res://main.gd:9)
```

Android plugins signals are registered at

https://github.com/godotengine/godot/blob/4a280218fcfdd69408cceb74577c9e69086be23a/platform/android/plugin/godot_plugin_jni.cpp#L94-L113

https://github.com/godotengine/godot/blob/4a280218fcfdd69408cceb74577c9e69086be23a/platform/android/api/jni_singleton.cpp#L70-L77