### PR TITLE
Deprecate `ScriptLanguage::instance_has`

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -163,7 +163,6 @@ PropertyInfo Script::get_class_category() const {
 void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("can_instantiate"), &Script::can_instantiate);
 	//ClassDB::bind_method(D_METHOD("instance_create","base_object"),&Script::instance_create);
-	ClassDB::bind_method(D_METHOD("instance_has", "base_object"), &Script::instance_has);
 	ClassDB::bind_method(D_METHOD("has_source_code"), &Script::has_source_code);
 	ClassDB::bind_method(D_METHOD("get_source_code"), &Script::get_source_code);
 	ClassDB::bind_method(D_METHOD("set_source_code", "source"), &Script::set_source_code);
@@ -186,6 +185,14 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_abstract"), &Script::is_abstract);
 
 	ClassDB::bind_method(D_METHOD("get_rpc_config"), &Script::_get_rpc_config_bind);
+
+#ifndef DISABLE_DEPRECATED
+	GODOT_PUSH_IGNORE_DEPRECATION();
+
+	ClassDB::bind_method(D_METHOD("instance_has", "base_object"), &Script::instance_has);
+
+	GODOT_POP_IGNORE_DEPRECATION();
+#endif // !DISABLE_DEPRECATED
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_source_code", "get_source_code");
 }

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -151,7 +151,6 @@ public:
 	virtual StringName get_instance_base_type() const = 0; // this may not work in all scripts, will return empty if so
 	virtual ScriptInstance *instance_create(Object *p_this) = 0;
 	virtual PlaceHolderScriptInstance *placeholder_instance_create(Object *p_this) { return nullptr; }
-	virtual bool instance_has(const Object *p_this) const = 0;
 
 	virtual bool has_source_code() const = 0;
 	virtual String get_source_code() const = 0;
@@ -200,6 +199,10 @@ public:
 	Script() {
 		_define_ancestry(AncestralClass::SCRIPT);
 	}
+
+#ifndef DISABLE_DEPRECATED
+	[[deprecated("Use Object::get_script instead.")]] bool instance_has(const Object *p_this) const { return p_this != nullptr && Object::cast_to<Script>(p_this->get_script()) == this; }
+#endif // !DISABLE_DEPRECATED
 };
 
 class ScriptLanguage : public Object {

--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -45,8 +45,6 @@ void ScriptExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_instance_create, "for_object");
 	GDVIRTUAL_BIND(_placeholder_instance_create, "for_object");
 
-	GDVIRTUAL_BIND(_instance_has, "object");
-
 	GDVIRTUAL_BIND(_has_source_code);
 	GDVIRTUAL_BIND(_get_source_code);
 
@@ -86,6 +84,10 @@ void ScriptExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_is_placeholder_fallback_enabled);
 
 	GDVIRTUAL_BIND(_get_rpc_config);
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND(_instance_has, "object");
+#endif // !DISABLE_DEPRECATED
 }
 
 void ScriptLanguageExtension::_bind_methods() {

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -69,7 +69,6 @@ public:
 		return reinterpret_cast<PlaceHolderScriptInstance *>(ret.operator void *());
 	}
 
-	EXBIND1RC(bool, instance_has, const Object *)
 	EXBIND0RC(bool, has_source_code)
 	EXBIND0RC(String, get_source_code)
 	EXBIND1(set_source_code, const String &)
@@ -214,6 +213,10 @@ public:
 		GDVIRTUAL_CALL(_get_rpc_config, ret);
 		return ret;
 	}
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL1RC(bool, _instance_has, const Object *)
+#endif // !DISABLE_DEPRECATED
 };
 
 typedef ScriptLanguage::ProfilingInfo ScriptLanguageExtensionProfilingInfo;

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -309,6 +309,22 @@ inline constexpr bool is_zero_constructible_v = is_zero_constructible<T>::value;
 #define GODOT_MSVC_WARNING_PUSH_AND_IGNORE(m_warning)
 #endif
 
