### PR TITLE
Allow narrowed type hints to show from compound boolean expressions

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2243,11 +2243,55 @@ void GDScriptAnalyzer::resolve_parameter(GDScriptParser::ParameterNode *p_parame
 	resolve_assignable(p_parameter, kind);
 }
 
+void GDScriptAnalyzer::extract_type_tests(GDScriptParser::ExpressionNode *p_expression, HashMap<StringName, GDScriptParser::DataType> &r_overrides) {
+	if (p_expression == nullptr) {
+		return;
+	}
+
+	if (p_expression->type == GDScriptParser::Node::BINARY_OPERATOR) {
+		GDScriptParser::BinaryOpNode *binary_op = static_cast<GDScriptParser::BinaryOpNode *>(p_expression);
+		if (binary_op->variant_op == Variant::OP_AND) {
+			extract_type_tests(binary_op->left_operand, r_overrides);
+			extract_type_tests(binary_op->right_operand, r_overrides);
+			return;
+		}
+	}
+
+	if (p_expression->type == GDScriptParser::Node::TYPE_TEST) {
+		GDScriptParser::TypeTestNode *type_test = static_cast<GDScriptParser::TypeTestNode *>(p_expression);
+		if (type_test->operand && type_test->operand->type == GDScriptParser::Node::IDENTIFIER) {
+			GDScriptParser::IdentifierNode *identifier = static_cast<GDScriptParser::IdentifierNode *>(type_test->operand);
+			if (type_test->test_datatype.is_set()) {
+				r_overrides[identifier->name] = type_test->test_datatype;
+			}
+		}
+	}
+}
+
 void GDScriptAnalyzer::resolve_if(GDScriptParser::IfNode *p_if) {
 	reduce_expression(p_if->condition);
 
+	HashMap<StringName, GDScriptParser::DataType> narrowed;
+	extract_type_tests(p_if->condition, narrowed);
+
+	HashMap<StringName, GDScriptParser::DataType> saved;
+	for (const KeyValue<StringName, GDScriptParser::DataType> &kv : narrowed) {
+		if (type_overrides.has(kv.key)) {
+			saved[kv.key] = type_overrides[kv.key];
+		}
+		type_overrides[kv.key] = kv.value;
+	}
+
 	resolve_suite(p_if->true_block);
 	p_if->set_datatype(p_if->true_block->get_datatype());
+
+	for (const KeyValue<StringName, GDScriptParser::DataType> &kv : narrowed) {
+		if (saved.has(kv.key)) {
+			type_overrides[kv.key] = saved[kv.key];
+		} else {
+			type_overrides.erase(kv.key);
+		}
+	}
 
 	if (p_if->false_block != nullptr) {
 		resolve_suite(p_if->false_block);
@@ -3093,7 +3137,42 @@ void GDScriptAnalyzer::reduce_await(GDScriptParser::AwaitNode *p_await) {
 
 void GDScriptAnalyzer::reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_op) {
 	reduce_expression(p_binary_op->left_operand);
-	reduce_expression(p_binary_op->right_operand);
+
+	if (p_binary_op->variant_op == Variant::OP_AND) {
+		HashMap<StringName, GDScriptParser::DataType> narrowed;
+		extract_type_tests(p_binary_op->left_operand, narrowed);
+
+		HashMap<StringName, GDScriptParser::DataType> saved;
+		for (const KeyValue<StringName, GDScriptParser::DataType> &kv : narrowed) {
+			if (type_overrides.has(kv.key)) {
+				saved[kv.key] = type_overrides[kv.key];
+			}
+			type_overrides[kv.key] = kv.value;
+		}
+
+		if (p_binary_op->right_operand != nullptr && p_binary_op->right_operand->type == GDScriptParser::Node::SUBSCRIPT) {
+			GDScriptParser::SubscriptNode *subscript = static_cast<GDScriptParser::SubscriptNode *>(p_binary_op->right_operand);
+			if (subscript->base != nullptr && subscript->base->type == GDScriptParser::Node::IDENTIFIER) {
+				GDScriptParser::IdentifierNode *base_id = static_cast<GDScriptParser::IdentifierNode *>(subscript->base);
+				if (type_overrides.has(base_id->name)) {
+					base_id->narrowed_datatype = type_overrides[base_id->name];
+					base_id->has_narrowed_datatype = true;
+				}
+			}
+		}
+
+		reduce_expression(p_binary_op->right_operand);
+
+		for (const KeyValue<StringName, GDScriptParser::DataType> &kv : narrowed) {
+			if (saved.has(kv.key)) {
+				type_overrides[kv.key] = saved[kv.key];
+			} else {
+				type_overrides.erase(kv.key);
+			}
+		}
+	} else {
+		reduce_expression(p_binary_op->right_operand);
+	}
 
 	GDScriptParser::DataType left_type;
 	if (p_binary_op->left_operand) {
@@ -4461,6 +4540,12 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 	}
 
 	if (found_source) {
+		if (type_overrides.has(p_identifier->name)) {
+			p_identifier->narrowed_datatype = type_overrides[p_identifier->name];
+			p_identifier->has_narrowed_datatype = true;
+			p_identifier->set_datatype(type_overrides[p_identifier->name]);
+		}
+
 		const bool source_is_instance_variable = p_identifier->source == GDScriptParser::IdentifierNode::MEMBER_VARIABLE || p_identifier->source == GDScriptParser::IdentifierNode::INHERITED_VARIABLE;
 		const bool source_is_instance_function = p_identifier->source == GDScriptParser::IdentifierNode::MEMBER_FUNCTION && !p_identifier->function_source_is_static;
 		const bool source_is_signal = p_identifier->source == GDScriptParser::IdentifierNode::MEMBER_SIGNAL;

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -54,6 +54,7 @@ class GDScriptAnalyzer {
 	GDScriptParser::LambdaNode *current_lambda = nullptr;
 	List<GDScriptParser::LambdaNode *> pending_body_resolution_lambdas;
 	HashMap<const GDScriptParser::ClassNode *, Ref<GDScriptParserRef>> external_class_parser_cache;
+	HashMap<StringName, GDScriptParser::DataType> type_overrides;
 	bool static_context = false;
 
 	// Tests for detecting invalid overloading of script members
@@ -153,6 +154,7 @@ class GDScriptAnalyzer {
 	void mark_lambda_use_self();
 	void resolve_pending_lambda_bodies();
 	void reduce_identifier_from_base_set_class(GDScriptParser::IdentifierNode *p_identifier, GDScriptParser::DataType p_identifier_datatype);
+	void extract_type_tests(GDScriptParser::ExpressionNode *p_expression, HashMap<StringName, GDScriptParser::DataType> &r_overrides);
 	Ref<GDScriptParserRef> ensure_cached_external_parser_for_class(const GDScriptParser::ClassNode *p_class, const GDScriptParser::ClassNode *p_from_class, const char *p_context, const GDScriptParser::Node *p_source);
 	Ref<GDScriptParserRef> find_cached_external_parser_for_class(const GDScriptParser::ClassNode *p_class, const Ref<GDScriptParserRef> &p_dependant_parser);
 	Ref<GDScriptParserRef> find_cached_external_parser_for_class(const GDScriptParser::ClassNode *p_class, GDScriptParser *p_dependant_parser);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1915,6 +1915,11 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 		switch (p_expression->type) {
 			case GDScriptParser::Node::IDENTIFIER: {
 				const GDScriptParser::IdentifierNode *id = static_cast<const GDScriptParser::IdentifierNode *>(p_expression);
+				if (id->has_narrowed_datatype) {
+					r_type.type = id->narrowed_datatype;
+					found = true;
+					break;
+				}
 				found = _guess_identifier_type(p_context, id, r_type);
 			} break;
 			case GDScriptParser::Node::DICTIONARY: {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -895,6 +895,9 @@ public:
 		StringName name;
 		SuiteNode *suite = nullptr; // The block in which the identifier is used.
 
+		DataType narrowed_datatype;
+		bool has_narrowed_datatype = false;
+
 		enum Source {
 			UNDEFINED_SOURCE,
 			FUNCTION_PARAMETER,


### PR DESCRIPTION
This adds type narrowing for variables in compound and expressions and if conditions, so that code like:
```gdscript
if owner is CustomClass and owner. # here
```
or
```gdscript
if is_inside_tree() and owner is CustomClass:
    owner. # also here
```
actually properly shows custom class hints. Unless I'm missing something, the only way to get correct intelisense here previously was to either annotate the variable beforehand or split the condition, both of which feel more tedious than they should.

The impleentation pulls `is` type checks out of `and` conditions, then tracks the narrowed types in a map that only applies inside the `if` (and the right side of the `and`). It also stores the narrowed type directly on each identifier so things like autocomplete can use it later.

This could also be expanded to the inverse of `is not` + `else` blocks and (potentially) early returns

Comparisons:
| Before | After |
|--------|--------|
| <img width="646" height="207" alt="image" src="https://github.com/user-attachments/assets/6b37c985-5220-4fce-8c0f-7e3dc572f972" /> | <img width="647" height="205" alt="image" src="https://github.com/user-attachments/assets/c7fb3d17-c387-4b24-b435-45a76adeb052" /> |
| <img width="459" height="226" alt="image" src="https://github.com/user-attachments/assets/2a7a7869-0dbf-41cd-9e9f-fda18698627c" /> | <img width="469" height="231" alt="image" src="https://github.com/user-attachments/assets/ac21bb80-89f9-4f44-bf30-84d20c1ac235" /> | 

I did not run into any edge case issues in my testing, but any extra testing would of course be appreciated!