### PR TITLE
Fix frozen kinematic RigidBody3D notifying children of unchanged transform

### DIFF
--- a/scene/3d/physics/rigid_body_3d.cpp
+++ b/scene/3d/physics/rigid_body_3d.cpp
@@ -147,9 +147,11 @@ struct _RigidBodyInOut {
 };
 
 void RigidBody3D::_sync_body_state(PhysicsDirectBodyState3D *p_state) {
-	set_ignore_transform_notification(true);
-	set_global_transform(p_state->get_transform());
-	set_ignore_transform_notification(false);
+	if (!get_global_transform().is_equal_approx(p_state->get_transform())) {
+		set_ignore_transform_notification(true);
+		set_global_transform(p_state->get_transform());
+		set_ignore_transform_notification(false);
+	}
 
 	linear_velocity = p_state->get_linear_velocity();
 	angular_velocity = p_state->get_angular_velocity();

--- a/scene/3d/physics/rigid_body_3d.cpp
+++ b/scene/3d/physics/rigid_body_3d.cpp
@@ -147,7 +147,7 @@ struct _RigidBodyInOut {
 };
 
 void RigidBody3D::_sync_body_state(PhysicsDirectBodyState3D *p_state) {
-	if (!get_global_transform().is_equal_approx(p_state->get_transform())) {
+	if (!freeze || freeze_mode != FREEZE_MODE_KINEMATIC) {
 		set_ignore_transform_notification(true);
 		set_global_transform(p_state->get_transform());
 		set_ignore_transform_notification(false);


### PR DESCRIPTION
Fixes #117852.

When a `RigidBody3D` is frozen in kinematic mode, `_sync_body_state` is still called every physics frame. Previously, it unconditionally called `set_global_transform()`, which triggers `NOTIFICATION_TRANSFORM_CHANGED` on all children — even when the transform hasn't actually changed.

This adds a freeze-mode guard to skip the `set_global_transform()` call when the body is frozen in kinematic mode, matching the pattern already used in `RigidBody2D::_sync_body_state`.

---

**AI disclosure:** AI tooling (Claude Code) was used to assist with writing and reviewing the code. All modifications were reviewed and tested by the author.