### PR TITLE
GDScript: Remove unused `get_script_by_fully_qualified_name`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2886,26 +2886,6 @@ Ref<GDScript> GDScriptLanguage::get_orphan_subclass(const String &p_qualified_na
 	return Ref<GDScript>(Object::cast_to<GDScript>(obj));
 }
 
-Ref<GDScript> GDScriptLanguage::get_script_by_fully_qualified_name(const String &p_name) {
-	{
-		MutexLock lock(mutex);
-
-		SelfList<GDScript> *elem = script_list.first();
-		while (elem) {
-			GDScript *scr = elem->self();
-			if (scr->fully_qualified_name == p_name) {
-				return scr;
-			}
-			elem = elem->next();
-		}
-	}
-
-	Ref<GDScript> scr;
-	scr.instantiate();
-	scr->fully_qualified_name = p_name;
-	return scr;
-}
-
 /*************** RESOURCE ***************/
 
 Ref<Resource> ResourceFormatLoaderGDScript::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -656,8 +656,6 @@ public:
 	void add_orphan_subclass(const String &p_qualified_name, const ObjectID &p_subclass);
 	Ref<GDScript> get_orphan_subclass(const String &p_qualified_name);
 
-	Ref<GDScript> get_script_by_fully_qualified_name(const String &p_name);
-
 	GDScriptLanguage();
 	~GDScriptLanguage();
 };


### PR DESCRIPTION
This does not really fit with the current loading infrastructure and is unused. Probably a leftover.