### PR TITLE
[LSP] Hover on a `uid://` string literal shows resource information

### DIFF
--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1627,6 +1627,7 @@ public:
 	Error parse(const String &p_source_code, const String &p_script_path, bool p_for_completion, bool p_parse_body = true);
 	Error parse_binary(const Vector<uint8_t> &p_binary, const String &p_script_path);
 	ClassNode *get_tree() const { return head; }
+	const Node *get_node_list() const { return list; }
 	bool is_tool() const { return _is_tool; }
 	Ref<GDScriptParserRef> get_depended_parser_for(const String &p_path);
 	const HashMap<String, Ref<GDScriptParserRef>> &get_depended_parsers();

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -766,6 +766,52 @@ String ExtendGDScriptParser::get_identifier_under_position(const LSP::Position &
 	return "";
 }
 
+String ExtendGDScriptParser::get_string_literal_under_position(const LSP::Position &p_position, LSP::Range &r_range) const {
+	ERR_FAIL_INDEX_V(p_position.line, lines.size(), "");
+	String line = lines[p_position.line];
+	if (line.is_empty()) {
+		return "";
+	}
+
+	// Convert LSP position (0-based) to Godot position (1-based).
+	const GodotPosition godot_pos = GodotPosition::from_lsp(p_position, lines);
+	for (const Node *node = get_node_list(); node != nullptr; node = node->next) {
+		if (node->type != Node::LITERAL) {
+			continue;
+		}
+
+		const LiteralNode *literal_node = static_cast<const LiteralNode *>(node);
+		if (literal_node->value.get_type() != Variant::STRING) {
+			continue;
+		}
+
+		if (godot_pos.line != literal_node->start_line || godot_pos.column <= literal_node->start_column || godot_pos.column >= literal_node->end_column) {
+			continue;
+		}
+
+		// Determine quote width.
+		LSP::Position lsp_start = GodotPosition(literal_node->start_line, literal_node->start_column).to_lsp(lines);
+		String start_line_text = lines[lsp_start.line];
+		int quote_width = 1;
+		if (lsp_start.character + 2 < start_line_text.length()) {
+			char32_t c = start_line_text[lsp_start.character];
+			if ((c == '"' || c == '\'') &&
+					start_line_text[lsp_start.character + 1] == c &&
+					start_line_text[lsp_start.character + 2] == c) {
+				quote_width = 3;
+			}
+		}
+
+		GodotPosition content_start(literal_node->start_line, literal_node->start_column + quote_width);
+		GodotPosition content_end(literal_node->end_line, literal_node->end_column - quote_width);
+		r_range = GodotRange(content_start, content_end).to_lsp(lines);
+
+		return literal_node->value;
+	}
+
+	return "";
+}
+
 String ExtendGDScriptParser::get_uri() const {
 	return GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_uri(path);
 }

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -140,6 +140,7 @@ public:
 	String get_text_for_completion(const LSP::Position &p_cursor) const;
 	String get_text_for_lookup_symbol(const LSP::Position &p_cursor, const String &p_symbol = "", bool p_func_required = false) const;
 	String get_identifier_under_position(const LSP::Position &p_position, LSP::Range &r_range) const;
