### PR TITLE
GDScript: Clear base script in `GDScript::clear`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1482,6 +1482,11 @@ void GDScript::clear() {
 		memdelete(E);
 	}
 	functions_to_clear.clear();
+
+#ifdef TOOLS_ENABLED
+	base_cache = Ref<GDScript>();
+#endif
+	base = Ref<GDScript>();
 }
 
 void GDScript::cancel_pending_functions(bool warn) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/117975

We can access an already freed script when clearing dependencies between scripts. It can happen because sometimes the reference to the base script can be the last reference and at the same time the next one in the `script_list`. So we first advance list to the next node and then free the base script in the `Ref<GDScript> scr` destructor.

~~To fix it I choose to manually clear the base script before moving to the next node to allow it to remove itself from the `script_list` if it needs to.~~

As recommended in Rocket chat the code to clean it was moved to `GDScript::clear`. It was still tested with tsan build and it also fixes it.

Tbh, not sure how often it happens, but it does happen in my project and in the mrp at least.