### PR TITLE
Use `iterate_children()` in Container nodes

### DIFF
--- a/scene/gui/aspect_ratio_container.cpp
+++ b/scene/gui/aspect_ratio_container.cpp
@@ -35,8 +35,8 @@
 
 Size2 AspectRatioContainer::get_minimum_size() const {
 	Size2 ms;
-	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i), SortableVisibilityMode::VISIBLE);
+	for (Node *child : iterate_children()) {
+		Control *c = as_sortable_control(child, SortableVisibilityMode::VISIBLE);
 		if (!c) {
 			continue;
 		}
@@ -101,8 +101,8 @@ void AspectRatioContainer::_notification(int p_what) {
 		case NOTIFICATION_SORT_CHILDREN: {
 			bool rtl = is_layout_rtl();
 			Size2 size = get_size();
-			for (int i = 0; i < get_child_count(); i++) {
-				Control *c = as_sortable_control(get_child(i));
+			for (Node *child : iterate_children()) {
+				Control *c = as_sortable_control(child);
 				if (!c) {
 					continue;
 				}

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -55,8 +55,8 @@ void BoxContainer::_resort() {
 	float stretch_ratio_total = 0.0;
 	HashMap<Control *, _MinSizeCache> min_size_cache;
 
-	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i));
+	for (Node *child : iterate_children()) {
+		Control *c = as_sortable_control(child);
 		if (!c) {
 			continue;
 		}

--- a/scene/gui/center_container.cpp
+++ b/scene/gui/center_container.cpp
@@ -37,8 +37,8 @@ Size2 CenterContainer::get_minimum_size() const {
 		return Size2();
 	}
 	Size2 ms;
-	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i), SortableVisibilityMode::VISIBLE);
+	for (Node *child : iterate_children()) {
+		Control *c = as_sortable_control(child, SortableVisibilityMode::VISIBLE);
 		if (!c) {
 			continue;
 		}
@@ -76,8 +76,8 @@ void CenterContainer::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_SORT_CHILDREN: {
 			Size2 size = get_size();
-			for (int i = 0; i < get_child_count(); i++) {
-				Control *c = as_sortable_control(get_child(i));
+			for (Node *child : iterate_children()) {
+				Control *c = as_sortable_control(child);
 				if (!c) {
 					continue;
 				}

--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -64,8 +64,8 @@ void FlowContainer::_resort() {
 	Control *last_child = nullptr;
 
 	// First pass for line wrapping and minimum size calculation.
-	for (int i = 0; i < get_child_count(); i++) {
-		Control *child = as_sortable_control(get_child(i));
+	for (Node *childn : iterate_children()) {
+		Control *child = as_sortable_control(childn);
 		if (!child) {
 			continue;
 		}
@@ -136,8 +136,8 @@ void FlowContainer::_resort() {
 	ofs.x = 0;
 	ofs.y = 0;
 
-	for (int i = 0; i < get_child_count(); i++) {
-		Control *child = as_sortable_control(get_child(i));
+	for (Node *childn : iterate_children()) {
+		Control *child = as_sortable_control(childn);
 		if (!child) {
 			continue;
 		}
@@ -268,8 +268,8 @@ void FlowContainer::_resort() {
 Size2 FlowContainer::get_minimum_size() const {
 	Size2i minimum;
 
-	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i), SortableVisibilityMode::VISIBLE);
+	for (Node *child : iterate_children()) {
+		Control *c = as_sortable_control(child, SortableVisibilityMode::VISIBLE);
 		if (!c) {
 			continue;
 		}

--- a/scene/gui/foldable_container.cpp
+++ b/scene/gui/foldable_container.cpp
@@ -42,8 +42,8 @@ Size2 FoldableContainer::get_minimum_size() const {
 	}
 	Size2 ms;
 
-	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i));
+	for (Node *child : iterate_children()) {
+		Control *c = as_sortable_control(child);
 		if (!c) {
 			continue;
 		}

--- a/scene/gui/graph_element.cpp
+++ b/scene/gui/graph_element.cpp
@@ -49,8 +49,8 @@ void GraphElement::_edit_set_position(const Point2 &p_position) {
 void GraphElement::_resort() {
 	Size2 size = get_size();
 
-	for (int i = 0; i < get_child_count(); i++) {
-		Control *child = as_sortable_control(get_child(i));
+	for (Node *childn : iterate_children()) {
+		Control *child = as_sortable_control(childn);
 		if (!child) {
 			continue;
 		}
@@ -60,8 +60,8 @@ void GraphElement::_resort() {
 
 Size2 GraphElement::get_minimum_size() const {
 	Size2 minsize;
-	for (int i = 0; i < get_child_count(); i++) {
-		Control *child = as_sortable_control(get_child(i), SortableVisibilityMode::IGNORE);
+	for (Node *childn : iterate_children()) {
+		Control *child = as_sortable_control(childn, SortableVisibilityMode::IGNORE);
 		if (!child) {
 			continue;
 		}

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -45,8 +45,8 @@ void GridContainer::_notification(int p_what) {
 
 			// Compute the per-column/per-row data.
 			int valid_controls_index = 0;
-			for (int i = 0; i < get_child_count(); i++) {
-				Control *c = as_sortable_control(get_child(i));
+			for (Node *child : iterate_children()) {
+				Control *c = as_sortable_control(child);
 				if (!c) {
 					continue;
 				}
@@ -184,8 +184,8 @@ void GridContainer::_notification(int p_what) {
 			}
 
 			valid_controls_index = 0;
-			for (int i = 0; i < get_child_count(); i++) {
-				Control *c = as_sortable_control(get_child(i));
+			for (Node *child : iterate_children()) {
+				Control *c = as_sortable_control(child);
 				if (!c) {
 					continue;
 				}
@@ -280,8 +280,8 @@ Size2 GridContainer::get_minimum_size() const {
 	int max_col = 0;
 
 	int valid_controls_index = 0;
-	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i), SortableVisibilityMode::VISIBLE);
+	for (Node *child : iterate_children()) {
+		Control *c = as_sortable_control(child, SortableVisibilityMode::VISIBLE);
 		if (!c) {
 			continue;
 		}

--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -35,8 +35,8 @@
 Size2 MarginContainer::get_minimum_size() const {
 	Size2 max;
 
-	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i), SortableVisibilityMode::VISIBLE);
+	for (Node *child : iterate_children()) {
+		Control *c = as_sortable_control(child, SortableVisibilityMode::VISIBLE);
 		if (!c) {
 			continue;
 		}
@@ -96,8 +96,8 @@ void MarginContainer::_notification(int p_what) {
 		case NOTIFICATION_SORT_CHILDREN: {
 			Size2 s = get_size();
 
-			for (int i = 0; i < get_child_count(); i++) {
-				Control *c = as_sortable_control(get_child(i));
+			for (Node *child : iterate_children()) {
+				Control *c = as_sortable_control(child);
 				if (!c) {
 					continue;
 				}

--- a/scene/gui/panel_container.cpp
+++ b/scene/gui/panel_container.cpp
@@ -34,8 +34,8 @@
 
 Size2 PanelContainer::get_minimum_size() const {
 	Size2 ms;
-	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i), SortableVisibilityMode::VISIBLE);
+	for (Node *child : iterate_children()) {
+		Control *c = as_sortable_control(child, SortableVisibilityMode::VISIBLE);
 		if (!c) {
 			continue;
 		}
@@ -83,8 +83,8 @@ void PanelContainer::_notification(int p_what) {
 				ofs += theme_cache.panel_style->get_offset();
 			}
 
-			for (int i = 0; i < get_child_count(); i++) {
-				Control *c = as_sortable_control(get_child(i));
+			for (Node *child : iterate_children()) {
+				Control *c = as_sortable_control(child);
 				if (!c) {
 					continue;
 				}

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -45,8 +45,8 @@ Size2 ScrollContainer::get_minimum_size() const {
 	// and needs to be calculated before being used by `_update_scrollbars()`.
 	largest_child_min_size = Size2();
 
-	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i), SortableVisibilityMode::VISIBLE);
+	for (Node *child : iterate_children()) {
+		Control *c = as_sortable_control(child, SortableVisibilityMode::VISIBLE);
 		if (!c || c == h_scroll || c == v_scroll || c == focus_panel || c == scroll_hint_top_left || c == scroll_hint_bottom_right) {
 			continue;
 		}
@@ -367,8 +367,8 @@ void ScrollContainer::_reposition_children() {
 		}
 	}
 
-	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i));
+	for (Node *child : iterate_children()) {
+		Control *c = as_sortable_control(child);
 		if (!c || c == h_scroll || c == v_scroll || c == focus_panel || c == scroll_hint_top_left || c == scroll_hint_bottom_right) {
 			continue;
 		}
@@ -788,8 +788,8 @@ PackedStringArray ScrollContainer::get_configuration_warnings() const {
 
 	int found = 0;
 
-	for (int i = 0; i < get_child_count(); i++) {
-		Control *c = as_sortable_control(get_child(i), SortableVisibilityMode::VISIBLE);
+	for (Node *child : iterate_children()) {
+		Control *c = as_sortable_control(child, SortableVisibilityMode::VISIBLE);
 		if (!c || c == h_scroll || c == v_scroll || c == focus_panel || c == scroll_hint_top_left || c == scroll_hint_bottom_right) {
 			continue;
 		}

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -39,8 +39,8 @@ Size2 SubViewportContainer::get_minimum_size() const {
 		return Size2();
 	}
 	Size2 ms;
-	for (int i = 0; i < get_child_count(); i++) {
-		SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
+	for (Node *child : iterate_children()) {
+		SubViewport *c = Object::cast_to<SubViewport>(child);
 		if (!c) {
 			continue;
 		}
@@ -86,8 +86,8 @@ void SubViewportContainer::recalc_force_viewport_sizes() {
 	}
 
 	// If stretch is enabled, make sure that all child SubViwewports have the correct size.
-	for (int i = 0; i < get_child_count(); i++) {
-		SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
+	for (Node *child : iterate_children()) {
+		SubViewport *c = Object::cast_to<SubViewport>(child);
 		if (!c) {
 			continue;
 		}
@@ -116,8 +116,8 @@ void SubViewportContainer::_notification(int p_what) {
 
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			for (int i = 0; i < get_child_count(); i++) {
-				SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
+			for (Node *child : iterate_children()) {
+				SubViewport *c = Object::cast_to<SubViewport>(child);
 				if (!c) {
 					continue;
 				}
@@ -133,8 +133,8 @@ void SubViewportContainer::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			for (int i = 0; i < get_child_count(); i++) {
-				SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
+			for (Node *child : iterate_children()) {
+				SubViewport *c = Object::cast_to<SubViewport>(child);
 				if (!c) {
 					continue;
 				}
@@ -162,8 +162,8 @@ void SubViewportContainer::_notification(int p_what) {
 }
 
 void SubViewportContainer::_notify_viewports(int p_notification) {
-	for (int i = 0; i < get_child_count(); i++) {
-		SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
+	for (Node *child : iterate_children()) {
+		SubViewport *c = Object::cast_to<SubViewport>(child);
 		if (!c) {
 			continue;
 		}
@@ -228,8 +228,8 @@ void SubViewportContainer::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void SubViewportContainer::_send_event_to_viewports(const Ref<InputEvent> &p_event) {
-	for (int i = 0; i < get_child_count(); i++) {
-		SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
+	for (Node *child : iterate_children()) {
+		SubViewport *c = Object::cast_to<SubViewport>(child);
 		if (!c || c->is_input_disabled()) {
 			continue;
 		}
@@ -271,8 +271,8 @@ PackedStringArray SubViewportContainer::get_configuration_warnings() const {
 	PackedStringArray warnings = Container::get_configuration_warnings();
 
 	bool has_viewport = false;
-	for (int i = 0; i < get_child_count(); i++) {
-		if (Object::cast_to<SubViewport>(get_child(i))) {
+	for (Node *child : iterate_children()) {
+		if (Object::cast_to<SubViewport>(child)) {
 			has_viewport = true;
 			break;
 		}

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -106,8 +106,7 @@ void TabContainer::_notification(int p_what) {
 
 			int tab_index = 0;
 			int tab_cur = tab_bar->get_current_tab();
-			for (int i = 0; i < get_child_count(); i++) {
-				Node *child_node = get_child(i);
+			for (Node *child_node : iterate_children()) {
 				Window *child_wnd = Object::cast_to<Window>(child_node);
 				if (child_wnd && !child_wnd->is_embedded()) {
 					continue;


### PR DESCRIPTION
Changes `for (int i = 0; i < get_child_count(); i++)` to `for (Node *child : iterate_children())` in all Container nodes where applicable. This might improve the performance a bit (especially in the editor, where there is lots of containers), but I didn't measure anything, so not adding the label.