### PR TITLE
Make OpenXR Spatial Entities easier to extend

### DIFF
--- a/misc/extension_api_validation/4.6-stable/GH-118128.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-118128.txt
@@ -1,0 +1,8 @@
+GH-118128
+---------
+Validate extension JSON: Error: Field 'classes/OpenXRSpatialAnchorCapability/methods/create_new_anchor/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/OpenXRSpatialComponentData/methods/_get_structure_data': is_const changed value in new API, from true to false.
+
+Added optional "next" structure when creating a new anchor.  The "next" structure is passed to the XR runtime.
+Made "OpenXRSpatialComponentData::_get_structure_data" (which is the virtual method that GDExtensions can override) non-const, which is consistent with the core virtual "OpenXRSpatialComponentData::get_structure_data" method.
+Compatibility methods registered.

--- a/modules/openxr/doc_classes/OpenXRSpatialAnchorCapability.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialAnchorCapability.xml
@@ -9,12 +9,22 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="create_default_persistence_context">
+			<return type="OpenXRFutureResult" />
+			<param index="0" name="user_callback" type="Callable" default="Callable()" />
+			<description>
+				Calls [method create_persistence_context] with a configuration that likely works with the XR runtime.
+				[param user_callback] is called when the context is created.
+			</description>
+		</method>
 		<method name="create_new_anchor">
 			<return type="OpenXRAnchorTracker" />
 			<param index="0" name="transform" type="Transform3D" />
 			<param index="1" name="spatial_context" type="RID" default="RID()" />
+			<param index="2" name="next" type="OpenXRStructureBase" default="null" />
 			<description>
 				Creates a new anchor that will be tracked by the XR runtime. The [param transform] should be a transform in the local space of your [XROrigin3D] node. If [param spatial_context] is not specified the default will be used, this requires [member ProjectSettings.xr/openxr/extensions/spatial_entity/enable_builtin_anchor_detection] to be set. The returned tracker will track the location in case our reference space changes.
+				[param next] must be a valid next object for the [code]XrSpatialAnchorCreateInfoEXT[/code] chain.
 			</description>
 		</method>
 		<method name="create_persistence_context">
@@ -24,6 +34,19 @@
 			<description>
 				Creates a new persistence context for storing persistent data.
 				[b]Note:[/b] This is an asynchronous method and returns an [OpenXRFutureResult] object with which to track the status, discarding this object will not cancel the creation process. On success [param user_callback] will be called if specified. The result value for this function is the [RID] for our persistence context.
+			</description>
+		</method>
+		<method name="do_entity_update">
+			<return type="void" />
+			<param index="0" name="spatial_context" type="RID" />
+			<param index="1" name="component_data" type="OpenXRSpatialComponentData[]" />
+			<param index="2" name="next_snapshot_create" type="OpenXRStructureBase" default="null" />
+			<param index="3" name="next_snapshot_query" type="OpenXRStructureBase" default="null" />
+			<description>
+				Calls [method OpenXRSpatialEntityExtension.update_spatial_entities] and [method OpenXRSpatialEntityExtension.query_snapshot] with the anchor entities associated with [param spatial_context].
+				[param component_data] are the [OpenXRSpatialComponentData]s to update for this anchor capability.
+				If [param next_snapshot_create] is non-null, then pass this to the [code]next[/code] parameter in [method OpenXRSpatialEntityExtension.update_spatial_entities].
+				If [param next_snapshot_query] is non-null, then pass this to the [code]next[/code] parameter in [method OpenXRSpatialEntityExtension.query_snapshot].
 			</description>
 		</method>
 		<method name="free_persistence_context">
@@ -76,6 +99,22 @@
 			<param index="0" name="anchor_tracker" type="OpenXRAnchorTracker" />
 			<description>
 				Remove an anchor previously created with [method create_new_anchor]. If this anchor was persistent you must first call [method unpersist_anchor] and await its callback.
+			</description>
+		</method>
+		<method name="start_entity_discovery">
+			<return type="OpenXRFutureResult" />
+			<param index="0" name="spatial_context" type="RID" />
+			<param index="1" name="component_data" type="OpenXRSpatialComponentData[]" />
+			<param index="2" name="next_snapshot_create" type="OpenXRStructureBase" default="null" />
+			<param index="3" name="next_snapshot_query" type="OpenXRStructureBase" default="null" />
+			<param index="4" name="user_callback" type="Callable" default="Callable()" />
+			<description>
+				Calls [method OpenXRSpatialEntityExtension.discover_spatial_entities] and [method OpenXRSpatialEntityExtension.query_snapshot] with the anchor entities associated with [param spatial_context].
+				[param component_data] are the [OpenXRSpatialComponentData]s to discover for this anchor capability.
+				If [param next_snapshot_create] is non-null, then pass this to the [code]next[/code] parameter in [method OpenXRSpatialEntityExtension.discover_spatial_entities].
+				If [param next_snapshot_query] is non-null, then pass this to the [code]next[/code] parameter in [method OpenXRSpatialEntityExtension.query_snapshot].
+				[param user_callback], when non-null, is called with two parameters usually twice. The first parameter is the [RID] of the discovery snapshot and the second parameter is a boolean where [code]false[/code] indicates the discovery snapshot is about to be processed, and [code]true[/code] indicates the discovery snapshot has been processed and [param component_data] has valid data. The second call is skipped if an error was encountered.
+				The returned [OpenXRFutureResult] is identical to the return from [method OpenXRSpatialEntityExtension.discover_spatial_entities].
 			</description>
 		</method>
 		<method name="unpersist_anchor">

--- a/modules/openxr/doc_classes/OpenXRSpatialCapabilityConfigurationBaseHeader.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialCapabilityConfigurationBaseHeader.xml
@@ -21,6 +21,13 @@
 				Return [code]true[/code] if this object contains a valid configuration that can be retrieved when calling [method _get_configuration].
 			</description>
 		</method>
+		<method name="get_configuration">
+			<return type="int" />
+			<description>
+				Gets a pointer to the [code]XrSpatialCapabilityConfigurationBaseHeaderEXT[/code] struct.
+				[b]Note:[/b] This method is intended to be used from GDExtensions.
+			</description>
+		</method>
 		<method name="has_valid_configuration" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/modules/openxr/doc_classes/OpenXRSpatialComponentData.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialComponentData.xml
@@ -15,7 +15,7 @@
 				Return the component type for the component we store data for.
 			</description>
 		</method>
-		<method name="_get_structure_data" qualifiers="virtual const">
+		<method name="_get_structure_data" qualifiers="virtual">
 			<return type="int" />
 			<param index="0" name="next" type="int" />
 			<description>
@@ -26,14 +26,20 @@
 			<return type="void" />
 			<param index="0" name="capacity" type="int" />
 			<description>
-				Set the expected capacity as provided by the spatial entities query system. Buffers should be initialized with the correct storage.
+				Sets the expected capacity as provided by the spatial entities query system. Buffers should be initialized with the correct storage.
+			</description>
+		</method>
+		<method name="get_component_type" qualifiers="const">
+			<return type="int" />
+			<description>
+				Gets this [OpenXRSpatialComponentData]'s [code]XrSpatialComponentTypeEXT[/code].
 			</description>
 		</method>
 		<method name="set_capacity">
 			<return type="void" />
 			<param index="0" name="capacity" type="int" />
 			<description>
-				Set the expected capacity as provided by the spatial entities query system. Buffers should be initialized with the correct storage.
+				Sets the expected capacity as provided by the spatial entities query system. Buffers should be initialized with the correct storage.
 			</description>
 		</method>
 	</methods>

--- a/modules/openxr/doc_classes/OpenXRSpatialContextPersistenceConfig.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialContextPersistenceConfig.xml
@@ -16,6 +16,12 @@
 				Adds a persistence context to this configuration. You must add at least one persistence context to create a valid configuration. You can create a persistence context by calling [method OpenXRSpatialAnchorCapability.create_persistence_context].
 			</description>
 		</method>
+		<method name="get_persistence_contexts" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Gets the persistence context(s) (as [RID]s) received by [method add_persistence_context].
+			</description>
+		</method>
 		<method name="remove_persistence_context">
 			<return type="void" />
 			<param index="0" name="persistence_context" type="RID" />

--- a/modules/openxr/doc_classes/OpenXRSpatialEntityExtension.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialEntityExtension.xml
@@ -41,6 +41,16 @@
 				[b]Note:[/b] This is an asynchronous method and returns an [OpenXRFutureResult] object with which to track the status, discarding this object will not cancel the discovery process. On success [param user_callback] will be called if specified. The result data for this function is the [RID] for our snapshot.
 			</description>
 		</method>
+		<method name="discover_spatial_entities_with_component_data">
+			<return type="OpenXRFutureResult" />
+			<param index="0" name="spatial_context" type="RID" />
+			<param index="1" name="component_data" type="OpenXRSpatialComponentData[]" />
+			<param index="2" name="next" type="OpenXRStructureBase" default="null" />
+			<param index="3" name="user_callback" type="Callable" default="Callable()" />
+			<description>
+				Convenience method when the caller only has an [Array] of [OpenXRSpatialComponentData] and needs to discover spatial entities.
+			</description>
+		</method>
 		<method name="find_spatial_entity">
 			<return type="RID" />
 			<param index="0" name="entity_id" type="int" />

--- a/modules/openxr/doc_classes/OpenXRSpatialEntityTracker.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialEntityTracker.xml
@@ -8,6 +8,43 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="add_next">
+			<return type="void" />
+			<param index="0" name="next" type="OpenXRStructureBase" />
+			<description>
+				Adds a new [OpenXRStructureBase] to the next-chain.
+				[method get_next] will return this [param next] until either [method add_next] is called again or it's removed in [method remove_next].
+			</description>
+		</method>
+		<method name="get_next" qualifiers="const">
+			<return type="OpenXRStructureBase" />
+			<description>
+				Gets the head [OpenXRStructureBase] in the next-chain.
+				See also [method add_next] and [method remove_next].
+			</description>
+		</method>
+		<method name="get_spatial_context" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Gets the spatial context used to create this [OpenXRSpatialEntityTracker].
+			</description>
+		</method>
+		<method name="remove_next">
+			<return type="void" />
+			<param index="0" name="next" type="OpenXRStructureBase" />
+			<description>
+				Removes a [param next] object previously added in [method add_next] from the next-chain.
+			</description>
+		</method>
+		<method name="set_spatial_context">
+			<return type="void" />
+			<param index="0" name="spatial_context" type="RID" />
+			<description>
+				Sets the spatial context used to create this tracker.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="entity" type="RID" setter="set_entity" getter="get_entity" default="RID()">
 			The spatial entity associated with this tracker.
@@ -18,6 +55,11 @@
 		<member name="type" type="int" setter="set_tracker_type" getter="get_tracker_type" overrides="XRTracker" enum="XRServer.TrackerType" default="8" />
 	</members>
 	<signals>
+		<signal name="next_changed">
+			<description>
+				Emitted when the next-chain changes, from either [method add_next] or [method remove_next].
+			</description>
+		</signal>
 		<signal name="spatial_tracking_state_changed">
 			<param index="0" name="spatial_tracking_state" type="int" />
 			<description>

--- a/modules/openxr/doc_classes/OpenXRSpatialMarkerTrackingCapability.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialMarkerTrackingCapability.xml
@@ -9,6 +9,19 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="do_entity_update">
+			<return type="void" />
+			<param index="0" name="spatial_context" type="RID" />
+			<param index="1" name="component_data" type="OpenXRSpatialComponentData[]" />
+			<param index="2" name="next_snapshot_create" type="OpenXRStructureBase" default="null" />
+			<param index="3" name="next_snapshot_query" type="OpenXRStructureBase" default="null" />
+			<description>
+				Calls [method OpenXRSpatialEntityExtension.update_spatial_entities] and [method OpenXRSpatialEntityExtension.query_snapshot] with the marker entities associated with [param spatial_context].
+				[param component_data] are the [OpenXRSpatialComponentData]s to update for this marker capability.
+				If [param next_snapshot_create] is non-null, then pass this to the [code]next[/code] parameter in [method OpenXRSpatialEntityExtension.update_spatial_entities].
+				If [param next_snapshot_query] is non-null, then pass this to the [code]next[/code] parameter in [method OpenXRSpatialEntityExtension.query_snapshot].
+			</description>
+		</method>
 		<method name="is_april_tag_supported">
 			<return type="bool" />
 			<description>
