### PR TITLE
Fix incorrect line number passed to external editor from `EditorLog`

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -219,7 +219,7 @@ void EditorLog::_meta_clicked(const String &p_meta) {
 		if (ResourceLoader::exists(path)) {
 			const Ref<Resource> res = ResourceLoader::load(path);
 			ScriptEditor::get_singleton()->edit(res, line, 0);
-			InspectorDock::get_singleton()->edit_resource(res);
+			EditorNode::get_singleton()->push_item(res.ptr(), "", true);
 		}
 	} else if (path.has_extension("cpp") || path.has_extension("h") || path.has_extension("mm") || path.has_extension("hpp")) {
 		// Godot source file. Try to open it in external editor.

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -38,7 +38,6 @@
 #include "core/os/os.h"
 #include "core/version.h"
 #include "editor/docks/editor_dock.h"
-#include "editor/docks/inspector_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/script/script_editor_plugin.h"

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -218,7 +218,11 @@ void EditorLog::_meta_clicked(const String &p_meta) {
 		if (ResourceLoader::exists(path)) {
 			const Ref<Resource> res = ResourceLoader::load(path);
 			ScriptEditor::get_singleton()->edit(res, line, 0);
-			EditorNode::get_singleton()->push_item(res.ptr(), "", true);
+			EditorNode *editor_node = EditorNode::get_singleton();
+			if (res.is_valid() && editor_node->get_editor_selection_history()->get_current() != res->get_instance_id()) {
+				// Avoid re-editing the current script without the clicked line number.
+				editor_node->push_item(res.ptr(), "", true);
+			}
 		}
 	} else if (path.has_extension("cpp") || path.has_extension("h") || path.has_extension("mm") || path.has_extension("hpp")) {
 		// Godot source file. Try to open it in external editor.

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -38,7 +38,6 @@
 #include "core/os/os.h"
 #include "core/version.h"
 #include "editor/docks/editor_dock.h"
-#include "editor/docks/inspector_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/script/script_editor_plugin.h"
@@ -219,7 +218,11 @@ void EditorLog::_meta_clicked(const String &p_meta) {
 		if (ResourceLoader::exists(path)) {
 			const Ref<Resource> res = ResourceLoader::load(path);
 			ScriptEditor::get_singleton()->edit(res, line, 0);
-			InspectorDock::get_singleton()->edit_resource(res);
+			EditorNode *editor_node = EditorNode::get_singleton();
+			if (res.is_valid() && editor_node->get_editor_selection_history()->get_current() != res->get_instance_id()) {
+				// Avoid re-editing the current script without the clicked line number.
+				editor_node->push_item(res.ptr(), "", true);
+			}
 		}
 	} else if (path.has_extension("cpp") || path.has_extension("h") || path.has_extension("mm") || path.has_extension("hpp")) {
 		// Godot source file. Try to open it in external editor.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/118228.

When clicking a parse error link in EditorLog, `_meta_clicked()` called both `ScriptEditor::edit()` (with the correct line number) and `InspectorDock::edit_resource()`. The latter triggered a second call chain (`_resource_selected` → `push_item` → `_edit_current` → `ScriptEditorPlugin::edit`) that re-opened the script with `line=-1`, overwriting the correct cursor position in the external editor.

The fix replaces `InspectorDock::edit_resource(res)` with `EditorNode::push_item(res.ptr(), "", true)`. The `inspector_only=true` flag still updates the inspector dock and editor history, but skips the `main_plugin->edit()` call in `_edit_current()` that was causing the second unwanted `open_in_external_editor()` invocation.

## Test plan

- Set up an external editor with `{line}` in the Exec Flags
- Create a GDScript file with a syntax error after line 1
- Click the parse error in the EditorLog
- Verify the external editor opens at the correct error line (not line 1)
- Verify the inspector dock still shows the script resource when clicking the link