### PR TITLE
Fix regression when parsing a shortened IPv6 Address

### DIFF
--- a/core/io/ip_address.cpp
+++ b/core/io/ip_address.cpp
@@ -135,8 +135,8 @@ bool IPAddress::_parse_ipv6(const String &p_string, IPAddress &r_ip) {
 		return cur == 8; // Should have parsed 8 16-bits ints.
 	} else if (shift > 7) {
 		return false; // Can't shorten more than this.
-	} else if (shift == cur) {
-		return true; // Nothing to do, end is assumed zeroized.
+	} else if (shift == cur || cur == 8) {
+		return true; // Nothing to do (fields are assumed zeroized).
 	}
 	// Shift bytes.
 	int pad = 8 - cur;
@@ -146,6 +146,7 @@ bool IPAddress::_parse_ipv6(const String &p_string, IPAddress &r_ip) {
 			r_ip.field16[i] = 0;
 		} else {
 			r_ip.field16[i] = r_ip.field16[i - pad];
+			r_ip.field16[i - pad] = 0;
 		}
 	}
 	return true;

--- a/tests/core/io/test_ip_address.cpp
+++ b/tests/core/io/test_ip_address.cpp
@@ -265,6 +265,11 @@ TEST_CASE("[IPAddress] IPv6 Parsing") {
 	CHECK(test_ip("1:1::", { 1, 1, 0, 0, 0, 0, 0, 0 }));
 	CHECK(test_ip("1::", { 1, 0, 0, 0, 0, 0, 0, 0 }));
 
+	CHECK(test_ip("1::1", { 1, 0, 0, 0, 0, 0, 0, 1 }));
+	CHECK(test_ip("1:1:1:1:1::1", { 1, 1, 1, 1, 1, 0, 0, 1 }));
+	CHECK(test_ip("1:1:1::1:1:1", { 1, 1, 1, 0, 0, 1, 1, 1 }));
+	CHECK(test_ip("1::1:1:1:1:1", { 1, 0, 0, 1, 1, 1, 1, 1 }));
+
 	CHECK(test_ip("ffff::", { 0xFFFF, 0, 0, 0, 0, 0, 0, 0 }));
 	CHECK(test_ip("::ffff", { 0, 0, 0, 0, 0, 0, 0, 0xFFFF }));
 	CHECK(test_ip("::fffe:0", { 0, 0, 0, 0, 0, 0, 0xFFFE, 0 }));


### PR DESCRIPTION
For shortened IPv6 addresses, bytes are shifted to their correct position as a last step. When copying the byte, the "old position" of the byte dosent get reset to 0 which results in a incorrectly parsed address.
`[14882, 4660, 26505, 4626, *12850*, 0, 0, 0] -> [14882, 4660, 26505, 4626, **12850**, 0, 0, *12850*]`
This PR fixes this

This PR also adds a few unit tests that check for this

closes https://github.com/godotengine/godot/issues/118050