### PR TITLE
SpriteFramesEditor: Fix build with `deprecated=no`

### DIFF
--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -1429,7 +1429,7 @@ void SpriteFramesEditor::_animation_remove_undo_redo(const StringName &p_action_
 	undo_redo->add_undo_method(frames.ptr(), "add_animation", edited_anim);
 	_rename_node_animation(undo_redo, true, edited_anim, edited_anim, edited_anim);
 	undo_redo->add_undo_method(frames.ptr(), "set_animation_speed", edited_anim, frames->get_animation_speed(edited_anim));
-	undo_redo->add_undo_method(frames.ptr(), "set_animation_loop", edited_anim, frames->get_animation_loop(edited_anim));
+	undo_redo->add_undo_method(frames.ptr(), "set_animation_loop_mode", edited_anim, frames->get_animation_loop_mode(edited_anim));
 	for (int i = 0; i < frame_count; i++) {
 		Ref<Texture2D> texture;
 		float duration;


### PR DESCRIPTION
Since #114556 / ad46310, SpriteFramesEditor no longer built with `deprecated=no` due to `SpriteFrames::get_animation_loop` and `set_animation_loop` being undefined.

This commit directly uses the `{get,set}_animation_loop_mode` replacements, which are always available.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for new contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
-->
