### PR TITLE
Add mutex lock in `get_shader_rid()`

### DIFF
--- a/scene/resources/canvas_item_material.cpp
+++ b/scene/resources/canvas_item_material.cpp
@@ -233,6 +233,7 @@ void CanvasItemMaterial::_validate_property(PropertyInfo &p_property) const {
 }
 
 RID CanvasItemMaterial::get_shader_rid() const {
+	MutexLock lock(material_mutex);
 	ERR_FAIL_COND_V(!shader_map.has(current_key), RID());
 	return shader_map[current_key].shader;
 }


### PR DESCRIPTION
`CanvasItemMaterial::get_shader_rid()` accesses the static `shader_map` and `current_key` without holding `material_mutex`, while `flush_changes()` (idle callback) modifies both under the mutex via `_update_shader()`. When the rendering thread calls `get_shader_rid()` concurrently, it can read a stale key that was just erased from the map, causing a use-after-free crash.

This is most easily triggered by rapidly toggling the Blend Mode property on a CanvasItemMaterial assigned to a GPUParticles2D node, but affects any CanvasItemMaterial during rendering.

The fix adds `MutexLock lock(material_mutex)` to `get_shader_rid()`, matching the locking convention already used by `flush_changes()`, `_queue_shader_change()`, and `~CanvasItemMaterial()`. CanvasItemMaterial was the only material class missing this protection, BaseMaterial3D, ParticleProcessMaterial, and others all synchronize correctly.

- *Bugsquad edit:* This PR fixes #118151