### PR TITLE
[Editor] Display current Git branch and dirty status

### DIFF
--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -42,6 +42,8 @@ def version_hash_builder(target, source, env):
 
 const char *const GODOT_VERSION_HASH = "{git_hash}";
 const unsigned long long GODOT_VERSION_TIMESTAMP = {git_timestamp};
+const bool GODOT_VERSION_GIT_DIRTY = {git_dirty};
+const char *const GODOT_VERSION_GIT_BRANCH = "{git_current_branch}";
 """.format(**source[0].read())
         )
 

--- a/core/version.h
+++ b/core/version.h
@@ -85,6 +85,14 @@ extern const char *const GODOT_VERSION_HASH;
 // Set to 0 if unknown.
 extern const unsigned long long GODOT_VERSION_TIMESTAMP;
 
+// Determines if the build was based on modified git tracked files, generated at build time in `core/version_hash.gen.cpp`.
+// Set to `false` if unknown.
+extern const bool GODOT_VERSION_GIT_DIRTY;
+
+// Git branch name of the build, generated at build time in `core/version_hash.gen.cpp`.
+// Set to `""` if unknown.
+extern const char *const GODOT_VERSION_GIT_BRANCH;
+
 #ifndef DISABLE_DEPRECATED
 // Compatibility with pre-4.5 modules.
 #define VERSION_SHORT_NAME GODOT_VERSION_SHORT_NAME

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5963,10 +5963,36 @@ String EditorNode::_get_system_info() const {
 	const String distribution_version = OS::get_singleton()->get_version_alias();
 
 	String godot_version = "Godot v" + String(GODOT_VERSION_FULL_CONFIG);
+
 	if (String(GODOT_VERSION_BUILD) != "official") {
-		String hash = String(GODOT_VERSION_HASH);
-		hash = hash.is_empty() ? String("unknown") : vformat("(%s)", hash.left(9));
-		godot_version += " " + hash;
+		String hash = GODOT_VERSION_HASH;
+		String branch = GODOT_VERSION_GIT_BRANCH;
+		StringBuilder git_data;
+
+		git_data.append(" ");
+
+		if (hash.is_empty()) {
+			git_data.append("unknown");
+		} else {
+			git_data.append(hash.left(9));
+		}
+
+		if (!branch.is_empty() && branch == "master") {
+			branch = "";
+		}
+
+		if (!branch.is_empty()) {
+			git_data.append(vformat("@%s", branch));
+		}
+
+		if (GODOT_VERSION_GIT_DIRTY) {
+			if (!hash.is_empty() || !branch.is_empty()) {
+				git_data.append(" ");
+			}
+			git_data.append("(dirty)");
+		}
+
+		godot_version += git_data.as_string();
 	}
 
 	String display_session_type;

--- a/editor/gui/editor_version_button.cpp
+++ b/editor/gui/editor_version_button.cpp
@@ -31,14 +31,52 @@
 #include "editor_version_button.h"
 
 #include "core/os/time.h"
+#include "core/string/string_builder.h"
 #include "core/version.h"
 #include "servers/display/display_server.h"
 
 String _get_version_string(EditorVersionButton::VersionFormat p_format) {
 	String main;
+	String hash = GODOT_VERSION_HASH;
+	String branch = GODOT_VERSION_GIT_BRANCH;
+	const int BRANCH_MAX_LENGTH = 20;
+	StringBuilder git_data;
+
+	if (!hash.is_empty() || !branch.is_empty() || GODOT_VERSION_GIT_DIRTY) {
+		git_data.append(" ");
+
+		if (p_format == EditorVersionButton::FORMAT_WITH_BUILD || p_format == EditorVersionButton::FORMAT_WITH_NAME_AND_BUILD) {
+			if (!hash.is_empty()) {
+				git_data.append(hash.left(9));
+			}
+		} else if (!hash.is_empty()) {
+			hash = "";
+		}
+
+		if (!branch.is_empty() && branch == "master") {
+			branch = "";
+		}
+
+		if (!branch.is_empty()) {
+			// The KoBeWi clause.
+			if (branch.length() > BRANCH_MAX_LENGTH) {
+				branch = vformat("%s…", branch.substr(0, BRANCH_MAX_LENGTH));
+			}
+
+			git_data.append(vformat("@%s", branch));
+		}
+
+		if (GODOT_VERSION_GIT_DIRTY) {
+			if (!hash.is_empty() || !branch.is_empty()) {
+				git_data.append(" ");
+			}
+			git_data.append("(dirty)");
+		}
+	}
+
 	switch (p_format) {
 		case EditorVersionButton::FORMAT_BASIC: {
-			return GODOT_VERSION_FULL_CONFIG;
+			return GODOT_VERSION_FULL_CONFIG + git_data.as_string();
 		} break;
 		case EditorVersionButton::FORMAT_WITH_BUILD: {
 			main = "v" GODOT_VERSION_FULL_BUILD;
@@ -51,11 +89,7 @@ String _get_version_string(EditorVersionButton::VersionFormat p_format) {
 		} break;
 	}
 
-	String hash = GODOT_VERSION_HASH;
-	if (!hash.is_empty()) {
-		hash = vformat(" [%s]", hash.left(9));
-	}
-	return main + hash;
+	return main + git_data.as_string();
 }
 
 void EditorVersionButton::_notification(int p_what) {

--- a/methods.py
+++ b/methods.py
@@ -206,20 +206,41 @@ def get_git_info():
         else:
             git_hash = head
 
-    # Get the UNIX timestamp of the build commit.
+    # UNIX timestamp of the build commit.
     git_timestamp = 0
+    git_dirty = False
+    git_current_branch = ""
     if os.path.exists(".git"):
         try:
             git_timestamp = subprocess.check_output(
-                ["git", "log", "-1", "--pretty=format:%ct", "--no-show-signature", git_hash], encoding="utf-8"
+                ["git", "log", "-1", "--pretty=format:%ct", "--no-show-signature", git_hash],
+                encoding="utf-8",
             )
-        except (subprocess.CalledProcessError, OSError):
-            # `git` not found in PATH.
+
+            changed_files = subprocess.check_output(
+                ["git", "status", "--porcelain"],
+                encoding="utf-8",
+            )
+            git_dirty = len(changed_files) > 0
+
+            git_current_branch = subprocess.check_output(
+                ["git", "branch", "--show-current"],
+                encoding="utf-8",
+            ).strip()
+            if len(git_current_branch) == 0:
+                git_current_branch = "<detached HEAD>"
+        except subprocess.CalledProcessError:
+            # `git` returned an error.
+            raise
+        except (FileNotFoundError, OSError):
+            # `git` not found in PATH, we can rely on default values.
             pass
 
     return {
         "git_hash": git_hash,
         "git_timestamp": git_timestamp,
+        "git_dirty": "true" if git_dirty else "false",
+        "git_current_branch": git_current_branch,
     }
 
 


### PR DESCRIPTION
![Capture d’écran, le 2026-03-25 à 11 26 59](https://github.com/user-attachments/assets/f94defdf-76cc-4ddf-832f-e952f407712d)

This PR adds more Git data to the editor.
- On the version button at the bottom right of the editor.
- The text copied to the clipboard when clicking on that previous button.
- The "Copy System Info" text from the toolbar menu.

Essentially, it adds:
- the build branch (if it's not master)
- if the build was dirty or not (if `git status` returns some unstaged files (new or edited))