### PR TITLE
Add configuration warning for shared SkeletonModificationStack2D

### DIFF
--- a/doc/classes/Skeleton2D.xml
+++ b/doc/classes/Skeleton2D.xml
@@ -68,6 +68,10 @@
 			<param index="0" name="modification_stack" type="SkeletonModificationStack2D" />
 			<description>
 				Sets the [SkeletonModificationStack2D] attached to this skeleton.
+				[b]Note:[/b] The [SkeletonModificationStack2D] is a [Resource] and is shared between instances by default.
+				If the same stack is assigned to multiple [Skeleton2D] nodes (for example, when the scene is instantiated more than once),
+				enable [member Resource.resource_local_to_scene] on it so each node receives a unique copy.
+				Otherwise the instances conflict, producing errors and incorrect behavior.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SkeletonModificationStack2D.xml
+++ b/doc/classes/SkeletonModificationStack2D.xml
@@ -7,6 +7,7 @@
 		This resource is used by the Skeleton and holds a stack of [SkeletonModification2D]s.
 		This controls the order of the modifications and how they are applied. Modification order is especially important for full-body IK setups, as you need to execute the modifications in the correct order to get the desired results. For example, you want to execute a modification on the spine [i]before[/i] the arms on a humanoid skeleton.
 		This resource also controls how strongly all of the modifications are applied to the [Skeleton2D].
+		[b]Note:[/b] Because this is a [Resource], it is shared by default. If the same modification stack is used by multiple [Skeleton2D] nodes (for example, when its owning scene is instantiated more than once), the instances overwrite each other's runtime state, producing "Drawing is only allowed inside [code]_draw()[/code]" errors and incorrect bone transforms. Enable [member Resource.resource_local_to_scene] on this resource (or otherwise make it unique per instance) so that each [Skeleton2D] gets its own copy.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -764,10 +764,21 @@ void Skeleton2D::set_modification_stack(Ref<SkeletonModificationStack2D> p_stack
 #endif // TOOLS_ENABLED
 	}
 	_update_process_mode();
+	update_configuration_warnings();
 }
 
 Ref<SkeletonModificationStack2D> Skeleton2D::get_modification_stack() const {
 	return modification_stack;
+}
+
+PackedStringArray Skeleton2D::get_configuration_warnings() const {
+	PackedStringArray warnings = Node2D::get_configuration_warnings();
+
+	if (modification_stack.is_valid() && modification_stack->get_modification_count() > 0 && !modification_stack->is_local_to_scene()) {
+		warnings.push_back(RTR("This Skeleton2D holds a SkeletonModificationStack2D that is not local to the scene.\nBecause the resource is shared, instancing this scene more than once will make the instances share the same modification stack, causing errors and incorrect bone transforms.\nEnable \"Local to Scene\" on the modification stack resource (or otherwise make it unique) so each instance gets its own copy."));
+	}
+
+	return warnings;
 }
 
 void Skeleton2D::execute_modifications(real_t p_delta, int p_execution_mode) {

--- a/scene/2d/skeleton_2d.h
+++ b/scene/2d/skeleton_2d.h
@@ -170,6 +170,8 @@ public:
 	void set_modification_stack(Ref<SkeletonModificationStack2D> p_stack);
 	void execute_modifications(real_t p_delta, int p_execution_mode);
 
+	PackedStringArray get_configuration_warnings() const override;
+
 	Skeleton2D();
 	~Skeleton2D();
 };


### PR DESCRIPTION
## Description
This PR refactors the `SkeletonModificationStack2D` and its associated modifiers to decouple runtime state from the Resource configuration.


## The Problem:
Currently, `SkeletonModificationStack2D` (a Resource) stores volatile runtime data—specifically the `skeleton` pointer, `is_setup` flag, and `editor_gizmo_dirty` status—as class member variables. Because Resources are shared by default in Godot, when multiple `Skeleton2D` instances share the same modification stack, they overwrite these variables every frame. This leads to:

- "Drawing is only allowed inside _draw()" errors in the editor.
- State corruption where one skeleton's logic is applied to another's bones.
- Performance degradation and unpredictable behavior.

<img width="2559" height="1522" alt="BugShowcase" src="https://github.com/user-attachments/assets/d3be505a-a5e4-4897-b435-f07e2feaeeba" />

## The changes made:

Following the review discussion, this PR no longer refactors
`SkeletonModificationStack2D`. As @TokageItLab pointed out,
`SkeletonModification2D` is slated to be deprecated and migrated to
`SkeletonModifier2D` (godotengine/godot-proposals#10247), so reworking
the current Resource-based design is not the right solution.

Instead, this PR implements a warning suggested in the review:

- Adds a configuration warning on `Skeleton2D` when it holds a non-empty
  `SkeletonModificationStack2D` that is not local to the scene,
  advising the user to enable **Local to Scene** (or otherwise make the
  resource unique) so each instance gets its own copy.
- Documents this in the class reference for `Skeleton2D` and
  `SkeletonModificationStack2D` (per @hjl12345's suggestion).

This does not fix the root cause. 
The true fix would be the bigger refactor as mentioned.


https://github.com/user-attachments/assets/9ee02fd1-a165-4130-a5d0-54f2f1c97e63


Tests performed:
- Ran all Unit-tests to ensure nothing was breaking because of the changes made.


Addresses #117090 (full fix tracked by the `SkeletonModifier2D` migration).