### PR TITLE
Fix gravity not being initialized properly when using Jolt

### DIFF
--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -446,6 +446,7 @@ void JoltBody3D::_space_changed() {
 	_update_group_filter();
 	_update_joint_constraints();
 	_update_sleep_allowed();
+	_update_environmental_properties();
 }
 
 void JoltBody3D::_areas_changed() {


### PR DESCRIPTION
Fixes the regression from #118197 mentioned [here](https://github.com/godotengine/godot/pull/118197#issuecomment-4202538199).