### PR TITLE
GDScript: Improve error message for static/non-static function conflicts

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -298,6 +298,15 @@ Error GDScriptAnalyzer::check_class_member_name_conflict(const GDScriptParser::C
 			if (current_class_node->identifier != nullptr) {
 				parent_class_name = current_class_node->identifier->name;
 			}
+			// Provide a more specific error when the conflict involves a static function.
+			if (current_class_node->members_indices.has(p_member_name)) {
+				int index = current_class_node->members_indices[p_member_name];
+				const GDScriptParser::ClassNode::Member &member = current_class_node->members[index];
+				if (member.type == GDScriptParser::ClassNode::Member::FUNCTION && member.function->is_static) {
+					push_error(vformat(R"(The member "%s" already exists in parent class %s as a static function.)", p_member_name, parent_class_name), p_member_node);
+					return ERR_PARSE_ERROR;
+				}
+			}
 			push_error(vformat(R"(The member "%s" already exists in parent class %s.)", p_member_name, parent_class_name), p_member_node);
 			return ERR_PARSE_ERROR;
 		}
@@ -1873,7 +1882,8 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 		BitField<MethodFlags> method_flags = {};
 		StringName native_base;
 		if (!p_is_lambda && get_function_signature(p_function, false, base_type, function_name, parent_return_type, parameters_types, default_par_count, method_flags, &native_base)) {
-			bool valid = p_function->is_static == method_flags.has_flag(METHOD_FLAG_STATIC);
+			bool is_static_match = p_function->is_static == method_flags.has_flag(METHOD_FLAG_STATIC);
+			bool valid = is_static_match;
 
 			if (p_function->return_type == nullptr) {
 				p_function->set_datatype(parent_return_type);
@@ -1923,40 +1933,49 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 			}
 
 			if (!valid) {
-				// Compute parent signature as a string to show in the error message.
-				String parent_signature = String(function_name) + "(";
-				int j = 0;
-				for (const GDScriptParser::DataType &par_type : parameters_types) {
-					if (j > 0) {
-						parent_signature += ", ";
+				if (!is_static_match) {
+					// The mismatch is due to a static/non-static conflict.
+					if (method_flags.has_flag(METHOD_FLAG_STATIC)) {
+						push_error(vformat(R"(The function "%s" is not static, but the parent function of the same name is static. A static function cannot be overridden with a non-static function.)", function_name), p_function);
+					} else {
+						push_error(vformat(R"(The function "%s" is static, but the parent function of the same name is not static. A non-static function cannot be overridden with a static function.)", function_name), p_function);
 					}
-					String parameter = par_type.to_string();
-					if (parameter == "null") {
-						parameter = "Variant";
-					}
-					parent_signature += parameter;
-					if (j >= parameters_types.size() - default_par_count) {
-						parent_signature += " = <default>";
-					}
-
-					j++;
-				}
-				if (method_flags & METHOD_FLAG_VARARG) {
-					if (!parameters_types.is_empty()) {
-						parent_signature += ", ";
-					}
-					parent_signature += "...";
-				}
-				parent_signature += ") -> ";
-
-				const String return_type = parent_return_type.to_string_strict();
-				if (return_type == "null") {
-					parent_signature += "void";
 				} else {
-					parent_signature += return_type;
-				}
+					// Compute parent signature as a string to show in the error message.
+					String parent_signature = String(function_name) + "(";
+					int j = 0;
+					for (const GDScriptParser::DataType &par_type : parameters_types) {
+						if (j > 0) {
+							parent_signature += ", ";
+						}
+						String parameter = par_type.to_string();
+						if (parameter == "null") {
+							parameter = "Variant";
+						}
+						parent_signature += parameter;
+						if (j >= parameters_types.size() - default_par_count) {
+							parent_signature += " = <default>";
+						}
 
-				push_error(vformat(R"(The function signature doesn't match the parent. Parent signature is "%s".)", parent_signature), p_function);
+						j++;
+					}
+					if (method_flags & METHOD_FLAG_VARARG) {
+						if (!parameters_types.is_empty()) {
+							parent_signature += ", ";
+						}
+						parent_signature += "...";
+					}
+					parent_signature += ") -> ";
+
+					const String return_type = parent_return_type.to_string_strict();
+					if (return_type == "null") {
+						parent_signature += "void";
+					} else {
+						parent_signature += return_type;
+					}
+
+					push_error(vformat(R"(The function signature doesn't match the parent. Parent signature is "%s".)", parent_signature), p_function);
+				}
 			}
 #ifdef DEBUG_ENABLED
 			if (native_base != StringName()) {

--- a/modules/gdscript/tests/scripts/analyzer/errors/override_non_static_function_with_static.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/override_non_static_function_with_static.gd
@@ -1,0 +1,12 @@
+# GH-117912
+
+class A:
+	func my_function() -> void:
+		pass
+
+class B extends A:
+	static func my_function() -> void:
+		pass
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/override_non_static_function_with_static.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/override_non_static_function_with_static.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 8: The function "my_function" is static, but the parent function of the same name is not static. A non-static function cannot be overridden with a static function.

--- a/modules/gdscript/tests/scripts/analyzer/errors/override_static_function_with_non_static.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/override_static_function_with_non_static.gd
@@ -1,0 +1,12 @@
+# GH-117912
+
+class A:
+	static func my_function() -> void:
+		pass
+
+class B extends A:
+	func my_function() -> void:
+		pass
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/override_static_function_with_non_static.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/override_static_function_with_non_static.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 8: The function "my_function" is not static, but the parent function of the same name is static. A static function cannot be overridden with a non-static function.

--- a/modules/gdscript/tests/scripts/analyzer/errors/variable_overloads_superclass_static_function.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/variable_overloads_superclass_static_function.gd
@@ -1,0 +1,11 @@
+# GH-117912
+
+class A:
+	static func overload_me() -> void:
+		pass
+
+class B extends A:
+	var overload_me
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/variable_overloads_superclass_static_function.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/variable_overloads_superclass_static_function.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 8: The member "overload_me" already exists in parent class A as a static function.


### PR DESCRIPTION
Fixes #117912.

When a child class defines a function with the same name as a parent's static function (or vice versa), the error messages were not specific enough about the static/non-static mismatch.

**Changes:**

1. In `check_class_member_name_conflict`: When a member name conflicts with a parent class's static function, the error now says `The member "X" already exists in parent class Y as a static function.` instead of the generic `The member "X" already exists in parent class Y.`

2. In `resolve_function_signature`: Split the validation into two cases:
   - **Static mismatch**: Shows a specific error like `The function "X" is not static, but the parent function of the same name is static.`
   - **Signature mismatch**: Shows the existing signature comparison error (unchanged behavior).

<details>
<summary>Before</summary>

```
# Case 1: Child non-static overrides parent static
ERROR at line 8: The function signature doesn't match the parent. Parent signature is "my_function() -> void".

# Case 2: Variable overloads parent static function
ERROR at line 8: The member "overload_me" already exists in parent class A.
```

</details>

<details>
<summary>After</summary>

```
# Case 1: Child non-static overrides parent static
ERROR at line 8: The function "my_function" is not static, but the parent function of the same name is static. A static function cannot be overridden with a non-static function.

# Case 2: Child static overrides parent non-static
ERROR at line 8: The function "my_function" is static, but the parent function of the same name is not static. A non-static function cannot be overridden with a static function.

# Case 3: Variable overloads parent static function
ERROR at line 8: The member "overload_me" already exists in parent class A as a static function.
```

</details>

**Tests added:**
- `override_static_function_with_non_static.gd/.out`
- `override_non_static_function_with_static.gd/.out`
- `variable_overloads_superclass_static_function.gd/.out`

---

**AI disclosure:** AI tooling (Claude Code) was used to assist with writing and reviewing the code. All modifications were reviewed and tested by the author.