### PR TITLE
Allow copy and paste of inspector properties as json

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -979,6 +979,9 @@
 		<member name="interface/editor/behavior/automatically_open_screenshots" type="bool" setter="" getter="">
 			If [code]true[/code], automatically opens screenshots with the default program associated to [code].png[/code] files after a screenshot is taken using the [b]Editor &gt; Take Screenshot[/b] action.
 		</member>
+		<member name="interface/editor/behavior/copy_properties_as_json_to_os_clipboard_as_well" type="bool" setter="" getter="">
+			If [code]true[/code], clicking [b]Copy Value[/b] in the right click menu on an inspector option will copy the value as JSON to the OS clipboard, in addition to the Inspector clipboard. When clicking [b]Paste Value[/b], the value on the OS clipboard will attempt to be pasted. If this fails, the Inspector clipboard is pasted instead.
+		</member>
 		<member name="interface/editor/behavior/import_resources_when_unfocused" type="bool" setter="" getter="">
 			If [code]true[/code], (re)imports resources even if the editor window is unfocused or minimized. If [code]false[/code], resources are only (re)imported when the editor window is focused. This can be set to [code]true[/code] to speed up iteration by starting the import process earlier when saving files in the project folder. This also allows getting visual feedback on changes without having to click the editor window, which is useful with multi-monitor setups. The downside of setting this to [code]true[/code] is that it increases idle CPU usage and may steal CPU time from other applications when importing resources.
 		</member>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -980,7 +980,7 @@
 			If [code]true[/code], automatically opens screenshots with the default program associated to [code].png[/code] files after a screenshot is taken using the [b]Editor &gt; Take Screenshot[/b] action.
 		</member>
 		<member name="interface/editor/behavior/copy_properties_as_json_to_os_clipboard_as_well" type="bool" setter="" getter="">
-			If [code]true[/code], clicking [b]Copy Value[/b] in the right click menu on an inspector option will copy the value as JSON to the OS clipboard, in addition to the Inspector clipboard. When clicking [b]Paste Value[/b], the value on the OS clipboard will attempt to be pasted. If this fails, the Inspector clipboard is pasted instead.
+			If [code]true[/code], clicking [b]Copy Value[/b] in the right click menu on an inspector option will copy the value as JSON to the OS clipboard, in addition to the Inspector clipboard. When clicking [b]Paste Value[/b], an attempt to paste the value on the OS clipboard will be made. If this fails, the Inspector clipboard is pasted instead.
 		</member>
 		<member name="interface/editor/behavior/import_resources_when_unfocused" type="bool" setter="" getter="">
 			If [code]true[/code], (re)imports resources even if the editor window is unfocused or minimized. If [code]false[/code], resources are only (re)imported when the editor window is focused. This can be set to [code]true[/code] to speed up iteration by starting the import process earlier when saving files in the project folder. This also allows getting visual feedback on changes without having to click the editor window, which is useful with multi-monitor setups. The downside of setting this to [code]true[/code] is that it increases idle CPU usage and may steal CPU time from other applications when importing resources.

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -32,6 +32,7 @@
 #include "editor_inspector.compat.inc"
 
 #include "core/input/input.h"
+#include "core/io/json.h"
 #include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
@@ -1236,6 +1237,12 @@ void EditorProperty::shortcut_input(const Ref<InputEvent> &p_event) {
 		} else if (!internal && ED_IS_SHORTCUT("property_editor/copy_property_path", p_event)) {
 			menu_option(MENU_COPY_PROPERTY_PATH);
 			accept_event();
+		} else if (ED_IS_SHORTCUT("property_editor/copy_value_to_json", p_event)) {
+			menu_option(MENU_COPY_VALUE_TO_JSON);
+			accept_event();
+		} else if (!is_read_only() && ED_IS_SHORTCUT("property_editor/paste_value_from_json", p_event)) {
+			menu_option(MENU_PASTE_VALUE_FROM_JSON);
+			accept_event();
 		}
 	}
 }
@@ -1456,12 +1463,48 @@ Control *EditorProperty::make_custom_tooltip(const String &p_text) const {
 	return nullptr;
 }
 
