### PR TITLE
[Accessibility] Fix `update_set_name` setting a space character as the node label when name and `name_extra_info` is empty

### DIFF
--- a/drivers/accesskit/accessibility_server_accesskit.cpp
+++ b/drivers/accesskit/accessibility_server_accesskit.cpp
@@ -708,8 +708,8 @@ _FORCE_INLINE_ void AccessibilityServerAccessKit::_ensure_node(const RID &p_id, 
 
 		// Re-apply stored name if any, so nodes recreated by _ensure_node
 		// retain their label even if the caller doesn't re-set all properties.
-		if (!p_ae->name.is_empty() || !p_ae->name_extra_info.is_empty()) {
-			String full_name = p_ae->name + " " + p_ae->name_extra_info;
+		String full_name = (p_ae->name + " " + p_ae->name_extra_info).strip_edges();
+		if (!full_name.is_empty()) {
 			accesskit_node_set_label(p_ae->node, full_name.utf8().ptr());
 		}
 	}
@@ -764,7 +764,7 @@ void AccessibilityServerAccessKit::update_set_name(const RID &p_id, const String
 	_ensure_node(p_id, ae);
 
 	ae->name = p_name;
-	String full_name = ae->name + " " + ae->name_extra_info;
+	String full_name = (ae->name + " " + ae->name_extra_info).strip_edges();
 	if (!full_name.is_empty()) {
 		accesskit_node_set_label(ae->node, full_name.utf8().ptr());
 	} else {
@@ -808,7 +808,7 @@ void AccessibilityServerAccessKit::update_set_extra_info(const RID &p_id, const 
 	_ensure_node(p_id, ae);
 
 	ae->name_extra_info = p_name_extra_info;
-	String full_name = ae->name + " " + ae->name_extra_info;
+	String full_name = (ae->name + " " + ae->name_extra_info).strip_edges();
 	if (!full_name.is_empty()) {
 		accesskit_node_set_label(ae->node, full_name.utf8().ptr());
 	} else {


### PR DESCRIPTION
When both name and name_extra_info are empty, the resulting name is a single space character. Screen readers may then speak out the word 'Space' because it is one character (occurs with ORCA v46).

## Reproduction
Set everything on empty on a control node. Then using espeak-ng and ORCA (tested with v46), focus on the node. The read-out will be "Space".

```
DisplayServer.accessibility_update_set_name(rid, '')
DisplayServer.accessibility_update_set_description(rid, '')
DisplayServer.accessibility_update_set_role(rid, DisplayServer.ROLE_UNKNOWN)
DisplayServer.accessibility_update_set_tooltip(rid, '')
DisplayServer.accessibility_update_set_value(rid, '')
DisplayServer.accessibility_update_set_role_description(rid, '')
```

ORCA will be silent when you set the name as a space ' '. Then ORCA recognizes 2 or more characters and treats it differently. Here is that branching code for ORCA: https://gitlab.gnome.org/GNOME/orca/-/blob/main/src/orca/speechdispatcherfactory.py#L545

## AI Use
Claude helped me identify the problem and point me to the relevant code files in Godot, Accesskit, and ORCA. Claude's fix was naive and left trailing spaces. strip_edges() should take care of that.

## Background
I need elements to be ignored by the screen reader because I have voice actors speaking the text. For nodes that are accounted for with a voice from a different source, a screen reader must remain silent. Currently the only way to do this is to set everything to an empty string and set role to ROLE_UNKNOWN. ROLE_CONTAINER would be better but this will not work with some screen readers (ORCA), it will read out as 'Section'. But that is a different bug.

P.s. this is my first contribution and I'm figuring out how to do this. I just read that making a PR through github is generally not accepted unless it is a small fix. I deemed this pretty small and confined. But if desired I'll fork and fix it locally.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
