### PR TITLE
Editor: Add setting to auto-collapse regions on script open

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1448,6 +1448,9 @@
 		<member name="text_editor/appearance/lines/code_folding" type="bool" setter="" getter="">
 			If [code]true[/code], displays the folding arrows next to indented code sections and allows code folding. If [code]false[/code], hides the folding arrows next to indented code sections and disallows code folding.
 		</member>
+		<member name="text_editor/appearance/lines/collapse_regions_on_start" type="int" setter="" getter="">
+			If [code]true[/code], code regions will be automatically collapsed when a script is first loaded in the editor.
+		</member>
 		<member name="text_editor/appearance/lines/word_wrap" type="int" setter="" getter="">
 			If [code]true[/code], wraps long lines over multiple lines to avoid horizontal scrolling. This is a display-only feature; it does not actually insert line breaks in your scripts.
 		</member>

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -411,7 +411,6 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 			}
 		}
 
-
 		Ref<Script> scr = seb->get_edited_resource();
 		if (scr.is_valid()) {
 			notify_script_changed(scr);

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -406,7 +406,7 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 		if (EDITOR_GET("text_editor/appearance/lines/collapse_regions_on_start")) {
 			if (c->get_meta("__editor_pass", 0).operator int() == 0) {
 				if (ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(seb)) {
-					ste->get_code_editor()->get_text_editor()->fold_all_lines();
+					ste->get_code_editor()->get_text_editor()->fold_all_regions();
 				}
 			}
 		}

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -403,6 +403,15 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 			teb->ensure_focus();
 		}
 
+		if (EDITOR_GET("text_editor/appearance/lines/collapse_regions_on_start")) {
+			if (c->get_meta("__editor_pass", 0).operator int() == 0) {
+				if (ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(seb)) {
+					ste->get_code_editor()->get_text_editor()->fold_all_lines();
+				}
+			}
+		}
+
+
 		Ref<Script> scr = seb->get_edited_resource();
 		if (scr.is_valid()) {
 			notify_script_changed(scr);

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -802,6 +802,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Appearance: Lines
 	_initial_set("text_editor/appearance/lines/code_folding", true, true);
+	_initial_set("text_editor/appearance/lines/collapse_regions_on_start", false, true);
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/appearance/lines/word_wrap", 0, "None,Boundary")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/appearance/lines/autowrap_mode", 3, "Arbitrary:1,Word:2,Word (Smart):3")
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2094,6 +2094,21 @@ PackedInt32Array CodeEdit::get_folded_lines() const {
 	return folded_lines;
 }
 
+void CodeEdit::fold_all_regions() {
+	bool any_line_folded = false;
+
+	for (int i = 0; i < get_line_count(); i++) {
+		if (is_line_code_region_start(i) && !is_line_folded(i)) {
+			_fold_line(i);
+			any_line_folded = true;
+		}
+	}
+
+	if (any_line_folded) {
+		emit_signal(SNAME("_fold_line_updated"));
+	}
+}
+
 /* Code region */
 void CodeEdit::create_code_region() {
 	// Abort if there is no selected text.

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -439,6 +439,8 @@ public:
 	void toggle_foldable_line(int p_line);
 	void toggle_foldable_lines_at_carets();
 
+	void fold_all_regions();
+
 	int get_folded_line_header(int p_line) const;
 	bool is_line_folded(int p_line) const;
 	TypedArray<int> get_folded_lines_bind() const;


### PR DESCRIPTION
This PR adds a new editor setting: text_editor/appearance/lines/collapse_regions_on_start (default: false).
When enabled, it automatically collapses all code regions the first time a script is opened in the current editor session.

AI Use:
I used AI for the code in editor/script/script_editor_plugin.cpp. Everything else was written by me.

Reasoning:
This setting improves workspace organization for projects using large scripts with multiple #region blocks. While regions help group code, they can lead to visual clutter when a script is reopened after some time. Auto-collapsing them ensures a clean, "top-down" view of the script's structure every time a developer returns to it, allowing them to expand only what is currently relevant.