### PR TITLE
Web: Reuse AudioBuffer for sample playback

### DIFF
--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -124,7 +124,12 @@ class Sample {
 	 * @returns {AudioBuffer}
 	 */
 	getAudioBuffer() {
-		return this._duplicateAudioBuffer();
+		if (this._audioBuffer == null) {
+			throw new Error('couldn\'t get a null audioBuffer');
+		}
+		// AudioBuffer can be shared by multiple AudioBufferSourceNode instances.
+		// Duplicating it on every playback causes large browser-side allocations.
+		return this._audioBuffer;
 	}
 
 	/**
@@ -143,31 +148,6 @@ class Sample {
 	clear() {
 		this.setAudioBuffer(null);
 		GodotAudio.Sample.delete(this.id);
-	}
-
-	/**
-	 * Returns a duplicate of the stored audio buffer.
-	 * @returns {AudioBuffer}
-	 */
-	_duplicateAudioBuffer() {
-		if (this._audioBuffer == null) {
-			throw new Error('couldn\'t duplicate a null audioBuffer');
-		}
-		/** @type {Array<Float32Array>} */
-		const channels = new Array(this._audioBuffer.numberOfChannels);
-		for (let i = 0; i < this._audioBuffer.numberOfChannels; i++) {
-			const channel = new Float32Array(this._audioBuffer.getChannelData(i));
-			channels[i] = channel;
-		}
-		const buffer = GodotAudio.ctx.createBuffer(
-			this.numberOfChannels,
-			this._audioBuffer.length,
-			this._audioBuffer.sampleRate
-		);
-		for (let i = 0; i < channels.length; i++) {
-			buffer.copyToChannel(channels[i], i, 0);
-		}
-		return buffer;
 	}
 }
 


### PR DESCRIPTION
 - AudioBuffer can be shared by multiple AudioBufferSourceNode instances.
 - Duplicating it on every playback causes large browser-side allocations.
