### PR TITLE
Add decal support to compatibility renderer

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3209,6 +3209,11 @@
 			The maximum number of uniforms that can be used by the global shader uniform buffer. Each item takes up one slot. In other words, a single uniform float and a uniform vec4 will take the same amount of space in the buffer.
 			[b]Note:[/b] When using the Compatibility renderer, most mobile devices (and all web exports) will be limited to a maximum size of 1024 due to hardware constraints.
 		</member>
+		<member name="rendering/limits/opengl/max_decals" type="int" setter="" getter="" default="64">
+			Max number of decals that can be rendered in a frame. This is further limited by hardware support. Setting this low will reduce memory usage, may decrease shader compile times, and may result in faster rendering on low-end, mobile, or web devices.
+			[b]Note:[/b] This setting is only effective when using the Compatibility rendering method, not Forward+ and Mobile.
+			[b]Note:[/b] Regardless of this setting's value, the number of decals on each surface is limited to 8.
+		</member>
 		<member name="rendering/limits/opengl/max_lights_per_object" type="int" setter="" getter="" default="8">
 			Max number of omnilights and spotlights renderable per object. At the default value of 8, this means that each surface can be affected by up to 8 omnilights and 8 spotlights. This is further limited by hardware support and [member rendering/limits/opengl/max_renderable_lights]. Setting this low will slightly reduce memory usage, may decrease shader compile times, and may result in faster rendering on low-end, mobile, or web devices.
 			[b]Note:[/b] This setting is only effective when using the Compatibility rendering method, not Forward+ and Mobile.

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -73,7 +73,7 @@ RenderGeometryInstance *RasterizerSceneGLES3::geometry_instance_create(RID p_bas
 }
 
 uint32_t RasterizerSceneGLES3::geometry_instance_get_pair_mask() {
-	return ((1 << RSE::INSTANCE_LIGHT) | (1 << RSE::INSTANCE_REFLECTION_PROBE));
+	return ((1 << RSE::INSTANCE_LIGHT) | (1 << RSE::INSTANCE_REFLECTION_PROBE) | (1 << RSE::INSTANCE_DECAL));
 }
 
 uint32_t RasterizerSceneGLES3::get_max_lights_total() {
@@ -132,6 +132,13 @@ void RasterizerSceneGLES3::GeometryInstanceGLES3::pair_reflection_probe_instance
 
 	for (uint32_t i = 0; i < p_reflection_probe_instance_count; i++) {
 		paired_reflection_probes.push_back(p_reflection_probe_instances[i]);
+	}
+}
+
+void RasterizerSceneGLES3::GeometryInstanceGLES3::pair_decal_instances(const RID *p_decal_instances, uint32_t p_decal_instance_count) {
+	decals_count = p_decal_instance_count < (uint32_t)MAX_DECAL_CULL ? p_decal_instance_count : (uint32_t)MAX_DECAL_CULL;
+	for (uint32_t i = 0; i < decals_count; i++) {
+		decals[i] = GLES3::TextureStorage::get_singleton()->decal_instance_get_decal_id(p_decal_instances[i]);
 	}
 }
 
@@ -2567,6 +2574,8 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	}
 	_render_shadows(&render_data, screen_size);
 
+	texture_storage->update_decal_buffer(p_decals, render_data.cam_transform);
+
 	_setup_lights(&render_data, true, render_data.directional_light_count, render_data.omni_light_count, render_data.spot_light_count, render_data.area_light_count, render_data.directional_shadow_count);
 	_setup_environment(&render_data, is_reflection_probe, screen_size, flip_y, clear_color, false);
 
@@ -3176,6 +3185,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 	GLES3::MeshStorage *mesh_storage = GLES3::MeshStorage::get_singleton();
 	GLES3::ParticlesStorage *particles_storage = GLES3::ParticlesStorage::get_singleton();
 	GLES3::MaterialStorage *material_storage = GLES3::MaterialStorage::get_singleton();
+	GLES3::Config *config = GLES3::Config::get_singleton();
 
 	GLuint prev_vertex_array_gl = 0;
 	GLuint prev_index_array_gl = 0;
@@ -3192,7 +3202,6 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 
 	if constexpr (p_pass_mode == PASS_MODE_COLOR || p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) {
 		GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
-		GLES3::Config *config = GLES3::Config::get_singleton();
 		glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 2);
 		GLuint texture_to_bind = texture_storage->get_texture(texture_storage->texture_gl_get_default(GLES3::DEFAULT_GL_TEXTURE_CUBEMAP_BLACK))->tex_id;
 		if (p_render_data->environment.is_valid()) {
@@ -3317,7 +3326,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 
 		if constexpr (p_pass_mode != PASS_MODE_SHADOW) {
 			if (shader->depth_draw == GLES3::SceneShaderData::DEPTH_DRAW_OPAQUE) {
-				scene_state.enable_gl_depth_draw((p_pass_mode == PASS_MODE_COLOR && !GLES3::Config::get_singleton()->use_depth_prepass) || p_pass_mode == PASS_MODE_DEPTH || p_pass_mode == PASS_MODE_MOTION_VECTORS);
+				scene_state.enable_gl_depth_draw((p_pass_mode == PASS_MODE_COLOR && !config->use_depth_prepass) || p_pass_mode == PASS_MODE_DEPTH || p_pass_mode == PASS_MODE_MOTION_VECTORS);
 			} else {
 				scene_state.enable_gl_depth_draw(shader->depth_draw == GLES3::SceneShaderData::DEPTH_DRAW_ALWAYS);
 			}
@@ -3582,6 +3591,14 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 							spec_constants |= SceneShaderGLES3::SECOND_REFLECTION_PROBE;
 						}
 
+						if (inst->decals_count > 0) {
+							spec_constants |= SceneShaderGLES3::USE_DECALS;
+
+							if (decals_filter == RSE::DECAL_FILTER_NEAREST_MIPMAPS || decals_filter == RSE::DECAL_FILTER_LINEAR_MIPMAPS || decals_filter == RSE::DECAL_FILTER_NEAREST_MIPMAPS_ANISOTROPIC || decals_filter == RSE::DECAL_FILTER_LINEAR_MIPMAPS_ANISOTROPIC) {
+								spec_constants |= SceneShaderGLES3::USE_DECAL_MIPMAPS;
+							}
+						}
+
 						if (inst->lightmap_instance.is_valid()) {
 							spec_constants |= SceneShaderGLES3::USE_LIGHTMAP;
 
@@ -3703,7 +3720,6 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 
 			// Pass in lighting uniforms.
 			if constexpr (p_pass_mode == PASS_MODE_COLOR || p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) {
-				GLES3::Config *config = GLES3::Config::get_singleton();
 				// Pass light and shadow index and bind shadow texture.
 				if (uses_additive_lighting) {
 					if (pass < int32_t(inst->light_passes.size())) {
@@ -3837,7 +3853,6 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 			// Pass in reflection probe data
 			if constexpr (p_pass_mode == PASS_MODE_COLOR || p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) {
 				if (pass == 0 && inst->reflection_probe_rid_cache.size() > 0) {
-					GLES3::Config *config = GLES3::Config::get_singleton();
 					GLES3::LightStorage *light_storage = GLES3::LightStorage::get_singleton();
 
 					// Setup first probe.
@@ -3879,6 +3894,40 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 
 						spec_constants |= SceneShaderGLES3::SECOND_REFLECTION_PROBE;
 					}
+				}
+
+				if (inst->decals_count > 0) {
+					GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
+					uint64_t current_frame = RSG::rasterizer->get_frame_number();
+					uint32_t decals[2] = { 0xFFFFFFFF, 0xFFFFFFFF };
+
+					uint32_t idx = 0;
+					for (uint32_t d = 0; d < inst->decals_count; d++) {
+						uint32_t ofs = idx < 4 ? 0 : 1;
+						uint32_t shift = (idx & 0x3) << 3;
+						uint32_t mask = ~(0xFF << shift);
+						if (texture_storage->get_decal_last_pass(inst->decals[d]) == current_frame) {
+							decals[ofs] &= mask;
+							decals[ofs] |= uint32_t(texture_storage->get_decal_map(inst->decals[d])) << shift;
+							idx++;
+						}
+					}
+
+					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::DECAL_COUNT, inst->decals_count, shader->version, instance_variant, spec_constants);
+					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::DECALS0, decals[0], shader->version, instance_variant, spec_constants);
+					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::DECALS1, decals[1], shader->version, instance_variant, spec_constants);
+
+					GLuint decal_atlas = texture_storage->decal_atlas_get_texture();
+					if (decal_atlas == 0) {
+						GLES3::Texture *tex = texture_storage->get_texture(texture_storage->texture_gl_get_default(GLES3::DEFAULT_GL_TEXTURE_WHITE));
+						decal_atlas = tex->tex_id;
+					}
+					glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 12);
+					glBindTexture(GL_TEXTURE_2D, decal_atlas);
+					texture_storage->decal_atlas_set_filter(decals_filter);
+
+					// Shouldn't this already be set up above??
+					spec_constants |= SceneShaderGLES3::USE_DECALS;
 				}
 			}
 
