### PR TITLE
Increase max RID count for some owners, decrease RID usage by `RichTextLabel`.

### DIFF
--- a/drivers/accesskit/accessibility_server_accesskit.h
+++ b/drivers/accesskit/accessibility_server_accesskit.h
@@ -58,7 +58,7 @@ class AccessibilityServerAccessKit : public AccessibilityServer {
 		accesskit_role role = ACCESSKIT_ROLE_UNKNOWN;
 		accesskit_node *node = nullptr;
 	};
-	mutable RID_PtrOwner<AccessibilityElement> rid_owner;
+	mutable RID_PtrOwner<AccessibilityElement> rid_owner{ 65536, 1048576 };
 
 	struct WindowData {
 		// Adapter.

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -582,7 +582,7 @@ class TextServerAdvanced : public TextServerExtension {
 
 	mutable RID_PtrOwner<FontAdvancedLinkedVariation> font_var_owner;
 	mutable RID_PtrOwner<FontAdvanced> font_owner;
-	mutable RID_PtrOwner<ShapedTextDataAdvanced> shaped_owner;
+	mutable RID_PtrOwner<ShapedTextDataAdvanced> shaped_owner{ 65536, 1048576 };
 
 	_FORCE_INLINE_ FontAdvanced *_get_font_data(const RID &p_font_rid) const {
 		RID rid = p_font_rid;

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -456,7 +456,7 @@ class TextServerFallback : public TextServerExtension {
 
 	mutable RID_PtrOwner<FontFallbackLinkedVariation> font_var_owner;
 	mutable RID_PtrOwner<FontFallback> font_owner;
-	mutable RID_PtrOwner<ShapedTextDataFallback> shaped_owner;
+	mutable RID_PtrOwner<ShapedTextDataFallback> shaped_owner{ 65536, 1048576 };
 
 	_FORCE_INLINE_ FontFallback *_get_font_data(const RID &p_font_rid) const {
 		RID rid = p_font_rid;

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4216,7 +4216,6 @@ void RichTextLabel::add_text(const String &p_text) {
 			} else {
 				//append item condition
 				ItemText *item = memnew(ItemText);
-				item->owner = get_instance_id();
 				item->rid = items.make_rid(item);
 				item->text = line;
 				_add_item(item, false);
@@ -4225,7 +4224,6 @@ void RichTextLabel::add_text(const String &p_text) {
 
 		if (eol) {
 			ItemNewline *item = memnew(ItemNewline); // Sets item->type to ITEM_NEWLINE.
-			item->owner = get_instance_id();
 			item->rid = items.make_rid(item);
 			item->line = current_frame->lines.size();
 			_add_item(item, false);
@@ -4341,8 +4339,6 @@ void RichTextLabel::add_hr(int p_width, int p_height, const Color &p_color, Hori
 	ERR_FAIL_COND(p_height < 0);
 
 	ItemParagraph *p_item = memnew(ItemParagraph);
-	p_item->owner = get_instance_id();
-	p_item->rid = items.make_rid(p_item);
 	p_item->alignment = p_alignment;
 	_add_item(p_item, true, true);
 
@@ -4520,7 +4516,6 @@ void RichTextLabel::add_newline() {
 		return;
 	}
 	ItemNewline *item = memnew(ItemNewline);
-	item->owner = get_instance_id();
 	item->rid = items.make_rid(item);
 	item->line = current_frame->lines.size();
 	_add_item(item, false);
@@ -4611,8 +4606,6 @@ bool RichTextLabel::remove_paragraph(int p_paragraph, bool p_no_invalidate) {
 			if (!erase_list.has(it->parent)) {
 				it->E->erase();
 			}
-			items.free(it->rid);
-			it->subitems.clear();
 			memdelete(it);
 		}
 		main->lines.remove_at(p_paragraph);
@@ -4699,7 +4692,6 @@ void RichTextLabel::push_dropcap(const String &p_string, const Ref<Font> &p_font
 
 	ItemDropcap *item = memnew(ItemDropcap);
 	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->text = p_string.replace("\r\n", "\n");
 	item->font = p_font;
 	item->font_size = p_size;
@@ -4719,7 +4711,6 @@ void RichTextLabel::_push_def_font_var(DefaultFont p_def_font, const Ref<Font> &
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemFont *item = memnew(ItemFont);
 	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->def_font = p_def_font;
 	item->variation = true;
 	item->font = p_font;
@@ -4737,7 +4728,6 @@ void RichTextLabel::_push_def_font(DefaultFont p_def_font) {
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemFont *item = memnew(ItemFont);
 	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->def_font = p_def_font;
 	item->def_size = true;
 	_add_item(item, true);
@@ -4751,7 +4741,6 @@ void RichTextLabel::push_font(const Ref<Font> &p_font, int p_size) {
 	ERR_FAIL_COND(p_font.is_null());
 	ItemFont *item = memnew(ItemFont);
 	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->font = p_font;
 	item->font_size = p_size;
 	p_font->connect_changed(callable_mp(this, &RichTextLabel::_invalidate_fonts), CONNECT_REFERENCE_COUNTED);
@@ -4805,8 +4794,6 @@ void RichTextLabel::push_font_size(int p_font_size) {
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemFontSize *item = memnew(ItemFontSize);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->font_size = p_font_size;
 	_add_item(item, true);
 }
@@ -4817,8 +4804,6 @@ void RichTextLabel::push_outline_size(int p_ol_size) {
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemOutlineSize *item = memnew(ItemOutlineSize);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->outline_size = p_ol_size;
 	_add_item(item, true);
 }
@@ -4829,8 +4814,6 @@ void RichTextLabel::push_color(const Color &p_color) {
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemColor *item = memnew(ItemColor);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->color = p_color;
 	_add_item(item, true);
 }
@@ -4841,8 +4824,6 @@ void RichTextLabel::push_outline_color(const Color &p_color) {
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemOutlineColor *item = memnew(ItemOutlineColor);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->color = p_color;
 	_add_item(item, true);
 }
@@ -4854,8 +4835,6 @@ void RichTextLabel::push_underline(const Color &p_color) {
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemUnderline *item = memnew(ItemUnderline);
 	item->color = p_color;
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 
 	_add_item(item, true);
 }
@@ -4867,8 +4846,6 @@ void RichTextLabel::push_strikethrough(const Color &p_color) {
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemStrikethrough *item = memnew(ItemStrikethrough);
 	item->color = p_color;
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 
 	_add_item(item, true);
 }
@@ -4880,8 +4857,6 @@ void RichTextLabel::push_paragraph(HorizontalAlignment p_alignment, Control::Tex
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 
 	ItemParagraph *item = memnew(ItemParagraph);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->alignment = p_alignment;
 	item->direction = p_direction;
 	item->language = p_language;
@@ -4899,8 +4874,6 @@ void RichTextLabel::push_indent(int p_level) {
 	ERR_FAIL_COND(p_level < 0);
 
 	ItemIndent *item = memnew(ItemIndent);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->level = p_level;
 	_add_item(item, true, true);
 }
@@ -4913,8 +4886,6 @@ void RichTextLabel::push_list(int p_level, ListType p_list, bool p_capitalize, c
 	ERR_FAIL_COND(p_level < 0);
 
 	ItemList *item = memnew(ItemList);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->list_type = p_list;
 	item->level = p_level;
 	item->capitalize = p_capitalize;
@@ -4928,8 +4899,6 @@ void RichTextLabel::push_meta(const Variant &p_meta, MetaUnderline p_underline_m
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemMeta *item = memnew(ItemMeta);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->meta = p_meta;
 	item->underline = p_underline_mode;
 	item->tooltip = p_tooltip;
@@ -4942,8 +4911,6 @@ void RichTextLabel::push_language(const String &p_language) {
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemLanguage *item = memnew(ItemLanguage);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->language = p_language;
 	_add_item(item, true);
 }
@@ -4954,8 +4921,6 @@ void RichTextLabel::push_hint(const String &p_string) {
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemHint *item = memnew(ItemHint);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->description = p_string;
 	_add_item(item, true);
 }
@@ -4967,7 +4932,6 @@ void RichTextLabel::push_table(int p_columns, InlineAlignment p_alignment, int p
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ERR_FAIL_COND(p_columns < 1);
 	ItemTable *item = memnew(ItemTable);
-	item->owner = get_instance_id();
 	item->rid = items.make_rid(item);
 	item->name = p_alt_text;
 	item->columns.resize(p_columns);
@@ -4988,8 +4952,6 @@ void RichTextLabel::push_fade(int p_start_index, int p_length) {
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemFade *item = memnew(ItemFade);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->starting_index = p_start_index;
 	item->length = p_length;
 	_add_item(item, true);
@@ -5001,8 +4963,6 @@ void RichTextLabel::push_shake(int p_strength = 10, float p_rate = 24.0f, bool p
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemShake *item = memnew(ItemShake);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->strength = p_strength;
 	item->rate = p_rate;
 	item->connected = p_connected;
@@ -5015,8 +4975,6 @@ void RichTextLabel::push_wave(float p_frequency = 1.0f, float p_amplitude = 10.0
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemWave *item = memnew(ItemWave);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->frequency = p_frequency;
 	item->amplitude = p_amplitude;
 	item->connected = p_connected;
@@ -5029,8 +4987,6 @@ void RichTextLabel::push_tornado(float p_frequency = 1.0f, float p_radius = 10.0
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemTornado *item = memnew(ItemTornado);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->frequency = p_frequency;
 	item->radius = p_radius;
 	item->connected = p_connected;
@@ -5043,8 +4999,6 @@ void RichTextLabel::push_rainbow(float p_saturation, float p_value, float p_freq
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemRainbow *item = memnew(ItemRainbow);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->speed = p_speed;
 	item->frequency = p_frequency;
 	item->saturation = p_saturation;
@@ -5057,8 +5011,6 @@ void RichTextLabel::push_pulse(const Color &p_color, float p_frequency, float p_
 	MutexLock data_lock(data_mutex);
 
 	ItemPulse *item = memnew(ItemPulse);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->color = p_color;
 	item->frequency = p_frequency;
 	item->ease = p_ease;
@@ -5071,8 +5023,6 @@ void RichTextLabel::push_bgcolor(const Color &p_color) {
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemBGColor *item = memnew(ItemBGColor);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->color = p_color;
 	_add_item(item, true);
 }
@@ -5083,8 +5033,6 @@ void RichTextLabel::push_fgcolor(const Color &p_color) {
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemFGColor *item = memnew(ItemFGColor);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->color = p_color;
 	_add_item(item, true);
 }
@@ -5095,8 +5043,6 @@ void RichTextLabel::push_customfx(Ref<RichTextEffect> p_custom_effect, Dictionar
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemCustomFX *item = memnew(ItemCustomFX);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->custom_effect = p_custom_effect;
 	item->char_fx_transform->environment = p_environment;
 	_add_item(item, true);
@@ -5110,8 +5056,6 @@ void RichTextLabel::push_context() {
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ItemContext *item = memnew(ItemContext);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	_add_item(item, true);
 }
 
@@ -5192,8 +5136,6 @@ void RichTextLabel::push_cell() {
 	ERR_FAIL_COND(current->type != ITEM_TABLE);
 
 	ItemFrame *item = memnew(ItemFrame);
-	item->owner = get_instance_id();
-	item->rid = items.make_rid(item);
 	item->parent_frame = current_frame;
 	_add_item(item, true);
 	current_frame = item;
@@ -8388,8 +8330,6 @@ Dictionary RichTextLabel::parse_expressions_for_values(Vector<String> p_expressi
 
 RichTextLabel::RichTextLabel(const String &p_text) {
 	main = memnew(ItemFrame);
-	main->owner = get_instance_id();
-	main->rid = items.make_rid(main);
 	main->index = 0;
 	current = main;
 	main->lines.resize(1);
@@ -8427,6 +8367,5 @@ RichTextLabel::RichTextLabel(const String &p_text) {
 
 RichTextLabel::~RichTextLabel() {
 	_stop_thread();
-	items.free(main->rid);
 	memdelete(main);
 }

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -201,25 +201,25 @@ private:
 		ItemType type = ITEM_FRAME;
 		List<Item *> subitems;
 		List<Item *>::Element *E = nullptr;
-		ObjectID owner;
 		int line = 0; // `line` is the index number of the paragraph (Line) this item is inside of (zero if the first paragraph).
 		RID rid;
 
 		RID accessibility_item_element;
 
 		void _clear_children() { // Only ever called on main or a paragraph (Line).
-			RichTextLabel *owner_rtl = ObjectDB::get_instance<RichTextLabel>(owner);
 			while (subitems.size()) {
 				Item *subitem = subitems.front()->get();
-				if (subitem && subitem->rid.is_valid() && owner_rtl) {
-					owner_rtl->items.free(subitem->rid);
-				}
 				memdelete(subitem);
 				subitems.pop_front();
 			}
 		}
 
-		virtual ~Item() { _clear_children(); }
+		virtual ~Item() {
+			_clear_children();
+			if (rid.is_valid()) {
+				items.free(rid);
+			}
+		}
 	};
 
 	struct ItemFrame : public Item {
@@ -261,6 +261,7 @@ private:
 		int ol_size = 0;
 		Color ol_color;
 		Rect2 dropcap_margins;
+		ObjectID owner;
 		ItemDropcap() { type = ITEM_DROPCAP; }
 		~ItemDropcap();
 	};
@@ -278,6 +279,7 @@ private:
 		Color color;
 		Variant key;
 		String tooltip;
+		ObjectID owner;
 		ItemImage() { type = ITEM_IMAGE; }
 		~ItemImage();
 	};
@@ -288,6 +290,7 @@ private:
 		bool variation = false;
 		bool def_size = false;
 		int font_size = 0;
+		ObjectID owner;
 		ItemFont() { type = ITEM_FONT; }
 		~ItemFont();
 	};
@@ -579,7 +582,7 @@ private:
 
 	void _texture_changed(RID p_item);
 
-	static inline RID_PtrOwner<Item, true> items;
+	static inline RID_PtrOwner<Item, true> items{ 65536, 1048576 };
 	List<String> tag_stack;
 	HashSet<RID> hr_list;
 


### PR DESCRIPTION
- Increase max RID count for `AccessibilityServer` elements (multiple elements for each node and for each complex text span)
- Increase max RID count for `TextServer` shaped text buffers (for each complex text span)
- Increase max RID count for `RichTextLabel` items.
- Only use `RID` (text spans, images, and tables) and `owner` (drop cap, image, and font elements) for elements using it.

Fixes https://github.com/godotengine/godot/issues/118275
