### PR TITLE
GDScript: Add tests for Dictionary type tests

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/features/type_test_usage.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/type_test_usage.gd
@@ -75,6 +75,62 @@ func test():
 	Utils.check((const_b_array is int) == false)
 	Utils.check(is_instance_of(const_b_array, TYPE_INT) == false)
 
+	var untyped_dict: Variant = {}
+	Utils.check((untyped_dict is Variant) == true)
+	Utils.check((untyped_dict is Dictionary) == true)
+	Utils.check(is_instance_of(untyped_dict, TYPE_DICTIONARY) == true)
+	Utils.check((untyped_dict is Dictionary[int, int]) == false)
+	Utils.check((untyped_dict is Dictionary[float, String]) == false)
+	Utils.check((untyped_dict is int) == false)
+	Utils.check(is_instance_of(untyped_dict, TYPE_INT) == false)
+
+	const const_untyped_dict: Variant = {}
+	Utils.check((const_untyped_dict is Variant) == true)
+	Utils.check((const_untyped_dict is Dictionary) == true)
+	Utils.check(is_instance_of(const_untyped_dict, TYPE_DICTIONARY) == true)
+	Utils.check((const_untyped_dict is Dictionary[int, int]) == false)
+	Utils.check((const_untyped_dict is Dictionary[float, String]) == false)
+	Utils.check((const_untyped_dict is int) == false)
+	Utils.check(is_instance_of(const_untyped_dict, TYPE_INT) == false)
+
+	var int_dict: Variant = {} as Dictionary[int, int]
+	Utils.check((int_dict is Variant) == true)
+	Utils.check((int_dict is Dictionary) == true)
+	Utils.check(is_instance_of(int_dict, TYPE_DICTIONARY) == true)
+	Utils.check((int_dict is Dictionary[int, int]) == true)
+	Utils.check((int_dict is Dictionary[float, String]) == false)
+	Utils.check((int_dict is int) == false)
+	Utils.check(is_instance_of(int_dict, TYPE_INT) == false)
+
+	const const_int_dict: Variant = {} as Dictionary[int, int]
+	Utils.check((const_int_dict is Variant) == true)
+	Utils.check((const_int_dict is Dictionary) == true)
+	Utils.check(is_instance_of(const_int_dict, TYPE_DICTIONARY) == true)
+	Utils.check((const_int_dict is Dictionary[int, int]) == true)
+	Utils.check((const_int_dict is Dictionary[float, String]) == false)
+	Utils.check((const_int_dict is int) == false)
+	Utils.check(is_instance_of(const_int_dict, TYPE_INT) == false)
+
+	var b_dict: Variant = {} as Dictionary[String, B]
+	Utils.check((b_dict is Variant) == true)
+	Utils.check((b_dict is Dictionary) == true)
+	Utils.check(is_instance_of(b_dict, TYPE_DICTIONARY) == true)
+	Utils.check((b_dict is Dictionary[String, B]) == true)
+	Utils.check((b_dict is Dictionary[String, A]) == false)
+	Utils.check((b_dict is Dictionary[String, int]) == false)
+	Utils.check((b_dict is int) == false)
+	Utils.check(is_instance_of(b_dict, TYPE_INT) == false)
+
+	const const_b_dict: Variant = {} as Dictionary[String, B]
+	Utils.check((const_b_dict is Variant) == true)
+	Utils.check((const_b_dict is Dictionary) == true)
+	Utils.check(is_instance_of(const_b_dict, TYPE_DICTIONARY) == true)
+	Utils.check((const_b_dict is Dictionary[String, B]) == true)
+	Utils.check((const_b_dict is Dictionary[String, A]) == false)
+	Utils.check((const_b_dict is Dictionary[String, int]) == false)
+	Utils.check((const_b_dict is int) == false)
+	Utils.check(is_instance_of(const_b_dict, TYPE_INT) == false)
+
 	var native: Variant = RefCounted.new()
 	Utils.check((native is Variant) == true)
 	Utils.check((native is Object) == true)


### PR DESCRIPTION
Adds tests to cover `OPCODE_TYPE_TEST_DICTIONARY` in the test suite.