@@ -31,6 +44,22 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if QR code marker tracking is supported by the current device.
+			</description>
+		</method>
+		<method name="start_entity_discovery">
+			<return type="OpenXRFutureResult" />
+			<param index="0" name="spatial_context" type="RID" />
+			<param index="1" name="component_data" type="OpenXRSpatialComponentData[]" />
+			<param index="2" name="next_snapshot_create" type="OpenXRStructureBase" default="null" />
+			<param index="3" name="next_snapshot_query" type="OpenXRStructureBase" default="null" />
+			<param index="4" name="user_callback" type="Callable" default="Callable()" />
+			<description>
+				Calls [method OpenXRSpatialEntityExtension.discover_spatial_entities] and [method OpenXRSpatialEntityExtension.query_snapshot] with the marker entities associated with [param spatial_context].
+				[param component_data] are the [OpenXRSpatialComponentData]s to discover for this marker capability.
+				If [param next_snapshot_create] is non-null, then pass this to the [code]next[/code] parameter in [method OpenXRSpatialEntityExtension.discover_spatial_entities].
+				If [param next_snapshot_query] is non-null, then pass this to the [code]next[/code] parameter in [method OpenXRSpatialEntityExtension.query_snapshot].
+				[param user_callback], when non-null, is called with two parameters usually twice. The first parameter is the [RID] of the discovery snapshot and the second parameter is a boolean where [code]false[/code] indicates the discovery snapshot is about to be processed, and [code]true[/code] indicates the discovery snapshot has been processed and [param component_data] has valid data. The second call is skipped if an error was encountered.
+				The returned [OpenXRFutureResult] is identical to the return from [method OpenXRSpatialEntityExtension.discover_spatial_entities].
 			</description>
 		</method>
 	</methods>

--- a/modules/openxr/doc_classes/OpenXRSpatialPlaneTrackingCapability.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialPlaneTrackingCapability.xml
@@ -15,5 +15,21 @@
 				Returns [code]true[/code] if plane tracking is supported by the current device.
 			</description>
 		</method>
+		<method name="start_entity_discovery">
+			<return type="OpenXRFutureResult" />
+			<param index="0" name="spatial_context" type="RID" />
+			<param index="1" name="component_data" type="OpenXRSpatialComponentData[]" />
+			<param index="2" name="next_snapshot_create" type="OpenXRStructureBase" default="null" />
+			<param index="3" name="next_snapshot_query" type="OpenXRStructureBase" default="null" />
+			<param index="4" name="user_callback" type="Callable" default="Callable()" />
+			<description>
+				Calls [method OpenXRSpatialEntityExtension.discover_spatial_entities] and [method OpenXRSpatialEntityExtension.query_snapshot] with the plane entities associated with [param spatial_context].
+				[param component_data] are the [OpenXRSpatialComponentData]s to discover for this plane capability.
+				If [param next_snapshot_create] is non-null, then pass this to the [code]next[/code] parameter in [method OpenXRSpatialEntityExtension.discover_spatial_entities].
+				If [param next_snapshot_query] is non-null, then pass this to the [code]next[/code] parameter in [method OpenXRSpatialEntityExtension.query_snapshot].
+				[param user_callback], when non-null, is called with two parameters usually twice. The first parameter is the [RID] of the discovery snapshot and the second parameter is a boolean where [code]false[/code] indicates the discovery snapshot is about to be processed, and [code]true[/code] indicates the discovery snapshot has been processed and [param component_data] has valid data. The second call is skipped if an error was encountered.
+				The returned [OpenXRFutureResult] is identical to the return from [method OpenXRSpatialEntityExtension.discover_spatial_entities].
+			</description>
+		</method>
 	</methods>
 </class>

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.compat.inc
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.compat.inc
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  openxr_spatial_anchor.compat.inc                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "openxr_spatial_anchor.h"
+
+#include "core/object/class_db.h"
+
+void OpenXRSpatialAnchorCapability::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("create_new_anchor", "transform", "spatial_context"), &OpenXRSpatialAnchorCapability::_create_new_anchor_compat_118128, DEFVAL(RID()));
+}
+
+Ref<OpenXRAnchorTracker> OpenXRSpatialAnchorCapability::_create_new_anchor_compat_118128(const Transform3D &p_transform, RID p_spatial_context) {
+	return create_new_anchor(p_transform, p_spatial_context, Ref<OpenXRStructureBase>());
+}
+
+#endif

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "openxr_spatial_anchor.h"
+#include "openxr_spatial_anchor.compat.inc"
 
 #include "../../openxr_api.h"
 #include "../../openxr_util.h"
@@ -129,6 +130,7 @@ Transform3D OpenXRSpatialComponentAnchorList::get_entity_pose(int64_t p_index) c
 void OpenXRSpatialContextPersistenceConfig::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_persistence_context", "persistence_context"), &OpenXRSpatialContextPersistenceConfig::add_persistence_context);
 	ClassDB::bind_method(D_METHOD("remove_persistence_context", "persistence_context"), &OpenXRSpatialContextPersistenceConfig::remove_persistence_context);
