### PR TITLE
Improve `MoveToward` docs in C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -514,7 +514,7 @@ namespace Godot
         }
 
         /// <summary>
-        /// Moves this vector toward <paramref name="to"/> by the fixed <paramref name="delta"/> amount.
+        /// Returns a new vector moved toward <paramref name="to"/> by the fixed <paramref name="delta"/> amount. Will not go past the final value.
         /// </summary>
         /// <param name="to">The vector to move towards.</param>
         /// <param name="delta">The amount to move towards by.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -525,7 +525,7 @@ namespace Godot
         }
 
         /// <summary>
-        /// Moves this vector toward <paramref name="to"/> by the fixed <paramref name="delta"/> amount.
+        /// Returns a new vector moved toward <paramref name="to"/> by the fixed <paramref name="delta"/> amount. Will not go past the final value.
         /// </summary>
         /// <param name="to">The vector to move towards.</param>
         /// <param name="delta">The amount to move towards by.</param>


### PR DESCRIPTION
Currently `Vector2.MoveToward` and `Vector3.MoveToward` are ambiguous about whether they can overshoot the target.

This is [specified in the docs for GDScript](https://docs.godotengine.org/en/stable/classes/class_vector3.html#class-vector3-method-move-toward), but not the docs for C#.

I copied the docs from GDScript to the docs for C# for these two methods.