### PR TITLE
Fix AnimationTree AnimationPlayerEditor broken

### DIFF
--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -2485,10 +2485,6 @@ bool AnimationPlayerEditorPlugin::handles(Object *p_object) const {
 
 void AnimationPlayerEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
-		// if AnimationTree editor is visible, do not occupy the bottom panel
-		if (AnimationTreeEditor::get_singleton() && AnimationTreeEditor::get_singleton()->is_visible_in_tree()) {
-			return;
-		}
 		anim_editor->make_visible();
 		anim_editor->set_process(true);
 		anim_editor->ensure_visibility();

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -271,9 +271,9 @@ EditorPlugin *EditorData::get_handling_main_editor(Object *p_object) {
 
 Vector<EditorPlugin *> EditorData::get_handling_sub_editors(Object *p_object) {
 	Vector<EditorPlugin *> sub_plugins;
-	for (int i = editor_plugins.size() - 1; i > -1; i--) {
-		if (!editor_plugins[i]->has_main_screen() && editor_plugins[i]->handles(p_object)) {
-			sub_plugins.push_back(editor_plugins[i]);
+	for (EditorPlugin *plugin : editor_plugins) {
+		if (!plugin->has_main_screen() && plugin->handles(p_object)) {
+			sub_plugins.push_back(plugin);
 		}
 	}
 	return sub_plugins;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/117941

I assumed that this code that used to prevent the AnimationPlayerEditor from showing over the AnimationTreeEditor was fine, but it seems that something has changed since it was last used and now there are issues.

https://github.com/godotengine/godot/blob/220b0b2f74d8e089481b140c42a42992a76dd6fc/editor/animation/animation_player_editor_plugin.cpp#L2490-L2491

The logic in `AnimationPlayerEditorPlugin::make_visible` needs to run even if opening the AnimationTreeEditor over it, so I removed the check. 
This also makes the AnimationPlayerEditor show if it is not in the same dock as the AnimationTreeEditor, which is now possible with some of the bottom dock reworks.
But then there needs to be a different way to make sure that the AnimationTreeEditor opens over it. (https://github.com/godotengine/godot/issues/115947)
So I changed the order in `EditorData::get_handling_sub_editors`.

The order of sub editor plugins (non main screen ones) was changed in https://github.com/godotengine/godot/pull/37022 as an addition to the main editor plugins, in order to give user plugins priority. But all sub editor plugins are edited, so to give users priority they should actually be edited after the default ones so they can show over them.
This change also makes plugins edit in the order they are added, the AnimationTreeEditor is added after the AnimationPlayerEditor, so it now shows over it. 
Generally, I think more general plugins are added before more specific ones, so it should make sense to edit the more specific ones after.

I don't think any other sub editors edit the same object and care about order where this would be an issue.
Here are all plugins in the order that they are added to EditorData's `editor_plugins` in a default build. I'm still looking through it to see if there would be any issues from changing it to be in reverse order to forward order for non-main screens, but I haven't found any issues.

<details><summary>All EditorPlugins in order</summary>

1. DebuggerEditorPlugin does not handle any
2. CanvasItemEditorPlugin handles (main screen) `CanvasItem`
3. Node3DEditorPlugin handles (main screen) `Node3D`
4. ScriptEditorPlugin handles (main screen) `Script` || `JSON` || `TextFile`
5. GameViewPlugin (main screen) does not handle any
6. AssetLibraryEditorPlugin (main screen) does not handle any
7. AnimationPlayerEditorPlugin handles `AnimationPlayer` || `AnimationTree` || `AnimationMixer`
8. AnimationTrackKeyEditEditorPlugin handles `AnimationTrackKeyEdit`
9. AnimationMarkerKeyEditEditorPlugin handles `AnimationMarkerKeyEdit`
10. VersionControlEditorPlugin does not handle any
11. AudioBusesEditorPlugin handles `AudioBusLayout`
12. AnimationTreeEditorPlugin handles `AnimationTree`
13. AudioStreamEditorPlugin does not handle any
14. AudioStreamRandomizerEditorPlugin handles none
15. BitMapEditorPlugin does not handle any
16. BoneMapEditorPlugin does not handle any
17. Camera3DEditorPlugin handles `Camera3D`
18. ControlEditorPlugin handles `Control`
19. CPUParticles3DEditorPlugin handles `CPUParticles3D` (ParticlesEditorPlugin)
20. CurveEditorPlugin does not handle any
21. DebugAdapterServer does not handle any
22. EditorScriptPlugin does not handle any
23. FontEditorPlugin does not handle any
24. GPUParticles3DEditorPlugin handles `GPUParticles3D` (ParticlesEditorPlugin)
25. GPUParticlesCollisionSDF3DEditorPlugin handles `GPUParticlesCollisionSDF3D`
26. GradientEditorPlugin does not handle any
27. GradientTexture2DEditorPlugin does not handle any
28. InputEventEditorPlugin does not handle any
29. LightmapGIEditorPlugin handles `LightmapGI`
30. MarginContainerEditorPlugin handles `MarginContainer`
31. MaterialEditorPlugin does not handle any
32. MultiMeshEditorPlugin handles `MultiMeshInstance3D`
33. MeshInstance3DEditorPlugin handles `MeshInstance3D` || `MultiNodeEdit` with 2+ `MeshInstance3D`
34. MeshLibraryEditorPlugin handles `MeshLibrary`
35. MultiMeshEditorPlugin handles `MultiMeshInstance3D`
36. OccluderInstance3DEditorPlugin handles `OccluderInstance3D`
37. PackedSceneEditorPlugin does not handle any
38. Path3DEditorPlugin handles `Path3D`
39. PhysicalBone3DEditorPlugin does not handle any
40. Polygon3DEditorPlugin handles `Node3D` && bool(p_object->call("_is_editable_3d_polygon"))
41. ResourcePreloaderEditorPlugin handles `ResourcePreloader`
42. ShaderEditorPlugin handles `Shader` || `ShaderInclude`
43. ShaderFileEditorPlugin handles `RDShaderFile`
44. Skeleton3DEditorPlugin handles `Skeleton3D`
45. SpriteFramesEditorPlugin handles `AnimatedSprite2D` with get_sprite_frames() || `AnimatedSprite3D` with get_sprite_frames() || `SpriteFrames` if currently editing those frames or not editing any.
46. StyleBoxEditorPlugin does not handle any
47. SubViewportPreviewEditorPlugin does not handle any
48. Texture3DEditorPlugin does not handle any
49. TextureEditorPlugin does not handle any
50. TextureLayeredEditorPlugin does not handle any
51. TextureRegionEditorPlugin does not handle any
52. ThemeEditorPlugin handles `Theme`
53. ToolButtonEditorPlugin does not handle any
54. VirtualJoystickEditorPlugin handles `VirtualJoystick`
55. VoxelGIEditorPlugin handles `VoxelGI`
56. SkeletonIK3DEditorPlugin handles `SkeletonIK3D`
57. Camera2DEditorPlugin handles `Camera2D`
58. CollisionPolygon2DEditorPlugin handles `CollisionPolygon2D` (AbstractPolygon2DEditorPlugin)
59. CollisionShape2DEditorPlugin handles `CollisionShape2D`
60. CPUParticles2DEditorPlugin handles `CPUParticles2D` (ParticlesEditorPlugin)
61. GPUParticles2DEditorPlugin handles `GPUParticles2D` (ParticlesEditorPlugin)
62. LightOccluder2DEditorPlugin handles `LightOccluder2D` (AbstractPolygon2DEditorPlugin)
63. Line2DEditorPlugin handles `Line2D` (AbstractPolygon2DEditorPlugin)
64. Path2DEditorPlugin handles `Path2D`
65. Polygon2DEditorPlugin handles `Polygon2D` (AbstractPolygon2DEditorPlugin)
66. Cast2DEditorPlugin handles `RayCast2D` || `ShapeCast2D`
67. Skeleton2DEditorPlugin handles `Skeleton2D`
68. Sprite2DEditorPlugin handles `Sprite2D`
69. TileSetEditorPlugin handles `TileSet`
70. TileMapEditorPlugin handles `TileMapLayer` || `TileMap` || `MultiNodeEdit` with all `TileMapLayer`s
71. ScenePaint2DEditorPlugin handles `Node2D`
72. ParallaxBackgroundEditorPlugin handles `ParallaxBackground`
73. EditorPluginCSG handles `CSGShape3D` && csg_shape->is_root_shape()
74. GDScriptLanguageServer does not handle any
75. SceneExporterGLTFPlugin does not handle any
76. GridMapEditorPlugin handles `GridMap`
77. AudioStreamInteractiveEditorPlugin does not handle any
78. MultiplayerEditorPlugin handles `MultiplayerSynchronizer`
79. NavigationLink2DEditorPlugin handles `NavigationLink2D`
80. NavigationRegion2DEditorPlugin handles `NavigationRegion2D` (AbstractPolygon2DEditorPlugin)
81. NavigationObstacle2DEditorPlugin handles `NavigationObstacle2D` (AbstractPolygon2DEditorPlugin)
82. NavigationLink3DEditorPlugin handles `NavigationLink3D`
83. NavigationRegion3DEditorPlugin handles `NavigationRegion3D` || `MultiNodeEdit` with any `NavigationRegion3D`
84. NavigationObstacle3DEditorPlugin handles `NavigationObstacle3D`
85. NoiseEditorPlugin does not handle any
86. ObjectDBProfilerPlugin does not handle any
87. OpenXREditorPlugin handles `OpenXRActionMap` && action_map_editor
88. User plugins go here

</details>

