### PR TITLE
[Scene] Add `SceneStringName::timeout`

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -1135,7 +1135,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	add_child(index_focus_cooldown_timer);
 	index_focus_cooldown_timer->set_wait_time(1.5);
 	index_focus_cooldown_timer->set_one_shot(true);
-	index_focus_cooldown_timer->connect("timeout", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_index_focus_cooldown_timeout));
+	index_focus_cooldown_timer->connect(SceneStringName(timeout), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_index_focus_cooldown_timeout));
 
 	set_custom_minimum_size(Size2(0, 150 * EDSCALE));
 }

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -1445,7 +1445,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	add_child(index_focus_cooldown_timer);
 	index_focus_cooldown_timer->set_wait_time(1.5);
 	index_focus_cooldown_timer->set_one_shot(true);
-	index_focus_cooldown_timer->connect("timeout", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_index_focus_cooldown_timeout));
+	index_focus_cooldown_timer->connect(SceneStringName(timeout), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_index_focus_cooldown_timeout));
 
 	selected_point = -1;
 	selected_triangle = -1;

--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -1663,7 +1663,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	filter_debounce_timer = memnew(Timer);
 	filter_debounce_timer->set_one_shot(true);
 	filter_debounce_timer->set_wait_time(0.25);
-	filter_debounce_timer->connect("timeout", callable_mp(this, &EditorAssetLibrary::_filter_debounce_timer_timeout));
+	filter_debounce_timer->connect(SceneStringName(timeout), callable_mp(this, &EditorAssetLibrary::_filter_debounce_timer_timeout));
 	search_hb->add_child(filter_debounce_timer);
 
 	if (!p_templates_only) {

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -930,7 +930,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 
 	slider->connect(SceneStringName(value_changed), callable_mp(this, &EditorAudioBus::_volume_changed));
 	slider->connect(SceneStringName(value_changed), callable_mp(this, &EditorAudioBus::_show_value));
-	preview_timer->connect("timeout", callable_mp(this, &EditorAudioBus::_hide_value_preview));
+	preview_timer->connect(SceneStringName(timeout), callable_mp(this, &EditorAudioBus::_hide_value_preview));
 	hb->add_child(slider);
 
 	cc = 0;
@@ -1440,7 +1440,7 @@ EditorAudioBuses::EditorAudioBuses() {
 	save_timer->set_wait_time(0.8);
 	save_timer->set_one_shot(true);
 	main_vb->add_child(save_timer);
-	save_timer->connect("timeout", callable_mp(this, &EditorAudioBuses::_server_save));
+	save_timer->connect(SceneStringName(timeout), callable_mp(this, &EditorAudioBuses::_server_save));
 
 	set_v_size_flags(SIZE_EXPAND_FILL);
 

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -796,13 +796,13 @@ EditorProfiler::EditorProfiler() {
 	frame_delay->set_wait_time(0.1);
 	frame_delay->set_one_shot(true);
 	add_child(frame_delay);
-	frame_delay->connect("timeout", callable_mp(this, &EditorProfiler::_update_frame));
+	frame_delay->connect(SceneStringName(timeout), callable_mp(this, &EditorProfiler::_update_frame));
 
 	plot_delay = memnew(Timer);
 	plot_delay->set_wait_time(0.1);
 	plot_delay->set_one_shot(true);
 	add_child(plot_delay);
-	plot_delay->connect("timeout", callable_mp(this, &EditorProfiler::_update_plot));
+	plot_delay->connect(SceneStringName(timeout), callable_mp(this, &EditorProfiler::_update_plot));
 
 	plot_sigs.insert("physics_frame_time");
 	plot_sigs.insert("category_frame_time");

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -882,11 +882,11 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	frame_delay->set_wait_time(0.1);
 	frame_delay->set_one_shot(true);
 	add_child(frame_delay);
-	frame_delay->connect("timeout", callable_mp(this, &EditorVisualProfiler::_update_frame).bind(false));
+	frame_delay->connect(SceneStringName(timeout), callable_mp(this, &EditorVisualProfiler::_update_frame).bind(false));
 
 	plot_delay = memnew(Timer);
 	plot_delay->set_wait_time(0.1);
 	plot_delay->set_one_shot(true);
 	add_child(plot_delay);
-	plot_delay->connect("timeout", callable_mp(this, &EditorVisualProfiler::_update_plot));
+	plot_delay->connect(SceneStringName(timeout), callable_mp(this, &EditorVisualProfiler::_update_plot));
 }

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -5039,7 +5039,7 @@ EditorHelpBitTooltip::EditorHelpBitTooltip(Control *p_target, bool p_shortcut) {
 
 	timer = memnew(Timer);
 	timer->set_wait_time(0.25);
-	timer->connect("timeout", callable_mp(static_cast<Node *>(this), &Node::queue_free));
+	timer->connect(SceneStringName(timeout), callable_mp(static_cast<Node *>(this), &Node::queue_free));
 	add_child(timer);
 
 	p_target->connect(SceneStringName(mouse_exited), callable_mp(this, &EditorHelpBitTooltip::_start_timer));

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -5085,7 +5085,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	scene_tree->set_editor_selection(editor_selection);
 
 	inspect_hovered_node_delay = memnew(Timer);
-	inspect_hovered_node_delay->connect("timeout", callable_mp(this, &SceneTreeDock::_inspect_hovered_node));
+	inspect_hovered_node_delay->connect(SceneStringName(timeout), callable_mp(this, &SceneTreeDock::_inspect_hovered_node));
 	inspect_hovered_node_delay->set_one_shot(true);
 	add_child(inspect_hovered_node_delay);
 

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -483,7 +483,7 @@ EditorLog::EditorLog() {
 	save_state_timer = memnew(Timer);
 	save_state_timer->set_wait_time(2);
 	save_state_timer->set_one_shot(true);
-	save_state_timer->connect("timeout", callable_mp(this, &EditorLog::_save_state));
+	save_state_timer->connect(SceneStringName(timeout), callable_mp(this, &EditorLog::_save_state));
 	add_child(save_state_timer);
 
 	line_limit = int(EDITOR_GET("run/output/max_lines"));

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1531,7 +1531,7 @@ void EditorNode::_sources_changed(bool p_exist) {
 			}
 		}
 
-		get_tree()->create_timer(1.0f)->connect("timeout", callable_mp(this, &EditorNode::_remove_lock_file));
+		get_tree()->create_timer(1.0f)->connect(SceneStringName(timeout), callable_mp(this, &EditorNode::_remove_lock_file));
 	}
 }
 
@@ -8771,12 +8771,12 @@ EditorNode::EditorNode() {
 	add_child(editor_layout_save_delay_timer);
 	editor_layout_save_delay_timer->set_wait_time(0.5);
 	editor_layout_save_delay_timer->set_one_shot(true);
-	editor_layout_save_delay_timer->connect("timeout", callable_mp(this, &EditorNode::_save_editor_layout));
+	editor_layout_save_delay_timer->connect(SceneStringName(timeout), callable_mp(this, &EditorNode::_save_editor_layout));
 
 	scan_changes_timer = memnew(Timer);
 	scan_changes_timer->set_wait_time(0.5);
 	scan_changes_timer->set_autostart(EDITOR_GET("interface/editor/behavior/import_resources_when_unfocused"));
-	scan_changes_timer->connect("timeout", callable_mp(EditorFileSystem::get_singleton(), &EditorFileSystem::scan_changes));
+	scan_changes_timer->connect(SceneStringName(timeout), callable_mp(EditorFileSystem::get_singleton(), &EditorFileSystem::scan_changes));
 	add_child(scan_changes_timer);
 
 	top_split = memnew(VSplitContainer);
@@ -9553,7 +9553,7 @@ EditorNode::EditorNode() {
 	screenshot_timer = memnew(Timer);
 	screenshot_timer->set_one_shot(true);
 	screenshot_timer->set_wait_time(settings_menu->get_submenu_popup_delay() + 0.1f);
-	screenshot_timer->connect("timeout", callable_mp(this, &EditorNode::_request_screenshot));
+	screenshot_timer->connect(SceneStringName(timeout), callable_mp(this, &EditorNode::_request_screenshot));
 	add_child(screenshot_timer);
 	screenshot_timer->set_owner(get_owner());
 

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -532,7 +532,7 @@ EditorExport::EditorExport() {
 	add_child(save_timer);
 	save_timer->set_wait_time(0.8);
 	save_timer->set_one_shot(true);
-	save_timer->connect("timeout", callable_mp(this, &EditorExport::_save));
+	save_timer->connect(SceneStringName(timeout), callable_mp(this, &EditorExport::_save));
 
 	_export_presets_updated = StringName("export_presets_updated", true);
 	_export_presets_runnable_updated = StringName("export_presets_runnable_updated", true);

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -2078,7 +2078,7 @@ CodeTextEditor::CodeTextEditor() {
 	text_editor->connect("code_completion_requested", callable_mp(this, &CodeTextEditor::_complete_request));
 	TypedArray<String> cs = { ".", ",", "(", "=", "$", "@", "\"", "\'" };
 	text_editor->set_code_completion_prefixes(cs);
-	idle->connect("timeout", callable_mp(this, &CodeTextEditor::_text_changed_idle_timeout));
+	idle->connect(SceneStringName(timeout), callable_mp(this, &CodeTextEditor::_text_changed_idle_timeout));
 
-	code_complete_timer->connect("timeout", callable_mp(this, &CodeTextEditor::_code_complete_timer_timeout));
+	code_complete_timer->connect(SceneStringName(timeout), callable_mp(this, &CodeTextEditor::_code_complete_timer_timeout));
 }

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1994,7 +1994,7 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	update_view_timer = memnew(Timer);
 	update_view_timer->set_wait_time(0.2);
 	update_view_timer->set_one_shot(true);
-	update_view_timer->connect("timeout", callable_mp(this, &SceneImportSettingsDialog::_update_view_gizmos));
+	update_view_timer->connect(SceneStringName(timeout), callable_mp(this, &SceneImportSettingsDialog::_update_view_gizmos));
 	add_child(update_view_timer);
 
 	EditorNode::get_singleton()->register_hdr_viewport(base_viewport);

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -2822,7 +2822,7 @@ EditorInspectorSection::EditorInspectorSection() {
 	dropping_unfold_timer->set_wait_time(EDITOR_GET("interface/editor/timers/dragging_hover_wait_seconds"));
 	dropping_unfold_timer->set_one_shot(true);
 	add_child(dropping_unfold_timer);
-	dropping_unfold_timer->connect("timeout", callable_mp(this, &EditorInspectorSection::unfold));
+	dropping_unfold_timer->connect(SceneStringName(timeout), callable_mp(this, &EditorInspectorSection::unfold));
 }
 
 EditorInspectorSection::~EditorInspectorSection() {

--- a/editor/run/embedded_process.cpp
+++ b/editor/run/embedded_process.cpp
@@ -450,12 +450,12 @@ EmbeddedProcess::EmbeddedProcess() {
 	timer_embedding->set_wait_time(0.1);
 	timer_embedding->set_one_shot(true);
 	add_child(timer_embedding);
-	timer_embedding->connect("timeout", callable_mp(this, &EmbeddedProcess::_timer_embedding_timeout));
+	timer_embedding->connect(SceneStringName(timeout), callable_mp(this, &EmbeddedProcess::_timer_embedding_timeout));
 
 	timer_update_embedded_process = memnew(Timer);
 	timer_update_embedded_process->set_wait_time(0.1);
 	add_child(timer_update_embedded_process);
-	timer_update_embedded_process->connect("timeout", callable_mp(this, &EmbeddedProcess::_timer_update_embedded_process_timeout));
+	timer_update_embedded_process->connect(SceneStringName(timeout), callable_mp(this, &EmbeddedProcess::_timer_update_embedded_process_timeout));
 }
 
 EmbeddedProcess::~EmbeddedProcess() {

--- a/editor/run/run_instances_dialog.cpp
+++ b/editor/run/run_instances_dialog.cpp
@@ -303,13 +303,13 @@ RunInstancesDialog::RunInstancesDialog() {
 	main_apply_timer->set_wait_time(0.5);
 	main_apply_timer->set_one_shot(true);
 	add_child(main_apply_timer);
-	main_apply_timer->connect("timeout", callable_mp(this, &RunInstancesDialog::_save_main_args));
+	main_apply_timer->connect(SceneStringName(timeout), callable_mp(this, &RunInstancesDialog::_save_main_args));
 
 	instance_apply_timer = memnew(Timer);
 	instance_apply_timer->set_wait_time(0.5);
 	instance_apply_timer->set_one_shot(true);
 	add_child(instance_apply_timer);
-	instance_apply_timer->connect("timeout", callable_mp(this, &RunInstancesDialog::_save_arguments));
+	instance_apply_timer->connect(SceneStringName(timeout), callable_mp(this, &RunInstancesDialog::_save_arguments));
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);

--- a/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
@@ -287,7 +287,7 @@ Joint3DGizmoPlugin::Joint3DGizmoPlugin() {
 	update_timer = memnew(Timer);
 	update_timer->set_name("JointGizmoUpdateTimer");
 	update_timer->set_wait_time(1.0 / 120.0);
-	update_timer->connect("timeout", callable_mp(this, &Joint3DGizmoPlugin::incremental_update_gizmos));
+	update_timer->connect(SceneStringName(timeout), callable_mp(this, &Joint3DGizmoPlugin::incremental_update_gizmos));
 	update_timer->set_autostart(true);
 	callable_mp((Node *)EditorNode::get_singleton(), &Node::add_child).call_deferred(update_timer, false, Node::INTERNAL_MODE_DISABLED);
 }

--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -691,7 +691,7 @@ MeshLibraryEditor::MeshLibraryEditor() {
 	update_items_delay = memnew(Timer);
 	update_items_delay->set_wait_time(UPDATE_ITEMS_DELAY_TIMEOUT);
 	update_items_delay->set_one_shot(true);
-	update_items_delay->connect("timeout", callable_mp(this, &MeshLibraryEditor::_update_mesh_items).bind(true, Ref<MeshLibrary>()));
+	update_items_delay->connect(SceneStringName(timeout), callable_mp(this, &MeshLibraryEditor::_update_mesh_items).bind(true, Ref<MeshLibrary>()));
 	add_child(update_items_delay);
 
 	search_box = memnew(FilterLineEdit);

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -6102,7 +6102,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	resample_timer->set_wait_time(resample_delay);
 	resample_timer->set_one_shot(true);
 	add_child(resample_timer);
-	resample_timer->connect("timeout", callable_mp(this, &CanvasItemEditor::_update_oversampling));
+	resample_timer->connect(SceneStringName(timeout), callable_mp(this, &CanvasItemEditor::_update_oversampling));
 
 	multiply_grid_step_shortcut = ED_SHORTCUT("canvas_item_editor/multiply_grid_step", TTRC("Multiply grid step by 2"), Key::KP_MULTIPLY);
 	divide_grid_step_shortcut = ED_SHORTCUT("canvas_item_editor/divide_grid_step", TTRC("Divide grid step by 2"), Key::KP_DIVIDE);

--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -3694,7 +3694,7 @@ ThemeTypeEditor::ThemeTypeEditor() {
 	update_debounce_timer = memnew(Timer);
 	update_debounce_timer->set_one_shot(true);
 	update_debounce_timer->set_wait_time(0.5);
-	update_debounce_timer->connect("timeout", callable_mp(this, &ThemeTypeEditor::_update_type_list));
+	update_debounce_timer->connect(SceneStringName(timeout), callable_mp(this, &ThemeTypeEditor::_update_type_list));
 	add_child(update_debounce_timer);
 }
 

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -661,11 +661,11 @@ void SceneTreeEditor::_update_if_clean() {
 
 void SceneTreeEditor::_queue_update_node_tooltip(Node *p_node, TreeItem *p_item) {
 	Callable update_tooltip = callable_mp(this, &SceneTreeEditor::_update_node_tooltip);
-	if (update_node_tooltip_delay->is_connected("timeout", update_tooltip)) {
-		update_node_tooltip_delay->disconnect("timeout", update_tooltip);
+	if (update_node_tooltip_delay->is_connected(SceneStringName(timeout), update_tooltip)) {
+		update_node_tooltip_delay->disconnect(SceneStringName(timeout), update_tooltip);
 	}
 
-	update_node_tooltip_delay->connect("timeout", update_tooltip.bind(p_node, p_item));
+	update_node_tooltip_delay->connect(SceneStringName(timeout), update_tooltip.bind(p_node, p_item));
 	update_node_tooltip_delay->start();
 }
 
@@ -2207,7 +2207,7 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 	blocked = 0;
 
 	update_timer = memnew(Timer);
-	update_timer->connect("timeout", callable_mp(this, &SceneTreeEditor::_update_tree).bind(false));
+	update_timer->connect(SceneStringName(timeout), callable_mp(this, &SceneTreeEditor::_update_tree).bind(false));
 	update_timer->set_one_shot(true);
 	update_timer->set_wait_time(0.5);
 	add_child(update_timer);

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -4175,7 +4175,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	autosave_timer = memnew(Timer);
 	autosave_timer->set_one_shot(false);
 	autosave_timer->connect(SceneStringName(tree_entered), callable_mp(this, &ScriptEditor::_update_autosave_timer));
-	autosave_timer->connect("timeout", callable_mp(this, &ScriptEditor::_autosave_scripts));
+	autosave_timer->connect(SceneStringName(timeout), callable_mp(this, &ScriptEditor::_autosave_scripts));
 	add_child(autosave_timer);
 
 	grab_focus_block = false;

--- a/editor/settings/editor_feature_profile.cpp
+++ b/editor/settings/editor_feature_profile.cpp
@@ -1087,7 +1087,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	update_timer = memnew(Timer);
 	update_timer->set_wait_time(1); //wait a second before updating editor
 	add_child(update_timer);
-	update_timer->connect("timeout", callable_mp(this, &EditorFeatureProfileManager::_emit_current_profile_changed));
+	update_timer->connect(SceneStringName(timeout), callable_mp(this, &EditorFeatureProfileManager::_emit_current_profile_changed));
 	update_timer->set_one_shot(true);
 
 	singleton = this;

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -1076,7 +1076,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 
 	timer = memnew(Timer);
 	timer->set_wait_time(1.5);
-	timer->connect("timeout", callable_mp(this, &EditorSettingsDialog::_settings_save));
+	timer->connect(SceneStringName(timeout), callable_mp(this, &EditorSettingsDialog::_settings_save));
 	timer->set_one_shot(true);
 	add_child(timer);
 	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorSettingsDialog::_settings_changed));

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -854,7 +854,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 
 	timer = memnew(Timer);
 	timer->set_wait_time(1.5);
-	timer->connect("timeout", callable_mp(this, &ProjectSettingsEditor::_save));
+	timer->connect(SceneStringName(timeout), callable_mp(this, &ProjectSettingsEditor::_save));
 	timer->set_one_shot(true);
 	add_child(timer);
 

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -2153,7 +2153,7 @@ TextShaderEditor::TextShaderEditor() {
 	add_child(preview_timer);
 	preview_timer->set_one_shot(true);
 	preview_timer->set_wait_time(0.001);
-	preview_timer->connect("timeout", callable_mp(code_editor, &ShaderTextEditor::redraw_preview_lines));
+	preview_timer->connect(SceneStringName(timeout), callable_mp(code_editor, &ShaderTextEditor::redraw_preview_lines));
 
 	_apply_editor_settings();
 	code_editor->show_toggle_files_button(); // TODO: Disabled for now, because it doesn't work properly.

--- a/modules/gltf/editor/editor_import_blend_runner.cpp
+++ b/modules/gltf/editor/editor_import_blend_runner.cpp
@@ -396,7 +396,7 @@ EditorImportBlendRunner::EditorImportBlendRunner() {
 	add_child(kill_timer);
 	kill_timer->set_one_shot(true);
 	kill_timer->set_wait_time(EDITOR_GET("filesystem/import/blender/rpc_server_uptime"));
-	kill_timer->connect("timeout", callable_mp(this, &EditorImportBlendRunner::_kill_blender));
+	kill_timer->connect(SceneStringName(timeout), callable_mp(this, &EditorImportBlendRunner::_kill_blender));
 
 	EditorFileSystem::get_singleton()->connect("resources_reimported", callable_mp(this, &EditorImportBlendRunner::_resources_reimported));
 }

--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -445,6 +445,6 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 
 	refresh_timer = memnew(Timer);
 	refresh_timer->set_wait_time(0.5);
-	refresh_timer->connect("timeout", callable_mp(this, &EditorNetworkProfiler::_refresh));
+	refresh_timer->connect(SceneStringName(timeout), callable_mp(this, &EditorNetworkProfiler::_refresh));
 	add_child(refresh_timer);
 }

--- a/modules/navigation_2d/editor/navigation_region_2d_editor_plugin.cpp
+++ b/modules/navigation_2d/editor/navigation_region_2d_editor_plugin.cpp
@@ -170,7 +170,7 @@ NavigationRegion2DEditor::NavigationRegion2DEditor() {
 	if (_rebake_timer_delay >= 0.0) {
 		rebake_timer->set_wait_time(_rebake_timer_delay);
 	}
-	rebake_timer->connect("timeout", callable_mp(this, &NavigationRegion2DEditor::_rebake_timer_timeout));
+	rebake_timer->connect(SceneStringName(timeout), callable_mp(this, &NavigationRegion2DEditor::_rebake_timer_timeout));
 
 	err_dialog = memnew(AcceptDialog);
 	add_child(err_dialog);

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
@@ -7826,7 +7826,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	panning_debounce_timer = memnew(Timer);
 	panning_debounce_timer->set_one_shot(true);
 	panning_debounce_timer->set_wait_time(1.0);
-	panning_debounce_timer->connect("timeout", callable_mp(this, &VisualShaderEditor::save_editor_layout));
+	panning_debounce_timer->connect(SceneStringName(timeout), callable_mp(this, &VisualShaderEditor::save_editor_layout));
 	add_child(panning_debounce_timer);
 }
 

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -339,7 +339,7 @@ void PathFollow2D::_notification(int p_what) {
 				update_timer = memnew(Timer);
 				update_timer->set_wait_time(0.2);
 				update_timer->set_one_shot(true);
-				update_timer->connect("timeout", callable_mp(this, &PathFollow2D::_update_transform));
+				update_timer->connect(SceneStringName(timeout), callable_mp(this, &PathFollow2D::_update_transform));
 				add_child(update_timer, false, Node::INTERNAL_MODE_BACK);
 			}
 		} break;

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -506,7 +506,7 @@ void BaseButton::shortcut_input(const Ref<InputEvent> &p_event) {
 				shortcut_feedback_timer->set_one_shot(true);
 				add_child(shortcut_feedback_timer, false, INTERNAL_MODE_BACK);
 				shortcut_feedback_timer->set_wait_time(GLOBAL_GET_CACHED(double, "gui/timers/button_shortcut_feedback_highlight_time"));
-				shortcut_feedback_timer->connect("timeout", callable_mp(this, &BaseButton::_shortcut_feedback_timeout));
+				shortcut_feedback_timer->connect(SceneStringName(timeout), callable_mp(this, &BaseButton::_shortcut_feedback_timeout));
 			}
 
 			in_shortcut_feedback = true;

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -4177,7 +4177,7 @@ CodeEdit::CodeEdit() {
 	symbol_tooltip_timer = memnew(Timer);
 	symbol_tooltip_timer->set_wait_time(0.5); // See `_apply_project_settings()`.
 	symbol_tooltip_timer->set_one_shot(true);
-	symbol_tooltip_timer->connect("timeout", callable_mp(this, &CodeEdit::_on_symbol_tooltip_timer_timeout));
+	symbol_tooltip_timer->connect(SceneStringName(timeout), callable_mp(this, &CodeEdit::_on_symbol_tooltip_timer_timeout));
 	add_child(symbol_tooltip_timer, false, INTERNAL_MODE_FRONT);
 
 	/* Fold Lines Private signal */

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3698,13 +3698,13 @@ PopupMenu::PopupMenu() {
 	submenu_timer = memnew(Timer);
 	submenu_timer->set_wait_time(submenu_timer_popup_delay); // Default is 0.2.
 	submenu_timer->set_one_shot(true);
-	submenu_timer->connect("timeout", callable_mp(this, &PopupMenu::_submenu_timeout));
+	submenu_timer->connect(SceneStringName(timeout), callable_mp(this, &PopupMenu::_submenu_timeout));
 	add_child(submenu_timer, false, INTERNAL_MODE_FRONT);
 
 	close_suspended_timer = memnew(Timer);
 	close_suspended_timer->set_wait_time(CLOSE_SUSPENDED_TIMER_DELAY);
 	close_suspended_timer->set_one_shot(true);
-	close_suspended_timer->connect("timeout", callable_mp(this, &PopupMenu::_close_suspended_timeout));
+	close_suspended_timer->connect(SceneStringName(timeout), callable_mp(this, &PopupMenu::_close_suspended_timeout));
 	add_child(close_suspended_timer, false, INTERNAL_MODE_FRONT);
 
 	property_helper.setup_for_instance(base_property_helper, this);

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -8448,7 +8448,7 @@ RichTextLabel::RichTextLabel(const String &p_text) {
 	click_select_held = memnew(Timer);
 	add_child(click_select_held, false, INTERNAL_MODE_FRONT);
 	click_select_held->set_wait_time(0.05);
-	click_select_held->connect("timeout", callable_mp(this, &RichTextLabel::_update_selection));
+	click_select_held->connect(SceneStringName(timeout), callable_mp(this, &RichTextLabel::_update_selection));
 }
 
 RichTextLabel::~RichTextLabel() {

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -746,6 +746,6 @@ SpinBox::SpinBox() {
 	line_edit->connect(SceneStringName(gui_input), callable_mp(this, &SpinBox::_line_edit_input));
 
 	range_click_timer = memnew(Timer);
-	range_click_timer->connect("timeout", callable_mp(this, &SpinBox::_range_click_timeout));
+	range_click_timer->connect(SceneStringName(timeout), callable_mp(this, &SpinBox::_range_click_timeout));
 	add_child(range_click_timer, false, INTERNAL_MODE_FRONT);
 }

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -2234,7 +2234,7 @@ TabBar::TabBar() {
 	connect(SceneStringName(mouse_exited), callable_mp(this, &TabBar::_on_mouse_exited));
 
 	hover_switch_delay = memnew(Timer);
-	hover_switch_delay->connect("timeout", callable_mp(this, &TabBar::_hover_switch_timeout));
+	hover_switch_delay->connect(SceneStringName(timeout), callable_mp(this, &TabBar::_hover_switch_timeout));
 	hover_switch_delay->set_one_shot(true);
 	add_child(hover_switch_delay, false, INTERNAL_MODE_FRONT);
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -9377,20 +9377,20 @@ TextEdit::TextEdit(const String &p_placeholder) {
 	caret_blink_timer = memnew(Timer);
 	add_child(caret_blink_timer, false, INTERNAL_MODE_FRONT);
 	caret_blink_timer->set_wait_time(0.65);
-	caret_blink_timer->connect("timeout", callable_mp(this, &TextEdit::_toggle_draw_caret));
+	caret_blink_timer->connect(SceneStringName(timeout), callable_mp(this, &TextEdit::_toggle_draw_caret));
 	set_caret_blink_enabled(false);
 
 	/* Selection. */
 	click_select_held = memnew(Timer);
 	add_child(click_select_held, false, INTERNAL_MODE_FRONT);
 	click_select_held->set_wait_time(0.05);
-	click_select_held->connect("timeout", callable_mp(this, &TextEdit::_click_selection_held));
+	click_select_held->connect(SceneStringName(timeout), callable_mp(this, &TextEdit::_click_selection_held));
 
 	idle_detect = memnew(Timer);
 	add_child(idle_detect, false, INTERNAL_MODE_FRONT);
 	idle_detect->set_one_shot(true);
 	idle_detect->set_wait_time(GLOBAL_GET_CACHED(double, "gui/timers/text_edit_idle_detect_sec"));
-	idle_detect->connect("timeout", callable_mp(this, &TextEdit::_push_current_op));
+	idle_detect->connect(SceneStringName(timeout), callable_mp(this, &TextEdit::_push_current_op));
 
 	undo_stack_max_size = GLOBAL_GET_CACHED(int, "gui/common/text_edit_undo_stack_max_size");
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -7445,12 +7445,12 @@ Tree::Tree() {
 	add_child(v_scroll, false, INTERNAL_MODE_FRONT);
 
 	range_click_timer = memnew(Timer);
-	range_click_timer->connect("timeout", callable_mp(this, &Tree::_range_click_timeout));
+	range_click_timer->connect(SceneStringName(timeout), callable_mp(this, &Tree::_range_click_timeout));
 	add_child(range_click_timer, false, INTERNAL_MODE_FRONT);
 
 	dropping_unfold_timer = memnew(Timer);
 	dropping_unfold_timer->set_one_shot(true);
-	dropping_unfold_timer->connect("timeout", callable_mp(this, &Tree::_on_dropping_unfold_timer_timeout));
+	dropping_unfold_timer->connect(SceneStringName(timeout), callable_mp(this, &Tree::_on_dropping_unfold_timer_timeout));
 	add_child(dropping_unfold_timer);
 
 	h_scroll->connect(SceneStringName(value_changed), callable_mp(this, &Tree::_scroll_moved));

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -729,6 +729,6 @@ HTTPRequest::HTTPRequest() {
 	timer = memnew(Timer);
 	timer->set_one_shot(true);
 	timer->set_ignore_time_scale(true);
-	timer->connect("timeout", callable_mp(this, &HTTPRequest::_timeout));
+	timer->connect(SceneStringName(timeout), callable_mp(this, &HTTPRequest::_timeout));
 	add_child(timer);
 }

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -808,7 +808,7 @@ void SceneTree::process_timers(double p_delta, bool p_physics_frame) {
 		timer->set_time_left(time_left);
 
 		if (time_left <= 0) {
-			E->get()->emit_signal(SNAME("timeout"));
+			E->get()->emit_signal(SceneStringName(timeout));
 			timers.erase(E);
 		}
 		if (E == L) {

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -64,7 +64,7 @@ void Timer::_notification(int p_what) {
 					stop();
 				}
 
-				emit_signal(SNAME("timeout"));
+				emit_signal(SceneStringName(timeout));
 			}
 		} break;
 
@@ -84,7 +84,7 @@ void Timer::_notification(int p_what) {
 				} else {
 					stop();
 				}
-				emit_signal(SNAME("timeout"));
+				emit_signal(SceneStringName(timeout));
 			}
 		} break;
 	}

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2152,7 +2152,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 						gui.tooltip_pos = new_tooltip_pos;
 						gui.tooltip_timer = get_tree()->create_timer(gui.tooltip_delay);
 						gui.tooltip_timer->set_ignore_time_scale(true);
-						gui.tooltip_timer->connect("timeout", callable_mp(this, &Viewport::_gui_show_tooltip));
+						gui.tooltip_timer->connect(SceneStringName(timeout), callable_mp(this, &Viewport::_gui_show_tooltip));
 					}
 				}
 			}

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -151,6 +151,8 @@ public:
 	const StringName text_submitted = "text_submitted";
 	const StringName value_changed = "value_changed";
 
+	const StringName timeout = "timeout";
+
 	const StringName Start = "Start";
 	const StringName End = "End";
 	const StringName state_started = "state_started";

--- a/tests/scene/test_timer.cpp
+++ b/tests/scene/test_timer.cpp
@@ -154,53 +154,53 @@ TEST_CASE("[SceneTree][Timer] Check Timer timeout signal") {
 	test_timer->set_physics_process(true);
 
 	SUBCASE("[Timer] Timer process timeout signal must be emitted") {
-		SIGNAL_WATCH(test_timer, SNAME("timeout"));
+		SIGNAL_WATCH(test_timer, SceneStringName(timeout));
 		test_timer->start(0.1);
 
 		SceneTree::get_singleton()->process(0.2);
 
 		Array signal_args = { {} };
-		SIGNAL_CHECK(SNAME("timeout"), signal_args);
+		SIGNAL_CHECK(SceneStringName(timeout), signal_args);
 
-		SIGNAL_UNWATCH(test_timer, SNAME("timeout"));
+		SIGNAL_UNWATCH(test_timer, SceneStringName(timeout));
 	}
 
 	SUBCASE("[Timer] Timer process timeout signal must not be emitted") {
-		SIGNAL_WATCH(test_timer, SNAME("timeout"));
+		SIGNAL_WATCH(test_timer, SceneStringName(timeout));
 		test_timer->start(0.1);
 
 		SceneTree::get_singleton()->process(0.05);
 
 		Array signal_args = { {} };
-		SIGNAL_CHECK_FALSE(SNAME("timeout"));
+		SIGNAL_CHECK_FALSE(SceneStringName(timeout));
 
-		SIGNAL_UNWATCH(test_timer, SNAME("timeout"));
+		SIGNAL_UNWATCH(test_timer, SceneStringName(timeout));
 	}
 
 	test_timer->set_timer_process_callback(Timer::TimerProcessCallback::TIMER_PROCESS_PHYSICS);
 
 	SUBCASE("[Timer] Timer physics process timeout signal must be emitted") {
-		SIGNAL_WATCH(test_timer, SNAME("timeout"));
+		SIGNAL_WATCH(test_timer, SceneStringName(timeout));
 		test_timer->start(0.1);
 
 		SceneTree::get_singleton()->physics_process(0.2);
 
 		Array signal_args = { {} };
-		SIGNAL_CHECK(SNAME("timeout"), signal_args);
+		SIGNAL_CHECK(SceneStringName(timeout), signal_args);
 
-		SIGNAL_UNWATCH(test_timer, SNAME("timeout"));
+		SIGNAL_UNWATCH(test_timer, SceneStringName(timeout));
 	}
 
 	SUBCASE("[Timer] Timer physics process timeout signal must not be emitted") {
-		SIGNAL_WATCH(test_timer, SNAME("timeout"));
+		SIGNAL_WATCH(test_timer, SceneStringName(timeout));
 		test_timer->start(0.1);
 
 		SceneTree::get_singleton()->physics_process(0.05);
 
 		Array signal_args = { {} };
-		SIGNAL_CHECK_FALSE(SNAME("timeout"));
+		SIGNAL_CHECK_FALSE(SceneStringName(timeout));
 
-		SIGNAL_UNWATCH(test_timer, SNAME("timeout"));
+		SIGNAL_UNWATCH(test_timer, SceneStringName(timeout));
 	}
 
 	memdelete(test_timer);


### PR DESCRIPTION
`Timer` used in a lot of places so there no reason to declare its main signal `StringName` multiple times.