### PR TITLE
Fix LightmapGI probe interpolation at lightmap AABB edges

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2069,6 +2069,10 @@ void RendererSceneCull::_update_instance_lightmap_captures(Instance *p_instance)
 	float accum_blend = 0.0;
 
 	InstanceGeometryData *geom = static_cast<InstanceGeometryData *>(p_instance->base_data);
+	// Don't blend if only one lightmap affects the dynamic object.
+	// This prevents ambient light from being pure black until the object has fully entered the LightmapGI's AABB.
+	const bool use_blending = geom->lightmap_captures.size() >= 2;
+
 	for (Instance *E : geom->lightmap_captures) {
 		Instance *lightmap = E;
 
@@ -2084,9 +2088,6 @@ void RendererSceneCull::_update_instance_lightmap_captures(Instance *p_instance)
 		Vector3 lm_pos = to_bounds.xform(center);
 
 		AABB bounds = RSG::light_storage->lightmap_get_aabb(lightmap->base);
-		if (!bounds.has_point(lm_pos)) {
-			continue; //not in this lightmap
-		}
 
 		Color sh[9];
 		RSG::light_storage->lightmap_tap_sh_light(lightmap->base, lm_pos, sh);
@@ -2106,11 +2107,14 @@ void RendererSceneCull::_update_instance_lightmap_captures(Instance *p_instance)
 
 		Vector3 inner_pos = ((lm_pos - bounds.position) / bounds.size) * 2.0 - Vector3(1.0, 1.0, 1.0);
 
-		real_t blend = MAX(Math::abs(inner_pos.x), MAX(Math::abs(inner_pos.y), Math::abs(inner_pos.z)));
-		//make blend more rounded
-		blend = Math::lerp(inner_pos.length(), blend, blend);
-		blend *= blend;
-		blend = MAX(0.0, 1.0 - blend);
+		real_t blend = 1.0;
+		if (use_blending) {
+			blend = MAX(Math::abs(inner_pos.x), MAX(Math::abs(inner_pos.y), Math::abs(inner_pos.z)));
+			// Make blend more rounded.
+			blend = Math::lerp(inner_pos.length(), blend, blend);
+			blend *= blend;
+			blend = MAX(0.0, 1.0 - blend);
+		}
 
 		if (interior && !inside) {
 			//do not blend, just replace


### PR DESCRIPTION
This prevents ambient light from being pure black when an object sits at the edge of a LightmapGI node's bounds.

Thanks @permelin for the fix suggested in https://github.com/godotengine/godot/issues/88101#issuecomment-1984257129 :slightly_smiling_face: 

- This closes https://github.com/godotengine/godot/issues/88101.

**Testing project:** [Lightmap.zip](https://github.com/user-attachments/files/26197648/Lightmap.zip)

## Preview

*In this scene, two LightmapGI nodes (delimited by the red and green emissive floors) partially overlap. Blending probe data between LightmapGI nodes is preserved with this fix.*

### Before

[probe_interpolation_before.webm](https://github.com/user-attachments/assets/cf688cd7-7097-44ff-a697-4b8fc0ad56b5)

### After

[probe_interpolation_after.webm](https://github.com/user-attachments/assets/63a6f211-1b89-4eae-b086-b27999035d31)