### PR TITLE
[4.6] Fix Metal driver build with Xcode 26.4

### DIFF
--- a/drivers/metal/metal_objects.mm
+++ b/drivers/metal/metal_objects.mm
@@ -2270,11 +2270,11 @@ id<MTLDepthStencilState> MDResourceCache::get_depth_stencil_state(bool p_use_dep
 }
 
 static const char *SHADER_STAGE_NAMES[] = {
-	[RD::SHADER_STAGE_VERTEX] = "vert",
-	[RD::SHADER_STAGE_FRAGMENT] = "frag",
-	[RD::SHADER_STAGE_TESSELATION_CONTROL] = "tess_ctrl",
-	[RD::SHADER_STAGE_TESSELATION_EVALUATION] = "tess_eval",
-	[RD::SHADER_STAGE_COMPUTE] = "comp",
+	"vert", // [RD::SHADER_STAGE_VERTEX]
+	"frag", // [RD::SHADER_STAGE_FRAGMENT]
+	"tess_ctrl", // [RD::SHADER_STAGE_TESSELATION_CONTROL]
+	"tess_eval", // [RD::SHADER_STAGE_TESSELATION_EVALUATION]
+	"comp", // [RD::SHADER_STAGE_COMPUTE]
 };
 
 void ShaderCacheEntry::notify_free() const {

--- a/drivers/metal/pixel_formats.mm
+++ b/drivers/metal/pixel_formats.mm
@@ -579,7 +579,7 @@ void PixelFormats::initDataFormatCapabilities() {
 
 void PixelFormats::addMTLPixelFormatDescImpl(MTLPixelFormat p_pix_fmt, MTLPixelFormat p_pix_fmt_linear,
 		MTLViewClass p_view_class, MTLFmtCaps p_fmt_caps, const char *p_name) {
-	_mtl_pixel_format_descs[p_pix_fmt] = { .mtlPixelFormat = p_pix_fmt, DataFormat::DATA_FORMAT_MAX, p_fmt_caps, p_view_class, p_pix_fmt_linear, p_name };
+	_mtl_pixel_format_descs[p_pix_fmt] = { .mtlPixelFormat = p_pix_fmt, .dataFormat = DataFormat::DATA_FORMAT_MAX, .mtlFmtCaps = p_fmt_caps, .mtlViewClass = p_view_class, .mtlPixelFormatLinear = p_pix_fmt_linear, .name = p_name };
 }
 
 #define addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, appleGPUCaps)                             \
@@ -783,7 +783,7 @@ void PixelFormats::addMTLVertexFormatDescImpl(MTLVertexFormat mtlVtxFmt, MTLFmtC
 	if (mtlVtxFmt >= _mtl_vertex_format_descs.size()) {
 		_mtl_vertex_format_descs.resize(mtlVtxFmt + 1);
 	}
-	_mtl_vertex_format_descs[mtlVtxFmt] = { .mtlVertexFormat = mtlVtxFmt, RD::DATA_FORMAT_MAX, vtxCap, MTLViewClass::None, MTLPixelFormatInvalid, name };
+	_mtl_vertex_format_descs[mtlVtxFmt] = { .mtlVertexFormat = mtlVtxFmt, .dataFormat = RD::DATA_FORMAT_MAX, .mtlFmtCaps = vtxCap, .mtlViewClass = MTLViewClass::None, .mtlPixelFormatLinear = MTLPixelFormatInvalid, .name = name };
 }
 
 // Check mtlVtx exists on platform, to avoid overwriting the MTLVertexFormatInvalid entry.

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -1652,14 +1652,14 @@ RDD::RenderPassID RenderingDeviceDriverMetal::render_pass_create(VectorView<Atta
 	}
 
 	static const MTLLoadAction LOAD_ACTIONS[] = {
-		[ATTACHMENT_LOAD_OP_LOAD] = MTLLoadActionLoad,
-		[ATTACHMENT_LOAD_OP_CLEAR] = MTLLoadActionClear,
-		[ATTACHMENT_LOAD_OP_DONT_CARE] = MTLLoadActionDontCare,
+		MTLLoadActionLoad, // ATTACHMENT_LOAD_OP_LOAD
+		MTLLoadActionClear, // ATTACHMENT_LOAD_OP_CLEAR
+		MTLLoadActionDontCare, // ATTACHMENT_LOAD_OP_DONT_CARE
 	};
 
 	static const MTLStoreAction STORE_ACTIONS[] = {
-		[ATTACHMENT_STORE_OP_STORE] = MTLStoreActionStore,
-		[ATTACHMENT_STORE_OP_DONT_CARE] = MTLStoreActionDontCare,
+		MTLStoreActionStore, // ATTACHMENT_STORE_OP_STORE
+		MTLStoreActionDontCare, // ATTACHMENT_STORE_OP_DONT_CARE
 	};
 
 	Vector<MDAttachment> attachments;

--- a/drivers/metal/rendering_shader_container_metal.mm
+++ b/drivers/metal/rendering_shader_container_metal.mm
@@ -218,11 +218,11 @@ Error RenderingShaderContainerMetal::compile_metal_source(const char *p_source, 
 #pragma clang diagnostic ignored "-Wunguarded-availability"
 
 static spv::ExecutionModel SHADER_STAGE_REMAP[RDD::SHADER_STAGE_MAX] = {
-	[RDD::SHADER_STAGE_VERTEX] = spv::ExecutionModelVertex,
-	[RDD::SHADER_STAGE_FRAGMENT] = spv::ExecutionModelFragment,
-	[RDD::SHADER_STAGE_TESSELATION_CONTROL] = spv::ExecutionModelTessellationControl,
-	[RDD::SHADER_STAGE_TESSELATION_EVALUATION] = spv::ExecutionModelTessellationEvaluation,
-	[RDD::SHADER_STAGE_COMPUTE] = spv::ExecutionModelGLCompute,
+	spv::ExecutionModelVertex, // RDD::SHADER_STAGE_VERTEX
+	spv::ExecutionModelFragment, // RDD::SHADER_STAGE_FRAGMENT
+	spv::ExecutionModelTessellationControl, // RDD::SHADER_STAGE_TESSELATION_CONTROL
+	spv::ExecutionModelTessellationEvaluation, // RDD::SHADER_STAGE_TESSELATION_EVALUATION
+	spv::ExecutionModelGLCompute, // RDD::SHADER_STAGE_COMPUTE
 };
 
 spv::ExecutionModel get_stage(uint32_t p_stages_mask, RDD::ShaderStage p_stage) {


### PR DESCRIPTION
This PR is a manual backport of PR #117819 to the 4.6 branch, because there were conflicts.

This change is required to fix compiling Godot 4.6 on the latest macOS.
