### PR TITLE
Use class name instead of Object ID in `Debugger`

### DIFF
--- a/core/debugger/debugger_marshalls.cpp
+++ b/core/debugger/debugger_marshalls.cpp
@@ -81,16 +81,20 @@ Array DebuggerMarshalls::ScriptStackVariable::serialize(int max_size) {
 	} else {
 		arr.push_back(var);
 	}
+
+	arr.push_back(type_hint);
+
 	return arr;
 }
 
 bool DebuggerMarshalls::ScriptStackVariable::deserialize(const Array &p_arr) {
-	CHECK_SIZE(p_arr, 4, "ScriptStackVariable");
+	CHECK_SIZE(p_arr, 5, "ScriptStackVariable");
 	name = p_arr[0];
 	type = p_arr[1];
 	var_type = p_arr[2];
 	value = p_arr[3];
-	CHECK_END(p_arr, 4, "ScriptStackVariable");
+	type_hint = p_arr[4];
+	CHECK_END(p_arr, 5, "ScriptStackVariable");
 	return true;
 }
 
@@ -176,4 +180,28 @@ Ref<Shortcut> DebuggerMarshalls::deserialize_key_shortcut(const Array &p_keys) {
 	shortcut.instantiate();
 	shortcut->set_events(key_events);
 	return shortcut;
+}
+
+String DebuggerMarshalls::parse_type_from_variant(const Variant &p_variant) {
+	String name;
+
+	if (p_variant.get_type() == Variant::OBJECT) {
+		const Object *obj = p_variant.get_validated_object();
+		if (obj) {
+			const ScriptInstance *script_instance = obj->get_script_instance();
+
+			if (script_instance) {
+				Ref<Script> script = script_instance->get_script();
+				if (script.is_valid()) {
+					name = script->get_global_name();
+				}
+			}
+
+			if (name.is_empty()) {
+				return obj->get_class();
+			}
+		}
+	}
+
+	return name;
 }

