### PR TITLE
Fix editor spin slider clamp (reverted)

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -143,6 +143,8 @@ void EditorSpinSlider::gui_input(const Ref<InputEvent> &p_event) {
 				const double new_value = pre_grab_value + drag_step * grabbing_spinner_dist_cache;
 
 				double val = (mm->is_command_or_control_pressed() && !editing_integer) ? Math::round(new_value) : new_value;
+				val = CLAMP(val, get_min(), get_max());
+
 				if (deferred_drag_mode) {
 					set_value_no_signal(val);
 				} else {


### PR DESCRIPTION
this addresses the bug  mentioned in: https://github.com/godotengine/godot/issues/118194

by clamping value in spin slider clamp when dragging.

- *Bugsquad edit:* This PR fixes https://github.com/godotengine/godot/issues/118194