### PR TITLE
C#: Add support for class documentation generation

### DIFF
--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -33,6 +33,7 @@
 #include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/object/script_language.h"
 #include "editor/debugger/editor_debugger_inspector.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/docks/filesystem_dock.h"
@@ -104,7 +105,18 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case OBJECT_REQUEST_HELP: {
 			if (current) {
 				EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
-				emit_signal(SNAME("request_help"), current->get_class());
+				// Prefer the documentation page of the object's script (e.g. a C# or
+				// GDScript class) over the one of its native base class, mirroring what
+				// the inspector categories do.
+				StringName class_name;
+				Ref<Script> script = current->get_script();
+				if (script.is_valid() && !script->get_doc_class_name().is_empty()) {
+					class_name = script->get_doc_class_name();
+				}
+				if (class_name.is_empty()) {
+					class_name = current->get_class();
+				}
+				emit_signal(SNAME("request_help"), class_name);
 			}
 		} break;
 

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -2300,6 +2300,10 @@ bool EditorFileSystem::_should_reload_script(const String &p_path) {
 		return false;
 	}
 
+	if (scr->get_language()->get_name() == "C#") {
+		return false;
+	}
+
 	// Scripts are reloaded via the script editor if they are currently opened.
 	if (ScriptEditor::get_singleton()->get_open_scripts().has(scr)) {
 		return false;

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -1543,7 +1543,6 @@ void ConnectionsDock::update_tree() {
 	}
 
 	TreeItem *root = tree->create_item();
-	DocTools *doc_data = EditorHelp::get_doc_data();
 	EditorData &editor_data = EditorNode::get_editor_data();
 	StringName native_base = selected_object->get_class();
 	Ref<Script> script_base = selected_object->get_script();
@@ -1563,12 +1562,12 @@ void ConnectionsDock::update_tree() {
 				class_name = script_base->get_path().get_file();
 			}
 
-			doc_class_name = script_base->get_global_name();
+			doc_class_name = script_base->get_doc_class_name();
 			if (doc_class_name.is_empty()) {
-				doc_class_name = script_base->get_path().trim_prefix("res://").quote();
-			}
-			if (!doc_class_name.is_empty() && !doc_data->class_list.find(doc_class_name)) {
-				doc_class_name = String();
+				doc_class_name = script_base->get_global_name();
+				if (doc_class_name.is_empty()) {
+					doc_class_name = script_base->get_path().trim_prefix("res://").quote();
+				}
 			}
 
 			class_icon = editor_data.get_script_icon(script_base->get_path());
@@ -1600,10 +1599,6 @@ void ConnectionsDock::update_tree() {
 		} else {
 			class_name = native_base;
 			doc_class_name = native_base;
-
-			if (!doc_data->class_list.find(doc_class_name)) {
-				doc_class_name = String();
-			}
 
 			if (has_theme_icon(native_base, EditorStringName(EditorIcons))) {
 				class_icon = get_editor_theme_icon(native_base);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1042,6 +1042,10 @@ Error CSharpLanguage::open_in_external_editor(const Ref<Script> &p_script, int p
 bool CSharpLanguage::overrides_external_editor() {
 	return get_godotsharp_editor()->call("OverridesExternalEditor");
 }
+
+bool CSharpLanguage::supports_documentation() const {
+	return true;
+}
 #endif
 
 bool CSharpLanguage::debug_break_parse(const String &p_file, int p_line, const String &p_error) {
@@ -2078,9 +2082,15 @@ void GD_CLR_STDCALL CSharpScript::_add_property_info_list_callback(CSharpScript 
 	GDMonoCache::godotsharp_property_info *props = (GDMonoCache::godotsharp_property_info *)p_props;
 
 #ifdef TOOLS_ENABLED
-	p_script->exported_members_cache.push_back(PropertyInfo(
-			Variant::NIL, p_script->type_info.class_name, PROPERTY_HINT_NONE,
-			p_script->get_path(), PROPERTY_USAGE_CATEGORY));
+	if (p_script->get_path().is_empty()) {
+		p_script->exported_members_cache.push_back(PropertyInfo(
+				Variant::NIL, p_script->type_info.class_name, PROPERTY_HINT_NONE,
+				String("res://") + String(p_script->doc_class_name).lstrip("\"").rstrip("\""), PROPERTY_USAGE_CATEGORY));
+	} else {
+		p_script->exported_members_cache.push_back(PropertyInfo(
+				Variant::NIL, p_script->type_info.class_name, PROPERTY_HINT_NONE,
+				p_script->get_path(), PROPERTY_USAGE_CATEGORY));
+	}
 #endif
 
 	for (int i = 0; i < p_count; i++) {
@@ -2117,6 +2127,55 @@ void GD_CLR_STDCALL CSharpScript::_add_property_default_values_callback(CSharpSc
 
 		p_script->exported_members_defval_cache[name] = value;
 	}
+}
+
+void CSharpScript::get_docs(Ref<CSharpScript> p_script) {
+	if (CSharpLanguage::get_singleton()->get_godotsharp_editor() == nullptr) {
+		return;
+	}
+	Variant v = CSharpLanguage::get_singleton()->get_godotsharp_editor()->call("GetDocs", Variant(p_script));
+
+	Dictionary class_doc_dict = (Dictionary)v;
+
+	p_script->docs.clear();
+
+	if (class_doc_dict.is_empty()) {
+		// Script has no docs.
+		return;
+	}
+
+	String inherits;
+	Ref<CSharpScript> base = p_script->get_base_script();
+	if (base.is_null()) {
+		// Must be a native base type.
+		inherits = p_script->get_instance_base_type();
+	} else {
+		inherits = base->get_global_name();
+		if (inherits == StringName()) {
+			inherits = base->get_path().trim_prefix("res://").quote();
+		}
+	}
+
+	// The C# side supplies property default values as Variant values. The ClassDoc::from_dict
+	// path assigns them directly to a String field, which would stringify Variant using its
+	// generic representation (e.g. "(0.35, 0.7, 0.95, 1)" for Color) rather than the construct
+	// format used by the rest of the documentation ("Color(0.35, 0.7, 0.95, 1)"). Convert them
+	// here with DocData::get_default_value_string so the rendered output matches GDScript.
+	if (class_doc_dict.has("properties")) {
+		Array properties = class_doc_dict["properties"];
+		for (int i = 0; i < properties.size(); i++) {
+			Dictionary property = properties[i];
+			if (property.has("default_value")) {
+				property["default_value"] = DocData::get_default_value_string(property["default_value"]);
+			}
+		}
+	}
+
+	DocData::ClassDoc class_doc = DocData::ClassDoc().from_dict(class_doc_dict);
+	class_doc.inherits = inherits;
+
+	p_script->doc_class_name = class_doc.name;
+	p_script->docs.append(class_doc);
 }
 #endif
 
@@ -2342,6 +2401,10 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 	}
 
 	p_script->base_script = base_script;
+
+#ifdef TOOLS_ENABLED
+	get_docs(p_script);
+#endif
 }
 
 bool CSharpScript::can_instantiate() const {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -197,6 +197,8 @@ private:
 	bool exports_invalidated = true;
 	void _update_exports_values(HashMap<StringName, Variant> &values, List<PropertyInfo> &propnames);
 	void _placeholder_erased(PlaceHolderScriptInstance *p_placeholder) override;
+	StringName doc_class_name;
+	Vector<DocData::ClassDoc> docs;
 #endif
 
 #if defined(TOOLS_ENABLED) || defined(DEBUG_ENABLED)
@@ -210,6 +212,7 @@ private:
 	static void GD_CLR_STDCALL _add_property_info_list_callback(CSharpScript *p_script, const String *p_current_class_name, void *p_props, int32_t p_count);
 #ifdef TOOLS_ENABLED
 	static void GD_CLR_STDCALL _add_property_default_values_callback(CSharpScript *p_script, void *p_def_vals, int32_t p_count);
+	static void get_docs(Ref<CSharpScript> p_script);
 #endif
 	bool _update_exports(PlaceHolderScriptInstance *p_instance_to_update = nullptr);
 
@@ -241,10 +244,8 @@ public:
 	void set_source_code(const String &p_code) override;
 
 #ifdef TOOLS_ENABLED
-	virtual StringName get_doc_class_name() const override { return StringName(); } // TODO
+	virtual StringName get_doc_class_name() const override { return doc_class_name; }
 	virtual Vector<DocData::ClassDoc> get_documentation() const override {
-		// TODO
-		Vector<DocData::ClassDoc> docs;
 		return docs;
 	}
 	virtual String get_class_icon_path() const override {
@@ -572,6 +573,7 @@ public:
 #ifdef TOOLS_ENABLED
 	Error open_in_external_editor(const Ref<Script> &p_script, int p_line, int p_col) override;
 	bool overrides_external_editor() override;
+	virtual bool supports_documentation() const override;
 #endif
 
 	RBMap<Object *, CSharpScriptBinding>::Element *insert_script_binding(Object *p_object, const CSharpScriptBinding &p_script_binding);

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -55,6 +55,10 @@
     <Optimize Condition=" '$(Optimize)' == '' ">true</Optimize>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <GenerateDocumentationFile Condition="'$(GenerateDocumentationFile)' == ''">true</GenerateDocumentationFile>
+  </PropertyGroup>
+
   <PropertyGroup>
     <GodotApiConfiguration Condition=" '$(Configuration)' != 'ExportRelease' ">Debug</GodotApiConfiguration>
     <GodotApiConfiguration Condition=" '$(Configuration)' == 'ExportRelease' ">Release</GodotApiConfiguration>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
@@ -21,6 +21,7 @@
     <DefineConstants Condition=" '$(Configuration)' == 'Debug' ">$(DefineConstants);TOOLS</DefineConstants>
 
     <DefineConstants>$(_GodotDefineConstants);$(DefineConstants)</DefineConstants>
+    <NoWarn Condition=" '$(EnableDocumentationWarning)' != 'true' ">$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(EnableGodotDotNetPreview)' == 'true'">

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -82,6 +82,9 @@ namespace GodotTools.Build
             // Notify running game for hot-reload.
             Internal.EditorDebuggerNodeReloadScripts();
 
+            // Clear XML documentation cache before reload
+            ScriptDoc.ClearXmlCache();
+
             // Hot-reload in the editor.
             GodotSharpEditor.Instance.GetNode<HotReloadAssemblyWatcher>("HotReloadAssemblyWatcher").RestartTimer();
 
@@ -102,6 +105,9 @@ namespace GodotTools.Build
 
             // Notify running game for hot-reload.
             Internal.EditorDebuggerNodeReloadScripts();
+
+            // Clear XML documentation cache before reload
+            ScriptDoc.ClearXmlCache();
 
             // Hot-reload in the editor.
             GodotSharpEditor.Instance.GetNode<HotReloadAssemblyWatcher>("HotReloadAssemblyWatcher").RestartTimer();

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -425,6 +425,374 @@ namespace GodotTools
             return _editorSettings.GetSetting(Settings.ExternalEditor).As<ExternalEditorId>() != ExternalEditorId.None;
         }
 
+        public Variant GetDocs(Script script)
+        {
+            try
+            {
+                var scriptType = ScriptDoc.GetScriptType(script.NativeInstance);
+                var scriptPathAttr = scriptType?.GetCustomAttributes<ScriptPathAttribute>().FirstOrDefault();
+
+                if (scriptType is null || scriptPathAttr is null)
+                {
+                    return new Godot.Collections.Dictionary();
+                }
+
+                string scriptPath = scriptPathAttr.Path.Replace("res://", "");
+
+                ScriptDoc.XmlDocumentationCache? xmlDocs = ScriptDoc.GetXmlDocumentationCache(scriptType.Assembly);
+
+                string typeDocId = ScriptDoc.GetTypeDocumentationId(scriptType);
+
+                string? briefDescription = ScriptDoc.TryGetDocTag(xmlDocs, scriptType, typeDocId, "summary",
+                    implicitInheritResolver: () => scriptType.BaseType != null ? ScriptDoc.GetTypeDocumentationId(scriptType.BaseType) : null);
+
+                string? fullDescription = ScriptDoc.TryGetDocTag(xmlDocs, scriptType, typeDocId, "remarks",
+                    implicitInheritResolver: () => scriptType.BaseType != null ? ScriptDoc.GetTypeDocumentationId(scriptType.BaseType) : null);
+
+                bool isGlobalClass = scriptType.IsDefined(typeof(GlobalClassAttribute), inherit: false);
+                string classDocName;
+
+                if (isGlobalClass)
+                {
+                    classDocName = scriptType.Name;
+                }
+                else
+                {
+                    classDocName = "\"" + scriptPath + "\"";
+                    if (scriptType.DeclaringType != null)
+                    {
+                        classDocName += scriptType.Name;
+                    }
+                }
+
+                using Godot.Collections.Dictionary docs = new global::Godot.Collections.Dictionary();
+
+                docs.Add("name", classDocName);
+                docs.Add("brief_description", briefDescription ?? "");
+                docs.Add("description", fullDescription ?? "");
+
+                var exportedProperties = scriptType
+                    .GetProperties(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+                    .Where(p => p.IsDefined(typeof(ExportAttribute), inherit: false))
+                    .ToArray();
+
+                var exportedFields = scriptType
+                    .GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+                    .Where(f => !f.IsSpecialName && f.IsDefined(typeof(ExportAttribute), inherit: false))
+                    .ToArray();
+
+                var propertyDocs = new global::Godot.Collections.Array();
+                var enumTypes = new HashSet<Type>();
+
+                // Default values for exported members, as evaluated from their initializers by the
+                // Godot source generators. Passed through as Variant values; the native side
+                // (CSharpScript::get_docs) serializes them with DocData::get_default_value_string
+                // so the rendered format matches GDScript documentation.
+                var defaultValues = ScriptDoc.GetPropertyDefaultValues(scriptType);
+
+                foreach (System.Reflection.PropertyInfo property in exportedProperties)
+                {
+                    Type propertyType = property.PropertyType;
+                    if (propertyType.IsEnum)
+                        enumTypes.Add(propertyType);
+
+                    string propertyDocId = ScriptDoc.GetPropertyDocumentationId(property);
+                    string? propertyDescription = ScriptDoc.TryGetFullDocDescription(xmlDocs, scriptType, propertyDocId,
+                        implicitInheritResolver: () => ScriptDoc.FindInheritedPropertyDocumentationId(property));
+
+                    var propertyDoc = new global::Godot.Collections.Dictionary()
+                    {
+                        { "name", property.Name },
+                        { "type", ScriptDoc.GetPropertyDocTypeName(propertyType) },
+                    };
+
+                    if (defaultValues != null && defaultValues.TryGetValue(property.Name, out Variant defaultValue))
+                    {
+                        propertyDoc["default_value"] = defaultValue;
+                    }
+
+                    if (propertyType.IsEnum)
+                    {
+                        propertyDoc["enumeration"] = propertyType.Name;
+                        // Add full name with namespace for proper documentation lookup
+                        if (!string.IsNullOrEmpty(propertyType.Namespace))
+                            propertyDoc["enumeration_full_name"] = $"{propertyType.Namespace}.{propertyType.Name}";
+                        else
+                            propertyDoc["enumeration_full_name"] = propertyType.Name;
+
+                        if (propertyType.IsDefined(typeof(FlagsAttribute), inherit: false))
+                            propertyDoc["is_bitfield"] = true;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(propertyDescription))
+                        propertyDoc["description"] = propertyDescription;
+
+                    propertyDocs.Add(propertyDoc);
+                }
+
+                foreach (System.Reflection.FieldInfo field in exportedFields)
+                {
+                    Type fieldType = field.FieldType;
+                    if (fieldType.IsEnum)
+                        enumTypes.Add(fieldType);
+
+                    string fieldDocId = ScriptDoc.GetFieldDocumentationId(field);
+                    string? fieldDescription = ScriptDoc.TryGetFullDocDescription(xmlDocs, scriptType, fieldDocId,
+                        implicitInheritResolver: () => ScriptDoc.FindInheritedFieldDocumentationId(field));
+
+                    var propertyDoc = new global::Godot.Collections.Dictionary()
+                    {
+                        { "name", field.Name },
+                        { "type", ScriptDoc.GetPropertyDocTypeName(fieldType) },
+                    };
+
+                    if (defaultValues != null && defaultValues.TryGetValue(field.Name, out Variant fieldDefaultValue))
+                    {
+                        propertyDoc["default_value"] = fieldDefaultValue;
+                    }
+
+                    if (fieldType.IsEnum)
+                    {
+                        propertyDoc["enumeration"] = fieldType.Name;
+                        // Add full name with namespace for proper documentation lookup
+                        if (!string.IsNullOrEmpty(fieldType.Namespace))
+                            propertyDoc["enumeration_full_name"] = $"{fieldType.Namespace}.{fieldType.Name}";
+                        else
+                            propertyDoc["enumeration_full_name"] = fieldType.Name;
+
+                        if (fieldType.IsDefined(typeof(FlagsAttribute), inherit: false))
+                            propertyDoc["is_bitfield"] = true;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(fieldDescription))
+                        propertyDoc["description"] = fieldDescription;
+
+                    propertyDocs.Add(propertyDoc);
+                }
+
+                if (propertyDocs.Count > 0)
+                    docs.Add("properties", propertyDocs);
+
+                var signalDocs = new global::Godot.Collections.Array();
+
+                var nestedSignalTypes = scriptType.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic)
+                    .Where(t => t.IsDefined(typeof(SignalAttribute), inherit: false) && typeof(MulticastDelegate).IsAssignableFrom(t.BaseType))
+                    .ToArray();
+
+                foreach (Type signalType in nestedSignalTypes)
+                {
+                    string signalName = signalType.Name.EndsWith("EventHandler", StringComparison.Ordinal)
+                        ? signalType.Name.Substring(0, signalType.Name.Length - "EventHandler".Length)
+                        : signalType.Name;
+
+                    string signalDocId = ScriptDoc.GetTypeDocumentationId(signalType);
+                    string? signalDescription = ScriptDoc.TryGetFullDocDescription(xmlDocs, scriptType, signalDocId);
+
+                    var signalDoc = new global::Godot.Collections.Dictionary()
+                    {
+                        { "name", signalName },
+                    };
+
+                    if (!string.IsNullOrWhiteSpace(signalDescription))
+                        signalDoc["description"] = signalDescription;
+
+                    signalDocs.Add(signalDoc);
+                }
+
+                if (signalDocs.Count > 0)
+                    docs.Add("signals", signalDocs);
+
+                var methodDocs = new global::Godot.Collections.Array();
+
+                // Collect public instance/static methods declared on this type, mirroring how
+                // GDScript documents functions. We exclude:
+                //   - special-name members (property accessors, operators, event add/remove)
+                //   - Godot virtual callbacks that begin with an underscore (e.g. _Ready)
+                //   - members marked EditorBrowsableState.Never: the Godot source generators tag
+                //     every method they emit (GetGodotMethodList, InvokeGodotClassMethod, etc.)
+                //     with this attribute so they stay hidden from IntelliSense; reusing it here
+                //     keeps generated boilerplate out of the documentation.
+                var exportedMethods = scriptType
+                    .GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly)
+                    .Where(m => !m.IsSpecialName
+                                && !m.Name.StartsWith("_", StringComparison.Ordinal)
+                                && !ScriptDoc.IsHiddenFromEditor(m))
+                    .ToArray();
+
+                foreach (System.Reflection.MethodInfo method in exportedMethods)
+                {
+                    string methodDocId = ScriptDoc.GetMethodDocumentationId(method);
+                    string? methodDescription = ScriptDoc.TryGetFullDocDescription(xmlDocs, scriptType, methodDocId);
+
+                    var methodDoc = new global::Godot.Collections.Dictionary()
+                    {
+                        { "name", method.Name },
+                        { "return_type", ScriptDoc.GetPropertyDocTypeName(method.ReturnType) },
+                    };
+
+                    if (method.IsStatic)
+                        methodDoc["qualifiers"] = "static";
+
+                    var arguments = new global::Godot.Collections.Array();
+                    foreach (System.Reflection.ParameterInfo parameter in method.GetParameters())
+                    {
+                        var argumentDoc = new global::Godot.Collections.Dictionary()
+                        {
+                            { "name", parameter.Name ?? string.Empty },
+                            { "type", ScriptDoc.GetPropertyDocTypeName(parameter.ParameterType) },
+                        };
+
+                        // Reflect the parameter's default value when one is declared.
+                        if (parameter.HasDefaultValue && parameter.DefaultValue != null)
+                        {
+                            object defaultValue = parameter.DefaultValue;
+                            string defaultValueString = defaultValue switch
+                            {
+                                bool b => b ? "true" : "false",
+                                string s => "\"" + s + "\"",
+                                _ => defaultValue.ToString() ?? string.Empty,
+                            };
+                            argumentDoc["default_value"] = defaultValueString;
+                        }
+
+                        arguments.Add(argumentDoc);
+                    }
+
+                    if (arguments.Count > 0)
+                        methodDoc["arguments"] = arguments;
+
+                    if (!string.IsNullOrWhiteSpace(methodDescription))
+                        methodDoc["description"] = methodDescription;
+
+                    methodDocs.Add(methodDoc);
+                }
+
+                if (methodDocs.Count > 0)
+                    docs.Add("methods", methodDocs);
+
+                var constantDocs = new global::Godot.Collections.Array();
+
+                // Collect public constant fields (const/static-literal members) declared on this
+                // type, mirroring how GDScript documents `const` declarations. We exclude enum
+                // value fields (those are emitted below under their owning enum) and literals
+                // generated by the source generator.
+                var exportedConstants = scriptType
+                    .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                    .Where(f => f.IsLiteral && !f.IsSpecialName
+                                && !ScriptDoc.IsHiddenFromEditor(f))
+                    .ToArray();
+
+                foreach (System.Reflection.FieldInfo constField in exportedConstants)
+                {
+                    string constFieldDocId = ScriptDoc.GetFieldDocumentationId(constField);
+                    string? constDescription = ScriptDoc.TryGetFullDocDescription(xmlDocs, scriptType, constFieldDocId);
+
+                    var constantDoc = new Godot.Collections.Dictionary()
+                    {
+                        { "name", constField.Name },
+                        { "value", GetConstantDisplayValue(constField) },
+                        { "is_value_valid", true },
+                        { "type", ScriptDoc.GetPropertyDocTypeName(constField.FieldType) },
+                    };
+
+                    if (!string.IsNullOrWhiteSpace(constDescription))
+                        constantDoc["description"] = constDescription;
+
+                    constantDocs.Add(constantDoc);
+                }
+
+                if (enumTypes.Count > 0)
+                {
+                    var enumDocs = new global::Godot.Collections.Dictionary();
+
+                    foreach (Type enumType in enumTypes)
+                    {
+                        string enumDocId = ScriptDoc.GetTypeDocumentationId(enumType);
+                        string? enumDescription = ScriptDoc.TryGetDocTag(xmlDocs, xmlDocs != null ? enumType : scriptType, enumDocId, "summary");
+
+                        var enumDoc = new global::Godot.Collections.Dictionary();
+
+                        enumDoc["name"] = enumType.Name;
+                        if (!string.IsNullOrWhiteSpace(enumType.Namespace))
+                            enumDoc["full_name"] = $"{enumType.Namespace}.{enumType.Name}";
+                        else
+                            enumDoc["full_name"] = enumType.Name;
+
+                        if (!string.IsNullOrWhiteSpace(enumDescription))
+                            enumDoc["description"] = enumDescription;
+
+                        enumDocs[enumType.Name] = enumDoc;
+
+                        bool isBitfield = enumType.IsDefined(typeof(FlagsAttribute), inherit: false);
+                        foreach (System.Reflection.FieldInfo enumField in enumType.GetFields(BindingFlags.Public | BindingFlags.Static))
+                        {
+                            string enumFieldDocId = ScriptDoc.GetFieldDocumentationId(enumField);
+                            string? enumFieldDescription = ScriptDoc.TryGetDocTag(xmlDocs, enumType, enumFieldDocId, "summary");
+
+                            var constantDoc = new Godot.Collections.Dictionary()
+                            {
+                                { "name", enumField.Name },
+                                { "value", Convert.ToInt64(enumField.GetRawConstantValue(), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture) },
+                                { "enumeration", enumType.Name },
+                                // Add full name with namespace for proper documentation lookup
+                                { "enumeration_full_name", string.IsNullOrEmpty(enumType.Namespace) ? enumType.Name : $"{enumType.Namespace}.{enumType.Name}" },
+                                { "is_bitfield", isBitfield },
+                            };
+
+                            if (!string.IsNullOrWhiteSpace(enumFieldDescription))
+                                constantDoc["description"] = enumFieldDescription;
+
+                            constantDocs.Add(constantDoc);
+                        }
+                    }
+
+                    if (enumDocs.Count > 0)
+                        docs.Add("enums", enumDocs);
+                }
+
+                if (constantDocs.Count > 0)
+                    docs.Add("constants", constantDocs);
+
+                docs.Add("is_script_doc", true);
+                docs.Add("script_path", scriptPath ?? string.Empty);
+
+                return docs;
+            }
+            catch (Exception e)
+            {
+                GD.PushError(e.ToString());
+                return new Godot.Collections.Dictionary();
+            }
+        }
+
+        /// <summary>
+        /// Renders a constant field's value into a documentation-friendly display string,
+        /// mirroring GDScript's constant serialization (strings quoted, enums by name, etc.).
+        /// </summary>
+        private static string GetConstantDisplayValue(System.Reflection.FieldInfo constField)
+        {
+            object? rawValue = constField.GetRawConstantValue();
+            if (rawValue == null)
+                return "null";
+
+            Type fieldType = constField.FieldType;
+
+            // Enum constants render as their member name (e.g. "Primary") rather than the
+            // underlying integer, which matches how GDScript documents enum-typed constants.
+            if (fieldType.IsEnum)
+                return Enum.GetName(fieldType, rawValue) ?? rawValue.ToString() ?? string.Empty;
+
+            return rawValue switch
+            {
+                bool b => b ? "true" : "false",
+                char c => $"\"{c}\"",
+                string s => "\"" + s.Replace("\"", "\\\"") + "\"",
+                float f => f.ToString("R", CultureInfo.InvariantCulture),
+                double d => d.ToString("R", CultureInfo.InvariantCulture),
+                _ => Convert.ToString(rawValue, CultureInfo.InvariantCulture) ?? string.Empty,
+            };
+        }
+
         public override bool _Build()
         {
             return BuildManager.EditorBuildCallback();
@@ -728,7 +1096,6 @@ namespace GodotTools
         public static GodotSharpEditor Instance { get; private set; }
 #nullable enable
 
-        [UsedImplicitly]
         private static IntPtr InternalCreateInstance(IntPtr unmanagedCallbacks, int unmanagedCallbacksSize)
         {
             Internal.Initialize(unmanagedCallbacks, unmanagedCallbacksSize);

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -446,7 +446,11 @@ namespace GodotTools
                 string? briefDescription = ScriptDoc.TryGetDocTag(xmlDocs, scriptType, typeDocId, "summary",
                     implicitInheritResolver: () => scriptType.BaseType != null ? ScriptDoc.GetTypeDocumentationId(scriptType.BaseType) : null);
 
-                string? fullDescription = ScriptDoc.TryGetDocTag(xmlDocs, scriptType, typeDocId, "remarks",
+                // The full description combines summary, remarks and seealso like member
+                // descriptions do, so the class page's Description section shows the summary
+                // text too (previously it only received the remarks, while the summary was
+                // rendered above the section as the brief description).
+                string? fullDescription = ScriptDoc.TryGetFullDocDescription(xmlDocs, scriptType, typeDocId,
                     implicitInheritResolver: () => scriptType.BaseType != null ? ScriptDoc.GetTypeDocumentationId(scriptType.BaseType) : null);
 
                 bool isGlobalClass = scriptType.IsDefined(typeof(GlobalClassAttribute), inherit: false);

--- a/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
@@ -19,6 +19,7 @@ namespace GodotTools
 
                 if (Internal.IsAssembliesReloadingNeeded())
                 {
+                    ScriptDoc.ClearXmlCache();
                     BuildManager.UpdateLastValidBuildDateTime();
                     Internal.ReloadAssemblies(softReload: false);
                 }
@@ -29,6 +30,7 @@ namespace GodotTools
         {
             if (Internal.IsAssembliesReloadingNeeded())
             {
+                ScriptDoc.ClearXmlCache();
                 BuildManager.UpdateLastValidBuildDateTime();
                 Internal.ReloadAssemblies(softReload: false);
             }

--- a/modules/mono/editor/GodotTools/GodotTools/ScriptDoc.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/ScriptDoc.cs
@@ -1,0 +1,471 @@
+using Godot;
+using Godot.Bridge;
+using GodotTools.Utils;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+using ReflectionFieldInfo = System.Reflection.FieldInfo;
+using ReflectionPropertyInfo = System.Reflection.PropertyInfo;
+
+namespace GodotTools
+{
+    public static class ScriptDoc
+    {
+        private static object? _scriptTypeBiMap;
+        private static System.Reflection.MethodInfo? _getScriptTypeMethod;
+
+        public static Type? GetScriptType(IntPtr scriptPtr)
+        {
+            if (_scriptTypeBiMap == null || _getScriptTypeMethod == null)
+            {
+
+                var scriptManagerBridge = typeof(ScriptManagerBridge).GetField("_scriptTypeBiMap", BindingFlags.NonPublic | BindingFlags.Static);
+                _scriptTypeBiMap = scriptManagerBridge?.GetValue(null);
+                _getScriptTypeMethod = _scriptTypeBiMap?.GetType().GetMethod("GetScriptType", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+            }
+            var result = _getScriptTypeMethod?.Invoke(_scriptTypeBiMap, new object[] { scriptPtr });
+
+            return result is Type t ? t : null;
+        }
+
+        /// <summary>
+        /// Gets the default values for exported members of a Godot script type.
+        /// </summary>
+        /// <remarks>
+        /// The Godot source generators emit a static <c>GetGodotPropertyDefaultValues</c> method on
+        /// Godot script classes that returns a <c>System.Collections.Generic.Dictionary&lt;StringName, Variant&gt;</c>
+        /// with the default values for each exported member (as evaluated from its initializer).
+        /// This method invokes it via reflection so the documentation generator can surface those
+        /// values in the inspector and built-in documentation, mirroring how GDScript exposes
+        /// property defaults.
+        /// </remarks>
+        public static System.Collections.Generic.Dictionary<StringName, Variant>? GetPropertyDefaultValues(Type scriptType)
+        {
+            var getGodotPropertyDefaultValuesMethod = scriptType.GetMethod(
+                "GetGodotPropertyDefaultValues",
+                BindingFlags.DeclaredOnly | BindingFlags.Static |
+                BindingFlags.NonPublic | BindingFlags.Public);
+
+            if (getGodotPropertyDefaultValuesMethod == null)
+                return null;
+
+            try
+            {
+                var defaultValuesObj = getGodotPropertyDefaultValuesMethod.Invoke(null, null);
+                return defaultValuesObj as System.Collections.Generic.Dictionary<StringName, Variant>;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        internal static string GetTypeDocumentationId(Type type)
+        {
+            Type xmlType = type.IsConstructedGenericType ? type.GetGenericTypeDefinition() : type;
+            string fullName = xmlType.FullName ?? throw new InvalidOperationException($"Unable to resolve full name for type '{type}'.");
+            return $"T:{fullName.Replace('+', '.')}";
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> when the given member is marked with
+        /// <c>[EditorBrowsable(EditorBrowsableState.Never)]</c>. The Godot source generators
+        /// tag every method/property they emit with this attribute so the members stay hidden
+        /// from IntelliSense; we reuse that signal to keep generated boilerplate (e.g.
+        /// <c>GetGodotMethodList</c>, <c>InvokeGodotClassMethod</c>) out of the documentation.
+        /// </summary>
+        public static bool IsHiddenFromEditor(System.Reflection.MemberInfo member)
+        {
+            var attribute = member.GetCustomAttribute<System.ComponentModel.EditorBrowsableAttribute>(inherit: false);
+            return attribute?.State == System.ComponentModel.EditorBrowsableState.Never;
+        }
+
+        internal static string GetPropertyDocumentationId(System.Reflection.PropertyInfo property)
+            => $"P:{GetTypeDocumentationId(property.DeclaringType!).Substring(2)}.{property.Name}";
+
+        internal static string GetFieldDocumentationId(System.Reflection.FieldInfo field)
+            => $"F:{GetTypeDocumentationId(field.DeclaringType!).Substring(2)}.{field.Name}";
+
+        /// <summary>
+        /// Builds the XML documentation member id for a method, following the .NET XML
+        /// documentation signature rules (e.g. <c>M:Namespace.Class.Method(System.Int32)</c>).
+        /// </summary>
+        internal static string GetMethodDocumentationId(System.Reflection.MethodInfo method)
+        {
+            string declaringId = GetTypeDocumentationId(method.DeclaringType!).Substring(2);
+
+            // Method name includes the generic arity suffix for generic methods (e.g. ``1).
+            string methodName = method.Name;
+            if (method.IsGenericMethod)
+            {
+                methodName += "``" + method.GetGenericArguments().Length;
+            }
+
+            var sb = new System.Text.StringBuilder();
+            sb.Append("M:").Append(declaringId).Append('.').Append(methodName);
+
+            System.Reflection.ParameterInfo[] parameters = method.GetParameters();
+            if (parameters.Length > 0)
+            {
+                sb.Append('(');
+                for (int i = 0; i < parameters.Length; i++)
+                {
+                    if (i > 0)
+                        sb.Append(',');
+                    sb.Append(GetXmlParameterTypeString(parameters[i].ParameterType));
+                }
+                sb.Append(')');
+            }
+
+            // Specialization: methods whose return type differs only in return type need a
+            // disambiguating suffix (e.g. M:C.M(System.Int32)~System.String). We omit this
+            // since exported/public method overloads differing only by return type are rare
+            // and the documentation lookup falls back gracefully when not found.
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns the XML documentation string for a parameter type, matching the format
+        /// used in member id signatures (fully qualified, TRANSREF for by-ref, array notation).
+        /// </summary>
+        private static string GetXmlParameterTypeString(Type type)
+        {
+            if (type.IsByRef)
+                return GetXmlParameterTypeString(type.GetElementType()!) + "@";
+
+            if (type.IsArray)
+                return GetXmlParameterTypeString(type.GetElementType()!) + "[]";
+
+            if (type.IsPointer)
+                return GetXmlParameterTypeString(type.GetElementType()!) + "*";
+
+            if (type.IsGenericParameter)
+                return "``" + type.GenericParameterPosition;
+
+            if (type.IsConstructedGenericType)
+            {
+                Type genericDef = type.GetGenericTypeDefinition();
+                string defName = (genericDef.FullName ?? genericDef.Name).Replace('+', '.');
+                Type[] args = type.GetGenericArguments();
+                var sb = new System.Text.StringBuilder(defName).Append('{');
+                for (int i = 0; i < args.Length; i++)
+                {
+                    if (i > 0)
+                        sb.Append(',');
+                    sb.Append(GetXmlParameterTypeString(args[i]));
+                }
+                return sb.Append('}').ToString();
+            }
+
+            return (type.FullName ?? type.Name).Replace('+', '.');
+        }
+
+        public static Dictionary<string, XElement> LoadMembersFromFile(string xmlPath)
+        {
+            if (!System.IO.File.Exists(xmlPath))
+                throw new FileNotFoundException($"Required XML documentation file was not found: '{xmlPath}'.", xmlPath);
+
+            using var stream = System.IO.File.OpenRead(xmlPath);
+            XDocument document = XDocument.Load(stream);
+            XElement? membersElement = document.Root?.Element("members");
+
+            if (membersElement == null)
+                throw new InvalidOperationException($"Invalid XML documentation format. Missing '<members>' in '{xmlPath}'.");
+
+            var members = new Dictionary<string, XElement>(StringComparer.Ordinal);
+
+            foreach (XElement member in membersElement.Elements("member"))
+            {
+                XAttribute? nameAttr = member.Attribute("name");
+                if (nameAttr == null)
+                    continue;
+
+                members[nameAttr.Value] = member;
+            }
+
+            if (members.Count == 0)
+                throw new InvalidOperationException($"XML documentation '{xmlPath}' does not contain any member entries.");
+
+            return members;
+        }
+
+        public sealed class XmlDocumentationCache
+        {
+            public XmlDocumentationCache(Dictionary<string, System.Xml.Linq.XElement> members)
+            {
+                Members = members;
+            }
+
+            public Dictionary<string, System.Xml.Linq.XElement> Members { get; }
+        }
+
+        public sealed class AssemblyXmlDocumentationPath
+        {
+            public AssemblyXmlDocumentationPath(string xmlPath)
+            {
+                XmlPath = xmlPath;
+            }
+
+            public string XmlPath { get; }
+        }
+
+        public static readonly ConcurrentDictionary<string, XmlDocumentationCache> _xmlDocumentationCacheByPath =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        public static readonly ConditionalWeakTable<Assembly, AssemblyXmlDocumentationPath> _xmlDocPathByAssembly =
+            new();
+
+        public static XmlDocumentationCache LoadXmlDocumentationCache(string xmlPath) => new(LoadMembersFromFile(xmlPath));
+
+        public static XmlDocumentationCache? GetXmlDocumentationCache(Assembly assembly)
+        {
+            static bool TryGetXmlPathFromAssemblyLocation(Assembly targetAssembly, out string? xmlPath)
+            {
+                string assemblyPath = targetAssembly.Location;
+                if (!string.IsNullOrEmpty(assemblyPath))
+                {
+                    string candidate = Path.ChangeExtension(assemblyPath, ".xml");
+                    if (System.IO.File.Exists(candidate))
+                    {
+                        xmlPath = candidate;
+                        return true;
+                    }
+                }
+
+                xmlPath = null;
+                return false;
+            }
+
+            if (_xmlDocPathByAssembly.TryGetValue(assembly, out AssemblyXmlDocumentationPath? knownPath) &&
+                System.IO.File.Exists(knownPath.XmlPath))
+            {
+                return _xmlDocumentationCacheByPath.GetOrAdd(knownPath.XmlPath, LoadXmlDocumentationCache);
+            }
+
+            if (TryGetXmlPathFromAssemblyLocation(assembly, out string? resolvedXmlPath))
+                return _xmlDocumentationCacheByPath.GetOrAdd(resolvedXmlPath!, LoadXmlDocumentationCache);
+
+            // For assemblies loaded from stream (where Assembly.Location is empty),
+            // try the project's known build output directory. In the editor,
+            // assemblies are loaded via LoadFromStream to prevent file locking,
+            // which causes Assembly.Location to return empty.
+            if (TryGetXmlPathFromProjectBuildOutput(assembly, out string? projectXmlPath))
+            {
+                _xmlDocPathByAssembly.AddOrUpdate(assembly, new AssemblyXmlDocumentationPath(projectXmlPath!));
+                return _xmlDocumentationCacheByPath.GetOrAdd(projectXmlPath!, LoadXmlDocumentationCache);
+            }
+
+            string? assemblySimpleName = assembly.GetName().Name;
+            if (string.IsNullOrEmpty(assemblySimpleName))
+                return null;
+
+            string[] probeDirectories =
+            {
+                AppContext.BaseDirectory,
+                System.Environment.CurrentDirectory,
+            };
+
+            foreach (string probeDirectory in probeDirectories)
+            {
+                if (string.IsNullOrEmpty(probeDirectory))
+                    continue;
+
+                string candidate = Path.Combine(probeDirectory, assemblySimpleName + ".xml");
+                if (System.IO.File.Exists(candidate))
+                    return _xmlDocumentationCacheByPath.GetOrAdd(candidate, LoadXmlDocumentationCache);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Tries to find the XML documentation file in the project's build output directory.
+        /// This is needed because project assemblies are loaded from a memory stream
+        /// (to avoid file locking), which causes <see cref="Assembly.Location"/> to be empty.
+        /// </summary>
+        private static bool TryGetXmlPathFromProjectBuildOutput(Assembly assembly, out string? xmlPath)
+        {
+            xmlPath = null;
+
+            string? assemblyName = assembly.GetName().Name;
+            if (string.IsNullOrEmpty(assemblyName))
+                return false;
+
+            try
+            {
+                // Derive the build output directory from the known metadata directory.
+                // ResMetadataDir returns e.g. "res://.godot/mono/metadata".
+                // The editor build output is at "res://.godot/mono/temp/bin/Debug/".
+                string globalMetadataDir = ProjectSettings.GlobalizePath(
+                    Internals.GodotSharpDirs.ResMetadataDir);
+                string? monoDir = Path.GetDirectoryName(globalMetadataDir);
+                if (string.IsNullOrEmpty(monoDir))
+                    return false;
+
+                string tempAssembliesDir = Path.Combine(monoDir, "temp", "bin", "Debug");
+                string candidate = Path.Combine(tempAssembliesDir, assemblyName + ".xml");
+                if (System.IO.File.Exists(candidate))
+                {
+                    xmlPath = candidate;
+                    return true;
+                }
+            }
+            catch
+            {
+                // Ignore errors when accessing project directories.
+            }
+
+            return false;
+        }
+
+        public static string? TryGetDocTag(
+            XmlDocumentationCache? cache,
+            Type contextType,
+            string memberId,
+            string tagName,
+            Func<string?>? implicitInheritResolver = null,
+            HashSet<string>? visited = null)
+        {
+            if (cache == null)
+                return null;
+
+            return XmlDocToBBCode.TryGetTagBbCode(
+                cache.Members,
+                contextType,
+                memberId,
+                tagName,
+                implicitInheritResolver,
+                visited);
+        }
+
+        /// <summary>
+        /// Gets the full documentation description for a member, combining its
+        /// <c>summary</c>, <c>remarks</c>, <c>param</c>, <c>returns</c> and <c>exception</c>
+        /// XML documentation tags into a single BBCode string (sectioned like GDScript docs).
+        /// </summary>
+        public static string? TryGetFullDocDescription(
+            XmlDocumentationCache? cache,
+            Type contextType,
+            string memberId,
+            Func<string?>? implicitInheritResolver = null)
+        {
+            if (cache == null)
+                return null;
+
+            return XmlDocToBBCode.TryGetFullDescriptionBbCode(
+                cache.Members,
+                contextType,
+                memberId,
+                implicitInheritResolver);
+        }
+
+        public static string GetPropertyDocTypeName(Type type)
+        {
+            if (type.IsEnum)
+                return "int";
+
+            // void only applies to method return types (properties are never void).
+            // Map it to the documentation convention used by GDScript.
+            if (type == typeof(void))
+                return "void";
+
+            // Typed arrays use the "T[]" format, matching the GDScript documentation generator
+            // (gdscript_docgen.cpp appends "[]" for typed arrays). This is the format the editor
+            // documentation renderer (_add_type_to_rt in editor_help.cpp) recognizes via
+            // ends_with("[]") to produce clickable type links for the element type.
+            // e.g. float[] -> "float[]", Array<Vector3> -> "Vector3[]".
+            if (type.IsArray)
+            {
+                Type? elementType = type.GetElementType();
+                if (elementType != null)
+                    return $"{GetPropertyDocTypeName(elementType)}[]";
+            }
+
+            // Godot typed collections.
+            // Array<T> -> "T[]" (same typed-array format as above, for clickable element links).
+            // Dictionary<TKey, TValue> -> "Dictionary[TKey, TValue]" (matches the renderer's
+            // begins_with("Dictionary[") branch, which splits key/value into separate links).
+            // Using these formats avoids the raw reflection names ("Array`1", "Dictionary`2")
+            // leaking into the docs.
+            if (type.IsConstructedGenericType)
+            {
+                Type genericDefinition = type.GetGenericTypeDefinition();
+                Type[] genericArguments = type.GetGenericArguments();
+
+                if (genericDefinition == typeof(Godot.Collections.Array<>))
+                    return $"{GetPropertyDocTypeName(genericArguments[0])}[]";
+
+                if (genericDefinition == typeof(Godot.Collections.Dictionary<,>))
+                    return $"Dictionary[{GetPropertyDocTypeName(genericArguments[0])}, {GetPropertyDocTypeName(genericArguments[1])}]";
+            }
+
+            return Type.GetTypeCode(type) switch
+            {
+                TypeCode.Boolean => "bool",
+                TypeCode.Char => "int",
+                TypeCode.SByte => "int",
+                TypeCode.Byte => "int",
+                TypeCode.Int16 => "int",
+                TypeCode.UInt16 => "int",
+                TypeCode.Int32 => "int",
+                TypeCode.UInt32 => "int",
+                TypeCode.Int64 => "int",
+                TypeCode.UInt64 => "int",
+                TypeCode.Single => "float",
+                TypeCode.Double => "float",
+                TypeCode.String => "String",
+                _ => type == typeof(Variant) ? "Variant" : type.Name,
+            };
+        }
+
+        public static string? FindInheritedPropertyDocumentationId(ReflectionPropertyInfo property)
+        {
+            Type? baseType = property.DeclaringType?.BaseType;
+
+            while (baseType != null)
+            {
+                ReflectionPropertyInfo? inherited = baseType.GetProperty(property.Name,
+                    BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+
+                if (inherited != null)
+                    return XmlDocToBBCode.GetPropertyDocumentationId(inherited);
+
+                baseType = baseType.BaseType;
+            }
+
+            return null;
+        }
+
+        public static string? FindInheritedFieldDocumentationId(ReflectionFieldInfo field)
+        {
+            Type? baseType = field.DeclaringType?.BaseType;
+
+            while (baseType != null)
+            {
+                ReflectionFieldInfo? inherited = baseType.GetField(field.Name,
+                    BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+
+                if (inherited != null)
+                    return XmlDocToBBCode.GetFieldDocumentationId(inherited);
+
+                baseType = baseType.BaseType;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Clear cache when assemblies are reloaded
+        /// </summary>
+        public static void ClearXmlCache()
+        {
+            _xmlDocumentationCacheByPath.Clear();
+            _xmlDocPathByAssembly.Clear();
+        }
+    }
+}

--- a/modules/mono/editor/GodotTools/GodotTools/ScriptDoc.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/ScriptDoc.cs
@@ -171,7 +171,10 @@ namespace GodotTools
                 throw new FileNotFoundException($"Required XML documentation file was not found: '{xmlPath}'.", xmlPath);
 
             using var stream = System.IO.File.OpenRead(xmlPath);
-            XDocument document = XDocument.Load(stream);
+            // PreserveWhitespace keeps whitespace-only text nodes between adjacent elements
+            // (e.g. the space between "<b>DO NOT USE</b>" and a following "<c>...</c>"),
+            // which the default load options drop.
+            XDocument document = XDocument.Load(stream, LoadOptions.PreserveWhitespace);
             XElement? membersElement = document.Root?.Element("members");
 
             if (membersElement == null)

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/XmlDocToBBCode.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/XmlDocToBBCode.cs
@@ -1,0 +1,558 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Xml.Linq;
+
+namespace GodotTools.Utils
+{
+    internal static class XmlDocToBBCode
+    {
+        internal static string GetTypeDocumentationId(Type type)
+        {
+            Type xmlType = type.IsConstructedGenericType ? type.GetGenericTypeDefinition() : type;
+            string fullName = xmlType.FullName ?? throw new InvalidOperationException($"Unable to resolve full name for type '{type}'.");
+            return $"T:{fullName.Replace('+', '.')}";
+        }
+
+        internal static string GetPropertyDocumentationId(System.Reflection.PropertyInfo property)
+            => $"P:{GetTypeDocumentationId(property.DeclaringType!).Substring(2)}.{property.Name}";
+
+        internal static string GetFieldDocumentationId(System.Reflection.FieldInfo field)
+            => $"F:{GetTypeDocumentationId(field.DeclaringType!).Substring(2)}.{field.Name}";
+
+        internal static string? ResolveCrefToDocumentationId(
+            Dictionary<string, XElement> members,
+            Type contextType,
+            string? rawCref)
+        {
+            if (string.IsNullOrWhiteSpace(rawCref))
+                return null;
+
+            string cref = rawCref.Trim();
+
+            if (cref.Contains(':'))
+                return members.ContainsKey(cref) ? cref : null;
+
+            string contextTypeName = GetTypeDocumentationId(contextType).Substring(2);
+
+            static IEnumerable<string> PrefixedCandidates(string value)
+            {
+                yield return "T:" + value;
+                yield return "M:" + value;
+                yield return "P:" + value;
+                yield return "F:" + value;
+                yield return "E:" + value;
+            }
+
+            if (cref.Contains('('))
+            {
+                foreach (string candidate in PrefixedCandidates(contextTypeName + "." + cref))
+                {
+                    if (members.ContainsKey(candidate))
+                        return candidate;
+                }
+
+                foreach (string candidate in PrefixedCandidates(cref))
+                {
+                    if (members.ContainsKey(candidate))
+                        return candidate;
+                }
+
+                return null;
+            }
+
+            foreach (string candidate in PrefixedCandidates(cref))
+            {
+                if (members.ContainsKey(candidate))
+                    return candidate;
+            }
+
+            foreach (string candidate in PrefixedCandidates(contextTypeName + "." + cref))
+            {
+                if (members.ContainsKey(candidate))
+                    return candidate;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Strips an XML documentation <c>cref</c> value down to a human-readable name for
+        /// plain-text fallback display. Removes the member-kind prefix (<c>T:</c>, <c>M:</c>,
+        /// <c>P:</c>, <c>F:</c>, <c>E:</c>, or the unresolved <c>!:</c> marker), normalizes
+        /// generic braces to angle brackets, and drops any method parameter list.
+        /// </summary>
+        private static string StripCrefPrefix(string cref)
+        {
+            string value = cref.Trim();
+
+            // Drop the XML documentation prefix ("T:", "M:", "P:", "F:", "E:", "!:").
+            int colon = value.IndexOf(':');
+            if (colon >= 0 && colon <= 2)
+                value = value.Substring(colon + 1);
+
+            // Drop a method parameter list, e.g. "Ns.Type.Method(System.Int32)".
+            int paren = value.IndexOf('(');
+            if (paren >= 0)
+                value = value.Substring(0, paren);
+
+            // Generic type arguments use {} in cref; show them as <> for readability.
+            value = value.Replace('{', '<').Replace('}', '>');
+
+            return value.Trim();
+        }
+
+        /// <summary>
+        /// Resolves a <c>cref</c> reference to a Godot BBCode cross-reference link when the
+        /// target is a member of <paramref name="contextType"/> (the class currently being
+        /// documented). Returns <see langword="null"/> for cross-class references, in which
+        /// case the caller falls back to plain text.
+        /// </summary>
+        /// <remarks>
+        /// Uses the same bare-tag syntax the Godot documentation itself uses (e.g.
+        /// <c>[member Name]</c>, <c>[method Name]</c>, <c>[enum Name]</c>), which
+        /// <c>_add_text_to_rt</c> (editor_help.cpp) parses into clickable meta links. Only
+        /// members that actually appear on the current class's doc page are linked; anything
+        /// else (foreign types, generated helpers like SignalName.X) stays as plain text.
+        /// </remarks>
+        private static string? TryResolveDocLink(Type contextType, string rawCref)
+        {
+            // Normalize the cref into a kind prefix (T/M/P/F/E) and a dotted member path.
+            // The compiler may supply either a prefixed id ("P:Ns.T.Prop") or a bare name.
+            char kind;
+            string memberPath;
+            string cref = rawCref.Trim();
+
+            if (cref.Length > 2 && cref[1] == ':')
+            {
+                kind = cref[0];
+                memberPath = StripCrefPrefix(cref);
+            }
+            else
+            {
+                // Bare name: infer the kind by reflecting on the current type.
+                memberPath = cref;
+                kind = InferMemberKind(contextType, cref);
+            }
+
+            if (kind == '\0')
+                return null;
+
+            // For references that include a dotted path, require the path to be a direct
+            // member of the current class. We strip the current class prefix; any remaining dot
+            // means the target lives on a nested type (e.g. SignalName.StatsChanged) and must
+            // not be linked, since those helpers are not part of the documented API surface.
+            if (memberPath.Contains('.'))
+            {
+                string? fullName = contextType.FullName;
+                string shortName = contextType.Name;
+
+                string? trimmed = null;
+                if (fullName != null && (memberPath == fullName || memberPath.StartsWith(fullName + ".", StringComparison.Ordinal)))
+                    trimmed = memberPath == fullName ? string.Empty : memberPath.Substring(fullName.Length + 1);
+                else if (memberPath == shortName || memberPath.StartsWith(shortName + ".", StringComparison.Ordinal))
+                    trimmed = memberPath == shortName ? string.Empty : memberPath.Substring(shortName.Length + 1);
+
+                // trimmed now holds the member name relative to the current class. If it still
+                // contains a dot, the target is on a nested type -> not a direct member -> skip.
+                if (trimmed == null || trimmed.Contains('.'))
+                    return null;
+            }
+
+            string simpleName = GetSimpleName(memberPath);
+
+            switch (kind)
+            {
+                case 'M':
+                    return $"[method {simpleName}]";
+                case 'P':
+                    return $"[member {simpleName}]";
+                case 'E':
+                    return $"[signal {simpleName}]";
+                case 'F':
+                    // If the constant is a value of a nested enum, link to that enum.
+                    if (TryResolveEnumValue(contextType, simpleName, out string enumName))
+                        return $"[enum {enumName}]";
+                    return $"[constant {simpleName}]";
+                case 'T':
+                    // A nested enum of the current class links via [enum Name].
+                    Type? nested = contextType.GetNestedType(simpleName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
+                    if (nested != null && nested.IsEnum)
+                        return $"[enum {simpleName}]";
+                    return null;
+                default:
+                    return null;
+            }
+        }
+
+        /// <summary>
+        /// Infers the documentation kind of a bare cref name by reflecting on the current type,
+        /// returning 'T'/'M'/'P'/'F'/'E'/'\0'. '\0' means the name was not found or refers to a
+        /// source-generator helper that should not be linked (e.g. SignalName/MethodName/PropertyName
+        /// nested classes, or members marked EditorBrowsableState.Never).
+        /// </summary>
+        private static char InferMemberKind(Type contextType, string cref)
+        {
+            const System.Reflection.BindingFlags Flags =
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Static |
+                System.Reflection.BindingFlags.DeclaredOnly;
+
+            string name = GetSimpleName(cref);
+
+            // Nested type. Skip source-generator helper classes (SignalName, MethodName,
+            // PropertyName) and anything hidden from the editor, since those are not part of
+            // the documented API surface and links to them would not resolve.
+            Type? nestedType = contextType.GetNestedType(name, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
+            if (nestedType != null)
+            {
+                if (IsGeneratedHelperType(nestedType))
+                    return '\0';
+                return 'T';
+            }
+
+            if (contextType.GetProperty(name, Flags) is { } prop && !IsHiddenMember(prop))
+                return 'P';
+
+            if (contextType.GetMethod(name, Flags) is { } method && !IsHiddenMember(method))
+                return 'M';
+
+            if (contextType.GetField(name, Flags) is { } field && !IsHiddenMember(field))
+                return 'F';
+
+            if (contextType.GetEvent(name, Flags) is { } evt && !IsHiddenMember(evt))
+                return 'E';
+
+            return '\0';
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> for the source-generator-emitted helper nested types
+        /// (SignalName, MethodName, PropertyName) and any type marked EditorBrowsableState.Never,
+        /// which must not be linked from documentation.
+        /// </summary>
+        private static bool IsGeneratedHelperType(Type type)
+        {
+            if (type.GetCustomAttribute<System.ComponentModel.EditorBrowsableAttribute>(inherit: false)?.State
+                == System.ComponentModel.EditorBrowsableState.Never)
+                return true;
+
+            // The well-known generated nested classes used to reference exported members.
+            return type.Name is "SignalName" or "MethodName" or "PropertyName";
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> for members the source generator marks as hidden from
+        /// the editor (EditorBrowsableState.Never), so they are not linked from documentation.
+        /// </summary>
+        private static bool IsHiddenMember(System.Reflection.MemberInfo member)
+        {
+            return member.GetCustomAttribute<System.ComponentModel.EditorBrowsableAttribute>(inherit: false)?.State
+                == System.ComponentModel.EditorBrowsableState.Never;
+        }
+
+        /// <summary>
+        /// Returns the simple (last) segment of a dotted member path, with any method
+        /// parameter list stripped.
+        /// </summary>
+        private static string GetSimpleName(string memberPath)
+        {
+            int paren = memberPath.IndexOf('(');
+            string path = paren >= 0 ? memberPath.Substring(0, paren) : memberPath;
+            int dot = path.LastIndexOf('.');
+            return dot >= 0 ? path.Substring(dot + 1) : path;
+        }
+
+        /// <summary>
+        /// If <paramref name="simpleName"/> names a static field of one of the current class's
+        /// nested enums, returns that enum's name via <paramref name="enumName"/>.
+        /// </summary>
+        private static bool TryResolveEnumValue(Type contextType, string simpleName, out string enumName)
+        {
+            enumName = string.Empty;
+            Type[] nestedTypes = contextType.GetNestedTypes(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
+            foreach (Type nested in nestedTypes)
+            {
+                if (!nested.IsEnum)
+                    continue;
+                if (nested.GetField(simpleName) != null)
+                {
+                    enumName = nested.Name;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        internal static string RenderNodesToBbCode(Dictionary<string, XElement> members, Type contextType, IEnumerable<XNode> nodes)
+        {
+            var sb = new StringBuilder();
+
+            void Render(XNode node)
+            {
+                switch (node)
+                {
+                    case XCData cdata:
+                        sb.Append(cdata.Value);
+                        break;
+                    case XText text:
+                        sb.Append(text.Value);
+                        break;
+                    case XElement element:
+                    {
+                        string elementName = element.Name.LocalName;
+
+                        switch (elementName)
+                        {
+                            case "c":
+                                sb.Append("[code]");
+                                foreach (XNode child in element.Nodes())
+                                    Render(child);
+                                sb.Append("[/code]");
+                                break;
+                            case "code":
+                                sb.Append("[codeblocks][csharp]");
+                                sb.Append(element.Value.Trim());
+                                sb.Append("[/csharp][/codeblocks]");
+                                break;
+                            case "para":
+                                sb.AppendLine();
+                                foreach (XNode child in element.Nodes())
+                                    Render(child);
+                                sb.AppendLine();
+                                break;
+                            case "see":
+                            {
+                                string? href = element.Attribute("href")?.Value;
+                                if (!string.IsNullOrWhiteSpace(href))
+                                {
+                                    string label = element.Value.Trim();
+                                    if (string.IsNullOrEmpty(label))
+                                        label = href;
+                                    sb.Append("[url=").Append(href).Append(']').Append(label).Append("[/url]");
+                                    break;
+                                }
+
+                                string? langword = element.Attribute("langword")?.Value;
+                                if (!string.IsNullOrWhiteSpace(langword))
+                                {
+                                    sb.Append("[code]").Append(langword).Append("[/code]");
+                                    break;
+                                }
+
+                                string? cref = element.Attribute("cref")?.Value;
+                                if (!string.IsNullOrWhiteSpace(cref))
+                                {
+                                    // Try to emit a clickable in-page link when the cref targets
+                                    // a member of the class currently being documented. Otherwise
+                                    // fall back to plain text showing the cleaned-up cref name.
+                                    string? link = TryResolveDocLink(contextType, cref);
+                                    if (link != null)
+                                        sb.Append(link);
+                                    else
+                                        sb.Append("[code]").Append(StripCrefPrefix(cref)).Append("[/code]");
+                                }
+
+                                break;
+                            }
+                            case "paramref":
+                            {
+                                string? name = element.Attribute("name")?.Value;
+                                if (!string.IsNullOrEmpty(name))
+                                    sb.Append("[param ").Append(name).Append(']');
+                                break;
+                            }
+                            case "typeparamref":
+                            {
+                                string? name = element.Attribute("name")?.Value;
+                                if (!string.IsNullOrEmpty(name))
+                                    sb.Append("[code]").Append(name).Append("[/code]");
+                                break;
+                            }
+                            case "inheritdoc":
+                            {
+                                string? targetId = ResolveCrefToDocumentationId(members, contextType, element.Attribute("cref")?.Value);
+                                if (targetId != null && members.TryGetValue(targetId, out XElement? inheritedMember))
+                                {
+                                    XElement? inheritedSummary = inheritedMember.Element("summary");
+                                    if (inheritedSummary != null)
+                                    {
+                                        foreach (XNode child in inheritedSummary.Nodes())
+                                            Render(child);
+                                    }
+                                }
+                                break;
+                            }
+                            default:
+                                foreach (XNode child in element.Nodes())
+                                    Render(child);
+                                break;
+                        }
+
+                        break;
+                    }
+                }
+            }
+
+            foreach (XNode node in nodes)
+                Render(node);
+
+            string rendered = sb.ToString();
+            if (rendered.Length == 0)
+                return rendered;
+
+            // Trim leading whitespace on each line because XML doc has indentation
+            string[] lines = rendered.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+
+            StringBuilder sbNormalized = new StringBuilder();
+            bool firstLine = true;
+            foreach (string line in lines)
+            {
+                string trimmedLine = line.TrimStart();
+                if (string.IsNullOrWhiteSpace(trimmedLine))
+                    continue;
+
+                if (!firstLine)
+                    sbNormalized.Append("[br]");
+
+                sbNormalized.Append(trimmedLine);
+                firstLine = false;
+            }
+
+            return sbNormalized.ToString().Trim();
+        }
+
+        internal static string? TryGetTagBbCode(
+            Dictionary<string, XElement> members,
+            Type contextType,
+            string memberId,
+            string tagName,
+            Func<string?>? implicitInheritResolver = null,
+            HashSet<string>? visited = null)
+        {
+            visited ??= new HashSet<string>(StringComparer.Ordinal);
+            string recursionKey = memberId + "|" + tagName;
+
+            if (!visited.Add(recursionKey))
+                return null;
+
+            if (!members.TryGetValue(memberId, out XElement? memberElement))
+                return null;
+
+            XElement? tagElement = memberElement.Element(tagName);
+            if (tagElement != null)
+            {
+                string text = RenderNodesToBbCode(members, contextType, tagElement.Nodes());
+                if (!string.IsNullOrWhiteSpace(text))
+                    return text;
+            }
+
+            string? inheritedTarget = ResolveCrefToDocumentationId(members, contextType, memberElement.Element("inheritdoc")?.Attribute("cref")?.Value);
+            inheritedTarget ??= implicitInheritResolver?.Invoke();
+
+            if (string.IsNullOrEmpty(inheritedTarget))
+                return null;
+
+            return TryGetTagBbCode(members, contextType, inheritedTarget, tagName, null, visited);
+        }
+
+        /// <summary>
+        /// Renders a full BBCode description for a documentation member, combining its
+        /// <c>summary</c>, <c>remarks</c>, <c>param</c>, <c>returns</c> and <c>exception</c>
+        /// tags into a single string using the same sectioned layout as the GDScript
+        /// documentation (e.g. "[b]Parameters:[/b]", "[b]Exceptions:[/b]"). This lets C#
+        /// XML documentation tags that were previously dropped (remarks, exception, etc.)
+        /// surface in the inspector and built-in documentation.
+        /// </summary>
+        internal static string? TryGetFullDescriptionBbCode(
+            Dictionary<string, XElement> members,
+            Type contextType,
+            string memberId,
+            Func<string?>? implicitInheritResolver = null,
+            HashSet<string>? visited = null)
+        {
+            visited ??= new HashSet<string>(StringComparer.Ordinal);
+            string recursionKey = memberId + "|fulldesc";
+            if (!visited.Add(recursionKey))
+                return null;
+
+            if (!members.TryGetValue(memberId, out XElement? memberElement))
+                return null;
+
+            var sections = new StringBuilder();
+
+            // summary
+            string? summary = TryGetTagBbCode(members, contextType, memberId, "summary", null, visited);
+            if (!string.IsNullOrWhiteSpace(summary))
+                sections.Append(summary);
+
+            // remarks -> Note section
+            string? remarks = TryGetTagBbCode(members, contextType, memberId, "remarks", null, visited);
+            if (!string.IsNullOrWhiteSpace(remarks))
+            {
+                if (sections.Length > 0)
+                    sections.Append("[br]");
+                sections.Append("[b]Note:[/b] ").Append(remarks);
+            }
+
+            // param -> Parameters section
+            var paramElements = memberElement.Elements("param").ToList();
+            if (paramElements.Count > 0)
+            {
+                if (sections.Length > 0)
+                    sections.Append("[br]");
+                sections.Append("[b]Parameters:[/b]");
+                foreach (XElement param in paramElements)
+                {
+                    string paramName = param.Attribute("name")?.Value ?? string.Empty;
+                    string paramDesc = RenderNodesToBbCode(members, contextType, param.Nodes());
+                    sections.Append("[br] • [b]").Append(paramName).Append("[/b]");
+                    if (!string.IsNullOrWhiteSpace(paramDesc))
+                        sections.Append(": ").Append(paramDesc);
+                }
+            }
+
+            // returns -> Returns section
+            string? returns = TryGetTagBbCode(members, contextType, memberId, "returns", null, visited);
+            if (!string.IsNullOrWhiteSpace(returns))
+            {
+                if (sections.Length > 0)
+                    sections.Append("[br]");
+                sections.Append("[b]Returns:[/b][br] • ").Append(returns);
+            }
+
+            // exception -> Exceptions section
+            var exceptionElements = memberElement.Elements("exception").ToList();
+            if (exceptionElements.Count > 0)
+            {
+                if (sections.Length > 0)
+                    sections.Append("[br]");
+                sections.Append("[b]Exceptions:[/b]");
+                foreach (XElement exception in exceptionElements)
+                {
+                    string cref = exception.Attribute("cref")?.Value ?? string.Empty;
+                    string cleanedCref = cref.Replace('{', '<').Replace('}', '>');
+                    string exceptionDesc = RenderNodesToBbCode(members, contextType, exception.Nodes());
+                    sections.Append("[br] • [b]").Append(cleanedCref).Append("[/b]");
+                    if (!string.IsNullOrWhiteSpace(exceptionDesc))
+                        sections.Append(": ").Append(exceptionDesc);
+                }
+            }
+
+            if (sections.Length > 0)
+                return sections.ToString();
+
+            // If this member has nothing of its own, follow inheritdoc / implicit inheritance.
+            string? inheritedTarget = ResolveCrefToDocumentationId(members, contextType, memberElement.Element("inheritdoc")?.Attribute("cref")?.Value);
+            inheritedTarget ??= implicitInheritResolver?.Invoke();
+
+            if (string.IsNullOrEmpty(inheritedTarget))
+                return null;
+
+            return TryGetFullDescriptionBbCode(members, contextType, inheritedTarget, null, visited);
+        }
+    }
+}

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/XmlDocToBBCode.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/XmlDocToBBCode.cs
@@ -307,6 +307,18 @@ namespace GodotTools.Utils
 
                         switch (elementName)
                         {
+                            case "b":
+                                sb.Append("[b]");
+                                foreach (XNode child in element.Nodes())
+                                    Render(child);
+                                sb.Append("[/b]");
+                                break;
+                            case "i":
+                                sb.Append("[i]");
+                                foreach (XNode child in element.Nodes())
+                                    Render(child);
+                                sb.Append("[/i]");
+                                break;
                             case "c":
                                 sb.Append("[code]");
                                 foreach (XNode child in element.Nodes())
@@ -319,9 +331,13 @@ namespace GodotTools.Utils
                                 sb.Append("[/csharp][/codeblocks]");
                                 break;
                             case "para":
+                                // Blank lines around the content so the normalization pass
+                                // below turns them into a [br] paragraph separator.
+                                sb.AppendLine();
                                 sb.AppendLine();
                                 foreach (XNode child in element.Nodes())
                                     Render(child);
+                                sb.AppendLine();
                                 sb.AppendLine();
                                 break;
                             case "see":
@@ -404,22 +420,63 @@ namespace GodotTools.Utils
             if (rendered.Length == 0)
                 return rendered;
 
-            // Trim leading whitespace on each line because XML doc has indentation
-            string[] lines = rendered.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            // XML doc comments are hard-wrapped at the source line width, so a single newline
+            // is a soft wrap that must be joined with a space; only a blank line between two
+            // paragraphs becomes a [br]. Content inside [codeblocks] is left untouched, since
+            // the editor renders it as preformatted code that keeps its own line structure.
+            var sbNormalized = new StringBuilder();
 
-            StringBuilder sbNormalized = new StringBuilder();
-            bool firstLine = true;
-            foreach (string line in lines)
+            // Separator to place before the next content line: null when nothing was emitted
+            // yet, a space after a soft wrap, "[br]" across a paragraph boundary.
+            string? pendingSeparator = null;
+
+            void AppendTextLines(string text)
             {
-                string trimmedLine = line.TrimStart();
-                if (string.IsNullOrWhiteSpace(trimmedLine))
-                    continue;
+                string[] lines = text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+                foreach (string line in lines)
+                {
+                    // Trim leading whitespace on each line because XML doc has indentation.
+                    string trimmedLine = line.TrimStart();
+                    if (string.IsNullOrWhiteSpace(trimmedLine))
+                    {
+                        if (pendingSeparator != null)
+                            pendingSeparator = "[br]";
+                        continue;
+                    }
 
-                if (!firstLine)
+                    if (pendingSeparator != null)
+                        sbNormalized.Append(pendingSeparator);
+                    sbNormalized.Append(trimmedLine);
+                    pendingSeparator = " ";
+                }
+            }
+
+            int pos = 0;
+            while (pos < rendered.Length)
+            {
+                int blockStart = rendered.IndexOf("[codeblocks]", pos, StringComparison.Ordinal);
+                if (blockStart < 0)
+                {
+                    AppendTextLines(rendered.Substring(pos));
+                    break;
+                }
+
+                AppendTextLines(rendered.Substring(pos, blockStart - pos));
+
+                int blockEnd = rendered.IndexOf("[/codeblocks]", blockStart, StringComparison.Ordinal);
+                if (blockEnd < 0)
+                {
+                    // Unterminated marker; treat the rest as regular text.
+                    AppendTextLines(rendered.Substring(blockStart));
+                    break;
+                }
+
+                if (pendingSeparator != null)
                     sbNormalized.Append("[br]");
-
-                sbNormalized.Append(trimmedLine);
-                firstLine = false;
+                int afterBlock = blockEnd + "[/codeblocks]".Length;
+                sbNormalized.Append(rendered, blockStart, afterBlock - blockStart);
+                pendingSeparator = "[br]";
+                pos = afterBlock;
             }
 
             return sbNormalized.ToString().Trim();
@@ -539,6 +596,44 @@ namespace GodotTools.Utils
                     sections.Append("[br] • [b]").Append(cleanedCref).Append("[/b]");
                     if (!string.IsNullOrWhiteSpace(exceptionDesc))
                         sections.Append(": ").Append(exceptionDesc);
+                }
+            }
+
+            // seealso -> See also section
+            var seealsoElements = memberElement.Elements("seealso").ToList();
+            if (seealsoElements.Count > 0)
+            {
+                if (sections.Length > 0)
+                    sections.Append("[br]");
+                sections.Append("[b]See also:[/b]");
+                foreach (XElement seealso in seealsoElements)
+                {
+                    string? href = seealso.Attribute("href")?.Value;
+                    string? cref = seealso.Attribute("cref")?.Value;
+                    if (!string.IsNullOrWhiteSpace(href))
+                    {
+                        string label = seealso.Value.Trim();
+                        if (string.IsNullOrEmpty(label))
+                            label = href;
+                        sections.Append("[br] • [url=").Append(href).Append(']').Append(label).Append("[/url]");
+                    }
+                    else if (!string.IsNullOrWhiteSpace(cref))
+                    {
+                        // Same resolution rules as an inline <see>: link members of the class
+                        // currently being documented, fall back to plain text otherwise.
+                        string? link = TryResolveDocLink(contextType, cref);
+                        sections.Append("[br] • ");
+                        if (link != null)
+                            sections.Append(link);
+                        else
+                            sections.Append("[code]").Append(StripCrefPrefix(cref)).Append("[/code]");
+                    }
+                    else
+                    {
+                        string text = RenderNodesToBbCode(members, contextType, seealso.Nodes());
+                        if (!string.IsNullOrWhiteSpace(text))
+                            sections.Append("[br] • ").Append(text);
+                    }
                 }
             }
 


### PR DESCRIPTION
Supersedes #83505
I am opening an additional PR so that the two approaches can be compared in terms of their strengths and weaknesses.

This PR moves the implementation logic into GodotTools.dll instead of using a source generator.
Under debug mode, the default settings are 'GenerateDocumentationFile=true' and 'NoWarn1591'.
You can manually set 'EnableDocumentationWarning=true' to recover 1591 separately.

For related discussion, please continue in #83505.

"ScriptManagerBridge.GetManagedScriptType" is currently obtained using reflection. If there is a public method (#117696), reflection is not necessary