### PR TITLE
[Web] Add option to enable offscreen canvas

### DIFF
--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -43,10 +43,7 @@
 #include <unistd.h>
 
 #include <cerrno>
-
-#if defined(TOOLS_ENABLED)
 #include <cstdlib>
-#endif
 
 void FileAccessUnix::check_errors(bool p_write) const {
 	ERR_FAIL_NULL_MSG(f, "File must be opened before use.");

--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -591,8 +591,12 @@ function startEditor(zip) {
 		const width = window.innerWidth;
 		const height = window.innerHeight - headerHeight;
 		if (lastScale !== scale || lastWidth !== width || lastHeight !== height) {
-			editorCanvas.width = width * scale;
-			editorCanvas.height = height * scale;
+			if (editor) {
+				editor.setCanvasSize(width * scale, height * scale);
+			} else {
+				editorCanvas.width = width * scale;
+				editorCanvas.height = height * scale;
+			}
 			editorCanvas.style.width = `${width}px`;
 			editorCanvas.style.height = `${height}px`;
 			lastScale = scale;
@@ -669,11 +673,13 @@ function startEditor(zip) {
 		'canvasResizePolicy': 1,
 		'onExit': function () {
 			gameCanvas = replaceCanvas(gameCanvas);
+			this.canvas = gameCanvas;
 			setGameTabEnabled(false);
 			showTab('editor');
 			game = null;
 		},
 	};
+	gameConfig.onExit = gameConfig.onExit.bind(gameConfig);
 
 	let OnEditorExit = function () {
 		showTab('loader');
@@ -745,6 +751,7 @@ function startEditor(zip) {
 		'canvasResizePolicy': 0,
 		'onExit': function () {
 			editorCanvas = replaceCanvas(editorCanvas);
+			editor.config.update({ 'canvas': editorCanvas });
 			if (OnEditorExit) {
 				OnEditorExit();
 			}

--- a/modules/theora/editor/movie_writer_ogv.cpp
+++ b/modules/theora/editor/movie_writer_ogv.cpp
@@ -35,6 +35,8 @@
 #include "core/config/project_settings.h"
 #include "core/io/file_access.h"
 
+#include <cstdlib>
+
 void MovieWriterOGV::push_audio(const int32_t *p_audio_data) {
 	// Read and process more audio.
 	float **vorbis_buffer = vorbis_analysis_buffer(&vd, audio_frames);

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -23,6 +23,7 @@ if "serve" in COMMAND_LINE_TARGETS or "run" in COMMAND_LINE_TARGETS:
 web_files = [
     "audio_driver_web.cpp",
     "webmidi_driver.cpp",
+    "godot_webgl2.cpp",
     "display_server_web.cpp",
     "http_client_web.cpp",
     "javascript_bridge_singleton.cpp",
@@ -55,6 +56,12 @@ sys_env.AddJSPost([
 
 if env["javascript_eval"]:
     sys_env.AddJSLibraries(["js/libs/library_godot_javascript_singleton.js"])
+
+if env["use_offscreen_canvas"] == "yes" and not env["proxy_to_pthread"]:
+    # Workaround https://github.com/emscripten-core/emscripten/issues/26394.
+    sys_env.AddJSPost([
+        "js/patches/set_offscreen_canvas_size.js",
+    ])
 
 for lib in sys_env["JS_LIBS"]:
     sys_env.Append(LINKFLAGS=["--js-library", lib.abspath])

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -36,7 +36,7 @@ def get_tools(env: "SConsEnvironment"):
 
 
 def get_opts():
-    from SCons.Variables import BoolVariable
+    from SCons.Variables import BoolVariable, EnumVariable
 
     return [
         ("initial_memory", "Initial WASM memory (in MiB)", 32),
@@ -58,6 +58,13 @@ def get_opts():
             "proxy_to_pthread",
             "Use Emscripten PROXY_TO_PTHREAD option to run the main application code to a separate thread",
             False,
+        ),
+        EnumVariable(
+            "use_offscreen_canvas",
+            "Use Emscripten OFFSCREENCANVAS_SUPPORT option to use offscreen canvas for rendering",
+            "auto",
+            ["auto", "no", "yes"],
+            ignorecase=2,
         ),
         BoolVariable("wasm_simd", "Use WebAssembly SIMD to improve CPU performance", True),
     ]
@@ -306,9 +313,20 @@ def configure(env: "SConsEnvironment"):
     if env["proxy_to_pthread"]:
         env.Append(LINKFLAGS=["-sPROXY_TO_PTHREAD=1"])
         env.Append(CPPDEFINES=["PROXY_TO_PTHREAD_ENABLED"])
-        env["EXPORTED_RUNTIME_METHODS"] += ["_emscripten_proxy_main"]
-        # https://github.com/emscripten-core/emscripten/issues/18034#issuecomment-1277561925
-        env.Append(LINKFLAGS=["-sTEXTDECODER=0"])
+        # Webxr doesn't work in a worker thread main loop.
+        # See https://github.com/immersive-web/webxr/issues/1102.
+        print_warning('"proxy_to_pthread=yes" support requires "disable_xr=yes", disabling xr.')
+        env["disable_xr"] = True
+
+    # Configure offscreen canvas.
+    if env["use_offscreen_canvas"] == "auto":
+        env["use_offscreen_canvas"] = "yes" if env["proxy_to_pthread"] else "no"
+
+    if env["use_offscreen_canvas"] == "yes":
+        env.AppendUnique(LINKFLAGS=["-sOFFSCREENCANVAS_SUPPORT=1"])
+        env.AppendUnique(CPPDEFINES=["OFFSCREENCANVAS_ENABLED"])
+        if env["lto"] != "none" and env["threads"]:
+            env.Append(LINKFLAGS=["-Wl,-u,_emscripten_set_offscreencanvas_size_on_thread"])
 
     # Enable WebAssembly SIMD
     if env["wasm_simd"]:

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -59,6 +59,8 @@
 #define DOM_BUTTON_XBUTTON1 3
 #define DOM_BUTTON_XBUTTON2 4
 
+void setup_canvas_proxying(bool p_canvas_is_on_runtime);
+
 DisplayServerWeb *DisplayServerWeb::get_singleton() {
 	return static_cast<DisplayServerWeb *>(DisplayServer::get_singleton());
 }
@@ -1120,10 +1122,13 @@ DisplayServerWeb::DisplayServerWeb(const String &p_rendering_driver, DisplayServ
 	native_menu = memnew(NativeMenu); // Dummy native menu.
 
 	// Ensure the canvas ID.
-	godot_js_config_canvas_id_get(canvas_id, 256);
+	canvas_id = godot_js_config_canvas_id_allocate();
 
 	// Handle contextmenu, webglcontextlost
 	godot_js_display_setup_canvas(p_resolution.x, p_resolution.y, (p_window_mode == DisplayServerEnums::WINDOW_MODE_FULLSCREEN || p_window_mode == DisplayServerEnums::WINDOW_MODE_EXCLUSIVE_FULLSCREEN), OS::get_singleton()->is_hidpi_allowed() ? 1 : 0);
+
+	int initial_size[2];
+	godot_js_display_window_size_get(initial_size, initial_size + 1);
 
 	// Check if it's windows.
 	swap_cancel_ok = godot_js_display_is_swap_ok_cancel() == 1;
@@ -1140,6 +1145,11 @@ DisplayServerWeb::DisplayServerWeb(const String &p_rendering_driver, DisplayServ
 		attributes.antialias = false;
 		attributes.majorVersion = 2;
 		attributes.explicitSwapControl = true;
+#ifdef OFFSCREENCANVAS_ENABLED
+		// Enable fallback in case offscreen canvas is enabled, but is not available.
+		attributes.renderViaOffscreenBackBuffer = true;
+		attributes.proxyContextToMainThread = EMSCRIPTEN_WEBGL_CONTEXT_PROXY_FALLBACK;
+#endif
 
 		webgl_ctx = emscripten_webgl_create_context(canvas_id, &attributes);
 		webgl2_inited = webgl_ctx && emscripten_webgl_make_context_current(webgl_ctx) == EMSCRIPTEN_RESULT_SUCCESS;
@@ -1160,6 +1170,12 @@ DisplayServerWeb::DisplayServerWeb(const String &p_rendering_driver, DisplayServ
 #else
 	RasterizerDummy::make_current();
 #endif
+
+	// Register canvas thread.
+	setup_canvas_proxying(godot_js_display_check_canvas() != 0);
+
+	// Refresh offscreen canvas if needed.
+	emscripten_set_canvas_element_size(canvas_id, initial_size[0], initial_size[1]);
 
 	// JS Input interface (js/libs/library_godot_input.js)
 	godot_js_input_mouse_button_cb(&DisplayServerWeb::mouse_button_callback);
@@ -1196,6 +1212,8 @@ DisplayServerWeb::~DisplayServerWeb() {
 		emscripten_webgl_destroy_context(webgl_ctx);
 	}
 #endif
+	godot_js_config_canvas_id_free();
+	canvas_id = nullptr;
 }
 
 bool DisplayServerWeb::has_feature(DisplayServerEnums::Feature p_feature) const {

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -80,7 +80,7 @@ private:
 
 	Array voices;
 
-	char canvas_id[256] = { 0 };
+	const char *canvas_id = nullptr;
 	bool cursor_inside_canvas = true;
 	DisplayServerEnums::CursorShape cursor_shape = DisplayServerEnums::CURSOR_ARROW;
 	Point2i last_click_pos = Point2(-100, -100); // TODO check this again.

--- a/platform/web/eslint.config.cjs
+++ b/platform/web/eslint.config.cjs
@@ -26,6 +26,8 @@ const emscriptenGlobals = {
 	'UTF8ToString': true,
 	'UTF8Decoder': true,
 	'_emscripten_webgl_get_current_context': true,
+	'_emscripten_set_canvas_element_size': true,
+	'_emscripten_get_canvas_element_size': true,
 	'_free': true,
 	'_malloc': true,
 	'autoAddDeps': true,

--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -43,7 +43,8 @@ extern char *godot_js_emscripten_get_version();
 
 // Config
 extern void godot_js_config_locale_get(char *p_ptr, int p_ptr_max);
-extern void godot_js_config_canvas_id_get(char *p_ptr, int p_ptr_max);
+extern const char *godot_js_config_canvas_id_allocate();
+extern void godot_js_config_canvas_id_free();
 
 // OS
 extern void godot_js_os_finish_async(void (*p_callback)());
@@ -95,6 +96,7 @@ extern void godot_js_display_alert(const char *p_text);
 extern int godot_js_display_touchscreen_is_available();
 extern int godot_js_display_is_swap_ok_cancel();
 extern void godot_js_display_setup_canvas(int p_width, int p_height, int p_fullscreen, int p_hidpi);
+extern int godot_js_display_check_canvas();
 
 // Display canvas
 extern void godot_js_display_canvas_focus();

--- a/platform/web/godot_webgl2.cpp
+++ b/platform/web/godot_webgl2.cpp
@@ -1,0 +1,202 @@
+/**************************************************************************/
+/*  godot_webgl2.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "godot_webgl2.h"
+
+#ifdef THREADS_ENABLED
+
+#include "core/os/memory.h"
+#include "core/templates/simple_type.h"
+
+#include <emscripten/proxying.h>
+#include <emscripten/threading.h>
+#include <pthread.h>
+
+#include <cstring>
+#include <type_traits>
+
+pthread_t web_canvas_thread;
+
+void setup_canvas_proxying(bool p_canvas_is_on_runtime) {
+	// Forward calls to the thread with WebGL context.
+	if (p_canvas_is_on_runtime) {
+		// Canvas is on the runtime thread.
+		web_canvas_thread = emscripten_main_runtime_thread_id();
+	} else {
+		// Offscren canvas is enabled and outside of the runtime thread.
+		// We are assuming that canvas is on the same thread that created
+		// the display server.
+		web_canvas_thread = pthread_self();
+	}
+}
+
+static _FORCE_INLINE_ bool is_canvas_thread() {
+	return web_canvas_thread == pthread_self();
+}
+
+template <typename R, typename... P, typename... VarArgs>
+static void proxy_canvas_sync(R (*p_func)(P...), VarArgs &&...p_args) {
+	using FuncType = R (*)(P... args);
+
+	// Declare pointers as const pointers to accept const references.
+	void const *argptrs[1 + sizeof...(p_args)];
+
+	// Store only pointers, as emscripten_proxy_sync waits for the function call to finish.
+	argptrs[0] = &p_func;
+	size_t index = 1;
+	([&] {
+		argptrs[index] = &p_args;
+		index += 1;
+	}(),
+			...);
+
+	emscripten_proxy_sync(
+			emscripten_proxy_get_system_queue(),
+			web_canvas_thread,
+			[](void *p_userdata) {
+				// Remove const from all stored pointers and add it when unpacking if needed.
+				void **argptrs = static_cast<void **>(p_userdata);
+
+				FuncType func = *static_cast<FuncType *>(argptrs[0]);
+				size_t index = 1;
+				// Dereference pointers after the lambda call, it allows references to bind directly
+				// to the actual values.
+				func(*[&] {
+					// Cast it back to a pointer, while preserving original constness.
+					using ArgMaybeConst = std::remove_reference_t<VarArgs>;
+					ArgMaybeConst *arg = static_cast<ArgMaybeConst *>(argptrs[index]);
+					index += 1;
+					return arg;
+				}()...);
+			},
+			argptrs);
+}
+
+template <typename R, typename... P, typename... VarArgs>
+static void proxy_canvas_async(R (*p_func)(P...), VarArgs &&...p_args) {
+	using FuncType = R (*)(P... args);
+	constexpr size_t func_size = sizeof(FuncType);
+	constexpr size_t buffer_size = func_size + (0 + ... + sizeof(GetSimpleTypeT<VarArgs>));
+
+	// Allocate buffer for function pointer + all arguments.
+	uint8_t *buffer = static_cast<uint8_t *>(memalloc(buffer_size));
+
+	// Copy function pointer to the buffer.
+	memcpy(buffer, &p_func, func_size);
+
+	// Begin offset after stored function pointer.
+	size_t offset = func_size;
+	([&] {
+		using ArgT = GetSimpleTypeT<VarArgs>;
+		// Copy arguments to the buffer while invoking appropriate copy or move constructors if they exist.
+		memnew_placement((buffer + offset), ArgT(std::forward<VarArgs>(p_args)));
+		offset += sizeof(ArgT);
+	}(),
+			...);
+
+	emscripten_proxy_async(
+			emscripten_proxy_get_system_queue(),
+			web_canvas_thread,
+			[](void *p_userdata) {
+				uint8_t *buffer = static_cast<uint8_t *>(p_userdata);
+				FuncType func;
+				// Copy function pointer back.
+				memcpy(&func, buffer, func_size);
+
+				size_t offset_call = func_size;
+				// Dereference pointers after the lambda call, references will be bound to the copy inside the buffer.
+				func(*[&] {
+					using ArgMaybeConst = std::remove_reference_t<VarArgs>;
+					using ArgT = GetSimpleTypeT<VarArgs>;
+					// std::launder is needed to prevent compiler optimizations and
+					// indicate that the value with type ArgT * actually exists here.
+					ArgT *arg = std::launder(reinterpret_cast<ArgT *>(buffer + offset_call));
+					offset_call += sizeof(ArgT);
+					// Add const to the argument if it was passed with const, preserves correct semantics
+					// and won't allow you to pass const argument to non-const function parameter.
+					return static_cast<ArgMaybeConst *>(arg);
+				}()...);
+
+				size_t offset_dstr = func_size;
+				([&] {
+					using ArgT = GetSimpleTypeT<VarArgs>;
+					// Call destructor on the created with memnew_placement values.
+					std::launder(reinterpret_cast<ArgT *>(buffer + offset_dstr))->~ArgT();
+					offset_dstr += sizeof(ArgT);
+				}(),
+						...);
+
+				// Deallocate buffer.
+				memfree(buffer);
+			},
+			buffer);
+}
+
+void godot_webgl2_glFramebufferTextureMultiviewOVRDirect(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint baseViewIndex, GLsizei numViews) {
+	if (!is_canvas_thread()) {
+		proxy_canvas_sync(godot_webgl2_glFramebufferTextureMultiviewOVR, target, attachment, texture, level, baseViewIndex, numViews);
+		return;
+	}
+	godot_webgl2_glFramebufferTextureMultiviewOVR(target, attachment, texture, level, baseViewIndex, numViews);
+}
+
+void godot_webgl2_glFramebufferTextureMultisampleMultiviewOVRDirect(GLenum target, GLenum attachment, GLuint texture, GLint level, GLsizei samples, GLint baseViewIndex, GLsizei numViews) {
+	if (!is_canvas_thread()) {
+		proxy_canvas_sync(godot_webgl2_glFramebufferTextureMultisampleMultiviewOVR, target, attachment, texture, level, samples, baseViewIndex, numViews);
+		return;
+	}
+	godot_webgl2_glFramebufferTextureMultisampleMultiviewOVR(target, attachment, texture, level, samples, baseViewIndex, numViews);
+}
+
+void godot_webgl2_glGetBufferSubDataDirect(GLenum target, GLintptr offset, GLsizeiptr size, GLvoid *data) {
+	if (!is_canvas_thread()) {
+		proxy_canvas_sync(godot_webgl2_wrapper_glGetBufferSubData, target, offset, size, data);
+		return;
+	}
+	godot_webgl2_wrapper_glGetBufferSubData(target, offset, size, data);
+}
+
+#else
+
+void setup_canvas_proxying(bool p_canvas_is_on_runtime) {}
+
+void godot_webgl2_glFramebufferTextureMultiviewOVRDirect(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint baseViewIndex, GLsizei numViews) {
+	godot_webgl2_glFramebufferTextureMultiviewOVR(target, attachment, texture, level, baseViewIndex, numViews);
+}
+
+void godot_webgl2_glFramebufferTextureMultisampleMultiviewOVRDirect(GLenum target, GLenum attachment, GLuint texture, GLint level, GLsizei samples, GLint baseViewIndex, GLsizei numViews) {
+	godot_webgl2_glFramebufferTextureMultisampleMultiviewOVR(target, attachment, texture, level, samples, baseViewIndex, numViews);
+}
+
+void godot_webgl2_glGetBufferSubDataDirect(GLenum target, GLintptr offset, GLsizeiptr size, GLvoid *data) {
+	godot_webgl2_wrapper_glGetBufferSubData(target, offset, size, data);
+}
+
+#endif

--- a/platform/web/js/engine/config.js
+++ b/platform/web/js/engine/config.js
@@ -250,6 +250,9 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 			}
 			return config[key];
 		}
+		// Common config
+		this.canvas = parse('canvas', this.canvas);
+
 		// Module config
 		this.unloadAfterInit = parse('unloadAfterInit', this.unloadAfterInit);
 		this.onPrintError = parse('onPrintError', this.onPrintError);
@@ -257,7 +260,6 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		this.onProgress = parse('onProgress', this.onProgress);
 
 		// Godot config
-		this.canvas = parse('canvas', this.canvas);
 		this.executable = parse('executable', this.executable);
 		this.mainPack = parse('mainPack', this.mainPack);
 		this.locale = parse('locale', this.locale);
@@ -278,13 +280,36 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 
 	/**
 	 * @ignore
+	 */
+	Config.prototype.checkCanvas = function () {
+		// Try to find a canvas
+		if (!(this.canvas instanceof HTMLCanvasElement)) {
+			const nodes = document.getElementsByTagName('canvas');
+			if (nodes.length && nodes[0] instanceof HTMLCanvasElement) {
+				const first = nodes[0];
+				this.canvas = /** @type {!HTMLCanvasElement} */ (first);
+			}
+			if (!this.canvas) {
+				throw new Error('No canvas found in page');
+			}
+		}
+	};
+
+	/**
+	 * @ignore
 	 * @param {string} loadPath
 	 * @param {Response} response
 	 */
 	Config.prototype.getModuleConfig = function (loadPath, response) {
+		// Try to find a canvas
+		this.checkCanvas();
+
 		let r = response;
 		const gdext = this.gdextensionLibs;
 		return {
+			// if OFFSCREENCANVAS_SUPPORT is enabled it will try to use it
+			// for OffscreenCanvas, does nothing otherwise.
+			'canvas': this.canvas,
 			'print': this.onPrint,
 			'printErr': this.onPrintError,
 			'thisProgram': this.executable,
@@ -332,16 +357,7 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 	 */
 	Config.prototype.getGodotConfig = function (cleanup) {
 		// Try to find a canvas
-		if (!(this.canvas instanceof HTMLCanvasElement)) {
-			const nodes = document.getElementsByTagName('canvas');
-			if (nodes.length && nodes[0] instanceof HTMLCanvasElement) {
-				const first = nodes[0];
-				this.canvas = /** @type {!HTMLCanvasElement} */ (first);
-			}
-			if (!this.canvas) {
-				throw new Error('No canvas found in page');
-			}
-		}
+		this.checkCanvas();
 		// Canvas can grab focus on click, or key events won't work.
 		if (this.canvas.tabIndex < 0) {
 			this.canvas.tabIndex = 0;

--- a/platform/web/js/engine/engine.js
+++ b/platform/web/js/engine/engine.js
@@ -249,6 +249,21 @@ const Engine = (function () {
 				}
 				return Promise.resolve();
 			},
+
+			/**
+			 * Sets the size of the canvas used by the engine.
+			 *
+			 * If offscreen canvas is used the control from the main canvas is transferred to the
+			 * offscreen canvas, which makes it impossible to set size on the main canvas directly.
+			 */
+			setCanvasSize: function (width, height) {
+				if (this.rtenv) {
+					this.rtenv['setCanvasSize'](width, height);
+				} else if (this.config.canvas && !this.config.canvas.controlTransferredOffscreen) {
+					this.config.canvas.width = width;
+					this.config.canvas.height = height;
+				}
+			},
 		};
 
 		Engine.prototype = proto;
@@ -260,6 +275,7 @@ const Engine = (function () {
 		Engine.prototype['copyToFS'] = Engine.prototype.copyToFS;
 		Engine.prototype['requestQuit'] = Engine.prototype.requestQuit;
 		Engine.prototype['installServiceWorker'] = Engine.prototype.installServiceWorker;
+		Engine.prototype['setCanvasSize'] = Engine.prototype.setCanvasSize;
 		// Also expose static methods as instance methods
 		Engine.prototype['load'] = Engine.load;
 		Engine.prototype['unload'] = Engine.unload;

--- a/platform/web/js/libs/library_godot_display.js
+++ b/platform/web/js/libs/library_godot_display.js
@@ -230,7 +230,8 @@ const GodotDisplayCursor = {
 mergeInto(LibraryManager.library, GodotDisplayCursor);
 
 const GodotDisplayScreen = {
-	$GodotDisplayScreen__deps: ['$GodotConfig', '$GodotOS', '$GL', 'emscripten_webgl_get_current_context'],
+	$GodotDisplayScreen__postset: 'Module["setCanvasSize"] = GodotDisplayScreen._setCanvasSize;',
+	$GodotDisplayScreen__deps: ['$GodotConfig', '$GodotOS', 'emscripten_set_canvas_element_size'],
 	$GodotDisplayScreen: {
 		desired_size: [0, 0],
 		hidpi: true,
@@ -289,11 +290,9 @@ const GodotDisplayScreen = {
 			}
 			return 0;
 		},
-		_updateGL: function () {
-			const gl_context_handle = _emscripten_webgl_get_current_context();
-			const gl = GL.getContext(gl_context_handle);
-			if (gl) {
-				GL.resizeOffscreenFramebuffer(gl);
+		_setCanvasSize: function (width, height) {
+			if (GodotConfig.canvas_id_ptr) {
+				_emscripten_set_canvas_element_size(GodotConfig.canvas_id_ptr, width, height);
 			}
 		},
 		updateSize: function () {
@@ -309,7 +308,7 @@ const GodotDisplayScreen = {
 				// Don't resize canvas, just update GL if needed.
 				if (canvas.width !== width || canvas.height !== height) {
 					GodotDisplayScreen.desired_size = [canvas.width, canvas.height];
-					GodotDisplayScreen._updateGL();
+					GodotDisplayScreen._setCanvasSize(canvas.width, canvas.height);
 					return 1;
 				}
 				return 0;
@@ -324,12 +323,10 @@ const GodotDisplayScreen = {
 			const csh = `${Math.floor(height / scale)}px`;
 			if (canvas.style.width !== csw || canvas.style.height !== csh || canvas.width !== width || canvas.height !== height) {
 				// Size doesn't match.
-				// Resize canvas, set correct CSS pixel size, update GL.
-				canvas.width = width;
-				canvas.height = height;
+				// Resize canvas, set correct CSS pixel size.
+				GodotDisplayScreen._setCanvasSize(width, height);
 				canvas.style.width = csw;
 				canvas.style.height = csh;
-				GodotDisplayScreen._updateGL();
 				return 1;
 			}
 			return 0;
@@ -514,11 +511,11 @@ const GodotDisplay = {
 		GodotRuntime.setHeapValue(height, window.screen.height * scale, 'i32');
 	},
 
+	godot_js_display_window_size_get__deps: ['emscripten_get_canvas_element_size'],
 	godot_js_display_window_size_get__proxy: 'sync',
 	godot_js_display_window_size_get__sig: 'vii',
 	godot_js_display_window_size_get: function (p_width, p_height) {
-		GodotRuntime.setHeapValue(p_width, GodotConfig.canvas.width, 'i32');
-		GodotRuntime.setHeapValue(p_height, GodotConfig.canvas.height, 'i32');
+		_emscripten_get_canvas_element_size(GodotConfig.canvas_id_ptr, p_width, p_height);
 	},
 
 	godot_js_display_has_webgl__proxy: 'sync',
@@ -766,6 +763,18 @@ const GodotDisplay = {
 		if (p_fullscreen) {
 			GodotDisplayScreen.requestFullscreen();
 		}
+	},
+
+	godot_js_display_check_canvas__deps: ['$GL'],
+	godot_js_display_check_canvas__proxy: 'sync',
+	godot_js_display_check_canvas__sig: 'i',
+	godot_js_display_check_canvas: function () {
+		// Canvas is an offscreen canvas and it is outside of the main thread.
+		if (GodotConfig.canvas.controlTransferredOffscreen && GL.offscreenCanvases[GodotConfig.canvas.id] === undefined) {
+			return 0;
+		}
+		// Canvas is on the main thread, either as offscreen canvas or a normal canvas.
+		return 1;
 	},
 
 	/*

--- a/platform/web/js/libs/library_godot_os.js
+++ b/platform/web/js/libs/library_godot_os.js
@@ -57,6 +57,7 @@ const GodotConfig = {
 	$GodotConfig__deps: ['$GodotRuntime'],
 	$GodotConfig: {
 		canvas: null,
+		canvas_id_ptr: null,
 		locale: 'en',
 		canvas_resize_policy: 2, // Adaptive
 		virtual_keyboard: false,
@@ -93,10 +94,22 @@ const GodotConfig = {
 		},
 	},
 
-	godot_js_config_canvas_id_get__proxy: 'sync',
-	godot_js_config_canvas_id_get__sig: 'vii',
-	godot_js_config_canvas_id_get: function (p_ptr, p_ptr_max) {
-		GodotRuntime.stringToHeap(`#${GodotConfig.canvas.id}`, p_ptr, p_ptr_max);
+	godot_js_config_canvas_id_allocate__proxy: 'sync',
+	godot_js_config_canvas_id_allocate__sig: 'p',
+	godot_js_config_canvas_id_allocate: function () {
+		if (!GodotConfig.canvas_id_ptr) {
+			GodotConfig.canvas_id_ptr = GodotRuntime.allocString(`#${GodotConfig.canvas.id}`);
+		}
+		return GodotConfig.canvas_id_ptr;
+	},
+
+	godot_js_config_canvas_id_free__proxy: 'sync',
+	godot_js_config_canvas_id_free__sig: 'v',
+	godot_js_config_canvas_id_free: function () {
+		if (GodotConfig.canvas_id_ptr) {
+			GodotRuntime.free(GodotConfig.canvas_id_ptr);
+			GodotConfig.canvas_id_ptr = null;
+		}
 	},
 
 	godot_js_config_locale_get__proxy: 'sync',

--- a/platform/web/js/libs/library_godot_webgl2.js
+++ b/platform/web/js/libs/library_godot_webgl2.js
@@ -34,10 +34,9 @@ const GodotWebGL2 = {
 
 	// This is implemented as "glGetBufferSubData" in new emscripten versions.
 	// Since we have to support older (pre 2.0.17) emscripten versions, we add this wrapper function instead.
-	godot_webgl2_glGetBufferSubData__proxy: 'sync',
-	godot_webgl2_glGetBufferSubData__sig: 'vippp',
-	godot_webgl2_glGetBufferSubData__deps: ['$GL', 'emscripten_webgl_get_current_context'],
-	godot_webgl2_glGetBufferSubData: function (target, offset, size, data) {
+	godot_webgl2_wrapper_glGetBufferSubData__sig: 'vippp',
+	godot_webgl2_wrapper_glGetBufferSubData__deps: ['$GL', 'emscripten_webgl_get_current_context'],
+	godot_webgl2_wrapper_glGetBufferSubData: function (target, offset, size, data) {
 		const gl_context_handle = _emscripten_webgl_get_current_context();
 		const gl = GL.getContext(gl_context_handle);
 		if (gl) {
@@ -46,7 +45,6 @@ const GodotWebGL2 = {
 	},
 
 	godot_webgl2_glFramebufferTextureMultiviewOVR__deps: ['emscripten_webgl_get_current_context'],
-	godot_webgl2_glFramebufferTextureMultiviewOVR__proxy: 'sync',
 	godot_webgl2_glFramebufferTextureMultiviewOVR__sig: 'viiiiii',
 	godot_webgl2_glFramebufferTextureMultiviewOVR: function (target, attachment, texture, level, base_view_index, num_views) {
 		const context = GL.currentContext;
@@ -63,7 +61,6 @@ const GodotWebGL2 = {
 	},
 
 	godot_webgl2_glFramebufferTextureMultisampleMultiviewOVR__deps: ['emscripten_webgl_get_current_context'],
-	godot_webgl2_glFramebufferTextureMultisampleMultiviewOVR__proxy: 'sync',
 	godot_webgl2_glFramebufferTextureMultisampleMultiviewOVR__sig: 'viiiiiii',
 	godot_webgl2_glFramebufferTextureMultisampleMultiviewOVR: function (target, attachment, texture, level, samples, base_view_index, num_views) {
 		const context = GL.currentContext;

--- a/platform/web/js/patches/set_offscreen_canvas_size.js
+++ b/platform/web/js/patches/set_offscreen_canvas_size.js
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  godot_webgl2.h                                                        */
+/*  set_offscreen_canvas_size.js                                          */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,32 +28,20 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
-
-#include <GLES3/gl3.h>
-#include <webgl/webgl2.h>
-
-#define GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR 0x9630
-#define GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR 0x9632
-#define GL_MAX_VIEWS_OVR 0x9631
-#define GL_FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR 0x9633
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-void godot_webgl2_glFramebufferTextureMultiviewOVR(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint baseViewIndex, GLsizei numViews);
-void godot_webgl2_glFramebufferTextureMultisampleMultiviewOVR(GLenum target, GLenum attachment, GLuint texture, GLint level, GLsizei samples, GLint baseViewIndex, GLsizei numViews);
-void godot_webgl2_wrapper_glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, GLvoid *data);
-
-void godot_webgl2_glFramebufferTextureMultiviewOVRDirect(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint baseViewIndex, GLsizei numViews);
-void godot_webgl2_glFramebufferTextureMultisampleMultiviewOVRDirect(GLenum target, GLenum attachment, GLuint texture, GLint level, GLsizei samples, GLint baseViewIndex, GLsizei numViews);
-void godot_webgl2_glGetBufferSubDataDirect(GLenum target, GLintptr offset, GLsizeiptr size, GLvoid *data);
-
-#define glFramebufferTextureMultiviewOVR godot_webgl2_glFramebufferTextureMultiviewOVRDirect
-#define glFramebufferTextureMultisampleMultiviewOVR godot_webgl2_glFramebufferTextureMultisampleMultiviewOVRDirect
-#define godot_webgl2_glGetBufferSubData godot_webgl2_glGetBufferSubDataDirect
-
-#ifdef __cplusplus
-}
-#endif
+// This is only needed if the offscreen canvas is being used on the main thread.
+// We are only calling it from JS, so it's fine that wasm is already imported the old version.
+// https://github.com/emscripten-core/emscripten/issues/26394
+const original_emscripten_set_canvas_element_size = _emscripten_set_canvas_element_size;
+_emscripten_set_canvas_element_size = (target, width, height) => {
+	const result = original_emscripten_set_canvas_element_size(target, width, height);
+	const canvasRecord = GL.offscreenCanvases[GodotRuntime.parseString(target).slice(1)];
+	if (canvasRecord && canvasRecord.canvas) {
+		const canvas = canvasRecord.canvas;
+		canvas.width = width;
+		canvas.height = height;
+		if (canvas.GLctxObject) {
+			GL.resizeOffscreenFramebuffer(canvas.GLctxObject);
+		}
+	}
+	return result;
+};

--- a/platform/web/web_main.cpp
+++ b/platform/web/web_main.cpp
@@ -58,17 +58,25 @@ static uint64_t target_ticks = 0;
 static bool main_started = false;
 static bool shutdown_complete = false;
 
+void delete_os() {
+	if (!predelete_handler(os)) {
+		return; // doesn't want to be deleted
+	}
+	delete os; // we used a normal new, so it needs a normal delete
+	os = nullptr;
+}
+
 void exit_callback() {
 	if (!shutdown_complete) {
 		return; // Still waiting.
 	}
+	emscripten_cancel_main_loop(); // We are exiting in this iteration.
 	if (main_started) {
 		Main::cleanup();
 		main_started = false;
 	}
 	int exit_code = OS_Web::get_singleton()->get_exit_code();
-	memdelete(os);
-	os = nullptr;
+	delete_os();
 	godot_cleanup_profiler();
 	emscripten_force_exit(exit_code); // Exit runtime.
 }


### PR DESCRIPTION
This PR adds support for OffscreenCanvas. If we look at https://web.dev/articles/offscreen-canvas this seems to boost performance if used together with `proxy_to_pthread`. So it will try to use offscreen canvas if proxy to pthread is enabled, but disable it otherwise.

The link to proxy to pthread pr: https://github.com/godotengine/godot/pull/79711. As of now Safari also supports it, and with `EMSCRIPTEN_WEBGL_CONTEXT_PROXY_FALLBACK` and enabled render via backbuffer it should also activate fallback if the offscreen canvas is not supported.

This is implemented as option, because it can also be enabled without proxy to pthread in both single and multi threaded builds. I'm not sure how useful it is, but it works.

This is mainly created so that the future C# multi-threading could be supported more easily. I don't know the full details of how it works, but the "main" C# thread is not a main runtime thread https://github.com/dotnet/runtime/issues/101421, so because of it multi-threaded C# works similar to `proxy_to_pthread`.

It was tested locally with web editor build by creating a Mesh inside MeshInstance3D, and launching and stopping project several times, and a separate simple project that used a method that called `godot_webgl2_glGetBufferSubData` from the main thread and a new separate thread in both debug and release export.

The main downside is that after creating offscreen canvas from the canvas, you can't change width and height on the canvas directly, it needs to be changed on the resulted `OffscreenCanvas` object that we got from it. So I used `emscripten_set_canvas_element_size`/`emscripten_get_canvas_element_size`, it automatically forwards new sizes to the correct thread and changes canvas/offscreen canvas correctly, it also calls `resizeOffscreenFramebuffer` for us. And to make it possible to change sizes from outside of the module I also added a new method `setCanvasSize` to the `Engine`. 

Various other changes:
- Enabling proxy to pthread now disables xr automatically. For now webxr can't be used inside worker thread's main loop as it's not supported, see the link inside this comment https://github.com/godotengine/godot/issues/83733#issuecomment-4165775205 
- Removed `-sTEXTDECODER=0` as the support for the value 0 was removed entirely.
> TEXTDECODER[](https://emscripten.org/docs/tools_reference/settings_reference.html#textdecoder)
> The default value or 1 means the generated code will use TextDecoder if available and fall back to custom decoder code when not available. If set to 2, we assume TextDecoder is present and usable, and do not emit any JS code to fall back if it is missing. **Setting this zero to avoid even conditional usage of TextDecoder is no longer supported**. Note: In -Oz builds, the default value of TEXTDECODER is set to 2, to save on code size (except when AUDIO_WORKLET is specified, or when shell is part of ENVIRONMENT since TextDecoder is not available in those environments).
- Removed `_emscripten_proxy_main` from exported methods, it was undefined in both Emscripten 4.0.0 and the latest at the moment version, and builds fine without it.
- `file_access_unix.cpp` needed `<cstdlib>` in a single-threaded export build for `mkstemp`. `movie_writer_ogv.cpp` needed `<cstdlib>` for `rand` and `srand` in a single-threaded editor web build.
- Single-threaded web editor dev build complained about calling user callback after abort or `emscripten_force_exit`, so exit callback now cancels itself with `emscripten_cancel_main_loop`. It also crashed on `memdelete(os)`, but worked correctly after I changed it to normal `delete` to match the normal `new` it was created with. Multi-threaded web editor worked fine, so I'm not sure why single-threaded build behaved this way.