### PR TITLE
Filter and sanitize volumetric fog to stop invalid values flooding the screen with black pixels through temporal reprojection.

### DIFF
--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -254,6 +254,11 @@ float henyey_greenstein(float cos_theta, float g) {
 	return k * (1.0 - g * g) / (pow(1.0 + g * g - 2.0 * g * cos_theta, 1.5));
 }
 
+vec3 safe_normalize(vec3 v) {
+	float length_squared = dot(v, v);
+	return (length_squared > 1e-12) ? v * inversesqrt(length_squared) : vec3(0.0);
+}
+
 #define TEMPORAL_FRAMES 16
 
 const vec3 halton_map[TEMPORAL_FRAMES] = vec3[](
@@ -422,7 +427,7 @@ void main() {
 					shadow_attenuation = mix(vec3(1.0 - directional_lights.data[i].shadow_opacity), vec3(1.0), shadow);
 				}
 
-				total_light += shadow_attenuation * directional_lights.data[i].color * directional_lights.data[i].energy * henyey_greenstein(dot(normalize(view_pos), normalize(directional_lights.data[i].direction)), params.phase_g) * directional_lights.data[i].volumetric_fog_energy;
+				total_light += shadow_attenuation * directional_lights.data[i].color * directional_lights.data[i].energy * henyey_greenstein(dot(safe_normalize(view_pos), safe_normalize(directional_lights.data[i].direction)), params.phase_g) * directional_lights.data[i].volumetric_fog_energy;
 			}
 		}
 
@@ -432,7 +437,7 @@ void main() {
 			vec3 anisotropic = vec3(0.0);
 			if (params.sky_contribution > 0.0) {
 				float mip_bias = 2.0 + total_density * (MAX_SKY_LOD - 2.0); // Not physically based, but looks nice
-				vec3 scatter_direction = (params.radiance_inverse_xform * normalize(view_pos)) * sign(params.phase_g);
+				vec3 scatter_direction = (params.radiance_inverse_xform * safe_normalize(view_pos)) * sign(params.phase_g);
 #ifdef USE_RADIANCE_OCTMAP_ARRAY
 				isotropic = texture(sampler2DArray(sky_texture, linear_sampler_with_mipmaps), vec3(vec3_to_oct_with_border(vec3(0.0, 1.0, 0.0), params.sky_border_size), mip_bias)).rgb;
 				anisotropic = texture(sampler2DArray(sky_texture, linear_sampler_with_mipmaps), vec3(vec3_to_oct_with_border(scatter_direction, params.sky_border_size), mip_bias)).rgb;
@@ -490,7 +495,7 @@ void main() {
 							vec3 local_vert = (omni_lights.data[light_index].shadow_matrix * vec4(view_pos, 1.0)).xyz;
 
 							float shadow_len = length(local_vert); //need to remember shadow len from here
-							vec3 shadow_sample = normalize(local_vert);
+							vec3 shadow_sample = safe_normalize(local_vert);
 
 							if (shadow_sample.z >= 0.0) {
 								uv_rect.xy += flip_offset;
@@ -508,7 +513,7 @@ void main() {
 
 							shadow_attenuation = mix(1.0 - omni_lights.data[light_index].shadow_opacity, 1.0, exp(min(0.0, (pos.z - depth)) / omni_lights.data[light_index].inv_radius * INV_FOG_FADE));
 						}
-						total_light += light * attenuation * shadow_attenuation * henyey_greenstein(dot(normalize(light_pos - view_pos), normalize(view_pos)), params.phase_g) * omni_lights.data[light_index].volumetric_fog_energy;
+						total_light += light * attenuation * shadow_attenuation * henyey_greenstein(dot(safe_normalize(light_pos - view_pos), safe_normalize(view_pos)), params.phase_g) * omni_lights.data[light_index].volumetric_fog_energy;
 					}
 				}
 			}
@@ -550,7 +555,7 @@ void main() {
 
 						vec3 spot_dir = spot_lights.data[light_index].direction;
 						float cone_angle = spot_lights.data[light_index].cone_angle;
-						float scos = max(dot(-normalize(light_rel_vec), spot_dir), cone_angle);
+						float scos = max(dot(-safe_normalize(light_rel_vec), spot_dir), cone_angle);
 						float spot_rim = max(0.0001, (1.0 - scos) / (1.0 - cone_angle));
 						attenuation *= 1.0 - pow(spot_rim, spot_lights.data[light_index].cone_attenuation);
 
@@ -564,7 +569,8 @@ void main() {
 
 							vec4 splane = (spot_lights.data[light_index].shadow_matrix * v);
 							splane.z -= spot_lights.data[light_index].shadow_bias;
-							splane /= splane.w;
+							float safe_w = abs(splane.w) > 1e-6 ? splane.w : (splane.w >= 0.0 ? 1e-6 : -1e-6);
+							splane /= safe_w;
 
 							vec3 pos = vec3(splane.xy * spot_lights.data[light_index].atlas_rect.zw + spot_lights.data[light_index].atlas_rect.xy, splane.z);
 
@@ -572,7 +578,7 @@ void main() {
 
 							shadow_attenuation = mix(1.0 - spot_lights.data[light_index].shadow_opacity, 1.0, exp(min(0.0, (pos.z - depth)) / spot_lights.data[light_index].inv_radius * INV_FOG_FADE));
 						}
-						total_light += light * attenuation * shadow_attenuation * henyey_greenstein(dot(normalize(light_rel_vec), normalize(view_pos)), params.phase_g) * spot_lights.data[light_index].volumetric_fog_energy;
+						total_light += light * attenuation * shadow_attenuation * henyey_greenstein(dot(safe_normalize(light_rel_vec), safe_normalize(view_pos)), params.phase_g) * spot_lights.data[light_index].volumetric_fog_energy;
 					}
 				}
 			}
