### PR TITLE
Fix scene drag-drop selection override for non-scene-tree drags

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -76,6 +76,7 @@
 void SceneTreeDock::_nodes_drag_begin() {
 	pending_click_select = nullptr;
 	edited_object_at_drag_start = InspectorDock::get_inspector_singleton()->get_edited_object();
+	scene_tree_drag_active = true;
 }
 
 void SceneTreeDock::_quick_open(const String &p_file_path) {
@@ -1820,6 +1821,11 @@ void SceneTreeDock::_notification(int p_what) {
 				_restore_treeitem_custom_color(tree_item_inspected);
 				tree_item_inspected = nullptr;
 			}
+
+			if (!scene_tree_drag_active) {
+				return;
+			}
+			scene_tree_drag_active = false;
 
 			InspectorDock *inspector_dock = InspectorDock::get_singleton();
 			if (!inspector_dock->get_rect().has_point(inspector_dock->get_local_mouse_position())) {

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -243,6 +243,7 @@ class SceneTreeDock : public EditorDock {
 	Node *node_hovered_now = nullptr;
 	Node *node_hovered_previously = nullptr;
 	Object *edited_object_at_drag_start = nullptr;
+	bool scene_tree_drag_active = false;
 
 	virtual void input(const Ref<InputEvent> &p_event) override;
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Regression from: 
* https://github.com/godotengine/godot/pull/112269 

CC: @AeioMuch

Drags from `SceneTreeDock` unconditionally restored the pre-drag selection, overwriting the selection set by the drop. This fix prevents that when the drop comes from the file system or plugins.

Before:


https://github.com/user-attachments/assets/34e0eb20-45bc-4036-b4a5-9ad2304af847



After: 

https://github.com/user-attachments/assets/123d8f5f-aad2-4bf4-bf7d-2a93ffd61981

