### PR TITLE
Move `fallback_locale` from `TranslationServer` to `TranslationDomain` & expose for edit

### DIFF
--- a/core/string/translation_domain.cpp
+++ b/core/string/translation_domain.cpp
@@ -373,9 +373,9 @@ StringName TranslationDomain::translate(const StringName &p_message, const Strin
 	const String &locale = locale_override.is_empty() ? TranslationServer::get_singleton()->get_locale() : locale_override;
 	StringName res = get_message_from_translations(locale, p_message, p_context);
 
-	const bool &allow_fallback = is_fallback_allowed();
+	const bool &fallback_allowed = is_fallback_allowed();
 	const String &fallback_locale = get_fallback_locale();
-	if (!res && allow_fallback && fallback_locale.length() >= 2) {
+	if (!res && fallback_allowed && fallback_locale.length() >= 2) {
 		res = get_message_from_translations(fallback_locale, p_message, p_context);
 	}
 
@@ -393,9 +393,9 @@ StringName TranslationDomain::translate_plural(const StringName &p_message, cons
 	const String &locale = locale_override.is_empty() ? TranslationServer::get_singleton()->get_locale() : locale_override;
 	StringName res = get_message_from_translations(locale, p_message, p_message_plural, p_n, p_context);
 
-	const bool &allow_fallback = is_fallback_allowed();
+	const bool &fallback_allowed = is_fallback_allowed();
 	const String &fallback_locale = get_fallback_locale();
-	if (!res && allow_fallback && fallback.length() >= 2) {
+	if (!res && fallback_allowed && fallback.length() >= 2) {
 		res = get_message_from_translations(fallback_locale, p_message, p_message_plural, p_n, p_context);
 	}
 

--- a/core/string/translation_domain.cpp
+++ b/core/string/translation_domain.cpp
@@ -273,11 +273,11 @@ Ref<Translation> TranslationDomain::get_translation_object(const String &p_local
 }
 #endif
 
-void TranslationServer::set_fallback_allowed(const bool &p_allow) {
+void TranslationDomain::set_fallback_allowed(const bool &p_allow) {
 	allow_fallback = p_allow;
 }
 
-bool TranslationServer::is_fallback_allowed() const {
+bool TranslationDomain::is_fallback_allowed() const {
 	return allow_fallback;
 }
 
@@ -527,6 +527,8 @@ void TranslationDomain::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_translation_object", "locale"), &TranslationDomain::get_translation_object);
 #endif
 
+	ClassDB::bind_method(D_METHOD("is_fallback_allowed"), &TranslationDomain::is_fallback_allowed);
+	ClassDB::bind_method(D_METHOD("set_fallback_allowed", "enabled"), &TranslationDomain::set_fallback_allowed);
 	ClassDB::bind_method(D_METHOD("set_fallback_locale", "locale"), &TranslationDomain::set_fallback_locale);
 	ClassDB::bind_method(D_METHOD("get_fallback_locale"), &TranslationDomain::get_fallback_locale);
 	ClassDB::bind_method(D_METHOD("add_translation", "translation"), &TranslationDomain::add_translation);

--- a/core/string/translation_domain.cpp
+++ b/core/string/translation_domain.cpp
@@ -273,6 +273,22 @@ Ref<Translation> TranslationDomain::get_translation_object(const String &p_local
 }
 #endif
 
+void TranslationServer::set_fallback_allowed(const bool &p_allow) {
+	allow_fallback = p_allow;
+}
+
+bool TranslationServer::is_fallback_allowed() const {
+	return allow_fallback;
+}
+
+void TranslationDomain::set_fallback_locale(const String &p_locale) {
+	fallback = p_locale;
+}
+
+String TranslationDomain::get_fallback_locale() const {
+	return fallback;
+}
+
 void TranslationDomain::add_translation(const Ref<Translation> &p_translation) {
 	ERR_FAIL_COND_MSG(p_translation.is_null(), "Invalid translation provided.");
 	translations.insert(p_translation);
@@ -357,10 +373,10 @@ StringName TranslationDomain::translate(const StringName &p_message, const Strin
 	const String &locale = locale_override.is_empty() ? TranslationServer::get_singleton()->get_locale() : locale_override;
 	StringName res = get_message_from_translations(locale, p_message, p_context);
 
-	const bool &allow_fallback = TranslationServer::get_singleton()->is_fallback_allowed();
-	const String &fallback = TranslationServer::get_singleton()->get_fallback_locale();
-	if (!res && allow_fallback && fallback.length() >= 2) {
-		res = get_message_from_translations(fallback, p_message, p_context);
+	const bool &allow_fallback = is_fallback_allowed();
+	const String &fallback_locale = get_fallback_locale();
+	if (!res && allow_fallback && fallback_locale.length() >= 2) {
+		res = get_message_from_translations(fallback_locale, p_message, p_context);
 	}
 
 	if (!res) {
@@ -377,10 +393,10 @@ StringName TranslationDomain::translate_plural(const StringName &p_message, cons
 	const String &locale = locale_override.is_empty() ? TranslationServer::get_singleton()->get_locale() : locale_override;
 	StringName res = get_message_from_translations(locale, p_message, p_message_plural, p_n, p_context);
 
-	const bool &allow_fallback = TranslationServer::get_singleton()->is_fallback_allowed();
-	const String &fallback = TranslationServer::get_singleton()->get_fallback_locale();
+	const bool &allow_fallback = is_fallback_allowed();
+	const String &fallback_locale = get_fallback_locale();
 	if (!res && allow_fallback && fallback.length() >= 2) {
-		res = get_message_from_translations(fallback, p_message, p_message_plural, p_n, p_context);
+		res = get_message_from_translations(fallback_locale, p_message, p_message_plural, p_n, p_context);
 	}
 
 	if (!res) {
@@ -511,6 +527,8 @@ void TranslationDomain::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_translation_object", "locale"), &TranslationDomain::get_translation_object);
 #endif
 
+	ClassDB::bind_method(D_METHOD("set_fallback_locale", "locale"), &TranslationDomain::set_fallback_locale);
+	ClassDB::bind_method(D_METHOD("get_fallback_locale"), &TranslationDomain::get_fallback_locale);
 	ClassDB::bind_method(D_METHOD("add_translation", "translation"), &TranslationDomain::add_translation);
 	ClassDB::bind_method(D_METHOD("remove_translation", "translation"), &TranslationDomain::remove_translation);
 	ClassDB::bind_method(D_METHOD("clear"), &TranslationDomain::clear);

--- a/core/string/translation_domain.h
+++ b/core/string/translation_domain.h
@@ -50,6 +50,8 @@ class TranslationDomain : public RefCounted {
 	};
 
 	bool enabled = true;
+	bool allow_fallback = true;
+	String fallback;
 
 	String locale_override;
 	HashSet<Ref<Translation>> translations;
@@ -76,6 +78,10 @@ public:
 	// These two methods are public for easier TranslationServer bindings.
 	TypedArray<Translation> get_translations_bind() const;
 	TypedArray<Translation> find_translations_bind(const String &p_locale, bool p_exact) const;
+	void set_fallback_allowed(const bool &p_allow);
+	bool is_fallback_allowed() const;
+	void set_fallback_locale(const String &p_locale);
+	String get_fallback_locale() const;
 
 #ifndef DISABLE_DEPRECATED
 	Ref<Translation> get_translation_object(const String &p_locale) const;

--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -499,19 +499,19 @@ String TranslationServer::get_locale() const {
 }
 
 void TranslationServer::set_fallback_allowed(const bool &p_allow) {
-	allow_fallback = p_allow;
+	main_domain->set_fallback_allowed(p_allow);
 }
 
 bool TranslationServer::is_fallback_allowed() const {
-	return allow_fallback;
+	return main_domain->is_fallback_allowed();
 }
 
 void TranslationServer::set_fallback_locale(const String &p_locale) {
-	fallback = p_locale;
+	main_domain->set_fallback_locale(p_locale);
 }
 
 String TranslationServer::get_fallback_locale() const {
-	return fallback;
+	return main_domain->get_fallback_locale();
 }
 
 bool TranslationServer::is_script_suppored_by_locale(const String &p_locale, const String &p_script) const {
@@ -590,6 +590,7 @@ Ref<TranslationDomain> TranslationServer::get_or_add_domain(const StringName &p_
 		ERR_PRINT("Bug (please report): Found invalid translation domain.");
 	}
 	Ref<TranslationDomain> new_domain = memnew(TranslationDomain);
+	new_domain->set_fallback_locale(GLOBAL_DEF("internationalization/locale/fallback", "en"));
 	custom_domains[p_domain] = new_domain;
 	return new_domain;
 }
@@ -608,8 +609,8 @@ void TranslationServer::setup() {
 		set_locale(OS::get_singleton()->get_locale());
 	}
 
-	fallback = GLOBAL_DEF("internationalization/locale/fallback", "en");
-	allow_fallback = GLOBAL_DEF("internationalization/locale/allow_fallback", true);
+	main_domain->set_fallback_locale(GLOBAL_DEF("internationalization/locale/fallback", "en"));
+	main_domain->set_fallback_allowed(GLOBAL_DEF("internationalization/locale/allow_fallback", true));
 	main_domain->set_pseudolocalization_enabled(GLOBAL_DEF("internationalization/pseudolocalization/use_pseudolocalization", false));
 	main_domain->set_pseudolocalization_accents_enabled(GLOBAL_DEF("internationalization/pseudolocalization/replace_with_accents", true));
 	main_domain->set_pseudolocalization_double_vowels_enabled(GLOBAL_DEF("internationalization/pseudolocalization/double_vowels", false));
@@ -649,7 +650,7 @@ String TranslationServer::get_tool_locale() {
 			}
 		}
 	}
-	return res.is_valid() ? res->get_locale() : fallback;
+	return res.is_valid() ? res->get_locale() : main_domain->get_fallback_locale();
 }
 
 bool TranslationServer::is_pseudolocalization_enabled() const {
@@ -713,6 +714,8 @@ void TranslationServer::get_argument_options(const StringName &p_function, int p
 void TranslationServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_locale", "locale"), &TranslationServer::set_locale);
 	ClassDB::bind_method(D_METHOD("get_locale"), &TranslationServer::get_locale);
+	ClassDB::bind_method(D_METHOD("set_fallback_locale", "locale"), &TranslationServer::set_fallback_locale);
+	ClassDB::bind_method(D_METHOD("get_fallback_locale"), &TranslationServer::get_fallback_locale);
 	ClassDB::bind_method(D_METHOD("get_tool_locale"), &TranslationServer::get_tool_locale);
 
 	ClassDB::bind_method(D_METHOD("compare_locales", "locale_a", "locale_b"), &TranslationServer::compare_locales);

--- a/core/string/translation_server.h
+++ b/core/string/translation_server.h
@@ -37,8 +37,6 @@ class TranslationServer : public Object {
 	GDCLASS(TranslationServer, Object);
 
 	String locale = "en";
-	bool allow_fallback = true;
-	String fallback;
 
 	Ref<TranslationDomain> main_domain;
 #ifdef TOOLS_ENABLED

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1727,11 +1727,13 @@
 			If [code]true[/code], the magnetometer sensor is enabled and [method Input.get_magnetometer] returns valid data.
 		</member>
 		<member name="internationalization/locale/allow_fallback" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], the locale will fall back to [member internationalization/locale/fallback] when a translation isn't available in a given language.
+			The default value of [member TranslationDomain.allow_fallback] when creating a new [TranslationDomain]
+			If [code]true[/code], the locale will fall back to [member TranslationDomain.fallback] when a translation isn't available in a given language.
 			[b]Note:[/b] Not to be confused with [TextServerFallback].
 		</member>
 		<member name="internationalization/locale/fallback" type="String" setter="" getter="" default="&quot;en&quot;">
 			The locale to fall back to if a translation isn't available in a given language if [member internationalization/locale/allow_fallback] is [code]true[/code]. If left empty, [code]en[/code] (English) will be used.
+			The default locale to fall back to if a translation isn't available in a given language when creating a new [TranslationDomain]. If left empty, [code]en[/code] (English) will be used.
 			[b]Note:[/b] Not to be confused with [TextServerFallback].
 		</member>
 		<member name="internationalization/locale/include_text_server_data" type="bool" setter="" getter="" default="false">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1727,7 +1727,6 @@
 			If [code]true[/code], the magnetometer sensor is enabled and [method Input.get_magnetometer] returns valid data.
 		</member>
 		<member name="internationalization/locale/allow_fallback" type="bool" setter="" getter="" default="true">
-			The default value of [member TranslationDomain.allow_fallback] when creating a new [TranslationDomain]
 			If [code]true[/code], the locale will fall back to [member internationalization/locale/fallback] by default when a translation isn't available in a given language.
 			[b]Note:[/b] Not to be confused with [TextServerFallback].
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1728,7 +1728,7 @@
 		</member>
 		<member name="internationalization/locale/allow_fallback" type="bool" setter="" getter="" default="true">
 			The default value of [member TranslationDomain.allow_fallback] when creating a new [TranslationDomain]
-			If [code]true[/code], the locale will fall back to [internationalization/locale/fallback] by default when a translation isn't available in a given language.
+			If [code]true[/code], the locale will fall back to [member internationalization/locale/fallback] by default when a translation isn't available in a given language.
 			[b]Note:[/b] Not to be confused with [TextServerFallback].
 		</member>
 		<member name="internationalization/locale/fallback" type="String" setter="" getter="" default="&quot;en&quot;">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1728,7 +1728,7 @@
 		</member>
 		<member name="internationalization/locale/allow_fallback" type="bool" setter="" getter="" default="true">
 			The default value of [member TranslationDomain.allow_fallback] when creating a new [TranslationDomain]
-			If [code]true[/code], the locale will fall back to [member TranslationDomain.fallback] when a translation isn't available in a given language.
+			If [code]true[/code], the locale will fall back to [internationalization/locale/fallback] by default when a translation isn't available in a given language.
 			[b]Note:[/b] Not to be confused with [TextServerFallback].
 		</member>
 		<member name="internationalization/locale/fallback" type="String" setter="" getter="" default="&quot;en&quot;">

--- a/doc/classes/TranslationDomain.xml
+++ b/doc/classes/TranslationDomain.xml
@@ -125,7 +125,7 @@
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
 			If [code]true[/code], translation is enabled. Otherwise, [method translate] and [method translate_plural] will return the input message unchanged regardless of the current locale.
 		</member>
-		<member name="fallback_allowed" type="bool" setter="set_fallback_allowed" getter="is_fallback_allowed" default="true">
+		<member name="allow_fallback" type="bool" setter="set_fallback_allowed" getter="is_fallback_allowed" default="true">
 			If [code]true[/code], the locale will fall back to [member allow_fallback] when a translation isn't available in a given language.
 		</member>
 		<member name="pseudolocalization_accents_enabled" type="bool" setter="set_pseudolocalization_accents_enabled" getter="is_pseudolocalization_accents_enabled" default="true">

--- a/doc/classes/TranslationDomain.xml
+++ b/doc/classes/TranslationDomain.xml
@@ -71,6 +71,12 @@
 				Returns [code]true[/code] if there are any [Translation] instances that match [param locale] (see [method TranslationServer.compare_locales]). If [param exact] is [code]true[/code], only instances whose locale exactly equals [param locale] are considered.
 			</description>
 		</method>
+		<method name="is_fallback_allowed" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if fall back is allowed.
+			</description>
+		</method>
 		<method name="pseudolocalize" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="message" type="StringName" />
@@ -83,6 +89,13 @@
 			<param index="0" name="translation" type="Translation" />
 			<description>
 				Removes the given translation.
+			</description>
+		</method>
+		<method name="set_fallback_allowed">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				Sets whether fall back is allowed.
 			</description>
 		</method>
 		<method name="set_fallback_locale">
@@ -124,9 +137,6 @@
 	<members>
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
 			If [code]true[/code], translation is enabled. Otherwise, [method translate] and [method translate_plural] will return the input message unchanged regardless of the current locale.
-		</member>
-		<member name="allow_fallback" type="bool" setter="set_fallback_allowed" getter="is_fallback_allowed" default="true">
-			If [code]true[/code], the locale will fall back to [member allow_fallback] when a translation isn't available in a given language.
 		</member>
 		<member name="pseudolocalization_accents_enabled" type="bool" setter="set_pseudolocalization_accents_enabled" getter="is_pseudolocalization_accents_enabled" default="true">
 			Replace all characters with their accented variants during pseudolocalization.

--- a/doc/classes/TranslationDomain.xml
+++ b/doc/classes/TranslationDomain.xml
@@ -31,6 +31,12 @@
 				Returns the [Translation] instances that match [param locale] (see [method TranslationServer.compare_locales]). If [param exact] is [code]true[/code], only instances whose locale exactly equals [param locale] will be returned.
 			</description>
 		</method>
+		<method name="get_fallback_locale" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the locale to fall back to if a translation isn't available in a given language.
+			</description>
+		</method>
 		<method name="get_locale_override" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -79,6 +85,13 @@
 				Removes the given translation.
 			</description>
 		</method>
+		<method name="set_fallback_locale">
+			<return type="void" />
+			<param index="0" name="locale" type="String" />
+			<description>
+				Sets the locale to fall back to if a translation isn't available in a given language.
+			</description>
+		</method>
 		<method name="set_locale_override">
 			<return type="void" />
 			<param index="0" name="locale" type="String" />
@@ -111,6 +124,9 @@
 	<members>
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
 			If [code]true[/code], translation is enabled. Otherwise, [method translate] and [method translate_plural] will return the input message unchanged regardless of the current locale.
+		</member>
+		<member name="fallback_allowed" type="bool" setter="set_fallback_allowed" getter="is_fallback_allowed" default="true">
+			If [code]true[/code], the locale will fall back to [member allow_fallback] when a translation isn't available in a given language.
 		</member>
 		<member name="pseudolocalization_accents_enabled" type="bool" setter="set_pseudolocalization_accents_enabled" getter="is_pseudolocalization_accents_enabled" default="true">
 			Replace all characters with their accented variants during pseudolocalization.

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -74,6 +74,12 @@
 				Returns a readable country name for the [param country] code.
 			</description>
 		</method>
+		<method name="get_fallback_locale" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the locale to fall back to if a translation isn't available in a given language.
+			</description>
+		</method>
 		<method name="get_language_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="language" type="String" />
@@ -206,6 +212,13 @@
 			<param index="0" name="translation" type="Translation" />
 			<description>
 				Removes the given translation from the main translation domain.
+			</description>
+		</method>
+		<method name="set_fallback_locale">
+			<return type="void" />
+			<param index="0" name="locale" type="String" />
+			<description>
+				Sets the locale to fall back to if a translation isn't available in a given language.
 			</description>
 		</method>
 		<method name="set_locale">


### PR DESCRIPTION
Move `fallback_locale` & `allow_fallback` from `TranslationServer` to `TranslationDomain` and expose for edit
This change can allow users use different fallback locale in different `TranslationDomain`

e.g., game uses `zh_CN` as fallback since it's author's native language; And in UGCs uses `en_US` as fallback for i18n