@@ -4518,6 +4567,7 @@ void RasterizerSceneGLES3::sdfgi_set_debug_probe_select(const Vector3 &p_positio
 }
 
 void RasterizerSceneGLES3::decals_set_filter(RSE::DecalFilter p_filter) {
+	decals_filter = p_filter;
 }
 
 void RasterizerSceneGLES3::light_projectors_set_filter(RSE::LightProjectorFilter p_filter) {
@@ -4545,6 +4595,11 @@ RasterizerSceneGLES3::RasterizerSceneGLES3() {
 	positional_soft_shadow_filter_set_quality((RSE::ShadowQuality)(int)GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/soft_shadow_filter_quality"));
 	directional_soft_shadow_filter_set_quality((RSE::ShadowQuality)(int)GLOBAL_GET("rendering/lights_and_shadows/directional_shadow/soft_shadow_filter_quality"));
 	lightmaps_set_bicubic_filter(GLOBAL_GET("rendering/lightmapping/lightmap_gi/use_bicubic_filter"));
+
+	{ //decals
+		config->max_decals = MIN(config->max_decals, config->max_uniform_buffer_size / (int)sizeof(GLES3::DecalData));
+		GLES3::TextureStorage::get_singleton()->set_max_decals(config->max_decals);
+	}
 
 	{
 		// Setup Lights
@@ -4612,6 +4667,8 @@ RasterizerSceneGLES3::RasterizerSceneGLES3() {
 		global_defines += "\n#define MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS " + itos(MAX_DIRECTIONAL_LIGHTS) + "\n";
 		global_defines += "\n#define MAX_FORWARD_LIGHTS " + itos(config->max_lights_per_object) + "u\n";
 		global_defines += "\n#define MAX_ROUGHNESS_LOD " + itos(sky_globals.roughness_layers - 1) + ".0\n";
+		global_defines += "\n#define MAX_DECALS " + itos(config->max_decals) + "\n";
+
 		if (config->force_vertex_shading) {
 			global_defines += "\n#define USE_VERTEX_LIGHTING\n";
 		}

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -77,6 +77,7 @@ enum SceneUniformLocation {
 	SCENE_EMPTY2, // Unused, put here to avoid conflicts with SKY_MULTIVIEW_UNIFORM_LOCATION.
 	SCENE_PREV_DATA_UNIFORM_LOCATION,
 	SCENE_PREV_MULTIVIEW_UNIFORM_LOCATION,
+	SCENE_DECAL_DATA,
 };
 
 enum SkyUniformLocation {
@@ -95,6 +96,7 @@ enum SkyUniformLocation {
 	SKY_MULTIVIEW_UNIFORM_LOCATION,
 	SKY_EMPTY9, // Unused, put here to avoid conflicts with SCENE_PREV_DATA_UNIFORM_LOCATION.
 	SKY_EMPTY10, // Unused, put here to avoid conflicts with SCENE_PREV_MULTIVIEW_UNIFORM_LOCATION.
+	SKY_EMPTY11, // Unused, put here to avoid conflicts with SCENE_DECAL_DATA.
 };
 
 struct RenderDataGLES3 {
@@ -345,6 +347,9 @@ private:
 		LocalVector<RID> reflection_probe_rid_cache;
 		LocalVector<Transform3D> reflection_probes_local_transform_cache;
 
+		uint32_t decals_count = 0;
+		int32_t decals[MAX_DECAL_CULL];
+
 		RID lightmap_instance;
 		Rect2 lightmap_uv_scale;
 		uint32_t lightmap_slice_index;
@@ -364,7 +369,7 @@ private:
 		virtual void clear_light_instances() override;
 		virtual void pair_light_instance(const RID p_light_instance, RSE::LightType light_type, uint32_t placement_idx) override;
 		virtual void pair_reflection_probe_instances(const RID *p_reflection_probe_instances, uint32_t p_reflection_probe_instance_count) override;
-		virtual void pair_decal_instances(const RID *p_decal_instances, uint32_t p_decal_instance_count) override {}
+		virtual void pair_decal_instances(const RID *p_decal_instances, uint32_t p_decal_instance_count) override;
 		virtual void pair_voxel_gi_instances(const RID *p_voxel_gi_instances, uint32_t p_voxel_gi_instance_count) override {}
 
 		virtual void set_softshadow_projector_pairing(bool p_softshadow, bool p_projector) override {}
@@ -738,6 +743,8 @@ private:
 	};
 
 	RenderList render_list[RENDER_LIST_MAX];
+
+	RSE::DecalFilter decals_filter = RSE::DECAL_FILTER_LINEAR_MIPMAPS;
 
 	void _update_scene_ubo(GLuint &p_ubo_buffer, GLuint p_index, uint32_t p_size, const void *p_source_data, String p_name = "");
 

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -22,6 +22,8 @@ USE_LIGHTMAP = false
 USE_SH_LIGHTMAP = false
 USE_LIGHTMAP_CAPTURE = false
 USE_MULTIVIEW = false
+USE_DECALS = false
+USE_DECAL_MIPMAPS = false
 RENDER_SHADOWS = false
 RENDER_SHADOWS_LINEAR = false
 SHADOW_MODE_PCF_5 = false
@@ -1036,6 +1038,7 @@ void main() {
 9-reflection probe 2
 10-area light LUT 1
 11-area light LUT 2
+12-decal texture atlas
 
 */
 
@@ -1148,6 +1151,38 @@ uniform samplerCube refprobe2_texture; // texunit:-9
 #endif // SECOND_REFLECTION_PROBE
 
 #endif // DISABLE_REFLECTION_PROBE
+
+#ifdef USE_DECALS
+uniform sampler2D decal_atlas; // texunit:-12
+
+uniform uint decal_count;
+uniform uint decals0;
+uniform uint decals1;
+
+struct DecalData {
+	mat4 xform; //to decal transform
+	vec3 inv_extents;
+	float albedo_mix;
+	vec4 albedo_rect;
+	vec4 normal_rect;
+	vec4 orm_rect;
+	vec4 emission_rect;
+	vec4 modulate;
+	float emission_energy;
+	uint mask;
+	float upper_fade;
+	float lower_fade;
+	mat3x4 normal_xform;
+	vec3 normal;
+	float normal_fade;
+};
+
+layout(std140) uniform DecalDataBlock { // ubo:15
+	DecalData data[MAX_DECALS];
+}
+decal_data_block;
+
+#endif // USE_DECALS
 
 layout(std140) uniform GlobalShaderUniformData { //ubo:1
 	vec4 global_shader_uniforms[MAX_GLOBAL_SHADER_UNIFORMS];
@@ -2397,6 +2432,84 @@ void main() {
 	// Convert colors to linear
 	albedo = srgb_to_linear(albedo);
 	emission = srgb_to_linear(emission);
+
+#ifdef USE_DECALS
+
+	vec3 vertex_ddx = dFdx(vertex);
+	vec3 vertex_ddy = dFdy(vertex);
+
+	for (uint i = 0u; i < decal_count; i++) {
+		uint decal_index = (i > 3u) ? ((decals1 >> ((i - 4u) * 8u)) & uint(0xFF)) : ((decals0 >> (i * 8u)) & uint(0xFF));
+		if (decal_index == uint(0xFF)) {
+			break;
+		}
+
+		vec3 uv_local = (decal_data_block.data[decal_index].xform * vec4(vertex, 1.0)).xyz;
+		if (any(lessThan(uv_local, vec3(0.0, -1.0, 0.0))) || any(greaterThan(uv_local, vec3(1.0)))) {
+			continue; //out of decal
+		}
+
+		float fade = pow(1.0 - (uv_local.y > 0.0 ? uv_local.y : -uv_local.y), uv_local.y > 0.0 ? decal_data_block.data[decal_index].upper_fade : decal_data_block.data[decal_index].lower_fade);
+
+		if (decal_data_block.data[decal_index].normal_fade > 0.0) {
+			fade *= smoothstep(decal_data_block.data[decal_index].normal_fade, 1.0, dot(vec3(geo_normal), decal_data_block.data[decal_index].normal) * 0.5 + 0.5);
+		}
+
+		//we need ddx/ddy for mipmaps, so simulate them
+		vec2 ddx = (decal_data_block.data[decal_index].xform * vec4(vertex_ddx, 0.0)).xz;
+		vec2 ddy = (decal_data_block.data[decal_index].xform * vec4(vertex_ddy, 0.0)).xz;
+
+		if (decal_data_block.data[decal_index].albedo_rect != vec4(0.0)) {
+			//has albedo
+			vec4 decal_albedo;
+#ifdef USE_DECAL_MIPMAPS
+			decal_albedo = textureGrad(decal_atlas, uv_local.xz * decal_data_block.data[decal_index].albedo_rect.zw + decal_data_block.data[decal_index].albedo_rect.xy, ddx * decal_data_block.data[decal_index].albedo_rect.zw, ddy * decal_data_block.data[decal_index].albedo_rect.zw);
+#else
+			decal_albedo = textureLod(decal_atlas, uv_local.xz * decal_data_block.data[decal_index].albedo_rect.zw + decal_data_block.data[decal_index].albedo_rect.xy, 0.0);
+#endif // USE_DECAL_MIPMAPS
+			decal_albedo.rgb = srgb_to_linear(decal_albedo.rgb) * decal_data_block.data[decal_index].modulate.rgb;
+			decal_albedo.a *= fade * decal_data_block.data[decal_index].modulate.a;
+			albedo = vec3(mix(vec3(albedo), decal_albedo.rgb, decal_albedo.a * decal_data_block.data[decal_index].albedo_mix));
+
+			if (decal_data_block.data[decal_index].normal_rect != vec4(0.0)) {
+				vec3 decal_normal;
+#ifdef USE_DECAL_MIPMAPS
+				decal_normal = textureGrad(decal_atlas, uv_local.xz * decal_data_block.data[decal_index].normal_rect.zw + decal_data_block.data[decal_index].normal_rect.xy, ddx * decal_data_block.data[decal_index].normal_rect.zw, ddy * decal_data_block.data[decal_index].normal_rect.zw).xyz;
+#else
+				decal_normal = textureLod(decal_atlas, uv_local.xz * decal_data_block.data[decal_index].normal_rect.zw + decal_data_block.data[decal_index].normal_rect.xy, 0.0).xyz;
+#endif // USE_DECAL_MIPMAPS
+				decal_normal.xy = decal_normal.xy * vec2(2.0, -2.0) - vec2(1.0, -1.0); //users prefer flipped y normal maps in most authoring software
+				decal_normal.z = sqrt(max(0.0, 1.0 - dot(decal_normal.xy, decal_normal.xy)));
+				//convert to view space, use xzy because y is up
+				decal_normal = (mat3(decal_data_block.data[decal_index].normal_xform) * decal_normal.xzy).xyz;
+
+				normal = vec3(normalize(mix(vec3(normal), decal_normal, decal_albedo.a)));
+			}
+
+			if (decal_data_block.data[decal_index].orm_rect != vec4(0.0)) {
+				vec3 decal_orm;
+#ifdef USE_DECAL_MIPMAPS
+				decal_orm = textureGrad(decal_atlas, uv_local.xz * decal_data_block.data[decal_index].orm_rect.zw + decal_data_block.data[decal_index].orm_rect.xy, ddx * decal_data_block.data[decal_index].orm_rect.zw, ddy * decal_data_block.data[decal_index].orm_rect.zw).xyz;
+#else
+				decal_orm = textureLod(decal_atlas, uv_local.xz * decal_data_block.data[decal_index].orm_rect.zw + decal_data_block.data[decal_index].orm_rect.xy, 0.0).xyz;
+#endif // USE_DECAL_MIPMAPS
+				ao = mix(float(ao), decal_orm.r, decal_albedo.a);
+				roughness = mix(float(roughness), decal_orm.g, decal_albedo.a);
+				metallic = mix(float(metallic), decal_orm.b, decal_albedo.a);
+			}
+		}
+
+		if (decal_data_block.data[decal_index].emission_rect != vec4(0.0)) {
+			//emission is additive, so its independent from albedo
+#ifdef USE_DECAL_MIPMAPS
+			emission += srgb_to_linear(textureGrad(decal_atlas, uv_local.xz * decal_data_block.data[decal_index].emission_rect.zw + decal_data_block.data[decal_index].emission_rect.xy, ddx * decal_data_block.data[decal_index].emission_rect.zw, ddy * decal_data_block.data[decal_index].emission_rect.zw).xyz) * decal_data_block.data[decal_index].modulate.rgb * decal_data_block.data[decal_index].emission_energy * fade;
+#else
+			emission += srgb_to_linear(textureLod(decal_atlas, uv_local.xz * decal_data_block.data[decal_index].emission_rect.zw + decal_data_block.data[decal_index].emission_rect.xy, 0.0).xyz) * decal_data_block.data[decal_index].modulate.rgb * decal_data_block.data[decal_index].emission_energy * fade;
+#endif // USE_DECAL_MIPMAPS
+		}
+	}
+#endif //!USE_DECALS
+
 	// TODO Backlight and transmittance when used
 #ifndef MODE_UNSHADED
 	vec3 f0 = F0(metallic, specular, albedo);

--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -217,6 +217,7 @@ Config::Config() {
 	}
 
 	max_renderable_elements = GLOBAL_GET("rendering/limits/opengl/max_renderable_elements");
+	max_decals = GLOBAL_GET("rendering/limits/opengl/max_decals");
 	max_renderable_lights = GLOBAL_GET("rendering/limits/opengl/max_renderable_lights");
 	max_lights_per_object = GLOBAL_GET("rendering/limits/opengl/max_lights_per_object");
 

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -65,6 +65,7 @@ public:
 	GLint64 max_uniform_buffer_size = 0;
 	uint32_t max_shader_varyings = 0;
 
+	int64_t max_decals = 64;
 	int64_t max_renderable_elements = 0;
 	int64_t max_renderable_lights = 0;
 	int64_t max_lights_per_object = 0;

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -292,16 +292,27 @@ TextureStorage::TextureStorage() {
 }
 
 TextureStorage::~TextureStorage() {
+	free_decal_data();
+
 	singleton = nullptr;
 	for (int i = 0; i < DEFAULT_GL_TEXTURE_MAX; i++) {
 		texture_free(default_gl_textures[i]);
 	}
+
 	if (texture_atlas.texture != 0) {
 		GLES3::Utilities::get_singleton()->texture_free_data(texture_atlas.texture);
 	}
 	texture_atlas.texture = 0;
 	glDeleteFramebuffers(1, &texture_atlas.framebuffer);
 	texture_atlas.framebuffer = 0;
+
+	if (decal_atlas.texture != 0) {
+		GLES3::Utilities::get_singleton()->texture_free_data(decal_atlas.texture);
+	}
+	decal_atlas.texture = 0;
+	glDeleteFramebuffers(1, &decal_atlas.framebuffer);
+	decal_atlas.framebuffer = 0;
+
 	sdf_shader.shader.version_free(sdf_shader.shader_version);
 }
 
@@ -1041,7 +1052,9 @@ void TextureStorage::texture_free(RID p_texture) {
 		t->tex_id = 0;
 	}
 
+	// Remove from any atlas these are in.
 	texture_atlas_remove_texture(p_texture);
+	decal_atlas_remove_texture(p_texture);
 
 	for (uint32_t i = 0; i < t->proxies.size(); i++) {
 		Texture *p = texture_owner.get_or_null(t->proxies[i]);
@@ -1878,7 +1891,9 @@ void TextureStorage::texture_replace(RID p_texture, RID p_by_texture) {
 	//delete last, so proxies can be updated
 	texture_owner.free(p_by_texture);
 
+	// Mark any atlas that has this texture in it as dirty.
 	texture_atlas_mark_dirty_on_texture(p_texture);
+	decal_atlas_mark_dirty_on_texture(p_texture);
 }
 
 void TextureStorage::texture_set_size_override(RID p_texture, int p_width, int p_height) {
@@ -2468,7 +2483,12 @@ void TextureStorage::update_texture_atlas() {
 	}
 
 	{ // Atlas Texture initialize.
-		// TODO validate texture atlas size with maximum texture size
+		Config *config = Config::get_singleton();
+		ERR_FAIL_NULL(config);
+
+		// Validate texture atlas size with maximum texture size
+		ERR_FAIL_COND_MSG(texture_atlas.size.width >= config->max_texture_size || texture_atlas.size.height >= config->max_texture_size, "Texture atlas texture size (" + itos(texture_atlas.size.width) + ", " + itos(texture_atlas.size.height) + " exceeds (" + itos(config->max_texture_size) + ", " + itos(config->max_texture_size) + ")");
+
 		glGenTextures(1, &texture_atlas.texture);
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, texture_atlas.texture);
@@ -2519,41 +2539,673 @@ void TextureStorage::update_texture_atlas() {
 /* DECAL API */
 
 RID TextureStorage::decal_allocate() {
-	return RID();
+	return decal_owner.allocate_rid();
 }
 
-void TextureStorage::decal_initialize(RID p_rid) {
+void TextureStorage::decal_initialize(RID p_decal) {
+	decal_owner.initialize_rid(p_decal, Decal());
+}
+
+void TextureStorage::decal_free(RID p_decal) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	for (int i = 0; i < RSE::DECAL_TEXTURE_MAX; i++) {
+		if (decal->textures[i].is_valid() && owns_texture(decal->textures[i])) {
+			texture_remove_from_decal_atlas(decal->textures[i]);
+		}
+	}
+	decal->dependency.deleted_notify(p_decal);
+	decal_owner.free(p_decal);
 }
 
 void TextureStorage::decal_set_size(RID p_decal, const Vector3 &p_size) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->size = p_size;
+	decal->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_AABB);
 }
 
 void TextureStorage::decal_set_texture(RID p_decal, RSE::DecalTexture p_type, RID p_texture) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	ERR_FAIL_INDEX(p_type, RSE::DECAL_TEXTURE_MAX);
+
+	if (decal->textures[p_type] == p_texture) {
+		return;
+	}
+
+	ERR_FAIL_COND(p_texture.is_valid() && !owns_texture(p_texture));
+
+	if (decal->textures[p_type].is_valid() && owns_texture(decal->textures[p_type])) {
+		texture_remove_from_decal_atlas(decal->textures[p_type]);
+	}
+
+	decal->textures[p_type] = p_texture;
+
+	if (decal->textures[p_type].is_valid()) {
+		texture_add_to_decal_atlas(decal->textures[p_type]);
+	}
+
+	decal->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_DECAL);
 }
 
 void TextureStorage::decal_set_emission_energy(RID p_decal, float p_energy) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->emission_energy = p_energy;
 }
 
 void TextureStorage::decal_set_albedo_mix(RID p_decal, float p_mix) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->albedo_mix = p_mix;
 }
 
 void TextureStorage::decal_set_modulate(RID p_decal, const Color &p_modulate) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->modulate = p_modulate;
 }
 
 void TextureStorage::decal_set_cull_mask(RID p_decal, uint32_t p_layers) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->cull_mask = p_layers;
+	decal->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_CULL_MASK);
 }
 
 void TextureStorage::decal_set_distance_fade(RID p_decal, bool p_enabled, float p_begin, float p_length) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->distance_fade = p_enabled;
+	decal->distance_fade_begin = p_begin;
+	decal->distance_fade_length = p_length;
 }
 
 void TextureStorage::decal_set_fade(RID p_decal, float p_above, float p_below) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->upper_fade = p_above;
+	decal->lower_fade = p_below;
 }
 
 void TextureStorage::decal_set_normal_fade(RID p_decal, float p_fade) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->normal_fade = p_fade;
 }
 
 AABB TextureStorage::decal_get_aabb(RID p_decal) const {
-	return AABB();
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL_V(decal, AABB());
+
+	return AABB(-decal->size / 2, decal->size);
+}
+
+uint32_t TextureStorage::decal_get_cull_mask(RID p_decal) const {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL_V(decal, 0);
+
+	return decal->cull_mask;
+}
+
+Dependency *TextureStorage::decal_get_dependency(RID p_decal) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL_V(decal, nullptr);
+
+	return &decal->dependency;
+}
+
+void TextureStorage::update_decal_atlas() {
+	CopyEffects *copy_effects = CopyEffects::get_singleton();
+	ERR_FAIL_NULL(copy_effects);
+
+	if (!decal_atlas.dirty) {
+		return; //nothing to do
+	}
+
+	decal_atlas.dirty = false;
+
+	if (decal_atlas.texture != 0) {
+		GLES3::Utilities::get_singleton()->texture_free_data(decal_atlas.texture);
+		decal_atlas.texture = 0;
+		glDeleteFramebuffers(1, &decal_atlas.framebuffer);
+		decal_atlas.framebuffer = 0;
+	}
+
+	int border = 1 << decal_atlas.mipmaps;
+
+	if (decal_atlas.textures.size()) {
+		//generate atlas
+		Vector<DecalAtlas::SortItem> itemsv;
+		itemsv.resize(decal_atlas.textures.size());
+		uint32_t base_size = 8;
+
+		int idx = 0;
+
+		for (const KeyValue<RID, DecalAtlas::Texture> &E : decal_atlas.textures) {
+			DecalAtlas::SortItem &si = itemsv.write[idx];
+
+			Texture *src_tex = get_texture(E.key);
+
+			si.size.width = (src_tex->width / border) + 1;
+			si.size.height = (src_tex->height / border) + 1;
+			si.pixel_size = Size2i(src_tex->width, src_tex->height);
+
+			if (base_size < (uint32_t)si.size.width) {
+				base_size = Math::nearest_power_of_2_templated(si.size.width);
+			}
+
+			si.texture = E.key;
+			idx++;
+		}
+
+		//sort items by size
+		itemsv.sort();
+
+		//attempt to create atlas
+		int item_count = itemsv.size();
+		DecalAtlas::SortItem *items = itemsv.ptrw();
+
+		int atlas_height = 0;
+
+		while (true) {
+			Vector<int> v_offsetsv;
+			v_offsetsv.resize(base_size);
+
+			int *v_offsets = v_offsetsv.ptrw();
+			memset(v_offsets, 0, sizeof(int) * base_size);
+
+			int max_height = 0;
+
+			for (int i = 0; i < item_count; i++) {
+				//best fit
+				DecalAtlas::SortItem &si = items[i];
+				int best_idx = -1;
+				int best_height = 0x7FFFFFFF;
+				for (uint32_t j = 0; j <= base_size - si.size.width; j++) {
+					int height = 0;
+					for (int k = 0; k < si.size.width; k++) {
+						int h = v_offsets[k + j];
+						if (h > height) {
+							height = h;
+							if (height > best_height) {
+								break; //already bad
+							}
+						}
+					}
+
+					if (height < best_height) {
+						best_height = height;
+						best_idx = j;
+					}
+				}
+
+				//update
+				for (int k = 0; k < si.size.width; k++) {
+					v_offsets[k + best_idx] = best_height + si.size.height;
+				}
+
+				si.pos.x = best_idx;
+				si.pos.y = best_height;
+
+				if (si.pos.y + si.size.height > max_height) {
+					max_height = si.pos.y + si.size.height;
+				}
+			}
+
+			if ((uint32_t)max_height <= base_size * 2) {
+				atlas_height = max_height;
+				break; //good ratio, break;
+			}
+
+			base_size *= 2;
+		}
+
+		decal_atlas.size.width = base_size * border;
+		decal_atlas.size.height = Math::nearest_power_of_2_templated(atlas_height * border);
+
+		for (int i = 0; i < item_count; i++) {
+			DecalAtlas::Texture *t = decal_atlas.textures.getptr(items[i].texture);
+			t->uv_rect.position = items[i].pos * border + Vector2i(border / 2, border / 2);
+			t->uv_rect.size = items[i].pixel_size;
+
+			t->uv_rect.position /= Size2(decal_atlas.size);
+			t->uv_rect.size /= Size2(decal_atlas.size);
+		}
+	} else {
+		decal_atlas.size.width = 4;
+		decal_atlas.size.height = 4;
+	}
+
+	{ // Atlas Texture initialize.
+		Config *config = Config::get_singleton();
+		ERR_FAIL_NULL(config);
+
+		// Validate texture atlas size with maximum texture size
+		ERR_FAIL_COND_MSG(decal_atlas.size.width >= config->max_texture_size || decal_atlas.size.height >= config->max_texture_size, "Decal atlas texture size (" + itos(decal_atlas.size.width) + ", " + itos(decal_atlas.size.height) + " exceeds (" + itos(config->max_texture_size) + ", " + itos(config->max_texture_size) + ")");
+
+		glGenTextures(1, &decal_atlas.texture);
+		glActiveTexture(GL_TEXTURE0);
+		glBindTexture(GL_TEXTURE_2D, decal_atlas.texture);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, decal_atlas.size.width, decal_atlas.size.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+		GLES3::Utilities::get_singleton()->texture_allocated_data(decal_atlas.texture, decal_atlas.size.width * decal_atlas.size.height * 4, "Decal atlas");
+
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+		glGenFramebuffers(1, &decal_atlas.framebuffer);
+		glBindFramebuffer(GL_FRAMEBUFFER, decal_atlas.framebuffer);
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, decal_atlas.texture, 0);
+
+		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+
+		if (status != GL_FRAMEBUFFER_COMPLETE) {
+			glDeleteFramebuffers(1, &decal_atlas.framebuffer);
+			decal_atlas.framebuffer = 0;
+			GLES3::Utilities::get_singleton()->texture_free_data(decal_atlas.texture);
+			decal_atlas.texture = 0;
+			WARN_PRINT("Could not create decal atlas, status: " + get_framebuffer_error(status));
+			return;
+		}
+		glViewport(0, 0, decal_atlas.size.width, decal_atlas.size.height);
+		glClearColor(0.0, 0.0, 0.0, 0.0);
+		glClear(GL_COLOR_BUFFER_BIT);
+		glBindTexture(GL_TEXTURE_2D, 0);
+	}
+
+	glDisable(GL_BLEND);
+
+	if (decal_atlas.textures.size()) {
+		for (const KeyValue<RID, DecalAtlas::Texture> &E : decal_atlas.textures) {
+			DecalAtlas::Texture *t = decal_atlas.textures.getptr(E.key);
+			Texture *src_tex = get_texture(E.key);
+			glActiveTexture(GL_TEXTURE0);
+			glBindTexture(GL_TEXTURE_2D, src_tex->tex_id);
+			copy_effects->copy_to_rect(t->uv_rect);
+		}
+	}
+	glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
+
+	glBindTexture(GL_TEXTURE_2D, decal_atlas.texture);
+	glGenerateMipmap(GL_TEXTURE_2D);
+	decal_atlas_set_filter(decal_atlas.filter_state, true);
+	glBindTexture(GL_TEXTURE_2D, 0);
+}
+
+void TextureStorage::decal_atlas_set_filter(RSE::DecalFilter p_filter, bool p_force) {
+	Config *config = Config::get_singleton();
+
+	if (decal_atlas.filter_state == p_filter && !p_force) {
+		// We're good.
+		return;
+	}
+	decal_atlas.filter_state = p_filter;
+
+	if (decal_atlas.texture == 0) {
+		// Not yet created, we will apply the correct filter after we've created our texture.
+		return;
+	}
+
+	GLenum pmin = GL_NEAREST;
+	GLenum pmag = GL_NEAREST;
+	GLint max_lod = 0;
+	GLfloat anisotropy = 1.0f;
+
+	switch (decal_atlas.filter_state) {
+		case RSE::DECAL_FILTER_NEAREST: {
+			pmin = GL_NEAREST;
+			pmag = GL_NEAREST;
+			max_lod = 0;
+		} break;
+		case RSE::DECAL_FILTER_LINEAR: {
+			pmin = GL_LINEAR;
+			pmag = GL_LINEAR;
+			max_lod = 0;
+		} break;
+		case RSE::DECAL_FILTER_NEAREST_MIPMAPS_ANISOTROPIC: {
+			anisotropy = config->anisotropic_level;
+		};
+			[[fallthrough]];
+		case RSE::DECAL_FILTER_NEAREST_MIPMAPS: {
+			pmag = GL_NEAREST;
+			if (decal_atlas.mipmaps <= 1) {
+				pmin = GL_NEAREST;
+				max_lod = 0;
+			} else if (config->use_nearest_mip_filter) {
+				pmin = GL_NEAREST_MIPMAP_NEAREST;
+				max_lod = decal_atlas.mipmaps - 1;
+			} else {
+				pmin = GL_NEAREST_MIPMAP_LINEAR;
+				max_lod = decal_atlas.mipmaps - 1;
+			}
+		} break;
+		case RSE::DECAL_FILTER_LINEAR_MIPMAPS_ANISOTROPIC: {
+			anisotropy = config->anisotropic_level;
+		};
+			[[fallthrough]];
+		case RSE::DECAL_FILTER_LINEAR_MIPMAPS: {
+			pmag = GL_LINEAR;
+			if (decal_atlas.mipmaps <= 1) {
+				pmin = GL_LINEAR;
+				max_lod = 0;
+			} else if (config->use_nearest_mip_filter) {
+				pmin = GL_LINEAR_MIPMAP_NEAREST;
+				max_lod = decal_atlas.mipmaps - 1;
+			} else {
+				pmin = GL_LINEAR_MIPMAP_LINEAR;
+				max_lod = decal_atlas.mipmaps - 1;
+			}
+		} break;
+	}
+
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, pmag);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, pmin);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, max_lod);
+	if (config->support_anisotropic_filter) {
+		glTexParameterf(GL_TEXTURE_2D, _GL_TEXTURE_MAX_ANISOTROPY_EXT, anisotropy);
+	}
+}
+
+GLuint TextureStorage::decal_atlas_get_texture() const {
+	return decal_atlas.texture;
+}
+
+void TextureStorage::texture_add_to_decal_atlas(RID p_texture, bool p_panorama_to_dp) {
+	// TODO: p_panorama_to_dp is used for light projectors, possibly add support for it at some point?
+	if (!decal_atlas.textures.has(p_texture)) {
+		DecalAtlas::Texture t;
+		t.users = 1;
+		decal_atlas.textures[p_texture] = t;
+		decal_atlas.dirty = true;
+	} else {
+		DecalAtlas::Texture *t = decal_atlas.textures.getptr(p_texture);
+		t->users++;
+	}
+}
+
+void TextureStorage::texture_remove_from_decal_atlas(RID p_texture, bool p_panorama_to_dp) {
+	DecalAtlas::Texture *t = decal_atlas.textures.getptr(p_texture);
+	ERR_FAIL_NULL(t);
+	t->users--;
+	if (t->users == 0) {
+		decal_atlas.textures.erase(p_texture);
+		// Do not mark it dirty, there is no need to since it remains working.
+	}
+}
+
+void TextureStorage::decal_atlas_mark_dirty_on_texture(RID p_texture) {
+	if (decal_atlas.textures.has(p_texture)) {
+		decal_atlas.dirty = true; // Mark it dirty since it was most likely modified.
+	}
+}
+
+void TextureStorage::decal_atlas_remove_texture(RID p_texture) {
+	if (decal_atlas.textures.has(p_texture)) {
+		decal_atlas.textures.erase(p_texture);
+		// There is not much a point of making it dirty, texture can be removed next time the atlas is updated.
+	}
+}
+
+/* DECAL INSTANCE */
+
+int32_t TextureStorage::allocate_decal_id() {
+	int32_t index = -1;
+	for (uint32_t i = 0; i < decal_id_allocator.allocations.size(); i++) {
+		if (decal_id_allocator.allocations[i] == false) {
+			index = i;
+			break;
+		}
+	}
+
+	if (index == -1) {
+		index = decal_id_allocator.allocations.size();
+		decal_id_allocator.allocations.push_back(true);
+		decal_id_allocator.map.push_back(0xFF);
+		decal_id_allocator.last_pass.push_back(0);
+	} else {
+		decal_id_allocator.allocations[index] = true;
+	}
+
+	return index;
+}
+
+void TextureStorage::free_decal_id(int32_t p_id) {
+	ERR_FAIL_INDEX(p_id, (int32_t)decal_id_allocator.allocations.size());
+	decal_id_allocator.allocations[p_id] = false;
+}
+
+void TextureStorage::map_decal_id(int32_t p_id, uint32_t p_index, uint64_t p_last_pass) {
+	decal_id_allocator.map[p_id] = p_index;
+	decal_id_allocator.last_pass[p_id] = p_last_pass;
+}
+
+RID TextureStorage::decal_instance_create(RID p_decal) {
+	DecalInstance di;
+	di.decal = p_decal;
+	di.decal_id = allocate_decal_id();
+	return decal_instance_owner.make_rid(di);
+}
+
+void TextureStorage::decal_instance_free(RID p_decal_instance) {
+	DecalInstance *di = decal_instance_owner.get_or_null(p_decal_instance);
+	free_decal_id(di->decal_id);
+	decal_instance_owner.free(p_decal_instance);
+}
+
+void TextureStorage::decal_instance_set_transform(RID p_decal_instance, const Transform3D &p_transform) {
+	DecalInstance *di = decal_instance_owner.get_or_null(p_decal_instance);
+	ERR_FAIL_NULL(di);
+	di->transform = p_transform;
+}
+
+void TextureStorage::decal_instance_set_sorting_offset(RID p_decal_instance, float p_sorting_offset) {
+	DecalInstance *di = decal_instance_owner.get_or_null(p_decal_instance);
+	ERR_FAIL_NULL(di);
+	di->sorting_offset = p_sorting_offset;
+}
+
+/* DECAL DATA API */
+
+void TextureStorage::free_decal_data() {
+	if (decal_buffer > 0) {
+		GLES3::Utilities::get_singleton()->buffer_free_data(decal_buffer);
+		decal_buffer = 0;
+	}
+
+	if (decals != nullptr) {
+		memdelete_arr(decals);
+		decals = nullptr;
+	}
+
+	if (decal_sort != nullptr) {
+		memdelete_arr(decal_sort);
+		decal_sort = nullptr;
+	}
+}
+
+void TextureStorage::set_max_decals(const uint32_t p_max_decals) {
+	max_decals = p_max_decals;
+	uint32_t decal_buffer_size = max_decals * sizeof(DecalData);
+	decals = memnew_arr(DecalData, max_decals);
+	decal_sort = memnew_arr(DecalInstanceSort, max_decals);
+
+	glGenBuffers(1, &decal_buffer);
+	glBindBufferBase(GL_UNIFORM_BUFFER, SCENE_DECAL_DATA, decal_buffer);
+	GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_UNIFORM_BUFFER, decal_buffer, decal_buffer_size, nullptr, GL_STREAM_DRAW, "Decal buffer");
+	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+}
+
+void TextureStorage::update_decal_buffer(const PagedArray<RID> &p_decals, const Transform3D &p_camera_xform) {
+	Transform3D uv_xform;
+	uv_xform.basis.scale(Vector3(2.0, 1.0, 2.0));
+	uv_xform.origin = Vector3(-1.0, 0.0, -1.0);
+
+	uint32_t decals_size = p_decals.size();
+
+	decal_count = 0;
+
+	for (uint32_t i = 0; i < decals_size; i++) {
+		if (decal_count == max_decals) {
+			break;
+		}
+
+		DecalInstance *decal_instance = decal_instance_owner.get_or_null(p_decals[i]);
+		if (!decal_instance) {
+			continue;
+		}
+		Decal *decal = decal_owner.get_or_null(decal_instance->decal);
+
+		Transform3D xform = decal_instance->transform;
+
+		real_t distance = p_camera_xform.origin.distance_to(xform.origin);
+
+		if (decal->distance_fade) {
+			float fade_begin = decal->distance_fade_begin;
+			float fade_length = decal->distance_fade_length;
+
+			if (distance > fade_begin) {
+				if (distance > fade_begin + fade_length) {
+					continue; // do not use this decal, its invisible
+				}
+			}
+		}
+
+		decal_sort[decal_count].decal_instance = decal_instance;
+		decal_sort[decal_count].decal = decal;
+		decal_sort[decal_count].depth = distance - decal_instance->sorting_offset;
+		decal_count++;
+	}
+
+	if (decal_count > 0) {
+		SortArray<DecalInstanceSort> sort_array;
+		sort_array.sort(decal_sort, decal_count);
+	}
+
+	for (uint32_t i = 0; i < decal_count; i++) {
+		DecalInstance *decal_instance = decal_sort[i].decal_instance;
+		Decal *decal = decal_sort[i].decal;
+
+		map_decal_id(decal_instance->decal_id, i, RSG::rasterizer->get_frame_number());
+
+		decal_instance->cull_mask = decal->cull_mask;
+
+		float fade = 1.0;
+
+		if (decal->distance_fade) {
+			const real_t distance = decal_sort[i].depth + decal_instance->sorting_offset;
+			const float fade_begin = decal->distance_fade_begin;
+			const float fade_length = decal->distance_fade_length;
+
+			if (distance > fade_begin) {
+				// Use `smoothstep()` to make opacity changes more gradual and less noticeable to the player.
+				fade = Math::smoothstep(0.0f, 1.0f, 1.0f - float(distance - fade_begin) / fade_length);
+			}
+		}
+
+		DecalData &dd = decals[i];
+
+		Vector3 decal_extents = decal->size / 2;
+
+		Transform3D scale_xform;
+		scale_xform.basis.scale(decal_extents);
+
+		Transform3D xform = decal_instance->transform;
+
+		Transform3D camera_inverse_xform = p_camera_xform.affine_inverse();
+
+		Transform3D to_decal_xform = (camera_inverse_xform * xform * scale_xform * uv_xform).affine_inverse();
+		MaterialStorage::store_transform(to_decal_xform, dd.xform);
+
+		Vector3 normal = xform.basis.get_column(Vector3::AXIS_Y).normalized();
+		normal = camera_inverse_xform.basis.xform(normal); //camera is normalized, so fine
+
+		dd.normal[0] = normal.x;
+		dd.normal[1] = normal.y;
+		dd.normal[2] = normal.z;
+		dd.normal_fade = decal->normal_fade;
+
+		RID albedo_tex = decal->textures[RSE::DECAL_TEXTURE_ALBEDO];
+		RID emission_tex = decal->textures[RSE::DECAL_TEXTURE_EMISSION];
+		if (albedo_tex.is_valid()) {
+			Rect2 rect = decal_atlas_get_texture_rect(albedo_tex);
+			dd.albedo_rect[0] = rect.position.x;
+			dd.albedo_rect[1] = rect.position.y;
+			dd.albedo_rect[2] = rect.size.x;
+			dd.albedo_rect[3] = rect.size.y;
+		} else {
+			if (!emission_tex.is_valid()) {
+				continue; //no albedo, no emission, no decal.
+			}
+			dd.albedo_rect[0] = 0;
+			dd.albedo_rect[1] = 0;
+			dd.albedo_rect[2] = 0;
+			dd.albedo_rect[3] = 0;
+		}
+
+		RID normal_tex = decal->textures[RSE::DECAL_TEXTURE_NORMAL];
+
+		if (normal_tex.is_valid()) {
+			Rect2 rect = decal_atlas_get_texture_rect(normal_tex);
+			dd.normal_rect[0] = rect.position.x;
+			dd.normal_rect[1] = rect.position.y;
+			dd.normal_rect[2] = rect.size.x;
+			dd.normal_rect[3] = rect.size.y;
+
+			Basis normal_xform = camera_inverse_xform.basis * xform.basis.orthonormalized();
+			MaterialStorage::store_transform_3x3(normal_xform, dd.normal_xform);
+		} else {
+			dd.normal_rect[0] = 0;
+			dd.normal_rect[1] = 0;
+			dd.normal_rect[2] = 0;
+			dd.normal_rect[3] = 0;
+		}
+
+		RID orm_tex = decal->textures[RSE::DECAL_TEXTURE_ORM];
+		if (orm_tex.is_valid()) {
+			Rect2 rect = decal_atlas_get_texture_rect(orm_tex);
+			dd.orm_rect[0] = rect.position.x;
+			dd.orm_rect[1] = rect.position.y;
+			dd.orm_rect[2] = rect.size.x;
+			dd.orm_rect[3] = rect.size.y;
+		} else {
+			dd.orm_rect[0] = 0;
+			dd.orm_rect[1] = 0;
+			dd.orm_rect[2] = 0;
+			dd.orm_rect[3] = 0;
+		}
+
+		if (emission_tex.is_valid()) {
+			Rect2 rect = decal_atlas_get_texture_rect(emission_tex);
+			dd.emission_rect[0] = rect.position.x;
+			dd.emission_rect[1] = rect.position.y;
+			dd.emission_rect[2] = rect.size.x;
+			dd.emission_rect[3] = rect.size.y;
+		} else {
+			dd.emission_rect[0] = 0;
+			dd.emission_rect[1] = 0;
+			dd.emission_rect[2] = 0;
+			dd.emission_rect[3] = 0;
+		}
+
+		Color modulate = decal->modulate.srgb_to_linear();
+		dd.modulate[0] = modulate.r;
+		dd.modulate[1] = modulate.g;
+		dd.modulate[2] = modulate.b;
+		dd.modulate[3] = modulate.a * fade;
+		dd.emission_energy = decal->emission_energy * fade;
+		dd.albedo_mix = decal->albedo_mix;
+		dd.mask = decal->cull_mask;
+		dd.upper_fade = decal->upper_fade;
+		dd.lower_fade = decal->lower_fade;
+	}
+
+	if (decal_count > 0) {
+		glBindBufferBase(GL_UNIFORM_BUFFER, SCENE_DECAL_DATA, decal_buffer);
+		glBufferSubData(GL_UNIFORM_BUFFER, 0, decal_count * sizeof(DecalData), decals);
+		glBindBuffer(GL_UNIFORM_BUFFER, 0);
+	}
 }
 
 /* RENDER TARGET API */

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -292,16 +292,27 @@ TextureStorage::TextureStorage() {
 }
 
 TextureStorage::~TextureStorage() {
+	free_decal_data();
+
 	singleton = nullptr;
 	for (int i = 0; i < DEFAULT_GL_TEXTURE_MAX; i++) {
 		texture_free(default_gl_textures[i]);
 	}
+
 	if (texture_atlas.texture != 0) {
 		GLES3::Utilities::get_singleton()->texture_free_data(texture_atlas.texture);
 	}
 	texture_atlas.texture = 0;
 	glDeleteFramebuffers(1, &texture_atlas.framebuffer);
 	texture_atlas.framebuffer = 0;
+
+	if (decal_atlas.texture != 0) {
+		GLES3::Utilities::get_singleton()->texture_free_data(decal_atlas.texture);
+	}
+	decal_atlas.texture = 0;
+	glDeleteFramebuffers(1, &decal_atlas.framebuffer);
+	decal_atlas.framebuffer = 0;
+
 	sdf_shader.shader.version_free(sdf_shader.shader_version);
 }
 
