### PR TITLE
Implement MeshRD for RenderingDevice buffers

### DIFF
--- a/doc/classes/MeshRD.xml
+++ b/doc/classes/MeshRD.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="MeshRD" inherits="Mesh" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		[Mesh] backed by caller-owned [RenderingDevice] buffers.
+	</brief_description>
+	<description>
+		[MeshRD] is a low-level mesh for GPU-generated geometry. It uses caller-supplied [RenderingDevice] buffers and can draw from an indirect command buffer.
+		Use it for procedural meshes updated from compute shaders. Use [ArrayMesh] for CPU-built mesh data.
+		[b]Note:[/b] [MeshRD] is intended for low-level usage with [RenderingDevice]. For most use cases, use [Mesh] instead.
+		[MeshRD] does not own, free, or serialize its buffers. Keep them valid while the mesh uses them.
+		Blend shapes and skinning are not supported yet.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_surface">
+			<return type="void" />
+			<param index="0" name="format" type="int" enum="Mesh.ArrayFormat" is_bitfield="true" />
+			<param index="1" name="primitive" type="int" enum="Mesh.PrimitiveType" />
+			<param index="2" name="vertex_count" type="int" />
+			<param index="3" name="vertex_buffer" type="RID" />
+			<param index="4" name="aabb" type="AABB" />
+			<param index="5" name="attribute_buffer" type="RID" default="RID()" />
+			<param index="6" name="index_count" type="int" default="0" />
+			<param index="7" name="index_buffer" type="RID" default="RID()" />
+			<param index="8" name="material" type="Material" default="null" />
+			<param index="9" name="uv_scale" type="Vector4" default="Vector4(0, 0, 0, 0)" />
+			<param index="10" name="indirect_buffer" type="RID" default="RID()" />
+			<param index="11" name="indirect_buffer_offset" type="int" default="0" />
+			<description>
+				Adds a surface from caller-owned [RenderingDevice] buffers.
+				[param format] describes the vertex layout. Provide [param vertex_buffer] unless using [constant Mesh.ARRAY_FLAG_USES_EMPTY_VERTEX_ARRAY]. Provide [param attribute_buffer] when the format uses color, UV, UV2, or custom attributes. Provide [param index_buffer] when [param index_count] is greater than [code]0[/code].
+				[param vertex_count] and [param index_count] are used for direct draws. [param aabb] sets the surface bounds. For GPU-written draw counts, use [param indirect_buffer] or [method surface_set_indirect_buffer]. Indirect buffers must use [constant RenderingDevice.STORAGE_BUFFER_USAGE_DISPATCH_INDIRECT].
+			</description>
+		</method>
+		<method name="clear_surfaces">
+			<return type="void" />
+			<description>
+				Removes all surfaces. Buffers passed to [method add_surface] are not freed.
+			</description>
+		</method>
+		<method name="surface_remove">
+			<return type="void" />
+			<param index="0" name="surf_idx" type="int" />
+			<description>
+				Removes the surface, shifting later indices down. Buffers passed to [method add_surface] are not freed.
+			</description>
+		</method>
+		<method name="surface_set_indirect_buffer">
+			<return type="void" />
+			<param index="0" name="surf_idx" type="int" />
+			<param index="1" name="indirect_buffer" type="RID" />
+			<param index="2" name="offset" type="int" default="0" />
+			<description>
+				Sets the surface's indirect draw buffer. The renderer reads one draw command at byte [param offset].
+				Pass an invalid [RID] to disable indirect drawing for this surface.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB(0, 0, 0, 0, 0, 0)">
+			Custom culling bounds. If empty, [MeshRD] uses its surface bounds.
+		</member>
+	</members>
+</class>

--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -450,6 +450,10 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RenderingServerTypes::Surfa
 	mesh->material_cache.clear();
 }
 
