### PR TITLE
Fix shortcut input being disabled in MenuButton

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -420,7 +420,7 @@ bool BaseButton::is_shortcut_feedback() const {
 void BaseButton::set_shortcut(const Ref<Shortcut> &p_shortcut) {
 	if (shortcut != p_shortcut) {
 		shortcut = p_shortcut;
-		set_process_shortcut_input(shortcut.is_valid());
+		_update_shortcut_input();
 		queue_accessibility_update();
 	}
 }
@@ -525,6 +525,10 @@ void BaseButton::set_button_group(const Ref<ButtonGroup> &p_group) {
 
 Ref<ButtonGroup> BaseButton::get_button_group() const {
 	return button_group;
+}
+
+void BaseButton::_update_shortcut_input() {
+	set_process_shortcut_input(shortcut.is_valid());
 }
 
 bool BaseButton::_was_pressed_by_mouse() const {

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -86,6 +86,7 @@ protected:
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	void _notification(int p_what);
 
+	virtual void _update_shortcut_input();
 	bool _was_pressed_by_mouse() const;
 	void _accessibility_action_click(const Variant &p_data);
 

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -244,7 +244,7 @@ MenuButton::MenuButton(const String &p_text) :
 	set_flat(true);
 	set_toggle_mode(true);
 	set_disable_shortcuts(false);
-	set_process_shortcut_input(true);
+	_update_shortcut_input();
 	set_focus_mode(FOCUS_ACCESSIBILITY);
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);
 
@@ -255,7 +255,4 @@ MenuButton::MenuButton(const String &p_text) :
 	popup->connect("popup_hide", callable_mp(this, &MenuButton::_popup_visibility_changed).bind(false));
 
 	property_helper.setup_for_instance(base_property_helper, this);
-}
-
-MenuButton::~MenuButton() {
 }

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -55,6 +55,7 @@ protected:
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return property_helper.property_get_revert(p_name, r_property); }
 	static void _bind_methods();
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
+	virtual void _update_shortcut_input() override { set_process_shortcut_input(true); }
 
 public:
 	virtual void pressed() override;
@@ -74,5 +75,4 @@ public:
 #endif
 
 	MenuButton(const String &p_text = String());
-	~MenuButton();
 };

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -669,7 +669,7 @@ PackedStringArray OptionButton::get_configuration_warnings() const {
 OptionButton::OptionButton(const String &p_text) :
 		Button(p_text) {
 	set_toggle_mode(true);
-	set_process_shortcut_input(true);
+	_update_shortcut_input();
 	set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);
 
@@ -682,7 +682,4 @@ OptionButton::OptionButton(const String &p_text) :
 	popup->connect("popup_hide", callable_mp((BaseButton *)this, &BaseButton::set_pressed).bind(false));
 
 	property_helper.setup_for_instance(base_property_helper, this);
-}
-
-OptionButton::~OptionButton() {
 }

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -91,6 +91,7 @@ protected:
 	static void _bind_methods();
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
+	virtual void _update_shortcut_input() override { set_process_shortcut_input(true); }
 
 public:
 	// ATTENTION: This is used by the POT generator's scene parser. If the number of properties returned by `_get_items()` ever changes,
@@ -153,5 +154,4 @@ public:
 #endif
 
 	OptionButton(const String &p_text = String());
-	~OptionButton();
 };


### PR DESCRIPTION
Niche bug, but:
1. Create MenuButton
2. Add menu item with a shortcut
3. Assign `shortcut` property of MenuButton
4. Remove that shortcut

BaseButton will now disable shortcut input, because you set shortcut to null, but that means the MenuButton's menu's shortcuts stop working.

I added a virtual method called when setting `shortcut`. There might be better solutions.