### PR TITLE
Make `TextEdit`'s `scroll_fit_content_*` properties work properly with maximum sizes

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1375,10 +1375,10 @@
 			Text shown when the [TextEdit] is empty. It is [b]not[/b] the [TextEdit]'s default value (see [member text]).
 		</member>
 		<member name="scroll_fit_content_height" type="bool" setter="set_fit_content_height_enabled" getter="is_fit_content_height_enabled" default="false">
-			If [code]true[/code], [TextEdit] will disable vertical scroll and fit minimum height to the number of visible lines. When both this property and [member scroll_fit_content_width] are [code]true[/code], no scrollbars will be displayed.
+			If [code]true[/code], [TextEdit] fits its minimum height to the number of visible lines instead of scrolling vertically. If a maximum height is set (for example via [member Control.custom_maximum_size]) and content exceeds it, a vertical scrollbar is shown.
 		</member>
 		<member name="scroll_fit_content_width" type="bool" setter="set_fit_content_width_enabled" getter="is_fit_content_width_enabled" default="false">
-			If [code]true[/code], [TextEdit] will disable horizontal scroll and fit minimum width to the widest line in the text. When both this property and [member scroll_fit_content_height] are [code]true[/code], no scrollbars will be displayed.
+			If [code]true[/code], [TextEdit] fits its minimum width to the widest line instead of scrolling horizontally. If a maximum width is set (for example via [member Control.custom_maximum_size]) and content exceeds it, a horizontal scrollbar is shown.
 		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">
 			If there is a horizontal scrollbar, this determines the current horizontal scroll value in pixels.

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -8678,9 +8678,16 @@ void TextEdit::_update_scrollbars() {
 		update_minimum_size();
 	}
 
+	const Size2 combined_maximum_size = get_combined_maximum_size();
+	const Size2 style_minimum_size = style->get_minimum_size();
+	const bool fit_content_height_exceeds_maximum = fit_content_height && combined_maximum_size.y >= 0 &&
+			style_minimum_size.y + content_size_cache.y > combined_maximum_size.y;
+	const bool fit_content_width_exceeds_maximum = fit_content_width && combined_maximum_size.x >= 0 &&
+			style_minimum_size.x + content_size_cache.x > combined_maximum_size.x;
+
 	updating_scrolls = true;
 
-	if (!fit_content_height && total_rows > visible_rows) {
+	if ((!fit_content_height || fit_content_height_exceeds_maximum) && total_rows > visible_rows) {
 		double visible_rows_exact = (double)_get_control_height() / (double)get_line_height();
 		double fractional_visible_rows = visible_rows_exact - (double)visible_rows;
 		fractional_visible_rows = CLAMP(fractional_visible_rows, 0.0, 1.0);
@@ -8696,7 +8703,7 @@ void TextEdit::_update_scrollbars() {
 		v_scroll->hide();
 	}
 
-	if (total_width > visible_width) {
+	if ((!fit_content_width || fit_content_width_exceeds_maximum) && total_width > visible_width) {
 		h_scroll->show();
 		h_scroll->set_max(total_width);
 		h_scroll->set_page(visible_width);

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -8045,6 +8045,46 @@ TEST_CASE("[SceneTree][TextEdit] small height value") {
 	memdelete(text_edit);
 }
 
+TEST_CASE("[SceneTree][TextEdit] fit content scrollbar behavior") {
+	TextEdit *text_edit = memnew(TextEdit);
+	SceneTree::get_singleton()->get_root()->add_child(text_edit);
+
+	text_edit->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_NONE);
+	text_edit->set_fit_content_width_enabled(true);
+	text_edit->set_fit_content_height_enabled(true);
+
+	const String long_line = "0123456789012345678901234567890123456789012345678901234567890123456789";
+	String content;
+	for (int i = 0; i < 40; i++) {
+		if (i > 0) {
+			content += "\n";
+		}
+		content += long_line;
+	}
+	text_edit->set_text(content);
+	MessageQueue::get_singleton()->flush();
+
+	SUBCASE("[TextEdit] fit content without maximum size") {
+		text_edit->set_custom_maximum_size(Size2(-1, -1));
+		text_edit->set_size(text_edit->get_combined_minimum_size());
+		MessageQueue::get_singleton()->flush();
+
+		CHECK_FALSE(text_edit->get_h_scroll_bar()->is_visible());
+		CHECK_FALSE(text_edit->get_v_scroll_bar()->is_visible());
+	}
+
+	SUBCASE("[TextEdit] fit content with maximum size") {
+		text_edit->set_custom_maximum_size(Size2(180, 120));
+		text_edit->set_size(text_edit->get_combined_maximum_size());
+		MessageQueue::get_singleton()->flush();
+
+		CHECK(text_edit->get_h_scroll_bar()->is_visible());
+		CHECK(text_edit->get_v_scroll_bar()->is_visible());
+	}
+
+	memdelete(text_edit);
+}
+
 TEST_CASE("[SceneTree][TextEdit] setter getters") {
 	TextEdit *text_edit = memnew(TextEdit);
 	SceneTree::get_singleton()->get_root()->add_child(text_edit);


### PR DESCRIPTION
* Follow up to #116640 
* cc @pippenpaddleopsicopolis 

During the late stages of the PR review for `Control::custom_maximum_size`, it was reported that the `TextEdit` class' `scroll_fit_content_*` properties didn't play well with the new maximum size.
If a height was reached through the text that is larger than the maximum size whilst `scroll_fit_content_height == true`, the text would simply be clipped, which is undesired behavior. 
*`scroll_fit_content_width` would already result in scrollbars showing... Explanation below*

This PR rectifies that by updating the behavior of a `TextEdit` with `scroll_fit_content_*` enabled to behave just like before (not showing scrollbars) up until the point the maximum size is reached (if one is defined), at which point they return. 
This behavior is analogous to `SCROLL_MODE_MAXIMIZE_FIRST`, which was introduced for `ScrollContainer` in that PR. 

Also added tests for `scroll_fit_content_*` which weren't there before and added the necessary ones for the new behavior. Related #43440.

Before:
Smaller than max size:
<img width="377" height="156" alt="image" src="https://github.com/user-attachments/assets/c8603ca9-5b81-4dfe-954a-5afdc10b786d" />

Larger than max size:
<img width="291" height="132" alt="image" src="https://github.com/user-attachments/assets/3c0fe5f7-5375-4b10-9695-854ca8fe750e" />
^ This should show no scrollbars at all, as per the old property descriptions, but it was bugged, as said, explanation below.


After:
Smaller than max size:
<img width="360" height="149" alt="image" src="https://github.com/user-attachments/assets/66f8a9a4-f5d7-49e9-885a-54ab6d22576a" />

Larger than max size:
<img width="343" height="168" alt="image" src="https://github.com/user-attachments/assets/566d0bc6-07ee-457b-9ed4-3c2c7668d9c5" />

Regarding `scroll_fit_content_width`:
For `scroll_fit_content_height`, the check for whether scrollbars should show was the following: `!fit_content_height && total_rows > visible_rows`.
But for `scroll_fit_content_width`, it was the following: `total_width > visible_width`. This was never checking for `fit_content_width`. 
Now, this couldn't be an issue before max size was introduced, since `fit_content_*` (which is the code version of `scroll_fit_content_*`) would always force minimum size, and thus the `true` condition could only be reached with it disabled. This was fragile, though. Fixed it with this PR.