@@ -1041,7 +1052,9 @@ void TextureStorage::texture_free(RID p_texture) {
 		t->tex_id = 0;
 	}
 
+	// Remove from any atlas these are in.
 	texture_atlas_remove_texture(p_texture);
+	decal_atlas_remove_texture(p_texture);
 
 	for (uint32_t i = 0; i < t->proxies.size(); i++) {
 		Texture *p = texture_owner.get_or_null(t->proxies[i]);
@@ -1878,7 +1891,9 @@ void TextureStorage::texture_replace(RID p_texture, RID p_by_texture) {
 	//delete last, so proxies can be updated
 	texture_owner.free(p_by_texture);
 
+	// Mark any atlas that has this texture in it as dirty.
 	texture_atlas_mark_dirty_on_texture(p_texture);
+	decal_atlas_mark_dirty_on_texture(p_texture);
 }
 
 void TextureStorage::texture_set_size_override(RID p_texture, int p_width, int p_height) {
@@ -2519,41 +2534,668 @@ void TextureStorage::update_texture_atlas() {
 /* DECAL API */
 
 RID TextureStorage::decal_allocate() {
-	return RID();
+	return decal_owner.allocate_rid();
 }
 
-void TextureStorage::decal_initialize(RID p_rid) {
+void TextureStorage::decal_initialize(RID p_decal) {
+	decal_owner.initialize_rid(p_decal, Decal());
+}
+
+void TextureStorage::decal_free(RID p_decal) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	for (int i = 0; i < RSE::DECAL_TEXTURE_MAX; i++) {
+		if (decal->textures[i].is_valid() && owns_texture(decal->textures[i])) {
+			texture_remove_from_decal_atlas(decal->textures[i]);
+		}
+	}
+	decal->dependency.deleted_notify(p_decal);
+	decal_owner.free(p_decal);
 }
 
 void TextureStorage::decal_set_size(RID p_decal, const Vector3 &p_size) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->size = p_size;
+	decal->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_AABB);
 }
 
 void TextureStorage::decal_set_texture(RID p_decal, RSE::DecalTexture p_type, RID p_texture) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	ERR_FAIL_INDEX(p_type, RSE::DECAL_TEXTURE_MAX);
+
+	if (decal->textures[p_type] == p_texture) {
+		return;
+	}
+
+	ERR_FAIL_COND(p_texture.is_valid() && !owns_texture(p_texture));
+
+	if (decal->textures[p_type].is_valid() && owns_texture(decal->textures[p_type])) {
+		texture_remove_from_decal_atlas(decal->textures[p_type]);
+	}
+
+	decal->textures[p_type] = p_texture;
+
+	if (decal->textures[p_type].is_valid()) {
+		texture_add_to_decal_atlas(decal->textures[p_type]);
+	}
+
+	decal->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_DECAL);
 }
 
 void TextureStorage::decal_set_emission_energy(RID p_decal, float p_energy) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->emission_energy = p_energy;
 }
 
 void TextureStorage::decal_set_albedo_mix(RID p_decal, float p_mix) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->albedo_mix = p_mix;
 }
 
 void TextureStorage::decal_set_modulate(RID p_decal, const Color &p_modulate) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->modulate = p_modulate;
 }
 
 void TextureStorage::decal_set_cull_mask(RID p_decal, uint32_t p_layers) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->cull_mask = p_layers;
