### PR TITLE
Add `_get_tooltip_auto_translate_mode_at()` to Control

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -141,6 +141,13 @@
 				[b]Note:[/b] If this method returns an empty [String] and [method _make_custom_tooltip] is not overridden, no tooltip is displayed.
 			</description>
 		</method>
+		<method name="_get_tooltip_auto_translate_mode_at" qualifiers="virtual const">
+			<return type="int" enum="Node.AutoTranslateMode" />
+			<param index="0" name="at_position" type="Vector2" />
+			<description>
+				Return the auto-translation mode at the given [param at_position]. If not implemented, the [member tooltip_auto_translate_mode] property will be used instead.
+			</description>
+		</method>
 		<method name="_gui_input" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="event" type="InputEvent" />

--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -521,6 +521,7 @@ void EditorAutoloadSettings::update_autoload() {
 
 		TreeItem *item = tree->create_item(root);
 		item->set_text(0, name);
+		item->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED); // For tooltip.
 		item->set_editable(0, true);
 
 		item->set_text(1, ResourceUID::ensure_path(scr_path));

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3952,6 +3952,15 @@ Node::AutoTranslateMode Control::get_tooltip_auto_translate_mode() const {
 	return data.tooltip_auto_translate_mode;
 }
 
+Node::AutoTranslateMode Control::get_tooltip_auto_translate_mode_at(const Vector2 &p_at) const {
+	ERR_READ_THREAD_GUARD_V(AUTO_TRANSLATE_MODE_INHERIT);
+	AutoTranslateMode auto_translating;
+	if (GDVIRTUAL_CALL(_get_tooltip_auto_translate_mode_at, p_at, auto_translating)) {
+		return auto_translating;
+	}
+	return get_tooltip_auto_translate_mode();
+}
+
 // Extra properties.
 
 void Control::set_tooltip_text(const String &p_hint) {
@@ -4756,6 +4765,7 @@ void Control::_bind_methods() {
 	GDVIRTUAL_BIND(_structured_text_parser, "args", "text");
 	GDVIRTUAL_BIND(_get_minimum_size);
 	GDVIRTUAL_BIND(_get_tooltip, "at_position");
+	GDVIRTUAL_BIND(_get_tooltip_auto_translate_mode_at, "at_position");
 
 	GDVIRTUAL_BIND(_get_drag_data, "at_position");
 	GDVIRTUAL_BIND(_can_drop_data, "at_position", "data");

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -435,6 +435,7 @@ protected:
 	GDVIRTUAL2RC(TypedArray<Vector3i>, _structured_text_parser, Array, String)
 	GDVIRTUAL0RC(Vector2, _get_minimum_size)
 	GDVIRTUAL1RC(String, _get_tooltip, Vector2)
+	GDVIRTUAL1RC(AutoTranslateMode, _get_tooltip_auto_translate_mode_at, Vector2)
 
 	GDVIRTUAL1R(Variant, _get_drag_data, Vector2)
 	GDVIRTUAL2RC(bool, _can_drop_data, Vector2, Variant)
@@ -790,6 +791,7 @@ public:
 
 	void set_tooltip_auto_translate_mode(AutoTranslateMode p_mode);
 	AutoTranslateMode get_tooltip_auto_translate_mode() const;
+	virtual AutoTranslateMode get_tooltip_auto_translate_mode_at(const Vector2 &p_at) const;
 
 	// Extra properties.
 

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -2077,6 +2077,14 @@ String ItemList::get_tooltip(const Point2 &p_pos) const {
 	return Control::get_tooltip(p_pos);
 }
 
+Node::AutoTranslateMode ItemList::get_tooltip_auto_translate_mode_at(const Point2 &p_at) const {
+	int closest = get_item_at_position(p_at, true);
+	if (closest != -1) {
+		return items[closest].auto_translate_mode;
+	}
+	return Control::get_tooltip_auto_translate_mode_at(p_at);
+}
+
 void ItemList::sort_items_by_text() {
 	items.sort();
 	queue_accessibility_update();

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -325,6 +325,7 @@ public:
 	int find_metadata(const Variant &p_metadata) const;
 
 	virtual String get_tooltip(const Point2 &p_pos) const override;
+	virtual AutoTranslateMode get_tooltip_auto_translate_mode_at(const Point2 &p_at) const override;
 	int get_item_at_position(const Point2 &p_pos, bool p_exact = false) const;
 	bool is_pos_at_end_of_items(const Point2 &p_pos) const;
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -6691,6 +6691,26 @@ String Tree::get_tooltip(const Point2 &p_pos) const {
 	return Control::get_tooltip(p_pos);
 }
 
+Node::AutoTranslateMode Tree::get_tooltip_auto_translate_mode_at(const Point2 &p_at) const {
+	Point2 pos = p_at - theme_cache.panel_style->get_offset();
+	pos.y -= _get_title_button_height();
+
+	// `pos.y` less than 0 indicates we're in the header.
+	if (pos.y < 0) {
+		// Columns don't have auto-translate mode, so return the default.
+		return Control::get_tooltip_auto_translate_mode_at(p_at);
+	}
+
+	TreeItem *it;
+	int col, index, section;
+	_find_button_at_pos(p_at, it, col, index, section);
+
+	if (it) {
+		return it->get_auto_translate_mode(col);
+	}
+	return Control::get_tooltip_auto_translate_mode_at(p_at);
+}
+
 void Tree::set_cursor_can_exit_tree(bool p_enable) {
 	cursor_can_exit_tree = p_enable;
 }

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -834,6 +834,7 @@ public:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 	virtual String get_tooltip(const Point2 &p_pos) const override;
+	virtual AutoTranslateMode get_tooltip_auto_translate_mode_at(const Point2 &p_at) const override;
 
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
 	virtual Variant get_drag_data(const Point2 &p_point) override;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1675,7 +1675,7 @@ void Viewport::_gui_show_tooltip_at(const Point2i &p_pos) {
 		gui.tooltip_label = memnew(Label);
 		gui.tooltip_label->set_theme_type_variation(SNAME("TooltipLabel"));
 		gui.tooltip_label->set_text(gui.tooltip_text);
-		gui.tooltip_label->set_auto_translate_mode(tooltip_owner->get_tooltip_auto_translate_mode());
+		gui.tooltip_label->set_auto_translate_mode(tooltip_owner->get_tooltip_auto_translate_mode_at(tooltip_owner->get_global_transform_with_canvas().affine_inverse().xform(gui.last_mouse_pos)));
 		base_tooltip = gui.tooltip_label;
 		panel->connect(SceneStringName(mouse_entered), callable_mp(this, &Viewport::_gui_cancel_tooltip));
 	}


### PR DESCRIPTION
This PR adds `_get_tooltip_auto_translate_mode_at()` as complementary to `_get_tooltip()` and `tooltip_translate_mode`. It allows to customize auto-translation at a specific position. This is relevant for Tree and ItemList, which allow customizing auto-translation per item, and notably allows to fix autoload names being translated in tooltip.