### PR TITLE
Fix GLTFPhysicsShape import/export for OMI_physics_shape capsules and cylinders

### DIFF
--- a/modules/gltf/doc_classes/GLTFPhysicsShape.xml
+++ b/modules/gltf/doc_classes/GLTFPhysicsShape.xml
@@ -50,13 +50,13 @@
 			<return type="Shape3D" />
 			<param index="0" name="cache_shapes" type="bool" default="false" />
 			<description>
-				Converts this GLTFPhysicsShape instance into a Godot [Shape3D] resource.
+				Converts this GLTFPhysicsShape instance into a Godot [Shape3D] resource. Capsule and cylinder shapes with different top and bottom radii are approximated using the average radius.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
-			The height of the shape, in meters. This is only used when the shape type is [code]"capsule"[/code] or [code]"cylinder"[/code]. This value should not be negative, and for [code]"capsule"[/code] it should be at least twice the radius.
+			The height of the shape, in meters. This is only used when the shape type is [code]"capsule"[/code] or [code]"cylinder"[/code]. This value should not be negative. For [code]"capsule"[/code], this is the full height, so it should be at least [code]radius_top + radius_bottom[/code].
 		</member>
 		<member name="importer_mesh" type="ImporterMesh" setter="set_importer_mesh" getter="get_importer_mesh">
 			The [ImporterMesh] resource of the shape. This is only used when the shape type is [code]"hull"[/code] (convex hull) or [code]"trimesh"[/code] (concave trimesh).
@@ -69,7 +69,13 @@
 			The index of the shape's mesh in the glTF file. This is only used when the shape type is [code]"hull"[/code] (convex hull) or [code]"trimesh"[/code] (concave trimesh).
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
-			The radius of the shape, in meters. This is only used when the shape type is [code]"capsule"[/code], [code]"cylinder"[/code], or [code]"sphere"[/code]. This value should not be negative.
+			The effective radius of the shape, in meters. This is used when the shape type is [code]"sphere"[/code], and for [code]"capsule"[/code] and [code]"cylinder"[/code] it sets both [member radius_top] and [member radius_bottom]. When [member radius_top] and [member radius_bottom] differ, this returns their average. This value should not be negative.
+		</member>
+		<member name="radius_bottom" type="float" setter="set_radius_bottom" getter="get_radius_bottom" default="0.5">
+			The bottom radius of the shape, in meters. This is only used when the shape type is [code]"capsule"[/code] or [code]"cylinder"[/code]. This value should not be negative.
+		</member>
+		<member name="radius_top" type="float" setter="set_radius_top" getter="get_radius_top" default="0.5">
+			The top radius of the shape, in meters. This is only used when the shape type is [code]"capsule"[/code] or [code]"cylinder"[/code]. This value should not be negative.
 		</member>
 		<member name="shape_type" type="String" setter="set_shape_type" getter="get_shape_type" default="&quot;&quot;">
 			The type of shape this shape represents. Valid values are [code]"box"[/code], [code]"capsule"[/code], [code]"cylinder"[/code], [code]"sphere"[/code], [code]"hull"[/code], and [code]"trimesh"[/code].

--- a/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
+++ b/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
@@ -67,7 +67,9 @@ Error GLTFDocumentExtensionPhysics::import_preflight(Ref<GLTFState> p_state, con
 				if (state_collider_dicts.size() > 0) {
 					Array state_colliders;
 					for (int i = 0; i < state_collider_dicts.size(); i++) {
-						state_colliders.push_back(GLTFPhysicsShape::from_dictionary(state_collider_dicts[i]));
+						Dictionary state_collider_dict = state_collider_dicts[i];
+						state_collider_dict["extension"] = "OMI_collider";
+						state_colliders.push_back(GLTFPhysicsShape::from_dictionary(state_collider_dict));
 					}
 					p_state->set_additional_data(StringName("GLTFPhysicsShapes"), state_colliders);
 				}
@@ -97,6 +99,7 @@ Error GLTFDocumentExtensionPhysics::parse_node_extensions(Ref<GLTFState> p_state
 			ERR_FAIL_INDEX_V_MSG(node_collider_index, state_colliders.size(), Error::ERR_FILE_CORRUPT, "glTF Physics: On node " + p_gltf_node->get_name() + ", the collider index " + itos(node_collider_index) + " is not in the state colliders (size: " + itos(state_colliders.size()) + ").");
 			p_gltf_node->set_additional_data(StringName("GLTFPhysicsShape"), state_colliders[node_collider_index]);
 		} else {
+			node_collider_ext["extension"] = "OMI_collider";
 			p_gltf_node->set_additional_data(StringName("GLTFPhysicsShape"), GLTFPhysicsShape::from_dictionary(node_collider_ext));
 		}
 	}

