### PR TITLE
Improve history and scroll for material in Quick Open dialog

### DIFF
--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -265,7 +265,7 @@ void EditorQuickOpenDialog::preview_property() {
 	property_object->set_block_signals(false);
 }
 
-void EditorQuickOpenDialog::update_property() {
+void EditorQuickOpenDialog::update_property() const {
 	// Set the property back to the initial value first, so that the undo action
 	// has the correct object.
 	if (property_object) {
@@ -519,7 +519,7 @@ void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
 		_set_display_mode(get_adaptive_display_mode(p_base_types));
 	} else if (never_opened) {
 		int last = EditorSettings::get_singleton()->get_project_metadata("quick_open_dialog", "last_mode", (int)QuickOpenDisplayMode::LIST);
-		_set_display_mode((QuickOpenDisplayMode)last);
+		_set_display_mode(static_cast<QuickOpenDisplayMode>(last));
 	}
 
 	const bool do_instant_preview = EDITOR_GET("filesystem/quick_open_dialog/instant_preview");
@@ -539,11 +539,8 @@ void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
 
 	if (first_open && history_file->load(_get_cache_file_path()) == OK) {
 		// Load history when opening for the first time.
-		file_type_icons.insert(SNAME("__default_icon"), get_editor_theme_icon(SNAME("Object")));
-
 		Vector<String> history_keys = history_file->get_section_keys("selected_history");
 		for (const String &type : history_keys) {
-			const StringName type_name = type;
 			const PackedStringArray history_uids = history_file->get_value("selected_history", type);
 
 			PackedStringArray cleaned_text_uids;
@@ -573,7 +570,6 @@ void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
 						continue;
 					}
 
-					filetypes.insert(id, type_name);
 					text_write[i] = uid;
 					id_write[i] = id;
 					i++;
@@ -599,10 +595,10 @@ void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
 
 		if (history) {
 			Vector<ResourceUID::ID> clean_history;
-
-			for (const ResourceUID::ID &uid : *history) {
-				if (ResourceUID::get_singleton()->has_id(uid)) {
-					clean_history.push_back(uid);
+			clean_history.reserve(history->size());
+			for (const ResourceUID::ID &id : *history) {
+				if (ResourceUID::get_singleton()->has_id(id)) {
+					clean_history.push_back(id);
 				} else {
 					history_modified = true;
 				}
@@ -623,7 +619,7 @@ void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
 	_create_initial_results();
 }
 
-void QuickOpenResultContainer::_sort_uids(int p_max_results) {
+void QuickOpenResultContainer::_sort_ids(int p_max_results) {
 	struct FilepathComparator {
 		bool operator()(const ResourceUID::ID &p_lhs, const ResourceUID::ID &p_rhs) const {
 			String lhs_path = ResourceUID::get_singleton()->get_id_path(p_lhs);
@@ -636,43 +632,37 @@ void QuickOpenResultContainer::_sort_uids(int p_max_results) {
 
 	SortArray<ResourceUID::ID, FilepathComparator> sorter{};
 
-	if ((int)uids.size() > p_max_results) {
-		sorter.partial_sort(0, uids.size(), p_max_results, uids.ptr());
+	if (static_cast<int>(ids.size()) > p_max_results) {
+		sorter.partial_sort(0, ids.size(), p_max_results, ids.ptr());
 	} else {
-		sorter.sort(uids.ptr(), uids.size());
+		sorter.sort(ids.ptr(), ids.size());
 	}
 }
 
 void QuickOpenResultContainer::_create_initial_results() {
 	file_type_icons.clear();
 	file_type_icons.insert(SNAME("__default_icon"), get_editor_theme_icon(SNAME("Object")));
-	uids.clear();
+	ids.clear();
 	filetypes.clear();
-	history_set.clear();
 
-	Vector<ResourceUID::ID> *history = _get_history();
-	if (history) {
-		for (const ResourceUID::ID &uid : *history) {
-			history_set.insert(uid);
-		}
-	}
+	_update_history();
 
-	_find_uids_in_folder(EditorFileSystem::get_singleton()->get_filesystem(), include_addons_toggle->is_pressed());
-	_sort_uids(result_items.size());
-	max_total_results = MIN(uids.size(), result_items.size());
+	_find_ids_in_folder(EditorFileSystem::get_singleton()->get_filesystem(), include_addons_toggle->is_pressed());
+	_sort_ids(result_items.size());
+	max_total_results = MIN(ids.size(), result_items.size());
 	update_results();
 }
 
-void QuickOpenResultContainer::_find_uids_in_folder(EditorFileSystemDirectory *p_directory, bool p_include_addons) {
+void QuickOpenResultContainer::_find_ids_in_folder(EditorFileSystemDirectory *p_directory, bool p_include_addons) {
 	for (int i = 0; i < p_directory->get_subdir_count(); i++) {
 		if (p_include_addons || p_directory->get_name() != "addons") {
-			_find_uids_in_folder(p_directory->get_subdir(i), p_include_addons);
+			_find_ids_in_folder(p_directory->get_subdir(i), p_include_addons);
 		}
 	}
 
 	for (int i = 0; i < p_directory->get_file_count(); i++) {
-		ResourceUID::ID uid = p_directory->get_file_uid(i);
-		if (uid == ResourceUID::INVALID_ID) {
+		ResourceUID::ID id = p_directory->get_file_uid(i);
+		if (id == ResourceUID::INVALID_ID) {
 			continue;
 		}
 
@@ -686,8 +676,8 @@ void QuickOpenResultContainer::_find_uids_in_folder(EditorFileSystemDirectory *p
 			bool is_valid = ClassDB::is_parent_class(engine_type, parent_type) || (!is_engine_type && EditorNode::get_editor_data().script_class_is_parent(script_type, parent_type));
 
 			if (is_valid) {
-				uids.push_back(uid);
-				filetypes.insert(uid, actual_type);
+				ids.push_back(id);
+				filetypes.insert(id, actual_type);
 				break; // Stop testing base types as soon as we get a match.
 			}
 		}
@@ -699,32 +689,45 @@ void QuickOpenResultContainer::set_query_and_update(const String &p_query) {
 	update_results();
 }
 
-Vector<ResourceUID::ID> *QuickOpenResultContainer::_get_history() {
+void QuickOpenResultContainer::_update_history() {
+	Vector<ResourceUID::ID> *history = nullptr;
 	if (base_types.size() == 1) {
-		return selected_history.getptr(base_types[0]);
+		history = selected_history.getptr(base_types[0]);
 	}
-	return nullptr;
+	if (!history) {
+		return;
+	}
+
+	const bool include_addons = include_addons_toggle->is_pressed();
+	visible_history.reserve(history->size());
+	for (const ResourceUID::ID &id : *history) {
+		if (!include_addons && ResourceUID::get_singleton()->get_id_path(id).begins_with("res://addons/")) {
+			continue;
+		}
+		visible_history.push_back(id);
+		history_set.insert(id);
+	}
 }
 
-QuickOpenResultCandidate QuickOpenResultCandidate::from_uid(const ResourceUID::ID &p_uid, bool &r_success) {
-	if (p_uid == ResourceUID::INVALID_ID || !ResourceUID::get_singleton()->has_id(p_uid)) {
+QuickOpenResultCandidate QuickOpenResultCandidate::from_id(const ResourceUID::ID &p_id, bool &r_success) {
+	if (p_id == ResourceUID::INVALID_ID || !ResourceUID::get_singleton()->has_id(p_id)) {
 		r_success = false;
 		return QuickOpenResultCandidate();
 	}
 
 	QuickOpenResultCandidate candidate;
-	candidate.uid = p_uid;
+	candidate.id = p_id;
 	candidate.result = nullptr;
 	r_success = true;
 	return candidate;
 }
 
 QuickOpenResultCandidate QuickOpenResultCandidate::from_result(const FuzzySearchResult &p_result, bool &r_success) {
-	ResourceUID::ID uid = EditorFileSystem::get_singleton()->get_file_uid(p_result.target);
+	const ResourceUID::ID id = EditorFileSystem::get_singleton()->get_file_uid(p_result.target);
 
-	QuickOpenResultCandidate candidate = from_uid(uid, r_success);
+	QuickOpenResultCandidate candidate = from_id(id, r_success);
 	if (!r_success) {
-		return QuickOpenResultCandidate();
+		return candidate;
 	}
 
 	candidate.result = &p_result;
@@ -732,19 +735,19 @@ QuickOpenResultCandidate QuickOpenResultCandidate::from_result(const FuzzySearch
 }
 
 void QuickOpenResultContainer::_add_candidate(QuickOpenResultCandidate &p_candidate) {
-	ERR_FAIL_COND(!ResourceUID::get_singleton()->has_id(p_candidate.uid));
+	ERR_FAIL_COND(!ResourceUID::get_singleton()->has_id(p_candidate.id));
 
 	StringName actual_type;
 	{
-		StringName *actual_type_ptr = filetypes.getptr(p_candidate.uid);
+		StringName *actual_type_ptr = filetypes.getptr(p_candidate.id);
 		if (actual_type_ptr) {
 			actual_type = *actual_type_ptr;
 		} else {
-			ERR_PRINT(vformat("EditorQuickOpenDialog: No type for path %s.", ResourceUID::get_singleton()->get_id_path(p_candidate.uid)));
+			ERR_PRINT(vformat("EditorQuickOpenDialog: No type for path %s.", ResourceUID::get_singleton()->get_id_path(p_candidate.id)));
 		}
 	}
 
-	String file_path = ResourceUID::get_singleton()->get_id_path(p_candidate.uid);
+	String file_path = ResourceUID::get_singleton()->get_id_path(p_candidate.id);
 	EditorResourcePreview::PreviewItem item = EditorResourcePreview::get_singleton()->get_resource_preview_if_available(file_path);
 	if (item.preview.is_valid()) {
 		p_candidate.thumbnail = item.preview;
@@ -758,12 +761,12 @@ void QuickOpenResultContainer::_add_candidate(QuickOpenResultCandidate &p_candid
 	}
 
 	candidates.push_back(p_candidate);
-	candidates_uids.insert(p_candidate.uid);
+	candidates_ids.insert(p_candidate.id);
 }
 
 void QuickOpenResultContainer::update_results() {
 	candidates.clear();
-	candidates_uids.clear();
+	candidates_ids.clear();
 
 	if (query.is_empty()) {
 		_use_default_candidates();
@@ -775,13 +778,11 @@ void QuickOpenResultContainer::update_results() {
 }
 
 void QuickOpenResultContainer::_use_default_candidates() {
-	HashSet<ResourceUID::ID> existing_uids;
-
-	Vector<ResourceUID::ID> *history = _get_history();
-	if (history) {
-		for (const ResourceUID::ID &uid : *history) {
+	candidates.reserve(visible_history.size() + ids.size());
+	if (!visible_history.is_empty()) {
+		for (const ResourceUID::ID &id : visible_history) {
 			bool success;
-			QuickOpenResultCandidate candidate = QuickOpenResultCandidate::from_uid(uid, success);
+			QuickOpenResultCandidate candidate = QuickOpenResultCandidate::from_id(id, success);
 			if (!success) {
 				continue;
 			}
@@ -789,16 +790,16 @@ void QuickOpenResultContainer::_use_default_candidates() {
 		}
 	}
 
-	for (const ResourceUID::ID &uid : uids) {
+	for (const ResourceUID::ID &id : ids) {
 		if (candidates.size() >= max_total_results) {
 			break;
 		}
-		if (candidates_uids.has(uid)) {
+		if (candidates_ids.has(id)) {
 			continue;
 		}
 
 		bool success;
-		QuickOpenResultCandidate candidate = QuickOpenResultCandidate::from_uid(uid, success);
+		QuickOpenResultCandidate candidate = QuickOpenResultCandidate::from_id(id, success);
 		if (!success) {
 			continue;
 		}
@@ -818,10 +819,9 @@ void QuickOpenResultContainer::_update_fuzzy_search_results() {
 	fuzzy_search.max_misses = fuzzy_matching ? max_misses : 0;
 
 	PackedStringArray paths;
-	paths.reserve_exact(uids.size());
-
-	for (const ResourceUID::ID &uid : uids) {
-		paths.push_back(ResourceUID::get_singleton()->get_id_path(uid));
+	paths.reserve_exact(ids.size());
+	for (const ResourceUID::ID &id : ids) {
+		paths.push_back(ResourceUID::get_singleton()->get_id_path(id));
 	}
 
 	fuzzy_search.search_all(paths, search_results);
@@ -830,6 +830,7 @@ void QuickOpenResultContainer::_update_fuzzy_search_results() {
 void QuickOpenResultContainer::_score_and_sort_candidates() {
 	_update_fuzzy_search_results();
 
+	candidates.reserve(search_results.size());
 	for (const FuzzySearchResult &result : search_results) {
 		bool success;
 		QuickOpenResultCandidate candidate = QuickOpenResultCandidate::from_result(result, success);
@@ -854,7 +855,7 @@ void QuickOpenResultContainer::_update_result_items(int p_new_visible_results_co
 		} else {
 			item->reset();
 		}
-	};
+	}
 
 	const bool any_results = num_visible_results > 0;
 	_select_item(any_results ? p_new_selection_index : -1);
@@ -863,7 +864,7 @@ void QuickOpenResultContainer::_update_result_items(int p_new_visible_results_co
 	no_results_container->set_visible(!any_results);
 
 	if (!any_results) {
-		if (uids.is_empty()) {
+		if (ids.is_empty()) {
 			no_results_label->set_text(TTR("No files found for this type"));
 		} else {
 			no_results_label->set_text(TTR("No results found"));
@@ -960,7 +961,7 @@ void QuickOpenResultContainer::_select_item(int p_index) {
 	}
 
 	result_items[selection_index]->highlight_item(true);
-	bool in_history = history_set.has(candidates[selection_index].uid);
+	bool in_history = history_set.has(candidates[selection_index].id);
 	file_details_path->set_text(get_selected_path() + (in_history ? TTR(" (recently opened)") : ""));
 
 	emit_signal(SNAME("selection_changed"));
@@ -1073,12 +1074,12 @@ bool QuickOpenResultContainer::has_nothing_selected() const {
 
 ResourceUID::ID QuickOpenResultContainer::get_selected() const {
 	ERR_FAIL_COND_V_MSG(has_nothing_selected(), ResourceUID::INVALID_ID, "Tried to get selected file, but nothing was selected.");
-	return candidates[selection_index].uid;
+	return candidates[selection_index].id;
 }
 
 String QuickOpenResultContainer::get_selected_path() const {
 	ERR_FAIL_COND_V_MSG(has_nothing_selected(), "", "Tried to get selected file path, but nothing was selected.");
-	String path = ResourceUID::get_singleton()->get_id_path(candidates[selection_index].uid);
+	String path = ResourceUID::get_singleton()->get_id_path(candidates[selection_index].id);
 	ERR_FAIL_COND_V_MSG(path.is_empty(), "", "Failed to get selected file path.");
 	return path;
 }
@@ -1106,16 +1107,11 @@ QuickOpenDisplayMode QuickOpenResultContainer::get_adaptive_display_mode(const V
 	return QuickOpenDisplayMode::LIST;
 }
 
-String _get_uid_string(const String &p_filepath) {
-	ResourceUID::ID id = EditorFileSystem::get_singleton()->get_file_uid(p_filepath);
-	return id == ResourceUID::INVALID_ID ? p_filepath : ResourceUID::get_singleton()->id_to_text(id);
-}
-
 bool QuickOpenResultContainer::is_instant_preview_enabled() const {
 	return instant_preview_toggle && instant_preview_toggle->is_visible() && instant_preview_toggle->is_pressed();
 }
 
-void QuickOpenResultContainer::set_instant_preview_toggle_visible(bool p_visible) {
+void QuickOpenResultContainer::set_instant_preview_toggle_visible(bool p_visible) const {
 	instant_preview_toggle->set_visible(p_visible);
 }
 
@@ -1142,7 +1138,6 @@ void QuickOpenResultContainer::save_selected_item() {
 		}
 	}
 
-	history_set.insert(selected);
 	type_history->insert(0, selected);
 	if (type_history->size() > MAX_HISTORY_SIZE) {
 		type_history->resize(MAX_HISTORY_SIZE);
@@ -1154,8 +1149,8 @@ void QuickOpenResultContainer::save_selected_item() {
 		String *uids_write = history_uids.ptrw();
 
 		int i = 0;
-		for (const ResourceUID::ID &uid : *type_history) {
-			uids_write[i] = ResourceUID::get_singleton()->id_to_text(uid);
+		for (const ResourceUID::ID &id : *type_history) {
+			uids_write[i] = ResourceUID::get_singleton()->id_to_text(id);
 			i++;
 		}
 	}
@@ -1167,6 +1162,7 @@ void QuickOpenResultContainer::cleanup() {
 	num_visible_results = 0;
 	candidates.clear();
 	history_set.clear();
+	visible_history.clear();
 	_select_item(-1);
 
 	for (QuickOpenResultItem *item : result_items) {
@@ -1356,7 +1352,7 @@ QuickOpenResultListItem::QuickOpenResultListItem() {
 void QuickOpenResultListItem::set_content(const QuickOpenResultCandidate &p_candidate, bool p_highlight) {
 	thumbnail->set_texture(p_candidate.thumbnail);
 
-	String file_path = ResourceUID::get_singleton()->get_id_path(p_candidate.uid);
+	String file_path = ResourceUID::get_singleton()->get_id_path(p_candidate.id);
 	name->set_text(file_path.get_file());
 	path->set_text(file_path.get_base_dir());
 	name->reset_highlights();
@@ -1429,7 +1425,7 @@ QuickOpenResultGridItem::QuickOpenResultGridItem() {
 void QuickOpenResultGridItem::set_content(const QuickOpenResultCandidate &p_candidate, bool p_highlight) {
 	thumbnail->set_texture(p_candidate.thumbnail);
 
-	String file_path = ResourceUID::get_singleton()->get_id_path(p_candidate.uid);
+	String file_path = ResourceUID::get_singleton()->get_id_path(p_candidate.id);
 	name->set_text(file_path.get_file());
 	name->set_tooltip_text(file_path);
 	name->reset_highlights();

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -140,16 +140,21 @@ EditorQuickOpenDialog::EditorQuickOpenDialog() {
 	get_ok_button()->hide();
 }
 
-String EditorQuickOpenDialog::get_dialog_title(const Vector<StringName> &p_base_types) {
-	if (p_base_types.size() > 1) {
-		return TTR("Select Resource");
+String EditorQuickOpenDialog::get_dialog_title() const {
+	Vector<StringName> allowed_types = container->get_base_types();
+	if (allowed_types.size() > 1) {
+		String joined_types;
+		for (int i = 0; i < allowed_types.size(); i++) {
+			joined_types += String(allowed_types[i]) + (i < allowed_types.size() - 1 ? ", " : "");
+		}
+		return vformat(TTR("Select %s"), joined_types);
 	}
 
-	if (p_base_types[0] == SNAME("PackedScene")) {
+	if (allowed_types[0] == SNAME("PackedScene")) {
 		return TTR("Select Scene");
 	}
 
-	return vformat(TTR("Select %s"), p_base_types[0]);
+	return vformat(TTR("Select %s"), allowed_types[0]);
 }
 
 void EditorQuickOpenDialog::popup_dialog(const Vector<StringName> &p_base_types, const Callable &p_item_selected_callback, bool p_allow_type_switching) {
@@ -178,10 +183,9 @@ void EditorQuickOpenDialog::popup_dialog_for_property(const Vector<StringName> &
 	initial_property_value = property_object->get(property_path);
 	allow_type_switching = false;
 
-	// Reset this, so that the property isn't updated immediately upon opening
-	// the window.
-	initial_selection_performed = false;
-
+	if (!initial_property_value.is_null()) {
+		container->set_assigned_resource_id(EditorFileSystem::get_singleton()->get_file_uid(initial_property_value.call("get_path")));
+	}
 	container->init(p_base_types);
 	container->set_instant_preview_toggle_visible(true);
 	_finish_dialog_setup(p_base_types);
@@ -190,7 +194,7 @@ void EditorQuickOpenDialog::popup_dialog_for_property(const Vector<StringName> &
 void EditorQuickOpenDialog::_finish_dialog_setup(const Vector<StringName> &p_base_types) {
 	set_process_shortcut_input(allow_type_switching);
 	get_ok_button()->set_disabled(container->has_nothing_selected());
-	set_title(get_dialog_title(p_base_types));
+	set_title(get_dialog_title());
 	popup_centered_clamped(Size2(780, 650) * EDSCALE, 0.8f);
 	search_box->grab_focus();
 }
@@ -202,24 +206,20 @@ void EditorQuickOpenDialog::ok_pressed() {
 	container->cleanup();
 	search_box->clear();
 	hide();
+	// Don't clear when toggling include addons
+	container->set_assigned_resource_id(ResourceUID::INVALID_ID);
 }
 
 bool EditorQuickOpenDialog::_is_instant_preview_active() const {
 	return property_object != nullptr && container->is_instant_preview_enabled();
 }
 
-void EditorQuickOpenDialog::selection_changed() {
+void EditorQuickOpenDialog::selection_changed() const {
 	if (!_is_instant_preview_active()) {
 		return;
 	}
 
-	// This prevents the property from being changed the first time the Quick Open
-	// window is opened.
-	if (!initial_selection_performed) {
-		initial_selection_performed = true;
-	} else {
-		preview_property();
-	}
+	preview_property();
 }
 
 void EditorQuickOpenDialog::item_pressed(bool p_double_click) {
@@ -236,21 +236,26 @@ void EditorQuickOpenDialog::item_pressed(bool p_double_click) {
 	}
 }
 
-void EditorQuickOpenDialog::preview_property() {
-	ERR_FAIL_COND(container->get_selected() == ResourceUID::INVALID_ID);
-	String path = container->get_selected_path();
+void EditorQuickOpenDialog::preview_property() const {
+	Variant preview_resource;
+	if (!container->has_nothing_selected()) {
+		String path = container->get_selected_path();
 
-	Ref<Resource> loaded_resource = ResourceLoader::load(path);
-	ERR_FAIL_COND_MSG(loaded_resource.is_null(), "Cannot load resource from path '" + path + "'.");
+		preview_resource = ResourceLoader::load(path);
+		ERR_FAIL_COND_MSG(preview_resource.is_null(), "Cannot load resource from path '" + path + "'.");
 
-	Resource *res = Object::cast_to<Resource>(property_object);
-	if (res) {
-		HashSet<Resource *> resources_found;
-		resources_found.insert(res);
-		if (EditorNode::find_recursive_resources(loaded_resource, resources_found)) {
-			EditorToaster::get_singleton()->popup_str(TTR("Recursion detected, Instant Preview failed."), EditorToaster::SEVERITY_ERROR);
-			loaded_resource = Ref<Resource>();
+		Resource *res = Object::cast_to<Resource>(property_object);
+		if (res) {
+			HashSet<Resource *> resources_found;
+			resources_found.insert(res);
+			if (EditorNode::find_recursive_resources(preview_resource, resources_found)) {
+				EditorToaster::get_singleton()->popup_str(TTR("Recursion detected, Instant Preview failed."), EditorToaster::SEVERITY_ERROR);
+				preview_resource = Ref<Resource>();
+			}
 		}
+	} else {
+		// Reset preview resource to initial value.
+		preview_resource = initial_property_value;
 	}
 
 	// MultiNodeEdit has adding to the undo/redo stack baked into its set function.
@@ -258,9 +263,9 @@ void EditorQuickOpenDialog::preview_property() {
 	// create undo/redo actions.
 	property_object->set_block_signals(true);
 	if (Object::cast_to<MultiNodeEdit>(property_object)) {
-		Object::cast_to<MultiNodeEdit>(property_object)->_set_impl(property_path, loaded_resource, "", false);
+		Object::cast_to<MultiNodeEdit>(property_object)->_set_impl(property_path, preview_resource, "", false);
 	} else {
-		property_object->set(property_path, loaded_resource);
+		property_object->set(property_path, preview_resource);
 	}
 	property_object->set_block_signals(false);
 }
@@ -297,6 +302,7 @@ void EditorQuickOpenDialog::cancel_pressed() {
 	}
 	container->cleanup();
 	search_box->clear();
+	container->set_assigned_resource_id(ResourceUID::INVALID_ID);
 }
 
 void EditorQuickOpenDialog::shortcut_input(const Ref<InputEvent> &p_event) {
@@ -340,7 +346,7 @@ void EditorQuickOpenDialog::shortcut_input(const Ref<InputEvent> &p_event) {
 		container->init(new_base_types);
 		container->set_instant_preview_toggle_visible(false);
 		is_cycling_items = false;
-		set_title(get_dialog_title(new_base_types));
+		set_title(get_dialog_title());
 		search_box->clear();
 		search_box->grab_focus();
 	}
@@ -507,16 +513,37 @@ void QuickOpenResultContainer::_ensure_result_vector_capacity() {
 	}
 }
 
+void QuickOpenResultContainer::_resolve_actual_type(const Vector<StringName> &p_base_types) {
+	Vector<StringName> allowed_types;
+	for (const StringName &type : p_base_types) {
+		if (ClassDB::is_abstract(type)) {
+			List<StringName> inheriters;
+			ClassDB::get_direct_inheriters_from_class(type, &inheriters);
+			for (const StringName &inheritor : inheriters) {
+				allowed_types.push_back(inheritor);
+			}
+		} else {
+			allowed_types.push_back(type);
+		}
+	}
+	actual_types = allowed_types;
+}
+
 void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
 	_ensure_result_vector_capacity();
-	base_types = p_base_types;
+	if (p_base_types.size() > 1) {
+		// Material
+		_resolve_actual_type(p_base_types);
+	} else {
+		actual_types = p_base_types;
+	}
 
 	const int display_mode_behavior = EDITOR_GET("filesystem/quick_open_dialog/default_display_mode");
 	const bool adaptive_display_mode = (display_mode_behavior == 0);
 	const bool first_open = never_opened;
 
 	if (adaptive_display_mode) {
-		_set_display_mode(get_adaptive_display_mode(p_base_types));
+		_set_display_mode(get_adaptive_display_mode(actual_types));
 	} else if (never_opened) {
 		int last = EditorSettings::get_singleton()->get_project_metadata("quick_open_dialog", "last_mode", (int)QuickOpenDisplayMode::LIST);
 		_set_display_mode(static_cast<QuickOpenDisplayMode>(last));
@@ -589,25 +616,25 @@ void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
 				}
 			}
 		}
-	} else if (!first_open && base_types.size() == 1) {
-		const StringName &type = base_types[0];
-		Vector<ResourceUID::ID> *history = selected_history.getptr(type);
-
-		if (history) {
-			Vector<ResourceUID::ID> clean_history;
-			clean_history.reserve(history->size());
-			for (const ResourceUID::ID &id : *history) {
-				if (ResourceUID::get_singleton()->has_id(id)) {
-					clean_history.push_back(id);
-				} else {
-					history_modified = true;
+	} else if (!first_open) {
+		for (const StringName &type : actual_types) {
+			Vector<ResourceUID::ID> *history = selected_history.getptr(type);
+			if (history) {
+				Vector<ResourceUID::ID> clean_history;
+				clean_history.reserve(history->size());
+				for (const ResourceUID::ID &id : *history) {
+					if (ResourceUID::get_singleton()->has_id(id)) {
+						clean_history.push_back(id);
+					} else {
+						history_modified = true;
+					}
 				}
-			}
 
-			if (clean_history.is_empty()) {
-				selected_history.erase(type);
-			} else if (history_modified) {
-				*history = clean_history;
+				if (clean_history.is_empty()) {
+					selected_history.erase(type);
+				} else if (history_modified) {
+					*history = clean_history;
+				}
 			}
 		}
 	}
@@ -672,7 +699,7 @@ void QuickOpenResultContainer::_find_ids_in_folder(EditorFileSystemDirectory *p_
 		const bool is_engine_type = script_type == StringName();
 		const StringName &actual_type = is_engine_type ? engine_type : script_type;
 
-		for (const StringName &parent_type : base_types) {
+		for (const StringName &parent_type : actual_types) {
 			bool is_valid = ClassDB::is_parent_class(engine_type, parent_type) || (!is_engine_type && EditorNode::get_editor_data().script_class_is_parent(script_type, parent_type));
 
 			if (is_valid) {
@@ -684,28 +711,31 @@ void QuickOpenResultContainer::_find_ids_in_folder(EditorFileSystemDirectory *p_
 	}
 }
 
+void QuickOpenResultContainer::set_assigned_resource_id(ResourceUID::ID p_id) {
+	assigned_resource_id = p_id;
+}
+
 void QuickOpenResultContainer::set_query_and_update(const String &p_query) {
 	query = p_query;
 	update_results();
 }
 
 void QuickOpenResultContainer::_update_history() {
-	Vector<ResourceUID::ID> *history = nullptr;
-	if (base_types.size() == 1) {
-		history = selected_history.getptr(base_types[0]);
-	}
-	if (!history) {
-		return;
-	}
-
 	const bool include_addons = include_addons_toggle->is_pressed();
-	visible_history.reserve(history->size());
-	for (const ResourceUID::ID &id : *history) {
-		if (!include_addons && ResourceUID::get_singleton()->get_id_path(id).begins_with("res://addons/")) {
+	for (const StringName &type : actual_types) {
+		Vector<ResourceUID::ID> *history = selected_history.getptr(type);
+		if (!history) {
 			continue;
 		}
-		visible_history.push_back(id);
-		history_set.insert(id);
+
+		visible_history.reserve(visible_history.size() + static_cast<int>(history->size()));
+		for (const ResourceUID::ID &id : *history) {
+			if (!include_addons && ResourceUID::get_singleton()->get_id_path(id).begins_with("res://addons/")) {
+				continue;
+			}
+			visible_history.push_back(id);
+			history_set.insert(id);
+		}
 	}
 }
 
@@ -774,12 +804,18 @@ void QuickOpenResultContainer::update_results() {
 		_score_and_sort_candidates();
 	}
 
-	_update_result_items(MIN(candidates.size(), max_total_results), 0);
+	if (has_nothing_selected()) {
+		reset_preview = true;
+	}
+	_update_result_items(MIN(candidates.size(), max_total_results));
 }
 
 void QuickOpenResultContainer::_use_default_candidates() {
 	candidates.reserve(visible_history.size() + ids.size());
-	if (!visible_history.is_empty()) {
+	const bool has_valid_resource_id = assigned_resource_id != ResourceUID::INVALID_ID;
+
+	// When no resource is selected, show history first.
+	if (!visible_history.is_empty() && !has_valid_resource_id) {
 		for (const ResourceUID::ID &id : visible_history) {
 			bool success;
 			QuickOpenResultCandidate candidate = QuickOpenResultCandidate::from_id(id, success);
@@ -804,6 +840,9 @@ void QuickOpenResultContainer::_use_default_candidates() {
 			continue;
 		}
 
+		if (has_valid_resource_id && id == assigned_resource_id) {
+			selection_index = static_cast<int>(candidates.size());
+		}
 		_add_candidate(candidate);
 	}
 }
@@ -842,7 +881,7 @@ void QuickOpenResultContainer::_score_and_sort_candidates() {
 	}
 }
 
-void QuickOpenResultContainer::_update_result_items(int p_new_visible_results_count, int p_new_selection_index) {
+void QuickOpenResultContainer::_update_result_items(int p_new_visible_results_count) {
 	// Only need to update items that were not hidden in previous update.
 	int num_items_needing_updates = MAX(num_visible_results, p_new_visible_results_count);
 	num_visible_results = p_new_visible_results_count;
@@ -858,7 +897,7 @@ void QuickOpenResultContainer::_update_result_items(int p_new_visible_results_co
 	}
 
 	const bool any_results = num_visible_results > 0;
-	_select_item(any_results ? p_new_selection_index : -1);
+	_select_item(any_results ? selection_index : -1, true);
 
 	scroll_container->set_visible(any_results);
 	no_results_container->set_visible(!any_results);
@@ -948,7 +987,7 @@ void QuickOpenResultContainer::_move_selection_index(Key p_key) {
 	_select_item(idx);
 }
 
-void QuickOpenResultContainer::_select_item(int p_index) {
+void QuickOpenResultContainer::_select_item(int p_index, bool p_center_on_scroll) {
 	if (!has_nothing_selected()) {
 		result_items[selection_index]->highlight_item(false);
 	}
@@ -956,29 +995,46 @@ void QuickOpenResultContainer::_select_item(int p_index) {
 	selection_index = p_index;
 
 	if (has_nothing_selected()) {
+		if (reset_preview) {
+			emit_signal(SNAME("selection_changed"));
+			reset_preview = false;
+		}
 		file_details_path->set_text("");
 		return;
 	}
 
-	result_items[selection_index]->highlight_item(true);
+	QuickOpenResultItem *selection_item = result_items[selection_index];
+	selection_item->highlight_item(true);
 	bool in_history = history_set.has(candidates[selection_index].id);
 	file_details_path->set_text(get_selected_path() + (in_history ? TTR(" (recently opened)") : ""));
 
 	emit_signal(SNAME("selection_changed"));
 
-	const QuickOpenResultItem *item = result_items[selection_index];
+	if (p_center_on_scroll) {
+		// Wait for layout pending finished before scrolling.
+		selection_item->call_on_all_layout_pending_finished(callable_mp(this, &QuickOpenResultContainer::_scroll_to_center).bind(selection_item));
+	} else {
+		// Copied from Tree.
+		const int selection_position = selection_item->get_position().y;
+		const int selection_size = selection_item->get_size().y;
+		const int scroll_window_size = scroll_container->get_size().y;
+		const int scroll_position = scroll_container->get_v_scroll();
 
-	// Copied from Tree.
-	const int selected_position = item->get_position().y;
-	const int selected_size = item->get_size().y;
-	const int scroll_window_size = scroll_container->get_size().y;
-	const int scroll_position = scroll_container->get_v_scroll();
-
-	if (selected_position <= scroll_position) {
-		scroll_container->set_v_scroll(selected_position);
-	} else if (selected_position + selected_size > scroll_position + scroll_window_size) {
-		scroll_container->set_v_scroll(selected_position + selected_size - scroll_window_size);
+		if (selection_position <= scroll_position) {
+			scroll_container->set_v_scroll(selection_position);
+		} else if (selection_position + selection_size > scroll_position + scroll_window_size) {
+			scroll_container->set_v_scroll(selection_position + selection_size - scroll_window_size);
+		}
 	}
+}
+
+void QuickOpenResultContainer::_scroll_to_center(QuickOpenResultItem *p_item) const {
+	const int selection_position = p_item->get_position().y;
+	const int selection_size = p_item->get_size().y;
+	const int scroll_window_size = scroll_container->get_size().y;
+
+	const int centered_scroll = selection_position + selection_size / 2 - scroll_window_size / 2;
+	scroll_container->set_v_scroll(centered_scroll);
 }
 
 void QuickOpenResultContainer::_item_input(const Ref<InputEvent> &p_ev, int p_index) {
@@ -1057,7 +1113,7 @@ void QuickOpenResultContainer::_set_display_mode(QuickOpenDisplayMode p_display_
 		_layout_result_item(item);
 	}
 
-	_update_result_items(num_visible_results, selection_index);
+	_update_result_items(num_visible_results);
 
 	if (content_display_mode == QuickOpenDisplayMode::LIST) {
 		display_mode_toggle->set_button_icon(get_editor_theme_icon(SNAME("FileThumbnail")));
@@ -1085,7 +1141,7 @@ String QuickOpenResultContainer::get_selected_path() const {
 }
 
 const Vector<StringName> &QuickOpenResultContainer::get_base_types() const {
-	return base_types;
+	return actual_types;
 }
 
 QuickOpenDisplayMode QuickOpenResultContainer::get_adaptive_display_mode(const Vector<StringName> &p_base_types) {
@@ -1116,29 +1172,23 @@ void QuickOpenResultContainer::set_instant_preview_toggle_visible(bool p_visible
 }
 
 void QuickOpenResultContainer::save_selected_item() {
-	if (base_types.size() > 1) {
-		// Getting the type of the file and checking which base type it belongs to should be possible.
-		// However, for now these are not supported, and we don't record this.
-		return;
-	}
-
-	const StringName &base_type = base_types[0];
-	ResourceUID::ID selected = get_selected();
-	Vector<ResourceUID::ID> *type_history = selected_history.getptr(base_type);
+	const ResourceUID::ID selection_id = get_selected();
+	const StringName &selection_type = filetypes.get(selection_id);
+	Vector<ResourceUID::ID> *type_history = selected_history.getptr(selection_type);
 
 	if (!type_history) {
-		selected_history.insert(base_type, Vector<ResourceUID::ID>());
-		type_history = selected_history.getptr(base_type);
+		selected_history.insert(selection_type, Vector<ResourceUID::ID>());
+		type_history = selected_history.getptr(selection_type);
 	} else {
 		for (int i = 0; i < type_history->size(); i++) {
-			if (selected == type_history->get(i)) {
+			if (selection_id == type_history->get(i)) {
 				type_history->remove_at(i);
 				break;
 			}
 		}
 	}
 
-	type_history->insert(0, selected);
+	type_history->insert(0, selection_id);
 	if (type_history->size() > MAX_HISTORY_SIZE) {
 		type_history->resize(MAX_HISTORY_SIZE);
 	}
@@ -1154,7 +1204,7 @@ void QuickOpenResultContainer::save_selected_item() {
 			i++;
 		}
 	}
-	history_file->set_value("selected_history", base_type, history_uids);
+	history_file->set_value("selected_history", selection_type, history_uids);
 	history_file->save(_get_cache_file_path());
 }
 

--- a/editor/gui/editor_quick_open_dialog.h
+++ b/editor/gui/editor_quick_open_dialog.h
@@ -97,6 +97,7 @@ public:
 	void set_query_and_update(const String &p_query);
 	void update_results();
 
+	void set_assigned_resource_id(ResourceUID::ID p_id);
 	bool has_nothing_selected() const;
 	ResourceUID::ID get_selected() const;
 	String get_selected_path() const;
@@ -117,7 +118,7 @@ private:
 	static constexpr int MAX_HISTORY_SIZE = 20;
 
 	Vector<FuzzySearchResult> search_results;
-	Vector<StringName> base_types;
+	Vector<StringName> actual_types;
 	LocalVector<ResourceUID::ID> ids;
 	AHashMap<ResourceUID::ID, StringName> filetypes;
 	Vector<QuickOpenResultCandidate> candidates;
@@ -128,11 +129,13 @@ private:
 	HashSet<ResourceUID::ID> history_set;
 
 	String query;
+	ResourceUID::ID assigned_resource_id;
 	int selection_index = -1;
 	int num_visible_results = 0;
 	int max_total_results = 0;
 
 	bool never_opened = true;
+	bool reset_preview = false;
 	Ref<ConfigFile> history_file;
 
 	QuickOpenDisplayMode content_display_mode = QuickOpenDisplayMode::LIST;
@@ -162,15 +165,17 @@ private:
 	void _create_initial_results();
 	void _find_ids_in_folder(EditorFileSystemDirectory *p_directory, bool p_include_addons);
 
+	void _resolve_actual_type(const Vector<StringName> &p_base_types);
 	void _update_history();
 	void _add_candidate(QuickOpenResultCandidate &p_candidate);
 	void _update_fuzzy_search_results();
 	void _use_default_candidates();
 	void _score_and_sort_candidates();
-	void _update_result_items(int p_new_visible_results_count, int p_new_selection_index);
+	void _update_result_items(int p_new_visible_results_count);
 
 	void _move_selection_index(Key p_key);
-	void _select_item(int p_index);
+	void _select_item(int p_index, bool p_center_on_scroll = false);
+	void _scroll_to_center(QuickOpenResultItem *p_item) const;
 
 	void _item_input(const Ref<InputEvent> &p_ev, int p_index);
 
@@ -271,10 +276,10 @@ protected:
 	virtual void ok_pressed() override;
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	void item_pressed(bool p_double_click);
-	void selection_changed();
+	void selection_changed() const;
 
 private:
-	static String get_dialog_title(const Vector<StringName> &p_base_types);
+	String get_dialog_title() const;
 
 	LineEdit *search_box = nullptr;
 	QuickOpenResultContainer *container = nullptr;
@@ -284,13 +289,12 @@ private:
 	Object *property_object = nullptr;
 	StringName property_path;
 	Variant initial_property_value;
-	bool initial_selection_performed = false;
 	bool allow_type_switching = false;
 	bool is_cycling_items = false;
 	bool _is_instant_preview_active() const;
 	void _search_box_text_changed(const String &p_query);
 	void _finish_dialog_setup(const Vector<StringName> &p_base_types);
 
-	void preview_property();
+	void preview_property() const;
 	void update_property() const;
 };

--- a/editor/gui/editor_quick_open_dialog.h
+++ b/editor/gui/editor_quick_open_dialog.h
@@ -60,11 +60,11 @@ enum class QuickOpenDisplayMode {
 };
 
 struct QuickOpenResultCandidate {
-	ResourceUID::ID uid;
+	ResourceUID::ID id;
 	Ref<Texture2D> thumbnail;
 	const FuzzySearchResult *result = nullptr;
 
-	static QuickOpenResultCandidate from_uid(const ResourceUID::ID &p_uid, bool &r_success);
+	static QuickOpenResultCandidate from_id(const ResourceUID::ID &p_id, bool &r_success);
 	static QuickOpenResultCandidate from_result(const FuzzySearchResult &p_result, bool &r_success);
 };
 
@@ -103,7 +103,7 @@ public:
 	const Vector<StringName> &get_base_types() const;
 
 	bool is_instant_preview_enabled() const;
-	void set_instant_preview_toggle_visible(bool p_visible);
+	void set_instant_preview_toggle_visible(bool p_visible) const;
 
 	void save_selected_item();
 	void cleanup();
@@ -118,12 +118,13 @@ private:
 
 	Vector<FuzzySearchResult> search_results;
 	Vector<StringName> base_types;
-	LocalVector<ResourceUID::ID> uids;
+	LocalVector<ResourceUID::ID> ids;
 	AHashMap<ResourceUID::ID, StringName> filetypes;
 	Vector<QuickOpenResultCandidate> candidates;
-	HashSet<ResourceUID::ID> candidates_uids;
+	HashSet<ResourceUID::ID> candidates_ids;
 
 	AHashMap<StringName, Vector<ResourceUID::ID>> selected_history;
+	LocalVector<ResourceUID::ID> visible_history;
 	HashSet<ResourceUID::ID> history_set;
 
 	String query;
@@ -157,11 +158,11 @@ private:
 	static QuickOpenDisplayMode get_adaptive_display_mode(const Vector<StringName> &p_base_types);
 
 	void _ensure_result_vector_capacity();
-	void _sort_uids(int p_max_results);
+	void _sort_ids(int p_max_results);
 	void _create_initial_results();
-	void _find_uids_in_folder(EditorFileSystemDirectory *p_directory, bool p_include_addons);
+	void _find_ids_in_folder(EditorFileSystemDirectory *p_directory, bool p_include_addons);
 
-	Vector<ResourceUID::ID> *_get_history();
+	void _update_history();
 	void _add_candidate(QuickOpenResultCandidate &p_candidate);
 	void _update_fuzzy_search_results();
 	void _use_default_candidates();
@@ -291,5 +292,5 @@ private:
 	void _finish_dialog_setup(const Vector<StringName> &p_base_types);
 
 	void preview_property();
-	void update_property();
+	void update_property() const;
 };


### PR DESCRIPTION
Close https://github.com/godotengine/godot-proposals/issues/14513
Based on #117970

Bonus:
This PR makes Quick Open smarter about type handling by expanding abstract types into concrete selectable ones, then using those resolved types (e.g. `BaseMaterial3D` -> `ORMMaterial3D, StandardMaterial3D`) for filtering and per-type history.

More coherent selection behavior when toggling `include_addons`: keep selected otherwise hide.

Dalog title generation now pulls concrete types from current state and builds a clearer multi-type title.

![85d6cb41-81d6-4497-b2e1-787f8e4a259d](https://github.com/user-attachments/assets/e6f43ffc-87f4-4065-b46b-b6dcfc6179d2)
![3a7b3d7e-d025-4767-9aec-c3a70dc39e7c](https://github.com/user-attachments/assets/cae4392e-e4ce-4e32-85e1-378dd04e4f40)
