### PR TITLE
Use physical key shortcuts for FOV adjustments in the 3D editor

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -10538,9 +10538,9 @@ Node3DEditor::Node3DEditor() {
 					int32_t(KeyModifierMask::ALT | KeyModifierMask::META | Key::G) });
 	ED_SHORTCUT("spatial_editor/align_rotation_with_view", TTRC("Align Rotation with View"), KeyModifierMask::ALT + KeyModifierMask::CMD_OR_CTRL + Key::F);
 	ED_SHORTCUT("spatial_editor/freelook_toggle", TTRC("Toggle Freelook"), KeyModifierMask::SHIFT + Key::F);
-	ED_SHORTCUT("spatial_editor/decrease_fov", TTRC("Decrease Field of View"), KeyModifierMask::CMD_OR_CTRL + Key::EQUAL); // Usually direct access key for `KEY_PLUS`.
-	ED_SHORTCUT("spatial_editor/increase_fov", TTRC("Increase Field of View"), KeyModifierMask::CMD_OR_CTRL + Key::MINUS);
-	ED_SHORTCUT("spatial_editor/reset_fov", TTRC("Reset Field of View to Default"), KeyModifierMask::CMD_OR_CTRL + Key::KEY_0);
+	ED_SHORTCUT("spatial_editor/decrease_fov", TTRC("Decrease Field of View"), Key::EQUAL, true); // Usually direct access key for `KEY_PLUS`.
+	ED_SHORTCUT("spatial_editor/increase_fov", TTRC("Increase Field of View"), Key::MINUS, true);
+	ED_SHORTCUT("spatial_editor/reset_fov", TTRC("Reset Field of View to Default"), Key::KEY_0);
 
 	PopupMenu *p;
 


### PR DESCRIPTION
This ensures shortcuts work out of the box on non-QWERTY keyboard layouts, at their intended location. This also removes the requirement to hold <kbd>Ctrl</kbd> to use the shortcuts, as there were no conflicting shortcuts. (It appears I didn't need to hold <kbd>Ctrl</kbd> in the first place, at least when **Emulate Numpad** is enabled, which is the default.)

Previously, on AZERTY, pressing <kbd>6</kbd> made the editor camera rotate to the left *and* increase its FOV, as <kbd>6</kbd> on AZERTY is also <kbd>-</kbd>. This conflict no longer occurs now.

This change also affects game embedding, as the shortcut is sent to the game process.

Note that this change will conflict with https://github.com/godotengine/godot/pull/117935 if we adopt the grid shortcuts proposed there (but not implemented there so far). What we should probably do is bind two different shortcuts by default, and have the grid size take priority in case of a conflict. This way, runtime camera FOV adjustments can use both shortcuts (as there is no grid to adjust at runtime), while the editor can use the one remaining shortcut that doesn't conflict.
