### PR TITLE
Prioritize external text editor path over language

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -2190,20 +2190,21 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 
 	const bool should_open = (open_dominant && !use_external_editor) || !EditorNode::get_singleton()->is_changing_scene();
 
-	if (scr.is_valid() && scr->get_language()->overrides_external_editor()) {
-		if (should_open) {
-			Error err = scr->get_language()->open_in_external_editor(scr, p_line >= 0 ? p_line : 0, p_col);
-			if (err != OK) {
-				ERR_PRINT("Couldn't open script in the overridden external text editor");
+	if (use_external_editor) {
+		// Check Text Editor before language override.
+		if ((EditorDebuggerNode::get_singleton()->get_dump_stack_script() != p_resource || EditorDebuggerNode::get_singleton()->get_debug_with_external_editor()) &&
+				p_resource->get_path().is_resource_file()) {
+			if (ScriptEditorPlugin::open_in_external_editor(ProjectSettings::get_singleton()->globalize_path(p_resource->get_path()), p_line, p_col)) {
+				return false;
 			}
 		}
-		return false;
-	}
-
-	if (use_external_editor &&
-			(EditorDebuggerNode::get_singleton()->get_dump_stack_script() != p_resource || EditorDebuggerNode::get_singleton()->get_debug_with_external_editor()) &&
-			p_resource->get_path().is_resource_file()) {
-		if (ScriptEditorPlugin::open_in_external_editor(ProjectSettings::get_singleton()->globalize_path(p_resource->get_path()), p_line, p_col)) {
+		if (scr.is_valid() && scr->get_language()->overrides_external_editor()) {
+			if (should_open) {
+				Error err = scr->get_language()->open_in_external_editor(scr, p_line >= 0 ? p_line : 0, p_col);
+				if (err != OK) {
+					ERR_PRINT("Couldn't open script in the overridden external text editor");
+				}
+			}
 			return false;
 		} else {
 			ERR_PRINT("Couldn't open external text editor, falling back to the internal editor. Review your `text_editor/external/` editor settings.");


### PR DESCRIPTION
Closes #117513 where double clicking on .cs file would use dotnet/editor/external_editor over text_editor/external/exec_path, which requires user's PATH environment variable to be set. This change would check text_editor/external/exec_path first before checking dotnet/editor/external_editor.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
