### PR TITLE
Add simple symbol renaming

### DIFF
--- a/core/object/editor_language.h
+++ b/core/object/editor_language.h
@@ -111,6 +111,7 @@ public:
 	 * @param r_result The returned `LookupResult`.
 	 */
 	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) { return ERR_UNAVAILABLE; }
+	virtual Error lookup_code_for_rename(const String &p_code, const String &p_symbol, const String &p_path, LookupResult &r_result) { return ERR_UNAVAILABLE; }
 
 	/**
 	 * Called by the editor to find a top-level function in the given source code.

--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -32,12 +32,14 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "core/os/os.h"
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
@@ -347,6 +349,12 @@ void FindInFilesDialog::set_search_text(const String &p_text) {
 
 void FindInFilesDialog::set_replace_text(const String &p_text) {
 	replace_text_line_edit->set_text(p_text);
+}
+
+void FindInFilesPanel::set_symbol_rename(const EditorLanguage::LookupResult &p_symbol, const String &p_new_name) {
+	symbol_rename = p_symbol;
+	set_with_replace(true);
+	set_replace_text(p_new_name);
 }
 
 void FindInFilesDialog::set_replace_mode(bool p_replace) {
@@ -837,8 +845,37 @@ void FindInFilesPanel::_on_result_found(const String &p_fpath, int p_line_number
 	result_items[item] = r;
 
 	if (with_replace) {
+		bool check_item = false;
+		if (!symbol_rename.script_path.is_empty()) {
+			if (ResourceLoader::exists(p_fpath, "Script")) {
+				Ref<Script> source_script = ResourceLoader::load(p_fpath);
+				if (source_script.is_valid()) {
+					PackedStringArray lines = source_script->get_source_code().split("\n");
+					const String current_line = lines[p_line_number - 1];
+					lines.write[p_line_number - 1] = current_line.insert(p_begin, String::chr(0xFFFF));
+
+					EditorLanguage::LookupResult result;
+					Error err = source_script->get_language()->get_editor_language()->lookup_code_for_rename(String("\n").join(lines), current_line.substr(p_begin, p_end - p_begin), source_script->get_path(), result);
+					if (err == OK) {
+						check_item = result.type == symbol_rename.type &&
+								result.class_name == symbol_rename.class_name &&
+								result.class_member == symbol_rename.class_member &&
+								result.description == symbol_rename.description &&
+								result.doc_type == symbol_rename.doc_type &&
+								result.enumeration == symbol_rename.enumeration &&
+								result.is_bitfield == symbol_rename.is_bitfield &&
+								result.value == symbol_rename.value &&
+								result.script_path == symbol_rename.script_path &&
+								result.location == symbol_rename.location;
+					}
+				}
+			}
+		} else {
+			check_item = true;
+		}
+
 		item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-		item->set_checked(0, true);
+		item->set_checked(0, check_item);
 		item->set_editable(0, true);
 		item->add_button(1, replace_texture, FIND_BUTTON_REPLACE, false, TTR("Replace"));
 		item->add_button(1, remove_texture, FIND_BUTTON_REMOVE, false, TTR("Remove result"));
@@ -967,8 +1004,31 @@ void FindInFilesPanel::_on_replace_text_changed(const String &p_text) {
 	_update_replace_buttons();
 }
 
-void FindInFilesPanel::_on_replace_all_clicked() {
-	String replace_text = _get_replace_text();
+void FindInFilesPanel::_on_replace_all_clicked(bool p_confirmed) {
+	const String replace_text = _get_replace_text();
+	if (symbol_rename.type == EditorLanguage::LookupResult::Type::CLASS_PROPERTY && !p_confirmed) {
+		const Ref<Script> script = ResourceLoader::load(symbol_rename.script_path);
+		const String old_symbol = finder->get_search_text();
+
+		List<PropertyInfo> script_properties;
+		script->get_script_property_list(&script_properties);
+		for (const PropertyInfo &pi : script_properties) {
+			if (pi.name == old_symbol) {
+				if (pi.usage & PROPERTY_USAGE_STORAGE) {
+					if (!rename_confirm) {
+						rename_confirm = memnew(ConfirmationDialog);
+						rename_confirm->set_text(TTRC("The renamed symbol is an exported variable. Renaming it may result in losing values stored in scene files. They have to be updated manually."));
+						add_child(rename_confirm);
+						rename_confirm->connect(SceneStringName(confirmed), callable_mp(this, &FindInFilesPanel::_on_replace_all_clicked).bind(true));
+					}
+					rename_confirm->popup_centered();
+					return;
+				} else {
+					break;
+				}
+			}
+		}
+	}
 
 	for (KeyValue<String, TreeItem *> &E : file_items) {
 		TreeItem *file_item = E.value;
@@ -1283,7 +1343,7 @@ FindInFilesPanel::FindInFilesPanel() {
 
 		replace_all_button = memnew(Button);
 		replace_all_button->set_text(TTRC("Replace all (no undo)"));
-		replace_all_button->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesPanel::_on_replace_all_clicked));
+		replace_all_button->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesPanel::_on_replace_all_clicked).bind(false));
 		replace_container->add_child(replace_all_button);
 
 		replace_container->hide();

--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "core/os/os.h"
 #include "editor/docks/editor_dock_manager.h"
@@ -40,6 +41,7 @@
 #include "editor/file_system/editor_file_system.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/script/script_editor_plugin.h"
+#include "editor/script/script_text_editor.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/shader/shader_editor_plugin.h"
@@ -420,7 +422,12 @@ void FindInFilesSearch::_bind_methods() {
 
 void FindInFilesSearchPanel::set_finder(FindInFilesSearch *p_finder, bool p_init) {
 	finder = p_finder;
+
+	default_view->set_visible(!p_finder->is_rename_mode());
+	rename_view->set_visible(p_finder->is_rename_mode());
+
 	search_text_line_edit->set_text(finder->get_search_text());
+	renamed_symbol_name->set_text(finder->get_search_text());
 	match_case_checkbox->set_pressed_no_signal(finder->get_match_case());
 	whole_words_checkbox->set_pressed_no_signal(finder->get_whole_words());
 	folder_line_edit->set_text(finder->get_folder());
@@ -441,6 +448,7 @@ void FindInFilesSearchPanel::set_finder(FindInFilesSearch *p_finder, bool p_init
 }
 
 void FindInFilesSearchPanel::set_search_text(const String &p_text) {
+	renamed_symbol_name->set_text(p_text);
 	if (!p_text.is_empty()) {
 		search_text_line_edit->set_text(p_text);
 		_on_search_submitted();
@@ -450,6 +458,7 @@ void FindInFilesSearchPanel::set_search_text(const String &p_text) {
 
 void FindInFilesSearchPanel::set_replace_text(const String &p_text) {
 	replace_line_edit->set_text(p_text);
+	rename_line_edit->set_text(p_text);
 	replace_line_edit->emit_signal(SceneStringName(text_changed), p_text);
 }
 
@@ -458,11 +467,19 @@ void FindInFilesSearchPanel::set_replace(bool p_replace_mode) {
 }
 
 String FindInFilesSearchPanel::get_search_text() const {
-	return search_text_line_edit->get_text();
+	if (is_rename_mode()) {
+		return renamed_symbol_name->get_text();
+	} else {
+		return search_text_line_edit->get_text();
+	}
 }
 
 bool FindInFilesSearchPanel::is_replace_pressed() const {
 	return toggle_replace_button->is_pressed();
+}
+
+bool FindInFilesSearchPanel::is_rename_mode() const {
+	return rename_view->is_visible();
 }
 
 HashSet<String> FindInFilesSearchPanel::get_filter() const {
@@ -576,6 +593,7 @@ void FindInFilesSearchPanel::_on_folder_selected(String p_path) {
 void FindInFilesSearchPanel::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("find_requested"));
 	ADD_SIGNAL(MethodInfo("replace_all_requested"));
+	ADD_SIGNAL(MethodInfo("close_tab_requested"));
 }
 
 FindInFilesSearchPanel::FindInFilesSearchPanel() {
@@ -588,18 +606,18 @@ FindInFilesSearchPanel::FindInFilesSearchPanel() {
 	sb->set_content_margin_all(6 * EDSCALE);
 	add_theme_style_override("panel", sb);
 
-	VBoxContainer *vbc = memnew(VBoxContainer);
-	vbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	add_child(vbc);
+	default_view = memnew(VBoxContainer);
+	default_view->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	add_child(default_view);
 
 	{
 		Label *find_label = memnew(Label);
 		find_label->set_text(TTRC("Find"));
-		vbc->add_child(find_label);
+		default_view->add_child(find_label);
 
 		HBoxContainer *search_hbc = memnew(HBoxContainer);
 		search_hbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		vbc->add_child(search_hbc);
+		default_view->add_child(search_hbc);
 
 		search_text_line_edit = memnew(LineEdit);
 		search_text_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -629,11 +647,11 @@ FindInFilesSearchPanel::FindInFilesSearchPanel() {
 		toggle_replace_button->set_text(TTRC("Replace"));
 		toggle_replace_button->set_tooltip_text(TTRC("Toggle Replace Mode"));
 		toggle_replace_button->connect(SceneStringName(toggled), callable_mp(this, &FindInFilesSearchPanel::_toggle_replace_pressed));
-		vbc->add_child(toggle_replace_button);
+		default_view->add_child(toggle_replace_button);
 
 		replace_hbox = memnew(HBoxContainer);
 		replace_hbox->set_visible(toggle_replace_button->is_pressed());
-		vbc->add_child(replace_hbox);
+		default_view->add_child(replace_hbox);
 
 		replace_line_edit = memnew(LineEdit);
 		replace_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -668,11 +686,11 @@ FindInFilesSearchPanel::FindInFilesSearchPanel() {
 
 	filters_label = memnew(Label);
 	filters_label->set_text(TTRC("Filters"));
-	vbc->add_child(filters_label);
+	default_view->add_child(filters_label);
 
 	additional_options_vbc = memnew(VBoxContainer);
 	additional_options_vbc->add_theme_constant_override("separation", 0);
-	vbc->add_child(additional_options_vbc);
+	default_view->add_child(additional_options_vbc);
 	{
 		HBoxContainer *hbc = memnew(HBoxContainer);
 		additional_options_vbc->add_child(hbc);
@@ -742,6 +760,43 @@ FindInFilesSearchPanel::FindInFilesSearchPanel() {
 	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &FindInFilesSearchPanel::_update_file_extensions).bind(false));
 	_update_file_extensions(true);
 
+	rename_view = memnew(VBoxContainer);
+	rename_view->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	rename_view->hide();
+	add_child(rename_view);
+
+	{
+		Label *rename_label = memnew(Label);
+		rename_label->set_text(TTRC("Rename Symbol"));
+		rename_view->add_child(rename_label);
+
+		renamed_symbol_name = memnew(LineEdit);
+		renamed_symbol_name->set_accessibility_name(TTRC("Symbol to Rename"));
+		renamed_symbol_name->set_editable(false);
+		rename_view->add_child(renamed_symbol_name);
+
+		Label *new_name_label = memnew(Label);
+		new_name_label->set_text(TTRC("New Name"));
+		rename_view->add_child(new_name_label);
+
+		rename_line_edit = memnew(LineEdit);
+		rename_line_edit->set_accessibility_name(TTRC("New Name"));
+		rename_view->add_child(rename_line_edit);
+		rename_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &FindInFilesSearchPanel::_on_rename_apply).bind(false).unbind(1));
+
+		HBoxContainer *applydiscard_hb = memnew(HBoxContainer);
+		applydiscard_hb->set_alignment(BoxContainer::ALIGNMENT_CENTER);
+		rename_view->add_child(applydiscard_hb);
+
+		apply_rename = memnew(Button(TTRC("Rename Selected")));
+		applydiscard_hb->add_child(apply_rename);
+		apply_rename->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesSearchPanel::_on_rename_apply).bind(false));
+
+		apply_rename = memnew(Button(TTRC("Cancel")));
+		applydiscard_hb->add_child(apply_rename);
+		apply_rename->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesSearchPanel::_on_rename_discard));
+	}
+
 	debounce_timer = memnew(Timer);
 	debounce_timer->set_one_shot(true);
 	debounce_timer->connect("timeout", callable_mp(this, &FindInFilesSearchPanel::_emit_find_requested));
@@ -768,6 +823,11 @@ void FindInFilesResultsPanel::set_with_replace(bool p_with_replace) {
 void FindInFilesResultsPanel::set_replace_text(const String &p_text) {
 	replace_text = p_text;
 	_update_replace_preview();
+}
+
+void FindInFilesResultsPanel::set_symbol_rename(const EditorLanguage::LookupResult &p_symbol) {
+	symbol_rename = p_symbol;
+	set_with_replace(true);
 }
 
 void FindInFilesResultsPanel::set_search_labels_visibility(bool p_visible) {
@@ -848,6 +908,42 @@ void FindInFilesResultsPanel::update_layout(EditorDock::DockLayout p_layout, int
 	} else {
 		results_display->set_theme_type_variation("NoBorderHorizontalBottom");
 		results_display->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
+	}
+}
+
+void FindInFilesContainer::create_rename_control(const String &p_symbol, const EditorLanguage::LookupResult &p_lookup) {
+	FindInFilesResultsPanel *new_panel = memnew(FindInFilesResultsPanel);
+	tabs->add_child(new_panel);
+	tabs->set_current_tab(tabs->get_tab_count() - 1);
+	_update_bar_visibility();
+
+	new_panel->connect("result_selected", callable_mp(this, &FindInFilesContainer::_result_selected));
+	new_panel->connect("files_modified", callable_mp(this, &FindInFilesContainer::_files_modified));
+	new_panel->get_new_tab_button()->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesContainer::create_new_panel));
+
+	HashSet<String> exts;
+
+	Ref<Script> scr = ResourceLoader::load(p_lookup.script_path);
+	ERR_FAIL_COND(scr.is_null());
+	exts.insert(scr->get_language()->get_extension());
+
+	FindInFilesSearch *finder = new_panel->get_finder();
+	finder->set_search_text(p_symbol);
+	finder->set_match_case(true);
+	finder->set_whole_words(true);
+	finder->set_filter(exts);
+	finder->set_symbol_rename(p_lookup);
+
+	search_control->set_finder(finder, false);
+	search_control->set_search_text(p_symbol);
+	search_control->set_replace(true);
+	search_control->set_replace_text(p_symbol);
+
+	new_panel->set_symbol_rename(p_lookup);
+	new_panel->start_search();
+
+	if (tabs->get_tab_count() == 1) {
+		_update_bar_visibility();
 	}
 }
 
@@ -946,8 +1042,36 @@ void FindInFilesResultsPanel::_on_result_found(const String &p_fpath, int p_line
 	if (with_replace) {
 		_update_replace_item(item, r);
 
+		bool check_item = false;
+		if (!symbol_rename.script_path.is_empty()) {
+			if (ResourceLoader::exists(p_fpath, "Script")) {
+				Ref<Script> source_script = ResourceLoader::load(p_fpath);
+				if (source_script.is_valid()) {
+					PackedStringArray lines = source_script->get_source_code().split("\n");
+					const String current_line = lines[p_line_number - 1];
+					lines.write[p_line_number - 1] = current_line.insert(p_begin, String::chr(0xFFFF));
+
+					EditorLanguage::LookupResult result;
+					Error err = source_script->get_language()->get_editor_language()->lookup_code_for_rename(String("\n").join(lines), current_line.substr(p_begin, p_end - p_begin), source_script->get_path(), result);
+					if (err == OK) {
+						check_item = result.type == symbol_rename.type &&
+								result.class_name == symbol_rename.class_name &&
+								result.class_member == symbol_rename.class_member &&
+								result.description == symbol_rename.description &&
+								result.doc_type == symbol_rename.doc_type &&
+								result.enumeration == symbol_rename.enumeration &&
+								result.is_bitfield == symbol_rename.is_bitfield &&
+								result.value == symbol_rename.value &&
+								result.script_path == symbol_rename.script_path &&
+								result.location == symbol_rename.location;
+					}
+				}
+			}
+		} else {
+			check_item = true;
+		}
 		item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-		item->set_checked(0, true);
+		item->set_checked(0, check_item);
 		item->set_editable(0, true);
 		item->add_button(1, replace_texture, FIND_BUTTON_REPLACE, false, TTR("Replace"));
 		item->add_button(1, remove_texture, FIND_BUTTON_REMOVE, false, TTR("Remove result"));
@@ -1120,6 +1244,14 @@ void FindInFilesResultsPanel::replace_all() {
 	}
 
 	emit_signal(SNAME("files_modified"));
+
+	if (!symbol_rename.script_path.is_empty()) {
+		// Go back to the Script Editor.
+		ScriptTextEditor *script_editor = Object::cast_to<ScriptTextEditor>(ScriptEditor::get_singleton()->get_active_editor());
+		if (script_editor && script_editor->is_visible_in_tree()) {
+			script_editor->get_code_editor()->get_text_editor()->grab_focus();
+		}
+	}
 }
 
 void FindInFilesResultsPanel::_on_button_clicked(TreeItem *p_item, int p_column, int p_id, int p_mouse_button_index) {
@@ -1334,9 +1466,10 @@ FindInFilesResultsPanel::FindInFilesResultsPanel() {
 
 //-----------------------------------------------------------------------------
 
-FindInFilesResultsPanel *FindInFilesContainer::_create_new_panel() {
+FindInFilesResultsPanel *FindInFilesContainer::create_new_panel() {
 	int index = tabs->get_current_tab();
 	FindInFilesResultsPanel *old_panel = Object::cast_to<FindInFilesResultsPanel>(tabs->get_current_tab_control());
+	bool copy_old_panel = old_panel && !old_panel->get_finder()->is_rename_mode();
 
 	FindInFilesResultsPanel *new_panel = memnew(FindInFilesResultsPanel);
 	tabs->add_child(new_panel);
@@ -1347,29 +1480,38 @@ FindInFilesResultsPanel *FindInFilesContainer::_create_new_panel() {
 
 	new_panel->connect("result_selected", callable_mp(this, &FindInFilesContainer::_result_selected));
 	new_panel->connect("files_modified", callable_mp(this, &FindInFilesContainer::_files_modified));
-	new_panel->get_new_tab_button()->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesContainer::_create_new_panel));
+	new_panel->get_new_tab_button()->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesContainer::create_new_panel));
 
 	FindInFilesSearch *new_finder = new_panel->get_finder();
-	if (old_panel) {
-		if (FindInFilesSearch *old_finder = old_panel->get_finder()) {
-			new_finder->copy_from(old_finder);
-		}
+	if (copy_old_panel) {
+		new_finder->copy_from(old_panel->get_finder());
 		search_control->set_replace_text(old_panel->get_replace_text());
+	} else {
+		search_control->set_replace(false);
 	}
-	search_control->set_finder(new_finder, !old_panel);
+	search_control->set_finder(new_finder, !copy_old_panel);
 	search_control->set_search_text(new_finder->get_search_text());
 	return new_panel;
 }
 
 void FindInFilesContainer::_update_current_title() {
-	tabs->set_tab_title(tabs->get_current_tab(), vformat(TTR("Find: %s"), search_control->get_search_text()));
+	FindInFilesResultsPanel *panel = Object::cast_to<FindInFilesResultsPanel>(tabs->get_current_tab_control());
+	if (panel->get_finder()->is_rename_mode()) {
+		tabs->set_tab_title(tabs->get_current_tab(), vformat(TTR("Rename: %s"), search_control->get_search_text()));
+	} else {
+		tabs->set_tab_title(tabs->get_current_tab(), vformat(TTR("Find: %s"), search_control->get_search_text()));
+	}
+}
+
+void FindInFilesContainer::_close_current_tab() {
+	_close_panel(Object::cast_to<FindInFilesResultsPanel>(tabs->get_current_tab_control()));
 }
 
 void FindInFilesContainer::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible() && tabs->get_tab_count() == 0) {
-				_create_new_panel();
+				create_new_panel();
 			}
 		} break;
 		case NOTIFICATION_POSTINITIALIZE: {
@@ -1396,6 +1538,9 @@ void FindInFilesContainer::_on_theme_changed() {
 
 void FindInFilesContainer::_on_tab_changed() {
 	if (FindInFilesResultsPanel *panel = Object::cast_to<FindInFilesResultsPanel>(tabs->get_current_tab_control())) {
+		if (panel->get_finder()->is_rename_mode()) {
+			search_control->set_replace(true);
+		}
 		search_control->set_replace_text(panel->get_replace_text());
 		search_control->set_finder(panel->get_finder(), false);
 	}
@@ -1467,7 +1612,7 @@ void FindInFilesContainer::_update_bar_visibility() {
 	for (int i = 0; i < tabs->get_tab_count(); i++) {
 		FindInFilesResultsPanel *panel = Object::cast_to<FindInFilesResultsPanel>(tabs->get_tab_control(i));
 		if (panel) {
-			panel->set_search_labels_visibility(!bar_visible);
+			panel->set_search_labels_visibility(!bar_visible && !panel->get_finder()->is_rename_mode());
 			panel->get_new_tab_button()->set_visible(!bar_visible);
 		}
 	}
@@ -1557,7 +1702,9 @@ FindInFilesContainer::FindInFilesContainer() {
 	search_control = memnew(FindInFilesSearchPanel);
 	search_control->connect("find_requested", callable_mp(this, &FindInFilesContainer::_start_find_in_files));
 	search_control->connect("replace_all_requested", callable_mp(this, &FindInFilesContainer::_replace_all));
+	search_control->connect("close_tab_requested", callable_mp(this, &FindInFilesContainer::_close_current_tab));
 	search_control->get_replace_line_edit()->connect(SceneStringName(text_changed), callable_mp(this, &FindInFilesContainer::_set_replace_text));
+	search_control->get_rename_line_edit()->connect(SceneStringName(text_changed), callable_mp(this, &FindInFilesContainer::_set_replace_text));
 	hsplit->add_child(search_control);
 
 	tabs = memnew(TabContainer);
@@ -1573,7 +1720,7 @@ FindInFilesContainer::FindInFilesContainer() {
 
 	new_tab_button = memnew(Button);
 	new_tab_button->set_flat(true);
-	new_tab_button->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesContainer::_create_new_panel));
+	new_tab_button->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesContainer::create_new_panel));
 	tabs->get_internal_container()->add_child(new_tab_button);
 
 	tabs_context_menu = memnew(PopupMenu);
@@ -1590,6 +1737,9 @@ FindInFilesContainer::FindInFilesContainer() {
 void FindInFiles::open_dock(const String &p_initial_text, bool p_replace) {
 	FindInFilesSearchPanel *search_control = container->get_search_control();
 	EditorDockManager::get_singleton()->focus_dock(container);
+	if (search_control->is_rename_mode()) {
+		container->create_new_panel();
+	}
 	search_control->set_search_text(p_initial_text);
 	search_control->set_replace(p_replace);
 }
@@ -1599,4 +1749,40 @@ FindInFiles::FindInFiles() {
 	container = memnew(FindInFilesContainer);
 	EditorDockManager::get_singleton()->add_dock(container);
 	container->close();
+}
+
+void FindInFilesSearchPanel::_on_rename_apply(bool p_confirm) {
+	if (rename_line_edit->get_text() == renamed_symbol_name->get_text()) {
+		return;
+	}
+	if (!p_confirm && finder->get_symbol_rename().type == EditorLanguage::LookupResult::Type::CLASS_PROPERTY) {
+		const Ref<Script> script = ResourceLoader::load(finder->get_symbol_rename().script_path);
+		const String old_symbol = finder->get_search_text();
+
+		List<PropertyInfo> script_properties;
+		script->get_script_property_list(&script_properties);
+		for (const PropertyInfo &pi : script_properties) {
+			if (pi.name == old_symbol) {
+				if (pi.usage & PROPERTY_USAGE_STORAGE) {
+					if (!rename_confirm) {
+						rename_confirm = memnew(ConfirmationDialog);
+						rename_confirm->set_autowrap(true);
+						rename_confirm->set_text(TTRC("The renamed symbol is an exported property. Renaming it may result in losing values stored in scene or resource files. They have to be updated manually."));
+						add_child(rename_confirm);
+						rename_confirm->connect(SceneStringName(confirmed), callable_mp(this, &FindInFilesSearchPanel::_on_rename_apply).bind(true));
+					}
+					rename_confirm->popup_centered(Vector2i(EDSCALE_RND(400), 0));
+					return;
+				} else {
+					break;
+				}
+			}
+		}
+	}
+	emit_signal("replace_all_requested");
+	emit_signal("close_tab_requested");
+}
+
+void FindInFilesSearchPanel::_on_rename_discard() {
+	emit_signal("close_tab_requested");
 }

--- a/editor/script/find_in_files.h
+++ b/editor/script/find_in_files.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/editor_language.h"
 #include "core/templates/hash_map.h"
 #include "editor/docks/editor_dock.h"
 #include "scene/gui/dialogs.h"
@@ -182,6 +183,9 @@ class FindInFilesPanel : public MarginContainer {
 	HashMap<TreeItem *, Result> result_items;
 	bool with_replace = false;
 
+	ConfirmationDialog *rename_confirm = nullptr;
+	EditorLanguage::LookupResult symbol_rename;
+
 	HBoxContainer *replace_container = nullptr;
 	LineEdit *replace_line_edit = nullptr;
 	Button *replace_all_button = nullptr;
@@ -198,7 +202,7 @@ class FindInFilesPanel : public MarginContainer {
 	void _on_result_selected();
 	void _on_item_edited();
 	void _on_replace_text_changed(const String &p_text);
-	void _on_replace_all_clicked();
+	void _on_replace_all_clicked(bool p_confirmed);
 
 	void _apply_replaces_in_file(const String &p_fpath, const Vector<Result> &p_locations, const String &p_new_text);
 	void _update_replace_buttons();
@@ -218,6 +222,7 @@ public:
 
 	void set_with_replace(bool p_with_replace);
 	void set_replace_text(const String &p_text);
+	void set_symbol_rename(const EditorLanguage::LookupResult &p_symbol, const String &p_new_name);
 	bool is_keep_results() const;
 	void set_search_labels_visibility(bool p_visible);
 
@@ -291,6 +296,8 @@ protected:
 
 public:
 	void open_dialog(const String &p_initial_text, bool p_replace = false);
+
+	FindInFilesContainer *get_dock() const { return container; }
 
 	FindInFiles();
 };

--- a/editor/script/find_in_files.h
+++ b/editor/script/find_in_files.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/editor_language.h"
 #include "core/templates/hash_map.h"
 #include "editor/docks/editor_dock.h"
 #include "scene/gui/scroll_container.h"
@@ -46,6 +47,7 @@ class FindInFilesSearch : public Node {
 	String root_dir;
 	bool whole_words = false;
 	bool match_case = false;
+	EditorLanguage::LookupResult symbol_rename;
 
 	// State.
 	HashSet<String> include_wildcards;
@@ -80,6 +82,7 @@ public:
 	void set_includes(const String &p_include_wildcards);
 	void set_excludes(const String &p_exclude_wildcards);
 	void set_folder(const String &p_folder);
+	void set_symbol_rename(const EditorLanguage::LookupResult &p_symbol) { symbol_rename = p_symbol; }
 
 	String get_search_text() const { return pattern; }
 	bool get_whole_words() { return whole_words; }
@@ -88,9 +91,11 @@ public:
 	String get_includes() { return include_string; }
 	String get_excludes() { return exclude_string; }
 	String get_folder() { return root_dir; }
+	EditorLanguage::LookupResult get_symbol_rename() const { return symbol_rename; }
 
 	bool is_whole_words() const { return whole_words; }
 	bool is_match_case() const { return match_case; }
+	bool is_rename_mode() const { return !symbol_rename.script_path.is_empty(); }
 
 	void start();
 	void stop();
@@ -122,12 +127,16 @@ class FindInFilesSearchPanel : public ScrollContainer {
 	void _emit_find_requested();
 	void _toggle_replace_pressed(bool p_with_replace);
 	void _on_replace_all_clicked(bool p_dialog);
+	void _on_rename_apply(bool p_confirm);
+	void _on_rename_discard();
 	void _on_additional_options_toggled(bool p_toggled);
 	void _on_add_new_tab_clicked();
 	void _on_filter_toggled(bool p_pressed, const String &p_ext);
 	void _update_finder();
 	void _update_file_extensions(bool p_init);
 	void _highlight_search_text();
+
+	VBoxContainer *default_view = nullptr;
 
 	FindInFilesSearch *finder = nullptr;
 	Timer *debounce_timer = nullptr;
@@ -155,6 +164,14 @@ class FindInFilesSearchPanel : public ScrollContainer {
 	LineEdit *includes_line_edit = nullptr;
 	LineEdit *excludes_line_edit = nullptr;
 
+	VBoxContainer *rename_view = nullptr;
+	LineEdit *renamed_symbol_name = nullptr;
+	LineEdit *rename_line_edit = nullptr;
+	Button *apply_rename = nullptr;
+	Button *discard_rename = nullptr;
+
+	ConfirmationDialog *rename_confirm = nullptr;
+
 protected:
 	void _notification(int p_what);
 
@@ -169,9 +186,11 @@ public:
 
 	String get_search_text() const;
 	bool is_replace_pressed() const;
+	bool is_rename_mode() const;
 	HashSet<String> get_filter() const;
 
 	LineEdit *get_replace_line_edit() const { return replace_line_edit; }
+	LineEdit *get_rename_line_edit() const { return rename_line_edit; }
 
 	FindInFilesSearchPanel();
 };
@@ -221,6 +240,7 @@ class FindInFilesResultsPanel : public MarginContainer {
 	bool with_replace = false;
 
 	String replace_text;
+	EditorLanguage::LookupResult symbol_rename;
 
 	MarginContainer *results_mc = nullptr;
 
@@ -255,6 +275,7 @@ public:
 
 	void set_with_replace(bool p_with_replace);
 	void set_replace_text(const String &p_text);
+	void set_symbol_rename(const EditorLanguage::LookupResult &p_symbol);
 	void set_search_labels_visibility(bool p_visible);
 
 	void start_search();
@@ -297,8 +318,8 @@ class FindInFilesContainer : public EditorDock {
 	void _bar_input(const Ref<InputEvent> &p_input);
 	void _on_theme_changed();
 
-	FindInFilesResultsPanel *_create_new_panel();
 	void _update_current_title();
+	void _close_current_tab();
 
 	void _result_selected(const String &p_fpath, int p_line_number, int p_begin, int p_end);
 	void _files_modified();
@@ -316,6 +337,8 @@ public:
 	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) override;
 
 	FindInFilesSearchPanel *get_search_control() { return search_control; }
+	FindInFilesResultsPanel *create_new_panel();
+	void create_rename_control(const String &p_symbol, const EditorLanguage::LookupResult &p_lookup);
 
 	FindInFilesContainer();
 };
@@ -333,6 +356,8 @@ public:
 	FindInFilesContainer *get_container() { return container; }
 
 	void open_dock(const String &p_initial_text = "", bool p_replace = false);
+
+	FindInFilesContainer *get_dock() const { return container; }
 
 	FindInFiles();
 };

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -39,6 +39,7 @@
 #include "core/io/resource_saver.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/object/editor_language.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "core/string/fuzzy_search.h"
@@ -2727,6 +2728,30 @@ Error ScriptEditor::close_file(const String &p_file) {
 		}
 	}
 	return ERR_FILE_NOT_FOUND;
+}
+
+void ScriptEditor::rename_symbol(const String &p_symbol, const String &p_new_name, const EditorLanguage::LookupResult &p_lookup) {
+	FindInFilesPanel *panel = find_in_files->get_dock()->get_panel_for_results(TTR("Rename symbol:") + " " + p_symbol);
+	FindInFilesSearch *finder = panel->get_finder();
+
+	HashSet<String> exts;
+
+	Ref<Script> scr = ResourceLoader::load(p_lookup.script_path);
+	ERR_FAIL_COND(scr.is_null());
+	exts.insert(scr->get_language()->get_extension());
+
+	finder->set_search_text(p_symbol);
+	finder->set_match_case(true);
+	finder->set_whole_words(true);
+	finder->set_folder(String());
+	finder->set_filter(exts);
+	finder->set_includes(HashSet<String>());
+	finder->set_excludes(HashSet<String>());
+
+	panel->set_symbol_rename(p_lookup, p_new_name);
+	panel->start_search();
+
+	find_in_files->get_dock()->make_visible();
 }
 
 void ScriptEditor::_add_callback(Object *p_obj, const String &p_function, const PackedStringArray &p_args) {

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -38,6 +38,7 @@
 #include "core/io/resource_saver.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/object/editor_language.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "core/string/fuzzy_search.h"
@@ -2993,6 +2994,15 @@ Error ScriptEditor::close_file(const String &p_file) {
 		}
 	}
 	return ERR_FILE_NOT_FOUND;
+}
+
+void ScriptEditor::rename_symbol(const String &p_symbol, const EditorLanguage::LookupResult &p_lookup) {
+	FindInFiles::get_singleton()->get_container()->create_rename_control(p_symbol, p_lookup);
+	FindInFiles::get_singleton()->get_dock()->make_visible();
+
+	LineEdit *name_edit = FindInFiles::get_singleton()->get_container()->get_search_control()->get_rename_line_edit();
+	callable_mp((Control *)name_edit, &Control::grab_focus).call_deferred(false);
+	callable_mp(name_edit, &LineEdit::select_all).call_deferred();
 }
 
 void ScriptEditor::_add_callback(Object *p_obj, const String &p_function, const PackedStringArray &p_args) {

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/error/error_list.h"
+#include "core/object/editor_language.h"
 #include "core/object/script_language.h"
 #include "editor/plugins/editor_plugin.h"
 #include "editor/script/script_editor_base.h"
@@ -421,6 +422,8 @@ public:
 	void open_text_file_create_dialog(const String &p_base_path, const String &p_base_name = "");
 	Ref<Resource> open_file(const String &p_file);
 	Error close_file(const String &p_file);
+
+	void rename_symbol(const String &p_symbol, const String &p_new_name, const EditorLanguage::LookupResult &p_lookup);
 
 	void ensure_select_current();
 

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/error/error_list.h"
+#include "core/object/editor_language.h"
 #include "core/object/script_language.h"
 #include "editor/plugins/editor_plugin.h"
 #include "editor/script/script_editor_base.h"
@@ -468,6 +469,8 @@ public:
 	Ref<Resource> open_file(const String &p_file);
 	bool can_open_file(const String &p_file) const;
 	Error close_file(const String &p_file);
+
+	void rename_symbol(const String &p_symbol, const EditorLanguage::LookupResult &p_lookup);
 
 	void ensure_select_current();
 

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -50,12 +50,14 @@
 #include "editor/inspector/editor_context_menu_plugin.h"
 #include "editor/inspector/editor_inspector.h"
 #include "editor/inspector/multi_node_edit.h"
+#include "editor/script/find_in_files.h"
 #include "editor/script/script_editor_navigation_marker.h"
 #include "editor/script/syntax_highlighters.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/grid_container.h"
+#include "scene/gui/line_edit.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/split_container.h"
@@ -1864,6 +1866,57 @@ bool ScriptTextEditor::_edit_option(int p_op) {
 				_lookup_symbol(text, tx->get_caret_line(0), tx->get_caret_column(0));
 			}
 		} break;
+		case RENAME_SYMBOL: {
+			String text = tx->get_word_under_caret(0);
+			if (text.is_empty()) {
+				text = tx->get_selected_text(0);
+			}
+			if (text.is_empty()) {
+				break;
+			}
+			Ref<Script> script = edited_res;
+
+			EditorLanguage::LookupResult result;
+			String code_text = code_editor->get_text_editor()->get_text_with_cursor_char(tx->get_caret_line(0), tx->get_caret_column(0));
+			if (script->get_language()->get_editor_language()->lookup_code_for_rename(code_text, text, script->get_path(), result) != OK) {
+				break;
+			}
+
+			if (result.script_path.is_empty()) {
+				// Don't allow renaming native symbols.
+				break;
+			}
+
+			rename_lookup_cache = result;
+			symbol_to_rename = text;
+
+			if (!rename_popup) {
+				rename_popup = memnew(Popup);
+				add_child(rename_popup);
+
+				rename_input = memnew(LineEdit);
+				rename_input->set_select_all_on_focus(true);
+				rename_input->set_theme_type_variation("TreeLineEdit");
+				rename_input->set_custom_minimum_size(Vector2(200 * EDSCALE, 0));
+				rename_popup->add_child(rename_input);
+				rename_input->connect(SceneStringName(text_submitted), callable_mp(this, &ScriptTextEditor::_confirm_rename));
+			}
+			rename_input->set_text(text);
+
+			Vector2 pos = tx->get_screen_position();
+			// Set popup at the beginning of the word.
+			const PackedInt32Array words = TS->shaped_text_get_word_breaks(tx->get_line_data(tx->get_caret_line(0))->get_rid());
+			for (int i = 0; i < words.size(); i = i + 2) {
+				if ((words[i] <= tx->get_caret_column(0) && words[i + 1] >= tx->get_caret_column(0)) || (i == words.size() - 2 && tx->get_caret_column(0) == words[i + 1])) {
+					pos += tx->get_rect_at_line_column(tx->get_caret_line(), words[i] + 1).position;
+					break;
+				}
+			}
+			rename_popup->popup(Rect2i(pos, Vector2i()));
+
+			rename_input->grab_focus(false);
+		} break;
+
 		default: {
 			if (TextEditorBase::_edit_option(p_op)) {
 				return true;
@@ -2430,6 +2483,13 @@ void ScriptTextEditor::_assign_dragged_export_variables() {
 	}
 }
 
+void ScriptTextEditor::_confirm_rename(const String &p_new_name) {
+	if (p_new_name != symbol_to_rename) {
+		ScriptEditor::get_singleton()->rename_symbol(symbol_to_rename, p_new_name, rename_lookup_cache);
+	}
+	rename_popup->hide();
+}
+
 void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &p_ev) {
 	Ref<InputEventMouseButton> mb = p_ev;
 	Ref<InputEventKey> k = p_ev;
@@ -2605,6 +2665,7 @@ void ScriptTextEditor::_make_context_menu(bool p_selection, bool p_color, bool p
 		context_menu->add_separator();
 		if (p_open_docs) {
 			context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_symbol"), LOOKUP_SYMBOL);
+			context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/rename_symbol"), RENAME_SYMBOL);
 		}
 		if (p_color) {
 			context_menu->add_item(TTRC("Pick Color"), EDIT_PICK_COLOR);
@@ -2677,6 +2738,7 @@ void ScriptTextEditor::register_editor() {
 	ED_SHORTCUT("script_text_editor/goto_line", TTRC("Go to Line..."), KeyModifierMask::CMD_OR_CTRL | Key::G);
 	ED_SHORTCUT_OVERRIDE("script_text_editor/goto_line", "macos", KeyModifierMask::CMD_OR_CTRL | Key::L);
 	ED_SHORTCUT("script_text_editor/goto_symbol", TTRC("Lookup Symbol"));
+	ED_SHORTCUT("script_text_editor/rename_symbol", TTRC("Rename Symbol"), Key::F2);
 
 	ED_SHORTCUT("script_text_editor/toggle_breakpoint", TTRC("Toggle Breakpoint"), Key::F9);
 	ED_SHORTCUT_OVERRIDE("script_text_editor/toggle_breakpoint", "macos", KeyModifierMask::META | KeyModifierMask::SHIFT | Key::B);

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -50,12 +50,14 @@
 #include "editor/inspector/editor_context_menu_plugin.h"
 #include "editor/inspector/editor_inspector.h"
 #include "editor/inspector/multi_node_edit.h"
+#include "editor/script/find_in_files.h"
 #include "editor/script/script_editor_navigation_marker.h"
 #include "editor/script/syntax_highlighters.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/grid_container.h"
+#include "scene/gui/line_edit.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/split_container.h"
@@ -1861,6 +1863,39 @@ bool ScriptTextEditor::_edit_option(int p_op) {
 				_lookup_symbol(text, tx->get_caret_line(0), tx->get_caret_column(0));
 			}
 		} break;
+		case RENAME_SYMBOL: {
+			String text = tx->get_word_under_caret(0);
+			if (text.is_empty()) {
+				text = tx->get_selected_text(0);
+			}
+			if (text.is_empty()) {
+				break;
+			}
+			Ref<Script> script = edited_res;
+
+			EditorLanguage::LookupResult result;
+			String code_text = code_editor->get_text_editor()->get_text_with_cursor_char(tx->get_caret_line(0), tx->get_caret_column(0));
+			if (script->get_language()->get_editor_language()->lookup_code_for_rename(code_text, text, script->get_path(), result) != OK) {
+				break;
+			}
+
+			if (result.script_path.is_empty()) {
+				// Don't allow renaming native symbols.
+				break;
+			}
+
+			Vector2 pos = tx->get_screen_position();
+			// Set popup at the beginning of the word.
+			const PackedInt32Array words = TS->shaped_text_get_word_breaks(tx->get_line_data(tx->get_caret_line(0))->get_rid());
+			for (int i = 0; i < words.size(); i = i + 2) {
+				if ((words[i] <= tx->get_caret_column(0) && words[i + 1] >= tx->get_caret_column(0)) || (i == words.size() - 2 && tx->get_caret_column(0) == words[i + 1])) {
+					pos += tx->get_rect_at_line_column(tx->get_caret_line(), words[i] + 1).position;
+					break;
+				}
+			}
+			ScriptEditor::get_singleton()->rename_symbol(text, result);
+		} break;
+
 		default: {
 			if (CodeEditorBase::_edit_option(p_op)) {
 				return true;
@@ -2462,9 +2497,11 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &p_ev) {
 
 		bool foldable = tx->can_fold_line(mouse_line) || tx->is_line_folded(mouse_line);
 		bool open_docs = false;
+		bool allow_rename = false;
 
 		if (ScriptServer::is_global_class(word_at_pos) || word_at_pos.is_resource_file()) {
 			open_docs = true;
+			allow_rename = ScriptServer::is_global_class(word_at_pos);
 		} else {
 			Ref<Script> script = edited_res;
 			Node *base = get_tree()->get_edited_scene_root();
@@ -2474,6 +2511,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &p_ev) {
 			EditorLanguage::LookupResult result;
 			if (script->get_language()->get_editor_language()->lookup_code(tx->get_text_for_symbol_lookup(), word_at_pos, script->get_path(), base, result) == OK) {
 				open_docs = true;
+				allow_rename = !result.script_path.is_empty();
 			}
 		}
 
@@ -2501,11 +2539,11 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &p_ev) {
 			}
 		}
 
-		_make_ste_context_menu(tx->has_selection(), has_color, foldable, open_docs, local_pos);
+		_make_ste_context_menu(tx->has_selection(), has_color, foldable, open_docs, allow_rename, local_pos);
 	}
 }
 
-void ScriptTextEditor::_make_ste_context_menu(bool p_selection, bool p_color, bool p_foldable, bool p_open_docs, const Vector2 &p_position) {
+void ScriptTextEditor::_make_ste_context_menu(bool p_selection, bool p_color, bool p_foldable, bool p_open_docs, bool p_allow_rename, const Vector2 &p_position) {
 	CodeEditorBase::_make_context_menu(p_selection, p_foldable, p_position, false);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_comment"), EDIT_TOGGLE_COMMENT);
 	_popup_move_item(EDIT_UNINDENT, context_menu);
@@ -2521,6 +2559,9 @@ void ScriptTextEditor::_make_ste_context_menu(bool p_selection, bool p_color, bo
 		context_menu->add_separator();
 		if (p_open_docs) {
 			context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_symbol"), LOOKUP_SYMBOL);
+		}
+		if (p_allow_rename) {
+			context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/rename_symbol"), RENAME_SYMBOL);
 		}
 		if (p_color) {
 			context_menu->add_item(TTRC("Pick Color"), EDIT_PICK_COLOR);
@@ -2604,6 +2645,7 @@ void ScriptTextEditor::register_editor() {
 	ED_SHORTCUT("script_text_editor/goto_line", TTRC("Go to Line..."), KeyModifierMask::CMD_OR_CTRL | Key::G);
 	ED_SHORTCUT_OVERRIDE("script_text_editor/goto_line", "macos", KeyModifierMask::CMD_OR_CTRL | Key::L);
 	ED_SHORTCUT("script_text_editor/goto_symbol", TTRC("Lookup Symbol"));
+	ED_SHORTCUT("script_text_editor/rename_symbol", TTRC("Rename Symbol"), Key::F2);
 
 	ED_SHORTCUT("script_text_editor/toggle_breakpoint", TTRC("Toggle Breakpoint"), Key::F9);
 	ED_SHORTCUT_OVERRIDE("script_text_editor/toggle_breakpoint", "macos", KeyModifierMask::META | KeyModifierMask::SHIFT | Key::B);

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/editor_language.h"
 #include "editor/gui/code_editor.h"
 #include "editor/script/script_editor_base.h"
 #include "editor/script/script_editor_plugin.h"
@@ -59,6 +60,11 @@ class ScriptTextEditor : public CodeEditorBase {
 
 	Variant pending_state;
 	bool script_is_valid = false;
+
+	String symbol_to_rename;
+	EditorLanguage::LookupResult rename_lookup_cache;
+	Popup *rename_popup = nullptr;
+	LineEdit *rename_input = nullptr;
 
 	RichTextLabel *errors_panel = nullptr;
 	Label *drag_info_label = nullptr;
@@ -117,6 +123,7 @@ class ScriptTextEditor : public CodeEditorBase {
 		SHOW_TOOLTIP_AT_CARET,
 		HELP_CONTEXTUAL,
 		LOOKUP_SYMBOL,
+		RENAME_SYMBOL,
 	};
 
 	enum COLOR_MODE {
@@ -153,6 +160,7 @@ class ScriptTextEditor : public CodeEditorBase {
 	Vector<ObjectID> _get_objects_for_export_assignment() const;
 	String _get_dropped_resource_as_exported_member(const Ref<Resource> &p_resource, const Vector<ObjectID> &p_script_instance_obj_ids);
 	void _assign_dragged_export_variables();
+	void _confirm_rename(const String &p_new_name);
 
 	static ScriptEditorBase *create_editor(const Ref<Resource> &p_resource);
 

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/editor_language.h"
 #include "editor/gui/code_editor.h"
 #include "editor/script/script_editor_base.h"
 #include "editor/script/script_editor_plugin.h"
@@ -109,6 +110,7 @@ class ScriptTextEditor : public CodeEditorBase {
 		SHOW_TOOLTIP_AT_CARET,
 		HELP_CONTEXTUAL,
 		LOOKUP_SYMBOL,
+		RENAME_SYMBOL,
 	};
 
 	class EditMenusScTE : public EditMenusCEB {
@@ -185,7 +187,7 @@ protected:
 
 	void _goto_line(int p_line);
 
-	void _make_ste_context_menu(bool p_selection, bool p_color, bool p_foldable, bool p_open_docs, const Vector2 &p_pos);
+	void _make_ste_context_menu(bool p_selection, bool p_color, bool p_foldable, bool p_open_docs, bool p_allow_rename, const Vector2 &p_pos);
 	Dictionary _get_context_data() const;
 
 	virtual void _text_edit_gui_input(const Ref<InputEvent> &p_ev) override;

--- a/modules/gdscript/editor/gdscript_editor_language.h
+++ b/modules/gdscript/editor/gdscript_editor_language.h
@@ -41,6 +41,7 @@ public:
 	virtual Error complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force, String &r_call_hint) override;
 
 	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) override;
+	virtual Error lookup_code_for_rename(const String &p_code, const String &p_symbol, const String &p_path, LookupResult &r_result) override;
 
 	virtual int32_t find_function(const String &p_function, const String &p_code) const override;
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -4636,4 +4636,8 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 	return ERR_CANT_RESOLVE;
 }
 
+Error GDScriptEditorLanguage::lookup_code_for_rename(const String &p_code, const String &p_symbol, const String &p_path, LookupResult &r_result) {
+	return lookup_code(p_code, p_symbol, p_path, nullptr, r_result);
+}
+
 #endif // TOOLS_ENABLED

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -4656,4 +4656,8 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 	return ERR_CANT_RESOLVE;
 }
 
+Error GDScriptEditorLanguage::lookup_code_for_rename(const String &p_code, const String &p_symbol, const String &p_path, LookupResult &r_result) {
+	return lookup_code(p_code, p_symbol, p_path, nullptr, r_result);
+}
+
 #endif // TOOLS_ENABLED

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -824,6 +824,7 @@ public:
 	/* Text */
 	// Text properties.
 	RID get_text_canvas_item() const;
