### PR TITLE
Add optional 'fast save' option when saving PNG files

### DIFF
--- a/core/io/image.compat.inc
+++ b/core/io/image.compat.inc
@@ -30,6 +30,8 @@
 
 #ifndef DISABLE_DEPRECATED
 
+#include "image.h"
+
 #include "core/object/class_db.h"
 
 static Image::CompressProfile _astc_format_to_compress_profile(Image::ASTCFormat p_format) {
@@ -59,11 +61,21 @@ Error Image::_save_exr_bind_compat_117800(const String &p_path, bool p_grayscale
 	return save_exr(p_path, p_grayscale);
 }
 
+Error Image::_save_png_bind_compat_117943(const String &p_path) const {
+	return save_png(p_path, false);
+}
+
+Vector<uint8_t> Image::_save_png_to_buffer_bind_compat_117943() const {
+	return save_png_to_buffer(false);
+}
+
 void Image::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("compress", "mode", "source", "astc_format"), &Image::_compress_bind_compat_115003, DEFVAL(COMPRESS_SOURCE_GENERIC), DEFVAL(ASTC_FORMAT_4x4));
 	ClassDB::bind_compatibility_method(D_METHOD("compress_from_channels", "mode", "channels", "astc_format"), &Image::_compress_from_channels_compat_115003, DEFVAL(ASTC_FORMAT_4x4));
 	ClassDB::bind_compatibility_method(D_METHOD("save_exr", "path", "grayscale"), &Image::_save_exr_bind_compat_117800, DEFVAL(false));
 	ClassDB::bind_compatibility_method(D_METHOD("save_exr_to_buffer", "grayscale"), &Image::_save_exr_to_buffer_bind_compat_117800, DEFVAL(false));
+	ClassDB::bind_compatibility_method(D_METHOD("save_png", "path"), &Image::_save_png_bind_compat_117943);
+	ClassDB::bind_compatibility_method(D_METHOD("save_png_to_buffer"), &Image::_save_png_to_buffer_bind_compat_117943);
 }
 
 #endif // DISABLE_DEPRECATED

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2813,12 +2813,12 @@ Ref<Image> Image::load_from_file(const String &p_path) {
 	return image;
 }
 
