### PR TITLE
Fix clashing shortcut between camera preview and quick open on Win/Linux

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -6800,8 +6800,11 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	preview_camera = memnew(CheckBox);
 	preview_camera->set_text(TTRC("Preview"));
 	preview_camera->set_tooltip_text(TTRC("Preview through the selected camera.\nHold Shift while clicking to also enable Pilot mode."));
-	// Using Control even on macOS to avoid conflict with Quick Open shortcut.
-	preview_camera->set_shortcut(ED_SHORTCUT("spatial_editor/toggle_camera_preview", TTRC("Toggle Camera Preview"), KeyModifierMask::CTRL | Key::P));
+	// Quick Open uses Ctrl+P on Win/Linux (Cmd+P on macOS). 
+	// macOS keeps Ctrl+P (distinct from Cmd+P for Quick Open) for camera preview but on Win/Linux it's Shift+P.
+	ED_SHORTCUT("spatial_editor/toggle_camera_preview", TTRC("Toggle Camera Preview"), KeyModifierMask::SHIFT | Key::P);
+	ED_SHORTCUT_OVERRIDE("spatial_editor/toggle_camera_preview", "macos", KeyModifierMask::CTRL | Key::P);
+	preview_camera->set_shortcut(ED_GET_SHORTCUT("spatial_editor/toggle_camera_preview"));
 	vbox->add_child(preview_camera);
 	preview_camera->set_h_size_flags(0);
 	preview_camera->set_theme_type_variation("CheckBoxNoIconTint");

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4333,7 +4333,7 @@ int Main::start() {
 #endif
 
 	MainLoop *main_loop = nullptr;
-	if (editor) {
+	if (editor && script.is_empty()) {
 		main_loop = memnew(SceneTree);
 	}
 	if (main_loop_type.is_empty()) {


### PR DESCRIPTION
Fix  #118069.

Both `spatial_editor` and `toggle_camera_preview` use ctrl+P, which opens Quick Open, on Windows/Linux. 

My suggestion: Change `toggle_camera_preview` to shift+P on Win/Linux. Mac behaviors stay the same. Cmd+P opens Quick Open and Ctrl+P toggles camera preview.