+	String get_string_literal_under_position(const LSP::Position &p_position, LSP::Range &r_range) const;
 	String get_uri() const;
 
 	/**

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -361,8 +361,14 @@ Variant GDScriptTextDocument::hover(const Dictionary &p_params) {
 		hover.range.start = params.position;
 		hover.range.end = params.position;
 		return hover.to_json();
+	}
 
-	} else if (GDScriptLanguageProtocol::get_singleton()->is_smart_resolve_enabled()) {
+	LSP::Hover resource_hover;
+	if (GDScriptLanguageProtocol::get_singleton()->get_workspace()->resolve_resource_path(params, resource_hover)) {
+		return resource_hover.to_json();
+	}
+
+	if (GDScriptLanguageProtocol::get_singleton()->is_smart_resolve_enabled()) {
 		Dictionary ret;
 		Array contents;
 		List<const LSP::DocumentSymbol *> list;

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -35,6 +35,8 @@
 #include "gdscript_language_protocol.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/resource_loader.h"
+#include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
@@ -699,6 +701,42 @@ const LSP::DocumentSymbol *GDScriptWorkspace::resolve_symbol(const LSP::TextDocu
 	}
 
 	return symbol;
+}
+
+bool GDScriptWorkspace::resolve_resource_path(const LSP::TextDocumentPositionParams &p_doc_pos, LSP::Hover &r_hover) {
+	String path = get_file_path(p_doc_pos.textDocument.uri);
+	const ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_parse_result(path);
+	if (!parser) {
+		return false;
+	}
+
+	LSP::Range string_range;
+	String literal = parser->get_string_literal_under_position(p_doc_pos.position, string_range);
+	if (!literal.begins_with("uid://")) {
+		return false;
+	}
+
+	r_hover.range = string_range;
+
+	String res_path = literal;
+	ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(literal);
+	if (uid == ResourceUID::INVALID_ID) {
+		r_hover.contents.value = "**" + TTR("Invalid UID") + "**\n\n*" + TTR("This UID does not point to any valid Resource.") + "*";
+		return true;
+	}
+	res_path = ResourceUID::get_singleton()->get_id_path(uid);
+	if (res_path.is_empty()) {
+		r_hover.contents.value = "**" + TTR("Invalid UID") + "**\n\n*" + TTR("This UID does not point to any valid Resource.") + "*";
+		return true;
+	}
+
+	String type = ResourceLoader::get_resource_type(res_path);
+	String name = res_path.get_file();
+	if (type.is_empty()) {
+		type = "Unknown";
+	}
+	r_hover.contents.value = "**" + TTR("Resource") + "** `" + name + "`: " + type + "\n\n" + TTR("Path") + ": `" + res_path + "`";
+	return true;
 }
 
 const LSP::DocumentSymbol *GDScriptWorkspace::resolve_native_symbol(const LSP::NativeSymbolInspectParams &p_params) {

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -87,6 +87,7 @@ public:
 	void completion(const LSP::CompletionParams &p_params, List<ScriptLanguage::CodeCompletionOption> *r_options);
 
 	const LSP::DocumentSymbol *resolve_symbol(const LSP::TextDocumentPositionParams &p_doc_pos, const String &p_symbol_name = "", bool p_func_required = false);
+	bool resolve_resource_path(const LSP::TextDocumentPositionParams &p_doc_pos, LSP::Hover &r_hover);
 
 	const LSP::DocumentSymbol *resolve_native_symbol(const LSP::NativeSymbolInspectParams &p_params);
 	void resolve_document_links(const String &p_uri, List<LSP::DocumentLink> &r_list);

--- a/modules/gdscript/tests/scripts/.gitignore
+++ b/modules/gdscript/tests/scripts/.gitignore
@@ -1,2 +1,3 @@
 # Ignore metadata if someone open this on Godot.
 /.godot
+*.uid

--- a/modules/gdscript/tests/scripts/lsp/resource_paths.gd
+++ b/modules/gdscript/tests/scripts/lsp/resource_paths.gd
@@ -1,0 +1,21 @@
+extends Node
+
+var uid_invalid = "uid://zzz_not_a_real_uid"
+var uid_valid = "uid://a1b2c3"
+var res_path = "res://lsp/local_variables.gd"
+var normal_string = "hello world"
+var empty_string = ""
+var number = 42
+var multi = "first" + "second" + "third"
+var escaped = "hello \"world\" bye"
+var single_quoted = 'single quotes'
+var mixed_quotes = "it's a test"
+var multiline_str = """I'm also "a" String"""
+var uid_in_call = str("uid://a1b2c3")
+# var uid_commented = "uid://a1b2c3"
+
+func use_path(_p: String) -> void:
+	pass
+
+func caller():
+	use_path("uid://a1b2c3")

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -42,6 +42,7 @@
 #include "gdscript_test_runner.h"
 
 #include "core/io/dir_access.h"
+#include "core/io/resource_uid.h"
 #include "editor/file_system/editor_file_system.h"
 #include "tests/test_macros.h"
 
@@ -530,6 +531,203 @@ func f():
 			REQUIRE(cls.documentation.contains("t1"));
 			REQUIRE(cls.documentation.contains("t2"));
 			REQUIRE(cls.documentation.contains("t3"));
+		}
+
+		memdelete(efs);
+		finish_language();
+	}
+
+	TEST_CASE("[workspace][get_string_literal_under_position]") {
+		EditorFileSystem *efs = memnew(EditorFileSystem);
+		GDScriptLanguageProtocol *proto = initialize(root);
+		REQUIRE(proto);
+
+		String path = "res://lsp/resource_paths.gd";
+		ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_parse_result(path);
+		REQUIRE(parser);
+
+		SUBCASE("Returns uid:// string when cursor is inside uid:// literal") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(3, 25), r);
+			CHECK_EQ(result, "uid://a1b2c3");
+		}
+
+		SUBCASE("Returns empty for cursor on non-string token") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(7, 14), r);
+			CHECK(result.is_empty());
+		}
+
+		SUBCASE("Returns empty for cursor on empty line") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(2, 0), r);
+			CHECK(result.is_empty());
+		}
+
+		SUBCASE("Returns plain string when cursor is inside a non-path string") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(5, 24), r);
+			CHECK_EQ(result, "hello world");
+		}
+
+		SUBCASE("Returns string with range excluding quotes") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(2, 20), r);
+			CHECK_EQ(result, "uid://zzz_not_a_real_uid");
+			CHECK_EQ(r.start.line, 2);
+			CHECK_EQ(r.end.line, 2);
+			CHECK_EQ(r.start.character, 19);
+			CHECK_EQ(r.end.character, 43);
+		}
+
+		SUBCASE("Returns middle string when cursor is inside it on a multi-string line") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(8, 25), r);
+			CHECK_EQ(result, "second");
+			CHECK_EQ(r.start.character, 23);
+			CHECK_EQ(r.end.character, 29);
+		}
+
+		SUBCASE("Returns empty when cursor is between strings on a multi-string line") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(8, 20), r);
+			CHECK(result.is_empty());
+		}
+
+		SUBCASE("Returns full content for string with escaped quotes") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(9, 20), r);
+			CHECK_EQ(result, "hello \"world\" bye");
+		}
+
+		SUBCASE("Returns content for single-quoted string") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(10, 25), r);
+			CHECK_EQ(result, "single quotes");
+			CHECK_EQ(r.start.line, 10);
+			CHECK_EQ(r.start.character, 21);
+			CHECK_EQ(r.end.character, 34);
+		}
+
+		SUBCASE("Returns content for double-quoted string containing single quote") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(11, 25), r);
+			CHECK_EQ(result, "it's a test");
+			CHECK_EQ(r.start.character, 20);
+			CHECK_EQ(r.end.character, 31);
+		}
+
+		SUBCASE("Returns content for triple-quoted string") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(12, 30), r);
+			CHECK_EQ(result, "I'm also \"a\" String");
+			CHECK_EQ(r.start.line, 12);
+			CHECK_EQ(r.start.character, 23);
+			CHECK_EQ(r.end.character, 42);
+		}
+
+		SUBCASE("Returns content for triple-quoted string even when cursor is on a double-quoted internal string") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(12, 33), r);
+			CHECK_EQ(result, "I'm also \"a\" String");
+			CHECK_EQ(r.start.line, 12);
+			CHECK_EQ(r.start.character, 23);
+			CHECK_EQ(r.end.character, 42);
+		}
+
+		SUBCASE("Returns string when inside a function call argument") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(13, 27), r);
+			CHECK_EQ(result, "uid://a1b2c3");
+			CHECK_EQ(r.start.line, 13);
+		}
+
+		SUBCASE("Returns empty when cursor is on the opening quote") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(13, 22), r);
+			CHECK(result.is_empty());
+		}
+
+		SUBCASE("Returns empty when cursor is past the closing quote") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(13, 36), r);
+			CHECK(result.is_empty());
+		}
+
+		SUBCASE("Returns string when cursor is at the closing quote") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(13, 35), r);
+			CHECK_EQ(result, "uid://a1b2c3");
+			CHECK_EQ(r.start.line, 13);
+		}
+
+		SUBCASE("Returns empty for cursor inside a comment") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(14, 28), r);
+			CHECK(result.is_empty());
+		}
+
+		SUBCASE("Returns string for tab-indented line") {
+			LSP::Range r;
+			String result = parser->get_string_literal_under_position(pos(20, 14), r);
+			CHECK_EQ(result, "uid://a1b2c3");
+			CHECK_EQ(r.start.line, 20);
+			CHECK_EQ(r.start.character, 11);
+			CHECK_EQ(r.end.character, 23);
+		}
+
+		memdelete(efs);
+		finish_language();
+	}
+
+	TEST_CASE("[workspace][hover_resource_path]") {
+		EditorFileSystem *efs = memnew(EditorFileSystem);
+		GDScriptLanguageProtocol *proto = initialize(root);
+		REQUIRE(proto);
+		Ref<GDScriptWorkspace> workspace = GDScriptLanguageProtocol::get_singleton()->get_workspace();
+
+		String path = "res://lsp/resource_paths.gd";
+		String uri = workspace->get_file_uri(path);
+		GDScriptLanguageProtocol::get_singleton()->get_parse_result(path);
+
+		SUBCASE("Hover on invalid uid:// returns invalid UID message") {
+			Dictionary params;
+			Dictionary text_doc;
+			text_doc["uri"] = uri;
+			params["textDocument"] = text_doc;
+			Dictionary position;
+			position["line"] = 2;
+			position["character"] = 25;
+			params["position"] = position;
+
+			Variant result = GDScriptLanguageProtocol::get_singleton()->get_text_document()->hover(params);
+			REQUIRE(result.get_type() == Variant::DICTIONARY);
+			CHECK(String(Dictionary(Dictionary(result)["contents"])["value"]).contains("Invalid UID"));
+		}
+
+		SUBCASE("Hover on valid uid:// returns resource info") {
+			String target_path = "res://lsp/local_variables.gd";
+			ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id("uid://a1b2c3");
+			REQUIRE(uid != ResourceUID::INVALID_ID);
+			ResourceUID::get_singleton()->add_id(uid, target_path);
+
+			Dictionary params;
+			Dictionary text_doc;
+			text_doc["uri"] = uri;
+			params["textDocument"] = text_doc;
+			Dictionary position;
+			position["line"] = 3;
+			position["character"] = 20;
+			params["position"] = position;
+
+			Variant result = GDScriptLanguageProtocol::get_singleton()->get_text_document()->hover(params);
+			REQUIRE(result.get_type() == Variant::DICTIONARY);
+
+			String value = Dictionary(Dictionary(result)["contents"])["value"];
+			CHECK(value.contains("Resource"));
+			CHECK(value.contains("local_variables.gd"));
+
+			ResourceUID::get_singleton()->remove_id(uid);
 		}
 
 		memdelete(efs);


### PR DESCRIPTION
Now, an editor using Godot LSP is able to show a tooltip when a `uid://` is hovered, showing information about the resource related to that uid.

![LSP_uid_hover](https://github.com/user-attachments/assets/242d27eb-45e6-4b70-8fab-74378be9977b)

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
