### PR TITLE
Add a separate `blend_rect()` method to DrawableTexture2D

### DIFF
--- a/doc/classes/DrawableTexture2D.xml
+++ b/doc/classes/DrawableTexture2D.xml
@@ -9,6 +9,16 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="blend_rect">
+			<return type="void" />
+			<param index="0" name="rect" type="Rect2i" />
+			<param index="1" name="source" type="Texture2D" />
+			<param index="2" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="3" name="mipmap" type="int" default="0" />
+			<description>
+				Draws to given [param rect] on this texture by copying from the given [param source]. A [param modulate] color can be passed in for the shader to use, but defaults to White. The [param mipmap] value can specify a draw to a lower mipmap level. The texture is drawn using mix blending, i.e. respecting the pixel transparency. If you want to replace pixels or use a custom material, use [method blit_rect] instead.
+			</description>
+		</method>
 		<method name="blit_rect" experimental="This function and its parameters are likely to change in the 4.7 Dev Cycle">
 			<return type="void" />
 			<param index="0" name="rect" type="Rect2i" />

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3929,10 +3929,14 @@
 				Calculates new MipMaps for the given Drawable [param texture].
 			</description>
 		</method>
-		<method name="texture_drawable_get_default_material" qualifiers="const">
+		<method name="texture_drawable_get_default_blend_material" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns a ShaderMaterial with the default texture_blit Shader.
+			</description>
+		</method>
+		<method name="texture_drawable_get_default_blit_material" qualifiers="const">
+			<return type="RID" />
+			<description>
 			</description>
 		</method>
 		<method name="texture_get_format" qualifiers="const">

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -316,14 +316,12 @@ void TextureStorage::_tex_blit_shader_initialize() {
 	}
 
 	{
-		// default material and shader for Texture Blit shader
-		tex_blit_shader.default_shader = material_storage->shader_allocate();
-		material_storage->shader_initialize(tex_blit_shader.default_shader);
-		material_storage->shader_set_code(tex_blit_shader.default_shader, R"(
+		// Default materials and shaders for Texture Blit shader
+		const String shader_code = R"(
 // Default Texture Blit shader.
 
 shader_type texture_blit;
-render_mode blend_mix;
+render_mode %s;
 
 uniform sampler2D source_texture0 : hint_blit_source0;
 uniform sampler2D source_texture1 : hint_blit_source1;
@@ -337,10 +335,21 @@ void blit() {
 	COLOR2 = texture(source_texture2, UV) * MODULATE;
 	COLOR3 = texture(source_texture3, UV) * MODULATE;
 }
-)");
-		tex_blit_shader.default_material = material_storage->material_allocate();
-		material_storage->material_initialize(tex_blit_shader.default_material);
-		material_storage->material_set_shader(tex_blit_shader.default_material, tex_blit_shader.default_shader);
+)";
+
+		tex_blit_shader.default_blit_shader = material_storage->shader_allocate();
+		material_storage->shader_initialize(tex_blit_shader.default_blit_shader);
+		material_storage->shader_set_code(tex_blit_shader.default_blit_shader, vformat(shader_code, "blend_disabled"));
+		tex_blit_shader.default_blit_material = material_storage->material_allocate();
+		material_storage->material_initialize(tex_blit_shader.default_blit_material);
+		material_storage->material_set_shader(tex_blit_shader.default_blit_material, tex_blit_shader.default_blit_shader);
+
+		tex_blit_shader.default_blend_shader = material_storage->shader_allocate();
+		material_storage->shader_initialize(tex_blit_shader.default_blend_shader);
+		material_storage->shader_set_code(tex_blit_shader.default_blend_shader, vformat(shader_code, "blend_mix"));
+		tex_blit_shader.default_blend_material = material_storage->material_allocate();
+		material_storage->material_initialize(tex_blit_shader.default_blend_material);
+		material_storage->material_set_shader(tex_blit_shader.default_blend_material, tex_blit_shader.default_blend_shader);
 	}
 
 	{
@@ -388,8 +397,10 @@ void TextureStorage::_tex_blit_shader_free() {
 		glDeleteFramebuffers(1, &tex_blit_fbo);
 		glDeleteBuffers(1, &tex_blit_quad);
 		glDeleteVertexArrays(1, &tex_blit_quad_array);
-		material_storage->material_free(tex_blit_shader.default_material);
-		material_storage->shader_free(tex_blit_shader.default_shader);
+		material_storage->material_free(tex_blit_shader.default_blit_material);
+		material_storage->shader_free(tex_blit_shader.default_blit_shader);
+		material_storage->material_free(tex_blit_shader.default_blend_material);
+		material_storage->shader_free(tex_blit_shader.default_blend_shader);
 	}
 }
 
