### PR TITLE
Fix SpinBox displayed value rounding

### DIFF
--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -93,6 +93,24 @@ int Math::range_step_decimals(double p_step) {
 	return step_decimals(p_step);
 }
 
+int Math::count_decimals(double p_value) {
+	int maxn = 5;
+	double abs_value = Math::abs(p_value);
+	int64_t integer = (int64_t)abs_value;
+	double frac = (abs_value - integer);
+	// Sliding window to the left to avoid evaluating float rounding noise.
+	maxn -= (int)(Math::log(integer * 10 + 0.5) / Math::log(10.0));
+	int64_t exponent = Math::pow(10.0, maxn + 1.0) + 0.5;
+	int64_t shifted = (frac * exponent) + 0.5;
+	for (int i = maxn; i >= 0; i--) {
+		if (shifted % 10) {
+			return i + 1;
+		}
+		shifted /= 10;
+	}
+	return 0;
+}
+
 double Math::ease(double p_x, double p_c) {
 	if (p_x < 0) {
 		p_x = 0;

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -674,6 +674,7 @@ _ALWAYS_INLINE_ float pingpong(float p_value, float p_length) {
 double ease(double p_x, double p_c);
 int step_decimals(double p_step);
 int range_step_decimals(double p_step); // For editor use only.
+int count_decimals(double p_value);
 double snapped(double p_value, double p_step);
 
 uint32_t larger_prime(uint32_t p_val);

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -98,7 +98,7 @@ Size2 SpinBox::get_minimum_size() const {
 
 void SpinBox::_update_text(bool p_only_update_if_value_changed) {
 	double step = get_step();
-	String value = String::num(get_value(), Math::range_step_decimals(step));
+	String value = String::num(get_value(), Math::count_decimals(step));
 	if (is_localizing_numeral_system()) {
 		value = TranslationServer::get_singleton()->format_number(value, _get_locale());
 	}

--- a/tests/core/math/test_math_funcs.cpp
+++ b/tests/core/math/test_math_funcs.cpp
@@ -338,6 +338,30 @@ TEST_CASE_TEMPLATE("[Math] range_step_decimals", T, float, double) {
 	CHECK(Math::range_step_decimals((T)-0.5) == 16);
 }
 
+TEST_CASE_TEMPLATE("[Math] count_decimals", T, float, double) {
+	CHECK(Math::count_decimals((T)-0.5) == 1);
+	CHECK(Math::count_decimals((T)0) == 0);
+	CHECK(Math::count_decimals((T)1) == 0);
+	CHECK(Math::count_decimals((T)2.1) == 1);
+	CHECK(Math::count_decimals((T)1.21) == 2);
+	CHECK(Math::count_decimals((T)1.121) == 3);
+	CHECK(Math::count_decimals((T)1.1121) == 4);
+	CHECK(Math::count_decimals((T)1.11121) == 5);
+	CHECK(Math::count_decimals((T)0.111121) == 6);
+	// Round digits beyond range
+	CHECK(Math::count_decimals((T)1.111121) == 5);
+	CHECK(Math::count_decimals((T)11.111121) == 4);
+	CHECK(Math::count_decimals((T)111.111121) == 3);
+	CHECK(Math::count_decimals((T)1111.111121) == 2);
+	CHECK(Math::count_decimals((T)11111.111121) == 1);
+	CHECK(Math::count_decimals((T)111111.111121) == 0);
+	CHECK(Math::count_decimals((T)0.1000001) == 1);
+	CHECK(Math::count_decimals((T)0.0000001) == 0);
+	CHECK(Math::count_decimals((T)0.9999994) == 6);
+	CHECK(Math::count_decimals((T)0.9999995) == 0);
+	CHECK(Math::count_decimals((T)0.0000099) == 5);
+}
+
 TEST_CASE_TEMPLATE("[Math] lerp", T, float, double) {
 	CHECK(Math::lerp((T)2.0, (T)5.0, (T)-0.1) == doctest::Approx((T)1.7));
 	CHECK(Math::lerp((T)2.0, (T)5.0, (T)0.0) == doctest::Approx((T)2.0));


### PR DESCRIPTION
Hello there, this PR fixes #118017 the SpinBox wrongfully using step_decimals to figure out how many decimals to render.

Adding Math::count_decimals to core seemed reasonable to me as it has wide utility which is why I diverted from a local fix (contained within SpinBox). (Maybe it can be added to GDScripts @global_scope as well)