### PR TITLE
Add HDR output support to Vulkan on macOS.

### DIFF
--- a/drivers/apple_embedded/display_server_apple_embedded.mm
+++ b/drivers/apple_embedded/display_server_apple_embedded.mm
@@ -837,6 +837,7 @@ void DisplayServerAppleEmbedded::_update_hdr_output(bool edr_headroom_changed) {
 
 	float reference_luminance = _calculate_current_reference_luminance();
 	rendering_context->window_set_hdr_output_reference_luminance(DisplayServerEnums::MAIN_WINDOW_ID, reference_luminance);
+	rendering_context->window_set_hdr_output_linear_luminance_scale(DisplayServerEnums::MAIN_WINDOW_ID, reference_luminance);
 
 	float max_luminance = _screen_potential_edr_headroom() * hardware_reference_luminance_nits;
 	rendering_context->window_set_hdr_output_max_luminance(DisplayServerEnums::MAIN_WINDOW_ID, max_luminance);

--- a/drivers/metal/rendering_context_driver_metal.cpp
+++ b/drivers/metal/rendering_context_driver_metal.cpp
@@ -461,11 +461,13 @@ float RenderingContextDriverMetal::surface_get_hdr_output_max_luminance(SurfaceI
 }
 
 void RenderingContextDriverMetal::surface_set_hdr_output_linear_luminance_scale(SurfaceID p_surface, float p_linear_luminance_scale) {
+	Surface *surface = (Surface *)(p_surface);
+	surface->hdr_linear_luminance_scale = p_linear_luminance_scale;
 }
 
 float RenderingContextDriverMetal::surface_get_hdr_output_linear_luminance_scale(SurfaceID p_surface) const {
 	Surface *surface = (Surface *)(p_surface);
-	return surface->hdr_reference_luminance;
+	return surface->hdr_linear_luminance_scale;
 }
 
 float RenderingContextDriverMetal::surface_get_hdr_output_max_value(SurfaceID p_surface) const {

--- a/drivers/metal/rendering_context_driver_metal.h
+++ b/drivers/metal/rendering_context_driver_metal.h
@@ -98,6 +98,8 @@ public:
 		// to be a more pleasant player-facing value.
 		float hdr_reference_luminance = 200.0f;
 		float hdr_max_luminance = 1000.0f;
+		// linear_luminance_scale must always equal hdr_reference_luminance on Apple platforms.
+		float hdr_linear_luminance_scale = 200.0f;
 		bool needs_resize = false;
 		bool hdr_output = false;
 

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -7332,8 +7332,8 @@ bool RenderingDeviceDriverVulkan::has_feature(Features p_feature) {
 			// involving integrated GPU hardware do not function correctly
 			// with HDR output.
 			return false;
-#elif defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
-			// HDR support has not yet been thoroughly tested and validated for Apple platforms.
+#elif defined(APPLE_EMBEDDED_ENABLED)
+			// HDR output with Vulkan currently does not function correctly on iOS. (Tested on iPhone 13 Pro, iOS 26.3.1(a))
 			return false;
 #else
 			return context_driver->is_colorspace_supported();

--- a/platform/macos/display_server_macos_base.mm
+++ b/platform/macos/display_server_macos_base.mm
@@ -569,6 +569,7 @@ void DisplayServerMacOSBase::_update_hdr_output(DisplayServerEnums::WindowID p_w
 	float current_ref_luminance = rendering_context->window_get_hdr_output_reference_luminance(p_window);
 	if (!Math::is_equal_approx(current_ref_luminance, new_reference_luminance)) {
 		rendering_context->window_set_hdr_output_reference_luminance(p_window, new_reference_luminance);
+		rendering_context->window_set_hdr_output_linear_luminance_scale(p_window, new_reference_luminance);
 		hdr_state_changed = true;
 	}
 


### PR DESCRIPTION
### What problem(s) does this PR solve?

- HDR output does not function with the Vulkan rendering device driver on macOS.
- Users targeting macOS with HDR support must check project settings to ensure they are not using the Vulkan driver. This complicates the debugging experience for users.
- Documentation for HDR output is a tiny bit more complicated by needing to note that Vulkan does not support HDR output on macOS.

### What is the rationale for the approach used in this PR?

When HDR output support was added to Apple platforms, the PR was pretty big and there was a lot to test. At the time, we [decided that Vulkan support would be better suited for a followup PR](https://github.com/godotengine/godot/pull/106814#issuecomment-3886589015). This is that followup PR.

**iOS**

I tested iOS vulkan support on my iPhone 13 Pro and it doesn't work well. If I switch from an HDR app to my vulkan Godot app, it appears like HDR output works well for a moment, and then snaps down to 1.2 max linear value. After a few moments, it will drop to a max linear value of 1.0 and stay there. Strange behaviour. Smells like an iOS vulkan driver bug to me. Probably best to just leave iOS not supporting HDR output on Vulkan until someone wants to figure out what's going on.

(Note for those who know the history: [I was wrong with my initial guess about why Vulkan wasn't working](https://github.com/godotengine/godot/pull/106814#issuecomment-3886550928). Turns out linear luminance scale needs to be reference luminance on Vulkan as well. My apologies!)

### Was generative AI (LLM AI) used to create a portion of this PR?

No.

### Are there any parts of this PR that you are uncertain of or require special attention from reviewers?

- I believe that it would be better to merge this sooner rather than later, specifically before Godot 4.7 goes into feature freeze/beta. This way we will get maximum testing of Vulkan HDR output on macOS during the beta period. In the future, it may be a lot harder to get real-world testing of this feature. If this turns out to be broken, we can always roll back support before 4.7 goes stable.

I've tested on my Macbook Pro with an external display connected and everything seems to be working great.