### PR TITLE
Add with_ methods to color

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -322,6 +322,54 @@ static int _parse_col8(const String &p_str, int p_ofs) {
 	return _parse_col4(p_str, p_ofs) * 16 + _parse_col4(p_str, p_ofs + 1);
 }
 
+Color Color::with_red8(int64_t p_r8) const {
+	Color c = *this;
+	c.r = p_r8 / 255.0f;
+	return c;
+}
+
+Color Color::with_green8(int64_t p_g8) const {
+	Color c = *this;
+	c.g = p_g8 / 255.0f;
+	return c;
+}
+
+Color Color::with_blue8(int64_t p_b8) const {
+	Color c = *this;
+	c.b = p_b8 / 255.0f;
+	return c;
+}
+
+Color Color::with_alpha8(int64_t p_a8) const {
+	Color c = *this;
+	c.a = p_a8 / 255.0f;
+	return c;
+}
+
+Color Color::with_red(float p_r) const {
+	Color c = *this;
+	c.r = p_r;
+	return c;
+}
+
+Color Color::with_green(float p_g) const {
+	Color c = *this;
+	c.g = p_g;
+	return c;
+}
+
+Color Color::with_blue(float p_b) const {
+	Color c = *this;
+	c.b = p_b;
+	return c;
+}
+
+Color Color::with_alpha(float p_a) const {
+	Color c = *this;
+	c.a = p_a;
+	return c;
+}
+
 Color Color::inverted() const {
 	Color c = *this;
 	c.invert();

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -103,6 +103,16 @@ struct [[nodiscard]] Color {
 	void invert();
 	Color inverted() const;
 
+	Color with_red(float p_r) const;
+	Color with_green(float p_g) const;
+	Color with_blue(float p_b) const;
+	Color with_alpha(float p_a) const;
+
+	Color with_red8(int64_t p_r8) const;
+	Color with_green8(int64_t p_g8) const;
+	Color with_blue8(int64_t p_b8) const;
+	Color with_alpha8(int64_t p_a8) const;
+
 	_FORCE_INLINE_ float get_luminance() const {
 		return 0.2126f * r + 0.7152f * g + 0.0722f * b;
 	}

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2420,6 +2420,16 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Color, to_rgba64, sarray(), varray());
 	bind_method(Color, to_html, sarray("with_alpha"), varray(true));
 
+	bind_method(Color, with_red8, sarray("r8"), varray());
+	bind_method(Color, with_green8, sarray("g8"), varray());
+	bind_method(Color, with_blue8, sarray("b8"), varray());
+	bind_method(Color, with_alpha8, sarray("a8"), varray());
+
+	bind_method(Color, with_red, sarray("r"), varray());
+	bind_method(Color, with_green, sarray("g"), varray());
+	bind_method(Color, with_blue, sarray("b"), varray());
+	bind_method(Color, with_alpha, sarray("a"), varray());
+
 	bind_method(Color, clamp, sarray("min", "max"), varray(Color(0, 0, 0, 0), Color(1, 1, 1, 1)));
 	bind_method(Color, inverted, sarray(), varray());
 	bind_method(Color, lerp, sarray("to", "weight"), varray());

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -492,6 +492,62 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="with_alpha" qualifiers="const">
+			<return type="Color" />
+			<param index="0" name="a" type="float" />
+			<description>
+				Returns a new color resulting from setting the existing [member a] value to [param a].
+			</description>
+		</method>
+		<method name="with_alpha8" qualifiers="const">
+			<return type="Color" />
+			<param index="0" name="a8" type="int" />
+			<description>
+				Returns a new color resulting from setting the existing [member a] value to [param a8] divided by [code]255.0[/code].
+			</description>
+		</method>
+		<method name="with_blue" qualifiers="const">
+			<return type="Color" />
+			<param index="0" name="b" type="float" />
+			<description>
+				Returns a new color resulting from setting the existing [member b] value to [param b].
+			</description>
+		</method>
+		<method name="with_blue8" qualifiers="const">
+			<return type="Color" />
+			<param index="0" name="b8" type="int" />
+			<description>
+				Returns a new color resulting from setting the existing [member b] value to [param b8] divided by [code]255.0[/code].
+			</description>
+		</method>
+		<method name="with_green" qualifiers="const">
+			<return type="Color" />
+			<param index="0" name="g" type="float" />
+			<description>
+				Returns a new color resulting from setting the existing [member g] value to [param g].
+			</description>
+		</method>
+		<method name="with_green8" qualifiers="const">
+			<return type="Color" />
+			<param index="0" name="g8" type="int" />
+			<description>
+				Returns a new color resulting from setting the existing [member g] value to [param g8] divided by [code]255.0[/code].
+			</description>
+		</method>
+		<method name="with_red" qualifiers="const">
+			<return type="Color" />
+			<param index="0" name="r" type="float" />
+			<description>
+				Returns a new color resulting from setting the existing [member r] value to [param r].
+			</description>
+		</method>
+		<method name="with_red8" qualifiers="const">
+			<return type="Color" />
+			<param index="0" name="r8" type="int" />
+			<description>
+				Returns a new color resulting from setting the existing [member r] value to [param r8] divided by [code]255.0[/code].
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="a" type="float" setter="" getter="" default="1.0">

--- a/tests/core/math/test_color.cpp
+++ b/tests/core/math/test_color.cpp
@@ -167,6 +167,36 @@ TEST_CASE("[Color] Linear <-> sRGB conversion") {
 			"White converted from linear to sRGB should remain white.");
 }
 
