### PR TITLE
Enable clang-tidy's performance-move-const-arg check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@
 
 Checks:
   - -*
+  - performance-move-const-arg
   - bugprone-use-after-move
   - modernize-deprecated-headers
   - modernize-redundant-void-arg

--- a/core/object/gdtype.cpp
+++ b/core/object/gdtype.cpp
@@ -122,5 +122,5 @@ void GDType::add_signal(MethodInfo p_signal) {
 	const MethodInfo *ptr = memnew(MethodInfo(std::move(p_signal)));
 
 	signal_map[signal_name] = ptr;
-	self_signal_map[std::move(signal_name)] = ptr;
+	self_signal_map[signal_name] = ptr;
 }


### PR DESCRIPTION
This PR enables the clang-tidy check [`performance-move-const-arg`](https://clang.llvm.org/extra/clang-tidy/checks/performance/move-const-arg.html). This check validates that when `<utility>`'s [`std::move`](https://en.cppreference.com/w/cpp/utility/move.html) is used, that the result of invoking `move` matches expected behavior (i.e. actually doing a move and not silently falling back to a copy).

There is not a compiler-level warning for this issue on Linux (I don't see a comparable warning for GCC/Clang). MSVC has [C26478](https://learn.microsoft.com/en-us/cpp/code-quality/c26478?view=msvc-170) which covers the same issue there.