### PR TITLE
Fix tutorial links for the GDExtension section for a move of the articles

### DIFF
--- a/doc/classes/GDExtension.xml
+++ b/doc/classes/GDExtension.xml
@@ -8,7 +8,7 @@
 		[b]Note:[/b] GDExtension itself is not a scripting language and has no relation to [GDScript] resources.
 	</description>
 	<tutorials>
-		<link title="GDExtension overview">$DOCS_URL/tutorials/scripting/gdextension/what_is_gdextension.html</link>
+		<link title="GDExtension overview">$DOCS_URL/engine_details/engine_api/gdextension/what_is_gdextension.html</link>
 		<link title="GDExtension example in C++">$DOCS_URL/tutorials/scripting/cpp/gdextension_cpp_example.html</link>
 	</tutorials>
 	<methods>

--- a/doc/classes/GDExtensionManager.xml
+++ b/doc/classes/GDExtensionManager.xml
@@ -8,7 +8,7 @@
 		[b]Note:[/b] Do not worry about GDExtension unless you know what you are doing.
 	</description>
 	<tutorials>
-		<link title="GDExtension overview">$DOCS_URL/tutorials/scripting/gdextension/what_is_gdextension.html</link>
+		<link title="GDExtension overview">$DOCS_URL/engine_details/engine_api/gdextension/what_is_gdextension.html</link>
 		<link title="GDExtension example in C++">$DOCS_URL/tutorials/scripting/cpp/gdextension_cpp_example.html</link>
 	</tutorials>
 	<methods>


### PR DESCRIPTION
- Companion to https://github.com/godotengine/godot-docs/pull/11652

Both should be merged at the same time.
