### PR TITLE
GDScript: Destruct remaining instances when language is `finish`ed

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2192,6 +2192,15 @@ void GDScriptLanguage::finish() {
 	}
 	finishing = true;
 
+	// Destruct and detach instances that still exist.
+	// Other systems might try to call/destruct them which will crash if `GDScriptLanguage` is not around anymore.
+	for (const SelfList<GDScript> *E = script_list.first(); E != nullptr; E = E->next()) {
+		const Ref<GDScript> script = E->self();
+		while (script->instances.first() != nullptr) {
+			script->instances.first()->self()->get_owner()->set_script(Variant());
+		}
+	}
+
 	// Clear the cache before parsing the script_list
 	GDScriptCache::clear();
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/106401

When `GDScriptLanguage` is destructed we now detach `GDScript`s from all remaining instances. This prevents crashes when other systems that get destructed later still hold references to those instances.
