### PR TITLE
Remove redundant TOOLS_ENABLED ifdefs

### DIFF
--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -203,9 +203,7 @@ public:
 	void set_movie_maker_enabled(bool p_enabled);
 	bool is_movie_maker_enabled() const;
 
-#ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
-#endif
 
 	// Base.
 	static void create();

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -214,9 +214,7 @@ public:
 
 	void notify_changes();
 
-#ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
-#endif
 
 	EditorSettings();
 };

--- a/platform/android/editor/editor_utils_jni.cpp
+++ b/platform/android/editor/editor_utils_jni.cpp
@@ -30,7 +30,6 @@
 
 #include "editor_utils_jni.h"
 
-#ifdef TOOLS_ENABLED
 #include "jni_utils.h"
 
 #include "core/os/os.h"
@@ -40,11 +39,9 @@
 #include "editor/gui/editor_title_bar.h"
 #include "editor/run/editor_run_bar.h"
 #include "main/main.h"
-#endif
 
 extern "C" {
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_runScene(JNIEnv *p_env, jclass, jstring p_scene, jobjectArray p_scene_args) {
-#ifdef TOOLS_ENABLED
 	Vector<String> scene_args;
 	jint length = p_env->GetArrayLength(p_scene_args);
 	for (jint i = 0; i < length; ++i) {
@@ -93,17 +90,14 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_runSc
 		Error err = OS::get_singleton()->create_instance(args);
 		ERR_FAIL_COND(err);
 	}
-#endif
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_toggleTitleBar(JNIEnv *p_env, jclass, jboolean p_visible) {
-#ifdef TOOLS_ENABLED
 	if (EditorNode::get_singleton() != nullptr) {
 		EditorTitleBar *title_bar = EditorNode::get_singleton()->get_title_bar();
 		if (title_bar != nullptr) {
 			title_bar->call_deferred("set_visible", p_visible);
 		}
 	}
-#endif
 }
 }

--- a/platform/android/editor/game_menu_utils_jni.cpp
+++ b/platform/android/editor/game_menu_utils_jni.cpp
@@ -30,7 +30,6 @@
 
 #include "game_menu_utils_jni.h"
 
-#ifdef TOOLS_ENABLED
 #include "editor/editor_interface.h"
 #include "editor/editor_node.h"
 #include "editor/run/game_view_plugin.h"
@@ -41,123 +40,95 @@ _FORCE_INLINE_ static GameViewPlugin *_get_game_view_plugin() {
 	return Object::cast_to<GameViewPlugin>(EditorNode::get_singleton()->get_editor_main_screen()->get_plugin_by_name("Game"));
 }
 
-#endif
-
 extern "C" {
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_GameMenuUtils_setSuspend(JNIEnv *env, jclass clazz, jboolean enabled) {
-#ifdef TOOLS_ENABLED
 	GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 	if (game_view_plugin != nullptr && game_view_plugin->get_debugger().is_valid()) {
 		game_view_plugin->get_debugger()->set_suspend(enabled);
 	}
-#endif
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_GameMenuUtils_nextFrame(JNIEnv *env, jclass clazz) {
-#ifdef TOOLS_ENABLED
 	GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 	if (game_view_plugin != nullptr && game_view_plugin->get_debugger().is_valid()) {
 		game_view_plugin->get_debugger()->next_frame();
 	}
-#endif
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_GameMenuUtils_setNodeType(JNIEnv *env, jclass clazz, jint type) {
-#ifdef TOOLS_ENABLED
 	GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 	if (game_view_plugin != nullptr && game_view_plugin->get_debugger().is_valid()) {
 		game_view_plugin->get_debugger()->set_node_type(type);
 	}
-#endif
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_GameMenuUtils_setSelectMode(JNIEnv *env, jclass clazz, jint mode) {
-#ifdef TOOLS_ENABLED
 	GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 	if (game_view_plugin != nullptr && game_view_plugin->get_debugger().is_valid()) {
 		game_view_plugin->get_debugger()->set_select_mode(mode);
 	}
-#endif
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_GameMenuUtils_setSelectionVisible(JNIEnv *env, jclass clazz, jboolean visible) {
-#ifdef TOOLS_ENABLED
 	GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 	if (game_view_plugin != nullptr && game_view_plugin->get_debugger().is_valid()) {
 		game_view_plugin->get_debugger()->set_selection_visible(visible);
 	}
-#endif
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_GameMenuUtils_setCameraOverride(JNIEnv *env, jclass clazz, jboolean enabled) {
-#ifdef TOOLS_ENABLED
 	GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 	if (game_view_plugin != nullptr && game_view_plugin->get_debugger().is_valid()) {
 		game_view_plugin->get_debugger()->set_camera_override(enabled);
 	}
-#endif
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_GameMenuUtils_setCameraManipulateMode(JNIEnv *env, jclass clazz, jint mode) {
-#ifdef TOOLS_ENABLED
 	GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 	if (game_view_plugin != nullptr && game_view_plugin->get_debugger().is_valid()) {
 		game_view_plugin->get_debugger()->set_camera_manipulate_mode(static_cast<EditorDebuggerNode::CameraOverride>(mode));
 	}
-#endif
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_GameMenuUtils_resetCamera2DPosition(JNIEnv *env, jclass clazz) {
-#ifdef TOOLS_ENABLED
 	GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 	if (game_view_plugin != nullptr && game_view_plugin->get_debugger().is_valid()) {
 		game_view_plugin->get_debugger()->reset_camera_2d_position();
 	}
-#endif
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_GameMenuUtils_resetCamera3DPosition(JNIEnv *env, jclass clazz) {
-#ifdef TOOLS_ENABLED
 	GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 	if (game_view_plugin != nullptr && game_view_plugin->get_debugger().is_valid()) {
 		game_view_plugin->get_debugger()->reset_camera_3d_position();
 	}
-#endif
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_GameMenuUtils_playMainScene(JNIEnv *env, jclass clazz) {
-#ifdef TOOLS_ENABLED
 	if (EditorInterface::get_singleton()) {
 		EditorInterface::get_singleton()->play_main_scene();
 	}
-#endif
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_GameMenuUtils_setDebugMuteAudio(JNIEnv *env, jclass clazz, jboolean enabled) {
-#ifdef TOOLS_ENABLED
 	GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 	if (game_view_plugin != nullptr && game_view_plugin->get_debugger().is_valid()) {
 		game_view_plugin->get_debugger()->set_debug_mute_audio(enabled);
 	}
-#endif
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_GameMenuUtils_resetTimeScale(JNIEnv *env, jclass clazz) {
-#ifdef TOOLS_ENABLED
 	GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 	if (game_view_plugin != nullptr && game_view_plugin->get_debugger().is_valid()) {
 		game_view_plugin->get_debugger()->reset_time_scale();
 	}
-#endif
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_GameMenuUtils_setTimeScale(JNIEnv *env, jclass clazz, jdouble scale) {
-#ifdef TOOLS_ENABLED
 	GameViewPlugin *game_view_plugin = _get_game_view_plugin();
 	if (game_view_plugin != nullptr && game_view_plugin->get_debugger().is_valid()) {
 		game_view_plugin->get_debugger()->set_time_scale(scale);
 	}
-#endif
 }
 }


### PR DESCRIPTION
I just had this on my TODO list. Seems like I already did #104130 once and forgot about it, but there are some new cases added apparently.
Not sure about the Android editor changes though. Looks like it was done for a reason?