### PR TITLE
Autocompletion: Utilize `get_autoload_list` instead of searching the property list

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3162,17 +3162,8 @@ static void _list_call_arguments(GDScriptParser::CompletionContext &p_context, c
 				}
 
 				if (p_argidx == 0 && ClassDB::is_parent_class(class_name, SNAME("Node")) && (method == SNAME("get_node") || method == SNAME("has_node"))) {
-					// Get autoloads
-					List<PropertyInfo> props;
-					ProjectSettings::get_singleton()->get_property_list(&props);
-
-					for (const PropertyInfo &E : props) {
-						String s = E.name;
-						if (!s.begins_with("autoload/")) {
-							continue;
-						}
-						String name = s.get_slicec('/', 1);
-						ScriptLanguage::CodeCompletionOption option = _calculate_string_insertion(existing_argument, "/root/" + name, Variant::NODE_PATH);
+					for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : ProjectSettings::get_singleton()->get_autoload_list()) {
+						ScriptLanguage::CodeCompletionOption option = _calculate_string_insertion(existing_argument, "/root/" + E.value.name, Variant::NODE_PATH);
 						option.kind = ScriptLanguage::CODE_COMPLETION_KIND_NODE_PATH;
 						r_result.insert(option.display, option);
 					}


### PR DESCRIPTION
Searching for autoloads based on the `autoload/` prefix is more busy work. It also is not entirely correct, since plugins could be utilizing `autoload_prepend` introduced in https://github.com/godotengine/godot/pull/113078
