### PR TITLE
Fix Android editor stops accepting touch, mouse, and keyboard input after prolonged usage.

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1608,6 +1608,8 @@ void Input::release_pressed_events() {
 	keys_pressed.clear();
 	physical_keys_pressed.clear();
 	key_label_pressed.clear();
+	mouse_button_mask.clear();
+	touch_velocity_track.clear();
 	if (ignore_joypad_on_unfocused_application) {
 		joy_buttons_pressed.clear();
 		_joy_axis.clear();

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
@@ -920,8 +920,12 @@ class Godot private constructor(val context: Context) {
 	 *
 	 * This must be called after the render thread has started.
 	 */
-	fun runOnRenderThread(action: Runnable) {
-		renderView?.queueOnRenderThread(action)
+	fun runOnRenderThread(action: Runnable): Boolean {
+		if (renderView != null) {
+			renderView?.queueOnRenderThread(action)
+			return true
+		}
+		return false
 	}
 
 	/**

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/gl/GLSurfaceView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/gl/GLSurfaceView.java
@@ -1307,6 +1307,12 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 			} catch (InterruptedException e) {
 				// fall thru and exit normally
 			} finally {
+				synchronized (sGLThreadManager) {
+					for (Runnable r : mEventQueue) {
+						r.run();
+					}
+					mEventQueue.clear();
+				}
 				sGLThreadManager.threadExiting(this);
 			}
 		}

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
@@ -788,7 +788,9 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 
 	private void dispatchInputEventRunnable(@NonNull InputEventRunnable runnable) {
 		if (shouldDispatchInputToRenderThread()) {
-			godot.runOnRenderThread(runnable);
+			if (!godot.runOnRenderThread(runnable)) {
+				runnable.run();
+			}
 		} else {
 			runnable.run();
 		}

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/vulkan/VkThread.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/vulkan/VkThread.kt
@@ -79,6 +79,11 @@ internal class VkThread(private val vkSurfaceView: VkSurfaceView, private val vk
 			Log.d(TAG, "Exiting render thread")
 			vkRenderer.onRenderThreadExiting()
 
+			for (event in eventQueue) {
+				event.run()
+			}
+			eventQueue.clear()
+
 			exited = true
 			lockCondition.signalAll()
 		}


### PR DESCRIPTION
- Fixed InputEventRunnable pool exhaustion by recycling unexecuted events on exit in GL/VK threads.
- Added a fallback in GodotInputHandler.java to recycle unexecuted events when runOnRenderThread fails.
- Fixed an input state desync by clearing mouse_button_mask and touch_velocity_track in - - --- Input::release_pressed_events() when the application loses focus.

I have tested the update and fixes by myself and it is truly fixed, I was working on a godot game since 2hour and the input never stopped. it was heavy editing map. I hope it fixes issue for all android devices aswell. I will update if needed

- *Bugsquad edit:* This PR fixes https://github.com/godotengine/godot/issues/117720