### PR TITLE
Make ResourceFormatDDS infer the actual texture type from a file's data

### DIFF
--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -488,9 +488,9 @@ static Ref<Resource> _dds_create_texture_from_images(const Vector<Ref<Image>> &p
 	return _dds_create_texture(p_images, p_dds_type, p_width, p_height, p_layer_count, p_mipmaps, r_error);
 }
 
-static Vector<Ref<Image>> _dds_load_images_from_buffer(Ref<FileAccess> p_f, DDSFormat &r_dds_format, uint32_t &r_width, uint32_t &r_height, uint32_t &r_mipmaps, uint32_t &r_pitch, uint32_t &r_flags, uint32_t &r_layer_count, uint32_t &r_dds_type, const String &p_path = "") {
-	ERR_FAIL_COND_V_MSG(p_f.is_null(), Vector<Ref<Image>>(), vformat("Empty DDS texture file."));
-	ERR_FAIL_COND_V_MSG(!p_f->get_length(), Vector<Ref<Image>>(), vformat("Empty DDS texture file."));
+static Error _dds_read_header(Ref<FileAccess> p_f, DDSFormat &r_dds_format, uint32_t &r_width, uint32_t &r_height, uint32_t &r_mipmaps, uint32_t &r_pitch, uint32_t &r_flags, uint32_t &r_layer_count, uint32_t &r_dds_type, const String &p_path = "") {
+	ERR_FAIL_COND_V_MSG(p_f.is_null(), ERR_FILE_CANT_OPEN, vformat("Empty DDS texture file."));
+	ERR_FAIL_COND_V_MSG(!p_f->get_length(), ERR_FILE_CANT_OPEN, vformat("Empty DDS texture file."));
 
 	uint32_t magic = p_f->get_32();
 	uint32_t hsize = p_f->get_32();
@@ -510,7 +510,7 @@ static Vector<Ref<Image>> _dds_load_images_from_buffer(Ref<FileAccess> p_f, DDSF
 	// We don't check DDSD_CAPS or DDSD_PIXELFORMAT, as they're mandatory when writing,
 	// but non-mandatory when reading (as some writers don't set them).
 	if (magic != DDS_MAGIC || hsize != 124) {
-		ERR_FAIL_V_MSG(Vector<Ref<Image>>(), vformat("Invalid or unsupported DDS texture file '%s'.", p_path));
+		ERR_FAIL_V_MSG(ERR_UNAVAILABLE, vformat("Invalid or unsupported DDS texture file '%s'.", p_path));
 	}
 
 	/* uint32_t format_size = */ p_f->get_32();
@@ -613,7 +613,7 @@ static Vector<Ref<Image>> _dds_load_images_from_buffer(Ref<FileAccess> p_f, DDSF
 			} break;
 
 			default: {
-				ERR_FAIL_V_MSG(Vector<Ref<Image>>(), vformat("Unrecognized or unsupported FourCC in DDS '%s'.", p_path));
+				ERR_FAIL_V_MSG(ERR_UNAVAILABLE, vformat("Unrecognized or unsupported FourCC in DDS '%s'.", p_path));
 			}
 		}
 
@@ -693,11 +693,19 @@ static Vector<Ref<Image>> _dds_load_images_from_buffer(Ref<FileAccess> p_f, DDSF
 
 	// No format detected, error.
 	if (r_dds_format == DDS_MAX) {
-		ERR_FAIL_V_MSG(Vector<Ref<Image>>(), vformat("Unrecognized or unsupported color layout in DDS '%s'.", p_path));
+		ERR_FAIL_V_MSG(ERR_UNAVAILABLE, vformat("Unrecognized or unsupported color layout in DDS '%s'.", p_path));
 	}
 
 	if (!(r_flags & DDSD_MIPMAPCOUNT)) {
 		r_mipmaps = 1;
+	}
+
+	return OK;
+}
+
+static Vector<Ref<Image>> _dds_load_images_from_buffer(Ref<FileAccess> p_f, DDSFormat &r_dds_format, uint32_t &r_width, uint32_t &r_height, uint32_t &r_mipmaps, uint32_t &r_pitch, uint32_t &r_flags, uint32_t &r_layer_count, uint32_t &r_dds_type, const String &p_path = "") {
+	if (_dds_read_header(p_f, r_dds_format, r_width, r_height, r_mipmaps, r_pitch, r_flags, r_layer_count, r_dds_type, p_path) != OK) {
+		return Vector<Ref<Image>>();
 	}
 
 	return _dds_load_images(p_f, r_dds_format, r_width, r_height, r_mipmaps, r_pitch, r_flags, r_layer_count);
@@ -742,10 +750,43 @@ bool ResourceFormatDDS::handles_type(const String &p_type) const {
 }
 
 String ResourceFormatDDS::get_resource_type(const String &p_path) const {
-	if (p_path.has_extension("dds")) {
-		return "Texture";
+	if (!p_path.has_extension("dds")) {
+		return "";
 	}
-	return "";
+
+	Ref<FileAccess> dds_file = FileAccess::open(p_path, FileAccess::READ);
+	if (dds_file.is_null()) {
+		return "";
+	}
+
+	DDSFormat format;
+	uint32_t width;
+	uint32_t height;
+	uint32_t mipmaps;
+	uint32_t pitch;
+	uint32_t flags;
+	uint32_t layer_count;
+	uint32_t type;
+
+	if (_dds_read_header(dds_file, format, width, height, mipmaps, pitch, flags, layer_count, type) != OK) {
+		return "";
+	}
+
+	switch (type) {
+		case DDST_2D:
+			return "ImageTexture";
+		case DDST_2D | DDST_ARRAY:
+			return "Texture2DArray";
+		case DDST_CUBEMAP:
+			return "Cubemap";
+		case DDST_CUBEMAP | DDST_ARRAY:
+			return "CubemapArray";
+		case DDST_3D:
+			return "ImageTexture3D";
+
+		default:
+			return "Texture";
+	}
 }
 
 Ref<Image> load_mem_dds(const uint8_t *p_dds, int p_size) {


### PR DESCRIPTION
Inspired by #114125

At the moment, the .dds loader gets the resource type string based on the extension. As a result, all .dds files are internally treated as the base class `Texture`, so it can support all the subtypes. This, however, meant that features such as quick search or the filesystem resource type display would not function correctly with these files.

This change makes the engine open the texture files to quickly parse their header information in order to properly deduce their specific type. This is already done in `ResourceFormatLoaderText` and `ResourceFormatLoaderBinary`, since these loaders were designed to handle miscellaneous resource types.