### PR TITLE
Fix case sensitivity for file search

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2861,7 +2861,7 @@ bool FileSystemDock::_matches_all_search_tokens(const String &p_text) {
 	}
 	const String s = p_text.to_lower();
 	for (const String &t : searched_tokens) {
-		if (!s.contains(t)) {
+		if (!s.containsn(t)) {
 			return false;
 		}
 	}

--- a/editor/inspector/editor_property_name_processor.cpp
+++ b/editor/inspector/editor_property_name_processor.cpp
@@ -155,7 +155,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["arm32"] = "arm32";
 	capitalize_string_remaps["arm64"] = "arm64";
 	capitalize_string_remaps["arm64-v8a"] = "arm64-v8a";
-	capitalize_string_remaps["armeabi-v7a"] = "armabi-v7a";
+	capitalize_string_remaps["armeabi-v7a"] = "armeabi-v7a";
 	capitalize_string_remaps["arvr"] = "ARVR";
 	capitalize_string_remaps["astc"] = "ASTC";
 	capitalize_string_remaps["bbcode"] = "BBCode";

--- a/editor/inspector/editor_property_name_processor.cpp
+++ b/editor/inspector/editor_property_name_processor.cpp
@@ -154,8 +154,8 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["apk"] = "APK";
 	capitalize_string_remaps["arm32"] = "arm32";
 	capitalize_string_remaps["arm64"] = "arm64";
-	capitalize_string_remaps["arm64-v8a"] = "arm-v8a";
-	capitalize_string_remaps["armeabi-v7a"] = "arm-v7a";
+	capitalize_string_remaps["arm64-v8a"] = "arm64-v8a";
+	capitalize_string_remaps["armeabi-v7a"] = "armabi-v7a";
 	capitalize_string_remaps["arvr"] = "ARVR";
 	capitalize_string_remaps["astc"] = "ASTC";
 	capitalize_string_remaps["bbcode"] = "BBCode";

--- a/editor/inspector/editor_property_name_processor.cpp
+++ b/editor/inspector/editor_property_name_processor.cpp
@@ -152,7 +152,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["ao"] = "AO";
 	capitalize_string_remaps["api"] = "API";
 	capitalize_string_remaps["apk"] = "APK";
-	capitalize_string_remaps["32"] = "arm32";
+	capitalize_string_remaps["arm32"] = "arm32";
 	capitalize_string_remaps["arm64"] = "arm64";
 	capitalize_string_remaps["arm64-v8a"] = "arm-v8a";
 	capitalize_string_remaps["armeabi-v7a"] = "arm-v7a";

--- a/editor/inspector/editor_property_name_processor.cpp
+++ b/editor/inspector/editor_property_name_processor.cpp
@@ -152,10 +152,10 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["ao"] = "AO";
 	capitalize_string_remaps["api"] = "API";
 	capitalize_string_remaps["apk"] = "APK";
-	capitalize_string_remaps["arm32"] = "arm32";
-	capitalize_string_remaps["arm64"] = "arm64";
-	capitalize_string_remaps["arm64-v8a"] = "arm64-v8a";
-	capitalize_string_remaps["armeabi-v7a"] = "armeabi-v7a";
+	capitalize_string_remaps["arm32"] = "ARM32";
+	capitalize_string_remaps["arm64"] = "ARM64";
+	capitalize_string_remaps["arm64-v8a"] = "ARM64-v8a";
+	capitalize_string_remaps["armeabi-v7a"] = "ARMeabi-v7a";
 	capitalize_string_remaps["arvr"] = "ARVR";
 	capitalize_string_remaps["astc"] = "ASTC";
 	capitalize_string_remaps["bbcode"] = "BBCode";

--- a/editor/inspector/editor_property_name_processor.cpp
+++ b/editor/inspector/editor_property_name_processor.cpp
@@ -152,10 +152,10 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["ao"] = "AO";
 	capitalize_string_remaps["api"] = "API";
 	capitalize_string_remaps["apk"] = "APK";
-	capitalize_string_remaps["arm32"] = "ARM32";
-	capitalize_string_remaps["arm64"] = "ARM64";
-	capitalize_string_remaps["arm64-v8a"] = "ARM64-v8a";
-	capitalize_string_remaps["armeabi-v7a"] = "ARMeabi-v7a";
+	capitalize_string_remaps["32"] = "arm32";
+	capitalize_string_remaps["arm64"] = "arm64";
+	capitalize_string_remaps["arm64-v8a"] = "arm-v8a";
+	capitalize_string_remaps["armeabi-v7a"] = "arm-v7a";
 	capitalize_string_remaps["arvr"] = "ARVR";
 	capitalize_string_remaps["astc"] = "ASTC";
 	capitalize_string_remaps["bbcode"] = "BBCode";


### PR DESCRIPTION
By reading the flow, it seems like the file filter system is already intended be non case sensitive. For some reason though, t is not always lowercase. Because of this I have changed .contains to .containsn (n for no case). The same result could also be achieved with if (!s.containsn(t.to_lower())) but single letter commit is better.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
