### PR TITLE
Fix floating dock rects from invisible docks

### DIFF
--- a/editor/docks/dock_tab_container.cpp
+++ b/editor/docks/dock_tab_container.cpp
@@ -247,6 +247,14 @@ void DockTabContainer::show_drag_hint() {
 	drag_hint->show();
 }
 
+Rect2 DockTabContainer::get_default_floating_dock_rect(EditorDock *p_dock) {
+	Size2 borders = Size2(4, 4) * EDSCALE;
+	Rect2 ret;
+	ret.position = p_dock->get_screen_position();
+	ret.size = p_dock->get_size() + borders * 2;
+	return ret;
+}
+
 DockTabContainer::DockTabContainer(EditorDock::DockSlot p_slot) {
 	ERR_FAIL_INDEX(p_slot, EditorDock::DOCK_SLOT_MAX);
 	dock_slot = p_slot;
@@ -264,12 +272,28 @@ DockTabContainer::DockTabContainer(EditorDock::DockSlot p_slot) {
 	get_tab_bar()->connect("tab_rmb_clicked", callable_mp(this, &DockTabContainer::_tab_rmb_clicked));
 }
 
+Rect2 SideDockTabContainer::get_floating_dock_rect(EditorDock *p_dock) {
+	if (p_dock->is_visible_in_tree()) {
+		return DockTabContainer::get_default_floating_dock_rect(p_dock);
+	}
+	const float tab_bar_height = get_tab_bar()->get_size().y;
+	return Rect2(get_screen_position() + Vector2(0, tab_bar_height), get_size() - Vector2(0, tab_bar_height));
+}
+
 SideDockTabContainer::SideDockTabContainer(EditorDock::DockSlot p_slot, const Rect2i &p_slot_rect) :
 		DockTabContainer(p_slot) {
 	grid_rect = p_slot_rect;
 	set_custom_minimum_size(Size2(170 * EDSCALE, 0));
 	set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	set_use_hidden_tabs_for_min_size(true);
+}
+
+Rect2 BottomSideDockTabContainer::get_floating_dock_rect(EditorDock *p_dock) {
+	if (p_dock->is_visible_in_tree()) {
+		return DockTabContainer::get_default_floating_dock_rect(p_dock);
+	}
+	const float tab_bar_height = get_tab_bar()->get_size().y;
+	return Rect2(get_screen_position() + Vector2(0, tab_bar_height), get_size() - Vector2(0, tab_bar_height));
 }
 
 BottomSideDockTabContainer::BottomSideDockTabContainer(EditorDock::DockSlot p_slot, const Rect2i &p_slot_rect) :

--- a/editor/docks/dock_tab_container.h
+++ b/editor/docks/dock_tab_container.h
@@ -99,6 +99,7 @@ public:
 	virtual void update_visibility();
 	virtual TabStyle get_tab_style() const;
 	virtual bool can_switch_dock() const;
+	virtual Rect2 get_floating_dock_rect(EditorDock *p_dock) { return DockTabContainer::get_default_floating_dock_rect(p_dock); }
 
 	// There is no equivalent load method, because loading needs to handle floating and closing.
 	void save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section);
@@ -111,6 +112,8 @@ public:
 	EditorDock *get_dock(int p_idx) const;
 	void show_drag_hint();
 
+	static Rect2 get_default_floating_dock_rect(EditorDock *p_dock);
+
 	DockTabContainer(EditorDock::DockSlot p_slot);
 };
 
@@ -118,6 +121,8 @@ class SideDockTabContainer : public DockTabContainer {
 	GDCLASS(SideDockTabContainer, DockTabContainer);
 
 public:
+	virtual Rect2 get_floating_dock_rect(EditorDock *p_dock) override;
+
 	SideDockTabContainer(EditorDock::DockSlot p_slot, const Rect2i &p_slot_rect);
 };
 
@@ -125,5 +130,7 @@ class BottomSideDockTabContainer : public DockTabContainer {
 	GDCLASS(BottomSideDockTabContainer, DockTabContainer);
 
 public:
+	virtual Rect2 get_floating_dock_rect(EditorDock *p_dock) override;
+
 	BottomSideDockTabContainer(EditorDock::DockSlot p_slot, const Rect2i &p_slot_rect);
 };

--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -272,10 +272,12 @@ EditorDock *EditorDockManager::_close_window(WindowWrapper *p_wrapper) {
 void EditorDockManager::_open_dock_in_window(EditorDock *p_dock, bool p_show_window, bool p_reset_size) {
 	ERR_FAIL_NULL(p_dock);
 
-	Size2 borders = Size2(4, 4) * EDSCALE;
-	// Remember size and position before removing it from the main window.
-	Size2 dock_size = p_dock->get_size() + borders * 2;
-	Point2 dock_screen_pos = p_dock->get_screen_position();
+	DockTabContainer *parent_container = p_dock->get_parent_container();
+	const Rect2 floating_rect = parent_container
+			? parent_container->get_floating_dock_rect(p_dock)
+			: DockTabContainer::get_default_floating_dock_rect(p_dock);
+	Size2 dock_size = floating_rect.size;
+	Point2 dock_screen_pos = floating_rect.position;
 
 	WindowWrapper *wrapper = memnew(WindowWrapper);
 	wrapper->set_window_title(vformat(TTR("%s - Godot Engine"), TTR(p_dock->get_display_title())));

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -139,6 +139,23 @@ bool EditorBottomPanel::can_switch_dock() const {
 	return !is_locked();
 }
 
+Rect2 EditorBottomPanel::get_floating_dock_rect(EditorDock *p_dock) {
+	if (p_dock->is_visible_in_tree()) {
+		return DockTabContainer::get_default_floating_dock_rect(p_dock);
+	}
+	// If dock is  not visible, its size may not be initialized.
+	Rect2 ret;
+	ret.size = get_size();
+
+	int *stored_size = dock_offsets.getptr(p_dock->get_effective_layout_key());
+	if (stored_size) {
+		ret.size.y = -(*stored_size);
+	}
+	ret.size.y -= get_tab_bar()->get_size().y;
+	ret.position = get_tab_bar()->get_screen_position() - Vector2(0, ret.size.y);
+	return ret;
+}
+
 void EditorBottomPanel::load_selected_tab(int p_idx) {
 	EditorDock *selected_dock = get_dock(p_idx);
 	if (!selected_dock) {

--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -85,6 +85,7 @@ public:
 	virtual void update_visibility() override { show(); } // Never hide bottom panel.
 	virtual TabStyle get_tab_style() const override;
 	virtual bool can_switch_dock() const override;
+	virtual Rect2 get_floating_dock_rect(EditorDock *p_dock) override;
 	virtual void load_selected_tab(int p_idx) override;
 
 	void save_layout_to_config(Ref<ConfigFile> p_config_file, const String &p_section) const;


### PR DESCRIPTION
When a bottom dock was never opened, its window position may be wrong.

https://github.com/user-attachments/assets/158af674-3b0d-4836-bb9e-0e2a742516a7

This PR makes the window rect initialized from bottom panel's size and dock's remembered size (stored in editor layout).

EDIT:
Also fixes side docks.