@@ -679,8 +685,15 @@ void main() {
 	}
 
 	vec4 final_density = vec4(total_light * scattering + emission, total_density);
+	bool is_reprojected_density_invalid = any(isnan(reprojected_density)) || any(isinf(reprojected_density));
+	bool is_final_density_invalid = any(isnan(final_density)) || any(isinf(final_density));
 
-	final_density = mix(final_density, reprojected_density, reproject_amount);
+	if (is_final_density_invalid) {
+		final_density = is_reprojected_density_invalid ? vec4(0.0) : reprojected_density;
+	} else if (!is_reprojected_density_invalid) {
+		final_density = mix(final_density, reprojected_density, reproject_amount);
+	}
+	final_density = clamp(final_density, vec4(0.0), vec4(65504.0));
 
 	imageStore(density_map, pos, final_density);
 #ifdef NO_IMAGE_ATOMICS
@@ -723,7 +736,11 @@ void main() {
 
 		prev_z = z;
 
-		imageStore(fog_map, fog_pos, vec4(fog_accum.rgb, fog_accum.a));
+		vec4 final_fog = vec4(fog_accum.rgb, fog_accum.a);
+		bool is_final_fog_invalid = any(isnan(final_fog)) || any(isinf(final_fog));
+		final_fog = is_final_fog_invalid ? vec4(0.0) : final_fog;
+		final_fog = clamp(final_fog, vec4(0.0), vec4(65504.0));
+		imageStore(fog_map, fog_pos, final_fog);
 	}
 
 #endif


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/87136
_(Hopefully, considering how often this issue comes back, I'm not claiming this handles all the possibilities but so far people confirmed their issues are no longer happening.)_

**Explanation**
1. Added checks for invalid values in final_density and is_reprojected_density_invalid to filter them out, the code tries to reuse any valid value if there's any, if none is valid then default to 0.0.
(The broadest solution to the issue, but not all encompasing.)
Several months ago I asked Clayjohn at the rendering meeting if it's ok to just check for invalids and not store them and he said yeah let's use the hammer so hammer it is. I'm not 100% sure if he had a different hammer in mind so let me know please :).

2. Same checks as in 1/ above for final_fog. Some are needed, some are technically not necessary here (at least I think so), but it's safer and considering the never ending issues with fog I decided to include both for safety.
('m also not 100% the not needed check is actually not needed, there might be things happening with the texture I'm not aware of, I also did not check what happens when a custom fog shader is used so it seemed to me as a practical way to addressing the potential issues now/in the future, it's not a hot path so hopefully fine?)

3. I added clamps for final_density and final_fog. Both have a tendency to overflow (a lot), textures are 16 bit, valuesi n the fog can go way past that limit. Just attenuation itself has a minimum magnitude 10^4 which is the same magnituted the 16 bit max limit is at.
(For clarity here, 16 bit textures, 32 bit float shader variables, values can oftne overflow 16 bit but they can also relatively easily overflow the 32 bit max limit - yep - thus the clamp seemed necessary.)

4. I also sanitized couple more common paths of invalid values to avoid potential visual issues. These were results of division by zero. For this I added `safe_normalize` function. This technically is not 100% necessary since step 1/ filters out the invalid values before storing them, but I believe these problematic values can happen more than at rare times thus causing visual issues thus I include them here.
I did avoid sanitizing another potential issue for 2 reasons: 1. It's just a one frame thing at very rare times producing invalid values which are filtered out later on anyway; 2. Since the issue can happen only during one frame it didn't feel like introducing extra code just for that was worth it.

**Fix verification**
I could only reproduce some of the issues while the other reported issues never occured on my system thus I could not personally verify everything on my own.
I can verify the issue with invalid values coming due to attenuation and its logic do not happen on my computer anymore.
Other users, notably https://github.com/godotengine/godot/issues/87136#issuecomment-4156769623 and https://github.com/godotengine/godot/issues/87136#issuecomment-4154731911 who were able to reproduce the issues (or even reported them to begin with) did test this PR and confirmed that they no longer have the issues.

**Noteable issues**
1. If you try to reproduce the issue through attenuation even with this PR you can still find issues with lights as commented by Calinou here https://github.com/godotengine/godot/issues/87136#issuecomment-4156769623 and me in response here https://github.com/godotengine/godot/issues/87136#issuecomment-4157011697. As we both mentioned in the discussion, this issue is not a fog issue, it's the lights issue so not related to this PR (but it can confuse you if you don't know about it).
Since the lights in the volumetric fog had the same issue with attenuation as the lights without the fog (as shown in the above comments), it might be possible the attenuation in light shaders in general might need the same treatment as in this PR.
So this should not be a blocker since it's not a fog issue.

3. I did not touch the FogVolumes. There might be an issue with it - I think so from someone's comment? But I haven't even looked for a report or anything yet. It's not part of this PR anyway.

Don't take me as an expert, I'm still learning. I'll gladly defer to your better judgement. :-)