### PR TITLE
LSP: Disable "smart resolve" by default

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1316,7 +1316,6 @@
 			[/codeblock]
 			When using static typing it is recommended to disable this setting, since it will mostly add false positives for typed code.
 			[b]Note:[/b] This setting also influences how symbols are resolved when using renaming capabilities.
-			[b]Note:[/b] The default value of this setting might change in future versions.
 		</member>
 		<member name="network/language_server/poll_limit_usec" type="int" setter="" getter="">
 			The upper limit of time, that the language server spends for IO each poll.

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1130,7 +1130,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	/* GDScript Language Server */
 	_initial_set("network/language_server/remote_host", "127.0.0.1"); // Hints provided in setup_network
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "network/language_server/remote_port", 6005, "1,65535,1");
-	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "network/language_server/enable_smart_resolve", true, String());
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "network/language_server/enable_smart_resolve", false, String());
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "network/language_server/show_native_symbols_in_editor", false, String());
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "network/language_server/use_thread", false, String());
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_NONE, "network/language_server/poll_limit_usec", 100000, "");


### PR DESCRIPTION
What is "smart resolve"?: In the language server we have a big list of all symbols in the entire API and project. Then when resolving something by semantics does not work (e.g. untyped code) we take the name look into the big list and use that as fallback result.

This can lead to unexpected or even incorrect results. With the availability of static typing having this beahviour enabled by default makes no sense. If people like untyped code and still want LSP results on a best effort basis they can make the informed decission to enable it at the risk of getting incorrect results.