### PR TITLE
Fix newly imported files not having existing UID assigned

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -920,15 +920,26 @@ bool EditorFileSystem::_update_scan_actions() {
 				const String new_file_path = ia.dir->get_file_path(idx);
 				const ResourceUID::ID existing_id = ResourceLoader::get_resource_uid(new_file_path);
 				if (existing_id != ResourceUID::INVALID_ID) {
-					const String old_path = ResourceUID::get_singleton()->get_id_path(existing_id);
-					if (old_path != new_file_path && FileAccess::exists(old_path)) {
+					const bool id_known = ResourceUID::get_singleton()->has_id(existing_id);
+					const String old_path = id_known ? ResourceUID::get_singleton()->get_id_path(existing_id) : String();
+
+					if (id_known && old_path != new_file_path && FileAccess::exists(old_path)) {
 						const ResourceUID::ID new_id = ResourceUID::get_singleton()->create_id_for_path(new_file_path);
 						ResourceUID::get_singleton()->add_id(new_id, new_file_path);
 						ResourceSaver::set_uid(new_file_path, new_id);
 						WARN_PRINT(vformat("Duplicate UID detected for Resource at \"%s\".\nOld Resource path: \"%s\". The new file UID was changed automatically.", new_file_path, old_path));
+						ia.new_file->uid = new_id;
 					} else {
 						// Re-assign the UID to file, just in case it was pulled from cache.
 						ResourceSaver::set_uid(new_file_path, existing_id);
+
+						if (id_known) {
+							ResourceUID::get_singleton()->set_id(existing_id, new_file_path);
+						} else {
+							ResourceUID::get_singleton()->add_id(existing_id, new_file_path);
+						}
+
+						ia.new_file->uid = existing_id;
 					}
 				} else if (ResourceLoader::should_create_uid_file(new_file_path)) {
 					Ref<FileAccess> f = FileAccess::open(new_file_path + ".uid", FileAccess::WRITE);


### PR DESCRIPTION
Fixes #109636.
Fixes #118038.

This change fixes three issues with the `ItemAction::ACTION_FILE_ADD` case in `EditorFileSystem::_update_scan_actions`:

1. It currently does a `ResourceUID::get_id_path` call without checking if the UID actually exists first, causing needless `Unrecognized UID: [...]` errors.
    - To fix this, I've added a `ResourceUID::has_id` check.
2. It does not currently assign anything to `ia.new_file->uid` for the case where the UID exists on disk but isn't known to `ResourceUID`, which becomes a problem for `ResourceSaver::get_resource_id_for_path` when saving out any file that references this UID, since it relies on whatever is cached in `EditorFileSystemDirectory::files`, leading to the UID part of the reference being erroneously removed.
    - To fix this, I've added said assignments.
3. It does not currently store the UID in `ResourceUID` for the case where the UID exists on disk but isn't known to `ResourceUID`, which seemed weird/broken.
    - To fix this, I've added `ResourceUID::set_id`/`ResourceUID::add_id` calls for that case.

---

_Disclaimer: AI tooling was used during the triage of these issues._