### PR TITLE
GDScript: use `TightLocalVector` for lambda captures

### DIFF
--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -150,12 +150,12 @@ void GDScriptLambdaCallable::call(const Variant **p_arguments, int p_argcount, V
 	}
 }
 
-GDScriptLambdaCallable::GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, const Vector<Variant> &p_captures) :
+GDScriptLambdaCallable::GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, TightLocalVector<Variant> &&p_captures) :
 		function(p_function) {
 	ERR_FAIL_COND(p_script.is_null());
 	ERR_FAIL_NULL(p_function);
 	script = p_script;
-	captures = p_captures;
+	captures = std::move(p_captures);
 
 	h = (uint32_t)hash_murmur3_one_64((uint64_t)this);
 }
@@ -282,23 +282,23 @@ void GDScriptLambdaSelfCallable::call(const Variant **p_arguments, int p_argcoun
 	}
 }
 
-GDScriptLambdaSelfCallable::GDScriptLambdaSelfCallable(Ref<RefCounted> p_self, GDScriptFunction *p_function, const Vector<Variant> &p_captures) :
+GDScriptLambdaSelfCallable::GDScriptLambdaSelfCallable(Ref<RefCounted> p_self, GDScriptFunction *p_function, TightLocalVector<Variant> &&p_captures) :
 		function(p_function) {
 	ERR_FAIL_COND(p_self.is_null());
 	ERR_FAIL_NULL(p_function);
 	reference = p_self;
 	object = p_self.ptr();
-	captures = p_captures;
+	captures = std::move(p_captures);
 
 	h = (uint32_t)hash_murmur3_one_64((uint64_t)this);
 }
 
-GDScriptLambdaSelfCallable::GDScriptLambdaSelfCallable(Object *p_self, GDScriptFunction *p_function, const Vector<Variant> &p_captures) :
+GDScriptLambdaSelfCallable::GDScriptLambdaSelfCallable(Object *p_self, GDScriptFunction *p_function, TightLocalVector<Variant> &&p_captures) :
 		function(p_function) {
 	ERR_FAIL_NULL(p_self);
 	ERR_FAIL_NULL(p_function);
 	object = p_self;
-	captures = p_captures;
+	captures = std::move(p_captures);
 
 	h = (uint32_t)hash_murmur3_one_64((uint64_t)this);
 }

--- a/modules/gdscript/gdscript_lambda_callable.h
+++ b/modules/gdscript/gdscript_lambda_callable.h
@@ -33,7 +33,6 @@
 #include "gdscript.h"
 
 #include "core/object/ref_counted.h"
-#include "core/templates/vector.h"
 #include "core/variant/callable.h"
 #include "core/variant/variant.h"
 
@@ -45,7 +44,7 @@ class GDScriptLambdaCallable : public CallableCustom {
 	Ref<GDScript> script;
 	uint32_t h;
 
-	Vector<Variant> captures;
+	TightLocalVector<Variant> captures;
 
 	static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);
 	static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
@@ -63,7 +62,7 @@ public:
 
 	GDScriptLambdaCallable(GDScriptLambdaCallable &) = delete;
 	GDScriptLambdaCallable(const GDScriptLambdaCallable &) = delete;
-	GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, const Vector<Variant> &p_captures);
+	GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, TightLocalVector<Variant> &&p_captures);
 	virtual ~GDScriptLambdaCallable() = default;
 };
 
@@ -74,7 +73,7 @@ class GDScriptLambdaSelfCallable : public CallableCustom {
 	Object *object = nullptr; // For non RefCounted objects, use a direct pointer.
 	uint32_t h;
 
-	Vector<Variant> captures;
+	TightLocalVector<Variant> captures;
 
 	static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);
 	static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
@@ -92,7 +91,7 @@ public:
 
 	GDScriptLambdaSelfCallable(GDScriptLambdaSelfCallable &) = delete;
 	GDScriptLambdaSelfCallable(const GDScriptLambdaSelfCallable &) = delete;
