### PR TITLE
Add user-defined code snippets support for GDScript

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -43,6 +43,9 @@
 
 #ifdef TOOLS_ENABLED
 #include "editor/gdscript_docgen.h"
+#include "core/io/dir_access.h"
+#include "core/io/json.h"
+#include "core/os/os.h"
 #endif
 
 #ifdef TESTS_ENABLED
@@ -3052,3 +3055,95 @@ void ResourceFormatSaverGDScript::get_recognized_extensions(const Ref<Resource> 
 bool ResourceFormatSaverGDScript::recognize(const Ref<Resource> &p_resource) const {
 	return Object::cast_to<GDScript>(*p_resource) != nullptr;
 }
+
+#ifdef TOOLS_ENABLED
+
+void GDScriptLanguage::_check_snippets_reload() {
+	uint64_t current_time = OS::get_singleton()->get_ticks_usec();
+	if (current_time - snippets_last_check_time < 1000000) {
+		return;
+	}
+	snippets_last_check_time = current_time;
+
+	if (snippets_dir_path.is_empty()) {
+		snippets_dir_path = ProjectSettings::get_singleton()->get_resource_path() + "/snippets";
+	}
+
+	if (!DirAccess::exists(snippets_dir_path)) {
+		return;
+	}
+
+	Ref<DirAccess> dir = DirAccess::open(snippets_dir_path);
+	if (dir.is_null()) {
+		return;
+	}
+
+	uint64_t latest_timestamp = 0;
+	dir->list_dir_begin();
+	String file_name = dir->get_next();
+	while (!file_name.is_empty()) {
+		if (!dir->current_is_dir() && file_name.ends_with(".json")) {
+			String file_path = snippets_dir_path + "/" + file_name;
+			uint64_t file_time = FileAccess::get_modified_time(file_path);
+			if (file_time > latest_timestamp) {
+				latest_timestamp = file_time;
+			}
+		}
+		file_name = dir->get_next();
+	}
+	dir->list_dir_end();
+
+	if (latest_timestamp != snippets_dir_timestamp) {
+		snippets_dir_timestamp = latest_timestamp;
+		load_snippets();
+	}
+}
+
+void GDScriptLanguage::load_snippets() {
+	snippets.clear();
+	if (snippets_dir_path.is_empty() || !DirAccess::exists(snippets_dir_path)) {
+		return;
+	}
+
+	Ref<DirAccess> dir = DirAccess::open(snippets_dir_path);
+	if (dir.is_null()) {
+		return;
+	}
+
+	dir->list_dir_begin();
+	String file_name = dir->get_next();
+	while (!file_name.is_empty()) {
+		if (!dir->current_is_dir() && file_name.ends_with(".json")) {
+			_load_snippet_file(snippets_dir_path + "/" + file_name);
+		}
+		file_name = dir->get_next();
+	}
+	dir->list_dir_end();
+}
+
+void GDScriptLanguage::_load_snippet_file(const String &p_path) {
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
+	if (f.is_null()) {
+		return;
+	}
+
+	String content = f->get_as_text();
+	JSON json;
+	if (json.parse(content) != OK) {
+		return;
+	}
+
+	Dictionary snippet_data = json.get_data();
+	if (!snippet_data.has("prefix") || !snippet_data.has("body")) {
+		return;
+	}
+
+	SnippetConfig config(snippet_data.get("prefix", ""), snippet_data.get("body", ""),
+			snippet_data.get("description", ""));
+
+	if (!config.prefix.is_empty() && !config.body.is_empty()) {
+		snippets[config.prefix] = config;
+	}
+}
+
+#endif // TOOLS_ENABLED

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -42,10 +42,10 @@
 #include "core/object/class_db.h"
 
 #ifdef TOOLS_ENABLED
-#include "editor/gdscript_docgen.h"
 #include "core/io/dir_access.h"
 #include "core/io/json.h"
 #include "core/os/os.h"
+#include "editor/gdscript_docgen.h"
 #endif
 
 #ifdef TESTS_ENABLED

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -419,6 +419,26 @@ class GDScriptLanguage : public ScriptLanguage {
 	HashMap<StringName, Variant> named_globals;
 	Vector<int> global_array_empty_indexes;
 
+#ifdef TOOLS_ENABLED
+	struct SnippetConfig {
+		String prefix;
+		String body;
+		String description;
+
+		SnippetConfig() {}
+
+		SnippetConfig(const String &p_prefix, const String &p_body, const String &p_description) :
+				prefix(p_prefix), body(p_body), description(p_description) {}
+	};
+
+	HashMap<String, SnippetConfig> snippets;
+	String snippets_dir_path;
+	uint64_t snippets_dir_timestamp = 0;
+	uint64_t snippets_last_check_time = 0;
+	void _load_snippet_file(const String &p_path);
+	void _check_snippets_reload();
+#endif
+
 	struct CallLevel {
 		Variant *stack = nullptr;
 		GDScriptFunction *function = nullptr;
@@ -605,6 +625,7 @@ public:
 	virtual String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const override;
 	virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_forced, String &r_call_hint) override;
 #ifdef TOOLS_ENABLED
+	void load_snippets();
 	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) override;
 #endif
 	virtual String _get_indentation() const;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3446,6 +3446,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 }
 
 ::Error GDScriptLanguage::complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_forced, String &r_call_hint) {
+	_check_snippets_reload();
 	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
 
 	GDScriptParser parser;
@@ -3847,6 +3848,18 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 			}
 			_find_identifiers_in_class(completion_context.current_class, true, false, false, true, !_guess_expecting_callable(completion_context), options, 0);
 		} break;
