### PR TITLE
Fix `Theme` editor's default preview not having the correct theme

### DIFF
--- a/editor/scene/gui/theme_editor_preview.cpp
+++ b/editor/scene/gui/theme_editor_preview.cpp
@@ -214,7 +214,9 @@ void ThemeEditorPreview::_notification(int p_what) {
 			}
 		} break;
 
-		case NOTIFICATION_READY: {
+		// Due to NOTIFICATION_READY being called only once, and theme contexts being destroyed on node removal,
+		// this is the notification needed, as it can be triggered indefinitely.
+		case NOTIFICATION_POST_ENTER_TREE: {
 			Vector<Ref<Theme>> preview_themes;
 			preview_themes.push_back(ThemeDB::get_singleton()->get_default_theme());
 			ThemeDB::get_singleton()->create_theme_context(preview_root, preview_themes);


### PR DESCRIPTION
~I'm not sure if this the Correct™ fix, but it solves the problem. For the theme context creation to work, it appears that the node must be visible when it happens. Whatever happened in #108647 made so that the `Theme` editor didn't count as "visible" anymore, and broke the mechanism.~

~The actual source of the problem may be deeper than this. If so, I'm all ears for suggestions.~

Found the actual problem: theme contexts get destroyed on node removal, and after #108647, `EditorDockManager::_move_dock()` gets called after the default theme preview gets ready, and since the ready state only happens once, it never gets re-created again.

This PR changes the notification to `NOTIFICATION_POST_ENTER_TREE`, which can be triggered indefinitely.

Fixes #116118.