### PR TITLE
Buildsystem: Support clang source based coverage on linux

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -49,7 +49,7 @@ def get_opts():
         EnumVariable("linker", "Linker program", "default", ["default", "bfd", "gold", "lld", "mold"], ignorecase=2),
         BoolVariable("use_llvm", "Use the LLVM compiler", False),
         BoolVariable("use_static_cpp", "Link libgcc and libstdc++ statically for better portability", True),
-        BoolVariable("use_coverage", "Test Godot coverage", False),
+        EnumVariable("use_coverage", "Test Godot coverage", "no", ["no", "gnu", "llvm"], ignorecase=2),
         BoolVariable("use_ubsan", "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)", False),
         BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN)", False),
         BoolVariable("use_lsan", "Use LLVM/GCC compiler leak sanitizer (LSAN)", False),
@@ -155,9 +155,15 @@ def configure(env: "SConsEnvironment"):
         else:
             env.Append(LINKFLAGS=["-fuse-ld=%s" % env["linker"]])
 
-    if env["use_coverage"]:
+    if env["use_coverage"] == "gnu":
         env.Append(CCFLAGS=["-ftest-coverage", "-fprofile-arcs"])
         env.Append(LINKFLAGS=["-ftest-coverage", "-fprofile-arcs"])
+    elif env["use_coverage"] == "llvm":
+        if not env["use_llvm"]:
+            print_error("Source based coverage requires using clang, use `use_llvm=yes`.")
+            raise
+        env.Append(CCFLAGS=["-fprofile-instr-generate", "-fcoverage-mapping"])
+        env.Append(LINKFLAGS=["-fprofile-instr-generate"])
 
     if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"] or env["use_msan"]:
         env.extra_suffix += ".san"


### PR DESCRIPTION
The `use_coverage` flag does enable gcov based coverage at the moment. This is supported by clang and gcc and generates data files per object file. So when you need a report to use with other tools (e.g. VSCode plugin) it is necessary to aggregate those data files. For example using a tool like `gcovr`. `gcovr` performs poorly for Godot and aggregating the gcov data takes multiple minutes for me.

clang has another strategy: [source based coverage](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html). It produces bigger binaries but outputs into a single file. llvm also comes with utilities to generate summaries or export data from this file.

For my setup I require an lcov file for use with a VSCode extension and producing this lcov file is much faster when using the llvm utils compared to gcovr.

This PR adds an easy way to use clang source based coverage to our scons options. It does break compat of the scons flag, I'm not sure if that is an issue.

I did not touch the macos flag, since I can't test that and I'm not sure to how to programatically check whether clang is used on mac.

For reference here's the workflow to get a summary using this approach:

```
scons dev_build=yes use_coverage=llvm use_llvm=yes dev_mode=yes linker=mold extra_suffix=cov
LLVM_PROFILE_FILE="coverage.profraw" ./bin/godot.linuxbsd.editor.dev.x86_64.llvm.cov --test
llvm-profdata merge --sparse coverage.profraw -o coverage.profdata
llvm-cov report -instr-profile coverage.profdata ./bin/godot.linuxbsd.editor.dev.x86_64.llvm.cov -ignore-filename-regex="(modules/[^/]+/)?tests/|thirdparty/|.*\.gen\.h" > coverage-report.txt
```
