### PR TITLE
Autocompletion: Remove unnecessary `HashMap` copy

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1176,9 +1176,7 @@ static void _list_available_types(bool p_inherit_only, GDScriptParser::Completio
 	}
 
 	// Autoload singletons
-	HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads(ProjectSettings::get_singleton()->get_autoload_list());
-
-	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
+	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : ProjectSettings::get_singleton()->get_autoload_list()) {
 		const ProjectSettings::AutoloadInfo &info = E.value;
 		if (!info.is_singleton || !info.path.has_extension("gd")) {
 			continue;


### PR DESCRIPTION
The explicit copy is from https://github.com/godotengine/godot/pull/115093 so the original implicit copy was likely an accident. There is no need to copy in this situation.
