### PR TITLE
Add fill rule optional argument to Geometry2D clipping functions

### DIFF
--- a/core/core_bind.compat.inc
+++ b/core/core_bind.compat.inc
@@ -63,6 +63,42 @@ void OS::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("execute_with_pipe", "path", "arguments"), &OS::_execute_with_pipe_bind_compat_94434);
 }
 
+// Geometry2D
+
+TypedArray<PackedVector2Array> Geometry2D::_merge_polygons_bind_compat_118171(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
+	return merge_polygons(p_polygon_a, p_polygon_b, PolyFillRule::FILL_EVEN_ODD);
+}
+
+TypedArray<PackedVector2Array> Geometry2D::_clip_polygons_bind_compat_118171(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
+	return clip_polygons(p_polygon_a, p_polygon_b, PolyFillRule::FILL_EVEN_ODD);
+}
+
+TypedArray<PackedVector2Array> Geometry2D::_intersect_polygons_bind_compat_118171(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
+	return intersect_polygons(p_polygon_a, p_polygon_b, PolyFillRule::FILL_EVEN_ODD);
+}
+
+TypedArray<PackedVector2Array> Geometry2D::_exclude_polygons_bind_compat_118171(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
+	return exclude_polygons(p_polygon_a, p_polygon_b, PolyFillRule::FILL_EVEN_ODD);
+}
+
+TypedArray<PackedVector2Array> Geometry2D::_clip_polyline_with_polygon_bind_compat_118171(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
+	return clip_polyline_with_polygon(p_polyline, p_polygon, PolyFillRule::FILL_EVEN_ODD);
+}
+
+TypedArray<PackedVector2Array> Geometry2D::_intersect_polyline_with_polygon_bind_compat_118171(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
+	return intersect_polyline_with_polygon(p_polyline, p_polygon, PolyFillRule::FILL_EVEN_ODD);
+}
+
+void Geometry2D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("merge_polygons", "polygon_a", "polygon_b"), &Geometry2D::_merge_polygons_bind_compat_118171);
+	ClassDB::bind_compatibility_method(D_METHOD("clip_polygons", "polygon_a", "polygon_b"), &Geometry2D::_clip_polygons_bind_compat_118171);
+	ClassDB::bind_compatibility_method(D_METHOD("intersect_polygons", "polygon_a", "polygon_b"), &Geometry2D::_intersect_polygons_bind_compat_118171);
+	ClassDB::bind_compatibility_method(D_METHOD("exclude_polygons", "polygon_a", "polygon_b"), &Geometry2D::_exclude_polygons_bind_compat_118171);
+
+	ClassDB::bind_compatibility_method(D_METHOD("clip_polyline_with_polygon", "polyline", "polygon"), &Geometry2D::_merge_polygons_bind_compat_118171);
+	ClassDB::bind_compatibility_method(D_METHOD("intersect_polyline_with_polygon", "polyline", "polygon"), &Geometry2D::_merge_polygons_bind_compat_118171);
+}
+
 } // namespace CoreBind
 
 #endif // DISABLE_DEPRECATED

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -981,8 +981,8 @@ TypedArray<PackedVector2Array> Geometry2D::decompose_polygon_in_convex(const Vec
 	return ret;
 }
 
