### PR TITLE
Fix Change version link in web editor shell

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -360,7 +360,7 @@ a:active {
 					<br >
 					<img src="logo.svg" alt="Godot Engine logo" width="1024" height="414" style="width: auto; height: auto; max-width: min(85%, 50vh); max-height: 200px">
 					<br >
-					___GODOT_VERSION___ - <a href="releases/">Change version</a>
+					___GODOT_VERSION___ - <a href="/releases/">Change version</a>
 					<br >
 					<br >
 					<label for="zip-file" style="margin-right: 1rem">Preload project ZIP:</label>


### PR DESCRIPTION
- `master` version of https://github.com/godotengine/godot/pull/117763.

The URL needs to be absolute to point to the correct location regardless of the editor version.

- This closes https://github.com/godotengine/godot/issues/117579.
- Closes https://github.com/godotengine/godot/issues/105974.
