### PR TITLE
Core: Restore legacy keyboard/mouse device IDs for old projects

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1018,6 +1018,10 @@ Error ProjectSettings::_load_settings_text_or_binary(const String &p_text_path, 
 					// Enable MeshInstance3D compat for projects created before 4.6.
 					set_setting("animation/compatibility/default_parent_skeleton_in_mesh_instance_3d", true);
 				}
+				if (major_version == 4 && minor_version < 7 && !has_setting("input_devices/compatibility/legacy_keyboard_mouse_device_ids")) {
+					// Keep legacy keyboard/mouse device IDs (device=0) for projects created before 4.7.
+					set_setting("input_devices/compatibility/legacy_keyboard_mouse_device_ids", true);
+				}
 				break;
 			}
 		}

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -803,6 +803,17 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 	// Regardless where the event came from originally, this has to happen on the main thread.
 	DEV_ASSERT(Thread::get_caller_id() == Thread::get_main_id());
 
+	// Backward compatibility for projects before 4.7: keyboard/mouse device IDs used to be 0.
+	if (legacy_keyboard_mouse_device_ids) {
+		const InputEventType type = p_event->get_type();
+		if (type == InputEventType::KEY || type == InputEventType::MOUSE_BUTTON || type == InputEventType::MOUSE_MOTION) {
+			const int device = p_event->get_device();
+			if (device == InputEvent::DEVICE_ID_KEYBOARD || device == InputEvent::DEVICE_ID_MOUSE) {
+				p_event->set_device(0);
+			}
+		}
+	}
+
 	// Notes on mouse-touch emulation:
 	// - Emulated mouse events are parsed, that is, re-routed to this method, so they make the same effects
 	//   as true mouse events. The only difference is the situation is flagged as emulated so they are not
@@ -2362,6 +2373,7 @@ Input::Input() {
 	}
 
 	legacy_just_pressed_behavior = GLOBAL_DEF("input_devices/compatibility/legacy_just_pressed_behavior", false);
+	legacy_keyboard_mouse_device_ids = GLOBAL_DEF("input_devices/compatibility/legacy_keyboard_mouse_device_ids", false);
 	if (Engine::get_singleton()->is_editor_hint()) {
 		// Always use standard behavior in the editor.
 		legacy_just_pressed_behavior = false;

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -125,6 +125,7 @@ private:
 	Vector2 mouse_pos;
 	int64_t mouse_window = 0;
 	bool legacy_just_pressed_behavior = false;
+	bool legacy_keyboard_mouse_device_ids = false;
 	bool disable_input = false;
 	bool ignore_joypad_on_unfocused_application = false;
 	bool application_focused = true;

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -206,19 +206,41 @@ void InputMap::action_add_event(const StringName &p_action, RequiredParam<InputE
 		return; // Already added.
 	}
 
-	// Normalize legacy device IDs: before the device ID change,
-	// keyboard and mouse events defaulted to device=0.
-	if (p_event->get_device() == 0) {
+	bool legacy_keyboard_mouse_device_ids = false;
+	if (ProjectSettings::get_singleton()->has_setting("input_devices/compatibility/legacy_keyboard_mouse_device_ids")) {
+		legacy_keyboard_mouse_device_ids = GLOBAL_GET("input_devices/compatibility/legacy_keyboard_mouse_device_ids");
+	}
+	if (legacy_keyboard_mouse_device_ids) {
+		// Legacy behavior: keyboard and mouse events used device=0.
 		switch (p_event->get_type()) {
 			case InputEventType::KEY:
-				p_event->set_device(InputEvent::DEVICE_ID_KEYBOARD);
+				if (p_event->get_device() == InputEvent::DEVICE_ID_KEYBOARD) {
+					p_event->set_device(0);
+				}
 				break;
 			case InputEventType::MOUSE_BUTTON:
 			case InputEventType::MOUSE_MOTION:
-				p_event->set_device(InputEvent::DEVICE_ID_MOUSE);
+				if (p_event->get_device() == InputEvent::DEVICE_ID_MOUSE) {
+					p_event->set_device(0);
+				}
 				break;
 			default:
 				break;
+		}
+	} else {
+		// keyboard and mouse events defaults to device=0.
+		if (p_event->get_device() == 0) {
+			switch (p_event->get_type()) {
+				case InputEventType::KEY:
+					p_event->set_device(InputEvent::DEVICE_ID_KEYBOARD);
+					break;
+				case InputEventType::MOUSE_BUTTON:
+				case InputEventType::MOUSE_MOTION:
+					p_event->set_device(InputEvent::DEVICE_ID_MOUSE);
+					break;
+				default:
+					break;
+			}
 		}
 	}
 

--- a/tests/core/input/test_input_event.cpp
+++ b/tests/core/input/test_input_event.cpp
@@ -32,6 +32,7 @@
 
 TEST_FORCE_LINK(test_input_event)
 
+#include "core/config/project_settings.h"
 #include "core/input/input_event.h"
 #include "core/input/input_map.h"
 #include "core/math/rect2.h"
@@ -95,6 +96,38 @@ TEST_CASE("[InputEvent][SceneTree] Test methods that interact with the InputMap"
 	CHECK(iejm->is_action_pressed(mock_action));
 
 	InputMap::get_singleton()->erase_action(mock_action);
+}
+
+TEST_CASE("[InputEvent][SceneTree][Compatibility] InputMap legacy keyboard/mouse device IDs") {
+	const String action = "compat_device_ids_action";
+	const String setting = "input_devices/compatibility/legacy_keyboard_mouse_device_ids";
+
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	InputMap *im = InputMap::get_singleton();
+	const bool had_setting = ps->has_setting(setting);
+	const Variant prev_value = had_setting ? ps->get_setting(setting) : Variant();
+
+	Ref<InputEventKey> key;
+	key.instantiate();
+
+	ps->set_setting(setting, true);
+	im->add_action(action, 0.5);
+	im->action_add_event(action, key);
+	CHECK(key->get_device() == 0);
+	im->erase_action(action);
+
+	ps->set_setting(setting, false);
+	im->add_action(action, 0.5);
+	key->set_device(0);
+	im->action_add_event(action, key);
+	CHECK(key->get_device() == InputEvent::DEVICE_ID_KEYBOARD);
+	im->erase_action(action);
+
+	if (had_setting) {
+		ps->set_setting(setting, prev_value);
+	} else {
+		ps->clear(setting);
+	}
 }
 
 TEST_CASE("[InputEvent] Test xformed_by") {


### PR DESCRIPTION
## Summary
Restore device ID 0 for keyboard/mouse events when a legacy compatibility setting is enabled.

## Motivation
Regression in 4.7-dev: keyboard/mouse events now default to device IDs 16/32, which breaks projects that relied on device=0. Fixes #118025.

## Technical overview
- Add a project setting: input_devices/compatibility/legacy_keyboard_mouse_device_ids.
- Auto-enable it for projects created before 4.7.
- When enabled, normalize keyboard/mouse events to device=0 at input dispatch and in InputMap event storage.
- Keep the new IDs as the default for new projects.

## Testing
Not run (code change + unit test update only).

## AI disclosure
This PR description was assisted by an AI tool.

## Breaking changes
None. Default behavior stays the same for new projects.
