### PR TITLE
Add math constants to texture-blit

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1573,9 +1573,9 @@ MaterialStorage::MaterialStorage() {
 		ShaderCompiler::DefaultIdentifierActions actions;
 
 		actions.renames["TIME"] = "time";
-		actions.renames["PI"] = _MKSTR(Math_PI);
-		actions.renames["TAU"] = _MKSTR(Math_TAU);
-		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["PI"] = String::num(Math::PI);
+		actions.renames["TAU"] = String::num(Math::TAU);
+		actions.renames["E"] = String::num(Math::E);
 
 		actions.renames["FRAGCOORD"] = "gl_FragCoord";
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -659,9 +659,9 @@ void TextureStorage::_tex_blit_shader_initialize() {
 		ShaderCompiler::DefaultIdentifierActions actions;
 
 		actions.renames["TIME"] = "data.time";
-		actions.renames["PI"] = _MKSTR(Math_PI);
-		actions.renames["TAU"] = _MKSTR(Math_TAU);
-		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["PI"] = String::num(Math::PI);
+		actions.renames["TAU"] = String::num(Math::TAU);
+		actions.renames["E"] = String::num(Math::E);
 
 		actions.renames["FRAGCOORD"] = "gl_FragCoord";
 


### PR DESCRIPTION
Fixes #118144 

The texture-blit shader was missing math constant definitions (PI, E, TAU) that are normally injected into regular shaders. This caused compilation errors when using these constants in blit() functions.

Solution: Add **Math_PI**, **Math_E**, & **Math_TAU** constant definition to the shader preamble during **TYPE_VERSION_DEFINES** processing