### PR TITLE
Default multi-node property revert to node revert

### DIFF
--- a/editor/inspector/multi_node_edit.cpp
+++ b/editor/inspector/multi_node_edit.cpp
@@ -35,6 +35,7 @@
 #include "core/object/class_db.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
+#include "scene/property_utils.h"
 
 bool MultiNodeEdit::_set(const StringName &p_name, const Variant &p_value) {
 	return _set_impl(p_name, p_value, "");
@@ -243,7 +244,16 @@ bool MultiNodeEdit::_property_get_revert(const StringName &p_name, Variant &r_pr
 			continue;
 		}
 
-		r_property = ClassDB::class_get_default_property_value(node->get_class_name(), p_name);
+		// Check if property can revert before using class default.
+		if (node->property_can_revert(p_name)) {
+			r_property = node->property_get_revert(p_name);
+		} else {
+			bool is_valid = false;
+			r_property = PropertyUtils::get_property_default_value(node, p_name, &is_valid);
+			if (!is_valid) {
+				r_property = ClassDB::class_get_default_property_value(node->get_class_name(), p_name);
+			}
+		}
 		return true;
 	}
 


### PR DESCRIPTION
Fixes #117759 where single select and multi-select reverts are inconsistent. Currently the editor property revert option will do an instance reset to scene property value if one node is selected, but revert to class default if multiple nodes are selected. This change would check for node revert first and then class default for multiple nodes for consistent behavior.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