-	GDScriptLambdaSelfCallable(Ref<RefCounted> p_self, GDScriptFunction *p_function, const Vector<Variant> &p_captures);
-	GDScriptLambdaSelfCallable(Object *p_self, GDScriptFunction *p_function, const Vector<Variant> &p_captures);
+	GDScriptLambdaSelfCallable(Ref<RefCounted> p_self, GDScriptFunction *p_function, TightLocalVector<Variant> &&p_captures);
+	GDScriptLambdaSelfCallable(Object *p_self, GDScriptFunction *p_function, TightLocalVector<Variant> &&p_captures);
 	virtual ~GDScriptLambdaSelfCallable() = default;
 };

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -2679,14 +2679,14 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(lambda_index < 0 || lambda_index >= _lambdas_count);
 				GDScriptFunction *lambda = _lambdas_ptr[lambda_index];
 
-				Vector<Variant> captures;
+				TightLocalVector<Variant> captures;
 				captures.resize(captures_count);
 				for (int i = 0; i < captures_count; i++) {
 					GET_INSTRUCTION_ARG(arg, i);
-					captures.write[i] = *arg;
+					captures[i] = *arg;
 				}
 
-				GDScriptLambdaCallable *callable = memnew(GDScriptLambdaCallable(Ref<GDScript>(script), lambda, captures));
+				GDScriptLambdaCallable *callable = memnew(GDScriptLambdaCallable(Ref<GDScript>(script), lambda, std::move(captures)));
 
 				GET_INSTRUCTION_ARG(result, captures_count);
 				*result = Callable(callable);
@@ -2710,18 +2710,18 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(lambda_index < 0 || lambda_index >= _lambdas_count);
 				GDScriptFunction *lambda = _lambdas_ptr[lambda_index];
 
-				Vector<Variant> captures;
+				TightLocalVector<Variant> captures;
 				captures.resize(captures_count);
 				for (int i = 0; i < captures_count; i++) {
 					GET_INSTRUCTION_ARG(arg, i);
-					captures.write[i] = *arg;
+					captures[i] = *arg;
 				}
 
 				GDScriptLambdaSelfCallable *callable;
 				if (Object::cast_to<RefCounted>(p_instance->owner)) {
-					callable = memnew(GDScriptLambdaSelfCallable(Ref<RefCounted>(Object::cast_to<RefCounted>(p_instance->owner)), lambda, captures));
+					callable = memnew(GDScriptLambdaSelfCallable(Ref<RefCounted>(Object::cast_to<RefCounted>(p_instance->owner)), lambda, std::move(captures)));
 				} else {
-					callable = memnew(GDScriptLambdaSelfCallable(p_instance->owner, lambda, captures));
+					callable = memnew(GDScriptLambdaSelfCallable(p_instance->owner, lambda, std::move(captures)));
 				}
 
 				GET_INSTRUCTION_ARG(result, captures_count);


### PR DESCRIPTION
There is no need for copy-on-write outside of constructing a `GDScriptLambda(Self)Callable`, which can be bypassed with `std::move()` on a non-const vector.

And since the vector never gets resized more than once, it may straight up be a `TightLocalVector`.

## Profiling

There should be virtually no performance difference between read-accessing a `Vector` and read-accessing a `LocalVector`, so the tests had another focus.

- Project used: [Gaijin's Bunnymark but modified to make heavy use of lambdas](https://github.com/user-attachments/files/26308205/gaijin_bunnymark_lambda.zip).
- Engine build args: `target=editor dev_build=yes optimize=debug`

While I felt little to no performance impact when measuring FPS (it has heavy fluctuations if the change isn't big), the profiler results on `GDScriptLambdaSelfCallable` construction/destruction were interesting:

### Construction (before/after)
<img width="1918" height="497" alt="image" src="https://github.com/user-attachments/assets/bd530b1c-73a2-4312-bf6c-c1b35834072c" />

### Destruction (before/after)
<img width="1920" height="500" alt="image" src="https://github.com/user-attachments/assets/d145931d-65d4-426b-9f06-1173234e853c" />

---
My interpretation on a quick look is that this removes any overhead from `CowData` referencing/unreferencing.