+void EditorProperty::copy_to_json(Variant p_to_copy) {
+	Variant json_value = JSON::from_native(p_to_copy, true);
+	String json_string = JSON::stringify(json_value, "\t");
+	DisplayServer::get_singleton()->clipboard_set(json_string);
+}
+
+bool EditorProperty::try_to_paste_json() {
+	String json_string = DisplayServer::get_singleton()->clipboard_get();
+	if (!json_string.is_empty()) {
+		Variant json_value = JSON::parse_string(json_string);
+		if (json_value.get_type() != Variant::NIL) {
+			Variant native_value = JSON::to_native(json_value, true);
+			if (native_value.get_type() != Variant::NIL) {
+				emit_changed(property, native_value);
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 void EditorProperty::menu_option(int p_option) {
 	switch (p_option) {
+		case MENU_COPY_VALUE_TO_JSON: {
+			copy_to_json(object->get(property));
+		} break;
+		case MENU_PASTE_VALUE_FROM_JSON: {
+			try_to_paste_json();
+		} break;
 		case MENU_COPY_VALUE: {
 			EditorInspector::set_property_clipboard(EditorInspector::PropertyClipboard::Type::PROPERTY, object->get(property));
+			if (EDITOR_GET("interface/editor/behavior/copy_properties_as_json_to_os_clipboard_as_well")) {
+				copy_to_json(object->get(property));
+			}
 		} break;
 		case MENU_PASTE_VALUE: {
+			if (EDITOR_GET("interface/editor/behavior/copy_properties_as_json_to_os_clipboard_as_well")) {
+				bool worked = try_to_paste_json();
+				if (worked) {
+					return;
+				}
+			}
 			if (EditorInspector::get_property_clipboard_type() != EditorInspector::PropertyClipboard::Type::PROPERTY) {
 				return;
 			}
@@ -1631,6 +1674,9 @@ void EditorProperty::_update_popup() {
 	menu->set_item_disabled(-1, read_only || EditorInspector::get_property_clipboard_type() != EditorInspector::PropertyClipboard::Type::PROPERTY);
 	menu->add_icon_shortcut(theme_cache.copy_node_path_icon, ED_GET_SHORTCUT("property_editor/copy_property_path"), MENU_COPY_PROPERTY_PATH);
 	menu->set_item_disabled(-1, internal);
+	menu->add_separator();
+	menu->add_icon_shortcut(theme_cache.paste_icon, ED_GET_SHORTCUT("property_editor/copy_value_to_json"), MENU_COPY_VALUE_TO_JSON);
+	menu->add_icon_shortcut(theme_cache.paste_icon, ED_GET_SHORTCUT("property_editor/paste_value_from_json"), MENU_PASTE_VALUE_FROM_JSON);
 
 	if (can_favorite || !pin_hidden) {
 		menu->add_separator();
@@ -6354,6 +6400,9 @@ EditorInspector::EditorInspector() {
 	ED_SHORTCUT("property_editor/copy_value", TTRC("Copy Value"), KeyModifierMask::CMD_OR_CTRL | Key::C);
 	ED_SHORTCUT("property_editor/paste_value", TTRC("Paste Value"), KeyModifierMask::CMD_OR_CTRL | Key::V);
 	ED_SHORTCUT("property_editor/copy_property_path", TTRC("Copy Property Path"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::C);
+
+	ED_SHORTCUT("property_editor/copy_value_to_json", TTRC("Copy Value To JSON"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::C);
+	ED_SHORTCUT("property_editor/paste_value_from_json", TTRC("Paste Value From JSON"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::V);
 
 	// `use_settings_name_style` is true by default, set the name style accordingly.
 	set_property_name_style(EditorPropertyNameProcessor::get_singleton()->get_settings_style());

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -126,6 +126,8 @@ public:
 		MENU_DELETE,
 		MENU_REVERT_VALUE,
 		MENU_OPEN_DOCUMENTATION,
+		MENU_COPY_VALUE_TO_JSON,
+		MENU_PASTE_VALUE_FROM_JSON,
 	};
 
 	enum ColorationMode {
@@ -328,6 +330,8 @@ public:
 
 	bool can_revert_to_default() const { return can_revert; }
 
+	void copy_to_json(Variant p_to_copy);
+	bool try_to_paste_json();
 	void menu_option(int p_option);
 
 	EditorProperty();

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -553,6 +553,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// being focused again, so this should be used at the user's discretion.
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/timers/unfocused_low_processor_mode_sleep_usec", 100000, "1,1000000,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/behavior/copy_properties_as_json_to_os_clipboard_as_well", false, "")
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/behavior/import_resources_when_unfocused", false, "")
 
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/display/vsync_mode", 1, "Disabled,Enabled,Adaptive,Mailbox")


### PR DESCRIPTION
Allows copying and pasting of properties as json to the OS clipboard, not just the inspector clipboard.

Adds an editor setting to make the existing "copy value" and "paste value" buttons also copy to the OS clipboard as well as the inspector one. Users can optionally only copy as json.

As a bonus, this also works when a using the built in debugger/ a breakpoint is hit. The value of a very large dictionary can be copied out of the editor easily as json instead of needing to be printed.

One change I wanted to make, but was having trouble figuring out how to do, was being able to right click the property itself/the button that expands it in the case of a dictionary. (If you know how/ I'm all ears.)

Fixes https://github.com/godotengine/godot-proposals/issues/13617

Uses some of the code provided in that thread by @DexterFstone 


https://github.com/user-attachments/assets/f8b1ec96-e7b0-41b4-9af7-2e8829699662

