### PR TITLE
Replace `Callable::is_valid` with `is_null` in Jolt module

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -134,11 +134,11 @@ bool JoltArea3D::_remove_shape_pair(Overlap &p_overlap, const JPH::SubShapeID &p
 	return true;
 }
 
-void JoltArea3D::_flush_events(OverlapsById &p_objects, const Callable &p_callback) {
+void JoltArea3D::_flush_events(OverlapsById &p_objects, Callable &p_callback) {
 	for (OverlapsById::Iterator E = p_objects.begin(); E;) {
 		Overlap &overlap = E->value;
 
-		if (p_callback.is_valid()) {
+		if (!p_callback.is_null()) {
 			for (const ShapeIndexPair &shape_indices : overlap.pending_added) {
 				int &ref_count = overlap.ref_counts[shape_indices];
 				if (ref_count++ == 0) {
@@ -170,8 +170,10 @@ void JoltArea3D::_flush_events(OverlapsById &p_objects, const Callable &p_callba
 	}
 }
 
-void JoltArea3D::_report_event(const Callable &p_callback, PhysicsServer3D::AreaBodyStatus p_status, const RID &p_other_rid, ObjectID p_other_instance_id, int p_other_shape_index, int p_self_shape_index) const {
-	ERR_FAIL_COND(!p_callback.is_valid());
+void JoltArea3D::_report_event(Callable &p_callback, PhysicsServer3D::AreaBodyStatus p_status, const RID &p_other_rid, ObjectID p_other_instance_id, int p_other_shape_index, int p_self_shape_index) {
+	if (unlikely(p_callback.is_null())) {
+		return;
+	}
 
 	const Variant arg1 = p_status;
 	const Variant arg2 = p_other_rid;
@@ -185,7 +187,13 @@ void JoltArea3D::_report_event(const Callable &p_callback, PhysicsServer3D::Area
 	p_callback.callp(args, 5, ret, ce);
 
 	if (unlikely(ce.error != Callable::CallError::CALL_OK)) {
-		ERR_PRINT_ONCE(vformat("Failed to call area monitor callback for '%s'. It returned the following error: '%s'.", to_string(), Variant::get_callable_error_text(p_callback, args, 5, ce)));
+		if (ce.error == Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL) {
+			// Godot Physics effectively silences this error by virtue of doing a `Callable::is_valid` check before the call, so we silently ignore this for compatibility.
+			// There's no point in trying to call this callback again though, so we clear it.
+			p_callback = Callable();
+		} else {
+			ERR_PRINT_ONCE(vformat("Failed to call area monitor callback for '%s'. It returned the following error: '%s'.", to_string(), Variant::get_callable_error_text(p_callback, args, 5, ce)));
+		}
 	}
 }
 

--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -134,11 +134,11 @@ bool JoltArea3D::_remove_shape_pair(Overlap &p_overlap, const JPH::SubShapeID &p
 	return true;
 }
 
-void JoltArea3D::_flush_events(OverlapsById &p_objects, const Callable &p_callback) {
+void JoltArea3D::_flush_events(OverlapsById &p_objects, Callable &p_callback) {
 	for (OverlapsById::Iterator E = p_objects.begin(); E;) {
 		Overlap &overlap = E->value;
 
-		if (p_callback.is_valid()) {
+		if (!p_callback.is_null()) {
 			for (const ShapeIndexPair &shape_indices : overlap.pending_added) {
 				int &ref_count = overlap.ref_counts[shape_indices];
 				if (ref_count++ == 0) {
@@ -170,8 +170,10 @@ void JoltArea3D::_flush_events(OverlapsById &p_objects, const Callable &p_callba
 	}
 }
 
-void JoltArea3D::_report_event(const Callable &p_callback, PS3DE::AreaBodyStatus p_status, const RID &p_other_rid, ObjectID p_other_instance_id, int p_other_shape_index, int p_self_shape_index) const {
-	ERR_FAIL_COND(!p_callback.is_valid());
+void JoltArea3D::_report_event(Callable &p_callback, PS3DE::AreaBodyStatus p_status, const RID &p_other_rid, ObjectID p_other_instance_id, int p_other_shape_index, int p_self_shape_index) {
+	if (unlikely(p_callback.is_null())) {
+		return;
+	}
 
 	const Variant arg1 = p_status;
 	const Variant arg2 = p_other_rid;
@@ -185,7 +187,13 @@ void JoltArea3D::_report_event(const Callable &p_callback, PS3DE::AreaBodyStatus
 	p_callback.callp(args, 5, ret, ce);
 
 	if (unlikely(ce.error != Callable::CallError::CALL_OK)) {
-		ERR_PRINT_ONCE(vformat("Failed to call area monitor callback for '%s'. It returned the following error: '%s'.", to_string(), Variant::get_callable_error_text(p_callback, args, 5, ce)));
+		if (ce.error == Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL) {
+			// Godot Physics effectively silences this error by virtue of doing a `Callable::is_valid` check before the call, so we silently ignore this for compatibility.
+			// There's no point in trying to call this callback again though, so we clear it.
+			p_callback = Callable();
+		} else {
+			ERR_PRINT_ONCE(vformat("Failed to call area monitor callback for '%s'. It returned the following error: '%s'.", to_string(), Variant::get_callable_error_text(p_callback, args, 5, ce)));
+		}
 	}
 }
 

--- a/modules/jolt_physics/objects/jolt_area_3d.h
+++ b/modules/jolt_physics/objects/jolt_area_3d.h
@@ -137,9 +137,8 @@ private:
 	void _add_shape_pair(Overlap &p_overlap, const JPH::BodyID &p_body_id, const JPH::SubShapeID &p_other_shape_id, const JPH::SubShapeID &p_self_shape_id);
 	bool _remove_shape_pair(Overlap &p_overlap, const JPH::SubShapeID &p_other_shape_id, const JPH::SubShapeID &p_self_shape_id);
 
-	void _flush_events(OverlapsById &p_objects, const Callable &p_callback);
-
-	void _report_event(const Callable &p_callback, PhysicsServer3D::AreaBodyStatus p_status, const RID &p_other_rid, ObjectID p_other_instance_id, int p_other_shape_index, int p_self_shape_index) const;
+	void _flush_events(OverlapsById &p_objects, Callable &p_callback);
+	void _report_event(Callable &p_callback, PhysicsServer3D::AreaBodyStatus p_status, const RID &p_other_rid, ObjectID p_other_instance_id, int p_other_shape_index, int p_self_shape_index);
 
 	void _notify_body_entered(const JPH::BodyID &p_body_id);
 	void _notify_body_exited(const JPH::BodyID &p_body_id);
@@ -164,10 +163,10 @@ public:
 	Variant get_param(PhysicsServer3D::AreaParameter p_param) const;
 	void set_param(PhysicsServer3D::AreaParameter p_param, const Variant &p_value);
 
-	bool has_body_monitor_callback() const { return body_monitor_callback.is_valid(); }
+	bool has_body_monitor_callback() const { return !body_monitor_callback.is_null(); }
 	void set_body_monitor_callback(const Callable &p_callback);
 
-	bool has_area_monitor_callback() const { return area_monitor_callback.is_valid(); }
+	bool has_area_monitor_callback() const { return !area_monitor_callback.is_null(); }
 	void set_area_monitor_callback(const Callable &p_callback);
 
 	bool is_monitoring_bodies() const { return has_body_monitor_callback(); }

--- a/modules/jolt_physics/objects/jolt_area_3d.h
+++ b/modules/jolt_physics/objects/jolt_area_3d.h
@@ -137,9 +137,8 @@ private:
 	void _add_shape_pair(Overlap &p_overlap, const JPH::BodyID &p_body_id, const JPH::SubShapeID &p_other_shape_id, const JPH::SubShapeID &p_self_shape_id);
 	bool _remove_shape_pair(Overlap &p_overlap, const JPH::SubShapeID &p_other_shape_id, const JPH::SubShapeID &p_self_shape_id);
 
-	void _flush_events(OverlapsById &p_objects, const Callable &p_callback);
-
-	void _report_event(const Callable &p_callback, PS3DE::AreaBodyStatus p_status, const RID &p_other_rid, ObjectID p_other_instance_id, int p_other_shape_index, int p_self_shape_index) const;
+	void _flush_events(OverlapsById &p_objects, Callable &p_callback);
+	void _report_event(Callable &p_callback, PS3DE::AreaBodyStatus p_status, const RID &p_other_rid, ObjectID p_other_instance_id, int p_other_shape_index, int p_self_shape_index);
 
 	void _notify_body_entered(const JPH::BodyID &p_body_id);
 	void _notify_body_exited(const JPH::BodyID &p_body_id);
@@ -165,10 +164,10 @@ public:
 	Variant get_param(PS3DE::AreaParameter p_param) const;
 	void set_param(PS3DE::AreaParameter p_param, const Variant &p_value);
 
-	bool has_body_monitor_callback() const { return body_monitor_callback.is_valid(); }
+	bool has_body_monitor_callback() const { return !body_monitor_callback.is_null(); }
 	void set_body_monitor_callback(const Callable &p_callback);
 
-	bool has_area_monitor_callback() const { return area_monitor_callback.is_valid(); }
+	bool has_area_monitor_callback() const { return !area_monitor_callback.is_null(); }
 	void set_area_monitor_callback(const Callable &p_callback);
 
 	bool is_monitoring_bodies() const { return has_body_monitor_callback(); }

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -1056,7 +1056,7 @@ void JoltBody3D::remove_joint(JoltJoint3D *p_joint) {
 }
 
 void JoltBody3D::call_queries() {
-	if (custom_integration_callback.is_valid()) {
+	if (!custom_integration_callback.is_null()) {
 		const Variant direct_state_variant = get_direct_state();
 		const Variant *args[2] = { &direct_state_variant, &custom_integration_userdata };
 		const int argc = custom_integration_userdata.get_type() != Variant::NIL ? 2 : 1;
@@ -1066,11 +1066,17 @@ void JoltBody3D::call_queries() {
 		custom_integration_callback.callp(args, argc, ret, ce);
 
 		if (unlikely(ce.error != Callable::CallError::CALL_OK)) {
-			ERR_PRINT_ONCE(vformat("Failed to call force integration callback for '%s'. It returned the following error: '%s'.", to_string(), Variant::get_callable_error_text(custom_integration_callback, args, argc, ce)));
+			if (ce.error == Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL) {
+				// Godot Physics effectively silences this error by virtue of doing a `Callable::is_valid` check before the call, so we silently ignore this for compatibility.
+				// There's no point in trying to call this callback again though, so we clear it.
+				custom_integration_callback = Callable();
+			} else {
+				ERR_PRINT_ONCE(vformat("Failed to call force integration callback for '%s'. It returned the following error: '%s'.", to_string(), Variant::get_callable_error_text(custom_integration_callback, args, argc, ce)));
+			}
 		}
 	}
 
-	if (state_sync_callback.is_valid()) {
+	if (!state_sync_callback.is_null()) {
 		const Variant direct_state_variant = get_direct_state();
 		const Variant *args[1] = { &direct_state_variant };
 
@@ -1079,7 +1085,13 @@ void JoltBody3D::call_queries() {
 		state_sync_callback.callp(args, 1, ret, ce);
 
 		if (unlikely(ce.error != Callable::CallError::CALL_OK)) {
-			ERR_PRINT_ONCE(vformat("Failed to call state synchronization callback for '%s'. It returned the following error: '%s'.", to_string(), Variant::get_callable_error_text(state_sync_callback, args, 1, ce)));
+			if (ce.error == Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL) {
+				// Godot Physics effectively silences this error by virtue of doing a `Callable::is_valid` check before the call, so we silently ignore this for compatibility.
+				// There's no point in trying to call this callback again though, so we clear it.
+				state_sync_callback = Callable();
+			} else {
+				ERR_PRINT_ONCE(vformat("Failed to call state synchronization callback for '%s'. It returned the following error: '%s'.", to_string(), Variant::get_callable_error_text(state_sync_callback, args, 1, ce)));
+			}
 		}
 	}
 }

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -1074,7 +1074,7 @@ void JoltBody3D::remove_joint(JoltJoint3D *p_joint) {
 }
 
 void JoltBody3D::call_queries() {
-	if (custom_integration_callback.is_valid()) {
+	if (!custom_integration_callback.is_null()) {
 		const Variant direct_state_variant = get_direct_state();
 		const Variant *args[2] = { &direct_state_variant, &custom_integration_userdata };
 		const int argc = custom_integration_userdata.get_type() != Variant::NIL ? 2 : 1;
@@ -1084,11 +1084,17 @@ void JoltBody3D::call_queries() {
 		custom_integration_callback.callp(args, argc, ret, ce);
 
 		if (unlikely(ce.error != Callable::CallError::CALL_OK)) {
-			ERR_PRINT_ONCE(vformat("Failed to call force integration callback for '%s'. It returned the following error: '%s'.", to_string(), Variant::get_callable_error_text(custom_integration_callback, args, argc, ce)));
+			if (ce.error == Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL) {
+				// Godot Physics effectively silences this error by virtue of doing a `Callable::is_valid` check before the call, so we silently ignore this for compatibility.
+				// There's no point in trying to call this callback again though, so we clear it.
+				custom_integration_callback = Callable();
+			} else {
+				ERR_PRINT_ONCE(vformat("Failed to call force integration callback for '%s'. It returned the following error: '%s'.", to_string(), Variant::get_callable_error_text(custom_integration_callback, args, argc, ce)));
+			}
 		}
 	}
 
-	if (state_sync_callback.is_valid()) {
+	if (!state_sync_callback.is_null()) {
 		const Variant direct_state_variant = get_direct_state();
 		const Variant *args[1] = { &direct_state_variant };
 
@@ -1097,7 +1103,13 @@ void JoltBody3D::call_queries() {
 		state_sync_callback.callp(args, 1, ret, ce);
 
 		if (unlikely(ce.error != Callable::CallError::CALL_OK)) {
-			ERR_PRINT_ONCE(vformat("Failed to call state synchronization callback for '%s'. It returned the following error: '%s'.", to_string(), Variant::get_callable_error_text(state_sync_callback, args, 1, ce)));
+			if (ce.error == Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL) {
+				// Godot Physics effectively silences this error by virtue of doing a `Callable::is_valid` check before the call, so we silently ignore this for compatibility.
+				// There's no point in trying to call this callback again though, so we clear it.
+				state_sync_callback = Callable();
+			} else {
+				ERR_PRINT_ONCE(vformat("Failed to call state synchronization callback for '%s'. It returned the following error: '%s'.", to_string(), Variant::get_callable_error_text(state_sync_callback, args, 1, ce)));
+			}
 		}
 	}
 }

--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -110,7 +110,7 @@ private:
 
 	virtual void _add_to_space() override;
 
-	bool _should_call_queries() const { return state_sync_callback.is_valid() || custom_integration_callback.is_valid(); }
+	bool _should_call_queries() const { return !state_sync_callback.is_null() || !custom_integration_callback.is_null(); }
 	void _enqueue_call_queries();
 	void _dequeue_call_queries();
 
@@ -162,10 +162,10 @@ public:
 	Variant get_param(PhysicsServer3D::BodyParameter p_param) const;
 	void set_param(PhysicsServer3D::BodyParameter p_param, const Variant &p_value);
 
-	bool has_state_sync_callback() const { return state_sync_callback.is_valid(); }
+	bool has_state_sync_callback() const { return !state_sync_callback.is_null(); }
 	void set_state_sync_callback(const Callable &p_callback) { state_sync_callback = p_callback; }
 
-	bool has_custom_integration_callback() const { return custom_integration_callback.is_valid(); }
+	bool has_custom_integration_callback() const { return !custom_integration_callback.is_null(); }
 	void set_custom_integration_callback(const Callable &p_callback, const Variant &p_userdata) {
 		custom_integration_callback = p_callback;
 		custom_integration_userdata = p_userdata;

--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -113,7 +113,7 @@ private:
 
 	virtual void _add_to_space() override;
 
-	bool _should_call_queries() const { return state_sync_callback.is_valid() || custom_integration_callback.is_valid(); }
+	bool _should_call_queries() const { return !state_sync_callback.is_null() || !custom_integration_callback.is_null(); }
 	void _enqueue_call_queries();
 	void _dequeue_call_queries();
 
@@ -165,10 +165,10 @@ public:
 	Variant get_param(PS3DE::BodyParameter p_param) const;
 	void set_param(PS3DE::BodyParameter p_param, const Variant &p_value);
 
-	bool has_state_sync_callback() const { return state_sync_callback.is_valid(); }
+	bool has_state_sync_callback() const { return !state_sync_callback.is_null(); }
 	void set_state_sync_callback(const Callable &p_callback) { state_sync_callback = p_callback; }
 
-	bool has_custom_integration_callback() const { return custom_integration_callback.is_valid(); }
+	bool has_custom_integration_callback() const { return !custom_integration_callback.is_null(); }
 	void set_custom_integration_callback(const Callable &p_callback, const Variant &p_userdata) {
 		custom_integration_callback = p_callback;
 		custom_integration_userdata = p_userdata;


### PR DESCRIPTION
Improves #118047 (but needs #118236 to actually fix it).
Depends on #118229.

`Callable::is_valid` is mildly expensive, and we're calling it from a number of hot code paths in the Jolt module, some of which are in multi-threaded contexts, causing contention at the spin lock in `ObjectDB::get_instance`.

**EDIT:** It's perhaps more fair to say that `Callable::is_valid` is expensive _because_ of the spin lock in `ObjectDB::get_instance`, and is seemingly (when ignoring the problem described below) redundant as used in this module anyway, since `Callable::callp` is already doing the validity check.

This change replaces all instances of `Callable::is_valid` with `Callabe::is_null` instead, which only checks to see if the `Callable` is a non-empty reference.

<details><summary><i>[Resolved issue, click to expand/collapse]</i></summary>
<p>

This has one rather serious implication currently, which is that if somebody has set any of these callbacks:

1. `PhysicsServer3D::area_set_monitor_callback`
2. `PhysicsServer3D::area_set_area_monitor_callback`
3. `PhysicsServer3D::body_set_state_sync_callback`
4. `PhysicsServer3D::body_set_force_integration_callback`

... and then frees the target object for that callback, before removing the relevant area/body from the physics space first (or clearing the callback), they can theoretically be subject to a `nullptr` access in release builds, due to this `#ifdef` here:

https://github.com/godotengine/godot/blob/ee713ccb7cbaddf59f8258ed6663461779d00856/core/variant/callable.cpp#L60-L70

This particular `#ifdef` has come up before as being highly questionable, so I'll just make a separate pull request to remove it. That should allow `Callable::callp` to safely return `CALL_ERROR_INSTANCE_IS_NULL` in all cases where the object has been freed already (apart from race conditions).

Note that this `nullptr` access is only applicable to custom physics bodies created through `PhysicsServer3D` and **not** applicable to the built-in physics scene nodes, as they not only perform the appropriate cleanup, but also use `callable_mp` when binding the callbacks, meaning a `CallableCustomMethodPointer`, which always checks against `ObjectDB` before calling, in all builds.

</p>
</details> 