-TypedArray<PackedVector2Array> Geometry2D::merge_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
-	Vector<Vector<Point2>> polys = ::Geometry2D::merge_polygons(p_polygon_a, p_polygon_b);
+TypedArray<PackedVector2Array> Geometry2D::merge_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b, PolyFillRule p_fill_rule) {
+	Vector<Vector<Point2>> polys = ::Geometry2D::merge_polygons(p_polygon_a, p_polygon_b, ::Geometry2D::PolyFillRule(p_fill_rule));
 
 	TypedArray<PackedVector2Array> ret;
 
@@ -992,8 +992,8 @@ TypedArray<PackedVector2Array> Geometry2D::merge_polygons(const Vector<Vector2> 
 	return ret;
 }
 
-TypedArray<PackedVector2Array> Geometry2D::clip_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
-	Vector<Vector<Point2>> polys = ::Geometry2D::clip_polygons(p_polygon_a, p_polygon_b);
+TypedArray<PackedVector2Array> Geometry2D::clip_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b, PolyFillRule p_fill_rule) {
+	Vector<Vector<Point2>> polys = ::Geometry2D::clip_polygons(p_polygon_a, p_polygon_b, ::Geometry2D::PolyFillRule(p_fill_rule));
 
 	TypedArray<PackedVector2Array> ret;
 
@@ -1003,8 +1003,8 @@ TypedArray<PackedVector2Array> Geometry2D::clip_polygons(const Vector<Vector2> &
 	return ret;
 }
 
-TypedArray<PackedVector2Array> Geometry2D::intersect_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
-	Vector<Vector<Point2>> polys = ::Geometry2D::intersect_polygons(p_polygon_a, p_polygon_b);
+TypedArray<PackedVector2Array> Geometry2D::intersect_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b, PolyFillRule p_fill_rule) {
+	Vector<Vector<Point2>> polys = ::Geometry2D::intersect_polygons(p_polygon_a, p_polygon_b, ::Geometry2D::PolyFillRule(p_fill_rule));
 
 	TypedArray<PackedVector2Array> ret;
 
@@ -1014,8 +1014,8 @@ TypedArray<PackedVector2Array> Geometry2D::intersect_polygons(const Vector<Vecto
 	return ret;
 }
 
-TypedArray<PackedVector2Array> Geometry2D::exclude_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
-	Vector<Vector<Point2>> polys = ::Geometry2D::exclude_polygons(p_polygon_a, p_polygon_b);
+TypedArray<PackedVector2Array> Geometry2D::exclude_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b, PolyFillRule p_fill_rule) {
+	Vector<Vector<Point2>> polys = ::Geometry2D::exclude_polygons(p_polygon_a, p_polygon_b, ::Geometry2D::PolyFillRule(p_fill_rule));
 
 	TypedArray<PackedVector2Array> ret;
 
@@ -1025,8 +1025,8 @@ TypedArray<PackedVector2Array> Geometry2D::exclude_polygons(const Vector<Vector2
 	return ret;
 }
 
-TypedArray<PackedVector2Array> Geometry2D::clip_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
-	Vector<Vector<Point2>> polys = ::Geometry2D::clip_polyline_with_polygon(p_polyline, p_polygon);
+TypedArray<PackedVector2Array> Geometry2D::clip_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon, PolyFillRule p_fill_rule) {
+	Vector<Vector<Point2>> polys = ::Geometry2D::clip_polyline_with_polygon(p_polyline, p_polygon, ::Geometry2D::PolyFillRule(p_fill_rule));
 
 	TypedArray<PackedVector2Array> ret;
 
@@ -1036,8 +1036,8 @@ TypedArray<PackedVector2Array> Geometry2D::clip_polyline_with_polygon(const Vect
 	return ret;
 }
 
-TypedArray<PackedVector2Array> Geometry2D::intersect_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
-	Vector<Vector<Point2>> polys = ::Geometry2D::intersect_polyline_with_polygon(p_polyline, p_polygon);
+TypedArray<PackedVector2Array> Geometry2D::intersect_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon, PolyFillRule p_fill_rule) {
+	Vector<Vector<Point2>> polys = ::Geometry2D::intersect_polyline_with_polygon(p_polyline, p_polygon, ::Geometry2D::PolyFillRule(p_fill_rule));
 
 	TypedArray<PackedVector2Array> ret;
 
@@ -1127,13 +1127,13 @@ void Geometry2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("convex_hull", "points"), &Geometry2D::convex_hull);
 	ClassDB::bind_method(D_METHOD("decompose_polygon_in_convex", "polygon"), &Geometry2D::decompose_polygon_in_convex);
 
