### PR TITLE
Remove experimental flag from EditorDock

### DIFF
--- a/doc/classes/EditorDock.xml
+++ b/doc/classes/EditorDock.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="EditorDock" inherits="MarginContainer" api_type="editor" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="EditorDock" inherits="MarginContainer" api_type="editor" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Dockable container for the editor.
 	</brief_description>


### PR DESCRIPTION
The EditorDock's API is not going to have any major changes anymore (it's not like it can at this point xd), so the flag is no longer necessary.