### PR TITLE
Properly set `drawable_type` property in RenderingServer's `DrawableTexture`

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1237,6 +1237,7 @@ void TextureStorage::texture_drawable_initialize(RID p_texture, int p_width, int
 	texture.alloc_height = texture.height;
 	texture.mipmaps = image->get_mipmap_count() + 1;
 	texture.format = image->get_format();
+	texture.drawable_type = p_format;
 	texture.type = Texture::TYPE_2D;
 	texture.target = GL_TEXTURE_2D;
 	_get_gl_image_and_format(Ref<Image>(), texture.format, texture.real_format, texture.gl_format_cache, texture.gl_internal_format_cache, texture.gl_type_cache, texture.compressed, false);

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1294,6 +1294,7 @@ void TextureStorage::texture_drawable_initialize(RID p_texture, int p_width, int
 	texture.depth = 1;
 	texture.format = image->get_format();
 	texture.validated_format = image->get_format();
+	texture.drawable_type = p_format;
 
 	texture.rd_type = RD::TEXTURE_TYPE_2D;
 	texture.rd_format = ret_format.format;


### PR DESCRIPTION
The `drawable_type` property was not initialized properly, which caused `TEXTURE_DRAWABLE_FORMAT_RGBA8_SRGB` to never be taken into account and the sRGB conversion code to never be executed.

Note: Compatibility is still broken due to passing an int as a uint. #117805 is needed to fix it.