### PR TITLE
Add key details to `ProjectSettings.get_global_class_list` description

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -83,6 +83,8 @@
 				- [code]icon[/code] is a path to a custom icon of the global class, if it has any;
 				- [code]language[/code] is a name of a programming language in which the global class is written;
 				- [code]path[/code] is a path to a file containing the global class.
+				- [code]is_abstract[/code] is set to [code]true[/code] if the global class is abstract.
+				- [code]is_tool[/code] is set to [code]true[/code] if the global class is a tool script and will run in editor.
 				[b]Note:[/b] Both the script and the icon paths are local to the project filesystem, i.e. they start with [code]res://[/code].
 			</description>
 		</method>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -84,7 +84,7 @@
 				- [code]language[/code] is a name of a programming language in which the global class is written;
 				- [code]path[/code] is a path to a file containing the global class.
 				- [code]is_abstract[/code] is set to [code]true[/code] if the global class is abstract.
-				- [code]is_tool[/code] is set to [code]true[/code] if the global class is a tool script and will run in editor.
+				- [code]is_tool[/code] is set to [code]true[/code] if the global class is a tool script and will run in the editor.
 				[b]Note:[/b] Both the script and the icon paths are local to the project filesystem, i.e. they start with [code]res://[/code].
 			</description>
 		</method>


### PR DESCRIPTION
Updated `ProjectSettings.get_global_class_list` description to include `is_abstract` and `is_tool`.