### PR TITLE
Implement `internationalization/locale/allow_fallback` [reverted]

### DIFF
--- a/core/string/translation_domain.cpp
+++ b/core/string/translation_domain.cpp
@@ -357,8 +357,9 @@ StringName TranslationDomain::translate(const StringName &p_message, const Strin
 	const String &locale = locale_override.is_empty() ? TranslationServer::get_singleton()->get_locale() : locale_override;
 	StringName res = get_message_from_translations(locale, p_message, p_context);
 
+	const bool &allow_fallback = TranslationServer::get_singleton()->is_fallback_allowed();
 	const String &fallback = TranslationServer::get_singleton()->get_fallback_locale();
-	if (!res && fallback.length() >= 2) {
+	if (!res && allow_fallback && fallback.length() >= 2) {
 		res = get_message_from_translations(fallback, p_message, p_context);
 	}
 
@@ -376,8 +377,9 @@ StringName TranslationDomain::translate_plural(const StringName &p_message, cons
 	const String &locale = locale_override.is_empty() ? TranslationServer::get_singleton()->get_locale() : locale_override;
 	StringName res = get_message_from_translations(locale, p_message, p_message_plural, p_n, p_context);
 
+	const bool &allow_fallback = TranslationServer::get_singleton()->is_fallback_allowed();
 	const String &fallback = TranslationServer::get_singleton()->get_fallback_locale();
-	if (!res && fallback.length() >= 2) {
+	if (!res && allow_fallback && fallback.length() >= 2) {
 		res = get_message_from_translations(fallback, p_message, p_message_plural, p_n, p_context);
 	}
 

--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -498,6 +498,14 @@ String TranslationServer::get_locale() const {
 	return locale;
 }
 
+void TranslationServer::set_fallback_allowed(const bool &p_allow) {
+	allow_fallback = p_allow;
+}
+
+bool TranslationServer::is_fallback_allowed() const {
+	return allow_fallback;
+}
+
 void TranslationServer::set_fallback_locale(const String &p_locale) {
 	fallback = p_locale;
 }
@@ -601,6 +609,7 @@ void TranslationServer::setup() {
 	}
 
 	fallback = GLOBAL_DEF("internationalization/locale/fallback", "en");
+	allow_fallback = GLOBAL_DEF("internationalization/locale/allow_fallback", true);
 	main_domain->set_pseudolocalization_enabled(GLOBAL_DEF("internationalization/pseudolocalization/use_pseudolocalization", false));
 	main_domain->set_pseudolocalization_accents_enabled(GLOBAL_DEF("internationalization/pseudolocalization/replace_with_accents", true));
 	main_domain->set_pseudolocalization_double_vowels_enabled(GLOBAL_DEF("internationalization/pseudolocalization/double_vowels", false));

--- a/core/string/translation_server.h
+++ b/core/string/translation_server.h
@@ -37,6 +37,7 @@ class TranslationServer : public Object {
 	GDCLASS(TranslationServer, Object);
 
 	String locale = "en";
+	bool allow_fallback = true;
 	String fallback;
 
 	Ref<TranslationDomain> main_domain;
@@ -109,6 +110,8 @@ public:
 
 	void set_locale(const String &p_locale);
 	String get_locale() const;
+	void set_fallback_allowed(const bool &p_allow);
+	bool is_fallback_allowed() const;
 	void set_fallback_locale(const String &p_locale);
 	String get_fallback_locale() const;
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1726,8 +1726,12 @@
 		<member name="input_devices/sensors/enable_magnetometer" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the magnetometer sensor is enabled and [method Input.get_magnetometer] returns valid data.
 		</member>
+		<member name="internationalization/locale/allow_fallback" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], the locale will fall back to [member internationalization/locale/fallback] when a translation isn't available in a given language.
+			[b]Note:[/b] Not to be confused with [TextServerFallback].
+		</member>
 		<member name="internationalization/locale/fallback" type="String" setter="" getter="" default="&quot;en&quot;">
-			The locale to fall back to if a translation isn't available in a given language. If left empty, [code]en[/code] (English) will be used.
+			The locale to fall back to if a translation isn't available in a given language if [member internationalization/locale/allow_fallback] is [code]true[/code]. If left empty, [code]en[/code] (English) will be used.
 			[b]Note:[/b] Not to be confused with [TextServerFallback].
 		</member>
 		<member name="internationalization/locale/include_text_server_data" type="bool" setter="" getter="" default="false">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -486,8 +486,9 @@ void EditorNode::_update_from_settings() {
 		Viewport::DefaultCanvasItemTextureRepeat tr = (Viewport::DefaultCanvasItemTextureRepeat)current_repeat;
 		scene_root->set_default_canvas_item_texture_repeat(tr);
 	}
+	bool allow_fallback = GLOBAL_GET("internationalization/locale/allow_fallback");
 	String current_fallback_locale = GLOBAL_GET("internationalization/locale/fallback");
-	if (current_fallback_locale != TranslationServer::get_singleton()->get_fallback_locale()) {
+	if (allow_fallback && current_fallback_locale != TranslationServer::get_singleton()->get_fallback_locale()) {
 		TranslationServer::get_singleton()->set_fallback_locale(current_fallback_locale);
 		Ref<TranslationDomain> domain = TranslationServer::get_singleton()->get_main_domain();
 		if (!domain->is_enabled()) {


### PR DESCRIPTION
Implement `internationalization/locale/allow_fallback`
Which can control if `internationalization/locale/fallback` will be use
If `false`, no fallback will happen
This feature is useful for those use a language's original texts as keys (loc with `gettext`), they can disable fallback entirely, to allow "original strings as fallback"