### PR TITLE
Make shortcuts that use letters or alt work in the scene tree

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4030,9 +4030,8 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		if (k->get_unicode() > 0) {
-			_do_incr_search(String::chr(k->get_unicode()));
-			accept_event();
-
+			// Only try to search for the typed letter if it was not a valid shortcut.
+			callable_mp(this, &Tree::_incr_search_as_needed).call_deferred(k);
 			return;
 		} else {
 			if (k->get_keycode() != Key::SHIFT) {
@@ -4324,6 +4323,12 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		if (v_scroll->get_value() != prev_v || h_scroll->get_value() != prev_h) {
 			accept_event();
 		}
+	}
+}
+
+void Tree::_incr_search_as_needed(const Ref<InputEventKey> &p_event_key) {
+	if (!get_viewport()->is_input_handled()) {
+		_do_incr_search(String::chr(p_event_key->get_unicode()));
 	}
 }
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -741,6 +741,7 @@ private:
 	String incr_search;
 	bool cursor_can_exit_tree = true;
 	void _do_incr_search(const String &p_add);
+	void _incr_search_as_needed(const Ref<InputEventKey> &p_event_key);
 
 	TreeItem *_search_item_text(TreeItem *p_at, const String &p_find, int *r_col, bool p_selectable, bool p_backwards = false);
 


### PR DESCRIPTION
Takes over this outdated PR/ rebases (most of the code is theirs) https://github.com/godotengine/godot/pull/93711

Fixes a bug mentioned in the conversation of #93631 

Previously, using a shortcut in the Scene tree that used any valid unicode letter did not work. This PR makes it work. 

- *Bugsquad edit:* fixes #93631