+// Deprecation warning suppression helper macros.
+#if defined(__clang__)
+#define GODOT_PUSH_IGNORE_DEPRECATION() GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations")
+#define GODOT_POP_IGNORE_DEPRECATION() GODOT_CLANG_WARNING_POP
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+#define GODOT_PUSH_IGNORE_DEPRECATION() GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations")
+#define GODOT_POP_IGNORE_DEPRECATION() GODOT_GCC_WARNING_POP
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#define GODOT_PUSH_IGNORE_DEPRECATION() GODOT_MSVC_WARNING_PUSH_AND_IGNORE(4996)
+#define GODOT_POP_IGNORE_DEPRECATION() GODOT_MSVC_WARNING_POP
+#endif
+
 template <typename T, typename = void>
 struct is_fully_defined : std::false_type {};
 

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -112,7 +112,7 @@
 				[b]Note:[/b] If a script does not have source code, this does not mean that it is invalid or unusable. For example, a [GDScript] that was exported with binary tokenization has no source code, but still behaves as expected and could be instantiated. This can be checked with [method can_instantiate].
 			</description>
 		</method>
-		<method name="instance_has" qualifiers="const">
+		<method name="instance_has" qualifiers="const" deprecated="Compare this script with [method Object.get_script] instead.">
 			<return type="bool" />
 			<param index="0" name="base_object" type="Object" />
 			<description>

--- a/doc/classes/ScriptExtension.xml
+++ b/doc/classes/ScriptExtension.xml
@@ -153,7 +153,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_instance_has" qualifiers="virtual required const">
+		<method name="_instance_has" qualifiers="virtual const" deprecated="This method is not called by the engine.">
 			<return type="bool" />
 			<param index="0" name="object" type="Object" />
 			<description>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -435,15 +435,6 @@ PlaceHolderScriptInstance *GDScript::placeholder_instance_create(Object *p_this)
 #endif
 }
 
-bool GDScript::instance_has(const Object *p_this) const {
-	GDScriptInstance *instance = dynamic_cast<GDScriptInstance *>(p_this->get_script_instance());
-
-	if (instance == nullptr) {
-		return false;
-	}
-	return instance->script.ptr() == this;
-}
-
 bool GDScript::has_source_code() const {
 	return !source.is_empty();
 }

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -285,7 +285,6 @@ public:
 	virtual StringName get_instance_base_type() const override; // this may not work in all scripts, will return empty if so
 	virtual ScriptInstance *instance_create(Object *p_this) override;
 	virtual PlaceHolderScriptInstance *placeholder_instance_create(Object *p_this) override;
-	virtual bool instance_has(const Object *p_this) const override;
 
 	virtual bool has_source_code() const override;
 	virtual String get_source_code() const override;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2488,11 +2488,6 @@ PlaceHolderScriptInstance *CSharpScript::placeholder_instance_create(Object *p_t
 #endif
 }
 
-bool CSharpScript::instance_has(const Object *p_this) const {
-	MutexLock lock(CSharpLanguage::get_singleton()->script_instances_mutex);
-	return instances.has((Object *)p_this);
-}
-
 bool CSharpScript::has_source_code() const {
 	return !source.is_empty();
 }

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -234,7 +234,6 @@ public:
 	StringName get_instance_base_type() const override;
 	ScriptInstance *instance_create(Object *p_this) override;
 	PlaceHolderScriptInstance *placeholder_instance_create(Object *p_this) override;
-	bool instance_has(const Object *p_this) const override;
 
 	bool has_source_code() const override;
 	String get_source_code() const override;


### PR DESCRIPTION
Stumbled into this method over in https://github.com/godotengine/godot/pull/118186

It's present since "Godot is open source" and unused by the engine. The implementation seems pretty dubious to me (requiring thread synchronization for this check). Based on the current GDScript implementation, `some_script.instance_has(some_object)` behaves the same as `some_object.get_script() == some_script` except for two differences:
- `instance_has` accepts `null` values, `Object::get_script()` requires a manual null check
- `instance_has` does not recognize placeholder instances, `Object::get_script()` does. I don't consider this a relevant part of the methods contract.

By removing this we get rid of a severely under-documented method that `ScriptLanguage`s need to implement.

~I did leave the C# implementation in place, but assuming it behaves identical we could remove it as well I guess.~ -> I also removed the C# implementation based on feedback on RC, that it behaves identical