### PR TITLE
Fix `Go to Previous Keyframe` shortcut needs to be pressed twice to work

### DIFF
--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -315,7 +315,9 @@ void AnimationPlayerEditor::go_to_nearest_keyframe(bool p_backward) {
 	}
 
 	player->seek_internal(nearest_key_time, true, true, true);
+	updating = true;
 	frame->set_value(nearest_key_time);
+	updating = false;
 	track_editor->set_anim_pos(nearest_key_time);
 }
 


### PR DESCRIPTION
- Fix #117543

`go_to_nearest_keyframe()` seeks to the exact keyframe time, then updates the timeline spinbox with `frame->set_value(nearest_key_time)`. This triggers `_seek_value_changed()`, because it is connected to the spinner's `value_changed` signal. The method snaps the position to the editor step grid and sets the animation player to that snapped value, overwriting the exact keyframe time.

It worked the second time because the spinbox doesn't emit the `value_changed` signal since it's the same snapped value.