+	decal->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_CULL_MASK);
 }
 
 void TextureStorage::decal_set_distance_fade(RID p_decal, bool p_enabled, float p_begin, float p_length) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->distance_fade = p_enabled;
+	decal->distance_fade_begin = p_begin;
+	decal->distance_fade_length = p_length;
 }
 
 void TextureStorage::decal_set_fade(RID p_decal, float p_above, float p_below) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->upper_fade = p_above;
+	decal->lower_fade = p_below;
 }
 
 void TextureStorage::decal_set_normal_fade(RID p_decal, float p_fade) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL(decal);
+	decal->normal_fade = p_fade;
 }
 
 AABB TextureStorage::decal_get_aabb(RID p_decal) const {
-	return AABB();
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL_V(decal, AABB());
+
+	return AABB(-decal->size / 2, decal->size);
+}
+
+uint32_t TextureStorage::decal_get_cull_mask(RID p_decal) const {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL_V(decal, 0);
+
+	return decal->cull_mask;
+}
+
+Dependency *TextureStorage::decal_get_dependency(RID p_decal) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_NULL_V(decal, nullptr);
+
+	return &decal->dependency;
+}
+
+void TextureStorage::update_decal_atlas() {
+	CopyEffects *copy_effects = CopyEffects::get_singleton();
+	ERR_FAIL_NULL(copy_effects);
+
+	if (!decal_atlas.dirty) {
+		return; //nothing to do
+	}
+
+	decal_atlas.dirty = false;
+
+	if (decal_atlas.texture != 0) {
+		GLES3::Utilities::get_singleton()->texture_free_data(decal_atlas.texture);
+		decal_atlas.texture = 0;
+		glDeleteFramebuffers(1, &decal_atlas.framebuffer);
+		decal_atlas.framebuffer = 0;
+	}
+
+	int border = 1 << decal_atlas.mipmaps;
+
+	if (decal_atlas.textures.size()) {
+		//generate atlas
+		Vector<DecalAtlas::SortItem> itemsv;
+		itemsv.resize(decal_atlas.textures.size());
+		uint32_t base_size = 8;
+
+		int idx = 0;
+
+		for (const KeyValue<RID, DecalAtlas::Texture> &E : decal_atlas.textures) {
+			DecalAtlas::SortItem &si = itemsv.write[idx];
+
+			Texture *src_tex = get_texture(E.key);
+
+			si.size.width = (src_tex->width / border) + 1;
+			si.size.height = (src_tex->height / border) + 1;
+			si.pixel_size = Size2i(src_tex->width, src_tex->height);
+
+			if (base_size < (uint32_t)si.size.width) {
+				base_size = Math::nearest_power_of_2_templated(si.size.width);
+			}
+
+			si.texture = E.key;
+			idx++;
+		}
+
+		//sort items by size
+		itemsv.sort();
+
+		//attempt to create atlas
+		int item_count = itemsv.size();
+		DecalAtlas::SortItem *items = itemsv.ptrw();
+
+		int atlas_height = 0;
+
+		while (true) {
+			Vector<int> v_offsetsv;
+			v_offsetsv.resize(base_size);
+
+			int *v_offsets = v_offsetsv.ptrw();
+			memset(v_offsets, 0, sizeof(int) * base_size);
+
+			int max_height = 0;
+
+			for (int i = 0; i < item_count; i++) {
+				//best fit
+				DecalAtlas::SortItem &si = items[i];
+				int best_idx = -1;
+				int best_height = 0x7FFFFFFF;
+				for (uint32_t j = 0; j <= base_size - si.size.width; j++) {
+					int height = 0;
+					for (int k = 0; k < si.size.width; k++) {
+						int h = v_offsets[k + j];
+						if (h > height) {
+							height = h;
+							if (height > best_height) {
+								break; //already bad
+							}
+						}
+					}
+
+					if (height < best_height) {
+						best_height = height;
+						best_idx = j;
+					}
+				}
+
+				//update
+				for (int k = 0; k < si.size.width; k++) {
+					v_offsets[k + best_idx] = best_height + si.size.height;
+				}
+
+				si.pos.x = best_idx;
+				si.pos.y = best_height;
+
+				if (si.pos.y + si.size.height > max_height) {
+					max_height = si.pos.y + si.size.height;
+				}
+			}
+
+			if ((uint32_t)max_height <= base_size * 2) {
+				atlas_height = max_height;
+				break; //good ratio, break;
+			}
+
+			base_size *= 2;
+		}
+
+		decal_atlas.size.width = base_size * border;
+		decal_atlas.size.height = Math::nearest_power_of_2_templated(atlas_height * border);
+
+		for (int i = 0; i < item_count; i++) {
+			DecalAtlas::Texture *t = decal_atlas.textures.getptr(items[i].texture);
+			t->uv_rect.position = items[i].pos * border + Vector2i(border / 2, border / 2);
+			t->uv_rect.size = items[i].pixel_size;
+
+			t->uv_rect.position /= Size2(decal_atlas.size);
+			t->uv_rect.size /= Size2(decal_atlas.size);
+		}
+	} else {
+		decal_atlas.size.width = 4;
+		decal_atlas.size.height = 4;
+	}
+
+	{ // Atlas Texture initialize.
+		// TODO validate texture atlas size with maximum texture size
+		glGenTextures(1, &decal_atlas.texture);
+		glActiveTexture(GL_TEXTURE0);
+		glBindTexture(GL_TEXTURE_2D, decal_atlas.texture);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, decal_atlas.size.width, decal_atlas.size.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+		GLES3::Utilities::get_singleton()->texture_allocated_data(decal_atlas.texture, decal_atlas.size.width * decal_atlas.size.height * 4, "Decal atlas");
+
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+		glGenFramebuffers(1, &decal_atlas.framebuffer);
+		glBindFramebuffer(GL_FRAMEBUFFER, decal_atlas.framebuffer);
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, decal_atlas.texture, 0);
+
+		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+
+		if (status != GL_FRAMEBUFFER_COMPLETE) {
+			glDeleteFramebuffers(1, &decal_atlas.framebuffer);
+			decal_atlas.framebuffer = 0;
+			GLES3::Utilities::get_singleton()->texture_free_data(decal_atlas.texture);
+			decal_atlas.texture = 0;
+			WARN_PRINT("Could not create decal atlas, status: " + get_framebuffer_error(status));
+			return;
+		}
+		glViewport(0, 0, decal_atlas.size.width, decal_atlas.size.height);
+		glClearColor(0.0, 0.0, 0.0, 0.0);
+		glClear(GL_COLOR_BUFFER_BIT);
+		glBindTexture(GL_TEXTURE_2D, 0);
+	}
+
+	glDisable(GL_BLEND);
+
+	if (decal_atlas.textures.size()) {
+		for (const KeyValue<RID, DecalAtlas::Texture> &E : decal_atlas.textures) {
+			DecalAtlas::Texture *t = decal_atlas.textures.getptr(E.key);
+			Texture *src_tex = get_texture(E.key);
+			glActiveTexture(GL_TEXTURE0);
+			glBindTexture(GL_TEXTURE_2D, src_tex->tex_id);
+			copy_effects->copy_to_rect(t->uv_rect);
+		}
+	}
+	glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
+
+	glBindTexture(GL_TEXTURE_2D, decal_atlas.texture);
+	glGenerateMipmap(GL_TEXTURE_2D);
+	decal_atlas_set_filter(decal_atlas.filter_state, true);
+	glBindTexture(GL_TEXTURE_2D, 0);
+}
+
+void TextureStorage::decal_atlas_set_filter(RSE::DecalFilter p_filter, bool p_force) {
+	Config *config = Config::get_singleton();
+
+	if (decal_atlas.filter_state == p_filter && !p_force) {
+		// We're good.
+		return;
+	}
+	decal_atlas.filter_state = p_filter;
+
+	if (decal_atlas.texture == 0) {
+		// Not yet created, we will apply the correct filter after we've created our texture.
+		return;
+	}
+
+	GLenum pmin = GL_NEAREST;
+	GLenum pmag = GL_NEAREST;
+	GLint max_lod = 0;
+	GLfloat anisotropy = 1.0f;
+
+	switch (decal_atlas.filter_state) {
+		case RSE::DECAL_FILTER_NEAREST: {
+			pmin = GL_NEAREST;
+			pmag = GL_NEAREST;
+			max_lod = 0;
+		} break;
+		case RSE::DECAL_FILTER_LINEAR: {
+			pmin = GL_LINEAR;
+			pmag = GL_LINEAR;
+			max_lod = 0;
+		} break;
+		case RSE::DECAL_FILTER_NEAREST_MIPMAPS_ANISOTROPIC: {
+			anisotropy = config->anisotropic_level;
+		};
+			[[fallthrough]];
+		case RSE::DECAL_FILTER_NEAREST_MIPMAPS: {
+			pmag = GL_NEAREST;
+			if (decal_atlas.mipmaps <= 1) {
+				pmin = GL_NEAREST;
+				max_lod = 0;
+			} else if (config->use_nearest_mip_filter) {
+				pmin = GL_NEAREST_MIPMAP_NEAREST;
+				max_lod = decal_atlas.mipmaps - 1;
+			} else {
+				pmin = GL_NEAREST_MIPMAP_LINEAR;
+				max_lod = decal_atlas.mipmaps - 1;
+			}
+		} break;
+		case RSE::DECAL_FILTER_LINEAR_MIPMAPS_ANISOTROPIC: {
+			anisotropy = config->anisotropic_level;
+		};
+			[[fallthrough]];
+		case RSE::DECAL_FILTER_LINEAR_MIPMAPS: {
+			pmag = GL_LINEAR;
+			if (decal_atlas.mipmaps <= 1) {
+				pmin = GL_LINEAR;
+				max_lod = 0;
+			} else if (config->use_nearest_mip_filter) {
+				pmin = GL_LINEAR_MIPMAP_NEAREST;
+				max_lod = decal_atlas.mipmaps - 1;
+			} else {
+				pmin = GL_LINEAR_MIPMAP_LINEAR;
+				max_lod = decal_atlas.mipmaps - 1;
+			}
+		} break;
+	}
+
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, pmag);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, pmin);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, max_lod);
+	if (config->support_anisotropic_filter) {
+		glTexParameterf(GL_TEXTURE_2D, _GL_TEXTURE_MAX_ANISOTROPY_EXT, anisotropy);
+	}
+}
+
+GLuint TextureStorage::decal_atlas_get_texture() const {
+	return decal_atlas.texture;
+}
+
+void TextureStorage::texture_add_to_decal_atlas(RID p_texture, bool p_panorama_to_dp) {
+	// TODO: p_panorama_to_dp is used for light projectors, possibly add support for it at some point?
+	if (!decal_atlas.textures.has(p_texture)) {
+		DecalAtlas::Texture t;
+		t.users = 1;
+		decal_atlas.textures[p_texture] = t;
+		decal_atlas.dirty = true;
+	} else {
+		DecalAtlas::Texture *t = decal_atlas.textures.getptr(p_texture);
+		t->users++;
+	}
+}
+
+void TextureStorage::texture_remove_from_decal_atlas(RID p_texture, bool p_panorama_to_dp) {
+	DecalAtlas::Texture *t = decal_atlas.textures.getptr(p_texture);
+	ERR_FAIL_NULL(t);
+	t->users--;
+	if (t->users == 0) {
+		decal_atlas.textures.erase(p_texture);
+		// Do not mark it dirty, there is no need to since it remains working.
+	}
+}
+
+void TextureStorage::decal_atlas_mark_dirty_on_texture(RID p_texture) {
+	if (decal_atlas.textures.has(p_texture)) {
+		decal_atlas.dirty = true; // Mark it dirty since it was most likely modified.
+	}
+}
+
+void TextureStorage::decal_atlas_remove_texture(RID p_texture) {
+	if (decal_atlas.textures.has(p_texture)) {
+		decal_atlas.textures.erase(p_texture);
+		// There is not much a point of making it dirty, texture can be removed next time the atlas is updated.
+	}
+}
+
+/* DECAL INSTANCE */
+
+int32_t TextureStorage::allocate_decal_id() {
+	int32_t index = -1;
+	for (uint32_t i = 0; i < decal_id_allocator.allocations.size(); i++) {
+		if (decal_id_allocator.allocations[i] == false) {
+			index = i;
+			break;
+		}
+	}
+
+	if (index == -1) {
+		index = decal_id_allocator.allocations.size();
+		decal_id_allocator.allocations.push_back(true);
+		decal_id_allocator.map.push_back(0xFF);
+		decal_id_allocator.last_pass.push_back(0);
+	} else {
+		decal_id_allocator.allocations[index] = true;
+	}
+
+	return index;
+}
+
+void TextureStorage::free_decal_id(int32_t p_id) {
+	ERR_FAIL_INDEX(p_id, (int32_t)decal_id_allocator.allocations.size());
+	decal_id_allocator.allocations[p_id] = false;
+}
+
+void TextureStorage::map_decal_id(int32_t p_id, uint32_t p_index, uint64_t p_last_pass) {
+	decal_id_allocator.map[p_id] = p_index;
+	decal_id_allocator.last_pass[p_id] = p_last_pass;
+}
+
+RID TextureStorage::decal_instance_create(RID p_decal) {
+	DecalInstance di;
+	di.decal = p_decal;
+	di.decal_id = allocate_decal_id();
+	return decal_instance_owner.make_rid(di);
+}
+
+void TextureStorage::decal_instance_free(RID p_decal_instance) {
+	DecalInstance *di = decal_instance_owner.get_or_null(p_decal_instance);
+	free_decal_id(di->decal_id);
+	decal_instance_owner.free(p_decal_instance);
+}
+
+void TextureStorage::decal_instance_set_transform(RID p_decal_instance, const Transform3D &p_transform) {
+	DecalInstance *di = decal_instance_owner.get_or_null(p_decal_instance);
+	ERR_FAIL_NULL(di);
+	di->transform = p_transform;
+}
+
+void TextureStorage::decal_instance_set_sorting_offset(RID p_decal_instance, float p_sorting_offset) {
+	DecalInstance *di = decal_instance_owner.get_or_null(p_decal_instance);
+	ERR_FAIL_NULL(di);
+	di->sorting_offset = p_sorting_offset;
+}
+
+/* DECAL DATA API */
+
+void TextureStorage::free_decal_data() {
+	if (decal_buffer > 0) {
+		GLES3::Utilities::get_singleton()->buffer_free_data(decal_buffer);
+		decal_buffer = 0;
+	}
+
+	if (decals != nullptr) {
+		memdelete_arr(decals);
+		decals = nullptr;
+	}
+
+	if (decal_sort != nullptr) {
+		memdelete_arr(decal_sort);
+		decal_sort = nullptr;
+	}
+}
+
+void TextureStorage::set_max_decals(const uint32_t p_max_decals) {
+	max_decals = p_max_decals;
+	uint32_t decal_buffer_size = max_decals * sizeof(DecalData);
+	decals = memnew_arr(DecalData, max_decals);
+	decal_sort = memnew_arr(DecalInstanceSort, max_decals);
+
+	glGenBuffers(1, &decal_buffer);
+	glBindBufferBase(GL_UNIFORM_BUFFER, SCENE_DECAL_DATA, decal_buffer);
+	GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_UNIFORM_BUFFER, decal_buffer, decal_buffer_size, nullptr, GL_STREAM_DRAW, "Decal buffer");
+	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+}
+
+void TextureStorage::update_decal_buffer(const PagedArray<RID> &p_decals, const Transform3D &p_camera_xform) {
+	Transform3D uv_xform;
+	uv_xform.basis.scale(Vector3(2.0, 1.0, 2.0));
+	uv_xform.origin = Vector3(-1.0, 0.0, -1.0);
+
+	uint32_t decals_size = p_decals.size();
+
+	decal_count = 0;
+
+	for (uint32_t i = 0; i < decals_size; i++) {
+		if (decal_count == max_decals) {
+			break;
+		}
+
+		DecalInstance *decal_instance = decal_instance_owner.get_or_null(p_decals[i]);
+		if (!decal_instance) {
+			continue;
+		}
+		Decal *decal = decal_owner.get_or_null(decal_instance->decal);
+
+		Transform3D xform = decal_instance->transform;
+
+		real_t distance = p_camera_xform.origin.distance_to(xform.origin);
+
+		if (decal->distance_fade) {
+			float fade_begin = decal->distance_fade_begin;
+			float fade_length = decal->distance_fade_length;
+
+			if (distance > fade_begin) {
+				if (distance > fade_begin + fade_length) {
+					continue; // do not use this decal, its invisible
+				}
+			}
+		}
+
+		decal_sort[decal_count].decal_instance = decal_instance;
+		decal_sort[decal_count].decal = decal;
+		decal_sort[decal_count].depth = distance - decal_instance->sorting_offset;
+		decal_count++;
+	}
+
+	if (decal_count > 0) {
+		SortArray<DecalInstanceSort> sort_array;
+		sort_array.sort(decal_sort, decal_count);
+	}
+
+	for (uint32_t i = 0; i < decal_count; i++) {
+		DecalInstance *decal_instance = decal_sort[i].decal_instance;
+		Decal *decal = decal_sort[i].decal;
+
+		map_decal_id(decal_instance->decal_id, i, RSG::rasterizer->get_frame_number());
+
+		decal_instance->cull_mask = decal->cull_mask;
+
+		float fade = 1.0;
+
+		if (decal->distance_fade) {
+			const real_t distance = decal_sort[i].depth + decal_instance->sorting_offset;
+			const float fade_begin = decal->distance_fade_begin;
+			const float fade_length = decal->distance_fade_length;
+
+			if (distance > fade_begin) {
+				// Use `smoothstep()` to make opacity changes more gradual and less noticeable to the player.
+				fade = Math::smoothstep(0.0f, 1.0f, 1.0f - float(distance - fade_begin) / fade_length);
+			}
+		}
+
+		DecalData &dd = decals[i];
+
+		Vector3 decal_extents = decal->size / 2;
+
+		Transform3D scale_xform;
+		scale_xform.basis.scale(decal_extents);
+
+		Transform3D xform = decal_instance->transform;
+
+		Transform3D camera_inverse_xform = p_camera_xform.affine_inverse();
+
+		Transform3D to_decal_xform = (camera_inverse_xform * xform * scale_xform * uv_xform).affine_inverse();
+		MaterialStorage::store_transform(to_decal_xform, dd.xform);
+
+		Vector3 normal = xform.basis.get_column(Vector3::AXIS_Y).normalized();
+		normal = camera_inverse_xform.basis.xform(normal); //camera is normalized, so fine
+
+		dd.normal[0] = normal.x;
+		dd.normal[1] = normal.y;
+		dd.normal[2] = normal.z;
+		dd.normal_fade = decal->normal_fade;
+
+		RID albedo_tex = decal->textures[RSE::DECAL_TEXTURE_ALBEDO];
+		RID emission_tex = decal->textures[RSE::DECAL_TEXTURE_EMISSION];
+		if (albedo_tex.is_valid()) {
+			Rect2 rect = decal_atlas_get_texture_rect(albedo_tex);
+			dd.albedo_rect[0] = rect.position.x;
+			dd.albedo_rect[1] = rect.position.y;
+			dd.albedo_rect[2] = rect.size.x;
+			dd.albedo_rect[3] = rect.size.y;
+		} else {
+			if (!emission_tex.is_valid()) {
+				continue; //no albedo, no emission, no decal.
+			}
+			dd.albedo_rect[0] = 0;
+			dd.albedo_rect[1] = 0;
+			dd.albedo_rect[2] = 0;
+			dd.albedo_rect[3] = 0;
+		}
+
+		RID normal_tex = decal->textures[RSE::DECAL_TEXTURE_NORMAL];
+
+		if (normal_tex.is_valid()) {
+			Rect2 rect = decal_atlas_get_texture_rect(normal_tex);
+			dd.normal_rect[0] = rect.position.x;
+			dd.normal_rect[1] = rect.position.y;
+			dd.normal_rect[2] = rect.size.x;
+			dd.normal_rect[3] = rect.size.y;
+
+			Basis normal_xform = camera_inverse_xform.basis * xform.basis.orthonormalized();
+			MaterialStorage::store_transform_3x3(normal_xform, dd.normal_xform);
+		} else {
+			dd.normal_rect[0] = 0;
+			dd.normal_rect[1] = 0;
+			dd.normal_rect[2] = 0;
+			dd.normal_rect[3] = 0;
+		}
+
+		RID orm_tex = decal->textures[RSE::DECAL_TEXTURE_ORM];
+		if (orm_tex.is_valid()) {
+			Rect2 rect = decal_atlas_get_texture_rect(orm_tex);
+			dd.orm_rect[0] = rect.position.x;
+			dd.orm_rect[1] = rect.position.y;
+			dd.orm_rect[2] = rect.size.x;
+			dd.orm_rect[3] = rect.size.y;
+		} else {
+			dd.orm_rect[0] = 0;
+			dd.orm_rect[1] = 0;
+			dd.orm_rect[2] = 0;
+			dd.orm_rect[3] = 0;
+		}
+
+		if (emission_tex.is_valid()) {
+			Rect2 rect = decal_atlas_get_texture_rect(emission_tex);
+			dd.emission_rect[0] = rect.position.x;
+			dd.emission_rect[1] = rect.position.y;
+			dd.emission_rect[2] = rect.size.x;
+			dd.emission_rect[3] = rect.size.y;
+		} else {
+			dd.emission_rect[0] = 0;
+			dd.emission_rect[1] = 0;
+			dd.emission_rect[2] = 0;
+			dd.emission_rect[3] = 0;
+		}
+
+		Color modulate = decal->modulate.srgb_to_linear();
+		dd.modulate[0] = modulate.r;
+		dd.modulate[1] = modulate.g;
+		dd.modulate[2] = modulate.b;
+		dd.modulate[3] = modulate.a * fade;
+		dd.emission_energy = decal->emission_energy * fade;
+		dd.albedo_mix = decal->albedo_mix;
+		dd.mask = decal->cull_mask;
+		dd.upper_fade = decal->upper_fade;
+		dd.lower_fade = decal->lower_fade;
+	}
+
+	if (decal_count > 0) {
+		glBindBufferBase(GL_UNIFORM_BUFFER, SCENE_DECAL_DATA, decal_buffer);
+		glBufferSubData(GL_UNIFORM_BUFFER, 0, decal_count * sizeof(DecalData), decals);
+		glBindBuffer(GL_UNIFORM_BUFFER, 0);
+	}
 }
 
 /* RENDER TARGET API */

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -33,6 +33,8 @@
 #ifdef GLES3_ENABLED
 
 #include "core/io/image.h"