-	ClassDB::bind_method(D_METHOD("merge_polygons", "polygon_a", "polygon_b"), &Geometry2D::merge_polygons);
-	ClassDB::bind_method(D_METHOD("clip_polygons", "polygon_a", "polygon_b"), &Geometry2D::clip_polygons);
-	ClassDB::bind_method(D_METHOD("intersect_polygons", "polygon_a", "polygon_b"), &Geometry2D::intersect_polygons);
-	ClassDB::bind_method(D_METHOD("exclude_polygons", "polygon_a", "polygon_b"), &Geometry2D::exclude_polygons);
+	ClassDB::bind_method(D_METHOD("merge_polygons", "polygon_a", "polygon_b", "fill_rule"), &Geometry2D::merge_polygons, DEFVAL(FILL_EVEN_ODD));
+	ClassDB::bind_method(D_METHOD("clip_polygons", "polygon_a", "polygon_b", "fill_rule"), &Geometry2D::clip_polygons, DEFVAL(FILL_EVEN_ODD));
+	ClassDB::bind_method(D_METHOD("intersect_polygons", "polygon_a", "polygon_b", "fill_rule"), &Geometry2D::intersect_polygons, DEFVAL(FILL_EVEN_ODD));
+	ClassDB::bind_method(D_METHOD("exclude_polygons", "polygon_a", "polygon_b", "fill_rule"), &Geometry2D::exclude_polygons, DEFVAL(FILL_EVEN_ODD));
 
-	ClassDB::bind_method(D_METHOD("clip_polyline_with_polygon", "polyline", "polygon"), &Geometry2D::clip_polyline_with_polygon);
-	ClassDB::bind_method(D_METHOD("intersect_polyline_with_polygon", "polyline", "polygon"), &Geometry2D::intersect_polyline_with_polygon);
+	ClassDB::bind_method(D_METHOD("clip_polyline_with_polygon", "polyline", "polygon", "fill_rule"), &Geometry2D::clip_polyline_with_polygon, DEFVAL(FILL_EVEN_ODD));
+	ClassDB::bind_method(D_METHOD("intersect_polyline_with_polygon", "polyline", "polygon", "fill_rule"), &Geometry2D::intersect_polyline_with_polygon, DEFVAL(FILL_EVEN_ODD));
 
 	ClassDB::bind_method(D_METHOD("offset_polygon", "polygon", "delta", "join_type"), &Geometry2D::offset_polygon, DEFVAL(JOIN_SQUARE));
 	ClassDB::bind_method(D_METHOD("offset_polyline", "polyline", "delta", "join_type", "end_type"), &Geometry2D::offset_polyline, DEFVAL(JOIN_SQUARE), DEFVAL(END_SQUARE));
@@ -1156,6 +1156,11 @@ void Geometry2D::_bind_methods() {
 	BIND_ENUM_CONSTANT(END_BUTT);
 	BIND_ENUM_CONSTANT(END_SQUARE);
 	BIND_ENUM_CONSTANT(END_ROUND);
+
+	BIND_ENUM_CONSTANT(FILL_EVEN_ODD);
+	BIND_ENUM_CONSTANT(FILL_NON_ZERO);
+	BIND_ENUM_CONSTANT(FILL_POSITIVE);
+	BIND_ENUM_CONSTANT(FILL_NEGATIVE);
 }
 
 ////// Geometry3D //////

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -329,6 +329,18 @@ class Geometry2D : public Object {
 protected:
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	TypedArray<PackedVector2Array> _merge_polygons_bind_compat_118171(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b);
+	TypedArray<PackedVector2Array> _clip_polygons_bind_compat_118171(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b);
+	TypedArray<PackedVector2Array> _intersect_polygons_bind_compat_118171(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b);
+	TypedArray<PackedVector2Array> _exclude_polygons_bind_compat_118171(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b);
+
+	TypedArray<PackedVector2Array> _clip_polyline_with_polygon_bind_compat_118171(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon);
+	TypedArray<PackedVector2Array> _intersect_polyline_with_polygon_bind_compat_118171(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon);
+
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
+
 public:
 	static Geometry2D *get_singleton();
 	Variant segment_intersects_segment(const Vector2 &p_from_a, const Vector2 &p_to_a, const Vector2 &p_from_b, const Vector2 &p_to_b);
@@ -354,15 +366,22 @@ public:
 		OPERATION_INTERSECTION,
 		OPERATION_XOR
 	};
