### PR TITLE
Fix property drag activating from inspector preview widgets

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1287,6 +1287,16 @@ Variant EditorProperty::get_drag_data(const Point2 &p_point) {
 		return Variant();
 	}
 
+	// Only allow dragging from the property label area, not from child controls
+	// like mesh/material previews.
+	if (bottom_child_rect.has_point(p_point)) {
+		return Variant();
+	}
+	real_t label_x = is_layout_rtl() ? get_size().x - p_point.x : p_point.x;
+	if (label_x > text_size) {
+		return Variant();
+	}
+
 	Dictionary dp;
 	dp["type"] = "obj_property";
 	dp["object"] = object;


### PR DESCRIPTION
When clicking and dragging inside a 3D preview (mesh or material) in the inspector, `EditorProperty::get_drag_data()` unconditionally initiates a property name drag. This causes a "forbidden" cursor to appear and the property label to be visually selected, even though the user is interacting with the preview widget.

This adds bounds checks in `get_drag_data()` to reject drags that originate inside `bottom_child_rect` (the preview/bottom editor area) or to the right of the property label text (the content/value area).

**Steps to reproduce (before fix):**
1. Add a `MeshInstance3D` node and assign any mesh (e.g. `BoxMesh`)
2. In the inspector, click the mesh resource to expand it
3. Click and drag inside the 3D mesh preview
4. Observe: the "Mesh" property label gets selected and a forbidden cursor appears

**After fix:** Dragging inside the preview only rotates the mesh, as expected. Dragging the property label still works normally.