### PR TITLE
Issue template improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,11 +5,13 @@ body:
   - type: markdown
     attributes:
       value: |
+        See [how to write a good issue report](https://contributing.godotengine.org/en/latest/feedback/issue_report_writing.html) for detailed instructions. Make sure you have read this page before reporting issues.
+
+        **Before opening an issue, please follow [these steps](https://contributing.godotengine.org/en/latest/feedback/issue_report_writing.html#before-opening-an-issue).**
+
         When reporting bugs, please follow the guidelines in this template. This helps identify the problem precisely and thus enables contributors to fix it faster.
         - Write a descriptive issue title above.
         - The golden rule is to **always open *one* issue for *one* bug**. If you notice several bugs and want to report them, make sure to create one new issue for each of them.
-        - Search [open](https://github.com/godotengine/godot/issues) and [closed](https://github.com/godotengine/godot/issues?q=is%3Aissue+is%3Aclosed) issues to ensure it has not already been reported. If you don't find a relevant match or if you're unsure, don't hesitate to **open a new issue**. The bugsquad will handle it from there if it's a duplicate.
-        - Verify that you are using a [supported Godot version](https://docs.godotengine.org/en/latest/about/release_policy.html). Please always check if your issue is reproducible in the latest version – it may already have been fixed!
         - If you use a custom build, please test if your issue is reproducible in official builds too. Likewise if you use any C++ modules, GDExtensions, or editor plugins, you should check if the bug is reproducible in a project without these.
 
   - type: textarea
@@ -20,6 +22,8 @@ body:
         - Please specify the Godot version you found the issue in, including the **Git commit hash** if using a development or non-official build. The exact Godot version (including the commit hash) can be copied by clicking the version shown in the editor (bottom bar) or in the project manager (top bar).
         - If you can, **please test earlier Godot versions** (previous stable branch, and development snapshots of the current feature release) and, if applicable, newer versions (development snapshots for the next feature release). Mention whether the bug is reproducible or not in the versions you tested. You can find all Godot releases in our [download archive](https://godotengine.org/download/archive/).
         - The aim is for us to identify whether a bug is a **regression**, i.e. an issue that didn't exist in a previous version, but was introduced later on, breaking existing functionality. For example, if a bug is reproducible in 4.2.stable but not in 4.1.stable, we would like you to test intermediate 4.2 dev and beta snapshots to find which snapshot is the first one where the issue can be reproduced.
+
+        For more details, see [here](https://contributing.godotengine.org/en/latest/feedback/issue_report_writing.html#the-tested-versions).
       placeholder: |
 
         - Reproducible in: 4.3.dev [d76c1d0e5], 4.2.stable, 4.2.dev5 and later 4.2 snapshots.
@@ -36,6 +40,8 @@ body:
         - For graphics-related issues, specify the GPU model, driver version, and the rendering backend (GLES2, GLES3, Vulkan).
         - **Bug reports not including the required information may be closed at the maintainers' discretion.** If in doubt, always include all the requested information; it's better to include too much information than not enough information.
         - **Starting from Godot 4.1, you can copy this information to your clipboard by using *Help > Copy System Info* at the top of the editor window.**
+
+        For more details, see [here](https://contributing.godotengine.org/en/latest/feedback/issue_report_writing.html#the-system-details).
       placeholder: Windows 10 - Godot v4.0.3.stable - Vulkan (Forward+) - dedicated NVIDIA GeForce GTX 970 (nvidia, 510.85.02) - Intel Core i7-10700KF CPU @ 3.80GHz (16 Threads)
     validations:
       required: true
@@ -47,6 +53,8 @@ body:
         Describe your issue briefly. What doesn't work, and how do you expect it to work instead?
         You can include images or videos with drag and drop, and format code blocks or logs with <code>\`\`\`</code> tags, on separate lines before and after the text. (Use <code>\`\`\`gdscript</code> to add GDScript syntax highlighting.)
         Please do not add code examples or error messages as screenshots, but as text, this helps searching for issues and testing the code. If you are reporting a bug in the editor interface, like the script editor, please provide both a screenshot *and* the text of the code to help with testing.
+
+        For more details, see [here](https://contributing.godotengine.org/en/latest/feedback/issue_report_writing.html#the-issue-description).
     validations:
       required: true
 
@@ -56,6 +64,8 @@ body:
       description: |
         List of steps or sample code that reproduces the issue. Having reproducible issues is a prerequisite for contributors to be able to solve them.
         If you include a minimal reproduction project below, you can detail how to use it here.
+
+        For more details, see [here](https://contributing.godotengine.org/en/latest/feedback/issue_report_writing.html#the-reproduction-steps).
     validations:
       required: true
 
@@ -68,5 +78,7 @@ body:
         - If the reproduction steps are not project dependent (e.g. the bug is visible in a brand new project), you can write "N/A" in the field.
         - Drag and drop a ZIP archive to upload it (max 10 MB). **Do not select another field until the project is done uploading.**
         - **Note for C# users:** If your issue is *not* C#-specific, please upload a minimal reproduction project written in GDScript. This will make it easier for contributors to reproduce the issue locally as not everyone has a .NET setup available.
+
+        For more details, see [here](https://contributing.godotengine.org/en/latest/feedback/issue_report_writing.html#the-minimal-reproduction-project-mrp).
     validations:
       required: true


### PR DESCRIPTION
Adding links to the contributor documentation and general cleaning

Will add some more details from the template that were missed in the writing of the new page, but this should get the process going of cross linking and moving information out of the template

This is ready as a first step to provide useful links in the template, after feature freeze and release I will focus on improving the doc page and moving more details out of the template, but this would be good to get as a first step before that

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
