### PR TITLE
Fix scenetree conflict in editor script

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4333,7 +4333,7 @@ int Main::start() {
 #endif
 
 	MainLoop *main_loop = nullptr;
-	if (editor) {
+	if (editor && script.is_empty()) {
 		main_loop = memnew(SceneTree);
 	}
 	if (main_loop_type.is_empty()) {


### PR DESCRIPTION
Fix #118053.

Avoid the allocation of SceneTree when --script is used.

