### PR TITLE
Fix detection for main scene in FileSystemDock after move

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1718,6 +1718,10 @@ void FileSystemDock::_update_project_settings_after_move(const HashMap<String, S
 		}
 	}
 
+	if (p_renames.has(main_scene_path)) {
+		main_scene_path = p_renames[main_scene_path];
+	}
+
 	// Update folder colors.
 	for (const KeyValue<String, String> &rename : p_folders_renames) {
 		if (assigned_folder_colors.has(rename.key)) {


### PR DESCRIPTION
A race between `settings_changed` and `filesystem_changed` after the main scene is moved in FileSystemDock leads to this bug:

https://github.com/user-attachments/assets/12abb4e9-0394-4b82-9232-b78db4844e9e

Which can disqualify the main scene from correctly having its accent set or the "Set as Main Scene" menu option correctly hidden when right-clicked, indefinitely, until another scene is set as main scene. This PR fixes that.