### PR TITLE
Fix incorrect `inv_view_matrix` in double precision

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -201,6 +201,7 @@ vec3 two_sum(vec3 a, vec3 b, out vec3 out_p) {
 	return s;
 }
 
+// a + b
 vec3 double_add_vec3(vec3 base_a, vec3 prec_a, vec3 base_b, vec3 prec_b, out vec3 out_precision) {
 	vec3 s, t, se, te;
 	s = two_sum(base_a, base_b, se);
@@ -210,6 +211,11 @@ vec3 double_add_vec3(vec3 base_a, vec3 prec_a, vec3 base_b, vec3 prec_b, out vec
 	se += te;
 	s = quick_two_sum(s, se, out_precision);
 	return s;
+}
+
+// a - b
+vec3 double_sub_vec3(vec3 base_a, vec3 prec_a, vec3 base_b, vec3 prec_b, out vec3 out_precision) {
+	return double_add_vec3(base_a, prec_a, -base_b, -prec_b, out_precision);
 }
 #endif
 
@@ -249,7 +255,7 @@ void vertex_shader(vec3 vertex_input,
 			vec4(0.0, 0.0, 0.0, 1.0)));
 
 #ifdef USE_DOUBLE_PRECISION
-	vec3 view_precision = scene_data.inv_view_precision.xyz;
+	vec3 inv_view_precision = scene_data.inv_view_precision.xyz;
 #endif
 
 	mat3 model_normal_matrix;
@@ -434,7 +440,7 @@ void vertex_shader(vec3 vertex_input,
 
 	// Overwrite the translation part of modelview with improved precision.
 	vec3 temp_precision; // Will be ignored.
-	modelview[3].xyz = double_add_vec3(model_origin, model_precision, inv_view_matrix[3].xyz, view_precision, temp_precision);
+	modelview[3].xyz = double_sub_vec3(model_origin, model_precision, inv_view_matrix[3].xyz, inv_view_precision, temp_precision);
 	modelview[3].xyz = mat3(read_view_matrix) * modelview[3].xyz;
 #else
 	mat4 modelview = read_view_matrix * model_matrix;

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
@@ -93,9 +93,9 @@ void RenderSceneDataRD::update_ubo(RID p_uniform_buffer, RSE::ViewportDebugDraw 
 	RendererRD::MaterialStorage::store_transform_transposed_3x4(cam_transform.affine_inverse(), ubo.view_matrix);
 
 #ifdef REAL_T_IS_DOUBLE
-	RendererRD::MaterialStorage::split_double(-cam_transform.origin.x, &ubo.inv_view_matrix[3], &ubo.inv_view_precision[0]);
-	RendererRD::MaterialStorage::split_double(-cam_transform.origin.y, &ubo.inv_view_matrix[7], &ubo.inv_view_precision[1]);
-	RendererRD::MaterialStorage::split_double(-cam_transform.origin.z, &ubo.inv_view_matrix[11], &ubo.inv_view_precision[2]);
+	RendererRD::MaterialStorage::split_double(cam_transform.origin.x, &ubo.inv_view_matrix[3], &ubo.inv_view_precision[0]);
+	RendererRD::MaterialStorage::split_double(cam_transform.origin.y, &ubo.inv_view_matrix[7], &ubo.inv_view_precision[1]);
+	RendererRD::MaterialStorage::split_double(cam_transform.origin.z, &ubo.inv_view_matrix[11], &ubo.inv_view_precision[2]);
 #endif
 
 	for (uint32_t v = 0; v < view_count; v++) {


### PR DESCRIPTION
When building with double precision there's a few tricks used to
emulate double precision with floats only. In one instance precision
must be recovered after doing `read_view_matrix * model_matrix` so the
translation part must be recomputed as `model_origin - inv_view_origin`.
But this operation was written as `model_origin + inv_view_origin`, so
what was done before was to pass `inv_view_origin` as its negative to
the shader in `render_scene_data_rd.cpp`...

This commit removes the negation from `render_scene_data_rd.cpp` and
instead does the substraction in the shader.