### PR TITLE
Fix compile errors in sky shader in the compatibility renderer

### DIFF
--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -72,6 +72,22 @@ directional_lights;
 
 #define DIRECTIONAL_LIGHT_ENABLED uint(1 << 0)
 
+// mat4 is a waste of space, but we don't have an easy way to set a mat3 uniform for now
+uniform mat4 orientation;
+uniform vec4 projection;
+uniform vec3 position;
+uniform float time;
+uniform float sky_energy_multiplier;
+uniform float luminance_multiplier;
+
+uniform float fog_aerial_perspective;
+uniform vec4 fog_light_color;
+uniform float fog_sun_scatter;
+uniform bool fog_enabled;
+uniform float fog_density;
+uniform float fog_sky_affect;
+uniform uint directional_light_count;
+
 /* clang-format off */
 
 #ifdef MATERIAL_UNIFORMS_USED
@@ -101,22 +117,6 @@ layout(std140) uniform MaterialUniforms{ //ubo:3
 #else
 #define AT_QUARTER_RES_PASS false
 #endif
-
-// mat4 is a waste of space, but we don't have an easy way to set a mat3 uniform for now
-uniform mat4 orientation;
-uniform vec4 projection;
-uniform vec3 position;
-uniform float time;
-uniform float sky_energy_multiplier;
-uniform float luminance_multiplier;
-
-uniform float fog_aerial_perspective;
-uniform vec4 fog_light_color;
-uniform float fog_sun_scatter;
-uniform bool fog_enabled;
-uniform float fog_density;
-uniform float fog_sky_affect;
-uniform uint directional_light_count;
 
 #ifdef USE_MULTIVIEW
 layout(std140) uniform MultiviewData { // ubo:11
@@ -218,24 +218,24 @@ void main() {
 
 #ifdef USE_CUBEMAP_PASS
 #ifdef USES_HALF_RES_COLOR
-	half_res_color = texture(samplerCube(half_res, SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), cube_normal);
+	half_res_color = texture(half_res, cube_normal);
 #endif
 #ifdef USES_QUARTER_RES_COLOR
-	quarter_res_color = texture(samplerCube(quarter_res, SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), cube_normal);
+	quarter_res_color = texture(quarter_res, cube_normal);
 #endif
 #else
 #ifdef USES_HALF_RES_COLOR
 #ifdef USE_MULTIVIEW
-	half_res_color = textureLod(sampler2DArray(half_res, SAMPLER_LINEAR_CLAMP), vec3(uv, ViewIndex), 0.0);
+	half_res_color = textureLod(half_res, vec3(uv, ViewIndex), 0.0);
 #else
-	half_res_color = textureLod(sampler2D(half_res, SAMPLER_LINEAR_CLAMP), uv, 0.0);
+	half_res_color = textureLod(half_res, uv, 0.0);
 #endif
 #endif
 #ifdef USES_QUARTER_RES_COLOR
 #ifdef USE_MULTIVIEW
-	quarter_res_color = textureLod(sampler2DArray(quarter_res, SAMPLER_LINEAR_CLAMP), vec3(uv, ViewIndex), 0.0);
+	quarter_res_color = textureLod(quarter_res, vec3(uv, ViewIndex), 0.0);
 #else
-	quarter_res_color = textureLod(sampler2D(quarter_res, SAMPLER_LINEAR_CLAMP), uv, 0.0);
+	quarter_res_color = textureLod(quarter_res, uv, 0.0);
 #endif
 #endif
 #endif


### PR DESCRIPTION
I caught these errors when testing the MRP from https://github.com/godotengine/godot/issues/118278. 

1. Compile error when using TIME in a custom function. The problem here is just that `time` was defined below where the custom functions are defined. The solution is just to move it up
2. HALF_RES_COLOR and QUARTER_RES_COLOR lead to compile errors since they are copy-pasted from the vulkan backend. The compatibility renderer doesn't support half or quarter res rendering right now. So they don't do anything, but the shader shouldn't fail with an internal compile error. 