### PR TITLE
Mark template function in math_funcs_binary constexpr

### DIFF
--- a/core/math/math_funcs_binary.h
+++ b/core/math/math_funcs_binary.h
@@ -38,7 +38,7 @@ namespace Math {
 
 // Returns `true` if a positive integer is a power of 2, `false` otherwise.
 template <typename T>
-inline bool is_power_of_2(const T x) {
+constexpr bool is_power_of_2(const T x) {
 	return x && ((x & (x - 1)) == 0);
 }
 
@@ -129,7 +129,7 @@ constexpr int32_t get_shift_from_power_of_2(uint32_t p_bits) {
 }
 
 template <typename T>
-_FORCE_INLINE_ T nearest_power_of_2_templated(T p_number) {
+constexpr T nearest_power_of_2_templated(T p_number) {
 	--p_number;
 
 	// The number of operations on x is the base two logarithm


### PR DESCRIPTION
In fixing a compile error of my gdextension I noticed the inconsistency of using `inline`, `inline static`, `constexpr` between `godot-cpp`([`include/godot_cpp/core/defs.hpp`](https://github.com/godotengine/godot-cpp/blob/master/include/godot_cpp/core/defs.hpp))  and `godot` ([`core/math/math_funcs_binary.h`](https://github.com/godotengine/godot/blob/master/core/math/math_funcs_binary.h)). The detail of my issue can be found below:
https://github.com/godotengine/godot-cpp/pull/1962

`godot` uses `constexpr` for most of functions in that file except for the two template functions `is_power_of_2` and `nearest_power_of_2_templated` which use just `inline`. `godot-cpp` uses `static inline` everywhere, and the `static inline` template function made my gdextension lib fail to build. Though I am not sure if it is a real error according to C++ standard or is just a clang bug with module, but I think `static inline` is not something appropriate in modern C++. So to be consistent I suggest that we put everything `constexpr` while possible. For the engine the only change is the two template functions.


