### PR TITLE
Fix non-positive frame numbers misaligned in FPS mode

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -1653,8 +1653,8 @@ void AnimationTimelineEdit::_notification(int p_what) {
 						float pos = get_value() + double(i) / scale;
 						float prev = get_value() + (double(i) - 1.0) / scale;
 
-						int frame = pos / step_size;
-						int prev_frame = prev / step_size;
+						int frame = int(Math::floor(pos / step_size));
+						int prev_frame = int(Math::floor(prev / step_size));
 
 						bool sub = Math::floor(prev) == Math::floor(pos);
 


### PR DESCRIPTION
## Summary                                                                                                                                                               
  - Use `Math::floor()` instead of integer truncation when converting time positions to frame indices in FPS mode                                                          
  - Matches the existing non-FPS code path which already uses `Math::floor()` correctly                                                                                    
  - Integer truncation rounds toward zero for negative values, causing frame labels to be placed at wrong positions                                                  
 
Fixes #118267
                                                                                                                                                                                                                                                                                                                                       
  ## Test plan   
  - Open an animation with FPS snap enabled (e.g., 30 FPS)
  - Scroll the timeline into negative time                                                                                                                                 
  - Verify frame numbers are consistent (..., -3, -2, -1, 0, 1, 2, 3, ...)                                                                                                 
  - Verify grid lines are evenly spaced across the zero boundary                                                                                                           
  - Verify positive frame numbers and non-FPS timeline are unaffected