### PR TITLE
Make click to copy more visible

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -2784,7 +2784,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 			p_rt->set_cell_padding(Rect2(0, 10 * EDSCALE, 0, 10 * EDSCALE));
 			p_rt->set_cell_size_override(Vector2(1, 1), Vector2(10, 10) * EDSCALE);
 			p_rt->push_meta("^" + codeblock_copy_text, RichTextLabel::META_UNDERLINE_ON_HOVER);
-			p_rt->add_image(p_owner_node->get_editor_theme_icon(SNAME("ActionCopy")), 24 * EDSCALE, 24 * EDSCALE, Color(link_property_color, 0.3), INLINE_ALIGNMENT_BOTTOM_TO, Rect2(), Variant(), false, TTR("Click to copy."));
+			p_rt->add_image(p_owner_node->get_editor_theme_icon(SNAME("ActionCopy")), 24 * EDSCALE, 24 * EDSCALE, Color(link_property_color, 0.5), INLINE_ALIGNMENT_BOTTOM_TO, Rect2(), Variant(), false, TTR("Click to copy."));
 			p_rt->pop(); // meta
 			p_rt->pop(); // cell
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/14546

Goes from this (.3 opacity)
<img width="1916" height="1050" alt="image" src="https://github.com/user-attachments/assets/28c7687e-7775-4005-82ca-da1864c6c64a" />

To this with my change (0.5 opacity )
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ea4a2565-4859-4743-94c5-440545c5c9f7" />

OLD (I had tried this amount, but people said it was too much 0.9 opacity):
<img width="1916" height="1050" alt="image" src="https://github.com/user-attachments/assets/a5fa2db0-18e8-4312-aa44-6f9ff4178411" />

