### PR TITLE
Fix behavior of `window_is_hdr_output_supported` for Wayland and adjust warnings.

### DIFF
--- a/drivers/apple_embedded/display_server_apple_embedded.mm
+++ b/drivers/apple_embedded/display_server_apple_embedded.mm
@@ -853,18 +853,32 @@ void DisplayServerAppleEmbedded::current_edr_headroom_changed() {
 }
 
 bool DisplayServerAppleEmbedded::window_is_hdr_output_supported(DisplayServerEnums::WindowID p_window) const {
+	bool renderer_supports_hdr_output = false;
 #if defined(RD_ENABLED)
-	if (rendering_device && !rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) {
-		return false;
+	if (rendering_device && rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) {
+		renderer_supports_hdr_output = true;
 	}
 #endif
+	if (!renderer_supports_hdr_output) {
+		return false;
+	}
+
 	return _screen_hdr_is_supported();
 }
 
 void DisplayServerAppleEmbedded::window_request_hdr_output(const bool p_enabled, DisplayServerEnums::WindowID p_window) {
+	if (p_enabled) {
+		bool renderer_supports_hdr_output = false;
 #if defined(RD_ENABLED)
-	ERR_FAIL_COND_MSG(p_enabled && rendering_device && !rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT), "HDR output is not supported by the rendering device.");
+		if (rendering_device && rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) {
+			renderer_supports_hdr_output = true;
+		}
 #endif
+		if (!renderer_supports_hdr_output) {
+			WARN_PRINT("HDR output requested, but is not supported by the renderer or rendering device driver.");
+			return;
+		}
+	}
 
 	edr_requested = p_enabled;
 	_update_hdr_output(false);

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1535,15 +1535,34 @@ void DisplayServerWayland::_window_update_hdr_state(WindowData &p_window) {
 
 bool DisplayServerWayland::window_is_hdr_output_supported(DisplayServerEnums::WindowID p_window_id) const {
 	ERR_FAIL_COND_V(!windows.has(p_window_id), false);
+	bool renderer_supports_hdr_output = false;
+#if defined(RD_ENABLED)
+	if (rendering_device && rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) {
+		renderer_supports_hdr_output = true;
+	}
+#endif
+	if (!renderer_supports_hdr_output) {
+		return false;
+	}
+
 	const WindowData &wd = windows[p_window_id];
 
 	return wd.color_profile.target_max_luminance > wd.color_profile.reference_luminance;
 }
 
 void DisplayServerWayland::window_request_hdr_output(const bool p_enabled, DisplayServerEnums::WindowID p_window_id) {
+	if (p_enabled) {
+		bool renderer_supports_hdr_output = false;
 #if defined(RD_ENABLED)
-	ERR_FAIL_COND_MSG(p_enabled && !(rendering_device && rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)), "HDR output is not supported by the rendering device.");
+		if (rendering_device && rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) {
+			renderer_supports_hdr_output = true;
+		}
 #endif
+		if (!renderer_supports_hdr_output) {
+			WARN_PRINT("HDR output requested, but is not supported by the renderer or rendering device driver.");
+			return;
+		}
+	}
 
 	ERR_FAIL_COND(!windows.has(p_window_id));
 	WindowData &wd = windows[p_window_id];

--- a/platform/macos/display_server_macos_base.mm
+++ b/platform/macos/display_server_macos_base.mm
@@ -590,11 +590,16 @@ bool DisplayServerMacOSBase::window_is_hdr_output_supported(DisplayServerEnums::
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_COND_V(!has_window(p_window), false);
+	bool renderer_supports_hdr_output = false;
 #if defined(RD_ENABLED)
-	if (rendering_device && !rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) {
-		return false;
+	if (rendering_device && rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) {
+		renderer_supports_hdr_output = true;
 	}
 #endif
+	if (!renderer_supports_hdr_output) {
+		return false;
+	}
+
 	CGFloat max_potential_edr;
 	window_get_edr_values(p_window, &max_potential_edr, nullptr);
 	return max_potential_edr > 1.0f;
@@ -604,9 +609,18 @@ void DisplayServerMacOSBase::window_request_hdr_output(const bool p_enabled, Dis
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_COND(!has_window(p_window));
+	if (p_enabled) {
+		bool renderer_supports_hdr_output = false;
 #if defined(RD_ENABLED)
-	ERR_FAIL_COND_MSG(p_enabled && rendering_device && !rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT), "HDR output is not supported by the rendering device.");
+		if (rendering_device && rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) {
+			renderer_supports_hdr_output = true;
+		}
 #endif
+		if (!renderer_supports_hdr_output) {
+			WARN_PRINT("HDR output requested, but is not supported by the renderer or rendering device driver.");
+			return;
+		}
+	}
 
 	HDROutput &hdr = _get_hdr_output(p_window);
 	hdr.requested = p_enabled;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4750,11 +4750,15 @@ bool DisplayServerWindows::window_is_hdr_output_supported(DisplayServerEnums::Wi
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_COND_V(!windows.has(p_window), false);
+	bool renderer_supports_hdr_output = false;
 #if defined(RD_ENABLED)
-	if (rendering_device && !rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) {
-		return false; // HDR output is not supported by the rendering device.
+	if (rendering_device && rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) {
+		renderer_supports_hdr_output = true;
 	}
 #endif
+	if (!renderer_supports_hdr_output) {
+		return false;
+	}
 
 	// The window supports HDR if the screen it is on supports HDR.
 	DisplayServerWindows::ScreenHdrData data = _get_screen_hdr_data(p_window, false);
@@ -4765,9 +4769,18 @@ void DisplayServerWindows::window_request_hdr_output(const bool p_enable, Displa
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_COND(!windows.has(p_window));
+	if (p_enable) {
+		bool renderer_supports_hdr_output = false;
 #if defined(RD_ENABLED)
-	ERR_FAIL_COND_EDMSG(p_enable && (rendering_device && rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) == false, "HDR output is not supported by the rendering device.");
+		if (rendering_device && rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) {
+			renderer_supports_hdr_output = true;
+		}
 #endif
+		if (!renderer_supports_hdr_output) {
+			WARN_PRINT("HDR output requested, but is not supported by the renderer or rendering device driver.");
+			return;
+		}
+	}
 
 	WindowData &wd = windows[p_window];
 	wd.hdr_output_requested = p_enable;

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -1304,7 +1304,7 @@ bool DisplayServer::window_is_hdr_output_supported(DisplayServerEnums::WindowID 
 
 void DisplayServer::window_request_hdr_output(const bool p_enable, DisplayServerEnums::WindowID p_window) {
 	if (p_enable) {
-		WARN_PRINT_ED("HDR output is not supported by this display server.");
+		WARN_PRINT("HDR output requested, but it is not supported by this display server.");
 	}
 }
 
@@ -1317,7 +1317,7 @@ bool DisplayServer::window_is_hdr_output_enabled(DisplayServerEnums::WindowID p_
 }
 
 void DisplayServer::window_set_hdr_output_reference_luminance(const float p_reference_luminance, DisplayServerEnums::WindowID p_window) {
-	WARN_PRINT_ED("HDR output is not supported by this display server.");
+	WARN_PRINT("Attempting to set reference luminance, but HDR output is not supported by this display server.");
 }
 
 float DisplayServer::window_get_hdr_output_reference_luminance(DisplayServerEnums::WindowID p_window) const {
@@ -1329,7 +1329,7 @@ float DisplayServer::window_get_hdr_output_current_reference_luminance(DisplaySe
 }
 
 void DisplayServer::window_set_hdr_output_max_luminance(const float p_max_luminance, DisplayServerEnums::WindowID p_window) {
-	WARN_PRINT_ED("HDR output is not supported by this display server.");
+	WARN_PRINT("Attempting to set max luminance, but HDR output is not supported by this display server.");
 }
 
 float DisplayServer::window_get_hdr_output_max_luminance(DisplayServerEnums::WindowID p_window) const {


### PR DESCRIPTION
### What problem(s) does this PR solve?

1. `DisplayServerWayland::window_is_hdr_output_supported` returns `true` when the rendering device does not support HDR output. This behaviour is incorrect and does not match the behaviour of other display servers.

2. If Godot is compiled with `RD_ENABLED` not defined or `rendering_device == nullptr`, the `rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)` checks will never be run and the code assumes that HDR output is supported, which is the opposite behaviour of how this should be written.

### What is the rationale for the approach used in this PR?

The problem is resolved by simply adding a check to the `DisplayServerWayland::window_is_hdr_output_supported` function so it matches other display servers.

In addition to this change, I have adjusted some errors to be warnings and improved some of the warning messages.

Finally, because the functions that enable HDR output do not check if the rendering device supports HDR output, I have slightly changed the `window_request_hdr_output` logic to fail to request HDR output when `rendering_device` is `nullptr` or `RD_ENABLED` is not defined. This is safer logic that ensures its impossible for HDR output to be successfully requested when the rendering device does not support HDR output.

### Was generative AI (LLM AI) used to create a portion of this PR?

No.

### Are there any parts of this PR that you are uncertain of or require special attention from reviewers?

No, but please double check that my logic statements are correct.