### PR TITLE
Add progress indicator for background template download

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -42,6 +42,7 @@
 #include "editor/export/editor_export_preset.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/file_system/editor_paths.h"
+#include "editor/gui/editor_bottom_panel.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/progress_dialog.h"
 #include "editor/settings/editor_settings.h"
@@ -213,6 +214,11 @@ void ExportTemplateManager::_download_template(const String &p_url, bool p_skip_
 
 	set_process(true);
 	_set_current_progress_status(TTR("Connecting to the mirror..."));
+
+	ProgressIndicator *indicator = EditorNode::get_bottom_panel()->get_progress_indicator();
+	indicator->set_tooltip_text(TTRC("Downloading export templates..."));
+	indicator->set_value(0);
+	indicator->show();
 }
 
 void ExportTemplateManager::_download_template_completed(int p_status, int p_code, const PackedStringArray &headers, const PackedByteArray &p_data) {
@@ -259,6 +265,7 @@ void ExportTemplateManager::_download_template_completed(int p_status, int p_cod
 		} break;
 	}
 
+	EditorNode::get_bottom_panel()->get_progress_indicator()->hide();
 	set_process(false);
 }
 
@@ -421,6 +428,9 @@ void ExportTemplateManager::_set_current_progress_status(const String &p_status,
 }
 
 void ExportTemplateManager::_set_current_progress_value(float p_value, const String &p_status) {
+	if (!is_visible()) {
+		return;
+	}
 	download_progress_bar->show();
 	download_progress_bar->set_indeterminate(false);
 	download_progress_bar->set_value(p_value);
@@ -929,20 +939,16 @@ Error ExportTemplateManager::install_android_template_from_file(const String &p_
 
 void ExportTemplateManager::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_READY: {
+			EditorNode::get_bottom_panel()->get_progress_indicator()->connect("clicked", callable_mp(this, &ExportTemplateManager::popup_manager));
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			current_value->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("main"), EditorStringName(EditorFonts)));
 			current_missing_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 			current_installed_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor)));
 
 			mirror_options_button->set_button_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
-		} break;
-
-		case NOTIFICATION_VISIBILITY_CHANGED: {
-			if (!is_visible()) {
-				set_process(false);
-			} else if (is_visible() && is_downloading_templates) {
-				set_process(true);
-			}
 		} break;
 
 		case NOTIFICATION_PROCESS: {
@@ -959,7 +965,9 @@ void ExportTemplateManager::_notification(int p_what) {
 
 			if (downloaded_bytes >= 0) {
 				if (total_bytes > 0) {
-					_set_current_progress_value(float(downloaded_bytes) / total_bytes, status);
+					float progress = float(downloaded_bytes) / total_bytes;
+					EditorNode::get_bottom_panel()->get_progress_indicator()->set_value(progress);
+					_set_current_progress_value(progress, status);
 				} else {
 					_set_current_progress_value(0, status);
 				}
@@ -968,6 +976,7 @@ void ExportTemplateManager::_notification(int p_what) {
 			}
 
 			if (!success) {
+				EditorNode::get_bottom_panel()->get_progress_indicator()->hide();
 				set_process(false);
 			}
 		} break;

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -287,6 +287,12 @@ EditorBottomPanel::EditorBottomPanel() :
 	editor_toaster = memnew(EditorToaster);
 	bottom_hbox->add_child(editor_toaster);
 
+	// NOTE: This is currently used only for ExportTemplateManager and hard-coded for that task.
+	progress_indicator = memnew(ProgressIndicator);
+	progress_indicator->set_v_size_flags(SIZE_SHRINK_CENTER);
+	progress_indicator->hide();
+	bottom_hbox->add_child(progress_indicator);
+
 	EditorVersionButton *version_btn = memnew(EditorVersionButton(EditorVersionButton::FORMAT_BASIC));
 	// Fade out the version label to be less prominent, but still readable.
 	version_btn->set_self_modulate(Color(1, 1, 1, 0.65));
@@ -320,4 +326,31 @@ EditorBottomPanel::~EditorBottomPanel() {
 	for (Button *b : legacy_buttons) {
 		memdelete(b);
 	}
+}
+
+void ProgressIndicator::_notification(int p_what) {
+	if (p_what == NOTIFICATION_THEME_CHANGED) {
+		const Ref<Texture2D> ring_texture = get_editor_theme_icon(SNAME("ProgressRing"));
+		set_progress_texture(ring_texture);
+		set_tint_progress(get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
+		set_under_texture(ring_texture);
+	}
+}
+
+void ProgressIndicator::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("clicked"));
+}
+
+void ProgressIndicator::gui_input(const Ref<InputEvent> &p_event) {
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
+		emit_signal("clicked");
+	}
+}
+
+ProgressIndicator::ProgressIndicator() {
+	set_fill_mode(FILL_CLOCKWISE);
+	set_tint_under(Color());
+	set_step(0.0);
+	set_max(1.0);
 }

--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "editor/docks/dock_tab_container.h"
+#include "scene/gui/texture_progress_bar.h"
 
 class Button;
 class ConfigFile;
@@ -38,11 +39,25 @@ class EditorDock;
 class EditorToaster;
 class HBoxContainer;
 
+class ProgressIndicator : public TextureProgressBar {
+	GDCLASS(ProgressIndicator, TextureProgressBar);
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+
+public:
+	ProgressIndicator();
+};
+
 class EditorBottomPanel : public DockTabContainer {
 	GDCLASS(EditorBottomPanel, DockTabContainer);
 
 	HBoxContainer *bottom_hbox = nullptr;
 	EditorToaster *editor_toaster = nullptr;
+	ProgressIndicator *progress_indicator = nullptr;
 	Button *pin_button = nullptr;
 	Button *expand_button = nullptr;
 
@@ -83,6 +98,8 @@ public:
 	void set_expanded(bool p_expanded);
 	void _theme_changed();
 	bool is_locked() const { return lock_panel_switching; }
+
+	ProgressIndicator *get_progress_indicator() { return progress_indicator; }
 
 	void set_bottom_panel_offset(int p_offset);
 	int get_bottom_panel_offset();

--- a/editor/icons/ProgressRing.svg
+++ b/editor/icons/ProgressRing.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="6" fill="none" stroke="#fff" stroke-width="4"/></svg>


### PR DESCRIPTION
Part of #117072

Adds a progress indicator at the bottom when templates are being downloaded.

https://github.com/user-attachments/assets/7e868805-8697-47b6-9421-498bfb324b1f

