### PR TITLE
Fix iOS virtual keyboard auto-capitalization for email, password, and URL types

### DIFF
--- a/drivers/apple_embedded/display_server_apple_embedded.mm
+++ b/drivers/apple_embedded/display_server_apple_embedded.mm
@@ -710,6 +710,7 @@ void DisplayServerAppleEmbedded::virtual_keyboard_show(const String &p_existing_
 
 	GDTAppDelegateService.viewController.keyboardView.keyboardType = UIKeyboardTypeDefault;
 	GDTAppDelegateService.viewController.keyboardView.textContentType = nil;
+	GDTAppDelegateService.viewController.keyboardView.autocapitalizationType = UITextAutocapitalizationTypeSentences;
 	switch (p_type) {
 		case DisplayServerEnums::KEYBOARD_TYPE_DEFAULT: {
 			GDTAppDelegateService.viewController.keyboardView.keyboardType = UIKeyboardTypeDefault;
@@ -730,14 +731,17 @@ void DisplayServerAppleEmbedded::virtual_keyboard_show(const String &p_existing_
 		case DisplayServerEnums::KEYBOARD_TYPE_EMAIL_ADDRESS: {
 			GDTAppDelegateService.viewController.keyboardView.keyboardType = UIKeyboardTypeEmailAddress;
 			GDTAppDelegateService.viewController.keyboardView.textContentType = UITextContentTypeEmailAddress;
+			GDTAppDelegateService.viewController.keyboardView.autocapitalizationType = UITextAutocapitalizationTypeNone;
 		} break;
 		case DisplayServerEnums::KEYBOARD_TYPE_PASSWORD: {
 			GDTAppDelegateService.viewController.keyboardView.keyboardType = UIKeyboardTypeDefault;
 			GDTAppDelegateService.viewController.keyboardView.textContentType = UITextContentTypePassword;
+			GDTAppDelegateService.viewController.keyboardView.autocapitalizationType = UITextAutocapitalizationTypeNone;
 		} break;
 		case DisplayServerEnums::KEYBOARD_TYPE_URL: {
 			GDTAppDelegateService.viewController.keyboardView.keyboardType = UIKeyboardTypeWebSearch;
 			GDTAppDelegateService.viewController.keyboardView.textContentType = UITextContentTypeURL;
+			GDTAppDelegateService.viewController.keyboardView.autocapitalizationType = UITextAutocapitalizationTypeNone;
 		} break;
 	}
 

--- a/drivers/apple_embedded/display_server_apple_embedded.mm
+++ b/drivers/apple_embedded/display_server_apple_embedded.mm
@@ -711,6 +711,8 @@ void DisplayServerAppleEmbedded::virtual_keyboard_show(const String &p_existing_
 	GDTAppDelegateService.viewController.keyboardView.keyboardType = UIKeyboardTypeDefault;
 	GDTAppDelegateService.viewController.keyboardView.textContentType = nil;
 	GDTAppDelegateService.viewController.keyboardView.autocapitalizationType = UITextAutocapitalizationTypeSentences;
+	GDTAppDelegateService.viewController.keyboardView.autocorrectionType = UITextAutocorrectionTypeDefault;
+	GDTAppDelegateService.viewController.keyboardView.secureTextEntry = NO;
 	switch (p_type) {
 		case DisplayServerEnums::KEYBOARD_TYPE_DEFAULT: {
 			GDTAppDelegateService.viewController.keyboardView.keyboardType = UIKeyboardTypeDefault;


### PR DESCRIPTION
On iOS, the virtual keyboard has two issues related to missing UITextInputTraits configuration on the `GDTKeyboardInputView`:

**1. Auto-capitalization ignores keyboard type**

The keyboard always opens with shift pressed (auto-capitalizes the first character), even when using `KEYBOARD_TYPE_EMAIL_ADDRESS`, `KEYBOARD_TYPE_PASSWORD`, or `KEYBOARD_TYPE_URL`. This is pretty annoying for login screens where both email and password fields start uppercased.

The root cause is that `autocapitalizationType` is never set on the keyboard view. UIKit defaults it to `UITextAutocapitalizationTypeSentences`, which capitalizes the first letter, regardless of what `keyboardType` is set to. Unlike Android where `TYPE_TEXT_VARIATION_EMAIL_ADDRESS` implicitly disables auto-capitalization, iOS requires setting it explicitly.

**2. Password mode "poisons" subsequent keyboard invocations**

After using `KEYBOARD_TYPE_PASSWORD`, all subsequent `virtual_keyboard_show()` calls inherit the password-mode state: no autocorrect, no predictive text, secure text entry. This happens because `autocorrectionType` and `secureTextEntry` are never reset on the shared keyboard view between invocations. So if a login screen has email + password fields, tapping the password field first makes the email field (and any other text field in the app) lose autocomplete until the app is restarted.

**Fix**

Reset all relevant UITextInputTraits at the top of `virtual_keyboard_show()` before applying type-specific settings:
- `autocapitalizationType` → `UITextAutocapitalizationTypeSentences` (default)
- `autocorrectionType` → `UITextAutocorrectionTypeDefault` (default)
- `secureTextEntry` → `NO`

Then set `autocapitalizationType = UITextAutocapitalizationTypeNone` for email, password, and URL keyboard types where auto-capitalization doesn't make sense.

Fixes #108383.

**Tested on iPhone 13 mini, iOS 18.3.1, Godot 4.6.1** (the fix applies cleanly to master as the relevant code is the same).