+TEST_CASE("[Color] with_* methods") {
+	constexpr Color start_color = Color(0.5, 0.5, 0.5, 0.5);
+	Color start_color_for_ints = Color::from_rgba8(123, 123, 123, 123);
+	CHECK_MESSAGE(
+			start_color.with_red(.7).is_equal_approx(Color(0.7, 0.5, 0.5, 0.5)),
+			"The color with red should only change the red component");
+	CHECK_MESSAGE(
+			start_color.with_green(.7).is_equal_approx(Color(0.5, 0.7, 0.5, 0.5)),
+			"The color with green should only change the green component");
+	CHECK_MESSAGE(
+			start_color.with_blue(.7).is_equal_approx(Color(0.5, 0.5, 0.7, 0.5)),
+			"The color with blue should only change the blue component");
+	CHECK_MESSAGE(
+			start_color.with_alpha(.7).is_equal_approx(Color(0.5, 0.5, 0.5, 0.7)),
+			"The color with alpha should only change the alpha");
+
+	CHECK_MESSAGE(
+			start_color_for_ints.with_red8(60).is_equal_approx(Color::from_rgba8(60, 123, 123, 123)),
+			"The color with red should only change the red component");
+	CHECK_MESSAGE(
+			start_color_for_ints.with_green8(60).is_equal_approx(Color::from_rgba8(123, 60, 123, 123)),
+			"The color with green should only change the green component");
+	CHECK_MESSAGE(
+			start_color_for_ints.with_blue8(60).is_equal_approx(Color::from_rgba8(123, 123, 60, 123)),
+			"The color with blue should only change the blue component");
+	CHECK_MESSAGE(
+			start_color_for_ints.with_alpha8(60).is_equal_approx(Color::from_rgba8(123, 123, 123, 60)),
+			"The color with alpha should only change the alpha");
+}
+
 TEST_CASE("[Color] Named colors") {
 	CHECK_MESSAGE(
 			Color::named("red").is_equal_approx(Color::hex(0xFF0000FF)),


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/2150

adds
```
with_red
with_green
with_blue
with_alpha

with_red8
with_green8
with_blue8
with_alpha8
```

which allows for things like this:
<img width="634" height="112" alt="image" src="https://github.com/user-attachments/assets/a849286d-ca25-401a-94d8-dc6711e09c8f" />


