### PR TITLE
Fix over-removal of area overlaps when using Jolt

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -622,8 +622,9 @@ void JoltArea3D::body_exited(const JPH::BodyID &p_body_id, bool p_notify) {
 	}
 
 	for (const KeyValue<ShapeIDPair, ShapeIndexPair> &E : overlap->shape_pairs) {
-		overlap->pending_added.erase(E.value);
-		overlap->pending_removed.push_back(E.value);
+		if (!overlap->pending_added.erase(E.value)) {
+			overlap->pending_removed.push_back(E.value);
+		}
 	}
 
 	_events_changed();
@@ -646,8 +647,9 @@ void JoltArea3D::area_exited(const JPH::BodyID &p_body_id) {
 	}
 
 	for (const KeyValue<ShapeIDPair, ShapeIndexPair> &E : overlap->shape_pairs) {
-		overlap->pending_added.erase(E.value);
-		overlap->pending_removed.push_back(E.value);
+		if (!overlap->pending_added.erase(E.value)) {
+			overlap->pending_removed.push_back(E.value);
+		}
 	}
 
 	_events_changed();


### PR DESCRIPTION
Fixes #118284.

The following flow is what's causing the error:

1. Physics processing begins.
2. A `RigidBody3D` moves to overlap an `Area3D`.
3. `JoltPhysicsServer3D::step` runs.
4. `JoltContactListener3D::_flush_area_enters` runs.
5. `JoltArea3D::_add_shape_pair` queues up the `pending_added` event.
6. Physics processing ends.
7. Idle processing begins.
8. The body is freed from a `_process`/timer/whatever
9. `JoltBody3D::_exit_all_areas` runs.
10. `JoltArea3D::body_exited` runs.
11. We **both** erase the `pending_added` event **and** queue up a new `pending_removed` event.
12. Idle processing ends.
13. Physics processing begins.
14. `JoltPhysicsServer3D::flush_queries` runs.
15. `JoltArea3D::_flush_events` runs.
16. The `pending_removed` event tries to decrement a ref count we never incremented.
17. 💥

This fixes that by only queueing up a `pending_removed` event if we didn't have a `pending_added` event for that shape pair already.

---

_Disclaimer: AI tooling was used in both finding the bug and in coming up with the fix._