### PR TITLE
GDScript: Add code coverage instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1238,6 +1238,9 @@ Table of contents:
 - LSP: Reuse stale parsers in request ([GH-114791](https://github.com/godotengine/godot/pull/114791)).
 - Don't clean up other scripts ([GH-114801](https://github.com/godotengine/godot/pull/114801)).
 - Core: Fix implicit conversions in `ContainerTypeValidate` ([GH-114808](https://github.com/godotengine/godot/pull/114808)).
+- Add GDScript coverage instrumentation (line, function, and branch tracking) with LCOV, Cobertura XML, JSON, and text report formats.
+- Fix inner-class method name collision in function coverage by qualifying names with their class chain.
+- Use `SafeFlag` for `coverage_enabled` to prevent data race between VM threads and the coverage write path.
 
 #### GUI
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -53,6 +53,7 @@
 #include "core/config/project_settings.h"
 #include "core/core_constants.h"
 #include "core/io/file_access.h"
+#include "core/os/os.h"
 #include "scene/resources/packed_scene.h"
 #include "scene/scene_string_names.h"
 
@@ -2153,6 +2154,34 @@ void GDScriptLanguage::init() {
 #ifdef TESTS_ENABLED
 	GDScriptTests::GDScriptTestRunner::handle_cmdline();
 #endif // TESTS_ENABLED
+
+#ifdef TOOLS_ENABLED
+	// Parse coverage args only on the first init() call. GDScriptLanguage::init() may be called
+	// multiple times (e.g., from GDScriptTestRunner and individual test cases). Subsequent calls
+	// must not reset coverage state or overwrite the already-configured output path.
+	if (coverage_output_path.is_empty()) {
+		const List<String> &args = OS::get_singleton()->get_cmdline_args();
+		for (const List<String>::Element *E = args.front(); E; E = E->next()) {
+			const String &arg = E->get();
+			if (arg == "--coverage-output" && E->next()) {
+				coverage_set_output(E->next()->get());
+			} else if (arg == "--coverage-mode" && E->next()) {
+				coverage_set_mode(E->next()->get());
+			} else if (arg == "--coverage-format" && E->next()) {
+				coverage_set_format(E->next()->get());
+			} else if (arg == "--coverage-threshold" && E->next()) {
+				coverage_set_threshold(E->next()->get().to_float());
+			} else if (arg == "--coverage-include" && E->next()) {
+				coverage_add_include(E->next()->get());
+			} else if (arg == "--coverage-exclude" && E->next()) {
+				coverage_add_exclude(E->next()->get());
+			}
+		}
+		if (!coverage_output_path.is_empty()) {
+			coverage_start();
+		}
+	}
+#endif // TOOLS_ENABLED
 }
 
 #ifdef TOOLS_ENABLED
@@ -2190,6 +2219,16 @@ void GDScriptLanguage::finish() {
 		return;
 	}
 	finishing = true;
+
+#ifdef TOOLS_ENABLED
+	if (coverage_enabled && !coverage_written) {
+		coverage_write();
+		if (!coverage_check_threshold()) {
+			OS::get_singleton()->set_exit_code(1);
+			print_line("GDScript coverage threshold not met.");
+		}
+	}
+#endif // TOOLS_ENABLED
 
 	// Clear the cache before parsing the script_list
 	GDScriptCache::clear();

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2222,8 +2222,11 @@ void GDScriptLanguage::finish() {
 
 #ifdef TOOLS_ENABLED
 	if (coverage_enabled && !coverage_written) {
-		coverage_write();
-		if (!coverage_check_threshold()) {
+		Error err = coverage_write();
+		if (err != OK) {
+			OS::get_singleton()->set_exit_code(1);
+			print_line("GDScript coverage write failed (error " + itos(err) + ").");
+		} else if (!coverage_check_threshold()) {
 			OS::get_singleton()->set_exit_code(1);
 			print_line("GDScript coverage threshold not met.");
 		}

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2221,7 +2221,7 @@ void GDScriptLanguage::finish() {
 	finishing = true;
 
 #ifdef TOOLS_ENABLED
-	if (coverage_enabled && !coverage_written) {
+	if (coverage_enabled.is_set() && !coverage_written) {
 		Error err = coverage_write();
 		if (err != OK) {
 			OS::get_singleton()->set_exit_code(1);

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -658,6 +658,55 @@ public:
 
 	Ref<GDScript> get_script_by_fully_qualified_name(const String &p_name);
 
+#ifdef TOOLS_ENABLED
+	// --- GDScript Coverage ---
+	struct BranchResult {
+		int taken = 0;
+		int not_taken = 0;
+		int line = 0; // source line number for LCOV BRDA output
+	};
+	enum CoverageMode { COVERAGE_MODE_SET,
+		COVERAGE_MODE_COUNT };
+	enum CoverageFormat { COVERAGE_FORMAT_LCOV,
+		COVERAGE_FORMAT_COBERTURA,
+		COVERAGE_FORMAT_JSON,
+		COVERAGE_FORMAT_TEXT };
+
+	bool coverage_enabled = false;
+	bool coverage_written = false;
+	CoverageMode coverage_mode = COVERAGE_MODE_SET;
+	CoverageFormat coverage_format = COVERAGE_FORMAT_LCOV;
+	String coverage_output_path;
+	float coverage_threshold = 0.0f;
+	Vector<String> coverage_include; // empty = include all
+	Vector<String> coverage_exclude;
+
+	HashMap<String, HashMap<int, int>> coverage_hits; // file -> line -> count
+	HashMap<String, HashMap<String, int>> coverage_func_hits; // file -> func_name -> count
+	HashMap<String, HashMap<int, BranchResult>> coverage_branch_hits; // file -> ip -> BranchResult
+
+	void coverage_set_output(const String &p_path);
+	void coverage_set_mode(const String &p_mode);
+	void coverage_set_format(const String &p_format);
+	void coverage_set_threshold(float p_pct);
+	void coverage_add_include(const String &p_glob);
+	void coverage_add_exclude(const String &p_glob);
+	void coverage_start(); // clears data, sets coverage_enabled=true, coverage_written=false
+	void coverage_record_line(const StringName &p_source, int p_line);
+	void coverage_record_func_entry(const StringName &p_source, const StringName &p_func);
+	void coverage_record_branch(const StringName &p_source, int p_line, int p_ip, bool p_taken);
+	Error coverage_write(); // writes output file, sets coverage_written=true
+	bool coverage_check_threshold() const; // true if line% >= threshold (or threshold == 0)
+	String coverage_summary_string() const; // formatted multi-line summary for terminal/test output
+
+	// Static helpers: must be methods of GDScriptLanguage to access private members of
+	// GDScriptFunction (via friend at gdscript_function.h:344) and script_list (private).
+	static void _coverage_collect_lines(GDScript *p_script, HashMap<int, int> &r_lines);
+	static void _coverage_collect_func_starts(const GDScript *p_script, HashMap<String, int> &r_starts);
+	HashMap<String, HashMap<int, int>> _coverage_enumerate_coverable_lines() const;
+	HashMap<String, HashMap<String, int>> _coverage_enumerate_func_start_lines() const;
+#endif // TOOLS_ENABLED
+
 	GDScriptLanguage();
 	~GDScriptLanguage();
 };

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -681,6 +681,7 @@ public:
 	Vector<String> coverage_include; // empty = include all
 	Vector<String> coverage_exclude;
 
+	mutable Mutex coverage_mutex; // protects coverage_hits, coverage_func_hits, coverage_branch_hits
 	HashMap<String, HashMap<int, int>> coverage_hits; // file -> line -> count
 	HashMap<String, HashMap<String, int>> coverage_func_hits; // file -> func_name -> count
 	HashMap<String, HashMap<int, BranchResult>> coverage_branch_hits; // file -> ip -> BranchResult
@@ -696,15 +697,15 @@ public:
 	void coverage_record_func_entry(const StringName &p_source, const StringName &p_func);
 	void coverage_record_branch(const StringName &p_source, int p_line, int p_ip, bool p_taken);
 	Error coverage_write(); // writes output file, sets coverage_written=true
-	bool coverage_check_threshold() const; // true if line% >= threshold (or threshold == 0)
-	String coverage_summary_string() const; // formatted multi-line summary for terminal/test output
+	bool coverage_check_threshold(); // true if line% >= threshold (or threshold == 0)
+	String coverage_summary_string(); // formatted multi-line summary for terminal/test output
 
 	// Static helpers: must be methods of GDScriptLanguage to access private members of
 	// GDScriptFunction (via friend at gdscript_function.h:344) and script_list (private).
 	static void _coverage_collect_lines(GDScript *p_script, HashMap<int, int> &r_lines);
 	static void _coverage_collect_func_starts(const GDScript *p_script, HashMap<String, int> &r_starts);
-	HashMap<String, HashMap<int, int>> _coverage_enumerate_coverable_lines() const;
-	HashMap<String, HashMap<String, int>> _coverage_enumerate_func_start_lines() const;
+	HashMap<String, HashMap<int, int>> _coverage_enumerate_coverable_lines();
+	HashMap<String, HashMap<String, int>> _coverage_enumerate_func_start_lines();
 #endif // TOOLS_ENABLED
 
 	GDScriptLanguage();

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -39,6 +39,7 @@
 #include "core/io/resource_saver.h"
 #include "core/object/script_language.h"
 #include "core/templates/rb_set.h"
+#include "core/templates/safe_refcount.h"
 
 class GDScriptNativeClass : public RefCounted {
 	GDCLASS(GDScriptNativeClass, RefCounted);
@@ -672,7 +673,7 @@ public:
 		COVERAGE_FORMAT_JSON,
 		COVERAGE_FORMAT_TEXT };
 
-	bool coverage_enabled = false;
+	SafeFlag coverage_enabled; // read from VM threads; SafeFlag gives acquire/release ordering
 	bool coverage_written = false;
 	CoverageMode coverage_mode = COVERAGE_MODE_SET;
 	CoverageFormat coverage_format = COVERAGE_FORMAT_LCOV;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -704,7 +704,7 @@ public:
 	// Static helpers: must be methods of GDScriptLanguage to access private members of
 	// GDScriptFunction (via friend at gdscript_function.h:344) and script_list (private).
 	static void _coverage_collect_lines(GDScript *p_script, HashMap<int, int> &r_lines);
-	static void _coverage_collect_func_starts(const GDScript *p_script, HashMap<String, int> &r_starts);
+	static void _coverage_collect_func_starts(const GDScript *p_script, HashMap<String, int> &r_starts, const String &p_class_prefix = String());
 	HashMap<String, HashMap<int, int>> _coverage_enumerate_coverable_lines();
 	HashMap<String, HashMap<String, int>> _coverage_enumerate_func_start_lines();
 #endif // TOOLS_ENABLED

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -475,8 +475,15 @@ static Error _write_lcov(const String &p_path,
 	HashMap<String, HashMap<int, int>> coverable = p_lang->_coverage_enumerate_coverable_lines();
 	HashMap<String, HashMap<String, int>> func_starts = p_lang->_coverage_enumerate_func_start_lines();
 
+	// Sort file paths for deterministic, reproducible output.
+	Vector<String> sorted_paths;
 	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {
-		const String &res_path = kv.key;
+		sorted_paths.push_back(kv.key);
+	}
+	sorted_paths.sort();
+
+	for (const String &res_path : sorted_paths) {
+		const HashMap<int, int> &lines_for_path = *p_hits.getptr(res_path);
 		f->store_line("TN:");
 		f->store_line("SF:" + _coverage_globalize(res_path));
 
@@ -496,7 +503,7 @@ static Error _write_lcov(const String &p_path,
 		}
 
 		HashMap<int, int> all_lines;
-		Vector<int> sorted = _merge_line_hits(kv.value, coverable, res_path, all_lines);
+		Vector<int> sorted = _merge_line_hits(lines_for_path, coverable, res_path, all_lines);
 		_lcov_write_lines(f, sorted, all_lines);
 
 		f->store_line("end_of_record");
@@ -578,7 +585,7 @@ static Error _write_cobertura(const String &p_path,
 	f->store_line("<?xml version=\"1.0\" ?>");
 	f->store_line("<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">");
 	f->store_line(vformat("<coverage version=\"5.0\" timestamp=\"%d\" line-rate=\"%.4f\" branch-rate=\"%.4f\" lines-covered=\"%d\" lines-valid=\"%d\" branches-covered=\"%d\" branches-valid=\"%d\">",
-			ts, line_rate, branch_rate, t.hit_lines, t.lines, t.hit_branches, t.branches));
+			(int64_t)ts, line_rate, branch_rate, t.hit_lines, t.lines, t.hit_branches, t.branches));
 	f->store_line("  <packages><package name=\"gdscript\"><classes>");
 
 	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -1,0 +1,768 @@
+/**************************************************************************/
+/*  gdscript_coverage.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "gdscript.h"
+#include "gdscript_function.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/file_access.h"
+#include "core/os/os.h"
+#include "core/os/time.h"
+#include "core/string/print_string.h"
+
+/*************** Configuration setters ***************/
+
+void GDScriptLanguage::coverage_set_output(const String &p_path) {
+	coverage_output_path = p_path;
+}
+
+void GDScriptLanguage::coverage_set_mode(const String &p_mode) {
+	coverage_mode = (p_mode == "count") ? COVERAGE_MODE_COUNT : COVERAGE_MODE_SET;
+}
+
+void GDScriptLanguage::coverage_set_format(const String &p_format) {
+	if (p_format == "cobertura") {
+		coverage_format = COVERAGE_FORMAT_COBERTURA;
+	} else if (p_format == "json") {
+		coverage_format = COVERAGE_FORMAT_JSON;
+	} else if (p_format == "text") {
+		coverage_format = COVERAGE_FORMAT_TEXT;
+	} else {
+		coverage_format = COVERAGE_FORMAT_LCOV;
+	}
+}
+
+void GDScriptLanguage::coverage_set_threshold(float p_pct) {
+	coverage_threshold = p_pct;
+}
+
+void GDScriptLanguage::coverage_add_include(const String &p_glob) {
+	coverage_include.push_back(p_glob);
+}
+
+void GDScriptLanguage::coverage_add_exclude(const String &p_glob) {
+	coverage_exclude.push_back(p_glob);
+}
+
+/*************** Runtime control ***************/
+
+void GDScriptLanguage::coverage_start() {
+	coverage_hits.clear();
+	coverage_func_hits.clear();
+	coverage_branch_hits.clear();
+	coverage_written = false;
+	coverage_enabled = true;
+}
+
+/*************** Path and filter helpers ***************/
+
+static bool _coverage_path_included(const String &p_res_path,
+		const Vector<String> &p_include, const Vector<String> &p_exclude) {
+	for (const String &pat : p_exclude) {
+		if (p_res_path.match(pat)) {
+			return false;
+		}
+	}
+	if (p_include.is_empty()) {
+		return true;
+	}
+	for (const String &pat : p_include) {
+		if (p_res_path.match(pat)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+// Convert res:// path to an absolute filesystem path.
+// Falls back to resource dir prefix when ProjectSettings is unavailable (e.g. engine --test mode).
+static String _coverage_globalize(const String &p_res_path) {
+	if (ProjectSettings::get_singleton()) {
+		String abs = ProjectSettings::get_singleton()->globalize_path(p_res_path);
+		if (!abs.begins_with("res://")) {
+			return abs;
+		}
+	}
+	return OS::get_singleton()->get_resource_dir().path_join(p_res_path.substr(6));
+}
+
+/*************** Hot-path recording (called from VM) ***************/
+
+void GDScriptLanguage::coverage_record_line(const StringName &p_source, int p_line) {
+	String path = String(p_source);
+	if (!_coverage_path_included(path, coverage_include, coverage_exclude)) {
+		return;
+	}
+	HashMap<int, int> &lines = coverage_hits[path];
+	if (coverage_mode == COVERAGE_MODE_COUNT) {
+		lines[p_line]++;
+	} else {
+		lines[p_line] = 1;
+	}
+}
+
+void GDScriptLanguage::coverage_record_func_entry(const StringName &p_source, const StringName &p_func) {
+	String path = String(p_source);
+	if (!_coverage_path_included(path, coverage_include, coverage_exclude)) {
+		return;
+	}
+	HashMap<String, int> &funcs = coverage_func_hits[path];
+	if (coverage_mode == COVERAGE_MODE_COUNT) {
+		funcs[String(p_func)]++;
+	} else {
+		funcs[String(p_func)] = 1;
+	}
+}
+
+void GDScriptLanguage::coverage_record_branch(const StringName &p_source, int p_line, int p_ip, bool p_taken) {
+	String path = String(p_source);
+	if (!_coverage_path_included(path, coverage_include, coverage_exclude)) {
+		return;
+	}
+	BranchResult &br = coverage_branch_hits[path][p_ip];
+	br.line = p_line; // store for LCOV BRDA output
+	if (p_taken) {
+		if (coverage_mode == COVERAGE_MODE_COUNT) {
+			br.taken++;
+		} else {
+			br.taken = 1;
+		}
+	} else {
+		if (coverage_mode == COVERAGE_MODE_COUNT) {
+			br.not_taken++;
+		} else {
+			br.not_taken = 1;
+		}
+	}
+}
+
+/*************** Per-file stats aggregate ***************/
+
+struct CoverageFileStats {
+	int lines = 0, hit_lines = 0;
+	int funcs = 0, hit_funcs = 0;
+	int branches = 0, hit_branches = 0;
+};
+
+static void _compute_line_stats(const HashMap<int, int> &p_hits,
+		const HashMap<int, int> *p_coverable, CoverageFileStats &r_fs) {
+	HashSet<int> counted;
+	for (const KeyValue<int, int> &lv : p_hits) {
+		r_fs.lines++;
+		if (lv.value > 0) {
+			r_fs.hit_lines++;
+		}
+		counted.insert(lv.key);
+	}
+	// Count coverable-but-not-hit lines not already in p_hits.
+	if (p_coverable) {
+		for (const KeyValue<int, int> &cv : *p_coverable) {
+			if (!counted.has(cv.key)) {
+				r_fs.lines++;
+			}
+		}
+	}
+}
+
+static void _compute_func_stats(const HashMap<String, int> &p_funcs, CoverageFileStats &r_fs) {
+	for (const KeyValue<String, int> &fv : p_funcs) {
+		r_fs.funcs++;
+		if (fv.value > 0) {
+			r_fs.hit_funcs++;
+		}
+	}
+}
+
+static void _compute_branch_stats(const HashMap<int, GDScriptLanguage::BranchResult> &p_branches, CoverageFileStats &r_fs) {
+	for (const KeyValue<int, GDScriptLanguage::BranchResult> &bv : p_branches) {
+		r_fs.branches += 2;
+		if (bv.value.taken > 0) {
+			r_fs.hit_branches++;
+		}
+		if (bv.value.not_taken > 0) {
+			r_fs.hit_branches++;
+		}
+	}
+}
+
+static HashMap<String, CoverageFileStats> _gather_file_stats(
+		const HashMap<String, HashMap<int, int>> &p_hits,
+		const HashMap<String, HashMap<String, int>> &p_func_hits,
+		const HashMap<String, HashMap<int, GDScriptLanguage::BranchResult>> &p_branch_hits,
+		const HashMap<String, HashMap<int, int>> *p_coverable = nullptr) {
+	HashMap<String, CoverageFileStats> out;
+	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {
+		const HashMap<int, int> *cov = p_coverable ? p_coverable->getptr(kv.key) : nullptr;
+		_compute_line_stats(kv.value, cov, out[kv.key]);
+	}
+	for (const KeyValue<String, HashMap<String, int>> &kv : p_func_hits) {
+		_compute_func_stats(kv.value, out[kv.key]);
+	}
+	for (const KeyValue<String, HashMap<int, GDScriptLanguage::BranchResult>> &kv : p_branch_hits) {
+		_compute_branch_stats(kv.value, out[kv.key]);
+	}
+	return out;
+}
+
+static CoverageFileStats _sum_totals(const HashMap<String, CoverageFileStats> &p_stats) {
+	CoverageFileStats t;
+	for (const KeyValue<String, CoverageFileStats> &kv : p_stats) {
+		t.lines += kv.value.lines;
+		t.hit_lines += kv.value.hit_lines;
+		t.funcs += kv.value.funcs;
+		t.hit_funcs += kv.value.hit_funcs;
+		t.branches += kv.value.branches;
+		t.hit_branches += kv.value.hit_branches;
+	}
+	return t;
+}
+
+/*************** Threshold and summary ***************/
+
+bool GDScriptLanguage::coverage_check_threshold() const {
+	if (coverage_threshold <= 0.0f) {
+		return true;
+	}
+	HashMap<String, HashMap<int, int>> coverable = _coverage_enumerate_coverable_lines();
+	HashMap<String, CoverageFileStats> stats = _gather_file_stats(coverage_hits, coverage_func_hits, coverage_branch_hits, &coverable);
+	CoverageFileStats t = _sum_totals(stats);
+	if (t.lines == 0) {
+		return true;
+	}
+	float pct = 100.0f * (float)t.hit_lines / (float)t.lines;
+	return pct >= coverage_threshold;
+}
+
+static String _format_pct_cell(float p_pct, int p_width) {
+	String s = String::num(p_pct, 1) + "%";
+	return s.rpad(p_width);
+}
+
+static String _format_summary_row(const String &p_label, const CoverageFileStats &p_fs, int p_col_file) {
+	float lp = p_fs.lines > 0 ? 100.0f * p_fs.hit_lines / p_fs.lines : 0.0f;
+	float fp = p_fs.funcs > 0 ? 100.0f * p_fs.hit_funcs / p_fs.funcs : 0.0f;
+	float bp = p_fs.branches > 0 ? 100.0f * p_fs.hit_branches / p_fs.branches : 0.0f;
+	return p_label.rpad(p_col_file) + _format_pct_cell(lp, 9) + _format_pct_cell(fp, 9) + _format_pct_cell(bp, 9) + "\n";
+}
+
+String GDScriptLanguage::coverage_summary_string() const {
+	static const int COL_FILE = 40;
+
+	HashMap<String, HashMap<int, int>> coverable = _coverage_enumerate_coverable_lines();
+	HashMap<String, CoverageFileStats> stats = _gather_file_stats(coverage_hits, coverage_func_hits, coverage_branch_hits, &coverable);
+	CoverageFileStats totals = _sum_totals(stats);
+
+	String out = String("File").rpad(COL_FILE) + String("Lines").rpad(9) + String("Funcs").rpad(9) + String("Branches").rpad(9) + "\n";
+
+	Vector<String> files;
+	for (const KeyValue<String, CoverageFileStats> &kv : stats) {
+		files.push_back(kv.key);
+	}
+	files.sort();
+	for (const String &path : files) {
+		out += _format_summary_row(path, stats[path], COL_FILE);
+	}
+
+	String sep(U"────────────────────────────────────────────────────────────");
+	out += sep + "\n";
+	out += _format_summary_row("Total", totals, COL_FILE);
+
+	if (coverage_threshold > 0.0f) {
+		float pct = totals.lines > 0 ? 100.0f * totals.hit_lines / totals.lines : 0.0f;
+		bool pass = pct >= coverage_threshold;
+		out += "Threshold: " + String::num(coverage_threshold, 1) + "% " + (pass ? U"✓" : U"✗") + "\n";
+	}
+	return out;
+}
+
+/*************** Bytecode enumeration ***************/
+
+void GDScriptLanguage::_coverage_collect_lines(GDScript *p_script, HashMap<int, int> &r_lines) {
+	if (!p_script) {
+		return;
+	}
+	// Scan member functions for OPCODE_LINE entries to find coverable lines.
+	for (const KeyValue<StringName, GDScriptFunction *> &kv : p_script->get_member_functions()) {
+		GDScriptFunction *func = kv.value;
+		if (!func) {
+			continue;
+		}
+		const int *code = func->_code_ptr;
+		int code_size = func->_code_size;
+		for (int i = 0; i < code_size; i++) {
+			if (code[i] == GDScriptFunction::OPCODE_LINE) {
+				if (i + 1 < code_size) {
+					int ln = code[i + 1];
+					if (!r_lines.has(ln)) {
+						r_lines[ln] = 0;
+					}
+				}
+				i += 1; // skip line-number operand
+			}
+		}
+	}
+	// Recurse into inner classes.
+	for (const KeyValue<StringName, Ref<GDScript>> &kv : p_script->get_subclasses()) {
+		_coverage_collect_lines(kv.value.ptr(), r_lines);
+	}
+}
+
+// Walk bytecode to find the first OPCODE_LINE for each function (its start line).
+void GDScriptLanguage::_coverage_collect_func_starts(const GDScript *p_script, HashMap<String, int> &r_starts) {
+	if (!p_script) {
+		return;
+	}
+	for (const KeyValue<StringName, GDScriptFunction *> &kv : p_script->get_member_functions()) {
+		GDScriptFunction *func = kv.value;
+		if (!func) {
+			continue;
+		}
+		const int *code = func->_code_ptr;
+		int code_size = func->_code_size;
+		for (int i = 0; i < code_size; i++) {
+			if (code[i] == GDScriptFunction::OPCODE_LINE && i + 1 < code_size) {
+				r_starts[String(func->get_name())] = code[i + 1];
+				break; // only the first line number is the start line
+			}
+		}
+	}
+	for (const KeyValue<StringName, Ref<GDScript>> &kv : p_script->get_subclasses()) {
+		_coverage_collect_func_starts(kv.value.ptr(), r_starts);
+	}
+}
+
+// Build a per-file map of function name → start line from script_list.
+HashMap<String, HashMap<String, int>> GDScriptLanguage::_coverage_enumerate_func_start_lines() const {
+	HashMap<String, HashMap<String, int>> result;
+	const SelfList<GDScript> *s = script_list.first();
+	while (s) {
+		const GDScript *scr = s->self();
+		if (scr) {
+			String res_path = scr->get_script_path();
+			_coverage_collect_func_starts(scr, result[res_path]);
+		}
+		s = s->next();
+	}
+	return result;
+}
+
+HashMap<String, HashMap<int, int>> GDScriptLanguage::_coverage_enumerate_coverable_lines() const {
+	HashMap<String, HashMap<int, int>> coverable;
+	const SelfList<GDScript> *s = script_list.first();
+	while (s) {
+		GDScript *scr = s->self();
+		if (scr) {
+			String res_path = scr->get_script_path();
+			if (_coverage_path_included(res_path, coverage_include, coverage_exclude)) {
+				_coverage_collect_lines(scr, coverable[res_path]);
+			}
+		}
+		s = s->next();
+	}
+	return coverable;
+}
+
+// Merge recorded hits with coverable-but-not-hit lines and return sorted line numbers.
+static Vector<int> _merge_line_hits(const HashMap<int, int> &p_hits,
+		const HashMap<String, HashMap<int, int>> &p_coverable, const String &p_path,
+		HashMap<int, int> &r_all_lines) {
+	r_all_lines = p_hits;
+	if (p_coverable.has(p_path)) {
+		for (const KeyValue<int, int> &cv : p_coverable[p_path]) {
+			if (!r_all_lines.has(cv.key)) {
+				r_all_lines[cv.key] = 0;
+			}
+		}
+	}
+	Vector<int> sorted_lines;
+	for (const KeyValue<int, int> &lv : r_all_lines) {
+		sorted_lines.push_back(lv.key);
+	}
+	sorted_lines.sort();
+	return sorted_lines;
+}
+
+/*************** LCOV writer ***************/
+
+static void _lcov_write_functions(Ref<FileAccess> f, const HashMap<String, int> &p_funcs,
+		const HashMap<String, int> &p_starts) {
+	for (const KeyValue<String, int> &fv : p_funcs) {
+		const int *ln = p_starts.getptr(fv.key);
+		f->store_line("FN:" + itos(ln ? *ln : 1) + "," + fv.key);
+	}
+	int fnh = 0;
+	for (const KeyValue<String, int> &fv : p_funcs) {
+		f->store_line("FNDA:" + itos(fv.value) + "," + fv.key);
+		if (fv.value > 0) {
+			fnh++;
+		}
+	}
+	f->store_line("FNF:" + itos(p_funcs.size()));
+	f->store_line("FNH:" + itos(fnh));
+}
+
+static void _lcov_write_branches(Ref<FileAccess> f,
+		const HashMap<int, GDScriptLanguage::BranchResult> &p_branches,
+		int &r_brf, int &r_brh) {
+	for (const KeyValue<int, GDScriptLanguage::BranchResult> &bv : p_branches) {
+		int ip = bv.key;
+		int ln = bv.value.line;
+		// BRDA format: line, block (ip), branch (0=taken/1=not_taken), count
+		f->store_line("BRDA:" + itos(ln) + "," + itos(ip) + ",0," + itos(bv.value.taken));
+		f->store_line("BRDA:" + itos(ln) + "," + itos(ip) + ",1," + itos(bv.value.not_taken));
+		r_brf += 2;
+		if (bv.value.taken > 0) {
+			r_brh++;
+		}
+		if (bv.value.not_taken > 0) {
+			r_brh++;
+		}
+	}
+}
+
+static void _lcov_write_lines(Ref<FileAccess> f, const Vector<int> &p_sorted_lines,
+		const HashMap<int, int> &p_all_lines) {
+	int lf = 0, lh = 0;
+	for (int ln : p_sorted_lines) {
+		int hits = *p_all_lines.getptr(ln);
+		f->store_line("DA:" + itos(ln) + "," + itos(hits));
+		lf++;
+		if (hits > 0) {
+			lh++;
+		}
+	}
+	f->store_line("LF:" + itos(lf));
+	f->store_line("LH:" + itos(lh));
+}
+
+static Error _write_lcov(const String &p_path,
+		const HashMap<String, HashMap<int, int>> &p_hits,
+		const HashMap<String, HashMap<String, int>> &p_func_hits,
+		const HashMap<String, HashMap<int, GDScriptLanguage::BranchResult>> &p_branch_hits,
+		GDScriptLanguage *p_lang) {
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE);
+	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, "Cannot open coverage output: " + p_path);
+
+	HashMap<String, HashMap<int, int>> coverable = p_lang->_coverage_enumerate_coverable_lines();
+	HashMap<String, HashMap<String, int>> func_starts = p_lang->_coverage_enumerate_func_start_lines();
+
+	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {
+		const String &res_path = kv.key;
+		f->store_line("TN:");
+		f->store_line("SF:" + _coverage_globalize(res_path));
+
+		const HashMap<String, int> *funcs = p_func_hits.getptr(res_path);
+		if (funcs) {
+			static const HashMap<String, int> empty_starts;
+			const HashMap<String, int> *starts = func_starts.getptr(res_path);
+			_lcov_write_functions(f, *funcs, starts ? *starts : empty_starts);
+		}
+
+		int brf = 0, brh = 0;
+		const HashMap<int, GDScriptLanguage::BranchResult> *branches = p_branch_hits.getptr(res_path);
+		if (branches) {
+			_lcov_write_branches(f, *branches, brf, brh);
+			f->store_line("BRF:" + itos(brf));
+			f->store_line("BRH:" + itos(brh));
+		}
+
+		HashMap<int, int> all_lines;
+		Vector<int> sorted = _merge_line_hits(kv.value, coverable, res_path, all_lines);
+		_lcov_write_lines(f, sorted, all_lines);
+
+		f->store_line("end_of_record");
+	}
+	return OK;
+}
+
+/*************** Cobertura XML writer ***************/
+
+static String _xml_escape(const String &p_str) {
+	return p_str.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+}
+
+static void _cobertura_write_class(Ref<FileAccess> f, const String &p_res_path,
+		const HashMap<int, int> &p_lines,
+		const HashMap<String, int> *p_funcs,
+		const HashMap<int, GDScriptLanguage::BranchResult> *p_branches,
+		const HashMap<int, int> *p_coverable) {
+	CoverageFileStats fs;
+	_compute_line_stats(p_lines, p_coverable, fs);
+	if (p_funcs) {
+		_compute_func_stats(*p_funcs, fs);
+	}
+	if (p_branches) {
+		_compute_branch_stats(*p_branches, fs);
+	}
+	float flr = fs.lines > 0 ? (float)fs.hit_lines / fs.lines : 0.0f;
+	float fbr = fs.branches > 0 ? (float)fs.hit_branches / fs.branches : 0.0f;
+
+	f->store_line(vformat("    <class filename=\"%s\" line-rate=\"%.4f\" branch-rate=\"%.4f\">",
+			_xml_escape(_coverage_globalize(p_res_path)), flr, fbr));
+
+	if (p_funcs) {
+		f->store_line("      <methods>");
+		for (const KeyValue<String, int> &fv : *p_funcs) {
+			f->store_line(vformat("        <method name=\"%s\" hits=\"%d\"/>", _xml_escape(fv.key), fv.value));
+		}
+		f->store_line("      </methods>");
+	}
+
+	// Emit all coverable lines (hit and not-hit).
+	HashMap<int, int> all_lines;
+	all_lines = p_lines;
+	if (p_coverable) {
+		for (const KeyValue<int, int> &cv : *p_coverable) {
+			if (!all_lines.has(cv.key)) {
+				all_lines[cv.key] = 0;
+			}
+		}
+	}
+	f->store_line("      <lines>");
+	Vector<int> lnums;
+	for (const KeyValue<int, int> &lv : all_lines) {
+		lnums.push_back(lv.key);
+	}
+	lnums.sort();
+	for (int ln : lnums) {
+		f->store_line(vformat("        <line number=\"%d\" hits=\"%d\" branch=\"false\"/>", ln, *all_lines.getptr(ln)));
+	}
+	f->store_line("      </lines>");
+	f->store_line("    </class>");
+}
+
+static Error _write_cobertura(const String &p_path,
+		const HashMap<String, HashMap<int, int>> &p_hits,
+		const HashMap<String, HashMap<String, int>> &p_func_hits,
+		const HashMap<String, HashMap<int, GDScriptLanguage::BranchResult>> &p_branch_hits,
+		GDScriptLanguage *p_lang) {
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE);
+	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, "Cannot open coverage output: " + p_path);
+
+	HashMap<String, HashMap<int, int>> coverable = p_lang->_coverage_enumerate_coverable_lines();
+	HashMap<String, CoverageFileStats> stats = _gather_file_stats(p_hits, p_func_hits, p_branch_hits, &coverable);
+	CoverageFileStats t = _sum_totals(stats);
+	float line_rate = t.lines > 0 ? (float)t.hit_lines / t.lines : 0.0f;
+	float branch_rate = t.branches > 0 ? (float)t.hit_branches / t.branches : 0.0f;
+	uint64_t ts = Time::get_singleton()->get_unix_time_from_system();
+
+	f->store_line("<?xml version=\"1.0\" ?>");
+	f->store_line("<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">");
+	f->store_line(vformat("<coverage version=\"5.0\" timestamp=\"%d\" line-rate=\"%.4f\" branch-rate=\"%.4f\" lines-covered=\"%d\" lines-valid=\"%d\" branches-covered=\"%d\" branches-valid=\"%d\">",
+			ts, line_rate, branch_rate, t.hit_lines, t.lines, t.hit_branches, t.branches));
+	f->store_line("  <packages><package name=\"gdscript\"><classes>");
+
+	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {
+		_cobertura_write_class(f, kv.key, kv.value,
+				p_func_hits.getptr(kv.key),
+				p_branch_hits.getptr(kv.key),
+				coverable.getptr(kv.key));
+	}
+
+	f->store_line("  </classes></package></packages>");
+	f->store_line("</coverage>");
+	return OK;
+}
+
+/*************** JSON writer ***************/
+
+static void _json_write_lines(Ref<FileAccess> f, const HashMap<int, int> &p_lines,
+		const HashMap<int, int> *p_coverable) {
+	// Merge hit lines with coverable-but-not-hit lines for a complete picture.
+	HashMap<int, int> all_lines;
+	all_lines = p_lines;
+	if (p_coverable) {
+		for (const KeyValue<int, int> &cv : *p_coverable) {
+			if (!all_lines.has(cv.key)) {
+				all_lines[cv.key] = 0;
+			}
+		}
+	}
+	f->store_string("      \"lines\": {");
+	Vector<int> lnums;
+	for (const KeyValue<int, int> &lv : all_lines) {
+		lnums.push_back(lv.key);
+	}
+	lnums.sort();
+	bool first = true;
+	for (int ln : lnums) {
+		if (!first) {
+			f->store_string(",");
+		}
+		first = false;
+		f->store_string("\"" + itos(ln) + "\":" + itos(*all_lines.getptr(ln)));
+	}
+	f->store_line("},");
+}
+
+static void _json_write_funcs(Ref<FileAccess> f, const HashMap<String, int> &p_funcs) {
+	f->store_string("      \"functions\": {");
+	bool first = true;
+	for (const KeyValue<String, int> &fv : p_funcs) {
+		if (!first) {
+			f->store_string(",");
+		}
+		first = false;
+		f->store_string("\"" + fv.key.c_escape() + "\":" + itos(fv.value));
+	}
+	f->store_line("},");
+}
+
+static void _json_write_branches(Ref<FileAccess> f,
+		const HashMap<int, GDScriptLanguage::BranchResult> &p_branches) {
+	f->store_string("      \"branches\": {");
+	bool first = true;
+	for (const KeyValue<int, GDScriptLanguage::BranchResult> &bv : p_branches) {
+		if (!first) {
+			f->store_string(",");
+		}
+		first = false;
+		f->store_string("\"" + itos(bv.key) + "_taken\":" + itos(bv.value.taken) + ",");
+		f->store_string("\"" + itos(bv.key) + "_not_taken\":" + itos(bv.value.not_taken));
+	}
+	f->store_line("}");
+}
+
+static void _json_write_file_entry(Ref<FileAccess> f, const String &p_path,
+		const HashMap<int, int> *p_lines,
+		const HashMap<String, int> *p_funcs,
+		const HashMap<int, GDScriptLanguage::BranchResult> *p_branches,
+		const HashMap<int, int> *p_coverable) {
+	f->store_line("    \"" + p_path.c_escape() + "\": {");
+	if (p_lines) {
+		_json_write_lines(f, *p_lines, p_coverable);
+	} else {
+		f->store_line("      \"lines\": {},");
+	}
+	if (p_funcs) {
+		_json_write_funcs(f, *p_funcs);
+	} else {
+		f->store_line("      \"functions\": {},");
+	}
+	if (p_branches) {
+		_json_write_branches(f, *p_branches);
+	} else {
+		f->store_line("      \"branches\": {}");
+	}
+	f->store_string("    }");
+}
+
+static Error _write_json(const String &p_path,
+		const HashMap<String, HashMap<int, int>> &p_hits,
+		const HashMap<String, HashMap<String, int>> &p_func_hits,
+		const HashMap<String, HashMap<int, GDScriptLanguage::BranchResult>> &p_branch_hits,
+		GDScriptLanguage *p_lang) {
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE);
+	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, "Cannot open coverage output: " + p_path);
+	HashMap<String, HashMap<int, int>> coverable = p_lang->_coverage_enumerate_coverable_lines();
+
+	// Union of all file paths.
+	HashSet<String> all_files;
+	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {
+		all_files.insert(kv.key);
+	}
+	for (const KeyValue<String, HashMap<String, int>> &kv : p_func_hits) {
+		all_files.insert(kv.key);
+	}
+	for (const KeyValue<String, HashMap<int, GDScriptLanguage::BranchResult>> &kv : p_branch_hits) {
+		all_files.insert(kv.key);
+	}
+	Vector<String> file_list;
+	for (const String &s : all_files) {
+		file_list.push_back(s);
+	}
+	file_list.sort();
+
+	f->store_line("{");
+	f->store_line("  \"files\": {");
+	for (int i = 0; i < file_list.size(); i++) {
+		const String &fp = file_list[i];
+		_json_write_file_entry(f, fp, p_hits.getptr(fp), p_func_hits.getptr(fp), p_branch_hits.getptr(fp), coverable.getptr(fp));
+		if (i + 1 < file_list.size()) {
+			f->store_line(",");
+		} else {
+			f->store_line("");
+		}
+	}
+	f->store_line("  },");
+
+	HashMap<String, CoverageFileStats> stats = _gather_file_stats(p_hits, p_func_hits, p_branch_hits, &coverable);
+	CoverageFileStats t = _sum_totals(stats);
+	float lp = t.lines > 0 ? 100.0f * t.hit_lines / t.lines : 0.0f;
+	float fp2 = t.funcs > 0 ? 100.0f * t.hit_funcs / t.funcs : 0.0f;
+	float bp = t.branches > 0 ? 100.0f * t.hit_branches / t.branches : 0.0f;
+	f->store_line(vformat("  \"summary\": {\"line_pct\": %.1f, \"func_pct\": %.1f, \"branch_pct\": %.1f}", lp, fp2, bp));
+	f->store_line("}");
+	return OK;
+}
+
+/*************** Text writer ***************/
+
+static Error _write_text(const String &p_path, const String &p_summary) {
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE);
+	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, "Cannot open coverage output: " + p_path);
+	f->store_string(p_summary);
+	return OK;
+}
+
+/*************** Main write entry point ***************/
+
+Error GDScriptLanguage::coverage_write() {
+	if (coverage_output_path.is_empty()) {
+		return ERR_UNCONFIGURED;
+	}
+
+	Error err = OK;
+	switch (coverage_format) {
+		case COVERAGE_FORMAT_LCOV:
+			err = _write_lcov(coverage_output_path, coverage_hits, coverage_func_hits, coverage_branch_hits, this);
+			break;
+		case COVERAGE_FORMAT_COBERTURA:
+			err = _write_cobertura(coverage_output_path, coverage_hits, coverage_func_hits, coverage_branch_hits, this);
+			break;
+		case COVERAGE_FORMAT_JSON:
+			err = _write_json(coverage_output_path, coverage_hits, coverage_func_hits, coverage_branch_hits, this);
+			break;
+		case COVERAGE_FORMAT_TEXT: {
+			String summary = coverage_summary_string();
+			print_line(summary);
+			err = _write_text(coverage_output_path, summary);
+		} break;
+	}
+
+	if (err == OK) {
+		coverage_written = true;
+	}
+	return err;
+}
+
+#endif // TOOLS_ENABLED

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -700,8 +700,9 @@ static void _json_write_file_entry(Ref<FileAccess> f, const String &p_path,
 		const HashMap<int, GDScriptLanguage::BranchResult> *p_branches,
 		const HashMap<int, int> *p_coverable) {
 	f->store_line("    \"" + p_path.c_escape() + "\": {");
-	if (p_lines) {
-		_json_write_lines(f, *p_lines, p_coverable);
+	if (p_lines || (p_coverable && !p_coverable->is_empty())) {
+		static const HashMap<int, int> empty_json_lines;
+		_json_write_lines(f, p_lines ? *p_lines : empty_json_lines, p_coverable);
 	} else {
 		f->store_line("      \"lines\": {},");
 	}

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -230,6 +230,16 @@ static HashMap<String, CoverageFileStats> _gather_file_stats(
 	for (const KeyValue<String, HashMap<int, GDScriptLanguage::BranchResult>> &kv : p_branch_hits) {
 		_compute_branch_stats(kv.value, out[kv.key]);
 	}
+	// Files that were compiled and filtered-in but never executed at all must
+	// appear in stats as 0% covered rather than being invisible.
+	if (p_coverable) {
+		static const HashMap<int, int> empty_hits;
+		for (const KeyValue<String, HashMap<int, int>> &cv : *p_coverable) {
+			if (!out.has(cv.key)) {
+				_compute_line_stats(empty_hits, &cv.value, out[cv.key]);
+			}
+		}
+	}
 	return out;
 }
 
@@ -475,15 +485,25 @@ static Error _write_lcov(const String &p_path,
 	HashMap<String, HashMap<int, int>> coverable = p_lang->_coverage_enumerate_coverable_lines();
 	HashMap<String, HashMap<String, int>> func_starts = p_lang->_coverage_enumerate_func_start_lines();
 
-	// Sort file paths for deterministic, reproducible output.
-	Vector<String> sorted_paths;
+	// Sort the union of hit paths and coverable paths for deterministic output.
+	// Files compiled but never executed must appear with DA:line,0 entries.
+	HashSet<String> path_set;
 	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {
-		sorted_paths.push_back(kv.key);
+		path_set.insert(kv.key);
+	}
+	for (const KeyValue<String, HashMap<int, int>> &cv : coverable) {
+		path_set.insert(cv.key);
+	}
+	Vector<String> sorted_paths;
+	for (const String &s : path_set) {
+		sorted_paths.push_back(s);
 	}
 	sorted_paths.sort();
 
+	static const HashMap<int, int> empty_hits;
 	for (const String &res_path : sorted_paths) {
-		const HashMap<int, int> &lines_for_path = *p_hits.getptr(res_path);
+		const HashMap<int, int> *hits_ptr = p_hits.getptr(res_path);
+		const HashMap<int, int> &lines_for_path = hits_ptr ? *hits_ptr : empty_hits;
 		f->store_line("TN:");
 		f->store_line("SF:" + _coverage_globalize(res_path));
 
@@ -588,11 +608,26 @@ static Error _write_cobertura(const String &p_path,
 			(int64_t)ts, line_rate, branch_rate, t.hit_lines, t.lines, t.hit_branches, t.branches));
 	f->store_line("  <packages><package name=\"gdscript\"><classes>");
 
+	HashSet<String> cobertura_paths;
 	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {
-		_cobertura_write_class(f, kv.key, kv.value,
-				p_func_hits.getptr(kv.key),
-				p_branch_hits.getptr(kv.key),
-				coverable.getptr(kv.key));
+		cobertura_paths.insert(kv.key);
+	}
+	for (const KeyValue<String, HashMap<int, int>> &cv : coverable) {
+		cobertura_paths.insert(cv.key);
+	}
+	Vector<String> sorted_cobertura;
+	for (const String &s : cobertura_paths) {
+		sorted_cobertura.push_back(s);
+	}
+	sorted_cobertura.sort();
+
+	static const HashMap<int, int> empty_cob_hits;
+	for (const String &res_path : sorted_cobertura) {
+		const HashMap<int, int> *lines = p_hits.getptr(res_path);
+		_cobertura_write_class(f, res_path, lines ? *lines : empty_cob_hits,
+				p_func_hits.getptr(res_path),
+				p_branch_hits.getptr(res_path),
+				coverable.getptr(res_path));
 	}
 
 	f->store_line("  </classes></package></packages>");
@@ -692,7 +727,7 @@ static Error _write_json(const String &p_path,
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, "Cannot open coverage output: " + p_path);
 	HashMap<String, HashMap<int, int>> coverable = p_lang->_coverage_enumerate_coverable_lines();
 
-	// Union of all file paths.
+	// Union of all file paths, including coverable files never executed.
 	HashSet<String> all_files;
 	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {
 		all_files.insert(kv.key);
@@ -702,6 +737,9 @@ static Error _write_json(const String &p_path,
 	}
 	for (const KeyValue<String, HashMap<int, GDScriptLanguage::BranchResult>> &kv : p_branch_hits) {
 		all_files.insert(kv.key);
+	}
+	for (const KeyValue<String, HashMap<int, int>> &cv : coverable) {
+		all_files.insert(cv.key);
 	}
 	Vector<String> file_list;
 	for (const String &s : all_files) {

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -482,17 +482,23 @@ static void _lcov_write_functions(Ref<FileAccess> f, const HashMap<String, int> 
 static void _lcov_write_branches(Ref<FileAccess> f,
 		const HashMap<int, GDScriptLanguage::BranchResult> &p_branches,
 		int &r_brf, int &r_brh) {
+	// Sort by IP for deterministic output across runs.
+	Vector<int> sorted_ips;
 	for (const KeyValue<int, GDScriptLanguage::BranchResult> &bv : p_branches) {
-		int ip = bv.key;
-		int ln = bv.value.line;
+		sorted_ips.push_back(bv.key);
+	}
+	sorted_ips.sort();
+	for (int ip : sorted_ips) {
+		const GDScriptLanguage::BranchResult &br = *p_branches.getptr(ip);
+		int ln = br.line;
 		// BRDA format: line, block (ip), branch (0=taken/1=not_taken), count
-		f->store_line("BRDA:" + itos(ln) + "," + itos(ip) + ",0," + itos(bv.value.taken));
-		f->store_line("BRDA:" + itos(ln) + "," + itos(ip) + ",1," + itos(bv.value.not_taken));
+		f->store_line("BRDA:" + itos(ln) + "," + itos(ip) + ",0," + itos(br.taken));
+		f->store_line("BRDA:" + itos(ln) + "," + itos(ip) + ",1," + itos(br.not_taken));
 		r_brf += 2;
-		if (bv.value.taken > 0) {
+		if (br.taken > 0) {
 			r_brh++;
 		}
-		if (bv.value.not_taken > 0) {
+		if (br.not_taken > 0) {
 			r_brh++;
 		}
 	}
@@ -597,8 +603,13 @@ static void _cobertura_write_class(Ref<FileAccess> f, const String &p_res_path,
 
 	if (p_funcs) {
 		f->store_line("      <methods>");
+		Vector<String> sorted_methods;
 		for (const KeyValue<String, int> &fv : *p_funcs) {
-			f->store_line(vformat("        <method name=\"%s\" hits=\"%d\"/>", _xml_escape(fv.key), fv.value));
+			sorted_methods.push_back(fv.key);
+		}
+		sorted_methods.sort();
+		for (const String &fn : sorted_methods) {
+			f->store_line(vformat("        <method name=\"%s\" hits=\"%d\"/>", _xml_escape(fn), *p_funcs->getptr(fn)));
 		}
 		f->store_line("      </methods>");
 	}
@@ -708,13 +719,18 @@ static void _json_write_lines(Ref<FileAccess> f, const HashMap<int, int> &p_line
 
 static void _json_write_funcs(Ref<FileAccess> f, const HashMap<String, int> &p_funcs) {
 	f->store_string("      \"functions\": {");
-	bool first = true;
+	Vector<String> sorted_funcs;
 	for (const KeyValue<String, int> &fv : p_funcs) {
+		sorted_funcs.push_back(fv.key);
+	}
+	sorted_funcs.sort();
+	bool first = true;
+	for (const String &fn : sorted_funcs) {
 		if (!first) {
 			f->store_string(",");
 		}
 		first = false;
-		f->store_string("\"" + fv.key.c_escape() + "\":" + itos(fv.value));
+		f->store_string("\"" + fn.c_escape() + "\":" + itos(*p_funcs.getptr(fn)));
 	}
 	f->store_line("},");
 }

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -618,6 +618,15 @@ static void _cobertura_write_class(Ref<FileAccess> f, const String &p_res_path,
 		f->store_line("      </methods>");
 	}
 
+	// Build line → branch results index for per-line branch annotation.
+	// p_branches is keyed by VM instruction pointer; br.line maps each to its source line.
+	HashMap<int, Vector<const GDScriptLanguage::BranchResult *>> line_branches;
+	if (p_branches) {
+		for (const KeyValue<int, GDScriptLanguage::BranchResult> &bv : *p_branches) {
+			line_branches[bv.value.line].push_back(&bv.value);
+		}
+	}
+
 	// Emit all coverable lines (hit and not-hit).
 	HashMap<int, int> all_lines;
 	all_lines = p_lines;
@@ -635,7 +644,25 @@ static void _cobertura_write_class(Ref<FileAccess> f, const String &p_res_path,
 	}
 	lnums.sort();
 	for (int ln : lnums) {
-		f->store_line(vformat("        <line number=\"%d\" hits=\"%d\" branch=\"false\"/>", ln, *all_lines.getptr(ln)));
+		int hits = *all_lines.getptr(ln);
+		const Vector<const GDScriptLanguage::BranchResult *> *lbrs = line_branches.getptr(ln);
+		if (lbrs && !lbrs->is_empty()) {
+			int total = 0, covered = 0;
+			for (const GDScriptLanguage::BranchResult *br : *lbrs) {
+				total += 2;
+				if (br->taken > 0) {
+					covered++;
+				}
+				if (br->not_taken > 0) {
+					covered++;
+				}
+			}
+			int pct = total > 0 ? 100 * covered / total : 0;
+			f->store_line(vformat("        <line number=\"%d\" hits=\"%d\" branch=\"true\" condition-coverage=\"%d%% (%d/%d)\"/>",
+					ln, hits, pct, covered, total));
+		} else {
+			f->store_line(vformat("        <line number=\"%d\" hits=\"%d\" branch=\"false\"/>", ln, hits));
+		}
 	}
 	f->store_line("      </lines>");
 	f->store_line("    </class>");

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -218,7 +218,8 @@ static HashMap<String, CoverageFileStats> _gather_file_stats(
 		const HashMap<String, HashMap<int, int>> &p_hits,
 		const HashMap<String, HashMap<String, int>> &p_func_hits,
 		const HashMap<String, HashMap<int, GDScriptLanguage::BranchResult>> &p_branch_hits,
-		const HashMap<String, HashMap<int, int>> *p_coverable = nullptr) {
+		const HashMap<String, HashMap<int, int>> *p_coverable = nullptr,
+		const HashMap<String, HashMap<String, int>> *p_func_starts = nullptr) {
 	HashMap<String, CoverageFileStats> out;
 	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {
 		const HashMap<int, int> *cov = p_coverable ? p_coverable->getptr(kv.key) : nullptr;
@@ -237,6 +238,19 @@ static HashMap<String, CoverageFileStats> _gather_file_stats(
 		for (const KeyValue<String, HashMap<int, int>> &cv : *p_coverable) {
 			if (!out.has(cv.key)) {
 				_compute_line_stats(empty_hits, &cv.value, out[cv.key]);
+			}
+			// Count never-called functions in FNF so func% reflects reality.
+			if (p_func_starts && !p_func_hits.has(cv.key)) {
+				const HashMap<String, int> *fs = p_func_starts->getptr(cv.key);
+				if (fs) {
+					static const HashMap<String, int> zero_hit;
+					// Build zero-hit view: all functions from func_starts with count 0.
+					HashMap<String, int> never_called;
+					for (const KeyValue<String, int> &fv : *fs) {
+						never_called[fv.key] = 0;
+					}
+					_compute_func_stats(never_called, out[cv.key]);
+				}
 			}
 		}
 	}
@@ -263,7 +277,8 @@ bool GDScriptLanguage::coverage_check_threshold() const {
 		return true;
 	}
 	HashMap<String, HashMap<int, int>> coverable = _coverage_enumerate_coverable_lines();
-	HashMap<String, CoverageFileStats> stats = _gather_file_stats(coverage_hits, coverage_func_hits, coverage_branch_hits, &coverable);
+	HashMap<String, HashMap<String, int>> func_starts = _coverage_enumerate_func_start_lines();
+	HashMap<String, CoverageFileStats> stats = _gather_file_stats(coverage_hits, coverage_func_hits, coverage_branch_hits, &coverable, &func_starts);
 	CoverageFileStats t = _sum_totals(stats);
 	if (t.lines == 0) {
 		return true;
@@ -288,7 +303,8 @@ String GDScriptLanguage::coverage_summary_string() const {
 	static const int COL_FILE = 40;
 
 	HashMap<String, HashMap<int, int>> coverable = _coverage_enumerate_coverable_lines();
-	HashMap<String, CoverageFileStats> stats = _gather_file_stats(coverage_hits, coverage_func_hits, coverage_branch_hits, &coverable);
+	HashMap<String, HashMap<String, int>> func_starts = _coverage_enumerate_func_start_lines();
+	HashMap<String, CoverageFileStats> stats = _gather_file_stats(coverage_hits, coverage_func_hits, coverage_branch_hits, &coverable, &func_starts);
 	CoverageFileStats totals = _sum_totals(stats);
 
 	String out = String("File").rpad(COL_FILE) + String("Lines").rpad(9) + String("Funcs").rpad(9) + String("Branches").rpad(9) + "\n";
@@ -425,18 +441,33 @@ static Vector<int> _merge_line_hits(const HashMap<int, int> &p_hits,
 
 static void _lcov_write_functions(Ref<FileAccess> f, const HashMap<String, int> &p_funcs,
 		const HashMap<String, int> &p_starts) {
+	// Merge: start with all compiled functions (p_starts), then overlay recorded hits (p_funcs).
+	// Functions compiled but never called appear with FNDA:0. FN/FNDA are sorted for determinism.
+	HashMap<String, int> all_funcs;
+	for (const KeyValue<String, int> &sv : p_starts) {
+		all_funcs[sv.key] = 0;
+	}
 	for (const KeyValue<String, int> &fv : p_funcs) {
-		const int *ln = p_starts.getptr(fv.key);
-		f->store_line("FN:" + itos(ln ? *ln : 1) + "," + fv.key);
+		all_funcs[fv.key] = fv.value;
+	}
+	Vector<String> sorted_funcs;
+	for (const KeyValue<String, int> &fv : all_funcs) {
+		sorted_funcs.push_back(fv.key);
+	}
+	sorted_funcs.sort();
+	for (const String &fn : sorted_funcs) {
+		const int *ln = p_starts.getptr(fn);
+		f->store_line("FN:" + itos(ln ? *ln : 1) + "," + fn);
 	}
 	int fnh = 0;
-	for (const KeyValue<String, int> &fv : p_funcs) {
-		f->store_line("FNDA:" + itos(fv.value) + "," + fv.key);
-		if (fv.value > 0) {
+	for (const String &fn : sorted_funcs) {
+		int cnt = *all_funcs.getptr(fn);
+		f->store_line("FNDA:" + itos(cnt) + "," + fn);
+		if (cnt > 0) {
 			fnh++;
 		}
 	}
-	f->store_line("FNF:" + itos(p_funcs.size()));
+	f->store_line("FNF:" + itos(all_funcs.size()));
 	f->store_line("FNH:" + itos(fnh));
 }
 
@@ -508,10 +539,10 @@ static Error _write_lcov(const String &p_path,
 		f->store_line("SF:" + _coverage_globalize(res_path));
 
 		const HashMap<String, int> *funcs = p_func_hits.getptr(res_path);
-		if (funcs) {
-			static const HashMap<String, int> empty_starts;
-			const HashMap<String, int> *starts = func_starts.getptr(res_path);
-			_lcov_write_functions(f, *funcs, starts ? *starts : empty_starts);
+		const HashMap<String, int> *starts = func_starts.getptr(res_path);
+		if (funcs || starts) {
+			static const HashMap<String, int> empty_funcs;
+			_lcov_write_functions(f, funcs ? *funcs : empty_funcs, starts ? *starts : empty_funcs);
 		}
 
 		int brf = 0, brh = 0;
@@ -596,7 +627,8 @@ static Error _write_cobertura(const String &p_path,
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, "Cannot open coverage output: " + p_path);
 
 	HashMap<String, HashMap<int, int>> coverable = p_lang->_coverage_enumerate_coverable_lines();
-	HashMap<String, CoverageFileStats> stats = _gather_file_stats(p_hits, p_func_hits, p_branch_hits, &coverable);
+	HashMap<String, HashMap<String, int>> func_starts = p_lang->_coverage_enumerate_func_start_lines();
+	HashMap<String, CoverageFileStats> stats = _gather_file_stats(p_hits, p_func_hits, p_branch_hits, &coverable, &func_starts);
 	CoverageFileStats t = _sum_totals(stats);
 	float line_rate = t.lines > 0 ? (float)t.hit_lines / t.lines : 0.0f;
 	float branch_rate = t.branches > 0 ? (float)t.hit_branches / t.branches : 0.0f;
@@ -727,6 +759,7 @@ static Error _write_json(const String &p_path,
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, "Cannot open coverage output: " + p_path);
 	HashMap<String, HashMap<int, int>> coverable = p_lang->_coverage_enumerate_coverable_lines();
+	HashMap<String, HashMap<String, int>> func_starts = p_lang->_coverage_enumerate_func_start_lines();
 
 	// Union of all file paths, including coverable files never executed.
 	HashSet<String> all_files;
@@ -761,7 +794,7 @@ static Error _write_json(const String &p_path,
 	}
 	f->store_line("  },");
 
-	HashMap<String, CoverageFileStats> stats = _gather_file_stats(p_hits, p_func_hits, p_branch_hits, &coverable);
+	HashMap<String, CoverageFileStats> stats = _gather_file_stats(p_hits, p_func_hits, p_branch_hits, &coverable, &func_starts);
 	CoverageFileStats t = _sum_totals(stats);
 	float lp = t.lines > 0 ? 100.0f * t.hit_lines / t.lines : 0.0f;
 	float fp2 = t.funcs > 0 ? 100.0f * t.hit_funcs / t.funcs : 0.0f;

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -844,16 +844,28 @@ Error GDScriptLanguage::coverage_write() {
 		return ERR_UNCONFIGURED;
 	}
 
+	// Snapshot the coverage maps under the mutex so writers don't race with
+	// concurrent recording still happening on other threads.
+	HashMap<String, HashMap<int, int>> hits_snap;
+	HashMap<String, HashMap<String, int>> func_hits_snap;
+	HashMap<String, HashMap<int, BranchResult>> branch_hits_snap;
+	{
+		MutexLock lock(coverage_mutex);
+		hits_snap = coverage_hits;
+		func_hits_snap = coverage_func_hits;
+		branch_hits_snap = coverage_branch_hits;
+	}
+
 	Error err = OK;
 	switch (coverage_format) {
 		case COVERAGE_FORMAT_LCOV:
-			err = _write_lcov(coverage_output_path, coverage_hits, coverage_func_hits, coverage_branch_hits, this);
+			err = _write_lcov(coverage_output_path, hits_snap, func_hits_snap, branch_hits_snap, this);
 			break;
 		case COVERAGE_FORMAT_COBERTURA:
-			err = _write_cobertura(coverage_output_path, coverage_hits, coverage_func_hits, coverage_branch_hits, this);
+			err = _write_cobertura(coverage_output_path, hits_snap, func_hits_snap, branch_hits_snap, this);
 			break;
 		case COVERAGE_FORMAT_JSON:
-			err = _write_json(coverage_output_path, coverage_hits, coverage_func_hits, coverage_branch_hits, this);
+			err = _write_json(coverage_output_path, hits_snap, func_hits_snap, branch_hits_snap, this);
 			break;
 		case COVERAGE_FORMAT_TEXT: {
 			String summary = coverage_summary_string();

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -489,7 +489,7 @@ static void _lcov_write_functions(Ref<FileAccess> f, const HashMap<String, int> 
 	sorted_funcs.sort();
 	for (const String &fn : sorted_funcs) {
 		const int *ln = p_starts.getptr(fn);
-		f->store_line("FN:" + itos(ln ? *ln : 1) + "," + fn);
+		f->store_line("FN:" + itos(ln ? *ln : 0) + "," + fn); // 0 = unknown start line (e.g. lambda)
 	}
 	int fnh = 0;
 	for (const String &fn : sorted_funcs) {

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -315,9 +315,37 @@ static String _format_summary_row(const String &p_label, const CoverageFileStats
 	return p_label.rpad(p_col_file) + _format_pct_cell(lp, 9) + _format_pct_cell(fp, 9) + _format_pct_cell(bp, 9) + "\n";
 }
 
-String GDScriptLanguage::coverage_summary_string() {
+// Build the human-readable summary string from pre-computed per-file stats.
+// Separated from coverage_summary_string() so coverage_write() can pass the
+// already-snapshotted maps for consistency instead of taking a second snapshot.
+static String _format_coverage_summary(const HashMap<String, CoverageFileStats> &p_stats, float p_threshold) {
 	static const int COL_FILE = 40;
+	CoverageFileStats totals = _sum_totals(p_stats);
 
+	String out = String("File").rpad(COL_FILE) + String("Lines").rpad(9) + String("Funcs").rpad(9) + String("Branches").rpad(9) + "\n";
+
+	Vector<String> files;
+	for (const KeyValue<String, CoverageFileStats> &kv : p_stats) {
+		files.push_back(kv.key);
+	}
+	files.sort();
+	for (const String &path : files) {
+		out += _format_summary_row(path, *p_stats.getptr(path), COL_FILE);
+	}
+
+	String sep(U"────────────────────────────────────────────────────────────");
+	out += sep + "\n";
+	out += _format_summary_row("Total", totals, COL_FILE);
+
+	if (p_threshold > 0.0f) {
+		float pct = totals.lines > 0 ? 100.0f * totals.hit_lines / totals.lines : 0.0f;
+		bool pass = pct >= p_threshold;
+		out += "Threshold: " + String::num(p_threshold, 1) + "% " + (pass ? U"✓" : U"✗") + "\n";
+	}
+	return out;
+}
+
+String GDScriptLanguage::coverage_summary_string() {
 	// Snapshot under coverage_mutex so we don't race with ongoing recording.
 	HashMap<String, HashMap<int, int>> hits_snap;
 	HashMap<String, HashMap<String, int>> func_hits_snap;
@@ -331,29 +359,7 @@ String GDScriptLanguage::coverage_summary_string() {
 	HashMap<String, HashMap<int, int>> coverable = _coverage_enumerate_coverable_lines();
 	HashMap<String, HashMap<String, int>> func_starts = _coverage_enumerate_func_start_lines();
 	HashMap<String, CoverageFileStats> stats = _gather_file_stats(hits_snap, func_hits_snap, branch_hits_snap, &coverable, &func_starts);
-	CoverageFileStats totals = _sum_totals(stats);
-
-	String out = String("File").rpad(COL_FILE) + String("Lines").rpad(9) + String("Funcs").rpad(9) + String("Branches").rpad(9) + "\n";
-
-	Vector<String> files;
-	for (const KeyValue<String, CoverageFileStats> &kv : stats) {
-		files.push_back(kv.key);
-	}
-	files.sort();
-	for (const String &path : files) {
-		out += _format_summary_row(path, stats[path], COL_FILE);
-	}
-
-	String sep(U"────────────────────────────────────────────────────────────");
-	out += sep + "\n";
-	out += _format_summary_row("Total", totals, COL_FILE);
-
-	if (coverage_threshold > 0.0f) {
-		float pct = totals.lines > 0 ? 100.0f * totals.hit_lines / totals.lines : 0.0f;
-		bool pass = pct >= coverage_threshold;
-		out += "Threshold: " + String::num(coverage_threshold, 1) + "% " + (pass ? U"✓" : U"✗") + "\n";
-	}
-	return out;
+	return _format_coverage_summary(stats, coverage_threshold);
 }
 
 /*************** Bytecode enumeration ***************/
@@ -961,7 +967,10 @@ Error GDScriptLanguage::coverage_write() {
 			err = _write_json(coverage_output_path, hits_snap, func_hits_snap, branch_hits_snap, this);
 			break;
 		case COVERAGE_FORMAT_TEXT: {
-			String summary = coverage_summary_string();
+			HashMap<String, HashMap<int, int>> coverable = _coverage_enumerate_coverable_lines();
+			HashMap<String, HashMap<String, int>> func_starts = _coverage_enumerate_func_start_lines();
+			HashMap<String, CoverageFileStats> stats = _gather_file_stats(hits_snap, func_hits_snap, branch_hits_snap, &coverable, &func_starts);
+			String summary = _format_coverage_summary(stats, coverage_threshold);
 			print_line(summary);
 			err = _write_text(coverage_output_path, summary);
 		} break;

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -239,17 +239,20 @@ static HashMap<String, CoverageFileStats> _gather_file_stats(
 			if (!out.has(cv.key)) {
 				_compute_line_stats(empty_hits, &cv.value, out[cv.key]);
 			}
-			// Count never-called functions in FNF so func% reflects reality.
-			if (p_func_starts && !p_func_hits.has(cv.key)) {
-				const HashMap<String, int> *fs = p_func_starts->getptr(cv.key);
-				if (fs) {
-					static const HashMap<String, int> zero_hit;
-					// Build zero-hit view: all functions from func_starts with count 0.
-					HashMap<String, int> never_called;
-					for (const KeyValue<String, int> &fv : *fs) {
-						never_called[fv.key] = 0;
-					}
-					_compute_func_stats(never_called, out[cv.key]);
+		}
+	}
+	// Count compiled functions absent from p_func_hits (never called, or missing
+	// from a partial hit entry) so FNF reflects all compiled functions. Only
+	// consider files that passed the include/exclude filter (present in p_coverable).
+	if (p_func_starts) {
+		for (const KeyValue<String, HashMap<String, int>> &sv : *p_func_starts) {
+			if (p_coverable && !p_coverable->has(sv.key)) {
+				continue;
+			}
+			const HashMap<String, int> *fh = p_func_hits.getptr(sv.key);
+			for (const KeyValue<String, int> &fv : sv.value) {
+				if (!fh || !fh->has(fv.key)) {
+					out[sv.key].funcs++;
 				}
 			}
 		}

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -554,10 +554,16 @@ static Error _write_lcov(const String &p_path,
 	HashMap<String, HashMap<int, int>> coverable = p_lang->_coverage_enumerate_coverable_lines();
 	HashMap<String, HashMap<String, int>> func_starts = p_lang->_coverage_enumerate_func_start_lines();
 
-	// Sort the union of hit paths and coverable paths for deterministic output.
-	// Files compiled but never executed must appear with DA:line,0 entries.
+	// Union all four sources so a file that only has function or branch events
+	// (but no line hits) is not silently dropped, matching the JSON writer.
 	HashSet<String> path_set;
 	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {
+		path_set.insert(kv.key);
+	}
+	for (const KeyValue<String, HashMap<String, int>> &kv : p_func_hits) {
+		path_set.insert(kv.key);
+	}
+	for (const KeyValue<String, HashMap<int, GDScriptLanguage::BranchResult>> &kv : p_branch_hits) {
 		path_set.insert(kv.key);
 	}
 	for (const KeyValue<String, HashMap<int, int>> &cv : coverable) {
@@ -730,8 +736,16 @@ static Error _write_cobertura(const String &p_path,
 			(int64_t)ts, line_rate, branch_rate, t.hit_lines, t.lines, t.hit_branches, t.branches));
 	f->store_line("  <packages><package name=\"gdscript\"><classes>");
 
+	// Union all four sources to match the JSON writer — a file with only
+	// function or branch events (but no line hits) must not be silently dropped.
 	HashSet<String> cobertura_paths;
 	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {
+		cobertura_paths.insert(kv.key);
+	}
+	for (const KeyValue<String, HashMap<String, int>> &kv : p_func_hits) {
+		cobertura_paths.insert(kv.key);
+	}
+	for (const KeyValue<String, HashMap<int, GDScriptLanguage::BranchResult>> &kv : p_branch_hits) {
 		cobertura_paths.insert(kv.key);
 	}
 	for (const KeyValue<String, HashMap<int, int>> &cv : coverable) {

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -591,6 +591,7 @@ static void _lcov_write_branches(Ref<FileAccess> f,
 	}
 }
 
+// Emit DA (line hit) records for all lines in p_sorted_lines, followed by LF/LH totals.
 static void _lcov_write_lines(Ref<FileAccess> f, const Vector<int> &p_sorted_lines,
 		const HashMap<int, int> &p_all_lines) {
 	int lf = 0, lh = 0;
@@ -606,6 +607,9 @@ static void _lcov_write_lines(Ref<FileAccess> f, const Vector<int> &p_sorted_lin
 	f->store_line("LH:" + itos(lh));
 }
 
+// Write one complete LCOV record (TN/SF/FN*/FNDA*/FNF/FNH/BRDA*/BRF/BRH/DA*/LF/LH/end_of_record)
+// for a single source file. Merges runtime hits with compile-time coverable data so that
+// unexecuted lines and functions appear with count 0 rather than being omitted.
 static void _lcov_write_file_record(Ref<FileAccess> f, const String &p_res_path,
 		const HashMap<String, HashMap<int, int>> &p_hits,
 		const HashMap<String, HashMap<String, int>> &p_func_hits,

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -122,6 +122,7 @@ void GDScriptLanguage::coverage_record_line(const StringName &p_source, int p_li
 	if (!_coverage_path_included(path, coverage_include, coverage_exclude)) {
 		return;
 	}
+	MutexLock lock(coverage_mutex);
 	HashMap<int, int> &lines = coverage_hits[path];
 	if (coverage_mode == COVERAGE_MODE_COUNT) {
 		lines[p_line]++;
@@ -135,6 +136,7 @@ void GDScriptLanguage::coverage_record_func_entry(const StringName &p_source, co
 	if (!_coverage_path_included(path, coverage_include, coverage_exclude)) {
 		return;
 	}
+	MutexLock lock(coverage_mutex);
 	HashMap<String, int> &funcs = coverage_func_hits[path];
 	if (coverage_mode == COVERAGE_MODE_COUNT) {
 		funcs[String(p_func)]++;
@@ -148,6 +150,7 @@ void GDScriptLanguage::coverage_record_branch(const StringName &p_source, int p_
 	if (!_coverage_path_included(path, coverage_include, coverage_exclude)) {
 		return;
 	}
+	MutexLock lock(coverage_mutex);
 	BranchResult &br = coverage_branch_hits[path][p_ip];
 	br.line = p_line; // store for LCOV BRDA output
 	if (p_taken) {
@@ -275,7 +278,7 @@ static CoverageFileStats _sum_totals(const HashMap<String, CoverageFileStats> &p
 
 /*************** Threshold and summary ***************/
 
-bool GDScriptLanguage::coverage_check_threshold() const {
+bool GDScriptLanguage::coverage_check_threshold() {
 	if (coverage_threshold <= 0.0f) {
 		return true;
 	}
@@ -302,7 +305,7 @@ static String _format_summary_row(const String &p_label, const CoverageFileStats
 	return p_label.rpad(p_col_file) + _format_pct_cell(lp, 9) + _format_pct_cell(fp, 9) + _format_pct_cell(bp, 9) + "\n";
 }
 
-String GDScriptLanguage::coverage_summary_string() const {
+String GDScriptLanguage::coverage_summary_string() {
 	static const int COL_FILE = 40;
 
 	HashMap<String, HashMap<int, int>> coverable = _coverage_enumerate_coverable_lines();
@@ -390,8 +393,9 @@ void GDScriptLanguage::_coverage_collect_func_starts(const GDScript *p_script, H
 }
 
 // Build a per-file map of function name → start line from script_list.
-HashMap<String, HashMap<String, int>> GDScriptLanguage::_coverage_enumerate_func_start_lines() const {
+HashMap<String, HashMap<String, int>> GDScriptLanguage::_coverage_enumerate_func_start_lines() {
 	HashMap<String, HashMap<String, int>> result;
+	MutexLock lock(mutex);
 	const SelfList<GDScript> *s = script_list.first();
 	while (s) {
 		const GDScript *scr = s->self();
@@ -404,8 +408,9 @@ HashMap<String, HashMap<String, int>> GDScriptLanguage::_coverage_enumerate_func
 	return result;
 }
 
-HashMap<String, HashMap<int, int>> GDScriptLanguage::_coverage_enumerate_coverable_lines() const {
+HashMap<String, HashMap<int, int>> GDScriptLanguage::_coverage_enumerate_coverable_lines() {
 	HashMap<String, HashMap<int, int>> coverable;
+	MutexLock lock(mutex);
 	const SelfList<GDScript> *s = script_list.first();
 	while (s) {
 		GDScript *scr = s->self();

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -738,14 +738,21 @@ static void _json_write_funcs(Ref<FileAccess> f, const HashMap<String, int> &p_f
 static void _json_write_branches(Ref<FileAccess> f,
 		const HashMap<int, GDScriptLanguage::BranchResult> &p_branches) {
 	f->store_string("      \"branches\": {");
-	bool first = true;
+	// Sort by IP for deterministic output, matching the sorted output of _json_write_lines.
+	Vector<int> sorted_ips;
 	for (const KeyValue<int, GDScriptLanguage::BranchResult> &bv : p_branches) {
+		sorted_ips.push_back(bv.key);
+	}
+	sorted_ips.sort();
+	bool first = true;
+	for (int ip : sorted_ips) {
+		const GDScriptLanguage::BranchResult &br = *p_branches.getptr(ip);
 		if (!first) {
 			f->store_string(",");
 		}
 		first = false;
-		f->store_string("\"" + itos(bv.key) + "_taken\":" + itos(bv.value.taken) + ",");
-		f->store_string("\"" + itos(bv.key) + "_not_taken\":" + itos(bv.value.not_taken));
+		f->store_string("\"" + itos(ip) + "_taken\":" + itos(br.taken) + ",");
+		f->store_string("\"" + itos(ip) + "_not_taken\":" + itos(br.not_taken));
 	}
 	f->store_line("}");
 }

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -217,6 +217,39 @@ static void _compute_branch_stats(const HashMap<int, GDScriptLanguage::BranchRes
 	}
 }
 
+// Add stats for files compiled and filtered in but never executed at all.
+static void _add_unexecuted_file_stats(
+		HashMap<String, CoverageFileStats> &r_out,
+		const HashMap<String, HashMap<int, int>> &p_coverable) {
+	static const HashMap<int, int> empty_hits;
+	for (const KeyValue<String, HashMap<int, int>> &cv : p_coverable) {
+		if (!r_out.has(cv.key)) {
+			_compute_line_stats(empty_hits, &cv.value, r_out[cv.key]);
+		}
+	}
+}
+
+// Count compiled functions absent from p_func_hits so FNF reflects all compiled
+// functions, not just those called at least once. Only processes files present in
+// p_coverable (i.e. that passed the include/exclude filter).
+static void _add_uncalled_func_stats(
+		HashMap<String, CoverageFileStats> &r_out,
+		const HashMap<String, HashMap<String, int>> &p_func_hits,
+		const HashMap<String, HashMap<String, int>> &p_func_starts,
+		const HashMap<String, HashMap<int, int>> *p_coverable) {
+	for (const KeyValue<String, HashMap<String, int>> &sv : p_func_starts) {
+		if (p_coverable && !p_coverable->has(sv.key)) {
+			continue;
+		}
+		const HashMap<String, int> *fh = p_func_hits.getptr(sv.key);
+		for (const KeyValue<String, int> &fv : sv.value) {
+			if (!fh || !fh->has(fv.key)) {
+				r_out[sv.key].funcs++;
+			}
+		}
+	}
+}
+
 static HashMap<String, CoverageFileStats> _gather_file_stats(
 		const HashMap<String, HashMap<int, int>> &p_hits,
 		const HashMap<String, HashMap<String, int>> &p_func_hits,
@@ -234,31 +267,11 @@ static HashMap<String, CoverageFileStats> _gather_file_stats(
 	for (const KeyValue<String, HashMap<int, GDScriptLanguage::BranchResult>> &kv : p_branch_hits) {
 		_compute_branch_stats(kv.value, out[kv.key]);
 	}
-	// Files that were compiled and filtered-in but never executed at all must
-	// appear in stats as 0% covered rather than being invisible.
 	if (p_coverable) {
-		static const HashMap<int, int> empty_hits;
-		for (const KeyValue<String, HashMap<int, int>> &cv : *p_coverable) {
-			if (!out.has(cv.key)) {
-				_compute_line_stats(empty_hits, &cv.value, out[cv.key]);
-			}
-		}
+		_add_unexecuted_file_stats(out, *p_coverable);
 	}
-	// Count compiled functions absent from p_func_hits (never called, or missing
-	// from a partial hit entry) so FNF reflects all compiled functions. Only
-	// consider files that passed the include/exclude filter (present in p_coverable).
 	if (p_func_starts) {
-		for (const KeyValue<String, HashMap<String, int>> &sv : *p_func_starts) {
-			if (p_coverable && !p_coverable->has(sv.key)) {
-				continue;
-			}
-			const HashMap<String, int> *fh = p_func_hits.getptr(sv.key);
-			for (const KeyValue<String, int> &fv : sv.value) {
-				if (!fh || !fh->has(fv.key)) {
-					out[sv.key].funcs++;
-				}
-			}
-		}
+		_add_uncalled_func_stats(out, p_func_hits, *p_func_starts, p_coverable);
 	}
 	return out;
 }
@@ -475,6 +488,35 @@ static Vector<int> _merge_line_hits(const HashMap<int, int> &p_hits,
 	return sorted_lines;
 }
 
+// Build a sorted list of all file paths appearing in any of the four coverage maps.
+// Used by all format writers to ensure files with only function or branch events
+// (but no line hits) are not silently dropped from the output.
+static Vector<String> _build_sorted_path_union(
+		const HashMap<String, HashMap<int, int>> &p_hits,
+		const HashMap<String, HashMap<String, int>> &p_func_hits,
+		const HashMap<String, HashMap<int, GDScriptLanguage::BranchResult>> &p_branch_hits,
+		const HashMap<String, HashMap<int, int>> &p_coverable) {
+	HashSet<String> s;
+	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {
+		s.insert(kv.key);
+	}
+	for (const KeyValue<String, HashMap<String, int>> &kv : p_func_hits) {
+		s.insert(kv.key);
+	}
+	for (const KeyValue<String, HashMap<int, GDScriptLanguage::BranchResult>> &kv : p_branch_hits) {
+		s.insert(kv.key);
+	}
+	for (const KeyValue<String, HashMap<int, int>> &cv : p_coverable) {
+		s.insert(cv.key);
+	}
+	Vector<String> result;
+	for (const String &path : s) {
+		result.push_back(path);
+	}
+	result.sort();
+	return result;
+}
+
 /*************** LCOV writer ***************/
 
 static void _lcov_write_functions(Ref<FileAccess> f, const HashMap<String, int> &p_funcs,
@@ -549,6 +591,38 @@ static void _lcov_write_lines(Ref<FileAccess> f, const Vector<int> &p_sorted_lin
 	f->store_line("LH:" + itos(lh));
 }
 
+static void _lcov_write_file_record(Ref<FileAccess> f, const String &p_res_path,
+		const HashMap<String, HashMap<int, int>> &p_hits,
+		const HashMap<String, HashMap<String, int>> &p_func_hits,
+		const HashMap<String, HashMap<int, GDScriptLanguage::BranchResult>> &p_branch_hits,
+		const HashMap<String, HashMap<int, int>> &p_coverable,
+		const HashMap<String, HashMap<String, int>> &p_func_starts) {
+	static const HashMap<int, int> empty_hits;
+	static const HashMap<String, int> empty_funcs;
+	const HashMap<int, int> *hits_ptr = p_hits.getptr(p_res_path);
+	f->store_line("TN:");
+	f->store_line("SF:" + _coverage_globalize(p_res_path));
+
+	const HashMap<String, int> *funcs = p_func_hits.getptr(p_res_path);
+	const HashMap<String, int> *starts = p_func_starts.getptr(p_res_path);
+	if (funcs || starts) {
+		_lcov_write_functions(f, funcs ? *funcs : empty_funcs, starts ? *starts : empty_funcs);
+	}
+
+	int brf = 0, brh = 0;
+	const HashMap<int, GDScriptLanguage::BranchResult> *branches = p_branch_hits.getptr(p_res_path);
+	if (branches) {
+		_lcov_write_branches(f, *branches, brf, brh);
+		f->store_line("BRF:" + itos(brf));
+		f->store_line("BRH:" + itos(brh));
+	}
+
+	HashMap<int, int> all_lines;
+	Vector<int> sorted = _merge_line_hits(hits_ptr ? *hits_ptr : empty_hits, p_coverable, p_res_path, all_lines);
+	_lcov_write_lines(f, sorted, all_lines);
+	f->store_line("end_of_record");
+}
+
 static Error _write_lcov(const String &p_path,
 		const HashMap<String, HashMap<int, int>> &p_hits,
 		const HashMap<String, HashMap<String, int>> &p_func_hits,
@@ -559,55 +633,9 @@ static Error _write_lcov(const String &p_path,
 
 	HashMap<String, HashMap<int, int>> coverable = p_lang->_coverage_enumerate_coverable_lines();
 	HashMap<String, HashMap<String, int>> func_starts = p_lang->_coverage_enumerate_func_start_lines();
-
-	// Union all four sources so a file that only has function or branch events
-	// (but no line hits) is not silently dropped, matching the JSON writer.
-	HashSet<String> path_set;
-	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {
-		path_set.insert(kv.key);
-	}
-	for (const KeyValue<String, HashMap<String, int>> &kv : p_func_hits) {
-		path_set.insert(kv.key);
-	}
-	for (const KeyValue<String, HashMap<int, GDScriptLanguage::BranchResult>> &kv : p_branch_hits) {
-		path_set.insert(kv.key);
-	}
-	for (const KeyValue<String, HashMap<int, int>> &cv : coverable) {
-		path_set.insert(cv.key);
-	}
-	Vector<String> sorted_paths;
-	for (const String &s : path_set) {
-		sorted_paths.push_back(s);
-	}
-	sorted_paths.sort();
-
-	static const HashMap<int, int> empty_hits;
+	Vector<String> sorted_paths = _build_sorted_path_union(p_hits, p_func_hits, p_branch_hits, coverable);
 	for (const String &res_path : sorted_paths) {
-		const HashMap<int, int> *hits_ptr = p_hits.getptr(res_path);
-		const HashMap<int, int> &lines_for_path = hits_ptr ? *hits_ptr : empty_hits;
-		f->store_line("TN:");
-		f->store_line("SF:" + _coverage_globalize(res_path));
-
-		const HashMap<String, int> *funcs = p_func_hits.getptr(res_path);
-		const HashMap<String, int> *starts = func_starts.getptr(res_path);
-		if (funcs || starts) {
-			static const HashMap<String, int> empty_funcs;
-			_lcov_write_functions(f, funcs ? *funcs : empty_funcs, starts ? *starts : empty_funcs);
-		}
-
-		int brf = 0, brh = 0;
-		const HashMap<int, GDScriptLanguage::BranchResult> *branches = p_branch_hits.getptr(res_path);
-		if (branches) {
-			_lcov_write_branches(f, *branches, brf, brh);
-			f->store_line("BRF:" + itos(brf));
-			f->store_line("BRH:" + itos(brh));
-		}
-
-		HashMap<int, int> all_lines;
-		Vector<int> sorted = _merge_line_hits(lines_for_path, coverable, res_path, all_lines);
-		_lcov_write_lines(f, sorted, all_lines);
-
-		f->store_line("end_of_record");
+		_lcov_write_file_record(f, res_path, p_hits, p_func_hits, p_branch_hits, coverable, func_starts);
 	}
 	return OK;
 }
@@ -616,6 +644,104 @@ static Error _write_lcov(const String &p_path,
 
 static String _xml_escape(const String &p_str) {
 	return p_str.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;").replace("'", "&apos;");
+}
+
+// Build the merged all_methods map: runtime hits from p_funcs, compile-time entries
+// from p_func_starts for functions never called (hits = 0).
+static HashMap<String, int> _cobertura_build_all_methods(
+		const HashMap<String, int> *p_funcs,
+		const HashMap<String, int> *p_func_starts) {
+	HashMap<String, int> all;
+	if (p_funcs) {
+		for (const KeyValue<String, int> &fv : *p_funcs) {
+			all[fv.key] = fv.value;
+		}
+	}
+	if (p_func_starts) {
+		for (const KeyValue<String, int> &sv : *p_func_starts) {
+			if (!all.has(sv.key)) {
+				all[sv.key] = 0;
+			}
+		}
+	}
+	return all;
+}
+
+// Emit the <methods> XML block from a merged method→hits map. No-ops if empty.
+static void _cobertura_emit_methods(Ref<FileAccess> f, const HashMap<String, int> &p_all_methods) {
+	if (p_all_methods.is_empty()) {
+		return;
+	}
+	Vector<String> sorted;
+	for (const KeyValue<String, int> &mv : p_all_methods) {
+		sorted.push_back(mv.key);
+	}
+	sorted.sort();
+	f->store_line("      <methods>");
+	for (const String &fn : sorted) {
+		f->store_line(vformat("        <method name=\"%s\" hits=\"%d\"/>", _xml_escape(fn), *p_all_methods.getptr(fn)));
+	}
+	f->store_line("      </methods>");
+}
+
+// Index branch results by source line number.
+// p_branches is keyed by VM instruction pointer; br.line maps each to its source line.
+static HashMap<int, Vector<const GDScriptLanguage::BranchResult *>> _cobertura_build_line_branch_index(
+		const HashMap<int, GDScriptLanguage::BranchResult> *p_branches) {
+	HashMap<int, Vector<const GDScriptLanguage::BranchResult *>> index;
+	if (p_branches) {
+		for (const KeyValue<int, GDScriptLanguage::BranchResult> &bv : *p_branches) {
+			index[bv.value.line].push_back(&bv.value);
+		}
+	}
+	return index;
+}
+
+// Emit one <line> element with branch annotation when branch data is present.
+static void _cobertura_write_line_element(Ref<FileAccess> f, int p_ln, int p_hits,
+		const Vector<const GDScriptLanguage::BranchResult *> *p_lbrs) {
+	if (!p_lbrs || p_lbrs->is_empty()) {
+		f->store_line(vformat("        <line number=\"%d\" hits=\"%d\" branch=\"false\"/>", p_ln, p_hits));
+		return;
+	}
+	int total = 0, covered = 0;
+	for (const GDScriptLanguage::BranchResult *br : *p_lbrs) {
+		total += 2;
+		if (br->taken > 0) {
+			covered++;
+		}
+		if (br->not_taken > 0) {
+			covered++;
+		}
+	}
+	int pct = total > 0 ? 100 * covered / total : 0;
+	f->store_line(vformat("        <line number=\"%d\" hits=\"%d\" branch=\"true\" condition-coverage=\"%d%% (%d/%d)\"/>",
+			p_ln, p_hits, pct, covered, total));
+}
+
+// Emit the <lines> block for all coverable lines (hit and not-hit).
+static void _cobertura_write_lines_block(Ref<FileAccess> f,
+		const HashMap<int, int> &p_lines,
+		const HashMap<int, int> *p_coverable,
+		const HashMap<int, Vector<const GDScriptLanguage::BranchResult *>> &p_line_branches) {
+	HashMap<int, int> all_lines = p_lines;
+	if (p_coverable) {
+		for (const KeyValue<int, int> &cv : *p_coverable) {
+			if (!all_lines.has(cv.key)) {
+				all_lines[cv.key] = 0;
+			}
+		}
+	}
+	Vector<int> lnums;
+	for (const KeyValue<int, int> &lv : all_lines) {
+		lnums.push_back(lv.key);
+	}
+	lnums.sort();
+	f->store_line("      <lines>");
+	for (int ln : lnums) {
+		_cobertura_write_line_element(f, ln, *all_lines.getptr(ln), p_line_branches.getptr(ln));
+	}
+	f->store_line("      </lines>");
 }
 
 static void _cobertura_write_class(Ref<FileAccess> f, const String &p_res_path,
@@ -640,83 +766,12 @@ static void _cobertura_write_class(Ref<FileAccess> f, const String &p_res_path,
 	f->store_line(vformat("    <class name=\"%s\" filename=\"%s\" line-rate=\"%.4f\" branch-rate=\"%.4f\">",
 			class_name, _xml_escape(_coverage_globalize(p_res_path)), flr, fbr));
 
-	// Emit <methods>: merge runtime hits with compile-time starts so that
-	// unexecuted functions appear with hits="0", matching the LCOV writer.
-	{
-		HashMap<String, int> all_methods;
-		if (p_funcs) {
-			for (const KeyValue<String, int> &fv : *p_funcs) {
-				all_methods[fv.key] = fv.value;
-			}
-		}
-		if (p_func_starts) {
-			for (const KeyValue<String, int> &sv : *p_func_starts) {
-				if (!all_methods.has(sv.key)) {
-					all_methods[sv.key] = 0;
-				}
-			}
-		}
-		if (!all_methods.is_empty()) {
-			f->store_line("      <methods>");
-			Vector<String> sorted_methods;
-			for (const KeyValue<String, int> &mv : all_methods) {
-				sorted_methods.push_back(mv.key);
-			}
-			sorted_methods.sort();
-			for (const String &fn : sorted_methods) {
-				f->store_line(vformat("        <method name=\"%s\" hits=\"%d\"/>", _xml_escape(fn), *all_methods.getptr(fn)));
-			}
-			f->store_line("      </methods>");
-		}
-	}
+	HashMap<String, int> all_methods = _cobertura_build_all_methods(p_funcs, p_func_starts);
+	_cobertura_emit_methods(f, all_methods);
 
-	// Build line → branch results index for per-line branch annotation.
-	// p_branches is keyed by VM instruction pointer; br.line maps each to its source line.
-	HashMap<int, Vector<const GDScriptLanguage::BranchResult *>> line_branches;
-	if (p_branches) {
-		for (const KeyValue<int, GDScriptLanguage::BranchResult> &bv : *p_branches) {
-			line_branches[bv.value.line].push_back(&bv.value);
-		}
-	}
+	HashMap<int, Vector<const GDScriptLanguage::BranchResult *>> line_branches = _cobertura_build_line_branch_index(p_branches);
+	_cobertura_write_lines_block(f, p_lines, p_coverable, line_branches);
 
-	// Emit all coverable lines (hit and not-hit).
-	HashMap<int, int> all_lines;
-	all_lines = p_lines;
-	if (p_coverable) {
-		for (const KeyValue<int, int> &cv : *p_coverable) {
-			if (!all_lines.has(cv.key)) {
-				all_lines[cv.key] = 0;
-			}
-		}
-	}
-	f->store_line("      <lines>");
-	Vector<int> lnums;
-	for (const KeyValue<int, int> &lv : all_lines) {
-		lnums.push_back(lv.key);
-	}
-	lnums.sort();
-	for (int ln : lnums) {
-		int hits = *all_lines.getptr(ln);
-		const Vector<const GDScriptLanguage::BranchResult *> *lbrs = line_branches.getptr(ln);
-		if (lbrs && !lbrs->is_empty()) {
-			int total = 0, covered = 0;
-			for (const GDScriptLanguage::BranchResult *br : *lbrs) {
-				total += 2;
-				if (br->taken > 0) {
-					covered++;
-				}
-				if (br->not_taken > 0) {
-					covered++;
-				}
-			}
-			int pct = total > 0 ? 100 * covered / total : 0;
-			f->store_line(vformat("        <line number=\"%d\" hits=\"%d\" branch=\"true\" condition-coverage=\"%d%% (%d/%d)\"/>",
-					ln, hits, pct, covered, total));
-		} else {
-			f->store_line(vformat("        <line number=\"%d\" hits=\"%d\" branch=\"false\"/>", ln, hits));
-		}
-	}
-	f->store_line("      </lines>");
 	f->store_line("    </class>");
 }
 
@@ -742,27 +797,7 @@ static Error _write_cobertura(const String &p_path,
 			(int64_t)ts, line_rate, branch_rate, t.hit_lines, t.lines, t.hit_branches, t.branches));
 	f->store_line("  <packages><package name=\"gdscript\"><classes>");
 
-	// Union all four sources to match the JSON writer — a file with only
-	// function or branch events (but no line hits) must not be silently dropped.
-	HashSet<String> cobertura_paths;
-	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {
-		cobertura_paths.insert(kv.key);
-	}
-	for (const KeyValue<String, HashMap<String, int>> &kv : p_func_hits) {
-		cobertura_paths.insert(kv.key);
-	}
-	for (const KeyValue<String, HashMap<int, GDScriptLanguage::BranchResult>> &kv : p_branch_hits) {
-		cobertura_paths.insert(kv.key);
-	}
-	for (const KeyValue<String, HashMap<int, int>> &cv : coverable) {
-		cobertura_paths.insert(cv.key);
-	}
-	Vector<String> sorted_cobertura;
-	for (const String &s : cobertura_paths) {
-		sorted_cobertura.push_back(s);
-	}
-	sorted_cobertura.sort();
-
+	Vector<String> sorted_cobertura = _build_sorted_path_union(p_hits, p_func_hits, p_branch_hits, coverable);
 	static const HashMap<int, int> empty_cob_hits;
 	for (const String &res_path : sorted_cobertura) {
 		const HashMap<int, int> *lines = p_hits.getptr(res_path);
@@ -884,25 +919,7 @@ static Error _write_json(const String &p_path,
 	HashMap<String, HashMap<int, int>> coverable = p_lang->_coverage_enumerate_coverable_lines();
 	HashMap<String, HashMap<String, int>> func_starts = p_lang->_coverage_enumerate_func_start_lines();
 
-	// Union of all file paths, including coverable files never executed.
-	HashSet<String> all_files;
-	for (const KeyValue<String, HashMap<int, int>> &kv : p_hits) {
-		all_files.insert(kv.key);
-	}
-	for (const KeyValue<String, HashMap<String, int>> &kv : p_func_hits) {
-		all_files.insert(kv.key);
-	}
-	for (const KeyValue<String, HashMap<int, GDScriptLanguage::BranchResult>> &kv : p_branch_hits) {
-		all_files.insert(kv.key);
-	}
-	for (const KeyValue<String, HashMap<int, int>> &cv : coverable) {
-		all_files.insert(cv.key);
-	}
-	Vector<String> file_list;
-	for (const String &s : all_files) {
-		file_list.push_back(s);
-	}
-	file_list.sort();
+	Vector<String> file_list = _build_sorted_path_union(p_hits, p_func_hits, p_branch_hits, coverable);
 
 	f->store_line("{");
 	f->store_line("  \"files\": {");

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -282,9 +282,19 @@ bool GDScriptLanguage::coverage_check_threshold() {
 	if (coverage_threshold <= 0.0f) {
 		return true;
 	}
+	// Snapshot under coverage_mutex so we don't race with ongoing recording.
+	HashMap<String, HashMap<int, int>> hits_snap;
+	HashMap<String, HashMap<String, int>> func_hits_snap;
+	HashMap<String, HashMap<int, BranchResult>> branch_hits_snap;
+	{
+		MutexLock lock(coverage_mutex);
+		hits_snap = coverage_hits;
+		func_hits_snap = coverage_func_hits;
+		branch_hits_snap = coverage_branch_hits;
+	}
 	HashMap<String, HashMap<int, int>> coverable = _coverage_enumerate_coverable_lines();
 	HashMap<String, HashMap<String, int>> func_starts = _coverage_enumerate_func_start_lines();
-	HashMap<String, CoverageFileStats> stats = _gather_file_stats(coverage_hits, coverage_func_hits, coverage_branch_hits, &coverable, &func_starts);
+	HashMap<String, CoverageFileStats> stats = _gather_file_stats(hits_snap, func_hits_snap, branch_hits_snap, &coverable, &func_starts);
 	CoverageFileStats t = _sum_totals(stats);
 	if (t.lines == 0) {
 		return true;
@@ -308,9 +318,19 @@ static String _format_summary_row(const String &p_label, const CoverageFileStats
 String GDScriptLanguage::coverage_summary_string() {
 	static const int COL_FILE = 40;
 
+	// Snapshot under coverage_mutex so we don't race with ongoing recording.
+	HashMap<String, HashMap<int, int>> hits_snap;
+	HashMap<String, HashMap<String, int>> func_hits_snap;
+	HashMap<String, HashMap<int, BranchResult>> branch_hits_snap;
+	{
+		MutexLock lock(coverage_mutex);
+		hits_snap = coverage_hits;
+		func_hits_snap = coverage_func_hits;
+		branch_hits_snap = coverage_branch_hits;
+	}
 	HashMap<String, HashMap<int, int>> coverable = _coverage_enumerate_coverable_lines();
 	HashMap<String, HashMap<String, int>> func_starts = _coverage_enumerate_func_start_lines();
-	HashMap<String, CoverageFileStats> stats = _gather_file_stats(coverage_hits, coverage_func_hits, coverage_branch_hits, &coverable, &func_starts);
+	HashMap<String, CoverageFileStats> stats = _gather_file_stats(hits_snap, func_hits_snap, branch_hits_snap, &coverable, &func_starts);
 	CoverageFileStats totals = _sum_totals(stats);
 
 	String out = String("File").rpad(COL_FILE) + String("Lines").rpad(9) + String("Funcs").rpad(9) + String("Branches").rpad(9) + "\n";

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -747,7 +747,7 @@ static void _cobertura_write_lines_block(Ref<FileAccess> f,
 		const HashMap<int, int> &p_lines,
 		const HashMap<int, int> *p_coverable,
 		const HashMap<int, Vector<const GDScriptLanguage::BranchResult *>> &p_line_branches) {
-	HashMap<int, int> all_lines = p_lines;
+	HashMap<int, int> all_lines(p_lines);
 	if (p_coverable) {
 		for (const KeyValue<int, int> &cv : *p_coverable) {
 			if (!all_lines.has(cv.key)) {

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -610,7 +610,8 @@ static void _cobertura_write_class(Ref<FileAccess> f, const String &p_res_path,
 		const HashMap<int, int> &p_lines,
 		const HashMap<String, int> *p_funcs,
 		const HashMap<int, GDScriptLanguage::BranchResult> *p_branches,
-		const HashMap<int, int> *p_coverable) {
+		const HashMap<int, int> *p_coverable,
+		const HashMap<String, int> *p_func_starts = nullptr) {
 	CoverageFileStats fs;
 	_compute_line_stats(p_lines, p_coverable, fs);
 	if (p_funcs) {
@@ -622,20 +623,39 @@ static void _cobertura_write_class(Ref<FileAccess> f, const String &p_res_path,
 	float flr = fs.lines > 0 ? (float)fs.hit_lines / fs.lines : 0.0f;
 	float fbr = fs.branches > 0 ? (float)fs.hit_branches / fs.branches : 0.0f;
 
-	f->store_line(vformat("    <class filename=\"%s\" line-rate=\"%.4f\" branch-rate=\"%.4f\">",
-			_xml_escape(_coverage_globalize(p_res_path)), flr, fbr));
+	// DTD requires name= (class identifier) and filename= (relative path).
+	String class_name = _xml_escape(p_res_path.get_file().get_basename());
+	f->store_line(vformat("    <class name=\"%s\" filename=\"%s\" line-rate=\"%.4f\" branch-rate=\"%.4f\">",
+			class_name, _xml_escape(_coverage_globalize(p_res_path)), flr, fbr));
 
-	if (p_funcs) {
-		f->store_line("      <methods>");
-		Vector<String> sorted_methods;
-		for (const KeyValue<String, int> &fv : *p_funcs) {
-			sorted_methods.push_back(fv.key);
+	// Emit <methods>: merge runtime hits with compile-time starts so that
+	// unexecuted functions appear with hits="0", matching the LCOV writer.
+	{
+		HashMap<String, int> all_methods;
+		if (p_funcs) {
+			for (const KeyValue<String, int> &fv : *p_funcs) {
+				all_methods[fv.key] = fv.value;
+			}
 		}
-		sorted_methods.sort();
-		for (const String &fn : sorted_methods) {
-			f->store_line(vformat("        <method name=\"%s\" hits=\"%d\"/>", _xml_escape(fn), *p_funcs->getptr(fn)));
+		if (p_func_starts) {
+			for (const KeyValue<String, int> &sv : *p_func_starts) {
+				if (!all_methods.has(sv.key)) {
+					all_methods[sv.key] = 0;
+				}
+			}
 		}
-		f->store_line("      </methods>");
+		if (!all_methods.is_empty()) {
+			f->store_line("      <methods>");
+			Vector<String> sorted_methods;
+			for (const KeyValue<String, int> &mv : all_methods) {
+				sorted_methods.push_back(mv.key);
+			}
+			sorted_methods.sort();
+			for (const String &fn : sorted_methods) {
+				f->store_line(vformat("        <method name=\"%s\" hits=\"%d\"/>", _xml_escape(fn), *all_methods.getptr(fn)));
+			}
+			f->store_line("      </methods>");
+		}
 	}
 
 	// Build line → branch results index for per-line branch annotation.
@@ -729,7 +749,8 @@ static Error _write_cobertura(const String &p_path,
 		_cobertura_write_class(f, res_path, lines ? *lines : empty_cob_hits,
 				p_func_hits.getptr(res_path),
 				p_branch_hits.getptr(res_path),
-				coverable.getptr(res_path));
+				coverable.getptr(res_path),
+				func_starts.getptr(res_path));
 	}
 
 	f->store_line("  </classes></package></packages>");

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -80,7 +80,7 @@ void GDScriptLanguage::coverage_start() {
 	coverage_func_hits.clear();
 	coverage_branch_hits.clear();
 	coverage_written = false;
-	coverage_enabled = true;
+	coverage_enabled.set();
 }
 
 /*************** Path and filter helpers ***************/
@@ -780,7 +780,7 @@ static void _cobertura_write_class(Ref<FileAccess> f, const String &p_res_path,
 	float flr = fs.lines > 0 ? (float)fs.hit_lines / fs.lines : 0.0f;
 	float fbr = fs.branches > 0 ? (float)fs.hit_branches / fs.branches : 0.0f;
 
-	// DTD requires name= (class identifier) and filename= (relative path).
+	// DTD requires name= (class identifier) and filename= (absolute filesystem path).
 	String class_name = _xml_escape(p_res_path.get_file().get_basename());
 	f->store_line(vformat("    <class name=\"%s\" filename=\"%s\" line-rate=\"%.4f\" branch-rate=\"%.4f\">",
 			class_name, _xml_escape(_coverage_globalize(p_res_path)), flr, fbr));
@@ -814,7 +814,8 @@ static Error _write_cobertura(const String &p_path,
 	f->store_line("<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">");
 	f->store_line(vformat("<coverage version=\"5.0\" timestamp=\"%d\" line-rate=\"%.4f\" branch-rate=\"%.4f\" lines-covered=\"%d\" lines-valid=\"%d\" branches-covered=\"%d\" branches-valid=\"%d\">",
 			(int64_t)ts, line_rate, branch_rate, t.hit_lines, t.lines, t.hit_branches, t.branches));
-	f->store_line("  <packages><package name=\"gdscript\"><classes>");
+	f->store_line(vformat("  <packages><package name=\"gdscript\" line-rate=\"%.4f\" branch-rate=\"%.4f\" complexity=\"0\"><classes>",
+			line_rate, branch_rate));
 
 	Vector<String> sorted_cobertura = _build_sorted_path_union(p_hits, p_func_hits, p_branch_hits, coverable);
 	static const HashMap<int, int> empty_cob_hits;
@@ -863,10 +864,23 @@ static void _json_write_lines(Ref<FileAccess> f, const HashMap<int, int> &p_line
 	f->store_line("},");
 }
 
-static void _json_write_funcs(Ref<FileAccess> f, const HashMap<String, int> &p_funcs) {
+static void _json_write_funcs(Ref<FileAccess> f, const HashMap<String, int> *p_funcs,
+		const HashMap<String, int> *p_func_starts) {
+	// Merge: start with all compiled functions (p_func_starts), then overlay recorded hits.
+	HashMap<String, int> all_funcs;
+	if (p_func_starts) {
+		for (const KeyValue<String, int> &kv : *p_func_starts) {
+			all_funcs[kv.key] = 0;
+		}
+	}
+	if (p_funcs) {
+		for (const KeyValue<String, int> &kv : *p_funcs) {
+			all_funcs[kv.key] = kv.value;
+		}
+	}
 	f->store_string("      \"functions\": {");
 	Vector<String> sorted_funcs;
-	for (const KeyValue<String, int> &fv : p_funcs) {
+	for (const KeyValue<String, int> &fv : all_funcs) {
 		sorted_funcs.push_back(fv.key);
 	}
 	sorted_funcs.sort();
@@ -876,7 +890,7 @@ static void _json_write_funcs(Ref<FileAccess> f, const HashMap<String, int> &p_f
 			f->store_string(",");
 		}
 		first = false;
-		f->store_string("\"" + fn.c_escape() + "\":" + itos(*p_funcs.getptr(fn)));
+		f->store_string("\"" + fn.c_escape() + "\":" + itos(*all_funcs.getptr(fn)));
 	}
 	f->store_line("},");
 }
@@ -907,7 +921,8 @@ static void _json_write_file_entry(Ref<FileAccess> f, const String &p_path,
 		const HashMap<int, int> *p_lines,
 		const HashMap<String, int> *p_funcs,
 		const HashMap<int, GDScriptLanguage::BranchResult> *p_branches,
-		const HashMap<int, int> *p_coverable) {
+		const HashMap<int, int> *p_coverable,
+		const HashMap<String, int> *p_func_starts) {
 	f->store_line("    \"" + p_path.c_escape() + "\": {");
 	if (p_lines || (p_coverable && !p_coverable->is_empty())) {
 		static const HashMap<int, int> empty_json_lines;
@@ -915,11 +930,7 @@ static void _json_write_file_entry(Ref<FileAccess> f, const String &p_path,
 	} else {
 		f->store_line("      \"lines\": {},");
 	}
-	if (p_funcs) {
-		_json_write_funcs(f, *p_funcs);
-	} else {
-		f->store_line("      \"functions\": {},");
-	}
+	_json_write_funcs(f, p_funcs, p_func_starts);
 	if (p_branches) {
 		_json_write_branches(f, *p_branches);
 	} else {
@@ -944,7 +955,7 @@ static Error _write_json(const String &p_path,
 	f->store_line("  \"files\": {");
 	for (int i = 0; i < file_list.size(); i++) {
 		const String &fp = file_list[i];
-		_json_write_file_entry(f, fp, p_hits.getptr(fp), p_func_hits.getptr(fp), p_branch_hits.getptr(fp), coverable.getptr(fp));
+		_json_write_file_entry(f, fp, p_hits.getptr(fp), p_func_hits.getptr(fp), p_branch_hits.getptr(fp), coverable.getptr(fp), func_starts.getptr(fp));
 		if (i + 1 < file_list.size()) {
 			f->store_line(",");
 		} else {

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -423,7 +423,9 @@ void GDScriptLanguage::_coverage_collect_lines(GDScript *p_script, HashMap<int, 
 }
 
 // Walk bytecode to find the first OPCODE_LINE for each function (its start line).
-void GDScriptLanguage::_coverage_collect_func_starts(const GDScript *p_script, HashMap<String, int> &r_starts) {
+// p_class_prefix is the dot-separated inner-class chain (e.g. "Outer.Inner") for subclasses,
+// so that same-named methods in different inner classes get distinct keys.
+void GDScriptLanguage::_coverage_collect_func_starts(const GDScript *p_script, HashMap<String, int> &r_starts, const String &p_class_prefix) {
 	if (!p_script) {
 		return;
 	}
@@ -436,13 +438,15 @@ void GDScriptLanguage::_coverage_collect_func_starts(const GDScript *p_script, H
 		int code_size = func->_code_size;
 		for (int i = 0; i < code_size; i++) {
 			if (code[i] == GDScriptFunction::OPCODE_LINE && i + 1 < code_size) {
-				r_starts[String(func->get_name())] = code[i + 1];
+				String key = p_class_prefix.is_empty() ? String(func->get_name()) : p_class_prefix + "." + String(func->get_name());
+				r_starts[key] = code[i + 1];
 				break; // only the first line number is the start line
 			}
 		}
 	}
 	for (const KeyValue<StringName, Ref<GDScript>> &kv : p_script->get_subclasses()) {
-		_coverage_collect_func_starts(kv.value.ptr(), r_starts);
+		String child_prefix = p_class_prefix.is_empty() ? String(kv.key) : p_class_prefix + "." + String(kv.key);
+		_coverage_collect_func_starts(kv.value.ptr(), r_starts, child_prefix);
 	}
 }
 

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -170,12 +170,18 @@ void GDScriptLanguage::coverage_record_branch(const StringName &p_source, int p_
 
 /*************** Per-file stats aggregate ***************/
 
+// Aggregate coverage counts for a single source file.
+// Used by _gather_file_stats to accumulate line/function/branch totals that
+// are then consumed by the format writers and the threshold/summary logic.
 struct CoverageFileStats {
 	int lines = 0, hit_lines = 0;
 	int funcs = 0, hit_funcs = 0;
 	int branches = 0, hit_branches = 0;
 };
 
+// Accumulate line coverage counts into r_fs.
+// p_hits contains recorded hit counts; p_coverable (optional) adds lines that
+// were compiled but never reached so they appear as not-hit rather than absent.
 static void _compute_line_stats(const HashMap<int, int> &p_hits,
 		const HashMap<int, int> *p_coverable, CoverageFileStats &r_fs) {
 	HashSet<int> counted;
@@ -196,6 +202,7 @@ static void _compute_line_stats(const HashMap<int, int> &p_hits,
 	}
 }
 
+// Accumulate function coverage counts from recorded hits into r_fs.
 static void _compute_func_stats(const HashMap<String, int> &p_funcs, CoverageFileStats &r_fs) {
 	for (const KeyValue<String, int> &fv : p_funcs) {
 		r_fs.funcs++;
@@ -205,6 +212,8 @@ static void _compute_func_stats(const HashMap<String, int> &p_funcs, CoverageFil
 	}
 }
 
+// Accumulate branch coverage counts from recorded results into r_fs.
+// Each IP contributes two branches (taken + not_taken); each counts as hit if > 0.
 static void _compute_branch_stats(const HashMap<int, GDScriptLanguage::BranchResult> &p_branches, CoverageFileStats &r_fs) {
 	for (const KeyValue<int, GDScriptLanguage::BranchResult> &bv : p_branches) {
 		r_fs.branches += 2;
@@ -250,6 +259,11 @@ static void _add_uncalled_func_stats(
 	}
 }
 
+// Build per-file coverage stats from the three recorded hit maps.
+// When p_coverable is provided, files that were compiled but never executed are
+// included as 0%-covered rather than absent. When p_func_starts is provided,
+// compiled functions that were never called are counted toward FNF so that the
+// reported total matches the number of functions in the bytecode.
 static HashMap<String, CoverageFileStats> _gather_file_stats(
 		const HashMap<String, HashMap<int, int>> &p_hits,
 		const HashMap<String, HashMap<String, int>> &p_func_hits,
@@ -276,6 +290,7 @@ static HashMap<String, CoverageFileStats> _gather_file_stats(
 	return out;
 }
 
+// Sum per-file stats into a single aggregate for threshold checking and summary output.
 static CoverageFileStats _sum_totals(const HashMap<String, CoverageFileStats> &p_stats) {
 	CoverageFileStats t;
 	for (const KeyValue<String, CoverageFileStats> &kv : p_stats) {

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -393,6 +393,8 @@ void GDScriptLanguage::_coverage_collect_func_starts(const GDScript *p_script, H
 }
 
 // Build a per-file map of function name → start line from script_list.
+// Applies the same include/exclude filter as _coverage_enumerate_coverable_lines
+// so callers receive a consistent view of which files are in scope.
 HashMap<String, HashMap<String, int>> GDScriptLanguage::_coverage_enumerate_func_start_lines() {
 	HashMap<String, HashMap<String, int>> result;
 	MutexLock lock(mutex);
@@ -401,7 +403,9 @@ HashMap<String, HashMap<String, int>> GDScriptLanguage::_coverage_enumerate_func
 		const GDScript *scr = s->self();
 		if (scr) {
 			String res_path = scr->get_script_path();
-			_coverage_collect_func_starts(scr, result[res_path]);
+			if (_coverage_path_included(res_path, coverage_include, coverage_exclude)) {
+				_coverage_collect_func_starts(scr, result[res_path]);
+			}
 		}
 		s = s->next();
 	}

--- a/modules/gdscript/gdscript_coverage.cpp
+++ b/modules/gdscript/gdscript_coverage.cpp
@@ -579,7 +579,7 @@ static Error _write_lcov(const String &p_path,
 /*************** Cobertura XML writer ***************/
 
 static String _xml_escape(const String &p_str) {
-	return p_str.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+	return p_str.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;").replace("'", "&apos;");
 }
 
 static void _cobertura_write_class(Ref<FileAccess> f, const String &p_res_path,

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -668,6 +668,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 	GDScriptLanguage::CallLevel call_level;
 	GDScriptLanguage::get_singleton()->enter_function(&call_level, p_instance, this, stack, &ip, &line);
 
+#ifdef TOOLS_ENABLED
+	if (unlikely(GDScriptLanguage::get_singleton()->coverage_enabled)) {
+		GDScriptLanguage::get_singleton()->coverage_record_func_entry(source, name);
+	}
+#endif // TOOLS_ENABLED
+
 #ifdef DEBUG_ENABLED
 #define GD_ERR_BREAK(m_cond) \
 	{ \
@@ -2747,6 +2753,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				bool result = test->booleanize();
 
+#ifdef TOOLS_ENABLED
+				if (unlikely(GDScriptLanguage::get_singleton()->coverage_enabled)) {
+					GDScriptLanguage::get_singleton()->coverage_record_branch(source, line, ip, result);
+				}
+#endif // TOOLS_ENABLED
+
 				if (result) {
 					int to = _code_ptr[ip + 2];
 					GD_ERR_BREAK(to < 0 || to > _code_size);
@@ -2763,6 +2775,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GET_VARIANT_PTR(test, 0);
 
 				bool result = test->booleanize();
+
+#ifdef TOOLS_ENABLED
+				if (unlikely(GDScriptLanguage::get_singleton()->coverage_enabled)) {
+					GDScriptLanguage::get_singleton()->coverage_record_branch(source, line, ip, !result);
+				}
+#endif // TOOLS_ENABLED
 
 				if (!result) {
 					int to = _code_ptr[ip + 2];
@@ -3910,6 +3928,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				line = _code_ptr[ip + 1];
 				ip += 2;
+
+#ifdef TOOLS_ENABLED
+				if (unlikely(GDScriptLanguage::get_singleton()->coverage_enabled)) {
+					GDScriptLanguage::get_singleton()->coverage_record_line(source, line);
+				}
+#endif // TOOLS_ENABLED
 
 				if (EngineDebugger::is_active()) {
 					// line

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -670,7 +670,19 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 #ifdef TOOLS_ENABLED
 	if (unlikely(GDScriptLanguage::get_singleton()->coverage_enabled.is_set())) {
-		GDScriptLanguage::get_singleton()->coverage_record_func_entry(source, name);
+		// Qualify the function name with its inner-class chain so that same-named
+		// methods in different inner classes (e.g. A._ready and B._ready) produce
+		// distinct keys in coverage_func_hits. For top-level scripts the fqn is
+		// just the file path, so no prefix is prepended.
+		StringName qualified_name = name;
+		if (script) {
+			const String fqn = script->get_fully_qualified_name();
+			const int sep = fqn.find("::");
+			if (sep >= 0) {
+				qualified_name = StringName(fqn.substr(sep + 2).replace("::", ".") + "." + String(name));
+			}
+		}
+		GDScriptLanguage::get_singleton()->coverage_record_func_entry(source, qualified_name);
 	}
 #endif // TOOLS_ENABLED
 

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -669,7 +669,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 	GDScriptLanguage::get_singleton()->enter_function(&call_level, p_instance, this, stack, &ip, &line);
 
 #ifdef TOOLS_ENABLED
-	if (unlikely(GDScriptLanguage::get_singleton()->coverage_enabled)) {
+	if (unlikely(GDScriptLanguage::get_singleton()->coverage_enabled.is_set())) {
 		GDScriptLanguage::get_singleton()->coverage_record_func_entry(source, name);
 	}
 #endif // TOOLS_ENABLED
@@ -2754,7 +2754,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				bool result = test->booleanize();
 
 #ifdef TOOLS_ENABLED
-				if (unlikely(GDScriptLanguage::get_singleton()->coverage_enabled)) {
+				if (unlikely(GDScriptLanguage::get_singleton()->coverage_enabled.is_set())) {
 					GDScriptLanguage::get_singleton()->coverage_record_branch(source, line, ip, result);
 				}
 #endif // TOOLS_ENABLED
@@ -2777,7 +2777,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				bool result = test->booleanize();
 
 #ifdef TOOLS_ENABLED
-				if (unlikely(GDScriptLanguage::get_singleton()->coverage_enabled)) {
+				if (unlikely(GDScriptLanguage::get_singleton()->coverage_enabled.is_set())) {
 					GDScriptLanguage::get_singleton()->coverage_record_branch(source, line, ip, !result);
 				}
 #endif // TOOLS_ENABLED
@@ -3930,7 +3930,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				ip += 2;
 
 #ifdef TOOLS_ENABLED
-				if (unlikely(GDScriptLanguage::get_singleton()->coverage_enabled)) {
+				if (unlikely(GDScriptLanguage::get_singleton()->coverage_enabled.is_set())) {
 					GDScriptLanguage::get_singleton()->coverage_record_line(source, line);
 				}
 #endif // TOOLS_ENABLED

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -60,8 +60,27 @@ TEST_SUITE("[Modules][GDScript]") {
 	TEST_CASE("Script compilation and runtime") {
 		bool print_filenames = OS::get_singleton()->get_cmdline_args().find("--print-filenames") != nullptr;
 		bool use_binary_tokens = OS::get_singleton()->get_cmdline_args().find("--use-binary-tokens") != nullptr;
+
+		// GDScriptTestRunner calls init_language(), which calls GDScriptLanguage::init(),
+		// which parses --coverage-* args and auto-starts coverage if --coverage-output is set.
 		GDScriptTestRunner runner("modules/gdscript/tests/scripts", true, print_filenames, use_binary_tokens);
+
+		// Check after init_language() so coverage_output_path is already populated.
+		const bool coverage_active = !GDScriptLanguage::get_singleton()->coverage_output_path.is_empty();
+		if (coverage_active) {
+			// Reset to exclude any data recorded during language init / script loading.
+			GDScriptLanguage::get_singleton()->coverage_start();
+		}
+
 		int fail_count = runner.run_tests();
+
+		if (coverage_active) {
+			GDScriptLanguage::get_singleton()->coverage_write();
+			print_line(GDScriptLanguage::get_singleton()->coverage_summary_string());
+			REQUIRE_MESSAGE(GDScriptLanguage::get_singleton()->coverage_check_threshold(),
+					"GDScript coverage below configured threshold.");
+		}
+
 		INFO("Make sure `*.out` files have expected results.");
 		REQUIRE_MESSAGE(fail_count == 0, "All GDScript tests should pass.");
 	}

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -75,7 +75,8 @@ TEST_SUITE("[Modules][GDScript]") {
 		int fail_count = runner.run_tests();
 
 		if (coverage_active) {
-			GDScriptLanguage::get_singleton()->coverage_write();
+			Error cov_err = GDScriptLanguage::get_singleton()->coverage_write();
+			REQUIRE_MESSAGE(cov_err == OK, "GDScript coverage write failed.");
 			print_line(GDScriptLanguage::get_singleton()->coverage_summary_string());
 			REQUIRE_MESSAGE(GDScriptLanguage::get_singleton()->coverage_check_threshold(),
 					"GDScript coverage below configured threshold.");

--- a/modules/gdscript/tests/test_gdscript_coverage.h
+++ b/modules/gdscript/tests/test_gdscript_coverage.h
@@ -715,19 +715,35 @@ TEST_SUITE("[Modules][GDScript]") {
 		CHECK_MESSAGE(!contents.contains("gut.gd"), "Excluded file must not appear in LCOV output");
 	}
 
-	TEST_CASE("[Modules][GDScript] Coverage: write JSON zero-hit file shows coverable lines") {
+	TEST_CASE("[Modules][GDScript] Coverage: write JSON compiled-but-unexecuted file shows coverable lines") {
+		// Exercises the p_lines==null, p_coverable!=null path in _json_write_file_entry:
+		// a script that was compiled (in script_list) but never had any VM opcodes
+		// recorded must still appear in JSON output with its coverable lines at count 0.
 		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
 		REQUIRE(lang != nullptr);
 		CoverageScopedReset guard;
 
+		// Write a simple GDScript with executable lines.
+		const String script_path = TestUtils::get_temp_path("coverage_zero_compiled.gd");
+		{
+			Ref<FileAccess> fw = FileAccess::open(script_path, FileAccess::WRITE);
+			REQUIRE(fw.is_valid());
+			fw->store_string("extends RefCounted\n\nfunc greet():\n\tvar x = 1\n\treturn x\n");
+		}
+
+		// Load (compile) the script — this adds it to script_list without executing any function.
+		// Suppress the spurious "Condition err is true" message from reload().
+		ERR_PRINT_OFF;
+		Ref<GDScript> script = ResourceLoader::load(script_path, "GDScript");
+		ERR_PRINT_ON;
+		REQUIRE_MESSAGE(script.is_valid(), "Script must compile successfully");
+
+		// coverage_hits is empty (CoverageScopedReset cleared it). No function was called, so
+		// p_hits.getptr(script_path) returns null inside _write_json → p_lines == null.
+		// _coverage_enumerate_coverable_lines() finds the script in script_list → p_coverable != null.
 		const String out_path = TestUtils::get_temp_path("coverage_zero_hit.json");
 		lang->coverage_set_output(out_path);
 		lang->coverage_set_format("json");
-		// Record a hit file and inject a zero-hit coverable file directly.
-		lang->coverage_record_line("res://hit_file.gd", 5);
-		// Inject coverable lines for a file that was "compiled but never executed".
-		lang->coverage_hits["res://zero_file.gd"]; // create empty entry in hits
-		lang->coverage_hits["res://zero_file.gd"][7] = 0; // line 7: explicitly zero
 
 		Error err = lang->coverage_write();
 		REQUIRE(err == OK);
@@ -736,9 +752,10 @@ TEST_SUITE("[Modules][GDScript]") {
 		REQUIRE(f.is_valid());
 		String contents = f->get_as_text();
 
-		CHECK_MESSAGE(contents.contains("hit_file.gd"), "Hit file must appear in JSON");
-		CHECK_MESSAGE(contents.contains("zero_file.gd"), "Zero-hit file must appear in JSON");
-		CHECK_MESSAGE(contents.contains("\"7\":0"), "Zero-hit line must appear with count 0");
+		const String script_basename = script_path.get_file();
+		CHECK_MESSAGE(contents.contains(script_basename), "Compiled-but-unexecuted script must appear in JSON output");
+		// Lines must appear with count 0, not be omitted entirely.
+		CHECK_MESSAGE(contents.contains(": 0"), "Coverable lines of unexecuted script must show count 0 in JSON");
 	}
 
 	TEST_CASE("[Modules][GDScript] Coverage: write LCOV multiple files") {
@@ -749,6 +766,9 @@ TEST_SUITE("[Modules][GDScript]") {
 		const String out_path = TestUtils::get_temp_path("coverage_multi.lcov");
 		lang->coverage_set_output(out_path);
 		lang->coverage_set_format("lcov");
+		// Restrict to these two synthetic paths so real scripts compiled by other
+		// tests and still alive in script_list do not add extra records.
+		lang->coverage_add_include("res://file_*.gd");
 		lang->coverage_record_line("res://file_a.gd", 1);
 		lang->coverage_record_line("res://file_b.gd", 5);
 

--- a/modules/gdscript/tests/test_gdscript_coverage.h
+++ b/modules/gdscript/tests/test_gdscript_coverage.h
@@ -690,7 +690,7 @@ TEST_SUITE("[Modules][GDScript]") {
 		CHECK_MESSAGE(contents.contains("Threshold:"), "Text output must show the threshold");
 	}
 
-	TEST_CASE("[Modules][GDScript] Coverage: write filters files from output") {
+	TEST_CASE("[Modules][GDScript] Coverage: write LCOV contains only recorded files") {
 		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
 		REQUIRE(lang != nullptr);
 		CoverageScopedReset guard;
@@ -698,11 +698,11 @@ TEST_SUITE("[Modules][GDScript]") {
 		const String out_path = TestUtils::get_temp_path("coverage_filtered.lcov");
 		lang->coverage_set_output(out_path);
 		lang->coverage_set_format("lcov");
-		// Include only src/, exclude addons/ even if it somehow appeared.
+		// Filtering happens at record time: only paths passing the include filter
+		// enter coverage_hits, so only those paths appear in the LCOV output.
 		lang->coverage_add_include("res://src/**");
 		lang->coverage_record_line("res://src/player.gd", 1);
-		// Addons path bypasses the filter by being injected directly.
-		lang->coverage_hits["res://addons/gut/gut.gd"][1] = 1;
+		lang->coverage_record_line("res://addons/gut/gut.gd", 1); // filtered out at record time
 
 		Error err = lang->coverage_write();
 		REQUIRE(err == OK);
@@ -711,13 +711,8 @@ TEST_SUITE("[Modules][GDScript]") {
 		REQUIRE(f.is_valid());
 		String contents = f->get_as_text();
 
-		// The LCOV writer iterates coverage_hits which has both entries,
-		// but SF: uses _coverage_globalize; the path string itself must appear.
-		CHECK_MESSAGE(contents.contains("player.gd"), "Included file must appear in output");
-		// gut.gd was injected but is not in the include list — it still appears in
-		// coverage_hits so it will be in the file, but its SF: path won't pass the filter.
-		// The real test is that record_line filtered it at recording time, which is verified
-		// in the "include filter" and "exclude filter" test cases above.
+		CHECK_MESSAGE(contents.contains("player.gd"), "Included file must appear in LCOV output");
+		CHECK_MESSAGE(!contents.contains("gut.gd"), "Excluded file must not appear in LCOV output");
 	}
 
 	TEST_CASE("[Modules][GDScript] Coverage: write LCOV multiple files") {

--- a/modules/gdscript/tests/test_gdscript_coverage.h
+++ b/modules/gdscript/tests/test_gdscript_coverage.h
@@ -1,0 +1,443 @@
+/**************************************************************************/
+/*  test_gdscript_coverage.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+#include "../gdscript.h"
+
+#include "tests/test_macros.h"
+
+namespace GDScriptTests {
+
+// Helper: reset coverage state to a clean baseline between test cases.
+// Saves and restores config so tests do not interfere with each other.
+struct CoverageScopedReset {
+	GDScriptLanguage *lang = nullptr;
+	GDScriptLanguage::CoverageMode saved_mode;
+	GDScriptLanguage::CoverageFormat saved_format;
+	String saved_output_path;
+	float saved_threshold = 0.0f;
+	Vector<String> saved_include;
+	Vector<String> saved_exclude;
+	bool saved_enabled = false;
+	bool saved_written = false;
+
+	CoverageScopedReset() {
+		lang = GDScriptLanguage::get_singleton();
+		if (!lang) {
+			return;
+		}
+		saved_mode = lang->coverage_mode;
+		saved_format = lang->coverage_format;
+		saved_output_path = lang->coverage_output_path;
+		saved_threshold = lang->coverage_threshold;
+		saved_include = lang->coverage_include;
+		saved_exclude = lang->coverage_exclude;
+		saved_enabled = lang->coverage_enabled;
+		saved_written = lang->coverage_written;
+
+		// Start fresh so recorded data is isolated to this test.
+		lang->coverage_hits.clear();
+		lang->coverage_func_hits.clear();
+		lang->coverage_branch_hits.clear();
+		lang->coverage_include.clear();
+		lang->coverage_exclude.clear();
+		lang->coverage_enabled = true;
+		lang->coverage_written = false;
+		lang->coverage_threshold = 0.0f;
+		lang->coverage_mode = GDScriptLanguage::COVERAGE_MODE_SET;
+		lang->coverage_format = GDScriptLanguage::COVERAGE_FORMAT_LCOV;
+	}
+
+	~CoverageScopedReset() {
+		if (!lang) {
+			return;
+		}
+		lang->coverage_mode = saved_mode;
+		lang->coverage_format = saved_format;
+		lang->coverage_output_path = saved_output_path;
+		lang->coverage_threshold = saved_threshold;
+		lang->coverage_include = saved_include;
+		lang->coverage_exclude = saved_exclude;
+		lang->coverage_enabled = saved_enabled;
+		lang->coverage_written = saved_written;
+		lang->coverage_hits.clear();
+		lang->coverage_func_hits.clear();
+		lang->coverage_branch_hits.clear();
+	}
+};
+
+TEST_SUITE("[Modules][GDScript]") {
+	TEST_CASE("[Modules][GDScript] Coverage: configuration setters") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		SUBCASE("coverage_set_mode 'set' selects set mode") {
+			lang->coverage_set_mode("set");
+			CHECK(lang->coverage_mode == GDScriptLanguage::COVERAGE_MODE_SET);
+		}
+
+		SUBCASE("coverage_set_mode 'count' selects count mode") {
+			lang->coverage_set_mode("count");
+			CHECK(lang->coverage_mode == GDScriptLanguage::COVERAGE_MODE_COUNT);
+		}
+
+		SUBCASE("coverage_set_mode unknown value defaults to set") {
+			lang->coverage_set_mode("bogus");
+			CHECK(lang->coverage_mode == GDScriptLanguage::COVERAGE_MODE_SET);
+		}
+
+		SUBCASE("coverage_set_format 'lcov' selects LCOV") {
+			lang->coverage_set_format("lcov");
+			CHECK(lang->coverage_format == GDScriptLanguage::COVERAGE_FORMAT_LCOV);
+		}
+
+		SUBCASE("coverage_set_format 'cobertura' selects Cobertura") {
+			lang->coverage_set_format("cobertura");
+			CHECK(lang->coverage_format == GDScriptLanguage::COVERAGE_FORMAT_COBERTURA);
+		}
+
+		SUBCASE("coverage_set_format 'json' selects JSON") {
+			lang->coverage_set_format("json");
+			CHECK(lang->coverage_format == GDScriptLanguage::COVERAGE_FORMAT_JSON);
+		}
+
+		SUBCASE("coverage_set_format 'text' selects text") {
+			lang->coverage_set_format("text");
+			CHECK(lang->coverage_format == GDScriptLanguage::COVERAGE_FORMAT_TEXT);
+		}
+
+		SUBCASE("coverage_set_format unknown value defaults to LCOV") {
+			lang->coverage_set_format("bogus");
+			CHECK(lang->coverage_format == GDScriptLanguage::COVERAGE_FORMAT_LCOV);
+		}
+
+		SUBCASE("coverage_set_threshold stores the value") {
+			lang->coverage_set_threshold(75.0f);
+			CHECK(lang->coverage_threshold == doctest::Approx(75.0f));
+		}
+
+		SUBCASE("coverage_set_output stores the path") {
+			lang->coverage_set_output("/tmp/test_cov.lcov");
+			CHECK(lang->coverage_output_path == "/tmp/test_cov.lcov");
+		}
+
+		SUBCASE("coverage_add_include appends pattern") {
+			lang->coverage_add_include("res://src/**");
+			lang->coverage_add_include("res://lib/**");
+			REQUIRE(lang->coverage_include.size() == 2);
+			CHECK(lang->coverage_include[0] == "res://src/**");
+			CHECK(lang->coverage_include[1] == "res://lib/**");
+		}
+
+		SUBCASE("coverage_add_exclude appends pattern") {
+			lang->coverage_add_exclude("res://addons/**");
+			REQUIRE(lang->coverage_exclude.size() == 1);
+			CHECK(lang->coverage_exclude[0] == "res://addons/**");
+		}
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: start resets state") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		// Pre-populate data.
+		lang->coverage_record_line("res://a.gd", 5);
+		lang->coverage_record_func_entry("res://a.gd", "my_func");
+		lang->coverage_record_branch("res://a.gd", 10, 42, true);
+		lang->coverage_written = true;
+
+		// start() must wipe everything and mark enabled.
+		lang->coverage_start();
+
+		CHECK(lang->coverage_hits.is_empty());
+		CHECK(lang->coverage_func_hits.is_empty());
+		CHECK(lang->coverage_branch_hits.is_empty());
+		CHECK(lang->coverage_enabled);
+		CHECK(!lang->coverage_written);
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: record line (set mode)") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_set_mode("set");
+		lang->coverage_record_line("res://foo.gd", 10);
+
+		REQUIRE(lang->coverage_hits.has("res://foo.gd"));
+		const HashMap<int, int> &lines = lang->coverage_hits["res://foo.gd"];
+		REQUIRE(lines.has(10));
+		CHECK(lines[10] == 1);
+
+		SUBCASE("second hit stays at 1 in set mode") {
+			lang->coverage_record_line("res://foo.gd", 10);
+			CHECK(lang->coverage_hits["res://foo.gd"][10] == 1);
+		}
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: record line (count mode)") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_set_mode("count");
+		lang->coverage_record_line("res://foo.gd", 10);
+		lang->coverage_record_line("res://foo.gd", 10);
+		lang->coverage_record_line("res://foo.gd", 10);
+
+		REQUIRE(lang->coverage_hits.has("res://foo.gd"));
+		CHECK(lang->coverage_hits["res://foo.gd"][10] == 3);
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: record line include filter") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_add_include("res://src/**");
+		lang->coverage_record_line("res://src/player.gd", 1);
+		lang->coverage_record_line("res://addons/gut/gut.gd", 1);
+
+		CHECK(lang->coverage_hits.has("res://src/player.gd"));
+		CHECK(!lang->coverage_hits.has("res://addons/gut/gut.gd"));
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: record line exclude filter") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_add_exclude("res://addons/**");
+		lang->coverage_record_line("res://src/player.gd", 1);
+		lang->coverage_record_line("res://addons/gut/gut.gd", 1);
+
+		CHECK(lang->coverage_hits.has("res://src/player.gd"));
+		CHECK(!lang->coverage_hits.has("res://addons/gut/gut.gd"));
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: record func entry") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_set_mode("count");
+		lang->coverage_record_func_entry("res://bar.gd", "_ready");
+		lang->coverage_record_func_entry("res://bar.gd", "_ready");
+		lang->coverage_record_func_entry("res://bar.gd", "_process");
+
+		REQUIRE(lang->coverage_func_hits.has("res://bar.gd"));
+		const HashMap<String, int> &funcs = lang->coverage_func_hits["res://bar.gd"];
+		CHECK(funcs["_ready"] == 2);
+		CHECK(funcs["_process"] == 1);
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: record func entry set mode caps at 1") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_set_mode("set");
+		lang->coverage_record_func_entry("res://bar.gd", "_ready");
+		lang->coverage_record_func_entry("res://bar.gd", "_ready");
+
+		CHECK(lang->coverage_func_hits["res://bar.gd"]["_ready"] == 1);
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: record branch") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_set_mode("count");
+		// ip=100 is the branch instruction pointer, line=42 is the source line.
+		lang->coverage_record_branch("res://baz.gd", 42, 100, true);
+		lang->coverage_record_branch("res://baz.gd", 42, 100, true);
+		lang->coverage_record_branch("res://baz.gd", 42, 100, false);
+
+		REQUIRE(lang->coverage_branch_hits.has("res://baz.gd"));
+		const HashMap<int, GDScriptLanguage::BranchResult> &branches = lang->coverage_branch_hits["res://baz.gd"];
+		REQUIRE(branches.has(100));
+		const GDScriptLanguage::BranchResult &br = branches[100];
+		CHECK(br.taken == 2);
+		CHECK(br.not_taken == 1);
+		CHECK(br.line == 42);
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: record branch set mode caps at 1") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_set_mode("set");
+		lang->coverage_record_branch("res://baz.gd", 10, 50, true);
+		lang->coverage_record_branch("res://baz.gd", 10, 50, true);
+		lang->coverage_record_branch("res://baz.gd", 10, 50, false);
+
+		const GDScriptLanguage::BranchResult &br = lang->coverage_branch_hits["res://baz.gd"][50];
+		CHECK(br.taken == 1);
+		CHECK(br.not_taken == 1);
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: branch stores source line") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_record_branch("res://baz.gd", 99, 200, true);
+
+		REQUIRE(lang->coverage_branch_hits.has("res://baz.gd"));
+		REQUIRE(lang->coverage_branch_hits["res://baz.gd"].has(200));
+		CHECK(lang->coverage_branch_hits["res://baz.gd"][200].line == 99);
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: threshold check") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		// Record 4 lines, 3 hit and 1 not hit.
+		lang->coverage_record_line("res://t.gd", 1);
+		lang->coverage_record_line("res://t.gd", 2);
+		lang->coverage_record_line("res://t.gd", 3);
+		// Line 4 is coverable but not hit: inject it directly.
+		lang->coverage_hits["res://t.gd"][4] = 0;
+
+		SUBCASE("threshold 0.0 always passes") {
+			lang->coverage_set_threshold(0.0f);
+			CHECK(lang->coverage_check_threshold());
+		}
+
+		SUBCASE("threshold below actual coverage passes") {
+			lang->coverage_set_threshold(70.0f); // actual is 75%
+			CHECK(lang->coverage_check_threshold());
+		}
+
+		SUBCASE("threshold exactly at actual coverage passes") {
+			lang->coverage_set_threshold(75.0f);
+			CHECK(lang->coverage_check_threshold());
+		}
+
+		SUBCASE("threshold above actual coverage fails") {
+			lang->coverage_set_threshold(76.0f); // actual is 75%
+			CHECK(!lang->coverage_check_threshold());
+		}
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: threshold with no data passes") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_set_threshold(90.0f);
+		CHECK(lang->coverage_check_threshold());
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: summary string contains expected sections") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_record_line("res://summary_test.gd", 1);
+		lang->coverage_record_func_entry("res://summary_test.gd", "_init");
+		lang->coverage_record_branch("res://summary_test.gd", 5, 10, true);
+
+		String s = lang->coverage_summary_string();
+
+		CHECK_MESSAGE(s.contains("Lines"), "Summary must have a Lines column");
+		CHECK_MESSAGE(s.contains("Funcs"), "Summary must have a Funcs column");
+		CHECK_MESSAGE(s.contains("Branches"), "Summary must have a Branches column");
+		CHECK_MESSAGE(s.contains("Total"), "Summary must have a Total row");
+		CHECK_MESSAGE(s.contains("res://summary_test.gd"), "Summary must list the recorded file");
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: summary string shows threshold status") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_record_line("res://t2.gd", 1);
+		lang->coverage_hits["res://t2.gd"][2] = 0; // unhit line
+
+		SUBCASE("pass indicator shown when threshold is met") {
+			lang->coverage_set_threshold(40.0f);
+			CHECK(lang->coverage_summary_string().contains(U"✓"));
+		}
+
+		SUBCASE("fail indicator shown when threshold is not met") {
+			lang->coverage_set_threshold(90.0f);
+			CHECK(lang->coverage_summary_string().contains(U"✗"));
+		}
+
+		SUBCASE("no threshold line when threshold is 0") {
+			lang->coverage_set_threshold(0.0f);
+			String s = lang->coverage_summary_string();
+			CHECK(!s.contains("Threshold:"));
+		}
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: multiple files tracked independently") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_record_line("res://a.gd", 1);
+		lang->coverage_record_line("res://a.gd", 2);
+		lang->coverage_record_line("res://b.gd", 10);
+
+		CHECK(lang->coverage_hits.has("res://a.gd"));
+		CHECK(lang->coverage_hits.has("res://b.gd"));
+		CHECK(lang->coverage_hits["res://a.gd"].size() == 2);
+		CHECK(lang->coverage_hits["res://b.gd"].size() == 1);
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: exclude takes priority over include") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_add_include("res://src/**");
+		lang->coverage_add_exclude("res://src/ignored/**");
+
+		lang->coverage_record_line("res://src/player.gd", 1);
+		lang->coverage_record_line("res://src/ignored/stub.gd", 1);
+
+		CHECK(lang->coverage_hits.has("res://src/player.gd"));
+		CHECK(!lang->coverage_hits.has("res://src/ignored/stub.gd"));
+	}
+}
+
+} // namespace GDScriptTests
+
+#endif // TOOLS_ENABLED

--- a/modules/gdscript/tests/test_gdscript_coverage.h
+++ b/modules/gdscript/tests/test_gdscript_coverage.h
@@ -34,7 +34,9 @@
 
 #include "../gdscript.h"
 
+#include "core/io/file_access.h"
 #include "tests/test_macros.h"
+#include "tests/test_utils.h"
 
 namespace GDScriptTests {
 
@@ -435,6 +437,321 @@ TEST_SUITE("[Modules][GDScript]") {
 
 		CHECK(lang->coverage_hits.has("res://src/player.gd"));
 		CHECK(!lang->coverage_hits.has("res://src/ignored/stub.gd"));
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: write returns ERR_UNCONFIGURED with no path") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_output_path = "";
+		lang->coverage_record_line("res://t.gd", 1);
+
+		Error err = lang->coverage_write();
+
+		CHECK(err == ERR_UNCONFIGURED);
+		CHECK(!lang->coverage_written);
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: write sets coverage_written on success") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		lang->coverage_set_output(TestUtils::get_temp_path("coverage_written_flag.lcov"));
+		lang->coverage_set_format("lcov");
+		lang->coverage_record_line("res://t.gd", 1);
+
+		CHECK(!lang->coverage_written);
+		Error err = lang->coverage_write();
+		CHECK(err == OK);
+		CHECK(lang->coverage_written);
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: write LCOV format produces valid output") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		const String out_path = TestUtils::get_temp_path("coverage_test.lcov");
+		lang->coverage_set_output(out_path);
+		lang->coverage_set_format("lcov");
+		lang->coverage_record_line("res://lcov_test.gd", 10);
+		lang->coverage_record_line("res://lcov_test.gd", 20);
+		// Inject an unhit line directly.
+		lang->coverage_hits["res://lcov_test.gd"][30] = 0;
+
+		Error err = lang->coverage_write();
+		REQUIRE(err == OK);
+
+		Ref<FileAccess> f = FileAccess::open(out_path, FileAccess::READ);
+		REQUIRE_MESSAGE(f.is_valid(), "Output file must be readable");
+		String contents = f->get_as_text();
+
+		CHECK_MESSAGE(contents.contains("TN:"), "LCOV must have TN: record");
+		CHECK_MESSAGE(contents.contains("SF:"), "LCOV must have SF: record");
+		CHECK_MESSAGE(contents.contains("lcov_test.gd"), "SF path must include the filename");
+		CHECK_MESSAGE(contents.contains("DA:10,1"), "Line 10 must be hit");
+		CHECK_MESSAGE(contents.contains("DA:20,1"), "Line 20 must be hit");
+		CHECK_MESSAGE(contents.contains("DA:30,0"), "Line 30 must be recorded as unhit");
+		CHECK_MESSAGE(contents.contains("LF:3"), "LF must count all coverable lines");
+		CHECK_MESSAGE(contents.contains("LH:2"), "LH must count only hit lines");
+		CHECK_MESSAGE(contents.contains("end_of_record"), "LCOV record must end with end_of_record");
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: write LCOV count mode records hit counts") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		const String out_path = TestUtils::get_temp_path("coverage_count.lcov");
+		lang->coverage_set_output(out_path);
+		lang->coverage_set_format("lcov");
+		lang->coverage_set_mode("count");
+		lang->coverage_record_line("res://count_test.gd", 5);
+		lang->coverage_record_line("res://count_test.gd", 5);
+		lang->coverage_record_line("res://count_test.gd", 5);
+
+		Error err = lang->coverage_write();
+		REQUIRE(err == OK);
+
+		Ref<FileAccess> f = FileAccess::open(out_path, FileAccess::READ);
+		REQUIRE(f.is_valid());
+		String contents = f->get_as_text();
+
+		CHECK_MESSAGE(contents.contains("DA:5,3"), "Count mode must record 3 hits");
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: write LCOV includes function records") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		const String out_path = TestUtils::get_temp_path("coverage_funcs.lcov");
+		lang->coverage_set_output(out_path);
+		lang->coverage_set_format("lcov");
+		lang->coverage_record_line("res://func_test.gd", 1);
+		lang->coverage_record_func_entry("res://func_test.gd", "_ready");
+		lang->coverage_record_func_entry("res://func_test.gd", "_process");
+
+		Error err = lang->coverage_write();
+		REQUIRE(err == OK);
+
+		Ref<FileAccess> f = FileAccess::open(out_path, FileAccess::READ);
+		REQUIRE(f.is_valid());
+		String contents = f->get_as_text();
+
+		CHECK_MESSAGE(contents.contains("FNDA:1,_ready"), "Hit function must appear in FNDA");
+		CHECK_MESSAGE(contents.contains("FNDA:1,_process"), "Hit function must appear in FNDA");
+		CHECK_MESSAGE(contents.contains("FNF:2"), "FNF must count all functions");
+		CHECK_MESSAGE(contents.contains("FNH:2"), "FNH must count hit functions");
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: write LCOV includes branch records") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		const String out_path = TestUtils::get_temp_path("coverage_branches.lcov");
+		lang->coverage_set_output(out_path);
+		lang->coverage_set_format("lcov");
+		lang->coverage_record_line("res://branch_test.gd", 15);
+		lang->coverage_record_branch("res://branch_test.gd", 15, 100, true);
+		lang->coverage_record_branch("res://branch_test.gd", 15, 100, true);
+		lang->coverage_record_branch("res://branch_test.gd", 15, 100, false);
+
+		Error err = lang->coverage_write();
+		REQUIRE(err == OK);
+
+		Ref<FileAccess> f = FileAccess::open(out_path, FileAccess::READ);
+		REQUIRE(f.is_valid());
+		String contents = f->get_as_text();
+
+		CHECK_MESSAGE(contents.contains("BRDA:15,100,0,1"), "Taken branch must use set-mode count");
+		CHECK_MESSAGE(contents.contains("BRDA:15,100,1,1"), "Not-taken branch must use set-mode count");
+		CHECK_MESSAGE(contents.contains("BRF:2"), "BRF must count both branch arms");
+		CHECK_MESSAGE(contents.contains("BRH:2"), "BRH must count hit arms");
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: write LCOV unhit branch arm shows zero") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		const String out_path = TestUtils::get_temp_path("coverage_branch_zero.lcov");
+		lang->coverage_set_output(out_path);
+		lang->coverage_set_format("lcov");
+		lang->coverage_record_line("res://branch_zero.gd", 5);
+		// Only the taken arm fires.
+		lang->coverage_record_branch("res://branch_zero.gd", 5, 200, true);
+
+		Error err = lang->coverage_write();
+		REQUIRE(err == OK);
+
+		Ref<FileAccess> f = FileAccess::open(out_path, FileAccess::READ);
+		REQUIRE(f.is_valid());
+		String contents = f->get_as_text();
+
+		CHECK_MESSAGE(contents.contains("BRDA:5,200,0,1"), "Taken arm must show 1");
+		CHECK_MESSAGE(contents.contains("BRDA:5,200,1,0"), "Not-taken arm must show 0");
+		CHECK_MESSAGE(contents.contains("BRF:2"), "BRF counts both arms");
+		CHECK_MESSAGE(contents.contains("BRH:1"), "BRH counts only the hit arm");
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: write Cobertura format produces valid XML") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		const String out_path = TestUtils::get_temp_path("coverage_test.xml");
+		lang->coverage_set_output(out_path);
+		lang->coverage_set_format("cobertura");
+		lang->coverage_record_line("res://cobertura_test.gd", 10);
+		lang->coverage_record_line("res://cobertura_test.gd", 20);
+		lang->coverage_hits["res://cobertura_test.gd"][30] = 0;
+		lang->coverage_record_func_entry("res://cobertura_test.gd", "_init");
+
+		Error err = lang->coverage_write();
+		REQUIRE(err == OK);
+
+		Ref<FileAccess> f = FileAccess::open(out_path, FileAccess::READ);
+		REQUIRE_MESSAGE(f.is_valid(), "Cobertura output file must be readable");
+		String contents = f->get_as_text();
+
+		CHECK_MESSAGE(contents.contains("<?xml"), "Cobertura must start with XML declaration");
+		CHECK_MESSAGE(contents.contains("<coverage"), "Cobertura must have a coverage element");
+		CHECK_MESSAGE(contents.contains("line-rate="), "Cobertura must include line-rate attribute");
+		CHECK_MESSAGE(contents.contains("<line number=\"10\" hits=\"1\""), "Hit line must appear");
+		CHECK_MESSAGE(contents.contains("<line number=\"30\" hits=\"0\""), "Unhit line must appear");
+		CHECK_MESSAGE(contents.contains("method name=\"_init\""), "Function must appear in methods");
+		CHECK_MESSAGE(contents.contains("</coverage>"), "XML must be closed");
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: write JSON format produces valid JSON structure") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		const String out_path = TestUtils::get_temp_path("coverage_test.json");
+		lang->coverage_set_output(out_path);
+		lang->coverage_set_format("json");
+		lang->coverage_record_line("res://json_test.gd", 5);
+		lang->coverage_record_line("res://json_test.gd", 10);
+		lang->coverage_hits["res://json_test.gd"][15] = 0;
+		lang->coverage_record_func_entry("res://json_test.gd", "my_func");
+		lang->coverage_record_branch("res://json_test.gd", 5, 50, true);
+
+		Error err = lang->coverage_write();
+		REQUIRE(err == OK);
+
+		Ref<FileAccess> f = FileAccess::open(out_path, FileAccess::READ);
+		REQUIRE_MESSAGE(f.is_valid(), "JSON output file must be readable");
+		String contents = f->get_as_text();
+
+		CHECK_MESSAGE(contents.contains("\"files\""), "JSON must have files key");
+		CHECK_MESSAGE(contents.contains("json_test.gd"), "JSON must list the recorded file");
+		CHECK_MESSAGE(contents.contains("\"lines\""), "JSON must have lines section");
+		CHECK_MESSAGE(contents.contains("\"functions\""), "JSON must have functions section");
+		CHECK_MESSAGE(contents.contains("\"branches\""), "JSON must have branches section");
+		CHECK_MESSAGE(contents.contains("\"summary\""), "JSON must have a summary");
+		CHECK_MESSAGE(contents.contains("\"line_pct\""), "Summary must include line_pct");
+		CHECK_MESSAGE(contents.contains("\"func_pct\""), "Summary must include func_pct");
+		CHECK_MESSAGE(contents.contains("\"branch_pct\""), "Summary must include branch_pct");
+		// 2 of 3 lines hit → 66.7%
+		CHECK_MESSAGE(contents.contains("\"5\":1"), "Hit line 5 must appear with count 1");
+		CHECK_MESSAGE(contents.contains("\"15\":0"), "Unhit line 15 must appear with count 0");
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: write text format produces summary file") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		const String out_path = TestUtils::get_temp_path("coverage_test.txt");
+		lang->coverage_set_output(out_path);
+		lang->coverage_set_format("text");
+		lang->coverage_set_threshold(50.0f);
+		lang->coverage_record_line("res://text_test.gd", 1);
+		lang->coverage_record_line("res://text_test.gd", 2);
+		lang->coverage_record_func_entry("res://text_test.gd", "_ready");
+
+		Error err = lang->coverage_write();
+		REQUIRE(err == OK);
+
+		Ref<FileAccess> f = FileAccess::open(out_path, FileAccess::READ);
+		REQUIRE_MESSAGE(f.is_valid(), "Text output file must be readable");
+		String contents = f->get_as_text();
+
+		CHECK_MESSAGE(contents.contains("Lines"), "Text output must have Lines column");
+		CHECK_MESSAGE(contents.contains("Funcs"), "Text output must have Funcs column");
+		CHECK_MESSAGE(contents.contains("Branches"), "Text output must have Branches column");
+		CHECK_MESSAGE(contents.contains("Total"), "Text output must have a Total row");
+		CHECK_MESSAGE(contents.contains("text_test.gd"), "Text output must list the recorded file");
+		CHECK_MESSAGE(contents.contains("Threshold:"), "Text output must show the threshold");
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: write filters files from output") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		const String out_path = TestUtils::get_temp_path("coverage_filtered.lcov");
+		lang->coverage_set_output(out_path);
+		lang->coverage_set_format("lcov");
+		// Include only src/, exclude addons/ even if it somehow appeared.
+		lang->coverage_add_include("res://src/**");
+		lang->coverage_record_line("res://src/player.gd", 1);
+		// Addons path bypasses the filter by being injected directly.
+		lang->coverage_hits["res://addons/gut/gut.gd"][1] = 1;
+
+		Error err = lang->coverage_write();
+		REQUIRE(err == OK);
+
+		Ref<FileAccess> f = FileAccess::open(out_path, FileAccess::READ);
+		REQUIRE(f.is_valid());
+		String contents = f->get_as_text();
+
+		// The LCOV writer iterates coverage_hits which has both entries,
+		// but SF: uses _coverage_globalize; the path string itself must appear.
+		CHECK_MESSAGE(contents.contains("player.gd"), "Included file must appear in output");
+		// gut.gd was injected but is not in the include list — it still appears in
+		// coverage_hits so it will be in the file, but its SF: path won't pass the filter.
+		// The real test is that record_line filtered it at recording time, which is verified
+		// in the "include filter" and "exclude filter" test cases above.
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: write LCOV multiple files") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		const String out_path = TestUtils::get_temp_path("coverage_multi.lcov");
+		lang->coverage_set_output(out_path);
+		lang->coverage_set_format("lcov");
+		lang->coverage_record_line("res://file_a.gd", 1);
+		lang->coverage_record_line("res://file_b.gd", 5);
+
+		Error err = lang->coverage_write();
+		REQUIRE(err == OK);
+
+		Ref<FileAccess> f = FileAccess::open(out_path, FileAccess::READ);
+		REQUIRE(f.is_valid());
+		String contents = f->get_as_text();
+
+		// Both files must have separate records.
+		int record_count = 0;
+		int idx = 0;
+		while (true) {
+			idx = contents.find("end_of_record", idx);
+			if (idx == -1) {
+				break;
+			}
+			record_count++;
+			idx++;
+		}
+		CHECK_MESSAGE(record_count == 2, "Two files must produce two LCOV records");
+		CHECK(contents.contains("file_a.gd"));
+		CHECK(contents.contains("file_b.gd"));
 	}
 }
 

--- a/modules/gdscript/tests/test_gdscript_coverage.h
+++ b/modules/gdscript/tests/test_gdscript_coverage.h
@@ -715,6 +715,32 @@ TEST_SUITE("[Modules][GDScript]") {
 		CHECK_MESSAGE(!contents.contains("gut.gd"), "Excluded file must not appear in LCOV output");
 	}
 
+	TEST_CASE("[Modules][GDScript] Coverage: write JSON zero-hit file shows coverable lines") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		const String out_path = TestUtils::get_temp_path("coverage_zero_hit.json");
+		lang->coverage_set_output(out_path);
+		lang->coverage_set_format("json");
+		// Record a hit file and inject a zero-hit coverable file directly.
+		lang->coverage_record_line("res://hit_file.gd", 5);
+		// Inject coverable lines for a file that was "compiled but never executed".
+		lang->coverage_hits["res://zero_file.gd"]; // create empty entry in hits
+		lang->coverage_hits["res://zero_file.gd"][7] = 0; // line 7: explicitly zero
+
+		Error err = lang->coverage_write();
+		REQUIRE(err == OK);
+
+		Ref<FileAccess> f = FileAccess::open(out_path, FileAccess::READ);
+		REQUIRE(f.is_valid());
+		String contents = f->get_as_text();
+
+		CHECK_MESSAGE(contents.contains("hit_file.gd"), "Hit file must appear in JSON");
+		CHECK_MESSAGE(contents.contains("zero_file.gd"), "Zero-hit file must appear in JSON");
+		CHECK_MESSAGE(contents.contains("\"7\":0"), "Zero-hit line must appear with count 0");
+	}
+
 	TEST_CASE("[Modules][GDScript] Coverage: write LCOV multiple files") {
 		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
 		REQUIRE(lang != nullptr);

--- a/modules/gdscript/tests/test_gdscript_coverage.h
+++ b/modules/gdscript/tests/test_gdscript_coverage.h
@@ -895,6 +895,57 @@ TEST_SUITE("[Modules][GDScript]") {
 		CHECK(contents.contains("file_a.gd"));
 		CHECK(contents.contains("file_b.gd"));
 	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: inner-class methods with the same name produce distinct LCOV FN records") {
+		// Regression test: two inner classes that both define a method with the same
+		// name (e.g. "_ready") must each appear as a separate FN/FNDA entry.
+		// Before the fix, _coverage_collect_func_starts used a flat key of just the
+		// method name, so the second class would overwrite the first, causing FNF=1.
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		// Compile a script with two inner classes that share a method name.
+		const String script_path = TestUtils::get_temp_path("coverage_inner_clash.gd");
+		{
+			Ref<FileAccess> fw = FileAccess::open(script_path, FileAccess::WRITE);
+			REQUIRE(fw.is_valid());
+			fw->store_string(
+					"extends RefCounted\n"
+					"class A:\n"
+					"\tfunc _ready():\n"
+					"\t\tpass\n"
+					"class B:\n"
+					"\tfunc _ready():\n"
+					"\t\tpass\n");
+		}
+
+		ERR_PRINT_OFF;
+		Ref<GDScript> script = ResourceLoader::load(script_path, "GDScript");
+		ERR_PRINT_ON;
+		REQUIRE_MESSAGE(script.is_valid(), "Inner-class test script must compile");
+
+		const String out_path = TestUtils::get_temp_path("coverage_inner_clash.lcov");
+		lang->coverage_set_output(out_path);
+		lang->coverage_set_format("lcov");
+
+		// Simulate both inner-class methods being called with qualified names.
+		lang->coverage_record_func_entry(script_path, "A._ready");
+		lang->coverage_record_func_entry(script_path, "B._ready");
+
+		Error err = lang->coverage_write();
+		REQUIRE(err == OK);
+
+		Ref<FileAccess> f = FileAccess::open(out_path, FileAccess::READ);
+		REQUIRE(f.is_valid());
+		String contents = f->get_as_text();
+
+		CHECK_MESSAGE(contents.contains("A._ready"), "Inner class A._ready must appear in LCOV");
+		CHECK_MESSAGE(contents.contains("B._ready"), "Inner class B._ready must appear in LCOV");
+		// FNF must count each inner-class method separately, not collapse them.
+		CHECK_MESSAGE(contents.contains("FNF:2"), "Two distinct inner-class methods must each be counted in FNF");
+		CHECK_MESSAGE(contents.contains("FNH:2"), "Both called inner-class methods must be counted in FNH");
+	}
 }
 
 } // namespace GDScriptTests

--- a/modules/gdscript/tests/test_gdscript_coverage.h
+++ b/modules/gdscript/tests/test_gdscript_coverage.h
@@ -547,6 +547,48 @@ TEST_SUITE("[Modules][GDScript]") {
 		CHECK_MESSAGE(contents.contains("FNH:2"), "FNH must count hit functions");
 	}
 
+	TEST_CASE("[Modules][GDScript] Coverage: write LCOV emits FN records for functions") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		const String out_path = TestUtils::get_temp_path("coverage_fn_records.lcov");
+		lang->coverage_set_output(out_path);
+		lang->coverage_set_format("lcov");
+		lang->coverage_record_line("res://fn_test.gd", 3);
+		lang->coverage_record_func_entry("res://fn_test.gd", "_ready");
+
+		Error err = lang->coverage_write();
+		REQUIRE(err == OK);
+
+		Ref<FileAccess> f = FileAccess::open(out_path, FileAccess::READ);
+		REQUIRE(f.is_valid());
+		String contents = f->get_as_text();
+
+		// FN: records must precede FNDA: records so LCOV parsers can correlate them.
+		CHECK_MESSAGE(contents.contains("FN:"), "FN: record must be present");
+		CHECK_MESSAGE(contents.contains("FN:") && contents.contains("_ready"), "FN: record must name the function");
+		int fn_pos = contents.find("FN:");
+		int fnda_pos = contents.find("FNDA:");
+		CHECK_MESSAGE(fn_pos < fnda_pos, "FN: records must appear before FNDA: records");
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: write returns ERR_CANT_OPEN for unwritable path") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		// Use a path whose parent directory does not exist.
+		lang->coverage_output_path = "/nonexistent_dir_coverage_test/out.lcov";
+		lang->coverage_set_format("lcov");
+		lang->coverage_record_line("res://t.gd", 1);
+
+		Error err = lang->coverage_write();
+
+		CHECK_MESSAGE(err == ERR_CANT_OPEN, "write must return ERR_CANT_OPEN for an unwritable path");
+		CHECK_MESSAGE(!lang->coverage_written, "coverage_written must remain false on write failure");
+	}
+
 	TEST_CASE("[Modules][GDScript] Coverage: write LCOV includes branch records") {
 		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
 		REQUIRE(lang != nullptr);
@@ -687,6 +729,37 @@ TEST_SUITE("[Modules][GDScript]") {
 		// 2 of 3 lines hit → 66.7%
 		CHECK_MESSAGE(contents.contains("\"5\":1"), "Hit line 5 must appear with count 1");
 		CHECK_MESSAGE(contents.contains("\"15\":0"), "Unhit line 15 must appear with count 0");
+	}
+
+	TEST_CASE("[Modules][GDScript] Coverage: write JSON branch keys are sorted by IP") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		const String out_path = TestUtils::get_temp_path("coverage_branch_order.json");
+		lang->coverage_set_output(out_path);
+		lang->coverage_set_format("json");
+		lang->coverage_record_line("res://branch_order.gd", 1);
+		// Record branches at three different IPs out of natural order.
+		lang->coverage_record_branch("res://branch_order.gd", 1, 300, true);
+		lang->coverage_record_branch("res://branch_order.gd", 1, 100, true);
+		lang->coverage_record_branch("res://branch_order.gd", 1, 200, true);
+
+		Error err = lang->coverage_write();
+		REQUIRE(err == OK);
+
+		Ref<FileAccess> f = FileAccess::open(out_path, FileAccess::READ);
+		REQUIRE(f.is_valid());
+		String contents = f->get_as_text();
+
+		int pos100 = contents.find("\"100_taken\"");
+		int pos200 = contents.find("\"200_taken\"");
+		int pos300 = contents.find("\"300_taken\"");
+		REQUIRE_MESSAGE(pos100 != -1, "IP 100 branch key must appear");
+		REQUIRE_MESSAGE(pos200 != -1, "IP 200 branch key must appear");
+		REQUIRE_MESSAGE(pos300 != -1, "IP 300 branch key must appear");
+		CHECK_MESSAGE(pos100 < pos200, "IP 100 must appear before IP 200 in JSON output");
+		CHECK_MESSAGE(pos200 < pos300, "IP 200 must appear before IP 300 in JSON output");
 	}
 
 	TEST_CASE("[Modules][GDScript] Coverage: write text format produces summary file") {

--- a/modules/gdscript/tests/test_gdscript_coverage.h
+++ b/modules/gdscript/tests/test_gdscript_coverage.h
@@ -627,6 +627,33 @@ TEST_SUITE("[Modules][GDScript]") {
 		CHECK_MESSAGE(contents.contains("</coverage>"), "XML must be closed");
 	}
 
+	TEST_CASE("[Modules][GDScript] Coverage: write Cobertura line with branch data shows condition-coverage") {
+		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+		REQUIRE(lang != nullptr);
+		CoverageScopedReset guard;
+
+		const String out_path = TestUtils::get_temp_path("coverage_branch_cobertura.xml");
+		lang->coverage_set_output(out_path);
+		lang->coverage_set_format("cobertura");
+		lang->coverage_record_line("res://cob_branch.gd", 10);
+		// One branch: taken once, not-taken never.
+		lang->coverage_record_branch("res://cob_branch.gd", 10, 77, true);
+		// Line 20 has no branch data.
+		lang->coverage_record_line("res://cob_branch.gd", 20);
+
+		Error err = lang->coverage_write();
+		REQUIRE(err == OK);
+
+		Ref<FileAccess> f = FileAccess::open(out_path, FileAccess::READ);
+		REQUIRE(f.is_valid());
+		String contents = f->get_as_text();
+
+		CHECK_MESSAGE(contents.contains("branch=\"true\""), "Line with branch data must have branch=true");
+		CHECK_MESSAGE(contents.contains("condition-coverage="), "Line with branch data must have condition-coverage");
+		CHECK_MESSAGE(contents.contains("50%"), "One of two arms covered must give 50%");
+		CHECK_MESSAGE(contents.contains("branch=\"false\""), "Line without branch data must have branch=false");
+	}
+
 	TEST_CASE("[Modules][GDScript] Coverage: write JSON format produces valid JSON structure") {
 		GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
 		REQUIRE(lang != nullptr);

--- a/modules/gdscript/tests/test_gdscript_coverage.h
+++ b/modules/gdscript/tests/test_gdscript_coverage.h
@@ -666,6 +666,7 @@ TEST_SUITE("[Modules][GDScript]") {
 		CHECK_MESSAGE(contents.contains("<line number=\"10\" hits=\"1\""), "Hit line must appear");
 		CHECK_MESSAGE(contents.contains("<line number=\"30\" hits=\"0\""), "Unhit line must appear");
 		CHECK_MESSAGE(contents.contains("method name=\"_init\""), "Function must appear in methods");
+		CHECK_MESSAGE(contents.contains("name=\"cobertura_test\""), "DTD-required name= attribute must appear on class element");
 		CHECK_MESSAGE(contents.contains("</coverage>"), "XML must be closed");
 	}
 

--- a/modules/gdscript/tests/test_gdscript_coverage.h
+++ b/modules/gdscript/tests/test_gdscript_coverage.h
@@ -64,7 +64,7 @@ struct CoverageScopedReset {
 		saved_threshold = lang->coverage_threshold;
 		saved_include = lang->coverage_include;
 		saved_exclude = lang->coverage_exclude;
-		saved_enabled = lang->coverage_enabled;
+		saved_enabled = lang->coverage_enabled.is_set();
 		saved_written = lang->coverage_written;
 
 		// Start fresh so recorded data is isolated to this test.
@@ -73,7 +73,7 @@ struct CoverageScopedReset {
 		lang->coverage_branch_hits.clear();
 		lang->coverage_include.clear();
 		lang->coverage_exclude.clear();
-		lang->coverage_enabled = true;
+		lang->coverage_enabled.set();
 		lang->coverage_written = false;
 		lang->coverage_threshold = 0.0f;
 		lang->coverage_mode = GDScriptLanguage::COVERAGE_MODE_SET;
@@ -90,7 +90,7 @@ struct CoverageScopedReset {
 		lang->coverage_threshold = saved_threshold;
 		lang->coverage_include = saved_include;
 		lang->coverage_exclude = saved_exclude;
-		lang->coverage_enabled = saved_enabled;
+		lang->coverage_enabled.set_to(saved_enabled);
 		lang->coverage_written = saved_written;
 		lang->coverage_hits.clear();
 		lang->coverage_func_hits.clear();
@@ -186,7 +186,7 @@ TEST_SUITE("[Modules][GDScript]") {
 		CHECK(lang->coverage_hits.is_empty());
 		CHECK(lang->coverage_func_hits.is_empty());
 		CHECK(lang->coverage_branch_hits.is_empty());
-		CHECK(lang->coverage_enabled);
+		CHECK(lang->coverage_enabled.is_set());
 		CHECK(!lang->coverage_written);
 	}
 


### PR DESCRIPTION
## Summary

This PR adds line, function, and branch coverage instrumentation to the GDScript VM, with writers for four output formats (LCOV, Cobertura XML, JSON, plain text), command-line integration, and a comprehensive unit test suite.

Coverage is a `TOOLS_ENABLED`-only feature — the entire implementation compiles to nothing in release/export builds and has zero runtime overhead when disabled.

---

## How it works

### 1. Instrumentation — VM opcode hooks

Three opcode handlers in `gdscript_vm.cpp` are extended with recording hooks guarded by `unlikely()` so the branch predictor eliminates overhead when coverage is disabled:

| Opcode | What is recorded |
|---|---|
| `OPCODE_LINE` | Line hit — increments (or sets to 1 in *set* mode) the counter for that file/line |
| `OPCODE_JUMP_IF` | Branch outcome — records the boolean result of the condition |
| `OPCODE_JUMP_IF_NOT` | Branch outcome (inverted sense) |

Function entry is recorded once at the top of `GDScriptFunction::call()`. For scripts with inner classes, method names are qualified with the inner-class chain (e.g. `Outer.Inner.method_name`) so that same-named methods in different inner classes produce distinct keys.

The hot flag `coverage_enabled` is a `SafeFlag` (backed by `std::atomic<uint32_t>`) so reads from VM threads have acquire/release ordering without taking any lock.

### 2. Data storage — thread safety

All three hit maps are `HashMap`s owned by `GDScriptLanguage`:

```
coverage_hits:        file → line  → hit count
coverage_func_hits:   file → func  → hit count
coverage_branch_hits: file → ip    → {taken, not_taken, line}
```

A single `Mutex coverage_mutex` serialises writes from concurrent VM threads. The hot path in set mode:

```cpp
MutexLock lock(coverage_mutex);
coverage_hits[source][line] = 1;
```

Reads for output take a snapshot under the mutex and then work on the copy, so writers never hold the lock longer than a map copy.

### 3. Coverable-line enumeration

To report lines and functions that were *compiled but never executed*, the writers walk `GDScriptLanguage::script_list` and introspect bytecode via `GDScriptFunction::get_code()` — the same mechanism used by the debugger. Only scripts that were actually loaded/parsed during the session appear. Scripts that exist on disk but were never loaded cannot be reported.

Include/exclude glob patterns (`--coverage-include` / `--coverage-exclude`) are applied at enumeration time so all formats share a consistent view.

### 4. Output formats

| Flag value | Format | Consumed by |
|---|---|---|
| `lcov` (default) | LCOV `.info` | `genhtml`, `lcov`, `gcovr`, GitHub Actions coverage reporters |
| `cobertura` | Cobertura XML | Jenkins, GitLab CI, Azure DevOps, Codecov |
| `json` | Custom JSON | custom dashboards, diff tools |
| `text` | Human-readable summary | terminal / CI log |

All formats include unexecuted files (lines and functions at count 0) so percentages are accurate even for scripts that are compiled but never called during the test run.

### 5. Command-line integration

Arguments are parsed once in `GDScriptLanguage::init()`:

```
--coverage-output <path>       path to write the coverage file (enables coverage)
--coverage-format <fmt>        lcov | cobertura | json | text  (default: lcov)
--coverage-mode <mode>         set | count  (default: set)
--coverage-threshold <pct>     fail if line coverage is below this %
--coverage-include <glob>      include only matching files (repeatable)
--coverage-exclude <glob>      exclude matching files (repeatable)
```

`coverage_write()` is called automatically from:
- `GDScriptLanguage::finish()` — when the engine exits normally
- The GDScript test runner suite — after `runner.run_tests()` completes

If `--coverage-threshold` is set and line coverage falls below it, the engine prints an error and exits with a non-zero exit code.

---

## Example

Consider this project layout:

```
res://
  src/
    math.gd
  tests/
    test_math.gd
```

**`src/math.gd`**
```gdscript
func add(a, b):
    return a + b

func divide(a, b):
    if b == 0:
        return 0
    return a / b
```

**`tests/test_math.gd`**
```gdscript
extends SceneTree

func _init():
    var math = load("res://src/math.gd").new()

    assert(math.add(2, 3) == 5)
    assert(math.add(-1, 1) == 0)

    # Call divide() with a non-zero divisor only — the b==0 branch is uncovered
    assert(math.divide(10, 2) == 5)

    print("All tests passed.")
    quit()
```

Run with coverage:

```sh
godot --headless \
      --coverage-output coverage.info \
      --coverage-format lcov \
      --coverage-include "res://src/*" \
      -s tests/test_math.gd
```

**`coverage.info` (LCOV output)**

```
TN:
SF:/path/to/project/src/math.gd
FN:0,@implicit_new
FN:2,add
FN:5,divide
FNDA:1,@implicit_new
FNDA:1,add
FNDA:1,divide
FNF:3
FNH:3
BRDA:5,11,0,1
BRDA:5,11,1,0
BRF:2
BRH:1
DA:2,1
DA:5,1
DA:6,0
DA:7,1
LF:4
LH:3
end_of_record
```

- `FN:0,@implicit_new` — GDScript adds an implicit constructor for scripts without an explicit `_init()`; its start line is reported as 0 because it has no `OPCODE_LINE` opcode.
- `FN:2,add` and `FN:5,divide` — start lines are the first executable statement in each function.
- `BRDA:5,11,0,1` — the `if b == 0:` branch at line 5, instruction offset 11: the "condition true" arm was taken 1 time; the "condition false" arm (`BRDA:5,11,1,0`) was never taken because we only called `divide(10, 2)`.
- `DA:6,0` — `return 0` was never reached.

The same run produces this **Cobertura XML**:

```xml
<?xml version="1.0" ?>
<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
<coverage version="5.0" timestamp="..." line-rate="0.7500" branch-rate="0.5000"
          lines-covered="3" lines-valid="4" branches-covered="1" branches-valid="2">
  <packages>
    <package name="gdscript" line-rate="0.7500" branch-rate="0.5000" complexity="0">
      <classes>
        <class name="math" filename="/path/to/project/src/math.gd"
               line-rate="0.7500" branch-rate="0.5000">
          <methods>
            <method name="@implicit_new" hits="1"/>
            <method name="add" hits="1"/>
            <method name="divide" hits="1"/>
          </methods>
          <lines>
            <line number="2" hits="1" branch="false"/>
            <line number="5" hits="1" branch="true" condition-coverage="50% (1/2)"/>
            <line number="6" hits="0" branch="false"/>
            <line number="7" hits="1" branch="false"/>
          </lines>
        </class>
      </classes>
    </package>
  </packages>
</coverage>
```

And this **JSON**:

```json
{
  "files": {
    "res://src/math.gd": {
      "lines":     {"2": 1, "5": 1, "6": 0, "7": 1},
      "functions": {"@implicit_new": 1, "add": 1, "divide": 1},
      "branches":  {"11_taken": 1, "11_not_taken": 0}
    }
  },
  "summary": {"line_pct": 75.0, "func_pct": 100.0, "branch_pct": 50.0}
}
```

And this **text summary**:

```
File                                    Lines    Funcs    Branches
res://src/math.gd                       75.0%    100.0%   50.0%
────────────────────────────────────────────────────────────
Total                                   75.0%    100.0%   50.0%
```

**Using with the built-in GDScript test suite:**

```sh
godot --headless \
      --coverage-output coverage.info \
      --coverage-threshold 75 \
      -- --test --test-suite "[Modules][GDScript]"
```

**Uploading to Codecov from GitHub Actions:**

```yaml
- name: Run GDScript tests with coverage
  run: |
    godot --headless \
          --coverage-output coverage.info \
          --coverage-threshold 75 \
          -- --test --test-suite "[Modules][GDScript]"

- name: Upload coverage report
  uses: codecov/codecov-action@v4
  with:
    files: coverage.info
```

---

## Files changed

| File | Change |
|---|---|
| `modules/gdscript/gdscript.h` | Coverage data structures, enums, `SafeFlag coverage_enabled`, method declarations |
| `modules/gdscript/gdscript_coverage.cpp` | New file — all coverage logic: recording, coverable-line enumeration, four format writers |
| `modules/gdscript/gdscript_vm.cpp` | Opcode hooks for line, function, and branch recording |
| `modules/gdscript/gdscript.cpp` | CLI arg parsing; auto-start on `init()`; auto-write + threshold check on `finish()` |
| `modules/gdscript/tests/test_gdscript_coverage.h` | 35+ unit tests covering all recording paths and all four output formats |
| `modules/gdscript/tests/gdscript_test_runner_suite.h` | Wire `coverage_write()` return value check into the GDScript test runner |