--- a/core/debugger/debugger_marshalls.h
+++ b/core/debugger/debugger_marshalls.h
@@ -39,6 +39,7 @@ struct DebuggerMarshalls {
 		Variant value;
 		int type = -1;
 		int var_type = -1;
+		String type_hint;
 
 		Array serialize(int max_size = 1 << 20); // 1 MiB default.
 		bool deserialize(const Array &p_arr);
@@ -70,4 +71,6 @@ struct DebuggerMarshalls {
 
 	static Array serialize_key_shortcut(const Ref<Shortcut> &p_shortcut);
 	static Ref<Shortcut> deserialize_key_shortcut(const Array &p_keys);
+
+	static String parse_type_from_variant(const Variant &p_variant);
 };

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -329,6 +329,7 @@ void RemoteDebugger::_send_stack_vars(List<String> &p_names, List<Variant> &p_va
 		stvar.name = E->get();
 		stvar.value = F->get();
 		stvar.type = p_type;
+		stvar.type_hint = DebuggerMarshalls::parse_type_from_variant(F->get());
 		send_message("stack_frame_var", stvar.serialize());
 		E = E->next();
 		F = F->next();

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -411,7 +411,7 @@ void EditorDebuggerInspector::add_stack_variable(const Array &p_array, int p_off
 	if (var.var_type == Variant::OBJECT && v) {
 		v = Object::cast_to<EncodedObjectAsID>(v)->get_object_id();
 		h = PROPERTY_HINT_OBJECT_ID;
-		hs = "Object";
+		hs = var.type_hint;
 	}
 	String type;
 	switch (var.type) {

--- a/scene/debugger/scene_debugger_object.cpp
+++ b/scene/debugger/scene_debugger_object.cpp
@@ -32,6 +32,7 @@
 
 #include "scene_debugger_object.h"
 
+#include "core/debugger/debugger_marshalls.h"
 #include "core/io/marshalls.h"
 #include "core/object/script_language.h"
 #include "scene/main/node.h"
@@ -79,7 +80,7 @@ SceneDebuggerObject::SceneDebuggerObject(Object *p_obj) {
 		const Variant &m = p_obj->get(E.name);
 
 		if (!m.is_null() && E.type == Variant::OBJECT && E.hint == PROPERTY_HINT_NODE_TYPE && E.usage & PROPERTY_USAGE_EDITOR) {
-			E.hint_string = _parse_type_from_remote_object(m);
+			E.hint_string = DebuggerMarshalls::parse_type_from_variant(m);
 		}
 
 		if (E.usage & (PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_CATEGORY)) {
@@ -146,7 +147,7 @@ void SceneDebuggerObject::_parse_script_properties(Script *p_script, ScriptInsta
 			if (p_instance->get(E, m)) {
 				const String script_path = sm.key == p_script ? "" : sm.key->get_path().get_file() + "/";
 				if (!m.is_null() && m.get_type() == Variant::OBJECT) {
-					PropertyInfo pi(m.get_type(), "Members/" + script_path + E, PROPERTY_HINT_OBJECT_ID, _parse_type_from_remote_object(m));
+					PropertyInfo pi(m.get_type(), "Members/" + script_path + E, PROPERTY_HINT_OBJECT_ID, DebuggerMarshalls::parse_type_from_variant(m));
 					properties.push_back(SceneDebuggerProperty(pi, m));
 				} else {
 					PropertyInfo pi;
@@ -168,7 +169,7 @@ void SceneDebuggerObject::_parse_script_properties(Script *p_script, ScriptInsta
 		for (const KeyValue<StringName, Variant> &E : sc.value) {
 			const String script_path = sc.key == p_script ? "" : sc.key->get_path().get_file() + "/";
 			if (!E.value.is_null() && E.value.get_type() == Variant::OBJECT) {
-				PropertyInfo pi(E.value.get_type(), "Constants/" + E.key, PROPERTY_HINT_OBJECT_ID, _parse_type_from_remote_object(E.value), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY);
+				PropertyInfo pi(E.value.get_type(), "Constants/" + E.key, PROPERTY_HINT_OBJECT_ID, DebuggerMarshalls::parse_type_from_variant(E.value), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY);
 				properties.push_back(SceneDebuggerProperty(pi, E.value));
 			} else {
 				PropertyInfo pi(E.value.get_type(), "Constants/" + script_path + E.key);
@@ -178,29 +179,6 @@ void SceneDebuggerObject::_parse_script_properties(Script *p_script, ScriptInsta
 			}
 		}
 	}
-}
-String SceneDebuggerObject::_parse_type_from_remote_object(const Variant &p_variant) {
-	String name;
-
-	if (p_variant.get_type() == Variant::OBJECT) {
-		const Object *obj = p_variant.get_validated_object();
-		if (obj) {
-			const ScriptInstance *script_instance = obj->get_script_instance();
-
-			if (script_instance) {
-				Ref<Script> script = script_instance->get_script();
-				if (script.is_valid()) {
-					name = script->get_global_name();
-				}
-			}
-
-			if (name.is_empty()) {
-				return obj->get_class();
-			}
-		}
-	}
-
-	return name;
 }
 
 void SceneDebuggerObject::serialize(Array &r_arr, int p_max_size) {

--- a/scene/debugger/scene_debugger_object.h
+++ b/scene/debugger/scene_debugger_object.h
@@ -43,7 +43,6 @@ class Script;
 class SceneDebuggerObject {
 private:
 	void _parse_script_properties(Script *p_script, ScriptInstance *p_instance);
-	static String _parse_type_from_remote_object(const Variant &p_variant);
 
 public:
 	typedef Pair<PropertyInfo, Variant> SceneDebuggerProperty;


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/115738, but for the `Debugger`.
_Also_ refactors helper function from https://github.com/godotengine/godot/pull/115738 to be in a more appropriate place for reuse.

--

| Before | After |
| ------------- | ------------- |
|  ![image](https://github.com/user-attachments/assets/7b391caf-461f-44c5-b57e-96447c9f261c) | ![image](https://github.com/user-attachments/assets/87798789-4eb4-4db7-ab04-546bad28ce9a) |