### PR TITLE
[Windows] WinRT build improvements.

### DIFF
--- a/misc/scripts/install_winrt.py
+++ b/misc/scripts/install_winrt.py
@@ -35,7 +35,7 @@ if os.path.isfile(winrt_archive):
 
 print(f"Downloading WinRT {winrt_filename} ...")
 urllib.request.urlretrieve(
-    f"https://github.com/bruvzg/winrt_mingw/releases/download/{winrt_version}/{winrt_filename}",
+    f"https://github.com/godotengine/winrt-mingw/releases/download/{winrt_version}/{winrt_filename}",
     winrt_archive,
 )
 if os.path.exists(winrt_folder):

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -82,22 +82,24 @@ env.Depends(res_obj, "#core/version_generated.gen.h")
 env.add_source_files(sources, common_win)
 
 env_winrt = env.Clone()
-if not env_winrt.msvc:
-    if "-std=gnu++17" in env_winrt["CXXFLAGS"]:
-        env_winrt["CXXFLAGS"].remove("-std=gnu++17")
-    env_winrt.Append(CXXFLAGS=["-std=gnu++20"])
-    if "-fno-exceptions" in env_winrt["CXXFLAGS"]:
-        env_winrt["CXXFLAGS"].remove("-fno-exceptions")
-    env_winrt.Append(CXXFLAGS=["-fexceptions"])
-else:
-    if "/std:c++17" in env_winrt["CXXFLAGS"]:
-        env_winrt["CXXFLAGS"].remove("/std:c++17")
-    env_winrt.Append(CXXFLAGS=["/std:c++20"])
-    if "_HAS_EXCEPTIONS" in env_winrt["CPPDEFINES"]:
-        env_winrt["CPPDEFINES"].remove("_HAS_EXCEPTIONS")
-    env_winrt.Append(CXXFLAGS=["/EHsc"])
 tts_sources = ["tts_windows.cpp", "tts_driver_sapi.cpp"]
-if env_winrt["winrt_path"] != "" or env_winrt.msvc:
+if env["winrt"]:
+    if not env_winrt.msvc:
+        if "-std=gnu++17" in env_winrt["CXXFLAGS"]:
+            env_winrt["CXXFLAGS"].remove("-std=gnu++17")
+        env_winrt.Append(CXXFLAGS=["-std=gnu++20"])
+        if "-fno-exceptions" in env_winrt["CXXFLAGS"]:
+            env_winrt["CXXFLAGS"].remove("-fno-exceptions")
+        env_winrt.Append(CXXFLAGS=["-fexceptions"])
+    else:
+        if not env["use_llvm"]:
+            env_winrt.Append(CXXFLAGS=["/await"])
+        if "/std:c++17" in env_winrt["CXXFLAGS"]:
+            env_winrt["CXXFLAGS"].remove("/std:c++17")
+        env_winrt.Append(CXXFLAGS=["/std:c++20"])
+        if "_HAS_EXCEPTIONS" in env_winrt["CPPDEFINES"]:
+            env_winrt["CPPDEFINES"].remove("_HAS_EXCEPTIONS")
+        env_winrt.Append(CXXFLAGS=["/EHsc"])
     if not env_winrt.msvc:
         env_winrt.Append(CPPPATH=[env["winrt_path"]])
     env_winrt.AppendUnique(CPPDEFINES=["WINRT_ENABLED"])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -194,6 +194,7 @@ def get_opts():
         BoolVariable("debug_crt", "Compile with MSVC's debug CRT (/MDd)", False),
         BoolVariable("incremental_link", "Use MSVC incremental linking. May increase or decrease build times.", False),
         BoolVariable("silence_msvc", "Silence MSVC's cl/link stdout bloat, redirecting any errors to stderr.", True),
+        BoolVariable("winrt", "Use WinRT API (OneCore TTS support).", True),
         # Screen reader support.
         (
             "accesskit_sdk_path",
@@ -209,7 +210,7 @@ def get_opts():
         # WinRT.
         (
             "winrt_path",
-            "Path to the WinRT headers",
+            "Path to the WinRT headers (MinGW only)",
             os.path.join(deps_folder, "winrt_mingw"),
         ),
         # Direct3D 12 support.
@@ -822,6 +823,30 @@ def configure_mingw(env: "SConsEnvironment"):
             "mincore",
         ]
     )
+
+    if env["winrt"]:
+        if not os.path.exists(env["winrt_path"]):
+            prefix = os.getenv("MINGW_PREFIX", "")
+            msys = os.getenv("MSYSTEM", "")
+            if msys != "" and prefix != "":
+                if not os.path.exists(os.path.join(prefix, "include/winrt")):
+                    print_warning(
+                        "The WinRT/OneCore API requires dependencies to be installed.\n"
+                        f"You can install them by installing `cppwinrt` MSYS2 package or by running `python {os.path.join('misc', 'scripts', 'install_winrt.py')}`.\n"
+                        "See the documentation for more information:\n"
+                        "\thttps://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_windows.html\n"
+                        "Alternatively, disable this driver by compiling with `winrt=no` explicitly."
+                    )
+                env["winrt"] = False
+            else:
+                print_warning(
+                    "The WinRT/OneCore API requires dependencies to be installed.\n"
+                    f"You can install them by running `python {os.path.join('misc', 'scripts', 'install_winrt.py')}`.\n"
+                    "See the documentation for more information:\n"
+                    "\thttps://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_windows.html\n"
+                    "Alternatively, disable this driver by compiling with `winrt=no` explicitly."
+                )
+                env["winrt"] = False
 
     if env["accesskit"]:
         if os.path.exists(env["accesskit_sdk_path"]):


### PR DESCRIPTION
Fixes various issues with https://github.com/godotengine/godot/pull/116349 build.

- Adds warning and link to the script when winrt headers are missing.
- Adds CXXFLAG to fix build with old (Windows 10) SDKs.
- Moves WinRT from `github.com/bruvzg/winrt_mingw` to `github.com/godotengine/winrt_mingw`.