### PR TITLE
Revert using shared item RIDOwner for all RichTextLabel instances

### DIFF
--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -579,7 +579,7 @@ private:
 
 	void _texture_changed(RID p_item);
 
-	static inline RID_PtrOwner<Item, true> items;
+	RID_PtrOwner<Item> items;
 	List<String> tag_stack;
 	HashSet<RID> hr_list;
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
Fixes #118275. I don't know if this issue counts as a release blocker, in which case this may not be the right solution. But I'll put it out here just in case.

- *Bugsquad edit:* This PR reverts https://github.com/godotengine/godot/pull/117101