### PR TITLE
Add support for saving HDR screenshots to `Image.save_exr` functions.

### DIFF
--- a/core/io/image.compat.inc
+++ b/core/io/image.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  image_saver_tinyexr.h                                                 */
+/*  image.compat.inc                                                      */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,9 +28,21 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#ifndef DISABLE_DEPRECATED
 
-#include "core/io/image.h"
+#include "core/object/class_db.h"
 
-Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale, bool p_color_image, float p_max_value);
-Vector<uint8_t> save_exr_buffer(const Ref<Image> &p_img, bool p_grayscale, bool p_color_image, float p_max_value);
+Vector<uint8_t> Image::_save_exr_to_buffer_bind_compat_117800(bool p_grayscale) const {
+	return save_exr_to_buffer(p_grayscale);
+}
+
+Error Image::_save_exr_bind_compat_117800(const String &p_path, bool p_grayscale) const {
+	return save_exr(p_path, p_grayscale);
+}
+
+void Image::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("save_exr", "path", "grayscale"), &Image::_save_exr_bind_compat_117800, DEFVAL(false));
+	ClassDB::bind_compatibility_method(D_METHOD("save_exr_to_buffer", "grayscale"), &Image::_save_exr_to_buffer_bind_compat_117800, DEFVAL(false));
+}
+
+#endif // DISABLE_DEPRECATED

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "image.h"
+#include "image.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
@@ -2820,19 +2821,18 @@ Vector<uint8_t> Image::save_jpg_to_buffer(float p_quality) const {
 	return save_jpg_buffer_func(Ref<Image>((Image *)this), p_quality);
 }
 
