### PR TITLE
GDScript: Use full parser in `find_function`

### DIFF
--- a/core/object/editor_language.h
+++ b/core/object/editor_language.h
@@ -117,7 +117,7 @@ public:
 	 *
 	 * @return The zero-based line number of the function or `-1` if not found.
 	 */
-	virtual int32_t find_function(const String &p_function, const String &p_code) const { return -1; }
+	virtual int32_t find_function(const String &p_function, const String &p_code, const String &p_path) const { return -1; }
 
 	virtual ~EditorLanguage() = default;
 };

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -279,7 +279,7 @@ private:
 			return script_language->lookup_code(p_code, p_symbol, p_path, p_owner, r_result);
 		}
 
-		virtual int32_t find_function(const String &p_function, const String &p_code) const override {
+		virtual int32_t find_function(const String &p_function, const String &p_code, const String &p_path) const override {
 			return script_language->find_function(p_function, p_code);
 		}
 

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -1014,7 +1014,7 @@ void ConnectionsDock::_make_or_edit_connection() {
 
 	if (scr.is_valid() && !ClassDB::has_method(target->get_class(), cd.method)) {
 		// Check in target's own script.
-		int32_t line = scr->get_language()->get_editor_language()->find_function(cd.method, scr->get_source_code());
+		int32_t line = scr->get_language()->get_editor_language()->find_function(cd.method, scr->get_source_code(), scr->get_path());
 		if (line != -1) {
 			add_script_function_request = EDITOR_GET("text_editor/behavior/navigation/open_script_when_connecting_signal_to_existing_method");
 		} else {
@@ -1022,7 +1022,7 @@ void ConnectionsDock::_make_or_edit_connection() {
 			bool found_inherited_function = false;
 			Ref<Script> inherited_scr = scr->get_base_script();
 			while (inherited_scr.is_valid()) {
-				int32_t inherited_line = inherited_scr->get_language()->get_editor_language()->find_function(cd.method, inherited_scr->get_source_code());
+				int32_t inherited_line = inherited_scr->get_language()->get_editor_language()->find_function(cd.method, inherited_scr->get_source_code(), inherited_scr->get_path());
 				if (inherited_line != -1) {
 					found_inherited_function = true;
 					break;

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -448,7 +448,7 @@ void ScriptTextEditor::add_callback(const String &p_function, const PackedString
 	code_editor->get_text_editor()->remove_secondary_carets();
 	code_editor->get_text_editor()->deselect();
 	String code = code_editor->get_text_editor()->get_text();
-	int32_t pos = language->get_editor_language()->find_function(p_function, code);
+	int32_t pos = language->get_editor_language()->find_function(p_function, code, script->get_path());
 	if (pos == -1) {
 		// Function does not exist, create it at the end of the file.
 		int last_line = code_editor->get_text_editor()->get_line_count() - 1;

--- a/modules/gdscript/editor/gdscript_editor_language.h
+++ b/modules/gdscript/editor/gdscript_editor_language.h
@@ -42,7 +42,7 @@ public:
 
 	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) override;
 
-	virtual int32_t find_function(const String &p_function, const String &p_code) const override;
+	virtual int32_t find_function(const String &p_function, const String &p_code, const String &p_path) const override;
 
 	GDScriptEditorLanguage() {
 		ERR_FAIL_COND(singleton != nullptr);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -31,7 +31,6 @@
 #include "gdscript.h"
 #include "gdscript_analyzer.h"
 #include "gdscript_parser.h"
-#include "gdscript_tokenizer.h"
 #include "gdscript_utility_functions.h"
 
 #ifdef TOOLS_ENABLED
@@ -232,28 +231,14 @@ bool GDScriptLanguage::supports_documentation() const {
 }
 
 #ifdef TOOLS_ENABLED
-int32_t GDScriptEditorLanguage::find_function(const String &p_function, const String &p_code) const {
-	GDScriptTokenizerText tokenizer;
-	tokenizer.set_source_code(p_code);
-	int indent = 0;
-	GDScriptTokenizer::Token current = tokenizer.scan();
-	while (current.type != GDScriptTokenizer::Token::TK_EOF && current.type != GDScriptTokenizer::Token::ERROR) {
-		if (current.type == GDScriptTokenizer::Token::INDENT) {
-			indent++;
-		} else if (current.type == GDScriptTokenizer::Token::DEDENT) {
-			indent--;
-		}
-		if (indent == 0 && current.type == GDScriptTokenizer::Token::FUNC) {
-			current = tokenizer.scan();
-			if (current.is_identifier()) {
-				String identifier = current.get_identifier();
-				if (identifier == p_function) {
-					return current.start_line;
-				}
-			}
-		}
-		current = tokenizer.scan();
+int32_t GDScriptEditorLanguage::find_function(const String &p_function, const String &p_code, const String &p_path) const {
+	GDScriptParser parser;
+	parser.parse(p_code, p_path, false);
+
+	if (parser.get_tree() && parser.get_tree()->has_function(p_function)) {
+		return parser.get_tree()->get_member(p_function).get_line() - 1;
 	}
+
 	return -1;
 }
 #endif // TOOLS_ENABLED

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -39,6 +39,8 @@
 #include "tests/test_utils.h"
 
 #ifdef TOOLS_ENABLED
+#include "../editor/gdscript_editor_language.h"
+
 #include "core/os/os.h"
 #endif
 
@@ -141,5 +143,21 @@ TEST_CASE("[Modules][GDScript] Validate built-in API") {
 		}
 	}
 }
+
+#ifdef TOOLS_ENABLED
+TEST_CASE("[Modules][GDScript] find_function") {
+	SUBCASE("[Modules][GDScript] Over-indented dictionary") {
+		const String code = "var dictionary = {\n"
+							"		\"foo\": \"bar\"\n"
+							"	}\n"
+							"\n"
+							"func button_pressed():\n"
+							"	print(\"pressed!\")\n"
+							"\n";
+
+		CHECK_EQ(GDScriptEditorLanguage::get_singleton()->find_function("button_pressed", code, "res://my_script.gd"), 4);
+	}
+}
+#endif // TOOLS_ENABLED
 
 } // namespace GDScriptTests


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/117416

The GDScript implementation of `find_function` tried  to do island parsing for functions using the tokenizer. This is not a viable approach, since multiline mode (controls indentation errors produced by the tokenizer) is controlled by the parser. Instead we need to use parser+tokenizer to get correct results.
