### PR TITLE
Add clarification on ClassDB `Dictionary` structure

### DIFF
--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -95,7 +95,7 @@
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns an array with all the methods of [param class] or its ancestry if [param no_inheritance] is [code]false[/code]. Every element of the array is a [Dictionary] with the following keys: [code]args[/code], [code]default_args[/code], [code]flags[/code], [code]id[/code], [code]name[/code], [code]return: (class_name, hint, hint_string, name, type, usage)[/code].
+				Returns an array with all the methods of [param class] or its ancestry if [param no_inheritance] is [code]false[/code]. Every element of the array is a [Dictionary] formatted identically to [method Object.get_method_list].
 				[b]Note:[/b] In exported release builds the debug info is not available, so the returned dictionaries will contain only method names.
 			</description>
 		</method>
@@ -128,7 +128,7 @@
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns an array with all the properties of [param class] or its ancestry if [param no_inheritance] is [code]false[/code].
+				Returns an array with all the properties of [param class] or its ancestry if [param no_inheritance] is [code]false[/code]. Every element of the array is a [Dictionary] formatted identically to [method Object.get_property_list].
 			</description>
 		</method>
 		<method name="class_get_property_setter">
@@ -144,7 +144,7 @@
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="signal" type="StringName" />
 			<description>
-				Returns the [param signal] data of [param class] or its ancestry. The returned value is a [Dictionary] with the following keys: [code]args[/code], [code]default_args[/code], [code]flags[/code], [code]id[/code], [code]name[/code], [code]return: (class_name, hint, hint_string, name, type, usage)[/code].
+				Returns the [param signal] data of [param class] or its ancestry. The returned value is a [Dictionary] formatted identically to [method Object.get_signal_list].
 			</description>
 		</method>
 		<method name="class_get_signal_list" qualifiers="const">

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -669,6 +669,7 @@
 				- [code]id[/code] is the method's internal identifier [int];
 				- [code]return[/code] is the returned value, as a [Dictionary];
 				[b]Note:[/b] The dictionaries of [code]args[/code] and [code]return[/code] are formatted identically to the results of [method get_property_list], although not all entries are used.
+				[b]Note:[/b] In exported release builds the debug info is not available, so the returned dictionaries will contain only method names.
 			</description>
 		</method>
 		<method name="get_property_list" qualifiers="const">


### PR DESCRIPTION
Previously, `ClassDB`'s documentation on the dictionary format of it's [property](https://docs.godotengine.org/en/stable/classes/class_classdb.html#class-classdb-method-class-get-property-list), [method](https://docs.godotengine.org/en/stable/classes/class_classdb.html#class-classdb-method-class-get-method-list), and [signal](https://docs.godotengine.org/en/stable/classes/class_classdb.html#class-classdb-method-class-get-signal) reflection methods was vague regarding what each field in the returned `Dictionary`s described, this now links to the corresponding methods in `Object`'s documentation page ([property](https://docs.godotengine.org/en/stable/classes/class_object.html#class-object-method-get-property-list), [method](https://docs.godotengine.org/en/stable/classes/class_object.html#class-object-method-get-method-list), [signal](https://docs.godotengine.org/en/stable/classes/class_object.html#class-object-method-get-signal-list)) which go into greater detail on each property (although I think [Object.get_signal_list()](https://docs.godotengine.org/en/stable/classes/class_object.html#class-object-method-get-signal-list) could potentially use a better description, I'm not confident enough about it's inner workings to guarantee that anything I write will be accurate).

Additionally, since internally [Object.get_method_list()](https://docs.godotengine.org/en/stable/classes/class_object.html#class-object-method-get-method-list) simply invokes [ClassDB.class_get_method_list()](https://docs.godotengine.org/en/stable/classes/class_classdb.html#class-classdb-method-class-get-method-list), I have also copied the same warning there to `Object.get_method_list()`. While I kept this as '**Note:**' to maintain consistency with `ClassDB`'s notice, due to this potentially introducing major, breaking changes between testing and production environments, should this maybe be listed as '**Warning:**' instead?