### PR TITLE
GDScript: Fix wrong line number reported for errors in while loop condition

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2122,6 +2122,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 				codegen.start_block(); // Add an extra block, since we use custom logic to clear block locals.
 
 				gen->start_while_condition();
+				gen->write_newline(while_n->condition->start_line);
 
 				GDScriptCodeGenerator::Address condition = _parse_expression(codegen, err, while_n->condition);
 				if (err) {

--- a/modules/gdscript/tests/scripts/runtime/errors/while_condition_error_line.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/while_condition_error_line.gd
@@ -1,0 +1,5 @@
+func test() -> void:
+	var array: Array[int] = [1, 2, 3]
+	var i: int = 0
+	while array[i] < 9:
+		i += 1

--- a/modules/gdscript/tests/scripts/runtime/errors/while_condition_error_line.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/while_condition_error_line.out
@@ -1,0 +1,2 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR at runtime/errors/while_condition_error_line.gd:4 on test(): Out of bounds get index '3' (on base: 'Array[int]')


### PR DESCRIPTION
Fixes #118308.

When an error occurs in a `while` loop's condition on the 2nd+ iteration, the reported line number points to the last line of the loop body instead of the condition line.

This happens because `start_while_condition()` sets the continue jump target after the `OPCODE_LINE` instruction, so jumping back to re-evaluate the condition skips the line update.

Adding a `write_newline()` call after `start_while_condition()` emits an `OPCODE_LINE` at the jump target, so the line number is correctly set when the condition is re-evaluated.