### PR TITLE
GDScript: Initialize language when generating test output

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -46,7 +46,10 @@
 #endif
 
 #ifdef TESTS_ENABLED
-#include "tests/gdscript_test_runner.h"
+#ifndef DISABLE_DEPRECATED
+#include "core/error/error_macros.h"
+#include "core/os/os.h"
+#endif
 #endif
 
 #include "core/config/engine.h"
@@ -2151,7 +2154,12 @@ void GDScriptLanguage::init() {
 #endif // DEBUG_ENABLED
 
 #ifdef TESTS_ENABLED
-	GDScriptTests::GDScriptTestRunner::handle_cmdline();
+#ifndef DISABLE_DEPRECATED
+	if (OS::get_singleton()->get_cmdline_args().find("--gdscript-generate-tests")) {
+		ERR_PRINT(R"(The command for generating GDScript test output has changed to "--test gdscript-generate-tests")");
+		exit(-1);
+	}
+#endif // !DISABLE_DEPRECATED
 #endif // TESTS_ENABLED
 }
 

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -230,4 +230,5 @@ REGISTER_TEST_COMMAND("gdscript-tokenizer-buffer", &test_tokenizer_buffer);
 REGISTER_TEST_COMMAND("gdscript-parser", &test_parser);
 REGISTER_TEST_COMMAND("gdscript-compiler", &test_compiler);
 REGISTER_TEST_COMMAND("gdscript-bytecode", &test_bytecode);
+REGISTER_TEST_COMMAND("gdscript-generate-tests", &GDScriptTests::generate_tests);
 #endif

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -131,9 +131,8 @@ void finish_language() {
 
 StringName GDScriptTestRunner::test_function_name;
 
-GDScriptTestRunner::GDScriptTestRunner(const String &p_source_dir, bool p_init_language, bool p_print_filenames, bool p_use_binary_tokens) {
+GDScriptTestRunner::GDScriptTestRunner(const String &p_source_dir, bool p_print_filenames, bool p_use_binary_tokens) {
 	test_function_name = StringName("test");
-	do_init_languages = p_init_language;
 	print_filenames = p_print_filenames;
 	binary_tokens = p_use_binary_tokens;
 
@@ -142,9 +141,7 @@ GDScriptTestRunner::GDScriptTestRunner(const String &p_source_dir, bool p_init_l
 		source_dir += "/";
 	}
 
-	if (do_init_languages) {
-		init_language(p_source_dir);
-	}
+	init_language(p_source_dir);
 
 #ifdef DEBUG_ENABLED
 	// Set all warning levels to "Warn" in order to test them properly, even the ones that default to error.
@@ -170,9 +167,7 @@ GDScriptTestRunner::GDScriptTestRunner(const String &p_source_dir, bool p_init_l
 
 GDScriptTestRunner::~GDScriptTestRunner() {
 	test_function_name = StringName();
-	if (do_init_languages) {
-		finish_language();
-	}
+	finish_language();
 }
 
 #ifndef DEBUG_ENABLED
@@ -410,28 +405,6 @@ GDScriptTest::GDScriptTest(const String &p_source_path, const String &p_output_p
 	base_dir = p_base_dir;
 	_print_handler.printfunc = print_handler;
 	_error_handler.errfunc = error_handler;
-}
-
-void GDScriptTestRunner::handle_cmdline() {
-	List<String> cmdline_args = OS::get_singleton()->get_cmdline_args();
-
-	for (List<String>::Element *E = cmdline_args.front(); E; E = E->next()) {
-		String &cmd = E->get();
-		if (cmd == "--gdscript-generate-tests") {
-			String path;
-			if (E->next()) {
-				path = E->next()->get();
-			} else {
-				path = "modules/gdscript/tests/scripts";
-			}
-
-			GDScriptTestRunner runner(path, false, cmdline_args.find("--print-filenames") != nullptr);
-
-			bool completed = runner.generate_outputs();
-			int failed = completed ? 0 : -1;
-			exit(failed);
-		}
-	}
 }
 
 void GDScriptTest::enable_stdout() {

--- a/modules/gdscript/tests/gdscript_test_runner.h
+++ b/modules/gdscript/tests/gdscript_test_runner.h
@@ -114,7 +114,6 @@ class GDScriptTestRunner {
 	Vector<GDScriptTest> tests;
 
 	bool is_generating = false;
-	bool do_init_languages = false;
 	bool print_filenames; // Whether filenames should be printed when generated/running tests
 	bool binary_tokens; // Test with buffer tokenizer.
 
@@ -125,11 +124,10 @@ class GDScriptTestRunner {
 public:
 	static StringName test_function_name;
 
-	static void handle_cmdline();
 	int run_tests();
 	bool generate_outputs();
 
-	GDScriptTestRunner(const String &p_source_dir, bool p_init_language, bool p_print_filenames = false, bool p_use_binary_tokens = false);
+	GDScriptTestRunner(const String &p_source_dir, bool p_print_filenames = false, bool p_use_binary_tokens = false);
 	~GDScriptTestRunner();
 };
 

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -60,7 +60,7 @@ TEST_SUITE("[Modules][GDScript]") {
 	TEST_CASE("Script compilation and runtime") {
 		bool print_filenames = OS::get_singleton()->get_cmdline_args().find("--print-filenames") != nullptr;
 		bool use_binary_tokens = OS::get_singleton()->get_cmdline_args().find("--use-binary-tokens") != nullptr;
-		GDScriptTestRunner runner("modules/gdscript/tests/scripts", true, print_filenames, use_binary_tokens);
+		GDScriptTestRunner runner("modules/gdscript/tests/scripts", print_filenames, use_binary_tokens);
 		int fail_count = runner.run_tests();
 		INFO("Make sure `*.out` files have expected results.");
 		REQUIRE_MESSAGE(fail_count == 0, "All GDScript tests should pass.");

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -364,4 +364,24 @@ void test(TestType p_type) {
 
 	finish_language();
 }
+
+void generate_tests() {
+	List<String> cmdline_args = OS::get_singleton()->get_cmdline_args();
+
+	const bool print_filenames = cmdline_args.erase("--print-filenames");
+
+	String path;
+	if (cmdline_args.size() == 4) { // "<executable>", "--test", "gdscript-generate-tests", "<path>"
+		path = cmdline_args.back()->get();
+	} else {
+		path = "modules/gdscript/tests/scripts";
+	}
+
+	GDScriptTestRunner runner(path, print_filenames);
+
+	bool completed = runner.generate_outputs();
+	int failed = completed ? 0 : -1;
+	exit(failed);
+}
+
 } // namespace GDScriptTests

--- a/modules/gdscript/tests/test_gdscript.h
+++ b/modules/gdscript/tests/test_gdscript.h
@@ -41,5 +41,6 @@ enum TestType {
 };
 
 void test(TestType p_type);
+void generate_tests();
 
 } // namespace GDScriptTests


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/116938 adds a test which uses a non relative path. This works when running the tests, however when generating output this would fail, because we do not initialize the language in the same way when generating tests.

The reason for that, is that the cmd option for generating tests is handled in the language initialization. So if we tried to init the language when generating tests we would run into an infinite recursion.

This PR moves the entrypoint for generating test output to use `REGISTER_TEST_COMMAND`, so we can always run the language initialization.

As a result the cmd option changed from `--gdscript-generate-tests` to `--test gdscript-generate-tests`. This only effects developers, I also added an error message when using the old option. So I don't consider this compat breaking.

Accompanying docs PR: https://github.com/godotengine/godot-docs/pull/11874
