### PR TITLE
EditorFileDialog: Document native file dialogs in sandboxed environments

### DIFF
--- a/doc/classes/EditorFileDialog.xml
+++ b/doc/classes/EditorFileDialog.xml
@@ -7,6 +7,7 @@
 		[EditorFileDialog] is a [FileDialog] tweaked to work in the editor. It automatically handles favorite and recent directory lists, and synchronizes some properties with their corresponding editor settings.
 		[EditorFileDialog] will automatically show a native dialog based on the [member EditorSettings.interface/editor/appearance/use_native_file_dialogs] editor setting and ignores [member FileDialog.use_native_dialog].
 		[b]Note:[/b] [EditorFileDialog] is invisible by default. To make it visible, call one of the [code]popup_*[/code] methods from [Window] on the node, such as [method Window.popup_centered_clamped].
+		[b]Note:[/b] On Linux and macOS, sandboxed apps always use native dialogs to access the host file system.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
In the `EditorFileDialog` documentation, it states that `FileDialog.use_native_dialog` is ignored and editor settings `interface/editor/appearance/use_native_file_dialogs` will be used instead to determine if native file dialog should be used [[1]](https://github.com/godotengine/godot/blob/4a280218fcfdd69408cceb74577c9e69086be23a/doc/classes/EditorFileDialog.xml#L8). However `EditorFileDialog::_should_use_native_popup` will return true when Godot detects it is running in sandbox, ignoring said editor settings[[2]](https://github.com/godotengine/godot/blob/4a280218fcfdd69408cceb74577c9e69086be23a/editor/gui/editor_file_dialog.cpp#L74). Such behaviour is not documented in `EditorFileDialog` nor `EditorSettings`, and might confuse macOS and Linux users running Godot editor in a sandbox.

This PR simply copy the note about sandbox from `FileDialog.use_native_dialog` to `EditorFileDialog` description, which should correctly reflects the current behaviour of `EditorFileDialog`.

Related issue: https://github.com/flathub/org.godotengine.Godot/issues/187