### PR TITLE
Document which performance monitors are only effective in debug mode

### DIFF
--- a/doc/classes/Performance.xml
+++ b/doc/classes/Performance.xml
@@ -6,7 +6,6 @@
 	<description>
 		This class provides access to a number of different monitors related to performance, such as memory usage, draw calls, and FPS. These are the same as the values displayed in the [b]Monitor[/b] tab in the editor's [b]Debugger[/b] panel. By using the [method get_monitor] method of this class, you can access this data from your code.
 		You can add custom monitors using the [method add_custom_monitor] method. Custom monitors are available in [b]Monitor[/b] tab in the editor's [b]Debugger[/b] panel together with built-in monitors.
-		[b]Note:[/b] Some of the built-in monitors are only available in debug mode and will always return [code]0[/code] when used in a project exported in release mode.
 		[b]Note:[/b] Some of the built-in monitors are not updated in real-time for performance reasons, so there may be a delay of up to 1 second between changes.
 		[b]Note:[/b] Custom monitors do not support negative values. Negative values are clamped to 0.
 	</description>
@@ -143,9 +142,11 @@
 		</constant>
 		<constant name="MEMORY_STATIC" value="4" enum="Monitor">
 			Static memory currently used, in bytes. Not available in release builds. [i]Lower is better.[/i]
+			[b]Note:[/b] This monitor is only effective in debug mode. It will always return [code]0[/code] when used in a project exported in release mode.
 		</constant>
 		<constant name="MEMORY_STATIC_MAX" value="5" enum="Monitor">
 			Available static memory. Not available in release builds. [i]Lower is better.[/i]
+			[b]Note:[/b] This monitor is only effective in debug mode. It will always return [code]0[/code] when used in a project exported in release mode.
 		</constant>
 		<constant name="MEMORY_MESSAGE_BUFFER_MAX" value="6" enum="Monitor">
 			Largest amount of memory the message queue buffer has used, in bytes. The message queue is used for deferred functions calls and notifications. [i]Lower is better.[/i]
@@ -161,7 +162,7 @@
 		</constant>
 		<constant name="OBJECT_ORPHAN_NODE_COUNT" value="10" enum="Monitor">
 			Number of orphan nodes, i.e. nodes which are not parented to a node of the scene tree. [i]Lower is better.[/i]
-			[b]Note:[/b] This is only available in debug mode and will always return [code]0[/code] when used in a project exported in release mode.
+			[b]Note:[/b] This monitor is only effective in debug mode. It will always return [code]0[/code] when used in a project exported in release mode.
 		</constant>
 		<constant name="RENDER_TOTAL_OBJECTS_IN_FRAME" value="11" enum="Monitor">
 			The total number of objects in the last rendered frame. This metric doesn't include culled objects (either via hiding nodes, frustum culling or occlusion culling). [i]Lower is better.[/i]
@@ -200,112 +201,112 @@
 			Number of islands in the 3D physics engine. [i]Lower is better.[/i]
 		</constant>
 		<constant name="AUDIO_OUTPUT_LATENCY" value="23" enum="Monitor">
