### PR TITLE
Refactor raytracing pipelines.

### DIFF
--- a/core/templates/rb_map.h
+++ b/core/templates/rb_map.h
@@ -358,6 +358,23 @@ private:
 		return prev;
 	}
 
+	Element *_lower_bound(const K &p_key) const {
+		Element *node = _data._root->left;
+		Element *result = nullptr;
+		C less;
+
+		while (node != _data._nil) {
+			if (!less(node->_data.key, p_key)) {
+				result = node;
+				node = node->left;
+			} else {
+				node = node->right;
+			}
+		}
+
+		return result;
+	}
+
 	void _insert_rb_fix(Element *p_new_node) {
 		Element *node = p_new_node;
 		Element *nparent = node->parent;
@@ -632,6 +649,20 @@ public:
 
 		Element *res = _find_closest(p_key);
 		return res;
+	}
+
+	Element *lower_bound(const K &p_key) {
+		if (!_data._root) {
+			return nullptr;
+		}
+		return _lower_bound(p_key);
+	}
+
+	const Element *lower_bound(const K &p_key) const {
+		if (!_data._root) {
+			return nullptr;
+		}
+		return _lower_bound(p_key);
 	}
 
 	bool has(const K &p_key) const {

--- a/doc/classes/RDAccelerationStructureInstance.xml
+++ b/doc/classes/RDAccelerationStructureInstance.xml
@@ -15,6 +15,9 @@
 		<member name="flags" type="int" setter="set_flags" getter="get_flags" enum="RenderingDevice.AccelerationStructureInstanceFlagBits" is_bitfield="true" default="0">
 			Flags for the instance.
 		</member>
+		<member name="hit_sbt_range" type="int" setter="set_hit_sbt_range" getter="get_hit_sbt_range" default="0">
+			Hit shader binding table range used for this instance, allocated using the [method RenderingDevice.hit_sbt_range_alloc] method.
+		</member>
 		<member name="id" type="int" setter="set_id" getter="get_id" default="0">
 			Custom instance ID that can be accessed in GLSL using [code]gl_InstanceCustomIndexEXT[/code].
 		</member>

--- a/doc/classes/RDHitGroup.xml
+++ b/doc/classes/RDHitGroup.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RDHitGroup" inherits="RefCounted" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Hit group (used by [RenderingDevice]).
+	</brief_description>
+	<description>
+		Defines a hit group for use with [method RenderingDevice.raytracing_pipeline_create].
+		A hit group combines shaders that are executed when a ray intersects geometry. It may include a closest-hit shader, any-hit shader, and intersection shader.
+		Hit groups are referenced by index when populating hit shader binding tables using [method RenderingDevice.hit_sbt_range_update].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="any_hit_shader" type="RDPipelineShader" setter="set_any_hit_shader" getter="get_any_hit_shader">
+			Any-hit shader for this hit group. Executed for each potential intersection. Can be [code]null[/code].
+		</member>
+		<member name="closest_hit_shader" type="RDPipelineShader" setter="set_closest_hit_shader" getter="get_closest_hit_shader">
+			Closest-hit shader for this hit group. Executed for the closest intersection. Can be [code]null[/code].
+		</member>
+		<member name="intersection_shader" type="RDPipelineShader" setter="set_intersection_shader" getter="get_intersection_shader">
+			Intersection shader for this hit group. Required for non-triangle geometry. Must be [code]null[/code] when using for triangle geometry.
+		</member>
+	</members>
+</class>

--- a/doc/classes/RDPipelineShader.xml
+++ b/doc/classes/RDPipelineShader.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RDPipelineShader" inherits="RefCounted" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Pipeline shader (used by [RenderingDevice]).
+	</brief_description>
+	<description>
+		Wraps a shader resource and allows specialization constants to be applied at pipeline creation time.
+		Used by [method RenderingDevice.raytracing_pipeline_create] for ray generation, miss, and hit shaders. The pipeline selects the required shader stage automatically.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="shader" type="RID" setter="set_shader" getter="get_shader" default="RID()">
+			Shader resource. The required stage is selected by the pipeline.
+		</member>
+		<member name="specialization_constants" type="RDPipelineSpecializationConstant[]" setter="set_specialization_constants" getter="get_specialization_constants" default="[]">
+			Specialization constants applied to the selected shader stage at pipeline creation time.
+		</member>
+	</members>
+</class>

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -717,6 +717,66 @@
 				Returns [code]true[/code] if the [param feature] is supported by the GPU.
 			</description>
 		</method>
+		<method name="hit_sbt_create">
+			<return type="RID" />
+			<param index="0" name="raytracing_pipeline" type="RID" />
+			<param index="1" name="initial_hit_group_capacity" type="int" />
+			<description>
+				Creates a new hit shader binding table (SBT). It can be accessed with the RID that is returned.
+				Once finished with your RID, you will want to free the RID using the RenderingDevice's [method free_rid] method.
+				This will be freed automatically when the [param raytracing_pipeline] is freed.
+				The hit SBT resizes itself as needed. [param initial_hit_group_capacity] is used to allocate the initial backing memory.
+			</description>
+		</method>
+		<method name="hit_sbt_range_alloc">
+			<return type="int" />
+			<param index="0" name="hit_sbt" type="RID" />
+			<param index="1" name="hit_group_count" type="int" />
+			<description>
+				Allocates a contiguous range of SBT entries from [param hit_sbt].
+				The returned value should be assigned to [member RDAccelerationStructureInstance.hit_sbt_range].
+				During ray traversal, hit group index is computed as:
+					(geometry index in [member RDAccelerationStructureInstance.blas])
+					× (SBT stride used in [code]traceRayEXT[/code])
+					+ (SBT offset used in [code]traceRayEXT[/code])
+					+ (range offset)
+				[param hit_group_count] must be large enough to cover all SBT entries that may be indexed by this equation. This typically corresponds to:
+					(geometry count in [member RDAccelerationStructureInstance.blas])
+					× (SBT stride used in [code]traceRayEXT[/code])
+				The allocated range is uninitialized and must be filled using [method hit_sbt_range_update].
+			</description>
+		</method>
+		<method name="hit_sbt_range_free">
+			<return type="int" enum="Error" />
+			<param index="0" name="hit_sbt" type="RID" />
+			<param index="1" name="range" type="int" />
+			<description>
+				Frees a hit SBT range previously allocated with [method hit_sbt_range_alloc].
+				The range must not be in use by any acceleration structure after being freed.
+			</description>
+		</method>
+		<method name="hit_sbt_range_update">
+			<return type="int" enum="Error" />
+			<param index="0" name="hit_sbt" type="RID" />
+			<param index="1" name="range" type="int" />
+			<param index="2" name="offset" type="int" />
+			<param index="3" name="hit_group_indices" type="PackedInt32Array" />
+			<description>
+				Updates the contents of a hit SBT range.
+				[param hit_group_indices] specifies indices into the hit group array provided in [method raytracing_pipeline_create].
+				The [param offset] parameter specifies where within the allocated range the writing begins. This allows partial updates of a range. However, the complete range must be fully initialized before it is used in a raytracing dispatch.
+			</description>
+		</method>
+		<method name="hit_sbt_set_pipeline">
+			<return type="int" enum="Error" />
+			<param index="0" name="hit_sbt" type="RID" />
+			<param index="1" name="raytracing_pipeline" type="RID" />
+			<description>
+				Sets a new [param raytracing_pipeline] for [param hit_sbt].
+				The new pipeline must be a superset of the previous one. Existing hit groups must keep the same order and new hit groups should be appended to the end. This preserves existing SBT entries.
+				The previous pipeline must remain valid during the call.
+			</description>
+		</method>
 		<method name="index_array_create">
 			<return type="RID" />
 			<param index="0" name="index_buffer" type="RID" />
@@ -780,6 +840,10 @@
 
 				var instance = RDAccelerationStructureInstance.new()
 				instance.blas = blas
+
+				instance.hit_sbt_range = rd.hit_sbt_range_alloc(hit_sbt, 1)
+				rd.hit_sbt_range_update(hit_sbt, instance.hit_sbt_range, 0, [0])
+
 				rd.tlas_build(tlas, [instance])
 
 				var raylist = rd.raytracing_list_begin()
@@ -791,7 +855,7 @@
 				# Trace rays.
 				var width = get_viewport().size.x
 				var height = get_viewport().size.y
-				rd.raytracing_list_trace_rays(raylist, width, height)
+				rd.raytracing_list_trace_rays(raylist, 0, hit_sbt, width, height, 1)
 
 				rd.raytracing_list_end()
 				[/gdscript]
@@ -833,20 +897,31 @@
 		<method name="raytracing_list_trace_rays">
 			<return type="void" />
 			<param index="0" name="raytracing_list" type="int" />
-			<param index="1" name="width" type="int" />
-			<param index="2" name="height" type="int" />
+			<param index="1" name="raygen_shader_index" type="int" />
+			<param index="2" name="hit_sbt" type="RID" />
+			<param index="3" name="width" type="int" />
+			<param index="4" name="height" type="int" />
+			<param index="5" name="depth" type="int" />
 			<description>
-				Initializes a ray tracing dispatch for the specified [param raytracing_list] assembling a group of [param width] x [param height] rays.
+				Initializes a raytracing dispatch for [param raytracing_list], launching [param width] × [param height] × [param depth] rays.
+				[param raygen_shader_index] selects the ray generation shader from the pipeline bound with [method raytracing_list_bind_raytracing_pipeline].
+				[param hit_sbt] must use the same pipeline bound to [param raytracing_list].
 			</description>
 		</method>
 		<method name="raytracing_pipeline_create">
 			<return type="RID" />
-			<param index="0" name="shader" type="RID" />
-			<param index="1" name="specialization_constants" type="RDPipelineSpecializationConstant[]" default="[]" />
+			<param index="0" name="raygen_shaders" type="RDPipelineShader[]" />
+			<param index="1" name="miss_shaders" type="RDPipelineShader[]" />
+			<param index="2" name="hit_groups" type="RDHitGroup[]" />
+			<param index="3" name="max_trace_recursion_depth" type="int" />
 			<description>
 				Creates a new raytracing pipeline. It can be accessed with the RID that is returned.
 				Once finished with your RID, you will want to free the RID using the RenderingDevice's [method free_rid] method.
-				[b]Note:[/b]: Recursive raytracing is not permitted.
+				Each shader must provide the required stage. All stages must use compatible pipeline layouts. The pipeline selects the required stage from each shader.
+				Input order defines stable indices used by the API:
+				- [param raygen_shaders] is indexed in [method raytracing_list_trace_rays].
+				- [param miss_shaders] is indexed in [code]traceRayEXT[/code].
+				- [param hit_groups] is indexed in [method hit_sbt_range_update].
 			</description>
 		</method>
 		<method name="raytracing_pipeline_is_valid">

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -5516,12 +5516,16 @@ uint32_t RenderingDeviceDriverD3D12::acceleration_structure_get_scratch_size_byt
 
 // ----- PIPELINE -----
 
-RDD::RaytracingPipelineID RenderingDeviceDriverD3D12::raytracing_pipeline_create(ShaderID p_shader, VectorView<PipelineSpecializationConstant> p_specialization_constants) {
+RDD::RaytracingPipelineID RenderingDeviceDriverD3D12::raytracing_pipeline_create(VectorView<PipelineShader> p_shaders, VectorView<uint32_t> p_raygen_shader_indices, VectorView<uint32_t> p_miss_shader_indices, VectorView<HitGroup> p_hit_groups, uint32_t p_max_trace_recursion_depth, ShaderID p_layout_defining_shader) {
 	ERR_FAIL_V_MSG(RaytracingPipelineID(), "Ray tracing is not currently supported by the D3D12 driver.");
 }
 
 void RenderingDeviceDriverD3D12::raytracing_pipeline_free(RDD::RaytracingPipelineID p_pipeline) {
 	ERR_FAIL_MSG("Ray tracing is not currently supported by the D3D12 driver.");
+}
+
+bool RenderingDeviceDriverD3D12::raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data) {
+	ERR_FAIL_V_MSG(false, "Ray tracing is not currently supported by the D3D12 driver.");
 }
 
 // ----- COMMANDS -----
@@ -5542,7 +5546,7 @@ void RenderingDeviceDriverD3D12::command_bind_raytracing_uniform_set(CommandBuff
 	ERR_FAIL_MSG("Ray tracing is not currently supported by the D3D12 driver.");
 }
 
-void RenderingDeviceDriverD3D12::command_trace_rays(CommandBufferID p_cmd_buffer, uint32_t p_width, uint32_t p_height) {
+void RenderingDeviceDriverD3D12::command_trace_rays(CommandBufferID p_cmd_buffer, const ShaderBindingTable &p_raygen_sbt, const ShaderBindingTable &p_miss_sbt, const ShaderBindingTable &p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth) {
 	ERR_FAIL_MSG("Ray tracing is not currently supported by the D3D12 driver.");
 }
 

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -843,8 +843,10 @@ public:
 
 	// ----- PIPELINE -----
 
-	virtual RaytracingPipelineID raytracing_pipeline_create(ShaderID p_shader, VectorView<PipelineSpecializationConstant> p_specialization_constants) override final;
+	virtual RaytracingPipelineID raytracing_pipeline_create(VectorView<PipelineShader> p_shaders, VectorView<uint32_t> p_raygen_shader_indices, VectorView<uint32_t> p_miss_shader_indices, VectorView<HitGroup> p_hit_groups, uint32_t p_max_trace_recursion_depth, ShaderID p_layout_defining_shader) override final;
 	virtual void raytracing_pipeline_free(RaytracingPipelineID p_pipeline) override final;
+
+	virtual bool raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data) override final;
 
 	// ----- COMMANDS -----
 
@@ -852,7 +854,7 @@ public:
 	virtual void command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count) override final;
 	virtual void command_bind_raytracing_pipeline(CommandBufferID p_cmd_buffer, RaytracingPipelineID p_pipeline) override final;
 	virtual void command_bind_raytracing_uniform_set(CommandBufferID p_cmd_buffer, UniformSetID p_uniform_set, ShaderID p_shader, uint32_t p_set_index) override final;
-	virtual void command_trace_rays(CommandBufferID p_cmd_buffer, uint32_t p_width, uint32_t p_height) override final;
+	virtual void command_trace_rays(CommandBufferID p_cmd_buffer, const ShaderBindingTable &p_raygen_sbt, const ShaderBindingTable &p_miss_sbt, const ShaderBindingTable &p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth) override final;
 
 	/*****************/
 	/**** QUERIES ****/

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -2284,12 +2284,16 @@ uint32_t RenderingDeviceDriverMetal::acceleration_structure_get_scratch_size_byt
 
 // ----- PIPELINE -----
 
-RDD::RaytracingPipelineID RenderingDeviceDriverMetal::raytracing_pipeline_create(ShaderID p_shader, VectorView<PipelineSpecializationConstant> p_specialization_constants) {
+RDD::RaytracingPipelineID RenderingDeviceDriverMetal::raytracing_pipeline_create(VectorView<PipelineShader> p_shaders, VectorView<uint32_t> p_raygen_shader_indices, VectorView<uint32_t> p_miss_shader_indices, VectorView<HitGroup> p_hit_groups, uint32_t p_max_trace_recursion_depth, ShaderID p_layout_defining_shader) {
 	ERR_FAIL_V_MSG(RaytracingPipelineID(), "Ray tracing is not currently supported by the Metal driver.");
 }
 
 void RenderingDeviceDriverMetal::raytracing_pipeline_free(RDD::RaytracingPipelineID p_pipeline) {
 	ERR_FAIL_MSG("Ray tracing is not currently supported by the Metal driver.");
+}
+
+bool RenderingDeviceDriverMetal::raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data) {
+	ERR_FAIL_V_MSG(false, "Ray tracing is not currently supported by the Metal driver.");
 }
 
 // ----- COMMANDS -----
@@ -2310,7 +2314,7 @@ void RenderingDeviceDriverMetal::command_bind_raytracing_uniform_set(CommandBuff
 	ERR_FAIL_MSG("Ray tracing is not currently supported by the Metal driver.");
 }
 
-void RenderingDeviceDriverMetal::command_trace_rays(CommandBufferID p_cmd_buffer, uint32_t p_width, uint32_t p_height) {
+void RenderingDeviceDriverMetal::command_trace_rays(CommandBufferID p_cmd_buffer, const ShaderBindingTable &p_raygen_sbt, const ShaderBindingTable &p_miss_sbt, const ShaderBindingTable &p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth) {
 	ERR_FAIL_MSG("Ray tracing is not currently supported by the Metal driver.");
 }
 

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -469,8 +469,10 @@ public:
 
 	// ----- PIPELINE -----
 
-	virtual RaytracingPipelineID raytracing_pipeline_create(ShaderID p_shader, VectorView<PipelineSpecializationConstant> p_specialization_constants) override final;
+	virtual RaytracingPipelineID raytracing_pipeline_create(VectorView<PipelineShader> p_shaders, VectorView<uint32_t> p_raygen_shader_indices, VectorView<uint32_t> p_miss_shader_indices, VectorView<HitGroup> p_hit_groups, uint32_t p_max_trace_recursion_depth, ShaderID p_layout_defining_shader) override final;
 	virtual void raytracing_pipeline_free(RaytracingPipelineID p_pipeline) override final;
+
+	virtual bool raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data) override final;
 
 	// ----- COMMANDS -----
 
@@ -478,7 +480,7 @@ public:
 	virtual void command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count) override final;
 	virtual void command_bind_raytracing_pipeline(CommandBufferID p_cmd_buffer, RaytracingPipelineID p_pipeline) override final;
 	virtual void command_bind_raytracing_uniform_set(CommandBufferID p_cmd_buffer, UniformSetID p_uniform_set, ShaderID p_shader, uint32_t p_set_index) override final;
