### PR TITLE
Add a power-of-2 hotkeys to the 3D scene grid.

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -103,6 +103,7 @@
 #include "scene/gui/center_container.h"
 #include "scene/gui/color_picker.h"
 #include "scene/gui/flow_container.h"
+#include "scene/gui/grid_container.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/split_container.h"
@@ -139,6 +140,102 @@ constexpr real_t MAX_Z = 1000000.0;
 
 constexpr real_t MIN_FOV = 0.01;
 constexpr real_t MAX_FOV = 179;
+
+class Node3DEditorPluginSnap : public ConfirmationDialog {
+	GDCLASS(Node3DEditorPluginSnap, ConfirmationDialog);
+
+	friend class Node3DEditor;
+
+	EditorSpinSlider *grid_step = nullptr;
+	SpinBox *rotation_step = nullptr;
+	SpinBox *scale_step = nullptr;
+
+private:
+	GridContainer *separate(VBoxContainer *p_container) {
+		p_container->add_child(memnew(HSeparator));
+
+		GridContainer *child_container = memnew(GridContainer);
+		child_container->set_columns(2);
+		p_container->add_child(child_container);
+
+		return child_container;
+	}
+
+public:
+	Node3DEditorPluginSnap() {
+		const int SPIN_BOX_ROTATION_RANGE = 360;
+		const real_t SPIN_BOX_GRID_STEP_RANGE = 10.0;
+		const real_t SPIN_BOX_SCALE_MIN = 0.01;
+		const real_t SPIN_BOX_SCALE_MAX = 100;
+
+		set_title(TTRC("Configure Snap"));
+		VBoxContainer *container = memnew(VBoxContainer);
+		add_child(container);
+		GridContainer *child_container = memnew(GridContainer);
+		child_container->set_columns(2);
+		container->add_child(child_container);
+
+		Label *label = memnew(Label);
+		label->set_text(TTRC("Grid Step:"));
+		label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		child_container->add_child(label);
+
+		grid_step = memnew(EditorSpinSlider);
+		grid_step->set_min(0.01);
+		grid_step->set_step(0.001);
+		grid_step->set_max(SPIN_BOX_GRID_STEP_RANGE);
+		grid_step->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		grid_step->set_suffix("m");
+		grid_step->set_allow_greater(true);
+		grid_step->set_accessibility_name(TTRC("Grid Step"));
+		child_container->add_child(grid_step);
+
+		child_container = separate(container);
+
+		label = memnew(Label);
+		label->set_text(TTRC("Rotation Step:"));
+		child_container->add_child(label);
+		label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+
+		rotation_step = memnew(SpinBox);
+		rotation_step->set_min(-SPIN_BOX_ROTATION_RANGE);
+		rotation_step->set_max(SPIN_BOX_ROTATION_RANGE);
+		rotation_step->set_suffix(U"°");
+		rotation_step->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		rotation_step->set_select_all_on_focus(true);
+		rotation_step->set_accessibility_name(TTRC("Rotation Step"));
+		child_container->add_child(rotation_step);
+
+		child_container = separate(container);
+
+		label = memnew(Label);
+		label->set_text(TTRC("Scale Step:"));
+		child_container->add_child(label);
+		label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+
+		scale_step = memnew(SpinBox);
+		scale_step->set_min(SPIN_BOX_SCALE_MIN);
+		scale_step->set_max(SPIN_BOX_SCALE_MAX);
+		scale_step->set_allow_greater(true);
+		scale_step->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		scale_step->set_step(0.01f);
+		scale_step->set_select_all_on_focus(true);
+		scale_step->set_accessibility_name(TTRC("Scale Step"));
+		child_container->add_child(scale_step);
+	}
+
+	void set_fields(real_t p_grid_step, real_t p_rotation_step, real_t p_scale_step) {
+		grid_step->set_value(p_grid_step);
+		rotation_step->set_value(p_rotation_step);
+		scale_step->set_value(p_scale_step);
+	}
+
+	void get_fields(real_t &r_grid_step, real_t &r_rotation_step, real_t &r_scale_step) {
+		r_grid_step = grid_step->get_value();
+		r_rotation_step = rotation_step->get_value();
+		r_scale_step = scale_step->get_value();
+	}
+};
 
 void ViewportNavigationControl::_notification(int p_what) {
 	switch (p_what) {
@@ -6668,6 +6765,9 @@ void Node3DEditorViewport::_load_viewport_inputs() {
 	register_shortcut_action("spatial_editor/viewport_zoom_modifier_1", TTRC("Viewport Zoom Modifier 1"), Key::CTRL);
 	register_shortcut_action("spatial_editor/viewport_zoom_modifier_2", TTRC("Viewport Zoom Modifier 2"), Key::NONE);
 
+	register_shortcut_action("spatial_editor/multiply_grid_step", TTRC("Multiply grid step by 2"), Key::KP_MULTIPLY);
+	register_shortcut_action("spatial_editor/divide_grid_step", TTRC("Divide grid step by 2"), Key::KP_DIVIDE);
+
 	register_shortcut_action("spatial_editor/freelook_left", TTRC("Freelook Left"), Key::A, true);
 	register_shortcut_action("spatial_editor/freelook_right", TTRC("Freelook Right"), Key::D, true);
 	register_shortcut_action("spatial_editor/freelook_forward", TTRC("Freelook Forward"), Key::W, true);
@@ -7548,9 +7648,10 @@ Dictionary Node3DEditor::get_state() const {
 
 	d["snap_enabled"] = snap_enabled;
 	d["trackball_enabled"] = trackball_enabled;
-	d["translate_snap"] = snap_translate_value;
-	d["rotate_snap"] = snap_rotate_value;
-	d["scale_snap"] = snap_scale_value;
+	d["grid_step"] = grid_step;
+	d["grid_step_multiplier"] = grid_step_multiplier;
+	d["rotate_snap"] = snap_rotate_step;
+	d["scale_snap"] = snap_scale_step;
 
 	d["local_coords"] = tool_option_button[TOOL_OPT_LOCAL_COORDS]->is_pressed();
 	d["preserve_children_transform"] = tool_option_button[TOOL_OPT_PRESERVE_CHILDREN_TRANSFORM]->is_pressed();
@@ -7637,16 +7738,20 @@ void Node3DEditor::set_state(const Dictionary &p_state) {
 		tool_option_button[TOOL_OPT_USE_TRACKBALL]->set_pressed(d["trackball_enabled"]);
 	}
 
-	if (d.has("translate_snap")) {
-		snap_translate_value = d["translate_snap"];
+	if (d.has("grid_step")) {
+		grid_step = d["grid_step"];
+	}
+
+	if (d.has("grid_step_multiplier")) {
+		grid_step_multiplier = d["grid_step_multiplier"];
 	}
 
 	if (d.has("rotate_snap")) {
-		snap_rotate_value = d["rotate_snap"];
+		snap_rotate_step = d["rotate_snap"];
 	}
 
 	if (d.has("scale_snap")) {
-		snap_scale_value = d["scale_snap"];
+		snap_scale_step = d["scale_snap"];
 	}
 
 	_snap_update();
@@ -7831,19 +7936,21 @@ void Node3DEditor::edit(Node3D *p_spatial) {
 }
 
 void Node3DEditor::_snap_changed() {
-	snap_translate_value = snap_translate->get_value();
-	snap_rotate_value = snap_rotate->get_value();
-	snap_scale_value = snap_scale->get_value();
+	static_cast<Node3DEditorPluginSnap *>(snap_dialog)->get_fields(grid_step, snap_rotate_step, snap_scale_step);
+	// Reset multiplier; Reconfigured grid must reflect values set by the user.
+	grid_step_multiplier = 0;
 
-	EditorSettings::get_singleton()->set_project_metadata("3d_editor", "snap_translate_value", snap_translate_value);
-	EditorSettings::get_singleton()->set_project_metadata("3d_editor", "snap_rotate_value", snap_rotate_value);
-	EditorSettings::get_singleton()->set_project_metadata("3d_editor", "snap_scale_value", snap_scale_value);
+	EditorSettings::get_singleton()->set_project_metadata("3d_editor", "grid_step", grid_step);
+	EditorSettings::get_singleton()->set_project_metadata("3d_editor", "grid_step_multiplier", grid_step_multiplier);
+	EditorSettings::get_singleton()->set_project_metadata("3d_editor", "snap_rotate_value", snap_rotate_step);
+	EditorSettings::get_singleton()->set_project_metadata("3d_editor", "snap_scale_value", snap_scale_step);
+
+	update_grid(true);
 }
 
 void Node3DEditor::_snap_update() {
-	snap_translate->set_value(snap_translate_value);
-	snap_rotate->set_value(snap_rotate_value);
-	snap_scale->set_value(snap_scale_value);
+	static_cast<Node3DEditorPluginSnap *>(snap_dialog)->set_fields(grid_step, snap_rotate_step, snap_scale_step);
+	update_grid(true);
 }
 
 void Node3DEditor::_update_vertex_snap_tooltips() {
@@ -8022,7 +8129,7 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 			}
 		} break;
 		case MENU_TRANSFORM_CONFIGURE_SNAP: {
-			snap_dialog->popup_centered(Size2(200, 180));
+			snap_dialog->popup_centered(Size2(320, 160) * EDSCALE);
 		} break;
 		case MENU_VERTEX_SNAP_BASE_VERTEX: {
 			vertex_snap_origin_mode = false;
@@ -9031,10 +9138,12 @@ void Node3DEditor::_init_grid() {
 		real_t division_level_floored = Math::floor(clamped_division_level);
 		real_t division_level_decimals = clamped_division_level - division_level_floored;
 
-		real_t small_step_size = Math::pow(primary_grid_steps, division_level_floored);
-		real_t large_step_size = small_step_size * primary_grid_steps;
-		real_t center_a = large_step_size * (int)(camera_position[a] / large_step_size);
-		real_t center_b = large_step_size * (int)(camera_position[b] / large_step_size);
+		// Note - `get_translate_snap` is not used to prevent grid from shrinking when `shift` is pressed.
+		const real_t snap_value = grid_step * (real_t)Math::pow(2.0, grid_step_multiplier);
+		const real_t small_step_size = Math::pow(primary_grid_steps, division_level_floored) * snap_value;
+		const real_t large_step_size = small_step_size * primary_grid_steps;
+		const real_t center_a = large_step_size * (int)(camera_position[a] / large_step_size);
+		const real_t center_b = large_step_size * (int)(camera_position[b] / large_step_size);
 
 		real_t bgn_a = center_a - grid_size * small_step_size;
 		real_t end_a = center_a + grid_size * small_step_size;
@@ -9184,7 +9293,7 @@ void Node3DEditor::update_gizmo_opacity() {
 	}
 }
 
-void Node3DEditor::update_grid() {
+void Node3DEditor::update_grid(bool p_force) {
 	const Camera3D::ProjectionType current_projection = viewports[0]->camera->get_projection();
 
 	if (current_projection != grid_camera_last_update_perspective) {
@@ -9195,7 +9304,7 @@ void Node3DEditor::update_grid() {
 	// Gets a orthogonal or perspective position correctly (for the grid comparison)
 	const Vector3 camera_position = get_editor_viewport(0)->camera->get_position();
 
-	if (!grid_init_draw || grid_camera_last_update_position.distance_squared_to(camera_position) >= 100.0f) {
+	if (p_force || !grid_init_draw || grid_camera_last_update_position.distance_squared_to(camera_position) >= 100.0f) {
 		_finish_grid();
 		_init_grid();
 		grid_init_draw = true;
@@ -9492,6 +9601,28 @@ void Node3DEditor::_snap_selected_nodes_to_floor() {
 	}
 }
 
+void Node3DEditor::handle_grid_shortcut_input(const Ref<InputEvent> &p_event) {
+	const int GRID_STEP_MAX_MULTIPLIER = 6;
+	const int GRID_STEP_MIN_MULTIPLIER = -4;
+
+	Ref<InputEventKey> k = p_event;
+	if (!k.is_valid()) {
+		return;
+	}
+
+	if (k->is_pressed() && ED_IS_SHORTCUT("spatial_editor/multiply_grid_step", p_event)) {
+		grid_step_multiplier = MIN(grid_step_multiplier + 1, GRID_STEP_MAX_MULTIPLIER);
+	} else if (k->is_pressed() && ED_IS_SHORTCUT("spatial_editor/divide_grid_step", p_event)) {
+		grid_step_multiplier = MAX(grid_step_multiplier - 1, GRID_STEP_MIN_MULTIPLIER);
+	} else {
+		return;
+	}
+
+	EditorSettings::get_singleton()->set_project_metadata("3d_editor", "grid_step_multiplier", grid_step_multiplier);
+
+	update_grid(true);
+}
+
 void Node3DEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
@@ -9500,6 +9631,7 @@ void Node3DEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 	}
 
 	snap_key_enabled = Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL);
+	handle_grid_shortcut_input(p_event);
 }
 
 void Node3DEditor::_sun_environ_settings_pressed() {
@@ -9592,6 +9724,8 @@ void Node3DEditor::_update_theme() {
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_button_icon(get_editor_theme_icon(SNAME("Snap")));
 	tool_option_button[TOOL_OPT_USE_TRACKBALL]->set_button_icon(get_editor_theme_icon(SNAME("Trackball")));
 	tool_option_button[TOOL_OPT_PRESERVE_CHILDREN_TRANSFORM]->set_button_icon(get_editor_theme_icon(SNAME("Pin")));
+
+	transform_menu->set_button_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
 
 	view_layout_menu->get_popup()->set_item_icon(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_1_VIEWPORT), get_editor_theme_icon(SNAME("Panels1")));
 	view_layout_menu->get_popup()->set_item_icon(view_layout_menu->get_popup()->get_item_index(MENU_VIEW_USE_2_VIEWPORTS), get_editor_theme_icon(SNAME("Panels2")));
@@ -10088,9 +10222,11 @@ void Node3DEditor::clear() {
 	settings_znear->set_value(EDITOR_GET("editors/3d/default_z_near"));
 	settings_zfar->set_value(EDITOR_GET("editors/3d/default_z_far"));
 
-	snap_translate_value = EditorSettings::get_singleton()->get_project_metadata("3d_editor", "snap_translate_value", 1);
-	snap_rotate_value = EditorSettings::get_singleton()->get_project_metadata("3d_editor", "snap_rotate_value", 15);
-	snap_scale_value = EditorSettings::get_singleton()->get_project_metadata("3d_editor", "snap_scale_value", 10);
+	grid_step = EditorSettings::get_singleton()->get_project_metadata("3d_editor", "grid_step", 1);
+	grid_step_multiplier = EditorSettings::get_singleton()->get_project_metadata("3d_editor", "grid_step_multiplier", 0);
+	snap_rotate_step = EditorSettings::get_singleton()->get_project_metadata("3d_editor", "snap_rotate_value", 15);
+	snap_scale_step = EditorSettings::get_singleton()->get_project_metadata("3d_editor", "snap_scale_value", 10);
+
 	_snap_update();
 
 	for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
@@ -10583,6 +10719,36 @@ Node3DEditor::Node3DEditor() {
 	tool_option_button[TOOL_OPT_PRESERVE_CHILDREN_TRANSFORM]->set_accessibility_name(TTRC("Preserve Children Transform"));
 	tool_option_button[TOOL_OPT_PRESERVE_CHILDREN_TRANSFORM]->set_tooltip_text(TTRC("When enabled, transforming a node will preserve the global transform of its children.\nThis also applies when editing transform properties in the Inspector."));
 
+	transform_menu = memnew(MenuButton);
+	transform_menu->set_flat(false);
+	transform_menu->set_theme_type_variation(SceneStringName(FlatMenuButton));
+	transform_menu->set_switch_on_hover(true);
+	transform_menu->set_shortcut_context(this);
+	transform_menu->set_h_size_flags(SIZE_SHRINK_END);
+	transform_menu->set_tooltip_text(TTRC("Snapping Options"));
+	main_menu_hbox->add_child(transform_menu);
+
+	PopupMenu *p = transform_menu->get_popup();
+	p->add_shortcut(ED_SHORTCUT("spatial_editor/snap_to_floor", TTRC("Snap Object to Floor"), Key::PAGEDOWN), MENU_SNAP_TO_FLOOR);
+	p->add_shortcut(ED_SHORTCUT("spatial_editor/transform_dialog", TTRC("Transform Dialog...")), MENU_TRANSFORM_DIALOG);
+
+	p->add_separator();
+	ED_SHORTCUT("spatial_editor/vertex_snap", TTRC("Vertex Snap"), Key::B);
+	p->add_radio_check_item(TTRC("Snap Vertex to Vertex"), MENU_VERTEX_SNAP_BASE_VERTEX);
+	p->set_item_checked(p->get_item_index(MENU_VERTEX_SNAP_BASE_VERTEX), true);
+	p->add_radio_check_item(TTRC("Snap Origin to Vertex"), MENU_VERTEX_SNAP_BASE_ORIGIN);
+
+	p->add_separator();
+	p->add_radio_check_item(TTRC("Snap to Mesh Vertices"), MENU_VERTEX_SNAP_SOURCE_MESH);
+	p->set_item_checked(p->get_item_index(MENU_VERTEX_SNAP_SOURCE_MESH), true);
+	p->add_radio_check_item(TTRC("Snap to Collision Vertices"), MENU_VERTEX_SNAP_SOURCE_COLLISION);
+	_update_vertex_snap_tooltips();
+
+	p->add_separator();
+	p->add_shortcut(ED_SHORTCUT("spatial_editor/configure_snap", TTRC("Configure Snap...")), MENU_TRANSFORM_CONFIGURE_SNAP);
+
+	p->connect(SceneStringName(id_pressed), callable_mp(this, &Node3DEditor::_menu_item_pressed));
+
 	main_menu_hbox->add_child(memnew(VSeparator));
 	sun_button = memnew(Button);
 	sun_button->set_tooltip_text(TTRC("Toggle preview sunlight.\nIf a DirectionalLight3D node is added to the scene, preview sunlight is disabled."));
@@ -10647,37 +10813,6 @@ Node3DEditor::Node3DEditor() {
 	ED_SHORTCUT("spatial_editor/increase_fov", TTRC("Increase Field of View"), KeyModifierMask::CMD_OR_CTRL + Key::MINUS);
 	ED_SHORTCUT("spatial_editor/reset_fov", TTRC("Reset Field of View to Default"), KeyModifierMask::CMD_OR_CTRL + Key::KEY_0);
 
-	PopupMenu *p;
-
-	transform_menu = memnew(MenuButton);
-	transform_menu->set_flat(false);
-	transform_menu->set_theme_type_variation("FlatMenuButton");
-	transform_menu->set_text(TTRC("Transform"));
-	transform_menu->set_switch_on_hover(true);
-	transform_menu->set_shortcut_context(this);
-	main_menu_hbox->add_child(transform_menu);
-
-	p = transform_menu->get_popup();
-	p->add_shortcut(ED_SHORTCUT("spatial_editor/snap_to_floor", TTRC("Snap Object to Floor"), Key::PAGEDOWN), MENU_SNAP_TO_FLOOR);
-	p->add_shortcut(ED_SHORTCUT("spatial_editor/transform_dialog", TTRC("Transform Dialog...")), MENU_TRANSFORM_DIALOG);
-
-	p->add_separator();
-	ED_SHORTCUT("spatial_editor/vertex_snap", TTRC("Vertex Snap"), Key::B);
-	p->add_radio_check_item(TTRC("Snap Vertex to Vertex"), MENU_VERTEX_SNAP_BASE_VERTEX);
-	p->set_item_checked(p->get_item_index(MENU_VERTEX_SNAP_BASE_VERTEX), true);
-	p->add_radio_check_item(TTRC("Snap Origin to Vertex"), MENU_VERTEX_SNAP_BASE_ORIGIN);
-
-	p->add_separator();
-	p->add_radio_check_item(TTRC("Snap to Mesh Vertices"), MENU_VERTEX_SNAP_SOURCE_MESH);
-	p->set_item_checked(p->get_item_index(MENU_VERTEX_SNAP_SOURCE_MESH), true);
-	p->add_radio_check_item(TTRC("Snap to Collision Vertices"), MENU_VERTEX_SNAP_SOURCE_COLLISION);
-	_update_vertex_snap_tooltips();
-
-	p->add_separator();
-	p->add_shortcut(ED_SHORTCUT("spatial_editor/configure_snap", TTRC("Configure Snap...")), MENU_TRANSFORM_CONFIGURE_SNAP);
-
-	p->connect(SceneStringName(id_pressed), callable_mp(this, &Node3DEditor::_menu_item_pressed));
-
 	view_layout_menu = memnew(MenuButton);
 	view_layout_menu->set_flat(false);
 	view_layout_menu->set_theme_type_variation("FlatMenuButton");
@@ -10717,7 +10852,7 @@ Node3DEditor::Node3DEditor() {
 
 	p->add_separator();
 	p->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_origin", TTRC("View Origin")), MENU_VIEW_ORIGIN);
-	p->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_grid", TTRC("View Grid"), Key::NUMBERSIGN), MENU_VIEW_GRID);
+	p->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_grid", TTRC("View Grid"), KeyModifierMask::CMD_OR_CTRL + Key::G), MENU_VIEW_GRID);
 
 	p->add_separator();
 	p->add_submenu_node_item(TTRC("Preview Translation"), memnew(EditorTranslationPreviewMenu));
@@ -10759,39 +10894,9 @@ Node3DEditor::Node3DEditor() {
 
 	/* SNAP DIALOG */
 
-	snap_dialog = memnew(ConfirmationDialog);
-	snap_dialog->set_title(TTRC("Snap Settings"));
+	snap_dialog = memnew(Node3DEditorPluginSnap);
 	add_child(snap_dialog);
 	snap_dialog->connect(SceneStringName(confirmed), callable_mp(this, &Node3DEditor::_snap_changed));
-	snap_dialog->get_cancel_button()->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_snap_update));
-
-	VBoxContainer *snap_dialog_vbc = memnew(VBoxContainer);
-	snap_dialog->add_child(snap_dialog_vbc);
-
-	snap_translate = memnew(EditorSpinSlider);
-	snap_translate->set_min(0.0);
-	snap_translate->set_step(0.001);
-	snap_translate->set_max(10.0);
-	snap_translate->set_suffix("m");
-	snap_translate->set_allow_greater(true);
-	snap_translate->set_accessibility_name(TTRC("Translate Snap"));
-	snap_dialog_vbc->add_margin_child(TTR("Translate Snap:"), snap_translate);
-
-	snap_rotate = memnew(EditorSpinSlider);
-	snap_rotate->set_min(0.0);
-	snap_rotate->set_step(0.1);
-	snap_rotate->set_max(360);
-	snap_rotate->set_suffix(U"°");
-	snap_rotate->set_accessibility_name(TTRC("Rotate Snap"));
-	snap_dialog_vbc->add_margin_child(TTR("Rotate Snap:"), snap_rotate);
-
-	snap_scale = memnew(EditorSpinSlider);
-	snap_scale->set_min(0.0);
-	snap_scale->set_step(1.0);
-	snap_scale->set_max(100);
-	snap_scale->set_suffix("%");
-	snap_scale->set_accessibility_name(TTRC("Scale Snap"));
-	snap_dialog_vbc->add_margin_child(TTR("Scale Snap:"), snap_scale);
 
 	/* SETTINGS DIALOG */
 
@@ -11178,7 +11283,7 @@ bool Node3DEditor::is_vertex_snap_use_collision() const {
 }
 
 real_t Node3DEditor::get_translate_snap() const {
-	real_t snap_value = snap_translate_value;
+	real_t snap_value = grid_step * (real_t)Math::pow(2.0, grid_step_multiplier);
 	if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
 		snap_value /= 10.0f;
 	}
@@ -11186,7 +11291,7 @@ real_t Node3DEditor::get_translate_snap() const {
 }
 
 real_t Node3DEditor::get_rotate_snap() const {
-	real_t snap_value = snap_rotate_value;
+	real_t snap_value = snap_rotate_step;
 	if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
 		snap_value /= 3.0f;
 	}
@@ -11194,7 +11299,7 @@ real_t Node3DEditor::get_rotate_snap() const {
 }
 
 real_t Node3DEditor::get_scale_snap() const {
-	real_t snap_value = snap_scale_value;
+	real_t snap_value = snap_scale_step;
 	if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
 		snap_value /= 2.0f;
 	}

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -674,9 +674,13 @@ private:
 
 	DynamicBVH gizmo_bvh;
 
-	real_t snap_translate_value = 0;
-	real_t snap_rotate_value = 0;
-	real_t snap_scale_value = 0;
+	real_t snap_rotate_step = 0.15;
+	real_t snap_scale_step = 0.1;
+
+	/// Distance between individual vertices of the grid (in meters).
+	real_t grid_step = 0;
+	/// Power of 2 used to multiply our `grid_step` (i.e. snap = grid_step * 2^grid_step_multiplier).
+	int grid_step_multiplier = 0;
 
 	Ref<ArrayMesh> active_selection_box_xray;
 	Ref<ArrayMesh> active_selection_box;
@@ -850,6 +854,7 @@ private:
 	uint32_t world_env_count = 0;
 	uint32_t directional_light_count = 0;
 
+	MenuButton *snap_config_menu = nullptr;
 	Button *sun_button = nullptr;
 	Label *sun_state = nullptr;
 	Label *sun_title = nullptr;
@@ -892,6 +897,8 @@ private:
 	Ref<ProceduralSkyMaterial> sky_material;
 
 	bool sun_environ_updating = false;
+
+	void handle_grid_shortcut_input(const Ref<InputEvent> &p_event);
 
 	void _sun_direction_draw();
 	void _sun_direction_input(const Ref<InputEvent> &p_event);
@@ -964,7 +971,7 @@ public:
 	Ref<ArrayMesh> get_scale_plane_gizmo(int idx) const { return scale_plane_gizmo[idx]; }
 	Ref<ArrayMesh> get_trackball_sphere_gizmo() const { return trackball_sphere_gizmo; }
 
-	void update_grid();
+	void update_grid(bool p_force = false);
 	void update_transform_gizmo();
 	void update_all_gizmos(Node *p_node = nullptr);
 	void update_gizmo_opacity();

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -157,6 +157,7 @@ public:
 	const StringName state_finished = "state_finished";
 
 	const StringName FlatButton = "FlatButton";
+	const StringName FlatMenuButton = "FlatMenuButton";
 };
 
 #define SceneStringName(m_name) SceneStringNames::get_singleton()->m_name


### PR DESCRIPTION
## What problem does this PR solve?

One outlined in: https://github.com/godotengine/godot-proposals/issues/14555. Tl;dr – make grid follow snap + give shortcuts to multiply said grid by power of 2. It follows the very same logic as canvas item plugin – i.e. snap menu is in the same place, shortcuts are the same and whatnot.

Based on previous @Calinou work: https://github.com/Calinou/godot/commit/4eecb50f12ffd7f1414b0f78adf3aa30b361477b#diff-57832e09092105245d5eaa89d7834a30f5c6bd6e5b5166450fde12f61a585d4cL6256. 

<details>

<summary> Manual testing / how it looks in action </summary>


https://github.com/user-attachments/assets/5b83117c-5f2f-41c4-92ab-1ecd2d75b6a9


</details>


## Other things / followups etc

As outlined in the proposal – exposing a menu with the info about current snap would be nice, as well as standardizing shortcuts to ones used by the Trenchbroom (i.e. `+`\\`-` instead of `*`\\`/`). This PR is fairly conservative – we should create a proper design beforehand. Whatever we set on both modes should use the same language.

We should standardize rulers as well.  The 2D one packs in a lot of useful info, while 3D one is very basic.

<img width="319" height="246" alt="image" src="https://github.com/user-attachments/assets/e35e02ef-fe86-4cee-8bcb-ea7d732f41e7" />
