### PR TITLE
Supports longer enet timeouts

### DIFF
--- a/modules/enet/doc_classes/ENetPacketPeer.xml
+++ b/modules/enet/doc_classes/ENetPacketPeer.xml
@@ -106,12 +106,15 @@
 		</method>
 		<method name="set_timeout">
 			<return type="void" />
-			<param index="0" name="timeout" type="int" />
+			<param index="0" name="timeout_retry_limit" type="int" />
 			<param index="1" name="timeout_min" type="int" />
 			<param index="2" name="timeout_max" type="int" />
 			<description>
-				Sets the timeout parameters for a peer. The timeout parameters control how and when a peer will timeout from a failure to acknowledge reliable traffic. Timeout values are expressed in milliseconds.
-				The [param timeout] is a factor that, multiplied by a value based on the average round trip time, will determine the timeout limit for a reliable packet. When that limit is reached, the timeout will be doubled, and the peer will be disconnected if that limit has reached [param timeout_min]. The [param timeout_max] parameter, on the other hand, defines a fixed timeout for which any packet must be acknowledged or the peer will be dropped.
+				Sets the timeout parameters for a peer. The timeout parameters control how and when a peer will timeout from a failure to acknowledge reliable traffic. [param timeout_min] and [param timeout_max] values are expressed in milliseconds.
+				It uses an exponential backoff scheme, where the retransmission interval is doubled each time a reliable packet is not acknowledged within an interval derived from the average RTT plus a variance tolerance. The [param timeout_retry_limit] specifies the maximum number of exponential backoff retransmissions allowed.
+				A peer is disconnected if either of the following conditions is met:
+				- Reliable packets have been sent but remain unacknowledged for a duration exceeding [param timeout_max].
+				- The number of retransmissions has reached the [param timeout_retry_limit], and reliable packets have been unacknowledged for at least [param timeout_min].
 			</description>
 		</method>
 		<method name="throttle_configure">

--- a/modules/enet/enet_packet_peer.cpp
+++ b/modules/enet/enet_packet_peer.cpp
@@ -76,10 +76,10 @@ void ENetPacketPeer::throttle_configure(int p_interval, int p_acceleration, int 
 	enet_peer_throttle_configure(peer, p_interval, p_acceleration, p_deceleration);
 }
 
