### PR TITLE
Editor: Show root node name for unsaved scenes on closing editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6746,7 +6746,7 @@ void EditorNode::_scene_tab_closed(int p_tab) {
 
 	if (EditorUndoRedoManager::get_singleton()->is_history_unsaved(editor_data.get_scene_history_id(p_tab))) {
 		if (scene_filename.is_empty()) {
-			unsaved_message = TTR("This scene was never saved.");
+			unsaved_message = vformat(TTR("This scene was never saved (root node: \"%s\")."), scene->get_name());
 		} else {
 			uint32_t time_opened = editor_data.get_scene_time_opened(p_tab);
 			unsaved_message = _get_unsaved_scene_dialog_text(scene_filename, time_opened);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3414,21 +3414,21 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				if (i == option_tab) {
 					continue;
 				}
-				tabs_to_close.push_back(editor_data.get_scene_path(i));
+				tabs_to_close.push_back(i);
 			}
 			_proceed_closing_scene_tabs();
 		} break;
 		case EditorSceneTabs::SCENE_CLOSE_RIGHT: {
 			tab_closing_menu_option = -1;
 			for (int i = scene_tabs->get_option_tab() + 1; i < editor_data.get_edited_scene_count(); i++) {
-				tabs_to_close.push_back(editor_data.get_scene_path(i));
+				tabs_to_close.push_back(i);
 			}
 			_proceed_closing_scene_tabs();
 		} break;
 		case SCENE_CLOSE_ALL: {
 			tab_closing_menu_option = -1;
 			for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
-				tabs_to_close.push_back(editor_data.get_scene_path(i));
+				tabs_to_close.push_back(i);
 			}
 			_proceed_closing_scene_tabs();
 		} break;
@@ -3812,7 +3812,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				if (save_each) {
 					tab_closing_menu_option = current_menu_option;
 					for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
-						tabs_to_close.push_back(editor_data.get_scene_path(i));
+						tabs_to_close.push_back(i);
 					}
 					_proceed_closing_scene_tabs();
 				} else {
@@ -6650,7 +6650,7 @@ void EditorNode::_layout_menu_option(int p_id) {
 }
 
 void EditorNode::_proceed_closing_scene_tabs() {
-	List<String>::Element *E = tabs_to_close.front();
+	List<int>::Element *E = tabs_to_close.front();
 	if (!E) {
 		if (_is_closing_editor()) {
 			current_menu_option = tab_closing_menu_option;
@@ -6661,16 +6661,9 @@ void EditorNode::_proceed_closing_scene_tabs() {
 		}
 		return;
 	}
-	String scene_to_close = E->get();
+	int tab_idx = E->get();
 	tabs_to_close.pop_front();
-
-	int tab_idx = -1;
-	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
-		if (editor_data.get_scene_path(i) == scene_to_close) {
-			tab_idx = i;
-			break;
-		}
-	}
+	
 	ERR_FAIL_COND(tab_idx < 0);
 
 	_scene_tab_closed(tab_idx);
@@ -6746,7 +6739,7 @@ void EditorNode::_scene_tab_closed(int p_tab) {
 
 	if (EditorUndoRedoManager::get_singleton()->is_history_unsaved(editor_data.get_scene_history_id(p_tab))) {
 		if (scene_filename.is_empty()) {
-			unsaved_message = vformat(TTR("This scene was never saved (root node: \"%s\")."), scene->get_name());
+			unsaved_message = vformat(TTR("This scene was never saved (root node: \"%s\")."), editor_data.get_edited_scene_root(p_tab)->get_name());
 		} else {
 			uint32_t time_opened = editor_data.get_scene_time_opened(p_tab);
 			unsaved_message = _get_unsaved_scene_dialog_text(scene_filename, time_opened);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6663,7 +6663,7 @@ void EditorNode::_proceed_closing_scene_tabs() {
 	}
 	int tab_idx = E->get();
 	tabs_to_close.pop_front();
-	
+
 	ERR_FAIL_COND(tab_idx < 0);
 
 	_scene_tab_closed(tab_idx);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -312,7 +312,7 @@ private:
 	EditorSceneTabs *scene_tabs = nullptr;
 
 	int tab_closing_idx = 0;
-	List<String> tabs_to_close;
+	List<int> tabs_to_close;
 	List<int> scenes_to_save_as;
 	int tab_closing_menu_option = -1;
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
Fixes #118230

When closing unsaved scenes the dialog now displays the name of the root node to help differentiate between closed scenes.