### PR TITLE
Fix 3D zoom indicator not showing in editor 

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2995,6 +2995,11 @@ void Node3DEditorViewport::_cursor_interpolated() {
 	spatial_editor->update_grid();
 }
 
+void Node3DEditorViewport::_cursor_distance_scaled() {
+	zoom_indicator_delay = ZOOM_FREELOOK_INDICATOR_DELAY_S;
+	surface->queue_redraw();
+}
+
 void Node3DEditorViewport::_freelook_changed() {
 	spatial_editor->set_freelook_viewport(view_3d_controller->is_freelook_enabled() ? this : nullptr);
 }
@@ -7052,6 +7057,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	view_3d_controller->connect("freelook_speed_scaled", callable_mp(this, &Node3DEditorViewport::_freelook_speed_scaled));
 	view_3d_controller->connect("cursor_panned", callable_mp(this, &Node3DEditorViewport::_disable_follow_mode));
 	view_3d_controller->connect("cursor_interpolated", callable_mp(this, &Node3DEditorViewport::_cursor_interpolated));
+	view_3d_controller->connect("cursor_distance_scaled", callable_mp(this, &Node3DEditorViewport::_cursor_distance_scaled));
 	_update_view_3d_controller(true);
 
 	_update_name();

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -394,6 +394,7 @@ private:
 	void _update_view_3d_controller(bool p_update_all = true);
 
 	void _cursor_interpolated();
+	void _cursor_distance_scaled();
 
 	void _freelook_changed();
 	void _freelook_speed_scaled();

--- a/scene/debugger/view_3d_controller.cpp
+++ b/scene/debugger/view_3d_controller.cpp
@@ -619,6 +619,8 @@ void View3DController::scale_cursor_distance(const float p_scale) {
 	} else {
 		zoom_failed_attempts_count = 0;
 	}
+
+	emit_signal(SNAME("cursor_distance_scaled"));
 }
 
 void View3DController::set_shortcut(const ShortcutName p_name, const Ref<Shortcut> &p_shortcut) {
@@ -792,6 +794,7 @@ void View3DController::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("cursor_panned"));
 	ADD_SIGNAL(MethodInfo("cursor_interpolated"));
+	ADD_SIGNAL(MethodInfo("cursor_distance_scaled"));
 }
 
 #endif // _3D_DISABLED


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Regression from: https://github.com/godotengine/godot/pull/115957 CC: @YeldhamDev 

<img width="260" height="447" alt="image" src="https://github.com/user-attachments/assets/26596972-619a-457a-9cf2-acfcfab57454" />
