### PR TITLE
Jolt: Update `RigidBody3D` environmental properties more appropriately

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -205,6 +205,14 @@ void JoltArea3D::_notify_body_exited(const JPH::BodyID &p_body_id) {
 	}
 }
 
+void JoltArea3D::_notify_bodies_updated(bool p_priority_changed) {
+	for (KeyValue<JPH::BodyID, Overlap> &E : bodies_by_id) {
+		if (JoltBody3D *body = space->try_get_body(E.key)) {
+			body->update_area(this, p_priority_changed);
+		}
+	}
+}
+
 void JoltArea3D::_remove_all_overlaps() {
 	for (KeyValue<JPH::BodyID, Overlap> &E : bodies_by_id) {
 		_notify_body_exited(E.key);
@@ -356,13 +364,13 @@ void JoltArea3D::set_param(PhysicsServer3D::AreaParameter p_param, const Variant
 			set_linear_damp_mode((OverrideMode)(int)p_value);
 		} break;
 		case PhysicsServer3D::AREA_PARAM_LINEAR_DAMP: {
-			set_area_linear_damp(p_value);
+			set_linear_damp(p_value);
 		} break;
 		case PhysicsServer3D::AREA_PARAM_ANGULAR_DAMP_OVERRIDE_MODE: {
 			set_angular_damp_mode((OverrideMode)(int)p_value);
 		} break;
 		case PhysicsServer3D::AREA_PARAM_ANGULAR_DAMP: {
-			set_area_angular_damp(p_value);
+			set_angular_damp(p_value);
 		} break;
 		case PhysicsServer3D::AREA_PARAM_PRIORITY: {
 			set_priority(p_value);
@@ -438,6 +446,106 @@ bool JoltArea3D::can_interact_with(const JoltSoftBody3D &p_other) const {
 
 bool JoltArea3D::can_interact_with(const JoltArea3D &p_other) const {
 	return can_monitor(p_other) || p_other.can_monitor(*this);
+}
+
+void JoltArea3D::set_priority(float p_priority) {
+	if (p_priority == priority) {
+		return;
+	}
+
+	priority = p_priority;
+
+	_notify_bodies_updated(true);
+}
+
+void JoltArea3D::set_gravity(float p_gravity) {
+	if (p_gravity == gravity) {
+		return;
+	}
+
+	gravity = p_gravity;
+
+	_notify_bodies_updated();
+}
+
+void JoltArea3D::set_point_gravity(bool p_enabled) {
+	if (p_enabled == point_gravity) {
+		return;
+	}
+
+	point_gravity = p_enabled;
+
+	_notify_bodies_updated();
+}
+
+void JoltArea3D::set_point_gravity_distance(float p_distance) {
+	if (p_distance == point_gravity_distance) {
+		return;
+	}
+
+	point_gravity_distance = p_distance;
+
+	_notify_bodies_updated();
+}
+
+void JoltArea3D::set_linear_damp(float p_damp) {
+	if (p_damp == linear_damp) {
+		return;
+	}
+
+	linear_damp = p_damp;
+
+	_notify_bodies_updated();
+}
+
+void JoltArea3D::set_angular_damp(float p_damp) {
+	if (p_damp == angular_damp) {
+		return;
+	}
+
+	angular_damp = p_damp;
+
+	_notify_bodies_updated();
+}
+
+void JoltArea3D::set_gravity_mode(OverrideMode p_mode) {
+	if (p_mode == gravity_mode) {
+		return;
+	}
+
+	gravity_mode = p_mode;
+
+	_notify_bodies_updated();
+}
+
+void JoltArea3D::set_linear_damp_mode(OverrideMode p_mode) {
+	if (p_mode == linear_damp_mode) {
+		return;
+	}
+
+	linear_damp_mode = p_mode;
+
+	_notify_bodies_updated();
+}
+
+void JoltArea3D::set_angular_damp_mode(OverrideMode p_mode) {
+	if (p_mode == angular_damp_mode) {
+		return;
+	}
+
+	angular_damp_mode = p_mode;
+
+	_notify_bodies_updated();
+}
+
+void JoltArea3D::set_gravity_vector(const Vector3 &p_vector) {
+	if (p_vector == gravity_vector) {
+		return;
+	}
+
+	gravity_vector = p_vector;
+
+	_notify_bodies_updated();
 }
 
 Vector3 JoltArea3D::compute_gravity(const Vector3 &p_position) const {

--- a/modules/jolt_physics/objects/jolt_area_3d.h
+++ b/modules/jolt_physics/objects/jolt_area_3d.h
@@ -143,6 +143,7 @@ private:
 
 	void _notify_body_entered(const JPH::BodyID &p_body_id);
 	void _notify_body_exited(const JPH::BodyID &p_body_id);
+	void _notify_bodies_updated(bool p_priority_changed = false);
 
 	void _remove_all_overlaps();
 
@@ -189,35 +190,35 @@ public:
 
 	virtual bool reports_contacts() const override { return false; }
 
-	bool is_point_gravity() const { return point_gravity; }
-	void set_point_gravity(bool p_enabled) { point_gravity = p_enabled; }
-
 	float get_priority() const { return priority; }
-	void set_priority(float p_priority) { priority = p_priority; }
+	void set_priority(float p_priority);
 
 	float get_gravity() const { return gravity; }
-	void set_gravity(float p_gravity) { gravity = p_gravity; }
+	void set_gravity(float p_gravity);
+
+	bool is_point_gravity() const { return point_gravity; }
+	void set_point_gravity(bool p_enabled);
 
 	float get_point_gravity_distance() const { return point_gravity_distance; }
-	void set_point_gravity_distance(float p_distance) { point_gravity_distance = p_distance; }
+	void set_point_gravity_distance(float p_distance);
 
 	float get_linear_damp() const { return linear_damp; }
-	void set_area_linear_damp(float p_damp) { linear_damp = p_damp; }
+	void set_linear_damp(float p_damp);
 
 	float get_angular_damp() const { return angular_damp; }
-	void set_area_angular_damp(float p_damp) { angular_damp = p_damp; }
+	void set_angular_damp(float p_damp);
 
 	OverrideMode get_gravity_mode() const { return gravity_mode; }
-	void set_gravity_mode(OverrideMode p_mode) { gravity_mode = p_mode; }
+	void set_gravity_mode(OverrideMode p_mode);
 
 	OverrideMode get_linear_damp_mode() const { return linear_damp_mode; }
-	void set_linear_damp_mode(OverrideMode p_mode) { linear_damp_mode = p_mode; }
+	void set_linear_damp_mode(OverrideMode p_mode);
 
 	OverrideMode get_angular_damp_mode() const { return angular_damp_mode; }
-	void set_angular_damp_mode(OverrideMode p_mode) { angular_damp_mode = p_mode; }
+	void set_angular_damp_mode(OverrideMode p_mode);
 
 	Vector3 get_gravity_vector() const { return gravity_vector; }
-	void set_gravity_vector(const Vector3 &p_vector) { gravity_vector = p_vector; }
+	void set_gravity_vector(const Vector3 &p_vector);
 
 	float get_wind_pressure() const { return wind_pressure; }
 	void set_wind_pressure(float p_wind_pressure) { wind_pressure = p_wind_pressure; }

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -142,35 +142,35 @@ void JoltBody3D::_dequeue_call_queries() {
 	}
 }
 
-void JoltBody3D::_integrate_forces(float p_step, JPH::Body &p_jolt_body) {
-	_update_gravity(p_jolt_body);
-
-	if (!custom_integrator) {
-		JPH::MotionProperties &motion_properties = *p_jolt_body.GetMotionPropertiesUnchecked();
-
-		// Jolt applies damping differently from Godot Physics, where Godot Physics applies damping before integrating
-		// forces whereas Jolt does it after integrating forces. The way Godot Physics does it seems to yield more
-		// consistent results across different update frequencies when using high (>1) damping values, so we apply the
-		// damping ourselves instead, before any force integration happens.
-		JPH::Vec3 linear_velocity = motion_properties.GetLinearVelocity();
-		linear_velocity *= MAX(1.0f - total_linear_damp * p_step, 0.0f);
-		motion_properties.SetLinearVelocity(linear_velocity);
-
-		JPH::Vec3 angular_velocity = motion_properties.GetAngularVelocity();
-		angular_velocity *= MAX(1.0f - total_angular_damp * p_step, 0.0f);
-		motion_properties.SetAngularVelocity(angular_velocity);
-
-		p_jolt_body.AddForce(to_jolt(gravity / motion_properties.GetInverseMass() + constant_force));
-		p_jolt_body.AddTorque(to_jolt(constant_torque));
+void JoltBody3D::_integrate_forces(float p_step) {
+	if (custom_integrator) {
+		return;
 	}
+
+	JPH::MotionProperties &motion_properties = *jolt_body->GetMotionPropertiesUnchecked();
+
+	// Jolt applies damping differently from Godot Physics, where Godot Physics applies damping before integrating
+	// forces whereas Jolt does it after integrating forces. The way Godot Physics does it seems to yield more
+	// consistent results across different update frequencies when using high (>1) damping values, so we apply the
+	// damping ourselves instead, before any force integration happens.
+	JPH::Vec3 linear_velocity = motion_properties.GetLinearVelocity();
+	linear_velocity *= MAX(1.0f - total_linear_damp * p_step, 0.0f);
+	motion_properties.SetLinearVelocity(linear_velocity);
+
+	JPH::Vec3 angular_velocity = motion_properties.GetAngularVelocity();
+	angular_velocity *= MAX(1.0f - total_angular_damp * p_step, 0.0f);
+	motion_properties.SetAngularVelocity(angular_velocity);
+
+	jolt_body->AddForce(to_jolt(total_gravity / motion_properties.GetInverseMass() + constant_force));
+	jolt_body->AddTorque(to_jolt(constant_torque));
 }
 
-void JoltBody3D::_move_kinematic(float p_step, JPH::Body &p_jolt_body) {
-	p_jolt_body.SetLinearVelocity(JPH::Vec3::sZero());
-	p_jolt_body.SetAngularVelocity(JPH::Vec3::sZero());
+void JoltBody3D::_move_kinematic(float p_step) {
+	jolt_body->SetLinearVelocity(JPH::Vec3::sZero());
+	jolt_body->SetAngularVelocity(JPH::Vec3::sZero());
 
-	const JPH::RVec3 current_position = p_jolt_body.GetPosition();
-	const JPH::Quat current_rotation = p_jolt_body.GetRotation();
+	const JPH::RVec3 current_position = jolt_body->GetPosition();
+	const JPH::Quat current_rotation = jolt_body->GetRotation();
 
 	const JPH::RVec3 new_position = to_jolt_r(kinematic_transform.origin);
 	const JPH::Quat new_rotation = to_jolt(kinematic_transform.basis);
@@ -179,7 +179,7 @@ void JoltBody3D::_move_kinematic(float p_step, JPH::Body &p_jolt_body) {
 		return;
 	}
 
-	p_jolt_body.MoveKinematic(new_position, new_rotation, p_step);
+	jolt_body->MoveKinematic(new_position, new_rotation, p_step);
 }
 
 JPH::EAllowedDOFs JoltBody3D::_calculate_allowed_dofs() const {
@@ -279,42 +279,28 @@ void JoltBody3D::_update_mass_properties() {
 	}
 }
 
-void JoltBody3D::_update_gravity(JPH::Body &p_jolt_body) {
-	gravity = Vector3();
-
-	const Vector3 position = to_godot(p_jolt_body.GetPosition());
-
-	bool gravity_done = false;
-
-	for (const JoltArea3D *area : areas) {
-		gravity_done = JoltArea3D::apply_override(gravity, area->get_gravity_mode(), [&]() {
-			return area->compute_gravity(position);
-		});
-
-		if (gravity_done) {
-			break;
-		}
-	}
-
-	if (!gravity_done) {
-		gravity += space->get_default_area()->compute_gravity(position);
-	}
-
-	gravity *= p_jolt_body.GetMotionPropertiesUnchecked()->GetGravityFactor();
-}
-
-void JoltBody3D::_update_damp() {
-	if (!in_space()) {
+void JoltBody3D::_update_environmental_properties() {
+	if (unlikely(!in_space())) {
 		return;
 	}
 
-	total_linear_damp = 0.0;
-	total_angular_damp = 0.0;
+	total_gravity = Vector3();
+	total_linear_damp = 0.0f;
+	total_angular_damp = 0.0f;
 
+	const Vector3 position = to_godot(jolt_body->GetPosition());
+
+	bool gravity_done = false;
 	bool linear_damp_done = linear_damp_mode == PhysicsServer3D::BODY_DAMP_MODE_REPLACE;
 	bool angular_damp_done = angular_damp_mode == PhysicsServer3D::BODY_DAMP_MODE_REPLACE;
 
 	for (const JoltArea3D *area : areas) {
+		if (!gravity_done) {
+			gravity_done = JoltArea3D::apply_override(total_gravity, area->get_gravity_mode(), [&]() {
+				return area->compute_gravity(position);
+			});
+		}
+
 		if (!linear_damp_done) {
 			linear_damp_done = JoltArea3D::apply_override(total_linear_damp, area->get_linear_damp_mode(), [&]() {
 				return area->get_linear_damp();
@@ -327,20 +313,24 @@ void JoltBody3D::_update_damp() {
 			});
 		}
 
-		if (linear_damp_done && angular_damp_done) {
+		if (gravity_done && linear_damp_done && angular_damp_done) {
 			break;
 		}
 	}
 
-	const JoltArea3D *default_area = space->get_default_area();
+	if (!gravity_done) {
+		total_gravity += space->get_default_area()->compute_gravity(position);
+	}
 
 	if (!linear_damp_done) {
-		total_linear_damp += default_area->get_linear_damp();
+		total_linear_damp += space->get_default_area()->get_linear_damp();
 	}
 
 	if (!angular_damp_done) {
-		total_angular_damp += default_area->get_angular_damp();
+		total_angular_damp += space->get_default_area()->get_angular_damp();
 	}
+
+	total_gravity *= jolt_body->GetMotionPropertiesUnchecked()->GetGravityFactor();
 
 	switch (linear_damp_mode) {
 		case PhysicsServer3D::BODY_DAMP_MODE_COMBINE: {
@@ -359,8 +349,6 @@ void JoltBody3D::_update_damp() {
 			total_angular_damp = angular_damp;
 		} break;
 	}
-
-	_motion_changed();
 }
 
 void JoltBody3D::_update_kinematic_transform() {
@@ -411,6 +399,8 @@ void JoltBody3D::_exit_all_areas() {
 	}
 
 	areas.clear();
+
+	_areas_changed();
 }
 
 void JoltBody3D::_update_group_filter() {
@@ -456,12 +446,23 @@ void JoltBody3D::_space_changed() {
 	_update_group_filter();
 	_update_joint_constraints();
 	_update_sleep_allowed();
-	_areas_changed();
 }
 
 void JoltBody3D::_areas_changed() {
-	_update_damp();
-	wake_up();
+	has_point_gravity = false;
+	for (JoltArea3D *area : areas) {
+		if (area->is_point_gravity()) {
+			has_point_gravity = true;
+			break;
+		}
+	}
+
+	Vector3 previous_total_gravity = total_gravity;
+	_update_environmental_properties();
+
+	if (!total_gravity.is_equal_approx(previous_total_gravity)) {
+		wake_up();
+	}
 }
 
 void JoltBody3D::_joints_changed() {
@@ -1043,6 +1044,15 @@ void JoltBody3D::remove_area(JoltArea3D *p_area) {
 	_areas_changed();
 }
 
+void JoltBody3D::update_area(JoltArea3D *p_area, bool p_priority_changed) {
+	if (p_priority_changed) {
+		areas.erase(p_area);
+		add_area(p_area);
+	} else {
+		_areas_changed();
+	}
+}
+
 void JoltBody3D::add_joint(JoltJoint3D *p_joint) {
 	joints.push_back(p_joint);
 
@@ -1084,8 +1094,8 @@ void JoltBody3D::call_queries() {
 	}
 }
 
-void JoltBody3D::pre_step(float p_step, JPH::Body &p_jolt_body) {
-	JoltObject3D::pre_step(p_step, p_jolt_body);
+void JoltBody3D::pre_step(float p_step) {
+	JoltObject3D::pre_step(p_step);
 
 	switch (mode) {
 		case PhysicsServer3D::BODY_MODE_STATIC: {
@@ -1093,11 +1103,18 @@ void JoltBody3D::pre_step(float p_step, JPH::Body &p_jolt_body) {
 		} break;
 		case PhysicsServer3D::BODY_MODE_RIGID:
 		case PhysicsServer3D::BODY_MODE_RIGID_LINEAR: {
-			_integrate_forces(p_step, p_jolt_body);
+			if (has_point_gravity) {
+				_update_environmental_properties();
+			}
+
+			_integrate_forces(p_step);
 		} break;
 		case PhysicsServer3D::BODY_MODE_KINEMATIC: {
-			_update_gravity(p_jolt_body);
-			_move_kinematic(p_step, p_jolt_body);
+			if (has_point_gravity) {
+				_update_environmental_properties();
+			}
+
+			_move_kinematic(p_step);
 		} break;
 	}
 
@@ -1240,7 +1257,7 @@ void JoltBody3D::set_linear_damp(float p_damp) {
 
 	linear_damp = p_damp;
 
-	_update_damp();
+	_update_environmental_properties();
 }
 
 void JoltBody3D::set_angular_damp(float p_damp) {
@@ -1252,7 +1269,7 @@ void JoltBody3D::set_angular_damp(float p_damp) {
 
 	angular_damp = p_damp;
 
-	_update_damp();
+	_update_environmental_properties();
 }
 
 void JoltBody3D::set_linear_damp_mode(DampMode p_mode) {
@@ -1262,7 +1279,7 @@ void JoltBody3D::set_linear_damp_mode(DampMode p_mode) {
 
 	linear_damp_mode = p_mode;
 
-	_update_damp();
+	_update_environmental_properties();
 }
 
 void JoltBody3D::set_angular_damp_mode(DampMode p_mode) {
@@ -1272,7 +1289,7 @@ void JoltBody3D::set_angular_damp_mode(DampMode p_mode) {
 
 	angular_damp_mode = p_mode;
 
-	_update_damp();
+	_update_environmental_properties();
 }
 
 bool JoltBody3D::is_axis_locked(PhysicsServer3D::BodyAxis p_axis) const {

--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -75,7 +75,7 @@ private:
 	Vector3 constant_torque;
 	Vector3 linear_surface_velocity;
 	Vector3 angular_surface_velocity;
-	Vector3 gravity;
+	Vector3 total_gravity;
 
 	Callable state_sync_callback;
 	Callable custom_integration_callback;
@@ -102,6 +102,7 @@ private:
 	bool sleep_initially = false;
 	bool custom_center_of_mass = false;
 	bool custom_integrator = false;
+	bool has_point_gravity = false;
 
 	virtual JPH::BroadPhaseLayer _get_broad_phase_layer() const override;
 	virtual JPH::ObjectLayer _get_object_layer() const override;
@@ -114,8 +115,8 @@ private:
 	void _enqueue_call_queries();
 	void _dequeue_call_queries();
 
-	void _integrate_forces(float p_step, JPH::Body &p_jolt_body);
-	void _move_kinematic(float p_step, JPH::Body &p_jolt_body);
+	void _integrate_forces(float p_step);
+	void _move_kinematic(float p_step);
 
 	JPH::EAllowedDOFs _calculate_allowed_dofs() const;
 
@@ -125,8 +126,7 @@ private:
 	void _on_wake_up();
 
 	void _update_mass_properties();
-	void _update_gravity(JPH::Body &p_jolt_body);
-	void _update_damp();
+	void _update_environmental_properties();
 	void _update_kinematic_transform();
 	void _update_group_filter();
 	void _update_joint_constraints();
@@ -240,13 +240,14 @@ public:
 
 	void add_area(JoltArea3D *p_area);
 	void remove_area(JoltArea3D *p_area);
+	void update_area(JoltArea3D *p_area, bool p_priority_changed = false);
 
 	void add_joint(JoltJoint3D *p_joint);
 	void remove_joint(JoltJoint3D *p_joint);
 
 	void call_queries();
 
-	virtual void pre_step(float p_step, JPH::Body &p_jolt_body) override;
+	virtual void pre_step(float p_step) override;
 
 	JoltPhysicsDirectBodyState3D *get_direct_state();
 
@@ -278,7 +279,7 @@ public:
 	float get_gravity_scale() const;
 	void set_gravity_scale(float p_scale);
 
-	Vector3 get_gravity() const { return gravity; }
+	Vector3 get_total_gravity() const { return total_gravity; }
 
 	float get_linear_damp() const { return linear_damp; }
 	void set_linear_damp(float p_damp);

--- a/modules/jolt_physics/objects/jolt_object_3d.h
+++ b/modules/jolt_physics/objects/jolt_object_3d.h
@@ -145,7 +145,7 @@ public:
 
 	virtual bool reports_contacts() const = 0;
 
-	virtual void pre_step(float p_step, JPH::Body &p_jolt_body) {}
+	virtual void pre_step(float p_step) {}
 
 	String to_string() const;
 };

--- a/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.cpp
@@ -39,7 +39,7 @@ JoltPhysicsDirectBodyState3D::JoltPhysicsDirectBodyState3D(JoltBody3D *p_body) :
 }
 
 Vector3 JoltPhysicsDirectBodyState3D::get_total_gravity() const {
-	return body->get_gravity();
+	return body->get_total_gravity();
 }
 
 real_t JoltPhysicsDirectBodyState3D::get_total_angular_damp() const {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -229,9 +229,9 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
 	return settings;
 }
 
-void JoltSoftBody3D::_apply_environmental_forces(float p_step, JPH::Body &p_jolt_body) {
+void JoltSoftBody3D::_apply_environmental_forces(float p_step) {
 	// Get approximation of the center of the soft body.
-	Vector3 com_position = to_godot(p_jolt_body.GetCenterOfMassPosition());
+	Vector3 com_position = to_godot(jolt_body->GetCenterOfMassPosition());
 
 	// Calculate gravity and which areas affect the soft body through wind.
 	bool gravity_done = false;
@@ -255,10 +255,10 @@ void JoltSoftBody3D::_apply_environmental_forces(float p_step, JPH::Body &p_jolt
 	}
 
 	// Apply gravity to soft body. Note that this only works so long as vertices have uniform mass (excluding pinned vertices).
-	p_jolt_body.AddForce(to_jolt(gravity) * mass);
+	jolt_body->AddForce(to_jolt(gravity) * mass);
 
 	if (!wind_areas.is_empty()) {
-		JPH::SoftBodyMotionProperties &motion_properties = static_cast<JPH::SoftBodyMotionProperties &>(*p_jolt_body.GetMotionPropertiesUnchecked());
+		JPH::SoftBodyMotionProperties &motion_properties = static_cast<JPH::SoftBodyMotionProperties &>(*jolt_body->GetMotionPropertiesUnchecked());
 		JPH::Array<JPH::SoftBodyVertex> &physics_vertices = motion_properties.GetVertices();
 
 		for (const JPH::SoftBodySharedSettings::Face &physics_face : motion_properties.GetFaces()) {
@@ -487,8 +487,8 @@ Vector3 JoltSoftBody3D::get_velocity_at_position(const Vector3 &p_position) cons
 	return Vector3();
 }
 
-void JoltSoftBody3D::pre_step(float p_step, JPH::Body &p_jolt_body) {
-	_apply_environmental_forces(p_step, p_jolt_body);
+void JoltSoftBody3D::pre_step(float p_step) {
+	_apply_environmental_forces(p_step);
 }
 
 void JoltSoftBody3D::set_mesh(const RID &p_mesh) {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -72,7 +72,7 @@ class JoltSoftBody3D final : public JoltObject3D {
 
 	JPH::SoftBodySharedSettings *_create_shared_settings();
 
-	void _apply_environmental_forces(float p_step, JPH::Body &p_jolt_body);
+	void _apply_environmental_forces(float p_step);
 
 	void _update_mass();
 	void _update_pressure();
@@ -115,7 +115,7 @@ public:
 
 	virtual Vector3 get_velocity_at_position(const Vector3 &p_position) const override;
 
-	virtual void pre_step(float p_step, JPH::Body &p_jolt_body) override;
+	virtual void pre_step(float p_step) override;
 
 	void set_mesh(const RID &p_mesh);
 

--- a/modules/jolt_physics/spaces/jolt_space_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_space_3d.cpp
@@ -81,7 +81,7 @@ void JoltSpace3D::_pre_step(float p_step) {
 	for (JPH::uint32 i = 0; i < active_rigid_body_count; i++) {
 		JPH::Body *jolt_body = lock_iface.TryGetBody(active_rigid_bodies[i]);
 		JoltObject3D *object = reinterpret_cast<JoltObject3D *>(jolt_body->GetUserData());
-		object->pre_step(p_step, *jolt_body);
+		object->pre_step(p_step);
 	}
 
 	const JPH::BodyID *active_soft_bodies = physics_system->GetActiveBodiesUnsafe(JPH::EBodyType::SoftBody);
@@ -90,7 +90,7 @@ void JoltSpace3D::_pre_step(float p_step) {
 	for (JPH::uint32 i = 0; i < active_soft_body_count; i++) {
 		JPH::Body *jolt_body = lock_iface.TryGetBody(active_soft_bodies[i]);
 		JoltObject3D *object = reinterpret_cast<JoltObject3D *>(jolt_body->GetUserData());
-		object->pre_step(p_step, *jolt_body);
+		object->pre_step(p_step);
 	}
 
 	physics_system->SetBodyActivationListener(body_activation_listener);


### PR DESCRIPTION
Fixes #108715.
Fixes #118193.

The main purpose of this change is to:

- Actually propagate runtime damping changes from `Area3D` to any overlapping `RigidBody3D` correctly.
- Stop changes in area overlaps from waking the `RigidBody3D` up if there isn't actually a change in total gravity as a result.

This happens to also fix:

- A body's total gravity likely being stale on the first physics frame after a `RigidBody3D` has had area overlaps added/removed, as we weren't updating its total gravity until the next physics step.
- A body likely always starting out as awake due to `JoltBody3D::_space_changed()` always calling `_areas_changed()` which in turn called `wake_up()`. Now instead we call `_areas_changed()` in `_exit_all_areas()`, which serves the same purpose. This fix really only applies to custom `PhysicsServer3D` bodies though, as `RigidBody3D` suffers from this problem for other reasons anyway.
- A body being saved out with stale total gravity/damping when leaving a physics space while overlapping areas. This caused no problems in practice, since they would previously have been updated immediately when put into another physics space anyway, but it's arguably more correct now.

I've also thrown in refactoring that:

- Combines the `_update_gravity` and `_update_damp` methods into `_update_environmental_properties`, so we don't have to loop the areas twice.
- Stops passing `JPH::Body&` from `JoltSpace3D::_pre_step` into `JoltObject3D::pre_step` (and any method it forwards it to) since we already have `JoltObject3D::jolt_body` these days.
- Renames `JoltBody3D::gravity` to `JoltBody3D::total_gravity`.