-Error Image::save_png(const String &p_path) const {
+Error Image::save_png(const String &p_path, bool p_fast_save) const {
 	if (save_png_func == nullptr) {
 		return ERR_UNAVAILABLE;
 	}
 
-	return save_png_func(p_path, Ref<Image>((Image *)this));
+	return save_png_func(p_path, Ref<Image>((Image *)this), p_fast_save);
 }
 
 Error Image::save_jpg(const String &p_path, float p_quality) const {
@@ -2829,12 +2829,12 @@ Error Image::save_jpg(const String &p_path, float p_quality) const {
 	return save_jpg_func(p_path, Ref<Image>((Image *)this), p_quality);
 }
 
-Vector<uint8_t> Image::save_png_to_buffer() const {
+Vector<uint8_t> Image::save_png_to_buffer(bool p_fast_save) const {
 	if (save_png_buffer_func == nullptr) {
 		return Vector<uint8_t>();
 	}
 
-	return save_png_buffer_func(Ref<Image>((Image *)this));
+	return save_png_buffer_func(Ref<Image>((Image *)this), p_fast_save);
 }
 
 Vector<uint8_t> Image::save_jpg_to_buffer(float p_quality) const {
@@ -3903,8 +3903,8 @@ void Image::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("load", "path"), &Image::load);
 	ClassDB::bind_static_method("Image", D_METHOD("load_from_file", "path"), &Image::load_from_file);
-	ClassDB::bind_method(D_METHOD("save_png", "path"), &Image::save_png);
-	ClassDB::bind_method(D_METHOD("save_png_to_buffer"), &Image::save_png_to_buffer);
+	ClassDB::bind_method(D_METHOD("save_png", "path", "fast_save"), &Image::save_png, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("save_png_to_buffer", "fast_save"), &Image::save_png_to_buffer, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("save_jpg", "path", "quality"), &Image::save_jpg, DEFVAL(0.75));
 	ClassDB::bind_method(D_METHOD("save_jpg_to_buffer", "quality"), &Image::save_jpg_to_buffer, DEFVAL(0.75));
 	ClassDB::bind_method(D_METHOD("save_exr", "path", "grayscale", "color_image", "max_linear_value"), &Image::save_exr, DEFVAL(false), DEFVAL(false), DEFVAL(-1.0));

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -43,8 +43,8 @@ class Image;
 
 // Function pointer prototypes.
 
-typedef Error (*SavePNGFunc)(const String &p_path, const Ref<Image> &p_img);
-typedef Vector<uint8_t> (*SavePNGBufferFunc)(const Ref<Image> &p_img);
+typedef Error (*SavePNGFunc)(const String &p_path, const Ref<Image> &p_img, bool p_fast_save);
+typedef Vector<uint8_t> (*SavePNGBufferFunc)(const Ref<Image> &p_img, bool p_fast_save);
 
 typedef Error (*SaveJPGFunc)(const String &p_path, const Ref<Image> &p_img, float p_quality);
 typedef Vector<uint8_t> (*SaveJPGBufferFunc)(const Ref<Image> &p_img, float p_quality);
@@ -280,6 +280,8 @@ protected:
 	Error _compress_from_channels_compat_115003(CompressMode p_mode, UsedChannels p_channels, ASTCFormat p_format);
 	Vector<uint8_t> _save_exr_to_buffer_bind_compat_117800(bool p_grayscale = false) const;
 	Error _save_exr_bind_compat_117800(const String &p_path, bool p_grayscale = false) const;
+	Error _save_png_bind_compat_117943(const String &p_path) const;
+	Vector<uint8_t> _save_png_to_buffer_bind_compat_117943() const;
 
 	static void _bind_compatibility_methods();
 #endif
@@ -383,10 +385,10 @@ public:
 
 	Error load(const String &p_path);
 	static Ref<Image> load_from_file(const String &p_path);
-	Error save_png(const String &p_path) const;
+	Error save_png(const String &p_path, bool p_fast_save = false) const;
 	Error save_jpg(const String &p_path, float p_quality = 0.75) const;
 	Error save_dds(const String &p_path) const;
-	Vector<uint8_t> save_png_to_buffer() const;
+	Vector<uint8_t> save_png_to_buffer(bool p_fast_save = false) const;
 	Vector<uint8_t> save_jpg_to_buffer(float p_quality = 0.75) const;
 	Vector<uint8_t> save_exr_to_buffer(bool p_grayscale = false, bool p_color_image = false, float p_max_value = -1.0f) const;
 	Vector<uint8_t> save_dds_to_buffer() const;

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -532,14 +532,16 @@
 		<method name="save_png" qualifiers="const">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
+			<param index="1" name="fast_save" type="bool" default="false" />
 			<description>
-				Saves the image as a PNG file to the file at [param path].
+				Saves the image as a PNG file to the file at [param path]. [param fast_save] optimizes saving speed at the cost of file size.
 			</description>
 		</method>
 		<method name="save_png_to_buffer" qualifiers="const">
 			<return type="PackedByteArray" />
+			<param index="0" name="fast_save" type="bool" default="false" />
 			<description>
-				Saves the image as a PNG file to a byte array.
+				Saves the image as a PNG file to a byte array. [param fast_save] optimizes saving speed at the cost of file size.
 			</description>
 		</method>
 		<method name="save_webp" qualifiers="const">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1171,6 +1171,9 @@
 		<member name="editor/movie_writer/ogv/keyframe_interval" type="int" setter="" getter="" default="64" keywords="theora">
 			Forces keyframes at the specified interval (in frame count). Higher values can improve compression up to a certain level at the expense of higher latency when seeking.
 		</member>
+		<member name="editor/movie_writer/png/optimize_speed" type="bool" setter="" getter="" default="true">
+			Optimizes rendering speed at the cost of file size, by changing PNG compression behavior.
+		</member>
 		<member name="editor/movie_writer/speaker_mode" type="int" setter="" getter="" default="0" keywords="stereo, surround">
 			The speaker mode to use in the recorded audio when writing a movie. See [enum AudioServer.SpeakerMode] for possible values.
 		</member>

--- a/drivers/png/png_driver_common.cpp
+++ b/drivers/png/png_driver_common.cpp
@@ -125,7 +125,7 @@ Error png_to_image(const uint8_t *p_source, size_t p_size, bool p_force_linear, 
 	return OK;
 }
 
-Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer) {
+Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer, bool p_fast_save) {
 	Ref<Image> source_image = p_image->duplicate();
 
 	if (source_image->is_compressed()) {
@@ -139,6 +139,9 @@ Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer) {
 	png_img.version = PNG_IMAGE_VERSION;
 	png_img.width = source_image->get_width();
 	png_img.height = source_image->get_height();
+	if (p_fast_save) {
+		png_img.flags = PNG_IMAGE_FLAG_FAST;
+	}
 
 	switch (source_image->get_format()) {
 		case Image::FORMAT_L8:

--- a/drivers/png/png_driver_common.h
+++ b/drivers/png/png_driver_common.h
@@ -39,5 +39,6 @@ Error png_to_image(const uint8_t *p_source, size_t p_size, bool p_force_linear, 
 
 // Append p_image, as a png, to p_buffer.
 // Contents of p_buffer is unspecified if error returned.
-Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer);
+// p_fast_save uses libpng's PNG_IMAGE_FLAG_FAST to emphasize speed over compression.
+Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer, bool p_fast_save = false);
 } // namespace PNGDriverCommon

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -48,9 +48,9 @@ Error ResourceSaverPNG::save(const Ref<Resource> &p_resource, const String &p_pa
 	return err;
 }
 
-Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img) {
+Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img, bool p_fast_save) {
 	Vector<uint8_t> buffer;
-	Error err = PNGDriverCommon::image_to_png(p_img, buffer);
+	Error err = PNGDriverCommon::image_to_png(p_img, buffer, p_fast_save);
 	ERR_FAIL_COND_V_MSG(err, err, "Can't convert image to PNG.");
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
 	ERR_FAIL_COND_V_MSG(err, err, vformat("Can't save PNG at path: '%s'.", p_path));
@@ -65,9 +65,9 @@ Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img
 	return OK;
 }
 
-Vector<uint8_t> ResourceSaverPNG::save_image_to_buffer(const Ref<Image> &p_img) {
+Vector<uint8_t> ResourceSaverPNG::save_image_to_buffer(const Ref<Image> &p_img, bool p_fast_save) {
 	Vector<uint8_t> buffer;
-	Error err = PNGDriverCommon::image_to_png(p_img, buffer);
+	Error err = PNGDriverCommon::image_to_png(p_img, buffer, p_fast_save);
 	ERR_FAIL_COND_V_MSG(err, Vector<uint8_t>(), "Can't convert image to PNG.");
 	return buffer;
 }

--- a/drivers/png/resource_saver_png.h
+++ b/drivers/png/resource_saver_png.h
@@ -37,8 +37,8 @@ class ResourceSaverPNG : public ResourceFormatSaver {
 	GDSOFTCLASS(ResourceSaverPNG, ResourceFormatSaver);
 
 public:
-	static Error save_image(const String &p_path, const Ref<Image> &p_img);
-	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img);
+	static Error save_image(const String &p_path, const Ref<Image> &p_img, bool p_fast_save = false);
+	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img, bool p_fast_save = false);
 
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;

--- a/misc/extension_api_validation/4.7-stable/GH-117943.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-117943.txt
@@ -1,0 +1,7 @@
+GH-117943
+--------
+Validate extension JSON: Error: Field 'classes/Image/methods/save_png/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Image/methods/save_png_to_buffer': arguments
+
+Added optional "fast_save" argument to save_png and save_png_to_buffer methods in Image classes with default value.
+Compatibility methods registered.

--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -154,6 +154,7 @@ void MovieWriter::_bind_methods() {
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "editor/movie_writer/ogv/audio_quality", PROPERTY_HINT_RANGE, "-0.1,1.0,0.01"), 0.5);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/movie_writer/ogv/encoding_speed", PROPERTY_HINT_ENUM, "Fastest (Lowest Efficiency):4,Fast (Low Efficiency):3,Slow (High Efficiency):2,Slowest (Highest Efficiency):1"), 4);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/movie_writer/ogv/keyframe_interval", PROPERTY_HINT_RANGE, "1,1024,1"), 64);
+	GLOBAL_DEF(PropertyInfo(Variant::BOOL, "editor/movie_writer/png/optimize_speed"), true);
 
 	// Used by the editor.
 	GLOBAL_DEF_BASIC("editor/movie_writer/movie_file", "");

