### PR TITLE
Clarify children visibility in FoldableContainer

### DIFF
--- a/doc/classes/FoldableContainer.xml
+++ b/doc/classes/FoldableContainer.xml
@@ -7,6 +7,7 @@
 		A container that can be expanded/collapsed, with a title that can be filled with controls, such as buttons. This is also called an accordion.
 		The title can be positioned at the top or bottom of the container. The container can be expanded or collapsed by clicking the title or by pressing [code]ui_accept[/code] when focused. Child control nodes are hidden when the container is collapsed. Ignores non-control children.
 		A FoldableContainer can be grouped with other FoldableContainers so that only one of them can be opened at a time; see [member foldable_group] and [FoldableGroup].
+		[b]Note:[/b] The FoldableContainer manages the visibility of its children. Their visibility depends on the folded state and can't be changed manually.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Closes #117917

The line that causes visibility changes is
https://github.com/godotengine/godot/blob/2af785641ae249573f45eb61852d22e0b1a8a03c/scene/gui/foldable_container.cpp#L382
which is part of NOTIFICATION_SORT_CHILDREN, which is received every time child visibility changes.