### PR TITLE
Implement Swizzling for Vectors and Color types (no zero templates)

### DIFF
--- a/core/math/color.h
+++ b/core/math/color.h
@@ -31,9 +31,13 @@
 #pragma once
 
 #include "core/math/math_funcs.h"
+#include "core/math/vector_swizzling.h"
 #include "core/templates/hashfuncs.h"
 
 class String;
+struct Vector2;
+struct Vector3;
+struct Vector4;
 
 struct [[nodiscard]] Color {
 	union {
@@ -47,6 +51,8 @@ struct [[nodiscard]] Color {
 		float components[4] = { 0, 0, 0, 1.0 };
 		// NOLINTEND(modernize-use-default-member-init)
 	};
+
+	COLOR_SWIZZLING_SETGET()
 
 	uint32_t to_rgba32() const;
 	uint32_t to_argb32() const;

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -32,9 +32,12 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
+#include "core/math/vector_swizzling.h"
 #include "core/templates/hashfuncs.h"
 
 class String;
+struct Vector3;
+struct Vector4;
 struct Vector2i;
 
 struct [[nodiscard]] Vector2 {
@@ -65,6 +68,8 @@ struct [[nodiscard]] Vector2 {
 		real_t coord[2] = { 0 };
 		// NOLINTEND(modernize-use-default-member-init)
 	};
+
+	VECTOR_SWIZZLING_SETGET()
 
 	_FORCE_INLINE_ real_t &operator[](int p_axis) {
 		DEV_ASSERT((unsigned int)p_axis < 2);

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -32,9 +32,12 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
+#include "core/math/vector_swizzling.h"
 #include "core/templates/hashfuncs.h"
 
 class String;
+struct Vector3i;
+struct Vector4i;
 struct Vector2;
 
 struct [[nodiscard]] Vector2i {
@@ -65,6 +68,8 @@ struct [[nodiscard]] Vector2i {
 		int32_t coord[2] = { 0 };
 		// NOLINTEND(modernize-use-default-member-init)
 	};
+
+	VECTOR_SWIZZLING_SETGET()
 
 	_FORCE_INLINE_ int32_t &operator[](int p_axis) {
 		DEV_ASSERT((unsigned int)p_axis < 2);

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -32,10 +32,12 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
+#include "core/math/vector_swizzling.h"
 #include "core/string/ustring.h"
 
 struct Basis;
 struct Vector2;
+struct Vector4;
 struct Vector3i;
 
 struct [[nodiscard]] Vector3 {
@@ -71,6 +73,8 @@ struct [[nodiscard]] Vector3 {
 		real_t coord[3] = { 0 };
 		// NOLINTEND(modernize-use-default-member-init)
 	};
+
+	VECTOR_SWIZZLING_SETGET()
 
 	_FORCE_INLINE_ const real_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 3);

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -32,9 +32,12 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
+#include "core/math/vector_swizzling.h"
 #include "core/templates/hashfuncs.h"
 
 class String;
+struct Vector2i;
+struct Vector4i;
 struct Vector3;
 
 struct [[nodiscard]] Vector3i {
@@ -64,6 +67,8 @@ struct [[nodiscard]] Vector3i {
 		int32_t coord[3] = { 0 };
 		// NOLINTEND(modernize-use-default-member-init)
 	};
+
+	VECTOR_SWIZZLING_SETGET()
 
 	_FORCE_INLINE_ const int32_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 3);

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -32,10 +32,13 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/math_defs.h"
+#include "core/math/vector_swizzling.h"
 #include "core/templates/hashfuncs.h"
 #include "core/typedefs.h"
 
 class String;
+struct Vector2;
+struct Vector3;
 struct Vector4i;
 
 struct [[nodiscard]] Vector4 {
@@ -59,6 +62,8 @@ struct [[nodiscard]] Vector4 {
 		real_t coord[4] = { 0, 0, 0, 0 };
 		// NOLINTEND(modernize-use-default-member-init)
 	};
+
+	VECTOR_SWIZZLING_SETGET()
 
 	_FORCE_INLINE_ real_t &operator[](int p_axis) {
 		DEV_ASSERT((unsigned int)p_axis < 4);

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -32,9 +32,12 @@
 
 #include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
+#include "core/math/vector_swizzling.h"
 #include "core/templates/hashfuncs.h"
 
 class String;
+struct Vector2i;
+struct Vector3i;
 struct Vector4;
 
 struct [[nodiscard]] Vector4i {
@@ -59,6 +62,8 @@ struct [[nodiscard]] Vector4i {
 		int32_t coord[4] = { 0 };
 		// NOLINTEND(modernize-use-default-member-init)
 	};
+
+	VECTOR_SWIZZLING_SETGET()
 
 	_FORCE_INLINE_ const int32_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 4);

--- a/core/math/vector_swizzling.h
+++ b/core/math/vector_swizzling.h
@@ -1,0 +1,113 @@
+/**************************************************************************/
+/*  vector_swizzling.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#define VECTOR_SWIZZLING_SETGET() \
+	template <typename V> \
+	void swizzled_set(int comp1, int comp2, const V &other) { \
+		coord[comp1] = other[0]; \
+		coord[comp2] = other[1]; \
+	} \
+	template <typename V> \
+	V swizzled_get(int comp1, int comp2) const { \
+		return V( \
+				coord[comp1], \
+				coord[comp2]); \
+	} \
+	template <typename V> \
+	void swizzled_set(int comp1, int comp2, int comp3, const V &other) { \
+		coord[comp1] = other[0]; \
+		coord[comp2] = other[1]; \
+		coord[comp3] = other[2]; \
+	} \
+	template <typename V> \
+	V swizzled_get(int comp1, int comp2, int comp3) const { \
+		return V( \
+				coord[comp1], \
+				coord[comp2], \
+				coord[comp3]); \
+	} \
+	template <typename V> \
+	void swizzled_set(int comp1, int comp2, int comp3, int comp4, const V &other) { \
+		coord[comp1] = other[0]; \
+		coord[comp2] = other[1]; \
+		coord[comp3] = other[2]; \
+		coord[comp4] = other[3]; \
+	} \
+	template <typename V> \
+	V swizzled_get(int comp1, int comp2, int comp3, int comp4) const { \
+		return V( \
+				coord[comp1], \
+				coord[comp2], \
+				coord[comp3], \
+				coord[comp4]); \
+	}
+
+#define COLOR_SWIZZLING_SETGET() \
+	template <typename V> \
+	void swizzled_set(int comp1, int comp2, const V &other) { \
+		components[comp1] = other[0]; \
+		components[comp2] = other[1]; \
+	} \
+	template <typename V> \
+	V swizzled_get(int comp1, int comp2) const { \
+		return V( \
+				components[comp1], \
+				components[comp2]); \
+	} \
+	template <typename V> \
+	void swizzled_set(int comp1, int comp2, int comp3, const V &other) { \
+		components[comp1] = other[0]; \
+		components[comp2] = other[1]; \
+		components[comp3] = other[2]; \
+	} \
+	template <typename V> \
+	V swizzled_get(int comp1, int comp2, int comp3) const { \
+		return V( \
+				components[comp1], \
+				components[comp2], \
+				components[comp3]); \
+	} \
+	template <typename V> \
+	void swizzled_set(int comp1, int comp2, int comp3, int comp4, const V &other) { \
+		components[comp1] = other[0]; \
+		components[comp2] = other[1]; \
+		components[comp3] = other[2]; \
+		components[comp4] = other[3]; \
+	} \
+	template <typename V> \
+	V swizzled_get(int comp1, int comp2, int comp3, int comp4) const { \
+		return V( \
+				components[comp1], \
+				components[comp2], \
+				components[comp3], \
+				components[comp4]); \
+	}

--- a/core/variant/SCsub
+++ b/core/variant/SCsub
@@ -1,8 +1,15 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
 
+import swizzling_builders
+
 Import("env")
 
 env_variant = env.Clone()
 
+swizzling_setget = env.CommandNoCache(
+    "swizzling_setget.gen.h", "swizzling_builders.py", env.Run(swizzling_builders.swizzling_setget_builder)
+)
+
 env_variant.add_source_files(env.core_sources, "*.cpp")
+env_variant.Depends("variant_setget.cpp", swizzling_setget)

--- a/core/variant/swizzling_builders.py
+++ b/core/variant/swizzling_builders.py
@@ -1,0 +1,73 @@
+"""Functions used to generate swizzling member bindings during build time"""
+
+import methods
+
+
+def swizzling_setget_builder(target, source, env):
+    with methods.generated_wrapper(str(target[0])) as file:
+        file.write("#define swizzled_set(...) swizzled_set<__VA_ARGS__>\n")
+        file.write("#define swizzled_get(...) swizzled_get<__VA_ARGS__>\n")
+        file.write("#define SETGET_SWIZZLING_STRUCTS() \\\n")
+        write_setget_template("Vector2", ["x", "y"], file)
+        write_setget_template("Vector3", ["x", "y", "z"], file)
+        write_setget_template("Vector4", ["x", "y", "z", "w"], file)
+        write_setget_template("Vector2i", ["x", "y"], file)
+        write_setget_template("Vector3i", ["x", "y", "z"], file)
+        write_setget_template("Vector4i", ["x", "y", "z", "w"], file)
+        write_setget_template("Color", ["r", "g", "b", "a"], file)
+        file.write("// end\n\n")
+        file.write("#define SETGET_SWIZZLING_MEMBERS() \\\n")
+        write_members_template("Vector2", ["x", "y"], file)
+        write_members_template("Vector3", ["x", "y", "z"], file)
+        write_members_template("Vector4", ["x", "y", "z", "w"], file)
+        write_members_template("Vector2i", ["x", "y"], file)
+        write_members_template("Vector3i", ["x", "y", "z"], file)
+        write_members_template("Vector4i", ["x", "y", "z", "w"], file)
+        write_members_template("Color", ["r", "g", "b", "a"], file)
+        file.write("\t// end\n\n")
+
+
+_COMP_NAMES = {
+    "x": 0,
+    "y": 1,
+    "z": 2,
+    "w": 3,
+    "r": 0,
+    "g": 1,
+    "b": 2,
+    "a": 3,
+}
+
+
+def write_setget_template(type: str, valid_components: list[str], out_file):
+    other_types = ["Vector2", "Vector3", "Vector4"]
+    if type.endswith("i"):
+        other_types = ["Vector2i", "Vector3i", "Vector4i"]
+    valid = list(filter(lambda comp: comp in valid_components, _COMP_NAMES))
+    for c1 in valid:
+        for c2 in valid:
+            out_file.write(
+                f"SETGET_STRUCT_FUNC_VAR_ARGS({type}, {other_types[0]}, {c1}{c2}, swizzled_set({other_types[0]}), swizzled_get({other_types[0]}),{_COMP_NAMES[c1]}, {_COMP_NAMES[c2]}) \\\n"
+            )
+            for c3 in valid:
+                out_file.write(
+                    f"SETGET_STRUCT_FUNC_VAR_ARGS({type}, {other_types[1]}, {c1}{c2}{c3}, swizzled_set({other_types[1]}), swizzled_get({other_types[1]}),{_COMP_NAMES[c1]}, {_COMP_NAMES[c2]},{_COMP_NAMES[c3]}) \\\n"
+                )
+                for c4 in valid:
+                    out_file.write(
+                        f"SETGET_STRUCT_FUNC_VAR_ARGS({type}, {other_types[2]}, {c1}{c2}{c3}{c4}, swizzled_set({other_types[2]}), swizzled_get({other_types[2]}),{_COMP_NAMES[c1]}, {_COMP_NAMES[c2]},{_COMP_NAMES[c3]},{_COMP_NAMES[c4]})\\\n"
+                    )
+
+
+def write_members_template(type: str, valid_components: list[str], out_file):
+    valid = list(filter(lambda comp: comp in valid_components, _COMP_NAMES))
+    for c1 in valid:
+        for c2 in valid:
+            if not (c1 == "o" and c2 == "o"):
+                out_file.write(f"\tREGISTER_MEMBER({type}, {c1}{c2}); \\\n")
+            for c3 in valid:
+                if not (c1 == "o" and c2 == "o" and c3 == "o"):
+                    out_file.write(f"\tREGISTER_MEMBER({type}, {c1}{c2}{c3}); \\\n")
+                for c4 in valid:
+                    if not (c1 == "o" and c2 == "o" and c3 == "o" and c4 == "o"):
+                        out_file.write(f"\tREGISTER_MEMBER({type}, {c1}{c2}{c3}{c4}); \\\n")

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -91,6 +91,8 @@ void register_named_setters_getters() {
 	REGISTER_MEMBER(Vector4i, z);
 	REGISTER_MEMBER(Vector4i, w);
 
+	SETGET_SWIZZLING_MEMBERS()
+
 	REGISTER_MEMBER(Rect2, position);
 	REGISTER_MEMBER(Rect2, size);
 	REGISTER_MEMBER(Rect2, end);

--- a/core/variant/variant_setget.h
+++ b/core/variant/variant_setget.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/variant/method_ptrcall.h"
+#include "core/variant/swizzling_setget.gen.h"
 #include "core/variant/variant.h"
 #include "core/variant/variant_internal.h"
 
@@ -207,6 +208,39 @@
 		} \
 	};
 
+#define SETGET_STRUCT_FUNC_VAR_ARGS(m_base_type, m_member_type, m_member, m_setter, m_getter, ...) \
+	struct VariantSetGet_##m_base_type##_##m_member { \
+		static void get(const Variant *base, Variant *member) { \
+			VariantTypeAdjust<m_member_type>::adjust(member); \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(__VA_ARGS__); \
+		} \
+		static inline void validated_get(const Variant *base, Variant *member) { \
+			VariantInternalAccessor<m_member_type>::get(member) = VariantInternalAccessor<m_base_type>::get(base).m_getter(__VA_ARGS__); \
+		} \
+		static void ptr_get(const void *base, void *member) { \
+			PtrToArg<m_member_type>::encode(PtrToArg<m_base_type>::convert(base).m_getter(__VA_ARGS__), member); \
+		} \
+		static void set(Variant *base, const Variant *value, bool &valid) { \
+			if (value->get_type() == GetTypeInfo<m_member_type>::VARIANT_TYPE) { \
+				VariantInternalAccessor<m_base_type>::get(base).m_setter(__VA_ARGS__, VariantInternalAccessor<m_member_type>::get(value)); \
+				valid = true; \
+			} else { \
+				valid = false; \
+			} \
+		} \
+		static inline void validated_set(Variant *base, const Variant *value) { \
+			VariantInternalAccessor<m_base_type>::get(base).m_setter(__VA_ARGS__, VariantInternalAccessor<m_member_type>::get(value)); \
+		} \
+		static void ptr_set(void *base, const void *member) { \
+			m_base_type b = PtrToArg<m_base_type>::convert(base); \
+			b.m_setter(__VA_ARGS__, PtrToArg<m_member_type>::convert(member)); \
+			PtrToArg<m_base_type>::encode(b, base); \
+		} \
+		static Variant::Type get_type() { \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE; \
+		} \
+	};
+
 #define SETGET_NUMBER_STRUCT_FUNC(m_base_type, m_member_type, m_member, m_setter, m_getter) \
 	struct VariantSetGet_##m_base_type##_##m_member { \
 		static void get(const Variant *base, Variant *member) { \
@@ -299,6 +333,8 @@ SETGET_NUMBER_STRUCT(Vector4i, int64_t, x)
 SETGET_NUMBER_STRUCT(Vector4i, int64_t, y)
 SETGET_NUMBER_STRUCT(Vector4i, int64_t, z)
 SETGET_NUMBER_STRUCT(Vector4i, int64_t, w)
+
+SETGET_SWIZZLING_STRUCTS()
 
 SETGET_STRUCT(Rect2, Vector2, position)
 SETGET_STRUCT(Rect2, Vector2, size)


### PR DESCRIPTION
Closes:
- https://github.com/godotengine/godot-proposals/issues/727
- https://github.com/godotengine/godot-proposals/issues/14342
- https://github.com/godotengine/godot-proposals/issues/4822

----

This is an alternative to https://github.com/godotengine/godot/pull/118203 but it doesn't create members using the `o` for zeroes. Is closer to shader language and much smaller binary