### PR TITLE
Add folding to the Visual Profiler tree

### DIFF
--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -114,6 +114,7 @@ void EditorVisualProfiler::clear() {
 	last_metric = -1;
 	variables->clear();
 	//activate->set_pressed(false);
+	category_folding.clear();
 
 	graph_limit = 1000.0f / CLAMP(int(EDITOR_GET("debugger/profiler_target_fps")), 1, 1000);
 
@@ -159,6 +160,11 @@ void EditorVisualProfiler::_item_selected() {
 	}
 	selected_area = item->get_metadata(0);
 	_update_plot();
+}
+
+void EditorVisualProfiler::_item_collapsed(TreeItem *p_item) {
+	StringName fullpath = p_item->get_metadata(0);
+	category_folding[fullpath] = p_item->is_collapsed();
 }
 
 void EditorVisualProfiler::_update_plot() {
@@ -370,9 +376,14 @@ void EditorVisualProfiler::_update_frame(bool p_focus_selected) {
 
 			name = name.substr(1);
 
+			category->set_metadata(0, m.areas[i].fullpath_cache);
 			category->set_text(0, name);
 			category->set_metadata(1, cpu_time);
 			category->set_metadata(2, gpu_time);
+
+			if (category_folding.has(m.areas[i].fullpath_cache)) {
+				category->set_collapsed(category_folding[m.areas[i].fullpath_cache]);
+			}
 			continue;
 		}
 
@@ -417,6 +428,14 @@ void EditorVisualProfiler::_update_frame(bool p_focus_selected) {
 	}
 
 	if (ensure_selected) {
+		// Make visible when it's collapsed.
+		TreeItem *node = ensure_selected->get_parent();
+		while (node) {
+			node->set_collapsed(false);
+			node = node->get_parent();
+		}
+		ensure_selected->select(0);
+		ensure_selected->set_as_cursor(0);
 		variables->ensure_cursor_is_visible();
 	}
 	updating_frame = false;
@@ -823,7 +842,6 @@ EditorVisualProfiler::EditorVisualProfiler() {
 
 	variables = memnew(Tree);
 	variables->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
-	variables->set_hide_folding(true);
 	h_split->add_child(variables);
 	variables->set_hide_root(true);
 	variables->set_columns(3);
@@ -842,6 +860,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	variables->set_column_custom_minimum_width(2, 75 * EDSCALE);
 	variables->set_theme_type_variation("TreeSecondary");
 	variables->connect("cell_selected", callable_mp(this, &EditorVisualProfiler::_item_selected));
+	variables->connect("item_collapsed", callable_mp(this, &EditorVisualProfiler::_item_collapsed));
 
 	graph = memnew(TextureRect);
 	graph->set_custom_minimum_size(Size2(250 * EDSCALE, 0));

--- a/editor/debugger/editor_visual_profiler.h
+++ b/editor/debugger/editor_visual_profiler.h
@@ -88,6 +88,7 @@ private:
 	int hover_metric = -1;
 
 	StringName selected_area;
+	HashMap<StringName, bool> category_folding;
 
 	bool updating_frame = false;
 
@@ -116,6 +117,7 @@ private:
 
 	//void _make_metric_ptrs(Metric &m);
 	void _item_selected();
+	void _item_collapsed(TreeItem *p_item);
 
 	void _update_plot();
 

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -493,8 +493,6 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 }
 
 void RendererCanvasCull::render_canvas(RID p_render_target, Canvas *p_canvas, const Transform2D &p_transform, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, const Rect2 &p_clip_rect, RSE::CanvasItemTextureFilter p_default_filter, RSE::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_transforms_to_pixel, bool p_snap_2d_vertices_to_pixel, uint32_t canvas_cull_mask, RenderingServerTypes::RenderInfo *r_render_info) {
-	RENDER_TIMESTAMP("> Render Canvas");
-
 	sdf_used = false;
 	snapping_2d_transforms_to_pixel = p_snap_2d_transforms_to_pixel;
 
@@ -507,8 +505,6 @@ void RendererCanvasCull::render_canvas(RID p_render_target, Canvas *p_canvas, co
 	Canvas::ChildItem *ci = p_canvas->child_items.ptrw();
 
 	_render_canvas_item_tree(p_render_target, ci, l, p_transform, p_clip_rect, p_canvas->modulate, p_lights, p_directional_lights, p_default_filter, p_default_repeat, p_snap_2d_vertices_to_pixel, canvas_cull_mask, r_render_info);
-
-	RENDER_TIMESTAMP("< Render Canvas");
 }
 
 bool RendererCanvasCull::was_sdf_used() {

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -676,6 +676,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 			scenario_draw_canvas_bg = false;
 		}
 
+		int canvas_idx = 0;
 		for (const KeyValue<Viewport::CanvasKey, Viewport::CanvasData *> &E : canvas_map) {
 			RendererCanvasCull::Canvas *canvas = static_cast<RendererCanvasCull::Canvas *>(E.value->canvas);
 
@@ -702,7 +703,12 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 				ptr = ptr->filter_next_ptr;
 			}
 
+			RENDER_TIMESTAMP("> Render Canvas " + itos(canvas_idx));
+
 			RSG::canvas->render_canvas(p_viewport->render_target, canvas, xform, canvas_lights, canvas_directional_lights, clip_rect, p_viewport->texture_filter, p_viewport->texture_repeat, p_viewport->snap_2d_transforms_to_pixel, p_viewport->snap_2d_vertices_to_pixel, p_viewport->canvas_cull_mask, &p_viewport->render_info);
+
+			RENDER_TIMESTAMP("< Render Canvas " + itos(canvas_idx));
+
 			if (RSG::canvas->was_sdf_used()) {
 				p_viewport->sdf_active = true;
 			}
@@ -719,6 +725,8 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 
 				scenario_draw_canvas_bg = false;
 			}
+
+			canvas_idx++;
 		}
 
 		if (scenario_draw_canvas_bg) {


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/issues/14593

This enables tree folding in the Visual Profiler.

https://github.com/user-attachments/assets/7a2b0066-50c8-4ad0-90ea-8b1ceba6682e