### PR TITLE
Fix BaseButton shortcut firing pressed on key down instead of up

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -437,7 +437,14 @@ void BaseButton::_shortcut_feedback_timeout() {
 void BaseButton::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
-	if (!is_disabled() && p_event->is_pressed() && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->matches_event(p_event)) {
+	bool action_mode_match = false;
+	if (action_mode == ACTION_MODE_BUTTON_PRESS && p_event->is_pressed()) {
+		action_mode_match = true;
+	} else if (action_mode == ACTION_MODE_BUTTON_RELEASE && p_event->is_released()) {
+		action_mode_match = true;
+	}
+
+	if (!is_disabled() && action_mode_match && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->matches_event(p_event)) {
 		if (toggle_mode) {
 			status.pressed = !status.pressed;
 


### PR DESCRIPTION
Fix #118133.

Shortcut input handler in BaseButton only checked if the input was pressed without taking into account the action mode of the button.

Fix: Add a check if the button is released or pressed depending on the action mode.