### PR TITLE
Add checkbox to exclude title from translation template

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1872,6 +1872,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translations", PackedStringArray());
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translations_pot_files", PackedStringArray());
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translation_add_builtin_strings_to_pot", false);
+	GLOBAL_DEF_INTERNAL("internationalization/locale/translation_add_project_title_to_translation_template", false);
 
 #if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
 	GLOBAL_DEF("navigation/world/map_use_async_iterations", true);

--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -53,6 +53,7 @@ void LocalizationEditor::_notification(int p_what) {
 			translation_list->connect("button_clicked", callable_mp(this, &LocalizationEditor::_translation_delete));
 			template_source_list->connect("button_clicked", callable_mp(this, &LocalizationEditor::_template_source_delete));
 			template_add_builtin->set_pressed(GLOBAL_GET("internationalization/locale/translation_add_builtin_strings_to_pot"));
+			template_add_title->set_pressed(GLOBAL_GET("internationalization/locale/translation_add_project_title_to_translation_template"));
 
 			List<String> tfn;
 			ResourceLoader::get_recognized_extensions_for_type("Translation", &tfn);
@@ -421,6 +422,11 @@ void LocalizationEditor::_template_generate_command() {
 
 void LocalizationEditor::_template_add_builtin_toggled() {
 	ProjectSettings::get_singleton()->set_setting("internationalization/locale/translation_add_builtin_strings_to_pot", template_add_builtin->is_pressed());
+	ProjectSettings::get_singleton()->save();
+}
+
+void LocalizationEditor::_template_add_title_toggled() {
+	ProjectSettings::get_singleton()->set_setting("internationalization/locale/translation_add_project_title_to_translation_template", template_add_title->is_pressed());
 	ProjectSettings::get_singleton()->save();
 }
 
@@ -896,10 +902,17 @@ LocalizationEditor::LocalizationEditor() {
 		tree_data_types[template_source_list] = "localization_editor_pot_item";
 		tree_settings[template_source_list] = "internationalization/locale/translations_pot_files";
 
+		HBoxContainer *checkbox_hb = memnew(HBoxContainer);
+		tvb->add_child(checkbox_hb);
+
 		template_add_builtin = memnew(CheckBox(TTRC("Add Built-in Strings")));
 		template_add_builtin->set_tooltip_text(TTRC("Add strings from built-in components such as certain Control nodes."));
 		template_add_builtin->connect(SceneStringName(pressed), callable_mp(this, &LocalizationEditor::_template_add_builtin_toggled));
-		tvb->add_child(template_add_builtin);
+		checkbox_hb->add_child(template_add_builtin);
+
+		template_add_title = memnew(CheckBox(TTRC("Add Project Title")));
+		template_add_title->connect(SceneStringName(pressed), callable_mp(this, &LocalizationEditor::_template_add_title_toggled));
+		checkbox_hb->add_child(template_add_title);
 
 		template_generate_dialog = memnew(EditorFileDialog);
 		template_generate_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);

--- a/editor/translations/localization_editor.h
+++ b/editor/translations/localization_editor.h
@@ -53,6 +53,7 @@ class LocalizationEditor : public VBoxContainer {
 
 	Tree *template_source_list = nullptr;
 	CheckBox *template_add_builtin = nullptr;
+	CheckBox *template_add_title = nullptr;
 	EditorFileDialog *template_source_open_dialog = nullptr;
 	EditorFileDialog *template_generate_dialog = nullptr;
 	Button *template_generate_button = nullptr;
@@ -85,6 +86,7 @@ class LocalizationEditor : public VBoxContainer {
 	void _template_generate_open();
 	void _template_generate_command();
 	void _template_add_builtin_toggled();
+	void _template_add_title_toggled();
 	void _template_generate(const String &p_file);
 	void _update_template_source_file_extensions();
 

--- a/editor/translations/template_generator.cpp
+++ b/editor/translations/template_generator.cpp
@@ -34,7 +34,7 @@
 #include "editor/translations/editor_translation.h"
 #include "editor/translations/editor_translation_parser.h"
 
-TranslationTemplateGenerator::MessageMap TranslationTemplateGenerator::parse(const Vector<String> &p_sources, bool p_add_builtin) const {
+TranslationTemplateGenerator::MessageMap TranslationTemplateGenerator::parse(const Vector<String> &p_sources, bool p_add_builtin, bool p_add_title) const {
 	Vector<Vector<String>> raw;
 
 	for (const String &path : p_sources) {
@@ -67,7 +67,7 @@ TranslationTemplateGenerator::MessageMap TranslationTemplateGenerator::parse(con
 		}
 	}
 
-	if (GLOBAL_GET("application/config/name_localized").operator Dictionary().is_empty()) {
+	if (p_add_title && GLOBAL_GET("application/config/name_localized").operator Dictionary().is_empty()) {
 		const String &project_name = GLOBAL_GET("application/config/name");
 		if (!project_name.is_empty()) {
 			raw.push_back({ project_name, String(), String(), String(), String() });
@@ -106,8 +106,9 @@ TranslationTemplateGenerator::MessageMap TranslationTemplateGenerator::parse(con
 void TranslationTemplateGenerator::generate(const String &p_file) {
 	const Vector<String> files = GLOBAL_GET("internationalization/locale/translations_pot_files");
 	const bool add_builtin = GLOBAL_GET("internationalization/locale/translation_add_builtin_strings_to_pot");
+	const bool add_title = GLOBAL_GET("internationalization/locale/translation_add_project_title_to_translation_template");
 
-	const MessageMap &map = parse(files, add_builtin);
+	const MessageMap &map = parse(files, add_builtin, add_title);
 	if (map.is_empty()) {
 		WARN_PRINT_ED(TTR("No translatable strings found."));
 		return;

--- a/editor/translations/template_generator.h
+++ b/editor/translations/template_generator.h
@@ -44,7 +44,7 @@ class TranslationTemplateGenerator {
 
 	using MessageMap = HashMap<Translation::MessageKey, MessageData, Translation::MessageKey>;
 
-	MessageMap parse(const Vector<String> &p_sources, bool p_add_builtin) const;
+	MessageMap parse(const Vector<String> &p_sources, bool p_add_builtin, bool p_add_title) const;
 
 	void _write_to_pot(Ref<FileAccess> p_file, const MessageMap &p_map) const;
 	void _write_to_csv(Ref<FileAccess> p_file, const MessageMap &p_map) const;


### PR DESCRIPTION
Follow-up to #112415
Adds a checkbox to disable it.
<img width="366" height="83" alt="image" src="https://github.com/user-attachments/assets/ad9edf24-095b-4294-a4a0-f0d7433057f6" />
Most projects don't localize their title.