### PR TITLE
Fix OOB access during CCD vs soft body collision when using Jolt

### DIFF
--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
@@ -41,6 +41,10 @@
 #include <Jolt/Physics/SoftBody/SoftBodyManifold.h>
 
 void JoltContactListener3D::OnContactAdded(const JPH::Body &p_body1, const JPH::Body &p_body2, const JPH::ContactManifold &p_manifold, JPH::ContactSettings &p_settings) {
+	if (unlikely(p_body1.IsSoftBody() || p_body2.IsSoftBody())) {
+		return;
+	}
+
 	_try_override_collision_response(p_body1, p_body2, p_settings);
 	_try_apply_surface_velocities(p_body1, p_body2, p_settings);
 	_try_add_contacts(p_body1, p_body2, p_manifold, p_settings);


### PR DESCRIPTION
Fixes #118281.

When CCD is enabled on a `RigidBody3D` and it collides with a `SoftBody3D`, `JoltContactListener3D::OnContactAdded` ends up being called, which currently assumes that all dynamic bodies are `JoltBody3D` (i.e. not soft bodies), which means that this `reinterpret_cast` leads to a crash (or just a read of random memory):

https://github.com/godotengine/godot/blob/223c9417bd3f5cb5df89858a778db9967e7a279a/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp#L185-L190

This PR fixes that by just doing an early-out if either of the two bodies are a `SoftBody3D`, since any contact between them should (and seems to) be handled in the `OnSoftBodyContact*` methods instead.