+	enum PolyFillRule {
+		FILL_EVEN_ODD,
+		FILL_NON_ZERO,
+		FILL_POSITIVE,
+		FILL_NEGATIVE,
+	};
+
 	// 2D polygon boolean operations.
-	TypedArray<PackedVector2Array> merge_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b); // Union (add).
-	TypedArray<PackedVector2Array> clip_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b); // Difference (subtract).
-	TypedArray<PackedVector2Array> intersect_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b); // Common area (multiply).
-	TypedArray<PackedVector2Array> exclude_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b); // All but common area (xor).
+	TypedArray<PackedVector2Array> merge_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b, PolyFillRule p_fill_rule = PolyFillRule::FILL_EVEN_ODD); // Union (add).
+	TypedArray<PackedVector2Array> clip_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b, PolyFillRule p_fill_rule = PolyFillRule::FILL_EVEN_ODD); // Difference (subtract).
+	TypedArray<PackedVector2Array> intersect_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b, PolyFillRule p_fill_rule = PolyFillRule::FILL_EVEN_ODD); // Common area (multiply).
+	TypedArray<PackedVector2Array> exclude_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b, PolyFillRule p_fill_rule = PolyFillRule::FILL_EVEN_ODD); // All but common area (xor).
 
 	// 2D polyline vs polygon operations.
-	TypedArray<PackedVector2Array> clip_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon); // Cut.
-	TypedArray<PackedVector2Array> intersect_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon); // Chop.
+	TypedArray<PackedVector2Array> clip_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon, PolyFillRule p_fill_rule = PolyFillRule::FILL_EVEN_ODD); // Cut.
+	TypedArray<PackedVector2Array> intersect_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon, PolyFillRule p_fill_rule = PolyFillRule::FILL_EVEN_ODD); // Chop.
 
 	// 2D offset polygons/polylines.
 	enum PolyJoinType {
@@ -705,6 +724,7 @@ VARIANT_ENUM_CAST(CoreBind::OS::SystemDir);
 VARIANT_ENUM_CAST(CoreBind::OS::StdHandleType);
 
 VARIANT_ENUM_CAST(CoreBind::Geometry2D::PolyBooleanOperation);
+VARIANT_ENUM_CAST(CoreBind::Geometry2D::PolyFillRule);
 VARIANT_ENUM_CAST(CoreBind::Geometry2D::PolyJoinType);
 VARIANT_ENUM_CAST(CoreBind::Geometry2D::PolyEndType);
 

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -247,7 +247,7 @@ void Geometry2D::make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_re
 	r_size = Size2(results[best].max_w, results[best].max_h);
 }
 
