### PR TITLE
HTTPClient: Wait for available data in blocking mode

### DIFF
--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -171,6 +171,7 @@ public:
 	virtual void set_connection(const Ref<StreamPeer> &p_connection) = 0;
 	virtual Ref<StreamPeer> get_connection() const = 0;
 
+	virtual void disconnect_from_host() = 0;
 	virtual void close() = 0;
 
 	virtual Status get_status() const = 0;

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -246,14 +246,18 @@ Error HTTPClientTCP::get_response_headers(List<String> *r_response) {
 	return OK;
 }
 
-void HTTPClientTCP::close() {
+void HTTPClientTCP::disconnect_from_host() {
+	status = STATUS_DISCONNECTED;
 	if (tcp_connection->get_status() != StreamPeerTCP::STATUS_NONE) {
 		tcp_connection->disconnect_from_host();
 	}
+}
+
+void HTTPClientTCP::close() {
+	disconnect_from_host();
 
 	connection.unref();
 	proxy_client.unref();
-	status = STATUS_DISCONNECTED;
 	head_request = false;
 	if (resolving != IP::RESOLVER_INVALID_ID) {
 		IP::get_singleton()->erase_resolve_item(resolving);
@@ -744,6 +748,14 @@ Error HTTPClientTCP::_get_http_data(uint8_t *p_buffer, int p_bytes, int &r_recei
 		int left = p_bytes;
 		r_received = 0;
 		while (left > 0) {
+			if (connection->get_available_bytes() == 0) {
+				tcp_connection->wait(NetSocket::POLL_TYPE_IN, -1);
+				if (status == STATUS_DISCONNECTED) {
+					// Connection socket closed.
+					err = ERR_FILE_EOF;
+					break;
+				}
+			}
 			err = connection->get_partial_data(p_buffer + r_received, left, read);
 			if (err == OK) {
 				r_received += read;

--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -86,6 +86,7 @@ public:
 	Error connect_to_host(const String &p_host, int p_port = -1, Ref<TLSOptions> p_tls_options = Ref<TLSOptions>()) override;
 	void set_connection(const Ref<StreamPeer> &p_connection) override;
 	Ref<StreamPeer> get_connection() const override;
+	void disconnect_from_host() override;
 	void close() override;
 	Status get_status() const override;
 	bool has_response() const override;

--- a/drivers/unix/net_socket_unix.cpp
+++ b/drivers/unix/net_socket_unix.cpp
@@ -350,6 +350,7 @@ Error NetSocketUnix::open(NetSocket::Family p_family, NetSocket::Type p_sock_typ
 
 void NetSocketUnix::close() {
 	if (_sock != -1) {
+		::shutdown(_sock, SHUT_RDWR);
 		::close(_sock);
 
 		if (_family == Family::UNIX) {

--- a/drivers/windows/net_socket_winsock.cpp
+++ b/drivers/windows/net_socket_winsock.cpp
@@ -268,6 +268,7 @@ Error NetSocketWinSock::open(Family p_family, Type p_sock_type, IP::Type &ip_typ
 
 void NetSocketWinSock::close() {
 	if (_sock != INVALID_SOCKET) {
+		shutdown(_sock, SD_BOTH);
 		closesocket(_sock);
 	}
 

--- a/platform/web/http_client_web.cpp
+++ b/platform/web/http_client_web.cpp
@@ -113,6 +113,9 @@ Error HTTPClientWeb::request(Method p_method, const String &p_url, const Vector<
 	return OK;
 }
 
+void HTTPClientWeb::disconnect_from_host() {
+}
+
 void HTTPClientWeb::close() {
 	host = "";
 	port = -1;

--- a/platform/web/http_client_web.h
+++ b/platform/web/http_client_web.h
@@ -87,6 +87,7 @@ public:
 	Error connect_to_host(const String &p_host, int p_port = -1, Ref<TLSOptions> p_tls_options = Ref<TLSOptions>()) override;
 	void set_connection(const Ref<StreamPeer> &p_connection) override;
 	Ref<StreamPeer> get_connection() const override;
+	void disconnect_from_host() override;
 	void close() override;
 	Status get_status() const override;
 	bool has_response() const override;

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -201,6 +201,7 @@ void HTTPRequest::cancel_request() {
 	} else {
 		thread_request_quit.set();
 		if (thread.is_started()) {
+			client->disconnect_from_host();
 			thread.wait_to_finish();
 		}
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Fixes #33479, fixes #35868, fixes #118666 and high CPU usage when performing HTTP requests with `HTTPRequest` using threads.

When using `HTTPRequest.request` with `use_threads` setting to true, which configures its `HTTPClient` to enable blocking mode internally, most of CPU time is wasted on reading zero byte from `StreamPeer::get_partial_data` loop in `HTTPClientTCP::_get_http_data`[[1]](https://github.com/godotengine/godot/blob/65e73b3a5eec19e3269809b0f00e73a646723067/core/io/http_client_tcp.cpp#L747).

Since `StreamPeer::get_data` cannot be used (reason already stated in the comment of `HTTPClientTCP::_get_http_data`), and `StreamPeer::get_partial_data` is a non-blocking method, meaning it returns immediately regardless of the bytes actually read, most of the time there are no data available even with very fast internet connection in a tight loop.

This PR made the following change to fix the problem:

- Use `StreamPeerTCP::wait` in `HTTPClientTCP::_get_http_data` when running in blocking mode. `StreamPeerTCP::get_available_bytes` returning 0 means that we should wait for available data rather than doing busy loop.
- Add `HTTPClient::disconnect_from_host` that will only close the client connection socket without deleting it. When calling `HTTPRequest::cancel_request` with `use_threads=true`, this method will be called first before waiting for the thread to finish. This makes sure that:
  1. `StreamPeerTCP::wait` will not stall during `HTTPRequest::cancel_request`, the wait should return after the socket is closed.
  2. The client socket will not be deleted by `HTTPClient::close` before the thread is finished.

  (Note that `HTTPClient::disconnect_from_host` has no effect on Web platform.)
- `NetSocket::close` now shutdown the socket first before closing it. This change is to make sure `StreamPeerTCP::wait` does not stall when network is disconnected below application-level (cable unplug, turning off Wi-Fi).

With my profiling result using Tracy as reference:
Before:
<img width="500" height="600" alt="before" src="https://github.com/user-attachments/assets/b689bdfc-62d8-4ca6-9736-23aa23dd03de" />
<img width="1400" height="600" alt="stats_before" src="https://github.com/user-attachments/assets/a459a6af-256b-4a12-8ba7-51ef3dafc110" />

After:
<img width="500" height="600" alt="after" src="https://github.com/user-attachments/assets/36e66601-f7f3-4711-8b10-1562bfe98edc" />
<img width="1400" height="600" alt="stats_after" src="https://github.com/user-attachments/assets/360dbbcf-da07-4e36-b619-4d7bae837351" />


