### PR TITLE
GetScriptType for CSharpScript

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -76,6 +76,16 @@ namespace Godot.Bridge
         private static ConcurrentDictionary<IntPtr, (string? assemblyName, string classFullName)>
             _scriptDataForReload = new();
 
+        internal static Type GetManagedScriptType(IntPtr scriptPtr)
+        {
+            if (!_scriptTypeBiMap.TryGetScriptType(scriptPtr, out Type? type))
+            {
+                throw new InvalidOperationException($"Script type not found for script pointer: {scriptPtr}");
+            }
+
+            return type;
+        }
+
         [UnmanagedCallersOnly]
         internal static void FrameCallback()
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/CSharpScriptExtension.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/CSharpScriptExtension.cs
@@ -6,7 +6,7 @@ namespace Godot
     public partial class CSharpScript
     {
         /// <summary>
-        /// Return the <see cref="Type"/> of the C# Script associated to this instance. 
+        /// Return the <see cref="Type"/> of the C# Script associated to this instance.
         /// </summary>
         /// <exception cref="InvalidOperationException">
         /// The C# Script cannot be found (in case of an invalid pointer).

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/CSharpScriptExtension.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/CSharpScriptExtension.cs
@@ -1,0 +1,19 @@
+using System;
+using Godot.Bridge;
+
+namespace Godot
+{
+    public partial class CSharpScript
+    {
+        /// <summary>
+        /// Return the <see cref="Type"/> of the C# Script associated to this instance. 
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The C# Script cannot be found (in case of an invalid pointer).
+        /// </exception>
+        public Type GetScriptType()
+        {
+            return ScriptManagerBridge.GetManagedScriptType(GetPtr(this));
+        }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Core\DelegateUtils.cs" />
     <Compile Include="Core\Dictionary.cs" />
     <Compile Include="Core\Dispatcher.cs" />
+    <Compile Include="Core\Extensions\CSharpScriptExtension.cs" />
     <Compile Include="Core\Extensions\GodotObjectExtensions.cs" />
     <Compile Include="Core\Extensions\NodeExtensions.cs" />
     <Compile Include="Core\Extensions\PackedSceneExtensions.cs" />


### PR DESCRIPTION
A new method allowing to retrieve the C# Type behind the CSharpScript

Close: [Add a method to get the C# type of CSharpScript](https://github.com/godotengine/godot-proposals/issues/12294)

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