-Error Image::save_exr(const String &p_path, bool p_grayscale) const {
+Error Image::save_exr(const String &p_path, bool p_grayscale, bool p_color_image, float p_max_value) const {
 	if (save_exr_func == nullptr) {
 		return ERR_UNAVAILABLE;
 	}
-
-	return save_exr_func(p_path, Ref<Image>((Image *)this), p_grayscale);
+	return save_exr_func(p_path, Ref<Image>((Image *)this), p_grayscale, p_color_image, p_max_value);
 }
 
-Vector<uint8_t> Image::save_exr_to_buffer(bool p_grayscale) const {
+Vector<uint8_t> Image::save_exr_to_buffer(bool p_grayscale, bool p_color_image, float p_max_value) const {
 	if (save_exr_buffer_func == nullptr) {
 		return Vector<uint8_t>();
 	}
-	return save_exr_buffer_func(Ref<Image>((Image *)this), p_grayscale);
+	return save_exr_buffer_func(Ref<Image>((Image *)this), p_grayscale, p_color_image, p_max_value);
 }
 
 Error Image::save_dds(const String &p_path) const {
@@ -3879,8 +3879,8 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("save_png_to_buffer"), &Image::save_png_to_buffer);
 	ClassDB::bind_method(D_METHOD("save_jpg", "path", "quality"), &Image::save_jpg, DEFVAL(0.75));
 	ClassDB::bind_method(D_METHOD("save_jpg_to_buffer", "quality"), &Image::save_jpg_to_buffer, DEFVAL(0.75));
-	ClassDB::bind_method(D_METHOD("save_exr", "path", "grayscale"), &Image::save_exr, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("save_exr_to_buffer", "grayscale"), &Image::save_exr_to_buffer, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("save_exr", "path", "grayscale", "color_image", "max_linear_value"), &Image::save_exr, DEFVAL(false), DEFVAL(false), DEFVAL(-1.0));
+	ClassDB::bind_method(D_METHOD("save_exr_to_buffer", "grayscale", "color_image", "max_linear_value"), &Image::save_exr_to_buffer, DEFVAL(false), DEFVAL(false), DEFVAL(-1.0));
 	ClassDB::bind_method(D_METHOD("save_dds", "path"), &Image::save_dds);
 	ClassDB::bind_method(D_METHOD("save_dds_to_buffer"), &Image::save_dds_to_buffer);
 

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -55,8 +55,8 @@ typedef Ref<Image> (*ScalableImageMemLoadFunc)(const uint8_t *p_data, int p_size
 typedef Error (*SaveWebPFunc)(const String &p_path, const Ref<Image> &p_img, const bool p_lossy, const float p_quality);
 typedef Vector<uint8_t> (*SaveWebPBufferFunc)(const Ref<Image> &p_img, const bool p_lossy, const float p_quality);
 
-typedef Error (*SaveEXRFunc)(const String &p_path, const Ref<Image> &p_img, bool p_grayscale);
-typedef Vector<uint8_t> (*SaveEXRBufferFunc)(const Ref<Image> &p_img, bool p_grayscale);
+typedef Error (*SaveEXRFunc)(const String &p_path, const Ref<Image> &p_img, bool p_grayscale, bool p_color_image, float p_max_value);
+typedef Vector<uint8_t> (*SaveEXRBufferFunc)(const Ref<Image> &p_img, bool p_grayscale, bool p_color_image, float p_max_value);
 
 typedef Error (*SaveDDSFunc)(const String &p_path, const Ref<Image> &p_img);
 typedef Vector<uint8_t> (*SaveDDSBufferFunc)(const Ref<Image> &p_img);
@@ -257,6 +257,12 @@ protected:
 
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	Vector<uint8_t> _save_exr_to_buffer_bind_compat_117800(bool p_grayscale = false) const;
+	Error _save_exr_bind_compat_117800(const String &p_path, bool p_grayscale = false) const;
+	static void _bind_compatibility_methods();
+#endif
+
 private:
 	Format format = FORMAT_L8;
 	Vector<uint8_t> data;
@@ -361,9 +367,9 @@ public:
 	Error save_dds(const String &p_path) const;
 	Vector<uint8_t> save_png_to_buffer() const;
 	Vector<uint8_t> save_jpg_to_buffer(float p_quality = 0.75) const;
-	Vector<uint8_t> save_exr_to_buffer(bool p_grayscale = false) const;
+	Vector<uint8_t> save_exr_to_buffer(bool p_grayscale = false, bool p_color_image = false, float p_max_value = -1.0f) const;
 	Vector<uint8_t> save_dds_to_buffer() const;
-	Error save_exr(const String &p_path, bool p_grayscale = false) const;
+	Error save_exr(const String &p_path, bool p_grayscale = false, bool p_color_image = false, float p_max_value = -1.0f) const;
 	Error save_webp(const String &p_path, const bool p_lossy = false, const float p_quality = 0.75f) const;
 	Vector<uint8_t> save_webp_to_buffer(const bool p_lossy = false, const float p_quality = 0.75f) const;
 

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -495,15 +495,21 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="grayscale" type="bool" default="false" />
+			<param index="2" name="color_image" type="bool" default="false" />
+			<param index="3" name="max_linear_value" type="float" default="-1.0" />
 			<description>
-				Saves the image as an EXR file to [param path]. If [param grayscale] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return [constant ERR_UNAVAILABLE] if Godot was compiled without the TinyEXR module.
+				Saves the image as an EXR file to [param path]. If [param grayscale] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. Set [param color_image] to [code]true[/code] when saving a color image, such as a screenshot. Negative values will be included when [param color_image] is [code]false[/code], which may be useful for saving raw floating point data such as a lightmap that includes negative light information. Color component values in the resulting EXR file will not exceed [param max_linear_value] if [param max_linear_value] is not negative. This function will return [constant ERR_UNAVAILABLE] if Godot was compiled without the TinyEXR module.
+				When saving screenshots of a project that uses HDR output, use [method Window.get_output_max_linear_value] for [param max_linear_value].
 			</description>
 		</method>
 		<method name="save_exr_to_buffer" qualifiers="const">
 			<return type="PackedByteArray" />
 			<param index="0" name="grayscale" type="bool" default="false" />
+			<param index="1" name="color_image" type="bool" default="false" />
+			<param index="2" name="max_linear_value" type="float" default="-1.0" />
 			<description>
-				Saves the image as an EXR file to a byte array. If [param grayscale] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return an empty byte array if Godot was compiled without the TinyEXR module.
+				Saves the image as an EXR file to a byte array. If [param grayscale] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. Set [param color_image] to [code]true[/code] when saving a color image, such as a screenshot. Negative values will be included when [param color_image] is [code]false[/code], which may be useful for saving raw floating point data such as a lightmap that includes negative light information. Color component values in the resulting EXR file will not exceed [param max_linear_value] if [param max_linear_value] is not negative. This function will return an empty byte array if Godot was compiled without the TinyEXR module.
+				When saving screenshots of a project that uses HDR output, use [method Window.get_output_max_linear_value] for [param max_linear_value].
 			</description>
 		</method>
 		<method name="save_jpg" qualifiers="const">

--- a/misc/extension_api_validation/4.6-stable/GH-117800.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-117800.txt
@@ -1,0 +1,7 @@
+GH-117800
+--------------
+
+Validate extension JSON: Error: Field 'classes/Image/methods/save_exr/arguments': size changed value in new API, from 2 to 4.
+Validate extension JSON: Error: Field 'classes/Image/methods/save_exr_to_buffer/arguments': size changed value in new API, from 1 to 3.
+
+Added color_image and max_linear_value parameters to Image.save_exr functions for saving HDR screenshots. Use default values for existing behavior.

--- a/modules/tinyexr/image_saver_tinyexr.cpp
+++ b/modules/tinyexr/image_saver_tinyexr.cpp
@@ -145,7 +145,7 @@ static int get_channel_count(Image::Format p_format) {
 	}
 }
 
-Vector<uint8_t> save_exr_buffer(const Ref<Image> &p_img, bool p_grayscale) {
+Vector<uint8_t> save_exr_buffer(const Ref<Image> &p_img, bool p_grayscale, bool p_color_image, float p_max_value) {
 	Image::Format format = p_img->get_format();
 
 	if (!is_supported_format(format)) {
@@ -213,7 +213,14 @@ Vector<uint8_t> save_exr_buffer(const Ref<Image> &p_img, bool p_grayscale) {
 				float *dst_wp = (float *)dst_w;
 
 				for (int i = 0; i < pixel_count; ++i) {
-					dst_wp[i] = src_rp[channel_index + i * channel_count];
+					float src_float = src_rp[channel_index + i * channel_count];
+					if (p_max_value >= 0.f) {
+						src_float = fmin(p_max_value, src_float);
+					}
+					if (p_color_image) {
+						src_float = fmax(0.f, src_float);
+					}
+					dst_wp[i] = src_float;
 				}
 
 			} else if (src_pixel_type == SRC_HALF && target_pixel_type == TINYEXR_PIXELTYPE_HALF) {
@@ -223,7 +230,19 @@ Vector<uint8_t> save_exr_buffer(const Ref<Image> &p_img, bool p_grayscale) {
 				uint16_t *dst_wp = (uint16_t *)dst_w;
 
 				for (int i = 0; i < pixel_count; ++i) {
-					dst_wp[i] = src_rp[channel_index + i * channel_count];
+					int src_rp_index = channel_index + i * channel_count;
+					if (p_max_value >= 0.f || p_color_image) {
+						float src_float = Math::halfptr_to_float(src_rp + src_rp_index);
+						if (p_max_value >= 0.f) {
+							src_float = fmin(p_max_value, src_float);
+						}
+						if (p_color_image) {
+							src_float = fmax(0.f, src_float);
+						}
+						dst_wp[i] = Math::make_half_float(src_float);
+					} else {
+						dst_wp[i] = src_rp[src_rp_index];
+					}
 				}
 
 			} else if (src_pixel_type == SRC_BYTE && target_pixel_type == TINYEXR_PIXELTYPE_HALF) {
@@ -233,7 +252,11 @@ Vector<uint8_t> save_exr_buffer(const Ref<Image> &p_img, bool p_grayscale) {
 				uint16_t *dst_wp = (uint16_t *)dst_w;
 
 				for (int i = 0; i < pixel_count; ++i) {
-					dst_wp[i] = Math::make_half_float(src_rp[channel_index + i * channel_count] / 255.f);
+					float src_float = src_rp[channel_index + i * channel_count] / 255.f;
+					if (p_max_value >= 0.f) {
+						src_float = fmin(p_max_value, src_float);
+					}
+					dst_wp[i] = Math::make_half_float(src_float);
 				}
 
 			} else {
@@ -285,8 +308,8 @@ Vector<uint8_t> save_exr_buffer(const Ref<Image> &p_img, bool p_grayscale) {
 	return buffer;
 }
 
-Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale) {
-	const Vector<uint8_t> buffer = save_exr_buffer(p_img, p_grayscale);
+Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale, bool p_color_image, float p_max_value) {
+	const Vector<uint8_t> buffer = save_exr_buffer(p_img, p_grayscale, p_color_image, p_max_value);
 	if (buffer.is_empty()) {
 		print_error(String("Saving EXR failed."));
 		return ERR_FILE_CANT_WRITE;


### PR DESCRIPTION
### What problem(s) does this PR solve?

- Fixes #117795

### What is the rationale for the approach used in this PR?

`Image.save_exr` functions have been modified to add two new parameters:
1. `color_image: bool`
   - Set `color_image` to `true` when saving a color image, such as a screenshot. Negative values will be included when `color_image` is `false`, which may be useful for saving raw floating point data such as a lightmap that includes negative light information.
   - When `true`, negative values are clipped to `0.0` to give correct colour rendering for screenshots.
3. `max_linear_value`
   -  Color component values in the resulting EXR file will not exceed `max_linear_value` if `max_linear_value` is not negative.
   - When saving screenshots of a project that uses HDR output, use `Window.get_output_max_linear_value` for `max_linear_value`.

**Clipping negative values (`color_image == true`)**

Internal to Godot, negative color values represent negative radiant energy for the purposes of lighting simulation. But for the purposes of CIE colorimetry, which is used for HDR image formats such as EXR, negative RGB values represent colors that are outside of the current RGB gamut and are positive RGB values in other color gamuts. For this reason, negative values should never be saved to EXR files that are intended to represent a color image such as a screenshot. This PR adds parameters to the existing `save_exr` and `save_exr_to_buffer` functions to allow saving of HDR screenshots.

**New `max_linear_value` parameter**

The new `max_linear_value` parameter matches [`Window.get_output_max_linear_value()`](https://docs.godotengine.org/en/latest/classes/class_window.html#class-window-method-get-output-max-linear-value). This means that producing an EXR image that is identical to the rendering presented by Godot is as simple as:

``` C++
get_window().get_texture().get_image().save_exr("screenshot.exr", false, get_window().get_output_max_linear_value())
```

With these changes, it is now possible to save an image that is identical to the image presented by HDR output:

<img width="1453" height="880" alt="image" src="https://github.com/user-attachments/assets/6f2d7486-3978-421f-ba08-1d372034ff0c" />

In the above renderings: the red, green, and blue rectangles shown on the bottom left corner contain negative values, such as those that may be created by negative lights. The colour sweep that comprises the majority of the render exceeds values of `1.0` on the right side.

### Was generative AI (LLM AI) used to create a portion of this PR?

No.

### Are there any parts of this PR that you are uncertain of or require special attention from reviewers?

- I haven't yet tested `SRC_FLOAT`. I don't know how to do this, but if it's possible to test this code path it should be done before merging. Anyone know how to?