### PR TITLE
Add "Build C# project" to command palette

### DIFF
--- a/editor/settings/editor_command_palette.cpp
+++ b/editor/settings/editor_command_palette.cpp
@@ -188,7 +188,7 @@ void EditorCommandPalette::_confirmed() {
 	const String command_key = selected_option != nullptr ? selected_option->get_metadata(0) : "";
 	if (!command_key.is_empty()) {
 		hide();
-		callable_mp(this, &EditorCommandPalette::execute_command).call_deferred(command_key);
+		execute_command(command_key);
 	}
 }
 

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -533,6 +533,8 @@ namespace GodotTools
             // Move Build button so it appears to the left of the Play button.
             _toolBarBuildButton.GetParent().MoveChild(_toolBarBuildButton, 0);
 
+            EditorInterface.Singleton.GetCommandPalette().AddCommand("Build C# project".TTR(), "dotnet/build_solution", Callable.From(BuildProjectPressed), _toolBarBuildButton.Shortcut.GetAsText());
+
             if (File.Exists(GodotSharpDirs.ProjectCsProjPath))
             {
                 ApplyNecessaryChangesToSolution();


### PR DESCRIPTION
The "Build C# project" command opens the `EditorProgress` dialog and this seems to be disallowed in deferred calls, I would get this error:

```
Do not use progress dialog (task) while flushing the message queue or using call_deferred()!
```

But changing `EditorCommandPalette` to call `execute_command` directly instead of deferred seemed to fix it. There's likely a reason why it shouldn't be called directly, so if this is not the proper solution let me know if there's a better way to resolve the issues with `EditorProgress`.