### PR TITLE
Fix gutter icons not resizing at the same time

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -766,6 +766,7 @@ void ScriptTextEditor::update_settings() {
 		code_editor->get_text_editor()->set_inline_object_handlers(Callable(), Callable(), Callable());
 	}
 	TextEditorBase::update_settings();
+	code_editor->get_text_editor()->set_gutter_width(connection_gutter, code_editor->get_text_editor()->get_line_height());
 }
 
 Variant ScriptTextEditor::get_edit_state() {


### PR DESCRIPTION
Fixed a bug where an icon wouldn't scale instantly after changing whitespace value in the settings. This was because the size for the icon in question wasn't recalculated upon settings change.
The fix was to simply to calculate the size when the settings change.


Before:

<img width="336" height="70" alt="557682542-141e488d-393b-4359-a3e5-ac507a8e738a" src="https://github.com/user-attachments/assets/7615ce85-f93b-45b7-8ac6-9b97d5652748" />

After:

https://github.com/user-attachments/assets/178ac0af-21dc-4afb-a06a-dca6a325ab4e

Fixes #117038