-	virtual void command_trace_rays(CommandBufferID p_cmd_buffer, uint32_t p_width, uint32_t p_height) override final;
+	virtual void command_trace_rays(CommandBufferID p_cmd_buffer, const ShaderBindingTable &p_raygen_sbt, const ShaderBindingTable &p_miss_sbt, const ShaderBindingTable &p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth) override final;
 
 #pragma mark - Queries
 

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -1866,6 +1866,7 @@ static_assert(ENUM_MEMBERS_EQUAL(RDD::BUFFER_USAGE_STORAGE_BIT, VK_BUFFER_USAGE_
 static_assert(ENUM_MEMBERS_EQUAL(RDD::BUFFER_USAGE_INDEX_BIT, VK_BUFFER_USAGE_INDEX_BUFFER_BIT));
 static_assert(ENUM_MEMBERS_EQUAL(RDD::BUFFER_USAGE_VERTEX_BIT, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT));
 static_assert(ENUM_MEMBERS_EQUAL(RDD::BUFFER_USAGE_INDIRECT_BIT, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT));
+static_assert(ENUM_MEMBERS_EQUAL(RDD::BUFFER_USAGE_SHADER_BINDING_TABLE_BIT, VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR));
 static_assert(ENUM_MEMBERS_EQUAL(RDD::BUFFER_USAGE_DEVICE_ADDRESS_BIT, VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT));
 static_assert(ENUM_MEMBERS_EQUAL(RDD::BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT, VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR));
 static_assert(ENUM_MEMBERS_EQUAL(RDD::BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT, VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR));
@@ -4197,9 +4198,6 @@ RDD::ShaderID RenderingDeviceDriverVulkan::shader_create_from_container(const Re
 		shader_info.respv_stage_shaders.reserve(stage_count);
 	}
 
-	// AnyHit and ClosestHit go in the same group.
-	uint32_t hit_group_index = UINT32_MAX;
-
 	for (int i = 0; i < stage_count; i++) {
 		const RenderingShaderContainer::Shader &shader = p_shader_container->shaders[i];
 		bool requires_decompression = (shader.code_decompressed_size > 0);
@@ -4281,52 +4279,6 @@ RDD::ShaderID RenderingDeviceDriverVulkan::shader_create_from_container(const Re
 		create_info.module = vk_module;
 		create_info.pName = "main";
 		shader_info.vk_stages_create_info.push_back(create_info);
-
-		ShaderStage stage = shader_refl.stages_vector[i];
-
-		if (stage == ShaderStage::SHADER_STAGE_RAYGEN || stage == ShaderStage::SHADER_STAGE_MISS) {
-			VkRayTracingShaderGroupCreateInfoKHR group_info = {};
-			group_info.sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR;
-			group_info.type = VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_KHR;
-			group_info.anyHitShader = VK_SHADER_UNUSED_KHR;
-			group_info.closestHitShader = VK_SHADER_UNUSED_KHR;
-			group_info.intersectionShader = VK_SHADER_UNUSED_KHR;
-			group_info.generalShader = i;
-
-			shader_info.vk_groups_create_info.push_back(group_info);
-		}
-		if (stage == ShaderStage::SHADER_STAGE_ANY_HIT || stage == ShaderStage::SHADER_STAGE_CLOSEST_HIT) {
-			if (hit_group_index == UINT32_MAX) {
-				VkRayTracingShaderGroupCreateInfoKHR group_info = {};
-				group_info.sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR;
-				group_info.type = VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_KHR;
-				group_info.anyHitShader = VK_SHADER_UNUSED_KHR;
-				group_info.closestHitShader = VK_SHADER_UNUSED_KHR;
-				group_info.intersectionShader = VK_SHADER_UNUSED_KHR;
-				group_info.generalShader = VK_SHADER_UNUSED_KHR;
-
-				hit_group_index = shader_info.vk_groups_create_info.size();
-				shader_info.vk_groups_create_info.push_back(group_info);
-			}
-
-			VkRayTracingShaderGroupCreateInfoKHR &group_info = shader_info.vk_groups_create_info[hit_group_index];
-			if (stage == ShaderStage::SHADER_STAGE_ANY_HIT) {
-				group_info.anyHitShader = i;
-			} else if (stage == ShaderStage::SHADER_STAGE_CLOSEST_HIT) {
-				group_info.closestHitShader = i;
-			}
-		}
-		if (stage == ShaderStage::SHADER_STAGE_INTERSECTION) {
-			VkRayTracingShaderGroupCreateInfoKHR group_info = {};
-			group_info.sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR;
-			group_info.type = VK_RAY_TRACING_SHADER_GROUP_TYPE_PROCEDURAL_HIT_GROUP_KHR;
-			group_info.anyHitShader = VK_SHADER_UNUSED_KHR;
-			group_info.closestHitShader = VK_SHADER_UNUSED_KHR;
-			group_info.intersectionShader = i;
-			group_info.generalShader = VK_SHADER_UNUSED_KHR;
-
-			shader_info.vk_groups_create_info.push_back(group_info);
-		}
 	}
 
 	// Descriptor sets.
@@ -4394,30 +4346,6 @@ RDD::ShaderID RenderingDeviceDriverVulkan::shader_create_from_container(const Re
 		}
 
 		ERR_FAIL_V_MSG(ShaderID(), error_text);
-	}
-
-	if (shader_refl.pipeline_type == PIPELINE_TYPE_RAYTRACING) {
-		// Regions
-
-		for (ShaderStage stage : shader_refl.stages_vector) {
-			switch (stage) {
-				case ShaderStage::SHADER_STAGE_RAYGEN:
-					shader_info.region_count.raygen_count += 1;
-					break;
-				case ShaderStage::SHADER_STAGE_ANY_HIT:
-				case ShaderStage::SHADER_STAGE_CLOSEST_HIT:
-					shader_info.region_count.hit_count += 1;
-					break;
-				case ShaderStage::SHADER_STAGE_MISS:
-					shader_info.region_count.miss_count += 1;
-					break;
-				default:
-					// nothing
-					break;
-			}
-		}
-
-		shader_info.region_count.group_count = shader_info.region_count.raygen_count + shader_info.region_count.hit_count + shader_info.region_count.miss_count;
 	}
 
 	// Bookkeep.
@@ -6310,7 +6238,7 @@ void RenderingDeviceDriverVulkan::acceleration_structure_instance_write(uint8_t 
 	_store_transform_transposed_3x4(p_instance.transform, vk_instance->transform);
 	vk_instance->instanceCustomIndex = p_instance.id;
 	vk_instance->mask = p_instance.mask;
-	vk_instance->instanceShaderBindingTableRecordOffset = 0;
+	vk_instance->instanceShaderBindingTableRecordOffset = p_instance.hit_sbt_offset;
 	vk_instance->flags = p_instance.flags;
 
 	if (p_instance.blas) {
@@ -6368,6 +6296,19 @@ uint32_t RenderingDeviceDriverVulkan::acceleration_structure_get_scratch_size_by
 	return accel_info->scratch_size;
 }
 
+VkStridedDeviceAddressRegionKHR RenderingDeviceDriverVulkan::_sbt_to_vk_strided_device_address_region(const ShaderBindingTable &p_sbt) {
+	VkStridedDeviceAddressRegionKHR vk_strided_device_address_region = {};
+	if (p_sbt.buffer) {
+		vk_strided_device_address_region.deviceAddress = buffer_get_device_address(p_sbt.buffer) + p_sbt.offset;
+		vk_strided_device_address_region.stride = p_sbt.stride;
+		vk_strided_device_address_region.size = p_sbt.size;
+
+		DEV_ASSERT((vk_strided_device_address_region.deviceAddress & (raytracing_capabilities.shader_group_base_alignment - 1)) == 0 && "Shader binding table address must be aligned to API_TRAIT_SHADER_GROUP_BASE_ALIGNMENT.");
+		DEV_ASSERT((vk_strided_device_address_region.stride & (raytracing_capabilities.shader_group_handle_alignment - 1)) == 0 && "Shader binding table stride must be aligned to API_TRAIT_SHADER_GROUP_HANDLE_ALIGNMENT.");
+	}
+	return vk_strided_device_address_region;
+}
+
 // ----- COMMANDS -----
 
 void RenderingDeviceDriverVulkan::command_build_blas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer) {
@@ -6405,9 +6346,7 @@ void RenderingDeviceDriverVulkan::command_build_tlas(CommandBufferID p_cmd_buffe
 
 void RenderingDeviceDriverVulkan::command_bind_raytracing_pipeline(CommandBufferID p_cmd_buffer, RaytracingPipelineID p_pipeline) {
 	const CommandBufferInfo *command_buffer = (const CommandBufferInfo *)p_cmd_buffer.id;
-	bound_raytracing_pipeline_id = p_pipeline;
-	const RaytracingPipelineInfo *rpi = (const RaytracingPipelineInfo *)p_pipeline.id;
-	vkCmdBindPipeline(command_buffer->vk_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, rpi->vk_pipeline);
+	vkCmdBindPipeline(command_buffer->vk_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, (VkPipeline)p_pipeline.id);
 }
 
 void RenderingDeviceDriverVulkan::command_bind_raytracing_uniform_set(CommandBufferID p_cmd_buffer, UniformSetID p_uniform_set, ShaderID p_shader, uint32_t p_set_index) {
@@ -6417,160 +6356,135 @@ void RenderingDeviceDriverVulkan::command_bind_raytracing_uniform_set(CommandBuf
 	vkCmdBindDescriptorSets(command_buffer->vk_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, shader_info->vk_pipeline_layout, p_set_index, 1, &usi->vk_descriptor_set, 0, nullptr);
 }
 
-void RenderingDeviceDriverVulkan::command_trace_rays(CommandBufferID p_cmd_buffer, uint32_t p_width, uint32_t p_height) {
+void RenderingDeviceDriverVulkan::command_trace_rays(CommandBufferID p_cmd_buffer, const ShaderBindingTable &p_raygen_sbt, const ShaderBindingTable &p_miss_sbt, const ShaderBindingTable &p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth) {
 #if VULKAN_RAYTRACING_ENABLED
 	const CommandBufferInfo *command_buffer = (const CommandBufferInfo *)p_cmd_buffer.id;
-	ERR_FAIL_COND_MSG(bound_raytracing_pipeline_id == RaytracingPipelineID(), "A raytracing pipeline must have been bound with `command_bind_raytracing_pipeline()`.");
-	const RaytracingPipelineInfo *rpi = (const RaytracingPipelineInfo *)bound_raytracing_pipeline_id.id;
-	vkCmdTraceRaysKHR(command_buffer->vk_command_buffer, &rpi->regions.raygen, &rpi->regions.miss, &rpi->regions.hit, &rpi->regions.call, p_width, p_height, 1);
+	VkStridedDeviceAddressRegionKHR raygen_sbt = _sbt_to_vk_strided_device_address_region(p_raygen_sbt);
+	VkStridedDeviceAddressRegionKHR miss_sbt = _sbt_to_vk_strided_device_address_region(p_miss_sbt);
+	VkStridedDeviceAddressRegionKHR hit_sbt = _sbt_to_vk_strided_device_address_region(p_hit_sbt);
+	VkStridedDeviceAddressRegionKHR callable_sbt = {};
+	vkCmdTraceRaysKHR(command_buffer->vk_command_buffer, &raygen_sbt, &miss_sbt, &hit_sbt, &callable_sbt, p_width, p_height, p_depth);
 #endif
 }
 
 // --- PIPELINE ---
 
-RDD::RaytracingPipelineID RenderingDeviceDriverVulkan::raytracing_pipeline_create(ShaderID p_shader, VectorView<PipelineSpecializationConstant> p_specialization_constants) {
+RDD::RaytracingPipelineID RenderingDeviceDriverVulkan::raytracing_pipeline_create(VectorView<PipelineShader> p_shaders, VectorView<uint32_t> p_raygen_shader_indices, VectorView<uint32_t> p_miss_shader_indices, VectorView<HitGroup> p_hit_groups, uint32_t p_max_trace_recursion_depth, ShaderID p_layout_defining_shader) {
 #if VULKAN_RAYTRACING_ENABLED
-	const ShaderInfo *shader_info = (const ShaderInfo *)p_shader.id;
+	VkPipelineShaderStageCreateInfo *stages = ALLOCA_ARRAY(VkPipelineShaderStageCreateInfo, p_shaders.size());
+
+	for (uint32_t i = 0; i < p_shaders.size(); i++) {
+		const PipelineShader &shader = p_shaders[i];
+		const ShaderInfo *shader_info = (const ShaderInfo *)shader.shader.id;
+		bool found_shader_stage = false;
+
+		for (uint32_t j = 0; j < shader_info->vk_stages_create_info.size(); j++) {
+			const VkPipelineShaderStageCreateInfo &create_info = shader_info->vk_stages_create_info[j];
+			if (create_info.stage & RD_STAGE_TO_VK_SHADER_STAGE_BITS[shader.shader_stage]) {
+				stages[i] = create_info;
+
+				if (shader.specialization_constants.size()) {
+					VkSpecializationMapEntry *specialization_map_entries = ALLOCA_ARRAY(VkSpecializationMapEntry, shader.specialization_constants.size());
+					for (uint32_t k = 0; k < shader.specialization_constants.size(); k++) {
+						specialization_map_entries[k] = {};
+						specialization_map_entries[k].constantID = shader.specialization_constants[k].constant_id;
+						specialization_map_entries[k].offset = (const char *)&shader.specialization_constants[k].int_value - (const char *)shader.specialization_constants.ptr();
+						specialization_map_entries[k].size = sizeof(uint32_t);
+					}
+
+					VkSpecializationInfo *specialization_info = ALLOCA_SINGLE(VkSpecializationInfo);
+					specialization_info->dataSize = shader.specialization_constants.size() * sizeof(PipelineSpecializationConstant);
+					specialization_info->pData = shader.specialization_constants.ptr();
+					specialization_info->mapEntryCount = shader.specialization_constants.size();
+					specialization_info->pMapEntries = specialization_map_entries;
+
+					stages[i].pSpecializationInfo = specialization_info;
+				}
+
+				found_shader_stage = true;
+				break;
+			}
+		}
+
+		ERR_FAIL_COND_V(!found_shader_stage, RaytracingPipelineID());
+	}
+
+	uint32_t shader_group_count = p_raygen_shader_indices.size() + p_miss_shader_indices.size() + p_hit_groups.size();
+	VkRayTracingShaderGroupCreateInfoKHR *shader_groups = ALLOCA_ARRAY(VkRayTracingShaderGroupCreateInfoKHR, shader_group_count);
+
+	for (uint32_t i = 0; i < p_raygen_shader_indices.size(); i++) {
+		VkRayTracingShaderGroupCreateInfoKHR &vk_shader_group = shader_groups[i];
+		vk_shader_group = {};
+		vk_shader_group.sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR;
+		vk_shader_group.type = VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_KHR;
+		vk_shader_group.generalShader = p_raygen_shader_indices[i];
+		vk_shader_group.closestHitShader = VK_SHADER_UNUSED_KHR;
+		vk_shader_group.anyHitShader = VK_SHADER_UNUSED_KHR;
+		vk_shader_group.intersectionShader = VK_SHADER_UNUSED_KHR;
+	}
+
+	for (uint32_t i = 0; i < p_miss_shader_indices.size(); i++) {
+		VkRayTracingShaderGroupCreateInfoKHR &vk_shader_group = shader_groups[p_raygen_shader_indices.size() + i];
+		vk_shader_group = {};
+		vk_shader_group.sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR;
+		vk_shader_group.type = VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_KHR;
+		vk_shader_group.generalShader = p_miss_shader_indices[i];
+		vk_shader_group.closestHitShader = VK_SHADER_UNUSED_KHR;
+		vk_shader_group.anyHitShader = VK_SHADER_UNUSED_KHR;
+		vk_shader_group.intersectionShader = VK_SHADER_UNUSED_KHR;
+	}
+
+	for (uint32_t i = 0; i < p_hit_groups.size(); i++) {
+		const HitGroup &hit_group = p_hit_groups[i];
+
+		VkRayTracingShaderGroupCreateInfoKHR &vk_shader_group = shader_groups[p_raygen_shader_indices.size() + p_miss_shader_indices.size() + i];
+		vk_shader_group = {};
+		vk_shader_group.sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR;
+		vk_shader_group.type = hit_group.intersection_shader_index != UINT32_MAX ? VK_RAY_TRACING_SHADER_GROUP_TYPE_PROCEDURAL_HIT_GROUP_KHR : VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_KHR;
+		vk_shader_group.generalShader = VK_SHADER_UNUSED_KHR;
+		vk_shader_group.closestHitShader = hit_group.closest_hit_shader_index;
+		vk_shader_group.anyHitShader = hit_group.any_hit_shader_index;
+		vk_shader_group.intersectionShader = hit_group.intersection_shader_index;
+	}
+
+	const ShaderInfo *layout_defining_shader_info = (const ShaderInfo *)p_layout_defining_shader.id;
 
 	VkRayTracingPipelineCreateInfoKHR pipeline_create_info = {};
 	pipeline_create_info.sType = VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR;
+	pipeline_create_info.layout = layout_defining_shader_info->vk_pipeline_layout;
+	pipeline_create_info.stageCount = p_shaders.size();
+	pipeline_create_info.pStages = stages;
+	pipeline_create_info.groupCount = shader_group_count;
+	pipeline_create_info.pGroups = shader_groups;
+	pipeline_create_info.maxPipelineRayRecursionDepth = p_max_trace_recursion_depth;
 
-	// Stages.
-	pipeline_create_info.stageCount = shader_info->vk_stages_create_info.size();
-
-	VkPipelineShaderStageCreateInfo *vk_pipeline_stages = ALLOCA_ARRAY(VkPipelineShaderStageCreateInfo, pipeline_create_info.stageCount);
-
-	for (uint32_t i = 0; i < pipeline_create_info.stageCount; i++) {
-		vk_pipeline_stages[i] = shader_info->vk_stages_create_info[i];
-
-		if (p_specialization_constants.size()) {
-			VkSpecializationMapEntry *specialization_map_entries = ALLOCA_ARRAY(VkSpecializationMapEntry, p_specialization_constants.size());
-			for (uint32_t j = 0; j < p_specialization_constants.size(); j++) {
-				specialization_map_entries[j] = {};
-				specialization_map_entries[j].constantID = p_specialization_constants[j].constant_id;
-				specialization_map_entries[j].offset = (const char *)&p_specialization_constants[j].int_value - (const char *)p_specialization_constants.ptr();
-				specialization_map_entries[j].size = sizeof(uint32_t);
-			}
-
-			VkSpecializationInfo *specialization_info = ALLOCA_SINGLE(VkSpecializationInfo);
-			*specialization_info = {};
-			specialization_info->dataSize = p_specialization_constants.size() * sizeof(PipelineSpecializationConstant);
-			specialization_info->pData = p_specialization_constants.ptr();
-			specialization_info->mapEntryCount = p_specialization_constants.size();
-			specialization_info->pMapEntries = specialization_map_entries;
-
-			vk_pipeline_stages[i].pSpecializationInfo = specialization_info;
-		}
-	}
-
-	// Groups.
-	pipeline_create_info.groupCount = pipeline_create_info.stageCount;
-	VkRayTracingShaderGroupCreateInfoKHR *vk_pipeline_groups = ALLOCA_ARRAY(VkRayTracingShaderGroupCreateInfoKHR, pipeline_create_info.groupCount);
-	for (uint32_t i = 0; i < pipeline_create_info.stageCount; i++) {
-		vk_pipeline_groups[i] = shader_info->vk_groups_create_info[i];
-	}
-
-	// Pipeline.
-	pipeline_create_info.layout = shader_info->vk_pipeline_layout;
-	pipeline_create_info.pStages = vk_pipeline_stages;
-	pipeline_create_info.pGroups = vk_pipeline_groups;
-	pipeline_create_info.maxPipelineRayRecursionDepth = 1;
-
-	RaytracingPipelineInfo *rpi = VersatileResource::allocate<RaytracingPipelineInfo>(resources_allocator);
-
-	VkResult err = vkCreateRayTracingPipelinesKHR(vk_device, VK_NULL_HANDLE, pipelines_cache.vk_cache, 1, &pipeline_create_info, nullptr, &rpi->vk_pipeline);
+	VkPipeline vk_pipeline = VK_NULL_HANDLE;
+	VkResult err = vkCreateRayTracingPipelinesKHR(vk_device, VK_NULL_HANDLE, pipelines_cache.vk_cache, 1, &pipeline_create_info, nullptr, &vk_pipeline);
 	ERR_FAIL_COND_V_MSG(err, RaytracingPipelineID(), "vkCreateRayTracingPipelinesKHR failed with error " + itos(err) + ".");
 
-	RaytracingPipelineID raytracing_pipeline = RaytracingPipelineID(rpi);
-	err = _raytracing_pipeline_stb_create(raytracing_pipeline, p_shader);
-	ERR_FAIL_COND_V_MSG(err, RaytracingPipelineID(), "_raytracing_pipeline_stb_create failed with error " + itos(err) + ".");
-
-	return raytracing_pipeline;
+	return RaytracingPipelineID(vk_pipeline);
 #else
 	return RaytracingPipelineID();
 #endif
 }
 
-VkResult RenderingDeviceDriverVulkan::_raytracing_pipeline_stb_create(RaytracingPipelineID p_pipeline, ShaderID p_shader) {
+void RenderingDeviceDriverVulkan::raytracing_pipeline_free(RaytracingPipelineID p_pipeline) {
 #if VULKAN_RAYTRACING_ENABLED
-	RaytracingPipelineInfo *rpi = (RaytracingPipelineInfo *)p_pipeline.id;
-	const ShaderInfo *shader_info = (const ShaderInfo *)p_shader.id;
-
-	// Shader group handles.
-	uint32_t handle_size_aligned = raytracing_capabilities.shader_group_handle_size_aligned;
-	uint32_t base_alignment = raytracing_capabilities.shader_group_base_alignment;
-
-	rpi->regions.raygen.stride = _align_up(handle_size_aligned * shader_info->region_count.raygen_count, base_alignment);
-	rpi->regions.raygen.size = rpi->regions.raygen.stride; // odd but ok.
-
-	rpi->regions.hit.stride = handle_size_aligned;
-	rpi->regions.hit.size = _align_up(handle_size_aligned * shader_info->region_count.hit_count, base_alignment);
-
-	rpi->regions.miss.stride = handle_size_aligned;
-	rpi->regions.miss.size = _align_up(handle_size_aligned * shader_info->region_count.miss_count, base_alignment);
-
-	rpi->regions.call.stride = 0;
-	rpi->regions.call.size = 0;
-
-	// Shader binding table.
-	uint32_t sbt_size = rpi->regions.raygen.size + rpi->regions.hit.size + rpi->regions.miss.size + rpi->regions.call.size;
-	rpi->sbt_buffer = buffer_create(sbt_size, BUFFER_USAGE_TRANSFER_FROM_BIT | BUFFER_USAGE_DEVICE_ADDRESS_BIT | BUFFER_USAGE_SHADER_BINDING_TABLE_BIT, MEMORY_ALLOCATION_TYPE_CPU, UINT64_MAX);
-
-	// Update regions addresses.
-	rpi->regions.raygen.deviceAddress = buffer_get_device_address(rpi->sbt_buffer);
-	rpi->regions.hit.deviceAddress = rpi->regions.raygen.deviceAddress + rpi->regions.raygen.size;
-	rpi->regions.miss.deviceAddress = rpi->regions.hit.deviceAddress + rpi->regions.hit.size;
-	rpi->regions.call.deviceAddress = 0;
-
-	// Update shader binding table buffer.
-	uint32_t handle_size = raytracing_capabilities.shader_group_handle_size;
-	uint32_t handles_size = shader_info->region_count.group_count * handle_size;
-	LocalVector<uint8_t> handles_data;
-	handles_data.resize(handles_size);
-	uint8_t *handles_ptr = handles_data.ptr();
-
-	VkResult err = vkGetRayTracingShaderGroupHandlesKHR(vk_device, rpi->vk_pipeline, 0, shader_info->region_count.group_count, handles_size, handles_ptr);
-	ERR_FAIL_COND_V_MSG(err, err, "vkGetRayTracingShaderGroupHandlesKHR failed with error " + itos(err) + ".");
-
-	uint8_t *sbt_ptr = buffer_map(rpi->sbt_buffer);
-	uint8_t *sbt_data = sbt_ptr;
-	uint32_t handle_index = 0;
-
-	// Raygen.
-	memcpy(sbt_data, handles_ptr + handle_index * handle_size, handle_size);
-	++handle_index;
-
-	// Hit.
-	sbt_data = sbt_ptr + rpi->regions.raygen.size;
-	for (uint32_t i = 0; i < shader_info->region_count.hit_count; ++i) {
-		memcpy(sbt_data, handles_ptr + handle_index * handle_size, handle_size);
-		sbt_data += rpi->regions.hit.stride;
-		++handle_index;
-	}
-
-	// Miss.
-	sbt_data = sbt_ptr + rpi->regions.raygen.size + rpi->regions.hit.size;
-	for (uint32_t i = 0; i < shader_info->region_count.miss_count; ++i) {
-		memcpy(sbt_data, handles_ptr + handle_index * handle_size, handle_size);
-		sbt_data += rpi->regions.miss.stride;
-		++handle_index;
-	}
-
-	buffer_unmap(rpi->sbt_buffer);
-
-	return err;
-#else
-	return VK_ERROR_UNKNOWN;
+	vkDestroyPipeline(vk_device, (VkPipeline)p_pipeline.id, nullptr);
 #endif
 }
 
-void RenderingDeviceDriverVulkan::raytracing_pipeline_free(RaytracingPipelineID p_pipeline) {
-	const RaytracingPipelineInfo *rpi = (const RaytracingPipelineInfo *)p_pipeline.id;
-	vkDestroyPipeline(vk_device, rpi->vk_pipeline, nullptr);
-	if (rpi->sbt_buffer) {
-		buffer_free(rpi->sbt_buffer);
+bool RenderingDeviceDriverVulkan::raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data) {
+#if VULKAN_RAYTRACING_ENABLED
+	for (uint32_t i = 0; i < p_group_indices.size(); i++) {
+		VkResult err = vkGetRayTracingShaderGroupHandlesKHR(vk_device, (VkPipeline)p_pipeline.id, p_group_index_offset + p_group_indices[i], 1, raytracing_capabilities.shader_group_handle_size, r_data);
+		ERR_FAIL_COND_V_MSG(err != VK_SUCCESS, false, "vkGetRayTracingShaderGroupHandlesKHR failed with error " + itos(err) + ".");
+		r_data += raytracing_capabilities.shader_group_handle_size;
 	}
-	VersatileResource::free(resources_allocator, rpi);
+	return true;
+#else
+	return false;
+#endif
 }
 
 /*****************/
@@ -7115,8 +7029,7 @@ void RenderingDeviceDriverVulkan::set_object_name(ObjectType p_type, ID p_driver
 			_set_object_name(VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR, (uint64_t)asi->vk_acceleration_structure, p_name);
 		} break;
 		case OBJECT_TYPE_RAYTRACING_PIPELINE: {
-			const RaytracingPipelineInfo *rpi = (const RaytracingPipelineInfo *)p_driver_id.id;
-			_set_object_name(VK_OBJECT_TYPE_PIPELINE, (uint64_t)rpi->vk_pipeline, p_name);
+			_set_object_name(VK_OBJECT_TYPE_PIPELINE, (uint64_t)p_driver_id.id, p_name);
 		} break;
 		default: {
 			DEV_ASSERT(false);
@@ -7295,6 +7208,12 @@ uint64_t RenderingDeviceDriverVulkan::api_trait_get(ApiTrait p_trait) {
 			return (uint64_t)SHADER_CHANGE_INVALIDATION_INCOMPATIBLE_SETS_PLUS_CASCADE;
 		case API_TRAIT_ACCELERATION_STRUCTURE_INSTANCE_SIZE:
 			return sizeof(VkAccelerationStructureInstanceKHR);
+		case API_TRAIT_SHADER_GROUP_HANDLE_SIZE:
+			return raytracing_capabilities.shader_group_handle_size;
+		case API_TRAIT_SHADER_GROUP_HANDLE_ALIGNMENT:
+			return raytracing_capabilities.shader_group_handle_alignment;
+		case API_TRAIT_SHADER_GROUP_BASE_ALIGNMENT:
+			return raytracing_capabilities.shader_group_base_alignment;
 		default:
 			return RenderingDeviceDriver::api_trait_get(p_trait);
 	}

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -473,25 +473,15 @@ public:
 	/**** SHADER ****/
 	/****************/
 private:
-	struct RaytracingShaderRegionCount {
-		uint32_t raygen_count = 0;
-		uint32_t hit_count = 0;
-		uint32_t miss_count = 0;
-		uint32_t group_count = 0;
-	};
-
 	struct ShaderInfo {
 		String name;
 		VkShaderStageFlags vk_push_constant_stages = 0;
 		TightLocalVector<VkPipelineShaderStageCreateInfo> vk_stages_create_info;
-		TightLocalVector<VkRayTracingShaderGroupCreateInfoKHR> vk_groups_create_info;
 		TightLocalVector<VkDescriptorSetLayout> vk_descriptor_set_layouts;
 		TightLocalVector<respv::Shader> respv_stage_shaders;
 		TightLocalVector<Vector<uint8_t>> spirv_stage_bytes;
 		TightLocalVector<uint64_t> original_stage_size;
 		VkPipelineLayout vk_pipeline_layout = VK_NULL_HANDLE;
-		// Used to update the shader binding table buffer.
-		RaytracingShaderRegionCount region_count;
 	};
 
 public:
@@ -729,40 +719,23 @@ public:
 private:
 	void _acceleration_structure_create(VkAccelerationStructureTypeKHR p_type, VkAccelerationStructureBuildSizesInfoKHR p_size_info, AccelerationStructureInfo *r_accel_info);
 
+private:
+	VkStridedDeviceAddressRegionKHR _sbt_to_vk_strided_device_address_region(const ShaderBindingTable &p_sbt);
+
 public:
 	// ----- COMMANDS -----
-
 	virtual void command_build_blas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer) override final;
 	virtual void command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count) override final;
 	virtual void command_bind_raytracing_pipeline(CommandBufferID p_cmd_buffer, RaytracingPipelineID p_pipeline) override final;
 	virtual void command_bind_raytracing_uniform_set(CommandBufferID p_cmd_buffer, UniformSetID p_uniform_set, ShaderID p_shader, uint32_t p_set_index) override final;
-	virtual void command_trace_rays(CommandBufferID p_cmd_buffer, uint32_t p_width, uint32_t p_height) override final;
-
-private:
-	RaytracingPipelineID bound_raytracing_pipeline_id;
-
-	// ----- PIPELINE -----
-
-	struct RaytracingShaderRegions {
-		VkStridedDeviceAddressRegionKHR raygen;
-		VkStridedDeviceAddressRegionKHR hit;
-		VkStridedDeviceAddressRegionKHR miss;
-		VkStridedDeviceAddressRegionKHR call;
-	};
-
-	struct RaytracingPipelineInfo {
-		VkPipeline vk_pipeline = VK_NULL_HANDLE;
-		ShaderID shader;
-		// Used vkCmdTraceRaysKHR.
-		RaytracingShaderRegions regions;
-		// Shader binding table.
-		BufferID sbt_buffer;
-	};
+	virtual void command_trace_rays(CommandBufferID p_cmd_buffer, const ShaderBindingTable &p_raygen_sbt, const ShaderBindingTable &p_miss_sbt, const ShaderBindingTable &p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth) override final;
 
 public:
-	virtual RaytracingPipelineID raytracing_pipeline_create(ShaderID p_shader, VectorView<PipelineSpecializationConstant> p_specialization_constants) override final;
-	VkResult _raytracing_pipeline_stb_create(RaytracingPipelineID p_pipeline, ShaderID p_shader);
+	// ----- PIPELINE -----
+	virtual RaytracingPipelineID raytracing_pipeline_create(VectorView<PipelineShader> p_shaders, VectorView<uint32_t> p_raygen_shader_indices, VectorView<uint32_t> p_miss_shader_indices, VectorView<HitGroup> p_hit_groups, uint32_t p_max_trace_recursion_depth, ShaderID p_layout_defining_shader) override final;
 	virtual void raytracing_pipeline_free(RaytracingPipelineID p_pipeline) override final;
+
+	virtual bool raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data) override final;
 
 	/*****************/
 	/**** QUERIES ****/

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -247,6 +247,8 @@ void register_server_types() {
 	GDREGISTER_CLASS(RDPipelineSpecializationConstant);
 	GDREGISTER_CLASS(RDAccelerationStructureGeometry);
 	GDREGISTER_CLASS(RDAccelerationStructureInstance);
+	GDREGISTER_CLASS(RDPipelineShader);
+	GDREGISTER_CLASS(RDHitGroup);
 
 	GDREGISTER_ABSTRACT_CLASS(RenderData);
 	GDREGISTER_CLASS(RenderDataExtension);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -116,6 +116,18 @@ static uint32_t _get_device_type_score(const RenderingContextDriver::Device &p_d
 	}
 }
 
+static uint32_t _decode_hit_sbt_range_offset(RD::HitShaderBindingTableRange p_range) {
+	return uint32_t(uint64_t(p_range) & 0xFFFFFFFF);
+}
+
+static uint32_t _decode_hit_sbt_range_count(RD::HitShaderBindingTableRange p_range) {
+	return uint32_t((uint64_t(p_range) >> 32) & 0xFFFFFFFF);
+}
+
+static RD::HitShaderBindingTableRange _encode_hit_sbt_range(uint32_t p_offset, uint32_t p_count) {
+	return RD::HitShaderBindingTableRange((uint64_t(p_count) << 32) | uint64_t(p_offset));
+}
+
 /**************************/
 /**** RENDERING DEVICE ****/
 /**************************/
@@ -165,6 +177,20 @@ void RenderingDevice::_add_dependency(RID p_id, RID p_depends_on) {
 		set = &reverse_dependency_map.insert(p_id, HashSet<RID>())->value;
 	}
 	set->insert(p_depends_on);
+}
+
+void RenderingDevice::_remove_dependency(RID p_id, RID p_depends_on) {
+	_THREAD_SAFE_METHOD_
+
+	HashSet<RID> *set = dependency_map.getptr(p_depends_on);
+	if (set != nullptr) {
+		set->erase(p_id);
+	}
+
+	set = reverse_dependency_map.getptr(p_id);
+	if (set != nullptr) {
+		set->erase(p_depends_on);
+	}
 }
 
 void RenderingDevice::_free_dependencies(RID p_id) {
@@ -513,9 +539,12 @@ Error RenderingDevice::tlas_build(RID p_tlas, Span<AccelerationStructureInstance
 		rdd_instance.transform = rd_instance.transform;
 		rdd_instance.id = rd_instance.id;
 		rdd_instance.mask = rd_instance.mask;
+		rdd_instance.hit_sbt_offset = _decode_hit_sbt_range_offset(rd_instance.hit_sbt_range);
 		rdd_instance.flags = rd_instance.flags;
 
 		if (rd_instance.blas.is_valid()) {
+			ERR_FAIL_COND_V_MSG(!rd_instance.hit_sbt_range, ERR_INVALID_PARAMETER, "Instance " + itos(i) + " has an invalid hit shader binding table range.");
+
 			AccelerationStructure *blas = acceleration_structure_owner.get_or_null(rd_instance.blas);
 			ERR_FAIL_NULL_V(blas, ERR_INVALID_PARAMETER);
 			ERR_FAIL_COND_V(blas->type != RDD::ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL, ERR_INVALID_PARAMETER);
@@ -538,6 +567,267 @@ Error RenderingDevice::tlas_build(RID p_tlas, Span<AccelerationStructureInstance
 	draw_graph.add_tlas_build(tlas->driver_id, tlas->scratch_buffer, instance_buffer.driver_id, instance_buffer_offset, p_instances.size(), tlas->draw_tracker, draw_trackers);
 
 	tlas->invalidated = false;
+
+	return OK;
+}
+
+/**********************************/
+/**** HIT SHADER BINDING TABLE ****/
+/**********************************/
+
+RDD::BufferID RenderingDevice::_hit_sbt_buffer_create(uint32_t p_buffer_size) {
+	RDD::BufferID buffer = driver->buffer_create(p_buffer_size, RDD::BUFFER_USAGE_TRANSFER_TO_BIT | RDD::BUFFER_USAGE_DEVICE_ADDRESS_BIT | RDD::BUFFER_USAGE_SHADER_BINDING_TABLE_BIT, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
+	if (buffer) {
+		_THREAD_SAFE_LOCK_
+		buffer_memory += p_buffer_size;
+		_THREAD_SAFE_UNLOCK_
+	}
+
+	return buffer;
+}
+
+Error RenderingDevice::_hit_sbt_buffer_update(HitShaderBindingTable *p_hit_sbt, RID p_hit_sbt_id, RDD::ShaderBindingTable &r_sbt) {
+	uint32_t shader_group_size = driver->api_trait_get(RDD::API_TRAIT_SHADER_GROUP_HANDLE_SIZE);
+	uint32_t buffer_size = p_hit_sbt->hit_group_indices.size() * shader_group_size;
+
+	if (p_hit_sbt->size != buffer_size) {
+		RDD::BufferID buffer = _hit_sbt_buffer_create(buffer_size);
+		ERR_FAIL_COND_V(!buffer, ERR_CANT_CREATE);
+
+		RDG::resource_tracker_free(p_hit_sbt->draw_tracker);
+		frames[frame].buffers_to_dispose_of.push_back(*p_hit_sbt);
+
+		p_hit_sbt->driver_id = buffer;
+		p_hit_sbt->size = buffer_size;
+		p_hit_sbt->draw_tracker = RDG::resource_tracker_create();
+		p_hit_sbt->draw_tracker->buffer_driver_id = buffer;
+
+		_hit_sbt_add_dirty_range(p_hit_sbt, 0, p_hit_sbt->used_hit_group_count);
+	}
+
+	if (p_hit_sbt->first_dirty_index != UINT32_MAX) {
+		uint32_t count = p_hit_sbt->last_dirty_index - p_hit_sbt->first_dirty_index;
+		uint32_t offset = shader_group_size * p_hit_sbt->first_dirty_index;
+		uint32_t size = shader_group_size * count;
+
+		thread_local LocalVector<uint8_t> data;
+		data.resize(size);
+
+		bool success = driver->raytracing_pipeline_get_shader_group_handles(
+				p_hit_sbt->raytracing_pipeline,
+				p_hit_sbt->index_offset,
+				VectorView<uint32_t>(p_hit_sbt->hit_group_indices.ptr() + p_hit_sbt->first_dirty_index, count),
+				data.ptr());
+
+		ERR_FAIL_COND_V(!success, ERR_CANT_CREATE);
+
+		Error err = _buffer_update(p_hit_sbt, p_hit_sbt_id, offset, size, data.ptr());
+		ERR_FAIL_COND_V(err != OK, err);
+
+		p_hit_sbt->first_dirty_index = UINT32_MAX;
+		p_hit_sbt->last_dirty_index = 0;
+	}
+
+	r_sbt.buffer = p_hit_sbt->driver_id;
+	r_sbt.offset = 0;
+	r_sbt.stride = shader_group_size;
+	r_sbt.size = buffer_size;
+
+	return OK;
+}
+
+void RenderingDevice::_hit_sbt_add_dirty_range(HitShaderBindingTable *p_hit_sbt, uint32_t p_offset, uint32_t p_count) {
+	p_hit_sbt->first_dirty_index = MIN(p_hit_sbt->first_dirty_index, p_offset);
+	p_hit_sbt->last_dirty_index = MAX(p_hit_sbt->last_dirty_index, p_offset + p_count);
+}
+
+RID RenderingDevice::hit_sbt_create(RID p_raytracing_pipeline, uint32_t p_initial_hit_group_capacity) {
+	ERR_FAIL_COND_V_MSG(!has_feature(SUPPORTS_RAYTRACING_PIPELINE) && !has_feature(SUPPORTS_RAY_QUERY), RID(), "The current rendering device has neither raytracing pipeline nor ray query support.");
+
+	RaytracingPipeline *raytracing_pipeline = raytracing_pipeline_owner.get_or_null(p_raytracing_pipeline);
+	ERR_FAIL_NULL_V(raytracing_pipeline, RID());
+	ERR_FAIL_COND_V(p_initial_hit_group_capacity == 0, RID());
+
+	uint32_t shader_group_size = driver->api_trait_get(RDD::API_TRAIT_SHADER_GROUP_HANDLE_SIZE);
+
+	HitShaderBindingTable hit_sbt;
+	hit_sbt.size = p_initial_hit_group_capacity * shader_group_size;
+	hit_sbt.driver_id = _hit_sbt_buffer_create(hit_sbt.size);
+	ERR_FAIL_COND_V(!hit_sbt.driver_id, RID());
+
+	hit_sbt.draw_tracker = RDG::resource_tracker_create();
+	hit_sbt.draw_tracker->buffer_driver_id = hit_sbt.driver_id;
+
+	hit_sbt.raytracing_pipeline_id = p_raytracing_pipeline;
+	hit_sbt.raytracing_pipeline = raytracing_pipeline->driver_id;
+	hit_sbt.index_offset = raytracing_pipeline->raygen_shader_count + raytracing_pipeline->miss_shader_count;
+	hit_sbt.raytracing_pipeline_hit_group_count = raytracing_pipeline->hit_group_count;
+	hit_sbt.hit_group_indices.resize_initialized(p_initial_hit_group_capacity);
+
+	RID id = hit_sbt_owner.make_rid(hit_sbt);
+#ifdef DEV_ENABLED
+	set_resource_name(id, "RID:" + itos(id.get_id()));
+#endif
+	_add_dependency(id, p_raytracing_pipeline);
+
+	return id;
+}
+
+Error RenderingDevice::hit_sbt_set_pipeline(RID p_hit_sbt, RID p_raytracing_pipeline) {
+	ERR_RENDER_THREAD_GUARD_V(ERR_UNAVAILABLE);
+
+	HitShaderBindingTable *hit_sbt = hit_sbt_owner.get_or_null(p_hit_sbt);
+	ERR_FAIL_NULL_V(hit_sbt, ERR_INVALID_PARAMETER);
+
+	if (hit_sbt->raytracing_pipeline_id != p_raytracing_pipeline) {
+		RaytracingPipeline *raytracing_pipeline = raytracing_pipeline_owner.get_or_null(p_raytracing_pipeline);
+		ERR_FAIL_NULL_V(raytracing_pipeline, ERR_INVALID_PARAMETER);
+		ERR_FAIL_COND_V_MSG(raytracing_pipeline->hit_group_count < hit_sbt->raytracing_pipeline_hit_group_count, ERR_INVALID_PARAMETER, "The new pipeline must be a superset of the existing pipeline.");
+
+		_remove_dependency(p_hit_sbt, hit_sbt->raytracing_pipeline_id);
+
+		hit_sbt->raytracing_pipeline_id = p_raytracing_pipeline;
+		hit_sbt->raytracing_pipeline = raytracing_pipeline->driver_id;
+		hit_sbt->index_offset = raytracing_pipeline->raygen_shader_count + raytracing_pipeline->miss_shader_count;
+		hit_sbt->raytracing_pipeline_hit_group_count = raytracing_pipeline->hit_group_count;
+
+		_add_dependency(p_hit_sbt, p_raytracing_pipeline);
+
+		_hit_sbt_add_dirty_range(hit_sbt, 0, hit_sbt->used_hit_group_count);
+	}
+
+	return OK;
+}
+
+RD::HitShaderBindingTableRange RenderingDevice::hit_sbt_range_alloc(RID p_hit_sbt, uint32_t p_hit_group_count) {
+	ERR_RENDER_THREAD_GUARD_V(ERR_UNAVAILABLE);
+
+	HitShaderBindingTable *hit_sbt = hit_sbt_owner.get_or_null(p_hit_sbt);
+	ERR_FAIL_NULL_V(hit_sbt, RD::HitShaderBindingTableRange());
+	ERR_FAIL_COND_V(p_hit_group_count == 0, RD::HitShaderBindingTableRange());
+
+	uint32_t offset;
+
+	HitShaderBindingTable::FreeList::Element *free_list_elem = hit_sbt->free_list.lower_bound(p_hit_group_count);
+	if (free_list_elem) {
+		uint32_t free_count = free_list_elem->key();
+		RBSet<uint32_t> &free_offsets = free_list_elem->value();
+		RBSet<uint32_t>::Element *free_offset_elem = free_offsets.front();
+		DEV_ASSERT(free_offset_elem);
+
+		offset = free_offset_elem->get();
+
+		free_offsets.erase(free_offset_elem);
+		if (free_offsets.is_empty()) {
+			hit_sbt->free_list.erase(free_list_elem);
+		}
+		hit_sbt->reverse_free_list.erase(offset);
+
+		uint32_t remaining = free_count - p_hit_group_count;
+		if (remaining > 0) {
+			uint32_t new_offset = offset + p_hit_group_count;
+			hit_sbt->free_list[remaining].insert(new_offset);
+			hit_sbt->reverse_free_list[new_offset] = remaining;
+		}
+	} else {
+		offset = hit_sbt->used_hit_group_count;
+		hit_sbt->used_hit_group_count += p_hit_group_count;
+
+		if (hit_sbt->hit_group_indices.size() < hit_sbt->used_hit_group_count) {
+			hit_sbt->hit_group_indices.resize_initialized(MAX(hit_sbt->hit_group_indices.size() * 2, hit_sbt->used_hit_group_count));
+		}
+	}
+
+	_hit_sbt_add_dirty_range(hit_sbt, offset, p_hit_group_count);
+
+	return _encode_hit_sbt_range(offset, p_hit_group_count);
+}
+
+Error RenderingDevice::hit_sbt_range_free(RID p_hit_sbt, HitShaderBindingTableRange p_range) {
+	ERR_RENDER_THREAD_GUARD_V(ERR_UNAVAILABLE);
+
+	HitShaderBindingTable *hit_sbt = hit_sbt_owner.get_or_null(p_hit_sbt);
+	ERR_FAIL_NULL_V(hit_sbt, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(!p_range, ERR_INVALID_PARAMETER);
+
+	uint32_t offset = _decode_hit_sbt_range_offset(p_range);
+	uint32_t count = _decode_hit_sbt_range_count(p_range);
+
+	ERR_FAIL_COND_V((offset + count) > hit_sbt->used_hit_group_count, ERR_INVALID_PARAMETER);
+
+	HitShaderBindingTable::ReverseFreeList::Element *next_reverse_free_list_elem = hit_sbt->reverse_free_list.lower_bound(offset);
+	if (next_reverse_free_list_elem) {
+		HitShaderBindingTable::ReverseFreeList::Element *prev_reverse_free_list_elem = next_reverse_free_list_elem->prev();
+		if (prev_reverse_free_list_elem) {
+			uint32_t prev_free_offset = prev_reverse_free_list_elem->key();
+			uint32_t prev_free_count = prev_reverse_free_list_elem->value();
+
+			if ((prev_free_offset + prev_free_count) == offset) {
+				offset = prev_free_offset;
+				count += prev_free_count;
+
+				HitShaderBindingTable::FreeList::Element *prev_free_list_elem = hit_sbt->free_list.find(prev_free_count);
+				DEV_ASSERT(prev_free_list_elem);
+
+				prev_free_list_elem->value().erase(prev_free_offset);
+				if (prev_free_list_elem->value().is_empty()) {
+					hit_sbt->free_list.erase(prev_free_list_elem);
+				}
+
+				hit_sbt->reverse_free_list.erase(prev_reverse_free_list_elem);
+			}
+		}
+
+		uint32_t next_free_offset = next_reverse_free_list_elem->key();
+		uint32_t next_free_count = next_reverse_free_list_elem->value();
+
+		if ((offset + count) == next_free_offset) {
+			count += next_free_count;
+
+			HitShaderBindingTable::FreeList::Element *next_free_list_elem = hit_sbt->free_list.find(next_free_count);
+			DEV_ASSERT(next_free_list_elem);
+
+			next_free_list_elem->value().erase(next_free_offset);
+			if (next_free_list_elem->value().is_empty()) {
+				hit_sbt->free_list.erase(next_free_list_elem);
+			}
+
+			hit_sbt->reverse_free_list.erase(next_reverse_free_list_elem);
+		}
+	}
+
+	if ((offset + count) == hit_sbt->used_hit_group_count) {
+		hit_sbt->used_hit_group_count = offset;
+	} else {
+		hit_sbt->free_list[count].insert(offset);
+		hit_sbt->reverse_free_list[offset] = count;
+	}
+
+	return OK;
+}
+
+Error RenderingDevice::hit_sbt_range_update(RID p_hit_sbt, HitShaderBindingTableRange p_range, uint32_t p_offset, Span<uint32_t> p_hit_group_indices) {
+	ERR_RENDER_THREAD_GUARD_V(ERR_UNAVAILABLE);
+
+	HitShaderBindingTable *hit_sbt = hit_sbt_owner.get_or_null(p_hit_sbt);
+	ERR_FAIL_NULL_V(hit_sbt, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(!p_range, ERR_INVALID_PARAMETER);
+
+	uint32_t offset = _decode_hit_sbt_range_offset(p_range);
+	uint32_t count = _decode_hit_sbt_range_count(p_range);
+
+	ERR_FAIL_COND_V((offset + count) > hit_sbt->used_hit_group_count, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V((p_offset + p_hit_group_indices.size()) > count, ERR_INVALID_PARAMETER);
+
+#ifdef DEBUG_ENABLED
+	for (uint32_t i = 0; i < p_hit_group_indices.size(); i++) {
+		ERR_FAIL_COND_V(p_hit_group_indices[i] >= hit_sbt->raytracing_pipeline_hit_group_count, ERR_INVALID_PARAMETER);
+	}
+#endif
+
+	memcpy(hit_sbt->hit_group_indices.ptrw() + (offset + p_offset), p_hit_group_indices.ptr(), sizeof(uint32_t) * p_hit_group_indices.size());
+
+	_hit_sbt_add_dirty_range(hit_sbt, offset + p_offset, p_hit_group_indices.size());
 
 	return OK;
 }
@@ -791,32 +1081,19 @@ Error RenderingDevice::buffer_copy(RID p_src_buffer, RID p_dst_buffer, uint32_t 
 	return OK;
 }
 
-Error RenderingDevice::buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p_size, const void *p_data, bool p_skip_check) {
-	ERR_RENDER_THREAD_GUARD_V(ERR_UNAVAILABLE);
-
+Error RenderingDevice::_buffer_update(Buffer *p_buffer, RID p_buffer_id, uint32_t p_offset, uint32_t p_size, const void *p_data) {
 	copy_bytes_count += p_size;
 
-	ERR_FAIL_COND_V_MSG(draw_list.active && !p_skip_check, ERR_INVALID_PARAMETER,
-			"Updating buffers is forbidden during creation of a draw list.");
-	ERR_FAIL_COND_V_MSG(compute_list.active && !p_skip_check, ERR_INVALID_PARAMETER,
-			"Updating buffers is forbidden during creation of a compute list.");
-	ERR_FAIL_COND_V_MSG(raytracing_list.active && !p_skip_check, ERR_INVALID_PARAMETER,
-			"Updating buffers is forbidden during creation of a raytracing list.");
-
-	Buffer *buffer = _get_buffer_from_owner(p_buffer);
-	ERR_FAIL_NULL_V_MSG(buffer, ERR_INVALID_PARAMETER, "Buffer argument is not a valid buffer of any type.");
-	ERR_FAIL_COND_V_MSG(p_offset + p_size > buffer->size, ERR_INVALID_PARAMETER, "Attempted to write buffer (" + itos((p_offset + p_size) - buffer->size) + " bytes) past the end.");
-
-	if (buffer->usage.has_flag(RDD::BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT)) {
-		uint8_t *dst_data = driver->buffer_persistent_map_advance(buffer->driver_id, frames_drawn);
+	if (p_buffer->usage.has_flag(RDD::BUFFER_USAGE_DYNAMIC_PERSISTENT_BIT)) {
+		uint8_t *dst_data = driver->buffer_persistent_map_advance(p_buffer->driver_id, frames_drawn);
 
 		memcpy(dst_data + p_offset, p_data, p_size);
 		direct_copy_count++;
-		buffer_flush(p_buffer);
+		buffer_flush(p_buffer_id);
 		return OK;
 	}
 
-	_check_transfer_worker_buffer(buffer);
+	_check_transfer_worker_buffer(p_buffer);
 
 	// Submitting may get chunked for various reasons, so convert this to a task.
 	size_t to_submit = p_size;
@@ -838,12 +1115,12 @@ Error RenderingDevice::buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p
 		}
 
 		if (!command_buffer_copies_vector.is_empty() && required_action == STAGING_REQUIRED_ACTION_FLUSH_AND_STALL_ALL) {
-			if (_buffer_make_mutable(buffer, p_buffer)) {
+			if (_buffer_make_mutable(p_buffer, p_buffer_id)) {
 				// The buffer must be mutable to be used as a copy destination.
 				draw_graph.add_synchronization();
 			}
 
-			draw_graph.add_buffer_update(buffer->driver_id, buffer->draw_tracker, command_buffer_copies_vector);
+			draw_graph.add_buffer_update(p_buffer->driver_id, p_buffer->draw_tracker, command_buffer_copies_vector);
 			command_buffer_copies_vector.clear();
 		}
 
@@ -870,17 +1147,34 @@ Error RenderingDevice::buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p
 	}
 
 	if (!command_buffer_copies_vector.is_empty()) {
-		if (_buffer_make_mutable(buffer, p_buffer)) {
+		if (_buffer_make_mutable(p_buffer, p_buffer_id)) {
 			// The buffer must be mutable to be used as a copy destination.
 			draw_graph.add_synchronization();
 		}
 
-		draw_graph.add_buffer_update(buffer->driver_id, buffer->draw_tracker, command_buffer_copies_vector);
+		draw_graph.add_buffer_update(p_buffer->driver_id, p_buffer->draw_tracker, command_buffer_copies_vector);
 	}
 
 	gpu_copy_count++;
 
 	return OK;
+}
+
+Error RenderingDevice::buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p_size, const void *p_data, bool p_skip_check) {
+	ERR_RENDER_THREAD_GUARD_V(ERR_UNAVAILABLE);
+
+	ERR_FAIL_COND_V_MSG(draw_list.active && !p_skip_check, ERR_INVALID_PARAMETER,
+			"Updating buffers is forbidden during creation of a draw list.");
+	ERR_FAIL_COND_V_MSG(compute_list.active && !p_skip_check, ERR_INVALID_PARAMETER,
+			"Updating buffers is forbidden during creation of a compute list.");
+	ERR_FAIL_COND_V_MSG(raytracing_list.active && !p_skip_check, ERR_INVALID_PARAMETER,
+			"Updating buffers is forbidden during creation of a raytracing list.");
+
+	Buffer *buffer = _get_buffer_from_owner(p_buffer);
+	ERR_FAIL_NULL_V_MSG(buffer, ERR_INVALID_PARAMETER, "Buffer argument is not a valid buffer of any type.");
+	ERR_FAIL_COND_V_MSG(p_offset + p_size > buffer->size, ERR_INVALID_PARAMETER, "Attempted to write buffer (" + itos((p_offset + p_size) - buffer->size) + " bytes) past the end.");
+
+	return _buffer_update(buffer, p_buffer, p_offset, p_size, p_data);
 }
 
 Error RenderingDevice::driver_callback_add(RDD::DriverCallback p_callback, void *p_userdata, VectorView<CallbackResource> p_resources) {
@@ -4767,54 +5061,259 @@ bool RenderingDevice::compute_pipeline_is_valid(RID p_pipeline) {
 	return compute_pipeline_owner.owns(p_pipeline);
 }
 
-RID RenderingDevice::raytracing_pipeline_create(RID p_shader, const Vector<PipelineSpecializationConstant> &p_specialization_constants) {
-	_THREAD_SAFE_METHOD_
+Error RenderingDevice::_raytracing_pipeline_create_sbt_buffer(RDD::RaytracingPipelineID p_raytracing_pipeline, uint32_t p_raygen_shader_count, uint32_t p_miss_shader_count, Buffer &r_sbt_buffer) {
+	// Ray generation and miss shader group handles are placed next to each other in the same buffer.
 
-	// Needs a shader.
-	Shader *shader = shader_owner.get_or_null(p_shader);
-	ERR_FAIL_NULL_V(shader, RID());
+	uint32_t shader_group_handle_size = driver->api_trait_get(RDD::API_TRAIT_SHADER_GROUP_HANDLE_SIZE);
+	uint32_t shader_group_base_alignment = driver->api_trait_get(RDD::API_TRAIT_SHADER_GROUP_BASE_ALIGNMENT);
 
-	ERR_FAIL_COND_V_MSG(shader->pipeline_type != PIPELINE_TYPE_RAYTRACING, RID(),
-			"Only raytracing shaders can be used in raytracing pipelines");
+	uint32_t raygen_sbt_size = p_raygen_shader_count * shader_group_handle_size;
+	uint32_t miss_sbt_offset = STEPIFY(raygen_sbt_size, shader_group_base_alignment);
+	uint32_t miss_sbt_size = p_miss_shader_count * shader_group_handle_size;
 
-	for (int i = 0; i < shader->specialization_constants.size(); i++) {
-		const ShaderSpecializationConstant &sc = shader->specialization_constants[i];
-		for (int j = 0; j < p_specialization_constants.size(); j++) {
-			const PipelineSpecializationConstant &psc = p_specialization_constants[j];
-			if (psc.constant_id == sc.constant_id) {
-				ERR_FAIL_COND_V_MSG(psc.type != sc.type, RID(), "Specialization constant provided for id (" + itos(sc.constant_id) + ") is of the wrong type.");
-				break;
-			}
+	r_sbt_buffer.size = miss_sbt_offset + miss_sbt_size;
+	r_sbt_buffer.driver_id = driver->buffer_create(r_sbt_buffer.size, RDD::BUFFER_USAGE_TRANSFER_TO_BIT | RDD::BUFFER_USAGE_SHADER_BINDING_TABLE_BIT, RDD::MEMORY_ALLOCATION_TYPE_GPU, frames_drawn);
+	ERR_FAIL_COND_V(!r_sbt_buffer.driver_id, ERR_CANT_CREATE);
+
+	thread_local LocalVector<uint8_t> sbt_data;
+	sbt_data.resize(r_sbt_buffer.size);
+
+	for (uint32_t i = 0; i < p_raygen_shader_count; i++) {
+		bool success = driver->raytracing_pipeline_get_shader_group_handles(p_raytracing_pipeline, 0, VectorView<uint32_t>(i), sbt_data.ptr() + (i * shader_group_handle_size));
+		if (unlikely(!success)) {
+			driver->buffer_free(r_sbt_buffer.driver_id);
+			ERR_FAIL_V(ERR_CANT_CREATE);
 		}
 	}
 
+	for (uint32_t i = 0; i < p_miss_shader_count; i++) {
+		bool success = driver->raytracing_pipeline_get_shader_group_handles(p_raytracing_pipeline, p_raygen_shader_count, VectorView<uint32_t>(i), sbt_data.ptr() + miss_sbt_offset + (i * shader_group_handle_size));
+		if (unlikely(!success)) {
+			driver->buffer_free(r_sbt_buffer.driver_id);
+			ERR_FAIL_V(ERR_CANT_CREATE);
+		}
+	}
+
+	Error err = _buffer_initialize(&r_sbt_buffer, sbt_data);
+	if (unlikely(err != OK)) {
+		driver->buffer_free(r_sbt_buffer.driver_id);
+		ERR_FAIL_V(err);
+	}
+
+	_THREAD_SAFE_LOCK_
+	buffer_memory += r_sbt_buffer.size;
+	_THREAD_SAFE_UNLOCK_
+
+	return OK;
+}
+
+RID RenderingDevice::raytracing_pipeline_create(Span<PipelineShader> p_raygen_shaders, Span<PipelineShader> p_miss_shaders, Span<HitGroup> p_hit_groups, uint32_t p_max_trace_recursion_depth) {
+	ERR_FAIL_COND_V_MSG(!has_feature(SUPPORTS_RAYTRACING_PIPELINE) && !has_feature(SUPPORTS_RAY_QUERY), RID(), "The current rendering device has neither raytracing pipeline nor ray query support.");
+
+	struct PipelineShaderKey : PipelineShader {
+		ShaderStage shader_stage = {};
+
+		uint32_t hash() const {
+			uint32_t h = hash_murmur3_one_64(shader.get_id());
+			h = hash_murmur3_one_32(shader_stage, h);
+
+			for (uint32_t i = 0; i < specialization_constants.size(); i++) {
+				const PipelineSpecializationConstant &specialization_constant = specialization_constants[i];
+				h = hash_murmur3_one_32(specialization_constant.type, h);
+				h = hash_murmur3_one_32(specialization_constant.constant_id, h);
+				h = hash_murmur3_one_32(specialization_constant.int_value, h);
+			}
+
+			return hash_fmix32(h);
+		}
+
+		bool operator==(const PipelineShaderKey &p_rhs) const {
+			if (shader != p_rhs.shader) {
+				return false;
+			}
+			if (shader_stage != p_rhs.shader_stage) {
+				return false;
+			}
+			if (specialization_constants != p_rhs.specialization_constants) {
+				return false;
+			}
+			return true;
+		}
+	};
+
+	thread_local LocalVector<RDD::PipelineShader> shaders;
+	thread_local AHashMap<PipelineShaderKey, uint32_t> shader_indices;
+	thread_local LocalVector<uint32_t> raygen_and_miss_shader_indices;
+	thread_local LocalVector<RDD::HitGroup> hit_groups;
+	shaders.clear();
+	shader_indices.clear();
+	raygen_and_miss_shader_indices.clear();
+	hit_groups.clear();
+
+	RID layout_defining_shader_rid;
+	Shader *layout_defining_shader = nullptr;
+
+	auto _get_shader_index = [&](const PipelineShader &p_shader, ShaderStage p_shader_stage) -> uint32_t {
+		PipelineShaderKey shader_key;
+		shader_key.shader = p_shader.shader;
+		shader_key.specialization_constants = p_shader.specialization_constants;
+		shader_key.shader_stage = p_shader_stage;
+
+		uint32_t &index = shader_indices[shader_key];
+		if (!index) {
+			Shader *shader = shader_owner.get_or_null(p_shader.shader);
+			ERR_FAIL_NULL_V(shader, UINT32_MAX);
+			ERR_FAIL_COND_V_MSG(shader->pipeline_type != PIPELINE_TYPE_RAYTRACING, UINT32_MAX, "Only raytracing shaders can be used in raytracing pipelines.");
+			ERR_FAIL_COND_V_MSG(!(shader->stages_bits & (1 << p_shader_stage)), UINT32_MAX, "Shader does not contain the required stage.");
+
+			for (int i = 0; i < shader->specialization_constants.size(); i++) {
+				const ShaderSpecializationConstant &sc = shader->specialization_constants[i];
+				for (int j = 0; j < p_shader.specialization_constants.size(); j++) {
+					const PipelineSpecializationConstant &psc = p_shader.specialization_constants[j];
+					if (psc.constant_id == sc.constant_id) {
+						ERR_FAIL_COND_V_MSG(psc.type != sc.type, UINT32_MAX, "Specialization constant provided for id (" + itos(sc.constant_id) + ") is of the wrong type.");
+						break;
+					}
+				}
+			}
+
+			if (layout_defining_shader) {
+				bool compatible_layout = true;
+
+				for (uint32_t i = 0; i < MIN(layout_defining_shader->set_formats.size(), shader->set_formats.size()); i++) {
+					if (layout_defining_shader->set_formats[i] != shader->set_formats[i]) {
+						compatible_layout = false;
+						break;
+					}
+				}
+
+				if (layout_defining_shader->push_constant_size != shader->push_constant_size || layout_defining_shader->push_constant_stages != shader->push_constant_stages) {
+					compatible_layout = false;
+				}
+
+				ERR_FAIL_COND_V_MSG(!compatible_layout, UINT32_MAX, "All shaders must have compatible layouts.");
+			}
+
+			if (!layout_defining_shader || layout_defining_shader->set_formats.size() < shader->set_formats.size()) {
+				layout_defining_shader_rid = p_shader.shader;
+				layout_defining_shader = shader;
+			}
+
+			index = shaders.size() + 1;
+
+			RDD::PipelineShader rdd_shader;
+			rdd_shader.shader = shader->driver_id;
+			rdd_shader.shader_stage = p_shader_stage;
+			rdd_shader.specialization_constants = p_shader.specialization_constants;
+			shaders.push_back(rdd_shader);
+		}
+
+		return index - 1;
+	};
+
+	for (uint32_t i = 0; i < p_raygen_shaders.size(); i++) {
+		uint32_t raygen_shader_index = _get_shader_index(p_raygen_shaders[i], SHADER_STAGE_RAYGEN);
+		ERR_FAIL_COND_V(raygen_shader_index == UINT32_MAX, RID());
+
+		raygen_and_miss_shader_indices.push_back(raygen_shader_index);
+	}
+
+	for (uint32_t i = 0; i < p_miss_shaders.size(); i++) {
+		uint32_t miss_shader_index = _get_shader_index(p_miss_shaders[i], SHADER_STAGE_MISS);
+		ERR_FAIL_COND_V(miss_shader_index == UINT32_MAX, RID());
+
+		raygen_and_miss_shader_indices.push_back(miss_shader_index);
+	}
+
+	for (uint32_t i = 0; i < p_hit_groups.size(); i++) {
+		const HitGroup &hit_group = p_hit_groups[i];
+
+		RDD::HitGroup rdd_hit_group;
+
+		if (hit_group.closest_hit_shader.is_valid()) {
+			rdd_hit_group.closest_hit_shader_index = _get_shader_index(hit_group.closest_hit_shader, SHADER_STAGE_CLOSEST_HIT);
+			ERR_FAIL_COND_V(rdd_hit_group.closest_hit_shader_index == UINT32_MAX, RID());
+		}
+
+		if (hit_group.any_hit_shader.is_valid()) {
+			rdd_hit_group.any_hit_shader_index = _get_shader_index(hit_group.any_hit_shader, SHADER_STAGE_ANY_HIT);
+			ERR_FAIL_COND_V(rdd_hit_group.any_hit_shader_index == UINT32_MAX, RID());
+		}
+
+		if (hit_group.intersection_shader.is_valid()) {
+			rdd_hit_group.intersection_shader_index = _get_shader_index(hit_group.intersection_shader, SHADER_STAGE_INTERSECTION);
+			ERR_FAIL_COND_V(rdd_hit_group.intersection_shader_index == UINT32_MAX, RID());
+		}
+
+		hit_groups.push_back(rdd_hit_group);
+	}
+
+	ERR_FAIL_NULL_V(layout_defining_shader, RID());
+
 	RaytracingPipeline pipeline;
-	pipeline.driver_id = driver->raytracing_pipeline_create(shader->driver_id, p_specialization_constants);
+	pipeline.driver_id = driver->raytracing_pipeline_create(
+			shaders,
+			VectorView(raygen_and_miss_shader_indices.ptr(), p_raygen_shaders.size()),
+			VectorView(raygen_and_miss_shader_indices.ptr() + p_raygen_shaders.size(), p_miss_shaders.size()),
+			hit_groups,
+			p_max_trace_recursion_depth,
+			layout_defining_shader->driver_id);
+
 	ERR_FAIL_COND_V(!pipeline.driver_id, RID());
 
 	if (pipeline_cache_enabled) {
 		update_pipeline_cache();
 	}
 
-	pipeline.shader = p_shader;
-	pipeline.shader_driver_id = shader->driver_id;
-	pipeline.shader_layout_hash = shader->layout_hash;
-	pipeline.set_formats = shader->set_formats;
-	pipeline.push_constant_size = shader->push_constant_size;
+	pipeline.layout_defining_shader = layout_defining_shader_rid;
+	pipeline.layout_defining_shader_driver_id = layout_defining_shader->driver_id;
+	pipeline.layout_defining_shader_layout_hash = layout_defining_shader->layout_hash;
+	pipeline.set_formats = layout_defining_shader->set_formats;
+	pipeline.push_constant_size = layout_defining_shader->push_constant_size;
+
+	Error err = _raytracing_pipeline_create_sbt_buffer(pipeline.driver_id, p_raygen_shaders.size(), p_miss_shaders.size(), pipeline.sbt_buffer);
+	if (unlikely(err != OK)) {
+		driver->raytracing_pipeline_free(pipeline.driver_id);
+		ERR_FAIL_V(RID());
+	}
+
+	pipeline.raygen_shader_count = p_raygen_shaders.size();
+	pipeline.miss_shader_count = p_miss_shaders.size();
+	pipeline.hit_group_count = p_hit_groups.size();
 
 	// Create ID to associate with this pipeline.
 	RID id = raytracing_pipeline_owner.make_rid(pipeline);
 #ifdef DEV_ENABLED
 	set_resource_name(id, "RID:" + itos(id.get_id()));
 #endif
+
 	// Now add all the dependencies.
-	_add_dependency(id, p_shader);
+	for (uint32_t i = 0; i < p_raygen_shaders.size(); i++) {
+		_add_dependency(id, p_raygen_shaders[i].shader);
+	}
+	for (uint32_t i = 0; i < p_miss_shaders.size(); i++) {
+		_add_dependency(id, p_miss_shaders[i].shader);
+	}
+	for (uint32_t i = 0; i < p_hit_groups.size(); i++) {
+		const HitGroup &hit_group = p_hit_groups[i];
+
+		if (hit_group.closest_hit_shader.is_valid()) {
+			_add_dependency(id, hit_group.closest_hit_shader.shader);
+		}
+
+		if (hit_group.any_hit_shader.is_valid()) {
+			_add_dependency(id, hit_group.any_hit_shader.shader);
+		}
+
+		if (hit_group.intersection_shader.is_valid()) {
+			_add_dependency(id, hit_group.intersection_shader.shader);
+		}
+	}
+
 	return id;
 }
 
 bool RenderingDevice::raytracing_pipeline_is_valid(RID p_pipeline) {
-	_THREAD_SAFE_METHOD_
-
 	return raytracing_pipeline_owner.owns(p_pipeline);
 }
 
@@ -5847,19 +6346,24 @@ void RenderingDevice::raytracing_list_bind_raytracing_pipeline(RaytracingListID 
 	ERR_FAIL_COND(p_list != ID_TYPE_RAYTRACING_LIST);
 	ERR_FAIL_COND(!raytracing_list.active);
 
-	const RaytracingPipeline *pipeline = raytracing_pipeline_owner.get_or_null(p_raytracing_pipeline);
+	RaytracingPipeline *pipeline = raytracing_pipeline_owner.get_or_null(p_raytracing_pipeline);
 	ERR_FAIL_NULL(pipeline);
 
 	if (p_raytracing_pipeline == raytracing_list.state.pipeline) {
 		return; // Redundant state, return.
 	}
 
+	_check_transfer_worker_buffer(&pipeline->sbt_buffer);
+
 	raytracing_list.state.pipeline = p_raytracing_pipeline;
 	raytracing_list.state.pipeline_driver_id = pipeline->driver_id;
+	raytracing_list.state.sbt_buffer = pipeline->sbt_buffer.driver_id;
+	raytracing_list.state.raygen_shader_count = pipeline->raygen_shader_count;
+	raytracing_list.state.miss_shader_count = pipeline->miss_shader_count;
 
 	draw_graph.add_raytracing_list_bind_pipeline(pipeline->driver_id);
 
-	if (raytracing_list.state.pipeline_shader != pipeline->shader) {
+	if (raytracing_list.state.layout_defining_shader != pipeline->layout_defining_shader) {
 		// Shader changed, so descriptor sets may become incompatible.
 
 		uint32_t pcount = pipeline->set_formats.size(); // Formats count in this pipeline.
@@ -5880,7 +6384,7 @@ void RenderingDevice::raytracing_list_bind_raytracing_pipeline(RaytracingListID 
 				}
 			} break;
 			case RDD::SHADER_CHANGE_INVALIDATION_ALL_OR_NONE_ACCORDING_TO_LAYOUT_HASH: {
-				if (raytracing_list.state.pipeline_shader_layout_hash != pipeline->shader_layout_hash) {
+				if (raytracing_list.state.layout_defining_shader_layout_hash != pipeline->layout_defining_shader_layout_hash) {
 					first_invalid_set = 0;
 				}
 			} break;
@@ -5904,9 +6408,9 @@ void RenderingDevice::raytracing_list_bind_raytracing_pipeline(RaytracingListID 
 #endif
 		}
 
-		raytracing_list.state.pipeline_shader = pipeline->shader;
-		raytracing_list.state.pipeline_shader_driver_id = pipeline->shader_driver_id;
-		raytracing_list.state.pipeline_shader_layout_hash = pipeline->shader_layout_hash;
+		raytracing_list.state.layout_defining_shader = pipeline->layout_defining_shader;
+		raytracing_list.state.layout_defining_shader_driver_id = pipeline->layout_defining_shader_driver_id;
+		raytracing_list.state.layout_defining_shader_layout_hash = pipeline->layout_defining_shader_layout_hash;
 	}
 
 #ifdef DEBUG_ENABLED
@@ -5962,7 +6466,7 @@ void RenderingDevice::raytracing_list_set_push_constant(RaytracingListID p_list,
 			"This raytracing pipeline requires (" + itos(raytracing_list.validation.pipeline_push_constant_size) + ") bytes of push constant data, supplied: (" + itos(p_data_size) + ")");
 #endif
 
-	draw_graph.add_raytracing_list_set_push_constant(raytracing_list.state.pipeline_shader_driver_id, p_data, p_data_size);
+	draw_graph.add_raytracing_list_set_push_constant(raytracing_list.state.layout_defining_shader_driver_id, p_data, p_data_size);
 
 	// Store it in the state in case we need to restart the raytracing list.
 	memcpy(raytracing_list.state.push_constant_data, p_data, p_data_size);
@@ -5973,14 +6477,14 @@ void RenderingDevice::raytracing_list_set_push_constant(RaytracingListID p_list,
 #endif
 }
 
-void RenderingDevice::raytracing_list_trace_rays(RaytracingListID p_list, uint32_t p_width, uint32_t p_height) {
+void RenderingDevice::raytracing_list_trace_rays(RaytracingListID p_list, uint32_t p_raygen_shader_index, RID p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth) {
 	ERR_RENDER_THREAD_GUARD();
 
 	ERR_FAIL_COND(p_list != ID_TYPE_RAYTRACING_LIST);
 	ERR_FAIL_COND(!raytracing_list.active);
 
 #ifdef DEBUG_ENABLED
-	ERR_FAIL_NULL_MSG(shader_owner.get_or_null(raytracing_list.state.pipeline_shader), "No shader was set before attempting to trace rays.");
+	ERR_FAIL_NULL_MSG(shader_owner.get_or_null(raytracing_list.state.layout_defining_shader), "No shader was set before attempting to trace rays.");
 	ERR_FAIL_NULL_MSG(raytracing_pipeline_owner.get_or_null(raytracing_list.state.pipeline), "No raytracing pipeline was set before attempting to trace rays.");
 #endif
 
@@ -6008,9 +6512,9 @@ void RenderingDevice::raytracing_list_trace_rays(RaytracingListID p_list, uint32
 				ERR_FAIL_MSG("Uniforms were never supplied for set (" + itos(i) + ") at the time of drawing, which are required by the pipeline.");
 			} else if (uniform_set_owner.owns(raytracing_list.state.sets[i].uniform_set)) {
 				UniformSet *us = uniform_set_owner.get_or_null(raytracing_list.state.sets[i].uniform_set);
-				ERR_FAIL_MSG("Uniforms supplied for set (" + itos(i) + "):\n" + _shader_uniform_debug(us->shader_id, us->shader_set) + "\nare not the same format as required by the pipeline shader. Pipeline shader requires the following bindings:\n" + _shader_uniform_debug(raytracing_list.state.pipeline_shader));
+				ERR_FAIL_MSG("Uniforms supplied for set (" + itos(i) + "):\n" + _shader_uniform_debug(us->shader_id, us->shader_set) + "\nare not the same format as required by the pipeline shader. Pipeline shader requires the following bindings:\n" + _shader_uniform_debug(raytracing_list.state.layout_defining_shader));
 			} else {
-				ERR_FAIL_MSG("Uniforms supplied for set (" + itos(i) + ", which was just freed) are not the same format as required by the pipeline shader. Pipeline shader requires the following bindings:\n" + _shader_uniform_debug(raytracing_list.state.pipeline_shader));
+				ERR_FAIL_MSG("Uniforms supplied for set (" + itos(i) + ", which was just freed) are not the same format as required by the pipeline shader. Pipeline shader requires the following bindings:\n" + _shader_uniform_debug(raytracing_list.state.layout_defining_shader));
 			}
 		}
 	}
@@ -6024,7 +6528,7 @@ void RenderingDevice::raytracing_list_trace_rays(RaytracingListID p_list, uint32
 				continue;
 			}
 
-			draw_graph.add_raytracing_list_uniform_set_prepare_for_use(raytracing_list.state.pipeline_shader_driver_id, raytracing_list.state.sets[i].uniform_set_driver_id, i);
+			draw_graph.add_raytracing_list_uniform_set_prepare_for_use(raytracing_list.state.layout_defining_shader_driver_id, raytracing_list.state.sets[i].uniform_set_driver_id, i);
 		}
 	}
 
@@ -6035,7 +6539,7 @@ void RenderingDevice::raytracing_list_trace_rays(RaytracingListID p_list, uint32
 		}
 		if (!raytracing_list.state.sets[i].bound) {
 			// All good, see if this requires re-binding.
-			draw_graph.add_raytracing_list_bind_uniform_set(raytracing_list.state.pipeline_shader_driver_id, raytracing_list.state.sets[i].uniform_set_driver_id, i);
+			draw_graph.add_raytracing_list_bind_uniform_set(raytracing_list.state.layout_defining_shader_driver_id, raytracing_list.state.sets[i].uniform_set_driver_id, i);
 
 			UniformSet *uniform_set = uniform_set_owner.get_or_null(raytracing_list.state.sets[i].uniform_set);
 			_uniform_set_update_shared(uniform_set);
@@ -6046,7 +6550,35 @@ void RenderingDevice::raytracing_list_trace_rays(RaytracingListID p_list, uint32
 		}
 	}
 
-	draw_graph.add_raytracing_list_trace_rays(p_width, p_height);
+	uint32_t shader_group_handle_size = driver->api_trait_get(RDD::API_TRAIT_SHADER_GROUP_HANDLE_SIZE);
+	uint32_t shader_group_base_alignment = driver->api_trait_get(RDD::API_TRAIT_SHADER_GROUP_BASE_ALIGNMENT);
+
+	ERR_FAIL_COND(p_raygen_shader_index >= raytracing_list.state.raygen_shader_count);
+
+	RDD::ShaderBindingTable raygen_sbt;
+	raygen_sbt.buffer = raytracing_list.state.sbt_buffer;
+	raygen_sbt.offset = p_raygen_shader_index * shader_group_handle_size;
+	raygen_sbt.stride = shader_group_handle_size;
+	raygen_sbt.size = shader_group_handle_size;
+
+	RDD::ShaderBindingTable miss_sbt;
+	miss_sbt.buffer = raytracing_list.state.sbt_buffer;
+	miss_sbt.offset = STEPIFY(raytracing_list.state.raygen_shader_count * shader_group_handle_size, shader_group_base_alignment);
+	miss_sbt.stride = shader_group_handle_size;
+	miss_sbt.size = raytracing_list.state.miss_shader_count * shader_group_handle_size;
+
+	HitShaderBindingTable *hit_sbt = hit_sbt_owner.get_or_null(p_hit_sbt);
+	ERR_FAIL_NULL(hit_sbt);
+	ERR_FAIL_COND(hit_sbt->raytracing_pipeline != raytracing_list.state.pipeline_driver_id);
+
+	RDD::ShaderBindingTable rdd_hit_sbt;
+	_hit_sbt_buffer_update(hit_sbt, p_hit_sbt, rdd_hit_sbt);
+
+	if (hit_sbt->draw_tracker != nullptr) {
+		draw_graph.add_raytracing_list_usage(hit_sbt->draw_tracker, RDG::RESOURCE_USAGE_STORAGE_BUFFER_READ);
+	}
+
+	draw_graph.add_raytracing_list_trace_rays(raygen_sbt, miss_sbt, rdd_hit_sbt, p_width, p_height, p_depth);
 	raytracing_list.state.trace_count++;
 }
 
@@ -7145,6 +7677,11 @@ void RenderingDevice::_free_internal(RID p_id) {
 		RaytracingPipeline *pipeline = raytracing_pipeline_owner.get_or_null(p_id);
 		frames[frame].raytracing_pipelines_to_dispose_of.push_back(*pipeline);
 		raytracing_pipeline_owner.free(p_id);
+	} else if (hit_sbt_owner.owns(p_id)) {
+		HitShaderBindingTable *hit_sbt = hit_sbt_owner.get_or_null(p_id);
+		RDG::resource_tracker_free(hit_sbt->draw_tracker);
+		frames[frame].buffers_to_dispose_of.push_back(*hit_sbt);
+		hit_sbt_owner.free(p_id);
 	} else {
 #ifdef DEV_ENABLED
 		ERR_PRINT("Attempted to free invalid ID: " + itos(p_id.get_id()) + " " + resource_name);
@@ -7203,6 +7740,9 @@ void RenderingDevice::set_resource_name(RID p_id, const String &p_name) {
 	} else if (raytracing_pipeline_owner.owns(p_id)) {
 		RaytracingPipeline *pipeline = raytracing_pipeline_owner.get_or_null(p_id);
 		driver->set_object_name(RDD::OBJECT_TYPE_RAYTRACING_PIPELINE, pipeline->driver_id, p_name);
+	} else if (hit_sbt_owner.owns(p_id)) {
+		HitShaderBindingTable *hit_sbt = hit_sbt_owner.get_or_null(p_id);
+		driver->set_object_name(RDD::OBJECT_TYPE_BUFFER, hit_sbt->driver_id, p_name);
 	} else {
 		ERR_PRINT("Attempted to name invalid ID: " + itos(p_id.get_id()));
 		return;
@@ -7322,6 +7862,9 @@ void RenderingDevice::_free_pending_resources(int p_frame) {
 
 	while (frames[p_frame].raytracing_pipelines_to_dispose_of.front()) {
 		RaytracingPipeline *pipeline = &frames[p_frame].raytracing_pipelines_to_dispose_of.front()->get();
+
+		driver->buffer_free(pipeline->sbt_buffer.driver_id);
+		buffer_memory -= pipeline->sbt_buffer.size;
 
 		driver->raytracing_pipeline_free(pipeline->driver_id);
 
@@ -8268,6 +8811,9 @@ void RenderingDevice::finalize() {
 	// Free all resources.
 	_free_rids(render_pipeline_owner, "Pipeline");
 	_free_rids(compute_pipeline_owner, "Compute");
+	_free_rids(raytracing_pipeline_owner, "RaytracingPipeline");
+	_free_rids(acceleration_structure_owner, "AccelerationStructure");
+	_free_rids(hit_sbt_owner, "HitShaderBindingTable");
 	_free_rids(uniform_set_owner, "UniformSet");
 	_free_rids(texture_buffer_owner, "TextureBuffer");
 	_free_rids(storage_buffer_owner, "StorageBuffer");
@@ -8513,13 +9059,20 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("compute_pipeline_create", "shader", "specialization_constants"), &RenderingDevice::_compute_pipeline_create, DEFVAL(TypedArray<RDPipelineSpecializationConstant>()));
 	ClassDB::bind_method(D_METHOD("compute_pipeline_is_valid", "compute_pipeline"), &RenderingDevice::compute_pipeline_is_valid);
 
-	ClassDB::bind_method(D_METHOD("raytracing_pipeline_create", "shader", "specialization_constants"), &RenderingDevice::_raytracing_pipeline_create, DEFVAL(TypedArray<RDPipelineSpecializationConstant>()));
+	ClassDB::bind_method(D_METHOD("raytracing_pipeline_create", "raygen_shaders", "miss_shaders", "hit_groups", "max_trace_recursion_depth"), &RenderingDevice::_raytracing_pipeline_create);
 	ClassDB::bind_method(D_METHOD("raytracing_pipeline_is_valid", "raytracing_pipeline"), &RenderingDevice::raytracing_pipeline_is_valid);
 
 	ClassDB::bind_method(D_METHOD("blas_create", "geometries", "flags"), &RenderingDevice::_blas_create);
 	ClassDB::bind_method(D_METHOD("tlas_create", "max_instance_count", "flags"), &RenderingDevice::tlas_create);
 	ClassDB::bind_method(D_METHOD("blas_build", "blas"), &RenderingDevice::blas_build);
 	ClassDB::bind_method(D_METHOD("tlas_build", "tlas", "instances"), &RenderingDevice::_tlas_build);
+
+	ClassDB::bind_method(D_METHOD("hit_sbt_create", "raytracing_pipeline", "initial_hit_group_capacity"), &RenderingDevice::hit_sbt_create);
+	ClassDB::bind_method(D_METHOD("hit_sbt_set_pipeline", "hit_sbt", "raytracing_pipeline"), &RenderingDevice::hit_sbt_set_pipeline);
+
+	ClassDB::bind_method(D_METHOD("hit_sbt_range_alloc", "hit_sbt", "hit_group_count"), &RenderingDevice::hit_sbt_range_alloc);
+	ClassDB::bind_method(D_METHOD("hit_sbt_range_free", "hit_sbt", "range"), &RenderingDevice::hit_sbt_range_free);
+	ClassDB::bind_method(D_METHOD("hit_sbt_range_update", "hit_sbt", "range", "offset", "hit_group_indices"), &RenderingDevice::_hit_sbt_range_update);
 
 	ClassDB::bind_method(D_METHOD("screen_get_width", "screen"), &RenderingDevice::screen_get_width, DEFVAL(DisplayServerEnums::MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("screen_get_height", "screen"), &RenderingDevice::screen_get_height, DEFVAL(DisplayServerEnums::MAIN_WINDOW_ID));
@@ -8566,7 +9119,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("raytracing_list_bind_raytracing_pipeline", "raytracing_list", "raytracing_pipeline"), &RenderingDevice::raytracing_list_bind_raytracing_pipeline);
 	ClassDB::bind_method(D_METHOD("raytracing_list_set_push_constant", "raytracing_list", "buffer", "size_bytes"), &RenderingDevice::_raytracing_list_set_push_constant);
 	ClassDB::bind_method(D_METHOD("raytracing_list_bind_uniform_set", "raytracing_list", "uniform_set", "set_index"), &RenderingDevice::raytracing_list_bind_uniform_set);
-	ClassDB::bind_method(D_METHOD("raytracing_list_trace_rays", "raytracing_list", "width", "height"), &RenderingDevice::raytracing_list_trace_rays);
+	ClassDB::bind_method(D_METHOD("raytracing_list_trace_rays", "raytracing_list", "raygen_shader_index", "hit_sbt", "width", "height", "depth"), &RenderingDevice::raytracing_list_trace_rays);
 	ClassDB::bind_method(D_METHOD("raytracing_list_end"), &RenderingDevice::raytracing_list_end);
 
 	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &RenderingDevice::free_rid);
@@ -9489,6 +10042,10 @@ Error RenderingDevice::_tlas_build(RID p_tlas, const TypedArray<RDAccelerationSt
 	return tlas_build(p_tlas, instances);
 }
 
+Error RenderingDevice::_hit_sbt_range_update(RID p_hit_sbt, HitShaderBindingTableRange p_range, uint32_t p_offset, const Vector<int32_t> &p_hit_group_indices) {
+	return hit_sbt_range_update(p_hit_sbt, p_range, p_offset, Span<int32_t>(p_hit_group_indices).reinterpret<uint32_t>());
+}
+
 static Vector<RenderingDevice::PipelineSpecializationConstant> _get_spec_constants(const TypedArray<RDPipelineSpecializationConstant> &p_constants) {
 	Vector<RenderingDevice::PipelineSpecializationConstant> ret;
 	ret.resize(p_constants.size());
@@ -9557,8 +10114,55 @@ RID RenderingDevice::_compute_pipeline_create(RID p_shader, const TypedArray<RDP
 	return compute_pipeline_create(p_shader, _get_spec_constants(p_specialization_constants));
 }
 
-RID RenderingDevice::_raytracing_pipeline_create(RID p_shader, const TypedArray<RDPipelineSpecializationConstant> &p_specialization_constants = TypedArray<RDPipelineSpecializationConstant>()) {
-	return raytracing_pipeline_create(p_shader, _get_spec_constants(p_specialization_constants));
+RID RenderingDevice::_raytracing_pipeline_create(const TypedArray<RDPipelineShader> &p_raygen_shaders, const TypedArray<RDPipelineShader> &p_miss_shaders, const TypedArray<RDHitGroup> &p_hit_groups, uint32_t p_max_trace_recursion_depth) {
+	thread_local LocalVector<PipelineShader> raygen_and_miss_shaders;
+	thread_local LocalVector<HitGroup> hit_groups;
+	raygen_and_miss_shaders.clear();
+	hit_groups.clear();
+
+	auto _get_shader = [&](const RDPipelineShader *p_shader) -> PipelineShader {
+		PipelineShader shader = p_shader->base;
+		shader.specialization_constants = _get_spec_constants(p_shader->specialization_constants);
+		return shader;
+	};
+
+	for (int i = 0; i < p_raygen_shaders.size(); i++) {
+		Ref<RDPipelineShader> raygen_shader = p_raygen_shaders[i];
+		ERR_FAIL_COND_V(raygen_shader.is_null(), RID());
+
+		raygen_and_miss_shaders.push_back(_get_shader(*raygen_shader));
+	}
+
+	for (int i = 0; i < p_miss_shaders.size(); i++) {
+		Ref<RDPipelineShader> miss_shader = p_miss_shaders[i];
+		ERR_FAIL_COND_V(miss_shader.is_null(), RID());
+
+		raygen_and_miss_shaders.push_back(_get_shader(*miss_shader));
+	}
+
+	for (int i = 0; i < p_hit_groups.size(); i++) {
+		Ref<RDHitGroup> rd_hit_group = p_hit_groups[i];
+		ERR_FAIL_COND_V(rd_hit_group.is_null(), RID());
+
+		HitGroup hit_group;
+		if (rd_hit_group->closest_hit_shader.is_valid()) {
+			hit_group.closest_hit_shader = _get_shader(*rd_hit_group->closest_hit_shader);
+		}
+		if (rd_hit_group->any_hit_shader.is_valid()) {
+			hit_group.any_hit_shader = _get_shader(*rd_hit_group->any_hit_shader);
+		}
+		if (rd_hit_group->intersection_shader.is_valid()) {
+			hit_group.intersection_shader = _get_shader(*rd_hit_group->intersection_shader);
+		}
+
+		hit_groups.push_back(hit_group);
+	}
+
+	return raytracing_pipeline_create(
+			Span<PipelineShader>(raygen_and_miss_shaders.ptr(), p_raygen_shaders.size()),
+			Span<PipelineShader>(raygen_and_miss_shaders.ptr() + p_raygen_shaders.size(), p_miss_shaders.size()),
+			hit_groups,
+			p_max_trace_recursion_depth);
 }
 
 #ifndef DISABLE_DEPRECATED

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -35,6 +35,7 @@
 #include "core/os/thread_safe.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/rb_map.h"
+#include "core/templates/rb_set.h"
 #include "core/templates/rid_owner.h"
 #include "core/variant/type_info.h"
 #include "core/variant/typed_array.h"
@@ -60,6 +61,8 @@ class RDFramebufferPass;
 class RDPipelineSpecializationConstant;
 class RDAccelerationStructureGeometry;
 class RDAccelerationStructureInstance;
+class RDPipelineShader;
+class RDHitGroup;
 
 class RenderingDevice : public RenderingDeviceCommons {
 	GDCLASS(RenderingDevice, Object)
@@ -120,6 +123,7 @@ private:
 	HashMap<RID, HashSet<RID>> reverse_dependency_map; // Same as above, but in reverse.
 
 	void _add_dependency(RID p_id, RID p_depends_on);
+	void _remove_dependency(RID p_id, RID p_depends_on);
 	void _free_dependencies(RID p_id);
 
 private:
@@ -212,6 +216,8 @@ private:
 		Callable callback;
 		uint32_t size = 0;
 	};
+
+	Error _buffer_update(Buffer *p_buffer, RID p_buffer_id, uint32_t p_offset, uint32_t p_size, const void *p_data);
 
 public:
 	Error buffer_copy(RID p_src_buffer, RID p_dst_buffer, uint32_t p_src_offset, uint32_t p_dst_offset, uint32_t p_size);
@@ -1246,15 +1252,21 @@ private:
 	RID_Owner<ComputePipeline, true> compute_pipeline_owner;
 
 	struct RaytracingPipeline {
-		RID shader;
-		RDD::ShaderID shader_driver_id;
-		uint32_t shader_layout_hash = 0;
+		RID layout_defining_shader;
+		RDD::ShaderID layout_defining_shader_driver_id;
+		uint32_t layout_defining_shader_layout_hash = 0;
 		Vector<uint32_t> set_formats;
 		RDD::RaytracingPipelineID driver_id;
 		uint32_t push_constant_size = 0;
+		Buffer sbt_buffer;
+		uint32_t raygen_shader_count = 0;
+		uint32_t miss_shader_count = 0;
+		uint32_t hit_group_count = 0;
 	};
 
-	RID_Owner<RaytracingPipeline> raytracing_pipeline_owner;
+	Error _raytracing_pipeline_create_sbt_buffer(RDD::RaytracingPipelineID p_raytracing_pipeline, uint32_t p_raygen_shader_count, uint32_t p_miss_shader_count, Buffer &r_sbt_buffer);
+
+	RID_Owner<RaytracingPipeline, true> raytracing_pipeline_owner;
 
 public:
 	RID render_pipeline_create(RID p_shader, FramebufferFormatID p_framebuffer_format, VertexFormatID p_vertex_format, RenderPrimitive p_render_primitive, const PipelineRasterizationState &p_rasterization_state, const PipelineMultisampleState &p_multisample_state, const PipelineDepthStencilState &p_depth_stencil_state, const PipelineColorBlendState &p_blend_state, BitField<PipelineDynamicStateFlags> p_dynamic_state_flags = 0, uint32_t p_for_render_pass = 0, const Vector<PipelineSpecializationConstant> &p_specialization_constants = Vector<PipelineSpecializationConstant>());
@@ -1263,7 +1275,22 @@ public:
 	RID compute_pipeline_create(RID p_shader, const Vector<PipelineSpecializationConstant> &p_specialization_constants = Vector<PipelineSpecializationConstant>());
 	bool compute_pipeline_is_valid(RID p_pipeline);
 
-	RID raytracing_pipeline_create(RID p_shader, const Vector<PipelineSpecializationConstant> &p_specialization_constants = Vector<PipelineSpecializationConstant>());
+	struct PipelineShader {
+		RID shader;
+		Vector<PipelineSpecializationConstant> specialization_constants;
+
+		bool is_valid() const {
+			return shader.is_valid();
+		}
+	};
+
+	struct HitGroup {
+		PipelineShader closest_hit_shader;
+		PipelineShader any_hit_shader;
+		PipelineShader intersection_shader;
+	};
+
+	RID raytracing_pipeline_create(Span<PipelineShader> p_raygen_shaders, Span<PipelineShader> p_miss_shaders, Span<HitGroup> p_hit_groups, uint32_t p_max_trace_recursion_depth);
 	bool raytracing_pipeline_is_valid(RID p_pipeline);
 
 	void update_pipeline_cache(bool p_closing = false);
@@ -1344,16 +1371,57 @@ public:
 	RID blas_create(Span<AccelerationStructureGeometry> p_geometries, BitField<AccelerationStructureFlagBits> p_flags);
 	RID tlas_create(uint32_t p_max_instance_count, BitField<AccelerationStructureFlagBits> p_flags);
 
+	typedef int64_t HitShaderBindingTableRange;
+
 	struct AccelerationStructureInstance {
 		Transform3D transform;
 		uint32_t id = 0;
 		uint8_t mask = 0xFF;
+		HitShaderBindingTableRange hit_sbt_range = 0;
 		BitField<AccelerationStructureInstanceFlagBits> flags = {};
 		RID blas;
 	};
 
 	Error blas_build(RID p_blas);
 	Error tlas_build(RID p_tlas, Span<AccelerationStructureInstance> p_instances);
+
+private:
+	/**********************************/
+	/**** HIT SHADER BINDING TABLE ****/
+	/**********************************/
+
+	struct HitShaderBindingTable : Buffer {
+		RID raytracing_pipeline_id;
+		RDD::RaytracingPipelineID raytracing_pipeline;
+		uint32_t index_offset = 0;
+		uint32_t raytracing_pipeline_hit_group_count = 0; // Used for validation.
+
+		Vector<uint32_t> hit_group_indices;
+		uint32_t used_hit_group_count = 0;
+
+		uint32_t first_dirty_index = UINT32_MAX;
+		uint32_t last_dirty_index = 0;
+
+		typedef RBMap<uint32_t, RBSet<uint32_t>> FreeList;
+		typedef RBMap<uint32_t, uint32_t> ReverseFreeList;
+
+		FreeList free_list;
+		ReverseFreeList reverse_free_list;
+	};
+
+	RID_Owner<HitShaderBindingTable, true> hit_sbt_owner;
+
+	RDD::BufferID _hit_sbt_buffer_create(uint32_t p_buffer_size);
+	Error _hit_sbt_buffer_update(HitShaderBindingTable *p_hit_sbt, RID p_hit_sbt_id, RDD::ShaderBindingTable &r_sbt);
+	void _hit_sbt_add_dirty_range(HitShaderBindingTable *p_hit_sbt, uint32_t p_offset, uint32_t p_count);
+
+public:
+	RID hit_sbt_create(RID p_raytracing_pipeline, uint32_t p_initial_hit_group_capacity);
+	Error hit_sbt_set_pipeline(RID p_hit_sbt, RID p_raytracing_pipeline);
+
+	HitShaderBindingTableRange hit_sbt_range_alloc(RID p_hit_sbt, uint32_t p_hit_group_count);
+	Error hit_sbt_range_free(RID p_hit_sbt, HitShaderBindingTableRange p_range);
+	Error hit_sbt_range_update(RID p_hit_sbt, HitShaderBindingTableRange p_range, uint32_t p_hit_group_offset, Span<uint32_t> p_hit_group_indices);
 
 	/*************************/
 	/**** DRAW LISTS (II) ****/
@@ -1517,11 +1585,14 @@ private:
 			uint32_t set_count = 0;
 			RID pipeline;
 			RDD::RaytracingPipelineID pipeline_driver_id;
-			RID pipeline_shader;
-			RDD::ShaderID pipeline_shader_driver_id;
-			uint32_t pipeline_shader_layout_hash = 0;
+			RID layout_defining_shader;
+			RDD::ShaderID layout_defining_shader_driver_id;
+			uint32_t layout_defining_shader_layout_hash = 0;
 			uint8_t push_constant_data[MAX_PUSH_CONSTANT_SIZE] = {};
 			uint32_t push_constant_size = 0;
+			RDD::BufferID sbt_buffer;
+			uint32_t raygen_shader_count = 0;
+			uint32_t miss_shader_count = 0;
 			uint32_t trace_count = 0;
 		} state;
 
@@ -1549,7 +1620,7 @@ public:
 	void raytracing_list_bind_raytracing_pipeline(RaytracingListID p_list, RID p_raytracing_pipeline);
 	void raytracing_list_bind_uniform_set(RaytracingListID p_list, RID p_uniform_set, uint32_t p_index);
 	void raytracing_list_set_push_constant(RaytracingListID p_list, const void *p_data, uint32_t p_data_size);
-	void raytracing_list_trace_rays(RaytracingListID p_list, uint32_t p_width, uint32_t p_height);
+	void raytracing_list_trace_rays(RaytracingListID p_list, uint32_t p_raygen_shader_index, RID p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth);
 	void raytracing_list_end();
 
 private:
@@ -1936,9 +2007,11 @@ private:
 	RID _blas_create(const TypedArray<RDAccelerationStructureGeometry> &p_geometries, BitField<AccelerationStructureFlagBits> p_flags);
 	Error _tlas_build(RID p_tlas, const TypedArray<RDAccelerationStructureInstance> &p_instances);
 
+	Error _hit_sbt_range_update(RID p_hit_sbt, HitShaderBindingTableRange p_range, uint32_t p_offset, const Vector<int32_t> &p_hit_group_indices);
+
 	RID _render_pipeline_create(RID p_shader, FramebufferFormatID p_framebuffer_format, VertexFormatID p_vertex_format, RenderPrimitive p_render_primitive, const Ref<RDPipelineRasterizationState> &p_rasterization_state, const Ref<RDPipelineMultisampleState> &p_multisample_state, const Ref<RDPipelineDepthStencilState> &p_depth_stencil_state, const Ref<RDPipelineColorBlendState> &p_blend_state, BitField<PipelineDynamicStateFlags> p_dynamic_state_flags, uint32_t p_for_render_pass, const TypedArray<RDPipelineSpecializationConstant> &p_specialization_constants);
 	RID _compute_pipeline_create(RID p_shader, const TypedArray<RDPipelineSpecializationConstant> &p_specialization_constants);
-	RID _raytracing_pipeline_create(RID p_shader, const TypedArray<RDPipelineSpecializationConstant> &p_specialization_constants);
+	RID _raytracing_pipeline_create(const TypedArray<RDPipelineShader> &p_raygen_shaders, const TypedArray<RDPipelineShader> &p_miss_shaders, const TypedArray<RDHitGroup> &p_hit_groups, uint32_t p_max_trace_recursion_depth);
 
 	void _draw_list_set_push_constant(DrawListID p_list, const Vector<uint8_t> &p_data, uint32_t p_data_size);
 	void _compute_list_set_push_constant(ComputeListID p_list, const Vector<uint8_t> &p_data, uint32_t p_data_size);

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -785,6 +785,7 @@ public:
 	RD_SETGET(Transform3D, transform)
 	RD_SETGET(uint32_t, id)
 	RD_SETGET(uint8_t, mask)
+	RD_SETGET(RD::HitShaderBindingTableRange, hit_sbt_range)
 	RD_SETGET(BitField<RD::AccelerationStructureInstanceFlagBits>, flags)
 	RD_SETGET(RID, blas)
 
@@ -793,7 +794,77 @@ protected:
 		RD_BIND(Variant::TRANSFORM3D, RDAccelerationStructureInstance, transform);
 		RD_BIND(Variant::INT, RDAccelerationStructureInstance, id);
 		RD_BIND(Variant::INT, RDAccelerationStructureInstance, mask);
+		RD_BIND(Variant::INT, RDAccelerationStructureInstance, hit_sbt_range);
 		RD_BIND(Variant::INT, RDAccelerationStructureInstance, flags);
 		RD_BIND(Variant::RID, RDAccelerationStructureInstance, blas);
+	}
+};
+
+class RDPipelineShader : public RefCounted {
+	GDCLASS(RDPipelineShader, RefCounted)
+	friend class RenderingDevice;
+	RD::PipelineShader base;
+
+	TypedArray<RDPipelineSpecializationConstant> specialization_constants;
+
+public:
+	RD_SETGET(RID, shader)
+
+	void set_specialization_constants(const TypedArray<RDPipelineSpecializationConstant> &p_specialization_constants) {
+		specialization_constants = p_specialization_constants;
+	}
+
+	TypedArray<RDPipelineSpecializationConstant> get_specialization_constants() const {
+		return specialization_constants;
+	}
+
+protected:
+	static void _bind_methods() {
+		RD_BIND(Variant::RID, RDPipelineShader, shader);
+
+		ClassDB::bind_method(D_METHOD("set_specialization_constants", "specialization_constants"), &RDPipelineShader::set_specialization_constants);
+		ClassDB::bind_method(D_METHOD("get_specialization_constants"), &RDPipelineShader::get_specialization_constants);
+		ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "specialization_constants", PROPERTY_HINT_ARRAY_TYPE, "RDPipelineSpecializationConstant"), "set_specialization_constants", "get_specialization_constants");
+	}
+};
+
+class RDHitGroup : public RefCounted {
+	GDCLASS(RDHitGroup, RefCounted)
+	friend class RenderingDevice;
+
+	Ref<RDPipelineShader> closest_hit_shader;
+	Ref<RDPipelineShader> any_hit_shader;
+	Ref<RDPipelineShader> intersection_shader;
+
+public:
+	void set_closest_hit_shader(const Ref<RDPipelineShader> &p_closest_hit_shader) {
+		closest_hit_shader = p_closest_hit_shader;
+	}
+
+	Ref<RDPipelineShader> get_closest_hit_shader() const {
+		return closest_hit_shader;
+	}
+
+	void set_any_hit_shader(const Ref<RDPipelineShader> &p_any_hit_shader) {
+		any_hit_shader = p_any_hit_shader;
+	}
+
+	Ref<RDPipelineShader> get_any_hit_shader() const {
+		return any_hit_shader;
+	}
+
+	void set_intersection_shader(const Ref<RDPipelineShader> &p_intersection_shader) {
+		intersection_shader = p_intersection_shader;
+	}
+
+	Ref<RDPipelineShader> get_intersection_shader() const {
+		return intersection_shader;
+	}
+
+protected:
+	static void _bind_methods() {
+		RD_BIND(Variant::OBJECT, RDHitGroup, closest_hit_shader);
+		RD_BIND(Variant::OBJECT, RDHitGroup, any_hit_shader);
+		RD_BIND(Variant::OBJECT, RDHitGroup, intersection_shader);
 	}
 };

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -39,10 +39,10 @@
 template <typename T>
 class VectorView {
 	const T *_ptr = nullptr;
-	const uint32_t _size = 0;
+	uint32_t _size = 0;
 
 public:
-	const T &operator[](uint32_t p_index) {
+	const T &operator[](uint32_t p_index) const {
 		DEV_ASSERT(p_index < _size);
 		return _ptr[p_index];
 	}
@@ -682,6 +682,23 @@ public:
 			float float_value;
 			bool bool_value;
 		};
+
+		bool operator==(const PipelineSpecializationConstant &p_rhs) const {
+			if (type != p_rhs.type) {
+				return false;
+			}
+			if (constant_id != p_rhs.constant_id) {
+				return false;
+			}
+			if (int_value != p_rhs.int_value) {
+				return false;
+			}
+			return true;
+		}
+
+		bool operator!=(const PipelineSpecializationConstant &p_rhs) const {
+			return !(*this == p_rhs);
+		}
 	};
 
 	/*******************/

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -761,6 +761,7 @@ public:
 		Transform3D transform;
 		uint32_t id = 0;
 		uint8_t mask = 0;
+		uint32_t hit_sbt_offset = 0;
 		BitField<AccelerationStructureInstanceFlagBits> flags = {};
 		AccelerationStructureID blas;
 	};
@@ -773,8 +774,22 @@ public:
 
 	// ----- PIPELINE -----
 
-	virtual RaytracingPipelineID raytracing_pipeline_create(ShaderID p_shader, VectorView<PipelineSpecializationConstant> p_specialization_constants) = 0;
+	struct PipelineShader {
+		ShaderID shader;
+		VectorView<PipelineSpecializationConstant> specialization_constants;
+		ShaderStage shader_stage = {};
+	};
+
+	struct HitGroup {
+		uint32_t closest_hit_shader_index = UINT32_MAX;
+		uint32_t any_hit_shader_index = UINT32_MAX;
+		uint32_t intersection_shader_index = UINT32_MAX;
+	};
+
+	virtual RaytracingPipelineID raytracing_pipeline_create(VectorView<PipelineShader> p_shaders, VectorView<uint32_t> p_raygen_shader_indices, VectorView<uint32_t> p_miss_shader_indices, VectorView<HitGroup> p_hit_groups, uint32_t p_max_trace_recursion_depth, ShaderID p_layout_defining_shader) = 0;
 	virtual void raytracing_pipeline_free(RaytracingPipelineID p_pipeline) = 0;
+
+	virtual bool raytracing_pipeline_get_shader_group_handles(RaytracingPipelineID p_pipeline, uint32_t p_group_index_offset, VectorView<uint32_t> p_group_indices, uint8_t *r_data) = 0;
 
 	// ----- COMMANDS -----
 
@@ -782,7 +797,15 @@ public:
 	virtual void command_build_tlas(CommandBufferID p_cmd_buffer, AccelerationStructureID p_acceleration_structure, BufferID p_scratch_buffer, BufferID p_instance_buffer, uint32_t p_instance_offset, uint32_t p_instance_count) = 0;
 	virtual void command_bind_raytracing_pipeline(CommandBufferID p_cmd_buffer, RaytracingPipelineID p_pipeline) = 0;
 	virtual void command_bind_raytracing_uniform_set(CommandBufferID p_cmd_buffer, UniformSetID p_uniform_set, ShaderID p_shader, uint32_t p_set_index) = 0;
-	virtual void command_trace_rays(CommandBufferID p_cmd_buffer, uint32_t p_width, uint32_t p_height) = 0;
+
+	struct ShaderBindingTable {
+		BufferID buffer;
+		uint32_t offset = 0;
+		uint32_t stride = 0;
+		uint32_t size = 0;
+	};
+
+	virtual void command_trace_rays(CommandBufferID p_cmd_buffer, const ShaderBindingTable &p_raygen_sbt, const ShaderBindingTable &p_miss_sbt, const ShaderBindingTable &p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth) = 0;
 
 	/******************/
 	/**** CALLBACK ****/
@@ -879,6 +902,9 @@ public:
 		API_TRAIT_BUFFERS_REQUIRE_TRANSITIONS,
 		API_TRAIT_TEXTURE_OUTPUTS_REQUIRE_CLEARS,
 		API_TRAIT_ACCELERATION_STRUCTURE_INSTANCE_SIZE,
+		API_TRAIT_SHADER_GROUP_HANDLE_SIZE,
+		API_TRAIT_SHADER_GROUP_BASE_ALIGNMENT,
+		API_TRAIT_SHADER_GROUP_HANDLE_ALIGNMENT,
 	};
 
 	enum ShaderChangeInvalidation {

--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -813,7 +813,7 @@ void RenderingDeviceGraph::_run_raytracing_list_command(RDD::CommandBufferID p_c
 			} break;
 			case RaytracingListInstruction::TYPE_TRACE_RAYS: {
 				const RaytracingListTraceRaysInstruction *trace_rays_instruction = reinterpret_cast<const RaytracingListTraceRaysInstruction *>(instruction);
-				driver->command_trace_rays(p_command_buffer, trace_rays_instruction->width, trace_rays_instruction->height);
+				driver->command_trace_rays(p_command_buffer, trace_rays_instruction->raygen_sbt, trace_rays_instruction->miss_sbt, trace_rays_instruction->hit_sbt, trace_rays_instruction->width, trace_rays_instruction->height, trace_rays_instruction->depth);
 				instruction_data_cursor += sizeof(RaytracingListTraceRaysInstruction);
 			} break;
 			case RaytracingListInstruction::TYPE_SET_PUSH_CONSTANT: {
@@ -1959,11 +1959,15 @@ void RenderingDeviceGraph::add_raytracing_list_set_push_constant(RDD::ShaderID p
 	memcpy(instruction->data(), p_data, p_data_size);
 }
 
-void RenderingDeviceGraph::add_raytracing_list_trace_rays(uint32_t p_width, uint32_t p_height) {
+void RenderingDeviceGraph::add_raytracing_list_trace_rays(const RDD::ShaderBindingTable &p_raygen_sbt, const RDD::ShaderBindingTable &p_miss_sbt, const RDD::ShaderBindingTable &p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth) {
 	RaytracingListTraceRaysInstruction *instruction = reinterpret_cast<RaytracingListTraceRaysInstruction *>(_allocate_raytracing_list_instruction(sizeof(RaytracingListTraceRaysInstruction)));
 	instruction->type = RaytracingListInstruction::TYPE_TRACE_RAYS;
+	instruction->raygen_sbt = p_raygen_sbt;
+	instruction->miss_sbt = p_miss_sbt;
+	instruction->hit_sbt = p_hit_sbt;
 	instruction->width = p_width;
 	instruction->height = p_height;
+	instruction->depth = p_depth;
 }
 
 void RenderingDeviceGraph::add_raytracing_list_uniform_set_prepare_for_use(RDD::ShaderID p_shader, RDD::UniformSetID p_uniform_set, uint32_t set_index) {

--- a/servers/rendering/rendering_device_graph.h
+++ b/servers/rendering/rendering_device_graph.h
@@ -708,8 +708,12 @@ private:
 	};
 
 	struct RaytracingListTraceRaysInstruction : RaytracingListInstruction {
+		RDD::ShaderBindingTable raygen_sbt;
+		RDD::ShaderBindingTable miss_sbt;
+		RDD::ShaderBindingTable hit_sbt;
 		uint32_t width = 0;
 		uint32_t height = 0;
+		uint32_t depth = 0;
 	};
 
 	struct RaytracingListUniformSetPrepareForUseInstruction : RaytracingListInstruction {
@@ -897,7 +901,7 @@ public:
 	void add_raytracing_list_bind_pipeline(RDD::RaytracingPipelineID p_pipeline);
 	void add_raytracing_list_bind_uniform_set(RDD::ShaderID p_shader, RDD::UniformSetID p_uniform_set, uint32_t set_index);
 	void add_raytracing_list_set_push_constant(RDD::ShaderID p_shader, const void *p_data, uint32_t p_data_size);
-	void add_raytracing_list_trace_rays(uint32_t p_width, uint32_t p_height);
+	void add_raytracing_list_trace_rays(const RDD::ShaderBindingTable &p_raygen_sbt, const RDD::ShaderBindingTable &p_miss_sbt, const RDD::ShaderBindingTable &p_hit_sbt, uint32_t p_width, uint32_t p_height, uint32_t p_depth);
 	void add_raytracing_list_uniform_set_prepare_for_use(RDD::ShaderID p_shader, RDD::UniformSetID p_uniform_set, uint32_t set_index);
 	void add_raytracing_list_usage(ResourceTracker *p_tracker, ResourceUsage p_usage);
 	void add_raytracing_list_usages(VectorView<ResourceTracker *> p_trackers, VectorView<ResourceUsage> p_usages);

--- a/servers/rendering/rendering_shader_container.cpp
+++ b/servers/rendering/rendering_shader_container.cpp
@@ -249,28 +249,32 @@ Error RenderingShaderContainer::reflect_spirv(const String &p_shader_name, Span<
 		r_refl[i].shader_stage = stage;
 		r_refl[i]._spirv_data = p_spirv[i].spirv;
 
-		if (!pipeline_type_detected) {
-			switch (stage) {
-				case RDC::SHADER_STAGE_VERTEX:
-				case RDC::SHADER_STAGE_FRAGMENT:
-				case RDC::SHADER_STAGE_TESSELATION_CONTROL:
-				case RDC::SHADER_STAGE_TESSELATION_EVALUATION:
-					r_shader.pipeline_type = RDC::PIPELINE_TYPE_RASTERIZATION;
-					break;
-				case RDC::SHADER_STAGE_COMPUTE:
-					r_shader.pipeline_type = RDC::PIPELINE_TYPE_COMPUTE;
-					break;
-				case RDC::SHADER_STAGE_RAYGEN:
-				case RDC::SHADER_STAGE_ANY_HIT:
-				case RDC::SHADER_STAGE_CLOSEST_HIT:
-				case RDC::SHADER_STAGE_MISS:
-				case RDC::SHADER_STAGE_INTERSECTION:
-					r_shader.pipeline_type = RDC::PIPELINE_TYPE_RAYTRACING;
-					break;
-				default:
-					DEV_ASSERT(false && "Unknown shader stage.");
-			}
+		RDC::PipelineType pipeline_type = {};
+		switch (stage) {
+			case RDC::SHADER_STAGE_VERTEX:
+			case RDC::SHADER_STAGE_FRAGMENT:
+			case RDC::SHADER_STAGE_TESSELATION_CONTROL:
+			case RDC::SHADER_STAGE_TESSELATION_EVALUATION:
+				pipeline_type = RDC::PIPELINE_TYPE_RASTERIZATION;
+				break;
+			case RDC::SHADER_STAGE_COMPUTE:
+				pipeline_type = RDC::PIPELINE_TYPE_COMPUTE;
+				break;
+			case RDC::SHADER_STAGE_RAYGEN:
+			case RDC::SHADER_STAGE_ANY_HIT:
+			case RDC::SHADER_STAGE_CLOSEST_HIT:
+			case RDC::SHADER_STAGE_MISS:
+			case RDC::SHADER_STAGE_INTERSECTION:
+				pipeline_type = RDC::PIPELINE_TYPE_RAYTRACING;
+				break;
+			default:
+				DEV_ASSERT(false && "Unknown shader stage.");
+		}
 
+		if (pipeline_type_detected) {
+			ERR_FAIL_COND_V_MSG(r_shader.pipeline_type != pipeline_type, FAILED, "Shader stages of different pipeline types cannot be mixed in the same shader container.");
+		} else {
+			r_shader.pipeline_type = pipeline_type;
 			pipeline_type_detected = true;
 		}
 
@@ -283,6 +287,19 @@ Error RenderingShaderContainer::reflect_spirv(const String &p_shader_name, Span<
 		ERR_FAIL_COND_V_MSG(reflection.stages_bits.has_flag(stage_flag), FAILED,
 				"Stage " + String(RDC::SHADER_STAGE_NAMES[stage]) + " submitted more than once.");
 		reflection.stages_bits.set_flag(stage_flag);
+
+		// We make all raytracing stages visible to make our lives easier when creating raytracing pipelines.
+		// This makes no practical difference in current graphics drivers, since Vulkan is the outlier.
+		BitField<RDC::ShaderStage> uniform_stage_flags;
+		if (pipeline_type == RDC::PIPELINE_TYPE_RAYTRACING) {
+			uniform_stage_flags = RDC::SHADER_STAGE_RAYGEN |
+					RDC::SHADER_STAGE_ANY_HIT |
+					RDC::SHADER_STAGE_CLOSEST_HIT |
+					RDC::SHADER_STAGE_MISS |
+					RDC::SHADER_STAGE_INTERSECTION;
+		} else {
+			uniform_stage_flags = stage_flag;
+		}
 
 		{
 			SpvReflectShaderModule &module = *r_refl.ptr()[i]._module;
@@ -449,7 +466,7 @@ Error RenderingShaderContainer::reflect_spirv(const String &p_shader_name, Span<
 										"On shader stage '" + String(RDC::SHADER_STAGE_NAMES[stage]) + "', uniform '" + binding.name + "' trying to reuse location for set=" + itos(set) + ", binding=" + itos(uniform.binding) + " with different writability.");
 
 								// Just append stage mask and return.
-								reflection.uniform_sets[set][k].stages.set_flag(stage_flag);
+								reflection.uniform_sets[set][k].stages.set_flag(uniform_stage_flags);
 								exists = true;
 								break;
 							}
@@ -460,7 +477,7 @@ Error RenderingShaderContainer::reflect_spirv(const String &p_shader_name, Span<
 						}
 					}
 
-					uniform.stages.set_flag(stage_flag);
+					uniform.stages.set_flag(uniform_stage_flags);
 
 					if (set >= (uint32_t)reflection.uniform_sets.size()) {
 						reflection.uniform_sets.resize(set + 1);
@@ -619,7 +636,7 @@ Error RenderingShaderContainer::reflect_spirv(const String &p_shader_name, Span<
 						"Reflection of SPIR-V shader stage '" + String(RDC::SHADER_STAGE_NAMES[p_spirv[i].shader_stage]) + "': Push constant block must be the same across shader stages.");
 
 				reflection.push_constant_size = pconstants[0]->size;
-				reflection.push_constant_stages.set_flag(stage_flag);
+				reflection.push_constant_stages.set_flag(uniform_stage_flags);
 
 				//print_line("Stage: " + String(RDC::SHADER_STAGE_NAMES[stage]) + " push constant of size=" + itos(push_constant.push_constant_size));
 			}


### PR DESCRIPTION
# Raytracing pipelines

Raytracing pipelines currently accept only one shader, which prevents having multiple of the same raytracing stage in a single pipeline. The issue comes from Godot shader containers supporting only one shader per stage. This is very limiting and doesn't allow for any advanced usage of the RT API.

To address this, I modified the raytracing pipeline creation method to accept multiple shader objects. Since the order of these objects are user defined, they can be referenced directly by their index.

Example GDScript:
```gdscript
shader = rd.shader_create_from_spirv(load("res://ray.glsl").get_spirv())
shader_2 = rd.shader_create_from_spirv(load("res://ray_2.glsl").get_spirv())

var pipeline_shader = RDPipelineShader.new()
pipeline_shader.shader = shader

var spec_constant = RDPipelineSpecializationConstant.new()
spec_constant.constant_id = 0
spec_constant.value = true

# Pipeline shaders can specify specialization constants.
var specialized_pipeline_shader = RDPipelineShader.new()
specialized_pipeline_shader.shader = shader
specialized_pipeline_shader.specialization_constants = [spec_constant]

var pipeline_shader_2 = RDPipelineShader.new()
pipeline_shader_2.shader = shader_2

var hit_group := RDHitGroup.new()
hit_group.closest_hit_shader = pipeline_shader

var hit_group_2 := RDHitGroup.new()
hit_group_2.closest_hit_shader = specialized_pipeline_shader

var hit_group_3 := RDHitGroup.new()
hit_group_3.closest_hit_shader = pipeline_shader_2

raytracing_pipeline = rd.raytracing_pipeline_create(
    [pipeline_shader],
    [pipeline_shader],
    [hit_group, hit_group_2, hit_group_3],
    1 # max recursion depth
)
```

During pipeline creation, the implementation looks up the appropriate stage in each shader container. Shaders can be specialized using the newly introduced `PipelineShader` type.

Each shader has its own pipeline layout, so they must all be compatible to be compiled into a single raytracing pipeline. I based this on Vulkan descriptor set compatibility. The layout that works with every shader is selected and used for the pipeline.

To make this actually work, I had to force all raytracing stages to be visible in raytracing shaders when enumerating uniform binding and push constant reflection information. Otherwise, shaders may be considered incompatible due to differing stage visibility flags.

Practically though, forcing visibility doesn't seem to make any difference in GPU drivers, since all raytracing stages appear to be treated the same. D3D12 also has no stage granularity for raytracing in root signatures and expects "ALL". Vulkan is the outlier here.

# Shader binding table

Raytracing pipelines still manage shader records for ray generation and miss shaders. Accessing them is simple. The `raytracing_list_trace_rays` function now takes an argument specifying the index of the ray generation shader in the pipeline. Similarly, in GLSL, `traceRayEXT`  uses the index of the miss shader in the pipeline. The order is the same.

For hit groups, however, it doesn't make much sense for pipelines to manage them, since their records depend on instance data such as  geometry count, material type, etc. To handle this, I added a new RD type called "hit shader binding table", hit SBT for short. 

This part is something I took some liberty in so I'm not fully sure if the API design is ideal.

The hit SBT allocates an internal buffer based on a user defined initial hit group capacity. Ranges can then be suballocated from this buffer using a free list implementation, and assigned to the `hit_sbt_range` field of an `AccelerationStructureInstance`. The returned range value is an opaque 64-bit integer encoding the offset and count of the range. The user is intended to treat it like a RID object.

To populate the data, the suballocated range and hit group indices are passed into `hit_sbt_range_update`. When `raytracing_list_trace_rays` is called, RD fills the buffer internally using shader record handles provided by RDD.

There are two concerns when managing this:

- Expanding the size of the SBT.
- Recreating the raytracing pipeline. This'll basically always happen whenever materials with new shaders are added to the scene, since the pipeline is a singular object.

To handle resizing, the hit SBT object keeps track of its internal capacity and expands as required. 

As for the raytracing pipeline, I made it possible to change it after creation. Since hit groups are just indices, the buffer can be repopulated using the new pipeline. This assumes pipeline recreations are _incremental_, keeping previous hit groups and only adding new ones. If shrinking is needed, it could likely be handled via an index remapping array, but I'd need to experiment with that.

Example usage of hit SBT in GDScript:

```gdscript
	sbt = rd.hit_sbt_create(raytracing_pipeline, 1024)

	range = rd.hit_sbt_range_alloc(sbt, 2)
	rd.hit_sbt_range_update(sbt, range, 0, [0, 1])

	range_2 = rd.hit_sbt_range_alloc(sbt, 2)
	rd.hit_sbt_range_update(sbt, range_2, 0, [1, 0])

	var inst = RDAccelerationStructureInstance.new()
	inst.transform.origin = Vector3(-0.5, 0.0, 0.0)
	inst.hit_sbt_range = range
	inst.blas = blas
	
	var inst_2 = RDAccelerationStructureInstance.new()
	inst_2.transform.origin = Vector3(0.5, 0.0, 0)
	inst_2.hit_sbt_range = range_2
	inst_2.blas = blas
```

Result:

<img width="1154" height="680" alt="godot windows editor dev x86_64 llvm_1774975520" src="https://github.com/user-attachments/assets/23318270-3417-464b-80d2-ff82cb8b723a" />

# To do

- [x] Thread safety for hit SBT. 
- [x] Actual free list allocator for ranges in hit SBT.
- [x] Keeping raytracing pipeline managed SBT in GPU.
- [x] Should specialization constants be per shader or applied globally to the pipeline?
    - Made per shader.
- [x] Documentation.