### PR TITLE
[4.6] Fix Change version link in web editor shell

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -295,7 +295,7 @@ a:active {
 					<br >
 					___GODOT_VERSION___
 					<br >
-					<a href="releases/">Need an old version?</a>
+					<a href="/releases/">Need an old version?</a>
 					<br >
 					<br >
 					<br >


### PR DESCRIPTION
- `4.6` version of https://github.com/godotengine/godot/pull/117762.

The URL needs to be absolute to point to the correct location regardless of the editor version.

- This closes #117579.
