### PR TITLE
[Windows] Remove polling of SDR white level when HDR output is enabled.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3385,7 +3385,7 @@ HWND DisplayServerWindows::_find_window_from_process_id(ProcessID p_pid, HWND p_
 }
 
 // Get screen HDR capabilities for internal use only.
-DisplayServerWindows::ScreenHdrData DisplayServerWindows::_get_screen_hdr_data(int p_screen) const {
+DisplayServerWindows::ScreenHdrData DisplayServerWindows::_get_screen_hdr_data(int p_screen, bool p_include_sdr_white_level) const {
 	ScreenHdrData data;
 	HMONITOR monitor = _get_hmonitor_of_screen(p_screen);
 	if (!monitor) {
@@ -3408,17 +3408,19 @@ DisplayServerWindows::ScreenHdrData DisplayServerWindows::_get_screen_hdr_data(i
 	}
 #endif // D3D12_ENABLED
 
-	uint32_t path_count = 0;
-	uint32_t mode_count = 0;
+	if (p_include_sdr_white_level) {
+		uint32_t path_count = 0;
+		uint32_t mode_count = 0;
 
-	if (GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &path_count, &mode_count) == ERROR_SUCCESS) {
-		LocalVector<DISPLAYCONFIG_PATH_INFO> paths;
-		LocalVector<DISPLAYCONFIG_MODE_INFO> modes;
-		paths.resize(path_count);
-		modes.resize(mode_count);
+		if (GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &path_count, &mode_count) == ERROR_SUCCESS) {
+			LocalVector<DISPLAYCONFIG_PATH_INFO> paths;
+			LocalVector<DISPLAYCONFIG_MODE_INFO> modes;
+			paths.resize(path_count);
+			modes.resize(mode_count);
 
-		if (QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &path_count, paths.ptr(), &mode_count, modes.ptr(), nullptr) == ERROR_SUCCESS) {
-			data.sdr_white_level = _get_sdr_white_level_for_hmonitor(monitor, paths);
+			if (QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &path_count, paths.ptr(), &mode_count, modes.ptr(), nullptr) == ERROR_SUCCESS) {
+				data.sdr_white_level = _get_sdr_white_level_for_hmonitor(monitor, paths);
+			}
 		}
 	}
 
@@ -3455,7 +3457,7 @@ void DisplayServerWindows::_update_hdr_output_for_window(DisplayServerEnums::Win
 #endif // RD_ENABLED
 }
 
-void DisplayServerWindows::_update_hdr_output_for_tracked_windows() {
+void DisplayServerWindows::_update_hdr_output_for_tracked_windows(bool p_include_sdr_white_level) {
 	hdr_output_cache.clear();
 	for (const KeyValue<DisplayServerEnums::WindowID, WindowData> &E : windows) {
 		if (E.value.hdr_output_requested) {
@@ -3463,7 +3465,7 @@ void DisplayServerWindows::_update_hdr_output_for_tracked_windows() {
 
 			ScreenHdrData data;
 			if (!hdr_output_cache.has(screen)) {
-				data = _get_screen_hdr_data(screen);
+				data = _get_screen_hdr_data(screen, p_include_sdr_white_level);
 				hdr_output_cache.insert(screen, data);
 			} else {
 				data = hdr_output_cache[screen];
@@ -4161,7 +4163,16 @@ void DisplayServerWindows::process_events() {
 
 	// Poll HDR output state for windows that have requested it.
 	// Needed to detect changes in luminance values due to a lack of Windows events for such changes.
-	_update_hdr_output_for_tracked_windows();
+	// System-reported max luminance changes when the user adjust the screen brightness of a laptop
+	// with a built-in HDR screen. Additionally, some computers may continue to report a
+	// DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709 color space for a period of time after the
+	// WM_DISPLAYCHANGE event is received by Godot which means we must poll this regularly to
+	// capture this change in HDR capabilities of the screen triggered by the Win + Alt + B shortcut.
+	// The SDR white level (reference white luminance) does not need to be polled every frame
+	// because the only way to adjust this is to leave the Godot Window and adjust the SDR/HDR
+	// Content Brightness Windows display setting. This means the user must return to the Godot
+	// window, which triggers a WM_WINDOWPOSCHANGED event.
+	_update_hdr_output_for_tracked_windows(false);
 
 	LocalVector<List<FileDialogData *>::Element *> to_remove;
 	for (List<FileDialogData *>::Element *E = file_dialogs.front(); E; E = E->next()) {
@@ -4633,7 +4644,7 @@ bool DisplayServerWindows::window_is_hdr_output_supported(DisplayServerEnums::Wi
 
 	// The window supports HDR if the screen it is on supports HDR.
 	int screen = window_get_current_screen(p_window);
-	DisplayServerWindows::ScreenHdrData data = _get_screen_hdr_data(screen);
+	DisplayServerWindows::ScreenHdrData data = _get_screen_hdr_data(screen, false);
 	return data.hdr_supported;
 }
 
@@ -4648,7 +4659,7 @@ void DisplayServerWindows::window_request_hdr_output(const bool p_enable, Displa
 	wd.hdr_output_requested = p_enable;
 
 	int screen = window_get_current_screen(p_window);
-	DisplayServerWindows::ScreenHdrData data = _get_screen_hdr_data(screen);
+	DisplayServerWindows::ScreenHdrData data = _get_screen_hdr_data(screen, true);
 	_update_hdr_output_for_window(p_window, wd, data);
 }
 
@@ -4685,7 +4696,7 @@ void DisplayServerWindows::window_set_hdr_output_reference_luminance(const float
 	// Negative luminance means auto-adjust
 	if (wd.hdr_output_reference_luminance < 0.0f) {
 		int screen = window_get_current_screen(p_window);
-		DisplayServerWindows::ScreenHdrData data = _get_screen_hdr_data(screen);
+		DisplayServerWindows::ScreenHdrData data = _get_screen_hdr_data(screen, true);
 		_update_hdr_output_for_window(p_window, wd, data);
 	} else {
 		// Otherwise, apply the requested luminance
@@ -4730,7 +4741,7 @@ void DisplayServerWindows::window_set_hdr_output_max_luminance(const float p_max
 	// Negative luminance means auto-adjust
 	if (wd.hdr_output_max_luminance < 0.0f) {
 		int screen = window_get_current_screen(p_window);
-		DisplayServerWindows::ScreenHdrData data = _get_screen_hdr_data(screen);
+		DisplayServerWindows::ScreenHdrData data = _get_screen_hdr_data(screen, true);
 		_update_hdr_output_for_window(p_window, wd, data);
 	} else {
 		// Otherwise, apply the requested luminance
@@ -6249,7 +6260,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 		case WM_DISPLAYCHANGE: {
 			// Update HDR capabilities and reference luminance when display changes.
-			_update_hdr_output_for_tracked_windows();
+			_update_hdr_output_for_tracked_windows(true);
 		} break;
 
 		case WM_WINDOWPOSCHANGED: {
@@ -6347,9 +6358,6 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					window.rect_changed_callback.call(Rect2i(window.last_pos.x, window.last_pos.y, window.width, window.height));
 				}
 
-				// Update HDR capabilities and reference luminance when window moves to different screen.
-				_update_hdr_output_for_tracked_windows();
-
 				// Update cursor clip region after window rect has changed.
 				if (mouse_mode == DisplayServerEnums::MOUSE_MODE_CAPTURED || mouse_mode == DisplayServerEnums::MOUSE_MODE_CONFINED || mouse_mode == DisplayServerEnums::MOUSE_MODE_CONFINED_HIDDEN) {
 					RECT crect;
@@ -6387,6 +6395,11 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					}
 				}
 			}
+
+			// Update HDR capabilities and reference luminance when window moves to different screen.
+			// Also update when Godot has regained focus because the user may have adjusted their SDR white
+			// level while Godot was not in focus.
+			_update_hdr_output_for_tracked_windows(true);
 
 			// Return here to prevent WM_MOVE and WM_SIZE from being sent
 			// See: https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-windowposchanged#remarks

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -548,9 +548,9 @@ class DisplayServerWindows : public DisplayServer {
 	};
 	AHashMap<int, ScreenHdrData> hdr_output_cache;
 
-	ScreenHdrData _get_screen_hdr_data(int p_screen) const;
+	ScreenHdrData _get_screen_hdr_data(int p_screen, bool p_include_sdr_white_level) const;
 	void _update_hdr_output_for_window(DisplayServerEnums::WindowID p_window, const WindowData &p_window_data, ScreenHdrData p_screen_data);
-	void _update_hdr_output_for_tracked_windows();
+	void _update_hdr_output_for_tracked_windows(bool p_include_sdr_white_level);
 
 public:
 	LRESULT WndProcFileDialog(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
### What problem(s) does this PR solve?

- Polling of HDR luminance values every frame is slow.
- Fixes #118092
   - At least it won't flicker anymore. The brightness may still be incorrect until the player or system does something to trigger a request of `SDRWhiteLevel`, such as changing window focus away and back to the Godot window.

### What is the rationale for the approach used in this PR?

Oh, boy. Here we go:

The SDR white level on Windows is the reference white luminance used by Godot. As far as I am able to tell, the only way to adjust this value is by changing the "SDR/HDR Content Brightness" slider in the HDR section of the Windows Display Settings.

If my understanding is correct, then it is not strictly necessary to poll this SDR white level every frame. Instead, it is only necessary to check for changes in SDR white level when a Godot window regains focus. As far as I can tell, this is the behaviour exhibited by Chromium browsers, for example. Here is a video comparing this PR (bottom left) with a chromium browser (Edge, top left):

https://github.com/user-attachments/assets/31b4cdc8-a9b0-4ff9-903e-d925fe36335b

The current behaviour of checking every frame is a better user experience when the user is actively changing their SDR white level through the Windows display settings... But it is possibly a worse user experience when actually playing the game as performance may suffer if the game is CPU-bound.

Importantly, how often the SDR white level must be retrieved is very different than how often the other HDR capabilities and luminance values must be retrieved. This was discussed in detail in this thread: https://github.com/godotengine/godot/pull/94496#discussion_r2736272524 (Note: Firefox is struggling to load that conversation for me, but other browsers work fine.)

<details>
<summary>I mentioned the idea of this PR previously...</summary>

> I should mention: I believe it is not common for Windows apps to poll for SDRWhiteLevel. Normally apps will just have a hardcoded brightness in HDR and it makes for a pretty terrible user experience. Matching the SDRWhiteLevel is what will really give Godot a head above all other HDR apps/games. Conversely, polling for Max luminance is required as that changes all the time on HDR laptops because it's tied directly to the brightness control.
> 
> If the performance cost is too high to be polling for SDRWhiteLevel, we could instead check for this any time a window changes to be foreground and active. This makes for a bad user experience when adjusting brightness with the SDR Content Brightness slider, but if it's that or spending hundreds of microseconds to retrieve it from the system... well, maybe that's just a tradeoff we'll need to make :(

</details>

...but I believe the performance of this specific behaviour was never measured with the [latest optimizations](https://github.com/godotengine/godot/pull/94496#issuecomment-3881605335) that were merged into master.

### Performance

**Single monitor:** 
- Average of **71 microseconds savings.**
- Polling that has been removed with this PR would take as long as 731 microseconds or as short as 10 microseconds, which suggests that this polling can contribute to stutters.

**Dual monitor:**
- Average of **163 microseconds savings.**

<details>
<summary>Test computer specs</summary>
Mid-range gaming laptop with an i7-10750H:

Windows 11 (build 26200) - Multi-window, 2 monitors - Vulkan (Forward+) - dedicated NVIDIA GeForce RTX 3060 Laptop GPU (NVIDIA; 32.0.15.8088) - Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz (12 threads) - 15.82 GiB memory
</details>

<details>
<summary>Test procedure</summary>
I used `QueryPerformanceCounter` to measure the microseconds, saving 1000 consecutive measurements before writing them to a file for analysis.

I built the release template with the following command:
`scons platform=windows arch=x86_64 production=yes use_mingw=yes d3d12=yes target=template_release`
</details

### Was generative AI (LLM AI) used to create a portion of this PR?

No.

### Are there any parts of this PR that you are uncertain of or require special attention from reviewers?

This PR should ideally be merged before 4.7 or never merged because this sets a precedence/expectation for how the SDR/HDR content brightness Windows setting should behave in relation to Godot.