### PR TITLE
Disable auto-translation of plugin names

### DIFF
--- a/editor/plugins/editor_plugin_settings.cpp
+++ b/editor/plugins/editor_plugin_settings.cpp
@@ -116,15 +116,18 @@ void EditorPluginSettings::update_plugins() {
 
 				TreeItem *item = plugin_list->create_item(root);
 				item->set_text(COLUMN_NAME, name);
+				item->set_auto_translate_mode(COLUMN_NAME, AUTO_TRANSLATE_MODE_DISABLED);
 				if (!is_enabled) {
 					item->set_custom_color(COLUMN_NAME, disabled_color);
 				}
 				item->set_tooltip_text(COLUMN_NAME, vformat(TTR("Name: %s\nPath: %s\nMain Script: %s\n\n%s"), name, path, scr, wrapped_description));
 				item->set_metadata(COLUMN_NAME, path);
 				item->set_text(COLUMN_VERSION, version);
+				item->set_auto_translate_mode(COLUMN_VERSION, AUTO_TRANSLATE_MODE_DISABLED);
 				item->set_custom_font(COLUMN_VERSION, get_theme_font("source", EditorStringName(EditorFonts)));
 				item->set_metadata(COLUMN_VERSION, scr);
 				item->set_text(COLUMN_AUTHOR, author);
+				item->set_auto_translate_mode(COLUMN_AUTHOR, AUTO_TRANSLATE_MODE_DISABLED);
 				item->set_metadata(COLUMN_AUTHOR, description);
 				item->set_cell_mode(COLUMN_STATUS, TreeItem::CELL_MODE_CHECK);
 				item->set_text(COLUMN_STATUS, TTRC("On"));


### PR DESCRIPTION
Prevents auto-translating of plugin name, version and author.

Although I wonder if the name should be optionally translateable? It's useful if you include a custom translation in your plugin, but   auto-translation is not always desirable if your plugin name happens to be a word that exists in editor translation. The option would need to be stored in the plugin config though.