### PR TITLE
Improve undo redo API and docs

### DIFF
--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -443,16 +443,38 @@ int UndoRedo::get_history_count() {
 	return actions.size();
 }
 
+// Use the word "action" everywhere rather than mixing in "history".
+int UndoRedo::get_action_count() {
+	return get_history_count();
+}
+
 int UndoRedo::get_current_action() {
 	ERR_FAIL_COND_V(action_level > 0, -1);
 
 	return current_action;
 }
 
+// This is more descriptive than "get_current_action()"
+int UndoRedo::get_current_action_index() {
+	return get_current_action();
+}
+
 String UndoRedo::get_action_name(int p_id) {
-	ERR_FAIL_INDEX_V(p_id, actions.size(), "");
+	// Allow negative indices, as long as it doesn't double wrap.
+	// i.e. ensure abs(p_id) <= actions.size().
+	if (p_id < 0) {
+		p_id = actions.size() + p_id;
+		if (p_id < 0) {
+			ERR_FAIL_INDEX_V(p_id, actions.size(), "");
+		}
+	}
 
 	return actions[p_id].name;
+}
+
+// More descriptive version of get_action_name.
+String UndoRedo::get_action_name_at_index(int p_index) {
+	return get_action_name(p_index);
 }
 
 void UndoRedo::clear_history(bool p_increase_version) {
@@ -540,12 +562,16 @@ void UndoRedo::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("end_force_keep_in_merge_ends"), &UndoRedo::end_force_keep_in_merge_ends);
 
 	ClassDB::bind_method(D_METHOD("get_history_count"), &UndoRedo::get_history_count);
+	ClassDB::bind_method(D_METHOD("get_action_count"), &UndoRedo::get_action_count);
+	ClassDB::bind_method(D_METHOD("get_current_action_index"), &UndoRedo::get_current_action_index);
 	ClassDB::bind_method(D_METHOD("get_current_action"), &UndoRedo::get_current_action);
 	ClassDB::bind_method(D_METHOD("get_action_name", "id"), &UndoRedo::get_action_name);
+	ClassDB::bind_method(D_METHOD("get_action_name_at_index", "index"), &UndoRedo::get_action_name_at_index);
 	ClassDB::bind_method(D_METHOD("clear_history", "increase_version"), &UndoRedo::clear_history, DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("get_current_action_name"), &UndoRedo::get_current_action_name);
 
+	ClassDB::bind_method(D_METHOD("discard_redo"), &UndoRedo::discard_redo);
 	ClassDB::bind_method(D_METHOD("has_undo"), &UndoRedo::has_undo);
 	ClassDB::bind_method(D_METHOD("has_redo"), &UndoRedo::has_redo);
 	ClassDB::bind_method(D_METHOD("get_version"), &UndoRedo::get_version);

--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -115,6 +115,7 @@ public:
 
 	void start_force_keep_in_merge_ends();
 	void end_force_keep_in_merge_ends();
+	void set_index_in_history(int p_new_state_index);
 
 	bool is_committing_action() const;
 	void commit_action(bool p_execute = true);
@@ -125,8 +126,11 @@ public:
 	int get_action_level() const;
 
 	int get_history_count();
+	int get_action_count();
 	int get_current_action();
+	int get_current_action_index();
 	String get_action_name(int p_id);
+	String get_action_name_at_index(int p_index);
 	void clear_history(bool p_increase_version = true);
 	void discard_redo();
 

--- a/doc/classes/UndoRedo.xml
+++ b/doc/classes/UndoRedo.xml
@@ -88,6 +88,64 @@
 		_undo_redo.CommitAction();
 		[/csharp]
 		[/codeblocks]
