### PR TITLE
Prioritize exact filename start matches in fuzzy search

### DIFF
--- a/core/string/fuzzy_search.cpp
+++ b/core/string/fuzzy_search.cpp
@@ -50,7 +50,7 @@ static Vector2i _extend_interval(const Vector2i &p_a, const Vector2i &p_b) {
 }
 
 static bool _is_word_boundary(const String &p_str, int p_index) {
-	if (p_index == -1 || p_index == p_str.size()) {
+	if (p_index == -1 || p_index == p_str.length()) {
 		return true;
 	}
 	return boundary_chars.find_char(p_str[p_index]) != -1;
@@ -73,7 +73,7 @@ bool FuzzySearchToken::try_fuzzy_match(FuzzyTokenMatch &p_match, const String &p
 	int run_start = -1;
 	int run_len = 0;
 
-	// Search for the subsequence p_token in p_target starting from p_offset, recording each substring for
+	// Search for the subsequence string in p_target starting from p_offset, recording each substring for
 	// later scoring and display.
 	for (int i = 0; i < string.length(); i++) {
 		int new_offset = p_target.find_char(string[i], p_offset);
@@ -155,14 +155,18 @@ void FuzzySearchResult::score_token_match(FuzzyTokenMatch &p_match, bool p_case_
 	p_match.score = -20 * p_match.get_miss_count() - (p_case_insensitive ? 3 : 0);
 
 	for (const Vector2i &substring : p_match.substrings) {
-		// Score longer substrings higher than short substrings.
+		// Score longer substrings higher than short substrings
 		int substring_score = substring.y * substring.y;
-		// Score matches deeper in path higher than shallower matches
+		// Score matches in the filename higher than those earlier in the path
 		if (substring.x > dir_index) {
 			substring_score *= 2;
 		}
 		// Score matches on a word boundary higher than matches within a word
 		if (_is_word_boundary(target, substring.x - 1) || _is_word_boundary(target, substring.x + substring.y)) {
+			substring_score += 4;
+		}
+		// Score matches on filename start higher than matches later in filename
+		if (substring.x - 1 == dir_index) {
 			substring_score += 4;
 		}
 		// Score exact query matches higher than non-compact subsequence matches

--- a/tests/core/string/test_fuzzy_search.cpp
+++ b/tests/core/string/test_fuzzy_search.cpp
@@ -46,7 +46,7 @@ struct FuzzySearchTestCase {
 // Ideally each of these test queries should represent a different aspect, and potentially bottleneck, of the search process.
 const FuzzySearchTestCase test_cases[] = {
 	// Short query, many matches, few adjacent characters
-	{ "///gd", "./menu/hud/hud.gd" },
+	{ "///gd", "./menu/menu/characters/dead_guy/dead_guy.gd" },
 	// Filename match with typo
 	{ "sm.png", "./entity/blood_sword/sam.png" },
 	// Multipart filename word matches
@@ -58,7 +58,19 @@ const FuzzySearchTestCase test_cases[] = {
 	// Many matches, many short tokens
 	{ "menu menu characters wav", "./menu/menu/characters/smoker/0.wav" },
 	// Maximize total matches
-	{ "entity gd", "./entity/entity_man.gd" }
+	{ "entity gd", "./entity/entity_man.gd" },
+	// End of filename bonus (vs ".menu/widgets/toggle.gd")
+	{ "gg", "./entity/background_freighter/Master.ogg" },
+	// Exact filename start beats exact word boundary in the filename of a shorter path
+	{ "fallback", "./menu/fonts/fallback_font.tres" },
+	// Incomplete exact word at filename start beats exact complete word later in filename
+	{ "me", "./menu/metal_text.tres" },
+	// Exact word boundary in middle of a filename beats exact dirname start
+	{ "floor", "./entity/background_freighter/background/background_floor.png" },
+	// Exact match beats inexact filename start match (vs "./entity/background_zone_2/background/wall_overlay.png")
+	{ "wor", "./entity/blood_sword/data.gd" },
+	// Match starting on filename beats match later in filename (vs "./menu/ui_colors.tres")
+	{ "colo.tres", "./menu/menu/characters/color.tres" }
 };
 
 Vector<String> load_test_data() {


### PR DESCRIPTION
Fixes #103563.

Fuzzy search tokens that exactly match the beginning of a filename get a score bonus, so that e.g. searching for `menu` causes this priority order:

```
res://deep/nested/path/menu.gd
res://pause_menu.gd
```

rather than the reverse.