### PR TITLE
2x Performance Improvement to Forward+ Auto Exposure

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/luminance_reduce.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/luminance_reduce.glsl
@@ -4,11 +4,15 @@
 
 #VERSION_DEFINES
 
-#define BLOCK_SIZE 8
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+#define BLOCK_SIZE 8u
 
 layout(local_size_x = BLOCK_SIZE, local_size_y = BLOCK_SIZE, local_size_z = 1) in;
 
 shared float tmp_data[BLOCK_SIZE * BLOCK_SIZE];
+
+shared float accumulator[BLOCK_SIZE * BLOCK_SIZE];
 
 #ifdef READ_TEXTURE
 
@@ -37,41 +41,99 @@ layout(push_constant, std430) uniform Params {
 }
 params;
 
-void main() {
-	uint t = gl_LocalInvocationID.y * BLOCK_SIZE + gl_LocalInvocationID.x;
-	ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+float sharedmem_reduction(float fetch, ivec2 pos) {
+	// Ensure that subgroup == 0 with subgroupinvocation == 0 will return summation
+	const uint subgroup_size = (BLOCK_SIZE * BLOCK_SIZE) / gl_NumSubgroups;
+	uint t = gl_SubgroupInvocationID + (gl_SubgroupID * subgroup_size);
 
-	if (any(lessThan(pos, params.source_size))) {
-#ifdef READ_TEXTURE
-		vec3 v = texelFetch(source_texture, pos, 0).rgb;
-		tmp_data[t] = max(v.r, max(v.g, v.b));
-#else
-		tmp_data[t] = imageLoad(source_luminance, pos).r;
-#endif
-	} else {
-		tmp_data[t] = 0.0;
-	}
-
-	groupMemoryBarrier();
+	tmp_data[t] = fetch;
 	barrier();
 
-	uint size = (BLOCK_SIZE * BLOCK_SIZE) >> 1;
-
-	do {
+#pragma unroll
+	for (uint size = (BLOCK_SIZE * BLOCK_SIZE) >> 1; size > 0u; size >>= 1) {
 		if (t < size) {
 			tmp_data[t] += tmp_data[t + size];
 		}
-		groupMemoryBarrier();
+		barrier();
+	}
+
+	return tmp_data[0];
+}
+
+float subgroup_reduction(float fetch, ivec2 pos) {
+	const uint subgroup_size = (BLOCK_SIZE * BLOCK_SIZE) / gl_NumSubgroups;
+
+	// Failsafe max to avoid infinite loops
+	const uint shift = uint(max(findMSB(subgroup_size), 1));
+
+	// Ensure subgroup has finished fetch before subgroup op
+	subgroupBarrier();
+	float avg_numerator = subgroupAdd(fetch);
+
+	// Shared memory fetch location ensuring group 0 fetches [0,...N-1]
+	const uint accumulate_index = gl_SubgroupInvocationID + (gl_SubgroupID * subgroup_size);
+
+	// While more than 1 group has values to share
+	for (uint remaining_size = (BLOCK_SIZE * BLOCK_SIZE) >> shift; remaining_size > 1u; remaining_size >>= shift) {
+		// Write subgroup's value to shared memory -- elect worker 0
+		if (gl_SubgroupInvocationID == 0u) {
+			accumulator[gl_SubgroupID] = avg_numerator;
+		}
+		// Wait for memory sync within workgroup
 		barrier();
 
-		size >>= 1;
-	} while (size >= 1);
+		// Zero all work items
+		avg_numerator = 0.;
+		// Read into active workitems only
+		if (accumulate_index < remaining_size) {
+			avg_numerator = accumulator[accumulate_index];
+		}
 
-	if (t == 0) {
-		//compute rect size
-		ivec2 rect_size = min(params.source_size - pos, ivec2(BLOCK_SIZE));
-		float avg = tmp_data[0] / float(rect_size.x * rect_size.y);
-		//float avg = tmp_data[0] / float(BLOCK_SIZE*BLOCK_SIZE);
+		// Wait for subgroup to finish reading
+		subgroupBarrier();
+		// Accumulate within the subgroups
+		avg_numerator = subgroupAdd(avg_numerator);
+
+		// Wait for all work items to finish read before writing
+		// to shared memory -- if necessary
+		if (remaining_size > subgroup_size) {
+			barrier();
+		}
+	}
+
+	return avg_numerator;
+}
+
+void main() {
+	ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+	float avg_numerator = 0.;
+
+	// Initialize to zero
+	float fetch = 0.;
+	// Update if active
+	if (all(lessThan(pos, params.source_size))) {
+#ifdef READ_TEXTURE
+		vec3 v = texelFetch(source_texture, pos, 0).rgb;
+		fetch = max(v.r, max(v.g, v.b));
+#else
+		fetch = imageLoad(source_luminance, pos).r;
+#endif
+	}
+
+	// Do binary tree reduction in shared memory if subgroup size is 1 or 2
+	// otherwise do register shuffle plan
+	if (gl_NumSubgroups > ((BLOCK_SIZE * BLOCK_SIZE) >> 2u)) {
+		avg_numerator = sharedmem_reduction(fetch, pos);
+	} else {
+		avg_numerator = subgroup_reduction(fetch, pos);
+	}
+
+	// Now subgroup 0 is guaranteed to have avg_numerator = sum of pixel luminances
+	if ((gl_SubgroupID == 0u) && (gl_SubgroupInvocationID == 0u)) {
+		// compute rect size w.r.t. work group corner (no guarantee worker 0 executes here)
+		ivec2 pos_0 = ivec2(gl_WorkGroupID.xy * gl_WorkGroupSize.xy);
+		ivec2 rect_size = min(params.source_size - pos_0, ivec2(BLOCK_SIZE));
+		float avg = avg_numerator / float(rect_size.x * rect_size.y);
 		pos /= ivec2(BLOCK_SIZE);
 #ifdef WRITE_LUMINANCE
 		float prev_lum = texelFetch(prev_luminance, ivec2(0, 0), 0).r; //1 pixel previous exposure


### PR DESCRIPTION
# Summary

Improved the `luminance_reduce.glsl` shader which is used in calculating Auto Exposure for cameras in the Forward+ renderer. GPU traces indicate the improved version is approximately 2x faster for three passes. Bottlenecked framerate measurements show a 25% improvement in total draw frame rate.

## Motivation

Optimizing post-processing pipelines improves Godot's ability to produce both stylized and realistic effects while still hitting target frame rates. Auto exposure creates a realistic adaptive lighting effect important in scenes with dynamic lighting by measuring the average luminance across portions of the screen.

The current implementation uses a binary tree reduction scheme to compute the average, which is an optimal parallel summation algorithm, but the reduction is performed entirely in shared memory which leaves room for improvement. With a fixed work-group size of 64, the reduction requires `log2(64)` stages, which means 6 write/read trips to shared memory in the current scheme.

The `GL_KHR_shader_subgroup_arithmetic` extension provides `subgroupAdd`, which allows stages of the reduction to be computed with register shuffles. Register shuffles are approximately 5~10x faster than shared memory, allowing for significant reductions in cache waits.

Shared memory is still needed to synchronize between subgroups, but only need `[log2(64)/log2(subgroupSize)] - 1` write/read trips are required. This corresponds to 0 trips for AMD, and 1 for most other major manufacturers (any device with `subgroupSize` > 4), which moves the shader bottleneck to the initial texture fetch.

## Changes

- Moved current implementation to `sharedmem_reduction()` as fallback behavior for `subgroupSize` < 4
- Created alternative subgroup implementation `subgroup_reduction()`
- Shader selects plan based on workgroup level `gl_NumSubgroups` to avoid group divergence

**NOTE:** For subgroup sizes of 2 `subgroup_reduction()` reduces to the original algorithm but with unnecessary barriers, and subgroup sizes of 1 would cause infinte loops so a defensive `max(shift, 1u)` is used for the loop iteration. These cases necessitate preserving `sharedmem_reduction()` as an alternative route.

## Accuracy

The resulting algorithm produces identical results up to floating point precision. Comparison of visual outputs using the [Physical Light Camera Units demo](https://github.com/godotengine/godot-demo-projects/tree/master/3d/physical_light_camera_units) are shown below.

### Current Output

<img width="1152" height="648" alt="new_shader_output" src="https://github.com/user-attachments/assets/6948d5fd-873c-4277-9c5b-067b7af6599e" />

### Output this PR

<img width="1152" height="648" alt="old_shader_output" src="https://github.com/user-attachments/assets/cf758a62-d399-46d0-b651-a4abfb5342aa" />


## Benchmarks

Benchmarks were performed on an NVIDIA 3080 Ti. Using NSIGHT Graphics, traces of the shader indicated roughly 2x overall improvement for 3 passes of 4K viewport.

|Shader Pass|Current time (μs)|New time (μs)|
|-|-|-|
|0|304.2|140.8|
|1|13.6|11.3|
|2|6.1|5.1|
|**Total**|**324.0**|**157.2**|

Additionally a small project was created to record FPS statistics of a 4K Viewport with autoexposure, with V-Sync disabled and uncapped framerates.

Godot project and comparison of the measurements are below.

[stress_test.tar.gz](https://github.com/user-attachments/files/26331199/stress_test.tar.gz)

<img width="50%" alt="fps_comparison" src="https://github.com/user-attachments/assets/b4508f7e-06ab-405f-ba05-73e4b84fe5e9" />


## Verified Compatibilities

- **Hardware**
  - Nvidia
- **OS**
  - Linux
  - Windows
- **Drivers**
  - Vulkan
  - D3D12

## Notes

- The change is isolated to `servers/rendering/renderer_rd/shaders/effects/luminance_reduce.glsl`
- This only affects the Forward+ renderer
- No AI was used to develop this code
