### PR TITLE
Make NavigationLink consider navigation layers when connecting regions

### DIFF
--- a/doc/classes/NavigationLink2D.xml
+++ b/doc/classes/NavigationLink2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A link between two positions on [NavigationRegion2D]s that agents can be routed through. These positions can be on the same [NavigationRegion2D] or on two different ones. Links are useful to express navigation methods other than traveling along the surface of the navigation polygon, such as ziplines, teleporters, or gaps that can be jumped across.
+		[b]Note:[/b] A link can only connect one region to one other region, or one region to itself. If your map contains multiple overlapping regions, make sure to set the navigation layers such that each link is a one-to-one relation between regions. For example, suppose you have a region on layer 1 for small agents and one on layer 2 for big agents. You can't make a single link on layers 1 and 2 for both agents to use, instead make one link for layer 1 and another link for layer 2.
 	</description>
 	<tutorials>
 		<link title="Using NavigationLinks">$DOCS_URL/tutorials/navigation/navigation_using_navigationlinks.html</link>

--- a/doc/classes/NavigationLink3D.xml
+++ b/doc/classes/NavigationLink3D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A link between two positions on [NavigationRegion3D]s that agents can be routed through. These positions can be on the same [NavigationRegion3D] or on two different ones. Links are useful to express navigation methods other than traveling along the surface of the navigation mesh, such as ziplines, teleporters, or gaps that can be jumped across.
+		[b]Note:[/b] A link can only connect one region to one other region, or one region to itself. If your map contains multiple overlapping regions, make sure to set the navigation layers such that each link is a one-to-one relation between regions. For example, suppose you have a region on layer 1 for small agents and one on layer 2 for big agents. You can't make a single link on layers 1 and 2 for both agents to use, instead make one link for layer 1 and another link for layer 2.
 	</description>
 	<tutorials>
 		<link title="Using NavigationLinks">$DOCS_URL/tutorials/navigation/navigation_using_navigationlinks.html</link>

