### PR TITLE
Hide renderer selector in main editor window and add editor setting

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -959,6 +959,9 @@
 		<member name="interface/editor/appearance/project_manager_screen" type="int" setter="" getter="">
 			The preferred monitor to display the project manager.
 		</member>
+		<member name="interface/editor/appearance/show_renderer_selector" type="bool" setter="" getter="">
+			If [code]true[/code], a renderer selector that can be used to change the [member ProjectSettings.rendering/renderer/rendering_method] project setting will be shown in the top right of the main editor window.
+		</member>
 		<member name="interface/editor/appearance/show_update_spinner" type="int" setter="" getter="">
 			If enabled, displays an icon in the top-right corner of the editor that spins when the editor redraws a frame. This can be used to diagnose situations where the engine is constantly redrawing, which should be avoided as this increases CPU and GPU utilization for no good reason. To further troubleshoot these situations, start the editor with the [code]--debug-canvas-item-redraw[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url].
 			Consider enabling this if you are developing editor plugins to ensure they only make the editor redraw when required.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1153,6 +1153,7 @@ void EditorNode::_notification(int p_what) {
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/appearance")) {
 				_update_update_spinner();
 				_update_main_menu_type();
+				renderer->set_visible(EDITOR_GET("interface/editor/appearance/show_renderer_selector"));
 			}
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/display")) {
 				_update_vsync_mode();
@@ -8990,7 +8991,6 @@ EditorNode::EditorNode() {
 	title_bar->add_child(right_menu_hb);
 
 	renderer = memnew(OptionButton);
-	renderer->set_visible(true);
 	renderer->set_flat(true);
 	renderer->set_theme_type_variation("TopBarOptionButton");
 	renderer->set_fit_to_longest_item(false);
@@ -9035,6 +9035,8 @@ EditorNode::EditorNode() {
 		renderer->set_item_metadata(-1, current_renderer_os);
 	}
 	_update_renderer_color();
+
+	renderer->set_visible(EDITOR_GET("interface/editor/appearance/show_renderer_selector"));
 
 	progress_hb = memnew(BackgroundProgress);
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -566,6 +566,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 #endif
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/appearance/collapse_main_menu", is_android_editor, "")
 
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/appearance/show_renderer_selector", false, "")
+
 	_initial_set("interface/editors/derive_script_globals_by_name", true);
 	_initial_set("docks/scene_tree/ask_before_revoking_unique_name", true);
 


### PR DESCRIPTION
## For users upgrading to 4.7

The renderer selector is now hidden by default. As always, you can change your project’s renderer by changing the `rendering/renderer/rendering_method` project setting.

If you need to change your project’s renderer often, you can show renderer selector in the editor’s main window by changing the `interface/editor/appearance/show_renderer_selector` editor setting.

### What problem(s) does this PR solve?

1. The renderer selector takes up precious real estate on the main Godot editor window while not being used by most users.
2. The renderer selector adds visual complexity to the main editor window for new users.

### Does this PR include any additional changes beyond those required to solve these problems?

- This PR adds a new editor setting to restore existing behaviour for users who have a project that targets multiple renderers and use the renderer selector often during authoring to tweak the appearance of scenes.

### What is the rationale for the approach used in this PR?

**Design**
This PR prioritizes user experience.

This means that it does not prioritize the Godot developer experience: The renderer can no longer be seen in screenshots or screen recordings of the main editor window, which may make it slightly more difficult for Godot developers to debug issues that are discovered through screen recordings and screenshots rather than issues that have been reported using the "Copy System Info" text. I believe that the design and approach to including additional debug information in the main editor window or title bar should be handled in a separate PR, such as #103042 or that renderer information should never be visible on the main editor window or title bar to ensure that there is less visual noise for new users.

**Technical**
Because the renderer cannot be changed without restarting the editor, all configuration of this `OptionButton` can simply remain in the `EditorNode` constructor. The initial setting of visibility of this control is moved to be the final step of setup for this control to ensure consistent behaviour of setup regardless of the setting (both now and in the future if anything relating to the setup of this control is changed).

### Was generative AI (LLM AI) used to create a portion of this PR?

No.

### Are there any parts of this PR that you are uncertain of or require special attention from reviewers?

As [demonstrated in this comment](https://github.com/godotengine/godot/pull/103042#pullrequestreview-3987253242), the renderer selector could be implemented instead as a plugin, so it's possible that the renderer selector could be removed entirely from Godot. I have chosen to not go with this approach because this will make for a less optimal workflow for users who switch often during authoring as [described in this comment](https://github.com/godotengine/godot/pull/103042#issuecomment-4085934771).

_Bugsquad edit: Closes https://github.com/godotengine/godot-proposals/issues/11806_