### PR TITLE
Remove "ID" from Object ID display

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1649,10 +1649,10 @@ void EditorPropertyObjectID::update_property() {
 		type = "Object";
 	}
 
-	ObjectID id = _get_object_id();
+	const ObjectID id = _get_object_id();
 	if (id.is_valid()) {
-		edit->set_text(type + " ID: " + uitos(id));
-		edit->set_tooltip_text(type + " ID: " + uitos(id));
+		edit->set_text(type + ": " + uitos(id));
+		edit->set_tooltip_text(type + ": " + uitos(id));
 		edit->set_disabled(false);
 		edit->set_button_icon(EditorNode::get_singleton()->get_class_icon(type));
 	} else {


### PR DESCRIPTION
Related to https://github.com/godotengine/godot-proposals/issues/14433.
Saves a bit of space by removing the "ID" piece from the Object display. Matches the header as well, as that does not display "ID".

--

| Before | After |
| ------------- | ------------- |
|  ![image](https://github.com/user-attachments/assets/55e7a3ed-1f89-43e2-bf1e-1debc1668f41) | ![image](https://github.com/user-attachments/assets/0994d8bb-d381-4601-ab77-c6a293357811) |