### PR TITLE
Try to avoid calling `queue_redraw` in 2D ray and shape cast `set_enabled` methods

### DIFF
--- a/scene/2d/physics/ray_cast_2d.cpp
+++ b/scene/2d/physics/ray_cast_2d.cpp
@@ -102,10 +102,19 @@ Vector2 RayCast2D::get_collision_normal() const {
 }
 
 void RayCast2D::set_enabled(bool p_enabled) {
+	if (enabled == p_enabled) {
+		return;
+	}
 	enabled = p_enabled;
-	queue_redraw();
-	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint()) {
-		set_physics_process_internal(p_enabled);
+
+	if (is_inside_tree()) {
+		if (get_tree()->is_debugging_collisions_hint()) {
+			queue_redraw();
+		}
+
+		if (!Engine::get_singleton()->is_editor_hint()) {
+			set_physics_process_internal(p_enabled);
+		}
 	}
 	if (!p_enabled) {
 		collided = false;

--- a/scene/2d/physics/shape_cast_2d.cpp
+++ b/scene/2d/physics/shape_cast_2d.cpp
@@ -137,10 +137,19 @@ real_t ShapeCast2D::get_closest_collision_unsafe_fraction() const {
 }
 
 void ShapeCast2D::set_enabled(bool p_enabled) {
+	if (enabled == p_enabled) {
+		return;
+	}
 	enabled = p_enabled;
-	queue_redraw();
-	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint()) {
-		set_physics_process_internal(p_enabled);
+
+	if (is_inside_tree()) {
+		if (get_tree()->is_debugging_collisions_hint()) {
+			queue_redraw();
+		}
+
+		if (!Engine::get_singleton()->is_editor_hint()) {
+			set_physics_process_internal(p_enabled);
+		}
 	}
 	if (!p_enabled) {
 		collided = false;


### PR DESCRIPTION
This commit tries to avoid calling `queue_redraw`, when possible, in the `RayCast2D::set_enabled` and `ShapeCast2D::set_enabled` methods so the redraw logic can be skipped.

Adds a fast path if `set_enabled` was called with the existing `enabled` value, meaning it has no effect.

Adds a check that only queues a redraw if collisions are being debugged because, based on what I can tell, ray casts and shape casts are only drawn when collisions are being debugged.