### PR TITLE
`RWLock`: use C++17's `shared_mutex` instead of timed variant

### DIFF
--- a/core/os/rw_lock.h
+++ b/core/os/rw_lock.h
@@ -42,7 +42,7 @@
 #endif
 
 class RWLock {
-	mutable THREADING_NAMESPACE::shared_timed_mutex mutex;
+	mutable THREADING_NAMESPACE::shared_mutex mutex;
 
 public:
 	// Lock the RWLock, block if locked by someone else.


### PR DESCRIPTION
C++17 (the current standard used by Godot, soon to be upgraded to C++20) added `shared_mutex` as a cheaper version of C++14's `shared_timed_mutex` that leaves timed features out.

`RWLock` uses none of `shared_timed_mutex`'s timed features (any functions using `_for` and `_until`), so it's completely safe for the mutex to be a `shared_mutex`.

(Considering Godot was already using C++17 at the time, I wonder why `shared_mutex` wasn't used in #45314. If it was some compatibility issue at the time, recent tests don't show anymore.)