### PR TITLE
Add `ImageFormatLoader` support for DDS textures

### DIFF
--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -116,6 +116,17 @@ void ImageLoader::get_recognized_extensions(List<String> *p_extensions) {
 	}
 }
 
+// Some texture formats should be imported as is, and are thus ignored by the various editor importers
+void ImageLoader::get_editor_importer_recognized_extensions(List<String> *p_extensions) {
+	List<String> loader_extensions;
+	ImageLoader::get_recognized_extensions(&loader_extensions);
+	for (const String &extension : loader_extensions) {
+		if (extension.nocasecmp_to("dds") != 0) {
+			p_extensions->push_back(extension);
+		}
+	}
+}
+
 Ref<ImageFormatLoader> ImageLoader::recognize(const String &p_extension) {
 	for (int i = 0; i < loader.size(); i++) {
 		if (loader[i]->recognize(p_extension)) {

--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -90,6 +90,7 @@ protected:
 public:
 	static Error load_image(const String &p_file, Ref<Image> p_image, Ref<FileAccess> p_custom = Ref<FileAccess>(), BitField<ImageFormatLoader::LoaderFlags> p_flags = ImageFormatLoader::FLAG_NONE, float p_scale = 1.0);
 	static void get_recognized_extensions(List<String> *p_extensions);
+	static void get_editor_importer_recognized_extensions(List<String> *p_extensions);
 	static Ref<ImageFormatLoader> recognize(const String &p_extension);
 
 	static void add_image_format_loader(Ref<ImageFormatLoader> p_loader);

--- a/editor/import/resource_importer_bitmask.cpp
+++ b/editor/import/resource_importer_bitmask.cpp
@@ -44,7 +44,7 @@ String ResourceImporterBitMap::get_visible_name() const {
 }
 
 void ResourceImporterBitMap::get_recognized_extensions(List<String> *p_extensions) const {
-	ImageLoader::get_recognized_extensions(p_extensions);
+	ImageLoader::get_editor_importer_recognized_extensions(p_extensions);
 }
 
 String ResourceImporterBitMap::get_save_extension() const {

--- a/editor/import/resource_importer_image.cpp
+++ b/editor/import/resource_importer_image.cpp
@@ -42,7 +42,7 @@ String ResourceImporterImage::get_visible_name() const {
 }
 
 void ResourceImporterImage::get_recognized_extensions(List<String> *p_extensions) const {
-	ImageLoader::get_recognized_extensions(p_extensions);
+	ImageLoader::get_editor_importer_recognized_extensions(p_extensions);
 }
 
 String ResourceImporterImage::get_save_extension() const {

--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -45,7 +45,7 @@ String ResourceImporterImageFont::get_visible_name() const {
 
 void ResourceImporterImageFont::get_recognized_extensions(List<String> *p_extensions) const {
 	if (p_extensions) {
-		ImageLoader::get_recognized_extensions(p_extensions);
+		ImageLoader::get_editor_importer_recognized_extensions(p_extensions);
 	}
 }
 

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -78,7 +78,7 @@ String ResourceImporterLayeredTexture::get_visible_name() const {
 }
 
 void ResourceImporterLayeredTexture::get_recognized_extensions(List<String> *p_extensions) const {
-	ImageLoader::get_recognized_extensions(p_extensions);
+	ImageLoader::get_editor_importer_recognized_extensions(p_extensions);
 }
 
 String ResourceImporterLayeredTexture::get_save_extension() const {

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -168,7 +168,7 @@ String ResourceImporterTexture::get_visible_name() const {
 }
 
 void ResourceImporterTexture::get_recognized_extensions(List<String> *p_extensions) const {
-	ImageLoader::get_recognized_extensions(p_extensions);
+	ImageLoader::get_editor_importer_recognized_extensions(p_extensions);
 }
 
 String ResourceImporterTexture::get_save_extension() const {

--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -51,7 +51,7 @@ String ResourceImporterTextureAtlas::get_visible_name() const {
 }
 
 void ResourceImporterTextureAtlas::get_recognized_extensions(List<String> *p_extensions) const {
-	ImageLoader::get_recognized_extensions(p_extensions);
+	ImageLoader::get_editor_importer_recognized_extensions(p_extensions);
 }
 
 String ResourceImporterTextureAtlas::get_save_extension() const {

--- a/modules/dds/image_loader_dds.cpp
+++ b/modules/dds/image_loader_dds.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  register_types.cpp                                                    */
+/*  image_loader_dds.cpp                                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "register_types.h"
-
 #include "image_loader_dds.h"
-#include "image_saver_dds.h"
-#include "texture_loader_dds.h"
 
-#include "core/io/resource_loader.h"
-#include "core/object/class_db.h"
-#include "scene/resources/texture.h"
-
-static Ref<ImageLoaderDDS> image_loader_dds;
-static Ref<ResourceFormatDDS> resource_loader_dds;
-
-void initialize_dds_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-
-	Image::save_dds_func = save_dds;
-	Image::save_dds_buffer_func = save_dds_buffer;
-
-	image_loader_dds.instantiate();
-	ImageLoader::add_image_format_loader(image_loader_dds);
-
-	if constexpr (GD_IS_CLASS_ENABLED(Texture)) {
-		resource_loader_dds.instantiate();
-		ResourceLoader::add_resource_format_loader(resource_loader_dds);
-	}
+Error ImageLoaderDDS::load_image(Ref<Image> p_image, Ref<FileAccess> file, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
+	Ref<Image> dds_image = load_file_dds(file);
+	p_image->copy_internals_from(dds_image);
+	return OK;
 }
 
-void uninitialize_dds_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-
-	if constexpr (GD_IS_CLASS_ENABLED(Texture)) {
-		ResourceLoader::remove_resource_format_loader(resource_loader_dds);
-		resource_loader_dds.unref();
-	}
-
-	Image::save_dds_func = nullptr;
-	Image::save_dds_buffer_func = nullptr;
-
-	ImageLoader::remove_image_format_loader(image_loader_dds);
-	image_loader_dds.unref();
+void ImageLoaderDDS::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("dds");
 }

--- a/modules/dds/image_loader_dds.h
+++ b/modules/dds/image_loader_dds.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  register_types.cpp                                                    */
+/*  image_loader_dds.h                                                    */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "register_types.h"
+#pragma once
 
-#include "image_loader_dds.h"
-#include "image_saver_dds.h"
-#include "texture_loader_dds.h"
+#include "core/io/image_loader.h"
 
-#include "core/io/resource_loader.h"
-#include "core/object/class_db.h"
-#include "scene/resources/texture.h"
+Ref<Image> load_file_dds(Ref<FileAccess> file);
 
-static Ref<ImageLoaderDDS> image_loader_dds;
-static Ref<ResourceFormatDDS> resource_loader_dds;
-
-void initialize_dds_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-
-	Image::save_dds_func = save_dds;
-	Image::save_dds_buffer_func = save_dds_buffer;
-
-	image_loader_dds.instantiate();
-	ImageLoader::add_image_format_loader(image_loader_dds);
-
-	if constexpr (GD_IS_CLASS_ENABLED(Texture)) {
-		resource_loader_dds.instantiate();
-		ResourceLoader::add_resource_format_loader(resource_loader_dds);
-	}
-}
-
-void uninitialize_dds_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-
-	if constexpr (GD_IS_CLASS_ENABLED(Texture)) {
-		ResourceLoader::remove_resource_format_loader(resource_loader_dds);
-		resource_loader_dds.unref();
-	}
-
-	Image::save_dds_func = nullptr;
-	Image::save_dds_buffer_func = nullptr;
-
-	ImageLoader::remove_image_format_loader(image_loader_dds);
-	image_loader_dds.unref();
-}
+class ImageLoaderDDS : public ImageFormatLoader {
+public:
+	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
+	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+};

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -748,6 +748,16 @@ String ResourceFormatDDS::get_resource_type(const String &p_path) const {
 	return "";
 }
 
+Ref<Image> load_file_dds(Ref<FileAccess> file) {
+	DDSFormat dds_format;
+	uint32_t width, height, mipmaps, pitch, flags, layer_count, dds_type;
+
+	Vector<Ref<Image>> images = _dds_load_images_from_buffer(file, dds_format, width, height, mipmaps, pitch, flags, layer_count, dds_type);
+	ERR_FAIL_COND_V_MSG(images.is_empty(), Ref<Image>(), "Failed to load DDS image.");
+
+	return images[0];
+}
+
 Ref<Image> load_mem_dds(const uint8_t *p_dds, int p_size) {
 	ERR_FAIL_NULL_V(p_dds, Ref<Image>());
 	ERR_FAIL_COND_V(!p_size, Ref<Image>());
@@ -756,13 +766,7 @@ Ref<Image> load_mem_dds(const uint8_t *p_dds, int p_size) {
 	Error open_memfile_error = memfile->open_custom(p_dds, p_size);
 	ERR_FAIL_COND_V_MSG(open_memfile_error, Ref<Image>(), "Could not create memfile for DDS image buffer.");
 
-	DDSFormat dds_format;
-	uint32_t width, height, mipmaps, pitch, flags, layer_count, dds_type;
-
-	Vector<Ref<Image>> images = _dds_load_images_from_buffer(memfile, dds_format, width, height, mipmaps, pitch, flags, layer_count, dds_type);
-	ERR_FAIL_COND_V_MSG(images.is_empty(), Ref<Image>(), "Failed to load DDS image.");
-
-	return images[0];
+	return load_file_dds(memfile);
 }
 
 ResourceFormatDDS::ResourceFormatDDS() {


### PR DESCRIPTION
Loading DDS files as images has been supported for some time now https://github.com/godotengine/godot/pull/101994/ but has lacked integration with `ImageFormatLoader`. This results in functions such as `Image.load_from_file()` which rely on `ImageLoader` not working, while functions like `Image.load_dds_from_buffer()` do work. This PR adds a trivial `ImageFormatLoader` implementation that hooks into the existing DDS image loading functionality.