### PR TITLE
Reset follow mode count on subgizmo point switch

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2374,6 +2374,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 								seg->redraw();
 								spatial_editor->update_transform_gizmo();
+								_reset_follow_mode_count();
 								intersected_subgizmo = true;
 								break;
 							}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Another situation similar to:

* https://github.com/godotengine/godot/pull/117214

* https://github.com/godotengine/godot/pull/117289


Related:
* https://github.com/godotengine/godot/pull/116972