### PR TITLE
[Web] Fix `poll_export` changing current export_preset

### DIFF
--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -624,11 +624,14 @@ bool EditorExportPlatformWeb::poll_export() {
 
 	if (preset.is_valid()) {
 		const bool debug = true;
-		// Throwaway variables to pass to `can_export`.
+		// Throwaway variables to pass to validation functions.
 		String err;
 		bool missing_templates;
 
-		if (can_export(preset, err, missing_templates, debug)) {
+		bool valid = has_valid_export_configuration(preset, err, missing_templates, debug) &&
+				has_valid_project_configuration(preset, err);
+
+		if (valid) {
 			if (server->is_listening()) {
 				remote_debug_state = REMOTE_DEBUG_STATE_SERVING;
 			} else {


### PR DESCRIPTION
Fixes #115994

`EditorExportPlatformWeb::poll_export` was calling `EditorExportPlatform::can_export`, which iterates through the export plugins and ends up changing their `export_preset` field to check for configuration warnings. These warnings were propagated to `poll_export`, but they were not used for anything. `poll_export` gets called constantly, even while an export is ongoing, so the `export_preset` might change between calls to `EditorExportPlugin::_export_begin` and `EditorExportPlugin::_export_end`.

This PR replaces the call to `can_export` with the two calls inside it that actually report errors.

It would be ideal to have the option to check for export plugin configuration warnings without changing its state, but that would probably take a more significant redesign.