### PR TITLE
Change `GDScriptFunction::temporary_slots` to be a `LocalVector`

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -189,7 +189,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 			opcodes.write[temporaries[i].bytecode_indices[j]] = stack_index | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
 		}
 		if (temporaries[i].type != Variant::NIL) {
-			function->temporary_slots[stack_index] = temporaries[i].type;
+			function->temporary_slots.push_back(Pair(stack_index, temporaries[i].type));
 		}
 	}
 

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -360,7 +360,7 @@ private:
 
 	SelfList<GDScriptFunction> function_list{ this };
 	mutable Variant nil;
-	HashMap<int, Variant::Type> temporary_slots;
+	TightLocalVector<Pair<int, Variant::Type>> temporary_slots;
 	List<StackDebug> stack_debug;
 
 	Vector<int> code;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -648,8 +648,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			instruction_args = nullptr;
 		}
 
-		for (const KeyValue<int, Variant::Type> &E : temporary_slots) {
-			type_init_function_table[E.value](&stack[E.key]);
+		for (const Pair<int, Variant::Type> &E : temporary_slots) {
+			type_init_function_table[E.second](&stack[E.first]);
 		}
 	}
 


### PR DESCRIPTION
I ran into this seemingly low-hanging fruit while doing some profiling.

These are the results we're seeing in `GDScriptFunction::call`, in a real-world project using a fork of 4.6.1-stable, when running the exact same replay of the game both times, on an AMD 9950X3D running Fedora 43.

Before:

<img width="789" height="278" alt="Before" src="https://github.com/user-attachments/assets/7970ff88-9961-4f2f-9ac0-942f0357ebd7" />

After:

<img width="792" height="283" alt="After" src="https://github.com/user-attachments/assets/1b997710-f9e4-4cd6-a630-f8d4339f0010" />

The leftmost number in the gutter is probably the more interesting one in this case, as it represents how many of the `GDScriptFunction:call` samples it made up.

~~This `temporary_slots` doesn't really need to be a map at all, since there's no actual lookup happening, and could just as well be a `LocalVector<Pair<int, Variant::Type>>` instead, but the performance gains were identical, so I opted for this smaller change. I'm fine with either one though.~~

(I tried also ditching `type_init_function_table` in favor of an explicit `switch`, but saw surprisingly little gains.)