### PR TITLE
Add hotkeys to focus scene tree and inspector filters

### DIFF
--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -711,10 +711,14 @@ void InspectorDock::shortcut_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
-		search->grab_focus();
-		search->select_all();
+		focus_search();
 		accept_event();
 	}
+}
+
+void InspectorDock::focus_search() {
+	search->grab_focus();
+	search->select_all();
 }
 
 InspectorDock::InspectorDock(EditorData &p_editor_data) {

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -715,10 +715,14 @@ void InspectorDock::shortcut_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
-		search->grab_focus();
-		search->select_all();
+		focus_search();
 		accept_event();
 	}
+}
+
+void InspectorDock::focus_search() {
+	search->grab_focus();
+	search->select_all();
 }
 
 InspectorDock::InspectorDock(EditorData &p_editor_data) {

--- a/editor/docks/inspector_dock.h
+++ b/editor/docks/inspector_dock.h
@@ -147,6 +147,7 @@ protected:
 	void _notification(int p_what);
 
 public:
+	void focus_search();
 	void go_back();
 	void edit_resource(const Ref<Resource> &p_resource);
 	void open_resource(const String &p_type);

--- a/editor/docks/inspector_dock.h
+++ b/editor/docks/inspector_dock.h
@@ -145,6 +145,7 @@ protected:
 	void _notification(int p_what);
 
 public:
+	void focus_search();
 	void edit_resource(const Ref<Resource> &p_resource);
 	void open_resource(const String &p_type);
 	void clear();

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -273,8 +273,7 @@ void SceneTreeDock::_scene_tree_gui_input(Ref<InputEvent> p_event) {
 	}
 
 	if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
-		filter->grab_focus();
-		filter->select_all();
+		focus_filter();
 		accept_event();
 	} else if (ED_IS_SHORTCUT("scene_tree/open_scene_in_editor", p_event)) {
 		_tool_selected(TOOL_SCENE_OPEN);
@@ -4217,6 +4216,11 @@ void SceneTreeDock::_append_filter_options_to(PopupMenu *p_menu) {
 
 String SceneTreeDock::get_filter() {
 	return filter->get_text();
+}
+
+void SceneTreeDock::focus_filter() {
+	filter->grab_focus();
+	filter->select_all();
 }
 
 void SceneTreeDock::set_filter(const String &p_filter) {

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -289,8 +289,7 @@ void SceneTreeDock::_scene_tree_gui_input(Ref<InputEvent> p_event) {
 	}
 
 	if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
-		filter->grab_focus();
-		filter->select_all();
+		focus_filter();
 		accept_event();
 	} else if (ED_IS_SHORTCUT("scene_tree/open_scene_in_editor", p_event)) {
 		_tool_selected(TOOL_SCENE_OPEN);
@@ -4268,6 +4267,11 @@ void SceneTreeDock::_append_filter_options_to(PopupMenu *p_menu) {
 
 String SceneTreeDock::get_filter() {
 	return filter->get_text();
+}
+
+void SceneTreeDock::focus_filter() {
+	filter->grab_focus();
+	filter->select_all();
 }
 
 void SceneTreeDock::set_filter(const String &p_filter) {

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -327,6 +327,7 @@ public:
 
 	void _focus_node();
 
+	void focus_filter();
 	void add_root_node(Node *p_node);
 	void set_edited_scene(Node *p_scene);
 	void instantiate(const String &p_file);

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -328,6 +328,7 @@ public:
 
 	void _focus_node();
 
+	void focus_filter();
 	void add_root_node(Node *p_node);
 	void set_edited_scene(Node *p_scene);
 	void instantiate(const String &p_file);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -431,6 +431,10 @@ void EditorNode::shortcut_input(const Ref<InputEvent> &p_event) {
 			_open_command_palette();
 		} else if (ED_IS_SHORTCUT("editor/toggle_last_opened_bottom_panel", p_event)) {
 			bottom_panel->toggle_last_opened_bottom_panel();
+		} else if (ED_IS_SHORTCUT("editor/focus_scene_tree_filter", p_event)) {
+			SceneTreeDock::get_singleton()->focus_filter();
+		} else if (ED_IS_SHORTCUT("editor/focus_inspector_filter", p_event)) {
+			InspectorDock::get_singleton()->focus_search();
 		} else if (ED_IS_SHORTCUT("editor/toggle_selected_nodes_visibility", p_event)) {
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 			undo_redo->create_action(TTR("Toggle Selected Node(s) Visibility"));
@@ -8946,6 +8950,9 @@ EditorNode::EditorNode() {
 	ED_SHORTCUT_AND_COMMAND("editor/editor_script", TTRC("Open Script Editor"), KeyModifierMask::CTRL | Key::F3);
 	ED_SHORTCUT_AND_COMMAND("editor/editor_game", TTRC("Open Game View"), KeyModifierMask::CTRL | Key::F4);
 	ED_SHORTCUT_AND_COMMAND("editor/editor_assetlib", TTRC("Open Asset Library"), KeyModifierMask::CTRL | Key::F5);
+
+	ED_SHORTCUT_AND_COMMAND("editor/focus_scene_tree_filter", TTRC("Focus Scene Tree Filter"), KeyModifierMask::ALT | Key::U);
+	ED_SHORTCUT_AND_COMMAND("editor/focus_inspector_filter", TTRC("Focus Inspector Filter"), KeyModifierMask::ALT | Key::I);
 
 	ED_SHORTCUT_OVERRIDE("editor/editor_2d", "macos", KeyModifierMask::META | KeyModifierMask::CTRL | Key::KEY_1);
 	ED_SHORTCUT_OVERRIDE("editor/editor_3d", "macos", KeyModifierMask::META | KeyModifierMask::CTRL | Key::KEY_2);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -440,6 +440,10 @@ void EditorNode::shortcut_input(const Ref<InputEvent> &p_event) {
 			_open_command_palette();
 		} else if (ED_IS_SHORTCUT("editor/toggle_last_opened_bottom_panel", p_event)) {
 			bottom_panel->toggle_last_opened_bottom_panel();
+		} else if (ED_IS_SHORTCUT("editor/focus_scene_tree_filter", p_event)) {
+			SceneTreeDock::get_singleton()->focus_filter();
+		} else if (ED_IS_SHORTCUT("editor/focus_inspector_filter", p_event)) {
+			InspectorDock::get_singleton()->focus_search();
 		} else if (ED_IS_SHORTCUT("editor/toggle_selected_nodes_visibility", p_event)) {
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 			undo_redo->create_action(TTR("Toggle Selected Node(s) Visibility"));
@@ -9117,6 +9121,9 @@ EditorNode::EditorNode() {
 	ED_SHORTCUT_AND_COMMAND("editor/editor_script", TTRC("Open Script Editor"), KeyModifierMask::CTRL | Key::F3);
 	ED_SHORTCUT_AND_COMMAND("editor/editor_game", TTRC("Open Game View"), KeyModifierMask::CTRL | Key::F4);
 	ED_SHORTCUT_AND_COMMAND("editor/editor_asset_store", TTRC("Open Asset Store"), KeyModifierMask::CTRL | Key::F5);
+
+	ED_SHORTCUT_AND_COMMAND("editor/focus_scene_tree_filter", TTRC("Focus Scene Tree Filter"), KeyModifierMask::ALT | Key::U);
+	ED_SHORTCUT_AND_COMMAND("editor/focus_inspector_filter", TTRC("Focus Inspector Filter"), KeyModifierMask::ALT | Key::I);
 
 	ED_SHORTCUT_OVERRIDE("editor/editor_2d", "macos", KeyModifierMask::META | KeyModifierMask::CTRL | Key::KEY_1);
 	ED_SHORTCUT_OVERRIDE("editor/editor_3d", "macos", KeyModifierMask::META | KeyModifierMask::CTRL | Key::KEY_2);


### PR DESCRIPTION
Adds hotkeys to focus the property filter and scene tree filter.

Fixes https://github.com/godotengine/godot-proposals/issues/14617

Pairs well with my other PR which fixes an issue where many hotkeys don't work when the scene tree is selected https://github.com/godotengine/godot/pull/118246