### PR TITLE
Fix misaligned timeline indicator on the Bezier editor

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -4130,7 +4130,7 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim, bool p_re
 			}
 		}
 
-		if (bezier_edit->is_visible()) {
+		if (bezier_mc->is_visible()) {
 			for (int i = 0; i < animation->get_track_count(); ++i) {
 				if (animation->track_get_type(i) == Animation::TrackType::TYPE_BEZIER) {
 					_bezier_edit(i);
@@ -4175,7 +4175,7 @@ void AnimationTrackEditor::_check_bezier_exist() {
 	if (is_exist) {
 		bezier_edit_icon->set_disabled(false);
 	} else {
-		if (bezier_edit->is_visible()) {
+		if (bezier_mc->is_visible()) {
 			_cancel_bezier_edit();
 		}
 		bezier_edit_icon->set_disabled(true);
@@ -5177,7 +5177,7 @@ void AnimationTrackEditor::resolve_insertion_offset(float &r_offset) const {
 }
 
 bool AnimationTrackEditor::is_bezier_editor_active() const {
-	return bezier_edit->is_visible();
+	return bezier_mc->is_visible();
 }
 
 bool AnimationTrackEditor::can_add_reset_key() const {
@@ -6534,7 +6534,7 @@ void AnimationTrackEditor::_scroll_input(const Ref<InputEvent> &p_event) {
 }
 
 void AnimationTrackEditor::_toggle_bezier_edit() {
-	if (bezier_edit->is_visible()) {
+	if (bezier_mc->is_visible()) {
 		_cancel_bezier_edit();
 	} else {
 		int track_count = animation->get_track_count();
@@ -6599,7 +6599,7 @@ void AnimationTrackEditor::_zoom_callback(float p_zoom_factor, Vector2 p_origin,
 }
 
 void AnimationTrackEditor::_cancel_bezier_edit() {
-	bezier_edit->hide();
+	bezier_mc->hide();
 	box_selection_container->show();
 	bezier_edit_icon->set_pressed(false);
 	auto_fit->show();
@@ -6611,7 +6611,7 @@ void AnimationTrackEditor::_bezier_edit(int p_for_track) {
 	bezier_edit->set_root(root);
 	bezier_edit->set_animation_and_track(animation, p_for_track, read_only);
 	box_selection_container->hide();
-	bezier_edit->show();
+	bezier_mc->show();
 	auto_fit->hide();
 	auto_fit_bezier->show();
 	// Search everything within the track and curve - edit it.
@@ -7437,21 +7437,21 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 		} break;
 
 		case EDIT_DUPLICATE_SELECTED_KEYS: {
-			if (bezier_edit->is_visible()) {
+			if (bezier_mc->is_visible()) {
 				bezier_edit->duplicate_selected_keys(-1.0, false);
 				break;
 			}
 			_anim_duplicate_keys(-1.0, false, -1.0);
 		} break;
 		case EDIT_CUT_KEYS: {
-			if (bezier_edit->is_visible()) {
+			if (bezier_mc->is_visible()) {
 				bezier_edit->copy_selected_keys(true);
 				break;
 			}
 			_anim_copy_keys(true);
 		} break;
 		case EDIT_COPY_KEYS: {
-			if (bezier_edit->is_visible()) {
+			if (bezier_mc->is_visible()) {
 				bezier_edit->copy_selected_keys(false);
 				break;
 			}
@@ -7560,7 +7560,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 
 		} break;
 		case EDIT_DELETE_SELECTION: {
-			if (bezier_edit->is_visible()) {
+			if (bezier_mc->is_visible()) {
 				bezier_edit->delete_selection();
 				break;
 			}
@@ -7905,7 +7905,7 @@ void AnimationTrackEditor::_auto_fit() {
 void AnimationTrackEditor::_auto_fit_bezier() {
 	timeline->auto_fit();
 
-	if (bezier_edit->is_visible()) {
+	if (bezier_mc->is_visible()) {
 		bezier_edit->auto_fit_vertically();
 	}
 }
@@ -7987,6 +7987,8 @@ void AnimationTrackEditor::_update_timeline_margins() {
 
 	timeline_mc->add_theme_constant_override(SNAME("margin_left"), margin_left);
 	timeline_mc->add_theme_constant_override(SNAME("margin_right"), margin_right);
+
+	bezier_mc->add_theme_constant_override(SNAME("margin_left"), margin_left);
 }
 
 void AnimationTrackEditor::_add_animation_player() {
@@ -8189,12 +8191,16 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	box_selection_container->set_clip_contents(true);
 	timeline_vbox->add_child(box_selection_container);
 
+	bezier_mc = memnew(MarginContainer);
+	bezier_mc->set_v_size_flags(SIZE_EXPAND_FILL);
+	bezier_mc->set_theme_type_variation("AnimationBezierMargin");
+	timeline_vbox->add_child(bezier_mc);
+	bezier_mc->hide();
+
 	bezier_edit = memnew(AnimationBezierTrackEdit);
-	timeline_vbox->add_child(bezier_edit);
+	bezier_mc->add_child(bezier_edit);
 	bezier_edit->set_editor(this);
 	bezier_edit->set_timeline(timeline);
-	bezier_edit->hide();
-	bezier_edit->set_v_size_flags(SIZE_EXPAND_FILL);
 	bezier_edit->connect("timeline_changed", callable_mp(this, &AnimationTrackEditor::_timeline_changed));
 
 	marker_edit = memnew(AnimationMarkerEdit);

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -621,6 +621,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	HScrollBar *hscroll = nullptr;
 	ScrollContainer *scroll = nullptr;
 	VBoxContainer *track_vbox = nullptr;
+	MarginContainer *bezier_mc = nullptr;
 	AnimationBezierTrackEdit *bezier_edit = nullptr;
 	VBoxContainer *timeline_vbox = nullptr;
 

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -2547,6 +2547,9 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_constant("margin_left", "AnimationTrackMargins", margin);
 		p_theme->set_constant("margin_right", "AnimationTrackMargins", margin);
 
+		p_theme->set_type_variation("AnimationBezierMargin", "MarginContainer");
+		p_theme->set_constant("margin_left", "AnimationBezierMargin", margin);
+
 		// AnimationTimelineEdit.
 		// "primary" is used for integer timeline values, "secondary" for decimals.
 


### PR DESCRIPTION
Fixes this:
<img width="131" height="99" alt="image" src="https://github.com/user-attachments/assets/206a9460-d1ce-4751-a4c8-97d3311ce4f6" />