### PR TITLE
SCons: Enable C/C++ standard selection

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -314,6 +314,24 @@ opts.Add(
         ("executable", "static_library", "shared_library"),
     )
 )
+opts.Add(
+    EnumVariable(
+        ["cpp_standard", "cpp_std"],
+        "Set the C++ standard (Experimental)",
+        "17",
+        ("17", "20", "23"),
+        ignorecase=2,
+    )
+)
+opts.Add(
+    EnumVariable(
+        ["c_standard", "c_std"],
+        "Set the C Standard (Experimental)",
+        "17",
+        ("17", "23"),
+        ignorecase=2,
+    )
+)
 
 # Thirdparty libraries
 opts.Add(BoolVariable("builtin_brotli", "Use the built-in Brotli library", True))
@@ -708,89 +726,13 @@ print(f'Building for platform "{platform_string}", architecture "{env["arch"]}",
 if env.dev_build:
     print_info("Developer build, with debug optimization level and debug symbols (unless overridden).")
 
-# Enforce our minimal compiler version requirements
-cc_version = methods.get_compiler_version(env)
-cc_version_major = cc_version["major"]
-cc_version_minor = cc_version["minor"]
-cc_version_metadata1 = cc_version["metadata1"]
+# Set our C and C++ standard requirements.
+# This needs to come after `configure`, otherwise we don't have env.msvc.
+methods.update_c_standard(env)
+methods.update_cpp_standard(env)
 
-if cc_version_major == -1:
-    print_warning(
-        "Couldn't detect compiler version, skipping version checks. "
-        "Build may fail if the compiler doesn't support C++17 fully."
-    )
-elif methods.using_gcc(env):
-    if env.get("winrt"):
-        if cc_version_major < 11:
-            print_error(
-                "Detected GCC version older than 11, which does not fully support "
-                "C++20, or has bugs when compiling Godot. Supported versions are 12 "
-                "and later. Use a newer GCC version, or Clang 14 or later by passing "
-                '"use_llvm=yes" to the SCons command line, or disable WinRT support by '
-                'passing "winrt=no" to the SCons command line.'
-            )
-            Exit(255)
-    else:
-        if cc_version_major < 9:
-            print_error(
-                "Detected GCC version older than 9, which does not fully support "
-                "C++17, or has bugs when compiling Godot. Supported versions are 9 "
-                "and later. Use a newer GCC version, or Clang 6 or later by passing "
-                '"use_llvm=yes" to the SCons command line.'
-            )
-            Exit(255)
-    if cc_version_metadata1 == "win32":
-        print_error(
-            "Detected mingw version is not using posix threads. Only posix "
-            "version of mingw is supported. "
-            'Use "update-alternatives --config x86_64-w64-mingw32-g++" '
-            "to switch to posix threads."
-        )
-        Exit(255)
-elif methods.using_clang(env):
-    # Apple LLVM versions differ from upstream LLVM version \o/, compare
-    # in https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
-    if methods.is_apple_clang(env):
-        if cc_version_major < 16:
-            print_error(
-                "Detected Apple Clang version older than 16, supported versions are Apple Clang 16 (Xcode 16) and later."
-            )
-            Exit(255)
-    else:
-        if env.get("winrt"):
-            if cc_version_major < 13:
-                print_error(
-                    "Detected Clang version older than 13, which does not fully support "
-                    "C++20. Supported versions are Clang 14 and later, or disable WinRT "
-                    'support by passing "winrt=no" to the SCons command line.'
-                )
-                Exit(255)
-        else:
-            if cc_version_major < 6:
-                print_error(
-                    "Detected Clang version older than 6, which does not fully support "
-                    "C++17. Supported versions are Clang 6 and later."
-                )
-                Exit(255)
-            elif env["debug_paths_relative"] and cc_version_major < 10:
-                print_warning("Clang < 10 doesn't support -ffile-prefix-map, disabling `debug_paths_relative` option.")
-                env["debug_paths_relative"] = False
-
-elif env.msvc:
-    if cc_version_major == 16 and cc_version_minor < 11:
-        # Ensure latest minor build of Visual Studio 2019.
-        # https://github.com/godotengine/godot/pull/94995#issuecomment-2336464574
-        print_error(
-            "Detected Visual Studio 2019 version older than 16.11, which has bugs "
-            "when compiling Godot. Use a newer VS2019 version, or VS2022+."
-        )
-        Exit(255)
-    elif cc_version_major < 16:
-        print_error(
-            "Detected Visual Studio 2017 or earlier, which is unsupported in Godot. "
-            "Supported versions are Visual Studio 2019 and later."
-        )
-        Exit(255)
+env.Prepend(CFLAGS=["$CSTD"])
+env.Prepend(CXXFLAGS=["$CXXSTD"])
 
 # Set x86 CPU instruction sets to use by the compiler's autovectorization.
 if env["arch"] == "x86_64":
@@ -905,20 +847,7 @@ else:
 if env["lto"] != "none":
     print("Using LTO: " + env["lto"])
 
-# Set our C and C++ standard requirements.
-# C++17 is required as we need guaranteed copy elision as per GH-36436.
-# Prepending to make it possible to override.
-# This needs to come after `configure`, otherwise we don't have env.msvc.
-if not env.msvc:
-    # Specifying GNU extensions support explicitly, which are supported by
-    # both GCC and Clang. Both currently default to gnu17 and gnu++17.
-    env.Prepend(CFLAGS=["-std=gnu17"])
-    env.Prepend(CXXFLAGS=["-std=gnu++17"])
-else:
-    # MSVC started offering C standard support with Visual Studio 2019 16.8, which covers all
-    # of our supported Visual Studio versions.
-    env.Prepend(CFLAGS=["/std:c17"])
-    env.Prepend(CXXFLAGS=["/std:c++17"])
+if env.msvc:
     # MSVC is non-conforming with the C++ standard by default, so we enable more conformance.
     # Note that this is still not complete conformance, as certain Windows-related headers
     # don't compile under complete conformance.
@@ -974,6 +903,7 @@ if env.msvc and not methods.using_clang(env):  # MSVC
         env.AppendUnique(LINKFLAGS=["/WX"])
 
 else:  # GCC, Clang
+    cc_version_major = methods.get_compiler_version(env)["major"]
     common_warnings = []
     if methods.using_gcc(env):
         common_warnings += ["-Wshadow", "-Wno-misleading-indentation"]

--- a/core/math/rect2.cpp
+++ b/core/math/rect2.cpp
@@ -293,3 +293,10 @@ Rect2::operator String() const {
 Rect2::operator Rect2i() const {
 	return Rect2i(position, size);
 }
+
+bool Rect2::operator==(const Rect2i &p_rect2i) const {
+	return operator==(Rect2(p_rect2i));
+}
+bool Rect2::operator!=(const Rect2i &p_rect2i) const {
+	return operator!=(Rect2(p_rect2i));
+}

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -209,6 +209,9 @@ struct [[nodiscard]] Rect2 {
 	constexpr bool operator==(const Rect2 &p_rect) const { return position == p_rect.position && size == p_rect.size; }
 	constexpr bool operator!=(const Rect2 &p_rect) const { return position != p_rect.position || size != p_rect.size; }
 
+	bool operator==(const Rect2i &p_rect2i) const;
+	bool operator!=(const Rect2i &p_rect2i) const;
+
 	inline Rect2 grow(real_t p_amount) const {
 		Rect2 g = *this;
 		g.grow_by(p_amount);

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -223,3 +223,22 @@ Vector2::operator String() const {
 Vector2::operator Vector2i() const {
 	return Vector2i(x, y);
 }
+
+bool Vector2::operator==(const Vector2i &p_vector2i) const {
+	return operator==(Vector2(p_vector2i));
+}
+bool Vector2::operator!=(const Vector2i &p_vector2i) const {
+	return operator!=(Vector2(p_vector2i));
+}
+bool Vector2::operator<(const Vector2i &p_vector2i) const {
+	return operator<(Vector2(p_vector2i));
+}
+bool Vector2::operator>(const Vector2i &p_vector2i) const {
+	return operator>(Vector2(p_vector2i));
+}
+bool Vector2::operator<=(const Vector2i &p_vector2i) const {
+	return operator<=(Vector2(p_vector2i));
+}
+bool Vector2::operator>=(const Vector2i &p_vector2i) const {
+	return operator>=(Vector2(p_vector2i));
+}

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -168,6 +168,13 @@ struct [[nodiscard]] Vector2 {
 	constexpr bool operator<=(const Vector2 &p_vec2) const { return x == p_vec2.x ? (y <= p_vec2.y) : (x < p_vec2.x); }
 	constexpr bool operator>=(const Vector2 &p_vec2) const { return x == p_vec2.x ? (y >= p_vec2.y) : (x > p_vec2.x); }
 
+	bool operator==(const Vector2i &p_vector2i) const;
+	bool operator!=(const Vector2i &p_vector2i) const;
+	bool operator<(const Vector2i &p_vector2i) const;
+	bool operator>(const Vector2i &p_vector2i) const;
+	bool operator<=(const Vector2i &p_vector2i) const;
+	bool operator>=(const Vector2i &p_vector2i) const;
+
 	real_t angle() const;
 	static Vector2 from_angle(real_t p_angle);
 

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -161,3 +161,22 @@ Vector3::operator String() const {
 Vector3::operator Vector3i() const {
 	return Vector3i(x, y, z);
 }
+
+bool Vector3::operator==(const Vector3i &p_vector3i) const {
+	return operator==(Vector3(p_vector3i));
+}
+bool Vector3::operator!=(const Vector3i &p_vector3i) const {
+	return operator!=(Vector3(p_vector3i));
+}
+bool Vector3::operator<(const Vector3i &p_vector3i) const {
+	return operator<(Vector3(p_vector3i));
+}
+bool Vector3::operator>(const Vector3i &p_vector3i) const {
+	return operator>(Vector3(p_vector3i));
+}
+bool Vector3::operator<=(const Vector3i &p_vector3i) const {
+	return operator<=(Vector3(p_vector3i));
+}
+bool Vector3::operator>=(const Vector3i &p_vector3i) const {
+	return operator>=(Vector3(p_vector3i));
+}

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -211,6 +211,13 @@ struct [[nodiscard]] Vector3 {
 	constexpr bool operator>(const Vector3 &p_v) const;
 	constexpr bool operator>=(const Vector3 &p_v) const;
 
+	bool operator==(const Vector3i &p_vector3i) const;
+	bool operator!=(const Vector3i &p_vector3i) const;
+	bool operator<(const Vector3i &p_vector3i) const;
+	bool operator>(const Vector3i &p_vector3i) const;
+	bool operator<=(const Vector3i &p_vector3i) const;
+	bool operator>=(const Vector3i &p_vector3i) const;
+
 	explicit operator String() const;
 	operator Vector3i() const;
 

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -233,3 +233,22 @@ static_assert(sizeof(Vector4) == 4 * sizeof(real_t));
 Vector4::operator Vector4i() const {
 	return Vector4i(x, y, z, w);
 }
+
+bool Vector4::operator==(const Vector4i &p_vector4i) const {
+	return operator==(Vector4(p_vector4i));
+}
+bool Vector4::operator!=(const Vector4i &p_vector4i) const {
+	return operator!=(Vector4(p_vector4i));
+}
+bool Vector4::operator<(const Vector4i &p_vector4i) const {
+	return operator<(Vector4(p_vector4i));
+}
+bool Vector4::operator>(const Vector4i &p_vector4i) const {
+	return operator>(Vector4(p_vector4i));
+}
+bool Vector4::operator<=(const Vector4i &p_vector4i) const {
+	return operator<=(Vector4(p_vector4i));
+}
+bool Vector4::operator>=(const Vector4i &p_vector4i) const {
+	return operator>=(Vector4(p_vector4i));
+}

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -146,6 +146,13 @@ struct [[nodiscard]] Vector4 {
 	constexpr bool operator>=(const Vector4 &p_vec4) const;
 	constexpr bool operator<=(const Vector4 &p_vec4) const;
 
+	bool operator==(const Vector4i &p_vector4i) const;
+	bool operator!=(const Vector4i &p_vector4i) const;
+	bool operator<(const Vector4i &p_vector4i) const;
+	bool operator>(const Vector4i &p_vector4i) const;
+	bool operator<=(const Vector4i &p_vector4i) const;
+	bool operator>=(const Vector4i &p_vector4i) const;
+
 	explicit operator String() const;
 	operator Vector4i() const;
 

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -114,6 +114,15 @@ public:
 		return reference != p_r.reference;
 	}
 
+	template <typename T_Other>
+	_FORCE_INLINE_ bool operator==(const Ref<T_Other> &p_other) const {
+		return reference == p_other.ptr();
+	}
+	template <typename T_Other>
+	_FORCE_INLINE_ bool operator!=(const Ref<T_Other> &p_other) const {
+		return reference != p_other.ptr();
+	}
+
 	_FORCE_INLINE_ T *operator*() const {
 		return reference;
 	}

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -822,6 +822,22 @@ public:
 	[[nodiscard]] _ALWAYS_INLINE_ bool operator>(const Variant &p_variant) const { return p_variant < *this; }
 	[[nodiscard]] _ALWAYS_INLINE_ bool operator>=(const Variant &p_variant) const { return !(*this < p_variant); }
 
+	// HACK: Simplest way to ensure a nearly-complete set of comparison operations across all
+	//       supported types. Only excludes unscoped enumerations, as they clash with builtin
+	//       operators in such a way that can't be easily worked around.
+	template <typename T, std::enable_if_t<std::is_convertible_v<T, Variant> && (!std::is_enum_v<T> || !std::is_convertible_v<T, int>), int> = 0>
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator==(const T &p_value) const { return *this == Variant(p_value); }
+	template <typename T, std::enable_if_t<std::is_convertible_v<T, Variant> && (!std::is_enum_v<T> || !std::is_convertible_v<T, int>), int> = 0>
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator!=(const T &p_value) const { return *this != Variant(p_value); }
+	template <typename T, std::enable_if_t<std::is_convertible_v<T, Variant> && (!std::is_enum_v<T> || !std::is_convertible_v<T, int>), int> = 0>
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator<(const T &p_value) const { return *this < Variant(p_value); }
+	template <typename T, std::enable_if_t<std::is_convertible_v<T, Variant> && (!std::is_enum_v<T> || !std::is_convertible_v<T, int>), int> = 0>
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator<=(const T &p_value) const { return *this <= Variant(p_value); }
+	template <typename T, std::enable_if_t<std::is_convertible_v<T, Variant> && (!std::is_enum_v<T> || !std::is_convertible_v<T, int>), int> = 0>
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator>(const T &p_value) const { return *this > Variant(p_value); }
+	template <typename T, std::enable_if_t<std::is_convertible_v<T, Variant> && (!std::is_enum_v<T> || !std::is_convertible_v<T, int>), int> = 0>
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator>=(const T &p_value) const { return *this >= Variant(p_value); }
+
 	uint32_t hash() const;
 	uint32_t recursive_hash(int recursion_count) const;
 

--- a/drivers/metal/SCsub
+++ b/drivers/metal/SCsub
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
 
+from methods import update_cpp_standard
+
 Import("env")
 
 # If we're using Metal, we need metal-cpp.
@@ -45,9 +47,8 @@ env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
 env_metal.drivers_sources += thirdparty_obj
 
 # Enable C++20 for the Objective-C++ Metal code, which uses C++20 concepts.
-if "-std=gnu++17" in env_metal["CXXFLAGS"]:
-    env_metal["CXXFLAGS"].remove("-std=gnu++17")
-env_metal.Append(CXXFLAGS=["-std=gnu++20"])
+if env_metal["cpp_standard"] == "17":
+    update_cpp_standard(env_metal, "20")
 
 # Enable module support
 env_metal.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])

--- a/methods.py
+++ b/methods.py
@@ -678,6 +678,138 @@ def is_apple_clang(env):
     return version.startswith("Apple")
 
 
+COMPILER_STANDARD_SUPPORT = {
+    "gcc": {
+        "c": {
+            "17": "9",
+            "23": "15",
+        },
+        "cpp": {
+            "17": "9",
+            "20": "11",
+            "23": "14",
+        },
+    },
+    "clang": {
+        "c": {
+            "17": "6",
+            "23": "19",
+        },
+        "cpp": {
+            "17": "6",
+            "20": "13",
+            "23": "18",
+        },
+    },
+    "apple-clang": {
+        "c": {
+            "17": "16",
+            "23": "16",
+        },
+        "cpp": {
+            "17": "16",
+            "20": "16",
+            "23": "16",
+        },
+    },
+    "emcc": {
+        "c": {
+            "17": "4",
+            "23": "4",
+        },
+        "cpp": {
+            "17": "4",
+            "20": "4",
+            "23": "4",
+        },
+    },
+    "msvc": {
+        "c": {
+            "17": "16.11",
+            "23": "16.11",
+        },
+        "cpp": {
+            "17": "16.11",
+            "20": "16.11",
+            "23": "17",
+        },
+    },
+}
+
+
+def _supports_standard(env, standard: str, language: str, verbose: bool) -> bool:
+    compiler = (
+        "msvc"
+        if env.msvc
+        else "apple-clang"
+        if is_apple_clang(env)
+        else "gcc"
+        if using_gcc(env)
+        else "emcc"
+        if using_emcc(env)
+        else "clang"
+    )
+    min_version = COMPILER_STANDARD_SUPPORT[compiler][language][standard]
+
+    if not min_version:
+        if verbose:
+            print_warning(
+                f'Using unevaluated {language.upper()} Standard "{standard}" on compiler "{compiler}"; skipping validation checks.'
+            )
+        return True
+
+    major, minor, patch, *_ = get_compiler_version(env).values()
+    if major == -1:
+        if verbose:
+            print_warning(f'Failed to parse version of compiler "{compiler}"; skipping validation checks.')
+        return True
+
+    supported = (major, minor, patch) >= tuple(int(value) for value in min_version.split("."))
+    if not supported and verbose:
+        print_error(
+            f'Compiler "{compiler}" cannot support {language.upper()} Standard {standard}; '
+            f'detected version "{major}.{minor}.{patch}", but requires version "{min_version}" or later.'
+        )
+
+    return supported
+
+
+def supports_c_standard(env, c_standard: str) -> bool:
+    return _supports_standard(env, c_standard, "c", False)
+
+
+def supports_cpp_standard(env, cpp_standard: str) -> bool:
+    return _supports_standard(env, cpp_standard, "cpp", False)
+
+
+def update_c_standard(env, new_standard: str = "") -> None:
+    if new_standard:
+        env["c_standard"] = new_standard
+
+    c_std: str = env["c_standard"]
+    if not _supports_standard(env, c_std, "c", True):
+        env.Exit(255)
+
+    if not env.msvc:
+        env["CSTD"] = f"-std=gnu{c_std}"
+    else:
+        env["CSTD"] = f"/std:c{'latest' if c_std == '23' else c_std}"
+
+
+def update_cpp_standard(env, new_standard: str = "") -> None:
+    if new_standard:
+        env["cpp_standard"] = new_standard
+
+    cpp_std: str = env["cpp_standard"]
+    if not _supports_standard(env, cpp_std, "cpp", True):
+        env.Exit(255)
+
+    if not env.msvc:
+        env["CXXSTD"] = f"-std=gnu++{cpp_std}"
+    else:
+        env["CXXSTD"] = f"/std:c++{'23preview' if cpp_std == '23' else cpp_std}"
+
+
 def get_compiler_version(env):
     """
     Returns a dictionary with various version information:
@@ -690,8 +822,6 @@ def get_compiler_version(env):
     global compiler_version_cache
     if compiler_version_cache is not None:
         return compiler_version_cache
-
-    import shlex
 
     ret = {
         "major": -1,
@@ -721,8 +851,8 @@ def get_compiler_version(env):
                 "*",
                 "-utf8",
             ]
-            version = subprocess.check_output(args, encoding="utf-8").strip()
-            for line in version.splitlines():
+            out = subprocess.run(args, encoding="utf-8", capture_output=True, check=True)
+            for line in out.stdout.strip().splitlines():
                 split = line.split(":", 1)
                 if split[0] == "catalog_productSemanticVersion":
                     match = re.match(r" ([0-9]*).([0-9]*).([0-9]*)-?([a-z0-9.+]*)", split[1])
@@ -743,12 +873,12 @@ def get_compiler_version(env):
     # Not using -dumpversion as some GCC distros only return major, and
     # Clang used to return hardcoded 4.2.1: # https://reviews.llvm.org/D56803
     try:
-        version = subprocess.check_output(
-            shlex.split(env.subst(env["CXX"]), posix=False) + ["--version"], shell=(os.name == "nt"), encoding="utf-8"
-        ).strip()
+        out = subprocess.run([env["CXX"], "--version"], encoding="utf-8", capture_output=True, check=True)
     except (subprocess.CalledProcessError, OSError):
         print_warning("Couldn't parse CXX environment variable to infer compiler version.")
         return update_compiler_version_cache(ret)
+
+    version = out.stdout.strip()
 
     match = re.search(
         r"(?:(?<=version )|(?<=\) )|(?<=^))"
@@ -791,6 +921,14 @@ def get_compiler_version(env):
         "apple_patch3",
     ]:
         ret[key] = int(ret[key] or -1)
+
+    if using_gcc(env) and ret["metadata1"] == "win32":
+        print_error(
+            "Detected mingw version is not using posix threads. Only posix version of mingw is supported. "
+            "Use `update-alternatives --config x86_64-w64-mingw32-g++` to switch to posix threads."
+        )
+        sys.exit(255)
+
     return update_compiler_version_cache(ret)
 
 

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -362,10 +362,10 @@ String GridMapEditor::_get_cursor_coordinates() const {
 	if (cursor_visible || !set_items.is_empty() || !clipboard_items.is_empty()) {
 		if (selection.active) {
 			if (selection.begin == selection.end) {
-				text = vformat(String::utf8(u8"(%d, %d, %d)  \u2317  (%d, %d, %d)"),
+				text = vformat(String::utf8("(%d, %d, %d)  \u2317  (%d, %d, %d)"),
 						(int)cursor_gridpos.x, (int)cursor_gridpos.y, (int)cursor_gridpos.z, (int)selection.begin.x, (int)selection.begin.y, (int)selection.begin.z);
 			} else {
-				text = vformat(String::utf8(u8"(%d, %d, %d)  \u2317  (%d, %d, %d) \u2192 (%d, %d, %d)"),
+				text = vformat(String::utf8("(%d, %d, %d)  \u2317  (%d, %d, %d) \u2192 (%d, %d, %d)"),
 						(int)cursor_gridpos.x, (int)cursor_gridpos.y, (int)cursor_gridpos.z, (int)selection.begin.x, (int)selection.begin.y, (int)selection.begin.z, (int)selection.end.x, (int)selection.end.y, (int)selection.end.z);
 			}
 		} else {

--- a/modules/mono/mono_gc_handle.h
+++ b/modules/mono/mono_gc_handle.h
@@ -49,10 +49,14 @@ extern "C" {
 struct GCHandleIntPtr {
 	void *value;
 
-	_FORCE_INLINE_ bool operator==(const GCHandleIntPtr &p_other) { return value == p_other.value; }
-	_FORCE_INLINE_ bool operator!=(const GCHandleIntPtr &p_other) { return value != p_other.value; }
+	_FORCE_INLINE_ bool operator==(const GCHandleIntPtr &p_other) const { return value == p_other.value; }
+	_FORCE_INLINE_ bool operator!=(const GCHandleIntPtr &p_other) const { return value != p_other.value; }
 
+	// FIXME: C++20 doesn't allow aggregate initializers to bypass deleted constructors.
+	// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1008r1.pdf
+#if __cplusplus < 202002L
 	GCHandleIntPtr() = delete;
+#endif
 };
 }
 

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import platform_windows_builders
 
-from methods import get_compiler_version, redirect_emitter
+from methods import redirect_emitter, update_cpp_standard
 
 sources = []
 
@@ -84,19 +84,13 @@ env.add_source_files(sources, common_win)
 env_winrt = env.Clone()
 tts_sources = ["tts_windows.cpp", "tts_driver_sapi.cpp", "winrt_utils.cpp"]
 if env["winrt"]:
+    if env_winrt["cpp_standard"] == "17":
+        update_cpp_standard(env_winrt, "20")
     if not env_winrt.msvc:
-        if "-std=gnu++17" in env_winrt["CXXFLAGS"]:
-            env_winrt["CXXFLAGS"].remove("-std=gnu++17")
-        env_winrt.Append(CXXFLAGS=["-std=gnu++20"])
         if "-fno-exceptions" in env_winrt["CXXFLAGS"]:
             env_winrt["CXXFLAGS"].remove("-fno-exceptions")
         env_winrt.Append(CXXFLAGS=["-fexceptions"])
     else:
-        cc_version = get_compiler_version(env)
-        cc_version_major = cc_version["major"]
-        if "/std:c++17" in env_winrt["CXXFLAGS"]:
-            env_winrt["CXXFLAGS"].remove("/std:c++17")
-        env_winrt.Append(CXXFLAGS=["/std:c++20"])
         if "_HAS_EXCEPTIONS" in env_winrt["CPPDEFINES"]:
             env_winrt["CPPDEFINES"].remove("_HAS_EXCEPTIONS")
         env_winrt.Append(CXXFLAGS=["/EHsc"])

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -91,6 +91,7 @@ Patches:
 - `0004-clang-warning-exclude.patch` ([GH-111346](https://github.com/godotengine/godot/pull/111346))
 - `0005-unused-typedef.patch` ([GH-111445](https://github.com/godotengine/godot/pull/111445))
 - `0006-explicit-includes.patch` ([GH-111557](https://github.com/godotengine/godot/pull/111557))
+- `0007-enum-to-int32.patch` ([GH-118260](https://github.com/godotengine/godot/pull/118260))
 
 
 ## brotli
@@ -849,7 +850,7 @@ Collection of single-file libraries used in Godot components.
   * Modifications: Added implementation through `qoa.c`.
 - `r128.{c,h}`
   * Upstream: https://github.com/fahickman/r128
-  * Version: git (6fc177671c47640d5bb69af10cf4ee91050015a1, 2023)
+  * Version: 1.6.1 (2024)
   * License: Public Domain or Unlicense
 - `smaz.{c,h}`
   * Upstream: https://github.com/antirez/smaz

--- a/thirdparty/basis_universal/encoder/basisu_math.h
+++ b/thirdparty/basis_universal/encoder/basisu_math.h
@@ -35,10 +35,7 @@ namespace bu_math
 	{
 	public:
 		typedef T scalar_type;
-		enum
-		{
-			num_elements = N
-		};
+		static constexpr int32_t num_elements = N;
 
 		inline vec()
 		{
@@ -1186,11 +1183,8 @@ namespace bu_math
 	{
 	public:
 		typedef T scalar_type;
-		enum
-		{
-			num_rows = R,
-			num_cols = C
-		};
+		static constexpr int32_t num_rows = R;
+		static constexpr int32_t num_cols = C;
 
 		typedef vec<R, T> col_vec;
 		typedef vec < (R > 1) ? (R - 1) : 0, T > subcol_vec;

--- a/thirdparty/basis_universal/patches/0007-enum-to-int32.patch
+++ b/thirdparty/basis_universal/patches/0007-enum-to-int32.patch
@@ -1,0 +1,30 @@
+diff --git a/thirdparty/basis_universal/encoder/basisu_math.h b/thirdparty/basis_universal/encoder/basisu_math.h
+index 3e56747bea..d4aa219a36 100644
+--- a/thirdparty/basis_universal/encoder/basisu_math.h
++++ b/thirdparty/basis_universal/encoder/basisu_math.h
+@@ -35,10 +35,7 @@ namespace bu_math
+ 	{
+ 	public:
+ 		typedef T scalar_type;
+-		enum
+-		{
+-			num_elements = N
+-		};
++		static constexpr int32_t num_elements = N;
+ 
+ 		inline vec()
+ 		{
+@@ -1186,11 +1183,8 @@ namespace bu_math
+ 	{
+ 	public:
+ 		typedef T scalar_type;
+-		enum
+-		{
+-			num_rows = R,
+-			num_cols = C
+-		};
++		static constexpr int32_t num_rows = R;
++		static constexpr int32_t num_cols = C;
+ 
+ 		typedef vec<R, T> col_vec;
+ 		typedef vec < (R > 1) ? (R - 1) : 0, T > subcol_vec;

--- a/thirdparty/misc/r128.h
+++ b/thirdparty/misc/r128.h
@@ -1,5 +1,5 @@
 /*
-r128.h: 128-bit (64.64) signed fixed-point arithmetic. Version 1.6.0
+r128.h: 128-bit (64.64) signed fixed-point arithmetic. Version 1.6.1
 
 COMPILATION
 -----------
@@ -302,8 +302,10 @@ struct numeric_limits<R128>
    static const bool has_infinity = false;
    static const bool has_quiet_NaN = false;
    static const bool has_signaling_NaN = false;
+#if !(__cplusplus > 202002L || (defined(_MSVC_LANG) && _MSVC_LANG > 202002L))
    static const float_denorm_style has_denorm = denorm_absent;
    static const bool has_denorm_loss = false;
+#endif
 
    static R128 infinity() throw() { return R128_zero; }
    static R128 quiet_NaN() throw() { return R128_zero; }
@@ -670,7 +672,7 @@ static R128_U64 r128__umul64(R128_U32 a, R128_U32 b)
 {
 #  if defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
    return __emulu(a, b);
-#  elif defined(_M_ARM) && !defined(R128_STDC_ONLY)
+#  elif defined(_M_ARM) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
    return _arm_umull(a, b);
 #  else
    return a * (R128_U64)b;
@@ -813,7 +815,7 @@ static const r128__udiv128Proc r128__udiv128 = (r128__udiv128Proc)(void*)r128__u
 #else
 static R128_U64 r128__udiv128(R128_U64 nlo, R128_U64 nhi, R128_U64 d, R128_U64 *rem)
 {
-#if defined(_M_X64) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
+#if defined(_M_X64) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__) && !defined(__clang__)
    return _udiv128(nhi, nlo, d, rem);
 #elif defined(__x86_64__) && !defined(R128_STDC_ONLY)
    R128_U64 q, r;


### PR DESCRIPTION
- Preceeds #100749
- Supersedes #117697

We're going full-circle by allowing users to specify a C/C++ standard at build-time! This will make prospective migrations to later C/C++ standards more streamlined by ensuring that we can test those kinds of changes in isolation. Unlike the first time[^1] I tried this idea, the amount of necessary changes has been reduced to a fraction of what it once was, which should make the propsect of adding these options much less daunting.

The primary change from the original implementation is dynamic validation. Because we already have logic in the repo that changes the standard to C++20 selectively, the original validators for C++17 aren't going to necessarily be accurate. This implementation instead changes the validation to the moment a specific standard is requested, which simplifies the `SConstruct` logic somewhat.

C++20 compilation confirmed here: https://github.com/Repiteo/godot/actions/runs/24047900318

[^1]: #89660