### PR TITLE
Fix PopupMenu internal ScrollContainer inheriting global theme styles

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3684,6 +3684,7 @@ PopupMenu::PopupMenu() {
 	scroll_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	scroll_container->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	vbox_container->add_child(scroll_container, false, INTERNAL_MODE_FRONT);
+	scroll_container->add_theme_style_override(SceneStringName(panel), memnew(StyleBoxEmpty));
 
 	// The control which will display the items
 	control = memnew(Control);


### PR DESCRIPTION
Fixes #118033.

PopupMenu's internal `ScrollContainer` picks up user-defined global `ScrollContainer` theme styles (specifically the `panel` StyleBox), causing the dropdown to display an unintended background behind its items.

This adds a `StyleBoxEmpty` theme style override on the internal `ScrollContainer`'s `panel` property, preventing any user-defined `ScrollContainer` theme from bleeding through. PopupMenu's own panel background (drawn by its `PanelContainer`) is unaffected.