### PR TITLE
MeshLibrary: Do not duplicate external meshes when generating from scene

### DIFF
--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -526,11 +526,17 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 	}
 	p_mesh_instances[item_id] = mesh_instance_node;
 
-	Ref<Mesh> item_mesh = source_mesh->duplicate();
-	for (int i = 0; i < item_mesh->get_surface_count(); i++) {
-		Ref<Material> surface_override_material = mesh_instance_node->get_surface_override_material(i);
-		if (surface_override_material.is_valid()) {
-			item_mesh->surface_set_material(i, surface_override_material);
+	Ref<Mesh> item_mesh;
+	if (!source_mesh->is_built_in()) {
+		item_mesh = source_mesh;
+	} else {
+		item_mesh = source_mesh->duplicate();
+
+		for (int i = 0; i < item_mesh->get_surface_count(); i++) {
+			Ref<Material> surface_override_material = mesh_instance_node->get_surface_override_material(i);
+			if (surface_override_material.is_valid()) {
+				item_mesh->surface_set_material(i, surface_override_material);
+			}
 		}
 	}
 	p_library->set_item_mesh(item_id, item_mesh);


### PR DESCRIPTION
Part of https://github.com/godotengine/godot-proposals/issues/14521

This makes meshes in standalone files, including these extracted from the scene advanced import dialog, not be duplicated in the mesh library and stay external so the library is more suitable for storing in text format.