### PR TITLE
Fix icons and code completion colors when following system theme

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4066,7 +4066,10 @@ void EditorNode::_check_system_theme_changed() {
 	}
 
 	if (system_theme_changed) {
+		class_icon_cache.clear();
 		_update_theme();
+		_build_icon_type_cache();
+		recent_scenes->reset_size();
 	} else if (menu_type == MENU_TYPE_GLOBAL && display_server->is_dark_mode_supported() && display_server->is_dark_mode() != last_dark_mode_state) {
 		last_dark_mode_state = display_server->is_dark_mode();
 

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1635,6 +1635,11 @@ void CodeTextEditor::_update_text_editor_theme() {
 	}
 
 	_update_font_ligatures();
+
+	update_editor_settings();
+	if (text_editor->get_code_completion_selected_index() != -1) {
+		_complete_request();
+	}
 }
 
 void CodeTextEditor::_update_font_ligatures() {


### PR DESCRIPTION
This change fixes the font color and some icons colors in the code completion dropdown menu when the theme is changed due to a change of the system theme.

This also fixes #116697 

Current behavior:
https://github.com/user-attachments/assets/8d831517-5ede-432e-ab07-d055b2f179df

With this change:
https://github.com/user-attachments/assets/8d0d6be3-0a60-4d0e-ad68-4bf304b044d0

This fix include two changes : 
One as pointed out here https://github.com/godotengine/godot/issues/116697#issuecomment-3960993322 to clear and rebuild the icon cache on system theme change to fix the icon colors.
Another change in `CodeTextEditor::_update_text_editor_theme()` to refresh the code completion font colors from the editor settings and resubmit the code completion suggestions with the correct font color if the dropdown is open when the theme change happens. (If the dropdown is not open, the correct font colors are still submitted the next time it is open anyway.)