### PR TITLE
Add `Signal.emitv()` that takes Array arguments, just like `Callable.callv()` and `Callable.bindv()`

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -540,6 +540,24 @@ Error Signal::emit(const Variant **p_arguments, int p_argcount) const {
 	return obj->emit_signalp(name, p_arguments, p_argcount);
 }
 
+Error Signal::emitv(const Array &p_arguments) const {
+	Object *obj = ObjectDB::get_instance(object);
+	if (!obj) {
+		return ERR_INVALID_DATA;
+	}
+
+	int argcount = p_arguments.size();
+	const Variant **argptrs = nullptr;
+	if (argcount) {
+		argptrs = (const Variant **)alloca(sizeof(Variant *) * argcount);
+		for (int i = 0; i < argcount; i++) {
+			argptrs[i] = &p_arguments[i];
+		}
+	}
+
+	return obj->emit_signalp(name, argptrs, argcount);
+}
+
 Error Signal::connect(const Callable &p_callable, uint32_t p_flags) {
 	Object *obj = get_object();
 	ERR_FAIL_NULL_V(obj, ERR_UNCONFIGURED);

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -194,6 +194,7 @@ public:
 	explicit operator String() const;
 
 	Error emit(const Variant **p_arguments, int p_argcount) const;
+	Error emitv(const Array &p_arguments) const;
 	Error connect(const Callable &p_callable, uint32_t p_flags = 0);
 	void disconnect(const Callable &p_callable);
 	bool is_connected(const Callable &p_callable) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2503,7 +2503,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Signal, is_connected, sarray("callable"), varray());
 	bind_method(Signal, get_connections, sarray(), varray());
 	bind_method(Signal, has_connections, sarray(), varray());
-	bind_method(Signal, emitv, sarray("arguments"), varray())
+	bind_method(Signal, emitv, sarray("arguments"), varray());
 
 	bind_custom(Signal, emit, _VariantCall::func_Signal_emit, false, Variant);
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2503,6 +2503,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Signal, is_connected, sarray("callable"), varray());
 	bind_method(Signal, get_connections, sarray(), varray());
 	bind_method(Signal, has_connections, sarray(), varray());
+	bind_method(Signal, emitv, sarray("arguments"), varray())
 
 	bind_custom(Signal, emit, _VariantCall::func_Signal_emit, false, Variant);
 

--- a/doc/classes/Signal.xml
+++ b/doc/classes/Signal.xml
@@ -206,6 +206,13 @@
 				Emits this signal. All [Callable]s connected to this signal will be triggered. This method supports a variable number of arguments, so parameters can be passed as a comma separated list.
 			</description>
 		</method>
+		<method name="emitv" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="arguments" type="Array" />
+			<description>
+				Emits this signal. All [Callable]s connected to this signal will be triggered. Unlike [method emit], this method expects all arguments to be contained inside the [param arguments] [Array].
+			</description>
+		</method>
 		<method name="get_connections" qualifiers="const">
 			<return type="Array" />
 			<description>


### PR DESCRIPTION
As it stands currently, there is no way to emit a `Signal` with flexible number of user-defined arguments, because `Signal.emit()` can only take a hard-coded number of arguments separated by commas.

`Callable` doesn't have this issue because it has `callv()` and `bindv()` as the dynamic alternative to `call()` and `bind()`. So then, why not implement `Signal.emitv()`?

**(Before) passing an Array of user-defined arguments using `Signal.emit()`:**
<img width="955" height="552" alt="image" src="https://github.com/user-attachments/assets/74d65549-7e7a-44ff-bebf-a931714cb168" />

**(After) passing an Array of user-defined arguments using `Signal.emitv()`:**
<img width="651" height="220" alt="image" src="https://github.com/user-attachments/assets/9d7826cf-f139-463e-b793-1dc67de08a36" />

One thing I'm a bit worried about is that, passing the wrong number of arguments only silently cancels the emit and throws a soft error that doesn't stop the gameplay. But considering that's the default behavior of `Signal.emit()` anyway, I think that's outside of the scope of this pull request.

This is my first time tinkering with source code and making a pull request, please do let me know if I'm doing anything wrong with the codes. I basically just transplanted some codes used in `Callable.callv()` and `Callable.bindv()`, I'm not really familiar with the project structure and C++ in general.