### PR TITLE
Fix resizing a DrawableTexture2D not updating the texture size

### DIFF
--- a/scene/resources/drawable_texture_2d.cpp
+++ b/scene/resources/drawable_texture_2d.cpp
@@ -76,6 +76,7 @@ void DrawableTexture2D::set_width(int p_width) {
 		return;
 	}
 	width = p_width;
+	_initialize();
 	notify_property_list_changed();
 	emit_changed();
 }
@@ -90,6 +91,7 @@ void DrawableTexture2D::set_height(int p_height) {
 		return;
 	}
 	height = p_height;
+	_initialize();
 	notify_property_list_changed();
 	emit_changed();
 }


### PR DESCRIPTION
The pull request is to correct the bug https://github.com/godotengine/godot/issues/118178, which raise the issue that resizeing a DrawableTexture2D would not update the texture size.

I just added an _initialize(), which reinitialize the texture, when you set either width or height. Otherwise the texture remained the same size.

I checked a few textures implementations and none of them implemented the size setter.

I tested in the UI, and it reset the texture, but once Update is pressed, the texture has the correct behavior and size.

- *Bugsquad edit:* This PR fixes https://github.com/godotengine/godot/issues/118178