### PR TITLE
Add cell origin indicators to the `GridMap` editor

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -661,11 +661,20 @@
 		</member>
 		<member name="editors/bone_mapper/handle_colors/unset" type="Color" setter="" getter="">
 		</member>
+		<member name="editors/grid_map/cell_origin_base_scale" type="float" setter="" getter="">
+			The base scale of the origin indicators, which is then multiplied by the shortest non-edited axis in [member GridMap.cell_size].
+		</member>
+		<member name="editors/grid_map/cell_origin_cursor_area" type="int" setter="" getter="">
+			The number of cells around the cursor where non-selected occupied cells will show their origin.
+		</member>
 		<member name="editors/grid_map/pick_distance" type="float" setter="" getter="">
 			The maximum distance at which tiles can be placed on a GridMap, relative to the camera position (in 3D units).
 		</member>
 		<member name="editors/grid_map/preview_size" type="int" setter="" getter="">
 			Texture size of mesh previews generated for GridMap's MeshLibrary.
+		</member>
+		<member name="editors/grid_map/show_cell_origins" type="bool" setter="" getter="">
+			If enabled, shows origin indicators of occupied cells, both selected and around the cursor.
 		</member>
 		<member name="editors/panning/2d_editor_pan_speed" type="int" setter="" getter="">
 			The panning speed when using the mouse wheel or touchscreen events in the 2D editor. This setting does not apply to panning by holding down the middle or right mouse buttons.

--- a/editor/icons/GridMapOrigin.svg
+++ b/editor/icons/GridMapOrigin.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><circle cx="32" cy="32" r="30" fill="gray"/><circle cx="32" cy="32" r="28" fill="#fff"/></svg>

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -888,8 +888,11 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// GridMap
 	// GridMapEditor
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "editors/grid_map/show_cell_origins", true, "");
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "editors/grid_map/cell_origin_cursor_area", 3, "0,12,or_greater");
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/grid_map/cell_origin_base_scale", 1, "0.02,6,or_greater");
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/grid_map/pick_distance", 5000.0, "1,8192,0.1,or_greater");
-	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "editors/grid_map/preview_size", 64, "16,128,1")
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "editors/grid_map/preview_size", 64, "16,128,1");
 
 	// 3D
 	EDITOR_SETTING_BASIC(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d/primary_grid_color", Color(0.56, 0.56, 0.56, 0.5), "")

--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -276,6 +276,11 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="cell_center_changed">
+			<description>
+				Emitted when [member cell_center_x], [member cell_center_y], or [member cell_center_z] changes.
+			</description>
+		</signal>
 		<signal name="cell_size_changed">
 			<param index="0" name="cell_size" type="Vector3" />
 			<description>

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -50,6 +50,7 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/debugger/view_3d_controller.h"
+#include "scene/gui/check_button.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/item_list.h"
 #include "scene/gui/label.h"
@@ -104,6 +105,7 @@ void GridMapEditor::_menu_option(int p_option) {
 			}
 			edit_axis = Vector3::Axis(new_axis);
 			update_grid();
+			_update_cell_origin_scale();
 
 		} break;
 
@@ -141,6 +143,9 @@ void GridMapEditor::_menu_option(int p_option) {
 					undo_redo->add_do_method(node, "set_cell_item", cell, node->get_cell_item(cell), node->get_orthogonal_index_from_basis(r));
 					undo_redo->add_undo_method(node, "set_cell_item", cell, node->get_cell_item(cell), node->get_cell_item_orientation(cell));
 				}
+
+				undo_redo->add_do_method(this, "_update_cell_origins");
+				undo_redo->add_undo_method(this, "_update_cell_origins");
 
 				undo_redo->commit_action();
 
@@ -321,6 +326,7 @@ void GridMapEditor::_set_selection(bool p_active, const Vector3 &p_begin, const 
 		_update_selection_transform();
 
 		if (was_active != selection.active || begin_old != selection.begin || end_old != selection.end) {
+			_update_cell_origins();
 			emit_signal(SNAME("overlay_update_requested"));
 		}
 	}
@@ -453,6 +459,7 @@ bool GridMapEditor::do_input_action(Camera3D *p_camera, const Point2 &p_point, b
 		}
 
 		_update_cursor_transform();