--- a/modules/gltf/extensions/physics/gltf_physics_shape.cpp
+++ b/modules/gltf/extensions/physics/gltf_physics_shape.cpp
@@ -284,11 +284,31 @@ Ref<GLTFPhysicsShape> GLTFPhysicsShape::from_dictionary(const Dictionary &p_dict
 	} else {
 		properties = p_dictionary;
 	}
-	if (properties.has("radius")) {
-		gltf_shape->set_radius(properties["radius"]);
-	}
-	if (properties.has("height")) {
-		gltf_shape->set_height(properties["height"]);
+	const String extension = p_dictionary.get("extension", "");
+	if (extension != "OMI_collider" && (shape_type == "capsule" || shape_type == "cylinder")) {
+		real_t radius = properties.get("radius", gltf_shape->get_radius());
+		real_t radius_top = properties.get("radiusTop", radius);
+		real_t radius_bottom = properties.get("radiusBottom", radius);
+		if (!Math::is_equal_approx(radius_top, radius_bottom)) {
+			WARN_PRINT("GLTFPhysicsShape: The " + shape_type + " shape has different radiusTop and radiusBottom values. Using the average radius as an approximation.");
+			radius_top = (radius_top + radius_bottom) * real_t(0.5);
+			radius_bottom = radius_top;
+		}
+		gltf_shape->set_radius(radius_top);
+		if (shape_type == "capsule") {
+			real_t mid_height = properties.get("height", real_t(1.0));
+			gltf_shape->set_height(mid_height + radius_top + radius_bottom);
+		} else { // cylinder
+			real_t total_height = properties.get("height", real_t(2.0));
+			gltf_shape->set_height(total_height);
+		}
+	} else {
+		if (properties.has("radius")) {
+			gltf_shape->set_radius(properties["radius"]);
+		}
+		if (properties.has("height")) {
+			gltf_shape->set_height(properties["height"]);
+		}
 	}
 	if (properties.has("size")) {
 		const Array &arr = properties["size"];
@@ -322,10 +342,12 @@ Dictionary GLTFPhysicsShape::to_dictionary() const {
 		size_array[2] = size.z;
 		sub["size"] = size_array;
 	} else if (shape_type == "capsule") {
-		sub["radius"] = get_radius();
-		sub["height"] = get_height();
+		sub["radiusTop"] = get_radius();
+		sub["radiusBottom"] = get_radius();
+		sub["height"] = MAX(get_height() - (get_radius() * real_t(2.0)), real_t(0.0));
 	} else if (shape_type == "cylinder") {
-		sub["radius"] = get_radius();
+		sub["radiusTop"] = get_radius();
+		sub["radiusBottom"] = get_radius();
 		sub["height"] = get_height();
 	} else if (shape_type == "sphere") {
 		sub["radius"] = get_radius();

--- a/modules/gltf/extensions/physics/gltf_physics_shape.cpp
+++ b/modules/gltf/extensions/physics/gltf_physics_shape.cpp
@@ -57,6 +57,10 @@ void GLTFPhysicsShape::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_size", "size"), &GLTFPhysicsShape::set_size);
 	ClassDB::bind_method(D_METHOD("get_radius"), &GLTFPhysicsShape::get_radius);
 	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &GLTFPhysicsShape::set_radius);
+	ClassDB::bind_method(D_METHOD("get_radius_top"), &GLTFPhysicsShape::get_radius_top);
+	ClassDB::bind_method(D_METHOD("set_radius_top", "radius_top"), &GLTFPhysicsShape::set_radius_top);
+	ClassDB::bind_method(D_METHOD("get_radius_bottom"), &GLTFPhysicsShape::get_radius_bottom);
+	ClassDB::bind_method(D_METHOD("set_radius_bottom", "radius_bottom"), &GLTFPhysicsShape::set_radius_bottom);
 	ClassDB::bind_method(D_METHOD("get_height"), &GLTFPhysicsShape::get_height);
 	ClassDB::bind_method(D_METHOD("set_height", "height"), &GLTFPhysicsShape::set_height);
 	ClassDB::bind_method(D_METHOD("get_is_trigger"), &GLTFPhysicsShape::get_is_trigger);
@@ -69,6 +73,8 @@ void GLTFPhysicsShape::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "shape_type"), "set_shape_type", "get_shape_type");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "size"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius"), "set_radius", "get_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius_top"), "set_radius_top", "get_radius_top");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius_bottom"), "set_radius_bottom", "get_radius_bottom");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height"), "set_height", "get_height");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "is_trigger"), "set_is_trigger", "get_is_trigger");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mesh_index"), "set_mesh_index", "get_mesh_index");
@@ -92,11 +98,32 @@ void GLTFPhysicsShape::set_size(const Vector3 &p_size) {
 }
 
 real_t GLTFPhysicsShape::get_radius() const {
-	return radius;
+	if (Math::is_equal_approx(radius_top, radius_bottom)) {
+		return radius_top;
+	}
+	// Until Godot has tapered collision shapes, return the average as an approximation.
+	return (radius_top + radius_bottom) * real_t(0.5);
 }
 
 void GLTFPhysicsShape::set_radius(real_t p_radius) {
-	radius = p_radius;
+	radius_top = p_radius;
+	radius_bottom = p_radius;
+}
+
+real_t GLTFPhysicsShape::get_radius_top() const {
+	return radius_top;
+}
+
+void GLTFPhysicsShape::set_radius_top(real_t p_radius_top) {
+	radius_top = p_radius_top;
+}
+
+real_t GLTFPhysicsShape::get_radius_bottom() const {
+	return radius_bottom;
+}
+
+void GLTFPhysicsShape::set_radius_bottom(real_t p_radius_bottom) {
+	radius_bottom = p_radius_bottom;
 }
 
 real_t GLTFPhysicsShape::get_height() const {
@@ -237,19 +264,25 @@ Ref<Shape3D> GLTFPhysicsShape::to_resource(bool p_cache_shapes) {
 		} else if (shape_type == "capsule") {
 			Ref<CapsuleShape3D> capsule;
 			capsule.instantiate();
-			capsule->set_radius(radius);
+			if (!Math::is_equal_approx(get_radius_top(), get_radius_bottom())) {
+				WARN_PRINT("GLTFPhysicsShape: The capsule shape has different radiusTop and radiusBottom values. Using the average radius as an approximation.");
+			}
+			capsule->set_radius(get_radius());
 			capsule->set_height(height);
 			_shape_cache = capsule;
 		} else if (shape_type == "cylinder") {
 			Ref<CylinderShape3D> cylinder;
 			cylinder.instantiate();
-			cylinder->set_radius(radius);
+			if (!Math::is_equal_approx(get_radius_top(), get_radius_bottom())) {
+				WARN_PRINT("GLTFPhysicsShape: The cylinder shape has different radiusTop and radiusBottom values. Using the average radius as an approximation.");
+			}
+			cylinder->set_radius(get_radius());
 			cylinder->set_height(height);
 			_shape_cache = cylinder;
 		} else if (shape_type == "sphere") {
 			Ref<SphereShape3D> sphere;
 			sphere.instantiate();
-			sphere->set_radius(radius);
+			sphere->set_radius(get_radius());
 			_shape_cache = sphere;
 		} else if (shape_type == "convex") {
 			ERR_FAIL_COND_V_MSG(importer_mesh.is_null(), _shape_cache, "GLTFPhysicsShape: Error converting convex hull shape to a shape resource: The mesh resource is null.");
@@ -284,17 +317,17 @@ Ref<GLTFPhysicsShape> GLTFPhysicsShape::from_dictionary(const Dictionary &p_dict
 	} else {
 		properties = p_dictionary;
 	}
+	real_t radius = properties.get("radius", gltf_shape->get_radius_top());
+	real_t radius_top = radius;
+	real_t radius_bottom = radius;
+	if (shape_type == "capsule" || shape_type == "cylinder") {
+		radius_top = properties.get("radiusTop", radius);
+		radius_bottom = properties.get("radiusBottom", radius);
+	}
+	gltf_shape->set_radius_top(radius_top);
+	gltf_shape->set_radius_bottom(radius_bottom);
 	const String extension = p_dictionary.get("extension", "");
 	if (extension != "OMI_collider" && (shape_type == "capsule" || shape_type == "cylinder")) {
-		real_t radius = properties.get("radius", gltf_shape->get_radius());
-		real_t radius_top = properties.get("radiusTop", radius);
-		real_t radius_bottom = properties.get("radiusBottom", radius);
-		if (!Math::is_equal_approx(radius_top, radius_bottom)) {
-			WARN_PRINT("GLTFPhysicsShape: The " + shape_type + " shape has different radiusTop and radiusBottom values. Using the average radius as an approximation.");
-			radius_top = (radius_top + radius_bottom) * real_t(0.5);
-			radius_bottom = radius_top;
-		}
-		gltf_shape->set_radius(radius_top);
 		if (shape_type == "capsule") {
 			real_t mid_height = properties.get("height", real_t(1.0));
 			gltf_shape->set_height(mid_height + radius_top + radius_bottom);
@@ -302,13 +335,8 @@ Ref<GLTFPhysicsShape> GLTFPhysicsShape::from_dictionary(const Dictionary &p_dict
 			real_t total_height = properties.get("height", real_t(2.0));
 			gltf_shape->set_height(total_height);
 		}
-	} else {
-		if (properties.has("radius")) {
-			gltf_shape->set_radius(properties["radius"]);
-		}
-		if (properties.has("height")) {
-			gltf_shape->set_height(properties["height"]);
-		}
+	} else if (properties.has("height")) {
+		gltf_shape->set_height(properties["height"]);
 	}
 	if (properties.has("size")) {
 		const Array &arr = properties["size"];
@@ -342,12 +370,12 @@ Dictionary GLTFPhysicsShape::to_dictionary() const {
 		size_array[2] = size.z;
 		sub["size"] = size_array;
 	} else if (shape_type == "capsule") {
-		sub["radiusTop"] = get_radius();
-		sub["radiusBottom"] = get_radius();
-		sub["height"] = MAX(get_height() - (get_radius() * real_t(2.0)), real_t(0.0));
+		sub["radiusTop"] = get_radius_top();
+		sub["radiusBottom"] = get_radius_bottom();
+		sub["height"] = MAX(get_height() - (get_radius_top() + get_radius_bottom()), real_t(0.0));
 	} else if (shape_type == "cylinder") {
-		sub["radiusTop"] = get_radius();
-		sub["radiusBottom"] = get_radius();
+		sub["radiusTop"] = get_radius_top();
+		sub["radiusBottom"] = get_radius_bottom();
 		sub["height"] = get_height();
 	} else if (shape_type == "sphere") {
 		sub["radius"] = get_radius();

--- a/modules/gltf/extensions/physics/gltf_physics_shape.h
+++ b/modules/gltf/extensions/physics/gltf_physics_shape.h
@@ -49,7 +49,8 @@ protected:
 private:
 	String shape_type;
 	Vector3 size = Vector3(1.0, 1.0, 1.0);
-	real_t radius = 0.5;
+	real_t radius_top = 0.5;
+	real_t radius_bottom = 0.5;
 	real_t height = 2.0;
 	bool is_trigger = false;
 	GLTFMeshIndex mesh_index = -1;
@@ -66,6 +67,12 @@ public:
 
 	real_t get_radius() const;
 	void set_radius(real_t p_radius);
+
+	real_t get_radius_top() const;
+	void set_radius_top(real_t p_radius_top);
+
+	real_t get_radius_bottom() const;
+	void set_radius_bottom(real_t p_radius_bottom);
 
 	real_t get_height() const;
 	void set_height(real_t p_height);


### PR DESCRIPTION
Importing a glTF file containing a capsule/cylinder compliant with the OMI_physics_shape spec currently ignores the `radiusTop`/`radiusBottom` fields. Additionally the spec defines `height` to be the mid-height for capsules and total height for cylinders, but both are currently interpreted as total height.
The `GLTFPhysicsShape` documentation states that both OMI_physics_shape and OMI_collider are supported and that its `to_dictionary()` method serializes in the format defined by OMI_physics_shape.

This change makes capsule and cylinder imports read `radiusTop` and `radiusBottom` (falling back to `radius`) and interpret `height` depending on the shape type. Since Godot does not have tapered capsules/cylinders the importer emits a warning when `radiusTop` and `radiusBottom` differ and uses their average as an approximation.
OMI_collider imports are still working like before. To avoid changing method signatures or adding new helpers I used an `extension` field in the dictionary to distinguish between OMI_physics_shape and OMI_collider handling.
The `to_dictionary()` method now sets `radiusTop`/`radiusBottom` (identical) and `height` values that are compliant with OMI_physics_shape.