--- a/modules/navigation_2d/2d/nav_map_builder_2d.cpp
+++ b/modules/navigation_2d/2d/nav_map_builder_2d.cpp
@@ -305,7 +305,8 @@ void NavMapBuilder2D::_build_step_navlink_connections(NavMapIterationBuild2D &r_
 
 		for (const Ref<NavRegionIteration2D> &region : map_iteration->region_iterations) {
 			Rect2 region_bounds = region->get_bounds().grow(link_connection_radius);
-			if (!region_bounds.has_point(link_start_pos) && !region_bounds.has_point(link_end_pos)) {
+			if ((!region_bounds.has_point(link_start_pos) && !region_bounds.has_point(link_end_pos)) ||
+					((region->navigation_layers & link->navigation_layers) == 0)) {
 				continue;
 			}
 

--- a/modules/navigation_3d/3d/nav_map_builder_3d.cpp
+++ b/modules/navigation_3d/3d/nav_map_builder_3d.cpp
@@ -306,7 +306,8 @@ void NavMapBuilder3D::_build_step_navlink_connections(NavMapIterationBuild3D &r_
 
 		for (const Ref<NavRegionIteration3D> &region : map_iteration->region_iterations) {
 			AABB region_bounds = region->get_bounds().grow(link_connection_radius);
-			if (!region_bounds.has_point(link_start_pos) && !region_bounds.has_point(link_end_pos)) {
+			if ((!region_bounds.has_point(link_start_pos) && !region_bounds.has_point(link_end_pos)) ||
+					((region->navigation_layers & link->navigation_layers) == 0)) {
 				continue;
 			}
 

--- a/tests/servers/test_navigation_server_2d.cpp
+++ b/tests/servers/test_navigation_server_2d.cpp
@@ -747,6 +747,113 @@ TEST_SUITE("[Navigation2D]") {
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 
+	// This test case does not check precise values on purpose - to not be too sensitive.
+	TEST_CASE("[NavigationServer2D] Links should function properly when multiple overlapping regions are present") {
+		NavigationServer2D *navigation_server = NavigationServer2D::get_singleton();
+		Ref<NavigationPolygon> navigation_polygon;
+		navigation_polygon.instantiate();
+		Ref<NavigationMeshSourceGeometryData2D> source_geometry;
+		source_geometry.instantiate();
+
+		navigation_polygon->add_outline(PackedVector2Array({ Vector2(-1250.0, -250.0), Vector2(-750.0, -250.0), Vector2(-750.0, 250.0), Vector2(-1250.0, 250.0) }));
+		navigation_polygon->add_outline(PackedVector2Array({ Vector2(-250.0, -250.0), Vector2(250.0, -250.0), Vector2(250.0, 250.0), Vector2(-250.0, 250.0) }));
+		navigation_polygon->add_outline(PackedVector2Array({ Vector2(750.0, -250.0), Vector2(1250.0, -250.0), Vector2(1250.0, 250.0), Vector2(750.0, 250.0) }));
+		navigation_server->bake_from_source_geometry_data(navigation_polygon, source_geometry, Callable());
+
+		RID map = navigation_server->map_create();
+		navigation_server->map_set_use_edge_connections(map, false);
+		RID region1 = navigation_server->region_create();
+		RID region2 = navigation_server->region_create();
+		navigation_server->map_set_active(map, true);
+		navigation_server->map_set_use_async_iterations(map, false);
+		navigation_server->region_set_use_async_iterations(region1, false);
+		navigation_server->region_set_use_async_iterations(region2, false);
+		navigation_server->region_set_navigation_layers(region1, 1);
+		navigation_server->region_set_navigation_layers(region2, 2);
+		navigation_server->region_set_map(region1, map);
+		navigation_server->region_set_map(region2, map);
+		navigation_server->region_set_navigation_polygon(region1, navigation_polygon);
+		navigation_server->region_set_navigation_polygon(region2, navigation_polygon);
+
+		RID link1 = navigation_server->link_create();
+		navigation_server->link_set_navigation_layers(link1, 2);
+		navigation_server->link_set_bidirectional(link1, true);
+		navigation_server->link_set_start_position(link1, Vector2(-800, 0));
+		navigation_server->link_set_end_position(link1, Vector2(-200, 0));
+		navigation_server->link_set_map(link1, map);
+		RID link2 = navigation_server->link_create();
+		navigation_server->link_set_navigation_layers(link2, 2);
+		navigation_server->link_set_bidirectional(link2, false);
+		navigation_server->link_set_start_position(link2, Vector2(200, 0));
+		navigation_server->link_set_end_position(link2, Vector2(800, 0));
+		navigation_server->link_set_map(link2, map);
+
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
+
+		SUBCASE("Should not find path from left platform to right platform as there are no links on first layer") {
+			Ref<NavigationPathQueryParameters2D> query_parameters;
+			query_parameters.instantiate();
+			query_parameters->set_map(map);
+			query_parameters->set_path_postprocessing(NavigationPathQueryParameters2D::PATH_POSTPROCESSING_CORRIDORFUNNEL);
+			query_parameters->set_navigation_layers(1);
+			query_parameters->set_start_position(Vector2(-1000, 0));
+			query_parameters->set_target_position(Vector2(1000, 0));
+			Ref<NavigationPathQueryResult2D> query_result;
+			query_result.instantiate();
+			navigation_server->query_path(query_parameters, query_result);
+			uint32_t path_size = query_result->get_path().size();
+			CHECK_GT(path_size, 0);
+			if (path_size > 0) {
+				CHECK_LT(query_result->get_path()[path_size - 1].x, -500);
+			}
+		}
+
+		SUBCASE("Should find path from left platform to right platform on second layer") {
+			Ref<NavigationPathQueryParameters2D> query_parameters;
+			query_parameters.instantiate();
+			query_parameters->set_map(map);
+			query_parameters->set_path_postprocessing(NavigationPathQueryParameters2D::PATH_POSTPROCESSING_CORRIDORFUNNEL);
+			query_parameters->set_navigation_layers(2);
+			query_parameters->set_start_position(Vector2(-1000, 0));
+			query_parameters->set_target_position(Vector2(1000, 0));
+			Ref<NavigationPathQueryResult2D> query_result;
+			query_result.instantiate();
+			navigation_server->query_path(query_parameters, query_result);
+			uint32_t path_size = query_result->get_path().size();
+			CHECK_GT(path_size, 0);
+			if (path_size > 0) {
+				CHECK_GT(query_result->get_path()[path_size - 1].x, 500);
+			}
+		}
+
+		SUBCASE("Should not find path from right platform to left platform because of unidirectional link") {
+			Ref<NavigationPathQueryParameters2D> query_parameters;
+			query_parameters.instantiate();
+			query_parameters->set_map(map);
+			query_parameters->set_path_postprocessing(NavigationPathQueryParameters2D::PATH_POSTPROCESSING_CORRIDORFUNNEL);
+			for (uint32_t layer = 1; layer <= 2; layer *= 2) {
+				query_parameters->set_navigation_layers(layer);
+				query_parameters->set_start_position(Vector2(1000, 0));
+				query_parameters->set_target_position(Vector2(-1000, 0));
+				Ref<NavigationPathQueryResult2D> query_result;
+				query_result.instantiate();
+				navigation_server->query_path(query_parameters, query_result);
+				uint32_t path_size = query_result->get_path().size();
+				CHECK_GT(path_size, 0);
+				if (path_size > 0) {
+					CHECK_GT(query_result->get_path()[path_size - 1].x, 500);
+				}
+			}
+		}
+
+		navigation_server->free_rid(region1);
+		navigation_server->free_rid(region2);
+		navigation_server->free_rid(link1);
+		navigation_server->free_rid(link2);
+		navigation_server->free_rid(map);
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
+	}
+
 	TEST_CASE("[NavigationServer2D] Server should simplify path properly") {
 		real_t simplify_epsilon = 0.2;
 		Vector<Vector2> source_path;

--- a/tests/servers/test_navigation_server_3d.cpp
+++ b/tests/servers/test_navigation_server_3d.cpp
@@ -813,6 +813,108 @@ TEST_SUITE("[Navigation3D]") {
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 
+	// This test case does not check precise values on purpose - to not be too sensitive.
+	TEST_CASE("[NavigationServer3D] Links should function properly when multiple overlapping regions are present") {
+		NavigationServer3D *navigation_server = NavigationServer3D::get_singleton();
+		Ref<NavigationMesh> navigation_mesh = memnew(NavigationMesh);
+		Ref<NavigationMeshSourceGeometryData3D> source_geometry = memnew(NavigationMeshSourceGeometryData3D);
+
+		Array arr;
+		arr.resize(RSE::ARRAY_MAX);
+		BoxMesh::create_mesh_array(arr, Vector3(5.0, 0.1, 5.0));
+		source_geometry->add_mesh_array(arr, Transform3D(Basis(), Vector3(-10, 0, 0)));
+		source_geometry->add_mesh_array(arr, Transform3D());
+		source_geometry->add_mesh_array(arr, Transform3D(Basis(), Vector3(10, 0, 0)));
+		navigation_server->bake_from_source_geometry_data(navigation_mesh, source_geometry, Callable());
+
+		RID map = navigation_server->map_create();
+		navigation_server->map_set_use_edge_connections(map, false);
+		RID region1 = navigation_server->region_create();
+		RID region2 = navigation_server->region_create();
+		navigation_server->map_set_active(map, true);
+		navigation_server->map_set_use_async_iterations(map, false);
+		navigation_server->region_set_use_async_iterations(region1, false);
+		navigation_server->region_set_use_async_iterations(region2, false);
+		navigation_server->region_set_navigation_layers(region1, 1);
+		navigation_server->region_set_navigation_layers(region2, 2);
+		navigation_server->region_set_map(region1, map);
+		navigation_server->region_set_map(region2, map);
+		navigation_server->region_set_navigation_mesh(region1, navigation_mesh);
+		navigation_server->region_set_navigation_mesh(region2, navigation_mesh);
+
+		RID link1 = navigation_server->link_create();
+		navigation_server->link_set_navigation_layers(link1, 2);
+		navigation_server->link_set_bidirectional(link1, true);
+		navigation_server->link_set_start_position(link1, Vector3(-8, 0, 0));
+		navigation_server->link_set_end_position(link1, Vector3(-2, 0, 0));
+		navigation_server->link_set_map(link1, map);
+		RID link2 = navigation_server->link_create();
+		navigation_server->link_set_navigation_layers(link2, 2);
+		navigation_server->link_set_bidirectional(link2, false);
+		navigation_server->link_set_start_position(link2, Vector3(2, 0, 0));
+		navigation_server->link_set_end_position(link2, Vector3(8, 0, 0));
+		navigation_server->link_set_map(link2, map);
+
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
+
+		SUBCASE("Should not find path from left platform to right platform as there are no links on first layer") {
+			Ref<NavigationPathQueryParameters3D> query_parameters = memnew(NavigationPathQueryParameters3D);
+			query_parameters->set_map(map);
+			query_parameters->set_path_postprocessing(NavigationPathQueryParameters3D::PATH_POSTPROCESSING_CORRIDORFUNNEL);
+			query_parameters->set_navigation_layers(1);
+			query_parameters->set_start_position(Vector3(-10, 0, 0));
+			query_parameters->set_target_position(Vector3(10, 0, 0));
+			Ref<NavigationPathQueryResult3D> query_result = memnew(NavigationPathQueryResult3D);
+			navigation_server->query_path(query_parameters, query_result);
+			uint32_t path_size = query_result->get_path().size();
+			CHECK_GT(path_size, 0);
+			if (path_size > 0) {
+				CHECK_LT(query_result->get_path()[path_size - 1].x, -5);
+			}
+		}
+
+		SUBCASE("Should find path from left platform to right platform on second layer") {
+			Ref<NavigationPathQueryParameters3D> query_parameters = memnew(NavigationPathQueryParameters3D);
+			query_parameters->set_map(map);
+			query_parameters->set_path_postprocessing(NavigationPathQueryParameters3D::PATH_POSTPROCESSING_CORRIDORFUNNEL);
+			query_parameters->set_navigation_layers(2);
+			query_parameters->set_start_position(Vector3(-10, 0, 0));
+			query_parameters->set_target_position(Vector3(10, 0, 0));
+			Ref<NavigationPathQueryResult3D> query_result = memnew(NavigationPathQueryResult3D);
+			navigation_server->query_path(query_parameters, query_result);
+			uint32_t path_size = query_result->get_path().size();
+			CHECK_GT(path_size, 0);
+			if (path_size > 0) {
+				CHECK_GT(query_result->get_path()[path_size - 1].x, 5);
+			}
+		}
+
+		SUBCASE("Should not find path from right platform to left platform because of unidirectional link") {
+			Ref<NavigationPathQueryParameters3D> query_parameters = memnew(NavigationPathQueryParameters3D);
+			query_parameters->set_map(map);
+			query_parameters->set_path_postprocessing(NavigationPathQueryParameters3D::PATH_POSTPROCESSING_CORRIDORFUNNEL);
+			for (uint32_t layer = 1; layer <= 2; layer *= 2) {
+				query_parameters->set_navigation_layers(layer);
+				query_parameters->set_start_position(Vector3(10, 0, 0));
+				query_parameters->set_target_position(Vector3(-10, 0, 0));
+				Ref<NavigationPathQueryResult3D> query_result = memnew(NavigationPathQueryResult3D);
+				navigation_server->query_path(query_parameters, query_result);
+				uint32_t path_size = query_result->get_path().size();
+				CHECK_GT(path_size, 0);
+				if (path_size > 0) {
+					CHECK_GT(query_result->get_path()[path_size - 1].x, 5);
+				}
+			}
+		}
+
+		navigation_server->free_rid(region1);
+		navigation_server->free_rid(region2);
+		navigation_server->free_rid(link1);
+		navigation_server->free_rid(link2);
+		navigation_server->free_rid(map);
+		navigation_server->physics_process(0.0); // Give server some cycles to commit.
+	}
+
 	// FIXME: The race condition mentioned below is actually a problem and fails on CI (GH-90613).
 	/*
 	TEST_CASE("[NavigationServer3D] Server should be able to bake asynchronously") {


### PR DESCRIPTION
Fixes #117138

The navigation link connection function previously did not consider the navigation layers when deciding which regions to connect. Because only one connection is made per link, this could result in links not working in scenarios with multiple overlapping regions.

This commit skips regions that don't match the link's navigation layers. Because there is still only one connection made per link, it is the user's responsibility to make sure all links represent one-to-one relationships between regions. A note to that effect has been added to the navigation link class documentation.

The test cases test a scenario with 2 regions on different layers and nav links with layer 2 set. Pathfinding across floating platforms should fail on layer 1 and succeed on layer 2.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
