### PR TITLE
glTF: Use safe methods to get data from dictionaries with `get_additional_data`

### DIFF
--- a/modules/gltf/extensions/gltf_light.cpp
+++ b/modules/gltf/extensions/gltf_light.cpp
@@ -251,7 +251,7 @@ Dictionary GLTFLight::to_dictionary() const {
 }
 
 Variant GLTFLight::get_additional_data(const StringName &p_extension_name) {
-	return additional_data[p_extension_name];
+	return additional_data.get(p_extension_name, Variant());
 }
 
 void GLTFLight::set_additional_data(const StringName &p_extension_name, Variant p_additional_data) {

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -446,7 +446,7 @@ void GLTFState::set_filename(const String &p_filename) {
 }
 
 Variant GLTFState::get_additional_data(const StringName &p_extension_name) const {
-	return additional_data[p_extension_name];
+	return additional_data.get(p_extension_name, Variant());
 }
 
 void GLTFState::set_additional_data(const StringName &p_extension_name, Variant p_additional_data) {

--- a/modules/gltf/structures/gltf_animation.cpp
+++ b/modules/gltf/structures/gltf_animation.cpp
@@ -104,7 +104,7 @@ GLTFAnimation::GLTFAnimation() {
 }
 
 Variant GLTFAnimation::get_additional_data(const StringName &p_extension_name) {
-	return additional_data[p_extension_name];
+	return additional_data.get(p_extension_name, Variant());
 }
 
 void GLTFAnimation::set_additional_data(const StringName &p_extension_name, Variant p_additional_data) {

--- a/modules/gltf/structures/gltf_mesh.cpp
+++ b/modules/gltf/structures/gltf_mesh.cpp
@@ -84,7 +84,7 @@ void GLTFMesh::set_blend_weights(const Vector<float> &p_blend_weights) {
 }
 
 Variant GLTFMesh::get_additional_data(const StringName &p_extension_name) {
-	return additional_data[p_extension_name];
+	return additional_data.get(p_extension_name, Variant());
 }
 
 void GLTFMesh::set_additional_data(const StringName &p_extension_name, Variant p_additional_data) {

--- a/modules/gltf/structures/gltf_node.cpp
+++ b/modules/gltf/structures/gltf_node.cpp
@@ -200,7 +200,7 @@ void GLTFNode::set_visible(bool p_visible) {
 }
 
 Variant GLTFNode::get_additional_data(const StringName &p_extension_name) {
-	return additional_data[p_extension_name];
+	return additional_data.get(p_extension_name, Variant());
 }
 
 bool GLTFNode::has_additional_data(const StringName &p_extension_name) {


### PR DESCRIPTION
Similar to https://github.com/godotengine/godot/pull/111684. The `get_additional_data` properties directly use the `[]` operator, even though it is allowed to pass keys that are not in the dictionary. This would then incorrectly result in the `Bug: Dictionary::operator[] used when there was no value for the given key, please report.` error message.