### PR TITLE
Initialize ReflectionAtlas in `LightStorage::reflection_atlas_create`

### DIFF
--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -662,7 +662,7 @@ Dependency *LightStorage::reflection_probe_get_dependency(RID p_probe) const {
 /* REFLECTION ATLAS */
 
 RID LightStorage::reflection_atlas_create() {
-	ReflectionAtlas ra;
+	ReflectionAtlas ra = {};
 	ra.count = GLOBAL_GET("rendering/reflections/reflection_atlas/reflection_count");
 	ra.size = GLOBAL_GET("rendering/reflections/reflection_atlas/reflection_size");
 


### PR DESCRIPTION
Disclaimer: I don't know what any of those code does, all I know is that without this change, this code fails to compile when building Godot with `scons target=template_release werror=yes` on Linux Arm64:

```
In file included from drivers/gles3/storage/light_storage.cpp:31:
In copy constructor 'GLES3::ReflectionAtlas::ReflectionAtlas(const GLES3::ReflectionAtlas&)',
    inlined from 'void RID_Alloc<T, THREAD_SAFE>::initialize_rid(RID, const T&) [with T = GLES3::ReflectionAtlas; bool THREAD_SAFE = false]' at ./core/templates/rid_owner.h:292:3,
    inlined from 'RID RID_Alloc<T, THREAD_SAFE>::make_rid(const T&) [with T = GLES3::ReflectionAtlas; bool THREAD_SAFE = false]' at ./core/templates/rid_owner.h:182:17,
    inlined from 'RID RID_Owner<T, THREAD_SAFE>::make_rid(const T&) [with T = GLES3::ReflectionAtlas; bool THREAD_SAFE = false]' at ./core/templates/rid_owner.h:525:24,
    inlined from 'virtual RID GLES3::LightStorage::reflection_atlas_create()' at drivers/gles3/storage/light_storage.cpp:669:40:
drivers/gles3/storage/light_storage.h:138:8: error: 'ra.GLES3::ReflectionAtlas::mipmap_size' may be used uninitialized [-Werror=maybe-uninitialized]
  138 | struct ReflectionAtlas {
      |        ^~~~~~~~~~~~~~~
drivers/gles3/storage/light_storage.cpp: In member function 'virtual RID GLES3::LightStorage::reflection_atlas_create()':
drivers/gles3/storage/light_storage.cpp:665:25: note: 'ra' declared here
  665 |         ReflectionAtlas ra;
      |                         ^~
```