+	ClassDB::bind_method(D_METHOD("get_persistence_contexts"), &OpenXRSpatialContextPersistenceConfig::get_persistence_contexts);
 }
 
 bool OpenXRSpatialContextPersistenceConfig::has_valid_configuration() const {
@@ -192,6 +194,17 @@ void OpenXRSpatialContextPersistenceConfig::remove_persistence_context(RID p_per
 	ERR_FAIL_COND(!persistence_contexts.has(p_persistence_context));
 
 	persistence_contexts.erase(p_persistence_context);
+}
+
+Array OpenXRSpatialContextPersistenceConfig::get_persistence_contexts() const {
+	Array ret;
+
+	ret.resize(persistence_contexts.size());
+	for (int i = 0; i < persistence_contexts.size(); ++i) {
+		ret[i] = persistence_contexts[i];
+	}
+
+	return ret;
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -322,14 +335,18 @@ void OpenXRSpatialAnchorCapability::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_spatial_persistence_supported"), &OpenXRSpatialAnchorCapability::is_spatial_persistence_supported);
 
 	ClassDB::bind_method(D_METHOD("is_persistence_scope_supported", "scope"), &OpenXRSpatialAnchorCapability::_is_persistence_scope_supported);
+	ClassDB::bind_method(D_METHOD("create_default_persistence_context", "user_callback"), &OpenXRSpatialAnchorCapability::create_default_persistence_context, DEFVAL(Callable()));
 	ClassDB::bind_method(D_METHOD("create_persistence_context", "scope", "user_callback"), &OpenXRSpatialAnchorCapability::_create_persistence_context, DEFVAL(Callable()));
 	ClassDB::bind_method(D_METHOD("get_persistence_context_handle", "persistence_context"), &OpenXRSpatialAnchorCapability::_get_persistence_context_handle);
 	ClassDB::bind_method(D_METHOD("free_persistence_context", "persistence_context"), &OpenXRSpatialAnchorCapability::free_persistence_context);
 
-	ClassDB::bind_method(D_METHOD("create_new_anchor", "transform", "spatial_context"), &OpenXRSpatialAnchorCapability::create_new_anchor, DEFVAL(RID()));
+	ClassDB::bind_method(D_METHOD("create_new_anchor", "transform", "spatial_context", "next"), &OpenXRSpatialAnchorCapability::create_new_anchor, DEFVAL(RID()), DEFVAL(Ref<OpenXRStructureBase>()));
 	ClassDB::bind_method(D_METHOD("remove_anchor", "anchor_tracker"), &OpenXRSpatialAnchorCapability::remove_anchor);
 	ClassDB::bind_method(D_METHOD("persist_anchor", "anchor_tracker", "persistence_context", "user_callback"), &OpenXRSpatialAnchorCapability::persist_anchor, DEFVAL(RID()), DEFVAL(Callable()));
 	ClassDB::bind_method(D_METHOD("unpersist_anchor", "anchor_tracker", "persistence_context", "user_callback"), &OpenXRSpatialAnchorCapability::unpersist_anchor, DEFVAL(RID()), DEFVAL(Callable()));
+
+	ClassDB::bind_method(D_METHOD("start_entity_discovery", "spatial_context", "component_data", "next_snapshot_create", "next_snapshot_query", "user_callback"), &OpenXRSpatialAnchorCapability::start_entity_discovery, DEFVAL(Variant()), DEFVAL(Variant()), DEFVAL(Callable()));
+	ClassDB::bind_method(D_METHOD("do_entity_update", "spatial_context", "component_data", "next_snapshot_create", "next_snapshot_query"), &OpenXRSpatialAnchorCapability::do_entity_update, DEFVAL(Variant()), DEFVAL(Variant()));
 
 	BIND_ENUM_CONSTANT(PERSISTENCE_SCOPE_SYSTEM_MANAGED);
 	BIND_ENUM_CONSTANT(PERSISTENCE_SCOPE_LOCAL_ANCHORS);
@@ -419,25 +436,7 @@ void OpenXRSpatialAnchorCapability::on_session_created(const XrSession p_session
 			// We may even want to create multiple here so we get access to all
 			// but then mark one that we use to create our persistent anchors on.
 
-			XrSpatialPersistenceScopeEXT scope = XR_SPATIAL_PERSISTENCE_SCOPE_MAX_ENUM_EXT;
-
-			// Lets check these in order of importance to us and find the best applicable scope.
-			if (supported_persistence_scopes.has(XR_SPATIAL_PERSISTENCE_SCOPE_LOCAL_ANCHORS_EXT)) {
-				// This scope allows for local storage and is required if we want to create our own anchors.
-				scope = XR_SPATIAL_PERSISTENCE_SCOPE_LOCAL_ANCHORS_EXT;
-			} else if (supported_persistence_scopes.has(XR_SPATIAL_PERSISTENCE_SCOPE_SYSTEM_MANAGED_EXT)) {
-				// The system managed scope is a read only scope with system managed anchors.
-				scope = XR_SPATIAL_PERSISTENCE_SCOPE_SYSTEM_MANAGED_EXT;
-			} else {
-				// Just use the first supported scope, but this will be an unknown type.
-				scope = supported_persistence_scopes[0];
-			}
-
-			// Output what we're using:
-			print_verbose("OpenXR: Using persistence scope " + get_spatial_persistence_scope_name(scope));
-
-			// Start by creating our persistence context.
-			create_persistence_context(scope, callable_mp(this, &OpenXRSpatialAnchorCapability::_on_persistence_context_completed));
+			create_default_persistence_context(callable_mp(this, &OpenXRSpatialAnchorCapability::_on_persistence_context_completed));
 		} else {
 			// Start by creating our spatial context
 			_create_spatial_context();
@@ -457,10 +456,12 @@ void OpenXRSpatialAnchorCapability::on_session_destroyed() {
 	ERR_FAIL_NULL(xr_server);
 
 	// Free and unregister our anchors
-	for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRAnchorTracker>> &anchor : anchors) {
-		xr_server->remove_tracker(anchor.value);
+	for (const KeyValue<RID, HashMap<XrSpatialEntityIdEXT, Ref<OpenXRAnchorTracker>>> &anchors : anchor_trackers) {
+		for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRAnchorTracker>> &anchor : anchors.value) {
+			xr_server->remove_tracker(anchor.value);
+		}
 	}
-	anchors.clear();
+	anchor_trackers.clear();
 
 	// Free our configurations
 	anchor_configuration.unref();
@@ -506,36 +507,42 @@ void OpenXRSpatialAnchorCapability::on_process() {
 	}
 
 	// Check if we need to start our discovery.
-	if (need_discovery && discovery_cooldown == 0 && !discovery_query_result.is_valid()) {
+	if (need_discovery && discovery_cooldown == 0 && !discovery_query_result.is_valid() && persistence_context.is_valid()) {
 		need_discovery = false;
 		discovery_cooldown = 60; // Set our cooldown to 60 frames, it doesn't need to be an exact science.
 
-		_start_entity_discovery();
+		if (anchor_discovery_component_data.is_empty()) {
+			// We always need a query result data object, and it must be first
+			Ref<OpenXRSpatialQueryResultData> query_result_data;
+			query_result_data.instantiate();
+			anchor_discovery_component_data.push_back(query_result_data);
+
+			Ref<OpenXRSpatialComponentAnchorList> anchor_list_data;
+			anchor_list_data.instantiate();
+			anchor_discovery_component_data.push_back(anchor_list_data);
+
+			Ref<OpenXRSpatialComponentPersistenceList> persistence_list_data;
+			persistence_list_data.instantiate();
+			anchor_discovery_component_data.push_back(persistence_list_data);
+		}
+
+		discovery_query_result = start_entity_discovery(spatial_context, anchor_discovery_component_data);
 	}
 
-	// If we have a valid spatial context, and we have anchors, we want updates!
-	if (spatial_context.is_valid() && !anchors.is_empty()) {
-		OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
-		ERR_FAIL_NULL(se_extension);
+	// If we have anchors, we want updates!
+	if (!anchor_trackers[spatial_context].is_empty()) {
+		if (anchor_update_component_data.is_empty()) {
+			// We always need a query result data object, and it must be first
+			Ref<OpenXRSpatialQueryResultData> query_result_data;
+			query_result_data.instantiate();
+			anchor_update_component_data.push_back(query_result_data);
 
-		// We want updates for all anchors
-		thread_local LocalVector<RID> entities;
-		entities.resize(anchors.size());
-		RID *entity = entities.ptr();
-		for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRAnchorTracker>> &e : anchors) {
-			*entity = e.value->get_entity();
-			entity++;
+			Ref<OpenXRSpatialComponentAnchorList> anchor_list_data;
+			anchor_list_data.instantiate();
+			anchor_update_component_data.push_back(anchor_list_data);
 		}
 
-		// We just want our anchor component
-		thread_local LocalVector<XrSpatialComponentTypeEXT> component_types;
-		component_types.push_back(XR_SPATIAL_COMPONENT_TYPE_ANCHOR_EXT);
-
-		// And we get our update snapshot, this is NOT async!
-		RID snapshot = se_extension->update_spatial_entities(spatial_context, entities, component_types, nullptr);
-		if (snapshot.is_valid()) {
-			_process_update_snapshot(snapshot);
-		}
+		do_entity_update(spatial_context, anchor_update_component_data);
 	}
 }
 
@@ -610,6 +617,28 @@ bool OpenXRSpatialAnchorCapability::is_persistence_scope_supported(XrSpatialPers
 
 bool OpenXRSpatialAnchorCapability::_is_persistence_scope_supported(PersistenceScope p_scope) {
 	return is_persistence_scope_supported((XrSpatialPersistenceScopeEXT)p_scope);
+}
+
+Ref<OpenXRFutureResult> OpenXRSpatialAnchorCapability::create_default_persistence_context(const Callable &p_user_callback) {
+	XrSpatialPersistenceScopeEXT scope = XR_SPATIAL_PERSISTENCE_SCOPE_MAX_ENUM_EXT;
+
+	// Lets check these in order of importance to us and find the best applicable scope.
+	if (supported_persistence_scopes.has(XR_SPATIAL_PERSISTENCE_SCOPE_LOCAL_ANCHORS_EXT)) {
+		// This scope allows for local storage and is required if we want to create our own anchors.
+		scope = XR_SPATIAL_PERSISTENCE_SCOPE_LOCAL_ANCHORS_EXT;
+	} else if (supported_persistence_scopes.has(XR_SPATIAL_PERSISTENCE_SCOPE_SYSTEM_MANAGED_EXT)) {
+		// The system managed scope is a read only scope with system managed anchors.
+		scope = XR_SPATIAL_PERSISTENCE_SCOPE_SYSTEM_MANAGED_EXT;
+	} else {
+		// Just use the first supported scope, but this will be an unknown type.
+		scope = supported_persistence_scopes[0];
+	}
+
+	// Output what we're using:
+	print_verbose("OpenXR: Using persistence scope " + get_spatial_persistence_scope_name(scope));
+
+	// Start by creating our persistence context.
+	return create_persistence_context(scope, p_user_callback);
 }
 
 Ref<OpenXRFutureResult> OpenXRSpatialAnchorCapability::create_persistence_context(XrSpatialPersistenceScopeEXT p_scope, const Callable &p_user_callback) {
@@ -763,33 +792,11 @@ void OpenXRSpatialAnchorCapability::_on_spatial_discovery_recommended(RID p_spat
 	}
 }
 
-Ref<OpenXRFutureResult> OpenXRSpatialAnchorCapability::_start_entity_discovery() {
-	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
-	ERR_FAIL_NULL_V(se_extension, nullptr);
-
-	// It makes no sense to discover non persistent anchors as we'd have created them during this session.
-	if (!persistence_context.is_valid()) {
-		return nullptr;
+void OpenXRSpatialAnchorCapability::_process_discovery_snapshot(RID p_snapshot, RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_query, const Callable &p_user_callback) {
+	if (p_user_callback.is_valid()) {
+		p_user_callback.call(p_snapshot, false);
 	}
 
-	// Already running or ran discovery, cancel/clean up.
-	if (discovery_query_result.is_valid()) {
-		discovery_query_result->cancel_future();
-		discovery_query_result.unref();
-	}
-
-	// We want both our anchor and persistence component.
-	Vector<XrSpatialComponentTypeEXT> component_types;
-	component_types.push_back(XR_SPATIAL_COMPONENT_TYPE_ANCHOR_EXT);
-	component_types.push_back(XR_SPATIAL_COMPONENT_TYPE_PERSISTENCE_EXT);
-
-	// Start our new snapshot.
-	discovery_query_result = se_extension->discover_spatial_entities(spatial_context, component_types, nullptr, callable_mp(this, &OpenXRSpatialAnchorCapability::_process_discovery_snapshot));
-
-	return discovery_query_result;
-}
-
-void OpenXRSpatialAnchorCapability::_process_discovery_snapshot(RID p_snapshot) {
 	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
 	ERR_FAIL_NULL(se_extension);
 	XRServer *xr_server = XRServer::get_singleton();
@@ -797,25 +804,32 @@ void OpenXRSpatialAnchorCapability::_process_discovery_snapshot(RID p_snapshot) 
 	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
 	ERR_FAIL_NULL(openxr_api);
 
-	// Build our component data.
-	TypedArray<OpenXRSpatialComponentData> component_data;
+	// The first must be OpenXRSpatialQueryResultData
+	Ref<OpenXRSpatialQueryResultData> query_result_data = p_component_data.is_empty() ? Variant() : p_component_data[0];
+	ERR_FAIL_COND(query_result_data.is_null());
 
-	// We always need a query result data object.
-	Ref<OpenXRSpatialQueryResultData> query_result_data;
-	query_result_data.instantiate();
-	component_data.push_back(query_result_data);
-
-	// And an anchor list object.
 	Ref<OpenXRSpatialComponentAnchorList> anchor_list_data;
-	anchor_list_data.instantiate();
-	component_data.push_back(anchor_list_data);
-
-	// Note that adding this data object means our snapshot will only return persistent anchors!
 	Ref<OpenXRSpatialComponentPersistenceList> persistence_list_data;
-	persistence_list_data.instantiate();
-	component_data.push_back(persistence_list_data);
+	for (Ref<OpenXRSpatialComponentData> data : p_component_data) {
+		switch (data->get_component_type()) {
+			case XR_SPATIAL_COMPONENT_TYPE_ANCHOR_EXT:
+				anchor_list_data = data;
+				break;
+			case XR_SPATIAL_COMPONENT_TYPE_PERSISTENCE_EXT:
+				persistence_list_data = data;
+				break;
+			default:
+				// Okay, maybe other data types are being queried that we don't know about
+				break;
+		}
+	}
 
-	if (se_extension->query_snapshot(p_snapshot, component_data, nullptr)) {
+	// Must be discovering at least persisted anchors, otherwise why are we here?
+	ERR_FAIL_COND(anchor_list_data.is_null());
+	ERR_FAIL_COND(persistence_list_data.is_null());
+
+	HashMap<XrSpatialEntityIdEXT, Ref<OpenXRAnchorTracker>> &anchors = anchor_trackers[p_spatial_context];
+	if (se_extension->query_snapshot(p_snapshot, p_component_data, p_next_snapshot_query)) {
 		// Now loop through our data and update our anchors.
 		int64_t size = query_result_data->get_capacity();
 		for (int64_t i = 0; i < size; i++) {
@@ -840,6 +854,7 @@ void OpenXRSpatialAnchorCapability::_process_discovery_snapshot(RID p_snapshot) 
 				} else {
 					// Create a new anchor.
 					anchor.instantiate();
+					anchor->set_spatial_context(p_spatial_context);
 					anchor->set_entity(se_extension->make_spatial_entity(se_extension->get_spatial_snapshot_context(p_snapshot), entity_id));
 					anchors[entity_id] = anchor;
 
@@ -876,6 +891,10 @@ void OpenXRSpatialAnchorCapability::_process_discovery_snapshot(RID p_snapshot) 
 		// in another device removing the shared anchor we need to deal with this.
 	}
 
+	if (p_user_callback.is_valid()) {
+		p_user_callback.call(p_snapshot, true);
+	}
+
 	// Now that we're done, clean up our snapshot!
 	se_extension->free_spatial_snapshot(p_snapshot);
 
@@ -885,7 +904,7 @@ void OpenXRSpatialAnchorCapability::_process_discovery_snapshot(RID p_snapshot) 
 	}
 }
 
-void OpenXRSpatialAnchorCapability::_process_update_snapshot(RID p_snapshot) {
+void OpenXRSpatialAnchorCapability::_process_update_snapshot(RID p_snapshot, RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_query) {
 	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
 	ERR_FAIL_NULL(se_extension);
 	XRServer *xr_server = XRServer::get_singleton();
@@ -893,20 +912,27 @@ void OpenXRSpatialAnchorCapability::_process_update_snapshot(RID p_snapshot) {
 	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
 	ERR_FAIL_NULL(openxr_api);
 
-	// Build our component data.
-	TypedArray<OpenXRSpatialComponentData> component_data;
+	// The first must be OpenXRSpatialQueryResultData
+	Ref<OpenXRSpatialQueryResultData> query_result_data = p_component_data.is_empty() ? Variant() : p_component_data[0];
+	ERR_FAIL_COND(query_result_data.is_null());
 
-	// We always need a query result data object.
-	Ref<OpenXRSpatialQueryResultData> query_result_data;
-	query_result_data.instantiate();
-	component_data.push_back(query_result_data);
-
-	// And an anchor list object.
 	Ref<OpenXRSpatialComponentAnchorList> anchor_list_data;
-	anchor_list_data.instantiate();
-	component_data.push_back(anchor_list_data);
+	for (Ref<OpenXRSpatialComponentData> data : p_component_data) {
+		switch (data->get_component_type()) {
+			case XR_SPATIAL_COMPONENT_TYPE_ANCHOR_EXT:
+				anchor_list_data = data;
+				break;
+			default:
+				// Okay, maybe other data types are being queried that we don't know about
+				break;
+		}
+	}
 
-	if (se_extension->query_snapshot(p_snapshot, component_data, nullptr)) {
+	// Must be updating at least anchors, otherwise why are we here?
+	ERR_FAIL_COND(anchor_list_data.is_null());
+
+	HashMap<XrSpatialEntityIdEXT, Ref<OpenXRAnchorTracker>> &anchors = anchor_trackers[p_spatial_context];
+	if (se_extension->query_snapshot(p_snapshot, p_component_data, p_next_snapshot_query)) {
 		// Now loop through our data and update our anchors.
 		int64_t size = query_result_data->get_capacity();
 		for (int64_t i = 0; i < size; i++) {
@@ -941,7 +967,7 @@ void OpenXRSpatialAnchorCapability::_process_update_snapshot(RID p_snapshot) {
 ////////////////////////////////////////////////////////////////////////////
 // Anchor creation
 
-Ref<OpenXRAnchorTracker> OpenXRSpatialAnchorCapability::create_new_anchor(const Transform3D &p_transform, RID p_spatial_context) {
+Ref<OpenXRAnchorTracker> OpenXRSpatialAnchorCapability::create_new_anchor(const Transform3D &p_transform, RID p_spatial_context, Ref<OpenXRStructureBase> p_next) {
 	Ref<OpenXRAnchorTracker> tracker;
 
 	ERR_FAIL_COND_V_MSG(!is_spatial_anchor_supported(), tracker, "OpenXR: Spatial entity anchor capability is not supported on this hardware!");
@@ -960,9 +986,14 @@ Ref<OpenXRAnchorTracker> OpenXRSpatialAnchorCapability::create_new_anchor(const 
 	RID sc = p_spatial_context.is_valid() ? p_spatial_context : spatial_context;
 	ERR_FAIL_COND_V(sc.is_null(), tracker);
 
+	void *next = nullptr;
+	if (p_next.is_valid()) {
+		next = p_next->get_header(next);
+	}
+
 	XrSpatialAnchorCreateInfoEXT create_info = {
 		XR_TYPE_SPATIAL_ANCHOR_CREATE_INFO_EXT, // type
-		nullptr, // next
+		next, // next
 		openxr_api->get_play_space(), // baseSpace
 		openxr_api->get_predicted_display_time(), // time
 		pose // pose
@@ -975,12 +1006,14 @@ Ref<OpenXRAnchorTracker> OpenXRSpatialAnchorCapability::create_new_anchor(const 
 	}
 
 	tracker.instantiate();
+	tracker->set_spatial_context(sc);
 	tracker->set_entity(se_extension->add_spatial_entity(sc, entity_id, entity));
 	tracker->set_tracker_desc("Anchor");
 	tracker->set_pose(SNAME("default"), p_transform, Vector3(), Vector3());
+	tracker->add_next(p_next);
 
 	// Remember our tracker.
-	anchors[entity_id] = tracker;
+	anchor_trackers[sc][entity_id] = tracker;
 	xr_server->add_tracker(tracker);
 
 	return tracker;
@@ -1009,8 +1042,11 @@ void OpenXRSpatialAnchorCapability::remove_anchor(Ref<OpenXRAnchorTracker> p_anc
 	ERR_FAIL_COND(entity_id == XR_NULL_ENTITY);
 
 	// Remove it from our entity list.
-	if (anchors.has(entity_id)) {
-		anchors.erase(entity_id);
+	for (KeyValue<RID, HashMap<XrSpatialEntityIdEXT, Ref<OpenXRAnchorTracker>>> &anchors : anchor_trackers) {
+		if (anchors.value.has(entity_id)) {
+			anchors.value.erase(entity_id);
+			break;
+		}
 	}
 
 	// Clear our entity, this will free it as well.
@@ -1136,6 +1172,50 @@ Ref<OpenXRFutureResult> OpenXRSpatialAnchorCapability::unpersist_anchor(Ref<Open
 	Ref<OpenXRFutureResult> future_result = future_api->register_future(future, callable_mp(this, &OpenXRSpatialAnchorCapability::_on_made_anchor_unpersistent).bind(pc, p_anchor_tracker, p_user_callback));
 
 	return future_result;
+}
+
+Ref<OpenXRFutureResult> OpenXRSpatialAnchorCapability::start_entity_discovery(RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_create, Ref<OpenXRStructureBase> p_next_snapshot_query, const Callable &p_user_callback) {
+	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
+	ERR_FAIL_NULL_V(se_extension, nullptr);
+	return se_extension->discover_spatial_entities_with_component_data(p_spatial_context, p_component_data, p_next_snapshot_create, callable_mp(this, &OpenXRSpatialAnchorCapability::_process_discovery_snapshot).bind(p_spatial_context, p_component_data, p_next_snapshot_query, p_user_callback));
+}
+
+void OpenXRSpatialAnchorCapability::do_entity_update(RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_create, Ref<OpenXRStructureBase> p_next_snapshot_query) {
+	if (anchor_trackers.is_empty() || anchor_trackers[p_spatial_context].is_empty()) {
+		return;
+	}
+
+	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
+	ERR_FAIL_NULL(se_extension);
+
+	// The first should be OpenXRSpatialQueryResultData
+	Ref<OpenXRSpatialQueryResultData> query_result_data = p_component_data[0];
+	ERR_FAIL_COND_MSG(query_result_data.is_null(), "OpenXR: The first component must be of type OpenXRSpatialQueryResultData");
+
+	// Skip OpenXRSpatialQueryResultData and copy the other component types
+	LocalVector<XrSpatialComponentTypeEXT> component_types;
+	component_types.resize(p_component_data.size() - 1);
+	XrSpatialComponentTypeEXT *dst = component_types.ptr();
+	for (unsigned int i = 0; i < component_types.size(); ++i) {
+		Ref<OpenXRSpatialComponentData> ele = p_component_data[i + 1];
+		dst[i] = ele->get_component_type();
+	}
+
+	// We want updates for all anchors
+	thread_local LocalVector<RID> entities;
+	HashMap<XrSpatialEntityIdEXT, Ref<OpenXRAnchorTracker>> &anchors = anchor_trackers[p_spatial_context];
+	entities.resize(anchors.size());
+	RID *entity = entities.ptr();
+	for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRAnchorTracker>> &e : anchors) {
+		*entity = e.value->get_entity();
+		entity++;
+	}
+
+	// And we get our update snapshot, this is NOT async!
+	RID snapshot = se_extension->update_spatial_entities(p_spatial_context, entities, component_types, p_next_snapshot_create);
+	if (snapshot.is_valid()) {
+		_process_update_snapshot(snapshot, p_spatial_context, p_component_data, p_next_snapshot_query);
+	}
 }
 
 void OpenXRSpatialAnchorCapability::_on_made_anchor_unpersistent(Ref<OpenXRFutureResult> p_future_result, RID p_persistence_context, Ref<OpenXRAnchorTracker> p_anchor_tracker, const Callable &p_user_callback) {

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.h
@@ -45,8 +45,6 @@ public:
 	virtual bool has_valid_configuration() const override;
 	virtual XrSpatialCapabilityConfigurationBaseHeaderEXT *get_configuration() override;
 
-	Vector<XrSpatialComponentTypeEXT> get_enabled_components() const { return anchor_enabled_components; }
-
 protected:
 	static void _bind_methods();
 
@@ -88,6 +86,7 @@ public:
 
 	void add_persistence_context(RID p_persistence_context);
 	void remove_persistence_context(RID p_persistence_context);
+	Array get_persistence_contexts() const;
 
 protected:
 	static void _bind_methods();
@@ -175,20 +174,28 @@ public:
 
 	// Persistence scopes
 	bool is_persistence_scope_supported(XrSpatialPersistenceScopeEXT p_scope);
+	Ref<OpenXRFutureResult> create_default_persistence_context(const Callable &p_user_callback = Callable());
 	Ref<OpenXRFutureResult> create_persistence_context(XrSpatialPersistenceScopeEXT p_scope, const Callable &p_user_callback = Callable());
 	XrSpatialPersistenceContextEXT get_persistence_context_handle(RID p_persistence_context) const;
 	void free_persistence_context(RID p_persistence_context);
 
-	Ref<OpenXRAnchorTracker> create_new_anchor(const Transform3D &p_transform, RID p_spatial_context = RID());
+	Ref<OpenXRAnchorTracker> create_new_anchor(const Transform3D &p_transform, RID p_spatial_context = RID(), Ref<OpenXRStructureBase> p_next = Ref<OpenXRStructureBase>());
 	void remove_anchor(Ref<OpenXRAnchorTracker> p_anchor_tracker);
 	Ref<OpenXRFutureResult> persist_anchor(Ref<OpenXRAnchorTracker> p_anchor_tracker, RID p_persistence_context = RID(), const Callable &p_user_callback = Callable());
 	Ref<OpenXRFutureResult> unpersist_anchor(Ref<OpenXRAnchorTracker> p_anchor_tracker, RID p_persistence_context = RID(), const Callable &p_user_callback = Callable());
+
+	Ref<OpenXRFutureResult> start_entity_discovery(RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_create = nullptr, Ref<OpenXRStructureBase> p_next_snapshot_query = nullptr, const Callable &p_user_callback = Callable());
+	void do_entity_update(RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_create = nullptr, Ref<OpenXRStructureBase> p_next_snapshot_query = nullptr);
 
 	static String get_spatial_persistence_scope_name(XrSpatialPersistenceScopeEXT p_scope);
 	static String get_spatial_persistence_context_result_name(XrSpatialPersistenceContextResultEXT p_result);
 
 protected:
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	Ref<OpenXRAnchorTracker> _create_new_anchor_compat_118128(const Transform3D &p_transform, RID p_spatial_context);
+#endif
 
 private:
 	static OpenXRSpatialAnchorCapability *singleton;
@@ -206,6 +213,8 @@ private:
 
 	Ref<OpenXRSpatialCapabilityConfigurationAnchor> anchor_configuration;
 	Ref<OpenXRSpatialContextPersistenceConfig> persistence_configuration;
+	TypedArray<OpenXRSpatialComponentData> anchor_discovery_component_data;
+	TypedArray<OpenXRSpatialComponentData> anchor_update_component_data;
 
 	Vector<XrSpatialPersistenceScopeEXT> supported_persistence_scopes;
 	bool _load_supported_persistence_scopes();
@@ -231,16 +240,15 @@ private:
 
 	void _on_spatial_discovery_recommended(RID p_spatial_context);
 
-	Ref<OpenXRFutureResult> _start_entity_discovery();
-	void _process_discovery_snapshot(RID p_snapshot);
-	void _process_update_snapshot(RID p_snapshot);
+	void _process_discovery_snapshot(RID p_snapshot, RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_query, const Callable &p_user_callback);
+	void _process_update_snapshot(RID p_snapshot, RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_query);
 
 	// Entities
 	void _on_made_anchor_persistent(Ref<OpenXRFutureResult> p_future_result, RID p_persistence_context, Ref<OpenXRAnchorTracker> p_anchor_tracker, const Callable &p_callback);
 	void _on_made_anchor_unpersistent(Ref<OpenXRFutureResult> p_future_result, RID p_persistence_context, Ref<OpenXRAnchorTracker> p_anchor_tracker, const Callable &p_callback);
 
-	// Trackers
-	HashMap<XrSpatialEntityIdEXT, Ref<OpenXRAnchorTracker>> anchors;
+	// Trackers; maps each Spatial Context RID to their anchor entities and trackers
+	HashMap<RID, HashMap<XrSpatialEntityIdEXT, Ref<OpenXRAnchorTracker>>> anchor_trackers;
 
 	// OpenXR API call wrappers
 	EXT_PROTO_XRRESULT_FUNC4(xrCreateSpatialAnchorEXT, (XrSpatialContextEXT), spatialContext, (const XrSpatialAnchorCreateInfoEXT *), create_info, (XrSpatialEntityIdEXT *), anchor_entity_id, (XrSpatialEntityEXT *), anchor_entity);

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entities.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entities.cpp
@@ -43,6 +43,7 @@
 
 void OpenXRSpatialCapabilityConfigurationBaseHeader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_valid_configuration"), &OpenXRSpatialCapabilityConfigurationBaseHeader::has_valid_configuration);
+	ClassDB::bind_method(D_METHOD("get_configuration"), &OpenXRSpatialCapabilityConfigurationBaseHeader::_get_configurationgd);
 
 	GDVIRTUAL_BIND(_has_valid_configuration);
 	GDVIRTUAL_BIND(_get_configuration);
@@ -56,6 +57,11 @@ bool OpenXRSpatialCapabilityConfigurationBaseHeader::has_valid_configuration() c
 	}
 
 	return false;
+}
+
+// For exposing this to GDExtension
+uint64_t OpenXRSpatialCapabilityConfigurationBaseHeader::_get_configurationgd() {
+	return (uint64_t)get_configuration();
 }
 
 XrSpatialCapabilityConfigurationBaseHeaderEXT *OpenXRSpatialCapabilityConfigurationBaseHeader::get_configuration() {
@@ -72,6 +78,9 @@ XrSpatialCapabilityConfigurationBaseHeaderEXT *OpenXRSpatialCapabilityConfigurat
 // OpenXRSpatialEntityTracker
 
 void OpenXRSpatialEntityTracker::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_spatial_context", "spatial_context"), &OpenXRSpatialEntityTracker::set_spatial_context);
+	ClassDB::bind_method(D_METHOD("get_spatial_context"), &OpenXRSpatialEntityTracker::get_spatial_context);
+
 	ClassDB::bind_method(D_METHOD("set_entity", "entity"), &OpenXRSpatialEntityTracker::set_entity);
 	ClassDB::bind_method(D_METHOD("get_entity"), &OpenXRSpatialEntityTracker::get_entity);
 
@@ -80,6 +89,11 @@ void OpenXRSpatialEntityTracker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_spatial_tracking_state", "spatial_tracking_state"), &OpenXRSpatialEntityTracker::_set_spatial_tracking_state);
 	ClassDB::bind_method(D_METHOD("get_spatial_tracking_state"), &OpenXRSpatialEntityTracker::_get_spatial_tracking_state);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "spatial_tracking_state"), "set_spatial_tracking_state", "get_spatial_tracking_state");
+
+	ClassDB::bind_method(D_METHOD("get_next"), &OpenXRSpatialEntityTracker::get_next);
+	ClassDB::bind_method(D_METHOD("add_next", "next"), &OpenXRSpatialEntityTracker::add_next);
+	ClassDB::bind_method(D_METHOD("remove_next", "next"), &OpenXRSpatialEntityTracker::remove_next);
+	ADD_SIGNAL(MethodInfo("next_changed"));
 
 	ADD_SIGNAL(MethodInfo("spatial_tracking_state_changed", PropertyInfo(Variant::INT, "spatial_tracking_state")));
 
@@ -100,6 +114,16 @@ OpenXRSpatialEntityTracker::~OpenXRSpatialEntityTracker() {
 			spatial_entity = RID();
 		}
 	}
+}
+
+void OpenXRSpatialEntityTracker::set_spatial_context(const RID &p_spatial_context) {
+	// Trackers shouldn't be switching spatial contexts; always create a new tracker for new contexts
+	ERR_FAIL_COND(spatial_context.is_valid() && spatial_context != p_spatial_context);
+	spatial_context = p_spatial_context;
+}
+
+RID OpenXRSpatialEntityTracker::get_spatial_context() const {
+	return spatial_context;
 }
 
 void OpenXRSpatialEntityTracker::set_entity(const RID &p_entity) {
@@ -154,19 +178,67 @@ OpenXRSpatialEntityTracker::EntityTrackingState OpenXRSpatialEntityTracker::_get
 	return (EntityTrackingState)get_spatial_tracking_state();
 }
 
+void OpenXRSpatialEntityTracker::add_next(Ref<OpenXRStructureBase> p_next) {
+	// Prepend p_next to next
+	if (p_next.is_valid()) {
+		if (next.is_valid()) {
+			p_next->set_next(next);
+		}
+
+		next = p_next;
+		emit_signal(SNAME("next_changed"));
+	}
+}
+
+void OpenXRSpatialEntityTracker::remove_next(Ref<OpenXRStructureBase> p_next) {
+	if (p_next.is_null()) {
+		return;
+	}
+
+	Ref<OpenXRStructureBase> prev;
+	for (Ref<OpenXRStructureBase> n = next; n.is_valid(); n = n->get_next()) {
+		if (n == p_next) {
+			if (prev.is_null()) {
+				next = p_next->get_next();
+			} else {
+				prev->set_next(p_next->get_next());
+			}
+
+			p_next->set_next(nullptr);
+			emit_signal(SNAME("next_changed"));
+			break;
+		}
+
+		prev = n;
+	}
+}
+
+Ref<OpenXRStructureBase> OpenXRSpatialEntityTracker::get_next() const {
+	return next;
+}
+
 ////////////////////////////////////////////////////////////////////////////
 // OpenXRSpatialComponentData
 
 void OpenXRSpatialComponentData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_capacity", "capacity"), &OpenXRSpatialComponentData::set_capacity);
+	ClassDB::bind_method(D_METHOD("get_component_type"), &OpenXRSpatialComponentData::_get_component_typegd);
 
 	GDVIRTUAL_BIND(_set_capacity, "capacity");
 	GDVIRTUAL_BIND(_get_component_type);
 	GDVIRTUAL_BIND(_get_structure_data, "next");
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND_COMPAT(_get_structure_data_bind_compat_118128, "next");
+#endif
 }
 
 void OpenXRSpatialComponentData::set_capacity(uint32_t p_capacity) {
 	GDVIRTUAL_CALL(_set_capacity, p_capacity);
+}
+
+// For exposing this to GDExtension
+int64_t OpenXRSpatialComponentData::_get_component_typegd() const {
+	return (int64_t)get_component_type();
 }
 
 XrSpatialComponentTypeEXT OpenXRSpatialComponentData::get_component_type() const {
@@ -185,6 +257,12 @@ void *OpenXRSpatialComponentData::get_structure_data(void *p_next) {
 	if (GDVIRTUAL_CALL(_get_structure_data, (uint64_t)p_next, pointer)) {
 		return reinterpret_cast<void *>(pointer);
 	}
+
+#ifndef DISABLE_DEPRECATED
+	if (GDVIRTUAL_CALL(_get_structure_data_bind_compat_118128, (uint64_t)p_next, pointer)) {
+		return reinterpret_cast<void *>(pointer);
+	}
+#endif
 
 	return p_next;
 }

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entities.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entities.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "../../openxr_structure.h"
+
 #include "scene/resources/mesh.h"
 #include "servers/xr/xr_positional_tracker.h"
 
@@ -46,6 +48,7 @@ protected:
 
 public:
 	virtual bool has_valid_configuration() const;
+	uint64_t _get_configurationgd();
 	virtual XrSpatialCapabilityConfigurationBaseHeaderEXT *get_configuration();
 
 	GDVIRTUAL0RC(bool, _has_valid_configuration);
@@ -66,18 +69,27 @@ public:
 	OpenXRSpatialEntityTracker();
 	virtual ~OpenXRSpatialEntityTracker();
 
+	void set_spatial_context(const RID &p_spatial_context);
+	RID get_spatial_context() const;
+
 	void set_entity(const RID &p_entity);
 	RID get_entity() const;
 
 	void set_spatial_tracking_state(const XrSpatialEntityTrackingStateEXT p_state);
 	XrSpatialEntityTrackingStateEXT get_spatial_tracking_state() const;
 
+	void add_next(Ref<OpenXRStructureBase> p_next);
+	void remove_next(Ref<OpenXRStructureBase> p_next);
+	Ref<OpenXRStructureBase> get_next() const;
+
 protected:
 	static void _bind_methods();
 
 private:
+	RID spatial_context;
 	RID spatial_entity;
 	XrSpatialEntityTrackingStateEXT spatial_tracking_state = XR_SPATIAL_ENTITY_TRACKING_STATE_PAUSED_EXT;
+	Ref<OpenXRStructureBase> next;
 
 	void _set_spatial_tracking_state(const EntityTrackingState p_state);
 	EntityTrackingState _get_spatial_tracking_state() const;
@@ -94,12 +106,16 @@ protected:
 
 public:
 	virtual void set_capacity(uint32_t p_capacity);
+	int64_t _get_component_typegd() const;
 	virtual XrSpatialComponentTypeEXT get_component_type() const;
 	virtual void *get_structure_data(void *p_next);
 
 	GDVIRTUAL1(_set_capacity, uint32_t);
 	GDVIRTUAL0RC(uint64_t, _get_component_type);
-	GDVIRTUAL1RC(uint64_t, _get_structure_data, uint64_t);
+	GDVIRTUAL1R(uint64_t, _get_structure_data, uint64_t);
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL1RC_COMPAT(_get_structure_data_bind_compat_118128, uint64_t, _get_structure_data, uint64_t);
+#endif
 };
 
 class OpenXRSpatialComponentBounded2DList : public OpenXRSpatialComponentData {

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.cpp
@@ -58,6 +58,7 @@ void OpenXRSpatialEntityExtension::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("spatial_discovery_recommended", PropertyInfo(Variant::RID, "spatial_context")));
 
 	// Component_types should be an int array typed to ComponentType(XrSpatialComponentTypeEXT), but we currently don't support that.
+	ClassDB::bind_method(D_METHOD("discover_spatial_entities_with_component_data", "spatial_context", "component_data", "next", "user_callback"), &OpenXRSpatialEntityExtension::discover_spatial_entities_with_component_data, DEFVAL(Variant()), DEFVAL(Callable()));
 	ClassDB::bind_method(D_METHOD("discover_spatial_entities", "spatial_context", "component_types", "next", "user_callback"), &OpenXRSpatialEntityExtension::_discover_spatial_entities, DEFVAL(Variant()), DEFVAL(Callable()));
 	ClassDB::bind_method(D_METHOD("update_spatial_entities", "spatial_context", "entities", "component_types", "next"), &OpenXRSpatialEntityExtension::_update_spatial_entities, DEFVAL(Variant()));
 
@@ -493,6 +494,27 @@ uint64_t OpenXRSpatialEntityExtension::_get_spatial_context_handle(RID p_spatial
 ////////////////////////////////////////////////////////////////////////////
 // Discovery queries
 
+Ref<OpenXRFutureResult> OpenXRSpatialEntityExtension::discover_spatial_entities_with_component_data(RID p_spatial_context, const TypedArray<OpenXRSpatialComponentData> &p_component_data, Ref<OpenXRStructureBase> p_next, const Callable &p_user_callback) {
+	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
+	ERR_FAIL_NULL_V(se_extension, nullptr);
+	ERR_FAIL_COND_V(p_component_data.is_empty(), nullptr);
+
+	// The first should be OpenXRSpatialQueryResultData
+	Ref<OpenXRSpatialQueryResultData> query_result_data = p_component_data[0];
+	ERR_FAIL_COND_V_MSG(query_result_data.is_null(), nullptr, "OpenXR: The first component must be of type OpenXRSpatialQueryResultData");
+
+	// Skip OpenXRSpatialQueryResultData and copy the other component types
+	Vector<XrSpatialComponentTypeEXT> component_types;
+	component_types.resize(p_component_data.size() - 1);
+	XrSpatialComponentTypeEXT *dst = component_types.ptrw();
+	for (int i = 0; i < component_types.size(); ++i) {
+		Ref<OpenXRSpatialComponentData> ele = p_component_data[i + 1];
+		dst[i] = ele->get_component_type();
+	}
+
+	return discover_spatial_entities(p_spatial_context, component_types, p_next, p_user_callback);
+}
+
 Ref<OpenXRFutureResult> OpenXRSpatialEntityExtension::discover_spatial_entities(RID p_spatial_context, const Vector<XrSpatialComponentTypeEXT> &p_component_types, Ref<OpenXRStructureBase> p_next, const Callable &p_user_callback) {
 	if (!get_active()) {
 		return nullptr;
@@ -749,6 +771,8 @@ bool OpenXRSpatialEntityExtension::query_snapshot(RID p_spatial_snapshot, const 
 	query_condition.componentTypes = component_types.ptr();
 
 	XrSpatialComponentDataQueryResultEXT *query_result = (XrSpatialComponentDataQueryResultEXT *)query_result_data->get_structure_data(nullptr);
+	query_result->entityIdCapacityInput = 0;
+	query_result->entityStateCapacityInput = 0;
 	XrResult result = xrQuerySpatialComponentDataEXT(snapshot_data->spatial_snapshot, &query_condition, query_result);
 	if (XR_FAILED(result)) {
 		ERR_FAIL_V_MSG(false, "OpenXR: Failed to query snapshot count [" + openxr_api->get_error_string(result) + "]");
@@ -756,6 +780,13 @@ bool OpenXRSpatialEntityExtension::query_snapshot(RID p_spatial_snapshot, const 
 
 	// Nothing to do?
 	if (query_result->entityIdCountOutput == 0) {
+		// Ensure the component data reflects this result.
+		for (Ref<OpenXRSpatialComponentData> component_data : p_component_data) {
+			if (component_data.is_valid()) {
+				component_data->set_capacity(0);
+			}
+		}
+
 		return true;
 	}
 

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.h
@@ -90,6 +90,7 @@ public:
 	XrSpatialContextEXT get_spatial_context_handle(RID p_spatial_context) const;
 
 	// Discovery query
+	Ref<OpenXRFutureResult> discover_spatial_entities_with_component_data(RID p_spatial_context, const TypedArray<OpenXRSpatialComponentData> &p_component_data, Ref<OpenXRStructureBase> p_next, const Callable &p_user_callback);
 	Ref<OpenXRFutureResult> discover_spatial_entities(RID p_spatial_context, const Vector<XrSpatialComponentTypeEXT> &p_component_types, Ref<OpenXRStructureBase> p_next, const Callable &p_user_callback);
 
 	// Update query

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
@@ -135,6 +135,14 @@ PackedInt64Array OpenXRSpatialCapabilityConfigurationMicroQrCode::_get_enabled_c
 ////////////////////////////////////////////////////////////////////////////
 // OpenXRSpatialCapabilityConfigurationAruco
 
+OpenXRSpatialCapabilityConfigurationAruco::OpenXRSpatialCapabilityConfigurationAruco() {
+	int aruco_dict = GLOBAL_GET_CACHED(int, "xr/openxr/extensions/spatial_entity/aruco_dict");
+	set_aruco_dict((XrSpatialMarkerArucoDictEXT)(XR_SPATIAL_MARKER_ARUCO_DICT_4X4_50_EXT + aruco_dict));
+}
+
+OpenXRSpatialCapabilityConfigurationAruco::~OpenXRSpatialCapabilityConfigurationAruco() {
+}
+
 void OpenXRSpatialCapabilityConfigurationAruco::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_enabled_components"), &OpenXRSpatialCapabilityConfigurationAruco::_get_enabled_components);
 
@@ -218,6 +226,14 @@ PackedInt64Array OpenXRSpatialCapabilityConfigurationAruco::_get_enabled_compone
 
 ////////////////////////////////////////////////////////////////////////////
 // OpenXRSpatialCapabilityConfigurationAprilTag
+
+OpenXRSpatialCapabilityConfigurationAprilTag::OpenXRSpatialCapabilityConfigurationAprilTag() {
+	int april_tag_dict = GLOBAL_GET_CACHED(int, "xr/openxr/extensions/spatial_entity/april_tag_dict");
+	set_april_dict((XrSpatialMarkerAprilTagDictEXT)(XR_SPATIAL_MARKER_APRIL_TAG_DICT_16H5_EXT + april_tag_dict));
+}
+
+OpenXRSpatialCapabilityConfigurationAprilTag::~OpenXRSpatialCapabilityConfigurationAprilTag() {
+}
 
 void OpenXRSpatialCapabilityConfigurationAprilTag::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_enabled_components"), &OpenXRSpatialCapabilityConfigurationAprilTag::_get_enabled_components);
@@ -445,6 +461,9 @@ void OpenXRSpatialMarkerTrackingCapability::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_micro_qrcode_supported"), &OpenXRSpatialMarkerTrackingCapability::is_micro_qrcode_supported);
 	ClassDB::bind_method(D_METHOD("is_aruco_supported"), &OpenXRSpatialMarkerTrackingCapability::is_aruco_supported);
 	ClassDB::bind_method(D_METHOD("is_april_tag_supported"), &OpenXRSpatialMarkerTrackingCapability::is_april_tag_supported);
+
+	ClassDB::bind_method(D_METHOD("start_entity_discovery", "spatial_context", "component_data", "next_snapshot_create", "next_snapshot_query", "user_callback"), &OpenXRSpatialMarkerTrackingCapability::start_entity_discovery, DEFVAL(Variant()), DEFVAL(Variant()), DEFVAL(Callable()));
+	ClassDB::bind_method(D_METHOD("do_entity_update", "spatial_context", "component_data", "next_snapshot_create", "next_snapshot_query"), &OpenXRSpatialMarkerTrackingCapability::do_entity_update, DEFVAL(Variant()), DEFVAL(Variant()));
 }
 
 HashMap<String, bool *> OpenXRSpatialMarkerTrackingCapability::get_requested_extensions(XrVersion p_version) {
@@ -480,8 +499,10 @@ void OpenXRSpatialMarkerTrackingCapability::on_session_destroyed() {
 	ERR_FAIL_NULL(xr_server);
 
 	// Free and unregister our anchors
-	for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>> &marker_tracker : marker_trackers) {
-		xr_server->remove_tracker(marker_tracker.value);
+	for (const KeyValue<RID, HashMap<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>>> &markers : marker_trackers) {
+		for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>> &marker_tracker : markers.value) {
+			xr_server->remove_tracker(marker_tracker.value);
+		}
 	}
 	marker_trackers.clear();
 
@@ -509,32 +530,84 @@ void OpenXRSpatialMarkerTrackingCapability::on_process() {
 		need_discovery = false;
 		discovery_cooldown = 60; // Set our cooldown to 60 frames, it doesn't need to be an exact science.
 
-		_start_entity_discovery();
+		if (marker_discovery_component_data.is_empty()) {
+			// We always need a query result data object, and it must be first
+			Ref<OpenXRSpatialQueryResultData> query_result_data;
+			query_result_data.instantiate();
+			marker_discovery_component_data.push_back(query_result_data);
+
+			// Add bounded2D.
+			Ref<OpenXRSpatialComponentBounded2DList> bounded2d_list;
+			bounded2d_list.instantiate();
+			marker_discovery_component_data.push_back(bounded2d_list);
+
+			// Marker data list.
+			Ref<OpenXRSpatialComponentMarkerList> marker_list;
+			marker_list.instantiate();
+			marker_discovery_component_data.push_back(marker_list);
+		}
+
+		discovery_query_result = start_entity_discovery(spatial_context, marker_discovery_component_data);
 	}
 
-	// If we have markers, we do an update query to check for changed positions.
-	if (!marker_trackers.is_empty()) {
-		OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
-		ERR_FAIL_NULL(se_extension);
+	if (marker_update_component_data.is_empty()) {
+		// We always need a query result data object, and it must be first
+		Ref<OpenXRSpatialQueryResultData> query_result_data;
+		query_result_data.instantiate();
+		marker_update_component_data.push_back(query_result_data);
 
-		// We want updates for all anchors
-		thread_local LocalVector<RID> entities;
-		entities.resize(marker_trackers.size());
-		RID *entity = entities.ptr();
-		for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>> &e : marker_trackers) {
-			*entity = e.value->get_entity();
-			entity++;
-		}
+		// Add bounded2D.
+		Ref<OpenXRSpatialComponentBounded2DList> bounded2d_list;
+		bounded2d_list.instantiate();
+		marker_update_component_data.push_back(bounded2d_list);
+	}
 
-		// We just want our anchor component
-		thread_local LocalVector<XrSpatialComponentTypeEXT> component_types;
-		component_types.push_back(XR_SPATIAL_COMPONENT_TYPE_BOUNDED_2D_EXT);
+	do_entity_update(spatial_context, marker_update_component_data);
+}
 
-		// And we get our update snapshot, this is NOT async!
-		RID snapshot = se_extension->update_spatial_entities(spatial_context, entities, component_types, nullptr);
-		if (snapshot.is_valid()) {
-			_process_snapshot(snapshot, false);
-		}
+Ref<OpenXRFutureResult> OpenXRSpatialMarkerTrackingCapability::start_entity_discovery(RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_create, Ref<OpenXRStructureBase> p_next_snapshot_query, const Callable &p_user_callback) {
+	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
+	ERR_FAIL_NULL_V(se_extension, nullptr);
+	return se_extension->discover_spatial_entities_with_component_data(p_spatial_context, p_component_data, p_next_snapshot_create, callable_mp(this, &OpenXRSpatialMarkerTrackingCapability::_process_snapshot).bind(p_spatial_context, true, p_component_data, p_next_snapshot_query, p_user_callback));
+}
+
+void OpenXRSpatialMarkerTrackingCapability::do_entity_update(RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_create, Ref<OpenXRStructureBase> p_next_snapshot_query) {
+	if (marker_trackers.is_empty() || marker_trackers[p_spatial_context].is_empty()) {
+		return;
+	}
+
+	// We have markers, do an update query to check for changed positions.
+
+	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
+	ERR_FAIL_NULL(se_extension);
+
+	// The first should be OpenXRSpatialQueryResultData
+	Ref<OpenXRSpatialQueryResultData> query_result_data = p_component_data[0];
+	ERR_FAIL_COND_MSG(query_result_data.is_null(), "OpenXR: The first component must be of type OpenXRSpatialQueryResultData");
+
+	// Skip OpenXRSpatialQueryResultData and copy the other component types
+	LocalVector<XrSpatialComponentTypeEXT> component_types;
+	component_types.resize(p_component_data.size() - 1);
+	XrSpatialComponentTypeEXT *dst = component_types.ptr();
+	for (unsigned int i = 0; i < component_types.size(); ++i) {
+		Ref<OpenXRSpatialComponentData> ele = p_component_data[i + 1];
+		dst[i] = ele->get_component_type();
+	}
+
+	// We want updates for all anchors
+	thread_local LocalVector<RID> entities;
+	HashMap<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>> &markers = marker_trackers[p_spatial_context];
+	entities.resize(markers.size());
+	RID *entity = entities.ptr();
+	for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>> &e : markers) {
+		*entity = e.value->get_entity();
+		entity++;
+	}
+
+	// And we get our update snapshot, this is NOT async!
+	RID snapshot = se_extension->update_spatial_entities(p_spatial_context, entities, component_types, p_next_snapshot_create);
+	if (snapshot.is_valid()) {
+		_process_snapshot(snapshot, p_spatial_context, false, p_component_data, p_next_snapshot_query, nullptr);
 	}
 }
 
@@ -593,17 +666,11 @@ Ref<OpenXRFutureResult> OpenXRSpatialMarkerTrackingCapability::_create_spatial_c
 
 	if (is_aruco_supported()) {
 		aruco_configuration.instantiate();
-
-		int aruco_dict = GLOBAL_GET_CACHED(int, "xr/openxr/extensions/spatial_entity/aruco_dict");
-		aruco_configuration->set_aruco_dict((XrSpatialMarkerArucoDictEXT)(XR_SPATIAL_MARKER_ARUCO_DICT_4X4_50_EXT + aruco_dict));
 		capability_configurations.push_back(aruco_configuration);
 	}
 
 	if (is_april_tag_supported()) {
 		april_tag_configuration.instantiate();
-
-		int april_tag_dict = GLOBAL_GET_CACHED(int, "xr/openxr/extensions/spatial_entity/april_tag_dict");
-		april_tag_configuration->set_april_dict((XrSpatialMarkerAprilTagDictEXT)(XR_SPATIAL_MARKER_APRIL_TAG_DICT_16H5_EXT + april_tag_dict));
 		capability_configurations.push_back(april_tag_configuration);
 	}
 
@@ -627,28 +694,11 @@ void OpenXRSpatialMarkerTrackingCapability::_on_spatial_discovery_recommended(RI
 	}
 }
 
-Ref<OpenXRFutureResult> OpenXRSpatialMarkerTrackingCapability::_start_entity_discovery() {
-	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
-	ERR_FAIL_NULL_V(se_extension, nullptr);
-
-	// Already running or ran discovery, cancel/clean up.
-	if (discovery_query_result.is_valid()) {
-		discovery_query_result->cancel_future();
-		discovery_query_result.unref();
+void OpenXRSpatialMarkerTrackingCapability::_process_snapshot(RID p_snapshot, RID p_spatial_context, bool p_is_discovery, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_query, const Callable &p_user_callback) {
+	if (p_user_callback.is_valid()) {
+		p_user_callback.call(p_snapshot, false);
 	}
 
-	// We want both our anchor and persistence component.
-	Vector<XrSpatialComponentTypeEXT> component_types;
-	component_types.push_back(XR_SPATIAL_COMPONENT_TYPE_MARKER_EXT);
-	component_types.push_back(XR_SPATIAL_COMPONENT_TYPE_BOUNDED_2D_EXT);
-
-	// Start our new snapshot.
-	discovery_query_result = se_extension->discover_spatial_entities(spatial_context, component_types, nullptr, callable_mp(this, &OpenXRSpatialMarkerTrackingCapability::_process_snapshot).bind(true));
-
-	return discovery_query_result;
-}
-
-void OpenXRSpatialMarkerTrackingCapability::_process_snapshot(RID p_snapshot, bool p_is_discovery) {
 	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
 	ERR_FAIL_NULL(se_extension);
 	XRServer *xr_server = XRServer::get_singleton();
@@ -657,36 +707,40 @@ void OpenXRSpatialMarkerTrackingCapability::_process_snapshot(RID p_snapshot, bo
 	ERR_FAIL_NULL(openxr_api);
 
 	// Make a copy of the markers we have right now, so we know which ones to clean up.
+	HashMap<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>> &markers = marker_trackers[p_spatial_context];
 	LocalVector<XrSpatialEntityIdEXT> current_markers;
 	if (p_is_discovery) {
-		current_markers.resize(marker_trackers.size());
+		current_markers.resize(markers.size());
 		int m = 0;
-		for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>> &marker : marker_trackers) {
+		for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>> &marker : markers) {
 			current_markers[m++] = marker.key;
 		}
 	}
 
-	// Build our component data.
-	TypedArray<OpenXRSpatialComponentData> component_data;
+	// The first must be OpenXRSpatialQueryResultData
+	Ref<OpenXRSpatialQueryResultData> query_result_data = p_component_data.is_empty() ? Variant() : p_component_data[0];
+	ERR_FAIL_COND(query_result_data.is_null());
 
-	// We always need a query result data object.
-	Ref<OpenXRSpatialQueryResultData> query_result_data;
-	query_result_data.instantiate();
-	component_data.push_back(query_result_data);
-
-	// Add bounded2D.
 	Ref<OpenXRSpatialComponentBounded2DList> bounded2d_list;
-	bounded2d_list.instantiate();
-	component_data.push_back(bounded2d_list);
-
-	// Marker data list.
 	Ref<OpenXRSpatialComponentMarkerList> marker_list;
-	if (p_is_discovery) {
-		marker_list.instantiate();
-		component_data.push_back(marker_list);
+	for (Ref<OpenXRSpatialComponentData> data : p_component_data) {
+		switch (data->get_component_type()) {
+			case XR_SPATIAL_COMPONENT_TYPE_BOUNDED_2D_EXT:
+				bounded2d_list = data;
+				break;
+			case XR_SPATIAL_COMPONENT_TYPE_MARKER_EXT:
+				marker_list = data;
+				break;
+			default:
+				// Okay, maybe other data types are being queried that we don't know about
+				break;
+		}
 	}
 
-	if (se_extension->query_snapshot(p_snapshot, component_data, nullptr)) {
+	// If discovering, we must be at least discovering markers, otherwise why are we here?
+	ERR_FAIL_COND(p_is_discovery && marker_list.is_null());
+
+	if (se_extension->query_snapshot(p_snapshot, p_component_data, p_next_snapshot_query)) {
 		// Now loop through our data and update our markers.
 		int64_t size = query_result_data->get_capacity();
 
@@ -700,8 +754,8 @@ void OpenXRSpatialMarkerTrackingCapability::_process_snapshot(RID p_snapshot, bo
 			if (entity_state == XR_SPATIAL_ENTITY_TRACKING_STATE_STOPPED_EXT) {
 				// We should only get this status on update queries.
 				// We'll remove the marker.
-				if (marker_trackers.has(entity_id)) {
-					Ref<OpenXRMarkerTracker> marker_tracker = marker_trackers[entity_id];
+				if (markers.has(entity_id)) {
+					Ref<OpenXRMarkerTracker> marker_tracker = markers[entity_id];
 
 					marker_tracker->invalidate_pose(SNAME("default"));
 					marker_tracker->set_spatial_tracking_state(XR_SPATIAL_ENTITY_TRACKING_STATE_STOPPED_EXT);
@@ -710,21 +764,22 @@ void OpenXRSpatialMarkerTrackingCapability::_process_snapshot(RID p_snapshot, bo
 					xr_server->remove_tracker(marker_tracker);
 
 					// Remove it from our trackers.
-					marker_trackers.erase(entity_id);
+					markers.erase(entity_id);
 				}
 			} else {
 				// Process our entity.
 				bool add_to_xr_server = false;
 				Ref<OpenXRMarkerTracker> marker_tracker;
 
-				if (marker_trackers.has(entity_id)) {
+				if (markers.has(entity_id)) {
 					// We know about this one already.
-					marker_tracker = marker_trackers[entity_id];
+					marker_tracker = markers[entity_id];
 				} else {
 					// Create a new anchor.
 					marker_tracker.instantiate();
+					marker_tracker->set_spatial_context(p_spatial_context);
 					marker_tracker->set_entity(se_extension->make_spatial_entity(se_extension->get_spatial_snapshot_context(p_snapshot), entity_id));
-					marker_trackers[entity_id] = marker_tracker;
+					markers[entity_id] = marker_tracker;
 
 					add_to_xr_server = true;
 				}
@@ -736,17 +791,18 @@ void OpenXRSpatialMarkerTrackingCapability::_process_snapshot(RID p_snapshot, bo
 
 					// No further component data will be valid in this state, we need to ignore it!
 				} else if (entity_state == XR_SPATIAL_ENTITY_TRACKING_STATE_TRACKING_EXT) {
-					Transform3D transform = bounded2d_list->get_center_pose(i);
-					marker_tracker->set_pose(SNAME("default"), transform, Vector3(), Vector3());
 					marker_tracker->set_spatial_tracking_state(XR_SPATIAL_ENTITY_TRACKING_STATE_TRACKING_EXT);
 
-					// Process our component data.
+					if (bounded2d_list.is_valid()) {
+						Transform3D transform = bounded2d_list->get_center_pose(i);
+						marker_tracker->set_pose(SNAME("default"), transform, Vector3(), Vector3());
 
-					// Set bounds size.
-					marker_tracker->set_bounds_size(bounded2d_list->get_size(i));
+						// Set bounds size.
+						marker_tracker->set_bounds_size(bounded2d_list->get_size(i));
+					}
 
 					// Set marker data.
-					if (p_is_discovery) {
+					if (marker_list.is_valid()) {
 						marker_tracker->set_marker_type(marker_list->get_marker_type(i));
 						marker_tracker->set_marker_id(marker_list->get_marker_id(i));
 						marker_tracker->set_marker_data(marker_list->get_marker_data(p_snapshot, i));
@@ -763,8 +819,8 @@ void OpenXRSpatialMarkerTrackingCapability::_process_snapshot(RID p_snapshot, bo
 		if (p_is_discovery) {
 			// Remove any markers that are no longer there...
 			for (const XrSpatialEntityIdEXT &entity_id : current_markers) {
-				if (marker_trackers.has(entity_id)) {
-					Ref<OpenXRMarkerTracker> marker_tracker = marker_trackers[entity_id];
+				if (markers.has(entity_id)) {
+					Ref<OpenXRMarkerTracker> marker_tracker = markers[entity_id];
 
 					// Just in case there are still references out there to this marker,
 					// reset some stuff.
@@ -775,10 +831,14 @@ void OpenXRSpatialMarkerTrackingCapability::_process_snapshot(RID p_snapshot, bo
 					xr_server->remove_tracker(marker_tracker);
 
 					// Remove it from our trackers.
-					marker_trackers.erase(entity_id);
+					markers.erase(entity_id);
 				}
 			}
 		}
+	}
+
+	if (p_user_callback.is_valid()) {
+		p_user_callback.call(p_snapshot, true);
 	}
 
 	// Now that we're done, clean up our snapshot!

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.h
@@ -98,6 +98,9 @@ public:
 		ARUCO_DICT_7X7_1000 = XR_SPATIAL_MARKER_ARUCO_DICT_7X7_1000_EXT,
 	};
 
+	OpenXRSpatialCapabilityConfigurationAruco();
+	virtual ~OpenXRSpatialCapabilityConfigurationAruco() override;
+
 	virtual bool has_valid_configuration() const override;
 	virtual XrSpatialCapabilityConfigurationBaseHeaderEXT *get_configuration() override;
 
@@ -132,6 +135,9 @@ public:
 		APRIL_TAG_DICT_36H10 = XR_SPATIAL_MARKER_APRIL_TAG_DICT_36H10_EXT,
 		APRIL_TAG_DICT_36H11 = XR_SPATIAL_MARKER_APRIL_TAG_DICT_36H11_EXT,
 	};
+
+	OpenXRSpatialCapabilityConfigurationAprilTag();
+	virtual ~OpenXRSpatialCapabilityConfigurationAprilTag() override;
 
 	virtual bool has_valid_configuration() const override;
 	virtual XrSpatialCapabilityConfigurationBaseHeaderEXT *get_configuration() override;
@@ -237,6 +243,9 @@ public:
 
 	virtual void on_process() override;
 
+	Ref<OpenXRFutureResult> start_entity_discovery(RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_create = nullptr, Ref<OpenXRStructureBase> p_next_snapshot_query = nullptr, const Callable &p_user_callback = Callable());
+	void do_entity_update(RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_create = nullptr, Ref<OpenXRStructureBase> p_next_snapshot_query = nullptr);
+
 	bool is_qrcode_supported();
 	bool is_micro_qrcode_supported();
 	bool is_aruco_supported();
@@ -250,6 +259,8 @@ private:
 	bool need_discovery = false;
 	int discovery_cooldown = 0;
 	Ref<OpenXRFutureResult> discovery_query_result;
+	TypedArray<OpenXRSpatialComponentData> marker_discovery_component_data;
+	TypedArray<OpenXRSpatialComponentData> marker_update_component_data;
 
 	Ref<OpenXRSpatialCapabilityConfigurationQrCode> qrcode_configuration;
 	Ref<OpenXRSpatialCapabilityConfigurationMicroQrCode> micro_qrcode_configuration;
@@ -262,9 +273,8 @@ private:
 
 	void _on_spatial_discovery_recommended(RID p_spatial_context);
 
-	Ref<OpenXRFutureResult> _start_entity_discovery();
-	void _process_snapshot(RID p_snapshot, bool p_is_discovery);
+	void _process_snapshot(RID p_snapshot, RID p_spatial_context, bool p_is_discovery, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_query, const Callable &p_user_callback);
 
-	// Trackers
-	HashMap<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>> marker_trackers;
+	// Trackers; maps each Spatial Context RID to their marker entities and trackers
+	HashMap<RID, HashMap<XrSpatialEntityIdEXT, Ref<OpenXRMarkerTracker>>> marker_trackers;
 };

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
@@ -67,6 +67,8 @@ XrSpatialCapabilityConfigurationBaseHeaderEXT *OpenXRSpatialCapabilityConfigurat
 		OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
 		ERR_FAIL_NULL_V(se_extension, nullptr);
 
+		plane_enabled_components.clear();
+
 		// Guaranteed components:
 		plane_enabled_components.push_back(XR_SPATIAL_COMPONENT_TYPE_BOUNDED_2D_EXT);
 		plane_enabled_components.push_back(XR_SPATIAL_COMPONENT_TYPE_PLANE_ALIGNMENT_EXT);
@@ -585,6 +587,7 @@ OpenXRSpatialPlaneTrackingCapability::~OpenXRSpatialPlaneTrackingCapability() {
 
 void OpenXRSpatialPlaneTrackingCapability::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_supported"), &OpenXRSpatialPlaneTrackingCapability::is_supported);
+	ClassDB::bind_method(D_METHOD("start_entity_discovery", "spatial_context", "component_data", "next_snapshot_create", "next_snapshot_query", "user_callback"), &OpenXRSpatialPlaneTrackingCapability::start_entity_discovery, DEFVAL(Variant()), DEFVAL(Variant()), DEFVAL(Callable()));
 }
 
 HashMap<String, bool *> OpenXRSpatialPlaneTrackingCapability::get_requested_extensions(XrVersion p_version) {
@@ -631,8 +634,10 @@ void OpenXRSpatialPlaneTrackingCapability::on_session_destroyed() {
 	ERR_FAIL_NULL(xr_server);
 
 	// Free and unregister our anchors
-	for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRPlaneTracker>> &plane_tracker : plane_trackers) {
-		xr_server->remove_tracker(plane_tracker.value);
+	for (const KeyValue<RID, HashMap<XrSpatialEntityIdEXT, Ref<OpenXRPlaneTracker>>> &planes : plane_trackers) {
+		for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRPlaneTracker>> &plane_tracker : planes.value) {
+			xr_server->remove_tracker(plane_tracker.value);
+		}
 	}
 	plane_trackers.clear();
 
@@ -660,8 +665,65 @@ void OpenXRSpatialPlaneTrackingCapability::on_process() {
 		need_discovery = false;
 		discovery_cooldown = 60; // Set our cooldown to 60 frames, it doesn't need to be an exact science.
 
-		_start_entity_discovery();
+		if (plane_component_data.is_empty()) {
+			if (plane_configuration.is_null()) {
+				plane_configuration.instantiate();
+			}
+
+			// We always need a query result data object, and it must be first
+			Ref<OpenXRSpatialQueryResultData> query_result_data;
+			query_result_data.instantiate();
+			plane_component_data.push_back(query_result_data);
+
+			// Base our plane_component_data on the component types used in plane_configuration
+			XrSpatialCapabilityConfigurationBaseHeaderEXT *config = plane_configuration->get_configuration();
+			for (uint32_t i = 0; i < config->enabledComponentCount; ++i) {
+				switch (config->enabledComponents[i]) {
+					case XR_SPATIAL_COMPONENT_TYPE_BOUNDED_2D_EXT: {
+						Ref<OpenXRSpatialComponentBounded2DList> bounded2d_list;
+						bounded2d_list.instantiate();
+						plane_component_data.push_back(bounded2d_list);
+						break;
+					}
+					case XR_SPATIAL_COMPONENT_TYPE_PLANE_ALIGNMENT_EXT: {
+						Ref<OpenXRSpatialComponentPlaneAlignmentList> alignment_list;
+						alignment_list.instantiate();
+						plane_component_data.push_back(alignment_list);
+						break;
+					}
+					case XR_SPATIAL_COMPONENT_TYPE_MESH_2D_EXT: {
+						Ref<OpenXRSpatialComponentMesh2DList> mesh2d_list;
+						mesh2d_list.instantiate();
+						plane_component_data.push_back(mesh2d_list);
+						break;
+					}
+					case XR_SPATIAL_COMPONENT_TYPE_POLYGON_2D_EXT: {
+						Ref<OpenXRSpatialComponentPolygon2DList> poly2d_list;
+						poly2d_list.instantiate();
+						plane_component_data.push_back(poly2d_list);
+						break;
+					}
+					case XR_SPATIAL_COMPONENT_TYPE_PLANE_SEMANTIC_LABEL_EXT: {
+						Ref<OpenXRSpatialComponentPlaneSemanticLabelList> label_list;
+						label_list.instantiate();
+						plane_component_data.push_back(label_list);
+						break;
+					}
+					default:
+						WARN_PRINT("Unexpected plane component; ignoring");
+						break;
+				}
+			}
+		}
+
+		discovery_query_result = start_entity_discovery(spatial_context, plane_component_data);
 	}
+}
+
+Ref<OpenXRFutureResult> OpenXRSpatialPlaneTrackingCapability::start_entity_discovery(RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_create, Ref<OpenXRStructureBase> p_next_snapshot_query, const Callable &p_user_callback) {
+	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
+	ERR_FAIL_NULL_V(se_extension, nullptr);
+	return se_extension->discover_spatial_entities_with_component_data(p_spatial_context, p_component_data, p_next_snapshot_create, callable_mp(this, &OpenXRSpatialPlaneTrackingCapability::_process_snapshot).bind(p_spatial_context, p_component_data, p_next_snapshot_query, p_user_callback));
 }
 
 bool OpenXRSpatialPlaneTrackingCapability::is_supported() {
@@ -695,24 +757,11 @@ void OpenXRSpatialPlaneTrackingCapability::_on_spatial_discovery_recommended(RID
 	}
 }
 
-Ref<OpenXRFutureResult> OpenXRSpatialPlaneTrackingCapability::_start_entity_discovery() {
-	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
-	ERR_FAIL_NULL_V(se_extension, nullptr);
-
-	// Already running or ran discovery, cancel/clean up.
-	if (discovery_query_result.is_valid()) {
-		WARN_PRINT("OpenXR: Starting new discovery before previous discovery has been processed!");
-		discovery_query_result->cancel_future();
-		discovery_query_result.unref();
+void OpenXRSpatialPlaneTrackingCapability::_process_snapshot(RID p_snapshot, RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_query, const Callable &p_user_callback) {
+	if (p_user_callback.is_valid()) {
+		p_user_callback.call(p_snapshot, false);
 	}
 
-	// Start our new snapshot.
-	discovery_query_result = se_extension->discover_spatial_entities(spatial_context, plane_configuration->get_enabled_components(), nullptr, callable_mp(this, &OpenXRSpatialPlaneTrackingCapability::_process_snapshot));
-
-	return discovery_query_result;
-}
-
-void OpenXRSpatialPlaneTrackingCapability::_process_snapshot(RID p_snapshot) {
 	OpenXRSpatialEntityExtension *se_extension = OpenXRSpatialEntityExtension::get_singleton();
 	ERR_FAIL_NULL(se_extension);
 	XRServer *xr_server = XRServer::get_singleton();
@@ -722,49 +771,47 @@ void OpenXRSpatialPlaneTrackingCapability::_process_snapshot(RID p_snapshot) {
 
 	// Make a copy of the planes we have right now, so we know which ones to clean up.
 	LocalVector<XrSpatialEntityIdEXT> current_planes;
-	current_planes.resize(plane_trackers.size());
+	HashMap<XrSpatialEntityIdEXT, Ref<OpenXRPlaneTracker>> &planes = plane_trackers[p_spatial_context];
+	current_planes.resize(planes.size());
 	int p = 0;
-	for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRPlaneTracker>> &plane : plane_trackers) {
+	for (const KeyValue<XrSpatialEntityIdEXT, Ref<OpenXRPlaneTracker>> &plane : planes) {
 		current_planes[p++] = plane.key;
 	}
 
-	// Build our component data
-	TypedArray<OpenXRSpatialComponentData> component_data;
+	// The first must be OpenXRSpatialQueryResultData
+	Ref<OpenXRSpatialQueryResultData> query_result_data = p_component_data.is_empty() ? Variant() : p_component_data[0];
+	ERR_FAIL_COND(query_result_data.is_null());
 
-	// We always need a query result data object
-	Ref<OpenXRSpatialQueryResultData> query_result_data;
-	query_result_data.instantiate();
-	component_data.push_back(query_result_data);
-
-	// Add bounded2D
 	Ref<OpenXRSpatialComponentBounded2DList> bounded2d_list;
-	bounded2d_list.instantiate();
-	component_data.push_back(bounded2d_list);
-
-	// Plane alignment list
 	Ref<OpenXRSpatialComponentPlaneAlignmentList> alignment_list;
-	alignment_list.instantiate();
-	component_data.push_back(alignment_list);
-
 	Ref<OpenXRSpatialComponentMesh2DList> mesh2d_list;
 	Ref<OpenXRSpatialComponentPolygon2DList> poly2d_list;
-	if (plane_configuration->get_supports_mesh_2d()) {
-		mesh2d_list.instantiate();
-		component_data.push_back(mesh2d_list);
-	} else if (plane_configuration->get_supports_polygons()) {
-		poly2d_list.instantiate();
-		component_data.push_back(poly2d_list);
-	}
-
-	// Plane semantic label
 	Ref<OpenXRSpatialComponentPlaneSemanticLabelList> label_list;
-	if (plane_configuration->get_supports_labels()) {
-		label_list.instantiate();
-		component_data.push_back(label_list);
+	for (Ref<OpenXRSpatialComponentData> data : p_component_data) {
+		switch (data->get_component_type()) {
+			case XR_SPATIAL_COMPONENT_TYPE_BOUNDED_2D_EXT:
+				bounded2d_list = data;
+				break;
+			case XR_SPATIAL_COMPONENT_TYPE_PLANE_ALIGNMENT_EXT:
+				alignment_list = data;
+				break;
+			case XR_SPATIAL_COMPONENT_TYPE_MESH_2D_EXT:
+				mesh2d_list = data;
+				break;
+			case XR_SPATIAL_COMPONENT_TYPE_POLYGON_2D_EXT:
+				poly2d_list = data;
+				break;
+			case XR_SPATIAL_COMPONENT_TYPE_PLANE_SEMANTIC_LABEL_EXT:
+				label_list = data;
+				break;
+			default:
+				// Okay, maybe other data types are being queried that we don't know about
+				break;
+		}
 	}
 
-	if (se_extension->query_snapshot(p_snapshot, component_data, nullptr)) {
-		// Now loop through our data and update our anchors.
+	if (se_extension->query_snapshot(p_snapshot, p_component_data, p_next_snapshot_query)) {
+		// Now loop through our data and update our planes.
 		// Q we're assuming entity ID, size and state size are equal, is there ever a situation where they would not be?
 		int64_t size = query_result_data->get_capacity();
 		for (int64_t i = 0; i < size; i++) {
@@ -777,8 +824,8 @@ void OpenXRSpatialPlaneTrackingCapability::_process_snapshot(RID p_snapshot) {
 			if (entity_state == XR_SPATIAL_ENTITY_TRACKING_STATE_STOPPED_EXT) {
 				// We should only get this status on updates as a prelude to needing to remove this marker.
 				// So we just update the status.
-				if (plane_trackers.has(entity_id)) {
-					Ref<OpenXRPlaneTracker> plane_tracker = plane_trackers[entity_id];
+				if (planes.has(entity_id)) {
+					Ref<OpenXRPlaneTracker> plane_tracker = planes[entity_id];
 					plane_tracker->invalidate_pose(SNAME("default"));
 					plane_tracker->set_spatial_tracking_state(XR_SPATIAL_ENTITY_TRACKING_STATE_STOPPED_EXT);
 				}
@@ -787,14 +834,15 @@ void OpenXRSpatialPlaneTrackingCapability::_process_snapshot(RID p_snapshot) {
 				bool add_to_xr_server = false;
 				Ref<OpenXRPlaneTracker> plane_tracker;
 
-				if (plane_trackers.has(entity_id)) {
+				if (planes.has(entity_id)) {
 					// We know about this one already
-					plane_tracker = plane_trackers[entity_id];
+					plane_tracker = planes[entity_id];
 				} else {
 					// Create a new anchor
 					plane_tracker.instantiate();
+					plane_tracker->set_spatial_context(p_spatial_context);
 					plane_tracker->set_entity(se_extension->make_spatial_entity(se_extension->get_spatial_snapshot_context(p_snapshot), entity_id));
-					plane_trackers[entity_id] = plane_tracker;
+					planes[entity_id] = plane_tracker;
 
 					add_to_xr_server = true;
 				}
@@ -806,13 +854,17 @@ void OpenXRSpatialPlaneTrackingCapability::_process_snapshot(RID p_snapshot) {
 
 					// No further component data will be valid in this state, we need to ignore it!
 				} else if (entity_state == XR_SPATIAL_ENTITY_TRACKING_STATE_TRACKING_EXT) {
-					Transform3D transform = bounded2d_list->get_center_pose(i);
-					plane_tracker->set_pose(SNAME("default"), transform, Vector3(), Vector3());
-					plane_tracker->set_spatial_tracking_state(XR_SPATIAL_ENTITY_TRACKING_STATE_TRACKING_EXT);
+					if (bounded2d_list.is_valid()) {
+						Transform3D transform = bounded2d_list->get_center_pose(i);
+						plane_tracker->set_pose(SNAME("default"), transform, Vector3(), Vector3());
+						plane_tracker->set_spatial_tracking_state(XR_SPATIAL_ENTITY_TRACKING_STATE_TRACKING_EXT);
+					}
 
-					// Process our component data.
-					plane_tracker->set_bounds_size(bounded2d_list->get_size(i));
-					plane_tracker->set_plane_alignment((OpenXRSpatialComponentPlaneAlignmentList::PlaneAlignment)alignment_list->get_plane_alignment(i));
+					if (alignment_list.is_valid()) {
+						// Process our component data.
+						plane_tracker->set_bounds_size(bounded2d_list->get_size(i));
+						plane_tracker->set_plane_alignment((OpenXRSpatialComponentPlaneAlignmentList::PlaneAlignment)alignment_list->get_plane_alignment(i));
+					}
 
 					if (mesh2d_list.is_valid()) {
 						plane_tracker->set_mesh_data(mesh2d_list->get_transform(i), mesh2d_list->get_vertices(p_snapshot, i), mesh2d_list->get_indices(p_snapshot, i));
@@ -856,8 +908,8 @@ void OpenXRSpatialPlaneTrackingCapability::_process_snapshot(RID p_snapshot) {
 
 		// Remove any planes that are no longer there...
 		for (const XrSpatialEntityIdEXT &entity_id : current_planes) {
-			if (plane_trackers.has(entity_id)) {
-				Ref<OpenXRPlaneTracker> plane_tracker = plane_trackers[entity_id];
+			if (planes.has(entity_id)) {
+				Ref<OpenXRPlaneTracker> plane_tracker = planes[entity_id];
 
 				// Just in case there are still references out there to this marker,
 				// reset some stuff.
@@ -868,9 +920,13 @@ void OpenXRSpatialPlaneTrackingCapability::_process_snapshot(RID p_snapshot) {
 				xr_server->remove_tracker(plane_tracker);
 
 				// Remove it from our trackers
-				plane_trackers.erase(entity_id);
+				planes.erase(entity_id);
 			}
 		}
+	}
+
+	if (p_user_callback.is_valid()) {
+		p_user_callback.call(p_snapshot, true);
 	}
 
 	// Now that we're done, clean up our snapshot!

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.h
@@ -228,6 +228,8 @@ public:
 
 	virtual void on_process() override;
 
+	Ref<OpenXRFutureResult> start_entity_discovery(RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_create = nullptr, Ref<OpenXRStructureBase> p_next_snapshot_query = nullptr, const Callable &p_user_callback = Callable());
+
 	bool is_supported();
 
 private:
@@ -241,6 +243,7 @@ private:
 	Ref<OpenXRFutureResult> discovery_query_result;
 
 	Ref<OpenXRSpatialCapabilityConfigurationPlaneTracking> plane_configuration;
+	TypedArray<OpenXRSpatialComponentData> plane_component_data;
 
 	// Discovery logic
 	Ref<OpenXRFutureResult> _create_spatial_context();
@@ -248,9 +251,8 @@ private:
 
 	void _on_spatial_discovery_recommended(RID p_spatial_context);
 
-	Ref<OpenXRFutureResult> _start_entity_discovery();
-	void _process_snapshot(RID p_snapshot);
+	void _process_snapshot(RID p_snapshot, RID p_spatial_context, TypedArray<OpenXRSpatialComponentData> p_component_data, Ref<OpenXRStructureBase> p_next_snapshot_query, const Callable &p_user_callback);
 
-	// Trackers
-	HashMap<XrSpatialEntityIdEXT, Ref<OpenXRPlaneTracker>> plane_trackers;
+	// Trackers; maps each Spatial Context RID to their plane entities and trackers
+	HashMap<RID, HashMap<XrSpatialEntityIdEXT, Ref<OpenXRPlaneTracker>>> plane_trackers;
 };


### PR DESCRIPTION
Update the existing OpenXR Spatial Entities APIs to be more accessible for GDExtension and GDScript.

Notable changes
* Hardcoded behavior is either moved to a constructor which could be overridden later or to a function with the word `default` in it (like `create_default_persistence_context`) which could be ignored by the caller.
* Trackers are now scoped by the spatial context `RID` that was used to create them.  This shouldn't break any existing functionality since spatial entities are "siloed" within the runtime already.
* Added APIs (`do_entity_update` and `start_entity_discovery`) to each capability to make manual anchor/marker/plane updates easier to customize.  These APIs were also expanded so that the snapshot creation and query can use custom `next` objects.
* The `process snapshot` functions can now process any number of components.  Each capability has a few required components that they must have since otherwise it doesn't make sense for that capability to be processing anything (for example, anchors requires the anchor list (for entity update) and anchor list + persistence list (for discovery) at minimum).
* Since `start_entity_discovery` is asynchronous, added a callback to be called when the snapshot is ready.  Since the `_process_discovery_snapshot` methods can early return, the callback is called at the very start as well as after processing the snapshot.
* Added another parameter to `create_new_anchor` for a custom `next` object to pass to OpenXR.
* As a side effect of these changes, capabilities now cache their `*ComponentData` instances instead of potentially re-creating them every frame (only when the builtin project setting is set).
* Added a `next` object to `OpenXRSpatialEntityTracker` to potentially chain multiple next-objects.  These objects act as metadata associated with the trackers, and their order does not matter.  They're unused in this code but can be used by GDExtension/GDScript.
* There should be no breaking functionality, though two existing APIs changed which could break existing GDExtensions (GDScript shouldn't be affected since const-ness was changed for one function and an optional parameter was added for another).