### PR TITLE
ResourceFormatLoader/Saver: Document `_exists`, `_get_classes_used`, and add examples.

### DIFF
--- a/doc/classes/ResourceFormatLoader.xml
+++ b/doc/classes/ResourceFormatLoader.xml
@@ -7,6 +7,44 @@
 		Godot loads resources in the editor or in exported games using ResourceFormatLoaders. They are queried automatically via the [ResourceLoader] singleton, or when a resource with internal dependencies is loaded. Each file type may load as a different resource type, so multiple ResourceFormatLoaders are registered in the engine.
 		Extending this class allows you to define your own loader. Be sure to respect the documented return types and values. You should give it a global class name with [code]class_name[/code] for it to be registered. Like built-in ResourceFormatLoaders, it will be called automatically when loading resources of its handled type(s). You may also implement a [ResourceFormatSaver].
 		[b]Note:[/b] You can also extend [EditorImportPlugin] if the resource type you need exists but Godot is unable to load its format. Choosing one way over another depends on if the format is suitable or not for the final exported game. For example, it's better to import [code].png[/code] textures as [code].ctex[/code] ([CompressedTexture2D]) first, so they can be loaded with better efficiency on the graphics card.
+		[b]Example:[/b] A minimal [ResourceFormatLoader] that loads a custom resource called [code]GameSave[/code] from a [code].save[/code] file. For the matching saver, see [ResourceFormatSaver].
+		[codeblock]
+		@tool
+		class_name GameSaveLoader
+		extends ResourceFormatLoader
+
+		func _get_recognized_extensions() -> PackedStringArray:
+			return PackedStringArray(["save"])
+
+		func _get_resource_type(path: String) -> String:
+			if path.get_extension() == "save":
+				return "Resource" # Use the ClassDB recognized class here.
+			return ""
+
+		func _get_resource_script_class(path: String) -> String:
+			if path.get_extension() == "save":
+				return "GameSave"
+			return ""
+
+		func _load(path: String, original_path: String, use_sub_threads: bool, cache_mode: int) -> Variant:
+			var file = FileAccess.open(path, FileAccess.READ)
+
+			if not file:
+				var err = FileAccess.get_open_error()
+				if err != OK:
+					push_error("Can't open save file ", path)
+					return
+
+			var file_data = file.get_as_text()
+			var read_err = file.get_error()
+			if read_err != OK and read_err != ERR_FILE_EOF:
+				return ERR_FILE_CANT_READ
+
+			return from_json(file_data)
+
+		func from_json(file_data: String) -> GameSave:
+			# ... Convert to GameSave from json text here
+		[/codeblock]
 	</description>
 	<tutorials>
 	</tutorials>
@@ -15,12 +53,17 @@
 			<return type="bool" />
 			<param index="0" name="path" type="String" />
 			<description>
+				Tells whether this loader recognizes a resource exists for the given [param path].
+				If it is not implemented, [param path] is checked for whether the file exists.
 			</description>
 		</method>
 		<method name="_get_classes_used" qualifiers="virtual const">
 			<return type="PackedStringArray" />
 			<param index="0" name="path" type="String" />
 			<description>
