### PR TITLE
Add common color names to EditorStringNames

### DIFF
--- a/editor/animation/animation_bezier_editor.cpp
+++ b/editor/animation/animation_bezier_editor.cpp
@@ -599,7 +599,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 				}
 			}
 
-			const Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			const Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 
 			// Guides.
 			{
@@ -992,7 +992,7 @@ void AnimationBezierTrackEdit::_play_position_draw() {
 	int px = (-timeline->get_value() + play_position_pos) * scale + limit;
 
 	if (px >= limit && px < (get_size().width)) {
-		const Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		const Color color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
 	}
 }

--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -290,7 +290,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 	Size2 s = blend_space_draw->get_size();
 
 	if (blend_space_draw->has_focus()) {
-		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		blend_space_draw->draw_rect(Rect2(Point2(), s), color, false);
 	}
 
@@ -351,7 +351,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 			Vector2 text_size = font->get_string_size(name_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size);
 			Vector2 text_pos = Vector2(CLAMP(point - text_size.x / 2.0, 0, s.width - text_size.x), gui_point.y - 4 * EDSCALE);
 
-			Color name_color = i == selected_point ? get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) : linecolor;
+			Color name_color = i == selected_point ? get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)) : linecolor;
 			blend_space_draw->draw_string(font, text_pos, name_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
 
 			if (text_rects.size() <= i) {
@@ -366,7 +366,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 	{
 		Color color;
 		if (tool_blend->is_pressed()) {
-			color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		} else {
 			color = linecolor;
 			color.a *= 0.5;
@@ -739,7 +739,7 @@ void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			error_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
-			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 			panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
 			tool_blend->set_button_icon(get_editor_theme_icon(SNAME("EditPivot")));
 			tool_select->set_button_icon(get_editor_theme_icon(SNAME("ToolSelect")));
@@ -814,9 +814,9 @@ void AnimationNodeBlendSpace1DEditor::_start_inline_edit(int p_point) {
 	inline_editor = memnew(LineEdit);
 	blend_space_draw->add_child(inline_editor);
 
-	inline_editor->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
+	inline_editor->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)));
 	inline_editor->add_theme_color_override("font_selected_color", Color::named("white"));
-	inline_editor->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
+	inline_editor->add_theme_color_override("selection_color", get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)));
 	Ref<StyleBoxEmpty> empty_style = memnew(StyleBoxEmpty);
 	empty_style->set_content_margin_all(0);
 	inline_editor->add_theme_style_override(CoreStringName(normal), empty_style);

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -531,7 +531,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 	Size2 s = blend_space_draw->get_size();
 
 	if (blend_space_draw->has_focus(true)) {
-		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		blend_space_draw->draw_rect(Rect2(Point2(), s), color, false);
 	}
 	blend_space_draw->draw_line(Point2(1, 0), Point2(1, s.height - 1), linecolor, Math::round(EDSCALE));
@@ -611,7 +611,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 
 		Color color;
 		if (i == selected_triangle) {
-			color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 			color.a *= 0.5;
 		} else {
 			color = linecolor;
@@ -655,7 +655,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 			float text_y = above_pos_y >= text_size.y ? above_pos_y : point.y + half_icon_h + font->get_ascent(font_size);
 			Vector2 text_pos = Vector2(text_x, text_y);
 
-			Color name_color = i == selected_point ? get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) : linecolor;
+			Color name_color = i == selected_point ? get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)) : linecolor;
 			blend_space_draw->draw_string(font, text_pos, name_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
 
 			if (text_rects.size() <= i) {
@@ -687,7 +687,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 	{
 		Color color;
 		if (tool_blend->is_pressed()) {
-			color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		} else {
 			color = linecolor;
 			color.a *= 0.5;
@@ -979,7 +979,7 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			error_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
-			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 			panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
 			tool_blend->set_button_icon(get_editor_theme_icon(SNAME("EditPivot")));
 			tool_select->set_button_icon(get_editor_theme_icon(SNAME("ToolSelect")));
@@ -1079,9 +1079,9 @@ void AnimationNodeBlendSpace2DEditor::_start_inline_edit(int p_point) {
 	inline_editor = memnew(LineEdit);
 	blend_space_draw->add_child(inline_editor);
 
-	inline_editor->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
+	inline_editor->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)));
 	inline_editor->add_theme_color_override("font_selected_color", Color::named("white"));
-	inline_editor->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
+	inline_editor->add_theme_color_override("selection_color", get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)));
 	Ref<StyleBoxEmpty> empty_style = memnew(StyleBoxEmpty);
 	empty_style->set_content_margin_all(0);
 	inline_editor->add_theme_style_override(CoreStringName(normal), empty_style);

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -1045,7 +1045,7 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 
 		case NOTIFICATION_THEME_CHANGED: {
 			error_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
-			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			error_label->add_theme_color_override(SNAME("default_color"), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 
 			if (is_visible_in_tree()) {
 				update_graph();

--- a/editor/animation/animation_library_editor.cpp
+++ b/editor/animation/animation_library_editor.cpp
@@ -87,7 +87,7 @@ void AnimationLibraryEditor::_add_library_validate(const String &p_name) {
 	}
 
 	if (error != "") {
-		add_library_validate->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		add_library_validate->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 		add_library_validate->set_text(error);
 		add_library_dialog->get_ok_button()->set_disabled(true);
 	} else {
@@ -100,7 +100,7 @@ void AnimationLibraryEditor::_add_library_validate(const String &p_name) {
 				add_library_validate->set_text(TTR("Library name is valid."));
 			}
 		}
-		add_library_validate->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("success_color"), EditorStringName(Editor)));
+		add_library_validate->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(success_color), EditorStringName(Editor)));
 		add_library_dialog->get_ok_button()->set_disabled(false);
 	}
 }

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -36,6 +36,7 @@
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_node.h"
+#include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/settings/editor_settings.h"
@@ -2005,7 +2006,7 @@ void AnimationNodeStateMachineEditor::_bind_methods() {
 
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, panel_style, "panel", "GraphStateMachine");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, AnimationNodeStateMachineEditor, error_panel_style, "error_panel", "GraphStateMachine");
-	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, error_color, "error_color", "GraphStateMachine");
+	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_COLOR, AnimationNodeStateMachineEditor, error_color, EditorStringName(error_color), "GraphStateMachine");
 
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, tool_icon_select, "ToolSelect", "EditorIcons");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_ICON, AnimationNodeStateMachineEditor, tool_icon_create, "ToolAddNode", "EditorIcons");

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -1891,7 +1891,7 @@ void AnimationTimelineEdit::_play_position_draw() {
 
 	if (px >= get_name_limit() && px < (play_position->get_size().width - get_buttons_width())) {
 		int h = editor->box_selection_container->get_global_position().y - get_global_position().y;
-		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 
 		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
 		play_position->draw_texture(
@@ -2214,7 +2214,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 				String text;
 				Color text_color = color;
 				if (node && EditorNode::get_singleton()->get_editor_selection()->is_selected(node)) {
-					text_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+					text_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 				}
 
 				if (in_group) {
@@ -2536,7 +2536,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 			}
 
 			if (dropping_at != 0) {
-				Color drop_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+				Color drop_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 				if (dropping_at < 0) {
 					draw_line(Vector2(0, 0), Vector2(get_size().width, 0), drop_color, Math::round(EDSCALE));
 				} else {
@@ -2801,7 +2801,7 @@ void AnimationTrackEdit::_play_position_draw() {
 	int px = (-timeline->get_value() + play_position_pos) * scale + timeline->get_name_limit();
 
 	if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
-		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
 	}
 }
@@ -3827,7 +3827,7 @@ void AnimationTrackEditGroup::_notification(int p_what) {
 			if (root) {
 				Node *n = root->get_node_or_null(node);
 				if (n && EditorNode::get_singleton()->get_editor_selection()->is_selected(n)) {
-					color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+					color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 				}
 			}
 
@@ -3929,7 +3929,7 @@ void AnimationTrackEditGroup::_notification(int p_what) {
 
 			int px = (-timeline->get_value() + timeline->get_play_position()) * timeline->get_zoom_scale() + timeline->get_name_limit();
 			if (px >= timeline->get_name_limit() && px < limit_end) {
-				const Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+				const Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 				draw_line(Point2(px, 0), Point2(px, get_size().height), accent, Math::round(2 * EDSCALE));
 			}
 
@@ -8851,7 +8851,7 @@ void AnimationMarkerEdit::_play_position_draw() {
 	int px = (play_position_pos - timeline->get_value()) * scale + timeline->get_name_limit();
 
 	if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
-		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		play_position->draw_line(Point2(px, 0), Point2(px, get_size().height), color, Math::round(2 * EDSCALE));
 	}
 }

--- a/editor/animation/animation_track_editor_plugins.cpp
+++ b/editor/animation/animation_track_editor_plugins.cpp
@@ -75,7 +75,7 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 	draw_texture(icon, ofs);
 
 	if (p_selected) {
-		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		draw_rect_clipped(Rect2(ofs, icon->get_size()), color, false);
 	}
 }
@@ -182,7 +182,7 @@ void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x,
 	draw_rect_clipped(rect, color);
 
 	if (p_selected) {
-		Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		draw_rect_clipped(rect, accent, false);
 		if (color.get_luminance() > 0.3) {
 			draw_rect_clipped(rect.grow(-1), Color(0.0, 0.0, 0.0, 0.5), false);
@@ -334,7 +334,7 @@ void AnimationTrackEditAudio::draw_key(int p_index, float p_pixels_sec, int p_x,
 		RS::get_singleton()->canvas_item_add_multiline(get_canvas_item(), points, colors);
 
 		if (p_selected) {
-			Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 			draw_rect(rect, accent, false);
 		}
 	} else {
@@ -347,7 +347,7 @@ void AnimationTrackEditAudio::draw_key(int p_index, float p_pixels_sec, int p_x,
 		draw_rect_clipped(rect, color);
 
 		if (p_selected) {
-			Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 			draw_rect_clipped(rect, accent, false);
 		}
 	}
@@ -559,7 +559,7 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 		return;
 	}
 
-	Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+	Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 	Color bg = accent;
 	bg.a = 0.15;
 
@@ -718,7 +718,7 @@ void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_
 		}
 
 		if (p_selected) {
-			Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 			draw_rect(rect, accent, false);
 		}
 	} else {
@@ -731,7 +731,7 @@ void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_
 		draw_rect_clipped(rect, color);
 
 		if (p_selected) {
-			Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 			draw_rect_clipped(rect, accent, false);
 		}
 	}
@@ -954,7 +954,7 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 
 	RS::get_singleton()->canvas_item_add_multiline(get_canvas_item(), points, colors);
 
-	Color cut_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+	Color cut_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 	cut_color.a = 0.7;
 	if (start_ofs > 0 && pixel_begin > p_clip_left) {
 		draw_rect(Rect2(pixel_begin, rect.position.y, 1, rect.size.y), cut_color);
@@ -964,7 +964,7 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 	}
 
 	if (p_selected) {
-		Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		draw_rect(rect, accent, false);
 	}
 }
@@ -1320,7 +1320,7 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 		}
 
 		if (p_selected) {
-			Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 			draw_rect(rect, accent, false);
 		}
 	} else {
@@ -1333,7 +1333,7 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 		draw_rect_clipped(rect, color);
 
 		if (p_selected) {
-			Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 			draw_rect_clipped(rect, accent, false);
 		}
 	}

--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -708,7 +708,7 @@ void EditorAssetLibrary::_notification(int p_what) {
 			filter->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 			library_scroll->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
 			downloads_scroll->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("downloads"), SNAME("AssetLib")));
