### PR TITLE
Expose new `create_default_inspector` method for `EditorInspector`

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -14,12 +14,37 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="collapse_all_folding">
+			<return type="void" />
+			<description>
+				Collapses all foldable sections.
+			</description>
+		</method>
+		<method name="create_default_inspector" qualifiers="static">
+			<return type="EditorInspector" />
+			<param index="0" name="filter_line_edit" type="LineEdit" default="null" />
+			<description>
+				Creates an inspector with the same configuration as the one used in the editor's Inspector dock. When passing a [LineEdit] into [param filter_line_edit], the inspector will filter its properties based on [member LineEdit.text] whenever [signal LineEdit.text_changed] is emitted.
+			</description>
+		</method>
 		<method name="edit">
 			<return type="void" />
 			<param index="0" name="object" type="Object" />
 			<description>
 				Shows the properties of the given [param object] in this inspector for editing. To clear the inspector, call this method with [code]null[/code].
 				[b]Note:[/b] If you want to edit an object in the editor's main inspector, use the [code]edit_*[/code] methods in [EditorInterface] instead.
+			</description>
+		</method>
+		<method name="expand_all_folding">
+			<return type="void" />
+			<description>
+				Expands all foldable sections.
+			</description>
+		</method>
+		<method name="expand_revertable">
+			<return type="void" />
+			<description>
+				Expands only the foldable sections that contain a revertable (i.e. non-default) property.
 			</description>
 		</method>
 		<method name="get_edited_object">

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -879,21 +879,8 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	mc->set_theme_type_variation("NoBorderHorizontalBottom");
 	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
-	inspector = memnew(EditorInspector);
+	inspector = EditorInspector::create_default_inspector(search);
 	mc->add_child(inspector);
-	inspector->set_autoclear(true);
-	inspector->set_show_categories(true, true);
-	inspector->set_use_doc_hints(true);
-	inspector->set_hide_script(false);
-	inspector->set_hide_metadata(false);
-	inspector->set_use_settings_name_style(false);
-	inspector->set_property_name_style(property_name_style);
-	inspector->set_use_folding(!bool(EDITOR_GET("interface/inspector/disable_folding")));
-	inspector->register_text_enter(search);
-	inspector->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_TOP_AND_LEFT);
-
-	inspector->set_use_filter(true);
-
 	inspector->connect("resource_selected", callable_mp(this, &InspectorDock::_resource_selected));
 
 	FileSystemDock::get_singleton()->connect("files_moved", callable_mp(this, &InspectorDock::_files_moved));

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -3936,6 +3936,26 @@ void EditorInspector::initialize_property_theme(EditorProperty::ThemeCache &p_ca
 	}
 }
 
+EditorInspector *EditorInspector::create_default_inspector(LineEdit *p_filter_line_edit) {
+	EditorInspector *inspector = memnew(EditorInspector);
+	inspector->set_autoclear(true);
+	inspector->set_show_categories(true, true);
+	inspector->set_use_doc_hints(true);
+	inspector->set_hide_script(false);
+	inspector->set_hide_metadata(false);
+	inspector->set_use_settings_name_style(false);
+	inspector->set_property_name_style(EditorPropertyNameProcessor::get_default_inspector_style());
+	inspector->set_use_folding(!bool(EDITOR_GET("interface/inspector/disable_folding")));
+	inspector->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_TOP_AND_LEFT);
+
+	if (p_filter_line_edit != nullptr) {
+		inspector->register_text_enter(p_filter_line_edit);
+		inspector->set_use_filter(true);
+	}
+
+	return inspector;
+}
+
 void EditorInspector::add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin) {
 	ERR_FAIL_COND(inspector_plugin_count == MAX_PLUGINS);
 
@@ -6163,8 +6183,12 @@ void EditorInspector::_bind_methods() {
 	ClassDB::bind_method("_edit_request_change", &EditorInspector::_edit_request_change);
 	ClassDB::bind_method("get_selected_path", &EditorInspector::get_selected_path);
 	ClassDB::bind_method("get_edited_object", &EditorInspector::get_edited_object);
+	ClassDB::bind_method("collapse_all_folding", &EditorInspector::collapse_all_folding);
+	ClassDB::bind_method("expand_all_folding", &EditorInspector::expand_all_folding);
+	ClassDB::bind_method("expand_revertable", &EditorInspector::expand_revertable);
 
 	ClassDB::bind_static_method("EditorInspector", D_METHOD("instantiate_property_editor", "object", "type", "path", "hint", "hint_text", "usage", "wide"), &EditorInspector::instantiate_property_editor, DEFVAL(false));
+	ClassDB::bind_static_method("EditorInspector", D_METHOD("create_default_inspector", "filter_line_edit"), &EditorInspector::create_default_inspector, DEFVAL(Variant()));
 
 	ADD_SIGNAL(MethodInfo("property_selected", PropertyInfo(Variant::STRING, "property")));
 	ADD_SIGNAL(MethodInfo("property_keyed", PropertyInfo(Variant::STRING, "property"), PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), PropertyInfo(Variant::BOOL, "advance")));

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -900,6 +900,8 @@ public:
 	static PropertyClipboard::Type get_property_clipboard_type() { return property_clipboard.type; }
 	static Variant get_property_clipboard_value() { return property_clipboard.value; }
 
+	static EditorInspector *create_default_inspector(LineEdit *p_filter_line_edit = nullptr);
+
 	bool is_main_editor_inspector() const;
 	String get_selected_path() const;
 


### PR DESCRIPTION
Relates to (but doesn't necessarily resolve): godotengine/godot-proposals#12755
Relates to #110412.

This exposes the following new methods on the `EditorInspector` class:

1. A static `create_default_inspector`, for creating an `EditorInspector` instance that is set up just like the one in the editor's Inspector dock, which takes an optional `LineEdit` to use as the filter.
2. A non-static `collapse_all_folding`, for collapsing all foldable sections.
3. A non-static `expand_all_folding`, for expanding all foldable sections.
4. A non-static `expand_revertable`, for expanding only the foldable sections with revertable properties in them.

(Note that "revertible" is the more common spelling of "revertable", if that's important. I just exposed it as found in the existing code. That method could also be exposed as `expand_non_default`, since that's how the Inspector dock refers to it.)

Here's a minimal test project where you can see a custom inspector be added through an add-on using this new API: [custom-editor-inspector.zip](https://github.com/user-attachments/files/26566338/custom-editor-inspector.zip)