+				Gets a list of all [ClassDB] recognized classes that are used by this loader at the given [param path]. 
+				If it is not implemented, returns the class given by [method _get_resource_type].
+				[b]NOTE:[/b] This is used to trim unused features by the [url=$DOCS_URL//tutorials/editor/using_engine_compilation_configuration_editor.html]Compilation Configuration Editor[/url].
 			</description>
 		</method>
 		<method name="_get_dependencies" qualifiers="virtual const">

--- a/doc/classes/ResourceFormatLoader.xml
+++ b/doc/classes/ResourceFormatLoader.xml
@@ -63,7 +63,7 @@
 			<description>
 				Gets a list of all [ClassDB] recognized classes that are used by this loader at the given [param path].
 				If it is not implemented, returns the class given by [method _get_resource_type].
-				[b]NOTE:[/b] This is used to trim unused features by the [url=$DOCS_URL/tutorials/editor/using_engine_compilation_configuration_editor.html]Compilation Configuration Editor[/url].
+				[b]Note:[/b] This is used to trim unused features by the [url=$DOCS_URL/tutorials/editor/using_engine_compilation_configuration_editor.html]Compilation Configuration Editor[/url].
 			</description>
 		</method>
 		<method name="_get_dependencies" qualifiers="virtual const">

--- a/doc/classes/ResourceFormatLoader.xml
+++ b/doc/classes/ResourceFormatLoader.xml
@@ -13,20 +13,20 @@
 		class_name GameSaveLoader
 		extends ResourceFormatLoader
 
-		func _get_recognized_extensions() -> PackedStringArray:
+		func _get_recognized_extensions() -&gt; PackedStringArray:
 			return PackedStringArray(["save"])
 
-		func _get_resource_type(path: String) -> String:
+		func _get_resource_type(path: String) -&gt; String:
 			if path.get_extension() == "save":
 				return "Resource" # Use the ClassDB recognized class here.
 			return ""
 
-		func _get_resource_script_class(path: String) -> String:
+		func _get_resource_script_class(path: String) -&gt; String:
 			if path.get_extension() == "save":
 				return "GameSave"
 			return ""
 
-		func _load(path: String, original_path: String, use_sub_threads: bool, cache_mode: int) -> Variant:
+		func _load(path: String, original_path: String, use_sub_threads: bool, cache_mode: int) -&gt; Variant:
 			var file = FileAccess.open(path, FileAccess.READ)
 
 			if not file:
@@ -42,8 +42,8 @@
 
 			return from_json(file_data)
 
-		func from_json(file_data: String) -> GameSave:
-			# ... Convert to GameSave from json text here
+		func from_json(file_data: String) -&gt; GameSave:
+			# ... Convert to GameSave from json text here.
 		[/codeblock]
 	</description>
 	<tutorials>
@@ -61,9 +61,9 @@
 			<return type="PackedStringArray" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Gets a list of all [ClassDB] recognized classes that are used by this loader at the given [param path]. 
+				Gets a list of all [ClassDB] recognized classes that are used by this loader at the given [param path].
 				If it is not implemented, returns the class given by [method _get_resource_type].
-				[b]NOTE:[/b] This is used to trim unused features by the [url=$DOCS_URL//tutorials/editor/using_engine_compilation_configuration_editor.html]Compilation Configuration Editor[/url].
+				[b]NOTE:[/b] This is used to trim unused features by the [url=$DOCS_URL/tutorials/editor/using_engine_compilation_configuration_editor.html]Compilation Configuration Editor[/url].
 			</description>
 		</method>
 		<method name="_get_dependencies" qualifiers="virtual const">

--- a/doc/classes/ResourceFormatSaver.xml
+++ b/doc/classes/ResourceFormatSaver.xml
@@ -6,6 +6,40 @@
 	<description>
 		The engine can save resources when you do it from the editor, or when you use the [ResourceSaver] singleton. This is accomplished thanks to multiple [ResourceFormatSaver]s, each handling its own format and called automatically by the engine.
 		By default, Godot saves resources as [code].tres[/code] (text-based), [code].res[/code] (binary) or another built-in format, but you can choose to create your own format by extending this class. Be sure to respect the documented return types and values. You should give it a global class name with [code]class_name[/code] for it to be registered. Like built-in ResourceFormatSavers, it will be called automatically when saving resources of its recognized type(s). You may also implement a [ResourceFormatLoader].
+		[b]Example:[/b] A minimal [ResourceFormatSaver] that saves a custom resource called [code]GameSave[/code] to a [code].save[/code] file. For the matching loader, see [ResourceFormatLoader].
+		[codeblock]
+		@tool
+		class_name GameSaveSaver
+		extends ResourceFormatSaver
+
+		func _get_recognized_extensions(resource: Resource) -> PackedStringArray:
+			if resource is GameSave:
+				return PackedStringArray(["save"])
+			return PackedStringArray()
+
+		func _recognize(resource: Resource) -> bool:
+			return resource is GameSave
+
+		func _save(resource: Resource, path: String, flags: int) -> Error:
+			if not resource:
+				return ERR_INVALID_PARAMETER
+
+			var data = to_json(GameSave)
+			var file = FileAccess.open(path, FileAccess.WRITE)
+			if not file:
+				var err = FileAccess.get_open_error()
+				if err != OK:
+					push_error("Cannot save GameSave file %s." % path)
+					return err
+
+			# Store serialized file bits here
+			file.store_string(data)
+
+			return OK
+
+		func to_json(game_save: GameSave) -> String:
+			# ... Convert to json text from GameSave here
+		[/codeblock]
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/ResourceFormatSaver.xml
+++ b/doc/classes/ResourceFormatSaver.xml
@@ -12,15 +12,15 @@
 		class_name GameSaveSaver
 		extends ResourceFormatSaver
 
-		func _get_recognized_extensions(resource: Resource) -> PackedStringArray:
+		func _get_recognized_extensions(resource: Resource) -&gt; PackedStringArray:
 			if resource is GameSave:
 				return PackedStringArray(["save"])
 			return PackedStringArray()
 
-		func _recognize(resource: Resource) -> bool:
+		func _recognize(resource: Resource) -&gt; bool:
 			return resource is GameSave
 
-		func _save(resource: Resource, path: String, flags: int) -> Error:
+		func _save(resource: Resource, path: String, flags: int) -&gt; Error:
 			if not resource:
 				return ERR_INVALID_PARAMETER
 
@@ -32,13 +32,13 @@
 					push_error("Cannot save GameSave file %s." % path)
 					return err
 
-			# Store serialized file bits here
+			# Store serialized file bits here.
 			file.store_string(data)
 
 			return OK
 
-		func to_json(game_save: GameSave) -> String:
-			# ... Convert to json text from GameSave here
+		func to_json(game_save: GameSave) -&gt; String:
+			# ... Convert to json text from GameSave here.
 		[/codeblock]
 	</description>
 	<tutorials>


### PR DESCRIPTION
- Document `_exists` and `_get_classes_used` in `ResourceFormatLoader`
- Add minimal examples to `ResourceFormatLoader` and `ResourceFormatSaver`

A minimal example has been often requested in the comments on these docs.