### PR TITLE
Make `Node.get_path_to()` error user-friendly when there is no common parent

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1477,7 +1477,7 @@ void Node::set_name(const StringName &p_name) {
 }
 
 // Returns a clear description of this node depending on what is available. Useful for error messages.
-String Node::get_description() const {
+String Node::get_description(bool p_show_not_in_tree) const {
 	String description;
 	if (is_inside_tree()) {
 		description = String(get_path());
@@ -1485,6 +1485,9 @@ String Node::get_description() const {
 		description = get_name();
 		if (description.is_empty()) {
 			description = get_class();
+		}
+		if (p_show_not_in_tree) {
+			description += " (not inside tree)";
 		}
 	}
 	return description;
@@ -2362,7 +2365,7 @@ NodePath Node::get_path_to(RequiredParam<const Node> rp_node, bool p_use_unique_
 		common_parent = common_parent->data.parent;
 	}
 
-	ERR_FAIL_NULL_V(common_parent, NodePath()); //nodes not in the same tree
+	ERR_FAIL_NULL_V_MSG(common_parent, NodePath(), vformat("No path can be resolved between the nodes %s and %s as they share no common ancestor.", get_description(true), p_node->get_description(true)));
 
 	visited.clear();
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -512,7 +512,7 @@ public:
 	/* NODE/TREE */
 
 	StringName get_name() const;
-	String get_description() const;
+	String get_description(bool p_show_not_in_tree = false) const;
 	void set_name(const StringName &p_name);
 
 	InternalMode get_internal_mode() const;


### PR DESCRIPTION
Resolves this issue seen on Discord, flagged by @AdriaandeJongh:

<img width="638" height="223" alt="image" src="https://github.com/user-attachments/assets/dcd5895e-f481-48fd-a4bc-48897cec1601" />

In Godot, `ERR_FAIL` checks are used for either:
1. Engine bugs which should never happen. If they do, contributors should see an obnoxious error, set a breakpoint and fix it. In such cases we typically don't bother writing a detailed error message.
2. Invalid usage of APIs which can be triggered by Godot users. Those should have an explicit error message with useful information so they can pinpoint what API they misused and where.

Here we're in the second case, but there was no error message.

The issue can be triggered trivially:
```gdscript
extends Node

func _ready();
    var orphan = Node.new()
    print(get_path_to(orphan))
```

We seem to have cases where engine code is also misusing this API though, which are examples of (1) and will need to be fixed. Notably:
- #117012
- #115512