### PR TITLE
Add project settings to toggle Steam time tracker.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1203,6 +1203,23 @@
 		<member name="editor/script/templates_search_path" type="String" setter="" getter="" default="&quot;res://script_templates&quot;">
 			Search path for project-specific script templates. Godot will search for script templates both in the editor-specific path and in this project-specific path.
 		</member>
+		<member name="editor/steam/library_path" type="String" setter="" getter="" default="&quot;&quot;">
+			Path to the [code]libsteam_api[/code] library, leave empty to use default version.
+			[b]Note:[/b] This project setting is only effective in Steam version of the engine (built with [code]steamapi=yes[/code].).
+		</member>
+		<member name="editor/steam/library_path.linuxbsd" type="String" setter="" getter="" default="&quot;&quot;">
+			Linux/BSD override for [member editor/steam/library_path].
+		</member>
+		<member name="editor/steam/library_path.macos" type="String" setter="" getter="" default="&quot;&quot;">
+			macOS override for [member editor/steam/library_path].
+		</member>
+		<member name="editor/steam/library_path.windows" type="String" setter="" getter="" default="&quot;&quot;">
+			Windows override for [member editor/steam/library_path].
+		</member>
+		<member name="editor/steam/time_tracker" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], loads Steam API library to track running time when project is opened in the editor.
+			[b]Note:[/b] This project setting is only effective in Steam version of the engine (built with [code]steamapi=yes[/code].).
+		</member>
 		<member name="editor/version_control/autoload_on_startup" type="bool" setter="" getter="" default="false">
 		</member>
 		<member name="editor/version_control/plugin_name" type="String" setter="" getter="" default="&quot;&quot;">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2901,9 +2901,16 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	Thread::release_main_thread(); // If setup2() is called from another thread, that one will become main thread, so preventively release this one.
 	set_current_thread_safe_for_nodes(false);
 
+	GLOBAL_DEF_RST(PropertyInfo(Variant::STRING, "editor/steam/library_path", PROPERTY_HINT_FILE_PATH, ""), "");
+	GLOBAL_DEF_RST(PropertyInfo(Variant::STRING, "editor/steam/library_path.windows", PROPERTY_HINT_FILE_PATH, "*.dll"), "");
+	GLOBAL_DEF_RST(PropertyInfo(Variant::STRING, "editor/steam/library_path.linuxbsd", PROPERTY_HINT_FILE_PATH, "*.so"), "");
+	GLOBAL_DEF_RST(PropertyInfo(Variant::STRING, "editor/steam/library_path.macos", PROPERTY_HINT_FILE_PATH, "*.dylib"), "");
+	GLOBAL_DEF_RST("editor/steam/time_tracker", true);
 #if defined(STEAMAPI_ENABLED)
 	if (editor || project_manager) {
-		steam_tracker = memnew(SteamTracker);
+		if (bool(GLOBAL_GET("editor/steam/time_tracker"))) {
+			steam_tracker = memnew(SteamTracker(ProjectSettings::get_singleton()->globalize_path(GLOBAL_GET("editor/steam/library_path"))));
+		}
 	}
 #endif
 

--- a/main/steam_tracker.cpp
+++ b/main/steam_tracker.cpp
@@ -37,35 +37,39 @@
 
 // https://partner.steamgames.com/doc/sdk/api#initialization_and_shutdown
 
-SteamTracker::SteamTracker() {
+SteamTracker::SteamTracker(const String &p_path) {
 	String path;
-	if (OS::get_singleton()->has_feature("linuxbsd")) {
-		path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("libsteam_api.so");
-		if (!FileAccess::exists(path)) {
-			path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("../lib").path_join("libsteam_api.so");
+	if (p_path.is_empty()) {
+		if (OS::get_singleton()->has_feature("linuxbsd")) {
+			path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("libsteam_api.so");
+			if (!FileAccess::exists(path)) {
+				path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("../lib").path_join("libsteam_api.so");
+				if (!FileAccess::exists(path)) {
+					return;
+				}
+			}
+		} else if (OS::get_singleton()->has_feature("windows")) {
+			if (OS::get_singleton()->has_feature("64")) {
+				path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("steam_api64.dll");
+			} else {
+				path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("steam_api.dll");
+			}
 			if (!FileAccess::exists(path)) {
 				return;
 			}
-		}
-	} else if (OS::get_singleton()->has_feature("windows")) {
-		if (OS::get_singleton()->has_feature("64")) {
-			path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("steam_api64.dll");
+		} else if (OS::get_singleton()->has_feature("macos")) {
+			path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("libsteam_api.dylib");
+			if (!FileAccess::exists(path)) {
+				path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("../Frameworks").path_join("libsteam_api.dylib");
+				if (!FileAccess::exists(path)) {
+					return;
+				}
+			}
 		} else {
-			path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("steam_api.dll");
-		}
-		if (!FileAccess::exists(path)) {
 			return;
 		}
-	} else if (OS::get_singleton()->has_feature("macos")) {
-		path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("libsteam_api.dylib");
-		if (!FileAccess::exists(path)) {
-			path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("../Frameworks").path_join("libsteam_api.dylib");
-			if (!FileAccess::exists(path)) {
-				return;
-			}
-		}
 	} else {
-		return;
+		path = p_path;
 	}
 
 	Error err = OS::get_singleton()->open_dynamic_library(path, steam_library_handle);

--- a/main/steam_tracker.h
+++ b/main/steam_tracker.h
@@ -32,6 +32,8 @@
 
 #if defined(STEAMAPI_ENABLED)
 
+#include "core/string/ustring.h"
+
 // SteamTracker is used to load SteamAPI dynamic library and initialize
 // the interface, this notifies Steam that Godot editor is running and
 // allow tracking of the usage time of child instances of the engine
@@ -62,7 +64,7 @@ class SteamTracker {
 	bool steam_initialized = false;
 
 public:
-	SteamTracker();
+	SteamTracker(const String &p_path);
 	~SteamTracker();
 };
 


### PR DESCRIPTION
Adds project setting to disable SteamAPI library loading for specific project.

See https://github.com/godotengine/godot/issues/113868