### PR TITLE
Fix GLES3 batching skipping rendering all items on specific buffer sizes

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -661,7 +661,7 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 		}
 	}
 
-	if (index == 0) {
+	if (state.current_batch_index == 0 && state.canvas_instance_batches[0].instance_count == 0) {
 		// Nothing to render, just return.
 		return;
 	}


### PR DESCRIPTION
Fixes #117602.

As far as I've tested, also:
Fixes #105645.
Fixes #107297.

When adding last instance to the batch, it instantly starts another batch and resets the index to zero. So when the batched instance count was a multiple of the `max_instances_per_buffer` then because of the `if (index == 0)` check it would skip rendering all the batched instances.
AFAICT a correct check is to ensure we're still at the first batch and that its instance count is zero.