### PR TITLE
Support Commit Amends

### DIFF
--- a/doc/classes/EditorVCSInterface.xml
+++ b/doc/classes/EditorVCSInterface.xml
@@ -10,6 +10,12 @@
 		<link title="Version control systems">$DOCS_URL/tutorials/best_practices/version_control_systems.html</link>
 	</tutorials>
 	<methods>
+		<method name="_allow_amends" qualifiers="virtual">
+			<return type="bool" />
+			<description>
+				Returns whether or not the plugin allows commit amends.
+			</description>
+		</method>
 		<method name="_checkout_branch" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="branch_name" type="String" />
@@ -17,11 +23,12 @@
 				Checks out a [param branch_name] in the VCS.
 			</description>
 		</method>
-		<method name="_commit" qualifiers="virtual required">
+		<method name="_commit" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="msg" type="String" />
+			<param index="1" name="amend" type="bool" />
 			<description>
-				Commits the currently staged changes and applies the commit [param msg] to the resulting commit.
+				Commits the currently staged changes and applies the commit [param msg] to the resulting commit. If [param amend] is [code]true[/code] the commit will modify the most recent commit instead.
 			</description>
 		</method>
 		<method name="_create_branch" qualifiers="virtual required">

--- a/editor/version_control/editor_vcs_interface.cpp
+++ b/editor/version_control/editor_vcs_interface.cpp
@@ -88,8 +88,24 @@ void EditorVCSInterface::discard_file(const String &p_file_path) {
 	GDVIRTUAL_CALL(_discard_file, p_file_path);
 }
 
