### PR TITLE
Editor autocompletion get argument options rework

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -2149,7 +2149,7 @@ void ClassDB::get_argument_options_getters(const StringName &p_class, List<Metho
 		MethodBind **method = ti->method_map.getptr(SNAME("get_argument_options"));
 		ti = ti->inherits_ptr; // do this now so we can do early continues
 		if (method && *method) {
-			// check get_argument_options method is static and takes parameters (Object* instance, const StringName &p_function, int p_idx)
+			// check get_argument_options method is static and takes parameters (const Object* instance, const StringName &p_function, int p_idx)
 			const String error_msg = vformat("method 'get_argument_options' of class '%s' can only be declared with signature (const Object* , StringName, int) -> PackedStringArray.", String(p_class));
 			MethodInfo mi = info_from_bind(*method);
 			ERR_CONTINUE_MSG(mi.return_val.type != Variant::PACKED_STRING_ARRAY, error_msg);

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -69,6 +69,8 @@ HashMap<StringName, StringName> ClassDB::resource_base_extensions;
 HashMap<StringName, StringName> ClassDB::compat_classes;
 
 #ifdef TOOLS_ENABLED
+HashMap<StringName, ClassDB::StaticArgOptionGetter> ClassDB::static_arg_options_getters;
+
 HashMap<StringName, ObjectGDExtension> ClassDB::placeholder_extensions;
 
 class PlaceholderExtensionInstance {
@@ -2139,26 +2141,21 @@ void ClassDB::get_class_dependencies(const StringName &p_class, List<StringName>
 	}
 }
 
-void ClassDB::get_argument_options_getters(const StringName &p_class, List<MethodBind *> *r_methods) {
+void ClassDB::get_argument_options_getters(const StringName &p_class, List<ClassDB::StaticArgOptionGetter> *r_arg_option_getters) {
 	Locker::Lock lock(Locker::STATE_READ);
 
 	ClassInfo *ti = classes.getptr(p_class);
 	ERR_FAIL_NULL_MSG(ti, vformat("Cannot get class '%s'.", String(p_class)));
 
 	while (ti) {
-		MethodBind **method = ti->method_map.getptr(SNAME("get_argument_options"));
-		ti = ti->inherits_ptr; // do this now so we can do early continues
-		if (method && *method) {
-			// check get_argument_options method is static and takes parameters (const Object* instance, const StringName &p_function, int p_idx)
-			const String error_msg = vformat("method 'get_argument_options' of class '%s' can only be declared with signature (const Object* , StringName, int) -> PackedStringArray.", String(p_class));
-			MethodInfo mi = info_from_bind(*method);
-			ERR_CONTINUE_MSG(mi.return_val.type != Variant::PACKED_STRING_ARRAY, error_msg);
-			ERR_CONTINUE_MSG(mi.arguments.size() != 3, error_msg);
-			ERR_CONTINUE_MSG(mi.arguments[0].type != Variant::OBJECT, error_msg);
-			ERR_CONTINUE_MSG(mi.arguments[1].type != Variant::STRING_NAME, error_msg);
-			ERR_CONTINUE_MSG(mi.arguments[2].type != Variant::INT, error_msg);
-			r_methods->push_back(*method);
+		ClassDB::StaticArgOptionGetter *arg_option_getter_ptr = nullptr;
+		if (ti->gdtype) {
+			arg_option_getter_ptr = ClassDB::static_arg_options_getters.getptr(ti->gdtype->get_name());
 		}
+		if (arg_option_getter_ptr) {
+			r_arg_option_getters->push_back(*arg_option_getter_ptr);
+		}
+		ti = ti->inherits_ptr;
 	}
 }
 #endif // TOOLS_ENABLED

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -2138,6 +2138,29 @@ void ClassDB::get_class_dependencies(const StringName &p_class, List<StringName>
 		r_rependencies->push_back(dep);
 	}
 }
+
+void ClassDB::get_argument_options_getters(const StringName &p_class, List<MethodBind *> *r_methods) {
+	Locker::Lock lock(Locker::STATE_READ);
+
+	ClassInfo *ti = classes.getptr(p_class);
+	ERR_FAIL_NULL_MSG(ti, vformat("Cannot get class '%s'.", String(p_class)));
+
+	while (ti) {
+		MethodBind **method = ti->method_map.getptr(SNAME("get_argument_options"));
+		ti = ti->inherits_ptr; // do this now so we can do early continues
+		if (method && *method) {
+			// check get_argument_options method is static and takes parameters (Object* instance, const StringName &p_function, int p_idx)
+			const String error_msg = vformat("method 'get_argument_options' of class '%s' can only be declared with signature (const Object* , StringName, int) -> PackedStringArray.", String(p_class));
+			MethodInfo mi = info_from_bind(*method);
+			ERR_CONTINUE_MSG(mi.return_val.type != Variant::PACKED_STRING_ARRAY, error_msg);
+			ERR_CONTINUE_MSG(mi.arguments.size() != 3, error_msg);
+			ERR_CONTINUE_MSG(mi.arguments[0].type != Variant::OBJECT, error_msg);
+			ERR_CONTINUE_MSG(mi.arguments[1].type != Variant::STRING_NAME, error_msg);
+			ERR_CONTINUE_MSG(mi.arguments[2].type != Variant::INT, error_msg);
+			r_methods->push_back(*method);
+		}
+	}
+}
 #endif // TOOLS_ENABLED
 
 void ClassDB::add_resource_base_extension(const StringName &p_extension, const StringName &p_class) {

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -522,6 +522,8 @@ public:
 #ifdef TOOLS_ENABLED
 	static void add_class_dependency(const StringName &p_class, const StringName &p_dependency);
 	static void get_class_dependencies(const StringName &p_class, List<StringName> *r_rependencies);
+
+	static void get_argument_options_getters(const StringName &p_class, List<MethodBind *> *r_methods);
 #endif
 
 	static void add_resource_base_extension(const StringName &p_extension, const StringName &p_class);

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -40,6 +40,10 @@
 
 #include <type_traits>
 
+#ifdef TOOLS_ENABLED
+#include <functional>
+#endif
+
 template <typename T, typename = void>
 struct is_class_enabled;
 
@@ -197,6 +201,10 @@ public:
 
 #ifdef TOOLS_ENABLED
 	static HashMap<StringName, ObjectGDExtension> placeholder_extensions;
+
+	// Contains static methods registered by each class to provide argument options for auto completion
+	using StaticArgOptionGetter = std::function<Vector<String>(const Object * /*p_instance*/, const StringName & /*p_function*/, int /*p_idx*/)>;
+	static HashMap<StringName, StaticArgOptionGetter> static_arg_options_getters;
 #endif
 
 #ifdef DEBUG_ENABLED
@@ -523,7 +531,12 @@ public:
 	static void add_class_dependency(const StringName &p_class, const StringName &p_dependency);
 	static void get_class_dependencies(const StringName &p_class, List<StringName> *r_rependencies);
 
-	static void get_argument_options_getters(const StringName &p_class, List<MethodBind *> *r_methods);
+	static void register_argument_options_getters(const StringName &p_class, const StaticArgOptionGetter& p_arg_option_getter) {
+		Locker::Lock lock(Locker::STATE_WRITE);
+		static_arg_options_getters.insert(p_class, p_arg_option_getter);
+	}
+	// return static argument options getters for the class and its parent classes
+	static void get_argument_options_getters(const StringName &p_class, List<ClassDB::StaticArgOptionGetter> *r_arg_option_getters);
 #endif
 
 	static void add_resource_base_extension(const StringName &p_extension, const StringName &p_class);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3076,19 +3076,22 @@ static void _list_call_arguments(GDScriptParser::CompletionContext &p_context, c
 
 				if (ClassDB::get_method_info(class_name, method, &info)) {
 					method_args = info.arguments.size();
+					Vector<String> options;
+					Object *obj = NULL;
 					if (base.get_type() == Variant::OBJECT) {
-						Object *obj = base.operator Object *();
-						if (obj) {
-							List<String> options;
-							obj->get_argument_options(method, p_argidx, &options);
-							const GDScriptParser::Node *existing_node = p_call->arguments.size() > p_argidx ? p_call->arguments[p_argidx] : nullptr;
-							const Variant::Type expected_type = info.arguments.size() > p_argidx ? info.arguments[p_argidx].type : Variant::NIL;
-							for (String &opt : options) {
-								if (opt.is_quoted()) {
-									ScriptLanguage::CodeCompletionOption option = _calculate_string_insertion(existing_node, opt.unquote(), expected_type);
-									r_result.insert(option.display, option);
-								}
-							}
+						obj = base.operator Object *();
+					}
+					List<ClassDB::StaticArgOptionGetter> options_getters;
+					ClassDB::get_argument_options_getters(class_name, &options_getters);
+					for (ClassDB::StaticArgOptionGetter options_getter : options_getters) {
+						options.append_array(options_getter(obj, method, p_argidx));
+					}
+					const GDScriptParser::Node *existing_node = p_call->arguments.size() > p_argidx ? p_call->arguments[p_argidx] : nullptr;
+					const Variant::Type expected_type = info.arguments.size() > p_argidx ? info.arguments[p_argidx].type : Variant::NIL;
+					for (String &opt : options) {
+						if (opt.is_quoted()) {
+							ScriptLanguage::CodeCompletionOption option = _calculate_string_insertion(existing_node, opt.unquote(), expected_type);
+							r_result.insert(option.display, option);
 						}
 					}
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1961,6 +1961,10 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_multiplayer_poll_enabled", "enabled"), &SceneTree::set_multiplayer_poll_enabled);
 	ClassDB::bind_method(D_METHOD("is_multiplayer_poll_enabled"), &SceneTree::is_multiplayer_poll_enabled);
 
+#ifdef TOOLS_ENABLED
+	ClassDB::register_argument_options_getters("SceneTree", &SceneTree::get_argument_options);
+#endif
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_accept_quit"), "set_auto_accept_quit", "is_auto_accept_quit");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "quit_on_go_back"), "set_quit_on_go_back", "is_quit_on_go_back");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_collisions_hint"), "set_debug_collisions_hint", "is_debugging_collisions_hint");
@@ -2007,7 +2011,8 @@ void SceneTree::add_idle_callback(IdleCallback p_callback) {
 }
 
 #ifdef TOOLS_ENABLED
-void SceneTree::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+PackedStringArray SceneTree::get_argument_options(const Object *p_instance, const StringName &p_function, int p_idx) {
+	Vector<String> returned_options;
 	bool add_options = false;
 	if (p_idx == 0) {
 		static const Vector<StringName> names = {
@@ -2031,11 +2036,12 @@ void SceneTree::get_argument_options(const StringName &p_function, int p_idx, Li
 	}
 	if (add_options) {
 		HashMap<StringName, String> global_groups(ProjectSettings::get_singleton()->get_global_groups_list());
+		returned_options.reserve(global_groups.size());
 		for (const KeyValue<StringName, String> &E : global_groups) {
-			r_options->push_back(E.key.string().quote());
+			returned_options.push_back(E.key.string().quote());
 		}
 	}
-	MainLoop::get_argument_options(p_function, p_idx, r_options);
+	return returned_options;
 }
 #endif
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -441,7 +441,7 @@ public:
 	static SceneTree *get_singleton() { return singleton; }
 
 #ifdef TOOLS_ENABLED
-	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+	static PackedStringArray get_argument_options(const Object *instance, const StringName &p_function, int p_idx);
 #endif
 
 	//network API


### PR DESCRIPTION
This is a draft PR, work is still in progress

fixes https://github.com/godotengine/godot/issues/114869

After https://github.com/godotengine/godot/pull/109297, autocompletion will sometimes not be able to get hold of an object instance, but some autocompletion for function parameters do not always require an instance and should work anyway.
In this regard, the `get_argument_options` method that used to be overriden for any Object-derived class is now a static method which takes a possibly null instance as first parameter.

As it is WIP, I only changed the `get_argument_options` declaration for one class as an example. the rest will be changed after feedback from my mentor on the subject