### PR TITLE
Fix `overwrite_dialog` size on Android

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2027,7 +2027,7 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 			overwrite_dialog_footer->set_text(
 					p_copy ? TTRC("Do you wish to overwrite them or rename the copied files?")
 						   : TTRC("Do you wish to overwrite them or rename the moved files?"));
-			overwrite_dialog->popup_centered();
+			overwrite_dialog->popup_centered_ratio(0.6);
 			return;
 		}
 	}
@@ -2542,7 +2542,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			}
 			if (to_move.size() > 0) {
 				move_dialog->config(p_selected);
-				move_dialog->popup_centered_ratio(0.4);
+				move_dialog->popup_centered_ratio(0.5);
 			}
 		} break;
 
@@ -4533,7 +4533,8 @@ FileSystemDock::FileSystemDock() {
 
 	overwrite_dialog_scroll = memnew(ScrollContainer);
 	overwrite_dialog_vb->add_child(overwrite_dialog_scroll);
-	overwrite_dialog_scroll->set_custom_minimum_size(Vector2(400, 600) * EDSCALE);
+	overwrite_dialog_scroll->set_custom_minimum_size(Vector2(50, 50) * EDSCALE);
+	overwrite_dialog_scroll->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	overwrite_dialog_file_list = memnew(Label);
 	overwrite_dialog_scroll->add_child(overwrite_dialog_file_list);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/117918

Also, increases the `move_dialog` minimum size for better usability on Android.

| Before | After |
|--------|--------|
|  <img width="1230" height="540" alt="Screenshot_20260328_162355" src="https://github.com/user-attachments/assets/76be8506-94ab-44e5-a517-3cba05b09357" /> | <img width="1230" height="540" alt="Screenshot_20260328_162832" src="https://github.com/user-attachments/assets/b9dbd85c-f3aa-41ca-9a67-cb140a484b2a" /> |
| <img width="1230" height="540" alt="Screenshot_20260328_162412" src="https://github.com/user-attachments/assets/e7b1cf35-05f2-4e82-ba04-9f19935e9510" /> | <img width="1230" height="540" alt="Screenshot_20260328_162846" src="https://github.com/user-attachments/assets/ba7a3fa0-9266-4deb-90bc-940de6f51718" /> | 






