### PR TITLE
Fix tab bar max width behavior

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -135,10 +135,15 @@ Size2 TabBar::get_minimum_size() const {
 	}
 
 	if (clip_tabs) {
-		ms.width = max_tab_width + buttons_size;
-	}
-
-	if (combined_max.width >= 0) {
+		int clip_min_width = max_tab_width + buttons_size;
+		if (combined_max.width >= 0) {
+			int fitted_width = stop_adding ? (computed_max_width + buttons_size) : computed_max_width;
+			ms.width = MAX(clip_min_width, fitted_width);
+			ms.width = MIN(ms.width, int(combined_max.width));
+		} else {
+			ms.width = clip_min_width;
+		}
+	} else if (combined_max.width >= 0) {
 		ms.width = stop_adding ? combined_max.width : MIN(computed_max_width, combined_max.width);
 	}
 


### PR DESCRIPTION
* Follow up to #116640 

Now that #116640 got merged, I got back to helping @KoBeWi with trying to make #113051's editor title bar behave as we want it to, and we kept seeing gaps in between the arrows and the tabs when tabs were being clipped (image below).

<img width="452" height="73" alt="image" src="https://github.com/user-attachments/assets/225e048b-80b3-48e9-9b92-9dfbe82ec1f7" />

I initially assumed that the issue was due to the - frankly awful - band-aiding holding the whole editor stuff together, but no, it was an issue directly with TabBar when using a maximum size and clip tabs. 

This PR removes that ugly gap. Images below show an example with a fairly tame gap, but it could get quite egregious depending on the size of the hidden tabs, as seen above. 

Before:
<img width="462" height="69" alt="image" src="https://github.com/user-attachments/assets/d1a5f51f-9c54-42cd-8cef-b33f9ca3e63a" />

After:
<img width="414" height="75" alt="image" src="https://github.com/user-attachments/assets/fca410d5-5cd7-4e53-863b-fc949ff6ff5b" />

<sub> Did not expect to have to do a bugfix that quickly :/ Oh well, it was a massive PR after all. </sub>