### PR TITLE
Fix color correction not applying in mobile renderer without glow

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -955,7 +955,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 		if (rb->get_scaling_3d_mode() != RSE::VIEWPORT_SCALING_3D_MODE_OFF) {
 			// can't do blit subpass because we're scaling
 			using_subpass_post_process = false;
-		} else if (p_render_data->environment.is_valid() && (environment_get_glow_enabled(p_render_data->environment) || RSG::camera_attributes->camera_attributes_uses_auto_exposure(p_render_data->camera_attributes) || RSG::camera_attributes->camera_attributes_uses_dof(p_render_data->camera_attributes) || environment_get_background(p_render_data->environment) == RSE::ENV_BG_CANVAS)) {
+		} else if (p_render_data->environment.is_valid() && (environment_get_glow_enabled(p_render_data->environment) || RSG::camera_attributes->camera_attributes_uses_auto_exposure(p_render_data->camera_attributes) || RSG::camera_attributes->camera_attributes_uses_dof(p_render_data->camera_attributes) || environment_get_background(p_render_data->environment) == RSE::ENV_BG_CANVAS || environment_get_color_correction(p_render_data->environment).is_valid())) {
 			// can't do blit subpass because we're using post processes
 			using_subpass_post_process = false;
 		}


### PR DESCRIPTION
Fixes #117890 .
Problem:
color correction wasn't being applied in forward mobile backend unless glow was enabled

Cause:
"using_subpass_post_process" was only disabled when glow, auto exposure, DOF, or canvas background were active. Color correction was missing from this condition, so when only color correction was enabled, the post-process pass was skipped entirely.

Fix:
Added `environment_get_color_correction_enabled()` to the condition so the post-process pass runs correctly when color correction is active.