### PR TITLE
Fix compressed Pos3D track interpolation

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -2872,8 +2872,8 @@ void Animation::track_get_key_indices_in_range(int p_track, double p_time, doubl
 					case TYPE_POSITION_3D: {
 						const PositionTrack *tt = static_cast<const PositionTrack *>(t);
 						if (tt->compressed_track >= 0) {
-							_get_compressed_key_indices_in_range<3>(tt->compressed_track, from_time, length, r_indices);
-							_get_compressed_key_indices_in_range<3>(tt->compressed_track, p_start, to_time, r_indices);
+							_get_compressed_key_indices_in_range<3>(tt->compressed_track, from_time, end, r_indices);
+							_get_compressed_key_indices_in_range<3>(tt->compressed_track, start, to_time, r_indices);
 						} else {
 							if (!is_backward) {
 								_track_get_key_indices_in_range(tt->positions, from_time, anim_end, r_indices, is_backward);


### PR DESCRIPTION
- Follow up https://github.com/godotengine/godot/pull/116046

Corrected [this section](https://github.com/godotengine/godot/pull/116046/changes#diff-a14f5713a139cb37bbd9e32a7c3bdbad83faf96faa61c4755d143145bb2ee0bbR2880-R2881) to ensure consistency, as it had been migrated incorrectly.