### PR TITLE
Fix breakpoints resetting on external editor save

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1503,21 +1503,27 @@ void CodeTextEditor::set_edit_state(const Variant &p_state) {
 	if (state.has("folded_lines")) {
 		const PackedInt32Array folded_lines = state["folded_lines"];
 		for (const int &line : folded_lines) {
-			text_editor->fold_line(line);
+			if (line < text_editor->get_line_count()) {
+				text_editor->fold_line(line);
+			}
 		}
 	}
 
 	if (state.has("breakpoints")) {
 		const PackedInt32Array breakpoints = state["breakpoints"];
 		for (const int &line : breakpoints) {
-			text_editor->set_line_as_breakpoint(line, true);
+			if (line < text_editor->get_line_count()) {
+				text_editor->set_line_as_breakpoint(line, true);
+			}
 		}
 	}
 
 	if (state.has("bookmarks")) {
 		const PackedInt32Array bookmarks = state["bookmarks"];
 		for (const int &line : bookmarks) {
-			text_editor->set_line_as_bookmarked(line, true);
+			if (line < text_editor->get_line_count()) {
+				text_editor->set_line_as_bookmarked(line, true);
+			}
 		}
 	}
 

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -41,6 +41,7 @@
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "core/string/fuzzy_search.h"
+#include "core/variant/dictionary.h"
 #include "core/version.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"
@@ -2546,7 +2547,9 @@ void ScriptEditor::_reload_scripts(bool p_refresh_only) {
 		}
 
 		if (TextEditorBase *teb = Object::cast_to<TextEditorBase>(seb)) {
+			Dictionary state = teb->get_edit_state();
 			teb->reload_text();
+			teb->set_edit_state(state);
 		}
 	}
 


### PR DESCRIPTION
Currently, Godot-defined breakpoints disappear when a file is saved from an external editor. This fixes it by restoring the previous editor state upon reloading a file. Therefore, it also applies to bookmarks and folded sections, as they had the same issue and it was easier to fix all of them at once this way.

This new behavior has better consistency, since previously the breakpoints were cleared, but only if the file was opened in Godot's script editor. Now, breakpoints are never cleared, which is also more similar to what external editors such as vscode do when they receive external changes.

It also fixes a related error, which was triggered if you:
1. Had a file with breakpoint at line n
2. Closed its editor in Godot
3. Edited the file externally to have m < n lines
4. Reopened the editor. You would expect this error:
`Index p_line = (n-1) is out of bounds (get_line_count() = m)`

The fix is included in this PR as it was necessary for the other changes and is harmless.

Fixes #116672.