### PR TITLE
Core: Provide more detailed metadata for `Variant` method arguments

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2497,7 +2497,7 @@ static void _register_variant_builtin_methods_math() {
 	bind_static_method(Color, from_rgba8, sarray("r8", "g8", "b8", "a8"), varray(255));
 }
 
-VARIANT_ENUM_CAST(ResourceDeepDuplicateMode);
+VARIANT_ENUM_CAST_EXT(ResourceDeepDuplicateMode, Resource::DeepDuplicateMode);
 
 static void _register_variant_builtin_methods_misc() {
 	/* RID */

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -273,6 +273,36 @@ static _FORCE_INLINE_ Variant::Type vc_get_argument_type_static(R (*method)(P...
 }
 
 template <typename R, typename T, typename... P>
+static _FORCE_INLINE_ void vc_get_argument_info(R (T::*method)(P...), int p_arg, PropertyInfo &r_info) {
+	call_get_argument_type_info<P...>(p_arg, r_info);
+}
+
+template <typename R, typename T, typename... P>
+static _FORCE_INLINE_ void vc_get_argument_info(R (T::*method)(P...) const, int p_arg, PropertyInfo &r_info) {
+	call_get_argument_type_info<P...>(p_arg, r_info);
+}
+
+template <typename T, typename... P>
+static _FORCE_INLINE_ void vc_get_argument_info(void (T::*method)(P...), int p_arg, PropertyInfo &r_info) {
+	call_get_argument_type_info<P...>(p_arg, r_info);
+}
+
+template <typename T, typename... P>
+static _FORCE_INLINE_ void vc_get_argument_info(void (T::*method)(P...) const, int p_arg, PropertyInfo &r_info) {
+	call_get_argument_type_info<P...>(p_arg, r_info);
+}
+
+template <typename R, typename T, typename... P>
+static _FORCE_INLINE_ void vc_get_argument_info(R (*method)(T *, P...), int p_arg, PropertyInfo &r_info) {
+	call_get_argument_type_info<P...>(p_arg, r_info);
+}
+
+template <typename R, typename... P>
+static _FORCE_INLINE_ void vc_get_argument_info_static(R (*method)(P...), int p_arg, PropertyInfo &r_info) {
+	call_get_argument_type_info<P...>(p_arg, r_info);
+}
+
+template <typename R, typename T, typename... P>
 static _FORCE_INLINE_ Variant::Type vc_get_return_type(R (T::*method)(P...)) {
 	return GetTypeInfo<R>::VARIANT_TYPE;
 }
@@ -386,6 +416,9 @@ static _FORCE_INLINE_ Variant::Type vc_get_base_type(void (T::*method)(P...) con
 		static Variant::Type get_argument_type(int p_arg) { \
 			return vc_get_argument_type(m_method_ptr, p_arg); \
 		} \
+		static void get_argument_info(int p_arg, PropertyInfo &r_info) { \
+			vc_get_argument_info(m_method_ptr, p_arg, r_info); \
+		} \
 		static Variant::Type get_return_type() { \
 			return vc_get_return_type(m_method_ptr); \
 		} \
@@ -425,6 +458,9 @@ static _FORCE_INLINE_ Variant::Type vc_get_base_type(void (T::*method)(P...) con
 		} \
 		static Variant::Type get_argument_type(int p_arg) { \
 			return vc_get_argument_type(m_method_ptr, p_arg); \
+		} \
+		static void get_argument_info(int p_arg, PropertyInfo &r_info) { \
+			vc_get_argument_info(m_method_ptr, p_arg, r_info); \
 		} \
 		static Variant::Type get_return_type() { \
 			return vc_get_return_type(m_method_ptr); \
@@ -476,6 +512,9 @@ static _FORCE_INLINE_ void vc_static_ptrcall(void (*method)(P...), const void **
 		static Variant::Type get_argument_type(int p_arg) { \
 			return vc_get_argument_type_static(m_method_ptr, p_arg); \
 		} \
+		static void get_argument_info(int p_arg, PropertyInfo &r_info) { \
+			vc_get_argument_info_static(m_method_ptr, p_arg, r_info); \
+		} \
 		static Variant::Type get_return_type() { \
 			return vc_get_return_type(m_method_ptr); \
 		} \
@@ -525,6 +564,9 @@ static _FORCE_INLINE_ void vc_ptrcall(void (*method)(T *, P...), void *p_base, c
 		} \
 		static Variant::Type get_argument_type(int p_arg) { \
 			return vc_get_argument_type(m_method_ptr, p_arg); \
+		} \
+		static void get_argument_info(int p_arg, PropertyInfo &r_info) { \
+			vc_get_argument_info(m_method_ptr, p_arg, r_info); \
 		} \
 		static Variant::Type get_return_type() { \
 			return vc_get_return_type(m_method_ptr); \
@@ -582,6 +624,8 @@ static _FORCE_INLINE_ void vc_ptrcall(void (*method)(T *, P...), void *p_base, c
 		static Variant::Type get_argument_type(int p_arg) { \
 			return Variant::NIL; \
 		} \
+		static void get_argument_info(int p_arg, PropertyInfo &r_info) { \
+		} \
 		static Variant::Type get_return_type() { \
 			return GetTypeInfo<m_return_type>::VARIANT_TYPE; \
 		} \
@@ -633,6 +677,9 @@ static _FORCE_INLINE_ void vc_ptrcall(void (*method)(T *, P...), void *p_base, c
 		} \
 		static Variant::Type get_argument_type(int p_arg) { \
 			return m_arg_type; \
+		} \
+		static void get_argument_info(int p_arg, PropertyInfo &r_info) { \
+			r_info.type = m_arg_type; \
 		} \
 		static Variant::Type get_return_type() { \
 			return Variant::NIL; \
@@ -1290,6 +1337,7 @@ struct VariantBuiltInMethodInfo {
 	Variant::Type return_type;
 	int argument_count = 0;
 	Variant::Type (*get_argument_type)(int p_arg) = nullptr;
+	void (*get_argument_info)(int p_arg, PropertyInfo &r_info) = nullptr;
 
 	MethodInfo get_method_info(const StringName &p_name) const {
 		MethodInfo mi;
@@ -1314,12 +1362,16 @@ struct VariantBuiltInMethodInfo {
 
 		for (int i = 0; i < argument_count; i++) {
 			PropertyInfo pi;
+			if (get_argument_info) {
+				(*get_argument_info)(i, pi);
+			} else {
+				pi.type = (*get_argument_type)(i);
+			}
 #ifdef DEBUG_ENABLED
 			pi.name = argument_names[i];
 #else
 			pi.name = "arg" + itos(i + 1);
 #endif // DEBUG_ENABLED
-			pi.type = (*get_argument_type)(i);
 			if (pi.type == Variant::NIL) {
 				pi.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
 			}
@@ -1373,6 +1425,7 @@ static void _populate_variant_builtin_method_info(VariantBuiltInMethodInfo &r_im
 	r_imi.return_type = T::get_return_type();
 	r_imi.argument_count = T::get_argument_count();
 	r_imi.get_argument_type = T::get_argument_type;
+	r_imi.get_argument_info = T::get_argument_info;
 }
 
 template <typename T>

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -347,7 +347,7 @@
 		</method>
 		<method name="duplicate_deep" qualifiers="const">
 			<return type="Array" />
-			<param index="0" name="deep_subresources_mode" type="int" default="1" />
+			<param index="0" name="deep_subresources_mode" type="int" enum="Resource.DeepDuplicateMode" default="1" />
 			<description>
 				Duplicates this array, deeply, like [method duplicate] when passing [code]true[/code], with extra control over how subresources are handled.
 				[param deep_subresources_mode] must be one of the values from [enum Resource.DeepDuplicateMode]. By default, only internal resources will be duplicated (recursively).

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -81,7 +81,7 @@
 		<method name="from_euler" qualifiers="static">
 			<return type="Basis" />
 			<param index="0" name="euler" type="Vector3" />
-			<param index="1" name="order" type="int" default="2" />
+			<param index="1" name="order" type="int" enum="EulerOrder" default="2" />
 			<description>
 				Constructs a new [Basis] that only represents rotation from the given [Vector3] of [url=https://en.wikipedia.org/wiki/Euler_angles]Euler angles[/url], in radians.
 				- The [member Vector3.x] should contain the angle around the [member x] axis (pitch);
@@ -130,7 +130,7 @@
 		</method>
 		<method name="get_euler" qualifiers="const">
 			<return type="Vector3" />
-			<param index="0" name="order" type="int" default="2" />
+			<param index="0" name="order" type="int" enum="EulerOrder" default="2" />
 			<description>
 				Returns this basis's rotation as a [Vector3] of [url=https://en.wikipedia.org/wiki/Euler_angles]Euler angles[/url], in radians. For the returned value:
 				- The [member Vector3.x] contains the angle around the [member x] axis (pitch);

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -228,7 +228,7 @@
 		</method>
 		<method name="duplicate_deep" qualifiers="const">
 			<return type="Dictionary" />
-			<param index="0" name="deep_subresources_mode" type="int" default="1" />
+			<param index="0" name="deep_subresources_mode" type="int" enum="Resource.DeepDuplicateMode" default="1" />
 			<description>
 				Duplicates this dictionary, deeply, like [method duplicate] when passing [code]true[/code], with extra control over how subresources are handled.
 				[param deep_subresources_mode] must be one of the values from [enum Resource.DeepDuplicateMode]. By default, only internal resources will be duplicated (recursively).

--- a/doc/classes/Projection.xml
+++ b/doc/classes/Projection.xml
@@ -213,7 +213,7 @@
 		</method>
 		<method name="get_projection_plane" qualifiers="const">
 			<return type="Plane" />
-			<param index="0" name="plane" type="int" />
+			<param index="0" name="plane" type="int" enum="Projection.Planes" />
 			<description>
 				Returns the clipping plane of this [Projection] whose index is given by [param plane].
 				[param plane] should be equal to one of [constant PLANE_NEAR], [constant PLANE_FAR], [constant PLANE_LEFT], [constant PLANE_TOP], [constant PLANE_RIGHT], or [constant PLANE_BOTTOM].

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -114,7 +114,7 @@
 		</method>
 		<method name="get_euler" qualifiers="const">
 			<return type="Vector3" />
-			<param index="0" name="order" type="int" default="2" />
+			<param index="0" name="order" type="int" enum="EulerOrder" default="2" />
 			<description>
 				Returns this quaternion's rotation as a [Vector3] of [url=https://en.wikipedia.org/wiki/Euler_angles]Euler angles[/url], in radians.
 				The order of each consecutive rotation can be changed with [param order] (see [enum EulerOrder] constants). By default, the YXZ convention is used ([constant EULER_ORDER_YXZ]): Z (roll) is calculated first, then X (pitch), and lastly Y (yaw). When using the opposite method [method from_euler], this order is reversed.


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/118184

`get_euler` incorrectly references an argument of type `int` instead of `enum EulerOrder`