### PR TITLE
Fix Visual Profiler cursor not appearing when graph is partially filled

### DIFF
--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -473,7 +473,9 @@ void EditorVisualProfiler::_graph_tex_draw() {
 
 	if (seeking) {
 		int max_frames = frame_metrics.size();
-		int frame = cursor_metric_edit->get_value() - (frame_metrics[last_metric].frame_number - max_frames + 1);
+
+		int64_t first_visible_frame = static_cast<int64_t>(frame_metrics[last_metric].frame_number) - max_frames + 1;
+		int frame = (cursor_metric_edit->get_value() - first_visible_frame);
 		if (frame < 0) {
 			frame = 0;
 		}


### PR DESCRIPTION
Fix Visual Profiler cursor not appearing when graph is partially filled

### Issue

Fixes https://github.com/godotengine/godot/issues/118279

When the Visual Profiler graph is not fully filled, clicking does not show the cursor (vertical line). The cursor appears stuck at the left edge.

---

### Cause

The issue was caused by arithmetic involving mixed numeric types.

frame_metrics[last_metric].frame_number is uint64_t, while max_frames is int. When frame_metrics[last_metric].frame_number is smaller than max_frames, the subtraction produces an incorrect value. This leads to a negative frame index after further calculation, which gets clamped to 0, causing the cursor to appear stuck at the left edge.

---

### Fix

Cast frame_metrics[last_metric].frame_number to int64_t before performing the subtraction:

```cpp
int64_t first_visible_frame = static_cast<int64_t>(frame_metrics[last_metric].frame_number) - max_frames + 1;
int frame = cursor_metric_edit->get_value() - first_visible_frame;
````

This ensures correct frame index calculation and proper cursor positioning when the graph is not fully filled.

---

### Notes

AI-assisted: Used an LLM for initial understanding of the issue. Final solution was validated and refined manually.
