### PR TITLE
Fix `Resource file not found` error during Live-Edit by serializing unsaved resources in-memory

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -281,17 +281,25 @@ void ScriptEditorDebugger::update_remote_object(ObjectID p_obj_id, const String 
 	Array msg = { p_obj_id, p_prop };
 
 	Ref<Resource> res = p_value;
-	if (res.is_valid() && !res->get_path().is_empty()) {
-		msg.append(res->get_path());
+	if (res.is_valid()) {
+		bool is_valid_file = !res->get_path().is_empty() && !res->get_path().contains("::") && FileAccess::exists(res->get_path());
+		if (is_valid_file) {
+			msg.append(res->get_path());
+		} else {
+			msg.append(res->get_path());
+			msg.append(res->get_class());
+		}
 	} else {
 		msg.append(p_value);
 	}
 
+	bool is_data_msg = msg.size() == 4;
+
 	if (p_field.is_empty()) {
-		_put_msg("scene:set_object_property", msg);
+		_put_msg(is_data_msg ? "scene:set_object_property_data" : "scene:set_object_property", msg);
 	} else {
 		msg.push_back(p_field);
-		_put_msg("scene:set_object_property_field", msg);
+		_put_msg(is_data_msg ? "scene:set_object_property_field_data" : "scene:set_object_property_field", msg);
 	}
 }
 
@@ -1514,9 +1522,15 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 
 		if (p_value.is_ref_counted()) {
 			Ref<Resource> res = p_value;
-			if (res.is_valid() && !res->get_path().is_empty()) {
-				Array msg = { pathid, p_property, res->get_path() };
-				_put_msg("scene:live_node_prop_res", msg);
+			if (res.is_valid()) {
+				bool is_valid_file = !res->get_path().is_empty() && !res->get_path().contains("::") && FileAccess::exists(res->get_path());
+				if (is_valid_file) {
+					Array msg = { pathid, p_property, res->get_path() };
+					_put_msg("scene:live_node_prop_res", msg);
+				} else {
+					Array msg = { pathid, p_property, res->get_path(), res->get_class() };
+					_put_msg("scene:live_node_prop_data", msg);
+				}
 			}
 		} else {
 			Array msg = { pathid, p_property, p_value };
@@ -1534,9 +1548,15 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 
 		if (p_value.is_ref_counted()) {
 			Ref<Resource> res2 = p_value;
-			if (res2.is_valid() && !res2->get_path().is_empty()) {
-				Array msg = { pathid, p_property, res2->get_path() };
-				_put_msg("scene:live_res_prop_res", msg);
+			if (res2.is_valid()) {
+				bool is_valid_file = !res2->get_path().is_empty() && !res2->get_path().contains("::") && FileAccess::exists(res2->get_path());
+				if (is_valid_file) {
+					Array msg = { pathid, p_property, res2->get_path() };
+					_put_msg("scene:live_res_prop_res", msg);
+				} else {
+					Array msg = { pathid, p_property, res2->get_path(), res2->get_class() };
+					_put_msg("scene:live_res_prop_data", msg);
+				}
 			}
 		} else {
 			Array msg = { pathid, p_property, p_value };

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -289,6 +289,61 @@ Error SceneDebugger::_msg_live_node_prop_res(const Array &p_args) {
 	LiveEditor::get_singleton()->_node_set_res_func(p_args[0], p_args[1], p_args[2]);
 	return OK;
 }
+Error SceneDebugger::_msg_live_node_prop_data(const Array &p_args) {
+	ERR_FAIL_COND_V(p_args.size() < 4, ERR_INVALID_DATA);
+	LiveEditor::get_singleton()->_node_set_data_func(p_args[0], p_args[1], p_args[2], p_args[3]);
+	return OK;
+}
+
+Error SceneDebugger::_msg_live_res_prop_data(const Array &p_args) {
+	ERR_FAIL_COND_V(p_args.size() < 4, ERR_INVALID_DATA);
+	LiveEditor::get_singleton()->_res_set_data_func(p_args[0], p_args[1], p_args[2], p_args[3]);
+	return OK;
+}
+
+Error SceneDebugger::_msg_set_object_property_data(const Array &p_args) {
+	ERR_FAIL_COND_V(p_args.size() < 4, ERR_INVALID_DATA);
+	String path = p_args[2];
+	String class_name = p_args[3];
+
+	Ref<Resource> r;
+	if (!path.is_empty()) {
+		r = ResourceCache::get_ref(path);
+	}
+
+	if (r.is_null()) {
+		r = Object::cast_to<Resource>(ClassDB::instantiate(class_name));
+		if (r.is_valid() && !path.is_empty()) {
+			r->set_path(path);
+		}
+	}
+
+	_set_object_property(p_args[0], p_args[1], r);
+	RuntimeNodeSelect::get_singleton()->_queue_selection_update();
+	return OK;
+}
+
+Error SceneDebugger::_msg_set_object_property_field_data(const Array &p_args) {
+	ERR_FAIL_COND_V(p_args.size() < 5, ERR_INVALID_DATA);
+	String path = p_args[2];
+	String class_name = p_args[3];
+
+	Ref<Resource> r;
+	if (!path.is_empty()) {
+		r = ResourceCache::get_ref(path);
+	}
+
+	if (r.is_null()) {
+		r = Object::cast_to<Resource>(ClassDB::instantiate(class_name));
+		if (r.is_valid() && !path.is_empty()) {
+			r->set_path(path);
+		}
+	}
+
+	_set_object_property(p_args[0], p_args[1], r, p_args[4]);
+	RuntimeNodeSelect::get_singleton()->_queue_selection_update();
+	return OK;
+}
 
 Error SceneDebugger::_msg_live_node_prop(const Array &p_args) {
 	ERR_FAIL_COND_V(p_args.size() < 3, ERR_INVALID_DATA);
@@ -552,6 +607,10 @@ void SceneDebugger::_init_message_handlers() {
 	message_handlers["request_scene_tree"] = _msg_request_scene_tree;
 	message_handlers["save_node"] = _msg_save_node;
 	message_handlers["inspect_objects"] = _msg_inspect_objects;
+	message_handlers["live_node_prop_data"] = _msg_live_node_prop_data;
+	message_handlers["live_res_prop_data"] = _msg_live_res_prop_data;
+	message_handlers["set_object_property_data"] = _msg_set_object_property_data;
+	message_handlers["set_object_property_field_data"] = _msg_set_object_property_field_data;
 #ifndef DISABLE_DEPRECATED
 	message_handlers["inspect_object"] = _msg_inspect_object;
 #endif // DISABLE_DEPRECATED
@@ -945,6 +1004,39 @@ void LiveEditor::_res_set_func(int p_id, const StringName &p_prop, const Variant
 	}
 
 	r->set(p_prop, p_value);
+}
+void LiveEditor::_node_set_data_func(int p_id, const StringName &p_prop, const String &p_res_path, const String &p_class_name) {
+	Ref<Resource> r = ResourceCache::get_ref(p_res_path);
+
+	if (r.is_null()) {
+		r = Object::cast_to<Resource>(ClassDB::instantiate(p_class_name));
+		if (r.is_valid() && !p_res_path.is_empty()) {
+			r->set_path(p_res_path);
+		}
+	}
+
+	if (r.is_null()) {
+		return;
+	}
+
+	_node_set_func(p_id, p_prop, r);
+}
+
+void LiveEditor::_res_set_data_func(int p_id, const StringName &p_prop, const String &p_res_path, const String &p_class_name) {
+	Ref<Resource> r = ResourceCache::get_ref(p_res_path);
+
+	if (r.is_null()) {
+		r = Object::cast_to<Resource>(ClassDB::instantiate(p_class_name));
+		if (r.is_valid() && !p_res_path.is_empty()) {
+			r->set_path(p_res_path);
+		}
+	}
+
+	if (r.is_null()) {
+		return;
+	}
+
+	_res_set_func(p_id, p_prop, r);
 }
 
 void LiveEditor::_res_set_res_func(int p_id, const StringName &p_prop, const String &p_value) {

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -87,6 +87,10 @@ private:
 	static Error _msg_live_node_path(const Array &p_args);
 	static Error _msg_live_res_path(const Array &p_args);
 	static Error _msg_live_node_prop_res(const Array &p_args);
+	static Error _msg_live_node_prop_data(const Array &p_args);
+	static Error _msg_live_res_prop_data(const Array &p_args);
+	static Error _msg_set_object_property_data(const Array &p_args);
+	static Error _msg_set_object_property_field_data(const Array &p_args);
 	static Error _msg_live_node_prop(const Array &p_args);
 	static Error _msg_live_res_prop_res(const Array &p_args);
 	static Error _msg_live_res_prop(const Array &p_args);
@@ -137,7 +141,8 @@ private:
 	HashMap<Node *, HashMap<ObjectID, Node *>> live_edit_remove_list;
 
 	void _send_tree();
-
+	void _node_set_data_func(int p_id, const StringName &p_prop, const String &p_res_path, const String &p_class_name);
+	void _res_set_data_func(int p_id, const StringName &p_prop, const String &p_res_path, const String &p_class_name);
 	void _node_path_func(const NodePath &p_path, int p_id);
 	void _res_path_func(const String &p_path, int p_id);
 


### PR DESCRIPTION
Fix: #117753

Now it checks if the resource actually exists on disk. If it doesn't, instead of failing, it serializes the resource and reconstructs it directly in memory on the remote instance.

it should work fine =)