@@ -1374,7 +1385,7 @@ void TextureStorage::texture_drawable_blit_rect(const TypedArray<RID> &p_texture
 
 	TexBlitMaterialData *m = static_cast<TexBlitMaterialData *>(material_storage->material_get_data(p_material, RSE::SHADER_TEXTURE_BLIT));
 	if (!m) {
-		m = static_cast<TexBlitMaterialData *>(material_storage->material_get_data(tex_blit_shader.default_material, RSE::SHADER_TEXTURE_BLIT));
+		m = static_cast<TexBlitMaterialData *>(material_storage->material_get_data(tex_blit_shader.default_blit_material, RSE::SHADER_TEXTURE_BLIT));
 	}
 	// GUARDRAIL: p_material MUST BE ShaderType TextureBlit
 	ERR_FAIL_NULL(m);
@@ -1807,9 +1818,14 @@ void TextureStorage::texture_drawable_generate_mipmaps(RID p_texture) {
 	CopyEffects::get_singleton()->bilinear_blur(texture->tex_id, texture->mipmaps, Rect2i(0, 0, size.x, size.y));
 }
 
-RID TextureStorage::texture_drawable_get_default_material() const {
+RID TextureStorage::texture_drawable_get_default_blit_material() const {
 	// This should never be called before DrawableTexture stuff is initialized.
-	return tex_blit_shader.default_material;
+	return tex_blit_shader.default_blit_material;
+}
+
+RID TextureStorage::texture_drawable_get_default_blend_material() const {
+	// This should never be called before DrawableTexture stuff is initialized.
+	return tex_blit_shader.default_blend_material;
 }
 
 void TextureStorage::texture_replace(RID p_texture, RID p_by_texture) {

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -492,8 +492,10 @@ private:
 
 	struct TexBlitShader {
 		bool initialized = false;
-		RID default_shader;
-		RID default_material;
+		RID default_blit_shader;
+		RID default_blit_material;
+		RID default_blend_shader;
+		RID default_blend_material;
 		RID default_shader_version;
 	} tex_blit_shader;
 
@@ -579,7 +581,8 @@ public:
 	virtual Vector<Ref<Image>> texture_3d_get(RID p_texture) const override;
 
 	virtual void texture_drawable_generate_mipmaps(RID p_texture) override;
-	virtual RID texture_drawable_get_default_material() const override;
+	virtual RID texture_drawable_get_default_blit_material() const override;
+	virtual RID texture_drawable_get_default_blend_material() const override;
 
 	virtual void texture_replace(RID p_texture, RID p_by_texture) override;
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) override;

--- a/scene/resources/drawable_texture_2d.cpp
+++ b/scene/resources/drawable_texture_2d.cpp
@@ -36,7 +36,8 @@
 #include "servers/rendering/rendering_server.h"
 
 DrawableTexture2D::DrawableTexture2D() {
-	default_material = RS::get_singleton()->texture_drawable_get_default_material();
+	default_blit_material = RS::get_singleton()->texture_drawable_get_default_blit_material();
+	default_blend_material = RS::get_singleton()->texture_drawable_get_default_blend_material();
 }
 
 DrawableTexture2D::~DrawableTexture2D() {
@@ -44,6 +45,25 @@ DrawableTexture2D::~DrawableTexture2D() {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RenderingServer::get_singleton()->free_rid(texture);
 	}
+}
+
+void DrawableTexture2D::_blit_rect(const Rect2i p_rect, const Ref<Texture2D> &p_source, const Color &p_modulate, int p_mipmap, RID p_material) {
+	// Rendering server expects textureParameters as a TypedArray[RID]
+	Array textures;
+	textures.push_back(texture);
+
+	if (p_source.is_valid()) {
+		ERR_FAIL_COND_MSG(texture == p_source->get_rid(), "Cannot use self as a source.");
+	}
+	Array src_textures;
+	if (Ref<AtlasTexture>(p_source).is_valid()) {
+		WARN_PRINT("AtlasTexture not supported as a source for blit_rect. Using default White.");
+		src_textures.push_back(RID());
+	} else {
+		src_textures.push_back(p_source);
+	}
+
+	RS::get_singleton()->texture_drawable_blit_rect(textures, p_rect, p_material, p_modulate, src_textures, p_mipmap);
 }
 
 // Initialize Texture Resource with a call to rendering server. Overwrite existing.
@@ -172,36 +192,24 @@ void DrawableTexture2D::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect,
 // Perform a blit operation from the given source to the given rect on self.
 void DrawableTexture2D::blit_rect(const Rect2i p_rect, const Ref<Texture2D> &p_source, const Color &p_modulate, int p_mipmap, const Ref<Material> &p_material) {
 	// Use user Shader if exists.
-	RID material = default_material;
+	RID material = default_blit_material;
 	if (p_material.is_valid()) {
-		material = p_material->get_rid();
-		if (p_material->get_shader_mode() != Shader::MODE_TEXTURE_BLIT) {
+		if (p_material->get_shader_mode() == Shader::MODE_TEXTURE_BLIT) {
+			material = p_material->get_rid();
+		} else {
 			WARN_PRINT("ShaderMaterial passed to blit_rect() is not a texture_blit shader. Using default instead.");
 		}
 	}
+	_blit_rect(p_rect, p_source, p_modulate, p_mipmap, material);
+}
 
-	// Rendering server expects textureParameters as a TypedArray[RID]
-	Array textures;
-	textures.push_back(texture);
-
-	if (p_source.is_valid()) {
-		ERR_FAIL_COND_MSG(texture == p_source->get_rid(), "Cannot use self as a source.");
-	}
-	Array src_textures;
-	if (Ref<AtlasTexture>(p_source).is_valid()) {
-		WARN_PRINT("AtlasTexture not supported as a source for blit_rect. Using default White.");
-		src_textures.push_back(RID());
-	} else {
-		src_textures.push_back(p_source);
-	}
-
-	RS::get_singleton()->texture_drawable_blit_rect(textures, p_rect, material, p_modulate, src_textures, p_mipmap);
-	notify_property_list_changed();
+void DrawableTexture2D::blend_rect(const Rect2i p_rect, const Ref<Texture2D> &p_source, const Color &p_modulate, int p_mipmap) {
+	_blit_rect(p_rect, p_source, p_modulate, p_mipmap, default_blend_material);
 }
 
 // Perform a blit operation from the given sources to the given rect on self and extra targets
 void DrawableTexture2D::blit_rect_multi(const Rect2i p_rect, const TypedArray<Texture2D> &p_sources, const TypedArray<DrawableTexture2D> &p_extra_targets, const Color &p_modulate, int p_mipmap, const Ref<Material> &p_material) {
-	RID material = default_material;
+	RID material = default_blit_material;
 	if (p_material.is_valid()) {
 		material = p_material->get_rid();
 		if (p_material->get_shader_mode() != Shader::MODE_TEXTURE_BLIT) {
@@ -257,6 +265,7 @@ void DrawableTexture2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("setup", "width", "height", "format", "color", "use_mipmaps"), &DrawableTexture2D::setup, DEFVAL(Color(1, 1, 1, 1)), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("blit_rect", "rect", "source", "modulate", "mipmap", "material"), &DrawableTexture2D::blit_rect, DEFVAL(Color(1, 1, 1, 1)), DEFVAL(0), DEFVAL(Ref<Material>()));
+	ClassDB::bind_method(D_METHOD("blend_rect", "rect", "source", "modulate", "mipmap"), &DrawableTexture2D::blend_rect, DEFVAL(Color(1, 1, 1, 1)), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("blit_rect_multi", "rect", "sources", "extra_targets", "modulate", "mipmap", "material"), &DrawableTexture2D::blit_rect_multi, DEFVAL(Color(1, 1, 1, 1)), DEFVAL(0), DEFVAL(Ref<Material>()));
 	ClassDB::bind_method(D_METHOD("generate_mipmaps"), &DrawableTexture2D::generate_mipmaps);
 

--- a/scene/resources/drawable_texture_2d.h
+++ b/scene/resources/drawable_texture_2d.h
@@ -55,7 +55,10 @@ private:
 
 	Color base_color = Color(1, 1, 1, 1);
 
-	RID default_material;
+	RID default_blit_material;
+	RID default_blend_material;
+
+	void _blit_rect(const Rect2i p_rect, const Ref<Texture2D> &p_source, const Color &p_modulate, int p_mipmap, RID p_material);
 
 	void _initialize();
 
@@ -83,6 +86,7 @@ public:
 	void setup(int p_width, int p_height, DrawableFormat p_format, const Color &p_modulate = Color(1, 1, 1, 1), bool p_use_mipmaps = false);
 
 	void blit_rect(const Rect2i p_rect, const Ref<Texture2D> &p_source, const Color &p_modulate = Color(1, 1, 1, 1), int p_mipmap = 0, const Ref<Material> &p_material = Ref<Material>());
+	void blend_rect(const Rect2i p_rect, const Ref<Texture2D> &p_source, const Color &p_modulate = Color(1, 1, 1, 1), int p_mipmap = 0);
 	void blit_rect_multi(const Rect2i p_rect, const TypedArray<Texture2D> &p_sources, const TypedArray<DrawableTexture2D> &p_extra_targets, const Color &p_modulate = Color(1, 1, 1, 1), int p_mipmap = 0, const Ref<Material> &p_material = Ref<Material>());
 
 	virtual Ref<Image> get_image() const override;

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -114,7 +114,8 @@ public:
 	virtual Vector<Ref<Image>> texture_3d_get(RID p_texture) const override { return Vector<Ref<Image>>(); }
 
 	virtual void texture_drawable_generate_mipmaps(RID p_texture) override {}
-	virtual RID texture_drawable_get_default_material() const override { return RID(); }
+	virtual RID texture_drawable_get_default_blit_material() const override { return RID(); }
+	virtual RID texture_drawable_get_default_blend_material() const override { return RID(); }
 
 	virtual void texture_replace(RID p_texture, RID p_by_texture) override { texture_free(p_by_texture); }
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) override {}

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -681,14 +681,12 @@ void TextureStorage::_tex_blit_shader_initialize() {
 	}
 
 	{
-		// default material and shader for Texture Blit shader
-		tex_blit_shader.default_shader = material_storage->shader_allocate();
-		material_storage->shader_initialize(tex_blit_shader.default_shader);
-		material_storage->shader_set_code(tex_blit_shader.default_shader, R"(
+		// Default materials and shaders for Texture Blit shader.
+		const String shader_code = R"(
 // Default Texture Blit shader.
 
 shader_type texture_blit;
-render_mode blend_mix;
+render_mode %s;
 
 uniform sampler2D source_texture0 : hint_blit_source0;
 uniform sampler2D source_texture1 : hint_blit_source1;
@@ -702,10 +700,21 @@ void blit() {
 	COLOR2 = texture(source_texture2, UV) * MODULATE;
 	COLOR3 = texture(source_texture3, UV) * MODULATE;
 }
-)");
-		tex_blit_shader.default_material = material_storage->material_allocate();
-		material_storage->material_initialize(tex_blit_shader.default_material);
-		material_storage->material_set_shader(tex_blit_shader.default_material, tex_blit_shader.default_shader);
+)";
+
+		tex_blit_shader.default_blit_shader = material_storage->shader_allocate();
+		material_storage->shader_initialize(tex_blit_shader.default_blit_shader);
+		material_storage->shader_set_code(tex_blit_shader.default_blit_shader, vformat(shader_code, "blend_disabled"));
+		tex_blit_shader.default_blit_material = material_storage->material_allocate();
+		material_storage->material_initialize(tex_blit_shader.default_blit_material);
+		material_storage->material_set_shader(tex_blit_shader.default_blit_material, tex_blit_shader.default_blit_shader);
+
+		tex_blit_shader.default_blend_shader = material_storage->shader_allocate();
+		material_storage->shader_initialize(tex_blit_shader.default_blend_shader);
+		material_storage->shader_set_code(tex_blit_shader.default_blend_shader, vformat(shader_code, "blend_mix"));
+		tex_blit_shader.default_blend_material = material_storage->material_allocate();
+		material_storage->material_initialize(tex_blit_shader.default_blend_material);
+		material_storage->material_set_shader(tex_blit_shader.default_blend_material, tex_blit_shader.default_blend_shader);
 	}
 
 	tex_blit_shader.initialized = true;
@@ -717,8 +726,10 @@ void TextureStorage::_tex_blit_shader_free() {
 		MaterialStorage *material_storage = MaterialStorage::get_singleton();
 
 		print_verbose("Freeing Default Tex_Blit Shader");
-		material_storage->material_free(tex_blit_shader.default_material);
-		material_storage->shader_free(tex_blit_shader.default_shader);
+		material_storage->material_free(tex_blit_shader.default_blit_material);
+		material_storage->shader_free(tex_blit_shader.default_blit_shader);
+		material_storage->material_free(tex_blit_shader.default_blend_material);
+		material_storage->shader_free(tex_blit_shader.default_blend_shader);
 	}
 }
 
@@ -1672,7 +1683,7 @@ void TextureStorage::texture_drawable_blit_rect(const TypedArray<RID> &p_texture
 
 	RendererRD::MaterialStorage::TexBlitMaterialData *m = static_cast<RendererRD::MaterialStorage::TexBlitMaterialData *>(material_storage->material_get_data(p_material, RendererRD::MaterialStorage::SHADER_TYPE_TEXTURE_BLIT));
 	if (!m) {
-		m = static_cast<RendererRD::MaterialStorage::TexBlitMaterialData *>(material_storage->material_get_data(tex_blit_shader.default_material, RendererRD::MaterialStorage::SHADER_TYPE_TEXTURE_BLIT));
+		m = static_cast<RendererRD::MaterialStorage::TexBlitMaterialData *>(material_storage->material_get_data(tex_blit_shader.default_blit_material, RendererRD::MaterialStorage::SHADER_TYPE_TEXTURE_BLIT));
 	}
 	// GUARDRAIL:: p_material MUST BE ShaderType TextureBlit
 	ERR_FAIL_NULL(m);
@@ -1954,9 +1965,13 @@ void TextureStorage::texture_drawable_generate_mipmaps(RID p_texture) {
 	}
 }
 
-RID TextureStorage::texture_drawable_get_default_material() const {
-	// Return a material with a default Texture_Blit shader for DrawableTexture2D to use
-	return tex_blit_shader.default_material;
+RID TextureStorage::texture_drawable_get_default_blit_material() const {
+	// Return a material with a default Texture_Blit shader for DrawableTexture2D to use.
+	return tex_blit_shader.default_blit_material;
+}
+
+RID TextureStorage::texture_drawable_get_default_blend_material() const {
+	return tex_blit_shader.default_blend_material;
 }
 
 void TextureStorage::texture_replace(RID p_texture, RID p_by_texture) {

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -495,8 +495,10 @@ private:
 		ShaderCompiler compiler;
 
 		bool initialized = false;
-		RID default_shader;
-		RID default_material;
+		RID default_blit_shader;
+		RID default_blit_material;
+		RID default_blend_shader;
+		RID default_blend_material;
 		RID default_shader_version;
 	} tex_blit_shader;
 
@@ -580,7 +582,8 @@ public:
 	virtual Vector<Ref<Image>> texture_3d_get(RID p_texture) const override;
 
 	virtual void texture_drawable_generate_mipmaps(RID p_texture) override;
-	virtual RID texture_drawable_get_default_material() const override;
+	virtual RID texture_drawable_get_default_blit_material() const override;
+	virtual RID texture_drawable_get_default_blend_material() const override;
 
 	virtual void texture_replace(RID p_texture, RID p_by_texture) override;
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) override;

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2284,7 +2284,8 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("texture_3d_get", "texture"), &RenderingServer::_texture_3d_get);
 
 	ClassDB::bind_method(D_METHOD("texture_drawable_generate_mipmaps", "texture"), &RenderingServer::texture_drawable_generate_mipmaps);
-	ClassDB::bind_method(D_METHOD("texture_drawable_get_default_material"), &RenderingServer::texture_drawable_get_default_material);
+	ClassDB::bind_method(D_METHOD("texture_drawable_get_default_blit_material"), &RenderingServer::texture_drawable_get_default_blit_material);
+	ClassDB::bind_method(D_METHOD("texture_drawable_get_default_blend_material"), &RenderingServer::texture_drawable_get_default_blend_material);
 
 	ClassDB::bind_method(D_METHOD("texture_replace", "texture", "by_texture"), &RenderingServer::texture_replace);
 	ClassDB::bind_method(D_METHOD("texture_set_size_override", "texture", "width", "height"), &RenderingServer::texture_set_size_override);

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -139,7 +139,8 @@ public:
 	virtual String texture_get_path(RID p_texture) const = 0;
 
 	virtual void texture_drawable_generate_mipmaps(RID p_texture) = 0; // Update mipmaps if modified
-	virtual RID texture_drawable_get_default_material() const = 0; // To use with simplified functions in DrawableTexture2D
+	virtual RID texture_drawable_get_default_blit_material() const = 0; // To use with simplified functions in DrawableTexture2D
+	virtual RID texture_drawable_get_default_blend_material() const = 0;
 
 	virtual Image::Format texture_get_format(RID p_texture) const = 0;
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -241,7 +241,8 @@ public:
 	FUNC1RC(Vector<Ref<Image>>, texture_3d_get, RID)
 
 	FUNC1(texture_drawable_generate_mipmaps, RID)
-	FUNC0RC(RID, texture_drawable_get_default_material)
+	FUNC0RC(RID, texture_drawable_get_default_blit_material)
+	FUNC0RC(RID, texture_drawable_get_default_blend_material)
 
 	FUNC2(texture_replace, RID, RID)
 

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -91,7 +91,8 @@ public:
 	virtual Vector<Ref<Image>> texture_3d_get(RID p_texture) const = 0;
 
 	virtual void texture_drawable_generate_mipmaps(RID p_texture) = 0;
-	virtual RID texture_drawable_get_default_material() const = 0;
+	virtual RID texture_drawable_get_default_blit_material() const = 0;
+	virtual RID texture_drawable_get_default_blend_material() const = 0;
 
 	virtual void texture_replace(RID p_texture, RID p_by_texture) = 0;
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) = 0;


### PR DESCRIPTION
I originally [commented about this](https://github.com/godotengine/godot/pull/105701#issuecomment-3079066340) in the original PR, but the `blit_rect()` method in DrawableTexture2D is inconsistent with Image API. Image has 2 methods for "drawing": `blit_rect()`, which replaces pixels and `blend_rect()`, which blends pixels. The `blit_rect()` in drawable texture works like `blend_rect()` in Image, and there is no method that replaces pixels. This was also mentioned in https://github.com/godotengine/godot-proposals/issues/14625.

This PR fixes this inconsistency by introducing `blend_rect()` method, which works the same as `blit_rect()` did with the default material. The `blit_rect()` will now by default replace pixels.