### PR TITLE
CI: Add `clangd-tidy` hook for pre-commit

### DIFF
--- a/.github/actions/pre-commit/action.yml
+++ b/.github/actions/pre-commit/action.yml
@@ -1,0 +1,48 @@
+name: pre-commit
+description: Run and cache pre-commit
+
+inputs:
+  args:
+    description: Options to pass to the pre-commit run.
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Restore pre-commit cache
+      id: pre-commit-restore
+      uses: actions/cache/restore@v5
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit|${{ hashFiles('.pre-commit-config.yaml') }}|${{ github.sha }}
+        restore-keys: pre-commit|${{ hashFiles('.pre-commit-config.yaml') }}
+
+    - name: Setup pre-commit
+      shell: sh
+      run: |
+        echo "::group::Installing pre-commit"
+        # Don't know which python we're using, so just access the global scope.
+        python -m pip install pre-commit
+        echo "::endgroup::"
+
+        echo "::group::Preparing pre-commit dependencies"
+        # Specify manual hook stage to capture `clangd-tidy` as well.
+        pre-commit run --hook-stage manual
+        echo "::endgroup::"
+
+        echo "::group::Removing unused dependencies"
+        # Prevent cache bloat by only keeping current dependencies.
+        pre-commit gc
+        echo "::endgroup::"
+
+    - name: Save pre-commit cache
+      uses: actions/cache/save@v5
+      if: steps.pre-commit-restore.outputs.cache-hit != 'true'
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit|${{ hashFiles('.pre-commit-config.yaml') }}|${{ github.sha }}
+
+    - name: Run pre-commit
+      shell: sh
+      run: pre-commit run --show-diff-on-failure --color=always ${{ inputs.args }}

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -188,9 +188,9 @@ jobs:
 
       - name: Style checks via clangd-tidy
         if: matrix.clangd-tidy
-        uses: ./.github/actions/clangd-tidy
+        uses: ./.github/actions/pre-commit
         with:
-          changed-files: ${{ inputs.changed-files }}
+          args: --hook-stage manual clangd-tidy --files ${{ inputs.changed-files }}
 
       - name: Compilation (godot-cpp)
         uses: ./.github/actions/godot-cpp-build

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -40,8 +40,8 @@ jobs:
           files_yaml_from_source_file: .github/changed_files.yml
 
       - name: Style checks via pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: ./.github/actions/pre-commit
         env:
           CHANGED_FILES: '"${{ steps.changed-files.outputs.everything_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
         with:
-          extra_args: --files ${{ env.CHANGED_FILES }}
+          args: --files ${{ env.CHANGED_FILES }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,6 +79,18 @@ repos:
 
   - repo: local
     hooks:
+      # Not automatically triggered (because it requires compile_commands.json to be up-to-date).
+      # Invoke it manually via `pre-commit run --hook-stage manual clangd-tidy`.
+      - id: clangd-tidy
+        name: clangd-tidy
+        language: python
+        entry: clangd-tidy --allow-extensions c,h,cpp,hpp,cc,hh,cxx,hxx,m,mm,java
+        # TODO .inc ignored for now because they don't include their parent header.
+        files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|m|mm|java)$
+        additional_dependencies: [clangd-tidy, clangd, clang-tidy==22.1.0.1]
+        require_serial: true
+        stages: [manual]
+
       - id: make-rst
         name: make-rst
         language: python


### PR DESCRIPTION
- Related #117654

Implements `clangd-tidy` as a proper pre-commit hook, making the tool more readily accessible for all users. This required reworking the pre-commit action into our own implementation, which is arguably for the best as that action has been unsupported for years now & is the main source of false-positive warnings in CI output

However: despite being fully-functional, I'm hesitant to implement this as-is. As there's no way to enforce `compile_commands.json`, nor is there a reliable way to exclude platform-specific files, the hook stage is still "manual". To make this into a readily-accessible hook, I believe that we'd have to either make upstream changes to `clangd-tidy` or produce our own wrapper script to achieve our desired results. Having said that, I'm setting this up as-is in order to verify that the pre-commit action functions as expected, which will get a dedicated PR if so