### PR TITLE
GridMap Editor: Make the grid cursor's size customizable, cache editor settings

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -661,6 +661,9 @@
 		</member>
 		<member name="editors/bone_mapper/handle_colors/unset" type="Color" setter="" getter="">
 		</member>
+		<member name="editors/grid_map/grid_cursor_size" type="int" setter="" getter="">
+			The radius, in cells, of the grid that follows the cursor.
+		</member>
 		<member name="editors/grid_map/pick_distance" type="float" setter="" getter="">
 			The maximum distance at which tiles can be placed on a GridMap, relative to the camera position (in 3D units).
 		</member>

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -886,6 +886,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// GridMapEditor
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/grid_map/pick_distance", 5000.0, "1,8192,0.1,or_greater");
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "editors/grid_map/preview_size", 64, "16,128,1")
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "editors/grid_map/grid_cursor_size", 50, "2,100,1")
 
 	// 3D
 	EDITOR_SETTING_BASIC(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d/primary_grid_color", Color(0.56, 0.56, 0.56, 0.5), "")

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -905,7 +905,6 @@ EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D 
 
 		if (mb->is_pressed()) {
 			if (mb->get_button_index() == MouseButton::LEFT) {
-				View3DController::NavigationScheme nav_scheme = (View3DController::NavigationScheme)EDITOR_GET("editors/3d/navigation/navigation_scheme").operator int();
 				if ((nav_scheme == View3DController::NAV_SCHEME_MAYA || nav_scheme == View3DController::NAV_SCHEME_MODO) && mb->is_alt_pressed()) {
 					return EditorPlugin::AFTER_GUI_INPUT_PASS;
 				}
@@ -1078,7 +1077,7 @@ void GridMapEditor::_icon_size_changed(float p_value) {
 }
 
 void GridMapEditor::update_palette() {
-	float min_size = EDITOR_GET("editors/grid_map/preview_size");
+	float min_size = preview_size;
 	min_size *= EDSCALE;
 
 	mesh_library_palette->clear();
@@ -1271,16 +1270,16 @@ void GridMapEditor::_draw_grids(const Vector3 &cell_size) {
 		Vector3 axis_n2;
 		axis_n2[(i + 2) % 3] = cell_size[(i + 2) % 3];
 
-		for (int j = -GRID_CURSOR_SIZE; j <= GRID_CURSOR_SIZE; j++) {
-			for (int k = -GRID_CURSOR_SIZE; k <= GRID_CURSOR_SIZE; k++) {
+		for (int j = -grid_cursor_size; j <= grid_cursor_size; j++) {
+			for (int k = -grid_cursor_size; k <= grid_cursor_size; k++) {
 				Vector3 p = axis_n1 * j + axis_n2 * k;
-				float trans = Math::pow(MAX(0, 1.0 - (Vector2(j, k).length() / GRID_CURSOR_SIZE)), 2);
+				float trans = Math::pow(MAX(0, 1.0 - (Vector2(j, k).length() / grid_cursor_size)), 2);
 
 				Vector3 pj = axis_n1 * (j + 1) + axis_n2 * k;
-				float transj = Math::pow(MAX(0, 1.0 - (Vector2(j + 1, k).length() / GRID_CURSOR_SIZE)), 2);
+				float transj = Math::pow(MAX(0, 1.0 - (Vector2(j + 1, k).length() / grid_cursor_size)), 2);
 
 				Vector3 pk = axis_n1 * j + axis_n2 * (k + 1);
-				float transk = Math::pow(MAX(0, 1.0 - (Vector2(j, k + 1).length() / GRID_CURSOR_SIZE)), 2);
+				float transk = Math::pow(MAX(0, 1.0 - (Vector2(j, k + 1).length() / grid_cursor_size)), 2);
 
 				grid_points[i].push_back(p);
 				grid_points[i].push_back(pk);
@@ -1408,10 +1407,20 @@ void GridMapEditor::_notification(int p_what) {
 		} break;
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			indicator_mat->set_albedo(EDITOR_GET("editors/3d_gizmos/gizmo_colors/gridmap_grid"));
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/3d_gizmos/gizmo_colors")) {
+				indicator_mat->set_albedo(EDITOR_GET("editors/3d_gizmos/gizmo_colors/gridmap_grid"));
+			}
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/3d/navigation")) {
+				nav_scheme = (View3DController::NavigationScheme)EDITOR_GET("editors/3d/navigation/navigation_scheme").operator int();
+			}
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/grid_map")) {
+				preview_size = EDITOR_GET("editors/grid_map/preview_size");
+				grid_cursor_size = EDITOR_GET("editors/grid_map/grid_cursor_size");
 
-			// Take Preview Size changes into account.
-			update_palette();
+				update_palette();
+				_draw_grids(node->get_cell_size());
+				update_grid();
+			}
 		} break;
 	}
 }
@@ -1938,6 +1947,10 @@ GridMapEditor::GridMapEditor() {
 	indicator_mat->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 	indicator_mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
 	indicator_mat->set_albedo(EDITOR_GET("editors/3d_gizmos/gizmo_colors/gridmap_grid"));
+
+	nav_scheme = (View3DController::NavigationScheme)EDITOR_GET("editors/3d/navigation/navigation_scheme").operator int();
+	preview_size = EDITOR_GET("editors/grid_map/preview_size");
+	grid_cursor_size = EDITOR_GET("editors/grid_map/grid_cursor_size");
 }
 
 GridMapEditor::~GridMapEditor() {

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -34,6 +34,7 @@
 
 #include "editor/docks/editor_dock.h"
 #include "editor/plugins/editor_plugin.h"
+#include "scene/debugger/view_3d_controller.h"
 #include "scene/gui/box_container.h"
 
 class Button;
@@ -50,8 +51,6 @@ class SpinBox;
 
 class GridMapEditor : public EditorDock {
 	GDCLASS(GridMapEditor, EditorDock);
-
-	static constexpr int32_t GRID_CURSOR_SIZE = 50;
 
 	enum InputAction {
 		INPUT_NONE,
@@ -218,6 +217,11 @@ class GridMapEditor : public EditorDock {
 
 	ItemList *mesh_library_palette = nullptr;
 	Label *info_message = nullptr;
+
+	// Editor settings.
+	int grid_cursor_size = 0;
+	View3DController::NavigationScheme nav_scheme = View3DController::NavigationScheme::NAV_SCHEME_GODOT;
+	float preview_size = 0;
 
 	void update_grid(); // Change which and where the grid is displayed
 	void _draw_grids(const Vector3 &cell_size);


### PR DESCRIPTION
As it is, the gridmap editor grid is very large and gets in the way of properly perceiving the scene while editing. The size is already a constant in code, so it is a matter of exposing it as an editor setting.

Also introduce a cache for the other settings the editor uses, as `EDITOR_GET()` has proven to be very slow.

Current grid:
<img width="1339" height="693" alt="image" src="https://github.com/user-attachments/assets/06e524ca-bebe-48f1-8e66-3450ff658efa" />


Now possible:
<img width="1345" height="738" alt="image" src="https://github.com/user-attachments/assets/00db8438-45d3-4ef5-a99d-7f5deaa9c0fa" />
