### PR TITLE
Clarify when to use ResourceFormatLoader vs EditorImportPlugin

### DIFF
--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -115,6 +115,7 @@
 		[/csharp]
 		[/codeblocks]
 		To use [EditorImportPlugin], register it using the [method EditorPlugin.add_import_plugin] method first.
+		[b]Note:[/b] [EditorImportPlugin] is only available in the editor. To implement a loader for a file format that can be used at runtime in an exported project, you need to extend [ResourceFormatLoader] instead.
 	</description>
 	<tutorials>
 		<link title="Import plugins">$DOCS_URL/tutorials/plugins/editor/import_plugins.html</link>

--- a/doc/classes/ResourceFormatLoader.xml
+++ b/doc/classes/ResourceFormatLoader.xml
@@ -5,10 +5,11 @@
 	</brief_description>
 	<description>
 		Godot loads resources in the editor or in exported games using ResourceFormatLoaders. They are queried automatically via the [ResourceLoader] singleton, or when a resource with internal dependencies is loaded. Each file type may load as a different resource type, so multiple ResourceFormatLoaders are registered in the engine.
-		Extending this class allows you to define your own loader. Be sure to respect the documented return types and values. You should give it a global class name with [code]class_name[/code] for it to be registered. Like built-in ResourceFormatLoaders, it will be called automatically when loading resources of its handled type(s). You may also implement a [ResourceFormatSaver].
-		[b]Note:[/b] You can also extend [EditorImportPlugin] if the resource type you need exists but Godot is unable to load its format. Choosing one way over another depends on if the format is suitable or not for the final exported game. For example, it's better to import [code].png[/code] textures as [code].ctex[/code] ([CompressedTexture2D]) first, so they can be loaded with better efficiency on the graphics card.
+		Extending this class allows you to define your own loader for file formats not natively recognized by Godot at runtime. Be sure to respect the documented return types and values. You should give it a global class name with [code]class_name[/code] for it to be registered. Like built-in ResourceFormatLoaders, it will be called automatically when loading resources of its handled type(s). You may also implement a [ResourceFormatSaver].
+		[b]Note:[/b] You can also extend [EditorImportPlugin] to implement a custom resource importer. Unlike [ResourceFormatLoader], this is not available for use at runtime in an imported project, but is called while in the editor during the import process instead. Choosing one way over another depends on if the format is suitable or not for the final exported game. For example, it's better to import [code].png[/code] textures as [code].ctex[/code] ([CompressedTexture2D]) first, so they can be loaded with better efficiency on the graphics card.
 	</description>
 	<tutorials>
+		<link title="Runtime file loading and saving">$DOCS_URL/tutorials/io/runtime_file_loading_and_saving.html</link>
 	</tutorials>
 	<methods>
 		<method name="_exists" qualifiers="virtual const">


### PR DESCRIPTION
This also adds a link to the Runtime file loading and saving tutorial in the ResourceFormatLoader documentation.

- This closes https://github.com/godotengine/godot-docs/issues/10322.