### PR TITLE
Remove `DEBUG_ENABLED` condition from null check in `Callable::callp`

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -58,15 +58,13 @@ void Callable::callp(const Variant **p_arguments, int p_argcount, Variant &r_ret
 		custom->call(p_arguments, p_argcount, r_return_value, r_call_error);
 	} else {
 		Object *obj = ObjectDB::get_instance(ObjectID(object));
-#ifdef DEBUG_ENABLED
-		if (!obj) {
+		if (unlikely(!obj)) {
 			r_call_error.error = CallError::CALL_ERROR_INSTANCE_IS_NULL;
 			r_call_error.argument = 0;
 			r_call_error.expected = 0;
 			r_return_value = Variant();
 			return;
 		}
-#endif
 		r_return_value = obj->callp(method, p_arguments, p_argcount, r_call_error);
 	}
 }


### PR DESCRIPTION
Omitting this single `nullptr` comparison in non-`DEBUG_ENABLED` builds seems like a questionable optimization.

See the description of #118227 for at least one motivation as to why it might be good to have this null check in all builds.