### PR TITLE
Improve Remote/Local SceneTreeDock buttons' appearance

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -68,6 +68,7 @@
 #include "scene/audio/audio_stream_player.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/check_box.h"
+#include "scene/gui/panel_container.h"
 #include "scene/main/scene_tree.h"
 #include "scene/property_utils.h"
 #include "scene/resources/packed_scene.h"
@@ -4600,11 +4601,11 @@ void SceneTreeDock::hide_remote_tree() {
 }
 
 void SceneTreeDock::show_tab_buttons() {
-	button_hb->show();
+	button_panel->show();
 }
 
 void SceneTreeDock::hide_tab_buttons() {
-	button_hb->hide();
+	button_panel->hide();
 }
 
 void SceneTreeDock::_remote_tree_selected() {
@@ -5021,8 +5022,12 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	PopupMenu *tree_menu = button_tree_menu->get_popup();
 	tree_menu->connect(SceneStringName(id_pressed), callable_mp(this, &SceneTreeDock::_tool_selected).bind(false));
 
-	button_hb = memnew(HBoxContainer);
-	main_vbox->add_child(button_hb);
+	button_panel = memnew(PanelContainer);
+	button_panel->set_theme_type_variation("PanelContainerTabbarInner");
+	main_vbox->add_child(button_panel);
+
+	HBoxContainer *button_hb = memnew(HBoxContainer);
+	button_panel->add_child(button_hb);
 
 	edit_remote = memnew(Button);
 	edit_remote->set_theme_type_variation(SceneStringName(FlatButton));
@@ -5043,7 +5048,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	edit_local->connect(SceneStringName(pressed), callable_mp(this, &SceneTreeDock::_local_tree_selected));
 
 	remote_tree = nullptr;
-	button_hb->hide();
+	button_panel->hide();
 
 	main_mc = memnew(MarginContainer);
 	main_vbox->add_child(main_mc);

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -38,8 +38,8 @@
 class CheckBox;
 class EditorData;
 class EditorSelection;
-class HBoxContainer;
 class MenuButton;
+class PanelContainer;
 class RenameDialog;
 class ReparentDialog;
 class Shader;
@@ -128,7 +128,7 @@ class SceneTreeDock : public EditorDock {
 	Button *button_custom = nullptr;
 	Button *button_clipboard = nullptr;
 
-	HBoxContainer *button_hb = nullptr;
+	PanelContainer *button_panel = nullptr;
 	Button *edit_local, *edit_remote;
 	SceneTreeEditor *scene_tree = nullptr;
 	Tree *remote_tree = nullptr;


### PR DESCRIPTION
The Remote/Local buttons in SceneTreeDock do not currently feel severe or separated enough for how important their role is to development. This PR places them in a panel with the "TabbarInner" style to be more eye-catching on game run.

Discussion [here](https://chat.godotengine.org/channel/usability/thread/ah3vMr8L7vxGTgg5m).

## After

https://github.com/user-attachments/assets/6e4360ba-f680-4e61-9dd6-2330da4be81e

## Before

https://github.com/user-attachments/assets/f3a44bfb-bbf1-43af-9693-dd8271e4539c