### PR TITLE
[RTL] Fix `remove_paragraph` crash.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4622,6 +4622,7 @@ bool RichTextLabel::remove_paragraph(int p_paragraph, bool p_no_invalidate) {
 			if (!erase_list.has(it->parent)) {
 				it->E->erase();
 			}
+			it->subitems.clear();
 			memdelete(it);
 		}
 		main->lines.remove_at(p_paragraph);


### PR DESCRIPTION
Regression from https://github.com/godotengine/godot/pull/118277 (extra line was accidentally removed).

Fixes https://github.com/godotengine/godot/pull/118277#issuecomment-4206184534