### PR TITLE
Add debug warning for failed triangulation.

### DIFF
--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -326,6 +326,9 @@ void Polygon2D::_notification(int p_what) {
 
 			if (invert || polygons.is_empty()) {
 				index_array = Geometry2D::triangulate_polygon(points);
+				if (index_array.is_empty()) {
+					WARN_PRINT_ONCE_ED("Failed to triangulate polygon(s). Polygon data may be invalid, degenerate or self-intersecting.");
+				}
 			} else {
 				//draw individual polygons
 				for (int i = 0; i < polygons.size(); i++) {

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -327,7 +327,7 @@ void Polygon2D::_notification(int p_what) {
 			if (invert || polygons.is_empty()) {
 				index_array = Geometry2D::triangulate_polygon(points);
 				if (index_array.is_empty()) {
-					WARN_PRINT_ONCE_ED("Failed to triangulate polygon(s). Polygon data may be invalid, degenerate or self-intersecting.");
+					WARN_PRINT_ONCE_ED("Failed to triangulate polygon(s). Polygon data may be invalid, degenerate, or self-intersecting.");
 				}
 			} else {
 				//draw individual polygons


### PR DESCRIPTION
added warning message when failing triangulation in polygon2D, like in #117960 
Tested with the file provided in issue and also checking that no warning message is created in a separate scene with a random 2D polygon.
Used AI to ask specific questions about the surrounding code to get up to speed (mostly for personal learning and might be irrelevant to the actual line of code) as I am new to contributing to godot and contributing in general.

* *Bugsquad edit, fixes: #117960*