-void EditorVCSInterface::commit(const String &p_msg) {
-	GDVIRTUAL_CALL(_commit, p_msg);
+void EditorVCSInterface::commit(const String &p_msg, bool p_amend) {
+	if (GDVIRTUAL_CALL(_commit, p_msg, p_amend)) {
+		return;
+	}
+
+#ifndef DISABLE_DEPRECATED
+	if (GDVIRTUAL_CALL(_commit_bind_compat_117968, p_msg)) {
+		return;
+	}
+#endif
+
+	ERR_PRINT_ONCE("Required virtual method " + get_class() + "::_commit must be overridden before calling.");
+}
+
+bool EditorVCSInterface::allow_amends() {
+	bool result = false;
+	GDVIRTUAL_CALL(_allow_amends, result);
+	return result;
 }
 
 List<EditorVCSInterface::DiffFile> EditorVCSInterface::get_diff(const String &p_identifier, TreeArea p_area) {
@@ -313,7 +329,8 @@ void EditorVCSInterface::_bind_methods() {
 	GDVIRTUAL_BIND(_stage_file, "file_path");
 	GDVIRTUAL_BIND(_unstage_file, "file_path");
 	GDVIRTUAL_BIND(_discard_file, "file_path");
-	GDVIRTUAL_BIND(_commit, "msg");
+	GDVIRTUAL_BIND(_commit, "msg", "amend");
+	GDVIRTUAL_BIND(_allow_amends);
 	GDVIRTUAL_BIND(_get_diff, "identifier", "area");
 	GDVIRTUAL_BIND(_shut_down);
 	GDVIRTUAL_BIND(_get_vcs_name);
@@ -330,6 +347,10 @@ void EditorVCSInterface::_bind_methods() {
 	GDVIRTUAL_BIND(_push, "remote", "force");
 	GDVIRTUAL_BIND(_fetch, "remote");
 	GDVIRTUAL_BIND(_get_line_diff, "file_path", "text");
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND_COMPAT(_commit_bind_compat_117968, "msg");
+#endif
 
 	ClassDB::bind_method(D_METHOD("create_diff_line", "new_line_no", "old_line_no", "content", "status"), &EditorVCSInterface::create_diff_line);
 	ClassDB::bind_method(D_METHOD("create_diff_hunk", "old_start", "new_start", "old_lines", "new_lines"), &EditorVCSInterface::create_diff_hunk);

--- a/editor/version_control/editor_vcs_interface.h
+++ b/editor/version_control/editor_vcs_interface.h
@@ -109,7 +109,8 @@ protected:
 	GDVIRTUAL1_REQUIRED(_stage_file, String);
 	GDVIRTUAL1_REQUIRED(_unstage_file, String);
 	GDVIRTUAL1_REQUIRED(_discard_file, String);
-	GDVIRTUAL1_REQUIRED(_commit, String);
+	GDVIRTUAL2(_commit, String, bool);
+	GDVIRTUAL0R(bool, _allow_amends);
 	GDVIRTUAL2R_REQUIRED(TypedArray<Dictionary>, _get_diff, String, int);
 	GDVIRTUAL0R_REQUIRED(bool, _shut_down);
 	GDVIRTUAL0R_REQUIRED(String, _get_vcs_name);
@@ -126,6 +127,10 @@ protected:
 	GDVIRTUAL2_REQUIRED(_push, String, bool);
 	GDVIRTUAL1_REQUIRED(_fetch, String);
 	GDVIRTUAL2R_REQUIRED(TypedArray<Dictionary>, _get_line_diff, String, String);
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL1_COMPAT(_commit_bind_compat_117968, _commit, String);
+#endif
 
 public:
 	static EditorVCSInterface *get_singleton();
@@ -144,7 +149,8 @@ public:
 	void stage_file(const String &p_file_path);
 	void unstage_file(const String &p_file_path);
 	void discard_file(const String &p_file_path);
-	void commit(const String &p_msg);
+	void commit(const String &p_msg, bool p_amend);
+	bool allow_amends();
 	List<DiffFile> get_diff(const String &p_identifier, TreeArea p_area);
 	bool shut_down();
 	String get_vcs_name();

--- a/editor/version_control/version_control_editor_plugin.cpp
+++ b/editor/version_control/version_control_editor_plugin.cpp
@@ -204,6 +204,8 @@ bool VersionControlEditorPlugin::_load_plugin(const String &p_name) {
 	_refresh_branch_list();
 	_refresh_remote_list();
 
+	toggle_amend_commit->set_visible(EditorVCSInterface::get_singleton()->allow_amends());
+
 	return true;
 }
 
@@ -280,6 +282,17 @@ void VersionControlEditorPlugin::_refresh_commit_list() {
 		item->set_text(1, commit.author.strip_edges());
 		item->set_metadata(0, meta_data);
 	}
+
+	toggle_amend_commit->set_disabled(commit_info_list.size() == 0);
+
+	if (commit_info_list.size() > 0) {
+		amend_commit_message = commit_info_list.get(0).msg;
+		if (toggle_amend_commit->is_pressed()) {
+			commit_message->set_text(amend_commit_message);
+		}
+	} else {
+		amend_commit_message = "";
+	}
 }
 
 void VersionControlEditorPlugin::_refresh_remote_list() {
@@ -310,7 +323,7 @@ void VersionControlEditorPlugin::_commit() {
 
 	ERR_FAIL_COND_MSG(msg.is_empty(), "No commit message was provided.");
 
-	EditorVCSInterface::get_singleton()->commit(msg);
+	EditorVCSInterface::get_singleton()->commit(msg, toggle_amend_commit->is_pressed());
 
 	if (version_control_dock->get_current_layout() == EditorDock::DOCK_LAYOUT_HORIZONTAL) {
 		version_control_dock->hide();
@@ -318,12 +331,25 @@ void VersionControlEditorPlugin::_commit() {
 
 	commit_message->release_focus();
 	commit_button->release_focus();
+	toggle_amend_commit->set_pressed_no_signal(false);
 	commit_message->set_text("");
+	previous_commit_message = "";
 
 	_refresh_stage_area();
 	_refresh_commit_list();
 	_refresh_branch_list();
 	_clear_diff();
+}
+
+void VersionControlEditorPlugin::_toggle_amend_commit(bool p_toggled) {
+	if (p_toggled) {
+		previous_commit_message = commit_message->get_text();
+		commit_message->set_text(amend_commit_message);
+	} else {
+		commit_message->set_text(previous_commit_message);
+		previous_commit_message = "";
+	}
+	_update_commit_button();
 }
 
 void VersionControlEditorPlugin::_branch_item_selected(int p_index) {
@@ -840,6 +866,11 @@ void VersionControlEditorPlugin::_display_diff_unified_view(List<EditorVCSInterf
 
 void VersionControlEditorPlugin::_update_commit_button() {
 	commit_button->set_disabled(commit_message->get_text().strip_edges().is_empty());
+	if (toggle_amend_commit->is_pressed()) {
+		commit_button->set_text(TTR("Amend Commit Changes"));
+	} else {
+		commit_button->set_text(TTR("Commit Changes"));
+	}
 }
 
 void VersionControlEditorPlugin::_remove_branch() {
@@ -1309,11 +1340,21 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	ED_SHORTCUT("version_control/commit", TTRC("Commit"), KeyModifierMask::CMD_OR_CTRL | Key::ENTER);
 
+	HBoxContainer *hbox = memnew(HBoxContainer);
+	commit_area->add_child(hbox);
+
 	commit_button = memnew(Button);
+	commit_button->set_h_size_flags(Tree::SIZE_EXPAND_FILL);
 	commit_button->set_text(TTR("Commit Changes"));
 	commit_button->set_disabled(true);
 	commit_button->connect(SceneStringName(pressed), callable_mp(this, &VersionControlEditorPlugin::_commit));
-	commit_area->add_child(commit_button);
+	hbox->add_child(commit_button);
+
+	toggle_amend_commit = memnew(CheckButton);
+	toggle_amend_commit->set_text(TTR("Amend"));
+	toggle_amend_commit->set_pressed_no_signal(false);
+	toggle_amend_commit->connect(SceneStringName(toggled), callable_mp(this, &VersionControlEditorPlugin::_toggle_amend_commit));
+	hbox->add_child(toggle_amend_commit);
 
 	dock_vb->add_child(memnew(HSeparator));
 

--- a/editor/version_control/version_control_editor_plugin.h
+++ b/editor/version_control/version_control_editor_plugin.h
@@ -130,6 +130,10 @@ private:
 	Button *refresh_button = nullptr;
 	TextEdit *commit_message = nullptr;
 	Button *commit_button = nullptr;
+	CheckButton *toggle_amend_commit = nullptr;
+
+	String amend_commit_message;
+	String previous_commit_message;
 
 	EditorDock *version_control_dock = nullptr;
 	Label *diff_title = nullptr;
@@ -158,6 +162,7 @@ private:
 	void _force_push();
 	void _fetch();
 	void _commit();
+	void _toggle_amend_commit(bool p_toggled);
 	void _confirm_discard_all();
 	void _discard_all();
 	void _refresh_stage_area();

--- a/misc/extension_api_validation/4.6-stable/GH-117968.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-117968.txt
@@ -1,0 +1,5 @@
+GH-117968
+---------
+Validate extension JSON: Error: Field 'classes/EditorVCSInterface/methods/_commit/arguments': size changed value in new API, from 1 to 2.
+
+Added "amend" parameter. Compatibility method registered.


### PR DESCRIPTION
This PR adds support for Commit Amends for Editor VCS.

Related Git Plugin PR: https://github.com/godotengine/godot-git-plugin/pull/323