--- a/servers/movie_writer/movie_writer_pngwav.cpp
+++ b/servers/movie_writer/movie_writer_pngwav.cpp
@@ -144,7 +144,7 @@ Error MovieWriterPNGWAV::write_begin(const Size2i &p_movie_size, uint32_t p_fps,
 Error MovieWriterPNGWAV::write_frame(const Ref<Image> &p_image, const int32_t *p_audio_data) {
 	ERR_FAIL_COND_V(f_wav.is_null(), ERR_UNCONFIGURED);
 
-	Vector<uint8_t> png_buffer = p_image->save_png_to_buffer();
+	Vector<uint8_t> png_buffer = p_image->save_png_to_buffer(optimize_speed);
 
 	Ref<FileAccess> fi = FileAccess::open(base_path + zeros_str(frame_count) + ".png", FileAccess::WRITE);
 	fi->store_buffer(png_buffer.ptr(), png_buffer.size());
@@ -169,4 +169,5 @@ void MovieWriterPNGWAV::write_end() {
 MovieWriterPNGWAV::MovieWriterPNGWAV() {
 	mix_rate = GLOBAL_GET("editor/movie_writer/mix_rate");
 	speaker_mode = AudioServer::SpeakerMode(int(GLOBAL_GET("editor/movie_writer/speaker_mode")));
+	optimize_speed = GLOBAL_GET("editor/movie_writer/png/optimize_speed");
 }

--- a/servers/movie_writer/movie_writer_pngwav.h
+++ b/servers/movie_writer/movie_writer_pngwav.h
@@ -45,6 +45,8 @@ class MovieWriterPNGWAV : public MovieWriter {
 	uint32_t frame_count = 0;
 	uint32_t fps = 0;
 
+	bool optimize_speed = true;
+
 	uint32_t audio_block_size = 0;
 
 	Ref<FileAccess> f_wav;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
## Important
Simpler PR: https://github.com/godotengine/godot/pull/121437

## Overview
Addresses https://github.com/godotengine/godot/issues/51868
Supersedes: https://github.com/godotengine/godot/pull/74324
Related to: https://github.com/godotengine/godot-proposals/discussions/14534

This PR adds a parameter to functions that save PNG images, that sets libpng's `flags` to `PNG_IMAGE_FLAG_FAST`. This emphasizes speed over compression, allowing images to be saved faster, at the cost of a slighly bigger file size. This tradeoff is especially significant when saving multiple PNG files, like with MovieWriter, which has been in need of a speed boost.
[Read more in libpng's code.](https://github.com/godotengine/godot/blob/a3c62ca6d39102ef10ca8ae50dc330e1ebdd9944/thirdparty/libpng/png.h#L3190)
Initially, my idea was to just make this a project setting, however, in the PR which this one supersedes, it was recommended to make this a function parameter instead (I had to make it a project setting for MovieWriter).
To maintain expected behavior, I set the default value of the parameter to false, including for MovieWriter.

My motivation for this PR is that my app needs a faster MovieWriter. My only option is to use lossless image sequences, and the only option Godot offers at the moment, PNG, is incredibly slow. I've been waiting for different [solutions](https://github.com/godotengine/godot-proposals/discussions/14534), but I decided to try making one myself.
As you can see in the benchmarks below, it's not that big of a difference **(I recommend others to try benchmarking as well, since in the past others have gotten much better results)**, but I think it's still worth it, especially considering how slow PNG MovieWriter is at the moment.

Here are my benchmarks:

PC specs: Windows 10 64-bit, SSD, 16 GB RAM 2400MHz, dedicated Radeon RX 580 8 GB, Intel Core i5-9600KF CPU at 3.70GHz
Project settings: Forward+ (I think D3D12)
Executable used: godot.windows.editor.dev.x86_64.console

**Single image benchmarks**
- Tests 1a (1080p without PNG optimization)
Time: 417ms + 393ms + 388ms + 394ms + 388ms = 396ms average
Size: 89.257 KB + 89.229 KB + 89.227 KB + 89.300 KB + 89.331 KB = 89.2688 KB average

- Tests 1b (1080p with PNG optimization)
Time: 124ms + 133ms + 138ms + 121ms + 125ms = 128.2ms average
Size: 134.905 KB + 134.87 KB + 134.87 KB + 134.822 KB + 134.822 KB = 134.8578 KB average

All generated images were loaded afterwards in GDScript in the tests above. I had no errors, neither opening them externally, but further tests are encouraged.

**MovieWriter benchmarks**
All tests below done at 60 FPS, with a duration of 10 seconds, displaying a moving shader.

- Test 1a (720p without PNG optimization)
600 frames at 60 FPS (movie length: 00:00:10:00), recorded in 00:01:21 (12% of real-time speed).
CPU render time: 0.09 seconds (average: 0.14 ms/frame)
GPU render time: 0.38 seconds (average: 0.63 ms/frame)
Encoding time: 71.22 seconds (average: 118.70 ms/frame)
Size of all frames: 12.4 MB (13.7 MB on disk)

- Test 1b (720p with PNG optimization)
600 frames at 60 FPS (movie length: 00:00:10:00), recorded in 00:00:26 (38% of real-time speed).
CPU render time: 0.09 seconds (average: 0.14 ms/frame)
GPU render time: 0.37 seconds (average: 0.61 ms/frame)
Encoding time: 16.49 seconds (average: 27.49 ms/frame)
Size of all frames: 21.9 MB (23.1 MB on disk)

- Test 2a (1080p without PNG optimization)
600 frames at 60 FPS (movie length: 00:00:10:00), recorded in 00:04:28 (3% of real-time speed).
CPU render time: 0.08 seconds (average: 0.14 ms/frame)
GPU render time: 0.79 seconds (average: 1.31 ms/frame)
Encoding time: 190.38 seconds (average: 317.31 ms/frame)
Size of all frames: 107 MB (108 MB on disk)

- Test 2b (1080p with PNG optimization)
600 frames at 60 FPS (movie length: 00:00:10:00), recorded in 00:01:57 (8% of real-time speed).
CPU render time: 0.08 seconds (average: 0.14 ms/frame)
GPU render time: 0.80 seconds (average: 1.34 ms/frame)
Encoding time: 39.22 seconds (average: 65.37 ms/frame)
Size of all frames: 95.8 MB (97 MB on disk) (not sure why this is smaller)

- Test 3a (720p without PNG optimization - more complex shader)
600 frames at 60 FPS (movie length: 00:00:10:00), recorded in 00:06:40 (2% of real-time speed).
CPU render time: 0.09 seconds (average: 0.15 ms/frame)
GPU render time: 0.61 seconds (average: 1.02 ms/frame)
Encoding time: 389.90 seconds (average: 649.84 ms/frame)
Size of all frames: 314 MB (315 MB on disk)

- Test 3b (720p with PNG optimization - more complex shader)
600 frames at 60 FPS (movie length: 00:00:10:00), recorded in 00:01:22 (12% of real-time speed).
CPU render time: 0.09 seconds (average: 0.14 ms/frame)
GPU render time: 0.60 seconds (average: 1.00 ms/frame)
Encoding time: 72.36 seconds (average: 120.61 ms/frame)
Size of all frames: 388 MB (390 MB on disk)

- Test 4a (1080p without PNG optimization - more complex shader)
600 frames at 60 FPS (movie length: 00:00:10:00), recorded in 00:13:14 (1% of real-time speed).
CPU render time: 0.08 seconds (average: 0.14 ms/frame)
GPU render time: 1.28 seconds (average: 2.13 ms/frame)
Encoding time: 714.14 seconds (average: 1190.23 ms/frame)
Size of all frames: 556 MB (557 MB on disk)

- Test 4b (1080p with PNG optimization - more complex shader)
600 frames at 60 FPS (movie length: 00:00:10:00), recorded in 00:03:27 (4% of real-time speed).
CPU render time: 0.08 seconds (average: 0.14 ms/frame)
GPU render time: 1.27 seconds (average: 2.11 ms/frame)
Encoding time: 128.58 seconds (average: 214.30 ms/frame)
Size of all frames: 748 MB (749 MB on disk)

--

Last tests for now: did test 3 again. Compiled with `production=yes dev_build=no debug_symbols=no optimize=speed_trace`
3a:
600 frames at 60 FPS (movie length: 00:00:10:00), recorded in 00:03:07 (5% of real-time speed).
CPU render time: 0.03 seconds (average: 0.06 ms/frame)
GPU render time: 1.25 seconds (average: 2.08 ms/frame)
Encoding time: 182.51 seconds (average: 304.19 ms/frame)
Same size

3b:
600 frames at 60 FPS (movie length: 00:00:10:00), recorded in 00:00:35 (28% of real-time speed).
CPU render time: 0.04 seconds (average: 0.06 ms/frame)
GPU render time: 1.26 seconds (average: 2.10 ms/frame)
Encoding time: 30.37 seconds (average: 50.62 ms/frame)
Same size

Also single image, same build:
`fast_save = false`
Time = ~128ms, size = ~207 KB

`fast_save = true`
Time = ~52m, size = ~234 KB

Overall better results on these last tests.

----

**Final notes:**
This is definitely out of my comfort zone, but I really want an improvement to the MovieWriter. I believe this can be helpful to many others as well, since I'm far from the only one who has had issues with MovieWriter. Please let me know if I have missed anything, and I'll try my best to solve it.