### PR TITLE
Add find all references to the script editor

### DIFF
--- a/doc/classes/ScriptEditorBase.xml
+++ b/doc/classes/ScriptEditorBase.xml
@@ -83,5 +83,14 @@
 				Emitted when the user request to search text in the file system.
 			</description>
 		</signal>
+		<signal name="search_references_in_files_requested">
+			<param index="0" name="text" type="String" />
+			<param index="1" name="origin_script_path" type="String" />
+			<param index="2" name="lookup_type" type="int" />
+			<param index="3" name="lookup_location" type="int" />
+			<description>
+				Emitted when the user requests to search all references in scripts.
+			</description>
+		</signal>
 	</signals>
 </class>

--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
+#include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
@@ -692,11 +693,6 @@ const char *FindInFilesPanel::SIGNAL_FILES_MODIFIED = "files_modified";
 const char *FindInFilesPanel::SIGNAL_CLOSE_BUTTON_CLICKED = "close_button_clicked";
 
 FindInFilesPanel::FindInFilesPanel() {
-	_finder = memnew(FindInFiles);
-	_finder->connect(FindInFiles::SIGNAL_RESULT_FOUND, callable_mp(this, &FindInFilesPanel::_on_result_found));
-	_finder->connect(SceneStringName(finished), callable_mp(this, &FindInFilesPanel::_on_finished));
-	add_child(_finder);
-
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	vbc->set_anchor_and_offset(SIDE_LEFT, ANCHOR_BEGIN, 0);
 	vbc->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, 0);
@@ -800,6 +796,13 @@ FindInFilesPanel::FindInFilesPanel() {
 
 		vbc->add_child(_replace_container);
 	}
