### PR TITLE
Fix `convert_to_srgb` uniform being set as the wrong data type.

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1393,7 +1393,7 @@ void TextureStorage::texture_drawable_blit_rect(const TypedArray<RID> &p_texture
 	TightLocalVector<GLenum> draw_buffers;
 
 	Texture *tar_textures[4];
-	int convert_to_srgb_mask = 0;
+	uint32_t convert_to_srgb_mask = 0;
 	Texture *src_textures[4];
 
 	int i = 0;


### PR DESCRIPTION
This causes an error to be printed and probably means that the srgb format is treated as if it was the non-srgb format:

```
GL ERROR: Source: OpenGL    Type: Error    ID: 1    Severity: High    Message: GL_INVALID_OPERATION in glUniform1("convert_to_srgb"@3 is uint, not int)
```