### PR TITLE
Update reminder about valid section and property names to remove erroneous information

### DIFF
--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -85,7 +85,7 @@
 		[/csharp]
 		[/codeblocks]
 		Any operation that mutates the ConfigFile such as [method set_value], [method clear], or [method erase_section], only changes what is loaded in memory. If you want to write the change to a file, you have to save the changes with [method save], [method save_encrypted], or [method save_encrypted_pass].
-		Keep in mind that section and property names can't contain spaces. Anything after a space will be ignored on save and on load.
+		Keep in mind that property names that are not valid identifiers should be quoted. Any non-valid characters in a non-quoted property name will be ignored on load.
 		ConfigFiles can also contain manually written comment lines starting with a semicolon ([code];[/code]). Those lines will be ignored when parsing the file. Note that comments will be lost when saving the ConfigFile. This can still be useful for dedicated server configuration files, which are typically never overwritten without explicit user action.
 		[b]Note:[/b] The file extension given to a ConfigFile does not have any impact on its formatting or behavior. By convention, the [code].cfg[/code] extension is used here, but any other extension such as [code].ini[/code] is also valid. Since neither [code].cfg[/code] nor [code].ini[/code] are standardized, Godot's ConfigFile formatting may differ from files written by other programs.
 	</description>


### PR DESCRIPTION
After a discussion with someone I discovered that the documentation of `ConfigFile` said that space were not supported while this does not seem true from my experience.

For example doing  :
```
var config_file := ConfigFile.new()

func _ready() -> void:
	config_file.set_value("test avec espace section","test avec espace key", "n'importe quoi")
	config_file.save("res://test.ini")
	config_file.load("res://test.ini")
	print(config_file.get_sections())
	print(config_file.get_section_keys("test avec espace section"))
```
Would result in this two line being printed
```
["test avec espace section"]
["test avec espace key"]
```
showing that it is in fact supported. 

And the file saved would look like that :
```
[test avec espace section]

"test avec espace key"="n'importe quoi"
```
The property name is quoted and section doesn't seem to have any problem about it at all.
This was tested on macos only and I assume there is no difference between platforms but wouldn't mind people double checking it is the case.

As I think people might be writing those file by hand I am adding a reminder to quote property name when they are not valid identifier.
I'm wondering wether we should add an example of quoted property name in the format example.

