### PR TITLE
Add `_editor_ready()` virtual to `EditorPlugin` and fix `is_editor_ready()`

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -45,6 +45,12 @@
 				[param object] can be [code]null[/code] if the plugin was editing an object, but there is no longer any selected object handled by this plugin. It can be used to cleanup editing state.
 			</description>
 		</method>
+		<method name="_editor_ready" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the editor has fully initialized. Override this method to perform actions that require the entire editor to be ready.
+			</description>
+		</method>
 		<method name="_enable_plugin" qualifiers="virtual">
 			<return type="void" />
 			<description>

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -376,6 +376,12 @@ void EditorData::notify_scene_saved(const String &p_path) {
 	}
 }
 
+void EditorData::notify_editor_ready() {
+	for (int i = 0; i < editor_plugins.size(); i++) {
+		editor_plugins[i]->editor_ready();
+	}
+}
+
 void EditorData::clear_editor_states() {
 	for (int i = 0; i < editor_plugins.size(); i++) {
 		editor_plugins[i]->clear();

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -242,6 +242,7 @@ public:
 	void notify_edited_scene_changed();
 	void notify_resource_saved(const Ref<Resource> &p_resource);
 	void notify_scene_saved(const String &p_path);
+	void notify_editor_ready();
 
 	bool script_class_is_parent(const String &p_class, const String &p_inherits);
 	Variant script_class_instance(const String &p_class);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1529,6 +1529,9 @@ void EditorNode::_sources_changed(bool p_exist) {
 		}
 
 		get_tree()->create_timer(1.0f)->connect("timeout", callable_mp(this, &EditorNode::_remove_lock_file));
+
+		editor_ready = true;
+		editor_data.notify_editor_ready();
 	}
 }
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -449,6 +449,7 @@ private:
 	bool requested_first_scan = false;
 	bool waiting_for_first_scan = true;
 	bool load_editor_layout_done = false;
+	bool editor_ready = false;
 
 	bool select_current_scene_file_requested = false;
 
@@ -740,8 +741,7 @@ public:
 	bool call_build();
 	void call_run_scene(const String &p_scene, Vector<String> &r_args);
 
-	// This is a very naive estimation, but we need something now. Will be reworked later.
-	bool is_editor_ready() const { return is_inside_tree() && !waiting_for_first_scan; }
+	bool is_editor_ready() const { return editor_ready; }
 
 	static EditorNode *get_singleton() { return singleton; }
 

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -284,6 +284,10 @@ void EditorPlugin::notify_scene_saved(const String &p_scene_filepath) {
 	emit_signal(SNAME("scene_saved"), p_scene_filepath);
 }
 
+void EditorPlugin::editor_ready() {
+	GDVIRTUAL_CALL(_editor_ready);
+}
+
 bool EditorPlugin::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
 	bool success = false;
 	GDVIRTUAL_CALL(_forward_canvas_gui_input, p_event, success);
@@ -706,6 +710,7 @@ void EditorPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_run_scene, "scene", "args");
 	GDVIRTUAL_BIND(_enable_plugin);
 	GDVIRTUAL_BIND(_disable_plugin);
+	GDVIRTUAL_BIND(_editor_ready);
 
 	ADD_SIGNAL(MethodInfo("scene_changed", PropertyInfo(Variant::OBJECT, "scene_root", PROPERTY_HINT_RESOURCE_TYPE, Node::get_class_static())));
 	ADD_SIGNAL(MethodInfo("scene_closed", PropertyInfo(Variant::STRING, "filepath")));

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -144,6 +144,7 @@ protected:
 	GDVIRTUAL2RC(Vector<String>, _run_scene, String, Vector<String>)
 	GDVIRTUAL0(_enable_plugin)
 	GDVIRTUAL0(_disable_plugin)
+	GDVIRTUAL0(_editor_ready)
 
 #ifndef DISABLE_DEPRECATED
 	Button *_add_control_to_bottom_panel_compat_88081(Control *p_control, const String &p_title);
@@ -184,6 +185,7 @@ public:
 	void notify_scene_closed(const String &scene_filepath);
 	void notify_resource_saved(const Ref<Resource> &p_resource);
 	void notify_scene_saved(const String &p_scene_filepath);
+	void editor_ready();
 
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event);
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Closes: https://github.com/godotengine/godot-proposals/issues/14502

Tested with: https://github.com/Open-Industry-Project/Open-Industry-Project which does bunch of whacky stuff with the editor and previously used an ad-hoc editor signal. 

`is_editor_ready()` is now called at the end of the sources changed method; after `_load_editor_layout();`. 

Could use more testing with other plugins or services. 