### PR TITLE
Fix Sky shader lighting with `TIME`

### DIFF
--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -302,7 +302,8 @@ ALBEDO = vec3(1.0);
 
 	{
 		String defines = "\n#define MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS " + itos(p_max_directional_lights) + "\n";
-		defines += "\n#define MAX_SKY_LOD " + itos(p_roughness_layers - 1) + ".0\n";
+		const int max_sky_roughness_lod = MIN(p_roughness_layers, SkyRD::Sky::REAL_TIME_ROUGHNESS_LAYERS) - 1;
+		defines += "\n#define MAX_SKY_LOD " + itos(max_sky_roughness_lod) + ".0\n";
 		if (p_is_using_radiance_octmap_array) {
 			defines += "\n#define USE_RADIANCE_OCTMAP_ARRAY \n";
 		}

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -5002,7 +5002,8 @@ RenderForwardClustered::RenderForwardClustered() {
 
 	{
 		String defines;
-		defines += "\n#define MAX_ROUGHNESS_LOD " + itos(get_roughness_layers() - 1) + ".0\n";
+		const int max_sky_roughness_lod = MIN(get_roughness_layers(), RendererRD::SkyRD::Sky::REAL_TIME_ROUGHNESS_LAYERS) - 1;
+		defines += "\n#define MAX_ROUGHNESS_LOD " + itos(max_sky_roughness_lod) + ".0\n";
 		if (is_using_radiance_octmap_array()) {
 			defines += "\n#define USE_RADIANCE_OCTMAP_ARRAY \n";
 		}

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -3445,7 +3445,8 @@ RenderForwardMobile::RenderForwardMobile() {
 
 	String defines;
 
-	defines += "\n#define MAX_ROUGHNESS_LOD " + itos(get_roughness_layers() - 1) + ".0\n";
+	const int max_sky_roughness_lod = MIN(get_roughness_layers(), RendererRD::SkyRD::Sky::REAL_TIME_ROUGHNESS_LAYERS) - 1;
+	defines += "\n#define MAX_ROUGHNESS_LOD " + itos(max_sky_roughness_lod) + ".0\n";
 	if (is_using_radiance_octmap_array()) {
 		defines += "\n#define USE_RADIANCE_OCTMAP_ARRAY \n";
 	}


### PR DESCRIPTION
Fix #118110.

Thanks to @Calinou for have bisected the issue to e226db0. 

4.6.1 used 7 layers as the default but 4.6.2 changed it to 8 layers so there's a mismatch where shaders sample a 8th layer when TIME is used. Hence the broken lighting.

Fix: Make the shader check the actual real-time limit.