+		Actions count up starting from 0.
+		Here is a simplified toy example that doesn't use [code]add_do*[/code] or [code]add_undo*[/code]. This is for example only, in practice you would always want at least one [code]add_do*[/code] or [code]add_undo*[/code].
+		[codeblocks]
+		[gdscript]
+		undo_redo.create_action("action A")
+		undo_redo.commit_action()
+		# Prints 0.
+		print(undo_redo.get_current_action_index())
+
+		undo_redo.create_action("action B")
+		undo_redo.commit_action()
+		# Prints 1.
+		print(undo_redo.get_current_action_index())
+
+		undo_redo.create_action("action C")
+		undo_redo.commit_action()
+		# Prints 2.
+		print(undo_redo.get_current_action_index())
+
+		undo_redo.undo()
+		undo_redo.undo()
+		# Prints 0.
+		print(undo_redo.get_current_action_index())
+		# This still prints 3 though.
+		print(undo_redo.get_history_count())
+		# Removes the actions that were undone by the two calls to "undo_redo.undo()" above.
+		undo_redo.discard_redo()
+		# Now this prints 1.
+		print(undo_redo.get_history_count())
+		[/gdscript]
+		[csharp]
+		_undo_redo.CreateAction("action A");
+		_undo_redo.CommitAction();
+		// Prints 0.
+		GD.Print(_undo_redo.GetCurrentActionIndex());
+
+		_undo_redo.CreateAction("action B");
+		_undo_redo.CommitAction();
+		// Prints 1.
+		GD.Print(_undo_redo.GetCurrentActionIndex());
+
+		_undo_redo.CreateAction("action C");
+		_undo_redo.CommitAction();
+		// Prints 2.
+		GD.Print(_undo_redo.GetCurrentActionIndex());
+
+		_undo_redo.Undo();
+		_undo_redo.Undo();
+		// Prints 0.
+		GD.Print(_undo_redo.GetCurrentActionIndex());
+		// This still prints 3 though.
+		GD.Print(_undo_redo.GetHistoryCount());
+		// Removes the actions that were undone by the two calls to "_undo_redo.Undo()" above.
+		_undo_redo.DiscardRedo();
+		// Now this prints 1.
+		GD.Print(_undo_redo.GetHistoryCount());
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 	</tutorials>
@@ -182,10 +240,22 @@
 				The way undo operation are ordered in actions is dictated by [param backward_undo_ops]. When [param backward_undo_ops] is [code]false[/code] undo option are ordered in the same order they were added. Which means the first operation to be added will be the first to be undone.
 			</description>
 		</method>
+		<method name="discard_redo">
+			<return type="void" />
+			<description>
+				Removes all actions that come after the current action. Calling this only has an effect when [method undo] has been called, to erase the undone actions from the action list.
+			</description>
+		</method>
 		<method name="end_force_keep_in_merge_ends">
 			<return type="void" />
 			<description>
 				Stops marking operations as to be processed even if the action gets merged with another in the [constant MERGE_ENDS] mode. See [method start_force_keep_in_merge_ends].
+			</description>
+		</method>
+		<method name="get_action_count">
+			<return type="int" />
+			<description>
+				Returns how many elements are in the history (same value as [method get_history_count]).
 			</description>
 		</method>
 		<method name="get_action_name">
@@ -193,12 +263,31 @@
 			<param index="0" name="id" type="int" />
 			<description>
 				Gets the action name from its index.
+				Negative indices can also be used.
+				To make index [code]-1[/code] be the index where the [method get_current_action_index] is, use [method discard_redo].
+				Same as [method get_action_name_at_index].
+			</description>
+		</method>
+		<method name="get_action_name_at_index">
+			<return type="String" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Gets the index of the current action (same as [method get_current_action]).
+				Negative indices can also be used.
+				To make index [code]-1[/code] be the index where the [method get_current_action_index] is, use [method discard_redo].
+				Same as [method get_action_name].
 			</description>
 		</method>
 		<method name="get_current_action">
 			<return type="int" />
 			<description>
-				Gets the index of the current action.
+				Gets the index of the current action (same as [method get_current_action_index]).
+			</description>
+		</method>
+		<method name="get_current_action_index">
+			<return type="int" />
+			<description>
+				Gets the index of the current action (same as [method get_current_action]).
 			</description>
 		</method>
 		<method name="get_current_action_name" qualifiers="const">
@@ -210,7 +299,7 @@
 		<method name="get_history_count">
 			<return type="int" />
 			<description>
-				Returns how many elements are in the history.
+				Returns how many elements are in the history (same value as [method get_action_count]).
 			</description>
 		</method>
 		<method name="get_version" qualifiers="const">
@@ -254,6 +343,7 @@
 			<return type="bool" />
 			<description>
 				Undo the last action.
+				[b]Note:[/b] Use [method discard_redo] after calling [method undo] to make the current action index be at the end of the action list.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
The API was a bit inconsistent and unclear. This attempts to fix some of that with examples and aliases for existing API methods, and exposing `discard_redo()`

Fixes https://github.com/godotengine/godot-proposals/issues/14539

The examples can be updated to use bind once https://github.com/godotengine/godot/pull/107756 gets merged

Maybe in a followup PR or this one depending on what people think:
- `get_action_name` could be `get_action_name_at_index`
- Add a built in way to print the UndoRedo object (just the names of the states, and maybe function names?)
- The editor inspector could show the state names, currently if the godot program hits a breakpoint in the editor, it is unknown what the state of the undo redo history was 
<img width="374" height="313" alt="image" src="https://github.com/user-attachments/assets/f860ca5e-f21a-4c5c-9e1c-b422d6de6180" />

