### PR TITLE
Fix undo moving GraphNode inside GraphEdit

### DIFF
--- a/scene/gui/graph_element.cpp
+++ b/scene/gui/graph_element.cpp
@@ -44,6 +44,18 @@ void GraphElement::_edit_set_position(const Point2 &p_position) {
 	}
 	set_position(p_position);
 }
+
+Dictionary GraphElement::_edit_get_state() const {
+	Dictionary state = super_type::_edit_get_state();
+	state["position_offset"] = position_offset;
+	return state;
+}
+
+void GraphElement::_edit_set_state(const Dictionary &p_state) {
+	super_type::_edit_set_state(p_state);
+	ERR_FAIL_COND(!p_state.has("position_offset"));
+	set_position_offset(p_state["position_offset"]);
+}
 #endif
 
 void GraphElement::_resort() {

--- a/scene/gui/graph_element.h
+++ b/scene/gui/graph_element.h
@@ -56,6 +56,8 @@ protected:
 
 #ifdef TOOLS_ENABLED
 	void _edit_set_position(const Point2 &p_position) override;
+	Dictionary _edit_get_state() const override;
+	void _edit_set_state(const Dictionary &p_state) override;
 #endif
 
 protected:


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Fixes https://github.com/godotengine/godot/issues/117734

The root cause of the bug isn't the lack of `_edit_get_position()`, but rather the lack of `_edit_get_state()` and `_edit_set_state()`. This PR adds `position_offset` to the edit state so it can be restored during undo/redo.

![godot_editor_undo_redo_graph_node](https://github.com/user-attachments/assets/e931145e-8576-496f-9364-00fffc239f27)
