### PR TITLE
Fix GDExtension ptrcall Ref<T> return refcount leak

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1343,9 +1343,32 @@ static void gdextension_object_method_bind_call(GDExtensionMethodBindPtr p_metho
 }
 
 static void gdextension_object_method_bind_ptrcall(GDExtensionMethodBindPtr p_method_bind, GDExtensionObjectPtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr p_ret) {
-	const MethodBind *mb = reinterpret_cast<const MethodBind *>(p_method_bind);
+	// Non-const cast needed because is_return_type_raw_object_ptr() lacks const qualifier.
+	MethodBind *mb = const_cast<MethodBind *>(reinterpret_cast<const MethodBind *>(p_method_bind));
 	Object *o = (Object *)p_instance;
+
+	// Methods returning Ref<T> use PtrToArg<Ref<T>>::encode which treats the
+	// return buffer as a Ref<T> and calls Ref::operator= — this increments the
+	// refcount. Internal C++ callers provide a proper Ref<T> on the stack whose
+	// destructor balances the increment. GDExtension callers provide a raw
+	// Object** buffer with no destructor, so the refcount is never decremented.
+	//
+	// Detect Ref<T> returns (OBJECT type + not raw_obj_ptr) and unreference
+	// after ptrcall to compensate. The GDExtension caller receives a borrowed
+	// pointer — it does not own an additional reference.
+	bool returns_ref = p_ret &&
+			mb->has_return() &&
+			mb->get_argument_type(-1) == Variant::OBJECT &&
+			!mb->is_return_type_raw_object_ptr();
+
 	mb->ptrcall(o, (const void **)p_args, p_ret);
+
+	if (returns_ref) {
+		RefCounted *rc = Object::cast_to<RefCounted>(*reinterpret_cast<Object **>(p_ret));
+		if (rc) {
+			rc->unreference();
+		}
+	}
 }
 
 static void gdextension_object_destroy(GDExtensionObjectPtr p_o) {


### PR DESCRIPTION
## Summary

GDExtension `object_method_bind_ptrcall` leaks one reference on every call to a method that returns `Ref<T>` (e.g. `get_mesh()`, `get_material()`, `get_texture()`, `get_shader()`). The leaked reference prevents the `RefCounted` object from ever being freed, causing RID leaks reported at shutdown.

This affects **all GDExtension bindings** that use ptrcall — godot-zig, godot-rust/gdext, godot-cpp, etc.

## Root Cause

`PtrToArg<Ref<T>>::encode` (in `core/variant/method_ptrcall.h:287`) treats the return buffer as a `Ref<T>` and assigns into it via `Ref<T>::operator=`, which calls `reference()` to increment the refcount.

- **Internal C++ callers** allocate a `Ref<T>` on the stack and pass its address. The `Ref<T>` destructor eventually calls `unreference()`, balancing the increment. ✅
- **GDExtension callers** provide a raw `Object**` buffer (8 bytes initialized to null) with no destructor. The `encode` writes into it, incrementing the refcount, but nothing ever decrements it. The GDExtension binding reads the raw `Object*` pointer and has no mechanism to know a `Ref<T>` was involved. ❌

Every ptrcall to a method returning `Ref<T>` permanently increments the refcount by 1.

## Fix

After `mb->ptrcall()`, detect `Ref<T>` returns (return type is `Variant::OBJECT` and `!is_return_type_raw_object_ptr()`) and call `unreference()` on the returned object to compensate. The GDExtension caller receives a borrowed pointer with the correct refcount — matching GDScript semantics.

## Reproduction

**Minimal reproduction using godot-zig** (same issue applies to any GDExtension binding using ptrcall):

1. Create a GDExtension `MeshInstance3D` subclass that:
   - Creates an `ArrayMesh` via `ArrayMesh::init()`
   - Adds a surface via `variantCall("add_surface_from_arrays", ...)`
   - Calls `setMesh()` via ptrcall
   - Calls `getMesh()` via ptrcall (this is the leak trigger)
2. Create multiple instances, `queue_free` them in cycles, then quit
3. Observe `ERROR: N RID allocations of type 'Mesh' were leaked at exit` and `ObjectDB instances leaked`

## Related Issues

- #73577 — RID leaks at exit with dynamic meshes (partially explained by this bug)
- #80140 — Mesh RID leaks on scene change
- #69910 — RID leak warnings at shutdown
- godot-rust/gdext#108 — `get_mesh()` ptrcall return leaks a reference (identified the symptom)

## Testing

- Verified zero RID leaks with the fix using both a minimal reproduction scene and a full tile rendering system (~3,452 dynamically created `ArrayMesh` instances with visual mode cycling)
- The fix only affects the GDExtension ptrcall path — internal C++ ptrcall semantics are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)