### PR TITLE
Add unary plus operations to C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -1095,6 +1095,15 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the same value as if the <c>+</c> was not there.
+        /// Unary <c>+</c> does nothing, but sometimes it can make your
+        /// code more readable.
+        /// </summary>
+        /// <param name="color">The color to do nothing to.</param>
+        /// <returns>The original color.</returns>
+        public static Color operator +(Color color) => color;
+
+        /// <summary>
         /// Inverts the given color. This is equivalent to
         /// <c>Colors.White - c</c> or
         /// <c>new Color(1 - c.R, 1 - c.G, 1 - c.B, 1 - c.A)</c>.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
@@ -340,6 +340,15 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the same value as if the <c>+</c> was not there.
+        /// Unary <c>+</c> does nothing, but sometimes it can make your
+        /// code more readable.
+        /// </summary>
+        /// <param name="plane">The plane to do nothing to.</param>
+        /// <returns>The original plane.</returns>
+        public static Plane operator +(Plane plane) => plane;
+
+        /// <summary>
         /// Returns the negative value of the <see cref="Plane"/>.
         /// This is the same as writing <c>new Plane(-p.Normal, -p.D)</c>.
         /// This operation flips the direction of the normal vector and

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -710,6 +710,15 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the same value as if the <c>+</c> was not there.
+        /// Unary <c>+</c> does nothing, but sometimes it can make your
+        /// code more readable.
+        /// </summary>
+        /// <param name="quat">The quaternion to do nothing to.</param>
+        /// <returns>The original quaternion.</returns>
+        public static Quaternion operator +(Quaternion quat) => quat;
+
+        /// <summary>
         /// Returns the negative value of the <see cref="Quaternion"/>.
         /// This is the same as writing
         /// <c>new Quaternion(-q.X, -q.Y, -q.Z, -q.W)</c>. This operation

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -811,6 +811,15 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the same value as if the <c>+</c> was not there.
+        /// Unary <c>+</c> does nothing, but sometimes it can make your
+        /// code more readable.
+        /// </summary>
+        /// <param name="vec">The vector to do nothing to.</param>
+        /// <returns>The original vector.</returns>
+        public static Vector2 operator +(Vector2 vec) => vec;
+
+        /// <summary>
         /// Returns the negative value of the <see cref="Vector2"/>.
         /// This is the same as writing <c>new Vector2(-v.X, -v.Y)</c>.
         /// This operation flips the direction of the vector while

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
@@ -412,6 +412,15 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the same value as if the <c>+</c> was not there.
+        /// Unary <c>+</c> does nothing, but sometimes it can make your
+        /// code more readable.
+        /// </summary>
+        /// <param name="vec">The vector to do nothing to.</param>
+        /// <returns>The original vector.</returns>
+        public static Vector2I operator +(Vector2I vec) => vec;
+
+        /// <summary>
         /// Returns the negative value of the <see cref="Vector2I"/>.
         /// This is the same as writing <c>new Vector2I(-v.X, -v.Y)</c>.
         /// This operation flips the direction of the vector while

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -951,6 +951,15 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the same value as if the <c>+</c> was not there.
+        /// Unary <c>+</c> does nothing, but sometimes it can make your
+        /// code more readable.
+        /// </summary>
+        /// <param name="vec">The vector to do nothing to.</param>
+        /// <returns>The original vector.</returns>
+        public static Vector3 operator +(Vector3 vec) => vec;
+
+        /// <summary>
         /// Returns the negative value of the <see cref="Vector3"/>.
         /// This is the same as writing <c>new Vector3(-v.X, -v.Y, -v.Z)</c>.
         /// This operation flips the direction of the vector while

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
@@ -450,6 +450,15 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the same value as if the <c>+</c> was not there.
+        /// Unary <c>+</c> does nothing, but sometimes it can make your
+        /// code more readable.
+        /// </summary>
+        /// <param name="vec">The vector to do nothing to.</param>
+        /// <returns>The original vector.</returns>
+        public static Vector3I operator +(Vector3I vec) => vec;
+
+        /// <summary>
         /// Returns the negative value of the <see cref="Vector3I"/>.
         /// This is the same as writing <c>new Vector3I(-v.X, -v.Y, -v.Z)</c>.
         /// This operation flips the direction of the vector while

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
@@ -656,6 +656,15 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the same value as if the <c>+</c> was not there.
+        /// Unary <c>+</c> does nothing, but sometimes it can make your
+        /// code more readable.
+        /// </summary>
+        /// <param name="vec">The vector to do nothing to.</param>
+        /// <returns>The original vector.</returns>
+        public static Vector4 operator +(Vector4 vec) => vec;
+
+        /// <summary>
         /// Returns the negative value of the <see cref="Vector4"/>.
         /// This is the same as writing <c>new Vector4(-v.X, -v.Y, -v.Z, -v.W)</c>.
         /// This operation flips the direction of the vector while

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
@@ -452,6 +452,15 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the same value as if the <c>+</c> was not there.
+        /// Unary <c>+</c> does nothing, but sometimes it can make your
+        /// code more readable.
+        /// </summary>
+        /// <param name="vec">The vector to do nothing to.</param>
+        /// <returns>The original vector.</returns>
+        public static Vector4I operator +(Vector4I vec) => vec;
+
+        /// <summary>
         /// Returns the negative value of the <see cref="Vector4I"/>.
         /// This is the same as writing <c>new Vector4I(-v.X, -v.Y, -v.Z, -v.W)</c>.
         /// This operation flips the direction of the vector while


### PR DESCRIPTION
Adds missing unary plus (`+`) operations to the following C# types:
- `Vector2`
- `Vector2I`
- `Vector3`
- `Vector3I`
- `Vector4`
- `Vector4I`
- `Color`
- `Plane`
- `Quaternion`

You can see these operators are supported by GDScript, for example [Vector3](https://docs.godotengine.org/en/stable/classes/class_vector3.html#class-vector3-operator-unplus) and [Color](https://docs.godotengine.org/en/stable/classes/class_color.html#class-color-operator-unplus).

The purpose of this operator, as described by the docs:
> Unary + does nothing, but sometimes it can make your code more readable.

I will note that unary plus is supported by C# built-in types like `int` and `System.Numerics.Vector3`.