### PR TITLE
Ask before quitting when templates are downloading

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3698,6 +3698,12 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				p_confirmed = false;
 			}
 
+			if (p_confirmed && stop_download_confirmation && export_template_manager->is_downloading()) {
+				export_template_manager->stop_download();
+				stop_download_confirmation = false;
+				p_confirmed = false;
+			}
+
 			if (!p_confirmed) {
 				if (!stop_project_confirmation && project_run_bar->is_playing()) {
 					if (p_option == PROJECT_RELOAD_CURRENT_PROJECT) {
@@ -3707,10 +3713,24 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 						confirmation->set_text(TTR("Stop running project before exiting the editor?"));
 						confirmation->set_ok_button_text(TTR("Stop & Quit"));
 					}
+					confirmation_button->hide();
 					confirmation->reset_size();
 					confirmation->popup_centered();
-					confirmation_button->hide();
 					stop_project_confirmation = true;
+					break;
+				}
+
+				if (!stop_download_confirmation && export_template_manager->is_downloading()) {
+					confirmation->set_text(TTR("The export templates are still being downloaded."));
+					if (p_option == PROJECT_RELOAD_CURRENT_PROJECT) {
+						confirmation->set_ok_button_text(TTR("Stop & Reload"));
+					} else {
+						confirmation->set_ok_button_text(TTR("Stop & Quit"));
+					}
+					confirmation_button->hide();
+					confirmation->reset_size();
+					confirmation->popup_centered();
+					stop_download_confirmation = true;
 					break;
 				}
 
@@ -6734,6 +6754,7 @@ void EditorNode::_cancel_close_scene_tab() {
 
 void EditorNode::_cancel_confirmation() {
 	stop_project_confirmation = false;
+	stop_download_confirmation = false;
 }
 
 void EditorNode::_prepare_save_confirmation_popup() {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -373,6 +373,7 @@ private:
 
 	ConfirmationDialog *confirmation = nullptr;
 	bool stop_project_confirmation = false;
+	bool stop_download_confirmation = false;
 	Button *confirmation_button = nullptr;
 	ConfirmationDialog *save_confirmation = nullptr;
 	ConfirmationDialog *import_confirmation = nullptr;

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -766,6 +766,11 @@ void ExportTemplateManager::popup_manager() {
 	popup_centered(Size2(720, 280) * EDSCALE);
 }
 
+void ExportTemplateManager::stop_download() {
+	download_templates->cancel_request();
+	is_downloading_templates = false;
+}
+
 void ExportTemplateManager::ok_pressed() {
 	if (!is_downloading_templates) {
 		hide();

--- a/editor/export/export_template_manager.h
+++ b/editor/export/export_template_manager.h
@@ -132,6 +132,8 @@ public:
 	Error install_android_template_from_file(const String &p_file, const Ref<EditorExportPreset> &p_preset);
 
 	void popup_manager();
+	bool is_downloading() const { return is_downloading_templates; }
+	void stop_download();
 
 	ExportTemplateManager();
 };


### PR DESCRIPTION
Related: #117072

The editor is able to download templates in background and will warn you when you try to close the template manager dialog, but does not warn you when you try to quit the editor while downloading.

This PR adds such warning.
<img width="452" height="128" alt="image" src="https://github.com/user-attachments/assets/c12918aa-ff6c-4d26-9640-48d0d1a0e141" />
