### PR TITLE
Reduce `RefCounted` copies in `GDScriptFunction::call`

### DIFF
--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -363,6 +363,16 @@ public:
 		v->_get_obj().ref(r);
 	}
 
+	// This should be used with extreme caution, as it does not increment the reference count in the
+	// case where the object is `RefCounted`. You *must* ensure that the destructor of this
+	// `Variant` is never called, and that the assigned object always outlives the `Variant`.
+	_FORCE_INLINE_ static void object_assign_without_ref_unsafe(Variant *v, Object *o) {
+		v->type = Variant::OBJECT;
+		Variant::ObjData &obj_data = v->_get_obj();
+		obj_data.id = o->get_instance_id();
+		obj_data.obj = o;
+	}
+
 	_FORCE_INLINE_ static void object_reset_data(Variant *v) {
 		v->_get_obj() = Variant::ObjData();
 	}

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -660,7 +660,11 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		memnew_placement(&stack[ADDR_STACK_SELF], Variant);
 		script = _script;
 	}
-	memnew_placement(&stack[ADDR_STACK_CLASS], Variant(script));
+
+	// We must call a `Variant` constructor here, as accessing an object without doing so is undefined behavior.
+	memnew_placement(&stack[ADDR_STACK_CLASS], Variant);
+	VariantInternal::object_assign_without_ref_unsafe(&stack[ADDR_STACK_CLASS], script);
+
 	memnew_placement(&stack[ADDR_STACK_NIL], Variant);
 
 	String err_text;
@@ -4009,7 +4013,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		GDScriptLanguage::get_singleton()->exit_function();
 	}
 
-	for (int i = 0; i < _stack_size; i++) {
+	// We deliberately avoid calling the destructor for `ADDR_STACK_CLASS`, since we initialized it
+	// without incrementing any reference count that it might have.
+	stack[ADDR_STACK_SELF].~Variant();
+	stack[ADDR_STACK_NIL].~Variant();
+
+	for (int i = FIXED_ADDRESSES_MAX; i < _stack_size; i++) {
 		stack[i].~Variant();
 	}
 


### PR DESCRIPTION
Related to #117121.

As [talked about](https://chat.godotengine.org/channel/gdscript?msg=pBRsJstLjavoPhqHh) on the contributor's chat, in a GDScript-heavy real-world project that we've been profiling there seems to be a troubling amount of overhead coming from `RefCounted::reference`/`RefCounted::unreference`, a big chunk of which is coming from initializing these `Variant` instances here, as the GDScript VM puts the script and instance references onto the GDScript stack:

https://github.com/godotengine/godot/blob/60fff00a660a2aeb03f88c07fb7baed353bcb72f/modules/gdscript/gdscript_vm.cpp#L656-L663

The reference count increment/decrement that come as a result of this are seemingly entirely redundant, as ~~both~~ the script ~~and instance~~ by definition (?) have to survive the entire function call.

This pull request fixes that by introducing a `VariantInternal::object_assign_raw`, which allows us to (dangerously) write the object pointer/ID/type into the GDScript stack `Variant` without incrementing the reference counter. Then we simply don't run the destructor for these at all, thereby avoiding decrementing the reference counter as well.

I'll see if I can provide some hard numbers from Tracy later on, ~~but we're seeing somewhere on the order of a 10% bump in performance from this in one particular benchmark in this particular project.~~