### PR TITLE
Wayland: Fix use-after-free of `Ref<ColorManagementProfile>`

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -2721,7 +2721,10 @@ void WaylandThread::_wp_image_description_on_ready2(void *data, struct wp_image_
 
 	struct wp_image_description_info_v1 *image_info = wp_image_description_v1_get_information(image_descriptor);
 	if (image_info != nullptr) {
+		// The wp_image_description_info_v1 listener takes ownership of this msg.
+		// We need to add a virtual reference so this msg is not freed when we leave the scope.
 		Ref<ColorProfileMessage> msg = memnew(ColorProfileMessage);
+		msg->reference();
 		msg->id = ws->id;
 		msg->wayland_thread = ws->wayland_thread;
 
@@ -2733,8 +2736,10 @@ void WaylandThread::_wp_image_description_on_ready2(void *data, struct wp_image_
 void WaylandThread::_wp_image_description_info_on_done(void *data, struct wp_image_description_info_v1 *wp_image_description_info_v1) {
 	wp_image_description_info_v1_destroy(wp_image_description_info_v1);
 
-	ColorProfileMessage *msg = (ColorProfileMessage *)data;
-	ERR_FAIL_NULL(msg);
+	ERR_FAIL_NULL(data);
+	// Now that we have claimed ownership of the msg, remove the virtual reference.
+	Ref<ColorProfileMessage> msg = (ColorProfileMessage *)data;
+	msg->unreference();
 
 	msg->wayland_thread->push_message(msg);
 }


### PR DESCRIPTION
Fixes #117676

PR #111964 made a Ref<ColorManagementProfile> which we intentionally leaked across a client-server barrier owned, which caused a use-after-free. Manually adding reference/unreference calls keeps the ptr valid without memory leaks.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
