### PR TITLE
Fix LightmapGI probe update speed setting not applying in Compatibility

### DIFF
--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -55,7 +55,7 @@ LightStorage::LightStorage() {
 	directional_shadow.size = GLOBAL_GET("rendering/lights_and_shadows/directional_shadow/size");
 	directional_shadow.use_16_bits = GLOBAL_GET("rendering/lights_and_shadows/directional_shadow/16_bits");
 
-	// lightmap_probe_capture_update_speed = GLOBAL_GET("rendering/lightmapping/probe_capture/update_speed");
+	lightmap_probe_capture_update_speed = GLOBAL_GET("rendering/lightmapping/probe_capture/update_speed");
 }
 
 LightStorage::~LightStorage() {


### PR DESCRIPTION
This now applies the setting on project launch like in Forward+/Mobile. Runtime changes with `RenderingServer.lightmap_set_probe_capture_update_speed()` were already functional.

- This closes https://github.com/godotengine/godot/issues/117770.
