### PR TITLE
Restore bounds for Quick Open and all dialogs that inherit AcceptDialog

### DIFF
--- a/editor/doc/editor_help_search.cpp
+++ b/editor/doc/editor_help_search.cpp
@@ -217,7 +217,6 @@ void EditorHelpSearch::_notification(int p_what) {
 				search = Ref<Runner>();
 				callable_mp(results_tree, &Tree::clear).call_deferred(); // Wait for the Tree's mouse event propagation.
 				get_ok_button()->set_disabled(true);
-				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "search_help", Rect2(get_position(), get_size()));
 			}
 		} break;
 
@@ -277,13 +276,7 @@ void EditorHelpSearch::popup_dialog() {
 }
 
 void EditorHelpSearch::popup_dialog(const String &p_term) {
-	// Restore valid window bounds or pop up at default size.
-	Rect2 saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "search_help", Rect2());
-	if (saved_size != Rect2()) {
-		popup(saved_size);
-	} else {
-		popup_centered_ratio(0.5F);
-	}
+	popup_centered_ratio(0.5F);
 
 	old_search_flags = 0;
 	if (p_term.is_empty()) {

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -106,7 +106,6 @@ void ProjectExportDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_visible()) {
-				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "export", Rect2(get_position(), get_size()));
 				show_script_key->set_pressed(false);
 			}
 		} break;
@@ -147,13 +146,7 @@ void ProjectExportDialog::popup_export() {
 		_update_current_preset(); // triggers rescan for templates if newly installed
 	}
 
-	// Restore valid window bounds or pop up at default size.
-	Rect2 saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "export", Rect2());
-	if (saved_size != Rect2()) {
-		popup(saved_size);
-	} else {
-		popup_centered_clamped(Size2(900, 500) * EDSCALE, 0.7);
-	}
+	popup_centered_clamped(Size2(900, 500) * EDSCALE, 0.7);
 }
 
 void ProjectExportDialog::_add_preset(int p_platform) {

--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -74,13 +74,7 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 	_load_favorites_and_history();
 	_save_and_update_favorite_list();
 
-	// Restore valid window bounds or pop up at default size.
-	Rect2 saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "create_new_node", Rect2());
-	if (saved_size != Rect2()) {
-		popup(saved_size);
-	} else {
-		popup_centered_clamped(Size2(900, 700) * EDSCALE, 0.8);
-	}
+	popup_centered_clamped(Size2(900, 700) * EDSCALE, 0.8);
 }
 
 void CreateDialog::for_inherit() {
@@ -570,7 +564,6 @@ void CreateDialog::_notification(int p_what) {
 				callable_mp((Control *)search_box, &Control::grab_focus).call_deferred(false); // Still not visible.
 				search_box->select_all();
 			} else {
-				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "create_new_node", Rect2(get_position(), get_size()));
 			}
 		} break;
 

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -225,15 +225,7 @@ void EditorSettingsDialog::popup_edit_settings() {
 	_update_shortcuts();
 	set_process_shortcut_input(true);
 
-	// Restore valid window bounds or pop up at default size.
-	Rect2 saved_size;
-	if (!_is_in_project_manager()) {
-		saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "editor_settings", Rect2());
-	}
-
-	if (saved_size != Rect2()) {
-		popup(saved_size);
-	} else if (_is_in_project_manager()) {
+	if (_is_in_project_manager()) {
 		popup_centered_clamped(Size2(800, 600) * EDSCALE, 0.8); // Make it smaller that the default Project Manager size.
 	} else {
 		popup_centered_clamped(Size2(900, 700) * EDSCALE, 0.8);
@@ -258,7 +250,6 @@ void EditorSettingsDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_visible() && !_is_in_project_manager()) {
-				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "editor_settings", Rect2(get_position(), get_size()));
 				set_process_shortcut_input(false);
 			}
 		} break;

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -51,13 +51,7 @@ void ProjectSettingsEditor::connect_filesystem_dock_signals(FileSystemDock *p_fs
 }
 
 void ProjectSettingsEditor::popup_project_settings(bool p_clear_filter) {
-	// Restore valid window bounds or pop up at default size.
-	Rect2 saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "project_settings", Rect2());
-	if (saved_size != Rect2()) {
-		popup(saved_size);
-	} else {
-		popup_centered_clamped(Size2(1200, 700) * EDSCALE, 0.8);
-	}
+	popup_centered_clamped(Size2(1200, 700) * EDSCALE, 0.8);
 
 	_add_feature_overrides();
 	general_settings_inspector->update_category_list();
@@ -661,7 +655,6 @@ void ProjectSettingsEditor::_notification(int p_what) {
 				}
 				ProjectSettings::get_singleton()->editor_settings_info = editor_settings_info;
 			} else {
-				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "project_settings", Rect2(get_position(), get_size()));
 				if (settings_changed) {
 					timer->stop();
 					_save();

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -38,6 +38,10 @@
 #include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"
 
+#ifdef TOOLS_ENABLED
+#include "editor/settings/editor_settings.h"
+#endif
+
 // AcceptDialog
 
 void AcceptDialog::_input_from_window(const Ref<InputEvent> &p_event) {
@@ -45,6 +49,17 @@ void AcceptDialog::_input_from_window(const Ref<InputEvent> &p_event) {
 		_cancel_pressed();
 	}
 	Window::_input_from_window(p_event);
+}
+
+Rect2i AcceptDialog::_popup_adjust_rect() const {
+	Rect2i rect = Window::_popup_adjust_rect();
+#ifdef TOOLS_ENABLED
+	rect = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", this->get_class_name(), Rect2i());
+	if (rect != Rect2i()) {
+		return rect;
+	}
+#endif
+	return rect;
 }
 
 void AcceptDialog::_parent_focused() {
@@ -78,6 +93,9 @@ void AcceptDialog::_notification(int p_what) {
 					parent_visible->connect(SceneStringName(focus_entered), callable_mp(this, &AcceptDialog::_parent_focused));
 				}
 			} else {
+#ifdef TOOLS_ENABLED
+				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", this->get_class_name(), Rect2i(get_position(), get_size()));
+#endif
 				popped_up = false;
 				if (parent_visible) {
 					parent_visible->disconnect(SceneStringName(focus_entered), callable_mp(this, &AcceptDialog::_parent_focused));

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -75,6 +75,7 @@ class AcceptDialog : public Window {
 protected:
 	virtual Size2 _get_contents_minimum_size() const override;
 	virtual void _input_from_window(const Ref<InputEvent> &p_event) override;
+	virtual Rect2i _popup_adjust_rect() const override;
 	virtual void _post_popup() override;
 
 	void _notification(int p_what);


### PR DESCRIPTION
This PR adds persistence for dialog bounds (position and size) for the Quick Open, Scene Tree dialogs etc. similar to how it is handled in the Create Dialog, as a lightweight alternative for #106648
Close https://github.com/godotengine/godot-proposals/issues/5005

The previous PR introduced a `session_id` to make dialog bounds restoration work in-game. However, that approach still has some unresolved issues and maybe requires further adjustments to integrate.

This PR proposes a less intrusive solution that aligns with the current implementation of Create Dialog, allowing this feature to be completed sooner. A more comprehensive refactor, either of the existing approach or at the project level, can be considered in the future.

![47af9e74-a80e-4be7-966e-a65dad829287](https://github.com/user-attachments/assets/70a03a20-9876-43ee-ae87-51cd96930a49)