+		_update_cell_origins();
 	}
 
 	if (input_action == INPUT_NONE) {
@@ -797,6 +804,9 @@ void GridMapEditor::_do_paste() {
 		}
 		undo_redo->add_do_method(this, "_set_selection", true, temp_begin, temp_end);
 		undo_redo->add_undo_method(this, "_set_selection", selection.active, selection.begin, selection.end);
+	} else {
+		undo_redo->add_do_method(this, "_update_cell_origins");
+		undo_redo->add_undo_method(this, "_update_cell_origins");
 	}
 
 	undo_redo->commit_action();
@@ -962,6 +972,9 @@ EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D 
 						const SetItem &si = set_items[i - 1];
 						undo_redo->add_undo_method(node, "set_cell_item", si.position, si.old_value, si.old_orientation);
 					}
+
+					undo_redo->add_do_method(this, "_update_cell_origins");
+					undo_redo->add_undo_method(this, "_update_cell_origins");
 
 					undo_redo->commit_action();
 				}
@@ -1204,6 +1217,8 @@ void GridMapEditor::_update_mesh_library() {
 void GridMapEditor::edit(GridMap *p_gridmap) {
 	if (node) {
 		node->disconnect(SNAME("cell_size_changed"), callable_mp(this, &GridMapEditor::_draw_grids));
+		node->disconnect(SNAME("cell_size_changed"), callable_mp(this, &GridMapEditor::_update_cell_origin_scale));
+		node->disconnect(SNAME("cell_center_changed"), callable_mp(this, &GridMapEditor::_update_cell_origins));
 		node->disconnect(CoreStringName(changed), callable_mp(this, &GridMapEditor::_update_mesh_library));
 		if (mesh_library.is_valid()) {
 			mesh_library->disconnect_changed(callable_mp(this, &GridMapEditor::update_palette));
@@ -1237,6 +1252,7 @@ void GridMapEditor::edit(GridMap *p_gridmap) {
 
 	update_palette();
 	_update_cursor_instance();
+	_update_cell_origin_scale();
 
 	set_process(true);
 
@@ -1244,6 +1260,8 @@ void GridMapEditor::edit(GridMap *p_gridmap) {
 	update_grid();
 
 	node->connect(SNAME("cell_size_changed"), callable_mp(this, &GridMapEditor::_draw_grids));
+	node->connect(SNAME("cell_size_changed"), callable_mp(this, &GridMapEditor::_update_cell_origin_scale).unbind(1));
+	node->connect(SNAME("cell_center_changed"), callable_mp(this, &GridMapEditor::_update_cell_origins));
 	node->connect(CoreStringName(changed), callable_mp(this, &GridMapEditor::_update_mesh_library));
 	_update_mesh_library();
 }
@@ -1334,6 +1352,11 @@ void GridMapEditor::_update_theme() {
 	mode_thumbnail->set_button_icon(get_theme_icon(SNAME("FileThumbnail"), EditorStringName(EditorIcons)));
 	mode_list->set_button_icon(get_theme_icon(SNAME("FileList"), EditorStringName(EditorIcons)));
 	options->set_button_icon(get_theme_icon(SNAME("Tools"), EditorStringName(EditorIcons)));
+
+	Ref<Texture2D> cell_origin_icon = EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("GridMapOrigin"), EditorStringName(EditorIcons));
+	for (int i = 0; i < ORIGIN_COUNT; i++) {
+		cell_origin_mat[i]->set_texture(StandardMaterial3D::TEXTURE_ALBEDO, cell_origin_icon);
+	}
 }
 
 void GridMapEditor::_notification(int p_what) {
@@ -1374,6 +1397,11 @@ void GridMapEditor::_notification(int p_what) {
 				RenderingServer::get_singleton()->free_rid(selection_level_instance[i]);
 			}
 
+			for (const RID &E : cell_origin_instance) {
+				RS::get_singleton()->free_rid(E);
+			}
+			cell_origin_instance.clear();
+
 			RenderingServer::get_singleton()->free_rid(cursor_instance);
 			RenderingServer::get_singleton()->free_rid(selection_instance);
 			RenderingServer::get_singleton()->free_rid(paste_instance);
@@ -1397,6 +1425,7 @@ void GridMapEditor::_notification(int p_what) {
 				grid_xform = xf;
 				_update_cursor_transform();
 				_update_selection_transform();
+				_update_cell_origins();
 			}
 		} break;
 
@@ -1424,8 +1453,14 @@ void GridMapEditor::_notification(int p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			indicator_mat->set_albedo(EDITOR_GET("editors/3d_gizmos/gizmo_colors/gridmap_grid"));
 
-			// Take Preview Size changes into account.
-			update_palette();
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/grid_map")) {
+				update_palette(); // Take Preview Size changes into account.
+				_update_cell_origin_scale();
+
+				settings_show_cell_origins->set_pressed_no_signal(EDITOR_GET("editors/grid_map/show_cell_origins"));
+				settings_cell_origin_area->set_value_no_signal(EDITOR_GET("editors/grid_map/cell_origin_cursor_area"));
+				settings_pick_distance->set_value_no_signal(EDITOR_GET("editors/grid_map/pick_distance"));
+			}
 		} break;
 	}
 }
@@ -1482,9 +1517,141 @@ void GridMapEditor::_update_cursor_instance() {
 	_update_cursor_transform();
 }
 
+void GridMapEditor::_update_cell_origin_scale() {
+	float mult_by = 0;
+	Vector3 cell_size = node->get_cell_size();
+	for (int i = 0; i < Vector3::AXIS_COUNT; i++) {
+		if (i != edit_axis) {
+			mult_by = mult_by == 0 ? cell_size[i] : MIN(mult_by, cell_size[i]);
+		}
+	}
+
+	float base_scale = EDITOR_GET("editors/grid_map/cell_origin_base_scale");
+	float scale = MAX(0.01, 0.1 * mult_by * base_scale);
+	if (Math::is_equal_approx(scale, cell_origin_scale)) {
+		return;
+	}
+
+	cell_origin_scale = scale;
+
+	Vector<Vector3> vs = {
+		Vector3(-scale, scale, 0),
+		Vector3(scale, scale, 0),
+		Vector3(scale, -scale, 0),
+		Vector3(-scale, -scale, 0)
+	};
+
+	Vector<Vector2> uv = {
+		Vector2(0, 0),
+		Vector2(1, 0),
+		Vector2(1, 1),
+		Vector2(0, 1)
+	};
+
+	Vector<int> indices = { 0, 1, 2, 0, 2, 3 };
+
+	Array a;
+	a.resize(Mesh::ARRAY_MAX);
+	a[Mesh::ARRAY_VERTEX] = vs;
+	a[Mesh::ARRAY_TEX_UV] = uv;
+	a[Mesh::ARRAY_INDEX] = indices;
+
+	if (RS::get_singleton()->mesh_get_surface_count(cell_origin_mesh) != 0) {
+		RS::get_singleton()->mesh_surface_remove(cell_origin_mesh, 0);
+	}
+	RS::get_singleton()->mesh_add_surface_from_arrays(cell_origin_mesh, RSE::PRIMITIVE_TRIANGLES, a);
+	RS::get_singleton()->mesh_set_custom_aabb(cell_origin_mesh, AABB(Vector3(-scale, -scale, -scale) * 100.0f, Vector3(scale, scale, scale) * 200.0f));
+
+	_update_cell_origins();
+}
+
+void GridMapEditor::_update_cell_origins() {
+	int idx = 0;
+
+	bool show_origins = EDITOR_GET("editors/grid_map/show_cell_origins");
+	int expand_by = EDITOR_GET("editors/grid_map/cell_origin_cursor_area");
+	if (show_origins) {
+		Vector<AABB> ignore_areas;
+		if (cursor_visible) {
+			AABB cursor_center(cursor_gridpos, Vector3());
+			idx = _fill_area_with_origins(cursor_center, ORIGIN_CURSOR);
+			ignore_areas.append(cursor_center);
+		}
+
+		AABB select = _get_selection();
+		if (select.size != Vector3i()) {
+			idx = _fill_area_with_origins(select, ORIGIN_SELECTED, ignore_areas, idx);
+			ignore_areas.append(select);
+		}
+
+		if (cursor_visible) {
+			Vector3i expansion(expand_by, expand_by, expand_by);
+			expansion[edit_axis] = 0;
+			AABB cursor_area = AABB(cursor_gridpos - expansion, expansion * 2);
+			idx = _fill_area_with_origins(cursor_area, ORIGIN_NEAR_CURSOR, ignore_areas, idx);
+		}
+	}
+
+	// Free unused instances.
+	for (int i = idx; i < cell_origin_instance.size(); i++) {
+		RS::get_singleton()->free_rid(cell_origin_instance[i]);
+	}
+	cell_origin_instance.resize(idx);
+}
+
+int GridMapEditor::_fill_area_with_origins(AABB p_area, CellOriginMaterial p_material, const Vector<AABB> &p_ignore_areas, int p_from) {
+	const RID scenario = get_tree()->get_root()->get_world_3d()->get_scenario();
+	int idx = p_from;
+	p_area.size += Vector3i(1, 1, 1);
+
+	for (int i = 0; i < p_area.size.x; i++) {
+		for (int j = 0; j < p_area.size.y; j++) {
+			for (int k = 0; k < p_area.size.z; k++) {
+				Vector3i pos(p_area.position.x + i, p_area.position.y + j, p_area.position.z + k);
+				bool has_cell = node->get_cell_item(pos) != GridMap::INVALID_CELL_ITEM;
+				if (!has_cell) {
+					continue;
+				}
+
+				bool skip = false;
+				for (const AABB &area : p_ignore_areas) {
+					if (area.has_point(pos)) {
+						skip = true;
+						break;
+					}
+				}
+				if (skip) {
+					continue;
+				}
+
+				Transform3D xf;
+				xf.origin = node->to_global(node->map_to_local(pos));
+
+				if (idx >= cell_origin_instance.size()) {
+					cell_origin_instance.append(RS::get_singleton()->instance_create2(cell_origin_mesh, scenario));
+					RS::get_singleton()->instance_set_layer_mask(cell_origin_instance[idx], 1 << Node3DEditorViewport::MISC_TOOL_LAYER);
+				}
+
+				RS::get_singleton()->instance_set_surface_override_material(cell_origin_instance[idx], 0, cell_origin_mat[p_material]->get_rid());
+				RS::get_singleton()->instance_set_transform(cell_origin_instance[idx], xf);
+
+				idx++;
+			}
+		}
+	}
+
+	return idx;
+}
+
 void GridMapEditor::_on_tool_mode_changed() {
 	_show_viewports_transform_gizmo(mode_buttons_group->get_pressed_button() == transform_mode_button);
 	_update_cursor_instance();
+}
+
+void GridMapEditor::_settings_changed() {
+	EditorSettings::get_singleton()->set_setting("editors/grid_map/show_cell_origins", settings_show_cell_origins->is_pressed());
+	EditorSettings::get_singleton()->set_setting("editors/grid_map/cell_origin_cursor_area", settings_cell_origin_area->get_value());
+	EditorSettings::get_singleton()->set_setting("editors/grid_map/pick_distance", settings_pick_distance->get_value());
 }
 
 void GridMapEditor::_item_selected_cbk(int idx) {
@@ -1511,6 +1678,7 @@ void GridMapEditor::_floor_mouse_exited() {
 void GridMapEditor::_bind_methods() {
 	ClassDB::bind_method("_configure", &GridMapEditor::_configure);
 	ClassDB::bind_method("_set_selection", &GridMapEditor::_set_selection);
+	ClassDB::bind_method("_update_cell_origins", &GridMapEditor::_update_cell_origins);
 
 	ADD_SIGNAL(MethodInfo("overlay_update_requested"));
 }
@@ -1555,13 +1723,35 @@ GridMapEditor::GridMapEditor() {
 	settings_vbc->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
 	settings_dialog->add_child(settings_vbc);
 
+	settings_show_cell_origins = memnew(CheckButton);
+	settings_show_cell_origins->set_text("Show Cell Origins");
+	settings_show_cell_origins->set_pressed_no_signal(EDITOR_GET("editors/grid_map/show_cell_origins"));
+	settings_show_cell_origins->set_accessibility_name(TTRC("Show Cell Origins"));
+	settings_vbc->add_child(settings_show_cell_origins);
+	settings_show_cell_origins->connect(SceneStringName(toggled), callable_mp(this, &GridMapEditor::_settings_changed).unbind(1));
+
+	settings_vbc->add_child(memnew(Label(TTRC("Cell Origin Area Near the Cursor:"))));
+
+	settings_cell_origin_area = memnew(SpinBox);
+	settings_cell_origin_area->set_max(12);
+	settings_cell_origin_area->set_allow_greater(true);
+	settings_cell_origin_area->set_min(0);
+	settings_cell_origin_area->set_value_no_signal(EDITOR_GET("editors/grid_map/cell_origin_cursor_area"));
+	settings_cell_origin_area->set_accessibility_name(TTRC("Cell Origin Area Near the Cursor:"));
+	settings_vbc->add_child(settings_cell_origin_area);
+	settings_cell_origin_area->connect(SceneStringName(value_changed), callable_mp(this, &GridMapEditor::_settings_changed).unbind(1));
+
+	settings_vbc->add_child(memnew(HSeparator));
+
+	settings_vbc->add_child(memnew(Label(TTRC("Pick Distance:"))));
+
 	settings_pick_distance = memnew(SpinBox);
-	settings_pick_distance->set_max(10000.0f);
-	settings_pick_distance->set_min(500.0f);
-	settings_pick_distance->set_step(1.0f);
-	settings_pick_distance->set_value(EDITOR_GET("editors/grid_map/pick_distance"));
+	settings_pick_distance->set_max(10000);
+	settings_pick_distance->set_min(500);
+	settings_pick_distance->set_value_no_signal(EDITOR_GET("editors/grid_map/pick_distance"));
 	settings_pick_distance->set_accessibility_name(TTRC("Pick Distance:"));
-	settings_vbc->add_margin_child(TTRC("Pick Distance:"), settings_pick_distance);
+	settings_vbc->add_child(settings_pick_distance);
+	settings_pick_distance->connect(SceneStringName(value_changed), callable_mp(this, &GridMapEditor::_settings_changed).unbind(1));
 
 	options->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &GridMapEditor::_menu_option));
 
@@ -1804,7 +1994,7 @@ GridMapEditor::GridMapEditor() {
 	paste_mesh = RenderingServer::get_singleton()->mesh_create();
 
 	{
-		// Selection mesh create.
+		// Selection mesh creation.
 
 		Vector<Vector3> lines;
 		Vector<Vector3> triangles;
@@ -1952,6 +2142,37 @@ GridMapEditor::GridMapEditor() {
 	indicator_mat->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 	indicator_mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
 	indicator_mat->set_albedo(EDITOR_GET("editors/3d_gizmos/gizmo_colors/gridmap_grid"));
+
+	cell_origin_mesh = RS::get_singleton()->mesh_create();
+
+	for (int i = 0; i < ORIGIN_COUNT; i++) {
+		cell_origin_mat[i].instantiate();
+		cell_origin_mat[i]->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+		cell_origin_mat[i]->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
+		cell_origin_mat[i]->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
+		cell_origin_mat[i]->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+		cell_origin_mat[i]->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA_SCISSOR);
+		cell_origin_mat[i]->set_alpha_scissor_threshold(0.1);
+		cell_origin_mat[i]->set_render_priority(1);
+		cell_origin_mat[i]->set_billboard_mode(StandardMaterial3D::BILLBOARD_ENABLED);
+		cell_origin_mat[i]->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
+
+		Color color;
+		switch (i) {
+			case ORIGIN_CURSOR: {
+				color = Color(1, 1, 1);
+			} break;
+
+			case ORIGIN_NEAR_CURSOR: {
+				color = Color(1, 0.79, 0.37);
+			} break;
+
+			case ORIGIN_SELECTED: {
+				color = Color(0, 0.56, 1);
+			} break;
+		}
+		cell_origin_mat[i]->set_albedo(color);
+	}
 }
 
 GridMapEditor::~GridMapEditor() {
@@ -1987,6 +2208,8 @@ GridMapEditor::~GridMapEditor() {
 	if (paste_instance.is_valid()) {
 		RenderingServer::get_singleton()->free_rid(paste_instance);
 	}
+
+	RenderingServer::get_singleton()->free_rid(cell_origin_mesh);
 }
 
 void GridMapEditorPlugin::_notification(int p_what) {

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -37,6 +37,7 @@
 #include "scene/gui/box_container.h"
 
 class Button;
+class CheckButton;
 class ConfirmationDialog;
 class FilterLineEdit;
 class HSlider;
@@ -66,6 +67,13 @@ class GridMapEditor : public EditorDock {
 	enum DisplayMode {
 		DISPLAY_THUMBNAIL,
 		DISPLAY_LIST
+	};
+
+	enum CellOriginMaterial {
+		ORIGIN_CURSOR,
+		ORIGIN_NEAR_CURSOR,
+		ORIGIN_SELECTED,
+		ORIGIN_COUNT,
 	};
 
 	InputAction input_action = INPUT_NONE;
@@ -103,6 +111,8 @@ class GridMapEditor : public EditorDock {
 	ConfirmationDialog *settings_dialog = nullptr;
 	VBoxContainer *settings_vbc = nullptr;
 	SpinBox *settings_pick_distance = nullptr;
+	CheckButton *settings_show_cell_origins = nullptr;
+	SpinBox *settings_cell_origin_area = nullptr;
 	Label *spin_box_label = nullptr;
 
 	struct SetItem {
@@ -123,6 +133,7 @@ class GridMapEditor : public EditorDock {
 	Vector3::Axis edit_axis;
 	int edit_floor[3];
 	Vector3 grid_ofs;
+	float cell_origin_scale = 0;
 
 	RID grid[3];
 	RID grid_instance[3];
@@ -134,6 +145,8 @@ class GridMapEditor : public EditorDock {
 	RID selection_level_instance[3];
 	RID paste_mesh;
 	RID paste_instance;
+	RID cell_origin_mesh;
+	Vector<RID> cell_origin_instance;
 
 	struct ClipboardItem {
 		int cell_item = 0;
@@ -154,6 +167,7 @@ class GridMapEditor : public EditorDock {
 	Ref<StandardMaterial3D> inner_mat;
 	Ref<StandardMaterial3D> outer_mat;
 	Ref<StandardMaterial3D> selection_floor_mat;
+	Ref<StandardMaterial3D> cell_origin_mat[ORIGIN_COUNT];
 
 	bool updating = false;
 
@@ -230,7 +244,11 @@ class GridMapEditor : public EditorDock {
 	void _item_selected_cbk(int idx);
 	void _update_cursor_transform();
 	void _update_cursor_instance();
+	void _update_cell_origin_scale();
+	void _update_cell_origins();
+	int _fill_area_with_origins(AABB p_area, CellOriginMaterial p_material, const Vector<AABB> &p_ignore_areas = Vector<AABB>(), int p_from = 0);
 	void _on_tool_mode_changed();
+	void _settings_changed();
 	void _update_theme();
 
 	void _text_changed(const String &p_text);

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -338,6 +338,7 @@ int GridMap::get_octant_size() const {
 void GridMap::set_center_x(bool p_enable) {
 	center_x = p_enable;
 	_recreate_octant_data();
+	emit_signal(SNAME("cell_center_changed"));
 }
 
 bool GridMap::get_center_x() const {
@@ -347,6 +348,7 @@ bool GridMap::get_center_x() const {
 void GridMap::set_center_y(bool p_enable) {
 	center_y = p_enable;
 	_recreate_octant_data();
+	emit_signal(SNAME("cell_center_changed"));
 }
 
 bool GridMap::get_center_y() const {
@@ -356,6 +358,7 @@ bool GridMap::get_center_y() const {
 void GridMap::set_center_z(bool p_enable) {
 	center_z = p_enable;
 	_recreate_octant_data();
+	emit_signal(SNAME("cell_center_changed"));
 }
 
 bool GridMap::get_center_z() const {
@@ -1308,6 +1311,7 @@ void GridMap::_bind_methods() {
 	BIND_CONSTANT(INVALID_CELL_ITEM);
 
 	ADD_SIGNAL(MethodInfo("cell_size_changed", PropertyInfo(Variant::VECTOR3, "cell_size")));
+	ADD_SIGNAL(MethodInfo("cell_center_changed"));
 	ADD_SIGNAL(MethodInfo(CoreStringName(changed)));
 
 	BIND_ENUM_CONSTANT(DEBUG_VISIBILITY_MODE_DEFAULT);


### PR DESCRIPTION
This PR adds indicator for the origin filled cells, both selected and those around the cursor. It also comes with editor settings to tune the scaling, how many show around the cursor, or just hide them all together.

<img width="1039" height="591" alt="Screenshot_20260331_185742" src="https://github.com/user-attachments/assets/419372dd-33ce-418e-9e3e-c852dff55365" />
<br><br>

Closes https://github.com/godotengine/godot-proposals/issues/6651.