### PR TITLE
Fix minimum height of Output buttons

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -114,16 +114,16 @@ void EditorLog::_update_theme() {
 
 	Button *button = type_filter_map[MSG_TYPE_STD]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("Popup")));
-	button->set_custom_minimum_size(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()) * EDSCALE);
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
 	button = type_filter_map[MSG_TYPE_ERROR]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("StatusError")));
-	button->set_custom_minimum_size(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()) * EDSCALE);
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
 	button = type_filter_map[MSG_TYPE_WARNING]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("StatusWarning")));
-	button->set_custom_minimum_size(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()) * EDSCALE);
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
 	button = type_filter_map[MSG_TYPE_EDITOR]->toggle_button;
 	button->set_button_icon(get_editor_theme_icon(SNAME("Edit")));
-	button->set_custom_minimum_size(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()) * EDSCALE);
+	button->set_custom_minimum_size(Vector2(button->get_minimum_size_for_text_and_icon(wide_text, button->get_button_icon()).x * EDSCALE, 0));
 
 	clear_button->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
 	collapse_button->set_button_icon(get_editor_theme_icon(SNAME("CombineLines")));


### PR DESCRIPTION
Output buttons were setting minimum size to make space for digits, but they should only set minimum width, not the whole size.

Should resolve https://github.com/godotengine/godot/pull/112690#issuecomment-4140843187
<img width="477" height="84" alt="image" src="https://github.com/user-attachments/assets/6aca9076-7262-44c0-a8a2-ce427d982a8d" />