-void ENetPacketPeer::set_timeout(int p_timeout, int p_timeout_min, int p_timeout_max) {
+void ENetPacketPeer::set_timeout(int p_timeout_retry_limit, int p_timeout_min, int p_timeout_max) {
 	ERR_FAIL_NULL_MSG(peer, "Peer not connected.");
-	ERR_FAIL_COND_MSG(p_timeout > p_timeout_min || p_timeout_min > p_timeout_max, "Timeout limit must be less than minimum timeout, which itself must be less than maximum timeout");
-	enet_peer_timeout(peer, p_timeout, p_timeout_min, p_timeout_max);
+	ERR_FAIL_COND_MSG(p_timeout_min > p_timeout_max, "Minimum timeout must be less than maximum timeout");
+	enet_peer_timeout(peer, p_timeout_retry_limit, p_timeout_min, p_timeout_max);
 }
 
 int ENetPacketPeer::get_max_packet_size() const {
@@ -215,7 +215,7 @@ void ENetPacketPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("reset"), &ENetPacketPeer::reset);
 	ClassDB::bind_method(D_METHOD("send", "channel", "packet", "flags"), &ENetPacketPeer::_send);
 	ClassDB::bind_method(D_METHOD("throttle_configure", "interval", "acceleration", "deceleration"), &ENetPacketPeer::throttle_configure);
-	ClassDB::bind_method(D_METHOD("set_timeout", "timeout", "timeout_min", "timeout_max"), &ENetPacketPeer::set_timeout);
+	ClassDB::bind_method(D_METHOD("set_timeout", "timeout_retry_limit", "timeout_min", "timeout_max"), &ENetPacketPeer::set_timeout);
 	ClassDB::bind_method(D_METHOD("get_packet_flags"), &ENetPacketPeer::get_packet_flags);
 	ClassDB::bind_method(D_METHOD("get_remote_address"), &ENetPacketPeer::get_remote_address);
 	ClassDB::bind_method(D_METHOD("get_remote_port"), &ENetPacketPeer::get_remote_port);

--- a/modules/enet/enet_packet_peer.h
+++ b/modules/enet/enet_packet_peer.h
@@ -108,7 +108,7 @@ public:
 	void reset();
 	int send(uint8_t p_channel, ENetPacket *p_packet);
 	void throttle_configure(int interval, int acceleration, int deceleration);
-	void set_timeout(int p_timeout, int p_timeout_min, int p_timeout_max);
+	void set_timeout(int p_timeout_retry_limit, int p_timeout_min, int p_timeout_max);
 	double get_statistic(PeerStatistic p_stat);
 	PeerState get_state() const;
 	int get_channels() const;

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -257,6 +257,7 @@ Files extracted from upstream source:
 Patches:
 
 - `0001-godot-socket.patch` ([GH-7985](https://github.com/godotengine/godot/pull/7985))
+- `0002-supports-long-timeouts.patch` ([GH-118158](https://github.com/godotengine/godot/pull/118158))
 
 Important: Building against a system wide ENet is possible, but will limit its
 functionality to IPv4 only and no DTLS. We recommend against it.

--- a/thirdparty/enet/enet/enet.h
+++ b/thirdparty/enet/enet/enet.h
@@ -233,7 +233,7 @@ enum
    ENET_PEER_PACKET_LOSS_SCALE            = (1 << 16),
    ENET_PEER_PACKET_LOSS_INTERVAL         = 10000,
    ENET_PEER_WINDOW_SIZE_SCALE            = 64 * 1024,
-   ENET_PEER_TIMEOUT_LIMIT                = 32,
+   ENET_PEER_TIMEOUT_LIMIT                = 5,
    ENET_PEER_TIMEOUT_MINIMUM              = 5000,
    ENET_PEER_TIMEOUT_MAXIMUM              = 30000,
    ENET_PEER_PING_INTERVAL                = 500,

--- a/thirdparty/enet/patches/0002-supports-long-timeouts.patch
+++ b/thirdparty/enet/patches/0002-supports-long-timeouts.patch
@@ -1,0 +1,26 @@
+diff --git a/thirdparty/enet/enet/enet.h b/thirdparty/enet/enet/enet.h
+index ccd8382c23..8f3c4489dc 100644
+--- a/thirdparty/enet/enet/enet.h
++++ b/thirdparty/enet/enet/enet.h
+@@ -233,7 +233,7 @@ enum
+    ENET_PEER_PACKET_LOSS_SCALE            = (1 << 16),
+    ENET_PEER_PACKET_LOSS_INTERVAL         = 10000,
+    ENET_PEER_WINDOW_SIZE_SCALE            = 64 * 1024,
+-   ENET_PEER_TIMEOUT_LIMIT                = 32,
++   ENET_PEER_TIMEOUT_LIMIT                = 5,
+    ENET_PEER_TIMEOUT_MINIMUM              = 5000,
+    ENET_PEER_TIMEOUT_MAXIMUM              = 30000,
+    ENET_PEER_PING_INTERVAL                = 500,
+diff --git a/thirdparty/enet/protocol.c b/thirdparty/enet/protocol.c
+index 5f18700599..873003db08 100644
+--- a/thirdparty/enet/protocol.c
++++ b/thirdparty/enet/protocol.c
+@@ -1372,7 +1372,7 @@ enet_protocol_check_timeouts (ENetHost * host, ENetPeer * peer, ENetEvent * even
+ 
+        if (peer -> earliestTimeout != 0 &&
+              (ENET_TIME_DIFFERENCE (host -> serviceTime, peer -> earliestTimeout) >= peer -> timeoutMaximum ||
+-               ((1 << (outgoingCommand -> sendAttempts - 1)) >= peer -> timeoutLimit &&
++               ((outgoingCommand -> sendAttempts - 1) >= peer -> timeoutLimit &&
+                  ENET_TIME_DIFFERENCE (host -> serviceTime, peer -> earliestTimeout) >= peer -> timeoutMinimum)))
+        {
+           enet_protocol_notify_disconnect (host, peer, event);

--- a/thirdparty/enet/protocol.c
+++ b/thirdparty/enet/protocol.c
@@ -1372,7 +1372,7 @@ enet_protocol_check_timeouts (ENetHost * host, ENetPeer * peer, ENetEvent * even
 
        if (peer -> earliestTimeout != 0 &&
              (ENET_TIME_DIFFERENCE (host -> serviceTime, peer -> earliestTimeout) >= peer -> timeoutMaximum ||
-               ((1 << (outgoingCommand -> sendAttempts - 1)) >= peer -> timeoutLimit &&
+               ((outgoingCommand -> sendAttempts - 1) >= peer -> timeoutLimit &&
                  ENET_TIME_DIFFERENCE (host -> serviceTime, peer -> earliestTimeout) >= peer -> timeoutMinimum)))
        {
           enet_protocol_notify_disconnect (host, peer, event);


### PR DESCRIPTION
Support enet longer timeout.

As discussed in https://github.com/godotengine/godot-proposals/discussions/14205#discussioncomment-15772907
it was found that the peer would still automatically close after around one minute even though we set the timeout a very large value, making debugging multiplayer game very tedious.

The issue stems from the original implementation using a bit‑shift operation `(1 << (outgoingCommand->sendAttempts - 1))` to compare against `peer->timeoutLimit`. This approach unnecessarily complicates the logic and imposes an artificial upper bound on the number of retries (<del>up to 63 attempts on a 64‑bit system, even when the user calls `set_timeout(9223372036854775807, 9223372036854775807, 9223372036854775807)`</del>up to 32 attempts because enet use usigned 32-bit type: `set_timeout(4294967295, 4294967295, 4294967295)`). A simpler and more efficient solution is to directly compare `outgoingCommand->sendAttempts - 1` with `peer->timeoutLimit`.

Benefits:

- Clarity: The logic becomes straightforward and easier to understand.
- Performance: Eliminates the overhead of bit-shift operations.
- No Limitations: Removes the artificial cap on retry attempts imposed by bit-shift operation.

