### PR TITLE
Fix incorrect animation section when playing a custom timeline with stretched time scale.

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -107,12 +107,21 @@ AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(ProcessState &p_pro
 	double anim_size = anim->get_length();
 
 	double cur_len;
+	double playback_end;
 	Animation::LoopMode cur_loop_mode;
 	if (use_custom_timeline) {
 		cur_len = timeline_length;
+		if (stretch_time_scale) {
+			// When time scale is stretched, the entire animation is played anyway using a time scale based on the timeline length.
+			// Therefore, the end of the animation section is the animation length.
+			playback_end = anim_size;
+		} else {
+			playback_end = timeline_length;
+		}
 		cur_loop_mode = loop_mode;
 	} else {
 		cur_len = anim_size;
+		playback_end = anim_size;
 		cur_loop_mode = anim->get_loop_mode();
 	}
 
@@ -244,7 +253,7 @@ AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(ProcessState &p_pro
 		if (immediately_after_start) {
 			AnimationMixer::PlaybackInfo pi = p_playback_info;
 			pi.start = 0.0;
-			pi.end = cur_len;
+			pi.end = playback_end;
 			if (play_mode == PLAY_MODE_FORWARD) {
 				pi.time = 0;
 			} else {
@@ -257,7 +266,7 @@ AnimationNode::NodeTimeInfo AnimationNodeAnimation::_process(ProcessState &p_pro
 
 		AnimationMixer::PlaybackInfo pi = p_playback_info;
 		pi.start = 0.0;
-		pi.end = cur_len;
+		pi.end = playback_end;
 		if (play_mode == PLAY_MODE_FORWARD) {
 			pi.time = cur_playback_time;
 		} else {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->

Fixes https://github.com/godotengine/godot/issues/118101

The PR basically sets the animation section's end to be the animation length when AnimationNodeAnimation's `use_custom_timeline` and `stretch_time_scale` are both enabled. (This effectively just plays the original animation at a different speed)

In https://github.com/godotengine/godot/pull/91765, I incorrectly set the animation section's end to be the custom timeline's length. However, AnimationNodeAnimation had been relying on the buggy behavior in https://github.com/godotengine/godot/issues/116002, which allowed it to evaluate keys after the incorrect animation section, which is why this error managed to stay hidden.

https://github.com/godotengine/godot/pull/116046 fixed the buggy behavior, revealing the error in AnimationNodeAnimation.