### PR TITLE
Fix incorrect line reporting for mixed indentation errors

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -254,6 +254,19 @@ void GDScriptParser::push_error(const String &p_message, const Node *p_origin) {
 	errors.push_back(err);
 }
 
+void GDScriptParser::push_error(const String &p_message, const GDScriptTokenizer::Token &p_origin) {
+	panic_mode = true;
+
+	ParserError err;
+	err.message = p_message;
+	err.start_line = p_origin.start_line;
+	err.start_column = p_origin.start_column;
+	err.end_line = p_origin.end_line;
+	err.end_column = p_origin.end_column;
+
+	errors.push_back(err);
+}
+
 #ifdef DEBUG_ENABLED
 void GDScriptParser::push_warning(const Node *p_source, GDScriptWarning::Code p_code, const Vector<String> &p_symbols) {
 	ERR_FAIL_NULL(p_source);
@@ -486,7 +499,7 @@ Error GDScriptParser::parse(const String &p_source_code, const String &p_script_
 	// The latter can mess with the parser when opening files filled exclusively with comments and newlines.
 	while (current.type == GDScriptTokenizer::Token::ERROR || current.type == GDScriptTokenizer::Token::NEWLINE) {
 		if (current.type == GDScriptTokenizer::Token::ERROR) {
-			push_error(current.literal);
+			push_error(current.literal, current);
 		}
 		current = tokenizer->scan();
 	}
@@ -549,7 +562,7 @@ Error GDScriptParser::parse_binary(const Vector<uint8_t> &p_binary, const String
 	// The latter can mess with the parser when opening files filled exclusively with comments and newlines.
 	while (current.type == GDScriptTokenizer::Token::ERROR || current.type == GDScriptTokenizer::Token::NEWLINE) {
 		if (current.type == GDScriptTokenizer::Token::ERROR) {
-			push_error(current.literal);
+			push_error(current.literal, current);
 		}
 		current = tokenizer->scan();
 	}
@@ -577,7 +590,7 @@ GDScriptTokenizer::Token GDScriptParser::advance() {
 	previous = current;
 	current = tokenizer->scan();
 	while (current.type == GDScriptTokenizer::Token::ERROR) {
-		push_error(current.literal);
+		push_error(current.literal, current);
 		current = tokenizer->scan();
 	}
 	if (previous.type != GDScriptTokenizer::Token::DEDENT) { // `DEDENT` belongs to the next non-empty line.

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1500,6 +1500,8 @@ private:
 	void clear();
 
 	void push_error(const String &p_message, const Node *p_origin = nullptr);
+	void push_error(const String &p_message, const GDScriptTokenizer::Token &p_origin);
+
 #ifdef DEBUG_ENABLED
 	void push_warning(const Node *p_source, GDScriptWarning::Code p_code, const Vector<String> &p_symbols);
 	template <typename... Symbols>


### PR DESCRIPTION
Fixes #118004 

Tokenizer did append correct error data to the token, but the parser ignored the errors location and only forwarded the error message. As a result the reported line would come from the parsers current location rather than the location of the actual error.

This change adds a push_error(const GDScriptTokenizer::Token &p_token) overload function, without touching the old API, allowing for the full use of the error tokens data. 

Also tested: 
- Mixed indentation inside functions, if blocks, and lambdas. 
- Standard parser errors still report correct locations.

 ## Steps to reproduce 
1. Create a new project and a script. 
3. Add this code to the script:
```
gdscript
func foo() -> int:
	var bar: int = 2 # Tab  <- Error shown here
    return bar # 4 spaces   <- But should be here
```
## Screenshots 

Before: 
<img width="1089" height="295" alt="2026-04-02-124313_1089x295_scrot" src="https://github.com/user-attachments/assets/48963fc1-3eea-420c-862f-8921d415f7f4" /> 

After: 
<img width="1084" height="295" alt="2026-04-02-123838_1084x295_scrot" src="https://github.com/user-attachments/assets/db805064-82e1-431c-ae34-3d79d226c3e2" /> 
