### PR TITLE
Only propagate physics server transforms when different

### DIFF
--- a/scene/2d/physics/rigid_body_2d.cpp
+++ b/scene/2d/physics/rigid_body_2d.cpp
@@ -148,9 +148,10 @@ struct _RigidBody2DInOut {
 };
 
 void RigidBody2D::_sync_body_state(PhysicsDirectBodyState2D *p_state) {
-	if (!freeze || freeze_mode != FREEZE_MODE_KINEMATIC) {
+	Transform2D new_transform = p_state->get_transform();
+	if (likely(new_transform != get_global_transform())) {
 		set_block_transform_notify(true);
-		set_global_transform(p_state->get_transform());
+		set_global_transform(new_transform);
 		set_block_transform_notify(false);
 	}
 

--- a/scene/3d/physics/physical_bone_3d.cpp
+++ b/scene/3d/physics/physical_bone_3d.cpp
@@ -791,9 +791,12 @@ void PhysicalBone3D::_notification(int p_what) {
 }
 
 void PhysicalBone3D::_sync_body_state(PhysicsDirectBodyState3D *p_state) {
-	set_ignore_transform_notification(true);
-	set_global_transform(p_state->get_transform());
-	set_ignore_transform_notification(false);
+	Transform3D new_transform = p_state->get_transform();
+	if (likely(new_transform != get_global_transform())) {
+		set_ignore_transform_notification(true);
+		set_global_transform(new_transform);
+		set_ignore_transform_notification(false);
+	}
 
 	linear_velocity = p_state->get_linear_velocity();
 	angular_velocity = p_state->get_angular_velocity();

--- a/scene/3d/physics/rigid_body_3d.cpp
+++ b/scene/3d/physics/rigid_body_3d.cpp
@@ -147,9 +147,12 @@ struct _RigidBodyInOut {
 };
 
 void RigidBody3D::_sync_body_state(PhysicsDirectBodyState3D *p_state) {
-	set_ignore_transform_notification(true);
-	set_global_transform(p_state->get_transform());
-	set_ignore_transform_notification(false);
+	Transform3D new_transform = p_state->get_transform();
+	if (likely(new_transform != get_global_transform())) {
+		set_ignore_transform_notification(true);
+		set_global_transform(new_transform);
+		set_ignore_transform_notification(false);
+	}
 
 	linear_velocity = p_state->get_linear_velocity();
 	angular_velocity = p_state->get_angular_velocity();


### PR DESCRIPTION
Fixes #117852.
Fixes #118077.
Supersedes #117964.

This changes the physics server state synchronization for `RigidBody2D`, `RigidBody3D` and `PhysicalBone3D` to check if the transform has actually changed before calling `set_global_transform` with said transform.

`RigidBody2D` was seemingly trying to do this for frozen/kinematic bodies already, by just ignoring transform updates completely, but doing so results in transform desync (#118077).

Note that this isn't strictly needed for `PhysicalBone3D`, since it doesn't currently support freezing, but that's something that definitely should be added at some point, at which point this fix will kick in there as well.

I suspect this change is also applicable to `AnimatableBody*D`, as there seems to be issues with redundant `NOTIFICATION_TRANSFORM_CHANGED` notifications when `sync_to_physics` is enabled, but I'm having trouble reasoning about potential regressions there, and it's not as pressing of an issue, so I'm leaving them alone for now.