### PR TITLE
Fix some regressions with the build profile editor

### DIFF
--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -258,6 +258,7 @@ const HashMap<EditorBuildProfile::BuildOption, LocalVector<EditorBuildProfile::B
 	} },
 };
 
+// Should also contain classes not derived from either `Resource` or `Node`.
 const HashMap<EditorBuildProfile::BuildOption, LocalVector<String>> EditorBuildProfile::build_option_classes = {
 	{ BUILD_OPTION_3D, {
 			"Node3D",
@@ -847,9 +848,7 @@ void EditorBuildProfileManager::_find_files(EditorFileSystemDirectory *p_dir, co
 		HashSet<StringName> classes;
 		ResourceLoader::get_classes_used(p, &classes);
 		for (const StringName &E : classes) {
-			if (E == "Resource" || E == "Node" || ClassDB::is_parent_class(E, "Resource") || ClassDB::is_parent_class(E, "Node")) {
-				cache.classes.push_back(E);
-			}
+			cache.classes.push_back(E);
 		}
 
 		HashSet<String> build_deps;
@@ -1060,7 +1059,7 @@ void EditorBuildProfileManager::_detect_from_project() {
 		const LocalVector<String> classes = EditorBuildProfile::get_build_option_classes(EditorBuildProfile::BuildOption(i));
 		if (!classes.is_empty()) {
 			for (StringName class_name : classes) {
-				if (!edited->is_class_disabled(class_name)) {
+				if (all_used_classes.has(class_name) && !edited->is_class_disabled(class_name)) {
 					skip = true;
 					break;
 				}
@@ -1404,7 +1403,7 @@ EditorBuildProfileManager::EditorBuildProfileManager() {
 	profiles_hbc->add_spacer();
 
 	profile_actions[ACTION_CLEAR_CACHE] = memnew(Button(TTRC("Clear Cache")));
-	profile_actions[ACTION_CLEAR_CACHE]->set_disabled(FileAccess::exists(EditorPaths::get_singleton()->get_project_settings_dir().path_join("used_class_cache")));
+	profile_actions[ACTION_CLEAR_CACHE]->set_disabled(!FileAccess::exists(EditorPaths::get_singleton()->get_project_settings_dir().path_join("used_class_cache")));
 	profiles_hbc->add_child(profile_actions[ACTION_CLEAR_CACHE]);
 	profile_actions[ACTION_CLEAR_CACHE]->connect(SceneStringName(pressed), callable_mp(this, &EditorBuildProfileManager::_profile_action).bind(ACTION_CLEAR_CACHE));
 


### PR DESCRIPTION
- Fix certain options not being disabled when they should (https://github.com/godotengine/godot/pull/117878#issuecomment-4137858052).
- Fix "Clear Cache" button always starting disabled.