### PR TITLE
GDScript: Replace incorrect usage of `GD_ERR_BREAK`

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -3813,7 +3813,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				int globalname_idx = _code_ptr[ip + 2];
 				GD_ERR_BREAK(globalname_idx < 0 || globalname_idx >= _global_names_count);
 				const StringName *globalname = &_global_names_ptr[globalname_idx];
-				GD_ERR_BREAK(!GDScriptLanguage::get_singleton()->get_named_globals_map().has(*globalname));
+				if (unlikely(!GDScriptLanguage::get_singleton()->get_named_globals_map().has(*globalname))) {
+					err_text = vformat(R"(Trying to access non-existent autoload singleton "%s".)", *globalname);
+					OPCODE_BREAK;
+				}
 
 				GET_VARIANT_PTR(dst, 0);
 				*dst = GDScriptLanguage::get_singleton()->get_named_globals_map()[*globalname];


### PR DESCRIPTION
* Closes #116967.
* See https://github.com/godotengine/godot/issues/116967#issuecomment-3986592923.

The `GD_ERR_BREAK` macro terminates function execution without setting `err_text`, prompting users to report a bug. `GD_ERR_BREAK` is primarily used to check indexes, jump addresses, etc. `GD_ERR_BREAK` should not be used for errors that may arise for unrelated reasons.

In the case of `OPCODE_STORE_NAMED_GLOBAL`, this is possible for tool scripts. The script can likely be compiled while the autoload singleton exists, but the code can be executed after the autoload singleton is deleted or recreated in `EditorAutoloadSettings`. The absence of an autoload singleton in this case does not indicate a compiler bug (incorrect bytecode), but rather a normal situation (the user deleted the autoload singleton) or a conflict with the initialization order on the editor side.