### PR TITLE
Fix `BoneAttachment3D` throws `!is_inside_tree()`

### DIFF
--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -170,6 +170,9 @@ void BoneAttachment3D::_transform_changed() {
 
 		Transform3D our_trans = get_transform();
 		if (use_external_skeleton) {
+			if (!sk->is_inside_tree()) {
+				return;
+			}
 			our_trans = sk->get_global_transform().affine_inverse() * get_global_transform();
 		}
 


### PR DESCRIPTION
Fix #118218.

Because `BoneAttachment3D` enters the tree first, with `override_pose` enabled, ` sk->get_global_transform().affine_inverse() * get_global_transform();` runs during that enter tree step before the skeleton has even entered the tree. Hence why it throws `!is_inside_tree()`.

This PR makes it wait until the skeleton is actually inside the tree.

