### PR TITLE
Fix Metal driver build with Xcode 26.4.

### DIFF
--- a/drivers/metal/metal_objects_shared.cpp
+++ b/drivers/metal/metal_objects_shared.cpp
@@ -634,11 +634,11 @@ void MDCommandBufferBase::encode_push_constant_data(RDD::ShaderID p_shader, Vect
 #pragma mark - Metal Library
 
 static const char *SHADER_STAGE_NAMES[] = {
-	[RDC::SHADER_STAGE_VERTEX] = "vert",
-	[RDC::SHADER_STAGE_FRAGMENT] = "frag",
-	[RDC::SHADER_STAGE_TESSELATION_CONTROL] = "tess_ctrl",
-	[RDC::SHADER_STAGE_TESSELATION_EVALUATION] = "tess_eval",
-	[RDC::SHADER_STAGE_COMPUTE] = "comp",
+	"vert", // RDC::SHADER_STAGE_VERTEX
+	"frag", // RDC::SHADER_STAGE_FRAGMENT
+	"tess_ctrl", // RDC::SHADER_STAGE_TESSELATION_CONTROL
+	"tess_eval", // RDC::SHADER_STAGE_TESSELATION_EVALUATION
+	"comp", // RDC::SHADER_STAGE_COMPUTE
 };
 
 void ShaderCacheEntry::notify_free() const {

--- a/drivers/metal/pixel_formats.cpp
+++ b/drivers/metal/pixel_formats.cpp
@@ -583,7 +583,7 @@ void PixelFormats::initDataFormatCapabilities() {
 
 void PixelFormats::addMTLPixelFormatDescImpl(MTL::PixelFormat p_pix_fmt, MTL::PixelFormat p_pix_fmt_linear,
 		MTLViewClass p_view_class, MTLFmtCaps p_fmt_caps, const char *p_name) {
-	_mtl_pixel_format_descs[p_pix_fmt] = { .mtlPixelFormat = p_pix_fmt, DataFormat::DATA_FORMAT_MAX, p_fmt_caps, p_view_class, p_pix_fmt_linear, p_name };
+	_mtl_pixel_format_descs[p_pix_fmt] = { .mtlPixelFormat = p_pix_fmt, .dataFormat = DataFormat::DATA_FORMAT_MAX, .mtlFmtCaps = p_fmt_caps, .mtlViewClass = p_view_class, .mtlPixelFormatLinear = p_pix_fmt_linear, .name = p_name };
 }
 
 #define addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, appleGPUCaps) \
@@ -787,7 +787,7 @@ void PixelFormats::addMTLVertexFormatDescImpl(MTL::VertexFormat mtlVtxFmt, MTLFm
 	if (mtlVtxFmt >= _mtl_vertex_format_descs.size()) {
 		_mtl_vertex_format_descs.resize(mtlVtxFmt + 1);
 	}
-	_mtl_vertex_format_descs[mtlVtxFmt] = { .mtlVertexFormat = mtlVtxFmt, RDC::DATA_FORMAT_MAX, vtxCap, MTLViewClass::None, MTL::PixelFormatInvalid, name };
+	_mtl_vertex_format_descs[mtlVtxFmt] = { .mtlVertexFormat = mtlVtxFmt, .dataFormat = RDC::DATA_FORMAT_MAX, .mtlFmtCaps = vtxCap, .mtlViewClass = MTLViewClass::None, .mtlPixelFormatLinear = MTL::PixelFormatInvalid, .name = name };
 }
 
 // Check mtlVtx exists on platform, to avoid overwriting the MTL::VertexFormatInvalid entry.

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -1603,14 +1603,14 @@ RDD::RenderPassID RenderingDeviceDriverMetal::render_pass_create(VectorView<Atta
 	}
 
 	static const MTL::LoadAction LOAD_ACTIONS[] = {
-		[ATTACHMENT_LOAD_OP_LOAD] = MTL::LoadActionLoad,
-		[ATTACHMENT_LOAD_OP_CLEAR] = MTL::LoadActionClear,
-		[ATTACHMENT_LOAD_OP_DONT_CARE] = MTL::LoadActionDontCare,
+		MTL::LoadActionLoad, // ATTACHMENT_LOAD_OP_LOAD
+		MTL::LoadActionClear, // ATTACHMENT_LOAD_OP_CLEAR
+		MTL::LoadActionDontCare, // ATTACHMENT_LOAD_OP_DONT_CARE
 	};
 
 	static const MTL::StoreAction STORE_ACTIONS[] = {
-		[ATTACHMENT_STORE_OP_STORE] = MTL::StoreActionStore,
-		[ATTACHMENT_STORE_OP_DONT_CARE] = MTL::StoreActionDontCare,
+		MTL::StoreActionStore, // ATTACHMENT_STORE_OP_STORE
+		MTL::StoreActionDontCare, // ATTACHMENT_STORE_OP_DONT_CARE
 	};
 
 	Vector<MDAttachment> attachments;

--- a/drivers/metal/rendering_shader_container_metal.cpp
+++ b/drivers/metal/rendering_shader_container_metal.cpp
@@ -217,11 +217,11 @@ Error RenderingShaderContainerMetal::compile_metal_source(const char *p_source, 
 #pragma clang diagnostic ignored "-Wunguarded-availability"
 
 static spv::ExecutionModel SHADER_STAGE_REMAP[RDD::SHADER_STAGE_MAX] = {
-	[RDD::SHADER_STAGE_VERTEX] = spv::ExecutionModelVertex,
-	[RDD::SHADER_STAGE_FRAGMENT] = spv::ExecutionModelFragment,
-	[RDD::SHADER_STAGE_TESSELATION_CONTROL] = spv::ExecutionModelTessellationControl,
-	[RDD::SHADER_STAGE_TESSELATION_EVALUATION] = spv::ExecutionModelTessellationEvaluation,
-	[RDD::SHADER_STAGE_COMPUTE] = spv::ExecutionModelGLCompute,
+	spv::ExecutionModelVertex, // RDD::SHADER_STAGE_VERTEX
+	spv::ExecutionModelFragment, // RDD::SHADER_STAGE_FRAGMENT
+	spv::ExecutionModelTessellationControl, // RDD::SHADER_STAGE_TESSELATION_CONTROL
+	spv::ExecutionModelTessellationEvaluation, // RDD::SHADER_STAGE_TESSELATION_EVALUATION
+	spv::ExecutionModelGLCompute, // RDD::SHADER_STAGE_COMPUTE
 };
 
 spv::ExecutionModel get_stage(uint32_t p_stages_mask, RDD::ShaderStage p_stage) {


### PR DESCRIPTION
With the latest Xcode (26.4 17E192), https://github.com/godotengine/godot/issues/105933 is back and setting standard C++20 no longer helps. This is likely due to LLVM update (it was failing with [custom LLVM-20 before](https://github.com/godotengine/godot/pull/109786#pullrequestreview-3133719510)).