### PR TITLE
Fix script editor errors shown out of order

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -838,6 +838,15 @@ Ref<Texture2D> ScriptTextEditor::get_theme_icon() {
 	return Ref<Texture2D>();
 }
 
+struct ScriptErrorLineComparator {
+	bool operator()(const ScriptLanguage::ScriptError &p_a, const ScriptLanguage::ScriptError &p_b) const {
+		if (p_a.line != p_b.line) {
+			return p_a.line < p_b.line;
+		}
+		return p_a.column < p_b.column;
+	}
+};
+
 void ScriptTextEditor::_validate_script() {
 	CodeEdit *te = code_editor->get_text_editor();
 
@@ -851,6 +860,8 @@ void ScriptTextEditor::_validate_script() {
 
 	Ref<Script> script = edited_res;
 	if (!script->get_language()->validate(text, script->get_path(), &fnc, &errors, &warnings, &safe_lines)) {
+		errors.sort_custom<ScriptErrorLineComparator>();
+
 		List<ScriptLanguage::ScriptError>::Element *E = errors.front();
 		while (E) {
 			List<ScriptLanguage::ScriptError>::Element *next_E = E->next();


### PR DESCRIPTION
Fixes #118122

When GDScript warnings are treated as errors, they are appended to the error list via `push_error()` without regard for line ordering. This causes them to appear after all other errors in the editor panel, regardless of their actual line numbers.

This PR sorts the error list by line number (with column as tiebreaker) in `ScriptTextEditor::_validate_script()` before errors are displayed. This ensures:
- The error panel shows errors in source order
- The first-error indicator points to the earliest error by line number
- Depended errors (from other scripts) also inherit correct ordering

The fix is language-agnostic, applied at the editor display layer rather than in the GDScript parser, so all script languages benefit.

## Testing

1. Create a new script with:
```gdscript
func _foo() -> void:
    var _i: int = 1.0

func _bar() -> void:
    var _v: Vector2 = 3
```
2. In Project Settings, set `debug/gdscript/warnings/narrowing_conversion` to **Error**
3. **Before**: Errors appear out of line-number order in the error panel
4. **After**: Errors are sorted by line number (line 2 first, line 5 second)