-Vector<Vector<Point2>> Geometry2D::_polypaths_do_operation(PolyBooleanOperation p_op, const Vector<Point2> &p_polypath_a, const Vector<Point2> &p_polypath_b, bool is_a_open) {
+Vector<Vector<Point2>> Geometry2D::_polypaths_do_operation(PolyBooleanOperation p_op, const Vector<Point2> &p_polypath_a, const Vector<Point2> &p_polypath_b, bool is_a_open, PolyFillRule p_fill_rule) {
 	using namespace Clipper2Lib;
 
 	ClipType op = ClipType::Union;
@@ -264,6 +264,22 @@ Vector<Vector<Point2>> Geometry2D::_polypaths_do_operation(PolyBooleanOperation 
 			break;
 		case OPERATION_XOR:
 			op = ClipType::Xor;
+			break;
+	}
+
+	FillRule fill_rule = FillRule::EvenOdd;
+	switch (p_fill_rule) {
+		case FILL_EVEN_ODD:
+			fill_rule = FillRule::EvenOdd;
+			break;
+		case FILL_NON_ZERO:
+			fill_rule = FillRule::NonZero;
+			break;
+		case FILL_NEGATIVE:
+			fill_rule = FillRule::Negative;
+			break;
+		case FILL_POSITIVE:
+			fill_rule = FillRule::Positive;
 			break;
 	}
 
@@ -289,9 +305,9 @@ Vector<Vector<Point2>> Geometry2D::_polypaths_do_operation(PolyBooleanOperation 
 
 	if (is_a_open) {
 		PolyTreeD tree; // Needed to populate polylines.
-		clp.Execute(op, FillRule::EvenOdd, tree, paths);
+		clp.Execute(op, fill_rule, tree, paths);
 	} else {
-		clp.Execute(op, FillRule::EvenOdd, paths); // Works on closed polygons only.
+		clp.Execute(op, fill_rule, paths); // Works on closed polygons only.
 	}
 
 	Vector<Vector<Point2>> polypaths;

--- a/core/math/geometry_2d.h
+++ b/core/math/geometry_2d.h
@@ -303,29 +303,35 @@ public:
 		END_SQUARE,
 		END_ROUND
 	};
+	enum PolyFillRule {
+		FILL_EVEN_ODD,
+		FILL_NON_ZERO,
+		FILL_POSITIVE,
+		FILL_NEGATIVE,
+	};
 
-	static Vector<Vector<Point2>> merge_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
-		return _polypaths_do_operation(OPERATION_UNION, p_polygon_a, p_polygon_b);
+	static Vector<Vector<Point2>> merge_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, PolyFillRule p_fill_rule = PolyFillRule::FILL_EVEN_ODD) {
+		return _polypaths_do_operation(OPERATION_UNION, p_polygon_a, p_polygon_b, false, p_fill_rule);
 	}
 
-	static Vector<Vector<Point2>> clip_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
-		return _polypaths_do_operation(OPERATION_DIFFERENCE, p_polygon_a, p_polygon_b);
+	static Vector<Vector<Point2>> clip_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, PolyFillRule p_fill_rule = PolyFillRule::FILL_EVEN_ODD) {
+		return _polypaths_do_operation(OPERATION_DIFFERENCE, p_polygon_a, p_polygon_b, false, p_fill_rule);
 	}
 
-	static Vector<Vector<Point2>> intersect_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
-		return _polypaths_do_operation(OPERATION_INTERSECTION, p_polygon_a, p_polygon_b);
+	static Vector<Vector<Point2>> intersect_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, PolyFillRule p_fill_rule = PolyFillRule::FILL_EVEN_ODD) {
+		return _polypaths_do_operation(OPERATION_INTERSECTION, p_polygon_a, p_polygon_b, false, p_fill_rule);
 	}
 
-	static Vector<Vector<Point2>> exclude_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
-		return _polypaths_do_operation(OPERATION_XOR, p_polygon_a, p_polygon_b);
+	static Vector<Vector<Point2>> exclude_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, PolyFillRule p_fill_rule = PolyFillRule::FILL_EVEN_ODD) {
+		return _polypaths_do_operation(OPERATION_XOR, p_polygon_a, p_polygon_b, false, p_fill_rule);
 	}
 
-	static Vector<Vector<Point2>> clip_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
-		return _polypaths_do_operation(OPERATION_DIFFERENCE, p_polyline, p_polygon, true);
+	static Vector<Vector<Point2>> clip_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon, PolyFillRule p_fill_rule = PolyFillRule::FILL_EVEN_ODD) {
+		return _polypaths_do_operation(OPERATION_DIFFERENCE, p_polyline, p_polygon, true, p_fill_rule);
 	}
 
-	static Vector<Vector<Point2>> intersect_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
-		return _polypaths_do_operation(OPERATION_INTERSECTION, p_polyline, p_polygon, true);
+	static Vector<Vector<Point2>> intersect_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon, PolyFillRule p_fill_rule = PolyFillRule::FILL_EVEN_ODD) {
+		return _polypaths_do_operation(OPERATION_INTERSECTION, p_polyline, p_polygon, true, p_fill_rule);
 	}
 
 	static Vector<Vector<Point2>> offset_polygon(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type) {
@@ -508,6 +514,6 @@ public:
 	static Vector<Vector3i> partial_pack_rects(const Vector<Vector2i> &p_sizes, const Size2i &p_atlas_size);
 
 private:
-	static Vector<Vector<Point2>> _polypaths_do_operation(PolyBooleanOperation p_op, const Vector<Point2> &p_polypath_a, const Vector<Point2> &p_polypath_b, bool is_a_open = false);
+	static Vector<Vector<Point2>> _polypaths_do_operation(PolyBooleanOperation p_op, const Vector<Point2> &p_polypath_a, const Vector<Point2> &p_polypath_b, bool is_a_open = false, PolyFillRule p_fill_rule = PolyFillRule::FILL_EVEN_ODD);
 	static Vector<Vector<Point2>> _polypath_offset(const Vector<Point2> &p_polypath, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type);
 };

