### PR TITLE
Fix infinite loop in debugger when script has parse error

### DIFF
--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -134,6 +134,13 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 	print_line("\nDebugger Break, Reason: '" + script_lang->debug_get_error() + "'");
 	print_line("*Frame " + itos(0) + " - " + script_lang->debug_get_stack_level_source(0) + ":" + itos(script_lang->debug_get_stack_level_line(0)) + " in function '" + script_lang->debug_get_stack_level_function(0) + "'");
 	print_line("Enter \"help\" for assistance.");
+
+	// Check if the stdin type is compatible with the interactive debugger, if not print error and return
+	if (OS::get_singleton()->get_stdin_type() != OS::STD_HANDLE_CONSOLE) {
+		print_line("Cannot start interactive debugger: invalid stdin type");
+		return;
+	}
+
 	int current_frame = 0;
 	int total_frames = script_lang->debug_get_stack_level_count();
 	while (true) {


### PR DESCRIPTION
If using Godot in a way that doesn't support stdin input (e.g. headless mode, or without the console wrapper on Windows), the interactive debugger gets stuck in an infinite loop when the --debug flag is used and a script has a parse error

Fixes #117123

When a parse error occurs during script loading, debug_break_parse() invokes the local interactive debugger. The debugger's main loop calls get_stdin_string() which returns empty immediately when there is no interactive console attached, and feof(stdin) never evaluates to true in this scenario, preventing the quit branch from being reached and causing an infinite loop.

The fix adds a check before entering the debugger loop in LocalDebugger::debug() that checks the stdin type, if it is not STD_HANDLE_CONSOLE then the error information is printed and the function returns early.

Tested on Windows with and without --headless, with and without the console wrapper executable. The interactive debugger still works correctly when launched via the console wrapper.

Claude was used to help me navigate and understand the codebase. All investigation, testing, and final decisions were made by me with help from the godot contributors chat (https://chat.godotengine.org/channel/new-contributors/thread/rgiMeto2TytKbxksu)