### PR TITLE
FTI: Fix property release updates

### DIFF
--- a/core/templates/interpolated_property.h
+++ b/core/templates/interpolated_property.h
@@ -46,6 +46,12 @@ class InterpolatedProperty {
 	// Only needs interpolating / updating the servers when
 	// curr and prev are different.
 	bool _needs_interpolating = false;
+
+	// Each time we hit a physics tick, curr = prev,
+	// BUT the server may be out of date, and needs an update
+	// on the next frame, OR taking the node off the property update list.
+	bool _server_stale = false;
+
 	T _interpolated;
 	T curr;
 	T prev;
@@ -57,6 +63,7 @@ public:
 	void pump() {
 		prev = curr;
 		_needs_interpolating = false;
+		_server_stale = true;
 	}
 	void reset() { pump(); }
 
@@ -64,11 +71,16 @@ public:
 		_interpolated = p_val;
 	}
 	const T &interpolated() const { return _interpolated; }
-	bool needs_interpolating() const { return _needs_interpolating; }
 
+	// Returns true if an update to the server is needed.
 	bool interpolate(float p_interpolation_fraction) {
 		if (_needs_interpolating) {
 			_interpolated = InterpolatedPropertyFuncs::lerp(prev, curr, p_interpolation_fraction);
+			return true;
+		}
+		if (_server_stale) {
+			_interpolated = curr;
+			_server_stale = false;
 			return true;
 		}
 		return false;

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -70,22 +70,28 @@ void Camera3D::fti_update_servers_property() {
 	if (camera.is_valid()) {
 		float f = Engine::get_singleton()->get_physics_interpolation_fraction();
 
+		bool update_fov = fov.interpolate(f);
+		bool update_near = _near.interpolate(f);
+		bool update_far = _far.interpolate(f);
+		bool update_size = size.interpolate(f);
+		bool update_frustum_offset = frustum_offset.interpolate(f);
+
+		// If there have been changes due to interpolated values, OR we are forcing an update, update the servers.
 		switch (mode) {
 			default:
 				break;
 			case PROJECTION_PERSPECTIVE: {
-				// If there have been changes due to interpolation, update the servers.
-				if (fov.interpolate(f) || _near.interpolate(f) || _far.interpolate(f)) {
+				if (update_fov || update_near || update_far) {
 					RS::get_singleton()->camera_set_perspective(camera, fov.interpolated(), _near.interpolated(), _far.interpolated());
 				}
 			} break;
 			case PROJECTION_ORTHOGONAL: {
-				if (size.interpolate(f) || _near.interpolate(f) || _far.interpolate(f)) {
+				if (update_size || update_near || update_far) {
 					RS::get_singleton()->camera_set_orthogonal(camera, size.interpolated(), _near.interpolated(), _far.interpolated());
 				}
 			} break;
 			case PROJECTION_FRUSTUM: {
-				if (size.interpolate(f) || frustum_offset.interpolate(f) || _near.interpolate(f) || _far.interpolate(f)) {
+				if (update_size || update_frustum_offset || update_near || update_far) {
 					RS::get_singleton()->camera_set_frustum(camera, size.interpolated(), frustum_offset.interpolated(), _near.interpolated(), _far.interpolated());
 				}
 			} break;


### PR DESCRIPTION
Ensures properties are correctly updated to the server when being removed from the property update list.

Fixes #116567.
Forward port of #117823.

The update when removing a node from the property update list was being called (`fti_update_servers_property`), _however_ it was not actually updating the server thanks to an optimization that only updates when `needs_interpolating` is true.

This PR fixes 2 bugs:
* By using a stale flag, it ensures there is an update to the server following a pump when no new data is coming in. It either does this on the following frame, or the following tick, whichever comes first.
* I noticed there was a subtle bug in the existing `||` condition for calling `interpolated()` - if the first statement returned true, the later ones never ran, and thus only the first property would be interpolated.
* The solution here was to force each condition to run longhand, store in a temporary variable, then evaluate the `||` condition afterwards.
* I'm actually evaluating _all_ the interpolated properties each time, ,even though usually only 3 are needed for each camera mode. This is slightly wasteful but there is usually only one camera at a time, so code clarity and brevity should be more important.

## Notes
* This was a slight oversight, and hadn't appeared in testing because it is only obvious at high tick rates and most testing was done with low tick rates.
* This is now more elegant than the original approach of forcing an update on releasing nodes from the property update list, and ensures server updates are kept to a minimum (1 in all cases).

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