+#include "core/math/transform_3d.h"
+#include "core/templates/paged_array.h"
 #include "core/templates/rb_map.h"
 #include "core/templates/rid_owner.h"
 #include "drivers/gles3/shaders/canvas_sdf.glsl.gen.h"
@@ -40,6 +42,7 @@
 #include "servers/rendering/rendering_server_enums.h"
 #include "servers/rendering/rendering_server_types.h"
 #include "servers/rendering/storage/texture_storage.h"
+#include "servers/rendering/storage/utilities.h"
 
 #include <platform_gl.h>
 
@@ -346,6 +349,51 @@ private:
 	RSE::CanvasItemTextureRepeat state_repeat = RSE::CANVAS_ITEM_TEXTURE_REPEAT_MAX;
 };
 
+struct Decal {
+	Vector3 size = Vector3(2, 2, 2);
+	RID textures[RSE::DECAL_TEXTURE_MAX];
+	float emission_energy = 1.0;
+	float albedo_mix = 1.0;
+	Color modulate = Color(1, 1, 1, 1);
+	uint32_t cull_mask = (1 << 20) - 1;
+	float upper_fade = 0.3;
+	float lower_fade = 0.3;
+	bool distance_fade = false;
+	float distance_fade_begin = 40.0;
+	float distance_fade_length = 10.0;
+	float normal_fade = 0.0;
+
+	Dependency dependency;
+};
+
+#define MAX_DECAL_CULL 8
+
+struct DecalInstance {
+	RID decal;
+	Transform3D transform;
+	float sorting_offset = 0.0;
+	uint32_t cull_mask = 0;
+	int32_t decal_id = -1;
+};
+
+struct DecalData {
+	float xform[16];
+	float inv_extents[3];
+	float albedo_mix;
+	float albedo_rect[4];
+	float normal_rect[4];
+	float orm_rect[4];
+	float emission_rect[4];
+	float modulate[4];
+	float emission_energy;
+	uint32_t mask;
+	float upper_fade;
+	float lower_fade;
+	float normal_xform[12];
+	float normal[3];
+	float normal_fade;
+};
+
 struct RenderTarget {
 	Point2i position = Point2i(0, 0);
 	Size2i size = Size2i(0, 0);
@@ -433,6 +481,73 @@ private:
 	mutable RID_Owner<Texture, true> texture_owner;
 
 	Ref<Image> _get_gl_image_and_format(const Ref<Image> &p_image, Image::Format p_format, Image::Format &r_real_format, GLenum &r_gl_format, GLenum &r_gl_internal_format, GLenum &r_gl_type, bool &r_compressed, bool p_force_decompress) const;
+
+	/* DECAL API */
+
+	struct DecalAtlas {
+		struct Texture {
+			int users;
+			Rect2 uv_rect;
+		};
+
+		struct SortItem {
+			RID texture;
+			Size2i pixel_size;
+			Size2i size;
+			Point2i pos;
+
+			bool operator<(const SortItem &p_item) const {
+				//sort larger to smaller
+				if (size.height == p_item.size.height) {
+					return size.width > p_item.size.width;
+				} else {
+					return size.height > p_item.size.height;
+				}
+			}
+		};
+
+		HashMap<RID, Texture> textures;
+		bool dirty = true;
+		int mipmaps = 5;
+
+		GLuint texture = 0;
+		GLuint framebuffer = 0;
+		Size2i size;
+		RSE::DecalFilter filter_state = RSE::DECAL_FILTER_NEAREST;
+	} decal_atlas;
+
+	mutable RID_Owner<Decal, true> decal_owner;
+
+	/* DECAL INSTANCE API */
+
+	struct DecalIDAllocator {
+		LocalVector<bool> allocations;
+		LocalVector<uint8_t> map;
+		LocalVector<uint64_t> last_pass;
+	} decal_id_allocator;
+
+	int32_t allocate_decal_id();
+	void free_decal_id(int32_t p_id);
+	void map_decal_id(int32_t p_id, uint32_t p_index, uint64_t p_last_pass);
+
+	mutable RID_Owner<DecalInstance> decal_instance_owner;
+
+	/* DECAL DATA (UBO) */
+
+	struct DecalInstanceSort {
+		float depth;
+		DecalInstance *decal_instance;
+		Decal *decal;
+		bool operator<(const DecalInstanceSort &p_sort) const {
+			return depth < p_sort.depth;
+		}
+	};
+
+	uint32_t max_decals = 0;
+	uint32_t decal_count = 0;
+	DecalData *decals = nullptr;
+	DecalInstanceSort *decal_sort = nullptr;
+	GLuint decal_buffer = 0;
 
 	/* TEXTURE ATLAS API */
 
@@ -636,9 +751,11 @@ public:
 
 	/* DECAL API */
 
+	bool owns_decal(RID p_rid) const { return decal_owner.owns(p_rid); }
+
 	virtual RID decal_allocate() override;
-	virtual void decal_initialize(RID p_rid) override;
-	virtual void decal_free(RID p_rid) override {}
+	virtual void decal_initialize(RID p_decal) override;
+	virtual void decal_free(RID p_decal) override;
 
 	virtual void decal_set_size(RID p_decal, const Vector3 &p_size) override;
 	virtual void decal_set_texture(RID p_decal, RSE::DecalTexture p_type, RID p_texture) override;
@@ -651,17 +768,73 @@ public:
 	virtual void decal_set_normal_fade(RID p_decal, float p_fade) override;
 
 	virtual AABB decal_get_aabb(RID p_decal) const override;
-	virtual uint32_t decal_get_cull_mask(RID p_decal) const override { return 0; }
+	virtual uint32_t decal_get_cull_mask(RID p_decal) const override;
 
-	virtual void texture_add_to_decal_atlas(RID p_texture, bool p_panorama_to_dp = false) override {}
-	virtual void texture_remove_from_decal_atlas(RID p_texture, bool p_panorama_to_dp = false) override {}
+	Dependency *decal_get_dependency(RID p_decal);
+
+	/* DECAL ATLAS API */
+
+	void update_decal_atlas();
+
+	GLuint decal_atlas_get_texture() const;
+	_FORCE_INLINE_ Rect2 decal_atlas_get_texture_rect(RID p_texture) {
+		DecalAtlas::Texture *t = decal_atlas.textures.getptr(p_texture);
+		if (!t) {
+			return Rect2();
+		}
+
+		return t->uv_rect;
+	}
+	void decal_atlas_set_filter(RSE::DecalFilter p_filter, bool p_force = false);
+
+	virtual void texture_add_to_decal_atlas(RID p_texture, bool p_panorama_to_dp = false) override;
+	virtual void texture_remove_from_decal_atlas(RID p_texture, bool p_panorama_to_dp = false) override;
+	void decal_atlas_mark_dirty_on_texture(RID p_texture);
+	void decal_atlas_remove_texture(RID p_texture);
 
 	/* DECAL INSTANCE */
 
-	virtual RID decal_instance_create(RID p_decal) override { return RID(); }
-	virtual void decal_instance_free(RID p_decal_instance) override {}
-	virtual void decal_instance_set_transform(RID p_decal, const Transform3D &p_transform) override {}
-	virtual void decal_instance_set_sorting_offset(RID p_decal_instance, float p_sorting_offset) override {}
+	bool owns_decal_instance(RID p_rid) const { return decal_instance_owner.owns(p_rid); }
+
+	virtual RID decal_instance_create(RID p_decal) override;
+	virtual void decal_instance_free(RID p_decal_instance) override;
+	virtual void decal_instance_set_transform(RID p_decal_instance, const Transform3D &p_transform) override;
+	virtual void decal_instance_set_sorting_offset(RID p_decal_instance, float p_sorting_offset) override;
+
+	_FORCE_INLINE_ RID decal_instance_get_base(RID p_decal_instance) const {
+		DecalInstance *di = decal_instance_owner.get_or_null(p_decal_instance);
+		return di->decal;
+	}
+
+	_FORCE_INLINE_ Transform3D decal_instance_get_transform(RID p_decal_instance) const {
+		DecalInstance *di = decal_instance_owner.get_or_null(p_decal_instance);
+		return di->transform;
+	}
+
+	_FORCE_INLINE_ int32_t decal_instance_get_decal_id(RID p_decal_instance) const {
+		DecalInstance *di = decal_instance_owner.get_or_null(p_decal_instance);
+		return di->decal_id;
+	}
+
+	_FORCE_INLINE_ void decal_instance_set_cullmask(RID p_decal_instance, uint32_t p_cull_mask) const {
+		DecalInstance *di = decal_instance_owner.get_or_null(p_decal_instance);
+		di->cull_mask = p_cull_mask;
+	}
+
+	_FORCE_INLINE_ uint64_t get_decal_last_pass(int32_t p_decal_id) {
+		return decal_id_allocator.last_pass[p_decal_id];
+	}
+
+	_FORCE_INLINE_ uint8_t get_decal_map(int32_t p_decal_id) {
+		return decal_id_allocator.map[p_decal_id];
+	}
+
+	/* DECAL DATA API */
+
+	void free_decal_data();
+	void set_max_decals(const uint32_t p_max_decals);
+	GLuint get_decal_buffer() { return decal_buffer; }
+	void update_decal_buffer(const PagedArray<RID> &p_decals, const Transform3D &p_camera_xform);
 
 	/* RENDER TARGET API */
 

--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -165,6 +165,8 @@ RSE::InstanceType Utilities::get_base_type(RID p_rid) const {
 		return RSE::INSTANCE_REFLECTION_PROBE;
 	} else if (GLES3::ParticlesStorage::get_singleton()->owns_particles_collision(p_rid)) {
 		return RSE::INSTANCE_PARTICLES_COLLISION;
+	} else if (GLES3::TextureStorage::get_singleton()->owns_decal(p_rid)) {
+		return RSE::INSTANCE_DECAL;
 	} else if (owns_visibility_notifier(p_rid)) {
 		return RSE::INSTANCE_VISIBLITY_NOTIFIER;
 	}
@@ -223,6 +225,9 @@ bool Utilities::free(RID p_rid) {
 	} else if (GLES3::MeshStorage::get_singleton()->owns_skeleton(p_rid)) {
 		GLES3::MeshStorage::get_singleton()->skeleton_free(p_rid);
 		return true;
+	} else if (GLES3::TextureStorage::get_singleton()->owns_decal(p_rid)) {
+		GLES3::TextureStorage::get_singleton()->decal_free(p_rid);
+		return true;
 	} else if (owns_visibility_notifier(p_rid)) {
 		visibility_notifier_free(p_rid);
 		return true;
@@ -254,6 +259,9 @@ void Utilities::base_update_dependency(RID p_base, DependencyTracker *p_instance
 		p_instance->update_dependency(dependency);
 	} else if (ParticlesStorage::get_singleton()->owns_particles_collision(p_base)) {
 		Dependency *dependency = ParticlesStorage::get_singleton()->particles_collision_get_dependency(p_base);
+		p_instance->update_dependency(dependency);
+	} else if (TextureStorage::get_singleton()->owns_decal(p_base)) {
+		Dependency *dependency = TextureStorage::get_singleton()->decal_get_dependency(p_base);
 		p_instance->update_dependency(dependency);
 	} else if (owns_visibility_notifier(p_base)) {
 		VisibilityNotifier *vn = get_visibility_notifier(p_base);
@@ -398,6 +406,7 @@ void Utilities::update_dirty_resources() {
 	MeshStorage::get_singleton()->_update_dirty_skeletons();
 	MeshStorage::get_singleton()->_update_dirty_multimeshes();
 	TextureStorage::get_singleton()->update_texture_atlas();
+	TextureStorage::get_singleton()->update_decal_atlas();
 }
 
 void Utilities::set_debug_generate_wireframes(bool p_generate) {

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -179,8 +179,8 @@ void Decal::_validate_property(PropertyInfo &p_property) const {
 PackedStringArray Decal::get_configuration_warnings() const {
 	PackedStringArray warnings = VisualInstance3D::get_configuration_warnings();
 
-	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility" || OS::get_singleton()->get_current_rendering_method() == "dummy") {
-		warnings.push_back(RTR("Decals are only available when using the Forward+ or Mobile renderer."));
+	if (OS::get_singleton()->get_current_rendering_method() == "dummy") {
+		warnings.push_back(RTR("Decals are not available when using the dummy renderer."));
 		return warnings;
 	}
 

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1542,9 +1542,9 @@ void main() {
 		if (decals.data[decal_index].emission_rect != vec4(0.0)) {
 			//emission is additive, so its independent from albedo
 			if (sc_decal_use_mipmaps()) {
-				emission += hvec3(textureGrad(sampler2D(decal_atlas_srgb, decal_sampler), uv_local.xz * decals.data[decal_index].emission_rect.zw + decals.data[decal_index].emission_rect.xy, ddx * decals.data[decal_index].emission_rect.zw, ddy * decals.data[decal_index].emission_rect.zw).xyz * decals.data[decal_index].emission_energy * fade);
+				emission += hvec3(textureGrad(sampler2D(decal_atlas_srgb, decal_sampler), uv_local.xz * decals.data[decal_index].emission_rect.zw + decals.data[decal_index].emission_rect.xy, ddx * decals.data[decal_index].emission_rect.zw, ddy * decals.data[decal_index].emission_rect.zw).xyz * decals.data[decal_index].modulate.rgb * decals.data[decal_index].emission_energy * fade);
 			} else {
-				emission += hvec3(textureLod(sampler2D(decal_atlas_srgb, decal_sampler), uv_local.xz * decals.data[decal_index].emission_rect.zw + decals.data[decal_index].emission_rect.xy, 0.0).xyz * decals.data[decal_index].emission_energy * fade);
+				emission += hvec3(textureLod(sampler2D(decal_atlas_srgb, decal_sampler), uv_local.xz * decals.data[decal_index].emission_rect.zw + decals.data[decal_index].emission_rect.xy, 0.0).xyz * decals.data[decal_index].modulate.rgb * decals.data[decal_index].emission_energy * fade);
 			}
 		}
 	}

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3813,6 +3813,7 @@ void RenderingServer::init() {
 
 	// OpenGL limits
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/limits/opengl/max_renderable_elements", PROPERTY_HINT_RANGE, "1024,65536,1"), 65536);
+	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/limits/opengl/max_decals", PROPERTY_HINT_RANGE, "2,512,1"), 64);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/limits/opengl/max_renderable_lights", PROPERTY_HINT_RANGE, "2,256,1"), 32);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/limits/opengl/max_lights_per_object", PROPERTY_HINT_RANGE, "2,1024,1"), 8);
 


### PR DESCRIPTION
This PR adds decal support to the compatibility renderer. It is based on the approach taken in the mobile renderer, adjusted for OpenGL.

- Maximum number of decals in one frame is determined by buffer limits on the hardware, we cap it by default to 64 with a project setting. On my GPU I could configure this up to approx 270 decals.
- Max 8 decals per surface, this is a hard limit

<img width="1920" height="1112" alt="image" src="https://github.com/user-attachments/assets/26f2148b-f35e-40ac-961c-b249697132eb" />

- *Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/discussions/12903.*
