### PR TITLE
Fix animation and key buttons of inspector sections being off-center in the RTL layout

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -2239,7 +2239,7 @@ void EditorInspectorSection::_notification(int p_what) {
 				Ref<Texture2D> key = theme_cache.icon_gui_animation_key;
 				if (keying && key.is_valid()) {
 					Point2 key_position;
-					key_position.x = (rtl ? margin_end : (get_size().width - key->get_width() - margin_end)) - theme_cache.padding_size / 2;
+					key_position.x = rtl ? margin_end + theme_cache.padding_size / 2 : (get_size().width - key->get_width() - margin_end - theme_cache.padding_size / 2);
 					keying_rect = Rect2(key_position.x - theme_cache.padding_size / 2, 0, key->get_width() + theme_cache.padding_size, header_height);
 
 					Color key_color(1, 1, 1);
@@ -2299,7 +2299,7 @@ void EditorInspectorSection::_notification(int p_what) {
 				const Ref<Texture2D> &revert = theme_cache.icon_gui_revert;
 				if (can_revert && revert.is_valid()) {
 					Point2 revert_position;
-					revert_position.x = (rtl ? margin_end : (get_size().width - revert->get_width() - margin_end)) - theme_cache.padding_size / 2;
+					revert_position.x = rtl ? margin_end + theme_cache.padding_size / 2 : (get_size().width - revert->get_width() - margin_end - theme_cache.padding_size / 2);
 					revert_rect = Rect2(revert_position.x - theme_cache.padding_size / 2, 0, revert->get_width() + theme_cache.padding_size, header_height);
 
 					Color revert_color(1, 1, 1);


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="260" height="29" alt="image" src="https://github.com/user-attachments/assets/dad2c029-e104-441e-8496-15bdb5e956ed" />|<img width="260" height="29" alt="image" src="https://github.com/user-attachments/assets/c9f85362-e53a-4c3f-9d40-01401a7b91da" />|