### PR TITLE
Use user signals for `JNISingleton`

### DIFF
--- a/platform/android/api/jni_singleton.cpp
+++ b/platform/android/api/jni_singleton.cpp
@@ -73,5 +73,5 @@ void JNISingleton::add_signal(const StringName &p_name, const Vector<Variant::Ty
 	for (int i = 0; i < p_args.size(); i++) {
 		mi.arguments.push_back(PropertyInfo(p_args[i], "arg" + itos(i + 1)));
 	}
-	ADD_SIGNAL(mi);
+	add_user_signal(mi);
 }


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/116615
- Supersedes https://github.com/godotengine/godot/pull/117079

This fixes an issue where signals would be registered on `JNISingleton` instead of singular instances (which is the expected behavior with the current API). It also prepares for #117443, since mutations of `GDType` after init are unexpected and can lead to crashes.

The trade-off is that signals are no longer registered in `ClassDB` on `JNISingleton`, which is a net plus since the signals are not expected to exist on `JNISingleton` but on individual singletons. Querying via `singleton.has_signal` is still supported.

**Note:** I did not test this change.