--- a/doc/classes/Geometry2D.xml
+++ b/doc/classes/Geometry2D.xml
@@ -27,8 +27,9 @@
 			<return type="PackedVector2Array[]" />
 			<param index="0" name="polygon_a" type="PackedVector2Array" />
 			<param index="1" name="polygon_b" type="PackedVector2Array" />
+			<param index="2" name="fill_rule" type="int" enum="Geometry2D.PolyFillRule" default="0" />
 			<description>
-				Clips [param polygon_a] against [param polygon_b] and returns an array of clipped polygons. This performs [constant OPERATION_DIFFERENCE] between polygons. Returns an empty array if [param polygon_b] completely overlaps [param polygon_a].
+				Clips [param polygon_a] against [param polygon_b] using [param fill_rule] and returns an array of clipped polygons. This performs [constant OPERATION_DIFFERENCE] between polygons. Returns an empty array if [param polygon_b] completely overlaps [param polygon_a].
 				If [param polygon_b] is enclosed by [param polygon_a], returns an outer polygon (boundary) and inner polygon (hole) which could be distinguished by calling [method is_polygon_clockwise].
 			</description>
 		</method>
@@ -36,8 +37,9 @@
 			<return type="PackedVector2Array[]" />
 			<param index="0" name="polyline" type="PackedVector2Array" />
 			<param index="1" name="polygon" type="PackedVector2Array" />
+			<param index="2" name="fill_rule" type="int" enum="Geometry2D.PolyFillRule" default="0" />
 			<description>
-				Clips [param polyline] against [param polygon] and returns an array of clipped polylines. This performs [constant OPERATION_DIFFERENCE] between the polyline and the polygon. This operation can be thought of as cutting a line with a closed shape.
+				Clips [param polyline] against [param polygon] using [param fill_rule] and returns an array of clipped polylines. This performs [constant OPERATION_DIFFERENCE] between the polyline and the polygon. This operation can be thought of as cutting a line with a closed shape.
 			</description>
 		</method>
 		<method name="convex_hull">
@@ -58,8 +60,9 @@
 			<return type="PackedVector2Array[]" />
 			<param index="0" name="polygon_a" type="PackedVector2Array" />
 			<param index="1" name="polygon_b" type="PackedVector2Array" />
+			<param index="2" name="fill_rule" type="int" enum="Geometry2D.PolyFillRule" default="0" />
 			<description>
