### PR TITLE
Clamp sun minimum energy to `1.0` in ProceduralSkyMaterial to fix dark suns

### DIFF
--- a/doc/classes/ProceduralSkyMaterial.xml
+++ b/doc/classes/ProceduralSkyMaterial.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[ProceduralSkyMaterial] provides a way to create an effective background quickly by defining procedural parameters for the sun, the sky and the ground. The sky and ground are defined by a main color, a color at the horizon, and an easing curve to interpolate between them. Suns are described by a position in the sky, a color, and a max angle from the sun at which the easing curve ends. The max angle therefore defines the size of the sun in the sky.
-		[ProceduralSkyMaterial] supports up to 4 suns, using the color, and energy, direction, and angular distance of the first four [DirectionalLight3D] nodes in the scene. This means that the suns are defined individually by the properties of their corresponding [DirectionalLight3D]s and globally by [member sun_angle_max] and [member sun_curve].
+		[ProceduralSkyMaterial] supports up to 4 suns, using the color, and energy, direction, and angular distance of the first four [DirectionalLight3D] nodes in the scene. This means that the suns are defined individually by the properties of their corresponding [DirectionalLight3D]s and globally by [member sun_angle_max] and [member sun_curve]. The suns' energy is always set to at least [code]1.0[/code] to ensure the suns don't appear too dark in the sky.
 		[ProceduralSkyMaterial] uses a lightweight shader to draw the sky and is therefore suited for real-time updates. This makes it a great option for a sky that is simple and computationally cheap, but unrealistic. If you need a more realistic procedural option, use [PhysicalSkyMaterial].
 	</description>
 	<tutorials>

--- a/scene/resources/3d/sky_material.cpp
+++ b/scene/resources/3d/sky_material.cpp
@@ -330,44 +330,48 @@ void sky() {
 	if (LIGHT0_ENABLED) {
 		float sun_angle = dot(LIGHT0_DIRECTION, EYEDIR);
 		float sun_size = cos(LIGHT0_SIZE);
+		vec3 color = LIGHT0_COLOR * max(LIGHT0_ENERGY, 1.0);
 		if (sun_angle > sun_size) {
-			sky = LIGHT0_COLOR * LIGHT0_ENERGY;
+			sky = color;
 		} else if (sun_angle > sun_angle_max) {
 			float c2 = (sun_size - sun_angle) / (sun_size - sun_angle_max);
-			sky = mix(sky, LIGHT0_COLOR * LIGHT0_ENERGY, clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0));
+			sky = mix(sky, color, clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0));
 		}
 	}
 
 	if (LIGHT1_ENABLED) {
 		float sun_angle = dot(LIGHT1_DIRECTION, EYEDIR);
 		float sun_size = cos(LIGHT1_SIZE);
+		vec3 color = LIGHT1_COLOR * max(LIGHT1_ENERGY, 1.0);
 		if (sun_angle > sun_size) {
-			sky = LIGHT1_COLOR * LIGHT1_ENERGY;
+			sky = color;
 		} else if (sun_angle > sun_angle_max) {
 			float c2 = (sun_size - sun_angle) / (sun_size - sun_angle_max);
-			sky = mix(sky, LIGHT1_COLOR * LIGHT1_ENERGY, clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0));
+			sky = mix(sky, color, clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0));
 		}
 	}
 
 	if (LIGHT2_ENABLED) {
 		float sun_angle = dot(LIGHT2_DIRECTION, EYEDIR);
 		float sun_size = cos(LIGHT2_SIZE);
+		vec3 color = LIGHT2_COLOR * max(LIGHT2_ENERGY, 1.0);
 		if (sun_angle > sun_size) {
-			sky = LIGHT2_COLOR * LIGHT2_ENERGY;
+			sky = color;
 		} else if (sun_angle > sun_angle_max) {
 			float c2 = (sun_size - sun_angle) / (sun_size - sun_angle_max);
-			sky = mix(sky, LIGHT2_COLOR * LIGHT2_ENERGY, clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0));
+			sky = mix(sky, color, clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0));
 		}
 	}
 
 	if (LIGHT3_ENABLED) {
 		float sun_angle = dot(LIGHT3_DIRECTION, EYEDIR);
 		float sun_size = cos(LIGHT3_SIZE);
+		vec3 color = LIGHT3_COLOR * max(LIGHT3_ENERGY, 1.0);
 		if (sun_angle > sun_size) {
-			sky = LIGHT3_COLOR * LIGHT3_ENERGY;
+			sky = color;
 		} else if (sun_angle > sun_angle_max) {
 			float c2 = (sun_size - sun_angle) / (sun_size - sun_angle_max);
-			sky = mix(sky, LIGHT3_COLOR * LIGHT3_ENERGY, clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0));
+			sky = mix(sky, color, clamp(pow(1.0 - c2, inv_sun_curve), 0.0, 1.0));
 		}
 	}
 


### PR DESCRIPTION
- Alternative to https://github.com/godotengine/godot/pull/113292.

This fix doesn't affect visuals for suns with energy set to `1.0` or greater, but it has some downsides:

- Dark colors will still result in a dark sun.
- Decreasing the energy will not fade the sun in the sky or hide it entirely when set to `0.0`.
  - This can make day/night cycles look less convincing in terms of sky rendering, with the sun potentially disappearing suddenly at the end of the sunset (if part of it is still visible when the sun is hidden).

**This only affects sky rendering**, not light rendering. PhysicalSkyMaterial does not have an issue with dark suns (as the sun appears to be rendered additively), so it's left unchanged.

- See https://github.com/godotengine/godot-proposals/issues/13748.

**Testing project:** [test_sky_sun_2.zip](https://github.com/user-attachments/files/26580691/test_sky_sun_2.zip)

## Preview

*From left to right: suns with energy `0.0`, `0.5`, `1.0`, and `2.0`.*

Before | After
-|-
<img width="1152" height="648" alt="Screenshot_20260408_225650" src="https://github.com/user-attachments/assets/32963f66-9479-4ba5-887e-2cf066763d74" /> | <img width="1152" height="648" alt="Screenshot_20260408_230317" src="https://github.com/user-attachments/assets/614e3876-f6e1-4689-9715-9a0c67877179" />
