### PR TITLE
Fix editor unsaved scenes getting file path updates

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -920,7 +920,7 @@ String EditorData::get_scene_path(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, edited_scene.size(), String());
 
 	if (edited_scene[p_idx].root) {
-		if (edited_scene[p_idx].root->get_scene_file_path().is_empty()) {
+		if (edited_scene[p_idx].root->get_scene_file_path().is_empty() && !edited_scene[p_idx].path.is_empty()) {
 			edited_scene[p_idx].root->set_scene_file_path(edited_scene[p_idx].path);
 		} else {
 			return edited_scene[p_idx].root->get_scene_file_path();


### PR DESCRIPTION
Fixes #116703

Unsaved scenes were getting their path set to another empty string every time `EditorData::get_scene_path` was called for them. This caused a scene tree update, resulting in some jitter for resource previews. The jitter could probably be investigated further, as it would be nice for it to not happen even on scene tree updates, but this seems to solve the main problem for now.