### PR TITLE
Editor: Fix Refresh Project Settings UI after reloading from disk

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1622,6 +1622,7 @@ void EditorNode::_reload_modified_scenes() {
 
 void EditorNode::_reload_project_settings() {
 	ProjectSettings::get_singleton()->setup(ProjectSettings::get_singleton()->get_resource_path(), String(), true, true);
+	project_settings_editor->notification(NOTIFICATION_PROJECT_SETTINGS_RELOADED);
 }
 
 void EditorNode::_vp_resized() {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -121,6 +121,10 @@ class EditorNode : public Node {
 	GDCLASS(EditorNode, Node);
 
 public:
+	enum {
+		NOTIFICATION_PROJECT_SETTINGS_RELOADED = 10001,
+	};
+	
 	enum SceneNameCasing {
 		SCENE_NAME_CASING_AUTO,
 		SCENE_NAME_CASING_PASCAL_CASE,

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -679,6 +679,14 @@ void ProjectSettingsEditor::_notification(int p_what) {
 			_update_theme();
 		} break;
 
+		case EditorNode::NOTIFICATION_PROJECT_SETTINGS_RELOADED: {
+			general_settings_inspector->update_category_list();
+			_update_action_map_editor();
+			localization_editor->update_translations();
+			autoload_settings->update_autoload();
+			plugin_settings->update_plugins();
+		} break;
+
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/touchscreen")) {
 				general_settings_inspector->set_touch_dragger_enabled(EDITOR_GET("interface/touchscreen/enable_touch_optimizations"));


### PR DESCRIPTION
When 'project.godot' is modified externally, the ProjectSettings singleton updates, but the ProjectSettingsEditor window remains stale.

This introduces a new editor-only notification (ID: 10001) named NOTIFICATION_PROJECT_SETTINGS_RELOADED to signal UI components like the Input Map and Localization tabs to refresh their views.

This Closes #114223 
