### PR TITLE
Mention relation of `download_file` and body parameter

### DIFF
--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -268,6 +268,7 @@
 			<param index="3" name="body" type="PackedByteArray" />
 			<description>
 				Emitted when a request is completed.
+				[b]Note:[/b] The [param body] will be empty if [member download_file] is set.
 			</description>
 		</signal>
 	</signals>


### PR DESCRIPTION
When you set `download_file` property of HTTPRequest, the `body` parameter of `request_completed` will be empty, and its contents instead dumped into the target file. The documentation failed to mention that.

`download_file` description could also get updated, but I wasn't sure how to include this info.