### PR TITLE
Fix mistake in folder name validation

### DIFF
--- a/editor/gui/directory_create_dialog.cpp
+++ b/editor/gui/directory_create_dialog.cpp
@@ -68,7 +68,7 @@ String DirectoryCreateDialog::_validate_path(const String &p_path) const {
 			}
 		}
 		if (part.contains_char('\\') || part.contains_char(':') || part.contains_char('*') ||
-				part.contains_char('|') || part.contains_char('>') || part.ends_with(".") || part.ends_with(" ")) {
+				part.contains_char('|') || part.contains_char('>') || part.contains_char('<') || part.contains_char('?') || part.contains_char('"') || part.ends_with(".") || part.ends_with(" ")) {
 			if (is_file) {
 				return TTR("File name contains invalid characters.");
 			} else {


### PR DESCRIPTION
fix #118029
There have already been codes that judges whether folder name contains invalid character, but it missed ? < and ",so I simply add the three character.
