### PR TITLE
Fix inconsistent hinting of monospace fonts

### DIFF
--- a/editor/themes/editor_fonts.cpp
+++ b/editor/themes/editor_fonts.cpp
@@ -147,7 +147,7 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 			break;
 		default:
 			font_hinting = TextServer::HINTING_NORMAL;
-			font_mono_hinting = TextServer::HINTING_LIGHT;
+			font_mono_hinting = TextServer::HINTING_NORMAL;
 			break;
 	}
 


### PR DESCRIPTION
When using full hinting (normal) monospace font is using light hinting.

This fixes the inconsistency.