### PR TITLE
Fix close dropdown popups correctly on focus loss (X11)

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4892,14 +4892,8 @@ void DisplayServerX11::process_events() {
 	bool ignore_events = mouse_process_popups();
 
 	if (app_focused) {
-		//verify that one of the windows has focus, else send focus out notification
-		bool focus_found = false;
-		for (const KeyValue<DisplayServerEnums::WindowID, WindowData> &E : windows) {
-			if (E.value.focused) {
-				focus_found = true;
-				break;
-			}
-		}
+		// Verify that one of the windows has focus, else send focus out notification.
+		bool focus_found = _window_focus_check();
 
 		if (!focus_found) {
 			uint64_t delta = OS::get_singleton()->get_ticks_msec() - time_since_no_focus;
@@ -4909,6 +4903,12 @@ void DisplayServerX11::process_events() {
 				if (OS::get_singleton()->get_main_loop()) {
 					DEBUG_LOG_X11("All focus lost, triggering NOTIFICATION_APPLICATION_FOCUS_OUT\n");
 					OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
+				}
+				// Clear stale focus state on no-focus popups when the app loses focus.
+				for (KeyValue<DisplayServerEnums::WindowID, WindowData> &E : windows) {
+					if (E.value.focused && E.value.is_popup && E.value.no_focus) {
+						E.value.focused = false;
+					}
 				}
 				app_focused = false;
 			}


### PR DESCRIPTION
Fixes #104267
Fixes an X11 issue where dropdown menus and similar popups could remain open after switching to another window or workspace.

On X11, some no_focus popup windows could remain internally marked as focused even after the application had actually lost focus. This stale focus state prevented the normal application focus loss path from fully updating popup state, which could leave dropdowns visible after Alt-Tab or workspace switching.

This change keeps the fix X11-specific, the only place I verified the bug occurred in my system as opposed to Wayland, by:

using _window_focus_check() to determine whether the application still has focus
clearing stale focused state for is_popup && no_focus windows only when the application has actually lost focus

Manual Testing:
(On X11 display server)
Open an editor dropdown menu, Alt-Tab away: popup no longer persists
Open an editor dropdown menu, switch workspace: popup no longer persists
Verify normal popup dismissal still works inside the editor

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