-			error_label->add_theme_color_override("color", get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			error_label->add_theme_color_override("color", get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {

--- a/editor/asset_library/editor_asset_installer.cpp
+++ b/editor/asset_library/editor_asset_installer.cpp
@@ -97,7 +97,7 @@ bool EditorAssetInstaller::_fix_conflicted_indeterminate_state(TreeItem *p_item,
 		p_item->set_checked(p_column, false);
 	}
 	if (has_conflict_child) {
-		p_item->set_custom_color(p_column, get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		p_item->set_custom_color(p_column, get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 	} else {
 		p_item->clear_custom_color(p_column);
 	}
@@ -278,7 +278,7 @@ bool EditorAssetInstaller::_update_source_item_status(TreeItem *p_item, const St
 
 	bool target_exists = FileAccess::exists(target_path);
 	if (target_exists) {
-		p_item->set_custom_color(0, get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		p_item->set_custom_color(0, get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 		p_item->set_tooltip_text(0, vformat(TTR("%s (already exists)"), target_path));
 		p_item->set_checked(0, false);
 	} else {
@@ -610,7 +610,7 @@ void EditorAssetInstaller::_notification(int p_what) {
 			} else {
 				show_source_files_button->set_button_icon(get_editor_theme_icon(SNAME("Forward")));
 			}
-			asset_conflicts_link->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			asset_conflicts_link->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 
 			generic_extension_icon = get_editor_theme_icon(SNAME("Object"));
 

--- a/editor/audio/audio_stream_editor_plugin.cpp
+++ b/editor/audio/audio_stream_editor_plugin.cpp
@@ -159,7 +159,7 @@ void AudioStreamEditor::_draw_indicator() {
 	Rect2 rect = _preview->get_rect();
 	float len = stream->get_length();
 	float ofs_x = _current / len * rect.size.width;
-	const Color col = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+	const Color col = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 	Ref<Texture2D> icon = get_editor_theme_icon(SNAME("TimelineIndicator"));
 	_indicator->draw_line(Point2(ofs_x, 0), Point2(ofs_x, rect.size.height), col, Math::round(2 * EDSCALE));
 	_indicator->draw_texture(

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -145,7 +145,7 @@ void EditorAudioBus::_notification(int p_what) {
 			}
 
 			if (get_index() != 0 && hovering_drop) {
-				Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+				Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 				accent.a *= 0.7;
 				draw_rect(Rect2(Point2(), get_size()), accent, false);
 			}
@@ -1035,7 +1035,7 @@ void EditorAudioBusDrop::_notification(int p_what) {
 			draw_style_box(get_theme_stylebox(CoreStringName(normal), SNAME("Button")), Rect2(Vector2(), get_size()));
 
 			if (hovering_drop) {
-				Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+				Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 				accent.a *= 0.7;
 				draw_rect(Rect2(Point2(), get_size()), accent, false);
 			}

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -464,13 +464,13 @@ void EditorDebuggerNode::_update_errors() {
 			if (error_count >= 1 && warning_count >= 1) {
 				set_dock_icon(get_editor_theme_icon(SNAME("ErrorWarning")));
 				// Use error color to represent the highest level of severity reported.
-				set_title_color(get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+				set_title_color(get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 			} else if (error_count >= 1) {
 				set_dock_icon(get_editor_theme_icon(SNAME("Error")));
-				set_title_color(get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+				set_title_color(get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 			} else {
 				set_dock_icon(get_editor_theme_icon(SNAME("Warning")));
-				set_title_color(get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+				set_title_color(get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 			}
 			set_force_show_icon(true);
 		}

--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -143,7 +143,7 @@ void EditorPerformanceProfiler::_monitor_draw() {
 
 		rect.position += graph_style_box->get_offset();
 		rect.size -= graph_style_box->get_minimum_size();
-		Color draw_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color draw_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		draw_color.set_hsv(Math::fmod(hue_shift * float(current.frame_index), 0.9f), draw_color.get_s() * 0.9f, draw_color.get_v() * value_multiplier, 0.6f);
 		monitor_draw->draw_string(graph_font, rect.position + Point2(0, graph_font->get_ascent(font_size)), current.item->get_text(0), HORIZONTAL_ALIGNMENT_LEFT, rect.size.x, font_size, draw_color);
 

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -151,7 +151,7 @@ String EditorProfiler::_get_time_as_text(const Metric &m, float p_time, int p_ca
 }
 
 Color EditorProfiler::_get_color_from_signature(const StringName &p_signature) const {
-	Color bc = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
+	Color bc = get_theme_color(EditorStringName(error_color), EditorStringName(Editor));
 	double rot = Math::abs(double(p_signature.hash()) / double(0x7FFFFFFF));
 	Color c;
 	c.set_hsv(rot, bc.get_s(), bc.get_v());

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -141,7 +141,7 @@ String EditorVisualProfiler::_get_time_as_text(float p_time) {
 }
 
 Color EditorVisualProfiler::_get_color_from_signature(const StringName &p_signature) const {
-	Color bc = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
+	Color bc = get_theme_color(EditorStringName(error_color), EditorStringName(Editor));
 	double rot = Math::abs(double(p_signature.hash()) / double(0x7FFFFFFF));
 	Color c;
 	c.set_hsv(rot, bc.get_s(), bc.get_v());

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -664,7 +664,7 @@ void ScriptEditorDebugger::_msg_error(uint64_t p_thread_id, const Array &p_data)
 	error->set_text(0, time);
 	error->set_text_alignment(0, HORIZONTAL_ALIGNMENT_LEFT);
 
-	const Color color = get_theme_color(oe.warning ? SNAME("warning_color") : SNAME("error_color"), EditorStringName(Editor));
+	const Color color = get_theme_color(oe.warning ? EditorStringName(warning_color) : EditorStringName(error_color), EditorStringName(Editor));
 	error->set_custom_color(0, color);
 	error->set_custom_color(1, color);
 
@@ -1038,13 +1038,13 @@ void ScriptEditorDebugger::_init_parse_message_handlers() {
 void ScriptEditorDebugger::_set_reason_text(const String &p_reason, MessageType p_type) {
 	switch (p_type) {
 		case MESSAGE_ERROR:
-			reason->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			reason->add_theme_color_override(SNAME("default_color"), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 			break;
 		case MESSAGE_WARNING:
-			reason->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+			reason->add_theme_color_override(SNAME("default_color"), get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 			break;
 		default:
-			reason->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("success_color"), EditorStringName(Editor)));
+			reason->add_theme_color_override(SNAME("default_color"), get_theme_color(EditorStringName(success_color), EditorStringName(Editor)));
 			break;
 	}
 
@@ -1106,10 +1106,10 @@ void ScriptEditorDebugger::_notification(int p_what) {
 
 			skip_breakpoints->set_button_icon(get_editor_theme_icon(skip_breakpoints_value ? SNAME("DebugSkipBreakpointsOn") : SNAME("DebugSkipBreakpointsOff")));
 			ignore_error_breaks->set_button_icon(get_editor_theme_icon(ignore_error_breaks_value ? SNAME("NotificationDisabled") : SNAME("Notification")));
-			ignore_error_breaks->add_theme_color_override("icon_normal_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
-			ignore_error_breaks->add_theme_color_override("icon_hover_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
-			ignore_error_breaks->add_theme_color_override("icon_pressed_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
-			ignore_error_breaks->add_theme_color_override("icon_focus_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+			ignore_error_breaks->add_theme_color_override("icon_normal_color", get_theme_color(EditorStringName(error_color), SNAME("Editor")));
+			ignore_error_breaks->add_theme_color_override("icon_hover_color", get_theme_color(EditorStringName(error_color), SNAME("Editor")));
+			ignore_error_breaks->add_theme_color_override("icon_pressed_color", get_theme_color(EditorStringName(error_color), SNAME("Editor")));
+			ignore_error_breaks->add_theme_color_override("icon_focus_color", get_theme_color(EditorStringName(error_color), SNAME("Editor")));
 			copy->set_button_icon(get_editor_theme_icon(SNAME("ActionCopy")));
 			step->set_button_icon(get_editor_theme_icon(SNAME("DebugStep")));
 			next->set_button_icon(get_editor_theme_icon(SNAME("DebugNext")));
@@ -1123,7 +1123,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			vmem_item_menu->set_item_icon(VMEM_MENU_SHOW_IN_EXPLORER, get_editor_theme_icon(SNAME("Filesystem")));
 			search->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 
-			reason->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			reason->add_theme_color_override(SNAME("default_color"), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 			reason->add_theme_style_override(SNAME("normal"), get_theme_stylebox(SNAME("normal"), SNAME("Label"))); // Empty stylebox.
 
 			const Ref<Font> source_font = get_theme_font(SNAME("output_source"), EditorStringName(EditorFonts));
@@ -1139,12 +1139,12 @@ void ScriptEditorDebugger::_notification(int p_what) {
 				while (error) {
 					if (error->has_meta("_is_warning")) {
 						error->set_icon(0, get_editor_theme_icon(SNAME("Warning")));
-						error->set_custom_color(0, get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
-						error->set_custom_color(1, get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+						error->set_custom_color(0, get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
+						error->set_custom_color(1, get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 					} else if (error->has_meta("_is_error")) {
 						error->set_icon(0, get_editor_theme_icon(SNAME("Error")));
-						error->set_custom_color(0, get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
-						error->set_custom_color(1, get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+						error->set_custom_color(0, get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
+						error->set_custom_color(1, get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 					}
 
 					error = error->get_next();

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -510,7 +510,7 @@ void EditorHelp::_add_type_icon(const String &p_type, int p_size, const String &
 
 #define DEPRECATED_DOC_TAG \
 	class_desc->push_font(theme_cache.doc_bold_font); \
-	class_desc->push_color(get_theme_color(SNAME("error_color"), EditorStringName(Editor))); \
+	class_desc->push_color(get_theme_color(EditorStringName(error_color), EditorStringName(Editor))); \
 	Ref<Texture2D> error_icon = get_editor_theme_icon(SNAME("StatusError")); \
 	class_desc->add_image(error_icon, error_icon->get_width(), error_icon->get_height()); \
 	class_desc->add_text(String::chr(160) + TTR("Deprecated")); \
@@ -519,7 +519,7 @@ void EditorHelp::_add_type_icon(const String &p_type, int p_size, const String &
 
 #define EXPERIMENTAL_DOC_TAG \
 	class_desc->push_font(theme_cache.doc_bold_font); \
-	class_desc->push_color(get_theme_color(SNAME("warning_color"), EditorStringName(Editor))); \
+	class_desc->push_color(get_theme_color(EditorStringName(warning_color), EditorStringName(Editor))); \
 	Ref<Texture2D> warning_icon = get_editor_theme_icon(SNAME("NodeWarning")); \
 	class_desc->add_image(warning_icon, warning_icon->get_width(), warning_icon->get_height()); \
 	class_desc->add_text(String::chr(160) + TTR("Experimental")); \
@@ -532,7 +532,7 @@ void EditorHelp::_add_type_icon(const String &p_type, int p_size, const String &
 	Ref<Texture2D> error_icon = get_editor_theme_icon(SNAME("StatusError")); \
 	class_desc->add_image(error_icon, error_icon->get_width(), error_icon->get_height()); \
 	class_desc->add_text(nbsp); \
-	class_desc->push_color(get_theme_color(SNAME("error_color"), EditorStringName(Editor))); \
+	class_desc->push_color(get_theme_color(EditorStringName(error_color), EditorStringName(Editor))); \
 	class_desc->push_font(theme_cache.doc_bold_font); \
 	class_desc->add_text(TTR("Deprecated:")); \
 	class_desc->pop(); \
@@ -548,7 +548,7 @@ void EditorHelp::_add_type_icon(const String &p_type, int p_size, const String &
 	Ref<Texture2D> warning_icon = get_editor_theme_icon(SNAME("NodeWarning")); \
 	class_desc->add_image(warning_icon, warning_icon->get_width(), warning_icon->get_height()); \
 	class_desc->add_text(nbsp); \
-	class_desc->push_color(get_theme_color(SNAME("warning_color"), EditorStringName(Editor))); \
+	class_desc->push_color(get_theme_color(EditorStringName(warning_color), EditorStringName(Editor))); \
 	class_desc->push_font(theme_cache.doc_bold_font); \
 	class_desc->add_text(TTR("Experimental:")); \
 	class_desc->pop(); \
@@ -2462,9 +2462,9 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 	const Color code_dark_color = Color(code_color, 0.8);
 
 	const Color link_color = p_owner_node->get_theme_color(SNAME("link_color"), SNAME("EditorHelp"));
-	const Color link_method_color = p_owner_node->get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-	const Color link_property_color = link_color.lerp(p_owner_node->get_theme_color(SNAME("accent_color"), EditorStringName(Editor)), 0.25);
-	const Color link_annotation_color = link_color.lerp(p_owner_node->get_theme_color(SNAME("accent_color"), EditorStringName(Editor)), 0.5);
+	const Color link_method_color = p_owner_node->get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
+	const Color link_property_color = link_color.lerp(p_owner_node->get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)), 0.25);
+	const Color link_annotation_color = link_color.lerp(p_owner_node->get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)), 0.5);
 
 	const Color code_bg_color = p_owner_node->get_theme_color(SNAME("code_bg_color"), SNAME("EditorHelp"));
 	const Color kbd_bg_color = p_owner_node->get_theme_color(SNAME("kbd_bg_color"), SNAME("EditorHelp"));
@@ -2691,7 +2691,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 			p_rt->push_font(doc_code_font);
 			p_rt->push_font_size(doc_code_font_size);
 			p_rt->push_bgcolor(code_bg_color);
-			p_rt->push_color(code_color.lerp(p_owner_node->get_theme_color(SNAME("error_color"), EditorStringName(Editor)), 0.6));
+			p_rt->push_color(code_color.lerp(p_owner_node->get_theme_color(EditorStringName(error_color), EditorStringName(Editor)), 0.6));
 
 			p_rt->add_text(_fix_newlines(bbcode.substr(brk_end + 1, end_pos - (brk_end + 1))));
 
@@ -4130,7 +4130,7 @@ void EditorHelpBit::_update_labels() {
 		Ref<Texture2D> error_icon = get_editor_theme_icon(SNAME("StatusError"));
 		content->add_image(error_icon, error_icon->get_width(), error_icon->get_height());
 		content->add_text(nbsp);
-		content->push_color(get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		content->push_color(get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 		content->push_font(doc_bold_font);
 		content->add_text(TTR("Deprecated:"));
 		content->pop(); // font
@@ -4148,7 +4148,7 @@ void EditorHelpBit::_update_labels() {
 		Ref<Texture2D> warning_icon = get_editor_theme_icon(SNAME("NodeWarning"));
 		content->add_image(warning_icon, warning_icon->get_width(), warning_icon->get_height());
 		content->add_text(nbsp);
-		content->push_color(get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+		content->push_color(get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 		content->push_font(doc_bold_font);
 		content->add_text(TTR("Experimental:"));
 		content->pop(); // font
@@ -5034,7 +5034,7 @@ void FindBar::_notification(int p_what) {
 			find_prev->set_button_icon(get_editor_theme_icon(SNAME("MoveUp")));
 			find_next->set_button_icon(get_editor_theme_icon(SNAME("MoveDown")));
 			hide_button->set_button_icon(get_editor_theme_icon(SNAME("Close")));
-			matches_label->add_theme_color_override(SceneStringName(font_color), results_count > 0 ? get_theme_color(SceneStringName(font_color), SNAME("Label")) : get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			matches_label->add_theme_color_override(SceneStringName(font_color), results_count > 0 ? get_theme_color(SceneStringName(font_color), SNAME("Label")) : get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -5117,7 +5117,7 @@ void FindBar::_update_matches_label() {
 	} else {
 		matches_label->show();
 
-		matches_label->add_theme_color_override(SceneStringName(font_color), results_count > 0 ? get_theme_color(SceneStringName(font_color), SNAME("Label")) : get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		matches_label->add_theme_color_override(SceneStringName(font_color), results_count > 0 ? get_theme_color(SceneStringName(font_color), SNAME("Label")) : get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 		if (results_count == 0) {
 			matches_label->set_text(TTR("No match"));
 		} else if (results_count_to_current == 0) {

--- a/editor/docks/dock_tab_container.cpp
+++ b/editor/docks/dock_tab_container.cpp
@@ -95,7 +95,7 @@ void EditorDockDragHint::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			valid_drop_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			valid_drop_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		} break;
 
 		case NOTIFICATION_MOUSE_ENTER:

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -341,7 +341,7 @@ void FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 				file_item->set_as_cursor(0);
 			}
 			if (main_scene_path == file_metadata) {
-				file_item->set_custom_color(0, get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
+				file_item->set_custom_color(0, get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)));
 			}
 			EditorResourcePreview::get_singleton()->queue_resource_preview(file_metadata, callable_mp(this, &FileSystemDock::_tree_thumbnail_done).bind(tree_update_id, file_item->get_instance_id()));
 		}
@@ -1221,7 +1221,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		}
 
 		if (fpath == main_scene_path) {
-			files->set_item_custom_fg_color(item_index, get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
+			files->set_item_custom_fg_color(item_index, get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)));
 		}
 
 		// Generate the preview.

--- a/editor/docks/history_dock.cpp
+++ b/editor/docks/history_dock.cpp
@@ -105,7 +105,7 @@ void HistoryDock::refresh_history() {
 	for (const EditorUndoRedoManager::Action &E : full_history) {
 		action_list->add_item(E.action_name);
 		if (E.history_id == EditorUndoRedoManager::GLOBAL_HISTORY) {
-			action_list->set_item_custom_fg_color(-1, get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
+			action_list->set_item_custom_fg_color(-1, get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)));
 		}
 	}
 

--- a/editor/docks/import_dock.cpp
+++ b/editor/docks/import_dock.cpp
@@ -705,7 +705,7 @@ void ImportDock::_notification(int p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
 			import_opts->edit(params);
-			label_warning->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+			label_warning->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 		} break;
 	}
 }
@@ -718,7 +718,7 @@ void ImportDock::_set_dirty(bool p_dirty) {
 	if (p_dirty) {
 		// Add a dirty marker to notify the user that they should reimport the selected resource to see changes.
 		import->set_text(TTR("Reimport") + " (*)");
-		import->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+		import->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 		import->set_tooltip_text(TTRC("You have pending changes that haven't been applied yet. Click Reimport to apply changes made to the import options.\nSelecting another resource in the FileSystem dock without clicking Reimport first will discard changes made in the Import dock."));
 	} else {
 		// Remove the dirty marker on the Reimport button.

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -491,7 +491,7 @@ void InspectorDock::_notification(int p_what) {
 			search->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 			if (info_is_warning) {
 				info->set_button_icon(get_editor_theme_icon(SNAME("NodeWarning")));
-				info->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+				info->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 			} else {
 				info->set_button_icon(get_editor_theme_icon(SNAME("NodeInfo")));
 				info->add_theme_color_override(SceneStringName(font_color), get_theme_color(SceneStringName(font_color), EditorStringName(Editor)));
@@ -531,7 +531,7 @@ void InspectorDock::set_info(const String &p_button_text, const String &p_messag
 
 	if (info_is_warning) {
 		info->set_button_icon(get_editor_theme_icon(SNAME("NodeWarning")));
-		info->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+		info->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 	} else {
 		info->set_button_icon(get_editor_theme_icon(SNAME("NodeInfo")));
 		info->add_theme_color_override(SceneStringName(font_color), get_theme_color(SceneStringName(font_color), EditorStringName(Editor)));

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -105,7 +105,7 @@ void SceneTreeDock::_inspect_hovered_node() {
 	tree_item_inspected = item;
 
 	if (item) {
-		Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color accent_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		tree_item_inspected->set_custom_color(0, accent_color);
 	}
 

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -129,9 +129,9 @@ void EditorLog::_update_theme() {
 	collapse_button->set_button_icon(get_editor_theme_icon(SNAME("CombineLines")));
 	search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 
-	theme_cache.error_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
+	theme_cache.error_color = get_theme_color(EditorStringName(error_color), EditorStringName(Editor));
 	theme_cache.error_icon = get_editor_theme_icon(SNAME("Error"));
-	theme_cache.warning_color = get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
+	theme_cache.warning_color = get_theme_color(EditorStringName(warning_color), EditorStringName(Editor));
 	theme_cache.warning_icon = get_editor_theme_icon(SNAME("Warning"));
 	theme_cache.message_color = get_theme_color(SceneStringName(font_color), EditorStringName(Editor)) * Color(1, 1, 1, 0.6);
 }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1205,7 +1205,7 @@ void EditorNode::_update_update_spinner() {
 		// Make the icon modulate color overbright because icons are not completely white on a dark theme.
 		// On a light theme, icons are dark, so we need to modulate them with an even brighter color.
 		const bool dark_icon_and_font = EditorThemeManager::is_dark_icon_and_font();
-		update_spinner->set_self_modulate(theme->get_color(SNAME("error_color"), EditorStringName(Editor)) * (dark_icon_and_font ? Color(1.1, 1.1, 1.1) : Color(4.25, 4.25, 4.25)));
+		update_spinner->set_self_modulate(theme->get_color(EditorStringName(error_color), EditorStringName(Editor)) * (dark_icon_and_font ? Color(1.1, 1.1, 1.1) : Color(4.25, 4.25, 4.25)));
 	} else {
 		update_spinner->set_tooltip_text(TTRC("Spins when the editor window redraws."));
 		update_spinner->set_self_modulate(Color(1, 1, 1));

--- a/editor/editor_string_names.h
+++ b/editor/editor_string_names.h
@@ -48,6 +48,11 @@ public:
 	const StringName EditorFonts = StringName("EditorFonts");
 	const StringName EditorIcons = StringName("EditorIcons");
 	const StringName EditorStyles = StringName("EditorStyles");
+
+	const StringName accent_color = StringName("accent_color");
+	const StringName error_color = StringName("error_color");
+	const StringName warning_color = StringName("warning_color");
+	const StringName success_color = StringName("success_color");
 };
 
 #define EditorStringName(m_name) EditorStringNames::get_singleton()->m_name

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -163,11 +163,11 @@ bool EditorExportPlatform::fill_log_messages(RichTextLabel *p_log, Error p_err) 
 				} break;
 				case EditorExportPlatform::EXPORT_MESSAGE_WARNING: {
 					icon = p_log->get_editor_theme_icon(SNAME("Warning"));
-					color = p_log->get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
+					color = p_log->get_theme_color(EditorStringName(warning_color), EditorStringName(Editor));
 				} break;
 				case EditorExportPlatform::EXPORT_MESSAGE_ERROR: {
 					icon = p_log->get_editor_theme_icon(SNAME("Error"));
-					color = p_log->get_theme_color(SNAME("error_color"), EditorStringName(Editor));
+					color = p_log->get_theme_color(EditorStringName(error_color), EditorStringName(Editor));
 				} break;
 				default:
 					break;
@@ -196,7 +196,7 @@ bool EditorExportPlatform::fill_log_messages(RichTextLabel *p_log, Error p_err) 
 		p_log->set_table_column_expand(1, true);
 
 		{
-			Color color = p_log->get_theme_color(SNAME("error_color"), EditorStringName(Editor));
+			Color color = p_log->get_theme_color(EditorStringName(error_color), EditorStringName(Editor));
 			Ref<Texture> icon = p_log->get_editor_theme_icon(SNAME("Error"));
 
 			p_log->push_cell();

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -414,7 +414,7 @@ void ExportTemplateManager::_set_current_progress_status(const String &p_status,
 
 	if (p_error) {
 		download_progress_bar->hide();
-		download_progress_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		download_progress_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 	} else {
 		download_progress_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SceneStringName(font_color), SNAME("Label")));
 	}
@@ -931,7 +931,7 @@ void ExportTemplateManager::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			current_value->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("main"), EditorStringName(EditorFonts)));
-			current_missing_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			current_missing_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 			current_installed_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor)));
 
 			mirror_options_button->set_button_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -77,7 +77,7 @@ void ProjectExportTextureFormatError::_bind_methods() {
 void ProjectExportTextureFormatError::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			texture_format_error_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			texture_format_error_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 		} break;
 	}
 }
@@ -1889,7 +1889,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	script_key_error = memnew(Label);
 	script_key_error->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	script_key_error->set_text(String::utf8("•  ") + TTR("Invalid Encryption Key (must be 64 hexadecimal characters long)"));
-	script_key_error->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor)));
+	script_key_error->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(error_color), EditorStringName(Editor)));
 	sec_vb->add_margin_child(TTRC("Encryption Key (256-bits as hexadecimal):"), encryption_hb);
 	sec_vb->add_child(script_key_error);
 	sections->add_child(sec_scroll_container);
@@ -1996,14 +1996,14 @@ ProjectExportDialog::ProjectExportDialog() {
 	main_vb->add_child(export_error);
 	export_error->hide();
 	export_error->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_WORD_ELLIPSIS);
-	export_error->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor)));
+	export_error->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(error_color), EditorStringName(Editor)));
 
 	export_warning = memnew(Label);
 	export_warning->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	main_vb->add_child(export_warning);
 	export_warning->hide();
 	export_warning->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_WORD_ELLIPSIS);
-	export_warning->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("warning_color"), EditorStringName(Editor)));
+	export_warning->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(warning_color), EditorStringName(Editor)));
 
 	export_templates_error = memnew(HBoxContainer);
 	main_vb->add_child(export_templates_error);
@@ -2013,7 +2013,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_error2->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	export_templates_error->add_child(export_error2);
 	export_error2->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_WORD_ELLIPSIS);
-	export_error2->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor)));
+	export_error2->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(error_color), EditorStringName(Editor)));
 	export_error2->set_text(String::utf8("•  ") + TTR("Export templates for this platform are missing:") + " ");
 
 	result_dialog = memnew(AcceptDialog);

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -165,7 +165,7 @@ void FindReplaceBar::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			matches_label->add_theme_color_override(SceneStringName(font_color), results_count > 0 ? get_theme_color(SceneStringName(font_color), SNAME("Label")) : get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			matches_label->add_theme_color_override(SceneStringName(font_color), results_count > 0 ? get_theme_color(SceneStringName(font_color), SNAME("Label")) : get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 		} break;
 
 		case NOTIFICATION_PREDELETE: {
@@ -383,7 +383,7 @@ void FindReplaceBar::_replace_all() {
 	}
 
 	text_editor->set_v_scroll(vsval);
-	matches_label->add_theme_color_override(SceneStringName(font_color), rc > 0 ? get_theme_color(SceneStringName(font_color), SNAME("Label")) : get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+	matches_label->add_theme_color_override(SceneStringName(font_color), rc > 0 ? get_theme_color(SceneStringName(font_color), SNAME("Label")) : get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 	matches_label->set_text(vformat(TTR("%d replaced."), rc));
 
 	callable_mp((Object *)text_editor, &Object::connect).call_deferred(SceneStringName(text_changed), callable_mp(this, &FindReplaceBar::_editor_text_changed), 0U);
@@ -495,7 +495,7 @@ void FindReplaceBar::_update_matches_display() {
 	} else {
 		matches_label->show();
 
-		matches_label->add_theme_color_override(SceneStringName(font_color), results_count > 0 ? get_theme_color(SceneStringName(font_color), SNAME("Label")) : get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		matches_label->add_theme_color_override(SceneStringName(font_color), results_count > 0 ? get_theme_color(SceneStringName(font_color), SNAME("Label")) : get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 
 		if (results_count == 0) {
 			matches_label->set_text(TTR("No match"));
@@ -1606,8 +1606,8 @@ void CodeTextEditor::_update_text_editor_theme() {
 
 	const Ref<Font> status_bar_font = get_theme_font(SNAME("status_source"), EditorStringName(EditorFonts));
 	const int status_bar_font_size = get_theme_font_size(SNAME("status_source_size"), EditorStringName(EditorFonts));
-	const Color &error_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
-	const Color &warning_color = get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
+	const Color &error_color = get_theme_color(EditorStringName(error_color), EditorStringName(Editor));
+	const Color &warning_color = get_theme_color(EditorStringName(warning_color), EditorStringName(Editor));
 	const Ref<StyleBox> label_stylebox = get_theme_stylebox(SNAME("normal"), SNAME("Label")); // Empty stylebox.
 
 	error->begin_bulk_theme_override();

--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -388,7 +388,7 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringN
 		r_item->set_meta(SNAME("_script_path"), script_path);
 		if (is_tool) {
 			int button_index = r_item->get_button_count(0) - 1;
-			r_item->set_button_color(0, button_index, get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
+			r_item->set_button_color(0, button_index, get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)));
 		}
 	} else {
 		is_custom_type = true;

--- a/editor/gui/editor_toaster.cpp
+++ b/editor/gui/editor_toaster.cpp
@@ -127,10 +127,10 @@ void EditorToaster::_notification(int p_what) {
 			info_panel_style_background->set_bg_color(bg_color);
 
 			warning_panel_style_background->set_bg_color(bg_color);
-			warning_panel_style_background->set_border_color(get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+			warning_panel_style_background->set_border_color(get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 
 			error_panel_style_background->set_bg_color(bg_color);
-			error_panel_style_background->set_border_color(get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			error_panel_style_background->set_border_color(get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 
 			// Styleboxes progress.
 			const Color bg_progress_color = base_color.lerp(get_theme_color(SNAME("mono_color"), EditorStringName(Editor)), 0.135);
@@ -138,10 +138,10 @@ void EditorToaster::_notification(int p_what) {
 			info_panel_style_progress->set_bg_color(bg_progress_color);
 
 			warning_panel_style_progress->set_bg_color(bg_progress_color);
-			warning_panel_style_progress->set_border_color(get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+			warning_panel_style_progress->set_border_color(get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 
 			error_panel_style_progress->set_bg_color(bg_progress_color);
-			error_panel_style_progress->set_border_color(get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			error_panel_style_progress->set_border_color(get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
@@ -296,13 +296,13 @@ void EditorToaster::_draw_button() {
 	real_t button_radius = main_button->get_size().x / 8;
 	switch (highest_severity) {
 		case SEVERITY_INFO:
-			color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 			break;
 		case SEVERITY_WARNING:
-			color = get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
+			color = get_theme_color(EditorStringName(warning_color), EditorStringName(Editor));
 			break;
 		case SEVERITY_ERROR:
-			color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
+			color = get_theme_color(EditorStringName(error_color), EditorStringName(Editor));
 			break;
 		default:
 			break;

--- a/editor/gui/editor_validation_panel.cpp
+++ b/editor/gui/editor_validation_panel.cpp
@@ -62,9 +62,9 @@ void EditorValidationPanel::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			theme_cache.valid_color = get_theme_color(SNAME("success_color"), EditorStringName(Editor));
-			theme_cache.warning_color = get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
-			theme_cache.error_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
+			theme_cache.valid_color = get_theme_color(EditorStringName(success_color), EditorStringName(Editor));
+			theme_cache.warning_color = get_theme_color(EditorStringName(warning_color), EditorStringName(Editor));
+			theme_cache.error_color = get_theme_color(EditorStringName(error_color), EditorStringName(Editor));
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {

--- a/editor/gui/window_wrapper.cpp
+++ b/editor/gui/window_wrapper.cpp
@@ -422,7 +422,7 @@ void ScreenSelect::_build_advanced_menu() {
 		button->set_tooltip_text(vformat(TTR("Make this panel floating in the screen %d."), i));
 
 		if (i == current_screen) {
-			Color accent_color = get_theme_color("accent_color", EditorStringName(Editor));
+			Color accent_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 			button->add_theme_color_override(SceneStringName(font_color), accent_color);
 		}
 

--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -321,7 +321,7 @@ void AudioStreamImportSettingsDialog::_draw_indicator() {
 		return;
 	}
 
-	const Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+	const Color color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 	_indicator->draw_line(Point2(ofs_x, rect.position.y), Point2(ofs_x, rect.position.y + rect.size.height), color, Math::round(2 * EDSCALE));
 	_indicator->draw_texture(
 			get_editor_theme_icon(SNAME("TimelineIndicator")),

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -633,7 +633,7 @@ void DynamicFontImportSettingsDialog::_notification(int p_what) {
 			preload_pages->set_theme_type_variation(type_variation);
 
 			add_var->set_button_icon(get_editor_theme_icon(SNAME("Add")));
-			label_warn->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+			label_warn->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 			glyph_tree->add_theme_color_override(SNAME("font_disabled_color"), glyph_tree->get_theme_color(SceneStringName(font_color)));
 		} break;
 	}

--- a/editor/import/fbx_importer_manager.cpp
+++ b/editor/import/fbx_importer_manager.cpp
@@ -95,11 +95,11 @@ void FBXImporterManager::_validate_path(const String &p_path) {
 
 	if (success) {
 		path_status->set_text(TTR("FBX2glTF executable is valid."));
-		path_status->add_theme_color_override(SceneStringName(font_color), path_status->get_theme_color(SNAME("success_color"), EditorStringName(Editor)));
+		path_status->add_theme_color_override(SceneStringName(font_color), path_status->get_theme_color(EditorStringName(success_color), EditorStringName(Editor)));
 		get_ok_button()->set_disabled(false);
 	} else {
 		path_status->set_text(error);
-		path_status->add_theme_color_override(SceneStringName(font_color), path_status->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		path_status->add_theme_color_override(SceneStringName(font_color), path_status->get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 		get_ok_button()->set_disabled(true);
 	}
 }

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -2935,7 +2935,7 @@ void EditorInspectorArray::_control_dropping_draw() {
 			from = xform.xform(Vector2(0, child->get_size().y));
 			to = xform.xform(Vector2(elements_vbox->get_size().x, child->get_size().y));
 		}
-		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		control_dropping->draw_line(from, to, color, 2);
 	}
 }
@@ -3856,7 +3856,7 @@ void EditorInspector::initialize_section_theme(EditorInspectorSection::ThemeCach
 	p_cache.indent_size = p_control->get_theme_constant(SNAME("indent_size"), SNAME("EditorInspectorSection"));
 	p_cache.key_padding_size = int(EDITOR_GET("interface/theme/base_spacing")) * 2;
 
-	p_cache.warning_color = p_control->get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
+	p_cache.warning_color = p_control->get_theme_color(EditorStringName(warning_color), EditorStringName(Editor));
 	p_cache.prop_subsection = p_control->get_theme_color(SNAME("prop_subsection"), EditorStringName(Editor));
 	p_cache.font_color = p_control->get_theme_color(SceneStringName(font_color), EditorStringName(Editor));
 	p_cache.font_disabled_color = p_control->get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor));
@@ -3950,7 +3950,7 @@ void EditorInspector::initialize_property_theme(EditorProperty::ThemeCache &p_ca
 
 	p_cache.property_color = p_control->get_theme_color(SNAME("property_color"), SNAME("EditorProperty"));
 	p_cache.readonly_property_color = p_control->get_theme_color(SNAME("readonly_color"), SNAME("EditorProperty"));
-	p_cache.warning_color = p_control->get_theme_color(SNAME("warning_color"), SNAME("EditorProperty"));
+	p_cache.warning_color = p_control->get_theme_color(EditorStringName(warning_color), SNAME("EditorProperty"));
 	p_cache.readonly_warning_color = p_control->get_theme_color(SNAME("readonly_warning_color"), SNAME("EditorProperty"));
 	p_cache.property_color_x = p_control->get_theme_color(SNAME("property_color_x"), EditorStringName(Editor));
 	p_cache.property_color_y = p_control->get_theme_color(SNAME("property_color_y"), EditorStringName(Editor));

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1858,7 +1858,7 @@ void EditorPropertyEasing::_draw_easing() {
 	const Color font_color = get_theme_color(is_read_only() ? SNAME("font_uneditable_color") : SceneStringName(font_color), SNAME("LineEdit"));
 	Color line_color;
 	if (dragging) {
-		line_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		line_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 	} else {
 		line_color = get_theme_color(is_read_only() ? SNAME("font_uneditable_color") : SceneStringName(font_color), SNAME("LineEdit")) * Color(1, 1, 1, 0.9);
 	}
@@ -2373,7 +2373,7 @@ void EditorPropertyQuaternion::_notification(int p_what) {
 			edit_button->set_button_icon(get_editor_theme_icon(SNAME("Edit")));
 			euler_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("property_color"), SNAME("EditorProperty")));
 			warning->set_button_icon(get_editor_theme_icon(SNAME("NodeWarning")));
-			warning->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+			warning->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 		} break;
 	}
 }
@@ -3056,7 +3056,7 @@ void EditorPropertyNodePath::_node_assign() {
 
 void EditorPropertyNodePath::_assign_draw() {
 	if (dropping) {
-		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		assign->draw_rect(Rect2(Point2(), assign->get_size()), color, false);
 	}
 }

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -575,14 +575,14 @@ void EditorPropertyArray::_remove_pressed(int p_slot_index) {
 
 void EditorPropertyArray::_button_draw() {
 	if (dropping) {
-		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		edit->draw_rect(Rect2(Point2(), edit->get_size()), color, false);
 	}
 }
 
 void EditorPropertyArray::_button_add_item_draw() {
 	if (dropping) {
-		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		button_add_item->draw_rect(Rect2(Point2(), button_add_item->get_size()), color, false);
 	}
 }

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -692,7 +692,7 @@ bool EditorResourcePicker::handle_menu_selected(int p_which) {
 
 void EditorResourcePicker::_button_draw() {
 	if (dropping) {
-		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		assign_button->draw_rect(Rect2(Point2(), assign_button->get_size()), color, false);
 	}
 }
@@ -1719,7 +1719,7 @@ void EditorAudioStreamPicker::_preview_draw() {
 		RS::get_singleton()->canvas_item_add_multiline(stream_preview_rect->get_canvas_item(), points, colors);
 
 		if (tagged_frame_offset_count) {
-			Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 
 			for (uint32_t i = 0; i < tagged_frame_offset_count; i++) {
 				int x = CLAMP(tagged_frame_offsets[i] * size.width / preview_len, 0, size.width);
@@ -1738,7 +1738,7 @@ void EditorAudioStreamPicker::_preview_draw() {
 	if (tagged_frame_offset_count > 0) {
 		icon = get_editor_theme_icon(SNAME("Play"));
 		if ((OS::get_singleton()->get_ticks_msec() % 500) > 250) {
-			icon_modulate = Color(1, 0.5, 0.5, 1); // get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			icon_modulate = Color(1, 0.5, 0.5, 1); // get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		}
 	} else {
 		icon = EditorNode::get_singleton()->get_object_icon(audio_stream.operator->());

--- a/editor/inspector/editor_resource_tooltip_plugins.cpp
+++ b/editor/inspector/editor_resource_tooltip_plugins.cpp
@@ -76,7 +76,7 @@ VBoxContainer *EditorResourceTooltipPlugin::make_default_tooltip(const String &p
 			vb->add_child(label);
 		} else {
 			Label *label = memnew(Label(TTR("Invalid file or broken link.")));
-			label->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			label->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_gui_base()->get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 			vb->add_child(label);
 			return vb;
 		}

--- a/editor/project_manager/engine_update_label.cpp
+++ b/editor/project_manager/engine_update_label.cpp
@@ -266,8 +266,8 @@ void EngineUpdateLabel::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			theme_cache.default_color = get_theme_color(SceneStringName(font_color), "Button");
 			theme_cache.disabled_color = get_theme_color("font_disabled_color", "Button");
-			theme_cache.error_color = get_theme_color("error_color", EditorStringName(Editor));
-			theme_cache.update_color = get_theme_color("warning_color", EditorStringName(Editor));
+			theme_cache.error_color = get_theme_color(EditorStringName(error_color), EditorStringName(Editor));
+			theme_cache.update_color = get_theme_color(EditorStringName(warning_color), EditorStringName(Editor));
 		} break;
 
 		case NOTIFICATION_READY: {

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -66,15 +66,15 @@ void ProjectDialog::_set_message(const String &p_msg, MessageType p_type, InputT
 	Ref<Texture2D> new_icon;
 	switch (p_type) {
 		case MESSAGE_ERROR: {
-			msg->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			msg->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 			new_icon = get_editor_theme_icon(SNAME("StatusError"));
 		} break;
 		case MESSAGE_WARNING: {
-			msg->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+			msg->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 			new_icon = get_editor_theme_icon(SNAME("StatusWarning"));
 		} break;
 		case MESSAGE_SUCCESS: {
-			msg->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("success_color"), EditorStringName(Editor)));
+			msg->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(success_color), EditorStringName(Editor)));
 			new_icon = get_editor_theme_icon(SNAME("StatusSuccess"));
 		} break;
 	}
@@ -528,7 +528,7 @@ void ProjectDialog::_renderer_selected() {
 	rd_not_supported->set_visible(rd_error);
 	if (rd_error) {
 		// Needs to be set here since theme colors aren't available at startup.
-		rd_not_supported->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		rd_not_supported->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 		invalid_state_flags.set_flag(InvalidStateFlag::INVALID_STATE_FLAG_RENDERER_SELECT);
 	} else {
 		invalid_state_flags.clear_flag(InvalidStateFlag::INVALID_STATE_FLAG_RENDERER_SELECT);

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -92,7 +92,7 @@ void ProjectListItemControl::_notification(int p_what) {
 
 			project_unsupported_features->set_texture(get_editor_theme_icon(SNAME("NodeWarning")));
 
-			favorite_focus_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			favorite_focus_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 			_update_favorite_button_focus_color();
 			if (is_favorite) {
 				favorite_button->set_texture_normal(get_editor_theme_icon(SNAME("Favorites")));

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -279,8 +279,8 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 			create_tag_btn->set_button_icon(get_editor_theme_icon("Add"));
 			donate_btn->set_button_icon(get_editor_theme_icon("Heart"));
 
-			tag_error->add_theme_color_override(SceneStringName(font_color), get_theme_color("error_color", EditorStringName(Editor)));
-			tag_edit_error->add_theme_color_override(SceneStringName(font_color), get_theme_color("error_color", EditorStringName(Editor)));
+			tag_error->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
+			tag_edit_error->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 
 			const int h_separation = get_theme_constant("sidebar_button_icon_separation", "ProjectManager");
 			create_btn->add_theme_constant_override("h_separation", h_separation);

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -285,7 +285,7 @@ void QuickSettingsDialog::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			settings_list_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("quick_settings_panel"), SNAME("ProjectManager")));
 
-			restart_required_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+			restart_required_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 			custom_theme_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("font_placeholder_color"), EditorStringName(Editor)));
 		} break;
 

--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -755,9 +755,9 @@ void GameView::_update_speed_state_color() {
 	if (time_scale_index == DEFAULT_TIME_SCALE_INDEX) {
 		text_color = get_theme_color(SceneStringName(font_color), EditorStringName(Editor));
 	} else if (time_scale_index > DEFAULT_TIME_SCALE_INDEX) {
-		text_color = get_theme_color(SNAME("success_color"), EditorStringName(Editor));
+		text_color = get_theme_color(EditorStringName(success_color), EditorStringName(Editor));
 	} else if (time_scale_index < DEFAULT_TIME_SCALE_INDEX) {
-		text_color = get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
+		text_color = get_theme_color(EditorStringName(warning_color), EditorStringName(Editor));
 	}
 	speed_state_button->add_theme_color_override(SceneStringName(font_color), text_color);
 }
@@ -862,7 +862,7 @@ void GameView::_update_ui() {
 			state_label->remove_theme_color_override(SceneStringName(font_color));
 		}
 	} else {
-		state_label->add_theme_color_override(SceneStringName(font_color), state_label->get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+		state_label->add_theme_color_override(SceneStringName(font_color), state_label->get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 	}
 
 	game_size_label->set_visible(show_game_size);

--- a/editor/scene/2d/particles_2d_editor_plugin.cpp
+++ b/editor/scene/2d/particles_2d_editor_plugin.cpp
@@ -308,7 +308,7 @@ Particles2DEditorPlugin::Particles2DEditorPlugin() {
 	error_message = memnew(Label);
 	error_message->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	error_message->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	error_message->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor)));
+	error_message->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(error_color), EditorStringName(Editor)));
 	emvb->add_child(error_message);
 
 	EditorNode::get_singleton()->get_gui_base()->add_child(emission_mask_dialog);

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -3749,7 +3749,7 @@ void Node3DEditorViewport::_draw() {
 				handle_color = get_theme_color(SNAME("axis_z_color"), EditorStringName(Editor));
 				break;
 			default:
-				handle_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+				handle_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 				break;
 		}
 
@@ -5531,7 +5531,7 @@ void Node3DEditorViewport::_show_tooltip(const String &p_title, const String &p_
 	tooltip_panel->set_text(
 			vformat("[font_size=%s][b][color=%s]%s[/color][/b][/font_size]\n%s",
 					get_theme_default_font_size() + 2,
-					get_theme_color(SNAME("accent_color"), EditorStringName(Editor)).to_html(false),
+					get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)).to_html(false),
 					p_title, p_description));
 	tooltip_panel->show();
 }

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -3403,7 +3403,7 @@ void CanvasItemEditor::_draw_ruler_tool() {
 		const String &lang = _get_locale();
 		const TranslationServer *ts = TranslationServer::get_singleton();
 
-		Color ruler_primary_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color ruler_primary_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 		Color ruler_secondary_color = ruler_primary_color;
 		ruler_secondary_color.a = 0.5;
 
@@ -3995,12 +3995,12 @@ void CanvasItemEditor::_draw_selection() {
 		viewport->draw_line(
 				transform.xform(drag_rotation_center),
 				transform.xform(drag_to),
-				get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.6),
+				get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)) * Color(1, 1, 1, 0.6),
 				Math::round(2 * EDSCALE));
 	}
 
 	if (!Math::is_inf(temp_pivot.x) || !Math::is_inf(temp_pivot.y)) {
-		viewport->draw_texture(pivot_icon, (temp_pivot - view_offset) * zoom - (pivot_icon->get_size() / 2).floor(), get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
+		viewport->draw_texture(pivot_icon, (temp_pivot - view_offset) * zoom - (pivot_icon->get_size() / 2).floor(), get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)));
 	}
 }
 
@@ -6518,7 +6518,7 @@ void CanvasItemEditorViewport::_show_tooltip(const String &p_title, const String
 	tooltip_panel->set_text(
 			vformat("[font_size=%s][b][color=%s]%s[/color][/b][/font_size]\n%s",
 					get_theme_default_font_size() + 2,
-					get_theme_color(SNAME("accent_color"), EditorStringName(Editor)).to_html(false),
+					get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)).to_html(false),
 					p_title, p_description));
 	tooltip_panel->show();
 }

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -378,7 +378,7 @@ List<MethodInfo> ConnectDialog::_filter_method_list(const List<MethodInfo> &p_me
 void ConnectDialog::_update_method_tree() {
 	method_tree->clear();
 
-	Color disabled_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) * 0.7;
+	Color disabled_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)) * 0.7;
 	String search_string = method_search->get_text();
 	Node *target = tree->get_selected();
 	if (!target) {
@@ -739,8 +739,8 @@ void ConnectDialog::init(const ConnectionData &p_cd, const PackedStringArray &p_
 
 void ConnectDialog::popup_dialog(const String &p_for_signal) {
 	from_signal->set_text(p_for_signal);
-	warning_label->add_theme_color_override(SceneStringName(font_color), warning_label->get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
-	error_label->add_theme_color_override(SceneStringName(font_color), error_label->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+	warning_label->add_theme_color_override(SceneStringName(font_color), warning_label->get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
+	error_label->add_theme_color_override(SceneStringName(font_color), error_label->get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 	filter_nodes->clear();
 
 	if (!advanced->is_pressed()) {
@@ -1724,7 +1724,7 @@ void ConnectionsDock::update_tree() {
 
 				if (_is_connection_inherited(connection)) {
 					// The scene inherits this connection.
-					connection_item->set_custom_color(0, get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+					connection_item->set_custom_color(0, get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 					connection_item->set_meta("_inherited_connection", true);
 				}
 			}

--- a/editor/scene/curve_editor_plugin.cpp
+++ b/editor/scene/curve_editor_plugin.cpp
@@ -852,11 +852,11 @@ void CurveEdit::_redraw() {
 
 	if (selected_index >= 0) {
 		const Vector2 point_pos = curve->get_point_position(selected_index);
-		const Color selected_point_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		const Color selected_point_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 
 		// Draw tangents if not dragging a point, or if holding a point without having moved it yet.
 		if (grabbing == GRAB_NONE || initial_grab_pos == point_pos || selected_tangent_index != TANGENT_NONE) {
-			const Color selected_tangent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor)).darkened(0.25);
+			const Color selected_tangent_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)).darkened(0.25);
 			const Color tangent_color = get_theme_color(SceneStringName(font_color), EditorStringName(Editor)).darkened(0.25);
 
 			if (selected_index != 0) {

--- a/editor/scene/gradient_editor_plugin.cpp
+++ b/editor/scene/gradient_editor_plugin.cpp
@@ -500,7 +500,7 @@ void GradientEdit::_redraw() {
 				draw_line(Vector2(handle_start_x + handle_thickness / 2.0, h * 0.9 - handle_thickness), Vector2(handle_start_x + handle_width - handle_thickness / 2.0, h * 0.9 - handle_thickness), border_col, handle_thickness);
 			}
 			rect = rect.grow(-handle_thickness);
-			const Color focus_col = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			const Color focus_col = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 			draw_rect(rect, has_focus() ? focus_col : focus_col.darkened(0.4), false, handle_thickness);
 			rect = rect.grow(-handle_thickness);
 			draw_rect(rect, border_col, false, handle_thickness);

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -125,7 +125,7 @@ void MaterialEditor::_notification(int p_what) {
 			box_switch->set_button_icon(theme_cache.box_icon);
 			quad_switch->set_button_icon(theme_cache.quad_icon);
 
-			error_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			error_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 		} break;
 
 		case NOTIFICATION_DRAW: {

--- a/editor/scene/particle_process_material_editor_plugin.cpp
+++ b/editor/scene/particle_process_material_editor_plugin.cpp
@@ -353,7 +353,7 @@ void ParticleProcessMaterialMinMaxPropertyEditor::_notification(int p_what) {
 			max_edit->add_theme_color_override(SNAME("label_color"), get_theme_color(SNAME("property_color_y"), EditorStringName(Editor)));
 
 			const bool dark_theme = EditorThemeManager::is_dark_theme();
-			const Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			const Color accent_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 			background_color = dark_theme ? Color(0.3, 0.3, 0.3) : Color(0.7, 0.7, 0.7);
 			normal_color = dark_theme ? Color(0.5, 0.5, 0.5) : Color(0.8, 0.8, 0.8);
 			hovered_color = dark_theme ? Color(0.8, 0.8, 0.8) : Color(0.6, 0.6, 0.6);

--- a/editor/scene/rename_dialog.cpp
+++ b/editor/scene/rename_dialog.cpp
@@ -406,11 +406,11 @@ void RenameDialog::_update_preview(const String &new_text) {
 
 		if (new_name == preview_node->get_name()) {
 			// New name is identical to the old one. Don't color it as much to avoid distracting the user.
-			const Color accent_color = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("accent_color"), EditorStringName(Editor));
+			const Color accent_color = EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(accent_color), EditorStringName(Editor));
 			const Color text_color = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("default_color"), SNAME("RichTextLabel"));
 			lbl_preview->add_theme_color_override(SceneStringName(font_color), accent_color.lerp(text_color, 0.5));
 		} else {
-			lbl_preview->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("success_color"), EditorStringName(Editor)));
+			lbl_preview->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(success_color), EditorStringName(Editor)));
 		}
 	}
 
@@ -496,7 +496,7 @@ void RenameDialog::_error_handler(void *p_self, const char *p_func, const char *
 
 	self->has_errors = true;
 	self->lbl_preview_title->set_text(TTR("Regular Expression Error:"));
-	self->lbl_preview->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor)));
+	self->lbl_preview->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(error_color), EditorStringName(Editor)));
 	self->lbl_preview->set_text(vformat(TTR("At character %s"), err_str));
 }
 

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -443,7 +443,7 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 	}
 
 	if (connect_to_script_mode) {
-		Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 
 		Ref<Script> scr = p_node->get_script();
 		bool has_custom_script = scr.is_valid() && EditorNode::get_singleton()->get_object_custom_type_base(p_node) == scr;
@@ -464,7 +464,7 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 		}
 	} else if (p_part_of_subscene) {
 		if (valid_types.is_empty()) {
-			_set_item_custom_color(p_item, get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+			_set_item_custom_color(p_item, get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 		}
 	} else if (marked.has(p_node)) {
 		String node_name = p_node->get_name();
@@ -473,7 +473,7 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 		}
 		p_item->set_text(0, node_name);
 		p_item->set_selectable(0, marked_selectable);
-		_set_item_custom_color(p_item, get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
+		_set_item_custom_color(p_item, get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)));
 	} else if (is_scene_tree_dock && !p_node->can_process()) {
 		_set_item_custom_color(p_item, get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor)));
 	} else if (!marked_selectable && !marked_children_selectable) {
@@ -481,7 +481,7 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 		while (node) {
 			if (marked.has(node)) {
 				p_item->set_selectable(0, false);
-				_set_item_custom_color(p_item, get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+				_set_item_custom_color(p_item, get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 				break;
 			}
 			node = node->get_parent();
@@ -591,10 +591,10 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 			if (scr->is_tool()) {
 				if (Engine::get_singleton()->is_recovery_mode_hint()) {
 					additional_notes += "\n" + TTR("This script can run in the editor.\nIt is currently disabled due to recovery mode.");
-					button_color = get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
+					button_color = get_theme_color(EditorStringName(warning_color), EditorStringName(Editor));
 				} else {
 					additional_notes += "\n" + TTR("This script is currently running in the editor.");
-					button_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+					button_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 				}
 			}
 			if (EditorNode::get_singleton()->get_object_custom_type_base(p_node) == scr) {

--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -143,7 +143,7 @@ void SpriteFramesEditor::_sheet_preview_draw() {
 		return;
 	}
 
-	Color accent = get_theme_color("accent_color", EditorStringName(Editor));
+	Color accent = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 
 	_sheet_sort_frames();
 

--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -1040,8 +1040,8 @@ void FindInFilesPanel::draw_result_text(Object *item_obj, Rect2 rect) {
 	match_rect.position.y += 1 * EDSCALE;
 	match_rect.size.y -= 2 * EDSCALE;
 
-	_results_display->draw_rect(match_rect, get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.33), false, 2.0);
-	_results_display->draw_rect(match_rect, get_theme_color(SNAME("accent_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.17), true);
+	_results_display->draw_rect(match_rect, get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)) * Color(1, 1, 1, 0.33), false, 2.0);
+	_results_display->draw_rect(match_rect, get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)) * Color(1, 1, 1, 0.17), true);
 
 	// Text is drawn by Tree already.
 }

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1863,7 +1863,7 @@ void ScriptEditor::_update_script_colors() {
 	bool script_temperature_enabled = EDITOR_GET("text_editor/script_list/script_temperature_enabled");
 
 	int hist_size = EDITOR_GET("text_editor/script_list/script_temperature_history_size");
-	Color hot_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+	Color hot_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 	hot_color.set_s(hot_color.get_s() * 0.9);
 	Color cold_color = get_theme_color(SceneStringName(font_color), EditorStringName(Editor));
 
@@ -2065,7 +2065,7 @@ void ScriptEditor::_update_script_names() {
 		}
 	}
 
-	Color tool_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+	Color tool_color = get_theme_color(EditorStringName(accent_color), EditorStringName(Editor));
 	tool_color.set_s(tool_color.get_s() * 1.5);
 	for (int i = 0; i < sedata_filtered.size(); i++) {
 		script_list->add_item(sedata_filtered[i].name, sedata_filtered[i].icon);

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -912,7 +912,7 @@ void ScriptTextEditor::_update_warnings() {
 				String target_path = base == connection.callable.get_object() ? base_path : base_path + "/" + String(base->get_path_to(Object::cast_to<Node>(connection.callable.get_object())));
 
 				warnings_panel->push_cell();
-				warnings_panel->push_color(warnings_panel->get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+				warnings_panel->push_color(warnings_panel->get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 				warnings_panel->add_text(vformat(TTR("Missing connected method '%s' for signal '%s' from node '%s' to node '%s'."), connection.callable.get_method(), connection.signal.get_name(), source_path, target_path));
 				warnings_panel->pop(); // Color.
 				warnings_panel->pop(); // Cell.
@@ -938,7 +938,7 @@ void ScriptTextEditor::_update_warnings() {
 		warnings_panel->push_cell();
 		warnings_panel->push_meta(ignore_meta);
 		warnings_panel->push_color(
-				warnings_panel->get_theme_color(SNAME("accent_color"), EditorStringName(Editor)).lerp(warnings_panel->get_theme_color(SNAME("mono_color"), EditorStringName(Editor)), 0.5f));
+				warnings_panel->get_theme_color(EditorStringName(accent_color), EditorStringName(Editor)).lerp(warnings_panel->get_theme_color(SNAME("mono_color"), EditorStringName(Editor)), 0.5f));
 		warnings_panel->add_text(TTR("[Ignore]"));
 		warnings_panel->pop(); // Color.
 		warnings_panel->pop(); // Meta ignore.
@@ -946,7 +946,7 @@ void ScriptTextEditor::_update_warnings() {
 
 		warnings_panel->push_cell();
 		warnings_panel->push_meta(w.start_line - 1);
-		warnings_panel->push_color(warnings_panel->get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+		warnings_panel->push_color(warnings_panel->get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 		warnings_panel->add_text(vformat(TTR("Line %d (%s):"), w.start_line, w.string_code));
 		warnings_panel->pop(); // Color.
 		warnings_panel->pop(); // Meta goto.
@@ -972,7 +972,7 @@ void ScriptTextEditor::_update_errors() {
 
 		errors_panel->push_cell();
 		errors_panel->push_meta(err.line - 1);
-		errors_panel->push_color(warnings_panel->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		errors_panel->push_color(warnings_panel->get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 		errors_panel->add_text(vformat(TTR("Line %d:"), err.line));
 		errors_panel->pop(); // Color.
 		errors_panel->pop(); // Meta goto.
@@ -1006,7 +1006,7 @@ void ScriptTextEditor::_update_errors() {
 
 			errors_panel->push_cell();
 			errors_panel->push_meta(click_meta);
-			errors_panel->push_color(errors_panel->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			errors_panel->push_color(errors_panel->get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 			errors_panel->add_text(vformat(TTR("Line %d:"), err.line));
 			errors_panel->pop(); // Color.
 			errors_panel->pop(); // Meta goto.

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -347,7 +347,7 @@ void EditorSettingsDialog::_update_icons() {
 	restart_close_button->set_button_icon(get_editor_theme_icon(SNAME("Close")));
 	restart_container->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
 	restart_icon->set_texture(get_editor_theme_icon(SNAME("StatusWarning")));
-	restart_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+	restart_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 }
 
 void EditorSettingsDialog::_event_config_confirmed() {

--- a/editor/settings/input_event_configuration_dialog.cpp
+++ b/editor/settings/input_event_configuration_dialog.cpp
@@ -615,7 +615,7 @@ void InputEventConfigurationDialog::_notification(int p_what) {
 			icon_cache.joypad_axis = get_editor_theme_icon(SNAME("JoyAxis"));
 
 			event_as_text->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("bold"), EditorStringName(EditorFonts)));
-			event_exists->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			event_exists->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 
 			_update_input_list();
 		} break;

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -644,7 +644,7 @@ void ProjectSettingsEditor::_update_theme() {
 	restart_close_button->set_button_icon(get_editor_theme_icon(SNAME("Close")));
 	restart_container->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
 	restart_icon->set_texture(get_editor_theme_icon(SNAME("StatusWarning")));
-	restart_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+	restart_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 }
 
 void ProjectSettingsEditor::_notification(int p_what) {

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -666,7 +666,7 @@ void ShaderTextEditor::_update_warning_panel() {
 
 		// First cell.
 		warnings_panel->push_cell();
-		warnings_panel->push_color(warnings_panel->get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+		warnings_panel->push_color(warnings_panel->get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 		if (line != -1) {
 			warnings_panel->push_meta(line - 1);
 			warnings_panel->add_text(vformat(TTR("Line %d (%s):"), line, w.get_name()));

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -1382,7 +1382,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 	if (!error.is_empty()) {
 		Label *error_label = memnew(Label);
 		error_label->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
-		error_label->add_theme_color_override(SceneStringName(font_color), editor->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		error_label->add_theme_color_override(SceneStringName(font_color), editor->get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 		error_label->set_text(error);
 		error_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD);
 		node->add_child(error_label);
@@ -2282,8 +2282,8 @@ void VisualShaderEditor::_update_options_menu() {
 
 	bool is_first_item = true;
 
-	Color unsupported_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
-	Color supported_color = get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
+	Color unsupported_color = get_theme_color(EditorStringName(error_color), EditorStringName(Editor));
+	Color supported_color = get_theme_color(EditorStringName(warning_color), EditorStringName(Editor));
 
 	static bool low_driver = GLOBAL_GET("rendering/renderer/rendering_method") == "gl_compatibility";
 
@@ -5313,7 +5313,7 @@ void VisualShaderEditor::_notification(int p_what) {
 
 		case NOTIFICATION_THEME_CHANGED: {
 			site_search->set_button_icon(get_editor_theme_icon(SNAME("ExternalLink")));
-			highend_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+			highend_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(EditorStringName(warning_color), EditorStringName(Editor)));
 
 			param_filter->set_right_icon(Control::get_editor_theme_icon(SNAME("Search")));
 
@@ -5329,7 +5329,7 @@ void VisualShaderEditor::_notification(int p_what) {
 				Color function_color = EDITOR_GET("text_editor/theme/highlighting/function_color");
 				Color number_color = EDITOR_GET("text_editor/theme/highlighting/number_color");
 				Color members_color = EDITOR_GET("text_editor/theme/highlighting/member_variable_color");
-				Color error_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
+				Color error_color = get_theme_color(EditorStringName(error_color), EditorStringName(Editor));
 
 				varying_error_label->add_theme_color_override(SceneStringName(font_color), error_color);
 

--- a/editor/themes/editor_icons.cpp
+++ b/editor/themes/editor_icons.cpp
@@ -91,9 +91,9 @@ void editor_register_icons(const Ref<Theme> &p_theme, bool p_dark_theme, float p
 		color_conversion_map_light[E.key] = E.value;
 	}
 	// These colors should be converted even if we are using a dark theme.
-	const Color error_color = p_theme->get_color(SNAME("error_color"), EditorStringName(Editor));
-	const Color success_color = p_theme->get_color(SNAME("success_color"), EditorStringName(Editor));
-	const Color warning_color = p_theme->get_color(SNAME("warning_color"), EditorStringName(Editor));
+	const Color error_color = p_theme->get_color(EditorStringName(error_color), EditorStringName(Editor));
+	const Color success_color = p_theme->get_color(EditorStringName(success_color), EditorStringName(Editor));
+	const Color warning_color = p_theme->get_color(EditorStringName(warning_color), EditorStringName(Editor));
 	color_conversion_map_dark[Color::html("#ff5f5f")] = error_color;
 	color_conversion_map_dark[Color::html("#5fff97")] = success_color;
 	color_conversion_map_dark[Color::html("#ffdd65")] = warning_color;
@@ -118,7 +118,7 @@ void editor_register_icons(const Ref<Theme> &p_theme, bool p_dark_theme, float p
 	Dictionary accent_color_map;
 	HashSet<StringName> accent_color_icons;
 
-	const Color accent_color = p_theme->get_color(SNAME("accent_color"), EditorStringName(Editor));
+	const Color accent_color = p_theme->get_color(EditorStringName(accent_color), EditorStringName(Editor));
 	accent_color_map[Color::html("699ce8")] = accent_color;
 	if (accent_color.get_luminance() > 0.75) {
 		accent_color_map[Color::html("ffffff")] = Color(0.2, 0.2, 0.2);

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -48,7 +48,7 @@ void ThemeClassic::populate_shared_styles(const Ref<EditorTheme> &p_theme, Edito
 		// Base colors.
 
 		p_theme->set_color("base_color", EditorStringName(Editor), p_config.base_color);
-		p_theme->set_color("accent_color", EditorStringName(Editor), p_config.accent_color);
+		p_theme->set_color(EditorStringName(accent_color), EditorStringName(Editor), p_config.accent_color);
 
 		// White (dark theme) or black (light theme), will be used to generate the rest of the colors
 		p_config.mono_color = p_config.dark_theme ? Color(1, 1, 1) : Color(0, 0, 0);
@@ -92,9 +92,9 @@ void ThemeClassic::populate_shared_styles(const Ref<EditorTheme> &p_theme, Edito
 		p_theme->set_color("contrast_color_2", EditorStringName(Editor), p_config.contrast_color_2);
 		p_theme->set_color("highlight_color", EditorStringName(Editor), p_config.highlight_color);
 		p_theme->set_color("highlight_disabled_color", EditorStringName(Editor), p_config.highlight_disabled_color);
-		p_theme->set_color("success_color", EditorStringName(Editor), p_config.success_color);
-		p_theme->set_color("warning_color", EditorStringName(Editor), p_config.warning_color);
-		p_theme->set_color("error_color", EditorStringName(Editor), p_config.error_color);
+		p_theme->set_color(EditorStringName(success_color), EditorStringName(Editor), p_config.success_color);
+		p_theme->set_color(EditorStringName(warning_color), EditorStringName(Editor), p_config.warning_color);
+		p_theme->set_color(EditorStringName(error_color), EditorStringName(Editor), p_config.error_color);
 		p_theme->set_color("ruler_color", EditorStringName(Editor), p_config.dark_color_2);
 #ifndef DISABLE_DEPRECATED // Used before 4.3.
 		p_theme->set_color("disabled_highlight_color", EditorStringName(Editor), p_config.highlight_disabled_color);
@@ -2109,7 +2109,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 
 		p_theme->set_color("property_color", "EditorProperty", property_color);
 		p_theme->set_color("readonly_color", "EditorProperty", readonly_color);
-		p_theme->set_color("warning_color", "EditorProperty", p_config.warning_color);
+		p_theme->set_color(EditorStringName(warning_color), "EditorProperty", p_config.warning_color);
 		p_theme->set_color("readonly_warning_color", "EditorProperty", readonly_warning_color);
 
 		Ref<StyleBoxFlat> style_property_group_note = p_config.base_style->duplicate();
@@ -2459,7 +2459,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		{
 			p_theme->set_stylebox(SceneStringName(panel), "GraphStateMachine", p_config.tree_panel_style);
 			p_theme->set_stylebox("error_panel", "GraphStateMachine", p_config.tree_panel_style);
-			p_theme->set_color("error_color", "GraphStateMachine", p_config.error_color);
+			p_theme->set_color(EditorStringName(error_color), "GraphStateMachine", p_config.error_color);
 
 			const int sm_margin_side = 10 * EDSCALE;
 			const int sm_margin_bottom = 2;

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -56,7 +56,7 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 		// Base colors.
 
 		p_theme->set_color("base_color", EditorStringName(Editor), p_config.base_color);
-		p_theme->set_color("accent_color", EditorStringName(Editor), p_config.accent_color);
+		p_theme->set_color(EditorStringName(accent_color), EditorStringName(Editor), p_config.accent_color);
 
 		// White (dark theme) or black (light theme), will be used to generate the rest of the colors
 		p_config.mono_color = p_config.dark_theme ? Color(1, 1, 1) : Color(0, 0, 0);
@@ -101,9 +101,9 @@ void ThemeModern::populate_shared_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_color("contrast_color_2", EditorStringName(Editor), p_config.contrast_color_2);
 		p_theme->set_color("highlight_color", EditorStringName(Editor), p_config.highlight_color);
 		p_theme->set_color("highlight_disabled_color", EditorStringName(Editor), p_config.highlight_disabled_color);
-		p_theme->set_color("success_color", EditorStringName(Editor), p_config.success_color);
-		p_theme->set_color("warning_color", EditorStringName(Editor), p_config.warning_color);
-		p_theme->set_color("error_color", EditorStringName(Editor), p_config.error_color);
+		p_theme->set_color(EditorStringName(success_color), EditorStringName(Editor), p_config.success_color);
+		p_theme->set_color(EditorStringName(warning_color), EditorStringName(Editor), p_config.warning_color);
+		p_theme->set_color(EditorStringName(error_color), EditorStringName(Editor), p_config.error_color);
 		p_theme->set_color("ruler_color", EditorStringName(Editor), p_config.base_color.lerp(p_config.mono_color_inv, 0.3) * Color(1, 1, 1, 0.8));
 #ifndef DISABLE_DEPRECATED // Used before 4.3.
 		p_theme->set_color("disabled_highlight_color", EditorStringName(Editor), p_config.highlight_disabled_color);
@@ -2331,7 +2331,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		p_theme->set_color("property_color", "EditorProperty", p_config.font_color);
 		p_theme->set_color("readonly_color", "EditorProperty", readonly_color);
-		p_theme->set_color("warning_color", "EditorProperty", p_config.warning_color);
+		p_theme->set_color(EditorStringName(warning_color), "EditorProperty", p_config.warning_color);
 		p_theme->set_color("readonly_warning_color", "EditorProperty", readonly_warning_color);
 
 		Ref<StyleBoxFlat> style_property_group_note = p_config.base_style->duplicate();
@@ -2787,7 +2787,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		{
 			p_theme->set_stylebox(SceneStringName(panel), "GraphStateMachine", p_config.tree_panel_style);
 			p_theme->set_stylebox("error_panel", "GraphStateMachine", p_config.tree_panel_style);
-			p_theme->set_color("error_color", "GraphStateMachine", p_config.error_color);
+			p_theme->set_color(EditorStringName(error_color), "GraphStateMachine", p_config.error_color);
 
 			const int sm_margin_side = 10 * EDSCALE;
 			const int sm_margin_bottom = 2;

--- a/editor/version_control/version_control_editor_plugin.cpp
+++ b/editor/version_control/version_control_editor_plugin.cpp
@@ -81,12 +81,12 @@ void VersionControlEditorPlugin::_notification(int p_what) {
 }
 
 void VersionControlEditorPlugin::_update_theme() {
-	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_NEW] = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("success_color"), EditorStringName(Editor));
-	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_MODIFIED] = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("warning_color"), EditorStringName(Editor));
-	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_RENAMED] = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("warning_color"), EditorStringName(Editor));
-	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_DELETED] = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor));
+	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_NEW] = EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(success_color), EditorStringName(Editor));
+	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_MODIFIED] = EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(warning_color), EditorStringName(Editor));
+	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_RENAMED] = EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(warning_color), EditorStringName(Editor));
+	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_DELETED] = EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(error_color), EditorStringName(Editor));
 	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_TYPECHANGE] = EditorNode::get_singleton()->get_editor_theme()->get_color(SceneStringName(font_color), EditorStringName(Editor));
-	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_UNMERGED] = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("warning_color"), EditorStringName(Editor));
+	change_type_to_color[EditorVCSInterface::CHANGE_TYPE_UNMERGED] = EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(warning_color), EditorStringName(Editor));
 
 	change_type_to_icon[EditorVCSInterface::CHANGE_TYPE_NEW] = EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("StatusSuccess"), EditorStringName(EditorIcons));
 	change_type_to_icon[EditorVCSInterface::CHANGE_TYPE_MODIFIED] = EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("StatusWarning"), EditorStringName(EditorIcons));
@@ -214,7 +214,7 @@ void VersionControlEditorPlugin::_update_set_up_warning(const String &p_new_text
 			set_up_ssh_passphrase->get_text().is_empty();
 
 	if (empty_settings) {
-		set_up_warning_text->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("warning_color"), EditorStringName(Editor)));
+		set_up_warning_text->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(warning_color), EditorStringName(Editor)));
 		set_up_warning_text->set_text(TTR("Remote settings are empty. VCS features that use the network may not work."));
 	} else {
 		set_up_warning_text->set_text("");
@@ -613,7 +613,7 @@ void VersionControlEditorPlugin::_display_diff(int p_idx) {
 		String commit_date_string = meta_data[SNAME("commit_date_string")];
 
 		diff->push_font(EditorNode::get_singleton()->get_editor_theme()->get_font(SNAME("doc_bold"), EditorStringName(EditorFonts)));
-		diff->push_color(EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("accent_color"), EditorStringName(Editor)));
+		diff->push_color(EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(accent_color), EditorStringName(Editor)));
 		diff->add_text(TTR("Commit:") + " " + commit_id);
 		diff->add_newline();
 		diff->add_text(TTR("Author:") + " " + commit_author);
@@ -631,7 +631,7 @@ void VersionControlEditorPlugin::_display_diff(int p_idx) {
 
 	for (const EditorVCSInterface::DiffFile &diff_file : diff_content) {
 		diff->push_font(EditorNode::get_singleton()->get_editor_theme()->get_font(SNAME("doc_bold"), EditorStringName(EditorFonts)));
-		diff->push_color(EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("accent_color"), EditorStringName(Editor)));
+		diff->push_color(EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(accent_color), EditorStringName(Editor)));
 		diff->add_text(TTR("File:") + " " + diff_file.new_file);
 		diff->pop();
 		diff->pop();
@@ -716,8 +716,8 @@ void VersionControlEditorPlugin::_display_diff_split_view(List<EditorVCSInterfac
 		EditorVCSInterface::DiffLine diff_line = parsed_diff[i];
 
 		bool has_change = diff_line.status != " ";
-		static const Color red = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor));
-		static const Color green = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("success_color"), EditorStringName(Editor));
+		static const Color red = EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(error_color), EditorStringName(Editor));
+		static const Color green = EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(success_color), EditorStringName(Editor));
 		static const Color white = EditorNode::get_singleton()->get_editor_theme()->get_color(SceneStringName(font_color), SNAME("Label")) * Color(1, 1, 1, 0.6);
 
 		if (diff_line.old_line_no >= 0) {
@@ -797,9 +797,9 @@ void VersionControlEditorPlugin::_display_diff_unified_view(List<EditorVCSInterf
 
 		Color color;
 		if (diff_line.status == "+") {
-			color = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("success_color"), EditorStringName(Editor));
+			color = EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(success_color), EditorStringName(Editor));
 		} else if (diff_line.status == "-") {
-			color = EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor));
+			color = EditorNode::get_singleton()->get_editor_theme()->get_color(EditorStringName(error_color), EditorStringName(Editor));
 		} else {
 			color = EditorNode::get_singleton()->get_editor_theme()->get_color(SceneStringName(font_color), SNAME("Label"));
 			color *= Color(1, 1, 1, 0.6);

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -434,10 +434,10 @@ void EditorFileSystemImportFormatSupportQueryBlend::_validate_path(String p_path
 	path_status->set_text(error);
 
 	if (success) {
-		path_status->add_theme_color_override(SceneStringName(font_color), path_status->get_theme_color(SNAME("success_color"), EditorStringName(Editor)));
+		path_status->add_theme_color_override(SceneStringName(font_color), path_status->get_theme_color(EditorStringName(success_color), EditorStringName(Editor)));
 		configure_blender_dialog->get_ok_button()->set_disabled(false);
 	} else {
-		path_status->add_theme_color_override(SceneStringName(font_color), path_status->get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+		path_status->add_theme_color_override(SceneStringName(font_color), path_status->get_theme_color(EditorStringName(error_color), EditorStringName(Editor)));
 		configure_blender_dialog->get_ok_button()->set_disabled(true);
 	}
 }


### PR DESCRIPTION
Follow-up to #80573

Adds EditorStringName for `accent_color`, `error_color`, `warning_color` and `success_color`.

The editor string names are underutilized, unlike other name collections. Another common one that can be considered is `class_icon_size` (I could add it in this PR, but it's not a color).