### PR TITLE
Add `node name` to `EditorDebuggerInspector`

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -104,7 +104,13 @@ void EditorDebuggerRemoteObjects::set_property_field(const StringName &p_propert
 String EditorDebuggerRemoteObjects::get_title() {
 	if (!remote_object_ids.is_empty() && ObjectID(remote_object_ids[0].operator uint64_t()).is_valid()) {
 		const int size = remote_object_ids.size();
-		return size == 1 ? vformat(TTR("Remote %s: %d"), type_name, remote_object_ids[0]) : vformat(TTR("Remote %s (%d Selected)"), type_name, size);
+		if (size == 1) {
+			if (node_name.is_empty() || node_name == type_name) {
+				return vformat(TTR("Remote %s: %d"), type_name, remote_object_ids[0]);
+			}
+			return vformat(TTR("Remote %s (%s): %d"), type_name, node_name, remote_object_ids[0]);
+		}
+		return vformat(TTR("Remote %s (%d Selected)"), type_name, size);
 	}
 
 	return "<null>";
@@ -347,6 +353,15 @@ EditorDebuggerRemoteObjects *EditorDebuggerInspector::set_objects(const Array &p
 		}
 	}
 	remote_objects->type_name = class_name;
+	remote_objects->node_name = "";
+	if (objects.size() == 1) {
+		for (const SceneDebuggerObject::SceneDebuggerProperty &prop : objects[0].properties) {
+			if (prop.first.name == "name") {
+				remote_objects->node_name = prop.second;
+				break;
+			}
+		}
+	}
 
 	if (old_prop_size == remote_objects->prop_list.size() && new_props_added == 0) {
 		// Only some may have changed, if so, then update those, if they exist.

--- a/editor/debugger/editor_debugger_inspector.h
+++ b/editor/debugger/editor_debugger_inspector.h
@@ -52,6 +52,7 @@ protected:
 public:
 	TypedArray<uint64_t> remote_object_ids;
 	String type_name;
+	String node_name; // For human-readable name.
 	List<PropertyInfo> prop_list;
 	HashMap<StringName, TypedDictionary<uint64_t, Variant>> prop_values;
 

--- a/scene/debugger/scene_debugger_object.cpp
+++ b/scene/debugger/scene_debugger_object.cpp
@@ -53,6 +53,11 @@ SceneDebuggerObject::SceneDebuggerObject(Object *p_obj) {
 	}
 
 	if (Node *node = Object::cast_to<Node>(p_obj)) {
+		{
+			PropertyInfo pi(Variant::STRING_NAME, "name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE);
+			properties.push_back(SceneDebuggerProperty(pi, node->get_name()));
+		}
+
 		// For debugging multiplayer.
 		{
 			PropertyInfo pi(Variant::INT, String("Node/multiplayer_authority"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY);


### PR DESCRIPTION
Fix: #117860

<img width="1295" height="135" alt="2026-03-26_11-16-48" src="https://github.com/user-attachments/assets/739e3ce0-7dde-4d8e-be30-996353711b8d" />

