### PR TITLE
Deprecate `Input.should_ignore_device()`

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -149,7 +149,9 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_joy_name", "device"), &Input::get_joy_name);
 	ClassDB::bind_method(D_METHOD("get_joy_guid", "device"), &Input::get_joy_guid);
 	ClassDB::bind_method(D_METHOD("get_joy_info", "device"), &Input::get_joy_info);
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("should_ignore_device", "vendor_id", "product_id"), &Input::should_ignore_device);
+#endif // DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("get_connected_joypads"), &Input::get_connected_joypads);
 	ClassDB::bind_method(D_METHOD("get_joy_vibration_strength", "device"), &Input::get_joy_vibration_strength);
 	ClassDB::bind_method(D_METHOD("get_joy_vibration_duration", "device"), &Input::get_joy_vibration_duration);
@@ -2283,10 +2285,12 @@ Dictionary Input::get_joy_info(int p_device) const {
 	return joy_names[p_device].info;
 }
 
+#ifndef DISABLE_DEPRECATED
 bool Input::should_ignore_device(int p_vendor_id, int p_product_id) const {
 	uint32_t full_id = (((uint32_t)p_vendor_id) << 16) | ((uint16_t)p_product_id);
 	return ignored_device_ids.has(full_id);
 }
+#endif // DISABLE_DEPRECATED
 
 TypedArray<int> Input::get_connected_joypads() {
 	TypedArray<int> ret;
@@ -2340,6 +2344,7 @@ Input::Input() {
 		}
 	}
 
+#ifndef DISABLE_DEPRECATED
 	String env_ignore_devices = OS::get_singleton()->get_environment("SDL_GAMECONTROLLER_IGNORE_DEVICES");
 	if (!env_ignore_devices.is_empty()) {
 		Vector<String> entries = env_ignore_devices.split(",");
@@ -2360,6 +2365,7 @@ Input::Input() {
 			ignored_device_ids.insert(full_id);
 		}
 	}
+#endif // DISABLE_DEPRECATED
 
 	legacy_just_pressed_behavior = GLOBAL_DEF("input_devices/compatibility/legacy_just_pressed_behavior", false);
 	if (Engine::get_singleton()->is_editor_hint()) {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -227,7 +227,9 @@ private:
 	HashMap<int, VelocityTrack> touch_velocity_track;
 	HashMap<int, Joypad> joy_names;
 
+#ifndef DISABLE_DEPRECATED
 	HashSet<uint32_t> ignored_device_ids;
+#endif // DISABLE_DEPRECATED
 
 	int fallback_mapping = -1; // Index of the guid in map_db.
 
@@ -465,7 +467,9 @@ public:
 
 	bool is_joy_known(int p_device);
 	String get_joy_guid(int p_device) const;
+#ifndef DISABLE_DEPRECATED
 	bool should_ignore_device(int p_vendor_id, int p_product_id) const;
+#endif // DISABLE_DEPRECATED
 	Dictionary get_joy_info(int p_device) const;
 	void set_fallback_mapping(const String &p_guid);
 

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -569,7 +569,7 @@
 				[b]Note:[/b] This value can be immediately overwritten by the hardware sensor value on Android and iOS.
 			</description>
 		</method>
-		<method name="should_ignore_device" qualifiers="const">
+		<method name="should_ignore_device" qualifiers="const" deprecated="Game code should not have to ignore unwanted devices by itself. If a device that should be ignored gets detected by Godot, please report it as a bug.">
 			<return type="bool" />
 			<param index="0" name="vendor_id" type="int" />
 			<param index="1" name="product_id" type="int" />


### PR DESCRIPTION
This PR deprecates `Input.should_ignore_device()` method. For context, it was added in https://github.com/godotengine/godot/pull/76045 .
- If a developer wants to ignore non-controller devices (or other devices that should be ignored) in their game, it should already be handled by the engine, or if an unnecessary device still gets detected, it should be considered a bug in the engine;
- If a game wants to detect if Steam is running (by checking if their connected controller's vendor/product ID is ignored, I assume?), there are better tools to do this job;
- This method only works with `SDL_GAMECONTROLLER_IGNORE_DEVICES` environment variable and it doesn't detect other types of devices that should be ignored:
https://github.com/godotengine/godot/blob/65e73b3a5eec19e3269809b0f00e73a646723067/thirdparty/sdl/joystick/SDL_gamepad.c#L169-L196
https://github.com/godotengine/godot/blob/65e73b3a5eec19e3269809b0f00e73a646723067/thirdparty/sdl/joystick/SDL_joystick.c#L169-L284
- And this method isn't used internally by the engine anymore, SDL and other joypad backends (Android) already handle ignored devices for us.

Please let me know if I missed an important use case of this method in my description. 😅 