+void MeshStorage::mesh_add_surface_from_buffers(RID p_mesh, const RenderingServerTypes::SurfaceBuffers &p_surface) {
+	ERR_PRINT("MeshRD requires the RenderingDevice backend.");
+}
+
 void MeshStorage::_mesh_surface_clear(Mesh *mesh, int p_surface) {
 	Mesh::Surface &s = *mesh->surfaces[p_surface];
 
@@ -594,6 +598,10 @@ void MeshStorage::mesh_surface_update_index_region(RID p_mesh, int p_surface, in
 	glBindBuffer(GL_ARRAY_BUFFER, mesh->surfaces[p_surface]->index_buffer);
 	glBufferSubData(GL_ARRAY_BUFFER, p_offset, data_size, r);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+void MeshStorage::mesh_surface_set_indirect_buffer(RID p_mesh, int p_surface, RID p_indirect_buffer, int p_offset) {
+	ERR_PRINT("Mesh surface indirect buffers require the RenderingDevice backend.");
 }
 
 void MeshStorage::mesh_surface_set_material(RID p_mesh, int p_surface, RID p_material) {

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -307,6 +307,8 @@ public:
 
 	virtual void mesh_add_surface(RID p_mesh, const RenderingServerTypes::SurfaceData &p_surface) override;
 
+	virtual void mesh_add_surface_from_buffers(RID p_mesh, const RenderingServerTypes::SurfaceBuffers &p_surface) override;
+
 	virtual int mesh_get_blend_shape_count(RID p_mesh) const override;
 
 	virtual void mesh_set_blend_shape_mode(RID p_mesh, RSE::BlendShapeMode p_mode) override;
@@ -317,11 +319,12 @@ public:
 	virtual void mesh_surface_update_skin_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) override;
 	virtual void mesh_surface_update_index_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) override;
 
+	virtual void mesh_surface_set_indirect_buffer(RID p_mesh, int p_surface, RID p_indirect_buffer, int p_offset) override;
+
 	virtual void mesh_surface_set_material(RID p_mesh, int p_surface, RID p_material) override;
 	virtual RID mesh_surface_get_material(RID p_mesh, int p_surface) const override;
 
 	virtual RenderingServerTypes::SurfaceData mesh_get_surface(RID p_mesh, int p_surface) const override;
-
 	virtual RID mesh_surface_get_vertex_buffer_rd_rid(RID p_mesh, int p_surface) const override { return RID(); }
 	virtual RID mesh_surface_get_attribute_buffer_rd_rid(RID p_mesh, int p_surface) const override { return RID(); }
 	virtual RID mesh_surface_get_skin_buffer_rd_rid(RID p_mesh, int p_surface) const override { return RID(); }

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -137,6 +137,7 @@
 #include "scene/resources/label_settings.h"
 #include "scene/resources/material.h"
 #include "scene/resources/mesh_data_tool.h"
+#include "scene/resources/mesh_rd.h"
 #include "scene/resources/mesh_texture.h"
 #include "scene/resources/multimesh.h"
 #if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
@@ -983,6 +984,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(TextureCubemapRD);
 	GDREGISTER_CLASS(TextureCubemapArrayRD);
 	GDREGISTER_CLASS(Texture3DRD);
+	GDREGISTER_CLASS(MeshRD);
 
 	GDREGISTER_CLASS(Animation);
 	GDREGISTER_CLASS(AnimationLibrary);

--- a/scene/resources/mesh_rd.cpp
+++ b/scene/resources/mesh_rd.cpp
@@ -1,0 +1,241 @@
+/**************************************************************************/
+/*  mesh_rd.cpp                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "mesh_rd.h"
+
+#include "core/object/class_db.h"
+#include "servers/rendering/rendering_server.h"
+
+void MeshRD::_create_if_empty() const {
+	if (!mesh.is_valid()) {
+		mesh = RS::get_singleton()->mesh_create();
+		RS::get_singleton()->mesh_set_path(mesh, get_path());
+	}
+}
+
+void MeshRD::_recompute_aabb() {
+	aabb = AABB();
+
+	for (int i = 0; i < surfaces.size(); i++) {
+		if (i == 0) {
+			aabb = surfaces[i].aabb;
+		} else {
+			aabb.merge_with(surfaces[i].aabb);
+		}
+	}
+}
+
+void MeshRD::add_surface(BitField<ArrayFormat> p_format, PrimitiveType p_primitive, int p_vertex_count, RID p_vertex_buffer, const AABB &p_aabb, RID p_attribute_buffer, int p_index_count, RID p_index_buffer, const Ref<Material> &p_material, const Vector4 &p_uv_scale, RID p_indirect_buffer, int p_indirect_buffer_offset) {
+	ERR_FAIL_COND(surfaces.size() == RSE::MAX_MESH_SURFACES);
+	ERR_FAIL_COND_MSG(get_blend_shape_count() != 0, "MeshRD does not support blend shapes.");
+	ERR_FAIL_COND_MSG(p_vertex_count < 0, "MeshRD surface vertex count must be non-negative.");
+	ERR_FAIL_COND_MSG(p_index_count < 0, "MeshRD surface index count must be non-negative.");
+	ERR_FAIL_COND_MSG(p_indirect_buffer_offset < 0, "Indirect buffer offset must be non-negative.");
+	const BitField<ArrayFormat> skinning_flags(uint64_t(ARRAY_FORMAT_BONES) | uint64_t(ARRAY_FORMAT_WEIGHTS));
+	ERR_FAIL_COND_MSG(p_format.has_flag(skinning_flags), "MeshRD does not support skeleton skinning.");
+
+	p_format = BitField<ArrayFormat>((uint64_t(p_format) & ~(uint64_t(ARRAY_FLAG_FORMAT_VERSION_MASK) << uint64_t(ARRAY_FLAG_FORMAT_VERSION_SHIFT))) | uint64_t(ARRAY_FLAG_FORMAT_CURRENT_VERSION));
+
+	const bool uses_empty_vertex_array = p_format.has_flag(ARRAY_FLAG_USES_EMPTY_VERTEX_ARRAY);
+	const BitField<ArrayFormat> attribute_flags(uint64_t(ARRAY_FORMAT_COLOR) | uint64_t(ARRAY_FORMAT_TEX_UV) | uint64_t(ARRAY_FORMAT_TEX_UV2) | uint64_t(ARRAY_FORMAT_CUSTOM0) | uint64_t(ARRAY_FORMAT_CUSTOM1) | uint64_t(ARRAY_FORMAT_CUSTOM2) | uint64_t(ARRAY_FORMAT_CUSTOM3));
+	const bool needs_attribute_buffer = p_format.has_flag(attribute_flags);
+	ERR_FAIL_COND_MSG(p_vertex_count == 0 && p_index_count == 0, "MeshRD surfaces must contain vertices, indices, or both.");
+	ERR_FAIL_COND_MSG(p_vertex_count > 0 && !uses_empty_vertex_array && p_vertex_buffer.is_null(), "MeshRD surfaces require a vertex buffer when vertex_count is greater than zero.");
+	ERR_FAIL_COND_MSG(needs_attribute_buffer && p_attribute_buffer.is_null(), "MeshRD surface format requires an attribute buffer.");
+	ERR_FAIL_COND_MSG(p_index_count > 0 && p_index_buffer.is_null(), "MeshRD surfaces require an index buffer when index_count is greater than zero.");
+
+	_create_if_empty();
+
+	Surface s;
+	s.aabb = p_aabb;
+	s.primitive = p_primitive;
+	s.vertex_count = p_vertex_count;
+	s.index_count = p_index_count;
+	s.format = p_format;
+	s.material = p_material;
+
+	RenderingServerTypes::SurfaceBuffers surface;
+	surface.format = uint64_t(p_format);
+	surface.primitive = RSE::PrimitiveType(p_primitive);
+	surface.vertex_count = p_vertex_count;
+	surface.vertex_buffer = p_vertex_buffer;
+	surface.attribute_buffer = p_attribute_buffer;
+	surface.index_count = p_index_count;
+	surface.index_buffer = p_index_buffer;
+	surface.indirect_buffer = p_indirect_buffer;
+	surface.indirect_buffer_offset = p_indirect_buffer_offset;
+	surface.aabb = p_aabb;
+	surface.uv_scale = p_uv_scale;
+	surface.material = p_material.is_valid() ? p_material->get_rid() : RID();
+
+	RS::get_singleton()->mesh_add_surface_from_buffers(mesh, surface);
+
+	surfaces.push_back(s);
+	_recompute_aabb();
+	clear_cache();
+	emit_changed();
+}
+
+void MeshRD::clear_surfaces() {
+	if (!mesh.is_valid()) {
+		return;
+	}
+	RS::get_singleton()->mesh_clear(mesh);
+	surfaces.clear();
+	aabb = AABB();
+	clear_cache();
+	emit_changed();
+}
+
+void MeshRD::surface_remove(int p_surface) {
+	ERR_FAIL_INDEX(p_surface, surfaces.size());
+	RS::get_singleton()->mesh_surface_remove(mesh, p_surface);
+	surfaces.remove_at(p_surface);
+
+	clear_cache();
+	_recompute_aabb();
+	emit_changed();
+}
+
+void MeshRD::surface_set_indirect_buffer(int p_surface, RID p_indirect_buffer, int p_offset) {
+	ERR_FAIL_INDEX(p_surface, surfaces.size());
+	ERR_FAIL_COND_MSG(p_offset < 0, "Indirect buffer offset must be non-negative.");
+
+	RS::get_singleton()->mesh_surface_set_indirect_buffer(mesh, p_surface, p_indirect_buffer, p_offset);
+	emit_changed();
+}
+
+Array MeshRD::surface_get_arrays(int p_surface) const {
+	ERR_FAIL_INDEX_V(p_surface, surfaces.size(), Array());
+	return Array();
+}
+
+TypedArray<Array> MeshRD::surface_get_blend_shape_arrays(int p_surface) const {
+	ERR_FAIL_INDEX_V(p_surface, surfaces.size(), TypedArray<Array>());
+	return TypedArray<Array>();
+}
+
+Dictionary MeshRD::surface_get_lods(int p_surface) const {
+	ERR_FAIL_INDEX_V(p_surface, surfaces.size(), Dictionary());
+	return Dictionary();
+}
+
+int MeshRD::get_surface_count() const {
+	return surfaces.size();
+}
+
+int MeshRD::surface_get_array_len(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, surfaces.size(), -1);
+	return surfaces[p_idx].vertex_count;
+}
+
+int MeshRD::surface_get_array_index_len(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, surfaces.size(), -1);
+	return surfaces[p_idx].index_count;
+}
+
+BitField<Mesh::ArrayFormat> MeshRD::surface_get_format(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, surfaces.size(), 0);
+	return surfaces[p_idx].format;
+}
+
+MeshRD::PrimitiveType MeshRD::surface_get_primitive_type(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, surfaces.size(), PRIMITIVE_LINES);
+	return surfaces[p_idx].primitive;
+}
+
+void MeshRD::surface_set_material(int p_idx, const Ref<Material> &p_material) {
+	ERR_FAIL_INDEX(p_idx, surfaces.size());
+	if (surfaces[p_idx].material == p_material) {
+		return;
+	}
+
+	surfaces.write[p_idx].material = p_material;
+	RS::get_singleton()->mesh_surface_set_material(mesh, p_idx, p_material.is_valid() ? p_material->get_rid() : RID());
+	emit_changed();
+}
+
+Ref<Material> MeshRD::surface_get_material(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, surfaces.size(), Ref<Material>());
+	return surfaces[p_idx].material;
+}
+
+int MeshRD::get_blend_shape_count() const {
+	return 0;
+}
+
+StringName MeshRD::get_blend_shape_name(int p_index) const {
+	ERR_FAIL_V(StringName());
+}
+
+void MeshRD::set_blend_shape_name(int p_index, const StringName &p_name) {
+	ERR_FAIL();
+}
+
+void MeshRD::set_custom_aabb(const AABB &p_custom) {
+	_create_if_empty();
+	custom_aabb = p_custom;
+	RS::get_singleton()->mesh_set_custom_aabb(mesh, custom_aabb);
+	emit_changed();
+}
+
+AABB MeshRD::get_custom_aabb() const {
+	return custom_aabb;
+}
+
+AABB MeshRD::get_aabb() const {
+	return aabb;
+}
+
+RID MeshRD::get_rid() const {
+	_create_if_empty();
+	return mesh;
+}
+
+void MeshRD::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_surface", "format", "primitive", "vertex_count", "vertex_buffer", "aabb", "attribute_buffer", "index_count", "index_buffer", "material", "uv_scale", "indirect_buffer", "indirect_buffer_offset"), &MeshRD::add_surface, DEFVAL(RID()), DEFVAL(0), DEFVAL(RID()), DEFVAL(Ref<Material>()), DEFVAL(Vector4()), DEFVAL(RID()), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("clear_surfaces"), &MeshRD::clear_surfaces);
+	ClassDB::bind_method(D_METHOD("surface_remove", "surf_idx"), &MeshRD::surface_remove);
+	ClassDB::bind_method(D_METHOD("surface_set_indirect_buffer", "surf_idx", "indirect_buffer", "offset"), &MeshRD::surface_set_indirect_buffer, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("set_custom_aabb", "aabb"), &MeshRD::set_custom_aabb);
+	ClassDB::bind_method(D_METHOD("get_custom_aabb"), &MeshRD::get_custom_aabb);
+
+	ADD_PROPERTY(PropertyInfo(Variant::AABB, "custom_aabb", PROPERTY_HINT_NO_NODEPATH, "suffix:m"), "set_custom_aabb", "get_custom_aabb");
+}
+
+MeshRD::MeshRD() {
+}
+
+MeshRD::~MeshRD() {
+	if (mesh.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
+		RenderingServer::get_singleton()->free_rid(mesh);
+	}
+}

--- a/scene/resources/mesh_rd.h
+++ b/scene/resources/mesh_rd.h
@@ -1,0 +1,89 @@
+/**************************************************************************/
+/*  mesh_rd.h                                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/resources/mesh.h"
+
+class MeshRD : public Mesh {
+	GDCLASS(MeshRD, Mesh);
+	RES_BASE_EXTENSION("mesh");
+
+	struct Surface {
+		uint64_t format = 0;
+		int vertex_count = 0;
+		int index_count = 0;
+		PrimitiveType primitive = PrimitiveType::PRIMITIVE_MAX;
+		AABB aabb;
+		Ref<Material> material;
+	};
+
+	Vector<Surface> surfaces;
+	mutable RID mesh;
+	AABB aabb;
+	AABB custom_aabb;
+
+	void _create_if_empty() const;
+	void _recompute_aabb();
+
+protected:
+	static void _bind_methods();
+
+public:
+	void add_surface(BitField<ArrayFormat> p_format, PrimitiveType p_primitive, int p_vertex_count, RID p_vertex_buffer, const AABB &p_aabb, RID p_attribute_buffer = RID(), int p_index_count = 0, RID p_index_buffer = RID(), const Ref<Material> &p_material = Ref<Material>(), const Vector4 &p_uv_scale = Vector4(), RID p_indirect_buffer = RID(), int p_indirect_buffer_offset = 0);
+	void clear_surfaces();
+	void surface_remove(int p_surface);
+	void surface_set_indirect_buffer(int p_surface, RID p_indirect_buffer, int p_offset = 0);
+
+	Array surface_get_arrays(int p_surface) const override;
+	TypedArray<Array> surface_get_blend_shape_arrays(int p_surface) const override;
+	Dictionary surface_get_lods(int p_surface) const override;
+
+	int get_surface_count() const override;
+	int surface_get_array_len(int p_idx) const override;
+	int surface_get_array_index_len(int p_idx) const override;
+	BitField<ArrayFormat> surface_get_format(int p_idx) const override;
+	PrimitiveType surface_get_primitive_type(int p_idx) const override;
+	void surface_set_material(int p_idx, const Ref<Material> &p_material) override;
+	Ref<Material> surface_get_material(int p_idx) const override;
+
+	int get_blend_shape_count() const override;
+	StringName get_blend_shape_name(int p_index) const override;
+	void set_blend_shape_name(int p_index, const StringName &p_name) override;
+
+	void set_custom_aabb(const AABB &p_custom);
+	AABB get_custom_aabb() const;
+
+	AABB get_aabb() const override;
+	RID get_rid() const override;
+
+	MeshRD();
+	~MeshRD();
+};

--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -99,6 +99,10 @@ public:
 		m->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MESH);
 	}
 
+	virtual void mesh_add_surface_from_buffers(RID p_mesh, const RenderingServerTypes::SurfaceBuffers &p_surface) override {
+		ERR_PRINT("MeshRD requires the RenderingDevice backend.");
+	}
+
 	virtual int mesh_get_blend_shape_count(RID p_mesh) const override {
 		DummyMesh *m = mesh_owner.get_or_null(p_mesh);
 		ERR_FAIL_NULL_V(m, 0);
@@ -121,6 +125,8 @@ public:
 	virtual void mesh_surface_update_attribute_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) override {}
 	virtual void mesh_surface_update_skin_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) override {}
 	virtual void mesh_surface_update_index_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) override {}
+
+	virtual void mesh_surface_set_indirect_buffer(RID p_mesh, int p_surface, RID p_indirect_buffer, int p_offset) override {}
 
 	virtual void mesh_surface_set_material(RID p_mesh, int p_surface, RID p_material) override {}
 	virtual RID mesh_surface_get_material(RID p_mesh, int p_surface) const override { return RID(); }

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -600,13 +600,17 @@ void RenderForwardClustered::_render_list_template(RenderingDevice::DrawListID p
 				instance_count /= surf->owner->trail_steps;
 			}
 
+			RID surface_indirect_buffer = mesh_storage->mesh_surface_get_indirect_buffer(mesh_surface);
+			uint32_t surface_indirect_offset = mesh_storage->mesh_surface_get_indirect_buffer_offset(mesh_surface);
 			bool indirect = bool(surf->owner->base_flags & INSTANCE_DATA_FLAG_MULTIMESH_INDIRECT);
 
 			if (emulate_point_size) {
-				if (indirect) {
+				if (indirect || surface_indirect_buffer.is_valid()) {
 					WARN_PRINT("Indirect draws are not supported when emulating point size.");
 				}
 				RD::get_singleton()->draw_list_draw(draw_list, false, mesh_storage->mesh_surface_get_vertex_count(mesh_surface), instance_count * 6);
+			} else if (surface_indirect_buffer.is_valid()) {
+				RD::get_singleton()->draw_list_draw_indirect(draw_list, index_array_rd.is_valid(), surface_indirect_buffer, surface_indirect_offset, 1, 0);
 			} else if (indirect) {
 				RD::get_singleton()->draw_list_draw_indirect(draw_list, index_array_rd.is_valid(), mesh_storage->_multimesh_get_command_buffer_rd_rid(surf->owner->data->base), surf->surface_index * sizeof(uint32_t) * mesh_storage->INDIRECT_MULTIMESH_COMMAND_STRIDE, 1, 0);
 			} else {

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -2676,13 +2676,17 @@ void RenderForwardMobile::_render_list_template(RenderingDevice::DrawListID p_dr
 				instance_count /= surf->owner->trail_steps;
 			}
 
+			RID surface_indirect_buffer = mesh_storage->mesh_surface_get_indirect_buffer(mesh_surface);
+			uint32_t surface_indirect_offset = mesh_storage->mesh_surface_get_indirect_buffer_offset(mesh_surface);
 			bool indirect = bool(surf->owner->base_flags & INSTANCE_DATA_FLAG_MULTIMESH_INDIRECT);
 
 			if (emulate_point_size) {
-				if (indirect) {
+				if (indirect || surface_indirect_buffer.is_valid()) {
 					WARN_PRINT("Indirect draws are not supported when emulating point size.");
 				}
 				RD::get_singleton()->draw_list_draw(draw_list, false, mesh_storage->mesh_surface_get_vertex_count(mesh_surface), instance_count * 6);
+			} else if (surface_indirect_buffer.is_valid()) {
+				RD::get_singleton()->draw_list_draw_indirect(draw_list, index_array_rd.is_valid(), surface_indirect_buffer, surface_indirect_offset, 1, 0);
 			} else if (indirect) {
 				RD::get_singleton()->draw_list_draw_indirect(draw_list, index_array_rd.is_valid(), mesh_storage->_multimesh_get_command_buffer_rd_rid(surf->owner->data->base), surf->surface_index * sizeof(uint32_t) * mesh_storage->INDIRECT_MULTIMESH_COMMAND_STRIDE, 1, 0);
 			} else {

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -427,7 +427,7 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RenderingServerTypes::Surfa
 
 			for (int i = 0; i < new_surface.lods.size(); i++) {
 				uint32_t indices = new_surface.lods[i].index_data.size() / (is_index_16 ? 2 : 4);
-				s->lods[i].index_buffer = RD::get_singleton()->index_buffer_create(indices, is_index_16 ? RD::INDEX_BUFFER_FORMAT_UINT16 : RD::INDEX_BUFFER_FORMAT_UINT32, new_surface.lods[i].index_data);
+				s->lods[i].index_buffer = RD::get_singleton()->index_buffer_create(indices, is_index_16 ? RD::INDEX_BUFFER_FORMAT_UINT16 : RD::INDEX_BUFFER_FORMAT_UINT32, new_surface.lods[i].index_data, false, requested_storage_flag);
 				s->lods[i].index_buffer_size = new_surface.lods[i].index_data.size();
 				s->lods[i].index_array = RD::get_singleton()->index_array_create(s->lods[i].index_buffer, 0, indices);
 				s->lods[i].edge_length = new_surface.lods[i].edge_length;
@@ -516,34 +516,124 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RenderingServerTypes::Surfa
 	mesh->material_cache.clear();
 }
 
+void MeshStorage::mesh_add_surface_from_buffers(RID p_mesh, const RenderingServerTypes::SurfaceBuffers &p_surface) {
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_NULL(mesh);
+
+	ERR_FAIL_COND(mesh->surface_count == RSE::MAX_MESH_SURFACES);
+	ERR_FAIL_COND_MSG(mesh->blend_shape_count > 0, "MeshRD surfaces do not support blend shapes yet.");
+	ERR_FAIL_COND_MSG(p_surface.format & (RSE::ARRAY_FORMAT_BONES | RSE::ARRAY_FORMAT_WEIGHTS), "MeshRD surfaces do not support skeleton skinning yet.");
+
+	uint64_t surface_version = p_surface.format & (uint64_t(RSE::ARRAY_FLAG_FORMAT_VERSION_MASK) << RSE::ARRAY_FLAG_FORMAT_VERSION_SHIFT);
+	ERR_FAIL_COND_MSG(surface_version != RSE::ARRAY_FLAG_FORMAT_CURRENT_VERSION,
+			"Surface version provided (" + itos(int(surface_version >> RSE::ARRAY_FLAG_FORMAT_VERSION_SHIFT)) + ") does not match current version (" + itos(RSE::ARRAY_FLAG_FORMAT_CURRENT_VERSION >> RSE::ARRAY_FLAG_FORMAT_VERSION_SHIFT) + ")");
+	ERR_FAIL_COND_MSG(!p_surface.index_count && !p_surface.vertex_count, "Meshes must contain a vertex array, an index array, or both");
+
+	const bool uses_empty_vertex_array = p_surface.format & RSE::ARRAY_FLAG_USES_EMPTY_VERTEX_ARRAY;
+	const bool needs_attribute_buffer = p_surface.format & (RSE::ARRAY_FORMAT_COLOR | RSE::ARRAY_FORMAT_TEX_UV | RSE::ARRAY_FORMAT_TEX_UV2 | RSE::ARRAY_FORMAT_CUSTOM0 | RSE::ARRAY_FORMAT_CUSTOM1 | RSE::ARRAY_FORMAT_CUSTOM2 | RSE::ARRAY_FORMAT_CUSTOM3);
+	const uint32_t vertex_stride = RS::get_singleton()->mesh_surface_get_format_vertex_stride(BitField<RSE::ArrayFormat>(p_surface.format), p_surface.vertex_count);
+	const uint32_t normal_tangent_stride = RS::get_singleton()->mesh_surface_get_format_normal_tangent_stride(BitField<RSE::ArrayFormat>(p_surface.format), p_surface.vertex_count);
+	const uint32_t attribute_stride = RS::get_singleton()->mesh_surface_get_format_attribute_stride(BitField<RSE::ArrayFormat>(p_surface.format), p_surface.vertex_count);
+	const uint32_t index_stride = p_surface.index_count > 0 ? RS::get_singleton()->mesh_surface_get_format_index_stride(BitField<RSE::ArrayFormat>(p_surface.format), p_surface.vertex_count) : 0;
+	ERR_FAIL_COND_MSG(p_surface.vertex_count > 0 && !uses_empty_vertex_array && p_surface.vertex_buffer.is_null(), "MeshRD surfaces require a vertex buffer when vertex_count is greater than zero.");
+	ERR_FAIL_COND_MSG(needs_attribute_buffer && p_surface.attribute_buffer.is_null(), "MeshRD surface format requires an attribute buffer.");
+	ERR_FAIL_COND_MSG(p_surface.index_count > 0 && p_surface.index_buffer.is_null(), "MeshRD surfaces require an index buffer when index_count is greater than zero.");
+	ERR_FAIL_COND_MSG(p_surface.indirect_buffer_offset < 0, "Indirect buffer offset must be non-negative.");
+
+	Mesh::Surface *s = memnew(Mesh::Surface);
+	s->format = p_surface.format;
+	s->primitive = p_surface.primitive;
+	s->vertex_count = p_surface.vertex_count;
+	s->vertex_buffer = p_surface.vertex_buffer;
+	s->vertex_buffer_size = p_surface.vertex_count * (vertex_stride + normal_tangent_stride);
+	s->owns_vertex_buffer = false;
+	s->attribute_buffer = p_surface.attribute_buffer;
+	s->attribute_buffer_size = p_surface.vertex_count * attribute_stride;
+	s->owns_attribute_buffer = false;
+	s->index_buffer = p_surface.index_buffer;
+	s->index_buffer_size = p_surface.index_count * index_stride;
+	s->owns_index_buffer = false;
+	s->index_count = p_surface.index_count;
+	s->indirect_buffer = p_surface.indirect_buffer;
+	s->indirect_buffer_offset = p_surface.indirect_buffer_offset;
+	s->aabb = p_surface.aabb;
+	s->uv_scale = p_surface.uv_scale;
+	s->material = p_surface.material;
+
+	if (s->index_buffer.is_valid()) {
+		s->index_array = RD::get_singleton()->index_array_create(s->index_buffer, 0, s->index_count);
+	}
+
+	if (mesh->surface_count == 0) {
+		mesh->aabb = p_surface.aabb;
+	} else {
+		mesh->aabb.merge_with(p_surface.aabb);
+	}
+	mesh->skeleton_aabb_version = 0;
+
+	mesh->surfaces = (Mesh::Surface **)memrealloc(mesh->surfaces, sizeof(Mesh::Surface *) * (mesh->surface_count + 1));
+	mesh->surfaces[mesh->surface_count] = s;
+	mesh->surface_count++;
+
+	for (MeshInstance *mi : mesh->instances) {
+		_mesh_instance_add_surface(mi, mesh, mesh->surface_count - 1);
+	}
+
+	mesh->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MESH);
+
+	for (Mesh *E : mesh->shadow_owners) {
+		Mesh *shadow_owner = E;
+		shadow_owner->shadow_mesh = RID();
+		shadow_owner->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MESH);
+	}
+
+	mesh->material_cache.clear();
+}
+
 void MeshStorage::_mesh_surface_clear(Mesh *p_mesh, int p_surface) {
 	Mesh::Surface &s = *p_mesh->surfaces[p_surface];
 
-	if (s.vertex_buffer.is_valid()) {
-		RD::get_singleton()->free_rid(s.vertex_buffer); // Clears arrays as dependency automatically, including all versions.
-	}
-	if (s.attribute_buffer.is_valid()) {
-		RD::get_singleton()->free_rid(s.attribute_buffer);
-	}
-	if (s.skin_buffer.is_valid()) {
-		RD::get_singleton()->free_rid(s.skin_buffer);
-	}
 	if (s.versions) {
+		for (uint32_t i = 0; i < s.version_count; i++) {
+			if (s.versions[i].vertex_array.is_valid()) {
+				RD::get_singleton()->free_rid(s.versions[i].vertex_array);
+			}
+		}
 		memfree(s.versions); // reallocs, so free with memfree.
 	}
 
-	if (s.index_buffer.is_valid()) {
+	if (s.index_array.is_valid()) {
+		RD::get_singleton()->free_rid(s.index_array);
+	}
+	if (s.uniform_set.is_valid()) {
+		RD::get_singleton()->free_rid(s.uniform_set);
+	}
+
+	if (s.vertex_buffer.is_valid() && s.owns_vertex_buffer) {
+		RD::get_singleton()->free_rid(s.vertex_buffer);
+	}
+	if (s.attribute_buffer.is_valid() && s.owns_attribute_buffer) {
+		RD::get_singleton()->free_rid(s.attribute_buffer);
+	}
+	if (s.skin_buffer.is_valid() && s.owns_skin_buffer) {
+		RD::get_singleton()->free_rid(s.skin_buffer);
+	}
+
+	if (s.index_buffer.is_valid() && s.owns_index_buffer) {
 		RD::get_singleton()->free_rid(s.index_buffer);
 	}
 
 	if (s.lod_count) {
 		for (uint32_t j = 0; j < s.lod_count; j++) {
+			if (s.lods[j].index_array.is_valid()) {
+				RD::get_singleton()->free_rid(s.lods[j].index_array);
+			}
 			RD::get_singleton()->free_rid(s.lods[j].index_buffer);
 		}
 		memdelete_arr(s.lods);
 	}
 
-	if (s.blend_shape_buffer.is_valid()) {
+	if (s.blend_shape_buffer.is_valid() && s.owns_blend_shape_buffer) {
 		RD::get_singleton()->free_rid(s.blend_shape_buffer);
 	}
 
@@ -576,8 +666,10 @@ void MeshStorage::mesh_surface_update_vertex_region(RID p_mesh, int p_surface, i
 	ERR_FAIL_NULL(mesh);
 	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
 	ERR_FAIL_COND(mesh->surfaces[p_surface]->vertex_buffer.is_null());
+	ERR_FAIL_COND_MSG(p_offset < 0, "Vertex buffer update offset must be non-negative.");
 
 	uint64_t data_size = p_data.size();
+	ERR_FAIL_COND_MSG(uint64_t(p_offset) + data_size > mesh->surfaces[p_surface]->vertex_buffer_size, "Vertex buffer update exceeds the surface vertex buffer size.");
 	const uint8_t *r = p_data.ptr();
 
 	RD::get_singleton()->buffer_update(mesh->surfaces[p_surface]->vertex_buffer, p_offset, data_size, r);
@@ -589,8 +681,10 @@ void MeshStorage::mesh_surface_update_attribute_region(RID p_mesh, int p_surface
 	ERR_FAIL_NULL(mesh);
 	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
 	ERR_FAIL_COND(mesh->surfaces[p_surface]->attribute_buffer.is_null());
+	ERR_FAIL_COND_MSG(p_offset < 0, "Attribute buffer update offset must be non-negative.");
 
 	uint64_t data_size = p_data.size();
+	ERR_FAIL_COND_MSG(uint64_t(p_offset) + data_size > mesh->surfaces[p_surface]->attribute_buffer_size, "Attribute buffer update exceeds the surface attribute buffer size.");
 	const uint8_t *r = p_data.ptr();
 
 	RD::get_singleton()->buffer_update(mesh->surfaces[p_surface]->attribute_buffer, p_offset, data_size, r);
@@ -602,8 +696,10 @@ void MeshStorage::mesh_surface_update_skin_region(RID p_mesh, int p_surface, int
 	ERR_FAIL_NULL(mesh);
 	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
 	ERR_FAIL_COND(mesh->surfaces[p_surface]->skin_buffer.is_null());
+	ERR_FAIL_COND_MSG(p_offset < 0, "Skin buffer update offset must be non-negative.");
 
 	uint64_t data_size = p_data.size();
+	ERR_FAIL_COND_MSG(uint64_t(p_offset) + data_size > mesh->surfaces[p_surface]->skin_buffer_size, "Skin buffer update exceeds the surface skin buffer size.");
 	const uint8_t *r = p_data.ptr();
 
 	RD::get_singleton()->buffer_update(mesh->surfaces[p_surface]->skin_buffer, p_offset, data_size, r);
@@ -615,8 +711,10 @@ void RendererRD::MeshStorage::mesh_surface_update_index_region(RID p_mesh, int p
 	ERR_FAIL_NULL(mesh);
 	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
 	ERR_FAIL_COND(mesh->surfaces[p_surface]->index_buffer.is_null());
+	ERR_FAIL_COND_MSG(p_offset < 0, "Index buffer update offset must be non-negative.");
 
 	uint64_t data_size = p_data.size();
+	ERR_FAIL_COND_MSG(uint64_t(p_offset) + data_size > mesh->surfaces[p_surface]->index_buffer_size, "Index buffer update exceeds the surface index buffer size.");
 	const uint8_t *r = p_data.ptr();
 
 	RD::get_singleton()->buffer_update(mesh->surfaces[p_surface]->index_buffer, p_offset, data_size, r);
@@ -1553,6 +1651,79 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 	v.input_motion_vectors = p_input_motion_vectors;
 	v.point_size_emulated = p_point_size_emulated;
 	v.vertex_array = RD::get_singleton()->vertex_array_create(p_point_size_emulated ? 0 : s->vertex_count, v.vertex_format, buffers, offsets);
+}
+
+void MeshStorage::_mesh_surface_invalidate_vertex_versions(Mesh *p_mesh, int p_surface) {
+	Mesh::Surface *surface = p_mesh->surfaces[p_surface];
+
+	if (surface->versions) {
+		for (uint32_t i = 0; i < surface->version_count; i++) {
+			if (surface->versions[i].vertex_array.is_valid()) {
+				RD::get_singleton()->free_rid(surface->versions[i].vertex_array);
+			}
+		}
+		memfree(surface->versions);
+		surface->versions = nullptr;
+		surface->version_count = 0;
+	}
+
+	for (MeshInstance *mi : p_mesh->instances) {
+		MeshInstance::Surface &mi_surface = mi->surfaces[p_surface];
+		if (mi_surface.versions) {
+			for (uint32_t i = 0; i < mi_surface.version_count; i++) {
+				if (mi_surface.versions[i].vertex_array.is_valid()) {
+					RD::get_singleton()->free_rid(mi_surface.versions[i].vertex_array);
+				}
+			}
+			memfree(mi_surface.versions);
+			mi_surface.versions = nullptr;
+			mi_surface.version_count = 0;
+		}
+		mi->dirty = true;
+	}
+}
+
+void MeshStorage::_mesh_surface_recreate_index_array(Mesh::Surface *p_surface) {
+	if (p_surface->index_array.is_valid()) {
+		RD::get_singleton()->free_rid(p_surface->index_array);
+		p_surface->index_array = RID();
+	}
+	if (p_surface->index_buffer.is_valid() && p_surface->index_count > 0) {
+		p_surface->index_array = RD::get_singleton()->index_array_create(p_surface->index_buffer, 0, p_surface->index_count);
+	}
+
+	// Recreate LOD index arrays so indirect draws can address the full index range.
+	for (uint32_t i = 0; i < p_surface->lod_count; i++) {
+		if (p_surface->lods[i].index_array.is_valid()) {
+			RD::get_singleton()->free_rid(p_surface->lods[i].index_array);
+			p_surface->lods[i].index_array = RID();
+		}
+		if (p_surface->lods[i].index_buffer.is_valid() && p_surface->lods[i].index_count > 0) {
+			p_surface->lods[i].index_array = RD::get_singleton()->index_array_create(p_surface->lods[i].index_buffer, 0, p_surface->lods[i].index_count);
+		}
+	}
+}
+
+void MeshStorage::mesh_surface_set_indirect_buffer(RID p_mesh, int p_surface, RID p_indirect_buffer, int p_offset) {
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_NULL(mesh);
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+
+	Mesh::Surface *surface = mesh->surfaces[p_surface];
+	ERR_FAIL_COND_MSG(p_offset < 0, "Indirect buffer offset must be non-negative.");
+
+	if (surface->indirect_buffer == p_indirect_buffer && surface->indirect_buffer_offset == (uint32_t)p_offset) {
+		return;
+	}
+
+	surface->indirect_buffer = p_indirect_buffer;
+	surface->indirect_buffer_offset = p_offset;
+
+	_mesh_surface_recreate_index_array(surface);
+	_mesh_surface_invalidate_vertex_versions(mesh, p_surface);
+
+	mesh->skeleton_aabb_version = 0;
+	mesh->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MESH);
 }
 
 ////////////////// MULTIMESH

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
@@ -82,12 +82,15 @@ private:
 			uint32_t vertex_count = 0;
 			RID vertex_buffer;
 			uint32_t vertex_buffer_size = 0;
+			bool owns_vertex_buffer = true;
 
 			RID attribute_buffer;
 			uint32_t attribute_buffer_size = 0;
+			bool owns_attribute_buffer = true;
 
 			RID skin_buffer;
 			uint32_t skin_buffer_size = 0;
+			bool owns_skin_buffer = true;
 
 			// A different pipeline needs to be allocated
 			// depending on the inputs available in the
@@ -114,6 +117,10 @@ private:
 			uint32_t index_buffer_size = 0;
 			RID index_array;
 			uint32_t index_count = 0;
+			bool owns_index_buffer = true;
+
+			RID indirect_buffer;
+			uint32_t indirect_buffer_offset = 0;
 
 			struct LOD {
 				float edge_length = 0.0;
@@ -138,6 +145,7 @@ private:
 
 			RID blend_shape_buffer;
 			uint32_t blend_shape_buffer_size = 0;
+			bool owns_blend_shape_buffer = true;
 
 			RID material;
 
@@ -212,6 +220,8 @@ private:
 
 	RD::VertexFormatID _mesh_surface_generate_vertex_format(uint64_t p_surface_format, uint64_t p_input_mask, bool p_instanced_surface, bool p_input_motion_vectors, bool p_point_size_emulated, uint32_t &r_position_stride);
 	void _mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint64_t p_input_mask, bool p_input_motion_vectors, bool p_point_size_emulated, MeshInstance::Surface *mis = nullptr, uint32_t p_current_buffer = 0, uint32_t p_previous_buffer = 0);
+	void _mesh_surface_invalidate_vertex_versions(Mesh *p_mesh, int p_surface);
+	void _mesh_surface_recreate_index_array(Mesh::Surface *p_surface);
 	void _mesh_surface_clear(Mesh *p_mesh, int p_surface);
 
 	void _mesh_instance_clear(MeshInstance *mi);
@@ -377,6 +387,8 @@ public:
 	/// Return stride
 	virtual void mesh_add_surface(RID p_mesh, const RenderingServerTypes::SurfaceData &p_surface) override;
 
+	virtual void mesh_add_surface_from_buffers(RID p_mesh, const RenderingServerTypes::SurfaceBuffers &p_surface) override;
+
 	virtual int mesh_get_blend_shape_count(RID p_mesh) const override;
 
 	virtual void mesh_set_blend_shape_mode(RID p_mesh, RSE::BlendShapeMode p_mode) override;
@@ -386,6 +398,8 @@ public:
 	virtual void mesh_surface_update_attribute_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) override;
 	virtual void mesh_surface_update_skin_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) override;
 	virtual void mesh_surface_update_index_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) override;
+
+	virtual void mesh_surface_set_indirect_buffer(RID p_mesh, int p_surface, RID p_indirect_buffer, int p_offset) override;
 
 	virtual void mesh_surface_set_material(RID p_mesh, int p_surface, RID p_material) override;
 	virtual RID mesh_surface_get_material(RID p_mesh, int p_surface) const override;
@@ -464,7 +478,7 @@ public:
 
 	_FORCE_INLINE_ uint32_t mesh_surface_get_vertices_drawn_count(void *p_surface) const {
 		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
-		return s->index_count ? s->index_count : s->vertex_count;
+		return s->index_buffer.is_valid() ? s->index_count : s->vertex_count;
 	}
 
 	_FORCE_INLINE_ AABB mesh_surface_get_aabb(void *p_surface) {
@@ -480,6 +494,36 @@ public:
 	_FORCE_INLINE_ Vector4 mesh_surface_get_uv_scale(void *p_surface) {
 		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
 		return s->uv_scale;
+	}
+
+	_FORCE_INLINE_ RID mesh_surface_get_vertex_buffer(void *p_surface) {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+		return s->vertex_buffer;
+	}
+
+	_FORCE_INLINE_ RID mesh_surface_get_attribute_buffer(void *p_surface) {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+		return s->attribute_buffer;
+	}
+
+	_FORCE_INLINE_ RID mesh_surface_get_index_buffer(void *p_surface, uint32_t p_lod = 0) {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+		if (p_lod == 0) {
+			return s->index_buffer;
+		} else {
+			ERR_FAIL_UNSIGNED_INDEX_V(p_lod - 1, s->lod_count, RID());
+			return s->lods[p_lod - 1].index_buffer;
+		}
+	}
+
+	_FORCE_INLINE_ uint32_t mesh_surface_get_index_count(void *p_surface, uint32_t p_lod = 0) {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+		if (p_lod == 0) {
+			return s->index_count;
+		} else {
+			ERR_FAIL_UNSIGNED_INDEX_V(p_lod - 1, s->lod_count, 0);
+			return s->lods[p_lod - 1].index_count;
+		}
 	}
 
 	_FORCE_INLINE_ uint32_t mesh_surface_get_lod(void *p_surface, float p_model_scale, float p_distance_threshold, float p_mesh_lod_threshold, uint32_t &r_index_count) const {
@@ -510,6 +554,21 @@ public:
 		} else {
 			return s->lods[p_lod - 1].index_array;
 		}
+	}
+
+	_FORCE_INLINE_ RID mesh_surface_get_indirect_buffer(void *p_surface) const {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+		return s->indirect_buffer;
+	}
+
+	_FORCE_INLINE_ uint32_t mesh_surface_get_indirect_buffer_offset(void *p_surface) const {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+		return s->indirect_buffer_offset;
+	}
+
+	_FORCE_INLINE_ bool mesh_surface_has_indirect_buffer(void *p_surface) const {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+		return s->indirect_buffer.is_valid();
 	}
 
 	_FORCE_INLINE_ void mesh_surface_get_vertex_arrays_and_format(void *p_surface, uint64_t p_input_mask, bool p_input_motion_vectors, bool p_point_size_emulated, RID &r_vertex_array_rd, RD::VertexFormatID &r_vertex_format) {

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -4684,6 +4684,10 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 					buffer = vertex_buffer_owner.get_or_null(buffer_id);
 
 					ERR_FAIL_COND_V_MSG(!(buffer->usage.has_flag(RDD::BUFFER_USAGE_STORAGE_BIT)), RID(), "Vertex buffer supplied (binding: " + itos(uniform.binding) + ") was not created with storage flag.");
+				} else if (index_buffer_owner.owns(buffer_id)) {
+					buffer = index_buffer_owner.get_or_null(buffer_id);
+
+					ERR_FAIL_COND_V_MSG(!(buffer->usage.has_flag(RDD::BUFFER_USAGE_STORAGE_BIT)), RID(), "Index buffer supplied (binding: " + itos(uniform.binding) + ") was not created with storage flag.");
 				}
 				ERR_FAIL_NULL_V_MSG(buffer, RID(), "Storage buffer supplied (binding: " + itos(uniform.binding) + ") is invalid.");
 

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -212,6 +212,7 @@ public:
 
 	virtual void mesh_add_surface_from_arrays(RID p_mesh, RSE::PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), BitField<RSE::ArrayFormat> p_compress_format = 0);
 	virtual void mesh_add_surface(RID p_mesh, const RenderingServerTypes::SurfaceData &p_surface) = 0;
+	virtual void mesh_add_surface_from_buffers(RID p_mesh, const RenderingServerTypes::SurfaceBuffers &p_surface) = 0;
 
 	virtual int mesh_get_blend_shape_count(RID p_mesh) const = 0;
 
@@ -223,6 +224,7 @@ public:
 	virtual void mesh_surface_update_skin_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) = 0;
 	virtual void mesh_surface_update_index_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) = 0;
 
+	virtual void mesh_surface_set_indirect_buffer(RID p_mesh, int p_surface, RID p_indirect_buffer, int p_offset) = 0;
 	virtual void mesh_surface_set_material(RID p_mesh, int p_surface, RID p_material) = 0;
 	virtual RID mesh_surface_get_material(RID p_mesh, int p_surface) const = 0;
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -391,6 +391,7 @@ public:
 	FUNCRIDSPLIT(mesh)
 
 	FUNC2(mesh_add_surface, RID, const RenderingServerTypes::SurfaceData &)
+	FUNC2(mesh_add_surface_from_buffers, RID, const RenderingServerTypes::SurfaceBuffers &)
 
 	FUNC1RC(int, mesh_get_blend_shape_count, RID)
 
@@ -401,6 +402,8 @@ public:
 	FUNC4(mesh_surface_update_attribute_region, RID, int, int, const Vector<uint8_t> &)
 	FUNC4(mesh_surface_update_skin_region, RID, int, int, const Vector<uint8_t> &)
 	FUNC4(mesh_surface_update_index_region, RID, int, int, const Vector<uint8_t> &)
+
+	FUNC4(mesh_surface_set_indirect_buffer, RID, int, RID, int)
 
 	FUNC3(mesh_surface_set_material, RID, int, RID)
 	FUNC2RC(RID, mesh_surface_get_material, RID, int)

--- a/servers/rendering/rendering_server_types.h
+++ b/servers/rendering/rendering_server_types.h
@@ -110,6 +110,23 @@ struct SurfaceData {
 	RID material;
 };
 
+struct SurfaceBuffers {
+	RSE::PrimitiveType primitive = RSE::PRIMITIVE_MAX;
+
+	uint64_t format = RSE::ARRAY_FLAG_FORMAT_CURRENT_VERSION;
+	uint32_t vertex_count = 0;
+	RID vertex_buffer;
+	RID attribute_buffer;
+	uint32_t index_count = 0;
+	RID index_buffer;
+	RID indirect_buffer;
+	int indirect_buffer_offset = 0;
+
+	AABB aabb;
+	Vector4 uv_scale;
+	RID material;
+};
+
 struct MeshInfo {
 	RID mesh;
 	String path;

--- a/servers/rendering/storage/mesh_storage.h
+++ b/servers/rendering/storage/mesh_storage.h
@@ -52,6 +52,7 @@ public:
 	/// Returns stride
 	virtual void mesh_add_surface(RID p_mesh, const RenderingServerTypes::SurfaceData &p_surface) = 0;
 
+	virtual void mesh_add_surface_from_buffers(RID p_mesh, const RenderingServerTypes::SurfaceBuffers &p_surface) = 0;
 	virtual int mesh_get_blend_shape_count(RID p_mesh) const = 0;
 
 	virtual void mesh_set_blend_shape_mode(RID p_mesh, RSE::BlendShapeMode p_mode) = 0;
@@ -62,6 +63,7 @@ public:
 	virtual void mesh_surface_update_skin_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) = 0;
 	virtual void mesh_surface_update_index_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) = 0;
 
+	virtual void mesh_surface_set_indirect_buffer(RID p_mesh, int p_surface, RID p_indirect_buffer, int p_offset) = 0;
 	virtual void mesh_surface_set_material(RID p_mesh, int p_surface, RID p_material) = 0;
 	virtual RID mesh_surface_get_material(RID p_mesh, int p_surface) const = 0;
 


### PR DESCRIPTION
Closes (partially) https://github.com/godotengine/godot-proposals/issues/7209.

This PR adds `MeshRD`, a low-level `Mesh` resource for indirect procedural GPU meshes.

The basic idea is simple: users create the `RenderingDevice` buffers themselves, pass those RIDs to `MeshRD.add_surface()`, then fill the buffers from compute shaders. `MeshRD` makes the result usable as a normal `Mesh` resource, so it can be assigned to `MeshInstance3D.mesh`.

This avoids the GPU -> CPU -> GPU roundtrip that `ArrayMesh` requires, and keeps ownership clear: `MeshRD` does not allocate, own, free, expose, or serialize the buffers passed to it. The caller owns all RD buffers.

Since https://github.com/godotengine/godot/pull/118973 already exposes existing mesh surface RD buffer RIDs, this PR no longer tries to cover that use case. It only focuses on creating a mesh from caller-owned buffers and drawing it indirectly.

---

Tested locally on macOS arm64.

Demo project:

https://github.com/maidopi-usagi/godot_meshrd_demo

Includes the following demos:

<table> <tr> <td align="center"> <img src="https://github.com/user-attachments/assets/64992f71-749f-40dd-a1bf-e4d2b97c6c56" width="100%" /> </td> <td align="center"> <img src="https://github.com/user-attachments/assets/33173bd6-233d-40c2-bf73-d33a9a87a46e" width="100%" /> </td> <td align="center"> <img src="https://github.com/user-attachments/assets/7b10aa1d-0953-4b6b-8b1a-848efad25a5d" width="100%" /> </td> </tr> <tr> <td align="center"><sub>Marching Cube Metaball</sub></td> <td align="center"><sub>Procedural ClipMap Terrain</sub></td> <td align="center"><sub>Animated Ribbons</sub></td> </tr> </table>

---

### API Overview

#### `MeshRD`

| Method | Description |
|---|---|
| `add_surface(format, primitive, vertex_count, vertex_buffer, aabb, attribute_buffer, index_count, index_buffer, ...)` | Attach caller-owned RD buffers as a mesh surface. |
| `surface_set_indirect_buffer(surf_idx, indirect_buffer, offset)` | Set or replace the indirect draw buffer for a surface. |
| `clear_surfaces()` / `surface_remove(surf_idx)` | Surface management. |

---

### Minimal Usage

```gdscript
var rd := RenderingServer.get_rendering_device()

var vb := rd.vertex_buffer_create(vertex_buffer_size, PackedByteArray(), RenderingDevice.BUFFER_CREATION_AS_STORAGE_BIT)
var ib := rd.index_buffer_create(max_indices, RenderingDevice.INDEX_BUFFER_FORMAT_UINT32, PackedByteArray(), false, RenderingDevice.BUFFER_CREATION_AS_STORAGE_BIT)
var ind := rd.storage_buffer_create(20, PackedByteArray(), RenderingDevice.STORAGE_BUFFER_USAGE_DISPATCH_INDIRECT)

var mesh_rd := MeshRD.new()
mesh_rd.add_surface(
    Mesh.ARRAY_FORMAT_VERTEX | Mesh.ARRAY_FORMAT_INDEX,
    Mesh.PRIMITIVE_TRIANGLES,
    max_vertices,
    vb,
    aabb,
    RID(),
    max_indices,
    ib,
    null,
    Vector4(),
    ind,
)
```

----

_Disclaimer: AI was used to resolve the conflicts and update the example demo project. The core changes and documentations were written by hand._
