### PR TITLE
Fix text alignment in check box inside `EditorInspectorSection`s

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -2279,7 +2279,7 @@ void EditorInspectorSection::_notification(int p_what) {
 						checkbox_position.x = label_position.x - checkbox->get_width() - 2 * EDSCALE;
 					}
 					checkbox_position.y = (header_height - checkbox->get_height()) / 2;
-					label_position.y = light_font->get_ascent(light_font_size) + (header_height - label_size.height) / 2.0;
+					label_position.y = light_font->get_ascent(light_font_size) + (header_height - light_font->get_height(light_font_size)) / 2;
 
 					check_rect = Rect2(checkbox_position.x, 0, checkbox->get_width() + label_size.width + 2 * EDSCALE, header_height);
 


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="310" height="59" alt="Screenshot_20260320_133903" src="https://github.com/user-attachments/assets/275f2327-3111-4dc5-babd-17dc7ca9160e" />|<img width="310" height="59" alt="Screenshot_20260320_133535" src="https://github.com/user-attachments/assets/377e595d-56ec-41bd-a424-935e93295580" />|