-				Mutually excludes common area defined by intersection of [param polygon_a] and [param polygon_b] (see [method intersect_polygons]) and returns an array of excluded polygons. This performs [constant OPERATION_XOR] between polygons. In other words, returns all but common area between polygons.
+				Mutually excludes common area defined by intersection of [param polygon_a] and [param polygon_b] (see [method intersect_polygons]) using [param fill_rule] and returns an array of excluded polygons. This performs [constant OPERATION_XOR] between polygons. In other words, returns all but common area between polygons.
 				The operation may result in an outer polygon (boundary) and inner polygon (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
 			</description>
 		</method>
@@ -95,8 +98,9 @@
 			<return type="PackedVector2Array[]" />
 			<param index="0" name="polygon_a" type="PackedVector2Array" />
 			<param index="1" name="polygon_b" type="PackedVector2Array" />
+			<param index="2" name="fill_rule" type="int" enum="Geometry2D.PolyFillRule" default="0" />
 			<description>
-				Intersects [param polygon_a] with [param polygon_b] and returns an array of intersected polygons. This performs [constant OPERATION_INTERSECTION] between polygons. In other words, returns common area shared by polygons. Returns an empty array if no intersection occurs.
+				Intersects [param polygon_a] with [param polygon_b] using [param fill_rule] and returns an array of intersected polygons. This performs [constant OPERATION_INTERSECTION] between polygons. In other words, returns common area shared by polygons. Returns an empty array if no intersection occurs.
 				The operation may result in an outer polygon (boundary) and inner polygon (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
 			</description>
 		</method>
@@ -104,8 +108,9 @@
 			<return type="PackedVector2Array[]" />
 			<param index="0" name="polyline" type="PackedVector2Array" />
 			<param index="1" name="polygon" type="PackedVector2Array" />
+			<param index="2" name="fill_rule" type="int" enum="Geometry2D.PolyFillRule" default="0" />
 			<description>
-				Intersects [param polyline] with [param polygon] and returns an array of intersected polylines. This performs [constant OPERATION_INTERSECTION] between the polyline and the polygon. This operation can be thought of as chopping a line with a closed shape.
+				Intersects [param polyline] with [param polygon] using [param fill_rule] and returns an array of intersected polylines. This performs [constant OPERATION_INTERSECTION] between the polyline and the polygon. This operation can be thought of as chopping a line with a closed shape.
 			</description>
 		</method>
 		<method name="is_point_in_circle">
@@ -181,8 +186,9 @@
 			<return type="PackedVector2Array[]" />
 			<param index="0" name="polygon_a" type="PackedVector2Array" />
 			<param index="1" name="polygon_b" type="PackedVector2Array" />
+			<param index="2" name="fill_rule" type="int" enum="Geometry2D.PolyFillRule" default="0" />
 			<description>
-				Merges (combines) [param polygon_a] and [param polygon_b] and returns an array of merged polygons. This performs [constant OPERATION_UNION] between polygons.
+				Merges (combines) [param polygon_a] and [param polygon_b] using [param fill_rule] and returns an array of merged polygons. This performs [constant OPERATION_UNION] between polygons.
 				The operation may result in an outer polygon (boundary) and multiple inner polygons (holes) produced which could be distinguished by calling [method is_polygon_clockwise].
 			</description>
 		</method>
@@ -306,6 +312,18 @@
 		</constant>
 		<constant name="END_ROUND" value="4" enum="PolyEndType">
 			Endpoints are rounded off and extended by [code]delta[/code] units.
+		</constant>
+		<constant name="FILL_EVEN_ODD" value="0" enum="PolyFillRule">
+			Only sub-regions with odd winding numbers are filled.
+		</constant>
+		<constant name="FILL_NON_ZERO" value="1" enum="PolyFillRule">
+			Only sub-regions with non-zero winding numbers are filled.
+		</constant>
+		<constant name="FILL_POSITIVE" value="2" enum="PolyFillRule">
+			Only sub-regions with positive winding counts are filled.
+		</constant>
+		<constant name="FILL_NEGATIVE" value="3" enum="PolyFillRule">
+			Only sub-regions with negative winding counts are filled.
 		</constant>
 	</constants>
 </class>

--- a/misc/extension_api_validation/4.6-stable/GH-118171.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-118171.txt
@@ -1,0 +1,14 @@
+GH-118171
+---------
+
+Validate extension JSON: Error: Field 'classes/Geometry2D/methods/merge_polygons/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/Geometry2D/methods/clip_polygons/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/Geometry2D/methods/intersect_polygons/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/Geometry2D/methods/exclude_polygons/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/Geometry2D/methods/clip_polyline_with_polygon/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/Geometry2D/methods/intersect_polyline_with_polygon/arguments': size changed value in new API, from 2 to 3.
+
+Added optional "fill_rule" argument to all polygon clipping functions (merge_polygons, clip_polygons, intersect_polygons and exclude_polygons),
+as well as all the polyline clipping functions (clip_polyline_with_polygon, intersect_polyline_with_polygon).
+Default value of optional argument guarantees previous behavior.
+Compatibility methods registered.


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5402

Allow specifying the fill rule for all the 4 polygon clipping operations and the 2 polyline clipping operations.

The fill rule argument is optional and defaults to "even-odd", which was the fixed value before the changes in this PR. As such, current code will continue to work exactly as before.