### PR TITLE
[Unix] Fix global state pollution in `DirAccessUnix::change_dir`

### DIFF
--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -345,14 +345,6 @@ Error DirAccessUnix::change_dir(String p_dir) {
 
 	p_dir = fix_path(p_dir);
 
-	// prev_dir is the directory we are changing out of
-	String prev_dir;
-	char real_current_dir_name[2048];
-	ERR_FAIL_NULL_V(getcwd(real_current_dir_name, 2048), ERR_BUG);
-	if (prev_dir.append_utf8(real_current_dir_name) != OK) {
-		prev_dir = real_current_dir_name; //no utf8, maybe latin?
-	}
-
 	// try_dir is the directory we are trying to change into
 	String try_dir = "";
 	if (p_dir.is_relative_path()) {
@@ -363,25 +355,34 @@ Error DirAccessUnix::change_dir(String p_dir) {
 		try_dir = p_dir;
 	}
 
-	bool worked = (chdir(try_dir.utf8().get_data()) == 0); // we can only give this utf8
-	if (!worked) {
+	// most of these functions require utf8 and try_dir is now immutable
+	// do the conversion once
+	CharString try_dir_utf8 = try_dir.utf8();
+
+	// verify the directory exists and is accessible, using stat()+access()
+	struct stat s;
+	if (stat(try_dir_utf8.get_data(), &s) != 0 || !S_ISDIR(s.st_mode)) {
+		return ERR_INVALID_PARAMETER;
+	}
+	if (access(try_dir_utf8.get_data(), X_OK) != 0) {
 		return ERR_INVALID_PARAMETER;
 	}
 
+	// verify that this is contained within our root path
 	String base = _get_root_path();
 	if (!base.is_empty() && !try_dir.begins_with(base)) {
-		ERR_FAIL_NULL_V(getcwd(real_current_dir_name, 2048), ERR_BUG);
+		char real_current_dir_name[PATH_MAX];
+		ERR_FAIL_NULL_V(realpath(try_dir_utf8.get_data(), real_current_dir_name), ERR_BUG);
 		String new_dir;
 		new_dir.append_utf8(real_current_dir_name);
 
 		if (!new_dir.begins_with(base)) {
-			try_dir = current_dir; //revert
+			return ERR_INVALID_PARAMETER;
 		}
 	}
 
-	// the directory exists, so set current_dir to try_dir
+	// all checks pass, so set current_dir to try_dir
 	current_dir = try_dir;
-	ERR_FAIL_COND_V(chdir(prev_dir.utf8().get_data()) != 0, ERR_BUG);
 	return OK;
 }
 


### PR DESCRIPTION
Replace `chdir`/`getcwd` with `stat`/`access`/`realpath` to validate directories without temporarily changing the process-wide working directory, which caused race conditions in multithreaded contexts.

Fixes #115321.

----

Here's the C# test I ended up putting in my test suite to verify that this doesn't happen again:

```cs
// project.godot is guaranteed to exist in the CWD
const string relativePath = "project.godot";

// Sanity check: the file must exist right now
Assert.IsTrue(File.Exists(relativePath), $"Precondition failed: {relativePath} does not exist from CWD {Directory.GetCurrentDirectory()}");

const int iterations = 10000;
bool raceDetected = false;
string failedCwd = null;

var readerThread = new Thread(() =>
{
    for (int i = 0; i < iterations; i++)
    {
        if (!File.Exists(relativePath))
        {
            raceDetected = true;
            failedCwd = Directory.GetCurrentDirectory();
            break;
        }
    }
});

var dirAccessThread = new Thread(() =>
{
    for (int i = 0; i < iterations; i++)
    {
        if (raceDetected)
        {
            break;
        }

        // This triggers DirAccessUnix::change_dir("user://") internally,
        // which temporarily chdir's the process to the user data directory.
        using (var da = Godot.DirAccess.Open("user://"))
        {
            // just opening and closing is enough to trigger the race
        }
    }
});

readerThread.Start();
dirAccessThread.Start();

readerThread.Join();
dirAccessThread.Join();

Assert.IsFalse(raceDetected, $"Race detected: File.Exists failed because CWD was temporarily changed to '{failedCwd}'");
```

I can replicate something of the sort in C++ if you want it added to Godot tests, but it's kind of a weird specialized test to add to the suite forever.

----

This is mostly a bugfix, but contains one behavior change, which is that trying to chdir outside the root path will now give an error instead of returning success but doing nothing.

----

Used Claude to find the original bug and write the first version of the fix. Then did a lot of tweaking and polishing. This carries my personal stamp of approval.