+	}
+
+	if (completion_context.type == GDScriptParser::COMPLETION_IDENTIFIER ||
+		completion_context.type == GDScriptParser::COMPLETION_METHOD ||
+		completion_context.type == GDScriptParser::COMPLETION_NONE) {
+		for (const KeyValue<String, SnippetConfig> &E : snippets) {
+			const SnippetConfig &snippet = E.value;
+			ScriptLanguage::CodeCompletionOption option(snippet.prefix, ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
+			option.insert_text = snippet.body;
+			option.display = snippet.prefix + "\t[snippet] " + snippet.description;
+			options.insert(option.display, option);
+		}
 	}
 
 	for (const KeyValue<String, ScriptLanguage::CodeCompletionOption> &E : options) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3851,8 +3851,8 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 	}
 
 	if (completion_context.type == GDScriptParser::COMPLETION_IDENTIFIER ||
-		completion_context.type == GDScriptParser::COMPLETION_METHOD ||
-		completion_context.type == GDScriptParser::COMPLETION_NONE) {
+			completion_context.type == GDScriptParser::COMPLETION_METHOD ||
+			completion_context.type == GDScriptParser::COMPLETION_NONE) {
 		for (const KeyValue<String, SnippetConfig> &E : snippets) {
 			const SnippetConfig &snippet = E.value;
 			ScriptLanguage::CodeCompletionOption option(snippet.prefix, ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);


### PR DESCRIPTION
## Function Description
Implemented user-defined code snippets based on local JSON files for the GDScript editor
## JSON file format
``` json
{
	   "prefix": "sig",
	   "body": "signal signal_name",
	   "description": "Define a signal",
}
```
## Usage instructions 
1. Create the "snippets/" directory in the project. 
2. Add the .json file to define the snippet 
3. Enter "prefix" in the GDScript editor to trigger the auto-completion. 
4. After selecting "snippet", the body content is directly inserted into the editor.
## Notes for Attention
This PR represents the first stage implementation of the code snippet functionality. Currently, it only supports snippet definitions based on local JSON files.

- *Bugsquad edit:* This PR closes https://github.com/godotengine/godot-proposals/issues/2402