+}
+
+void FindInFilesPanel::set_finder(FindInFiles *p_finder) {
+	_finder = p_finder;
+	_finder->connect(FindInFiles::SIGNAL_RESULT_FOUND, callable_mp(this, &FindInFilesPanel::_on_result_found));
+	_finder->connect(SceneStringName(finished), callable_mp(this, &FindInFilesPanel::_on_finished));
+	add_child(_finder);
 }
 
 void FindInFilesPanel::set_with_replace(bool with_replace) {
@@ -1321,6 +1324,8 @@ void FindInFilesPanel::_bind_methods() {
 
 //-----------------------------------------------------------------------------
 
+const char *FindInFilesContainer::FIND_ALL_REFERENCES_META = "find_all_references";
+
 FindInFilesContainer::FindInFilesContainer() {
 	set_name(TTRC("Search Results"));
 	set_icon_name("Search");
@@ -1353,9 +1358,13 @@ FindInFilesContainer::FindInFilesContainer() {
 	EditorNode::get_singleton()->get_gui_base()->connect(SceneStringName(theme_changed), callable_mp(this, &FindInFilesContainer::_on_theme_changed));
 }
 
-FindInFilesPanel *FindInFilesContainer::_create_new_panel() {
+FindInFilesPanel *FindInFilesContainer::_create_new_panel(bool p_for_references_search) {
 	int index = _tabs->get_current_tab();
 	FindInFilesPanel *panel = memnew(FindInFilesPanel);
+	panel->set_finder(_create_new_find_in_files(p_for_references_search));
+	if (p_for_references_search) {
+		panel->set_meta(FIND_ALL_REFERENCES_META, p_for_references_search);
+	}
 	_tabs->add_child(panel);
 	_tabs->move_child(panel, index + 1); // New panel is added after the current activated panel.
 	_tabs->set_current_tab(index + 1);
@@ -1367,20 +1376,41 @@ FindInFilesPanel *FindInFilesContainer::_create_new_panel() {
 	return panel;
 }
 
+FindInFiles *FindInFilesContainer::_create_new_find_in_files(bool p_for_references_search) {
+	if (p_for_references_search) {
+		return memnew(FindAllReferencesInFiles);
+	}
+
+	return memnew(FindInFiles);
+}
+
 FindInFilesPanel *FindInFilesContainer::_get_current_panel() {
 	return Object::cast_to<FindInFilesPanel>(_tabs->get_current_tab_control());
 }
 
-FindInFilesPanel *FindInFilesContainer::get_panel_for_results(const String &p_label) {
+bool FindInFilesContainer::_can_return_panel(const FindInFilesPanel *p_panel, bool p_for_references_search) {
+	if (!p_panel) {
+		return false;
+	}
+
+	if (p_panel->is_keep_results()) {
+		return false;
+	}
+
+	bool has_reference_finder = p_panel->has_meta(FIND_ALL_REFERENCES_META);
+	return has_reference_finder == p_for_references_search;
+}
+
+FindInFilesPanel *FindInFilesContainer::get_panel_for_results(const String &p_label, bool p_for_references_search) {
 	FindInFilesPanel *panel = nullptr;
 	// Prefer the current panel.
-	if (_get_current_panel() && !_get_current_panel()->is_keep_results()) {
+	if (_can_return_panel(_get_current_panel(), p_for_references_search)) {
 		panel = _get_current_panel();
 	} else {
 		// Find the first panel which does not keep results.
 		for (int i = 0; i < _tabs->get_tab_count(); i++) {
 			FindInFilesPanel *p = Object::cast_to<FindInFilesPanel>(_tabs->get_tab_control(i));
-			if (p && !p->is_keep_results()) {
+			if (_can_return_panel(p, p_for_references_search)) {
 				panel = p;
 				_tabs->set_current_tab(i);
 				break;
@@ -1388,7 +1418,7 @@ FindInFilesPanel *FindInFilesContainer::get_panel_for_results(const String &p_la
 		}
 
 		if (!panel) {
-			panel = _create_new_panel();
+			panel = _create_new_panel(p_for_references_search);
 		}
 	}
 	_tabs->set_tab_title(_tabs->get_current_tab(), p_label);
@@ -1532,4 +1562,86 @@ void FindInFilesContainer::_on_dock_closed() {
 		tab->queue_free();
 	}
 	_update_bar_visibility();
+}
+
+//-----------------------------------------------------------------------------
+
+void FindAllReferencesInFiles::_bind_methods() {
+	ADD_SIGNAL(MethodInfo(SIGNAL_RESULT_FOUND,
+			PropertyInfo(Variant::STRING, "path"),
+			PropertyInfo(Variant::INT, "line_number"),
+			PropertyInfo(Variant::INT, "begin"),
+			PropertyInfo(Variant::INT, "end"),
+			PropertyInfo(Variant::STRING, "text")));
+
+	ADD_SIGNAL(MethodInfo("finished"));
+}
+
+void FindAllReferencesInFiles::_scan_file(const String &p_fpath) {
+	if (!ResourceLoader::exists(p_fpath, "Script")) {
+		return;
+	}
+
+	Ref<Script> script = ResourceLoader::load(p_fpath);
+
+	if (!script.is_valid()) {
+		return;
+	}
+
+	PackedStringArray lines = script->get_source_code().split("\n");
+
+	for (int i = 0; i < lines.size(); i++) {
+		String current_line = lines[i];
+		// Line number starts at 1.
+		int line_number = i + 1;
+		int begin = 0;
+		int end = 0;
+		while (find_next(current_line, get_search_text(), end, is_match_case(), is_whole_words(), begin, end)) {
+			if (ScriptServer::is_global_class(get_search_text()) || _is_lookup_return_back(script, p_fpath, lines, line_number, begin)) {
+				emit_signal(SNAME(SIGNAL_RESULT_FOUND), p_fpath, line_number, begin, end, current_line);
+			}
+		}
+	}
+}
+
+void FindAllReferencesInFiles::initialize(const String &p_pattern, const String &p_origin_path, const int p_type, const int p_location) {
+	_origin_script_path = p_origin_path;
+
+	if (ResourceLoader::exists(p_origin_path)) {
+		_origin_script = ResourceLoader::load(p_origin_path);
+	}
+
+	_lookup_location = p_location;
+	_lookup_type = p_type;
+
+	set_search_text(p_pattern);
+	set_match_case(true);
+	set_whole_words(true);
+	set_folder("");
+	set_filter(HashSet<String>({ "gd" }));
+}
+
+static String _insert_cursor_char_to_text_line(const PackedStringArray &p_lines, int p_line, int p_column) {
+	PackedStringArray result;
+	result.append_array(p_lines);
+	result.write[p_line] = result[p_line].insert(p_column, String::chr(0xFFFF));
+	return String("\n").join(result);
+}
+
+bool FindAllReferencesInFiles::_is_lookup_return_back(Ref<Script> p_target, const String &p_path, const PackedStringArray &p_code_lines, const int p_row, const int p_column) {
+	ScriptLanguage::LookupResult result;
+	String code_text = _insert_cursor_char_to_text_line(p_code_lines, p_row - 1, p_column);
+	Error lc_error = p_target->get_language()->lookup_code(code_text, get_search_text(), p_target->get_path(), nullptr, result);
+
+	if (lc_error != OK || result.type != _lookup_type) {
+		return false;
+	}
+
+	bool is_same_script = p_path == _origin_script_path;
+	bool is_function_declaration = is_same_script && _lookup_location == p_row;
+	bool is_parent_script = !is_same_script && _origin_script->get_base_script() == p_target;
+	bool is_valid_return_path = result.script_path == _origin_script_path && result.location == _lookup_location;
+	bool is_success_return = is_valid_return_path || is_function_declaration || is_parent_script;
+
+	return is_success_return;
 }

--- a/editor/script/find_in_files.h
+++ b/editor/script/find_in_files.h
@@ -62,15 +62,15 @@ public:
 	float get_progress() const;
 
 protected:
-	void _notification(int p_what);
+	virtual void _scan_file(const String &p_fpath);
 
+	void _notification(int p_what);
 	static void _bind_methods();
 
 private:
 	void _process();
 	void _iterate();
 	void _scan_dir(const String &path, PackedStringArray &out_folders, PackedStringArray &out_files_to_scan);
-	void _scan_file(const String &fpath);
 
 	bool _is_file_matched(const HashSet<String> &p_wildcards, const String &p_file_path, bool p_case_sensitive) const;
 
@@ -89,6 +89,24 @@ private:
 	Vector<PackedStringArray> _folders_stack;
 	Vector<String> _files_to_scan;
 	int _initial_files_count = 0;
+};
+
+class FindAllReferencesInFiles : public FindInFiles {
+	GDCLASS(FindAllReferencesInFiles, Node);
+
+public:
+	void initialize(const String &p_pattern, const String &p_origin_path, const int p_type, const int p_location);
+
+protected:
+	Ref<Script> _origin_script;
+	String _origin_script_path;
+	int _lookup_type;
+	int _lookup_location;
+
+	virtual void _scan_file(const String &p_path) override;
+	bool _is_lookup_return_back(Ref<Script> p_target, const String &p_path, const PackedStringArray &p_code_lines, const int p_row, const int p_column);
+
+	static void _bind_methods();
 };
 
 class LineEdit;
@@ -177,6 +195,7 @@ public:
 
 	FindInFilesPanel();
 
+	void set_finder(FindInFiles *p_finder);
 	FindInFiles *get_finder() const { return _finder; }
 
 	void set_with_replace(bool with_replace);
@@ -261,6 +280,8 @@ class TabContainer;
 class FindInFilesContainer : public EditorDock {
 	GDCLASS(FindInFilesContainer, EditorDock);
 
+	static const char *FIND_ALL_REFERENCES_META;
+
 	enum {
 		PANEL_CLOSE,
 		PANEL_CLOSE_OTHERS,
@@ -279,8 +300,11 @@ class FindInFilesContainer : public EditorDock {
 	bool _update_bar = true;
 	PopupMenu *_tabs_context_menu = nullptr;
 
-	FindInFilesPanel *_create_new_panel();
+	FindInFilesPanel *_create_new_panel(bool p_for_references_search = false);
 	FindInFilesPanel *_get_current_panel();
+
+	FindInFiles *_create_new_find_in_files(bool p_for_references_search = false);
+	bool _can_return_panel(const FindInFilesPanel *p_panel, bool p_for_references_search = false);
 
 protected:
 	static void _bind_methods();
@@ -295,5 +319,5 @@ protected:
 public:
 	FindInFilesContainer();
 
-	FindInFilesPanel *get_panel_for_results(const String &p_label);
+	FindInFilesPanel *get_panel_for_results(const String &p_label, bool p_for_references_search = false);
 };

--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -48,6 +48,7 @@ void ScriptEditorBase::_bind_methods() {
 	// First use in TextEditorBase.
 	ADD_SIGNAL(MethodInfo("edited_script_changed"));
 	ADD_SIGNAL(MethodInfo("search_in_files_requested", PropertyInfo(Variant::STRING, "text")));
+	ADD_SIGNAL(MethodInfo("search_references_in_files_requested", PropertyInfo(Variant::STRING, "text"), PropertyInfo(Variant::STRING, "origin_script_path"), PropertyInfo(Variant::INT, "lookup_type"), PropertyInfo(Variant::INT, "lookup_location")));
 	ClassDB::bind_method(D_METHOD("add_syntax_highlighter", "highlighter"), &ScriptEditorBase::add_syntax_highlighter);
 	ClassDB::bind_method(D_METHOD("get_base_editor"), &ScriptEditorBase::get_base_editor);
 

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -2330,6 +2330,7 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 		teb->connect("request_save_history", callable_mp(this, &ScriptEditor::_save_history));
 		teb->connect("request_save_previous_state", callable_mp(this, &ScriptEditor::_save_previous_state));
 		teb->connect("search_in_files_requested", callable_mp(this, &ScriptEditor::open_find_in_files_dialog));
+		teb->connect("search_references_in_files_requested", callable_mp(this, &ScriptEditor::_start_find_all_references_in_files));
 		teb->connect("replace_in_files_requested", callable_mp(this, &ScriptEditor::_on_replace_in_files_requested));
 		teb->connect("go_to_method", callable_mp(this, &ScriptEditor::script_goto_method));
 
@@ -2579,6 +2580,22 @@ void ScriptEditor::_auto_format_text(ScriptEditorBase *p_seb) {
 			teb->convert_indent();
 		}
 	}
+}
+
+void ScriptEditor::_start_find_all_references_in_files(const String &p_text, const String &p_origin_script_path, const int p_lookup_type, const int p_lookup_location) {
+	FindInFilesPanel *panel = find_in_files->get_panel_for_results(TTR("Find All References:") + " " + p_text, true);
+	FindInFiles *f = panel->get_finder();
+	FindAllReferencesInFiles *ff = Object::cast_to<FindAllReferencesInFiles>(f);
+
+	if (!ff) {
+		return;
+	}
+
+	ff->initialize(p_text, p_origin_script_path, p_lookup_type, p_lookup_location);
+	panel->set_with_replace(false);
+
+	panel->start_search();
+	find_in_files->make_visible();
 }
 
 void ScriptEditor::open_find_in_files_dialog(const String &text) {

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -388,6 +388,8 @@ class ScriptEditor : public PanelContainer {
 	void _start_find_in_files(bool with_replace);
 	void _on_find_in_files_modified_files(const PackedStringArray &paths);
 
+	void _start_find_all_references_in_files(const String &p_text, const String &p_origin_script_path, const int p_lookup_type, const int p_lookup_location);
+
 	void _set_script_zoom_factor(float p_zoom_factor);
 	void _update_code_editor_zoom_factor(CodeTextEditor *p_code_text_editor);
 

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -193,6 +193,9 @@ ScriptTextEditor::EditMenusSTE::EditMenusSTE() {
 	edit_menu_convert_indent->add_shortcut(ED_GET_SHORTCUT("script_text_editor/auto_indent"), EDIT_AUTO_INDENT);
 
 	search_menu->get_popup()->add_separator();
+	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_all_references"), FIND_ALL_REFERENCES);
+
+	search_menu->get_popup()->add_separator();
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/show_tooltip"), SHOW_TOOLTIP_AT_CARET);
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/contextual_help"), HELP_CONTEXTUAL);
 
@@ -1846,6 +1849,40 @@ bool ScriptTextEditor::_edit_option(int p_op) {
 				_lookup_symbol(text, tx->get_caret_line(0), tx->get_caret_column(0));
 			}
 		} break;
+		case FIND_ALL_REFERENCES: {
+			String text = tx->get_word_under_caret(0);
+			if (text.is_empty()) {
+				text = tx->get_selected_text(0);
+			}
+			if (text.is_empty()) {
+				break;
+			}
+
+			Ref<Script> script = edited_res;
+
+			if (ScriptServer::is_global_class(text)) {
+				emit_signal(SNAME("search_references_in_files_requested"), text, script->get_path(), 0, 0);
+				break;
+			}
+
+			ScriptLanguage::LookupResult result;
+			String code_text = code_editor->get_text_editor()->get_text_with_cursor_char(tx->get_caret_line(0), tx->get_caret_column(0));
+			if (script->get_language()->lookup_code(code_text, text, script->get_path(), nullptr, result) != OK) {
+				break;
+			}
+
+			String origin_path = result.script_path;
+			int location = result.location;
+
+			String line = code_editor->get_text_editor()->get_line(tx->get_caret_line(0));
+			bool is_function_declaration = line.strip_edges().find("func") == 0;
+			if (is_function_declaration) {
+				origin_path = script->get_path();
+				location = tx->get_caret_line(0) + 1;
+			}
+
+			emit_signal(SNAME("search_references_in_files_requested"), text, origin_path, result.type, location);
+		} break;
 		default: {
 			if (TextEditorBase::_edit_option(p_op)) {
 				return true;
@@ -2592,6 +2629,10 @@ void ScriptTextEditor::_make_context_menu(bool p_selection, bool p_color, bool p
 		context_menu->add_separator();
 		if (p_open_docs) {
 			context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_symbol"), LOOKUP_SYMBOL);
+			context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_all_references"), FIND_ALL_REFERENCES);
+			_popup_move_item(EDIT_REDO, context_menu);
+			context_menu->add_separator();
+			_popup_move_item(EDIT_REDO, context_menu);
 		}
 		if (p_color) {
 			context_menu->add_item(TTRC("Pick Color"), EDIT_PICK_COLOR);
@@ -2672,6 +2713,8 @@ void ScriptTextEditor::register_editor() {
 	// Using Control for these shortcuts even on macOS because Command+Comma is taken for opening Editor Settings.
 	ED_SHORTCUT("script_text_editor/goto_next_breakpoint", TTRC("Go to Next Breakpoint"), KeyModifierMask::CTRL | Key::PERIOD);
 	ED_SHORTCUT("script_text_editor/goto_previous_breakpoint", TTRC("Go to Previous Breakpoint"), KeyModifierMask::CTRL | Key::COMMA);
+
+	ED_SHORTCUT("script_text_editor/find_all_references", TTRC("Find All References"), KeyModifierMask::SHIFT | KeyModifierMask::CTRL | Key::F12);
 
 	ScriptEditor::register_create_script_editor_function(create_editor);
 }

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -118,6 +118,7 @@ class ScriptTextEditor : public CodeEditorBase {
 		SHOW_TOOLTIP_AT_CARET,
 		HELP_CONTEXTUAL,
 		LOOKUP_SYMBOL,
+		FIND_ALL_REFERENCES,
 	};
 
 	enum COLOR_MODE {


### PR DESCRIPTION
- closes: https://github.com/godotengine/godot-proposals/issues/3126

## Examples

<img width="483" height="126" alt="menu-example" src="https://github.com/user-attachments/assets/9ccb227d-e588-49a9-9ad2-83619f1c1ce8" />


https://github.com/user-attachments/assets/8224f9ea-f0f6-44c6-b8db-70f9fcccfb60


https://github.com/user-attachments/assets/b0372960-1915-4ea1-ada2-e03d5ca56ad6

## How it works

At first, it search for all scripts containing the specified pattern, using logic from `Find in Files`. Then, it try trace back using `lookup_code` of the found pattern in script. If it's successfully, it's reference. There are some edge cases that had to be handled separately: local variables/constants and global class names.

And I'm not sure how search for overridden methods should work. 