-			Output latency of the [AudioServer]. Equivalent to calling [method AudioServer.get_output_latency], it is not recommended to call this every frame.
+			Output latency of the [AudioServer]. Equivalent to calling [method AudioServer.get_output_latency], it is not recommended to call this every frame. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_ACTIVE_MAPS" value="24" enum="Monitor">
-			Number of active navigation maps in [NavigationServer2D] and [NavigationServer3D]. This also includes the empty default navigation maps created by [World2D] and [World3D] instances.
+			Number of active navigation maps in [NavigationServer2D] and [NavigationServer3D]. This also includes the empty default navigation maps created by [World2D] and [World3D] instances. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_REGION_COUNT" value="25" enum="Monitor">
-			Number of active navigation regions in [NavigationServer2D] and [NavigationServer3D].
+			Number of active navigation regions in [NavigationServer2D] and [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_AGENT_COUNT" value="26" enum="Monitor">
-			Number of active navigation agents processing avoidance in [NavigationServer2D] and [NavigationServer3D].
+			Number of active navigation agents processing avoidance in [NavigationServer2D] and [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_LINK_COUNT" value="27" enum="Monitor">
-			Number of active navigation links in [NavigationServer2D] and [NavigationServer3D].
+			Number of active navigation links in [NavigationServer2D] and [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_POLYGON_COUNT" value="28" enum="Monitor">
-			Number of navigation mesh polygons in [NavigationServer2D] and [NavigationServer3D].
+			Number of navigation mesh polygons in [NavigationServer2D] and [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_EDGE_COUNT" value="29" enum="Monitor">
-			Number of navigation mesh polygon edges in [NavigationServer2D] and [NavigationServer3D].
+			Number of navigation mesh polygon edges in [NavigationServer2D] and [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_EDGE_MERGE_COUNT" value="30" enum="Monitor">
-			Number of navigation mesh polygon edges that were merged due to edge key overlap in [NavigationServer2D] and [NavigationServer3D].
+			Number of navigation mesh polygon edges that were merged due to edge key overlap in [NavigationServer2D] and [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_EDGE_CONNECTION_COUNT" value="31" enum="Monitor">
-			Number of polygon edges that are considered connected by edge proximity [NavigationServer2D] and [NavigationServer3D].
+			Number of polygon edges that are considered connected by edge proximity [NavigationServer2D] and [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_EDGE_FREE_COUNT" value="32" enum="Monitor">
-			Number of navigation mesh polygon edges that could not be merged in [NavigationServer2D] and [NavigationServer3D]. The edges still may be connected by edge proximity or with links.
+			Number of navigation mesh polygon edges that could not be merged in [NavigationServer2D] and [NavigationServer3D]. The edges still may be connected by edge proximity or with links. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_OBSTACLE_COUNT" value="33" enum="Monitor">
-			Number of active navigation obstacles in the [NavigationServer2D] and [NavigationServer3D].
+			Number of active navigation obstacles in the [NavigationServer2D] and [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="PIPELINE_COMPILATIONS_CANVAS" value="34" enum="Monitor">
-			Number of pipeline compilations that were triggered by the 2D canvas renderer.
+			Number of pipeline compilations that were triggered by the 2D canvas renderer. [i]Lower is better.[/i]
 		</constant>
 		<constant name="PIPELINE_COMPILATIONS_MESH" value="35" enum="Monitor">
-			Number of pipeline compilations that were triggered by loading meshes. These compilations will show up as longer loading times the first time a user runs the game and the pipeline is required.
+			Number of pipeline compilations that were triggered by loading meshes. These compilations will show up as longer loading times the first time a user runs the game and the pipeline is required. [i]Lower is better.[/i]
 		</constant>
 		<constant name="PIPELINE_COMPILATIONS_SURFACE" value="36" enum="Monitor">
-			Number of pipeline compilations that were triggered by building the surface cache before rendering the scene. These compilations will show up as a stutter when loading a scene the first time a user runs the game and the pipeline is required.
+			Number of pipeline compilations that were triggered by building the surface cache before rendering the scene. These compilations will show up as a stutter when loading a scene the first time a user runs the game and the pipeline is required. [i]Lower is better.[/i]
 		</constant>
 		<constant name="PIPELINE_COMPILATIONS_DRAW" value="37" enum="Monitor">
-			Number of pipeline compilations that were triggered while drawing the scene. These compilations will show up as stutters during gameplay the first time a user runs the game and the pipeline is required.
+			Number of pipeline compilations that were triggered while drawing the scene. These compilations will show up as stutters during gameplay the first time a user runs the game and the pipeline is required. [i]Lower is better.[/i]
 		</constant>
 		<constant name="PIPELINE_COMPILATIONS_SPECIALIZATION" value="38" enum="Monitor">
-			Number of pipeline compilations that were triggered to optimize the current scene. These compilations are done in the background and should not cause any stutters whatsoever.
+			Number of pipeline compilations that were triggered to optimize the current scene. These compilations are done in the background and should not cause any stutters whatsoever. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_2D_ACTIVE_MAPS" value="39" enum="Monitor">
-			Number of active navigation maps in the [NavigationServer2D]. This also includes the empty default navigation maps created by [World2D] instances.
+			Number of active navigation maps in the [NavigationServer2D]. This also includes the empty default navigation maps created by [World2D] instances. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_2D_REGION_COUNT" value="40" enum="Monitor">
-			Number of active navigation regions in the [NavigationServer2D].
+			Number of active navigation regions in the [NavigationServer2D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_2D_AGENT_COUNT" value="41" enum="Monitor">
-			Number of active navigation agents processing avoidance in the [NavigationServer2D].
+			Number of active navigation agents processing avoidance in the [NavigationServer2D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_2D_LINK_COUNT" value="42" enum="Monitor">
-			Number of active navigation links in the [NavigationServer2D].
+			Number of active navigation links in the [NavigationServer2D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_2D_POLYGON_COUNT" value="43" enum="Monitor">
-			Number of navigation mesh polygons in the [NavigationServer2D].
+			Number of navigation mesh polygons in the [NavigationServer2D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_2D_EDGE_COUNT" value="44" enum="Monitor">
-			Number of navigation mesh polygon edges in the [NavigationServer2D].
+			Number of navigation mesh polygon edges in the [NavigationServer2D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_2D_EDGE_MERGE_COUNT" value="45" enum="Monitor">
-			Number of navigation mesh polygon edges that were merged due to edge key overlap in the [NavigationServer2D].
+			Number of navigation mesh polygon edges that were merged due to edge key overlap in the [NavigationServer2D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_2D_EDGE_CONNECTION_COUNT" value="46" enum="Monitor">
-			Number of polygon edges that are considered connected by edge proximity [NavigationServer2D].
+			Number of polygon edges that are considered connected by edge proximity [NavigationServer2D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_2D_EDGE_FREE_COUNT" value="47" enum="Monitor">
-			Number of navigation mesh polygon edges that could not be merged in the [NavigationServer2D]. The edges still may be connected by edge proximity or with links.
+			Number of navigation mesh polygon edges that could not be merged in the [NavigationServer2D]. The edges still may be connected by edge proximity or with links. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_2D_OBSTACLE_COUNT" value="48" enum="Monitor">
-			Number of active navigation obstacles in the [NavigationServer2D].
+			Number of active navigation obstacles in the [NavigationServer2D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_3D_ACTIVE_MAPS" value="49" enum="Monitor">
-			Number of active navigation maps in the [NavigationServer3D]. This also includes the empty default navigation maps created by [World3D] instances.
+			Number of active navigation maps in the [NavigationServer3D]. This also includes the empty default navigation maps created by [World3D] instances. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_3D_REGION_COUNT" value="50" enum="Monitor">
-			Number of active navigation regions in the [NavigationServer3D].
+			Number of active navigation regions in the [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_3D_AGENT_COUNT" value="51" enum="Monitor">
-			Number of active navigation agents processing avoidance in the [NavigationServer3D].
+			Number of active navigation agents processing avoidance in the [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_3D_LINK_COUNT" value="52" enum="Monitor">
-			Number of active navigation links in the [NavigationServer3D].
+			Number of active navigation links in the [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_3D_POLYGON_COUNT" value="53" enum="Monitor">
-			Number of navigation mesh polygons in the [NavigationServer3D].
+			Number of navigation mesh polygons in the [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_3D_EDGE_COUNT" value="54" enum="Monitor">
-			Number of navigation mesh polygon edges in the [NavigationServer3D].
+			Number of navigation mesh polygon edges in the [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_3D_EDGE_MERGE_COUNT" value="55" enum="Monitor">
-			Number of navigation mesh polygon edges that were merged due to edge key overlap in the [NavigationServer3D].
+			Number of navigation mesh polygon edges that were merged due to edge key overlap in the [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_3D_EDGE_CONNECTION_COUNT" value="56" enum="Monitor">
-			Number of polygon edges that are considered connected by edge proximity [NavigationServer3D].
+			Number of polygon edges that are considered connected by edge proximity [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_3D_EDGE_FREE_COUNT" value="57" enum="Monitor">
-			Number of navigation mesh polygon edges that could not be merged in the [NavigationServer3D]. The edges still may be connected by edge proximity or with links.
+			Number of navigation mesh polygon edges that could not be merged in the [NavigationServer3D]. The edges still may be connected by edge proximity or with links. [i]Lower is better.[/i]
 		</constant>
 		<constant name="NAVIGATION_3D_OBSTACLE_COUNT" value="58" enum="Monitor">
-			Number of active navigation obstacles in the [NavigationServer3D].
+			Number of active navigation obstacles in the [NavigationServer3D]. [i]Lower is better.[/i]
 		</constant>
 		<constant name="MONITOR_MAX" value="59" enum="Monitor">
 			Represents the size of the [enum Monitor] enum.


### PR DESCRIPTION
The full list of monitors has been tested on the current `master` branch, with editor builds, debug templates and release templates.

Editor and debug template support the same set of monitors, while release templates support all monitors except 3 (`MEMORY_STATIC`, `MEMORY_STATIC_MAX` and `OBJECT_ORPHAN_NODE_COUNT`).

This also adds "lower is better" indications to monitors that were missing it.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/485#discussioncomment-16353268.

**Testing project:** [test_performance_monitors.zip](https://github.com/user-attachments/files/26358159/test_performance_monitors.zip)