+	const Ref<TextParagraph> get_line_data(int p_line) const { return text.get_line_data(p_line); }
 
 	bool has_ime_text() const;
 	void cancel_ime();

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -861,6 +861,7 @@ public:
 	/* Text */
 	// Text properties.
 	RID get_text_canvas_item() const;
+	const Ref<TextParagraph> get_line_data(int p_line) const { return text.get_line_data(p_line); }
 
 	bool has_ime_text() const;
 	void cancel_ime();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/899
Probably supersedes https://github.com/godotengine/godot/pull/102380

This PR adds Rename Symbol functionality, which renames symbols. Unlike the other PR, I've taken a very simple approach: lookup the symbol to be renamed, do an exact Find in Files search, filter out results based on the lookup. Seems to perform well enough.

Differentiating class identifier from a string/comment:

https://github.com/user-attachments/assets/70b36407-adfd-4b44-8ee5-1097760a7eb8

Differentiating same-named local variables from different methods:

https://github.com/user-attachments/assets/50047b7f-cdf9-4779-b936-7d8f96c4e675

I have tested it with my MetSys addon and it performs really well. The symbols can be renamed across files, and it even differentiates name aliases.
<img width="610" height="94" alt="image" src="https://github.com/user-attachments/assets/82ff4cb0-8157-48f0-b6cd-4bc2b28740bc" />

However I discovered a bug in the process (https://github.com/godotengine/godot/issues/117948), which makes some references incorrectly unmarked. You can still review the results manually and check them. (there shouldn't be false-positives, i.e. references checked, but belonging to other symbol)