### PR TITLE
Fix option alignment in command line help

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -302,8 +302,8 @@ static const String NULL_AUDIO_DRIVER("Dummy");
 
 // The length of the longest column in the command-line help we should align to
 // (excluding the 2-space left and right margins).
-// Currently, this is `--export-release <preset> <path>`.
-static const int OPTION_COLUMN_LENGTH = 32;
+// Currently, this is `--dump-gdextension-interface-json`.
+static const int OPTION_COLUMN_LENGTH = 33;
 
 /* Helper methods */
 


### PR DESCRIPTION
The longest option name has changed recently, which led to the option availability flag of `--dump-gdextension-interface-json` being misaligned with all other options.

(I just checked and the issue also exists in 4.6.1, so I marked this for cherry-picking.)

## Preview

### Before

<img width="1496" height="96" alt="Screenshot_20260330_190236" src="https://github.com/user-attachments/assets/f67d1849-8292-4576-b2a7-b33c1054fbeb" />

### After

<img width="1496" height="96" alt="Screenshot_20260330_190335" src="https://github.com/user-attachments/assets/60c00ce5-b559-4d36-918f-c895abb46bb4" />
