### PR TITLE
Increase available space for array properties

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -345,7 +345,7 @@ void EditorProperty::_notification(int p_what) {
 			bottom_child_rect = Rect2();
 
 			{
-				int child_room = size.width * (1.0 - split_ratio);
+				int child_room = size.width * (1.0 - split_ratio) - name_fixed_size;
 				int separation = 4 * EDSCALE;
 				int height = theme_cache.inspector_property_height;
 				int half_padding = theme_cache.padding / 2;
@@ -1378,6 +1378,14 @@ float EditorProperty::get_name_split_ratio() const {
 	return split_ratio;
 }
 
+void EditorProperty::set_name_fixed_size(float p_size) {
+	if (name_fixed_size == p_size) {
+		return;
+	}
+	name_fixed_size = p_size;
+	queue_sort();
+}
+
 void EditorProperty::set_favoritable(bool p_favoritable) {
 	can_favorite = p_favoritable;
 }
@@ -1621,7 +1629,6 @@ EditorProperty::EditorProperty() {
 	set_focus_mode(FOCUS_ACCESSIBILITY);
 
 	object = nullptr;
-	split_ratio = 0.5;
 	text_size = 0;
 	property_usage = 0;
 	selected_focusable = -1;

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -72,6 +72,7 @@ class EditorProperty : public Container {
 
 	friend class EditorInspector;
 
+protected:
 	struct ThemeCache {
 		Ref<Font> font;
 
@@ -197,7 +198,8 @@ private:
 	int selected_focusable;
 	bool deferred_drag_mode = false;
 
-	float split_ratio;
+	float split_ratio = 0.5;
+	float name_fixed_size = 0.0;
 
 	Vector<Control *> focusables;
 	Control *label_reference = nullptr;
@@ -317,6 +319,7 @@ public:
 
 	void set_name_split_ratio(float p_ratio);
 	float get_name_split_ratio() const;
+	void set_name_fixed_size(float p_size);
 
 	void set_favoritable(bool p_favoritable);
 	bool is_favoritable() const;

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -494,6 +494,7 @@ void EditorPropertyArray::update_property() {
 		paginator->update(page_index, max_page);
 		paginator->set_visible(max_page > 0);
 
+		float name_size = 0;
 		for (Slot &slot : slots) {
 			bool slot_visible = &slot != &reorder_slot && slot.index < size;
 			slot.container->set_visible(slot_visible);
@@ -524,6 +525,7 @@ void EditorPropertyArray::update_property() {
 				}
 				new_prop->set_selectable(false);
 				new_prop->set_use_folding(is_using_folding());
+				new_prop->set_name_split_ratio(0.0);
 				new_prop->connect(SNAME("property_changed"), callable_mp(this, &EditorPropertyArray::_property_changed));
 				new_prop->connect(SNAME("object_id_selected"), callable_mp(this, &EditorPropertyArray::_object_id_selected));
 				if (value_type == Variant::OBJECT) {
@@ -551,6 +553,15 @@ void EditorPropertyArray::update_property() {
 				callable_mp(slot.prop, &EditorProperty::grab_focus).call_deferred(0);
 				changing_type_index = EditorPropertyArrayObject::NOT_CHANGING_TYPE;
 			}
+			if (name_size == 0) {
+				int max_index = (page_index + 1) * page_length - 1;
+				const String ms = String("M").repeat(itos(max_index).length());
+
+				Ref<Font> font = theme_cache.font;
+				int font_size = theme_cache.font_size;
+				name_size = slots[0].reorder_button->get_minimum_size().x + theme_cache.horizontal_separation + font->get_string_size(ms, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x;
+			}
+			slot.prop->set_name_fixed_size(name_size);
 			slot.prop->update_property();
 		}
 


### PR DESCRIPTION
Array properties have been using the default name split ratio of 0.5, resulting in lots of wasted space.
<img width="301" height="375" alt="image" src="https://github.com/user-attachments/assets/c4d1eb16-6f8b-47c4-ab63-58fd368add77" />
The name is only a number, so it does not need that much space.

I experimented with decreasing the ratio, but it just does not make sense if the size of the names is always the same, so instead I introduced a fixed size for the name part.
<img width="282" height="360" alt="image" src="https://github.com/user-attachments/assets/d5a2f235-0a39-424a-ae06-147efabf6d23" />
Much more usable.

*Bugsquad edit:*
- Implements and closes https://github.com/godotengine/godot-proposals/issues/5457.